### PR TITLE
docs(playground): reframe empty-message-send as design contract

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -403,7 +403,7 @@
 - [-] Response polling → no dedicated spec
 - [-] Direct response → no dedicated spec
 - [x] Playground UX (playground-ux) → `playground/playground-ux.spec.ts`
-- [x] Send empty message — should disable send button → `playground/playground-empty-message-send.spec.ts` (**BUG: button enabled even when empty**)
+- [x] Send empty message — send button stays enabled by design (only disabled while a file upload is in progress) → `playground/playground-empty-message-send.spec.ts`
 - [ ] Send message while response is in progress — should wait or queue
 - [x] Attach image in chat — compact preview appears in input before sending → `core-functionality/playground/playground-output-image.spec.ts`
 - [x] Image rendered in user message bubble after sending → `core-functionality/playground/playground-output-image.spec.ts`
@@ -751,7 +751,7 @@
 - [x] bulk-delete-button must remove all selected sessions from the sidebar → `playground-bulk-delete.spec.ts`
 - [x] clear chat on Default session must remove messages but keep the session → `playground-clear-history.spec.ts`
 - [x] deleting a user-created session must remove it and return to Default session → `playground-clear-history.spec.ts`
-- [x] send button is enabled when input is empty (Langflow bug) → `playground-empty-message-send.spec.ts`
+- [x] send button stays enabled regardless of input content → `playground-empty-message-send.spec.ts`
 - [x] send button becomes enabled after typing a message → `playground-empty-message-send.spec.ts`
 - [x] clearing the input after typing leaves the field empty → `playground-empty-message-send.spec.ts`
 - [x] playground opens in fullscreen with chat input visible → `playground-fullscreen.spec.ts`

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -701,7 +701,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 68 `test()` calls carrying the `@stable` tag, distributed across 23 spec
+> 67 `test()` calls carrying the `@stable` tag, distributed across 23 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -752,7 +752,6 @@
 - [x] clear chat on Default session must remove messages but keep the session → `playground-clear-history.spec.ts`
 - [x] deleting a user-created session must remove it and return to Default session → `playground-clear-history.spec.ts`
 - [x] send button stays enabled regardless of input content → `playground-empty-message-send.spec.ts`
-- [x] send button becomes enabled after typing a message → `playground-empty-message-send.spec.ts`
 - [x] clearing the input after typing leaves the field empty → `playground-empty-message-send.spec.ts`
 - [x] playground opens in fullscreen with chat input visible → `playground-fullscreen.spec.ts`
 - [x] playground closes and reopens correctly from the flow editor → `playground-fullscreen.spec.ts`

--- a/docs/core-functionality/playground/playground-empty-message-send.md
+++ b/docs/core-functionality/playground/playground-empty-message-send.md
@@ -6,7 +6,7 @@
 
 ## What this test validates *(required)*
 
-Validates send button state and input field behavior in the Playground when dealing with empty input. Covers three scenarios: send button state when the input is empty (documenting a known Langflow bug), send button state after typing a message, and input field state after clearing typed content.
+Validates send button state and input field behavior in the Playground when dealing with empty input. Covers three scenarios: send button state when the input is empty (Langflow keeps it enabled by design), send button state after typing a message, and input field state after clearing typed content.
 
 ---
 
@@ -18,12 +18,12 @@ Validates send button state and input field behavior in the Playground when deal
 
 ## Step by step *(required)*
 
-**Test 1 — send button is enabled when input is empty (Langflow bug)**
+**Test 1 — send button stays enabled regardless of input content**
 1. Create a blank flow with ChatInput connected to ChatOutput via `setupPlayground`
 2. Open the Playground via `playground-btn-flow-io`
 3. Wait for `input-chat-playground` to be visible
 4. Confirm the input value is `""` (empty)
-5. Assert that `button-send` is **enabled** — documents the current buggy behavior
+5. Assert that `button-send` is **enabled** — pins Langflow's design choice of keeping send unconditionally enabled while no file upload is in flight
 
 **Test 2 — send button becomes enabled after typing a message**
 1. Create a blank flow with ChatInput connected to ChatOutput via `setupPlayground`
