### PR TITLE
chore(checklist): auto-generate Phase 0 from @stable test() calls

### DIFF
--- a/.github/workflows/update-coverage-summary.yml
+++ b/.github/workflows/update-coverage-summary.yml
@@ -14,6 +14,8 @@ on:
     paths:
       - "QA-CHECKLIST.md"
       - "scripts/coverage-summary.ts"
+      - "scripts/stable-tests.ts"
+      - "tests/**/*.spec.ts"
       - ".github/workflows/update-coverage-summary.yml"
 
 jobs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,11 +154,16 @@ GitHub Actions workflows:
 - **`weekly-stable.yml`** — Runs every Monday against `langflowai/langflow-nightly:latest`; runs only `@stable` tests; opens a GitHub issue on failure for triage.
 - **`manual.yml`** — Parameterized manual run; accepts a Docker tag or full URL, a specific test suite, and an optional grep filter.
 - **`file-watcher.yml`** — Detects upstream Langflow changes in critical paths and opens a GitHub issue with the exact `--grep` command needed to revalidate affected areas.
-- **`update-coverage-summary.yml`** — Runs on every push to `main` that touches `QA-CHECKLIST.md` (or the script itself); regenerates the Coverage Summary table from the bullets above it and commits any change with `[skip ci]`.
+- **`update-coverage-summary.yml`** — Runs on every push to `main` that touches `QA-CHECKLIST.md`, the regeneration scripts, or `tests/**/*.spec.ts`; regenerates the Coverage Summary table and the `Phase 0 — Validated` block (counts + bulleted list) from source and commits any change with `[skip ci]`.
 
 ## QA-CHECKLIST.md
 
-The **Coverage Summary table** at the bottom of `QA-CHECKLIST.md` is **auto-generated** from the bullet markers (`[x]` / `[-]` / `[ ]` / `[~]` / `[!]`) above it. Never propose manual edits to the table's numbers, percentages, or `**TOTAL**` row — only edit the bullets in Part II, and the `update-coverage-summary.yml` workflow will refresh the table on the next merge to `main`. Locally the same logic is available via `npm run coverage:summary` (or `npx ts-node scripts/coverage-summary.ts`); the script lives at `scripts/coverage-summary.ts`. If a new module section is added to Part II, update the `MODULES` array in the script.
+Two passages in `QA-CHECKLIST.md` are **auto-generated**:
+
+1. The **Coverage Summary table** is derived from the bullet markers (`[x]` / `[-]` / `[ ]` / `[~]` / `[!]`) inside Part II. Never propose manual edits to the table's numbers, percentages, or `**TOTAL**` row — only edit the bullets, and the workflow regenerates the table on the next merge to `main`. Logic lives in `scripts/coverage-summary.ts`. If a new module section is added to Part II, update the `MODULES` array in the script.
+2. The **Coverage Summary Note** and the **`Phase 0 — Validated`** block (header counts and bulleted list) are derived from `@stable` `test()` calls parsed out of `tests/tests-automations/regression/**.spec.ts`. Never edit those by hand. Add or remove the `@stable` tag on the relevant `test(...)` and the workflow regenerates on the next merge to `main`. Logic lives in `scripts/stable-tests.ts`.
+
+Both regenerators run together via `npm run coverage:summary` (locally or in `update-coverage-summary.yml`) and are idempotent — a second run produces no diff when in sync.
 
 ## Playwright Configuration
 

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -687,7 +687,11 @@
 | `ui-ux/` — Settings | 5 | 1 | 3 | 1 | 0 |
 | **TOTAL** | **373** | **80 (21%)** | **228 (61%)** | **6 (2%)** | **59 (16%)** |
 
-> Note: `Validated [x]` = checklist bullets, not unique tests. A single `@stable` test may cover multiple bullets (e.g. the agent suite covers 7 bullets via `test.step()`). The canonical list of 51 unique `@stable` tests is in **Phase 0 — Validated** below.
+> Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
+> `@stable` tag is per-`test()`, and a single `@stable` test may map to
+> several bullets via `test.step()` (e.g. the agent suite covers 7
+> bullets). The canonical list of `@stable` `test()` calls is in
+> **Phase 0 — Validated** below.
 
 ---
 
