### PR TITLE
feat(playground): add clear history and session delete tests (B1)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -390,12 +390,12 @@
 - [ ] Enviar mensagem enquanto resposta em curso — deve aguardar ou enfileirar
 
 #### 9.2 Histórico e Sessão
-- [-] Configurar session ID customizado → `core/features/settings-message-history.spec.ts`
-- [-] Trocar session ID — inicia nova conversa → `core/features/playground-session-id.spec.ts`
-- [-] Deletar mensagem individual do histórico → `core/features/playground-message-delete.spec.ts`
+- [-] Configurar session ID customizado → `playground/playground-session-id.spec.ts`
+- [-] Trocar session ID — inicia nova conversa → `playground/playground-session-id.spec.ts`
+- [-] Deletar mensagem individual do histórico → `playground/playground-message-delete.spec.ts`
 - [x] Limpar histórico completo de sessão (Default session) → `playground/playground-clear-history.spec.ts`
 - [x] Deletar sessão criada pelo usuário → `playground/playground-clear-history.spec.ts`
-- [-] Histórico persiste ao reabrir Playground → `core/features/playground-history-persist.spec.ts`
+- [-] Histórico persiste ao reabrir Playground → `playground/playground-history-persist.spec.ts`
 
 #### 9.3 Features Avançadas do Playground
 - [x] Modo fullscreen do Playground → `playground/playground-fullscreen.spec.ts`

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -390,11 +390,12 @@
 - [ ] Enviar mensagem enquanto resposta em curso — deve aguardar ou enfileirar
 
 #### 9.2 Histórico e Sessão
-- [-] Configurar session ID customizado
-- [-] Trocar session ID — inicia nova conversa
-- [-] Deletar mensagem individual do histórico
-- [ ] Limpar histórico completo de sessão
-- [-] Histórico persiste ao reabrir Playground
+- [-] Configurar session ID customizado → `core/features/settings-message-history.spec.ts`
+- [-] Trocar session ID — inicia nova conversa → `core/features/playground-session-id.spec.ts`
+- [-] Deletar mensagem individual do histórico → `core/features/playground-message-delete.spec.ts`
+- [x] Limpar histórico completo de sessão (Default session) → `playground/playground-clear-history.spec.ts`
+- [x] Deletar sessão criada pelo usuário → `playground/playground-clear-history.spec.ts`
+- [-] Histórico persiste ao reabrir Playground → `core/features/playground-history-persist.spec.ts`
 
 #### 9.3 Features Avançadas do Playground
 - [x] Modo fullscreen do Playground → `playground/playground-fullscreen.spec.ts`

