### PR TITLE
fix(api-request): anchor runAndOpenOutput on output button instead of toast

### DIFF
--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -33,11 +33,17 @@ async function addApiRequestComponent(page: Page) {
 // The output Data object is displayed in a Monaco editor — textContent gives the JSON string.
 async function runAndOpenOutput(page: Page): Promise<string> {
   await page.getByTestId("button_run_api request").click();
-  await expect(page.getByText("built successfully").last()).toBeVisible({
-    timeout: 45000,
-  });
 
-  await page.getByTestId("output-inspection-api response-apirequest").click();
+  // Anchor on the node-level output button instead of the global "built successfully"
+  // toast. The toast is shared across builds and can match prior runs (.last() is best-effort);
+  // the output-inspection button only becomes enabled after THIS component finishes building,
+  // so it is both the stronger signal and the exact precondition for the next click.
+  const outputButton = page.getByTestId(
+    "output-inspection-api response-apirequest",
+  );
+  await expect(outputButton).toBeEnabled({ timeout: 45000 });
+  await outputButton.click();
+
   const dialog = page.locator('[role="dialog"]');
   await expect(dialog).toBeVisible({ timeout: 10000 });
 


### PR DESCRIPTION
## Summary

- Replaces the fragile `getByText('built successfully').last()` wait in `runAndOpenOutput` with `expect(outputButton).toBeEnabled()` on `output-inspection-api response-apirequest`
- The toast is a global notification — `.last()` can match a stale toast from a previous build. The output-inspection button only becomes enabled after THIS component's build finishes, so it is both the stronger signal and the exact precondition for the next click

## Context

Surfaced by weekly run [25441253323](https://github.com/oriontech-me/langflow-e2e/actions/runs/25441253323) (tracked in #165) — the same root cause hit 3× in the API Request suite (1 fail + 2 flakies on retry), all on the 45s `built successfully` timeout. This PR addresses item 4 from the issue's "Recommended next steps". The webhook 403 and `Accept-Language` TypeError findings (items 1-2) remain open for separate PRs.

## Validation pipeline (local, against `langflowai/langflow-nightly`)

- `npx tsc --noEmit` — clean
- `npx eslint` on the file — 0 errors (1 pre-existing `any` warning unrelated)
- `playwright-test-linter` skill — all anti-pattern checks pass; 85 `expect()` for 13 tests
- `npx playwright test … --retries=0` — 13/13 passed (1.3m)
- Force-fail (changed testid to a nonexistent one) — assertion failed as expected, then reverted
- `npx playwright test … --trace=on` — 13/13 passed (1.5m)
- 0 occurrences of `🚨 Backend Error` in `test-results/`

Refs #165