### PR TITLE
fix(helpers): wait for sidebar-search-input before fill in setup-playground

### DIFF
--- a/tests/helpers/flows/setup-playground.ts
+++ b/tests/helpers/flows/setup-playground.ts
@@ -27,6 +27,11 @@ export async function setupPlayground(page: Page): Promise<string> {
   }
 
   try {
+    // The flow editor sidebar mounts after the POST /api/v1/flows response
+    // resolves; wait for sidebar-search-input before interacting (see #278).
+    await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
+      timeout: 30000,
+    });
     await page.getByTestId("sidebar-search-input").fill("chat output");
     await page.waitForSelector('[data-testid="input_outputChat Output"]', {
       timeout: 30000,


### PR DESCRIPTION
## Summary
- `setup-playground.ts` called `.fill()` on `sidebar-search-input` immediately after the flow-creation POST resolved, racing the React mount of the flow editor sidebar.
- Added a `toBeVisible({ timeout: 30000 })` wait before the first fill. The second fill is already protected — the sidebar is verified after the first interaction.

## Test plan
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — no new warnings in the touched file
- [x] `npx playwright test tests/tests-automations/regression/core-functionality/playground/playground-output-image.spec.ts` — 2/2 passed locally (13.9 s)
- [ ] Smoke remaining specs that import `setup-playground` (17 total) — fix is purely additive (extra wait before fill), so regression risk is minimal; relying on PR CI to catch anything

## Context
Identified during weekly-stable triage ([run 26027495405](https://github.com/oriontech-me/langflow-e2e/actions/runs/26027495405), 2026-05-18). The helper is imported by 17 specs across `playground/*` and `mcp/*` — fixing it should reduce first-render flakes broadly.

Closes #278