### PR TITLE
feat(playground): add image upload rendering tests (B0c)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -388,6 +388,8 @@
 - [x] Playground UX (playground-ux) → `playground/playground-ux.spec.ts`
 - [!] Send empty message — should disable send button → `playground/playground-empty-message-send.spec.ts` (**BUG: button enabled even when empty**)
 - [ ] Send message while response is in progress — should wait or queue
+- [x] Attach image in chat — compact preview appears in input before sending → `core-functionality/playground/playground-output-image.spec.ts`
+- [x] Image rendered in user message bubble after sending → `core-functionality/playground/playground-output-image.spec.ts`
 
 #### 9.2 History and Session
 - [-] Configure custom session ID → `playground/playground-session-id.spec.ts`
@@ -635,7 +637,7 @@
 | `api/` — REST API | 17 | 17 | 0 | 0 |
 | `core-components/` — Config | 20 | 18 | 0 | 2 |
 | `core-components/` — Components | 22 | 16 | 0 | 6 |
-| `core-functionality/playground/` | 17 | 14 | 0 | 3 |
+| `core-functionality/playground/` | 19 | 16 | 0 | 3 |
 | `core-functionality/observability-monitoring/` | 16 | 13 | 0 | 3 |
 | `core-functionality/model-provider/` | 21 | 13 | 0 | 8 |
 | `core-functionality/llm-agents/` | 15 | 8 | 0 | 7 |

--- a/docs/core-functionality/playground/playground-output-image.md
+++ b/docs/core-functionality/playground/playground-output-image.md
@@ -1,29 +1,29 @@
 # Spec: Playground Output – Image Upload
 
-**Arquivo de teste:** `tests/tests-automations/regression/core-functionality/playground/playground-output-image.spec.ts`
+**Test file:** `tests/tests-automations/regression/core-functionality/playground/playground-output-image.spec.ts`
 
-## O que este teste valida
+## What this test validates
 
-Verifica que o Playground lida corretamente com upload de imagem via chat input:
+Verifies that the Playground correctly handles image uploads via the chat input:
 
-1. Após anexar uma imagem, um preview compacto aparece na área de input antes do envio.
-2. Após enviar a mensagem, a imagem é renderizada na bolha da mensagem do usuário no histórico de chat.
+1. After attaching an image, a compact preview appears in the input area before sending.
+2. After sending the message, the image is rendered in the user message bubble in the chat history.
 
 ## Tags
 
 `@stable` `@regression` `@playground`
 
-## Critério de validação
+## Validation criterion
 
-| Teste | Critério |
+| Test | Criterion |
 |---|---|
-| Preview compacto no input | `img[alt="chain.png"]` visível dentro de `[data-testid="input-wrapper"]` após `setInputFiles()` |
-| Imagem renderizada na mensagem do usuário | `img[src*="/files/images/"]` visível após envio e resposta do bot — o servidor prefixa o nome do arquivo com timestamp, então o seletor usa `src` em vez de `alt` |
+| Compact preview in input | `img[alt="chain.png"]` visible inside `[data-testid="input-wrapper"]` after `setInputFiles()` |
+| Image rendered in user message | `img[src*="/files/images/"]` visible after sending and bot response — the server prefixes the filename with a timestamp, so the selector uses `src` instead of `alt` |
 
-## Dependências externas
+## External dependencies
 
-Nenhuma. O flow usa apenas ChatInput → ChatOutput (echo) — nenhuma API key ou LLM é necessária.
+None. The flow uses only ChatInput → ChatOutput (echo) — no API key or LLM is required.
 
-## Última validação
+## Last validated
 
 1.10.x

