### PR TITLE
feat(memory-chatbot): validar e estabilizar memory-history-regression.spec.ts

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -436,7 +436,7 @@
 - [-] Simple Agent (Anthropic)
 - [-] Simple Agent com memória
 - [-] Vector Store RAG
-- [-] Memory Chatbot
+- [x] Memory Chatbot
 - [-] **Basic Prompting** (OpenAI) → `core/integrations/Basic Prompting.spec.ts`
 - [-] **Basic Prompting** (Anthropic) → `core/integrations/Basic Prompting Anthropic.spec.ts`
 - [-] **Simple Agent** (OpenAI) → `core/integrations/Simple Agent.spec.ts`

--- a/docs/core-functionality/llm-agents/memory-history-regression.md
+++ b/docs/core-functionality/llm-agents/memory-history-regression.md
@@ -28,9 +28,9 @@ Não requer API key. Valida somente a estrutura do canvas.
 
 1. Apagar flows existentes e carregar o template "Memory Chatbot" em `All Templates`
 2. Aguardar `canvas_controls_dropdown` aparecer; ajustar view e atualizar componentes
-3. *Step: canvas has all 6 required nodes* — `expect.soft` para cada um dos 6 `title-*`:
+3. *Step: canvas has all 6 required nodes* — `expect.soft` para cada um dos 6 nós:
    - `title-Chat Input`, `title-Chat Output`, `title-Message History`
-   - `title-OpenAI`, `title-Prompt Template`, `title-Type Convert`
+   - `title-Language Model`, `title-Prompt Template`, `note_node`
 4. *Step: canvas has exactly 6 nodes* — contar `.react-flow__node` e verificar `=== 6`
 
 ---
@@ -39,10 +39,12 @@ Não requer API key. Valida somente a estrutura do canvas.
 
 Requer `OPENAI_API_KEY`. Agrupa as validações de comportamento em `test.step` com `expect.soft`.
 
-1. Carregar o template Memory Chatbot e configurar `OPENAI_API_KEY` no campo `popover-anchor-input-api_key` do nó OpenAI
+1. Carregar o template Memory Chatbot e configurar OpenAI via `setupLanguageModelOpenAI`:
+   - Se `model_model` não estiver visível (providers não configurados): clicar no botão "Setup Provider" (sem data-testid) → selecionar `provider-item-OpenAI` → preencher API key com `pressSequentially` → clicar "Save" → aguardar botão "Replace" aparecer → habilitar toggles `[data-testid^="llm-toggle"]` → fechar com Escape → aguardar `model_model` aparecer
+   - Clicar `model_model` e selecionar `gpt-4o-mini`
 2. Abrir o Playground (`playground-btn-flow-io`) e aguardar `input-chat-playground`
 3. *Step: context retention* — Enviar `"My name is Alice..."`, aguardar resposta, enviar `"What is my name?"` e verificar que a resposta contém "Alice"
-4. *Step: multiple messages* — contar `div-chat-message` ≥ 4
+4. *Step: multiple messages* — contar `div-chat-message` ≥ 2 (testid marca apenas respostas do bot)
 5. *Step: persistence* — fechar o Playground via `playground-close-button`, reabrir, confirmar que a contagem de mensagens é ≥ ao valor anterior
 
 ---
@@ -51,20 +53,20 @@ Requer `OPENAI_API_KEY`. Agrupa as validações de comportamento em `test.step` 
 
 Requer `OPENAI_API_KEY`. Separado por ser destrutivo (cria nova sessão).
 
-1. Carregar template, configurar API key
+1. Carregar template, configurar API key (mesmo fluxo do Teste 2)
 2. Abrir Playground, enviar `"My name is Bob..."`
 3. Aguardar resposta aparecer
-4. Clicar em `session-selector-trigger` → `New Session`
-5. Aguardar `input-chat-playground` na nova sessão
+4. Clicar em `new-chat` (botão "+" no painel de sessões do sidebar)
+5. Aguardar 500ms para reset do estado de sessão
 6. Verificar que `div-chat-message` count é `=== 0` (sessão começa vazia)
 
 ---
 
 ## Critério de validação *(obrigatório)*
 
