### PR TITLE
test(core-components): cover invalid mustache patterns in prompt template

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -182,6 +182,10 @@
 - [x] f-string parser rejects `{1var}` (leading digit) with an error toast and creates no handle → `core-components/prompt-template-invalid-patterns-regression.spec.ts`
 - [x] f-string parser accepts `{}` (empty braces) silently — no error, no handle → `core-components/prompt-template-invalid-patterns-regression.spec.ts`
 - [x] f-string parser deduplicates repeated variables — `{name} and {name}` yields exactly one handle → `core-components/prompt-template-invalid-patterns-regression.spec.ts`
+- [x] mustache parser rejects `{{ var }}` (spaces inside braces) with an error toast and creates no handle → `core-components/prompt-template-invalid-mustache-patterns-regression.spec.ts`
+- [x] mustache parser rejects `{{var.attr}}` (dot notation) with an error toast and creates no handle → `core-components/prompt-template-invalid-mustache-patterns-regression.spec.ts`
+- [x] mustache parser rejects `{{#section}}{{/section}}` with the complex-syntax message and creates no handle → `core-components/prompt-template-invalid-mustache-patterns-regression.spec.ts`
+- [x] mustache parser rejects `{{{var}}}` (triple braces) with the complex-syntax message and creates no handle → `core-components/prompt-template-invalid-mustache-patterns-regression.spec.ts`
 
 #### 3.3 API Request (HTTP)
 - [x] Renders on canvas with URL and API Response handles → `core-components/api-request-component-regression.spec.ts`
@@ -702,7 +706,7 @@
 |--------|-------|-----------------|------------------------|---------------------|---------------------|
 | `api/flows/` — REST API | 21 | 4 | 17 | 0 | 0 |
 | `core-components/` — Component Config | 22 | 1 | 19 | 0 | 2 |
-| `core-components/` — Core Components | 63 | 55 | 3 | 1 | 4 |
+| `core-components/` — Core Components | 67 | 59 | 3 | 1 | 4 |
 | `core-functionality/auth/` | 19 | 0 | 18 | 0 | 1 |
 | `core-functionality/knowledge-ingestion/` | 8 | 0 | 4 | 0 | 4 |
 | `core-functionality/llm-agents/` | 40 | 13 | 2 | 0 | 25 |
@@ -716,7 +720,7 @@
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 43 | 2 | 39 | 1 | 1 |
 | `ui-ux/` — Settings | 5 | 1 | 3 | 1 | 0 |
