### PR TITLE
fix(helpers): use force:true on Radix dropdown clicks in cleanAllFlows

### DIFF
--- a/tests/helpers/flows/clean-all-flows.ts
+++ b/tests/helpers/flows/clean-all-flows.ts
@@ -8,12 +8,15 @@ export const cleanAllFlows = async (page: Page) => {
       { timeout: 20000 },
     );
     if ((await emptyPageDescription.count()) > 0) break;
-    await page.getByTestId("home-dropdown-menu").first().click();
+    await page.getByTestId("home-dropdown-menu").first().click({ force: true });
     await page.waitForSelector('[data-testid="btn_delete_dropdown_menu"]', {
       state: "visible",
       timeout: 5000,
     });
-    await page.getByTestId("btn_delete_dropdown_menu").first().click();
+    await page
+      .getByTestId("btn_delete_dropdown_menu")
+      .first()
+      .click({ force: true });
     await page
       .getByTestId("btn_delete_delete_confirmation_modal")
       .first()

--- a/tests/pages/MainPage.ts
+++ b/tests/pages/MainPage.ts
@@ -78,8 +78,14 @@ export class MainPage extends BasePage {
       "empty_page_description",
     );
     while ((await emptyPageDescription.count()) === 0) {
-      await this.page.getByTestId("home-dropdown-menu").first().click();
-      await this.page.getByTestId("btn_delete_dropdown_menu").first().click();
+      await this.page
+        .getByTestId("home-dropdown-menu")
+        .first()
+        .click({ force: true });
+      await this.page
+        .getByTestId("btn_delete_dropdown_menu")
+        .first()
+        .click({ force: true });
       await this.page
         .getByTestId("btn_delete_delete_confirmation_modal")
         .first()

--- a/tests/pages/MainPage.ts
+++ b/tests/pages/MainPage.ts
@@ -2,6 +2,7 @@ import type { Page } from "@playwright/test";
 import { BasePage } from "./BasePage";
 import { SidebarComponent } from "./SidebarComponent";
 import { addFlowToTestOnEmptyLangflow } from "../helpers/flows/add-flow-to-test-on-empty-langflow";
+import { cleanAllFlows as cleanAllFlowsHelper } from "../helpers/flows/clean-all-flows";
 
 export class MainPage extends BasePage {
   readonly sidebar: SidebarComponent;
@@ -74,24 +75,7 @@ export class MainPage extends BasePage {
   }
 
   async cleanAllFlows() {
-    const emptyPageDescription = this.page.getByTestId(
-      "empty_page_description",
-    );
-    while ((await emptyPageDescription.count()) === 0) {
-      await this.page
-        .getByTestId("home-dropdown-menu")
-        .first()
-        .click({ force: true });
-      await this.page
-        .getByTestId("btn_delete_dropdown_menu")
-        .first()
-        .click({ force: true });
-      await this.page
-        .getByTestId("btn_delete_delete_confirmation_modal")
-        .first()
-        .click();
-      await this.page.waitForTimeout(1000);
-    }
+    await cleanAllFlowsHelper(this.page);
   }
 
   // Folders / Projects


### PR DESCRIPTION
## Summary

- `cleanAllFlows` in `tests/helpers/flows/clean-all-flows.ts` and `MainPage.cleanAllFlows()` were failing with `element was detached from the DOM` on both `home-dropdown-menu` and `btn_delete_dropdown_menu`
- Root cause: Radix UI remounts the DropdownMenu trigger during React re-renders and remounts the `DropdownMenuContent` portal during its entry animation — Playwright resolves the element, then it detaches before the click dispatches
- Fix: add `{ force: true }` to both clicks, bypassing Playwright's stability check; the elements are genuinely interactable at that point, so this is safe

## Files changed

| File | Change |
|---|---|
| `tests/helpers/flows/clean-all-flows.ts` | `{ force: true }` on both dropdown clicks |
| `tests/pages/MainPage.ts` | same fix in `cleanAllFlows()` method |

Closes #92