### PR TITLE
fix: corrigir erros de TypeScript no projeto

### DIFF
--- a/tests/tests-automations/regression/api/flows/unit-test-components.spec.ts
+++ b/tests/tests-automations/regression/api/flows/unit-test-components.spec.ts
@@ -1,3 +1,3 @@
-import { test } from "../fixtures/fixtures";
+import { test } from "../../../../fixtures/fixtures";
 
 test("your_test_name", async ({ page }) => {});

--- a/tests/tests-automations/regression/core-components/unit-test-components.spec.ts
+++ b/tests/tests-automations/regression/core-components/unit-test-components.spec.ts
@@ -1,3 +1,3 @@
-import { test } from "../fixtures/fixtures";
+import { test } from "../../../fixtures/fixtures";
 
 test("your_test_name", async ({ page }) => {});

--- a/tests/tests-automations/regression/core-functionality/auth/unit-test-components.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/auth/unit-test-components.spec.ts
@@ -1,3 +1,3 @@
-import { test } from "../fixtures/fixtures";
+import { test } from "../../../../fixtures/fixtures";
 
 test("your_test_name", async ({ page }) => {});

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/unit-test-components.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/unit-test-components.spec.ts
@@ -1,3 +1,3 @@
-import { test } from "../fixtures/fixtures";
+import { test } from "../../../../fixtures/fixtures";
 
 test("your_test_name", async ({ page }) => {});

