### PR TITLE
feat(adaptive): impacted-tests subset workflow

### DIFF
--- a/.github/workflows/adaptive-impacted.yml
+++ b/.github/workflows/adaptive-impacted.yml
@@ -83,9 +83,20 @@ jobs:
       - run: npm ci
       - id: impact
         name: Diff Langflow + map to specs
+        env:
+          DECISION: ${{ needs.decide.outputs.decision }}
+          FORCE_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.force_run || 'false' }}
         run: |
           BASE="${{ needs.decide.outputs.baseSha }}"
           CURRENT="${{ needs.decide.outputs.currentSha }}"
+
+          if [ "$FORCE_RUN" = "true" ] && [ "$DECISION" = "skip" ]; then
+            echo "force_run=true and no new nightly — running full suite."
+            echo "run_full=true" >> "$GITHUB_OUTPUT"
+            echo "specs=" >> "$GITHUB_OUTPUT"
+            echo "summary=Full suite (force_run, no new nightly)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           if [ -z "$BASE" ]; then
             echo "Bootstrap with no previous nightly available — running full suite."

--- a/.github/workflows/adaptive-impacted.yml
+++ b/.github/workflows/adaptive-impacted.yml
@@ -1,0 +1,254 @@
+name: Adaptive Impacted Tests
+
+# Runs only the spec files whose `External dependencies` reference Langflow
+# source paths that changed since the last nightly we tested against. Skips
+# entirely when no new nightly image has been published since the last
+# successful run.
+#
+# State is kept in repository variable LAST_TESTED_NIGHTLY_SHA. Updating it
+# requires a PAT with "Variables: read & write" exposed as the secret
+# GH_PAT_VARIABLES; without it the workflow still runs but cannot persist
+# state, so the same delta is recomputed each day until the variable is set
+# manually.
+
+on:
+  schedule:
+    - cron: "0 7 * * *" # 04:00 BRT (UTC-3) — after the Langflow 00:00 UTC nightly settles
+  workflow_dispatch:
+    inputs:
+      force_run:
+        description: "Run even if no new nightly is detected"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  decide:
+    name: Decide whether to run
+    runs-on: ubuntu-latest
+    outputs:
+      decision: ${{ steps.delta.outputs.decision }}
+      reason: ${{ steps.delta.outputs.reason }}
+      currentSha: ${{ steps.delta.outputs.currentSha }}
+      currentTag: ${{ steps.delta.outputs.currentTag }}
+      baseSha: ${{ steps.delta.outputs.baseSha }}
+      isBootstrap: ${{ steps.delta.outputs.isBootstrap }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - id: delta
+        name: Resolve current and previous nightly SHA
+        env:
+          LAST_TESTED_NIGHTLY_SHA: ${{ vars.LAST_TESTED_NIGHTLY_SHA }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          OUT=$(npx ts-node scripts/check-nightly-delta.ts)
+          echo "$OUT" | jq .
+          {
+            echo "decision=$(echo "$OUT" | jq -r .decision)"
+            echo "reason=$(echo "$OUT" | jq -r .reason)"
+            echo "currentSha=$(echo "$OUT" | jq -r .currentSha)"
+            echo "currentTag=$(echo "$OUT" | jq -r .currentTag)"
+            echo "baseSha=$(echo "$OUT" | jq -r .baseSha)"
+            echo "isBootstrap=$(echo "$OUT" | jq -r .isBootstrap)"
+          } >> "$GITHUB_OUTPUT"
+
+  compute-impact:
+    name: Compute impacted specs
+    needs: decide
+    if: needs.decide.outputs.decision == 'run' || (github.event_name == 'workflow_dispatch' && inputs.force_run)
+    runs-on: ubuntu-latest
+    outputs:
+      run_full: ${{ steps.impact.outputs.run_full }}
+      specs: ${{ steps.impact.outputs.specs }}
+      summary: ${{ steps.impact.outputs.summary }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: langflow-ai/langflow
+          path: langflow-upstream
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - id: impact
+        name: Diff Langflow + map to specs
+        run: |
+          BASE="${{ needs.decide.outputs.baseSha }}"
+          CURRENT="${{ needs.decide.outputs.currentSha }}"
+
+          if [ -z "$BASE" ]; then
+            echo "Bootstrap with no previous nightly available — running full suite."
+            echo "run_full=true" >> "$GITHUB_OUTPUT"
+            echo "specs=" >> "$GITHUB_OUTPUT"
+            echo "summary=Full suite (bootstrap, no previous nightly)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          cd langflow-upstream
+          CHANGED=$(git diff --name-only "$BASE".."$CURRENT" || true)
+          cd ..
+
+          if [ -z "$CHANGED" ]; then
+            echo "Empty diff between $BASE..$CURRENT — nothing to run."
+            echo "run_full=false" >> "$GITHUB_OUTPUT"
+            echo "specs=" >> "$GITHUB_OUTPUT"
+            echo "summary=No changes between base and current SHA" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Changed paths in Langflow:"
+          echo "$CHANGED"
+
+          IMPACT=$(echo "$CHANGED" | npx ts-node scripts/impacted-tests.ts --stdin --format=json)
+          echo "$IMPACT" | jq .
+
+          CATCH_ALL=$(echo "$IMPACT" | jq -r .catchAll)
+          if [ "$CATCH_ALL" = "true" ]; then
+            echo "run_full=true" >> "$GITHUB_OUTPUT"
+            echo "specs=" >> "$GITHUB_OUTPUT"
+            echo "summary=Full suite (catch-all path changed)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          SPEC_LIST=$(echo "$IMPACT" | jq -r '.specs | join(" ")')
+          SPEC_COUNT=$(echo "$IMPACT" | jq -r '.specs | length')
+          echo "run_full=false" >> "$GITHUB_OUTPUT"
+          echo "specs=$SPEC_LIST" >> "$GITHUB_OUTPUT"
+          echo "summary=$SPEC_COUNT impacted spec(s)" >> "$GITHUB_OUTPUT"
+
+  test:
+    name: Run impacted tests
+    needs: [decide, compute-impact]
+    if: needs.compute-impact.outputs.run_full == 'true' || needs.compute-impact.outputs.specs != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    services:
+      langflow:
+        image: langflowai/langflow-nightly:${{ needs.decide.outputs.currentTag }}
+        ports:
+          - 7860:7860
+        env:
+          LANGFLOW_AUTO_LOGIN: "true"
+          LANGFLOW_SUPERUSER: langflow
+          LANGFLOW_SUPERUSER_PASSWORD: langflow
+          LANGFLOW_DEACTIVATE_TRACING: "true"
+        options: >-
+          --health-cmd "curl -f http://localhost:7860/health_check || exit 1"
+          --health-interval 15s
+          --health-timeout 10s
+          --health-retries 10
+          --health-start-period 90s
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - run: npm ci
+
+      - run: npx playwright install chromium --with-deps
+
+      - name: Run tests
+        env:
+          CI: "true"
+          PLAYWRIGHT_BASE_URL: "http://localhost:7860/"
+          RUN_FULL: ${{ needs.compute-impact.outputs.run_full }}
+          SPECS: ${{ needs.compute-impact.outputs.specs }}
+          SUMMARY: ${{ needs.compute-impact.outputs.summary }}
+          REASON: ${{ needs.decide.outputs.reason }}
+        run: |
+          echo "Reason: $REASON"
+          echo "Subset: $SUMMARY"
+          if [ "$RUN_FULL" = "true" ]; then
+            npx playwright test --reporter=github
+          else
+            # shellcheck disable=SC2086
+            npx playwright test $SPECS --reporter=github
+          fi
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report-adaptive-${{ github.run_id }}
+          path: playwright-report/
+          retention-days: 14
+
+      - name: Upload test results on failure
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: test-results-adaptive-${{ github.run_id }}
+          path: test-results/
+          retention-days: 7
+
+      - name: Create issue on failure
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const today = new Date().toISOString().split('T')[0];
+            const tag = '${{ needs.decide.outputs.currentTag }}';
+            const summary = '${{ needs.compute-impact.outputs.summary }}';
+            const baseSha = '${{ needs.decide.outputs.baseSha }}';
+            const currentSha = '${{ needs.decide.outputs.currentSha }}';
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[Adaptive Failure] Impacted tests failed on ${today} (langflow:${tag})`,
+              body: [
+                '## Adaptive Impacted Tests Failure',
+                '',
+                `- **Date:** ${today}`,
+                `- **Langflow image:** \`langflowai/langflow-nightly:${tag}\``,
+                `- **Diff range:** \`${baseSha}..${currentSha}\``,
+                `- **Subset:** ${summary}`,
+                `- **Run:** [${context.runId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+                '',
+                '### Next steps',
+                '1. Check the Playwright report artifact in the run above',
+                '2. Determine if the failure is a test bug or a Langflow regression',
+                '3. Update or fix the affected tests',
+                '',
+                '/cc @Victor-w-Madeira',
+              ].join('\n'),
+              labels: ['adaptive-failure', 'needs-triage'],
+            });
+
+  update-state:
+    name: Persist last-tested SHA
+    needs: [decide, test]
+    if: needs.test.result == 'success' && needs.decide.outputs.currentSha != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update LAST_TESTED_NIGHTLY_SHA
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_VARIABLES }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ needs.decide.outputs.currentSha }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::warning::GH_PAT_VARIABLES is not set; skipping LAST_TESTED_NIGHTLY_SHA update. The next run will recompute the same delta."
+            exit 0
+          fi
+          if gh variable set LAST_TESTED_NIGHTLY_SHA --body "$SHA" --repo "$REPO"; then
+            echo "Persisted LAST_TESTED_NIGHTLY_SHA=$SHA"
+          else
+            echo "::warning::Failed to update LAST_TESTED_NIGHTLY_SHA via gh variable set."
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -465,6 +465,28 @@ The guide is the human-language specification of the automated tests. Keeping it
 4. Update the necessary tests and mark `QA_CHECKLIST.md`
 5. Close the issue
 
+### Adaptive impacted-tests subset
+
+`adaptive-impacted.yml` is a finer-grained companion to `nightly.yml`. Each day at 04:00 BRT it:
+
+1. Queries Docker Hub for the current `langflowai/langflow-nightly:latest` digest and resolves the matching git SHA in the Langflow repo.
+2. Compares to the SHA of the last nightly we tested (repo variable `LAST_TESTED_NIGHTLY_SHA`).
+   - **Same** → skip the run (no new image).
+   - **Different** → diff Langflow source between the two SHAs and run only the specs whose `## External dependencies` reference the changed paths.
+3. On success, advances `LAST_TESTED_NIGHTLY_SHA` to the current SHA.
+
+The mapping comes from each spec doc's `## External dependencies` section — keep that section accurate when you add or rename Langflow source paths a test depends on. Any path starting with `src/` is parsed; trailing `/` matches anything inside the directory.
+
+CLI for local inspection:
+
+```bash
+npm run impacted -- src/backend/.../webhook.py     # → list of impacted spec files
+npm run validate:specs                              # → which specs have/lack External dependencies
+npm run check:nightly-delta                         # → would the workflow skip or run today?
+```
+
+State persistence requires the secret `GH_PAT_VARIABLES` (a PAT with `Variables: read & write`); without it the workflow still runs but does not advance the cursor.
+
 ---
 
 ## Tag @stable — validated tests

--- a/README.md
+++ b/README.md
@@ -206,6 +206,38 @@ tests/
 | `nightly.yml` | Daily 03:00 BRT + manual | Runs everything against `langflow-nightly:latest`, opens an issue on failure |
 | `manual.yml` | Manual | Runs against any Docker tag or external URL, filters by suite/tag |
 | `file-watcher.yml` | Daily 05:00 BRT | Monitors changes in Langflow source and opens a review issue |
+| `adaptive-impacted.yml` | Daily 04:00 BRT + manual | Runs only the specs whose `External dependencies` reference the Langflow source paths that changed since the last nightly we tested; skips entirely when no new nightly was published |
+
+---
+
+## Adaptive impacted-tests subset
+
+The `adaptive-impacted.yml` workflow narrows each daily run to the spec files whose docs reference the Langflow source paths changed in the latest nightly. The mapping comes from the **External dependencies** section in each `docs/**/*.md` spec doc.
+
+CLI usage:
+
+```bash
+# Map changed paths to spec files (default output: file paths)
+npm run impacted -- src/backend/base/langflow/components/inputs/webhook.py
+
+# Read paths from stdin (e.g. piped from `git diff --name-only`)
+git diff --name-only main..HEAD | npm run impacted -- --stdin
+
+# Structured output
+npm run impacted -- --format=json src/foo.py
+
+# Inspect which specs have/lack a populated External dependencies section
+npm run validate:specs
+
+# Decide whether the workflow would skip or run (queries Docker Hub)
+npm run check:nightly-delta
+```
+
+Behavior:
+- **File-level matching.** A bullet `src/backend/.../webhook.py` matches the exact file; a bullet ending in `/` matches anything inside the directory.
+- **Catch-all paths** (routes, feature flags) trigger the full suite.
+- **Unmapped paths** are skipped with a warning — the daily nightly still covers them.
+- **State** is persisted in repository variable `LAST_TESTED_NIGHTLY_SHA`; updating it requires the `GH_PAT_VARIABLES` secret (PAT with `Variables: read & write`). Without it the workflow still runs but does not advance the cursor.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint tests/",
     "lint:ci": "eslint tests/ --quiet",
-    "coverage:summary": "ts-node scripts/coverage-summary.ts"
+    "coverage:summary": "ts-node scripts/coverage-summary.ts",
+    "impacted": "ts-node scripts/impacted-tests.ts",
+    "validate:specs": "ts-node scripts/validate-spec-deps.ts",
+    "check:nightly-delta": "ts-node scripts/check-nightly-delta.ts"
   },
   "dependencies": {
     "dotenv": "^16.4.5"

--- a/scripts/check-nightly-delta.ts
+++ b/scripts/check-nightly-delta.ts
@@ -1,0 +1,233 @@
+/**
+ * Decides whether the adaptive workflow should run by comparing the current
+ * `langflowai/langflow-nightly:latest` image to the last one we successfully
+ * tested.
+ *
+ * Run: `npx ts-node scripts/check-nightly-delta.ts`
+ *
+ * Inputs (env):
+ *   LAST_TESTED_NIGHTLY_SHA — Langflow git SHA of the last nightly we ran
+ *                             against; empty/unset triggers bootstrap.
+ *   GH_TOKEN / GITHUB_TOKEN — used by the `gh` CLI for the Langflow tag
+ *                             lookup (rate limits are friendlier with auth).
+ *
+ * Output (stdout, JSON, single object):
+ *   {
+ *     "decision":     "run" | "skip",
+ *     "reason":       string,
+ *     "currentDigest": string,    // sha256 manifest digest from Docker Hub
+ *     "currentTag":   string,    // e.g. "1.10.0.dev20260507"
+ *     "currentSha":   string,    // Langflow git SHA at the matching tag
+ *     "baseSha":      string,    // git SHA to diff against (last tested or
+ *                                //   previous nightly tag on bootstrap)
+ *     "isBootstrap":  boolean
+ *   }
+ *
+ * The workflow consumes this with `jq` and decides whether to run the subset
+ * and what diff range to feed `impacted-tests.ts`.
+ *
+ * Why Docker Hub digest, not just the git tag: the Langflow `nightly_build`
+ * workflow creates the git tag in an early job, *before* the Docker image is
+ * built and pushed. If a later job fails, the tag exists but the
+ * `:latest` image is stale. Treating the digest as the source of truth avoids
+ * acting on a tag whose image never shipped.
+ */
+
+import { execSync } from "child_process";
+
+const DOCKER_REPO = "langflowai/langflow-nightly";
+const LATEST_TAG = "latest";
+const NIGHTLY_VERSION_RE = /^\d+\.\d+\.\d+\.dev\d+$/;
+
+interface DockerImage {
+  digest: string;
+  architecture?: string;
+  os?: string;
+}
+
+interface DockerTag {
+  name: string;
+  last_updated: string;
+  images: DockerImage[];
+}
+
+interface DockerTagsPage {
+  results: DockerTag[];
+}
+
+interface Decision {
+  decision: "run" | "skip";
+  reason: string;
+  currentDigest: string;
+  currentTag: string;
+  currentSha: string;
+  baseSha: string;
+  isBootstrap: boolean;
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`GET ${url} → ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as T;
+}
+
+/**
+ * Compares two image lists by their first amd64/linux digest. Docker Hub
+ * returns one entry per platform variant, and `:latest` shares a manifest
+ * digest with the version tag built in the same run.
+ */
+function primaryDigest(images: DockerImage[]): string {
+  const linuxAmd64 = images.find(
+    (i) => i.os === "linux" && i.architecture === "amd64"
+  );
+  return (linuxAmd64 ?? images[0])?.digest ?? "";
+}
+
+async function fetchLatestTag(): Promise<DockerTag> {
+  return fetchJson<DockerTag>(
+    `https://hub.docker.com/v2/repositories/${DOCKER_REPO}/tags/${LATEST_TAG}`
+  );
+}
+
+async function fetchRecentTags(): Promise<DockerTag[]> {
+  const page = await fetchJson<DockerTagsPage>(
+    `https://hub.docker.com/v2/repositories/${DOCKER_REPO}/tags/?page_size=50&ordering=last_updated`
+  );
+  return page.results;
+}
+
+function findVersionTagForDigest(tags: DockerTag[], digest: string): DockerTag | undefined {
+  return tags.find(
+    (t) =>
+      t.name !== LATEST_TAG &&
+      NIGHTLY_VERSION_RE.test(t.name) &&
+      primaryDigest(t.images) === digest
+  );
+}
+
+function findPreviousVersionTag(
+  tags: DockerTag[],
+  excludeName: string
+): DockerTag | undefined {
+  // `tags` already comes ordered by last_updated desc when ordering is set;
+  // the first entry that is a version tag and not the current one is the
+  // previous nightly.
+  return tags.find(
+    (t) => t.name !== LATEST_TAG && t.name !== excludeName && NIGHTLY_VERSION_RE.test(t.name)
+  );
+}
+
+interface GitRef {
+  object: { sha: string; type: string };
+}
+
+interface GitTag {
+  object: { sha: string };
+}
+
+/**
+ * Resolves a Langflow nightly version tag (e.g. `1.10.0.dev20260507`) to the
+ * commit SHA the tag points at. The Langflow git tag uses a `v` prefix, and
+ * may be either a lightweight ref (points directly at the commit) or an
+ * annotated tag object (points at a tag object that points at the commit).
+ */
+function resolveTagToSha(versionTag: string): string {
+  const gitTag = `v${versionTag}`;
+  const refJson = execSync(
+    `gh api repos/langflow-ai/langflow/git/refs/tags/${gitTag}`,
+    { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }
+  );
+  const ref = JSON.parse(refJson) as GitRef;
+  if (ref.object.type === "commit") return ref.object.sha;
+  // Annotated tag — dereference to the underlying commit.
+  const tagJson = execSync(
+    `gh api repos/langflow-ai/langflow/git/tags/${ref.object.sha}`,
+    { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }
+  );
+  const tag = JSON.parse(tagJson) as GitTag;
+  return tag.object.sha;
+}
+
+function emit(d: Decision): void {
+  process.stdout.write(JSON.stringify(d) + "\n");
+}
+
+async function main(): Promise<void> {
+  const lastSha = (process.env.LAST_TESTED_NIGHTLY_SHA ?? "").trim();
+
+  const latest = await fetchLatestTag();
+  const currentDigest = primaryDigest(latest.images);
+  if (!currentDigest) {
+    throw new Error("Docker Hub returned :latest with no digest");
+  }
+
+  const recent = await fetchRecentTags();
+  const versionTag = findVersionTagForDigest(recent, currentDigest);
+  if (!versionTag) {
+    throw new Error(
+      `No version tag matches :latest digest ${currentDigest}. The nightly Docker push likely did not complete; aborting.`
+    );
+  }
+
+  const currentSha = resolveTagToSha(versionTag.name);
+
+  if (!lastSha) {
+    // Bootstrap: diff against the previous nightly so the first run is useful.
+    const prev = findPreviousVersionTag(recent, versionTag.name);
+    if (!prev) {
+      // No previous nightly available — fall back to "no diff base", which the
+      // workflow interprets as "run the full suite this time".
+      emit({
+        decision: "run",
+        reason: "bootstrap with no previous nightly available; running full suite",
+        currentDigest,
+        currentTag: versionTag.name,
+        currentSha,
+        baseSha: "",
+        isBootstrap: true,
+      });
+      return;
+    }
+    const prevSha = resolveTagToSha(prev.name);
+    emit({
+      decision: "run",
+      reason: `bootstrap; diffing against previous nightly ${prev.name}`,
+      currentDigest,
+      currentTag: versionTag.name,
+      currentSha,
+      baseSha: prevSha,
+      isBootstrap: true,
+    });
+    return;
+  }
+
+  if (lastSha === currentSha) {
+    emit({
+      decision: "skip",
+      reason: "current nightly SHA matches last tested SHA — no new image",
+      currentDigest,
+      currentTag: versionTag.name,
+      currentSha,
+      baseSha: lastSha,
+      isBootstrap: false,
+    });
+    return;
+  }
+
+  emit({
+    decision: "run",
+    reason: `new nightly: ${lastSha} → ${currentSha}`,
+    currentDigest,
+    currentTag: versionTag.name,
+    currentSha,
+    baseSha: lastSha,
+    isBootstrap: false,
+  });
+}
+
+main().catch((err: Error) => {
+  process.stderr.write(`[check-nightly-delta] ERROR: ${err.message}\n`);
+  process.exit(1);
+});

--- a/scripts/impacted-tests.ts
+++ b/scripts/impacted-tests.ts
@@ -1,0 +1,299 @@
+/**
+ * Maps changed Langflow source paths to the spec files whose `External
+ * dependencies` section references them.
+ *
+ * Run:
+ *   npx ts-node scripts/impacted-tests.ts <changed-path-1> <changed-path-2> ...
+ *   npx ts-node scripts/impacted-tests.ts --format=json <paths...>
+ *   cat changed.txt | npx ts-node scripts/impacted-tests.ts --stdin
+ *
+ * Output formats:
+ *   files  (default) — newline-separated spec file paths, ready to pass as
+ *                      positional args to `npx playwright test`
+ *   json             — `{ specs: string[], catchAll: boolean, unmapped: string[] }`
+ *   grep             — best-effort regex over spec basenames; only useful if
+ *                      the consumer matches against file paths, not test titles
+ *                      (Playwright's `--grep` matches titles, so prefer `files`)
+ *
+ * Behavior:
+ *   - File-level matching: a doc bullet `src/foo/bar.py` matches an exact diff
+ *     path, and a bullet ending in `/` (e.g. `src/foo/`) matches anything inside.
+ *   - Catch-all paths (routes / feature flags) trigger a full-suite signal.
+ *   - Unmapped paths are skipped with a warning on stderr — the nightly suite
+ *     still covers regressions broadly, so missing them in the adaptive run is
+ *     acceptable.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Paths that, when changed, can break any test (routes, feature flags, global
+ * config). Mirrors the "Routes & Feature Flags" area in
+ * `.github/workflows/file-watcher.yml`.
+ */
+const CATCH_ALL_PATHS: string[] = [
+  "src/frontend/src/routes.tsx",
+  "src/frontend/src/customization/feature-flags.ts",
+  "src/frontend/src/customization/config-constants.ts",
+];
+
+const DOCS_ROOT = "docs";
+const SPECS_ROOT = "tests/tests-automations/regression";
+
+const EXTERNAL_DEPS_HEADER_RE = /^##\s+External dependencies(\s+\*\(required\)\*)?\s*$/;
+const SECTION_END_RE = /^(##\s+|---\s*)$/;
+const BULLET_BACKTICK_RE = /^-\s+`([^`]+)`/;
+
+interface DocMap {
+  /** Map from Langflow source path (file or dir-with-trailing-slash) → set of spec file paths. */
+  pathToSpecs: Map<string, Set<string>>;
+  /** Spec files that have a parsed doc (regardless of whether dependencies were found). */
+  knownSpecs: Set<string>;
+}
+
+interface ImpactResult {
+  specs: string[];
+  catchAll: boolean;
+  unmapped: string[];
+}
+
+interface CliOptions {
+  format: "grep" | "files" | "json";
+  paths: string[];
+  fromStdin: boolean;
+}
+
+function readArgs(argv: string[]): CliOptions {
+  const opts: CliOptions = { format: "files", paths: [], fromStdin: false };
+  for (const arg of argv) {
+    if (arg === "--stdin") {
+      opts.fromStdin = true;
+    } else if (arg.startsWith("--format=")) {
+      const v = arg.slice("--format=".length);
+      if (v !== "grep" && v !== "files" && v !== "json") {
+        throw new Error(`Invalid --format value: ${v} (expected grep|files|json)`);
+      }
+      opts.format = v;
+    } else if (arg.startsWith("--")) {
+      throw new Error(`Unknown flag: ${arg}`);
+    } else {
+      opts.paths.push(arg);
+    }
+  }
+  return opts;
+}
+
+function readStdin(): string[] {
+  const data = fs.readFileSync(0, "utf-8");
+  return data
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+}
+
+function walkMarkdown(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walkMarkdown(full));
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Returns the spec path that mirrors the doc path under regression/, or null
+ * for top-level docs that are not test specs (template, model catalog, etc.).
+ */
+function specForDoc(docPath: string, repoRoot: string): string | null {
+  const rel = path.relative(path.join(repoRoot, DOCS_ROOT), docPath);
+  if (rel.startsWith("..") || rel === "TEST-SPEC-TEMPLATE.md" || rel === "collect-models.md") {
+    return null;
+  }
+  if (!rel.includes(path.sep)) {
+    // Top-level doc with no area folder — not a spec.
+    return null;
+  }
+  const withoutExt = rel.replace(/\.md$/, "");
+  return path.join(SPECS_ROOT, `${withoutExt}.spec.ts`);
+}
+
+/**
+ * Extracts the External dependencies bullets and keeps only entries whose
+ * leading backticked token starts with `src/` (Langflow source). Helpers,
+ * external services, and bare filenames are filtered out.
+ */
+function parseExternalDeps(markdown: string): string[] {
+  const lines = markdown.split("\n");
+  const out: string[] = [];
+  let inSection = false;
+
+  for (const line of lines) {
+    if (!inSection) {
+      if (EXTERNAL_DEPS_HEADER_RE.test(line)) {
+        inSection = true;
+      }
+      continue;
+    }
+    if (SECTION_END_RE.test(line)) break;
+    const m = line.match(BULLET_BACKTICK_RE);
+    if (!m) continue;
+    const token = m[1].trim();
+    if (token.startsWith("src/")) {
+      out.push(token);
+    }
+  }
+
+  return out;
+}
+
+function buildDocMap(repoRoot: string): DocMap {
+  const docsDir = path.join(repoRoot, DOCS_ROOT);
+  const docs = walkMarkdown(docsDir);
+  const pathToSpecs = new Map<string, Set<string>>();
+  const knownSpecs = new Set<string>();
+
+  for (const doc of docs) {
+    const spec = specForDoc(doc, repoRoot);
+    if (!spec) continue;
+    knownSpecs.add(spec);
+    const md = fs.readFileSync(doc, "utf-8");
+    const deps = parseExternalDeps(md);
+    for (const dep of deps) {
+      let set = pathToSpecs.get(dep);
+      if (!set) {
+        set = new Set<string>();
+        pathToSpecs.set(dep, set);
+      }
+      set.add(spec);
+    }
+  }
+
+  return { pathToSpecs, knownSpecs };
+}
+
+function isCatchAll(changedPath: string): boolean {
+  return CATCH_ALL_PATHS.some(
+    (p) => changedPath === p || changedPath.startsWith(`${p}/`)
+  );
+}
+
+function matchSpecsForPath(changedPath: string, docMap: DocMap): Set<string> {
+  const matched = new Set<string>();
+  for (const [depPath, specs] of docMap.pathToSpecs) {
+    const isDir = depPath.endsWith("/");
+    if (isDir) {
+      if (changedPath === depPath.slice(0, -1) || changedPath.startsWith(depPath)) {
+        for (const s of specs) matched.add(s);
+      }
+    } else if (changedPath === depPath) {
+      for (const s of specs) matched.add(s);
+    }
+  }
+  return matched;
+}
+
+function computeImpact(changedPaths: string[], docMap: DocMap): ImpactResult {
+  const specs = new Set<string>();
+  const unmapped: string[] = [];
+  let catchAll = false;
+
+  for (const cp of changedPaths) {
+    if (isCatchAll(cp)) {
+      catchAll = true;
+      continue;
+    }
+    const matched = matchSpecsForPath(cp, docMap);
+    if (matched.size === 0) {
+      unmapped.push(cp);
+    } else {
+      for (const s of matched) specs.add(s);
+    }
+  }
+
+  return {
+    specs: [...specs].sort(),
+    catchAll,
+    unmapped,
+  };
+}
+
+/**
+ * Builds a Playwright `--grep` regex from a list of spec paths. Uses each
+ * spec's basename (without `.spec.ts`) so the regex stays readable in CI logs.
+ * Playwright matches `--grep` against the test title, so we anchor on the
+ * file path component instead by escaping the basename and ORing them.
+ *
+ * Note: Playwright's `--grep` is matched against test titles, not file paths.
+ * For file-path filtering we instead use positional spec paths in the
+ * workflow. This function is kept for ad-hoc CLI use where a `--grep`-style
+ * pattern is convenient.
+ */
+function toGrep(specs: string[]): string {
+  if (specs.length === 0) return "";
+  const names = specs.map((s) => path.basename(s, ".spec.ts"));
+  const escaped = names.map((n) => n.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  return `(${escaped.join("|")})`;
+}
+
+function reportUnmapped(unmapped: string[]): void {
+  if (unmapped.length === 0) return;
+  console.error(
+    `[impacted-tests] WARNING: ${unmapped.length} changed path(s) are not referenced by any spec doc:`
+  );
+  for (const p of unmapped) {
+    console.error(`  - ${p}`);
+  }
+  console.error(
+    "[impacted-tests] These will not run in the adaptive subset; the nightly suite still covers them."
+  );
+}
+
+function main(): void {
+  const opts = readArgs(process.argv.slice(2));
+  const inputs = opts.fromStdin ? readStdin() : opts.paths;
+  if (inputs.length === 0) {
+    console.error(
+      "Usage: impacted-tests [--format=grep|files|json] [--stdin] <path1> <path2> ..."
+    );
+    process.exit(2);
+  }
+
+  const repoRoot = path.resolve(__dirname, "..");
+  const docMap = buildDocMap(repoRoot);
+  const result = computeImpact(inputs, docMap);
+  reportUnmapped(result.unmapped);
+
+  if (result.catchAll) {
+    console.error("[impacted-tests] Catch-all path changed — full suite required.");
+  }
+
+  if (result.catchAll) {
+    // Empty output signals "run everything" to the caller; the workflow checks
+    // the catchAll flag separately via --format=json before invoking playwright.
+    console.error(
+      "[impacted-tests] catch-all triggered — emitting empty output; caller should run full suite."
+    );
+  }
+
+  switch (opts.format) {
+    case "json":
+      console.log(JSON.stringify(result, null, 2));
+      break;
+    case "grep":
+      if (!result.catchAll) console.log(toGrep(result.specs));
+      break;
+    case "files":
+    default:
+      if (!result.catchAll) {
+        for (const s of result.specs) console.log(s);
+      }
+      break;
+  }
+}
+
+main();

--- a/scripts/impacted-tests.ts
+++ b/scripts/impacted-tests.ts
@@ -11,9 +11,6 @@
  *   files  (default) — newline-separated spec file paths, ready to pass as
  *                      positional args to `npx playwright test`
  *   json             — `{ specs: string[], catchAll: boolean, unmapped: string[] }`
- *   grep             — best-effort regex over spec basenames; only useful if
- *                      the consumer matches against file paths, not test titles
- *                      (Playwright's `--grep` matches titles, so prefer `files`)
  *
  * Behavior:
  *   - File-level matching: a doc bullet `src/foo/bar.py` matches an exact diff
@@ -59,7 +56,7 @@ interface ImpactResult {
 }
 
 interface CliOptions {
-  format: "grep" | "files" | "json";
+  format: "files" | "json";
   paths: string[];
   fromStdin: boolean;
 }
@@ -71,8 +68,8 @@ function readArgs(argv: string[]): CliOptions {
       opts.fromStdin = true;
     } else if (arg.startsWith("--format=")) {
       const v = arg.slice("--format=".length);
-      if (v !== "grep" && v !== "files" && v !== "json") {
-        throw new Error(`Invalid --format value: ${v} (expected grep|files|json)`);
+      if (v !== "files" && v !== "json") {
+        throw new Error(`Invalid --format value: ${v} (expected files|json)`);
       }
       opts.format = v;
     } else if (arg.startsWith("--")) {
@@ -111,11 +108,8 @@ function walkMarkdown(dir: string): string[] {
  */
 function specForDoc(docPath: string, repoRoot: string): string | null {
   const rel = path.relative(path.join(repoRoot, DOCS_ROOT), docPath);
-  if (rel.startsWith("..") || rel === "TEST-SPEC-TEMPLATE.md" || rel === "collect-models.md") {
-    return null;
-  }
-  if (!rel.includes(path.sep)) {
-    // Top-level doc with no area folder — not a spec.
+  if (rel.startsWith("..") || !rel.includes(path.sep)) {
+    // Outside docs/ or top-level doc with no area folder — not a spec.
     return null;
   }
   const withoutExt = rel.replace(/\.md$/, "");
@@ -222,24 +216,6 @@ function computeImpact(changedPaths: string[], docMap: DocMap): ImpactResult {
   };
 }
 
-/**
- * Builds a Playwright `--grep` regex from a list of spec paths. Uses each
- * spec's basename (without `.spec.ts`) so the regex stays readable in CI logs.
- * Playwright matches `--grep` against the test title, so we anchor on the
- * file path component instead by escaping the basename and ORing them.
- *
- * Note: Playwright's `--grep` is matched against test titles, not file paths.
- * For file-path filtering we instead use positional spec paths in the
- * workflow. This function is kept for ad-hoc CLI use where a `--grep`-style
- * pattern is convenient.
- */
-function toGrep(specs: string[]): string {
-  if (specs.length === 0) return "";
-  const names = specs.map((s) => path.basename(s, ".spec.ts"));
-  const escaped = names.map((n) => n.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
-  return `(${escaped.join("|")})`;
-}
-
 function reportUnmapped(unmapped: string[]): void {
   if (unmapped.length === 0) return;
   console.error(
@@ -258,7 +234,7 @@ function main(): void {
   const inputs = opts.fromStdin ? readStdin() : opts.paths;
   if (inputs.length === 0) {
     console.error(
-      "Usage: impacted-tests [--format=grep|files|json] [--stdin] <path1> <path2> ..."
+      "Usage: impacted-tests [--format=files|json] [--stdin] <path1> <path2> ..."
     );
     process.exit(2);
   }
@@ -269,23 +245,16 @@ function main(): void {
   reportUnmapped(result.unmapped);
 
   if (result.catchAll) {
-    console.error("[impacted-tests] Catch-all path changed — full suite required.");
-  }
-
-  if (result.catchAll) {
     // Empty output signals "run everything" to the caller; the workflow checks
     // the catchAll flag separately via --format=json before invoking playwright.
     console.error(
-      "[impacted-tests] catch-all triggered — emitting empty output; caller should run full suite."
+      "[impacted-tests] Catch-all path changed — full suite required; emitting empty output."
     );
   }
 
   switch (opts.format) {
     case "json":
       console.log(JSON.stringify(result, null, 2));
-      break;
-    case "grep":
-      if (!result.catchAll) console.log(toGrep(result.specs));
       break;
     case "files":
     default:

--- a/scripts/validate-spec-deps.ts
+++ b/scripts/validate-spec-deps.ts
@@ -1,0 +1,131 @@
+/**
+ * Reports which spec files have a corresponding doc with a populated
+ * `## External dependencies` section, and which do not.
+ *
+ * Run: `npx ts-node scripts/validate-spec-deps.ts`
+ *
+ * Always exits 0 — this is informational, not a gate. The known fragility
+ * (a developer can ship a spec without filling the doc) is accepted; this
+ * script lets the team see the current state when they want to triage.
+ *
+ * Output (stdout):
+ *   Total specs:        N
+ *   With doc + deps:    N
+ *   With doc, no deps:  N
+ *   Without doc:        N
+ *   Followed by lists for the last two categories.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const DOCS_ROOT = "docs";
+const SPECS_ROOT = "tests/tests-automations/regression";
+
+const EXTERNAL_DEPS_HEADER_RE = /^##\s+External dependencies(\s+\*\(required\)\*)?\s*$/;
+const SECTION_END_RE = /^(##\s+|---\s*)$/;
+const BULLET_BACKTICK_RE = /^-\s+`([^`]+)`/;
+
+interface SpecStatus {
+  spec: string;
+  docPath: string;
+  docExists: boolean;
+  hasDepsSection: boolean;
+  hasLangflowDeps: boolean;
+}
+
+function walk(dir: string, predicate: (name: string) => boolean): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walk(full, predicate));
+    } else if (entry.isFile() && predicate(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function docPathForSpec(specPath: string, repoRoot: string): string {
+  const rel = path.relative(path.join(repoRoot, SPECS_ROOT), specPath);
+  const withoutExt = rel.replace(/\.spec\.ts$/, "");
+  return path.join(repoRoot, DOCS_ROOT, `${withoutExt}.md`);
+}
+
+function inspectDoc(docPath: string): { hasDepsSection: boolean; hasLangflowDeps: boolean } {
+  if (!fs.existsSync(docPath)) {
+    return { hasDepsSection: false, hasLangflowDeps: false };
+  }
+  const lines = fs.readFileSync(docPath, "utf-8").split("\n");
+  let inSection = false;
+  let hasDepsSection = false;
+  let hasLangflowDeps = false;
+
+  for (const line of lines) {
+    if (!inSection) {
+      if (EXTERNAL_DEPS_HEADER_RE.test(line)) {
+        inSection = true;
+        hasDepsSection = true;
+      }
+      continue;
+    }
+    if (SECTION_END_RE.test(line)) break;
+    const m = line.match(BULLET_BACKTICK_RE);
+    if (!m) continue;
+    if (m[1].trim().startsWith("src/")) {
+      hasLangflowDeps = true;
+    }
+  }
+
+  return { hasDepsSection, hasLangflowDeps };
+}
+
+function main(): void {
+  const repoRoot = path.resolve(__dirname, "..");
+  const specs = walk(path.join(repoRoot, SPECS_ROOT), (n) => n.endsWith(".spec.ts"));
+
+  const statuses: SpecStatus[] = specs.map((spec) => {
+    const docPath = docPathForSpec(spec, repoRoot);
+    const docExists = fs.existsSync(docPath);
+    const { hasDepsSection, hasLangflowDeps } = inspectDoc(docPath);
+    return {
+      spec: path.relative(repoRoot, spec),
+      docPath: path.relative(repoRoot, docPath),
+      docExists,
+      hasDepsSection,
+      hasLangflowDeps,
+    };
+  });
+
+  const withDocAndDeps = statuses.filter((s) => s.docExists && s.hasLangflowDeps);
+  const withDocNoDeps = statuses.filter(
+    (s) => s.docExists && !s.hasLangflowDeps
+  );
+  const withoutDoc = statuses.filter((s) => !s.docExists);
+
+  console.log(`Total specs:        ${statuses.length}`);
+  console.log(`With doc + deps:    ${withDocAndDeps.length}`);
+  console.log(`With doc, no deps:  ${withDocNoDeps.length}`);
+  console.log(`Without doc:        ${withoutDoc.length}`);
+
+  if (withDocNoDeps.length > 0) {
+    console.log("\nSpecs whose doc lacks Langflow source paths in External dependencies:");
+    for (const s of withDocNoDeps) {
+      const reason = s.hasDepsSection
+        ? "section present but no `src/` paths"
+        : "no External dependencies section";
+      console.log(`  - ${s.spec}  (doc: ${s.docPath}; ${reason})`);
+    }
+  }
+
+  if (withoutDoc.length > 0) {
+    console.log("\nSpecs without a corresponding doc:");
+    for (const s of withoutDoc) {
+      console.log(`  - ${s.spec}  (expected doc: ${s.docPath})`);
+    }
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds an adaptive CI subset that runs only the specs whose `## External dependencies` reference Langflow source paths changed since the last nightly we tested. Skips entirely when no new nightly image has been published since the last successful run.

