### PR TITLE
chore: bump brace-expansion to 5.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -292,7 +292,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -598,9 +597,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Closes 2 medium Dependabot alerts for the transitive dependency `brace-expansion` (reached via `eslint` → `minimatch`):

- [GHSA-f886-m6hf-6m8v](https://github.com/advisories/GHSA-f886-m6hf-6m8v) — zero-step sequence causes process hang and memory exhaustion (`<5.0.5`)
- [GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2) — large numeric range defeats documented `max` DoS protection (`<5.0.6`)

Both are DoS-style issues. Real-world impact for this repo is low (the package is only used by dev tooling with trusted inputs) but the alerts block any future Dependabot signal, so resolving them now keeps the channel clean.

## What changed

- `package-lock.json` only: `brace-expansion@5.0.4 → 5.0.6`
- No `package.json` change required — the new version is within the existing range allowed by `minimatch`

## Test plan

- [x] `npm audit` reports 0 vulnerabilities after the bump
- [x] `npm ls brace-expansion` confirms the bump propagated through the tree
- [ ] CI `pr-validation.yml` (typecheck + lint) passes