### PR TITLE
test(core-components): bulk @stable validation + new If-Else regression spec

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -233,6 +233,16 @@
 - [-] Nested component
 - [-] Enter and exit grouped component
 
+#### 3.8 If-Else Component
+- [-] `operator=equals`: matching input routes through True branch (False branch stays inactive) → `core-components/if-else-component-regression.spec.ts`
+- [-] `operator=equals`: non-matching input routes through False branch (True branch stays inactive) → `core-components/if-else-component-regression.spec.ts`
+- [ ] `operator=contains` substring routing
+- [ ] `operator=regex` valid pattern routing
+- [ ] `operator=regex` hides `case_sensitive` field via `update_build_config`
+- [ ] Numeric operators (`greater than`, `less than`, etc.) — not exposed in docs but implemented in source
+- [ ] `case_sensitive` toggle behavior on text operators
+- [ ] `max_iterations` + `default_route` cycle break
+
 ---
 
 ## core-functionality/ — Core and Operational Logic

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -143,6 +143,7 @@
 - [-] Update component action
 - [ ] Update with breaking change — should alert user
 - [ ] Legacy component visible via configuration
+- [x] Re-saving code removes handles from previously-toggled advanced fields → `core-components/general-bugs-delete-handle-advanced-input.spec.ts`
 
 #### 2.4 Code Editing
 - [-] Edit Python code of custom component

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -236,11 +236,13 @@
 #### 3.8 If-Else Component
 - [-] `operator=equals`: matching input routes through True branch (False branch stays inactive) → `core-components/if-else-component-regression.spec.ts`
 - [-] `operator=equals`: non-matching input routes through False branch (True branch stays inactive) → `core-components/if-else-component-regression.spec.ts`
-- [ ] `operator=contains` substring routing
-- [ ] `operator=regex` valid pattern routing
-- [ ] `operator=regex` hides `case_sensitive` field via `update_build_config`
-- [ ] Numeric operators (`greater than`, `less than`, etc.) — not exposed in docs but implemented in source
-- [ ] `case_sensitive` toggle behavior on text operators
+- [-] `operator=contains` substring routing → `core-components/if-else-component-regression.spec.ts`
+- [-] `operator=regex` valid pattern routing → `core-components/if-else-component-regression.spec.ts`
+- [-] `operator=regex` hides `case_sensitive` field via `update_build_config` → `core-components/if-else-component-regression.spec.ts`
+- [-] `case_sensitive` ON (default) treats mixed case as no-match → `core-components/if-else-component-regression.spec.ts`
+- [-] `case_sensitive` OFF treats mixed case as a match → `core-components/if-else-component-regression.spec.ts`
+- [-] `operator=greater than` numeric routing → `core-components/if-else-component-regression.spec.ts`
+- [ ] Other numeric operators (`less than`, `less than or equal`, `greater than or equal`) — share the same `float(...)` cast as `greater than`, not separately covered
 - [ ] `max_iterations` + `default_route` cycle break
 
 ---

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -637,7 +637,7 @@
 #### 15.2 Add Components to Canvas
 - [-] Drag component from sidebar to canvas
 - [-] Double-click in sidebar adds component to canvas
-- [-] Hover + click "+" button adds component to canvas
+- [x] Hover + click "+" button adds component to canvas → `core-components/componentHoverAdd.spec.ts`
 - [-] Added component appears with default settings
 
 #### 15.3 Component Connections

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -145,7 +145,7 @@
 - [ ] Legacy component visible via configuration
 
 #### 2.4 Code Editing
-- [-] Edit Python code of custom component
+- [x] Edit Python code of custom component — Check & Save clears the pulse-pink indicator → `core-components/customComponentAdd.spec.ts`
 - [-] Full custom component
 
 ---

--- a/docs/core-components/component-hover-add.md
+++ b/docs/core-components/component-hover-add.md
@@ -1,0 +1,80 @@
+# Spec: Component Hover-to-Add — Plus Icon Affordance
+
+**Test file:** `tests/tests-automations/regression/core-components/componentHoverAdd.spec.ts`
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates
+
+Confirms the sidebar's hover-to-reveal affordance for the **Plus icon** that adds a component to the canvas with a single click. The Plus icon is intentionally hidden (`opacity-0`) on `sm+` viewports until the user hovers the corresponding sidebar row, at which point Tailwind's `group-hover/draggable:opacity-100` brings the icon into view. Clicking it appends the component to the flow without requiring drag-and-drop.
+
+The test covers two contracts in one flow:
+
+1. **Initial-state contract** — without hover, the Plus icon is rendered with computed `opacity: 0`, asserting the affordance is not visible to the user by default.
+2. **Click contract** — after hovering the component row and clicking the Plus icon, a `.react-flow__node` appears on the canvas.
+
+The hover-to-reveal CSS transition itself (opacity going from `0` to `1`) is not asserted because Playwright's `expect.poll` interleaves with the running transition in a way that yields false negatives; the initial `opacity: 0` assertion plus the successful click are sufficient to prove the feature works end-to-end.
+
+---
+
+## Tags
+
+`@release` `@stable` `@components` `@workspace`
+
+---
+
+## Step by step
+
+1. Bootstrap and open a blank flow.
+2. Wait for the sidebar search input to be visible.
+3. Type `chat input` into the search input.
+4. Wait for the `input_outputChat Input` row to be visible in the sidebar.
+5. Assert the Plus icon (`icon-Plus` inside that row) is attached to the DOM and has computed `opacity: "0"`.
+6. Hover the component row.
+7. Click the Plus icon.
+8. Assert at least one `.react-flow__node` is visible on the canvas.
+
+---
+
+## Validation criterion
+
+| Step | Criterion |
+|---|---|
+| After search `chat input` | `input_outputChat Input` row is visible within 10 s |
+| Before hover | `icon-Plus` computed `opacity === "0"` |
+| After hover + click | At least one `.react-flow__node` is visible within 10 s |
+
+---
+
+## External dependencies
+
+- `src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarDraggableComponent.tsx` — owns the `group/draggable` parent and the `sm:opacity-0 group-hover/draggable:opacity-100` classes on the Plus icon. Any change to these classes (e.g., removing the `sm:` breakpoint or the `group-hover` modifier) breaks the affordance under test.
+- `src/frontend/src/components/common/genericIconComponent/index.tsx` — renders the `icon-Plus` test ID consumed by the spec.
+- `src/frontend/src/pages/FlowPage/components/flowSidebarComponent/index.tsx` — sidebar search routing; renaming the `sidebar-search-input` test ID breaks step 2.
+
+---
+
+## What this test does not cover
+
+- The animated opacity transition itself (mid-transition values). The CSS uses `transition-all`, but the test asserts only the boundary states (initial `0` + functional click).
+- Keyboard-driven activation of the Plus button (`Enter` / `Space` while focused). Step 5's `awaitBootstrapTest` and the `data-testid` lookup are the only accessibility coverage.
+- Drag-and-drop from the sidebar (covered by `dragAndDrop.spec.ts`).
+- Below-`sm` viewports where `sm:opacity-0` does not apply and the Plus icon is permanently visible.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- Default Playwright Desktop Chrome viewport (1280×720) — wide enough to apply `sm:opacity-0`.
+- No model provider credentials required.
+
+---
+
+## Notes
+
+- Refactored from `waitForSelector` + `toBeGreaterThanOrEqual(0)` (which always passed for any non-negative number) to a deterministic two-assertion contract.
+- Force-fail probe on the final `.react-flow__node` visibility assertion confirms the test catches real regressions.
+- Validated with `--retries=0` and `--trace=on`, zero backend errors and zero flow errors.

