### PR TITLE
chore(weekly-232): demote @stable on 2 tests broken by upstream Langflow changes

### DIFF
--- a/tests/tests-automations/regression/core-components/webhook-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/webhook-component-regression.spec.ts
@@ -257,7 +257,7 @@ test(
 
 test(
   "Webhook component — POST to non-existent flow name returns 404",
-  { tag: ["@stable", "@release", "@regression"] },
+  { tag: ["@release", "@regression"] },
   async ({ request }) => {
     // The webhook endpoint returns 404 when the flow_id_or_name cannot be resolved.
     // This is confirmed by the backend unit test: test_webhook_not_found_invalid_endpoint.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/provider-invalid-auth-error.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/provider-invalid-auth-error.spec.ts
@@ -104,7 +104,7 @@ for (const {
   test.describe.serial(`Invalid Auth Error — ${provider}`, () => {
     test(
       `should display error message when using invalid authentication for provider ${provider}`,
-      { tag: ["@stable", "@regression", "@model-provider", "@agents"] },
+      { tag: ["@regression", "@model-provider", "@agents"] },
       async ({ page }) => {
 
         await page.goto("/");


### PR DESCRIPTION
## Summary
- Removes `@stable` from two tests that now fail against `langflowai/langflow-nightly:latest` due to intentional upstream Langflow changes.
- Unblocks the `weekly-stable` workflow so it stops opening duplicate failure issues every Monday until the fixes land.
- Fix work tracked in dedicated issues — `@stable` is re-added there.

## Failing tests demoted

| Test | Upstream change | Fix issue |
|---|---|---|
| `webhook-component-regression.spec.ts:258` — POST to non-existent flow returns 404 | Langflow [#12845](https://github.com/langflow-ai/langflow/pull/12845): `WEBHOOK_AUTH_ENABLE` defaults to `True`; unauth POST → 403 before flow lookup | #269 |
| `provider-invalid-auth-error.spec.ts:84` — clicks `icon-Brain` in Settings sidebar | Langflow [#13111](https://github.com/langflow-ai/langflow/pull/13111): icon renamed `Brain` → `BrainCircuit` | #270 |

The 6 flaky tests from the same weekly run remain `@stable` (single flake does not trigger demotion per the lifecycle rule). Investigation tracked in #271.

## Test plan
- [x] `npm run typecheck` — no errors
- [x] `npm run lint` — 0 errors (pre-existing warnings unchanged)
- [ ] Next `weekly-stable` run no longer reports these two tests as `@stable` failures

Closes #232