### PR TITLE
fix(ci): corrigir reporter, path do artifact e Node.js no weekly-stable

### DIFF
--- a/.github/workflows/weekly-stable.yml
+++ b/.github/workflows/weekly-stable.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/weekly-stable.yml
+++ b/.github/workflows/weekly-stable.yml
@@ -53,7 +53,7 @@ jobs:
         run: npx playwright install chromium --with-deps
 
       - name: Run @stable tests
-        run: npx playwright test --grep "@stable" --pass-with-no-tests --reporter=github
+        run: npx playwright test --grep "@stable" --pass-with-no-tests --reporter=blob,github
         env:
           CI: "true"
           PLAYWRIGHT_BASE_URL: "http://localhost:7860/"
@@ -64,7 +64,7 @@ jobs:
         if: always()
         with:
           name: playwright-report-weekly-${{ github.run_id }}
-          path: playwright-report/
+          path: blob-report/
           retention-days: 14
 
       - name: Upload test results on failure


### PR DESCRIPTION
## Summary

- Corrige o reporter do Playwright de `--reporter=github` para `--reporter=blob,github`: a flag via CLI sobrescrevia o reporter configurado no `playwright.config.ts` (`blob` em CI), fazendo o upload do artifact falhar toda semana porque `playwright-report/` nunca era gerado
- Atualiza o path do artifact de `playwright-report/` para `blob-report/`, que é onde o blob reporter grava por padrão
- Atualiza Node.js de `20` para `24` no `setup-node`: Node 20 será removido dos runners do GitHub Actions em setembro/2026 e já emite aviso de depreciação nos logs

## Test plan

- [ ] Verificar que o próximo run do weekly-stable gera e faz upload do artifact `playwright-report-weekly-*` com sucesso
- [ ] Verificar que as anotações inline do GitHub Actions continuam aparecendo nos logs (reporter `github` mantido)
- [ ] Confirmar ausência do aviso de depreciação de Node.js 20 nos logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)