### PR TITLE
test(observability): cover GET /monitor/traces list filters

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -415,10 +415,11 @@
 - [x] Trace displays tokens consumed
 - [x] Single-trace API returns 404 for an unknown trace_id → `traces-detail-single.spec.ts`
 - [x] Single-trace API returns the full TraceRead contract with a non-empty span tree → `traces-detail-single.spec.ts`
-- [x] Trace list filter `?status=error` returns only the failing trace → `traces-list-filters.spec.ts`
+- [x] Trace list filter `?status=error` returns only the failing trace; `?status=<unknown>` returns 422 → `traces-list-filters.spec.ts`
 - [x] Trace list filter `?status=ok` returns only the successful trace → `traces-list-filters.spec.ts`
-- [x] Trace list filter `?start_time=<future>` returns empty → `traces-list-filters.spec.ts`
-- [x] Trace list filter `?query=<substring>` filters by trace name/id/session → `traces-list-filters.spec.ts`
+- [x] Trace list filter `?start_time` pins the >= lower bound (past hits, future misses) → `traces-list-filters.spec.ts`
+- [x] Trace list filter `?query=<substring>` filters by trace name, incl. 50-char sanitize cap → `traces-list-filters.spec.ts`
+- [x] Trace list filter `?session_id` filters by the session passed at run time → `traces-list-filters.spec.ts`
 
 #### 8.2 Notifications
 - [-] System notifications

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -415,6 +415,10 @@
 - [x] Trace displays tokens consumed
 - [x] Single-trace API returns 404 for an unknown trace_id → `traces-detail-single.spec.ts`
 - [x] Single-trace API returns the full TraceRead contract with a non-empty span tree → `traces-detail-single.spec.ts`
+- [x] Trace list filter `?status=error` returns only the failing trace → `traces-list-filters.spec.ts`
+- [x] Trace list filter `?status=ok` returns only the successful trace → `traces-list-filters.spec.ts`
+- [x] Trace list filter `?start_time=<future>` returns empty → `traces-list-filters.spec.ts`
+- [x] Trace list filter `?query=<substring>` filters by trace name/id/session → `traces-list-filters.spec.ts`
 
 #### 8.2 Notifications
 - [-] System notifications

--- a/docs/core-functionality/observability-monitoring/traces-list-filters.md
+++ b/docs/core-functionality/observability-monitoring/traces-list-filters.md
@@ -1,0 +1,114 @@
+# Trace List Filters API — `GET /api/v1/monitor/traces` query params
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+`GET /api/v1/monitor/traces` accepts `status`, `query`, `start_time`, and `end_time` query params (`traces.py:48-55`). Before this spec only the `flow_id` filter was exercised by `traces-latency-tokens.spec.ts`; the other filters had zero coverage.
+
+This spec pins four discriminative scenarios on the wire:
+
+1. **`status=error`** returns only the failing trace; `?status=ok` on the same flow returns 0.
+2. **`status=ok`** returns only the successful trace; `?status=error` on the same flow returns 0.
+3. **`start_time=<future>`** returns 0 (every seeded trace precedes the cutoff).
+4. **`query=<unique substring of trace name>`** returns exactly 1; `query=<garbage>` returns 0.
+
+All assertions are scoped by `flow_id` so a concurrent run of another `@observability` test in the same user account cannot contaminate the totals.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@api` `@regression` `@observability`
+
+All four tests carry the same tag set.
+
+---
+
+## Step by step *(required)*
+
+**`describe("Trace list filters — status / start_time / query")` — `beforeAll` (shared setup)**
+1. Get a bearer token via `getAuthToken(request)`
+2. Create an API key (`POST /api/v1/api_key/` with Bearer auth, name `traces-filters-test-<timestamp>`); capture `api_key` + `id`
+3. Create **Flow A — error fixture** (`POST /api/v1/flows/` with `x-api-key`) from `tests/assets/flows/basic-prompting-trace-fixture.json`; expect HTTP 201; capture `errorFlowId`
+4. Create **Flow B — ok fixture** (`POST /api/v1/flows/` with `x-api-key`) from `tests/assets/flows/chat-io-ok-trace-fixture.json`; expect HTTP 201; capture `okFlowId`
+5. Run Flow A once (`POST /api/v1/run/{errorFlowId}` with `x-api-key`, `input_value: "filters-error-probe"`). The fixture has no provider configured, so the LanguageModelComponent fails — the failure is **intentional**: the trace still lands with `status=error`. Accept HTTP 200 or 500
+6. Run Flow B once (`POST /api/v1/run/{okFlowId}` with `x-api-key`, `input_value: "filters-ok-probe"`). The fixture is pure `ChatInput → ChatOutput` — no LLM, no external dependency, run completes in `status=ok`. Expect HTTP 200
+7. Poll `GET /api/v1/monitor/traces?flow_id=<id>` for each flow independently (intervals `[500, 1000, 2000]` ms up to 30 s) until `traces.length > 0`. Polling combined would race against the second insert
+8. Capture `errorTraceNameProbe = errorFlowId` for use in the `?query=` test. The trace name has the form `<flow.name> - <flowId>`, and the flow UUID is unique across concurrent test runs
+
+**`afterAll`** — delete both flows (`x-api-key`) and the API key (Bearer). `Promise.allSettled` keeps each delete independent.
+
+**Test 1 — `?status=error returns only the failing trace`**
+1. `GET /api/v1/monitor/traces?flow_id=<errorFlowId>&status=error` → 200, `total === 1`, `traces[0].status === "error"`, `traces[0].flowId === errorFlowId`
+2. `GET /api/v1/monitor/traces?flow_id=<errorFlowId>&status=ok` → 200, `total === 0`, `traces.length === 0`
+
+**Test 2 — `?status=ok returns only the successful trace`**
+1. `GET /api/v1/monitor/traces?flow_id=<okFlowId>&status=ok` → 200, `total === 1`, `traces[0].status === "ok"`, `traces[0].flowId === okFlowId`
+2. `GET /api/v1/monitor/traces?flow_id=<okFlowId>&status=error` → 200, `total === 0`, `traces.length === 0`
+
+**Test 3 — `?start_time=<future> returns empty`**
+1. Compute `future = new Date(Date.now() + 3600_000).toISOString()`
+2. `GET /api/v1/monitor/traces?flow_id=<errorFlowId>&start_time=<future>` → 200, `total === 0`, `traces.length === 0`
+
+**Test 4 — `?query=<substring> filters by trace name/id/session`**
+1. `GET /api/v1/monitor/traces?flow_id=<errorFlowId>&query=<errorFlowId>` → 200, `total === 1`, `traces[0].flowId === errorFlowId`
+2. `GET /api/v1/monitor/traces?flow_id=<errorFlowId>&query=zzz-no-trace-name-matches-this-<timestamp>` → 200, `total === 0`, `traces.length === 0`
+
+---
+
+## Validation criterion *(required)*
+
+- **Tests 1 + 2** — Pin the only documented behavior of `?status=` together: each value matches exactly the traces with that status and rejects the others. A regression that ignored the filter (returning all traces), inverted it, or accepted an unknown value (`"failed"` instead of `"error"`) would surface on at least one of the four assertions. Splitting into two tests, each owning one flow, keeps a failure narrow enough to point at the exact mismatch.
+- **Test 3** — Pins the lower-bound semantics of `?start_time` (`TraceTable.start_time >= start_time`, `repository.py:178-179`). A handler that flipped the comparator, or that parsed the ISO timestamp into a far-past value, would return non-empty here.
+- **Test 4** — Pins the `query` ILIKE behavior on `TraceTable.{name, id, session_id}` (`repository.py:169-177`). Both halves matter: the hit asserts the filter actually narrows; the miss asserts it does not silently return all traces when the substring is absent. Using a 36-char UUID as the probe also implicitly exercises the 50-char `sanitize_query_string` cap (`validation.py`) — a regression dropping the cap would still match.
+
+---
+
+## External dependencies *(required)*
+
+References in the **main Langflow repository** (compatible with Langflow 1.10.x):
+
+- `src/backend/base/langflow/api/v1/traces.py` (lines 45-99) — `GET /monitor/traces` handler; query params declared at lines 48-55; calls `sanitize_query_string` then `fetch_traces`
+- `src/backend/base/langflow/services/tracing/repository.py` (lines 134-189) — `fetch_traces` builds the filter expression list; `status` is an `==`, `start_time` is `>=`, `query` is `ILIKE %x%` across `name | id | session_id`
+- `src/backend/base/langflow/services/tracing/validation.py` — `sanitize_query_string` truncates query to 50 chars and strips non-printable ASCII; relevant to the UUID-as-probe choice
+- `src/backend/base/langflow/services/tracing/native.py` (line 296) — sets `trace_status = SpanStatus.ERROR if (error or has_span_errors) else SpanStatus.OK`; explains why `ChatInput → ChatOutput` resolves to `ok` and `basic-prompting` (with the LM error) resolves to `error`
+- `src/backend/base/langflow/services/database/models/traces/model.py` — `SpanStatus` enum (`unset | ok | error`)
+
+References in this repository:
+
+- `tests/assets/flows/basic-prompting-trace-fixture.json` — error fixture (no provider configured → LanguageModelComponent fails → `status=error`)
+- `tests/assets/flows/chat-io-ok-trace-fixture.json` — ok fixture (`ChatInput → ChatOutput`, pure local I/O → `status=ok`); derived programmatically from the basic-prompting fixture to keep the React Flow handle encoding identical
+- `tests/helpers/auth/get-auth-token.ts` — issues a bearer token for the superuser
+- `tests/tests-automations/regression/core-functionality/observability-monitoring/traces-latency-tokens.spec.ts` — list-endpoint contract for `flow_id`; companion to this spec
+
+---
+
+## What this test does not cover *(optional)*
+
+- **`?status=unset`** — neither fixture emits `unset` (Chat I/O → `ok`, basic-prompting → `error`). Producing `unset` deterministically would require a fixture for which `native.py` exits the run before any span error is raised — not obviously reachable without forking the tracer. Deliberate gap.
+- **`?query=` substring of `input_value` / message content** — the handler's `ILIKE` is only on `TraceTable.{name, id, session_id}` (`repository.py:173-175`), not on message body. A test that filtered by `input_value` would silently fail to narrow. The issue text suggested "substring of input_value" — that contract does not exist on the handler. Filed as a non-gap.
+- **`?end_time`** — symmetric to `start_time` (line 180-181). Lower-bound test alone pins the comparator direction; adding the upper bound would not catch a regression the existing test misses.
+- **`?session_id=`** — declared in the handler signature but no spec exercises it; the existing fixtures pass no session_id at run time, so the column lands as the auto-generated value. Out of scope here; would warrant its own spec with a session_id explicitly threaded through the run payload.
+- **Combined filters** (e.g., `?status=ok&start_time=<past>`) — each filter is asserted standalone. The repository combines filters with `AND` over the `filters: list` (`repository.py:183-185`), so combined behavior is a structural consequence of the per-filter contract — not asserted explicitly.
+- **`?page` / `?size` pagination** — out of scope for this spec; would need a fixture that emits enough traces to span pages.
+- **Negative auth path** (401/403 on missing/bad token) — no test pins this for the list endpoint.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
+- The configured superuser (`LANGFLOW_SUPERUSER` / `LANGFLOW_SUPERUSER_PASSWORD`) must be able to issue a token via `getAuthToken`
+- No provider keys required — both fixtures run end-to-end without external credentials
+
+---
+
+## Notes *(optional)*
+
+- The two flows are seeded once in `beforeAll` and reused across all four tests in `mode: "serial"`. The describe block runs single-flow on purpose: the four tests share the seeded state and would race each other if Playwright sharded them.
+- The `query` probe is the error-flow UUID. It is 36 ASCII characters, well under the 50-char sanitizer cap, and unique to this run — so a concurrent test that happened to land a trace with the same `name` substring would have to share a flow id, which is not possible.
+- The ok fixture (`chat-io-ok-trace-fixture.json`) was built by deriving a minimal `ChatInput → ChatOutput` slice from `basic-prompting-trace-fixture.json`, preserving the exact React Flow handle encoding (the `œ`-substituted JSON in `sourceHandle` / `targetHandle` / edge id). Hand-editing a brand-new fixture would risk an invalid handle that the importer silently accepts but the executor rejects.
+- The `start_time` test uses a one-hour-future cutoff, comfortably above any clock skew between the test client and the Langflow container.

--- a/docs/core-functionality/observability-monitoring/traces-list-filters.md
+++ b/docs/core-functionality/observability-monitoring/traces-list-filters.md
@@ -13,7 +13,7 @@ This spec pins five discriminative scenarios on the wire:
 1. **`status=error`** returns only the failing trace; `?status=ok` on the same flow returns 0; `?status=<unknown>` returns **422** (Pydantic enum rejection).
 2. **`status=ok`** returns only the successful trace; `?status=error` on the same flow returns 0.
 3. **`start_time`** is asserted on both halves of the `>=` comparator: a past cutoff returns 1 (pinning the direction), a future cutoff returns 0 (pinning that the filter is wired).
-4. **`query=<substring>`** is asserted three ways: a 36-char UUID probe inside the trace name returns 1; a 60-char probe (longer than the 50-char `sanitize_query_string` cap) whose first 50 chars are still inside the name returns 1 (pinning the cap behavior); a garbage probe returns 0.
+4. **`query=<substring>`** is asserted three ways: a 36-char UUID probe inside the trace name returns 1; a probe whose first 50 chars are inside the trace name but whose tail is a guaranteed-unmatched suffix returns 1 (genuinely pinning truncation — only the truncated 50 chars match the name, the full string does not); a garbage probe returns 0.
 5. **`session_id`** is asserted against a session id threaded through the ok run's payload: the exact match returns 1, an unknown session returns 0.
 
 All assertions are scoped by `flow_id` so a concurrent run of another `@observability` test in the same user account cannot contaminate the totals.
@@ -57,7 +57,7 @@ All five tests carry the same tag set.
 
 **Test 4 — `?query=<substring> filters by trace name (incl. 50-char sanitize cap)`**
 1. `GET ?flow_id=<errorFlowId>&query=<errorFlowId>` → 200, `total === 1`
-2. `longProbe = errorTraceName.slice(0, 60)` (asserted `>50` so the sanitizer cap engages) → `GET ?flow_id=<errorFlowId>&query=<longProbe>` → 200, `total === 1`. The sanitizer caps to 50 chars; the truncated string is still inside `errorTraceName`, so the ILIKE must still hit
+2. `longProbe = errorTraceName.slice(0, 50) + "-zzz-not-in-name-<timestamp>"` (length asserted `>50` so the sanitizer cap engages) → `GET ?flow_id=<errorFlowId>&query=<longProbe>` → 200, `total === 1`. The first 50 chars are inside `errorTraceName`, the tail is not. Only a backend that truncates to 50 chars before the ILIKE hits; a backend that uses the full string misses on the garbage suffix
 3. `GET ?flow_id=<errorFlowId>&query=zzz-no-trace-name-matches-this-<timestamp>` → 200, `total === 0`
 
 **Test 5 — `?session_id filters by the session passed at run time`**

--- a/docs/core-functionality/observability-monitoring/traces-list-filters.md
+++ b/docs/core-functionality/observability-monitoring/traces-list-filters.md
@@ -6,14 +6,15 @@
 
 ## What this test validates *(required)*
 
-`GET /api/v1/monitor/traces` accepts `status`, `query`, `start_time`, and `end_time` query params (`traces.py:48-55`). Before this spec only the `flow_id` filter was exercised by `traces-latency-tokens.spec.ts`; the other filters had zero coverage.
+`GET /api/v1/monitor/traces` accepts `status`, `query`, `start_time`, `end_time`, and `session_id` query params (`traces.py:48-55`). Before this spec only the `flow_id` filter was exercised by `traces-latency-tokens.spec.ts`; the other filters had zero coverage.
 
-This spec pins four discriminative scenarios on the wire:
+This spec pins five discriminative scenarios on the wire:
 
-1. **`status=error`** returns only the failing trace; `?status=ok` on the same flow returns 0.
+1. **`status=error`** returns only the failing trace; `?status=ok` on the same flow returns 0; `?status=<unknown>` returns **422** (Pydantic enum rejection).
 2. **`status=ok`** returns only the successful trace; `?status=error` on the same flow returns 0.
-3. **`start_time=<future>`** returns 0 (every seeded trace precedes the cutoff).
-4. **`query=<unique substring of trace name>`** returns exactly 1; `query=<garbage>` returns 0.
+3. **`start_time`** is asserted on both halves of the `>=` comparator: a past cutoff returns 1 (pinning the direction), a future cutoff returns 0 (pinning that the filter is wired).
+4. **`query=<substring>`** is asserted three ways: a 36-char UUID probe inside the trace name returns 1; a 60-char probe (longer than the 50-char `sanitize_query_string` cap) whose first 50 chars are still inside the name returns 1 (pinning the cap behavior); a garbage probe returns 0.
+5. **`session_id`** is asserted against a session id threaded through the ok run's payload: the exact match returns 1, an unknown session returns 0.
 
 All assertions are scoped by `flow_id` so a concurrent run of another `@observability` test in the same user account cannot contaminate the totals.
 
@@ -23,47 +24,54 @@ All assertions are scoped by `flow_id` so a concurrent run of another `@observab
 
 `@stable` `@release` `@api` `@regression` `@observability`
 
