### PR TITLE
test(playground): session creation, switching, logs and bulk delete (#127)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -418,6 +418,13 @@
 - [x] Rename unavailable for the Default Session → `core-functionality/playground/playground-session-rename.spec.ts`
 - [x] Rename unavailable for a session with no messages → `core-functionality/playground/playground-session-rename.spec.ts`
 - [x] Rename available and functional for a session with messages (Enter confirms, Escape cancels) → `core-functionality/playground/playground-session-rename.spec.ts`
+- [x] new-chat button creates a new session with isolated message history → `core-functionality/playground/playground-session-create-switch.spec.ts`
+- [x] Switching sessions via sidebar preserves message isolation in both directions → `core-functionality/playground/playground-session-create-switch.spec.ts`
+- [x] message-logs-option opens Session Logs modal → `core-functionality/playground/playground-session-logs.spec.ts`
+- [-] Delete messages from Session Logs table (disabled in playground context — playgroundPage === true disables row selection) → `core-functionality/playground/playground-session-logs.spec.ts`
+- [x] Individual session checkbox reveals bulk-delete-button → `core-functionality/playground/playground-session-bulk-delete.spec.ts`
+- [x] select-all-checkbox selects/deselects all non-default sessions → `core-functionality/playground/playground-session-bulk-delete.spec.ts`
+- [x] bulk-delete-button removes all selected sessions from the sidebar → `core-functionality/playground/playground-session-bulk-delete.spec.ts`
 
 #### 9.3 Advanced Playground Features
 - [x] Playground fullscreen mode → `playground/playground-fullscreen.spec.ts`

--- a/docs/core-functionality/playground/playground-session-bulk-delete.md
+++ b/docs/core-functionality/playground/playground-session-bulk-delete.md
@@ -1,0 +1,59 @@
+# Playground – Bulk Session Deletion
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+Validates the bulk session management controls in the Playground sidebar: individual session selection via checkbox, select-all toggle, and bulk deletion. If these tests fail, users cannot efficiently manage multiple sessions at once.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@playground`
+
+---
+
+## Step by step *(required)*
+
+**Test 1 — Individual checkbox reveals bulk-delete-button**
+1. Set up flow, open Playground, create 1 user session via `new-chat`
+2. Click `session-{id}-checkbox` for the user session
+3. Verify `bulk-delete-button` becomes visible
+
+**Test 2 — select-all-checkbox selects all non-default sessions**
+1. Create 2 user sessions
+2. Click `select-all-checkbox`
+3. Verify ≥2 individual session checkboxes exist and `bulk-delete-button` is visible
+4. Click `select-all-checkbox` again — verify `bulk-delete-button` is removed from DOM (count 0)
+
+**Test 3 — bulk-delete-button removes all selected sessions**
+1. Create 2 user sessions, select all via `select-all-checkbox`
+2. Click `bulk-delete-button`
+3. Verify sidebar has exactly 1 `session-selector` (only Default session remains)
+4. Verify no `session-{id}-checkbox` elements remain
+
+---
+
+## Validation criterion *(required)*
+
+- `bulk-delete-button` appears only when at least one session is selected; it is removed from the DOM (not hidden) when `selectedSessions.size === 0`
+- After `select-all-checkbox`, all individual session checkboxes are present and `bulk-delete-button` is visible
+- After bulk delete, sidebar returns to exactly 1 session (Default)
+
+---
+
+## External dependencies *(required)*
+
+- `src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/chat-sidebar.tsx` — `select-all-checkbox`, `bulk-delete-button`, and the `selectedSessions` state
+- `src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/session-selector.tsx` — `session-{id}-checkbox` on each user session row
+
+---
+
+## Notes *(optional)*
+
+- The Default session (`flowId`) is excluded from checkboxes — only user-created sessions are selectable.
+- `select-all-checkbox` renders only after the first non-default session entry exists in the list.
+- No confirmation dialog is shown before bulk deletion — `handleBulkDelete` fires directly.

--- a/docs/core-functionality/playground/playground-session-create-switch.md
+++ b/docs/core-functionality/playground/playground-session-create-switch.md
@@ -1,0 +1,65 @@
+# Playground – Session Creation and Switching
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+Validates that users can create new sessions via the sidebar `new-chat` button and switch between sessions using the sidebar. Each session maintains isolated message history — messages sent in one session are not visible in another. If these tests fail, multi-session workflows in the Playground are broken.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@playground`
+
+---
+
+## Step by step *(required)*
+
+**Test 1 — new-chat creates an isolated session**
+1. Set up ChatInput → ChatOutput flow and open Playground
+2. Send "default-session-message" in Default session
+3. Click `new-chat` button — verify sidebar `session-selector` count increases by 1
+4. Verify new session starts with empty chat (0 `div-chat-message` elements)
+5. Send "new-session-message" in new session
+6. Click first `session-selector` (Default session) in the sidebar
+7. Verify "default-session-message" is visible in `div-chat-message` and "new-session-message" is not
+
+**Test 2 — Switching sessions via sidebar preserves isolation in both directions**
+1. Set up flow, open Playground, send "switch-test-default" in Default session
+2. Click `new-chat`, send "switch-test-new-session" in new session
+3. Click first `session-selector` (Default) — verify Default message visible, new-session message absent
+4. Click last `session-selector` (new session) — verify new-session message visible, Default message absent
+
+---
+
+## Validation criterion *(required)*
+
+- After `new-chat`, sidebar has one more `session-selector` item
+- New session has 0 messages immediately after creation
+- After switching sessions, only the selected session's messages are shown in `div-chat-message`
+- Message isolation is verified in both switch directions
+
+---
+
+## External dependencies *(required)*
+
+- `src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/chat-sidebar.tsx` — `new-chat` button
+- `src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/session-selector.tsx` — `session-selector` items
+
+---
+
+## What this test does not cover *(optional)*
+
+- The `session-selector-trigger` header dropdown (`ChatSessionsDropdown`) is architecturally untestable in normal flow: it lives inside the `{!isFullscreen}` conditional in `ChatHeader`, and the flow-page playground always opens in fullscreen mode (`FlowPage.onOpenChange` sets `isFullscreen=true`). The element is never rendered during a standard test run. Session switching via the sidebar exercises the same underlying store logic.
+- Session persistence across browser reloads (covered in `playground-history-persist.spec.ts`)
+- Session rename (covered in `playground-session-rename.spec.ts`)
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`
+- No LLM required — ChatInput → ChatOutput is synchronous

--- a/docs/core-functionality/playground/playground-session-logs.md
+++ b/docs/core-functionality/playground/playground-session-logs.md
@@ -1,0 +1,55 @@
+# Playground – Message Logs
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+Validates that the Session Logs modal opens correctly from the session more menu and displays the session's messages in an ag-grid table. If this test fails, users cannot inspect individual message history for a session.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@playground` (Test 1)
+`@regression` `@playground` (Test 2 — skipped, see Notes)
+
+---
+
+## Step by step *(required)*
+
+**Test 1 — Open Message Logs modal**
+1. Set up flow, open Playground, send a message
+2. Click session more menu (`[data-testid^="session-"][data-testid$="-more-menu"]`)
+3. Click `message-logs-option`
+4. Verify modal opens with "Session logs" heading and the sent message visible inside `[role="dialog"]`
+
+**Test 2 — Delete messages from the table (skipped)**
+1. Set up flow, open Playground, send a message
+2. Open Session Logs modal
+3. Click `.ag-selection-checkbox` to select the row — verify `delete-row-button` appears
+4. Click `delete-row-button` — verify table has 0 rows
+
+---
+
+## Validation criterion *(required)*
+
+- "Session logs" text is visible after clicking `message-logs-option`
+- Sent message text appears inside the modal dialog
+
+---
+
+## External dependencies *(required)*
+
+- `src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/session-more-menu.tsx` — `message-logs-option`
+- `src/frontend/src/modals/IOModal/components/session-view.tsx` — table with row selection and delete; controls `playgroundPage` flag
+- `src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/TableOptions/index.tsx` — `delete-row-button`
+
+---
+
+## Notes *(optional)*
+
+- **Test 2 is permanently skipped:** When the Session Logs modal is opened from the Playground, `SessionView` receives `playgroundPage === true`, which sets `rowSelection={undefined}` and `onDelete={undefined}`. As a result, `.ag-selection-checkbox` and `delete-row-button` are never rendered. The test body is retained for future reference in case this restriction is lifted.
+- The Session Logs modal renders `"Session logs"` with a lowercase L (confirmed from source).
+- The ag-grid table shows both the user message and the bot echo as separate rows; assertions use `.first()` to target either.

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-bulk-delete.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-bulk-delete.spec.ts
@@ -1,0 +1,146 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+
+async function sendMessage(page: Page, text: string): Promise<void> {
+  await page.getByTestId("input-chat-playground").last().fill(text);
+  await page.getByTestId("button-send").last().click();
+  await expect(page.getByText(text).last()).toBeVisible({ timeout: 10000 });
+  await expect(page.getByTestId("button-stop")).toBeHidden({ timeout: 30000 });
+}
+
+async function createSession(page: Page, message: string): Promise<string> {
+  await page.getByTestId("new-chat").click();
+  await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+    timeout: 10000,
+  });
+  await sendMessage(page, message);
+  // Read the session ID from the last sidebar entry's more-menu testid
+  const lastMenuTestid = await page
+    .locator('[data-testid^="session-"][data-testid$="-more-menu"]')
+    .last()
+    .getAttribute("data-testid");
+  // testid format: session-{id}-more-menu
+  return (lastMenuTestid ?? "").replace(/^session-/, "").replace(/-more-menu$/, "");
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Playground – Bulk Session Deletion", () => {
+  let createdFlowId: string | null = null;
+
+  test.afterEach(async ({ page }) => {
+    if (createdFlowId) {
+      await page.goto("/");
+      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      createdFlowId = null;
+    }
+  });
+
+  test(
+    "selecting individual session checkbox reveals bulk-delete-button",
+    { tag: ["@stable", "@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step("Set up flow, open Playground, create a session", async () => {
+        createdFlowId = await setupPlayground(page);
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(page.getByTestId("input-chat-playground")).toBeVisible({
+          timeout: 15000,
+        });
+        await createSession(page, "bulk-test-session-1");
+      });
+
+      await test.step("Click the session checkbox to select it", async () => {
+        const checkbox = page
+          .locator('[data-testid^="session-"][data-testid$="-checkbox"]')
+          .first();
+        await expect(checkbox).toBeVisible({ timeout: 5000 });
+        await checkbox.click();
+      });
+
+      await test.step("Verify bulk-delete-button appears after selection", async () => {
+        await expect(page.getByTestId("bulk-delete-button")).toBeVisible({
+          timeout: 5000,
+        });
+      });
+    },
+  );
+
+  test(
+    "select-all-checkbox selects all non-default sessions",
+    { tag: ["@stable", "@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step("Set up flow, open Playground, create two sessions", async () => {
+        createdFlowId = await setupPlayground(page);
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(page.getByTestId("input-chat-playground")).toBeVisible({
+          timeout: 15000,
+        });
+        await createSession(page, "select-all-session-1");
+        await createSession(page, "select-all-session-2");
+      });
+
+      await test.step("Click select-all-checkbox", async () => {
+        await expect(page.getByTestId("select-all-checkbox")).toBeVisible({
+          timeout: 5000,
+        });
+        await page.getByTestId("select-all-checkbox").click();
+      });
+
+      await test.step("Verify all individual session checkboxes show selected state and bulk-delete-button appears", async () => {
+        const individualCheckboxes = page.locator(
+          '[data-testid^="session-"][data-testid$="-checkbox"]',
+        );
+        const count = await individualCheckboxes.count();
+        expect(count, "Expected at least 2 individual session checkboxes").toBeGreaterThanOrEqual(2);
+        await expect(page.getByTestId("bulk-delete-button")).toBeVisible({
+          timeout: 5000,
+        });
+      });
+
+      await test.step("Click select-all again to deselect all", async () => {
+        await page.getByTestId("select-all-checkbox").click();
+        await expect(page.getByTestId("bulk-delete-button")).toHaveCount(0, {
+          timeout: 5000,
+        });
+      });
+    },
+  );
+
+  test(
+    "bulk-delete-button removes all selected sessions from the sidebar",
+    { tag: ["@stable", "@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step("Set up flow, open Playground, create two sessions", async () => {
+        createdFlowId = await setupPlayground(page);
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(page.getByTestId("input-chat-playground")).toBeVisible({
+          timeout: 15000,
+        });
+        await createSession(page, "bulk-delete-session-1");
+        await createSession(page, "bulk-delete-session-2");
+      });
+
+      await test.step("Select all sessions and click bulk-delete-button", async () => {
+        await page.getByTestId("select-all-checkbox").click();
+        await expect(page.getByTestId("bulk-delete-button")).toBeVisible({
+          timeout: 5000,
+        });
+        const sessionCountBefore = await page
+          .locator('[data-testid="session-selector"]')
+          .count();
+        await page.getByTestId("bulk-delete-button").click();
+        // Only Default session remains after bulk delete
+        await expect(
+          page.locator('[data-testid="session-selector"]'),
+        ).toHaveCount(sessionCountBefore - 2, { timeout: 10000 });
+      });
+
+      await test.step("Verify no session checkboxes remain (all user sessions deleted)", async () => {
+        await expect(
+          page.locator('[data-testid^="session-"][data-testid$="-checkbox"]'),
+        ).toHaveCount(0, { timeout: 5000 });
+      });
+    },
+  );
+});

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-bulk-delete.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-bulk-delete.spec.ts
@@ -9,19 +9,12 @@ async function sendMessage(page: Page, text: string): Promise<void> {
   await expect(page.getByTestId("button-stop")).toBeHidden({ timeout: 30000 });
 }
 
