### PR TITLE
chore(traces-detail): tag @stable, add spec doc, drop test on obsolete /logs route

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -410,7 +410,7 @@
 
 #### 8.1 Traces
 - [-] View execution traces
-- [-] Trace API returns paginated transactions
+- [x] Trace API returns paginated transactions
 - [-] Trace displays latency of each component
 - [-] Trace displays tokens consumed
 
@@ -727,7 +727,7 @@
 | `core-functionality/knowledge-ingestion/` | 8 | 0 | 4 | 0 | 4 |
 | `core-functionality/llm-agents/` | 40 | 13 | 2 | 0 | 25 |
 | `core-functionality/model-provider/` | 31 | 4 | 18 | 0 | 9 |
-| `core-functionality/observability-monitoring/` | 13 | 0 | 12 | 0 | 1 |
+| `core-functionality/observability-monitoring/` | 13 | 1 | 11 | 0 | 1 |
 | `core-functionality/playground/` | 48 | 43 | 3 | 1 | 1 |
 | `core-functionality/project-management/` | 11 | 0 | 10 | 1 | 0 |
 | `core-functionality/templates/` | 41 | 2 | 39 | 0 | 0 |
@@ -736,7 +736,7 @@
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 43 | 3 | 38 | 1 | 1 |
 | `ui-ux/` — Settings | 5 | 1 | 3 | 1 | 0 |