-All four tests carry the same tag set.
+All five tests carry the same tag set.
 
 ---
 
 ## Step by step *(required)*
 
-**`describe("Trace list filters — status / start_time / query")` — `beforeAll` (shared setup)**
+**`describe("Trace list filters — status / start_time / query / session_id")` — `beforeAll` (shared setup)**
 1. Get a bearer token via `getAuthToken(request)`
 2. Create an API key (`POST /api/v1/api_key/` with Bearer auth, name `traces-filters-test-<timestamp>`); capture `api_key` + `id`
 3. Create **Flow A — error fixture** (`POST /api/v1/flows/` with `x-api-key`) from `tests/assets/flows/basic-prompting-trace-fixture.json`; expect HTTP 201; capture `errorFlowId`
 4. Create **Flow B — ok fixture** (`POST /api/v1/flows/` with `x-api-key`) from `tests/assets/flows/chat-io-ok-trace-fixture.json`; expect HTTP 201; capture `okFlowId`
 5. Run Flow A once (`POST /api/v1/run/{errorFlowId}` with `x-api-key`, `input_value: "filters-error-probe"`). The fixture has no provider configured, so the LanguageModelComponent fails — the failure is **intentional**: the trace still lands with `status=error`. Accept HTTP 200 or 500
-6. Run Flow B once (`POST /api/v1/run/{okFlowId}` with `x-api-key`, `input_value: "filters-ok-probe"`). The fixture is pure `ChatInput → ChatOutput` — no LLM, no external dependency, run completes in `status=ok`. Expect HTTP 200
+6. Run Flow B once (`POST /api/v1/run/{okFlowId}` with `x-api-key`, `input_value: "filters-ok-probe"`, `session_id: "filters-ok-session-<timestamp>"`). Threading a unique `session_id` lets the `?session_id=` filter target a deterministic value persisted on `TraceTable.session_id`. Expect HTTP 200
 7. Poll `GET /api/v1/monitor/traces?flow_id=<id>` for each flow independently (intervals `[500, 1000, 2000]` ms up to 30 s) until `traces.length > 0`. Polling combined would race against the second insert
-8. Capture `errorTraceNameProbe = errorFlowId` for use in the `?query=` test. The trace name has the form `<flow.name> - <flowId>`, and the flow UUID is unique across concurrent test runs
+8. Capture and assert `errorTraceName` — fetch the error-trace list, capture `traces[0].name`, and `expect(name).toContain(errorFlowId)`. The handler ILIKEs on `{name, id, session_id}`; in this setup the flow UUID is not the trace.id and we did not pass a session_id on the error run, so the `?query=` UUID hit must go through `name`. Asserting the substring here means a future change to the trace-name format surfaces at setup time, not as a confusing 0-hit on the query test
 
 **`afterAll`** — delete both flows (`x-api-key`) and the API key (Bearer). `Promise.allSettled` keeps each delete independent.
 
-**Test 1 — `?status=error returns only the failing trace`**
-1. `GET /api/v1/monitor/traces?flow_id=<errorFlowId>&status=error` → 200, `total === 1`, `traces[0].status === "error"`, `traces[0].flowId === errorFlowId`
-2. `GET /api/v1/monitor/traces?flow_id=<errorFlowId>&status=ok` → 200, `total === 0`, `traces.length === 0`
+**Test 1 — `?status=error returns only the failing trace; rejects unknown values`**
+1. `GET ?flow_id=<errorFlowId>&status=error` → 200, `total === 1`, `traces[0].status === "error"`, `flowId === errorFlowId`
+2. `GET ?flow_id=<errorFlowId>&status=ok` → 200, `total === 0`
+3. `GET ?flow_id=<errorFlowId>&status=failed` → **422** (FastAPI/Pydantic enum rejection; a handler that loosened the enum to plain str would leak through)
 
 **Test 2 — `?status=ok returns only the successful trace`**
