### PR TITLE
test(api-run-flow): promote to @stable and add spec doc

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -92,12 +92,12 @@
 - [x] GET `/api/v1/flows/{id}` after DELETE → should return 404 → `api/flows/api-flows-crud.spec.ts`
 
 #### 1.3 Flow Execution via API
-- [-] POST `/api/v1/run/{flow_id}` with `input_value` → returns response
+- [x] POST `/api/v1/run/{flow_id}` with `input_value` → returns response → `api/flows/api-run-flow.spec.ts`
 - [-] POST with `tweaks` → parameters override flow configuration
-- [-] POST with custom `session_id`
-- [-] POST with `input_type: "chat"` and `output_type: "chat"`
+- [x] POST with custom `session_id` → `api/flows/api-run-flow.spec.ts`
+- [x] POST with `input_type: "chat"` and `output_type: "chat"` → `api/flows/api-run-flow.spec.ts`
 - [x] POST with invalid API key → returns 401/403 → `api-invalid-key.spec.ts`
-- [-] POST to non-existent flow → returns 404
+- [x] POST to non-existent flow → returns 404 → `api/flows/api-run-flow.spec.ts`
 
 #### 1.4 Components via API
 - [-] GET `/api/v1/all` → lists all available components
@@ -704,7 +704,7 @@
 
 | Module | Total | Validated `[x]` | Needs validation `[-]` | Partial `[~]`/`[!]` | Not automated `[ ]` |
 |--------|-------|-----------------|------------------------|---------------------|---------------------|
-| `api/flows/` — REST API | 21 | 10 | 11 | 0 | 0 |
+| `api/flows/` — REST API | 21 | 14 | 7 | 0 | 0 |
 | `core-components/` — Component Config | 22 | 1 | 19 | 0 | 2 |
 | `core-components/` — Core Components | 67 | 61 | 3 | 1 | 2 |
 | `core-functionality/auth/` | 19 | 0 | 18 | 0 | 1 |
@@ -720,7 +720,7 @@
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 43 | 2 | 39 | 1 | 1 |
 | `ui-ux/` — Settings | 5 | 1 | 3 | 1 | 0 |
