### PR TITLE
test(observability): pin GET /monitor/traces/{trace_id} contract

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -413,6 +413,8 @@
 - [x] Trace API returns paginated transactions
 - [x] Trace displays latency of each component
 - [x] Trace displays tokens consumed
+- [x] Single-trace API returns 404 for an unknown trace_id → `traces-detail-single.spec.ts`
+- [x] Single-trace API returns the full TraceRead contract with a non-empty span tree → `traces-detail-single.spec.ts`
 
 #### 8.2 Notifications
 - [-] System notifications

--- a/docs/core-functionality/observability-monitoring/traces-detail-single.md
+++ b/docs/core-functionality/observability-monitoring/traces-detail-single.md
@@ -54,17 +54,20 @@ Both tests (negative and happy path) carry the same tag set.
 4. Assert `body.spans` is a non-empty array; flatten the tree (root + recursive `children`) and walk every node:
    - `typeof id === "string"`; `typeof name === "string"`
    - `type` ∈ `SpanType` enum; `status` ∈ `SpanStatus` enum (asserted on every node)
-   - `typeof latencyMs === "number"`
+   - `typeof latencyMs === "number"` and `>= 0`
    - Keys present (nullable): `startTime`, `endTime`, `inputs`, `outputs`, `error`, `modelName`, `tokenUsage`
    - `children` is an array
-   - When `tokenUsage` is non-null, assert `promptTokens`, `completionTokens`, `totalTokens` are all numbers (matches the OTel-derived shape produced by `formatting.py:105-109`)
+
+Note on `sessionId` and `tokenUsage`:
+- `sessionId` is typed `str` on `TraceRead` but the underlying column is nullable. The spec accepts `"string" | null` to match the wire reality.
+- `tokenUsage` shape (`promptTokens` / `completionTokens` / `totalTokens` numeric assertions) is **not** asserted here. The fixture errors before any LLM call, so the field always lands as `null` and a conditional shape check would be dead code under this fixture. The populated-LLM-span contract is tracked in issue #306 and will land as a dedicated spec with a provider-configured fixture.
 
 ---
 
 ## Validation criterion *(required)*
 
 - **Test 1** — Pins the only documented failure path for the single-trace endpoint: a 404 when the trace is not visible to the caller. A regression that returned 500, 403, or 200-with-empty-payload would surface here. Because the handler enforces ownership via the SQL join, this test also implicitly covers the "trace owned by a different user" case without needing a second user fixture.
-- **Test 2** — Pins the wire contract that `TraceDetailView` + `SpanTree` + `SpanDetail` consume. A rename or drop of any top-level `TraceRead` field, or any `SpanReadResponse` field, would surface here before the Trace Details modal breaks at render time. The enum checks on every span (not just the root) protect against drift in either `SpanType` or `SpanStatus`. The conditional `tokenUsage` shape check pins the OTel-derived `promptTokens`/`completionTokens`/`totalTokens` keys when populated.
+- **Test 2** — Pins the wire contract that `TraceDetailView` + `SpanTree` + `SpanDetail` consume. A rename or drop of any top-level `TraceRead` field, or any `SpanReadResponse` field, would surface here before the Trace Details modal breaks at render time. The enum checks on every span (not just the root) protect against drift in either `SpanType` or `SpanStatus`. Numeric guards (`totalLatencyMs`, `totalTokens`, per-span `latencyMs` all `>= 0`) catch regressions to sentinel values like `-1` or `NaN`. **Out of scope:** the populated `tokenUsage` / `modelName` contract on the LLM span — tracked in #306.
 
 ---
 
@@ -90,7 +93,7 @@ References in this repository:
 ## What this test does not cover *(optional)*
 
 - **`DELETE /api/v1/monitor/traces/{trace_id}`** — defined on the same router (`traces.py:138`) but exercised by no spec.
