### PR TITLE
Fix/test invalid provider api key sync main

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -312,18 +312,18 @@
 - [-] Configurar API key OpenAI via GlobalVariables
 - [-] Selecionar modelo GPT no agente
 - [-] Executar flow com OpenAI
-- [-] Erro de API key inválida — exibir mensagem de erro
+- [x] Erro de API key inválida — exibir mensagem de erro → `provider-invalid-auth-error.spec.ts`
 
 #### 7.3 Anthropic
 - [-] Configurar API key Anthropic
 - [-] Selecionar modelo Claude no agente
 - [-] Trocar entre modelos Claude (Sonnet, Haiku, Opus)
-- [-] Erro de API key Anthropic inválida
+- [x] Erro de API key Anthropic inválida → `provider-invalid-auth-error.spec.ts`
 
 #### 7.4 Google Generative AI
 - [-] Configurar API key Google no agente
 - [-] Selecionar modelo Gemini no agente
-- [-] Erro de API key Google inválida → `provider-invalid-auth-error.spec.ts`
+- [x] Erro de API key Google inválida → `provider-invalid-auth-error.spec.ts`
 
 #### 7.5 Gerenciamento de Providers
 - [-] Modal "Manage Model Providers"

--- a/QA-SCENARIOS-GUIDE.md
+++ b/QA-SCENARIOS-GUIDE.md
@@ -1525,14 +1525,15 @@
 **Pré-condição:** `OPENAI_API_KEY` configurado no `.env`.
 
 **Passo a passo:**
-1. Navegar para `Settings > Model Providers > OpenAI`.
-2. Substituir a API key por uma chave inválida (ex: `sk-invalid-openai-key-for-testing`).
-3. Carregar o template Simple Agent com provider OpenAI.
-4. Abrir o Playground e enviar uma mensagem.
-5. Verificar que `.error-build-message` exibe texto correspondendo a `/Invalid API key/i`.
-6. (Cleanup) Restaurar a chave válida via `Settings > Model Providers`.
+1. Navegar para `Settings` via menu do usuário.
+2. Clicar no ícone `icon-Brain` para acessar Model Providers.
+3. Clicar no provider OpenAI.
+4. Selecionar todo o conteúdo do campo de API key e inserir uma chave inválida (ex: `sk-invalid-openai-key-for-testing`).
+5. Clicar em `Save Configuration` (primeira vez) ou `Replace Configuration` (chave já existente).
+6. Verificar que `.error-build-message` exibe texto correspondendo a `/Invalid API key/i`.
+7. (Cleanup) Selecionar o campo, inserir a chave válida do `.env` e clicar em `Replace Configuration`.
 
-**Validação:** O Langflow exibe mensagem de erro de autenticação no canvas quando a chave OpenAI é inválida.
+**Validação:** O Langflow exibe `.error-build-message` com `/Invalid API key/i` imediatamente após salvar uma chave inválida na página de configuração do provider.
 
 ---
 
@@ -1543,14 +1544,15 @@
 **Pré-condição:** `ANTHROPIC_API_KEY` configurado no `.env`.
 
 **Passo a passo:**
-1. Navegar para `Settings > Model Providers > Anthropic`.
-2. Substituir a API key por uma chave inválida (ex: `sk-ant-invalid-for-testing`).
-3. Carregar o template Simple Agent com provider Anthropic.
-4. Abrir o Playground e enviar uma mensagem.
-5. Verificar que `.error-build-message` exibe texto correspondendo a `/Invalid API key|authentication_error|invalid.*key/i`.
-6. (Cleanup) Restaurar a chave válida via `Settings > Model Providers`.
+1. Navegar para `Settings` via menu do usuário.
+2. Clicar no ícone `icon-Brain` para acessar Model Providers.
+3. Clicar no provider Anthropic.
+4. Selecionar todo o conteúdo do campo de API key e inserir uma chave inválida (ex: `sk-ant-invalid-for-testing`).
+5. Clicar em `Save Configuration` ou `Replace Configuration`.
+6. Verificar que `.error-build-message` exibe texto correspondendo a `/Invalid API key/i`.
+7. (Cleanup) Selecionar o campo, inserir a chave válida do `.env` e clicar em `Replace Configuration`.
 
