### PR TITLE
test(core-components): adiciona testes de regressão do Loop component

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -182,8 +182,11 @@
 - [ ] Configurar model provider diretamente no componente Agent
 
 #### 3.6 Loop Component
-- [-] Componente Loop no canvas
-- [ ] Loop executa número correto de iterações
+- [x] Componente Loop renderiza no canvas com title e botão run → `core-components/loop-component-regression.spec.ts`
+- [x] Handles corretos: inputs-left, item-left, item-right, done-right → `core-components/loop-component-regression.spec.ts`
+- [x] Botões de output inspection presentes para item e done → `core-components/loop-component-regression.spec.ts`
+- [x] Run sem conexões exibe notificação "Flow build failed" sem crash → `core-components/loop-component-regression.spec.ts`
+- [ ] Loop executa número correto de iterações com lista conectada
 - [ ] Loop para ao atingir condição de saída
 
 #### 3.7 Nested / Agrupamento

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -186,7 +186,7 @@
 - [x] Handles corretos: inputs-left, item-left, item-right, done-right → `core-components/loop-component-regression.spec.ts`
 - [x] Botões de output inspection presentes para item e done → `core-components/loop-component-regression.spec.ts`
 - [x] Run sem conexões exibe notificação "Flow build failed" sem crash → `core-components/loop-component-regression.spec.ts`
-- [ ] Loop executa número correto de iterações com lista conectada
+- [x] Loop itera sobre 2 artigos ArXiv (template Research Translation Loop) e agrega resposta no Playground → `core-components/loop-component-regression.spec.ts`
 - [ ] Loop para ao atingir condição de saída
 
 #### 3.7 Nested / Agrupamento

