### PR TITLE
test(core-components): tag customComponentAdd as @stable after refactor

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -145,7 +145,7 @@
 - [ ] Legacy component visible via configuration
 
 #### 2.4 Code Editing
-- [-] Edit Python code of custom component
+- [x] Edit Python code of custom component — Check & Save clears the pulse-pink indicator → `core-components/customComponentAdd.spec.ts`
 - [-] Full custom component
 
 ---

--- a/docs/core-components/custom-component-add.md
+++ b/docs/core-components/custom-component-add.md
@@ -1,0 +1,78 @@
+# Spec: Custom Component — Add and Save Flow
+
+**Test file:** `tests/tests-automations/regression/core-components/customComponentAdd.spec.ts`
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates
+
+Confirms the end-to-end flow of adding a **Custom Component** from the sidebar and saving its code:
+
+1. The dedicated **`sidebar-custom-component-button`** drops a new Custom Component onto the canvas.
+2. The newly-added component renders its `code-button-modal` with the **`animate-pulse-pink`** class — a visual indicator that the code is unsaved and the user must review/save it before the component is usable.
+3. Opening the code editor (Ace editor inside the modal), replacing the boilerplate with valid Python, and clicking **Check & Save** removes the `animate-pulse-pink` class — confirming the save round-trip succeeded and the component is no longer flagged as needing attention.
+
+The pulse-pink visual contract is the user-facing signal that Langflow uses to disambiguate "default scaffolded code" from "user-confirmed code". Losing this signal would silently let unsaved scaffolds propagate into flows.
+
+---
+
+## Tags
+
+`@release` `@stable` `@components`
+
+---
+
+## Step by step
+
+1. Bootstrap and open a blank flow.
+2. Click `sidebar-custom-component-button` to add a Custom Component.
+3. Assert the last `code-button-modal` on the canvas is visible and has the `animate-pulse-pink` class.
+4. Click the `code-button-modal` to open the code editor.
+5. Click into the Ace editor, select all (`Ctrl/Cmd+A`), and fill with a minimal valid Custom Component class.
+6. Click **Check & Save**.
+7. Assert the `code-button-modal` no longer has the `animate-pulse-pink` class.
+
+---
+
+## Validation criterion
+
+| Step | Criterion |
+|---|---|
+| After sidebar click | `code-button-modal` is visible within 10 s |
+| Initial state | `code-button-modal` has `animate-pulse-pink` class |
+| After Check & Save | `code-button-modal` no longer has `animate-pulse-pink` class within 10 s |
+
+---
+
+## External dependencies
+
+- `src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarHeaderComponent/index.tsx` — owns the `sidebar-custom-component-button` test ID. Renaming it breaks step 2.
+- `src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/CodeButton/index.tsx` (or equivalent) — emits the `code-button-modal` test ID and applies the `animate-pulse-pink` class while code is unsaved. A change to either the test ID or the class name breaks the entire spec.
+- `src/frontend/src/modals/codeAreaModal/index.tsx` — Ace editor lives here. The `.ace_content` selector and the underlying `<textarea>` mirror are stable since multiple specs depend on them.
+- `src/backend/base/langflow/custom/custom_component/component.py` — Check & Save calls validation here; if validation rejects the minimal Component class shipped in the spec body, step 6 fails.
+
+---
+
+## What this test does not cover
+
+- Code validation errors. The spec ships a syntactically and semantically valid Custom Component; a syntax error would be caught by a separate test.
+- Connecting the saved Custom Component to other nodes. The test stops at save confirmation.
+- Persisting the Custom Component code across flow reload — covered by general save/load specs.
+- The drag-and-drop alternative to the dedicated sidebar button.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- No model provider credentials required.
+
+---
+
+## Notes
+
+- Refactored from `waitForSelector` with 3 s timeouts to `expect().toBeVisible({ timeout: 10000 })`, dropped the unused `sleep(60)` line from the embedded code (it was copy-pasted from a stop-building test and never exercised here).
+- Force-fail probe on the final `not.toHaveClass` assertion confirms the test catches real regressions.
+- Validated with `--retries=0` and `--trace=on`, zero backend errors.

