### PR TITLE
Docs/claude md configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,10 @@ LANGFLOW_SUPERUSER=langflow
 LANGFLOW_SUPERUSER_PASSWORD=langflow
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
+GOOGLE_API_KEY=
+MODEL_TEST_STRATEGY=               # all | provider | model (default: all)
+MODEL_TEST_PROVIDER=               # used when MODEL_TEST_STRATEGY=provider
+MODEL_TEST_ID=                     # used when MODEL_TEST_STRATEGY=model
 ```
 
 Start a Langflow instance before running tests:
@@ -45,6 +49,23 @@ npm run lint                                  # ESLint (mesmo check do CI de PR)
 ```
 
 Filter by tag: `npx playwright test --grep "@api"` — available tags listed in the Tag Semantics section below.
+
+### Agent / multi-provider tests
+
+Before running any LLM agent test, collect the available models from a live Langflow instance:
+
+```bash
+npx playwright test tests/collect-models.spec.ts
+```
+
+This generates `tests/helpers/provider-setup/data/providers.json` and `models.json`. Then run agent tests targeting a specific model:
+
+```bash
+MODEL_TEST_STRATEGY=model MODEL_TEST_ID=gpt-4o-mini \
+  npx playwright test tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts --workers=1
+```
+
+Always use `--workers=1` for agent tests — they create flows with unique names in Langflow and must not run in parallel.
 
 ## Architecture
 
@@ -86,6 +107,9 @@ regression/
 - Use `test.describe()` and `test()` blocks; document steps with `test.step()`
 - Tag every test with at least one tag (`@release`, `@regression`, etc.)
 - Use helpers from `tests/helpers/` instead of writing raw Playwright calls
+- Never hardcode provider, model, or API key — use `SimpleAgentTemplatePage` and the provider setup
+- Never commit with `test.only` — it breaks the entire CI suite
+- Use `--workers=1` for any test that creates flows in Langflow
 
 **Test validation checklist** before marking complete (from CONTRIBUTING.md):
 1. Run with full trace (`--trace=on`) and verify steps match screenshots
@@ -124,6 +148,34 @@ Tags are split into two groups: **transversais** (severidade/camada) e **funcion
 | `@templates` | Starter projects e templates de flow |
 | `@settings` | Navegação e configuração na página de Settings |
 | `@ui-ux` | Interface geral, atalhos, aparência |
+
+### Multi-provider setup
+
+`tests/helpers/provider-setup/` contains the logic for collecting and selecting models:
+
+- `collect-models.spec.ts` validates API keys via real calls and saves available models from the Langflow UI
+- `providers.json` — `{ provider, status, error, checkedAt }`
+- `models.json` — `{ provider, model }`
+- `agent-component-regression.spec.ts` reads both files and parametrizes tests per model; inactive providers appear as `skipped` with the exact reason
+
+**Supported providers**
+
+| Provider | Env var | Default model (fallback) |
+|---|---|---|
+| OpenAI | `OPENAI_API_KEY` | `gpt-4o-mini` |
+| Anthropic | `ANTHROPIC_API_KEY` | first available `claude` model |
+| Google | `GOOGLE_API_KEY` | first available `gemini` model |
+
+**Subfolders with their own CLAUDE.md**
+
+| Folder | Topic |
+|---|---|
+| `tests/helpers/` | Helper functions reference |
+| `tests/tests-automations/regression/api/` | REST API tests |
+| `tests/tests-automations/regression/core-functionality/llm-agents/` | Agent tests with multi-provider setup |
+| `tests/tests-automations/regression/core-functionality/model-provider/` | Provider configuration tests |
+| `tests/tests-automations/regression/core-functionality/playground/` | Playground tests |
+| `tests/tests-automations/regression/mcp/` | MCP integration tests |
 
 ## CI/CD
 

