### PR TITLE
feat: migration test workflow (latest → nightly)

### DIFF
--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -1,0 +1,184 @@
+name: "Langflow Migration Test: Latest → Nightly"
+
+on:
+  workflow_dispatch:
+
+env:
+  LANGFLOW_PORT: 7860
+  LANGFLOW_URL: http://localhost:7860
+  PG_USER: langflow
+  PG_PASSWORD: langflow_test_pw
+  PG_DB: langflow
+  STATE_FILE: /tmp/migration-test-state.json
+  REPORT_FILE: /tmp/migration-report.md
+
+jobs:
+  migration-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: langflow
+          POSTGRES_PASSWORD: langflow_test_pw
+          POSTGRES_DB: langflow
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          pip install requests playwright pytest pytest-playwright
+          playwright install chromium --with-deps
+
+      # ── Phase 1: Langflow Latest ──────────────────────────────
+      - name: Pull Langflow latest
+        run: |
+          docker pull langflowai/langflow:latest
+          docker inspect langflowai/langflow:latest --format='{{index .RepoDigests 0}}' > /tmp/latest-digest.txt
+          echo "Latest digest: $(cat /tmp/latest-digest.txt)"
+
+      - name: Start Langflow latest
+        run: |
+          docker run -d --name langflow \
+            --network host \
+            -e LANGFLOW_DATABASE_URL="postgresql://$PG_USER:$PG_PASSWORD@localhost:5432/$PG_DB" \
+            -e LANGFLOW_AUTO_LOGIN=true \
+            -e LANGFLOW_SUPERUSER=langflow \
+            -e LANGFLOW_SUPERUSER_PASSWORD=langflow123 \
+            -e LANGFLOW_STORE=false \
+            langflowai/langflow:latest
+
+      - name: Wait for Langflow latest
+        run: python tests/github-workflows/migration/wait_for_langflow.py
+
+      - name: Create flow, configure and execute on latest
+        run: python tests/github-workflows/migration/setup_latest.py
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+      - name: Save latest container logs
+        if: always()
+        run: docker logs langflow > /tmp/langflow-latest.log 2>&1 || true
+
+      # ── Phase 2: Upgrade to Nightly ───────────────────────────
+      - name: Stop Langflow latest
+        run: docker stop langflow && docker rm langflow
+
+      - name: Pull Langflow nightly
+        run: |
+          docker pull langflowai/langflow-nightly:latest
+          docker inspect langflowai/langflow-nightly:latest --format='{{index .RepoDigests 0}}' > /tmp/nightly-digest.txt
+          echo "Nightly digest: $(cat /tmp/nightly-digest.txt)"
+
+      - name: Start Langflow nightly (same database)
+        run: |
+          docker run -d --name langflow \
+            --network host \
+            -e LANGFLOW_DATABASE_URL="postgresql://$PG_USER:$PG_PASSWORD@localhost:5432/$PG_DB" \
+            -e LANGFLOW_AUTO_LOGIN=true \
+            -e LANGFLOW_SUPERUSER=langflow \
+            -e LANGFLOW_SUPERUSER_PASSWORD=langflow123 \
+            -e LANGFLOW_STORE=false \
+            langflowai/langflow-nightly:latest
+
+      - name: Wait for Langflow nightly (includes migration)
+        id: nightly_start
+        run: python tests/github-workflows/migration/wait_for_langflow.py --timeout 180
+
+      - name: Save nightly container logs
+        if: always()
+        run: docker logs langflow > /tmp/langflow-nightly.log 2>&1 || true
+
+      # ── Phase 3: Verify Migration ─────────────────────────────
+      - name: Verify migration via API
+        run: python tests/github-workflows/migration/verify_migration_api.py
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+      - name: Verify migration via UI (Playwright)
+        run: pytest tests/github-workflows/migration/test_ui_migration.py -v --tracing=retain-on-failure --output=test-results
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+      # ── Phase 4: Report ───────────────────────────────────────
+      - name: Generate report
+        if: always()
+        run: python tests/github-workflows/migration/generate_report.py
+
+      - name: Print report
+        if: always()
+        run: cat /tmp/migration-report.md
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: migration-test-${{ github.run_number }}
+          path: |
+            test-results/
+            /tmp/migration-report.md
+            /tmp/langflow-latest.log
+            /tmp/langflow-nightly.log
+            /tmp/migration-test-state.json
+            /tmp/latest-digest.txt
+            /tmp/nightly-digest.txt
+
+      - name: Create or update issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let report = 'Migration test failed. See workflow artifacts for details.';
+            try {
+              report = fs.readFileSync('/tmp/migration-report.md', 'utf8');
+            } catch (e) {
+              console.log('Report not available:', e.message);
+            }
+
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'migration-test',
+              state: 'open',
+            });
+
+            const body = [
+              `## Run #${context.runNumber} — ${new Date().toISOString().split('T')[0]}`,
+              '',
+              report,
+              '',
+              `[Workflow Run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+            ].join('\n');
+
+            if (existing.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing[0].number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `Langflow Migration Test Failed (latest → nightly)`,
+                body,
+                labels: ['migration-test', 'automated'],
+              });
+            }

--- a/tests/github-workflows/migration/README.md
+++ b/tests/github-workflows/migration/README.md
@@ -1,0 +1,71 @@
+# Migration Test
+
+Testes Python que verificam se o banco de dados do Langflow migra corretamente de `latest` para `nightly`. Executados pelo workflow `.github/workflows/migration-test.yml`, acionado manualmente via `workflow_dispatch`.
+
+## O que o workflow faz
+
+O workflow sobe dois containers Docker sequencialmente contra o mesmo banco PostgreSQL, simulando um upgrade real em produção.
+
+### Fase 1 — Langflow Latest
+
+1. Sobe `langflowai/langflow:latest` com um banco PostgreSQL vazio.
+2. Autentica na API e localiza o template de agente nos starter projects.
+3. Cria um flow a partir desse template.
+4. Cria a variável de ambiente `OPENAI_API_KEY` no Langflow.
+5. Executa o flow via API e salva o estado (flow ID, resultados) em `/tmp/migration-test-state.json`.
+
+### Fase 2 — Upgrade para Nightly
+
+6. Para o container `latest` (o banco PostgreSQL permanece intacto).
+7. Sobe `langflowai/langflow-nightly:latest` apontando para o mesmo banco — as migrações Alembic rodam automaticamente na inicialização.
+8. Aguarda o Langflow ficar disponível (timeout de 180s para dar tempo às migrações).
+
+### Fase 3 — Verificação
+
+Dois scripts verificam que a migração não quebrou nada:
+
+**`verify_migration_api.py`** — verificações via API REST:
+- O flow criado na Fase 1 ainda existe pelo mesmo ID.
+- Todos os flows aparecem na listagem.
+- A variável `OPENAI_API_KEY` foi preservada.
+- O flow executa com sucesso no nightly.
+
+**`test_ui_migration.py`** — verificações via Playwright (Chromium):
+- O flow abre no editor sem erros de componente.
+- O banner "Updates are available" é detectado e reportado.
+- Os componentes são atualizados via "Review All → Select All → Update Components".
+- O flow executa no Playground da UI.
+- O flow executa via API após a atualização dos componentes.
+
+### Fase 4 — Relatório
+
+`generate_report.py` consolida o estado coletado em `/tmp/migration-report.md` com status por fase e step (`PASS` / `FAIL` / `WARN` / `SKIP`).
+
+Em caso de falha, o workflow abre ou atualiza uma issue no repositório com label `migration-test`, incluindo o relatório completo e link para a run.
+
+## Artefatos gerados
+
+| Arquivo | Conteúdo |
+|---|---|
+| `test-results/` | Traces e screenshots do Playwright |
+| `/tmp/migration-report.md` | Relatório consolidado em Markdown |
+| `/tmp/langflow-latest.log` | Logs do container latest |
+| `/tmp/langflow-nightly.log` | Logs do container nightly |
+| `/tmp/migration-test-state.json` | Estado bruto coletado entre as fases |
+| `/tmp/latest-digest.txt` | Digest da imagem latest usada |
+| `/tmp/nightly-digest.txt` | Digest da imagem nightly usada |
+
+## Como executar manualmente
+
+No GitHub: **Actions → Langflow Migration Test: Latest → Nightly → Run workflow**.
+
+Requer o secret `OPENAI_API_KEY` configurado no repositório (usado para criar a variável no Langflow e executar o flow de agente).
+
+## Dependências Python
+
+```
+requests
+playwright
+pytest
+pytest-playwright
+```

--- a/tests/github-workflows/migration/conftest.py
+++ b/tests/github-workflows/migration/conftest.py
@@ -1,0 +1,25 @@
+"""Playwright fixtures for Langflow UI migration tests."""
+
+import json
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def langflow_url():
+    return os.environ.get("LANGFLOW_URL", "http://localhost:7860")
+
+
+@pytest.fixture(scope="session")
+def state():
+    state_file = os.environ.get("STATE_FILE", "/tmp/migration-test-state.json")
+    with open(state_file) as f:
+        return json.load(f)
+
+
+@pytest.fixture(scope="session")
+def flow_id(state):
+    fid = state.get("flow_id")
+    assert fid, "No flow_id in state file — setup_latest.py must run first"
+    return fid

--- a/tests/github-workflows/migration/generate_report.py
+++ b/tests/github-workflows/migration/generate_report.py
@@ -1,0 +1,124 @@
+"""Generate a markdown migration test report from the collected state."""
+
+import json
+import os
+from datetime import datetime, timezone
+
+STATE_FILE = os.environ.get("STATE_FILE", "/tmp/migration-test-state.json")
+REPORT_FILE = os.environ.get("REPORT_FILE", "/tmp/migration-report.md")
+
+STATUS_ICON = {
+    "pass": "PASS",
+    "fail": "FAIL",
+    "warn": "WARN",
+    "skip": "SKIP",
+}
+
+
+def load_state() -> dict:
+    try:
+        with open(STATE_FILE) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {"phases": {}}
+
+
+def load_digest(path: str) -> str:
+    try:
+        with open(path) as f:
+            return f.read().strip()
+    except FileNotFoundError:
+        return "unknown"
+
+
+def format_step(name: str, step: dict) -> str:
+    icon = STATUS_ICON.get(step.get("status", ""), "?")
+    line = f"| {icon} | {name} |"
+    detail = step.get("detail", "")
+    if not detail:
+        # Build detail from other fields
+        extras = {k: v for k, v in step.items() if k != "status"}
+        if extras:
+            detail = ", ".join(f"{k}={v}" for k, v in extras.items() if v is not None)
+    line += f" {detail[:120]} |"
+    return line
+
+
+def generate_report(state: dict) -> str:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    latest_digest = load_digest("/tmp/latest-digest.txt")
+    nightly_digest = load_digest("/tmp/nightly-digest.txt")
+
+    lines = [
+        f"# Langflow Migration Test Report",
+        f"**Date:** {now}",
+        f"**Flow:** {state.get('flow_name', 'N/A')} (`{state.get('flow_id', 'N/A')}`)",
+        f"**Latest digest:** `{latest_digest[-20:]}`",
+        f"**Nightly digest:** `{nightly_digest[-20:]}`",
+        "",
+    ]
+
+    # Overall result
+    all_statuses = []
+    for phase_data in state.get("phases", {}).values():
+        for step in phase_data.get("steps", {}).values():
+            all_statuses.append(step.get("status", ""))
+
+    has_fail = "fail" in all_statuses
+    has_warn = "warn" in all_statuses
+    if has_fail:
+        lines.append("## Result: FAILED")
+    elif has_warn:
+        lines.append("## Result: PASSED (with warnings)")
+    else:
+        lines.append("## Result: PASSED")
+    lines.append("")
+
+    # Phase details — only show failures and warnings in detail
+    for phase_name, phase_data in state.get("phases", {}).items():
+        duration = phase_data.get("duration_s", "?")
+        lines.append(f"### Phase: {phase_name} ({duration}s)")
+        lines.append("")
+        lines.append("| Status | Step | Detail |")
+        lines.append("|--------|------|--------|")
+
+        for step_name, step_data in phase_data.get("steps", {}).items():
+            lines.append(format_step(step_name, step_data))
+
+        lines.append("")
+
+    # Failures summary
+    failures = []
+    warnings = []
+    for phase_name, phase_data in state.get("phases", {}).items():
+        for step_name, step_data in phase_data.get("steps", {}).items():
+            if step_data.get("status") == "fail":
+                failures.append(f"- **{phase_name}/{step_name}**: {step_data.get('detail', 'no detail')[:200]}")
+            elif step_data.get("status") == "warn":
+                warnings.append(f"- **{phase_name}/{step_name}**: {step_data.get('detail', 'no detail')[:200]}")
+
+    if failures:
+        lines.append("## Failures")
+        lines.extend(failures)
+        lines.append("")
+
+    if warnings:
+        lines.append("## Warnings")
+        lines.extend(warnings)
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def main():
+    state = load_state()
+    report = generate_report(state)
+
+    with open(REPORT_FILE, "w") as f:
+        f.write(report)
+
+    print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/github-workflows/migration/helpers.py
+++ b/tests/github-workflows/migration/helpers.py
@@ -1,0 +1,163 @@
+"""Shared helpers for migration test scripts."""
+
+import json
+import os
+import time
+
+import requests
+
+BASE_URL = os.environ.get("LANGFLOW_URL", "http://localhost:7860")
+STATE_FILE = os.environ.get("STATE_FILE", "/tmp/migration-test-state.json")
+
+
+def get_auth_token() -> str:
+    """Get auth token via auto_login."""
+    r = requests.post(f"{BASE_URL}/api/v1/auto_login", timeout=10)
+    r.raise_for_status()
+    data = r.json()
+    return data.get("access_token", "")
+
+
+def api_headers(token: str) -> dict:
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def load_state() -> dict:
+    try:
+        with open(STATE_FILE) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {"phases": {}}
+
+
+def save_state(state: dict) -> None:
+    with open(STATE_FILE, "w") as f:
+        json.dump(state, f, indent=2)
+
+
+def get_starter_projects(token: str) -> list:
+    """Fetch starter project templates."""
+    r = requests.get(
+        f"{BASE_URL}/api/v1/starter-projects/",
+        headers=api_headers(token),
+        timeout=30,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def find_agent_template(starter_projects: list) -> dict | None:
+    """Find 'Simple Agent' or similar agent template."""
+    for project in starter_projects:
+        name = project.get("name", "").lower()
+        if "simple agent" in name or "basic agent" in name:
+            return project
+    # Fallback: any template with "agent" in the name
+    for project in starter_projects:
+        name = project.get("name", "").lower()
+        if "agent" in name:
+            return project
+    return None
+
+
+def create_flow(token: str, template: dict) -> dict:
+    """Create a flow from a starter project template."""
+    flow_data = {
+        "name": template.get("name", "Migration Test Agent"),
+        "description": "Auto-created for migration testing",
+        "data": template.get("data"),
+        "endpoint_name": template.get("endpoint_name"),
+    }
+    r = requests.post(
+        f"{BASE_URL}/api/v1/flows/",
+        headers=api_headers(token),
+        json=flow_data,
+        timeout=30,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def create_variable(token: str, name: str, value: str, var_type: str = "Credential") -> dict:
+    """Create a global variable (credential)."""
+    r = requests.post(
+        f"{BASE_URL}/api/v1/variables/",
+        headers=api_headers(token),
+        json={"name": name, "value": value, "type": var_type, "default_fields": []},
+        timeout=15,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def list_variables(token: str) -> list:
+    """List all global variables."""
+    r = requests.get(
+        f"{BASE_URL}/api/v1/variables/",
+        headers=api_headers(token),
+        timeout=15,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def get_flow(token: str, flow_id: str) -> dict:
+    """Get a flow by ID."""
+    r = requests.get(
+        f"{BASE_URL}/api/v1/flows/{flow_id}",
+        headers=api_headers(token),
+        timeout=15,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def list_flows(token: str) -> list:
+    """List all flows."""
+    r = requests.get(
+        f"{BASE_URL}/api/v1/flows/",
+        headers=api_headers(token),
+        timeout=15,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def run_flow(token: str, flow_id: str, message: str = "Hello, what is 2+2?") -> dict:
+    """Run a flow via API and return the result."""
+    payload = {
+        "input_value": message,
+        "output_type": "chat",
+        "input_type": "chat",
+    }
+    r = requests.post(
+        f"{BASE_URL}/api/v1/run/{flow_id}",
+        headers=api_headers(token),
+        json=payload,
+        timeout=120,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def run_flow_safe(token: str, flow_id: str, message: str = "Hello, what is 2+2?") -> tuple[bool, str]:
+    """Run a flow and return (success, detail)."""
+    try:
+        result = run_flow(token, flow_id, message)
+        outputs = result.get("outputs", [])
+        if outputs:
+            first_output = outputs[0]
+            results_list = first_output.get("outputs", [])
+            if results_list:
+                inner = results_list[0]
+                msg = inner.get("results", {}).get("message", {})
+                text = msg.get("text", str(msg)) if isinstance(msg, dict) else str(msg)
+                return True, text[:200]
+        return True, f"Flow executed (raw keys: {list(result.keys())})"
+    except requests.HTTPError as e:
+        return False, f"HTTP {e.response.status_code}: {e.response.text[:300]}"
+    except Exception as e:
+        return False, str(e)[:300]

--- a/tests/github-workflows/migration/setup_latest.py
+++ b/tests/github-workflows/migration/setup_latest.py
@@ -1,0 +1,89 @@
+"""Phase 1: Setup flow on Langflow latest, configure credentials, and execute."""
+
+import os
+import sys
+import time
+
+from helpers import (
+    create_flow,
+    create_variable,
+    find_agent_template,
+    get_auth_token,
+    get_starter_projects,
+    run_flow_safe,
+    save_state,
+    load_state,
+)
+
+
+def main():
+    state = load_state()
+    phase = {"start_time": time.time(), "steps": {}}
+
+    # 1. Authenticate
+    print("── Authenticating...")
+    token = get_auth_token()
+    phase["steps"]["auth"] = {"status": "pass"}
+    print("   OK")
+
+    # 2. Get starter projects and find agent template
+    print("── Fetching starter projects...")
+    projects = get_starter_projects(token)
+    print(f"   Found {len(projects)} starter projects")
+
+    template = find_agent_template(projects)
+    if not template:
+        names = [p.get("name") for p in projects]
+        print(f"   ERROR: No agent template found. Available: {names}")
+        phase["steps"]["find_template"] = {"status": "fail", "detail": f"Available: {names}"}
+        state["phases"]["latest"] = phase
+        save_state(state)
+        sys.exit(1)
+
+    print(f"   Using template: {template['name']}")
+    phase["steps"]["find_template"] = {"status": "pass", "template_name": template["name"]}
+
+    # 3. Create flow from template
+    print("── Creating flow...")
+    flow = create_flow(token, template)
+    flow_id = flow["id"]
+    flow_name = flow.get("name", template["name"])
+    print(f"   Created flow: {flow_name} (id={flow_id})")
+    phase["steps"]["create_flow"] = {"status": "pass", "flow_id": flow_id, "flow_name": flow_name}
+
+    # 4. Create OPENAI_API_KEY variable
+    openai_key = os.environ.get("OPENAI_API_KEY", "")
+    if openai_key:
+        print("── Creating OPENAI_API_KEY variable...")
+        try:
+            var = create_variable(token, "OPENAI_API_KEY", openai_key)
+            phase["steps"]["create_variable"] = {"status": "pass", "variable_id": var.get("id")}
+            print("   OK")
+        except Exception as e:
+            print(f"   WARNING: Could not create variable: {e}")
+            phase["steps"]["create_variable"] = {"status": "warn", "detail": str(e)[:200]}
+    else:
+        print("── OPENAI_API_KEY not set, skipping variable creation")
+        phase["steps"]["create_variable"] = {"status": "skip", "detail": "No OPENAI_API_KEY env var"}
+
+    # 5. Execute the flow
+    print("── Executing flow on latest...")
+    success, detail = run_flow_safe(token, flow_id)
+    status = "pass" if success else "fail"
+    print(f"   {status.upper()}: {detail[:120]}")
+    phase["steps"]["execute_flow"] = {"status": status, "detail": detail}
+
+    # Save state
+    phase["end_time"] = time.time()
+    phase["duration_s"] = round(phase["end_time"] - phase["start_time"], 1)
+    state["flow_id"] = flow_id
+    state["flow_name"] = flow_name
+    state["phases"]["latest"] = phase
+    save_state(state)
+
+    if not success:
+        print("\nWARNING: Flow execution failed on latest, but continuing to test migration.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/github-workflows/migration/test_ui_migration.py
+++ b/tests/github-workflows/migration/test_ui_migration.py
@@ -1,0 +1,353 @@
+"""Phase 3b: Playwright UI tests for migration verification.
+
+Tests:
+1. Open the migrated flow in the UI
+2. Check for component error messages
+3. Check for "Updates are available" banner
+4. Update components via Review All → Select All → Update Components
+5. Execute the flow from the Playground UI
+"""
+
+import json
+import os
+import re
+import time
+
+import pytest
+from playwright.sync_api import Page, expect
+
+STATE_FILE = os.environ.get("STATE_FILE", "/tmp/migration-test-state.json")
+
+
+def save_ui_state(results: dict):
+    """Append UI test results to the shared state file."""
+    try:
+        with open(STATE_FILE) as f:
+            state = json.load(f)
+    except FileNotFoundError:
+        state = {"phases": {}}
+
+    state["phases"]["nightly_ui"] = results
+    with open(STATE_FILE, "w") as f:
+        json.dump(state, f, indent=2)
+
+
+class TestMigrationUI:
+    """UI tests for the migrated flow."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, page: Page, langflow_url: str, flow_id: str):
+        self.page = page
+        self.base_url = langflow_url
+        self.flow_id = flow_id
+        self.results = {"steps": {}, "start_time": time.time()}
+
+        # Increase default timeout for CI environments
+        page.set_default_timeout(30_000)
+
+    def _save_results(self):
+        self.results["end_time"] = time.time()
+        self.results["duration_s"] = round(
+            self.results["end_time"] - self.results["start_time"], 1
+        )
+        save_ui_state(self.results)
+
+    def test_01_open_flow(self):
+        """Navigate to the migrated flow in the editor."""
+        self.page.goto(f"{self.base_url}/flow/{self.flow_id}", wait_until="networkidle")
+        self.page.wait_for_timeout(3000)
+
+        # Verify the flow editor loaded (look for the canvas/reactflow area)
+        canvas = self.page.locator(".react-flow, [data-testid='rf__wrapper']")
+        expect(canvas.first).to_be_visible(timeout=15_000)
+
+        self.results["steps"]["open_flow"] = {"status": "pass"}
+        self._save_results()
+
+    def test_02_check_component_errors(self):
+        """Check if any component error messages appear after migration."""
+        self.page.goto(f"{self.base_url}/flow/{self.flow_id}", wait_until="networkidle")
+        self.page.wait_for_timeout(5000)
+
+        # Look for error indicators: red error toasts/banners
+        error_elements = self.page.locator(
+            "[class*='error' i], [class*='destructive' i], "
+            "[data-testid*='error' i]"
+        ).all()
+
+        error_texts = []
+        for el in error_elements:
+            if el.is_visible():
+                text = el.inner_text()
+                if text.strip() and "error" in text.lower():
+                    error_texts.append(text.strip()[:200])
+
+        # Also check for the specific error toast from the screenshot
+        error_toast = self.page.locator("text=/Error while updating/i")
+        if error_toast.count() > 0 and error_toast.first.is_visible():
+            error_texts.append(error_toast.first.inner_text()[:200])
+
+        # Check for import errors
+        import_error = self.page.locator("text=/ImportError|Cannot import/i")
+        if import_error.count() > 0 and import_error.first.is_visible():
+            error_texts.append(import_error.first.inner_text()[:200])
+
+        has_errors = len(error_texts) > 0
+        self.results["steps"]["component_errors"] = {
+            "status": "fail" if has_errors else "pass",
+            "errors_found": error_texts,
+        }
+        self._save_results()
+
+        if has_errors:
+            # Take a screenshot of errors before asserting
+            self.page.screenshot(path="test-results/component-errors.png")
+
+        # Don't fail the test here — we want to continue with update components
+        # The report will flag this as an issue
+
+    def test_03_check_update_banner(self):
+        """Check if 'Updates are available' banner appears."""
+        self.page.goto(f"{self.base_url}/flow/{self.flow_id}", wait_until="networkidle")
+        self.page.wait_for_timeout(5000)
+
+        # Look for the update banner
+        update_banner = self.page.locator("text=/Updates are available/i")
+        banner_visible = update_banner.count() > 0 and update_banner.first.is_visible()
+
+        # Also check individual component update badges
+        update_badges = self.page.locator("text=/Update available/i")
+        badge_count = 0
+        if update_badges.count() > 0:
+            for i in range(update_badges.count()):
+                if update_badges.nth(i).is_visible():
+                    badge_count += 1
+
+        self.results["steps"]["update_banner"] = {
+            "status": "pass",
+            "banner_visible": banner_visible,
+            "component_update_count": badge_count,
+        }
+        self._save_results()
+
+    def test_04_update_components(self):
+        """Update all components via Review All → Select All → Update Components."""
+        self.page.goto(f"{self.base_url}/flow/{self.flow_id}", wait_until="networkidle")
+        self.page.wait_for_timeout(5000)
+
+        # Check if "Review All" button exists
+        review_all_btn = self.page.locator("button:has-text('Review All'), button:has-text('Review all')")
+
+        if review_all_btn.count() == 0 or not review_all_btn.first.is_visible():
+            self.results["steps"]["update_components"] = {
+                "status": "skip",
+                "detail": "No 'Review All' button found — no updates needed",
+            }
+            self._save_results()
+            return
+
+        # Click "Review All"
+        review_all_btn.first.click()
+        self.page.wait_for_timeout(2000)
+
+        # Wait for the modal to appear
+        modal = self.page.locator(
+            "[role='dialog'], [class*='modal' i], "
+            "div:has-text('Update components')"
+        )
+        expect(modal.first).to_be_visible(timeout=10_000)
+
+        # Screenshot the update modal
+        self.page.screenshot(path="test-results/update-modal.png")
+
+        # Click the "Component" header checkbox to select all components
+        # The checkbox is in the table header row
+        header_checkbox = self.page.locator(
+            "th input[type='checkbox'], "
+            "thead input[type='checkbox'], "
+            "[role='dialog'] input[type='checkbox']:first-of-type, "
+            "label:has-text('Component') input[type='checkbox']"
+        )
+
+        if header_checkbox.count() > 0:
+            # Check if already checked
+            first_cb = header_checkbox.first
+            if not first_cb.is_checked():
+                first_cb.click()
+                self.page.wait_for_timeout(500)
+        else:
+            # Fallback: try to find and click individual checkboxes
+            checkboxes = self.page.locator("[role='dialog'] input[type='checkbox']")
+            for i in range(checkboxes.count()):
+                cb = checkboxes.nth(i)
+                if cb.is_visible() and not cb.is_checked():
+                    cb.click()
+                    self.page.wait_for_timeout(200)
+
+        # Click "Update Components" button
+        update_btn = self.page.locator(
+            "button:has-text('Update Components'), button:has-text('Update components')"
+        )
+        expect(update_btn.first).to_be_visible(timeout=5_000)
+        update_btn.first.click()
+
+        # Wait for update to complete (modal should close or show success)
+        self.page.wait_for_timeout(5000)
+
+        # Check if modal closed (success)
+        modal_still_open = modal.first.is_visible() if modal.count() > 0 else False
+
+        # Check for any error after update
+        post_update_error = self.page.locator("text=/Error|Failed/i")
+        has_error = False
+        error_text = ""
+        if post_update_error.count() > 0:
+            for i in range(post_update_error.count()):
+                el = post_update_error.nth(i)
+                if el.is_visible():
+                    t = el.inner_text()
+                    if "error" in t.lower() or "failed" in t.lower():
+                        has_error = True
+                        error_text = t[:200]
+                        break
+
+        self.results["steps"]["update_components"] = {
+            "status": "fail" if has_error else "pass",
+            "modal_closed": not modal_still_open,
+            "error_after_update": error_text if has_error else None,
+        }
+        self._save_results()
+
+        self.page.screenshot(path="test-results/after-update-components.png")
+
+    def test_05_execute_flow_ui(self):
+        """Execute the flow from the Playground UI."""
+        self.page.goto(f"{self.base_url}/flow/{self.flow_id}", wait_until="networkidle")
+        self.page.wait_for_timeout(3000)
+
+        # Click the "Playground" button to open the playground panel
+        playground_btn = self.page.locator(
+            "button:has-text('Playground'), [data-testid='playground-btn']"
+        )
+        if playground_btn.count() > 0 and playground_btn.first.is_visible():
+            playground_btn.first.click()
+            self.page.wait_for_timeout(2000)
+
+        # Find the chat input
+        chat_input = self.page.locator(
+            "textarea[placeholder*='Send'], "
+            "textarea[placeholder*='message'], "
+            "textarea[placeholder*='Type'], "
+            "input[placeholder*='Send'], "
+            "input[placeholder*='message']"
+        )
+
+        if chat_input.count() == 0 or not chat_input.first.is_visible():
+            self.results["steps"]["execute_flow_ui"] = {
+                "status": "skip",
+                "detail": "Could not find chat input in Playground",
+            }
+            self._save_results()
+            self.page.screenshot(path="test-results/playground-no-input.png")
+            return
+
+        # Type a message
+        chat_input.first.fill("Hello, what is 2+2?")
+        self.page.wait_for_timeout(500)
+
+        # Send the message (press Enter or click send button)
+        send_btn = self.page.locator(
+            "button[data-testid='send-button'], "
+            "button[aria-label*='send' i], "
+            "button:has(svg):near(textarea)"
+        )
+
+        if send_btn.count() > 0 and send_btn.first.is_visible():
+            send_btn.first.click()
+        else:
+            chat_input.first.press("Enter")
+
+        # Wait for response (look for a new message bubble or loading indicator)
+        self.page.wait_for_timeout(3000)
+
+        # Wait for loading to finish (up to 60s for LLM response)
+        loading = self.page.locator(
+            "[class*='loading' i], [class*='spinner' i], "
+            "[class*='animate-spin']"
+        )
+        try:
+            if loading.count() > 0 and loading.first.is_visible():
+                loading.first.wait_for(state="hidden", timeout=60_000)
+        except Exception:
+            pass
+
+        self.page.wait_for_timeout(2000)
+
+        # Check for error messages in playground
+        error_in_playground = self.page.locator(
+            ".playground-error, [class*='error' i]:near(textarea)"
+        )
+        has_error = False
+        error_text = ""
+
+        # Check for the response message
+        messages = self.page.locator(
+            "[class*='message' i], [data-testid*='message'], "
+            "[class*='chat-message'], [class*='markdown']"
+        )
+
+        self.page.screenshot(path="test-results/playground-result.png")
+
+        msg_count = messages.count()
+        got_response = msg_count > 1  # At least the user message + bot response
+
+        self.results["steps"]["execute_flow_ui"] = {
+            "status": "pass" if got_response else "warn",
+            "message_count": msg_count,
+            "got_response": got_response,
+        }
+        self._save_results()
+
+    def test_06_execute_flow_api_post_update(self):
+        """Execute the flow via API after component updates."""
+        import requests
+
+        token_resp = requests.post(f"{self.base_url}/api/v1/auto_login", timeout=10)
+        token_resp.raise_for_status()
+        token = token_resp.json().get("access_token", "")
+
+        headers = {"Content-Type": "application/json"}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+
+        payload = {
+            "input_value": "What is 3+5?",
+            "output_type": "chat",
+            "input_type": "chat",
+        }
+
+        try:
+            r = requests.post(
+                f"{self.base_url}/api/v1/run/{self.flow_id}",
+                headers=headers,
+                json=payload,
+                timeout=120,
+            )
+            r.raise_for_status()
+            result = r.json()
+
+            outputs = result.get("outputs", [])
+            success = len(outputs) > 0
+            detail = str(outputs[0].get("outputs", [{}])[0].get("results", {}))[:200] if success else "No outputs"
+
+            self.results["steps"]["execute_flow_api_post_update"] = {
+                "status": "pass" if success else "fail",
+                "detail": detail,
+            }
+        except Exception as e:
+            self.results["steps"]["execute_flow_api_post_update"] = {
+                "status": "fail",
+                "detail": str(e)[:300],
+            }
+
+        self._save_results()

--- a/tests/github-workflows/migration/verify_migration_api.py
+++ b/tests/github-workflows/migration/verify_migration_api.py
@@ -1,0 +1,103 @@
+"""Phase 3a: Verify migration preserved the flow, variables, and execution works via API."""
+
+import sys
+import time
+
+from helpers import (
+    get_auth_token,
+    get_flow,
+    list_flows,
+    list_variables,
+    load_state,
+    run_flow_safe,
+    save_state,
+)
+
+
+def main():
+    state = load_state()
+    flow_id = state.get("flow_id")
+    if not flow_id:
+        print("ERROR: No flow_id in state. Did setup_latest.py run?")
+        sys.exit(1)
+
+    phase = {"start_time": time.time(), "steps": {}}
+    has_failure = False
+
+    # 1. Authenticate on nightly
+    print("── Authenticating on nightly...")
+    token = get_auth_token()
+    phase["steps"]["auth"] = {"status": "pass"}
+    print("   OK")
+
+    # 2. Check flow still exists
+    print(f"── Checking flow {flow_id} exists after migration...")
+    try:
+        flow = get_flow(token, flow_id)
+        flow_name = flow.get("name", "unknown")
+        print(f"   OK: Flow '{flow_name}' exists")
+        phase["steps"]["flow_exists"] = {"status": "pass", "flow_name": flow_name}
+    except Exception as e:
+        print(f"   FAIL: {e}")
+        phase["steps"]["flow_exists"] = {"status": "fail", "detail": str(e)[:300]}
+        has_failure = True
+
+    # 3. Check all flows are listed
+    print("── Listing all flows...")
+    try:
+        flows = list_flows(token)
+        flow_names = [f.get("name") for f in flows]
+        print(f"   Found {len(flows)} flows: {flow_names}")
+        phase["steps"]["list_flows"] = {"status": "pass", "count": len(flows), "names": flow_names}
+    except Exception as e:
+        print(f"   FAIL: {e}")
+        phase["steps"]["list_flows"] = {"status": "fail", "detail": str(e)[:300]}
+        has_failure = True
+
+    # 4. Check variables preserved
+    print("── Checking variables...")
+    try:
+        variables = list_variables(token)
+        var_names = [v.get("name") for v in variables]
+        print(f"   Found {len(variables)} variables: {var_names}")
+        has_openai = "OPENAI_API_KEY" in var_names
+        if has_openai:
+            print("   OK: OPENAI_API_KEY preserved")
+        else:
+            print("   WARN: OPENAI_API_KEY not found in variables")
+        phase["steps"]["variables_preserved"] = {
+            "status": "pass" if has_openai else "warn",
+            "count": len(variables),
+            "names": var_names,
+            "openai_key_present": has_openai,
+        }
+    except Exception as e:
+        print(f"   FAIL: {e}")
+        phase["steps"]["variables_preserved"] = {"status": "fail", "detail": str(e)[:300]}
+        has_failure = True
+
+    # 5. Execute flow on nightly via API
+    print("── Executing flow on nightly via API...")
+    success, detail = run_flow_safe(token, flow_id)
+    status = "pass" if success else "fail"
+    print(f"   {status.upper()}: {detail[:120]}")
+    phase["steps"]["execute_flow_api"] = {"status": status, "detail": detail}
+    if not success:
+        has_failure = True
+
+    # Save state
+    phase["end_time"] = time.time()
+    phase["duration_s"] = round(phase["end_time"] - phase["start_time"], 1)
+    phase["overall"] = "fail" if has_failure else "pass"
+    state["phases"]["nightly_api"] = phase
+    save_state(state)
+
+    if has_failure:
+        print("\nSome API migration checks FAILED.")
+        sys.exit(1)
+    else:
+        print("\nAll API migration checks PASSED.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/github-workflows/migration/wait_for_langflow.py
+++ b/tests/github-workflows/migration/wait_for_langflow.py
@@ -1,0 +1,42 @@
+"""Wait for Langflow to be healthy."""
+
+import argparse
+import sys
+import time
+
+import requests
+
+BASE_URL = "http://localhost:7860"
+
+
+def wait_for_langflow(timeout: int = 120) -> bool:
+    start = time.time()
+    print(f"Waiting for Langflow at {BASE_URL} (timeout: {timeout}s)")
+
+    while time.time() - start < timeout:
+        try:
+            r = requests.get(f"{BASE_URL}/health", timeout=5)
+            if r.status_code == 200:
+                elapsed = time.time() - start
+                print(f"Langflow is healthy after {elapsed:.1f}s")
+                return True
+        except requests.ConnectionError:
+            pass
+        except Exception as e:
+            print(f"  Unexpected error: {e}")
+
+        remaining = timeout - (time.time() - start)
+        print(f"  Not ready yet... ({remaining:.0f}s remaining)")
+        time.sleep(5)
+
+    print("TIMEOUT: Langflow did not become healthy")
+    return False
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--timeout", type=int, default=120)
+    args = parser.parse_args()
+
+    if not wait_for_langflow(args.timeout):
+        sys.exit(1)


### PR DESCRIPTION
## Summary

- Traz os testes de migração do repositório `langflow-migration-test` para cá, organizados em `tests/github-workflows/migration/`
- Adiciona o workflow `.github/workflows/migration-test.yml` configurado para rodar **somente manualmente** via `workflow_dispatch`
- Inclui `README.md` documentando as 4 fases do workflow

## O que o workflow testa

1. **Latest** — cria um flow a partir do template de agente, configura `OPENAI_API_KEY` e executa via API
2. **Upgrade** — para o container e sobe `langflow-nightly` no mesmo banco PostgreSQL
3. **Verificação** — valida via API REST (flow existe, variáveis preservadas, execução ok) e via Playwright UI (erros de componente, update banner, update components, execução no playground)
4. **Relatório** — gera markdown com status por step; abre issue no repo em caso de falha

## Como disparar

GitHub → Actions → **Langflow Migration Test: Latest → Nightly** → Run workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)