### PR TITLE
test(api-request): extend regression with body table + autosave persistence

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -201,7 +201,7 @@
 - [x] Headers table accepts key + value cell entries via inspector → `core-components/api-request-component-regression.spec.ts`
 - [x] cURL tab switches mode and exposes the cURL input field → `core-components/api-request-component-regression.spec.ts`
 - [x] cURL parser auto-fills URL field and executes the GET, returning 200 → `core-components/api-request-component-regression.spec.ts`
-- [x] Body table accepts key + value cell entries via Controls modal (body field is `advanced=True`) → `core-components/api-request-component-regression.spec.ts`
+- [x] Body table accepts key + value cell entries when method is POST (body field is `advanced=True` and hidden by inspector while method is GET) → `core-components/api-request-component-regression.spec.ts`
 - [x] Flow state (URL, method, headers row) persists in database after autosave and rehydrates on reload → `core-components/api-request-component-regression.spec.ts`
 
 #### 3.4 Webhook
@@ -768,7 +768,7 @@
 - [x] API Request component — inspector headers table accepts key + value cell entries → `api-request-component-regression.spec.ts`
 - [x] API Request component — cURL tab switches mode and field accepts a cURL command → `api-request-component-regression.spec.ts`
 - [x] API Request component — cURL mode parses command, auto-fills URL, executes GET and returns 200 → `api-request-component-regression.spec.ts`
-- [x] API Request component — body table accepts key + value cell entries via Controls modal → `api-request-component-regression.spec.ts`
+- [x] API Request component — body table accepts key + value cell entries when method is POST → `api-request-component-regression.spec.ts`
 - [x] API Request component — flow state persists in database after autosave (URL, method, headers) → `api-request-component-regression.spec.ts`
 - [x] Chat Input — toggling `showfiles` exposes the Files inspector field → `chat-input-files-field-regression.spec.ts`
 - [x] Chat Input — uploading via the inspector populates the Files field → `chat-input-files-field-regression.spec.ts`

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -201,8 +201,8 @@
 - [x] Headers table accepts key + value cell entries via inspector → `core-components/api-request-component-regression.spec.ts`
 - [x] cURL tab switches mode and exposes the cURL input field → `core-components/api-request-component-regression.spec.ts`
 - [x] cURL parser auto-fills URL field and executes the GET, returning 200 → `core-components/api-request-component-regression.spec.ts`
-- [ ] Body table key + value entries (body field is `advanced=True`)
-- [ ] Flow state persisted in database after autosave
+- [x] Body table accepts key + value cell entries via Controls modal (body field is `advanced=True`) → `core-components/api-request-component-regression.spec.ts`
+- [x] Flow state (URL, method, headers row) persists in database after autosave and rehydrates on reload → `core-components/api-request-component-regression.spec.ts`
 
 #### 3.4 Webhook
 - [x] POST aceita JSON e text/plain retornando 202 com `status: "in progress"` → `core-components/webhook-component-regression.spec.ts`
@@ -706,7 +706,7 @@
 |--------|-------|-----------------|------------------------|---------------------|---------------------|
 | `api/flows/` — REST API | 21 | 4 | 17 | 0 | 0 |
 | `core-components/` — Component Config | 22 | 1 | 19 | 0 | 2 |
-| `core-components/` — Core Components | 67 | 59 | 3 | 1 | 4 |
+| `core-components/` — Core Components | 67 | 61 | 3 | 1 | 2 |
 | `core-functionality/auth/` | 19 | 0 | 18 | 0 | 1 |
 | `core-functionality/knowledge-ingestion/` | 8 | 0 | 4 | 0 | 4 |
 | `core-functionality/llm-agents/` | 40 | 13 | 2 | 0 | 25 |
@@ -720,7 +720,7 @@
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 43 | 2 | 39 | 1 | 1 |
 | `ui-ux/` — Settings | 5 | 1 | 3 | 1 | 0 |
