### PR TITLE
fix/agent run without tools test

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -248,7 +248,7 @@
 #### 6.1 Execução de Agente
 - [x] Agent executa com múltiplos providers e modelos (OpenAI, Anthropic, Google) → `agent-component-regression.spec.ts`
 - [x] Agent exibe resposta válida para pergunta simples → `agent-component-regression.spec.ts`
-- [x] Agent responde sem tools conectadas (regressão ID 147) → `agent-component-regression.spec.ts`
+- [x] Agent responde sem tools conectadas → `agent-component-regression.spec.ts`
 - [-] Agent exibe steps de raciocínio no Playground → `agent-reasoning-steps.spec.ts`
 - [-] Composio (tool integration para Agent) → `composio.spec.ts`
 - [ ] Agent em modo streaming — resposta exibida progressivamente no Playground
@@ -279,7 +279,7 @@
 - [ ] Tool retorna erro — agent trata e continua execução
 
 #### 6.5 Output e Raciocínio
-- [x] Duração de execução exibida após run com tools → `agent-component-regression.spec.ts`
+- [x] Duração de execução exibida após run bem-sucedido → `agent-component-regression.spec.ts`
 - [ ] Inspecionar tools usadas pelo Agent no Playground
 - [ ] Agent retorna output em formato JSON estruturado
 - [ ] Agent retorna output em Markdown renderizado corretamente

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -245,25 +245,24 @@
 > Rode `npx playwright test tests/collect-models.spec.ts` antes de executar estes testes.
 > Veja `CLAUDE.md` nesta pasta para o guia completo.
 
-#### 6.1 Execução de Agente
-- [x] Agent executa com múltiplos providers e modelos (OpenAI, Anthropic, Google) → `agent-component-regression.spec.ts`
-- [x] Agent exibe resposta válida para pergunta simples → `agent-component-regression.spec.ts`
-- [x] Agent responde sem tools conectadas → `agent-component-regression.spec.ts`
+#### 6.1 agent-component-regression.spec.ts — Regressão de Comportamento do Agente
+- [x] Agent responde sem tools conectadas
+- [x] Agent exibe resposta válida e opcionalmente steps de raciocínio
+- [x] Botão Stop interrompe execução do agente
+- [x] Duração de execução exibida após run bem-sucedido
+- [x] Resposta exibida progressivamente no Playground (streaming)
+- [x] Indicador de duração exibido no canvas (`node_duration_agent`) após fechar o playground
+- [x] Agent responde múltiplas mensagens consecutivas na mesma sessão
+
+#### 6.2 Outros testes de execução
 - [-] Agent exibe steps de raciocínio no Playground → `agent-reasoning-steps.spec.ts`
 - [-] Composio (tool integration para Agent) → `composio.spec.ts`
-- [ ] Agent em modo streaming — resposta exibida progressivamente no Playground
-
-#### 6.2 Controle de Execução
-- [x] Botão Stop interrompe execução do agente → `agent-component-regression.spec.ts`
 - [ ] Agent para ao atingir stop condition configurada
 - [ ] Agent para ao atingir número máximo de iterações
 - [ ] Agent com múltiplas tools configuradas executa corretamente
 - [ ] Agent com timeout configurado respeita o limite
 
 #### 6.3 Memória e Contexto
-- [x] Agent responde múltiplas mensagens consecutivas na mesma sessão → `agent-component-regression.spec.ts`
-- [ ] Agent com memória persistente entre mensagens
-- [ ] Agent usa `context_id` customizado
 - [x] Memory Chatbot template carrega com estrutura correta de nós e arestas → `llm-agents/memory-history-regression.spec.ts`
 - [x] Message History retém contexto entre mensagens na mesma sessão do Playground → `llm-agents/memory-history-regression.spec.ts`
 - [x] Isolamento de sessão: session IDs distintos têm históricos independentes → `llm-agents/memory-history-regression.spec.ts`
@@ -279,7 +278,6 @@
 - [ ] Tool retorna erro — agent trata e continua execução
 
 #### 6.5 Output e Raciocínio
-- [x] Duração de execução exibida após run bem-sucedido → `agent-component-regression.spec.ts`
 - [ ] Inspecionar tools usadas pelo Agent no Playground
 - [ ] Agent retorna output em formato JSON estruturado
 - [ ] Agent retorna output em Markdown renderizado corretamente

--- a/QA-SCENARIOS-GUIDE.md
+++ b/QA-SCENARIOS-GUIDE.md
@@ -918,49 +918,142 @@
 
 ## 18. Agentes LLM — Execução e Controle
 
-**Arquivos:** `llm-agents/agent-component-regression.spec.ts`, `llm-agents/agent-reasoning-steps.spec.ts`, `llm-agents/memory-history-regression.spec.ts`
+**Arquivos:** `llm-agents/agent-component-regression.spec.ts`, `llm-agents/memory-history-regression.spec.ts`
 
 ---
 
