### PR TITLE
Feat/test invalid provider api key

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -311,6 +311,7 @@
 #### 7.4 Google Generative AI
 - [-] Configurar API key Google no agente
 - [-] Selecionar modelo Gemini no agente
+- [-] Erro de API key Google inválida → `provider-invalid-auth-error.spec.ts`
 
 #### 7.5 Gerenciamento de Providers
 - [-] Modal "Manage Model Providers"
@@ -616,7 +617,7 @@
 | `core-components/` — Componentes | 22 | 16 | 0 | 6 |
 | `core-functionality/playground/` | 17 | 14 | 0 | 3 |
 | `core-functionality/observability-monitoring/` | 16 | 13 | 0 | 3 |
-| `core-functionality/model-provider/` | 20 | 13 | 0 | 7 |
+| `core-functionality/model-provider/` | 21 | 13 | 0 | 8 |
 | `core-functionality/llm-agents/` | 15 | 8 | 0 | 7 |
 | `core-functionality/knowledge-ingestion/` | 8 | 4 | 0 | 4 |
 | `flow-functionality/` | 20 | 18 | 1 | 1 |
@@ -626,7 +627,7 @@
 | `templates/` | 35 | 33 | 0 | 2 |
 | `ui-ux/` — Canvas | 30 | 28 | 1 | 1 |
 | `ui-ux/` — Settings | 4 | 4 | 0 | 0 |
-| **TOTAL** | **265** | **213 (80%)** | **3** | **49 (18%)** |
+| **TOTAL** | **266** | **213 (80%)** | **3** | **50 (19%)** |
 
 ---
 

--- a/QA-SCENARIOS-GUIDE.md
+++ b/QA-SCENARIOS-GUIDE.md
@@ -1064,7 +1064,7 @@
 
 ## 19. Model Providers
 
-**Arquivos:** `core/features/globalVariables.spec.ts`, `claude-model-switch.spec.ts`, `modelProviderModal.spec.ts`
+**Arquivos:** `core/features/globalVariables.spec.ts`, `claude-model-switch.spec.ts`, `modelProviderModal.spec.ts`, `provider-invalid-auth-error.spec.ts`
 
 ---
 
@@ -1117,18 +1117,61 @@
 
 ---
 
-### 19.5 Erro de API key inválida `[-]` (mocked)
+### 19.5 Erro de autenticação inválida — OpenAI `[-]`
+
+**Arquivo:** `provider-invalid-auth-error.spec.ts`
+
+**Pré-condição:** `OPENAI_API_KEY` configurado no `.env`.
 
 **Passo a passo:**
-1. Configurar componente LLM com API key inválida (`sk-invalida`).
-2. Executar flow ou enviar mensagem no Playground.
-3. Verificar que mensagem de erro sobre API key inválida é exibida.
+1. Navegar para `Settings > Model Providers > OpenAI`.
+2. Substituir a API key por uma chave inválida (ex: `sk-invalid-openai-key-for-testing`).
+3. Carregar o template Simple Agent com provider OpenAI.
+4. Abrir o Playground e enviar uma mensagem.
+5. Verificar que `.error-build-message` exibe texto correspondendo a `/Invalid API key/i`.
+6. (Cleanup) Restaurar a chave válida via `Settings > Model Providers`.
 
-**Validação:** Erro de autenticação com LLM exibido ao usuário.
+**Validação:** O Langflow exibe mensagem de erro de autenticação no canvas quando a chave OpenAI é inválida.
 
 ---
 
-### 19.6 Modal "Manage Model Providers" `[-]`
+### 19.6 Erro de autenticação inválida — Anthropic `[-]`
+
+**Arquivo:** `provider-invalid-auth-error.spec.ts`
+
+**Pré-condição:** `ANTHROPIC_API_KEY` configurado no `.env`.
+
+**Passo a passo:**
+1. Navegar para `Settings > Model Providers > Anthropic`.
+2. Substituir a API key por uma chave inválida (ex: `sk-ant-invalid-for-testing`).
+3. Carregar o template Simple Agent com provider Anthropic.
+4. Abrir o Playground e enviar uma mensagem.
+5. Verificar que `.error-build-message` exibe texto correspondendo a `/Invalid API key|authentication_error|invalid.*key/i`.
+6. (Cleanup) Restaurar a chave válida via `Settings > Model Providers`.
+
+**Validação:** O Langflow exibe mensagem de erro de autenticação no canvas quando a chave Anthropic é inválida.
+
+---
+
+### 19.7 Erro de autenticação inválida — Google `[-]`
+
+**Arquivo:** `provider-invalid-auth-error.spec.ts`
+
+**Pré-condição:** `GOOGLE_API_KEY` configurado no `.env`.
+
+**Passo a passo:**
+1. Navegar para `Settings > Model Providers > Google Generative AI`.
+2. Substituir a API key por uma chave inválida (ex: `AIza-invalid-google-key-for-testing`).
+3. Carregar o template Simple Agent com provider Google.
+4. Abrir o Playground e enviar uma mensagem.
+5. Verificar que `.error-build-message` exibe texto correspondendo a `/Invalid API key|API key not valid|invalid.*key/i`.
+6. (Cleanup) Restaurar a chave válida via `Settings > Model Providers`.
+
+**Validação:** O Langflow exibe mensagem de erro de autenticação no canvas quando a chave Google é inválida.
+
+---
+
+### 19.8 Modal "Manage Model Providers" `[-]`
 
 **Passo a passo:**
 1. Clicar no botão de gerenciamento de providers.