--- a/tests/tests-automations/regression/core-components/customComponentAdd.spec.ts
+++ b/tests/tests-automations/regression/core-components/customComponentAdd.spec.ts
@@ -3,39 +3,33 @@ import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test"
 
 test(
   "custom component code button should be pink when adding custom component",
-  { tag: ["@release", "@components"] },
+  { tag: ["@release", "@components", "@stable"] },
 
   async ({ page }) => {
     await awaitBootstrapTest(page);
 
-    await page.waitForSelector('[data-testid="blank-flow"]', {
-      timeout: 3000,
+    await expect(page.getByTestId("blank-flow")).toBeVisible({
+      timeout: 10000,
     });
-
     await page.getByTestId("blank-flow").click();
 
-    await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
-      timeout: 3000,
+    await expect(page.getByTestId("canvas_controls_dropdown")).toBeVisible({
+      timeout: 10000,
     });
 
     await page.getByTestId("sidebar-custom-component-button").click();
 
-    await expect(page.getByTestId("code-button-modal").last()).toBeVisible({
-      timeout: 3000,
-    });
+    const codeButton = page.getByTestId("code-button-modal").last();
 
-    await expect(page.getByTestId("code-button-modal").last()).toHaveClass(
-      /animate-pulse-pink/,
-    );
+    await expect(codeButton).toBeVisible({ timeout: 10000 });
+    await expect(codeButton).toHaveClass(/animate-pulse-pink/);
 
-    await page.getByTestId("code-button-modal").last().click();
+    await codeButton.click();
 
-    const waitTimeoutCode = `
-# from langflow.field_typing import Data
+    const customComponentCode = `
 from langflow.custom import Component
 from langflow.io import MessageTextInput, Output
 from langflow.schema import Data
-from time import sleep
 from langflow.schema.message import Message
 
 class CustomComponent(Component):
@@ -56,18 +50,16 @@ class CustomComponent(Component):
     def build_output(self) -> Message:
         data = Data(value=self.input_value)
         self.status = data
-        sleep(60)
         return data`;
 
     await page.locator(".ace_content").click();
     await page.keyboard.press(`ControlOrMeta+A`);
-    await page.locator("textarea").fill(waitTimeoutCode);
+    await page.locator("textarea").fill(customComponentCode);
 
     await page.getByText("Check & Save").last().click();
 
-    await expect(page.getByTestId("code-button-modal").last()).not.toHaveClass(
-      /animate-pulse-pink/,
-      { timeout: 3000 },
-    );
+    await expect(codeButton).not.toHaveClass(/animate-pulse-pink/, {
+      timeout: 10000,
+    });
   },
 );


### PR DESCRIPTION
## Summary

- Replace 3 s \`waitForSelector\` calls in \`customComponentAdd.spec.ts\` with \`expect().toBeVisible({ timeout: 10000 })\`.
- Cache \`code-button-modal.last()\` into a local locator to keep assertions consistent and avoid re-querying.
- Drop the unused \`from time import sleep\` import and the trailing \`sleep(60)\` from the embedded Python — copy-pasted from a stop-building test and never exercised by this spec.
- Bump the final \`not.toHaveClass\` timeout to 10 s.
- Add \`@stable\` to the tags. Adds the matching spec doc under \`docs/core-components/custom-component-add.md\` and marks the corresponding QA-CHECKLIST.md bullet as \`[x]\`.

## Validation pipeline (7 steps, all PASS)

1. \`npm run typecheck\` — clean
2. \`npx eslint <spec>\` — 0 errors, 0 warnings
3. Anti-pattern checklist — imports, tags, no false positives
4. \`--workers=1 --retries=0\` — PASS (~7 s)
5. Force-fail — broke final assertion to \`toHaveClass(/animate-pulse-pink-XYZ/)\`, failed at the expected line, reverted, repassed
6. \`--trace=on\` — coherent trace
7. Backend errors audit — zero \`🚨 Backend Error\`

## Test plan

- [ ] \`npx playwright test tests/tests-automations/regression/core-components/customComponentAdd.spec.ts --workers=1 --retries=0\`
- [ ] Weekly stable workflow picks up the new \`@stable\` tag on next run