@@ -697,32 +701,49 @@
 
 ### 🟢 Phase 0 — Validated
 
-> Tests carrying the `@stable` tag — included in the weekly stable workflow. **51 tests across 20 spec files.**
+> 65 `test()` calls carrying the `@stable` tag, distributed across 22 spec
+> files. Run weekly by the stable workflow. New specs are merged with all
+> tests tagged `@stable`; the tag is removed per-test during weekly triage
+> when a failure is classified as a test bug — so a spec may end up with a
+> mix of tagged and untagged tests over time.
 
 #### core-components/
-- [x] Loop component — renders correctly with all handles and output inspection buttons → `core-components/loop-component-regression.spec.ts`
-- [x] Loop component — run without connections shows build failed notification → `core-components/loop-component-regression.spec.ts`
-- [x] Loop component — Research Translation Loop template: full wiring and iterates over 2 ArXiv papers → `core-components/loop-component-regression.spec.ts`
-- [x] Webhook component — HTTP POST accepts JSON and plain-text bodies returning 202 → `core-components/webhook-component-regression.spec.ts`
-- [x] Webhook component — flow is saved to database and contains the Webhook node → `core-components/webhook-component-regression.spec.ts`
-- [x] Webhook component — cURL command in inspector shows valid POST URL with flow ID → `core-components/webhook-component-regression.spec.ts`
-- [x] Webhook component — empty data field returns empty Data object → `core-components/webhook-component-regression.spec.ts`
-- [x] Webhook component — endpoint field renders the actual webhook URL → `core-components/webhook-component-regression.spec.ts`
-- [x] Webhook component — copy button copies the endpoint URL to clipboard → `core-components/webhook-component-regression.spec.ts`
-- [x] Webhook component — POST to non-existent flow name returns 404 → `core-components/webhook-component-regression.spec.ts`
-- [x] Webhook component — valid JSON payload is propagated as structured Data output → `core-components/webhook-component-regression.spec.ts`
-- [x] Webhook component — invalid JSON payload is encapsulated in `{payload: ...}` → `core-components/webhook-component-regression.spec.ts`
-- [x] GET `/api/v1/monitor/messages` returns 200 with array response → `core-components/webhook-component-regression.spec.ts`
+- [x] API Request component — renders on canvas with correct output and URL handles → `api-request-component-regression.spec.ts`
+- [x] API Request component — inspector fields accept configured values → `api-request-component-regression.spec.ts`
+- [x] API Request component — invalid URL is accepted by field and run shows error notification → `api-request-component-regression.spec.ts`
+- [x] API Request component — GET request returns 200 and output Data contains all required fields → `api-request-component-regression.spec.ts`
+- [x] API Request component — POST method executes POST verb and returns 200 → `api-request-component-regression.spec.ts`
+- [x] API Request component — PUT method executes PUT verb and returns 200 → `api-request-component-regression.spec.ts`
+- [x] API Request component — PATCH method executes PATCH verb and returns 200 → `api-request-component-regression.spec.ts`
+- [x] API Request component — DELETE method executes DELETE verb and returns 200 → `api-request-component-regression.spec.ts`
+- [x] API Request component — non-2xx HTTP response propagates status_code without crashing → `api-request-component-regression.spec.ts`
+- [x] API Request component — query parameters embedded in URL are sent and echoed → `api-request-component-regression.spec.ts`
+- [x] API Request component — inspector headers table accepts key + value cell entries → `api-request-component-regression.spec.ts`
+- [x] API Request component — cURL tab switches mode and field accepts a cURL command → `api-request-component-regression.spec.ts`
+- [x] API Request component — cURL mode parses command, auto-fills URL, executes GET and returns 200 → `api-request-component-regression.spec.ts`
+- [x] Loop component — renders correctly with all handles and output inspection buttons → `loop-component-regression.spec.ts`
+- [x] Loop component — run without connections shows build failed notification → `loop-component-regression.spec.ts`
+- [x] Loop component — Research Translation Loop template: full wiring and iterates over 2 ArXiv papers → `loop-component-regression.spec.ts`
+- [x] Webhook component — HTTP POST accepts JSON and plain-text bodies returning 202 → `webhook-component-regression.spec.ts`
+- [x] Webhook component — flow is saved to database and contains the Webhook node → `webhook-component-regression.spec.ts`
+- [x] Webhook component — cURL command in inspector shows valid POST URL with flow ID → `webhook-component-regression.spec.ts`
+- [x] Webhook component — empty data field returns empty Data object → `webhook-component-regression.spec.ts`
+- [x] Webhook component — endpoint field renders the actual webhook URL → `webhook-component-regression.spec.ts`
+- [x] Webhook component — copy button copies the endpoint URL to clipboard → `webhook-component-regression.spec.ts`
+- [x] Webhook component — POST to non-existent flow name returns 404 → `webhook-component-regression.spec.ts`
+- [x] Webhook component — valid JSON payload is propagated as structured Data output → `webhook-component-regression.spec.ts`
+- [x] Webhook component — invalid JSON payload is encapsulated in {payload: ...} → `webhook-component-regression.spec.ts`
+- [x] GET /api/v1/monitor/messages returns 200 with array response → `webhook-component-regression.spec.ts`
 
 #### core-functionality/llm-agents/