-| **TOTAL** | **404** | **128 (32%)** | **215 (53%)** | **7 (2%)** | **54 (13%)** |
+| **TOTAL** | **408** | **132 (32%)** | **215 (53%)** | **7 (2%)** | **54 (13%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -732,7 +736,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 128 `test()` calls carrying the `@stable` tag, distributed across 44 spec
+> 132 `test()` calls carrying the `@stable` tag, distributed across 45 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -789,6 +793,10 @@
 - [x] Prompt Template — enabling toggle switches parser to mustache mode; {{var}} creates handle and {var} is ignored → `prompt-template-double-brackets-regression.spec.ts`
 - [x] Prompt Template — disabling toggle reverts to f-string mode and variables are re-extracted under the new parser → `prompt-template-double-brackets-regression.spec.ts`
 - [x] Prompt Template — use_double_brackets value persists in the autosaved flow → `prompt-template-double-brackets-regression.spec.ts`
+- [x] Prompt Template — mustache `{{ var }}` (spaces inside braces) is rejected with an error toast and creates no handle → `prompt-template-invalid-mustache-patterns-regression.spec.ts`
+- [x] Prompt Template — mustache `{{var.attr}}` (dot notation) is rejected with an error toast and creates no handle → `prompt-template-invalid-mustache-patterns-regression.spec.ts`
+- [x] Prompt Template — mustache `{{#section}}{{/section}}` is rejected with the complex-syntax message and creates no handle → `prompt-template-invalid-mustache-patterns-regression.spec.ts`
+- [x] Prompt Template — mustache `{{{var}}}` (triple braces) is rejected with the complex-syntax message and creates no handle → `prompt-template-invalid-mustache-patterns-regression.spec.ts`
 - [x] Prompt Template — `{var.attr}` (dot notation) is rejected with an error toast and creates no handle → `prompt-template-invalid-patterns-regression.spec.ts`
 - [x] Prompt Template — `{var name}` (space inside identifier) is rejected with an error toast and creates no handle → `prompt-template-invalid-patterns-regression.spec.ts`
 - [x] Prompt Template — `{var,name}` (comma inside identifier) is rejected with an error toast and creates no handle → `prompt-template-invalid-patterns-regression.spec.ts`

--- a/docs/core-components/prompt-template-double-brackets-regression.md
+++ b/docs/core-components/prompt-template-double-brackets-regression.md
@@ -105,7 +105,7 @@ Both modes share the post-save preview (`edit-prompt-sanitized`) and the save bu
 
 ## What this test does not cover *(optional)*
 
-- Validation of invalid mustache patterns (e.g., `{{#section}}`, `{{var.attr}}`, dotted paths) — out of scope here; a companion regression is planned
+- Validation of invalid mustache patterns (e.g., `{{ var }}`, `{{var.attr}}`, `{{#section}}{{/section}}`, `{{{var}}}`) — covered by `prompt-template-invalid-mustache-patterns-regression.spec.ts`, which exercises the `validate_mustache_template` rejection contract with the toggle flipped ON
 - The `tool_placeholder` advanced input on the same component (covered by `tool-mode.spec.ts`)
 - Prompt rendering/execution behind an LLM (covered by `llm-agents` specs)
 - The single-bracket happy path and modal persistence in f-string mode (covered by `prompt-template-component-regression.spec.ts`)

--- a/docs/core-components/prompt-template-invalid-mustache-patterns-regression.md
+++ b/docs/core-components/prompt-template-invalid-mustache-patterns-regression.md
@@ -1,0 +1,119 @@
+# Prompt Template — Invalid Mustache Patterns Regression
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+Validates the **mustache parser rejection contract** of the Prompt Template component. The `use_double_brackets` toggle (covered by `prompt-template-double-brackets-regression.spec.ts`) flips the validator from `extract_input_variables_from_prompt` (f-string) to `validate_mustache_template` + `mustache_template_vars` (mustache). This spec asserts that the mustache validator rejects the four forbidden patterns that are out of scope for the simple-variable contract — independently of the f-string sibling spec (`prompt-template-invalid-patterns-regression.spec.ts`), which exercises a different branch upstream.
+
+All 4 tests run with the toggle flipped ON before the rejection contract is exercised.
+
+The suite has 4 tests — one per rejection branch of `validate_mustache_template`:
+
+**SIMPLE_VARIABLE_PATTERN miss (per-pattern match fails)**
+
+1. **`{{ var }}` (spaces inside braces)** — Whitespace inside braces fails `SIMPLE_VARIABLE_PATTERN.match()` because the regex requires no whitespace between the braces and the identifier. The error detail echoes the offending pattern verbatim: `"Invalid mustache variable: {{ var }}. Only simple variable names like {{variable}} are allowed."`.
+2. **`{{var.attr}}` (dot notation)** — Same code path as #1. Dot notation is intentionally unsupported because `safe_mustache_render` has no dot-path lookup (variables are resolved via `dict.get`), so the validator rejects the pattern before render. The detail echoes `{{var.attr}}`.
+
+**DANGEROUS_PATTERNS regex hit (forbidden mustache sigil detected)**
+
+3. **`{{#section}}{{/section}}` (section + closing tag)** — Both `{{#` and `{{/` are in the `DANGEROUS_PATTERNS` list; the first one to match short-circuits with the constant message `"Complex mustache syntax is not allowed. Only simple variable substitution like {{variable}} is permitted."`. The offending pattern is *not* echoed back in this branch.
+4. **`{{{var}}}` (triple braces)** — Triple braces are the mustache "unescaped HTML" sigil and are blocked by the `{{{` regex in `DANGEROUS_PATTERNS`. Same constant message as #3.
+
+If any of these tests fails, one of three contracts has regressed: (a) the toggle no longer switches the validator over, (b) the mustache validator stopped flagging a forbidden pattern, or (c) the frontend's error-handling path for the mustache modal stopped surfacing the upstream message.
+
+---
+
+## Tags *(required)*
+
+All 4 tests: `@stable` `@regression` `@components`
+
+None carry `@release` — these are defensive contract assertions, not happy-path flows.
+
+---
+
+## Step by step *(required)*
+
+Every test starts with the same `addPromptComponent(page)` helper used in the sibling specs (blank flow → sidebar search → add → adjust view → assert 1 node), followed by `enableMustacheMode(page)`, which clicks the `toggle_bool_use_double_brackets` toggle and waits for `button_open_mustache_prompt_modal` to mount (the re-render is the reliable signal that the validator switch has landed).
+
+All four rejection cases then run the same step sequence via the `runMustacheRejectionContract` helper:
+
+1. `addPromptComponent(page)` + `enableMustacheMode(page)`.
+2. Open the mustache prompt modal, fill the textarea with the invalid template, click `genericModalBtnSave` (helper `fillAndSaveMustacheTemplate`). The helper does **not** wait for modal close — the modal stays open on error.
+3. Assert the error toast (`.error-build-message`) is visible within 5 s (the toast auto-dismisses after 5 s — see `src/frontend/src/alerts/error/index.tsx:22`).
+4. Assert the toast text contains:
+   - The constant title `"There is something wrong with this prompt"` (from i18n `errors.prompt`).
+   - A per-case fragment that anchors the test to the branch of `validate_mustache_template` that fired:
+     - Cases 1–2: `"Invalid mustache variable: {{ var }}"` / `"Invalid mustache variable: {{var.attr}}"` — the offending pattern is echoed verbatim.
+     - Cases 3–4: `"Complex mustache syntax is not allowed"` — the constant message used by every `DANGEROUS_PATTERNS` hit.
+5. Assert the mustache textarea (`modal-mustachepromptarea_mustache_template`) is still visible — the frontend sets `isEdit=true` in the `onError` callback so the user can correct without losing input.
+6. Press `Escape` to leave the test in a clean state.
+7. (Final body-level check) Assert `dynamicHandlesLocator` count is exactly 0 — the rejected save never reached the node.
+
+Note on the fixture: the save deliberately returns HTTP 500, but `tests/fixtures/fixtures.ts` only fails on `flow_error`-type events from `/build/`, `/run/`, or `/events?event_delivery=`. HTTP 500s on `/api/v1/validate/prompt` are logged as `http_error` and do not fail the test, so no `page.allowFlowErrors()` opt-out is needed (same as the f-string sibling spec).
+
+---
+
+## Validation criterion *(required)*
+
+For each of the four forbidden mustache patterns:
+
+- The error toast `.error-build-message` is visible within 5 s and contains the upstream `ValueError` title from i18n key `errors.prompt`.
+- The toast detail carries the upstream message fragment that anchors the test to the specific rejection branch:
+  - SIMPLE_VARIABLE_PATTERN miss (`{{ var }}`, `{{var.attr}}`): `"Invalid mustache variable: <pattern>"`.
+  - DANGEROUS_PATTERNS hit (`{{#section}}{{/section}}`, `{{{var}}}`): `"Complex mustache syntax is not allowed"`.
+- The dynamic handle count on the canvas remains 0 — the rejected save did not propagate to the node.
+- The mustache modal stays open in edit mode (textarea visible) so the user can correct the input.
+
+---
+
+## External dependencies *(required)*
+
+- `src/lfx/src/lfx/utils/mustache_security.py` — `validate_mustache_template`, `DANGEROUS_PATTERNS`, `SIMPLE_VARIABLE_PATTERN`. Drives the entire rejection contract. Tests 1–2 exercise the `SIMPLE_VARIABLE_PATTERN.match()` miss branch; tests 3–4 exercise the `DANGEROUS_PATTERNS` regex-hit branch. Any change to the regex list, the simple-variable pattern, or either message string breaks the corresponding tests.
+- `src/lfx/src/lfx/base/prompts/api_utils.py` — `validate_prompt(..., is_mustache=True)` is the entry point that delegates to `validate_mustache_template` before extracting variables. If the `is_mustache` branch is short-circuited or reordered, the rejection contract no longer fires.
+- `src/backend/base/langflow/api/v1/validate.py` — `POST /validate/prompt`: returns HTTP 500 with `detail=str(ValueError(...))` on rejection. The HTTP status and the `detail` shape are what the frontend's `onError` callback consumes.
+- `src/frontend/src/modals/mustachePromptModal/index.tsx` — `button_open_mustache_prompt_modal`, `modal-mustachepromptarea_mustache_template`, and the `onError` callback (lines 148–153) that maps the API error into the toast (title from `t("errors.prompt")`, detail from `error.response.data.detail`). Also sets `isEdit=true` so the modal stays open on error.
+- `src/frontend/src/components/core/parameterRenderComponent/components/mustachePromptComponent/index.tsx` — owns the `button_open_mustache_prompt_modal` testid that the helper expects to be visible once mustache mode is enabled.
+- `src/frontend/src/alerts/error/index.tsx` — `ErrorAlert` component renders with CSS class `.error-build-message`; the 5-second auto-dismiss timeout there defines the maximum window in which the toast assertion must run.
+- `src/frontend/src/locales/en.json` — i18n key `errors.prompt` whose value `"There is something wrong with this prompt, please review it"` is the source for the toast title. All four tests assert via `toContainText("There is something wrong with this prompt")` — a substring check, not a full-string equality. Localizing this prefix (or shortening it past the asserted substring) would break the suite.
+
+---
+
+## What this test does not cover *(optional)*
+
+- F-string mode invalid patterns (covered by `prompt-template-invalid-patterns-regression.spec.ts`).
+- The `use_double_brackets` toggle behavior itself — exposure, default state, mode-switching semantics, backend persistence (covered by `prompt-template-double-brackets-regression.spec.ts`).
+- Variable extraction from valid mustache templates and dynamic-handle rendering (covered by `prompt-template-double-brackets-regression.spec.ts`, where the two parser modes are asserted side by side).
+- Other mustache sigils listed in `DANGEROUS_PATTERNS` but not in the issue scope: inverted sections `{{^...}}`, unescaped variables `{{&...}}`, partials `{{>...}}`, comments `{{!...}}`, current-context `{{.}}`. These all share the same constant `"Complex mustache syntax is not allowed"` message as cases 3–4 — extend this spec if a regression in those branches needs explicit coverage.
+- LLM/runtime errors when a flow built on top of the Prompt Template is executed.
+- Tool Mode interaction (covered by `tool-mode.spec.ts`).
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and accessible at `PLAYWRIGHT_BASE_URL`.
+- No API key required — the Prompt Template component is a pure templating layer with no LLM calls.
+- The fixture from `tests/fixtures/fixtures.ts` is used. The HTTP 500 the rejection cases trigger on `/api/v1/validate/prompt` is logged as `http_error` but does not fail the test (the fixture only fails on `flow_error`-type events from `/build/`, `/run/`, `/events?event_delivery=`).
+
+---
+
+## When to review this test *(optional)*
+
+- If `DANGEROUS_PATTERNS` or `SIMPLE_VARIABLE_PATTERN` in `src/lfx/src/lfx/utils/mustache_security.py` changes — the rejection branches and the message strings are coupled to that file.
+- If the two error messages (`"Complex mustache syntax is not allowed"`, `"Invalid mustache variable: <pattern>"`) are reworded or merged — the per-case fragment assertions are anchored on them.
+- If `validate_prompt` in `src/lfx/src/lfx/base/prompts/api_utils.py` reorders or short-circuits the `is_mustache` branch — `validate_mustache_template` may no longer fire before `mustache_template_vars`, and the cryptic mustache-parser fallback message (line 141) would surface instead.
+- If the i18n key `errors.prompt` is renamed or its English value shortened past the asserted prefix `"There is something wrong with this prompt"` — all four tests assert that substring.
+- If the frontend stops calling `setIsEdit(true)` in the mustache modal's `onError` (lines 148–153) — step 5 of the rejection contract asserts the textarea stays visible.
+- If the toast component's CSS class changes from `.error-build-message` to something else, or a `data-testid` is added (the spec could then anchor on it instead of the class).
+
+---
+
+## Notes *(optional)*
+
+- Each of the four patterns was probed against `POST /api/v1/validate/prompt` with `"mustache": true` on Langflow 1.10.x before the spec was written — all four return HTTP 500 today, with the exact two message strings the spec asserts. The probe is the safety valve for this kind of "issue says X errors" claim, because the f-string sibling spec surfaced two cases (`{}` and `{var-name}`) that did *not* error in practice. No such gap was found here.
+- The error toast auto-dismisses after 5 seconds (`src/frontend/src/alerts/error/index.tsx:22`). The first toast assertion uses a 5-second timeout to match — running additional waits before the toast assertion would race against the dismissal.
+- Cases 3 and 4 share the same constant message because every `DANGEROUS_PATTERNS` hit returns the same string. They are kept as separate `test()` declarations (not parameterised) so the auto-generated `Phase 0 — Validated` block in `QA-CHECKLIST.md` surfaces one bullet per case — `scripts/stable-tests.ts` renders `${expr}` template placeholders as `<expr>` and would otherwise collapse the runtime tests into a single, vague bullet.
+- The mustache modal uses a different open-button testid (`button_open_mustache_prompt_modal`) and textarea testid (`modal-mustachepromptarea_mustache_template`) than the f-string modal — the spec's helpers (`fillAndSaveMustacheTemplate`, `runMustacheRejectionContract`) keep those testids local rather than parameterising the f-string sibling's helpers, to keep each spec independently readable.

--- a/docs/core-components/prompt-template-invalid-patterns-regression.md
+++ b/docs/core-components/prompt-template-invalid-patterns-regression.md
@@ -100,7 +100,7 @@ Note on the fixture: the save deliberately returns HTTP 500, but `tests/fixtures
 
 - Variable extraction from valid templates and dynamic-handle rendering (covered by `prompt-template-component-regression.spec.ts`)
 - The `use_double_brackets` toggle and the f-string escape behavior `{{var}}` rendering as a literal (covered by `prompt-template-double-brackets-regression.spec.ts`, where the two parser modes are asserted side by side and the comparison is informative)
-- Invalid patterns in **mustache mode** (`{{ var }}`, `{{var.attr}}`, `{{#section}}{{/section}}`, `{{{var}}}`) — tracked as a follow-up issue, to be covered in a dedicated spec because the toggle flips a different code path (`validate_mustache_template`)
+- Invalid patterns in **mustache mode** (`{{ var }}`, `{{var.attr}}`, `{{#section}}{{/section}}`, `{{{var}}}`) — covered by `prompt-template-invalid-mustache-patterns-regression.spec.ts`, which exercises the `validate_mustache_template` code path independently from the f-string parser asserted here
 - LLM/runtime errors when a flow built on top of the Prompt Template is executed
 - Tool Mode interaction (covered by `tool-mode.spec.ts`)
 

--- a/tests/tests-automations/regression/core-components/prompt-template-invalid-mustache-patterns-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/prompt-template-invalid-mustache-patterns-regression.spec.ts
@@ -1,0 +1,268 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
+import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+
+// Run serially to avoid 500 errors from concurrent POST /api/v1/flows/
+// when several workers create a blank flow at the same time.
+test.describe.configure({ mode: "serial" });
+
+// Verified testids and selectors (mustache mode):
+//   add button:               "add-component-button-prompt-template"
+//   toggle (InspectionPanel): "toggle_bool_use_double_brackets"
+//   mustache modal open:      "button_open_mustache_prompt_modal"
+//   mustache textarea:        "modal-mustachepromptarea_mustache_template"
+//   modal save btn:           "genericModalBtnSave"
+//   modal preview:            "edit-prompt-sanitized"  (shared between both modes)
+//   dynamic handles:          "handle-prompt template-shownode-{varname}-left"
+//   error toast:              CSS class ".error-build-message" (no data-testid;
+//                             sourced from src/frontend/src/alerts/error/index.tsx)
+//
+// Backend contract — POST /api/v1/validate/prompt with `mustache: true` raises
+// HTTP 500 with `detail=str(ValueError(...))` when `validate_mustache_template`
+// flags a forbidden pattern. The mustache modal's `onError` callback
+// (src/frontend/src/modals/mustachePromptModal/index.tsx:148-153) calls
+// `setErrorData({ title: t("errors.prompt"), list: [error.response.data.detail] })`,
+// which renders the same `ErrorAlert` toast used by the f-string sibling spec
+// and sets `isEdit=true` so the modal stays open in edit mode.
+//
+// The four rejection cases below come from two distinct branches of
+// `validate_mustache_template` (src/lfx/src/lfx/utils/mustache_security.py):
+//   - DANGEROUS_PATTERNS regex hits (sections, triple braces) → "Complex mustache
+//     syntax is not allowed. ..."
+//   - SIMPLE_VARIABLE_PATTERN per-pattern match miss (spaces, dot notation) →
+//     "Invalid mustache variable: {{...}}. Only simple variable names ..."
+// Both branches were probed against the live endpoint on Langflow 1.10.x before
+// this spec was written.
+
+const ERROR_TOAST_TITLE = "There is something wrong with this prompt";
+const COMPLEX_SYNTAX_FRAGMENT =
+  "Complex mustache syntax is not allowed";
+const INVALID_VARIABLE_FRAGMENT = "Invalid mustache variable";
+
+const dynamicHandlesLocator = (page: Page): Locator =>
+  page.locator(
+    '[data-testid^="handle-prompt template-shownode-"][data-testid$="-left"]',
+  );
+
+const errorToastLocator = (page: Page): Locator =>
+  page.locator(".error-build-message");
+
+async function addPromptComponent(page: Page): Promise<void> {
+  await awaitBootstrapTest(page);
+  await expect(page.getByTestId("blank-flow")).toBeAttached({ timeout: 30000 });
+  await page.getByTestId("blank-flow").click();
+
+  await page.getByTestId("sidebar-search-input").click();
+  await page.getByTestId("sidebar-search-input").fill("prompt");
+  await expect(
+    page.getByTestId("add-component-button-prompt-template"),
+  ).toBeAttached({ timeout: 30000 });
+  await page.getByTestId("add-component-button-prompt-template").click();
+
+  await adjustScreenView(page);
+  await expect(page.locator(".react-flow__node")).toHaveCount(1, {
+    timeout: 10000,
+  });
+}
+
+// Flip `use_double_brackets` ON and wait for the mustache modal-open button to
+// mount — same approach as `flipDoubleBrackets(page, true)` in
+// prompt-template-double-brackets-regression.spec.ts. With `real_time_refresh=True`,
+// toggling the bool causes `update_build_config` to swap `template.type` between
+// PROMPT and MUSTACHE_PROMPT, which re-renders the modal-open button under a
+// different testid — that re-render is the reliable signal that the switch has
+// landed.
+async function enableMustacheMode(page: Page): Promise<void> {
+  await page.getByTestId("toggle_bool_use_double_brackets").click();
+  await expect(
+    page.getByTestId("button_open_mustache_prompt_modal"),
+  ).toBeVisible({ timeout: 10000 });
+}
+
+// Open the mustache prompt modal, replace its current value with `value`, and
+// click save — but do NOT wait for the modal to close. The save round-trip can
+// end in one of two states depending on whether validation passes:
+//   - success: textarea hides, sanitized preview appears
+//   - error:   `setIsEdit(true)` keeps the textarea visible and a toast
+//              with class `.error-build-message` is rendered
+// Callers assert on the expected state themselves; this helper just submits.
+async function fillAndSaveMustacheTemplate(
+  page: Page,
+  value: string,
+): Promise<void> {
+  await page.getByTestId("button_open_mustache_prompt_modal").click();
+
+  const textarea = page.getByTestId(
+    "modal-mustachepromptarea_mustache_template",
+  );
+
+  // After a previous save, the modal initially shows the sanitized preview
+  // (read-only) instead of the textarea. Clicking the preview re-enters edit
+  // mode and mounts the textarea. On the first save of a fresh component the
+  // preview is absent — keep the probe short so each test only pays a ~500ms
+  // tax instead of 2s.
+  const preview = page.getByTestId("edit-prompt-sanitized");
+  if (await preview.isVisible({ timeout: 500 }).catch(() => false)) {
+    await preview.click();
+  }
+
+  await expect(textarea).toBeVisible({ timeout: 10000 });
+  await textarea.click();
+  await textarea.fill(value);
+
+  await page.getByTestId("genericModalBtnSave").click();
+}
+
+// Runs the three-step rejection contract for a single invalid mustache template:
+//   1. submit the template via the mustache prompt modal
+//   2. assert the error toast carries the `errors.prompt` title + the upstream
+//      ValueError fragment (which branch of validate_mustache_template fired)
+//   3. assert the modal stays in edit mode (frontend sets isEdit=true on error)
+//
+// The fourth contract piece — "no dynamic handle was created on the node" —
+// lives at the test body level instead of inside the helper so that each
+// `test()` carries a visible body-level `expect()` for the
+// `playwright/expect-expect` lint rule.
+//
+// The four rejection tests below intentionally remain as separate `test()`
+// declarations (not a parameterised loop) so the auto-generated `Phase 0 —
+// Validated` block in QA-CHECKLIST.md surfaces one bullet per case —
+// `scripts/stable-tests.ts` renders `${expr}` template placeholders as `<expr>`
+// and would otherwise collapse the runtime tests into a single, vague bullet.
+async function runMustacheRejectionContract(
+  page: Page,
+  template: string,
+  detailIncludes: string,
+): Promise<void> {
+  await test.step(
+    `Submit \`${template}\` — invalid pattern flagged by validate_mustache_template`,
+    async () => {
+      await fillAndSaveMustacheTemplate(page, template);
+    },
+  );
+
+  await test.step(
+    "Error toast surfaces the upstream ValueError with the expected fragment",
+    async () => {
+      // The toast auto-dismisses after 5s — assert it before any other wait.
+      // `errors.prompt` title is constant; the detail list carries the upstream
+      // message that names which branch of validate_mustache_template fired.
+      const toast = errorToastLocator(page);
+      await expect(toast).toBeVisible({ timeout: 5000 });
+      await expect(toast).toContainText(ERROR_TOAST_TITLE);
+      await expect(toast).toContainText(detailIncludes);
+    },
+  );
+
+  await test.step(
+    "Modal stays in edit mode so the user can correct the input",
+    async () => {
+      await expect(
+        page.getByTestId("modal-mustachepromptarea_mustache_template"),
+      ).toBeVisible();
+      await page.keyboard.press("Escape");
+    },
+  );
+}
+
+// Note on the fixture interaction: the save POST /api/v1/validate/prompt
+// returns HTTP 500 by design in the rejection scenarios below. The fixture
+// (tests/fixtures/fixtures.ts) only fails the test on `flow_error`-type
+// events from /build/, /run/, or /events?event_delivery= — HTTP 500s on
+// other endpoints are logged as `http_error` and do not fail the test.
+// So no `page.allowFlowErrors()` opt-out is needed here (same as the f-string
+// sibling spec).
+
+test(
+  "Prompt Template — mustache `{{ var }}` (spaces inside braces) is rejected with an error toast and creates no handle",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    await test.step("Add Prompt Template and enable mustache mode", async () => {
+      await addPromptComponent(page);
+      await enableMustacheMode(page);
+    });
+
+    // Spaces inside the braces fail SIMPLE_VARIABLE_PATTERN's per-pattern match.
+    // The error detail names the offending pattern verbatim — assert on the
+    // "Invalid mustache variable" prefix plus the literal pattern.
+    await runMustacheRejectionContract(
+      page,
+      "Hello {{ var }}",
+      `${INVALID_VARIABLE_FRAGMENT}: {{ var }}`,
+    );
+
+    // Fourth piece of the rejection contract — kept at the test body level
+    // (rather than inside the helper) so each test carries a visible body-level
+    // `expect()` for the `playwright/expect-expect` rule.
+    await expect(dynamicHandlesLocator(page)).toHaveCount(0);
+  },
+);
+
+test(
+  "Prompt Template — mustache `{{var.attr}}` (dot notation) is rejected with an error toast and creates no handle",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    await test.step("Add Prompt Template and enable mustache mode", async () => {
+      await addPromptComponent(page);
+      await enableMustacheMode(page);
+    });
+
+    // Dot notation is intentionally unsupported — `safe_mustache_render` has no
+    // dot-path lookup, so the validator rejects via the SIMPLE_VARIABLE_PATTERN
+    // miss branch. Anchor on the literal `{{var.attr}}` to prove the offending
+    // pattern survived round-trip into the detail.
+    await runMustacheRejectionContract(
+      page,
+      "Hello {{var.attr}}",
+      `${INVALID_VARIABLE_FRAGMENT}: {{var.attr}}`,
+    );
+
+    await expect(dynamicHandlesLocator(page)).toHaveCount(0);
+  },
+);
+
+test(
+  "Prompt Template — mustache `{{#section}}{{/section}}` is rejected with the complex-syntax message and creates no handle",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    await test.step("Add Prompt Template and enable mustache mode", async () => {
+      await addPromptComponent(page);
+      await enableMustacheMode(page);
+    });
+
+    // `{{#` and `{{/` are both in DANGEROUS_PATTERNS — the first match short-
+    // circuits with the constant "Complex mustache syntax is not allowed"
+    // message (the pattern itself is not echoed back in this branch).
+    await runMustacheRejectionContract(
+      page,
+      "{{#section}}{{/section}}",
+      COMPLEX_SYNTAX_FRAGMENT,
+    );
+
+    await expect(dynamicHandlesLocator(page)).toHaveCount(0);
+  },
+);
+
+test(
+  "Prompt Template — mustache `{{{var}}}` (triple braces) is rejected with the complex-syntax message and creates no handle",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    await test.step("Add Prompt Template and enable mustache mode", async () => {
+      await addPromptComponent(page);
+      await enableMustacheMode(page);
+    });
+
+    // Triple braces are the mustache "unescaped HTML" sigil and are blocked by
+    // the `{{{` regex in DANGEROUS_PATTERNS — same constant message as the
+    // section case. Keeping it as its own test surfaces the case explicitly in
+    // the Phase 0 — Validated block in QA-CHECKLIST.md.
+    await runMustacheRejectionContract(
+      page,
+      "Hello {{{var}}}",
+      COMPLEX_SYNTAX_FRAGMENT,
+    );
+
+    await expect(dynamicHandlesLocator(page)).toHaveCount(0);
+  },
+);

