### PR TITLE
chore(weekly): drop @stable from 13 specs blocked by nightly upstream regressions

### DIFF
--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
@@ -144,7 +144,7 @@ for (const { label, options, skipReason } of targets) {
 
     test(
       "agent interaction suite",
-      { tag: ["@stable", "@release", "@components", "@agents", "@playground"] },
+      { tag: ["@release", "@components", "@agents", "@playground"] },
       async ({ page }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-delete.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-delete.spec.ts
@@ -141,7 +141,7 @@ test.describe("Bulk delete traces — seeded flow", () => {
 
   test(
     "DELETE /api/v1/monitor/traces?flow_id=... clears all traces, and a second DELETE on the empty owned flow still returns 204",
-    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
+    { tag: ["@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       // Anchor: the seeded flow MUST have traces before DELETE. Without this,
       // a post-DELETE empty envelope could come from a degraded GET (the

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-single.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-single.spec.ts
@@ -153,7 +153,7 @@ test.describe("Single trace shape — seeded flow", () => {
 
   test(
     "GET /api/v1/monitor/traces/{trace_id} returns the full TraceRead contract with a non-empty span tree",
-    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
+    { tag: ["@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       const res = await request.get(`/api/v1/monitor/traces/${traceId}`, {
         headers: { Authorization: bearerToken },

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-latency-tokens.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-latency-tokens.spec.ts
@@ -94,13 +94,7 @@ test.describe("Flow Activity / Traces — latency and tokens", () => {
   test(
     "GET /api/v1/monitor/traces returns totalLatencyMs and totalTokens for a flow run",
     {
-      tag: [
-        "@stable",
-        "@release",
-        "@api",
-        "@regression",
-        "@observability",
-      ],
+      tag: ["@release", "@api", "@regression", "@observability"],
     },
     async ({ request }) => {
       const res = await request.get(

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-list-filters.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-list-filters.spec.ts
@@ -183,7 +183,7 @@ test.describe("Trace list filters — status / start_time / query / session_id",
 
   test(
     "GET /api/v1/monitor/traces?status=error returns only the failing trace; rejects unknown values",
-    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
+    { tag: ["@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       const matchRes = await request.get(
         `/api/v1/monitor/traces?flow_id=${errorFlowId}&status=error`,

--- a/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
@@ -147,7 +147,7 @@ test.describe("Playground Output – Structured Data", () => {
 
   test(
     "playground must render DataFrame output as a markdown table",
-    { tag: ["@stable", "@release", "@regression", "@playground"] },
+    { tag: ["@release", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step(
         "Set up Mock Data (dataframe_output) → Chat Output flow and open playground",

--- a/tests/tests-automations/regression/core-functionality/playground/playground-output-image.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-output-image.spec.ts
@@ -54,7 +54,7 @@ test.describe("Playground Output – Image Upload (ID B0c)", () => {
 
   test(
     "playground must display uploaded image in user message after sending",
-    { tag: ["@stable", "@regression", "@playground"] },
+    { tag: ["@regression", "@playground"] },
     async ({ page }) => {
       await test.step(
         "Set up ChatInput → ChatOutput echo flow and open playground",

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-clear.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-clear.spec.ts
@@ -76,7 +76,7 @@ test.describe("Playground – Clear Session History", () => {
 
   test(
     "clear-chat removes all messages from Default Session",
-    { tag: ["@stable", "@regression", "@playground"] },
+    { tag: ["@regression", "@playground"] },
     async ({ page }) => {
       await test.step(
         "Set up ChatInput → ChatOutput echo flow and open playground",

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-id.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-id.spec.ts
@@ -19,7 +19,7 @@ test.describe("Playground — Session ID input", () => {
 
   test(
     "session ID input accepts a custom value",
-    { tag: ["@stable", "@release", "@regression", "@playground"] },
+    { tag: ["@release", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step("set up ChatInput → ChatOutput flow", async () => {
         createdFlowId = await setupPlayground(page);

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-nav.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-nav.spec.ts
@@ -19,7 +19,7 @@ test.describe("Playground – Session Creation and Navigation", () => {
 
   test(
     "new-chat button must add a new session entry to the sidebar",
-    { tag: ["@stable", "@regression", "@playground"] },
+    { tag: ["@regression", "@playground"] },
     async ({ page }) => {
       await test.step("set up ChatInput → ChatOutput flow and open playground", async () => {
         createdFlowId = await setupPlayground(page);

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-rename.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-rename.spec.ts
@@ -29,7 +29,7 @@ test.describe("Playground – Session Rename (B2)", () => {
 
   test(
     "rename option must not be available for the Default Session",
-    { tag: ["@stable", "@regression", "@playground"] },
+    { tag: ["@regression", "@playground"] },
     async ({ page }) => {
       await test.step(
         "Set up ChatInput → ChatOutput echo flow and open playground",

--- a/tests/tests-automations/regression/flow-functionality/run-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/run-flow.spec.ts
@@ -8,7 +8,7 @@ import { zoomOut } from "../../../helpers/ui/zoom-out";
 
 test(
   "user should be able to use Run Flow without any issues",
-  { tag: ["@stable", "@release", "@workspace", "@api", "@regression"] },
+  { tag: ["@release", "@workspace", "@api", "@regression"] },
   async ({ page, request }) => {
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../.env") });

--- a/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
@@ -162,7 +162,7 @@ for (const { label, options, skipReason } of targets) {
 
     test(
       "agent calls echo MCP tool and returns echoed message",
-      { tag: ["@mcp", "@agents", "@regression", "@stable"] },
+      { tag: ["@mcp", "@agents", "@regression"] },
       async ({ page }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(


### PR DESCRIPTION
## Summary

Weekly stable run #26395631563 (2026-05-25) recorded 13 hard failures, all traceable to two distinct upstream regressions in `langflowai/langflow-nightly:latest`. Per CONTRIBUTING.md "@stable lifecycle" rules, this PR removes `@stable` from each affected spec so the weekly workflow stops flagging the same upstream issue on every run. Tags will be restored in the correction PR that closes the upstream issues and re-validates each spec via the 5-step guide.

## Bug A — `LanguageModelComponent` missing default (#326)

Verified locally against Langflow 1.10.0 nightly: starter templates ship the component with `model_name.value = null` and `provider.value = null`, so any flow execution that uses it errors server-side with `Error building Component Language Model: A model selection is required`.

Specs with `@stable` removed (9):

- [x] `agent-component-regression.spec.ts:145` — agent interaction suite
- [x] `traces-delete.spec.ts:142`
- [x] `traces-detail-single.spec.ts:154`
- [x] `traces-latency-tokens.spec.ts:94`
- [x] `traces-list-filters.spec.ts:184`
- [x] `playground-output-data.spec.ts:148`
- [x] `playground-output-image.spec.ts:55`
- [x] `run-flow.spec.ts:9`
- [x] `mcp-client-agent.spec.ts:163`

The 4 trace tests time out polling for traces because the upstream flow execution never produces one; the Playground/Agent/MCP tests fail directly on the LLM call.

## Bug B — `mainpage_title` bootstrap timeout (#327)

All 4 `playground-session-*` specs fail at the first step in `setupPlayground → awaitBootstrapTest`, timing out at 30s on `[data-testid="mainpage_title"]`. The testid still exists in upstream source, so this is a timing/render regression rather than a renamed selector.

Specs with `@stable` removed (4):

- [x] `playground-session-clear.spec.ts:77`
- [x] `playground-session-id.spec.ts:20`
- [x] `playground-session-nav.spec.ts:20`
- [x] `playground-session-rename.spec.ts:30`

## Triage rationale (per CONTRIBUTING.md)

Cross-referenced against `reports/weekly-history.jsonl`:

| Spec | Prior status | Pattern | Action per table |
|---|---|---|---|
| `agent-component-regression:145` | flaky 2026-05-18 | Mix → 2nd consecutive | open issue, remove `@stable` |
| `mcp-client-agent:163` | flaky 2026-05-18 | Mix → 2nd consecutive | open issue, remove `@stable` |
| 11 others | not in history | 1st-occurrence hard fail | open issue. Remove `@stable` only if upstream won't fix before next weekly. |

Both upstream root causes are confirmed; the upstream fix timing for next Monday's weekly is unknown, so `@stable` is removed across all 13.

Per CONTRIBUTING.md ("When `@stable` is temporarily absent (cases 1 and 2): no spec doc update is required"), no `docs/` updates are included here. The `Phase 0 — Validated` block in `QA-CHECKLIST.md` will regenerate on merge via `update-coverage-summary.yml`.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` on changed files — 0 errors (only pre-existing warnings)
- [x] Diff scoped to exactly the 13 failing tests (no collateral changes to neighboring `@stable` tests in the same files)
- [ ] After merge: confirm `update-coverage-summary.yml` regenerates `QA-CHECKLIST.md` cleanly
- [ ] Monitor #326 and #327 for upstream fix; restoration PR re-runs the 5-step validation per spec

## References

- Weekly run that triggered this work: https://github.com/oriontech-me/langflow-e2e/actions/runs/26395631563
- Auto-opened weekly issue: #324
- Upstream bug A: #326
- Upstream bug B: #327
- Related (same upstream wave, docker-compose migration): #325