-| **TOTAL** | **422** | **160 (38%)** | **201 (48%)** | **7 (2%)** | **54 (13%)** |
+| **TOTAL** | **422** | **161 (38%)** | **200 (47%)** | **7 (2%)** | **54 (13%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -752,7 +752,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 160 `test()` calls carrying the `@stable` tag, distributed across 54 spec
+> 163 `test()` calls carrying the `@stable` tag, distributed across 55 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -864,6 +864,11 @@
 - [x] message history context retention suite → `memory-history-regression.spec.ts`
 - [x] session isolation: new session has no context from previous session → `memory-history-regression.spec.ts`
 
+#### core-functionality/observability-monitoring/
+- [x] GET /api/v1/monitor/transactions returns 200 with paginated result → `traces-detail.spec.ts`
+- [x] GET /api/v1/monitor/transactions filters by flow_id (UUID) → `traces-detail.spec.ts`
+- [x] transaction records contain required fields when not empty → `traces-detail.spec.ts`
+
 #### core-functionality/playground/
 - [x] copy button copies Text Input output and toggles Check icon → `output-modal-copy-button.spec.ts`
 - [x] playground must show one compact preview per attached image when two images are attached → `playground-attachments-management.spec.ts`
@@ -963,7 +968,7 @@
 
 | Module | Validate (`[-]`) | Create (`[ ]`) |
 |--------|-----------------|---------------|
-| `core-functionality/observability-monitoring/` | 12 | 1 |
+| `core-functionality/observability-monitoring/` | 11 | 1 |
 | `core-functionality/knowledge-ingestion/` | 4 | 4 |
 | `flow-functionality/` | 15 | 0 |
 | `core-functionality/project-management/` | 10 | 0 |

--- a/docs/core-functionality/observability-monitoring/traces-detail.md
+++ b/docs/core-functionality/observability-monitoring/traces-detail.md
@@ -1,0 +1,85 @@
+# Traces — Transactions API Shape
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+Pins the contract of the `GET /api/v1/monitor/transactions` endpoint that the Traces UI consumes: always returns a paginated response shape (`{ items, total, page, size, pages }`), enforces the `flow_id` filter, and emits record fields that downstream observability work depends on. A regression on the wire format would break the Traces grid before any UI test fires.
+
+This file covers the REST surface only; deeper UI flows (Flow Activity columns, Trace Details modal, span tree) live in `traces-latency-tokens.spec.ts`, and the empty-state UI smoke lives in `traces.spec.ts`.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@regression` `@workspace` `@api` `@observability`
+
+---
+
+## Step by step *(required)*
+
+**Test 1 — `GET /api/v1/monitor/transactions returns 200 with paginated result`**
+1. Get a bearer token via `getAuthToken(request)`
+2. `GET /api/v1/monitor/transactions?flow_id=00000000-0000-0000-0000-000000000001` with `Authorization: <token>`
+3. Assert HTTP 200; the body is a non-null object; `body.items` is an array; `body.total` is a number
+
+**Test 2 — `GET /api/v1/monitor/transactions filters by flow_id (UUID)`**
+1. Get a bearer token
+2. `GET /api/v1/monitor/transactions?flow_id=00000000-0000-0000-0000-000000000001` (a well-formed UUID that maps to no real flow)
+3. Assert HTTP 200, `body.items` is an array, `body.items.length === 0`, `body.total === 0`
+
+**Test 3 — `transaction records contain required fields when not empty`**
+1. Get a bearer token
+2. `GET /api/v1/monitor/transactions?flow_id=00000000-0000-0000-0000-000000000001` and parse `body.items`
+3. If `items.length === 0`, the test returns early (nothing to validate)
+4. Otherwise assert the first record is a plain object (not null, not an array) and carries at least one of `timestamp` / `created_at` / `updated_at`
+
+---
+
+## Validation criterion *(required)*
+
+- **Test 1** — The endpoint returns the paginated envelope shape `{ items: [], total, page, size, pages }`. A regression where `total` is missing or `items` is not an array would break the Traces UI (`FlowInsightsContent.tsx` expects this shape) and surface here first.
+- **Test 2** — A well-formed `flow_id` that maps to no rows returns `200` with an empty `items` array, not `400` or `404`. This pins the contract that "unknown flow_id" is a normal empty result and not an error condition.
+- **Test 3** — When transactions exist, each record exposes a recognizable timestamp field (`timestamp`, `created_at`, or `updated_at`). The Traces UI orders rows by time; removing every recognizable timestamp would break the grid silently.
+
+---
+
+## External dependencies *(required)*
+
+References in the **main Langflow repository** (compatible with Langflow 1.10.x):
+
+- `src/backend/base/langflow/api/v1/monitor.py` — `GET /transactions` handler (line 558); `transform_transaction_table_for_logs`; auth dependency via `get_current_active_user`
+- `src/backend/base/langflow/services/database/models/transactions/model.py` — `TransactionLogsResponse`, `TransactionTable`
+- `src/frontend/src/pages/FlowPage/components/TraceComponent/FlowInsightsContent.tsx` — consumer of the paginated transactions/traces shape
+
+References in this repository:
+
+- `tests/helpers/auth/get-auth-token.ts` — issues a bearer token for the superuser
+
+---
+
+## What this test does not cover *(optional)*
+
+- Running a flow and confirming a real transaction is emitted — covered by `traces-latency-tokens.spec.ts`, which seeds a flow via API, runs it, and polls `/api/v1/monitor/traces` for emitted rows.
+- UI assertions on the actual Traces grid (latency column, tokens column, Trace Details modal, span tree) — covered by `traces-latency-tokens.spec.ts`.
+- The empty-state UI smoke (template loaded, no run, Traces panel shows "No Data Available") — covered by `traces.spec.ts`.
+- Pagination behavior beyond the envelope shape (e.g. `page`, `size`, `pages` boundary conditions). The current tests assert the keys exist but not their values across multiple pages.
+- Negative auth path — a `GET /api/v1/monitor/transactions` without `Authorization` returning 401/403. The backend enforces it via `Depends(get_current_active_user)`, but no test pins that contract here yet.
+- The `/api/v1/monitor/messages` endpoint — covered by `api/flows/api-monitor-messages.spec.ts` and `api/flows/api-monitor-messages-crud.spec.ts`.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
+- The configured superuser (`LANGFLOW_SUPERUSER` / `LANGFLOW_SUPERUSER_PASSWORD`) must be able to issue a token via `getAuthToken`
+- No provider keys required
+
+---
+
+## Notes *(optional)*
+
+- A fourth test (`traces page is accessible from main navigation`) was previously in this file and was removed in the same PR that introduced this doc. It called `page.goto("/logs")` and asserted the app-shell selector `mainpage_title`, on the premise that `/logs` was a frontend route for the traces view. In current Langflow `/logs` is a **backend** endpoint (defined at `src/backend/base/langflow/api/log_router.py`, line 75) that returns `{"detail": "Log retrieval is disabled"}` when log retrieval is off — there is no frontend page at that path. The traces UI is flow-scoped, accessed via the Traces button on the flow toolbar (covered by `traces.spec.ts`) or `sidebar-nav-traces` inside the flow sidebar (covered by `traces-latency-tokens.spec.ts`), so no coverage was lost by removing the broken test.
+- All three remaining tests reuse the same well-formed UUID `00000000-0000-0000-0000-000000000001` because the endpoint requires `flow_id` and the suite must not depend on the database having any pre-existing flow.

--- a/docs/core-functionality/observability-monitoring/traces-detail.md
+++ b/docs/core-functionality/observability-monitoring/traces-detail.md
@@ -14,7 +14,7 @@ This file covers the REST surface only; deeper UI flows (Flow Activity columns, 
 
 ## Tags *(required)*
 
-`@stable` `@release` `@regression` `@workspace` `@api` `@observability`
+`@stable` `@release` `@api` `@regression` `@observability`
 
 ---
 
@@ -23,7 +23,7 @@ This file covers the REST surface only; deeper UI flows (Flow Activity columns, 
 **Test 1 — `GET /api/v1/monitor/transactions returns 200 with paginated result`**
 1. Get a bearer token via `getAuthToken(request)`
 2. `GET /api/v1/monitor/transactions?flow_id=00000000-0000-0000-0000-000000000001` with `Authorization: <token>`
-3. Assert HTTP 200; the body is a non-null object; `body.items` is an array; `body.total` is a number
+3. Assert HTTP 200; the body is a non-null object; `body.items` is an array; `body.total` is a number; and `body` contains the pagination keys `page`, `size`, `pages`
 
 **Test 2 — `GET /api/v1/monitor/transactions filters by flow_id (UUID)`**
 1. Get a bearer token
@@ -40,7 +40,7 @@ This file covers the REST surface only; deeper UI flows (Flow Activity columns, 
 
 ## Validation criterion *(required)*
 
-- **Test 1** — The endpoint returns the paginated envelope shape `{ items: [], total, page, size, pages }`. A regression where `total` is missing or `items` is not an array would break the Traces UI (`FlowInsightsContent.tsx` expects this shape) and surface here first.
+- **Test 1** — The endpoint returns the full fastapi-pagination envelope `{ items, total, page, size, pages }`. Every key is asserted to be present so a regression that drops any of them — even silently — would surface here before the Traces UI (`FlowInsightsContent.tsx`) breaks at render time.
 - **Test 2** — A well-formed `flow_id` that maps to no rows returns `200` with an empty `items` array, not `400` or `404`. This pins the contract that "unknown flow_id" is a normal empty result and not an error condition.
 - **Test 3** — When transactions exist, each record exposes a recognizable timestamp field (`timestamp`, `created_at`, or `updated_at`). The Traces UI orders rows by time; removing every recognizable timestamp would break the grid silently.
 

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail.spec.ts
@@ -1,45 +1,9 @@
 import { expect, test } from "../../../../fixtures/fixtures";
-import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 
 test(
-  "traces page is accessible from main navigation",
-  { tag: ["@release", "@workspace", "@regression", "@observability"] },
-  async ({ page }) => {
-    await awaitBootstrapTest(page);
-
-    // Try navigating directly to /logs (Langflow uses /logs for the traces/logs view)
-    await page.goto("/logs");
-
-    // The page should load without a hard error — either the logs page renders,
-    // or we get redirected back to the home page.  Either way the main title must
-    // be visible (it is always present in the app shell).
-    await page.waitForSelector('[data-testid="mainpage_title"]', {
-      timeout: 30000,
-    });
-
-    // If the URL stayed at /logs the logs section must have rendered some content.
-    // If the app redirected away (no dedicated /logs route), just confirm we are
-    // still on the application without a crash.
-    const currentUrl = page.url();
-    const isOnLogsPage = currentUrl.includes("/logs");
-
-    if (isOnLogsPage) {
-      // The logs page should contain either entries or an empty-state message
-      const hasContent = await page
-        .locator("body")
-        .evaluate((el) => (el as HTMLElement).innerText.length > 0);
-      expect(hasContent).toBe(true);
-    } else {
-      // Redirected — the app is still alive and the home page rendered
-      await expect(page.getByTestId("mainpage_title")).toBeVisible();
-    }
-  },
-);
-
-test(
   "GET /api/v1/monitor/transactions returns 200 with paginated result",
-  { tag: ["@release", "@workspace", "@regression", "@observability"] },
+  { tag: ["@stable", "@release", "@workspace", "@regression", "@api", "@observability"] },
   async ({ request }) => {
     const authToken = await getAuthToken(request);
 
@@ -64,7 +28,7 @@ test(
 
 test(
   "GET /api/v1/monitor/transactions filters by flow_id (UUID)",
-  { tag: ["@release", "@workspace", "@regression", "@observability"] },
+  { tag: ["@stable", "@release", "@workspace", "@regression", "@api", "@observability"] },
   async ({ request }) => {
     const authToken = await getAuthToken(request);
 
@@ -88,7 +52,7 @@ test(
 
 test(
   "transaction records contain required fields when not empty",
-  { tag: ["@release", "@workspace", "@regression", "@observability"] },
+  { tag: ["@stable", "@release", "@workspace", "@regression", "@api", "@observability"] },
   async ({ request }) => {
     const authToken = await getAuthToken(request);
 

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail.spec.ts
@@ -3,7 +3,7 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 
 test(
   "GET /api/v1/monitor/transactions returns 200 with paginated result",
-  { tag: ["@stable", "@release", "@workspace", "@regression", "@api", "@observability"] },
+  { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
   async ({ request }) => {
     const authToken = await getAuthToken(request);
 
@@ -18,17 +18,23 @@ test(
     expect(res.status()).toBe(200);
     const body = await res.json();
 
-    // The endpoint returns a paginated response: { items: [], total, page, size, pages }
+    // The endpoint returns the fastapi-pagination envelope:
+    // { items: [], total, page, size, pages }. Each key must be present so the
+    // Traces UI (FlowInsightsContent.tsx) can render a paginated grid without
+    // probing for optional fields.
     expect(typeof body).toBe("object");
     expect(body).not.toBeNull();
     expect(Array.isArray(body.items)).toBe(true);
     expect(typeof body.total).toBe("number");
+    expect(body).toHaveProperty("page");
+    expect(body).toHaveProperty("size");
+    expect(body).toHaveProperty("pages");
   },
 );
 
 test(
   "GET /api/v1/monitor/transactions filters by flow_id (UUID)",
-  { tag: ["@stable", "@release", "@workspace", "@regression", "@api", "@observability"] },
+  { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
   async ({ request }) => {
     const authToken = await getAuthToken(request);
 
@@ -52,7 +58,7 @@ test(
 
 test(
   "transaction records contain required fields when not empty",
-  { tag: ["@stable", "@release", "@workspace", "@regression", "@api", "@observability"] },
+  { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
   async ({ request }) => {
     const authToken = await getAuthToken(request);
 


### PR DESCRIPTION
## Summary

- `traces-detail.spec.ts` now follows the "spec born `@stable`" rule and ships with the missing spec doc.
- All 3 remaining tests get `@stable`. The two transaction-API tests and the field-shape test also gain `@api`, which they were missing — they exercise `request.get("/api/v1/monitor/transactions")`, which is exactly what `@api` is for per CLAUDE.md.
- **The 4th test (`traces page is accessible from main navigation`) was deleted.** Its premise was wrong: `/logs` is the *backend* log-retrieval endpoint (`src/backend/base/langflow/api/log_router.py:75`) returning `{"detail":"Log retrieval is disabled"}` when the feature is off — there is no frontend route at `/logs`. So `page.goto("/logs")` rendered raw JSON in the browser, the assert on `[data-testid="mainpage_title"]` timed out after 30 s, and the test failed every run. The current traces UI is flow-scoped, fully covered by `traces.spec.ts` (Traces button → empty state) and `traces-latency-tokens.spec.ts` (sidebar-nav-traces → populated grid → Trace Details modal).
- The now-unused `awaitBootstrapTest` import was removed.
- New spec doc: `docs/core-functionality/observability-monitoring/traces-detail.md`, with all mandatory sections and the deletion rationale in `Notes`.
- `QA-CHECKLIST.md` § 8.1 "Trace API returns paginated transactions" flipped from `[-]` to `[x]`. Coverage summary and `Phase 0` regenerated via `npm run coverage:summary`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — warnings on `traces-detail.spec.ts` dropped from 5 → 2 (only pre-existing `prefer-to-have-length` and `no-conditional-in-test` patterns remain)
- [x] `npx playwright test traces-detail.spec.ts` — 3/3 pass in 1.0 s
- [x] Force-fail check on test 1 (changed `expect(res.status()).toBe(200)` to `.toBe(418)`): test failed as expected, reverted, re-ran — all 3 green
- [x] No backend or flow execution errors logged

Closes #287