### PR TITLE
chore: auto-generate QA-CHECKLIST.md Coverage Summary table

### DIFF
--- a/.github/workflows/update-coverage-summary.yml
+++ b/.github/workflows/update-coverage-summary.yml
@@ -1,0 +1,54 @@
+name: Update Coverage Summary
+
+# Auto-regenerates the Coverage Summary table inside QA-CHECKLIST.md after
+# each merge to main. The table is derived data — counts of [x]/[-]/[ ]/[~]/[!]
+# bullets per module — so no developer should ever need to edit it manually.
+#
+# Pushes performed via the default GITHUB_TOKEN do not re-trigger workflows,
+# so this job cannot recurse on itself. The `[skip ci]` token in the commit
+# message is a defensive belt-and-suspenders.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "QA-CHECKLIST.md"
+      - "scripts/coverage-summary.ts"
+      - ".github/workflows/update-coverage-summary.yml"
+
+jobs:
+  update-coverage:
+    name: Regenerate Coverage Summary
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+
+    # Skip when this very workflow's auto-commit lands on main.
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Regenerate Coverage Summary
+        run: npm run coverage:summary
+
+      - name: Commit and push if changed
+        run: |
+          if git diff --quiet QA-CHECKLIST.md; then
+            echo "Coverage Summary table already up to date — nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add QA-CHECKLIST.md
+          git commit -m "chore(checklist): auto-update coverage summary [skip ci]"
+          git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,13 +147,18 @@ Tags are split into two groups: **cross-cutting** (severity/layer) and **functio
 
 ## CI/CD
 
-Five GitHub Actions workflows:
+GitHub Actions workflows:
 
 - **`pr-validation.yml`** — Runs on every PR to `main`; two parallel jobs: TypeScript check (`tsc --noEmit`) and ESLint. Both must pass before merge.
 - **`nightly.yml`** — Runs daily at 03:00 BRT against `langflowai/langflow-nightly:latest`; opens a GitHub issue on failure assigned to @Victor-w-Madeira.
 - **`weekly-stable.yml`** — Runs every Monday against `langflowai/langflow-nightly:latest`; runs only `@stable` tests; opens a GitHub issue on failure for triage.
 - **`manual.yml`** — Parameterized manual run; accepts a Docker tag or full URL, a specific test suite, and an optional grep filter.
 - **`file-watcher.yml`** — Detects upstream Langflow changes in critical paths and opens a GitHub issue with the exact `--grep` command needed to revalidate affected areas.
+- **`update-coverage-summary.yml`** — Runs on every push to `main` that touches `QA-CHECKLIST.md` (or the script itself); regenerates the Coverage Summary table from the bullets above it and commits any change with `[skip ci]`.
+
+## QA-CHECKLIST.md
+
+The **Coverage Summary table** at the bottom of `QA-CHECKLIST.md` is **auto-generated** from the bullet markers (`[x]` / `[-]` / `[ ]` / `[~]` / `[!]`) above it. Never propose manual edits to the table's numbers, percentages, or `**TOTAL**` row — only edit the bullets in Part II, and the `update-coverage-summary.yml` workflow will refresh the table on the next merge to `main`. Locally the same logic is available via `npm run coverage:summary` (or `npx ts-node scripts/coverage-summary.ts`); the script lives at `scripts/coverage-summary.ts`. If a new module section is added to Part II, update the `MODULES` array in the script.
 
 ## Playwright Configuration
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,8 @@ See the available tags table in the [README](./README.md#available-tags).
 
 After creating the test, find the corresponding item in `QA-CHECKLIST.md` and mark it as `[-]` (automated, needs validation). Only change to `[x]` after following the validation process below.
 
+> **Do not edit the Coverage Summary table** at the bottom of the checklist. It is derived data — the counts of `[x]`/`[-]`/`[ ]`/`[~]`/`[!]` bullets per module — and is regenerated automatically. The `update-coverage-summary.yml` workflow runs on every push to `main` and commits the refreshed table; the same logic is available locally via `npm run coverage:summary` (or `npx ts-node scripts/coverage-summary.ts`). Touch only the bullets above the table.
+
 **7. Create the spec documentation file**
 
 For each spec, create a corresponding `.md` file in `docs/`, mirroring the relative path from `regression/`. For example:

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,22 @@
         "eslint": "^10.1.0",
         "eslint-plugin-playwright": "^2.10.1",
         "playwright": "^1.57.0",
+        "ts-node": "^10.9.2",
         "typescript": "^5.4.5",
         "typescript-eslint": "^8.57.1"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -179,6 +193,34 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
@@ -194,6 +236,34 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -222,6 +292,7 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -481,6 +552,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -497,6 +581,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -520,6 +611,13 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -560,6 +658,16 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -997,6 +1105,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -1229,6 +1344,50 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -1298,6 +1457,13 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -1322,6 +1488,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "report": "npx playwright show-report",
     "typecheck": "tsc --noEmit",
     "lint": "eslint tests/",
-    "lint:ci": "eslint tests/ --quiet"
+    "lint:ci": "eslint tests/ --quiet",
+    "coverage:summary": "ts-node scripts/coverage-summary.ts"
   },
   "dependencies": {
     "dotenv": "^16.4.5"
@@ -26,6 +27,7 @@
     "eslint": "^10.1.0",
     "eslint-plugin-playwright": "^2.10.1",
     "playwright": "^1.57.0",
+    "ts-node": "^10.9.2",
     "typescript": "^5.4.5",
     "typescript-eslint": "^8.57.1"
   }

