### PR TITLE
refactor(api-request): scope table dialog by title instead of .last()

### DIFF
--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -415,7 +415,12 @@ test(
     await expect(headersDiv).toBeVisible({ timeout: 10000 });
     await headersDiv.getByRole("button", { name: "Open table" }).click();
 
-    const headersDialog = page.locator('[role="dialog"]').last();
+    // Scope by the TableModal's DialogTitle (Radix renders it as <h2>) so a
+    // co-mounted Radix Popover — which also reports role="dialog" — can't win
+    // the locator just by being later in DOM order. See issue #241.
+    const headersDialog = page
+      .locator('[role="dialog"]')
+      .filter({ has: page.getByRole("heading", { name: "Headers" }) });
     await expect(headersDialog).toBeVisible({ timeout: 10000 });
 
     await headersDialog.getByTestId("add-row-button").click();
@@ -556,7 +561,10 @@ test(
     await expect(bodyDiv).toBeVisible({ timeout: 10000 });
     await bodyDiv.getByRole("button", { name: "Open table" }).click();
 
-    const bodyDialog = page.locator('[role="dialog"]').last();
+    // Title-scoped — see issue #241 for why `.last()` was unsafe here.
+    const bodyDialog = page
+      .locator('[role="dialog"]')
+      .filter({ has: page.getByRole("heading", { name: "Body" }) });
     await expect(bodyDialog).toBeVisible({ timeout: 10000 });
 
     const addRowButton = bodyDialog.getByTestId("add-row-button");
@@ -643,7 +651,10 @@ test(
       await expect(headersDiv).toBeVisible({ timeout: 10000 });
       await headersDiv.getByRole("button", { name: "Open table" }).click();
 
-      const headersDialog = page.locator('[role="dialog"]').last();
+      // Title-scoped — see issue #241 for why `.last()` was unsafe here.
+      const headersDialog = page
+        .locator('[role="dialog"]')
+        .filter({ has: page.getByRole("heading", { name: "Headers" }) });
       await expect(headersDialog).toBeVisible({ timeout: 10000 });
 
       // The refresh has already completed in the step above (we waited for the
@@ -763,7 +774,10 @@ test(
         const headersDiv = page.getByTestId("div-table_headers");
         await expect(headersDiv).toBeVisible({ timeout: 10000 });
         await headersDiv.getByRole("button", { name: "Open table" }).click();
-        const headersDialog = page.locator('[role="dialog"]').last();
+        // Title-scoped — see issue #241 for why `.last()` was unsafe here.
+        const headersDialog = page
+          .locator('[role="dialog"]')
+          .filter({ has: page.getByRole("heading", { name: "Headers" }) });
         await expect(headersDialog).toBeVisible({ timeout: 10000 });
         await expect(
           headersDialog.getByRole("button", { name: headerKey, exact: true }),

--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -114,6 +114,19 @@ async function fillViewTextCell(
   }).toPass({ timeout: 40000 });
 }
 
+// Helper: locate a TableModal by its DialogTitle heading.
+//
+// Both Radix Dialog and Radix Popover render `role="dialog"` into portals at
+// the end of <body>, so any `.last()` selector resolves to whichever happens
+// to mount latest in DOM order — a coincidence, not a guarantee. Scoping by
+// the DialogTitle (which Radix renders as <h2>, fed from the field's
+// `display_name` upstream) ties the locator to a stable identity.
+function tableDialog(page: Page, title: "Headers" | "Body"): Locator {
+  return page
+    .locator('[role="dialog"]')
+    .filter({ has: page.getByRole("heading", { name: title, exact: true }) });
+}
+
 // =============================================================================
 // UI / Canvas tests — verify component rendering and inspector fields
 // =============================================================================
@@ -415,12 +428,7 @@ test(
     await expect(headersDiv).toBeVisible({ timeout: 10000 });
     await headersDiv.getByRole("button", { name: "Open table" }).click();
 
-    // Scope by the TableModal's DialogTitle (Radix renders it as <h2>) so a
-    // co-mounted Radix Popover — which also reports role="dialog" — can't win
-    // the locator just by being later in DOM order. See issue #241.
-    const headersDialog = page
-      .locator('[role="dialog"]')
-      .filter({ has: page.getByRole("heading", { name: "Headers" }) });
+    const headersDialog = tableDialog(page, "Headers");
     await expect(headersDialog).toBeVisible({ timeout: 10000 });
 
     await headersDialog.getByTestId("add-row-button").click();
@@ -561,10 +569,7 @@ test(
     await expect(bodyDiv).toBeVisible({ timeout: 10000 });
     await bodyDiv.getByRole("button", { name: "Open table" }).click();
 
-    // Title-scoped — see issue #241 for why `.last()` was unsafe here.
-    const bodyDialog = page
-      .locator('[role="dialog"]')
-      .filter({ has: page.getByRole("heading", { name: "Body" }) });
+    const bodyDialog = tableDialog(page, "Body");
     await expect(bodyDialog).toBeVisible({ timeout: 10000 });
 
     const addRowButton = bodyDialog.getByTestId("add-row-button");
@@ -651,10 +656,7 @@ test(
       await expect(headersDiv).toBeVisible({ timeout: 10000 });
       await headersDiv.getByRole("button", { name: "Open table" }).click();
 
-      // Title-scoped — see issue #241 for why `.last()` was unsafe here.
-      const headersDialog = page
-        .locator('[role="dialog"]')
-        .filter({ has: page.getByRole("heading", { name: "Headers" }) });
+      const headersDialog = tableDialog(page, "Headers");
       await expect(headersDialog).toBeVisible({ timeout: 10000 });
 
       // The refresh has already completed in the step above (we waited for the
@@ -774,10 +776,7 @@ test(
         const headersDiv = page.getByTestId("div-table_headers");
         await expect(headersDiv).toBeVisible({ timeout: 10000 });
         await headersDiv.getByRole("button", { name: "Open table" }).click();
-        // Title-scoped — see issue #241 for why `.last()` was unsafe here.
-        const headersDialog = page
-          .locator('[role="dialog"]')
-          .filter({ has: page.getByRole("heading", { name: "Headers" }) });
+        const headersDialog = tableDialog(page, "Headers");
         await expect(headersDialog).toBeVisible({ timeout: 10000 });
         await expect(
           headersDialog.getByRole("button", { name: headerKey, exact: true }),


### PR DESCRIPTION
## Summary

- Replaces the four `page.locator('[role="dialog"]').last()` calls in `api-request-component-regression.spec.ts` with a heading-scoped filter on the TableModal's `DialogTitle` (`"Headers"` / `"Body"`).
- Self-describing locator: no longer depends on DOM mount order between Radix Dialog and Radix Popover, both of which carry `role="dialog"`.
- No new lint warnings; only the pre-existing `any` on `allowFlowErrors` remains (documented in the spec doc).

## Why

In Langflow, `@radix-ui/react-dialog` and `@radix-ui/react-popover` both render their content with `role="dialog"`, portaled to the end of `<body>`. `.last()` is DOM order — not z-index, not identity. The locator only matched the TableModal because, at the assertion moment, no popover or confirmation dialog happened to be co-mounted. A future unsaved-changes AlertDialog or a stale URL/method popover would silently win the match.

The replacement scopes via `getByRole("heading", { name: "Headers" | "Body" })` — Radix `DialogTitle` renders as `<h2>`, and the title text comes from the field's `display_name` in the Python component (`api_request.py`), so it is stable across renames of unrelated dialogs.

## Out of scope

The `_tableDialog` parameter cleanup item from #241's acceptance criteria was already done in 278c039 (Copilot review on PR #240). Only the four `.last()` replacements remained.

The longer-term upstream change (passing a `data-testid` through `BaseModal` → `DialogContent`) belongs in the Langflow repo and is explicitly out of scope per the issue.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` — no new warnings on this file
- [x] `npx playwright test tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts` — 15/15 pass on first run (1.3m) against local Langflow nightly

Closes #241