-- Template carrega com exatamente 6 nós: Chat Input, Chat Output, Message History, OpenAI, Prompt Template, Type Convert
+- Template carrega com exatamente 6 nós: Chat Input, Chat Output, Message History, Language Model, Prompt Template, note (README)
 - O LLM recorda o nome informado em mensagem anterior da mesma sessão ("Alice")
-- Mensagens acumulam no histórico (≥ 4 após 2 trocas)
+- Respostas do bot acumulam no histórico (div-chat-message ≥ 2 após 2 trocas)
 - O histórico persiste após fechar e reabrir o Playground
 - Uma nova sessão começa com 0 mensagens, sem herdar contexto de sessões anteriores
 
@@ -72,19 +74,20 @@ Requer `OPENAI_API_KEY`. Separado por ser destrutivo (cria nova sessão).
 
 ## Dependências externas *(obrigatório)*
 
-- `src/backend/base/langflow/initial_setup/starter_projects/memory_chatbot.py` — define o grafo do template; mudanças nos nós ou arestas quebram o Teste 1
+- `src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json` — define o grafo do template em runtime (sobrescreve o `.py`); mudanças nos nós ou arestas quebram o Teste 1
 - `src/lfx/src/lfx/components/models_and_agents/memory.py` — `MemoryComponent` (`display_name = "Message History"`); renomear ou remover quebra o Teste 1 e o Teste 2
-- `src/lfx/src/lfx/components/openai/openai_chat_model.py` — `OpenAIModelComponent`; mudanças no campo `api_key` ou no `display_name` afetam Testes 1, 2 e 3
-- `src/frontend/src/components/core/playgroundComponent/` — `input-chat-playground`, `div-chat-message`, `playground-close-button`, `session-selector-trigger` — qualquer renomeação quebra Testes 2 e 3
+- `src/lfx/src/lfx/components/models_and_agents/language_model.py` — `LanguageModelComponent` (`display_name = "Language Model"`); mudanças no campo `model` ou no `display_name` afetam Testes 1, 2 e 3
+- `src/frontend/src/components/core/playgroundComponent/` — `input-chat-playground`, `div-chat-message`, `playground-close-button`, `new-chat` — qualquer renomeação quebra Testes 2 e 3
 - `src/frontend/src/CustomNodes/GenericNode/components/NodeName/index.tsx` — `data-testid="title-{display_name}"` — mudança no padrão de testid quebra o Teste 1
+- `src/frontend/src/modals/modelProviderModal/components/ProviderConfigurationForm.tsx` — botão "Save" (texto exato para salvar API key); mudar para outro texto quebra `setupLanguageModelOpenAI`
 
 ---
 
 ## O que este teste não cobre *(opcional)*
 
-- Comportamento do Memory Chatbot com outros providers (Anthropic, Google) — o template usa `OpenAIModelComponent` diretamente
+- Comportamento do Memory Chatbot com outros providers (Anthropic, Google) — `setupLanguageModelOpenAI` configura apenas OpenAI
 - Validação do conteúdo da resposta da IA além da referência ao nome ("Alice")
-- Verificação de que, sem o nó `Message History` conectado, o contexto se perde (coberto conceitualmente pelo Teste 3: nova sessão = histórico zerado)
+- Verificação de que, sem o nó `Message History` conectado, o contexto se perde
 - Persistência do histórico após restart do servidor Langflow
 
 ---
@@ -100,14 +103,17 @@ Requer `OPENAI_API_KEY`. Separado por ser destrutivo (cria nova sessão).
 ## Quando revisar este teste *(opcional)*
 
 - Se o template "Memory Chatbot" for removido ou renomeado em `starter_projects`
