### PR TITLE
feat(ci): add migration-summary.md artifact to migration-upgrade-with-flows

### DIFF
--- a/.github/workflows/migration-upgrade-with-flows.yml
+++ b/.github/workflows/migration-upgrade-with-flows.yml
@@ -139,13 +139,56 @@ jobs:
           LANGFLOW_URL: ${{ env.LANGFLOW_URL }}
           EXPECTED_FLOW_NAME: ${{ env.FLOW_NAME }}
 
-      # ── Phase 4: Artifacts ───────────────────────────────────
+      # ── Phase 4: Summary + Artifacts ─────────────────────────
+      - name: Generate migration summary
+        if: always()
+        run: |
+          LATEST_DIGEST=$(cat /tmp/latest-digest.txt 2>/dev/null || echo "(unavailable)")
+          NIGHTLY_DIGEST=$(cat /tmp/nightly-digest.txt 2>/dev/null || echo "(unavailable)")
+          OUTCOME="${{ job.status }}"
+          DATE=$(date -u +%Y-%m-%d)
+
+          {
+            echo "# Langflow Migration — Run Summary"
+            echo ""
+            echo "**Outcome:** \`${OUTCOME}\`   ·   Run #${{ github.run_number }} (${DATE}, ${{ github.event_name }})"
+            echo ""
+            echo "## Scenario"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Workflow | \`${{ github.workflow }}\` |"
+            echo "| Source image | \`langflowai/langflow:latest\` (\`${LATEST_DIGEST}\`) |"
+            echo "| Target image | \`langflowai/langflow-nightly:latest\` (\`${NIGHTLY_DIGEST}\`) |"
+            echo "| Database | PostgreSQL 16 (GHA service) |"
+            echo "| Deployment | \`docker run\` + \`LANGFLOW_LOAD_FLOWS_PATH=/flows\` (bind-mounted flow JSON) |"
+            echo "| Preloaded flow | \`${{ env.FLOW_NAME }}\` |"
+            echo ""
+            echo "## What this run verified"
+            echo ""
+            echo "- Source (latest) boots with \`LANGFLOW_LOAD_FLOWS_PATH\` and ingests the pre-built flow from disk."
+            echo "- Target (nightly) boots on the same Postgres database with the same \`LANGFLOW_LOAD_FLOWS_PATH\`."
+            echo "- Nightly logs contain no \`UniqueViolation\` / unique-constraint / duplicate-key errors after the re-import."
+            echo "- The pre-loaded flow remains accessible via API after the upgrade."
+            echo ""
+            echo "## Artifacts"
+            echo ""
+            echo "- \`langflow-latest.log\` — full container log for the source phase"
+            echo "- \`langflow-nightly.log\` — full container log for the target phase (includes alembic migration)"
+            echo "- \`latest-digest.txt\` / \`nightly-digest.txt\` — exact image digests tested"
+          } > /tmp/migration-summary.md
+
+          echo "::group::Generated summary"
+          cat /tmp/migration-summary.md
+          echo "::endgroup::"
+
       - name: Upload logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: upgrade-with-flows-${{ github.run_number }}
           path: |
+            /tmp/migration-summary.md
             /tmp/langflow-latest.log
             /tmp/langflow-nightly.log
             /tmp/latest-digest.txt


### PR DESCRIPTION
## Summary

Adds a structured summary markdown file (\`/tmp/migration-summary.md\`) to the artifact of \`migration-upgrade-with-flows.yml\`. The file is generated at the end of every run (\`if: always()\`), so it documents both successful runs and failures.

## What the summary contains

- Outcome (\`success\` / \`failure\`), run number, date, trigger
- Source and target image digests (read from the existing \`/tmp/latest-digest.txt\` and \`/tmp/nightly-digest.txt\`)
- Database backend (PostgreSQL via GHA service)
- Deployment shape (\`docker run\` + \`LANGFLOW_LOAD_FLOWS_PATH\` bind mount of the flow JSON)
- The preloaded flow name (\`env.FLOW_NAME\`)
- A bullet list of what the run verified
- List of artifacts produced

## Implementation

- New step \`Generate migration summary\` runs before \`Upload logs\` with \`if: always()\`.
- Writes to \`/tmp/migration-summary.md\` via inline bash heredoc (no new helpers).
- The existing upload-artifact step now also includes \`/tmp/migration-summary.md\` in its \`path:\`.

This is the first of three companion PRs adding the same summary pattern to:
- \`migration-upgrade-with-flows.yml\` ← this PR
- \`migration-test.yml\` (both jobs)
- \`migration-manual.yml\` (via existing #242)

Test plan:
- [ ] Trigger workflow manually after merge; confirm \`migration-summary.md\` appears in artifact and contains the expected fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)