### PR TITLE
fix(ui-ux): refactor theme toggle test to validate body class correctly

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -643,7 +643,7 @@
 #### 15.10 Settings and UI Configuration
 - [-] Access Settings page
 - [-] Message history settings
-- [-] Change appearance/theme settings
+- [x] Change appearance/theme settings — dark/light toggle updates #body.dark class → `ui-ux/settings-theme-toggle.spec.ts`
 - [-] Keyboard shortcuts work in editor
 - [~] All documented shortcuts work
 

--- a/docs/ui-ux/settings-theme-toggle.md
+++ b/docs/ui-ux/settings-theme-toggle.md
@@ -1,0 +1,32 @@
+# Spec: Settings — Theme Toggle
+
+**Test file:** `tests/tests-automations/regression/ui-ux/settings-theme-toggle.spec.ts`
+
+## What this test validates
+
+Verifies that the dark/light mode toggle in the Account Menu correctly updates the application theme by adding or removing the `dark` class on the `#body` element.
+
+The test normalizes to light mode, switches to dark (`menu_dark_button`), confirms `#body.dark` is attached to the DOM, switches back to light (`menu_light_button`), confirms `#body.dark` is detached, then restores system theme.
+
+Key implementation detail: `ThemeButtons` uses plain `<Button>` elements (not Radix `DropdownMenuItem`), so the Account Menu does **not** close automatically after a theme click. `Escape` is pressed after each click to dismiss the menu before re-opening it for the next step.
+
+## Tags
+
+`@release` `@stable` `@settings` `@ui-ux`
+
+## Validation criterion
+
+| Step | Criterion |
+|---|---|
+| After clicking `menu_dark_button` | `page.locator("#body.dark").toBeAttached()` passes |
+| After clicking `menu_light_button` | `page.locator("#body.dark").not.toBeAttached()` passes |
+
+## External dependencies
+
+- `src/frontend/src/components/core/appHeaderComponent/components/ThemeButtons/index.tsx` — `menu_dark_button`, `menu_light_button`, `menu_system_button` test IDs. Any rename breaks the test.
+- `src/frontend/src/App.tsx` — applies `.dark` class to `document.getElementById("body")`. If this changes to `document.documentElement`, update the `#body.dark` locator to `html.dark`.
+- `src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx` — `user-profile-settings` test ID.
+
+## Last validated
+
+1.10.x

--- a/tests/tests-automations/regression/ui-ux/settings-theme-toggle.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/settings-theme-toggle.spec.ts
@@ -1,145 +1,63 @@
 import { expect, test } from "../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 
