### PR TITLE
fix(duplicate-flow): assert duplicated flow by id instead of global count

### DIFF
--- a/docs/flow-functionality/duplicate-flow.md
+++ b/docs/flow-functionality/duplicate-flow.md
@@ -8,7 +8,7 @@
 
 Validates flow duplication in two complementary ways:
 
-1. **UI test:** Opens the Basic Prompting template (creates a flow), goes back to the home page, opens the dropdown for the first flow card, clicks `btn-duplicate-flow`, and asserts (a) the success toast renders and (b) the API flow count grew by **exactly one**.
+1. **UI test:** Opens the Basic Prompting template (creates a flow), goes back to the home page, opens the dropdown for the first flow card, clicks `btn-duplicate-flow`, and asserts (a) the duplicate `POST /api/v1/flows/` returns `201` with a non-empty `id`, (b) the success toast renders, and (c) that exact `id` appears in `GET /api/v1/flows/`.
 2. **API test:** Mirrors the duplicate hook (`useDuplicateFlow` → `createNewFlow` → `POST /api/v1/flows/`) by `POST`ing twice with the same name. Asserts the backend auto-suffixes the second flow with ` (N)` to keep names unique, and that both flows are listed with different IDs.
 
 Together the pair guarantees the duplicate dropdown action wires up to the real backend behavior — including the auto-suffix collision logic that the UI relies on for sane flow names.
@@ -30,10 +30,12 @@ API test: `@release` `@workspace` `@api` `@stable`
 2. Click `side_nav_options_all-templates`, then click the `Basic Prompting` heading to open the template (which creates a new flow)
 3. Wait for `sidebar-search-input` to confirm the editor loaded; navigate back via `icon-ChevronLeft`
 4. Wait for the first `home-dropdown-menu` to be visible
-5. Capture the current flow count via `GET /api/v1/flows/`
-6. Click the first `home-dropdown-menu`, wait for `btn-duplicate-flow` and click it
-7. Assert the toast `/duplicated successfully/i` renders
-8. Poll `GET /api/v1/flows/` until the count equals `countBefore + 1` (timeout 10s)
+5. Acquire a Bearer token via `getAuthToken(request)`
+6. Click the first `home-dropdown-menu`, wait for `btn-duplicate-flow`
+7. Register a `page.waitForResponse` listener for `POST /api/v1/flows/` with status `201`, then click `btn-duplicate-flow`
+8. Read the captured response body, extract the new flow's `id`, and assert it is truthy
+9. Assert the toast `/duplicated successfully/i` renders
+10. Poll `GET /api/v1/flows/` until the listing contains an entry whose `id` matches the captured `id` (timeout 10s)
 
 ### API test — `duplicate flow via API auto-suffixes the name on collision`
 
@@ -50,7 +52,7 @@ API test: `@release` `@workspace` `@api` `@stable`
 The UI test must:
 
 - Use `getByTestId("btn-duplicate-flow")`, **not** `getByText(/duplicate/i)` — i18n-proof
-- Snapshot the flow count via API before duplicate and assert exactly `+1` after — `count > 1` would always be true on a populated database (the home page lists 100+ flows in development environments)
+- Intercept the duplicate `POST /api/v1/flows/` response (status `201`) and assert by the returned `id`. The previous version snapshot the global flow count and polled for `countBefore + 1`, which falsely failed whenever a parallel worker created another flow during the poll window
 - Assert the success toast renders, confirming the action committed (not just the click landed)
 
 The API test must assert **all** of:
@@ -75,7 +77,7 @@ The API test must assert **all** of:
 
 ## What this test does not cover *(optional)*
 
-- Duplicating a flow with non-empty `data` (real components and edges) and verifying the duplicate's graph matches the original — this spec only validates **name** and **count** semantics, not graph cloning fidelity
+- Duplicating a flow with non-empty `data` (real components and edges) and verifying the duplicate's graph matches the original — this spec only validates **name** and **presence** semantics (the new flow exists in the listing), not graph cloning fidelity
 - Duplicating into a different folder (the hook supports `folder_id` via `useParams`, but this spec runs in the default folder)
 - Duplicating a flow the user does not own (permissions / multi-tenant scenarios)
 - The `(N)` suffix increment when N >= 2 (e.g., duplicating an already-duplicated flow). Current assertion `\(\d+\)` accepts any digit count
@@ -101,7 +103,9 @@ The API test must assert **all** of:
 
 ## Notes *(optional)*
 
