### PR TITLE
fix(playground): repair fullscreen selectors and test robustness (A1)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -397,7 +397,7 @@
 - [-] Histórico persiste ao reabrir Playground
 
 #### 9.3 Features Avançadas do Playground
-- [x] Modo fullscreen do Playground → `core/features/playground-fullscreen.spec.ts`
+- [x] Modo fullscreen do Playground → `playground/playground-fullscreen.spec.ts`
 - [ ] Playground compartilhável (URL pública, sem autenticação)
 - [-] Voice mode (assistente de voz)
 - [-] Botão Stop no Playground

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -397,7 +397,7 @@
 - [-] Histórico persiste ao reabrir Playground
 
 #### 9.3 Features Avançadas do Playground
-- [-] Modo fullscreen do Playground
+- [x] Modo fullscreen do Playground → `core/features/playground-fullscreen.spec.ts`
 - [ ] Playground compartilhável (URL pública, sem autenticação)
 - [-] Voice mode (assistente de voz)
 - [-] Botão Stop no Playground

--- a/docs/core-functionality/playground/playground-fullscreen.md
+++ b/docs/core-functionality/playground/playground-fullscreen.md
@@ -50,7 +50,7 @@ O Playground migrou de um modal com botão de expandir para um fullscreen direto
 
 ## Pré-condições *(opcional)*
 - Langflow rodando e acessível em `PLAYWRIGHT_BASE_URL`
-- Nenhum flow pré-existente necessário (o teste cria e limpa o próprio flow via API)
+- Nenhum flow pré-existente necessário; o teste cria o flow, registra o ID retornado na URL e o apaga via API no `afterEach`
 
 ---
 
@@ -69,5 +69,5 @@ O Playground migrou de um modal com botão de expandir para um fullscreen direto
 
 ## Notas *(opcional)*
 - Os dois testes rodam em modo `serial` para evitar conflitos de flow no editor
-- Limpeza de flows feita via API (`DELETE /api/v1/flows/{id}`) para evitar instabilidade do dropdown Radix UI no `cleanAllFlows`
+- Limpeza feita via API (`DELETE /api/v1/flows/{id}`) somente para o flow criado pelo próprio teste; o ID é extraído da URL após o setup
 - Última validação: 1.10.x (abril 2026)

--- a/docs/core-functionality/playground/playground-fullscreen.md
+++ b/docs/core-functionality/playground/playground-fullscreen.md
@@ -1,11 +1,12 @@
 # Playground — Open and Close Behavior
 
-## Objetivo *(obrigatório)*
-Valida que o Playground abre diretamente em modo fullscreen ao ser acionado no editor de flows e que pode ser fechado e reaberto corretamente. Se este teste falhar, o acesso ao Playground a partir do editor está quebrado.
+**Última validação:** Langflow 1.10.x
 
 ---
 
-## Motivação *(obrigatório)*
+## O que este teste valida *(obrigatório)*
+Valida que o Playground abre diretamente em modo fullscreen ao ser acionado no editor de flows e que pode ser fechado e reaberto corretamente. Se este teste falhar, o acesso ao Playground a partir do editor está quebrado.
+
 O Playground migrou de um modal com botão de expandir para um fullscreen direto. O teste anterior tentava localizar um botão de fullscreen com seletores genéricos (`[data-testid*="maximize"]`) e fazia skip silencioso quando não encontrava — o que mascarava regressões. Esta spec fixa os seletores contra o comportamento real da versão atual (1.10.x+).
 
 ---
@@ -41,6 +42,13 @@ O Playground migrou de um modal com botão de expandir para um fullscreen direto
 
 ---
 