-test(
-  "user profile menu has theme toggle buttons",
-  { tag: ["@release", "@workspace", "@regression", "@settings"] },
-  async ({ page }) => {
-    await awaitBootstrapTest(page, { skipModal: true });
-
-    // Open user profile menu
-    await page.getByTestId("user-profile-settings").click();
-    await page.waitForTimeout(400);
-
-    // Menu should show Theme section
-    const themeText = await page
-      .getByText(/theme/i)
-      .first()
-      .isVisible({ timeout: 5000 })
-      .catch(() => false);
-
-    expect(themeText, "User profile menu should have a Theme section").toBe(true);
-  },
-);
-
-test(
-  "theme can be toggled between light and dark mode",
-  { tag: ["@release", "@workspace", "@regression", "@settings"] },
-  async ({ page }) => {
-    await awaitBootstrapTest(page, { skipModal: true });
-
-    // Capture initial theme by checking html class
-    const initialHtmlClass = await page
-      .locator("html")
-      .getAttribute("class")
-      .catch(() => "");
-    const initialTheme = initialHtmlClass?.includes("dark") ? "dark" : "light";
-
-    // Open user profile menu
-    await page.getByTestId("user-profile-settings").click();
-    await page.waitForTimeout(400);
-
-    // Look for dark mode / light mode toggle button
-    const darkBtn = page
-      .locator('[data-testid*="dark"], button[aria-label*="dark"]')
-      .first();
-    const lightBtn = page
-      .locator('[data-testid*="light"], button[aria-label*="light"]')
-      .first();
-
-    const hasDarkBtn = await darkBtn
-      .isVisible({ timeout: 3000 })
-      .catch(() => false);
-    const hasLightBtn = await lightBtn
-      .isVisible({ timeout: 3000 })
-      .catch(() => false);
-
-    if (!hasDarkBtn && !hasLightBtn) {
-      // Try clicking a Theme button by text
-      const themeBtn = page.getByRole("button", { name: /dark|light|system/i }).first();
-      const hasThemeBtn = await themeBtn
-        .isVisible({ timeout: 3000 })
-        .catch(() => false);
-
-      if (!hasThemeBtn) {
-        console.log("INFO: Theme toggle buttons not found in expected location, skipping");
-        return;
-      }
-
-      await themeBtn.click();
-      await page.waitForTimeout(500);
-    } else {
-      // Click the opposite of current theme
-      if (initialTheme === "dark" && hasLightBtn) {
-        await lightBtn.click();
-      } else if (hasDarkBtn) {
-        await darkBtn.click();
-      }
-      await page.waitForTimeout(500);
-    }
-
-    // Close menu
-    await page.keyboard.press("Escape");
-    await page.waitForTimeout(300);
-
-    // Verify the html class changed to reflect the new theme
-    const newHtmlClass = await page
-      .locator("html")
-      .getAttribute("class")
-      .catch(() => "");
-
-    // The class should be different from initial OR contain the expected theme class
-    const themeChanged = newHtmlClass !== initialHtmlClass;
-    const safeClass = newHtmlClass ?? "";
-    const themeClassPresent = safeClass.includes("dark") || safeClass.includes("light");
-
-    // Langflow may apply theme via data-theme attribute or body class instead of html class
-    if (!themeChanged && !themeClassPresent) {
-      console.log("INFO: Theme not detectable via html.class — may use data-theme attribute or body class");
-      return;
-    }
-
-    expect(
-      themeChanged || themeClassPresent,
-      "Theme toggle should update the document class",
-    ).toBe(true);
-  },
-);
-
-test(
-  "settings page displays current theme configuration",
-  { tag: ["@release", "@workspace", "@regression", "@settings"] },
-  async ({ page }) => {
-    await awaitBootstrapTest(page, { skipModal: true });
-
-    // Navigate directly to settings
-    await page.goto("/settings");
-    await page.waitForTimeout(1000);
-
-    const currentUrl = page.url();
-
-    if (!currentUrl.includes("/settings")) {
-      // Redirected to main page — settings not available at this URL
-      await expect(page.getByTestId("mainpage_title")).toBeVisible({
-        timeout: 10000,
+test.describe("Settings — Theme Toggle", () => {
+  test(
+    "dark and light mode toggle correctly updates the body class",
+    { tag: ["@release", "@stable", "@settings", "@ui-ux"] },
+    async ({ page }) => {
+      await test.step("load home page", async () => {
+        await awaitBootstrapTest(page, { skipModal: true });
       });
-      return;
-    }
 
-    // Settings page has loaded — look for appearance/theme section
-    const appearanceSection = await page
-      .getByText(/appearance|theme|dark.*mode|display/i)
-      .first()
-      .isVisible({ timeout: 8000 })
-      .catch(() => false);
+      await test.step("normalize to light mode", async () => {
+        await page.getByTestId("user-profile-settings").click();
+        await expect(page.getByTestId("menu_light_button")).toBeVisible({
+          timeout: 5000,
+        });
+        await page.getByTestId("menu_light_button").click();
+        await expect(page.locator("#body.dark")).not.toBeAttached({
+          timeout: 5000,
+        });
+        // Theme buttons are not DropdownMenuItems and do not close the dropdown automatically.
+        // Press Escape to dismiss the menu before the next step.
+        await page.keyboard.press("Escape");
+        await expect(page.getByRole("menu")).toBeHidden({ timeout: 5000 });
+      });
 
-    const settingsContent = await page
-      .locator("body")
-      .evaluate((el) => (el as HTMLElement).innerText.length > 50);
+      await test.step("switch to dark mode and verify body class", async () => {
+        await page.getByTestId("user-profile-settings").click();
+        await expect(page.getByTestId("menu_dark_button")).toBeVisible({
+          timeout: 5000,
+        });
+        await page.getByTestId("menu_dark_button").click();
+        await expect(page.locator("#body.dark")).toBeAttached({ timeout: 5000 });
+        await page.keyboard.press("Escape");
+        await expect(page.getByRole("menu")).toBeHidden({ timeout: 5000 });
+      });
 
-    expect(
-      appearanceSection || settingsContent,
-      "Settings page should show appearance or theme options",
-    ).toBe(true);
-  },
-);
+      await test.step("switch to light mode and verify body class", async () => {
+        await page.getByTestId("user-profile-settings").click();
+        await expect(page.getByTestId("menu_light_button")).toBeVisible({
+          timeout: 5000,
+        });
+        await page.getByTestId("menu_light_button").click();
+        await expect(page.locator("#body.dark")).not.toBeAttached({
+          timeout: 5000,
+        });
+        await page.keyboard.press("Escape");
+        await expect(page.getByRole("menu")).toBeHidden({ timeout: 5000 });
+      });
+
+      await test.step("restore system theme", async () => {
+        await page.getByTestId("user-profile-settings").click();
+        await expect(page.getByTestId("menu_system_button")).toBeVisible({
+          timeout: 5000,
+        });
+        await page.getByTestId("menu_system_button").click();
+        await page.keyboard.press("Escape");
+        await expect(page.getByRole("menu")).toBeHidden({ timeout: 5000 });
+      });
+    },
+  );
+});


### PR DESCRIPTION
## What this PR fixes

The existing `settings-theme-toggle.spec.ts` had 3 tests that were all false positives — they passed without validating anything real:

- **Test 1:** checked if text `"theme"` was visible — trivially true
- **Test 2:** checked `.dark` on `<html>` instead of `#body` (wrong element); when it couldn't detect the class, printed `INFO: Theme not detectable` and returned early — passing without asserting
- **Test 3:** asserted `body.innerText.length > 50` — always true on any loaded page

Root cause: Langflow applies `.dark` to `document.getElementById("body")`, not `document.documentElement`. All three tests were checking the wrong element.

---

## Covered tests

| # | Test | What it validates |
|---|---|---|
| 1 | `dark and light mode toggle correctly updates the body class` | Clicking `menu_dark_button` attaches `.dark` to `#body`; clicking `menu_light_button` removes it. The system correctly applies and reverts the dark theme class on the document body. |

---

## How the test was built

The test uses `page.locator("#body.dark").toBeAttached()` / `.not.toBeAttached()` as the sole assertions — Playwright's auto-retry mechanism polls until the DOM mutation from the React state update settles, eliminating the race condition that `page.evaluate()` would introduce.

Key discovery during test execution: `ThemeButtons` renders plain `<Button>` elements inside the Radix `DropdownMenuContent` (not `DropdownMenuItem`). Radix only auto-closes the dropdown on `DropdownMenuItem` clicks — theme buttons leave the dropdown open. The open dropdown overlays the page and blocks subsequent pointer events. The fix: `Escape` is pressed after each theme button click, followed by `expect(getByRole("menu")).toBeHidden()` to confirm the dropdown is closed before the next step re-opens it.

State normalization: the test clicks `menu_light_button` at the start to establish a known starting state regardless of what previous tests or OS theme preference left behind.

---

## Dependencies

- No API key, no flow creation, no `afterEach` cleanup
- Execution: single test, no `serial` mode needed
- Requires Langflow running with the Account Menu accessible

---

## What this test does not cover

- Settings page Appearance section (same `ThemeButtons` component — YAGNI)
- System theme mode (OS-dependent, non-deterministic in CI)
- Theme persistence across page reload (separate concern)

---

## Validation

- [x] Test ran: 1/1 passed (3.7s)
- [x] Forced false positive confirmed: original tests passed even when `#body` never had `.dark` — proven by the `INFO:` log in test output
- [x] No backend errors (`🚨` not logged)
- [x] Spec doc: `docs/ui-ux/settings-theme-toggle.md`
- [x] QA-CHECKLIST.md updated: `[-]` → `[x]`