### PR TITLE
test(api-flows-crud): validate and tag @stable

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -84,12 +84,12 @@
 - [-] GET `/api/v1/health` → returns uptime and version
 
 #### 1.2 Flow CRUD via API
-- [-] POST `/api/v1/flows/` → creates flow, returns ID
-- [-] GET `/api/v1/flows/` → lists user flows
-- [-] GET `/api/v1/flows/{id}` → returns flow by ID
-- [-] PATCH `/api/v1/flows/{id}` → updates name/description
-- [-] DELETE `/api/v1/flows/{id}` → removes flow, returns 200
-- [-] GET `/api/v1/flows/{id}` after DELETE → should return 404
+- [x] POST `/api/v1/flows/` → creates flow, returns ID → `api/flows/api-flows-crud.spec.ts`
+- [x] GET `/api/v1/flows/` → lists user flows → `api/flows/api-flows-crud.spec.ts`
+- [x] GET `/api/v1/flows/{id}` → returns flow by ID → `api/flows/api-flows-crud.spec.ts`
+- [x] PATCH `/api/v1/flows/{id}` → updates name/description → `api/flows/api-flows-crud.spec.ts`
+- [x] DELETE `/api/v1/flows/{id}` → removes flow, returns 200 → `api/flows/api-flows-crud.spec.ts`
+- [x] GET `/api/v1/flows/{id}` after DELETE → should return 404 → `api/flows/api-flows-crud.spec.ts`
 
 #### 1.3 Flow Execution via API
 - [-] POST `/api/v1/run/{flow_id}` with `input_value` → returns response