-| **TOTAL** | **408** | **140 (34%)** | **209 (51%)** | **7 (2%)** | **52 (13%)** |
+| **TOTAL** | **408** | **144 (35%)** | **205 (50%)** | **7 (2%)** | **52 (13%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -736,7 +736,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 143 `test()` calls carrying the `@stable` tag, distributed across 46 spec
+> 146 `test()` calls carrying the `@stable` tag, distributed across 47 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -762,6 +762,9 @@
 - [x] POST /api/v1/run/{id} with invalid x-api-key returns 401 or 403 → `api-invalid-key.spec.ts`
 - [x] DELETE /api/v1/flows/{id} without Authorization header returns 401 or 403 → `api-invalid-key.spec.ts`
 - [x] PATCH /api/v1/flows/{id} with wrong token does not update the flow → `api-invalid-key.spec.ts`
+- [x] executes flow with input_value and returns outputs → `api-run-flow.spec.ts`
+- [x] executes flow with custom session_id and returns it in response → `api-run-flow.spec.ts`
+- [x] returns 404 for non-existent flow ID → `api-run-flow.spec.ts`
 
 #### core-components/
 - [x] API Request component — renders on canvas with correct output and URL handles → `api-request-component-regression.spec.ts`
@@ -907,7 +910,7 @@
 
 | Module | Validate (`[-]`) | Create (`[ ]`) |
 |--------|-----------------|---------------|
-| `api/flows/` — REST API | 11 | 0 |
+| `api/flows/` — REST API | 7 | 0 |
 | `core-components/` — Component Config | 19 | 2 |
 | `core-components/` — Core Components | 3 | 2 |
 | `core-functionality/auth/` | 18 | 1 |

--- a/docs/api/flows/api-run-flow.md
+++ b/docs/api/flows/api-run-flow.md
@@ -22,8 +22,8 @@ The spec runs **3 independent tests** via Playwright's `request` fixture, sharin
 
 **Setup (`beforeAll`)**
 1. Obtain a valid Bearer token via `getAuthToken(request)`.
-2. `POST /api/v1/api_key/` with the Bearer token to mint a temporary API key (asserts `200`).
-3. `POST /api/v1/flows/` with the new `x-api-key` to create a minimal empty flow (`nodes: []`, `edges: []`), asserts `201`, and stores `flowId`.
+2. `POST /api/v1/api_key/` with the Bearer token to mint a temporary API key (asserts `200` and that the response body contains `api_key` and `id` — gives an explicit failure if the API key response shape changes).
+3. `POST /api/v1/flows/` with the new `x-api-key` to create a minimal empty flow (`nodes: []`, `edges: []`), asserts `201`, and stores `flowId`. The empty-flow + structural-assertion convention is shared with `api-run-with-tweaks.spec.ts`; semantic assertions (non-empty `outputs`, message persistence) are tracked in issue #263.
 
 **Teardown (`afterAll`)**
 1. `DELETE /api/v1/flows/{flowId}` with the `x-api-key`.
@@ -63,7 +63,8 @@ This test covers the QA-CHECKLIST 1.3 bullets for `input_value` and for `input_t
 - Invalid `x-api-key` → `api-invalid-key.spec.ts` (already `@stable`)
 - `GET /api/v1/all` (component listing) → `api-custom-component-creation.spec.ts` (issue #250)
 - Streaming responses, batch runs, file uploads, multi-turn conversations beyond a single `session_id` echo
-- Semantic correctness of `outputs` content (an empty flow produces a structurally valid but functionally empty response)
+- Semantic correctness of `outputs` content (an empty flow produces a structurally valid but functionally empty response) → tracked in issue #263
+- Message persistence under the custom `session_id` (would require a runnable flow that actually emits chat messages) → tracked in issue #263
 
 ---
 

--- a/docs/api/flows/api-run-flow.md
+++ b/docs/api/flows/api-run-flow.md
@@ -79,4 +79,4 @@ This test covers the QA-CHECKLIST 1.3 bullets for `input_value` and for `input_t
 - `tests/helpers/auth/get-auth-token.ts` — issues a valid `Bearer` via `/api/v1/auto_login`; if its contract changes, `beforeAll` breaks
 - `src/backend/base/langflow/api/v1/endpoints.py` — implementation of `POST /api/v1/run/{flow_id}`; changing the response shape (e.g. dropping `outputs` or `session_id` from the body) breaks Tests 1 and 2
 - `src/backend/base/langflow/api/v1/flows.py` — `POST /api/v1/flows/` used in setup and `DELETE /api/v1/flows/{id}` used in teardown
-- `src/backend/base/langflow/api/v1/api_key.py` — `POST` / `DELETE` `/api/v1/api_key/` for temporary key lifecycle
+- `src/backend/base/langflow/api/v1/api_key.py` — `POST /api/v1/api_key/` and `DELETE /api/v1/api_key/{id}` for temporary key lifecycle

--- a/docs/api/flows/api-run-flow.md
+++ b/docs/api/flows/api-run-flow.md
@@ -1,0 +1,81 @@
+# API Run Flow
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+Validates the happy path and the `404` failure mode of `POST /api/v1/run/{flow_id}` — the REST endpoint that external clients use to execute Langflow flows programmatically. The endpoint authenticates with `x-api-key` (not Bearer), accepts a payload with `input_value`, `input_type`, `output_type`, and optionally `session_id`, and returns the flow execution outputs along with the session identifier.
+
+If any of these tests fail, the public flow-execution contract has regressed: integrations that drive Langflow from external systems (chat frontends, agent runtimes, batch jobs) stop receiving expected responses or stop being able to thread a conversation through a stable `session_id`.
+
+---
+
+## Tags *(required)*
+`@stable` `@release` `@api` `@regression`
+
+---
+
+## Step by step *(required)*
+
+The spec runs **3 independent tests** via Playwright's `request` fixture, sharing a single flow created in `beforeAll`.
+
+**Setup (`beforeAll`)**
+1. Obtain a valid Bearer token via `getAuthToken(request)`.
+2. `POST /api/v1/api_key/` with the Bearer token to mint a temporary API key (asserts `200`).
+3. `POST /api/v1/flows/` with the new `x-api-key` to create a minimal empty flow (`nodes: []`, `edges: []`), asserts `201`, and stores `flowId`.
+
+**Teardown (`afterAll`)**
+1. `DELETE /api/v1/flows/{flowId}` with the `x-api-key`.
+2. `DELETE /api/v1/api_key/{apiKeyId}` with the Bearer token.
+
+---
+
+**Test 1 — `POST /api/v1/run/{flow_id}` with `input_value`, `input_type: "chat"`, `output_type: "chat"`**
+1. POST to `/api/v1/run/{flowId}` with `x-api-key` and payload `{ input_value, input_type: "chat", output_type: "chat" }`.
+2. Assert response status is `200`.
+3. Assert `body.outputs` exists and is an array.
+
+This test covers the QA-CHECKLIST 1.3 bullets for `input_value` and for `input_type: "chat"` / `output_type: "chat"` in a single call — both parameters are sent explicitly in the request payload.
+
+**Test 2 — `POST /api/v1/run/{flow_id}` with custom `session_id`**
+1. Generate a deterministic `session_id` (e.g. `test-session-<timestamp>`).
+2. POST with payload including `session_id`.
+3. Assert response status is `200`.
+4. Assert `body.session_id` equals the value sent in the request.
+
+**Test 3 — `POST /api/v1/run/{non_existent_flow_id}` returns 404**
+1. POST to `/api/v1/run/00000000-0000-0000-0000-000000000000` with the valid `x-api-key`.
+2. Assert response status is `404` (not `500`, not `422`).
+
+---
+
+## Validation criterion *(required)*
+- Setup creates one flow and one API key; teardown removes both. No orphans on the backend after the suite.
+- Test 1 receives `200` and a body with an `outputs` array (content may be empty for an empty flow — the contract is structural, not semantic).
+- Test 2 receives `200` and the returned `session_id` is byte-identical to the value sent in the request.
+- Test 3 receives `404` — confirming the router differentiates missing-flow from auth failure and from input-validation failure.
+
+---
+
+## What this test does not cover *(optional)*
+- `tweaks` parameter override → `api-run-with-tweaks.spec.ts` (issue #249)
+- Invalid `x-api-key` → `api-invalid-key.spec.ts` (already `@stable`)
+- `GET /api/v1/all` (component listing) → `api-custom-component-creation.spec.ts` (issue #250)
+- Streaming responses, batch runs, file uploads, multi-turn conversations beyond a single `session_id` echo
+- Semantic correctness of `outputs` content (an empty flow produces a structurally valid but functionally empty response)
+
+---
+
+## Preconditions *(optional)*
+- Langflow running and reachable at `PLAYWRIGHT_BASE_URL`
+- Default superuser credentials available (`LANGFLOW_SUPERUSER` / `LANGFLOW_SUPERUSER_PASSWORD`) — used by `getAuthToken` to mint the Bearer used in setup
+- Backend allows API key creation via `POST /api/v1/api_key/` for the authenticated user
+
+---
+
+## External dependencies *(required)*
+- `tests/helpers/auth/get-auth-token.ts` — issues a valid `Bearer` via `/api/v1/auto_login`; if its contract changes, `beforeAll` breaks
+- `src/backend/base/langflow/api/v1/endpoints.py` — implementation of `POST /api/v1/run/{flow_id}`; changing the response shape (e.g. dropping `outputs` or `session_id` from the body) breaks Tests 1 and 2
+- `src/backend/base/langflow/api/v1/flows.py` — `POST /api/v1/flows/` used in setup and `DELETE /api/v1/flows/{id}` used in teardown
+- `src/backend/base/langflow/api/v1/api_key.py` — `POST` / `DELETE` `/api/v1/api_key/` for temporary key lifecycle

--- a/tests/tests-automations/regression/api/flows/api-run-flow.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-run-flow.spec.ts
@@ -3,6 +3,8 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 
 // The /api/v1/run endpoint requires x-api-key authentication (not Bearer).
 // This test creates a temporary API key in beforeAll and deletes it in afterAll.
+// The flow is intentionally empty — matching the convention in api-run-with-tweaks.spec.ts.
+// A runnable-flow fixture for semantic output assertions belongs in a separate spec.
 
 test.describe("POST /api/v1/run", () => {
   let flowId: string;
@@ -20,6 +22,8 @@ test.describe("POST /api/v1/run", () => {
     });
     expect(keyRes.status()).toBe(200);
     const keyBody = await keyRes.json();
+    expect(keyBody).toHaveProperty("api_key");
+    expect(keyBody).toHaveProperty("id");
     apiKey = keyBody.api_key;
     apiKeyId = keyBody.id;
 

--- a/tests/tests-automations/regression/api/flows/api-run-flow.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-run-flow.spec.ts
@@ -28,7 +28,7 @@ test.describe("POST /api/v1/run", () => {
       headers: { "x-api-key": apiKey },
       data: {
         name: `Run Test Flow - ${Date.now()}`,
-        description: "Flow para testes de API run",
+        description: "Flow for API run tests",
         data: { nodes: [], edges: [], viewport: { x: 0, y: 0, zoom: 1 } },
         is_component: false,
       },
@@ -55,7 +55,7 @@ test.describe("POST /api/v1/run", () => {
 
   test(
     "executes flow with input_value and returns outputs",
-    { tag: ["@release", "@api", "@regression"] },
+    { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
       const response = await request.post(`/api/v1/run/${flowId}`, {
         headers: { "x-api-key": apiKey },
@@ -75,7 +75,7 @@ test.describe("POST /api/v1/run", () => {
 
   test(
     "executes flow with custom session_id and returns it in response",
-    { tag: ["@release", "@api", "@regression"] },
+    { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
       const customSessionId = `test-session-${Date.now()}`;
 
@@ -98,7 +98,7 @@ test.describe("POST /api/v1/run", () => {
 
   test(
     "returns 404 for non-existent flow ID",
-    { tag: ["@release", "@api", "@regression"] },
+    { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
       const fakeFlowId = "00000000-0000-0000-0000-000000000000";
 
@@ -112,39 +112,6 @@ test.describe("POST /api/v1/run", () => {
       });
 
       expect(response.status()).toBe(404);
-    },
-  );
-
-  test(
-    "returns 403 with invalid API key",
-    { tag: ["@release", "@api", "@regression"] },
-    async ({ request }) => {
-      const response = await request.post(`/api/v1/run/${flowId}`, {
-        headers: { "x-api-key": "sk-invalid-key-that-does-not-exist" },
-        data: {
-          input_value: "Hello",
-          input_type: "chat",
-          output_type: "chat",
-        },
-      });
-
-      expect([401, 403]).toContain(response.status());
-    },
-  );
-
-  test(
-    "GET /api/v1/all returns list of available component types",
-    { tag: ["@release", "@api", "@regression"] },
-    async ({ request }) => {
-      const response = await request.get("/api/v1/all", {
-        headers: { Authorization: bearerToken },
-      });
-
-      expect(response.status()).toBe(200);
-      const body = await response.json();
-      // Response is an object with component type keys (e.g. "inputs", "outputs", "models"…)
-      expect(typeof body).toBe("object");
-      expect(Object.keys(body).length).toBeGreaterThan(0);
     },
   );
 });


### PR DESCRIPTION
## Summary

- Promotes `api-run-flow.spec.ts` to `@stable` for the 3 tests that belong to **QA-CHECKLIST section 1.3 Flow Execution via API**
- Removes 2 out-of-scope tests (one duplicated, one belonging to section 1.4)
- Adds the missing spec doc `docs/api/flows/api-run-flow.md`
- Flips 4 bullets in section 1.3 from `[-]` to `[x]`

Closes #248

## What changed

### `tests/tests-automations/regression/api/flows/api-run-flow.spec.ts`
- **Removed** `returns 403 with invalid API key` — already covered by `api-invalid-key.spec.ts` as `@stable` (per memory rule: do not duplicate tests across specs).
- **Removed** `GET /api/v1/all returns list of available component types` — belongs to QA-CHECKLIST section 1.4, not 1.3. Follow-up tracked in #261 to reinstate it in the correct spec under issue #250's scope.
- **Tagged `@stable`** on the 3 remaining tests:
  - `executes flow with input_value and returns outputs`
  - `executes flow with custom session_id and returns it in response`
  - `returns 404 for non-existent flow ID`
- Translated one residual Portuguese string in the payload to English to comply with CLAUDE.md.

### `docs/api/flows/api-run-flow.md` (new)
Follows the 8-section template established by `docs/api/flows/api-invalid-key.md`: title + `Last validated`, _What this test validates_, _Tags_, _Step by step_, _Validation criterion_, _What this test does not cover_, _Preconditions_, _External dependencies_.

### `QA-CHECKLIST.md`
Flipped to `[x]` in section 1.3:
- POST `/api/v1/run/{flow_id}` with `input_value` → `api/flows/api-run-flow.spec.ts`
- POST with custom `session_id` → `api/flows/api-run-flow.spec.ts`
- POST with `input_type: "chat"` and `output_type: "chat"` → `api/flows/api-run-flow.spec.ts`
- POST to non-existent flow → returns 404 → `api/flows/api-run-flow.spec.ts`

The Coverage Summary table and Phase 0 block were regenerated by `npm run coverage:summary` (idempotent on second run).

## Follow-up

#261 — move the removed `GET /api/v1/all` test to its rightful home (section 1.4 / #250).

## Test plan

- [x] Spec ran 5× consecutively locally against `langflowai/langflow-nightly:latest` — 3/3 passed every time
- [x] `npm run lint` — 0 errors (only pre-existing warnings, none in touched files)
- [x] `npm run typecheck` — clean
- [x] `npm run coverage:summary` — runs and is idempotent on second invocation
- [x] `npx playwright test --grep "@stable" tests/tests-automations/regression/api/flows/api-run-flow.spec.ts` lists all 3 tests