--- a/docs/core-functionality/playground/playground-clear-history.md
+++ b/docs/core-functionality/playground/playground-clear-history.md
@@ -1,0 +1,90 @@
+# Playground — Clear History & Session Delete
+
+**Última validação:** Langflow 1.10.x
+
+---
+
+## O que este teste valida *(obrigatório)*
+
+Validates session management actions in the Playground:
+
+1. **Clear chat** on the Default session removes all messages from the chat without deleting the session itself.
+2. **Delete session** on a user-created session removes it from the session list and returns the user to the Default session.
+
+These are distinct operations: Default sessions expose "Clear chat"; user-created sessions expose "Delete" (and never "Clear chat"). If either breaks, users lose the ability to manage conversation history.
+
+---
+
+## Tags *(obrigatório)*
+
+`@stable` `@release` `@regression` `@playground`
+
+---
+
+## Passo a passo *(obrigatório)*
+
+**Test 1 — clear chat on Default session must remove messages but keep the session**
+
+1. Create a blank flow with ChatInput connected to ChatOutput (echo setup, no LLM required)
+2. Open the Playground via `playground-btn-flow-io`
+3. Send a message ("Hello from test") and confirm it appears as `div-chat-message`
+4. Open the Default session menu via `chat-header-more-menu` (using `evaluate` to bypass framer-motion overlay)
+5. Click `clear-chat-option`
+6. Confirm `div-chat-message` count drops to 0
+7. Confirm `chat-header-more-menu` is still present (session was not deleted)
+
+**Test 2 — deleting a user-created session must remove it and return to Default session**
+
+1. Create the same ChatInput → ChatOutput flow and open the Playground
+2. Click `new-chat` to create a new session
+3. Send a message ("Message in new session") in the new session
+4. Open the session menu via `chat-header-more-menu` and click `delete-session-option`
+5. Confirm `chat-header-more-menu` is visible (app returned to Default session)
+6. Re-open the menu and confirm `clear-chat-option` is present (confirms Default session is active)
+7. Confirm `delete-session-option` has count 0 (not available on Default)
+
+---
+
+## Critério de validação *(obrigatório)*
+
+- After clearing: `div-chat-message` count is 0 and `chat-header-more-menu` remains visible
+- After deleting: app shows Default session menu (`clear-chat-option` visible, `delete-session-option` absent)
+
+---
+
+## Dependências externas *(obrigatório)*
+
+- `src/frontend/src/components/core/chatComponents/chatHeader/chat-header.tsx` — `isDefaultSession` logic controls which menu options are shown (`clear-chat-option` vs `delete-session-option`). Any change to this conditional or to the `data-testid` attributes will break these tests.
+- `src/frontend/src/components/core/chatComponents/chatHeader/` — `data-testid="chat-header-more-menu"` menu trigger; wrapped in `AnimatedConditional` (framer-motion), which is why `evaluate((el) => el.click())` is used instead of a coordinate-based click.
+
+---
+
+## O que este teste não cobre *(opcional)*
+
+- Renaming a session (covered separately)
+- Deleting individual messages within a session
+- Session persistence across page reloads
+- Voice mode or advanced Playground features
+
+---
+
+## Pré-condições *(opcional)*
+
+- Langflow running and reachable at `PLAYWRIGHT_BASE_URL`
+- No pre-existing flows required; the setup creates a flow per test and `cleanAllFlows` removes it in `afterEach`
+- No LLM or API key needed: ChatInput → ChatOutput acts as a synchronous echo
+
+---
+
+## Quando revisar este teste *(opcional)*
+
+- If the session menu trigger (`chat-header-more-menu`) is renamed or restructured
+- If `isDefaultSession` logic changes (e.g., session IDs are no longer compared to the flow ID)
+- If framer-motion animation is removed and `evaluate`-based click can be replaced by a normal `.click()`
+
+---
+
+## Notas *(opcional)*
+
+- Tests run in `serial` mode to prevent race conditions from `cleanAllFlows` deleting flows mid-execution
+- `evaluate((el) => el.click())` is intentional: the menu trigger sits inside an `AnimatedConditional` that may have an overlapping sibling div during the animation, making coordinate-based clicks unreliable

--- a/docs/core-functionality/playground/playground-clear-history.md
+++ b/docs/core-functionality/playground/playground-clear-history.md
@@ -48,7 +48,7 @@ These are distinct operations: Default sessions expose "Clear chat"; user-create
 ## Critério de validação *(obrigatório)*
 
 - After clearing: `div-chat-message` count is 0 and `chat-header-more-menu` remains visible
-- After deleting: app shows Default session menu (`clear-chat-option` visible, `delete-session-option` absent)
+- After deleting: session sidebar entry count decreases by 1; app shows Default session menu (`clear-chat-option` visible, `delete-session-option` absent)
 
 ---
 

