### PR TITLE
fix(ci): replace named volume with bind mount in migration-compose job

### DIFF
--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -377,6 +377,16 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
+          # Workaround: langflow:latest images built before langflow-ai/langflow#13212
+          # did not pre-create /app/langflow in the Dockerfile, so Docker seeded the
+          # named volume as root:root and uid 1000 (the container user) could not
+          # write secret_key — crashing the container on startup.
+          # Fix: replace the named volume with a world-writable bind mount so the
+          # container can always write to LANGFLOW_CONFIG_DIR regardless of image age.
+          # Remove the volumes override once langflow:latest ships with #13212.
+          mkdir -p /tmp/langflow-data
+          chmod 777 /tmp/langflow-data
+
           # Override file: pin the langflow image via env var substitution and
           # inject our auth + credential env vars. Default LANGFLOW_IMAGE is
           # the upstream `langflow:latest`; we'll flip it to nightly between
@@ -392,6 +402,8 @@ jobs:
                 - LANGFLOW_SUPERUSER=langflow
                 - LANGFLOW_SUPERUSER_PASSWORD=langflow123
                 - LANGFLOW_STORE=false
+              volumes:
+                - /tmp/langflow-data:/app/langflow
           YAML
 
           # .env consumed by docker compose for variable substitution


### PR DESCRIPTION
## Problem

The `migration-test-compose` job started failing with:

```
PermissionError: [Errno 13] Permission denied: '/app/langflow/secret_key'
```

Root cause: `langflowai/langflow:latest` images built before [langflow-ai/langflow#13212](https://github.com/langflow-ai/langflow/pull/13212) did not pre-create `/app/langflow` in the Dockerfile. Docker seeded the named volume as `root:root`, and the container user (`uid 1000`) could not write to it — crashing Langflow before the health check could pass.

The upstream fix was merged on 2026-05-21 but `langflow:latest` was last published on 2026-05-15, so the fix is not yet in the image. `langflow-nightly:latest` already includes it (published 2026-05-22).

## Fix

- Pre-create `/tmp/langflow-data` with world-writable permissions before `docker compose up`
- Override the named volume with a bind mount in `docker-compose.override.yml` so the container can write to `LANGFLOW_CONFIG_DIR` regardless of the image's age

## Revert when

Remove the `volumes` override and the `mkdir`/`chmod` lines once `langflowai/langflow:latest` is rebuilt with [langflow-ai/langflow#13212](https://github.com/langflow-ai/langflow/pull/13212).

🤖 Generated with [Claude Code](https://claude.com/claude-code)