### PR TITLE
chore(webhook): restore @stable on POST 202 test

### DIFF
--- a/QA-SCENARIOS-GUIDE.md
+++ b/QA-SCENARIOS-GUIDE.md
@@ -717,8 +717,6 @@
 
 ---
 
----
-
 ## 13. Core Components — Agent
 
 **Files:** `agent-reasoning-steps.spec.ts`, `agent-system-prompt.spec.ts`, `agent-provider-field-isolation.spec.ts`, `agent-config-persistence.spec.ts`, `agent-max-iterations.spec.ts`, `agent-max-tokens.spec.ts`, `agent-reasoning-effort.spec.ts`, `agent-input-sources.spec.ts`, `agent-structured-output.spec.ts`, `agent-empty-refusal-response.spec.ts`, `agent-current-date-tool.spec.ts`, `agent-parse-error-behavior.spec.ts`, `agent-multimodal-image-input.spec.ts`

--- a/QA-SCENARIOS-GUIDE.md
+++ b/QA-SCENARIOS-GUIDE.md
@@ -668,7 +668,7 @@
 
 ## 12. Core Components — Webhook
 
-**Files:** `core/unit/webhookComponent.spec.ts`, `core/features/webhook-component-regression.spec.ts`
+**Files:** `core-components/webhook-component-regression.spec.ts`
 
 ---
 
@@ -691,6 +691,29 @@
 3. Confirm that the URL contains the flow ID (format `/api/v1/webhook/{flow_id}`).
 
 **Validation:** Webhook URL automatically generated with correct flow ID.
+
+---
+
+### 12.3 POST endpoint accepts JSON and plain-text bodies returning 202 `[x]`
+
+**Objective:** Confirm that `POST /api/v1/webhook/{flowId}` accepts both `application/json` and `text/plain` bodies and returns `202` with `{status: "in progress", message: "Task started in the background"}`.
+
+**Preconditions:**
+- A blank flow with the Webhook component on the canvas (created via UI; autosave persists the flow).
+- A temporary `x-api-key` is required because Langflow's `WEBHOOK_AUTH_ENABLE` defaults to `True` since 1.9.2+ (PR langflow-ai/langflow#12845).
+
+**Step by step:**
+1. Add the Webhook component to a blank flow via the sidebar.
+2. Wait for autosave (4 s debounce) before any webhook POST.
+3. Create a temporary API key via `POST /api/v1/api_key/`.
+4. POST a JSON object with the `x-api-key` header to `/api/v1/webhook/{flowId}`.
+5. POST a plain-text body with `x-api-key` and `Content-Type: text/plain` to the same endpoint.
+6. Delete the temporary API key in `finally`.
+
+**Validation:**
+- JSON POST returns 202 with `status === "in progress"` and `message === "Task started in the background"`.
+- Plain-text POST returns 202 with `status === "in progress"`.
+- The temporary API key is deleted regardless of test outcome.
 
 ---
 

--- a/docs/core-components/webhook-component-regression.md
+++ b/docs/core-components/webhook-component-regression.md
@@ -1,6 +1,6 @@
 # Webhook Component — Regression
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.11.x
 
 ---
 

--- a/docs/core-components/webhook-component-regression.md
+++ b/docs/core-components/webhook-component-regression.md
@@ -31,7 +31,6 @@ If any of these tests fails, the Webhook component is broken in one of its core 
 
 **`@stable` exceptions:**
 