--- a/tests/helpers/CLAUDE.md
+++ b/tests/helpers/CLAUDE.md
@@ -1,0 +1,111 @@
+# helpers — Catálogo de utilitários
+
+Todos os helpers ficam nesta pasta. Antes de criar um novo, verifique se já existe algo adequado aqui.
+
+---
+
+## Estrutura
+
+```
+helpers/
+├── auth/           # Autenticação e criação de usuários
+├── flows/          # Manipulação de flows no canvas
+├── ui/             # Interações com a interface (zoom, scroll, drag)
+├── other/          # Bootstrap e setup geral
+├── provider-setup/ # Setup de providers OpenAI, Anthropic, Google
+├── filesystem/     # Upload de arquivos
+├── api/            # Utilitários para testes de API REST
+└── mcp/            # Utilitários para testes MCP
+```
+
+---
+
+## auth/
+
+| Helper | O que faz |
+|---|---|
+| `get-auth-token.ts` | Obtém Bearer token via `/api/v1/auto_login`. Usar em testes `{ request }` |
+| `login-langflow.ts` | Faz login via UI (preenche usuário/senha na tela de login) |
+| `auth-helpers.ts` | Funções auxiliares de autenticação |
+| `add-new-user-and-loggin.ts` | Cria novo usuário via API e loga com ele |
+
+```typescript
+// Uso típico em teste de API
+const authToken = await getAuthToken(request);
+const res = await request.get("/api/v1/flows/", {
+  headers: { Authorization: authToken },
+});
+```
+
+---
+
+## flows/
+
+| Helper | O que faz |
+|---|---|
+| `add-custom-component.ts` | Clica em `sidebar-custom-component-button` até adicionar um Custom Component |
+| `add-legacy-components.ts` | Habilita componentes legados no modal de aviso |
+| `clean-all-flows.ts` | Deleta todos os flows via API (útil em teardown) |
+| `rename-flow.ts` | Renomeia um flow pelo header da página |
+| `run-chat-output.ts` | Clica em `button_run_chat output` e espera `built successfully` |
+| `update-old-components.ts` | Clica em "Update All" para atualizar componentes desatualizados |
+| `load-simple-agent-with-openai.ts` | Carrega o template Simple Agent com OpenAI |
+| `lock-flow.ts` | Bloqueia um flow (ícone de cadeado) |
+| `add-flow-to-test-on-empty-langflow.ts` | Adiciona flow de teste via API quando não há flows |
+
+---
+
+## ui/
+
+| Helper | O que faz |
+|---|---|
+| `adjust-screen-view.ts` | Faz fit-view no canvas. Aceita `{ numberOfZoomOut }` para zoom out extra |
+| `zoom-out.ts` | Aplica zoom out N vezes via atalho de teclado |
+| `unselect-nodes.ts` | Clica em área vazia do canvas para desselecionar tudo |
+| `simulate-drag-and-drop.ts` | Simula drag-and-drop de arquivo para o canvas |
+| `go-to-settings.ts` | Navega para Settings via `user_menu_button` → `menu_settings_button` |
+| `open-advanced-options.ts` | Abre o painel de opções avançadas de um nó |
+| `wait-for-open-modal.ts` | Espera um modal ficar visível |
+
+```typescript
+// Uso típico
+await adjustScreenView(page);                        // fit-view
+await adjustScreenView(page, { numberOfZoomOut: 3 }); // fit-view + zoom out 3x
+await zoomOut(page, 2);                               // zoom out 2x
+```
+
+---
+
+## other/
+
+| Helper | O que faz |
+|---|---|
+| `await-bootstrap-test.ts` | Navega para `/` e espera `mainpage_title`. Sempre usar no início do teste |
+| `initialGPTsetup.ts` | Chama `adjustScreenView` + `updateOldComponents` + `setupOpenAI` |
+
+```typescript
+await awaitBootstrapTest(page);
+await awaitBootstrapTest(page, { skipModal: true }); // pula modal de "Get Started"
+```
+
+---
+
+## provider-setup/
+
+| Helper | O que faz |
+|---|---|
+| `setup-openai.ts` | Configura OpenAI no painel de Model Providers |
+| `setup-anthropic.ts` | Configura Anthropic no painel de Model Providers |
+| `setup-google.ts` | Configura Google Generative AI no painel de Model Providers |
+| `collect-models.ts` | Valida providers via API + coleta modelos da UI → `providers.json` / `models.json` |
+
+Todos os setup-*.ts esperam um nó com `data-testid="model_model"` no canvas antes de abrir o painel.
+
+---
+
+## Regras
+
+- **Nunca duplicar lógica** — se o comportamento já existe aqui, importe e use
+- **Helpers são stateless** — recebem `page` como parâmetro, não guardam estado
+- **Nomes em kebab-case** — `meu-helper.ts`, não `meuHelper.ts`
+- **Exportar como função nomeada** — não usar `export default`

