### PR TITLE
test(core-components): add If-Else routing regression spec (8 tests, @regression)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -233,6 +233,16 @@
 - [-] Nested component
 - [-] Enter and exit grouped component
 
+#### 3.8 If-Else Component
+- [-] `operator=equals`: matching input routes through True branch (False branch stays inactive) → `core-components/if-else-component-regression.spec.ts`
+- [-] `operator=equals`: non-matching input routes through False branch (True branch stays inactive) → `core-components/if-else-component-regression.spec.ts`
+- [ ] `operator=contains` substring routing
+- [ ] `operator=regex` valid pattern routing
+- [ ] `operator=regex` hides `case_sensitive` field via `update_build_config`
+- [ ] Numeric operators (`greater than`, `less than`, etc.) — not exposed in docs but implemented in source
+- [ ] `case_sensitive` toggle behavior on text operators
+- [ ] `max_iterations` + `default_route` cycle break
+
 ---
 
 ## core-functionality/ — Core and Operational Logic

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -236,11 +236,13 @@
 #### 3.8 If-Else Component
 - [-] `operator=equals`: matching input routes through True branch (False branch stays inactive) → `core-components/if-else-component-regression.spec.ts`
 - [-] `operator=equals`: non-matching input routes through False branch (True branch stays inactive) → `core-components/if-else-component-regression.spec.ts`
-- [ ] `operator=contains` substring routing
-- [ ] `operator=regex` valid pattern routing
-- [ ] `operator=regex` hides `case_sensitive` field via `update_build_config`
-- [ ] Numeric operators (`greater than`, `less than`, etc.) — not exposed in docs but implemented in source
-- [ ] `case_sensitive` toggle behavior on text operators
+- [-] `operator=contains` substring routing → `core-components/if-else-component-regression.spec.ts`
+- [-] `operator=regex` valid pattern routing → `core-components/if-else-component-regression.spec.ts`
+- [-] `operator=regex` hides `case_sensitive` field via `update_build_config` → `core-components/if-else-component-regression.spec.ts`
+- [-] `case_sensitive` ON (default) treats mixed case as no-match → `core-components/if-else-component-regression.spec.ts`
+- [-] `case_sensitive` OFF treats mixed case as a match → `core-components/if-else-component-regression.spec.ts`
+- [-] `operator=greater than` numeric routing → `core-components/if-else-component-regression.spec.ts`
+- [ ] Other numeric operators (`less than`, `less than or equal`, `greater than or equal`) — share the same `float(...)` cast as `greater than`, not separately covered
 - [ ] `max_iterations` + `default_route` cycle break
 
 ---

--- a/docs/core-components/if-else-component-regression.md
+++ b/docs/core-components/if-else-component-regression.md
@@ -28,8 +28,8 @@ The one exception is the regex side-effect test: when `operator=regex`, the comp
 
 | # | Scenario | operator | input_text | match_text | case_sensitive | Active branch | Inactive branch |
 |---|---|---|---|---|---|---|---|
-| 1 | `equals` match (existing) | equals | hello | hello | default | True | False |
-| 2 | `equals` no-match (existing) | equals | world | hello | default | False | True |
+| 1 | `equals` match | equals | hello | hello | default | True | False |
+| 2 | `equals` no-match | equals | world | hello | default | False | True |
 | 3 | `contains` substring match | contains | langflow | lang | default | True | False |
 | 4 | `regex` valid pattern match | regex | abc123 | `^abc` | (N/A — regex ignores) | True | False |
 | 5 | `regex` hides `case_sensitive` field | regex | — | — | — | — (DOM check) | — |
@@ -37,7 +37,7 @@ The one exception is the regex side-effect test: when `operator=regex`, the comp
 | 7 | `case_sensitive` OFF → match on mixed case | equals | HELLO | hello | OFF (toggled) | True | False |
 | 8 | `greater than` (numeric) match | greater than | 10 | 5 | default | True | False |
 
-Tests 1 & 2 are already implemented; this update adds tests 3–8.
+All eight scenarios are introduced in this spec; there is no pre-existing implementation elsewhere.
 
 ---
 
@@ -59,11 +59,12 @@ Each test calls this helper and then applies the scenario-specific configuration
 
 ## New local helpers
 
-| Helper | Purpose | Selectors |
+| Helper | Signature | Behaviour |
 |---|---|---|
-| `selectOperator(page, optionTestid)` | Click the operator dropdown trigger, then click the option | `dropdown_str_operator` button → `<operator>-<idx>-option` (e.g. `contains-2-option`, `regex-5-option`, `greater than-8-option`) |
-| `exposeCaseSensitive(page)` | Toggle the case_sensitive advanced field to be visible on the node | open `edit-fields-button` → click `showcase_sensitive` → close edit-fields |
-| `toggleCaseSensitiveOff(page)` | Switch the BoolInput on the node from ON to OFF after exposure | click `toggle_bool_case_sensitive` (BUTTON role=switch); precondition: `exposeCaseSensitive` already ran |
+| `selectOperator` | `(page: Page, operatorName: string)` | Clicks the `value-dropdown-dropdown_str_operator` trigger, picks the option by `getByRole("option", { name: operatorName, exact: true })`, and asserts the trigger text reflects the new value. The option click uses `dispatchEvent("click")` because numeric options at the bottom of the list overlap `main_canvas_controls`, which intercepts ordinary pointer events. |
+| `exposeCaseSensitive` | `(page: Page)` | Opens advanced options, clicks `showcase_sensitive` to surface the BoolInput on the node body, then closes advanced options. |
+
+Test #7 (case_sensitive OFF) does not use a dedicated helper to flip the switch — it clicks `getByTestId("toggle_bool_case_sensitive")` (BUTTON `role="switch"`) inline after calling `exposeCaseSensitive`.
 
 ---
 