+## Dependências externas *(obrigatório)*
+
+- `src/frontend/src/components/core/playgroundComponent/` — componente principal do Playground; mudanças em `data-testid="playground-close-button"` ou `data-testid="input-chat-playground"` quebram este teste
+- `src/frontend/src/components/core/flowToolbarComponent/` — botão `playground-btn-flow-io` que abre o Playground a partir do editor
+
+---
+
 ## O que este teste não cobre *(opcional)*
 - Envio de mensagens ou execução de flows no Playground
 - Voice mode e funcionalidades avançadas do Playground
@@ -54,13 +62,6 @@ O Playground migrou de um modal com botão de expandir para um fullscreen direto
 
 ---
 
-## Dependências externas *(obrigatório)*
-
-- `src/frontend/src/components/core/playgroundComponent/` — componente principal do Playground; mudanças em `data-testid="playground-close-button"` ou `data-testid="input-chat-playground"` quebram este teste
-- `src/frontend/src/components/core/flowToolbarComponent/` — botão `playground-btn-flow-io` que abre o Playground a partir do editor
-
----
-
 ## Quando revisar este teste *(opcional)*
 - Se o Playground voltar a ter um modo não-fullscreen (botão de expansão separado): o teste de abertura precisaria ser atualizado
 - Se o botão de fechar for removido ou renomeado
@@ -70,4 +71,3 @@ O Playground migrou de um modal com botão de expandir para um fullscreen direto
 ## Notas *(opcional)*
 - Os dois testes rodam em modo `serial` para evitar conflitos de flow no editor
 - Limpeza feita via API (`DELETE /api/v1/flows/{id}`) somente para o flow criado pelo próprio teste; o ID é extraído da URL após o setup
-- Última validação: 1.10.x (abril 2026)

--- a/docs/core-functionality/playground/playground-fullscreen.md
+++ b/docs/core-functionality/playground/playground-fullscreen.md
@@ -1,0 +1,73 @@
+# Playground — Open and Close Behavior
+
+## Objetivo *(obrigatório)*
+Valida que o Playground abre diretamente em modo fullscreen ao ser acionado no editor de flows e que pode ser fechado e reaberto corretamente. Se este teste falhar, o acesso ao Playground a partir do editor está quebrado.
+
+---
+
+## Motivação *(obrigatório)*
+O Playground migrou de um modal com botão de expandir para um fullscreen direto. O teste anterior tentava localizar um botão de fullscreen com seletores genéricos (`[data-testid*="maximize"]`) e fazia skip silencioso quando não encontrava — o que mascarava regressões. Esta spec fixa os seletores contra o comportamento real da versão atual (1.10.x+).
+
+---
+
+## Tags *(obrigatório)*
+`@stable` `@release` `@regression` `@playground`
+
+---
+
+## Passo a passo *(obrigatório)*
+
+**Teste 1 — playground opens in fullscreen with chat input visible**
+1. Criar flow em branco com ChatInput conectado ao ChatOutput
+2. Clicar no botão `playground-btn-flow-io` na toolbar
+3. Confirmar que `playground-close-button` aparece imediatamente (indica fullscreen)
+4. Confirmar que `input-chat-playground` está visível
+
+**Teste 2 — playground closes and reopens correctly from the flow editor**
+1. Criar flow em branco com ChatInput conectado ao ChatOutput
+2. Abrir o Playground e aguardar `playground-close-button`
+3. Clicar no botão de fechar (`playground-close-button`)
+4. Confirmar que `input-chat-playground` não está mais visível
+5. Reabrir o Playground via `playground-btn-flow-io`
+6. Confirmar que `input-chat-playground` volta a estar visível
+
+---
+
+## Critério de validação *(obrigatório)*
+- O Playground abre em fullscreen (sem etapa de expansão): `playground-close-button` presente imediatamente após abrir
+- O chat input (`input-chat-playground`) está visível após abrir
+- Após fechar, o chat input deixa de estar visível
+- Após reabrir, o chat input volta a estar visível
+
+---
+
+## O que este teste não cobre *(opcional)*
+- Envio de mensagens ou execução de flows no Playground
+- Voice mode e funcionalidades avançadas do Playground
+- Comportamento com múltiplas sessões abertas
+
+---
+
+## Pré-condições *(opcional)*
+- Langflow rodando e acessível em `PLAYWRIGHT_BASE_URL`
+- Nenhum flow pré-existente necessário (o teste cria e limpa o próprio flow via API)
+
+---
+
+## Dependências externas *(obrigatório)*
+
+- `src/frontend/src/components/core/playgroundComponent/` — componente principal do Playground; mudanças em `data-testid="playground-close-button"` ou `data-testid="input-chat-playground"` quebram este teste
+- `src/frontend/src/components/core/flowToolbarComponent/` — botão `playground-btn-flow-io` que abre o Playground a partir do editor
+
+---
+
+## Quando revisar este teste *(opcional)*
+- Se o Playground voltar a ter um modo não-fullscreen (botão de expansão separado): o teste de abertura precisaria ser atualizado
+- Se o botão de fechar for removido ou renomeado
+
+---
+
+## Notas *(opcional)*
+- Os dois testes rodam em modo `serial` para evitar conflitos de flow no editor
+- Limpeza de flows feita via API (`DELETE /api/v1/flows/{id}`) para evitar instabilidade do dropdown Radix UI no `cleanAllFlows`
+- Última validação: 1.10.x (abril 2026)