- **`scripts/impacted-tests.ts`** — file-level mapping of changed Langflow paths to spec files; emits `files`/`json`/`grep`. Catch-all paths (routes, feature flags) trigger full suite; unmapped paths skip with a stderr warning.
- **`scripts/check-nightly-delta.ts`** — queries Docker Hub for `langflowai/langflow-nightly:latest` digest, finds the matching version tag (e.g. `1.10.0.dev20`), resolves it to a Langflow SHA via `gh api` (with annotated-tag dereference), and compares to `LAST_TESTED_NIGHTLY_SHA`. Bootstrap path uses the previous nightly tag as the diff base so the first run is useful immediately.
- **`scripts/validate-spec-deps.ts`** — informational report of which specs have/lack a populated `## External dependencies` section. Always exits 0.
- **`.github/workflows/adaptive-impacted.yml`** — daily 04:00 BRT (after the Langflow 00:00 UTC nightly settles) + manual `force_run`. Pipeline: `decide → compute-impact → test → update-state`. Persists state via `gh variable set` when the `GH_PAT_VARIABLES` secret is configured; gracefully no-ops the cursor advance otherwise.

Why use Docker Hub digest instead of just the git tag: the Langflow `nightly_build` workflow creates the git tag in an early job, *before* the Docker image is built. If a later job fails, the tag exists but the `:latest` image is stale. Treating the manifest digest as the source of truth avoids acting on a tag whose image never shipped.

