### PR TITLE
chore: corrigir loop infinito em cleanAllFlows

### DIFF
--- a/tests/helpers/flows/clean-all-flows.ts
+++ b/tests/helpers/flows/clean-all-flows.ts
@@ -1,20 +1,22 @@
 import { Page } from "@playwright/test";
 
 export const cleanAllFlows = async (page: Page) => {
-  // Wait for the home page to be ready before starting the deletion loop.
-  // Prevents the loop from running against an incomplete page load.
-  await page.waitForSelector(
-    '[data-testid="empty_page_description"], [data-testid="home-dropdown-menu"]',
-    { timeout: 20000 },
-  );
   const emptyPageDescription = page.getByTestId("empty_page_description");
-  while ((await emptyPageDescription.count()) === 0) {
+  while (true) {
+    await page.waitForSelector(
+      '[data-testid="empty_page_description"], [data-testid="home-dropdown-menu"]',
+      { timeout: 20000 },
+    );
+    if ((await emptyPageDescription.count()) > 0) break;
     await page.getByTestId("home-dropdown-menu").first().click();
+    await page.waitForSelector('[data-testid="btn_delete_dropdown_menu"]', {
+      state: "visible",
+      timeout: 5000,
+    });
     await page.getByTestId("btn_delete_dropdown_menu").first().click();
     await page
       .getByTestId("btn_delete_delete_confirmation_modal")
       .first()
       .click();
-    await page.waitForTimeout(1000);
   }
 };


### PR DESCRIPTION
## Problema

`cleanAllFlows` podia travar indefinidamente em dois cenários:

1. Após cada deleção, o DOM fica brevemente sem `empty_page_description` e sem `home-dropdown-menu` (estado de transição). O código original só tinha `waitForSelector` **antes** do loop — dentro do loop, dependia de `waitForTimeout(1000)` fixo. Em ambientes mais lentos ou com reordenação de lista, o `.click()` no próximo `home-dropdown-menu` encontrava o elemento ainda instável, travando até o timeout padrão de 30s.

2. Após abrir o dropdown de um flow, o `btn_delete_dropdown_menu` aparecia no DOM mas com animação em andamento. Sem `waitForSelector` explícito, o Playwright clicava no elemento enquanto ele ainda estava sendo renderizado.

Reportado pelo @guimaraesaugusto no PR #37.

## Correção

- `waitForSelector` movido para **dentro do loop** — garante estado conhecido (vazio ou com flows) no início de cada iteração
- `waitForSelector` adicionado após abrir o dropdown — aguarda `btn_delete_dropdown_menu` estar visível antes de clicar
- `waitForTimeout(1000)` removido — substituído por espera determinística

## Specs afetados

| Spec | Resultado |
|---|---|
| `playground/playground-fullscreen.spec.ts` | 2/2 passando |
| `project-management/user-progress-track.spec.ts` | quebrado independentemente (falha em `get_started_progress_percentage` linha 99 — pré-existente, fora do escopo desta PR) |

## Próximo passo

Após merge, PR #37 (`fix/playground-fullscreen-selectors`) deve fazer rebase neste main para incorporar a correção.