-**Validação:** O Langflow exibe mensagem de erro de autenticação no canvas quando a chave Anthropic é inválida.
+**Validação:** O Langflow exibe `.error-build-message` com `/Invalid API key/i` imediatamente após salvar uma chave inválida na página de configuração do provider.
 
 ---
 
@@ -1561,14 +1563,15 @@
 **Pré-condição:** `GOOGLE_API_KEY` configurado no `.env`.
 
 **Passo a passo:**
-1. Navegar para `Settings > Model Providers > Google Generative AI`.
-2. Substituir a API key por uma chave inválida (ex: `AIza-invalid-google-key-for-testing`).
-3. Carregar o template Simple Agent com provider Google.
-4. Abrir o Playground e enviar uma mensagem.
-5. Verificar que `.error-build-message` exibe texto correspondendo a `/Invalid API key|API key not valid|invalid.*key/i`.
-6. (Cleanup) Restaurar a chave válida via `Settings > Model Providers`.
+1. Navegar para `Settings` via menu do usuário.
+2. Clicar no ícone `icon-Brain` para acessar Model Providers.
+3. Clicar no provider Google Generative AI.
+4. Selecionar todo o conteúdo do campo de API key e inserir uma chave inválida (ex: `AIza-invalid-google-key-for-testing`).
+5. Clicar em `Save Configuration` ou `Replace Configuration`.
+6. Verificar que `.error-build-message` exibe texto correspondendo a `/Invalid API key/i`.
+7. (Cleanup) Selecionar o campo, inserir a chave válida do `.env` e clicar em `Replace Configuration`.
 
