### PR TITLE
test(llm-agents): valida reasoning steps do Agent no Playground

### DIFF
--- a/tests/helpers/mcp/select-gemini-model.ts
+++ b/tests/helpers/mcp/select-gemini-model.ts
@@ -17,7 +17,7 @@ export const selectGeminiModel = async (page: Page) => {
       });
     } catch (error) {
       console.log("Node model not visible, proceeding...", error);
-      node.click();
+      await node.click();
     }
 
     const model = (await node.getByTestId("model_model").last().isVisible())

--- a/tests/helpers/mcp/select-gemini-model.ts
+++ b/tests/helpers/mcp/select-gemini-model.ts
@@ -1,0 +1,89 @@
+import type { Page } from "@playwright/test";
+import { expect } from "../../fixtures/fixtures";
+import { unselectNodes } from "../ui/unselect-nodes";
+
+export const selectGeminiModel = async (page: Page) => {
+  const nodes = page.locator(".react-flow__node", {
+    has: page.getByTestId("title-language model"),
+  });
+
+  const nodeCount = await nodes.count();
+
+  for (let i = 0; i < nodeCount; i++) {
+    const node = nodes.nth(i);
+    try {
+      await expect(node.getByTestId("model_model").last()).toBeVisible({
+        timeout: 10000,
+      });
+    } catch (error) {
+      console.log("Node model not visible, proceeding...", error);
+      node.click();
+    }
+
+    const model = (await node.getByTestId("model_model").last().isVisible())
+      ? node.getByTestId("model_model").last()
+      : page.getByTestId("model_model").last();
+
+    await expect(model).toBeVisible({ timeout: 10000 });
+    await model.click();
+    await page.waitForSelector('[role="listbox"]', { timeout: 10000 });
+
+    // Always open Manage Model Providers to ensure the API key is configured
+    await page.getByTestId("manage-model-providers").click();
+    await page.waitForSelector("text=Model providers", { timeout: 30000 });
+
+    await page.getByTestId("provider-item-Google Generative AI").click();
+    await page.waitForTimeout(500);
+
+    // Click the key input to enter edit mode (clears masked value if key exists)
+    const keyInput = page.getByPlaceholder("AIza...");
+    await keyInput.click();
+    await page.keyboard.type(process.env.GOOGLE_API_KEY!);
+
+    // Button label varies: "Save Configuration" (new) or "Replace Configuration" (existing key)
+    const saveBtn = page.getByRole("button", {
+      name: /Save Configuration|Replace Configuration/,
+    });
+    await expect(saveBtn).toBeEnabled({ timeout: 5000 });
+    await saveBtn.click();
+    await page.waitForSelector("text=Google Generative AI Configuration Saved", {
+      timeout: 30000,
+    });
+
+    // Wait for key verification to complete — toggle only appears after the API validates the key
+    await page
+      .getByTestId("llm-toggle-gemini-2.5-flash")
+      .waitFor({ state: "visible", timeout: 60000 });
+
+    const isChecked = await page
+      .getByTestId("llm-toggle-gemini-2.5-flash")
+      .isChecked();
+    if (!isChecked) {
+      await page.getByTestId("llm-toggle-gemini-2.5-flash").click();
+    }
+
+    await page.getByText("Close").last().click();
+
+    // Re-open dropdown and click Gemini option — retries if dropdown closes during re-render
+    let modelSelected = false;
+    for (let attempt = 0; attempt < 5 && !modelSelected; attempt++) {
+      await page.getByTestId("model_model").nth(i).click();
+      try {
+        const option = page.getByTestId("gemini-2.5-flash-option");
+        await option.waitFor({ state: "visible", timeout: 10000 });
+        await option.click({ timeout: 5000 });
+        modelSelected = true;
+      } catch {
+        // Dropdown may have closed or re-rendered, retry opening
+        await page.waitForTimeout(300);
+      }
+    }
+    if (!modelSelected) {
+      throw new Error("Failed to select gemini-2.5-flash after 5 attempts");
+    }
+
+    if (i < nodeCount - 1) {
+      await unselectNodes(page);
+    }
+  }
+};

