### PR TITLE
chore(playground): add @stable tag and spec doc for empty-message-send

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -403,7 +403,7 @@
 - [-] Response polling → `withEventDeliveryModes` (polling mode)
 - [-] Direct response → `withEventDeliveryModes` (direct mode)
 - [x] Playground UX (playground-ux) → `playground/playground-ux.spec.ts`
-- [!] Send empty message — should disable send button → `playground/playground-empty-message-send.spec.ts` (**BUG: button enabled even when empty**)
+- [x] Send empty message — should disable send button → `playground/playground-empty-message-send.spec.ts` (**BUG: button enabled even when empty**)
 - [ ] Send message while response is in progress — should wait or queue
 - [x] Attach image in chat — compact preview appears in input before sending → `core-functionality/playground/playground-output-image.spec.ts`
 - [x] Image rendered in user message bubble after sending → `core-functionality/playground/playground-output-image.spec.ts`

--- a/docs/core-functionality/playground/playground-empty-message-send.md
+++ b/docs/core-functionality/playground/playground-empty-message-send.md
@@ -82,5 +82,5 @@ References in this repository:
 
 ## Notes *(optional)*
 
-- Test 1 intentionally documents a **known Langflow bug**: the send button remains enabled on empty input. The assertion uses `toBeEnabled()` to reflect actual behavior; once the bug is fixed, the assertion must be changed to `toBeDisabled()` and the test name updated.
+- Test 1 intentionally documents a **known Langflow bug**: the send button remains enabled on empty input. It reflects actual behavior; once the bug is fixed, the assertion must be updated to expect the button to be disabled and the test name updated accordingly.
 - The ChatInput → ChatOutput flow is deterministic and requires no LLM or API keys.

