### PR TITLE
chore(playground): rewrite playground-session-id and mark @stable

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -409,7 +409,7 @@
 - [x] Image rendered in user message bubble after sending → `core-functionality/playground/playground-output-image.spec.ts`
 
 #### 9.2 History and Session
-- [-] Configure custom session ID → `playground/playground-session-id.spec.ts` (needs rewrite — see issue)
+- [x] Configure custom session ID → `core-functionality/playground/playground-session-id.spec.ts`
 - [x] Switch session — messages are isolated per session → `core-functionality/playground/playground-session-nav.spec.ts`
 - [x] Edit user message — hover reveals edit button, saved changes replace original text → `core-functionality/playground/playground-message-edit.spec.ts`
 - [x] Cancel message edit — original text is preserved → `core-functionality/playground/playground-message-edit.spec.ts`

--- a/docs/core-functionality/playground/playground-session-id.md
+++ b/docs/core-functionality/playground/playground-session-id.md
@@ -44,7 +44,7 @@ Validates that the Playground session ID input field is editable and correctly r
 
 ## What this test does not cover *(optional)*
 
-- Actual backend isolation between sessions (messages from session A not appearing in session B) — covered by `core-functionality/llm-agents/memory-history-regression.spec.ts`
+- Actual backend isolation between sessions (messages from session A not appearing in session B) — covered by `llm-agents/memory-history-regression.spec.ts`
 - The sidebar-based session management (create / switch / rename) introduced in Langflow 1.9+ — covered by `playground-session-nav.spec.ts` and `playground-session-rename.spec.ts`
 - Sending a message after switching the session ID — out of scope for this spec
 

