### PR TITLE
docs: introduz pasta docs/ e TEMPLATE.md para especificação de testes

### DIFF
--- a/docs/TEMPLATE.md
+++ b/docs/TEMPLATE.md
@@ -1,0 +1,47 @@
+# [Nome do Spec]
+
+## Objetivo *(obrigatório)*
+Validar que o usuário consegue fazer upload de um arquivo, processá-lo e visualizar os vetores gerados.
+
+---
+
+## Passo a passo *(obrigatório)*
+1. Acessar a página de Knowledge Base
+2. Clicar em "Upload File" e selecionar um `.pdf` válido
+3. Aguardar o processamento completar (spinner desaparecer)
+4. Navegar para a aba "Vectors"
+5. Verificar que os chunks gerados estão listados
+
+---
+
+## Critério de validação *(obrigatório)*
+- O arquivo aparece na lista com status `processed`
+- A aba "Vectors" exibe ao menos 1 chunk
+- Nenhum erro é exibido na interface durante o fluxo
+
+---
+
+## Pré-condições *(opcional)*
+- Usuário autenticado com permissão de escrita
+- Arquivo `sample.pdf` presente em `fixtures/files/`
+
+---
+
+## Dependências externas *(obrigatório)*
+<!-- Arquivos do repositório do Langflow que, se alterados, podem quebrar este teste.
+     Esta lista é lida pelo workflow de monitoramento — preencha com atenção. -->
+
+- `src/lfx/src/lfx/components/files_and_knowledge/file.py` — lógica de upload e processamento do File Component
+- `src/lfx/src/lfx/components/files_and_knowledge/vector_store.py` — geração e listagem de vetores
+
+---
+
+## Critério de revisão *(opcional)*
+- Revisar se o comportamento do spinner ou dos status labels mudar na UI
+- Revisar se o formato de resposta da API de vetores for alterado
+
+---
+
+## Notas *(opcional)*
+- O processamento pode levar até 10s em ambiente de CI — o teste usa `waitForSelector` com timeout estendido
+- Flaky em arquivos maiores que 5MB; manter fixture abaixo desse limite


### PR DESCRIPTION
## O que este PR adiciona

- Cria a pasta `docs/` no repositório
- Adiciona `docs/TEMPLATE.md` — template padrão para documentar specs de teste antes da implementação

## Estrutura do template

O arquivo cobre os campos:
- **Objetivo** — o que o teste valida
- **Passo a passo** — sequência de ações
- **Critério de validação** — o que deve ser verdade ao final
- **Pré-condições** — estado necessário antes de rodar
- **Dependências externas** — arquivos do Langflow monitorados pelo file-watcher
- **Critério de revisão** — quando revisar o teste
- **Notas** — observações de flakiness, timeouts, etc.

## Checklist

- [x] Alteração apenas em documentação — nenhum teste criado ou modificado
- [x] Branch segue padrão `docs/` conforme CONTRIBUTING