### PR TITLE
fix: restore @stable on JSON Data test; replace cleanAllFlows UI with REST API

### DIFF
--- a/docs/core-functionality/playground/playground-output-data.md
+++ b/docs/core-functionality/playground/playground-output-data.md
@@ -29,4 +29,4 @@ None. The tests use the native Langflow **Mock Data** component — no API key o
 
 ## Last validated
 
-1.10.x (re-validated after #120 — `runNoInputFlow` now waits for first message instead of exact count 2; `cleanAllFlows` retry wrapper added for Radix dropdown race)
+1.10.x (re-validated after #120 — `runNoInputFlow` now waits for first message instead of exact count 2; `cleanAllFlows` replaced with REST API-based flow deletion)

--- a/docs/core-functionality/playground/playground-output-data.md
+++ b/docs/core-functionality/playground/playground-output-data.md
@@ -13,7 +13,7 @@ Verifies that the Playground correctly renders structured data outputs generated
 
 | Test | Tags |
 |---|---|
-| JSON Data output as code block | `@release` `@regression` `@playground` _(`@stable` removed — tracked in [#120](https://github.com/oriontech-me/langflow-e2e/issues/120))_ |
+| JSON Data output as code block | `@stable` `@release` `@regression` `@playground` |
 | DataFrame output as Markdown table | `@stable` `@release` `@regression` `@playground` |
 
 ## Validation criterion
@@ -29,4 +29,4 @@ None. The tests use the native Langflow **Mock Data** component — no API key o
 
 ## Last validated
 
-1.10.x
+1.10.x (re-validated after #120 — `runNoInputFlow` now waits for first message instead of exact count 2; `cleanAllFlows` retry wrapper added for Radix dropdown race)

--- a/tests/helpers/flows/clean-all-flows.ts
+++ b/tests/helpers/flows/clean-all-flows.ts
@@ -1,21 +1,38 @@
-import { Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 
+/**
+ * Deletes all user-created flows via the Langflow REST API.
+ *
+ * The UI dropdown that previously handled this is a Radix UI portal element
+ * that detaches from the DOM mid-click under page re-renders, making it
+ * unreliable for cleanup. The API approach is deterministic and fast.
+ *
+ * Works in the default auto_login mode; falls back gracefully if the token
+ * endpoint is unavailable (flows simply won't be deleted in that case).
+ */
 export const cleanAllFlows = async (page: Page) => {
-  const emptyPageDescription = page.getByTestId("empty_page_description");
-  while (true) {
-    await page.waitForSelector(
-      '[data-testid="empty_page_description"], [data-testid="home-dropdown-menu"]',
-      { timeout: 20000 },
-    );
-    if ((await emptyPageDescription.count()) > 0) break;
-    await page.getByTestId("home-dropdown-menu").first().click();
-    await page
-      .getByTestId("btn_delete_dropdown_menu")
-      .first()
-      .click({ timeout: 8000 });
-    await page
-      .getByTestId("btn_delete_delete_confirmation_modal")
-      .first()
-      .click();
+  // Obtain a bearer token via auto_login (no credentials required in dev/test).
+  const loginRes = await page.request.get("/api/v1/auto_login");
+  let headers: Record<string, string> = {};
+  if (loginRes.ok()) {
+    const body = await loginRes.json();
+    if (body?.access_token) {
+      headers = { Authorization: `Bearer ${body.access_token}` };
+    }
+  }
+
+  // List only user-created flows (remove_example_flows excludes starter projects).
+  const listRes = await page.request.get("/api/v1/flows/", {
+    headers,
+    params: { get_all: "true", remove_example_flows: "true" },
+  });
+
+  if (!listRes.ok()) return;
+
+  const flows: Array<{ id: string }> = await listRes.json();
+  if (!Array.isArray(flows) || flows.length === 0) return;
+
+  for (const flow of flows) {
+    await page.request.delete(`/api/v1/flows/${flow.id}`, { headers });
   }
 };

--- a/tests/helpers/flows/clean-all-flows.ts
+++ b/tests/helpers/flows/clean-all-flows.ts
@@ -29,8 +29,9 @@ export const cleanAllFlows = async (page: Page) => {
 
   if (!listRes.ok()) return;
 
-  const flows: Array<{ id: string }> = await listRes.json();
-  if (!Array.isArray(flows) || flows.length === 0) return;
+  const raw = await listRes.json();
+  const flows: Array<{ id: string }> = Array.isArray(raw) ? raw : (raw.flows ?? []);
+  if (flows.length === 0) return;
 
   for (const flow of flows) {
     await page.request.delete(`/api/v1/flows/${flow.id}`, { headers });

--- a/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
@@ -88,9 +88,11 @@ async function runNoInputFlow(page: Page): Promise<void> {
     timeout: 60000,
   });
   // The AI response message is stored asynchronously after the build stream ends.
-  // Wait for both the empty user-trigger and the AI response to appear in the DOM.
-  await expect(page.getByTestId("div-chat-message")).toHaveCount(2, {
-    timeout: 15000,
+  // Wait for at least one message to appear. The exact count (1 or 2) depends on
+  // whether the backend stores the no-input user trigger, which varies across
+  // Langflow versions, so checking for first() is more resilient than toHaveCount(2).
+  await expect(page.getByTestId("div-chat-message").first()).toBeVisible({
+    timeout: 30000,
   });
 }
 
@@ -102,7 +104,7 @@ test.describe("Playground Output – Structured Data", () => {
 
   test(
     "playground must render JSON Data output as a code block",
-    { tag: ["@release", "@regression", "@playground"] },
+    { tag: ["@stable", "@release", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step(
         "Set up Mock Data (data_output) → Chat Output flow and open playground",
@@ -125,7 +127,7 @@ test.describe("Playground Output – Structured Data", () => {
           const chatMessage = page
             .getByTestId("div-chat-message")
             .filter({ has: page.locator("code") });
-          await expect(chatMessage).toBeVisible({ timeout: 10000 });
+          await expect(chatMessage).toBeVisible({ timeout: 30000 });
 
           const text = await chatMessage.innerText();
           // "records": is the top-level key in the Mock Data JSON serialisation
@@ -160,7 +162,7 @@ test.describe("Playground Output – Structured Data", () => {
           const chatMessage = page
             .getByTestId("div-chat-message")
             .filter({ has: page.locator("table") });
-          await expect(chatMessage).toBeVisible({ timeout: 10000 });
+          await expect(chatMessage).toBeVisible({ timeout: 30000 });
         },
       );
     },


### PR DESCRIPTION
## Summary

- **`clean-all-flows.ts`**: replace the Radix UI dropdown interaction with a direct REST API call. The home-page dropdown menu rendered in a Radix portal was detaching from the DOM mid-click on every page re-render (navigating back from the flow editor), making the element consistently unclickable regardless of retry strategy. The new implementation obtains a bearer token via `/api/v1/auto_login`, lists user-created flows via `GET /api/v1/flows/`, and deletes each one — deterministic and timing-immune.
- **`playground-output-data.spec.ts`**: replace `toHaveCount(2, {timeout:15000})` in `runNoInputFlow` with `first().toBeVisible({timeout:30000})`. The count-2 assertion assumed the backend always stores the empty no-input user trigger, which is not guaranteed across Langflow versions. When combined with state pollution from a prior retry's failed UI cleanup, messages never appeared within the 15 s window (root cause of the `Received: 0` failure in CI run #25309375279, retry #1). Content-assertion timeouts raised from 10 s to 30 s for the same reason. `@stable` restored on the JSON Data test.
- **`playground-output-data.md`**: spec doc updated to reflect `@stable` restored on both tests.

## Test plan

- [x] `npx playwright test playground-output-data` — 2 passed, 0 retries, two consecutive runs locally (Langflow 1.10.0)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors

Closes #120