-| **TOTAL** | **408** | **132 (32%)** | **215 (53%)** | **7 (2%)** | **54 (13%)** |
+| **TOTAL** | **408** | **134 (33%)** | **215 (53%)** | **7 (2%)** | **52 (13%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -736,7 +736,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 132 `test()` calls carrying the `@stable` tag, distributed across 45 spec
+> 134 `test()` calls carrying the `@stable` tag, distributed across 45 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -768,6 +768,8 @@
 - [x] API Request component — inspector headers table accepts key + value cell entries → `api-request-component-regression.spec.ts`
 - [x] API Request component — cURL tab switches mode and field accepts a cURL command → `api-request-component-regression.spec.ts`
 - [x] API Request component — cURL mode parses command, auto-fills URL, executes GET and returns 200 → `api-request-component-regression.spec.ts`
+- [x] API Request component — body table accepts key + value cell entries via Controls modal → `api-request-component-regression.spec.ts`
+- [x] API Request component — flow state persists in database after autosave (URL, method, headers) → `api-request-component-regression.spec.ts`
 - [x] Chat Input — toggling `showfiles` exposes the Files inspector field → `chat-input-files-field-regression.spec.ts`
 - [x] Chat Input — uploading via the inspector populates the Files field → `chat-input-files-field-regression.spec.ts`
 - [x] Chat Input → Chat Output — inspector-attached file is rendered in the Playground message → `chat-input-files-field-regression.spec.ts`
@@ -898,7 +900,7 @@
 |--------|-----------------|---------------|
 | `api/flows/` — REST API | 17 | 0 |
 | `core-components/` — Component Config | 19 | 2 |
-| `core-components/` — Core Components | 3 | 4 |
+| `core-components/` — Core Components | 3 | 2 |
 | `core-functionality/auth/` | 18 | 1 |
 | `core-functionality/llm-agents/` | 2 | 25 |
 | `core-functionality/model-provider/` | 18 | 9 |

--- a/docs/core-components/api-request-component-regression.md
+++ b/docs/core-components/api-request-component-regression.md
@@ -72,15 +72,18 @@ For each of GET, POST, PUT, PATCH, DELETE:
 - Fills the cURL command and waits for the parser to auto-populate `url_input` with `https://httpbin.org/get`. The `waitForFunction` directly proves the parser ran.
 - Runs the component and asserts the output Data contains `200`, the echoed URL, and the structural keys.
 
-### 14. `body table accepts key + value cell entries via Controls modal`
-- The body field is marked `advanced=True` on `APIRequestComponent`, so it does not render directly in the canvas view (unlike headers). Clicks the canvas node and opens the Controls modal via `edit-button-modal` to expose the advanced fields.
-- Inside the modal, finds `div-table_body`, clicks `Open table`, adds a row, then fills BOTH the `[col-id="key"]` cell with `payload` and the `[col-id="value"]` cell with `e2e-body-value` via the `fillViewTextCell` helper. The helper asserts each cell value renders as a button inside the table dialog after Save.
-- Closes the dialog with `btn-cancel-modal` and asserts canvas integrity.
+### 14. `body table accepts key + value cell entries when method is POST`
+- The body field is marked `advanced=True` AND the InspectionPanel has a hardcoded filter that hides `body` whenever `method.value === "GET"` (see `InspectionPanelFields.tsx` lines 58-60 and 92-94 — the filter is keyed off `data.type === "APIRequest"` + field name `"body"`). The test switches the method dropdown to `POST` first so the body table renders in the inspector. **Note:** there is no "Show Advanced" or `edit-button-modal` step — the inspector exposes the body table directly once method is POST.
+- The method switch triggers a `real_time_refresh` round-trip (`POST /api/v1/custom_component/update`). The test waits for that response BEFORE opening the body table so the `[value]` useEffect in `TableNodeComponent` finishes resetting `tempValue`. Without this wait, a click on `add-row-button` can land during the reset window and the new row is immediately wiped.
+- Finds `div-table_body`, clicks `Open table`, adds a row, then fills BOTH the `[col-id="key"]` cell with `payload` and the `[col-id="value"]` cell with `e2e-body-value` via the `fillViewTextCell` helper. The helper asserts each cell value renders as a button INSIDE that specific cell after Save (cell-scoped — not dialog-wide).
+- Closes the dialog with `btn-cancel-modal` — this test asserts in-session edit behavior only. End-to-end body persistence through reload is intentionally NOT covered (see "What this test does not cover").
 
 ### 15. `flow state persists in database after autosave (URL, method, headers)`
 - Configures URL (`https://httpbin.org/get?persist=true`), method (`POST`) and a headers row (`X-Persist-Header` / `persisted-value`) on a freshly created flow; captures the `flowId` from the URL.
-- Polls `GET /api/v1/flows/{id}` (using `page.request` which inherits the session cookie) until the autosave has written the URL, method and matching header row into the saved flow JSON. Polling the API directly proves the autosave reached the database — not just in-memory React state.
-- Reloads the page and asserts the inspector rehydrates with the same URL, method dropdown value, and that reopening the headers table shows the saved row as a button.
+- Like test 14, waits for the `POST /api/v1/custom_component/update` response after the method switch so the headers `[value]` useEffect settles before adding a new row.
+- Clicks the dialog-level **Save** button (not Cancel, which discards `tempValue` via `handleCancel` in `TableNodeComponent`) so the row commits before autosave fires.
+- Polls `GET /api/v1/flows/{id}` (using `page.request` which inherits the session cookie) until the autosave has written the URL, method and matching header row into the saved flow JSON. Polling the API directly proves the autosave reached the database — not just in-memory React state. The match key is `node.data.type === "APIRequest"` (Python class name, not the `"API Request"` display name).
+- Reloads the page and re-asserts: URL field still holds the saved URL, method dropdown still reads `POST`, and reopening the headers table (after clicking the canvas node and toggling `canvas_controls_toggle_inspector` if needed) still shows the saved key/value buttons. The reload check covers UI rehydration end-to-end.
 
 ---
 
@@ -93,8 +96,11 @@ The suite must:
 - For each verb test, hit a `httpbin.org` endpoint that returns 405 for any other verb — this guarantees the test fails if the wrong verb is sent (e.g. POST sent as GET).
 - For the cURL execution test, switch to the cURL tab *before* configuring the URL — and assert the parser auto-populates `url_input`. Asserting only the run output would let the test pass even if cURL parsing was broken.
 - For the headers and body table tests, fill both KEY and VALUE cells (not key only) — filling only the key cell would still pass even if the value column was non-functional or rejected entries.
-- For the body table test, open the Controls modal (`edit-button-modal`) before searching for `div-table_body` — the body field is `advanced=True` and does not render in the canvas view (unlike headers).
-- For the persistence test, poll `GET /api/v1/flows/{id}` directly through `page.request` and *also* reload the page to verify the UI rehydrates. Verifying only the in-memory state would let the test pass even if autosave was broken.
+- For the body table test, switch method to POST before searching for `div-table_body` — the `InspectionPanelFields` filter hides `body` while method is GET. (There is no Controls-modal / `edit-button-modal` step — the field renders directly in the inspector once method is POST.)
+- For tests 14 and 15, wait for the `POST /api/v1/custom_component/update` response after the method switch so the `[value]` useEffect in `TableNodeComponent` settles before adding a row. Without the wait, `add-row-button` can race the refresh that re-pushes the table's `value` (the freshly-added row is wiped by the useEffect reset).
+- `fillViewTextCell`'s post-Save assertion is **cell-scoped** (`cellLocator.getByRole("button", { name: value })`) — a dialog-wide match would pass even if the value landed on the wrong row.
+- For the persistence test, poll `GET /api/v1/flows/{id}` directly through `page.request` and *also* reload the page to verify the UI rehydrates URL, method AND the saved header row via the reopened table. Verifying only the in-memory state would let the test pass even if autosave was broken.
+- For the persistence test, click the dialog-level Save button after editing the headers table — the existing `btn-cancel-modal` pattern (used in test 11) intentionally exercises in-session state only and discards `tempValue` on close.
 - For the invalid URL test, call `allowFlowErrors()` so the fixture's `🚨 Backend Error` monitor does not flag the expected `400`/`422`.
 
 ---
@@ -106,6 +112,8 @@ The suite must:
 - `tests/fixtures/fixtures.ts` — provides `(page as any).allowFlowErrors()` (the cast is required because the helper is injected via the fixture without a typed augmentation; see "Notes")
 - `src/lfx/src/lfx/components/data_source/api_request.py` — owns the field schema (URL, method, headers/body table inputs, cURL textarea); the test would need updating if a field is renamed, removed, or its `advanced` flag changes
 - `src/frontend/src/CustomNodes/GenericNode/index.tsx` — owns the inspector layout that exposes `popover-anchor-input-url_input`, `dropdown_str_method`, `div-table_headers`, `tab_0_url`, `tab_1_curl`, etc.
+- `src/frontend/src/pages/FlowPage/components/InspectionPanel/components/InspectionPanelFields.tsx` — owns the `APIRequest` + `body` + GET filter that test 14 navigates around by switching method to POST
+- `src/frontend/src/components/core/parameterRenderComponent/components/TableNodeComponent/index.tsx` — owns the `[value]` useEffect that drives the `real_time_refresh` race in the body table (test 14's force+retry)
 - `httpbin.org` — external test target; if it is unreachable from CI, the 5 verb tests, the 404 test, and the query-parameter test all fail by external reason rather than by Langflow regression (see "Notes")
 
 ---
@@ -134,7 +142,8 @@ The suite must:
 - The inspector layout changes such that `popover-anchor-input-url_input`, `dropdown_str_method`, or `tab_0_url`/`tab_1_curl` testids are renamed or restructured
 - The cURL parser changes its auto-fill behavior (e.g., it stops auto-populating `url_input` from the cURL command, or moves to a different field)
 - `httpbin.org` becomes unavailable — switch the verb tests to a stable equivalent (e.g., a self-hosted echo server or `postman-echo.com`)
-- The body field's `advanced=True` flag is removed — at that point the body table test can drop the `edit-button-modal` step and mirror the headers test directly
+- `InspectionPanelFields.tsx` drops the `APIRequest` + `body` + GET filter (or makes it conditional on a different field) — at that point test 14 can drop the method-switch step and mirror the headers test directly
+- The `POST /api/v1/custom_component/update` endpoint is renamed or restructured — tests 14 and 15 both use `page.waitForResponse(...)` keyed on that URL substring
 - The autosave debounce interval is increased substantially — bump the persistence test's polling timeout (currently 20s) to match
 - The fixture is refactored to type `allowFlowErrors` properly — the `(page as any)` cast can be dropped
 

--- a/docs/core-components/api-request-component-regression.md
+++ b/docs/core-components/api-request-component-regression.md
@@ -6,20 +6,21 @@
 
 ## What this test validates *(required)*
 
-Validates the **API Request** component end-to-end via 13 scenarios grouped into four categories:
+Validates the **API Request** component end-to-end via 15 scenarios grouped into five categories:
 
 1. **Canvas rendering and inspector fields** — the node renders with the correct URL/API Response handles, and the inspector accepts URL + HTTP method input.
 2. **Execution per HTTP verb** — GET, POST, PUT, PATCH, DELETE each round-trip to a `httpbin.org` endpoint that **only** accepts that verb (any other verb returns 405). The output Data is asserted to contain `200`, the echoed URL, and the expected structural keys (`source`, `status_code`, `response_headers`, `result`).
 3. **Error and edge paths** — invalid URL shows the build-error notification, non-2xx responses (404) propagate as `status_code` without raising, query parameters embedded in the URL are sent and echoed back.
-4. **Inspector tables and cURL mode** — the headers key-value table accepts both key and value cell entries via the View Text editor; the cURL tab switches mode and the cURL parser auto-populates the URL field with the URL extracted from the cURL command, after which the run executes the GET successfully.
+4. **Inspector tables and cURL mode** — the headers key-value table accepts both key and value cell entries via the View Text editor; the body key-value table is accessed through the Controls modal (the body field is `advanced=True`) and accepts both key and value cell entries via the same editor; the cURL tab switches mode and the cURL parser auto-populates the URL field with the URL extracted from the cURL command, after which the run executes the GET successfully.
+5. **Persistence to flow JSON** — configuring URL, method and a headers row triggers an autosave that persists into the flow's saved state (verified by polling `GET /api/v1/flows/{id}`), and a full page reload rehydrates the inspector with the same values.
 
-If any of these tests fails, the API Request component is broken in the product — either in canvas rendering, inspector input, execution per verb, error propagation, table-input editing, or the cURL parser.
+If any of these tests fails, the API Request component is broken in the product — either in canvas rendering, inspector input, execution per verb, error propagation, table-input editing, cURL parsing, or autosave persistence.
 
 ---
 
 ## Tags *(required)*
 
-All 13 tests: `@stable` `@regression` `@components`
+All 15 tests: `@stable` `@regression` `@components`
 8 of them additionally carry `@release` (the canvas/inspector/GET/POST/PUT/PATCH/DELETE happy paths).
 
 ---
@@ -71,6 +72,16 @@ For each of GET, POST, PUT, PATCH, DELETE:
 - Fills the cURL command and waits for the parser to auto-populate `url_input` with `https://httpbin.org/get`. The `waitForFunction` directly proves the parser ran.
 - Runs the component and asserts the output Data contains `200`, the echoed URL, and the structural keys.
 
+### 14. `body table accepts key + value cell entries via Controls modal`
+- The body field is marked `advanced=True` on `APIRequestComponent`, so it does not render directly in the canvas view (unlike headers). Clicks the canvas node and opens the Controls modal via `edit-button-modal` to expose the advanced fields.
+- Inside the modal, finds `div-table_body`, clicks `Open table`, adds a row, then fills BOTH the `[col-id="key"]` cell with `payload` and the `[col-id="value"]` cell with `e2e-body-value` via the `fillViewTextCell` helper. The helper asserts each cell value renders as a button inside the table dialog after Save.
+- Closes the dialog with `btn-cancel-modal` and asserts canvas integrity.
+
+### 15. `flow state persists in database after autosave (URL, method, headers)`
+- Configures URL (`https://httpbin.org/get?persist=true`), method (`POST`) and a headers row (`X-Persist-Header` / `persisted-value`) on a freshly created flow; captures the `flowId` from the URL.
+- Polls `GET /api/v1/flows/{id}` (using `page.request` which inherits the session cookie) until the autosave has written the URL, method and matching header row into the saved flow JSON. Polling the API directly proves the autosave reached the database — not just in-memory React state.
+- Reloads the page and asserts the inspector rehydrates with the same URL, method dropdown value, and that reopening the headers table shows the saved row as a button.
+
 ---
 
 ## Validation criterion *(required)*
@@ -81,7 +92,9 @@ The suite must:
 - Run **serially** (`test.describe.configure({ mode: "serial" })`) — parallel autosaves on flow create cause `400 "flow must be unique"` errors that flag as backend errors in the fixture.
 - For each verb test, hit a `httpbin.org` endpoint that returns 405 for any other verb — this guarantees the test fails if the wrong verb is sent (e.g. POST sent as GET).
 - For the cURL execution test, switch to the cURL tab *before* configuring the URL — and assert the parser auto-populates `url_input`. Asserting only the run output would let the test pass even if cURL parsing was broken.
-- For the headers table test, fill both KEY and VALUE cells (not key only) — the previous version of this spec only filled the key cell, which would still pass even if the value column was non-functional or rejected entries.
+- For the headers and body table tests, fill both KEY and VALUE cells (not key only) — filling only the key cell would still pass even if the value column was non-functional or rejected entries.
+- For the body table test, open the Controls modal (`edit-button-modal`) before searching for `div-table_body` — the body field is `advanced=True` and does not render in the canvas view (unlike headers).
+- For the persistence test, poll `GET /api/v1/flows/{id}` directly through `page.request` and *also* reload the page to verify the UI rehydrates. Verifying only the in-memory state would let the test pass even if autosave was broken.
 - For the invalid URL test, call `allowFlowErrors()` so the fixture's `🚨 Backend Error` monitor does not flag the expected `400`/`422`.
 
 ---
@@ -99,11 +112,10 @@ The suite must:
 
 ## What this test does not cover *(optional)*
 
-- **Body table** — the body field is rendered with `advanced=True`, so it lives behind a "Show advanced" path on the inspector. This spec only covers the headers table; the body table widget is functionally identical (same `TableInput` type), so the headers coverage is intentionally treated as representative.
-- **Persistence to flow JSON** — the headers table test does not assert that closing the table dialog with the modal-level Save button persists rows into the flow's saved state. The current test asserts in-session edit behavior only (the `fillViewTextCell` helper verifies the cell renders correctly *inside* the open dialog).
 - **`include_httpx_metadata=true`** — this advanced toggle adds outgoing request headers to output. Covered by `tests/tests-automations/regression/api/flows/api-component-regression.spec.ts` (legacy spec scheduled for retirement; see "Notes").
 - **Timeout error path** — covered by the same legacy spec.
 - **cURL with POST + JSON body and parser-driven body fill** — covered by the legacy spec; not yet migrated to this consolidated suite.
+- **Body persistence through reload** — the persistence test exercises URL, method and headers but not the body table. The body and headers tables share the same `TableInput` widget and persistence path, so headers coverage is treated as representative for table autosave.
 - **Anonymous / multi-tenant access** — runs as `LANGFLOW_SUPERUSER`.
 
 ---
@@ -122,7 +134,8 @@ The suite must:
 - The inspector layout changes such that `popover-anchor-input-url_input`, `dropdown_str_method`, or `tab_0_url`/`tab_1_curl` testids are renamed or restructured
 - The cURL parser changes its auto-fill behavior (e.g., it stops auto-populating `url_input` from the cURL command, or moves to a different field)
 - `httpbin.org` becomes unavailable — switch the verb tests to a stable equivalent (e.g., a self-hosted echo server or `postman-echo.com`)
-- The body field's `advanced=True` flag is removed — at that point the body table test should be added back, mirroring the headers test pattern
+- The body field's `advanced=True` flag is removed — at that point the body table test can drop the `edit-button-modal` step and mirror the headers test directly
+- The autosave debounce interval is increased substantially — bump the persistence test's polling timeout (currently 20s) to match
 - The fixture is refactored to type `allowFlowErrors` properly — the `(page as any)` cast can be dropped
 
 ---

--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -65,8 +65,6 @@ async function fillViewTextCell(
   page: Page,
   cellLocator: Locator,
   value: string,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _tableDialog: Locator,
 ): Promise<void> {
   await expect(async () => {
     if (!(await page.getByTestId("textarea").isVisible())) {
@@ -432,13 +430,11 @@ test(
       page,
       lastRow.locator('[col-id="key"]'),
       "X-E2E-Header",
-      headersDialog,
     );
     await fillViewTextCell(
       page,
       lastRow.locator('[col-id="value"]'),
       "test-header-value",
-      headersDialog,
     );
 
     await headersDialog.getByTestId("btn-cancel-modal").click();
@@ -583,13 +579,11 @@ test(
       page,
       lastRow.locator('[col-id="key"]'),
       "payload",
-      bodyDialog,
     );
     await fillViewTextCell(
       page,
       lastRow.locator('[col-id="value"]'),
       "e2e-body-value",
-      bodyDialog,
     );
 
     await bodyDialog.getByTestId("btn-cancel-modal").click();
@@ -612,8 +606,15 @@ test(
 
     await test.step("Configure URL, method and a header on a new flow", async () => {
       await addApiRequestComponent(page);
-      flowId = page.url().split("/").slice(-1)[0];
-      expect(flowId).toMatch(/^[0-9a-f-]{36}$/);
+      // Match against the pathname rather than `split("/").slice(-1)` so a
+      // trailing slash / query string / hash on the route doesn't silently
+      // turn `flowId` into a non-UUID and make the persistence test fail for
+      // a routing change unrelated to the behavior under test.
+      const flowIdMatch = new URL(page.url()).pathname.match(
+        /\/flow\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/,
+      );
+      expect(flowIdMatch).not.toBeNull();
+      flowId = flowIdMatch![1];
 
       const urlInput = page.getByTestId("popover-anchor-input-url_input");
       await expect(urlInput).toBeVisible({ timeout: 10000 });
@@ -662,13 +663,11 @@ test(
         page,
         lastRow.locator('[col-id="key"]'),
         headerKey,
-        headersDialog,
       );
       await fillViewTextCell(
         page,
         lastRow.locator('[col-id="value"]'),
         headerValue,
-        headersDialog,
       );
       // Click the dialog-level Save button — Cancel discards `tempValue`
       // (see `handleCancel` in TableNodeComponent). The persistence test must

--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -2,6 +2,7 @@ import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { enableInspectPanel } from "../../../helpers/ui/open-advanced-options";
 
 // Run tests serially to avoid "flow must be unique" 400 errors from parallel autosaves
 test.describe.configure({ mode: "serial" });
@@ -55,13 +56,17 @@ async function runAndOpenOutput(page: Page): Promise<string> {
 
 // Helper: click an AG Grid cell, fill the resulting textarea editor, and save.
 // Uses toPass() for full retry on AG Grid re-render instability.
-// After save, verifies the value appears as a button in the table dialog
-// to guard against false-positive saves where the editor closed for another reason.
+// After save, verifies the value appears as a button INSIDE the same cell
+// (scoped to `cellLocator`, not the whole dialog) to guard against:
+//   - false-positive saves where the editor closed for another reason
+//   - the value landing in a different row/column but matching the dialog-wide
+//     button-by-name lookup
 async function fillViewTextCell(
   page: Page,
   cellLocator: Locator,
   value: string,
-  tableDialog: Locator,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _tableDialog: Locator,
 ): Promise<void> {
   await expect(async () => {
     if (!(await page.getByTestId("textarea").isVisible())) {
@@ -103,9 +108,11 @@ async function fillViewTextCell(
     if (!saveCoords) throw new Error("Save button not found in View Text dialog");
     await page.mouse.click(saveCoords.x, saveCoords.y);
     await expect(page.getByTestId("textarea")).toHaveCount(0, { timeout: 3000 });
-    await expect(tableDialog.getByRole("button", { name: value })).toBeVisible({
-      timeout: 5000,
-    });
+    // Cell-scoped — the rendered button must live inside this specific cell,
+    // not somewhere else in the dialog.
+    await expect(
+      cellLocator.getByRole("button", { name: value, exact: true }),
+    ).toBeVisible({ timeout: 5000 });
   }).toPass({ timeout: 40000 });
 }
 
@@ -531,11 +538,20 @@ test(
     // hardcoded filter that hides `body` when `method === "GET"` (see
     // InspectionPanelFields.tsx: it returns false for type === "APIRequest" +
     // field === "body" + method.value === "GET"). Switch to POST so the body
-    // table is rendered in the inspector.
+    // table is rendered in the inspector. Wait for the `real_time_refresh`
+    // response so the `[value]` useEffect in TableNodeComponent settles before
+    // the next interaction (see persistence test for full context).
     const methodDropdown = page.getByTestId("dropdown_str_method");
     await expect(methodDropdown).toBeVisible({ timeout: 10000 });
     await methodDropdown.click();
+    const refreshResponse = page.waitForResponse(
+      (r) =>
+        r.url().includes("/api/v1/custom_component/update") &&
+        r.request().method() === "POST",
+      { timeout: 15000 },
+    );
     await page.getByText("POST", { exact: true }).click();
+    await refreshResponse;
     await expect(
       page.getByTestId("value-dropdown-dropdown_str_method"),
     ).toHaveText("POST");
@@ -550,19 +566,14 @@ test(
     const addRowButton = bodyDialog.getByTestId("add-row-button");
     await expect(addRowButton).toBeVisible({ timeout: 5000 });
 
-    // Body is initialized as an empty list. AG Grid's `addRow` handler wires up
-    // after a 10ms `setTimeout` (TableOptions.tsx) AND switching method to POST
-    // triggers a `real_time_refresh` that re-pushes `value=[]` from the backend —
-    // a click landing in the middle of either of those gets dropped (no new row,
-    // useEffect resets `tempValue`). Force the click (the button is enabled but
-    // can momentarily lose pointer-event handling) and retry until a data row is
-    // actually rendered. Without both the test is flaky.
-    const dataRows = bodyDialog.locator('[role="treegrid"] [role="row"][row-id]');
-    await expect(async () => {
-      // eslint-disable-next-line playwright/no-force-option
-      await addRowButton.click({ force: true });
-      await expect(dataRows).toHaveCount(1, { timeout: 3000 });
-    }).toPass({ timeout: 30000 });
+    // The refresh has already completed in the step above (we waited for the
+    // response), so the `[value]` useEffect in TableNodeComponent has settled.
+    // A plain click adds the row reliably; no force or retry needed.
+    const dataRows = bodyDialog.locator(
+      '[role="treegrid"] [role="row"][row-id]',
+    );
+    await addRowButton.click();
+    await expect(dataRows).toHaveCount(1, { timeout: 5000 });
     const lastRow = dataRows.last();
 
     // Same `fillViewTextCell` pattern as the headers test — each cell is asserted
@@ -608,9 +619,21 @@ test(
       await expect(urlInput).toBeVisible({ timeout: 10000 });
       await urlInput.fill(expectedUrl);
 
+      // Switching the method dropdown triggers a `real_time_refresh` →
+      // POST /api/v1/custom_component/update — the backend re-renders the
+      // template and the new response resets the `[value]` useEffect in
+      // TableNodeComponent. Wait for that response BEFORE opening the headers
+      // table; otherwise the row-add can race against the reset.
       const methodDropdown = page.getByTestId("dropdown_str_method");
       await methodDropdown.click();
+      const refreshResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/v1/custom_component/update") &&
+          r.request().method() === "POST",
+        { timeout: 15000 },
+      );
       await page.getByText("POST", { exact: true }).click();
+      await refreshResponse;
       await expect(
         page.getByTestId("value-dropdown-dropdown_str_method"),
       ).toHaveText("POST");
@@ -622,23 +645,17 @@ test(
       const headersDialog = page.locator('[role="dialog"]').last();
       await expect(headersDialog).toBeVisible({ timeout: 10000 });
 
-      // Headers starts with 1 default row (User-Agent). Click add-row-button
-      // and retry until a second data row appears — AG Grid's `addRow` handler
-      // is wired up via a 10ms setTimeout, so the first click can race.
+      // The refresh has already completed in the step above (we waited for the
+      // response), so the `[value]` useEffect in TableNodeComponent has settled
+      // for `headers.value` too. A plain click reliably adds a second data row.
       const headersAddBtn = headersDialog.getByTestId("add-row-button");
       await expect(headersAddBtn).toBeVisible({ timeout: 5000 });
       const headersDataRows = headersDialog.locator(
         '[role="treegrid"] [role="row"][row-id]',
       );
       await expect(headersDataRows).toHaveCount(1, { timeout: 5000 });
-      // AG Grid's addRow handler wires after a 10ms setTimeout — the first click
-      // can race. Force the click and retry until a second data row is actually
-      // rendered. See the body table test for the same pattern.
-      await expect(async () => {
-        // eslint-disable-next-line playwright/no-force-option
-        await headersAddBtn.click({ force: true });
-        await expect(headersDataRows).toHaveCount(2, { timeout: 3000 });
-      }).toPass({ timeout: 30000 });
+      await headersAddBtn.click();
+      await expect(headersDataRows).toHaveCount(2, { timeout: 5000 });
 
       const lastRow = headersDataRows.last();
       await fillViewTextCell(
@@ -673,8 +690,16 @@ test(
               const res = await page.request.get(`/api/v1/flows/${flowId}`);
               if (!res.ok()) return null;
               const flow = await res.json();
-              // The frontend writes `node.data.type` as the component's class
-              // name (`APIRequest`) — not the human-readable display name.
+              // `node.data.type` is written as the component's Python class
+              // name (`APIRequest`) here — NOT the display name. This differs
+              // from `prompt-template-component-regression.spec.ts` which
+              // matches by the display name `"Prompt Template"`; that test is
+              // also correct because PromptComponent has `name = "Prompt
+              // Template"` (a space-separated identifier) so its class-name
+              // and display-name happen to coincide. For API Request, the
+              // class is `APIRequestComponent` registered as `APIRequest` in
+              // the type registry, while `display_name = "API Request"`. Use
+              // class name here.
               const apiNode = (flow?.data?.nodes ?? []).find(
                 (n: { data?: { type?: string } }) =>
                   n?.data?.type === "APIRequest",
@@ -706,12 +731,12 @@ test(
     );
 
     await test.step(
-      "Reload page — UI rehydrates URL and method from the saved flow",
+      "Reload page — UI rehydrates URL, method, and the saved header row",
       async () => {
-        // Headers row persistence is already proved by the API poll above.
-        // This step is a UI sanity check that the saved flow round-trips on
-        // reload — URL and method are visible on the compact node view, so
-        // there is no need to depend on the InspectionPanel being open.
+        // The API poll above already proves the autosave reached the database.
+        // This step is the UI counterpart: a full reload must rehydrate the
+        // node's compact view (URL, method) AND reopening the headers table
+        // must show the saved key/value buttons.
         await page.reload();
         await expect(
           page.getByTestId("canvas_controls_dropdown"),
@@ -725,6 +750,29 @@ test(
         await expect(
           page.getByTestId("value-dropdown-dropdown_str_method"),
         ).toHaveText("POST");
+
+        // After reload, the InspectionPanel may not be auto-open and the node
+        // is not selected. Select the node, then use the existing helper to
+        // open the panel idempotently (the helper no-ops if already open),
+        // so `div-table_headers` renders.
+        await page.locator(".react-flow__node").first().click();
+        await enableInspectPanel(page);
+
+        // Reopen the headers table — same locator pattern as test 11. Asserting
+        // the saved key + value render as buttons inside the dialog confirms
+        // the row survived the reload via the UI, not just the API.
+        const headersDiv = page.getByTestId("div-table_headers");
+        await expect(headersDiv).toBeVisible({ timeout: 10000 });
+        await headersDiv.getByRole("button", { name: "Open table" }).click();
+        const headersDialog = page.locator('[role="dialog"]').last();
+        await expect(headersDialog).toBeVisible({ timeout: 10000 });
+        await expect(
+          headersDialog.getByRole("button", { name: headerKey, exact: true }),
+        ).toBeVisible({ timeout: 5000 });
+        await expect(
+          headersDialog.getByRole("button", { name: headerValue, exact: true }),
+        ).toBeVisible({ timeout: 5000 });
+        await headersDialog.getByTestId("btn-cancel-modal").click();
       },
     );
   },

--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -520,3 +520,212 @@ test(
     await page.keyboard.press("Escape");
   },
 );
+
+test(
+  "API Request component — body table accepts key + value cell entries when method is POST",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    await addApiRequestComponent(page);
+
+    // The body field is declared `advanced=True` AND the InspectionPanel has a
+    // hardcoded filter that hides `body` when `method === "GET"` (see
+    // InspectionPanelFields.tsx: it returns false for type === "APIRequest" +
+    // field === "body" + method.value === "GET"). Switch to POST so the body
+    // table is rendered in the inspector.
+    const methodDropdown = page.getByTestId("dropdown_str_method");
+    await expect(methodDropdown).toBeVisible({ timeout: 10000 });
+    await methodDropdown.click();
+    await page.getByText("POST", { exact: true }).click();
+    await expect(
+      page.getByTestId("value-dropdown-dropdown_str_method"),
+    ).toHaveText("POST");
+
+    const bodyDiv = page.getByTestId("div-table_body");
+    await expect(bodyDiv).toBeVisible({ timeout: 10000 });
+    await bodyDiv.getByRole("button", { name: "Open table" }).click();
+
+    const bodyDialog = page.locator('[role="dialog"]').last();
+    await expect(bodyDialog).toBeVisible({ timeout: 10000 });
+
+    const addRowButton = bodyDialog.getByTestId("add-row-button");
+    await expect(addRowButton).toBeVisible({ timeout: 5000 });
+
+    // Body is initialized as an empty list. AG Grid's `addRow` handler wires up
+    // after a 10ms `setTimeout` (TableOptions.tsx) AND switching method to POST
+    // triggers a `real_time_refresh` that re-pushes `value=[]` from the backend —
+    // a click landing in the middle of either of those gets dropped (no new row,
+    // useEffect resets `tempValue`). Force the click (the button is enabled but
+    // can momentarily lose pointer-event handling) and retry until a data row is
+    // actually rendered. Without both the test is flaky.
+    const dataRows = bodyDialog.locator('[role="treegrid"] [role="row"][row-id]');
+    await expect(async () => {
+      // eslint-disable-next-line playwright/no-force-option
+      await addRowButton.click({ force: true });
+      await expect(dataRows).toHaveCount(1, { timeout: 3000 });
+    }).toPass({ timeout: 30000 });
+    const lastRow = dataRows.last();
+
+    // Same `fillViewTextCell` pattern as the headers test — each cell is asserted
+    // to render as a button inside the table dialog after Save, guaranteeing both
+    // key and value were persisted (not just one).
+    await fillViewTextCell(
+      page,
+      lastRow.locator('[col-id="key"]'),
+      "payload",
+      bodyDialog,
+    );
+    await fillViewTextCell(
+      page,
+      lastRow.locator('[col-id="value"]'),
+      "e2e-body-value",
+      bodyDialog,
+    );
+
+    await bodyDialog.getByTestId("btn-cancel-modal").click();
+    await expect(bodyDialog).not.toBeVisible({ timeout: 5000 });
+
+    // Canvas integrity after the table interaction
+    await expect(page.getByTestId("title-API Request")).toBeVisible();
+    await expect(page.locator(".react-flow__node")).toHaveCount(1);
+  },
+);
+
+test(
+  "API Request component — flow state persists in database after autosave (URL, method, headers)",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    const expectedUrl = "https://httpbin.org/get?persist=true";
+    const headerKey = "X-Persist-Header";
+    const headerValue = "persisted-value";
+    let flowId = "";
+
+    await test.step("Configure URL, method and a header on a new flow", async () => {
+      await addApiRequestComponent(page);
+      flowId = page.url().split("/").slice(-1)[0];
+      expect(flowId).toMatch(/^[0-9a-f-]{36}$/);
+
+      const urlInput = page.getByTestId("popover-anchor-input-url_input");
+      await expect(urlInput).toBeVisible({ timeout: 10000 });
+      await urlInput.fill(expectedUrl);
+
+      const methodDropdown = page.getByTestId("dropdown_str_method");
+      await methodDropdown.click();
+      await page.getByText("POST", { exact: true }).click();
+      await expect(
+        page.getByTestId("value-dropdown-dropdown_str_method"),
+      ).toHaveText("POST");
+
+      const headersDiv = page.getByTestId("div-table_headers");
+      await expect(headersDiv).toBeVisible({ timeout: 10000 });
+      await headersDiv.getByRole("button", { name: "Open table" }).click();
+
+      const headersDialog = page.locator('[role="dialog"]').last();
+      await expect(headersDialog).toBeVisible({ timeout: 10000 });
+
+      // Headers starts with 1 default row (User-Agent). Click add-row-button
+      // and retry until a second data row appears — AG Grid's `addRow` handler
+      // is wired up via a 10ms setTimeout, so the first click can race.
+      const headersAddBtn = headersDialog.getByTestId("add-row-button");
+      await expect(headersAddBtn).toBeVisible({ timeout: 5000 });
+      const headersDataRows = headersDialog.locator(
+        '[role="treegrid"] [role="row"][row-id]',
+      );
+      await expect(headersDataRows).toHaveCount(1, { timeout: 5000 });
+      // AG Grid's addRow handler wires after a 10ms setTimeout — the first click
+      // can race. Force the click and retry until a second data row is actually
+      // rendered. See the body table test for the same pattern.
+      await expect(async () => {
+        // eslint-disable-next-line playwright/no-force-option
+        await headersAddBtn.click({ force: true });
+        await expect(headersDataRows).toHaveCount(2, { timeout: 3000 });
+      }).toPass({ timeout: 30000 });
+
+      const lastRow = headersDataRows.last();
+      await fillViewTextCell(
+        page,
+        lastRow.locator('[col-id="key"]'),
+        headerKey,
+        headersDialog,
+      );
+      await fillViewTextCell(
+        page,
+        lastRow.locator('[col-id="value"]'),
+        headerValue,
+        headersDialog,
+      );
+      // Click the dialog-level Save button — Cancel discards `tempValue`
+      // (see `handleCancel` in TableNodeComponent). The persistence test must
+      // commit the row so autosave can write it to the database.
+      await headersDialog.getByRole("button", { name: "Save", exact: true }).click();
+      await expect(headersDialog).not.toBeVisible({ timeout: 5000 });
+    });
+
+    await test.step(
+      "Backend persistence — poll GET /api/v1/flows/{id} until autosave wrote URL/method/header",
+      async () => {
+        // `page.request` inherits session cookies — `GET /api/v1/flows/{id}` requires
+        // session auth in Langflow's auto-login mode. Polling the API directly (rather
+        // than reloading the page first) confirms the autosave reached the database,
+        // not just the in-memory React state.
+        await expect
+          .poll(
+            async () => {
+              const res = await page.request.get(`/api/v1/flows/${flowId}`);
+              if (!res.ok()) return null;
+              const flow = await res.json();
+              // The frontend writes `node.data.type` as the component's class
+              // name (`APIRequest`) — not the human-readable display name.
+              const apiNode = (flow?.data?.nodes ?? []).find(
+                (n: { data?: { type?: string } }) =>
+                  n?.data?.type === "APIRequest",
+              );
+              const template = apiNode?.data?.node?.template;
+              if (!template) return null;
+              const urlValue = template.url_input?.value ?? "";
+              const methodValue = template.method?.value ?? "";
+              const headersValue = Array.isArray(template.headers?.value)
+                ? template.headers.value
+                : [];
+              const matchedHeader = headersValue.find(
+                (h: { key?: string; value?: string }) =>
+                  h.key === headerKey && h.value === headerValue,
+              );
+              if (
+                urlValue === expectedUrl &&
+                methodValue === "POST" &&
+                matchedHeader
+              ) {
+                return "persisted";
+              }
+              return null;
+            },
+            { timeout: 20000, intervals: [500, 1000, 2000] },
+          )
+          .toBe("persisted");
+      },
+    );
+
+    await test.step(
+      "Reload page — UI rehydrates URL and method from the saved flow",
+      async () => {
+        // Headers row persistence is already proved by the API poll above.
+        // This step is a UI sanity check that the saved flow round-trips on
+        // reload — URL and method are visible on the compact node view, so
+        // there is no need to depend on the InspectionPanel being open.
+        await page.reload();
+        await expect(
+          page.getByTestId("canvas_controls_dropdown"),
+        ).toBeVisible({ timeout: 60000 });
+        await expect(page.getByTestId("title-API Request")).toBeVisible({
+          timeout: 30000,
+        });
+
+        const urlInput = page.getByTestId("popover-anchor-input-url_input");
+        await expect(urlInput).toHaveValue(expectedUrl, { timeout: 10000 });
+        await expect(
+          page.getByTestId("value-dropdown-dropdown_str_method"),
+        ).toHaveText("POST");
+      },
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Closes #188

Adds the two scenarios tracked as gaps in `QA-CHECKLIST.md` section 3.3 — **API Request (HTTP)**:

- **Body table key + value entries** — switches method to POST first because the InspectionPanel hides `body` when method is GET (hardcoded filter in `InspectionPanelFields.tsx`), then uses the same `fillViewTextCell` pattern as the headers test
- **Flow state persisted in DB after autosave** — configures URL, method, and a headers row; polls `GET /api/v1/flows/{id}` until the saved flow JSON contains the values; reloads the page to verify the UI rehydrates URL + method

Spec doc and `QA-CHECKLIST.md` are updated to reflect the new coverage (15 scenarios total, all 5 categories now covered).

Both tests are tagged `@stable @regression @components`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new errors on the modified file (pre-existing `any` warning stays)
- [x] `npx playwright test tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts` — 15/15 pass (with retries; suite has known POST-verb flakiness in the local env)
- [x] Body test passes both standalone and as part of the full spec
- [x] Persistence test verifies via both API poll and post-reload UI assertion