### PR TITLE
test(core-components): add Chat Input/Output regression spec

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -153,9 +153,12 @@
 ### 3. Core Components
 
 #### 3.1 Chat Input / Output
-- [-] ChatInput receives user message
-- [-] ChatOutput displays LLM response
-- [-] Chat Input/Output with user authentication
+- [x] ChatInput renders on canvas with Message output handle and Input Text field → `core-components/chat-input-output-component-regression.spec.ts`
+- [x] ChatOutput renders on canvas with Inputs handle and run button → `core-components/chat-input-output-component-regression.spec.ts`
+- [x] ChatInput → ChatOutput connection accepted (Message ↔ Message) → `core-components/chat-input-output-component-regression.spec.ts`
+- [x] Input Text propagates from ChatInput to ChatOutput on run → `core-components/chat-input-output-component-regression.spec.ts`
+- [x] Sender name override is reflected in the Playground chat message → `core-components/chat-input-output-component-regression.spec.ts`
+- [x] Default sender_name is "User" on input and "AI" on output → `core-components/chat-input-output-component-regression.spec.ts`
 
 #### 3.2 Prompt Template
 - [-] Prompt with variables in curly braces
@@ -671,7 +674,7 @@
 |--------|-------|-----------------|------------------------|---------------------|---------------------|
 | `api/flows/` — REST API | 21 | 0 | 21 | 0 | 0 |
 | `core-components/` — Component Config | 22 | 0 | 20 | 0 | 2 |
-| `core-components/` — Core Components | 43 | 28 | 10 | 0 | 5 |
+| `core-components/` — Core Components | 46 | 34 | 7 | 0 | 5 |
 | `core-functionality/auth/` | 19 | 0 | 18 | 0 | 1 |
 | `core-functionality/knowledge-ingestion/` | 8 | 0 | 4 | 0 | 4 |
 | `core-functionality/llm-agents/` | 40 | 13 | 2 | 0 | 25 |
@@ -685,7 +688,7 @@
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 42 | 0 | 40 | 1 | 1 |
 | `ui-ux/` — Settings | 5 | 1 | 3 | 1 | 0 |
