### PR TITLE
fix(api-request): harden runAndOpenOutput helper on inspect-button enabled signal

### DIFF
--- a/docs/core-components/api-request-component-regression.md
+++ b/docs/core-components/api-request-component-regression.md
@@ -19,10 +19,8 @@ If any of these tests fails, the API Request component is broken in the product 
 
 ## Tags *(required)*
 
-10 of 13 tests: `@stable` `@regression` `@components`
+All 13 tests: `@stable` `@regression` `@components`
 8 of them additionally carry `@release` (the canvas/inspector/GET/POST/PUT/PATCH/DELETE happy paths).
-
-**`@stable` exception:** Tests 4 (`GET request returns 200`), 6 (`PUT method executes PUT verb`), and 13 (`cURL mode parses command, auto-fills URL, executes GET`) do **not** carry `@stable` — removed in the triage of weekly run [25441253323](https://github.com/oriontech-me/langflow-e2e/actions/runs/25441253323) (issue #165) after all three tests timed out on `getByText('built successfully').last()`. The shared `runAndOpenOutput` helper anchors on a fragile, repeatable toast text that can match prior toasts and gives no node-level signal. Tag is restored once the helper is hardened (see follow-up issue).
 
 ---
 

--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -31,13 +31,19 @@ async function addApiRequestComponent(page: Page) {
 
 // Helper: run the component and return the raw text content from the output inspection dialog.
 // The output Data object is displayed in a Monaco editor — textContent gives the JSON string.
+//
+// Anchors the build-finished signal on the inspect-output button becoming enabled —
+// this is the actual precondition for the next click. The previous version waited on
+// a "built successfully" toast, which matched any visible toast with that text and
+// could resolve against a stale node from a prior step before fading.
 async function runAndOpenOutput(page: Page): Promise<string> {
+  const inspectButton = page.getByTestId(
+    "output-inspection-api response-apirequest",
+  );
   await page.getByTestId("button_run_api request").click();
-  await expect(page.getByText("built successfully").last()).toBeVisible({
-    timeout: 45000,
-  });
+  await expect(inspectButton).toBeEnabled({ timeout: 45000 });
 
-  await page.getByTestId("output-inspection-api response-apirequest").click();
+  await inspectButton.click();
   const dialog = page.locator('[role="dialog"]');
   await expect(dialog).toBeVisible({ timeout: 10000 });
 
@@ -192,7 +198,7 @@ test(
 
 test(
   "API Request component — GET request returns 200 and output Data contains all required fields",
-  { tag: ["@release", "@regression", "@components"] },
+  { tag: ["@stable", "@release", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
 
@@ -251,7 +257,7 @@ test(
 
 test(
   "API Request component — PUT method executes PUT verb and returns 200",
-  { tag: ["@release", "@regression", "@components"] },
+  { tag: ["@stable", "@release", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
 
@@ -475,7 +481,7 @@ test(
 
 test(
   "API Request component — cURL mode parses command, auto-fills URL, executes GET and returns 200",
-  { tag: ["@regression", "@components"] },
+  { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
 


### PR DESCRIPTION
## Summary

- Replaces the flaky `getByText('built successfully').last()` wait in the shared `runAndOpenOutput` helper with a node-level signal: `expect(inspectButton).toBeEnabled({ timeout: 45000 })`. This is the actual precondition for the next click instead of a global toast.
- Restores `@stable` on the three tests stripped during weekly-failure triage in #178: GET (line 199), PUT (line 258), cURL run (line 482).
- Reverts the `@stable` exception paragraph in `docs/core-components/api-request-component-regression.md` so the Tags section reads `All 13 tests: @stable @regression @components` again.

## Root cause

The toast-text wait matched any visible toast containing "built successfully". When a stale toast from a prior `test.step` was still on screen, `.last()` could resolve against a node that was about to fade — the build had not actually finished yet. First-attempt 45s timeouts; all three passed on retry, classifying them as flaky in weekly-stable run [25441253323](https://github.com/oriontech-me/langflow-e2e/actions/runs/25441253323).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx eslint <spec>` clean (1 pre-existing warning on `(page as any)` unrelated to this change)
- [x] `playwright-test-linter` skill clean
- [x] 3 affected tests passed **5× in a row** locally against `langflow 1.10.0` with `--retries=0` (~20s/run)
- [x] Force-fail check: replaced testid with non-existent value → test failed as expected in 5s (no silent pass)
- [x] `--trace=on` run shows **zero** `🚨 Backend Error`

Closes #181
Closes #182
Closes #183