--- a/docs/core-components/custom-component-add.md
+++ b/docs/core-components/custom-component-add.md
@@ -1,0 +1,78 @@
+# Spec: Custom Component — Add and Save Flow
+
+**Test file:** `tests/tests-automations/regression/core-components/customComponentAdd.spec.ts`
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates
+
+Confirms the end-to-end flow of adding a **Custom Component** from the sidebar and saving its code:
+
+1. The dedicated **`sidebar-custom-component-button`** drops a new Custom Component onto the canvas.
+2. The newly-added component renders its `code-button-modal` with the **`animate-pulse-pink`** class — a visual indicator that the code is unsaved and the user must review/save it before the component is usable.
+3. Opening the code editor (Ace editor inside the modal), replacing the boilerplate with valid Python, and clicking **Check & Save** removes the `animate-pulse-pink` class — confirming the save round-trip succeeded and the component is no longer flagged as needing attention.
+
+The pulse-pink visual contract is the user-facing signal that Langflow uses to disambiguate "default scaffolded code" from "user-confirmed code". Losing this signal would silently let unsaved scaffolds propagate into flows.
+
+---
+
+## Tags
+
+`@release` `@stable` `@components`
+
+---
+
+## Step by step
+
+1. Bootstrap and open a blank flow.
+2. Click `sidebar-custom-component-button` to add a Custom Component.
+3. Assert the last `code-button-modal` on the canvas is visible and has the `animate-pulse-pink` class.
+4. Click the `code-button-modal` to open the code editor.
+5. Click into the Ace editor, select all (`Ctrl/Cmd+A`), and fill with a minimal valid Custom Component class.
+6. Click **Check & Save**.
+7. Assert the `code-button-modal` no longer has the `animate-pulse-pink` class.
+
+---
+
+## Validation criterion
+
+| Step | Criterion |
+|---|---|
+| After sidebar click | `code-button-modal` is visible within 10 s |
+| Initial state | `code-button-modal` has `animate-pulse-pink` class |
+| After Check & Save | `code-button-modal` no longer has `animate-pulse-pink` class within 10 s |
+
+---
+
+## External dependencies
+
+- `src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarHeaderComponent/index.tsx` — owns the `sidebar-custom-component-button` test ID. Renaming it breaks step 2.
+- `src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/CodeButton/index.tsx` (or equivalent) — emits the `code-button-modal` test ID and applies the `animate-pulse-pink` class while code is unsaved. A change to either the test ID or the class name breaks the entire spec.
+- `src/frontend/src/modals/codeAreaModal/index.tsx` — Ace editor lives here. The `.ace_content` selector and the underlying `<textarea>` mirror are stable since multiple specs depend on them.
+- `src/backend/base/langflow/custom/custom_component/component.py` — Check & Save calls validation here; if validation rejects the minimal Component class shipped in the spec body, step 6 fails.
+
+---
+
+## What this test does not cover
+
+- Code validation errors. The spec ships a syntactically and semantically valid Custom Component; a syntax error would be caught by a separate test.
+- Connecting the saved Custom Component to other nodes. The test stops at save confirmation.
+- Persisting the Custom Component code across flow reload — covered by general save/load specs.
+- The drag-and-drop alternative to the dedicated sidebar button.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- No model provider credentials required.
+
+---
+
+## Notes
+
+- Refactored from `waitForSelector` with 3 s timeouts to `expect().toBeVisible({ timeout: 10000 })`, dropped the unused `sleep(60)` line from the embedded code (it was copy-pasted from a stop-building test and never exercised here).
+- Force-fail probe on the final `not.toHaveClass` assertion confirms the test catches real regressions.
+- Validated with `--retries=0` and `--trace=on`, zero backend errors.

--- a/docs/core-components/general-bugs-delete-handle-advanced-input.md
+++ b/docs/core-components/general-bugs-delete-handle-advanced-input.md
@@ -1,0 +1,84 @@
+# Spec: Delete Handles from Advanced Fields When Code Is Updated
+
+**Test file:** `tests/tests-automations/regression/core-components/general-bugs-delete-handle-advanced-input.spec.ts`
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates
+
+Regression test for a bug where dynamic handles tied to **advanced fields** lingered on the canvas after the component's code was re-saved. Toggling an advanced field exposes an input handle on the node; re-saving the component code should re-evaluate the field config and drop the now-orphaned handle (and the lock icon decorating connected upstream edges).
+
+The test exercises the **If-Else** component because it has a togglable `true_case_message` advanced field that historically left a dangling handle after the user re-saved the code. The contract under test:
+
+1. Toggling `showtrue_case_message` exposes a "Receiving input" placeholder.
+2. Connecting Text Input → If-Else's `case true` produces a locked handle (visible in Advanced view as another "Receiving input" placeholder + a lock icon).
+3. After clicking **Check & Save** in the code modal with the default code, the advanced field config is re-evaluated and both the "Receiving input" placeholders and the lock icon are removed (`count === 0`).
+
+---
+
+## Tags
+
+`@release` `@stable` `@components`
+
+---
+
+## Step by step
+
+1. Bootstrap and open a blank flow.
+2. Add the **If-Else** component from the sidebar.
+3. Disable the inspect panel, open Advanced Options.
+4. Toggle `showtrue_case_message`, then close Advanced Options.
+5. Add a **Text Input** component (drag onto canvas).
+6. Connect Text Input's output handle to If-Else's `case true` input handle.
+7. Click the If-Else title and open Advanced Options again — assert exactly 2 "Receiving input" placeholders are visible.
+8. Close Advanced Options.
+9. Click the If-Else title, open the code modal, click **Check & Save** (resaves the default code).
+10. Open Advanced Options.
+11. Assert exactly 0 "Receiving input" placeholders **and** exactly 0 `icon-lock` icons.
+12. Close Advanced Options and re-enable the inspect panel.
+
+---
+
+## Validation criterion
+
+| Step | Criterion |
+|---|---|
+| After connecting Text Input → If-Else | Advanced view shows `toHaveCount(2)` `Receiving input` placeholders |
+| After Check & Save on code modal | Advanced view shows `toHaveCount(0)` `Receiving input` placeholders |
+| After Check & Save on code modal | Advanced view shows `toHaveCount(0)` `icon-lock` icons |
+
+---
+
+## External dependencies
+
+- `src/backend/base/langflow/components/logic/conditional_router.py` — If-Else component. The `true_case_message` advanced field and its `show` toggle must exist for step 4 to find `showtrue_case_message` test ID.
+- `src/frontend/src/CustomNodes/GenericNode/components/parameterRenderComponent/index.tsx` — emits the `Receiving input` placeholder for unconnected handles.
+- `src/frontend/src/modals/codeAreaModal/index.tsx` — Check & Save flow. The post-save handle cleanup happens here (or in the store that handles the resulting reducer call).
+- `src/frontend/src/components/genericIconComponent/index.tsx` — emits the `icon-lock` test ID consumed by the spec.
+- `helpers/ui/open-advanced-options.ts` — `openAdvancedOptions`, `closeAdvancedOptions`, `enableInspectPanel`, `disableInspectPanel`. Renaming these helpers breaks the spec.
+
+---
+
+## What this test does not cover
+
+- Persistence across flow reload — the test re-opens the same node in the same session.
+- The case where the user modifies the code (not just resaves the default). The bug fix specifically targeted resave with unchanged code.
+- Other components with advanced fields. If-Else is the canonical reproduction case.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- No model provider credentials required.
+
+---
+
+## Notes
+
+- Refactored from `waitForSelector` (with one 100 s timeout) to `expect().toBeVisible({ timeout: 10000 })` and `toHaveCount`.
+- Replaced `.hover().then(...)` chain with sequential awaits.
+- Stability: 3 / 3 PASS across consecutive runs (~10–12 s each).
+- Force-fail probe on the post-save `toHaveCount(0)` assertion confirms the test catches real regressions.

