### PR TITLE
chore(checklist): auto-regenerate Phase tables and Last updated

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -797,7 +797,7 @@
 |--------|-----------------|---------------|
 | `api/flows/` — REST API | 21 | 0 |
 | `core-components/` — Component Config | 20 | 2 |
-| `core-components/` — Core Components | 18 | 9 |
+| `core-components/` — Core Components | 7 | 5 |
 | `core-functionality/auth/` | 18 | 1 |
 | `core-functionality/llm-agents/` | 2 | 25 |
 | `core-functionality/model-provider/` | 18 | 9 |
@@ -816,7 +816,7 @@
 |--------|-----------------|---------------|
 | `core-functionality/observability-monitoring/` | 12 | 1 |
 | `core-functionality/knowledge-ingestion/` | 4 | 4 |
-| `flow-functionality/` | 20 | 0 |
+| `flow-functionality/` | 21 | 0 |
 | `core-functionality/project-management/` | 10 | 0 |
 | `core-functionality/templates/` | 39 | 0 |
 | `ui-ux/` — Settings | 3 | 0 |

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -3,7 +3,7 @@
 > **Repository:** `C:/QAx/langflow-playwright/langflow-e2e`
 > **Tests:** `tests/tests-automations/regression/`
 > **Config:** `playwright.config.ts`
-> **Last updated:** 2026-05-05
+> **Last updated:** 2026-05-08
 
 ---
 

--- a/scripts/coverage-summary.ts
+++ b/scripts/coverage-summary.ts
@@ -53,6 +53,18 @@ const TABLE_HEADER =
 const TABLE_SEPARATOR =
   "|--------|-------|-----------------|------------------------|---------------------|---------------------|";
 
