### PR TITLE
test(core-components): tag general-bugs-delete-handle-advanced-input as @stable

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -143,6 +143,7 @@
 - [-] Update component action
 - [ ] Update with breaking change — should alert user
 - [ ] Legacy component visible via configuration
+- [x] Re-saving code removes handles from previously-toggled advanced fields → `core-components/general-bugs-delete-handle-advanced-input.spec.ts`
 
 #### 2.4 Code Editing
 - [-] Edit Python code of custom component

--- a/docs/core-components/general-bugs-delete-handle-advanced-input.md
+++ b/docs/core-components/general-bugs-delete-handle-advanced-input.md
@@ -57,7 +57,7 @@ The test exercises the **If-Else** component because it has a togglable `true_ca
 - `src/frontend/src/CustomNodes/GenericNode/components/parameterRenderComponent/index.tsx` — emits the `Receiving input` placeholder for unconnected handles.
 - `src/frontend/src/modals/codeAreaModal/index.tsx` — Check & Save flow. The post-save handle cleanup happens here (or in the store that handles the resulting reducer call).
 - `src/frontend/src/components/genericIconComponent/index.tsx` — emits the `icon-lock` test ID consumed by the spec.
-- `helpers/ui/open-advanced-options.ts` — `openAdvancedOptions`, `closeAdvancedOptions`, `enableInspectPanel`, `disableInspectPanel`. Renaming these helpers breaks the spec.
+- `tests/helpers/ui/open-advanced-options.ts` — `openAdvancedOptions`, `closeAdvancedOptions`, `enableInspectPanel`, `disableInspectPanel`. Renaming these helpers breaks the spec.
 
 ---
 
@@ -78,7 +78,7 @@ The test exercises the **If-Else** component because it has a togglable `true_ca
 
 ## Notes
 
-- Refactored from `waitForSelector` (with one 100 s timeout) to `expect().toBeVisible({ timeout: 10000 })` and `toHaveCount`.
+- Refactored from `waitForSelector` (with one 100 s timeout) to `expect().toBeVisible(...)` and `toHaveCount`. The first appearance check after canvas bootstrap uses a 30 s timeout (`canvas_controls_dropdown` settles slower on cold workers); subsequent sidebar visibility checks use 10 s.
 - Replaced `.hover().then(...)` chain with sequential awaits.
 - Stability: 3 / 3 PASS across consecutive runs (~10–12 s each).
 - Force-fail probe on the post-save `toHaveCount(0)` assertion confirms the test catches real regressions.

--- a/docs/core-components/general-bugs-delete-handle-advanced-input.md
+++ b/docs/core-components/general-bugs-delete-handle-advanced-input.md
@@ -1,0 +1,84 @@
+# Spec: Delete Handles from Advanced Fields When Code Is Updated
+
+**Test file:** `tests/tests-automations/regression/core-components/general-bugs-delete-handle-advanced-input.spec.ts`
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates
+
+Regression test for a bug where dynamic handles tied to **advanced fields** lingered on the canvas after the component's code was re-saved. Toggling an advanced field exposes an input handle on the node; re-saving the component code should re-evaluate the field config and drop the now-orphaned handle (and the lock icon decorating connected upstream edges).
+
+The test exercises the **If-Else** component because it has a togglable `true_case_message` advanced field that historically left a dangling handle after the user re-saved the code. The contract under test:
+
+1. Toggling `showtrue_case_message` exposes a "Receiving input" placeholder.
+2. Connecting Text Input → If-Else's `case true` produces a locked handle (visible in Advanced view as another "Receiving input" placeholder + a lock icon).
+3. After clicking **Check & Save** in the code modal with the default code, the advanced field config is re-evaluated and both the "Receiving input" placeholders and the lock icon are removed (`count === 0`).
+
+---
+
+## Tags
+
+`@release` `@stable` `@components`
+
+---
+
+## Step by step
+
+1. Bootstrap and open a blank flow.
+2. Add the **If-Else** component from the sidebar.
+3. Disable the inspect panel, open Advanced Options.
+4. Toggle `showtrue_case_message`, then close Advanced Options.
+5. Add a **Text Input** component (drag onto canvas).
+6. Connect Text Input's output handle to If-Else's `case true` input handle.
+7. Click the If-Else title and open Advanced Options again — assert exactly 2 "Receiving input" placeholders are visible.
+8. Close Advanced Options.
+9. Click the If-Else title, open the code modal, click **Check & Save** (resaves the default code).
+10. Open Advanced Options.
+11. Assert exactly 0 "Receiving input" placeholders **and** exactly 0 `icon-lock` icons.
+12. Close Advanced Options and re-enable the inspect panel.
+
+---
+
+## Validation criterion
+
+| Step | Criterion |
+|---|---|
+| After connecting Text Input → If-Else | Advanced view shows `toHaveCount(2)` `Receiving input` placeholders |
+| After Check & Save on code modal | Advanced view shows `toHaveCount(0)` `Receiving input` placeholders |
+| After Check & Save on code modal | Advanced view shows `toHaveCount(0)` `icon-lock` icons |
+
+---
+
+## External dependencies
+
+- `src/backend/base/langflow/components/logic/conditional_router.py` — If-Else component. The `true_case_message` advanced field and its `show` toggle must exist for step 4 to find `showtrue_case_message` test ID.
+- `src/frontend/src/CustomNodes/GenericNode/components/parameterRenderComponent/index.tsx` — emits the `Receiving input` placeholder for unconnected handles.
+- `src/frontend/src/modals/codeAreaModal/index.tsx` — Check & Save flow. The post-save handle cleanup happens here (or in the store that handles the resulting reducer call).
+- `src/frontend/src/components/genericIconComponent/index.tsx` — emits the `icon-lock` test ID consumed by the spec.
+- `helpers/ui/open-advanced-options.ts` — `openAdvancedOptions`, `closeAdvancedOptions`, `enableInspectPanel`, `disableInspectPanel`. Renaming these helpers breaks the spec.
+
+---
+
+## What this test does not cover
+
+- Persistence across flow reload — the test re-opens the same node in the same session.
+- The case where the user modifies the code (not just resaves the default). The bug fix specifically targeted resave with unchanged code.
+- Other components with advanced fields. If-Else is the canonical reproduction case.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- No model provider credentials required.
+
+---
+
+## Notes
+
+- Refactored from `waitForSelector` (with one 100 s timeout) to `expect().toBeVisible({ timeout: 10000 })` and `toHaveCount`.
+- Replaced `.hover().then(...)` chain with sequential awaits.
+- Stability: 3 / 3 PASS across consecutive runs (~10–12 s each).
+- Force-fail probe on the post-save `toHaveCount(0)` assertion confirms the test catches real regressions.

