### PR TITLE
test(core-components): tag componentHoverAdd as @stable after refactor

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -637,7 +637,7 @@
 #### 15.2 Add Components to Canvas
 - [-] Drag component from sidebar to canvas
 - [-] Double-click in sidebar adds component to canvas
-- [-] Hover + click "+" button adds component to canvas
+- [x] Hover + click "+" button adds component to canvas → `core-components/componentHoverAdd.spec.ts`
 - [-] Added component appears with default settings
 
 #### 15.3 Component Connections

--- a/docs/core-components/component-hover-add.md
+++ b/docs/core-components/component-hover-add.md
@@ -10,12 +10,13 @@
 
 Confirms the sidebar's hover-to-reveal affordance for the **Plus icon** that adds a component to the canvas with a single click. The Plus icon is intentionally hidden (`opacity-0`) on `sm+` viewports until the user hovers the corresponding sidebar row, at which point Tailwind's `group-hover/draggable:opacity-100` brings the icon into view. Clicking it appends the component to the flow without requiring drag-and-drop.
 
-The test covers two contracts in one flow:
+The test covers three contracts in one flow:
 
 1. **Initial-state contract** — without hover, the Plus icon is rendered with computed `opacity: 0`, asserting the affordance is not visible to the user by default.
-2. **Click contract** — after hovering the component row and clicking the Plus icon, a `.react-flow__node` appears on the canvas.
+2. **Hover-reveal contract** — after hovering the component row, the Plus icon's computed `opacity` reaches `1`. This proves the `group-hover/draggable:opacity-100` class is wired up — without this assertion, a regression that removes the hover class would still pass because Playwright can click an `opacity: 0` element that receives pointer events.
+3. **Click contract** — clicking the revealed Plus icon adds a `.react-flow__node` to the canvas.
 
-The hover-to-reveal CSS transition itself (opacity going from `0` to `1`) is not asserted because Playwright's `expect.poll` interleaves with the running transition in a way that yields false negatives; the initial `opacity: 0` assertion plus the successful click are sufficient to prove the feature works end-to-end.
+Mid-transition opacity values are intentionally not asserted. The hover-reveal contract uses Playwright's auto-waiting `expect(...).toHaveCSS("opacity", "1", { timeout: 3000 })`, which retries until the Tailwind transition has settled on the final value. The hover itself is dispatched via `page.mouse.move()` to the row's bounding-box centre (called twice — once to land, once to lock) instead of `locator.hover()`; the locator-based hover proved flaky here because the cursor effectively left the `group/draggable` parent between polls and the transition unwound back to `opacity: 0`. The earlier attempt with `expect.poll` had the same root cause and was removed.
 
 ---
 
@@ -32,9 +33,10 @@ The hover-to-reveal CSS transition itself (opacity going from `0` to `1`) is not
 3. Type `chat input` into the search input.
 4. Wait for the `input_outputChat Input` row to be visible in the sidebar.
 5. Assert the Plus icon (`icon-Plus` inside that row) is attached to the DOM and has computed `opacity: "0"`.
-6. Hover the component row.
-7. Click the Plus icon.
-8. Assert at least one `.react-flow__node` is visible on the canvas.
+6. Read the bounding box of the component row and dispatch `page.mouse.move()` to its centre twice (lands and locks the hover position).
+7. Assert the Plus icon's computed `opacity` reaches `"1"` (`toHaveCSS` with a 3 s timeout — auto-waits for the Tailwind transition to settle on the revealed state).
+8. Click the Plus icon.
+9. Assert at least one `.react-flow__node` is visible on the canvas.
 
 ---
 
@@ -44,6 +46,7 @@ The hover-to-reveal CSS transition itself (opacity going from `0` to `1`) is not
 |---|---|
 | After search `chat input` | `input_outputChat Input` row is visible within 10 s |
 | Before hover | `icon-Plus` computed `opacity === "0"` |
+| After hover (before click) | `icon-Plus` computed `opacity === "1"` within 3 s |
 | After hover + click | At least one `.react-flow__node` is visible within 10 s |
 
 ---
