### PR TITLE
chore: workflow semanal de testes @stable + documentação da tag

### DIFF
--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -1,0 +1,99 @@
+name: Weekly Release E2E
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # 03:00 BRT (UTC-3), toda segunda-feira
+  workflow_dispatch:
+    inputs:
+      langflow_image_tag:
+        description: "Langflow nightly image tag (e.g. latest, 1.5.1.dev36)"
+        required: false
+        default: "latest"
+
+jobs:
+  e2e-weekly-release:
+    name: Weekly Release E2E (langflow-nightly:${{ github.event.inputs.langflow_image_tag || 'latest' }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    services:
+      langflow:
+        image: langflowai/langflow-nightly:${{ github.event.inputs.langflow_image_tag || 'latest' }}
+        ports:
+          - 7860:7860
+        env:
+          LANGFLOW_AUTO_LOGIN: "true"
+          LANGFLOW_SUPERUSER: langflow
+          LANGFLOW_SUPERUSER_PASSWORD: langflow
+          LANGFLOW_DEACTIVATE_TRACING: "true"
+        options: >-
+          --health-cmd "curl -f http://localhost:7860/health_check || exit 1"
+          --health-interval 15s
+          --health-timeout 10s
+          --health-retries 10
+          --health-start-period 90s
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Run @release tests
+        run: npx playwright test --grep "@release" --reporter=github
+        env:
+          CI: "true"
+          PLAYWRIGHT_BASE_URL: "http://localhost:7860/"
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report-weekly-${{ github.run_id }}
+          path: playwright-report/
+          retention-days: 14
+
+      - name: Upload test results on failure
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: test-results-weekly-${{ github.run_id }}
+          path: test-results/
+          retention-days: 7
+
+      - name: Create issue on failure
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const today = new Date().toISOString().split('T')[0];
+            const tag = '${{ github.event.inputs.langflow_image_tag || "latest" }}';
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[Weekly Failure] @release tests failed on ${today} (langflow:${tag})`,
+              body: [
+                '## Weekly @release E2E Failure',
+                '',
+                `- **Date:** ${today}`,
+                `- **Langflow version:** \`langflowai/langflow-nightly:${tag}\``,
+                `- **Run:** [${context.runId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+                '',
+                '### Próximos passos',
+                '1. Abra o relatório Playwright no artefato da run acima',
+                '2. Determine se a falha é um bug no teste ou uma regressão no Langflow',
+                '3. Se o teste estiver incorreto ou desatualizado: remova a tag `@release` do teste e abra um PR de correção',
+                '4. Se for regressão no Langflow: sinalize para o time e acompanhe o upstream',
+                '',
+                '/cc @Victor-w-Madeira',
+              ].join('\n'),
+              labels: ['weekly-failure', 'needs-triage'],
+            });

--- a/.github/workflows/weekly-stable.yml
+++ b/.github/workflows/weekly-stable.yml
@@ -1,4 +1,4 @@
-name: Weekly Release E2E
+name: Weekly Stable E2E
 
 on:
   schedule:
@@ -11,8 +11,8 @@ on:
         default: "latest"
 
 jobs:
-  e2e-weekly-release:
-    name: Weekly Release E2E (langflow-nightly:${{ github.event.inputs.langflow_image_tag || 'latest' }})
+  e2e-weekly-stable:
+    name: Weekly Stable E2E (langflow-nightly:${{ github.event.inputs.langflow_image_tag || 'latest' }})
     runs-on: ubuntu-latest
     timeout-minutes: 90
 
@@ -47,8 +47,8 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install chromium --with-deps
 
-      - name: Run @release tests
-        run: npx playwright test --grep "@release" --reporter=github
+      - name: Run @stable tests
+        run: npx playwright test --grep "@stable" --reporter=github
         env:
           CI: "true"
           PLAYWRIGHT_BASE_URL: "http://localhost:7860/"
@@ -79,9 +79,9 @@ jobs:
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `[Weekly Failure] @release tests failed on ${today} (langflow:${tag})`,
+              title: `[Weekly Failure] @stable tests failed on ${today} (langflow:${tag})`,
               body: [
-                '## Weekly @release E2E Failure',
+                '## Weekly @stable E2E Failure',
                 '',
                 `- **Date:** ${today}`,
                 `- **Langflow version:** \`langflowai/langflow-nightly:${tag}\``,
@@ -90,10 +90,10 @@ jobs:
                 '### Próximos passos',
                 '1. Abra o relatório Playwright no artefato da run acima',
                 '2. Determine se a falha é um bug no teste ou uma regressão no Langflow',
-                '3. Se o teste estiver incorreto ou desatualizado: remova a tag `@release` do teste e abra um PR de correção',
+                '3. Se o teste estiver incorreto ou desatualizado: remova a tag `@stable` do teste e abra um PR de correção',
                 '4. Se for regressão no Langflow: sinalize para o time e acompanhe o upstream',
                 '',
-                '/cc @Victor-w-Madeira',
+                '/cc @Victor-w-Madeira @daniellicnerski1',
               ].join('\n'),
               labels: ['weekly-failure', 'needs-triage'],
             });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ Tags are split into two groups: **transversais** (severidade/camada) e **funcion
 
 | Tag | When to apply |
 |---|---|
