### PR TITLE
feat(playground): add structured data output rendering tests (B0 + B0b)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -365,7 +365,7 @@
 
 #### 9.5 Output de Dados Estruturados
 - [x] JSON Data output renderiza como code block → `core-functionality/playground/playground-output-data.spec.ts`
-- [x] DataFrame output renderiza como tabela markdown → `core-functionality/playground/playground-output-data.spec.ts`
+- [x] DataFrame output renderiza como tabela Markdown → `core-functionality/playground/playground-output-data.spec.ts`
 
 ---
 

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -591,7 +591,7 @@
 | `api/` — API REST | 17 | 17 | 0 | 0 |
 | `core-components/` — Config | 20 | 18 | 0 | 2 |
 | `core-components/` — Componentes | 22 | 16 | 0 | 6 |
-| `core-functionality/playground/` | 19 | 16 | 0 | 3 |
+| `core-functionality/playground/` | 17 | 14 | 0 | 3 |
 | `core-functionality/observability-monitoring/` | 16 | 13 | 0 | 3 |
 | `core-functionality/model-provider/` | 16 | 10 | 0 | 6 |
 | `core-functionality/knowledge-ingestion/` | 8 | 4 | 0 | 4 |

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -363,6 +363,10 @@
 - [-] Copiar output do componente → `extended/features/output-modal-copy-button.spec.ts`
 - [-] Botão de copy no output → `extended/features/copy-button-in-output.spec.ts`
 
+#### 9.5 Output de Dados Estruturados
+- [x] JSON Data output renderiza como code block → `core-functionality/playground/playground-output-data.spec.ts`
+- [x] DataFrame output renderiza como tabela markdown → `core-functionality/playground/playground-output-data.spec.ts`
+
 ---
 
 ### core-functionality/project-management/ — Gestão de Projetos e Pastas
@@ -587,7 +591,7 @@
 | `api/` — API REST | 17 | 17 | 0 | 0 |
 | `core-components/` — Config | 20 | 18 | 0 | 2 |
 | `core-components/` — Componentes | 22 | 16 | 0 | 6 |
-| `core-functionality/playground/` | 17 | 14 | 0 | 3 |
+| `core-functionality/playground/` | 19 | 16 | 0 | 3 |
 | `core-functionality/observability-monitoring/` | 16 | 13 | 0 | 3 |
 | `core-functionality/model-provider/` | 16 | 10 | 0 | 6 |
 | `core-functionality/knowledge-ingestion/` | 8 | 4 | 0 | 4 |

--- a/docs/core-functionality/playground/playground-output-data.md
+++ b/docs/core-functionality/playground/playground-output-data.md
@@ -6,8 +6,8 @@
 
 Verifica que o Playground renderiza corretamente saídas de dados estruturados gerados pelo componente Mock Data:
 
-1. `data_output` (tipo `Data`) é serializado via `_serialize_data` e exibido como um bloco de código JSON (`\`\`\`json`) no chat.
-2. `dataframe_output` (tipo `DataFrame`) é serializado via `df.to_markdown(index=False)` e exibido como uma tabela Markdown no chat.
+1. `data_output` (tipo `JSON`) é serializado via `_serialize_data` e exibido como um bloco de código JSON (`\`\`\`json`) no chat.
+2. `dataframe_output` (tipo `Table`) é serializado via `df.to_markdown(index=False)` e exibido como uma tabela Markdown no chat.
 
 ## Tags
 
@@ -17,8 +17,8 @@ Verifica que o Playground renderiza corretamente saídas de dados estruturados g
 
 | Teste | Critério |
 |---|---|
-| B0 – JSON Data | Mensagem do chat contém elemento `<code>` e o texto inclui `"records"` (chave raiz do JSON serializado) |
-| B0b – DataFrame | Mensagem do chat contém elemento `<table>` renderizado pelo react-markdown com remarkGfm |
+| JSON Data output como code block | Mensagem do chat contém elemento `<code>` e o texto inclui `"records"` (chave raiz do JSON serializado) |
+| DataFrame output como tabela Markdown | Mensagem do chat contém elemento `<table>` renderizado pelo react-markdown com remarkGfm |
 
 ## Dependências externas
 