@@ -86,9 +87,9 @@ Each test calls this helper and then applies the scenario-specific configuration
 
 - `src/lfx/src/lfx/components/flow_controls/conditional_router.py` — owns the routing logic; `evaluate_condition`, `update_build_config`, and `iterate_and_stop_once` together implement the active/inactive branch behavior, case-sensitivity, and the regex hides-`case_sensitive` side-effect the spec asserts.
 - `src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx` (or equivalent) — emits the `node_duration_*` and `node_status_icon_*_inactive` test IDs consumed by the assertions.
-- `src/frontend/src/components/core/parameterRenderComponent/components/dropdownComponent/index.tsx` — owns `dropdown_str_*` and the `<value>-<idx>-option` testids used by `selectOperator`.
-- `helpers/ui/open-advanced-options.ts` — `openAdvancedOptions`/`closeAdvancedOptions` (clicks `edit-fields-button`). Used by `exposeCaseSensitive` and by the regex side-effect assertion.
-- `helpers/ui/zoom-out.ts` and `helpers/ui/adjust-screen-view.ts` — used to fit all three nodes in the visible canvas before wiring.
+- `src/frontend/src/components/core/parameterRenderComponent/components/dropdownComponent/index.tsx` — owns the `value-dropdown-dropdown_str_*` trigger and the Radix Select `role="option"` options used by `selectOperator`.
+- `tests/helpers/ui/open-advanced-options.ts` — `openAdvancedOptions`/`closeAdvancedOptions` (clicks `edit-fields-button`). Used by `exposeCaseSensitive` and by the regex side-effect assertion.
+- `tests/helpers/ui/zoom-out.ts` and `tests/helpers/ui/adjust-screen-view.ts` — used to fit all three nodes in the visible canvas before wiring.
 
 ---
 
@@ -114,5 +115,5 @@ Each test calls this helper and then applies the scenario-specific configuration
 - Stability: 3 / 3 PASS for the original 2 tests (~16–23 s). New scenarios will be re-validated with the same pipeline (typecheck + lint + stability + force-fail + trace + backend audit) before commit.
 - Force-fail probe pattern: temporarily change the active-branch `node_duration_*` `toHaveCount(1)` to `toHaveCount(99)` for one representative scenario per setup variant (default, exposed case_sensitive, switched operator). Confirm failure at the expected line, revert, re-pass.
 - The two Text Output components are dragged via `dragTo` to avoid the default-stack issue noted in the project memory (two sidebar `+` clicks land in the same position).
-- Operator dropdown options are selected by testid `<operator>-<idx>-option` where the operator name is verbatim (with spaces — `greater than-8-option`, not `greater_than-8-option`). The dropdown is Radix Select; `role="option"` is also available as a fallback.
+- Operator dropdown options are selected via `getByRole("option", { name: operatorName, exact: true })` — the dropdown is Radix Select, which exposes stable accessible names. Selecting by `role` instead of testid avoids depending on the option's index suffix in the DOM, which historically drifts as new operators are added.
 - The `case_sensitive` BoolInput uses testid `toggle_bool_case_sensitive` with `role="switch"`; toggling once flips from ON to OFF.

--- a/docs/core-components/if-else-component-regression.md
+++ b/docs/core-components/if-else-component-regression.md
@@ -8,14 +8,11 @@
 
 ## What this test validates
 
-Covers the foundational routing contract of the **If-Else** (ConditionalRouter) component for `operator=equals`:
+Covers the routing contract of the **If-Else** (ConditionalRouter) component across the operator surface: every text operator (equals, contains, regex), the `case_sensitive` toggle (default ON / explicit OFF), and one representative numeric operator (`greater than`). Each scenario is a separate `test()` so a failure pinpoints the exact behavior that regressed.
 
-1. **Match → True branch:** when `input_text` exactly equals `match_text`, the True output's downstream node builds successfully and the False output's downstream node is marked **inactive** (skipped).
-2. **No-match → False branch:** when `input_text` differs from `match_text`, the False output's downstream node builds and the True output's downstream node is **inactive**.
+For every scenario except the regex side-effect test, the assertion surface is the canvas node status: `node_duration_<name>` testid for the branch that built (active) and `node_status_icon_<name>_inactive` testid for the branch that was skipped. This is the same surface used by `flow-functionality/general-bugs-reset-flow-run.spec.ts` and is more reliable than message-content assertions because the component returns an empty Message on the inactive branch (so message presence alone cannot distinguish the routes).
 
