### PR TITLE
fix(mcp-client): wait for sidebar-nav-mcp before click

### DIFF
--- a/tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts
@@ -75,6 +75,9 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
           headers: { Authorization: `Bearer ${token}` },
         });
 
+        await expect(page.getByTestId("sidebar-nav-mcp")).toBeVisible({
+          timeout: 15000,
+        });
         await page.getByTestId("sidebar-nav-mcp").click();
         await expect(page.getByTestId("sidebar-add-mcp-server-button")).toBeVisible({
           timeout: 15000,
@@ -185,6 +188,9 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
       });
 
       await test.step("Register unreachable HTTP server via HTTP tab", async () => {
+        await expect(page.getByTestId("sidebar-nav-mcp")).toBeVisible({
+          timeout: 15000,
+        });
         await page.getByTestId("sidebar-nav-mcp").click();
         await expect(page.getByTestId("sidebar-add-mcp-server-button")).toBeVisible({
           timeout: 15000,
@@ -276,6 +282,9 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
       });
 
       await test.step("Register server via HTTP form tab", async () => {
+        await expect(page.getByTestId("sidebar-nav-mcp")).toBeVisible({
+          timeout: 15000,
+        });
         await page.getByTestId("sidebar-nav-mcp").click();
         await expect(page.getByTestId("sidebar-add-mcp-server-button")).toBeVisible({
           timeout: 15000,
@@ -346,6 +355,9 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
           headers: { Authorization: `Bearer ${token}` },
         });
 
+        await expect(page.getByTestId("sidebar-nav-mcp")).toBeVisible({
+          timeout: 15000,
+        });
         await page.getByTestId("sidebar-nav-mcp").click();
         await expect(page.getByTestId("sidebar-add-mcp-server-button")).toBeVisible({
           timeout: 15000,


### PR DESCRIPTION
## Summary
- `mcp-client-regression.spec.ts` clicked `sidebar-nav-mcp` immediately after navigating into a blank flow, racing the React mount of the flow editor sidebar.
- Added a `toBeVisible({ timeout: 15000 })` wait before each of the four `sidebar-nav-mcp.click()` sites (lines 81, 194, 288, 361).

## Test plan
- [x] `npm run typecheck` — 0 errors
- [x] `npx playwright test tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts` — 4/4 passed locally (30.7 s)

## Context
Identified during weekly-stable triage ([run 26027495405](https://github.com/oriontech-me/langflow-e2e/actions/runs/26027495405), 2026-05-18). Only line 349 (now 361) flaked in that run, but the same pattern repeats at 4 sites in the file — fixed all for consistency.

Closes #280