-- **Test 1** (`HTTP POST accepts JSON and plain-text bodies returning 202`) does **not** carry `@stable` — removed in the triage of weekly run [25441253323](https://github.com/oriontech-me/langflow-e2e/actions/runs/25441253323) (issue #165) after the endpoint returned 403 instead of 202 on three consecutive attempts. The test fixture `request` is unauthenticated and the webhook endpoint appears to require session credentials in the current Langflow version. Tag is restored once the test is updated to authenticate (see follow-up issue).
 - **Test 2** (`flow is saved to database and contains the Webhook node`) does **not** carry `@stable` — removed in the triage of weekly run [25663131100](https://github.com/oriontech-me/langflow-e2e/actions/runs/25663131100) (issue #206) after the same upstream regression first observed in [25441253323](https://github.com/oriontech-me/langflow-e2e/actions/runs/25441253323) recurred on three consecutive attempts. The Langflow frontend bundle wraps `window.fetch` and the wrapper throws `Cannot set properties of undefined (setting 'Accept-Language')` when `fetch()` is called from `page.evaluate` without a `headers` init. Tracked in #180; tag is restored once upstream is fixed and one weekly cycle passes clean.
 
 ---

--- a/tests/tests-automations/regression/core-components/webhook-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/webhook-component-regression.spec.ts
@@ -32,49 +32,62 @@ async function addWebhookComponent(page: any) {
 
 test(
   "Webhook component — HTTP POST accepts JSON and plain-text bodies returning 202",
-  { tag: ["@release", "@regression"] },
+  { tag: ["@stable", "@release", "@regression"] },
   async ({ page, request }) => {
-    await addWebhookComponent(page);
-
-    const flowId = page.url().split("/").slice(-1)[0];
-    expect(flowId).toMatch(/^[0-9a-f-]{36}$/);
-
-    // Wait for autosave to persist the flow before posting
-    await page.waitForTimeout(4000);
-
-    // The webhook endpoint requires `x-api-key` whenever Langflow's
-    // WEBHOOK_AUTH_ENABLE setting is true (secure-by-default since 1.9.2+
-    // via PR langflow-ai/langflow#12845).
-    // Create a temporary key, use it for the POSTs, and delete it after.
+    let flowId!: string;
+    let apiKey!: string;
+    let apiKeyId!: string;
     const bearerToken = await getAuthToken(request);
-    const keyRes = await request.post("/api/v1/api_key/", {
-      headers: { Authorization: bearerToken },
-      data: { name: `webhook-regression-${Date.now()}` },
+
+    await test.step("Add Webhook component to a blank flow", async () => {
+      await addWebhookComponent(page);
+      flowId = page.url().split("/").slice(-1)[0];
+      expect(flowId).toMatch(/^[0-9a-f-]{36}$/);
     });
-    expect(keyRes.status()).toBe(200);
-    const keyBody = await keyRes.json();
-    const apiKey: string = keyBody.api_key;
-    const apiKeyId: string = keyBody.id;
+
+    await test.step("Wait for autosave to persist the flow", async () => {
+      // The flow is created via UI; autosave debounce flushes it to the
+      // database before any webhook POST can resolve flowId.
+      await page.waitForTimeout(4000);
+    });
+
+    await test.step("Create temporary x-api-key for webhook auth", async () => {
+      // The webhook endpoint requires `x-api-key` whenever Langflow's
+      // WEBHOOK_AUTH_ENABLE setting is true (secure-by-default since 1.9.2+
+      // via PR langflow-ai/langflow#12845). Create a temporary key, use it
+      // for the POSTs, and delete it in the `finally` block.
+      const keyRes = await request.post("/api/v1/api_key/", {
+        headers: { Authorization: bearerToken },
+        data: { name: `webhook-regression-${Date.now()}` },
+      });
+      expect(keyRes.status()).toBe(200);
+      const keyBody = await keyRes.json();
+      apiKey = keyBody.api_key;
+      apiKeyId = keyBody.id;
+    });
 
     try {
-      // JSON body — the primary use case
-      const jsonRes = await request.post(`/api/v1/webhook/${flowId}`, {
-        headers: { "x-api-key": apiKey },
-        data: { event: "regression-test", value: 42 },
+      await test.step("POST JSON body returns 202 with status 'in progress'", async () => {
+        const jsonRes = await request.post(`/api/v1/webhook/${flowId}`, {
+          headers: { "x-api-key": apiKey },
+          data: { event: "regression-test", value: 42 },
+        });
+        expect(jsonRes.status()).toBe(202);
+        const jsonBody = await jsonRes.json();
+        expect(jsonBody.status).toBe("in progress");
+        expect(jsonBody.message).toBe("Task started in the background");
       });
-      expect(jsonRes.status()).toBe(202);
-      const jsonBody = await jsonRes.json();
-      expect(jsonBody.status).toBe("in progress");
-      expect(jsonBody.message).toBe("Task started in the background");
 
-      // Plain-text body — the endpoint must accept any Content-Type
-      const textRes = await request.post(`/api/v1/webhook/${flowId}`, {
-        headers: { "x-api-key": apiKey, "Content-Type": "text/plain" },
-        data: "regression-plain-text",
+      await test.step("POST plain-text body returns 202 with status 'in progress'", async () => {
+        // The endpoint must accept any Content-Type, not only application/json.
+        const textRes = await request.post(`/api/v1/webhook/${flowId}`, {
+          headers: { "x-api-key": apiKey, "Content-Type": "text/plain" },
+          data: "regression-plain-text",
+        });
+        expect(textRes.status()).toBe(202);
+        const textBody = await textRes.json();
+        expect(textBody.status).toBe("in progress");
       });
-      expect(textRes.status()).toBe(202);
-      const textBody = await textRes.json();
-      expect(textBody.status).toBe("in progress");
     } finally {
       await request.delete(`/api/v1/api_key/${apiKeyId}`, {
         headers: { Authorization: bearerToken },


### PR DESCRIPTION
## Summary

Restores the `@stable` tag on `Webhook component — HTTP POST accepts JSON and plain-text bodies returning 202` after confirming the root cause documented in the original triage (issue #165) was already fixed in the test code.

The other 9 tests in the spec are untouched. Net: spec goes from 8 `@stable` + 1 `test.fixme` + 1 untagged → **9 `@stable` + 1 `test.fixme`**.

## Tests covered

| # | Test | What it validates |
|---|---|---|
| 1 | `Webhook component — HTTP POST accepts JSON and plain-text bodies returning 202` | The `POST /api/v1/webhook/{flowId}` endpoint accepts both `application/json` and `text/plain` bodies and returns `202` with `{status: "in progress", message: "Task started in the background"}`. Auth is required (`WEBHOOK_AUTH_ENABLE=True` since Langflow 1.9.2+ via PR langflow-ai/langflow#12845) — the test creates a temporary `x-api-key`, uses it for both POSTs, and deletes it in `finally` regardless of test outcome. Would catch a regression in the webhook handler (status code, response shape, multipart Content-Type tolerance) or in the auth dependency chain. |

## How the test was built

- **Authentication via temporary `x-api-key`**, not session cookies, because the `request` fixture is unauthenticated by default. The test creates the key via `POST /api/v1/api_key/` (using the bearer token from `getAuthToken`) and deletes it via `DELETE /api/v1/api_key/{id}` in `finally` so failures don't leak credentials.
- **`test.step()` per logical block** — Add component → wait for autosave → create api key → POST JSON → POST plain-text. Steps surface in the trace report so a failure is immediately attributable to a phase rather than to "somewhere in the test".
- **`waitForTimeout(4000)` retained** for autosave debounce because that is the established pattern across the other 9 tests in the spec (tests 2, 8, 9 also rely on the same 4s window). Changing only this test's wait pattern would introduce inconsistency without solving an actual flakiness problem — five consecutive runs (9.3–11.9 s) pass without retry.
- **Test 2's `test.fixme` is preserved** — it's blocked by a different upstream regression (#180 / Accept-Language wrapper in `page.evaluate(fetch)`) and is out of scope for this PR.

## Why `@stable` was removed and why it can come back

- **Removed** in the triage of weekly run [25441253323](https://github.com/oriontech-me/langflow-e2e/actions/runs/25441253323) (issue #165) after the endpoint returned 403 instead of 202 on three consecutive attempts.
- **Root cause** documented at the time: the `request` fixture is unauthenticated, and `WEBHOOK_AUTH_ENABLE` had defaulted to `True` since Langflow 1.9.2+ (PR langflow-ai/langflow#12845), so unauthenticated POSTs short-circuit to 403 before flow resolution.
- **Fix already in the test code** (predates this PR): the test creates a temporary `x-api-key`, passes it via the `x-api-key` header on both POSTs, and deletes it in `finally`. The 403 path is no longer reachable for this test.
- This PR just **restores the tag** and aligns the spec doc with that reality.

## Dependencies

- No env vars, no LLM keys, no `collect-models.spec.ts` setup
- `getAuthToken` (existing helper) for the bearer token used to create/delete the api key
- `cleanAllFlows` (existing helper, called inside `addWebhookComponent`) — already present
- Execution: must remain in `test.describe.configure({ mode: "serial" })` because `cleanAllFlows` deletes everyone's flows, including parallel siblings' (no change in this PR)
- Cleanup: temporary api key is deleted in `finally` regardless of pass/fail

## What this PR does not cover

- **Test 2 (`flow is saved to database…`)** — still `test.fixme`'d by upstream regression #180 (`page.evaluate(fetch)` throws `Cannot set properties of undefined (setting 'Accept-Language')`); restoration of `@stable` for that test depends on upstream fix + one clean weekly cycle
- **Webhook authentication edge cases** — invalid api key, expired key, missing header — out of scope for this PR (consider as follow-up if regression coverage is needed)
- **Concurrent or high-frequency webhook POSTs** — no load testing
- **Binary or multipart payloads** — only `application/json` and `text/plain` are exercised
- **Webhook connected to downstream components** — only the immediate POST acceptance is asserted, not downstream propagation (other tests in the same spec cover that via the inspector output panel)

## Known limitations

- **`waitForTimeout(4000)` is empirical** for autosave persistence. A high-latency CI environment could exceed this window. Replacing it with a deterministic poll (e.g. `expect.poll(GET /api/v1/flows/{id}).status() === 200`) is a candidate for a future cross-cutting cleanup across the whole spec, not just this test.
- **The "Task started in the background" message text is asserted exactly** — a copy change upstream would break the test even if the endpoint behavior is unchanged. The risk is low because that string lives in the API response, not in user-facing UI copy.

## Validation checklist

| Step | Result |
|---|---|
| `npm run typecheck` | ✅ PASS |
| `npx eslint ...spec.ts` | ✅ 0 errors, 24 warnings — all pre-existing in the file (unchanged from main) |
| Anti-pattern static check (no `\|\| true`, no `.catch(() => false)` in test logic, no `.isVisible()` orphan, no `waitForTimeout` as sync without follow-up assertion) | ✅ PASS |
| 5× `--workers=1 --retries=0` clean run | ✅ 5/5 PASS, 9.3–11.9 s |
| Force-fail (changed `expect(jsonRes.status()).toBe(202)` → `toBe(999)`) | ✅ Failed exactly at L75 inside step "POST JSON body returns 202 with status 'in progress'", reverted, repassed |
| `--trace=on` (1 trace in `test-results/`) | ✅ Generated |
| Backend errors audit (`grep -iE "backend error\|🚨"` on output) | ✅ Zero |

## Spec doc changes

`docs/core-components/webhook-component-regression.md`:
- **Removed** the `@stable` exception entry for Test 1 (the obsolete one — the auth fix it required is already in the test code)
- **Preserved** the Test 2 exception (still gated on upstream #180)

## QA-SCENARIOS-GUIDE.md changes

- **Section 12 "Files" reference cleaned**: removed non-existent `core/unit/webhookComponent.spec.ts` and the obsolete `core/features/` prefix path; the spec now lives at `core-components/webhook-component-regression.spec.ts`
- **New subsection 12.3** documenting the now-stable test (objective, preconditions, step-by-step, validation criteria)

## QA-CHECKLIST.md

No change required. The "POST aceita JSON e text/plain retornando 202..." bullet (section 3.4 Webhook, line 209) was already `[x]`. The Coverage Summary table is auto-regenerated by `update-coverage-summary.yml`.