-### 18.1 Agent com tool calling executa corretamente `[-]`
+### agent-component-regression.spec.ts
 
-**Objetivo:** Verificar que o Agent consegue usar ferramentas para responder perguntas.
+---
+
+### 18.1 Agent responde sem tools conectadas `[x]`
+
+**Objetivo:** Verificar que o agente executa e retorna uma resposta válida mesmo sem nenhuma tool conectada.
 
 **Passo a passo:**
-1. Criar flow: Agent + LLM configurado + Tool (ex: API Request em Tool Mode).
-2. Conectar Tool ao handle de tools do Agent.
-3. Conectar LLM ao handle de language model do Agent.
-4. Abrir Playground e enviar pergunta que requer uso da tool.
-5. Verificar que o Agent chama a tool e retorna resposta baseada no resultado.
+1. Carregar template "Simple Agent" e configurar modelo via `models.json`.
+2. Abrir Playground.
+3. Enviar: `"What is the capital of France?"`.
+4. Aguardar execução finalizar (botão Stop desaparece ou nunca aparece).
+5. Verificar que `div-chat-message` está visível.
+6. Verificar que o texto da resposta tem conteúdo (length > 1).
 
-**Validação:** Agent chama tool e retorna resposta coerente.
+**Validação:** Agente responde corretamente sem tools conectadas.
 
 ---
 
-### 18.2 Agent exibe steps de raciocínio no Playground `[x]`
+### 18.2 Agent exibe steps de raciocínio e retorna resposta válida `[x]`
 
 **Objetivo:** Verificar que o Agent responde com conteúdo válido e, quando utiliza raciocínio interno, exibe o indicador de duração no Playground. O check de steps é soft — modelos que respondem diretamente sem tools não geram o indicador, o que é comportamento esperado.
 
-**Arquivo:** `llm-agents/agent-component-regression.spec.ts`
-
 **Passo a passo:**
-1. Carregar template "Simple Agent" e configurar modelo via `models.json` (OpenAI, Anthropic ou Gemini).
+1. Carregar template "Simple Agent" e configurar modelo via `models.json`.
 2. Abrir Playground.
-3. Enviar mensagem de conhecimento geral: `"Who was the first astronaut to walk on the Moon?"`.
+3. Enviar: `"Who was the first astronaut to walk on the Moon?"`.
 4. Aguardar execução finalizar (botão Stop desaparece ou nunca aparece — ambos válidos).
-5. Verificar que a última mensagem do assistente está visível.
-6. Verificar que o texto da resposta tem conteúdo (length > 1).
-7. **(Soft check)** Se o texto `"Finished in Xs"` estiver visível, verificar que não está vazio.
+5. Verificar que `div-chat-message` está visível e tem conteúdo (length > 1).
+6. **(Soft check)** Se `"Finished in Xs"` estiver visível, verificar que não está vazio.
 
 **DOM relevante:**
 - `div-chat-message` → mensagem do assistente
-- `"Finished in"` → indicador de duração (`bot-message.tsx`), exibido quando o agente usa reasoning steps
+- `"Finished in"` → indicador de duração, exibido quando o agente usa reasoning steps
 
 **Validação:** Resposta válida retornada para todos os modelos; indicador de duração verificado quando presente.
 
 ---
 
