### PR TITLE
test(observability): extend traces-detail test 3 with TransactionLogsResponse field assertions

### DIFF
--- a/docs/core-functionality/observability-monitoring/traces-detail.md
+++ b/docs/core-functionality/observability-monitoring/traces-detail.md
@@ -41,14 +41,15 @@ _Seeding (`beforeAll`)_
 _Test body_
 1. `GET /api/v1/monitor/transactions?flow_id=<flowId>` (the real seeded flow id, not the placeholder UUID)
 2. Assert HTTP 200, `body.items` is an array, `body.items.length > 0`
-3. Assert the first record is a plain object (not null, not an array)
-4. Assert every key of `TransactionLogsResponse` exists on the record: `id`, `timestamp`, `vertex_id`, `target_id`, `inputs`, `outputs`, `status`
-5. Assert `vertex_id` is a non-empty string and matches one of the imported node IDs (`TRACE_FIXTURE.data.nodes[*].id`)
-6. Assert `target_id` is either `null` or a string (key always present)
-7. Assert `inputs` / `outputs` are either `null` or plain objects (not arrays)
-8. Assert `status` is a string in the allowed set `{"success", "error"}` (the only two values the runtime writes — see `lfx/graph/vertex/base.py:730,862`)
-9. Pin the deterministic seed path: with the endpoint ordering `timestamp DESC` (`monitor.py:574`), `items[0]` is the last vertex to emit a transaction — in this fixture, the `LanguageModelComponent-FLeYF` failing with "A model selection is required". Assert `record.vertex_id === "LanguageModelComponent-FLeYF"` (extracted as `FAILING_LLM_VERTEX_ID`) and `record.status === "error"`
-10. Assert `error` and `flow_id` keys are **absent** — `TransactionLogsResponse` deliberately excludes them ("Transaction response model for logs view - excludes error and flow_id fields"). Pinning the absence guards against the raw error message or flow_id leaking back into the logs view in a future refactor
+3. For **every** record in `body.items` (not just the first — the same `TransactionLogsResponse` contract applies to every row, so a regression on any vertex's emit path surfaces here):
+   - record is a plain object (not null, not an array)
+   - every key of `TransactionLogsResponse` is present: `id`, `timestamp`, `vertex_id`, `target_id`, `inputs`, `outputs`, `status`
+   - `vertex_id` is a non-empty string and matches one of the imported node IDs (`TRACE_FIXTURE.data.nodes[*].id`)
+   - `target_id` is either `null` or a string
+   - `inputs` / `outputs` are either `null` or plain objects (not arrays)
+   - `status` is a string in the allowed set `{"success", "error"}` (the only two values the runtime writes — see `lfx/graph/vertex/base.py:730,862`)
+   - `error` and `flow_id` keys are **absent** — `TransactionLogsResponse` deliberately excludes them ("Transaction response model for logs view - excludes error and flow_id fields"). Pinning the absence guards against the raw error message or flow_id leaking back into the logs view in a future refactor
+4. Pin the deterministic seed path on `items[0]`: with the endpoint ordering `timestamp DESC` (`monitor.py:574`), `items[0]` is the last vertex to emit a transaction — in this fixture, the `LanguageModelComponent` failing with "A model selection is required". Assert `body.items[0].vertex_id === "LanguageModelComponent-FLeYF"` and `body.items[0].status === "error"`
 
 _Cleanup (`afterAll`)_
 1. Delete the seeded flow via `DELETE /api/v1/flows/<flowId>`

--- a/docs/core-functionality/observability-monitoring/traces-detail.md
+++ b/docs/core-functionality/observability-monitoring/traces-detail.md
@@ -41,13 +41,13 @@ _Seeding (`beforeAll`)_
 _Test body_
 1. `GET /api/v1/monitor/transactions?flow_id=<flowId>` (the real seeded flow id, not the placeholder UUID)
 2. Assert HTTP 200, `body.items` is an array, `body.items.length > 0`
-3. Assert the first record is a plain object (not null, not an array) and carries at least one of `timestamp` / `created_at` / `updated_at`
-4. Assert every key of `TransactionLogsResponse` exists on the record: `id`, `vertex_id`, `target_id`, `inputs`, `outputs`, `status`
+3. Assert the first record is a plain object (not null, not an array)
+4. Assert every key of `TransactionLogsResponse` exists on the record: `id`, `timestamp`, `vertex_id`, `target_id`, `inputs`, `outputs`, `status`
 5. Assert `vertex_id` is a non-empty string and matches one of the imported node IDs (`TRACE_FIXTURE.data.nodes[*].id`)
 6. Assert `target_id` is either `null` or a string (key always present)
 7. Assert `inputs` / `outputs` are either `null` or plain objects (not arrays)
 8. Assert `status` is a string in the allowed set `{"success", "error"}` (the only two values the runtime writes — see `lfx/graph/vertex/base.py:730,862`)
-9. Pin the deterministic seed path: with the endpoint ordering `timestamp DESC` (`monitor.py:574`), `items[0]` is the last vertex to emit a transaction — in this fixture, the `LanguageModelComponent-FLeYF` failing with "A model selection is required". Assert `record.vertex_id === "LanguageModelComponent-FLeYF"` and `record.status === "error"`
+9. Pin the deterministic seed path: with the endpoint ordering `timestamp DESC` (`monitor.py:574`), `items[0]` is the last vertex to emit a transaction — in this fixture, the `LanguageModelComponent-FLeYF` failing with "A model selection is required". Assert `record.vertex_id === "LanguageModelComponent-FLeYF"` (extracted as `FAILING_LLM_VERTEX_ID`) and `record.status === "error"`
 10. Assert `error` and `flow_id` keys are **absent** — `TransactionLogsResponse` deliberately excludes them ("Transaction response model for logs view - excludes error and flow_id fields"). Pinning the absence guards against the raw error message or flow_id leaking back into the logs view in a future refactor
 
 _Cleanup (`afterAll`)_
@@ -60,7 +60,7 @@ _Cleanup (`afterAll`)_
 
 - **Test 1** — The endpoint returns the full fastapi-pagination envelope `{ items, total, page, size, pages }`. Every key is asserted to be present so a regression that drops any of them — even silently — would surface here before the Traces UI (`FlowInsightsContent.tsx`) breaks at render time.
 - **Test 2** — A well-formed `flow_id` that maps to no rows returns `200` with an empty `items` array, not `400` or `404`. This pins the contract that "unknown flow_id" is a normal empty result and not an error condition.
-- **Test 3** — After seeding one transaction by running a real flow, the emitted record exposes the full `TransactionLogsResponse` contract: a recognizable timestamp, the required keys (`id`, `vertex_id`, `target_id`, `inputs`, `outputs`, `status`), `vertex_id` resolving to a seeded node, `status` from the runtime's `{"success", "error"}` set, and `items[0]` deterministically pinned to the last vertex to run (the failing `LanguageModelComponent-FLeYF`). The test also pins the **absence** of `error` and `flow_id`: `TransactionLogsResponse` excludes them on purpose, and a regression that re-exposed the raw error message or the flow_id would leak data into the logs view without any other observable signal. The seed step is mandatory: on a clean Langflow instance no transactions exist for the fixture's flow id, so without it the assertion would never execute.
+- **Test 3** — After seeding one transaction by running a real flow, the emitted record exposes the full `TransactionLogsResponse` contract: the required keys (`id`, `timestamp`, `vertex_id`, `target_id`, `inputs`, `outputs`, `status`), `vertex_id` resolving to a seeded node, `status` from the runtime's `{"success", "error"}` set, and `items[0]` deterministically pinned to the last vertex to run (the failing `LanguageModelComponent-FLeYF`). The test also pins the **absence** of `error` and `flow_id`: `TransactionLogsResponse` excludes them on purpose, and a regression that re-exposed the raw error message or the flow_id would leak data into the logs view without any other observable signal. The seed step is mandatory: on a clean Langflow instance no transactions exist for the fixture's flow id, so without it the assertion would never execute.
 
 ---
 

--- a/docs/core-functionality/observability-monitoring/traces-detail.md
+++ b/docs/core-functionality/observability-monitoring/traces-detail.md
@@ -42,6 +42,13 @@ _Test body_
 1. `GET /api/v1/monitor/transactions?flow_id=<flowId>` (the real seeded flow id, not the placeholder UUID)
 2. Assert HTTP 200, `body.items` is an array, `body.items.length > 0`
 3. Assert the first record is a plain object (not null, not an array) and carries at least one of `timestamp` / `created_at` / `updated_at`
+4. Assert every key of `TransactionLogsResponse` exists on the record: `id`, `vertex_id`, `target_id`, `inputs`, `outputs`, `status`
+5. Assert `vertex_id` is a non-empty string and matches one of the imported node IDs (`TRACE_FIXTURE.data.nodes[*].id`)
+6. Assert `target_id` is either `null` or a string (key always present)
+7. Assert `inputs` / `outputs` are either `null` or plain objects (not arrays)
+8. Assert `status` is a string in the allowed set `{"success", "error"}` (the only two values the runtime writes — see `lfx/graph/vertex/base.py:730,862`)
+9. Pin the deterministic seed path: with the endpoint ordering `timestamp DESC` (`monitor.py:574`), `items[0]` is the last vertex to emit a transaction — in this fixture, the `LanguageModelComponent-FLeYF` failing with "A model selection is required". Assert `record.vertex_id === "LanguageModelComponent-FLeYF"` and `record.status === "error"`
+10. Assert `error` and `flow_id` keys are **absent** — `TransactionLogsResponse` deliberately excludes them ("Transaction response model for logs view - excludes error and flow_id fields"). Pinning the absence guards against the raw error message or flow_id leaking back into the logs view in a future refactor
 
 _Cleanup (`afterAll`)_
 1. Delete the seeded flow via `DELETE /api/v1/flows/<flowId>`
@@ -53,7 +60,7 @@ _Cleanup (`afterAll`)_
 
 - **Test 1** — The endpoint returns the full fastapi-pagination envelope `{ items, total, page, size, pages }`. Every key is asserted to be present so a regression that drops any of them — even silently — would surface here before the Traces UI (`FlowInsightsContent.tsx`) breaks at render time.
 - **Test 2** — A well-formed `flow_id` that maps to no rows returns `200` with an empty `items` array, not `400` or `404`. This pins the contract that "unknown flow_id" is a normal empty result and not an error condition.
-- **Test 3** — After seeding one transaction by running a real flow, the emitted record exposes a recognizable timestamp field (`timestamp`, `created_at`, or `updated_at`). The Traces UI orders rows by time; removing every recognizable timestamp would break the grid silently. The seed step is mandatory: on a clean Langflow instance no transactions exist for the fixture's flow id, so without it the assertion would never execute.
+- **Test 3** — After seeding one transaction by running a real flow, the emitted record exposes the full `TransactionLogsResponse` contract: a recognizable timestamp, the required keys (`id`, `vertex_id`, `target_id`, `inputs`, `outputs`, `status`), `vertex_id` resolving to a seeded node, `status` from the runtime's `{"success", "error"}` set, and `items[0]` deterministically pinned to the last vertex to run (the failing `LanguageModelComponent-FLeYF`). The test also pins the **absence** of `error` and `flow_id`: `TransactionLogsResponse` excludes them on purpose, and a regression that re-exposed the raw error message or the flow_id would leak data into the logs view without any other observable signal. The seed step is mandatory: on a clean Langflow instance no transactions exist for the fixture's flow id, so without it the assertion would never execute.
 
 ---
 
@@ -61,8 +68,9 @@ _Cleanup (`afterAll`)_
 
 References in the **main Langflow repository** (compatible with Langflow 1.10.x):
 
-- `src/backend/base/langflow/api/v1/monitor.py` — `GET /transactions` handler (line 558); `transform_transaction_table_for_logs`; auth dependency via `get_current_active_user`
-- `src/backend/base/langflow/services/database/models/transactions/model.py` — `TransactionLogsResponse`, `TransactionTable`
+- `src/backend/base/langflow/api/v1/monitor.py` — `GET /transactions` handler (line 558); ordering `.order_by(col(TransactionTable.timestamp).desc())` at line 574 (this is what makes `items[0]` deterministic); `transform_transaction_table_for_logs`; auth dependency via `get_current_active_user`
+- `src/backend/base/langflow/services/database/models/transactions/model.py` — `TransactionLogsResponse` (line 169, the response model documented as "excludes error and flow_id fields") and `TransactionTable`
+- `src/lfx/src/lfx/graph/vertex/base.py` — emits transactions with `status="error"` on build failure (line 730) and `status="success"` on completion (line 862); pins the allowed status set used by test 3
 - `src/frontend/src/pages/FlowPage/components/TraceComponent/FlowInsightsContent.tsx` — consumer of the paginated transactions/traces shape
 
 References in this repository:

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail.spec.ts
@@ -176,6 +176,78 @@ test.describe("Transaction record shape — seeded flow", () => {
         hasTimestamp,
         "Transaction record should contain a timestamp field",
       ).toBe(true);
+
+      // TransactionLogsResponse pins these keys (see backend
+      // services/database/models/transactions/model.py:169). Every record
+      // must carry them so the Traces grid can render rows without probing
+      // for optional fields.
+      for (const key of [
+        "id",
+        "vertex_id",
+        "target_id",
+        "inputs",
+        "outputs",
+        "status",
+      ]) {
+        expect(
+          record,
+          `Transaction record should contain '${key}'`,
+        ).toHaveProperty(key);
+      }
+
+      // vertex_id is required (nullable=False in the schema) and must match
+      // one of the imported node IDs — IDs are preserved on import, so a
+      // mismatch would indicate the seeded flow did not actually run.
+      const seededNodeIds = new Set<string>(
+        TRACE_FIXTURE.data.nodes.map((n: { id: string }) => n.id),
+      );
+      expect(typeof record.vertex_id).toBe("string");
+      expect(record.vertex_id.length).toBeGreaterThan(0);
+      expect(
+        seededNodeIds.has(record.vertex_id),
+        `vertex_id '${record.vertex_id}' should be one of the seeded node IDs`,
+      ).toBe(true);
+
+      // target_id is optional (string | null in the schema). The key must
+      // still exist so callers can read it without a guard.
+      if (record.target_id !== null) {
+        expect(typeof record.target_id).toBe("string");
+      }
+
+      // inputs / outputs are nullable JSON objects. When present they must
+      // be plain objects (not arrays) — the inputs panel in the Trace
+      // Details modal renders them as key/value rows.
+      for (const key of ["inputs", "outputs"] as const) {
+        const value = record[key];
+        if (value !== null) {
+          expect(typeof value).toBe("object");
+          expect(Array.isArray(value)).toBe(false);
+        }
+      }
+
+      // status is required and the only two values written by the runtime
+      // are "success" (lfx/graph/vertex/base.py:862) and "error"
+      // (line 730). Pin the allowed set so a new value would force an
+      // explicit decision here before it silently propagates to the UI.
+      expect(typeof record.status).toBe("string");
+      expect(["success", "error"]).toContain(record.status);
+
+      // The endpoint orders by timestamp DESC (monitor.py:574), so items[0]
+      // is the last vertex to emit a transaction. In this fixture that is
+      // the LanguageModelComponent failing with "A model selection is
+      // required". Pinning both the vertex and status keeps the seed path
+      // honest: a refactor that stops emitting the LLM error row would
+      // surface here.
+      expect(record.vertex_id).toBe("LanguageModelComponent-FLeYF");
+      expect(record.status).toBe("error");
+
+      // TransactionLogsResponse deliberately excludes `error` and `flow_id`
+      // ("Transaction response model for logs view - excludes error and
+      // flow_id fields"). Pin the absence so that if the schema regresses
+      // and starts leaking the raw error message or the flow_id back into
+      // the logs view we catch it here.
+      expect(record).not.toHaveProperty("error");
+      expect(record).not.toHaveProperty("flow_id");
     },
   );
 });

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail.spec.ts
@@ -164,83 +164,91 @@ test.describe("Transaction record shape — seeded flow", () => {
       expect(Array.isArray(body.items)).toBe(true);
       expect(body.items.length).toBeGreaterThan(0);
 
-      const record = body.items[0];
-      expect(record).toBeDefined();
-
-      // The transaction object must be a plain object (not null/array)
-      expect(typeof record).toBe("object");
-      expect(record).not.toBeNull();
-      expect(Array.isArray(record)).toBe(false);
-
-      // TransactionLogsResponse pins these keys (see backend
-      // services/database/models/transactions/model.py:169). Every record
-      // must carry them so the Traces grid can render rows without probing
-      // for optional fields.
-      for (const key of [
-        "id",
-        "timestamp",
-        "vertex_id",
-        "target_id",
-        "inputs",
-        "outputs",
-        "status",
-      ]) {
-        expect(
-          record,
-          `Transaction record should contain '${key}'`,
-        ).toHaveProperty(key);
-      }
-
       // vertex_id is required (nullable=False in the schema) and must match
       // one of the imported node IDs — IDs are preserved on import, so a
       // mismatch would indicate the seeded flow did not actually run.
       const seededNodeIds = new Set<string>(
         TRACE_FIXTURE.data.nodes.map((n: { id: string }) => n.id),
       );
-      expect(typeof record.vertex_id).toBe("string");
-      expect(record.vertex_id.length).toBeGreaterThan(0);
-      expect(
-        seededNodeIds.has(record.vertex_id),
-        `vertex_id '${record.vertex_id}' should be one of the seeded node IDs`,
-      ).toBe(true);
 
-      // target_id is optional (string | null in the schema). The key must
-      // still exist so callers can read it without a guard.
-      if (record.target_id !== null) {
-        expect(typeof record.target_id).toBe("string");
-      }
+      // Validate the TransactionLogsResponse contract on every returned
+      // record (not just items[0]). A regression that breaks any vertex's
+      // emit path — ChatInput, Prompt, or the failing LLM — surfaces here.
+      for (const [index, record] of body.items.entries()) {
+        const where = `body.items[${index}]`;
 
-      // inputs / outputs are nullable JSON objects. When present they must
-      // be plain objects (not arrays) — the inputs panel in the Trace
-      // Details modal renders them as key/value rows.
-      for (const key of ["inputs", "outputs"] as const) {
-        const value = record[key];
-        if (value !== null) {
-          expect(typeof value).toBe("object");
-          expect(Array.isArray(value)).toBe(false);
+        // The transaction object must be a plain object (not null/array)
+        expect(record, `${where} should be defined`).toBeDefined();
+        expect(typeof record).toBe("object");
+        expect(record).not.toBeNull();
+        expect(Array.isArray(record)).toBe(false);
+
+        // TransactionLogsResponse pins these keys (see backend
+        // services/database/models/transactions/model.py:169) — every
+        // record must carry them so the Traces grid can render rows
+        // without probing for optional fields.
+        for (const key of [
+          "id",
+          "timestamp",
+          "vertex_id",
+          "target_id",
+          "inputs",
+          "outputs",
+          "status",
+        ]) {
+          expect(
+            record,
+            `${where} should contain '${key}'`,
+          ).toHaveProperty(key);
         }
+
+        expect(typeof record.vertex_id).toBe("string");
+        expect(record.vertex_id.length).toBeGreaterThan(0);
+        expect(
+          seededNodeIds.has(record.vertex_id),
+          `${where}.vertex_id '${record.vertex_id}' should be one of the seeded node IDs`,
+        ).toBe(true);
+
+        // target_id is optional (string | null in the schema). The key
+        // must still exist (asserted above) so callers can read it
+        // without a guard.
+        if (record.target_id !== null) {
+          expect(typeof record.target_id).toBe("string");
+        }
+
+        // Schema says inputs / outputs are `dict | None`; arrays would
+        // pass `typeof === "object"` but violate the contract.
+        for (const key of ["inputs", "outputs"] as const) {
+          const value = record[key];
+          if (value !== null) {
+            expect(typeof value).toBe("object");
+            expect(Array.isArray(value)).toBe(false);
+          }
+        }
+
+        // status is required and the only two values written by the
+        // runtime are "success" (lfx/graph/vertex/base.py:862) and
+        // "error" (line 730). Pin the allowed set so a new value would
+        // force an explicit decision here before it silently propagates
+        // to the UI.
+        expect(typeof record.status).toBe("string");
+        expect(["success", "error"]).toContain(record.status);
+
+        // TransactionLogsResponse deliberately excludes `error` and
+        // `flow_id` ("Transaction response model for logs view -
+        // excludes error and flow_id fields"). Pin the absence so that
+        // if the schema regresses and starts leaking the raw error
+        // message or the flow_id back into the logs view we catch it
+        // here.
+        expect(record).not.toHaveProperty("error");
+        expect(record).not.toHaveProperty("flow_id");
       }
 
-      // status is required and the only two values written by the runtime
-      // are "success" (lfx/graph/vertex/base.py:862) and "error"
-      // (line 730). Pin the allowed set so a new value would force an
-      // explicit decision here before it silently propagates to the UI.
-      expect(typeof record.status).toBe("string");
-      expect(["success", "error"]).toContain(record.status);
-
-      // Pin both the vertex and status on items[0] (the last vertex to
+      // Pin the deterministic seed path on items[0] (the last vertex to
       // emit, per the DESC ordering) — a refactor that stops emitting the
       // LLM error row would surface here.
-      expect(record.vertex_id).toBe(FAILING_LLM_VERTEX_ID);
-      expect(record.status).toBe("error");
-
-      // TransactionLogsResponse deliberately excludes `error` and `flow_id`
-      // ("Transaction response model for logs view - excludes error and
-      // flow_id fields"). Pin the absence so that if the schema regresses
-      // and starts leaking the raw error message or the flow_id back into
-      // the logs view we catch it here.
-      expect(record).not.toHaveProperty("error");
-      expect(record).not.toHaveProperty("flow_id");
+      expect(body.items[0].vertex_id).toBe(FAILING_LLM_VERTEX_ID);
+      expect(body.items[0].status).toBe("error");
     },
   );
 });

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail.spec.ts
@@ -68,6 +68,13 @@ test(
   },
 );
 