--- a/docs/core-functionality/playground/playground-output-data.md
+++ b/docs/core-functionality/playground/playground-output-data.md
@@ -22,7 +22,7 @@ Verifica que o Playground renderiza corretamente saídas de dados estruturados g
 
 ## Dependências externas
 
-Nenhuma. Os testes usam o componente **Mock Data** nativo do Langflow — nenhuma API key ou LLM é necessário.
+Nenhuma. Os testes usam o componente **Mock Data** nativo do Langflow — nenhuma API key ou LLM é necessária.
 
 ## Última validação
 

--- a/docs/core-functionality/playground/playground-output-data.md
+++ b/docs/core-functionality/playground/playground-output-data.md
@@ -1,0 +1,29 @@
+# Spec: Playground Output – Structured Data
+
+**Arquivo de teste:** `tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts`
+
+## O que este teste valida
+
+Verifica que o Playground renderiza corretamente saídas de dados estruturados gerados pelo componente Mock Data:
+
+1. `data_output` (tipo `Data`) é serializado via `_serialize_data` e exibido como um bloco de código JSON (`\`\`\`json`) no chat.
+2. `dataframe_output` (tipo `DataFrame`) é serializado via `df.to_markdown(index=False)` e exibido como uma tabela Markdown no chat.
+
+## Tags
+
+`@stable` `@release` `@regression` `@playground`
+
+## Critério de validação
+
+| Teste | Critério |
+|---|---|
+| B0 – JSON Data | Mensagem do chat contém elemento `<code>` e o texto inclui `"records"` (chave raiz do JSON serializado) |
+| B0b – DataFrame | Mensagem do chat contém elemento `<table>` renderizado pelo react-markdown com remarkGfm |
+
+## Dependências externas
+
+Nenhuma. Os testes usam o componente **Mock Data** nativo do Langflow — nenhuma API key ou LLM é necessário.
+
+## Última validação
+
+1.10.x