--- a/tests/tests-automations/regression/core-functionality/llm-agents/unit-test-components.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/unit-test-components.spec.ts
@@ -1,3 +1,3 @@
-import { test } from "../fixtures/fixtures";
+import { test } from "../../../../fixtures/fixtures";
 
 test("your_test_name", async ({ page }) => {});

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail.spec.ts
@@ -28,7 +28,7 @@ test(
       // The logs page should contain either entries or an empty-state message
       const hasContent = await page
         .locator("body")
-        .evaluate((el) => el.innerText.length > 0);
+        .evaluate((el) => (el as HTMLElement).innerText.length > 0);
       expect(hasContent).toBe(true);
     } else {
       // Redirected — the app is still alive and the home page rendered

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/unit-test-components.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/unit-test-components.spec.ts
@@ -1,3 +1,3 @@
-import { test } from "../fixtures/fixtures";
+import { test } from "../../../../fixtures/fixtures";
 
 test("your_test_name", async ({ page }) => {});

--- a/tests/tests-automations/regression/core-functionality/playground/playground-history-persist.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-history-persist.spec.ts
@@ -1,3 +1,4 @@
+import type { Route } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
@@ -9,7 +10,7 @@ async function setupChatFlow(page: any) {
   await page.getByTestId("blank-flow").click();
 
   // Mock the run endpoint so no real backend call is needed
-  await page.route("**/api/v1/run/**", async (route) => {
+  await page.route("**/api/v1/run/**", async (route: Route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",

--- a/tests/tests-automations/regression/core-functionality/playground/playground-message-delete.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-message-delete.spec.ts
@@ -1,3 +1,4 @@
+import type { Route } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
@@ -9,7 +10,7 @@ async function setupConnectedFlow(page: any) {
   await page.getByTestId("blank-flow").click();
 
   // Mock run endpoint
-  await page.route("**/api/v1/run/**", async (route) => {
+  await page.route("**/api/v1/run/**", async (route: Route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",

--- a/tests/tests-automations/regression/core-functionality/playground/unit-test-components.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/unit-test-components.spec.ts
@@ -1,3 +1,3 @@
-import { test } from "../fixtures/fixtures";
+import { test } from "../../../../fixtures/fixtures";
 
 test("your_test_name", async ({ page }) => {});

--- a/tests/tests-automations/regression/core-functionality/project-management/unit-test-components.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/unit-test-components.spec.ts
@@ -1,3 +1,3 @@
-import { test } from "../fixtures/fixtures";
+import { test } from "../../../../fixtures/fixtures";
 
 test("your_test_name", async ({ page }) => {});

--- a/tests/tests-automations/regression/core-functionality/templates/unit-test-components.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/templates/unit-test-components.spec.ts
@@ -1,3 +1,3 @@
-import { test } from "../fixtures/fixtures";
+import { test } from "../../../../fixtures/fixtures";
 
 test("your_test_name", async ({ page }) => {});

--- a/tests/tests-automations/regression/flow-functionality/twoEdges.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/twoEdges.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from "@playwright/test";
 import { test } from "../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 
@@ -12,7 +13,7 @@ test(
     await page.getByText("Search Results", { exact: true }).first().isVisible();
     await page.getByTestId("canvas_controls_dropdown").click();
 
-    const focusElementsOnBoard = async ({ page }) => {
+    const focusElementsOnBoard = async ({ page }: { page: Page }) => {
       await page.waitForSelector('[data-testid="fit_view"]', {
         timeout: 30000,
       });

--- a/tests/tests-automations/regression/flow-functionality/unit-test-components.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/unit-test-components.spec.ts
@@ -1,3 +1,3 @@
-import { test } from "../fixtures/fixtures";
+import { test } from "../../../fixtures/fixtures";
 
 test("your_test_name", async ({ page }) => {});

--- a/tests/tests-automations/regression/mcp/client/unit-test-components.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/unit-test-components.spec.ts
@@ -1,3 +1,3 @@
-import { test } from "../fixtures/fixtures";
+import { test } from "../../../../fixtures/fixtures";
 
 test("your_test_name", async ({ page }) => {});

--- a/tests/tests-automations/regression/mcp/server/unit-test-components.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/unit-test-components.spec.ts
@@ -1,3 +1,3 @@
-import { test } from "../fixtures/fixtures";
+import { test } from "../../../../fixtures/fixtures";
 
 test("your_test_name", async ({ page }) => {});

--- a/tests/tests-automations/regression/ui-ux/filterEdge-shard-0.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/filterEdge-shard-0.spec.ts
@@ -35,7 +35,7 @@ test(
       }
     }
 
-    await visibleElementHandle.hover().then(async () => {
+    await visibleElementHandle!.hover().then(async () => {
       await expect(
         page.getByText("Drag to connect compatible inputs").first(),
       ).toBeVisible();
@@ -70,7 +70,7 @@ test(
 
     await page.waitForTimeout(500);
 
-    await visibleElementHandle.hover().then(async () => {
+    await visibleElementHandle!.hover().then(async () => {
       await page.waitForTimeout(1000);
 
       await expect(
@@ -104,7 +104,7 @@ test(
 
     await page.waitForTimeout(500);
 
-    await visibleElementHandle.hover().then(async () => {
+    await visibleElementHandle!.hover().then(async () => {
       await page.waitForTimeout(1000);
 
       await expect(
@@ -137,7 +137,7 @@ test(
       }
     }
 
-    await visibleElementHandle.hover().then(async () => {
+    await visibleElementHandle!.hover().then(async () => {
       await expect(
         page.getByText("Drag to connect compatible outputs").first(),
       ).toBeVisible();

--- a/tests/tests-automations/regression/ui-ux/unit-test-components.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/unit-test-components.spec.ts
@@ -1,3 +1,3 @@
-import { test } from "../fixtures/fixtures";
+import { test } from "../../../fixtures/fixtures";
 
 test("your_test_name", async ({ page }) => {});

--- a/tests/tests-automations/smoke/api/unit-test-components.spec.ts
+++ b/tests/tests-automations/smoke/api/unit-test-components.spec.ts
@@ -1,3 +1,3 @@
-import { test } from "../fixtures/fixtures";
+import { test } from "../../../fixtures/fixtures";
 
 test("your_test_name", async ({ page }) => {});

--- a/tests/tests-automations/smoke/ui-ux/unit-test-components.spec.ts
+++ b/tests/tests-automations/smoke/ui-ux/unit-test-components.spec.ts
@@ -1,3 +1,3 @@
-import { test } from "../fixtures/fixtures";
+import { test } from "../../../fixtures/fixtures";
 
 test("your_test_name", async ({ page }) => {});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
-    "lib": ["ES2020", "DOM"],
+    "lib": ["ES2022", "DOM"],
     "strict": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
## O que foi feito

Correção de 43 erros de TypeScript pré-existentes no projeto. Nenhuma lógica de teste foi alterada — todas as mudanças são exclusivamente de tipagem.

Esta PR é pré-requisito para a adição de um workflow de validação de PRs com `tsc --noEmit`.

## Correções por categoria

**15 arquivos `unit-test-components.spec.ts` com caminho de import errado**
Cada arquivo importava `from "../fixtures/fixtures"` com um nível a menos do que o necessário. Corrigido o caminho relativo correto para cada pasta.

**`tsconfig.json`: `lib` atualizado de `ES2020` para `ES2022`**
Necessário para reconhecer `Array.at()`, usado em `webhook-component-regression.spec.ts` e `webhook-url-generated.spec.ts`.

**`filterEdge-shard-0.spec.ts`: non-null assertion em `visibleElementHandle`**
A variável é declarada sem valor inicial e atribuída dentro de um `for`. O TypeScript não consegue garantir que o loop atribui o valor — adicionado `!` nos 4 pontos de uso. Comportamento de runtime não muda.

**`playground-history-persist.spec.ts` e `playground-message-delete.spec.ts`: tipo `Route` no callback de `page.route()`**
Parâmetro `route` sem anotação de tipo. Adicionado `import type { Route }` e anotação no callback.

**`twoEdges.spec.ts`: tipo `Page` em callback interno**
Função local `focusElementsOnBoard` recebia `{ page }` sem tipo. Adicionado `import type { Page }` e anotação.

**`traces-detail.spec.ts`: cast para `HTMLElement` em `.evaluate()`**
`el.innerText` falha no TypeScript porque `el` pode ser `SVGElement`. Adicionado cast `(el as HTMLElement)`.

## Como foi validado

`npx tsc --noEmit` passa sem nenhum erro após as correções.