--- a/tests/tests-automations/regression/core-functionality/playground/playground-fullscreen.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-fullscreen.spec.ts
@@ -8,7 +8,6 @@ async function setupPlayground(page: any) {
   await page.waitForSelector('[data-testid="blank-flow"]', { timeout: 30000 });
   await page.getByTestId("blank-flow").click();
 
-  // Add ChatOutput
   await page.getByTestId("sidebar-search-input").fill("chat output");
   await page.waitForSelector('[data-testid="input_outputChat Output"]', {
     timeout: 30000,
@@ -22,7 +21,6 @@ async function setupPlayground(page: any) {
 
   await zoomOut(page, 2);
 
-  // Add ChatInput via drag
   await page.getByTestId("sidebar-search-input").fill("chat input");
   await page.waitForSelector('[data-testid="input_outputChat Input"]', {
     timeout: 30000,
@@ -39,7 +37,6 @@ async function setupPlayground(page: any) {
     timeout: 10000,
   });
 
-  // Connect ChatInput → ChatOutput
   await page
     .getByTestId("handle-chatinput-noshownode-chat message-source")
     .click();
@@ -52,102 +49,80 @@ async function setupPlayground(page: any) {
   });
 }
 
-test(
-  "playground modal is visible after opening from the flow editor",
-  { tag: ["@release", "@workspace", "@regression", "@playground"] },
-  async ({ page }) => {
-    await setupPlayground(page);
+test.describe("Playground — fullscreen and panel behavior", () => {
+  test(
+    "playground modal is visible after opening from the flow editor",
+    { tag: ["@release", "@workspace", "@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step("Set up ChatInput → ChatOutput flow", async () => {
+        await setupPlayground(page);
+      });
 
-    await page.getByTestId("playground-btn-flow-io").click();
-    await page.waitForSelector('[data-testid="input-chat-playground"]', {
-      timeout: 15000,
-    });
+      await test.step("Open playground and confirm chat input is visible", async () => {
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(
+          page.getByTestId("input-chat-playground").last(),
+        ).toBeVisible({ timeout: 15000 });
+      });
+    },
+  );
 
-    await expect(
-      page.getByTestId("input-chat-playground").last(),
-    ).toBeVisible({ timeout: 5000 });
-  },
-);
+  test(
+    "playground fullscreen button expands the view",
+    { tag: ["@release", "@workspace", "@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step("Set up ChatInput → ChatOutput flow and open playground", async () => {
+        await setupPlayground(page);
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(
+          page.getByTestId("input-chat-playground").last(),
+        ).toBeVisible({ timeout: 15000 });
+      });
 
-test(
-  "playground fullscreen button expands the view when available",
-  { tag: ["@release", "@workspace", "@regression", "@playground"] },
-  async ({ page }) => {
-    await setupPlayground(page);
+      await test.step("Click fullscreen button", async () => {
+        await page.getByRole("button", { name: "Enter fullscreen" }).click();
+      });
 
-    await page.getByTestId("playground-btn-flow-io").click();
-    await page.waitForSelector('[data-testid="input-chat-playground"]', {
-      timeout: 15000,
-    });
+      await test.step("Confirm close button appears and chat input remains visible", async () => {
+        await expect(
+          page.getByTestId("playground-close-button"),
+        ).toBeVisible({ timeout: 5000 });
+        await expect(
+          page.getByTestId("input-chat-playground").last(),
+        ).toBeVisible({ timeout: 5000 });
+      });
+    },
+  );
 
-    await expect(
-      page.getByTestId("input-chat-playground").last(),
-    ).toBeVisible({ timeout: 5000 });
+  test(
+    "playground can be closed and reopened from the flow editor",
+    { tag: ["@release", "@workspace", "@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step("Set up ChatInput → ChatOutput flow and open playground", async () => {
+        await setupPlayground(page);
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(
+          page.getByTestId("input-chat-playground").last(),
+        ).toBeVisible({ timeout: 15000 });
+      });
 
-    // Locate fullscreen button — try the most common testid patterns
-    const fullscreenBtn = page
-      .locator('[data-testid*="maximize"], [data-testid*="fullscreen"], [data-testid="icon-Maximize2"], [data-testid="icon-Maximize"]')
-      .first();
+      await test.step("Enter fullscreen and close playground via keyboard", async () => {
+        await page.getByRole("button", { name: "Enter fullscreen" }).click();
+        const closeBtn = page.getByTestId("playground-close-button");
+        await expect(closeBtn).toBeVisible({ timeout: 5000 });
+        await closeBtn.focus();
+        await page.keyboard.press("Enter");
+        await expect(
+          page.getByTestId("input-chat-playground").last(),
+        ).not.toBeVisible({ timeout: 5000 });
+      });
 
-    const isPresent = await fullscreenBtn.isVisible({ timeout: 3000 }).catch(() => false);
-
-    if (!isPresent) {
-      test.skip(true, "Fullscreen button not found — run DOM discovery: page.evaluate(() => Array.from(document.querySelectorAll('[data-testid]')).map(e => e.getAttribute('data-testid')).filter(id => /max|full|screen/i.test(id ?? '')))");
-      return;
-    }
-
-    await fullscreenBtn.click();
-    await page.waitForTimeout(300);
-
-    // After expanding, the input must still be visible
-    await expect(
-      page.getByTestId("input-chat-playground").last(),
-    ).toBeVisible({ timeout: 5000 });
-
-    // A minimize/collapse button must appear
-    const minimizeBtn = page.locator(
-      '[data-testid*="minimize"], [data-testid*="collapse"], [data-testid="icon-Minimize2"], [data-testid="icon-Minimize"]',
-    ).first();
-    await expect(minimizeBtn).toBeVisible({ timeout: 3000 });
-  },
-);
-
-test(
-  "playground can be closed and reopened from the flow editor",
-  { tag: ["@release", "@workspace", "@regression", "@playground"] },
-  async ({ page }) => {
-    await setupPlayground(page);
-
-    // Open playground
-    await page.getByTestId("playground-btn-flow-io").click();
-    await page.waitForSelector('[data-testid="input-chat-playground"]', {
-      timeout: 15000,
-    });
-    await expect(
-      page.getByTestId("input-chat-playground").last(),
-    ).toBeVisible({ timeout: 5000 });
-
-    // Close the playground — use JS click because the panel overlaps the button
-    await page.evaluate(() => {
-      const btn = document.querySelector(
-        '[data-testid="playground-btn-flow-io"]',
-      ) as HTMLElement | null;
-      if (btn) btn.click();
-    });
-    await page.waitForTimeout(800);
-
-    // Playground input should no longer be visible
-    await expect(
-      page.getByTestId("input-chat-playground").last(),
-    ).not.toBeVisible({ timeout: 5000 });
-
-    // Reopen
-    await page.getByTestId("playground-btn-flow-io").click();
-    await page.waitForSelector('[data-testid="input-chat-playground"]', {
-      timeout: 15000,
-    });
-    await expect(
-      page.getByTestId("input-chat-playground").last(),
-    ).toBeVisible({ timeout: 5000 });
-  },
-);
+      await test.step("Reopen playground and confirm chat input is visible again", async () => {
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(
+          page.getByTestId("input-chat-playground").last(),
+        ).toBeVisible({ timeout: 15000 });
+      });
+    },
+  );
+});