-### 18.3 Memory History retém contexto entre mensagens na mesma sessão `[x]`
+### 18.3 Agent stop button halts execution mid-run `[x]`
+
+**Objetivo:** Verificar que o botão Stop interrompe a execução do agente durante um run em andamento.
+
+**Passo a passo:**
+1. Carregar template "Simple Agent" e configurar modelo via `models.json`.
+2. Abrir Playground.
+3. Enviar: `"Write a detailed story about the life and adventures of a fictional explorer in the 18th century."`.
+4. Aguardar o botão Stop aparecer (timeout 30s). Se não aparecer, o modelo respondeu rápido demais — skip implícito.
+5. Clicar no botão Stop via `dispatchEvent("click")`.
+6. Verificar que o botão Stop some.
+7. Verificar que `input-chat-playground` volta a estar visível.
+
+**Validação:** Execução interrompida com sucesso e playground volta ao estado de entrada.
+
+---
+
+### 18.4 Agent displays duration after successful run `[x]`
+
+**Objetivo:** Verificar que o tempo de execução é exibido ao final de um run bem-sucedido.
+
+**Passo a passo:**
+1. Carregar template "Simple Agent" e configurar modelo via `models.json`.
+2. Abrir Playground.
+3. Enviar: `"What are the main differences between mammals and reptiles?"`.
+4. Aguardar execução finalizar (botão Stop desaparece ou nunca aparece).
+5. Verificar que `div-chat-message` está visível.
+6. **(Soft check)** Se `"Finished in Xs"` estiver visível, verificar que não está vazio.
+
+**Validação:** Indicador de duração exibido quando presente após run bem-sucedido.
+
+---
+
+### 18.5 Agent streams response progressively in the playground `[x]`
+
+**Objetivo:** Verificar que a resposta do agente é exibida progressivamente no playground, confirmando que o streaming está ativo durante a geração.
+
+**Passo a passo:**
+1. Carregar template "Simple Agent" e configurar modelo via `models.json`.
+2. Abrir Playground.
+3. Enviar: `"Write a 5-paragraph summary explaining what artificial intelligence is, covering its definition, history, main techniques, applications, and future perspectives."`.
+4. Aguardar `div-chat-message` aparecer (agente iniciou a resposta).
+5. Capturar o texto naquele momento (`textAtStart`).
+6. Aguardar 3 segundos.
+7. Capturar o texto novamente (`textAfterWait`).
+8. Se o botão Stop ainda estiver visível: assert que `textAfterWait.length > textAtStart.length`.
+9. Aguardar o Stop desaparecer e verificar que o texto final tem conteúdo (length > 1).
+
+**Validação:** Texto cresce progressivamente durante o streaming; resposta final com conteúdo válido.
+
+---
+
+### 18.6 Playground displays response time on canvas after closing `[x]`
+
+**Objetivo:** Verificar que após o agente finalizar a resposta e o playground ser fechado, o indicador de duração é exibido no nó do agente no canvas.
+
+**Passo a passo:**
+1. Carregar template "Simple Agent" e configurar modelo via `models.json`.
+2. Abrir Playground.
+3. Enviar: `"What are the main differences between mammals and reptiles?"`.
+4. Aguardar a resposta finalizar (botão Stop desaparece) e `div-chat-message` estar visível.
+5. Clicar em `playground-close-button` para fechar o playground.
+6. Verificar que `node_duration_agent` está visível no canvas.
+
+**DOM relevante:**
+- `playground-close-button` → botão de fechar o playground
+- `node_duration_agent` → indicador de duração no nó do agente no canvas
+
+**Validação:** Indicador de duração exibido no canvas após fechar o playground.
+
+---
+
+### 18.7 Agent handles multiple consecutive messages in same session `[x]`
+
+**Objetivo:** Verificar que o agente responde corretamente a múltiplas mensagens em sequência na mesma sessão.
+
+**Passo a passo:**
+1. Carregar template "Simple Agent" e configurar modelo via `models.json`.
+2. Abrir Playground.
+3. Enviar `"Hello."` e aguardar resposta.
+4. Enviar `"Name three countries in South America."` e aguardar resposta.
+5. Verificar que há pelo menos 2 mensagens visíveis (`div-chat-message` count ≥ 2).
+
+**Validação:** Agente responde corretamente às duas mensagens na mesma sessão.
+
+---
+
+### memory-history-regression.spec.ts
+
+---
+
+### 18.8 Memory History retém contexto entre mensagens na mesma sessão `[x]`
 
 **Objetivo:** Verificar que o componente Message History mantém o histórico de conversa entre mensagens dentro da mesma sessão do Playground.
 
@@ -969,9 +1062,9 @@
 **Passo a passo:**
 1. Carregar template "Memory Chatbot" e configurar modelo OpenAI.
 2. Abrir Playground e iniciar nova sessão (`new-chat`).
-3. Enviar mensagem com dado único: `"In our conversation my name is TESTNAME_XY9Z."`.
-4. Aguardar resposta do assistente (1 mensagem exibida).
-5. Enviar segunda mensagem: `"What is my name from our conversation?"`.
+3. Enviar: `"In our conversation my name is TESTNAME_XY9Z."`.
+4. Aguardar resposta (1 mensagem exibida).
+5. Enviar: `"What is my name from our conversation?"`.
 6. Aguardar resposta (2 mensagens exibidas).
 7. Verificar que a resposta contém `"TESTNAME_XY9Z"`.
 
@@ -979,7 +1072,7 @@
 
 ---
 
-### 18.4 Isolamento de sessão: session IDs distintos têm históricos independentes `[x]`
+### 18.9 Isolamento de sessão: session IDs distintos têm históricos independentes `[x]`
 
 **Objetivo:** Verificar que duas sessões distintas não compartilham histórico.
 
@@ -987,72 +1080,54 @@
 
 **Passo a passo:**
 1. Carregar template "Memory Chatbot" e configurar modelo OpenAI.
-2. Abrir Playground — sessão A: enviar `"In our conversation my secret code is ALPHA_CODE_111."`.
+2. Sessão A: enviar `"In our conversation my secret code is ALPHA_CODE_111."`.
 3. Iniciar nova sessão (`new-chat`) — sessão B: enviar `"What secret code did I mention?"`.
-4. Aguardar resposta da sessão B.
-5. Verificar que a resposta da sessão B **não** contém `"ALPHA_CODE_111"`.
+4. Verificar que a resposta da sessão B **não** contém `"ALPHA_CODE_111"`.
 
 **Validação:** Sessão B não tem acesso ao histórico da sessão A.
 
 ---
 
