### PR TITLE
test(playground): cover ChatInput Input Text pre-fill behavior

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -407,6 +407,9 @@
 - [ ] Send message while response is in progress — should wait or queue
 - [x] Attach image in chat — compact preview appears in input before sending → `core-functionality/playground/playground-output-image.spec.ts`
 - [x] Image rendered in user message bubble after sending → `core-functionality/playground/playground-output-image.spec.ts`
+- [x] ChatInput Input Text pre-fills the playground textarea on first open → `core-functionality/playground/playground-input-text-prefill.spec.ts`
+- [x] ChatInput Input Text re-pre-fills the textarea on a new session → `core-functionality/playground/playground-input-text-prefill.spec.ts`
+- [x] Pre-filled Input Text can be sent as the first message of the session → `core-functionality/playground/playground-input-text-prefill.spec.ts`
 
 #### 9.2 History and Session
 - [-] Configure custom session ID → `playground/playground-session-id.spec.ts` (needs rewrite — see issue)
@@ -674,7 +677,7 @@
 | `core-functionality/llm-agents/` | 40 | 13 | 2 | 0 | 25 |
 | `core-functionality/model-provider/` | 31 | 4 | 18 | 0 | 9 |
 | `core-functionality/observability-monitoring/` | 13 | 0 | 12 | 0 | 1 |
-| `core-functionality/playground/` | 38 | 29 | 7 | 1 | 1 |
+| `core-functionality/playground/` | 41 | 32 | 7 | 1 | 1 |
 | `core-functionality/project-management/` | 11 | 0 | 10 | 1 | 0 |
 | `core-functionality/templates/` | 41 | 2 | 39 | 0 | 0 |
 | `flow-functionality/` | 23 | 0 | 21 | 2 | 0 |
@@ -682,7 +685,7 @@
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 42 | 0 | 40 | 1 | 1 |
 | `ui-ux/` — Settings | 5 | 1 | 3 | 1 | 0 |
-| **TOTAL** | **370** | **77 (21%)** | **228 (62%)** | **6 (2%)** | **59 (16%)** |
+| **TOTAL** | **373** | **80 (21%)** | **228 (61%)** | **6 (2%)** | **59 (16%)** |
 
 > Note: `Validated [x]` = checklist bullets, not unique tests. A single `@stable` test may cover multiple bullets (e.g. the agent suite covers 7 bullets via `test.step()`). The canonical list of 51 unique `@stable` tests is in **Phase 0 — Validated** below.
 

--- a/docs/core-functionality/playground/playground-input-text-prefill.md
+++ b/docs/core-functionality/playground/playground-input-text-prefill.md
@@ -33,7 +33,8 @@ A small helper, `setupFlowWithPrefill(page)`, performs the common setup for
 all three tests:
 
 1. Call `setupPlayground(page)` to create a `ChatInput → ChatOutput` flow
-2. Wait 4 s for the autosave debounce to flush the connection to the database
+2. Poll `GET /api/v1/flows/{flowId}` until `data.edges.length >= 1`, so the
+   autosave-driven persistence of the connection is confirmed before reload
 3. Register a `page.route` interceptor on `**/api/v1/flows/{flowId}` that
    patches the response and writes `"prefill message"` into the ChatInput
    node's `template.input_value.value`