-- Se o `MemoryComponent` mudar de `display_name` ou a sessão padrão mudar de comportamento
+- Se o `LanguageModelComponent` mudar de `display_name` ou a sessão padrão mudar de comportamento
+- Se o botão "Save" no provider modal mudar de texto (quebra `setupLanguageModelOpenAI`)
+- Se o botão `new-chat` no sidebar de sessões for renomeado (quebra Teste 3)
 - Se o Playground ganhar confirmação modal ao criar nova sessão (Teste 3 precisará de step extra)
 
 ---
 
 ## Notas *(opcional)*
 
-- **Estrutura**: 3 testes — estrutura (sem API), suite de retenção (com `expect.soft`), isolamento de sessão (destrutivo, separado). O `expect.soft` garante visibilidade total das falhas sem abortar o suite.
-- **`popover-anchor-input-api_key`**: testid gerado dinamicamente pelo `parameterRenderComponent` com `data-testid={id}` onde `id = "popover-anchor-input-api_key"`. Se o campo não estiver visível (Langflow picking up a key from env), `configureOpenAIApiKey` silencia e o teste continua.
-- **`session-selector-trigger`**: botão `ListRestart` no header do Playground que abre o dropdown de sessões; "New Session" cria uma sessão com ID aleatório e limpa o histórico exibido.
+- **Estrutura do template em runtime**: o template carrega de `Memory Chatbot.json` (não do `.py`), com 6 nós: Chat Input, Chat Output, Prompt Template, Message History, Language Model (não OpenAI direto), note/README.
+- **`div-chat-message`**: testid presente apenas em respostas do bot (`bot-message.tsx`), não em mensagens do usuário. 2 trocas → count = 2 (não 4).
+- **`setupLanguageModelOpenAI`**: função local ao spec que configura OpenAI via modal "Setup Provider". Usa `pressSequentially` (não `fill`) para garantir eventos de teclado no input controlado do React. Aguarda botão "Replace" aparecer para confirmar que o save completou.
+- **`new-chat`**: botão "+" no painel lateral de sessões (`chat-sidebar.tsx`). Equivalente funcional ao "New Session" do dropdown `session-selector-trigger` (que pode estar oculto por animação em certas builds).
 - **Teste 1 sem API key**: validação de estrutura pura — útil em CI sem keys configuradas.