-### 18.5 Mensagens persistem após fechar e reabrir o Playground `[x]`
-
-**Objetivo:** Verificar que o histórico da sessão é preservado ao fechar e reabrir o Playground.
+### 18.10 Mensagens persistem após fechar e reabrir o Playground `[x]`
 
 **Arquivo:** `llm-agents/memory-history-regression.spec.ts`
 
 **Passo a passo:**
 1. Carregar template "Memory Chatbot" e configurar modelo OpenAI.
 2. Abrir Playground, iniciar nova sessão e enviar: `"In our conversation my value is PERSIST_VALUE_42."`.
-3. Fechar o Playground (clicar fora ou no botão de fechar).
-4. Reabrir o Playground clicando em `playground-btn-flow-io`.
-5. Selecionar a mesma sessão anterior.
-6. Enviar: `"What value did I mention earlier?"`.
-7. Verificar que a resposta contém `"PERSIST_VALUE_42"`.
+3. Fechar o Playground e reabrir clicando em `playground-btn-flow-io`.
+4. Selecionar a mesma sessão e enviar: `"What value did I mention earlier?"`.
+5. Verificar que a resposta contém `"PERSIST_VALUE_42"`.
 
 **Validação:** Histórico persistiu entre aberturas do Playground.
 
 ---
 
-### 18.6 Sem Message History, LLM não retém contexto entre mensagens `[x]`
-
-**Objetivo:** Verificar que sem o componente Message History conectado, o LLM não tem acesso ao histórico de conversa anterior.
+### 18.11 Sem Message History, LLM não retém contexto entre mensagens `[x]`
 
 **Arquivo:** `llm-agents/memory-history-regression.spec.ts`
 
 **Passo a passo:**
-1. Carregar o template "Simple Agent" (sem Message History).
-2. Configurar modelo OpenAI.
-3. Abrir Playground e iniciar nova sessão.
-4. Enviar: `"In our conversation my secret is NOMEM5678."`.
-5. Aguardar resposta (1 mensagem).
-6. Enviar nova mensagem: `"What secret did I just tell you?"`.
-7. Aguardar resposta (2 mensagens).
-8. Verificar que a resposta **não** contém `"NOMEM5678"`.
+1. Carregar o template "Simple Agent" (sem Message History) e configurar modelo OpenAI.
+2. Abrir Playground, enviar: `"In our conversation my secret is NOMEM5678."`.
+3. Enviar: `"What secret did I just tell you?"`.
+4. Verificar que a resposta **não** contém `"NOMEM5678"`.
 
 **Validação:** LLM sem memória não recorda informações de mensagens anteriores.
 
 ---
 
-### 18.7 Parâmetro n_messages do Message History `[ ]`
-
-**Objetivo:** Verificar que o parâmetro `n_messages` limita corretamente a janela de mensagens retidas na memória.
+### 18.12 Parâmetro n_messages do Message History `[ ]`
 
 **Arquivo:** a criar — aguardando correção de bug no backend.
 
-> ⚠️ **Bug confirmado:** O parâmetro `n_messages` é salvo corretamente pelo frontend (verificado via interceptação do PATCH de autosave — payload contém `n_messages: 2`), mas o componente Message History ignora esse valor durante a execução do flow e usa o default (100 mensagens). Bug reportado ao time de desenvolvimento para correção no backend (`MemoryComponent.retrieve_messages()`).
+> ⚠️ **Bug confirmado:** O parâmetro `n_messages` é salvo corretamente pelo frontend mas ignorado na execução do backend (`MemoryComponent.retrieve_messages()`).
 
 **Passo a passo (quando o bug for corrigido):**
-1. Carregar template "Memory Chatbot" e configurar modelo OpenAI.
-2. Abrir InspectionPanel do nó "Message History" e alterar `n_messages` para `2`.
-3. Abrir Playground, iniciar nova sessão.
-4. Enviar Exchange 1: `"In our conversation my value_alpha equals ALPHA_VALUE_123."`.
-5. Enviar Exchange 2: `"In our conversation my value_beta equals BETA_VALUE_456."`.
-6. Enviar Exchange 3: `"In our conversation my value_gamma equals GAMMA_VALUE_789."`.
-7. Enviar Exchange 4: `"What are value_alpha, value_beta, and value_gamma?"`.
-8. Verificar que a resposta **contém** `"GAMMA_VALUE_789"` (dentro da janela).
-9. Verificar que a resposta **não contém** `"ALPHA_VALUE_123"` (fora da janela).
+1. Carregar template "Memory Chatbot", alterar `n_messages` para `2` no nó "Message History".
+2. Enviar 3 exchanges com valores distintos (ALPHA, BETA, GAMMA).
+3. Perguntar pelos 3 valores.
+4. Verificar que GAMMA está na resposta e ALPHA não está.
 
 **Validação:** Com `n_messages=2`, apenas os últimos 2 pares de mensagens estão no contexto.
 