-- **Successful (non-error) trace shape** — the fixture errors at the LanguageModelComponent by design, so `tokenUsage` and `modelName` on the LLM span land as `null`. The keys are asserted to exist; when populated, the `tokenUsage` shape is pinned. A spec that asserts non-null token counters would need a provider-configured fixture (separate cost/flake tradeoff).
+- **Populated LLM-span contract** — the fixture errors at the LanguageModelComponent by design, so `tokenUsage` and `modelName` always land as `null` on the LLM span. The keys are asserted to exist (shape contract), but value-level assertions (`promptTokens > 0`, `totalTokens === promptTokens + completionTokens`, `modelName` matches the provider response) are tracked in #306, which will land as a dedicated spec using a provider-configured fixture. Deliberate scope reduction to keep this spec free of provider keys / cost / flake.
 - **Explicit ownership test with a second user** — the upstream `test_monitor_ownership.py` covers `builds`/`transactions`/`messages` but not single-trace, and the handler's SQL join means the 404 path is identical to the foreign-owned case. The 404 test in this spec covers both cases. A dedicated cross-user spec would require seeding a second user (not currently supported by the helpers).
 - **Span tree structural assertions** (parent/child wiring, exact span count) — covered by Test 3 in `traces-latency-tokens.spec.ts` against the UI, where `span-node` data-testids are asserted to be exactly 4.
 - **Negative auth path** (401/403 on missing/bad token) — no test pins this for the single-trace endpoint.

--- a/docs/core-functionality/observability-monitoring/traces-detail-single.md
+++ b/docs/core-functionality/observability-monitoring/traces-detail-single.md
@@ -50,7 +50,7 @@ Both tests (negative and happy path) carry the same tag set.
    - `status` is one of `"unset" | "ok" | "error"`
    - `typeof startTime === "string"`; `endTime`, `input`, `output` keys are present (nullable)
    - `typeof totalLatencyMs === "number"` and `>= 0`; same for `totalTokens`
-   - `flowId === <seeded flowId>`; `typeof sessionId === "string"`
+   - `flowId === <seeded flowId>`; `sessionId` is `"string" | null` (column is nullable — see note below)
 4. Assert `body.spans` is a non-empty array; flatten the tree (root + recursive `children`) and walk every node:
    - `typeof id === "string"`; `typeof name === "string"`
    - `type` ∈ `SpanType` enum; `status` ∈ `SpanStatus` enum (asserted on every node)
@@ -75,11 +75,11 @@ Note on `sessionId` and `tokenUsage`:
 
 References in the **main Langflow repository** (compatible with Langflow 1.10.x):
 
-- `src/backend/base/langflow/api/v1/traces.py:102` — `GET /monitor/traces/{trace_id}` handler returning `TraceRead`
-- `src/backend/base/langflow/services/tracing/repository.py:218` — `fetch_single_trace` joins `trace → flow → user`, so unknown trace and foreign-owned trace both collapse to `None` → 404
-- `src/backend/base/langflow/services/database/models/traces/model.py:84-106` — `SpanType` and `SpanStatus` enum definitions asserted by both tests
-- `src/backend/base/langflow/services/database/models/traces/model.py:166-216` — `SpanReadResponse` and `TraceRead` Pydantic models (camelCase via `alias_generator=to_camel`)
-- `src/backend/base/langflow/services/tracing/formatting.py:105-109` — emits `tokenUsage` with `promptTokens`, `completionTokens`, `totalTokens`
+- `src/backend/base/langflow/api/v1/traces.py` (line 102) — `GET /monitor/traces/{trace_id}` handler returning `TraceRead`
+- `src/backend/base/langflow/services/tracing/repository.py` (line 218) — `fetch_single_trace` joins `trace → flow → user`, so unknown trace and foreign-owned trace both collapse to `None` → 404
+- `src/backend/base/langflow/services/database/models/traces/model.py` (lines 84-106) — `SpanType` and `SpanStatus` enum definitions asserted by both tests
+- `src/backend/base/langflow/services/database/models/traces/model.py` (lines 166-216) — `SpanReadResponse` and `TraceRead` Pydantic models (camelCase via `alias_generator=to_camel`)
+- `src/backend/base/langflow/services/tracing/formatting.py` (lines 97-109) — emits `tokenUsage` with `promptTokens`, `completionTokens`, `totalTokens`
 - `src/backend/tests/unit/api/v1/test_monitor_ownership.py` — upstream ownership coverage for `builds`, `transactions`, and `messages`; the single-trace endpoint is **not** covered there, which is the gap this spec fills
 
 References in this repository:

--- a/docs/core-functionality/observability-monitoring/traces-detail-single.md
+++ b/docs/core-functionality/observability-monitoring/traces-detail-single.md
@@ -1,0 +1,112 @@
+# Single-Trace API — `GET /api/v1/monitor/traces/{trace_id}` contract
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+The `/api/v1/monitor/traces` list endpoint is exercised by `traces-latency-tokens.spec.ts`, but the per-trace endpoint that feeds the **Trace Details modal** was previously unasserted. This spec pins that contract:
+
+1. **Negative path:** `GET /api/v1/monitor/traces/<unknown-uuid>` returns **404**. The handler joins `trace → flow → user`, so an unknown trace and a trace owned by a different user both collapse to the same response — one test covers both cases.
+2. **Happy path:** with a seeded flow + run + emitted trace, `GET /api/v1/monitor/traces/<trace_id>` returns **200** with the full `TraceRead` contract: top-level fields (`id`, `name`, `status`, `startTime`, `endTime`, `totalLatencyMs`, `totalTokens`, `flowId`, `sessionId`, `input`, `output`, `spans`) and a non-empty span tree where every span exposes the keys the `SpanDetail` panel consumes (`id`, `name`, `type`, `status`, `latencyMs`, `startTime`, `endTime`, `inputs`, `outputs`, `error`, `modelName`, `tokenUsage`, `children`).
+
+Enum coverage:
+- `SpanType` ∈ `chain | llm | tool | retriever | embedding | parser | agent`
+- `SpanStatus` ∈ `unset | ok | error`
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@api` `@regression` `@observability`
+
+Both tests (negative and happy path) carry the same tag set.
+
+---
+
+## Step by step *(required)*
+
+**Test 1 — `GET /api/v1/monitor/traces/{trace_id} returns 404 for an unknown but well-formed UUID`** *(standalone)*
+1. Get a bearer token via `getAuthToken(request)`
+2. `GET /api/v1/monitor/traces/00000000-0000-0000-0000-000000000001` with Bearer auth
+3. Assert HTTP 404
+
+**`describe("Single trace shape — seeded flow")` — `beforeAll` (shared setup)**
+1. Get a bearer token via `getAuthToken(request)`
+2. Create an API key (`POST /api/v1/api_key/` with Bearer auth, name `traces-detail-single-test-<timestamp>`); capture `api_key` + `id`
+3. Create a flow (`POST /api/v1/flows/` with `x-api-key` auth) from `tests/assets/flows/basic-prompting-trace-fixture.json`, name suffixed with the timestamp; expect HTTP 201; capture `flowId`
+4. Run the flow once (`POST /api/v1/run/{flowId}` with `x-api-key` auth, `input_value: "single-trace-probe"`, `input_type: "chat"`, `output_type: "chat"`). The fixture has no provider configured, so the LanguageModelComponent fails — the failure is **intentional**: the trace still lands. Accept HTTP 200 or 500
+5. Poll `GET /api/v1/monitor/traces?flow_id=<flowId>` (Bearer auth) with intervals `[500, 1000, 2000]` ms up to 30 s until `body.traces[0].id` is not null — trace writes are asynchronous
+6. Re-fetch the list and capture `traceId = body.traces[0].id`
+
+**`afterAll`** — delete the flow (`x-api-key`) and the API key (Bearer).
+
+**Test 2 — `GET /api/v1/monitor/traces/{trace_id} returns the full TraceRead contract with a non-empty span tree`**
+1. `GET /api/v1/monitor/traces/<traceId>` with Bearer auth
+2. Assert HTTP 200
+3. Assert top-level `TraceRead` fields:
+   - `id === traceId`; `typeof name === "string"`
+   - `status` is one of `"unset" | "ok" | "error"`
+   - `typeof startTime === "string"`; `endTime`, `input`, `output` keys are present (nullable)
+   - `typeof totalLatencyMs === "number"` and `>= 0`; same for `totalTokens`
+   - `flowId === <seeded flowId>`; `typeof sessionId === "string"`
+4. Assert `body.spans` is a non-empty array; flatten the tree (root + recursive `children`) and walk every node:
+   - `typeof id === "string"`; `typeof name === "string"`
+   - `type` ∈ `SpanType` enum; `status` ∈ `SpanStatus` enum (asserted on every node)
+   - `typeof latencyMs === "number"`
+   - Keys present (nullable): `startTime`, `endTime`, `inputs`, `outputs`, `error`, `modelName`, `tokenUsage`
+   - `children` is an array
+   - When `tokenUsage` is non-null, assert `promptTokens`, `completionTokens`, `totalTokens` are all numbers (matches the OTel-derived shape produced by `formatting.py:105-109`)
+
+---
+
+## Validation criterion *(required)*
+
+- **Test 1** — Pins the only documented failure path for the single-trace endpoint: a 404 when the trace is not visible to the caller. A regression that returned 500, 403, or 200-with-empty-payload would surface here. Because the handler enforces ownership via the SQL join, this test also implicitly covers the "trace owned by a different user" case without needing a second user fixture.
+- **Test 2** — Pins the wire contract that `TraceDetailView` + `SpanTree` + `SpanDetail` consume. A rename or drop of any top-level `TraceRead` field, or any `SpanReadResponse` field, would surface here before the Trace Details modal breaks at render time. The enum checks on every span (not just the root) protect against drift in either `SpanType` or `SpanStatus`. The conditional `tokenUsage` shape check pins the OTel-derived `promptTokens`/`completionTokens`/`totalTokens` keys when populated.
+
+---
+
+## External dependencies *(required)*
+
+References in the **main Langflow repository** (compatible with Langflow 1.10.x):
+
+- `src/backend/base/langflow/api/v1/traces.py:102` — `GET /monitor/traces/{trace_id}` handler returning `TraceRead`
+- `src/backend/base/langflow/services/tracing/repository.py:218` — `fetch_single_trace` joins `trace → flow → user`, so unknown trace and foreign-owned trace both collapse to `None` → 404
+- `src/backend/base/langflow/services/database/models/traces/model.py:84-106` — `SpanType` and `SpanStatus` enum definitions asserted by both tests
+- `src/backend/base/langflow/services/database/models/traces/model.py:166-216` — `SpanReadResponse` and `TraceRead` Pydantic models (camelCase via `alias_generator=to_camel`)
+- `src/backend/base/langflow/services/tracing/formatting.py:105-109` — emits `tokenUsage` with `promptTokens`, `completionTokens`, `totalTokens`
+- `src/backend/tests/unit/api/v1/test_monitor_ownership.py` — upstream ownership coverage for `builds`, `transactions`, and `messages`; the single-trace endpoint is **not** covered there, which is the gap this spec fills
+
+References in this repository:
+
+- `tests/assets/flows/basic-prompting-trace-fixture.json` — minimal Basic Prompting flow with no provider configured; runs to a LanguageModelComponent error that still emits a trace
+- `tests/helpers/auth/get-auth-token.ts` — issues a bearer token for the superuser
+- `tests/tests-automations/regression/core-functionality/observability-monitoring/traces-latency-tokens.spec.ts` — list-endpoint contract; companion to this spec
+
+---
+
+## What this test does not cover *(optional)*
+
+- **`DELETE /api/v1/monitor/traces/{trace_id}`** — defined on the same router (`traces.py:138`) but exercised by no spec.
+- **Successful (non-error) trace shape** — the fixture errors at the LanguageModelComponent by design, so `tokenUsage` and `modelName` on the LLM span land as `null`. The keys are asserted to exist; when populated, the `tokenUsage` shape is pinned. A spec that asserts non-null token counters would need a provider-configured fixture (separate cost/flake tradeoff).
+- **Explicit ownership test with a second user** — the upstream `test_monitor_ownership.py` covers `builds`/`transactions`/`messages` but not single-trace, and the handler's SQL join means the 404 path is identical to the foreign-owned case. The 404 test in this spec covers both cases. A dedicated cross-user spec would require seeding a second user (not currently supported by the helpers).
+- **Span tree structural assertions** (parent/child wiring, exact span count) — covered by Test 3 in `traces-latency-tokens.spec.ts` against the UI, where `span-node` data-testids are asserted to be exactly 4.
+- **Negative auth path** (401/403 on missing/bad token) — no test pins this for the single-trace endpoint.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
+- The configured superuser (`LANGFLOW_SUPERUSER` / `LANGFLOW_SUPERUSER_PASSWORD`) must be able to issue a token via `getAuthToken`
+- No provider keys required — the fixture is intentionally unconfigured
+
+---
+
+## Notes *(optional)*
+
+- The negative test runs standalone (no setup) because it only needs a valid token. Keeping it outside the `describe` block avoids paying the seeding cost for a test that does not need it and matches the layout of `traces-detail.spec.ts`.
+- The happy-path test runs inside a `describe` block with `mode: "serial"` and a shared `beforeAll`. The seeding pattern (key + flow + run + poll) is intentionally identical to `traces-latency-tokens.spec.ts` so both specs can rely on the same well-understood failure mode of the trace fixture.
+- The span walk uses a local `flattenSpans` helper that recurses through `children`. The flat list is checked against the `SpanType`/`SpanStatus` enums on every node — drift in either enum surfaces immediately, regardless of where in the tree it lands.

--- a/docs/core-functionality/observability-monitoring/traces-detail-single.md
+++ b/docs/core-functionality/observability-monitoring/traces-detail-single.md
@@ -92,10 +92,10 @@ References in this repository:
 
 ## What this test does not cover *(optional)*
 
-- **`DELETE /api/v1/monitor/traces/{trace_id}`** — defined on the same router (`traces.py:138`) but exercised by no spec.
+- **`DELETE /api/v1/monitor/traces/{trace_id}`** — defined on the same router as the single-trace GET handler, but exercised by no spec.
 - **Populated LLM-span contract** — the fixture errors at the LanguageModelComponent by design, so `tokenUsage` and `modelName` always land as `null` on the LLM span. The keys are asserted to exist (shape contract), but value-level assertions (`promptTokens > 0`, `totalTokens === promptTokens + completionTokens`, `modelName` matches the provider response) are tracked in #306, which will land as a dedicated spec using a provider-configured fixture. Deliberate scope reduction to keep this spec free of provider keys / cost / flake.
 - **Explicit ownership test with a second user** — the upstream `test_monitor_ownership.py` covers `builds`/`transactions`/`messages` but not single-trace, and the handler's SQL join means the 404 path is identical to the foreign-owned case. The 404 test in this spec covers both cases. A dedicated cross-user spec would require seeding a second user (not currently supported by the helpers).
-- **Span tree structural assertions** (parent/child wiring, exact span count) — covered by Test 3 in `traces-latency-tokens.spec.ts` against the UI, where `span-node` data-testids are asserted to be exactly 4.
+- **Span tree structural assertions** (parent/child wiring, exact span count) — covered by `traces-latency-tokens.spec.ts`'s "Trace Details modal shows span tree and per-span latency" test against the UI, where `span-node` data-testids are asserted to be exactly 4.
 - **Negative auth path** (401/403 on missing/bad token) — no test pins this for the single-trace endpoint.
 
 ---

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-single.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-single.spec.ts
@@ -1,0 +1,203 @@
+import { readFileSync } from "fs";
+import path from "path";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+
+const TRACE_FIXTURE = JSON.parse(
+  readFileSync(
+    path.resolve(
+      __dirname,
+      "../../../../assets/flows/basic-prompting-trace-fixture.json",
+    ),
+    "utf8",
+  ),
+);
+
+const SPAN_TYPES = [
+  "chain",
+  "llm",
+  "tool",
+  "retriever",
+  "embedding",
+  "parser",
+  "agent",
+] as const;
+const SPAN_STATUSES = ["unset", "ok", "error"] as const;
+
+function flattenSpans(
+  spans: Array<{ children?: unknown[] } & Record<string, unknown>>,
+): Array<Record<string, unknown>> {
+  const out: Array<Record<string, unknown>> = [];
+  for (const span of spans) {
+    out.push(span);
+    const children = Array.isArray(span.children) ? span.children : [];
+    out.push(...flattenSpans(children as typeof spans));
+  }
+  return out;
+}
+
+test(
+  "GET /api/v1/monitor/traces/{trace_id} returns 404 for an unknown but well-formed UUID",
+  { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
+  async ({ request }) => {
+    const authToken = await getAuthToken(request);
+
+    // Well-formed UUID that cannot match any existing trace. The handler joins
+    // trace → flow → user, so an unknown trace and a trace owned by a different
+    // user both collapse to the same 404 response — this case covers both.
+    const res = await request.get(
+      "/api/v1/monitor/traces/00000000-0000-0000-0000-000000000001",
+      { headers: { Authorization: authToken } },
+    );
+
+    expect(res.status()).toBe(404);
+  },
+);
+
+test.describe("Single trace shape — seeded flow", () => {
+  test.describe.configure({ mode: "serial" });
+
+  let bearerToken: string;
+  let apiKey: string;
+  let apiKeyId: string;
+  let flowId: string;
+  let traceId: string;
+
+  test.beforeAll(async ({ request }) => {
+    bearerToken = await getAuthToken(request);
+
+    const keyRes = await request.post("/api/v1/api_key/", {
+      headers: { Authorization: bearerToken },
+      data: { name: `traces-detail-single-test-${Date.now()}` },
+    });
+    expect(keyRes.status()).toBe(200);
+    const keyBody = await keyRes.json();
+    apiKey = keyBody.api_key;
+    apiKeyId = keyBody.id;
+
+    const flowRes = await request.post("/api/v1/flows/", {
+      headers: { "x-api-key": apiKey },
+      data: {
+        ...TRACE_FIXTURE,
+        name: `${TRACE_FIXTURE.name} ${Date.now()}`,
+      },
+    });
+    expect(flowRes.status()).toBe(201);
+    flowId = (await flowRes.json()).id;
+
+    // Run the flow once to emit a trace. The fixture has no provider configured,
+    // so the LanguageModelComponent fails with "A model selection is required" —
+    // that is intentional. The failure still emits a trace with a span tree,
+    // which is what this spec validates.
+    const runRes = await request.post(`/api/v1/run/${flowId}`, {
+      headers: { "x-api-key": apiKey },
+      data: {
+        input_value: "single-trace-probe",
+        input_type: "chat",
+        output_type: "chat",
+      },
+    });
+    expect([200, 500]).toContain(runRes.status());
+
+    // Trace writes are asynchronous: poll the list endpoint until at least one
+    // trace exists for this flow, then capture its id for the detail lookup.
+    await expect
+      .poll(
+        async () => {
+          const res = await request.get(
+            `/api/v1/monitor/traces?flow_id=${flowId}`,
+            { headers: { Authorization: bearerToken } },
+          );
+          if (res.status() !== 200) return null;
+          const body = await res.json();
+          return body.traces?.[0]?.id ?? null;
+        },
+        { timeout: 30000, intervals: [500, 1000, 2000] },
+      )
+      .not.toBeNull();
+
+    const listRes = await request.get(
+      `/api/v1/monitor/traces?flow_id=${flowId}`,
+      { headers: { Authorization: bearerToken } },
+    );
+    traceId = (await listRes.json()).traces[0].id;
+  });
+
+  test.afterAll(async ({ request }) => {
+    if (flowId) {
+      await request.delete(`/api/v1/flows/${flowId}`, {
+        headers: { "x-api-key": apiKey },
+      });
+    }
+    if (apiKeyId) {
+      await request.delete(`/api/v1/api_key/${apiKeyId}`, {
+        headers: { Authorization: bearerToken },
+      });
+    }
+  });
+
+  test(
+    "GET /api/v1/monitor/traces/{trace_id} returns the full TraceRead contract with a non-empty span tree",
+    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
+    async ({ request }) => {
+      const res = await request.get(`/api/v1/monitor/traces/${traceId}`, {
+        headers: { Authorization: bearerToken },
+      });
+      expect(res.status()).toBe(200);
+
+      const body = await res.json();
+
+      // Top-level TraceRead fields the Trace Details modal consumes.
+      expect(body.id).toBe(traceId);
+      expect(typeof body.name).toBe("string");
+      expect(SPAN_STATUSES).toContain(body.status);
+      expect(typeof body.startTime).toBe("string");
+      expect(typeof body.totalLatencyMs).toBe("number");
+      expect(body.totalLatencyMs).toBeGreaterThanOrEqual(0);
+      expect(typeof body.totalTokens).toBe("number");
+      expect(body.totalTokens).toBeGreaterThanOrEqual(0);
+      expect(body.flowId).toBe(flowId);
+      expect(typeof body.sessionId).toBe("string");
+      // input/output/endTime are optional in the schema — assert presence of
+      // the keys so a future rename surfaces here.
+      expect(body).toHaveProperty("input");
+      expect(body).toHaveProperty("output");
+      expect(body).toHaveProperty("endTime");
+
+      // Span tree must be non-empty; the seeded flow emits root + 3 components.
+      expect(Array.isArray(body.spans)).toBe(true);
+      expect(body.spans.length).toBeGreaterThan(0);
+
+      const allSpans = flattenSpans(body.spans);
+      expect(allSpans.length).toBeGreaterThan(0);
+
+      for (const span of allSpans) {
+        expect(typeof span.id).toBe("string");
+        expect(typeof span.name).toBe("string");
+        expect(SPAN_TYPES).toContain(span.type);
+        expect(SPAN_STATUSES).toContain(span.status);
+        expect(typeof span.latencyMs).toBe("number");
+        // Schema marks these as nullable but the key itself must be present so
+        // the SpanDetail panel can render without probing for optional fields.
+        expect(span).toHaveProperty("startTime");
+        expect(span).toHaveProperty("endTime");
+        expect(span).toHaveProperty("inputs");
+        expect(span).toHaveProperty("outputs");
+        expect(span).toHaveProperty("error");
+        expect(span).toHaveProperty("modelName");
+        expect(span).toHaveProperty("tokenUsage");
+        expect(Array.isArray(span.children)).toBe(true);
+
+        // When tokenUsage is populated it must expose the three OTel-derived
+        // counters the UI reads. The fixture errors before any LLM call, so
+        // tokenUsage is typically null — when it isn't, the shape is pinned.
+        if (span.tokenUsage !== null && span.tokenUsage !== undefined) {
+          const usage = span.tokenUsage as Record<string, unknown>;
+          expect(typeof usage.promptTokens).toBe("number");
+          expect(typeof usage.completionTokens).toBe("number");
+          expect(typeof usage.totalTokens).toBe("number");
+        }
+      }
+    },
+  );
+});

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-single.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-single.spec.ts
@@ -157,7 +157,12 @@ test.describe("Single trace shape — seeded flow", () => {
       expect(typeof body.totalTokens).toBe("number");
       expect(body.totalTokens).toBeGreaterThanOrEqual(0);
       expect(body.flowId).toBe(flowId);
-      expect(typeof body.sessionId).toBe("string");
+      // sessionId column is nullable on TraceTable; the Pydantic alias coerces
+      // it, so both shapes are valid wire responses today.
+      expect(["string", "object"]).toContain(typeof body.sessionId);
+      if (body.sessionId !== null) {
+        expect(typeof body.sessionId).toBe("string");
+      }
       // input/output/endTime are optional in the schema — assert presence of
       // the keys so a future rename surfaces here.
       expect(body).toHaveProperty("input");
@@ -177,6 +182,7 @@ test.describe("Single trace shape — seeded flow", () => {
         expect(SPAN_TYPES).toContain(span.type);
         expect(SPAN_STATUSES).toContain(span.status);
         expect(typeof span.latencyMs).toBe("number");
+        expect(span.latencyMs).toBeGreaterThanOrEqual(0);
         // Schema marks these as nullable but the key itself must be present so
         // the SpanDetail panel can render without probing for optional fields.
         expect(span).toHaveProperty("startTime");
@@ -187,16 +193,6 @@ test.describe("Single trace shape — seeded flow", () => {
         expect(span).toHaveProperty("modelName");
         expect(span).toHaveProperty("tokenUsage");
         expect(Array.isArray(span.children)).toBe(true);
-
-        // When tokenUsage is populated it must expose the three OTel-derived
-        // counters the UI reads. The fixture errors before any LLM call, so
-        // tokenUsage is typically null — when it isn't, the shape is pinned.
-        if (span.tokenUsage !== null && span.tokenUsage !== undefined) {
-          const usage = span.tokenUsage as Record<string, unknown>;
-          expect(typeof usage.promptTokens).toBe("number");
-          expect(typeof usage.completionTokens).toBe("number");
-          expect(typeof usage.totalTokens).toBe("number");
-        }
       }
     },
   );

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-single.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-single.spec.ts
@@ -100,7 +100,9 @@ test.describe("Single trace shape — seeded flow", () => {
     expect([200, 500]).toContain(runRes.status());
 
     // Trace writes are asynchronous: poll the list endpoint until at least one
-    // trace exists for this flow, then capture its id for the detail lookup.
+    // trace exists for this flow. Capture the id inside the poll closure to
+    // avoid a redundant re-fetch (and the row-shift race that comes with it).
+    let polledTraceId: string | null = null;
     await expect
       .poll(
         async () => {
@@ -110,17 +112,15 @@ test.describe("Single trace shape — seeded flow", () => {
           );
           if (res.status() !== 200) return null;
           const body = await res.json();
-          return body.traces?.[0]?.id ?? null;
+          polledTraceId = body.traces?.[0]?.id ?? null;
+          return polledTraceId;
         },
         { timeout: 30000, intervals: [500, 1000, 2000] },
       )
       .not.toBeNull();
 
-    const listRes = await request.get(
-      `/api/v1/monitor/traces?flow_id=${flowId}`,
-      { headers: { Authorization: bearerToken } },
-    );
-    traceId = (await listRes.json()).traces[0].id;
+    expect(polledTraceId).not.toBeNull();
+    traceId = polledTraceId as unknown as string;
   });
 
   test.afterAll(async ({ request }) => {
@@ -157,12 +157,11 @@ test.describe("Single trace shape — seeded flow", () => {
       expect(typeof body.totalTokens).toBe("number");
       expect(body.totalTokens).toBeGreaterThanOrEqual(0);
       expect(body.flowId).toBe(flowId);
-      // sessionId column is nullable on TraceTable; the Pydantic alias coerces
-      // it, so both shapes are valid wire responses today.
-      expect(["string", "object"]).toContain(typeof body.sessionId);
-      if (body.sessionId !== null) {
-        expect(typeof body.sessionId).toBe("string");
-      }
+      // TraceTable.session_id is nullable on the column, so the wire response
+      // is `string | null` even though TraceRead types it as str.
+      expect(
+        body.sessionId === null || typeof body.sessionId === "string",
+      ).toBe(true);
       // input/output/endTime are optional in the schema — assert presence of
       // the keys so a future rename surfaces here.
       expect(body).toHaveProperty("input");

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-single.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-single.spec.ts
@@ -124,16 +124,26 @@ test.describe("Single trace shape — seeded flow", () => {
   });
 
   test.afterAll(async ({ request }) => {
-    if (flowId) {
-      await request.delete(`/api/v1/flows/${flowId}`, {
-        headers: { "x-api-key": apiKey },
-      });
+    // Use allSettled so a failed flow delete does not skip the key delete (and
+    // vice versa). The guards already block calls when an entity was never
+    // created — allSettled covers the remaining case: a half-completed server
+    // operation that hands us a stale id we cannot delete cleanly.
+    const cleanups: Promise<unknown>[] = [];
+    if (flowId && apiKey) {
+      cleanups.push(
+        request.delete(`/api/v1/flows/${flowId}`, {
+          headers: { "x-api-key": apiKey },
+        }),
+      );
     }
     if (apiKeyId) {
-      await request.delete(`/api/v1/api_key/${apiKeyId}`, {
-        headers: { Authorization: bearerToken },
-      });
+      cleanups.push(
+        request.delete(`/api/v1/api_key/${apiKeyId}`, {
+          headers: { Authorization: bearerToken },
+        }),
+      );
     }
+    await Promise.allSettled(cleanups);
   });
 
   test(

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-single.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-single.spec.ts
@@ -120,7 +120,7 @@ test.describe("Single trace shape — seeded flow", () => {
       .not.toBeNull();
 
     expect(polledTraceId).not.toBeNull();
-    traceId = polledTraceId as unknown as string;
+    traceId = polledTraceId!;
   });
 
   test.afterAll(async ({ request }) => {


### PR DESCRIPTION
## Summary

- New API spec `traces-detail-single.spec.ts` covering the single-trace endpoint that feeds the Trace Details modal — previously unasserted while the list endpoint was already covered by `traces-latency-tokens.spec.ts`.
- Two tests, both `@stable @release @api @regression @observability`:
  - `GET /api/v1/monitor/traces/{trace_id}` returns **404** for a well-formed unknown UUID. Because the handler joins `trace → flow → user`, this also covers the foreign-owned case.
  - With a seeded flow + run + emitted trace, the endpoint returns **200** with the full `TraceRead` shape contract. A recursive walk pins `SpanType` / `SpanStatus` enums and the `SpanReadResponse` keys (`modelName`, `tokenUsage`, `latencyMs`, ...) on every node. Numeric guards (`>= 0`) on `totalLatencyMs`, `totalTokens`, per-span `latencyMs`.
- Spec doc at `docs/core-functionality/observability-monitoring/traces-detail-single.md` with all mandatory sections; `Last validated: Langflow 1.10.x`.
- `QA-CHECKLIST.md` gains two `[x]` entries under `8.1 Traces`.

## Scope reduction vs. issue #299

Issue #299 also asks for **populated** LLM-span assertions (`tokenUsage.{promptTokens,completionTokens,totalTokens}`, non-null `modelName`, non-zero `latencyMs`). This spec deliberately does **not** value-assert those: the shared no-provider fixture (`basic-prompting-trace-fixture.json`) errors before any LLM call, so `tokenUsage` and `modelName` always land as `null`. A conditional shape check would be dead code under this fixture.

Populated-LLM-span coverage is tracked as a separate spec in **#306**, which will use a provider-configured fixture. This PR delivers the shape contract + 404 negative path; #306 delivers the value contract.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (no new errors)
- [x] `npx playwright test traces-detail-single.spec.ts` — both tests pass against a local Langflow nightly
- [x] Full observability `@api` set (6 tests) re-run — all pass
- [x] Forced-failure check on both tests — assertions fail for the right reason (no false positives)
- [x] No `🚨 Backend Error` emitted during runs

Closes #299