### PR TITLE
fix(test): remover @stable do Loop component enquanto timeout é investigado

### DIFF
--- a/tests/tests-automations/regression/core-components/loop-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/loop-component-regression.spec.ts
@@ -105,7 +105,7 @@ test(
 
 test(
   "Loop component — Research Translation Loop template: full wiring and iterates over 2 ArXiv papers",
-  { tag: ["@stable", "@release", "@components", "@templates", "@playground"] },
+  { tag: ["@release", "@components", "@templates", "@playground"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 


### PR DESCRIPTION
## Summary

Remove a tag `@stable` do teste do Loop component que falhou por timeout no run de 2026-04-27, impedindo que continue poluindo o workflow semanal enquanto a causa é investigada.

O teste falhou nas 3 tentativas: o flow **Research Translation Loop** (ArXiv + LLM em loop) não produziu resposta dentro do timeout de 120s na infraestrutura de CI. A hipótese é que 120s é insuficiente para esse flow, não uma regressão do Langflow.

A tag `@stable` será devolvida no PR de correção após ajuste do timeout.

## Test plan

- [ ] Confirmar que o teste não aparece mais na listagem de `--grep "@stable"` após merge
- [ ] Confirmar que o teste continua acessível via `--grep "@release"` e demais tags funcionais

Closes #87
🤖 Generated with [Claude Code](https://claude.com/claude-code)