### PR TITLE
test(api): mark api-health-check as @stable

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -80,7 +80,7 @@
 ### api/flows/ — REST API
 
 #### 1.1 Health Check
-- [-] GET `/api/v1/health_check` → status 200, db ok
+- [x] GET `/health_check` → status 200, db ok → `api-health-check.spec.ts`
 - [-] GET `/api/v1/health` → returns uptime and version
 
 #### 1.2 Flow CRUD via API

--- a/docs/api/flows/api-health-check.md
+++ b/docs/api/flows/api-health-check.md
@@ -1,0 +1,73 @@
+# API Health Check
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+Validates that Langflow's `/health_check` endpoint is available and reports a healthy state. The endpoint is the primary uptime probe used by orchestrators and the project's CI pipelines, so its contract — status code, response body keys, latency, and content type — must remain stable across releases.
+
+If any of these tests fail, monitoring and CI scripts that rely on the health probe break, and outages are detected late.
+
+---
+
+## Tags *(required)*
+`@stable` `@release` `@api` `@regression`
+
+---
+
+## Step by step *(required)*
+
+The spec runs **4 independent tests**, each issuing a single `GET /health_check` request via Playwright's `request` fixture. No authentication is needed — the endpoint is public.
+
+---
+
+**Test 1 — `GET /health_check` returns 200 with `status: "ok"`**
+1. `GET /health_check`
+2. Assert HTTP status is `200`
+3. Assert response body has property `status`
+4. Assert `body.status === "ok"`
+
+**Test 2 — `GET /health_check` returns `db: "ok"`**
+1. `GET /health_check`
+2. Assert HTTP status is `200`
+3. Assert response body has property `db`
+4. Assert `body.db === "ok"`
+
+**Test 3 — `GET /health_check` responds within 5 seconds**
+1. Capture `start = Date.now()`
+2. `GET /health_check`
+3. Capture elapsed = `Date.now() - start`
+4. Assert HTTP status is `200`
+5. Assert `elapsed < 5000`
+
+**Test 4 — `GET /health_check` response has `content-type: application/json`**
+1. `GET /health_check`
+2. Assert HTTP status is `200`
+3. Assert `content-type` header contains `application/json`
+
+---
+
+## Validation criterion *(required)*
+- All four assertions must succeed against a freshly started Langflow instance.
+- The endpoint path is `/health_check` at the server root — **not** `/api/v1/health_check`.
+- Each test completes in well under 5 seconds; the latency assertion is the upper bound for an unhealthy backend.
+
+---
+
+## What this test does not cover *(optional)*
+- The `chat` field of the body (returned but not asserted on)
+- The unauthenticated `/api/v1/health` endpoint (uptime/version) — covered by a separate spec when added
+- Behavior under degraded states (e.g., DB down) — would require a fixture that intentionally breaks the database
+
+---
+
+## Preconditions *(optional)*
+- Langflow running and reachable at `PLAYWRIGHT_BASE_URL` (default `http://localhost:7860`)
+- No authentication, API key, or environment variables required
+
+---
+
+## External dependencies *(required)*
+- `src/backend/base/langflow/api/router.py` (or wherever the `/health_check` route is mounted) — if the path moves, the spec breaks
+- The Langflow process serving the route — the test does not start it

--- a/tests/tests-automations/regression/api/flows/api-health-check.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-health-check.spec.ts
@@ -6,7 +6,7 @@ import { expect, test } from "../../../../fixtures/fixtures";
 test.describe("API Health Check", () => {
   test(
     "GET /health_check returns 200 with status ok",
-    { tag: ["@release", "@api", "@regression"] },
+    { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
       const response = await request.get("/health_check");
 
@@ -20,7 +20,7 @@ test.describe("API Health Check", () => {
 
   test(
     "GET /health_check returns db ok",
-    { tag: ["@release", "@api", "@regression"] },
+    { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
       const response = await request.get("/health_check");
 
@@ -34,7 +34,7 @@ test.describe("API Health Check", () => {
 
   test(
     "GET /health_check responds within 5 seconds",
-    { tag: ["@release", "@api", "@regression"] },
+    { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
       const start = Date.now();
       const response = await request.get("/health_check");
@@ -47,7 +47,7 @@ test.describe("API Health Check", () => {
 
   test(
     "GET /health_check response has correct content-type",
-    { tag: ["@release", "@api", "@regression"] },
+    { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
       const response = await request.get("/health_check");
 


### PR DESCRIPTION
## Summary
- Add `@stable` to all 4 tests in `api-health-check.spec.ts` (4/4 pass cleanly in 1.1s, no retries).
- Add spec doc `docs/api/flows/api-health-check.md` (mandatory per CLAUDE.md PR review checklist).
- Update `QA-CHECKLIST.md` line 83: fix endpoint path (`/api/v1/health_check` → `/health_check`) and flip `[-] → [x]` with spec filename.

## Validation pipeline (all 7 steps performed)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` filtered to file — 0 errors / 0 warnings
- [x] `playwright-test-linter` skill — anti-pattern checklist clean (no if/else, no `.catch(()=>false)` in test logic, no standalone `.isVisible()`, expect count 10 ≥ test count 4×2)
- [x] `npx playwright test ... --workers=1 --retries=0` — 4/4 pass, 1.1s, no retries (3 separate runs)
- [x] **Force-fail check** — changed `expect(body.status).toBe("ok")` to `"FORCE_FAIL_PURPOSE"`; Test 1 failed exactly at line 17:27, other 3 passed; reverted; final run clean
- [x] `--trace=on` run — trace captured
- [x] Backend errors audit — zero `🚨 Backend Error:` in output

## Test plan
- [x] Local run passes 4/4 against `langflow-nightly` at `http://localhost:7860`.
- [ ] CI `pr-validation.yml` (typecheck + lint) passes.
- [ ] Weekly `weekly-stable.yml` picks up the test on next Monday's run.