-- [x] agent interaction suite (parameterized per provider/model: tools-free response, reasoning steps, streaming + duration, multiple consecutive messages, canvas duration indicator) → `agent-component-regression.spec.ts`
+- [x] agent interaction suite → `agent-component-regression.spec.ts`
 - [x] agent stop button must halt execution mid-run → `agent-component-regression.spec.ts`
 - [x] playground shows error when LLM run endpoint returns 500 (mocked invalid API key) → `llm-invalid-api-key-ui.spec.ts`
 - [x] playground input remains usable after API error (mocked) → `llm-invalid-api-key-ui.spec.ts`
 - [x] memory chatbot template loads with correct node structure → `memory-history-regression.spec.ts`
-- [x] message history context retention suite (within-session retention, accumulation, persistence after reopen) → `memory-history-regression.spec.ts`
+- [x] message history context retention suite → `memory-history-regression.spec.ts`
 - [x] session isolation: new session has no context from previous session → `memory-history-regression.spec.ts`
-- [x] should display error message when using invalid authentication for provider (parameterized per provider) → `provider-invalid-auth-error.spec.ts`
+- [x] should display error message when using invalid authentication for provider ${provider} → `provider-invalid-auth-error.spec.ts`
 
 #### core-functionality/playground/
 - [x] selecting an individual session checkbox must reveal the bulk-delete-button → `playground-bulk-delete.spec.ts`
@@ -735,6 +756,7 @@
 - [x] clearing the input after typing leaves the field empty → `playground-empty-message-send.spec.ts`
 - [x] playground opens in fullscreen with chat input visible → `playground-fullscreen.spec.ts`
 - [x] playground closes and reopens correctly from the flow editor → `playground-fullscreen.spec.ts`
+- [x] messages sent in playground must persist after closing and reopening → `playground-history-persist.spec.ts`
 - [x] edit user message — hover reveals edit button and saved changes replace original text → `playground-message-edit.spec.ts`
 - [x] cancel message edit — original text is preserved → `playground-message-edit.spec.ts`
 - [x] message edited in playground is reflected in Session Logs → `playground-message-edit.spec.ts`

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -701,7 +701,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 65 `test()` calls carrying the `@stable` tag, distributed across 22 spec
+> 68 `test()` calls carrying the `@stable` tag, distributed across 23 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -743,7 +743,7 @@
 - [x] memory chatbot template loads with correct node structure → `memory-history-regression.spec.ts`
 - [x] message history context retention suite → `memory-history-regression.spec.ts`
 - [x] session isolation: new session has no context from previous session → `memory-history-regression.spec.ts`
