### PR TITLE
fix(ci): pass fixed LANGFLOW_SECRET_KEY to both containers in migration-test

### DIFF
--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -13,6 +13,9 @@ env:
   PG_DB: langflow
   STATE_FILE: /tmp/migration-test-state.json
   REPORT_FILE: /tmp/migration-report.md
+  # Fixed key shared by both containers so credentials encrypted by latest
+  # can be decrypted by nightly after DB migration.
+  LANGFLOW_SECRET_KEY: "migration-test-fixed-secret-32chars!!"
 
 permissions:
   contents: read
@@ -68,6 +71,7 @@ jobs:
             -e LANGFLOW_SUPERUSER=langflow \
             -e LANGFLOW_SUPERUSER_PASSWORD=langflow123 \
             -e LANGFLOW_STORE=false \
+            -e LANGFLOW_SECRET_KEY="$LANGFLOW_SECRET_KEY" \
             langflowai/langflow:latest
 
       - name: Wait for Langflow latest
@@ -102,6 +106,7 @@ jobs:
             -e LANGFLOW_SUPERUSER=langflow \
             -e LANGFLOW_SUPERUSER_PASSWORD=langflow123 \
             -e LANGFLOW_STORE=false \
+            -e LANGFLOW_SECRET_KEY="$LANGFLOW_SECRET_KEY" \
             langflowai/langflow-nightly:latest
 
       - name: Wait for Langflow nightly (includes migration)


### PR DESCRIPTION
## Problem

The `migration-test` workflow was failing at `execute_flow_api` on the nightly phase with:
```
HTTP 500: Error building Component OpenAI: The api_key client option must be set
```

Even though `variables_preserved = True` confirmed the `OPENAI_API_KEY` global variable was in the database after migration.

## Root cause (validated locally)

Langflow encrypts credential values using `LANGFLOW_SECRET_KEY`. Without a fixed key, each container generates its own key on startup:

- `langflow:latest` encrypts `OPENAI_API_KEY` with key **A**
- `langflow-nightly` starts with key **B** → decryption silently returns empty → OpenAI SDK receives no key

**Validation:** Running the same flow on nightly with the variable set *directly* on nightly works perfectly (`2+2 = 4`). The problem is exclusively the cross-container decryption mismatch.

## Fix

Added a fixed `LANGFLOW_SECRET_KEY` to the workflow `env` block and passed it to both containers via `-e LANGFLOW_SECRET_KEY`. Both containers now share the same encryption key, so credentials stored by `latest` are decryptable by `nightly`.

## Test plan

- [ ] Merge and trigger `migration-test` manually
- [ ] Verify `execute_flow_api` step passes on the nightly phase
- [ ] Confirm flow returns a valid response (not HTTP 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)