--- a/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
@@ -1,0 +1,171 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
+import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { cleanAllFlows } from "../../../../helpers/flows/clean-all-flows";
+import { zoomOut } from "../../../../helpers/ui/zoom-out";
+
+/**
+ * Mock Data has 3 outputs all with display_name "Result".
+ * Only 1 handle is visible at a time: handle-mockdatagenerator-shownode-result-right
+ * Default selected output is dataframe_output (DataFrame).
+ * To switch output, use the dropdown trigger (dropdown-output-undefined) and select by index:
+ *   nth(0) → dataframe_output (DataFrame)
+ *   nth(1) → message_output  (Message)
+ *   nth(2) → data_output     (Data → ```json code block)
+ * Confirmed via diagnostic: item texts are "Result\nDataFrame", "Result\nMessage", "Result\nData"
+ *
+ * NOTE: dropdown-output-undefined testid reflects data.node.key being undefined in the component.
+ */
+
+async function setupMockDataFlow(
+  page: Page,
+  selectDataOutput: boolean = false,
+): Promise<void> {
+  await awaitBootstrapTest(page);
+  await expect(page.getByTestId("blank-flow")).toBeVisible({ timeout: 30000 });
+  await page.getByTestId("blank-flow").click();
+
+  // Add Chat Output
+  await page.getByTestId("sidebar-search-input").fill("chat output");
+  await expect(page.getByTestId("input_outputChat Output")).toBeVisible({
+    timeout: 30000,
+  });
+  await page
+    .getByTestId("input_outputChat Output")
+    .hover()
+    .then(async () => {
+      await page.getByTestId("add-component-button-chat-output").click();
+    });
+
+  await zoomOut(page, 2);
+
+  // Add Mock Data (section: data_source → testid prefix "data_source")
+  await page.getByTestId("sidebar-search-input").fill("mock data");
+  await expect(page.getByTestId("data_sourceMock Data")).toBeVisible({
+    timeout: 30000,
+  });
+  await page
+    .getByTestId("data_sourceMock Data")
+    .dragTo(page.locator('//*[@id="react-flow-id"]'), {
+      targetPosition: { x: 100, y: 100 },
+    });
+
+  await adjustScreenView(page);
+
+  await expect(page.locator(".react-flow__node")).toHaveCount(2, {
+    timeout: 10000,
+  });
+
+  // Switch to data_output when needed (default is dataframe_output)
+  if (selectDataOutput) {
+    await page.getByTestId("dropdown-output-undefined").click();
+    // data_output is at index 2: "Result\nData"
+    await page
+      .getByTestId("dropdown-item-output-undefined-result")
+      .nth(2)
+      .click();
+  }
+
+  // Connect the selected Mock Data output → Chat Output input
+  await page
+    .getByTestId("handle-mockdatagenerator-shownode-result-right")
+    .click();
+  await page
+    .getByTestId("handle-chatoutput-noshownode-inputs-target")
+    .click();
+
+  await expect(page.locator(".react-flow__edge")).toHaveCount(1, {
+    timeout: 8000,
+  });
+}
+
+async function runNoInputFlow(page: Page): Promise<void> {
+  // No-input playground: button-send = "Run Flow", button-stop appears while building
+  await page.getByTestId("button-send").click();
+  await expect(page.getByTestId("button-stop")).toBeVisible({
+    timeout: 30000,
+  });
+  await expect(page.getByTestId("button-stop")).toBeHidden({
+    timeout: 60000,
+  });
+  // The AI response message is stored asynchronously after the build stream ends.
+  // Wait for both the empty user-trigger and the AI response to appear in the DOM.
+  await expect(page.getByTestId("div-chat-message")).toHaveCount(2, {
+    timeout: 15000,
+  });
+}
+
+test.describe("Playground Output – Structured Data (IDs B0 + B0b)", () => {
+  test.afterEach(async ({ page }) => {
+    await page.goto("/");
+    await cleanAllFlows(page);
+  });
+
+  test(
+    "playground must render JSON Data output as a code block",
+    { tag: ["@release", "@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step(
+        "Set up Mock Data (data_output) → Chat Output flow and open playground",
+        async () => {
+          await setupMockDataFlow(page, true);
+          await page.getByTestId("playground-btn-flow-io").click();
+          await expect(page.getByTestId("button-send")).toBeVisible({
+            timeout: 15000,
+          });
+        },
+      );
+
+      await test.step(
+        "Run flow and verify JSON output renders as a code block containing expected keys",
+        async () => {
+          await runNoInputFlow(page);
+
+          // Chat Output serialises Data via _serialize_data → ```json\n...\n```
+          // react-markdown renders this as a <code> element inside a div-chat-message.
+          // The empty user-trigger message is also a div-chat-message, so we filter
+          // specifically for the one that contains a <code> element.
+          const chatMessage = page
+            .getByTestId("div-chat-message")
+            .filter({ has: page.locator("code") });
+          await expect(chatMessage).toBeVisible({ timeout: 10000 });
+
+          const text = await chatMessage.innerText();
+          expect(text).toContain("records");
+        },
+      );
+    },
+  );
+
+  test(
+    "playground must render DataFrame output as a markdown table",
+    { tag: ["@release", "@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step(
+        "Set up Mock Data (dataframe_output) → Chat Output flow and open playground",
+        async () => {
+          await setupMockDataFlow(page);
+          await page.getByTestId("playground-btn-flow-io").click();
+          await expect(page.getByTestId("button-send")).toBeVisible({
+            timeout: 15000,
+          });
+        },
+      );
+
+      await test.step(
+        "Run flow and verify DataFrame renders as a markdown table",
+        async () => {
+          await runNoInputFlow(page);
+
+          // Chat Output serialises DataFrame via safe_convert → df.to_markdown(index=False)
+          // react-markdown with remarkGfm renders markdown tables as <table> elements
+          const chatMessage = page
+            .getByTestId("div-chat-message")
+            .filter({ has: page.locator("table") });
+          await expect(chatMessage).toBeVisible({ timeout: 10000 });
+        },
+      );
+    },
+  );
+});

--- a/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
@@ -5,22 +5,11 @@ import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-te
 import { cleanAllFlows } from "../../../../helpers/flows/clean-all-flows";
 import { zoomOut } from "../../../../helpers/ui/zoom-out";
 
