### PR TITLE
docs: refinar template de spec e consolidar processo @stable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,10 +136,11 @@ Tags are split into two groups: **transversais** (severidade/camada) e **funcion
 
 ## CI/CD
 
-Four GitHub Actions workflows:
+Five GitHub Actions workflows:
 
 - **`pr-validation.yml`** — Runs on every PR to `main`; two parallel jobs: TypeScript check (`tsc --noEmit`) and ESLint. Both must pass before merge.
 - **`nightly.yml`** — Runs daily at 03:00 BRT against `langflowai/langflow-nightly:latest`; opens a GitHub issue on failure assigned to @Victor-w-Madeira.
+- **`weekly-stable.yml`** — Runs every Monday against `langflowai/langflow-nightly:latest`; runs only `@stable` tests; opens a GitHub issue on failure for triage.
 - **`manual.yml`** — Parameterized manual run; accepts a Docker tag or full URL, a specific test suite, and an optional grep filter.
 - **`file-watcher.yml`** — Detects upstream Langflow changes in critical paths and opens a GitHub issue with the exact `--grep` command needed to revalidate affected areas.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,14 @@ regression/
 4. Confirm no backend errors logged (`🚨 Backend Error:`)
 5. Update `QA-CHECKLIST.md` coverage symbols
 
