### PR TITLE
fix(webhook): add @stable tag and spec doc missing from PR #13

### DIFF
--- a/docs/core-components/webhook-component-regression.md
+++ b/docs/core-components/webhook-component-regression.md
@@ -1,0 +1,175 @@
+# Webhook Component — Regression
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+Validates the full surface of the Webhook component: rendering on the canvas, HTTP endpoint behavior, payload handling, inspector UI fields, and the monitor messages API.
+
+The 10 tests cover:
+
+1. **HTTP POST — JSON and plain-text bodies** — the endpoint accepts both `application/json` and `text/plain` bodies, returning 202 with `{"status": "in progress"}` in both cases.
+2. **Flow persistence** — after autosave, the flow is retrievable via `GET /api/v1/flows/{id}` and contains a Webhook node whose `endpoint.value` stores the `"BACKEND_URL"` placeholder (substituted by the frontend at render time).
+3. **cURL inspector field** — the inspector panel shows a pre-filled cURL command with `-X POST`, the correct `/api/v1/webhook/{flowId}` URL, `Content-Type: application/json`, and `-d`.
+4. **Empty data field** — running the component with no payload produces `{}` in the output inspection modal (`build_data()` short-circuit path).
+5. **Endpoint field renders real URL** — the `str_endpoint` field shows the actual webhook URL (protocol + host + `/api/v1/webhook/`), confirming the `BACKEND_URL` placeholder was resolved by the frontend.
+6. **Copy button** — clicking `btn_copy_str_endpoint` shows the "Endpoint URL copied" toast and writes the correct URL to the clipboard.
+7. **404 for non-existent flow** — `POST /api/v1/webhook/non-existent-flow-e2e-regression-test` returns 404.
+8. **Valid JSON payload propagated** — injecting `{"event": "regression-test", "value": 42}` into the `data` field and running produces the same object in the output inspection modal.
+9. **Invalid JSON payload fallback** — injecting a non-JSON string produces `{"payload": "<raw string>"}` in the output inspection modal (`json.JSONDecodeError` fallback path in `build_data()`).
+10. **Monitor messages API** — `GET /api/v1/monitor/messages` returns 200 with an array body.
+
+If any of these tests fails, the Webhook component is broken in one of its core contracts: HTTP acceptance, payload parsing, UI rendering, or the monitor API.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@regression`
+
+---
+
+## Step by step *(required)*
+
+**Setup helper — `addWebhookComponent`** (shared by tests 1–9)
+1. Call `awaitBootstrapTest` and `cleanAllFlows` to ensure a clean state
+2. Click `blank-flow`
+3. Search "webhook" in the sidebar and wait for `input_outputWebhook` to appear
+4. Hover over the result and click `add-component-button-webhook`
+5. Call `adjustScreenView`
+6. Wait for `input_output_webhook_draggable` to confirm the node is on the canvas
+
+**Test 1 — HTTP POST accepts JSON and plain-text bodies returning 202**
+1. Run `addWebhookComponent`
+2. Extract `flowId` from the URL and assert it matches UUID pattern
+3. Wait 4 s for autosave to persist the flow
+4. POST `{"event": "regression-test", "value": 42}` to `/api/v1/webhook/{flowId}`; assert 202, `status === "in progress"`, `message === "Task started in the background"`
+5. POST `"regression-plain-text"` with `Content-Type: text/plain`; assert 202 and `status === "in progress"`
+
+**Test 2 — flow is saved to database and contains the Webhook node**
+1. Run `addWebhookComponent`
+2. Wait 4 s for autosave
+3. Fetch `GET /api/v1/flows/{flowId}` via `page.evaluate(fetch)` (browser context carries session cookies)
+4. Assert the response is not null and contains a node with `data.type === "Webhook"`
+5. Assert `webhookNode.data.node.template.endpoint.value === "BACKEND_URL"`
+
+**Test 3 — cURL command in inspector shows valid POST URL with flow ID**
+1. Run `addWebhookComponent`
+2. Extract `flowId` from the URL
+3. Wait for the textbox with `placeholder="Type something..."` and read its value
+4. Assert the value contains `-X POST`, `/api/v1/webhook/{flowId}`, `Content-Type: application/json`, and `-d`
+
+**Test 4 — empty data field returns empty Data object**
+1. Run `addWebhookComponent`
+2. Click `button_run_webhook` and wait for "built successfully"
+3. Click `output-inspection-json-webhook`
+4. Wait for `[role="dialog"]` and read the editor textbox content
+5. Parse as JSON and assert it equals `{}`
+6. Press Escape to close
+
+**Test 5 — endpoint field renders the actual webhook URL**
+1. Run `addWebhookComponent`
+2. Wait for `str_endpoint` and read its value
+3. Assert value matches `/^https?:\/\//` and contains `/api/v1/webhook/`
+
+**Test 6 — copy button copies the endpoint URL to clipboard**
+1. Run `addWebhookComponent`
+2. Read the expected URL from `str_endpoint`
+3. Click `btn_copy_str_endpoint`
+4. Assert the "Endpoint URL copied" toast is visible
+5. Read `navigator.clipboard.readText()` via `page.evaluate` and assert it equals the expected URL
+
+**Test 7 — POST to non-existent flow name returns 404**
+1. POST directly to `/api/v1/webhook/non-existent-flow-e2e-regression-test`
+2. Assert the response status is 404 (no browser navigation needed)
+
+**Setup helper — `loadFlowWithDataField`** (shared by tests 8–9)
+1. Register a `page.route` intercept on `GET /api/v1/flows/{flowId}`
+2. Fetch the real response, find the Webhook node, and set `template.data.value` to the provided string
+3. Navigate to `/flow/{flowId}` and wait for `canvas_controls_dropdown` and `button_run_webhook`
+4. Call `adjustScreenView` and `page.unroute` to clean up
+
+**Test 8 — valid JSON payload is propagated as structured Data output**
+1. Run `addWebhookComponent`, extract `flowId`, wait 4 s for autosave
+2. Call `loadFlowWithDataField` with `'{"event": "regression-test", "value": 42}'`
+3. Click `button_run_webhook` and wait for "built successfully"
+4. Click `output-inspection-json-webhook`, wait for dialog, read editor content
+5. Parse as JSON and assert it equals `{"event": "regression-test", "value": 42}`
+6. Press Escape
+
+**Test 9 — invalid JSON payload is encapsulated in `{payload: ...}`**
+1. Run `addWebhookComponent`, extract `flowId`, wait 4 s for autosave
+2. Call `loadFlowWithDataField` with `"not valid json {{broken"`
+3. Click `button_run_webhook` and wait for "built successfully"
+4. Click `output-inspection-json-webhook`, wait for dialog, read editor content
+5. Parse as JSON and assert it equals `{"payload": "not valid json {{broken"}`
+6. Press Escape
+
+**Test 10 — GET /api/v1/monitor/messages returns 200 with array response**
+1. Call `getAuthToken(request)` to obtain a bearer token
+2. GET `/api/v1/monitor/messages` with `Authorization` header
+3. Assert status 200 and that the response body is an array
+
+---
+
+## Validation criterion *(required)*
+
+- `POST /api/v1/webhook/{flowId}` returns 202 for both JSON and plain-text bodies
+- The autosaved flow is retrievable via the flows API and contains a Webhook node with `endpoint.value === "BACKEND_URL"`
+- The cURL inspector field shows a command with correct method, URL, Content-Type header, and body flag
+- Running with empty `data` produces `{}` in the output inspection modal
+- The `str_endpoint` field displays a fully resolved URL beginning with `http://` or `https://`
+- The copy button shows a toast and writes the endpoint URL to the clipboard exactly
+- `POST` to a non-existent flow name returns 404
+- A valid JSON string in `data` produces the parsed object in the output inspection modal
+- An invalid JSON string in `data` is wrapped as `{"payload": "<raw string>"}` in the output inspection modal
+- `GET /api/v1/monitor/messages` returns 200 with an array body
+
+---
+
+## External dependencies *(required)*
+
+- `src/backend/base/langflow/components/inputs/webhook.py` — `WebhookComponent.build_data()`: JSON parsing, fallback wrapping, and empty-data short-circuit; changes here break tests 4, 8, and 9
+- `src/backend/base/langflow/api/v1/endpoints.py` — `POST /api/v1/webhook/{flow_id_or_name}` and `GET /api/v1/monitor/messages` endpoints; status codes and response shape affect tests 1, 7, and 10
+- `src/frontend/src/CustomNodes/GenericNode/components/NodeOutputParameter/` — renders `output-inspection-{name}-{component}` buttons; the `output-inspection-json-webhook` testid depends on the output `display_name` being `"JSON"` (updated in langflow-ai/langflow#11554); breaks tests 4, 8, and 9
+- `src/frontend/src/components/core/parameterRenderComponent/components/webhookFieldComponent/` — renders the cURL field inline as a textbox with `placeholder="Type something..."`; changes to the rendering break test 3
+- `src/frontend/src/components/core/parameterRenderComponent/components/copyFieldAreaComponent/` — renders `btn_copy_{id}` and the "Endpoint URL copied" toast; breaks test 6
+- `src/frontend/src/CustomNodes/GenericNode/` — resolves the `BACKEND_URL` placeholder for `str_endpoint` and `curl_webhook` fields; breaks tests 2, 3, and 5
+
+---
+
+## What this test does not cover *(optional)*
+
+- Webhook with authentication (API key in the request header)
+- Concurrent or high-frequency POST requests to the same flow
+- Binary or multipart payloads
+- Webhook connected to downstream components and producing a chained output
+- Webhook endpoint_name customization (using a slug instead of UUID in the URL)
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
+- No API key required — the Webhook component is a pure HTTP input with no LLM calls
+- Tests 1, 8, and 9 require autosave to flush within 4 s of creating the flow; environments with very high DB latency may need a longer wait
+- The `output-inspection-json-webhook` testid requires Langflow version including langflow-ai/langflow#11554, which renamed the output display name from `"Data"` to `"JSON"`
+
+---
+
+## When to review this test *(optional)*
+
+- If the Webhook component output display name changes again (away from `"JSON"`), the `output-inspection-json-webhook` selector in tests 4, 8, and 9 will break
+- If the `BACKEND_URL` or `CURL_WEBHOOK` placeholder strings are renamed in the frontend substitution logic
+- If the `/api/v1/webhook/` route path changes in the backend router
+- If `CopyFieldAreaComponent` changes its testid pattern (`btn_copy_{id}`)
+
+---
+
+## Notes *(optional)*
+
+- Tests 8 and 9 use `page.route` to inject a value into the Webhook's `data` field (Payload, `advanced=True`), which has no editable UI in the inspector. The intercept patches the `GET /api/v1/flows/{id}` response before the page navigates to the flow, simulating what the real webhook POST would write to that field. The intercept is removed via `page.unroute` after navigation to avoid side-effects.
+- The `request` fixture used in tests 1 and 7 is unauthenticated in Langflow's auto-login mode; the webhook POST endpoint is public (no auth required), but `GET /api/v1/flows/{id}` requires session cookies — that is why test 2 uses `page.evaluate(fetch)` instead of `request.get`.
+- The `output-inspection-json-webhook` testid is generated dynamically by the frontend as `output-inspection-{display_name.toLowerCase()}-{component_type}`; if the output display name reverts to `"Data"`, the testid becomes `output-inspection-data-webhook`.

--- a/tests/tests-automations/regression/core-components/webhook-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/webhook-component-regression.spec.ts
@@ -27,7 +27,7 @@ async function addWebhookComponent(page: any) {
 
 test(
   "Webhook component — HTTP POST accepts JSON and plain-text bodies returning 202",
-  { tag: ["@release", "@regression"] },
+  { tag: ["@stable", "@release", "@regression"] },
   async ({ page, request }) => {
     await addWebhookComponent(page);
 
@@ -59,7 +59,7 @@ test(
 
 test(
   "Webhook component — flow is saved to database and contains the Webhook node",
-  { tag: ["@release", "@regression"] },
+  { tag: ["@stable", "@release", "@regression"] },
   async ({ page, request }) => {
     await addWebhookComponent(page);
 
@@ -99,7 +99,7 @@ test(
 
 test(
   "Webhook component — cURL command in inspector shows valid POST URL with flow ID",
-  { tag: ["@release", "@regression"] },
+  { tag: ["@stable", "@release", "@regression"] },
   async ({ page }) => {
     await addWebhookComponent(page);
 
@@ -133,7 +133,7 @@ test(
 
 test(
   "Webhook component — empty data field returns empty Data object",
-  { tag: ["@release", "@regression"] },
+  { tag: ["@stable", "@release", "@regression"] },
   async ({ page }) => {
     await addWebhookComponent(page);
 
@@ -165,7 +165,7 @@ test(
 
 test(
   "Webhook component — endpoint field renders the actual webhook URL",
-  { tag: ["@release", "@regression"] },
+  { tag: ["@stable", "@release", "@regression"] },
   async ({ page }) => {
     await addWebhookComponent(page);
 
@@ -190,7 +190,7 @@ test(
 
 test(
   "Webhook component — copy button copies the endpoint URL to clipboard",
-  { tag: ["@release", "@regression"] },
+  { tag: ["@stable", "@release", "@regression"] },
   async ({ page }) => {
     await addWebhookComponent(page);
 
@@ -225,7 +225,7 @@ test(
 
 test(
   "Webhook component — POST to non-existent flow name returns 404",
-  { tag: ["@release", "@regression"] },
+  { tag: ["@stable", "@release", "@regression"] },
   async ({ request }) => {
     // The webhook endpoint returns 404 when the flow_id_or_name cannot be resolved.
     // This is confirmed by the backend unit test: test_webhook_not_found_invalid_endpoint.
@@ -282,7 +282,7 @@ async function loadFlowWithDataField(
 
 test(
   "Webhook component — valid JSON payload is propagated as structured Data output",
-  { tag: ["@release", "@regression"] },
+  { tag: ["@stable", "@release", "@regression"] },
   async ({ page }) => {
     await addWebhookComponent(page);
     const flowId = page.url().split("/").slice(-1)[0];
@@ -322,7 +322,7 @@ test(
 
 test(
   "Webhook component — invalid JSON payload is encapsulated in {payload: ...}",
-  { tag: ["@release", "@regression"] },
+  { tag: ["@stable", "@release", "@regression"] },
   async ({ page }) => {
     await addWebhookComponent(page);
     const flowId = page.url().split("/").slice(-1)[0];
@@ -359,7 +359,7 @@ test(
 
 test(
   "GET /api/v1/monitor/messages returns 200 with array response",
-  { tag: ["@release", "@regression"] },
+  { tag: ["@stable", "@release", "@regression"] },
   async ({ request }) => {
     const authToken = await getAuthToken(request);
 


### PR DESCRIPTION
## Summary

- Adds `@stable` to all 10 tests in `webhook-component-regression.spec.ts` (tag was omitted from PR #13)
- Creates `docs/core-components/webhook-component-regression.md` following the spec doc standard (doc was not delivered in PR #13)

Closes #13

## Commits

- `feat(webhook): add @stable tag to all 10 webhook regression tests`
- `docs(webhook): add spec doc for webhook-component-regression`