+| `@stable` | Teste validado pelo time — roda no workflow semanal; falhas abrem issue para triagem |
 | `@release` | Happy-path flows required before any deploy |
 | `@regression` | Tests for previously fixed bugs |
 | `@api` | Tests exercising REST API endpoints |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -461,3 +461,41 @@ O `file-watcher.yml` roda todo dia às 05h BRT e verifica se houve commits no re
 3. Para cada teste que falhar ou parecer desatualizado, siga o guia de validação acima
 4. Atualize os testes necessários e marque o `QA_CHECKLIST.md`
 5. Feche a issue
+
+---
+
+## Tag @stable — testes validados
+
+### O que é
+
+`@stable` identifica testes que foram revisados pelo time e estão confirmados como corretos e confiáveis. Apenas esses testes rodam no workflow semanal (`weekly-stable.yml`). Uma falha nesse workflow abre automaticamente uma issue para triagem.
+
+### Como adicionar
+
+O teste **entra com a tag no próprio PR**. O revisor, ao aprovar o merge, está confirmando que:
+
+1. O teste passou pelos 5 passos do guia de validação (trace, falha forçada, debug, sem backend errors, checklist)
+2. O comportamento validado é real e relevante para o monitoramento semanal
+
+```typescript
+test("deve criar um flow e executar com sucesso", { tag: ["@workspace", "@stable"] }, async ({ page }) => {
+```
+
+> A tag `@stable` coexiste com as demais tags funcionais e transversais — não as substitui.
+
+### Como remover e corrigir
+
+O fluxo tem dois passos para separar triagem de correção:
+
+**Passo 1 — Analista (ao receber a issue do workflow):**
+1. Identifique o teste que falhou
+2. Abra um PR removendo a tag `@stable` do teste
+3. Após merge, o teste para de rodar no workflow semanal imediatamente
+4. Atualize a issue indicando qual teste precisa de correção e por quê
+
+**Passo 2 — Dev (ao corrigir o teste):**
+1. Corrija o teste seguindo o guia de validação
+2. Devolva a tag `@stable` no mesmo PR de correção
+3. Referencie a issue no PR
+
+Esse processo garante rastreabilidade: fica registrado quando o teste saiu e quando voltou ao monitoramento semanal.


### PR DESCRIPTION
## Summary

- Adiciona `weekly-stable.yml`: workflow que roda toda segunda-feira às 03h BRT contra `langflow-nightly:latest`, filtrando apenas testes com tag `@stable`
- Falhas no schedule abrem issue automaticamente com label `weekly-failure` e cc para @Victor-w-Madeira e @daniellicnerski1
- Documenta a tag `@stable` no `CLAUDE.md` (tabela de tags) e no `CONTRIBUTING.md` (processo completo de adição e remoção)

## O que muda no processo do time

- Testes validados entram com `@stable` no próprio PR; o revisor confirma a tag ao aprovar
- Quando o workflow falha: analista abre PR para remover `@stable` e atualiza a issue; dev corrige e devolve a tag em PR separado
- `@release` permanece intocada com o significado original (prioridade de produto)

## Test plan

- [ ] Disparar o workflow manualmente via `workflow_dispatch` para confirmar que roda apenas testes `@stable`
- [ ] Confirmar que issues são criadas corretamente (testar com `if: always()` temporariamente se necessário)
- [ ] Verificar que o label `weekly-failure` aparece nas issues geradas