@@ -45,7 +45,7 @@ Validates send button state and input field behavior in the Playground when deal
 
 ## Validation criterion *(required)*
 
-- **Test 1 (bug documentation):** `button-send` is enabled even when `input-chat-playground` is empty. This reflects the **current buggy behavior**; the assertion must be updated to expect the button to be disabled once Langflow fixes the issue.
+- **Test 1:** `button-send` is enabled even when `input-chat-playground` is empty. In `button-send-wrapper.tsx`, the `disabled` attribute is tied only to `isLoading` (file upload in progress); chat-text emptiness intentionally does not gate the button. The assertion pins this contract so any regression to a content-aware disabled state surfaces for review.
 - **Test 2:** `button-send` is enabled after the user types a non-empty message.
 - **Test 3:** The message input field is empty after previously entered text is cleared.
 
@@ -82,5 +82,6 @@ References in this repository:
 
 ## Notes *(optional)*
 
-- Test 1 intentionally documents a **known Langflow bug**: the send button remains enabled on empty input. It reflects actual behavior; once the bug is fixed, the assertion must be updated to expect the button to be disabled and the test name updated accordingly.
+- Test 1 documents Langflow's intentional design: `button-send` is only disabled while a file upload is in progress, not when the textarea is empty. This is a deliberate UX choice — if the team ever switches to a content-aware disabled state, the test will fail and prompt a review of the new contract.
+- The `noInput` prop seen in the source (`flow-page-sliding-container.tsx`) signals that the flow has no `ChatInput` node and triggers a different UI (`NoInputView`); it is unrelated to whether the textarea is empty.
 - The ChatInput → ChatOutput flow is deterministic and requires no LLM or API keys.

--- a/docs/core-functionality/playground/playground-empty-message-send.md
+++ b/docs/core-functionality/playground/playground-empty-message-send.md
@@ -6,7 +6,7 @@
 
 ## What this test validates *(required)*
 
-Validates send button state and input field behavior in the Playground when dealing with empty input. Covers three scenarios: send button state when the input is empty (Langflow keeps it enabled by design), send button state after typing a message, and input field state after clearing typed content.
+Validates send button state and input field behavior in the Playground when dealing with empty input. Covers two scenarios: send button state when the input is empty (Langflow keeps it enabled by design) and input field state after clearing typed content.
 
 ---
 
@@ -25,15 +25,7 @@ Validates send button state and input field behavior in the Playground when deal
 4. Confirm the input value is `""` (empty)
 5. Assert that `button-send` is **enabled** — pins Langflow's design choice of keeping send unconditionally enabled while no file upload is in flight
 
-**Test 2 — send button becomes enabled after typing a message**
-1. Create a blank flow with ChatInput connected to ChatOutput via `setupPlayground`
-2. Open the Playground via `playground-btn-flow-io`
-3. Wait for `input-chat-playground` to be visible
-4. Fill the input with `"Hello, Langflow!"`
-5. Confirm the input holds the typed value
-6. Assert that `button-send` is enabled
-
-**Test 3 — clearing the input after typing leaves the field empty**
+**Test 2 — clearing the input after typing leaves the field empty**
 1. Create a blank flow with ChatInput connected to ChatOutput via `setupPlayground`
 2. Open the Playground via `playground-btn-flow-io`
 3. Wait for `input-chat-playground` to be visible
@@ -46,8 +38,7 @@ Validates send button state and input field behavior in the Playground when deal
 ## Validation criterion *(required)*
 
 - **Test 1:** `button-send` is enabled even when `input-chat-playground` is empty. In `button-send-wrapper.tsx`, the `disabled` attribute is tied only to `isLoading` (file upload in progress); chat-text emptiness intentionally does not gate the button. The assertion pins this contract so any regression to a content-aware disabled state surfaces for review.
-- **Test 2:** `button-send` is enabled after the user types a non-empty message.
-- **Test 3:** The message input field is empty after previously entered text is cleared.
+- **Test 2:** The message input field is empty after previously entered text is cleared.
 
 ---
 

