### PR TITLE
feat(playground): complete session management test coverage (#127)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -418,6 +418,13 @@
 - [x] Rename unavailable for the Default Session → `core-functionality/playground/playground-session-rename.spec.ts`
 - [x] Rename unavailable for a session with no messages → `core-functionality/playground/playground-session-rename.spec.ts`
 - [x] Rename available and functional for a session with messages (Enter confirms, Escape cancels) → `core-functionality/playground/playground-session-rename.spec.ts`
+- [x] Create new session via new-chat button → `core-functionality/playground/playground-session-nav.spec.ts`
+- [x] Switch between sessions via session selector dropdown (header) → `core-functionality/playground/playground-session-nav.spec.ts`
+- [x] Open Message Logs via session more-menu → `core-functionality/playground/playground-message-logs.spec.ts`
+- [x] Delete messages inside Message Logs table → `core-functionality/playground/playground-message-logs.spec.ts`
+- [x] Select individual session checkbox → reveals bulk-delete-button → `core-functionality/playground/playground-bulk-delete.spec.ts`
+- [x] Select all non-default sessions via select-all-checkbox → `core-functionality/playground/playground-bulk-delete.spec.ts`
+- [x] Bulk delete selected sessions → Default Session preserved → `core-functionality/playground/playground-bulk-delete.spec.ts`
 
 #### 9.3 Advanced Playground Features
 - [x] Playground fullscreen mode → `playground/playground-fullscreen.spec.ts`
@@ -657,7 +664,7 @@
 | `api/` — REST API | 17 | 17 | 0 | 0 |
 | `core-components/` — Config | 20 | 18 | 0 | 2 |
 | `core-components/` — Components | 22 | 16 | 0 | 6 |
-| `core-functionality/playground/` | 19 | 16 | 0 | 3 |
+| `core-functionality/playground/` | 26 | 23 | 0 | 3 |
 | `core-functionality/observability-monitoring/` | 16 | 13 | 0 | 3 |
 | `core-functionality/model-provider/` | 21 | 13 | 0 | 8 |
 | `core-functionality/llm-agents/` | 15 | 8 | 0 | 7 |

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -419,7 +419,7 @@
 - [x] Rename unavailable for a session with no messages → `core-functionality/playground/playground-session-rename.spec.ts`
 - [x] Rename available and functional for a session with messages (Enter confirms, Escape cancels) → `core-functionality/playground/playground-session-rename.spec.ts`
 - [x] Create new session via new-chat button → `core-functionality/playground/playground-session-nav.spec.ts`
-- [x] Switch between sessions via session selector dropdown (header) → `core-functionality/playground/playground-session-nav.spec.ts`
+- [x] Switch between sessions via session selector sidebar → `core-functionality/playground/playground-session-nav.spec.ts`
 - [x] Open Message Logs via session more-menu → `core-functionality/playground/playground-message-logs.spec.ts`
 - [x] Delete messages inside Message Logs table → `core-functionality/playground/playground-message-logs.spec.ts`
 - [x] Select individual session checkbox → reveals bulk-delete-button → `core-functionality/playground/playground-bulk-delete.spec.ts`

--- a/docs/core-functionality/playground/playground-bulk-delete.md
+++ b/docs/core-functionality/playground/playground-bulk-delete.md
@@ -1,0 +1,80 @@
+# Playground – Bulk Session Delete
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+Validates the bulk session selection and deletion feature in the Playground sidebar:
+
+1. **Individual session checkbox** — clicking a per-session checkbox reveals the `bulk-delete-button`.
+2. **Select All** — clicking `select-all-checkbox` selects every non-default session simultaneously.
+3. **Bulk delete** — clicking `bulk-delete-button` removes all selected sessions and leaves the Default Session intact.
+
+The Default session is excluded from bulk operations by design: `selectableSessions = sessions.filter(s => s !== flowId)`.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@playground`
+
+---
+
+## Step by step *(required)*
+
+**Test 1 — individual checkbox must reveal bulk-delete-button**
+
+1. Create a ChatInput → ChatOutput flow and open the Playground
+2. Click `new-chat` to create one non-default session
+3. Assert `bulk-delete-button` count is 0 (no selection yet)
+4. Click the per-session checkbox: `[data-testid$="-checkbox"]:not([data-testid="select-all-checkbox"])` (first match)
+5. Assert `bulk-delete-button` is visible
+
+**Test 2 — select-all-checkbox must select all non-default sessions**
+
+1. Create a ChatInput → ChatOutput flow and open the Playground
+2. Click `new-chat` twice to create two non-default sessions
+3. Click `select-all-checkbox`
+4. Assert `bulk-delete-button` is visible (at least one session selected)
+
+**Test 3 — bulk-delete-button must delete selected sessions**
+
+1. Create a ChatInput → ChatOutput flow and open the Playground
+2. Click `new-chat` twice; record total `session-selector` count and selectable count
+3. Click `select-all-checkbox`; assert `bulk-delete-button` is visible
+4. Click `bulk-delete-button`
+5. Assert `session-selector` count is `totalBefore - selectableCount`
+6. Assert "Default Session" entry is still visible
+
+---
+
+## Validation criterion *(required)*
+
+- Individual checkbox: `bulk-delete-button` appears after first selection
+- Select all: `bulk-delete-button` visible; all selectable checkboxes in selected state
+- Bulk delete: session count decreases by the number of selected sessions; Default Session entry remains
+
+---
+
+## External dependencies *(required)*
+
+- `chat-sidebar.tsx` — `data-testid="select-all-checkbox"` (appears between Default session and first non-default session when `selectableSessions.length > 0`); `data-testid="bulk-delete-button"` (appears when `selectedSessions.size > 0`)
+- `session-selector.tsx` — `data-testid="session-${session}-checkbox"` (dynamic; rendered only when `showCheckbox={selectableSessions.includes(session)}`)
+- Default session is never selectable; its entry never has a checkbox
+
+---
+
+## What this test does not cover *(optional)*
+
+- Deselecting individual sessions after a select-all
+- Bulk-delete confirmation dialog (none exists; deletion is immediate)
+- Session isolation or message persistence after bulk deletion
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
+- No LLM or API key needed

--- a/docs/core-functionality/playground/playground-bulk-delete.md
+++ b/docs/core-functionality/playground/playground-bulk-delete.md
@@ -37,7 +37,7 @@ The Default session is excluded from bulk operations by design: `selectableSessi
 1. Create a ChatInput → ChatOutput flow and open the Playground
 2. Click `new-chat` twice to create two non-default sessions
 3. Assert `select-all-checkbox` is visible; click it; assert `bulk-delete-button` is visible
-4. Assert every per-session checkbox (`[data-testid$="-checkbox"]:not([data-testid="select-all-checkbox"])`) is in checked state; assert count ≥ 2
+4. Assert count ≥ 2 and every per-session checkbox has a `.text-status-red` child visible (custom div — selected state is indicated by the icon CSS class, not a native checked attribute)
 
 **Test 3 — bulk-delete-button must delete selected sessions**
 
@@ -61,7 +61,7 @@ The Default session is excluded from bulk operations by design: `selectableSessi
 ## External dependencies *(required)*
 
 - `chat-sidebar.tsx` — `data-testid="select-all-checkbox"` (appears between Default session and first non-default session when `selectableSessions.length > 0`); `data-testid="bulk-delete-button"` (appears when `selectedSessions.size > 0`)
-- `session-selector.tsx` — `data-testid="session-${session}-checkbox"` (dynamic; rendered only when `showCheckbox={selectableSessions.includes(session)}`)
+- `session-selector.tsx` — `data-testid="session-${session}-checkbox"` (dynamic; rendered only when `showCheckbox={selectableSessions.includes(session)}`); a custom `div` — selected state is indicated by `.text-status-red` on the inner icon (`SquareCheck`), not by a native checked attribute
 - Default session is never selectable; its entry never has a checkbox
 
 ---

--- a/docs/core-functionality/playground/playground-bulk-delete.md
+++ b/docs/core-functionality/playground/playground-bulk-delete.md
@@ -36,14 +36,14 @@ The Default session is excluded from bulk operations by design: `selectableSessi
 
 1. Create a ChatInput → ChatOutput flow and open the Playground
 2. Click `new-chat` twice to create two non-default sessions
-3. Click `select-all-checkbox`
-4. Assert `bulk-delete-button` is visible (at least one session selected)
+3. Assert `select-all-checkbox` is visible; click it; assert `bulk-delete-button` is visible
+4. Assert every per-session checkbox (`[data-testid$="-checkbox"]:not([data-testid="select-all-checkbox"])`) is in checked state; assert count ≥ 2
 
 **Test 3 — bulk-delete-button must delete selected sessions**
 
 1. Create a ChatInput → ChatOutput flow and open the Playground
-2. Click `new-chat` twice; record total `session-selector` count and selectable count
-3. Click `select-all-checkbox`; assert `bulk-delete-button` is visible
+2. Click `new-chat` twice; record total `session-selector` count (`totalBefore`)
+3. Assert `select-all-checkbox` is visible; click it; assert `bulk-delete-button` is visible; record selectable checkbox count (`selectableCount`)
 4. Click `bulk-delete-button`
 5. Assert `session-selector` count is `totalBefore - selectableCount`
 6. Assert "Default Session" entry is still visible

--- a/docs/core-functionality/playground/playground-message-logs.md
+++ b/docs/core-functionality/playground/playground-message-logs.md
@@ -1,0 +1,76 @@
+# Playground – Message Logs
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+Validates the Message Logs feature accessible from the session more-menu in the Playground sidebar:
+
+1. **Open Message Logs** — clicking `message-logs-option` in the session sidebar more-menu opens the Session Logs modal (`SessionLogsModal`) containing an ag-grid table of messages.
+2. **Delete messages** — selecting rows via ag-grid checkboxes and clicking `delete-row-button` removes those rows from the table.
+
+Message Logs give users a structured view of a session's full message history and the ability to clean up individual messages without clearing the entire session.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@playground`
+
+---
+
+## Step by step *(required)*
+
+**Test 1 — message-logs-option must open the Session Logs modal**
+
+1. Create a ChatInput → ChatOutput flow and open the Playground
+2. Send "test log message" and wait for the echo
+3. Click the sidebar session more-menu: `[data-testid^="session-"][data-testid$="-more-menu"]` (first match = Default session)
+4. Click `message-logs-option`
+5. Assert "Session logs" text is visible (modal header)
+6. Assert at least one `.ag-row` is present in the table
+
+**Test 2 — selecting and deleting messages must reduce the row count**
+
+1. Create a ChatInput → ChatOutput flow and open the Playground
+2. Send "message to delete" and wait for the echo
+3. Open Message Logs modal (same steps as Test 1)
+4. Record row count before deletion
+5. Click `.ag-checkbox-input` (first row checkbox in ag-grid)
+6. Assert `delete-row-button` is enabled
+7. Click `delete-row-button`
+8. Assert row count is `rowsBefore - 1`
+
+---
+
+## Validation criterion *(required)*
+
+- After opening: modal with "Session logs" header is visible; `.ag-row` count > 0
+- After deletion: `.ag-row` count is `rowsBefore - 1`
+
+---
+
+## External dependencies *(required)*
+
+- `session-more-menu.tsx` — `data-testid="message-logs-option"` (visible by default for all sessions; `showMessageLogs` defaults to `true`)
+- `session-logs-modal.tsx` — renders `SessionView` inside `BaseModal`
+- `session-view.tsx` — ag-grid table with `rowSelection="multiple"` and `onDelete` enabled when `playgroundPage = false` (which is the case in the embedded playground)
+- `tableComponent/TableOptions/index.tsx` — `data-testid="delete-row-button"` (disabled until `hasSelection = true`)
+- `flowStore.ts` — `playgroundPage` defaults to `false`; deletion is only disabled on the standalone shareable playground page
+
+---
+
+## What this test does not cover *(optional)*
+
+- Editing message text inline in the table
+- Pagination behavior with large numbers of messages
+- Message Logs for a user-created session (same mechanism; only the sidebar menu trigger differs)
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
+- No LLM or API key needed — ChatInput → ChatOutput produces real messages stored via the messages API

--- a/docs/core-functionality/playground/playground-message-logs.md
+++ b/docs/core-functionality/playground/playground-message-logs.md
@@ -36,12 +36,11 @@ Message Logs give users a structured view of a session's full message history an
 
 1. Create a ChatInput → ChatOutput flow and open the Playground
 2. Send "message to delete" and wait for the echo
-3. Open Message Logs modal (same steps as Test 1)
-4. Record row count before deletion
-5. Click `.ag-checkbox-input` (first row checkbox in ag-grid)
-6. Assert `delete-row-button` is enabled
-7. Click `delete-row-button`
-8. Assert row count is `rowsBefore - 1`
+3. Open Message Logs modal (same steps as Test 1); wait for `.ag-row` to be visible and record the initial row count (`rowsBefore`)
+4. Click `.ag-checkbox-input` (first row checkbox in ag-grid)
+5. Assert `delete-row-button` is enabled
+6. Click `delete-row-button`
+7. Assert row count is `rowsBefore - 1`
 
 ---
 
@@ -56,7 +55,7 @@ Message Logs give users a structured view of a session's full message history an
 
 - `session-more-menu.tsx` — `data-testid="message-logs-option"` (visible by default for all sessions; `showMessageLogs` defaults to `true`)
 - `session-logs-modal.tsx` — renders `SessionView` inside `BaseModal`
-- `session-view.tsx` — ag-grid table with `rowSelection="multiple"` and `onDelete` enabled when `playgroundPage = false` (which is the case in the embedded playground)
+- `session-view.tsx` — ag-grid table with `rowSelection="multiple"` and `onDelete` enabled when `playgroundPage = false` (which is the case in the embedded playground); row and checkbox selectors (`.ag-row`, `.ag-checkbox-input`) are ag-grid internal CSS classes — ag-grid does not expose `data-testid` on row elements
 - `tableComponent/TableOptions/index.tsx` — `data-testid="delete-row-button"` (disabled until `hasSelection = true`)
 - `flowStore.ts` — `playgroundPage` defaults to `false`; deletion is only disabled on the standalone shareable playground page
 

--- a/docs/core-functionality/playground/playground-message-logs.md
+++ b/docs/core-functionality/playground/playground-message-logs.md
@@ -37,7 +37,7 @@ Message Logs give users a structured view of a session's full message history an
 1. Create a ChatInput → ChatOutput flow and open the Playground
 2. Send "message to delete" and wait for the echo
 3. Open Message Logs modal (same steps as Test 1); wait for `.ag-row` to be visible and record the initial row count (`rowsBefore`)
-4. Click `.ag-checkbox-input` (first row checkbox in ag-grid)
+4. Click `.ag-row .ag-checkbox-input` (first row-level checkbox; scoped to `.ag-row` to skip the header select-all checkbox)
 5. Assert `delete-row-button` is enabled
 6. Click `delete-row-button`
 7. Assert row count is `rowsBefore - 1`
@@ -55,7 +55,7 @@ Message Logs give users a structured view of a session's full message history an
 
 - `session-more-menu.tsx` — `data-testid="message-logs-option"` (visible by default for all sessions; `showMessageLogs` defaults to `true`)
 - `session-logs-modal.tsx` — renders `SessionView` inside `BaseModal`
-- `session-view.tsx` — ag-grid table with `rowSelection="multiple"` and `onDelete` enabled when `playgroundPage = false` (which is the case in the embedded playground); row and checkbox selectors (`.ag-row`, `.ag-checkbox-input`) are ag-grid internal CSS classes — ag-grid does not expose `data-testid` on row elements
+- `session-view.tsx` — ag-grid table with `rowSelection="multiple"` and `onDelete` enabled when `playgroundPage = false` (which is the case in the embedded playground); row and checkbox selectors (`.ag-row`, `.ag-row .ag-checkbox-input`) are ag-grid internal CSS classes — ag-grid does not expose `data-testid` on row elements; the header row also has a `.ag-checkbox-input` (select-all), so the selector must be scoped to `.ag-row` to target individual row checkboxes
 - `tableComponent/TableOptions/index.tsx` — `data-testid="delete-row-button"` (disabled until `hasSelection = true`)
 - `flowStore.ts` — `playgroundPage` defaults to `false`; deletion is only disabled on the standalone shareable playground page
 

--- a/docs/core-functionality/playground/playground-session-nav.md
+++ b/docs/core-functionality/playground/playground-session-nav.md
@@ -1,0 +1,72 @@
+# Playground – Session Creation and Navigation
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+Covers two related session navigation behaviors in the Playground:
+
+1. **New session creation via `new-chat`** — clicking the button adds a new entry to the session sidebar and opens an empty chat input.
+2. **Session switching via the header dropdown (`session-selector-trigger`)** — opening the dropdown lists all sessions; selecting one loads that session's messages and hides the others.
+
+These ensure users can manage multiple parallel conversations without cross-contamination between sessions.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@playground`
+
+---
+
+## Step by step *(required)*
+
+**Test 1 — new-chat button must add a new session entry to the sidebar**
+
+1. Create a ChatInput → ChatOutput flow and open the Playground via `playground-btn-flow-io`
+2. Count the current number of `session-selector` entries
+3. Click `new-chat`
+4. Assert `session-selector` count is `before + 1`
+5. Assert `input-chat-playground` is visible (new empty chat is active)
+
+**Test 2 — session selector dropdown must switch to the selected session**
+
+1. Create a ChatInput → ChatOutput flow and open the Playground
+2. Send "default session message" in the Default session; wait for the echo to appear
+3. Click `new-chat`; send "new session message"; wait for the echo
+4. Click `session-selector-trigger` to open the header dropdown
+5. Assert the `Default Session` menu item is visible
+6. Click `Default Session`
+7. Assert "default session message" is visible and "new session message" count is 0
+
+---
+
+## Validation criterion *(required)*
+
+- After `new-chat`: `session-selector` count increases by 1 and `input-chat-playground` is visible
+- After switching sessions: only the target session's messages are shown; the other session's messages have count 0
+
+---
+
+## External dependencies *(required)*
+
+- `chat-sidebar.tsx` — `data-testid="new-chat"` (creates session) and `data-testid="session-selector"` (sidebar items)
+- `chat-sessions-dropdown.tsx` — `data-testid="session-selector-trigger"` (header dropdown trigger); dropdown items labeled "Default Session" or the session ID (Radix `role="menuitem"`)
+- No API key required: ChatInput → ChatOutput is a synchronous echo flow
+
+---
+
+## What this test does not cover *(optional)*
+
+- Renaming sessions (covered in `playground-session-rename.spec.ts`)
+- Deleting sessions (covered in `playground-clear-history.spec.ts`)
+- Bulk session deletion (covered in `playground-bulk-delete.spec.ts`)
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
+- No LLM or API key needed

--- a/docs/core-functionality/playground/playground-session-nav.md
+++ b/docs/core-functionality/playground/playground-session-nav.md
@@ -9,9 +9,11 @@
 Covers two related session navigation behaviors in the Playground:
 
 1. **New session creation via `new-chat`** — clicking the button adds a new entry to the session sidebar and opens an empty chat input.
-2. **Session switching via the header dropdown (`session-selector-trigger`)** — opening the dropdown lists all sessions; selecting one loads that session's messages and hides the others.
+2. **Session switching via the sidebar (`session-selector`)** — clicking a session entry in the sidebar loads that session's messages and hides the others.
 
 These ensure users can manage multiple parallel conversations without cross-contamination between sessions.
+
+> Note: the header dropdown (`session-selector-trigger`) exists only in the fullscreen playground (`playgroundComponent`), not in the IOModal opened via `playground-btn-flow-io`. Session switching in this context is done via the sidebar.
 
 ---
 
@@ -31,29 +33,27 @@ These ensure users can manage multiple parallel conversations without cross-cont
 4. Assert `session-selector` count is `before + 1`
 5. Assert `input-chat-playground` is visible (new empty chat is active)
 
-**Test 2 — session selector dropdown must switch to the selected session**
+**Test 2 — session selector sidebar must switch to the selected session**
 
 1. Create a ChatInput → ChatOutput flow and open the Playground
 2. Send "default session message" in the Default session; wait for the echo to appear
 3. Click `new-chat`; send "new session message"; wait for the echo
-4. Click `session-selector-trigger` to open the header dropdown
-5. Assert the `Default Session` menu item is visible
-6. Click `Default Session`
-7. Assert "default session message" is visible and "new session message" count is 0
+4. Click the `session-selector` sidebar entry that contains "Default Session"
+5. Assert "default session message" is visible and "new session message" count is 0
 
 ---
 
 ## Validation criterion *(required)*
 
 - After `new-chat`: `session-selector` count increases by 1 and `input-chat-playground` is visible
-- After switching sessions: only the target session's messages are shown; the other session's messages have count 0
+- After clicking a sidebar session entry: only that session's messages are shown; the other session's messages have count 0
 
 ---
 
 ## External dependencies *(required)*
 
-- `chat-sidebar.tsx` — `data-testid="new-chat"` (creates session) and `data-testid="session-selector"` (sidebar items)
-- `chat-sessions-dropdown.tsx` — `data-testid="session-selector-trigger"` (header dropdown trigger); dropdown items labeled "Default Session" or the session ID (Radix `role="menuitem"`)
+- `chat-sidebar.tsx` — `data-testid="new-chat"` (creates session)
+- `IOModal/components/IOFieldView/components/session-selector.tsx` — `data-testid="session-selector"` (sidebar items); clicking an item calls `toggleVisibility()` to switch the active session; item text is "Default Session" when `session === currentFlowId`
 - No API key required: ChatInput → ChatOutput is a synchronous echo flow
 
 ---

--- a/docs/core-functionality/playground/playground-session-nav.md
+++ b/docs/core-functionality/playground/playground-session-nav.md
@@ -13,8 +13,6 @@ Covers two related session navigation behaviors in the Playground:
 
 These ensure users can manage multiple parallel conversations without cross-contamination between sessions.
 
-> Note: the header dropdown (`session-selector-trigger`) exists only in the fullscreen playground (`playgroundComponent`), not in the IOModal opened via `playground-btn-flow-io`. Session switching in this context is done via the sidebar.
-
 ---
 
 ## Tags *(required)*
@@ -52,8 +50,8 @@ These ensure users can manage multiple parallel conversations without cross-cont
 
 ## External dependencies *(required)*
 
-- `chat-sidebar.tsx` — `data-testid="new-chat"` (creates session)
-- `IOModal/components/IOFieldView/components/session-selector.tsx` — `data-testid="session-selector"` (sidebar items); clicking an item calls `toggleVisibility()` to switch the active session; item text is "Default Session" when `session === currentFlowId`
+- `src/frontend/src/modals/IOModal/components/sidebar-open-view.tsx` — `data-testid="new-chat"` (creates session)
+- `src/frontend/src/modals/IOModal/components/IOFieldView/components/session-selector.tsx` — `data-testid="session-selector"` (sidebar items); clicking an item switches the active session; item displays "Default Session" when `session === currentFlowId`
 - No API key required: ChatInput → ChatOutput is a synchronous echo flow
 
 ---
@@ -70,3 +68,9 @@ These ensure users can manage multiple parallel conversations without cross-cont
 
 - Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
 - No LLM or API key needed
+
+---
+
+## Notes *(optional)*
+
+- `session-selector-trigger` (the header dropdown) exists only in the fullscreen `playgroundComponent`, not in the IOModal opened via `playground-btn-flow-io`. Session switching in this test is done via the sidebar `session-selector` items.

--- a/tests/tests-automations/regression/core-functionality/playground/playground-bulk-delete.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-bulk-delete.spec.ts
@@ -101,8 +101,10 @@ test.describe("Playground – Bulk Session Operations", () => {
           checkboxCount,
           "Expected at least two selectable session checkboxes after creating two sessions",
         ).toBeGreaterThanOrEqual(2);
+        // Checkboxes are custom divs (not native inputs); selected state is indicated
+        // by the text-status-red class on the icon rendered inside the div.
         for (let i = 0; i < checkboxCount; i++) {
-          await expect(checkboxes.nth(i)).toBeChecked();
+          await expect(checkboxes.nth(i).locator(".text-status-red")).toBeVisible();
         }
       });
     },

--- a/tests/tests-automations/regression/core-functionality/playground/playground-bulk-delete.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-bulk-delete.spec.ts
@@ -1,0 +1,157 @@
+import { expect, test } from "../../../../fixtures/fixtures";
+import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+
+/**
+ * Bulk session operations in the Playground sidebar.
+ *
+ * The select-all-checkbox and per-session checkboxes appear only for
+ * non-default sessions (selectableSessions = sessions.filter(s => s !== flowId)).
+ * The bulk-delete-button appears only when selectedSessions.size > 0.
+ *
+ * Source files:
+ *   chat-sidebar.tsx    — data-testid="select-all-checkbox", "bulk-delete-button"
+ *   session-selector.tsx — data-testid="session-{id}-checkbox" (dynamic)
+ */
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Playground – Bulk Session Operations", () => {
+  let createdFlowId: string | null = null;
+
+  test.afterEach(async ({ page }) => {
+    if (createdFlowId) {
+      await page.goto("/");
+      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      createdFlowId = null;
+    }
+  });
+
+  test(
+    "selecting an individual session checkbox must reveal the bulk-delete-button",
+    { tag: ["@stable", "@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step("set up ChatInput → ChatOutput flow and open playground", async () => {
+        createdFlowId = await setupPlayground(page);
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+          timeout: 15000,
+        });
+      });
+
+      await test.step("create a new session so a selectable checkbox is available", async () => {
+        await page.getByTestId("new-chat").click();
+        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+          timeout: 10000,
+        });
+      });
+
+      await test.step("verify bulk-delete-button is not visible before any selection", async () => {
+        await expect(page.getByTestId("bulk-delete-button")).toHaveCount(0);
+      });
+
+      await test.step("click the per-session checkbox and verify bulk-delete-button appears", async () => {
+        await page
+          .locator('[data-testid$="-checkbox"]:not([data-testid="select-all-checkbox"])')
+          .first()
+          .click();
+        await expect(page.getByTestId("bulk-delete-button")).toBeVisible({
+          timeout: 5000,
+        });
+      });
+    },
+  );
+
+  test(
+    "select-all-checkbox must select all non-default sessions",
+    { tag: ["@stable", "@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step("set up ChatInput → ChatOutput flow and open playground", async () => {
+        createdFlowId = await setupPlayground(page);
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+          timeout: 15000,
+        });
+      });
+
+      await test.step("create two new sessions so multiple checkboxes are available", async () => {
+        await page.getByTestId("new-chat").click();
+        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+          timeout: 10000,
+        });
+        await page.getByTestId("new-chat").click();
+        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+          timeout: 10000,
+        });
+      });
+
+      await test.step("click select-all-checkbox and verify bulk-delete-button is visible", async () => {
+        await page.getByTestId("select-all-checkbox").click();
+        await expect(page.getByTestId("bulk-delete-button")).toBeVisible({
+          timeout: 5000,
+        });
+      });
+
+      await test.step("verify all per-session checkboxes are selectable and bulk-delete-button remains visible", async () => {
+        const checkboxCount = await page
+          .locator('[data-testid$="-checkbox"]:not([data-testid="select-all-checkbox"])')
+          .count();
+        expect(
+          checkboxCount,
+          "Expected at least two selectable session checkboxes after creating two sessions",
+        ).toBeGreaterThanOrEqual(2);
+        // bulk-delete-button visible confirms all sessions are selected
+        await expect(page.getByTestId("bulk-delete-button")).toBeVisible({ timeout: 3000 });
+      });
+    },
+  );
+
+  test(
+    "bulk-delete-button must remove all selected sessions from the sidebar",
+    { tag: ["@stable", "@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step("set up ChatInput → ChatOutput flow and open playground", async () => {
+        createdFlowId = await setupPlayground(page);
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+          timeout: 15000,
+        });
+      });
+
+      await test.step("create two new sessions", async () => {
+        await page.getByTestId("new-chat").click();
+        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+          timeout: 10000,
+        });
+        await page.getByTestId("new-chat").click();
+        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+          timeout: 10000,
+        });
+      });
+
+      const totalBefore = await page.getByTestId("session-selector").count();
+
+      await test.step("select all non-default sessions via select-all-checkbox", async () => {
+        await page.getByTestId("select-all-checkbox").click();
+        await expect(page.getByTestId("bulk-delete-button")).toBeVisible({
+          timeout: 5000,
+        });
+      });
+
+      const selectableCount = await page
+        .locator('[data-testid$="-checkbox"]:not([data-testid="select-all-checkbox"])')
+        .count();
+
+      await test.step("click bulk-delete-button and verify sessions are removed", async () => {
+        await page.getByTestId("bulk-delete-button").click();
+        await expect(page.getByTestId("session-selector")).toHaveCount(
+          totalBefore - selectableCount,
+          { timeout: 10000 },
+        );
+        // Default session must remain
+        await expect(
+          page.getByTestId("session-selector").filter({ hasText: "Default Session" }),
+        ).toBeVisible({ timeout: 5000 });
+      });
+    },
+  );
+});

--- a/tests/tests-automations/regression/core-functionality/playground/playground-bulk-delete.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-bulk-delete.spec.ts
@@ -85,22 +85,25 @@ test.describe("Playground – Bulk Session Operations", () => {
       });
 
       await test.step("click select-all-checkbox and verify bulk-delete-button is visible", async () => {
+        await expect(page.getByTestId("select-all-checkbox")).toBeVisible({ timeout: 5000 });
         await page.getByTestId("select-all-checkbox").click();
         await expect(page.getByTestId("bulk-delete-button")).toBeVisible({
           timeout: 5000,
         });
       });
 
-      await test.step("verify all per-session checkboxes are selectable and bulk-delete-button remains visible", async () => {
-        const checkboxCount = await page
-          .locator('[data-testid$="-checkbox"]:not([data-testid="select-all-checkbox"])')
-          .count();
+      await test.step("verify all per-session checkboxes are in checked state", async () => {
+        const checkboxes = page.locator(
+          '[data-testid$="-checkbox"]:not([data-testid="select-all-checkbox"])',
+        );
+        const checkboxCount = await checkboxes.count();
         expect(
           checkboxCount,
           "Expected at least two selectable session checkboxes after creating two sessions",
         ).toBeGreaterThanOrEqual(2);
-        // bulk-delete-button visible confirms all sessions are selected
-        await expect(page.getByTestId("bulk-delete-button")).toBeVisible({ timeout: 3000 });
+        for (let i = 0; i < checkboxCount; i++) {
+          await expect(checkboxes.nth(i)).toBeChecked();
+        }
       });
     },
   );
@@ -117,7 +120,8 @@ test.describe("Playground – Bulk Session Operations", () => {
         });
       });
 
-      await test.step("create two new sessions", async () => {
+      let totalBefore = 0;
+      await test.step("create two new sessions and record total session count", async () => {
         await page.getByTestId("new-chat").click();
         await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
           timeout: 10000,
@@ -126,20 +130,20 @@ test.describe("Playground – Bulk Session Operations", () => {
         await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
           timeout: 10000,
         });
+        totalBefore = await page.getByTestId("session-selector").count();
       });
 
-      const totalBefore = await page.getByTestId("session-selector").count();
-
+      let selectableCount = 0;
       await test.step("select all non-default sessions via select-all-checkbox", async () => {
+        await expect(page.getByTestId("select-all-checkbox")).toBeVisible({ timeout: 5000 });
         await page.getByTestId("select-all-checkbox").click();
         await expect(page.getByTestId("bulk-delete-button")).toBeVisible({
           timeout: 5000,
         });
+        selectableCount = await page
+          .locator('[data-testid$="-checkbox"]:not([data-testid="select-all-checkbox"])')
+          .count();
       });
-
-      const selectableCount = await page
-        .locator('[data-testid$="-checkbox"]:not([data-testid="select-all-checkbox"])')
-        .count();
 
       await test.step("click bulk-delete-button and verify sessions are removed", async () => {
         await page.getByTestId("bulk-delete-button").click();

--- a/tests/tests-automations/regression/core-functionality/playground/playground-bulk-delete.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-bulk-delete.spec.ts
@@ -51,7 +51,8 @@ test.describe("Playground – Bulk Session Operations", () => {
 
       await test.step("click the per-session checkbox and verify bulk-delete-button appears", async () => {
         await page
-          .locator('[data-testid$="-checkbox"]:not([data-testid="select-all-checkbox"])')
+          .locator('[data-testid="session-selector"]')
+          .locator('[data-testid$="-checkbox"]')
           .first()
           .click();
         await expect(page.getByTestId("bulk-delete-button")).toBeVisible({
@@ -93,9 +94,9 @@ test.describe("Playground – Bulk Session Operations", () => {
       });
 
       await test.step("verify all per-session checkboxes are in checked state", async () => {
-        const checkboxes = page.locator(
-          '[data-testid$="-checkbox"]:not([data-testid="select-all-checkbox"])',
-        );
+        const checkboxes = page
+          .locator('[data-testid="session-selector"]')
+          .locator('[data-testid$="-checkbox"]');
         const checkboxCount = await checkboxes.count();
         expect(
           checkboxCount,
@@ -143,7 +144,8 @@ test.describe("Playground – Bulk Session Operations", () => {
           timeout: 5000,
         });
         selectableCount = await page
-          .locator('[data-testid$="-checkbox"]:not([data-testid="select-all-checkbox"])')
+          .locator('[data-testid="session-selector"]')
+          .locator('[data-testid$="-checkbox"]')
           .count();
       });
 

--- a/tests/tests-automations/regression/core-functionality/playground/playground-message-logs.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-message-logs.spec.ts
@@ -1,0 +1,126 @@
+import { expect, test } from "../../../../fixtures/fixtures";
+import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+
+/**
+ * Message Logs are accessible via the session more-menu (message-logs-option).
+ * The modal renders an ag-grid table (SessionView) showing messages for the session.
+ * Rows can be selected via .ag-checkbox-input and deleted with delete-row-button.
+ *
+ * Source files:
+ *   session-more-menu.tsx       — data-testid="message-logs-option"
+ *   session-logs-modal.tsx      — renders SessionView inside BaseModal
+ *   session-view.tsx            — ag-grid table; onDelete enabled when !playgroundPage
+ *   tableComponent/TableOptions — data-testid="delete-row-button" (disabled until selection)
+ *
+ * playgroundPage is false in the embedded playground (flow editor),
+ * so row deletion is available.
+ */
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Playground – Message Logs", () => {
+  let createdFlowId: string | null = null;
+
+  test.afterEach(async ({ page }) => {
+    if (createdFlowId) {
+      await page.goto("/");
+      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      createdFlowId = null;
+    }
+  });
+
+  test(
+    "message-logs-option must open the Session Logs modal for the active session",
+    { tag: ["@stable", "@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step("set up ChatInput → ChatOutput flow and open playground", async () => {
+        createdFlowId = await setupPlayground(page);
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+          timeout: 15000,
+        });
+      });
+
+      await test.step("send a message to populate the session with log entries", async () => {
+        await page.getByTestId("input-chat-playground").last().fill("test log message");
+        await page.getByTestId("button-send").last().click();
+        await expect(page.getByText("test log message").last()).toBeVisible({
+          timeout: 15000,
+        });
+        await expect(page.getByTestId("button-stop").last()).toBeHidden({
+          timeout: 30000,
+        });
+      });
+
+      await test.step("open the sidebar session more-menu and click message-logs-option", async () => {
+        await page
+          .locator('[data-testid^="session-"][data-testid$="-more-menu"]')
+          .first()
+          .click();
+        await expect(page.getByTestId("message-logs-option")).toBeVisible({
+          timeout: 5000,
+        });
+        await page.getByTestId("message-logs-option").click();
+      });
+
+      await test.step("verify the Session Logs modal opens with message rows in the table", async () => {
+        await expect(page.getByText("Session logs")).toBeVisible({ timeout: 10000 });
+        await page.waitForSelector(".ag-row", { timeout: 10000 });
+        const rowCount = await page.locator(".ag-row").count();
+        expect(rowCount, "Session Logs table must contain at least one message row").toBeGreaterThan(0);
+      });
+    },
+  );
+
+  test(
+    "selecting messages in the log table and deleting them must reduce the row count",
+    { tag: ["@stable", "@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step("set up ChatInput → ChatOutput flow and open playground", async () => {
+        createdFlowId = await setupPlayground(page);
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+          timeout: 15000,
+        });
+      });
+
+      await test.step("send a message to have a row to delete", async () => {
+        await page.getByTestId("input-chat-playground").last().fill("message to delete");
+        await page.getByTestId("button-send").last().click();
+        await expect(page.getByText("message to delete").last()).toBeVisible({
+          timeout: 15000,
+        });
+        await expect(page.getByTestId("button-stop").last()).toBeHidden({
+          timeout: 30000,
+        });
+      });
+
+      await test.step("open the Session Logs modal", async () => {
+        await page
+          .locator('[data-testid^="session-"][data-testid$="-more-menu"]')
+          .first()
+          .click();
+        await expect(page.getByTestId("message-logs-option")).toBeVisible({
+          timeout: 5000,
+        });
+        await page.getByTestId("message-logs-option").click();
+        await expect(page.getByText("Session logs")).toBeVisible({ timeout: 10000 });
+        await page.waitForSelector(".ag-row", { timeout: 10000 });
+      });
+
+      const rowsBefore = await page.locator(".ag-row").count();
+
+      await test.step("select the first row via its checkbox", async () => {
+        await page.locator(".ag-checkbox-input").first().click();
+        await expect(page.getByTestId("delete-row-button")).toBeEnabled({ timeout: 5000 });
+      });
+
+      await test.step("click delete-row-button and verify the row count decreases", async () => {
+        await page.getByTestId("delete-row-button").click();
+        await expect(page.locator(".ag-row")).toHaveCount(rowsBefore - 1, {
+          timeout: 10000,
+        });
+      });
+    },
+  );
+});

--- a/tests/tests-automations/regression/core-functionality/playground/playground-message-logs.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-message-logs.spec.ts
@@ -70,7 +70,7 @@ test.describe("Playground – Message Logs", () => {
 
       await test.step("verify the Session Logs modal opens with message rows in the table", async () => {
         await expect(page.getByText("Session logs")).toBeVisible({ timeout: 10000 });
-        await page.waitForSelector(".ag-row", { timeout: 10000 });
+        await expect(page.locator(".ag-row").first()).toBeVisible({ timeout: 10000 });
         const rowCount = await page.locator(".ag-row").count();
         expect(rowCount, "Session Logs table must contain at least one message row").toBeGreaterThan(0);
       });
@@ -100,7 +100,8 @@ test.describe("Playground – Message Logs", () => {
         });
       });
 
-      await test.step("open the Session Logs modal", async () => {
+      let rowsBefore = 0;
+      await test.step("open the Session Logs modal and record initial row count", async () => {
         await page
           .locator('[data-testid^="session-"][data-testid$="-more-menu"]')
           .first()
@@ -110,10 +111,9 @@ test.describe("Playground – Message Logs", () => {
         });
         await page.getByTestId("message-logs-option").click();
         await expect(page.getByText("Session logs")).toBeVisible({ timeout: 10000 });
-        await page.waitForSelector(".ag-row", { timeout: 10000 });
+        await expect(page.locator(".ag-row").first()).toBeVisible({ timeout: 10000 });
+        rowsBefore = await page.locator(".ag-row").count();
       });
-
-      const rowsBefore = await page.locator(".ag-row").count();
 
       await test.step("select the first row via its checkbox", async () => {
         await page.locator(".ag-checkbox-input").first().click();

--- a/tests/tests-automations/regression/core-functionality/playground/playground-message-logs.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-message-logs.spec.ts
@@ -12,6 +12,10 @@ import { setupPlayground } from "../../../../helpers/flows/setup-playground";
  *   session-view.tsx            — ag-grid table; onDelete enabled when !playgroundPage
  *   tableComponent/TableOptions — data-testid="delete-row-button" (disabled until selection)
  *
+ * Row targeting uses .ag-row (ag-Grid internal class) because neither session-view.tsx
+ * nor ag-Grid itself exposes data-testid on individual rows. See tracking issue for a
+ * Langflow-side fix: https://github.com/oriontech-me/langflow-e2e/issues/135
+ *
  * playgroundPage is false in the embedded playground (flow editor),
  * so row deletion is available.
  *

--- a/tests/tests-automations/regression/core-functionality/playground/playground-message-logs.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-message-logs.spec.ts
@@ -116,7 +116,7 @@ test.describe("Playground – Message Logs", () => {
       });
 
       await test.step("select the first row via its checkbox", async () => {
-        await page.locator(".ag-checkbox-input").first().click();
+        await page.locator(".ag-row .ag-checkbox-input").first().click();
         await expect(page.getByTestId("delete-row-button")).toBeEnabled({ timeout: 5000 });
       });
 

--- a/tests/tests-automations/regression/core-functionality/playground/playground-message-logs.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-message-logs.spec.ts
@@ -14,6 +14,11 @@ import { setupPlayground } from "../../../../helpers/flows/setup-playground";
  *
  * playgroundPage is false in the embedded playground (flow editor),
  * so row deletion is available.
+ *
+ * Overlap note: playground.spec.ts (line 119-124) also opens message-logs-option
+ * and asserts "Page 1 of 1". That test is a monolithic integration spec without
+ * @stable; this spec is the dedicated, isolated, @stable coverage with different
+ * assertions (.ag-row count). Row deletion (Test 2) is not covered anywhere else.
  */
 
 test.describe.configure({ mode: "serial" });

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-nav.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-nav.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "../../../../fixtures/fixtures";
+import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+
+/**
+ * Session creation (new-chat) and session switching (session-selector-trigger).
+ *
+ * Source files:
+ *   chat-sidebar.tsx      — data-testid="new-chat", data-testid="session-selector"
+ *   chat-sessions-dropdown.tsx — data-testid="session-selector-trigger"
+ */
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Playground – Session Creation and Navigation", () => {
+  let createdFlowId: string | null = null;
+
+  test.afterEach(async ({ page }) => {
+    if (createdFlowId) {
+      await page.goto("/");
+      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      createdFlowId = null;
+    }
+  });
+
+  test(
+    "new-chat button must add a new session entry to the sidebar",
+    { tag: ["@stable", "@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step("set up ChatInput → ChatOutput flow and open playground", async () => {
+        createdFlowId = await setupPlayground(page);
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+          timeout: 15000,
+        });
+      });
+
+      const countBefore = await page.getByTestId("session-selector").count();
+
+      await test.step("click new-chat and verify session count increases by one", async () => {
+        await page.getByTestId("new-chat").click();
+        await expect(page.getByTestId("session-selector")).toHaveCount(
+          countBefore + 1,
+          { timeout: 5000 },
+        );
+        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+          timeout: 10000,
+        });
+      });
+    },
+  );
+
+  test(
+    "session selector dropdown must list sessions and switch to the selected one",
+    { tag: ["@stable", "@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step("set up ChatInput → ChatOutput flow and open playground", async () => {
+        createdFlowId = await setupPlayground(page);
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+          timeout: 15000,
+        });
+      });
+
+      await test.step("send a message in the Default session", async () => {
+        await page.getByTestId("input-chat-playground").last().fill("default session message");
+        await page.getByTestId("button-send").last().click();
+        await expect(page.getByText("default session message").last()).toBeVisible({
+          timeout: 15000,
+        });
+        await expect(page.getByTestId("button-stop").last()).toBeHidden({
+          timeout: 30000,
+        });
+      });
+
+      await test.step("create a new session and send a distinct message", async () => {
+        await page.getByTestId("new-chat").click();
+        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+          timeout: 10000,
+        });
+        await page.getByTestId("input-chat-playground").last().fill("new session message");
+        await page.getByTestId("button-send").last().click();
+        await expect(page.getByText("new session message").last()).toBeVisible({
+          timeout: 15000,
+        });
+        await expect(page.getByTestId("button-stop").last()).toBeHidden({
+          timeout: 30000,
+        });
+      });
+
+      await test.step("open the session selector dropdown and verify Default Session is listed", async () => {
+        await page.getByTestId("session-selector-trigger").click();
+        await expect(
+          page.getByRole("menuitem", { name: "Default Session" }),
+        ).toBeVisible({ timeout: 5000 });
+      });
+
+      await test.step("switch to Default Session and verify its messages are shown", async () => {
+        await page.getByRole("menuitem", { name: "Default Session" }).click();
+        await expect(page.getByText("default session message")).toBeVisible({
+          timeout: 10000,
+        });
+        await expect(page.getByText("new session message")).toHaveCount(0);
+      });
+    },
+  );
+});

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-nav.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-nav.spec.ts
@@ -1,19 +1,7 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { setupPlayground } from "../../../../helpers/flows/setup-playground";
 
-/**
- * Session creation (new-chat) and session switching (session-selector-trigger).
- *
- * Source files:
- *   chat-sidebar.tsx      — data-testid="new-chat", data-testid="session-selector"
- *   chat-sessions-dropdown.tsx — data-testid="session-selector-trigger"
- *
- * Overlap note: playground.spec.ts (line 127) also clicks new-chat and asserts
- * getByTitle("New Session 0"). That test is a monolithic integration spec without
- * @stable; this spec is the dedicated, isolated, @stable coverage for the same
- * behavior with different assertions (session-selector count). The header dropdown
- * (session-selector-trigger) is not covered anywhere else.
- */
+// Overlap: playground.spec.ts also clicks new-chat but is a monolithic, non-@stable spec; this is the dedicated @stable coverage with independent assertions.
 
 test.describe.configure({ mode: "serial" });
 
@@ -40,9 +28,8 @@ test.describe("Playground – Session Creation and Navigation", () => {
         });
       });
 
-      const countBefore = await page.getByTestId("session-selector").count();
-
       await test.step("click new-chat and verify session count increases by one", async () => {
+        const countBefore = await page.getByTestId("session-selector").count();
         await page.getByTestId("new-chat").click();
         await expect(page.getByTestId("session-selector")).toHaveCount(
           countBefore + 1,

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-nav.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-nav.spec.ts
@@ -86,10 +86,11 @@ test.describe("Playground – Session Creation and Navigation", () => {
           .getByTestId("session-selector")
           .filter({ hasText: "Default Session" })
           .click();
-        await expect(page.getByText("default session message").first()).toBeVisible({
+        // Use the user-bubble test ID (chat-message-User-{text}) to avoid matching the echoed AI reply.
+        await expect(page.getByTestId("chat-message-User-default session message")).toBeVisible({
           timeout: 10000,
         });
-        await expect(page.getByText("new session message")).toHaveCount(0);
+        await expect(page.getByTestId("chat-message-User-new session message")).toHaveCount(0);
       });
     },
   );

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-nav.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-nav.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "../../../../fixtures/fixtures";
 import { setupPlayground } from "../../../../helpers/flows/setup-playground";
 
 // Overlap: playground.spec.ts also clicks new-chat but is a monolithic, non-@stable spec; this is the dedicated @stable coverage with independent assertions.
+// Session switching is tested via sidebar click (session-selector); the header dropdown (session-selector-trigger) only exists in the fullscreen playground, not in the IOModal.
 
 test.describe.configure({ mode: "serial" });
 
@@ -43,7 +44,7 @@ test.describe("Playground – Session Creation and Navigation", () => {
   );
 
   test(
-    "session selector dropdown must list sessions and switch to the selected one",
+    "session selector sidebar must switch to the selected session",
     { tag: ["@stable", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step("set up ChatInput → ChatOutput flow and open playground", async () => {
@@ -80,16 +81,12 @@ test.describe("Playground – Session Creation and Navigation", () => {
         });
       });
 
-      await test.step("open the session selector dropdown and verify Default Session is listed", async () => {
-        await page.getByTestId("session-selector-trigger").click();
-        await expect(
-          page.getByRole("menuitem", { name: "Default Session" }),
-        ).toBeVisible({ timeout: 5000 });
-      });
-
-      await test.step("switch to Default Session and verify its messages are shown", async () => {
-        await page.getByRole("menuitem", { name: "Default Session" }).click();
-        await expect(page.getByText("default session message")).toBeVisible({
+      await test.step("click the Default Session sidebar entry and verify its messages are shown", async () => {
+        await page
+          .getByTestId("session-selector")
+          .filter({ hasText: "Default Session" })
+          .click();
+        await expect(page.getByText("default session message").first()).toBeVisible({
           timeout: 10000,
         });
         await expect(page.getByText("new session message")).toHaveCount(0);

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-nav.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-nav.spec.ts
@@ -7,6 +7,12 @@ import { setupPlayground } from "../../../../helpers/flows/setup-playground";
  * Source files:
  *   chat-sidebar.tsx      — data-testid="new-chat", data-testid="session-selector"
  *   chat-sessions-dropdown.tsx — data-testid="session-selector-trigger"
+ *
+ * Overlap note: playground.spec.ts (line 127) also clicks new-chat and asserts
+ * getByTitle("New Session 0"). That test is a monolithic integration spec without
+ * @stable; this spec is the dedicated, isolated, @stable coverage for the same
+ * behavior with different assertions (session-selector count). The header dropdown
+ * (session-selector-trigger) is not covered anywhere else.
  */
 
 test.describe.configure({ mode: "serial" });


### PR DESCRIPTION
## Summary

- Adds 3 new `@stable` spec files covering session management behaviors not previously tested in isolation
- Adds matching spec docs under `docs/core-functionality/playground/`
- Updates `QA-CHECKLIST.md` with 7 new `[x]` items (area stats: 19→26 total, 16→23 covered)

## Specs added

| File | Behaviors covered |
|------|-------------------|
| `playground-session-nav.spec.ts` | `new-chat` creates sidebar entry; `session-selector` sidebar switches sessions |
| `playground-message-logs.spec.ts` | `message-logs-option` opens Session Logs modal; ag-grid row selection + `delete-row-button` |
| `playground-bulk-delete.spec.ts` | per-session checkbox reveals `bulk-delete-button`; `select-all-checkbox`; bulk delete preserves Default Session |

> **Note:** `session-selector-trigger` (fullscreen header dropdown) is out of scope for this PR — it only renders in the fullscreen playground, not in the IOModal where these tests run. Covered by the inline comment in the spec file.

## Overlap with `playground.spec.ts`

`playground.spec.ts` is a monolithic integration test (no `@stable`) that also touches `new-chat` and `message-logs-option` as steps inside a larger flow. The new specs are the dedicated, isolated, `@stable` coverage for those behaviors — with different assertions and independent cleanup. The overlap is documented in each affected spec file.

## Test plan

- [ ] `npx playwright test playground-session-nav.spec.ts --trace=on`
- [ ] `npx playwright test playground-message-logs.spec.ts --trace=on`
- [ ] `npx playwright test playground-bulk-delete.spec.ts --trace=on`
- [ ] Force-fail each test to confirm no false positives
- [ ] `npm run typecheck && npm run lint` — both pass clean

Closes #127