--- a/docs/core-components/if-else-component-regression.md
+++ b/docs/core-components/if-else-component-regression.md
@@ -8,14 +8,11 @@
 
 ## What this test validates
 
-Covers the foundational routing contract of the **If-Else** (ConditionalRouter) component for `operator=equals`:
+Covers the routing contract of the **If-Else** (ConditionalRouter) component across the operator surface: every text operator (equals, contains, regex), the `case_sensitive` toggle (default ON / explicit OFF), and one representative numeric operator (`greater than`). Each scenario is a separate `test()` so a failure pinpoints the exact behavior that regressed.
 
-1. **Match → True branch:** when `input_text` exactly equals `match_text`, the True output's downstream node builds successfully and the False output's downstream node is marked **inactive** (skipped).
-2. **No-match → False branch:** when `input_text` differs from `match_text`, the False output's downstream node builds and the True output's downstream node is **inactive**.
+For every scenario except the regex side-effect test, the assertion surface is the canvas node status: `node_duration_<name>` testid for the branch that built (active) and `node_status_icon_<name>_inactive` testid for the branch that was skipped. This is the same surface used by `flow-functionality/general-bugs-reset-flow-run.spec.ts` and is more reliable than message-content assertions because the component returns an empty Message on the inactive branch (so message presence alone cannot distinguish the routes).
 
-This contract is the load-bearing behavior of If-Else — every other operator (`contains`, `regex`, numeric comparisons) builds on the same active/inactive routing model. If `equals` routing breaks, the rest of the operator surface breaks with it. The two tests in this spec are scoped to that foundational case; future scenarios (`contains`, `regex`, `case_sensitive`, numeric, `max_iterations`) are listed as unchecked items under QA-CHECKLIST.md §3.8.
-
-The assertion surface is the canvas node status — `node_duration_<name>` testid for the branch that built and `node_status_icon_<name>_inactive` testid for the branch that was skipped. This is the same surface used by `flow-functionality/general-bugs-reset-flow-run.spec.ts` and is more reliable than message-content assertions because the component returns an empty Message on the inactive branch (so message presence alone cannot distinguish the routes).
+The one exception is the regex side-effect test: when `operator=regex`, the component's `update_build_config` removes the `case_sensitive` field from the build config. The assertion there is that opening the edit-fields modal shows `toHaveCount(0)` for the `showcase_sensitive` testid (it is normally `1`).
 
 ---
 
@@ -27,50 +24,81 @@ The assertion surface is the canvas node status — `node_duration_<name>` testi
 
 ---
 
-## Step by step (per test)
+## Scenarios (one `test()` per row)
 
-Both tests share the same setup, parameterized only by `input_text`:
+| # | Scenario | operator | input_text | match_text | case_sensitive | Active branch | Inactive branch |
+|---|---|---|---|---|---|---|---|
+| 1 | `equals` match (existing) | equals | hello | hello | default | True | False |
+| 2 | `equals` no-match (existing) | equals | world | hello | default | False | True |
+| 3 | `contains` substring match | contains | langflow | lang | default | True | False |
+| 4 | `regex` valid pattern match | regex | abc123 | `^abc` | (N/A — regex ignores) | True | False |
+| 5 | `regex` hides `case_sensitive` field | regex | — | — | — | — (DOM check) | — |
+| 6 | `case_sensitive` ON (default) → no-match on mixed case | equals | HELLO | hello | ON (default) | False | True |
+| 7 | `case_sensitive` OFF → match on mixed case | equals | HELLO | hello | OFF (toggled) | True | False |
+| 8 | `greater than` (numeric) match | greater than | 10 | 5 | default | True | False |
+
+Tests 1 & 2 are already implemented; this update adds tests 3–8.
+
+---
+
+## Shared setup helper
+
+`buildIfElseRoutingFlow(page)` (defined in the spec):
 
 1. Bootstrap and open a blank flow.
 2. Add the **If-Else** component from the sidebar.
 3. Zoom out so two more components fit.
 4. Drop two **Text Output** components onto the canvas (positions: `{100, 100}` and `{200, 400}`).
-5. Rename the second Text Output to `textoutputfalse` (so its testid suffix is stable).
+5. Rename the second Text Output to `textoutputfalse` so its testid suffix is stable.
 6. Wire `handle-conditionalrouter-shownode-true-right` → first Text Output's `inputs-left` handle.
 7. Wire `handle-conditionalrouter-shownode-false-right` → `textoutputfalse`'s `inputs-left` handle.
-8. Fill `popover-anchor-input-input_text` and `popover-anchor-input-match_text` with the scenario values (`hello`/`hello` for match, `world`/`hello` for no-match).
-9. Click the run button on the branch that should activate (`button_run_text output` for True, `button_run_textoutputfalse` for False).
-10. Wait for the **built successfully** notification.
-11. Assert that the active branch's `node_duration_*` testid has count 1 and the inactive branch's `node_status_icon_*_inactive` testid has count 1.
+
+Each test calls this helper and then applies the scenario-specific configuration before running.
 
 ---
 
-## Validation criterion
+## New local helpers
 
-| Scenario | Active branch (`toHaveCount(1)`) | Inactive branch (`toHaveCount(1)`) |
+| Helper | Purpose | Selectors |
 |---|---|---|