--- a/QA-SCENARIOS-GUIDE.md
+++ b/QA-SCENARIOS-GUIDE.md
@@ -939,26 +939,24 @@
 
 ### 18.2 Agent exibe steps de raciocínio no Playground `[x]`
 
-**Objetivo:** Verificar que os passos de raciocínio do Agent são visíveis no Playground.
+**Objetivo:** Verificar que o Agent responde com conteúdo válido e, quando utiliza raciocínio interno, exibe o indicador de duração no Playground. O check de steps é soft — modelos que respondem diretamente sem tools não geram o indicador, o que é comportamento esperado.
 
-**Arquivo:** `core/features/agent-reasoning-steps.spec.ts`
+**Arquivo:** `llm-agents/agent-component-regression.spec.ts`
 
 **Passo a passo:**
-1. Carregar template "Simple Agent" e configurar modelo (OpenAI, Anthropic ou Gemini).
-2. Abrir Playground e iniciar nova sessão.
-3. Enviar mensagem que force uso de tool: `"You MUST use the Calculator tool. Compute 987 multiplied by 654."`.
-4. Aguardar execução finalizar (botão Stop desaparece).
-5. Verificar que o texto `"Finished in Xs"` aparece na mensagem do assistente.
-6. Verificar que ao menos um item `"Called tool <nome>"` está visível (accordion).
-7. Clicar no item `"Called tool"` para expandir.
-8. Verificar que o conteúdo expande (`data-state="open"`).
+1. Carregar template "Simple Agent" e configurar modelo via `models.json` (OpenAI, Anthropic ou Gemini).
+2. Abrir Playground.
+3. Enviar mensagem de conhecimento geral: `"Who was the first astronaut to walk on the Moon?"`.
+4. Aguardar execução finalizar (botão Stop desaparece ou nunca aparece — ambos válidos).
+5. Verificar que a última mensagem do assistente está visível.
+6. Verificar que o texto da resposta tem conteúdo (length > 1).
+7. **(Soft check)** Se o texto `"Finished in Xs"` estiver visível, verificar que não está vazio.
 
 **DOM relevante:**
-- `"Finished in"` → `bot-message.tsx` status text
-- `"Called tool"` → `ContentBlockDisplay.tsx` AccordionTrigger (renderizado como `<div>`, não `<button>`)
-- `[data-state="open"]` → Radix AccordionItem/AccordionContent após expansão
+- `div-chat-message` → mensagem do assistente
+- `"Finished in"` → indicador de duração (`bot-message.tsx`), exibido quando o agente usa reasoning steps
 
-**Validação:** Steps de raciocínio visíveis, clicáveis e expansíveis no Playground.
+**Validação:** Resposta válida retornada para todos os modelos; indicador de duração verificado quando presente.
 
 ---
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
@@ -406,8 +406,10 @@ for (const { label, options, skipReason } of targets) {
 
         await expect(page.getByTestId("div-chat-message").last()).toBeVisible({ timeout: 30000 });
 
-        // Assert that the response time indicator is displayed in the playground
-        await expect(page.getByText(/Finished in \d+(\.\d+)?s/).last()).toBeVisible({ timeout: 10000 });
+        // Close the playground and check the duration indicator on the canvas node
+        await page.getByTestId("playground-close-button").click();
+
+        await expect(page.getByTestId("node_duration_agent")).toBeVisible({ timeout: 10000 });
       },
     );
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
@@ -252,7 +252,7 @@ for (const { label, options, skipReason } of targets) {
       },
     );
 
