### PR TITLE
chore(traces-latency-tokens): tag @stable, add spec doc, drop duplicate + broken tests

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -411,8 +411,8 @@
 #### 8.1 Traces
 - [-] View execution traces
 - [x] Trace API returns paginated transactions
-- [-] Trace displays latency of each component
-- [-] Trace displays tokens consumed
+- [x] Trace displays latency of each component
+- [x] Trace displays tokens consumed
 
 #### 8.2 Notifications
 - [-] System notifications
@@ -727,7 +727,7 @@
 | `core-functionality/knowledge-ingestion/` | 8 | 0 | 4 | 0 | 4 |
 | `core-functionality/llm-agents/` | 40 | 13 | 2 | 0 | 25 |
 | `core-functionality/model-provider/` | 31 | 4 | 18 | 0 | 9 |
-| `core-functionality/observability-monitoring/` | 13 | 1 | 11 | 0 | 1 |
+| `core-functionality/observability-monitoring/` | 13 | 3 | 9 | 0 | 1 |
 | `core-functionality/playground/` | 48 | 43 | 3 | 1 | 1 |
 | `core-functionality/project-management/` | 11 | 0 | 10 | 1 | 0 |
 | `core-functionality/templates/` | 41 | 2 | 39 | 0 | 0 |
@@ -736,7 +736,7 @@
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 43 | 3 | 38 | 1 | 1 |
 | `ui-ux/` — Settings | 5 | 1 | 3 | 1 | 0 |