--- a/tests/tests-automations/regression/api/CLAUDE.md
+++ b/tests/tests-automations/regression/api/CLAUDE.md
@@ -1,0 +1,94 @@
+# api — Testes de API REST
+
+Testes que chamam diretamente os endpoints REST do Langflow, sem interação com a UI.
+
+---
+
+## Padrão obrigatório
+
+Todo teste de API usa `{ request }` (não `{ page }`) e obtém o token antes de qualquer chamada:
+
+```typescript
+import { expect, test } from "../../../../fixtures/fixtures";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+
+test("deve retornar 200", { tag: ["@api"] }, async ({ request }) => {
+  const authToken = await getAuthToken(request);
+
+  const res = await request.get("/api/v1/flows/", {
+    headers: { Authorization: authToken },
+  });
+
+  expect(res.status()).toBe(200);
+});
+```
+
+---
+
+## getAuthToken
+
+Localização: `tests/helpers/auth/get-auth-token.ts`
+
+Usa `/api/v1/auto_login` (modo padrão do Langflow sem auth obrigatória). Retorna `"Bearer <token>"` ou `""` se o ambiente não exigir autenticação.
+
+---
+
+## Nomes únicos em POST
+
+Ao criar flows, pastas ou componentes via POST, **sempre usar timestamp ou UUID no nome** para evitar conflito entre testes paralelos:
+
+```typescript
+const flowName = `Test Flow - ${Date.now()}`;
+// ou
+const flowName = `Test Flow - ${Math.random().toString(36).slice(2, 8)}`;
+```
+
+---
+
+## Cleanup no próprio teste
+
+Cada teste é responsável por deletar o que criou:
+
+```typescript
+// Ao final do teste (ou no bloco try/finally):
+await request.delete(`/api/v1/flows/${flowId}`, {
+  headers: { Authorization: authToken },
+});
+```
+
+---
+
+## Estrutura dos arquivos
+
+| Arquivo | O que testa |
+|---|---|
+| `api-flows-crud.spec.ts` | CRUD completo de flows (POST, GET, PATCH, DELETE) |
+| `api-flows-batch.spec.ts` | Endpoint de batch delete de flows |
+| `api-folders-crud.spec.ts` | CRUD de pastas/projetos |
+| `api-health-check.spec.ts` | `/api/v1/health` e `/api/v1/version` |
+| `api-run-flow.spec.ts` | `/api/v1/run/:id` — execução de flow via API |
+| `api-run-with-tweaks.spec.ts` | Execução com `tweaks` (override de campos) |
+| `api-monitor-messages.spec.ts` | `/api/v1/monitor/messages` — histórico de mensagens |
+| `api-monitor-messages-crud.spec.ts` | CRUD de mensagens no monitor |
+| `api-invalid-key.spec.ts` | Comportamento com API key inválida |
+| `api-custom-component.spec.ts` | CRUD de custom components via API |
+| `api-request-execute.spec.ts` | Componente API Request executado via API |
+
+---
+
+## Tags
+
+```typescript
+{ tag: ["@api"] }                    // mínimo para testes de API
+{ tag: ["@api", "@regression"] }     // para testes de regressão
+{ tag: ["@release", "@api"] }        // para testes incluídos no pipeline de release
+```
+
+---
+
+## O que NÃO fazer
+
+- Não usar `{ page }` em testes puramente de API — desnecessário e mais lento
+- Não hardcodar tokens ou credenciais — sempre usar `getAuthToken`
+- Não assumir IDs fixos — IDs mudam a cada execução
+- Não deixar dados criados sem cleanup