@@ -1775,14 +1818,14 @@
 | Componentes Principais | 22 | 16 | 6 |
 | Playground | 17 | 14 | 3 |
 | Observabilidade | 16 | 13 | 3 |
-| Model Providers | 16 | 10 | 6 |
+| Model Providers | 19 | 10 | 9 |
 | Knowledge Ingestion | 8 | 4 | 4 |
 | Flow Operations | 20 | 18 | 2 |
 | MCP | 13 | 3 | 10 |
 | Gestão de Projetos | 11 | 9 | 2 |
 | Templates | 35 | 33 | 2 |
 | UI/UX Canvas | 34 | 32 | 2 |
-| **TOTAL** | **246** | **202 (82%)** | **44 (18%)** |
+| **TOTAL** | **249** | **202 (81%)** | **47 (19%)** |
 
 ---
 


### PR DESCRIPTION
## Tipo                                                                                                                                                                                                                                                                                                                                                                             
  <!-- Marque com [x] o tipo desta PR -->                                                                                                                                                                                                                                                                                                                                             
  - [x] `feat` — novo teste ou novo helper/page object                                                                                                                                     
  - [ ] `fix` — correção de teste quebrado ou flaky
  - [ ] `chore` — CI, checklist, dependências, refatoração interna
  - [ ] `docs` — atualização de documentação

  ---

  ## O que esta PR faz

  Adiciona `provider-invalid-auth-error.spec.ts`, que valida que o Langflow exibe a mensagem de erro correta no canvas quando um provider é executado com uma autenticação inválida (chave 
  de API incorreta). Cobre OpenAI, Anthropic e Google via estrutura extensível. Atualiza `QA-CHECKLIST.md` e `QA-SCENARIOS-GUIDE.md` com os novos cenários.

  ---

  ## Testes cobertos

  | # | Teste | O que valida |
  |---|---|---|
  | 1 | `deve exibir mensagem de erro ao usar autenticação inválida do provider openai` | O Langflow exibe `.error-build-message` com texto de erro de autenticação quando o agente tenta executar com uma OpenAI API key inválida |
  | 2 | `deve exibir mensagem de erro ao usar autenticação inválida do provider anthropic` | O Langflow exibe `.error-build-message` com texto de erro de autenticação quando o agente tenta executar com uma Anthropic API key inválida |
  | 3 | `deve exibir mensagem de erro ao usar autenticação inválida do provider google` | O Langflow exibe `.error-build-message` com texto de erro de autenticação quando o agente tenta executar com uma Google API key inválida |

  ---

  ## Como os testes foram construídos

  O teste interage diretamente pela UI em todas as etapas. A chave inválida é injetada via `Settings > Model Providers` antes de carregar o flow. O `SimpleAgentTemplatePage.load()`       
  detecta que a chave já está configurada (via ausência do botão "Save Configuration") e não a sobrescreve, preservando a chave inválida durante a execução. A mensagem de erro é provocada
   enviando uma mensagem no Playground, que aciona o run do agente contra a API do provider com a chave inválida.

  ---

  ## Dependências

  - `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` e/ou `GOOGLE_API_KEY` devem estar configuradas no `.env` — o teste usa a chave válida para restaurar o estado após a execução. Providers sem env 
  var configurada são pulados automaticamente.
  - Execução em modo serial (`test.describe.serial`) por provider — cada describe seta e restaura a chave do seu provider de forma isolada.
  - O `finally` garante a restauração da chave válida mesmo em caso de falha.

  ---

  ## O que esta PR não cobre

  - Validação do erro via chamada de API REST direta (apenas UI).
  - Providers além de OpenAI, Anthropic e Google — a estrutura está pronta via `providerAuthConfigMap`, basta adicionar a entrada ao incluir um novo provider em `index.ts`.
  - Verificação de erro quando a chave é removida completamente (apenas substituída por uma inválida).

  ---

  ## Limitações conhecidas

  - A lógica de sobrescrita de chave já configurada (`else` em `configureProviderApiKey`) depende do input com `placeholder` ainda estar visível na UI. Se o Langflow alterar o estado do  
  campo quando a chave está configurada (ex: tornar o campo somente leitura sem botão de edição visível), o helper precisa ser adaptado.
  - O `errorPattern` para Anthropic e Google é mais amplo (`/authentication_error|invalid.*key/i`) porque a mensagem de erro retornada pela API desses providers não segue o mesmo formato 
  que a mensagem da OpenAI.
  - Timeout de 30s para `.error-build-message` — adequado para respostas de erro de API, mas pode ser longo em ambientes lentos.

  ---