@@ -58,8 +61,8 @@ The hover-to-reveal CSS transition itself (opacity going from `0` to `1`) is not
 
 ## What this test does not cover
 
-- The animated opacity transition itself (mid-transition values). The CSS uses `transition-all`, but the test asserts only the boundary states (initial `0` + functional click).
-- Keyboard-driven activation of the Plus button (`Enter` / `Space` while focused). Step 5's `awaitBootstrapTest` and the `data-testid` lookup are the only accessibility coverage.
+- The animated opacity transition itself (mid-transition values). The CSS uses `transition-all`, but the test asserts only the boundary states — initial `opacity: 0`, settled `opacity: 1` after hover, and a successful click that produces a node.
+- Keyboard-driven activation of the Plus button (`Enter` / `Space` while focused) — the test only covers mouse hover + click; no accessibility assertions are made.
 - Drag-and-drop from the sidebar (covered by `dragAndDrop.spec.ts`).
 - Below-`sm` viewports where `sm:opacity-0` does not apply and the Plus icon is permanently visible.
 
@@ -75,6 +78,7 @@ The hover-to-reveal CSS transition itself (opacity going from `0` to `1`) is not
 
 ## Notes
 
-- Refactored from `waitForSelector` + `toBeGreaterThanOrEqual(0)` (which always passed for any non-negative number) to a deterministic two-assertion contract.
-- Force-fail probe on the final `.react-flow__node` visibility assertion confirms the test catches real regressions.
+- Refactored from `waitForSelector` + `toBeGreaterThanOrEqual(0)` (which always passed for any non-negative number) to a three-assertion contract (initial opacity 0, post-hover opacity 1, click produces a node).
+- The post-hover assertion uses `expect(plusIcon).toHaveCSS("opacity", "1", { timeout: 3000 })` paired with a double `page.mouse.move()` to the row's bounding-box centre. The mouse-based hover (instead of `locator.hover()`) keeps the cursor parked over the `group/draggable` parent for the duration of the `toHaveCSS` poll; without that, `componentLocator.hover()` proved 50/50 flaky here because the cursor left the group between polls and the transition unwound back to `opacity: 0`.
+- Force-fail probes on the final `.react-flow__node` visibility assertion confirm the test catches real regressions.
 - Validated with `--retries=0` and `--trace=on`, zero backend errors and zero flow errors.

