### PR TITLE
fix(webhook-404): authenticate POST to reach 404 path after WEBHOOK_AUTH_ENABLE default flip

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -736,7 +736,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 148 `test()` calls carrying the `@stable` tag, distributed across 47 spec
+> 149 `test()` calls carrying the `@stable` tag, distributed across 47 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -826,6 +826,7 @@
 - [x] Webhook component — empty data field returns empty Data object → `webhook-component-regression.spec.ts`
 - [x] Webhook component — endpoint field renders the actual webhook URL → `webhook-component-regression.spec.ts`
 - [x] Webhook component — copy button copies the endpoint URL to clipboard → `webhook-component-regression.spec.ts`
+- [x] Webhook component — POST to non-existent flow name returns 404 → `webhook-component-regression.spec.ts`
 - [x] Webhook component — valid JSON payload is propagated as structured Data output → `webhook-component-regression.spec.ts`
 - [x] Webhook component — invalid JSON payload is encapsulated in {payload: ...} → `webhook-component-regression.spec.ts`
 - [x] GET /api/v1/monitor/messages returns 200 with array response → `webhook-component-regression.spec.ts`

--- a/docs/core-components/webhook-component-regression.md
+++ b/docs/core-components/webhook-component-regression.md
@@ -89,8 +89,10 @@ If any of these tests fails, the Webhook component is broken in one of its core 
 5. Read `navigator.clipboard.readText()` via `page.evaluate` and assert it equals the expected URL
 
 **Test 7 — POST to non-existent flow name returns 404**
