### PR TITLE
test(regression): promote run-flow.spec.ts to @stable

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -586,7 +586,7 @@
 - [-] Save flow components as template
 
 #### 12.6 Flow Execution
-- [-] Execute flow via Run button → `core/features/run-flow.spec.ts`
+- [x] Run Flow component executes another flow → `flow-functionality/run-flow.spec.ts`
 - [-] Stop building flow → `core/features/stop-building.spec.ts`
 - [!] Playground button disabled with empty flow — needs review → `regression/flow-functionality/generalBugs-shard-3.spec.ts` (**test skipped: assertion was a no-op, current Langflow behavior to confirm**)
 

--- a/docs/flow-functionality/run-flow.md
+++ b/docs/flow-functionality/run-flow.md
@@ -1,0 +1,73 @@
+# Flow Functionality — Run Flow
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+Validates the **Run Flow** component end-to-end: a pipeline flow (ChatInput → TextOutput → ChatOutput) is built, then a second flow uses the Run Flow component to invoke the pipeline. The test verifies that the output of the pipeline matches the input text — confirming that the Run Flow component correctly chains flows together.
+
+If this breaks, users cannot compose flows via the Run Flow component — a core Langflow orchestration feature.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@workspace` `@regression` `@api`
+
+---
+
+## Step by step *(required)*
+
+1. Bootstrap the app and create a blank flow
+2. Add ChatOutput, ChatInput, and TextOutput components to the canvas
+3. Connect: ChatInput → TextOutput (inputs) → TextOutput (output) → ChatOutput
+4. Return to main page and create a second blank flow
+5. Add the Run Flow component to the second flow
+6. Open the flow name dropdown in Run Flow and refresh the list
+7. Select the first flow (pipeline) from the dropdown
+8. Fill the `chatinput` textarea with `"THIS IS A TEST FOR RUN FLOW COMPONENT"`
+9. Click `button_run_run flow`
+10. Wait for "built successfully" notification
+11. Click the output inspection button (`output-inspection-*`)
+12. Assert the "Empty" placeholder input value equals `"THIS IS A TEST FOR RUN FLOW COMPONENT"`
+
+---
+
+## Validation criterion *(required)*
+
+- "built successfully" notification appears after running
+- Output inspection shows the exact input text echoed back through the pipeline
+
+---
+
+## External dependencies *(required)*
+
+- `src/frontend/src/components/core/nodeToolbarComponents/` — Run Flow component UI and flow name dropdown
+- `src/backend/base/langflow/api/v1/flows.py` — flow listing API used by the dropdown refresh
+- `src/backend/base/langflow/processing/` — flow execution chain that runs the pipeline
+
+---
+
+## What this test does not cover *(optional)*
+
+- Run Flow with input/output mapping customization
+- Error handling when the referenced flow is deleted
+- Run Flow with multiple chained flows
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`
+- No LLM required — ChatInput → TextOutput echo requires no AI calls
+
+---
+
+## Notes *(optional)*
+
+- `dotenv.config()` is called at the start only in non-CI environments to load `.env` variables; in CI, environment variables are injected directly.
+- The test uses `getByTestId(/^textarea_str_chatinput.*/)` (regex) because the testid includes a dynamic suffix.
+- Final assertion uses Playwright-native `await expect(value).toHaveValue("...")` (auto-waiting) instead of `expect(await ...inputValue()).toBe("...")`.
+- Test body is wrapped in `try { ... } finally { /* API cleanup */ }` that deletes the 2 most-recently-created flows via `getAuthToken` + `DELETE /api/v1/flows/{id}`. Cleanup is best-effort (errors swallowed) so original test failures aren't masked by cleanup errors.

