### PR TITLE
fix(ci): use broader canvas selector in migration UI test_01

### DIFF
--- a/tests/github-workflows/migration/test_ui_migration.py
+++ b/tests/github-workflows/migration/test_ui_migration.py
@@ -57,8 +57,13 @@ class TestMigrationUI:
         self.page.goto(f"{self.base_url}/flow/{self.flow_id}", wait_until="networkidle")
         self.page.wait_for_timeout(5000)
 
-        # Verify the flow editor loaded (look for the canvas/reactflow area)
-        canvas = self.page.locator(".react-flow, [data-testid='rf__wrapper']")
+        # Verify the flow editor loaded — use a broad selector resilient to
+        # ReactFlow version changes (class prefix match covers react-flow,
+        # react-flow__renderer, react-flow__pane, etc.)
+        canvas = self.page.locator("[class*='react-flow'], [data-testid='rf__wrapper']")
+        if canvas.count() == 0:
+            # Fallback: check for any generic node card present in the flow editor
+            canvas = self.page.locator(".generic-node, [data-testid*='node'], .node-card")
         expect(canvas.first).to_be_visible(timeout=20_000)
 
         self.results["steps"]["open_flow"] = {"status": "pass"}


### PR DESCRIPTION
## Problem

`test_01_open_flow` keeps failing: the `.react-flow` exact class selector no longer matches in the current nightly build. Tests 02–06 pass because they use text/attribute selectors, not CSS class names tied to ReactFlow internals.

## Fix

- Changed `.react-flow` → `[class*='react-flow']` (prefix match — covers `react-flow`, `react-flow__renderer`, `react-flow__pane`, etc.)
- Added fallback to `.generic-node, [data-testid*='node'], .node-card` in case the prefix match also returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)