## Decisions

All open decisions in #161 have been resolved:
- File-level granularity (function/symbol-level deferred to a future iteration).
- Unmapped paths → skip + warning (nightly is the broad-coverage rede).
- Catch-all (`routes.tsx`, feature flags, config-constants) → full suite.
- Doc malformation / specs without docs → `validate-spec-deps` reports, never blocks (the known fragility "dev forgets to document" is accepted).
- State storage → repo variable; PAT requirement documented.
- Bootstrap → diffs against the previous nightly tag.
- Diff base → SHA resolved from the Docker Hub manifest digest, not just "the latest git tag".

## Out of scope (future issues)

- Build-from-source / arbitrary-SHA testing (cross-repo trigger via Langflow PRs).
- Function-level granularity.
- Health check of nightly image age applied to `nightly.yml` and `weekly-stable.yml`.
- Comment integration with the file-watcher review issue.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 errors; only pre-existing warnings in `tests/`)
- [x] `npm run impacted -- src/backend/.../webhook.py` returns the webhook spec
- [x] `npm run impacted -- src/frontend/src/routes.tsx` triggers catch-all
- [x] `npm run impacted -- src/foo/new_file.py` warns on unmapped
- [x] `npm run check:nightly-delta` returns `bootstrap` (current `1.10.0.dev20` ← previous `1.10.0.dev19`)
- [x] With `LAST_TESTED_NIGHTLY_SHA=<currentSha>` → returns `skip`
- [x] With `LAST_TESTED_NIGHTLY_SHA=<oldSha>` → returns `run`
- [x] `npm run validate:specs` reports 21 / 198 specs with deps; exits 0
- [ ] Workflow validated end-to-end on `workflow_dispatch` (force_run=true) once merged
- [ ] `GH_PAT_VARIABLES` secret configured to enable cursor persistence

Closes #161