### PR TITLE
fix(ci): increase wait and timeout in migration UI test_01_open_flow

### DIFF
--- a/tests/github-workflows/migration/test_ui_migration.py
+++ b/tests/github-workflows/migration/test_ui_migration.py
@@ -55,11 +55,11 @@ class TestMigrationUI:
     def test_01_open_flow(self):
         """Navigate to the migrated flow in the editor."""
         self.page.goto(f"{self.base_url}/flow/{self.flow_id}", wait_until="networkidle")
-        self.page.wait_for_timeout(3000)
+        self.page.wait_for_timeout(5000)
 
         # Verify the flow editor loaded (look for the canvas/reactflow area)
         canvas = self.page.locator(".react-flow, [data-testid='rf__wrapper']")
-        expect(canvas.first).to_be_visible(timeout=15_000)
+        expect(canvas.first()).to_be_visible(timeout=20_000)
 
         self.results["steps"]["open_flow"] = {"status": "pass"}
         self._save_results()


### PR DESCRIPTION
## Problem

`test_01_open_flow` was failing with `element(s) not found` for `.react-flow` after migrating to nightly. The 3s wait was too short for the flow editor canvas to render in CI runners.

Tests 02–06 all passed because they each navigate to the same URL with a 5s wait.

## Fix

- Increased `wait_for_timeout` from `3000` → `5000` ms (consistent with all other tests)
- Extended `expect(...).to_be_visible` timeout from `15_000` → `20_000` ms for extra CI headroom
- Fixed `canvas.first` → `canvas.first()` (correct Playwright Python method call syntax)

🤖 Generated with [Claude Code](https://claude.com/claude-code)