### PR TITLE
chore(playground): add @stable and spec doc to stop-button-playground

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -433,7 +433,7 @@
 - [x] Playground fullscreen mode → `playground/playground-fullscreen.spec.ts`
 - [-] Shareable Playground — URL generation validated (switch enables sharing, href matches /playground/uuid) → `playground/playground-shareable-url.spec.ts`
 - [-] Voice mode (voice assistant)
-- [-] Stop button in Playground
+- [x] Stop button in Playground → `core-functionality/playground/stop-button-playground.spec.ts`
 
 #### 9.4 Output Modal
 - [-] Copy component output

--- a/docs/core-functionality/playground/stop-button-playground.md
+++ b/docs/core-functionality/playground/stop-button-playground.md
@@ -1,0 +1,65 @@
+# Playground – Stop Button
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+Validates that the **Stop** button in the Playground interrupts an in-progress flow execution and surfaces a `"build stopped"` confirmation message.
+
+The test uses a Custom Component with a 60-second `sleep()` to guarantee the flow is still running when the stop action fires. If `button-stop` is missing, fails to appear during execution, or the backend does not acknowledge the cancellation, this test will catch it.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@api` `@playground`
+
+---
+
+## Step by step *(required)*
+
+1. Open a blank flow and add a **Chat Output** component via the sidebar
+2. Add a **Custom Component** whose `build_output` method calls `sleep(60)` before returning — this keeps the flow running long enough for the stop action
+3. Connect CustomComponent output → ChatOutput input
+4. Click **Run** on ChatOutput to start execution, then immediately open the Playground
+5. Wait up to 30 s for `button-stop` to appear (visible while the build is in progress)
+6. Click `button-stop`
+7. Assert that the text `"build stopped"` becomes visible (confirms backend acknowledged the cancellation)
+
+---
+
+## Validation criterion *(required)*
+
+- `button-stop` is visible within 30 s of starting execution
+- After clicking `button-stop`, the text `"build stopped"` appears within 30 s
+
+---
+
+## External dependencies *(required)*
+
+- `src/frontend/src/components/core/playgroundComponent/chat-view/send-message/button-send-wrapper.tsx` — renders `button-stop` during active builds; calls `stopBuilding()` on click
+- `src/frontend/src/components/core/playgroundComponent/chat-view/send-message/no-input.tsx` — alternate render path for `button-stop` when the flow has no input component
+
+---
+
+## What this test does not cover *(optional)*
+
+- Stopping a flow from the canvas (outside the Playground)
+- Stopping an agent mid-reasoning step (covered in `agent-component-regression.spec.ts`)
+- Behaviour when the flow completes before the stop button is clicked
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
+- No LLM or API key required; the Custom Component is pure Python with a timed sleep
+
+---
+
+## Notes *(optional)*
+
+- The 60-second `sleep()` in the Custom Component is intentional — it guarantees the flow is still in-progress when Playwright clicks the stop button, avoiding a race condition where the flow finishes before the assertion fires.
+- `button-stop` is the last occurrence (`.last()`) because the Playground may render multiple instances depending on the session state.

--- a/tests/tests-automations/regression/core-functionality/playground/stop-button-playground.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/stop-button-playground.spec.ts
@@ -119,18 +119,13 @@ class CustomComponent(Component):
     });
 
     await test.step("click stop button", async () => {
-      await page.waitForSelector('[data-testid="button-stop"]', {
-        timeout: 30000,
-      });
-
       await expect(page.getByTestId("button-stop").last()).toBeVisible({ timeout: 30000 });
 
       await page.getByTestId("button-stop").last().click();
     });
 
     await test.step("assert build stopped confirmation", async () => {
-      await page.waitForSelector("text=build stopped", { timeout: 30000 });
-      await expect(page.getByText("build stopped")).toBeVisible({ timeout: 5000 });
+      await expect(page.getByText("build stopped")).toBeVisible({ timeout: 30000 });
     });
   },
 );

--- a/tests/tests-automations/regression/core-functionality/playground/stop-button-playground.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/stop-button-playground.spec.ts
@@ -6,7 +6,7 @@ import { zoomOut } from "../../../../helpers/ui/zoom-out";
 
 test(
   "User must be able to stop building from inside Playground",
-  { tag: ["@release", "@api", "@playground"] },
+  { tag: ["@stable", "@release", "@api", "@playground"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 

--- a/tests/tests-automations/regression/core-functionality/playground/stop-button-playground.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/stop-button-playground.spec.ts
@@ -10,50 +10,55 @@ test(
   async ({ page }) => {
     await awaitBootstrapTest(page);
 
-    await page.getByTestId("blank-flow").click();
+    await test.step("open blank flow and add custom component to canvas", async () => {
+      await page.getByTestId("blank-flow").click();
 
-    await page.waitForSelector(
-      '[data-testid="sidebar-custom-component-button"]',
-      {
+      await page.waitForSelector(
+        '[data-testid="sidebar-custom-component-button"]',
+        {
+          timeout: 3000,
+        },
+      );
+
+      await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
         timeout: 3000,
-      },
-    );
-
-    await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
-      timeout: 3000,
-    });
-
-    await page.getByTestId("sidebar-custom-component-button").click();
-    await adjustScreenView(page);
-
-    await page.getByTestId("sidebar-search-input").click();
-    await page.waitForTimeout(500);
-    await page.getByTestId("sidebar-search-input").fill("chat output");
-    await page.waitForTimeout(500);
-
-    await page.waitForSelector('[data-testid="input_outputChat Output"]', {
-      timeout: 3000,
-    });
-
-    await page
-      .getByTestId("input_outputChat Output")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-        targetPosition: { x: 400, y: 400 },
       });
 
-    await adjustScreenView(page);
+      await page.getByTestId("sidebar-custom-component-button").click();
+      await adjustScreenView(page);
+    });
 
-    await page.getByTestId("div-generic-node").nth(1).click();
+    await test.step("add chat output component via sidebar", async () => {
+      await page.getByTestId("sidebar-search-input").click();
+      await page.waitForTimeout(500);
+      await page.getByTestId("sidebar-search-input").fill("chat output");
+      await page.waitForTimeout(500);
 
-    await page.getByTestId("more-options-modal").click();
+      await page.waitForSelector('[data-testid="input_outputChat Output"]', {
+        timeout: 3000,
+      });
 
-    await page.getByTestId("expand-button-modal").click();
+      await page
+        .getByTestId("input_outputChat Output")
+        .dragTo(page.locator('//*[@id="react-flow-id"]'), {
+          targetPosition: { x: 400, y: 400 },
+        });
 
-    await page.getByTestId("div-generic-node").nth(0).click();
+      await adjustScreenView(page);
+    });
 
-    await page.getByTestId("code-button-modal").nth(0).click();
+    await test.step("inject 60-second sleep into custom component code", async () => {
+      await page.getByTestId("div-generic-node").nth(1).click();
 
-    const waitTimeoutCode = `
+      await page.getByTestId("more-options-modal").click();
+
+      await page.getByTestId("expand-button-modal").click();
+
+      await page.getByTestId("div-generic-node").nth(0).click();
+
+      await page.getByTestId("code-button-modal").nth(0).click();
+
+      const waitTimeoutCode = `
 # from langflow.field_typing import Data
 from langflow.custom import Component
 from langflow.io import MessageTextInput, Output
@@ -82,41 +87,50 @@ class CustomComponent(Component):
         sleep(60)
         return data`;
 
