### PR TITLE
chore(playground): rewrite output-modal-copy-button and mark @stable

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -436,8 +436,8 @@
 - [x] Stop button in Playground → `core-functionality/playground/stop-button-playground.spec.ts`
 
 #### 9.4 Output Modal
-- [-] Copy component output → `playground/output-modal-copy-button.spec.ts` (needs rewrite — see issue)
-- [-] Copy button in output → `playground/output-modal-copy-button.spec.ts` (needs rewrite — see issue)
+- [x] Copy component output → `core-functionality/playground/output-modal-copy-button.spec.ts`
+- [x] Copy button in output → `core-functionality/playground/output-modal-copy-button.spec.ts`
 
 #### 9.5 Structured Data Output
 - [x] JSON Data output renders as code block → `core-functionality/playground/playground-output-data.spec.ts`

--- a/docs/core-functionality/playground/output-modal-copy-button.md
+++ b/docs/core-functionality/playground/output-modal-copy-button.md
@@ -1,0 +1,75 @@
+# Output Modal — Copy Button
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+Validates that the **Copy** button inside a component's Output Modal copies the component's text output to the clipboard and gives the user a clear visual confirmation:
+
+1. The "Copied to clipboard" toast appears
+2. The button's icon transitions from Copy → Check (success state)
+3. The button reverts back to Copy after the success state expires
+
+If this breaks, users have no reliable way to grab the output of a component into the clipboard from the modal — a primary path for sharing or pasting results out of Langflow.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@workspace` `@playground`
+
+---
+
+## Step by step *(required)*
+
+1. Open Langflow and create a blank flow; capture the flow id from the `POST /api/v1/flows` 201 response
+2. Add a **Text Input** component and fill its `textarea_str_input_value` with `"Test content to copy"`
+3. Run the component (`button_run_text input`) and wait for the "built successfully" toast
+4. Click the first `output-inspection-*` button to open the Component Output modal
+5. Click `copy-output-button`
+6. Assert "Copied to clipboard" toast is visible
+7. Assert the Check icon (`icon-Check`) is visible inside the button
+8. Assert the Copy icon (`icon-Copy`) returns within 5s (web-first assertion — no `waitForTimeout`)
+
+`afterEach` navigates to `/` and deletes the captured flow via `DELETE /api/v1/flows/{id}`.
+
+---
+
+## Validation criterion *(required)*
+
+- "Copied to clipboard" toast appears within 5s of clicking the copy button
+- Button shows `icon-Check` immediately after the click (success state)
+- Button returns to `icon-Copy` within 5s (state revert)
+
+---
+
+## External dependencies *(required)*
+
+- `data-testid="copy-output-button"` — copy button rendered inside the Output Modal
+- `data-testid="icon-Check"` and `data-testid="icon-Copy"` — icon components inside the button
+- `data-testid="output-inspection-*"` — the inspector entry point that opens the Output Modal
+- `data-testid="textarea_str_input_value"` and `button_run_text input` — Text Input component fields
+- Backend endpoints: `POST /api/v1/flows` (flow creation), `DELETE /api/v1/flows/{id}` (cleanup)
+
+---
+
+## What this test does not cover *(optional)*
+
+- Copying outputs of other component types (e.g., JSON from API Request) — was previously a separate test that depended on `httpbin.org` and was removed for being flaky and externally dependent
+- The clipboard contents themselves — the test asserts the UI confirmation (toast + icon transitions), not the OS clipboard
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`
+- No LLM, no external HTTP calls — Text Input runs are local
+
+---
+
+## Notes *(optional)*
+
+- Runs in `serial` mode (only one test, but kept for consistency with sibling playground specs)
+- Cleanup is scoped to the flow this test creates (id captured from the 201 response of `POST /api/v1/flows`)