-1. `GET /api/v1/monitor/traces?flow_id=<okFlowId>&status=ok` → 200, `total === 1`, `traces[0].status === "ok"`, `traces[0].flowId === okFlowId`
-2. `GET /api/v1/monitor/traces?flow_id=<okFlowId>&status=error` → 200, `total === 0`, `traces.length === 0`
+1. `GET ?flow_id=<okFlowId>&status=ok` → 200, `total === 1`, `traces[0].status === "ok"`, `flowId === okFlowId`
+2. `GET ?flow_id=<okFlowId>&status=error` → 200, `total === 0`
 
-**Test 3 — `?start_time=<future> returns empty`**
-1. Compute `future = new Date(Date.now() + 3600_000).toISOString()`
-2. `GET /api/v1/monitor/traces?flow_id=<errorFlowId>&start_time=<future>` → 200, `total === 0`, `traces.length === 0`
+**Test 3 — `?start_time pins the >= lower bound`**
+1. `past = now - 1h` → `GET ?flow_id=<errorFlowId>&start_time=<past>` → 200, `total === 1` (pins the comparator direction — a `<=` regression would return 0 here)
+2. `future = now + 1h` → `GET ?flow_id=<errorFlowId>&start_time=<future>` → 200, `total === 0` (pins that the filter is wired and not a no-op)
 
-**Test 4 — `?query=<substring> filters by trace name/id/session`**
-1. `GET /api/v1/monitor/traces?flow_id=<errorFlowId>&query=<errorFlowId>` → 200, `total === 1`, `traces[0].flowId === errorFlowId`
-2. `GET /api/v1/monitor/traces?flow_id=<errorFlowId>&query=zzz-no-trace-name-matches-this-<timestamp>` → 200, `total === 0`, `traces.length === 0`
+**Test 4 — `?query=<substring> filters by trace name (incl. 50-char sanitize cap)`**
+1. `GET ?flow_id=<errorFlowId>&query=<errorFlowId>` → 200, `total === 1`
+2. `longProbe = errorTraceName.slice(0, 60)` (asserted `>50` so the sanitizer cap engages) → `GET ?flow_id=<errorFlowId>&query=<longProbe>` → 200, `total === 1`. The sanitizer caps to 50 chars; the truncated string is still inside `errorTraceName`, so the ILIKE must still hit
+3. `GET ?flow_id=<errorFlowId>&query=zzz-no-trace-name-matches-this-<timestamp>` → 200, `total === 0`
+
+**Test 5 — `?session_id filters by the session passed at run time`**
+1. `GET ?flow_id=<okFlowId>&session_id=<okSessionId>` → 200, `total === 1`, `traces[0].sessionId === okSessionId`
+2. `GET ?flow_id=<okFlowId>&session_id=missing-session-<timestamp>` → 200, `total === 0`
 
 ---
 
 ## Validation criterion *(required)*
 
-- **Tests 1 + 2** — Pin the only documented behavior of `?status=` together: each value matches exactly the traces with that status and rejects the others. A regression that ignored the filter (returning all traces), inverted it, or accepted an unknown value (`"failed"` instead of `"error"`) would surface on at least one of the four assertions. Splitting into two tests, each owning one flow, keeps a failure narrow enough to point at the exact mismatch.
-- **Test 3** — Pins the lower-bound semantics of `?start_time` (`TraceTable.start_time >= start_time`, `repository.py:178-179`). A handler that flipped the comparator, or that parsed the ISO timestamp into a far-past value, would return non-empty here.
-- **Test 4** — Pins the `query` ILIKE behavior on `TraceTable.{name, id, session_id}` (`repository.py:169-177`). Both halves matter: the hit asserts the filter actually narrows; the miss asserts it does not silently return all traces when the substring is absent. Using a 36-char UUID as the probe also implicitly exercises the 50-char `sanitize_query_string` cap (`validation.py`) — a regression dropping the cap would still match.
+- **Tests 1 + 2** — Pin the behavior of `?status=` together: each enum value matches exactly the traces with that status and rejects the others. Test 1 also pins the *type contract* on the query param — a regression that loosened `SpanStatus` to `str` and accepted any value (e.g. `failed` falling through to a `LIKE`) would surface on the 422 assertion.
+- **Test 3** — Two-sided. The past-cutoff hit pins the *direction* of the comparator (`>=`, `repository.py:178-179`): a swap to `<=` would return 0 against a past cutoff. The future-cutoff miss pins that the filter is *wired* and not a silent no-op. Either half alone would be insufficient — the past half catches a flipped comparator, the future half catches a dropped filter.
+- **Test 4** — Pins the `query` ILIKE behavior on `TraceTable.{name, id, session_id}` (`repository.py:169-177`) *and* the 50-char `sanitize_query_string` cap (`validation.py`). The short-probe hit asserts the filter narrows; the long-probe hit pins that a query longer than the cap is sanitized (not rejected, not used raw — both regressions would surface here); the garbage miss asserts the filter does not silently return all traces.
+- **Test 5** — Pins the `?session_id=` exact-match behavior (`TraceTable.session_id == session_id`, `repository.py:165-166`) and confirms that `session_id` passed in the run payload is persisted on the trace row. A regression that dropped session_id from the run-graph plumbing (so the column landed `None`) would surface on the hit assertion.
 
 ---
 
@@ -72,10 +80,11 @@ All four tests carry the same tag set.
 References in the **main Langflow repository** (compatible with Langflow 1.10.x):
 
 - `src/backend/base/langflow/api/v1/traces.py` (lines 45-99) — `GET /monitor/traces` handler; query params declared at lines 48-55; calls `sanitize_query_string` then `fetch_traces`
-- `src/backend/base/langflow/services/tracing/repository.py` (lines 134-189) — `fetch_traces` builds the filter expression list; `status` is an `==`, `start_time` is `>=`, `query` is `ILIKE %x%` across `name | id | session_id`
-- `src/backend/base/langflow/services/tracing/validation.py` — `sanitize_query_string` truncates query to 50 chars and strips non-printable ASCII; relevant to the UUID-as-probe choice
+- `src/backend/base/langflow/services/tracing/repository.py` (lines 134-189) — `fetch_traces` builds the filter expression list; `status` and `session_id` are `==`, `start_time` is `>=`, `end_time` is `<=`, `query` is `ILIKE %x%` across `name | id | session_id`
+- `src/backend/base/langflow/services/tracing/validation.py` — `sanitize_query_string` truncates query to 50 chars and strips non-printable ASCII
 - `src/backend/base/langflow/services/tracing/native.py` (line 296) — sets `trace_status = SpanStatus.ERROR if (error or has_span_errors) else SpanStatus.OK`; explains why `ChatInput → ChatOutput` resolves to `ok` and `basic-prompting` (with the LM error) resolves to `error`
 - `src/backend/base/langflow/services/database/models/traces/model.py` — `SpanStatus` enum (`unset | ok | error`)
+- `src/backend/base/langflow/api/v1/endpoints.py` (line 992) — `/api/v1/run/{flow_id}` accepts `session_id` in the request body and threads it through the graph executor
 
 References in this repository:
 
@@ -89,9 +98,8 @@ References in this repository:
 ## What this test does not cover *(optional)*
 
 - **`?status=unset`** — neither fixture emits `unset` (Chat I/O → `ok`, basic-prompting → `error`). Producing `unset` deterministically would require a fixture for which `native.py` exits the run before any span error is raised — not obviously reachable without forking the tracer. Deliberate gap.
-- **`?query=` substring of `input_value` / message content** — the handler's `ILIKE` is only on `TraceTable.{name, id, session_id}` (`repository.py:173-175`), not on message body. A test that filtered by `input_value` would silently fail to narrow. The issue text suggested "substring of input_value" — that contract does not exist on the handler. Filed as a non-gap.
-- **`?end_time`** — symmetric to `start_time` (line 180-181). Lower-bound test alone pins the comparator direction; adding the upper bound would not catch a regression the existing test misses.
-- **`?session_id=`** — declared in the handler signature but no spec exercises it; the existing fixtures pass no session_id at run time, so the column lands as the auto-generated value. Out of scope here; would warrant its own spec with a session_id explicitly threaded through the run payload.
+- **`?query=` substring of `input_value` / message content** — the handler's `ILIKE` is only on `TraceTable.{name, id, session_id}` (`repository.py:173-175`), not on message body. The handler does not expose that contract; calling it a gap would misrepresent the surface. Filed as a non-gap.
+- **`?end_time`** — the upper bound is `TraceTable.start_time <= end_time` (line 180-181). Symmetric to `start_time`; the two-sided test on `start_time` already pins the comparator pattern. Adding `end_time` would mirror those assertions without exercising new code paths.
 - **Combined filters** (e.g., `?status=ok&start_time=<past>`) — each filter is asserted standalone. The repository combines filters with `AND` over the `filters: list` (`repository.py:183-185`), so combined behavior is a structural consequence of the per-filter contract — not asserted explicitly.
 - **`?page` / `?size` pagination** — out of scope for this spec; would need a fixture that emits enough traces to span pages.
 - **Negative auth path** (401/403 on missing/bad token) — no test pins this for the list endpoint.
@@ -103,12 +111,13 @@ References in this repository:
 - Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
 - The configured superuser (`LANGFLOW_SUPERUSER` / `LANGFLOW_SUPERUSER_PASSWORD`) must be able to issue a token via `getAuthToken`
 - No provider keys required — both fixtures run end-to-end without external credentials
+- `describe.configure({ mode: "serial" })` is load-bearing: the five tests share a single `beforeAll` that seeds two flows + two runs. A block-level comment above the describe restates this so future refactors don't drop the serial config
 
 ---
 
 ## Notes *(optional)*
 
