### PR TITLE
refactor(playground-empty-message-send): adopt shared setupPlayground helper

### DIFF
--- a/tests/tests-automations/regression/core-functionality/playground/playground-empty-message-send.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-empty-message-send.spec.ts
@@ -1,66 +1,26 @@
 import { expect, test } from "../../../../fixtures/fixtures";
-import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
-import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
-import { zoomOut } from "../../../../helpers/ui/zoom-out";
-
-// Helper: builds a connected ChatInput → ChatOutput flow and opens the Playground.
-async function setupPlayground(page: any) {
-  await awaitBootstrapTest(page);
-  await page.waitForSelector('[data-testid="blank-flow"]', { timeout: 30000 });
-  await page.getByTestId("blank-flow").click();
-
-  // Add ChatOutput first via hover-click (lands at default canvas centre)
-  await page.getByTestId("sidebar-search-input").fill("chat output");
-  await page.waitForSelector('[data-testid="input_outputChat Output"]', {
-    timeout: 30000,
-  });
-  await page.getByTestId("input_outputChat Output").hover();
-  await page.getByTestId("add-component-button-chat-output").click();
-
-  await zoomOut(page, 2);
-
-  // Add ChatInput via dragTo so it lands at a different position
-  await page.getByTestId("sidebar-search-input").fill("chat input");
-  await page.waitForSelector('[data-testid="input_outputChat Input"]', {
-    timeout: 30000,
-  });
-  await page
-    .getByTestId("input_outputChat Input")
-    .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-      targetPosition: { x: 100, y: 100 },
-    });
-
-  await adjustScreenView(page);
-
-  await expect(page.locator(".react-flow__node")).toHaveCount(2, {
-    timeout: 10000,
-  });
-
-  // Connect: click ChatInput source handle, then ChatOutput target handle
-  await page
-    .getByTestId("handle-chatinput-noshownode-chat message-source")
-    .click();
-  await page
-    .getByTestId("handle-chatoutput-noshownode-inputs-target")
-    .click();
-
-  await expect(page.locator(".react-flow__edge")).toHaveCount(1, {
-    timeout: 8000,
-  });
-
-  // Open Playground
-  await page.getByTestId("playground-btn-flow-io").click();
-  await page.waitForSelector('[data-testid="input-chat-playground"]', {
-    timeout: 15000,
-  });
-}
+import { setupPlayground } from "../../../../helpers/flows/setup-playground";
 
 test.describe("Playground Empty-Message Send Behavior", () => {
+  let createdFlowId: string | null = null;
+
+  test.afterEach(async ({ page }) => {
+    if (createdFlowId) {
+      await page.goto("/");
+      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      createdFlowId = null;
+    }
+  });
+
   test(
     "send button is enabled when input is empty (Langflow bug)",
     { tag: ["@release", "@workspace", "@regression", "@playground"] },
     async ({ page }) => {
-      await setupPlayground(page);
+      createdFlowId = await setupPlayground(page);
+      await page.getByTestId("playground-btn-flow-io").click();
+      await page.waitForSelector('[data-testid="input-chat-playground"]', {
+        timeout: 15000,
+      });
 
       const input = page.getByTestId("input-chat-playground").last();
       const sendBtn = page.getByTestId("button-send").last();
@@ -82,7 +42,11 @@ test.describe("Playground Empty-Message Send Behavior", () => {
     "send button becomes enabled after typing a message",
     { tag: ["@release", "@workspace", "@regression", "@playground"] },
     async ({ page }) => {
-      await setupPlayground(page);
+      createdFlowId = await setupPlayground(page);
+      await page.getByTestId("playground-btn-flow-io").click();
+      await page.waitForSelector('[data-testid="input-chat-playground"]', {
+        timeout: 15000,
+      });
 
       const input = page.getByTestId("input-chat-playground").last();
       const sendBtn = page.getByTestId("button-send").last();
@@ -100,7 +64,11 @@ test.describe("Playground Empty-Message Send Behavior", () => {
     "clearing the input after typing leaves the field empty",
     { tag: ["@release", "@workspace", "@regression", "@playground"] },
     async ({ page }) => {
-      await setupPlayground(page);
+      createdFlowId = await setupPlayground(page);
+      await page.getByTestId("playground-btn-flow-io").click();
+      await page.waitForSelector('[data-testid="input-chat-playground"]', {
+        timeout: 15000,
+      });
 
       const input = page.getByTestId("input-chat-playground").last();
 


### PR DESCRIPTION
## Summary

- Removes the local `setupPlayground` function (lines 7–56) that duplicated the shared helper
- Imports `setupPlayground` from `helpers/flows/setup-playground`
- Removes now-unused imports (`adjustScreenView`, `awaitBootstrapTest`, `zoomOut`)
- Adds `afterEach` that deletes the created flow via API, following the pattern from `playground-fullscreen.spec.ts`
- Moves the playground-open step (`playground-btn-flow-io` click + wait for selector) into each test body — the shared helper does not open the playground

## Test plan

- [ ] Run `npx playwright test tests/tests-automations/regression/core-functionality/playground/playground-empty-message-send.spec.ts` and confirm all 3 tests pass
- [ ] Confirm no backend errors logged (`🚨 Backend Error:`)
- [ ] Confirm flow is deleted after each test (no leftover flows in Langflow)

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)