### PR TITLE
chore(stable): remove @stable from 4 tests failing in weekly run 25441253323

### DIFF
--- a/docs/core-components/api-request-component-regression.md
+++ b/docs/core-components/api-request-component-regression.md
@@ -19,8 +19,10 @@ If any of these tests fails, the API Request component is broken in the product 
 
 ## Tags *(required)*
 
-All 13 tests: `@stable` `@regression` `@components`
+10 of 13 tests: `@stable` `@regression` `@components`
 8 of them additionally carry `@release` (the canvas/inspector/GET/POST/PUT/PATCH/DELETE happy paths).
+
+**`@stable` exception:** Tests 4 (`GET request returns 200`), 6 (`PUT method executes PUT verb`), and 13 (`cURL mode parses command, auto-fills URL, executes GET`) do **not** carry `@stable` — removed in the triage of weekly run [25441253323](https://github.com/oriontech-me/langflow-e2e/actions/runs/25441253323) (issue #165) after all three tests timed out on `getByText('built successfully').last()`. The shared `runAndOpenOutput` helper anchors on a fragile, repeatable toast text that can match prior toasts and gives no node-level signal. Tag is restored once the helper is hardened (see follow-up issue).
 
 ---
 

--- a/docs/core-components/webhook-component-regression.md
+++ b/docs/core-components/webhook-component-regression.md
@@ -29,6 +29,8 @@ If any of these tests fails, the Webhook component is broken in one of its core 
 
 `@stable` `@release` `@regression`
 
+**`@stable` exception:** Test 1 (`HTTP POST accepts JSON and plain-text bodies returning 202`) does **not** carry `@stable` — removed in the triage of weekly run [25441253323](https://github.com/oriontech-me/langflow-e2e/actions/runs/25441253323) (issue #165) after the endpoint returned 403 instead of 202 on three consecutive attempts. The test fixture `request` is unauthenticated and the webhook endpoint appears to require session credentials in the current Langflow version. Tag is restored once the test is updated to authenticate (see follow-up issue).
+
 ---
 
 ## Step by step *(required)*

--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -192,7 +192,7 @@ test(
 
 test(
   "API Request component — GET request returns 200 and output Data contains all required fields",
-  { tag: ["@stable", "@release", "@regression", "@components"] },
+  { tag: ["@release", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
 
@@ -251,7 +251,7 @@ test(
 
 test(
   "API Request component — PUT method executes PUT verb and returns 200",
-  { tag: ["@stable", "@release", "@regression", "@components"] },
+  { tag: ["@release", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
 
@@ -475,7 +475,7 @@ test(
 
 test(
   "API Request component — cURL mode parses command, auto-fills URL, executes GET and returns 200",
-  { tag: ["@stable", "@regression", "@components"] },
+  { tag: ["@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
 

--- a/tests/tests-automations/regression/core-components/webhook-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/webhook-component-regression.spec.ts
@@ -27,7 +27,7 @@ async function addWebhookComponent(page: any) {
 
 test(
   "Webhook component — HTTP POST accepts JSON and plain-text bodies returning 202",
-  { tag: ["@stable", "@release", "@regression"] },
+  { tag: ["@release", "@regression"] },
   async ({ page, request }) => {
     await addWebhookComponent(page);
 


### PR DESCRIPTION
## Summary

Triage of [issue #165](https://github.com/oriontech-me/langflow-e2e/issues/165) (manual `weekly-stable.yml` run [25441253323](https://github.com/oriontech-me/langflow-e2e/actions/runs/25441253323) that surfaced 3 failed + 2 flaky tests on `langflow-nightly:latest`).

Removes `@stable` from the four tests whose root cause is on our side (test/helper). Keeps `@stable` on the one test whose root cause is suspected upstream Langflow regression — that one is tracked for upstream filing.

## Tests with `@stable` removed (4)

| Spec | Line | Test | Root cause | Follow-up |
|---|---|---|---|---|
| `webhook-component-regression.spec.ts` | 28 | HTTP POST accepts JSON and plain-text bodies returning 202 | Test uses unauthenticated `request` fixture; webhook endpoint appears to require session credentials. Fix: switch to authenticated request (mirror the pattern used at line 360-374 of the same spec). | #179 |
| `api-request-component-regression.spec.ts` | 193 | GET request returns 200 (flaky — passed on retry) | Shared helper `runAndOpenOutput` anchors on `getByText('built successfully').last()` which is fragile (matches prior toasts, no node-level signal). | #181 |
| `api-request-component-regression.spec.ts` | 252 | PUT method executes PUT verb (flaky — passed on retry) | Same helper, same root cause as above. | #182 |
| `api-request-component-regression.spec.ts` | 476 | cURL mode parses command, auto-fills URL, executes GET | Same helper, same root cause as above. Hard fail (no retry pass). | #183 |

## Tests with `@stable` kept (1)

| Spec | Line | Test | Why kept | Follow-up |
|---|---|---|---|---|
| `webhook-component-regression.spec.ts` | 60 | flow is saved to database and contains the Webhook node | `TypeError: Cannot set properties of undefined (setting 'Accept-Language')` originates inside the Langflow frontend bundle (`index-DSCuf7xn.js`). Our test only invokes a vanilla `fetch` via `page.evaluate`. Strongly suggests upstream regression in Langflow's HTTP wrapper. | #180 |

## Spec docs updated

- `docs/core-components/webhook-component-regression.md` — Tags section now flags Test 1 as the `@stable` exception with a link back to the run and to issue #165.
- `docs/core-components/api-request-component-regression.md` — Tags section now reads `10 of 13 tests: @stable @regression @components` and flags tests 4, 6, and 13 as exceptions.

## Out of scope

This PR does **not**:
- Fix any of the underlying issues (auth fix on the webhook test, helper hardening on the API Request tests, upstream issue filing for the Accept-Language TypeError).
- Touch any other tag (`@release`, `@regression`, `@components` left untouched).

Each of those becomes its own PR, mapped to the follow-up issues opened from #165 (#179, #180, #181, #182, #183).

## Validation

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 errors, baseline warnings only)

Closes #165