--- a/tests/tests-automations/regression/core-functionality/playground/output-modal-copy-button.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/output-modal-copy-button.spec.ts
@@ -36,10 +36,12 @@ test.describe("Output Modal — Copy Button", () => {
 
         const creationResponse = await flowCreationPromise;
         const flowData = await creationResponse.json();
+        // Capture id before asserting format so afterEach can still clean up
+        // if the regex assertion fails on an unexpected id shape.
+        createdFlowId = flowData.id ?? null;
         expect(flowData.id, "flow creation response missing id").toMatch(
           /^[0-9a-f-]{36}$/,
         );
-        createdFlowId = flowData.id;
       });
 
       await test.step("add Text Input and fill its value", async () => {

--- a/tests/tests-automations/regression/core-functionality/playground/output-modal-copy-button.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/output-modal-copy-button.spec.ts
@@ -1,136 +1,97 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 
-test.describe("Output Modal Copy Button", () => {
-  test(
-    "user should be able to copy text output from component output modal",
-    { tag: ["@release", "@workspace", "@playground"] },
-    async ({ page }) => {
-      await awaitBootstrapTest(page);
+test.describe("Output Modal — Copy Button", () => {
+  test.describe.configure({ mode: "serial" });
 
-      await page.getByTestId("blank-flow").click();
+  let createdFlowId: string | null = null;
 
-      await page.waitForSelector('[data-testid="sidebar-search-input"]', {
-        timeout: 30000,
-        state: "visible",
-      });
-
-      // Add a Text Input component
-      await page.getByTestId("sidebar-search-input").click();
-      await page.getByTestId("sidebar-search-input").fill("text input");
-
-      await page.waitForSelector('[data-testid="input_outputText Input"]', {
-        timeout: 10000,
-        state: "visible",
-      });
-
-      await page
-        .getByTestId("input_outputText Input")
-        .hover()
-        .then(async () => {
-          await page.getByTestId("add-component-button-text-input").click();
-        });
-
-      await page.waitForTimeout(500);
-
-      // Fill in some test text
-      await page
-        .getByTestId("textarea_str_input_value")
-        .fill("Test content to copy");
-
-      // Run the component
-      await page.getByTestId("button_run_text input").click();
-
-      await page.waitForSelector("text=built successfully", { timeout: 30000 });
-
-      // Open the output modal
-      await page.locator('[data-testid^="output-inspection-"]').first().click();
-
-      await page.waitForSelector("text=Component Output", { timeout: 30000 });
-
-      // Verify the copy button exists
-      const copyButton = page.getByTestId("copy-output-button");
-      await expect(copyButton).toBeVisible();
-
-      // Click the copy button
-      await copyButton.click();
-
-      // Verify the success message appears
-      await page.waitForSelector("text=Copied to clipboard", {
-        timeout: 5000,
-      });
-
-      // Verify the check icon appears (button changes state)
-      await expect(
-        copyButton.locator('[data-testid="icon-Check"]'),
-      ).toBeVisible();
-
-      // Wait for the icon to revert back to copy icon
-      await page.waitForTimeout(2500);
-      await expect(
-        copyButton.locator('[data-testid="icon-Copy"]'),
-      ).toBeVisible();
-    },
-  );
+  test.afterEach(async ({ page }) => {
+    if (createdFlowId) {
+      // Navigate to home before deleting to stop background browser requests
+      // for the current flow; without this, pending polling GETs complete
+      // after the DELETE and trigger spurious 404 fixture errors.
+      await page.goto("/");
+      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      createdFlowId = null;
+    }
+  });
 
   test(
-    "copy button should work with JSON output from API Request component",
-    { tag: ["@release", "@workspace", "@playground"] },
+    "copy button copies Text Input output and toggles Check icon",
+    { tag: ["@stable", "@release", "@workspace", "@playground"] },
     async ({ page }) => {
-      await awaitBootstrapTest(page);
+      await test.step("create blank flow and capture flow id", async () => {
+        await awaitBootstrapTest(page);
 
-      await page.getByTestId("blank-flow").click();
+        const flowCreationPromise = page.waitForResponse(
+          (resp) =>
+            resp.url().includes("/api/v1/flows") &&
+            resp.request().method() === "POST" &&
+            resp.status() === 201,
+          { timeout: 15000 },
+        );
 
-      await page.waitForSelector('[data-testid="sidebar-search-input"]', {
-        timeout: 30000,
-        state: "visible",
+        await page.getByTestId("blank-flow").click();
+
+        const creationResponse = await flowCreationPromise;
+        const flowData = await creationResponse.json();
+        expect(flowData.id, "flow creation response missing id").toMatch(
+          /^[0-9a-f-]{36}$/,
+        );
+        createdFlowId = flowData.id;
       });
 
-      await page.getByTestId("sidebar-search-input").fill("api request");
+      await test.step("add Text Input and fill its value", async () => {
+        await page.getByTestId("sidebar-search-input").fill("text input");
+        await page
+          .getByTestId("input_outputText Input")
+          .hover()
+          .then(async () => {
+            await page.getByTestId("add-component-button-text-input").click();
+          });
 
-      await page.waitForSelector('[data-testid="data_sourceAPI Request"]', {
-        timeout: 10000,
-        state: "visible",
-      });
-
-      await page
-        .getByTestId("data_sourceAPI Request")
-        .hover()
-        .then(async () => {
-          await page.getByTestId("add-component-button-api-request").click();
-
-          await page.waitForTimeout(500);
-
-          await page
-            .getByTestId("popover-anchor-input-url_input")
-            .first()
-            .fill("https://httpbin.org/json");
+        await expect(page.locator(".react-flow__node")).toHaveCount(1, {
+          timeout: 10000,
         });
 
-      await page.getByTestId("button_run_api request").click();
-
-      await page.waitForSelector("text=Running", {
-        timeout: 30000,
-        state: "visible",
+        await page
+          .getByTestId("textarea_str_input_value")
+          .fill("Test content to copy");
       });
 
-      await page.waitForSelector("text=built successfully", { timeout: 30000 });
+      await test.step("run component and open output modal", async () => {
+        await page.getByTestId("button_run_text input").click();
+        await expect(page.getByText("built successfully").last()).toBeVisible({
+          timeout: 30000,
+        });
 
-      await page
-        .getByTestId("output-inspection-api response-apirequest")
-        .click();
+        await page
+          .locator('[data-testid^="output-inspection-"]')
+          .first()
+          .click();
+        await expect(page.getByText("Component Output").first()).toBeVisible({
+          timeout: 30000,
+        });
+      });
 
-      await page.waitForSelector("text=Component Output", { timeout: 30000 });
+      await test.step("click copy and verify Check → Copy icon transition", async () => {
+        const copyButton = page.getByTestId("copy-output-button");
+        await expect(copyButton).toBeVisible();
+        await copyButton.click();
 
-      // Verify the copy button exists and click it
-      const copyButton = page.getByTestId("copy-output-button");
-      await expect(copyButton).toBeVisible();
+        await expect(page.getByText("Copied to clipboard")).toBeVisible({
+          timeout: 5000,
+        });
+        await expect(
+          copyButton.locator('[data-testid="icon-Check"]'),
+        ).toBeVisible();
 
-      await copyButton.click();
-
-      // Verify the success message appears
-      await page.waitForSelector("text=Copied to clipboard", {
-        timeout: 5000,
+        // Icon reverts to Copy after the success state expires (~2s in UI).
+        // Web-first assertion polls until the Copy icon reappears.
+        await expect(
+          copyButton.locator('[data-testid="icon-Copy"]'),
+        ).toBeVisible({ timeout: 5000 });
       });
     },
   );


### PR DESCRIPTION
Closes #146

## Summary

- Removes the second test that called `httpbin.org/json` — external services make the spec flaky by design and disqualify it for `@stable`.
- Keeps the Text Input copy test, which exercises the same UI surface (toast + `icon-Check` → `icon-Copy` transition) without external network calls.
- Adds `test.describe.configure({ mode: "serial" })` and an `afterEach` that navigates to `/` and deletes the created flow id via `DELETE /api/v1/flows/{id}`. The flow id is captured from the `POST /api/v1/flows` 201 response triggered by the blank-flow click.
- Removes both `waitForTimeout` calls — replaced with web-first assertions (notably the icon-revert assertion now polls via `expect(...).toBeVisible({ timeout: 5000 })`).
- Adds `test.step()` labels for trace readability.
- Adds `@stable` to the test tags.
- New spec doc at `docs/core-functionality/playground/output-modal-copy-button.md`.
- `QA-CHECKLIST.md`: *Copy component output* and *Copy button in output* `[-]` → `[x]`.

## Validation

7-step pipeline run locally:

| Step | Result |
|---|---|
| `npm run typecheck` | clean |
| `npx eslint <file>` | clean (after refactoring the flow-id guard from `if/throw` to `expect(...).toMatch()` to satisfy `playwright/no-conditional-in-test`) |
| `playwright-test-linter` checklist | all checks pass — 8 `expect()` for 1 `test()` |
| `--retries=0` run | 1 passed (12.4s) |
| Force-fail (assert wrong toast text) | failed as expected — catches real regression |
| `--trace=on` run | 1 passed (12.5s) |
| Backend-error audit | 0 occurrences |

## Test plan
- [ ] PR validation (TypeScript + ESLint) is green
- [ ] Reviewer confirms removing the `httpbin.org` test is acceptable (rationale in commit message)
- [ ] Reviewer confirms the icon-revert assertion (`toBeVisible({ timeout: 5000 })`) is the right replacement for the prior `waitForTimeout(2500)`