### PR TITLE
chore(playground): add afterEach flow cleanup to message-edit spec

### DIFF
--- a/tests/tests-automations/regression/core-functionality/playground/playground-message-edit.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-message-edit.spec.ts
@@ -85,12 +85,22 @@ async function setEditTextareaValue(page: any, value: string): Promise<void> {
 }
 
 test.describe("Playground Message Edit", () => {
+  let createdFlowId: string | null = null;
+
+  test.afterEach(async ({ page }) => {
+    if (createdFlowId) {
+      await page.goto("/");
+      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      createdFlowId = null;
+    }
+  });
+
   test(
     "edit user message — hover reveals edit button and saved changes replace original text",
     { tag: ["@release", "@playground", "@stable"] },
     async ({ page }) => {
       await test.step("set up flow", async () => {
-        await setupPlayground(page);
+        createdFlowId = await setupPlayground(page);
       });
 
       await test.step("open playground and send initial message", async () => {
@@ -128,7 +138,7 @@ test.describe("Playground Message Edit", () => {
     { tag: ["@regression", "@playground", "@stable"] },
     async ({ page }) => {
       await test.step("set up flow and send message", async () => {
-        await setupPlayground(page);
+        createdFlowId = await setupPlayground(page);
         await openPlaygroundWithMessage(page, "Original message");
       });
 
@@ -154,7 +164,7 @@ test.describe("Playground Message Edit", () => {
     { tag: ["@regression", "@playground", "@stable"] },
     async ({ page }) => {
       await test.step("set up flow and send message", async () => {
-        await setupPlayground(page);
+        createdFlowId = await setupPlayground(page);
         await openPlaygroundWithMessage(page, "Before edit");
       });
 


### PR DESCRIPTION
## Summary

- `playground-message-edit.spec.ts` was the only playground spec with `setupPlayground` that did not clean up its flow. The 3 tests called `setupPlayground(page)` and discarded the returned `flowId`, leaving an orphaned flow per test run.
- Capture the `flowId` and add an `afterEach` hook matching the pattern already used in `playground-session-rename.spec.ts` and `playground-output-image.spec.ts` (the other two specs the issue listed — both already cleaned up in earlier commits).
- Audited all specs in `tests/tests-automations/regression/core-functionality/playground/`: every other spec that uses `setupPlayground` already has cleanup. Specs that build flows manually (`output-modal-copy-button`, `playground-session-id`, `stop-button-playground`) don't capture a `flowId`, so the issue's pattern doesn't apply to them.

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes (no new warnings/errors)
- [ ] Local run of the 3 message-edit tests leaves no flow behind in the Langflow UI after completion

Closes #130