### PR TITLE
chore: capture richer evidence for weekly failures

### DIFF
--- a/.github/workflows/weekly-stable.yml
+++ b/.github/workflows/weekly-stable.yml
@@ -61,7 +61,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Run @stable tests
-        run: npx playwright test --grep "@stable" --pass-with-no-tests --reporter=blob,github
+        run: npx playwright test --grep "@stable" --pass-with-no-tests --reporter=html,github
         env:
           CI: "true"
           PLAYWRIGHT_BASE_URL: "http://localhost:7860/"
@@ -72,16 +72,8 @@ jobs:
         if: always()
         with:
           name: playwright-report-weekly-${{ github.run_id }}
-          path: blob-report/
+          path: playwright-report/
           retention-days: 14
-
-      - name: Upload test results on failure
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: test-results-weekly-${{ github.run_id }}
-          path: test-results/
-          retention-days: 7
 
       - name: Create issue on failure
         if: failure() && github.event_name == 'schedule'

--- a/README.md
+++ b/README.md
@@ -204,8 +204,24 @@ tests/
 |---|---|---|
 | `pr-validation.yml` | Every PR to `main` | TypeScript check (`tsc --noEmit`) + ESLint in parallel — both must pass before merge |
 | `nightly.yml` | Daily 03:00 BRT + manual | Runs everything against `langflow-nightly:latest`, opens an issue on failure |
+| `weekly-stable.yml` | Mondays 03:00 BRT + manual | Runs `@stable` tests against `langflow-nightly:latest`; opens a triage issue on failure and uploads a navigable HTML report |
 | `manual.yml` | Manual | Runs against any Docker tag or external URL, filters by suite/tag |
 | `file-watcher.yml` | Daily 05:00 BRT | Monitors changes in Langflow source and opens a review issue |
+
+### Debugging a weekly failure
+
+When the weekly `@stable` run fails, the auto-opened triage issue links to the GitHub Actions run. Open the run page and download the `playwright-report-weekly-<run-id>` artifact (retained for 14 days).
+
+The artifact unzips into a self-contained HTML report — open `index.html` to inspect:
+
+- **Failed tests** — file path, test title, and error stack
+- **Screenshots** — automatic on every failure
+- **Video** — captured on the first retry, useful when the failure only reproduces under timing pressure
+- **Trace** — captured on the first retry; click "Trace" in the report to step through the run in Playwright's trace viewer
+
+No local merge step is required: the report works offline once unzipped.
+
+If the failure is a Langflow regression, flag it to the team and keep `@stable` on the test. If it is a test bug, remove `@stable`, open a fix PR, and the next weekly run will be unblocked.
 
 ---
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,6 +23,8 @@ export default defineConfig({
     baseURL: BASE_URL,
     actionTimeout: 20000,
     trace: "on-first-retry",
+    screenshot: process.env.CI ? "only-on-failure" : "off",
+    video: process.env.CI ? "on-first-retry" : "off",
   },
 
   globalTeardown: require.resolve("./tests/globalTeardown.ts"),


### PR DESCRIPTION
## Summary

- Capture screenshots on failure and video on first retry, gated on `process.env.CI` so local runs are unaffected.
- Switch the weekly run reporter from `blob,github` to `html,github` so the uploaded artifact is a self-contained, navigable HTML report — no `merge-reports` step needed. Drop the now-redundant `test-results/` upload (the `html` reporter embeds screenshots, video, and trace in `playwright-report/`).
- Document the debugging flow in the README under a new "Debugging a weekly failure" section, and add the missing `weekly-stable.yml` row to the CI table.

## Decisions made

- `video: "on-first-retry"` (not `retain-on-failure`) — avoids storing video for transient flakes; trace + screenshot already cover the first fail.
- `html,github` directly (no `blob` + merge step) — we don't shard, so blob's flexibility is unused weight.
- Scope limited to `weekly-stable.yml` — keeps the PR focused; extending to `nightly.yml` / `manual.yml` can be a follow-up issue if useful.
- Retention 14d for the HTML report — mirrors the prior blob retention.
- README section title in English (issue body updated PT→EN to match CLAUDE.md's English-only rule).

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] Trigger `weekly-stable.yml` via `workflow_dispatch` and confirm (run [25441253323](https://github.com/oriontech-me/langflow-e2e/actions/runs/25441253323)):
  - [x] Run produces `playwright-report/` with `index.html` (871KB, self-contained)
  - [x] Artifact `playwright-report-weekly-25441253323` (14d retention) is uploaded — `if: always()` covers both success and failure
  - [x] On failure, the HTML report shows screenshots inline and video/trace links work after unzipping (9 screenshots, 6 videos, 6 trace zips embedded in `data/`)
  - [x] No `test-results/` artifact appears on failure (intentionally removed)
- [x] Local `npm test` run produces neither screenshots nor video (CI gating works)

> Note: the run surfaced 3 failed + 2 flaky tests on `langflow-nightly:latest` — unrelated to this PR's scope. Tracked separately for triage.

Closes #160