--- a/docs/core-functionality/llm-agents/memory-history-regression.md
+++ b/docs/core-functionality/llm-agents/memory-history-regression.md
@@ -1,0 +1,113 @@
+# Memory Chatbot — Regressão de Histórico e Memória
+
+**Última validação:** Langflow 1.10.x
+
+---
+
+## O que este teste valida *(obrigatório)*
+
+Valida o comportamento core do template **Memory Chatbot**: carregamento da estrutura do flow, retenção de contexto entre mensagens dentro da mesma sessão do Playground, persistência do histórico após fechar e reabrir o Playground, e isolamento de sessão (sessões distintas têm históricos independentes). Se qualquer um desses testes falhar, o Memory Chatbot está quebrado para uso real.
+
+---
+
+## Tags *(obrigatório)*
+
+`@stable` `@release` `@agents` `@playground`
+
+---
+
+## Passo a passo *(obrigatório)*
+
+O spec contém **3 testes** dentro de `test.describe("Memory Chatbot Regression")`.
+
+---
+
+**Teste 1 — memory chatbot template loads with correct node structure**
+
+Não requer API key. Valida somente a estrutura do canvas.
+
+1. Apagar flows existentes e carregar o template "Memory Chatbot" em `All Templates`
+2. Aguardar `canvas_controls_dropdown` aparecer; ajustar view e atualizar componentes
+3. *Step: canvas has all 6 required nodes* — `expect.soft` para cada um dos 6 `title-*`:
+   - `title-Chat Input`, `title-Chat Output`, `title-Message History`
+   - `title-OpenAI`, `title-Prompt Template`, `title-Type Convert`
+4. *Step: canvas has exactly 6 nodes* — contar `.react-flow__node` e verificar `=== 6`
+
+---
+
+**Teste 2 — message history context retention suite**
+
+Requer `OPENAI_API_KEY`. Agrupa as validações de comportamento em `test.step` com `expect.soft`.
+
+1. Carregar o template Memory Chatbot e configurar `OPENAI_API_KEY` no campo `popover-anchor-input-api_key` do nó OpenAI
+2. Abrir o Playground (`playground-btn-flow-io`) e aguardar `input-chat-playground`
+3. *Step: context retention* — Enviar `"My name is Alice..."`, aguardar resposta, enviar `"What is my name?"` e verificar que a resposta contém "Alice"
+4. *Step: multiple messages* — contar `div-chat-message` ≥ 4
+5. *Step: persistence* — fechar o Playground via `playground-close-button`, reabrir, confirmar que a contagem de mensagens é ≥ ao valor anterior
+
+---
+
+**Teste 3 — session isolation: new session has no context from previous session**
+
+Requer `OPENAI_API_KEY`. Separado por ser destrutivo (cria nova sessão).
+
+1. Carregar template, configurar API key
+2. Abrir Playground, enviar `"My name is Bob..."`
+3. Aguardar resposta aparecer
+4. Clicar em `session-selector-trigger` → `New Session`
+5. Aguardar `input-chat-playground` na nova sessão
+6. Verificar que `div-chat-message` count é `=== 0` (sessão começa vazia)
+
+---
+
+## Critério de validação *(obrigatório)*
+
+- Template carrega com exatamente 6 nós: Chat Input, Chat Output, Message History, OpenAI, Prompt Template, Type Convert
+- O LLM recorda o nome informado em mensagem anterior da mesma sessão ("Alice")
+- Mensagens acumulam no histórico (≥ 4 após 2 trocas)
+- O histórico persiste após fechar e reabrir o Playground
+- Uma nova sessão começa com 0 mensagens, sem herdar contexto de sessões anteriores
+
+---
+
+## Dependências externas *(obrigatório)*
+
+- `src/backend/base/langflow/initial_setup/starter_projects/memory_chatbot.py` — define o grafo do template; mudanças nos nós ou arestas quebram o Teste 1
+- `src/lfx/src/lfx/components/models_and_agents/memory.py` — `MemoryComponent` (`display_name = "Message History"`); renomear ou remover quebra o Teste 1 e o Teste 2
+- `src/lfx/src/lfx/components/openai/openai_chat_model.py` — `OpenAIModelComponent`; mudanças no campo `api_key` ou no `display_name` afetam Testes 1, 2 e 3
+- `src/frontend/src/components/core/playgroundComponent/` — `input-chat-playground`, `div-chat-message`, `playground-close-button`, `session-selector-trigger` — qualquer renomeação quebra Testes 2 e 3
+- `src/frontend/src/CustomNodes/GenericNode/components/NodeName/index.tsx` — `data-testid="title-{display_name}"` — mudança no padrão de testid quebra o Teste 1
+
+---
+
+## O que este teste não cobre *(opcional)*
+
+- Comportamento do Memory Chatbot com outros providers (Anthropic, Google) — o template usa `OpenAIModelComponent` diretamente
+- Validação do conteúdo da resposta da IA além da referência ao nome ("Alice")
+- Verificação de que, sem o nó `Message History` conectado, o contexto se perde (coberto conceitualmente pelo Teste 3: nova sessão = histórico zerado)
+- Persistência do histórico após restart do servidor Langflow
+
+---
+
+## Pré-condições *(opcional)*
+
+- Langflow rodando e acessível em `PLAYWRIGHT_BASE_URL`
+- `OPENAI_API_KEY` definida no `.env` para os Testes 2 e 3
+- Rodar com `--workers=1` para evitar conflito de flows
+
+---
+
+## Quando revisar este teste *(opcional)*
+
+- Se o template "Memory Chatbot" for removido ou renomeado em `starter_projects`
+- Se o `MemoryComponent` mudar de `display_name` ou a sessão padrão mudar de comportamento
+- Se o Playground ganhar confirmação modal ao criar nova sessão (Teste 3 precisará de step extra)
+
+---
+
+## Notas *(opcional)*
+
+- **Estrutura**: 3 testes — estrutura (sem API), suite de retenção (com `expect.soft`), isolamento de sessão (destrutivo, separado). O `expect.soft` garante visibilidade total das falhas sem abortar o suite.
+- **`popover-anchor-input-api_key`**: testid gerado dinamicamente pelo `parameterRenderComponent` com `data-testid={id}` onde `id = "popover-anchor-input-api_key"`. Se o campo não estiver visível (Langflow picking up a key from env), `configureOpenAIApiKey` silencia e o teste continua.
+- **`session-selector-trigger`**: botão `ListRestart` no header do Playground que abre o dropdown de sessões; "New Session" cria uma sessão com ID aleatório e limpa o histórico exibido.
+- **Teste 1 sem API key**: validação de estrutura pura — útil em CI sem keys configuradas.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/memory-history-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/memory-history-regression.spec.ts
@@ -1,0 +1,164 @@
+import * as dotenv from "dotenv";
+import path from "path";
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
+import { updateOldComponents } from "../../../../helpers/flows/update-old-components";
+import { FlowEditorPage, PlaygroundPage } from "../../../../pages";
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
+}
+
+async function loadMemoryChatbot(page: Page): Promise<void> {
+  await page.goto("/");
+  await page.waitForSelector('[data-testid="mainpage_title"]', { timeout: 30000 });
+
+  const emptyPageDescription = page.getByTestId("empty_page_description");
+  while ((await emptyPageDescription.count()) === 0) {
+    const dropdown = page.getByTestId("home-dropdown-menu").first();
+    if (!(await dropdown.isVisible({ timeout: 2000 }).catch(() => false))) break;
+    await dropdown.click();
+    await page.getByTestId("btn_delete_dropdown_menu").first().waitFor({ state: "visible", timeout: 5000 });
+    await page.getByTestId("btn_delete_dropdown_menu").first().click();
+    await page.getByTestId("btn_delete_delete_confirmation_modal").first().click();
+    await page.waitForTimeout(500);
+  }
+
+  const newProjectBtn = page.getByTestId("new-project-btn");
+  const emptyBtn = page.getByTestId("new_project_btn_empty_page");
+  if (await newProjectBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
+    await newProjectBtn.click();
+  } else {
+    await emptyBtn.click();
+  }
+
+  await page.waitForSelector('[data-testid="modal-title"]', { timeout: 10000 });
+  await page.getByTestId("side_nav_options_all-templates").click();
+  await page.getByRole("heading", { name: "Memory Chatbot" }).first().click();
+  await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', { timeout: 30000 });
+
+  await adjustScreenView(page);
+  await updateOldComponents(page);
+  await adjustScreenView(page);
+}
+
+async function configureOpenAIApiKey(page: Page): Promise<void> {
+  const apiKeyInput = page.getByTestId("popover-anchor-input-api_key");
+  if (await apiKeyInput.isVisible({ timeout: 5000 }).catch(() => false)) {
+    await apiKeyInput.fill(process.env.OPENAI_API_KEY ?? "");
+  }
+}
+
+async function waitForChatResponse(page: Page): Promise<void> {
+  await page.waitForSelector('[data-testid="div-chat-message"]', { timeout: 120000 });
+  const stopButton = page.getByRole("button", { name: "Stop" });
+  if (await stopButton.isVisible({ timeout: 3000 }).catch(() => false)) {
+    await expect(stopButton).toBeHidden({ timeout: 120000 });
+  }
+}
+
+test.describe("Memory Chatbot Regression", () => {
+  test(
+    "memory chatbot template loads with correct node structure",
+    { tag: ["@stable", "@release", "@agents", "@playground"] },
+    async ({ page }) => {
+      await loadMemoryChatbot(page);
+
+      await test.step("canvas has all 6 required nodes", async () => {
+        await expect.soft(page.getByTestId("title-Chat Input")).toBeVisible({ timeout: 10000 });
+        await expect.soft(page.getByTestId("title-Chat Output")).toBeVisible({ timeout: 10000 });
+        await expect.soft(page.getByTestId("title-Message History")).toBeVisible({ timeout: 10000 });
+        await expect.soft(page.getByTestId("title-OpenAI")).toBeVisible({ timeout: 10000 });
+        await expect.soft(page.getByTestId("title-Prompt Template")).toBeVisible({ timeout: 10000 });
+        await expect.soft(page.getByTestId("title-Type Convert")).toBeVisible({ timeout: 10000 });
+      });
+
+      await test.step("canvas has exactly 6 nodes", async () => {
+        const nodeCount = await page.locator(".react-flow__node").count();
+        expect.soft(nodeCount).toBe(6);
+      });
+    },
+  );
+
+  test(
+    "message history context retention suite",
+    { tag: ["@stable", "@release", "@agents", "@playground"] },
+    async ({ page }) => {
+      test.skip(
+        !process.env.OPENAI_API_KEY,
+        "OPENAI_API_KEY required to run this test",
+      );
+
+      await loadMemoryChatbot(page);
+      await configureOpenAIApiKey(page);
+
+      const flowEditor = new FlowEditorPage(page);
+      const playground = new PlaygroundPage(page);
+
+      await flowEditor.waitForCanvas();
+      await page.getByTestId("playground-btn-flow-io").click();
+      await page.waitForSelector('[data-testid="input-chat-playground"]', { timeout: 30000 });
+
+      await test.step("message history retains context within same session", async () => {
+        await playground.sendMessage("My name is Alice. Please confirm you received my name.");
+        await waitForChatResponse(page);
+        await expect.soft(page.getByTestId("div-chat-message").last()).toBeVisible({ timeout: 30000 });
+
+        await playground.sendMessage("What is my name?");
+        await waitForChatResponse(page);
+
+        const response = await page.getByTestId("div-chat-message").last().innerText();
+        expect.soft(response).toMatch(/Alice/i);
+      });
+
+      await test.step("multiple consecutive messages accumulate in history", async () => {
+        const count = await page.getByTestId("div-chat-message").count();
+        expect.soft(count).toBeGreaterThanOrEqual(4);
+      });
+
+      await test.step("messages persist after closing and reopening playground", async () => {
+        const messagesBefore = await page.getByTestId("div-chat-message").count();
+
+        await page.getByTestId("playground-close-button").click();
+        await page.waitForTimeout(500);
+
+        await page.getByTestId("playground-btn-flow-io").click();
+        await page.waitForSelector('[data-testid="input-chat-playground"]', { timeout: 30000 });
+
+        const messagesAfter = await page.getByTestId("div-chat-message").count();
+        expect.soft(messagesAfter).toBeGreaterThanOrEqual(messagesBefore);
+      });
+    },
+  );
+
+  test(
+    "session isolation: new session has no context from previous session",
+    { tag: ["@stable", "@release", "@agents", "@playground"] },
+    async ({ page }) => {
+      test.skip(
+        !process.env.OPENAI_API_KEY,
+        "OPENAI_API_KEY required to run this test",
+      );
+
+      await loadMemoryChatbot(page);
+      await configureOpenAIApiKey(page);
+
+      const playground = new PlaygroundPage(page);
+
+      await page.getByTestId("playground-btn-flow-io").click();
+      await page.waitForSelector('[data-testid="input-chat-playground"]', { timeout: 30000 });
+
+      await playground.sendMessage("My name is Bob. Please confirm you received my name.");
+      await waitForChatResponse(page);
+      await expect(page.getByTestId("div-chat-message").last()).toBeVisible({ timeout: 30000 });
+
+      await page.getByTestId("session-selector-trigger").click();
+      await page.getByText("New Session").click();
+      await page.waitForSelector('[data-testid="input-chat-playground"]', { timeout: 10000 });
+
+      const messagesInNewSession = await page.getByTestId("div-chat-message").count();
+      expect(messagesInNewSession).toBe(0);
+    },
+  );
+});