-async function createSession(page: Page, message: string): Promise<string> {
+async function createSession(page: Page, message: string): Promise<void> {
   await page.getByTestId("new-chat").click();
   await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
     timeout: 10000,
   });
   await sendMessage(page, message);
-  // Read the session ID from the last sidebar entry's more-menu testid
-  const lastMenuTestid = await page
-    .locator('[data-testid^="session-"][data-testid$="-more-menu"]')
-    .last()
-    .getAttribute("data-testid");
-  // testid format: session-{id}-more-menu
-  return (lastMenuTestid ?? "").replace(/^session-/, "").replace(/-more-menu$/, "");
 }
 
 test.describe.configure({ mode: "serial" });
@@ -126,14 +119,11 @@ test.describe("Playground – Bulk Session Deletion", () => {
         await expect(page.getByTestId("bulk-delete-button")).toBeVisible({
           timeout: 5000,
         });
-        const sessionCountBefore = await page
-          .locator('[data-testid="session-selector"]')
-          .count();
         await page.getByTestId("bulk-delete-button").click();
-        // Only Default session remains after bulk delete
+        // Only the Default session remains after bulk delete
         await expect(
           page.locator('[data-testid="session-selector"]'),
-        ).toHaveCount(sessionCountBefore - 2, { timeout: 10000 });
+        ).toHaveCount(1, { timeout: 10000 });
       });
 
       await test.step("Verify no session checkboxes remain (all user sessions deleted)", async () => {

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-create-switch.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-create-switch.spec.ts
@@ -1,0 +1,168 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+
+/**
+ * Session behavior confirmed from source:
+ *   - `new-chat` button creates a new isolated session in the sidebar
+ *   - `session-selector` testid is present on each session row (Default + user-created)
+ *   - `session-selector-trigger` opens the header dropdown (ChatSessionsDropdown) — this
+ *     button lives in the `{!isFullscreen}` branch of ChatHeader. The playground always
+ *     opens in fullscreen mode (FlowPage sets isFullscreen=true on first open), so
+ *     session-selector-trigger is not rendered during normal test flow. Session switching
+ *     is therefore tested exclusively via the sidebar session-selector items.
+ *   - Switching sessions via sidebar: click the `session-selector` item directly
+ *
+ * Serial mode is required: both tests share the Langflow backend.
+ * Flow cleanup in afterEach deletes flows to avoid state leakage.
+ */
+
+async function sendMessage(page: Page, text: string): Promise<void> {
+  await page.getByTestId("input-chat-playground").last().fill(text);
+  await page.getByTestId("button-send").last().click();
+  await expect(page.getByText(text).last()).toBeVisible({ timeout: 10000 });
+  await expect(page.getByTestId("button-stop")).toBeHidden({ timeout: 30000 });
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Playground – Session Create & Switch", () => {
+  let createdFlowId: string | null = null;
+
+  test.afterEach(async ({ page }) => {
+    if (createdFlowId) {
+      await page.goto("/");
+      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      createdFlowId = null;
+    }
+  });
+
+  test(
+    "new-chat button creates a new session with isolated message history",
+    { tag: ["@stable", "@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step("Set up ChatInput → ChatOutput flow and open playground", async () => {
+        createdFlowId = await setupPlayground(page);
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(page.getByTestId("button-send")).toBeVisible({
+          timeout: 15000,
+        });
+      });
+
+      await test.step("Send a message in the Default session", async () => {
+        await sendMessage(page, "default-session-message");
+      });
+
+      const sessionsBefore = page.getByTestId("session-selector");
+      let countBefore: number;
+
+      await test.step("Record session count before creating new session", async () => {
+        countBefore = await sessionsBefore.count();
+      });
+
+      await test.step("Click new-chat and verify sidebar count increases by 1", async () => {
+        await page.getByTestId("new-chat").click();
+        await expect(sessionsBefore).toHaveCount(countBefore + 1, {
+          timeout: 10000,
+        });
+      });
+
+      await test.step("Verify new session starts with 0 messages", async () => {
+        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+          timeout: 10000,
+        });
+        await expect(page.getByTestId("div-chat-message")).toHaveCount(0, {
+          timeout: 5000,
+        });
+      });
+
+      await test.step("Send a message in the new session", async () => {
+        await sendMessage(page, "new-session-message");
+      });
+
+      await test.step("Switch back to Default session via sidebar", async () => {
+        // The first session-selector item is the Default session
+        await page.getByTestId("session-selector").first().click();
+        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+          timeout: 10000,
+        });
+      });
+
+      await test.step("Verify Default session shows its message and not the new session's message", async () => {
+        await expect(page.getByText("default-session-message").last()).toBeVisible({
+          timeout: 10000,
+        });
+        await expect(
+          page.getByText("new-session-message"),
+        ).toHaveCount(0, { timeout: 5000 });
+      });
+    },
+  );
+
+  test(
+    "switching sessions via sidebar preserves message isolation in both directions",
+    { tag: ["@stable", "@regression", "@playground"] },
+    async ({ page }) => {
+      /**
+       * NOTE: session-selector-trigger (header dropdown) lives inside the
+       * `{!isFullscreen}` branch of ChatHeader. The flow-page playground always
+       * opens in fullscreen mode (FlowPage.onOpenChange sets isFullscreen=true),
+       * so that element is never rendered. Session switching is validated here
+       * via the sidebar session-selector, exercising the same underlying store
+       * logic that the header dropdown also invokes.
+       */
+      await test.step("Set up ChatInput → ChatOutput flow and open playground", async () => {
+        createdFlowId = await setupPlayground(page);
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(page.getByTestId("button-send")).toBeVisible({
+          timeout: 15000,
+        });
+      });
+
+      await test.step("Send a message in the Default session", async () => {
+        await sendMessage(page, "switch-test-default");
+      });
+
+      await test.step("Create a new session and send a message", async () => {
+        await page.getByTestId("new-chat").click();
+        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+          timeout: 10000,
+        });
+        await expect(page.getByTestId("div-chat-message")).toHaveCount(0, {
+          timeout: 5000,
+        });
+        await sendMessage(page, "switch-test-new-session");
+      });
+
+      await test.step("Switch back to Default session via sidebar and verify isolation", async () => {
+        // First session-selector is Default; clicking it switches the active session
+        await page.getByTestId("session-selector").first().click();
+        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+          timeout: 10000,
+        });
+        await expect(page.getByText("switch-test-default").last()).toBeVisible({
+          timeout: 10000,
+        });
+        // New-session message must not appear in Default session
+        await expect(page.getByText("switch-test-new-session")).toHaveCount(0, {
+          timeout: 5000,
+        });
+      });
+
+      await test.step("Switch back to new session and verify its message is preserved", async () => {
+        // Second session-selector is the user-created session
+        await page.getByTestId("session-selector").last().click();
+        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+          timeout: 10000,
+        });
+        await expect(page.getByText("switch-test-new-session").last()).toBeVisible({
+          timeout: 10000,
+        });
+        // Default session message must not bleed into new session
+        await expect(page.getByText("switch-test-default")).toHaveCount(0, {
+          timeout: 5000,
+        });
+      });
+    },
+  );
+});

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-create-switch.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-create-switch.spec.ts
@@ -26,7 +26,7 @@ async function sendMessage(page: Page, text: string): Promise<void> {
 
 test.describe.configure({ mode: "serial" });
 
-test.describe("Playground – Session Create & Switch", () => {
+test.describe("Playground – Session Creation and Switching", () => {
   let createdFlowId: string | null = null;
 
   test.afterEach(async ({ page }) => {
@@ -53,24 +53,19 @@ test.describe("Playground – Session Create & Switch", () => {
         await sendMessage(page, "default-session-message");
       });
 
-      const sessionsBefore = page.getByTestId("session-selector");
-      let countBefore: number;
-
-      await test.step("Record session count before creating new session", async () => {
-        countBefore = await sessionsBefore.count();
-      });
-
       await test.step("Click new-chat and verify sidebar count increases by 1", async () => {
+        const countBefore = await page.getByTestId("session-selector").count();
         await page.getByTestId("new-chat").click();
-        await expect(sessionsBefore).toHaveCount(countBefore + 1, {
-          timeout: 10000,
-        });
+        await expect(page.getByTestId("session-selector")).toHaveCount(
+          countBefore + 1,
+          { timeout: 10000 },
+        );
       });
 
       await test.step("Verify new session starts with 0 messages", async () => {
-        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
-          timeout: 10000,
-        });
+        await expect(
+          page.getByTestId("input-chat-playground").last(),
+        ).toBeVisible({ timeout: 10000 });
         await expect(page.getByTestId("div-chat-message")).toHaveCount(0, {
           timeout: 5000,
         });
@@ -83,17 +78,20 @@ test.describe("Playground – Session Create & Switch", () => {
       await test.step("Switch back to Default session via sidebar", async () => {
         // The first session-selector item is the Default session
         await page.getByTestId("session-selector").first().click();
-        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
-          timeout: 10000,
-        });
+        await expect(
+          page.getByTestId("input-chat-playground").last(),
+        ).toBeVisible({ timeout: 10000 });
       });
 
       await test.step("Verify Default session shows its message and not the new session's message", async () => {
-        await expect(page.getByText("default-session-message").last()).toBeVisible({
-          timeout: 10000,
-        });
         await expect(
-          page.getByText("new-session-message"),
+          page
+            .getByTestId("div-chat-message")
+            .getByText("default-session-message")
+            .last(),
+        ).toBeVisible({ timeout: 10000 });
+        await expect(
+          page.getByTestId("div-chat-message").getByText("new-session-message"),
         ).toHaveCount(0, { timeout: 5000 });
       });
     },
@@ -125,9 +123,9 @@ test.describe("Playground – Session Create & Switch", () => {
 
       await test.step("Create a new session and send a message", async () => {
         await page.getByTestId("new-chat").click();
-        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
-          timeout: 10000,
-        });
+        await expect(
+          page.getByTestId("input-chat-playground").last(),
+        ).toBeVisible({ timeout: 10000 });
         await expect(page.getByTestId("div-chat-message")).toHaveCount(0, {
           timeout: 5000,
         });
@@ -137,31 +135,41 @@ test.describe("Playground – Session Create & Switch", () => {
       await test.step("Switch back to Default session via sidebar and verify isolation", async () => {
         // First session-selector is Default; clicking it switches the active session
         await page.getByTestId("session-selector").first().click();
-        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
-          timeout: 10000,
-        });
-        await expect(page.getByText("switch-test-default").last()).toBeVisible({
-          timeout: 10000,
-        });
+        await expect(
+          page.getByTestId("input-chat-playground").last(),
+        ).toBeVisible({ timeout: 10000 });
+        await expect(
+          page
+            .getByTestId("div-chat-message")
+            .getByText("switch-test-default")
+            .last(),
+        ).toBeVisible({ timeout: 10000 });
         // New-session message must not appear in Default session
-        await expect(page.getByText("switch-test-new-session")).toHaveCount(0, {
-          timeout: 5000,
-        });
+        await expect(
+          page
+            .getByTestId("div-chat-message")
+            .getByText("switch-test-new-session"),
+        ).toHaveCount(0, { timeout: 5000 });
       });
 
       await test.step("Switch back to new session and verify its message is preserved", async () => {
         // Second session-selector is the user-created session
         await page.getByTestId("session-selector").last().click();
-        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
-          timeout: 10000,
-        });
-        await expect(page.getByText("switch-test-new-session").last()).toBeVisible({
-          timeout: 10000,
-        });
+        await expect(
+          page.getByTestId("input-chat-playground").last(),
+        ).toBeVisible({ timeout: 10000 });
+        await expect(
+          page
+            .getByTestId("div-chat-message")
+            .getByText("switch-test-new-session")
+            .last(),
+        ).toBeVisible({ timeout: 10000 });
         // Default session message must not bleed into new session
-        await expect(page.getByText("switch-test-default")).toHaveCount(0, {
-          timeout: 5000,
-        });
+        await expect(
+          page
+            .getByTestId("div-chat-message")
+            .getByText("switch-test-default"),
+        ).toHaveCount(0, { timeout: 5000 });
       });
     },
   );

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-logs.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-logs.spec.ts
@@ -54,9 +54,10 @@ test.describe("Playground – Message Logs", () => {
         await expect(
           page.getByText("Session logs").first(),
         ).toBeVisible({ timeout: 10000 });
-        // The sent message must appear inside the logs table.
+        // Scope to the dialog to avoid matching the chat history in the background.
+        // The table shows both the user message and bot echo, so .first() disambiguates.
         await expect(
-          page.getByText("log-test-message").last(),
+          page.locator('[role="dialog"]').getByText("log-test-message").first(),
         ).toBeVisible({ timeout: 10000 });
       });
     },
@@ -70,8 +71,10 @@ test.describe("Playground – Message Logs", () => {
   // skipped and documents the finding for future re-evaluation.
   test(
     "delete-row-button removes selected messages from the Session Logs table",
-    { tag: ["@stable", "@regression", "@playground"] },
+    { tag: ["@regression", "@playground"] },
     async ({ page }) => {
+      // @stable is intentionally absent: this test is permanently skipped because the feature
+      // under test (row deletion) is disabled in the playground context — it cannot be validated.
       test.skip(
         true,
         "Row selection and delete are disabled in playground context (playgroundPage === true). " +

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-logs.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-logs.spec.ts
@@ -1,0 +1,123 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+
+async function sendMessage(page: Page, text: string): Promise<void> {
+  await page.getByTestId("input-chat-playground").last().fill(text);
+  await page.getByTestId("button-send").last().click();
+  await expect(page.getByText(text).last()).toBeVisible({ timeout: 10000 });
+  await expect(page.getByTestId("button-stop")).toBeHidden({ timeout: 30000 });
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Playground – Message Logs", () => {
+  let createdFlowId: string | null = null;
+
+  test.afterEach(async ({ page }) => {
+    if (createdFlowId) {
+      await page.goto("/");
+      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      createdFlowId = null;
+    }
+  });
+
+  test(
+    "message-logs-option opens Session Logs modal for the session",
+    { tag: ["@stable", "@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step("Set up flow, open Playground, and send a message", async () => {
+        createdFlowId = await setupPlayground(page);
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(page.getByTestId("input-chat-playground")).toBeVisible({
+          timeout: 15000,
+        });
+        await sendMessage(page, "log-test-message");
+      });
+
+      await test.step("Open session more menu and click message-logs-option", async () => {
+        // The session more-menu button is inside ChatSidebar's SessionSelector.
+        // Its testid is dynamic: session-{sessionId}-more-menu.
+        // We target it with a partial-match pattern.
+        await page
+          .locator('[data-testid^="session-"][data-testid$="-more-menu"]')
+          .first()
+          .click();
+        await expect(page.getByTestId("message-logs-option")).toBeVisible({
+          timeout: 5000,
+        });
+        await page.getByTestId("message-logs-option").click();
+      });
+
+      await test.step("Verify Session Logs modal is open", async () => {
+        // The modal header renders "Session logs" (lowercase L).
+        await expect(
+          page.getByText("Session logs").first(),
+        ).toBeVisible({ timeout: 10000 });
+        // The sent message must appear inside the logs table.
+        await expect(
+          page.getByText("log-test-message").last(),
+        ).toBeVisible({ timeout: 10000 });
+      });
+    },
+  );
+
+  // NOTE: row selection and delete are disabled when playgroundPage === true.
+  // SessionView sets rowSelection={undefined} and onDelete={undefined} when
+  // playgroundPage is true (see session-view.tsx). The delete-row-button is
+  // only rendered by TableOptions when the deleteRow prop is defined, so it
+  // is never present in the playground context. This test is intentionally
+  // skipped and documents the finding for future re-evaluation.
+  test(
+    "delete-row-button removes selected messages from the Session Logs table",
+    { tag: ["@stable", "@regression", "@playground"] },
+    async ({ page }) => {
+      test.skip(
+        true,
+        "Row selection and delete are disabled in playground context (playgroundPage === true). " +
+          "SessionView passes rowSelection={undefined} and onDelete={undefined} when opened from " +
+          "the playground, so .ag-selection-checkbox and delete-row-button are never rendered.",
+      );
+
+      await test.step("Set up flow, open Playground, and send a message", async () => {
+        createdFlowId = await setupPlayground(page);
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(page.getByTestId("input-chat-playground")).toBeVisible({
+          timeout: 15000,
+        });
+        await sendMessage(page, "message-to-delete");
+      });
+
+      await test.step("Open Session Logs modal", async () => {
+        await page
+          .locator('[data-testid^="session-"][data-testid$="-more-menu"]')
+          .first()
+          .click();
+        await expect(page.getByTestId("message-logs-option")).toBeVisible({
+          timeout: 5000,
+        });
+        await page.getByTestId("message-logs-option").click();
+        await expect(page.getByText("Session logs").first()).toBeVisible({
+          timeout: 10000,
+        });
+      });
+
+      await test.step("Select the message row in the table", async () => {
+        await expect(page.locator(".ag-row").first()).toBeVisible({
+          timeout: 10000,
+        });
+        await page.locator(".ag-selection-checkbox").first().click();
+        await expect(page.getByTestId("delete-row-button")).toBeVisible({
+          timeout: 5000,
+        });
+      });
+
+      await test.step("Delete the selected row and verify it is removed", async () => {
+        await page.getByTestId("delete-row-button").click();
+        await expect(page.locator(".ag-row")).toHaveCount(0, {
+          timeout: 10000,
+        });
+      });
+    },
+  );
+});


### PR DESCRIPTION
## What this PR covers

Closes #127

Adds E2E regression tests for uncovered Playground session management behaviors:

- **Session creation & switching** — `new-chat` creates an isolated session; switching via sidebar preserves message history in both directions
- **Message Logs modal** — opens Session Logs modal from the session more-menu; verifies message appears in the ag-grid table
- **Bulk session deletion** — individual checkbox reveals `bulk-delete-button`; `select-all-checkbox` selects/deselects all; bulk delete removes all user sessions leaving only Default

## Architectural findings

**`session-selector-trigger` inaccessible:** The header dropdown (`ChatSessionsDropdown`) lives inside `{!isFullscreen}` in `ChatHeader`. The flow-page playground always opens fullscreen (`FlowPage.onOpenChange` sets `isFullscreen=true`), so this element is never rendered. Session switching is validated via sidebar `session-selector` items, which invoke the same store logic.

**Row deletion disabled in playground context:** `SessionView` receives `playgroundPage === true` when opened from the playground, which sets `rowSelection={undefined}` and `onDelete={undefined}`. The `delete-row-button` is never rendered. Test 2 in `playground-session-logs.spec.ts` is permanently skipped with a documented reason.

## Files changed

| File | Description |
|------|-------------|
| `playground-session-create-switch.spec.ts` | 2 tests — session creation + bidirectional switching |
| `playground-session-logs.spec.ts` | 1 passing test (modal open) + 1 skipped (delete disabled) |
| `playground-session-bulk-delete.spec.ts` | 3 tests — individual checkbox, select-all, bulk delete |
| `docs/.../playground-session-create-switch.md` | Spec doc |
| `docs/.../playground-session-logs.md` | Spec doc (with note on skipped test) |
| `docs/.../playground-session-bulk-delete.md` | Spec doc |
| `QA-CHECKLIST.md` | 7 new entries under `core-functionality/playground/` |

## Test results

```
6 passed, 1 skipped (intentional)
```

All active tests carry `@stable @regression @playground` tags.