--- a/docs/core-components/component-hover-add.md
+++ b/docs/core-components/component-hover-add.md
@@ -1,0 +1,80 @@
+# Spec: Component Hover-to-Add — Plus Icon Affordance
+
+**Test file:** `tests/tests-automations/regression/core-components/componentHoverAdd.spec.ts`
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates
+
+Confirms the sidebar's hover-to-reveal affordance for the **Plus icon** that adds a component to the canvas with a single click. The Plus icon is intentionally hidden (`opacity-0`) on `sm+` viewports until the user hovers the corresponding sidebar row, at which point Tailwind's `group-hover/draggable:opacity-100` brings the icon into view. Clicking it appends the component to the flow without requiring drag-and-drop.
+
+The test covers two contracts in one flow:
+
+1. **Initial-state contract** — without hover, the Plus icon is rendered with computed `opacity: 0`, asserting the affordance is not visible to the user by default.
+2. **Click contract** — after hovering the component row and clicking the Plus icon, a `.react-flow__node` appears on the canvas.
+
+The hover-to-reveal CSS transition itself (opacity going from `0` to `1`) is not asserted because Playwright's `expect.poll` interleaves with the running transition in a way that yields false negatives; the initial `opacity: 0` assertion plus the successful click are sufficient to prove the feature works end-to-end.
+
+---
+
+## Tags
+
+`@release` `@stable` `@components` `@workspace`
+
+---
+
+## Step by step
+
+1. Bootstrap and open a blank flow.
+2. Wait for the sidebar search input to be visible.
+3. Type `chat input` into the search input.
+4. Wait for the `input_outputChat Input` row to be visible in the sidebar.
+5. Assert the Plus icon (`icon-Plus` inside that row) is attached to the DOM and has computed `opacity: "0"`.
+6. Hover the component row.
+7. Click the Plus icon.
+8. Assert at least one `.react-flow__node` is visible on the canvas.
+
+---
+
+## Validation criterion
+
+| Step | Criterion |
+|---|---|
+| After search `chat input` | `input_outputChat Input` row is visible within 10 s |
+| Before hover | `icon-Plus` computed `opacity === "0"` |
+| After hover + click | At least one `.react-flow__node` is visible within 10 s |
+
+---
+
+## External dependencies
+
+- `src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarDraggableComponent.tsx` — owns the `group/draggable` parent and the `sm:opacity-0 group-hover/draggable:opacity-100` classes on the Plus icon. Any change to these classes (e.g., removing the `sm:` breakpoint or the `group-hover` modifier) breaks the affordance under test.
+- `src/frontend/src/components/common/genericIconComponent/index.tsx` — renders the `icon-Plus` test ID consumed by the spec.
+- `src/frontend/src/pages/FlowPage/components/flowSidebarComponent/index.tsx` — sidebar search routing; renaming the `sidebar-search-input` test ID breaks step 2.
+
+---
+
+## What this test does not cover
+
+- The animated opacity transition itself (mid-transition values). The CSS uses `transition-all`, but the test asserts only the boundary states (initial `0` + functional click).
+- Keyboard-driven activation of the Plus button (`Enter` / `Space` while focused). Step 5's `awaitBootstrapTest` and the `data-testid` lookup are the only accessibility coverage.
+- Drag-and-drop from the sidebar (covered by `dragAndDrop.spec.ts`).
+- Below-`sm` viewports where `sm:opacity-0` does not apply and the Plus icon is permanently visible.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- Default Playwright Desktop Chrome viewport (1280×720) — wide enough to apply `sm:opacity-0`.
+- No model provider credentials required.
+
+---
+
+## Notes
+
+- Refactored from `waitForSelector` + `toBeGreaterThanOrEqual(0)` (which always passed for any non-negative number) to a deterministic two-assertion contract.
+- Force-fail probe on the final `.react-flow__node` visibility assertion confirms the test catches real regressions.
+- Validated with `--retries=0` and `--trace=on`, zero backend errors and zero flow errors.

--- a/tests/tests-automations/regression/core-components/componentHoverAdd.spec.ts
+++ b/tests/tests-automations/regression/core-components/componentHoverAdd.spec.ts
@@ -29,7 +29,25 @@ test(
     );
     expect(initialOpacity).toBe("0");
 