--- a/tests/tests-automations/regression/core-components/prompt-template-invalid-mustache-patterns-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/prompt-template-invalid-mustache-patterns-regression.spec.ts
@@ -145,22 +145,27 @@ async function runMustacheRejectionContract(
   await test.step(
     "Error toast surfaces the upstream ValueError with the expected fragment",
     async () => {
-      // The toast auto-dismisses after 5s — assert it before any other wait.
-      // `errors.prompt` title is constant; the detail list carries the upstream
-      // message that names which branch of validate_mustache_template fired.
+      // The toast auto-dismisses after 5s — assert visibility once, then snapshot
+      // the text in a single read so the title + detail assertions can't race the
+      // dismissal timer. `toContainText`'s auto-retry would otherwise poll past
+      // the 5s window if the first call landed near the dismissal boundary.
       const toast = errorToastLocator(page);
       await expect(toast).toBeVisible({ timeout: 5000 });
-      await expect(toast).toContainText(ERROR_TOAST_TITLE);
-      await expect(toast).toContainText(detailIncludes);
+      const toastText = (await toast.textContent()) ?? "";
+      expect(toastText).toContain(ERROR_TOAST_TITLE);
+      expect(toastText).toContain(detailIncludes);
     },
   );
 
   await test.step(
     "Modal stays in edit mode so the user can correct the input",
     async () => {
+      // Bound to the toast's 5s lifetime — if `setIsEdit(true)` is broken, the
+      // textarea is already gone by the time we assert. Default expect timeout
+      // is 5s but pinning explicitly makes the intent visible.
       await expect(
         page.getByTestId("modal-mustachepromptarea_mustache_template"),
-      ).toBeVisible();
+      ).toBeVisible({ timeout: 5000 });
       await page.keyboard.press("Escape");
     },
   );