--- a/scripts/coverage-summary.ts
+++ b/scripts/coverage-summary.ts
@@ -1,0 +1,222 @@
+/**
+ * Regenerates the Coverage Summary table in QA-CHECKLIST.md from the bullet
+ * markers (`[x]`, `[-]`, `[ ]`, `[~]`, `[!]`) inside Part II.
+ *
+ * Run: `npx ts-node scripts/coverage-summary.ts`
+ *
+ * Idempotent: a second run produces no diff when the table is already in
+ * sync with the bullets above it.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+interface ModuleConfig {
+  /** Label as it appears in the first column of the table. */
+  label: string;
+  /** Prefix of the markdown header line where the section starts. */
+  sectionStart: string;
+}
+
+/**
+ * Ordered top-down by appearance in the document. Each module owns the
+ * bullets between its `sectionStart` line and the next module's start.
+ *
+ * If you restructure Part II in QA-CHECKLIST.md, update this list — the
+ * script throws if any prefix is not found.
+ */
+const MODULES: ModuleConfig[] = [
+  { label: "`api/flows/` — REST API",                        sectionStart: "### api/flows/" },
+  { label: "`core-components/` — Component Config",          sectionStart: "### 2." },
+  { label: "`core-components/` — Core Components",           sectionStart: "### 3." },
+  { label: "`core-functionality/auth/`",                     sectionStart: "### core-functionality/auth/" },
+  { label: "`core-functionality/knowledge-ingestion/`",      sectionStart: "### core-functionality/knowledge-ingestion-management/" },
+  { label: "`core-functionality/llm-agents/`",               sectionStart: "### core-functionality/llm-agents/" },
+  { label: "`core-functionality/model-provider/`",           sectionStart: "### core-functionality/model-provider/" },
+  { label: "`core-functionality/observability-monitoring/`", sectionStart: "### core-functionality/observability-monitoring/" },
+  { label: "`core-functionality/playground/`",               sectionStart: "### core-functionality/playground/" },
+  { label: "`core-functionality/project-management/`",       sectionStart: "### core-functionality/project-management/" },
+  { label: "`core-functionality/templates/`",                sectionStart: "### core-functionality/templates/" },
+  { label: "`flow-functionality/`",                          sectionStart: "## flow-functionality/" },
+  { label: "`mcp/client/`",                                  sectionStart: "### mcp/client/" },
+  { label: "`mcp/server/`",                                  sectionStart: "### mcp/server/" },
+  { label: "`ui-ux/` — Canvas",                              sectionStart: "## ui-ux/" },
+  { label: "`ui-ux/` — Settings",                            sectionStart: "#### 15.10" },
+];
+
+const PART_II_HEADER = "# PART II — TEST AUTOMATION COVERAGE";
+const COVERAGE_SUMMARY_HEADER_PREFIX = "## Coverage Summary";
+const TABLE_HEADER_PREFIX = "| Module | Total |";
+
+const TABLE_HEADER =
+  "| Module | Total | Validated `[x]` | Needs validation `[-]` | Partial `[~]`/`[!]` | Not automated `[ ]` |";
+const TABLE_SEPARATOR =
+  "|--------|-------|-----------------|------------------------|---------------------|---------------------|";
+
+const BULLET_RE = /^- \[([x\- ~!])\] /;
+
+interface Counts {
+  validated: number;       // [x]
+  needsValidation: number; // [-]
+  partial: number;         // [~] + [!]
+  notAutomated: number;    // [ ]
+}
+
+function emptyCounts(): Counts {
+  return { validated: 0, needsValidation: 0, partial: 0, notAutomated: 0 };
+}
+
+function totalOf(c: Counts): number {
+  return c.validated + c.needsValidation + c.partial + c.notAutomated;
+}
+
+function classify(marker: string): keyof Counts | null {
+  switch (marker) {
+    case "x": return "validated";
+    case "-": return "needsValidation";
+    case " ": return "notAutomated";
+    case "~":
+    case "!": return "partial";
+    default:  return null;
+  }
+}
+
+function findLineIndex(
+  lines: string[],
+  predicate: (line: string) => boolean,
+  from = 0,
+  to = lines.length
+): number {
+  for (let i = from; i < to; i++) {
+    if (predicate(lines[i])) return i;
+  }
+  return -1;
+}
+
+function fmtPercent(part: number, whole: number): string {
+  if (whole === 0) return "0%";
+  return `${Math.round((part / whole) * 100)}%`;
+}
+
+function regenerate(lines: string[]): string[] {
+  const partIIStart = findLineIndex(lines, (l) => l.trim() === PART_II_HEADER);
+  if (partIIStart === -1) {
+    throw new Error(`Part II header not found: "${PART_II_HEADER}"`);
+  }
+
+  const coverageHeader = findLineIndex(
+    lines,
+    (l) => l.startsWith(COVERAGE_SUMMARY_HEADER_PREFIX),
+    partIIStart
+  );
+  if (coverageHeader === -1) {
+    throw new Error(`Coverage Summary header not found: "${COVERAGE_SUMMARY_HEADER_PREFIX}"`);
+  }
+
+  // Resolve each module's start line within Part II.
+  const moduleStarts: number[] = MODULES.map((m) => {
+    const idx = findLineIndex(
+      lines,
+      (l) => l.startsWith(m.sectionStart),
+      partIIStart,
+      coverageHeader
+    );
+    if (idx === -1) {
+      throw new Error(
+        `Section start not found for module "${m.label}" (prefix: "${m.sectionStart}")`
+      );
+    }
+    return idx;
+  });
+
+  // Sanity check: starts must be strictly increasing — otherwise MODULES is misordered.
+  for (let i = 1; i < moduleStarts.length; i++) {
+    if (moduleStarts[i] <= moduleStarts[i - 1]) {
+      throw new Error(
+        `MODULES is misordered: "${MODULES[i].label}" appears before "${MODULES[i - 1].label}" in the document`
+      );
+    }
+  }
+
+  // Count bullets per module.
+  const counts: Counts[] = MODULES.map(() => emptyCounts());
+  for (let m = 0; m < MODULES.length; m++) {
+    const start = moduleStarts[m] + 1;
+    const end = m + 1 < MODULES.length ? moduleStarts[m + 1] : coverageHeader;
+    for (let i = start; i < end; i++) {
+      const match = lines[i].match(BULLET_RE);
+      if (!match) continue;
+      const cat = classify(match[1]);
+      if (cat) counts[m][cat]++;
+    }
+  }
+
+  // Aggregate TOTAL row.
+  const tot = emptyCounts();
+  for (const c of counts) {
+    tot.validated += c.validated;
+    tot.needsValidation += c.needsValidation;
+    tot.partial += c.partial;
+    tot.notAutomated += c.notAutomated;
+  }
+  const totSum = totalOf(tot);
+
+  // Build the new table block.
+  const dataRows = MODULES.map((m, i) => {
+    const c = counts[i];
+    return `| ${m.label} | ${totalOf(c)} | ${c.validated} | ${c.needsValidation} | ${c.partial} | ${c.notAutomated} |`;
+  });
+  const totalRow =
+    `| **TOTAL** | **${totSum}** | ` +
+    `**${tot.validated} (${fmtPercent(tot.validated, totSum)})** | ` +
+    `**${tot.needsValidation} (${fmtPercent(tot.needsValidation, totSum)})** | ` +
+    `**${tot.partial} (${fmtPercent(tot.partial, totSum)})** | ` +
+    `**${tot.notAutomated} (${fmtPercent(tot.notAutomated, totSum)})** |`;
+
+  const newTable = [TABLE_HEADER, TABLE_SEPARATOR, ...dataRows, totalRow];
+
+  // Replace the existing table block: from the `| Module | Total |` line through the
+  // last consecutive line that starts with `|`.
+  const tableHeaderIdx = findLineIndex(
+    lines,
+    (l) => l.startsWith(TABLE_HEADER_PREFIX),
+    coverageHeader
+  );
+  if (tableHeaderIdx === -1) {
+    throw new Error(`Table header line not found ("${TABLE_HEADER_PREFIX}")`);
+  }
+
+  let tableEndIdx = tableHeaderIdx;
+  while (tableEndIdx + 1 < lines.length && lines[tableEndIdx + 1].startsWith("|")) {
+    tableEndIdx++;
+  }
+
+  const before = lines.slice(0, tableHeaderIdx);
+  const after = lines.slice(tableEndIdx + 1);
+  return [...before, ...newTable, ...after];
+}
+
+function main(): void {
+  const filePath = path.resolve(__dirname, "..", "QA-CHECKLIST.md");
+  const original = fs.readFileSync(filePath, "utf-8");
+  const trailingNewline = original.endsWith("\n");
+
+  // Drop the empty trailing element produced by split when the file ends with `\n`,
+  // then add the newline back at write time so the file shape is preserved.
+  const lines = original.split("\n");
+  if (trailingNewline) lines.pop();
+
+  const updated = regenerate(lines);
+  let output = updated.join("\n");
+  if (trailingNewline) output += "\n";
+
+  if (output === original) {
+    console.log("Coverage Summary table is already up to date — no changes.");
+    return;
+  }
+
+  fs.writeFileSync(filePath, output, "utf-8");
+  console.log("Coverage Summary table updated in QA-CHECKLIST.md");
+}
+
+main();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,6 @@
     "outDir": "./dist",
     "rootDir": "."
   },
