### PR TITLE
test(core-components): cover invalid f-string patterns in prompt template

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -165,10 +165,12 @@
 - [x] Dismiss button on the Files field clears the value → `core-components/chat-input-files-field-regression.spec.ts`
 
 #### 3.2 Prompt Template
-- [x] Prompt with variables in curly braces → `core-components/prompt-template-component-regression.spec.ts`
-- [x] Prompt modal opens, accepts edits, and changes persist → `core-components/prompt-template-component-regression.spec.ts`
-- [x] Dynamic port generated when adding a variable to the prompt → `core-components/prompt-template-component-regression.spec.ts`
-- [x] Removing a variable from the prompt deletes the corresponding port → `core-components/prompt-template-component-regression.spec.ts`
+- [x] Prompt Template renders on canvas with output handle → `core-components/prompt-template-component-regression.spec.ts`
+- [x] Variables in curly braces generate dynamic input handles → `core-components/prompt-template-component-regression.spec.ts`
+- [x] Removing a variable removes its input handle → `core-components/prompt-template-component-regression.spec.ts`
+- [x] Replacing a variable updates handles accordingly → `core-components/prompt-template-component-regression.spec.ts`
+- [x] Clearing the template removes all dynamic handles → `core-components/prompt-template-component-regression.spec.ts`
+- [x] Modal edits persist in UI and in saved flow → `core-components/prompt-template-component-regression.spec.ts`
 - [x] `use_double_brackets` toggle is exposed in the InspectionPanel with its upstream display name → `core-components/prompt-template-double-brackets-regression.spec.ts`
 - [x] Default toggle state is OFF; f-string mode extracts `{var}` and treats `{{var}}` as literal → `core-components/prompt-template-double-brackets-regression.spec.ts`
 - [x] Enabling toggle switches parser to mustache mode; `{{var}}` creates handle and `{var}` is ignored → `core-components/prompt-template-double-brackets-regression.spec.ts`
@@ -693,7 +695,7 @@
 |--------|-------|-----------------|------------------------|---------------------|---------------------|
 | `api/flows/` — REST API | 21 | 0 | 21 | 0 | 0 |
 | `core-components/` — Component Config | 22 | 0 | 20 | 0 | 2 |
-| `core-components/` — Core Components | 60 | 52 | 3 | 0 | 5 |
+| `core-components/` — Core Components | 62 | 54 | 3 | 0 | 5 |
 | `core-functionality/auth/` | 19 | 0 | 18 | 0 | 1 |
 | `core-functionality/knowledge-ingestion/` | 8 | 0 | 4 | 0 | 4 |
 | `core-functionality/llm-agents/` | 40 | 13 | 2 | 0 | 25 |
@@ -707,7 +709,7 @@
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 42 | 0 | 40 | 1 | 1 |
 | `ui-ux/` — Settings | 5 | 1 | 3 | 1 | 0 |