--- a/QA-SCENARIOS-GUIDE.md
+++ b/QA-SCENARIOS-GUIDE.md
@@ -39,6 +39,7 @@
 24. [Flow — CRUD e Operações](#24-flow--crud-e-operações)
 25. [MCP — Client e Server](#25-mcp--client-e-server)
 26. [UI/UX — Sidebar e Canvas](#26-uiux--sidebar-e-canvas)
+27. [Componentes Principais — Loop](#27-componentes-principais--loop)
 
 ---
 
@@ -1802,11 +1803,88 @@
 9. Pipeline RAG completo
 
 ### 🟢 Baixa Prioridade
-10. Loop component — iterações corretas
+10. [x] Loop component — iterações corretas (coberto em seção 27)
 11. Provedores Ollama, Groq, Mistral
 12. Parâmetros de modelo (temperatura, max tokens)
 13. Editar texto de sticky note
 14. Usar variável global diretamente em componente
+
+---
+
+## 27. Componentes Principais — Loop
+
+**Arquivo:** `tests/tests-automations/regression/core-components/loop-component-regression.spec.ts`
+
+---
+
+### 27.1 Componente Loop renderiza no canvas com todos os handles `[x]`
+
+**Objetivo:** Verificar que o Loop aparece corretamente no canvas com todos os handles de entrada/saída e botões de output inspection.
+
+**Pré-condições:** Langflow em execução.
+
+**Passo a passo:**
+1. Criar um blank flow.
+2. Buscar "Loop" na sidebar e adicionar ao canvas.
+3. Verificar que o título `title-Loop` está visível.
+4. Verificar que o botão de run `button_run_loop` está visível.
+5. Verificar que existe exatamente 1 nó no canvas.
+6. Verificar handles de entrada (lado esquerdo):
+   - `handle-loopcomponent-shownode-inputs-left` — recebe o DataFrame a iterar
+   - `handle-loopcomponent-shownode-item-left` — porta de feedback: recebe o item processado
+7. Verificar handles de saída (lado direito):
+   - `handle-loopcomponent-shownode-item-right` — emite o item atual da iteração
+   - `handle-loopcomponent-shownode-done-right` — emite o DataFrame agregado ao fim
+8. Verificar botões de output inspection no rodapé do nó:
+   - `output-inspection-item-loopcomponent`
+   - `output-inspection-done-loopcomponent`
+
+**Validação:** Todos os handles e botões de inspection visíveis; canvas com exatamente 1 nó.
+
+---
+
+### 27.2 Loop sem conexões exibe notificação "Flow build failed" `[x]`
+
+**Objetivo:** Verificar que executar o Loop isolado (sem conexões) resulta em falha controlada — sem crash da aplicação.
+
+**Pré-condições:** Langflow em execução.
+
+**Passo a passo:**
+1. Criar um blank flow.
+2. Adicionar o componente Loop ao canvas.
+3. Clicar em `button_run_loop` (nó sem nenhuma conexão).
+4. Aguardar a notificação de erro aparecer.
+
+**Validação:**
+- Texto "Flow build failed" visível na tela.
+- Botão `button_run_loop` ainda acessível após a falha.
+- Nó `title-Loop` permanece intacto no canvas (1 nó).
+- Aplicação não trava nem recarrega.
+
+---
+
+### 27.3 Loop itera sobre 2 artigos ArXiv via template Research Translation Loop `[x]`
+
+**Objetivo:** Validar wiring completo do Loop e que ele itera corretamente — cada item do DataFrame entra no ciclo, é processado pelo LLM e retorna via porta `item`, até o `done` disparar com o resultado agregado.
+
+**Pré-condições:** Langflow em execução, OPENAI_API_KEY configurada.
+
+**Passo a passo:**
+1. Acessar a aba de Templates (`side_nav_options_all-templates`).
+2. Clicar no template `template-research-translation-loop`.
+3. Aguardar o canvas carregar com o nó Loop visível.
+4. Verificar wiring:
+   - Pelo menos 1 edge presente no canvas (template já conecta o Loop em ciclo).
+   - Handles `inputs-left`, `item-left`, `item-right` e `done-right` do Loop visíveis.
+5. Reduzir o campo `int_int_max_results` do ArXiv para `2` (mínimo para validar iteração sem esperar muito).
+6. Abrir o Playground (`playground-btn-flow-io`).
+7. Enviar a mensagem `"transformer neural networks"`.
+8. Aguardar a resposta do bot (`chat-message-AI-`).
+9. Verificar que a resposta contém pelo menos 2 ocorrências de "title" (case-insensitive) — cada artigo ArXiv tem um título, confirmando que o loop processou os 2 artigos.
+
+**Validação:** Resposta do bot não vazia; contagem de "title" ≥ 2 (confirma 2 iterações do loop).
+
+**Observação:** A validação via "Title" é intencional e levemente frágil — depende do formato de saída do Parser. Se o template mudar o template de prompt, o contador pode não bater. O foco do teste é confirmar que o Loop iterou, não o conteúdo exato.
 
 ---
 

--- a/tests/tests-automations/regression/core-components/loop-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/loop-component-regression.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "../../../fixtures/fixtures";
+import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
+import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+
+// Run tests serially to avoid "flow must be unique" 400 errors from parallel autosaves
+test.describe.configure({ mode: "serial" });
+
+// Helper: create a blank flow and add the Loop component to the canvas.
+// After this call the component node is visible and the inspector is open.
+async function addLoopComponent(page: any) {
+  await awaitBootstrapTest(page);
+  await page.getByTestId("blank-flow").click();
+  await page.getByTestId("sidebar-search-input").fill("Loop");
+  await page.waitForSelector('[data-testid="add-component-button-loop"]', {
+    timeout: 10000,
+    state: "attached",
+  });
+  await page.getByTestId("flow_controlsLoop").hover();
+  await page.getByTestId("add-component-button-loop").click();
+  await adjustScreenView(page);
+  await page.waitForSelector('[data-testid="title-Loop"]', {
+    timeout: 15000,
+  });
+}
+
+// =============================================================================
+// UI / Canvas tests — verify component rendering and handles
+// =============================================================================
+
+test(
+  "Loop component — renders on canvas with title and run button",
+  { tag: ["@release", "@regression", "@components"] },
+  async ({ page }) => {
+    await addLoopComponent(page);
+
+    // Node must be visible on the canvas
+    await expect(page.getByTestId("title-Loop")).toBeVisible();
+
+    // Run button must be present
+    await expect(page.getByTestId("button_run_loop")).toBeVisible();
+
+    // Exactly one node on the canvas
+    await expect(page.locator(".react-flow__node")).toHaveCount(1);
+  },
+);
+
+test(
+  "Loop component — has correct input and output handles",
+  { tag: ["@release", "@regression", "@components"] },
+  async ({ page }) => {
+    await addLoopComponent(page);
+
+    // Input handles (left side)
+    // inputs — receives the full list to iterate over
+    await expect(
+      page.getByTestId("handle-loopcomponent-shownode-inputs-left"),
+    ).toBeVisible();
+    // item — feedback port: receives the processed item to advance the loop
+    await expect(
+      page.getByTestId("handle-loopcomponent-shownode-item-left"),
+    ).toBeVisible();
+
+    // Output handles (right side)
+    // item — emits the current item in the iteration
+    await expect(
+      page.getByTestId("handle-loopcomponent-shownode-item-right"),
+    ).toBeVisible();
+    // done — emits True when all items have been processed
+    await expect(
+      page.getByTestId("handle-loopcomponent-shownode-done-right"),
+    ).toBeVisible();
+  },
+);
+
+test(
+  "Loop component — output inspection buttons are present for item and done ports",
+  { tag: ["@release", "@regression", "@components"] },
+  async ({ page }) => {
+    await addLoopComponent(page);
+
+    // Both output inspection triggers must be visible in the node footer
+    await expect(
+      page.getByTestId("output-inspection-item-loopcomponent"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("output-inspection-done-loopcomponent"),
+    ).toBeVisible();
+  },
+);
+
+test(
+  "Loop component — run without connections shows build failed notification",
+  { tag: ["@regression", "@components"] },
+  async ({ page }) => {
+    // The Loop component requires at least an `inputs` connection to execute.
+    // Running it standalone (no connections) is an expected error path —
+    // the component must show a build-failed notification and NOT crash.
+    (page as any).allowFlowErrors();
+
+    await addLoopComponent(page);
+
+    await page.getByTestId("button_run_loop").click();
+
+    // Standalone execution → build fails; the notification must appear
+    await page.waitForSelector("text=Flow build failed", { timeout: 30000 });
+    await expect(page.getByText("Flow build failed")).toBeVisible();
+
+    // The run button must still be accessible after the failure
+    await expect(page.getByTestId("button_run_loop")).toBeVisible();
+
+    // The node must remain intact on the canvas
+    await expect(page.getByTestId("title-Loop")).toBeVisible();
+    await expect(page.locator(".react-flow__node")).toHaveCount(1);
+  },
+);

--- a/tests/tests-automations/regression/core-components/loop-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/loop-component-regression.spec.ts
@@ -24,34 +24,22 @@ async function addLoopComponent(page: any) {
 }
 
 // =============================================================================
-// UI / Canvas tests — verify component rendering and handles
+// UI / Canvas — rendering, handles and output inspection in a single test
 // =============================================================================
 
 test(
-  "Loop component — renders on canvas with title and run button",
-  { tag: ["@release", "@regression", "@components"] },
+  "Loop component — renders correctly with all handles and output inspection buttons",
+  { tag: ["@release", "@components"] },
   async ({ page }) => {
     await addLoopComponent(page);
 
-    // Node must be visible on the canvas
+    // Node must be visible on the canvas with its run button
     await expect(page.getByTestId("title-Loop")).toBeVisible();
-
-    // Run button must be present
     await expect(page.getByTestId("button_run_loop")).toBeVisible();
-
-    // Exactly one node on the canvas
     await expect(page.locator(".react-flow__node")).toHaveCount(1);
-  },
-);
-
-test(
-  "Loop component — has correct input and output handles",
-  { tag: ["@release", "@regression", "@components"] },
-  async ({ page }) => {
-    await addLoopComponent(page);
 
     // Input handles (left side)
-    // inputs — receives the full list to iterate over
+    // inputs — receives the DataFrame to iterate over
     await expect(
       page.getByTestId("handle-loopcomponent-shownode-inputs-left"),
     ).toBeVisible();
@@ -61,24 +49,16 @@ test(
     ).toBeVisible();
 
     // Output handles (right side)
-    // item — emits the current item in the iteration
+    // item — emits the current item in each iteration
     await expect(
       page.getByTestId("handle-loopcomponent-shownode-item-right"),
     ).toBeVisible();
-    // done — emits True when all items have been processed
+    // done — emits aggregated DataFrame when all items are processed
     await expect(
       page.getByTestId("handle-loopcomponent-shownode-done-right"),
     ).toBeVisible();
-  },
-);
 
-test(
-  "Loop component — output inspection buttons are present for item and done ports",
-  { tag: ["@release", "@regression", "@components"] },
-  async ({ page }) => {
-    await addLoopComponent(page);
-
-    // Both output inspection triggers must be visible in the node footer
+    // Output inspection buttons must be present in the node footer
     await expect(
       page.getByTestId("output-inspection-item-loopcomponent"),
     ).toBeVisible();
@@ -88,9 +68,13 @@ test(
   },
 );
 
+// =============================================================================
+// Error path — run without connections
+// =============================================================================
+
 test(
   "Loop component — run without connections shows build failed notification",
-  { tag: ["@regression", "@components"] },
+  { tag: ["@release", "@components"] },
   async ({ page }) => {
     // The Loop component requires at least an `inputs` connection to execute.
     // Running it standalone (no connections) is an expected error path —
@@ -111,5 +95,83 @@ test(
     // The node must remain intact on the canvas
     await expect(page.getByTestId("title-Loop")).toBeVisible();
     await expect(page.locator(".react-flow__node")).toHaveCount(1);
+  },
+);
+
+
+// =============================================================================
+// Wiring + Iteration — Research Translation Loop template: wiring and real execution
+// =============================================================================
+
+test(
+  "Loop component — Research Translation Loop template: full wiring and iterates over 2 ArXiv papers",
+  { tag: ["@release", "@components", "@templates", "@playground"] },
+  async ({ page }) => {
+    await awaitBootstrapTest(page);
+
+    // Load the Research Translation Loop template
+    await page.getByTestId("side_nav_options_all-templates").click();
+    await page.waitForSelector('[data-testid="template-research-translation-loop"]', {
+      timeout: 10000,
+    });
+    await page.getByTestId("template-research-translation-loop").click();
+    await page.waitForSelector('[data-testid="title-Loop"]', { timeout: 15000 });
+    await adjustScreenView(page);
+
+    // --- Wiring checks ---
+    await expect(page.getByTestId("title-Loop")).toBeVisible();
+    await expect(page.getByTestId("button_run_loop")).toBeVisible();
+
+    // At least one edge must exist (the template wires Loop in a cycle)
+    await expect(page.locator(".react-flow__edge").first()).toBeVisible({
+      timeout: 8000,
+    });
+
+    // Input handles: inputs (DataFrame from ArXiv) and item (LLM feedback)
+    await expect(
+      page.getByTestId("handle-loopcomponent-shownode-inputs-left"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("handle-loopcomponent-shownode-item-left"),
+    ).toBeVisible();
+
+    // Output handles: item (current iteration) and done (aggregated result)
+    await expect(
+      page.getByTestId("handle-loopcomponent-shownode-item-right"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("handle-loopcomponent-shownode-done-right"),
+    ).toBeVisible();
+
+    // --- Iteration execution ---
+    // Limit ArXiv to 2 results so the loop runs exactly 2 iterations.
+    // The template default is 3; we reduce to 2 to keep the test fast (2 LLM calls).
+    await page.getByTestId("int_int_max_results").click({ clickCount: 3 });
+    await page.getByTestId("int_int_max_results").fill("2");
+
+    // Open the Playground and send a query — ArXiv is a public API, no key needed
+    await page.getByTestId("playground-btn-flow-io").click();
+    await page.waitForSelector('[data-testid="input-chat-playground"]', {
+      timeout: 10000,
+    });
+    await page.getByTestId("input-chat-playground").fill("transformer neural networks");
+    await page.getByTestId("button-send").click();
+
+    // The AI response element appears as soon as the flow starts streaming.
+    // Testid pattern: "chat-message-AI-{content}"
+    await page.waitForSelector('[data-testid^="chat-message-AI-"]', {
+      timeout: 120000,
+    });
+
+    // Verify the response contains at least 2 "Title" occurrences.
+    // The Parser formats every paper as "Title: {title}\nSummary: {summary}" before
+    // sending it to the LLM — so 2 ArXiv papers produce at least 2 "Title" mentions
+    // in the aggregated response, confirming the loop iterated twice.
+    const botMessage = page.locator('[data-testid^="chat-message-AI-"]').last();
+    await expect(botMessage).toBeVisible();
+    await expect(botMessage).not.toBeEmpty({ timeout: 120000 });
+    const responseText = await botMessage.textContent() ?? "";
+    const titleCount = (responseText.match(/title/gi) ?? []).length;
+    expect(titleCount).toBeGreaterThanOrEqual(2);
   },
 );


### PR DESCRIPTION
## Testes cobertos

- **Loop 27.1** — Renderização completa: título, botão run, 4 handles (inputs-left, item-left, item-right, done-right) e botões de output inspection (item, done)
- **Loop 27.2** — Execução sem conexões: deve exibir notificação "Flow build failed" sem crash, mantendo o nó intacto no canvas
- **Loop 27.3** — Iteração real via template Research Translation Loop: wiring completo + 2 artigos ArXiv processados pelo LLM + resposta validada no Playground

## Como foram construídos

- Testes 27.1 e 27.2 usam blank flow + sidebar search para adicionar o Loop isolado
- Teste 27.3 carrega o template "Research Translation Loop" diretamente pela aba de Templates, reduz `max_results` do ArXiv para 2, executa via Playground e valida que a resposta contém ≥ 2 ocorrências de "title" (uma por artigo processado)
- Todos os testids foram verificados no DOM via `page.evaluate()` antes de escrever as assertions
- Testes configurados em modo `serial` para evitar erros 400 de autosave paralelo

## Dependências

- `OPENAI_API_KEY` configurada no ambiente (obrigatória para o teste 27.3)
- Template "Research Translation Loop" presente na instância Langflow alvo
- ArXiv API pública — sem chave necessária

## O que não cobre

- Validação do número exato de iterações via backend (Monitor API retorna apenas mensagem inicial + final, não mensagens intermediárias do loop)
- Execução com DataFrame vazio (instabilidade de canvas com overlap de nós — descartado)
- Condição de parada customizada do Loop
- Loop com providers além de OpenAI

## Limitações conhecidas

- A validação de iteração (contagem de "title" na resposta) é frágil: depende do formato de saída do Parser no template. Se o template mudar o prompt, o contador pode não bater — mas confirma que o loop processou os artigos
- O teste 27.3 faz 2 chamadas reais à OpenAI API (~30-120s dependendo da latência)