-- [x] should display error message when using invalid authentication for provider ${provider} → `provider-invalid-auth-error.spec.ts`
+- [x] should display error message when using invalid authentication for provider <provider> → `provider-invalid-auth-error.spec.ts`
 
 #### core-functionality/playground/
 - [x] selecting an individual session checkbox must reveal the bulk-delete-button → `playground-bulk-delete.spec.ts`
@@ -757,6 +757,9 @@
 - [x] playground opens in fullscreen with chat input visible → `playground-fullscreen.spec.ts`
 - [x] playground closes and reopens correctly from the flow editor → `playground-fullscreen.spec.ts`
 - [x] messages sent in playground must persist after closing and reopening → `playground-history-persist.spec.ts`
+- [x] playground opens with chat textarea pre-filled from ChatInput Input Text → `playground-input-text-prefill.spec.ts`
+- [x] creating a new session re-applies the Input Text pre-fill → `playground-input-text-prefill.spec.ts`
+- [x] pre-filled value is sent as the first message of the session → `playground-input-text-prefill.spec.ts`
 - [x] edit user message — hover reveals edit button and saved changes replace original text → `playground-message-edit.spec.ts`
 - [x] cancel message edit — original text is preserved → `playground-message-edit.spec.ts`
 - [x] message edited in playground is reflected in Session Logs → `playground-message-edit.spec.ts`

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint tests/",
     "lint:ci": "eslint tests/ --quiet",
-    "coverage:summary": "ts-node scripts/coverage-summary.ts",
+    "coverage:summary": "ts-node scripts/coverage-summary.ts && ts-node scripts/stable-tests.ts",
     "impacted": "ts-node scripts/impacted-tests.ts",
     "validate:specs": "ts-node scripts/validate-spec-deps.ts",
     "check:nightly-delta": "ts-node scripts/check-nightly-delta.ts"