-- The previous version of this spec asserted only `count > 1` after duplicate, which is essentially always true once any flow exists in the database — a near-empty assertion that would pass even if duplicate silently failed and only the original was visible.
+- An earlier version of this spec asserted only `count > 1` after duplicate, which is essentially always true once any flow exists in the database — a near-empty assertion that would pass even if duplicate silently failed and only the original was visible.
+- A subsequent revision tightened this to a `countBefore + 1` global-count poll. That assertion was structurally racy under Playwright's parallel workers — any unrelated flow created by another worker during the 10s poll window inflated the count and failed the test (see weekly-stable run 26027495405, where it failed with `Expected 39 / Received 41`). The current version intercepts the duplicate `POST` response and asserts by the captured `id`, which is race-proof against any concurrent flow creation.
+- Trade-off: the new assertion no longer implicitly catches a hypothetical "double-create" regression (UI firing the duplicate POST twice). The duplicate handler (`use-handle-duplicate.ts`) fires the API once per click and there is no historical bug in that direction; the cost of this check is worth less than the cost of false failures every parallel run.
 - The previous API test manually constructed `${originalName} (copy)` as the duplicate name, bypassing the actual collision logic the backend implements. This spec rewrites the test to POST with the **same** name twice, which is what the UI duplicate hook actually triggers, and asserts the server's auto-suffix instead.
 - Empirical confirmation of the auto-suffix format (` (1)`, with a leading space) was captured by a direct `curl` round-trip against the running backend. The regex `^${originalName} \(\d+\)$` reflects that exact format.
-- The UI test mixes UI action (click) with API verification (count delta). This is intentional: counting cards on the home page is unreliable when the user has 100+ flows (paginated to 12 per page), so the API is the source of truth for the count assertion.
+- The UI test mixes UI action (click) with API verification (identity poll). This is intentional: counting cards on the home page is unreliable when the user has 100+ flows (paginated to 12 per page), so the API is the source of truth for persistence.

--- a/tests/tests-automations/regression/flow-functionality/duplicate-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/duplicate-flow.spec.ts
@@ -27,37 +27,48 @@ test(
       timeout: 30000,
     });
 
-    // Snapshot the flow count from the API so we can assert exactly +1 after duplicate
     const authToken = await getAuthToken(request);
-    const listBefore = await request.get("/api/v1/flows/", {
-      headers: { Authorization: authToken },
-    });
-    const countBefore = ((await listBefore.json()) as unknown[]).length;
 
     await page.getByTestId("home-dropdown-menu").first().click();
     // Use the testid (not localized text) so the test does not break under i18n
     await expect(page.getByTestId("btn-duplicate-flow")).toBeVisible({
       timeout: 5000,
     });
+
+    // Intercept the duplicate POST so we know the new flow's id directly.
+    // Asserting by id (instead of a count delta on GET /flows) makes the
+    // test resilient to parallel workers creating unrelated flows.
+    const duplicateResponsePromise = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/v1/flows") &&
+        resp.request().method() === "POST" &&
+        resp.status() === 201,
+      { timeout: 10000 },
+    );
     await page.getByTestId("btn-duplicate-flow").click();
+    const duplicateResponse = await duplicateResponsePromise;
+    const duplicateId = ((await duplicateResponse.json()) as { id: string })
+      .id;
+    expect(duplicateId).toBeTruthy();
 
     // Toast appears as soon as the duplicate POST resolves — confirms the action committed
     await expect(page.getByText(/duplicated successfully/i).last()).toBeVisible(
       { timeout: 10000 },
     );
 
-    // Confirm exactly one new flow exists in the database (not a no-op or a double-create)
+    // Confirm the duplicated flow exists in the database
     await expect
       .poll(
         async () => {
           const res = await request.get("/api/v1/flows/", {
             headers: { Authorization: authToken },
           });
-          return ((await res.json()) as unknown[]).length;
+          const flows = (await res.json()) as Array<{ id: string }>;
+          return flows.some((f) => f.id === duplicateId);
         },
         { timeout: 10000, intervals: [500, 1000, 2000] },
       )
-      .toBe(countBefore + 1);
+      .toBe(true);
   },
 );
 


### PR DESCRIPTION
## Summary
- The UI test snapshot the global flow count via `GET /api/v1/flows/`, then polled until it grew by exactly `+1`. Under fully-parallel test execution other workers inflated the count, producing false failures.
- Refactored to intercept the duplicate `POST /api/v1/flows` response, capture the new flow's `id`, and poll until that id appears in the list — race-proof against any concurrent flow creation.

## Test plan
- [x] `npm run typecheck` — 0 errors
- [x] `npx playwright test duplicate-flow.spec.ts` — 2/2 passed locally (7.8 s)
- [x] No-op protection preserved: `page.waitForResponse(POST 201, timeout: 10s)` fails the test if the duplicate request never fires
- [x] Toast assertion preserved

## Trade-off
The previous count-delta check also implicitly guarded against a hypothetical "double-create" (UI fires the API twice). That guarantee is dropped — the duplicate handler (`use-handle-duplicate.ts` in Langflow) fires the API once per click, no known bug. The cost of removing this implicit check is much smaller than the cost of false failures every parallel run.

## Context
Identified during weekly-stable triage ([run 26027495405](https://github.com/oriontech-me/langflow-e2e/actions/runs/26027495405), 2026-05-18). Failed with `Expected 39 / Received 41` — two unrelated parallel flows landed during the poll window.

Closes #277