-| **TOTAL** | **373** | **80 (21%)** | **228 (61%)** | **6 (2%)** | **59 (16%)** |
+| **TOTAL** | **376** | **86 (23%)** | **225 (60%)** | **6 (2%)** | **59 (16%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -701,7 +704,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 63 `test()` calls carrying the `@stable` tag, distributed across 23 spec
+> 69 `test()` calls carrying the `@stable` tag, distributed across 24 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -718,6 +721,12 @@
 - [x] API Request component — query parameters embedded in URL are sent and echoed → `api-request-component-regression.spec.ts`
 - [x] API Request component — inspector headers table accepts key + value cell entries → `api-request-component-regression.spec.ts`
 - [x] API Request component — cURL tab switches mode and field accepts a cURL command → `api-request-component-regression.spec.ts`
+- [x] Chat Input component — renders on canvas with Message output handle and Input Text field → `chat-input-output-component-regression.spec.ts`
+- [x] Chat Output component — renders on canvas with Inputs handle and run button → `chat-input-output-component-regression.spec.ts`
+- [x] Chat Input → Chat Output connection is accepted on canvas (Message ↔ Message) → `chat-input-output-component-regression.spec.ts`
+- [x] Chat Input → Chat Output — Input Text value propagates to ChatOutput on run → `chat-input-output-component-regression.spec.ts`
+- [x] Chat Input — sender_name override is reflected in the Playground chat message → `chat-input-output-component-regression.spec.ts`
+- [x] Chat Input/Output — default sender_name is 'User' on input and 'AI' on output → `chat-input-output-component-regression.spec.ts`
 - [x] Loop component — renders correctly with all handles and output inspection buttons → `loop-component-regression.spec.ts`
 - [x] Loop component — run without connections shows build failed notification → `loop-component-regression.spec.ts`
 - [x] Loop component — Research Translation Loop template: full wiring and iterates over 2 ArXiv papers → `loop-component-regression.spec.ts`

--- a/docs/core-components/chat-input-output-component-regression.md
+++ b/docs/core-components/chat-input-output-component-regression.md
@@ -1,0 +1,143 @@
+# Chat Input / Chat Output Components — Regression
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+Validates the canvas-side surface of the **Chat Input** and **Chat Output** components — the two endpoints of every Playground flow — without depending on an LLM. ChatInput → ChatOutput is a Message pass-through, so the suite stays deterministic and provider-independent (same approach used by `webhook-component-regression`).
+
+The 6 tests cover:
+
+1. **Chat Input renders on canvas** — title, run button, `Chat Message` output handle, default `Input Text` (`textarea_str_input_value`) field, output-inspection button, and exactly one node on the canvas after adding via the sidebar.
+2. **Chat Output renders on canvas** — title, run button, `Inputs` input handle, output-inspection button, and exactly one node on the canvas.
+3. **Chat Input → Chat Output connection accepted** — clicking the source handle then the target handle on Message ↔ Message creates exactly one edge; both nodes remain on the canvas.
+4. **Input Text propagates from ChatInput to ChatOutput on run** — configure the `Input Text` field with a known string, run from the Chat Output run button, and confirm the value reaches the ChatOutput output-inspection dialog.
+5. **Sender name override is reflected in the Playground chat message** — toggle the advanced `sender_name` field, set it to `"QA"`, and verify the user-side message in the Playground renders with `chat-message-QA-{text}` (the testid is built directly from the upstream sender_name).
+6. **Default sender_name values are the literal constants** — `Chat Input` defaults to `"User"` and `Chat Output` defaults to `"AI"` when the field is toggled visible. The defaults come from `MESSAGE_SENDER_NAME_USER` / `MESSAGE_SENDER_NAME_AI` in `lfx/utils/constants.py`; there is **no** fallback to the authenticated username.
+
+If any of these tests fails, one of the two endpoints of the Playground is broken — either rendering on the canvas, the Message connection contract, runtime pass-through, or the constants that drive sender labels in the chat UI.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@components`
+
+All 6 tests carry `@stable` per the project rule "spec is born 100% @stable; tag is removed per-test only during weekly triage".
+
+---
+
+## Step by step *(required)*
+
+**Setup helpers**
+
+- `addChatInputComponent(page)` — opens a blank flow, adds Chat Input via the sidebar, focuses the node and clicks `more-options-modal` → `expand-button-modal` so the run button and inspector content become available (ChatInput defaults to `minimized = True`).
+- `addChatOutputToCanvas(page)` — drags Chat Output onto an existing flow, then expands it the same way.
+- `connectChatInputToChatOutput(page)` — clicks `handle-chatinput-shownode-chat message-right` then `handle-chatoutput-shownode-inputs-left` and asserts exactly one `.react-flow__edge` is present.
+- `runFlowAndOpenChatOutputInspection(page)` — clicks `button_run_chat output`, waits for "built successfully", opens `output-inspection-output message-chatoutput`, and returns the dialog text content.
+
+**Test 1 — Chat Input rendering**
+1. Run `addChatInputComponent(page)`
+2. Assert `title-Chat Input` and `button_run_chat input` are visible
+3. Assert the output handle `handle-chatinput-shownode-chat message-right` is visible
+4. Assert the `textarea_str_input_value` field is visible (default `Input Text` field)
+5. Assert `output-inspection-chat message-chatinput` is visible
+6. Assert `.react-flow__node` count is exactly `1`
+
+**Test 2 — Chat Output rendering**
+1. Open a blank flow, add Chat Output via the sidebar, expand the node
+2. Assert `title-Chat Output` and `button_run_chat output` are visible
+3. Assert the input handle `handle-chatoutput-shownode-inputs-left` is visible
+4. Assert `output-inspection-output message-chatoutput` is visible
+5. Assert `.react-flow__node` count is exactly `1`
+
+**Test 3 — connection accepted**
+1. Run `addChatInputComponent` and `addChatOutputToCanvas`
+2. Assert two nodes exist on the canvas
+3. Run `connectChatInputToChatOutput`
+4. Assert two nodes still exist and both titles remain visible
+
+**Test 4 — Input Text propagation**
+1. Run `addChatInputComponent`
+2. Fill `textarea_str_input_value` with `"regression-chat-passthrough-42"` and assert the field holds that value
+3. Run `addChatOutputToCanvas` and `connectChatInputToChatOutput`
+4. Run `runFlowAndOpenChatOutputInspection` and assert the returned text contains the input string
+5. Press `Escape` to close the dialog
+
+**Test 5 — sender_name override via Playground**
+1. Run `addChatInputComponent`
+2. `openAdvancedOptions` → click `showsender_name` → `closeAdvancedOptions`
+3. Fill `popover-anchor-input-sender_name` (first instance) with `"QA"` and assert the value
+4. Run `addChatOutputToCanvas` and `connectChatInputToChatOutput`
+5. Click `playground-btn-flow-io` and wait for `input-chat-playground` to be visible
+6. Fill the playground input with `"sender-override-regression"` and click `button-send`
+7. Assert that `chat-message-QA-sender-override-regression` is visible (timeout 30s)
+
+**Test 6 — default sender_name values**
+1. Run `addChatInputComponent`
+2. Open advanced options, click `showsender_name`, close advanced options
+3. Assert `popover-anchor-input-sender_name` (first instance) has value `"User"`
+4. Run `addChatOutputToCanvas`, click `title-Chat Output` to focus it
+5. Open advanced options, click `showsender_name`, close advanced options
+6. Assert `popover-anchor-input-sender_name.nth(0)` is `"User"` (Chat Input) and `nth(1)` is `"AI"` (Chat Output)
+
+---
+
+## Validation criterion *(required)*
+
+- Both Chat Input and Chat Output add to a blank flow and render with their titles, run buttons, default handles, and inspection buttons.
+- Connecting `chat message` (right) → `inputs` (left) succeeds and produces exactly one edge.
+- A string set on Chat Input's `Input Text` reaches Chat Output's output inspection after running the flow from `button_run_chat output`.
+- Setting Chat Input's `sender_name` to `"QA"` and sending a message in the Playground produces the testid `chat-message-QA-{message}`.
+- Default `sender_name` field value is `"User"` for Chat Input and `"AI"` for Chat Output (no authenticated-username fallback).
+
+---
+
+## External dependencies *(required)*
+
+- `src/lfx/src/lfx/components/input_output/chat.py` — `ChatInput.message_response()`: emits the Message with the configured `sender_name`. Renaming `input_value`, `sender_name`, or the output `name="message"` breaks tests 1, 4, 5, and 6.
+- `src/lfx/src/lfx/components/input_output/chat_output.py` — `ChatOutput.message_response()`: receives the Message and re-stamps its own `sender_name`. Renaming `input_value`, the output `name="message"`, or the `Output Message` display name breaks tests 2, 4, and 6.
+- `src/lfx/src/lfx/utils/constants.py` — defines `MESSAGE_SENDER_NAME_USER = "User"` and `MESSAGE_SENDER_NAME_AI = "AI"`. Test 6 asserts these literal defaults; changing the constants flips the assertion.
+- `src/frontend/src/CustomNodes/GenericNode/` — renders the handles using the `handle-{component}-shownode-{port}-{side}` pattern. The `chat message` and `inputs` port names must remain stable.
+- `src/frontend/src/CustomNodes/GenericNode/components/NodeOutputParameter/` — renders the output-inspection buttons (`output-inspection-{display_name.toLowerCase()}-{component_type_lowercase}`). Renaming `Chat Message` or `Output Message` breaks the test 1, 2, and 4 selectors.
+- `src/frontend/src/modals/IOModal/components/chatView/chatMessage/chat-message.tsx` — generates the `chat-message-{sender_name}-{text}` testid from the upstream sender_name; test 5 depends on this format.
+- `src/frontend/src/components/core/parameterRenderComponent/` — renders `popover-anchor-input-sender_name`, `textarea_str_input_value`, and the `showsender_name` advanced-options toggle.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Chat Input multimodal/file attach (future spec under `playground/` or a new `chat-input-multimodal`).
+- Chat Input template variables / advanced settings beyond `sender_name`.
+- Playground rendering of the AI-side message (already covered by the Playground @stable suite).
+- Session ID isolation / context_id propagation (covered by `playground-session-id.spec.ts` and `playground-session-clear.spec.ts`).
+- Chat Output `data_template` behavior when receiving a Data object instead of a Message.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and accessible at `PLAYWRIGHT_BASE_URL`.
+- No API key required — the spec is fully LLM-free.
+- Tests 4 and 5 require the autosave/build pipeline to be functional (the "built successfully" toast, plus the Playground send button) within the configured timeouts.
+- Both Chat Input and Chat Output start `minimized = True` in upstream Langflow; the helpers expand them via `more-options-modal` → `expand-button-modal` so the run button and full inspector are reachable. If the expand-button testid changes, all tests break at the helper.
+
+---
+
+## When to review this test *(optional)*
+
+- If `MESSAGE_SENDER_NAME_USER` or `MESSAGE_SENDER_NAME_AI` change in `lfx/utils/constants.py`, test 6 must be updated.
+- If the Chat Input output display name moves away from `"Chat Message"`, the `output-inspection-chat message-chatinput` selector and the `handle-chatinput-shownode-chat message-right` selector both break.
+- If the Chat Output output display name moves away from `"Output Message"`, the `output-inspection-output message-chatoutput` selector breaks.
+- If the chat message testid pattern in `chat-message.tsx` changes (e.g. removes the sender_name prefix), test 5 breaks.
+- If Chat Input or Chat Output stop being `minimized = True` by default, the `expandFocusedNode` helper becomes unnecessary — the assertions still pass but the helper can be simplified.
+
+---
+
+## Notes *(optional)*
+
+- Test 5 deliberately validates the override through the **Playground** rather than the canvas-side output-inspection dialog, because the dialog renders a Message as plain text (no metadata fields exposed in `textContent`). The Playground's `chat-message-{sender_name}-{text}` testid is the user-visible surface where the override actually shows up.
+- Test 6 validates the defaults at the **inspector level** (the field value) rather than running the flow. The field value is the upstream of any runtime behavior — this avoids the same dialog-rendering limitation as test 5 while still catching a regression in the constants.
+- The original issue (#184) framed test 6 as "default sender uses authenticated username when `sender_name` is empty"; the actual upstream behavior (verified against `lfx/components/input_output/chat.py` and the upstream integration test `test_chat_input.test_default`) is that the default is the literal string `"User"`, with no username fallback. The test was reframed to match real behavior.

--- a/docs/core-components/chat-input-output-component-regression.md
+++ b/docs/core-components/chat-input-output-component-regression.md
@@ -69,7 +69,7 @@ All 6 tests carry `@stable` per the project rule "spec is born 100% @stable; tag
 **Test 5 — sender_name override via Playground**
 1. Run `addChatInputComponent`
 2. `openAdvancedOptions` → click `showsender_name` → `closeAdvancedOptions`
-3. Fill `popover-anchor-input-sender_name` (first instance) with `"QA"` and assert the value
+3. Scope a locator to the Chat Input `.react-flow__node` (filtered by `title-Chat Input`), fill its `popover-anchor-input-sender_name` with `"QA"` and assert the value
 4. Run `addChatOutputToCanvas` and `connectChatInputToChatOutput`
 5. Click `playground-btn-flow-io` and wait for `input-chat-playground` to be visible
 6. Fill the playground input with `"sender-override-regression"` and click `button-send`

--- a/docs/core-components/chat-input-output-component-regression.md
+++ b/docs/core-components/chat-input-output-component-regression.md
@@ -78,10 +78,10 @@ All 6 tests carry `@stable` per the project rule "spec is born 100% @stable; tag
 **Test 6 — default sender_name values**
 1. Run `addChatInputComponent`
 2. Open advanced options, click `showsender_name`, close advanced options
-3. Assert `popover-anchor-input-sender_name` (first instance) has value `"User"`
+3. Scope a locator to the Chat Input `.react-flow__node` (filtered by `title-Chat Input`) and assert its `popover-anchor-input-sender_name` has value `"User"`
 4. Run `addChatOutputToCanvas`, click `title-Chat Output` to focus it
 5. Open advanced options, click `showsender_name`, close advanced options
-6. Assert `popover-anchor-input-sender_name.nth(0)` is `"User"` (Chat Input) and `nth(1)` is `"AI"` (Chat Output)
+6. Scope each assertion to its own `.react-flow__node` container (filtered by `title-Chat Input` / `title-Chat Output`) and assert `popover-anchor-input-sender_name` is `"User"` on Chat Input and `"AI"` on Chat Output — using node-scoped filters keeps the test resilient to DOM ordering changes
 
 ---
 

--- a/tests/tests-automations/regression/core-components/chat-input-output-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/chat-input-output-component-regression.spec.ts
@@ -1,0 +1,338 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
+import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { zoomOut } from "../../../helpers/ui/zoom-out";
+import {
+  closeAdvancedOptions,
+  openAdvancedOptions,
+} from "../../../helpers/ui/open-advanced-options";
+
+// Run tests serially to avoid "flow must be unique" 400 errors from parallel autosaves
+test.describe.configure({ mode: "serial" });
+
+// Helper: expand the currently focused node from minimized to full view.
+// ChatInput / ChatOutput both default to `minimized = True` (see
+// lfx/components/input_output/chat.py); without expanding, the run button and
+// inspector fields rendered on the node body are not present in the DOM.
+async function expandFocusedNode(page: Page) {
+  await page.getByTestId("more-options-modal").click();
+  await expect(page.getByTestId("expand-button-modal")).toBeVisible({
+    timeout: 10000,
+  });
+  await page.getByTestId("expand-button-modal").click();
+  // Sanity: after expanding, hide-node-content is removed from the DOM
+  await expect(page.getByTestId("hide-node-content")).toHaveCount(0, {
+    timeout: 5000,
+  });
+}
+
+// Helper: create a blank flow and add the Chat Input component to the canvas
+// in expanded (non-minimized) state.
+async function addChatInputComponent(page: Page) {
+  await awaitBootstrapTest(page);
+  await page.getByTestId("blank-flow").click();
+  await page.getByTestId("sidebar-search-input").fill("chat input");
+  await expect(page.getByTestId("input_outputChat Input")).toBeVisible({
+    timeout: 30000,
+  });
+  await page.getByTestId("input_outputChat Input").hover();
+  await page.getByTestId("add-component-button-chat-input").click();
+  await adjustScreenView(page);
+  await expect(page.getByTestId("title-Chat Input")).toBeVisible({
+    timeout: 15000,
+  });
+  // Focus the node and expand it so run button / inspector fields are exposed
+  await page.getByTestId("title-Chat Input").click();
+  await expandFocusedNode(page);
+}
+
+// Helper: drag the Chat Output component onto the canvas and expand it.
+// Requires that a flow is already open and that at least one node is present.
+async function addChatOutputToCanvas(page: Page) {
+  // Zoom out so the drag target does not overlap the existing node
+  await zoomOut(page, 2);
+  await page.getByTestId("sidebar-search-input").fill("chat output");
+  await expect(page.getByTestId("input_outputChat Output")).toBeVisible({
+    timeout: 30000,
+  });
+  await page
+    .getByTestId("input_outputChat Output")
+    .dragTo(page.locator('//*[@id="react-flow-id"]'), {
+      targetPosition: { x: 100, y: 100 },
+    });
+  await adjustScreenView(page);
+  await expect(page.getByTestId("title-Chat Output")).toBeVisible({
+    timeout: 15000,
+  });
+  await page.getByTestId("title-Chat Output").click();
+  await expandFocusedNode(page);
+}
+
+// Helper: connect ChatInput "Chat Message" output → ChatOutput "Inputs" input
+// by clicking the source handle then the target handle. Both handles use the
+// noshownode variant because both components are minimized by default.
+async function connectChatInputToChatOutput(page: Page) {
+  await page
+    .getByTestId("handle-chatinput-shownode-chat message-right")
+    .click();
+  await page
+    .getByTestId("handle-chatoutput-shownode-inputs-left")
+    .click();
+  await expect(page.locator(".react-flow__edge")).toHaveCount(1, {
+    timeout: 8000,
+  });
+}
+
+// Helper: run the connected flow from the Chat Output run button and open the
+// output-inspection dialog for the Chat Output. Returns the dialog text content
+// (the whole modal — Message outputs render as a structured view that may mix
+// labeled sections and a JSON-style preview, so reading the full dialog body
+// avoids depending on a single inner element).
+async function runFlowAndOpenChatOutputInspection(page: Page): Promise<string> {
+  await page.getByTestId("button_run_chat output").click();
+  await expect(page.getByText("built successfully").last()).toBeVisible({
+    timeout: 45000,
+  });
+  await expect(
+    page.getByTestId("output-inspection-output message-chatoutput"),
+  ).toBeAttached({ timeout: 10000 });
+  await page.getByTestId("output-inspection-output message-chatoutput").click();
+  const dialog = page.locator('[role="dialog"]');
+  await expect(dialog).toBeVisible({ timeout: 10000 });
+  return (await dialog.evaluate((el: HTMLElement) => el.textContent ?? "")) ?? "";
+}
+
+// =============================================================================
+// Test 1 — Chat Input rendering on canvas
+// =============================================================================
+
+test(
+  "Chat Input component — renders on canvas with Message output handle and Input Text field",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    await addChatInputComponent(page);
+
+    // Title must be visible in the node header
+    await expect(page.getByTestId("title-Chat Input")).toBeVisible();
+
+    // Run button must be present
+    await expect(page.getByTestId("button_run_chat input")).toBeVisible();
+
+    // Output handle: "Chat Message" port on the right side (noshownode because
+    // ChatInput is minimized by default — see lfx/components/input_output/chat.py)
+    await expect(
+      page.getByTestId("handle-chatinput-shownode-chat message-right"),
+    ).toBeVisible();
+
+    // Default visible inspector field: "Input Text" (MultilineInput name="input_value")
+    await expect(page.getByTestId("textarea_str_input_value")).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Output inspection button for the "Chat Message" port
+    await expect(
+      page.getByTestId("output-inspection-chat message-chatinput"),
+    ).toBeVisible();
+
+    // Exactly one node on the canvas — no spurious duplicates
+    await expect(page.locator(".react-flow__node")).toHaveCount(1);
+  },
+);
+
+// =============================================================================
+// Test 2 — Chat Output rendering on canvas
+// =============================================================================
+
+test(
+  "Chat Output component — renders on canvas with Inputs handle and run button",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    await awaitBootstrapTest(page);
+    await page.getByTestId("blank-flow").click();
+    await page.getByTestId("sidebar-search-input").fill("chat output");
+    await expect(page.getByTestId("input_outputChat Output")).toBeVisible({
+      timeout: 30000,
+    });
+    await page.getByTestId("input_outputChat Output").hover();
+    await page.getByTestId("add-component-button-chat-output").click();
+    await adjustScreenView(page);
+
+    await expect(page.getByTestId("title-Chat Output")).toBeVisible({
+      timeout: 15000,
+    });
+
+    // Expand the node so the run button and inspector contents are exposed
+    await page.getByTestId("title-Chat Output").click();
+    await expandFocusedNode(page);
+
+    // Run button must be present
+    await expect(page.getByTestId("button_run_chat output")).toBeVisible();
+
+    // Input handle: "Inputs" port on the left side (target side, noshownode)
+    await expect(
+      page.getByTestId("handle-chatoutput-shownode-inputs-left"),
+    ).toBeVisible();
+
+    // Output inspection button for the "Output Message" port
+    await expect(
+      page.getByTestId("output-inspection-output message-chatoutput"),
+    ).toBeVisible();
+
+    // Exactly one node on the canvas
+    await expect(page.locator(".react-flow__node")).toHaveCount(1);
+  },
+);
+
+// =============================================================================
+// Test 3 — connection accepted between Chat Input and Chat Output
+// =============================================================================
+
+test(
+  "Chat Input → Chat Output connection is accepted on canvas (Message ↔ Message)",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    await addChatInputComponent(page);
+    await addChatOutputToCanvas(page);
+
+    await expect(page.locator(".react-flow__node")).toHaveCount(2);
+
+    await connectChatInputToChatOutput(page);
+
+    // After connecting, both nodes must remain on canvas with exactly one edge
+    await expect(page.locator(".react-flow__node")).toHaveCount(2);
+    await expect(page.getByTestId("title-Chat Input")).toBeVisible();
+    await expect(page.getByTestId("title-Chat Output")).toBeVisible();
+  },
+);
+
+// =============================================================================
+// Test 4 — Input Text propagates from ChatInput to ChatOutput on run
+// =============================================================================
+
+test(
+  "Chat Input → Chat Output — Input Text value propagates to ChatOutput on run",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    const inputText = "regression-chat-passthrough-42";
+
+    await addChatInputComponent(page);
+
+    // Configure the Input Text on the Chat Input
+    await page.getByTestId("textarea_str_input_value").fill(inputText);
+    await expect(page.getByTestId("textarea_str_input_value")).toHaveValue(
+      inputText,
+    );
+
+    await addChatOutputToCanvas(page);
+    await connectChatInputToChatOutput(page);
+
+    const output = await runFlowAndOpenChatOutputInspection(page);
+
+    // The output Message must carry the same text the ChatInput emitted
+    expect(output).toContain(inputText);
+
+    await page.keyboard.press("Escape");
+  },
+);
+
+// =============================================================================
+// Test 5 — sender_name override is reflected in output
+// =============================================================================
+
+test(
+  "Chat Input — sender_name override is reflected in the Playground chat message",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    const senderOverride = "QA";
+    // Doubles as a `chat-message-QA-{value}` testid suffix — keep it free of
+    // characters that would invalidate that selector.
+    const playgroundMessage = "sender-override-regression";
+
+    await addChatInputComponent(page);
+
+    // sender_name is advanced=True — toggle it visible via the inspector controls
+    await openAdvancedOptions(page);
+    await page.getByTestId("showsender_name").click();
+    await closeAdvancedOptions(page);
+
+    // Fill the now-visible sender_name input
+    await page
+      .getByTestId("popover-anchor-input-sender_name")
+      .first()
+      .fill(senderOverride);
+    await expect(
+      page.getByTestId("popover-anchor-input-sender_name").first(),
+    ).toHaveValue(senderOverride);
+
+    await addChatOutputToCanvas(page);
+    await connectChatInputToChatOutput(page);
+
+    // Drive the flow through the Playground — that is the surface where the
+    // override is actually rendered (chat-message testid is built from the
+    // user-side sender_name returned by ChatInput).
+    await page.getByTestId("playground-btn-flow-io").click();
+    await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+      timeout: 30000,
+    });
+
+    await page.getByTestId("input-chat-playground").last().fill(playgroundMessage);
+    await page.getByTestId("button-send").last().click();
+
+    // The user-side message must render with the QA override as sender_name —
+    // the testid pattern is `chat-message-{sender_name}-{text}` (see
+    // chat-message.tsx).
+    await expect(
+      page.getByTestId(`chat-message-${senderOverride}-${playgroundMessage}`),
+    ).toBeVisible({ timeout: 30000 });
+  },
+);
+
+// =============================================================================
+// Test 6 — default sender_name values are the literal constants
+// =============================================================================
+
+test(
+  "Chat Input/Output — default sender_name is 'User' on input and 'AI' on output",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    // The defaults are constants in lfx/utils/constants.py:
+    //   MESSAGE_SENDER_NAME_USER = "User"
+    //   MESSAGE_SENDER_NAME_AI   = "AI"
+    // There is no fallback to the authenticated username — the field is
+    // pre-filled with the literal string. Validate the defaults at the
+    // inspector level because the field controls what every Message will
+    // carry; this is the upstream of the runtime behaviour.
+    await addChatInputComponent(page);
+
+    // Toggle the advanced "sender_name" field visible on Chat Input and
+    // assert it contains the default "User"
+    await openAdvancedOptions(page);
+    await page.getByTestId("showsender_name").click();
+    await closeAdvancedOptions(page);
+
+    await expect(
+      page.getByTestId("popover-anchor-input-sender_name").first(),
+    ).toHaveValue("User", { timeout: 10000 });
+
+    // Now do the same for Chat Output — its default sender_name must be "AI"
+    await addChatOutputToCanvas(page);
+
+    // Focus the Chat Output node so the inspector targets it
+    await page.getByTestId("title-Chat Output").click();
+    await openAdvancedOptions(page);
+    await page.getByTestId("showsender_name").click();
+    await closeAdvancedOptions(page);
+
+    // After enabling sender_name on ChatOutput, two such inputs exist on the
+    // canvas. The first (.nth(0)) belongs to the ChatInput node added earlier
+    // and still holds "User"; the second (.nth(1)) is the ChatOutput's
+    // sender_name input, which must default to "AI".
+    await expect(
+      page.getByTestId("popover-anchor-input-sender_name").nth(0),
+    ).toHaveValue("User");
+    await expect(
+      page.getByTestId("popover-anchor-input-sender_name").nth(1),
+    ).toHaveValue("AI");
+  },
+);

--- a/tests/tests-automations/regression/core-components/chat-input-output-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/chat-input-output-component-regression.spec.ts
@@ -261,13 +261,16 @@ test(
     await page.getByTestId("showsender_name").click();
     await closeAdvancedOptions(page);
 
-    // Fill the now-visible sender_name input
-    await page
+    // Scope the sender_name field to the Chat Input node container so the
+    // assertion does not depend on DOM ordering once Chat Output is added.
+    const chatInputNode = page
+      .locator(".react-flow__node")
+      .filter({ has: page.getByTestId("title-Chat Input") });
+    await chatInputNode
       .getByTestId("popover-anchor-input-sender_name")
-      .first()
       .fill(senderOverride);
     await expect(
-      page.getByTestId("popover-anchor-input-sender_name").first(),
+      chatInputNode.getByTestId("popover-anchor-input-sender_name"),
     ).toHaveValue(senderOverride);
 
     await addChatOutputToCanvas(page);

--- a/tests/tests-automations/regression/core-components/chat-input-output-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/chat-input-output-component-regression.spec.ts
@@ -15,7 +15,11 @@ test.describe.configure({ mode: "serial" });
 // ChatInput / ChatOutput both default to `minimized = True` (see
 // lfx/components/input_output/chat.py); without expanding, the run button and
 // inspector fields rendered on the node body are not present in the DOM.
+// Idempotent: if the node is already expanded (no `hide-node-content` in the
+// DOM), the helper is a no-op — that future-proofs the spec against an
+// upstream change to the `minimized` default.
 async function expandFocusedNode(page: Page) {
+  if ((await page.getByTestId("hide-node-content").count()) === 0) return;
   await page.getByTestId("more-options-modal").click();
   await expect(page.getByTestId("expand-button-modal")).toBeVisible({
     timeout: 10000,
@@ -70,8 +74,8 @@ async function addChatOutputToCanvas(page: Page) {
 }
 
 // Helper: connect ChatInput "Chat Message" output → ChatOutput "Inputs" input
-// by clicking the source handle then the target handle. Both handles use the
-// noshownode variant because both components are minimized by default.
+// by clicking the source handle then the target handle. The shownode variant
+// is targeted because both components were expanded by the add helpers above.
 async function connectChatInputToChatOutput(page: Page) {
   await page
     .getByTestId("handle-chatinput-shownode-chat message-right")
@@ -119,8 +123,7 @@ test(
     // Run button must be present
     await expect(page.getByTestId("button_run_chat input")).toBeVisible();
 
-    // Output handle: "Chat Message" port on the right side (noshownode because
-    // ChatInput is minimized by default — see lfx/components/input_output/chat.py)
+    // Output handle: "Chat Message" port on the right side
     await expect(
       page.getByTestId("handle-chatinput-shownode-chat message-right"),
     ).toBeVisible();
@@ -169,7 +172,7 @@ test(
     // Run button must be present
     await expect(page.getByTestId("button_run_chat output")).toBeVisible();
 
-    // Input handle: "Inputs" port on the left side (target side, noshownode)
+    // Input handle: "Inputs" port on the left side
     await expect(
       page.getByTestId("handle-chatoutput-shownode-inputs-left"),
     ).toBeVisible();
@@ -227,9 +230,11 @@ test(
     await addChatOutputToCanvas(page);
     await connectChatInputToChatOutput(page);
 
+    // The helper waits for the "built successfully" toast before opening the
+    // dialog, so a green path here means: build ran, ChatInput emitted the
+    // Message, and the propagated text is visible in ChatOutput's inspection.
     const output = await runFlowAndOpenChatOutputInspection(page);
 
-    // The output Message must carry the same text the ChatInput emitted
     expect(output).toContain(inputText);
 
     await page.keyboard.press("Escape");
@@ -311,8 +316,13 @@ test(
     await page.getByTestId("showsender_name").click();
     await closeAdvancedOptions(page);
 
+    // Scope the field to the Chat Input node container so the assertion
+    // does not depend on DOM ordering once the second node is added.
+    const chatInputNode = page
+      .locator(".react-flow__node")
+      .filter({ has: page.getByTestId("title-Chat Input") });
     await expect(
-      page.getByTestId("popover-anchor-input-sender_name").first(),
+      chatInputNode.getByTestId("popover-anchor-input-sender_name"),
     ).toHaveValue("User", { timeout: 10000 });
 
     // Now do the same for Chat Output — its default sender_name must be "AI"
@@ -324,15 +334,17 @@ test(
     await page.getByTestId("showsender_name").click();
     await closeAdvancedOptions(page);
 
-    // After enabling sender_name on ChatOutput, two such inputs exist on the
-    // canvas. The first (.nth(0)) belongs to the ChatInput node added earlier
-    // and still holds "User"; the second (.nth(1)) is the ChatOutput's
-    // sender_name input, which must default to "AI".
+    // Scope each assertion to its node container — using the React Flow
+    // wrapper as the boundary keeps the test resilient to DOM ordering
+    // changes between Chat Input and Chat Output.
+    const chatOutputNode = page
+      .locator(".react-flow__node")
+      .filter({ has: page.getByTestId("title-Chat Output") });
     await expect(
-      page.getByTestId("popover-anchor-input-sender_name").nth(0),
+      chatInputNode.getByTestId("popover-anchor-input-sender_name"),
     ).toHaveValue("User");
     await expect(
-      page.getByTestId("popover-anchor-input-sender_name").nth(1),
+      chatOutputNode.getByTestId("popover-anchor-input-sender_name"),
     ).toHaveValue("AI");
   },
 );


### PR DESCRIPTION
## Summary

- New spec `tests/tests-automations/regression/core-components/chat-input-output-component-regression.spec.ts` with 6 LLM-free tests covering the canvas surface of ChatInput and ChatOutput: rendering, Message ↔ Message connection, Input Text propagation, sender_name override (validated via Playground because the canvas-side output-inspection dialog renders a Message as plain text and does not expose metadata fields), and the literal default sender_name constants from `lfx/utils/constants.py` (`"User"` / `"AI"` — no authenticated-username fallback).
- Mirrored spec doc under `docs/core-components/chat-input-output-component-regression.md` with all mandatory sections, including a note on why test #6 was reframed away from the "authenticated username" wording in the issue (the upstream code and the integration test `test_chat_input.test_default` both fix the default at the literal `"User"`).
- `QA-CHECKLIST.md` section 3.1 switched from 3 `[-]` bullets to 6 `[x]` bullets pointing at the new spec; coverage summary regenerated via `npm run coverage:summary`.

All 6 tests carry `@stable @regression @components` and pass locally against the running Langflow instance.

Closes #184

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` reports no warnings on the new spec
- [x] `npx playwright test tests/tests-automations/regression/core-components/chat-input-output-component-regression.spec.ts --workers=1` — 6/6 green locally
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)