+const PHASE_HEADERS = [
+  "### 🔵 Phase 1 — Next Delivery",
+  "### 🟡 Phase 2 — Next Delivery",
+] as const;
+
+const PHASE_TABLE_HEADER_PREFIX = "| Module | Validate";
+
+const PHASE_TABLE_HEADER =
+  "| Module | Validate (`[-]`) | Create (`[ ]`) |";
+const PHASE_TABLE_SEPARATOR =
+  "|--------|-----------------|---------------|";
+
 const BULLET_RE = /^- \[([x\- ~!])\] /;
 
 interface Counts {
@@ -210,6 +222,81 @@ function regenerateCoverageTable(
   return [...before, ...newTable, ...after];
 }
 
+function regeneratePhaseTables(lines: string[], counts: Counts[]): string[] {
+  const labelToIndex = new Map<string, number>();
+  MODULES.forEach((m, i) => labelToIndex.set(m.label, i));
+
+  let working = lines.slice();
+
+  for (let phaseIdx = 0; phaseIdx < PHASE_HEADERS.length; phaseIdx++) {
+    const phaseNumber = phaseIdx + 1;
+    const phaseHeader = PHASE_HEADERS[phaseIdx];
+
+    const headerLine = findLineIndex(working, (l) => l.trim() === phaseHeader);
+    if (headerLine === -1) {
+      throw new Error(`Phase ${phaseNumber} header not found: "${phaseHeader}"`);
+    }
+
+    // Bound the search to before the next phase header (if any) so a missing
+    // table header in this phase fails loudly instead of silently borrowing
+    // the next phase's header.
+    const nextPhaseHeader = PHASE_HEADERS[phaseIdx + 1];
+    const upperBound =
+      nextPhaseHeader !== undefined
+        ? findLineIndex(working, (l) => l.trim() === nextPhaseHeader, headerLine + 1)
+        : working.length;
+    const searchEnd = upperBound === -1 ? working.length : upperBound;
+
+    const tableHeaderIdx = findLineIndex(
+      working,
+      (l) => l.startsWith(PHASE_TABLE_HEADER_PREFIX),
+      headerLine,
+      searchEnd
+    );
+    if (tableHeaderIdx === -1) {
+      throw new Error(
+        `Phase ${phaseNumber} table header not found after "${phaseHeader}" (expected line starting with "${PHASE_TABLE_HEADER_PREFIX}")`
+      );
+    }
+
+    let tableEndIdx = tableHeaderIdx;
+    while (tableEndIdx + 1 < working.length && working[tableEndIdx + 1].startsWith("|")) {
+      tableEndIdx++;
+    }
+
+    // Data rows are everything between the separator (tableHeaderIdx + 2) and tableEndIdx, inclusive.
+    const dataStart = tableHeaderIdx + 2;
+    const dataLines = working.slice(dataStart, tableEndIdx + 1);
+
+    if (dataLines.length === 0) {
+      throw new Error(`Phase ${phaseNumber} table is empty — at least one module required`);
+    }
+
+    const newRows: string[] = [];
+    for (const row of dataLines) {
+      // Strip leading/trailing pipes, take first cell, trim.
+      const cells = row.split("|");
+      // First element is "" (before leading pipe), second is the label cell.
+      const label = (cells[1] ?? "").trim();
+      const moduleIdx = labelToIndex.get(label);
+      if (moduleIdx === undefined) {
+        throw new Error(
+          `Phase ${phaseNumber} row "${label}" does not match any module in MODULES — rename or remove the row`
+        );
+      }
+      const c = counts[moduleIdx];
+      newRows.push(`| ${label} | ${c.needsValidation} | ${c.notAutomated} |`);
+    }
+
+    const newBlock = [PHASE_TABLE_HEADER, PHASE_TABLE_SEPARATOR, ...newRows];
+    const before = working.slice(0, tableHeaderIdx);
+    const after = working.slice(tableEndIdx + 1);
+    working = [...before, ...newBlock, ...after];
+  }
+
+  return working;
+}
+
 function main(): void {
   const filePath = path.resolve(__dirname, "..", "QA-CHECKLIST.md");
   const original = fs.readFileSync(filePath, "utf-8");
@@ -219,18 +306,19 @@ function main(): void {
   if (trailingNewline) lines.pop();
 
   const counts = computeCounts(lines);
-  const updated = regenerateCoverageTable(lines, counts);
+  let updated = regenerateCoverageTable(lines, counts);
+  updated = regeneratePhaseTables(updated, counts);
 
   let output = updated.join("\n");
   if (trailingNewline) output += "\n";
 
   if (output === original) {
-    console.log("Coverage Summary table is already up to date — no changes.");
+    console.log("QA-CHECKLIST.md is already up to date — no changes.");
     return;
   }
 
   fs.writeFileSync(filePath, output, "utf-8");
-  console.log("Coverage Summary table updated in QA-CHECKLIST.md");
+  console.log("QA-CHECKLIST.md updated (Coverage Summary and/or Phase tables).");
 }
 
 main();

--- a/scripts/coverage-summary.ts
+++ b/scripts/coverage-summary.ts
@@ -1,11 +1,13 @@
 /**
- * Regenerates the Coverage Summary table in QA-CHECKLIST.md from the bullet
- * markers (`[x]`, `[-]`, `[ ]`, `[~]`, `[!]`) inside Part II.
+ * Regenerates three auto-generated blocks in QA-CHECKLIST.md:
+ *   1. The Coverage Summary table (counts per module from `[x]`/`[-]`/`[ ]`/`[~]`/`[!]` bullets in Part II).
+ *   2. The Phase 1 / Phase 2 delivery tables (per-module `[-]` and `[ ]` counts; phase membership read from the file).
+ *   3. The `> **Last updated:**` date stamp in the document header.
  *
  * Run: `npx ts-node scripts/coverage-summary.ts`
  *
- * Idempotent: a second run produces no diff when the table is already in
- * sync with the bullets above it.
+ * Idempotent within the same UTC day: a second run produces no diff when the
+ * file is already in sync with the bullets above and the date hasn't changed.
  */
 
 import * as fs from "fs";
@@ -64,6 +66,8 @@ const PHASE_TABLE_HEADER =
   "| Module | Validate (`[-]`) | Create (`[ ]`) |";
 const PHASE_TABLE_SEPARATOR =
   "|--------|-----------------|---------------|";
+
+const LAST_UPDATED_PREFIX = "> **Last updated:**";
 
 const BULLET_RE = /^- \[([x\- ~!])\] /;
 
@@ -297,6 +301,19 @@ function regeneratePhaseTables(lines: string[], counts: Counts[]): string[] {
   return working;
 }
 
+function regenerateLastUpdated(lines: string[]): string[] {
+  const idx = findLineIndex(lines, (l) => l.startsWith(LAST_UPDATED_PREFIX));
+  if (idx === -1) {
+    throw new Error(
+      `"Last updated:" line not found — expected a line starting with "${LAST_UPDATED_PREFIX}"`
+    );
+  }
+  const today = new Date().toISOString().slice(0, 10);
+  const next = lines.slice();
+  next[idx] = `${LAST_UPDATED_PREFIX} ${today}`;
+  return next;
+}
+
 function main(): void {
   const filePath = path.resolve(__dirname, "..", "QA-CHECKLIST.md");
   const original = fs.readFileSync(filePath, "utf-8");
@@ -308,6 +325,7 @@ function main(): void {
   const counts = computeCounts(lines);
   let updated = regenerateCoverageTable(lines, counts);
   updated = regeneratePhaseTables(updated, counts);
+  updated = regenerateLastUpdated(updated);
 
   let output = updated.join("\n");
   if (trailingNewline) output += "\n";
@@ -318,7 +336,7 @@ function main(): void {
   }
 
   fs.writeFileSync(filePath, output, "utf-8");
-  console.log("QA-CHECKLIST.md updated (Coverage Summary and/or Phase tables).");
+  console.log("QA-CHECKLIST.md updated (Coverage Summary, Phase tables, and/or Last updated).");
 }
 
 main();

--- a/scripts/coverage-summary.ts
+++ b/scripts/coverage-summary.ts
@@ -98,7 +98,7 @@ function fmtPercent(part: number, whole: number): string {
   return `${Math.round((part / whole) * 100)}%`;
 }
 
-function regenerate(lines: string[]): string[] {
+function computeCounts(lines: string[]): Counts[] {
   const partIIStart = findLineIndex(lines, (l) => l.trim() === PART_II_HEADER);
   if (partIIStart === -1) {
     throw new Error(`Part II header not found: "${PART_II_HEADER}"`);
@@ -113,7 +113,6 @@ function regenerate(lines: string[]): string[] {
     throw new Error(`Coverage Summary header not found: "${COVERAGE_SUMMARY_HEADER_PREFIX}"`);
   }
 
-  // Resolve each module's start line within Part II.
   const moduleStarts: number[] = MODULES.map((m) => {
     const idx = findLineIndex(
       lines,
@@ -129,7 +128,6 @@ function regenerate(lines: string[]): string[] {
     return idx;
   });
 
-  // Sanity check: starts must be strictly increasing — otherwise MODULES is misordered.
   for (let i = 1; i < moduleStarts.length; i++) {
     if (moduleStarts[i] <= moduleStarts[i - 1]) {
       throw new Error(
@@ -138,7 +136,6 @@ function regenerate(lines: string[]): string[] {
     }
   }
 
-  // Count bullets per module.
   const counts: Counts[] = MODULES.map(() => emptyCounts());
   for (let m = 0; m < MODULES.length; m++) {
     const start = moduleStarts[m] + 1;
@@ -151,7 +148,27 @@ function regenerate(lines: string[]): string[] {
     }
   }
 
-  // Aggregate TOTAL row.
+  return counts;
+}
+
+function regenerateCoverageTable(
+  lines: string[],
+  counts: Counts[]
+): string[] {
+  const partIIStart = findLineIndex(lines, (l) => l.trim() === PART_II_HEADER);
+  if (partIIStart === -1) {
+    throw new Error(`Part II header not found: "${PART_II_HEADER}"`);
+  }
+
+  const coverageHeader = findLineIndex(
+    lines,
+    (l) => l.startsWith(COVERAGE_SUMMARY_HEADER_PREFIX),
+    partIIStart
+  );
+  if (coverageHeader === -1) {
+    throw new Error(`Coverage Summary header not found: "${COVERAGE_SUMMARY_HEADER_PREFIX}"`);
+  }
+
   const tot = emptyCounts();
   for (const c of counts) {
     tot.validated += c.validated;
@@ -161,7 +178,6 @@ function regenerate(lines: string[]): string[] {
   }
   const totSum = totalOf(tot);
 
-  // Build the new table block.
   const dataRows = MODULES.map((m, i) => {
     const c = counts[i];
     return `| ${m.label} | ${totalOf(c)} | ${c.validated} | ${c.needsValidation} | ${c.partial} | ${c.notAutomated} |`;
@@ -175,8 +191,6 @@ function regenerate(lines: string[]): string[] {
 
   const newTable = [TABLE_HEADER, TABLE_SEPARATOR, ...dataRows, totalRow];
 
-  // Replace the existing table block: from the `| Module | Total |` line through the
-  // last consecutive line that starts with `|`.
   const tableHeaderIdx = findLineIndex(
     lines,
     (l) => l.startsWith(TABLE_HEADER_PREFIX),
@@ -201,12 +215,12 @@ function main(): void {
   const original = fs.readFileSync(filePath, "utf-8");
   const trailingNewline = original.endsWith("\n");
 
-  // Drop the empty trailing element produced by split when the file ends with `\n`,
-  // then add the newline back at write time so the file shape is preserved.
   const lines = original.split("\n");
   if (trailingNewline) lines.pop();
 
-  const updated = regenerate(lines);
+  const counts = computeCounts(lines);
+  const updated = regenerateCoverageTable(lines, counts);
+
   let output = updated.join("\n");
   if (trailingNewline) output += "\n";
 


### PR DESCRIPTION
## Summary

- Splits `scripts/coverage-summary.ts` into `computeCounts` + three `regenerate*` steps that share the same per-module `Counts[]`.
- Adds `regeneratePhaseTables`: rebuilds the numeric columns of the Phase 1 and Phase 2 tables in `QA-CHECKLIST.md` while preserving the existing module ordering and phase membership read from the file. Throws on label drift (`Phase N row "<label>" does not match any module in MODULES`) so silent desync becomes a CI failure — same approach as #153.
- Adds `regenerateLastUpdated`: rewrites the `> **Last updated:**` line with today's date.
- Updates the file-level JSDoc and console messages to reflect the three regeneration steps.

Fixes the two drift rows reported in #156:

| Module | Phase tables before | After (matches Coverage Summary) |
|---|---|---|
| `core-components/` — Core Components | 18 / 9 | 7 / 5 |
| `flow-functionality/` | 20 / 0 | 21 / 0 |

Note: the issue text predicted `12 / 15` for the first row; the actual value is `7 / 5` because bullets in Part II have evolved since the issue was filed. The script now keeps Phase tables in sync with the Coverage Summary table — that is the contract the issue requires.

`MODULES` stays the single source of truth for module labels. Phase membership stays under human control by living in the `.md` file. No changes to `update-coverage-summary.yml` — its `paths:` filter and `[skip ci]` already cover this work.

Closes #156.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (no new warnings introduced)
- [x] Running `npm run coverage:summary` against `main` produces exactly three line changes (two Phase rows + `Last updated:`)
- [x] Running it a second time on the same day is a no-op (`QA-CHECKLIST.md is already up to date — no changes.`)
- [x] Force-fail: renaming a Phase row label to a non-MODULES value throws `Phase N row "<label>" does not match any module in MODULES — rename or remove the row`
- [x] Force-fail: deleting Phase 1's table header throws `Phase 1 table header not found...` (bounded search prevents silent corruption of Phase 2)
- [x] Force-fail: deleting the `Last updated:` line throws `"Last updated:" line not found — expected a line starting with "> **Last updated:**"`