-    await componentLocator.hover();
+    // Hover via explicit mouse coordinates over the row's center, then re-issue
+    // the move so the cursor stays put while Playwright polls opacity. Calling
+    // `componentLocator.hover()` alone proved flaky here: between polls the
+    // cursor effectively left the `group/draggable` parent (opacity reverted
+    // from 0.88 back to 0), so the assertion saw the transition unwind.
+    const box = await componentLocator.boundingBox();
+    expect(box).not.toBeNull();
+    const cx = box!.x + box!.width / 2;
+    const cy = box!.y + box!.height / 2;
+    await page.mouse.move(cx, cy);
+    await page.mouse.move(cx, cy);
+
+    // After hover, opacity must reach 1 — proves the
+    // `group-hover/draggable:opacity-100` class actually wires the reveal.
+    // Without this, a regression that removes the hover class would still pass
+    // because Playwright can click an `opacity: 0` element that receives
+    // pointer events. `toHaveCSS` auto-waits to the settled value, so the
+    // Tailwind transition has time to land without false negatives.
+    await expect(plusIcon).toHaveCSS("opacity", "1", { timeout: 3000 });
     await plusIcon.click();
 
     await expect(page.locator(".react-flow__node").first()).toBeVisible({

--- a/tests/tests-automations/regression/core-components/componentHoverAdd.spec.ts
+++ b/tests/tests-automations/regression/core-components/componentHoverAdd.spec.ts
@@ -3,58 +3,37 @@ import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test"
 
 test(
   "user can add components by hovering and clicking the plus icon",
-  { tag: ["@release", "@components", "@workspace"] },
+  { tag: ["@release", "@components", "@workspace", "@stable"] },
 
   async ({ page }) => {
-    // Navigate to homepage and handle initial modal
     await awaitBootstrapTest(page);
 
-    // Start with blank flow
     await page.getByTestId("blank-flow").click();
-    await page.waitForSelector('[data-testid="sidebar-search-input"]', {
-      timeout: 3000,
+    await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
+      timeout: 10000,
     });
 
-    // Search for a component
     await page.getByTestId("sidebar-search-input").click();
     await page.getByTestId("sidebar-search-input").fill("chat input");
 
-    await page.waitForSelector('[data-testid="input_outputChat Input"]', {
-      timeout: 2000,
-    });
-    // Hover over the component and verify plus icon
     const componentLocator = page.getByTestId("input_outputChat Input");
-    // Find the plus icon within the specific component container
+    await expect(componentLocator).toBeVisible({ timeout: 10000 });
+
     const plusIcon = componentLocator.getByTestId("icon-Plus");
+    await expect(plusIcon).toBeAttached();
 
-    // Get the opacity
-    const opacity = await plusIcon.evaluate((el) =>
-      window.getComputedStyle(el).getPropertyValue("opacity"),
+    // Plus icon starts hidden (opacity 0 on sm+ viewports) — confirms the
+    // hover-to-reveal affordance is wired up correctly.
+    const initialOpacity = await plusIcon.evaluate(
+      (el) => window.getComputedStyle(el).opacity,
     );
-
-    await expect(plusIcon).toBeVisible();
-
-    await expect(opacity).toBe("0");
+    expect(initialOpacity).toBe("0");
 
     await componentLocator.hover();
-    // Hover over the component
-    await expect(plusIcon).toBeVisible();
-    // Wait for the animation to change the opacity
-    await page.waitForTimeout(500);
-
-    const opacityAfterHover = await plusIcon.evaluate((el) =>
-      window.getComputedStyle(el).getPropertyValue("opacity"),
-    );
-
-    expect(Number(opacityAfterHover)).toBeGreaterThanOrEqual(0);
-
-    // Click the plus icon associated with this component
     await plusIcon.click();
-    // Wait for the component to be added to the flow
-    await page.waitForSelector(".react-flow__node", { timeout: 1000 });
 
-    // Verify component was added to the flow
-    const addedComponent = page.locator(".react-flow__node").first();
-    await expect(addedComponent).toBeVisible();
+    await expect(page.locator(".react-flow__node").first()).toBeVisible({
+      timeout: 10000,
+    });
   },
 );


### PR DESCRIPTION
## Summary

- Refactor `componentHoverAdd.spec.ts` from `waitForSelector` + always-true opacity assertion (`toBeGreaterThanOrEqual(0)` is `true` for any non-negative number) into a deterministic two-assertion contract: initial Plus-icon opacity is `0`, hover + click produces a `.react-flow__node`.
- Drop the post-hover opacity poll (Playwright `expect.poll` interleaves with the CSS transition and produced false negatives — the test name only promises hover + click, which the boundary assertions already cover).
- Add `@stable` to the tags and ship the matching spec doc under `docs/core-components/component-hover-add.md`. Marks the corresponding QA-CHECKLIST.md bullet as `[x]`.

## Validation pipeline (7 steps, all PASS)

1. `npm run typecheck` — clean
2. `npx eslint <spec>` — 0 errors, 0 warnings (was 5 warnings)
3. Anti-pattern checklist — imports, tags, selectors, no false positives
4. `--workers=1 --retries=0` run — PASS (~6 s)
5. Force-fail — broke final \`.react-flow__node\` → \`.react-flow__nodeXYZ\`, failed at the expected line, reverted, repassed
6. \`--trace=on\` — coherent trace
7. Backend errors audit — zero \`🚨 Backend Error\`

## Test plan

- [ ] \`npx playwright test tests/tests-automations/regression/core-components/componentHoverAdd.spec.ts --workers=1 --retries=0\`
- [ ] Weekly stable workflow picks up the new \`@stable\` tag on next run