### PR TITLE
docs(playground): fix wrong file paths in playground-session-nav spec doc

### DIFF
--- a/docs/core-functionality/playground/playground-session-nav.md
+++ b/docs/core-functionality/playground/playground-session-nav.md
@@ -50,8 +50,8 @@ These ensure users can manage multiple parallel conversations without cross-cont
 
 ## External dependencies *(required)*
 
-- `src/frontend/src/modals/IOModal/components/sidebar-open-view.tsx` — `data-testid="new-chat"` (creates session)
-- `src/frontend/src/modals/IOModal/components/IOFieldView/components/session-selector.tsx` — `data-testid="session-selector"` (sidebar items); clicking an item switches the active session; item displays "Default Session" when `session === currentFlowId`
+- `src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/chat-sidebar.tsx` — `data-testid="new-chat"` (creates session)
+- `src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/session-selector.tsx` — `data-testid="session-selector"` (sidebar items); clicking an item switches the active session; item displays "Default Session" when `session === currentFlowId`
 - No API key required: ChatInput → ChatOutput is a synchronous echo flow
 
 ---


### PR DESCRIPTION
## Summary

- Replace IOModal paths with the correct `playgroundComponent` paths for `new-chat` and `session-selector` in the External dependencies section of `playground-session-nav.md`
- The playground opened via `playground-btn-flow-io` renders components from `playgroundComponent/`, not from `IOModal/`

## Test plan

- [ ] Verify `data-testid="new-chat"` lives in `src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/chat-sidebar.tsx`
- [ ] Verify `data-testid="session-selector"` lives in `src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/session-selector.tsx`

Closes #137