--- a/tests/tests-automations/regression/core-functionality/playground/playground-clear-history.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-clear-history.spec.ts
@@ -1,0 +1,191 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
+import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { cleanAllFlows } from "../../../../helpers/flows/clean-all-flows";
+import { zoomOut } from "../../../../helpers/ui/zoom-out";
+
+/**
+ * Session behavior confirmed from source (chat-header.tsx):
+ *   isDefaultSession = currentSessionId === flowId
+ *
+ * Default session:
+ *   - Menu trigger: data-testid="chat-header-more-menu"
+ *   - Shows "Clear chat" (clear-chat-option) — clears messages, session persists
+ *   - Never shows rename or delete options
+ *   - NOTE: button is inside AnimatedConditional (framer-motion); use { force: true } to click
+ *
+ * User-created session:
+ *   - Menu trigger: data-testid="session-{id}-more-menu" (in sessions sidebar)
+ *   - Shows "Delete" (delete-session-option) — removes session from list, returns to Default
+ *   - Shows "Rename" (rename-session-option) only when session has at least 1 message
+ *   - Never shows clear-chat-option
+ *
+ * Serial mode is required: both tests share the Langflow backend.
+ * cleanAllFlows in afterEach deletes ALL flows — parallel execution causes race conditions.
+ */
+
+async function setupChatFlow(page: Page): Promise<void> {
+  await awaitBootstrapTest(page);
+  await expect(page.getByTestId("blank-flow")).toBeVisible({ timeout: 30000 });
+  await page.getByTestId("blank-flow").click();
+
+  // Add Chat Output via button
+  await page.getByTestId("sidebar-search-input").fill("chat output");
+  await expect(page.getByTestId("input_outputChat Output")).toBeVisible({
+    timeout: 30000,
+  });
+  await page
+    .getByTestId("input_outputChat Output")
+    .hover()
+    .then(async () => {
+      await page.getByTestId("add-component-button-chat-output").click();
+    });
+
+  await zoomOut(page, 2);
+
+  // Add Chat Input via drag to avoid node overlap
+  await page.getByTestId("sidebar-search-input").fill("chat input");
+  await expect(page.getByTestId("input_outputChat Input")).toBeVisible({
+    timeout: 30000,
+  });
+  await page
+    .getByTestId("input_outputChat Input")
+    .dragTo(page.locator('//*[@id="react-flow-id"]'), {
+      targetPosition: { x: 100, y: 100 },
+    });
+
+  await adjustScreenView(page);
+
+  await expect(page.locator(".react-flow__node")).toHaveCount(2, {
+    timeout: 10000,
+  });
+
+  // Connect Chat Input → Chat Output
+  await page
+    .getByTestId("handle-chatinput-noshownode-chat message-source")
+    .click();
+  await page
+    .getByTestId("handle-chatoutput-noshownode-inputs-target")
+    .click();
+
+  await expect(page.locator(".react-flow__edge")).toHaveCount(1, {
+    timeout: 8000,
+  });
+}
+
+async function sendMessage(page: Page, text: string): Promise<void> {
+  await page.getByTestId("input-chat-playground").last().fill(text);
+  await page.getByTestId("button-send").last().click();
+  await expect(page.getByText(text).last()).toBeVisible({ timeout: 10000 });
+  await expect(page.getByTestId("button-stop")).toBeHidden({ timeout: 30000 });
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Playground – Clear History & Session Delete", () => {
+  test.afterEach(async ({ page }) => {
+    await page.goto("/");
+    await cleanAllFlows(page);
+  });
+
+  test(
+    "clear chat on Default session must remove messages but keep the session",
+    { tag: ["@release", "@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step("Set up ChatInput → ChatOutput flow and open playground", async () => {
+        await setupChatFlow(page);
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(page.getByTestId("button-send")).toBeVisible({
+          timeout: 15000,
+        });
+      });
+
+      await test.step("Send a message to populate the chat", async () => {
+        await sendMessage(page, "Hello from test");
+        await expect(page.getByTestId("div-chat-message").first()).toBeVisible({
+          timeout: 10000,
+        });
+      });
+
+      await test.step("Open Default session menu and clear chat", async () => {
+        // The SelectTrigger is inside AnimatedConditional (framer-motion) which can have
+        // a sibling div overlapping during animation. Use DOM .click() via evaluate to
+        // trigger Radix Select's internal event handler without coordinate dependency.
+        await page
+          .getByTestId("chat-header-more-menu")
+          .evaluate((el) => (el as HTMLElement).click());
+        await expect(page.getByTestId("clear-chat-option")).toBeVisible({
+          timeout: 5000,
+        });
+        await page.getByTestId("clear-chat-option").click();
+      });
+
+      await test.step("Verify messages are cleared and session persists", async () => {
+        await expect(page.getByTestId("div-chat-message")).toHaveCount(0, {
+          timeout: 10000,
+        });
+        // Default session menu trigger must still be present (session was not deleted)
+        await expect(
+          page.getByTestId("chat-header-more-menu"),
+        ).toBeVisible({ timeout: 5000 });
+      });
+    },
+  );
+
+  test(
+    "deleting a user-created session must remove it and return to Default session",
+    { tag: ["@release", "@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step("Set up ChatInput → ChatOutput flow and open playground", async () => {
+        await setupChatFlow(page);
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(page.getByTestId("button-send")).toBeVisible({
+          timeout: 15000,
+        });
+      });
+
+      await test.step("Create a new session and send a message", async () => {
+        await page.getByTestId("new-chat").click();
+        await expect(
+          page.getByTestId("input-chat-playground").last(),
+        ).toBeVisible({ timeout: 10000 });
+        await sendMessage(page, "Message in new session");
+        await expect(page.getByTestId("div-chat-message").first()).toBeVisible({
+          timeout: 10000,
+        });
+      });
+
+      await test.step("Delete the user-created session via the header menu", async () => {
+        // When a user-created session is active, chat-header-more-menu shows delete-session-option
+        // (showDelete={!isDefaultSession} in chat-header.tsx)
+        await page
+          .getByTestId("chat-header-more-menu")
+          .evaluate((el) => (el as HTMLElement).click());
+        await expect(page.getByTestId("delete-session-option")).toBeVisible({
+          timeout: 5000,
+        });
+        await page.getByTestId("delete-session-option").click();
+      });
+
+      await test.step("Verify session is removed and Default session is active", async () => {
+        // After deletion the app returns to Default session
+        // Default session menu trigger must be present
+        await expect(
+          page.getByTestId("chat-header-more-menu"),
+        ).toBeVisible({ timeout: 10000 });
+        // Clear chat option is exclusive to Default session
+        await page
+          .getByTestId("chat-header-more-menu")
+          .evaluate((el) => (el as HTMLElement).click());
+        await expect(page.getByTestId("clear-chat-option")).toBeVisible({
+          timeout: 5000,
+        });
+        // Delete option must not be present (we are on Default)
+        await expect(
+          page.getByTestId("delete-session-option"),
+        ).toHaveCount(0);
+      });
+    },
+  );
+});