-    test(
+    test.only(
       "agent must display duration after successful run",
       { tag: ["@release", "@components", "@agents"] },
       async ({ page }) => {
@@ -271,7 +271,7 @@ for (const { label, options, skipReason } of targets) {
 
         await page.getByTestId("playground-btn-flow-io").click();
 
-        await page.getByTestId("input-chat-playground").last().fill("What are the main differences between mammals and reptiles?");
+        await page.getByTestId("input-chat-playground").last().fill("What is IA?");
 
         await page.getByTestId("button-send").last().click();
 
@@ -283,13 +283,7 @@ for (const { label, options, skipReason } of targets) {
         }
 
         await expect(page.getByTestId("div-chat-message").last()).toBeVisible({ timeout: 30000 });
-
-        // "Finished in Xs" only appears when tools are used — soft-check
-        const finishedText = page.getByText(/Finished in/).last();
-        if (await finishedText.isVisible({ timeout: 5000 }).catch(() => false)) {
-          const durationText = await finishedText.innerText();
-          expect(durationText.trim().length).toBeGreaterThan(0);
-        }
+        await expect(page.getByText(/Finished in \d+(\.\d+)?s/)).toBeVisible();
       },
     );
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
@@ -252,7 +252,7 @@ for (const { label, options, skipReason } of targets) {
       },
     );
 
-    test.only(
+    test(
       "agent must display duration after successful run",
       { tag: ["@release", "@components", "@agents"] },
       async ({ page }) => {

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
@@ -368,6 +368,50 @@ for (const { label, options, skipReason } of targets) {
     );
 
     test(
+      "playground must display response time after agent finishes",
+      { tag: ["@release", "@components", "@agents", "@playground"] },
+      async ({ page }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        try {
+          await new SimpleAgentTemplatePage(page).load(options);
+        } catch (e: any) {
+          if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
+          throw e;
+        }
+
+        await page.getByTestId("playground-btn-flow-io").click();
+
+        await page.waitForSelector('[data-testid="input-chat-playground"]', {
+          timeout: 30000,
+        });
+
+        await page
+          .getByTestId("input-chat-playground")
+          .last()
+          .fill("What are the main differences between mammals and reptiles?");
+
+        await page.getByTestId("button-send").last().click();
+
+        // Aguarda a resposta finalizar
+        const stopButton = page.getByRole("button", { name: "Stop" });
+        const stopVisible = await stopButton.isVisible({ timeout: 10000 }).catch(() => false);
+        if (stopVisible) {
+          await expect(stopButton).toBeHidden({ timeout: 120000 });
+        }
+
+        await expect(page.getByTestId("div-chat-message").last()).toBeVisible({ timeout: 30000 });
+
+        // Valida que o indicador de tempo de resposta é exibido no playground
+        await expect(page.getByText(/Finished in \d+(\.\d+)?s/).last()).toBeVisible({ timeout: 10000 });
+      },
+    );
+
+    test(
       "agent must handle multiple consecutive messages in same session",
       { tag: ["@release", "@components", "@agents"] },
       async ({ page }) => {

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
@@ -110,6 +110,57 @@ for (const { label, options, skipReason } of targets) {
 
   test.describe.serial(`Agent Component Regression [${label}]`, () => {
     test(
+      "agent must run and respond without any tools connected",
+      { tag: ["@release", "@components", "@agents"] },
+      async ({ page }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        // Use Simple Agent template (has Chat I/O needed for playground) but
+        // send a knowledge question that doesn't require tools — verifies agent
+        // responds even when tool use is not needed (regression for ID 147)
+        try {
+          await new SimpleAgentTemplatePage(page).load(options);
+        } catch (e: any) {
+          if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
+          throw e;
+        }
+
+        await page.getByTestId("playground-btn-flow-io").click();
+
+        await page.waitForSelector('[data-testid="input-chat-playground"]', {
+          timeout: 30000,
+        });
+
+        await page
+          .getByTestId("input-chat-playground")
+          .last()
+          .fill("What is the capital of France?");
+
+        await page.getByTestId("button-send").last().click();
+
+        // Some models respond directly without tools — stop button may not appear
+        const stopButton = page.getByRole("button", { name: "Stop" });
+        const stopVisible = await stopButton.isVisible({ timeout: 10000 }).catch(() => false);
+        if (stopVisible) {
+          await expect(stopButton).toBeHidden({ timeout: 120000 });
+        }
+
+        await expect(page.getByTestId("div-chat-message").last()).toBeVisible({ timeout: 30000 });
+
+        const responseText = await page
+          .getByTestId("div-chat-message")
+          .last()
+          .innerText();
+
+        expect(responseText.trim().length).toBeGreaterThan(1);
+      },
+    );
+
+    test(
       "agent must show reasoning steps and produce a valid response",
       { tag: ["@release", "@components", "@agents"] },
       async ({ page }) => {
@@ -282,55 +333,5 @@ for (const { label, options, skipReason } of targets) {
       },
     );
 
-    test(
-      "agent must run and respond without any tools connected (ID 147)",
-      { tag: ["@release", "@components", "@agents"] },
-      async ({ page }) => {
-        test.skip(!!skipReason, skipReason ?? "");
-        test.skip(
-          !hasProviderEnvKeys(provider),
-          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
-        );
-
-        // Use Simple Agent template (has Chat I/O needed for playground) but
-        // send a knowledge question that doesn't require tools — verifies agent
-        // responds even when tool use is not needed (regression for ID 147)
-        try {
-          await new SimpleAgentTemplatePage(page).load(options);
-        } catch (e: any) {
-          if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
-          throw e;
-        }
-
-        await page.getByTestId("playground-btn-flow-io").click();
-
-        await page.waitForSelector('[data-testid="input-chat-playground"]', {
-          timeout: 30000,
-        });
-
-        await page
-          .getByTestId("input-chat-playground")
-          .last()
-          .fill("What is the capital of France?");
-
-        await page.getByTestId("button-send").last().click();
-
-        // Some models respond directly without tools — stop button may not appear
-        const stopButton = page.getByRole("button", { name: "Stop" });
-        const stopVisible = await stopButton.isVisible({ timeout: 10000 }).catch(() => false);
-        if (stopVisible) {
-          await expect(stopButton).toBeHidden({ timeout: 120000 });
-        }
-
-        await expect(page.getByTestId("div-chat-message").last()).toBeVisible({ timeout: 30000 });
-
-        const responseText = await page
-          .getByTestId("div-chat-message")
-          .last()
-          .innerText();
-
-        expect(responseText.trim().length).toBeGreaterThan(1);
-      },
-    );
   });
 }

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
@@ -181,7 +181,7 @@ for (const { label, options, skipReason } of targets) {
 
         await page.getByTestId("playground-btn-flow-io").click();
 
-        await page.getByTestId("input-chat-playground").last().fill("What is 2 + 2?");
+        await page.getByTestId("input-chat-playground").last().fill("Who was the first astronaut to walk on the Moon?");
 
         await page.getByTestId("button-send").last().click();
 
@@ -229,7 +229,7 @@ for (const { label, options, skipReason } of targets) {
         await page
           .getByTestId("input-chat-playground")
           .last()
-          .fill("Write a very long essay about the history of artificial intelligence.");
+          .fill("Write a detailed story about the life and adventures of a fictional explorer in the 18th century.");
 
         await page.getByTestId("button-send").last().click();
 
@@ -271,7 +271,7 @@ for (const { label, options, skipReason } of targets) {
 
         await page.getByTestId("playground-btn-flow-io").click();
 
-        await page.getByTestId("input-chat-playground").last().fill("What is 123 + 456?");
+        await page.getByTestId("input-chat-playground").last().fill("What are the main differences between mammals and reptiles?");
 
         await page.getByTestId("button-send").last().click();
 
@@ -312,7 +312,7 @@ for (const { label, options, skipReason } of targets) {
 
         await page.getByTestId("playground-btn-flow-io").click();
 
-        for (const message of ["Hello.", "What is 1 + 1?"]) {
+        for (const message of ["Hello.", "Name three countries in South America."]) {
           await page.getByTestId("input-chat-playground").last().fill(message);
 
           await page.getByTestId("button-send").last().click();

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
@@ -39,7 +39,7 @@ function getProviderSkipReasons(): Map<string, string> {
   const reasons = new Map<string, string>();
   for (const r of records) {
     if (r.status === "inactive") {
-      reasons.set(r.provider, `Provider "${r.provider}" inativo — ${r.error}`);
+      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
     }
   }
   return reasons;
@@ -316,7 +316,7 @@ for (const { label, options, skipReason } of targets) {
           timeout: 30000,
         });
 
-        // Prompt longo o suficiente para manter o agente gerando por alguns segundos
+        // Long enough prompt to keep the agent generating for a few seconds
         await page
           .getByTestId("input-chat-playground")
           .last()
@@ -324,18 +324,18 @@ for (const { label, options, skipReason } of targets) {
 
         await page.getByTestId("button-send").last().click();
 
-        // Aguarda o agente iniciar (~2s) e a primeira mensagem aparecer
+        // Wait for the agent to start (~2s) and the first message to appear
         await expect(page.getByTestId("div-chat-message").last()).toBeVisible({
           timeout: 30000,
         });
 
-        // Captura o texto parcial enquanto o agente ainda pode estar gerando
+        // Capture partial text while the agent may still be generating
         const textAtStart = await page
           .getByTestId("div-chat-message")
           .last()
           .innerText();
 
-        // Aguarda alguns segundos para que mais tokens sejam recebidos
+        // Wait a few seconds for more tokens to be received
         await page.waitForTimeout(3000);
 
         const textAfterWait = await page
@@ -343,19 +343,19 @@ for (const { label, options, skipReason } of targets) {
           .last()
           .innerText();
 
-        // Se o stop button ainda estava visível, o texto deve ter crescido (streaming ativo)
-        // Se já finalizou antes dos 3s, apenas valida que a resposta tem conteúdo
+        // If stop button is still visible, text must have grown (streaming active)
+        // If already finished within 3s, just validate that the response has content
         const stopButton = page.getByRole("button", { name: "Stop" });
         const stillGenerating = await stopButton.isVisible({ timeout: 500 }).catch(() => false);
 
         if (stillGenerating) {
           expect(
             textAfterWait.trim().length,
-            "Texto deve crescer durante streaming — resposta ainda em andamento",
+            "Text must grow during streaming — response still in progress",
           ).toBeGreaterThan(textAtStart.trim().length);
         }
 
-        // Aguarda a resposta finalizar completamente
+        // Wait for the response to finish completely
         await expect(stopButton).toBeHidden({ timeout: 120000 });
 
         const finalText = await page
@@ -397,7 +397,7 @@ for (const { label, options, skipReason } of targets) {
 
         await page.getByTestId("button-send").last().click();
 
-        // Aguarda a resposta finalizar
+        // Wait for the response to finish
         const stopButton = page.getByRole("button", { name: "Stop" });
         const stopVisible = await stopButton.isVisible({ timeout: 10000 }).catch(() => false);
         if (stopVisible) {
@@ -406,7 +406,7 @@ for (const { label, options, skipReason } of targets) {
 
         await expect(page.getByTestId("div-chat-message").last()).toBeVisible({ timeout: 30000 });
 
-        // Valida que o indicador de tempo de resposta é exibido no playground
+        // Assert that the response time indicator is displayed in the playground
         await expect(page.getByText(/Finished in \d+(\.\d+)?s/).last()).toBeVisible({ timeout: 10000 });
       },
     );

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
@@ -294,6 +294,80 @@ for (const { label, options, skipReason } of targets) {
     );
 
     test(
+      "agent must stream response progressively in the playground",
+      { tag: ["@release", "@components", "@agents", "@playground"] },
+      async ({ page }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        try {
+          await new SimpleAgentTemplatePage(page).load(options);
+        } catch (e: any) {
+          if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
+          throw e;
+        }
+
+        await page.getByTestId("playground-btn-flow-io").click();
+
+        await page.waitForSelector('[data-testid="input-chat-playground"]', {
+          timeout: 30000,
+        });
+
+        // Prompt longo o suficiente para manter o agente gerando por alguns segundos
+        await page
+          .getByTestId("input-chat-playground")
+          .last()
+          .fill("Write a 5-paragraph summary explaining what artificial intelligence is, covering its definition, history, main techniques, applications, and future perspectives.");
+
+        await page.getByTestId("button-send").last().click();
+
+        // Aguarda o agente iniciar (~2s) e a primeira mensagem aparecer
+        await expect(page.getByTestId("div-chat-message").last()).toBeVisible({
+          timeout: 30000,
+        });
+
+        // Captura o texto parcial enquanto o agente ainda pode estar gerando
+        const textAtStart = await page
+          .getByTestId("div-chat-message")
+          .last()
+          .innerText();
+
+        // Aguarda alguns segundos para que mais tokens sejam recebidos
+        await page.waitForTimeout(3000);
+
+        const textAfterWait = await page
+          .getByTestId("div-chat-message")
+          .last()
+          .innerText();
+
+        // Se o stop button ainda estava visível, o texto deve ter crescido (streaming ativo)
+        // Se já finalizou antes dos 3s, apenas valida que a resposta tem conteúdo
+        const stopButton = page.getByRole("button", { name: "Stop" });
+        const stillGenerating = await stopButton.isVisible({ timeout: 500 }).catch(() => false);
+
+        if (stillGenerating) {
+          expect(
+            textAfterWait.trim().length,
+            "Texto deve crescer durante streaming — resposta ainda em andamento",
+          ).toBeGreaterThan(textAtStart.trim().length);
+        }
+
+        // Aguarda a resposta finalizar completamente
+        await expect(stopButton).toBeHidden({ timeout: 120000 });
+
+        const finalText = await page
+          .getByTestId("div-chat-message")
+          .last()
+          .innerText();
+
+        expect(finalText.trim().length).toBeGreaterThan(1);
+      },
+    );
+
+    test(
       "agent must handle multiple consecutive messages in same session",
       { tag: ["@release", "@components", "@agents"] },
       async ({ page }) => {


### PR DESCRIPTION
## Tipo

<!-- Marque com [x] o tipo desta PR -->

- [x] `feat` — novo teste ou novo helper/page object
- [x] `fix` — correção de teste quebrado ou flaky
- [ ] `chore` — CI, checklist, dependências, refatoração interna
- [x] `docs` — atualização de documentação

---

   ## O que esta PR faz

  Remove prompts que ativavam tool calling dos testes de regressão do agente e refatora e corrige os testes que estavam quebrados, garantindo que todos os modelos —   
  incluindo os incompatíveis com ferramentas — possam ser validados sem falha.

  Além disso, adiciona dois novos testes de comportamento do agente no playground.

  Testes ajustados:

  | Teste | O que valida |
  |---|---|
  | `agent must run and respond without any tools connected` | Verifica se o agente executa e retorna uma resposta válida sem nenhuma tool conectada |
  | `agent must show reasoning steps and produce a valid response` | Verifica se o agente retorna uma resposta válida, checando opcionalmente a exibição de steps de raciocínio |
  | `agent stop button must halt execution mid-run` | Verifica se o botão de parar interrompe a execução do agente durante um run em andamento |
  | `agent must display duration after successful run` | Verifica se o tempo de execução é exibido ao final de um run bem-sucedido |

  Testes adicionados:

  | Teste | O que valida |
  |---|---|
  | `agent must stream response progressively in the playground` | Verifica se a resposta do agente é exibida progressivamente no playground (streaming ativo) |       
  | `playground must display response time after agent finishes` | Verifica se o indicador de duração (`node_duration_agent`) é exibido no canvas após fechar o playground |

  ### Atualização das documentações

  - `QA-CHECKLIST.md` — criado bloco dedicado para `agent-component-regression.spec.ts` agrupando todos os testes do spec
  - `QA-SCENARIOS-GUIDE.md` — seção 18 reorganizada em blocos por spec, com adição dos novos cenários e remoção de duplicatas

  ---

  ## Validação

  ```bash
  npx playwright test tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts --workers=1