--- a/scripts/stable-tests.ts
+++ b/scripts/stable-tests.ts
@@ -1,0 +1,306 @@
+/**
+ * Regenerates the `Phase 0 — Validated` block (and the Coverage Summary Note
+ * that points to it) inside QA-CHECKLIST.md by parsing `@stable` `test()`
+ * calls from `tests/tests-automations/regression/**.spec.ts`.
+ *
+ * Run: `npx ts-node scripts/stable-tests.ts`
+ *
+ * Idempotent: a second run produces no diff when Phase 0 is in sync with the
+ * `@stable` tags in the test source.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import * as ts from "typescript";
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const REGRESSION_ROOT = path.join(
+  REPO_ROOT,
+  "tests",
+  "tests-automations",
+  "regression",
+);
+const CHECKLIST_PATH = path.join(REPO_ROOT, "QA-CHECKLIST.md");
+
+const STABLE_TAG = "@stable";
+
+interface StableTest {
+  /** Title as written in the `test(...)` first argument (template `${...}` placeholders preserved). */
+  title: string;
+  /** Module path under `regression/`, e.g. `core-functionality/llm-agents`. */
+  modulePath: string;
+  /** Spec basename, e.g. `loop-component-regression.spec.ts`. */
+  specFile: string;
+  /** Path under `regression/`, e.g. `core-components/loop-component-regression.spec.ts`. */
+  relativePath: string;
+  /** 1-based source line of the `test(...)` call. */
+  line: number;
+}
+
+// ─── Filesystem walk ─────────────────────────────────────────────────────────
+
+function walkSpecs(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walkSpecs(full));
+    } else if (entry.isFile() && entry.name.endsWith(".spec.ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// ─── AST helpers ─────────────────────────────────────────────────────────────
+
+function literalText(node: ts.Node): string | null {
+  if (ts.isStringLiteral(node)) return node.text;
+  if (ts.isNoSubstitutionTemplateLiteral(node)) return node.text;
+  if (ts.isTemplateExpression(node)) {
+    let s = node.head.text;
+    for (const span of node.templateSpans) {
+      s += "${" + span.expression.getText() + "}" + span.literal.text;
+    }
+    return s;
+  }
+  return null;
+}
+
+function readTagsArray(node: ts.Node): string[] | null {
+  if (!ts.isObjectLiteralExpression(node)) return null;
+  for (const prop of node.properties) {
+    if (
+      !ts.isPropertyAssignment(prop) ||
+      !ts.isIdentifier(prop.name) ||
+      prop.name.text !== "tag"
+    ) {
+      continue;
+    }
+    const init = prop.initializer;
+    if (!ts.isArrayLiteralExpression(init)) return null;
+    const tags: string[] = [];
+    for (const el of init.elements) {
+      const t = literalText(el);
+      if (t !== null) tags.push(t);
+    }
+    return tags;
+  }
+  return null;
+}
+
+/** Match exactly `test(...)` — not `test.describe`, `test.skip`, `test.only`, etc. */
+function isPlainTestCall(call: ts.CallExpression): boolean {
+  return ts.isIdentifier(call.expression) && call.expression.text === "test";
+}
+
+function parseStableTestsInFile(
+  filePath: string,
+  source: ts.SourceFile,
+): StableTest[] {
+  const out: StableTest[] = [];
+  const relativePath = path
+    .relative(REGRESSION_ROOT, filePath)
+    .split(path.sep)
+    .join("/");
+  const modulePath = path.dirname(relativePath);
+
+  function visit(node: ts.Node): void {
+    if (ts.isCallExpression(node) && isPlainTestCall(node)) {
+      const args = node.arguments;
+      if (args.length >= 2) {
+        const title = literalText(args[0]);
+        const tags = readTagsArray(args[1]);
+        if (title !== null && tags && tags.includes(STABLE_TAG)) {
+          const { line } = source.getLineAndCharacterOfPosition(
+            node.getStart(source),
+          );
+          out.push({
+            title,
+            modulePath,
+            specFile: path.basename(relativePath),
+            relativePath,
+            line: line + 1,
+          });
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(source);
+  return out;
+}
+
+function collectStableTests(): StableTest[] {
+  const all: StableTest[] = [];
+  for (const file of walkSpecs(REGRESSION_ROOT)) {
+    const text = fs.readFileSync(file, "utf-8");
+    const source = ts.createSourceFile(
+      file,
+      text,
+      ts.ScriptTarget.Latest,
+      /* setParentNodes */ true,
+    );
+    all.push(...parseStableTestsInFile(file, source));
+  }
+  all.sort((a, b) => {
+    if (a.modulePath !== b.modulePath)
+      return a.modulePath.localeCompare(b.modulePath);
+    if (a.relativePath !== b.relativePath)
+      return a.relativePath.localeCompare(b.relativePath);
+    return a.line - b.line;
+  });
+  return all;
+}
+
+// ─── Markdown block builders ─────────────────────────────────────────────────
+
+function buildPhase0Block(tests: StableTest[]): string[] {
+  const totalTests = tests.length;
+  const distinctSpecs = new Set(tests.map((t) => t.relativePath)).size;
+
+  const lines: string[] = [
+    "### 🟢 Phase 0 — Validated",
+    "",
+    `> ${totalTests} \`test()\` calls carrying the \`@stable\` tag, distributed across ${distinctSpecs} spec`,
+    "> files. Run weekly by the stable workflow. New specs are merged with all",
+    "> tests tagged `@stable`; the tag is removed per-test during weekly triage",
+    "> when a failure is classified as a test bug — so a spec may end up with a",
+    "> mix of tagged and untagged tests over time.",
+    "",
+  ];
+
+  // Group preserving sort order.
+  const grouped = new Map<string, StableTest[]>();
+  for (const t of tests) {
+    const bucket = grouped.get(t.modulePath);
+    if (bucket) bucket.push(t);
+    else grouped.set(t.modulePath, [t]);
+  }
+
+  for (const [moduleKey, items] of grouped) {
+    lines.push(`#### ${moduleKey}/`);
+    for (const t of items) {
+      lines.push(`- [x] ${t.title} → \`${t.specFile}\``);
+    }
+    lines.push("");
+  }
+
+  return lines;
+}
+
+const NOTE_LINES: string[] = [
+  "> Note: `Validated [x]` counts checklist bullets, not `test()` calls. The",
+  "> `@stable` tag is per-`test()`, and a single `@stable` test may map to",
+  "> several bullets via `test.step()` (e.g. the agent suite covers 7",
+  "> bullets). The canonical list of `@stable` `test()` calls is in",
+  "> **Phase 0 — Validated** below.",
+];
+
+// ─── Checklist patching ──────────────────────────────────────────────────────
+
+function findIndex(
+  lines: string[],
+  pred: (l: string) => boolean,
+  from = 0,
+): number {
+  for (let i = from; i < lines.length; i++) if (pred(lines[i])) return i;
+  return -1;
+}
+
+function replaceNoteBlock(lines: string[]): string[] {
+  const coverageHeader = findIndex(lines, (l) =>
+    l.startsWith("## Coverage Summary"),
+  );
+  if (coverageHeader === -1) {
+    throw new Error('Coverage Summary header not found ("## Coverage Summary")');
+  }
+  const noteStart = findIndex(
+    lines,
+    (l) => l.startsWith("> Note:"),
+    coverageHeader,
+  );
+  if (noteStart === -1) {
+    throw new Error(
+      'Coverage Summary Note not found (line starting "> Note:" after "## Coverage Summary")',
+    );
+  }
+  let noteEnd = noteStart;
+  while (noteEnd + 1 < lines.length && lines[noteEnd + 1].startsWith(">")) {
+    noteEnd++;
+  }
+  return [
+    ...lines.slice(0, noteStart),
+    ...NOTE_LINES,
+    ...lines.slice(noteEnd + 1),
+  ];
+}
+
+function replacePhase0Block(
+  lines: string[],
+  phase0Lines: string[],
+): string[] {
+  const phase0Header = "### 🟢 Phase 0 — Validated";
+  const phase1Header = "### 🔵 Phase 1 — Next Delivery";
+
+  const phase0Idx = findIndex(lines, (l) => l.trim() === phase0Header);
+  if (phase0Idx === -1) {
+    throw new Error(`Phase 0 header not found: "${phase0Header}"`);
+  }
+  const phase1Idx = findIndex(
+    lines,
+    (l) => l.trim() === phase1Header,
+    phase0Idx + 1,
+  );
+  if (phase1Idx === -1) {
+    throw new Error(`Phase 1 header not found: "${phase1Header}"`);
+  }
+
+  // Walk back from Phase 1 across blank lines to land on the `---` separator.
+  let sepIdx = phase1Idx - 1;
+  while (sepIdx > phase0Idx && lines[sepIdx].trim() === "") sepIdx--;
+  if (lines[sepIdx].trim() !== "---") {
+    throw new Error(`Expected "---" separator before "${phase1Header}"`);
+  }
+
+  return [
+    ...lines.slice(0, phase0Idx),
+    ...phase0Lines,
+    ...lines.slice(sepIdx),
+  ];
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+function main(): void {
+  const tests = collectStableTests();
+  const phase0Lines = buildPhase0Block(tests);
+
+  const original = fs.readFileSync(CHECKLIST_PATH, "utf-8");
+  const trailingNewline = original.endsWith("\n");
+
+  const lines = original.split("\n");
+  if (trailingNewline) lines.pop();
+
+  let updated = replaceNoteBlock(lines);
+  updated = replacePhase0Block(updated, phase0Lines);
+
+  let output = updated.join("\n");
+  if (trailingNewline) output += "\n";
+
+  const distinctSpecs = new Set(tests.map((t) => t.relativePath)).size;
+  if (output === original) {
+    console.log(
+      `Phase 0 already up to date — ${tests.length} @stable test() calls across ${distinctSpecs} spec files.`,
+    );
+    return;
+  }
+
+  fs.writeFileSync(CHECKLIST_PATH, output, "utf-8");
+  console.log(
+    `Phase 0 regenerated in QA-CHECKLIST.md — ${tests.length} @stable test() calls across ${distinctSpecs} spec files.`,
+  );
+}
+
+main();

--- a/scripts/stable-tests.ts
+++ b/scripts/stable-tests.ts
@@ -7,6 +7,11 @@
  *
  * Idempotent: a second run produces no diff when Phase 0 is in sync with the
  * `@stable` tags in the test source.
+ *
+ * Test titles are now the source of truth for the Phase 0 bullet text — they
+ * surface in the rendered checklist as well as the Playwright report. Prefer
+ * self-explanatory titles; wrap code substrings in backticks (Markdown inline
+ * code) and template `${expr}` placeholders are rendered as `<expr>`.
  */
 
 import * as fs from "fs";
@@ -23,6 +28,8 @@ const REGRESSION_ROOT = path.join(
 const CHECKLIST_PATH = path.join(REPO_ROOT, "QA-CHECKLIST.md");
 
 const STABLE_TAG = "@stable";
+
+const warnings: string[] = [];
 
 interface StableTest {
   /** Title as written in the `test(...)` first argument (template `${...}` placeholders preserved). */
@@ -67,8 +74,17 @@ function literalText(node: ts.Node): string | null {
   return null;
 }
 
-function readTagsArray(node: ts.Node): string[] | null {
-  if (!ts.isObjectLiteralExpression(node)) return null;
+interface TagReadResult {
+  /** Tags extracted from the inline array literal, or null if no `tag` property was found. */
+  tags: string[] | null;
+  /** True when a `tag` property exists but its value is not a parseable inline array literal. */
+  unparseable: boolean;
+}
+
+function readTagsArray(node: ts.Node): TagReadResult {
+  if (!ts.isObjectLiteralExpression(node)) {
+    return { tags: null, unparseable: false };
+  }
   for (const prop of node.properties) {
     if (
       !ts.isPropertyAssignment(prop) ||
@@ -78,15 +94,22 @@ function readTagsArray(node: ts.Node): string[] | null {
       continue;
     }
     const init = prop.initializer;
-    if (!ts.isArrayLiteralExpression(init)) return null;
+    if (!ts.isArrayLiteralExpression(init)) {
+      return { tags: null, unparseable: true };
+    }
     const tags: string[] = [];
     for (const el of init.elements) {
       const t = literalText(el);
       if (t !== null) tags.push(t);
+      else {
+        // Non-literal element (spread, identifier, etc.) — treat as unparseable
+        // so an `@stable` constant referenced indirectly does not silently slip past.
+        return { tags: null, unparseable: true };
+      }
     }
-    return tags;
+    return { tags, unparseable: false };
   }
-  return null;
+  return { tags: null, unparseable: false };
 }
 
 /** Match exactly `test(...)` — not `test.describe`, `test.skip`, `test.only`, etc. */
@@ -110,11 +133,18 @@ function parseStableTestsInFile(
       const args = node.arguments;
       if (args.length >= 2) {
         const title = literalText(args[0]);
-        const tags = readTagsArray(args[1]);
-        if (title !== null && tags && tags.includes(STABLE_TAG)) {
-          const { line } = source.getLineAndCharacterOfPosition(
-            node.getStart(source),
+        const { tags, unparseable } = readTagsArray(args[1]);
+        const { line } = source.getLineAndCharacterOfPosition(
+          node.getStart(source),
+        );
+        if (unparseable) {
+          warnings.push(
+            `${relativePath}:${line + 1} — \`tag\` option is not an inline array of string literals; ` +
+              "the script cannot determine if this test is `@stable`. Inline the array " +
+              "(e.g. `tag: [\"@stable\", ...]`) so it shows up in Phase 0.",
           );
+        }
+        if (title !== null && tags && tags.includes(STABLE_TAG)) {
           out.push({
             title,
             modulePath,
@@ -156,6 +186,16 @@ function collectStableTests(): StableTest[] {
 
 // ─── Markdown block builders ─────────────────────────────────────────────────
 
+/**
+ * Render a test title for the checklist. Replaces template literal
+ * placeholders (e.g. `${provider}`) with angle-bracket markers (e.g.
+ * `<provider>`) so they read as parameter names rather than leaking raw
+ * template syntax into the rendered Markdown.
+ */
+function renderTitle(title: string): string {
+  return title.replace(/\$\{([^}]+)\}/g, (_, expr) => `<${expr.trim()}>`);
+}
+
 function buildPhase0Block(tests: StableTest[]): string[] {
   const totalTests = tests.length;
   const distinctSpecs = new Set(tests.map((t) => t.relativePath)).size;
@@ -182,7 +222,7 @@ function buildPhase0Block(tests: StableTest[]): string[] {
   for (const [moduleKey, items] of grouped) {
     lines.push(`#### ${moduleKey}/`);
     for (const t of items) {
-      lines.push(`- [x] ${t.title} → \`${t.specFile}\``);
+      lines.push(`- [x] ${renderTitle(t.title)} → \`${t.specFile}\``);
     }
     lines.push("");
   }
@@ -294,13 +334,20 @@ function main(): void {
     console.log(
       `Phase 0 already up to date — ${tests.length} @stable test() calls across ${distinctSpecs} spec files.`,
     );
-    return;
+  } else {
+    fs.writeFileSync(CHECKLIST_PATH, output, "utf-8");
+    console.log(
+      `Phase 0 regenerated in QA-CHECKLIST.md — ${tests.length} @stable test() calls across ${distinctSpecs} spec files.`,
+    );
   }
 
-  fs.writeFileSync(CHECKLIST_PATH, output, "utf-8");
-  console.log(
-    `Phase 0 regenerated in QA-CHECKLIST.md — ${tests.length} @stable test() calls across ${distinctSpecs} spec files.`,
-  );
+  if (warnings.length > 0) {
+    console.error(
+      `\n${warnings.length} warning(s) — non-literal \`tag\` arrays may have caused @stable tests to be skipped:`,
+    );
+    for (const w of warnings) console.error(`  • ${w}`);
+    process.exit(1);
+  }
 }
 
 main();


### PR DESCRIPTION
## Summary

- New `scripts/stable-tests.ts` parses `tests/**/*.spec.ts` via the TypeScript AST and regenerates the **Coverage Summary Note**, the **Phase 0 — Validated** header counters, and the Phase 0 bulleted list (grouped by module) from the `@stable` `test()` calls in source. Chained into `npm run coverage:summary` and triggered by the existing `update-coverage-summary.yml` workflow, whose path filter now also covers `tests/**/*.spec.ts`.
- Drift caught on first run: counts moved from a hand-maintained `51 across 20` to the actual `65 across 22` — `api-request-component-regression.spec.ts` and `playground-history-persist.spec.ts` had silently fallen out of Phase 0.
- Note wording was tightened per the issue: it no longer carries a duplicate hardcoded count, and the new Phase 0 header explicitly states that `@stable` is per-`test()` and that triage may leave a spec with a mix of tagged and untagged tests over time.

## Test plan

- [x] `npm run coverage:summary` regenerates the Note and Phase 0; second run produces no diff (idempotent).
- [x] `npm run typecheck` passes.
- [x] `npm run lint` passes (no new warnings introduced).
- [ ] After merge: an `update-coverage-summary` run lands `[skip ci]` if anything drifted between PR open and merge.
- [ ] Future test added/removed with `@stable`: confirm the workflow regenerates on the next push to `main`.

Closes #157