-This contract is the load-bearing behavior of If-Else — every other operator (`contains`, `regex`, numeric comparisons) builds on the same active/inactive routing model. If `equals` routing breaks, the rest of the operator surface breaks with it. The two tests in this spec are scoped to that foundational case; future scenarios (`contains`, `regex`, `case_sensitive`, numeric, `max_iterations`) are listed as unchecked items under QA-CHECKLIST.md §3.8.
-
-The assertion surface is the canvas node status — `node_duration_<name>` testid for the branch that built and `node_status_icon_<name>_inactive` testid for the branch that was skipped. This is the same surface used by `flow-functionality/general-bugs-reset-flow-run.spec.ts` and is more reliable than message-content assertions because the component returns an empty Message on the inactive branch (so message presence alone cannot distinguish the routes).
+The one exception is the regex side-effect test: when `operator=regex`, the component's `update_build_config` removes the `case_sensitive` field from the build config. The assertion there is that opening the edit-fields modal shows `toHaveCount(0)` for the `showcase_sensitive` testid (it is normally `1`).
 
 ---
 
@@ -27,50 +24,81 @@ The assertion surface is the canvas node status — `node_duration_<name>` testi
 
 ---
 
-## Step by step (per test)
+## Scenarios (one `test()` per row)
 
-Both tests share the same setup, parameterized only by `input_text`:
+| # | Scenario | operator | input_text | match_text | case_sensitive | Active branch | Inactive branch |
+|---|---|---|---|---|---|---|---|
+| 1 | `equals` match (existing) | equals | hello | hello | default | True | False |
+| 2 | `equals` no-match (existing) | equals | world | hello | default | False | True |
+| 3 | `contains` substring match | contains | langflow | lang | default | True | False |
+| 4 | `regex` valid pattern match | regex | abc123 | `^abc` | (N/A — regex ignores) | True | False |
+| 5 | `regex` hides `case_sensitive` field | regex | — | — | — | — (DOM check) | — |
+| 6 | `case_sensitive` ON (default) → no-match on mixed case | equals | HELLO | hello | ON (default) | False | True |
+| 7 | `case_sensitive` OFF → match on mixed case | equals | HELLO | hello | OFF (toggled) | True | False |
+| 8 | `greater than` (numeric) match | greater than | 10 | 5 | default | True | False |
+
+Tests 1 & 2 are already implemented; this update adds tests 3–8.
+
+---
+
+## Shared setup helper
+
+`buildIfElseRoutingFlow(page)` (defined in the spec):
 
 1. Bootstrap and open a blank flow.
 2. Add the **If-Else** component from the sidebar.
 3. Zoom out so two more components fit.
 4. Drop two **Text Output** components onto the canvas (positions: `{100, 100}` and `{200, 400}`).
-5. Rename the second Text Output to `textoutputfalse` (so its testid suffix is stable).
+5. Rename the second Text Output to `textoutputfalse` so its testid suffix is stable.
 6. Wire `handle-conditionalrouter-shownode-true-right` → first Text Output's `inputs-left` handle.
 7. Wire `handle-conditionalrouter-shownode-false-right` → `textoutputfalse`'s `inputs-left` handle.
-8. Fill `popover-anchor-input-input_text` and `popover-anchor-input-match_text` with the scenario values (`hello`/`hello` for match, `world`/`hello` for no-match).
-9. Click the run button on the branch that should activate (`button_run_text output` for True, `button_run_textoutputfalse` for False).
-10. Wait for the **built successfully** notification.
-11. Assert that the active branch's `node_duration_*` testid has count 1 and the inactive branch's `node_status_icon_*_inactive` testid has count 1.
+
+Each test calls this helper and then applies the scenario-specific configuration before running.
 
 ---
 
-## Validation criterion
+## New local helpers
 
-| Scenario | Active branch (`toHaveCount(1)`) | Inactive branch (`toHaveCount(1)`) |
+| Helper | Purpose | Selectors |
 |---|---|---|
-| `input_text=hello`, `match_text=hello` | `node_duration_text output` | `node_status_icon_textoutputfalse_inactive` |
-| `input_text=world`, `match_text=hello` | `node_duration_textoutputfalse` | `node_status_icon_text output_inactive` |
+| `selectOperator(page, optionTestid)` | Click the operator dropdown trigger, then click the option | `dropdown_str_operator` button → `<operator>-<idx>-option` (e.g. `contains-2-option`, `regex-5-option`, `greater than-8-option`) |
+| `exposeCaseSensitive(page)` | Toggle the case_sensitive advanced field to be visible on the node | open `edit-fields-button` → click `showcase_sensitive` → close edit-fields |
+| `toggleCaseSensitiveOff(page)` | Switch the BoolInput on the node from ON to OFF after exposure | click `toggle_bool_case_sensitive` (BUTTON role=switch); precondition: `exposeCaseSensitive` already ran |
+
+---
+
+## Validation criterion (per scenario)
+
+| # | Active branch (`toHaveCount(1)`) | Inactive branch (`toHaveCount(1)`) | Additional |
+|---|---|---|---|
+| 1 | `node_duration_text output` | `node_status_icon_textoutputfalse_inactive` | — |
+| 2 | `node_duration_textoutputfalse` | `node_status_icon_text output_inactive` | — |
+| 3 | `node_duration_text output` | `node_status_icon_textoutputfalse_inactive` | — |
+| 4 | `node_duration_text output` | `node_status_icon_textoutputfalse_inactive` | — |
+| 5 | — | — | After switching to `regex`, opening edit-fields shows `toHaveCount(0)` for `showcase_sensitive`. With `equals`, count is `1`. |
+| 6 | `node_duration_textoutputfalse` | `node_status_icon_text output_inactive` | — |
+| 7 | `node_duration_text output` | `node_status_icon_textoutputfalse_inactive` | — |
+| 8 | `node_duration_text output` | `node_status_icon_textoutputfalse_inactive` | — |
 
 ---
 
 ## External dependencies
 
