### PR TITLE
chore(playground): add @stable and spec doc to playground-session-clear

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -414,6 +414,7 @@
 - [x] Edit user message — hover reveals edit button, saved changes replace original text → `core-functionality/playground/playground-message-edit.spec.ts`
 - [x] Cancel message edit — original text is preserved → `core-functionality/playground/playground-message-edit.spec.ts`
 - [x] Message edited in playground is reflected in Session Logs → `core-functionality/playground/playground-message-edit.spec.ts`
+- [x] Clear chat removes all messages from Default Session (clear-chat-option via header menu) → `core-functionality/playground/playground-session-clear.spec.ts`
 - [x] Clear full session history (Default session) → `playground/playground-clear-history.spec.ts`
 - [x] Delete user-created session → `playground/playground-clear-history.spec.ts`
 - [-] History persists when reopening Playground → `playground/playground-history-persist.spec.ts`
@@ -666,7 +667,7 @@
 | `api/` — REST API | 17 | 17 | 0 | 0 |
 | `core-components/` — Config | 20 | 18 | 0 | 2 |
 | `core-components/` — Components | 22 | 16 | 0 | 6 |
-| `core-functionality/playground/` | 26 | 23 | 0 | 3 |
+| `core-functionality/playground/` | 27 | 24 | 0 | 3 |
 | `core-functionality/observability-monitoring/` | 16 | 13 | 0 | 3 |
 | `core-functionality/model-provider/` | 21 | 13 | 0 | 8 |
 | `core-functionality/llm-agents/` | 15 | 8 | 0 | 7 |
@@ -678,7 +679,7 @@
 | `templates/` | 35 | 33 | 0 | 2 |
 | `ui-ux/` — Canvas | 30 | 28 | 1 | 1 |
 | `ui-ux/` — Settings | 4 | 4 | 0 | 0 |
-| **TOTAL** | **266** | **213 (80%)** | **3** | **50 (19%)** |
+| **TOTAL** | **267** | **214 (80%)** | **3** | **50 (19%)** |
 
 ---
 

--- a/docs/core-functionality/playground/playground-session-clear.md
+++ b/docs/core-functionality/playground/playground-session-clear.md
@@ -38,8 +38,8 @@ This is a focused regression guard for the `clear-chat-option` path: open the he
 
 ## External dependencies *(required)*
 
-- `src/frontend/src/components/core/chatComponents/chatHeader/chat-header.tsx` — `clear-chat-option` is rendered only when `isDefaultSession` is true; clicking it fires `clearDefaultSession`. Any rename of the `data-testid` or change to the default-session condition will break the test.
-- `src/frontend/src/components/core/chatComponents/chatHeader/` — `chat-header-more-menu` trigger wrapped in `AnimatedConditional` (framer-motion); that is why `evaluate((el) => el.click())` is used instead of a coordinate-based click.
+- `src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/chat-header.tsx` — `clear-chat-option` is rendered only when `isDefaultSession` is true; clicking it fires `clearDefaultSession`. Any rename of the `data-testid` or change to the default-session condition will break the test.
+- `src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/session-more-menu.tsx` — `chat-header-more-menu` trigger wrapped in `AnimatedConditional` (framer-motion); that is why `evaluate((el) => el.click())` is used instead of a coordinate-based click.
 
 ---
 

--- a/docs/core-functionality/playground/playground-session-clear.md
+++ b/docs/core-functionality/playground/playground-session-clear.md
@@ -1,0 +1,64 @@
+# Playground – Clear Chat (Default Session)
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+Validates that the **Clear chat** action in the Default session header menu removes all messages from the active chat without deleting the session itself.
+
+This is a focused regression guard for the `clear-chat-option` path: open the header more-menu, click "Clear chat", and confirm that `div-chat-message` drops to zero. If this breaks, users lose the ability to reset the Default session's conversation history.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@playground`
+
+---
+
+## Step by step *(required)*
+
+1. Create a ChatInput → ChatOutput echo flow (no LLM required) and open the Playground via `playground-btn-flow-io`
+2. Send "hello clear test" and wait for the bot echo to appear as `div-chat-message`
+3. Assert at least one `div-chat-message` exists (pre-condition)
+4. Open the header menu by calling `.evaluate((el) => el.click())` on `chat-header-more-menu` (bypasses framer-motion overlay)
+5. Assert `clear-chat-option` is visible
+6. Click `clear-chat-option`
+7. Assert `div-chat-message` count is 0
+
+---
+
+## Validation criterion *(required)*
+
+- After clicking `clear-chat-option`: `div-chat-message` count drops to 0
+
+---
+
+## External dependencies *(required)*
+
+- `src/frontend/src/components/core/chatComponents/chatHeader/chat-header.tsx` — `clear-chat-option` is rendered only when `isDefaultSession` is true; clicking it fires `clearDefaultSession`. Any rename of the `data-testid` or change to the default-session condition will break the test.
+- `src/frontend/src/components/core/chatComponents/chatHeader/` — `chat-header-more-menu` trigger wrapped in `AnimatedConditional` (framer-motion); that is why `evaluate((el) => el.click())` is used instead of a coordinate-based click.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Deleting a user-created session (covered in `playground-clear-history.spec.ts`)
+- Renaming sessions (covered in `playground-session-rename.spec.ts`)
+- Session persistence across page reloads
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
+- No LLM or API key needed: ChatInput → ChatOutput acts as a synchronous echo
+
+---
+
+## Notes *(optional)*
+
+- `evaluate((el) => el.click())` is intentional: the menu trigger sits inside an `AnimatedConditional` that may have an overlapping sibling during the animation, making coordinate-based clicks unreliable.
+- `playground-clear-history.spec.ts` covers the same clear-chat behavior but in a more comprehensive serial suite that also covers delete-session. This spec is a simpler standalone guard for the clear-chat path only.

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-clear.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-clear.spec.ts
@@ -76,7 +76,7 @@ test.describe("Playground – Clear Session History", () => {
 
   test(
     "clear-chat removes all messages from Default Session",
-    { tag: ["@regression", "@playground"] },
+    { tag: ["@stable", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step(
         "Set up ChatInput → ChatOutput echo flow and open playground",


### PR DESCRIPTION
## Summary

- Adds `@stable` tag to `playground-session-clear.spec.ts` (originally added in PR #97, was missing the tag)
- Creates spec doc at `docs/core-functionality/playground/playground-session-clear.md` with all mandatory sections filled
- Adds coverage entry to `QA-CHECKLIST.md` and updates the playground row totals (26→27 total, 23→24 covered)

## Test plan

- [ ] `npx playwright test tests/tests-automations/regression/core-functionality/playground/playground-session-clear.spec.ts --trace=on` passes consistently
- [ ] TypeScript check: `npm run typecheck` ✅
- [ ] Spec doc has all mandatory sections: What this test validates, Tags, Step by step, Validation criterion, External dependencies

Closes #111