### PR TITLE
test(core-components): add Chat Input Files inspector field regression spec

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -159,6 +159,10 @@
 - [x] Input Text propagates from ChatInput to ChatOutput on run → `core-components/chat-input-output-component-regression.spec.ts`
 - [x] Sender name override is reflected in the Playground chat message → `core-components/chat-input-output-component-regression.spec.ts`
 - [x] Default sender_name is "User" on input and "AI" on output → `core-components/chat-input-output-component-regression.spec.ts`
+- [x] Toggling `showfiles` exposes the Files inspector field on Chat Input → `core-components/chat-input-files-field-regression.spec.ts`
+- [x] Uploading a file via the Chat Input inspector populates the Files field → `core-components/chat-input-files-field-regression.spec.ts`
+- [x] Inspector-attached file is rendered in the Playground after running ChatInput → ChatOutput → `core-components/chat-input-files-field-regression.spec.ts`
+- [x] Dismiss button on the Files field clears the value → `core-components/chat-input-files-field-regression.spec.ts`
 
 #### 3.2 Prompt Template
 - [-] Prompt with variables in curly braces

--- a/docs/core-components/chat-input-files-field-regression.md
+++ b/docs/core-components/chat-input-files-field-regression.md
@@ -6,7 +6,7 @@
 
 ## What this test validates *(required)*
 
-Validates the **canvas-side `Files` field** on the Chat Input node — the advanced FileInput surface declared in `lfx/components/input_output/chat.py:70-78` — without depending on an LLM. This is the inspector path users take to attach a file to a flow at design time, distinct from the Playground paperclip path covered by `playground-output-image.spec.ts`.
+Validates the **canvas-side `Files` field** on the Chat Input node — the advanced FileInput surface declared in `src/lfx/src/lfx/components/input_output/chat.py:70-78` — without depending on an LLM. This is the inspector path users take to attach a file to a flow at design time, distinct from the Playground paperclip path covered by `playground-output-image.spec.ts`.
 
 The 4 tests cover:
 
@@ -81,7 +81,7 @@ All 4 tests carry `@stable` per the project rule "spec is born 100% @stable; tag
 
 - `src/lfx/src/lfx/components/input_output/chat.py:70-78` — defines the FileInput `name="files"` with `advanced=True`, `is_list=True`, `temp_file=True`, `file_types=TEXT_FILE_TYPES + IMG_FILE_TYPES`. Renaming the field, dropping `advanced`, or flipping `temp_file=False` breaks Tests 1, 2, and 4.
 - `src/frontend/src/components/core/parameterRenderComponent/components/inputFileComponent/index.tsx` — renders the two branches based on `tempFile`. With `tempFile=True` (Chat Input case) it always renders the `input-file-component` text input + `button_upload_file` regardless of `ENABLE_FILE_MANAGEMENT`. The empty-value placeholder literal `"Upload a file..."` and the dismiss handler (which sets value/file_path to `""`) come from this file.
-- `src/frontend/src/CustomNodes/.../InspectionPanelEditField.tsx` — generates the `show${name}` toggle. Renaming the testid pattern breaks Test 1's toggle click and the helper used by Tests 2-4.
+- `src/frontend/src/pages/FlowPage/components/InspectionPanel/components/InspectionPanelEditField.tsx` — generates the `show${name}` toggle. Renaming the testid pattern breaks Test 1's toggle click and the helper used by Tests 2-4.
 - `src/lfx/src/lfx/schema/message.py` — `Message` carries `files: list[str | Image]` and serializes them so the Playground can render the user-side image. Test 3 depends on this propagation chain.
 - `src/frontend/src/helpers/create-file-upload.ts` — backs `handleButtonClick` on the FileInput; the hidden `<input type="file">` it creates is what `page.waitForEvent("filechooser")` captures.
 
@@ -110,7 +110,7 @@ All 4 tests carry `@stable` per the project rule "spec is born 100% @stable; tag
 
 ## When to review this test *(optional)*
 
-- If `temp_file=True` flips to `False` on the FileInput in `chat.py`, the rendering branch changes (`button_open_file_management` modal becomes the entry point) — the upload helper must be updated.
+- If `temp_file=True` flips to `False` on the FileInput in `src/lfx/src/lfx/components/input_output/chat.py`, the rendering branch changes (`button_open_file_management` modal becomes the entry point) — the upload helper must be updated.
 - If the placeholder literal in `inputFileComponent/index.tsx` changes from `"Upload a file..."`, Tests 2 and 4 fail.
 - If the server stops timestamp-prefixing uploaded filenames, the `img[alt$="chain.png"]` suffix match in Test 3 still works (no regression). If the alt attribute pattern changes, Test 3 must be updated.
 - If `is_list=True` flips to `False`, the value is stored as a string instead of a single-element array — `toHaveValue("chain.png")` still works because `Array.prototype.toString()` of `["chain.png"]` is `"chain.png"`.