-- `src/lfx/src/lfx/components/flow_controls/conditional_router.py` — owns the routing logic; `evaluate_condition` and `iterate_and_stop_once` together implement the active/inactive branch behavior the spec asserts.
+- `src/lfx/src/lfx/components/flow_controls/conditional_router.py` — owns the routing logic; `evaluate_condition`, `update_build_config`, and `iterate_and_stop_once` together implement the active/inactive branch behavior, case-sensitivity, and the regex hides-`case_sensitive` side-effect the spec asserts.
 - `src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx` (or equivalent) — emits the `node_duration_*` and `node_status_icon_*_inactive` test IDs consumed by the assertions.
+- `src/frontend/src/components/core/parameterRenderComponent/components/dropdownComponent/index.tsx` — owns `dropdown_str_*` and the `<value>-<idx>-option` testids used by `selectOperator`.
+- `helpers/ui/open-advanced-options.ts` — `openAdvancedOptions`/`closeAdvancedOptions` (clicks `edit-fields-button`). Used by `exposeCaseSensitive` and by the regex side-effect assertion.
 - `helpers/ui/zoom-out.ts` and `helpers/ui/adjust-screen-view.ts` — used to fit all three nodes in the visible canvas before wiring.
 
 ---
 
 ## What this test does not cover
 
-- All operators except `equals`. The other 9 operators (`not equals`, `contains`, `starts with`, `ends with`, `regex`, `less than`, `less than or equal`, `greater than`, `greater than or equal`) are exercised only via the underlying `evaluate_condition` Python logic, not via UI regression.
-- The `case_sensitive` toggle behavior on text operators.
-- The `regex` operator's hide-`case_sensitive` side effect (`update_build_config` real-time refresh).
-- The cycle-handling code path (`max_iterations`, `default_route`, `iterate_and_stop_once`).
-- The advanced fields `true_case_message` and `false_case_message` — left default (empty Message) for both tests since the assertion surface is node-status, not message content.
-- Numeric operators are documented as undocumented (the public docs list 6 operators; the Python source has 10). The numeric branch is therefore not covered until either the docs are updated or the team confirms the numeric surface is intentional.
-- Playground end-to-end interaction. The test uses direct `popover-anchor-input-*` fills instead of `ChatInput → Playground` because the routing assertion does not depend on which input source feeds `input_text`.
+- Operators `not equals`, `starts with`, `ends with`, `less than`, `less than or equal`, `greater than or equal`. The text operators all share `evaluate_condition` plumbing covered by tests 1–4 + 6–7; the remaining numeric operators are skipped because they all use the same `float(...)` cast covered by test 8.
+- Non-numeric input to a numeric operator (the Python `ValueError` fallback returning `False`). Documented in the source but not exposed in the public docs; tracked as `[ ]` in QA-CHECKLIST.md §3.8.
+- `max_iterations` and `default_route` cycle-handling behavior. Requires a flow with a cycle which is out of scope for a single-step regression.
+- Playground end-to-end (`ChatInput → If-Else → ChatOutput`). The routing assertion does not depend on which input source feeds `input_text`, and tests 1–8 already prove the routing logic.
+- Advanced field `true_case_message` / `false_case_message`: left empty for every scenario. Their custom-message routing is a separate behavior tested elsewhere.
 
 ---
 
@@ -83,6 +111,8 @@ Both tests share the same setup, parameterized only by `input_text`:
 
 ## Notes
 
-- Stability: 3 / 3 PASS across consecutive runs (~16–23 s for 2 tests).
-- Force-fail probe on the True-branch `node_duration_text output` `toHaveCount(1)` assertion (changed to `99`) failed at the expected line; reverted, re-passed.
-- The two ChatInput-positioned Text Output components are dragged via `dragTo` to avoid the default-stack issue noted in the project memory (two sidebar `+` clicks land in the same position).
+- Stability: 3 / 3 PASS for the original 2 tests (~16–23 s). New scenarios will be re-validated with the same pipeline (typecheck + lint + stability + force-fail + trace + backend audit) before commit.
+- Force-fail probe pattern: temporarily change the active-branch `node_duration_*` `toHaveCount(1)` to `toHaveCount(99)` for one representative scenario per setup variant (default, exposed case_sensitive, switched operator). Confirm failure at the expected line, revert, re-pass.
+- The two Text Output components are dragged via `dragTo` to avoid the default-stack issue noted in the project memory (two sidebar `+` clicks land in the same position).
+- Operator dropdown options are selected by testid `<operator>-<idx>-option` where the operator name is verbatim (with spaces — `greater than-8-option`, not `greater_than-8-option`). The dropdown is Radix Select; `role="option"` is also available as a fallback.
+- The `case_sensitive` BoolInput uses testid `toggle_bool_case_sensitive` with `role="switch"`; toggling once flips from ON to OFF.

