### PR TITLE
fix(ci): revert .first() to .first in migration UI test_01_open_flow

### DIFF
--- a/tests/github-workflows/migration/test_ui_migration.py
+++ b/tests/github-workflows/migration/test_ui_migration.py
@@ -59,7 +59,7 @@ class TestMigrationUI:
 
         # Verify the flow editor loaded (look for the canvas/reactflow area)
         canvas = self.page.locator(".react-flow, [data-testid='rf__wrapper']")
-        expect(canvas.first()).to_be_visible(timeout=20_000)
+        expect(canvas.first).to_be_visible(timeout=20_000)
 
         self.results["steps"]["open_flow"] = {"status": "pass"}
         self._save_results()


### PR DESCRIPTION
## Problem

PR #212 incorrectly changed `canvas.first` to `canvas.first()`. In Playwright Python, `locator.first` is a **property** (not a method), so calling it with `()` raises:

```
TypeError: 'Locator' object is not callable
```

## Fix

Reverted `canvas.first()` back to `canvas.first`. The 5s wait and 20s timeout from PR #212 are kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)