### PR TITLE
fix(traces-detail): seed transaction for record-shape assertion

### DIFF
--- a/docs/core-functionality/observability-monitoring/traces-detail.md
+++ b/docs/core-functionality/observability-monitoring/traces-detail.md
@@ -30,11 +30,22 @@ This file covers the REST surface only; deeper UI flows (Flow Activity columns, 
 2. `GET /api/v1/monitor/transactions?flow_id=00000000-0000-0000-0000-000000000001` (a well-formed UUID that maps to no real flow)
 3. Assert HTTP 200, `body.items` is an array, `body.items.length === 0`, `body.total === 0`
 
-**Test 3 — `transaction records contain required fields when not empty`**
-1. Get a bearer token
-2. `GET /api/v1/monitor/transactions?flow_id=00000000-0000-0000-0000-000000000001` and parse `body.items`
-3. If `items.length === 0`, the test returns early (nothing to validate)
-4. Otherwise assert the first record is a plain object (not null, not an array) and carries at least one of `timestamp` / `created_at` / `updated_at`
+**Test 3 — `transaction records contain required fields when not empty`** (runs inside a serial `describe` block that seeds a flow run in `beforeAll`)
+
+_Seeding (`beforeAll`)_
+1. Get a bearer token and create an API key via `POST /api/v1/api_key/`
+2. Import `tests/assets/flows/basic-prompting-trace-fixture.json` via `POST /api/v1/flows/` (using `x-api-key`)
+3. Trigger one run via `POST /api/v1/run/<flowId>`; accept HTTP 200 or 500 — the fixture has no provider configured and fails at the LanguageModelComponent, which is intentional and still emits a transaction row
+4. Poll `GET /api/v1/monitor/transactions?flow_id=<flowId>` until `items.length > 0` (timeout 30 s)
+
+_Test body_
+1. `GET /api/v1/monitor/transactions?flow_id=<flowId>` (the real seeded flow id, not the placeholder UUID)
+2. Assert HTTP 200, `body.items` is an array, `body.items.length > 0`
+3. Assert the first record is a plain object (not null, not an array) and carries at least one of `timestamp` / `created_at` / `updated_at`
+
+_Cleanup (`afterAll`)_
+1. Delete the seeded flow via `DELETE /api/v1/flows/<flowId>`
+2. Delete the API key via `DELETE /api/v1/api_key/<apiKeyId>`
 
 ---
 
@@ -42,7 +53,7 @@ This file covers the REST surface only; deeper UI flows (Flow Activity columns, 
 
 - **Test 1** — The endpoint returns the full fastapi-pagination envelope `{ items, total, page, size, pages }`. Every key is asserted to be present so a regression that drops any of them — even silently — would surface here before the Traces UI (`FlowInsightsContent.tsx`) breaks at render time.
 - **Test 2** — A well-formed `flow_id` that maps to no rows returns `200` with an empty `items` array, not `400` or `404`. This pins the contract that "unknown flow_id" is a normal empty result and not an error condition.
-- **Test 3** — When transactions exist, each record exposes a recognizable timestamp field (`timestamp`, `created_at`, or `updated_at`). The Traces UI orders rows by time; removing every recognizable timestamp would break the grid silently.
+- **Test 3** — After seeding one transaction by running a real flow, the emitted record exposes a recognizable timestamp field (`timestamp`, `created_at`, or `updated_at`). The Traces UI orders rows by time; removing every recognizable timestamp would break the grid silently. The seed step is mandatory: on a clean Langflow instance no transactions exist for the fixture's flow id, so without it the assertion would never execute.
 
 ---
 
@@ -57,17 +68,18 @@ References in the **main Langflow repository** (compatible with Langflow 1.10.x)
 References in this repository:
 
 - `tests/helpers/auth/get-auth-token.ts` — issues a bearer token for the superuser
+- `tests/assets/flows/basic-prompting-trace-fixture.json` — minimal flow imported by test 3's `beforeAll` to seed one transaction row
 
 ---
 
 ## What this test does not cover *(optional)*
 
-- Running a flow and confirming a real transaction is emitted — covered by `traces-latency-tokens.spec.ts`, which seeds a flow via API, runs it, and polls `/api/v1/monitor/traces` for emitted rows.
 - UI assertions on the actual Traces grid (latency column, tokens column, Trace Details modal, span tree) — covered by `traces-latency-tokens.spec.ts`.
 - The empty-state UI smoke (template loaded, no run, Traces panel shows "No Data Available") — covered by `traces.spec.ts`.
 - Pagination behavior beyond the envelope shape (e.g. `page`, `size`, `pages` boundary conditions). The current tests assert the keys exist but not their values across multiple pages.
 - Negative auth path — a `GET /api/v1/monitor/transactions` without `Authorization` returning 401/403. The backend enforces it via `Depends(get_current_active_user)`, but no test pins that contract here yet.
 - The `/api/v1/monitor/messages` endpoint — covered by `api/flows/api-monitor-messages.spec.ts` and `api/flows/api-monitor-messages-crud.spec.ts`.
+- The `/api/v1/monitor/traces` endpoint shape (latency / tokens / span tree) — covered by `traces-latency-tokens.spec.ts`. Test 3 here seeds via the same fixture but polls `/monitor/transactions`, which is a distinct endpoint with a distinct record schema.
 
 ---
 
@@ -82,4 +94,4 @@ References in this repository:
 ## Notes *(optional)*
 
 - A fourth test (`traces page is accessible from main navigation`) was previously in this file and was removed in the same PR that introduced this doc. It called `page.goto("/logs")` and asserted the app-shell selector `mainpage_title`, on the premise that `/logs` was a frontend route for the traces view. In current Langflow `/logs` is a **backend** endpoint (defined at `src/backend/base/langflow/api/log_router.py`, line 75) that returns `{"detail": "Log retrieval is disabled"}` when log retrieval is off — there is no frontend page at that path. The traces UI is flow-scoped, accessed via the Traces button on the flow toolbar (covered by `traces.spec.ts`) or `sidebar-nav-traces` inside the flow sidebar (covered by `traces-latency-tokens.spec.ts`), so no coverage was lost by removing the broken test.
-- All three remaining tests reuse the same well-formed UUID `00000000-0000-0000-0000-000000000001` because the endpoint requires `flow_id` and the suite must not depend on the database having any pre-existing flow.
+- Tests 1 and 2 reuse the same well-formed UUID `00000000-0000-0000-0000-000000000001` because the endpoint requires `flow_id` and the envelope-shape and empty-result assertions must not depend on the database having any pre-existing flow. Test 3 cannot use the same UUID — there are no transactions for a fake flow id, so the assertion would never execute on a clean environment — and therefore seeds its own flow + run + cleanup inside a serial `describe` block.

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail.spec.ts
@@ -1,5 +1,17 @@
+import { readFileSync } from "fs";
+import path from "path";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+
+const TRACE_FIXTURE = JSON.parse(
+  readFileSync(
+    path.resolve(
+      __dirname,
+      "../../../../assets/flows/basic-prompting-trace-fixture.json",
+    ),
+    "utf8",
+  ),
+);
 
 test(
   "GET /api/v1/monitor/transactions returns 200 with paginated result",
@@ -56,46 +68,114 @@ test(
   },
 );
 
-test(
-  "transaction records contain required fields when not empty",
-  { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
-  async ({ request }) => {
-    const authToken = await getAuthToken(request);
+test.describe("Transaction record shape — seeded flow", () => {
+  test.describe.configure({ mode: "serial" });
 
-    // flow_id is required — use a valid UUID
-    const res = await request.get(
-      "/api/v1/monitor/transactions?flow_id=00000000-0000-0000-0000-000000000001",
-      {
-        headers: { Authorization: authToken },
+  let bearerToken: string;
+  let apiKey: string;
+  let apiKeyId: string;
+  let flowId: string;
+
+  test.beforeAll(async ({ request }) => {
+    bearerToken = await getAuthToken(request);
+
+    const keyRes = await request.post("/api/v1/api_key/", {
+      headers: { Authorization: bearerToken },
+      data: { name: `traces-detail-test-${Date.now()}` },
+    });
+    expect(keyRes.status()).toBe(200);
+    const keyBody = await keyRes.json();
+    apiKey = keyBody.api_key;
+    apiKeyId = keyBody.id;
+
+    const flowRes = await request.post("/api/v1/flows/", {
+      headers: { "x-api-key": apiKey },
+      data: {
+        ...TRACE_FIXTURE,
+        name: `${TRACE_FIXTURE.name} ${Date.now()}`,
       },
-    );
+    });
+    expect(flowRes.status()).toBe(201);
+    flowId = (await flowRes.json()).id;
 
-    expect(res.status()).toBe(200);
-    const body = await res.json();
-    expect(Array.isArray(body.items)).toBe(true);
+    // Run the flow once to emit a transaction. The fixture has no provider
+    // configured, so the LanguageModelComponent fails with "A model selection
+    // is required" — that is intentional. The component failure still writes a
+    // transaction row, which is what this test validates.
+    const runRes = await request.post(`/api/v1/run/${flowId}`, {
+      headers: { "x-api-key": apiKey },
+      data: {
+        input_value: "transaction-probe",
+        input_type: "chat",
+        output_type: "chat",
+      },
+    });
+    expect([200, 500]).toContain(runRes.status());
 
-    if (body.items.length === 0) {
-      // No transactions yet — nothing to validate, test passes
-      return;
+    // Transaction writes are asynchronous: poll /monitor/transactions until at
+    // least one row exists for this flow before asserting record shape.
+    await expect
+      .poll(
+        async () => {
+          const res = await request.get(
+            `/api/v1/monitor/transactions?flow_id=${flowId}`,
+            { headers: { Authorization: bearerToken } },
+          );
+          if (res.status() !== 200) return 0;
+          const body = await res.json();
+          return body.items?.length ?? 0;
+        },
+        { timeout: 30000, intervals: [500, 1000, 2000] },
+      )
+      .toBeGreaterThan(0);
+  });
+
+  test.afterAll(async ({ request }) => {
+    if (flowId) {
+      await request.delete(`/api/v1/flows/${flowId}`, {
+        headers: { "x-api-key": apiKey },
+      });
     }
+    if (apiKeyId) {
+      await request.delete(`/api/v1/api_key/${apiKeyId}`, {
+        headers: { Authorization: bearerToken },
+      });
+    }
+  });
 
-    // Each record must have at minimum an id and a timestamp (or flow_id)
-    const record = body.items[0];
-    expect(record).toBeDefined();
+  test(
+    "transaction records contain required fields when not empty",
+    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
+    async ({ request }) => {
+      const res = await request.get(
+        `/api/v1/monitor/transactions?flow_id=${flowId}`,
+        { headers: { Authorization: bearerToken } },
+      );
 
-    // The transaction object must be a plain object (not null/array)
-    expect(typeof record).toBe("object");
-    expect(record).not.toBeNull();
-    expect(Array.isArray(record)).toBe(false);
+      expect(res.status()).toBe(200);
+      const body = await res.json();
+      expect(Array.isArray(body.items)).toBe(true);
+      expect(body.items.length).toBeGreaterThan(0);
 
-    // One of the common timestamp fields must be present
-    const hasTimestamp =
-      "timestamp" in record ||
-      "created_at" in record ||
-      "updated_at" in record;
-    expect(
-      hasTimestamp,
-      "Transaction record should contain a timestamp field",
-    ).toBe(true);
-  },
-);
+      const record = body.items[0];
+      expect(record).toBeDefined();
+
+      // The transaction object must be a plain object (not null/array)
+      expect(typeof record).toBe("object");
+      expect(record).not.toBeNull();
+      expect(Array.isArray(record)).toBe(false);
+
+      // One of the common timestamp fields must be present — the Traces UI
+      // orders rows by time, so losing every recognizable timestamp would
+      // break the grid silently.
+      const hasTimestamp =
+        "timestamp" in record ||
+        "created_at" in record ||
+        "updated_at" in record;
+      expect(
+        hasTimestamp,
+        "Transaction record should contain a timestamp field",
+      ).toBe(true);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- Test 3 of `traces-detail.spec.ts` (`transaction records contain required fields when not empty`) used a placeholder `flow_id`, so on any clean environment `items.length === 0` triggered the early-return and the record-shape assertions never executed. The test was effectively a no-op despite being `@stable`.
- Wraps test 3 in a serial `describe` block that mirrors `traces-latency-tokens.spec.ts`'s seeding pattern: create API key → import `basic-prompting-trace-fixture.json` → run once (component-error is intentional and still emits a transaction row) → poll `/monitor/transactions` until `items.length > 0` → assert record shape on the seeded result. `afterAll` deletes the flow and API key.
- Tests 1 and 2 are unchanged — they validate envelope shape and empty-result behavior, where the fake UUID is the correct input.
- Spec doc updated: revised Test 3 step-by-step + validation criterion, added the fixture under External dependencies, dropped the "real transaction not emitted" entry from "What this test does not cover", and clarified that this spec polls `/monitor/transactions` while `traces-latency-tokens.spec.ts` polls `/monitor/traces` (distinct endpoints, distinct schemas).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new warnings in the changed file (and one pre-existing `no-conditional-in-test` warning is removed along with the early-return)
- [x] `npx playwright test tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail.spec.ts` — 3/3 pass against a local Langflow instance (~3.5s total)
- [x] Verified the new `expect(body.items.length).toBeGreaterThan(0)` runs before the shape assertion, so a seeding failure would surface as a real failure (no silent pass)

Closes #291