--- a/docs/core-components/if-else-component-regression.md
+++ b/docs/core-components/if-else-component-regression.md
@@ -1,0 +1,88 @@
+# Spec: If-Else Component — Routing Regression
+
+**Test file:** `tests/tests-automations/regression/core-components/if-else-component-regression.spec.ts`
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates
+
+Covers the foundational routing contract of the **If-Else** (ConditionalRouter) component for `operator=equals`:
+
+1. **Match → True branch:** when `input_text` exactly equals `match_text`, the True output's downstream node builds successfully and the False output's downstream node is marked **inactive** (skipped).
+2. **No-match → False branch:** when `input_text` differs from `match_text`, the False output's downstream node builds and the True output's downstream node is **inactive**.
+
+This contract is the load-bearing behavior of If-Else — every other operator (`contains`, `regex`, numeric comparisons) builds on the same active/inactive routing model. If `equals` routing breaks, the rest of the operator surface breaks with it. The two tests in this spec are scoped to that foundational case; future scenarios (`contains`, `regex`, `case_sensitive`, numeric, `max_iterations`) are listed as unchecked items under QA-CHECKLIST.md §3.8.
+
+The assertion surface is the canvas node status — `node_duration_<name>` testid for the branch that built and `node_status_icon_<name>_inactive` testid for the branch that was skipped. This is the same surface used by `flow-functionality/general-bugs-reset-flow-run.spec.ts` and is more reliable than message-content assertions because the component returns an empty Message on the inactive branch (so message presence alone cannot distinguish the routes).
+
+---
+
+## Tags
+
+`@regression` `@components`
+
+> Not `@stable` initially — the spec is new; promote to `@stable` after a few weekly runs prove it stable.
+
+---
+
+## Step by step (per test)
+
+Both tests share the same setup, parameterized only by `input_text`:
+
+1. Bootstrap and open a blank flow.
+2. Add the **If-Else** component from the sidebar.
+3. Zoom out so two more components fit.
+4. Drop two **Text Output** components onto the canvas (positions: `{100, 100}` and `{200, 400}`).
+5. Rename the second Text Output to `textoutputfalse` (so its testid suffix is stable).
+6. Wire `handle-conditionalrouter-shownode-true-right` → first Text Output's `inputs-left` handle.
+7. Wire `handle-conditionalrouter-shownode-false-right` → `textoutputfalse`'s `inputs-left` handle.
+8. Fill `popover-anchor-input-input_text` and `popover-anchor-input-match_text` with the scenario values (`hello`/`hello` for match, `world`/`hello` for no-match).
+9. Click the run button on the branch that should activate (`button_run_text output` for True, `button_run_textoutputfalse` for False).
+10. Wait for the **built successfully** notification.
+11. Assert that the active branch's `node_duration_*` testid has count 1 and the inactive branch's `node_status_icon_*_inactive` testid has count 1.
+
+---
+
+## Validation criterion
+
+| Scenario | Active branch (`toHaveCount(1)`) | Inactive branch (`toHaveCount(1)`) |
+|---|---|---|
+| `input_text=hello`, `match_text=hello` | `node_duration_text output` | `node_status_icon_textoutputfalse_inactive` |
+| `input_text=world`, `match_text=hello` | `node_duration_textoutputfalse` | `node_status_icon_text output_inactive` |
+
+---
+
+## External dependencies
+
+- `src/lfx/src/lfx/components/flow_controls/conditional_router.py` — owns the routing logic; `evaluate_condition` and `iterate_and_stop_once` together implement the active/inactive branch behavior the spec asserts.
+- `src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx` (or equivalent) — emits the `node_duration_*` and `node_status_icon_*_inactive` test IDs consumed by the assertions.
+- `helpers/ui/zoom-out.ts` and `helpers/ui/adjust-screen-view.ts` — used to fit all three nodes in the visible canvas before wiring.
+
+---
+
+## What this test does not cover
+
+- All operators except `equals`. The other 9 operators (`not equals`, `contains`, `starts with`, `ends with`, `regex`, `less than`, `less than or equal`, `greater than`, `greater than or equal`) are exercised only via the underlying `evaluate_condition` Python logic, not via UI regression.
+- The `case_sensitive` toggle behavior on text operators.
+- The `regex` operator's hide-`case_sensitive` side effect (`update_build_config` real-time refresh).
+- The cycle-handling code path (`max_iterations`, `default_route`, `iterate_and_stop_once`).
+- The advanced fields `true_case_message` and `false_case_message` — left default (empty Message) for both tests since the assertion surface is node-status, not message content.
+- Numeric operators are documented as undocumented (the public docs list 6 operators; the Python source has 10). The numeric branch is therefore not covered until either the docs are updated or the team confirms the numeric surface is intentional.
+- Playground end-to-end interaction. The test uses direct `popover-anchor-input-*` fills instead of `ChatInput → Playground` because the routing assertion does not depend on which input source feeds `input_text`.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- No model provider credentials required — If-Else is pure text comparison.
+
+---
+
+## Notes
+
+- Stability: 3 / 3 PASS across consecutive runs (~16–23 s for 2 tests).
+- Force-fail probe on the True-branch `node_duration_text output` `toHaveCount(1)` assertion (changed to `99`) failed at the expected line; reverted, re-passed.
+- The two ChatInput-positioned Text Output components are dragged via `dragTo` to avoid the default-stack issue noted in the project memory (two sidebar `+` clicks land in the same position).