--- a/tests/tests-automations/regression/core-functionality/playground/playground-clear-history.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-clear-history.spec.ts
@@ -91,7 +91,7 @@ test.describe("Playground – Clear History & Session Delete", () => {
 
   test(
     "clear chat on Default session must remove messages but keep the session",
-    { tag: ["@release", "@regression", "@playground"] },
+    { tag: ["@stable", "@release", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step("Set up ChatInput → ChatOutput flow and open playground", async () => {
         await setupChatFlow(page);
@@ -135,7 +135,7 @@ test.describe("Playground – Clear History & Session Delete", () => {
 
   test(
     "deleting a user-created session must remove it and return to Default session",
-    { tag: ["@release", "@regression", "@playground"] },
+    { tag: ["@stable", "@release", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step("Set up ChatInput → ChatOutput flow and open playground", async () => {
         await setupChatFlow(page);

--- a/tests/tests-automations/regression/core-functionality/playground/playground-clear-history.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-clear-history.spec.ts
@@ -13,7 +13,7 @@ import { zoomOut } from "../../../../helpers/ui/zoom-out";
  *   - Menu trigger: data-testid="chat-header-more-menu"
  *   - Shows "Clear chat" (clear-chat-option) — clears messages, session persists
  *   - Never shows rename or delete options
- *   - NOTE: button is inside AnimatedConditional (framer-motion); use { force: true } to click
+ *   - NOTE: button is inside AnimatedConditional (framer-motion); this test clicks it via evaluate((el) => el.click())
  *
  * User-created session:
  *   - Menu trigger: data-testid="session-{id}-more-menu" (in sessions sidebar)

--- a/tests/tests-automations/regression/core-functionality/playground/playground-clear-history.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-clear-history.spec.ts
@@ -2,7 +2,6 @@ import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
-import { cleanAllFlows } from "../../../../helpers/flows/clean-all-flows";
 import { zoomOut } from "../../../../helpers/ui/zoom-out";
 
 /**
@@ -25,9 +24,18 @@ import { zoomOut } from "../../../../helpers/ui/zoom-out";
  * cleanAllFlows in afterEach deletes ALL flows — parallel execution causes race conditions.
  */
 
-async function setupChatFlow(page: Page): Promise<void> {
+async function setupChatFlow(page: Page): Promise<string> {
   await awaitBootstrapTest(page);
   await expect(page.getByTestId("blank-flow")).toBeVisible({ timeout: 30000 });
+
+  const flowCreationPromise = page.waitForResponse(
+    (resp) =>
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201,
+    { timeout: 15000 },
+  );
+
   await page.getByTestId("blank-flow").click();
 
   // Add Chat Output via button
@@ -72,6 +80,10 @@ async function setupChatFlow(page: Page): Promise<void> {
   await expect(page.locator(".react-flow__edge")).toHaveCount(1, {
     timeout: 8000,
   });
+
+  const creationResponse = await flowCreationPromise;
+  const flowData = await creationResponse.json();
+  return (flowData.id as string) ?? "";
 }
 
 async function sendMessage(page: Page, text: string): Promise<void> {
@@ -84,9 +96,14 @@ async function sendMessage(page: Page, text: string): Promise<void> {
 test.describe.configure({ mode: "serial" });
 
 test.describe("Playground – Clear History & Session Delete", () => {
+  let createdFlowId: string | null = null;
+
   test.afterEach(async ({ page }) => {
-    await page.goto("/");
-    await cleanAllFlows(page);
+    if (createdFlowId) {
+      await page.goto("/");
+      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      createdFlowId = null;
+    }
   });
 
   test(
@@ -94,7 +111,7 @@ test.describe("Playground – Clear History & Session Delete", () => {
     { tag: ["@stable", "@release", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step("Set up ChatInput → ChatOutput flow and open playground", async () => {
-        await setupChatFlow(page);
+        createdFlowId = await setupChatFlow(page);
         await page.getByTestId("playground-btn-flow-io").click();
         await expect(page.getByTestId("button-send")).toBeVisible({
           timeout: 15000,
@@ -138,7 +155,7 @@ test.describe("Playground – Clear History & Session Delete", () => {
     { tag: ["@stable", "@release", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step("Set up ChatInput → ChatOutput flow and open playground", async () => {
-        await setupChatFlow(page);
+        createdFlowId = await setupChatFlow(page);
         await page.getByTestId("playground-btn-flow-io").click();
         await expect(page.getByTestId("button-send")).toBeVisible({
           timeout: 15000,
@@ -157,6 +174,13 @@ test.describe("Playground – Clear History & Session Delete", () => {
       });
 
       await test.step("Delete the user-created session via the header menu", async () => {
+        // Capture how many session sidebar entries exist before deletion
+        const sessionMenus = page.locator(
+          '[data-testid$="-more-menu"]:not([data-testid="chat-header-more-menu"])',
+        );
+        const countBefore = await sessionMenus.count();
+        expect(countBefore, "Expected at least one session entry in sidebar before delete").toBeGreaterThanOrEqual(1);
+
         // When a user-created session is active, chat-header-more-menu shows delete-session-option
         // (showDelete={!isDefaultSession} in chat-header.tsx)
         await page
@@ -166,6 +190,9 @@ test.describe("Playground – Clear History & Session Delete", () => {
           timeout: 5000,
         });
         await page.getByTestId("delete-session-option").click();
+
+        // Session entry must be removed from the sidebar
+        await expect(sessionMenus).toHaveCount(countBefore - 1, { timeout: 5000 });
       });
 
       await test.step("Verify session is removed and Default session is active", async () => {


### PR DESCRIPTION
## Summary

- Creates `playground-clear-history.spec.ts` with 2 new tests covering session management in playground
- No LLM required: uses ChatInput + ChatOutput echo setup
- QA-CHECKLIST.md updated with coverage entries for B1

## Tests covered (2)

| # | Description |
|---|---|
| 1 | Clear chat option removes all messages from the Default session |
| 2 | Delete session option removes a user-created session entirely |

## Test plan

- [ ] Run with `--trace=on` and confirm all 2 tests pass
- [ ] Force a selector failure to confirm no false positives
- [ ] Confirm no `🚨 Backend Error:` in output