--- a/docs/core-functionality/playground/playground-output-image.md
+++ b/docs/core-functionality/playground/playground-output-image.md
@@ -1,0 +1,29 @@
+# Spec: Playground Output – Image Upload
+
+**Arquivo de teste:** `tests/tests-automations/regression/core-functionality/playground/playground-output-image.spec.ts`
+
+## O que este teste valida
+
+Verifica que o Playground lida corretamente com upload de imagem via chat input:
+
+1. Após anexar uma imagem, um preview compacto aparece na área de input antes do envio.
+2. Após enviar a mensagem, a imagem é renderizada na bolha da mensagem do usuário no histórico de chat.
+
+## Tags
+
+`@regression` `@playground`
+
+## Critério de validação
+
+| Teste | Critério |
+|---|---|
+| Preview compacto no input | `img[alt="chain.png"]` visível dentro de `[data-testid="input-wrapper"]` após `setInputFiles()` |
+| Imagem renderizada na mensagem do usuário | `img[src*="/files/images/"]` visível após envio e resposta do bot — o servidor prefixa o nome do arquivo com timestamp, então o seletor usa `src` em vez de `alt` |
+
+## Dependências externas
+
+Nenhuma. O flow usa apenas ChatInput → ChatOutput (echo) — nenhuma API key ou LLM é necessária.
+
+## Última validação
+
+1.10.x

--- a/docs/core-functionality/playground/playground-output-image.md
+++ b/docs/core-functionality/playground/playground-output-image.md
@@ -11,7 +11,7 @@ Verifica que o Playground lida corretamente com upload de imagem via chat input:
 
 ## Tags
 
-`@regression` `@playground`
+`@stable` `@regression` `@playground`
 
 ## Critério de validação
 