--- a/tests/tests-automations/regression/core-components/if-else-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/if-else-component-regression.spec.ts
@@ -1,0 +1,136 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
+import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { zoomOut } from "../../../helpers/ui/zoom-out";
+
+// Builds: If-Else (operator=equals) + two Text Output components, one renamed
+// to `textoutputfalse` so the True/False branches can be inspected
+// independently by testid. Direct-value path: `input_text` and `match_text`
+// are typed into the If-Else inspector popovers — no ChatInput/Playground
+// involved, mirroring `general-bugs-reset-flow-run.spec.ts` which validated
+// that the canvas node-status icons (`node_duration_*` vs
+// `node_status_icon_*_inactive`) are the most reliable assertion surface for
+// conditional routing.
+async function buildIfElseRoutingFlow(page: Page): Promise<void> {
+  await awaitBootstrapTest(page);
+  await expect(page.getByTestId("blank-flow")).toBeVisible({ timeout: 30000 });
+  await page.getByTestId("blank-flow").click();
+
+  // If-Else
+  await page.getByTestId("sidebar-search-input").click();
+  await page.getByTestId("sidebar-search-input").fill("if else");
+  await expect(page.getByTestId("flow_controlsIf-Else")).toBeVisible({
+    timeout: 10000,
+  });
+  await page.getByTestId("flow_controlsIf-Else").hover();
+  await page.getByTestId("add-component-button-if-else").click();
+
+  await zoomOut(page, 3);
+
+  // Text Output (will be wired to True branch — default name `text output`)
+  await page.getByTestId("sidebar-search-input").click();
+  await page.getByTestId("sidebar-search-input").fill("text output");
+  await expect(page.getByTestId("input_outputText Output")).toBeVisible({
+    timeout: 10000,
+  });
+  await page
+    .getByTestId("input_outputText Output")
+    .dragTo(page.locator('//*[@id="react-flow-id"]'), {
+      targetPosition: { x: 100, y: 100 },
+    });
+
+  await adjustScreenView(page);
+
+  // Second Text Output — will be wired to False branch and renamed to
+  // `textoutputfalse` so the False-branch status icon has a stable testid.
+  await page.getByTestId("sidebar-search-input").click();
+  await page.getByTestId("sidebar-search-input").fill("text output");
+  await expect(page.getByTestId("input_outputText Output")).toBeVisible({
+    timeout: 10000,
+  });
+  await page
+    .getByTestId("input_outputText Output")
+    .dragTo(page.locator('//*[@id="react-flow-id"]'), {
+      targetPosition: { x: 200, y: 400 },
+    });
+
+  await adjustScreenView(page);
+
+  // Rename the second Text Output to `textoutputfalse`
+  await page.getByTestId("generic-node-title-arrangement").last().click();
+  await page.getByTestId("panel-description").hover();
+  await page
+    .getByTestId("panel-description")
+    .getByTestId("edit-name-description-button")
+    .click();
+  await page.getByTestId("inspection-panel-name").fill("textoutputfalse");
+  await page
+    .getByTestId("panel-description")
+    .getByTestId("save-name-description-button")
+    .click();
+
+  // Connect True → first Text Output
+  await page
+    .getByTestId("handle-conditionalrouter-shownode-true-right")
+    .click();
+  await page
+    .getByTestId("handle-textoutput-shownode-inputs-left")
+    .first()
+    .click();
+
+  // Connect False → second Text Output (textoutputfalse)
+  await page
+    .getByTestId("handle-conditionalrouter-shownode-false-right")
+    .click();
+  await page
+    .getByTestId("handle-textoutput-shownode-inputs-left")
+    .last()
+    .click();
+}
+
+test(
+  "If-Else routes matching input through the True branch and skips the False branch",
+  { tag: ["@regression", "@components"] },
+  async ({ page }) => {
+    await buildIfElseRoutingFlow(page);
+
+    // Match: input_text === match_text → True branch should build.
+    await page.getByTestId("popover-anchor-input-input_text").fill("hello");
+    await page.getByTestId("popover-anchor-input-match_text").fill("hello");
+
+    await page.getByTestId("button_run_text output").click();
+    await expect(page.locator("text=built successfully")).toBeVisible({
+      timeout: 30000,
+    });
+
+    await expect(page.getByTestId("node_duration_text output")).toHaveCount(1);
+    await expect(
+      page.getByTestId("node_status_icon_textoutputfalse_inactive"),
+    ).toHaveCount(1);
+  },
+);
+
+test(
+  "If-Else routes non-matching input through the False branch and skips the True branch",
+  { tag: ["@regression", "@components"] },
+  async ({ page }) => {
+    await buildIfElseRoutingFlow(page);
+
+    // No match: input_text !== match_text → False branch should build.
+    await page.getByTestId("popover-anchor-input-input_text").fill("world");
+    await page.getByTestId("popover-anchor-input-match_text").fill("hello");
+
+    await page.getByTestId("button_run_textoutputfalse").click();
+    await expect(page.locator("text=built successfully")).toBeVisible({
+      timeout: 30000,
+    });
+
+    await expect(
+      page.getByTestId("node_duration_textoutputfalse"),
+    ).toHaveCount(1);
+    await expect(
+      page.getByTestId("node_status_icon_text output_inactive"),
+    ).toHaveCount(1);
+  },
+);