### PR DESCRIPTION
## Summary
- Adds 4 `@stable @regression @components` tests exercising the mustache parser rejection contract (with `use_double_brackets` toggle ON):
  - `{{ var }}` (spaces inside braces) and `{{var.attr}}` (dot notation) — `SIMPLE_VARIABLE_PATTERN` miss branch
  - `{{#section}}{{/section}}` and `{{{var}}}` (triple braces) — `DANGEROUS_PATTERNS` regex-hit branch
- Each case was probed against `POST /api/v1/validate/prompt` with `mustache=true` on Langflow 1.10.x before the spec was written — all 4 return HTTP 500 with the two distinct upstream messages the spec asserts on.
- Adds the matching spec doc and cross-references it from the two sibling docs; adds 4 bullets to QA-CHECKLIST.md §3.2 (Phase 0 — Validated block auto-regenerated, 128 → 132 `@stable` tests).

## Test plan
- [x] `npx playwright test tests/tests-automations/regression/core-components/prompt-template-invalid-mustache-patterns-regression.spec.ts` — 4 passed (17.5s)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new errors
- [x] `npm run coverage:summary` — idempotent regeneration
- [x] Live API probe confirmed all 4 cases reject as expected

## Notes
- Helper duplication with the f-string sibling spec (`addPromptComponent`, `dynamicHandlesLocator`, `errorToastLocator`, `fillAndSaveMustacheTemplate`) is intentional in this PR and tracked by #222, which now lists the 4th spec in its scope.

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)