--- a/docs/core-components/chat-input-files-field-regression.md
+++ b/docs/core-components/chat-input-files-field-regression.md
@@ -1,0 +1,124 @@
+# Chat Input — `Files` Inspector Field Regression
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+Validates the **canvas-side `Files` field** on the Chat Input node — the advanced FileInput surface declared in `lfx/components/input_output/chat.py:70-78` — without depending on an LLM. This is the inspector path users take to attach a file to a flow at design time, distinct from the Playground paperclip path covered by `playground-output-image.spec.ts`.
+
+The 4 tests cover:
+
+1. **`showfiles` exposes the Files inspector field** — the field is `advanced=True`, so `input-file-component` and `button_upload_file` must be absent from the DOM before the advanced toggle and visible after it (same contract as `showsender_name` validated by Test 6 of `chat-input-output-component-regression`).
+2. **Inspector upload populates the field** — clicking the upload button triggers a native file picker; setting a file via `filechooser` updates the readonly `input-file-component` value to the file name, and the upload button switches to "value present" mode (X dismiss icon revealed on hover).
+3. **Inspector-attached file participates in flow execution** — running ChatInput → ChatOutput from the Chat Output run button propagates the inspector-attached file as part of the Message; opening the Playground shows the user-side message with the image rendered as `<img alt$="chain.png">`. The signal mirrors the existing `general-bugs-shard-3836` test, but LLM-free (no Basic Prompting template, no API key).
+4. **Dismiss clears the field** — clicking the upload button while a value is present (X icon visible on hover) calls `handleDismissClick`, returning the input value to the placeholder literal `"Upload a file..."`.
+
+If any of these tests fails, the canvas-side multimodal entry point on Chat Input is broken — either the advanced field rendering contract, the inspector upload write path, runtime propagation of inspector-attached files, or the dismiss action.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@components`
+
+All 4 tests carry `@stable` per the project rule "spec is born 100% @stable; tag is removed per-test only during weekly triage".
+
+---
+
+## Step by step *(required)*
+
+**Setup helpers** (private to the spec — duplicated from `chat-input-output-component-regression` to avoid touching shared helpers in the same PR)
+
+- `addChatInputComponent(page)` — opens a blank flow, adds Chat Input via the sidebar, focuses and expands the node.
+- `addChatOutputToCanvas(page)` — drags Chat Output onto an existing flow and expands it.
+- `connectChatInputToChatOutput(page)` — clicks `handle-chatinput-shownode-chat message-right` then `handle-chatoutput-shownode-inputs-left` and asserts exactly one `.react-flow__edge` is present.
+- `toggleFilesFieldVisible(page)` — `openAdvancedOptions` → click `showfiles` → `closeAdvancedOptions`.
+- `chatInputNodeScope(page)` — returns a locator scoped to the Chat Input `.react-flow__node` container. The `input-file-component` and `button_upload_file` testids are also mounted by the side-panel/edit-fields modal even before the toggle, so all field assertions and the upload click target are scoped here.
+- `uploadFileViaInspector(page, filePath, scope)` — `waitForEvent("filechooser")`, click `scope.getByTestId("button_upload_file")`, `setFiles(filePath)` on the chooser. With `temp_file=True` the FileInput renders the simple `<input>` + button path (NOT `button_open_file_management`), so this is the only correct entry point.
+
+**Test 1 — `showfiles` exposes the Files inspector field**
+1. Run `addChatInputComponent`
+2. Scope to the Chat Input `.react-flow__node` (`chatInputNodeScope`); assert `input-file-component` and `button_upload_file` have count `0` within that scope (not on the node body — both testids are still mounted in the side-panel inspector, which is why the scope matters)
+3. Run `toggleFilesFieldVisible`
+4. Within the scope, assert `input-file-component` and `button_upload_file` are visible
+
+**Test 2 — Inspector upload populates the field**
+1. Run `addChatInputComponent` → `toggleFilesFieldVisible`
+2. Assert `input-file-component` has value `"Upload a file..."` (placeholder literal)
+3. Run `uploadFileViaInspector(page, IMAGE_PATH)` with `tests/assets/media/chain.png`
+4. Assert `input-file-component` has value `"chain.png"` (single-element list coerced to its element string by the `<input>` rendering)
+5. Hover `button_upload_file`; assert its inner `icon-X` reaches `opacity: 1` (button is in "value present" mode)
+
+**Test 3 — Inspector-attached file participates in flow execution**
+1. Run `addChatInputComponent` → `toggleFilesFieldVisible` → `uploadFileViaInspector`
+2. Assert the field value is `"chain.png"`
+3. Run `addChatOutputToCanvas` and `connectChatInputToChatOutput`
+4. Click `button_run_chat output`; wait for `"built successfully"` toast
+5. Click `playground-btn-flow-io` to open the Playground
+6. Assert `img[alt$="chain.png"]` is visible (suffix-match because the server prefixes uploaded filenames with a timestamp)
+
+**Test 4 — Dismiss clears the field**
+1. Run `addChatInputComponent` → `toggleFilesFieldVisible` → `uploadFileViaInspector`
+2. Assert the field value is `"chain.png"`
+3. Hover `button_upload_file`; assert `icon-X` has `opacity: 1`
+4. Click `button_upload_file` (in "value present" mode this calls `handleDismissClick`)
+5. Assert `input-file-component` has value `"Upload a file..."` (the placeholder literal returned by `value || "Upload a file..."` when the underlying value is `""`)
+
+---
+
+## Validation criterion *(required)*
+
+- The `Files` field is hidden until `showfiles` is toggled, then renders both `input-file-component` and `button_upload_file`.
+- A file uploaded via the inspector sets the field value to the file name and switches the upload button to "value present" mode.
+- After running ChatInput → ChatOutput from the canvas, the Playground shows the user-side message with the inspector-attached image rendered as `<img alt$="chain.png">`.
+- Clicking the upload button while a value is present clears the field back to the `"Upload a file..."` placeholder.
+
+---
+
+## External dependencies *(required)*
+
+- `src/lfx/src/lfx/components/input_output/chat.py:70-78` — defines the FileInput `name="files"` with `advanced=True`, `is_list=True`, `temp_file=True`, `file_types=TEXT_FILE_TYPES + IMG_FILE_TYPES`. Renaming the field, dropping `advanced`, or flipping `temp_file=False` breaks Tests 1, 2, and 4.
+- `src/frontend/src/components/core/parameterRenderComponent/components/inputFileComponent/index.tsx` — renders the two branches based on `tempFile`. With `tempFile=True` (Chat Input case) it always renders the `input-file-component` text input + `button_upload_file` regardless of `ENABLE_FILE_MANAGEMENT`. The empty-value placeholder literal `"Upload a file..."` and the dismiss handler (which sets value/file_path to `""`) come from this file.
+- `src/frontend/src/CustomNodes/.../InspectionPanelEditField.tsx` — generates the `show${name}` toggle. Renaming the testid pattern breaks Test 1's toggle click and the helper used by Tests 2-4.
+- `src/lfx/src/lfx/schema/message.py` — `Message` carries `files: list[str | Image]` and serializes them so the Playground can render the user-side image. Test 3 depends on this propagation chain.
+- `src/frontend/src/helpers/create-file-upload.ts` — backs `handleButtonClick` on the FileInput; the hidden `<input type="file">` it creates is what `page.waitForEvent("filechooser")` captures.
+
+---
+
+## What this test does not cover *(optional)*
+
+- **Playground-side attach/swap/remove** — already covered by `playground-output-image.spec.ts` and tracked further in #194.
+- **Non-image file type validation** — image happy path only; non-image (`text` types from `TEXT_FILE_TYPES`) is tracked in the non-image follow-up issue.
+- **File size limits and rejection** — partially covered by `limit-file-size-upload.spec.ts` for the Files page; canvas-side enforcement may diverge.
+- **`is_list=True` multi-file semantics** — only single-file upload is asserted; multi-file behavior (comma-joined display, multiple file paths in the Message) is not exercised.
+- **`button_open_file_management` path** — does not apply to Chat Input because `temp_file=True` forces the simple `<input>` + button path.
+- **Persistence to the global Files repository** — `temp_file=True` uploads do not land on the Files page; no cross-page assertion is needed and no cleanup is required.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and accessible at `PLAYWRIGHT_BASE_URL`.
+- No API key required — the spec is fully LLM-free.
+- `tests/assets/media/chain.png` must be present (already in the repo).
+- Test 3 requires the autosave/build pipeline and the Playground to be functional within the configured timeouts.
+- Chat Input starts `minimized = True` upstream; `expandFocusedNode` exposes the inspector content. If the expand testids change, all 4 tests break at the helper.
+
+---
+
+## When to review this test *(optional)*
+
+- If `temp_file=True` flips to `False` on the FileInput in `chat.py`, the rendering branch changes (`button_open_file_management` modal becomes the entry point) — the upload helper must be updated.
+- If the placeholder literal in `inputFileComponent/index.tsx` changes from `"Upload a file..."`, Tests 2 and 4 fail.
+- If the server stops timestamp-prefixing uploaded filenames, the `img[alt$="chain.png"]` suffix match in Test 3 still works (no regression). If the alt attribute pattern changes, Test 3 must be updated.
+- If `is_list=True` flips to `False`, the value is stored as a string instead of a single-element array — `toHaveValue("chain.png")` still works because `Array.prototype.toString()` of `["chain.png"]` is `"chain.png"`.
+
+---
+
+## Notes *(optional)*
+
+- The closest existing coverage of this surface is `flow-functionality/general-bugs-shard-3836.spec.ts`, but that test is `@release @components`, requires `OPENAI_API_KEY`, and uses the Basic Prompting template — so it does not run in the weekly `@stable` triage. This spec re-validates the same canvas-inspector surface in isolation, LLM-free, against a minimal ChatInput → ChatOutput flow.
+- The upstream backend integration test `src/backend/tests/integration/components/inputs/test_chat_input.py` does not assert anything about the `files` field — it covers only `text/sender/sender_name/session_id`. So the inspector-side path was previously untested both upstream and in this suite.
+- The four helper functions (`expandFocusedNode`, `addChatInputComponent`, `addChatOutputToCanvas`, `connectChatInputToChatOutput`) are duplicated from `chat-input-output-component-regression.spec.ts` to avoid editing a shared file in the same PR. A future refactor PR can extract them into `tests/helpers/`.

--- a/docs/core-components/chat-input-output-component-regression.md
+++ b/docs/core-components/chat-input-output-component-regression.md
@@ -109,7 +109,7 @@ All 6 tests carry `@stable` per the project rule "spec is born 100% @stable; tag
 
 ## What this test does not cover *(optional)*
 
-- Chat Input multimodal/file attach (future spec under `playground/` or a new `chat-input-multimodal`).
+- Chat Input multimodal/file attach via the canvas-side `Files` inspector field — covered by `chat-input-files-field-regression.spec.ts`.
 - Chat Input template variables / advanced settings beyond `sender_name`.
 - Playground rendering of the AI-side message (already covered by the Playground @stable suite).
 - Session ID isolation / context_id propagation (covered by `playground-session-id.spec.ts` and `playground-session-clear.spec.ts`).

--- a/tests/tests-automations/regression/core-components/chat-input-files-field-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/chat-input-files-field-regression.spec.ts
@@ -19,7 +19,7 @@ const IMAGE_PATH = path.resolve(
 );
 
 // Helper: expand the currently focused node from minimized to full view.
-// ChatInput defaults to `minimized = True` (lfx/components/input_output/chat.py);
+// ChatInput defaults to `minimized = True` (src/lfx/src/lfx/components/input_output/chat.py);
 // without expanding, the inspector fields rendered on the node body are not in
 // the DOM. Idempotent: no-op if the node is already expanded — that future-proofs
 // the spec against an upstream change to the `minimized` default.

--- a/tests/tests-automations/regression/core-components/chat-input-files-field-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/chat-input-files-field-regression.spec.ts
@@ -1,0 +1,255 @@
+import type { Page } from "@playwright/test";
+import path from "path";
+import { expect, test } from "../../../fixtures/fixtures";
+import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
+import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { zoomOut } from "../../../helpers/ui/zoom-out";
+import {
+  closeAdvancedOptions,
+  openAdvancedOptions,
+} from "../../../helpers/ui/open-advanced-options";
+
+// Run tests serially to avoid "flow must be unique" 400 errors from parallel autosaves
+test.describe.configure({ mode: "serial" });
+
+const IMAGE_NAME = "chain.png";
+const IMAGE_PATH = path.resolve(
+  __dirname,
+  "../../../assets/media/chain.png",
+);
+
+// Helper: expand the currently focused node from minimized to full view.
+// ChatInput defaults to `minimized = True` (lfx/components/input_output/chat.py);
+// without expanding, the inspector fields rendered on the node body are not in
+// the DOM. Idempotent: no-op if the node is already expanded — that future-proofs
+// the spec against an upstream change to the `minimized` default.
+async function expandFocusedNode(page: Page) {
+  if ((await page.getByTestId("hide-node-content").count()) === 0) return;
+  await page.getByTestId("more-options-modal").click();
+  await expect(page.getByTestId("expand-button-modal")).toBeVisible({
+    timeout: 10000,
+  });
+  await page.getByTestId("expand-button-modal").click();
+  await expect(page.getByTestId("hide-node-content")).toHaveCount(0, {
+    timeout: 5000,
+  });
+}
+
+// Helper: create a blank flow and add the Chat Input component to the canvas
+// in expanded (non-minimized) state.
+async function addChatInputComponent(page: Page) {
+  await awaitBootstrapTest(page);
+  await page.getByTestId("blank-flow").click();
+  await page.getByTestId("sidebar-search-input").fill("chat input");
+  await expect(page.getByTestId("input_outputChat Input")).toBeVisible({
+    timeout: 30000,
+  });
+  await page.getByTestId("input_outputChat Input").hover();
+  await page.getByTestId("add-component-button-chat-input").click();
+  await adjustScreenView(page);
+  await expect(page.getByTestId("title-Chat Input")).toBeVisible({
+    timeout: 15000,
+  });
+  await page.getByTestId("title-Chat Input").click();
+  await expandFocusedNode(page);
+}
+
+// Helper: drag the Chat Output component onto the canvas and expand it.
+async function addChatOutputToCanvas(page: Page) {
+  await zoomOut(page, 2);
+  await page.getByTestId("sidebar-search-input").fill("chat output");
+  await expect(page.getByTestId("input_outputChat Output")).toBeVisible({
+    timeout: 30000,
+  });
+  await page
+    .getByTestId("input_outputChat Output")
+    .dragTo(page.locator('//*[@id="react-flow-id"]'), {
+      targetPosition: { x: 100, y: 100 },
+    });
+  await adjustScreenView(page);
+  await expect(page.getByTestId("title-Chat Output")).toBeVisible({
+    timeout: 15000,
+  });
+  await page.getByTestId("title-Chat Output").click();
+  await expandFocusedNode(page);
+}
+
+// Helper: connect ChatInput "Chat Message" output → ChatOutput "Inputs" input.
+async function connectChatInputToChatOutput(page: Page) {
+  await page
+    .getByTestId("handle-chatinput-shownode-chat message-right")
+    .click();
+  await page
+    .getByTestId("handle-chatoutput-shownode-inputs-left")
+    .click();
+  await expect(page.locator(".react-flow__edge")).toHaveCount(1, {
+    timeout: 8000,
+  });
+}
+
+// Helper: toggle the advanced `Files` field visible on the focused node.
+// Mirrors the `showsender_name` toggle pattern in chat-input-output-component-regression.
+async function toggleFilesFieldVisible(page: Page) {
+  await openAdvancedOptions(page);
+  await page.getByTestId("showfiles").click();
+  await closeAdvancedOptions(page);
+}
+
+// Helper: upload a file via the Chat Input inspector's `Files` field.
+// With `temp_file=True` the FileInput renders the simple text-input + button_upload_file
+// path (inputFileComponent/index.tsx) — clicking the button opens a native file picker.
+// The button is scoped to the Chat Input node body to avoid the side-panel duplicate
+// of the same testid.
+async function uploadFileViaInspector(
+  page: Page,
+  filePath: string,
+  scope: ReturnType<Page["locator"]> = page.locator("body"),
+) {
+  const fileChooserPromise = page.waitForEvent("filechooser");
+  await scope.getByTestId("button_upload_file").click();
+  const fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles(filePath);
+}
+
+// Helper: returns a locator scoped to the Chat Input React Flow node container.
+function chatInputNodeScope(page: Page) {
+  return page
+    .locator(".react-flow__node")
+    .filter({ has: page.getByTestId("title-Chat Input") });
+}
+
+// =============================================================================
+// Test 1 — Files field is hidden by default and exposed by toggling `showfiles`
+// =============================================================================
+
+test(
+  "Chat Input — toggling `showfiles` exposes the Files inspector field",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    await addChatInputComponent(page);
+
+    // Scope to the Chat Input node body. The `input-file-component` testid is also
+    // mounted by the advanced-options side panel even before the toggle, so an
+    // unscoped assertion would always see count >= 1. The contract under test is
+    // "field appears on the node body after toggle" — the React Flow node wrapper
+    // is the right boundary.
+    const chatInputNode = chatInputNodeScope(page);
+
+    // Before the toggle the advanced field must not render on the node body
+    await expect(
+      chatInputNode.getByTestId("input-file-component"),
+    ).toHaveCount(0);
+    await expect(
+      chatInputNode.getByTestId("button_upload_file"),
+    ).toHaveCount(0);
+
+    await toggleFilesFieldVisible(page);
+
+    // After toggling, both controls render on the node body
+    await expect(
+      chatInputNode.getByTestId("input-file-component"),
+    ).toBeVisible({ timeout: 10000 });
+    await expect(
+      chatInputNode.getByTestId("button_upload_file"),
+    ).toBeVisible();
+  },
+);
+
+// =============================================================================
+// Test 2 — Uploading a file via the inspector populates the Files field value
+// =============================================================================
+
+test(
+  "Chat Input — uploading via the inspector populates the Files field",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    await addChatInputComponent(page);
+    await toggleFilesFieldVisible(page);
+
+    const chatInputNode = chatInputNodeScope(page);
+    const fileInput = chatInputNode.getByTestId("input-file-component");
+    const uploadButton = chatInputNode.getByTestId("button_upload_file");
+
+    // Empty state: the readonly input shows the placeholder literal
+    await expect(fileInput).toHaveValue("Upload a file...");
+
+    await uploadFileViaInspector(page, IMAGE_PATH, chatInputNode);
+
+    // After upload, the field value reflects the original file name. `is_list=True`
+    // stores the value as `[file.name]`; the <input> coerces a single-element array
+    // to its element string when rendering.
+    await expect(fileInput).toHaveValue(IMAGE_NAME, { timeout: 15000 });
+
+    // Hovering the upload button reveals the dismiss icon — confirms the button
+    // has switched into "value present" mode (handleDismissClick on click).
+    await uploadButton.hover();
+    await expect(uploadButton.getByTestId("icon-X")).toHaveCSS("opacity", "1");
+  },
+);
+
+// =============================================================================
+// Test 3 — Inspector-attached file propagates to the Playground rendering
+// =============================================================================
+
+test(
+  "Chat Input → Chat Output — inspector-attached file is rendered in the Playground message",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    await addChatInputComponent(page);
+    await toggleFilesFieldVisible(page);
+
+    const chatInputNode = chatInputNodeScope(page);
+    await uploadFileViaInspector(page, IMAGE_PATH, chatInputNode);
+    await expect(
+      chatInputNode.getByTestId("input-file-component"),
+    ).toHaveValue(IMAGE_NAME, { timeout: 15000 });
+
+    await addChatOutputToCanvas(page);
+    await connectChatInputToChatOutput(page);
+
+    // Run the flow from the Chat Output run button — this invokes ChatInput.message_response()
+    // with `self.files` populated by the inspector upload, then propagates to ChatOutput.
+    await page.getByTestId("button_run_chat output").click();
+    await expect(page.getByText("built successfully").last()).toBeVisible({
+      timeout: 45000,
+    });
+
+    // Open the Playground — the run history must show the user-side message
+    // with the inspector-attached image rendered as <img>.
+    await page.getByTestId("playground-btn-flow-io").click();
+    // The server prefixes uploaded filenames with a timestamp (e.g. `2026-05-08_..._chain.png`),
+    // so match the alt attribute by suffix rather than exact value.
+    await expect(page.locator('img[alt$="chain.png"]')).toBeVisible({
+      timeout: 30000,
+    });
+  },
+);
+
+// =============================================================================
+// Test 4 — Removing the file via the inspector returns the field to empty
+// =============================================================================
+
+test(
+  "Chat Input — clicking the dismiss button on the Files field clears the value",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    await addChatInputComponent(page);
+    await toggleFilesFieldVisible(page);
+
+    const chatInputNode = chatInputNodeScope(page);
+    const fileInput = chatInputNode.getByTestId("input-file-component");
+    const uploadButton = chatInputNode.getByTestId("button_upload_file");
+
+    await uploadFileViaInspector(page, IMAGE_PATH, chatInputNode);
+    await expect(fileInput).toHaveValue(IMAGE_NAME, { timeout: 15000 });
+
+    // The button is in "value present" mode: hovering reveals the X icon and
+    // clicking calls handleDismissClick (which sets value/file_path to "").
+    await uploadButton.hover();
+    await expect(uploadButton.getByTestId("icon-X")).toHaveCSS("opacity", "1");
+    await uploadButton.click();
+
+    // After dismiss, value is "" and the input falls back to the placeholder literal.
+    await expect(fileInput).toHaveValue("Upload a file...", { timeout: 10000 });
+  },
+);

--- a/tests/tests-automations/regression/core-components/chat-input-files-field-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/chat-input-files-field-regression.spec.ts
@@ -126,8 +126,6 @@ test(
   "Chat Input — toggling `showfiles` exposes the Files inspector field",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    await addChatInputComponent(page);
-
     // Scope to the Chat Input node body. The `input-file-component` testid is also
     // mounted by the advanced-options side panel even before the toggle, so an
     // unscoped assertion would always see count >= 1. The contract under test is
@@ -135,23 +133,40 @@ test(
     // is the right boundary.
     const chatInputNode = chatInputNodeScope(page);
 
-    // Before the toggle the advanced field must not render on the node body
-    await expect(
-      chatInputNode.getByTestId("input-file-component"),
-    ).toHaveCount(0);
-    await expect(
-      chatInputNode.getByTestId("button_upload_file"),
-    ).toHaveCount(0);
+    await test.step("Add Chat Input to a blank flow", async () => {
+      await addChatInputComponent(page);
+    });
 
-    await toggleFilesFieldVisible(page);
+    await test.step(
+      "Files field is absent from the node body before the showfiles toggle",
+      async () => {
+        await expect(
+          chatInputNode.getByTestId("input-file-component"),
+        ).toHaveCount(0);
+        await expect(
+          chatInputNode.getByTestId("button_upload_file"),
+        ).toHaveCount(0);
+      },
+    );
 
-    // After toggling, both controls render on the node body
-    await expect(
-      chatInputNode.getByTestId("input-file-component"),
-    ).toBeVisible({ timeout: 10000 });
-    await expect(
-      chatInputNode.getByTestId("button_upload_file"),
-    ).toBeVisible();
+    await test.step(
+      "Toggle showfiles via the advanced-options panel",
+      async () => {
+        await toggleFilesFieldVisible(page);
+      },
+    );
+
+    await test.step(
+      "Files field controls are visible on the node body after the toggle",
+      async () => {
+        await expect(
+          chatInputNode.getByTestId("input-file-component"),
+        ).toBeVisible({ timeout: 10000 });
+        await expect(
+          chatInputNode.getByTestId("button_upload_file"),
+        ).toBeVisible();
+      },
+    );
   },
 );
 
@@ -163,27 +178,51 @@ test(
   "Chat Input — uploading via the inspector populates the Files field",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    await addChatInputComponent(page);
-    await toggleFilesFieldVisible(page);
-
     const chatInputNode = chatInputNodeScope(page);
     const fileInput = chatInputNode.getByTestId("input-file-component");
     const uploadButton = chatInputNode.getByTestId("button_upload_file");
 
-    // Empty state: the readonly input shows the placeholder literal
-    await expect(fileInput).toHaveValue("Upload a file...");
+    await test.step(
+      "Add Chat Input and expose the Files field via showfiles",
+      async () => {
+        await addChatInputComponent(page);
+        await toggleFilesFieldVisible(page);
+      },
+    );
 
-    await uploadFileViaInspector(page, IMAGE_PATH, chatInputNode);
+    await test.step(
+      "Empty state shows the placeholder literal in the readonly input",
+      async () => {
+        await expect(fileInput).toHaveValue("Upload a file...");
+      },
+    );
 
-    // After upload, the field value reflects the original file name. `is_list=True`
-    // stores the value as `[file.name]`; the <input> coerces a single-element array
-    // to its element string when rendering.
-    await expect(fileInput).toHaveValue(IMAGE_NAME, { timeout: 15000 });
+    await test.step(
+      "Upload chain.png via the inspector upload button",
+      async () => {
+        await uploadFileViaInspector(page, IMAGE_PATH, chatInputNode);
+      },
+    );
 
-    // Hovering the upload button reveals the dismiss icon — confirms the button
-    // has switched into "value present" mode (handleDismissClick on click).
-    await uploadButton.hover();
-    await expect(uploadButton.getByTestId("icon-X")).toHaveCSS("opacity", "1");
+    await test.step(
+      "Field value reflects the original file name after upload",
+      async () => {
+        // `is_list=True` stores the value as `[file.name]`; the <input> coerces a
+        // single-element array to its element string when rendering.
+        await expect(fileInput).toHaveValue(IMAGE_NAME, { timeout: 15000 });
+      },
+    );
+
+    await test.step(
+      "Upload button switches to dismiss mode (X icon revealed on hover)",
+      async () => {
+        await uploadButton.hover();
+        await expect(uploadButton.getByTestId("icon-X")).toHaveCSS(
+          "opacity",
+          "1",
+        );
+      },
+    );
   },
 );
 
@@ -195,33 +234,51 @@ test(
   "Chat Input → Chat Output — inspector-attached file is rendered in the Playground message",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    await addChatInputComponent(page);
-    await toggleFilesFieldVisible(page);
-
     const chatInputNode = chatInputNodeScope(page);
-    await uploadFileViaInspector(page, IMAGE_PATH, chatInputNode);
-    await expect(
-      chatInputNode.getByTestId("input-file-component"),
-    ).toHaveValue(IMAGE_NAME, { timeout: 15000 });
 
-    await addChatOutputToCanvas(page);
-    await connectChatInputToChatOutput(page);
+    await test.step(
+      "Add Chat Input, expose Files, and upload chain.png via the inspector",
+      async () => {
+        await addChatInputComponent(page);
+        await toggleFilesFieldVisible(page);
+        await uploadFileViaInspector(page, IMAGE_PATH, chatInputNode);
+        await expect(
+          chatInputNode.getByTestId("input-file-component"),
+        ).toHaveValue(IMAGE_NAME, { timeout: 15000 });
+      },
+    );
 
-    // Run the flow from the Chat Output run button — this invokes ChatInput.message_response()
-    // with `self.files` populated by the inspector upload, then propagates to ChatOutput.
-    await page.getByTestId("button_run_chat output").click();
-    await expect(page.getByText("built successfully").last()).toBeVisible({
-      timeout: 45000,
-    });
+    await test.step(
+      "Add Chat Output and connect ChatInput → ChatOutput",
+      async () => {
+        await addChatOutputToCanvas(page);
+        await connectChatInputToChatOutput(page);
+      },
+    );
 
-    // Open the Playground — the run history must show the user-side message
-    // with the inspector-attached image rendered as <img>.
-    await page.getByTestId("playground-btn-flow-io").click();
-    // The server prefixes uploaded filenames with a timestamp (e.g. `2026-05-08_..._chain.png`),
-    // so match the alt attribute by suffix rather than exact value.
-    await expect(page.locator('img[alt$="chain.png"]')).toBeVisible({
-      timeout: 30000,
-    });
+    await test.step(
+      "Run the flow from the Chat Output run button",
+      async () => {
+        // Invokes ChatInput.message_response() with `self.files` populated by the
+        // inspector upload, then propagates to ChatOutput.
+        await page.getByTestId("button_run_chat output").click();
+        await expect(page.getByText("built successfully").last()).toBeVisible({
+          timeout: 45000,
+        });
+      },
+    );
+
+    await test.step(
+      "Open the Playground and verify the inspector-attached image rendered",
+      async () => {
+        await page.getByTestId("playground-btn-flow-io").click();
+        // The server prefixes uploaded filenames with a timestamp (e.g.
+        // `2026-05-08_..._chain.png`), so match the alt attribute by suffix.
+        await expect(page.locator('img[alt$="chain.png"]')).toBeVisible({
+          timeout: 30000,
+        });
+      },
+    );
   },
 );
 
@@ -233,23 +290,41 @@ test(
   "Chat Input — clicking the dismiss button on the Files field clears the value",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    await addChatInputComponent(page);
-    await toggleFilesFieldVisible(page);
-
     const chatInputNode = chatInputNodeScope(page);
     const fileInput = chatInputNode.getByTestId("input-file-component");
     const uploadButton = chatInputNode.getByTestId("button_upload_file");
 
-    await uploadFileViaInspector(page, IMAGE_PATH, chatInputNode);
-    await expect(fileInput).toHaveValue(IMAGE_NAME, { timeout: 15000 });
+    await test.step(
+      "Add Chat Input, expose Files, and upload chain.png",
+      async () => {
+        await addChatInputComponent(page);
+        await toggleFilesFieldVisible(page);
+        await uploadFileViaInspector(page, IMAGE_PATH, chatInputNode);
+        await expect(fileInput).toHaveValue(IMAGE_NAME, { timeout: 15000 });
+      },
+    );
 
-    // The button is in "value present" mode: hovering reveals the X icon and
-    // clicking calls handleDismissClick (which sets value/file_path to "").
-    await uploadButton.hover();
-    await expect(uploadButton.getByTestId("icon-X")).toHaveCSS("opacity", "1");
-    await uploadButton.click();
+    await test.step(
+      "Click the upload button while a value is present (dismiss mode)",
+      async () => {
+        // Hovering must reveal the X icon — confirms the button is in
+        // "value present" mode (handleDismissClick on click).
+        await uploadButton.hover();
+        await expect(uploadButton.getByTestId("icon-X")).toHaveCSS(
+          "opacity",
+          "1",
+        );
+        await uploadButton.click();
+      },
+    );
 
-    // After dismiss, value is "" and the input falls back to the placeholder literal.
-    await expect(fileInput).toHaveValue("Upload a file...", { timeout: 10000 });
+    await test.step(
+      "Field value falls back to the placeholder literal after dismiss",
+      async () => {
+        await expect(fileInput).toHaveValue("Upload a file...", {
+          timeout: 10000,
+        });
+      },
+    );
   },
 );


### PR DESCRIPTION
## Summary

- Adds 4 LLM-free `@stable @regression @components` tests covering the canvas-side `Files` inspector field on Chat Input (`lfx/components/input_output/chat.py:70-78`) — the field PR #192 explicitly excluded.
- Updates `chat-input-output-component-regression.md` to point its "does not cover" line to the new spec, and `QA-CHECKLIST.md` section 3.1 with 4 new bullets.

Closes #196

## Tests

| # | Test | Signal |
|---|---|---|
| 1 | `showfiles` toggle exposes the field on the node body | `input-file-component` + `button_upload_file` count goes 0 → visible within `.react-flow__node` scope |
| 2 | Inspector upload populates the field | `input-file-component` value: `"Upload a file..."` → `"chain.png"`; `button_upload_file` enters dismiss mode (X icon `opacity: 1` on hover) |
| 3 | Inspector-attached file participates in flow execution | After running ChatInput → ChatOutput via `button_run_chat output`, opening the Playground shows `img[alt$="chain.png"]` (suffix-match because the server prepends a timestamp) |
| 4 | Dismiss returns the field to empty | Click on `button_upload_file` in "value present" mode → `input-file-component` value back to `"Upload a file..."` |

## Pre-implementation research

Per the issue's "Please research before implementing" section:

1. **Suite coverage gap confirmed.** `grep -rn "showfiles\|input-file-component\|button_upload_file" tests/tests-automations/regression/` matches only `flow-functionality/general-bugs-shard-3836.spec.ts`, which is `@release @components`, requires `OPENAI_API_KEY`, and uses the Basic Prompting template — so it does not run in the weekly `@stable` triage. The `@stable` cohort had **zero** coverage of this surface.
2. **Upstream tests checked.** `src/frontend/tests/core/unit/chatInputOutput.spec.ts` covers ChatInput → ChatOutput pass-through but not the Files field. `src/backend/tests/integration/components/inputs/test_chat_input.py` only asserts `text/sender/sender_name/session_id` — no `files` assertion. `playground-output-image.spec.ts` covers the Playground paperclip path (`input-wrapper input[type=file]`), which is a **different surface** from the canvas inspector.
3. **Branch chosen empirically.** `inputFileComponent/index.tsx:215` shows the `temp_file=True` branch always renders the simple `<input>` + `button_upload_file` (NOT `button_open_file_management`), regardless of `ENABLE_FILE_MANAGEMENT`. The tests target this branch only.
4. **No persistence side effect.** `temp_file=True` uploads do not land on the global Files page — no cleanup is necessary.

## Notable design decisions

- **Helpers duplicated** from `chat-input-output-component-regression.spec.ts` (private to the new file) to avoid touching shared helpers in the same PR. A future refactor PR can extract them into `tests/helpers/`.
- **Scope all field assertions and the upload click target to `.react-flow__node`.** The `input-file-component` and `button_upload_file` testids are also mounted in the side-panel inspector (count >= 1 even before `showfiles` is toggled) — without scoping, Test 1 fails on the "absent before toggle" assertion. Same scoping pattern Test 5/6 of the chat-input-output spec already uses for `popover-anchor-input-sender_name`.

## Test plan

- [x] `npx playwright test tests/tests-automations/regression/core-components/chat-input-files-field-regression.spec.ts --trace=on` — 4/4 pass in 24.2s
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — new file clean (only pre-existing warnings on other files)
- [x] No backend errors logged via fixture monitor during the run
- [x] `QA-CHECKLIST.md` section 3.1 updated; Phase 0 — Validated block left untouched (auto-regenerated from `@stable` tags by `update-coverage-summary.yml`)