-| **TOTAL** | **395** | **109 (28%)** | **221 (56%)** | **6 (2%)** | **59 (15%)** |
+| **TOTAL** | **397** | **111 (28%)** | **221 (56%)** | **6 (2%)** | **59 (15%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -3,7 +3,7 @@
 > **Repository:** `C:/QAx/langflow-playwright/langflow-e2e`
 > **Tests:** `tests/tests-automations/regression/`
 > **Config:** `playwright.config.ts`
-> **Last updated:** 2026-05-11
+> **Last updated:** 2026-05-12
 
 ---
 
@@ -174,6 +174,11 @@
 - [x] Enabling toggle switches parser to mustache mode; `{{var}}` creates handle and `{var}` is ignored → `core-components/prompt-template-double-brackets-regression.spec.ts`
 - [x] Disabling toggle reverts to f-string mode and variables are re-extracted under the new parser → `core-components/prompt-template-double-brackets-regression.spec.ts`
 - [x] `use_double_brackets` value persists in the autosaved flow → `core-components/prompt-template-double-brackets-regression.spec.ts`
+- [x] f-string parser rejects `{var.attr}` (dot notation) with an error toast and creates no handle → `core-components/prompt-template-invalid-patterns-regression.spec.ts`
+- [x] f-string parser rejects `{var name}` (space inside identifier) with an error toast and creates no handle → `core-components/prompt-template-invalid-patterns-regression.spec.ts`
+- [x] f-string parser rejects `{1var}` (leading digit) with an error toast and creates no handle → `core-components/prompt-template-invalid-patterns-regression.spec.ts`
+- [x] f-string parser accepts `{}` (empty braces) silently — no error, no handle → `core-components/prompt-template-invalid-patterns-regression.spec.ts`
+- [x] f-string parser deduplicates repeated variables — `{name} and {name}` yields exactly one handle → `core-components/prompt-template-invalid-patterns-regression.spec.ts`
 
 #### 3.3 API Request (HTTP)
 - [x] Renders on canvas with URL and API Response handles → `core-components/api-request-component-regression.spec.ts`
@@ -688,7 +693,7 @@
 |--------|-------|-----------------|------------------------|---------------------|---------------------|
 | `api/flows/` — REST API | 21 | 0 | 21 | 0 | 0 |
 | `core-components/` — Component Config | 22 | 0 | 20 | 0 | 2 |
-| `core-components/` — Core Components | 55 | 47 | 3 | 0 | 5 |
+| `core-components/` — Core Components | 60 | 52 | 3 | 0 | 5 |
 | `core-functionality/auth/` | 19 | 0 | 18 | 0 | 1 |
 | `core-functionality/knowledge-ingestion/` | 8 | 0 | 4 | 0 | 4 |
 | `core-functionality/llm-agents/` | 40 | 13 | 2 | 0 | 25 |
@@ -702,7 +707,7 @@
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 42 | 0 | 40 | 1 | 1 |
 | `ui-ux/` — Settings | 5 | 1 | 3 | 1 | 0 |
-| **TOTAL** | **390** | **104 (27%)** | **221 (57%)** | **6 (2%)** | **59 (15%)** |
+| **TOTAL** | **395** | **109 (28%)** | **221 (56%)** | **6 (2%)** | **59 (15%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -718,7 +723,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 91 `test()` calls carrying the `@stable` tag, distributed across 28 spec
+> 96 `test()` calls carrying the `@stable` tag, distributed across 29 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -762,6 +767,11 @@
 - [x] Prompt Template — enabling toggle switches parser to mustache mode; {{var}} creates handle and {var} is ignored → `prompt-template-double-brackets-regression.spec.ts`
 - [x] Prompt Template — disabling toggle reverts to f-string mode and variables are re-extracted under the new parser → `prompt-template-double-brackets-regression.spec.ts`
 - [x] Prompt Template — use_double_brackets value persists in the autosaved flow → `prompt-template-double-brackets-regression.spec.ts`
+- [x] Prompt Template — `{var.attr}` (dot notation) is rejected with an error toast and creates no handle → `prompt-template-invalid-patterns-regression.spec.ts`
+- [x] Prompt Template — `{var name}` (space inside identifier) is rejected with an error toast and creates no handle → `prompt-template-invalid-patterns-regression.spec.ts`
+- [x] Prompt Template — `{1var}` (leading digit) is rejected with an error toast and creates no handle → `prompt-template-invalid-patterns-regression.spec.ts`
+- [x] Prompt Template — `{}` (empty braces) is accepted by the parser and creates no handle → `prompt-template-invalid-patterns-regression.spec.ts`
+- [x] Prompt Template — repeating the same variable produces exactly one handle (deduplication contract) → `prompt-template-invalid-patterns-regression.spec.ts`
 - [x] Webhook component — cURL command in inspector shows valid POST URL with flow ID → `webhook-component-regression.spec.ts`
 - [x] Webhook component — empty data field returns empty Data object → `webhook-component-regression.spec.ts`
 - [x] Webhook component — endpoint field renders the actual webhook URL → `webhook-component-regression.spec.ts`

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -178,6 +178,7 @@
 - [x] `use_double_brackets` value persists in the autosaved flow → `core-components/prompt-template-double-brackets-regression.spec.ts`
 - [x] f-string parser rejects `{var.attr}` (dot notation) with an error toast and creates no handle → `core-components/prompt-template-invalid-patterns-regression.spec.ts`
 - [x] f-string parser rejects `{var name}` (space inside identifier) with an error toast and creates no handle → `core-components/prompt-template-invalid-patterns-regression.spec.ts`
+- [x] f-string parser rejects `{var,name}` (comma inside identifier) with an error toast and creates no handle → `core-components/prompt-template-invalid-patterns-regression.spec.ts`
 - [x] f-string parser rejects `{1var}` (leading digit) with an error toast and creates no handle → `core-components/prompt-template-invalid-patterns-regression.spec.ts`
 - [x] f-string parser accepts `{}` (empty braces) silently — no error, no handle → `core-components/prompt-template-invalid-patterns-regression.spec.ts`
 - [x] f-string parser deduplicates repeated variables — `{name} and {name}` yields exactly one handle → `core-components/prompt-template-invalid-patterns-regression.spec.ts`
@@ -695,7 +696,7 @@
 |--------|-------|-----------------|------------------------|---------------------|---------------------|
 | `api/flows/` — REST API | 21 | 0 | 21 | 0 | 0 |
 | `core-components/` — Component Config | 22 | 0 | 20 | 0 | 2 |
-| `core-components/` — Core Components | 62 | 54 | 3 | 0 | 5 |
+| `core-components/` — Core Components | 63 | 55 | 3 | 0 | 5 |
 | `core-functionality/auth/` | 19 | 0 | 18 | 0 | 1 |
 | `core-functionality/knowledge-ingestion/` | 8 | 0 | 4 | 0 | 4 |
 | `core-functionality/llm-agents/` | 40 | 13 | 2 | 0 | 25 |
@@ -709,7 +710,7 @@
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 42 | 0 | 40 | 1 | 1 |
 | `ui-ux/` — Settings | 5 | 1 | 3 | 1 | 0 |
-| **TOTAL** | **397** | **111 (28%)** | **221 (56%)** | **6 (2%)** | **59 (15%)** |
+| **TOTAL** | **398** | **112 (28%)** | **221 (56%)** | **6 (2%)** | **59 (15%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -725,7 +726,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 96 `test()` calls carrying the `@stable` tag, distributed across 29 spec
+> 97 `test()` calls carrying the `@stable` tag, distributed across 29 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -771,6 +772,7 @@
 - [x] Prompt Template — use_double_brackets value persists in the autosaved flow → `prompt-template-double-brackets-regression.spec.ts`
 - [x] Prompt Template — `{var.attr}` (dot notation) is rejected with an error toast and creates no handle → `prompt-template-invalid-patterns-regression.spec.ts`
 - [x] Prompt Template — `{var name}` (space inside identifier) is rejected with an error toast and creates no handle → `prompt-template-invalid-patterns-regression.spec.ts`
+- [x] Prompt Template — `{var,name}` (comma inside identifier) is rejected with an error toast and creates no handle → `prompt-template-invalid-patterns-regression.spec.ts`
 - [x] Prompt Template — `{1var}` (leading digit) is rejected with an error toast and creates no handle → `prompt-template-invalid-patterns-regression.spec.ts`
 - [x] Prompt Template — `{}` (empty braces) is accepted by the parser and creates no handle → `prompt-template-invalid-patterns-regression.spec.ts`
 - [x] Prompt Template — repeating the same variable produces exactly one handle (deduplication contract) → `prompt-template-invalid-patterns-regression.spec.ts`

--- a/docs/core-components/prompt-template-component-regression.md
+++ b/docs/core-components/prompt-template-component-regression.md
@@ -104,7 +104,7 @@ Tests 2–6 use the helper `setPromptTemplate(page, value)` which:
 - Prompt rendering/execution behind an LLM (covered by `llm-agents` specs such as `memory-history-regression.spec.ts`)
 - Tool Mode interaction (covered by `tool-mode.spec.ts`)
 - Cross-component data flow (covered by `flow-functionality/` specs)
-- Variable name validation (e.g., reserved keywords, special characters)
+- Invalid-character rejection in variable names (e.g. `{var.attr}`, `{var name}`, `{1var}`), the empty-braces contract, and variable deduplication (covered by `prompt-template-invalid-patterns-regression.spec.ts`)
 - The `use_double_brackets` toggle and the mustache-mode parser (covered by `prompt-template-double-brackets-regression.spec.ts`)
 
 ---

--- a/docs/core-components/prompt-template-invalid-patterns-regression.md
+++ b/docs/core-components/prompt-template-invalid-patterns-regression.md
@@ -1,0 +1,130 @@
+# Prompt Template — Invalid Patterns Regression
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+Validates the **f-string parser contract** of the Prompt Template component when the template string contains patterns that the upstream validator either rejects or treats with specific positive-path semantics. The companion happy-path coverage lives in `prompt-template-component-regression.spec.ts`; this spec focuses on the negative-path and the dedup contract.
+
+The suite has 5 tests covering 3 rejection paths and 2 positive-path defensive assertions:
+
+**Rejection (toast surfaces, no handle created)**
+
+1. **`{var.attr}` (dot notation)** — the dot character is in the upstream `_INVALID_CHARACTERS` set. `_check_input_variables` raises `ValueError("Input variables contain invalid characters or formats. ...")`.
+2. **`{var name}` (space inside identifier)** — same path as #1; space is in `_INVALID_CHARACTERS`.
+3. **`{1var}` (leading digit)** — the upstream `_fix_variable` helper specifically flags identifiers starting with a digit.
+
+**Positive-path defensive**
+
+4. **`{}` (empty braces)** — Python's `Formatter().parse()` yields `("", "", "", None)` and `extract_input_variables_from_prompt` filters empty `field_name` out. The save succeeds, no error toast, no dynamic handle. This test exists so that if a future change starts rejecting `{}` or extracting it as a real variable, the regression surfaces immediately.
+5. **`{name} and {name}` (duplicate)** — `extract_input_variables_from_prompt` tracks seen field names in a `set`, so a repeated `{name}` yields exactly one input variable. Asserts exactly one `name` handle is rendered, not two.
+
+> **Note on scope.** The originally proposed cases `{}` rejection and `{var-name}` rejection (from issue #214) were dropped after probing the live `/api/v1/validate/prompt` endpoint: neither pattern raises today — `{}` is filtered out by the formatter and the hyphen character is **not** in `_INVALID_CHARACTERS`. The replaced cases (`{var name}` and `{1var}`) were chosen because they exercise distinct branches of `_check_input_variables`: the `_INVALID_CHARACTERS` set check and the `_fix_variable` leading-digit branch.
+
+If any of these tests fails, one of three contracts has regressed: the rejection of invalid characters in variable names, the dedup behavior of the parser, or the empty-braces / format-positional escape handling.
+
+---
+
+## Tags *(required)*
+
+All 5 tests: `@stable` `@regression` `@components`
+
+None carry `@release` — these are defensive contract assertions, not happy-path flows.
+
+---
+
+## Step by step *(required)*
+
+Every test starts with the same `addPromptComponent(page)` helper used in `prompt-template-component-regression.spec.ts` (blank flow → sidebar search → add → adjust view → assert 1 node).
+
+### Rejection tests (parameterised — tests 1, 2, 3)
+
+The three rejection cases share a parameterised template and run the same step sequence:
+
+1. Call `(page as any).allowFlowErrors()` — the save deliberately returns HTTP 500 from `/api/v1/validate/prompt`, and the fixture would otherwise fail on the backend-error monitor.
+2. `addPromptComponent(page)`.
+3. Open the prompt modal, fill the textarea with the invalid template, click `genericModalBtnSave` (helper `fillAndSavePromptTemplate`). The helper does **not** wait for modal close — the modal stays open on error.
+4. Assert the error toast (`.error-build-message`) is visible within 5 s (the toast auto-dismisses after 5 s — see `src/frontend/src/alerts/error/index.tsx:22`).
+5. Assert the toast text contains:
+   - The constant title `"There is something wrong with this prompt"` (from i18n `errors.prompt`).
+   - The upstream-error fragment `"Input variables contain invalid characters or formats"`.
+   - The offending variable name (e.g. `var.attr`, `var name`, or `1`) to confirm the right identifier is surfaced.
+6. Assert `dynamicHandlesLocator` count is exactly 0 — the rejected save never reached the node.
+7. Assert the textarea (`modal-promptarea_prompt_template`) is still visible — the frontend sets `isEdit=true` in the `onError` callback so the user can correct without losing input.
+8. Press `Escape` to leave the test in a clean state.
+
+### 4. `{}` is accepted by the parser and creates no handle
+- `addPromptComponent(page)`.
+- `fillAndSavePromptTemplate(page, "Plain {} text")`.
+- Assert the textarea is hidden within 10 s (save succeeded — the modal closed).
+- Assert error toast count is 0.
+- Assert dynamic-handle count is 0.
+
+### 5. Deduplication: `{name} and {name}` produces one handle
+- `addPromptComponent(page)`.
+- `fillAndSavePromptTemplate(page, "Hello {name}, goodbye {name}.")`.
+- Assert the textarea is hidden within 10 s.
+- Assert `handle-prompt template-shownode-name-left` is visible.
+- Assert dynamic-handle count is exactly 1.
+
+---
+
+## Validation criterion *(required)*
+
+- For each invalid pattern that hits `_INVALID_CHARACTERS` or `_fix_variable`'s leading-digit branch:
+  - The error toast `.error-build-message` is visible and contains the upstream `ValueError` title (`errors.prompt`) plus the message fragment `"Input variables contain invalid characters or formats"`.
+  - The toast also includes the offending variable identifier, confirming the right context is surfaced.
+  - The dynamic handle count on the canvas remains 0 — the rejected save did not propagate to the node.
+  - The modal stays open in edit mode (textarea visible) so the user can correct the input.
+- For `{}` (empty braces): the save closes the modal, no error toast appears, and no handle is created.
+- For `{name} and {name}`: the save closes the modal and exactly one `name` handle is rendered.
+
+---
+
+## External dependencies *(required)*
+
+- `src/lfx/src/lfx/base/prompts/api_utils.py` — `_INVALID_CHARACTERS` set, `_fix_variable` (leading-digit branch), `_check_input_variables`, `_check_for_errors`, `validate_prompt`. Drives the entire rejection contract; any change to the set or the message format breaks tests 1–3.
+- `src/lfx/src/lfx/interface/utils.py` — `extract_input_variables_from_prompt`: the dedup `set` and the empty `field_name` filter back tests 4 and 5.
+- `src/backend/base/langflow/api/v1/validate.py` — `POST /validate/prompt`: returns HTTP 500 with `detail=str(ValueError(...))` on rejection. The HTTP status and the `detail` shape are what the frontend's `onError` callback consumes.
+- `src/frontend/src/modals/promptModal/index.tsx` — `genericModalBtnSave`, `modal-promptarea_prompt_template`, and the `usePostValidatePrompt` mutation's `onError` callback that maps the API error into the toast (title from `t("errors.prompt")`, detail from `error.response.data.detail`). Also sets `isEdit=true` so the modal stays open on error.
+- `src/frontend/src/alerts/error/index.tsx` — `ErrorAlert` component renders with CSS class `.error-build-message`; the 5-second auto-dismiss timeout there defines the maximum window in which the toast assertion must run.
+- `src/frontend/src/locales/en.json` — i18n key `errors.prompt` whose value `"There is something wrong with this prompt, please review it"` is asserted as a constant. Localizing this string would break tests 1–3.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Variable extraction from valid templates and dynamic-handle rendering (covered by `prompt-template-component-regression.spec.ts`)
+- The `use_double_brackets` toggle and the f-string escape behavior `{{var}}` rendering as a literal (covered by `prompt-template-double-brackets-regression.spec.ts`, where the two parser modes are asserted side by side and the comparison is informative)
+- Invalid patterns in **mustache mode** (`{{ var }}`, `{{var.attr}}`, `{{#section}}{{/section}}`, `{{{var}}}`) — tracked as a follow-up issue, to be covered in a dedicated spec because the toggle flips a different code path (`validate_mustache_template`)
+- LLM/runtime errors when a flow built on top of the Prompt Template is executed
+- Tool Mode interaction (covered by `tool-mode.spec.ts`)
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
+- No API key required — the Prompt Template component is a pure templating layer with no LLM calls
+- The fixture from `tests/fixtures/fixtures.ts` is used (provides `page.allowFlowErrors()` to opt out of the automatic backend-error fail on the deliberately surfaced HTTP 500)
+
+---
+
+## When to review this test *(optional)*
+
+- If `_INVALID_CHARACTERS` in `src/lfx/src/lfx/base/prompts/api_utils.py` changes (add/remove a character) — the rejection tests are coupled to that set.
+- If the error message format in `_check_for_errors` changes — tests 1–3 assert the leading fragment `"Input variables contain invalid characters or formats"`.
+- If the i18n key `errors.prompt` is renamed or its value localized — tests 1–3 assert the literal English title.
+- If the frontend stops calling `setIsEdit(true)` in `onError` — test step 7 of the rejection tests asserts the textarea stays visible.
+- If the toast component's CSS class changes from `.error-build-message` to something else, or a `data-testid` is added (the spec could then anchor on it instead of the class).
+
+---
+
+## Notes *(optional)*
+
+- The rejection tests run with `(page as any).allowFlowErrors()` because the validate endpoint deliberately returns HTTP 500. This is the same pattern used by `loop-component-regression.spec.ts` and `api-request-component-regression.spec.ts`.
+- The error toast auto-dismisses after 5 seconds (`src/frontend/src/alerts/error/index.tsx:22`). The first toast assertion uses a 5-second timeout to match — running additional waits before the toast assertion would race against the dismissal.
+- The originally proposed `{var-name}` rejection case was dropped because hyphen is not in `_INVALID_CHARACTERS` upstream — `{var-name}` actually creates a `var-name` handle. Probed against `POST /api/v1/validate/prompt` on Langflow 1.10.x. If Langflow ever adds hyphen to the invalid-chars set, this spec should grow a case for it.
+- The originally proposed `{}` rejection case was reframed as a positive-path defensive test for the same reason: Python's `Formatter().parse()` yields an empty `field_name` that the extractor filters out, so the save succeeds silently. The test asserts that contract.

--- a/docs/core-components/prompt-template-invalid-patterns-regression.md
+++ b/docs/core-components/prompt-template-invalid-patterns-regression.md
@@ -92,7 +92,7 @@ Note on the fixture: the save deliberately returns HTTP 500, but `tests/fixtures
 - `src/backend/base/langflow/api/v1/validate.py` — `POST /validate/prompt`: returns HTTP 500 with `detail=str(ValueError(...))` on rejection. The HTTP status and the `detail` shape are what the frontend's `onError` callback consumes.
 - `src/frontend/src/modals/promptModal/index.tsx` — `genericModalBtnSave`, `modal-promptarea_prompt_template`, and the `usePostValidatePrompt` mutation's `onError` callback that maps the API error into the toast (title from `t("errors.prompt")`, detail from `error.response.data.detail`). Also sets `isEdit=true` so the modal stays open on error.
 - `src/frontend/src/alerts/error/index.tsx` — `ErrorAlert` component renders with CSS class `.error-build-message`; the 5-second auto-dismiss timeout there defines the maximum window in which the toast assertion must run.
-- `src/frontend/src/locales/en.json` — i18n key `errors.prompt` whose value `"There is something wrong with this prompt, please review it"` is asserted as a constant. Localizing this string would break tests 1–3.
+- `src/frontend/src/locales/en.json` — i18n key `errors.prompt` whose value `"There is something wrong with this prompt, please review it"` is the source for the toast title. All four rejection tests (1–4) assert via `toContainText("There is something wrong with this prompt")` — a substring check, not a full-string equality. Localizing this prefix (or shortening it past the asserted substring) would break tests 1–4.
 
 ---
 
@@ -118,7 +118,7 @@ Note on the fixture: the save deliberately returns HTTP 500, but `tests/fixtures
 
 - If `_INVALID_CHARACTERS` in `src/lfx/src/lfx/base/prompts/api_utils.py` changes (add/remove a character) — the rejection tests are coupled to that set.
 - If the error message format in `_check_for_errors` changes — tests 1–4 assert the leading fragment `"Input variables contain invalid characters or formats"`, and test 4 additionally anchors on `"Invalid variables: 1"`.
-- If the i18n key `errors.prompt` is renamed or its value localized — tests 1–4 assert the literal English title.
+- If the i18n key `errors.prompt` is renamed or its English value shortened past the asserted prefix `"There is something wrong with this prompt"` — tests 1–4 assert that substring.
 - If the frontend stops calling `setIsEdit(true)` in `onError` — step 5 of the rejection contract asserts the textarea stays visible.
 - If the toast component's CSS class changes from `.error-build-message` to something else, or a `data-testid` is added (the spec could then anchor on it instead of the class).
 

--- a/docs/core-components/prompt-template-invalid-patterns-regression.md
+++ b/docs/core-components/prompt-template-invalid-patterns-regression.md
@@ -8,20 +8,21 @@
 
 Validates the **f-string parser contract** of the Prompt Template component when the template string contains patterns that the upstream validator either rejects or treats with specific positive-path semantics. The companion happy-path coverage lives in `prompt-template-component-regression.spec.ts`; this spec focuses on the negative-path and the dedup contract.
 
-The suite has 5 tests covering 3 rejection paths and 2 positive-path defensive assertions:
+The suite has 6 tests covering 4 rejection paths and 2 positive-path defensive assertions:
 
 **Rejection (toast surfaces, no handle created)**
 
 1. **`{var.attr}` (dot notation)** — the dot character is in the upstream `_INVALID_CHARACTERS` set. `_check_input_variables` raises `ValueError("Input variables contain invalid characters or formats. ...")`.
 2. **`{var name}` (space inside identifier)** — same path as #1; space is in `_INVALID_CHARACTERS`.
-3. **`{1var}` (leading digit)** — the upstream `_fix_variable` helper specifically flags identifiers starting with a digit.
+3. **`{var,name}` (comma inside identifier)** — same path; comma is in `_INVALID_CHARACTERS`. Catches the common templating mistake where users write `{a,b}` thinking it declares multiple variables.
+4. **`{1var}` (leading digit)** — the upstream `_fix_variable` helper specifically flags identifiers starting with a digit. Anchored on the toast fragment `"Invalid variables: 1"` to confirm the leading-digit branch fired (not just an incidental match on the digit character).
 
 **Positive-path defensive**
 
-4. **`{}` (empty braces)** — Python's `Formatter().parse()` yields `("", "", "", None)` and `extract_input_variables_from_prompt` filters empty `field_name` out. The save succeeds, no error toast, no dynamic handle. This test exists so that if a future change starts rejecting `{}` or extracting it as a real variable, the regression surfaces immediately.
-5. **`{name} and {name}` (duplicate)** — `extract_input_variables_from_prompt` tracks seen field names in a `set`, so a repeated `{name}` yields exactly one input variable. Asserts exactly one `name` handle is rendered, not two.
+5. **`{}` (empty braces)** — Python's `Formatter().parse()` yields `("", "", "", None)` and `extract_input_variables_from_prompt` filters empty `field_name` out. The save succeeds, no error toast, no dynamic handle. This test exists so that if a future change starts rejecting `{}` or extracting it as a real variable, the regression surfaces immediately.
+6. **`{name} and {name}` (duplicate)** — `extract_input_variables_from_prompt` tracks seen field names in a `set`, so a repeated `{name}` yields exactly one input variable. Asserts exactly one `name` handle is rendered, not two.
 
-> **Note on scope.** The originally proposed cases `{}` rejection and `{var-name}` rejection (from issue #214) were dropped after probing the live `/api/v1/validate/prompt` endpoint: neither pattern raises today — `{}` is filtered out by the formatter and the hyphen character is **not** in `_INVALID_CHARACTERS`. The replaced cases (`{var name}` and `{1var}`) were chosen because they exercise distinct branches of `_check_input_variables`: the `_INVALID_CHARACTERS` set check and the `_fix_variable` leading-digit branch.
+> **Note on scope.** The originally proposed cases `{}` rejection and `{var-name}` rejection (from issue #214) were dropped after probing the live `/api/v1/validate/prompt` endpoint: neither pattern raises today — `{}` is filtered out by the formatter and the hyphen character is **not** in `_INVALID_CHARACTERS`. The replaced rejection cases (`{var name}`, `{var,name}`, `{1var}`) were chosen because they exercise distinct branches of `_check_input_variables`: the `_INVALID_CHARACTERS` set check (space, comma) and the `_fix_variable` leading-digit branch.
 
 If any of these tests fails, one of three contracts has regressed: the rejection of invalid characters in variable names, the dedup behavior of the parser, or the empty-braces / format-positional escape handling.
 
@@ -29,7 +30,7 @@ If any of these tests fails, one of three contracts has regressed: the rejection
 
 ## Tags *(required)*
 
-All 5 tests: `@stable` `@regression` `@components`
+All 6 tests: `@stable` `@regression` `@components`
 
 None carry `@release` — these are defensive contract assertions, not happy-path flows.
 
@@ -39,30 +40,31 @@ None carry `@release` — these are defensive contract assertions, not happy-pat
 
 Every test starts with the same `addPromptComponent(page)` helper used in `prompt-template-component-regression.spec.ts` (blank flow → sidebar search → add → adjust view → assert 1 node).
 
-### Rejection tests (parameterised — tests 1, 2, 3)
+### Rejection tests (tests 1–4)
 
-The three rejection cases share a parameterised template and run the same step sequence:
+The four rejection cases all run the same step sequence via the `runRejectionContract` helper:
 
-1. Call `(page as any).allowFlowErrors()` — the save deliberately returns HTTP 500 from `/api/v1/validate/prompt`, and the fixture would otherwise fail on the backend-error monitor.
-2. `addPromptComponent(page)`.
-3. Open the prompt modal, fill the textarea with the invalid template, click `genericModalBtnSave` (helper `fillAndSavePromptTemplate`). The helper does **not** wait for modal close — the modal stays open on error.
-4. Assert the error toast (`.error-build-message`) is visible within 5 s (the toast auto-dismisses after 5 s — see `src/frontend/src/alerts/error/index.tsx:22`).
-5. Assert the toast text contains:
+1. `addPromptComponent(page)`.
+2. Open the prompt modal, fill the textarea with the invalid template, click `genericModalBtnSave` (helper `fillAndSavePromptTemplate`). The helper does **not** wait for modal close — the modal stays open on error.
+3. Assert the error toast (`.error-build-message`) is visible within 5 s (the toast auto-dismisses after 5 s — see `src/frontend/src/alerts/error/index.tsx:22`).
+4. Assert the toast text contains:
    - The constant title `"There is something wrong with this prompt"` (from i18n `errors.prompt`).
    - The upstream-error fragment `"Input variables contain invalid characters or formats"`.
-   - The offending variable name (e.g. `var.attr`, `var name`, or `1`) to confirm the right identifier is surfaced.
-6. Assert `dynamicHandlesLocator` count is exactly 0 — the rejected save never reached the node.
-7. Assert the textarea (`modal-promptarea_prompt_template`) is still visible — the frontend sets `isEdit=true` in the `onError` callback so the user can correct without losing input.
-8. Press `Escape` to leave the test in a clean state.
+   - A per-case fragment that anchors the test to the offending pattern — `var.attr`, `var name`, `var,name`, or `"Invalid variables: 1"` for the leading-digit case.
+5. Assert the textarea (`modal-promptarea_prompt_template`) is still visible — the frontend sets `isEdit=true` in the `onError` callback so the user can correct without losing input.
+6. Press `Escape` to leave the test in a clean state.
+7. (Final body-level check) Assert `dynamicHandlesLocator` count is exactly 0 — the rejected save never reached the node.
 
-### 4. `{}` is accepted by the parser and creates no handle
+Note on the fixture: the save deliberately returns HTTP 500, but `tests/fixtures/fixtures.ts` only fails on `flow_error`-type events from `/build/`, `/run/`, or `/events?event_delivery=`. HTTP 500s on `/api/v1/validate/prompt` are logged as `http_error` and do not fail the test, so no `page.allowFlowErrors()` opt-out is needed.
+
+### 5. `{}` is accepted by the parser and creates no handle
 - `addPromptComponent(page)`.
 - `fillAndSavePromptTemplate(page, "Plain {} text")`.
 - Assert the textarea is hidden within 10 s (save succeeded — the modal closed).
 - Assert error toast count is 0.
 - Assert dynamic-handle count is 0.
 
-### 5. Deduplication: `{name} and {name}` produces one handle
+### 6. Deduplication: `{name} and {name}` produces one handle
 - `addPromptComponent(page)`.
 - `fillAndSavePromptTemplate(page, "Hello {name}, goodbye {name}.")`.
 - Assert the textarea is hidden within 10 s.
@@ -73,9 +75,9 @@ The three rejection cases share a parameterised template and run the same step s
 
 ## Validation criterion *(required)*
 
-- For each invalid pattern that hits `_INVALID_CHARACTERS` or `_fix_variable`'s leading-digit branch:
+- For each invalid pattern that hits `_INVALID_CHARACTERS` (dot, space, comma) or `_fix_variable`'s leading-digit branch:
   - The error toast `.error-build-message` is visible and contains the upstream `ValueError` title (`errors.prompt`) plus the message fragment `"Input variables contain invalid characters or formats"`.
-  - The toast also includes the offending variable identifier, confirming the right context is surfaced.
+  - The toast also includes a per-case fragment anchored on the offending pattern (the variable identifier for set-check failures, or `"Invalid variables: 1"` for the leading-digit branch), confirming the right code path fired.
   - The dynamic handle count on the canvas remains 0 — the rejected save did not propagate to the node.
   - The modal stays open in edit mode (textarea visible) so the user can correct the input.
 - For `{}` (empty braces): the save closes the modal, no error toast appears, and no handle is created.
@@ -85,8 +87,8 @@ The three rejection cases share a parameterised template and run the same step s
 
 ## External dependencies *(required)*
 
-- `src/lfx/src/lfx/base/prompts/api_utils.py` — `_INVALID_CHARACTERS` set, `_fix_variable` (leading-digit branch), `_check_input_variables`, `_check_for_errors`, `validate_prompt`. Drives the entire rejection contract; any change to the set or the message format breaks tests 1–3.
-- `src/lfx/src/lfx/interface/utils.py` — `extract_input_variables_from_prompt`: the dedup `set` and the empty `field_name` filter back tests 4 and 5.
+- `src/lfx/src/lfx/base/prompts/api_utils.py` — `_INVALID_CHARACTERS` set, `_fix_variable` (leading-digit branch), `_check_input_variables`, `_check_for_errors`, `validate_prompt`. Drives the entire rejection contract; tests 1–3 exercise the set-check branch (dot, space, comma), test 4 exercises the leading-digit branch. Any change to the set, the leading-digit logic, or the message format breaks tests 1–4.
+- `src/lfx/src/lfx/interface/utils.py` — `extract_input_variables_from_prompt`: the dedup `set` and the empty `field_name` filter back tests 5 and 6.
 - `src/backend/base/langflow/api/v1/validate.py` — `POST /validate/prompt`: returns HTTP 500 with `detail=str(ValueError(...))` on rejection. The HTTP status and the `detail` shape are what the frontend's `onError` callback consumes.
 - `src/frontend/src/modals/promptModal/index.tsx` — `genericModalBtnSave`, `modal-promptarea_prompt_template`, and the `usePostValidatePrompt` mutation's `onError` callback that maps the API error into the toast (title from `t("errors.prompt")`, detail from `error.response.data.detail`). Also sets `isEdit=true` so the modal stays open on error.
 - `src/frontend/src/alerts/error/index.tsx` — `ErrorAlert` component renders with CSS class `.error-build-message`; the 5-second auto-dismiss timeout there defines the maximum window in which the toast assertion must run.
@@ -108,23 +110,23 @@ The three rejection cases share a parameterised template and run the same step s
 
 - Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
 - No API key required — the Prompt Template component is a pure templating layer with no LLM calls
-- The fixture from `tests/fixtures/fixtures.ts` is used (provides `page.allowFlowErrors()` to opt out of the automatic backend-error fail on the deliberately surfaced HTTP 500)
+- The fixture from `tests/fixtures/fixtures.ts` is used. The HTTP 500 the rejection cases trigger on `/api/v1/validate/prompt` is logged as `http_error` but does not fail the test (the fixture only fails on `flow_error`-type events from `/build/`, `/run/`, `/events?event_delivery=`).
 
 ---
 
 ## When to review this test *(optional)*
 
 - If `_INVALID_CHARACTERS` in `src/lfx/src/lfx/base/prompts/api_utils.py` changes (add/remove a character) — the rejection tests are coupled to that set.
-- If the error message format in `_check_for_errors` changes — tests 1–3 assert the leading fragment `"Input variables contain invalid characters or formats"`.
-- If the i18n key `errors.prompt` is renamed or its value localized — tests 1–3 assert the literal English title.
-- If the frontend stops calling `setIsEdit(true)` in `onError` — test step 7 of the rejection tests asserts the textarea stays visible.
+- If the error message format in `_check_for_errors` changes — tests 1–4 assert the leading fragment `"Input variables contain invalid characters or formats"`, and test 4 additionally anchors on `"Invalid variables: 1"`.
+- If the i18n key `errors.prompt` is renamed or its value localized — tests 1–4 assert the literal English title.
+- If the frontend stops calling `setIsEdit(true)` in `onError` — step 5 of the rejection contract asserts the textarea stays visible.
 - If the toast component's CSS class changes from `.error-build-message` to something else, or a `data-testid` is added (the spec could then anchor on it instead of the class).
 
 ---
 
 ## Notes *(optional)*
 
-- The rejection tests run with `(page as any).allowFlowErrors()` because the validate endpoint deliberately returns HTTP 500. This is the same pattern used by `loop-component-regression.spec.ts` and `api-request-component-regression.spec.ts`.
+- The validate endpoint deliberately returns HTTP 500 for the rejection cases, but the fixture only fails on `flow_error`-type events from `/build/`, `/run/`, or `/events?event_delivery=` (see `tests/fixtures/fixtures.ts:230–262`). The 500 from `/api/v1/validate/prompt` is logged as `http_error` and is harmless — no `page.allowFlowErrors()` opt-out is needed here. Other specs (`loop-component-regression.spec.ts`, `api-request-component-regression.spec.ts`) do call `allowFlowErrors()` because they exercise the `/build/` and `/run/` endpoints, which would actually fail the test.
 - The error toast auto-dismisses after 5 seconds (`src/frontend/src/alerts/error/index.tsx:22`). The first toast assertion uses a 5-second timeout to match — running additional waits before the toast assertion would race against the dismissal.
 - The originally proposed `{var-name}` rejection case was dropped because hyphen is not in `_INVALID_CHARACTERS` upstream — `{var-name}` actually creates a `var-name` handle. Probed against `POST /api/v1/validate/prompt` on Langflow 1.10.x. If Langflow ever adds hyphen to the invalid-chars set, this spec should grow a case for it.
 - The originally proposed `{}` rejection case was reframed as a positive-path defensive test for the same reason: Python's `Formatter().parse()` yields an empty `field_name` that the extractor filters out, so the save succeeds silently. The test asserts that contract.

--- a/tests/tests-automations/regression/core-components/prompt-template-invalid-patterns-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/prompt-template-invalid-patterns-regression.spec.ts
@@ -74,26 +74,31 @@ async function fillAndSavePromptTemplate(
 
   // After a previous save, the modal initially shows the sanitized preview
   // (read-only) instead of the textarea. Clicking the preview re-enters edit
-  // mode and mounts the textarea.
+  // mode and mounts the textarea. On the first save of a fresh component the
+  // preview is absent — keep the probe short so each test only pays a ~500ms
+  // tax instead of 2s.
   const preview = page.getByTestId("edit-prompt-sanitized");
-  if (await preview.isVisible({ timeout: 2000 }).catch(() => false)) {
+  if (await preview.isVisible({ timeout: 500 }).catch(() => false)) {
     await preview.click();
   }
 
   await expect(textarea).toBeVisible({ timeout: 10000 });
   await textarea.click();
-  await page.keyboard.press("Control+a");
   await textarea.fill(value);
 
   await page.getByTestId("genericModalBtnSave").click();
 }
 
-// Runs the four-step rejection contract for a single invalid template:
+// Runs the three-step rejection contract for a single invalid template:
 //   1. submit the template via the prompt modal
 //   2. assert the error toast carries the upstream ValueError title + detail
 //      + the offending variable name (so a stale buffer regression is caught)
-//   3. assert no dynamic handle was created on the node
-//   4. assert the modal stays in edit mode (frontend sets isEdit=true on error)
+//   3. assert the modal stays in edit mode (frontend sets isEdit=true on error)
+//
+// The fourth contract piece — "no dynamic handle was created on the node" —
+// lives at the test body level instead of inside the helper so that each
+// `test()` carries a visible body-level `expect()` for the
+// `playwright/expect-expect` lint rule.
 //
 // The four rejection tests below intentionally remain as separate `test()`
 // declarations (not a parameterised loop) so the auto-generated `Phase 0 —
@@ -155,8 +160,9 @@ test(
 
     await runRejectionContract(page, "Hello {var.attr}", "var.attr");
 
-    // Final contract check on the test body so the rejection assertion is
-    // visible at the top level (and to the eslint expect-expect rule).
+    // Fourth piece of the rejection contract — kept at the test body level
+    // (rather than inside `runRejectionContract`) so each test carries a
+    // visible body-level `expect()` for the `playwright/expect-expect` rule.
     await expect(dynamicHandlesLocator(page)).toHaveCount(0);
   },
 );

--- a/tests/tests-automations/regression/core-components/prompt-template-invalid-patterns-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/prompt-template-invalid-patterns-regression.spec.ts
@@ -1,0 +1,254 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
+import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+
+// Run serially to avoid 500 errors from concurrent POST /api/v1/flows/
+// when several workers create a blank flow at the same time.
+test.describe.configure({ mode: "serial" });
+
+// Verified testids and selectors:
+//   add button:          "add-component-button-prompt-template"
+//   node title:          "title-Prompt Template"
+//   modal open btn:      "button_open_prompt_modal"
+//   modal textarea:      "modal-promptarea_prompt_template"
+//   modal save btn:      "genericModalBtnSave"
+//   dynamic handles:     "handle-prompt template-shownode-{varname}-left"
+//   error toast:         CSS class ".error-build-message" (no data-testid;
+//                        sourced from src/frontend/src/alerts/error/index.tsx)
+//
+// Backend contract — POST /api/v1/validate/prompt raises HTTP 500 with
+// `detail=str(ValueError(...))` when the f-string parser flags an invalid
+// pattern. The frontend's promptModal `onError` callback then calls
+// `setErrorData({ title: t("errors.prompt"), list: [error.response.data.detail] })`,
+// which renders an `ErrorAlert` toast and keeps the modal in edit mode
+// (the modal does NOT close — the textarea remains visible).
+//
+// Source upstream: src/lfx/src/lfx/base/prompts/api_utils.py — _INVALID_CHARACTERS
+// set drives `_check_input_variables`. Hyphen and the empty field name are
+// NOT in that set — `{var-name}` is accepted and `{}` is filtered out by the
+// formatter, so neither raises. They are intentionally excluded from this
+// spec's negative-path coverage.
+
+const ERROR_TOAST_TITLE = "There is something wrong with this prompt";
+const ERROR_DETAIL_FRAGMENT =
+  "Input variables contain invalid characters or formats";
+
+const dynamicHandlesLocator = (page: Page): Locator =>
+  page.locator(
+    '[data-testid^="handle-prompt template-shownode-"][data-testid$="-left"]',
+  );
+
+const errorToastLocator = (page: Page): Locator =>
+  page.locator(".error-build-message");
+
+async function addPromptComponent(page: Page): Promise<void> {
+  await awaitBootstrapTest(page);
+  await expect(page.getByTestId("blank-flow")).toBeAttached({ timeout: 30000 });
+  await page.getByTestId("blank-flow").click();
+
+  await page.getByTestId("sidebar-search-input").click();
+  await page.getByTestId("sidebar-search-input").fill("prompt");
+  await expect(
+    page.getByTestId("add-component-button-prompt-template"),
+  ).toBeAttached({ timeout: 30000 });
+  await page.getByTestId("add-component-button-prompt-template").click();
+
+  await adjustScreenView(page);
+  await expect(page.locator(".react-flow__node")).toHaveCount(1, {
+    timeout: 10000,
+  });
+}
+
+// Open the prompt modal, replace its current value with `value`, and click
+// save — but do NOT wait for the modal to close. The save round-trip can end
+// in one of two states depending on whether validation passes:
+//   - success: textarea hides, sanitized preview appears
+//   - error:   `setIsEdit(true)` keeps the textarea visible and a toast
+//              with class `.error-build-message` is rendered
+// Callers assert on the expected state themselves; this helper just submits.
+async function fillAndSavePromptTemplate(
+  page: Page,
+  value: string,
+): Promise<void> {
+  await page.getByTestId("button_open_prompt_modal").click();
+
+  const textarea = page.getByTestId("modal-promptarea_prompt_template");
+
+  // After a previous save, the modal initially shows the sanitized preview
+  // (read-only) instead of the textarea. Clicking the preview re-enters edit
+  // mode and mounts the textarea.
+  const preview = page.getByTestId("edit-prompt-sanitized");
+  if (await preview.isVisible({ timeout: 2000 }).catch(() => false)) {
+    await preview.click();
+  }
+
+  await expect(textarea).toBeVisible({ timeout: 10000 });
+  await textarea.click();
+  await page.keyboard.press("Control+a");
+  await textarea.fill(value);
+
+  await page.getByTestId("genericModalBtnSave").click();
+}
+
+// Runs the four-step rejection contract for a single invalid template:
+//   1. submit the template via the prompt modal
+//   2. assert the error toast carries the upstream ValueError title + detail
+//      + the offending variable name (so a stale buffer regression is caught)
+//   3. assert no dynamic handle was created on the node
+//   4. assert the modal stays in edit mode (frontend sets isEdit=true on error)
+//
+// The three rejection tests below intentionally remain as separate `test()`
+// declarations (not a parameterised loop) so the auto-generated `Phase 0 —
+// Validated` block in QA-CHECKLIST.md surfaces one bullet per case —
+// `scripts/stable-tests.ts` renders `${expr}` template placeholders as
+// `<expr>` and would otherwise collapse the three runtime tests into a
+// single, vague bullet.
+async function runRejectionContract(
+  page: Page,
+  template: string,
+  detailIncludes: string,
+): Promise<void> {
+  await test.step(
+    `Submit \`${template}\` — invalid pattern flagged by _check_input_variables`,
+    async () => {
+      await fillAndSavePromptTemplate(page, template);
+    },
+  );
+
+  await test.step(
+    "Error toast surfaces the upstream ValueError with the offending variable name",
+    async () => {
+      // The toast auto-dismisses after 5s — assert it before any other wait.
+      // `errors.prompt` title is constant; the detail list carries the upstream
+      // message that names the variable in question.
+      const toast = errorToastLocator(page);
+      await expect(toast).toBeVisible({ timeout: 5000 });
+      await expect(toast).toContainText(ERROR_TOAST_TITLE);
+      await expect(toast).toContainText(ERROR_DETAIL_FRAGMENT);
+      await expect(toast).toContainText(detailIncludes);
+    },
+  );
+
+  await test.step(
+    "Modal stays in edit mode so the user can correct the input",
+    async () => {
+      await expect(
+        page.getByTestId("modal-promptarea_prompt_template"),
+      ).toBeVisible();
+      await page.keyboard.press("Escape");
+    },
+  );
+}
+
+test(
+  "Prompt Template — `{var.attr}` (dot notation) is rejected with an error toast and creates no handle",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    // The save POST /api/v1/validate/prompt deliberately returns 500 in
+    // this scenario — opt out of the fixture's automatic backend-error fail.
+    (page as any).allowFlowErrors();
+
+    await test.step("Add Prompt Template to a blank flow", async () => {
+      await addPromptComponent(page);
+    });
+
+    await runRejectionContract(page, "Hello {var.attr}", "var.attr");
+
+    // Final contract check on the test body so the rejection assertion is
+    // visible at the top level (and to the eslint expect-expect rule).
+    await expect(dynamicHandlesLocator(page)).toHaveCount(0);
+  },
+);
+
+test(
+  "Prompt Template — `{var name}` (space inside identifier) is rejected with an error toast and creates no handle",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    (page as any).allowFlowErrors();
+
+    await test.step("Add Prompt Template to a blank flow", async () => {
+      await addPromptComponent(page);
+    });
+
+    await runRejectionContract(page, "Hello {var name}", "var name");
+
+    await expect(dynamicHandlesLocator(page)).toHaveCount(0);
+  },
+);
+
+test(
+  "Prompt Template — `{1var}` (leading digit) is rejected with an error toast and creates no handle",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    (page as any).allowFlowErrors();
+
+    await test.step("Add Prompt Template to a blank flow", async () => {
+      await addPromptComponent(page);
+    });
+
+    await runRejectionContract(page, "Hello {1var}", "1");
+
+    await expect(dynamicHandlesLocator(page)).toHaveCount(0);
+  },
+);
+
+test(
+  "Prompt Template — `{}` (empty braces) is accepted by the parser and creates no handle",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    // Positive-path-as-defensive coverage: empty braces are auto-numbered
+    // positional fields in Python's `Formatter().parse()`, which yields an
+    // empty `field_name` that `extract_input_variables_from_prompt` filters
+    // out. The save succeeds without raising and no dynamic handle appears.
+    // If a future change starts rejecting `{}` (or extracting it as a real
+    // variable), this test breaks first.
+    await test.step("Add Prompt Template to a blank flow", async () => {
+      await addPromptComponent(page);
+    });
+
+    await test.step(
+      "Save `Plain {} text` — save closes the modal, no error toast, no handle",
+      async () => {
+        await fillAndSavePromptTemplate(page, "Plain {} text");
+
+        // Save succeeded — textarea hides and the sanitized preview takes over.
+        await expect(
+          page.getByTestId("modal-promptarea_prompt_template"),
+        ).toBeHidden({ timeout: 10000 });
+
+        await expect(errorToastLocator(page)).toHaveCount(0);
+        await expect(dynamicHandlesLocator(page)).toHaveCount(0);
+      },
+    );
+  },
+);
+
+test(
+  "Prompt Template — repeating the same variable produces exactly one handle (deduplication contract)",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    // Documents the dedup behavior of `extract_input_variables_from_prompt`,
+    // which tracks seen field names in a set — repeating `{name}` does not
+    // duplicate the handle, even though the template has two placeholders.
+    await test.step("Add Prompt Template to a blank flow", async () => {
+      await addPromptComponent(page);
+    });
+
+    await test.step(
+      "Save `Hello {name}, goodbye {name}.` — both placeholders share the `name` slot",
+      async () => {
+        await fillAndSavePromptTemplate(page, "Hello {name}, goodbye {name}.");
+
+        await expect(
+          page.getByTestId("modal-promptarea_prompt_template"),
+        ).toBeHidden({ timeout: 10000 });
+
+        await expect(
+          page.getByTestId("handle-prompt template-shownode-name-left"),
+        ).toBeVisible({ timeout: 10000 });
+        await expect(dynamicHandlesLocator(page)).toHaveCount(1);
+      },
+    );
+  },
+);

--- a/tests/tests-automations/regression/core-components/prompt-template-invalid-patterns-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/prompt-template-invalid-patterns-regression.spec.ts
@@ -24,11 +24,8 @@ test.describe.configure({ mode: "serial" });
 // which renders an `ErrorAlert` toast and keeps the modal in edit mode
 // (the modal does NOT close — the textarea remains visible).
 //
-// Source upstream: src/lfx/src/lfx/base/prompts/api_utils.py — _INVALID_CHARACTERS
-// set drives `_check_input_variables`. Hyphen and the empty field name are
-// NOT in that set — `{var-name}` is accepted and `{}` is filtered out by the
-// formatter, so neither raises. They are intentionally excluded from this
-// spec's negative-path coverage.
+// See the spec doc's Notes for the rationale on why `{var-name}` and `{}`
+// rejection cases from the original issue scope were dropped after probing.
 
 const ERROR_TOAST_TITLE = "There is something wrong with this prompt";
 const ERROR_DETAIL_FRAGMENT =
@@ -98,12 +95,12 @@ async function fillAndSavePromptTemplate(
 //   3. assert no dynamic handle was created on the node
 //   4. assert the modal stays in edit mode (frontend sets isEdit=true on error)
 //
-// The three rejection tests below intentionally remain as separate `test()`
+// The four rejection tests below intentionally remain as separate `test()`
 // declarations (not a parameterised loop) so the auto-generated `Phase 0 —
 // Validated` block in QA-CHECKLIST.md surfaces one bullet per case —
 // `scripts/stable-tests.ts` renders `${expr}` template placeholders as
-// `<expr>` and would otherwise collapse the three runtime tests into a
-// single, vague bullet.
+// `<expr>` and would otherwise collapse the runtime tests into a single,
+// vague bullet.
 async function runRejectionContract(
   page: Page,
   template: string,
@@ -141,14 +138,17 @@ async function runRejectionContract(
   );
 }
 
+// Note on the fixture interaction: the save POST /api/v1/validate/prompt
+// returns HTTP 500 by design in the rejection scenarios below. The fixture
+// (tests/fixtures/fixtures.ts) only fails the test on `flow_error`-type
+// events from /build/, /run/, or /events?event_delivery= — HTTP 500s on
+// other endpoints are logged as `http_error` and do not fail the test.
+// So no `page.allowFlowErrors()` opt-out is needed here.
+
 test(
   "Prompt Template — `{var.attr}` (dot notation) is rejected with an error toast and creates no handle",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    // The save POST /api/v1/validate/prompt deliberately returns 500 in
-    // this scenario — opt out of the fixture's automatic backend-error fail.
-    (page as any).allowFlowErrors();
-
     await test.step("Add Prompt Template to a blank flow", async () => {
       await addPromptComponent(page);
     });
@@ -165,8 +165,6 @@ test(
   "Prompt Template — `{var name}` (space inside identifier) is rejected with an error toast and creates no handle",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    (page as any).allowFlowErrors();
-
     await test.step("Add Prompt Template to a blank flow", async () => {
       await addPromptComponent(page);
     });
@@ -178,16 +176,35 @@ test(
 );
 
 test(
-  "Prompt Template — `{1var}` (leading digit) is rejected with an error toast and creates no handle",
+  "Prompt Template — `{var,name}` (comma inside identifier) is rejected with an error toast and creates no handle",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    (page as any).allowFlowErrors();
-
+    // Comma is in `_INVALID_CHARACTERS` and users sometimes mistakenly write
+    // `{a,b}` thinking it declares multiple variables — this case catches a
+    // regression where comma is silently dropped from the set.
     await test.step("Add Prompt Template to a blank flow", async () => {
       await addPromptComponent(page);
     });
 
-    await runRejectionContract(page, "Hello {1var}", "1");
+    await runRejectionContract(page, "Hello {var,name}", "var,name");
+
+    await expect(dynamicHandlesLocator(page)).toHaveCount(0);
+  },
+);
+
+test(
+  "Prompt Template — `{1var}` (leading digit) is rejected with an error toast and creates no handle",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    await test.step("Add Prompt Template to a blank flow", async () => {
+      await addPromptComponent(page);
+    });
+
+    // Anchor on "Invalid variables: 1" instead of just "1" — the bare digit
+    // could match incidental substrings in the toast (build numbers, icon
+    // names, etc.); the full fragment proves the upstream `_fix_variable`
+    // leading-digit branch actually fired.
+    await runRejectionContract(page, "Hello {1var}", "Invalid variables: 1");
 
     await expect(dynamicHandlesLocator(page)).toHaveCount(0);
   },


### PR DESCRIPTION
## Summary

- Adds `prompt-template-invalid-patterns-regression.spec.ts` (6 `@stable` tests) covering the f-string parser contract of the Prompt Template component:
  - **Rejection** — `{var.attr}` (dot), `{var name}` (space), `{var,name}` (comma), `{1var}` (leading digit): each surfaces the upstream `ValueError` as an error toast (`.error-build-message`), creates no handle, and leaves the modal in edit mode so the user can correct the input.
  - **Positive defensive** — `{}` (empty braces filtered out by `Formatter().parse()`); `{name} and {name}` (deduplicated to one handle).
- Adds `docs/core-components/prompt-template-invalid-patterns-regression.md` with all mandatory sections.
- Extends `docs/core-components/prompt-template-component-regression.md` — replaces the generic "Variable name validation" line under **What this test does not cover** with a pointer to the new spec.
- Updates `QA-CHECKLIST.md` §3.2 with 6 new bullets (all `[x]`). Auto-generated Coverage Summary and Phase 0 block regenerated via `npm run coverage:summary`.

## Scope adjustments vs. issue #214

After probing `POST /api/v1/validate/prompt` directly against Langflow 1.10.x, two of the originally proposed cases were dropped because the upstream parser does not reject them:

- **`{}`** — Python's `Formatter().parse()` yields an empty `field_name` that `extract_input_variables_from_prompt` filters out; save succeeds silently. Reframed as a positive-path defensive test.
- **`{var-name}`** — hyphen is **not** in `_INVALID_CHARACTERS`; the save succeeds and a `var-name` handle is created. Replaced with `{var name}` (space), `{var,name}` (comma) and `{1var}` (leading digit), which exercise the `_INVALID_CHARACTERS` set check and the `_fix_variable` leading-digit branch respectively.

**Test 4 from the issue (`{{var}}` as literal)** was dropped to avoid duplicating an assertion already present in `prompt-template-double-brackets-regression.spec.ts` (test 2), where it sits naturally alongside the mustache-mode comparison.

**Mustache-mode invalid patterns (cases 6–9 in the issue)** are deferred to a follow-up issue and a dedicated PR.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` — no new errors (only the pre-existing `(page as any)` convention warnings used by sibling specs)
- [x] `npx playwright test prompt-template-invalid-patterns-regression.spec.ts` → 6/6 passing (~23 s on Langflow 1.10.x nightly)
- [x] False-positive check — flipped `ERROR_TOAST_TITLE` to a sentinel string; test failed at the expected assertion line, confirming the assertion is real
- [x] `npm run coverage:summary` is idempotent (a second run produces no diff)

Closes #214