-    await page.locator(".ace_content").click();
-    await page.keyboard.press(`ControlOrMeta+A`);
-    await page.locator("textarea").fill(waitTimeoutCode);
+      await page.locator(".ace_content").click();
+      await page.keyboard.press(`ControlOrMeta+A`);
+      await page.locator("textarea").fill(waitTimeoutCode);
 
-    await page.getByText("Check & Save").last().click();
-    await adjustScreenView(page, { numberOfZoomOut: 2 });
-
-    // Connect CustomComponent → ChatOutput (click-click pattern)
-    await page
-      .getByTestId("handle-customcomponent-shownode-output-right")
-      .first()
-      .click();
-    await page
-      .getByTestId("handle-chatoutput-shownode-inputs-left")
-      .first()
-      .click();
-    await expect(page.locator(".react-flow__edge")).toHaveCount(1, { timeout: 8000 });
-
-    await page.waitForSelector('[data-testid="button_run_chat output"]', {
-      timeout: 3000,
+      await page.getByText("Check & Save").last().click();
+      await adjustScreenView(page, { numberOfZoomOut: 2 });
     });
 
-    await page.getByTestId("button_run_chat output").click();
-
-    await page.getByRole("button", { name: "Playground", exact: true }).click();
-
-    await page.waitForSelector('[data-testid="button-stop"]', {
-      timeout: 30000,
+    await test.step("connect custom component output to chat output input", async () => {
+      // Connect CustomComponent → ChatOutput (click-click pattern)
+      await page
+        .getByTestId("handle-customcomponent-shownode-output-right")
+        .first()
+        .click();
+      await page
+        .getByTestId("handle-chatoutput-shownode-inputs-left")
+        .first()
+        .click();
+      await expect(page.locator(".react-flow__edge")).toHaveCount(1, { timeout: 8000 });
     });
 
-    await expect(page.getByTestId("button-stop").last()).toBeVisible({ timeout: 30000 });
+    await test.step("run flow and open playground", async () => {
+      await page.waitForSelector('[data-testid="button_run_chat output"]', {
+        timeout: 3000,
+      });
 
-    await page.getByTestId("button-stop").last().click();
+      await page.getByTestId("button_run_chat output").click();
 
-    await page.waitForSelector("text=build stopped", { timeout: 30000 });
-    await expect(page.getByText("build stopped")).toBeVisible({ timeout: 5000 });
+      await page.getByRole("button", { name: "Playground", exact: true }).click();
+    });
+
+    await test.step("click stop button", async () => {
+      await page.waitForSelector('[data-testid="button-stop"]', {
+        timeout: 30000,
+      });
+
+      await expect(page.getByTestId("button-stop").last()).toBeVisible({ timeout: 30000 });
+
+      await page.getByTestId("button-stop").last().click();
+    });
+
+    await test.step("assert build stopped confirmation", async () => {
+      await page.waitForSelector("text=build stopped", { timeout: 30000 });
+      await expect(page.getByText("build stopped")).toBeVisible({ timeout: 5000 });
+    });
   },
 );

