### PR TITLE
fix(ci): use valid Fernet key for LANGFLOW_SECRET_KEY in migration-test

### DIFF
--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -13,9 +13,6 @@ env:
   PG_DB: langflow
   STATE_FILE: /tmp/migration-test-state.json
   REPORT_FILE: /tmp/migration-report.md
-  # Fixed Fernet key shared by both containers so credentials encrypted by latest
-  # can be decrypted by nightly after DB migration.
-  LANGFLOW_SECRET_KEY: "moCrtdRACIjpyH3gvhAbPORR9jnXfEKi6bXdqSC2BdY="
 
 permissions:
   contents: read
@@ -53,6 +50,17 @@ jobs:
         run: |
           pip install requests playwright pytest pytest-playwright
           playwright install chromium --with-deps
+
+      - name: Generate ephemeral Fernet key for this run
+        run: |
+          python - <<'PY'
+          import base64
+          import os
+
+          key = base64.urlsafe_b64encode(os.urandom(32)).decode()
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as github_env:
+              github_env.write(f"LANGFLOW_SECRET_KEY={key}\n")
+          PY
 
       # ── Phase 1: Langflow Latest ──────────────────────────────
       - name: Pull Langflow latest

--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -13,9 +13,9 @@ env:
   PG_DB: langflow
   STATE_FILE: /tmp/migration-test-state.json
   REPORT_FILE: /tmp/migration-report.md
-  # Fixed key shared by both containers so credentials encrypted by latest
+  # Fixed Fernet key shared by both containers so credentials encrypted by latest
   # can be decrypted by nightly after DB migration.
-  LANGFLOW_SECRET_KEY: "migration-test-fixed-secret-32chars!!"
+  LANGFLOW_SECRET_KEY: "moCrtdRACIjpyH3gvhAbPORR9jnXfEKi6bXdqSC2BdY="
 
 permissions:
   contents: read

--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -13,6 +13,9 @@ env:
   PG_DB: langflow
   STATE_FILE: /tmp/migration-test-state.json
   REPORT_FILE: /tmp/migration-report.md
+  # Fixed key shared by both containers so credentials encrypted by latest
+  # can be decrypted by nightly after DB migration.
+  LANGFLOW_SECRET_KEY: "migration-test-fixed-secret-32chars!!"
 
 permissions:
   contents: read
@@ -68,6 +71,7 @@ jobs:
             -e LANGFLOW_SUPERUSER=langflow \
             -e LANGFLOW_SUPERUSER_PASSWORD=langflow123 \
             -e LANGFLOW_STORE=false \
+            -e LANGFLOW_SECRET_KEY="$LANGFLOW_SECRET_KEY" \
             langflowai/langflow:latest
 
       - name: Wait for Langflow latest
@@ -102,6 +106,7 @@ jobs:
             -e LANGFLOW_SUPERUSER=langflow \
             -e LANGFLOW_SUPERUSER_PASSWORD=langflow123 \
             -e LANGFLOW_STORE=false \
+            -e LANGFLOW_SECRET_KEY="$LANGFLOW_SECRET_KEY" \
             langflowai/langflow-nightly:latest
 
       - name: Wait for Langflow nightly (includes migration)


### PR DESCRIPTION
## Problem

PR #209 introduced `LANGFLOW_SECRET_KEY` with value `"migration-test-fixed-secret-32chars!!"` (38 chars), which is not a valid Fernet key. Langflow uses Fernet for credential encryption, which requires a 32-byte URL-safe base64 key (44 chars). The invalid key caused `langflow:latest` to crash with HTTP 500 when trying to encrypt the `OPENAI_API_KEY` global variable.

## Fix

Replaced the invalid string with a proper Fernet-compatible key (`base64.urlsafe_b64encode(os.urandom(32))`).

## Test plan

- [ ] Merge and trigger `migration-test` manually
- [ ] Verify `create_variable` step passes (no more HTTP 500)
- [ ] Verify `execute_flow` passes on both `latest` and `nightly` phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)