### PR TITLE
Fix/validate apikey with provider first model

### DIFF
--- a/tests/helpers/provider-setup/collect-models.ts
+++ b/tests/helpers/provider-setup/collect-models.ts
@@ -39,7 +39,6 @@ async function validateOpenAI(model: string): Promise<ProviderRecord> {
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
       body: JSON.stringify({
         model,
-        max_completion_tokens: 1,
         messages: [{ role: "user", content: "hi" }],
       }),
     });

--- a/tests/helpers/provider-setup/collect-models.ts
+++ b/tests/helpers/provider-setup/collect-models.ts
@@ -12,6 +12,7 @@ const MODELS_PATH = path.join(DATA_DIR, "models.json");
 
 export interface ProviderRecord {
   provider: string;
+  model: string | null;
   status: "active" | "inactive";
   error: string | null;
   checkedAt: string;
@@ -24,12 +25,12 @@ interface ModelRecord {
 
 // ─── Provider validation (API calls) ──────────────────────────────────────────
 
-async function validateOpenAI(): Promise<ProviderRecord> {
+async function validateOpenAI(model: string): Promise<ProviderRecord> {
   const apiKey = process.env.OPENAI_API_KEY ?? "";
   const provider = "openai";
 
   if (!apiKey) {
-    return { provider, status: "inactive", error: "OPENAI_API_KEY not set", checkedAt: new Date().toISOString() };
+    return { provider, model, status: "inactive", error: "OPENAI_API_KEY not set", checkedAt: new Date().toISOString() };
   }
 
   try {
@@ -37,7 +38,7 @@ async function validateOpenAI(): Promise<ProviderRecord> {
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
       body: JSON.stringify({
-        model: "gpt-4o-mini",
+        model,
         max_tokens: 1,
         messages: [{ role: "user", content: "hi" }],
       }),
@@ -45,21 +46,21 @@ async function validateOpenAI(): Promise<ProviderRecord> {
 
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
-      return { provider, status: "inactive", error: (body as any)?.error?.message ?? `HTTP ${res.status}`, checkedAt: new Date().toISOString() };
+      return { provider, model, status: "inactive", error: (body as any)?.error?.message ?? `HTTP ${res.status}`, checkedAt: new Date().toISOString() };
     }
 
-    return { provider, status: "active", error: null, checkedAt: new Date().toISOString() };
+    return { provider, model, status: "active", error: null, checkedAt: new Date().toISOString() };
   } catch (e: any) {
-    return { provider, status: "inactive", error: e?.message ?? "Unknown error", checkedAt: new Date().toISOString() };
+    return { provider, model, status: "inactive", error: e?.message ?? "Unknown error", checkedAt: new Date().toISOString() };
   }
 }
 
-async function validateAnthropic(): Promise<ProviderRecord> {
+async function validateAnthropic(model: string): Promise<ProviderRecord> {
   const apiKey = process.env.ANTHROPIC_API_KEY ?? "";
   const provider = "anthropic";
 
   if (!apiKey) {
-    return { provider, status: "inactive", error: "ANTHROPIC_API_KEY not set", checkedAt: new Date().toISOString() };
+    return { provider, model, status: "inactive", error: "ANTHROPIC_API_KEY not set", checkedAt: new Date().toISOString() };
   }
 
   try {
@@ -71,7 +72,7 @@ async function validateAnthropic(): Promise<ProviderRecord> {
         "anthropic-version": "2023-06-01",
       },
       body: JSON.stringify({
-        model: "claude-haiku-4-5-20251001",
+        model,
         max_tokens: 1,
         messages: [{ role: "user", content: "hi" }],
       }),
@@ -79,26 +80,26 @@ async function validateAnthropic(): Promise<ProviderRecord> {
 
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
-      return { provider, status: "inactive", error: (body as any)?.error?.message ?? `HTTP ${res.status}`, checkedAt: new Date().toISOString() };
+      return { provider, model, status: "inactive", error: (body as any)?.error?.message ?? `HTTP ${res.status}`, checkedAt: new Date().toISOString() };
     }
 
-    return { provider, status: "active", error: null, checkedAt: new Date().toISOString() };
+    return { provider, model, status: "active", error: null, checkedAt: new Date().toISOString() };
   } catch (e: any) {
-    return { provider, status: "inactive", error: e?.message ?? "Unknown error", checkedAt: new Date().toISOString() };
+    return { provider, model, status: "inactive", error: e?.message ?? "Unknown error", checkedAt: new Date().toISOString() };
   }
 }
 
-async function validateGoogle(): Promise<ProviderRecord> {
+async function validateGoogle(model: string): Promise<ProviderRecord> {
   const apiKey = process.env.GOOGLE_API_KEY ?? "";
   const provider = "google";
 
   if (!apiKey) {
-    return { provider, status: "inactive", error: "GOOGLE_API_KEY not set", checkedAt: new Date().toISOString() };
+    return { provider, model, status: "inactive", error: "GOOGLE_API_KEY not set", checkedAt: new Date().toISOString() };
   }
 
   try {
     const res = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${apiKey}`,
+      `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -111,28 +112,32 @@ async function validateGoogle(): Promise<ProviderRecord> {
 
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
-      return { provider, status: "inactive", error: (body as any)?.error?.message ?? `HTTP ${res.status}`, checkedAt: new Date().toISOString() };
+      return { provider, model, status: "inactive", error: (body as any)?.error?.message ?? `HTTP ${res.status}`, checkedAt: new Date().toISOString() };
     }
 
-    return { provider, status: "active", error: null, checkedAt: new Date().toISOString() };
+    return { provider, model, status: "active", error: null, checkedAt: new Date().toISOString() };
   } catch (e: any) {
-    return { provider, status: "inactive", error: e?.message ?? "Unknown error", checkedAt: new Date().toISOString() };
+    return { provider, model, status: "inactive", error: e?.message ?? "Unknown error", checkedAt: new Date().toISOString() };
   }
 }
 
-async function collectProviders(): Promise<ProviderRecord[]> {
+function firstModelFor(models: ModelRecord[], provider: string): string {
+  return models.find((m) => m.provider === provider)?.model ?? "";
+}
+
+async function collectProviders(models: ModelRecord[]): Promise<ProviderRecord[]> {
   console.log("Validando provedores via API...");
 
   const results = await Promise.all([
-    validateOpenAI(),
-    validateAnthropic(),
-    validateGoogle(),
+    validateOpenAI(firstModelFor(models, "openai")),
+    validateAnthropic(firstModelFor(models, "anthropic")),
+    validateGoogle(firstModelFor(models, "google")),
   ]);
 
   for (const r of results) {
     const icon = r.status === "active" ? "✅" : "❌";
     const detail = r.error ? ` — ${r.error}` : "";
-    console.log(`${icon} ${r.provider}${detail}`);
+    console.log(`${icon} ${r.provider} (${r.model ?? "no model"})${detail}`);
   }
 
   return results;
@@ -199,13 +204,13 @@ export async function collectAll(page: Page): Promise<void> {
     fs.mkdirSync(DATA_DIR, { recursive: true });
   }
 
-  // Step 1: Validate providers via API (no browser needed)
-  const providers = await collectProviders();
-  fs.writeFileSync(PROVIDERS_PATH, JSON.stringify(providers, null, 2), "utf-8");
-  console.log(`providers.json salvo com ${providers.length} provedores.`);
-
-  // Step 2: Collect models from UI via Settings
+  // Step 1: Collect models from UI via Settings
   const models = await collectModels(page);
   fs.writeFileSync(MODELS_PATH, JSON.stringify(models, null, 2), "utf-8");
   console.log(`models.json salvo com ${models.length} modelos.`);
+
+  // Step 2: Validate providers via API using the first model of each provider
+  const providers = await collectProviders(models);
+  fs.writeFileSync(PROVIDERS_PATH, JSON.stringify(providers, null, 2), "utf-8");
+  console.log(`providers.json salvo com ${providers.length} provedores.`);
 }

--- a/tests/helpers/provider-setup/collect-models.ts
+++ b/tests/helpers/provider-setup/collect-models.ts
@@ -39,7 +39,7 @@ async function validateOpenAI(model: string): Promise<ProviderRecord> {
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
       body: JSON.stringify({
         model,
-        max_tokens: 1,
+        max_completion_tokens: 1,
         messages: [{ role: "user", content: "hi" }],
       }),
     });


### PR DESCRIPTION
## Tipo                                                                                                                                                                                     
<!-- Marque com [x] o tipo desta PR -->

- [ ] `feat` — novo teste ou novo helper/page object
- [x] `fix` — correção de teste quebrado ou flaky
- [ ] `chore` — CI, checklist, dependências, refatoração interna
- [ ] `docs` — atualização de documentação

  ---

  ## O que esta PR faz

  Corrige a validação de providers em `collect-models.ts`:

  - **Validação dinâmica de modelo**: a coleta de modelos da UI (Step 1) passa a ocorrer antes da validação via API (Step 2). O primeiro modelo de cada provider coletado da UI é usado na  
  chamada de verificação — substituindo modelos hardcoded (`gpt-4o-mini`, `claude-haiku-4-5-20251001`, `gemini-2.5-flash`). `ProviderRecord` recebe o campo `model` para refletir qual      
  modelo foi usado na validação
  - **Compatibilidade com modelos novos da OpenAI**: removido o parâmetro `max_tokens`/`max_completion_tokens` da chamada de validação do OpenAI — modelos como `gpt-5.2` rejeitam
  `max_tokens` (descontinuado) e falham com `max_completion_tokens: 1` por limite mínimo, marcando o provider incorretamente como inativo

  ---

  ## Validação

  1. Rodar `npx playwright test tests/collect-models.spec.ts` com providers configurados no `.env`
  2. Confirmar que o output mostra o modelo real coletado da UI (ex: `✅ openai (gpt-5.2)`) em vez de um modelo hardcoded
  3. Confirmar que providers com modelos recentes não são marcados como inativos por erro de parâmetro
  4. Rodar `npx playwright test tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts --workers=1` e confirmar que os testes executam corretamente para todos os providers ativos