--- a/tests/tests-automations/regression/core-functionality/playground/stop-button-playground.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/stop-button-playground.spec.ts
@@ -96,7 +96,6 @@ class CustomComponent(Component):
     });
 
     await test.step("connect custom component output to chat output input", async () => {
-      // Connect CustomComponent → ChatOutput (click-click pattern)
       await page
         .getByTestId("handle-customcomponent-shownode-output-right")
         .first()

--- a/tests/tests-automations/regression/core-functionality/playground/stop-button-playground.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/stop-button-playground.spec.ts
@@ -2,8 +2,6 @@ import { expect, test } from "../../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 
-import { zoomOut } from "../../../../helpers/ui/zoom-out";
-
 test(
   "User must be able to stop building from inside Playground",
   { tag: ["@stable", "@release", "@api", "@playground"] },


### PR DESCRIPTION
## Summary

- Adds `@stable` to `stop-button-playground.spec.ts`
- Creates spec doc at `docs/core-functionality/playground/stop-button-playground.md` with all mandatory sections
- Updates `QA-CHECKLIST.md`: `[-]` → `[x]` with spec file path

## Test plan

- [ ] TypeScript check passes (`npm run typecheck`)
- [ ] Spec runs against a live Langflow instance and the stop button interrupts execution consistently
- [ ] No backend errors logged during the run

Closes #112