-**Validação:** O Langflow exibe mensagem de erro de autenticação no canvas quando a chave Google é inválida.
+**Validação:** O Langflow exibe `.error-build-message` com `/Invalid API key/i` imediatamente após salvar uma chave inválida na página de configuração do provider.
 
 ---
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/provider-invalid-auth-error.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/provider-invalid-auth-error.spec.ts
@@ -1,0 +1,177 @@
+import * as dotenv from "dotenv";
+import path from "path";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { SimpleAgentTemplatePage } from "../../../../pages";
+import { SettingsPage } from "../../../../pages/SettingsPage";
+import {
+  hasProviderEnvKeys,
+  providerEnvKeyMap,
+  type Provider,
+} from "../../../../helpers/provider-setup";
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
+}
+
+// ─── Auth config per provider ─────────────────────────────────────────────────
+// When adding a new provider to helpers/provider-setup/index.ts, add its entry
+// here so the invalid-auth test covers it automatically.
+
+type ProviderAuthConfig = {
+  providerTestId: string;
+  keyPlaceholder: string;
+  invalidKey: string;
+  errorPattern: RegExp;
+};
+
+const providerAuthConfigMap: Record<Provider, ProviderAuthConfig> = {
+  openai: {
+    providerTestId: "provider-item-OpenAI",
+    keyPlaceholder: "sk-...",
+    invalidKey: "sk-invalid-openai-key-for-testing-12345",
+    errorPattern: /Invalid API key/i,
+  },
+  anthropic: {
+    providerTestId: "provider-item-Anthropic",
+    keyPlaceholder: "sk-ant-...",
+    invalidKey: "sk-ant-invalid-for-testing-12345",
+    errorPattern: /Invalid API key|authentication_error|invalid.*key/i,
+  },
+  google: {
+    providerTestId: "provider-item-Google Generative AI",
+    keyPlaceholder: "AIza...",
+    invalidKey: "AIza-invalid-google-key-for-testing-12345",
+    errorPattern: /Invalid API key|API key not valid|invalid.*key/i,
+  },
+};
+
+// ─── Target builder ───────────────────────────────────────────────────────────
+
+type ProviderTarget = ProviderAuthConfig & {
+  provider: Provider;
+  primaryEnvVar: string;
+};
+
+function getProviderTargets(): ProviderTarget[] {
+  return (Object.keys(providerAuthConfigMap) as Provider[])
+    .filter(hasProviderEnvKeys)
+    .map((provider) => ({
+      provider,
+      primaryEnvVar: providerEnvKeyMap[provider][0],
+      ...providerAuthConfigMap[provider],
+    }));
+}
+
+// ─── Helper: configure API key via Settings > Model Providers ─────────────────
+// Follows the same setup pattern as collect-models.ts:
+//   - SettingsPage.navigate() + sidebar-nav-Model Providers
+//   - click input + pressSequentially (simulates real keypresses)
+//   - handles "Save Configuration" (new key) and "Replace Configuration" (existing key)
+//   - waits for "Replace Configuration" to confirm the key was persisted
+
+async function configureProviderApiKey(
+  page: any,
+  providerTestId: string,
+  keyPlaceholder: string,
+  apiKey: string,
+): Promise<void> {
+  const settingsPage = new SettingsPage(page);
+  await settingsPage.navigate();
+  await page.getByTestId("sidebar-nav-Model Providers").click();
+
+  await page.getByTestId(providerTestId).click();
+
+  const apiKeyInput = page.getByPlaceholder(keyPlaceholder);
+  if ((await apiKeyInput.count()) > 0) {
+    await apiKeyInput.click();
+    await apiKeyInput.pressSequentially(apiKey, { delay: 0 });
+
+    const saveConfigBtn = page.getByRole("button", { name: "Save Configuration" });
+    const replaceConfigBtn = page.getByRole("button", { name: "Replace Configuration" });
+
+    if ((await saveConfigBtn.count()) > 0) {
+      await saveConfigBtn.click();
+    } else if ((await replaceConfigBtn.count()) > 0) {
+      await replaceConfigBtn.click();
+    }
+
+    await replaceConfigBtn.waitFor({ state: "visible" });
+  }
+
+  await page.getByTestId("sidebar-nav-Model Providers").click();
+
+  await page.goto("/");
+  await page.waitForSelector('[data-testid="mainpage_title"]', {
+    timeout: 15000,
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+const targets = getProviderTargets();
+
+for (const {
+  provider,
+  primaryEnvVar,
+  providerTestId,
+  keyPlaceholder,
+  invalidKey,
+  errorPattern,
+} of targets) {
+  test.describe.serial(`Invalid Auth Error — ${provider}`, () => {
+    test(
+      `deve exibir mensagem de erro ao usar autenticação inválida do provider ${provider}`,
+      { tag: ["@regression", "@model-provider", "@agents"] },
+      async ({ page }) => {
+        (page as any).allowFlowErrors();
+
+        await test.step(`Configurar autenticação inválida para ${provider}`, async () => {
+          await configureProviderApiKey(
+            page,
+            providerTestId,
+            keyPlaceholder,
+            invalidKey,
+          );
+        });
+
+        try {
+          await test.step("Carregar Simple Agent template com o provider configurado", async () => {
+            try {
+              await new SimpleAgentTemplatePage(page).load({ provider });
+            } catch (e: any) {
+              if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) {
+                test.skip(true, e.message);
+              }
+              throw e;
+            }
+          });
+
+          await test.step("Abrir playground e enviar mensagem para acionar o erro", async () => {
+            await page.getByTestId("playground-btn-flow-io").click();
+            await page.waitForSelector('[data-testid="input-chat-playground"]', {
+              timeout: 15000,
+            });
+            await page.getByTestId("input-chat-playground").last().fill("Olá");
+            await page.getByTestId("button-send").last().click();
+          });
+
+          await test.step("Validar que o erro de autenticação inválida é exibido", async () => {
+            const errorBox = page.locator(".error-build-message");
+            await expect(
+              errorBox.getByText(errorPattern),
+            ).toBeVisible({ timeout: 30000 });
+          });
+        } finally {
+          await test.step(`Restaurar autenticação válida do provider ${provider}`, async () => {
+            await configureProviderApiKey(
+              page,
+              providerTestId,
+              keyPlaceholder,
+              process.env[primaryEnvVar] ?? "",
+            );
+          });
+        }
+      },
+    );
+  });
+}

--- a/tests/tests-automations/regression/core-functionality/llm-agents/provider-invalid-auth-error.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/provider-invalid-auth-error.spec.ts
@@ -1,7 +1,6 @@
 import * as dotenv from "dotenv";
 import path from "path";
 import { expect, test } from "../../../../fixtures/fixtures";
-import { SimpleAgentTemplatePage } from "../../../../pages";
 import { SettingsPage } from "../../../../pages/SettingsPage";
 import {
   hasProviderEnvKeys,
@@ -58,31 +57,18 @@ function getProviderTargets(): ProviderTarget[] {
     }));
 }
 