--- a/tests/tests-automations/regression/core-components/general-bugs-delete-handle-advanced-input.spec.ts
+++ b/tests/tests-automations/regression/core-components/general-bugs-delete-handle-advanced-input.spec.ts
@@ -10,25 +10,24 @@ import {
 
 test(
   "the system must delete the handles from advanced fields when the code is updated",
-  { tag: ["@release", "@components"] },
+  { tag: ["@release", "@components", "@stable"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 
     await page.getByTestId("blank-flow").click();
 
-    await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
-      timeout: 100000,
+    await expect(page.getByTestId("canvas_controls_dropdown")).toBeVisible({
+      timeout: 30000,
     });
 
     await page.getByTestId("sidebar-search-input").click();
     await page.getByTestId("sidebar-search-input").fill("if else");
 
-    await page
-      .getByTestId("flow_controlsIf-Else")
-      .hover()
-      .then(async () => {
-        await page.getByTestId("add-component-button-if-else").click();
-      });
+    await expect(page.getByTestId("flow_controlsIf-Else")).toBeVisible({
+      timeout: 10000,
+    });
+    await page.getByTestId("flow_controlsIf-Else").hover();
+    await page.getByTestId("add-component-button-if-else").click();
 
     await adjustScreenView(page, { numberOfZoomOut: 3 });
 
@@ -41,8 +40,8 @@ test(
 
     await page.getByTestId("sidebar-search-input").click();
     await page.getByTestId("sidebar-search-input").fill("text input");
-    await page.waitForSelector('[data-testid="input_outputText Input"]', {
-      timeout: 2000,
+    await expect(page.getByTestId("input_outputText Input")).toBeVisible({
+      timeout: 10000,
     });
     await page
       .getByTestId("input_outputText Input")
@@ -64,11 +63,7 @@ test(
 
     await openAdvancedOptions(page);
 
-    const numberOfDisabledInputs = await page
-      .getByPlaceholder("Receiving input")
-      .count();
-
-    expect(numberOfDisabledInputs).toBe(2);
+    await expect(page.getByPlaceholder("Receiving input")).toHaveCount(2);
 
     await closeAdvancedOptions(page);
 
@@ -80,15 +75,8 @@ test(
 
     await openAdvancedOptions(page);
 
-    const numberOfDisabledInputsAfter = await page
-      .getByPlaceholder("Receiving input")
-      .count();
-
-    expect(numberOfDisabledInputsAfter).toBe(0);
-
-    const numberOfLockIconsAfter = await page.getByTestId("icon-lock").count();
-
-    expect(numberOfLockIconsAfter).toBe(0);
+    await expect(page.getByPlaceholder("Receiving input")).toHaveCount(0);
+    await expect(page.getByTestId("icon-lock")).toHaveCount(0);
 
     await closeAdvancedOptions(page);
 


### PR DESCRIPTION
## Summary

- Drop \`waitForSelector\` with overlong (100 s) and undersized (2 s) timeouts in favor of \`expect().toBeVisible({ timeout })\`.
- Convert the \`.hover().then(...)\` chain to sequential awaits.
- Convert \`expect(await locator.count()).toBe(N)\` to \`expect(locator).toHaveCount(N)\` (3 occurrences) — eliminates the count-then-assert race and auto-waits.
- Add \`@stable\` to the tags. Ships the matching spec doc under \`docs/core-components/general-bugs-delete-handle-advanced-input.md\` and adds a new bullet under \`2.3 Component Updates\` in QA-CHECKLIST.md.

What this spec covers: regression for the bug where dynamic handles tied to **advanced fields** (e.g., \`showtrue_case_message\`) lingered on the canvas after the component's code was re-saved. Test toggles \`showtrue_case_message\` on If-Else, wires Text Input → \`case true\`, saves the default code via Check & Save, and asserts both \"Receiving input\" placeholders and \`icon-lock\` go to count 0.

## Validation pipeline (7 steps, all PASS)

1. \`npm run typecheck\` — clean
2. \`npx eslint <spec>\` — 0 errors, 0 warnings (was 3 warnings)
3. Anti-pattern checklist — imports, tags, no false positives
4. Stability: 3/3 PASS at \`--workers=1 --retries=0\` (9.9–12.4 s)
5. Force-fail — broke post-save \`toHaveCount(0)\` to \`toHaveCount(99)\`, failed at the expected line, reverted, repassed
6. \`--trace=on\` — coherent trace
7. Backend errors audit — zero \`🚨 Backend Error\`

## Test plan

- [ ] \`npx playwright test tests/tests-automations/regression/core-components/general-bugs-delete-handle-advanced-input.spec.ts --workers=1 --retries=0\`
- [ ] Weekly stable workflow picks up the new \`@stable\` tag on next run