--- a/tests/tests-automations/regression/core-functionality/playground/playground-output-image.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-output-image.spec.ts
@@ -1,0 +1,159 @@
+import path from "path";
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
+import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { cleanAllFlows } from "../../../../helpers/flows/clean-all-flows";
+import { zoomOut } from "../../../../helpers/ui/zoom-out";
+
+/**
+ * Image upload in the playground uses a hidden <input type="file"> inside the
+ * input-wrapper. We set files directly on that element to avoid depending on
+ * the OS file-chooser dialog or the tooltip-based button locator.
+ *
+ * Compact preview (before send):
+ *   - img inside [data-testid="input-wrapper"], alt="chain.png" (File object)
+ *
+ * Expanded preview (after send — user message in chat history):
+ *   - div-chat-message is the BOT message testid only; user messages use a
+ *     different testid. The uploaded image is in the user message, rendered
+ *     via FilePreviewDisplay (expanded variant).
+ *   - The server prefixes the filename with a timestamp, so the alt becomes
+ *     e.g. "2026-03-22_20-09-16_chain.png". We match by src instead:
+ *     img[src*="/files/images/"] is the stable selector.
+ */
+
+const IMAGE_PATH = path.resolve(
+  __dirname,
+  "../../../../assets/media/chain.png",
+);
+
+async function setupChatEchoFlow(page: Page): Promise<void> {
+  await awaitBootstrapTest(page);
+  await expect(page.getByTestId("blank-flow")).toBeVisible({ timeout: 30000 });
+  await page.getByTestId("blank-flow").click();
+
+  // Add Chat Output
+  await page.getByTestId("sidebar-search-input").fill("chat output");
+  await expect(page.getByTestId("input_outputChat Output")).toBeVisible({
+    timeout: 30000,
+  });
+  await page
+    .getByTestId("input_outputChat Output")
+    .hover()
+    .then(async () => {
+      await page.getByTestId("add-component-button-chat-output").click();
+    });
+
+  await zoomOut(page, 2);
+
+  // Add Chat Input
+  await page.getByTestId("sidebar-search-input").fill("chat input");
+  await expect(page.getByTestId("input_outputChat Input")).toBeVisible({
+    timeout: 30000,
+  });
+  await page
+    .getByTestId("input_outputChat Input")
+    .dragTo(page.locator('//*[@id="react-flow-id"]'), {
+      targetPosition: { x: 100, y: 100 },
+    });
+
+  await adjustScreenView(page);
+
+  // Connect ChatInput → ChatOutput
+  await page
+    .getByTestId("handle-chatinput-noshownode-chat message-source")
+    .click();
+  await page
+    .getByTestId("handle-chatoutput-noshownode-inputs-target")
+    .click();
+
+  await expect(page.locator(".react-flow__edge")).toHaveCount(1, {
+    timeout: 8000,
+  });
+}
+
+test.describe("Playground Output – Image Upload (ID B0c)", () => {
+  test.afterEach(async ({ page }) => {
+    await page.goto("/");
+    await cleanAllFlows(page);
+  });
+
+  test(
+    "playground must show image compact preview in input area after attaching an image",
+    { tag: ["@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step(
+        "Set up ChatInput → ChatOutput echo flow and open playground",
+        async () => {
+          await setupChatEchoFlow(page);
+          await page.getByTestId("playground-btn-flow-io").click();
+          await expect(
+            page.getByTestId("input-chat-playground"),
+          ).toBeVisible({ timeout: 15000 });
+        },
+      );
+
+      await test.step(
+        "Attach image via hidden file input and verify compact preview appears",
+        async () => {
+          await page
+            .locator('input[type="file"][accept*=".png"]')
+            .setInputFiles(IMAGE_PATH);
+
+          await expect(
+            page.locator('[data-testid="input-wrapper"] img[alt="chain.png"]'),
+          ).toBeVisible({ timeout: 5000 });
+        },
+      );
+    },
+  );
+
+  test(
+    "playground must display uploaded image in user message after sending",
+    { tag: ["@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step(
+        "Set up ChatInput → ChatOutput echo flow and open playground",
+        async () => {
+          await setupChatEchoFlow(page);
+          await page.getByTestId("playground-btn-flow-io").click();
+          await expect(
+            page.getByTestId("input-chat-playground"),
+          ).toBeVisible({ timeout: 15000 });
+        },
+      );
+
+      await test.step("Attach image and send message", async () => {
+        await page
+          .locator('input[type="file"][accept*=".png"]')
+          .setInputFiles(IMAGE_PATH);
+
+        await expect(
+          page.locator('[data-testid="input-wrapper"] img[alt="chain.png"]'),
+        ).toBeVisible({ timeout: 5000 });
+
+        await page.getByTestId("button-send").click();
+      });
+
+      await test.step(
+        "Verify user message contains the uploaded image",
+        async () => {
+          // div-chat-message is the bot message container; wait for the flow
+          // to complete so the full chat history (including user message) is rendered
+          await expect(page.getByTestId("div-chat-message")).toBeVisible({
+            timeout: 30000,
+          });
+
+          // The user message renders files via FilePreviewDisplay (expanded variant).
+          // The server prefixes the filename with a timestamp, so we match by
+          // src pattern instead of alt: all server-stored images are served
+          // from /api/v1/files/images/{flow_id}/{filename}.
+          await expect(
+            page.locator('img[src*="/files/images/"]'),
+          ).toBeVisible({ timeout: 10000 });
+        },
+      );
+    },
+  );
+});