--- a/tests/tests-automations/regression/core-functionality/playground/CLAUDE.md
+++ b/tests/tests-automations/regression/core-functionality/playground/CLAUDE.md
@@ -1,0 +1,124 @@
+# playground — Testes do Chat Playground
+
+Testes que validam a interface de chat do Playground: envio de mensagens, histórico, sessão, botão de stop, fullscreen, etc.
+
+---
+
+## Setup padrão do Playground
+
+A maioria dos testes precisa de um flow com ChatInput conectado ao ChatOutput. Padrão:
+
+```typescript
+import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
+import { zoomOut } from "../../../../helpers/ui/zoom-out";
+import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+
+async function setupChatFlow(page: Page) {
+  await awaitBootstrapTest(page);
+  await page.getByTestId("blank-flow").click();
+
+  // Adiciona ChatOutput via hover → click
+  await page.getByTestId("sidebar-search-input").fill("chat output");
+  await page.waitForSelector('[data-testid="input_outputChat Output"]', { timeout: 30000 });
+  await page
+    .getByTestId("input_outputChat Output")
+    .hover()
+    .then(async () => {
+      await page.getByTestId("add-component-button-chat-output").click();
+    });
+
+  await zoomOut(page, 2);
+
+  // Adiciona ChatInput via drag (posição diferente para não sobrepor)
+  await page.getByTestId("sidebar-search-input").fill("chat input");
+  await page.waitForSelector('[data-testid="input_outputChat Input"]', { timeout: 30000 });
+  await page.getByTestId("input_outputChat Input").dragTo(
+    page.locator('//*[@id="react-flow-id"]'),
+    { targetPosition: { x: 100, y: 100 } },
+  );
+
+  await adjustScreenView(page);
+
+  // Conecta ChatInput → ChatOutput
+  await page.getByTestId("handle-chatinput-noshownode-chat message-source").click();
+  await page.getByTestId("handle-chatoutput-noshownode-inputs-target").click();
+}
+```
+
+---
+
+## Mockar o backend (sem LLM real)
+
+Para testes que não precisam de resposta real de LLM, mocke o endpoint de run:
+
+```typescript
+await page.route("**/api/v1/run/**", async (route: import("@playwright/test").Route) => {
+  await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({
+      outputs: [{ outputs: [{ results: { message: { text: "Mock response" } } }] }],
+      session_id: "test-session",
+    }),
+  });
+});
+```
+
+---
+
+## Seletores principais
+
+| Elemento | Seletor |
+|---|---|
+| Input do chat | `[data-testid="input-chat-playground"]` |
+| Botão enviar | `[data-testid="button-send"]` |
+| Mensagem do chat | `[data-testid="div-chat-message"]` |
+| Botão Playground | `[data-testid="playground-btn-flow-io"]` |
+| Botão Stop | `getByRole("button", { name: "Stop" })` |
+| Campo Session ID | `[data-testid="session-id-input"]` (ou similar) |
+
+---
+
+## Armadilhas comuns
+
+### 1. ChatInput e ChatOutput sobrepostos
+Se ambos forem adicionados no centro, ficam sobrepostos e os handles não são clicáveis. Use `dragTo` com `targetPosition` para o segundo componente.
+
+### 2. Botão Playground bloqueado pelo painel
+Ao fechar o playground, o painel pode cobrir o botão. Use JavaScript click como fallback:
+```typescript
+await page.evaluate(() => {
+  const btn = document.querySelector('[data-testid="playground-btn-flow-io"]') as HTMLElement;
+  if (btn) btn.click();
+}).catch(() => {});
+```
+
+### 3. Usar `.last()` nos seletores
+O playground pode ter múltiplos elementos com o mesmo testId. Sempre use `.last()`:
+```typescript
+await page.getByTestId("input-chat-playground").last().fill("mensagem");
+await page.getByTestId("button-send").last().click();
+```
+
+### 4. Testes de playground NÃO precisam de --workers=1
+Diferente dos testes de agente, os testes de playground podem rodar em paralelo desde que cada um crie seu próprio flow (blank-flow).
+
+---
+
+## Tags
+
+```typescript
+{ tag: ["@playground"] }                      // mínimo
+{ tag: ["@playground", "@regression"] }       // para regressão de UI
+{ tag: ["@playground", "@agents"] }           // quando o flow usa LLM real
+```
+
+---
+
+## Quando usar mock vs LLM real
+
+| Situação | Abordagem |
+|---|---|
+| Testar UI do playground (input, botões, histórico) | Mock o endpoint `/api/v1/run/**` |
+| Testar que o agente responde corretamente | LLM real via `SimpleAgentTemplatePage` |
+| Testar stop button | LLM real (precisa de latência real para parar) |


### PR DESCRIPTION
## Tipo
<!-- Marque com [x] o tipo desta PR -->
- [ ] `feat` — novo teste ou novo helper/page object
- [ ] `fix` — correção de teste quebrado ou flaky
- [ ] `chore` — CI, checklist, dependências, refatoração interna
- [x] `docs` — atualização de documentação

---

## O que esta PR faz
- Adiciona `CLAUDE.md` em `tests/helpers/`, `tests/tests-automations/regression/api/` e `tests/tests-automations/regression/core-functionality/playground/` com guia de referência específico para cada área
- Atualiza o `CLAUDE.md` raiz compilando o conteúdo do `main` com informações de setup multi-provider: variáveis de ambiente de provider (`GOOGLE_API_KEY`, `MODEL_TEST_STRATEGY`, `MODEL_TEST_PROVIDER`, `MODEL_TEST_ID`), fluxo do `collect-models.spec.ts`, regras obrigatórias para testes com LLM, tabela de providers suportados e tabela de subpastas com CLAUDE.md