-/**
- * Mock Data has 3 outputs all with display_name "Result".
- * Only 1 handle is visible at a time: handle-mockdatagenerator-shownode-result-right
- * Default selected output is dataframe_output (DataFrame).
- * To switch output, use the dropdown trigger (dropdown-output-undefined) and select by index:
- *   nth(0) → dataframe_output (DataFrame)
- *   nth(1) → message_output  (Message)
- *   nth(2) → data_output     (Data → ```json code block)
- * Confirmed via diagnostic: item texts are "Result\nDataFrame", "Result\nMessage", "Result\nData"
- *
- * NOTE: dropdown-output-undefined testid reflects data.node.key being undefined in the component.
- */
+type SetupOptions = { selectDataOutput?: boolean };
 
 async function setupMockDataFlow(
   page: Page,
-  selectDataOutput: boolean = false,
+  { selectDataOutput = false }: SetupOptions = {},
 ): Promise<void> {
   await awaitBootstrapTest(page);
   await expect(page.getByTestId("blank-flow")).toBeVisible({ timeout: 30000 });
@@ -38,6 +27,7 @@ async function setupMockDataFlow(
       await page.getByTestId("add-component-button-chat-output").click();
     });
 
+  // Zoom out before dragging so the canvas target is not off-screen
   await zoomOut(page, 2);
 
   // Add Mock Data (section: data_source → testid prefix "data_source")
@@ -57,14 +47,15 @@ async function setupMockDataFlow(
     timeout: 10000,
   });
 
-  // Switch to data_output when needed (default is dataframe_output)
   if (selectDataOutput) {
+    // Default output is dataframe_output; switch to data_output (Data → JSON code block).
+    // testid "dropdown-output-undefined" reflects data.node.key being undefined in the component.
     await page.getByTestId("dropdown-output-undefined").click();
-    // data_output is at index 2: "Result\nData"
-    await page
+    const dataItem = page
       .getByTestId("dropdown-item-output-undefined-result")
-      .nth(2)
-      .click();
+      .filter({ hasText: "Result\nData" });
+    await expect(dataItem).toBeVisible({ timeout: 5000 });
+    await dataItem.click();
   }
 
   // Connect the selected Mock Data output → Chat Output input
