### PR TITLE
fix(ci): unify migration-compose issue label with migration-test

### DIFF
--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -535,7 +535,7 @@ jobs:
             const { data: existing } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: 'migration-compose',
+              labels: 'migration-test',
               state: 'open',
             });
             if (existing.length > 0) {
@@ -568,7 +568,7 @@ jobs:
             const { data: existing } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: 'migration-compose',
+              labels: 'migration-test',
               state: 'open',
             });
             const body = [
@@ -593,8 +593,8 @@ jobs:
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                title: 'Langflow Migration via docker-compose Failed (latest → nightly)',
+                title: 'Langflow Migration Test Failed (latest → nightly)',
                 body,
-                labels: ['migration-compose', 'automated'],
+                labels: ['migration-test', 'automated'],
               });
             }


### PR DESCRIPTION
## Summary

Follow-up to merged PR #256. The compose-job's issue handler was using a separate \`migration-compose\` label, but per review feedback after merge, the docker-compose job is just the migration test running in a different deployment environment — not a separate concern. Both jobs now share the \`migration-test\` label so failures fold into a single issue lifecycle.

The compose failure body still mentions \"docker-compose migration test\" in plain text, so the variant is distinguishable on read.

## Change

Four occurrences of \`migration-compose\` → \`migration-test\` in \`.github/workflows/migration-test.yml\`:
- 2× in the close-on-success script (label filter)
- 1× in the create-on-failure script (label filter)
- 1× in the create-on-failure script (labels assigned to new issue)
- Issue title also normalized to match the other job

## Note

This fix was intended to be applied before #256 merged, but landed on the now-stale \`feat/migration-compose-job\` branch (commit \`eee95dd\`) after the merge. Re-applying it cleanly here on a branch off the current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)