--- a/tests/tests-automations/regression/core-functionality/playground/playground-output-image.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-output-image.spec.ts
@@ -74,6 +74,8 @@ async function setupChatEchoFlow(page: Page): Promise<void> {
 }
 
 test.describe("Playground Output – Image Upload (ID B0c)", () => {
+  test.describe.configure({ mode: "serial" });
+
   test.afterEach(async ({ page }) => {
     await page.goto("/");
     await cleanAllFlows(page);

--- a/tests/tests-automations/regression/core-functionality/playground/playground-output-image.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-output-image.spec.ts
@@ -24,7 +24,7 @@ test.describe("Playground Output – Image Upload (ID B0c)", () => {
 
   test(
     "playground must show image compact preview in input area after attaching an image",
-    { tag: ["@regression", "@playground"] },
+    { tag: ["@stable", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step(
         "Set up ChatInput → ChatOutput echo flow and open playground",
@@ -54,7 +54,7 @@ test.describe("Playground Output – Image Upload (ID B0c)", () => {
 
   test(
     "playground must display uploaded image in user message after sending",
-    { tag: ["@regression", "@playground"] },
+    { tag: ["@stable", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step(
         "Set up ChatInput → ChatOutput echo flow and open playground",

--- a/tests/tests-automations/regression/core-functionality/playground/playground-output-image.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-output-image.spec.ts
@@ -41,7 +41,7 @@ test.describe("Playground Output – Image Upload (ID B0c)", () => {
         "Attach image via hidden file input and verify compact preview appears",
         async () => {
           await page
-            .locator('[data-testid="input-chat-playground"] input[type="file"]')
+            .locator('[data-testid="input-wrapper"] input[type="file"]')
             .setInputFiles(IMAGE_PATH);
 
           await expect(
@@ -69,7 +69,7 @@ test.describe("Playground Output – Image Upload (ID B0c)", () => {
 
       await test.step("Attach image and send message", async () => {
         await page
-          .locator('[data-testid="input-chat-playground"] input[type="file"]')
+          .locator('[data-testid="input-wrapper"] input[type="file"]')
           .setInputFiles(IMAGE_PATH);
 
         await expect(

--- a/tests/tests-automations/regression/core-functionality/playground/playground-output-image.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-output-image.spec.ts
@@ -1,84 +1,25 @@
 import path from "path";
-import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
-import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
-import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
-import { cleanAllFlows } from "../../../../helpers/flows/clean-all-flows";
-import { zoomOut } from "../../../../helpers/ui/zoom-out";
+import { setupPlayground } from "../../../../helpers/flows/setup-playground";
 
-/**
- * Image upload in the playground uses a hidden <input type="file"> inside the
- * input-wrapper. We set files directly on that element to avoid depending on
- * the OS file-chooser dialog or the tooltip-based button locator.
- *
- * Compact preview (before send):
- *   - img inside [data-testid="input-wrapper"], alt="chain.png" (File object)
- *
- * Expanded preview (after send — user message in chat history):
- *   - div-chat-message is the BOT message testid only; user messages use a
- *     different testid. The uploaded image is in the user message, rendered
- *     via FilePreviewDisplay (expanded variant).
- *   - The server prefixes the filename with a timestamp, so the alt becomes
- *     e.g. "2026-03-22_20-09-16_chain.png". We match by src instead:
- *     img[src*="/files/images/"] is the stable selector.
- */
-
+// The server prefixes uploaded filenames with a timestamp, so alt becomes e.g.
+// "2026-03-22_20-09-16_chain.png". Match by src path instead of alt.
 const IMAGE_PATH = path.resolve(
   __dirname,
   "../../../../assets/media/chain.png",
 );
 
-async function setupChatEchoFlow(page: Page): Promise<void> {
-  await awaitBootstrapTest(page);
-  await expect(page.getByTestId("blank-flow")).toBeVisible({ timeout: 30000 });
-  await page.getByTestId("blank-flow").click();
-
-  // Add Chat Output
-  await page.getByTestId("sidebar-search-input").fill("chat output");
-  await expect(page.getByTestId("input_outputChat Output")).toBeVisible({
-    timeout: 30000,
-  });
-  await page
-    .getByTestId("input_outputChat Output")
-    .hover()
-    .then(async () => {
-      await page.getByTestId("add-component-button-chat-output").click();
-    });
-
-  await zoomOut(page, 2);
-
-  // Add Chat Input
-  await page.getByTestId("sidebar-search-input").fill("chat input");
-  await expect(page.getByTestId("input_outputChat Input")).toBeVisible({
-    timeout: 30000,
-  });
-  await page
-    .getByTestId("input_outputChat Input")
-    .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-      targetPosition: { x: 100, y: 100 },
-    });
-
-  await adjustScreenView(page);
-
-  // Connect ChatInput → ChatOutput
-  await page
-    .getByTestId("handle-chatinput-noshownode-chat message-source")
-    .click();
-  await page
-    .getByTestId("handle-chatoutput-noshownode-inputs-target")
-    .click();
-
-  await expect(page.locator(".react-flow__edge")).toHaveCount(1, {
-    timeout: 8000,
-  });
-}
-
 test.describe("Playground Output – Image Upload (ID B0c)", () => {
   test.describe.configure({ mode: "serial" });
 
+  let createdFlowId: string | null = null;
+
   test.afterEach(async ({ page }) => {
-    await page.goto("/");
-    await cleanAllFlows(page);
+    if (createdFlowId) {
+      await page.goto("/");
+      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      createdFlowId = null;
+    }
   });
 
   test(
@@ -88,7 +29,7 @@ test.describe("Playground Output – Image Upload (ID B0c)", () => {
       await test.step(
         "Set up ChatInput → ChatOutput echo flow and open playground",
         async () => {
-          await setupChatEchoFlow(page);
+          createdFlowId = await setupPlayground(page);
           await page.getByTestId("playground-btn-flow-io").click();
           await expect(
             page.getByTestId("input-chat-playground"),
@@ -100,7 +41,7 @@ test.describe("Playground Output – Image Upload (ID B0c)", () => {
         "Attach image via hidden file input and verify compact preview appears",
         async () => {
           await page
-            .locator('input[type="file"][accept*=".png"]')
+            .locator('[data-testid="input-chat-playground"] input[type="file"]')
             .setInputFiles(IMAGE_PATH);
 
           await expect(
@@ -118,7 +59,7 @@ test.describe("Playground Output – Image Upload (ID B0c)", () => {
       await test.step(
         "Set up ChatInput → ChatOutput echo flow and open playground",
         async () => {
-          await setupChatEchoFlow(page);
+          createdFlowId = await setupPlayground(page);
           await page.getByTestId("playground-btn-flow-io").click();
           await expect(
             page.getByTestId("input-chat-playground"),
@@ -128,7 +69,7 @@ test.describe("Playground Output – Image Upload (ID B0c)", () => {
 
       await test.step("Attach image and send message", async () => {
         await page
-          .locator('input[type="file"][accept*=".png"]')
+          .locator('[data-testid="input-chat-playground"] input[type="file"]')
           .setInputFiles(IMAGE_PATH);
 
         await expect(
@@ -141,16 +82,11 @@ test.describe("Playground Output – Image Upload (ID B0c)", () => {
       await test.step(
         "Verify user message contains the uploaded image",
         async () => {
-          // div-chat-message is the bot message container; wait for the flow
-          // to complete so the full chat history (including user message) is rendered
+          // Wait for bot response — confirms the full chat history including user message is rendered
           await expect(page.getByTestId("div-chat-message")).toBeVisible({
             timeout: 30000,
           });
 
-          // The user message renders files via FilePreviewDisplay (expanded variant).
-          // The server prefixes the filename with a timestamp, so we match by
-          // src pattern instead of alt: all server-stored images are served
-          // from /api/v1/files/images/{flow_id}/{filename}.
           await expect(
             page.locator('img[src*="/files/images/"]'),
           ).toBeVisible({ timeout: 10000 });


### PR DESCRIPTION
## Summary

- Creates `playground-output-image.spec.ts` with 2 new tests covering image upload via the playground chat input
- Uses `setInputFiles()` on the hidden file input to bypass the OS file chooser
- Asserts compact preview in input area (before send) and rendered image in user message (after send)
- `test.describe.configure({ mode: "serial" })` added to prevent `400 flow must be unique` from parallel execution
- QA-CHECKLIST.md updated with coverage entries for B0c (counter reconciliation deferred to cleanup PR)

## Tests covered (2)

| # | Description |
|---|---|
| 1 | Compact image preview appears in the input area after attaching an image |
| 2 | Uploaded image is rendered in the user message bubble after sending |

## Notes

- Server prefixes uploaded filenames with a timestamp → selector uses `img[src*="/files/images/"]` instead of `alt`
- The `Files` field on the ChatInput canvas component is a separate mechanism and belongs to `core-components/` tests

## Test plan

- [ ] Run with `--trace=on` and confirm all 2 tests pass
- [ ] Force a selector failure to confirm no false positives
- [ ] Confirm no `🚨 Backend Error:` in output