+**PR review checklist** — request changes if any of these are missing:
+- `@stable` tag is present in the test (required for all new tests)
+- Spec doc exists under `docs/` mirroring the test's path under `regression/`
+- Spec doc has all mandatory sections filled: **O que este teste valida**, **Tags**, **Critério de validação**, **Dependências externas**
+- `Última validação` field reflects the current Langflow release cycle (ex: `1.10.x`)
+
+Exceptions where `@stable` is absent: inherited tests not yet reviewed, and tests temporarily without the tag while under correction.
+
 ### Tag Semantics
 
 Tags are split into two groups: **transversais** (severidade/camada) e **funcionais** (área de produto).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,11 +77,9 @@ test("deve configurar o model provider", { tag: ["@model-provider"] }, async ({ 
 
 Veja a tabela de tags disponíveis no [README](./README.md#tags-disponíveis).
 
-**6. Atualize o `QA_CHECKLIST.md` e o `QA-SCENARIOS-GUIDE.md`**
+**6. Atualize o `QA-CHECKLIST.md`**
 
-Após criar o teste, localize o item correspondente no `QA_CHECKLIST.md` e marque como `[-]` (automatizado, precisa validar). Somente mude para `[x]` após seguir o processo de validação abaixo.
-
-Adicione também uma entrada no `QA-SCENARIOS-GUIDE.md` descrevendo o cenário em linguagem humana — objetivo, pré-condições, passo a passo e critério de validação. Os dois documentos devem estar sempre sincronizados com os testes existentes.
+Após criar o teste, localize o item correspondente no `QA-CHECKLIST.md` e marque como `[-]` (automatizado, precisa validar). Somente mude para `[x]` após seguir o processo de validação abaixo.
 
 **7. Crie o arquivo de documentação do spec**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,9 @@ tests/tests-automations/regression/core-functionality/playground/playground-sess
 → docs/core-functionality/playground/playground-session-id.md
 ```
 
-Use `docs/TEMPLATE.md` como base. As seções obrigatórias são: **Motivação**, **O que este teste valida**, **Tags**, **Critério de validação** e **Dependências externas**.
+Use `docs/TEST-SPEC-TEMPLATE.md` como base. As seções obrigatórias são: **O que este teste valida**, **Tags**, **Critério de validação** e **Dependências externas**.
+
+No campo **Última validação**, registre o ciclo de release do Langflow em que o teste foi desenvolvido ou revisado pela última vez (ex: `Langflow 1.10.x`). Valide preferencialmente contra a imagem `langflowai/langflow-nightly:latest`, que acompanha a branch de release em desenvolvimento. Se a nightly estiver instável, use a branch de release correspondente (`release-1.x.x`) diretamente. Em ambos os casos, o campo deve refletir o ciclo, não o build exato.
 
 > A seção **Dependências externas** lista arquivos do repositório upstream do Langflow que, se alterados, podem quebrar o teste. Ela é lida pelo `file-watcher.yml` para determinar quais testes precisam ser revisados quando o Langflow muda. Preencha com atenção.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -472,12 +472,15 @@ O `file-watcher.yml` roda todo dia às 05h BRT e verifica se houve commits no re
 
 `@stable` identifica testes que foram revisados pelo time e estão confirmados como corretos e confiáveis. Apenas esses testes rodam no workflow semanal (`weekly-stable.yml`). Uma falha nesse workflow abre automaticamente uma issue para triagem.
 
-### Como adicionar
+### Padrão: todo teste novo entra com @stable
 
-O teste **entra com a tag no próprio PR**. O revisor, ao aprovar o merge, está confirmando que:
+`@stable` é o padrão para qualquer teste novo. O teste **entra com a tag no próprio PR**, junto com o arquivo de documentação em `docs/` (ver passo 7 do guia acima). O revisor, ao aprovar o merge, está confirmando que:
 
 1. O teste passou pelos 5 passos do guia de validação (trace, falha forçada, debug, sem backend errors, checklist)
 2. O comportamento validado é real e relevante para o monitoramento semanal
+3. O arquivo de documentação em `docs/` está presente e com as seções obrigatórias preenchidas
+
+Se qualquer um desses pontos estiver ausente ou incompleto, o revisor deve **solicitar mudanças** antes de aprovar.
 
 ```typescript
 test("deve criar um flow e executar com sucesso", { tag: ["@workspace", "@stable"] }, async ({ page }) => {
@@ -485,9 +488,19 @@ test("deve criar um flow e executar com sucesso", { tag: ["@workspace", "@stable
 
 > A tag `@stable` coexiste com as demais tags funcionais e transversais — não as substitui.
 
+### Exceções — quando o teste não terá @stable
+
+Dois casos em que a tag está intencionalmente ausente:
+
+1. **Testes herdados ainda não revisados** — existem no repositório mas ainda não passaram pelo processo de validação e documentação.
+2. **Testes com falha no workflow** — a tag foi temporariamente removida enquanto o teste aguarda correção (ver fluxo abaixo).
+
 ### Como remover e corrigir
 
-O fluxo tem dois passos para separar triagem de correção:
+Ao receber uma issue do workflow semanal, avalie a causa da falha:
+
+- **Regressão no Langflow** (produto quebrou, teste está correto): o teste cumpriu seu papel. Sinalize a issue para o time de produto e acompanhe o upstream. A tag permanece.
+- **Mudança de comportamento no produto ou teste incorreto**: siga o fluxo abaixo.
 
 **Passo 1 — Analista (ao receber a issue do workflow):**
 1. Identifique o teste que falhou

--- a/docs/TEST-SPEC-TEMPLATE.md
+++ b/docs/TEST-SPEC-TEMPLATE.md
@@ -1,12 +1,13 @@
 # [Nome do Spec]
 
-## Objetivo *(obrigatório)*
-O que o teste valida em termos funcionais, em uma ou duas frases. Pense: "se este teste falhar, o que quebrou no produto?"
+**Última validação:** Langflow X.X.x
 
 ---
 
-## Motivação *(obrigatório)*
-Por que este teste existe. Se veio de um bug, referencie a issue. Se é cobertura preventiva de release, diga qual funcionalidade protege.
+## O que este teste valida *(obrigatório)*
+O que o teste valida em termos funcionais e por que existe. Se veio de um bug, referencie a issue.
+Se é cobertura preventiva de release, diga qual funcionalidade protege.
+Pense: "se este teste falhar, o que quebrou no produto?"
 
 ---
 
@@ -28,6 +29,15 @@ Por que este teste existe. Se veio de um bug, referencie a issue. Se é cobertur
 
 ---
 
+## Dependências externas *(obrigatório)*
+<!-- Arquivos do repositório do Langflow que, se alterados, podem quebrar este teste.
+     Esta lista é lida pelo workflow de monitoramento — preencha com atenção. -->
+
+- `src/frontend/...` — descrição do que este arquivo faz e por que impacta o teste
+- `src/backend/...` — idem
+
+---
+
 ## O que este teste não cobre *(opcional)*
 - Comportamentos adjacentes que parecem relacionados mas estão intencionalmente fora do escopo
 - Ajuda o mantenedor a distinguir lacuna de decisão consciente
@@ -36,15 +46,6 @@ Por que este teste existe. Se veio de um bug, referencie a issue. Se é cobertur
 
 ## Pré-condições *(opcional)*
 - O que precisa estar configurado ou em execução antes de rodar o teste
-
----
-
-## Dependências externas *(obrigatório)*
-<!-- Arquivos do repositório do Langflow que, se alterados, podem quebrar este teste.
-     Esta lista é lida pelo workflow de monitoramento — preencha com atenção. -->
-
-- `src/frontend/...` — descrição do que este arquivo faz e por que impacta o teste
-- `src/backend/...` — idem
 
 ---
 


### PR DESCRIPTION
## O que esta PR faz

Refina a documentação de processo do repositório em três frentes:

### 1. Template de spec (`docs/TEST-SPEC-TEMPLATE.md`)
- Renomeia `TEMPLATE.md` para `TEST-SPEC-TEMPLATE.md`
- Funde as seções **Motivação** e **Objetivo** em **O que este teste valida** — eram redundantes na prática
- Adiciona campo **Última validação** com o ciclo de release do Langflow (ex: `1.10.x`)
- Remove campo Owner
- Mantém Pré-condições como opcional

### 2. Processo `@stable` (`CONTRIBUTING.md`)
- Estabelece `@stable` como padrão para todo teste novo — o teste entra com a tag na PR
- Documenta que a spec doc em `docs/` é requisito da PR junto com a tag
- Torna explícitas as exceções: testes herdados não revisados e testes sob correção
- Adiciona avaliação de causa antes de remover a tag (regressão no produto vs. teste incorreto)
- Adiciona diretriz de ambiente de validação: nightly ou release branch, com o ciclo registrado no campo `Última validação`
- Remove instrução de alimentar `QA-SCENARIOS-GUIDE.md` para testes novos (documento em processo de deprecação)

### 3. Checklist de revisão de PR (`CLAUDE.md`)
- Adiciona checklist explícito para revisores: `@stable` presente, spec doc existente e completa, `Última validação` preenchida
- Corrige contagem de workflows de 4 para 5 e adiciona `weekly-stable.yml` à lista

## O que esta PR não cobre
- Criação de spec docs para testes existentes — isso é trabalho de validação a ser feito separadamente
- Remoção do `QA-SCENARIOS-GUIDE.md` — permanece como referência histórica por ora