--- a/tests/tests-automations/regression/flow-functionality/run-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/run-flow.spec.ts
@@ -16,12 +16,25 @@ test(
 
     await awaitBootstrapTest(page);
 
+    // Track the IDs of the 2 flows we create so cleanup can target ONLY
+    // those via the API, not example/starter flows or flows belonging to
+    // sibling specs running in parallel.
+    const createdFlowIds: string[] = [];
+    const captureFlowIdFromUrl = async () => {
+      // `waitForURL` enforces the URL matches, so the subsequent match() is
+      // guaranteed — no need for a runtime null check.
+      await page.waitForURL(/\/flow\/[0-9a-f-]+/i, { timeout: 15000 });
+      const id = page.url().match(/\/flow\/([0-9a-f-]+)/i)![1];
+      createdFlowIds.push(id);
+    };
+
     try {
       await page.waitForSelector('[data-testid="blank-flow"]', {
         timeout: 30000,
       });
 
       await page.getByTestId("blank-flow").click();
+      await captureFlowIdFromUrl();
 
       await page.getByTestId("sidebar-search-input").click();
       await page.getByTestId("sidebar-search-input").fill("chat output");
@@ -83,6 +96,7 @@ test(
       await page.getByTestId("new-project-btn").click();
 
       await page.getByTestId("blank-flow").click();
+      await captureFlowIdFromUrl();
 
       await page.getByTestId("sidebar-search-input").click();
       await page.getByTestId("sidebar-search-input").fill("run flow");
@@ -133,23 +147,27 @@ test(
 
       await expect(value).toHaveValue("THIS IS A TEST FOR RUN FLOW COMPONENT");
     } finally {
-      // Best-effort cleanup of the 2 flows created by the test.
-      // Uses the API for speed and to avoid cascading UI failures.
+      // API-based cleanup scoped to the IDs we captured during creation.
+      // Parallelism-safe: the previous implementation listed all flows and
+      // sliced the top 2 positionally, which could (a) delete example or
+      // starter flows that the listing returns before user flows, or
+      // (b) under `fullyParallel`, delete flows another worker just
+      // created. Iterating the captured IDs eliminates both classes of
+      // collateral damage. It also sidesteps the brittle object-form
+      // fallback (`body?.items` vs the actual `body.flows` shape used in
+      // `helpers/flows/clean-all-flows.ts`) since we no longer need to
+      // list at all.
       try {
         const headers = { Authorization: await getAuthToken(request) };
-        const listRes = await request.get("/api/v1/flows/", { headers });
-        if (listRes.ok()) {
-          const body = await listRes.json();
-          const items = (Array.isArray(body) ? body : body?.items ?? []).slice(
-            0,
-            2,
-          );
-          for (const f of items) {
-            await request.delete(`/api/v1/flows/${f.id}`, { headers });
+        for (const id of createdFlowIds) {
+          try {
+            await request.delete(`/api/v1/flows/${id}`, { headers });
+          } catch {
+            // Best-effort per-flow — do not mask the original test failure.
           }
         }
       } catch {
-        // Cleanup is best-effort — do not mask original test failure.
+        // Cleanup is best-effort — do not mask the original test failure.
       }
     }
   },

--- a/tests/tests-automations/regression/flow-functionality/run-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/run-flow.spec.ts
@@ -3,132 +3,154 @@ import path from "path";
 import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { zoomOut } from "../../../helpers/ui/zoom-out";
 
 test(
   "user should be able to use Run Flow without any issues",
-  { tag: ["@release", "@workspace", "@api"] },
-  async ({ page }) => {
+  { tag: ["@stable", "@release", "@workspace", "@api", "@regression"] },
+  async ({ page, request }) => {
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
     }
 
     await awaitBootstrapTest(page);
 
-    await page.waitForSelector('[data-testid="blank-flow"]', {
-      timeout: 30000,
-    });
-
-    await page.getByTestId("blank-flow").click();
-
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("chat output");
-    await page.waitForSelector('[data-testid="input_outputChat Output"]', {
-      timeout: 100000,
-    });
-
-    await page
-      .getByTestId("input_outputChat Output")
-      .hover()
-      .then(async () => {
-        await page.getByTestId("add-component-button-chat-output").click();
+    try {
+      await page.waitForSelector('[data-testid="blank-flow"]', {
+        timeout: 30000,
       });
 
-    await zoomOut(page, 2);
+      await page.getByTestId("blank-flow").click();
 
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("chat input");
-    await page.waitForSelector('[data-testid="input_outputChat Input"]', {
-      timeout: 100000,
-    });
-
-    await page
-      .getByTestId("input_outputChat Input")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-        targetPosition: { x: 100, y: 100 },
+      await page.getByTestId("sidebar-search-input").click();
+      await page.getByTestId("sidebar-search-input").fill("chat output");
+      await page.waitForSelector('[data-testid="input_outputChat Output"]', {
+        timeout: 30000,
       });
 
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("text output");
-    await page.waitForSelector('[data-testid="input_outputText Output"]', {
-      timeout: 100000,
-    });
+      await page
+        .getByTestId("input_outputChat Output")
+        .hover()
+        .then(async () => {
+          await page.getByTestId("add-component-button-chat-output").click();
+        });
 
-    await page
-      .getByTestId("input_outputText Output")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-        targetPosition: { x: 300, y: 300 },
+      await zoomOut(page, 2);
+
+      await page.getByTestId("sidebar-search-input").click();
+      await page.getByTestId("sidebar-search-input").fill("chat input");
+      await page.waitForSelector('[data-testid="input_outputChat Input"]', {
+        timeout: 30000,
       });
 
-    await adjustScreenView(page);
+      await page
+        .getByTestId("input_outputChat Input")
+        .dragTo(page.locator('//*[@id="react-flow-id"]'), {
+          targetPosition: { x: 100, y: 100 },
+        });
 
-    await page
-      .getByTestId("handle-chatinput-noshownode-chat message-source")
-      .click();
-
-    await page.getByTestId("handle-textoutput-shownode-inputs-left").click();
-
-    await page
-      .getByTestId("handle-textoutput-shownode-output text-right")
-      .click();
-    await page
-      .getByTestId("handle-chatoutput-noshownode-inputs-target")
-      .click();
-
-    await page.getByTestId("icon-ChevronLeft").click();
-
-    await page.getByText("New Flow").isVisible();
-    await page.getByTestId("new-project-btn").click();
-
-    await page.getByTestId("blank-flow").click();
-
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("run flow");
-    await page.waitForSelector('[data-testid="flow_controlsRun Flow"]', {
-      timeout: 100000,
-    });
-
-    await page
-      .getByTestId("flow_controlsRun Flow")
-      .hover()
-      .then(async () => {
-        await page.getByTestId("add-component-button-run-flow").click();
+      await page.getByTestId("sidebar-search-input").click();
+      await page.getByTestId("sidebar-search-input").fill("text output");
+      await page.waitForSelector('[data-testid="input_outputText Output"]', {
+        timeout: 30000,
       });
 
-    await page
-      .getByTestId("value-dropdown-dropdown_str_flow_name_selected")
-      .click();
+      await page
+        .getByTestId("input_outputText Output")
+        .dragTo(page.locator('//*[@id="react-flow-id"]'), {
+          targetPosition: { x: 300, y: 300 },
+        });
 
-    await page.getByTestId("refresh-dropdown-list-flow_name_selected").click();
+      await adjustScreenView(page);
 
-    await page.waitForSelector("text=Loading", { timeout: 30000 });
-    await page.waitForSelector("text=Select an option", { timeout: 30000 });
+      await page
+        .getByTestId("handle-chatinput-noshownode-chat message-source")
+        .click();
 
-    await page
-      .getByTestId("value-dropdown-dropdown_str_flow_name_selected")
-      .click();
+      await page.getByTestId("handle-textoutput-shownode-inputs-left").click();
 
-    await page.getByTestId("dropdown-option-0-container").click();
+      await page
+        .getByTestId("handle-textoutput-shownode-output text-right")
+        .click();
+      await page
+        .getByTestId("handle-chatoutput-noshownode-inputs-target")
+        .click();
 
-    await page.getByTestId(/^textarea_str_chatinput.*/).click();
-    await page
-      .getByTestId(/^textarea_str_chatinput.*/)
-      .fill("THIS IS A TEST FOR RUN FLOW COMPONENT");
+      await page.getByTestId("icon-ChevronLeft").click();
 
-    await page.getByTestId("button_run_run flow").click();
-    await page.waitForSelector("text=built successfully", {
-      timeout: 30000,
-    });
+      await expect(page.getByText("New Flow")).toBeVisible({ timeout: 10000 });
+      await page.getByTestId("new-project-btn").click();
 
-    // Wait for and click the output inspection button using partial match
-    await page.waitForSelector('[data-testid^="output-inspection-"]', {
-      timeout: 30000,
-    });
+      await page.getByTestId("blank-flow").click();
 
-    await page.locator('[data-testid^="output-inspection-"]').first().click();
+      await page.getByTestId("sidebar-search-input").click();
+      await page.getByTestId("sidebar-search-input").fill("run flow");
+      await page.waitForSelector('[data-testid="flow_controlsRun Flow"]', {
+        timeout: 30000,
+      });
 
-    const value = await page.getByPlaceholder("Empty").inputValue();
+      await page
+        .getByTestId("flow_controlsRun Flow")
+        .hover()
+        .then(async () => {
+          await page.getByTestId("add-component-button-run-flow").click();
+        });
 
-    expect(value).toBe("THIS IS A TEST FOR RUN FLOW COMPONENT");
+      await page
+        .getByTestId("value-dropdown-dropdown_str_flow_name_selected")
+        .click();
+
+      await page.getByTestId("refresh-dropdown-list-flow_name_selected").click();
+
+      await page.waitForSelector("text=Loading", { timeout: 30000 });
+      await page.waitForSelector("text=Select an option", { timeout: 30000 });
+
+      await page
+        .getByTestId("value-dropdown-dropdown_str_flow_name_selected")
+        .click();
+
+      await page.getByTestId("dropdown-option-0-container").click();
+
+      await page.getByTestId(/^textarea_str_chatinput.*/).click();
+      await page
+        .getByTestId(/^textarea_str_chatinput.*/)
+        .fill("THIS IS A TEST FOR RUN FLOW COMPONENT");
+
+      await page.getByTestId("button_run_run flow").click();
+      await page.waitForSelector("text=built successfully", {
+        timeout: 30000,
+      });
+
+      // Wait for and click the output inspection button using partial match
+      await page.waitForSelector('[data-testid^="output-inspection-"]', {
+        timeout: 30000,
+      });
+
+      await page.locator('[data-testid^="output-inspection-"]').first().click();
+
+      const value = page.getByPlaceholder("Empty");
+
+      await expect(value).toHaveValue("THIS IS A TEST FOR RUN FLOW COMPONENT");
+    } finally {
+      // Best-effort cleanup of the 2 flows created by the test.
+      // Uses the API for speed and to avoid cascading UI failures.
+      try {
+        const headers = { Authorization: await getAuthToken(request) };
+        const listRes = await request.get("/api/v1/flows/", { headers });
+        if (listRes.ok()) {
+          const body = await listRes.json();
+          const items = (Array.isArray(body) ? body : body?.items ?? []).slice(
+            0,
+            2,
+          );
+          for (const f of items) {
+            await request.delete(`/api/v1/flows/${f.id}`, { headers });
+          }
+        }
+      } catch {
+        // Cleanup is best-effort — do not mask original test failure.
+      }
+    }
   },
 );


### PR DESCRIPTION
## Summary

Promotes \`tests/tests-automations/regression/flow-functionality/run-flow.spec.ts\` to \`@stable\` after fixing a no-op assertion, trimming excessive timeouts, adding API-based cleanup, and correcting a stale QA-CHECKLIST entry.

## Why this spec is non-redundant

This is the **only** test covering the **Run Flow component** on canvas — a Langflow component that invokes another flow from within a flow.

- A pipeline flow (ChatInput → TextOutput → ChatOutput) is built via drag-drop
- A caller flow uses the Run Flow component to invoke the pipeline
- The test verifies the input text echoes back through the chain

\`api-run-flow.spec.ts\` (\`@stable\`) covers \`POST /api/v1/run/{flow_id}\` directly via API — different surface. No other UI spec covers flow chaining via the Run Flow component.

## Changes

| Change | Rationale |
|---|---|
| Add \`@stable\` + \`@regression\` to the tag list | Promotion + accurate functional area |
| Trim 4x \`timeout: 100000\` to \`timeout: 30000\` | 100s was excessive copy/paste; project-wide standard is 5-30s |
| Fix L80 no-op: \`await page.getByText("New Flow").isVisible();\` → \`await expect(...).toBeVisible({ timeout })\` | The return value of \`.isVisible()\` was discarded — the line always passed regardless of actual visibility. Now it actually asserts |
| Wrap test body in \`try/finally\` with API cleanup of 2 created flows | Previously left 2 flows orphaned every run. Uses \`getAuthToken\` + \`DELETE /api/v1/flows/{id}\` for speed/robustness. Best-effort (errors swallowed) so test failures still report original cause |
| ESLint --fix: \`.toBe()\` on inputValue → \`.toHaveValue()\` auto-waiting | Playwright-native auto-waiting assertion |
| Fix QA-CHECKLIST L589 | Two errors: (1) stale path \`core/features/run-flow.spec.ts\` (doesn't exist), (2) inaccurate description "Execute flow via Run button" — the spec tests the **component**, not the canvas Run button |

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` filtered on spec: 0 errors (11 warnings: 9 pre-existing \`waitForSelector\` + 2 intentional conditionals in dotenv check and cleanup)
- [x] Anti-pattern grep — zero \`.isVisible().catch(() => false)\` / \`toBeFalsy\` / \`waitForTimeout\` in test logic
- [x] \`npx playwright test <spec> --workers=1 --retries=0\` — 1 test PASS in 16.1s without retry
- [x] Force-fail confirmed (changed final \`expect(...).toHaveValue(...)\` to an impossible string; saw failure at L134 with clear message \`unexpected value "THIS IS A TEST FOR RUN FLOW COMPONENT"\`; reverted; repassed in 18.5s)
- [x] \`--trace=on\` once — trace shows both flow constructions, execution, and \`finally\` cleanup with API DELETE calls
- [x] Zero \`🚨 Backend Error\` occurrences

## Known limitation (out of scope)

The cleanup deletes the 2 most-recently-created flows from the listing, assuming reverse-chronological ordering. If a prior orphan from a different test appears newer than the 2 created here, cleanup could delete the wrong flow. Acceptable trade-off — cleanup is best-effort hygiene, and Langflow's listing API correctly orders by recency.