--- a/docs/api/flows/api-flows-crud.md
+++ b/docs/api/flows/api-flows-crud.md
@@ -1,0 +1,110 @@
+# API Flows CRUD
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+Validates the full CRUD contract of `/api/v1/flows/` — the endpoint family that backs every flow created in the UI, every flow exported by the MCP server, every integration code snippet (curl/Python) generated from the Publish dropdown, and every external API consumer that programmatically manages flows.
+
+A regression in any of these endpoints silently breaks the editor (saved flows disappear), the MCP integration (server cannot enumerate flows), and the API access modal (codegen targets a broken URL). The spec catches that class of regression by exercising create, read, list, update, delete, and the negative paths around missing/non-existent IDs.
+
+If any of these tests fail against `langflowai/langflow-nightly:latest`, the flow persistence layer or its router has regressed and the next release is at risk.
+
+---
+
+## Tags *(required)*
+`@stable` `@release` `@api` `@regression`
+
+---
+
+## Step by step *(required)*
+
+The spec runs **9 independent tests** against `/api/v1/flows/` via Playwright's `request` fixture. Each test obtains a Bearer token through `getAuthToken()` (auto-login), creates its own ephemeral flow with a `Date.now()`-suffixed name to avoid collisions, and cleans up via `DELETE` at the end. No global setup/teardown.
+
+---
+
+**Test 1 — `POST creates flow and returns ID`**
+1. `POST /api/v1/flows/` with `{ name, description, data, is_component }`
+2. Assert HTTP status is `201`
+3. Assert response body has a non-empty string `id` and matching `name`
+4. Cleanup via `DELETE`
+
+**Test 2 — `GET lists flows and includes the created one`**
+1. Create a flow via `POST`
+2. `GET /api/v1/flows/`
+3. Assert HTTP status is `200` and the response is iterable (array or `{ flows: [...] }`)
+4. Assert the freshly created `id` is present in the list with the correct name
+5. Cleanup
+
+**Test 3 — `GET by ID returns correct flow`**
+1. Create a flow via `POST`
+2. `GET /api/v1/flows/{id}`
+3. Assert HTTP status is `200`
+4. Assert `body.id` and `body.name` match the created flow
+5. Cleanup
+
+**Test 4 — `PATCH updates flow name and description`**
+1. Create a flow via `POST`
+2. `PATCH /api/v1/flows/{id}` with `{ name, description }`
+3. Assert HTTP status is `200` and the PATCH response reflects both fields
+4. `GET /api/v1/flows/{id}` and assert persistence of both fields
+5. Cleanup
+
+**Test 5 — `DELETE removes flow and returns 200`**
+1. Create a flow via `POST`
+2. `DELETE /api/v1/flows/{id}`
+3. Assert HTTP status is `200`
+
+**Test 6 — `GET after DELETE returns 404`**
+1. Create a flow via `POST`
+2. `DELETE /api/v1/flows/{id}`
+3. `GET /api/v1/flows/{id}`
+4. Assert HTTP status is `404`
+
+**Test 7 — `GET non-existent flow returns 404`**
+1. `GET /api/v1/flows/{fakeUUID}` using `00000000-0000-0000-0000-000000000000`
+2. Assert HTTP status is `404`
+
+**Test 8 — `POST with missing name returns 422`**
+1. `POST /api/v1/flows/` with a body missing the `name` field
+2. Assert HTTP status is one of `400` or `422` (FastAPI returns 422 for missing required fields; tolerating 400 keeps the spec robust to backend stack changes)
+
+**Test 9 — `deleted flow does not appear in flows listing`**
+1. Create a flow via `POST`
+2. `DELETE /api/v1/flows/{id}`
+3. `GET /api/v1/flows/`
+4. Assert HTTP status is `200` and the deleted `id` is absent from the list
+
+---
+
+## Validation criterion *(required)*
+- All 9 tests pass 5× in a row against `langflowai/langflow-nightly:latest`.
+- Status codes match: `POST` returns `201`; `GET`/`PATCH`/`DELETE` on existing flows return `200`; operations against unknown IDs return `404`; missing required fields return `400` or `422`.
+- PATCH changes are durable: a subsequent `GET` reflects the new values.
+- Deleted flows disappear from both `GET /api/v1/flows/{id}` and the list endpoint.
+- Each test cleans up after itself — no orphan flows remain in the database after the suite completes.
+
+---
+
+## What this test does not cover *(optional)*
+- Flow **execution** via `POST /api/v1/run/{flow_id}` — covered by `api-run-flow.spec.ts` and `api-run-with-tweaks.spec.ts`.
+- Authentication failure modes (invalid API key, missing token) — covered by `api-invalid-key.spec.ts`.
+- Multi-user isolation (one user's flows not visible to another) — out of scope; would require seeding a second user.
+- Pagination, ordering, and filter parameters on `GET /api/v1/flows/` — the spec only asserts the unfiltered list contract.
+- Flow `data` field validation (nodes/edges schema) — the spec uses an empty data graph.
+
+---
+
+## Preconditions *(optional)*
+- Langflow running and reachable at `PLAYWRIGHT_BASE_URL` (default `http://localhost:7860`).
+- Auto-login enabled (the default in nightly) so `getAuthToken()` can mint a Bearer token. If auth is reconfigured, the helper at `tests/helpers/auth/get-auth-token.ts` must be updated first.
+
+---
+
+## External dependencies *(required)*
+<!-- Files from the Langflow repository that, if changed, could break this test. -->
+
+- `src/backend/base/langflow/api/v1/flows.py` — router that exposes `POST/GET/PATCH/DELETE /api/v1/flows/`; any signature, status code, or response shape change here directly affects the spec.
+- `src/backend/base/langflow/services/database/models/flow/model.py` — flow schema (name, description, data, is_component); renaming or removing a field breaks the POST payload and the PATCH/GET assertions.
+- `src/backend/base/langflow/api/utils.py` — shared API helpers used by the flows router (validation, current-user resolution); changes here can shift 422 vs 400 boundaries.

--- a/tests/tests-automations/regression/api/flows/api-flows-crud.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-flows-crud.spec.ts
@@ -12,7 +12,7 @@ test.describe("CRUD /api/v1/flows", () => {
   // Each test manages its own flow to remain independent
   test(
     "POST creates flow and returns ID",
-    { tag: ["@release", "@api", "@regression"] },
+    { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
       const authToken = await getAuthToken(request);
       const flowName = `API Test Flow - ${Date.now()}`;
@@ -39,7 +39,7 @@ test.describe("CRUD /api/v1/flows", () => {
 
   test(
     "GET lists flows and includes the created one",
-    { tag: ["@release", "@api", "@regression"] },
+    { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
       const authToken = await getAuthToken(request);
       const flowName = `API Test Flow List - ${Date.now()}`;
@@ -71,7 +71,7 @@ test.describe("CRUD /api/v1/flows", () => {
 
   test(
     "GET by ID returns correct flow",
-    { tag: ["@release", "@api", "@regression"] },
+    { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
       const authToken = await getAuthToken(request);
       const flowName = `API Test Flow Get - ${Date.now()}`;
@@ -100,12 +100,13 @@ test.describe("CRUD /api/v1/flows", () => {
   );
 
   test(
-    "PATCH updates flow name",
-    { tag: ["@release", "@api", "@regression"] },
+    "PATCH updates flow name and description",
+    { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
       const authToken = await getAuthToken(request);
       const flowName = `API Test Flow Patch - ${Date.now()}`;
       const updatedName = `${flowName} - Updated`;
+      const updatedDescription = "Updated description via PATCH";
 
       const createRes = await request.post("/api/v1/flows/", {
         headers: { Authorization: authToken },
@@ -116,12 +117,13 @@ test.describe("CRUD /api/v1/flows", () => {
 
       const patchRes = await request.patch(`/api/v1/flows/${id}`, {
         headers: { Authorization: authToken },
-        data: { name: updatedName },
+        data: { name: updatedName, description: updatedDescription },
       });
       expect(patchRes.status()).toBe(200);
 
       const updated = await patchRes.json();
       expect(updated.name).toBe(updatedName);
+      expect(updated.description).toBe(updatedDescription);
 
       // Confirm via GET
       const getRes = await request.get(`/api/v1/flows/${id}`, {
@@ -129,6 +131,7 @@ test.describe("CRUD /api/v1/flows", () => {
       });
       const fetched = await getRes.json();
       expect(fetched.name).toBe(updatedName);
+      expect(fetched.description).toBe(updatedDescription);
 
       // Cleanup
       await request.delete(`/api/v1/flows/${id}`, {
@@ -139,7 +142,7 @@ test.describe("CRUD /api/v1/flows", () => {
 
   test(
     "DELETE removes flow and returns 200",
-    { tag: ["@release", "@api", "@regression"] },
+    { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
       const authToken = await getAuthToken(request);
       const flowName = `API Test Flow Delete - ${Date.now()}`;
@@ -160,7 +163,7 @@ test.describe("CRUD /api/v1/flows", () => {
 
   test(
     "GET after DELETE returns 404",
-    { tag: ["@release", "@api", "@regression"] },
+    { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
       const authToken = await getAuthToken(request);
       const flowName = `API Test Flow 404 - ${Date.now()}`;
@@ -185,7 +188,7 @@ test.describe("CRUD /api/v1/flows", () => {
 
   test(
     "GET non-existent flow returns 404",
-    { tag: ["@release", "@api", "@regression"] },
+    { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
       const authToken = await getAuthToken(request);
       const fakeId = "00000000-0000-0000-0000-000000000000";
@@ -199,7 +202,7 @@ test.describe("CRUD /api/v1/flows", () => {
 
   test(
     "POST with missing name returns 422",
-    { tag: ["@release", "@api", "@regression"] },
+    { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
       const authToken = await getAuthToken(request);
 
@@ -214,7 +217,7 @@ test.describe("CRUD /api/v1/flows", () => {
 
   test(
     "deleted flow does not appear in flows listing",
-    { tag: ["@release", "@api", "@regression"] },
+    { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
       const authToken = await getAuthToken(request);
       const flowName = `API Test Flow Deleted List - ${Date.now()}`;

--- a/tests/tests-automations/regression/api/flows/api-flows-crud.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-flows-crud.spec.ts
@@ -1,9 +1,11 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 
+type Flow = { id: string; name: string; description?: string };
+
 const FLOW_BASE = {
   name: "",
-  description: "Criado pelo teste automatizado Playwright",
+  description: "Created by Playwright automated test",
   data: { nodes: [], edges: [], viewport: { x: 0, y: 0, zoom: 1 } },
   is_component: false,
 };
@@ -25,15 +27,19 @@ test.describe("CRUD /api/v1/flows", () => {
       expect(createRes.status()).toBe(201);
 
       const body = await createRes.json();
-      expect(body).toHaveProperty("id");
-      expect(typeof body.id).toBe("string");
-      expect(body.id.length).toBeGreaterThan(0);
-      expect(body.name).toBe(flowName);
 
-      // Cleanup
-      await request.delete(`/api/v1/flows/${body.id}`, {
-        headers: { Authorization: authToken },
-      });
+      try {
+        expect(body).toHaveProperty("id");
+        expect(typeof body.id).toBe("string");
+        expect(body.id.length).toBeGreaterThan(0);
+        expect(body.name).toBe(flowName);
+      } finally {
+        await request
+          .delete(`/api/v1/flows/${body.id}`, {
+            headers: { Authorization: authToken },
+          })
+          .catch(() => {});
+      }
     },
   );
 
@@ -51,21 +57,23 @@ test.describe("CRUD /api/v1/flows", () => {
       expect(createRes.status()).toBe(201);
       const { id } = await createRes.json();
 
-      const listRes = await request.get("/api/v1/flows/", {
-        headers: { Authorization: authToken },
-      });
-      expect(listRes.status()).toBe(200);
+      try {
+        const listRes = await request.get("/api/v1/flows/", {
+          headers: { Authorization: authToken },
+        });
+        expect(listRes.status()).toBe(200);
 
-      const flows = await listRes.json();
-      const flowList = Array.isArray(flows) ? flows : (flows.flows ?? []);
-      const found = flowList.find((f: any) => f.id === id);
-      expect(found).toBeDefined();
-      expect(found.name).toBe(flowName);
-
-      // Cleanup
-      await request.delete(`/api/v1/flows/${id}`, {
-        headers: { Authorization: authToken },
-      });
+        const flows = (await listRes.json()) as Flow[];
+        const found = flows.find((f) => f.id === id);
+        expect(found).toBeDefined();
+        expect(found?.name).toBe(flowName);
+      } finally {
+        await request
+          .delete(`/api/v1/flows/${id}`, {
+            headers: { Authorization: authToken },
+          })
+          .catch(() => {});
+      }
     },
   );
 
@@ -83,19 +91,22 @@ test.describe("CRUD /api/v1/flows", () => {
       expect(createRes.status()).toBe(201);
       const { id } = await createRes.json();
 
-      const getRes = await request.get(`/api/v1/flows/${id}`, {
-        headers: { Authorization: authToken },
-      });
-      expect(getRes.status()).toBe(200);
+      try {
+        const getRes = await request.get(`/api/v1/flows/${id}`, {
+          headers: { Authorization: authToken },
+        });
+        expect(getRes.status()).toBe(200);
 
-      const flow = await getRes.json();
-      expect(flow.id).toBe(id);
-      expect(flow.name).toBe(flowName);
-
-      // Cleanup
-      await request.delete(`/api/v1/flows/${id}`, {
-        headers: { Authorization: authToken },
-      });
+        const flow = await getRes.json();
+        expect(flow.id).toBe(id);
+        expect(flow.name).toBe(flowName);
+      } finally {
+        await request
+          .delete(`/api/v1/flows/${id}`, {
+            headers: { Authorization: authToken },
+          })
+          .catch(() => {});
+      }
     },
   );
 
@@ -115,28 +126,31 @@ test.describe("CRUD /api/v1/flows", () => {
       expect(createRes.status()).toBe(201);
       const { id } = await createRes.json();
 
-      const patchRes = await request.patch(`/api/v1/flows/${id}`, {
-        headers: { Authorization: authToken },
-        data: { name: updatedName, description: updatedDescription },
-      });
-      expect(patchRes.status()).toBe(200);
+      try {
+        const patchRes = await request.patch(`/api/v1/flows/${id}`, {
+          headers: { Authorization: authToken },
+          data: { name: updatedName, description: updatedDescription },
+        });
+        expect(patchRes.status()).toBe(200);
 
-      const updated = await patchRes.json();
-      expect(updated.name).toBe(updatedName);
-      expect(updated.description).toBe(updatedDescription);
+        const updated = await patchRes.json();
+        expect(updated.name).toBe(updatedName);
+        expect(updated.description).toBe(updatedDescription);
 
-      // Confirm via GET
-      const getRes = await request.get(`/api/v1/flows/${id}`, {
-        headers: { Authorization: authToken },
-      });
-      const fetched = await getRes.json();
-      expect(fetched.name).toBe(updatedName);
-      expect(fetched.description).toBe(updatedDescription);
-
-      // Cleanup
-      await request.delete(`/api/v1/flows/${id}`, {
-        headers: { Authorization: authToken },
-      });
+        // Confirm via GET
+        const getRes = await request.get(`/api/v1/flows/${id}`, {
+          headers: { Authorization: authToken },
+        });
+        const fetched = await getRes.json();
+        expect(fetched.name).toBe(updatedName);
+        expect(fetched.description).toBe(updatedDescription);
+      } finally {
+        await request
+          .delete(`/api/v1/flows/${id}`, {
+            headers: { Authorization: authToken },
+          })
+          .catch(() => {});
+      }
     },
   );
 
@@ -208,9 +222,10 @@ test.describe("CRUD /api/v1/flows", () => {
 
       const res = await request.post("/api/v1/flows/", {
         headers: { Authorization: authToken },
-        data: { description: "Flow sem nome" },
+        data: { description: "Flow without name" },
       });
-      // 422 Unprocessable Entity for missing required field
+      // Accept 400 or 422: FastAPI returns 422 for missing required fields,
+      // but the boundary may shift with backend stack changes.
       expect([400, 422]).toContain(res.status());
     },
   );
@@ -238,9 +253,8 @@ test.describe("CRUD /api/v1/flows", () => {
       });
       expect(listRes.status()).toBe(200);
 
-      const flows = await listRes.json();
-      const flowList = Array.isArray(flows) ? flows : (flows.flows ?? []);
-      const found = flowList.find((f: any) => f.id === id);
+      const flows = (await listRes.json()) as Flow[];
+      const found = flows.find((f) => f.id === id);
       expect(found).toBeUndefined();
     },
   );

--- a/tests/tests-automations/regression/api/flows/api-flows-crud.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-flows-crud.spec.ts
@@ -19,26 +19,30 @@ test.describe("CRUD /api/v1/flows", () => {
       const authToken = await getAuthToken(request);
       const flowName = `API Test Flow - ${Date.now()}`;
 
-      const createRes = await request.post("/api/v1/flows/", {
-        headers: { Authorization: authToken },
-        data: { ...FLOW_BASE, name: flowName },
+      const body = await test.step("POST /api/v1/flows/ with valid payload", async () => {
+        const createRes = await request.post("/api/v1/flows/", {
+          headers: { Authorization: authToken },
+          data: { ...FLOW_BASE, name: flowName },
+        });
+        expect(createRes.status()).toBe(201);
+        return createRes.json();
       });
 
-      expect(createRes.status()).toBe(201);
-
-      const body = await createRes.json();
-
       try {
-        expect(body).toHaveProperty("id");
-        expect(typeof body.id).toBe("string");
-        expect(body.id.length).toBeGreaterThan(0);
-        expect(body.name).toBe(flowName);
+        await test.step("response body contains a non-empty id and matching name", async () => {
+          expect(body).toHaveProperty("id");
+          expect(typeof body.id).toBe("string");
+          expect(body.id.length).toBeGreaterThan(0);
+          expect(body.name).toBe(flowName);
+        });
       } finally {
-        await request
-          .delete(`/api/v1/flows/${body.id}`, {
-            headers: { Authorization: authToken },
-          })
-          .catch(() => {});
+        await test.step("cleanup created flow", async () => {
+          await request
+            .delete(`/api/v1/flows/${body.id}`, {
+              headers: { Authorization: authToken },
+            })
+            .catch(() => {});
+        });
       }
     },
   );
@@ -50,29 +54,36 @@ test.describe("CRUD /api/v1/flows", () => {
       const authToken = await getAuthToken(request);
       const flowName = `API Test Flow List - ${Date.now()}`;
 
-      const createRes = await request.post("/api/v1/flows/", {
-        headers: { Authorization: authToken },
-        data: { ...FLOW_BASE, name: flowName },
+      const id = await test.step("create a flow via POST", async () => {
+        const createRes = await request.post("/api/v1/flows/", {
+          headers: { Authorization: authToken },
+          data: { ...FLOW_BASE, name: flowName },
+        });
+        expect(createRes.status()).toBe(201);
+        const json = await createRes.json();
+        return json.id as string;
       });
-      expect(createRes.status()).toBe(201);
-      const { id } = await createRes.json();
 
       try {
-        const listRes = await request.get("/api/v1/flows/", {
-          headers: { Authorization: authToken },
-        });
-        expect(listRes.status()).toBe(200);
-
-        const flows = (await listRes.json()) as Flow[];
-        const found = flows.find((f) => f.id === id);
-        expect(found).toBeDefined();
-        expect(found?.name).toBe(flowName);
-      } finally {
-        await request
-          .delete(`/api/v1/flows/${id}`, {
+        await test.step("GET /api/v1/flows/ returns 200 and includes the created flow", async () => {
+          const listRes = await request.get("/api/v1/flows/", {
             headers: { Authorization: authToken },
-          })
-          .catch(() => {});
+          });
+          expect(listRes.status()).toBe(200);
+
+          const flows = (await listRes.json()) as Flow[];
+          const found = flows.find((f) => f.id === id);
+          expect(found).toBeDefined();
+          expect(found?.name).toBe(flowName);
+        });
+      } finally {
+        await test.step("cleanup created flow", async () => {
+          await request
+            .delete(`/api/v1/flows/${id}`, {
+              headers: { Authorization: authToken },
+            })
+            .catch(() => {});
+        });
       }
     },
   );
@@ -84,28 +95,35 @@ test.describe("CRUD /api/v1/flows", () => {
       const authToken = await getAuthToken(request);
       const flowName = `API Test Flow Get - ${Date.now()}`;
 
-      const createRes = await request.post("/api/v1/flows/", {
-        headers: { Authorization: authToken },
-        data: { ...FLOW_BASE, name: flowName },
+      const id = await test.step("create a flow via POST", async () => {
+        const createRes = await request.post("/api/v1/flows/", {
+          headers: { Authorization: authToken },
+          data: { ...FLOW_BASE, name: flowName },
+        });
+        expect(createRes.status()).toBe(201);
+        const json = await createRes.json();
+        return json.id as string;
       });
-      expect(createRes.status()).toBe(201);
-      const { id } = await createRes.json();
 
       try {
-        const getRes = await request.get(`/api/v1/flows/${id}`, {
-          headers: { Authorization: authToken },
-        });
-        expect(getRes.status()).toBe(200);
-
-        const flow = await getRes.json();
-        expect(flow.id).toBe(id);
-        expect(flow.name).toBe(flowName);
-      } finally {
-        await request
-          .delete(`/api/v1/flows/${id}`, {
+        await test.step("GET /api/v1/flows/{id} returns 200 and matches the created flow", async () => {
+          const getRes = await request.get(`/api/v1/flows/${id}`, {
             headers: { Authorization: authToken },
-          })
-          .catch(() => {});
+          });
+          expect(getRes.status()).toBe(200);
+
+          const flow = await getRes.json();
+          expect(flow.id).toBe(id);
+          expect(flow.name).toBe(flowName);
+        });
+      } finally {
+        await test.step("cleanup created flow", async () => {
+          await request
+            .delete(`/api/v1/flows/${id}`, {
+              headers: { Authorization: authToken },
+            })
+            .catch(() => {});
+        });
       }
     },
   );
@@ -119,37 +137,45 @@ test.describe("CRUD /api/v1/flows", () => {
       const updatedName = `${flowName} - Updated`;
       const updatedDescription = "Updated description via PATCH";
 
-      const createRes = await request.post("/api/v1/flows/", {
-        headers: { Authorization: authToken },
-        data: { ...FLOW_BASE, name: flowName },
+      const id = await test.step("create a flow via POST", async () => {
+        const createRes = await request.post("/api/v1/flows/", {
+          headers: { Authorization: authToken },
+          data: { ...FLOW_BASE, name: flowName },
+        });
+        expect(createRes.status()).toBe(201);
+        const json = await createRes.json();
+        return json.id as string;
       });
-      expect(createRes.status()).toBe(201);
-      const { id } = await createRes.json();
 
       try {
-        const patchRes = await request.patch(`/api/v1/flows/${id}`, {
-          headers: { Authorization: authToken },
-          data: { name: updatedName, description: updatedDescription },
-        });
-        expect(patchRes.status()).toBe(200);
-
-        const updated = await patchRes.json();
-        expect(updated.name).toBe(updatedName);
-        expect(updated.description).toBe(updatedDescription);
-
-        // Confirm via GET
-        const getRes = await request.get(`/api/v1/flows/${id}`, {
-          headers: { Authorization: authToken },
-        });
-        const fetched = await getRes.json();
-        expect(fetched.name).toBe(updatedName);
-        expect(fetched.description).toBe(updatedDescription);
-      } finally {
-        await request
-          .delete(`/api/v1/flows/${id}`, {
+        await test.step("PATCH /api/v1/flows/{id} returns 200 with updated name and description", async () => {
+          const patchRes = await request.patch(`/api/v1/flows/${id}`, {
             headers: { Authorization: authToken },
-          })
-          .catch(() => {});
+            data: { name: updatedName, description: updatedDescription },
+          });
+          expect(patchRes.status()).toBe(200);
+
+          const updated = await patchRes.json();
+          expect(updated.name).toBe(updatedName);
+          expect(updated.description).toBe(updatedDescription);
+        });
+
+        await test.step("subsequent GET reflects the new name and description", async () => {
+          const getRes = await request.get(`/api/v1/flows/${id}`, {
+            headers: { Authorization: authToken },
+          });
+          const fetched = await getRes.json();
+          expect(fetched.name).toBe(updatedName);
+          expect(fetched.description).toBe(updatedDescription);
+        });
+      } finally {
+        await test.step("cleanup created flow", async () => {
+          await request
+            .delete(`/api/v1/flows/${id}`, {
+              headers: { Authorization: authToken },
+            })
+            .catch(() => {});
+        });
       }
     },
   );
@@ -161,17 +187,22 @@ test.describe("CRUD /api/v1/flows", () => {
       const authToken = await getAuthToken(request);
       const flowName = `API Test Flow Delete - ${Date.now()}`;
 
-      const createRes = await request.post("/api/v1/flows/", {
-        headers: { Authorization: authToken },
-        data: { ...FLOW_BASE, name: flowName },
+      const id = await test.step("create a flow via POST", async () => {
+        const createRes = await request.post("/api/v1/flows/", {
+          headers: { Authorization: authToken },
+          data: { ...FLOW_BASE, name: flowName },
+        });
+        expect(createRes.status()).toBe(201);
+        const json = await createRes.json();
+        return json.id as string;
       });
-      expect(createRes.status()).toBe(201);
-      const { id } = await createRes.json();
 
-      const deleteRes = await request.delete(`/api/v1/flows/${id}`, {
-        headers: { Authorization: authToken },
+      await test.step("DELETE /api/v1/flows/{id} returns 200", async () => {
+        const deleteRes = await request.delete(`/api/v1/flows/${id}`, {
+          headers: { Authorization: authToken },
+        });
+        expect(deleteRes.status()).toBe(200);
       });
-      expect(deleteRes.status()).toBe(200);
     },
   );
 
@@ -182,21 +213,28 @@ test.describe("CRUD /api/v1/flows", () => {
       const authToken = await getAuthToken(request);
       const flowName = `API Test Flow 404 - ${Date.now()}`;
 
-      const createRes = await request.post("/api/v1/flows/", {
-        headers: { Authorization: authToken },
-        data: { ...FLOW_BASE, name: flowName },
+      const id = await test.step("create a flow via POST", async () => {
+        const createRes = await request.post("/api/v1/flows/", {
+          headers: { Authorization: authToken },
+          data: { ...FLOW_BASE, name: flowName },
+        });
+        expect(createRes.status()).toBe(201);
+        const json = await createRes.json();
+        return json.id as string;
       });
-      expect(createRes.status()).toBe(201);
-      const { id } = await createRes.json();
 
-      await request.delete(`/api/v1/flows/${id}`, {
-        headers: { Authorization: authToken },
+      await test.step("DELETE the flow", async () => {
+        await request.delete(`/api/v1/flows/${id}`, {
+          headers: { Authorization: authToken },
+        });
       });
 
-      const getRes = await request.get(`/api/v1/flows/${id}`, {
-        headers: { Authorization: authToken },
+      await test.step("GET /api/v1/flows/{id} returns 404 after deletion", async () => {
+        const getRes = await request.get(`/api/v1/flows/${id}`, {
+          headers: { Authorization: authToken },
+        });
+        expect(getRes.status()).toBe(404);
       });
-      expect(getRes.status()).toBe(404);
     },
   );
 
@@ -207,10 +245,12 @@ test.describe("CRUD /api/v1/flows", () => {
       const authToken = await getAuthToken(request);
       const fakeId = "00000000-0000-0000-0000-000000000000";
 
-      const res = await request.get(`/api/v1/flows/${fakeId}`, {
-        headers: { Authorization: authToken },
+      await test.step("GET /api/v1/flows/{fakeUUID} returns 404", async () => {
+        const res = await request.get(`/api/v1/flows/${fakeId}`, {
+          headers: { Authorization: authToken },
+        });
+        expect(res.status()).toBe(404);
       });
-      expect(res.status()).toBe(404);
     },
   );
 
@@ -220,13 +260,15 @@ test.describe("CRUD /api/v1/flows", () => {
     async ({ request }) => {
       const authToken = await getAuthToken(request);
 
-      const res = await request.post("/api/v1/flows/", {
-        headers: { Authorization: authToken },
-        data: { description: "Flow without name" },
+      await test.step("POST /api/v1/flows/ without required name returns 400 or 422", async () => {
+        const res = await request.post("/api/v1/flows/", {
+          headers: { Authorization: authToken },
+          data: { description: "Flow without name" },
+        });
+        // Accept 400 or 422: FastAPI returns 422 for missing required fields,
+        // but the boundary may shift with backend stack changes.
+        expect([400, 422]).toContain(res.status());
       });
-      // Accept 400 or 422: FastAPI returns 422 for missing required fields,
-      // but the boundary may shift with backend stack changes.
-      expect([400, 422]).toContain(res.status());
     },
   );
 
@@ -237,25 +279,32 @@ test.describe("CRUD /api/v1/flows", () => {
       const authToken = await getAuthToken(request);
       const flowName = `API Test Flow Deleted List - ${Date.now()}`;
 
-      const createRes = await request.post("/api/v1/flows/", {
-        headers: { Authorization: authToken },
-        data: { ...FLOW_BASE, name: flowName },
+      const id = await test.step("create a flow via POST", async () => {
+        const createRes = await request.post("/api/v1/flows/", {
+          headers: { Authorization: authToken },
+          data: { ...FLOW_BASE, name: flowName },
+        });
+        expect(createRes.status()).toBe(201);
+        const json = await createRes.json();
+        return json.id as string;
       });
-      expect(createRes.status()).toBe(201);
-      const { id } = await createRes.json();
 
-      await request.delete(`/api/v1/flows/${id}`, {
-        headers: { Authorization: authToken },
+      await test.step("DELETE the flow", async () => {
+        await request.delete(`/api/v1/flows/${id}`, {
+          headers: { Authorization: authToken },
+        });
       });
 
-      const listRes = await request.get("/api/v1/flows/", {
-        headers: { Authorization: authToken },
-      });
-      expect(listRes.status()).toBe(200);
+      await test.step("GET /api/v1/flows/ does not include the deleted flow", async () => {
+        const listRes = await request.get("/api/v1/flows/", {
+          headers: { Authorization: authToken },
+        });
+        expect(listRes.status()).toBe(200);
 
-      const flows = (await listRes.json()) as Flow[];
-      const found = flows.find((f) => f.id === id);
-      expect(found).toBeUndefined();
+        const flows = (await listRes.json()) as Flow[];
+        const found = flows.find((f) => f.id === id);
+        expect(found).toBeUndefined();
+      });
     },
   );
 });


### PR DESCRIPTION
## Summary

- Tag all 9 `test()` blocks in `api-flows-crud.spec.ts` with `@stable`
- Extend the PATCH test to cover both `name` and `description` (closes the `name/description` bullet)
- Add `docs/api/flows/api-flows-crud.md` spec doc with all mandatory sections
- Mark the 6 bullets in `QA-CHECKLIST.md` section **1.2 Flow CRUD via API** as `[x]` with link to the spec

## Bullet → test mapping

| Checklist bullet (1.2) | Test |
|---|---|
| POST `/api/v1/flows/` creates flow | `POST creates flow and returns ID` |
| GET `/api/v1/flows/` lists user flows | `GET lists flows and includes the created one` |
| GET `/api/v1/flows/{id}` returns flow | `GET by ID returns correct flow` |
| PATCH `/api/v1/flows/{id}` updates name/description | `PATCH updates flow name and description` |
| DELETE `/api/v1/flows/{id}` returns 200 | `DELETE removes flow and returns 200` |
| GET after DELETE returns 404 | `GET after DELETE returns 404` |

Bonus coverage retained: `GET non-existent flow returns 404`, `POST with missing name returns 422`, `deleted flow does not appear in flows listing`.

## Test plan
- [x] Spec passes 5× in a row locally against `langflowai/langflow-nightly:latest` (9/9 each run, ~2s)
- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — clean
- [x] Spec doc covers all mandatory sections (What this test validates / Tags / Validation criterion / External dependencies)

Closes #247