-| **TOTAL** | **422** | **161 (38%)** | **200 (47%)** | **7 (2%)** | **54 (13%)** |
+| **TOTAL** | **422** | **163 (39%)** | **198 (47%)** | **7 (2%)** | **54 (13%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -752,7 +752,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 163 `test()` calls carrying the `@stable` tag, distributed across 55 spec
+> 166 `test()` calls carrying the `@stable` tag, distributed across 56 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -868,6 +868,9 @@
 - [x] GET /api/v1/monitor/transactions returns 200 with paginated result → `traces-detail.spec.ts`
 - [x] GET /api/v1/monitor/transactions filters by flow_id (UUID) → `traces-detail.spec.ts`
 - [x] transaction records contain required fields when not empty → `traces-detail.spec.ts`
+- [x] GET /api/v1/monitor/traces returns totalLatencyMs and totalTokens for a flow run → `traces-latency-tokens.spec.ts`
+- [x] Flow Activity page shows latency and token columns for the run → `traces-latency-tokens.spec.ts`
+- [x] Trace Details modal shows span tree and per-span latency → `traces-latency-tokens.spec.ts`
 
 #### core-functionality/playground/
 - [x] copy button copies Text Input output and toggles Check icon → `output-modal-copy-button.spec.ts`
@@ -968,7 +971,7 @@
 
 | Module | Validate (`[-]`) | Create (`[ ]`) |
 |--------|-----------------|---------------|
-| `core-functionality/observability-monitoring/` | 11 | 1 |
+| `core-functionality/observability-monitoring/` | 9 | 1 |
 | `core-functionality/knowledge-ingestion/` | 4 | 4 |
 | `flow-functionality/` | 15 | 0 |
 | `core-functionality/project-management/` | 10 | 0 |

--- a/docs/core-functionality/observability-monitoring/traces-latency-tokens.md
+++ b/docs/core-functionality/observability-monitoring/traces-latency-tokens.md
@@ -41,7 +41,7 @@ The 3 tests share a single `beforeAll` setup and run in `serial` mode so the see
    - `typeof totalLatencyMs === "number"` and `>= 0`
    - `typeof totalTokens === "number"` and `>= 0`
    - `flowId === <seeded flowId>`
-   - `status` is one of `"success" | "error" | "running"`
+   - `status` is one of `"unset" | "ok" | "error"` (the OpenTelemetry-aligned `SpanStatus` enum defined at `services/database/models/traces/model.py:96-106`)
    - `typeof startTime === "string"`
 
 **Test 2 — `Flow Activity page shows latency and token columns for the run`**

--- a/docs/core-functionality/observability-monitoring/traces-latency-tokens.md
+++ b/docs/core-functionality/observability-monitoring/traces-latency-tokens.md
@@ -96,6 +96,7 @@ References in this repository:
 - The empty-state UI smoke (template loaded, no run, Traces panel shows "No Data Available") — covered by `traces.spec.ts`.
 - The `/api/v1/monitor/transactions` envelope contract — covered by `traces-detail.spec.ts`.
 - Successful (non-error) trace shape: this spec exercises the failure path because no provider is configured in the fixture. A successful trace might surface extra fields (e.g., token counts > 0, span outputs). Not pinned here.
+- **Implicit contract:** the entire suite assumes Langflow emits a trace for a flow that fails at component-execution time (the seeded run intentionally errors at `LanguageModelComponent`). If a future Langflow release ever decided not to emit traces for component failures, the `beforeAll` polling at `/api/v1/monitor/traces` would time out at 30 s and surface as a flake on every nightly. The contract is not pinned by any test in the repo and is not documented as guaranteed in Langflow's docs — at most "observability captures runs regardless of success/failure" is the design intent. If this fragility ever materializes, the fix is to switch the fixture to a provider-configured flow that succeeds.
 - Span detail tabs other than latency (inputs/outputs, attributes, events). Test 3 only asserts the latency text appears in `span-detail`.
 - Trace filtering (status, query, start/end time, session_id). The handler supports those query params but no test pins them.
 - Negative auth path on `/api/v1/monitor/traces` — no test pins the 401/403 response on missing or bad token.

--- a/docs/core-functionality/observability-monitoring/traces-latency-tokens.md
+++ b/docs/core-functionality/observability-monitoring/traces-latency-tokens.md
@@ -1,0 +1,119 @@
+# Traces — Latency, Tokens, and Span Tree (end-to-end)
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+This is the deepest trace coverage in the suite. It seeds a real flow run via API, polls until at least one trace is emitted, then pins three contracts:
+
+1. **REST API:** `GET /api/v1/monitor/traces?flow_id=<id>` returns a trace list where each trace exposes the metrics consumed by the Flow Activity UI — `totalLatencyMs`, `totalTokens`, `flowId`, `status`, `startTime`.
+2. **Flow Activity UI:** opening the flow editor and clicking `sidebar-nav-traces` renders a grid with `totalLatencyMs` and `totalTokens` columns populated with real numeric values for the seeded run.
+3. **Trace Details UI:** clicking the `run` cell of a trace row opens the Trace Details modal showing the span tree (root + Prompt Template + Chat Input + Language Model), per-span latency, and the span detail panel.
+
+The 3 tests share a single `beforeAll` setup and run in `serial` mode so the seeded flow + emitted trace are reused.
+
+---
+
+## Tags *(required)*
+
+**Test 1 (API):** `@stable` `@release` `@api` `@regression` `@observability`
+**Tests 2–3 (UI inside the flow editor):** `@stable` `@release` `@workspace` `@regression` `@observability`
+
+---
+
+## Step by step *(required)*
+
+**`beforeAll` (shared setup)**
+1. Get a bearer token via `getAuthToken(request)`
+2. Create an API key (`POST /api/v1/api_key/` with bearer auth, name `traces-latency-test-<timestamp>`) and capture `api_key` + `id`
+3. Create a flow (`POST /api/v1/flows/` with `x-api-key` auth) from `tests/assets/flows/basic-prompting-trace-fixture.json`, name suffixed with the timestamp; expect HTTP 201; capture `flowId`
+4. Run the flow once (`POST /api/v1/run/{flowId}` with `x-api-key` auth, `input_value: "trace-probe"`, `input_type: "chat"`, `output_type: "chat"`). The fixture has no provider configured, so the LanguageModelComponent fails with "A model selection is required" — the failure is **intentional**: it still emits a trace entry with `totalLatencyMs` and `totalTokens`, which is what the suite validates. Accept HTTP 200 or 500; anything outside that range means the run never reached the graph executor.
+5. Poll `GET /api/v1/monitor/traces?flow_id=<flowId>` (Bearer auth) with intervals `[500, 1000, 2000]` ms up to 30 s until `body.traces.length > 0` — trace writes are asynchronous, so downstream tests must wait for them to land
+
+**`afterAll`** — delete the flow (`x-api-key`) and the API key (Bearer).
+
+**Test 1 — `GET /api/v1/monitor/traces returns totalLatencyMs and totalTokens for a flow run`**
+1. `GET /api/v1/monitor/traces?flow_id=<flowId>` with Bearer auth
+2. Assert HTTP 200; `body.traces` is an array with length > 0; `body.total` is a number > 0
+3. Pick the first trace and assert:
+   - `typeof totalLatencyMs === "number"` and `>= 0`
+   - `typeof totalTokens === "number"` and `>= 0`
+   - `flowId === <seeded flowId>`
+   - `status` is one of `"success" | "error" | "running"`
+   - `typeof startTime === "string"`
+
+**Test 2 — `Flow Activity page shows latency and token columns for the run`**
+1. Mark `page.allowFlowErrors()` (the seeded flow fails at the LanguageModelComponent by design; without this the fixture's HTTP error monitor would fail the test)
+2. `page.goto("/flow/<flowId>")`
+3. Wait for `sidebar-nav-traces` to be visible (30 s timeout), then click it
+4. Assert `flow-activity-header` is visible (10 s)
+5. Locate the first `.ag-cell[col-id="totalLatencyMs"]`; assert it is visible (15 s) and its text matches `/^\d+\s*ms$/` (15 s) — the cell renders before metrics populate, so the text-match timeout is larger than the visibility one on purpose
+6. Locate the first `.ag-cell[col-id="totalTokens"]`; assert it is visible and its text matches `/^\d+$/` (15 s)
+
+**Test 3 — `Trace Details modal shows span tree and per-span latency`**
+1. Mark `page.allowFlowErrors()`
+2. `page.goto("/flow/<flowId>")` and click `sidebar-nav-traces`
+3. Click the first `.ag-cell[col-id="run"]` — whole-row click does not trigger the panel because `onCellClicked` is the wired event
+4. Assert `trace-detail-view` is visible (10 s); `span-tree` is visible; `span-detail` is visible
+5. Assert there are exactly **4 span nodes** (`[data-testid^="span-node-"]`): 1 root + Prompt Template + Chat Input + Language Model
+6. In the `span-detail` panel, assert the text contains `Latency` and a `\d+\s*ms` pattern (per-span latency render)
+7. In the `span-tree`, assert the labels `Prompt Template`, `Chat Input`, `Language Model` are present
+
+---
+
+## Validation criterion *(required)*
+
+- **Test 1** — Pins the wire contract that downstream UI consumes: each trace exposes `totalLatencyMs`, `totalTokens`, `flowId`, `status`, `startTime`. A regression that renames any of these or drops a key would surface here before the Flow Activity grid breaks at render time. The bounds checks (`>= 0`, allowed status set) protect against type-shape regressions.
+- **Test 2** — The Flow Activity grid renders `totalLatencyMs` and `totalTokens` columns populated with actual numeric values for the seeded run. Regex anchors (`^\d+\s*ms$`, `^\d+$`) prevent silent regressions where the cell renders a placeholder like `—` or `null`.
+- **Test 3** — The Trace Details modal shows the full per-span breakdown for the seeded flow: 4 spans (root + 3 components), per-span latency in the detail panel, span labels in the tree. Pins the wiring between `onCellClicked` on the Run cell and `TraceDetailView` + `SpanTree` + `SpanDetail`.
+
+---
+
+## External dependencies *(required)*
+
+References in the **main Langflow repository** (compatible with Langflow 1.10.x):
+
+- `src/backend/base/langflow/api/v1/traces.py:45` — `GET /monitor/traces` handler returning `TraceListResponse`; line 42 mounts the router with prefix `/monitor/traces`
+- `src/backend/base/langflow/services/tracing/formatting.py:108` — defines `totalTokens` key on the trace payload (the formatter also emits `totalLatencyMs` and the other fields the test asserts)
+- `src/frontend/src/pages/FlowPage/components/TraceComponent/FlowInsightsContent.tsx:263` — defines `data-testid="flow-activity-header"`
+- `src/frontend/src/pages/FlowPage/components/TraceComponent/TraceDetailView.tsx:108` — defines `data-testid="trace-detail-view"`
+- `src/frontend/src/pages/FlowPage/components/TraceComponent/SpanTree.tsx:71` — defines `data-testid="span-tree"`
+- `src/frontend/src/pages/FlowPage/components/TraceComponent/SpanDetail.tsx:44` — defines `data-testid="span-detail"`
+- `data-testid="sidebar-nav-traces"` is asserted in Langflow's own unit tests under `flowSidebarComponent/components/__tests__/sidebarSegmentedNav.test.tsx`
+
+References in this repository:
+
+- `tests/assets/flows/basic-prompting-trace-fixture.json` — minimal Basic Prompting flow with no provider configured; runs to a LanguageModelComponent error that still emits a trace
+- `tests/helpers/auth/get-auth-token.ts` — issues a bearer token for the superuser
+- `tests/fixtures/fixtures.ts` — `page.allowFlowErrors()` opt-in for specs that intentionally trigger flow execution errors
+
+---
+
+## What this test does not cover *(optional)*
+
+- The empty-state UI smoke (template loaded, no run, Traces panel shows "No Data Available") — covered by `traces.spec.ts`.
+- The `/api/v1/monitor/transactions` envelope contract — covered by `traces-detail.spec.ts`.
+- Successful (non-error) trace shape: this spec exercises the failure path because no provider is configured in the fixture. A successful trace might surface extra fields (e.g., token counts > 0, span outputs). Not pinned here.
+- Span detail tabs other than latency (inputs/outputs, attributes, events). Test 3 only asserts the latency text appears in `span-detail`.
+- Trace filtering (status, query, start/end time, session_id). The handler supports those query params but no test pins them.
+- Negative auth path on `/api/v1/monitor/traces` — no test pins the 401/403 response on missing or bad token.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
+- The configured superuser (`LANGFLOW_SUPERUSER` / `LANGFLOW_SUPERUSER_PASSWORD`) must be able to issue a token via `getAuthToken`
+- No provider keys required — the fixture is intentionally unconfigured
+
+---
+
+## Notes *(optional)*
+
+- The 3 tests share a `beforeAll` that does heavy setup (key + flow + run + poll). `test.describe.configure({ mode: "serial" })` is critical: parallel execution would race on the seeded flow and the polled trace. Tests must not be reordered without considering this.
+- Two further tests previously lived at the bottom of this file and were removed in the same PR that introduced this doc:
+  - `GET /api/v1/monitor/messages response contains message content` — duplicated `api/flows/api-monitor-messages.spec.ts`, which has more thorough assertions (`id`, `session_id`, `timestamp`, `sender`, `text`). The version here used a looser `hasContent || hasContext` check. Removed as duplicate.
+  - `traces page is accessible in the UI` — gated on `GET /api/v1/monitor/transactions` without `flow_id`, which the backend rejects with 422; the early-return path made the test pass trivially without ever exercising the UI. It also navigated to `/logs`, which is a **backend** endpoint (`src/backend/base/langflow/api/log_router.py:75`), not a frontend route — the same pattern that broke the deleted test in `traces-detail.spec.ts`. UI coverage of the populated Traces grid is owned by tests 2 and 3 in this file.
+- The fixture deliberately runs to error (`LanguageModelComponent` requires a model selection). The trace is still emitted because Langflow's tracing service captures component runs regardless of success/failure — that is the whole point of observability.

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-latency-tokens.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-latency-tokens.spec.ts
@@ -121,7 +121,7 @@ test.describe("Flow Activity / Traces — latency and tokens", () => {
       expect(typeof trace.totalTokens).toBe("number");
       expect(trace.totalTokens).toBeGreaterThanOrEqual(0);
       expect(trace.flowId).toBe(flowId);
-      expect(["success", "error", "running"]).toContain(trace.status);
+      expect(["unset", "ok", "error"]).toContain(trace.status);
       expect(typeof trace.startTime).toBe("string");
     },
   );

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-latency-tokens.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-latency-tokens.spec.ts
@@ -129,7 +129,13 @@ test.describe("Flow Activity / Traces — latency and tokens", () => {
   test(
     "Flow Activity page shows latency and token columns for the run",
     {
-      tag: ["@stable", "@release", "@workspace", "@regression", "@observability"],
+      tag: [
+        "@stable",
+        "@release",
+        "@workspace",
+        "@regression",
+        "@observability",
+      ],
     },
     async ({ page }) => {
       (page as any).allowFlowErrors();
@@ -163,7 +169,13 @@ test.describe("Flow Activity / Traces — latency and tokens", () => {
   test(
     "Trace Details modal shows span tree and per-span latency",
     {
-      tag: ["@stable", "@release", "@workspace", "@regression", "@observability"],
+      tag: [
+        "@stable",
+        "@release",
+        "@workspace",
+        "@regression",
+        "@observability",
+      ],
     },
     async ({ page }) => {
       (page as any).allowFlowErrors();

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-latency-tokens.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-latency-tokens.spec.ts
@@ -95,11 +95,11 @@ test.describe("Flow Activity / Traces — latency and tokens", () => {
     "GET /api/v1/monitor/traces returns totalLatencyMs and totalTokens for a flow run",
     {
       tag: [
+        "@stable",
         "@release",
-        "@workspace",
+        "@api",
         "@regression",
         "@observability",
-        "@api",
       ],
     },
     async ({ request }) => {
@@ -129,7 +129,7 @@ test.describe("Flow Activity / Traces — latency and tokens", () => {
   test(
     "Flow Activity page shows latency and token columns for the run",
     {
-      tag: ["@release", "@workspace", "@regression", "@observability"],
+      tag: ["@stable", "@release", "@workspace", "@regression", "@observability"],
     },
     async ({ page }) => {
       (page as any).allowFlowErrors();
@@ -163,7 +163,7 @@ test.describe("Flow Activity / Traces — latency and tokens", () => {
   test(
     "Trace Details modal shows span tree and per-span latency",
     {
-      tag: ["@release", "@workspace", "@regression", "@observability"],
+      tag: ["@stable", "@release", "@workspace", "@regression", "@observability"],
     },
     async ({ page }) => {
       (page as any).allowFlowErrors();
@@ -199,93 +199,3 @@ test.describe("Flow Activity / Traces — latency and tokens", () => {
   );
 });
 
-test(
-  "GET /api/v1/monitor/messages response contains message content",
-  { tag: ["@release", "@workspace", "@regression", "@observability"] },
-  async ({ request }) => {
-    const authToken = await getAuthToken(request);
-
-    const res = await request.get("/api/v1/monitor/messages", {
-      headers: { Authorization: authToken },
-    });
-
-    expect(res.status()).toBe(200);
-
-    const body = await res.json();
-
-    // Accept both array and paginated object formats
-    const messages = Array.isArray(body) ? body : body.items ?? [];
-
-    // If messages exist, check their structure
-    if (messages.length > 0) {
-      const firstMsg = messages[0];
-
-      // Messages should have text content and session/flow info
-      const hasContent =
-        "text" in firstMsg ||
-        "message" in firstMsg ||
-        "content" in firstMsg;
-
-      const hasContext =
-        "session_id" in firstMsg ||
-        "flow_id" in firstMsg ||
-        "sender" in firstMsg;
-
-      expect(
-        hasContent || hasContext,
-        "Message items should contain message content and context metadata",
-      ).toBe(true);
-    }
-  },
-);
-
-test(
-  "traces page is accessible in the UI",
-  { tag: ["@release", "@workspace", "@regression", "@observability"] },
-  async ({ page, request }) => {
-    const authToken = await getAuthToken(request);
-
-    // Fetch transactions to see if any exist
-    const txRes = await request.get("/api/v1/monitor/transactions", {
-      headers: { Authorization: authToken },
-    });
-
-    if (txRes.status() !== 200) {
-      console.log("INFO: Transactions endpoint not available, skipping UI test");
-      return;
-    }
-
-    const body = await txRes.json();
-    const hasTransactions = body.total > 0;
-
-    if (!hasTransactions) {
-      console.log("INFO: No transactions in the system, skipping latency UI test");
-      return;
-    }
-
-    // Navigate to the traces/logs page
-    await page.goto("/logs");
-    await page.waitForTimeout(2000);
-
-    const hasTraceContent = await page
-      .locator("body")
-      .evaluate((el) => (el as HTMLElement).innerText.length > 50);
-
-    // Traces page might show latency info, duration, or token counts
-    const hasMetricsText = await page
-      .getByText(/latency|duration|tokens|ms|sec/i)
-      .first()
-      .isVisible({ timeout: 5000 })
-      .catch(() => false);
-
-    expect(
-      hasTraceContent,
-      "Traces page should have content when transactions exist",
-    ).toBe(true);
-
-    // Document whether latency metrics are shown in the UI
-    if (hasMetricsText) {
-      console.log("INFO: Latency/token metrics found in traces UI");
-    }
-  },
-);


### PR DESCRIPTION
## Summary

- `traces-latency-tokens.spec.ts` now follows the "spec born `@stable`" rule and ships with the missing spec doc.
- The 3 valuable tests inside the serial `describe` block get `@stable`. Test 1 (pure-API) drops `@workspace` and reorders to match the `api/flows/` convention `@stable @release @api @regression`; tests 2 and 3 are flow-editor UI and keep `@workspace`.
- **Two trailing tests outside the describe block were deleted:**
  - `GET /api/v1/monitor/messages response contains message content` — duplicated by `api/flows/api-monitor-messages.spec.ts`, which has stronger assertions (`id`, `session_id`, `timestamp`, `sender`, `text`). The version here used a looser `hasContent || hasContext` check. No coverage lost.
  - `traces page is accessible in the UI` — gated on `GET /api/v1/monitor/transactions` without `flow_id` (rejected with 422 by the backend), so the test always early-returned without exercising the UI. Even if the gate had been bypassed, `page.goto("/logs")` would have hit the backend log-retrieval endpoint, not a frontend page — same pattern as the deleted test in #287/#290. No coverage lost.
- New spec doc: `docs/core-functionality/observability-monitoring/traces-latency-tokens.md`, with all mandatory sections, the `beforeAll` setup walkthrough (key + flow + run + trace polling), and the deletion rationale in `Notes`.
- `QA-CHECKLIST.md` § 8.1 "Trace displays latency of each component" and "Trace displays tokens consumed" flipped from `[-]` to `[x]`. Coverage summary regenerated (Phase 0: 160 → 163).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — only the 2 pre-existing `any` warnings on `(page as any).allowFlowErrors()` (lines 135 and 169 of the post-edit file) remain
- [x] `npm run coverage:summary` — idempotent on the working tree
- [x] `npx playwright test traces-latency-tokens.spec.ts --trace=on` — 3/3 pass in 7.4 s; trace action sequences match the spec doc step-by-step (auto_login → api_key → flows → run → monitor/traces; UI tests: goto → sidebar-nav-traces → flow-activity-header / trace-detail-view assertions)
- [x] Force-fail run isolated for each of the 3 tests: each failed at the targeted assertion, reverted, full re-run green
- [x] No backend or flow execution errors logged

Closes #288