-| `input_text=hello`, `match_text=hello` | `node_duration_text output` | `node_status_icon_textoutputfalse_inactive` |
-| `input_text=world`, `match_text=hello` | `node_duration_textoutputfalse` | `node_status_icon_text output_inactive` |
+| `selectOperator(page, optionTestid)` | Click the operator dropdown trigger, then click the option | `dropdown_str_operator` button → `<operator>-<idx>-option` (e.g. `contains-2-option`, `regex-5-option`, `greater than-8-option`) |
+| `exposeCaseSensitive(page)` | Toggle the case_sensitive advanced field to be visible on the node | open `edit-fields-button` → click `showcase_sensitive` → close edit-fields |
+| `toggleCaseSensitiveOff(page)` | Switch the BoolInput on the node from ON to OFF after exposure | click `toggle_bool_case_sensitive` (BUTTON role=switch); precondition: `exposeCaseSensitive` already ran |
+
+---
+
+## Validation criterion (per scenario)
+
+| # | Active branch (`toHaveCount(1)`) | Inactive branch (`toHaveCount(1)`) | Additional |
+|---|---|---|---|
+| 1 | `node_duration_text output` | `node_status_icon_textoutputfalse_inactive` | — |
+| 2 | `node_duration_textoutputfalse` | `node_status_icon_text output_inactive` | — |
+| 3 | `node_duration_text output` | `node_status_icon_textoutputfalse_inactive` | — |
+| 4 | `node_duration_text output` | `node_status_icon_textoutputfalse_inactive` | — |
+| 5 | — | — | After switching to `regex`, opening edit-fields shows `toHaveCount(0)` for `showcase_sensitive`. With `equals`, count is `1`. |
+| 6 | `node_duration_textoutputfalse` | `node_status_icon_text output_inactive` | — |
+| 7 | `node_duration_text output` | `node_status_icon_textoutputfalse_inactive` | — |
+| 8 | `node_duration_text output` | `node_status_icon_textoutputfalse_inactive` | — |
 
 ---
 
 ## External dependencies
 
-- `src/lfx/src/lfx/components/flow_controls/conditional_router.py` — owns the routing logic; `evaluate_condition` and `iterate_and_stop_once` together implement the active/inactive branch behavior the spec asserts.
+- `src/lfx/src/lfx/components/flow_controls/conditional_router.py` — owns the routing logic; `evaluate_condition`, `update_build_config`, and `iterate_and_stop_once` together implement the active/inactive branch behavior, case-sensitivity, and the regex hides-`case_sensitive` side-effect the spec asserts.
 - `src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx` (or equivalent) — emits the `node_duration_*` and `node_status_icon_*_inactive` test IDs consumed by the assertions.
+- `src/frontend/src/components/core/parameterRenderComponent/components/dropdownComponent/index.tsx` — owns `dropdown_str_*` and the `<value>-<idx>-option` testids used by `selectOperator`.
+- `helpers/ui/open-advanced-options.ts` — `openAdvancedOptions`/`closeAdvancedOptions` (clicks `edit-fields-button`). Used by `exposeCaseSensitive` and by the regex side-effect assertion.
 - `helpers/ui/zoom-out.ts` and `helpers/ui/adjust-screen-view.ts` — used to fit all three nodes in the visible canvas before wiring.
 
 ---
 
 ## What this test does not cover
 
-- All operators except `equals`. The other 9 operators (`not equals`, `contains`, `starts with`, `ends with`, `regex`, `less than`, `less than or equal`, `greater than`, `greater than or equal`) are exercised only via the underlying `evaluate_condition` Python logic, not via UI regression.
-- The `case_sensitive` toggle behavior on text operators.
-- The `regex` operator's hide-`case_sensitive` side effect (`update_build_config` real-time refresh).
-- The cycle-handling code path (`max_iterations`, `default_route`, `iterate_and_stop_once`).
-- The advanced fields `true_case_message` and `false_case_message` — left default (empty Message) for both tests since the assertion surface is node-status, not message content.
-- Numeric operators are documented as undocumented (the public docs list 6 operators; the Python source has 10). The numeric branch is therefore not covered until either the docs are updated or the team confirms the numeric surface is intentional.
-- Playground end-to-end interaction. The test uses direct `popover-anchor-input-*` fills instead of `ChatInput → Playground` because the routing assertion does not depend on which input source feeds `input_text`.
+- Operators `not equals`, `starts with`, `ends with`, `less than`, `less than or equal`, `greater than or equal`. The text operators all share `evaluate_condition` plumbing covered by tests 1–4 + 6–7; the remaining numeric operators are skipped because they all use the same `float(...)` cast covered by test 8.
+- Non-numeric input to a numeric operator (the Python `ValueError` fallback returning `False`). Documented in the source but not exposed in the public docs; tracked as `[ ]` in QA-CHECKLIST.md §3.8.
+- `max_iterations` and `default_route` cycle-handling behavior. Requires a flow with a cycle which is out of scope for a single-step regression.
+- Playground end-to-end (`ChatInput → If-Else → ChatOutput`). The routing assertion does not depend on which input source feeds `input_text`, and tests 1–8 already prove the routing logic.
+- Advanced field `true_case_message` / `false_case_message`: left empty for every scenario. Their custom-message routing is a separate behavior tested elsewhere.
 
 ---
 
@@ -83,6 +111,8 @@ Both tests share the same setup, parameterized only by `input_text`:
 
 ## Notes
 
-- Stability: 3 / 3 PASS across consecutive runs (~16–23 s for 2 tests).
-- Force-fail probe on the True-branch `node_duration_text output` `toHaveCount(1)` assertion (changed to `99`) failed at the expected line; reverted, re-passed.
-- The two ChatInput-positioned Text Output components are dragged via `dragTo` to avoid the default-stack issue noted in the project memory (two sidebar `+` clicks land in the same position).
+- Stability: 3 / 3 PASS for the original 2 tests (~16–23 s). New scenarios will be re-validated with the same pipeline (typecheck + lint + stability + force-fail + trace + backend audit) before commit.
+- Force-fail probe pattern: temporarily change the active-branch `node_duration_*` `toHaveCount(1)` to `toHaveCount(99)` for one representative scenario per setup variant (default, exposed case_sensitive, switched operator). Confirm failure at the expected line, revert, re-pass.
+- The two Text Output components are dragged via `dragTo` to avoid the default-stack issue noted in the project memory (two sidebar `+` clicks land in the same position).
+- Operator dropdown options are selected by testid `<operator>-<idx>-option` where the operator name is verbatim (with spaces — `greater than-8-option`, not `greater_than-8-option`). The dropdown is Radix Select; `role="option"` is also available as a fallback.
+- The `case_sensitive` BoolInput uses testid `toggle_bool_case_sensitive` with `role="switch"`; toggling once flips from ON to OFF.

