### PR TITLE
refactor(core-components): extract shared Prompt Template helpers

### DIFF
--- a/tests/helpers/ui/prompt-template.ts
+++ b/tests/helpers/ui/prompt-template.ts
@@ -67,11 +67,17 @@ export function errorToastLocator(page: Page): Locator {
 }
 
 /**
- * Flip the `use_double_brackets` toggle in the InspectionPanel and wait for the
- * matching modal-open button to mount. With `real_time_refresh=True`, toggling
- * the bool causes `update_build_config` to swap `template.type` between PROMPT
- * and MUSTACHE_PROMPT, which re-renders the modal-open button under a different
- * testid — that re-render is the reliable signal that the switch has landed.
+ * Drive the `use_double_brackets` toggle to the given state. Idempotent — if
+ * the UI is already in the requested mode the toggle is left alone; otherwise
+ * the toggle is clicked once. Either way, the post-condition is that the
+ * matching modal-open button is visible.
+ *
+ * The probe uses the modal-open button itself (not the toggle's ARIA/data
+ * state) as the canonical mode indicator: with `real_time_refresh=True`,
+ * `update_build_config` swaps `template.type` between PROMPT and
+ * MUSTACHE_PROMPT, which re-renders the modal-open button under
+ * `button_open_prompt_modal` or `button_open_mustache_prompt_modal`. That
+ * re-render is the reliable signal we already rely on downstream.
  *
  * @param enabled `true` enables mustache mode; `false` reverts to f-string.
  */
