### PR TITLE
fix: corrigir provider-invalid-auth-error e adicionar @stable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,10 +136,11 @@ Tags are split into two groups: **transversais** (severidade/camada) e **funcion
 
 ## CI/CD
 
-Four GitHub Actions workflows:
+Five GitHub Actions workflows:
 
 - **`pr-validation.yml`** — Runs on every PR to `main`; two parallel jobs: TypeScript check (`tsc --noEmit`) and ESLint. Both must pass before merge.
 - **`nightly.yml`** — Runs daily at 03:00 BRT against `langflowai/langflow-nightly:latest`; opens a GitHub issue on failure assigned to @Victor-w-Madeira.
+- **`weekly-stable.yml`** — Runs every Monday against `langflowai/langflow-nightly:latest`; runs only `@stable` tests; opens a GitHub issue on failure for triage.
 - **`manual.yml`** — Parameterized manual run; accepts a Docker tag or full URL, a specific test suite, and an optional grep filter.
 - **`file-watcher.yml`** — Detects upstream Langflow changes in critical paths and opens a GitHub issue with the exact `--grep` command needed to revalidate affected areas.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,14 @@ regression/
 4. Confirm no backend errors logged (`🚨 Backend Error:`)
 5. Update `QA-CHECKLIST.md` coverage symbols
 