@@ -81,7 +72,6 @@ async function setupMockDataFlow(
 }
 
 async function runNoInputFlow(page: Page): Promise<void> {
-  // No-input playground: button-send = "Run Flow", button-stop appears while building
   await page.getByTestId("button-send").click();
   await expect(page.getByTestId("button-stop")).toBeVisible({
     timeout: 30000,
@@ -96,7 +86,7 @@ async function runNoInputFlow(page: Page): Promise<void> {
   });
 }
 
-test.describe("Playground Output – Structured Data (IDs B0 + B0b)", () => {
+test.describe("Playground Output – Structured Data", () => {
   test.afterEach(async ({ page }) => {
     await page.goto("/");
     await cleanAllFlows(page);
@@ -104,12 +94,12 @@ test.describe("Playground Output – Structured Data (IDs B0 + B0b)", () => {
 
   test(
     "playground must render JSON Data output as a code block",
-    { tag: ["@release", "@regression", "@playground"] },
+    { tag: ["@stable", "@release", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step(
         "Set up Mock Data (data_output) → Chat Output flow and open playground",
         async () => {
-          await setupMockDataFlow(page, true);
+          await setupMockDataFlow(page, { selectDataOutput: true });
           await page.getByTestId("playground-btn-flow-io").click();
           await expect(page.getByTestId("button-send")).toBeVisible({
             timeout: 15000,
@@ -124,15 +114,14 @@ test.describe("Playground Output – Structured Data (IDs B0 + B0b)", () => {
 
           // Chat Output serialises Data via _serialize_data → ```json\n...\n```
           // react-markdown renders this as a <code> element inside a div-chat-message.
-          // The empty user-trigger message is also a div-chat-message, so we filter
-          // specifically for the one that contains a <code> element.
           const chatMessage = page
             .getByTestId("div-chat-message")
             .filter({ has: page.locator("code") });
           await expect(chatMessage).toBeVisible({ timeout: 10000 });
 
           const text = await chatMessage.innerText();
-          expect(text).toContain("records");
+          // "records": is the top-level key in the Mock Data JSON serialisation
+          expect(text).toContain('"records"');
         },
       );
     },
@@ -140,7 +129,7 @@ test.describe("Playground Output – Structured Data (IDs B0 + B0b)", () => {
 
   test(
     "playground must render DataFrame output as a markdown table",
-    { tag: ["@release", "@regression", "@playground"] },
+    { tag: ["@stable", "@release", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step(
         "Set up Mock Data (dataframe_output) → Chat Output flow and open playground",

--- a/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
@@ -48,12 +48,13 @@ async function setupMockDataFlow(
   });
 
   if (selectDataOutput) {
-    // Default output is dataframe_output; switch to data_output (Data → JSON code block).
+    // Default output is the Table (DataFrame) output; switch to JSON output.
     // testid "dropdown-output-undefined" reflects data.node.key being undefined in the component.
+    // Item label in 1.10.x: "Result\nJSON" (was "Result\nData" in earlier versions).
     await page.getByTestId("dropdown-output-undefined").click();
     const dataItem = page
       .getByTestId("dropdown-item-output-undefined-result")
-      .filter({ hasText: "Result\nData" });
+      .filter({ hasText: "JSON" });
     await expect(dataItem).toBeVisible({ timeout: 5000 });
     await dataItem.click();
   }

--- a/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
@@ -49,11 +49,16 @@ async function setupMockDataFlow(
 
   if (selectDataOutput) {
     // Default output is the Table (DataFrame) output; switch to JSON output.
-    // testid "dropdown-output-undefined" reflects data.node.key being undefined in the component.
+    // Scope to the Mock Data node to avoid ambiguity if other nodes expose a similar dropdown.
+    // Uses ^= (starts-with) so the selector survives if Langflow sets data.node.key in the future
+    // (test ID pattern: dropdown-output-${data.node.key?.toLowerCase() ?? "undefined"}).
     // Item label in 1.10.x: "Result\nJSON" (was "Result\nData" in earlier versions).
-    await page.getByTestId("dropdown-output-undefined").click();
-    const dataItem = page
-      .getByTestId("dropdown-item-output-undefined-result")
+    const mockDataNode = page
+      .locator('[data-testid="div-generic-node"]')
+      .filter({ hasText: "Mock Data" });
+    await mockDataNode.locator('[data-testid^="dropdown-output-"]').click();
+    const dataItem = mockDataNode
+      .locator('[data-testid^="dropdown-item-output-"]')
       .filter({ hasText: "JSON" });
     await expect(dataItem).toBeVisible({ timeout: 5000 });
     await dataItem.click();

--- a/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
@@ -49,13 +49,15 @@ async function setupMockDataFlow(
 
   if (selectDataOutput) {
     // Default output is the Table (DataFrame) output; switch to JSON output.
-    // Scope to the Mock Data node to avoid ambiguity if other nodes expose a similar dropdown.
+    // Scope to the Mock Data node via its React Flow container (.react-flow__node).
+    // div-generic-node only holds the node header; outputs are rendered in a sibling div outside it.
     // Uses ^= (starts-with) so the selector survives if Langflow sets data.node.key in the future
     // (test ID pattern: dropdown-output-${data.node.key?.toLowerCase() ?? "undefined"}).
+    // "title-Mock Data" is data-testid set by NodeName as `"title-" + display_name`.
     // Item label in 1.10.x: "Result\nJSON" (was "Result\nData" in earlier versions).
     const mockDataNode = page
-      .locator('[data-testid="div-generic-node"]')
-      .filter({ hasText: "Mock Data" });
+      .locator(".react-flow__node")
+      .filter({ has: page.getByTestId("title-Mock Data") });
     await mockDataNode.locator('[data-testid^="dropdown-output-"]').click();
     const dataItem = mockDataNode
       .locator('[data-testid^="dropdown-item-output-"]')


### PR DESCRIPTION
## Summary

- Creates `playground-output-data.spec.ts` with 2 new tests covering structured data rendering in playground chat
- No LLM required: flow is built via UI (blank canvas → sidebar search → drag-drop) using the native Mock Data component
- QA-CHECKLIST.md updated with coverage entries for B0 and B0b (counter reconciliation deferred to cleanup PR)

## Tests covered (2)

| # | Description |
|---|---|
| 1 | JSON Data output renders as a code block in playground |
| 2 | DataFrame output renders as a markdown table in playground |

## Test plan

- [ ] Run with `--trace=on` and confirm all 2 tests pass
- [ ] Force a selector failure to confirm no false positives
- [ ] Confirm no `🚨 Backend Error:` in output