### PR TITLE
fix(playground-output-data): remove racy button-stop visibility assertion

### DIFF
--- a/docs/core-functionality/playground/playground-output-data.md
+++ b/docs/core-functionality/playground/playground-output-data.md
@@ -63,3 +63,4 @@ Both tests run without user input and without an API key or LLM — the Mock Dat
 ## Notes *(optional)*
 
 - Re-validated after PR #120: `runNoInputFlow` now waits for the first message instead of an exact count of 2; `cleanAllFlows` was replaced with REST API-based flow deletion.
+- Re-validated after #279: `runNoInputFlow` no longer asserts `button-stop` becomes visible — on instant Mock Data flows the Send→Stop→Hidden transition completed in <100 ms, faster than Playwright's auto-wait could observe. `toBeHidden` alone is the build-finished signal; `setupMockDataFlow` also gained an explicit `toBeVisible` wait on `sidebar-search-input` (same race pattern as #278).

--- a/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
@@ -16,6 +16,11 @@ async function setupMockDataFlow(
   await page.getByTestId("blank-flow").click();
 
   // Add Chat Output
+  // Sidebar mounts after blank-flow.click() navigates — wait before filling
+  // to avoid the same race as #278 (in setup-playground.ts).
+  await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
+    timeout: 30000,
+  });
   await page.getByTestId("sidebar-search-input").fill("chat output");
   await expect(page.getByTestId("input_outputChat Output")).toBeVisible({
     timeout: 30000,
@@ -81,9 +86,12 @@ async function setupMockDataFlow(
 
 async function runNoInputFlow(page: Page): Promise<void> {
   await page.getByTestId("button-send").click();
-  await expect(page.getByTestId("button-stop")).toBeVisible({
-    timeout: 30000,
-  });
+  // Mock Data → Chat Output has no LLM call, so the Send→Stop→Hidden
+  // transition can complete in under 100ms — faster than Playwright's
+  // auto-wait poll. Asserting `button-stop` appears was racy (#279).
+  // `toBeHidden` works in both cases: if it appeared, wait for hide; if it
+  // never appeared, this passes immediately — either way it confirms the
+  // build is no longer running before we check for the output.
   await expect(page.getByTestId("button-stop")).toBeHidden({
     timeout: 60000,
   });


### PR DESCRIPTION
## Summary
- `runNoInputFlow` asserted `button-stop` became visible then hidden after `button-send.click()`. Mock Data → Chat Output has no LLM call, so the Send→Stop→Hidden transition completes in under 100ms — too fast for Playwright's auto-wait. Dropped the `toBeVisible` step; `toBeHidden` alone works in both cases (if Stop appeared, wait for hide; if it never appeared, pass immediately).
- `setupMockDataFlow` filled `sidebar-search-input` without first awaiting visibility — same race pattern as #278, in this file's local helper. Added the same `toBeVisible` wait.

## Test plan
- [x] `npm run typecheck` — 0 errors
- [x] `npx playwright test playground-output-data.spec.ts --retries=0` — 2/2 passed cleanly (8.7 s)
- [x] Re-run `--retries=0` — 2/2 passed cleanly (9.0 s)

## Scope decision
This PR fixes both the documented #279 (Send→Stop window) **and** an adjacent race in `setupMockDataFlow:19` discovered while validating. They are the same pattern as #278 in a different file — fixing both here keeps the spec stable in one round-trip instead of two.

Closes #279