-1. POST directly to `/api/v1/webhook/non-existent-flow-e2e-regression-test`
-2. Assert the response status is 404 (no browser navigation needed)
+1. Create a temporary API key via `POST /api/v1/api_key/` (Langflow's `WEBHOOK_AUTH_ENABLE` defaults to `True` since 1.10+, so the auth dependency runs before the flow lookup; without `x-api-key` the endpoint short-circuits to 403 and never reaches the 404 path)
+2. POST to `/api/v1/webhook/non-existent-flow-e2e-regression-test` with the `x-api-key` header
+3. Assert the response status is 404 (no browser navigation needed)
+4. In `finally`, delete the temporary API key so failures don't leak credentials
 
 **Setup helper — `loadFlowWithDataField`** (shared by tests 8–9)
 1. Register a `page.route` intercept on `GET /api/v1/flows/{flowId}`
@@ -160,7 +162,7 @@ If any of these tests fails, the Webhook component is broken in one of its core 
 ## Preconditions *(optional)*
 
 - Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
-- The Webhook component is a pure HTTP input with no LLM calls, but the webhook POST endpoint requires an API key whenever `WEBHOOK_AUTH_ENABLE=True` (Langflow's default since 1.5+); test 1 creates a temporary key via `POST /api/v1/api_key/` and deletes it in `finally`
+- The Webhook component is a pure HTTP input with no LLM calls, but the webhook POST endpoint requires an API key whenever `WEBHOOK_AUTH_ENABLE=True` (Langflow's default since 1.10+); tests 1 and 7 create a temporary key via `POST /api/v1/api_key/` and delete it in `finally`
 - Tests 1, 8, and 9 require autosave to flush within 4 s of creating the flow; environments with very high DB latency may need a longer wait
 - The `output-inspection-json-webhook` testid requires Langflow version including langflow-ai/langflow#11554, which renamed the output display name from `"Data"` to `"JSON"`
 
@@ -178,5 +180,5 @@ If any of these tests fails, the Webhook component is broken in one of its core 
 ## Notes *(optional)*
 
 - Tests 8 and 9 use `page.route` to inject a value into the Webhook's `data` field (Payload, `advanced=True`), which has no editable UI in the inspector. The intercept patches the `GET /api/v1/flows/{id}` response before the page navigates to the flow, simulating what the real webhook POST would write to that field. The intercept is removed via `page.unroute` after navigation to avoid side-effects.
-- The `request` fixture used in tests 1 and 7 is unauthenticated by default; test 1 explicitly authenticates the webhook POSTs with a temporary `x-api-key` (required since Langflow 1.5+ where `WEBHOOK_AUTH_ENABLE` defaults to `True`). Test 7 still works without auth because FastAPI resolves `flow: Depends(get_flow_by_id_or_endpoint_name)` before the endpoint body, so the 404 fires before the auth check. `GET /api/v1/flows/{id}` requires session cookies — that is why test 2 uses `page.evaluate(fetch)` instead of `request.get`.
+- The `request` fixture used in tests 1 and 7 is unauthenticated by default; both tests now create a temporary `x-api-key` because Langflow's `WEBHOOK_AUTH_ENABLE` defaults to `True` since 1.10+ (PR langflow-ai/langflow#12845). The auth dependency `get_webhook_user` runs before `get_flow_by_id_or_endpoint_name` inside `get_webhook_auth`, so without an API key the endpoint returns 403 before any flow resolution — that is why test 7 also needs to authenticate to reach the 404 path. `GET /api/v1/flows/{id}` requires session cookies — that is why test 2 uses `page.evaluate(fetch)` instead of `request.get`.
 - The `output-inspection-json-webhook` testid is generated dynamically by the frontend as `output-inspection-{display_name.toLowerCase()}-{component_type}`; if the output display name reverts to `"Data"`, the testid becomes `output-inspection-data-webhook`.

--- a/docs/core-components/webhook-component-regression.md
+++ b/docs/core-components/webhook-component-regression.md
@@ -50,7 +50,7 @@ If any of these tests fails, the Webhook component is broken in one of its core 
 1. Run `addWebhookComponent`
 2. Extract `flowId` from the URL and assert it matches UUID pattern
 3. Wait 4 s for autosave to persist the flow
-4. Create a temporary API key via `POST /api/v1/api_key/` (Langflow's `WEBHOOK_AUTH_ENABLE` defaults to `True` since 1.5+, so unauthenticated webhook POSTs return 403)
+4. Create a temporary API key via `POST /api/v1/api_key/` (Langflow's `WEBHOOK_AUTH_ENABLE` defaults to `True` since 1.9.2+ via PR langflow-ai/langflow#12845, so unauthenticated webhook POSTs return 403)
 5. POST `{"event": "regression-test", "value": 42}` to `/api/v1/webhook/{flowId}` with `x-api-key`; assert 202, `status === "in progress"`, `message === "Task started in the background"`
 6. POST `"regression-plain-text"` with `x-api-key` and `Content-Type: text/plain`; assert 202 and `status === "in progress"`
 7. In `finally`, delete the temporary API key so failures don't leak credentials
@@ -89,7 +89,7 @@ If any of these tests fails, the Webhook component is broken in one of its core 
 5. Read `navigator.clipboard.readText()` via `page.evaluate` and assert it equals the expected URL
 
 **Test 7 — POST to non-existent flow name returns 404**
-1. Create a temporary API key via `POST /api/v1/api_key/` (Langflow's `WEBHOOK_AUTH_ENABLE` defaults to `True` since 1.10+, so the auth dependency runs before the flow lookup; without `x-api-key` the endpoint short-circuits to 403 and never reaches the 404 path)
+1. Create a temporary API key via `POST /api/v1/api_key/` (Langflow's `WEBHOOK_AUTH_ENABLE` defaults to `True` since 1.9.2+ via PR langflow-ai/langflow#12845, so the auth dependency runs before the flow lookup; without `x-api-key` the endpoint short-circuits to 403 and never reaches the 404 path)
 2. POST to `/api/v1/webhook/non-existent-flow-e2e-regression-test` with the `x-api-key` header
 3. Assert the response status is 404 (no browser navigation needed)
 4. In `finally`, delete the temporary API key so failures don't leak credentials
@@ -162,7 +162,7 @@ If any of these tests fails, the Webhook component is broken in one of its core 
 ## Preconditions *(optional)*
 
 - Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
-- The Webhook component is a pure HTTP input with no LLM calls, but the webhook POST endpoint requires an API key whenever `WEBHOOK_AUTH_ENABLE=True` (Langflow's default since 1.10+); tests 1 and 7 create a temporary key via `POST /api/v1/api_key/` and delete it in `finally`
+- The Webhook component is a pure HTTP input with no LLM calls, but the webhook POST endpoint requires an API key whenever `WEBHOOK_AUTH_ENABLE=True` (Langflow's default since 1.9.2+ via PR langflow-ai/langflow#12845); tests 1 and 7 create a temporary key via `POST /api/v1/api_key/` and delete it in `finally`
 - Tests 1, 8, and 9 require autosave to flush within 4 s of creating the flow; environments with very high DB latency may need a longer wait
 - The `output-inspection-json-webhook` testid requires Langflow version including langflow-ai/langflow#11554, which renamed the output display name from `"Data"` to `"JSON"`
 
@@ -180,5 +180,5 @@ If any of these tests fails, the Webhook component is broken in one of its core 
 ## Notes *(optional)*
 
 - Tests 8 and 9 use `page.route` to inject a value into the Webhook's `data` field (Payload, `advanced=True`), which has no editable UI in the inspector. The intercept patches the `GET /api/v1/flows/{id}` response before the page navigates to the flow, simulating what the real webhook POST would write to that field. The intercept is removed via `page.unroute` after navigation to avoid side-effects.
-- The `request` fixture used in tests 1 and 7 is unauthenticated by default; both tests now create a temporary `x-api-key` because Langflow's `WEBHOOK_AUTH_ENABLE` defaults to `True` since 1.10+ (PR langflow-ai/langflow#12845). The auth dependency `get_webhook_user` runs before `get_flow_by_id_or_endpoint_name` inside `get_webhook_auth`, so without an API key the endpoint returns 403 before any flow resolution — that is why test 7 also needs to authenticate to reach the 404 path. `GET /api/v1/flows/{id}` requires session cookies — that is why test 2 uses `page.evaluate(fetch)` instead of `request.get`.
+- The `request` fixture used in tests 1 and 7 is unauthenticated by default; both tests now create a temporary `x-api-key` because Langflow's `WEBHOOK_AUTH_ENABLE` defaults to `True` since 1.9.2+ (PR langflow-ai/langflow#12845). The auth dependency `get_webhook_user` runs before `get_flow_by_id_or_endpoint_name` inside `get_webhook_auth`, so without an API key the endpoint returns 403 before any flow resolution — that is why test 7 also needs to authenticate to reach the 404 path. `GET /api/v1/flows/{id}` requires session cookies — that is why test 2 uses `page.evaluate(fetch)` instead of `request.get`.
 - The `output-inspection-json-webhook` testid is generated dynamically by the frontend as `output-inspection-{display_name.toLowerCase()}-{component_type}`; if the output display name reverts to `"Data"`, the testid becomes `output-inspection-data-webhook`.

--- a/tests/tests-automations/regression/core-components/webhook-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/webhook-component-regression.spec.ts
@@ -43,7 +43,8 @@ test(
     await page.waitForTimeout(4000);
 
     // The webhook endpoint requires `x-api-key` whenever Langflow's
-    // WEBHOOK_AUTH_ENABLE setting is true (secure-by-default since 1.5+).
+    // WEBHOOK_AUTH_ENABLE setting is true (secure-by-default since 1.9.2+
+    // via PR langflow-ai/langflow#12845).
     // Create a temporary key, use it for the POSTs, and delete it after.
     const bearerToken = await getAuthToken(request);
     const keyRes = await request.post("/api/v1/api_key/", {
@@ -260,7 +261,7 @@ test(
   { tag: ["@stable", "@release", "@regression"] },
   async ({ request }) => {
     // The webhook endpoint returns 404 when the flow_id_or_name cannot be resolved.
-    // Since Langflow 1.10 (PR langflow-ai/langflow#12845) WEBHOOK_AUTH_ENABLE defaults
+    // Since Langflow 1.9.2 (PR langflow-ai/langflow#12845) WEBHOOK_AUTH_ENABLE defaults
     // to True, so the auth dependency runs before the flow lookup — without an x-api-key
     // the endpoint short-circuits to 403 and we never reach the 404. We create a temporary
     // API key, send the POST with it, and assert the resolver-driven 404 fires.

--- a/tests/tests-automations/regression/core-components/webhook-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/webhook-component-regression.spec.ts
@@ -257,19 +257,38 @@ test(
 
 test(
   "Webhook component — POST to non-existent flow name returns 404",
-  { tag: ["@release", "@regression"] },
+  { tag: ["@stable", "@release", "@regression"] },
   async ({ request }) => {
     // The webhook endpoint returns 404 when the flow_id_or_name cannot be resolved.
-    // This is confirmed by the backend unit test: test_webhook_not_found_invalid_endpoint.
-    // Using a string name (not UUID) as the backend resolves by endpoint_name first.
-    const response = await request.post(
-      "/api/v1/webhook/non-existent-flow-e2e-regression-test",
-      {
-        data: { test: "not-found" },
-      },
-    );
+    // Since Langflow 1.10 (PR langflow-ai/langflow#12845) WEBHOOK_AUTH_ENABLE defaults
+    // to True, so the auth dependency runs before the flow lookup — without an x-api-key
+    // the endpoint short-circuits to 403 and we never reach the 404. We create a temporary
+    // API key, send the POST with it, and assert the resolver-driven 404 fires.
+    const bearerToken = await getAuthToken(request);
+    const keyRes = await request.post("/api/v1/api_key/", {
+      headers: { Authorization: bearerToken },
+      data: { name: `webhook-404-regression-${Date.now()}` },
+    });
+    expect(keyRes.status()).toBe(200);
+    const keyBody = await keyRes.json();
+    const apiKey: string = keyBody.api_key;
+    const apiKeyId: string = keyBody.id;
 
-    expect(response.status()).toBe(404);
+    try {
+      const response = await request.post(
+        "/api/v1/webhook/non-existent-flow-e2e-regression-test",
+        {
+          headers: { "x-api-key": apiKey },
+          data: { test: "not-found" },
+        },
+      );
+
+      expect(response.status()).toBe(404);
+    } finally {
+      await request.delete(`/api/v1/api_key/${apiKeyId}`, {
+        headers: { Authorization: bearerToken },
+      });
+    }
   },
 );
 


### PR DESCRIPTION
## Summary

Re-enables the `Webhook component — POST to non-existent flow name returns 404` test, broken by an intentional upstream security change. The fix adds API-key authentication to the POST so the flow resolver actually runs and produces the 404 we assert on. `@stable` is restored.

## Investigation — how we concluded this is a product change, not a regression

We refused to jump straight to the "happy hypothesis" (product changed). Before re-writing the test we explicitly tried to falsify the other two:

### Hypothesis A — test bug

Ruled out. The test as it stood was 7 lines of `request.post` + `expect(response.status()).toBe(404)`. No selector, no race, no timing, no fixture coupling. The Playwright `request` fixture is unauthenticated by design and the previous test premise was "missing flow → 404 fires before any auth check." That premise is what broke — not the assertion or the wiring.

### Hypothesis B — Langflow regression (unintended)

Ruled out by four independent pieces of evidence:

1. **Commit message is self-labeled as an intentional security fix:**
   ```
   0e6d284bc4 fix(security): default WEBHOOK_AUTH_ENABLE to True (#12845)
   ```
   The author flipped the default *deliberately*. `fix(security)` is not how regressions get tagged.

2. **Upstream PR [langflow-ai/langflow#12845](https://github.com/langflow-ai/langflow/pull/12845)** is merged into Langflow's `main`, not a stale or abandoned branch.

3. **Source code matches the new contract.** In `src/backend/base/langflow/services/auth/service.py:394-434` (current `main` of the local Langflow clone), `get_webhook_user` explicitly:
   - Checks `settings_service.auth_settings.WEBHOOK_AUTH_ENABLE` first.
   - When `True` (now default), requires `x-api-key` from header or query and raises `HTTPException(status_code=403, detail="API key required when webhook authentication is enabled")` if absent.
   - Only after a valid key passes ownership validation via `get_user_by_flow_id_or_endpoint_name`, which raises `404 "Flow not found"` for missing flows.

4. **Dependency ordering is deliberate.** In `src/backend/base/langflow/api/v1/endpoints.py:569-579`, `get_webhook_auth` calls `get_webhook_user(...)` **before** `get_flow_by_id_or_endpoint_name(...)`. The route at line 899 (`@router.post("/webhook/{flow_id_or_name}")`) uses `Depends(get_webhook_auth)`. There is no execution path in which the 404 fires before the 403 when `WEBHOOK_AUTH_ENABLE=True`. The previous test only worked because the default was `False`.

### Hypothesis C — product changed ✓ (the actual cause)

Confirmed by live reproduction against the running Langflow instance:

| Scenario | HTTP | Body |
|---|---|---|
| `POST /api/v1/webhook/non-existent-flow-e2e-regression-test` *without* `x-api-key` | **403** | `{\"detail\":\"API key required when webhook authentication is enabled\"}` |
| Same POST *with* a valid `x-api-key` | **404** | `{\"detail\":\"Flow identifier non-existent-flow-e2e-regression-test not found\"}` |

The original assertion (\"missing flow returns 404\") is still observable — it just lives one auth hop further down the call stack now.

## Fix

`tests/tests-automations/regression/core-components/webhook-component-regression.spec.ts:258`:

- Acquire a bearer via `getAuthToken(request)` (same helper already imported in the file).
- `POST /api/v1/api_key/` to mint a temporary key.
- Send the webhook POST with `x-api-key`; assert 404 as before.
- Delete the API key in `finally` so credentials don't leak on failure.
- Restore `@stable` on the `test()` tag list.

This mirrors the existing 202 test (lines 33-83 of the same file) which already follows this exact pattern for the same upstream reason.

## Spec doc updates (`docs/core-components/webhook-component-regression.md`)

- Step list for Test 7 now describes the API-key dance.
- The Notes section previously claimed \"FastAPI resolves `flow: Depends(get_flow_by_id_or_endpoint_name)` before the endpoint body, so the 404 fires before the auth check\" — that statement is now factually wrong and has been rewritten to describe the actual `get_webhook_auth` ordering.
- Preconditions updated to mention that tests 1 **and** 7 mint a temporary key.

## QA-CHECKLIST.md

Auto-regenerated via `npm run coverage:summary`: `@stable` count goes from 148 → 149 and the Test 7 bullet flips to `[x]`. No manual edits.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors (2011 pre-existing warnings, unchanged)
- [x] Live reproduction without auth → 403 (matches issue); with auth → 404
- [x] `npx playwright test ... --grep \"POST to non-existent flow name returns 404\"` — 1 passed
- [x] `npm run coverage:summary` ran clean and bumped the count
- [ ] Next `weekly-stable` run includes this test as `@stable` and passes

Closes #269