### PR TITLE
docs: adiciona template de pull request

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+## Tipo
+
+<!-- Marque com [x] o tipo desta PR -->
+
+- [ ] `feat` — novo teste ou novo helper/page object
+- [ ] `fix` — correção de teste quebrado ou flaky
+- [ ] `chore` — CI, checklist, dependências, refatoração interna
+- [ ] `docs` — atualização de documentação
+
+---
+
+## O que esta PR faz
+
+<!-- Descreva o que foi adicionado, corrigido ou alterado. Seja direto. -->
+
+---
+
+## Issue relacionada
+
+<!-- Preencha se esta PR resolver uma issue gerada pelo file-watcher ou um bug rastreado.
+     Caso contrário, apague esta seção. -->
+
+Closes #
+
+---
+
+## Validação
+
+<!-- Para PRs do tipo feat ou fix, descreva como o teste foi validado.
+     Para chore e docs, descreva o que foi verificado (ex: tsc passou, nenhum teste quebrou).
+     Apague os itens que não se aplicam. -->
+
+- [ ] Rodei o teste isolado com `--trace=on` e verifiquei os steps no relatório
+- [ ] Forcei uma falha para confirmar que não é falso positivo
+- [ ] Rodei em modo `--debug` e acompanhei passo a passo
+- [ ] Confirmei que não há erros de backend (`🚨 Backend Error:`) no output
+- [ ] Atualizei o `QA-CHECKLIST.md`


### PR DESCRIPTION
## Tipo

- [x] `docs` — atualização de documentação

---

## O que esta PR faz

Cria `.github/PULL_REQUEST_TEMPLATE.md`, que o GitHub carrega automaticamente ao abrir qualquer nova PR neste repositório.

O CONTRIBUTING.md menciona um template de PR como parte do processo de revisão, mas o arquivo não existia. Esta PR resolve essa lacuna.

O template inclui:

- **Seletor de tipo** — checkboxes para `feat`, `fix`, `chore` e `docs`, alinhados às convenções de commit do CONTRIBUTING
- **Seção de descrição** — campo livre para descrever o que foi adicionado, corrigido ou alterado
- **Issue relacionada** — seção opcional (com instrução para apagar se não aplicável)
- **Checklist de validação** — os 5 passos do CONTRIBUTING (trace, falha forçada, debug, erro de backend, QA-CHECKLIST), com nota para apagar itens que não se aplicam ao tipo da PR

---

## Validação

- [x] Confirmei que o arquivo está em `.github/PULL_REQUEST_TEMPLATE.md` (caminho reconhecido pelo GitHub)
- [x] Confirmei que o conteúdo está alinhado ao CONTRIBUTING.md
- [x] `tsc --noEmit` não é aplicável (arquivo Markdown, sem código TypeScript)