+**PR review checklist** — request changes if any of these are missing:
+- `@stable` tag is present in the test (required for all new tests)
+- Spec doc exists under `docs/` mirroring the test's path under `regression/`
+- Spec doc has all mandatory sections filled: **O que este teste valida**, **Tags**, **Critério de validação**, **Dependências externas**
+- `Última validação` field reflects the current Langflow release cycle (ex: `1.10.x`)
+
+Exceptions where `@stable` is absent: inherited tests not yet reviewed, and tests temporarily without the tag while under correction.
+
 ### Tag Semantics
 
 Tags are split into two groups: **transversais** (severidade/camada) e **funcionais** (área de produto).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,11 +77,9 @@ test("deve configurar o model provider", { tag: ["@model-provider"] }, async ({ 
 
 Veja a tabela de tags disponíveis no [README](./README.md#tags-disponíveis).
 
-**6. Atualize o `QA_CHECKLIST.md` e o `QA-SCENARIOS-GUIDE.md`**
+**6. Atualize o `QA-CHECKLIST.md`**
 
-Após criar o teste, localize o item correspondente no `QA_CHECKLIST.md` e marque como `[-]` (automatizado, precisa validar). Somente mude para `[x]` após seguir o processo de validação abaixo.
-
-Adicione também uma entrada no `QA-SCENARIOS-GUIDE.md` descrevendo o cenário em linguagem humana — objetivo, pré-condições, passo a passo e critério de validação. Os dois documentos devem estar sempre sincronizados com os testes existentes.
+Após criar o teste, localize o item correspondente no `QA-CHECKLIST.md` e marque como `[-]` (automatizado, precisa validar). Somente mude para `[x]` após seguir o processo de validação abaixo.
 
 **7. Crie o arquivo de documentação do spec**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,9 @@ tests/tests-automations/regression/core-functionality/playground/playground-sess
 → docs/core-functionality/playground/playground-session-id.md
 ```
 
-Use `docs/TEMPLATE.md` como base. As seções obrigatórias são: **Motivação**, **O que este teste valida**, **Tags**, **Critério de validação** e **Dependências externas**.
+Use `docs/TEST-SPEC-TEMPLATE.md` como base. As seções obrigatórias são: **O que este teste valida**, **Tags**, **Critério de validação** e **Dependências externas**.
+
+No campo **Última validação**, registre o ciclo de release do Langflow em que o teste foi desenvolvido ou revisado pela última vez (ex: `Langflow 1.10.x`). Valide preferencialmente contra a imagem `langflowai/langflow-nightly:latest`, que acompanha a branch de release em desenvolvimento. Se a nightly estiver instável, use a branch de release correspondente (`release-1.x.x`) diretamente. Em ambos os casos, o campo deve refletir o ciclo, não o build exato.
 
 > A seção **Dependências externas** lista arquivos do repositório upstream do Langflow que, se alterados, podem quebrar o teste. Ela é lida pelo `file-watcher.yml` para determinar quais testes precisam ser revisados quando o Langflow muda. Preencha com atenção.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -472,12 +472,15 @@ O `file-watcher.yml` roda todo dia às 05h BRT e verifica se houve commits no re
 
 `@stable` identifica testes que foram revisados pelo time e estão confirmados como corretos e confiáveis. Apenas esses testes rodam no workflow semanal (`weekly-stable.yml`). Uma falha nesse workflow abre automaticamente uma issue para triagem.
 
-### Como adicionar
+### Padrão: todo teste novo entra com @stable
 
-O teste **entra com a tag no próprio PR**. O revisor, ao aprovar o merge, está confirmando que:
+`@stable` é o padrão para qualquer teste novo. O teste **entra com a tag no próprio PR**, junto com o arquivo de documentação em `docs/` (ver passo 7 do guia acima). O revisor, ao aprovar o merge, está confirmando que:
 
 1. O teste passou pelos 5 passos do guia de validação (trace, falha forçada, debug, sem backend errors, checklist)
 2. O comportamento validado é real e relevante para o monitoramento semanal
+3. O arquivo de documentação em `docs/` está presente e com as seções obrigatórias preenchidas
+
+Se qualquer um desses pontos estiver ausente ou incompleto, o revisor deve **solicitar mudanças** antes de aprovar.
 
 ```typescript
 test("deve criar um flow e executar com sucesso", { tag: ["@workspace", "@stable"] }, async ({ page }) => {
@@ -485,9 +488,19 @@ test("deve criar um flow e executar com sucesso", { tag: ["@workspace", "@stable
 
 > A tag `@stable` coexiste com as demais tags funcionais e transversais — não as substitui.
 
+### Exceções — quando o teste não terá @stable
+
+Dois casos em que a tag está intencionalmente ausente:
+
+1. **Testes herdados ainda não revisados** — existem no repositório mas ainda não passaram pelo processo de validação e documentação.
+2. **Testes com falha no workflow** — a tag foi temporariamente removida enquanto o teste aguarda correção (ver fluxo abaixo).
+
 ### Como remover e corrigir
 
-O fluxo tem dois passos para separar triagem de correção:
+Ao receber uma issue do workflow semanal, avalie a causa da falha:
+
+- **Regressão no Langflow** (produto quebrou, teste está correto): o teste cumpriu seu papel. Sinalize a issue para o time de produto e acompanhe o upstream. A tag permanece.
+- **Mudança de comportamento no produto ou teste incorreto**: siga o fluxo abaixo.
 
 **Passo 1 — Analista (ao receber a issue do workflow):**
 1. Identifique o teste que falhou

--- a/docs/TEST-SPEC-TEMPLATE.md
+++ b/docs/TEST-SPEC-TEMPLATE.md
@@ -1,12 +1,13 @@
 # [Nome do Spec]
 
-## Objetivo *(obrigatório)*
-O que o teste valida em termos funcionais, em uma ou duas frases. Pense: "se este teste falhar, o que quebrou no produto?"
+**Última validação:** Langflow X.X.x
 
 ---
 
-## Motivação *(obrigatório)*
-Por que este teste existe. Se veio de um bug, referencie a issue. Se é cobertura preventiva de release, diga qual funcionalidade protege.
+## O que este teste valida *(obrigatório)*
+O que o teste valida em termos funcionais e por que existe. Se veio de um bug, referencie a issue.
+Se é cobertura preventiva de release, diga qual funcionalidade protege.
+Pense: "se este teste falhar, o que quebrou no produto?"
 
 ---
 
@@ -28,6 +29,15 @@ Por que este teste existe. Se veio de um bug, referencie a issue. Se é cobertur
 
 ---
 
+## Dependências externas *(obrigatório)*
+<!-- Arquivos do repositório do Langflow que, se alterados, podem quebrar este teste.
+     Esta lista é lida pelo workflow de monitoramento — preencha com atenção. -->
+
+- `src/frontend/...` — descrição do que este arquivo faz e por que impacta o teste
+- `src/backend/...` — idem
+
+---
+
 ## O que este teste não cobre *(opcional)*
 - Comportamentos adjacentes que parecem relacionados mas estão intencionalmente fora do escopo
 - Ajuda o mantenedor a distinguir lacuna de decisão consciente
@@ -36,15 +46,6 @@ Por que este teste existe. Se veio de um bug, referencie a issue. Se é cobertur
 
 ## Pré-condições *(opcional)*
 - O que precisa estar configurado ou em execução antes de rodar o teste
-
----
-
-## Dependências externas *(obrigatório)*
-<!-- Arquivos do repositório do Langflow que, se alterados, podem quebrar este teste.
-     Esta lista é lida pelo workflow de monitoramento — preencha com atenção. -->
-
-- `src/frontend/...` — descrição do que este arquivo faz e por que impacta o teste
-- `src/backend/...` — idem
 
 ---
 

--- a/docs/core-functionality/llm-agents/provider-invalid-auth-error.md
+++ b/docs/core-functionality/llm-agents/provider-invalid-auth-error.md
@@ -1,0 +1,70 @@
+# provider-invalid-auth-error
+
+**Última validação:** Langflow 1.10.x
+
+---
+
+## O que este teste valida *(obrigatório)*
+
+Valida que o Langflow exibe uma mensagem de erro ao usuário quando ele tenta salvar uma API key inválida na tela de configuração de Model Providers (Settings → Model Providers). A chave não deve ser aceita e o provider não deve ser configurado com sucesso.
+
+Protege contra regressões na integração entre o frontend (ProviderConfigurationForm) e o endpoint `POST /api/v1/models/validate-provider`, que valida a credencial contra o provider externo antes de persistir.
+
+---
+
+## Tags *(obrigatório)*
+
+`@stable` `@regression` `@model-provider` `@agents`
+
+---
+
+## Passo a passo *(obrigatório)*
+
+1. Navega para Settings → Model Providers → [provider]
+2. Preenche o campo de API key com uma chave inválida (ex: `sk-invalid-openai-key-for-testing-12345`)
+3. Clica em "Save Configuration"
+4. Aguarda o toast de erro `.error-build-message` com texto correspondente a "Invalid API key"
+5. (finally) Restaura a chave válida original do provider
+
+O teste é parametrizado: roda para cada provider que tiver env var configurada (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`).
+
+---
+
+## Critério de validação *(obrigatório)*
+
+- O toast `.error-build-message` deve ficar visível após clicar em Save com chave inválida
+- O texto do toast deve corresponder a `/Invalid API key/i`
+- O timeout é de 30 segundos pois a validação faz uma chamada HTTP real ao provider externo
+
+---
+
+## Dependências externas *(obrigatório)*
+
+- `src/frontend/src/modals/modelProviderModal/components/ProviderConfigurationForm.tsx` — renderiza o formulário de API key e dispara o toast de erro
+- `src/frontend/src/modals/modelProviderModal/hooks/useProviderConfiguration.ts` — lógica de validação, chama o endpoint e gerencia o estado `validationState`
+- `src/frontend/src/alerts/error/index.tsx` — componente visual do toast `.error-build-message`
+- `src/backend/base/langflow/api/v1/models.py` — endpoint `POST /api/v1/models/validate-provider`
+- `src/backend/base/langflow/services/credentials.py` — função `validate_model_provider_key`, que testa a key contra o provider e retorna `"Invalid API key for {provider}"`
+
+---
+
+## O que este teste não cobre *(opcional)*
+
+- Validação de keys com formato correto mas expiradas ou revogadas (comportamento idêntico, mas depende do estado da key no provider)
+- Providers além de OpenAI, Anthropic e Google (ex: IBM WatsonX, Ollama)
+- Persistência do estado após erro (verificar que a key anterior permanece ativa)
+
+---
+
+## Pré-condições *(opcional)*
+
+- Pelo menos uma env var de provider configurada no `.env` (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY` ou `GOOGLE_API_KEY`)
+- Langflow rodando e acessível via `PLAYWRIGHT_BASE_URL`
+- Acesso à internet para que o backend consiga chamar o provider externo durante a validação
+
+---
+
+## Notas *(opcional)*
+
+- O timeout de 30s no `expect` é necessário porque o backend faz `llm.invoke("test")` contra o provider real — a resposta de erro do provider pode levar vários segundos
+- O `data-testid` dos providers na sidebar segue o padrão `provider-item-{NomeDoProvider}` (ex: `provider-item-OpenAI`)

--- a/tests/tests-automations/regression/core-functionality/llm-agents/provider-invalid-auth-error.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/provider-invalid-auth-error.spec.ts
@@ -46,16 +46,26 @@ async function fillProviderApiKey(
 ): Promise<void> {
   const apiKeyInput = page.getByPlaceholder(apiKeyPlaceholder);
   if ((await apiKeyInput.count()) > 0) {
-    await apiKeyInput.click({ clickCount: 3 });
-    await apiKeyInput.pressSequentially(apiKey, { delay: 0 });
+    await apiKeyInput.fill(apiKey);
 
-    const saveConfigBtn = page.getByRole("button", { name: "Save Configuration" });
-    const replaceConfigBtn = page.getByRole("button", { name: "Replace Configuration" });
+    const saveBtn = page.getByRole("button", { name: /^(Save|Replace|Retry Save)$|Save Configuration|Replace Configuration/i });
+    if ((await saveBtn.count()) > 0) {
+      await saveBtn.first().click();
+    }
 
-    if ((await saveConfigBtn.count()) > 0) {
-      await saveConfigBtn.click();
-    } else if ((await replaceConfigBtn.count()) > 0) {
-      await replaceConfigBtn.click();
+    // Confirm the disconnect warning dialog if it appears (shown when replacing an existing key).
+    // Uses evaluate because the Save button overlaps the Confirm button in the DOM layout.
+    try {
+      const confirmBtn = page.getByRole("button", { name: "Confirm" });
+      await confirmBtn.waitFor({ state: "visible", timeout: 5000 });
+      await page.evaluate(() => {
+        const btn = Array.from(document.querySelectorAll("button")).find(
+          (b) => b.textContent?.trim() === "Confirm",
+        );
+        btn?.click();
+      });
+    } catch {
+      // No confirmation dialog — key was saved directly
     }
   }
 }
@@ -74,6 +84,9 @@ async function navigateAndFillProviderApiKey(
   await page.getByTestId("icon-Brain").click();
   await page.getByTestId(providerTestId).click();
 
+  // Wait for the provider form to finish loading before filling
+  await page.getByPlaceholder(apiKeyPlaceholder).waitFor({ state: "visible", timeout: 15000 });
+
   await fillProviderApiKey(page, apiKeyPlaceholder, apiKey);
 }
 
@@ -91,9 +104,8 @@ for (const {
   test.describe.serial(`Invalid Auth Error — ${provider}`, () => {
     test(
       `deve exibir mensagem de erro ao usar autenticação inválida do provider ${provider}`,
-      { tag: ["@regression", "@model-provider", "@agents"] },
+      { tag: ["@stable", "@regression", "@model-provider", "@agents"] },
       async ({ page }) => {
-        (page as any).allowFlowErrors();
 
         await page.goto("/");
         await page.waitForSelector('[data-testid="mainpage_title"]', { timeout: 30000 });
@@ -112,7 +124,7 @@ for (const {
             const errorBox = page.locator(".error-build-message");
             await expect(
               errorBox.getByText(/Invalid API key/i),
-            ).toBeVisible({ timeout: 2000 });
+            ).toBeVisible({ timeout: 30000 });
           });
         } finally {
           await test.step(`Restaurar autenticação válida do provider ${provider}`, async () => {


### PR DESCRIPTION
## Contexto

Closes #75

Revalidação do spec `provider-invalid-auth-error.spec.ts` contra Langflow 1.10.x. O teste passou, mas exigiu correções de execução antes de receber `@stable`.

## O que foi corrigido

**Race condition (causa raiz):** `fillProviderApiKey` era chamado imediatamente após clicar no provider, antes do formulário de configuração renderizar. O `apiKeyInput.count()` retornava 0, o `if` era pulado silenciosamente, e a chave inválida nunca era preenchida. A validação nunca ocorria.

**Outros fixes:**
- `waitFor({ state: "visible" })` no input — aguarda o form carregar antes de preencher
- Regex do botão de save atualizada: `"Save Configuration"` / `"Replace Configuration"` → `"Save"` / `"Replace"` / `"Retry Save"` (textos reais da UI atual)
- Tratamento do disconnect warning dialog via `page.evaluate` (sobreposição de elementos impede clique normal do Playwright)
- `allowFlowErrors()` removido (pertence ao canvas de flow, irrelevante para tela de settings)
- Timeout da asserção: `2000ms` → `30000ms` (validação faz chamada HTTP ao provider externo)

## O que não mudou

A semântica do teste é idêntica: valida que salvar uma API key inválida em Settings → Model Providers exibe o toast de erro `"Invalid API key for {provider}"`. A cobertura e o critério de validação são os mesmos da review anterior.

## Checklist

- [x] Rodou com `--trace=on` — passou em ~4s (duas execuções consecutivas)
- [x] `@stable` adicionado
- [x] Doc criado em `docs/core-functionality/llm-agents/provider-invalid-auth-error.md`
- [x] `Última validação: Langflow 1.10.x` preenchido