--- a/tests/tests-automations/regression/core-components/if-else-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/if-else-component-regression.spec.ts
@@ -2,7 +2,35 @@ import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import {
+  closeAdvancedOptions,
+  openAdvancedOptions,
+} from "../../../helpers/ui/open-advanced-options";
 import { zoomOut } from "../../../helpers/ui/zoom-out";
+
+async function selectOperator(
+  page: Page,
+  operatorName: string,
+): Promise<void> {
+  await page.getByTestId("value-dropdown-dropdown_str_operator").click();
+  // Match by exact role+name — robust across option-index churn. Click via
+  // `dispatchEvent` because the bottom of the options list (numeric operators)
+  // overlaps `main_canvas_controls`, which intercepts ordinary pointer events.
+  await page
+    .getByRole("option", { name: operatorName, exact: true })
+    .dispatchEvent("click");
+  // Confirm the trigger reflects the new value before proceeding — guards
+  // against the real_time_refresh round-trip not having landed yet.
+  await expect(
+    page.getByTestId("value-dropdown-dropdown_str_operator"),
+  ).toHaveText(operatorName);
+}
+
+async function exposeCaseSensitive(page: Page): Promise<void> {
+  await openAdvancedOptions(page);
+  await page.getByTestId("showcase_sensitive").click();
+  await closeAdvancedOptions(page);
+}
 
 // Builds: If-Else (operator=equals) + two Text Output components, one renamed
 // to `textoutputfalse` so the True/False branches can be inspected
@@ -131,6 +159,159 @@ test(
     ).toHaveCount(1);
     await expect(
       page.getByTestId("node_status_icon_text output_inactive"),
+    ).toHaveCount(1);
+  },
+);
+
+test(
+  "If-Else operator=contains routes a substring match through the True branch",
+  { tag: ["@regression", "@components"] },
+  async ({ page }) => {
+    await buildIfElseRoutingFlow(page);
+
+    await selectOperator(page, "contains");
+
+    // `lang` is a substring of `langflow` → contains evaluates True.
+    await page.getByTestId("popover-anchor-input-input_text").fill("langflow");
+    await page.getByTestId("popover-anchor-input-match_text").fill("lang");
+
+    await page.getByTestId("button_run_text output").click();
+    await expect(page.locator("text=built successfully")).toBeVisible({
+      timeout: 30000,
+    });
+
+    await expect(page.getByTestId("node_duration_text output")).toHaveCount(1);
+    await expect(
+      page.getByTestId("node_status_icon_textoutputfalse_inactive"),
+    ).toHaveCount(1);
+  },
+);
+
+test(
+  "If-Else operator=regex routes a valid pattern match through the True branch",
+  { tag: ["@regression", "@components"] },
+  async ({ page }) => {
+    await buildIfElseRoutingFlow(page);
+
+    await selectOperator(page, "regex");
+
+    // `^abc` matches the start of `abc123` → regex evaluates True.
+    await page.getByTestId("popover-anchor-input-input_text").fill("abc123");
+    await page.getByTestId("popover-anchor-input-match_text").fill("^abc");
+
+    await page.getByTestId("button_run_text output").click();
+    await expect(page.locator("text=built successfully")).toBeVisible({
+      timeout: 30000,
+    });
+
+    await expect(page.getByTestId("node_duration_text output")).toHaveCount(1);
+    await expect(
+      page.getByTestId("node_status_icon_textoutputfalse_inactive"),
+    ).toHaveCount(1);
+  },
+);
+
+test(
+  "If-Else operator=regex hides the case_sensitive advanced field",
+  { tag: ["@regression", "@components"] },
+  async ({ page }) => {
+    await buildIfElseRoutingFlow(page);
+
+    // Focus the If-Else node — `openAdvancedOptions` operates on the
+    // currently-focused node, and the build helper leaves focus on the last
+    // Text Output it renamed.
+    await page.getByTestId("title-If-Else").click();
+
+    // Baseline: with the default operator (equals), the edit-fields modal
+    // exposes the case_sensitive toggle.
+    await openAdvancedOptions(page);
+    await expect(page.getByTestId("showcase_sensitive")).toHaveCount(1);
+    await closeAdvancedOptions(page);
+
+    // After switching to regex, `update_build_config` removes case_sensitive
+    // from the build config — the toggle should disappear.
+    await selectOperator(page, "regex");
+
+    await page.getByTestId("title-If-Else").click();
+    await openAdvancedOptions(page);
+    await expect(page.getByTestId("showcase_sensitive")).toHaveCount(0);
+    await closeAdvancedOptions(page);
+  },
+);
+
+test(
+  "If-Else case_sensitive defaults to ON — mixed-case inputs route to the False branch",
+  { tag: ["@regression", "@components"] },
+  async ({ page }) => {
+    await buildIfElseRoutingFlow(page);
+
+    // case_sensitive is True by default in the Python source. With operator
+    // equals, `HELLO` and `hello` differ — False branch should build.
+    await page.getByTestId("popover-anchor-input-input_text").fill("HELLO");
+    await page.getByTestId("popover-anchor-input-match_text").fill("hello");
+
+    await page.getByTestId("button_run_textoutputfalse").click();
+    await expect(page.locator("text=built successfully")).toBeVisible({
+      timeout: 30000,
+    });
+
+    await expect(
+      page.getByTestId("node_duration_textoutputfalse"),
+    ).toHaveCount(1);
+    await expect(
+      page.getByTestId("node_status_icon_text output_inactive"),
+    ).toHaveCount(1);
+  },
+);
+
+test(
+  "If-Else with case_sensitive=OFF treats mixed-case inputs as a match (True branch)",
+  { tag: ["@regression", "@components"] },
+  async ({ page }) => {
+    await buildIfElseRoutingFlow(page);
+
+    // Focus If-Else and expose the case_sensitive field on the node body,
+    // then toggle the switch from ON (default) to OFF.
+    await page.getByTestId("title-If-Else").click();
+    await exposeCaseSensitive(page);
+    await page.getByTestId("toggle_bool_case_sensitive").click();
+
+    // With case-insensitive comparison, `HELLO` and `hello` are equal.
+    await page.getByTestId("popover-anchor-input-input_text").fill("HELLO");
+    await page.getByTestId("popover-anchor-input-match_text").fill("hello");
+
+    await page.getByTestId("button_run_text output").click();
+    await expect(page.locator("text=built successfully")).toBeVisible({
+      timeout: 30000,
+    });
+
+    await expect(page.getByTestId("node_duration_text output")).toHaveCount(1);
+    await expect(
+      page.getByTestId("node_status_icon_textoutputfalse_inactive"),
+    ).toHaveCount(1);
+  },
+);
+
+test(
+  "If-Else operator=greater than routes a numeric match (10 > 5) through the True branch",
+  { tag: ["@regression", "@components"] },
+  async ({ page }) => {
+    await buildIfElseRoutingFlow(page);
+
+    await selectOperator(page, "greater than");
+
+    // Numeric: 10 > 5 → True.
+    await page.getByTestId("popover-anchor-input-input_text").fill("10");
+    await page.getByTestId("popover-anchor-input-match_text").fill("5");
+
+    await page.getByTestId("button_run_text output").click();
+    await expect(page.locator("text=built successfully")).toBeVisible({
+      timeout: 30000,
+    });
+
+    await expect(page.getByTestId("node_duration_text output")).toHaveCount(1);
+    await expect(
+      page.getByTestId("node_status_icon_textoutputfalse_inactive"),
     ).toHaveCount(1);
   },
 );


