### PR TITLE
feat(ci): add migration workflow for upgrade with LANGFLOW_LOAD_FLOWS_PATH

### DIFF
--- a/.github/workflows/migration-upgrade-with-flows.yml
+++ b/.github/workflows/migration-upgrade-with-flows.yml
@@ -1,0 +1,235 @@
+name: "Langflow Migration: Upgrade with LANGFLOW_LOAD_FLOWS_PATH"
+
+on:
+  schedule:
+    - cron: "0 9 * * *" # 06:00 BRT (UTC-3)
+  workflow_dispatch:
+
+env:
+  LANGFLOW_PORT: 7860
+  LANGFLOW_URL: http://localhost:7860
+  PG_USER: langflow
+  PG_PASSWORD: langflow_test_pw
+  PG_DB: langflow
+  FLOW_NAME: "Getting Started: Simple python function applied to each output"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  upgrade-with-flows:
+    name: Upgrade latest → nightly with LANGFLOW_LOAD_FLOWS_PATH
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: langflow
+          POSTGRES_PASSWORD: langflow_test_pw
+          POSTGRES_DB: langflow
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install requests
+
+      # ── Phase 1: Langflow Latest with LANGFLOW_LOAD_FLOWS_PATH ──
+      - name: Pull Langflow latest
+        run: |
+          docker pull langflowai/langflow:latest
+          docker inspect langflowai/langflow:latest \
+            --format='{{index .RepoDigests 0}}' | tee /tmp/latest-digest.txt
+          echo "Latest digest: $(cat /tmp/latest-digest.txt)"
+
+      - name: Start Langflow latest with flow pre-loaded
+        run: |
+          FLOWS_DIR="$(pwd)/tests/assets/flows"
+          docker run -d --name langflow \
+            --network host \
+            -v "${FLOWS_DIR}:/flows:ro" \
+            -e LANGFLOW_DATABASE_URL="postgresql://$PG_USER:$PG_PASSWORD@localhost:5432/$PG_DB" \
+            -e LANGFLOW_AUTO_LOGIN=true \
+            -e LANGFLOW_SUPERUSER=langflow \
+            -e LANGFLOW_SUPERUSER_PASSWORD=langflow123 \
+            -e LANGFLOW_STORE=false \
+            -e LANGFLOW_LOAD_FLOWS_PATH=/flows \
+            langflowai/langflow:latest
+
+      - name: Wait for Langflow latest
+        run: python tests/github-workflows/migration/wait_for_langflow.py --timeout 120
+        env:
+          LANGFLOW_URL: ${{ env.LANGFLOW_URL }}
+
+      - name: Verify flow was loaded on latest
+        run: python tests/github-workflows/migration/verify_upgrade_with_flows.py
+        env:
+          LANGFLOW_URL: ${{ env.LANGFLOW_URL }}
+          EXPECTED_FLOW_NAME: ${{ env.FLOW_NAME }}
+
+      - name: Save latest container logs
+        if: always()
+        run: docker logs langflow > /tmp/langflow-latest.log 2>&1 || true
+
+      # ── Phase 2: Upgrade to Nightly (same DB + same LANGFLOW_LOAD_FLOWS_PATH) ──
+      - name: Stop Langflow latest
+        run: docker stop langflow && docker rm langflow
+
+      - name: Pull Langflow nightly
+        run: |
+          docker pull langflowai/langflow-nightly:latest
+          docker inspect langflowai/langflow-nightly:latest \
+            --format='{{index .RepoDigests 0}}' | tee /tmp/nightly-digest.txt
+          echo "Nightly digest: $(cat /tmp/nightly-digest.txt)"
+
+      - name: Start Langflow nightly with same DB and LANGFLOW_LOAD_FLOWS_PATH
+        run: |
+          FLOWS_DIR="$(pwd)/tests/assets/flows"
+          docker run -d --name langflow \
+            --network host \
+            -v "${FLOWS_DIR}:/flows:ro" \
+            -e LANGFLOW_DATABASE_URL="postgresql://$PG_USER:$PG_PASSWORD@localhost:5432/$PG_DB" \
+            -e LANGFLOW_AUTO_LOGIN=true \
+            -e LANGFLOW_SUPERUSER=langflow \
+            -e LANGFLOW_SUPERUSER_PASSWORD=langflow123 \
+            -e LANGFLOW_STORE=false \
+            -e LANGFLOW_LOAD_FLOWS_PATH=/flows \
+            langflowai/langflow-nightly:latest
+
+      - name: Wait for Langflow nightly (includes DB migration)
+        run: python tests/github-workflows/migration/wait_for_langflow.py --timeout 180
+        env:
+          LANGFLOW_URL: ${{ env.LANGFLOW_URL }}
+
+      - name: Save nightly container logs
+        if: always()
+        run: docker logs langflow > /tmp/langflow-nightly.log 2>&1 || true
+
+      # ── Phase 3: Verify ───────────────────────────────────────
+      - name: Check nightly logs for UniqueViolation errors
+        run: |
+          if grep -i "UniqueViolation\|unique constraint\|duplicate key" /tmp/langflow-nightly.log; then
+            echo "FAIL: UniqueViolation detected in nightly logs after upgrade with LANGFLOW_LOAD_FLOWS_PATH"
+            exit 1
+          else
+            echo "OK: No UniqueViolation errors found"
+          fi
+
+      - name: Verify flow still accessible after upgrade
+        run: python tests/github-workflows/migration/verify_upgrade_with_flows.py
+        env:
+          LANGFLOW_URL: ${{ env.LANGFLOW_URL }}
+          EXPECTED_FLOW_NAME: ${{ env.FLOW_NAME }}
+
+      # ── Phase 4: Artifacts ───────────────────────────────────
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: upgrade-with-flows-${{ github.run_number }}
+          path: |
+            /tmp/langflow-latest.log
+            /tmp/langflow-nightly.log
+            /tmp/latest-digest.txt
+            /tmp/nightly-digest.txt
+
+      - name: Cleanup
+        if: always()
+        run: docker stop langflow 2>/dev/null; docker rm langflow 2>/dev/null; true
+
+      - name: Close issue on success
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'migration-upgrade-flows',
+              state: 'open',
+            });
+            if (existing.length > 0) {
+              const issue = existing[0];
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: [
+                  `## ✅ Run #${context.runNumber} — ${new Date().toISOString().split('T')[0]}`,
+                  '',
+                  'Upgrade-with-flows test passed. Closing this issue.',
+                  '',
+                  `[Workflow Run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+                ].join('\n'),
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              });
+            }
+
+      - name: Create or update issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const latestDigest = fs.existsSync('/tmp/latest-digest.txt')
+              ? fs.readFileSync('/tmp/latest-digest.txt', 'utf8').trim().slice(-20)
+              : 'unknown';
+            const nightlyDigest = fs.existsSync('/tmp/nightly-digest.txt')
+              ? fs.readFileSync('/tmp/nightly-digest.txt', 'utf8').trim().slice(-20)
+              : 'unknown';
+
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'migration-upgrade-flows',
+              state: 'open',
+            });
+
+            const body = [
+              `## Upgrade-with-Flows Failure — Run #${context.runNumber}`,
+              '',
+              `- **Date:** ${new Date().toISOString().split('T')[0]}`,
+              `- **From:** \`langflowai/langflow:latest\` (\`...${latestDigest}\`)`,
+              `- **To:** \`langflowai/langflow-nightly:latest\` (\`...${nightlyDigest}\`)`,
+              `- **Scenario:** Upgrade latest → nightly with \`LANGFLOW_LOAD_FLOWS_PATH\` set (flow already in DB)`,
+              `- **Expected:** Nightly starts cleanly without \`UniqueViolation\``,
+              '',
+              `[Workflow Run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+            ].join('\n');
+
+            if (existing.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing[0].number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: 'Langflow Nightly: Upgrade with LANGFLOW_LOAD_FLOWS_PATH Failed (UniqueViolation)',
+                body,
+                labels: ['migration-upgrade-flows', 'automated'],
+              });
+            }

--- a/tests/github-workflows/migration/verify_upgrade_with_flows.py
+++ b/tests/github-workflows/migration/verify_upgrade_with_flows.py
@@ -1,0 +1,67 @@
+"""Verify Langflow nightly started cleanly after upgrade with LANGFLOW_LOAD_FLOWS_PATH set."""
+
+import os
+import sys
+
+import requests
+
+BASE_URL = os.environ.get("LANGFLOW_URL", "http://localhost:7860")
+EXPECTED_FLOW_NAME = os.environ.get("EXPECTED_FLOW_NAME", "")
+
+
+def main():
+    has_failure = False
+
+    # 1. Health check
+    print("── Health check...")
+    try:
+        r = requests.get(f"{BASE_URL}/health_check", timeout=10)
+        r.raise_for_status()
+        print(f"   OK: {r.json()}")
+    except Exception as e:
+        print(f"   FAIL: {e}")
+        has_failure = True
+
+    # 2. Auth
+    print("── Auto login...")
+    token = ""
+    try:
+        r = requests.get(f"{BASE_URL}/api/v1/auto_login", timeout=10)
+        r.raise_for_status()
+        token = r.json().get("access_token", "")
+        print("   OK: token obtained")
+    except Exception as e:
+        print(f"   FAIL: {e}")
+        has_failure = True
+
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+    # 3. List flows — the flow loaded via LANGFLOW_LOAD_FLOWS_PATH must still exist
+    print("── List flows (checking pre-loaded flow survived upgrade)...")
+    try:
+        r = requests.get(f"{BASE_URL}/api/v1/flows/", headers=headers, timeout=15)
+        r.raise_for_status()
+        flows = r.json()
+        print(f"   OK: {len(flows)} flows found")
+        if EXPECTED_FLOW_NAME:
+            names = [f.get("name", "") for f in flows]
+            if EXPECTED_FLOW_NAME in names:
+                print(f"   OK: expected flow '{EXPECTED_FLOW_NAME}' is present")
+            else:
+                print(f"   FAIL: expected flow '{EXPECTED_FLOW_NAME}' not found. Found: {names}")
+                has_failure = True
+        elif len(flows) == 0:
+            print("   WARN: no flows found after upgrade")
+    except Exception as e:
+        print(f"   FAIL: {e}")
+        has_failure = True
+
+    if has_failure:
+        print("\nUpgrade-with-flows verification FAILED.")
+        sys.exit(1)
+    else:
+        print("\nUpgrade-with-flows verification PASSED.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/github-workflows/migration/verify_upgrade_with_flows.py
+++ b/tests/github-workflows/migration/verify_upgrade_with_flows.py
@@ -41,7 +41,8 @@ def main():
     try:
         r = requests.get(f"{BASE_URL}/api/v1/flows/", headers=headers, timeout=15)
         r.raise_for_status()
-        flows = r.json()
+        payload = r.json()
+        flows = payload if isinstance(payload, list) else payload.get("flows", [])
         print(f"   OK: {len(flows)} flows found")
         if EXPECTED_FLOW_NAME:
             names = [f.get("name", "") for f in flows]


### PR DESCRIPTION
## Summary

- Adds `migration-upgrade-with-flows.yml` — daily workflow (06:00 BRT) that tests the upgrade path from `langflow:latest` → `langflow-nightly:latest` with `LANGFLOW_LOAD_FLOWS_PATH` set and flows already in the database
- Adds `verify_upgrade_with_flows.py` — verifies health, auth, and that the pre-loaded flow survives the upgrade
- Workflow explicitly checks nightly container logs for `UniqueViolation` errors and fails the run if any are found
- Auto-creates/updates issue with label `migration-upgrade-flows` on failure; auto-closes on success
- Uses `tests/assets/flows/flow.json` as the test fixture (mounted read-only as `/flows` in both containers)

## Test plan

- [ ] Merge to main so `workflow_dispatch` becomes available
- [ ] Trigger `migration-upgrade-with-flows` manually via Actions tab
- [ ] Verify Phase 1 (latest + LANGFLOW_LOAD_FLOWS_PATH) starts and flow is present
- [ ] Verify Phase 2 (nightly upgrade) starts without UniqueViolation
- [ ] Confirm no new GitHub issue is created on a clean run

🤖 Generated with [Claude Code](https://claude.com/claude-code)