--- a/docs/core-components/if-else-component-regression.md
+++ b/docs/core-components/if-else-component-regression.md
@@ -1,0 +1,88 @@
+# Spec: If-Else Component — Routing Regression
+
+**Test file:** `tests/tests-automations/regression/core-components/if-else-component-regression.spec.ts`
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates
+
+Covers the foundational routing contract of the **If-Else** (ConditionalRouter) component for `operator=equals`:
+
+1. **Match → True branch:** when `input_text` exactly equals `match_text`, the True output's downstream node builds successfully and the False output's downstream node is marked **inactive** (skipped).
+2. **No-match → False branch:** when `input_text` differs from `match_text`, the False output's downstream node builds and the True output's downstream node is **inactive**.
+
+This contract is the load-bearing behavior of If-Else — every other operator (`contains`, `regex`, numeric comparisons) builds on the same active/inactive routing model. If `equals` routing breaks, the rest of the operator surface breaks with it. The two tests in this spec are scoped to that foundational case; future scenarios (`contains`, `regex`, `case_sensitive`, numeric, `max_iterations`) are listed as unchecked items under QA-CHECKLIST.md §3.8.
+
+The assertion surface is the canvas node status — `node_duration_<name>` testid for the branch that built and `node_status_icon_<name>_inactive` testid for the branch that was skipped. This is the same surface used by `flow-functionality/general-bugs-reset-flow-run.spec.ts` and is more reliable than message-content assertions because the component returns an empty Message on the inactive branch (so message presence alone cannot distinguish the routes).
+
+---
+
+## Tags
+
+`@regression` `@components`
+
+> Not `@stable` initially — the spec is new; promote to `@stable` after a few weekly runs prove it stable.
+
+---
+
+## Step by step (per test)
+
+Both tests share the same setup, parameterized only by `input_text`:
+
+1. Bootstrap and open a blank flow.
+2. Add the **If-Else** component from the sidebar.
+3. Zoom out so two more components fit.
+4. Drop two **Text Output** components onto the canvas (positions: `{100, 100}` and `{200, 400}`).
+5. Rename the second Text Output to `textoutputfalse` (so its testid suffix is stable).
+6. Wire `handle-conditionalrouter-shownode-true-right` → first Text Output's `inputs-left` handle.
+7. Wire `handle-conditionalrouter-shownode-false-right` → `textoutputfalse`'s `inputs-left` handle.
+8. Fill `popover-anchor-input-input_text` and `popover-anchor-input-match_text` with the scenario values (`hello`/`hello` for match, `world`/`hello` for no-match).
+9. Click the run button on the branch that should activate (`button_run_text output` for True, `button_run_textoutputfalse` for False).
+10. Wait for the **built successfully** notification.
+11. Assert that the active branch's `node_duration_*` testid has count 1 and the inactive branch's `node_status_icon_*_inactive` testid has count 1.
+
+---
+
+## Validation criterion
+
+| Scenario | Active branch (`toHaveCount(1)`) | Inactive branch (`toHaveCount(1)`) |
+|---|---|---|
+| `input_text=hello`, `match_text=hello` | `node_duration_text output` | `node_status_icon_textoutputfalse_inactive` |
+| `input_text=world`, `match_text=hello` | `node_duration_textoutputfalse` | `node_status_icon_text output_inactive` |
+
+---
+
+## External dependencies
+
+- `src/lfx/src/lfx/components/flow_controls/conditional_router.py` — owns the routing logic; `evaluate_condition` and `iterate_and_stop_once` together implement the active/inactive branch behavior the spec asserts.
+- `src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx` (or equivalent) — emits the `node_duration_*` and `node_status_icon_*_inactive` test IDs consumed by the assertions.
+- `helpers/ui/zoom-out.ts` and `helpers/ui/adjust-screen-view.ts` — used to fit all three nodes in the visible canvas before wiring.
+
+---
+
+## What this test does not cover
+
+- All operators except `equals`. The other 9 operators (`not equals`, `contains`, `starts with`, `ends with`, `regex`, `less than`, `less than or equal`, `greater than`, `greater than or equal`) are exercised only via the underlying `evaluate_condition` Python logic, not via UI regression.
+- The `case_sensitive` toggle behavior on text operators.
+- The `regex` operator's hide-`case_sensitive` side effect (`update_build_config` real-time refresh).
+- The cycle-handling code path (`max_iterations`, `default_route`, `iterate_and_stop_once`).
+- The advanced fields `true_case_message` and `false_case_message` — left default (empty Message) for both tests since the assertion surface is node-status, not message content.
+- Numeric operators are documented as undocumented (the public docs list 6 operators; the Python source has 10). The numeric branch is therefore not covered until either the docs are updated or the team confirms the numeric surface is intentional.
+- Playground end-to-end interaction. The test uses direct `popover-anchor-input-*` fills instead of `ChatInput → Playground` because the routing assertion does not depend on which input source feeds `input_text`.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- No model provider credentials required — If-Else is pure text comparison.
+
+---
+
+## Notes
+
+- Stability: 3 / 3 PASS across consecutive runs (~16–23 s for 2 tests).
+- Force-fail probe on the True-branch `node_duration_text output` `toHaveCount(1)` assertion (changed to `99`) failed at the expected line; reverted, re-passed.
+- The two ChatInput-positioned Text Output components are dragged via `dragTo` to avoid the default-stack issue noted in the project memory (two sidebar `+` clicks land in the same position).