--- a/docs/core-functionality/playground/playground-input-text-prefill.md
+++ b/docs/core-functionality/playground/playground-input-text-prefill.md
@@ -1,0 +1,144 @@
+# Playground — Input Text Pre-fill Behavior
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+Validates that the value set in the **Chat Input** node's `input_value` field
+("Input Text" on the canvas) is automatically written into the Playground
+chat textarea when chat history is empty. Three behaviors are exercised:
+the initial pre-fill when the Playground first opens, the re-pre-fill after
+the user creates a new session, and the ability to send the pre-filled value
+as the first message of a session without any user typing.
+
+The pre-fill effect is implemented in
+`flow-page-sliding-container.tsx` and runs whenever
+`chatHistory.length === 0`. If this effect breaks, users lose the pre-fill
+UX silently — none of the previously existing playground specs checked the
+initial value of the textarea, since they all called `.fill()` immediately.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@playground`
+
+---
+
+## Step by step *(required)*
+
+A small helper, `setupFlowWithPrefill(page)`, performs the common setup for
+all three tests:
+
+1. Call `setupPlayground(page)` to create a `ChatInput → ChatOutput` flow
+2. Wait 4 s for the autosave debounce to flush the connection to the database
+3. Register a `page.route` interceptor on `**/api/v1/flows/{flowId}` that
+   patches the response and writes `"prefill message"` into the ChatInput
+   node's `template.input_value.value`
+4. Reload the page so the canvas re-fetches the flow and renders with the
+   patched template
+
+**Test 1 — playground opens with chat textarea pre-filled from ChatInput Input Text**
+1. Run `setupFlowWithPrefill`
+2. Click `playground-btn-flow-io` and wait for `input-chat-playground`
+3. Assert `input-chat-playground` has value `"prefill message"` — without
+   any prior `.fill()` call
+
+**Test 2 — creating a new session re-applies the Input Text pre-fill**
+1. Run `setupFlowWithPrefill`
+2. Open the Playground and confirm the pre-fill (history is empty)
+3. Click `button-send` to dispatch the pre-filled message; wait for the
+   user bubble (`chat-message-User-prefill message`) and for `button-stop`
+   to disappear (run finished)
+4. Click `new-chat` to create a new session
+5. Assert `input-chat-playground` is once again pre-filled with
+   `"prefill message"`
+
+**Test 3 — pre-filled value is sent as the first message of the session**
+1. Run `setupFlowWithPrefill`
+2. Open the Playground; assert the textarea is pre-filled
+3. Click `button-send` without typing anything
+4. Assert `div-chat-message` is visible and that the user-bubble
+   (`chat-message-User-prefill message`) shows the pre-filled value
+5. Wait for `button-stop` to disappear (run finished)
+
+---
+
+## Validation criterion *(required)*
+
+- **Test 1:** the chat textarea value equals the ChatInput node's
+  `input_value` (`"prefill message"`) immediately on opening the Playground,
+  without any user input
+- **Test 2:** after sending the pre-filled message and creating a new
+  session via `new-chat`, the textarea is pre-filled again with the same
+  value (the effect re-fires because the new session starts with empty
+  history)
+- **Test 3:** clicking `button-send` with the textarea holding only the
+  pre-filled value sends `"prefill message"` as the first message and the
+  user bubble shows the same text
+
+---
+
+## External dependencies *(required)*
+
+References in the **main Langflow repository** (compatible with Langflow 1.10.x):
+
+- `src/frontend/src/components/core/playgroundComponent/sliding-container/components/flow-page-sliding-container.tsx`
+  — defines the pre-fill `useEffect` that reads
+  `chatInputNode.data.node.template["input_value"].value` when
+  `chatHistory.length === 0`
+- `src/frontend/src/components/core/playgroundComponent/chat-view/chat-input/components/text-area-wrapper.tsx`
+  — defines `data-testid="input-chat-playground"`
+- `src/frontend/src/components/core/playgroundComponent/chat-view/chat-input/components/button-send-wrapper.tsx`
+  — defines `data-testid="button-send"` / `"button-stop"`
+- `src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/chat-sidebar.tsx`
+  — defines `data-testid="new-chat"`
+- `src/frontend/src/components/core/playgroundComponent/chat-view/chat-messages/components/bot-message.tsx`
+  — defines `data-testid="div-chat-message"`
+- `src/lfx/src/lfx/components/input_output/chat.py` — `ChatInput` declares
+  `input_value` as a `MultilineInput` (display name "Input Text", default
+  empty)
+
+References in this repository:
+
+- `tests/helpers/flows/setup-playground.ts` — shared helper that creates the
+  ChatInput → ChatOutput flow and returns its ID for cleanup
+- `tests/tests-automations/regression/core-components/webhook-component-regression.spec.ts`
+  — same `page.route` interception pattern used here to inject a value into
+  a node template that has no editable canvas UI
+
+---
+
+## What this test does not cover *(optional)*
+
+- Sending the pre-filled value when an LLM-backed flow is used — this spec
+  uses `ChatInput → ChatOutput` (echo) which is deterministic and free
+- The pre-fill behavior with non-empty history (the effect intentionally
+  does **not** overwrite the textarea once the user has interacted)
+- Pre-fill behavior in the fullscreen Playground at `/playground/{id}` —
+  only the IOModal flavor is exercised here
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
+- No pre-existing flow needed; `setupPlayground` creates the flow and
+  `afterEach` deletes it via `DELETE /api/v1/flows/{id}`
+- ChatInput defaults to `minimized = True`, which collapses the node and
+  hides `input_value` from the canvas UI — that is why the value is
+  injected via the API response interceptor instead of being typed into a
+  visible textarea on the node
+
+---
+
+## Notes *(optional)*
+
+- The injected value is written into the **response** of
+  `GET /api/v1/flows/{flowId}` — the database row keeps `input_value=""`,
+  so cleanup via `DELETE /api/v1/flows/{id}` still works with no extra
+  steps
+- `page.unrouteAll({ behavior: "ignoreErrors" })` is called in `afterEach`
+  to remove the interceptor between tests in the serial group

--- a/docs/core-functionality/playground/playground-input-text-prefill.md
+++ b/docs/core-functionality/playground/playground-input-text-prefill.md
@@ -137,6 +137,9 @@ References in this repository:
 
 ## Notes *(optional)*
 
+- The interceptor only handles `GET` requests — `PATCH`/`DELETE` to the
+  same URL fall through with `route.fallback()` so autosave traffic and the
+  cleanup `DELETE /api/v1/flows/{id}` are not touched
 - The injected value is written into the **response** of
   `GET /api/v1/flows/{flowId}` — the database row keeps `input_value=""`,
   so cleanup via `DELETE /api/v1/flows/{id}` still works with no extra

--- a/tests/tests-automations/regression/core-functionality/playground/playground-input-text-prefill.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-input-text-prefill.spec.ts
@@ -39,11 +39,25 @@ async function injectChatInputValue(
   });
 }
 
+// Poll the backend until the ChatInput → ChatOutput edge is persisted, so the
+// upcoming reload renders the saved graph. Replaces a fixed-duration sleep
+// that was tuned to the autosave debounce.
+async function waitForEdgePersisted(
+  page: Page,
+  flowId: string,
+  timeoutMs = 15000,
+): Promise<void> {
+  await expect(async () => {
+    const response = await page.request.get(`/api/v1/flows/${flowId}`);
+    expect(response.ok()).toBe(true);
+    const flow = await response.json();
+    expect(flow?.data?.edges?.length ?? 0).toBeGreaterThanOrEqual(1);
+  }).toPass({ timeout: timeoutMs, intervals: [250, 500, 1000] });
+}
+
 async function setupFlowWithPrefill(page: Page): Promise<string> {
   const flowId = await setupPlayground(page);
-  // Wait for the autosave debounce to flush the ChatInput → ChatOutput
-  // connection to the database before we reload with the injected template.
-  await page.waitForTimeout(4000);
+  await waitForEdgePersisted(page, flowId);
   await injectChatInputValue(page, flowId, PREFILL_VALUE);
   await page.reload();
   await page.waitForSelector('[data-testid="playground-btn-flow-io"]', {

--- a/tests/tests-automations/regression/core-functionality/playground/playground-input-text-prefill.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-input-text-prefill.spec.ts
@@ -27,6 +27,9 @@ async function injectChatInputValue(
   value: string,
 ): Promise<void> {
   await page.route(`**/api/v1/flows/${flowId}`, async (route) => {
+    if (route.request().method() !== "GET") {
+      return route.fallback();
+    }
     const response = await route.fetch();
     const json = await response.json();
     const chatInputNode = (json?.data?.nodes ?? []).find(

--- a/tests/tests-automations/regression/core-functionality/playground/playground-input-text-prefill.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-input-text-prefill.spec.ts
@@ -1,0 +1,149 @@
+import { Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+
+/**
+ * Pre-fill behavior of the Playground textarea driven by the ChatInput
+ * node's "Input Text" field (`input_value`).
+ *
+ * The pre-fill effect lives in `flow-page-sliding-container.tsx` and writes
+ * the ChatInput template's `input_value` into the playground textarea
+ * whenever `chatHistory.length === 0`. If this effect breaks, users lose the
+ * pre-fill UX silently — none of the existing playground specs verify the
+ * initial textarea value because they all call `.fill()` immediately.
+ *
+ * The Input Text field has no exposed canvas UI when the node is collapsed
+ * (ChatInput defaults to `minimized = True`), so we set `input_value` by
+ * intercepting the GET /api/v1/flows/{id} response and injecting the value
+ * into the node template before the canvas renders. Same technique used by
+ * `webhook-component-regression.spec.ts`.
+ */
+
+const PREFILL_VALUE = "prefill message";
+
+async function injectChatInputValue(
+  page: Page,
+  flowId: string,
+  value: string,
+): Promise<void> {
+  await page.route(`**/api/v1/flows/${flowId}`, async (route) => {
+    const response = await route.fetch();
+    const json = await response.json();
+    const chatInputNode = (json?.data?.nodes ?? []).find(
+      (n: any) => n?.data?.type === "ChatInput",
+    );
+    if (chatInputNode) {
+      chatInputNode.data.node.template.input_value.value = value;
+    }
+    await route.fulfill({ json });
+  });
+}
+
+async function setupFlowWithPrefill(page: Page): Promise<string> {
+  const flowId = await setupPlayground(page);
+  // Wait for the autosave debounce to flush the ChatInput → ChatOutput
+  // connection to the database before we reload with the injected template.
+  await page.waitForTimeout(4000);
+  await injectChatInputValue(page, flowId, PREFILL_VALUE);
+  await page.reload();
+  await page.waitForSelector('[data-testid="playground-btn-flow-io"]', {
+    timeout: 30000,
+  });
+  return flowId;
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Playground – Input Text Pre-fill Behavior", () => {
+  let createdFlowId: string | null = null;
+
+  test.afterEach(async ({ page }) => {
+    if (createdFlowId) {
+      await page.unrouteAll({ behavior: "ignoreErrors" }).catch(() => {});
+      await page.goto("/");
+      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      createdFlowId = null;
+    }
+  });
+
+  test(
+    "playground opens with chat textarea pre-filled from ChatInput Input Text",
+    { tag: ["@stable", "@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step("set up flow with Input Text and open playground", async () => {
+        createdFlowId = await setupFlowWithPrefill(page);
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(
+          page.getByTestId("input-chat-playground").last(),
+        ).toBeVisible({ timeout: 15000 });
+      });
+
+      await test.step("textarea must hold the pre-filled value with no user input", async () => {
+        await expect(
+          page.getByTestId("input-chat-playground").last(),
+        ).toHaveValue(PREFILL_VALUE, { timeout: 10000 });
+      });
+    },
+  );
+
+  test(
+    "creating a new session re-applies the Input Text pre-fill",
+    { tag: ["@stable", "@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step("set up flow with Input Text and open playground", async () => {
+        createdFlowId = await setupFlowWithPrefill(page);
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(
+          page.getByTestId("input-chat-playground").last(),
+        ).toHaveValue(PREFILL_VALUE, { timeout: 15000 });
+      });
+
+      await test.step("send the pre-filled message so chat history becomes non-empty", async () => {
+        await page.getByTestId("button-send").last().click();
+        await expect(
+          page.getByTestId("chat-message-User-" + PREFILL_VALUE),
+        ).toBeVisible({ timeout: 15000 });
+        await expect(page.getByTestId("button-stop").last()).toBeHidden({
+          timeout: 30000,
+        });
+      });
+
+      await test.step("create a new session and verify the textarea is pre-filled again", async () => {
+        await page.getByTestId("new-chat").click();
+        await expect(
+          page.getByTestId("input-chat-playground").last(),
+        ).toBeVisible({ timeout: 10000 });
+        await expect(
+          page.getByTestId("input-chat-playground").last(),
+        ).toHaveValue(PREFILL_VALUE, { timeout: 10000 });
+      });
+    },
+  );
+
+  test(
+    "pre-filled value is sent as the first message of the session",
+    { tag: ["@stable", "@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step("set up flow with Input Text and open playground", async () => {
+        createdFlowId = await setupFlowWithPrefill(page);
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(
+          page.getByTestId("input-chat-playground").last(),
+        ).toHaveValue(PREFILL_VALUE, { timeout: 15000 });
+      });
+
+      await test.step("send without typing and verify the pre-filled value reaches the chat", async () => {
+        await page.getByTestId("button-send").last().click();
+        await expect(page.getByTestId("div-chat-message").first()).toBeVisible({
+          timeout: 15000,
+        });
+        await expect(
+          page.getByTestId("chat-message-User-" + PREFILL_VALUE),
+        ).toBeVisible({ timeout: 15000 });
+        await expect(page.getByTestId("button-stop").last()).toBeHidden({
+          timeout: 30000,
+        });
+      });
+    },
+  );
+});

--- a/tests/tests-automations/regression/core-functionality/playground/playground-input-text-prefill.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-input-text-prefill.spec.ts
@@ -73,7 +73,7 @@ async function setupFlowWithPrefill(page: Page): Promise<string> {
   await waitForEdgePersisted(page, flowId);
   await injectChatInputValue(page, flowId, PREFILL_VALUE);
   await page.reload();
-  await page.waitForSelector('[data-testid="playground-btn-flow-io"]', {
+  await expect(page.getByTestId("playground-btn-flow-io")).toBeVisible({
     timeout: 30000,
   });
   return flowId;

--- a/tests/tests-automations/regression/core-functionality/playground/playground-input-text-prefill.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-input-text-prefill.spec.ts
@@ -19,7 +19,16 @@ import { setupPlayground } from "../../../../helpers/flows/setup-playground";
  * `webhook-component-regression.spec.ts`.
  */
 
+// Doubles as a `chat-message-User-{value}` testid suffix — keep it free of
+// characters that would invalidate that selector.
 const PREFILL_VALUE = "prefill message";
+
+type FlowNode = {
+  data?: {
+    type?: string;
+    node?: { template?: Record<string, { value?: unknown }> };
+  };
+};
 
 async function injectChatInputValue(
   page: Page,
@@ -32,11 +41,12 @@ async function injectChatInputValue(
     }
     const response = await route.fetch();
     const json = await response.json();
-    const chatInputNode = (json?.data?.nodes ?? []).find(
-      (n: any) => n?.data?.type === "ChatInput",
+    const chatInputNode = ((json?.data?.nodes ?? []) as FlowNode[]).find(
+      (n) => n?.data?.type === "ChatInput",
     );
-    if (chatInputNode) {
-      chatInputNode.data.node.template.input_value.value = value;
+    const inputValue = chatInputNode?.data?.node?.template?.input_value;
+    if (inputValue) {
+      inputValue.value = value;
     }
     await route.fulfill({ json });
   });


### PR DESCRIPTION
## Summary

- Adds `playground-input-text-prefill.spec.ts` with 3 `@stable` tests covering the pre-fill effect that writes `ChatInput.template.input_value` into the Playground chat textarea whenever `chatHistory.length === 0` (`flow-page-sliding-container.tsx`).
- All existing playground specs call `.fill()` before any assertion, so this behavior was previously untested — a regression would silently strip the pre-fill UX.
- `ChatInput` defaults to `minimized = True` and exposes no editable canvas UI for `input_value`, so the value is injected via a `page.route` interceptor on `GET /api/v1/flows/{id}` (same pattern as `webhook-component-regression.spec.ts`). The DB row stays at `input_value=""`, so the standard `DELETE /api/v1/flows/{id}` cleanup is unaffected.
- Spec doc and 3 `[x]` entries under 9.1 Chat Interactions added.

## Test plan

- [x] `npx playwright test playground-input-text-prefill.spec.ts --trace=on --workers=1` → 3/3 pass on a clean run (~34 s)
- [x] Forced-failure run (injected `""` instead of the prefill value) → test 1 fails on `toHaveValue("prefill message")` as expected, confirming no false positives
- [x] `npm run typecheck` → 0 errors
- [x] `npm run lint` → 0 errors (only pre-existing warnings unrelated to this branch)
- [x] `@stable` present on all 3 tests
- [x] Spec doc has every mandatory section filled
- [x] No mocked API calls — only a response-body interceptor for a single field

Closes #152