-// ─── Helper: configure API key via Settings > Model Providers ─────────────────
-// Follows the same pattern as collect-models.ts / collectModelsForProvider:
-//   1. page.goto("/") → navigate to home
-//   2. SettingsPage.navigate() → open settings via user menu
-//   3. icon-Brain → navigate to Model Providers
-//   4. click provider item
-//   5. click input + pressSequentially (simulates real keypresses)
-//   6. Save Configuration (new key) or Replace Configuration (existing key)
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 
-async function configureProviderApiKey(
+// Fills the API key input on the current provider page and clicks Save/Replace.
+// Use when already on the provider configuration screen.
+async function fillProviderApiKey(
   page: any,
-  providerTestId: string,
   apiKeyPlaceholder: string,
   apiKey: string,
 ): Promise<void> {
-  const settingsPage = new SettingsPage(page);
-  await settingsPage.navigate();
-
-  await page.getByTestId("icon-Brain").click();
-
-  await page.getByTestId(providerTestId).click();
-
   const apiKeyInput = page.getByPlaceholder(apiKeyPlaceholder);
   if ((await apiKeyInput.count()) > 0) {
-    await apiKeyInput.click();
+    await apiKeyInput.click({ clickCount: 3 });
     await apiKeyInput.pressSequentially(apiKey, { delay: 0 });
 
     const saveConfigBtn = page.getByRole("button", { name: "Save Configuration" });
@@ -94,6 +80,23 @@ async function configureProviderApiKey(
       await replaceConfigBtn.click();
     }
   }
+}
+
+// Navigates to Settings > Model Providers > provider and fills the API key.
+// Use when not yet on the provider configuration screen.
+async function navigateAndFillProviderApiKey(
+  page: any,
+  providerTestId: string,
+  apiKeyPlaceholder: string,
+  apiKey: string,
+): Promise<void> {
+  const settingsPage = new SettingsPage(page);
+  await settingsPage.navigate();
+
+  await page.getByTestId("icon-Brain").click();
+  await page.getByTestId(providerTestId).click();
+
+  await fillProviderApiKey(page, apiKeyPlaceholder, apiKey);
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -114,10 +117,11 @@ for (const {
       async ({ page }) => {
         (page as any).allowFlowErrors();
 
+        await page.goto("/");
+        await page.waitForSelector('[data-testid="mainpage_title"]', { timeout: 30000 });
+
         await test.step(`Configurar autenticação inválida para ${provider}`, async () => {
-          await page.goto("/");
-          await page.waitForSelector('[data-testid="mainpage_title"]', { timeout: 30000 });
-          await configureProviderApiKey(
+          await navigateAndFillProviderApiKey(
             page,
             providerTestId,
             keyPlaceholder,
@@ -126,26 +130,6 @@ for (const {
         });
 
         try {
-          await test.step("Carregar Simple Agent template com o provider configurado", async () => {
-            try {
-              await new SimpleAgentTemplatePage(page).load({ provider });
-            } catch (e: any) {
-              if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) {
-                test.skip(true, e.message);
-              }
-              throw e;
-            }
-          });
-
-          await test.step("Abrir playground e enviar mensagem para acionar o erro", async () => {
-            await page.getByTestId("playground-btn-flow-io").click();
-            await page.waitForSelector('[data-testid="input-chat-playground"]', {
-              timeout: 15000,
-            });
-            await page.getByTestId("input-chat-playground").last().fill("Olá");
-            await page.getByTestId("button-send").last().click();
-          });
-
           await test.step("Validar que o erro de autenticação inválida é exibido", async () => {
             const errorBox = page.locator(".error-build-message");
             await expect(
@@ -154,9 +138,8 @@ for (const {
           });
         } finally {
           await test.step(`Restaurar autenticação válida do provider ${provider}`, async () => {
-            await configureProviderApiKey(
+            await fillProviderApiKey(
               page,
-              providerTestId,
               keyPlaceholder,
               process.env[primaryEnvVar] ?? "",
             );

--- a/tests/tests-automations/regression/core-functionality/llm-agents/provider-invalid-auth-error.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/provider-invalid-auth-error.spec.ts
@@ -21,7 +21,6 @@ type ProviderAuthConfig = {
   providerTestId: string;
   keyPlaceholder: string;
   invalidKey: string;
-  errorPattern: RegExp;
 };
 
 const providerAuthConfigMap: Record<Provider, ProviderAuthConfig> = {
@@ -29,19 +28,16 @@ const providerAuthConfigMap: Record<Provider, ProviderAuthConfig> = {
     providerTestId: "provider-item-OpenAI",
     keyPlaceholder: "sk-...",
     invalidKey: "sk-invalid-openai-key-for-testing-12345",
-    errorPattern: /Invalid API key/i,
   },
   anthropic: {
     providerTestId: "provider-item-Anthropic",
     keyPlaceholder: "sk-ant-...",
     invalidKey: "sk-ant-invalid-for-testing-12345",
-    errorPattern: /Invalid API key|authentication_error|invalid.*key/i,
   },
   google: {
     providerTestId: "provider-item-Google Generative AI",
     keyPlaceholder: "AIza...",
     invalidKey: "AIza-invalid-google-key-for-testing-12345",
-    errorPattern: /Invalid API key|API key not valid|invalid.*key/i,
   },
 };
 
@@ -63,16 +59,18 @@ function getProviderTargets(): ProviderTarget[] {
 }
 
 // ─── Helper: configure API key via Settings > Model Providers ─────────────────
-// Follows the same setup pattern as collect-models.ts:
-//   - SettingsPage.navigate() + sidebar-nav-Model Providers
-//   - click input + pressSequentially (simulates real keypresses)
-//   - handles "Save Configuration" (new key) and "Replace Configuration" (existing key)
-//   - waits for "Replace Configuration" to confirm the key was persisted
+// Follows the same pattern as collect-models.ts / collectModelsForProvider:
+//   1. page.goto("/") → navigate to home
+//   2. SettingsPage.navigate() → open settings via user menu
+//   3. icon-Brain → navigate to Model Providers
+//   4. click provider item
+//   5. click input + pressSequentially (simulates real keypresses)
+//   6. Save Configuration (new key) or Replace Configuration (existing key)
 
 async function configureProviderApiKey(
   page: any,
   providerTestId: string,
-  keyPlaceholder: string,
+  apiKeyPlaceholder: string,
   apiKey: string,
 ): Promise<void> {
   await page.goto("/");
@@ -80,11 +78,12 @@ async function configureProviderApiKey(
 
   const settingsPage = new SettingsPage(page);
   await settingsPage.navigate();
-  await page.getByTestId("sidebar-nav-Model Providers").click();
+
+  await page.getByTestId("icon-Brain").click();
 
   await page.getByTestId(providerTestId).click();
 
-  const apiKeyInput = page.getByPlaceholder(keyPlaceholder);
+  const apiKeyInput = page.getByPlaceholder(apiKeyPlaceholder);
   if ((await apiKeyInput.count()) > 0) {
     await apiKeyInput.click();
     await apiKeyInput.pressSequentially(apiKey, { delay: 0 });
@@ -97,16 +96,7 @@ async function configureProviderApiKey(
     } else if ((await replaceConfigBtn.count()) > 0) {
       await replaceConfigBtn.click();
     }
-
-    await replaceConfigBtn.waitFor({ state: "visible" });
   }
-
-  await page.getByTestId("sidebar-nav-Model Providers").click();
-
-  await page.goto("/");
-  await page.waitForSelector('[data-testid="mainpage_title"]', {
-    timeout: 15000,
-  });
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -119,7 +109,6 @@ for (const {
   providerTestId,
   keyPlaceholder,
   invalidKey,
-  errorPattern,
 } of targets) {
   test.describe.serial(`Invalid Auth Error — ${provider}`, () => {
     test(
@@ -161,7 +150,7 @@ for (const {
           await test.step("Validar que o erro de autenticação inválida é exibido", async () => {
             const errorBox = page.locator(".error-build-message");
             await expect(
-              errorBox.getByText(errorPattern),
+              errorBox.getByText(/Invalid API key/i),
             ).toBeVisible({ timeout: 30000 });
           });
         } finally {

--- a/tests/tests-automations/regression/core-functionality/llm-agents/provider-invalid-auth-error.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/provider-invalid-auth-error.spec.ts
@@ -75,6 +75,9 @@ async function configureProviderApiKey(
   keyPlaceholder: string,
   apiKey: string,
 ): Promise<void> {
+  await page.goto("/");
+  await page.waitForSelector('[data-testid="mainpage_title"]', { timeout: 30000 });
+
   const settingsPage = new SettingsPage(page);
   await settingsPage.navigate();
   await page.getByTestId("sidebar-nav-Model Providers").click();

--- a/tests/tests-automations/regression/core-functionality/llm-agents/provider-invalid-auth-error.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/provider-invalid-auth-error.spec.ts
@@ -134,7 +134,7 @@ for (const {
             const errorBox = page.locator(".error-build-message");
             await expect(
               errorBox.getByText(/Invalid API key/i),
-            ).toBeVisible({ timeout: 30000 });
+            ).toBeVisible({ timeout: 2000 });
           });
         } finally {
           await test.step(`Restaurar autenticação válida do provider ${provider}`, async () => {

--- a/tests/tests-automations/regression/core-functionality/llm-agents/provider-invalid-auth-error.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/provider-invalid-auth-error.spec.ts
@@ -73,9 +73,6 @@ async function configureProviderApiKey(
   apiKeyPlaceholder: string,
   apiKey: string,
 ): Promise<void> {
-  await page.goto("/");
-  await page.waitForSelector('[data-testid="mainpage_title"]', { timeout: 30000 });
-
   const settingsPage = new SettingsPage(page);
   await settingsPage.navigate();
 
@@ -118,6 +115,8 @@ for (const {
         (page as any).allowFlowErrors();
 
         await test.step(`Configurar autenticação inválida para ${provider}`, async () => {
+          await page.goto("/");
+          await page.waitForSelector('[data-testid="mainpage_title"]', { timeout: 30000 });
           await configureProviderApiKey(
             page,
             providerTestId,


### PR DESCRIPTION
## Tipo

<!-- Marque com [x] o tipo desta PR -->

- [ ] `feat` — novo teste ou novo helper/page object
- [x] `fix` — correção de teste quebrado ou flaky
- [ ] `chore` — CI, checklist, dependências, refatoração interna
- [ ] `docs` — atualização de documentação

---

## O que esta PR faz

Ajusta o teste tests\tests-automations\regression\core-functionality\llm-agents\provider-invalid-auth-error.spec.ts para reconfigurar a chave certa de API depois do teste de exibição da mensagem de erro
