### PR TITLE
chore(flow-functionality): add @stable and rewrite duplicate-flow

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -524,7 +524,7 @@
 #### 12.1 Create Flow
 - [-] Create blank flow
 - [-] Create flow from template
-- [-] Create flow by duplicating an existing one
+- [x] Create flow by duplicating an existing one → `flow-functionality/duplicate-flow.spec.ts`
 - [-] Create flow via JSON file import
 
 #### 12.2 View and Edit Flow

--- a/docs/flow-functionality/duplicate-flow.md
+++ b/docs/flow-functionality/duplicate-flow.md
@@ -1,0 +1,107 @@
+# Flow Functionality — Duplicate Flow
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+Validates flow duplication in two complementary ways:
+
+1. **UI test:** Opens the Basic Prompting template (creates a flow), goes back to the home page, opens the dropdown for the first flow card, clicks `btn-duplicate-flow`, and asserts (a) the success toast renders and (b) the API flow count grew by **exactly one**.
+2. **API test:** Mirrors the duplicate hook (`useDuplicateFlow` → `createNewFlow` → `POST /api/v1/flows/`) by `POST`ing twice with the same name. Asserts the backend auto-suffixes the second flow with ` (N)` to keep names unique, and that both flows are listed with different IDs.
+
+Together the pair guarantees the duplicate dropdown action wires up to the real backend behavior — including the auto-suffix collision logic that the UI relies on for sane flow names.
+
+---
+
+## Tags *(required)*
+
+UI test: `@release` `@workspace` `@stable`
+API test: `@release` `@workspace` `@api` `@stable`
+
+---
+
+## Step by step *(required)*
+
+### UI test — `user can duplicate a flow from the home page dropdown menu`
+
+1. Bootstrap the app
+2. Click `side_nav_options_all-templates`, then click the `Basic Prompting` heading to open the template (which creates a new flow)
+3. Wait for `sidebar-search-input` to confirm the editor loaded; navigate back via `icon-ChevronLeft`
+4. Wait for the first `home-dropdown-menu` to be visible
+5. Capture the current flow count via `GET /api/v1/flows/`
+6. Click the first `home-dropdown-menu`, wait for `btn-duplicate-flow` and click it
+7. Assert the toast `/duplicated successfully/i` renders
+8. Poll `GET /api/v1/flows/` until the count equals `countBefore + 1` (timeout 10s)
+
+### API test — `duplicate flow via API auto-suffixes the name on collision`
+
+1. Acquire a Bearer token via `getAuthToken(request)`
+2. `POST /api/v1/flows/` with `{ name: originalName, ...FLOW_BASE }` — expect `201` and `body.name === originalName`
+3. `POST /api/v1/flows/` again with the **same** name — expect `201`, `body.id !== original.id`, and `body.name` matches `^${originalName} \(\d+\)$`
+4. `GET /api/v1/flows/` — expect `200` and both IDs to be present in the list
+5. Cleanup both flows via `DELETE` in `finally`
+
+---
+
+## Validation criterion *(required)*
+
+The UI test must:
+
+- Use `getByTestId("btn-duplicate-flow")`, **not** `getByText(/duplicate/i)` — i18n-proof
+- Snapshot the flow count via API before duplicate and assert exactly `+1` after — `count > 1` would always be true on a populated database (the home page lists 100+ flows in development environments)
+- Assert the success toast renders, confirming the action committed (not just the click landed)
+
+The API test must assert **all** of:
+
+- First POST returns `201` with the original name unchanged
+- Second POST with the **same** name returns `201` and the response `name` matches `^${originalName} \(\d+\)$` (the auto-suffix pattern that `flow_service.create_flow` produces on collision)
+- The IDs are different
+- Both flows appear in the listing
+- Cleanup runs in `finally` so a mid-test failure does not leak flows
+
+---
+
+## External dependencies *(required)*
+
+- `tests/helpers/auth/get-auth-token.ts` — issues the Bearer token
+- `src/frontend/src/pages/MainPage/components/dropdown/index.tsx` — registers `btn-duplicate-flow` testid; the test would need updating if it is renamed or removed
+- `src/frontend/src/pages/MainPage/hooks/use-handle-duplicate.ts` — calls `createNewFlow` then `postAddFlow`; the API test mirrors this round-trip directly
+- `src/frontend/src/utils/reactflowUtils.ts` (`createNewFlow`) — keeps the original `name` (no client-side suffix); the suffix originates server-side
+- `src/backend/base/langflow/api/v1/flows.py` (`POST /api/v1/flows/`) — owns the auto-suffix collision logic asserted by the API test
+
+---
+
+## What this test does not cover *(optional)*
+
+- Duplicating a flow with non-empty `data` (real components and edges) and verifying the duplicate's graph matches the original — this spec only validates **name** and **count** semantics, not graph cloning fidelity
+- Duplicating into a different folder (the hook supports `folder_id` via `useParams`, but this spec runs in the default folder)
+- Duplicating a flow the user does not own (permissions / multi-tenant scenarios)
+- The `(N)` suffix increment when N >= 2 (e.g., duplicating an already-duplicated flow). Current assertion `\(\d+\)` accepts any digit count
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`
+- `LANGFLOW_SUPERUSER` and `LANGFLOW_SUPERUSER_PASSWORD` configured for the API test's auth token
+- No LLM required
+
+---
+
+## When to review this test *(optional)*
+
+- The auto-suffix logic in `flow_service.create_flow` changes (e.g., uses ` - copy` instead of ` (1)`, or stops auto-suffixing entirely) — the API test's regex must be updated
+- `use-handle-duplicate.ts` is refactored to call a dedicated `/api/v1/flows/{id}/duplicate` endpoint instead of `POST` repetition — the API test should mirror the new contract
+- `btn-duplicate-flow` testid is renamed or moved out of the home dropdown
+- `i18n` key `flow.duplicatedSuccess` text changes — the toast assertion uses `/duplicated successfully/i` and would still match if the wording is preserved
+
+---
+
+## Notes *(optional)*
+
+- The previous version of this spec asserted only `count > 1` after duplicate, which is essentially always true once any flow exists in the database — a near-empty assertion that would pass even if duplicate silently failed and only the original was visible.
+- The previous API test manually constructed `${originalName} (copy)` as the duplicate name, bypassing the actual collision logic the backend implements. This spec rewrites the test to POST with the **same** name twice, which is what the UI duplicate hook actually triggers, and asserts the server's auto-suffix instead.
+- Empirical confirmation of the auto-suffix format (` (1)`, with a leading space) was captured by a direct `curl` round-trip against the running backend. The regex `^${originalName} \(\d+\)$` reflects that exact format.
+- The UI test mixes UI action (click) with API verification (count delta). This is intentional: counting cards on the home page is unreliable when the user has 100+ flows (paginated to 12 per page), so the API is the source of truth for the count assertion.

--- a/tests/tests-automations/regression/flow-functionality/duplicate-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/duplicate-flow.spec.ts
@@ -2,109 +2,115 @@ import { expect, test } from "../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 
+const FLOW_BASE = {
+  description: "Flow duplicate test",
+  data: { nodes: [], edges: [], viewport: { x: 0, y: 0, zoom: 1 } },
+  is_component: false,
+};
+
 test(
   "user can duplicate a flow from the home page dropdown menu",
-  { tag: ["@release", "@workspace", "@regression"] },
-  async ({ page }) => {
+  { tag: ["@release", "@workspace", "@stable"] },
+  async ({ page, request }) => {
     await awaitBootstrapTest(page);
 
-    // Open Basic Prompting template to have a flow to duplicate
     await page.getByTestId("side_nav_options_all-templates").click();
     await page.getByRole("heading", { name: "Basic Prompting" }).click();
 
-    await page.waitForSelector('[data-testid="sidebar-search-input"]', {
+    await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
       timeout: 30000,
     });
 
-    // Go back to home
     await page.getByTestId("icon-ChevronLeft").first().click();
 
-    await page.waitForSelector('[data-testid="home-dropdown-menu"]', {
+    await expect(page.getByTestId("home-dropdown-menu").first()).toBeVisible({
       timeout: 30000,
     });
 
-    // Open dropdown for the first flow
+    // Snapshot the flow count from the API so we can assert exactly +1 after duplicate
+    const authToken = await getAuthToken(request);
+    const listBefore = await request.get("/api/v1/flows/", {
+      headers: { Authorization: authToken },
+    });
+    const countBefore = ((await listBefore.json()) as unknown[]).length;
+
     await page.getByTestId("home-dropdown-menu").first().click();
+    // Use the testid (not localized text) so the test does not break under i18n
+    await expect(page.getByTestId("btn-duplicate-flow")).toBeVisible({
+      timeout: 5000,
+    });
+    await page.getByTestId("btn-duplicate-flow").click();
 
-    // Look for "Duplicate" option
-    const duplicateOption = page.getByText(/duplicate/i).first();
-    const isDuplicateVisible = await duplicateOption
-      .isVisible({ timeout: 5000 })
-      .catch(() => false);
+    // Toast appears as soon as the duplicate POST resolves — confirms the action committed
+    await expect(page.getByText(/duplicated successfully/i).last()).toBeVisible(
+      { timeout: 10000 },
+    );
 
-    // Duplicate option must be available in the dropdown
-    expect(isDuplicateVisible).toBeTruthy();
-
-    await duplicateOption.click();
-
-    // Wait for the duplicate to appear
-    await page.waitForTimeout(2000);
-
-    // There should now be at least 2 flows with similar names on the page
-    const flowCards = page.locator('[data-testid="home-dropdown-menu"]');
-    const count = await flowCards.count();
-    expect(count).toBeGreaterThan(1);
+    // Confirm exactly one new flow exists in the database (not a no-op or a double-create)
+    await expect
+      .poll(
+        async () => {
+          const res = await request.get("/api/v1/flows/", {
+            headers: { Authorization: authToken },
+          });
+          return ((await res.json()) as unknown[]).length;
+        },
+        { timeout: 10000, intervals: [500, 1000, 2000] },
+      )
+      .toBe(countBefore + 1);
   },
 );
 
 test(
-  "duplicated flow via API has different ID but same name",
-  { tag: ["@release", "@api", "@regression"] },
+  "duplicate flow via API auto-suffixes the name on collision",
+  { tag: ["@release", "@workspace", "@api", "@stable"] },
   async ({ request }) => {
     const authToken = await getAuthToken(request);
-
-    // Create original flow
     const originalName = `Flow to Duplicate - ${Date.now()}`;
+
     const createRes = await request.post("/api/v1/flows/", {
       headers: { Authorization: authToken },
-      data: {
-        name: originalName,
-        description: "Flow original para duplicar",
-        data: { nodes: [], edges: [], viewport: { x: 0, y: 0, zoom: 1 } },
-        is_component: false,
-      },
+      data: { ...FLOW_BASE, name: originalName },
     });
-
     expect(createRes.status()).toBe(201);
     const original = await createRes.json();
+    expect(original.name).toBe(originalName);
 
-    // Duplicate by creating a new flow with the same data
-    const duplicatedName = `${originalName} (copy)`;
-    const duplicateRes = await request.post("/api/v1/flows/", {
-      headers: { Authorization: authToken },
-      data: {
-        name: duplicatedName,
-        description: original.description,
-        data: original.data,
-        is_component: false,
-      },
-    });
+    let duplicateId: string | undefined;
+    try {
+      // POST again with the SAME name — backend must auto-suffix " (1)" to keep names unique.
+      // This mirrors what the UI duplicate button triggers via use-handle-duplicate.ts.
+      const duplicateRes = await request.post("/api/v1/flows/", {
+        headers: { Authorization: authToken },
+        data: { ...FLOW_BASE, name: originalName },
+      });
+      expect(duplicateRes.status()).toBe(201);
+      const duplicate = await duplicateRes.json();
+      duplicateId = duplicate.id;
 
-    expect(duplicateRes.status()).toBe(201);
-    const duplicate = await duplicateRes.json();
+      expect(duplicate.id).not.toBe(original.id);
+      expect(duplicate.name).toMatch(
+        new RegExp(
+          `^${originalName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} \\(\\d+\\)$`,
+        ),
+      );
 
-    expect(duplicate.id).not.toBe(original.id);
-    expect(duplicate.name).toBe(duplicatedName);
-
-    // Both flows exist in the list
-    const listRes = await request.get("/api/v1/flows/", {
-      headers: { Authorization: authToken },
-    });
-    expect(listRes.status()).toBe(200);
-    const flows = await listRes.json();
-    const flowList = Array.isArray(flows) ? flows : flows.flows ?? [];
-
-    const originalExists = flowList.some((f: any) => f.id === original.id);
-    const duplicateExists = flowList.some((f: any) => f.id === duplicate.id);
-    expect(originalExists).toBeTruthy();
-    expect(duplicateExists).toBeTruthy();
-
-    // Cleanup
-    await request.delete(`/api/v1/flows/${original.id}`, {
-      headers: { Authorization: authToken },
-    });
-    await request.delete(`/api/v1/flows/${duplicate.id}`, {
-      headers: { Authorization: authToken },
-    });
+      const listRes = await request.get("/api/v1/flows/", {
+        headers: { Authorization: authToken },
+      });
+      expect(listRes.status()).toBe(200);
+      const flowList = (await listRes.json()) as Array<{ id: string }>;
+      expect(flowList.some((f) => f.id === original.id)).toBe(true);
+      expect(flowList.some((f) => f.id === duplicate.id)).toBe(true);
+    } finally {
+      await request.delete(`/api/v1/flows/${original.id}`, {
+        headers: { Authorization: authToken },
+      });
+      if (duplicateId) {
+        await request.delete(`/api/v1/flows/${duplicateId}`, {
+          headers: { Authorization: authToken },
+        });
+      }
+    }
   },
 );


### PR DESCRIPTION
## Summary

Validates `flow-functionality/duplicate-flow.spec.ts` and rewrites both tests to fix near-empty assertions and a flow-leak risk before promoting to `@stable`.

### Why a rewrite (not just a tag flip)

| Before | After |
|---|---|
| UI: `expect(count).toBeGreaterThan(1)` — always true on a populated DB (100+ flows on home page) | UI: `expect.poll(GET /api/v1/flows/ → length).toBe(countBefore + 1)` — exactly +1 |
| UI: `getByText(/duplicate/i)` — breaks under i18n | UI: `getByTestId("btn-duplicate-flow")` |
| UI: `.isVisible().catch(() => false)` then `expect(bool).toBeTruthy()` | UI: `expect(locator).toBeVisible()` direct |
| UI: bare `waitForTimeout(2000)` as sync | UI: removed |
| API: manually constructs `${name} (copy)` — bypasses real collision logic | API: POSTs twice with **same** name; asserts backend auto-suffix `^${name} \(\d+\)$` |
| API: cleanup outside try/finally — leaks on mid-test failure | API: cleanup in `finally` |

### Empirical confirmation

A direct `curl` round-trip against the running backend confirmed the suffix format: ` (1)` (leading space, parenthesized integer). The regex assertion reflects that exact format.

### Tags

- UI test: `@release @regression @workspace` → `@release @workspace @stable`
- API test: `@release @api @regression` → `@release @workspace @api @stable`

## Validation evidence

| Step | Result |
|---|---|
| Baseline serial 3x | 6/6 ✅ in 27.6s |
| Force-fail (regex `^FORCE_FAIL_SENTINEL$`) | ❌ as expected — confirmed real auto-suffix `Flow to Duplicate - … (1)` was produced |
| Stability serial 3x with `--trace=on` | 6/6 ✅ in 30.6s |
| Final post-cleanup serial 3x | 6/6 ✅ in 28.7s |
| ESLint | 0 errors, 1 warning (`if (duplicateId)` in `finally` cleanup — legitimate) |
| `tsc --noEmit` | clean |

## Test plan

- [x] `npx playwright test duplicate-flow.spec.ts --workers=1 --repeat-each=3 --retries=0` — 6/6 pass
- [x] Force-fail confirmed
- [x] Lint and typecheck clean
- [x] Spec doc at `docs/flow-functionality/duplicate-flow.md` with all required fields
- [x] `QA-CHECKLIST.md` entry `Create flow by duplicating an existing one` marked `[x]`