-- The two flows are seeded once in `beforeAll` and reused across all four tests in `mode: "serial"`. The describe block runs single-flow on purpose: the four tests share the seeded state and would race each other if Playwright sharded them.
-- The `query` probe is the error-flow UUID. It is 36 ASCII characters, well under the 50-char sanitizer cap, and unique to this run — so a concurrent test that happened to land a trace with the same `name` substring would have to share a flow id, which is not possible.
+- The two flows are seeded once in `beforeAll` and reused across all five tests in `mode: "serial"`. The session_id is also captured once and reused; a separate session_id per test would multiply the seeding cost without any gain.
+- The `query` probes are intentionally rooted in `errorTraceName`, which is captured *and asserted* in `beforeAll` (`expect(errorTraceName).toContain(errorFlowId)`). If a future Langflow release renames the trace or drops the flow_id from the name, the setup fails fast at the assertion rather than the query test silently hitting `total=0`.
 - The ok fixture (`chat-io-ok-trace-fixture.json`) was built by deriving a minimal `ChatInput → ChatOutput` slice from `basic-prompting-trace-fixture.json`, preserving the exact React Flow handle encoding (the `œ`-substituted JSON in `sourceHandle` / `targetHandle` / edge id). Hand-editing a brand-new fixture would risk an invalid handle that the importer silently accepts but the executor rejects.
-- The `start_time` test uses a one-hour-future cutoff, comfortably above any clock skew between the test client and the Langflow container.
+- The `start_time` test uses ±1-hour cutoffs, comfortably above any clock skew between the test client and the Langflow container.