--- a/tests/tests-automations/regression/core-functionality/playground/playground-fullscreen.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-fullscreen.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { cleanAllFlows } from "../../../../helpers/flows/clean-all-flows";
 import { zoomOut } from "../../../../helpers/ui/zoom-out";
 
 async function setupPlayground(page: any) {
@@ -49,10 +50,17 @@ async function setupPlayground(page: any) {
   });
 }
 
+test.describe.configure({ mode: "serial" });
+
 test.describe("Playground — fullscreen and panel behavior", () => {
+  test.afterEach(async ({ page }) => {
+    await page.goto("/");
+    await cleanAllFlows(page);
+  });
+
   test(
     "playground modal is visible after opening from the flow editor",
-    { tag: ["@release", "@workspace", "@regression", "@playground"] },
+    { tag: ["@release", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step("Set up ChatInput → ChatOutput flow", async () => {
         await setupPlayground(page);
@@ -69,7 +77,7 @@ test.describe("Playground — fullscreen and panel behavior", () => {
 
   test(
     "playground fullscreen button expands the view",
-    { tag: ["@release", "@workspace", "@regression", "@playground"] },
+    { tag: ["@release", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step("Set up ChatInput → ChatOutput flow and open playground", async () => {
         await setupPlayground(page);
@@ -79,14 +87,29 @@ test.describe("Playground — fullscreen and panel behavior", () => {
         ).toBeVisible({ timeout: 15000 });
       });
 
-      await test.step("Click fullscreen button", async () => {
-        await page.getByRole("button", { name: "Enter fullscreen" }).click();
+      await test.step("Confirm new-chat button is absent before entering fullscreen", async () => {
+        // new-chat only appears in the fullscreen toolbar; absence confirms we are not yet in fullscreen
+        await expect(page.getByTestId("new-chat")).not.toBeVisible();
       });
 
-      await test.step("Confirm close button appears and chat input remains visible", async () => {
+      await test.step("Click fullscreen button", async () => {
+        await page
+          .getByRole("button", { name: "Enter fullscreen" })
+          .click();
+      });
+
+      await test.step("Confirm fullscreen state toggled correctly", async () => {
+        // new-chat appearing is the definitive sign the fullscreen transition happened
+        await expect(
+          page.getByTestId("new-chat"),
+        ).toBeVisible({ timeout: 5000 });
+
+        // Close button must remain accessible
         await expect(
           page.getByTestId("playground-close-button"),
         ).toBeVisible({ timeout: 5000 });
+
+        // Chat input must remain reachable in the expanded panel
         await expect(
           page.getByTestId("input-chat-playground").last(),
         ).toBeVisible({ timeout: 5000 });
@@ -96,7 +119,7 @@ test.describe("Playground — fullscreen and panel behavior", () => {
 
   test(
     "playground can be closed and reopened from the flow editor",
-    { tag: ["@release", "@workspace", "@regression", "@playground"] },
+    { tag: ["@release", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step("Set up ChatInput → ChatOutput flow and open playground", async () => {
         await setupPlayground(page);
@@ -107,7 +130,9 @@ test.describe("Playground — fullscreen and panel behavior", () => {
       });
 
       await test.step("Enter fullscreen and close playground via keyboard", async () => {
-        await page.getByRole("button", { name: "Enter fullscreen" }).click();
+        await page
+          .getByRole("button", { name: "Enter fullscreen" })
+          .click();
         const closeBtn = page.getByTestId("playground-close-button");
         await expect(closeBtn).toBeVisible({ timeout: 5000 });
         await closeBtn.focus();

--- a/tests/tests-automations/regression/core-functionality/playground/playground-fullscreen.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-fullscreen.spec.ts
@@ -6,6 +6,16 @@ import { zoomOut } from "../../../../helpers/ui/zoom-out";
 async function setupPlayground(page: any): Promise<string> {
   await awaitBootstrapTest(page);
   await page.waitForSelector('[data-testid="blank-flow"]', { timeout: 30000 });
+
+  // Intercept the flow creation response to get the authoritative backend ID
+  const flowCreationPromise = page.waitForResponse(
+    (resp: { url: () => string; request: () => { method: () => string }; status: () => number }) =>
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201,
+    { timeout: 15000 },
+  );
+
   await page.getByTestId("blank-flow").click();
 
   await page.getByTestId("sidebar-search-input").fill("chat output");
@@ -48,10 +58,9 @@ async function setupPlayground(page: any): Promise<string> {
     timeout: 8000,
   });
 
-  const match = page
-    .url()
-    .match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i);
-  return match?.[1] ?? "";
+  const creationResponse = await flowCreationPromise;
+  const flowData = await creationResponse.json();
+  return (flowData.id as string) ?? "";
 }
 
 test.describe("Playground — open and close behavior", () => {
@@ -61,6 +70,10 @@ test.describe("Playground — open and close behavior", () => {
 
   test.afterEach(async ({ page }) => {
     if (createdFlowId) {
+      // Navigate to home before deleting to stop background browser requests
+      // for the current flow; without this, pending polling GETs complete
+      // after the DELETE and trigger spurious 404 fixture errors.
+      await page.goto("/");
       await page.request.delete(`/api/v1/flows/${createdFlowId}`);
       createdFlowId = null;
     }

--- a/tests/tests-automations/regression/core-functionality/playground/playground-fullscreen.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-fullscreen.spec.ts
@@ -50,66 +50,28 @@ async function setupPlayground(page: any) {
   });
 }
 
-test.describe.configure({ mode: "serial" });
+test.describe("Playground — open and close behavior", () => {
+  test.describe.configure({ mode: "serial" });
 
-test.describe("Playground — fullscreen and panel behavior", () => {
   test.afterEach(async ({ page }) => {
     await page.goto("/");
     await cleanAllFlows(page);
   });
 
   test(
-    "playground modal is visible after opening from the flow editor",
+    "playground opens in fullscreen with chat input visible",
     { tag: ["@release", "@regression", "@playground"] },
     async ({ page }) => {
-      await test.step("Set up ChatInput → ChatOutput flow", async () => {
+      await test.step("set up ChatInput → ChatOutput flow", async () => {
         await setupPlayground(page);
       });
 
-      await test.step("Open playground and confirm chat input is visible", async () => {
+      await test.step("open playground and confirm it opens in fullscreen with chat input", async () => {
         await page.getByTestId("playground-btn-flow-io").click();
-        await expect(
-          page.getByTestId("input-chat-playground").last(),
-        ).toBeVisible({ timeout: 15000 });
-      });
-    },
-  );
-
-  test(
-    "playground fullscreen button expands the view",
-    { tag: ["@release", "@regression", "@playground"] },
-    async ({ page }) => {
-      await test.step("Set up ChatInput → ChatOutput flow and open playground", async () => {
-        await setupPlayground(page);
-        await page.getByTestId("playground-btn-flow-io").click();
-        await expect(
-          page.getByTestId("input-chat-playground").last(),
-        ).toBeVisible({ timeout: 15000 });
-      });
-
-      await test.step("Confirm new-chat button is absent before entering fullscreen", async () => {
-        // new-chat only appears in the fullscreen toolbar; absence confirms we are not yet in fullscreen
-        await expect(page.getByTestId("new-chat")).not.toBeVisible();
-      });
-
-      await test.step("Click fullscreen button", async () => {
-        await page
-          .getByRole("button", { name: "Enter fullscreen" })
-          .click();
-      });
-
-      await test.step("Confirm fullscreen state toggled correctly", async () => {
-        // new-chat appearing is the definitive sign the fullscreen transition happened
-        await expect(
-          page.getByTestId("new-chat"),
-        ).toBeVisible({ timeout: 5000 });
-
-        // Close button must remain accessible
+        // playground always opens directly in fullscreen — close button is present immediately
         await expect(
           page.getByTestId("playground-close-button"),
-        ).toBeVisible({ timeout: 5000 });
-
-        // Chat input must remain reachable in the expanded panel
+        ).toBeVisible({ timeout: 15000 });
         await expect(
           page.getByTestId("input-chat-playground").last(),
         ).toBeVisible({ timeout: 5000 });
@@ -118,31 +80,25 @@ test.describe("Playground — fullscreen and panel behavior", () => {
   );
 
   test(
-    "playground can be closed and reopened from the flow editor",
+    "playground closes and reopens correctly from the flow editor",
     { tag: ["@release", "@regression", "@playground"] },
     async ({ page }) => {
-      await test.step("Set up ChatInput → ChatOutput flow and open playground", async () => {
+      await test.step("set up ChatInput → ChatOutput flow and open playground", async () => {
         await setupPlayground(page);
         await page.getByTestId("playground-btn-flow-io").click();
         await expect(
-          page.getByTestId("input-chat-playground").last(),
+          page.getByTestId("playground-close-button"),
         ).toBeVisible({ timeout: 15000 });
       });
 
-      await test.step("Enter fullscreen and close playground via keyboard", async () => {
-        await page
-          .getByRole("button", { name: "Enter fullscreen" })
-          .click();
-        const closeBtn = page.getByTestId("playground-close-button");
-        await expect(closeBtn).toBeVisible({ timeout: 5000 });
-        await closeBtn.focus();
-        await page.keyboard.press("Enter");
+      await test.step("close playground via close button", async () => {
+        await page.getByTestId("playground-close-button").click();
         await expect(
           page.getByTestId("input-chat-playground").last(),
         ).not.toBeVisible({ timeout: 5000 });
       });
 
-      await test.step("Reopen playground and confirm chat input is visible again", async () => {
+      await test.step("reopen playground and confirm chat input is visible again", async () => {
         await page.getByTestId("playground-btn-flow-io").click();
         await expect(
           page.getByTestId("input-chat-playground").last(),

--- a/tests/tests-automations/regression/core-functionality/playground/playground-fullscreen.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-fullscreen.spec.ts
@@ -3,7 +3,7 @@ import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { zoomOut } from "../../../../helpers/ui/zoom-out";
 
-async function setupPlayground(page: any) {
+async function setupPlayground(page: any): Promise<string> {
   await awaitBootstrapTest(page);
   await page.waitForSelector('[data-testid="blank-flow"]', { timeout: 30000 });
   await page.getByTestId("blank-flow").click();
@@ -47,18 +47,22 @@ async function setupPlayground(page: any) {
   await expect(page.locator(".react-flow__edge")).toHaveCount(1, {
     timeout: 8000,
   });
+
+  const match = page
+    .url()
+    .match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i);
+  return match?.[1] ?? "";
 }
 
 test.describe("Playground — open and close behavior", () => {
   test.describe.configure({ mode: "serial" });
 
+  let createdFlowId: string | null = null;
+
   test.afterEach(async ({ page }) => {
-    const flowsRes = await page.request.get("/api/v1/flows/?get_all=true");
-    if (flowsRes.ok()) {
-      const flows: Array<{ id: string }> = await flowsRes.json();
-      for (const flow of flows) {
-        await page.request.delete(`/api/v1/flows/${flow.id}`);
-      }
+    if (createdFlowId) {
+      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      createdFlowId = null;
     }
   });
 
@@ -67,7 +71,7 @@ test.describe("Playground — open and close behavior", () => {
     { tag: ["@stable", "@release", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step("set up ChatInput → ChatOutput flow", async () => {
-        await setupPlayground(page);
+        createdFlowId = await setupPlayground(page);
       });
 
       await test.step("open playground and confirm it opens in fullscreen with chat input", async () => {
@@ -88,7 +92,7 @@ test.describe("Playground — open and close behavior", () => {
     { tag: ["@stable", "@release", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step("set up ChatInput → ChatOutput flow and open playground", async () => {
-        await setupPlayground(page);
+        createdFlowId = await setupPlayground(page);
         await page.getByTestId("playground-btn-flow-io").click();
         await expect(
           page.getByTestId("playground-close-button"),

--- a/tests/tests-automations/regression/core-functionality/playground/playground-fullscreen.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-fullscreen.spec.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
-import { cleanAllFlows } from "../../../../helpers/flows/clean-all-flows";
 import { zoomOut } from "../../../../helpers/ui/zoom-out";
 
 async function setupPlayground(page: any) {
@@ -54,13 +53,18 @@ test.describe("Playground — open and close behavior", () => {
   test.describe.configure({ mode: "serial" });
 
   test.afterEach(async ({ page }) => {
-    await page.goto("/");
-    await cleanAllFlows(page);
+    const flowsRes = await page.request.get("/api/v1/flows/?get_all=true");
+    if (flowsRes.ok()) {
+      const flows: Array<{ id: string }> = await flowsRes.json();
+      for (const flow of flows) {
+        await page.request.delete(`/api/v1/flows/${flow.id}`);
+      }
+    }
   });
 
   test(
     "playground opens in fullscreen with chat input visible",
-    { tag: ["@release", "@regression", "@playground"] },
+    { tag: ["@stable", "@release", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step("set up ChatInput → ChatOutput flow", async () => {
         await setupPlayground(page);
@@ -81,7 +85,7 @@ test.describe("Playground — open and close behavior", () => {
 
   test(
     "playground closes and reopens correctly from the flow editor",
-    { tag: ["@release", "@regression", "@playground"] },
+    { tag: ["@stable", "@release", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step("set up ChatInput → ChatOutput flow and open playground", async () => {
         await setupPlayground(page);


### PR DESCRIPTION
## Summary

- Substitui os seletores quebrados em `playground-fullscreen.spec.ts` por `data-testid`s verificados no source do Langflow
- Remove o teste de botão fullscreen (o playground sempre abre já em fullscreen — o botão nunca aparece)
- Reescreve as asserções seguindo padrões web-first (`expect(...).toBeVisible()`, sem `waitForSelector` ou `waitForTimeout`)
- Agrupa os testes em `test.describe` com `mode: "serial"` para prevenir conflitos de estado no editor
- Cleanup via API: o `afterEach` registra o ID do flow criado e apaga apenas ele, sem tocar em flows de outros testes

## Tests covered (2)

| # | Descrição |
|---|---|
| 1 | Playground abre diretamente em fullscreen com o chat input visível |
| 2 | Playground fecha e reabre corretamente a partir do editor de flows |

## Test plan

- [ ] Rodar com `--trace=on` e confirmar que os 2 testes passam
- [ ] Forçar falha num seletor para confirmar ausência de falso positivo
- [ ] Confirmar ausência de `🚨 Backend Error:` na saída