### PR TITLE
feat(ci): add manual migration workflow with multi-user stress

### DIFF
--- a/.github/workflows/migration-manual.yml
+++ b/.github/workflows/migration-manual.yml
@@ -556,6 +556,7 @@ jobs:
                   "${LF_URL}/api/v1/users/whoami"
                 curl -s -o /dev/null -H "Authorization: Bearer ${TOKEN}" \
                   "${LF_URL}/api/v1/flows/?skip=0&limit=50"
+                sleep 0.1
               done
             ) &
           done < /tmp/tokens.txt

--- a/.github/workflows/migration-manual.yml
+++ b/.github/workflows/migration-manual.yml
@@ -165,9 +165,10 @@ jobs:
             fi
           done
 
-      - name: "[SOURCE] Create N users + witness flow"
+      - name: "[SOURCE] Create N users + witness flow + encrypted variable"
         env:
           N: ${{ inputs.concurrent_users }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -e
 
@@ -202,14 +203,55 @@ jobs:
 
           echo "Created and activated $(wc -l < /tmp/users.txt) users"
 
-          WITNESS_ID=$(curl -s -X POST "${LF_URL}/api/v1/flows/" \
-            -H "Authorization: Bearer ${ADMIN_TOKEN}" \
-            -H "Content-Type: application/json" \
-            -d '{"name":"migration-witness-manual","description":"Migration witness flow","data":{"nodes":[],"edges":[]}}' \
-            | jq -r '.id // empty')
-          if [[ -z "$WITNESS_ID" ]]; then
-            echo "::error::Failed to create witness flow"
-            exit 1
+          # ---- Witness flow (real Simple Agent starter if API key available) ----
+          if [[ -n "$OPENAI_API_KEY" ]]; then
+            echo "OPENAI_API_KEY secret available: using Simple Agent starter as witness"
+
+            # Find Simple Agent starter (matches helpers.find_agent_template)
+            STARTERS=$(curl -s -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+              "${LF_URL}/api/v1/starter-projects/")
+            TEMPLATE=$(echo "$STARTERS" | jq -c '
+              [.[] | select((.name // "" | ascii_downcase) | contains("simple agent") or contains("basic agent"))][0]
+            ')
+            if [[ -z "$TEMPLATE" || "$TEMPLATE" == "null" ]]; then
+              echo "::error::Simple Agent starter not found among $(echo "$STARTERS" | jq 'length') starter projects"
+              echo "$STARTERS" | jq -r '.[] | .name // "(unnamed)"' | head -20
+              exit 1
+            fi
+            FLOW_PAYLOAD=$(echo "$TEMPLATE" | jq '{
+              name: ((.name // "Simple Agent") + " — migration witness"),
+              description: "Migration test agent (auto-created)",
+              data: .data,
+              endpoint_name: .endpoint_name
+            }')
+            WITNESS_ID=$(curl -s -X POST "${LF_URL}/api/v1/flows/" \
+              -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d "$FLOW_PAYLOAD" \
+              | jq -r '.id // empty')
+            [[ -z "$WITNESS_ID" ]] && { echo "::error::Failed to create witness flow from starter"; exit 1; }
+
+            # Create encrypted Variable — this is the Fernet-encrypted credential
+            # that will be tested for survival across the migration
+            VAR_ID=$(curl -s -X POST "${LF_URL}/api/v1/variables/" \
+              -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d "{\"name\":\"OPENAI_API_KEY\",\"value\":\"${OPENAI_API_KEY}\",\"type\":\"Credential\",\"default_fields\":[]}" \
+              | jq -r '.id // empty')
+            [[ -z "$VAR_ID" ]] && { echo "::error::Failed to create OPENAI_API_KEY variable"; exit 1; }
+            echo "$VAR_ID" > /tmp/variable-id.txt
+
+            touch /tmp/has-openai-key
+            echo "Witness: Simple Agent flow ${WITNESS_ID} + encrypted variable ${VAR_ID}"
+          else
+            echo "::warning::OPENAI_API_KEY secret not configured. Using empty stub witness; skipping Fernet/flow-execution coverage."
+            WITNESS_ID=$(curl -s -X POST "${LF_URL}/api/v1/flows/" \
+              -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d '{"name":"migration-witness-manual","description":"Empty stub witness","data":{"nodes":[],"edges":[]}}' \
+              | jq -r '.id // empty')
+            [[ -z "$WITNESS_ID" ]] && { echo "::error::Failed to create stub witness flow"; exit 1; }
+            echo "Witness: empty stub ${WITNESS_ID}"
           fi
           echo "$WITNESS_ID" > /tmp/witness-id.txt
           echo "Witness flow id: ${WITNESS_ID}"
@@ -251,7 +293,7 @@ jobs:
             fi
           done
 
-      - name: "[TARGET] Verify witness flow + users preserved"
+      - name: "[TARGET] Verify witness flow + users + variable preserved"
         run: |
           set -e
 
@@ -285,12 +327,62 @@ jobs:
           fi
           echo "All ${EXPECTED} test users preserved"
 
+          # Variable preservation: only relevant if source created an encrypted variable.
+          # Note: this only checks the row exists. Actual Fernet decryption is checked
+          # in the next step by running the flow.
+          if [[ -f /tmp/has-openai-key ]]; then
+            VAR_COUNT=$(curl -s -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+              "${LF_URL}/api/v1/variables/" \
+              | jq '[.[] | select(.name == "OPENAI_API_KEY")] | length')
+            if [[ "$VAR_COUNT" -ne "1" ]]; then
+              echo "::error::OPENAI_API_KEY variable lost after migration (count=${VAR_COUNT})"
+              exit 1
+            fi
+            echo "OPENAI_API_KEY variable row preserved"
+          fi
+
+      - name: "[TARGET] Execute witness flow — Fernet decrypt + smoke test (1/10 OpenAI calls)"
+        if: hashFiles('/tmp/has-openai-key') != ''
+        run: |
+          set -e
+          ADMIN_TOKEN=$(curl -s -X POST "${LF_URL}/api/v1/login" \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            -d "username=${SUPERUSER}&password=${SUPERUSER_PASSWORD}" \
+            | jq -r '.access_token // empty')
+          WITNESS_ID=$(cat /tmp/witness-id.txt)
+
+          HTTP=$(curl -s -o /tmp/run-resp.json -w "%{http_code}" \
+            -X POST "${LF_URL}/api/v1/run/${WITNESS_ID}" \
+            -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+            -H "Content-Type: application/json" \
+            --max-time 120 \
+            -d '{"input_value":"What is 2+2? Answer with just the number.","output_type":"chat","input_type":"chat"}')
+
+          if [[ "$HTTP" != "200" ]]; then
+            echo "::error::Flow execution HTTP ${HTTP} after migration — possible Fernet decrypt or runtime regression"
+            head -c 2000 /tmp/run-resp.json
+            exit 1
+          fi
+
+          # Look for the Fernet/API-key silent-failure signature documented in the
+          # langflow-image-migration skill ("API key required" while UI shows green)
+          if grep -iE 'api[ _-]?key.{0,30}(required|missing|not[ _]?found|invalid)|fernet|invaliddecrypt|cannot[ _]decrypt' /tmp/run-resp.json; then
+            echo "::error::Flow ran but body indicates API key / Fernet decryption issue — silent regression"
+            head -c 2000 /tmp/run-resp.json
+            exit 1
+          fi
+
+          echo "Witness flow executed successfully — Fernet decryption survived migration"
+          echo "1" > /tmp/openai-calls-used
+
       # ── Phase C: stress — N concurrent users hit auth+read paths ──
-      - name: "[TARGET] Multi-user concurrent stress (issue 13157 scenario)"
+      - name: "[TARGET] Multi-user concurrent stress + paced flow runs (issue 13157 scenario)"
         env:
           DURATION: ${{ inputs.stress_duration_seconds }}
         run: |
           set -e
+
+          # ---- N user tokens ----
           : > /tmp/tokens.txt
           while IFS=: read -r USER PASS ID; do
             TOKEN=$(curl -s -X POST "${LF_URL}/api/v1/login" \
@@ -308,6 +400,40 @@ jobs:
           END_TIME=$(( $(date +%s) + DURATION ))
           echo "Stressing ${N} concurrent users for ${DURATION}s (until $(date -u -d @${END_TIME}))"
 
+          # ---- Paced flow-execution loop (only if witness is a real flow) ----
+          # Caps OpenAI cost: 1 call already in the Fernet smoke test + 9 here = 10 per matrix run.
+          if [[ -f /tmp/has-openai-key ]]; then
+            ADMIN_TOKEN=$(curl -s -X POST "${LF_URL}/api/v1/login" \
+              -H "Content-Type: application/x-www-form-urlencoded" \
+              -d "username=${SUPERUSER}&password=${SUPERUSER_PASSWORD}" \
+              | jq -r '.access_token // empty')
+            WITNESS_ID=$(cat /tmp/witness-id.txt)
+            REMAINING_CALLS=9
+            INTERVAL=$(( DURATION / (REMAINING_CALLS + 1) ))
+            [[ "$INTERVAL" -lt 5 ]] && INTERVAL=5
+
+            (
+              CALL_COUNT=0
+              for i in $(seq 1 "$REMAINING_CALLS"); do
+                sleep "$INTERVAL"
+                NOW=$(date +%s)
+                [[ "$NOW" -ge "$END_TIME" ]] && break
+                HTTP=$(curl -s -o /tmp/run-paced-${i}.json -w "%{http_code}" \
+                  -X POST "${LF_URL}/api/v1/run/${WITNESS_ID}" \
+                  -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+                  -H "Content-Type: application/json" \
+                  --max-time 60 \
+                  -d '{"input_value":"Reply with the word OK.","output_type":"chat","input_type":"chat"}' || echo "000")
+                CALL_COUNT=$((CALL_COUNT + 1))
+                echo "  paced call ${i}/${REMAINING_CALLS}: HTTP ${HTTP}"
+              done
+              echo "Paced executions done: ${CALL_COUNT}"
+            ) &
+            PACER_PID=$!
+            echo "Pacer firing ${REMAINING_CALLS} flow runs every ${INTERVAL}s (10 OpenAI calls total counting Fernet smoke test)"
+          fi
+
+          # ---- N user concurrent loops on cheap endpoints ----
           while IFS= read -r TOKEN; do
             (
               while [[ $(date +%s) -lt $END_TIME ]]; do
@@ -373,5 +499,8 @@ jobs:
             /tmp/source-digest.txt
             /tmp/target-digest.txt
             /tmp/witness-id.txt
+            /tmp/variable-id.txt
             /tmp/users.txt
+            /tmp/run-resp.json
+            /tmp/run-paced-*.json
           retention-days: 30

--- a/.github/workflows/migration-manual.yml
+++ b/.github/workflows/migration-manual.yml
@@ -598,6 +598,77 @@ jobs:
 
           echo "Target log clean — no langflow-ai/langflow#13157 patterns detected"
 
+      - name: Generate migration summary
+        if: always()
+        run: |
+          SOURCE_DIGEST=$(cat /tmp/source-digest.txt 2>/dev/null || echo "(direct mode only — not captured here)")
+          TARGET_DIGEST=$(cat /tmp/target-digest.txt 2>/dev/null || echo "(direct mode only — not captured here)")
+          WITNESS_ID=$(cat /tmp/witness-id.txt 2>/dev/null || echo "(unavailable)")
+          USER_COUNT=$(wc -l < /tmp/users.txt 2>/dev/null || echo "0")
+          OUTCOME="${{ job.status }}"
+          DATE=$(date -u +%Y-%m-%d)
+          HAS_OPENAI="no"
+          [[ -f /tmp/has-openai-key ]] && HAS_OPENAI="yes (Fernet + flow exec coverage active)"
+
+          {
+            echo "# Langflow Migration — Run Summary"
+            echo ""
+            echo "**Outcome:** \`${OUTCOME}\`   ·   Run #${{ github.run_number }} (${DATE}, ${{ github.event_name }})"
+            echo ""
+            echo "## Scenario"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Workflow | \`${{ github.workflow }}\` |"
+            echo "| Matrix entry | \`${{ matrix.database }}\` |"
+            echo "| Deploy mode | \`${DEPLOY_MODE}\` |"
+            echo "| Source image | \`${{ inputs.source_image }}\` (\`${SOURCE_DIGEST}\`) |"
+            echo "| Target image | \`${{ inputs.target_image }}\` (\`${TARGET_DIGEST}\`) |"
+            echo "| LANGFLOW_WORKERS | \`${{ inputs.workers }}\` (forced to 1 if SQLite) |"
+            echo "| Concurrent users | \`${{ inputs.concurrent_users }}\` |"
+            echo "| Stress duration | \`${{ inputs.stress_duration_seconds }}\`s |"
+            echo "| OPENAI_API_KEY available | ${HAS_OPENAI} |"
+            echo "| Witness flow id | \`${WITNESS_ID}\` |"
+            echo "| Test users created | \`${USER_COUNT}\` |"
+            echo ""
+            echo "## What this run verified"
+            echo ""
+            echo "- Source image boots cleanly."
+            echo "- \`${USER_COUNT}\` test users created and activated on source."
+            if [[ "$HAS_OPENAI" != "no" ]]; then
+              echo "- Simple Agent starter instantiated as witness flow on source."
+              echo "- OPENAI_API_KEY auto-imported as Credential Variable on source (env-based)."
+            else
+              echo "- Empty stub witness flow created (no OPENAI_API_KEY secret — Fernet/exec coverage skipped)."
+            fi
+            echo "- Target boots on the same database (alembic migration runs)."
+            echo "- Witness flow preserved on target (UUID matches)."
+            echo "- All \`${USER_COUNT}\` test users preserved on target."
+            if [[ "$HAS_OPENAI" != "no" ]]; then
+              echo "- OPENAI_API_KEY Credential row preserved on target."
+              echo "- Witness flow executes successfully on target (Fernet decryption preserved across migration)."
+              echo "- Paced flow execution during stress: up to 10 OpenAI calls total (1 smoke + 9 paced)."
+            fi
+            echo "- Multi-user concurrent stress: \`${USER_COUNT}\` users × \`${{ inputs.stress_duration_seconds }}\`s on whoami + flows endpoints."
+            echo "- Target log scanned for issue #13157 patterns (\`disk I/O error\`, \`database disk image is malformed\`, \`Unexpected error during token authentication\`, etc.)."
+            echo ""
+            echo "## Related artifacts in this run"
+            echo ""
+            echo "- \`logs/source-${{ matrix.database }}.log\` / \`logs/target-${{ matrix.database }}.log\` — Langflow logs per phase"
+            echo "- \`witness-id.txt\` — UUID of the witness flow (same on source and target)"
+            echo "- \`users.txt\` — list of test users created (\`username:password:uuid\`)"
+            echo "- \`run-resp.json\` — pre-migration / post-migration flow-execution response (if OPENAI_API_KEY available)"
+            echo "- \`run-paced-*.json\` — paced executions during stress"
+            if [[ "$DEPLOY_MODE" == "compose" ]]; then
+              echo "- \`logs/official-compose-snapshot.yml\` — exact upstream compose file fetched at runtime"
+              echo "- \`logs/postgres-${{ matrix.database }}.log\` — postgres service log (compose mode)"
+            fi
+          } > /tmp/migration-summary.md
+
+          echo "::group::Generated summary"
+          cat /tmp/migration-summary.md
+          echo "::endgroup::"
+
       - name: Cleanup
         if: always()
         run: |
@@ -617,6 +688,7 @@ jobs:
           name: migration-manual-${{ matrix.database }}-${{ github.run_number }}
           path: |
             /tmp/logs/
+            /tmp/migration-summary.md
             /tmp/source-digest.txt
             /tmp/target-digest.txt
             /tmp/witness-id.txt

--- a/.github/workflows/migration-manual.yml
+++ b/.github/workflows/migration-manual.yml
@@ -17,14 +17,15 @@ on:
         required: true
         default: "langflowai/langflow-nightly:latest"
       database:
-        description: "Database backend(s) to test"
+        description: "Scenario(s) to test. `docker-compose` uses the official compose from langflow-ai/langflow."
         required: true
         type: choice
         options:
           - postgresql
           - sqlite
-          - both
-        default: "both"
+          - docker-compose
+          - all
+        default: "all"
       workers:
         description: "LANGFLOW_WORKERS for PostgreSQL (SQLite forces 1 — see SQLite docs §2.7 fork+connection)"
         required: false
@@ -50,10 +51,11 @@ jobs:
       - id: build
         run: |
           case "${{ inputs.database }}" in
-            postgresql) echo 'databases=["postgresql"]' >> "$GITHUB_OUTPUT" ;;
-            sqlite)     echo 'databases=["sqlite"]' >> "$GITHUB_OUTPUT" ;;
-            both)       echo 'databases=["postgresql","sqlite"]' >> "$GITHUB_OUTPUT" ;;
-            *)          echo "Invalid database: ${{ inputs.database }}" && exit 1 ;;
+            postgresql)     echo 'databases=["postgresql"]' >> "$GITHUB_OUTPUT" ;;
+            sqlite)         echo 'databases=["sqlite"]' >> "$GITHUB_OUTPUT" ;;
+            docker-compose) echo 'databases=["docker-compose"]' >> "$GITHUB_OUTPUT" ;;
+            all)            echo 'databases=["postgresql","sqlite","docker-compose"]' >> "$GITHUB_OUTPUT" ;;
+            *)              echo "Invalid database: ${{ inputs.database }}" && exit 1 ;;
           esac
 
   migration:
@@ -78,10 +80,11 @@ jobs:
         run: |
           mkdir -p /tmp/logs
           SECRET_KEY=$(python3 -c "import base64,os; print(base64.urlsafe_b64encode(os.urandom(32)).decode())")
+          echo "LANGFLOW_SECRET_KEY=${SECRET_KEY}" >> "$GITHUB_ENV"
 
           # SQLite forces single worker (see SQLite docs §2.7 / §8.1).
           # Multi-worker + SQLite is fragile by design (file lock + fork-after-connect),
-          # not a Langflow-specific concern. PostgreSQL uses the input value.
+          # not a Langflow-specific concern. PostgreSQL / docker-compose use the input value.
           if [[ "${{ matrix.database }}" == "sqlite" ]]; then
             EFFECTIVE_WORKERS=1
             echo "Note: SQLite forces LANGFLOW_WORKERS=1 (input value ${{ inputs.workers }} ignored)"
@@ -89,6 +92,18 @@ jobs:
             EFFECTIVE_WORKERS="${{ inputs.workers }}"
           fi
 
+          # DEPLOY_MODE drives the per-step branching for source/target start, stop, cleanup.
+          #   direct  → `docker run` against a separately managed Postgres container or sqlite volume
+          #   compose → `docker compose` against the upstream langflow-ai/langflow docker_example/docker-compose.yml
+          case "${{ matrix.database }}" in
+            docker-compose) DEPLOY_MODE=compose ;;
+            *)              DEPLOY_MODE=direct ;;
+          esac
+          echo "DEPLOY_MODE=${DEPLOY_MODE}" >> "$GITHUB_ENV"
+          echo "Deploy mode: ${DEPLOY_MODE}"
+
+          # /tmp/lf.env is consumed by `docker run --env-file` in direct mode.
+          # In compose mode it is unused — the compose override + .env handle env injection.
           {
             echo "LANGFLOW_HOST=0.0.0.0"
             echo "LANGFLOW_PORT=7860"
@@ -100,21 +115,29 @@ jobs:
             echo "LANGFLOW_WORKERS=${EFFECTIVE_WORKERS}"
           } > /tmp/lf.env
 
-          if [[ "${{ matrix.database }}" == "postgresql" ]]; then
-            echo "LANGFLOW_DATABASE_URL=postgresql://langflow:langflow_test_pw@localhost:5432/langflow" >> /tmp/lf.env
-            echo "MOUNT_FLAGS=" >> "$GITHUB_ENV"
-          else
-            mkdir -p /tmp/lf-sqlite-data
-            chmod 777 /tmp/lf-sqlite-data
-            echo "LANGFLOW_DATABASE_URL=sqlite:////data/langflow.db" >> /tmp/lf.env
-            echo "LANGFLOW_CONFIG_DIR=/data" >> /tmp/lf.env
-            echo "MOUNT_FLAGS=-v /tmp/lf-sqlite-data:/data" >> "$GITHUB_ENV"
-          fi
+          case "${{ matrix.database }}" in
+            postgresql)
+              echo "LANGFLOW_DATABASE_URL=postgresql://langflow:langflow_test_pw@localhost:5432/langflow" >> /tmp/lf.env
+              echo "MOUNT_FLAGS=" >> "$GITHUB_ENV"
+              ;;
+            sqlite)
+              mkdir -p /tmp/lf-sqlite-data && chmod 777 /tmp/lf-sqlite-data
+              echo "LANGFLOW_DATABASE_URL=sqlite:////data/langflow.db" >> /tmp/lf.env
+              echo "LANGFLOW_CONFIG_DIR=/data" >> /tmp/lf.env
+              echo "MOUNT_FLAGS=-v /tmp/lf-sqlite-data:/data" >> "$GITHUB_ENV"
+              ;;
+            docker-compose)
+              # No mount needed; compose manages its own named volumes.
+              echo "MOUNT_FLAGS=" >> "$GITHUB_ENV"
+              echo "COMPOSE_DIR=/tmp/migration-compose" >> "$GITHUB_ENV"
+              echo "EFFECTIVE_WORKERS=${EFFECTIVE_WORKERS}" >> "$GITHUB_ENV"
+              ;;
+          esac
 
           echo "Effective env file:"
           cat /tmp/lf.env
 
-      - name: Start PostgreSQL (if needed)
+      - name: Start PostgreSQL (direct mode only)
         if: matrix.database == 'postgresql'
         run: |
           docker run -d --name pg \
@@ -135,8 +158,55 @@ jobs:
             fi
           done
 
+      - name: Setup docker-compose (compose mode only)
+        if: matrix.database == 'docker-compose'
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          mkdir -p "$COMPOSE_DIR"
+          # Fetch the official compose file from upstream main. Saved as artifact
+          # later for traceability of which upstream snapshot was tested.
+          curl -fsSL https://raw.githubusercontent.com/langflow-ai/langflow/main/docker_example/docker-compose.yml \
+            -o "$COMPOSE_DIR/docker-compose.yml"
+          cp "$COMPOSE_DIR/docker-compose.yml" /tmp/logs/official-compose-snapshot.yml
+          echo "Fetched upstream compose ($(wc -l < "$COMPOSE_DIR/docker-compose.yml") lines)"
+
+          # Override: inject our auth, secret_key, workers. Same env contract as
+          # the direct-mode containers (AUTO_LOGIN=false + superuser flow).
+          cat > "$COMPOSE_DIR/docker-compose.override.yml" <<'YAML'
+          services:
+            langflow:
+              image: ${LANGFLOW_IMAGE}
+              environment:
+                - LANGFLOW_SECRET_KEY=${LANGFLOW_SECRET_KEY}
+                - OPENAI_API_KEY=${OPENAI_API_KEY}
+                - LANGFLOW_AUTO_LOGIN=false
+                - LANGFLOW_SUPERUSER=${LANGFLOW_SUPERUSER}
+                - LANGFLOW_SUPERUSER_PASSWORD=${LANGFLOW_SUPERUSER_PASSWORD}
+                - LANGFLOW_STORE=false
+                - LANGFLOW_WORKERS=${LANGFLOW_WORKERS}
+          YAML
+
+          # .env consumed by docker compose. Source phase: image = source_image.
+          # The target phase rewrites both LANGFLOW_IMAGE and OPENAI_API_KEY
+          # (target clears the key so it relies on the migrated/encrypted row).
+          cat > "$COMPOSE_DIR/.env" <<EOF
+          LANGFLOW_IMAGE=${{ inputs.source_image }}
+          LANGFLOW_SECRET_KEY=${LANGFLOW_SECRET_KEY}
+          OPENAI_API_KEY=${OPENAI_API_KEY}
+          LANGFLOW_SUPERUSER=${SUPERUSER}
+          LANGFLOW_SUPERUSER_PASSWORD=${SUPERUSER_PASSWORD}
+          LANGFLOW_WORKERS=${EFFECTIVE_WORKERS}
+          EOF
+          chmod 600 "$COMPOSE_DIR/.env"
+
+          if [[ -n "$OPENAI_API_KEY" ]]; then
+            touch /tmp/has-openai-key
+          fi
+
       # ── Phase A: source — bootstrap state ─────────────────────
-      - name: "[SOURCE] Pull ${{ inputs.source_image }}"
+      - name: "[SOURCE] Pull ${{ inputs.source_image }} (direct mode)"
+        if: env.DEPLOY_MODE == 'direct'
         run: |
           docker pull "${{ inputs.source_image }}"
           docker inspect "${{ inputs.source_image }}" \
@@ -151,27 +221,35 @@ jobs:
           # Variable row, not on a re-import by the target process.
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          if [[ -n "$OPENAI_API_KEY" ]]; then
-            touch /tmp/has-openai-key
+          if [[ "$DEPLOY_MODE" == "compose" ]]; then
+            (cd "$COMPOSE_DIR" && docker compose up -d)
+          else
+            if [[ -n "$OPENAI_API_KEY" ]]; then
+              touch /tmp/has-openai-key
+            fi
+            docker run -d --name lf-source \
+              --network host \
+              $MOUNT_FLAGS \
+              --env-file /tmp/lf.env \
+              -e OPENAI_API_KEY \
+              "${{ inputs.source_image }}"
           fi
-          docker run -d --name lf-source \
-            --network host \
-            $MOUNT_FLAGS \
-            --env-file /tmp/lf.env \
-            -e OPENAI_API_KEY \
-            "${{ inputs.source_image }}"
 
       - name: "[SOURCE] Wait healthy"
         run: |
           for i in $(seq 1 72); do
             sleep 5
-            if docker logs lf-source 2>&1 | grep -q "Open Langflow"; then
+            if curl -fsS "${LF_URL}/health_check" >/dev/null 2>&1; then
               echo "Source up after $((i*5))s"
               break
             fi
             if [[ $i -eq 72 ]]; then
               echo "::error::Source did not become healthy in 360s"
-              docker logs lf-source 2>&1 | tail -100
+              if [[ "$DEPLOY_MODE" == "compose" ]]; then
+                (cd "$COMPOSE_DIR" && docker compose logs --tail=100)
+              else
+                docker logs lf-source 2>&1 | tail -100
+              fi
               exit 1
             fi
           done
@@ -272,12 +350,19 @@ jobs:
       - name: "[SOURCE] Save log and stop"
         if: always()
         run: |
-          docker logs lf-source > "/tmp/logs/source-${{ matrix.database }}.log" 2>&1 || true
-          docker stop lf-source >/dev/null 2>&1 || true
-          docker rm lf-source >/dev/null 2>&1 || true
+          if [[ "$DEPLOY_MODE" == "compose" ]]; then
+            (cd "$COMPOSE_DIR" && docker compose logs langflow > "/tmp/logs/source-${{ matrix.database }}.log" 2>&1) || true
+            # Preserve the postgres named volume; stop only the langflow service.
+            (cd "$COMPOSE_DIR" && docker compose stop langflow) || true
+          else
+            docker logs lf-source > "/tmp/logs/source-${{ matrix.database }}.log" 2>&1 || true
+            docker stop lf-source >/dev/null 2>&1 || true
+            docker rm lf-source >/dev/null 2>&1 || true
+          fi
 
       # ── Phase B: target — migration runs on first boot ────────
-      - name: "[TARGET] Pull ${{ inputs.target_image }}"
+      - name: "[TARGET] Pull ${{ inputs.target_image }} (direct mode)"
+        if: env.DEPLOY_MODE == 'direct'
         run: |
           docker pull "${{ inputs.target_image }}"
           docker inspect "${{ inputs.target_image }}" \
@@ -285,23 +370,36 @@ jobs:
 
       - name: "[TARGET] Start (migration on boot)"
         run: |
-          docker run -d --name lf-target \
-            --network host \
-            $MOUNT_FLAGS \
-            --env-file /tmp/lf.env \
-            "${{ inputs.target_image }}"
+          if [[ "$DEPLOY_MODE" == "compose" ]]; then
+            # Flip the image and clear OPENAI_API_KEY in compose .env. Target
+            # intentionally has NO OPENAI_API_KEY env so it depends entirely on
+            # the migrated/encrypted Variable row from the source phase.
+            sed -i 's|^LANGFLOW_IMAGE=.*|LANGFLOW_IMAGE=${{ inputs.target_image }}|' "$COMPOSE_DIR/.env"
+            sed -i 's|^OPENAI_API_KEY=.*|OPENAI_API_KEY=|' "$COMPOSE_DIR/.env"
+            (cd "$COMPOSE_DIR" && docker compose up -d langflow)
+          else
+            docker run -d --name lf-target \
+              --network host \
+              $MOUNT_FLAGS \
+              --env-file /tmp/lf.env \
+              "${{ inputs.target_image }}"
+          fi
 
       - name: "[TARGET] Wait healthy (alembic migration included)"
         run: |
           for i in $(seq 1 72); do
             sleep 5
-            if docker logs lf-target 2>&1 | grep -q "Open Langflow"; then
+            if curl -fsS "${LF_URL}/health_check" >/dev/null 2>&1; then
               echo "Target up after $((i*5))s"
               break
             fi
             if [[ $i -eq 72 ]]; then
               echo "::error::Target did not become healthy in 360s — likely migration failure"
-              docker logs lf-target 2>&1 | tail -100
+              if [[ "$DEPLOY_MODE" == "compose" ]]; then
+                (cd "$COMPOSE_DIR" && docker compose logs langflow --tail=100)
+              else
+                docker logs lf-target 2>&1 | tail -100
+              fi
               exit 1
             fi
           done
@@ -463,7 +561,12 @@ jobs:
       - name: "[TARGET] Save log"
         if: always()
         run: |
-          docker logs lf-target > "/tmp/logs/target-${{ matrix.database }}.log" 2>&1 || true
+          if [[ "$DEPLOY_MODE" == "compose" ]]; then
+            (cd "$COMPOSE_DIR" && docker compose logs langflow > "/tmp/logs/target-${{ matrix.database }}.log" 2>&1) || true
+            (cd "$COMPOSE_DIR" && docker compose logs postgres > "/tmp/logs/postgres-${{ matrix.database }}.log" 2>&1) || true
+          else
+            docker logs lf-target > "/tmp/logs/target-${{ matrix.database }}.log" 2>&1 || true
+          fi
 
       # ── Phase D: scan target log for issue 13157 patterns ─────
       - name: "Scan target log for runtime DB/session errors"
@@ -498,9 +601,14 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          docker stop lf-target lf-source pg 2>/dev/null || true
-          docker rm lf-target lf-source pg 2>/dev/null || true
-          rm -rf /tmp/lf-sqlite-data 2>/dev/null || true
+          if [[ "$DEPLOY_MODE" == "compose" ]]; then
+            (cd "$COMPOSE_DIR" && docker compose down -v) 2>/dev/null || true
+            rm -rf "$COMPOSE_DIR" 2>/dev/null || true
+          else
+            docker stop lf-target lf-source pg 2>/dev/null || true
+            docker rm lf-target lf-source pg 2>/dev/null || true
+            rm -rf /tmp/lf-sqlite-data 2>/dev/null || true
+          fi
 
       - name: Upload artifacts
         if: always()
@@ -516,3 +624,6 @@ jobs:
             /tmp/run-resp.json
             /tmp/run-paced-*.json
           retention-days: 30
+        # /tmp/logs/official-compose-snapshot.yml is included in compose mode runs
+        # (recorded by the Setup docker-compose step) — captures exactly which
+        # upstream compose was tested.

--- a/.github/workflows/migration-manual.yml
+++ b/.github/workflows/migration-manual.yml
@@ -453,9 +453,13 @@ jobs:
           fi
 
       - name: "[TARGET] Execute witness flow — Fernet decrypt + smoke test (1/10 OpenAI calls)"
-        if: hashFiles('/tmp/has-openai-key') != ''
         run: |
           set -e
+          if [[ ! -f /tmp/has-openai-key ]]; then
+            echo "Skipping witness flow smoke test because OPENAI_API_KEY is not configured"
+            exit 0
+          fi
+
           ADMIN_TOKEN=$(curl -s -X POST "${LF_URL}/api/v1/login" \
             -H "Content-Type: application/x-www-form-urlencoded" \
             -d "username=${SUPERUSER}&password=${SUPERUSER_PASSWORD}" \

--- a/.github/workflows/migration-manual.yml
+++ b/.github/workflows/migration-manual.yml
@@ -143,11 +143,22 @@ jobs:
             --format='{{index .RepoDigests 0}}' | tee /tmp/source-digest.txt
 
       - name: "[SOURCE] Start"
+        env:
+          # Exposed to Langflow so the OPENAI_API_KEY Credential is auto-imported
+          # at startup (see docs.langflow.org/configuration-global-variables).
+          # Target intentionally does NOT receive this env var — that way the
+          # post-migration flow execution depends on the migrated/encrypted
+          # Variable row, not on a re-import by the target process.
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
+          if [[ -n "$OPENAI_API_KEY" ]]; then
+            touch /tmp/has-openai-key
+          fi
           docker run -d --name lf-source \
             --network host \
             $MOUNT_FLAGS \
             --env-file /tmp/lf.env \
+            -e OPENAI_API_KEY \
             "${{ inputs.source_image }}"
 
       - name: "[SOURCE] Wait healthy"
@@ -165,10 +176,9 @@ jobs:
             fi
           done
 
-      - name: "[SOURCE] Create N users + witness flow + encrypted variable"
+      - name: "[SOURCE] Create N users + witness flow"
         env:
           N: ${{ inputs.concurrent_users }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -e
 
@@ -203,11 +213,15 @@ jobs:
 
           echo "Created and activated $(wc -l < /tmp/users.txt) users"
 
-          # ---- Witness flow (real Simple Agent starter if API key available) ----
-          if [[ -n "$OPENAI_API_KEY" ]]; then
-            echo "OPENAI_API_KEY secret available: using Simple Agent starter as witness"
+          # ---- Witness flow ----
+          # If OPENAI_API_KEY env was exposed to the source container, Langflow
+          # auto-imported it as a Credential Variable on startup. The Simple Agent
+          # starter is then a meaningful witness — it exercises the
+          # encrypted-Variable path through migration. Otherwise fall back to an
+          # empty stub (still exercises schema migration + state preservation).
+          if [[ -f /tmp/has-openai-key ]]; then
+            echo "OPENAI_API_KEY available: using Simple Agent starter as witness"
 
-            # Find Simple Agent starter (matches helpers.find_agent_template)
             STARTERS=$(curl -s -H "Authorization: Bearer ${ADMIN_TOKEN}" \
               "${LF_URL}/api/v1/starter-projects/")
             TEMPLATE=$(echo "$STARTERS" | jq -c '
@@ -231,18 +245,17 @@ jobs:
               | jq -r '.id // empty')
             [[ -z "$WITNESS_ID" ]] && { echo "::error::Failed to create witness flow from starter"; exit 1; }
 
-            # Create encrypted Variable — this is the Fernet-encrypted credential
-            # that will be tested for survival across the migration
-            VAR_ID=$(curl -s -X POST "${LF_URL}/api/v1/variables/" \
-              -H "Authorization: Bearer ${ADMIN_TOKEN}" \
-              -H "Content-Type: application/json" \
-              -d "{\"name\":\"OPENAI_API_KEY\",\"value\":\"${OPENAI_API_KEY}\",\"type\":\"Credential\",\"default_fields\":[]}" \
-              | jq -r '.id // empty')
-            [[ -z "$VAR_ID" ]] && { echo "::error::Failed to create OPENAI_API_KEY variable"; exit 1; }
-            echo "$VAR_ID" > /tmp/variable-id.txt
+            # Confirm the auto-imported Variable is present (env-based auto-import
+            # already happened at Langflow startup; no need to POST /api/v1/variables/)
+            VAR_COUNT=$(curl -s -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+              "${LF_URL}/api/v1/variables/" \
+              | jq '[.[] | select(.name == "OPENAI_API_KEY")] | length')
+            if [[ "$VAR_COUNT" -ne "1" ]]; then
+              echo "::error::Expected 1 OPENAI_API_KEY auto-imported Variable on source, found ${VAR_COUNT}"
+              exit 1
+            fi
 
-            touch /tmp/has-openai-key
-            echo "Witness: Simple Agent flow ${WITNESS_ID} + encrypted variable ${VAR_ID}"
+            echo "Witness: Simple Agent flow ${WITNESS_ID}; auto-imported Credential confirmed"
           else
             echo "::warning::OPENAI_API_KEY secret not configured. Using empty stub witness; skipping Fernet/flow-execution coverage."
             WITNESS_ID=$(curl -s -X POST "${LF_URL}/api/v1/flows/" \
@@ -499,7 +512,6 @@ jobs:
             /tmp/source-digest.txt
             /tmp/target-digest.txt
             /tmp/witness-id.txt
-            /tmp/variable-id.txt
             /tmp/users.txt
             /tmp/run-resp.json
             /tmp/run-paced-*.json

--- a/.github/workflows/migration-manual.yml
+++ b/.github/workflows/migration-manual.yml
@@ -1,0 +1,377 @@
+name: "Langflow Migration: Manual (source → target)"
+
+# Release-grade migration test, dispatched on demand only.
+# Goes beyond `migration-test.yml`: also exercises multi-user concurrent
+# auth against the target image, designed to surface runtime DB session
+# issues like upstream issue langflow-ai/langflow#13157.
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_image:
+        description: "Image full path. Accept published images from langflowai/langflow and langflowai/langflow-nightly"
+        required: true
+        default: "langflowai/langflow:latest"
+      target_image:
+        description: "Image full path. Accept published images from langflowai/langflow and langflowai/langflow-nightly"
+        required: true
+        default: "langflowai/langflow-nightly:latest"
+      database:
+        description: "Database backend(s) to test"
+        required: true
+        type: choice
+        options:
+          - postgresql
+          - sqlite
+          - both
+        default: "both"
+      workers:
+        description: "LANGFLOW_WORKERS for PostgreSQL (SQLite forces 1 — see SQLite docs §2.7 fork+connection)"
+        required: false
+        default: "2"
+      concurrent_users:
+        description: "Number of distinct user accounts created and stressed in parallel against the target"
+        required: false
+        default: "10"
+      stress_duration_seconds:
+        description: "How long to stress the target after migration (seconds)"
+        required: false
+        default: "300"
+
+permissions:
+  contents: read
+
+jobs:
+  prepare-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      databases: ${{ steps.build.outputs.databases }}
+    steps:
+      - id: build
+        run: |
+          case "${{ inputs.database }}" in
+            postgresql) echo 'databases=["postgresql"]' >> "$GITHUB_OUTPUT" ;;
+            sqlite)     echo 'databases=["sqlite"]' >> "$GITHUB_OUTPUT" ;;
+            both)       echo 'databases=["postgresql","sqlite"]' >> "$GITHUB_OUTPUT" ;;
+            *)          echo "Invalid database: ${{ inputs.database }}" && exit 1 ;;
+          esac
+
+  migration:
+    needs: prepare-matrix
+    name: "${{ matrix.database }} | ${{ inputs.source_image }} → ${{ inputs.target_image }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        database: ${{ fromJSON(needs.prepare-matrix.outputs.databases) }}
+
+    env:
+      LF_URL: http://localhost:7860
+      SUPERUSER: langflow_admin
+      SUPERUSER_PASSWORD: langflow_admin_pw
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve runtime configuration
+        run: |
+          mkdir -p /tmp/logs
+          SECRET_KEY=$(python3 -c "import base64,os; print(base64.urlsafe_b64encode(os.urandom(32)).decode())")
+
+          # SQLite forces single worker (see SQLite docs §2.7 / §8.1).
+          # Multi-worker + SQLite is fragile by design (file lock + fork-after-connect),
+          # not a Langflow-specific concern. PostgreSQL uses the input value.
+          if [[ "${{ matrix.database }}" == "sqlite" ]]; then
+            EFFECTIVE_WORKERS=1
+            echo "Note: SQLite forces LANGFLOW_WORKERS=1 (input value ${{ inputs.workers }} ignored)"
+          else
+            EFFECTIVE_WORKERS="${{ inputs.workers }}"
+          fi
+
+          {
+            echo "LANGFLOW_HOST=0.0.0.0"
+            echo "LANGFLOW_PORT=7860"
+            echo "LANGFLOW_AUTO_LOGIN=false"
+            echo "LANGFLOW_SUPERUSER=${SUPERUSER}"
+            echo "LANGFLOW_SUPERUSER_PASSWORD=${SUPERUSER_PASSWORD}"
+            echo "LANGFLOW_STORE=false"
+            echo "LANGFLOW_SECRET_KEY=${SECRET_KEY}"
+            echo "LANGFLOW_WORKERS=${EFFECTIVE_WORKERS}"
+          } > /tmp/lf.env
+
+          if [[ "${{ matrix.database }}" == "postgresql" ]]; then
+            echo "LANGFLOW_DATABASE_URL=postgresql://langflow:langflow_test_pw@localhost:5432/langflow" >> /tmp/lf.env
+            echo "MOUNT_FLAGS=" >> "$GITHUB_ENV"
+          else
+            mkdir -p /tmp/lf-sqlite-data
+            chmod 777 /tmp/lf-sqlite-data
+            echo "LANGFLOW_DATABASE_URL=sqlite:////data/langflow.db" >> /tmp/lf.env
+            echo "LANGFLOW_CONFIG_DIR=/data" >> /tmp/lf.env
+            echo "MOUNT_FLAGS=-v /tmp/lf-sqlite-data:/data" >> "$GITHUB_ENV"
+          fi
+
+          echo "Effective env file:"
+          cat /tmp/lf.env
+
+      - name: Start PostgreSQL (if needed)
+        if: matrix.database == 'postgresql'
+        run: |
+          docker run -d --name pg \
+            -e POSTGRES_USER=langflow \
+            -e POSTGRES_PASSWORD=langflow_test_pw \
+            -e POSTGRES_DB=langflow \
+            -p 5432:5432 \
+            postgres:16-alpine
+          for i in $(seq 1 15); do
+            sleep 2
+            if docker exec pg pg_isready -U langflow >/dev/null 2>&1; then
+              echo "Postgres ready after $((i*2))s"
+              break
+            fi
+            if [[ $i -eq 15 ]]; then
+              echo "::error::Postgres failed to become ready"
+              exit 1
+            fi
+          done
+
+      # ── Phase A: source — bootstrap state ─────────────────────
+      - name: "[SOURCE] Pull ${{ inputs.source_image }}"
+        run: |
+          docker pull "${{ inputs.source_image }}"
+          docker inspect "${{ inputs.source_image }}" \
+            --format='{{index .RepoDigests 0}}' | tee /tmp/source-digest.txt
+
+      - name: "[SOURCE] Start"
+        run: |
+          docker run -d --name lf-source \
+            --network host \
+            $MOUNT_FLAGS \
+            --env-file /tmp/lf.env \
+            "${{ inputs.source_image }}"
+
+      - name: "[SOURCE] Wait healthy"
+        run: |
+          for i in $(seq 1 72); do
+            sleep 5
+            if docker logs lf-source 2>&1 | grep -q "Open Langflow"; then
+              echo "Source up after $((i*5))s"
+              break
+            fi
+            if [[ $i -eq 72 ]]; then
+              echo "::error::Source did not become healthy in 360s"
+              docker logs lf-source 2>&1 | tail -100
+              exit 1
+            fi
+          done
+
+      - name: "[SOURCE] Create N users + witness flow"
+        env:
+          N: ${{ inputs.concurrent_users }}
+        run: |
+          set -e
+
+          ADMIN_TOKEN=$(curl -s -X POST "${LF_URL}/api/v1/login" \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            -d "username=${SUPERUSER}&password=${SUPERUSER_PASSWORD}" \
+            | jq -r '.access_token // empty')
+          if [[ -z "$ADMIN_TOKEN" ]]; then
+            echo "::error::Failed to login as superuser on source"
+            exit 1
+          fi
+
+          : > /tmp/users.txt
+          for i in $(seq 1 "$N"); do
+            USER="testuser_${i}"
+            PASS="pw_${i}_$(openssl rand -hex 4)"
+            ID=$(curl -s -X POST "${LF_URL}/api/v1/users/" \
+              -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d "{\"username\":\"${USER}\",\"password\":\"${PASS}\"}" \
+              | jq -r '.id // empty')
+            if [[ -z "$ID" ]]; then
+              echo "::error::Failed to create user ${USER}"
+              exit 1
+            fi
+            curl -s -X PATCH "${LF_URL}/api/v1/users/${ID}" \
+              -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d '{"is_active":true}' > /dev/null
+            echo "${USER}:${PASS}:${ID}" >> /tmp/users.txt
+          done
+
+          echo "Created and activated $(wc -l < /tmp/users.txt) users"
+
+          WITNESS_ID=$(curl -s -X POST "${LF_URL}/api/v1/flows/" \
+            -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d '{"name":"migration-witness-manual","description":"Migration witness flow","data":{"nodes":[],"edges":[]}}' \
+            | jq -r '.id // empty')
+          if [[ -z "$WITNESS_ID" ]]; then
+            echo "::error::Failed to create witness flow"
+            exit 1
+          fi
+          echo "$WITNESS_ID" > /tmp/witness-id.txt
+          echo "Witness flow id: ${WITNESS_ID}"
+
+      - name: "[SOURCE] Save log and stop"
+        if: always()
+        run: |
+          docker logs lf-source > "/tmp/logs/source-${{ matrix.database }}.log" 2>&1 || true
+          docker stop lf-source >/dev/null 2>&1 || true
+          docker rm lf-source >/dev/null 2>&1 || true
+
+      # ── Phase B: target — migration runs on first boot ────────
+      - name: "[TARGET] Pull ${{ inputs.target_image }}"
+        run: |
+          docker pull "${{ inputs.target_image }}"
+          docker inspect "${{ inputs.target_image }}" \
+            --format='{{index .RepoDigests 0}}' | tee /tmp/target-digest.txt
+
+      - name: "[TARGET] Start (migration on boot)"
+        run: |
+          docker run -d --name lf-target \
+            --network host \
+            $MOUNT_FLAGS \
+            --env-file /tmp/lf.env \
+            "${{ inputs.target_image }}"
+
+      - name: "[TARGET] Wait healthy (alembic migration included)"
+        run: |
+          for i in $(seq 1 72); do
+            sleep 5
+            if docker logs lf-target 2>&1 | grep -q "Open Langflow"; then
+              echo "Target up after $((i*5))s"
+              break
+            fi
+            if [[ $i -eq 72 ]]; then
+              echo "::error::Target did not become healthy in 360s — likely migration failure"
+              docker logs lf-target 2>&1 | tail -100
+              exit 1
+            fi
+          done
+
+      - name: "[TARGET] Verify witness flow + users preserved"
+        run: |
+          set -e
+
+          ADMIN_TOKEN=$(curl -s -X POST "${LF_URL}/api/v1/login" \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            -d "username=${SUPERUSER}&password=${SUPERUSER_PASSWORD}" \
+            | jq -r '.access_token // empty')
+          if [[ -z "$ADMIN_TOKEN" ]]; then
+            echo "::error::Failed to login as superuser on target — auth schema may have broken"
+            exit 1
+          fi
+
+          WITNESS_ID=$(cat /tmp/witness-id.txt)
+          STATUS=$(curl -s -o /tmp/witness-resp.json -w "%{http_code}" \
+            -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+            "${LF_URL}/api/v1/flows/${WITNESS_ID}")
+          if [[ "$STATUS" != "200" ]]; then
+            echo "::error::Witness flow ${WITNESS_ID} lost after migration: HTTP ${STATUS}"
+            cat /tmp/witness-resp.json
+            exit 1
+          fi
+          echo "Witness flow preserved"
+
+          EXPECTED=$(wc -l < /tmp/users.txt)
+          PRESENT=$(curl -s -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+            "${LF_URL}/api/v1/users/?skip=0&limit=1000" \
+            | jq '[.users[] | select(.username | startswith("testuser_"))] | length')
+          if [[ "$PRESENT" -ne "$EXPECTED" ]]; then
+            echo "::error::User count mismatch after migration: expected ${EXPECTED}, found ${PRESENT}"
+            exit 1
+          fi
+          echo "All ${EXPECTED} test users preserved"
+
+      # ── Phase C: stress — N concurrent users hit auth+read paths ──
+      - name: "[TARGET] Multi-user concurrent stress (issue 13157 scenario)"
+        env:
+          DURATION: ${{ inputs.stress_duration_seconds }}
+        run: |
+          set -e
+          : > /tmp/tokens.txt
+          while IFS=: read -r USER PASS ID; do
+            TOKEN=$(curl -s -X POST "${LF_URL}/api/v1/login" \
+              -H "Content-Type: application/x-www-form-urlencoded" \
+              -d "username=${USER}&password=${PASS}" \
+              | jq -r '.access_token // empty')
+            if [[ -z "$TOKEN" ]]; then
+              echo "::error::Failed login for ${USER} on target"
+              exit 1
+            fi
+            echo "$TOKEN" >> /tmp/tokens.txt
+          done < /tmp/users.txt
+
+          N=$(wc -l < /tmp/tokens.txt)
+          END_TIME=$(( $(date +%s) + DURATION ))
+          echo "Stressing ${N} concurrent users for ${DURATION}s (until $(date -u -d @${END_TIME}))"
+
+          while IFS= read -r TOKEN; do
+            (
+              while [[ $(date +%s) -lt $END_TIME ]]; do
+                curl -s -o /dev/null -H "Authorization: Bearer ${TOKEN}" \
+                  "${LF_URL}/api/v1/users/whoami"
+                curl -s -o /dev/null -H "Authorization: Bearer ${TOKEN}" \
+                  "${LF_URL}/api/v1/flows/?skip=0&limit=50"
+              done
+            ) &
+          done < /tmp/tokens.txt
+          wait
+          echo "Stress phase complete"
+
+      - name: "[TARGET] Save log"
+        if: always()
+        run: |
+          docker logs lf-target > "/tmp/logs/target-${{ matrix.database }}.log" 2>&1 || true
+
+      # ── Phase D: scan target log for issue 13157 patterns ─────
+      - name: "Scan target log for runtime DB/session errors"
+        id: scan
+        run: |
+          LOG="/tmp/logs/target-${{ matrix.database }}.log"
+          PATTERNS='disk I/O error|database disk image is malformed|Unexpected error during token authentication|An error occurred during the session scope|Exception in ASGI application'
+
+          TARGET_HITS=$(grep -cE "$PATTERNS" "$LOG" 2>/dev/null || true)
+          TARGET_HITS=${TARGET_HITS:-0}
+
+          SOURCE_LOG="/tmp/logs/source-${{ matrix.database }}.log"
+          if [[ -f "$SOURCE_LOG" ]]; then
+            SOURCE_HITS=$(grep -cE "$PATTERNS" "$SOURCE_LOG" 2>/dev/null || true)
+            SOURCE_HITS=${SOURCE_HITS:-0}
+          else
+            SOURCE_HITS="n/a"
+          fi
+
+          echo "Source error pattern matches: ${SOURCE_HITS}"
+          echo "Target error pattern matches: ${TARGET_HITS}"
+
+          if [[ "$TARGET_HITS" -gt 0 ]]; then
+            echo "::error::Target ${{ inputs.target_image }} accumulated ${TARGET_HITS} DB session/auth errors during stress — matches langflow-ai/langflow#13157"
+            echo "First matches:"
+            grep -nE "$PATTERNS" "$LOG" | head -30
+            exit 1
+          fi
+
+          echo "Target log clean — no langflow-ai/langflow#13157 patterns detected"
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker stop lf-target lf-source pg 2>/dev/null || true
+          docker rm lf-target lf-source pg 2>/dev/null || true
+          rm -rf /tmp/lf-sqlite-data 2>/dev/null || true
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: migration-manual-${{ matrix.database }}-${{ github.run_number }}
+          path: |
+            /tmp/logs/
+            /tmp/source-digest.txt
+            /tmp/target-digest.txt
+            /tmp/witness-id.txt
+            /tmp/users.txt
+          retention-days: 30


### PR DESCRIPTION
## Summary

On-demand migration workflow designed for **release-grade** validation. Unlike `migration-test.yml` (which runs daily and only verifies that the schema migration completes), this one also exercises the runtime conditions that surface DB session bugs — directly inspired by [langflow-ai/langflow#13157](https://github.com/langflow-ai/langflow/issues/13157).

## How it works

For each selected database backend (postgresql, sqlite, or both):

1. **Source phase** — pull \`source_image\`, boot with \`LANGFLOW_AUTO_LOGIN=false\` + superuser credentials, create N test users (\`testuser_1\` … \`testuser_N\`) and one witness flow via the API, stop.
2. **Target phase** — pull \`target_image\`, boot on the same DB. Alembic migration runs here. Verify the witness flow and all N user accounts are still present.
3. **Stress phase** — each of the N users logs in concurrently with its own credentials, then N parallel loops hammer \`/api/v1/users/whoami\` and \`/api/v1/flows/\` for \`stress_duration_seconds\`. This reproduces the multi-worker + concurrent-auth conditions described in #13157.
4. **Scan phase** — grep target log for the five error patterns reported in #13157. Job fails if any appear.

## Inputs

| Input | Default | Purpose |
|---|---|---|
| \`source_image\` | \`langflowai/langflow:latest\` | Source image (full path) |
| \`target_image\` | \`langflowai/langflow-nightly:latest\` | Target image (full path) |
| \`database\` | \`both\` | \`postgresql\` / \`sqlite\` / \`both\` |
| \`workers\` | \`2\` | \`LANGFLOW_WORKERS\` for PostgreSQL only |
| \`concurrent_users\` | \`10\` | Distinct accounts created and stressed in parallel |
| \`stress_duration_seconds\` | \`300\` | Post-migration stress duration |

## Design decisions

- **Trigger is \`workflow_dispatch\` only.** No schedule. This is meant for release cycles, not daily CI.
- **SQLite forces single worker** regardless of the \`workers\` input. Source: [sqlite.org/howtocorrupt.html §2.7](https://www.sqlite.org/howtocorrupt.html) (fork-after-open is a documented corruption vector) and [§8.1](https://www.sqlite.org/howtocorrupt.html) (WAL multi-connection race). Multi-worker + SQLite produces noise unrelated to the Langflow product. PostgreSQL uses the input value.
- **Cross-repo migrations are valid** (\`langflowai/langflow:1.9.3\` → \`langflowai/langflow-nightly:latest\`). Both repos publish from the same codebase and share the same alembic chain — this is exactly the path \`migration-test.yml\` exercises today.
- **Failure signal is binary on the target.** If the target log shows any of the five #13157 patterns during stress, the job fails. The source log is captured for context but not used in the pass/fail decision.

## Error patterns scanned in the target log

From the issue body of #13157:

- \`disk I/O error\`
- \`database disk image is malformed\`
- \`Unexpected error during token authentication\`
- \`An error occurred during the session scope\`
- \`Exception in ASGI application\`

## Test plan

- [ ] Trigger via Actions UI with defaults (latest → nightly, both DBs, 10 users, 300s) — expect green if no regression
- [ ] Trigger with \`source_image=langflowai/langflow:1.9.2\`, \`target_image=langflowai/langflow:1.9.3\`, \`database=sqlite\` — exercises the exact scenario from #13157; expected outcome depends on whether the reporter's regression reproduces in this exact harness
- [ ] Confirm artifacts upload: source/target logs, image digests, witness ID, user list

🤖 Generated with [Claude Code](https://claude.com/claude-code)