--- a/tests/tests-automations/regression/core-functionality/llm-agents/memory-history-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/memory-history-regression.spec.ts
@@ -4,7 +4,7 @@ import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { updateOldComponents } from "../../../../helpers/flows/update-old-components";
-import { FlowEditorPage, PlaygroundPage } from "../../../../pages";
+import { PlaygroundPage } from "../../../../pages";
 
 if (!process.env.CI) {
   dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
@@ -43,11 +43,62 @@ async function loadMemoryChatbot(page: Page): Promise<void> {
   await adjustScreenView(page);
 }
 
-async function configureOpenAIApiKey(page: Page): Promise<void> {
-  const apiKeyInput = page.getByTestId("popover-anchor-input-api_key");
-  if (await apiKeyInput.isVisible({ timeout: 5000 }).catch(() => false)) {
-    await apiKeyInput.fill(process.env.OPENAI_API_KEY ?? "");
+async function setupLanguageModelOpenAI(page: Page): Promise<void> {
+  const modelDropdown = page.getByTestId("model_model");
+  const hasModelDropdown = await modelDropdown.isVisible({ timeout: 5000 }).catch(() => false);
+
+  if (!hasModelDropdown) {
+    // "Setup Provider" opens the provider modal (no data-testid on this button)
+    await page.getByRole("button", { name: "Setup Provider" }).click();
+    await page.waitForSelector('[data-testid="provider-item-OpenAI"]', { timeout: 10000 });
+    await page.getByTestId("provider-item-OpenAI").click();
+
+    const apiKeyInput = page.getByPlaceholder("sk-...");
+    // Wait for the form panel to animate in before checking visibility
+    await apiKeyInput.waitFor({ state: "visible", timeout: 5000 }).catch(() => {});
+
+    const apiKey = process.env.OPENAI_API_KEY ?? "";
+    if ((await apiKeyInput.count()) > 0 && apiKey) {
+      await apiKeyInput.click();
+      await apiKeyInput.pressSequentially(apiKey, { delay: 0 });
+
+      const saveBtn = page.getByRole("button", { name: "Save", exact: true });
+      const replaceBtn = page.getByRole("button", { name: "Replace", exact: true });
+
+      if ((await saveBtn.count()) > 0) {
+        await saveBtn.click();
+      } else if ((await replaceBtn.count()) > 0) {
+        await replaceBtn.click();
+      }
+
+      // After save the button becomes "Replace" — wait for that to confirm save completed
+      await replaceBtn.waitFor({ state: "visible", timeout: 30000 });
+      // Wait for model toggles to load
+      await page.locator('[data-testid^="llm-toggle"]').first()
+        .waitFor({ state: "visible", timeout: 15000 })
+        .catch(() => {});
+    }
+
+    // Enable any model toggles that are off
+    const toggles = page.locator('[data-testid^="llm-toggle"]');
+    const toggleCount = await toggles.count();
+    for (let i = 0; i < toggleCount; i++) {
+      if ((await toggles.nth(i).getAttribute("aria-checked")) !== "true") {
+        await toggles.nth(i).click();
+      }
+    }
+
+    // Escape closes the Dialog and triggers refreshAllModelInputs on the node
+    await page.keyboard.press("Escape");
+    await modelDropdown.waitFor({ state: "visible", timeout: 30000 });
   }
+
+  await modelDropdown.click();
+  await page
+    .locator('[data-testid$="-option"]', { hasText: "gpt-4o-mini" })
+    .first()
+    .waitFor({ state: "visible", timeout: 10000 });
+  await page.locator('[data-testid$="-option"]', { hasText: "gpt-4o-mini" }).first().click();
 }
 
 async function waitForChatResponse(page: Page): Promise<void> {
@@ -69,9 +120,9 @@ test.describe("Memory Chatbot Regression", () => {
         await expect.soft(page.getByTestId("title-Chat Input")).toBeVisible({ timeout: 10000 });
         await expect.soft(page.getByTestId("title-Chat Output")).toBeVisible({ timeout: 10000 });
         await expect.soft(page.getByTestId("title-Message History")).toBeVisible({ timeout: 10000 });
-        await expect.soft(page.getByTestId("title-OpenAI")).toBeVisible({ timeout: 10000 });
+        await expect.soft(page.getByTestId("title-Language Model")).toBeVisible({ timeout: 10000 });
         await expect.soft(page.getByTestId("title-Prompt Template")).toBeVisible({ timeout: 10000 });
-        await expect.soft(page.getByTestId("title-Type Convert")).toBeVisible({ timeout: 10000 });
+        await expect.soft(page.getByTestId("note_node")).toBeVisible({ timeout: 10000 });
       });
 
       await test.step("canvas has exactly 6 nodes", async () => {
@@ -91,12 +142,10 @@ test.describe("Memory Chatbot Regression", () => {
       );
 
       await loadMemoryChatbot(page);
-      await configureOpenAIApiKey(page);
+      await setupLanguageModelOpenAI(page);
 
-      const flowEditor = new FlowEditorPage(page);
       const playground = new PlaygroundPage(page);
 
-      await flowEditor.waitForCanvas();
       await page.getByTestId("playground-btn-flow-io").click();
       await page.waitForSelector('[data-testid="input-chat-playground"]', { timeout: 30000 });
 
@@ -113,8 +162,9 @@ test.describe("Memory Chatbot Regression", () => {
       });
 
       await test.step("multiple consecutive messages accumulate in history", async () => {
+        // div-chat-message marks bot responses only; 2 exchanges → 2 bot responses
         const count = await page.getByTestId("div-chat-message").count();
-        expect.soft(count).toBeGreaterThanOrEqual(4);
+        expect.soft(count).toBeGreaterThanOrEqual(2);
       });
 
       await test.step("messages persist after closing and reopening playground", async () => {
@@ -142,7 +192,7 @@ test.describe("Memory Chatbot Regression", () => {
       );
 
       await loadMemoryChatbot(page);
-      await configureOpenAIApiKey(page);
+      await setupLanguageModelOpenAI(page);
 
       const playground = new PlaygroundPage(page);
 
@@ -153,9 +203,10 @@ test.describe("Memory Chatbot Regression", () => {
       await waitForChatResponse(page);
       await expect(page.getByTestId("div-chat-message").last()).toBeVisible({ timeout: 30000 });
 
-      await page.getByTestId("session-selector-trigger").click();
-      await page.getByText("New Session").click();
-      await page.waitForSelector('[data-testid="input-chat-playground"]', { timeout: 10000 });
+      // "new-chat" button is in the sessions sidebar (data-testid="new-chat")
+      await page.getByTestId("new-chat").click();
+      // Brief wait for session state to reset
+      await page.waitForTimeout(500);
 
       const messagesInNewSession = await page.getByTestId("div-chat-message").count();
       expect(messagesInNewSession).toBe(0);


### PR DESCRIPTION
## Summary

- Creates `memory-history-regression.spec.ts` with 3 `@stable` tests for the Memory Chatbot template
- Fixes all assertions to match the real nightly template structure (Language Model node, note node, no TypeConverter)
- Implements `setupLanguageModelOpenAI` — a local helper that configures OpenAI via the "Setup Provider" modal using the same pattern as `collect-models.ts` (`pressSequentially`, wait for "Replace" button, enable model toggles, Escape to close)
- Fixes `div-chat-message` count: testid marks bot responses only → `≥ 2`, not `≥ 4`
- Fixes new session creation: uses `data-testid="new-chat"` (sidebar button, always visible) instead of `session-selector-trigger` (header button behind animated wrapper)
- Adds spec doc under `docs/core-functionality/llm-agents/memory-history-regression.md` with all mandatory sections

## Test plan

- [ ] All 3 tests pass with `OPENAI_API_KEY` set (validated locally against nightly, 3/3 green, ~27s)
- [ ] Test 1 passes without API key (structure-only validation)
- [ ] Forced failure on `/Alice/i` regex confirms no false positive — received actual response "Your name is Alice."
- [ ] No backend errors (🚨 Backend Error) in any run
- [ ] QA-CHECKLIST entry `Memory Chatbot` updated to `[x]`

Closes #72