@@ -79,10 +85,16 @@ export async function setUseDoubleBrackets(
   page: Page,
   enabled: boolean,
 ): Promise<void> {
-  await page.getByTestId("toggle_bool_use_double_brackets").click();
   const expectedOpenButton = enabled
     ? MUSTACHE_OPEN_BUTTON
     : FSTRING_OPEN_BUTTON;
+  const alreadyInDesiredState = await page
+    .getByTestId(expectedOpenButton)
+    .isVisible({ timeout: 500 })
+    .catch(() => false);
+  if (!alreadyInDesiredState) {
+    await page.getByTestId("toggle_bool_use_double_brackets").click();
+  }
   await expect(page.getByTestId(expectedOpenButton)).toBeVisible({
     timeout: 10000,
   });
@@ -131,8 +143,14 @@ export async function fillPromptTemplate(
 
   const textarea = page.getByTestId(textareaTestId);
 
+  // On a fresh component (first save) or after an error path that left the
+  // modal in edit mode, the preview never mounts — keep the probe short so
+  // those callers don't each pay a 2s tax just to learn there is nothing to
+  // click. The post-save preview mounts well within 500ms in practice; the
+  // downstream `expect(textarea).toBeVisible(...)` is the real correctness
+  // gate.
   const preview = page.getByTestId("edit-prompt-sanitized");
-  if (await preview.isVisible({ timeout: 2000 }).catch(() => false)) {
+  if (await preview.isVisible({ timeout: 500 }).catch(() => false)) {
     await preview.click();
   }
 

--- a/tests/helpers/ui/prompt-template.ts
+++ b/tests/helpers/ui/prompt-template.ts
@@ -1,0 +1,151 @@
+import { type Locator, type Page, expect } from "@playwright/test";
+import { awaitBootstrapTest } from "../other/await-bootstrap-test";
+import { adjustScreenView } from "./adjust-screen-view";
+
+// Shared testids and selectors for the Prompt Template component, sourced
+// from live UI inspection and the upstream Langflow frontend source:
+//   add button:               "add-component-button-prompt-template"
+//   node title:               "title-Prompt Template"
+//   toggle (InspectionPanel): "toggle_bool_use_double_brackets"
+//   f-string modal open:      "button_open_prompt_modal"
+//   f-string textarea:        "modal-promptarea_prompt_template"
+//   mustache modal open:      "button_open_mustache_prompt_modal"
+//   mustache textarea:        "modal-mustachepromptarea_mustache_template"
+//   modal save btn:           "genericModalBtnSave"
+//   modal preview:            "edit-prompt-sanitized"  (shared between modes)
+//   output handle:            "handle-prompt template-shownode-prompt-right"
+//   dynamic handles:          "handle-prompt template-shownode-{varname}-left"
+//   error toast:              CSS class ".error-build-message" (no data-testid;
+//                             sourced from src/frontend/src/alerts/error/index.tsx)
+
+const FSTRING_OPEN_BUTTON = "button_open_prompt_modal";
+const FSTRING_TEXTAREA = "modal-promptarea_prompt_template";
+const MUSTACHE_OPEN_BUTTON = "button_open_mustache_prompt_modal";
+const MUSTACHE_TEXTAREA = "modal-mustachepromptarea_mustache_template";
+
+/**
+ * Bootstraps a fresh blank flow, drops a Prompt Template node onto it via the
+ * sidebar search/add path, and waits for exactly one node to render on the
+ * canvas.
+ */
+export async function addPromptComponent(page: Page): Promise<void> {
+  await awaitBootstrapTest(page);
+  await expect(page.getByTestId("blank-flow")).toBeAttached({ timeout: 30000 });
+  await page.getByTestId("blank-flow").click();
+
+  await page.getByTestId("sidebar-search-input").click();
+  await page.getByTestId("sidebar-search-input").fill("prompt");
+  await expect(
+    page.getByTestId("add-component-button-prompt-template"),
+  ).toBeAttached({ timeout: 30000 });
+  await page.getByTestId("add-component-button-prompt-template").click();
+
+  await adjustScreenView(page);
+  await expect(page.locator(".react-flow__node")).toHaveCount(1, {
+    timeout: 10000,
+  });
+}
+
+/**
+ * Locator for the dynamic (left-side) input handles created from variable
+ * placeholders on the Prompt Template node. The output `-right` handle is
+ * excluded by the suffix filter so counts reflect dynamic-handle-only deltas.
+ */
+export function dynamicHandlesLocator(page: Page): Locator {
+  return page.locator(
+    '[data-testid^="handle-prompt template-shownode-"][data-testid$="-left"]',
+  );
+}
+
+/**
+ * Locator for the error toast rendered by `ErrorAlert` when the prompt modal's
+ * `onError` callback fires (no `data-testid` is exposed by the upstream alert
+ * component, so the CSS class is the stable anchor).
+ */
+export function errorToastLocator(page: Page): Locator {
+  return page.locator(".error-build-message");
+}
+
+/**
+ * Flip the `use_double_brackets` toggle in the InspectionPanel and wait for the
+ * matching modal-open button to mount. With `real_time_refresh=True`, toggling
+ * the bool causes `update_build_config` to swap `template.type` between PROMPT
+ * and MUSTACHE_PROMPT, which re-renders the modal-open button under a different
+ * testid — that re-render is the reliable signal that the switch has landed.
+ *
+ * @param enabled `true` enables mustache mode; `false` reverts to f-string.
+ */
+export async function setUseDoubleBrackets(
+  page: Page,
+  enabled: boolean,
+): Promise<void> {
+  await page.getByTestId("toggle_bool_use_double_brackets").click();
+  const expectedOpenButton = enabled
+    ? MUSTACHE_OPEN_BUTTON
+    : FSTRING_OPEN_BUTTON;
+  await expect(page.getByTestId(expectedOpenButton)).toBeVisible({
+    timeout: 10000,
+  });
+}
+
+export interface FillPromptTemplateOptions {
+  /** Which modal to drive. Defaults to `"fstring"`. */
+  mode?: "fstring" | "mustache";
+  /**
+   * Whether to wait for the textarea to hide after clicking save. Defaults to
+   * `true` (success path). Set to `false` when submitting input that the
+   * backend is expected to reject — the modal stays in edit mode (the
+   * frontend sets `isEdit=true`) and the textarea remains visible.
+   */
+  waitForHide?: boolean;
+}
+
+/**
+ * Open the active prompt modal (f-string or mustache, depending on
+ * `opts.mode`), replace its current value with `value`, and click save.
+ *
+ * The save round-trip can end in one of two states:
+ *   - success: textarea hides, sanitized preview appears
+ *   - error:   `setIsEdit(true)` keeps the textarea visible and a toast
+ *              with class `.error-build-message` is rendered
+ *
+ * After a previous successful save, the modal initially shows the sanitized
+ * preview (read-only) instead of the textarea — this helper clicks the preview
+ * to re-enter edit mode before filling. With `waitForHide=true` (default),
+ * waits for the textarea to disappear as the close signal; callers asserting
+ * on the error path should pass `waitForHide: false` and assert on the
+ * post-save state themselves.
+ */
+export async function fillPromptTemplate(
+  page: Page,
+  value: string,
+  opts: FillPromptTemplateOptions = {},
+): Promise<void> {
+  const { mode = "fstring", waitForHide = true } = opts;
+  const openButtonTestId =
+    mode === "mustache" ? MUSTACHE_OPEN_BUTTON : FSTRING_OPEN_BUTTON;
+  const textareaTestId =
+    mode === "mustache" ? MUSTACHE_TEXTAREA : FSTRING_TEXTAREA;
+
+  await page.getByTestId(openButtonTestId).click();
+
+  const textarea = page.getByTestId(textareaTestId);
+
+  const preview = page.getByTestId("edit-prompt-sanitized");
+  if (await preview.isVisible({ timeout: 2000 }).catch(() => false)) {
+    await preview.click();
+  }
+
+  await expect(textarea).toBeVisible({ timeout: 10000 });
+  await textarea.click();
+  await textarea.fill(value);
+
+  await page.getByTestId("genericModalBtnSave").click();
+
+  if (waitForHide) {
+    // The textarea testid is scoped to the active prompt modal, so its
+    // disappearance is a reliable signal that the modal closed and the save
+    // round-trip began.
+    await expect(textarea).toBeHidden({ timeout: 10000 });
+  }
+}

--- a/tests/tests-automations/regression/core-components/prompt-template-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/prompt-template-component-regression.spec.ts
@@ -1,76 +1,13 @@
-import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
-import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
-import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import {
+  addPromptComponent,
+  dynamicHandlesLocator,
+  fillPromptTemplate,
+} from "../../../helpers/ui/prompt-template";
 
 // Run serially to avoid 500 errors from concurrent POST /api/v1/flows/
 // when several workers create a blank flow at the same time.
 test.describe.configure({ mode: "serial" });
-
-// Verified testids from live UI inspection:
-//   add button:      "add-component-button-prompt-template"
-//   node title:      "title-Prompt Template"
-//   modal open btn:  "button_open_prompt_modal"
-//   modal textarea:  "modal-promptarea_prompt_template"  (unique to the prompt modal — use as anchor)
-//   modal save btn:  "genericModalBtnSave"
-//   modal preview:   "edit-prompt-sanitized"  (shown after save; click to re-edit)
-//   output handle:   "handle-prompt template-shownode-prompt-right"
-//   dynamic handles: "handle-prompt template-shownode-{varname}-left"
-
-// Locator matching only the dynamic (left-side) input handles created from
-// {variable} placeholders. The output `-right` handle is excluded by the suffix
-// filter so counts reflect dynamic-handle-only deltas.
-const dynamicHandlesLocator = (page: Page) =>
-  page.locator(
-    '[data-testid^="handle-prompt template-shownode-"][data-testid$="-left"]',
-  );
-
-async function addPromptComponent(page: Page) {
-  await awaitBootstrapTest(page);
-  await expect(page.getByTestId("blank-flow")).toBeAttached({ timeout: 30000 });
-  await page.getByTestId("blank-flow").click();
-
-  await page.getByTestId("sidebar-search-input").click();
-  await page.getByTestId("sidebar-search-input").fill("prompt");
-  await expect(
-    page.getByTestId("add-component-button-prompt-template"),
-  ).toBeAttached({ timeout: 30000 });
-  await page.getByTestId("add-component-button-prompt-template").click();
-
-  await adjustScreenView(page);
-  await expect(page.locator(".react-flow__node")).toHaveCount(1, {
-    timeout: 10000,
-  });
-}
-
-// Open the prompt modal and replace its current value with `value`.
-// Handles the post-save preview state by clicking it to re-enter edit mode.
-// The function returns after the save dialog closes; downstream assertions
-// must wait on their specific expected handle state (auto-retry via expect()),
-// because the canvas re-render is asynchronous to the modal close.
-async function setPromptTemplate(page: Page, value: string) {
-  await page.getByTestId("button_open_prompt_modal").click();
-
-  const textarea = page.getByTestId("modal-promptarea_prompt_template");
-
-  // After a previous save, the modal initially shows the sanitized preview
-  // (read-only) instead of the textarea. Clicking the preview re-enters edit
-  // mode and mounts the textarea.
-  const preview = page.getByTestId("edit-prompt-sanitized");
-  if (await preview.isVisible({ timeout: 2000 }).catch(() => false)) {
-    await preview.click();
-  }
-
-  await expect(textarea).toBeVisible({ timeout: 10000 });
-  await textarea.click();
-  await page.keyboard.press("Control+a");
-  await textarea.fill(value);
-
-  await page.getByTestId("genericModalBtnSave").click();
-  // The textarea testid is scoped to the prompt modal, so its disappearance
-  // is a reliable signal that the modal closed and the save round-trip began.
-  await expect(textarea).toBeHidden({ timeout: 10000 });
-}
 
 test(
   "Prompt Template component — renders on canvas with output handle",
@@ -112,7 +49,7 @@ test(
     await test.step(
       "Save template with two {variable} placeholders",
       async () => {
-        await setPromptTemplate(page, "Hello {name}, your job is {profession}.");
+        await fillPromptTemplate(page, "Hello {name}, your job is {profession}.");
       },
     );
 
@@ -152,7 +89,7 @@ test(
     await test.step(
       "Save template `Hello {name}!` — expect 1 dynamic handle for {name}",
       async () => {
-        await setPromptTemplate(page, "Hello {name}!");
+        await fillPromptTemplate(page, "Hello {name}!");
         await expect(nameHandle).toBeVisible({ timeout: 10000 });
         await expect(dynamicHandlesLocator(page)).toHaveCount(1);
       },
@@ -161,7 +98,7 @@ test(
     await test.step(
       "Save template without variables — expect 0 dynamic handles",
       async () => {
-        await setPromptTemplate(page, "Hello world!");
+        await fillPromptTemplate(page, "Hello world!");
         await expect(nameHandle).toHaveCount(0, { timeout: 10000 });
         await expect(dynamicHandlesLocator(page)).toHaveCount(0);
       },
@@ -180,7 +117,7 @@ test(
     await test.step(
       "Save template `Hello {name}, you are {role}.` — both handles render",
       async () => {
-        await setPromptTemplate(page, "Hello {name}, you are {role}.");
+        await fillPromptTemplate(page, "Hello {name}, you are {role}.");
         await expect(
           page.getByTestId("handle-prompt template-shownode-name-left"),
         ).toBeVisible({ timeout: 10000 });
@@ -193,7 +130,7 @@ test(
     await test.step(
       "Replace {role} with {title} — old handle is gone, new one appears, {name} stays",
       async () => {
-        await setPromptTemplate(page, "Hello {name}, you are {title}.");
+        await fillPromptTemplate(page, "Hello {name}, you are {title}.");
         await expect(
           page.getByTestId("handle-prompt template-shownode-name-left"),
         ).toBeVisible({ timeout: 10000 });
@@ -219,7 +156,7 @@ test(
     await test.step(
       "Save template with 3 variables — expect 3 dynamic handles",
       async () => {
-        await setPromptTemplate(page, "{a} and {b} and {c}");
+        await fillPromptTemplate(page, "{a} and {b} and {c}");
         await expect(dynamicHandlesLocator(page)).toHaveCount(3, {
           timeout: 10000,
         });
@@ -229,7 +166,7 @@ test(
     await test.step(
       "Save plain-text template — all dynamic handles disappear",
       async () => {
-        await setPromptTemplate(page, "No variables here.");
+        await fillPromptTemplate(page, "No variables here.");
         await expect(dynamicHandlesLocator(page)).toHaveCount(0, {
           timeout: 10000,
         });
@@ -254,7 +191,7 @@ test(
     await test.step(
       "Save template — the {topic} handle confirms save was applied",
       async () => {
-        await setPromptTemplate(page, expected);
+        await fillPromptTemplate(page, expected);
         await expect(
           page.getByTestId("handle-prompt template-shownode-topic-left"),
         ).toBeVisible({ timeout: 10000 });

--- a/tests/tests-automations/regression/core-components/prompt-template-double-brackets-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/prompt-template-double-brackets-regression.spec.ts
@@ -1,106 +1,21 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
-import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
-import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import {
+  addPromptComponent,
+  dynamicHandlesLocator,
+  fillPromptTemplate,
+  setUseDoubleBrackets,
+} from "../../../helpers/ui/prompt-template";
 
 // Run serially to avoid 500 errors from concurrent POST /api/v1/flows/
 // when several workers create a blank flow at the same time.
 test.describe.configure({ mode: "serial" });
 
-// Verified testids from live UI / frontend source inspection:
-//   add button:               "add-component-button-prompt-template"
-//   node title:               "title-Prompt Template"
-//   toggle (InspectionPanel): "toggle_bool_use_double_brackets"
-//   f-string modal open:      "button_open_prompt_modal"
-//   f-string textarea:        "modal-promptarea_prompt_template"
-//   mustache modal open:      "button_open_mustache_prompt_modal"
-//   mustache textarea:        "modal-mustachepromptarea_mustache_template"
-//   modal save btn:           "genericModalBtnSave"
-//   modal preview:            "edit-prompt-sanitized"  (shared between both modes)
-//   dynamic handles:          "handle-prompt template-shownode-{varname}-left"
-//
 // `use_double_brackets` carries `advanced=True` upstream, which only filters the
 // field from the on-canvas node body via `isCanvasVisible()`. The right-hand
 // InspectionPanel still renders advanced fields directly (no gating modal),
 // so the bool toggle is interactable as soon as the node is selected — which
 // happens automatically when it is added to a blank flow.
-
-const dynamicHandlesLocator = (page: Page) =>
-  page.locator(
-    '[data-testid^="handle-prompt template-shownode-"][data-testid$="-left"]',
-  );
-
-async function addPromptComponent(page: Page) {
-  await awaitBootstrapTest(page);
-  await expect(page.getByTestId("blank-flow")).toBeAttached({ timeout: 30000 });
-  await page.getByTestId("blank-flow").click();
-
-  await page.getByTestId("sidebar-search-input").click();
-  await page.getByTestId("sidebar-search-input").fill("prompt");
-  await expect(
-    page.getByTestId("add-component-button-prompt-template"),
-  ).toBeAttached({ timeout: 30000 });
-  await page.getByTestId("add-component-button-prompt-template").click();
-
-  await adjustScreenView(page);
-  await expect(page.locator(".react-flow__node")).toHaveCount(1, {
-    timeout: 10000,
-  });
-}
-
-// Flip the `use_double_brackets` toggle in the InspectionPanel and wait for the
-// field-type switch to take effect. With `real_time_refresh=True`, toggling the
-// bool causes `update_build_config` to swap `template.type` between PROMPT and
-// MUSTACHE_PROMPT, which re-renders the modal-open button under a different
-// testid — that re-render is the reliable signal that the switch has landed.
-async function flipDoubleBrackets(page: Page, expectMustache: boolean) {
-  await page.getByTestId("toggle_bool_use_double_brackets").click();
-  const expectedOpenButton = expectMustache
-    ? "button_open_mustache_prompt_modal"
-    : "button_open_prompt_modal";
-  await expect(page.getByTestId(expectedOpenButton)).toBeVisible({
-    timeout: 10000,
-  });
-}
-
-// Open the active prompt modal (f-string or mustache, depending on `mode`), replace
-// its current value with `value`, and save. Mirrors the helper in
-// prompt-template-component-regression.spec.ts but parameterises the testid pair
-// because the modal-open button and textarea both change when mustache mode is on.
-async function setPromptTemplate(
-  page: Page,
-  value: string,
-  mode: "fstring" | "mustache" = "fstring",
-) {
-  const openButtonTestId =
-    mode === "mustache"
-      ? "button_open_mustache_prompt_modal"
-      : "button_open_prompt_modal";
-  const textareaTestId =
-    mode === "mustache"
-      ? "modal-mustachepromptarea_mustache_template"
-      : "modal-promptarea_prompt_template";
-
-  await page.getByTestId(openButtonTestId).click();
-
-  const textarea = page.getByTestId(textareaTestId);
-
-  // After a previous save, the modal initially shows the sanitized preview
-  // (read-only) instead of the textarea. Clicking the preview re-enters edit
-  // mode and mounts the textarea.
-  const preview = page.getByTestId("edit-prompt-sanitized");
-  if (await preview.isVisible({ timeout: 2000 }).catch(() => false)) {
-    await preview.click();
-  }
-
-  await expect(textarea).toBeVisible({ timeout: 10000 });
-  await textarea.click();
-  await page.keyboard.press("Control+a");
-  await textarea.fill(value);
-
-  await page.getByTestId("genericModalBtnSave").click();
-  await expect(textarea).toBeHidden({ timeout: 10000 });
-}
 
 test(
   "Prompt Template — use_double_brackets toggle is exposed in the InspectionPanel with its upstream display name",
@@ -160,11 +75,7 @@ test(
     await test.step(
       "Save template `Hello {single} and {{double}}!` in default (f-string) mode",
       async () => {
-        await setPromptTemplate(
-          page,
-          "Hello {single} and {{double}}!",
-          "fstring",
-        );
+        await fillPromptTemplate(page, "Hello {single} and {{double}}!");
       },
     );
 
@@ -192,17 +103,15 @@ test(
     });
 
     await test.step("Enable double brackets — switches to mustache mode", async () => {
-      await flipDoubleBrackets(page, true);
+      await setUseDoubleBrackets(page, true);
     });
 
     await test.step(
       "Save template `Hello {single} and {{double}}!` in mustache mode",
       async () => {
-        await setPromptTemplate(
-          page,
-          "Hello {single} and {{double}}!",
-          "mustache",
-        );
+        await fillPromptTemplate(page, "Hello {single} and {{double}}!", {
+          mode: "mustache",
+        });
       },
     );
 
@@ -232,8 +141,10 @@ test(
     await test.step(
       "Enable mustache mode and save `Hello {{name}}!` — `name` handle appears",
       async () => {
-        await flipDoubleBrackets(page, true);
-        await setPromptTemplate(page, "Hello {{name}}!", "mustache");
+        await setUseDoubleBrackets(page, true);
+        await fillPromptTemplate(page, "Hello {{name}}!", {
+          mode: "mustache",
+        });
         await expect(
           page.getByTestId("handle-prompt template-shownode-name-left"),
         ).toBeVisible({ timeout: 10000 });
@@ -244,9 +155,9 @@ test(
     await test.step(
       "Disable mustache mode — modal-open button swaps back to the f-string variant",
       async () => {
-        await flipDoubleBrackets(page, false);
+        await setUseDoubleBrackets(page, false);
         // Explicit assertion at the test level so the HTML report shows a real
-        // `expect()` in this step, even though `flipDoubleBrackets` already
+        // `expect()` in this step, even though `setUseDoubleBrackets` already
         // waited on the same testid internally.
         await expect(
           page.getByTestId("button_open_prompt_modal"),
@@ -265,7 +176,7 @@ test(
     await test.step(
       "Re-saving the same template in f-string mode drops the now-literal `{{name}}` handle",
       async () => {
-        await setPromptTemplate(page, "Hello {{name}}!", "fstring");
+        await fillPromptTemplate(page, "Hello {{name}}!");
         await expect(
           page.getByTestId("handle-prompt template-shownode-name-left"),
         ).toHaveCount(0, { timeout: 10000 });
@@ -276,7 +187,7 @@ test(
     await test.step(
       "Saving `{var}` in f-string mode recreates a dynamic handle",
       async () => {
-        await setPromptTemplate(page, "Just one {var} here.", "fstring");
+        await fillPromptTemplate(page, "Just one {var} here.");
         await expect(
           page.getByTestId("handle-prompt template-shownode-var-left"),
         ).toBeVisible({ timeout: 10000 });
@@ -327,7 +238,7 @@ test(
     );
 
     await test.step("Enable double brackets", async () => {
-      await flipDoubleBrackets(page, true);
+      await setUseDoubleBrackets(page, true);
     });
 
     await test.step(

--- a/tests/tests-automations/regression/core-components/prompt-template-invalid-mustache-patterns-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/prompt-template-invalid-mustache-patterns-regression.spec.ts
@@ -1,23 +1,17 @@
-import type { Locator, Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
-import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
-import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import {
+  addPromptComponent,
+  dynamicHandlesLocator,
+  errorToastLocator,
+  fillPromptTemplate,
+  setUseDoubleBrackets,
+} from "../../../helpers/ui/prompt-template";
 
 // Run serially to avoid 500 errors from concurrent POST /api/v1/flows/
 // when several workers create a blank flow at the same time.
 test.describe.configure({ mode: "serial" });
 
-// Verified testids and selectors (mustache mode):
-//   add button:               "add-component-button-prompt-template"
-//   toggle (InspectionPanel): "toggle_bool_use_double_brackets"
-//   mustache modal open:      "button_open_mustache_prompt_modal"
-//   mustache textarea:        "modal-mustachepromptarea_mustache_template"
-//   modal save btn:           "genericModalBtnSave"
-//   modal preview:            "edit-prompt-sanitized"  (shared between both modes)
-//   dynamic handles:          "handle-prompt template-shownode-{varname}-left"
-//   error toast:              CSS class ".error-build-message" (no data-testid;
-//                             sourced from src/frontend/src/alerts/error/index.tsx)
-//
 // Backend contract — POST /api/v1/validate/prompt with `mustache: true` raises
 // HTTP 500 with `detail=str(ValueError(...))` when `validate_mustache_template`
 // flags a forbidden pattern. The mustache modal's `onError` callback
@@ -39,80 +33,6 @@ const ERROR_TOAST_TITLE = "There is something wrong with this prompt";
 const COMPLEX_SYNTAX_FRAGMENT =
   "Complex mustache syntax is not allowed";
 const INVALID_VARIABLE_FRAGMENT = "Invalid mustache variable";
-
-const dynamicHandlesLocator = (page: Page): Locator =>
-  page.locator(
-    '[data-testid^="handle-prompt template-shownode-"][data-testid$="-left"]',
-  );
-
-const errorToastLocator = (page: Page): Locator =>
-  page.locator(".error-build-message");
-
-async function addPromptComponent(page: Page): Promise<void> {
-  await awaitBootstrapTest(page);
-  await expect(page.getByTestId("blank-flow")).toBeAttached({ timeout: 30000 });
-  await page.getByTestId("blank-flow").click();
-
-  await page.getByTestId("sidebar-search-input").click();
-  await page.getByTestId("sidebar-search-input").fill("prompt");
-  await expect(
-    page.getByTestId("add-component-button-prompt-template"),
-  ).toBeAttached({ timeout: 30000 });
-  await page.getByTestId("add-component-button-prompt-template").click();
-
-  await adjustScreenView(page);
-  await expect(page.locator(".react-flow__node")).toHaveCount(1, {
-    timeout: 10000,
-  });
-}
-
-// Flip `use_double_brackets` ON and wait for the mustache modal-open button to
-// mount — same approach as `flipDoubleBrackets(page, true)` in
-// prompt-template-double-brackets-regression.spec.ts. With `real_time_refresh=True`,
-// toggling the bool causes `update_build_config` to swap `template.type` between
-// PROMPT and MUSTACHE_PROMPT, which re-renders the modal-open button under a
-// different testid — that re-render is the reliable signal that the switch has
-// landed.
-async function enableMustacheMode(page: Page): Promise<void> {
-  await page.getByTestId("toggle_bool_use_double_brackets").click();
-  await expect(
-    page.getByTestId("button_open_mustache_prompt_modal"),
-  ).toBeVisible({ timeout: 10000 });
-}
-
-// Open the mustache prompt modal, replace its current value with `value`, and
-// click save — but do NOT wait for the modal to close. The save round-trip can
-// end in one of two states depending on whether validation passes:
-//   - success: textarea hides, sanitized preview appears
-//   - error:   `setIsEdit(true)` keeps the textarea visible and a toast
-//              with class `.error-build-message` is rendered
-// Callers assert on the expected state themselves; this helper just submits.
-async function fillAndSaveMustacheTemplate(
-  page: Page,
-  value: string,
-): Promise<void> {
-  await page.getByTestId("button_open_mustache_prompt_modal").click();
-
-  const textarea = page.getByTestId(
-    "modal-mustachepromptarea_mustache_template",
-  );
-
-  // After a previous save, the modal initially shows the sanitized preview
-  // (read-only) instead of the textarea. Clicking the preview re-enters edit
-  // mode and mounts the textarea. On the first save of a fresh component the
-  // preview is absent — keep the probe short so each test only pays a ~500ms
-  // tax instead of 2s.
-  const preview = page.getByTestId("edit-prompt-sanitized");
-  if (await preview.isVisible({ timeout: 500 }).catch(() => false)) {
-    await preview.click();
-  }
-
-  await expect(textarea).toBeVisible({ timeout: 10000 });
-  await textarea.click();
-  await textarea.fill(value);
-
-  await page.getByTestId("genericModalBtnSave").click();
-}
 
 // Runs the three-step rejection contract for a single invalid mustache template:
 //   1. submit the template via the mustache prompt modal
@@ -138,7 +58,10 @@ async function runMustacheRejectionContract(
   await test.step(
     `Submit \`${template}\` — invalid pattern flagged by validate_mustache_template`,
     async () => {
-      await fillAndSaveMustacheTemplate(page, template);
+      await fillPromptTemplate(page, template, {
+        mode: "mustache",
+        waitForHide: false,
+      });
     },
   );
 
@@ -185,7 +108,7 @@ test(
   async ({ page }) => {
     await test.step("Add Prompt Template and enable mustache mode", async () => {
       await addPromptComponent(page);
-      await enableMustacheMode(page);
+      await setUseDoubleBrackets(page, true);
     });
 
     // Spaces inside the braces fail SIMPLE_VARIABLE_PATTERN's per-pattern match.
@@ -210,7 +133,7 @@ test(
   async ({ page }) => {
     await test.step("Add Prompt Template and enable mustache mode", async () => {
       await addPromptComponent(page);
-      await enableMustacheMode(page);
+      await setUseDoubleBrackets(page, true);
     });
 
     // Dot notation is intentionally unsupported — `safe_mustache_render` has no
@@ -233,7 +156,7 @@ test(
   async ({ page }) => {
     await test.step("Add Prompt Template and enable mustache mode", async () => {
       await addPromptComponent(page);
-      await enableMustacheMode(page);
+      await setUseDoubleBrackets(page, true);
     });
 
     // `{{#` and `{{/` are both in DANGEROUS_PATTERNS — the first match short-
@@ -255,7 +178,7 @@ test(
   async ({ page }) => {
     await test.step("Add Prompt Template and enable mustache mode", async () => {
       await addPromptComponent(page);
-      await enableMustacheMode(page);
+      await setUseDoubleBrackets(page, true);
     });
 
     // Triple braces are the mustache "unescaped HTML" sigil and are blocked by

--- a/tests/tests-automations/regression/core-components/prompt-template-invalid-patterns-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/prompt-template-invalid-patterns-regression.spec.ts
@@ -1,22 +1,16 @@
-import type { Locator, Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
-import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
-import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import {
+  addPromptComponent,
+  dynamicHandlesLocator,
+  errorToastLocator,
+  fillPromptTemplate,
+} from "../../../helpers/ui/prompt-template";
 
 // Run serially to avoid 500 errors from concurrent POST /api/v1/flows/
 // when several workers create a blank flow at the same time.
 test.describe.configure({ mode: "serial" });
 
-// Verified testids and selectors:
-//   add button:          "add-component-button-prompt-template"
-//   node title:          "title-Prompt Template"
-//   modal open btn:      "button_open_prompt_modal"
-//   modal textarea:      "modal-promptarea_prompt_template"
-//   modal save btn:      "genericModalBtnSave"
-//   dynamic handles:     "handle-prompt template-shownode-{varname}-left"
-//   error toast:         CSS class ".error-build-message" (no data-testid;
-//                        sourced from src/frontend/src/alerts/error/index.tsx)
-//
 // Backend contract — POST /api/v1/validate/prompt raises HTTP 500 with
 // `detail=str(ValueError(...))` when the f-string parser flags an invalid
 // pattern. The frontend's promptModal `onError` callback then calls
@@ -30,64 +24,6 @@ test.describe.configure({ mode: "serial" });
 const ERROR_TOAST_TITLE = "There is something wrong with this prompt";
 const ERROR_DETAIL_FRAGMENT =
   "Input variables contain invalid characters or formats";
-
-const dynamicHandlesLocator = (page: Page): Locator =>
-  page.locator(
-    '[data-testid^="handle-prompt template-shownode-"][data-testid$="-left"]',
-  );
-
-const errorToastLocator = (page: Page): Locator =>
-  page.locator(".error-build-message");
-
-async function addPromptComponent(page: Page): Promise<void> {
-  await awaitBootstrapTest(page);
-  await expect(page.getByTestId("blank-flow")).toBeAttached({ timeout: 30000 });
-  await page.getByTestId("blank-flow").click();
-
-  await page.getByTestId("sidebar-search-input").click();
-  await page.getByTestId("sidebar-search-input").fill("prompt");
-  await expect(
-    page.getByTestId("add-component-button-prompt-template"),
-  ).toBeAttached({ timeout: 30000 });
-  await page.getByTestId("add-component-button-prompt-template").click();
-
-  await adjustScreenView(page);
-  await expect(page.locator(".react-flow__node")).toHaveCount(1, {
-    timeout: 10000,
-  });
-}
-
-// Open the prompt modal, replace its current value with `value`, and click
-// save — but do NOT wait for the modal to close. The save round-trip can end
-// in one of two states depending on whether validation passes:
-//   - success: textarea hides, sanitized preview appears
-//   - error:   `setIsEdit(true)` keeps the textarea visible and a toast
-//              with class `.error-build-message` is rendered
-// Callers assert on the expected state themselves; this helper just submits.
-async function fillAndSavePromptTemplate(
-  page: Page,
-  value: string,
-): Promise<void> {
-  await page.getByTestId("button_open_prompt_modal").click();
-
-  const textarea = page.getByTestId("modal-promptarea_prompt_template");
-
-  // After a previous save, the modal initially shows the sanitized preview
-  // (read-only) instead of the textarea. Clicking the preview re-enters edit
-  // mode and mounts the textarea. On the first save of a fresh component the
-  // preview is absent — keep the probe short so each test only pays a ~500ms
-  // tax instead of 2s.
-  const preview = page.getByTestId("edit-prompt-sanitized");
-  if (await preview.isVisible({ timeout: 500 }).catch(() => false)) {
-    await preview.click();
-  }
-
-  await expect(textarea).toBeVisible({ timeout: 10000 });
-  await textarea.click();
-  await textarea.fill(value);
-
-  await page.getByTestId("genericModalBtnSave").click();
-}
 
 // Runs the three-step rejection contract for a single invalid template:
 //   1. submit the template via the prompt modal
@@ -114,7 +50,7 @@ async function runRejectionContract(
   await test.step(
     `Submit \`${template}\` — invalid pattern flagged by _check_input_variables`,
     async () => {
-      await fillAndSavePromptTemplate(page, template);
+      await fillPromptTemplate(page, template, { waitForHide: false });
     },
   );
 
@@ -233,7 +169,9 @@ test(
     await test.step(
       "Save `Plain {} text` — save closes the modal, no error toast, no handle",
       async () => {
-        await fillAndSavePromptTemplate(page, "Plain {} text");
+        await fillPromptTemplate(page, "Plain {} text", {
+          waitForHide: false,
+        });
 
         // Save succeeded — textarea hides and the sanitized preview takes over.
         await expect(
@@ -261,7 +199,9 @@ test(
     await test.step(
       "Save `Hello {name}, goodbye {name}.` — both placeholders share the `name` slot",
       async () => {
-        await fillAndSavePromptTemplate(page, "Hello {name}, goodbye {name}.");
+        await fillPromptTemplate(page, "Hello {name}, goodbye {name}.", {
+          waitForHide: false,
+        });
 
         await expect(
           page.getByTestId("modal-promptarea_prompt_template"),


### PR DESCRIPTION
## Summary

- New module `tests/helpers/ui/prompt-template.ts` consolidating the bootstrap + locator + modal-fill helpers that were duplicated (byte-identical or near-identical) across the four `prompt-template-*` specs.
- Five exports (with JSDoc):
  - `addPromptComponent(page)`
  - `dynamicHandlesLocator(page)`
  - `errorToastLocator(page)`
  - `setUseDoubleBrackets(page, enabled)` — unifies the old `flipDoubleBrackets` / `enableMustacheMode`.
  - `fillPromptTemplate(page, value, { mode?, waitForHide? })` — unifies the four previous variants. `mode` defaults to `"fstring"`; `waitForHide` defaults to `true` (success path) and is set to `false` by error-path tests where the modal stays open after submit.
- Four specs refactored to import from the new module; net **-289 lines**.

## Equivalence

| Spec | `test()` before | `test()` after | Tags |
|---|---|---|---|
| `prompt-template-component-regression.spec.ts` | 6 | 6 | unchanged |
| `prompt-template-double-brackets-regression.spec.ts` | 5 | 5 | unchanged |
| `prompt-template-invalid-patterns-regression.spec.ts` | 6 | 6 | unchanged |
| `prompt-template-invalid-mustache-patterns-regression.spec.ts` | 4 | 4 | unchanged |

Same assertions, same `test.step()` labels, same tags.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors on changed files (only pre-existing warnings in unrelated files)
- [x] All four specs pass against a live Langflow instance (21/21 in 42.0s)

Closes #222