### PR TITLE
fix(ci): install langflow with [postgresql] extra in migration-test

### DIFF
--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -75,7 +75,7 @@ jobs:
       # ── Phase 1: Langflow Latest ──────────────────────────────
       - name: Install Langflow latest
         run: |
-          uv pip install langflow
+          uv pip install "langflow[postgresql]"
           LATEST_VERSION=$(uv pip show langflow | grep ^Version | awk '{print $2}')
           echo "LATEST_VERSION=$LATEST_VERSION" >> "$GITHUB_ENV"
           echo "langflow==$LATEST_VERSION" > /tmp/latest-digest.txt
@@ -125,7 +125,7 @@ jobs:
 
       - name: Install Langflow nightly
         run: |
-          uv pip install "langflow==$NIGHTLY_VERSION"
+          uv pip install "langflow[postgresql]==$NIGHTLY_VERSION"
           echo "Installed Langflow $NIGHTLY_VERSION (nightly)"
 
       - name: Start Langflow nightly (same database)


### PR DESCRIPTION
## Summary

- `migration-test.yml` started failing on the `Wait for Langflow latest` step after [PR #230](https://github.com/oriontech-me/langflow-e2e/pull/230) replaced the Docker-based setup with `uv pip install langflow`.
- Root cause: the official Docker image bundles `psycopg2-binary`, but the PyPI package declares `psycopg2` only under the `postgresql` extra (`sqlalchemy[postgresql-psycopg2binary]`). Without the extra, Langflow crashes on startup with `ModuleNotFoundError: No module named 'psycopg2'` inside `check_postgresql_version_sync` whenever `LANGFLOW_DATABASE_URL` starts with `postgresql://`.
- Fix: add `[postgresql]` to both install steps (latest and nightly). No code or migration logic changed.

## Investigation findings (for the record)

| Question | Answer |
|---|---|
| Is the migration latest → nightly broken with Postgres? | No — confirmed working via isolated Podman test (witness flow preserved, UUID matches, alembic ran cleanly, no `UniqueViolation`). |
| Did Langflow 1.9.3 introduce a regression? | No — Langflow 1.9.2 fails with the **exact same** `ModuleNotFoundError` at the same line. The function `check_postgresql_version_sync` is present and identical in both versions. PyPI metadata for psycopg has been identical since 1.9.0. |
| Why did the workflow pass before the refactor? | Earlier runs used `docker pull langflowai/langflow:latest`, which has `psycopg2-binary` baked in. |

## Test plan

- [x] Validated locally in a Podman container running `python:3.12-slim`:
  - `pip install uv` → `uv venv .venv` → `uv pip install "langflow[postgresql]"` → `uv run langflow run`
  - Confirmed `import psycopg2` succeeds (`psycopg2 2.9.12`)
  - Langflow 1.9.3 booted, served `/api/v1/version` and loaded 32 starter projects against a fresh Postgres 16
- [ ] Re-run `migration-test.yml` after merge — should now pass the full latest → nightly flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)