### PR TITLE
chore(helpers): fix race conditions in addFlowToTestOnEmptyLangflow and cleanAllFlows

### DIFF
--- a/tests/helpers/flows/add-flow-to-test-on-empty-langflow.ts
+++ b/tests/helpers/flows/add-flow-to-test-on-empty-langflow.ts
@@ -5,4 +5,10 @@ export const addFlowToTestOnEmptyLangflow = async (page: Page) => {
   await page.getByTestId("side_nav_options_all-templates").click();
   await page.getByRole("heading", { name: "Basic Prompting" }).click();
   await page.getByTestId("icon-ChevronLeft").click();
+  // Wait for home page to finish loading before awaitBootstrapTest continues.
+  // Without this, the subsequent new-project-btn click can fire before navigation
+  // completes, leaving tests in an inconsistent state.
+  await page.waitForSelector('[data-testid="mainpage_title"]', {
+    timeout: 15000,
+  });
 };

--- a/tests/helpers/flows/clean-all-flows.ts
+++ b/tests/helpers/flows/clean-all-flows.ts
@@ -1,6 +1,12 @@
 import { Page } from "@playwright/test";
 
 export const cleanAllFlows = async (page: Page) => {
+  // Wait for the home page to be ready before starting the deletion loop.
+  // Prevents the loop from running against an incomplete page load.
+  await page.waitForSelector(
+    '[data-testid="empty_page_description"], [data-testid="home-dropdown-menu"]',
+    { timeout: 20000 },
+  );
   const emptyPageDescription = page.getByTestId("empty_page_description");
   while ((await emptyPageDescription.count()) === 0) {
     await page.getByTestId("home-dropdown-menu").first().click();


### PR DESCRIPTION
## O que esta PR faz

Corrige dois race conditions em helpers compartilhados que causavam instabilidade ao rodar specs em isolamento — o cenário padrão de revisão de PR e de debug local.

### `addFlowToTestOnEmptyLangflow`

Adiciona `waitForSelector('[data-testid="mainpage_title"]')` após o clique no `icon-ChevronLeft`.

**Problema:** a função navega de volta para a home page clicando no ChevronLeft, mas não aguardava a navegação terminar. O `awaitBootstrapTest` continuava imediatamente — clicando em `new-project-btn` antes da página estar pronta. Resultado: setup do teste em estado inconsistente, com o flow de Basic Prompting aberto no lugar do blank flow esperado. Reportado como "abre um template de Basic Prompt que não é utilizado e trava após ser aberto o playground" na revisão da PR #37.

### `cleanAllFlows`

Adiciona `waitForSelector` que aguarda `empty_page_description` **ou** `home-dropdown-menu` antes de iniciar o loop de deleção.

**Problema:** chamado após `page.goto("/")`, o loop iniciava antes da home page terminar de renderizar. Em instâncias lentas ou após navegação de volta do canvas, `home-dropdown-menu` podia não estar presente ainda — fazendo o loop terminar prematuramente com flows ainda existentes.

---

## Estudo de impacto — conforme CONTRIBUTING.md

O `CONTRIBUTING.md` orienta a avaliar o impacto antes de modificar helpers compartilhados. O estudo foi feito em três etapas:

**1. Mapeamento de uso**

| Helper | Specs que usam diretamente ou via cadeia |
|---|---|
| `addFlowToTestOnEmptyLangflow` (via `awaitBootstrapTest`) | ~150 specs em toda a suíte |
| `cleanAllFlows` | 2 specs no main (`user-progress-track.spec.ts`, `MainPage.ts`) + 6 branches de playground abertas (PRs #37–#42) |

**2. Status no QA-CHECKLIST.md**

Todos os specs que usam esses helpers estão marcados como `[-]` (automatizados, aguardando validação) — com uma única exceção: os 6 itens `[x]` do `memory-history-regression.spec.ts`, que existe na branch `feat/memory-history` (não mergeada). Esse spec usa `awaitBootstrapTest` mas **não usa `cleanAllFlows`**. A mudança em `addFlowToTestOnEmptyLangflow` é aditiva e beneficia esse spec — tornando o setup mais confiável.

**Conclusão:** nenhum teste marcado como `[x]` é afetado negativamente por esta PR.

**3. Natureza das mudanças**

Ambas as mudanças são **estritamente aditivas** — adicionam waits que retornam imediatamente quando o elemento já está visível. Não alteram lógica, não removem comportamento, não introduzem novos caminhos de execução.

---

## Como foi validado

- Rodado `playground-fullscreen.spec.ts` em isolamento com `--headed` — 2 testes passaram em 30s
- O segundo teste aciona `cleanAllFlows` no `afterEach`, esvazia a instância, e o setup do próximo teste aciona `addFlowToTestOnEmptyLangflow` — exercitando exatamente o path corrigido
- Confirmado que nenhum `🚨 Backend Error:` apareceu no output

---

## Branches que dependem desta PR

Após o merge, as PRs #37–#42 devem ser rebased em main para herdar os fixes automaticamente — nenhuma alteração de código necessária nelas.