--- a/tests/assets/flows/chat-io-ok-trace-fixture.json
+++ b/tests/assets/flows/chat-io-ok-trace-fixture.json
@@ -1,0 +1,589 @@
+{
+  "name": "Chat IO OK Trace Fixture",
+  "description": "Fixture used by observability-monitoring traces test to generate a successful (SpanStatus.ok) trace via API. ChatInput → ChatOutput emits no LLM call and cannot fail without provider configuration — the run completes in 'ok' status deterministically.",
+  "data": {
+    "edges": [
+      {
+        "animated": false,
+        "className": "",
+        "data": {
+          "sourceHandle": {
+            "dataType": "ChatInput",
+            "id": "ChatInput-b6UCc",
+            "name": "message",
+            "output_types": [
+              "Message"
+            ]
+          },
+          "targetHandle": {
+            "fieldName": "input_value",
+            "id": "ChatOutput-yK0AU",
+            "inputTypes": [
+              "Data",
+              "JSON",
+              "DataFrame",
+              "Table",
+              "Message"
+            ],
+            "type": "str"
+          }
+        },
+        "id": "reactflow__edge-ChatInput-b6UCc{œdataTypeœ:œChatInputœ,œidœ:œChatInput-b6UCcœ,œnameœ:œmessageœ,œoutput_typesœ:[œMessageœ]}-ChatOutput-yK0AU{œfieldNameœ:œinput_valueœ,œidœ:œChatOutput-yK0AUœ,œinputTypesœ:[œDataœ,œJSONœ,œDataFrameœ,œTableœ,œMessageœ],œtypeœ:œstrœ}",
+        "selected": false,
+        "source": "ChatInput-b6UCc",
+        "sourceHandle": "{œdataTypeœ: œChatInputœ, œidœ: œChatInput-b6UCcœ, œnameœ: œmessageœ, œoutput_typesœ: [œMessageœ]}",
+        "target": "ChatOutput-yK0AU",
+        "targetHandle": "{œfieldNameœ: œinput_valueœ, œidœ: œChatOutput-yK0AUœ, œinputTypesœ: [œDataœ, œJSONœ, œDataFrameœ, œTableœ, œMessageœ], œtypeœ: œstrœ}"
+      }
+    ],
+    "nodes": [
+      {
+        "data": {
+          "description": "Get chat inputs from the Playground.",
+          "display_name": "Chat Input",
+          "id": "ChatInput-b6UCc",
+          "node": {
+            "base_classes": [
+              "Message"
+            ],
+            "beta": false,
+            "conditional_paths": [],
+            "custom_fields": {},
+            "description": "Get chat inputs from the Playground.",
+            "display_name": "Chat Input",
+            "documentation": "",
+            "edited": false,
+            "field_order": [
+              "input_value",
+              "should_store_message",
+              "sender",
+              "sender_name",
+              "session_id",
+              "context_id",
+              "files"
+            ],
+            "frozen": false,
+            "icon": "MessagesSquare",
+            "legacy": false,
+            "lf_version": "1.7.0",
+            "metadata": {
+              "code_hash": "7a26c54d89ed",
+              "dependencies": {
+                "dependencies": [
+                  {
+                    "name": "lfx",
+                    "version": null
+                  }
+                ],
+                "total_dependencies": 1
+              },
+              "module": "lfx.components.input_output.chat.ChatInput"
+            },
+            "output_types": [],
+            "outputs": [
+              {
+                "allows_loop": false,
+                "cache": true,
+                "display_name": "Chat Message",
+                "group_outputs": false,
+                "method": "message_response",
+                "name": "message",
+                "selected": "Message",
+                "tool_mode": true,
+                "types": [
+                  "Message"
+                ],
+                "value": "__UNDEFINED__"
+              }
+            ],
+            "pinned": false,
+            "template": {
+              "_type": "Component",
+              "code": {
+                "advanced": true,
+                "dynamic": true,
+                "fileTypes": [],
+                "file_path": "",
+                "info": "",
+                "list": false,
+                "load_from_db": false,
+                "multiline": true,
+                "name": "code",
+                "password": false,
+                "placeholder": "",
+                "required": true,
+                "show": true,
+                "title_case": false,
+                "type": "code",
+                "value": "from lfx.base.data.utils import IMG_FILE_TYPES, TEXT_FILE_TYPES\nfrom lfx.base.io.chat import ChatComponent\nfrom lfx.inputs.inputs import BoolInput\nfrom lfx.io import (\n    DropdownInput,\n    FileInput,\n    MessageTextInput,\n    MultilineInput,\n    Output,\n)\nfrom lfx.schema.message import Message\nfrom lfx.utils.constants import (\n    MESSAGE_SENDER_AI,\n    MESSAGE_SENDER_NAME_USER,\n    MESSAGE_SENDER_USER,\n)\n\n\nclass ChatInput(ChatComponent):\n    display_name = \"Chat Input\"\n    description = \"Get chat inputs from the Playground.\"\n    documentation: str = \"https://docs.langflow.org/chat-input-and-output\"\n    icon = \"MessagesSquare\"\n    name = \"ChatInput\"\n    minimized = True\n\n    inputs = [\n        MultilineInput(\n            name=\"input_value\",\n            display_name=\"Input Text\",\n            value=\"\",\n            info=\"Message to be passed as input.\",\n            input_types=[],\n        ),\n        BoolInput(\n            name=\"should_store_message\",\n            display_name=\"Store Messages\",\n            info=\"Store the message in the history.\",\n            value=True,\n            advanced=True,\n        ),\n        DropdownInput(\n            name=\"sender\",\n            display_name=\"Sender Type\",\n            options=[MESSAGE_SENDER_AI, MESSAGE_SENDER_USER],\n            value=MESSAGE_SENDER_USER,\n            info=\"Type of sender.\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"sender_name\",\n            display_name=\"Sender Name\",\n            info=\"Name of the sender.\",\n            value=MESSAGE_SENDER_NAME_USER,\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"session_id\",\n            display_name=\"Session ID\",\n            info=\"The session ID of the chat. If empty, the current session ID parameter will be used.\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"context_id\",\n            display_name=\"Context ID\",\n            info=\"The context ID of the chat. Adds an extra layer to the local memory.\",\n            value=\"\",\n            advanced=True,\n        ),\n        FileInput(\n            name=\"files\",\n            display_name=\"Files\",\n            file_types=TEXT_FILE_TYPES + IMG_FILE_TYPES,\n            info=\"Files to be sent with the message.\",\n            advanced=True,\n            is_list=True,\n            temp_file=True,\n        ),\n    ]\n    outputs = [\n        Output(display_name=\"Chat Message\", name=\"message\", method=\"message_response\"),\n    ]\n\n    async def message_response(self) -> Message:\n        # Ensure files is a list and filter out empty/None values\n        files = self.files if self.files else []\n        if files and not isinstance(files, list):\n            files = [files]\n        # Filter out None/empty values\n        files = [f for f in files if f is not None and f != \"\"]\n\n        session_id = self.session_id or self.graph.session_id or \"\"\n        message = await Message.create(\n            text=self.input_value,\n            sender=self.sender,\n            sender_name=self.sender_name,\n            session_id=session_id,\n            context_id=self.context_id,\n            files=files,\n        )\n        if session_id and isinstance(message, Message) and self.should_store_message:\n            stored_message = await self.send_message(\n                message,\n            )\n            self.message.value = stored_message\n            message = stored_message\n\n        self.status = message\n        return message\n"
+              },
+              "context_id": {
+                "_input_type": "MessageTextInput",
+                "advanced": true,
+                "display_name": "Context ID",
+                "dynamic": false,
+                "info": "The context ID of the chat. Adds an extra layer to the local memory.",
+                "input_types": [
+                  "Message"
+                ],
+                "list": false,
+                "list_add_label": "Add More",
+                "load_from_db": false,
+                "name": "context_id",
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "type": "str",
+                "value": ""
+              },
+              "files": {
+                "advanced": true,
+                "display_name": "Files",
+                "dynamic": false,
+                "fileTypes": [
+                  "csv",
+                  "json",
+                  "pdf",
+                  "txt",
+                  "md",
+                  "mdx",
+                  "yaml",
+                  "yml",
+                  "xml",
+                  "html",
+                  "htm",
+                  "docx",
+                  "py",
+                  "sh",
+                  "sql",
+                  "js",
+                  "ts",
+                  "tsx",
+                  "jpg",
+                  "jpeg",
+                  "png",
+                  "bmp",
+                  "image"
+                ],
+                "file_path": "",
+                "info": "Files to be sent with the message.",
+                "list": true,
+                "name": "files",
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "temp_file": true,
+                "title_case": false,
+                "trace_as_metadata": true,
+                "type": "file",
+                "value": ""
+              },
+              "input_value": {
+                "advanced": false,
+                "display_name": "Input Text",
+                "dynamic": false,
+                "info": "Message to be passed as input.",
+                "input_types": [],
+                "list": false,
+                "load_from_db": false,
+                "multiline": true,
+                "name": "input_value",
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "type": "str",
+                "value": "Hello"
+              },
+              "sender": {
+                "advanced": true,
+                "display_name": "Sender Type",
+                "dynamic": false,
+                "info": "Type of sender.",
+                "name": "sender",
+                "options": [
+                  "Machine",
+                  "User"
+                ],
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "trace_as_metadata": true,
+                "type": "str",
+                "value": "User"
+              },
+              "sender_name": {
+                "advanced": true,
+                "display_name": "Sender Name",
+                "dynamic": false,
+                "info": "Name of the sender.",
+                "input_types": [
+                  "Message"
+                ],
+                "list": false,
+                "load_from_db": false,
+                "name": "sender_name",
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "type": "str",
+                "value": "User"
+              },
+              "session_id": {
+                "advanced": true,
+                "display_name": "Session ID",
+                "dynamic": false,
+                "info": "The session ID of the chat. If empty, the current session ID parameter will be used.",
+                "input_types": [
+                  "Message"
+                ],
+                "list": false,
+                "load_from_db": false,
+                "name": "session_id",
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "type": "str",
+                "value": ""
+              },
+              "should_store_message": {
+                "_input_type": "BoolInput",
+                "advanced": true,
+                "display_name": "Store Messages",
+                "dynamic": false,
+                "info": "Store the message in the history.",
+                "list": false,
+                "name": "should_store_message",
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "trace_as_metadata": true,
+                "type": "bool",
+                "value": true
+              }
+            }
+          },
+          "selected_output": "message",
+          "type": "ChatInput"
+        },
+        "dragging": false,
+        "height": 234,
+        "id": "ChatInput-b6UCc",
+        "measured": {
+          "height": 234,
+          "width": 320
+        },
+        "position": {
+          "x": 689.5720422421635,
+          "y": 765.155834131403
+        },
+        "positionAbsolute": {
+          "x": 689.5720422421635,
+          "y": 765.155834131403
+        },
+        "selected": false,
+        "type": "genericNode"
+      },
+      {
+        "data": {
+          "id": "ChatOutput-yK0AU",
+          "node": {
+            "base_classes": [
+              "Message"
+            ],
+            "beta": false,
+            "conditional_paths": [],
+            "custom_fields": {},
+            "description": "Display a chat message in the Playground.",
+            "display_name": "Chat Output",
+            "documentation": "",
+            "edited": false,
+            "field_order": [
+              "input_value",
+              "should_store_message",
+              "sender",
+              "sender_name",
+              "session_id",
+              "context_id",
+              "data_template",
+              "clean_data"
+            ],
+            "frozen": false,
+            "icon": "MessagesSquare",
+            "legacy": false,
+            "lf_version": "1.7.0",
+            "metadata": {
+              "code_hash": "84009527d08c",
+              "dependencies": {
+                "dependencies": [
+                  {
+                    "name": "orjson",
+                    "version": "3.11.8"
+                  },
+                  {
+                    "name": "fastapi",
+                    "version": "0.136.1"
+                  },
+                  {
+                    "name": "lfx",
+                    "version": null
+                  }
+                ],
+                "total_dependencies": 3
+              },
+              "module": "lfx.components.input_output.chat_output.ChatOutput"
+            },
+            "output_types": [],
+            "outputs": [
+              {
+                "allows_loop": false,
+                "cache": true,
+                "display_name": "Output Message",
+                "group_outputs": false,
+                "method": "message_response",
+                "name": "message",
+                "selected": "Message",
+                "tool_mode": true,
+                "types": [
+                  "Message"
+                ],
+                "value": "__UNDEFINED__"
+              }
+            ],
+            "pinned": false,
+            "template": {
+              "_type": "Component",
+              "clean_data": {
+                "_input_type": "BoolInput",
+                "advanced": true,
+                "display_name": "Basic Clean Data",
+                "dynamic": false,
+                "info": "Whether to clean data before converting to string.",
+                "list": false,
+                "list_add_label": "Add More",
+                "name": "clean_data",
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "type": "bool",
+                "value": true
+              },
+              "code": {
+                "advanced": true,
+                "dynamic": true,
+                "fileTypes": [],
+                "file_path": "",
+                "info": "",
+                "list": false,
+                "load_from_db": false,
+                "multiline": true,
+                "name": "code",
+                "password": false,
+                "placeholder": "",
+                "required": true,
+                "show": true,
+                "title_case": false,
+                "type": "code",
+                "value": "from collections.abc import Generator\nfrom typing import Any\n\nimport orjson\nfrom fastapi.encoders import jsonable_encoder\n\nfrom lfx.base.io.chat import ChatComponent\nfrom lfx.helpers.data import safe_convert\nfrom lfx.inputs.inputs import BoolInput, DropdownInput, HandleInput, MessageTextInput\nfrom lfx.schema.data import Data\nfrom lfx.schema.dataframe import DataFrame\nfrom lfx.schema.message import Message\nfrom lfx.schema.properties import Source\nfrom lfx.template.field.base import Output\nfrom lfx.utils.constants import (\n    MESSAGE_SENDER_AI,\n    MESSAGE_SENDER_NAME_AI,\n    MESSAGE_SENDER_USER,\n)\n\n\nclass ChatOutput(ChatComponent):\n    display_name = \"Chat Output\"\n    description = \"Display a chat message in the Playground.\"\n    documentation: str = \"https://docs.langflow.org/chat-input-and-output\"\n    icon = \"MessagesSquare\"\n    name = \"ChatOutput\"\n    minimized = True\n\n    inputs = [\n        HandleInput(\n            name=\"input_value\",\n            display_name=\"Inputs\",\n            info=\"Message to be passed as output.\",\n            input_types=[\"Data\", \"JSON\", \"DataFrame\", \"Table\", \"Message\"],\n            required=True,\n        ),\n        BoolInput(\n            name=\"should_store_message\",\n            display_name=\"Store Messages\",\n            info=\"Store the message in the history.\",\n            value=True,\n            advanced=True,\n        ),\n        DropdownInput(\n            name=\"sender\",\n            display_name=\"Sender Type\",\n            options=[MESSAGE_SENDER_AI, MESSAGE_SENDER_USER],\n            value=MESSAGE_SENDER_AI,\n            advanced=True,\n            info=\"Type of sender.\",\n        ),\n        MessageTextInput(\n            name=\"sender_name\",\n            display_name=\"Sender Name\",\n            info=\"Name of the sender.\",\n            value=MESSAGE_SENDER_NAME_AI,\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"session_id\",\n            display_name=\"Session ID\",\n            info=\"The session ID of the chat. If empty, the current session ID parameter will be used.\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"context_id\",\n            display_name=\"Context ID\",\n            info=\"The context ID of the chat. Adds an extra layer to the local memory.\",\n            value=\"\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"data_template\",\n            display_name=\"Data Template\",\n            value=\"{text}\",\n            advanced=True,\n            info=\"Template to convert Data to Text. If left empty, it will be dynamically set to the Data's text key.\",\n        ),\n        BoolInput(\n            name=\"clean_data\",\n            display_name=\"Basic Clean Data\",\n            value=True,\n            advanced=True,\n            info=\"Whether to clean data before converting to string.\",\n        ),\n    ]\n    outputs = [\n        Output(\n            display_name=\"Output Message\",\n            name=\"message\",\n            method=\"message_response\",\n        ),\n    ]\n\n    def _build_source(self, id_: str | None, display_name: str | None, source: str | None) -> Source:\n        source_dict = {}\n        if id_:\n            source_dict[\"id\"] = id_\n        if display_name:\n            source_dict[\"display_name\"] = display_name\n        if source:\n            # Handle case where source is a ChatOpenAI object\n            if hasattr(source, \"model_name\"):\n                source_dict[\"source\"] = source.model_name\n            elif hasattr(source, \"model\"):\n                source_dict[\"source\"] = str(source.model)\n            else:\n                source_dict[\"source\"] = str(source)\n        return Source(**source_dict)\n\n    async def message_response(self) -> Message:\n        # First convert the input to string if needed\n        text = self.convert_to_string()\n\n        # Get source properties\n        source, _, display_name, source_id = self.get_properties_from_source_component()\n\n        # Create or use existing Message object\n        if isinstance(self.input_value, Message) and not self.is_connected_to_chat_input():\n            message = self.input_value\n            # Update message properties\n            message.text = text\n            # Preserve existing session_id from the incoming message if it exists\n            existing_session_id = message.session_id\n        else:\n            message = Message(text=text)\n            existing_session_id = None\n\n        # Set message properties\n        message.sender = self.sender\n        message.sender_name = self.sender_name\n        # Preserve session_id from incoming message, or use component/graph session_id\n        message.session_id = (\n            self.session_id or existing_session_id or (self.graph.session_id if hasattr(self, \"graph\") else None) or \"\"\n        )\n        message.context_id = self.context_id\n        message.flow_id = self.graph.flow_id if hasattr(self, \"graph\") else None\n        message.properties.source = self._build_source(source_id, display_name, source)\n\n        # Store message if needed\n        if message.session_id and self.should_store_message:\n            stored_message = await self.send_message(message)\n            self.message.value = stored_message\n            message = stored_message\n\n        # Set accumulated token usage from all upstream LLM vertices.\n        # This must happen AFTER send_message() because streaming captures\n        # usage from chunks and would overwrite accumulated totals.\n        if hasattr(self, \"_vertex\") and self._vertex is not None:\n            accumulated_usage = self._vertex._accumulate_upstream_token_usage()  # noqa: SLF001\n            if accumulated_usage:\n                message.properties.usage = accumulated_usage\n                if self.should_store_message and message.get_id():\n                    message = await self._update_stored_message(message)\n                    await self._send_message_event(message, id_=message.get_id())\n\n        self.status = message\n        return message\n\n    def _serialize_data(self, data: Data) -> str:\n        \"\"\"Serialize Data object to JSON string.\"\"\"\n        # Convert data.data to JSON-serializable format\n        serializable_data = jsonable_encoder(data.data)\n        # Serialize with orjson, enabling pretty printing with indentation\n        json_bytes = orjson.dumps(serializable_data, option=orjson.OPT_INDENT_2)\n        # Convert bytes to string and wrap in Markdown code blocks\n        return \"```json\\n\" + json_bytes.decode(\"utf-8\") + \"\\n```\"\n\n    def _validate_input(self) -> None:\n        \"\"\"Validate the input data and raise ValueError if invalid.\"\"\"\n        if self.input_value is None:\n            msg = \"Input data cannot be None\"\n            raise ValueError(msg)\n        if isinstance(self.input_value, list) and not all(\n            isinstance(item, Message | Data | DataFrame | str) for item in self.input_value\n        ):\n            invalid_types = [\n                type(item).__name__\n                for item in self.input_value\n                if not isinstance(item, Message | Data | DataFrame | str)\n            ]\n            msg = f\"Expected Data or DataFrame or Message or str, got {invalid_types}\"\n            raise TypeError(msg)\n        if not isinstance(\n            self.input_value,\n            Message | Data | DataFrame | str | list | Generator | type(None),\n        ):\n            type_name = type(self.input_value).__name__\n            msg = f\"Expected Data or DataFrame or Message or str, Generator or None, got {type_name}\"\n            raise TypeError(msg)\n\n    def convert_to_string(self) -> str | Generator[Any, None, None]:\n        \"\"\"Convert input data to string with proper error handling.\"\"\"\n        self._validate_input()\n        if isinstance(self.input_value, list):\n            clean_data: bool = getattr(self, \"clean_data\", False)\n            return \"\\n\".join([safe_convert(item, clean_data=clean_data) for item in self.input_value])\n        if isinstance(self.input_value, Generator):\n            return self.input_value\n        return safe_convert(self.input_value)\n"
+              },
+              "context_id": {
+                "_input_type": "MessageTextInput",
+                "advanced": true,
+                "display_name": "Context ID",
+                "dynamic": false,
+                "info": "The context ID of the chat. Adds an extra layer to the local memory.",
+                "input_types": [
+                  "Message"
+                ],
+                "list": false,
+                "list_add_label": "Add More",
+                "load_from_db": false,
+                "name": "context_id",
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "type": "str",
+                "value": ""
+              },
+              "data_template": {
+                "_input_type": "MessageTextInput",
+                "advanced": true,
+                "display_name": "Data Template",
+                "dynamic": false,
+                "info": "Template to convert Data to Text. If left empty, it will be dynamically set to the Data's text key.",
+                "input_types": [
+                  "Message"
+                ],
+                "list": false,
+                "load_from_db": false,
+                "name": "data_template",
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "type": "str",
+                "value": "{text}"
+              },
+              "input_value": {
+                "_input_type": "MessageInput",
+                "advanced": false,
+                "display_name": "Inputs",
+                "dynamic": false,
+                "info": "Message to be passed as output.",
+                "input_types": [
+                  "Data",
+                  "JSON",
+                  "DataFrame",
+                  "Table",
+                  "Message"
+                ],
+                "list": false,
+                "load_from_db": false,
+                "name": "input_value",
+                "placeholder": "",
+                "required": true,
+                "show": true,
+                "title_case": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "type": "str",
+                "value": ""
+              },
+              "sender": {
+                "_input_type": "DropdownInput",
+                "advanced": true,
+                "combobox": false,
+                "display_name": "Sender Type",
+                "dynamic": false,
+                "info": "Type of sender.",
+                "name": "sender",
+                "options": [
+                  "Machine",
+                  "User"
+                ],
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "type": "str",
+                "value": "Machine"
+              },
+              "sender_name": {
+                "_input_type": "MessageTextInput",
+                "advanced": true,
+                "display_name": "Sender Name",
+                "dynamic": false,
+                "info": "Name of the sender.",
+                "input_types": [
+                  "Message"
+                ],
+                "list": false,
+                "load_from_db": false,
+                "name": "sender_name",
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "type": "str",
+                "value": "AI"
+              },
+              "session_id": {
+                "_input_type": "MessageTextInput",
+                "advanced": true,
+                "display_name": "Session ID",
+                "dynamic": false,
+                "info": "The session ID of the chat. If empty, the current session ID parameter will be used.",
+                "input_types": [
+                  "Message"
+                ],
+                "list": false,
+                "load_from_db": false,
+                "name": "session_id",
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "type": "str",
+                "value": ""
+              },
+              "should_store_message": {
+                "_input_type": "BoolInput",
+                "advanced": true,
+                "display_name": "Store Messages",
+                "dynamic": false,
+                "info": "Store the message in the history.",
+                "list": false,
+                "name": "should_store_message",
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "trace_as_metadata": true,
+                "type": "bool",
+                "value": true
+              }
+            },
+            "tool_mode": false
+          },
+          "type": "ChatOutput"
+        },
+        "dragging": false,
+        "height": 234,
+        "id": "ChatOutput-yK0AU",
+        "measured": {
+          "height": 234,
+          "width": 320
+        },
+        "position": {
+          "x": 1460.070372772908,
+          "y": 872.7273956769025
+        },
+        "positionAbsolute": {
+          "x": 1444.936881624563,
+          "y": 872.7273956769025
+        },
+        "selected": false,
+        "type": "genericNode",
+        "width": 320
+      }
+    ],
+    "viewport": {
+      "x": -211.08737632991608,
+      "y": -465.0975538356132,
+      "zoom": 0.8960810767526934
+    }
+  },
+  "is_component": false
+}

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-list-filters.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-list-filters.spec.ts
@@ -22,7 +22,11 @@ const OK_FIXTURE = JSON.parse(
   ),
 );
 
