### PR TITLE
feat(ci): add docker-compose migration job (uses official upstream compose)

### DIFF
--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -279,3 +279,322 @@ jobs:
                 labels: ['migration-test', 'automated'],
               });
             }
+
+  # ─────────────────────────────────────────────────────────────────
+  # Companion job: same source → target migration via docker-compose,
+  # using the OFFICIAL compose file from langflow-ai/langflow's
+  # docker_example/docker-compose.yml (fetched at runtime). Catches
+  # bugs that only manifest in the user-facing deployment path:
+  # named volumes for Postgres, service-name DNS resolution,
+  # depends_on ordering, restart-on-recreate semantics.
+  # ─────────────────────────────────────────────────────────────────
+  migration-test-compose:
+    name: Migration via docker-compose (Postgres + named volumes)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      LF_URL: http://localhost:7860
+      COMPOSE_DIR: /tmp/migration-compose
+      OFFICIAL_COMPOSE_URL: https://raw.githubusercontent.com/langflow-ai/langflow/main/docker_example/docker-compose.yml
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify OPENAI_API_KEY secret is configured
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [[ -z "$OPENAI_API_KEY" ]]; then
+            echo "::error::OPENAI_API_KEY repository secret is required."
+            exit 1
+          fi
+          echo "OPENAI_API_KEY is configured."
+
+      - name: Generate ephemeral SECRET_KEY
+        run: |
+          python3 - <<'PY' >> "$GITHUB_ENV"
+          import base64, os
+          print(f"LANGFLOW_SECRET_KEY={base64.urlsafe_b64encode(os.urandom(32)).decode()}")
+          PY
+
+      - name: Fetch official docker-compose.yml from langflow-ai/langflow
+        run: |
+          mkdir -p "$COMPOSE_DIR" /tmp/logs
+          curl -fsSL "$OFFICIAL_COMPOSE_URL" -o "$COMPOSE_DIR/docker-compose.yml"
+          echo "=== Fetched official compose ($(wc -l < "$COMPOSE_DIR/docker-compose.yml") lines) ==="
+          cat "$COMPOSE_DIR/docker-compose.yml"
+          # Save raw copy as artifact for traceability
+          cp "$COMPOSE_DIR/docker-compose.yml" /tmp/logs/official-compose-snapshot.yml
+
+      - name: Write override + .env
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          # Override file: pin the langflow image via env var substitution and
+          # inject our auth + credential env vars. Default LANGFLOW_IMAGE is
+          # the upstream `langflow:latest`; we'll flip it to nightly between
+          # phases.
+          cat > "$COMPOSE_DIR/docker-compose.override.yml" <<'YAML'
+          services:
+            langflow:
+              image: ${LANGFLOW_IMAGE:-langflowai/langflow:latest}
+              environment:
+                - LANGFLOW_SECRET_KEY=${LANGFLOW_SECRET_KEY}
+                - OPENAI_API_KEY=${OPENAI_API_KEY}
+                - LANGFLOW_AUTO_LOGIN=true
+                - LANGFLOW_SUPERUSER=langflow
+                - LANGFLOW_SUPERUSER_PASSWORD=langflow123
+                - LANGFLOW_STORE=false
+          YAML
+
+          # .env consumed by docker compose for variable substitution
+          cat > "$COMPOSE_DIR/.env" <<EOF
+          LANGFLOW_IMAGE=langflowai/langflow:latest
+          LANGFLOW_SECRET_KEY=${LANGFLOW_SECRET_KEY}
+          OPENAI_API_KEY=${OPENAI_API_KEY}
+          EOF
+          chmod 600 "$COMPOSE_DIR/.env"
+
+          echo "=== docker-compose.override.yml ==="
+          cat "$COMPOSE_DIR/docker-compose.override.yml"
+          echo "=== docker compose config (merged, secrets redacted) ==="
+          (cd "$COMPOSE_DIR" && OPENAI_API_KEY=REDACTED LANGFLOW_SECRET_KEY=REDACTED docker compose config) || true
+
+      # ── Phase 1: Source (latest) via docker compose ──────────────
+      - name: "[SOURCE] docker compose up -d (langflowai/langflow:latest)"
+        working-directory: ${{ env.COMPOSE_DIR }}
+        run: docker compose up -d
+
+      - name: "[SOURCE] Wait for /health_check"
+        run: |
+          for i in $(seq 1 72); do
+            sleep 5
+            if curl -fsS "${LF_URL}/health_check" >/dev/null 2>&1; then
+              echo "Source up after $((i*5))s"
+              break
+            fi
+            if [[ $i -eq 72 ]]; then
+              echo "::error::Source did not become healthy in 360s"
+              (cd "$COMPOSE_DIR" && docker compose logs --tail=120)
+              exit 1
+            fi
+          done
+
+      - name: "[SOURCE] Create witness flow + execute (Simple Agent)"
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          set -e
+          TOKEN=$(curl -s "${LF_URL}/api/v1/auto_login" | jq -r '.access_token // empty')
+          [[ -z "$TOKEN" ]] && { echo "::error::auto_login failed on source"; exit 1; }
+
+          # Confirm Langflow auto-imported OPENAI_API_KEY as a Credential
+          VAR_COUNT=$(curl -s -H "Authorization: Bearer $TOKEN" \
+            "${LF_URL}/api/v1/variables/" \
+            | jq '[.[] | select(.name == "OPENAI_API_KEY")] | length')
+          if [[ "$VAR_COUNT" -ne "1" ]]; then
+            echo "::error::Expected 1 auto-imported OPENAI_API_KEY Variable on source, got ${VAR_COUNT}"
+            exit 1
+          fi
+          echo "Auto-imported Credential confirmed on source"
+
+          STARTERS=$(curl -s -H "Authorization: Bearer $TOKEN" "${LF_URL}/api/v1/starter-projects/")
+          TEMPLATE=$(echo "$STARTERS" | jq -c '
+            [.[] | select((.name // "" | ascii_downcase) | contains("simple agent") or contains("basic agent"))][0]
+          ')
+          [[ -z "$TEMPLATE" || "$TEMPLATE" == "null" ]] && {
+            echo "::error::Simple Agent starter not found"; exit 1; }
+          FLOW_PAYLOAD=$(echo "$TEMPLATE" | jq '{
+            name: ((.name // "Simple Agent") + " — migration witness"),
+            description: "compose migration witness",
+            data: .data,
+            endpoint_name: .endpoint_name
+          }')
+          WITNESS_ID=$(curl -s -X POST "${LF_URL}/api/v1/flows/" \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$FLOW_PAYLOAD" | jq -r '.id // empty')
+          [[ -z "$WITNESS_ID" ]] && { echo "::error::Failed to create witness flow"; exit 1; }
+          echo "$WITNESS_ID" > /tmp/witness-id.txt
+          echo "Witness flow: $WITNESS_ID"
+
+          # Smoke: execute it on source so we know it works before migration
+          HTTP=$(curl -s -o /tmp/run-source.json -w "%{http_code}" \
+            -X POST "${LF_URL}/api/v1/run/${WITNESS_ID}" \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Content-Type: application/json" \
+            --max-time 120 \
+            -d '{"input_value":"What is 2+2? Answer with just the number.","output_type":"chat","input_type":"chat"}')
+          if [[ "$HTTP" != "200" ]]; then
+            echo "::error::Source flow execution returned HTTP $HTTP"
+            head -c 2000 /tmp/run-source.json
+            exit 1
+          fi
+          echo "Source flow execution OK"
+
+      - name: "[SOURCE] Stop langflow (preserve volumes)"
+        if: always()
+        working-directory: ${{ env.COMPOSE_DIR }}
+        run: |
+          docker compose logs langflow > /tmp/logs/compose-source-langflow.log 2>&1 || true
+          docker compose stop langflow
+
+      # ── Phase 2: Target (nightly) via docker compose ─────────────
+      - name: "[TARGET] Switch image to nightly + compose up"
+        working-directory: ${{ env.COMPOSE_DIR }}
+        run: |
+          # Flip LANGFLOW_IMAGE; postgres volume stays intact
+          sed -i 's|^LANGFLOW_IMAGE=.*|LANGFLOW_IMAGE=langflowai/langflow-nightly:latest|' .env
+          grep LANGFLOW_IMAGE .env
+          docker compose up -d langflow
+
+      - name: "[TARGET] Wait for /health_check (migration runs)"
+        run: |
+          for i in $(seq 1 72); do
+            sleep 5
+            if curl -fsS "${LF_URL}/health_check" >/dev/null 2>&1; then
+              echo "Target up after $((i*5))s"
+              break
+            fi
+            if [[ $i -eq 72 ]]; then
+              echo "::error::Target did not become healthy — likely migration failure"
+              (cd "$COMPOSE_DIR" && docker compose logs langflow --tail=200)
+              exit 1
+            fi
+          done
+
+      - name: "[TARGET] Verify witness flow + execute"
+        run: |
+          set -e
+          TOKEN=$(curl -s "${LF_URL}/api/v1/auto_login" | jq -r '.access_token // empty')
+          [[ -z "$TOKEN" ]] && { echo "::error::auto_login failed on target"; exit 1; }
+
+          WITNESS_ID=$(cat /tmp/witness-id.txt)
+          STATUS=$(curl -s -o /tmp/witness-resp.json -w "%{http_code}" \
+            -H "Authorization: Bearer $TOKEN" \
+            "${LF_URL}/api/v1/flows/${WITNESS_ID}")
+          if [[ "$STATUS" != "200" ]]; then
+            echo "::error::Witness flow lost after compose migration: HTTP $STATUS"
+            cat /tmp/witness-resp.json
+            exit 1
+          fi
+          echo "Witness flow preserved"
+
+          VAR_COUNT=$(curl -s -H "Authorization: Bearer $TOKEN" \
+            "${LF_URL}/api/v1/variables/" \
+            | jq '[.[] | select(.name == "OPENAI_API_KEY")] | length')
+          if [[ "$VAR_COUNT" -ne "1" ]]; then
+            echo "::error::OPENAI_API_KEY Variable count on target: $VAR_COUNT (expected 1)"
+            exit 1
+          fi
+          echo "OPENAI_API_KEY Variable preserved"
+
+          HTTP=$(curl -s -o /tmp/run-target.json -w "%{http_code}" \
+            -X POST "${LF_URL}/api/v1/run/${WITNESS_ID}" \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Content-Type: application/json" \
+            --max-time 120 \
+            -d '{"input_value":"What is 2+2? Answer with just the number.","output_type":"chat","input_type":"chat"}')
+          if [[ "$HTTP" != "200" ]]; then
+            echo "::error::Target flow execution returned HTTP $HTTP (Fernet/migration regression)"
+            head -c 2000 /tmp/run-target.json
+            exit 1
+          fi
+          if grep -iE 'api[ _-]?key.{0,30}(required|missing|not[ _]?found)|fernet|cannot[ _]decrypt' /tmp/run-target.json; then
+            echo "::error::Target run body indicates credential / Fernet issue"
+            head -c 2000 /tmp/run-target.json
+            exit 1
+          fi
+          echo "Target flow execution OK"
+
+      - name: Save logs + cleanup
+        if: always()
+        working-directory: ${{ env.COMPOSE_DIR }}
+        run: |
+          docker compose logs langflow > /tmp/logs/compose-target-langflow.log 2>&1 || true
+          docker compose logs postgres > /tmp/logs/compose-postgres.log 2>&1 || true
+          docker compose down -v
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: migration-compose-${{ github.run_number }}
+          path: |
+            /tmp/logs/
+            /tmp/witness-id.txt
+            /tmp/run-source.json
+            /tmp/run-target.json
+          retention-days: 30
+
+      - name: Close issue on success
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'migration-compose',
+              state: 'open',
+            });
+            if (existing.length > 0) {
+              const issue = existing[0];
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: [
+                  `## ✅ Run #${context.runNumber} — ${new Date().toISOString().split('T')[0]}`,
+                  '',
+                  'docker-compose migration test passed. Closing.',
+                  '',
+                  `[Workflow Run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+                ].join('\n'),
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              });
+            }
+
+      - name: Create or update issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'migration-compose',
+              state: 'open',
+            });
+            const body = [
+              `## Run #${context.runNumber} — ${new Date().toISOString().split('T')[0]}`,
+              '',
+              `docker-compose migration test failed. Source: \`langflowai/langflow:latest\` → Target: \`langflowai/langflow-nightly:latest\`.`,
+              `Compose file: pinned to upstream main of \`langflow-ai/langflow/docker_example/docker-compose.yml\`.`,
+              '',
+              `[Workflow Run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+              '',
+              '/cc @lice-reis',
+            ].join('\n');
+
+            if (existing.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing[0].number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: 'Langflow Migration via docker-compose Failed (latest → nightly)',
+                body,
+                labels: ['migration-compose', 'automated'],
+              });
+            }


### PR DESCRIPTION
## Summary

Adds a parallel job \`migration-test-compose\` inside \`migration-test.yml\` that runs the same source → target migration scenario via the **official Langflow docker-compose.yml** from [langflow-ai/langflow/docker_example](https://github.com/langflow-ai/langflow/blob/main/docker_example/docker-compose.yml), fetched at runtime from upstream main.

Both jobs run in parallel on the same trigger (daily cron + manual dispatch). They share no state — failure on one doesn't block the other, and each opens its own GitHub issue on failure (\`migration-test\` label vs \`migration-compose\` label).

## Why

The existing \`migration-test\` job exercises the schema migration via \`uv pip install\` + \`uv run langflow run\`. That's good for validating Alembic, but it **bypasses the deployment path most production users actually follow**. Bugs that only surface in the compose deployment — named Postgres volumes, depends_on ordering, service-name DNS resolution, the \`docker compose pull / down / up\` lifecycle — would be missed.

## How

1. **Fetch** \`docker_example/docker-compose.yml\` from upstream main → \`/tmp/migration-compose/docker-compose.yml\` (left untouched; snapshot saved as artifact for traceability).
2. **Write override** \`docker-compose.override.yml\` + \`.env\` to:
   - Pin \`LANGFLOW_IMAGE\` via env var substitution
   - Inject \`OPENAI_API_KEY\`, \`LANGFLOW_SECRET_KEY\`, \`LANGFLOW_AUTO_LOGIN=true\`, superuser creds, \`LANGFLOW_STORE=false\`
3. **Phase 1 (source = latest)**: \`docker compose up -d\` → wait for \`/health_check\` → confirm OPENAI_API_KEY auto-imported → create Simple Agent witness flow → execute it (Fernet end-to-end smoke).
4. **Phase 2 (target = nightly)**: \`docker compose stop langflow\` (preserves the \`langflow-postgres\` named volume) → flip \`LANGFLOW_IMAGE\` to nightly in \`.env\` → \`docker compose up -d langflow\` → wait for migration → verify witness flow + variable survived → re-execute the flow.
5. **Cleanup** with \`docker compose down -v\`.

## Artifacts

- \`logs/\`: source and target Langflow container logs, postgres logs
- \`logs/official-compose-snapshot.yml\`: the exact upstream file fetched (so future regressions vs upstream are diff-able)
- \`witness-id.txt\`: ID of the witness flow
- \`run-source.json\`, \`run-target.json\`: full responses from the pre/post-migration flow executions

## Test plan

- [ ] Trigger after merge via \`workflow_dispatch\` — both jobs should run; compose job should pass green
- [ ] Confirm compose snapshot is present in artifacts
- [ ] Confirm \`logs/compose-target-langflow.log\` shows the alembic migration completing

## Out of scope

- The success-case summary report (\`migration-summary.md\`) is **not** in this PR — that's the next step, applied uniformly across \`migration-test\`, \`migration-test-compose\`, \`migration-upgrade-with-flows\`, and \`migration-manual\` (open in #242).

🤖 Generated with [Claude Code](https://claude.com/claude-code)