--- a/docs/core-functionality/playground/playground-empty-message-send.md
+++ b/docs/core-functionality/playground/playground-empty-message-send.md
@@ -1,0 +1,86 @@
+# Playground — Empty Message Send Behavior
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+Validates send button state and input field behavior in the Playground when dealing with empty input. Covers three scenarios: send button state when the input is empty (documenting a known Langflow bug), send button state after typing a message, and input field state after clearing typed content.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@regression` `@workspace` `@playground`
+
+---
+
+## Step by step *(required)*
+
+**Test 1 — send button is enabled when input is empty (Langflow bug)**
+1. Create a blank flow with ChatInput connected to ChatOutput via `setupPlayground`
+2. Open the Playground via `playground-btn-flow-io`
+3. Wait for `input-chat-playground` to be visible
+4. Confirm the input value is `""` (empty)
+5. Assert that `button-send` is **enabled** — documents the current buggy behavior
+
+**Test 2 — send button becomes enabled after typing a message**
+1. Create a blank flow with ChatInput connected to ChatOutput via `setupPlayground`
+2. Open the Playground via `playground-btn-flow-io`
+3. Wait for `input-chat-playground` to be visible
+4. Fill the input with `"Hello, Langflow!"`
+5. Confirm the input holds the typed value
+6. Assert that `button-send` is enabled
+
+**Test 3 — clearing the input after typing leaves the field empty**
+1. Create a blank flow with ChatInput connected to ChatOutput via `setupPlayground`
+2. Open the Playground via `playground-btn-flow-io`
+3. Wait for `input-chat-playground` to be visible
+4. Fill the input with `"some message"` and confirm the value
+5. Call `input.clear()` on the input
+6. Assert the input value is `""` (empty)
+
+---
+
+## Validation criterion *(required)*
+
+- **Test 1 (bug documentation):** `button-send` is enabled even when `input-chat-playground` is empty. This assertion reflects the **current buggy behavior**; it must be updated to `toBeDisabled()` once Langflow fixes the issue.
+- **Test 2:** `button-send` is enabled after the user types a non-empty message.
+- **Test 3:** `input-chat-playground` has value `""` after `input.clear()` is called on a previously filled field.
+
+---
+
+## External dependencies *(required)*
+
+References in the **main Langflow repository** (compatible with Langflow 1.10.x):
+
+- `src/frontend/src/components/core/playgroundComponent/chat-view/chat-input/components/text-area-wrapper.tsx` — defines `data-testid="input-chat-playground"`
+- `src/frontend/src/components/core/playgroundComponent/chat-view/chat-input/components/button-send-wrapper.tsx` — defines `data-testid="button-send"`
+- `src/frontend/src/components/ui/simple-sidebar.tsx` — defines `data-testid="playground-btn-flow-io"`
+
+References in this repository:
+
+- `tests/helpers/flows/setup-playground.ts` — shared helper that creates the ChatInput → ChatOutput flow and returns its ID for cleanup
+
+---
+
+## What this test does not cover *(optional)*
+
+- Sending a message while a response is in progress
+- Streaming, polling, and direct response modes
+- Voice mode and advanced Playground features
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
+- No pre-existing flow needed; the `setupPlayground` helper creates the flow and the `afterEach` deletes it via `DELETE /api/v1/flows/{id}`
+
+---
+
+## Notes *(optional)*
+
+- Test 1 intentionally documents a **known Langflow bug**: the send button remains enabled on empty input. The assertion uses `toBeEnabled()` to reflect actual behavior; once the bug is fixed, the assertion must be changed to `toBeDisabled()` and the test name updated.
+- The ChatInput → ChatOutput flow is deterministic and requires no LLM or API keys.

--- a/docs/core-functionality/playground/playground-empty-message-send.md
+++ b/docs/core-functionality/playground/playground-empty-message-send.md
@@ -45,9 +45,9 @@ Validates send button state and input field behavior in the Playground when deal
 
 ## Validation criterion *(required)*
 
-- **Test 1 (bug documentation):** `button-send` is enabled even when `input-chat-playground` is empty. This assertion reflects the **current buggy behavior**; it must be updated to `toBeDisabled()` once Langflow fixes the issue.
+- **Test 1 (bug documentation):** `button-send` is enabled even when `input-chat-playground` is empty. This reflects the **current buggy behavior**; the assertion must be updated to expect the button to be disabled once Langflow fixes the issue.
 - **Test 2:** `button-send` is enabled after the user types a non-empty message.
-- **Test 3:** `input-chat-playground` has value `""` after `input.clear()` is called on a previously filled field.
+- **Test 3:** The message input field is empty after previously entered text is cleared.
 
 ---
 

--- a/tests/tests-automations/regression/core-functionality/playground/playground-empty-message-send.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-empty-message-send.spec.ts
@@ -14,7 +14,7 @@ test.describe("Playground Empty-Message Send Behavior", () => {
 
   test(
     "send button is enabled when input is empty (Langflow bug)",
-    { tag: ["@release", "@workspace", "@regression", "@playground"] },
+    { tag: ["@stable", "@release", "@workspace", "@regression", "@playground"] },
     async ({ page }) => {
       createdFlowId = await setupPlayground(page);
       await page.getByTestId("playground-btn-flow-io").click();
@@ -40,7 +40,7 @@ test.describe("Playground Empty-Message Send Behavior", () => {
 
   test(
     "send button becomes enabled after typing a message",
-    { tag: ["@release", "@workspace", "@regression", "@playground"] },
+    { tag: ["@stable", "@release", "@workspace", "@regression", "@playground"] },
     async ({ page }) => {
       createdFlowId = await setupPlayground(page);
       await page.getByTestId("playground-btn-flow-io").click();
@@ -62,7 +62,7 @@ test.describe("Playground Empty-Message Send Behavior", () => {
 
   test(
     "clearing the input after typing leaves the field empty",
-    { tag: ["@release", "@workspace", "@regression", "@playground"] },
+    { tag: ["@stable", "@release", "@workspace", "@regression", "@playground"] },
     async ({ page }) => {
       createdFlowId = await setupPlayground(page);
       await page.getByTestId("playground-btn-flow-io").click();


### PR DESCRIPTION
## Summary

- Adds `@stable` to all three tests in `playground-empty-message-send.spec.ts`
- Creates `docs/core-functionality/playground/playground-empty-message-send.md` with all mandatory sections
- Updates `QA-CHECKLIST.md` coverage symbol from `[!]` to `[x]`

## Notes

- Test 1 intentionally documents a **known Langflow bug**: the send button remains enabled on empty input. The spec doc calls this out explicitly under **Validation criterion** so it's clear the assertion must be flipped to `toBeDisabled()` once the bug is fixed.
- No logic changes — only tag additions and documentation.

Closes #102