+// items[0] is deterministically the last vertex to write a transaction
+// (endpoint orders timestamp DESC, monitor.py:574). For this fixture's
+// error path, that is always the LanguageModelComponent failing with
+// "A model selection is required" — if the fixture is regenerated with
+// different node IDs, this constant fails loudly rather than silently.
+const FAILING_LLM_VERTEX_ID = "LanguageModelComponent-FLeYF";
+
 test.describe("Transaction record shape — seeded flow", () => {
   test.describe.configure({ mode: "serial" });
 
@@ -165,24 +172,13 @@ test.describe("Transaction record shape — seeded flow", () => {
       expect(record).not.toBeNull();
       expect(Array.isArray(record)).toBe(false);
 
-      // One of the common timestamp fields must be present — the Traces UI
-      // orders rows by time, so losing every recognizable timestamp would
-      // break the grid silently.
-      const hasTimestamp =
-        "timestamp" in record ||
-        "created_at" in record ||
-        "updated_at" in record;
-      expect(
-        hasTimestamp,
-        "Transaction record should contain a timestamp field",
-      ).toBe(true);
-
       // TransactionLogsResponse pins these keys (see backend
       // services/database/models/transactions/model.py:169). Every record
       // must carry them so the Traces grid can render rows without probing
       // for optional fields.
       for (const key of [
         "id",
+        "timestamp",
         "vertex_id",
         "target_id",
         "inputs",
@@ -232,13 +228,10 @@ test.describe("Transaction record shape — seeded flow", () => {
       expect(typeof record.status).toBe("string");
       expect(["success", "error"]).toContain(record.status);
 
-      // The endpoint orders by timestamp DESC (monitor.py:574), so items[0]
-      // is the last vertex to emit a transaction. In this fixture that is
-      // the LanguageModelComponent failing with "A model selection is
-      // required". Pinning both the vertex and status keeps the seed path
-      // honest: a refactor that stops emitting the LLM error row would
-      // surface here.
-      expect(record.vertex_id).toBe("LanguageModelComponent-FLeYF");
+      // Pin both the vertex and status on items[0] (the last vertex to
+      // emit, per the DESC ordering) — a refactor that stops emitting the
+      // LLM error row would surface here.
+      expect(record.vertex_id).toBe(FAILING_LLM_VERTEX_ID);
       expect(record.status).toBe("error");
 
       // TransactionLogsResponse deliberately excludes `error` and `flow_id`


### PR DESCRIPTION
## Summary

Extends test 3 in `traces-detail.spec.ts` to pin the full `TransactionLogsResponse` contract on records returned by `GET /api/v1/monitor/transactions?flow_id=...`. Closes #304.

## What changed

`traces-detail.spec.ts` test 3 now asserts, on the first record:
- Required keys exist: `id`, `vertex_id`, `target_id`, `inputs`, `outputs`, `status`
- `vertex_id` is a non-empty string and matches one of the imported node IDs (parsed from `TRACE_FIXTURE.data.nodes[*].id`)
- `target_id` is `null` or a string
- `inputs` / `outputs` are `null` or plain objects (not arrays)
- `status` is in the allowed set `{"success", "error"}` (the only two values the runtime writes — `lfx/graph/vertex/base.py:730,862`)
- `items[0]` is deterministically the failing `LanguageModelComponent-FLeYF` with `status === "error"`, because the endpoint orders `timestamp DESC` (`monitor.py:574`)
- The `error` and `flow_id` keys are **absent** — see "Scope deviation" below

Spec doc `docs/core-functionality/observability-monitoring/traces-detail.md` updated to mirror the broader contract and link the new anchors.

## Scope deviation from #304

The issue asked to assert `error: present (string or null) — when status is error, must be a non-empty string`. Reading `services/database/models/transactions/model.py:169-180` and confirming empirically against a live instance, `TransactionLogsResponse` is documented as *"excludes error and flow_id fields"* — neither field is actually exposed on the logs endpoint. They live only on `TransactionTable` / `TransactionReadResponse`, which the `GET /monitor/transactions` route does not return.

Rather than skip the assertion silently, the test now pins the **absence** of both `error` and `flow_id`. A future regression that reintroduces either (e.g. accidentally swapping the response model to `TransactionReadResponse`) would leak the raw error message or the flow_id into the logs view, and would surface here.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (no new errors; pre-existing warnings unchanged)
- [x] `npx playwright test traces-detail.spec.ts` — 3/3 pass
- [x] Forced an intentional vertex_id mismatch and confirmed the new assertion fails — no false positives