-  "include": ["tests/**/*.ts", "playwright.config.ts"],
+  "include": ["tests/**/*.ts", "playwright.config.ts", "scripts/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

- Adds `scripts/coverage-summary.ts` that parses Part II bullets in `QA-CHECKLIST.md` and rewrites only the Coverage Summary table block. Idempotent: a second run produces no diff.
- Adds `.github/workflows/update-coverage-summary.yml` — runs on every push to `main` that touches the checklist, regenerates the table, and commits it back with `[skip ci]`. Pushes via `GITHUB_TOKEN` do not re-trigger workflows, so the job cannot recurse on itself.
- `CONTRIBUTING.md` and `CLAUDE.md` updated so neither contributors nor Claude Code propose manual edits to the table.

## What changes for contributors

**Keep doing:** updating bullet markers (`[x]` / `[-]` / `[ ]` / `[~]` / `[!]`) in Part II as part of your spec PR.

**Stop doing:** editing the Coverage Summary table numbers, percentages, or `**TOTAL**` row. The workflow refreshes them after merge to `main`.

Locally the same logic is available via `npm run coverage:summary` (or `npx ts-node scripts/coverage-summary.ts`).

## Design notes

- **Module mapping is hardcoded.** `MODULES` in the script defines the ordered `(label, sectionStartPrefix)` list. This handles the non-trivial splits (`core-components/` Config vs Core Components, `ui-ux/` Canvas vs Settings) that pure auto-detection would not. If a new top-level module is added to Part II, the script throws with a clear error and the array must be updated — explicit failure beats silent miscounts.
- **Out of scope:** the Phase 1 / Phase 2 tables under Implementation Roadmap also contain derived counts. The issue only mentions the Coverage Summary table, so they are left as-is. A follow-up issue can extend the script if desired.
- **No-op when in sync.** Running against the current `main` produces no diff (verified locally before commit); the script logs `Coverage Summary table is already up to date — no changes.`
- **`ts-node` added as a devDependency** to match the invocation example from the issue. `tsconfig.json` `include` extended to cover `scripts/**/*.ts` so CI typecheck (`npm run typecheck`) covers the script.

## Acceptance criteria — issue #153

- [x] `scripts/coverage-summary.ts` exists and produces correct counts when run locally
- [x] Running the script twice in a row is idempotent (no diff on second run)
- [x] Script handles count increases and decreases correctly (no hardcoded totals)
- [x] `update-coverage-summary.yml` workflow triggers on push to `main` and commits the updated table when counts change
- [x] Workflow uses `[skip ci]` in the commit message to avoid triggering itself recursively
- [x] `CONTRIBUTING.md` updated with note about the auto-generated table
- [x] `CLAUDE.md` updated with note about the auto-generated table
- [ ] The Coverage Summary table is removed from the list of things developers are expected to update in PR review checklists *(no such list found in the repo's review docs — closing as N/A; the new CONTRIBUTING.md note covers the guidance)*

## Test plan

- [x] `npm run typecheck` passes (script included via tsconfig)
- [x] `npm run lint` produces no new errors
- [x] `npm run coverage:summary` against current `main` is a no-op (table already correct)
- [x] After flipping a bullet (`[-]` → `[x]`) in `api/flows/`, the script correctly bumps the row's `[x]` from 0 to 1 and `[-]` from 21 to 20, and updates the `**TOTAL**` row
- [x] Second run after the change is a no-op (idempotent)
- [ ] Reviewer: confirm the workflow's `permissions: contents: write` is sufficient under current branch protection rules — if `main` requires PRs, the workflow's direct push will fail and we'll need to either bypass the bot or switch to opening a PR

Closes #153