-test.describe("Trace list filters — status / start_time / query", () => {
+// REQUIRES serial mode. The five tests below share a single beforeAll that
+// seeds two flows, runs each once, and polls for trace emission. Removing
+// `describe.configure({ mode: "serial" })` would let Playwright shard the
+// tests across workers, all of which would race against the same setup.
+test.describe("Trace list filters — status / start_time / query / session_id", () => {
   test.describe.configure({ mode: "serial" });
 
   let bearerToken: string;
@@ -30,9 +34,14 @@ test.describe("Trace list filters — status / start_time / query", () => {
   let apiKeyId: string;
   let errorFlowId: string;
   let okFlowId: string;
-  // Unique substring captured from the trace name during setup — drives the
-  // `?query=` filter assertions without depending on the trace-name format.
-  let errorTraceNameProbe: string;
+  // Full trace.name of the error run — drives both the `?query=` substring
+  // probe and the 50-char sanitizer-cap probe. Captured (and asserted) in
+  // beforeAll so a future change to the trace-name format surfaces there
+  // instead of silently failing the query test.
+  let errorTraceName: string;
+  // Unique session_id threaded through the ok run's payload — drives the
+  // `?session_id=` filter assertions.
+  let okSessionId: string;
 
   test.beforeAll(async ({ request }) => {
     bearerToken = await getAuthToken(request);
@@ -72,6 +81,10 @@ test.describe("Trace list filters — status / start_time / query", () => {
     expect(okFlowRes.status()).toBe(201);
     okFlowId = (await okFlowRes.json()).id;
 
+    // Langflow returns 200 (with error payload) or 500 for component-level
+    // failures. Anything outside that range (401, 422, etc.) means the run
+    // never reached the graph executor and no trace will be emitted — fail
+    // fast instead of timing out on the poll below.
     const errorRunRes = await request.post(`/api/v1/run/${errorFlowId}`, {
       headers: { "x-api-key": apiKey },
       data: {
@@ -82,12 +95,17 @@ test.describe("Trace list filters — status / start_time / query", () => {
     });
     expect([200, 500]).toContain(errorRunRes.status());
 
+    // Thread a unique session_id through the ok run so the ?session_id=
+    // filter has a deterministic target. The session_id is persisted on
+    // TraceTable.session_id by the native tracer.
+    okSessionId = `filters-ok-session-${Date.now()}`;
     const okRunRes = await request.post(`/api/v1/run/${okFlowId}`, {
       headers: { "x-api-key": apiKey },
       data: {
         input_value: "filters-ok-probe",
         input_type: "chat",
         output_type: "chat",
+        session_id: okSessionId,
       },
     });
     expect(okRunRes.status()).toBe(200);
@@ -112,17 +130,21 @@ test.describe("Trace list filters — status / start_time / query", () => {
         .toBeGreaterThan(0);
     }
 
-    // Capture the unique trailing UUID of the error trace name for ?query=.
-    // The handler ILIKEs on TraceTable.{name,id,session_id}, and the trace
-    // name is `<flow.name> - <flowId>`, so the flow UUID is a substring of
-    // the name and unique across concurrent test runs.
+    // Capture and validate the error-trace name shape. The handler ILIKEs on
+    // TraceTable.{name, id, session_id} (repository.py:169-177), but trace.id
+    // is its own UUID (not flow_id), and we did not set a session_id on the
+    // error run — so the only column the flow-UUID probe can hit through is
+    // `name`. Asserting the substring here means a future change to the
+    // trace-name format surfaces at setup time, not as a confusing 0-hit on
+    // the ?query= test.
     const errorListRes = await request.get(
       `/api/v1/monitor/traces?flow_id=${errorFlowId}`,
       { headers: { Authorization: bearerToken } },
     );
     const errorBody = await errorListRes.json();
     expect(typeof errorBody.traces?.[0]?.name).toBe("string");
-    errorTraceNameProbe = errorFlowId;
+    errorTraceName = errorBody.traces[0].name as string;
+    expect(errorTraceName).toContain(errorFlowId);
   });
 
   test.afterAll(async ({ request }) => {
@@ -152,7 +174,7 @@ test.describe("Trace list filters — status / start_time / query", () => {
   });
 
   test(
-    "GET /api/v1/monitor/traces?status=error returns only the failing trace",
+    "GET /api/v1/monitor/traces?status=error returns only the failing trace; rejects unknown values",
     { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       const matchRes = await request.get(
@@ -174,6 +196,15 @@ test.describe("Trace list filters — status / start_time / query", () => {
       const missBody = await missRes.json();
       expect(missBody.total).toBe(0);
       expect(missBody.traces.length).toBe(0);
+
+      // Unknown SpanStatus value must be rejected by FastAPI's enum parser
+      // (Pydantic 422), not silently coerced to a string LIKE. A handler
+      // that loosened the enum to plain str would leak through here.
+      const invalidRes = await request.get(
+        `/api/v1/monitor/traces?flow_id=${errorFlowId}&status=failed`,
+        { headers: { Authorization: bearerToken } },
+      );
+      expect(invalidRes.status()).toBe(422);
     },
   );
 
@@ -204,33 +235,15 @@ test.describe("Trace list filters — status / start_time / query", () => {
   );
 
   test(
-    "GET /api/v1/monitor/traces?start_time=<future> returns empty",
+    "GET /api/v1/monitor/traces?start_time pins the >= lower bound",
     { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
-      // ISO timestamp 1 hour in the future — every seeded trace must precede it.
-      const future = new Date(Date.now() + 3600 * 1000).toISOString();
-
-      const res = await request.get(
-        `/api/v1/monitor/traces?flow_id=${errorFlowId}&start_time=${encodeURIComponent(future)}`,
-        { headers: { Authorization: bearerToken } },
-      );
-      expect(res.status()).toBe(200);
-      const body = await res.json();
-      expect(body.total).toBe(0);
-      expect(body.traces.length).toBe(0);
-    },
-  );
-
-  test(
-    "GET /api/v1/monitor/traces?query=<substring> filters by trace name/id/session",
-    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
-    async ({ request }) => {
-      // The handler ILIKEs on TraceTable.{name,id,session_id} (capped at 50
-      // chars by sanitize_query_string). The flow UUID is part of the trace
-      // name and unique across concurrent runs — a hit must return >= 1, and
-      // when narrowed by flow_id it must be exactly 1.
+      // Past cutoff: every seeded trace satisfies start_time >= past, so a
+      // handler that flipped the comparator to <= would return 0 here. This
+      // is the half that actually pins the direction.
+      const past = new Date(Date.now() - 3600 * 1000).toISOString();
       const hitRes = await request.get(
-        `/api/v1/monitor/traces?flow_id=${errorFlowId}&query=${encodeURIComponent(errorTraceNameProbe)}`,
+        `/api/v1/monitor/traces?flow_id=${errorFlowId}&start_time=${encodeURIComponent(past)}`,
         { headers: { Authorization: bearerToken } },
       );
       expect(hitRes.status()).toBe(200);
@@ -239,11 +252,83 @@ test.describe("Trace list filters — status / start_time / query", () => {
       expect(hitBody.traces.length).toBe(1);
       expect(hitBody.traces[0].flowId).toBe(errorFlowId);
 
+      // Future cutoff: every seeded trace precedes it, so the filter must
+      // exclude all rows. Confirms the filter is actually wired (not a no-op).
+      const future = new Date(Date.now() + 3600 * 1000).toISOString();
+      const missRes = await request.get(
+        `/api/v1/monitor/traces?flow_id=${errorFlowId}&start_time=${encodeURIComponent(future)}`,
+        { headers: { Authorization: bearerToken } },
+      );
+      expect(missRes.status()).toBe(200);
+      const missBody = await missRes.json();
+      expect(missBody.total).toBe(0);
+      expect(missBody.traces.length).toBe(0);
+    },
+  );
+
+  test(
+    "GET /api/v1/monitor/traces?query=<substring> filters by trace name (incl. 50-char sanitize cap)",
+    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
+    async ({ request }) => {
+      // The handler ILIKEs on TraceTable.{name, id, session_id} (capped at
+      // 50 chars by sanitize_query_string). In this setup the flow UUID is
+      // only inside `name`, so the hit here pins the `name` branch.
+      const hitRes = await request.get(
+        `/api/v1/monitor/traces?flow_id=${errorFlowId}&query=${encodeURIComponent(errorFlowId)}`,
+        { headers: { Authorization: bearerToken } },
+      );
+      expect(hitRes.status()).toBe(200);
+      const hitBody = await hitRes.json();
+      expect(hitBody.total).toBe(1);
+      expect(hitBody.traces.length).toBe(1);
+      expect(hitBody.traces[0].flowId).toBe(errorFlowId);
+
+      // 50-char sanitizer cap: send a probe longer than 50 chars whose first
+      // 50 chars are still inside trace.name. The cap truncates to 50, and
+      // those 50 must still hit. A regression dropping the cap would still
+      // hit (the full string is also inside the name) — but a regression
+      // that hardened the cap into a reject (e.g. raised 422 on len > 50)
+      // would surface here.
+      const longProbe = errorTraceName.slice(0, 60);
+      expect(longProbe.length).toBeGreaterThan(50);
+      const longRes = await request.get(
+        `/api/v1/monitor/traces?flow_id=${errorFlowId}&query=${encodeURIComponent(longProbe)}`,
+        { headers: { Authorization: bearerToken } },
+      );
+      expect(longRes.status()).toBe(200);
+      const longBody = await longRes.json();
+      expect(longBody.total).toBe(1);
+      expect(longBody.traces[0].flowId).toBe(errorFlowId);
+
       // Same query string with a guaranteed-unmatched fixed prefix returns 0.
-      // Using a hyphen-prefixed nonce keeps the probe within the 50-char
-      // sanitizer cap and within the printable-ASCII allowlist.
       const missRes = await request.get(
         `/api/v1/monitor/traces?flow_id=${errorFlowId}&query=zzz-no-trace-name-matches-this-${Date.now()}`,
+        { headers: { Authorization: bearerToken } },
+      );
+      expect(missRes.status()).toBe(200);
+      const missBody = await missRes.json();
+      expect(missBody.total).toBe(0);
+      expect(missBody.traces.length).toBe(0);
+    },
+  );
+
+  test(
+    "GET /api/v1/monitor/traces?session_id filters by the session passed at run time",
+    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
+    async ({ request }) => {
+      const hitRes = await request.get(
+        `/api/v1/monitor/traces?flow_id=${okFlowId}&session_id=${encodeURIComponent(okSessionId)}`,
+        { headers: { Authorization: bearerToken } },
+      );
+      expect(hitRes.status()).toBe(200);
+      const hitBody = await hitRes.json();
+      expect(hitBody.total).toBe(1);
+      expect(hitBody.traces.length).toBe(1);
+      expect(hitBody.traces[0].flowId).toBe(okFlowId);
+      expect(hitBody.traces[0].sessionId).toBe(okSessionId);
+
+      const missRes = await request.get(
+        `/api/v1/monitor/traces?flow_id=${okFlowId}&session_id=missing-session-${Date.now()}`,
         { headers: { Authorization: bearerToken } },
       );
       expect(missRes.status()).toBe(200);

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-list-filters.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-list-filters.spec.ts
@@ -141,6 +141,7 @@ test.describe("Trace list filters — status / start_time / query / session_id",
       `/api/v1/monitor/traces?flow_id=${errorFlowId}`,
       { headers: { Authorization: bearerToken } },
     );
+    expect(errorListRes.status()).toBe(200);
     const errorBody = await errorListRes.json();
     expect(typeof errorBody.traces?.[0]?.name).toBe("string");
     errorTraceName = errorBody.traces[0].name as string;
@@ -283,13 +284,17 @@ test.describe("Trace list filters — status / start_time / query / session_id",
       expect(hitBody.traces.length).toBe(1);
       expect(hitBody.traces[0].flowId).toBe(errorFlowId);
 
-      // 50-char sanitizer cap: send a probe longer than 50 chars whose first
-      // 50 chars are still inside trace.name. The cap truncates to 50, and
-      // those 50 must still hit. A regression dropping the cap would still
-      // hit (the full string is also inside the name) — but a regression
-      // that hardened the cap into a reject (e.g. raised 422 on len > 50)
-      // would surface here.
-      const longProbe = errorTraceName.slice(0, 60);
+      // 50-char sanitizer cap: send a probe whose first 50 chars are inside
+      // trace.name but whose tail is a guaranteed-unmatched suffix. This is
+      // the only shape that discriminates the cap from the no-cap case:
+      // - cap engaged → sanitizer truncates to first 50 chars (in-name) → HIT
+      // - cap dropped → backend ILIKEs the full string (50 in-name + garbage
+      //   suffix) which is *not* inside trace.name → MISS
+      // - cap hardened into a reject (e.g. 422 on len > 50) → status != 200
+      // A prefix-only probe (slice(0, 60)) would HIT in both the cap and
+      // no-cap cases and could not tell them apart.
+      const longProbe =
+        errorTraceName.slice(0, 50) + `-zzz-not-in-name-${Date.now()}`;
       expect(longProbe.length).toBeGreaterThan(50);
       const longRes = await request.get(
         `/api/v1/monitor/traces?flow_id=${errorFlowId}&query=${encodeURIComponent(longProbe)}`,

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-list-filters.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-list-filters.spec.ts
@@ -1,0 +1,255 @@
+import { readFileSync } from "fs";
+import path from "path";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+
+const ERROR_FIXTURE = JSON.parse(
+  readFileSync(
+    path.resolve(
+      __dirname,
+      "../../../../assets/flows/basic-prompting-trace-fixture.json",
+    ),
+    "utf8",
+  ),
+);
+const OK_FIXTURE = JSON.parse(
+  readFileSync(
+    path.resolve(
+      __dirname,
+      "../../../../assets/flows/chat-io-ok-trace-fixture.json",
+    ),
+    "utf8",
+  ),
+);
+
+test.describe("Trace list filters — status / start_time / query", () => {
+  test.describe.configure({ mode: "serial" });
+
+  let bearerToken: string;
+  let apiKey: string;
+  let apiKeyId: string;
+  let errorFlowId: string;
+  let okFlowId: string;
+  // Unique substring captured from the trace name during setup — drives the
+  // `?query=` filter assertions without depending on the trace-name format.
+  let errorTraceNameProbe: string;
+
+  test.beforeAll(async ({ request }) => {
+    bearerToken = await getAuthToken(request);
+
+    const keyRes = await request.post("/api/v1/api_key/", {
+      headers: { Authorization: bearerToken },
+      data: { name: `traces-filters-test-${Date.now()}` },
+    });
+    expect(keyRes.status()).toBe(200);
+    const keyBody = await keyRes.json();
+    apiKey = keyBody.api_key;
+    apiKeyId = keyBody.id;
+
+    // Flow A — basic-prompting without provider; the LanguageModelComponent
+    // fails with "A model selection is required", which still emits a trace
+    // with status=error.
+    const errorFlowRes = await request.post("/api/v1/flows/", {
+      headers: { "x-api-key": apiKey },
+      data: {
+        ...ERROR_FIXTURE,
+        name: `${ERROR_FIXTURE.name} ${Date.now()}`,
+      },
+    });
+    expect(errorFlowRes.status()).toBe(201);
+    errorFlowId = (await errorFlowRes.json()).id;
+
+    // Flow B — ChatInput → ChatOutput; pure local I/O, no LLM, run completes
+    // in status=ok. The two flows together let us pin the discriminative
+    // behavior of ?status=ok vs ?status=error scoped by flow_id.
+    const okFlowRes = await request.post("/api/v1/flows/", {
+      headers: { "x-api-key": apiKey },
+      data: {
+        ...OK_FIXTURE,
+        name: `${OK_FIXTURE.name} ${Date.now()}`,
+      },
+    });
+    expect(okFlowRes.status()).toBe(201);
+    okFlowId = (await okFlowRes.json()).id;
+
+    const errorRunRes = await request.post(`/api/v1/run/${errorFlowId}`, {
+      headers: { "x-api-key": apiKey },
+      data: {
+        input_value: "filters-error-probe",
+        input_type: "chat",
+        output_type: "chat",
+      },
+    });
+    expect([200, 500]).toContain(errorRunRes.status());
+
+    const okRunRes = await request.post(`/api/v1/run/${okFlowId}`, {
+      headers: { "x-api-key": apiKey },
+      data: {
+        input_value: "filters-ok-probe",
+        input_type: "chat",
+        output_type: "chat",
+      },
+    });
+    expect(okRunRes.status()).toBe(200);
+
+    // Poll each flow independently — a single combined poll could be satisfied
+    // by one flow's trace landing before the other and the assertions below
+    // would race against the second insert.
+    for (const fId of [errorFlowId, okFlowId]) {
+      await expect
+        .poll(
+          async () => {
+            const res = await request.get(
+              `/api/v1/monitor/traces?flow_id=${fId}`,
+              { headers: { Authorization: bearerToken } },
+            );
+            if (res.status() !== 200) return 0;
+            const body = await res.json();
+            return body.traces?.length ?? 0;
+          },
+          { timeout: 30000, intervals: [500, 1000, 2000] },
+        )
+        .toBeGreaterThan(0);
+    }
+
+    // Capture the unique trailing UUID of the error trace name for ?query=.
+    // The handler ILIKEs on TraceTable.{name,id,session_id}, and the trace
+    // name is `<flow.name> - <flowId>`, so the flow UUID is a substring of
+    // the name and unique across concurrent test runs.
+    const errorListRes = await request.get(
+      `/api/v1/monitor/traces?flow_id=${errorFlowId}`,
+      { headers: { Authorization: bearerToken } },
+    );
+    const errorBody = await errorListRes.json();
+    expect(typeof errorBody.traces?.[0]?.name).toBe("string");
+    errorTraceNameProbe = errorFlowId;
+  });
+
+  test.afterAll(async ({ request }) => {
+    const cleanups: Promise<unknown>[] = [];
+    if (errorFlowId && apiKey) {
+      cleanups.push(
+        request.delete(`/api/v1/flows/${errorFlowId}`, {
+          headers: { "x-api-key": apiKey },
+        }),
+      );
+    }
+    if (okFlowId && apiKey) {
+      cleanups.push(
+        request.delete(`/api/v1/flows/${okFlowId}`, {
+          headers: { "x-api-key": apiKey },
+        }),
+      );
+    }
+    if (apiKeyId) {
+      cleanups.push(
+        request.delete(`/api/v1/api_key/${apiKeyId}`, {
+          headers: { Authorization: bearerToken },
+        }),
+      );
+    }
+    await Promise.allSettled(cleanups);
+  });
+
+  test(
+    "GET /api/v1/monitor/traces?status=error returns only the failing trace",
+    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
+    async ({ request }) => {
+      const matchRes = await request.get(
+        `/api/v1/monitor/traces?flow_id=${errorFlowId}&status=error`,
+        { headers: { Authorization: bearerToken } },
+      );
+      expect(matchRes.status()).toBe(200);
+      const matchBody = await matchRes.json();
+      expect(matchBody.total).toBe(1);
+      expect(matchBody.traces.length).toBe(1);
+      expect(matchBody.traces[0].status).toBe("error");
+      expect(matchBody.traces[0].flowId).toBe(errorFlowId);
+
+      const missRes = await request.get(
+        `/api/v1/monitor/traces?flow_id=${errorFlowId}&status=ok`,
+        { headers: { Authorization: bearerToken } },
+      );
+      expect(missRes.status()).toBe(200);
+      const missBody = await missRes.json();
+      expect(missBody.total).toBe(0);
+      expect(missBody.traces.length).toBe(0);
+    },
+  );
+
+  test(
+    "GET /api/v1/monitor/traces?status=ok returns only the successful trace",
+    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
+    async ({ request }) => {
+      const matchRes = await request.get(
+        `/api/v1/monitor/traces?flow_id=${okFlowId}&status=ok`,
+        { headers: { Authorization: bearerToken } },
+      );
+      expect(matchRes.status()).toBe(200);
+      const matchBody = await matchRes.json();
+      expect(matchBody.total).toBe(1);
+      expect(matchBody.traces.length).toBe(1);
+      expect(matchBody.traces[0].status).toBe("ok");
+      expect(matchBody.traces[0].flowId).toBe(okFlowId);
+
+      const missRes = await request.get(
+        `/api/v1/monitor/traces?flow_id=${okFlowId}&status=error`,
+        { headers: { Authorization: bearerToken } },
+      );
+      expect(missRes.status()).toBe(200);
+      const missBody = await missRes.json();
+      expect(missBody.total).toBe(0);
+      expect(missBody.traces.length).toBe(0);
+    },
+  );
+
+  test(
+    "GET /api/v1/monitor/traces?start_time=<future> returns empty",
+    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
+    async ({ request }) => {
+      // ISO timestamp 1 hour in the future — every seeded trace must precede it.
+      const future = new Date(Date.now() + 3600 * 1000).toISOString();
+
+      const res = await request.get(
+        `/api/v1/monitor/traces?flow_id=${errorFlowId}&start_time=${encodeURIComponent(future)}`,
+        { headers: { Authorization: bearerToken } },
+      );
+      expect(res.status()).toBe(200);
+      const body = await res.json();
+      expect(body.total).toBe(0);
+      expect(body.traces.length).toBe(0);
+    },
+  );
+
+  test(
+    "GET /api/v1/monitor/traces?query=<substring> filters by trace name/id/session",
+    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
+    async ({ request }) => {
+      // The handler ILIKEs on TraceTable.{name,id,session_id} (capped at 50
+      // chars by sanitize_query_string). The flow UUID is part of the trace
+      // name and unique across concurrent runs — a hit must return >= 1, and
+      // when narrowed by flow_id it must be exactly 1.
+      const hitRes = await request.get(
+        `/api/v1/monitor/traces?flow_id=${errorFlowId}&query=${encodeURIComponent(errorTraceNameProbe)}`,
+        { headers: { Authorization: bearerToken } },
+      );
+      expect(hitRes.status()).toBe(200);
+      const hitBody = await hitRes.json();
+      expect(hitBody.total).toBe(1);
+      expect(hitBody.traces.length).toBe(1);
+      expect(hitBody.traces[0].flowId).toBe(errorFlowId);
+
+      // Same query string with a guaranteed-unmatched fixed prefix returns 0.
+      // Using a hyphen-prefixed nonce keeps the probe within the 50-char
+      // sanitizer cap and within the printable-ASCII allowlist.
+      const missRes = await request.get(
+        `/api/v1/monitor/traces?flow_id=${errorFlowId}&query=zzz-no-trace-name-matches-this-${Date.now()}`,
+        { headers: { Authorization: bearerToken } },
+      );
+      expect(missRes.status()).toBe(200);
+      const missBody = await missRes.json();
+      expect(missBody.total).toBe(0);
+      expect(missBody.traces.length).toBe(0);
+    },
+  );
+});

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-list-filters.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-list-filters.spec.ts
@@ -146,6 +146,13 @@ test.describe("Trace list filters — status / start_time / query / session_id",
     expect(typeof errorBody.traces?.[0]?.name).toBe("string");
     errorTraceName = errorBody.traces[0].name as string;
     expect(errorTraceName).toContain(errorFlowId);
+    // Guards the 50-char sanitizer-cap probe in test 4: the probe is built
+    // as `errorTraceName.slice(0, 50) + "<garbage>"`. If `errorTraceName`
+    // is shorter than 50 chars, `slice(0, 50)` returns the whole name and
+    // the truncated probe ends up containing garbage that is NOT in the
+    // name — the test would fail with a confusing 0-hit instead of the
+    // real surface (trace name format shortened upstream). Fail fast here.
+    expect(errorTraceName.length).toBeGreaterThanOrEqual(50);
   });
 
   test.afterAll(async ({ request }) => {


### PR DESCRIPTION
## Summary

- New API spec `traces-list-filters.spec.ts` covering all 4 query params on `GET /api/v1/monitor/traces` that had zero coverage: `status`, `start_time`, `query`, `session_id`. (`flow_id` was already pinned by `traces-latency-tokens.spec.ts`.)
- Five tests, all `@stable @release @api @regression @observability`:
  1. `?status=error` → only the failing trace; `?status=ok` on same flow → 0; `?status=<unknown>` → **422** (Pydantic enum rejection)
  2. `?status=ok` → only the successful trace; `?status=error` on same flow → 0
  3. `?start_time=<past>` → 1; `?start_time=<future>` → 0 (pins both halves of the `>=` comparator)
  4. `?query=<UUID substring>` → 1; `?query=<50 in-name chars + garbage suffix>` → 1 (genuinely pins the 50-char `sanitize_query_string` truncation — only a backend that truncates can match); `?query=<garbage>` → 0
  5. `?session_id=<threaded session>` → 1; `?session_id=<unknown>` → 0 (pins exact-match on `TraceTable.session_id` and confirms run-payload `session_id` is persisted)
- New fixture `tests/assets/flows/chat-io-ok-trace-fixture.json` — minimal `ChatInput → ChatOutput` slice, derived programmatically from `basic-prompting-trace-fixture.json` so the React Flow handle encoding (the `œ`-substituted JSON in `sourceHandle`/`targetHandle`/edge id) stays identical. Smoke-tested end to end: 13 ms run, deterministic `status=ok`, no LLM, no provider key.
- Spec doc landed alongside under `docs/core-functionality/observability-monitoring/traces-list-filters.md` with all mandatory sections and `Last validated: 1.10.x`.
- `QA-CHECKLIST.md` updated with the new bullets under §8.1 Traces; the Coverage Summary table and Phase 0 block regenerate on merge.

## Scope reductions (documented in the spec doc)

- **`?status=unset`** — neither fixture emits `unset` (Chat I/O → `ok`, basic-prompting → `error`). Producing `unset` deterministically would require forking the tracer; deliberate gap.
- **`?query=` substring of `input_value` / message content** — the handler's ILIKE only covers `TraceTable.{name, id, session_id}`. The issue text suggested `input_value`; that contract does not exist on the handler. Filed as a non-gap.
- **`?end_time`** — symmetric to `start_time`; not asserted explicitly.
- **Combined filters** (e.g. `?status=ok&start_time=<past>`) — each filter is asserted standalone; AND-combination is a structural consequence of the per-filter contract.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` — 0 new errors on the new file (existing `prefer-to-have-length` warnings match the pattern in `traces-detail.spec.ts`)
- [x] `npx playwright test tests/tests-automations/regression/core-functionality/observability-monitoring/traces-list-filters.spec.ts` → **5 passed (4.0s)** against a local Langflow 1.10.x instance
- [x] Fixture smoke-tested standalone (curl → flow create → run → poll → status=ok)
- [ ] CI green (`pr-validation.yml`)

Closes #301