--- a/tests/helpers/mcp/select-gemini-model.ts
+++ b/tests/helpers/mcp/select-gemini-model.ts
@@ -41,9 +41,7 @@ export const selectGeminiModel = async (page: Page) => {
     await page.keyboard.type(process.env.GOOGLE_API_KEY!);
 
     // Button label varies: "Save Configuration" (new) or "Replace Configuration" (existing key)
-    const saveBtn = page.getByRole("button", {
-      name: /Save Configuration|Replace Configuration/,
-    });
+    const saveBtn = page.getByRole("button", { name: /^Save$|^Replace$/ });
     await expect(saveBtn).toBeEnabled({ timeout: 5000 });
     await saveBtn.click();
     await page.waitForSelector("text=Google Generative AI Configuration Saved", {

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-reasoning-steps.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-reasoning-steps.spec.ts
@@ -1,259 +1,437 @@
+import * as dotenv from "dotenv";
+import path from "path";
 import { expect, test } from "../../../../fixtures/fixtures";
-import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { selectGptModel } from "../../../../helpers/mcp/select-gpt-model";
+import { selectAnthropicModel } from "../../../../helpers/mcp/select-anthropic-model";
+import { selectGeminiModel } from "../../../../helpers/mcp/select-gemini-model";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Opens the Playground, starts a fresh session, sends a message and waits for
+ * the agent to finish executing.
+ * Returns the count of bot messages BEFORE sending (for assertion after).
+ */
+async function sendMessageInPlayground(
+  page: import("@playwright/test").Page,
+  message: string,
+): Promise<number> {
+  await page.getByTestId("playground-btn-flow-io").click();
+  await page.waitForSelector('[data-testid="input-chat-playground"]', {
+    timeout: 30000,
+  });
+
+  // Always start a fresh session so each test is isolated
+  await page
+    .getByTestId("new-chat")
+    .waitFor({ state: "visible", timeout: 15000 });
+  await page.getByTestId("new-chat").click();
+  await page.waitForSelector('[data-testid="input-chat-playground"]', {
+    timeout: 10000,
+  });
+
+  const messageCountBefore = await page
+    .getByTestId("div-chat-message")
+    .count();
+
+  const chatInput = page.getByTestId("input-chat-playground").last();
+
+  // Wait for any pre-filled default value to populate, then clear it.
+  // Clearing via keyboard (Control+a → Backspace) fires a real browser input
+  // event, which triggers React onChange and clears the Zustand store.
+  // Plain fill() uses CDP insertText and does not replace an existing value.
+  await page
+    .waitForFunction(
+      () => {
+        const els = document.querySelectorAll(
+          '[data-testid="input-chat-playground"]',
+        );
+        const el = els[els.length - 1] as HTMLTextAreaElement;
+        return el && el.value.length > 0;
+      },
+      { timeout: 5000 },
+    )
+    .catch(() => {});
+
+  await chatInput.click();
+  await page.keyboard.press("Control+a");
+  await page.keyboard.press("Backspace");
+  await chatInput.fill(message);
+  await page.getByTestId("button-send").last().click();
+
+  // Wait for execution to finish: Stop button appears then disappears
+  const stopButton = page.getByRole("button", { name: "Stop" });
+  try {
+    await stopButton.waitFor({ state: "visible", timeout: 30000 });
+    await stopButton.waitFor({ state: "hidden", timeout: 120000 });
+  } catch {
+    // Stop button may appear and disappear too fast to catch both transitions
+  }
+
+  return messageCountBefore;
+}
+
+// ─── Smoke ────────────────────────────────────────────────────────────────────
 
 test(
+
   "Agent component can be added to canvas",
   { tag: ["@release", "@workspace", "@regression", "@agents"] },
+  "Agent component can be added to canvas with correct handles",
+  { tag: ["@release", "@components"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
-
-    await page.waitForSelector('[data-testid="blank-flow"]', { timeout: 30000 });
     await page.getByTestId("blank-flow").click();
 
-    // Search for Agent component
     await page.getByTestId("sidebar-search-input").fill("agent");
-    await page.waitForTimeout(1000);
-
-    const agentCard = page
-      .locator(
-        '[data-testid*="Agent"], [data-testid*="agent"]',
-      )
-      .first();
-    const hasAgent = await agentCard
-      .isVisible({ timeout: 5000 })
-      .catch(() => false);
-
-    if (!hasAgent) {
-      console.log("INFO: Agent component not found in sidebar, skipping");
-      return;
-    }
-
-    await agentCard.hover();
-    await page.waitForTimeout(300);
-
-    const addBtn = page
-      .locator('[data-testid*="add-component-button-agent"]')
-      .first();
-    const hasAddBtn = await addBtn
-      .isVisible({ timeout: 3000 })
-      .catch(() => false);
-
-    if (hasAddBtn) {
-      await addBtn.click();
-    } else {
-      await agentCard.dblclick();
-    }
-
-    await adjustScreenView(page);
+    await page.waitForSelector('[data-testid="models_and_agentsAgent"]', {
+      timeout: 10000,
+    });
+    await page.getByTestId("models_and_agentsAgent").hover();
+    await page.getByTestId("add-component-button-agent").click();
 
     await expect(page.locator(".react-flow__node")).toHaveCount(1, {
       timeout: 10000,
     });
 
-    // The agent node should be visible
-    await expect(page.locator(".react-flow__node").first()).toBeVisible();
+    // Verify all documented handles are present
+    await expect(
+      page.getByTestId("handle-agent-shownode-tools-left"),
+    ).toBeVisible({ timeout: 5000 });
+    await expect(
+      page.getByTestId("handle-agent-shownode-language model-left"),
+    ).toBeVisible({ timeout: 5000 });
+    await expect(
+      page.getByTestId("handle-agent-shownode-response-right"),
+    ).toBeVisible({ timeout: 5000 });
+    // Input handle: display_name="Input" on MessageInput → portName = "input"
+    await expect(
+      page.getByTestId("handle-agent-shownode-input-left"),
+    ).toBeVisible({ timeout: 5000 });
   },
 );
 
+// ─── Canvas connections ────────────────────────────────────────────────────────
+
 test(
+
   "Agent component has tool configuration options",
   { tag: ["@release", "@workspace", "@regression", "@agents"] },
+  "Agent connects to Chat Input and Chat Output forming a valid flow",
+  { tag: ["@release", "@components"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
-
-    await page.waitForSelector('[data-testid="blank-flow"]', { timeout: 30000 });
     await page.getByTestId("blank-flow").click();
 
+    // Add Chat Output first (via hover + button)
+    await page.getByTestId("sidebar-search-input").fill("chat output");
+    await page.waitForSelector('[data-testid="input_outputChat Output"]', {
+      timeout: 10000,
+    });
+    await page.getByTestId("input_outputChat Output").hover();
+    await page.getByTestId("add-component-button-chat-output").click();
+
+    // Add Chat Input via dragTo to avoid overlap with Chat Output
+    await page.getByTestId("sidebar-search-input").clear();
+    await page.getByTestId("sidebar-search-input").fill("chat input");
+    await page.waitForSelector('[data-testid="input_outputChat Input"]', {
+      timeout: 10000,
+    });
+    await page.getByTestId("input_outputChat Input").dragTo(
+      page.locator('//*[@id="react-flow-id"]'),
+      { targetPosition: { x: 100, y: 100 } },
+    );
+
+    // Add Agent via dragTo to a distinct canvas area
+    await page.getByTestId("sidebar-search-input").clear();
     await page.getByTestId("sidebar-search-input").fill("agent");
-    await page.waitForTimeout(1000);
+    await page.waitForSelector('[data-testid="models_and_agentsAgent"]', {
+      timeout: 10000,
+    });
+    await page.getByTestId("models_and_agentsAgent").dragTo(
+      page.locator('//*[@id="react-flow-id"]'),
+      { targetPosition: { x: 400, y: 300 } },
+    );
 
-    const agentCard = page
-      .locator('[data-testid*="Agent"], [data-testid*="agent"]')
-      .first();
-    const hasAgent = await agentCard
-      .isVisible({ timeout: 5000 })
-      .catch(() => false);
-
-    if (!hasAgent) {
-      console.log("INFO: Agent component not found, skipping");
-      return;
-    }
-
-    await agentCard.hover();
-    await page.waitForTimeout(300);
-
-    const addBtn = page
-      .locator('[data-testid*="add-component-button-agent"]')
-      .first();
-    const hasAddBtn = await addBtn
-      .isVisible({ timeout: 3000 })
-      .catch(() => false);
-
-    if (hasAddBtn) {
-      await addBtn.click();
-    } else {
-      await agentCard.dblclick();
-    }
-
-    await adjustScreenView(page);
-
-    await expect(page.locator(".react-flow__node")).toHaveCount(1, {
+    await expect(page.locator(".react-flow__node")).toHaveCount(3, {
       timeout: 10000,
     });
 
-    // Click node to select it
-    await page.locator(".react-flow__node").first().click();
-    await page.waitForTimeout(400);
+    // Connect Chat Input → Agent "Input" handle (display_name="Input")
+    await page
+      .getByTestId("handle-chatinput-noshownode-chat message-source")
+      .click();
+    await page.getByTestId("handle-agent-shownode-input-left").click();
+    await expect(page.locator(".react-flow__edge")).toHaveCount(1, {
+      timeout: 8000,
+    });
 
-    // Open edit modal
-    const editBtn = page.locator('[data-testid="edit-button-modal"]').first();
-    const hasEditBtn = await editBtn
-      .isVisible({ timeout: 3000 })
-      .catch(() => false);
+    // Connect Agent "Response" → Chat Output
+    await page.getByTestId("handle-agent-shownode-response-right").click();
+    await page
+      .getByTestId("handle-chatoutput-noshownode-inputs-target")
+      .click();
+    await expect(page.locator(".react-flow__edge")).toHaveCount(2, {
+      timeout: 8000,
+    });
 
-    if (hasEditBtn) {
-      await editBtn.click();
-      await page.waitForTimeout(500);
-    }
-
-    // Agent should have tool-related configuration
-    const hasToolsSection = await page
-      .getByText(/tools|tool.*calling|agent.*tools/i)
-      .first()
-      .isVisible({ timeout: 5000 })
-      .catch(() => false);
-
-    // Or check for tool mode toggle
-    const hasToolMode = await page
-      .locator('[data-testid*="tool-mode"], [data-testid*="tool_mode"]')
-      .first()
-      .isVisible({ timeout: 3000 })
-      .catch(() => false);
-
-    // Or just that the node has handles for tool connections
-    const hasHandles = await page
-      .locator(".react-flow__handle")
-      .first()
-      .isVisible({ timeout: 3000 })
-      .catch(() => false);
-
-    expect(
-      hasToolsSection || hasToolMode || hasHandles,
-      "Agent component should have tool configuration or connection handles",
-    ).toBe(true);
+    // Playground button must be available when Chat I/O are present and connected
+    await expect(page.getByTestId("playground-btn-flow-io")).toBeVisible({
+      timeout: 5000,
+    });
   },
 );
 
+// ─── Simple Agent template ────────────────────────────────────────────────────
+
 test(
+
   "Agent component shows reasoning steps section in playground via mock",
   { tag: ["@release", "@workspace", "@regression", "@agents"] },
+  "Simple Agent template loads with correct node and edge structure",
+  { tag: ["@release", "@components"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 
-    await page.waitForSelector('[data-testid="blank-flow"]', { timeout: 30000 });
-    await page.getByTestId("blank-flow").click();
-
-    // Add an Agent component
-    await page.getByTestId("sidebar-search-input").fill("agent");
-    await page.waitForTimeout(1000);
-
-    const agentCard = page
-      .locator('[data-testid*="Agent"], [data-testid*="agent"]')
-      .first();
-    const hasAgent = await agentCard
-      .isVisible({ timeout: 5000 })
-      .catch(() => false);
-
-    if (!hasAgent) {
-      console.log("INFO: Agent component not found, skipping");
-      return;
-    }
-
-    await agentCard.hover();
-    await page.waitForTimeout(300);
-
-    const addBtn = page
-      .locator('[data-testid*="add-component-button-agent"]')
-      .first();
-    const hasAddBtn = await addBtn
-      .isVisible({ timeout: 3000 })
-      .catch(() => false);
-
-    if (hasAddBtn) {
-      await addBtn.click();
-    } else {
-      await agentCard.dblclick();
-    }
-
-    await adjustScreenView(page);
-
-    await expect(page.locator(".react-flow__node")).toHaveCount(1, {
-      timeout: 10000,
-    });
-
-    // Open playground
-    const playgroundBtn = page.getByTestId("playground-btn-flow-io");
-    const hasPlayground = await playgroundBtn
-      .isVisible({ timeout: 5000 })
-      .catch(() => false);
-
-    if (!hasPlayground) {
-      console.log("INFO: Playground button not available for agent-only flow, skipping");
-      return;
-    }
-
-    await playgroundBtn.click();
-    await page.waitForSelector('[data-testid="input-chat-playground"]', {
+    await page.getByTestId("side_nav_options_all-templates").click();
+    await page.getByRole("heading", { name: "Simple Agent" }).first().click();
+    await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
       timeout: 30000,
     });
 
-    // Mock the build/run endpoint to return a response with agent steps
-    await page.route("**/api/v1/build/**", async (route) => {
-      const url = route.request().url();
-      if (url.includes("/flow")) {
-        // Return a streaming-style response with agent reasoning steps
-        await route.fulfill({
-          status: 200,
-          contentType: "text/event-stream",
-          body: [
-            'data: {"event": "token", "data": {"chunk": "Thinking..."}}',
-            'data: {"event": "end", "data": {}}',
-          ].join("\n\n"),
-        });
-      } else {
-        await route.continue();
-      }
+    const nodeCount = await page.locator(".react-flow__node").count();
+    expect(nodeCount).toBeGreaterThanOrEqual(1);
+
+    const edgeCount = await page.locator(".react-flow__edge").count();
+    expect(edgeCount).toBeGreaterThanOrEqual(1);
+
+    // Playground button requires Chat I/O components in the flow
+    await expect(page.getByTestId("playground-btn-flow-io")).toBeVisible({
+      timeout: 5000,
     });
-
-    // Send a message
-    await page.getByTestId("input-chat-playground").fill("What tools do you have?");
-    const sendBtn = page.getByTestId("button-send").first();
-    if (await sendBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
-      await sendBtn.click();
-    } else {
-      await page.keyboard.press("Enter");
-    }
-
-    await page.waitForTimeout(2000);
-
-    // Check for any response or agent steps display in the chat
-    const hasResponse = await page
-      .locator('[data-testid*="chat-message"], [class*="message"]')
-      .first()
-      .isVisible({ timeout: 8000 })
-      .catch(() => false);
-
-    const hasSteps = await page
-      .getByText(/thinking|step|reasoning|tool.*call|calling/i)
-      .first()
-      .isVisible({ timeout: 3000 })
-      .catch(() => false);
-
-    // The playground should show some output
-    expect(
-      hasResponse || hasSteps || true,
-      "Playground should display agent response or reasoning steps",
-    ).toBe(true);
   },
 );
+
+// ─── Reasoning steps in the Playground ────────────────────────────────────────
+//
+// Scenario 18.2: "Agent exibe steps de raciocínio no Playground"
+//
+// The agent must use at least one tool so that ContentBlockDisplay renders
+// "Called tool <name>" accordion items in the bot message.
+// The message deliberately asks for tool usage to ensure steps appear.
+//
+// DOM structure (from ContentBlockDisplay.tsx + bot-message.tsx):
+//   - hideHeader=true in bot-message → accordion always rendered (no toggle needed)
+//   - Each tool call → <AccordionTrigger> with text "Called tool <name>"
+//   - Clicking the trigger expands <AccordionContent> (data-state="open")
+//   - After execution → bot-message renders "Finished in Xs" status text
+
+test.describe.serial("Agent reasoning steps in Playground", () => {
+  test(
+    "Simple Agent shows tool call steps in Playground with OpenAI provider",
+    { tag: ["@release", "@components"] },
+    async ({ page }) => {
+      if (!process.env.CI) {
+        dotenv.config({ path: path.resolve(__dirname, "../../../../../.env") });
+      }
+
+      test.skip(
+        !process?.env?.OPENAI_API_KEY,
+        "OPENAI_API_KEY required to run this test",
+      );
+
+      await awaitBootstrapTest(page);
+      await page.getByTestId("side_nav_options_all-templates").click();
+      await page.getByRole("heading", { name: "Simple Agent" }).first().click();
+      await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
+        timeout: 30000,
+      });
+
+      await selectGptModel(page);
+
+      const messageCountBefore = await sendMessageInPlayground(
+        page,
+        // Explicit tool-use instruction ensures content_blocks are populated
+        "You MUST use the Calculator tool. Compute 987 multiplied by 654 using the tool. Do not answer from memory.",
+      );
+
+      // 1. A new bot message must appear
+      await expect(page.getByTestId("div-chat-message")).toHaveCount(
+        messageCountBefore + 1,
+        { timeout: 60000 },
+      );
+
+      // 2. "Finished in Xs" status appears after execution completes
+      await expect(page.getByText(/Finished in/i)).toBeVisible({
+        timeout: 60000,
+      });
+
+      // 3. At least one "Called tool" reasoning step must be visible
+      //    (proves content_blocks were populated and ContentBlockDisplay rendered)
+      await expect(
+        page.getByText(/Called tool/i).first(),
+      ).toBeVisible({ timeout: 10000 });
+
+      // 4. Clicking the first tool step expands its accordion content.
+      //    AccordionTrigger uses asChild=<div> (not <button>), so click the text directly.
+      await page.getByText(/Called tool/i).first().click();
+
+      // Radix AccordionItem/AccordionContent sets data-state="open" when expanded
+      await expect(
+        page.locator('[data-state="open"]').first(),
+      ).toBeVisible({ timeout: 5000 });
+    },
+  );
+
+  test(
+    "Simple Agent shows tool call steps in Playground with Anthropic provider",
+    { tag: ["@release", "@components"] },
+    async ({ page }) => {
+      if (!process.env.CI) {
+        dotenv.config({ path: path.resolve(__dirname, "../../../../../.env") });
+      }
+
+      test.skip(
+        !process?.env?.ANTHROPIC_API_KEY,
+        "ANTHROPIC_API_KEY required to run this test",
+      );
+
+      await awaitBootstrapTest(page);
+      await page.getByTestId("side_nav_options_all-templates").click();
+      await page.getByRole("heading", { name: "Simple Agent" }).first().click();
+      await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
+        timeout: 30000,
+      });
+
+      await selectAnthropicModel(page);
+
+      const messageCountBefore = await sendMessageInPlayground(
+        page,
+        "You MUST use the Calculator tool. Compute 987 multiplied by 654 using the tool. Do not answer from memory.",
+      );
+
+      await expect(page.getByTestId("div-chat-message")).toHaveCount(
+        messageCountBefore + 1,
+        { timeout: 60000 },
+      );
+
+      await expect(page.getByText(/Finished in/i)).toBeVisible({
+        timeout: 60000,
+      });
+
+      await expect(
+        page.getByText(/Called tool/i).first(),
+      ).toBeVisible({ timeout: 10000 });
+
+      await page.getByText(/Called tool/i).first().click();
+
+      await expect(
+        page.locator('[data-state="open"]').first(),
+      ).toBeVisible({ timeout: 5000 });
+    },
+  );
+
+  test(
+    "Simple Agent shows tool call steps in Playground with Google Gemini provider",
+    { tag: ["@release", "@components"] },
+    async ({ page }) => {
+      if (!process.env.CI) {
+        dotenv.config({ path: path.resolve(__dirname, "../../../../../.env") });
+      }
+
+      test.skip(
+        !process?.env?.GOOGLE_API_KEY,
+        "GOOGLE_API_KEY required to run this test",
+      );
+
+      await awaitBootstrapTest(page);
+      await page.getByTestId("side_nav_options_all-templates").click();
+      await page.getByRole("heading", { name: "Simple Agent" }).first().click();
+      await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
+        timeout: 30000,
+      });
+
+      await selectGeminiModel(page);
+
+      const messageCountBefore = await sendMessageInPlayground(
+        page,
+        "You MUST use the Calculator tool. Compute 987 multiplied by 654 using the tool. Do not answer from memory.",
+      );
+
+      await expect(page.getByTestId("div-chat-message")).toHaveCount(
+        messageCountBefore + 1,
+        { timeout: 60000 },
+      );
+
+      await expect(page.getByText(/Finished in/i)).toBeVisible({
+        timeout: 60000,
+      });
+
+      await expect(
+        page.getByText(/Called tool/i).first(),
+      ).toBeVisible({ timeout: 10000 });
+
+      await page.getByText(/Called tool/i).first().click();
+
+      await expect(
+        page.locator('[data-state="open"]').first(),
+      ).toBeVisible({ timeout: 5000 });
+    },
+  );
+
+  test(
+    "Simple Agent correctly switches provider from OpenAI to Anthropic and shows reasoning steps",
+    { tag: ["@release", "@components"] },
+    async ({ page }) => {
+      if (!process.env.CI) {
+        dotenv.config({ path: path.resolve(__dirname, "../../../../../.env") });
+      }
+
+      test.skip(
+        !process?.env?.OPENAI_API_KEY || !process?.env?.ANTHROPIC_API_KEY,
+        "OPENAI_API_KEY and ANTHROPIC_API_KEY are both required for this test",
+      );
+
+      await awaitBootstrapTest(page);
+      await page.getByTestId("side_nav_options_all-templates").click();
+      await page.getByRole("heading", { name: "Simple Agent" }).first().click();
+      await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
+        timeout: 30000,
+      });
+
+      // Configure OpenAI first, then switch to Anthropic
+      await selectGptModel(page);
+      await selectAnthropicModel(page);
+
+      // Model dropdown must reflect the Anthropic selection after the switch
+      await expect(
+        page.getByTestId("value-dropdown-model_model"),
+      ).toContainText("claude", { timeout: 5000 });
+
+      const messageCountBefore = await sendMessageInPlayground(
+        page,
+        "You MUST use the Calculator tool. Compute 987 multiplied by 654 using the tool. Do not answer from memory.",
+      );
+
+      await expect(page.getByTestId("div-chat-message")).toHaveCount(
+        messageCountBefore + 1,
+        { timeout: 60000 },
+      );
+
+      await expect(page.getByText(/Finished in/i)).toBeVisible({
+        timeout: 60000,
+      });
+
+      await expect(
+        page.getByText(/Called tool/i).first(),
+      ).toBeVisible({ timeout: 10000 });
+
+      await page.getByText(/Called tool/i).first().click();
+
+      await expect(
+        page.locator('[data-state="open"]').first(),
+      ).toBeVisible({ timeout: 5000 });
+    },
+  );
+});


### PR DESCRIPTION
## Resumo

- Refatora `agent-reasoning-steps.spec.ts` para testar o cenário **18.2** do `QA-SCENARIOS-GUIDE.md`: _"Agent exibe steps de raciocínio no Playground"_
- Adiciona helper `select-gemini-model.ts` para suporte a Google Gemini
- Refatora `select-gpt-model.ts` e `select-anthropic-model.ts`: fluxo unificado via modal "Manage Model Providers"
- Marca cenário 6.1 como `[x]` no `QA-CHECKLIST.md`

## O que mudou nos testes

**Antes:** verificavam apenas se a resposta chegava (`div-chat-message` count +1)

**Depois:** validam os reasoning steps visíveis no chat:
1. `"Finished in Xs"` — execução concluída com timing
2. `"Called tool <nome>"` — ao menos um tool call foi feito (content_blocks populados)
3. Clique no step — accordion expande (`data-state="open"`)

**Fix de seletor:** `AccordionTrigger` usa `asChild=<div>` (não `<button>`), então `locator("button").filter(...)` nunca encontrava o elemento. Corrigido para `getByText(/Called tool/i).first().click()`.

## Resultados da execução local

| Teste | Resultado |
|-------|-----------|
| Agent component can be added to canvas | ✅ |
| Agent connects to Chat Input and Chat Output | ✅ |
| Simple Agent template loads | ✅ |
| Reasoning steps — OpenAI | ✅ |
| Reasoning steps — Anthropic | ✅ |
| Reasoning steps — Google Gemini | ⚠️ API key inválida no ambiente local |
| OpenAI → Anthropic switch + reasoning steps | ✅ |

## Plano de testes

- [ ] Executar `npx playwright test agent-reasoning-steps.spec.ts --reporter=line`
- [ ] Confirmar que OpenAI e Anthropic passam com API keys válidas
- [ ] Configurar `GOOGLE_API_KEY` válida para validar o teste Gemini