--- a/tests/tests-automations/regression/core-functionality/playground/playground-empty-message-send.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-empty-message-send.spec.ts
@@ -39,28 +39,6 @@ test.describe("Playground Empty-Message Send Behavior", () => {
   );
 
   test(
-    "send button becomes enabled after typing a message",
-    { tag: ["@stable", "@release", "@workspace", "@regression", "@playground"] },
-    async ({ page }) => {
-      createdFlowId = await setupPlayground(page);
-      await page.getByTestId("playground-btn-flow-io").click();
-      await page.waitForSelector('[data-testid="input-chat-playground"]', {
-        timeout: 15000,
-      });
-
-      const input = page.getByTestId("input-chat-playground").last();
-      const sendBtn = page.getByTestId("button-send").last();
-
-      // Fill the input with a non-empty message
-      await input.fill("Hello, Langflow!");
-      await expect(input).toHaveValue("Hello, Langflow!");
-
-      // Send button must be enabled when there is content to send
-      await expect(sendBtn).toBeEnabled({ timeout: 5000 });
-    },
-  );
-
-  test(
     "clearing the input after typing leaves the field empty",
     { tag: ["@stable", "@release", "@workspace", "@regression", "@playground"] },
     async ({ page }) => {

--- a/tests/tests-automations/regression/core-functionality/playground/playground-empty-message-send.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-empty-message-send.spec.ts
@@ -13,7 +13,7 @@ test.describe("Playground Empty-Message Send Behavior", () => {
   });
 
   test(
-    "send button is enabled when input is empty (Langflow bug)",
+    "send button stays enabled regardless of input content",
     { tag: ["@stable", "@release", "@workspace", "@regression", "@playground"] },
     async ({ page }) => {
       createdFlowId = await setupPlayground(page);
@@ -29,11 +29,11 @@ test.describe("Playground Empty-Message Send Behavior", () => {
       const inputValue = await input.inputValue();
       expect(inputValue).toBe("");
 
-      // BUG: the send button should be disabled when the input is empty so
-      // that users cannot dispatch an empty-message run.  Current behaviour
-      // is that the button remains ENABLED regardless of input content.
-      // This assertion documents the actual (buggy) behaviour; the test will
-      // need updating once the bug is fixed.
+      // By design, button-send is only disabled while files are uploading;
+      // it is intentionally not tied to chat-text emptiness, so the button
+      // remains enabled even with an empty input. This test pins that
+      // contract so a regression to a content-aware disabled state is
+      // surfaced for review.
       await expect(sendBtn).toBeEnabled({ timeout: 5000 });
     },
   );


### PR DESCRIPTION
## Summary

- The send button staying enabled on empty input is **intentional design** in Langflow, not a bug. In `button-send-wrapper.tsx` the `disabled` attribute is tied only to `isLoading` (file upload in progress); chat-text emptiness is intentionally not a gate. The `noInput` prop seen in the source signals the absence of a `ChatInput` node and triggers a separate `NoInputView` UI — it is unrelated to whether the textarea is empty.
- Reworded test 1 (name + comment), spec doc (validation criterion + Notes) and `QA-CHECKLIST.md:406` to drop the "Langflow bug" framing and describe the design contract instead. Phase 0 auto-section regenerated via `npm run coverage:summary`.
- Removed the redundant "send button becomes enabled after typing a message" test — it asserted the same enabled state already covered by test 1 under the new framing. Spec is now 2 tests: (1) send button stays enabled regardless of input content, (2) clearing the input after typing leaves the field empty.
- The test continues to assert that `button-send` is enabled with empty input — so a regression to a content-aware disabled state would now surface for review rather than be hidden behind a "known bug" comment.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (warnings unchanged from baseline)
- [x] `npx playwright test playground-empty-message-send.spec.ts` — all 2 tests pass against local Langflow nightly
- [x] `npm run coverage:summary` — idempotent, Phase 0 list reflects new test name and reduced count (68 → 67)

Closes #115