### PR TITLE
test(regression): tag logout-flow as @stable and remove isVisible().catch() anti-pattern

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -242,11 +242,11 @@
 #### 4.1 Login / Logout
 - [-] Login with valid credentials
 - [-] Login with invalid credentials — should display error message
-- [-] Logout — should redirect to login screen
+- [x] Logout — should redirect to login screen
 - [-] Auto-login enabled — should skip login screen
 - [-] Auto-login disabled — should display login screen
 - [-] Expired session — should redirect to login
-- [-] Session cleanup after logout
+- [x] Session cleanup after logout
 
 #### 4.2 User Management (Admin)
 - [-] Admin creates new user

--- a/tests/tests-automations/regression/core-functionality/auth/logout-flow.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/auth/logout-flow.spec.ts
@@ -26,7 +26,7 @@ function setupAutoLoginMock(page: any) {
 
 test(
   "logout must redirect user to login page",
-  { tag: ["@release", "@api", "@regression", "@auth"] },
+  { tag: ["@stable", "@release", "@api", "@regression", "@auth"] },
   async ({ page }) => {
     await setupAutoLoginMock(page);
 
@@ -69,17 +69,15 @@ test(
     });
 
     // Main page must not be accessible
-    const isMainPageVisible = await page
-      .getByTestId("mainpage_title")
-      .isVisible()
-      .catch(() => false);
-    expect(isMainPageVisible).toBeFalsy();
+    await expect(page.getByTestId("mainpage_title")).toBeHidden({
+      timeout: 5000,
+    });
   },
 );
 
 test(
   "after logout, navigating to root must redirect to login",
-  { tag: ["@release", "@api", "@regression", "@auth"] },
+  { tag: ["@stable", "@release", "@api", "@regression", "@auth"] },
   async ({ page }) => {
     await setupAutoLoginMock(page);
 
@@ -115,17 +113,15 @@ test(
     // Should still show login — not bypass authentication
     await page.waitForSelector("text=sign in to langflow", { timeout: 30000 });
 
-    const isMainPageVisible = await page
-      .getByTestId("mainpage_title")
-      .isVisible()
-      .catch(() => false);
-    expect(isMainPageVisible).toBeFalsy();
+    await expect(page.getByTestId("mainpage_title")).toBeHidden({
+      timeout: 5000,
+    });
   },
 );
 
 test(
   "after logout, reload must stay on login page",
-  { tag: ["@release", "@api", "@regression", "@auth"] },
+  { tag: ["@stable", "@release", "@api", "@regression", "@auth"] },
   async ({ page }) => {
     await setupAutoLoginMock(page);
 
@@ -158,10 +154,8 @@ test(
 
     await page.waitForSelector("text=sign in to langflow", { timeout: 30000 });
 
-    const isLoggedIn = await page
-      .getByTestId("mainpage_title")
-      .isVisible()
-      .catch(() => false);
-    expect(isLoggedIn).toBeFalsy();
+    await expect(page.getByTestId("mainpage_title")).toBeHidden({
+      timeout: 5000,
+    });
   },
 );


### PR DESCRIPTION
## Summary

- Refactored the 3 tests in `tests/tests-automations/regression/core-functionality/auth/logout-flow.spec.ts` to replace `isVisible().catch(() => false)` + `toBeFalsy()` with `expect(...).toBeHidden({ timeout: 5000 })`. The previous form swallowed any locator exception into `false`, making the assertion pass for the wrong reasons.
- Validated end-to-end through the 7-step `playwright-test-linter` pipeline (typecheck, lint, static checklist, run, force-fail per test, --trace=on, backend error audit — all green).
- Tagged the 3 tests as `@stable` and updated the corresponding bullets in `QA-CHECKLIST.md` from `[-]` to `[x]`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx eslint <spec>` — 0 errors, warnings within accepted project-wide patterns (count reduced 16→13 after refactor)
- [x] `npx playwright test <spec> --workers=1 --retries=0` — 3 passed (11.0s)
- [x] Force-fail per test: inverted `toBeHidden` → `toBeVisible({ timeout: 2000 })` fails at the expected line; reverted; passes again
- [x] `--trace=on` run — 3 passed (13.0s) with trace
- [x] Zero `🚨 Backend Error` occurrences (the `/auto_login` 500 is intercepted by `page.route` and never hits the real backend)