--- a/tests/tests-automations/regression/core-components/componentHoverAdd.spec.ts
+++ b/tests/tests-automations/regression/core-components/componentHoverAdd.spec.ts
@@ -3,58 +3,37 @@ import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test"
 
 test(
   "user can add components by hovering and clicking the plus icon",
-  { tag: ["@release", "@components", "@workspace"] },
+  { tag: ["@release", "@components", "@workspace", "@stable"] },
 
   async ({ page }) => {
-    // Navigate to homepage and handle initial modal
     await awaitBootstrapTest(page);
 
-    // Start with blank flow
     await page.getByTestId("blank-flow").click();
-    await page.waitForSelector('[data-testid="sidebar-search-input"]', {
-      timeout: 3000,
+    await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
+      timeout: 10000,
     });
 
-    // Search for a component
     await page.getByTestId("sidebar-search-input").click();
     await page.getByTestId("sidebar-search-input").fill("chat input");
 
-    await page.waitForSelector('[data-testid="input_outputChat Input"]', {
-      timeout: 2000,
-    });
-    // Hover over the component and verify plus icon
     const componentLocator = page.getByTestId("input_outputChat Input");
-    // Find the plus icon within the specific component container
+    await expect(componentLocator).toBeVisible({ timeout: 10000 });
+
     const plusIcon = componentLocator.getByTestId("icon-Plus");
+    await expect(plusIcon).toBeAttached();
 
-    // Get the opacity
-    const opacity = await plusIcon.evaluate((el) =>
-      window.getComputedStyle(el).getPropertyValue("opacity"),
+    // Plus icon starts hidden (opacity 0 on sm+ viewports) — confirms the
+    // hover-to-reveal affordance is wired up correctly.
+    const initialOpacity = await plusIcon.evaluate(
+      (el) => window.getComputedStyle(el).opacity,
     );
-
-    await expect(plusIcon).toBeVisible();
-
-    await expect(opacity).toBe("0");
+    expect(initialOpacity).toBe("0");
 
     await componentLocator.hover();
-    // Hover over the component
-    await expect(plusIcon).toBeVisible();
-    // Wait for the animation to change the opacity
-    await page.waitForTimeout(500);
-
-    const opacityAfterHover = await plusIcon.evaluate((el) =>
-      window.getComputedStyle(el).getPropertyValue("opacity"),
-    );
-
-    expect(Number(opacityAfterHover)).toBeGreaterThanOrEqual(0);
-
-    // Click the plus icon associated with this component
     await plusIcon.click();
-    // Wait for the component to be added to the flow
-    await page.waitForSelector(".react-flow__node", { timeout: 1000 });
 
-    // Verify component was added to the flow
-    const addedComponent = page.locator(".react-flow__node").first();
-    await expect(addedComponent).toBeVisible();
+    await expect(page.locator(".react-flow__node").first()).toBeVisible({
+      timeout: 10000,
+    });
   },
 );

--- a/tests/tests-automations/regression/core-components/customComponentAdd.spec.ts
+++ b/tests/tests-automations/regression/core-components/customComponentAdd.spec.ts
@@ -3,39 +3,33 @@ import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test"
 
 test(
   "custom component code button should be pink when adding custom component",
-  { tag: ["@release", "@components"] },
+  { tag: ["@release", "@components", "@stable"] },
 
   async ({ page }) => {
     await awaitBootstrapTest(page);
 
-    await page.waitForSelector('[data-testid="blank-flow"]', {
-      timeout: 3000,
+    await expect(page.getByTestId("blank-flow")).toBeVisible({
+      timeout: 10000,
     });
-
     await page.getByTestId("blank-flow").click();
 
-    await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
-      timeout: 3000,
+    await expect(page.getByTestId("canvas_controls_dropdown")).toBeVisible({
+      timeout: 10000,
     });
 
     await page.getByTestId("sidebar-custom-component-button").click();
 
-    await expect(page.getByTestId("code-button-modal").last()).toBeVisible({
-      timeout: 3000,
-    });
+    const codeButton = page.getByTestId("code-button-modal").last();
 
-    await expect(page.getByTestId("code-button-modal").last()).toHaveClass(
-      /animate-pulse-pink/,
-    );
+    await expect(codeButton).toBeVisible({ timeout: 10000 });
+    await expect(codeButton).toHaveClass(/animate-pulse-pink/);
 
-    await page.getByTestId("code-button-modal").last().click();
+    await codeButton.click();
 
-    const waitTimeoutCode = `
-# from langflow.field_typing import Data
+    const customComponentCode = `
 from langflow.custom import Component
 from langflow.io import MessageTextInput, Output
 from langflow.schema import Data
-from time import sleep
 from langflow.schema.message import Message
 
 class CustomComponent(Component):
@@ -56,18 +50,16 @@ class CustomComponent(Component):
     def build_output(self) -> Message:
         data = Data(value=self.input_value)
         self.status = data
-        sleep(60)
         return data`;
 
     await page.locator(".ace_content").click();
     await page.keyboard.press(`ControlOrMeta+A`);
-    await page.locator("textarea").fill(waitTimeoutCode);
+    await page.locator("textarea").fill(customComponentCode);
 
     await page.getByText("Check & Save").last().click();
 
-    await expect(page.getByTestId("code-button-modal").last()).not.toHaveClass(
-      /animate-pulse-pink/,
-      { timeout: 3000 },
-    );
+    await expect(codeButton).not.toHaveClass(/animate-pulse-pink/, {
+      timeout: 10000,
+    });
   },
 );

--- a/tests/tests-automations/regression/core-components/general-bugs-delete-handle-advanced-input.spec.ts
+++ b/tests/tests-automations/regression/core-components/general-bugs-delete-handle-advanced-input.spec.ts
@@ -10,25 +10,24 @@ import {
 
 test(
   "the system must delete the handles from advanced fields when the code is updated",
-  { tag: ["@release", "@components"] },
+  { tag: ["@release", "@components", "@stable"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 
     await page.getByTestId("blank-flow").click();
 
-    await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
-      timeout: 100000,
+    await expect(page.getByTestId("canvas_controls_dropdown")).toBeVisible({
+      timeout: 30000,
     });
 
     await page.getByTestId("sidebar-search-input").click();
     await page.getByTestId("sidebar-search-input").fill("if else");
 
-    await page
-      .getByTestId("flow_controlsIf-Else")
-      .hover()
-      .then(async () => {
-        await page.getByTestId("add-component-button-if-else").click();
-      });
+    await expect(page.getByTestId("flow_controlsIf-Else")).toBeVisible({
+      timeout: 10000,
+    });
+    await page.getByTestId("flow_controlsIf-Else").hover();
+    await page.getByTestId("add-component-button-if-else").click();
 
     await adjustScreenView(page, { numberOfZoomOut: 3 });
 
@@ -41,8 +40,8 @@ test(
 
     await page.getByTestId("sidebar-search-input").click();
     await page.getByTestId("sidebar-search-input").fill("text input");
-    await page.waitForSelector('[data-testid="input_outputText Input"]', {
-      timeout: 2000,
+    await expect(page.getByTestId("input_outputText Input")).toBeVisible({
+      timeout: 10000,
     });
     await page
       .getByTestId("input_outputText Input")
@@ -64,11 +63,7 @@ test(
 
     await openAdvancedOptions(page);
 
-    const numberOfDisabledInputs = await page
-      .getByPlaceholder("Receiving input")
-      .count();
-
-    expect(numberOfDisabledInputs).toBe(2);
+    await expect(page.getByPlaceholder("Receiving input")).toHaveCount(2);
 
     await closeAdvancedOptions(page);
 
@@ -80,15 +75,8 @@ test(
 
     await openAdvancedOptions(page);
 
-    const numberOfDisabledInputsAfter = await page
-      .getByPlaceholder("Receiving input")
-      .count();
-
-    expect(numberOfDisabledInputsAfter).toBe(0);
-
-    const numberOfLockIconsAfter = await page.getByTestId("icon-lock").count();
-
-    expect(numberOfLockIconsAfter).toBe(0);
+    await expect(page.getByPlaceholder("Receiving input")).toHaveCount(0);
+    await expect(page.getByTestId("icon-lock")).toHaveCount(0);
 
     await closeAdvancedOptions(page);
 

--- a/tests/tests-automations/regression/core-components/if-else-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/if-else-component-regression.spec.ts
@@ -1,0 +1,136 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
+import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { zoomOut } from "../../../helpers/ui/zoom-out";
+
+// Builds: If-Else (operator=equals) + two Text Output components, one renamed
+// to `textoutputfalse` so the True/False branches can be inspected
+// independently by testid. Direct-value path: `input_text` and `match_text`
+// are typed into the If-Else inspector popovers — no ChatInput/Playground
+// involved, mirroring `general-bugs-reset-flow-run.spec.ts` which validated
+// that the canvas node-status icons (`node_duration_*` vs
+// `node_status_icon_*_inactive`) are the most reliable assertion surface for
+// conditional routing.
+async function buildIfElseRoutingFlow(page: Page): Promise<void> {
+  await awaitBootstrapTest(page);
+  await expect(page.getByTestId("blank-flow")).toBeVisible({ timeout: 30000 });
+  await page.getByTestId("blank-flow").click();
+
+  // If-Else
+  await page.getByTestId("sidebar-search-input").click();
+  await page.getByTestId("sidebar-search-input").fill("if else");
+  await expect(page.getByTestId("flow_controlsIf-Else")).toBeVisible({
+    timeout: 10000,
+  });
+  await page.getByTestId("flow_controlsIf-Else").hover();
+  await page.getByTestId("add-component-button-if-else").click();
+
+  await zoomOut(page, 3);
+
+  // Text Output (will be wired to True branch — default name `text output`)
+  await page.getByTestId("sidebar-search-input").click();
+  await page.getByTestId("sidebar-search-input").fill("text output");
+  await expect(page.getByTestId("input_outputText Output")).toBeVisible({
+    timeout: 10000,
+  });
+  await page
+    .getByTestId("input_outputText Output")
+    .dragTo(page.locator('//*[@id="react-flow-id"]'), {
+      targetPosition: { x: 100, y: 100 },
+    });
+
+  await adjustScreenView(page);
+
+  // Second Text Output — will be wired to False branch and renamed to
+  // `textoutputfalse` so the False-branch status icon has a stable testid.
+  await page.getByTestId("sidebar-search-input").click();
+  await page.getByTestId("sidebar-search-input").fill("text output");
+  await expect(page.getByTestId("input_outputText Output")).toBeVisible({
+    timeout: 10000,
+  });
+  await page
+    .getByTestId("input_outputText Output")
+    .dragTo(page.locator('//*[@id="react-flow-id"]'), {
+      targetPosition: { x: 200, y: 400 },
+    });
+
+  await adjustScreenView(page);
+
+  // Rename the second Text Output to `textoutputfalse`
+  await page.getByTestId("generic-node-title-arrangement").last().click();
+  await page.getByTestId("panel-description").hover();
+  await page
+    .getByTestId("panel-description")
+    .getByTestId("edit-name-description-button")
+    .click();
+  await page.getByTestId("inspection-panel-name").fill("textoutputfalse");
+  await page
+    .getByTestId("panel-description")
+    .getByTestId("save-name-description-button")
+    .click();
+
+  // Connect True → first Text Output
+  await page
+    .getByTestId("handle-conditionalrouter-shownode-true-right")
+    .click();
+  await page
+    .getByTestId("handle-textoutput-shownode-inputs-left")
+    .first()
+    .click();
+
+  // Connect False → second Text Output (textoutputfalse)
+  await page
+    .getByTestId("handle-conditionalrouter-shownode-false-right")
+    .click();
+  await page
+    .getByTestId("handle-textoutput-shownode-inputs-left")
+    .last()
+    .click();
+}
+
+test(
+  "If-Else routes matching input through the True branch and skips the False branch",
+  { tag: ["@regression", "@components"] },
+  async ({ page }) => {
+    await buildIfElseRoutingFlow(page);
+
+    // Match: input_text === match_text → True branch should build.
+    await page.getByTestId("popover-anchor-input-input_text").fill("hello");
+    await page.getByTestId("popover-anchor-input-match_text").fill("hello");
+
+    await page.getByTestId("button_run_text output").click();
+    await expect(page.locator("text=built successfully")).toBeVisible({
+      timeout: 30000,
+    });
+
+    await expect(page.getByTestId("node_duration_text output")).toHaveCount(1);
+    await expect(
+      page.getByTestId("node_status_icon_textoutputfalse_inactive"),
+    ).toHaveCount(1);
+  },
+);
+
+test(
+  "If-Else routes non-matching input through the False branch and skips the True branch",
+  { tag: ["@regression", "@components"] },
+  async ({ page }) => {
+    await buildIfElseRoutingFlow(page);
+
+    // No match: input_text !== match_text → False branch should build.
+    await page.getByTestId("popover-anchor-input-input_text").fill("world");
+    await page.getByTestId("popover-anchor-input-match_text").fill("hello");
+
+    await page.getByTestId("button_run_textoutputfalse").click();
+    await expect(page.locator("text=built successfully")).toBeVisible({
+      timeout: 30000,
+    });
+
+    await expect(
+      page.getByTestId("node_duration_textoutputfalse"),
+    ).toHaveCount(1);
+    await expect(
+      page.getByTestId("node_status_icon_text output_inactive"),
+    ).toHaveCount(1);
+  },
+);

--- a/tests/tests-automations/regression/core-components/if-else-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/if-else-component-regression.spec.ts
@@ -2,7 +2,35 @@ import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import {
+  closeAdvancedOptions,
+  openAdvancedOptions,
+} from "../../../helpers/ui/open-advanced-options";
 import { zoomOut } from "../../../helpers/ui/zoom-out";
+
+async function selectOperator(
+  page: Page,
+  operatorName: string,
+): Promise<void> {
+  await page.getByTestId("value-dropdown-dropdown_str_operator").click();
+  // Match by exact role+name — robust across option-index churn. Click via
+  // `dispatchEvent` because the bottom of the options list (numeric operators)
+  // overlaps `main_canvas_controls`, which intercepts ordinary pointer events.
+  await page
+    .getByRole("option", { name: operatorName, exact: true })
+    .dispatchEvent("click");
+  // Confirm the trigger reflects the new value before proceeding — guards
+  // against the real_time_refresh round-trip not having landed yet.
+  await expect(
+    page.getByTestId("value-dropdown-dropdown_str_operator"),
+  ).toHaveText(operatorName);
+}
+
+async function exposeCaseSensitive(page: Page): Promise<void> {
+  await openAdvancedOptions(page);
+  await page.getByTestId("showcase_sensitive").click();
+  await closeAdvancedOptions(page);
+}
 
 // Builds: If-Else (operator=equals) + two Text Output components, one renamed
 // to `textoutputfalse` so the True/False branches can be inspected
@@ -131,6 +159,159 @@ test(
     ).toHaveCount(1);
     await expect(
       page.getByTestId("node_status_icon_text output_inactive"),
+    ).toHaveCount(1);
+  },
+);
+
+test(
+  "If-Else operator=contains routes a substring match through the True branch",
+  { tag: ["@regression", "@components"] },
+  async ({ page }) => {
+    await buildIfElseRoutingFlow(page);
+
+    await selectOperator(page, "contains");
+
+    // `lang` is a substring of `langflow` → contains evaluates True.
+    await page.getByTestId("popover-anchor-input-input_text").fill("langflow");
+    await page.getByTestId("popover-anchor-input-match_text").fill("lang");
+
+    await page.getByTestId("button_run_text output").click();
+    await expect(page.locator("text=built successfully")).toBeVisible({
+      timeout: 30000,
+    });
+
+    await expect(page.getByTestId("node_duration_text output")).toHaveCount(1);
+    await expect(
+      page.getByTestId("node_status_icon_textoutputfalse_inactive"),
+    ).toHaveCount(1);
+  },
+);
+
+test(
+  "If-Else operator=regex routes a valid pattern match through the True branch",
+  { tag: ["@regression", "@components"] },
+  async ({ page }) => {
+    await buildIfElseRoutingFlow(page);
+
+    await selectOperator(page, "regex");
+
+    // `^abc` matches the start of `abc123` → regex evaluates True.
+    await page.getByTestId("popover-anchor-input-input_text").fill("abc123");
+    await page.getByTestId("popover-anchor-input-match_text").fill("^abc");
+
+    await page.getByTestId("button_run_text output").click();
+    await expect(page.locator("text=built successfully")).toBeVisible({
+      timeout: 30000,
+    });
+
+    await expect(page.getByTestId("node_duration_text output")).toHaveCount(1);
+    await expect(
+      page.getByTestId("node_status_icon_textoutputfalse_inactive"),
+    ).toHaveCount(1);
+  },
+);
+
+test(
+  "If-Else operator=regex hides the case_sensitive advanced field",
+  { tag: ["@regression", "@components"] },
+  async ({ page }) => {
+    await buildIfElseRoutingFlow(page);
+
+    // Focus the If-Else node — `openAdvancedOptions` operates on the
+    // currently-focused node, and the build helper leaves focus on the last
+    // Text Output it renamed.
+    await page.getByTestId("title-If-Else").click();
+
+    // Baseline: with the default operator (equals), the edit-fields modal
+    // exposes the case_sensitive toggle.
+    await openAdvancedOptions(page);
+    await expect(page.getByTestId("showcase_sensitive")).toHaveCount(1);
+    await closeAdvancedOptions(page);
+
+    // After switching to regex, `update_build_config` removes case_sensitive
+    // from the build config — the toggle should disappear.
+    await selectOperator(page, "regex");
+
+    await page.getByTestId("title-If-Else").click();
+    await openAdvancedOptions(page);
+    await expect(page.getByTestId("showcase_sensitive")).toHaveCount(0);
+    await closeAdvancedOptions(page);
+  },
+);
+
+test(
+  "If-Else case_sensitive defaults to ON — mixed-case inputs route to the False branch",
+  { tag: ["@regression", "@components"] },
+  async ({ page }) => {
+    await buildIfElseRoutingFlow(page);
+
+    // case_sensitive is True by default in the Python source. With operator
+    // equals, `HELLO` and `hello` differ — False branch should build.
+    await page.getByTestId("popover-anchor-input-input_text").fill("HELLO");
+    await page.getByTestId("popover-anchor-input-match_text").fill("hello");
+
+    await page.getByTestId("button_run_textoutputfalse").click();
+    await expect(page.locator("text=built successfully")).toBeVisible({
+      timeout: 30000,
+    });
+
+    await expect(
+      page.getByTestId("node_duration_textoutputfalse"),
+    ).toHaveCount(1);
+    await expect(
+      page.getByTestId("node_status_icon_text output_inactive"),
+    ).toHaveCount(1);
+  },
+);
+
+test(
+  "If-Else with case_sensitive=OFF treats mixed-case inputs as a match (True branch)",
+  { tag: ["@regression", "@components"] },
+  async ({ page }) => {
+    await buildIfElseRoutingFlow(page);
+
+    // Focus If-Else and expose the case_sensitive field on the node body,
+    // then toggle the switch from ON (default) to OFF.
+    await page.getByTestId("title-If-Else").click();
+    await exposeCaseSensitive(page);
+    await page.getByTestId("toggle_bool_case_sensitive").click();
+
+    // With case-insensitive comparison, `HELLO` and `hello` are equal.
+    await page.getByTestId("popover-anchor-input-input_text").fill("HELLO");
+    await page.getByTestId("popover-anchor-input-match_text").fill("hello");
+
+    await page.getByTestId("button_run_text output").click();
+    await expect(page.locator("text=built successfully")).toBeVisible({
+      timeout: 30000,
+    });
+
+    await expect(page.getByTestId("node_duration_text output")).toHaveCount(1);
+    await expect(
+      page.getByTestId("node_status_icon_textoutputfalse_inactive"),
+    ).toHaveCount(1);
+  },
+);
+
+test(
+  "If-Else operator=greater than routes a numeric match (10 > 5) through the True branch",
+  { tag: ["@regression", "@components"] },
+  async ({ page }) => {
+    await buildIfElseRoutingFlow(page);
+
+    await selectOperator(page, "greater than");
+
+    // Numeric: 10 > 5 → True.
+    await page.getByTestId("popover-anchor-input-input_text").fill("10");
+    await page.getByTestId("popover-anchor-input-match_text").fill("5");
+
+    await page.getByTestId("button_run_text output").click();
+    await expect(page.locator("text=built successfully")).toBeVisible({
+      timeout: 30000,
+    });
+
+    await expect(page.getByTestId("node_duration_text output")).toHaveCount(1);
+    await expect(
+      page.getByTestId("node_status_icon_textoutputfalse_inactive"),
     ).toHaveCount(1);
   },
 );


### PR DESCRIPTION
## Summary

Consolidates work across four feature branches into a single PR:

- **`componentHoverAdd.spec.ts`** → tagged `@stable`. Refactored from `waitForSelector` + always-true opacity assertion (`toBeGreaterThanOrEqual(0)`) into a deterministic boundary contract: initial Plus-icon opacity is `0`, hover + click adds a `.react-flow__node`. (Originally PR #233, closed for consolidation.)
- **`customComponentAdd.spec.ts`** → tagged `@stable`. Refactored 3 s `waitForSelector` calls to `expect().toBeVisible({ timeout: 10000 })`; dropped the unused `time.sleep` carried over from a stop-building spec; cached `code-button-modal.last()` to a stable locator.
- **`general-bugs-delete-handle-advanced-input.spec.ts`** → tagged `@stable`. Replaced `expect(await locator.count()).toBe(N)` with `expect(locator).toHaveCount(N)` (3 occurrences) to eliminate the count-then-assert race; collapsed the `.hover().then(...)` chain to sequential awaits.
- **`if-else-component-regression.spec.ts`** → **new spec**, 8 tests covering the routing contract of the ConditionalRouter component: `equals` (match/no-match), `contains`, `regex` (routing + the `update_build_config` side-effect that hides `case_sensitive`), `case_sensitive` (ON default / OFF), and `greater than` (numeric). Tagged `@regression @components` only — to be promoted to `@stable` after weekly cycles confirm stability.

Each promoted spec also ships a `docs/core-components/` spec doc and a matching QA-CHECKLIST.md bullet update. A new §3.8 If-Else section in QA-CHECKLIST.md tracks the new spec's scenarios plus the remaining uncovered items (`max_iterations`/`default_route` cycle break, other numeric operators).

## Pipeline (per spec, 7 steps, all PASS)

| Spec | typecheck | lint | anti-patterns | run --retries=0 | force-fail | trace | backend errors |
|---|---|---|---|---|---|---|---|
| componentHoverAdd | ✅ | ✅ (was 5 warnings) | ✅ | ✅ ~6 s | ✅ | ✅ | ✅ zero |
| customComponentAdd | ✅ | ✅ | ✅ | ✅ ~7 s | ✅ | ✅ | ✅ zero |
| general-bugs-delete-handle-advanced-input | ✅ | ✅ (was 3 warnings) | ✅ | ✅ 3/3 stable, ~10–12 s | ✅ | ✅ | ✅ zero |
| if-else-component-regression | ✅ | ✅ | ✅ | ✅ 3/3 stable, 8 tests in ~57–80 s | ✅ | ✅ | ✅ zero |

Skipped (not in this PR): `edit-tools.spec.ts` — flaky after refactor (1 PASS / 3 FAIL across consecutive runs); needs structural rework before `@stable`.

## Test plan

- [ ] `npx playwright test tests/tests-automations/regression/core-components/componentHoverAdd.spec.ts`
- [ ] `npx playwright test tests/tests-automations/regression/core-components/customComponentAdd.spec.ts`
- [ ] `npx playwright test tests/tests-automations/regression/core-components/general-bugs-delete-handle-advanced-input.spec.ts`
- [ ] `npx playwright test tests/tests-automations/regression/core-components/if-else-component-regression.spec.ts` (8 tests)
- [ ] CI typecheck + lint pass
- [ ] Weekly stable workflow picks up the three new `@stable` tags on next Monday run