### PR DESCRIPTION
## Summary

New spec \`if-else-component-regression.spec.ts\` with 8 tests covering the routing contract of the ConditionalRouter (If-Else) component:

1. \`equals\` match → True branch builds, False branch inactive
2. \`equals\` no-match → False branch builds, True branch inactive
3. \`contains\` substring match (\`langflow\` contains \`lang\`) → True
4. \`regex\` valid pattern match (\`^abc\` matches \`abc123\`) → True
5. \`regex\` hides the \`case_sensitive\` advanced field (DOM check on \`showcase_sensitive\` count: 1 with \`equals\`, 0 with \`regex\` — exercises the \`update_build_config\` real_time_refresh path)
6. \`case_sensitive\` ON default → \`HELLO\` vs \`hello\` routes to False
7. \`case_sensitive\` OFF → \`HELLO\` vs \`hello\` routes to True
8. \`operator=greater than\` numeric routing (\`10 > 5\`) → True

For every test except #5, the assertion surface is the canvas node-status (\`node_duration_<name>\` for the active branch, \`node_status_icon_<name>_inactive\` for the skipped branch) — the same pattern used by \`flow-functionality/general-bugs-reset-flow-run.spec.ts\` and the only reliable distinguisher between branches because the component emits an empty Message on the inactive branch regardless of route.

Local helpers introduced:
- \`selectOperator(page, operatorName)\` — clicks the dropdown trigger and picks the option by \`role=\"option\"\` + exact name; uses \`dispatchEvent\` for the click because numeric options at the bottom of the list sit behind \`main_canvas_controls\`, which intercepts ordinary pointer events. Confirms the trigger label reflects the new value before returning.
- \`exposeCaseSensitive(page)\` — opens the edit-fields modal, toggles \`showcase_sensitive\` to make the BoolInput visible on the node body. Once exposed, the test clicks \`toggle_bool_case_sensitive\` (role=\"switch\") to flip from ON to OFF.

Tagged \`@regression @components\` — not \`@stable\` yet. Promote after a few weekly cycles confirm stability. Ships the matching spec doc under \`docs/core-components/if-else-component-regression.md\` and a new §3.8 If-Else section in QA-CHECKLIST.md tracking the 8 covered scenarios + the remaining uncovered items (\`max_iterations\`/\`default_route\` cycle break, other numeric operators).

## Validation pipeline (7 steps, all PASS)

1. \`npm run typecheck\` — clean
2. \`npx eslint <spec>\` — 0 errors, 0 warnings
3. Anti-pattern checklist — imports, tags, expect count well above required ratio
4. Stability: 3/3 PASS at \`--workers=1 --retries=0\` (~57–80 s for 8 tests)
5. Force-fail — broke regex-hides \`showcase_sensitive\` \`toHaveCount(0)\` to \`toHaveCount(99)\`, failed at the expected line, reverted, repassed
6. \`--trace=on\` — coherent trace
7. Backend errors audit — zero \`🚨 Backend Error\`

## Test plan

- [ ] \`npx playwright test tests/tests-automations/regression/core-components/if-else-component-regression.spec.ts --workers=1 --retries=0\` (8 tests)
- [ ] After a few weekly cycles with no failures, promote selected tests to \`@stable\`