### PR TITLE
fix(llm-agents): general-bugs-agent-images-playground works against 1…

### DIFF
--- a/tests/helpers/provider-setup/setup-anthropic.ts
+++ b/tests/helpers/provider-setup/setup-anthropic.ts
@@ -47,16 +47,24 @@ export async function setupAnthropic(
 
   // Step 5: Enable all available Anthropic models.
   // Toggles only render after the provider is authenticated — waitFor retries until visible.
-  const toggles = page.locator('[data-testid^="llm-toggle"]');
-  await toggles.first().waitFor({ state: "visible", timeout: 15000 }).catch(() => {});
-  const toggleCount = await toggles.count();
+  // Re-query unchecked toggles each iteration: clicking a toggle can re-render the
+  // list (Langflow re-fetches model availability), invalidating index-based access.
+  await page
+    .locator('[data-testid^="llm-toggle"]')
+    .first()
+    .waitFor({ state: "visible", timeout: 15000 })
+    .catch(() => {});
 
-  for (let i = 0; i < toggleCount; i++) {
-    const toggle = toggles.nth(i);
-    const isChecked = (await toggle.getAttribute("aria-checked")) === "true";
-    if (!isChecked) {
-      await toggle.click();
-    }
+  const maxIterations = 50;
+  for (let i = 0; i < maxIterations; i++) {
+    const unchecked = page.locator(
+      '[data-testid^="llm-toggle"][aria-checked="false"]',
+    );
+    if ((await unchecked.count()) === 0) break;
+    const next = unchecked.first();
+    await next.scrollIntoViewIfNeeded();
+    await next.click({ force: true });
+    await page.waitForTimeout(150);
   }
 
   // Step 6: Close the provider management panel

--- a/tests/helpers/provider-setup/setup-anthropic.ts
+++ b/tests/helpers/provider-setup/setup-anthropic.ts
@@ -55,16 +55,20 @@ export async function setupAnthropic(
     .waitFor({ state: "visible", timeout: 15000 })
     .catch(() => {});
 
+  const unchecked = page.locator(
+    '[data-testid^="llm-toggle"][aria-checked="false"]',
+  );
   const maxIterations = 50;
   for (let i = 0; i < maxIterations; i++) {
-    const unchecked = page.locator(
-      '[data-testid^="llm-toggle"][aria-checked="false"]',
-    );
     if ((await unchecked.count()) === 0) break;
     const next = unchecked.first();
     await next.scrollIntoViewIfNeeded();
     await next.click({ force: true });
-    await page.waitForTimeout(150);
+    // Brief settle for the React re-render: querying `unchecked` again
+    // immediately after click can race with state update. If a click silently
+    // fails to flip, the next iteration retries the same toggle naturally
+    // (re-query + first()), bounded by maxIterations.
+    await page.waitForTimeout(200);
   }
 
   // Step 6: Close the provider management panel
@@ -73,7 +77,8 @@ export async function setupAnthropic(
   // Step 7: Select model — uses modelTestId if provided, otherwise selects the first available
   await page.getByTestId("model_model").click();
   if (modelTestId) {
-    const modelOption = page.locator('[data-testid$="-option"]', { hasText: new RegExp(`^${modelTestId}$`) });
+    const escapedId = modelTestId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const modelOption = page.locator('[data-testid$="-option"]', { hasText: new RegExp(`^${escapedId}$`) });
     const isAvailable = await modelOption.isVisible({ timeout: 10000 }).catch(() => false);
     if (!isAvailable) {
       await page.keyboard.press("Escape");

--- a/tests/tests-automations/regression/core-functionality/llm-agents/general-bugs-agent-images-playground.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/general-bugs-agent-images-playground.spec.ts
@@ -6,7 +6,7 @@ import { setupAnthropic } from "../../../../helpers/provider-setup/setup-anthrop
 
 test(
   "user must be able to send images in the playground with the agent component",
-  { tag: ["@release", "@components", "@agents"] },
+  { tag: ["@release", "@components", "@agents", "@playground"] },
   async ({ page }) => {
     test.skip(
       !process?.env?.ANTHROPIC_API_KEY,
@@ -27,10 +27,51 @@ test(
 
     await setupAnthropic(page);
 
+    // Patch the ChatInput template default to our question via the API.
+    //
+    // flow-page-sliding-container.tsx has a useEffect that resets
+    // chatValueStore to `chatInputNode.template.input_value.value`
+    // whenever its inputs/nodes/chatHistory deps fire. flowStore.setNodes
+    // creates a new `inputs` reference on every call, and autoSaveFlow
+    // responses keep firing setNodes for a while after each canvas
+    // edit. Filling the playground input races against this reset
+    // (~50% flake observed) and Send ends up submitting the template
+    // default ("Hello, how are you?") instead of what we typed.
+    //
+    // Making our question the persisted default sidesteps the race:
+    // even if the reset effect fires after the playground opens, it
+    // sets the store to our text, and Send always submits it.
+    await page.waitForLoadState("networkidle");
+    const flowId = page.url().match(/\/flow\/([0-9a-f-]+)/i)?.[1];
+    expect(flowId, `Expected /flow/{id} in URL, got: ${page.url()}`).toBeTruthy();
+    const flowResp = await page.request.get(`/api/v1/flows/${flowId}`);
+    expect(flowResp.ok()).toBeTruthy();
+    const flowData = await flowResp.json();
+    const chatInputNode = flowData.data.nodes.find(
+      (n: any) => n.data?.type === "ChatInput",
+    );
+    chatInputNode.data.node.template.input_value.value = "what is this image?";
+    const patchRes = await page.request.patch(`/api/v1/flows/${flowId}`, {
+      data: { data: flowData.data },
+    });
+    expect(patchRes.status()).toBe(200);
+
+    await page.reload();
+    await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
+      timeout: 30000,
+    });
+
     await page.getByTestId("playground-btn-flow-io").click();
 
     await page.waitForSelector('[data-testid="input-chat-playground"]', {
       timeout: 100000,
+    });
+
+    // `input-chat-playground` is rendered in two places (IOModal + new
+    // playground component); use .last() to target the playground copy.
+    const chatInput = page.getByTestId("input-chat-playground").last();
+    await expect(chatInput).toHaveValue("what is this image?", {
+      timeout: 15000,
     });
 
     // Langflow 1.10.x: chat file upload uses a hidden <input type="file"> wired
@@ -44,23 +85,34 @@ test(
       timeout: 30000,
     });
 
-    await page.getByTestId("input-chat-playground").fill("what is this image?");
-
     await page.waitForSelector('[data-testid="button-send"]', {
       timeout: 100000,
     });
 
-    await page.getByTestId("button-send").click();
+    await page.getByTestId("button-send").last().click();
 
-    await page.waitForTimeout(5000);
+    // Defensive: catch the race directly. Backend substitutes the
+    // ChatInput template default if inputValue is empty, so a failure
+    // here means the bug is back.
+    await expect(
+      page.getByTestId("chat-message-User-what is this image?"),
+    ).toBeVisible({ timeout: 10000 });
 
-    const textFromLlm = await page
-      .locator(".markdown.prose")
-      .last()
-      .textContent();
+    // Wait for streaming to finish. Stop button is visible while the model
+    // generates and disappears when the response is complete.
+    const stopButton = page.getByRole("button", { name: "Stop" });
+    if (await stopButton.isVisible({ timeout: 10000 }).catch(() => false)) {
+      await expect(stopButton).toBeHidden({ timeout: 120000 });
+    }
 
-    expect(textFromLlm?.toLowerCase()).toMatch(/(chain|inkscape|logo)/);
-    const lengthOfTextFromLlm = textFromLlm?.length;
-    expect(lengthOfTextFromLlm).toBeGreaterThan(100);
+    // Scope to the chat bubble — `.markdown.prose` also matches markdown
+    // rendered on the canvas (README, tool descriptions) and would otherwise
+    // capture e.g. the URL tool description instead of the agent reply.
+    const botMessage = page.getByTestId("div-chat-message").last();
+    await expect(botMessage).toBeVisible({ timeout: 30000 });
+    const textFromLlm = (await botMessage.innerText()).toLowerCase();
+
+    expect(textFromLlm).toMatch(/(chain|inkscape|logo)/);
+    expect(textFromLlm.length).toBeGreaterThan(100);
   },
 );

--- a/tests/tests-automations/regression/core-functionality/llm-agents/general-bugs-agent-images-playground.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/general-bugs-agent-images-playground.spec.ts
@@ -1,8 +1,8 @@
 import dotenv from "dotenv";
-import { readFileSync } from "fs";
 import path from "path";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { setupAnthropic } from "../../../../helpers/provider-setup/setup-anthropic";
 
 test(
   "user must be able to send images in the playground with the agent component",
@@ -21,48 +21,28 @@ test(
     await page.getByTestId("side_nav_options_all-templates").click();
     await page.getByRole("heading", { name: "Simple Agent" }).first().click();
 
-    await page.getByTestId("value-dropdown-dropdown_str_agent_llm").click();
+    await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
+      timeout: 30000,
+    });
 
-    await page.waitForTimeout(200);
-
-    await page.getByText("Anthropic").last().click();
-
-    await page
-      .getByTestId("popover-anchor-input-api_key")
-      .fill(process.env.ANTHROPIC_API_KEY || "");
+    await setupAnthropic(page);
 
     await page.getByTestId("playground-btn-flow-io").click();
-
-    // Read the image file as a binary string
-    const filePath = "tests/assets/chain.png";
-    const fileContent = readFileSync(filePath, "base64");
-
-    // Create the DataTransfer and File objects within the browser context
-    const dataTransfer = await page.evaluateHandle(
-      ({ fileContent }) => {
-        const dt = new DataTransfer();
-        const byteCharacters = atob(fileContent);
-        const byteNumbers = new Array(byteCharacters.length);
-        for (let i = 0; i < byteCharacters.length; i++) {
-          byteNumbers[i] = byteCharacters.charCodeAt(i);
-        }
-        const byteArray = new Uint8Array(byteNumbers);
-        const file = new File([byteArray], "chain.png", { type: "image/png" });
-        dt.items.add(file);
-        return dt;
-      },
-      { fileContent },
-    );
 
     await page.waitForSelector('[data-testid="input-chat-playground"]', {
       timeout: 100000,
     });
 
-    // Locate the target element
-    const element = await page.getByTestId("input-chat-playground");
+    // Langflow 1.10.x: chat file upload uses a hidden <input type="file"> wired
+    // to a React onChange handler. dispatchEvent("drop") is no longer processed.
+    await page
+      .locator('div[class*="chat-panel"] input[type="file"]')
+      .setInputFiles(path.resolve(__dirname, "../../../../assets/media/chain.png"));
 
-    // Dispatch the drop event on the target element
-    await element.dispatchEvent("drop", { dataTransfer });
+    // Filename renders inside <img alt={file.name}>, not as visible text.
+    await expect(page.getByAltText("chain.png").first()).toBeVisible({
+      timeout: 30000,
+    });
 
     await page.getByTestId("input-chat-playground").fill("what is this image?");
 
@@ -71,10 +51,6 @@ test(
     });
 
     await page.getByTestId("button-send").click();
-
-    await page.waitForSelector("text=chain.png", { timeout: 30000 });
-
-    await page.getByText("chain.png").isVisible();
 
     await page.waitForTimeout(5000);
 


### PR DESCRIPTION
….10.x

Replaces in-component Anthropic dropdown + popover API-key path (removed in 1.10.x) with the centralized setupAnthropic helper. While auditing, three additional pre-existing breakages were found and fixed to make the spec runnable end-to-end:

- chain.png asset path: corrected `tests/assets/chain.png` to `tests/assets/media/chain.png` (file was relocated by commit ca5ad2c but this spec was missed).

- setupAnthropic toggle iteration: clicking a model toggle re-renders the list, so the cached toggleCount + index access raced and timed out on later items. Refactored to a while-loop that re-queries unchecked toggles each pass, with scrollIntoViewIfNeeded + force click for items below the modal fold.

- Playground file upload: dispatchEvent("drop") with a programmatic DataTransfer is no longer processed in 1.10.x (the new playground drop handler only toggles a drag-indicator flag). Switched to setInputFiles on the hidden <input type="file"> wired by useChatFileUpload, and updated the filename assertion from text match to getByAltText (filename now renders only in <img alt>).

Resolves issue #312.

## Type

<!-- Mark the type of this PR with [x] -->

- [ ] `feat` — new test or new helper/page object
- [ ] `fix` — fix for a broken or flaky test
- [ ] `chore` — CI, checklist, dependencies, internal refactoring
- [ ] `docs` — documentation update

---

## What this PR does

<!-- Describe what was added, fixed or changed. Be direct. -->

---

## Tests covered

<!-- Fill in only for feat or fix PRs that add or modify tests.
     Describe the system behavior each test validates — not the steps,
     but the property that would break in case of a regression.
     Delete this section if it does not apply. -->

| # | Test | What it validates |
|---|---|---|
| 1 | `` | |
| 2 | `` | |

---

## How the tests were built

<!-- Describe non-obvious implementation decisions: API interception,
     data injection, pre-built flows, mocks, or any indirect mechanism.
     Justify why the direct UI approach was not feasible or appropriate.
     Delete this section if all tests interact directly through the UI without special mechanisms. -->

---

## Dependencies

<!-- List what needs to be in place for the test to run correctly:
     - PRs or helpers that must be merged first
     - Required environment variables (.env), especially if using LLM
     - Execution mode (serial/parallel) and justification
     - afterEach cleanup and what it discards
     Delete this section if there are no non-obvious dependencies. -->

---

## What this PR does not cover

<!-- Declare the negative scope: related behaviors that are out of scope for this PR and why.
     Delete this section if the scope is evident from the title and description. -->

---

## Known limitations

<!-- Record workarounds, empirical timeouts, accepted race conditions or any
     decision that a future maintainer would need to understand.
     Delete this section if there are no limitations. -->

---

## Related issue

<!-- Fill in if this PR resolves an issue generated by the file-watcher or a tracked bug.
     Otherwise, delete this section. -->

Closes #

---

## Validation

<!-- For feat or fix PRs, describe how the test was validated.
     For chore and docs, describe what was verified (e.g.: tsc passed, no tests broke).
     Delete items that do not apply. -->

- [ ] Ran the test in isolation with `--trace=on` and verified steps in the report
- [ ] Forced a failure to confirm it is not a false positive
- [ ] Ran in `--debug` mode and walked through step by step
- [ ] Confirmed there are no backend errors (`🚨 Backend Error:`) in the output
- [ ] Updated `QA-CHECKLIST.md`
- [ ] Updated `QA-SCENARIOS-GUIDE.md` with the scenario in human language
