### PR TITLE
chore(playground): add @stable to playground-ux tests

### DIFF
--- a/docs/core-functionality/playground/playground-ux.md
+++ b/docs/core-functionality/playground/playground-ux.md
@@ -12,7 +12,7 @@ Validates the chat UX behavior in the Playground using a deterministic flow (Cha
 
 ## Tags *(required)*
 
-`@release` `@regression` `@playground`
+`@release` `@regression` `@playground` `@stable`
 
 ---
 

--- a/tests/tests-automations/regression/core-functionality/playground/playground-ux.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-ux.spec.ts
@@ -16,7 +16,7 @@ test.describe("Playground UX", () => {
 
   test(
     "user message must appear instantly in playground before AI responds",
-    { tag: ["@release", "@regression", "@playground"] },
+    { tag: ["@release", "@regression", "@playground", "@stable"] },
     async ({ page }) => {
       await test.step("Set up ChatInput → ChatOutput flow and open playground", async () => {
         createdFlowId = await setupPlayground(page);
@@ -46,7 +46,7 @@ test.describe("Playground UX", () => {
 
   test(
     "playground must scroll to latest message after sending",
-    { tag: ["@release", "@regression", "@playground"] },
+    { tag: ["@release", "@regression", "@playground", "@stable"] },
     async ({ page }) => {
       await test.step("Set up ChatInput → ChatOutput flow and open playground", async () => {
         createdFlowId = await setupPlayground(page);
@@ -80,7 +80,7 @@ test.describe("Playground UX", () => {
 
   test(
     "playground input field must be ready after flow responds",
-    { tag: ["@release", "@regression", "@playground"] },
+    { tag: ["@release", "@regression", "@playground", "@stable"] },
     async ({ page }) => {
       await test.step("Set up ChatInput → ChatOutput flow and open playground", async () => {
         createdFlowId = await setupPlayground(page);


### PR DESCRIPTION
## Summary

- Added `@stable` to all 3 tests in `playground-ux.spec.ts`
- Updated `docs/core-functionality/playground/playground-ux.md` to include `@stable` in the Tags section

## Validation

- All 3 tests passed with `--trace=on` (31s, no retries)
- No backend errors (`🚨 Backend Error:`) during the run
- Spec doc was already complete — only the Tags section was missing `@stable`

Closes #110