--- a/docs/core-functionality/playground/playground-session-id.md
+++ b/docs/core-functionality/playground/playground-session-id.md
@@ -1,0 +1,63 @@
+# Playground — Session ID Input
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+Validates that the Playground session ID input field is editable and correctly reflects a custom value typed by the user. If this breaks, users cannot control which session context their messages are sent to — affecting multi-session workflows.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@regression` `@playground`
+
+---
+
+## Step by step *(required)*
+
+1. Use `setupPlayground(page)` to create a blank flow with ChatInput → ChatOutput connected and capture the created `flowId`
+2. Click `playground-btn-flow-io` and wait for `input-chat-playground` to be visible (confirms playground is open)
+3. Clear `popover-anchor-input-session_id` and fill it with `session-${Date.now()}`
+4. Assert the field's value equals the filled string via `toHaveValue`
+
+`afterEach` navigates to `/` and deletes the flow created by the helper via `DELETE /api/v1/flows/{id}`.
+
+---
+
+## Validation criterion *(required)*
+
+- After `.fill()`, `popover-anchor-input-session_id` holds the exact string typed (web-first `toHaveValue` assertion)
+
+---
+
+## External dependencies *(required)*
+
+- `src/frontend/src/components/core/chatComponents/` — session ID input rendered inside the Playground header
+- `data-testid="popover-anchor-input-session_id"` — session ID input field
+- `data-testid="playground-btn-flow-io"` — opens the Playground from the editor
+- `data-testid="input-chat-playground"` — chat input field used as a readiness signal for the Playground
+
+---
+
+## What this test does not cover *(optional)*
+
+- Actual backend isolation between sessions (messages from session A not appearing in session B) — covered by `core-functionality/llm-agents/memory-history-regression.spec.ts`
+- The sidebar-based session management (create / switch / rename) introduced in Langflow 1.9+ — covered by `playground-session-nav.spec.ts` and `playground-session-rename.spec.ts`
+- Sending a message after switching the session ID — out of scope for this spec
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`
+- No LLM required — the test only types into the session ID field, no flow execution happens
+
+---
+
+## Notes *(optional)*
+
+- Test runs in `serial` mode for consistency with sibling playground specs and to keep the cleanup contract simple
+- Cleanup deletes only the flow created by this test (id captured from `setupPlayground`'s return value)

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-id.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-id.spec.ts
@@ -1,132 +1,47 @@
 import { expect, test } from "../../../../fixtures/fixtures";
-import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
-import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
-import { zoomOut } from "../../../../helpers/ui/zoom-out";
+import { setupPlayground } from "../../../../helpers/flows/setup-playground";
 
-async function setupMockedChatFlow(page: any) {
-  await awaitBootstrapTest(page);
-  await page.waitForSelector('[data-testid="blank-flow"]', { timeout: 30000 });
-  await page.getByTestId("blank-flow").click();
+test.describe("Playground — Session ID input", () => {
+  test.describe.configure({ mode: "serial" });
 
-  // Add ChatOutput
-  await page.getByTestId("sidebar-search-input").fill("chat output");
-  await page.waitForSelector('[data-testid="input_outputChat Output"]', {
-    timeout: 30000,
-  });
-  await page
-    .getByTestId("input_outputChat Output")
-    .hover()
-    .then(async () => {
-      await page.getByTestId("add-component-button-chat-output").click();
-    });
+  let createdFlowId: string | null = null;
 
-  await zoomOut(page, 2);
-
-  // Add ChatInput via drag
-  await page.getByTestId("sidebar-search-input").fill("chat input");
-  await page.waitForSelector('[data-testid="input_outputChat Input"]', {
-    timeout: 30000,
-  });
-  await page
-    .getByTestId("input_outputChat Input")
-    .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-      targetPosition: { x: 100, y: 100 },
-    });
-
-  await adjustScreenView(page);
-
-  await expect(page.locator(".react-flow__node")).toHaveCount(2, {
-    timeout: 10000,
+  test.afterEach(async ({ page }) => {
+    if (createdFlowId) {
+      // Navigate to home before deleting to stop background browser requests
+      // for the current flow; without this, pending polling GETs complete
+      // after the DELETE and trigger spurious 404 fixture errors.
+      await page.goto("/");
+      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      createdFlowId = null;
+    }
   });
 
-  // Connect ChatInput → ChatOutput
-  await page
-    .getByTestId("handle-chatinput-noshownode-chat message-source")
-    .click();
-  await page
-    .getByTestId("handle-chatoutput-noshownode-inputs-target")
-    .click();
+  test(
+    "session ID input accepts a custom value",
+    { tag: ["@stable", "@release", "@regression", "@playground"] },
+    async ({ page }) => {
+      await test.step("set up ChatInput → ChatOutput flow", async () => {
+        createdFlowId = await setupPlayground(page);
+      });
 
-  await expect(page.locator(".react-flow__edge")).toHaveCount(1, {
-    timeout: 8000,
-  });
+      await test.step("open playground and wait for chat input", async () => {
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(
+          page.getByTestId("input-chat-playground").last(),
+        ).toBeVisible({ timeout: 15000 });
+      });
 
-  // Mock the run endpoint so no real LLM call is made
-  await page.route("**/api/v1/run/**", async (route: import("@playwright/test").Route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        outputs: [
-          {
-            outputs: [
-              { results: { message: { text: "Mocked response" } } },
-            ],
-          },
-        ],
-        session_id: "mocked-session",
-      }),
-    });
-  });
-}
+      await test.step("fill session ID and confirm value persists", async () => {
+        const customSession = `session-${Date.now()}`;
+        const sessionInput = page.getByTestId(
+          "popover-anchor-input-session_id",
+        );
 
-test(
-  "playground opens with a chat input field after connecting ChatInput and ChatOutput",
-  { tag: ["@release", "@workspace", "@regression", "@playground"] },
-  async ({ page }) => {
-    await setupMockedChatFlow(page);
-
-    await page.getByTestId("playground-btn-flow-io").click();
-    await page.waitForSelector('[data-testid="input-chat-playground"]', {
-      timeout: 15000,
-    });
-
-    const inputField = page.getByTestId("input-chat-playground").last();
-    await expect(inputField).toBeVisible({ timeout: 5000 });
-    await expect(inputField).toBeEnabled({ timeout: 3000 });
-  },
-);
-
-test(
-  "playground session ID input accepts a custom session value",
-  { tag: ["@release", "@workspace", "@regression", "@playground"] },
-  async ({ page }) => {
-    await setupMockedChatFlow(page);
-
-    await page.getByTestId("playground-btn-flow-io").click();
-    await page.waitForSelector('[data-testid="input-chat-playground"]', {
-      timeout: 15000,
-    });
-
-    const customSession = `session-${Date.now()}`;
-
-    await page.getByTestId("popover-anchor-input-session_id").clear();
-    await page.getByTestId("popover-anchor-input-session_id").fill(customSession);
-    await expect(page.getByTestId("popover-anchor-input-session_id")).toHaveValue(customSession);
-  },
-);
-
-test(
-  "changing session ID in playground resets the conversation history display",
-  { tag: ["@release", "@workspace", "@regression", "@playground"] },
-  async ({ page }) => {
-    await setupMockedChatFlow(page);
-
-    await page.getByTestId("playground-btn-flow-io").click();
-    await page.waitForSelector('[data-testid="input-chat-playground"]', {
-      timeout: 15000,
-    });
-
-    await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({ timeout: 5000 });
-
-    const sessionA = `session-a-${Date.now()}`;
-    await page.getByTestId("popover-anchor-input-session_id").clear();
-    await page.getByTestId("popover-anchor-input-session_id").fill(sessionA);
-    await expect(page.getByTestId("popover-anchor-input-session_id")).toHaveValue(sessionA);
-
-    const sessionB = `session-b-${Date.now()}`;
-    await page.getByTestId("popover-anchor-input-session_id").clear();
-    await page.getByTestId("popover-anchor-input-session_id").fill(sessionB);
-    await expect(page.getByTestId("popover-anchor-input-session_id")).toHaveValue(sessionB);
-  },
-);
+        await sessionInput.clear();
+        await sessionInput.fill(customSession);
+        await expect(sessionInput).toHaveValue(customSession);
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #145

## Summary

- Rewrites `tests/tests-automations/regression/core-functionality/playground/playground-session-id.spec.ts` keeping only the test that adds unique coverage: *session ID input accepts a custom value*. Removes the duplicate of `playground-fullscreen` (Test 1) and the bogus history-reset test that asserted nothing about history (Test 3 — real session isolation is covered by `memory-history-regression.spec.ts` and `playground-session-nav.spec.ts`).
- Replaces the inline `setupMockedChatFlow` with the shared `setupPlayground()` helper.
- Adds `test.describe.configure({ mode: "serial" })` and an `afterEach` that navigates home and deletes the created flow via API.
- Uses web-first assertions (`toHaveValue`) — no `waitForSelector`, no `waitForTimeout`.
- Adds `@stable` to the test tags.
- New spec doc at `docs/core-functionality/playground/playground-session-id.md`.
- `QA-CHECKLIST.md`: *Configure custom session ID* `[-]` → `[x]`.

## Validation

7-step pipeline run locally:

| Step | Result |
|---|---|
| `npm run typecheck` | clean |
| `npx eslint <file>` | clean |
| `playwright-test-linter` skill | all checks pass |
| `--retries=0` run | 1 passed (8.8s) |
| Force-fail (assert wrong value) | failed as expected — catches real regression |
| `--trace=on` run | 1 passed (11.4s) |
| Backend-error audit | 0 occurrences |

## Test plan
- [ ] PR validation (TypeScript + ESLint) is green
- [ ] Reviewer confirms Tests 1 and 3 removal is acceptable (rationale in commit message)
- [ ] Reviewer confirms `setupPlayground()` is the right helper for this case