### PR TITLE
fix(provider-setup): scope llm-toggle locator to visible elements only

### DIFF
--- a/tests/helpers/provider-setup/setup-openai.ts
+++ b/tests/helpers/provider-setup/setup-openai.ts
@@ -46,8 +46,11 @@ export async function setupOpenAI(
   }
 
   // Step 5: Enable all available OpenAI models.
-  // Toggles only render after the provider is authenticated — waitFor retries until visible.
-  const toggles = page.locator('[data-testid^="llm-toggle"]');
+  // The `:visible` filter excludes toggles inside the collapsed "deprecated
+  // models" section, which are mounted in the DOM but not displayed until the
+  // section's "Show N deprecated models" button is clicked. Without the
+  // filter, `.click()` on a hidden toggle retry-loops to a timeout.
+  const toggles = page.locator('[data-testid^="llm-toggle"]:visible');
   await toggles.first().waitFor({ state: "visible", timeout: 15000 }).catch(() => {});
   const toggleCount = await toggles.count();
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
@@ -144,7 +144,7 @@ for (const { label, options, skipReason } of targets) {
 
     test(
       "agent interaction suite",
-      { tag: ["@release", "@components", "@agents", "@playground"] },
+      { tag: ["@stable", "@release", "@components", "@agents", "@playground"] },
       async ({ page }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(

--- a/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
@@ -162,7 +162,7 @@ for (const { label, options, skipReason } of targets) {
 
     test(
       "agent calls echo MCP tool and returns echoed message",
-      { tag: ["@mcp", "@agents", "@regression"] },
+      { tag: ["@mcp", "@agents", "@regression", "@stable"] },
       async ({ page }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(


### PR DESCRIPTION
Closes #326

## Summary

`tests/helpers/provider-setup/setup-openai.ts` iterates every `[data-testid^="llm-toggle"]` toggle in the Manage Model Providers dialog and clicks the unchecked ones. The OpenAI panel renders **all** 49 models in DOM but collapses the last 7 ("deprecated models") under a "Show N deprecated models" button. The previous locator captured them too; when the for-loop hit the first hidden toggle, `.click()` retry-looped to 38 attempts and timed out.

The fix scopes the locator to `[data-testid^="llm-toggle"]:visible`. The iteration is now bounded to what the user can actually interact with.

## Evidence

Trace from the failing run shows:

```
- locator resolved to <button … role="switch" aria-checked="false"
                       data-state="unchecked"
                       aria-label="Enable gpt-4o-2024-11-20"
                       data-testid="llm-toggle-gpt-4o-2024-11-20" …>
  - waiting for element to be visible, enabled and stable
  - element is not visible
  - retrying click action (×38 / 19s)
```

`gpt-4o-2024-11-20` lives inside the collapsed "deprecated models" group.

## Validation

Both specs that were previously failing locally now pass (`--workers=1 --retries=0`, Langflow 1.10.0 nightly):

- `agent-component-regression.spec.ts:145` — 21.4s ✅
- `mcp-client-agent.spec.ts:163` — 21.5s ✅

7-step pipeline:
- [x] `npm run typecheck` — passes
- [x] `npm run lint` on changed file — 0 errors
- [x] Anti-pattern checklist — helper change, no test logic
- [x] Run with `--retries=0 --workers=1` — both specs PASS
- [x] Force-fail validation — broke a critical assertion (testid suffix) on `agent-component-regression`, confirmed test failed at the exact line; reverted, confirmed PASS
- [x] `--trace=on` — trace captured the original hidden-toggle failure, confirms the fix path
- [x] Audited `🚨 Backend Error` in run output — zero occurrences

## `@stable` status

Per the `@stable` lifecycle (Step 2 — restore the tag in the same correction PR), `@stable` is retained on both specs fixed here:

- `agent-component-regression.spec.ts:145`
- `mcp-client-agent.spec.ts:163`

The `:visible` fix unblocks them, so the tags stay and the specs remain in the weekly workflow. #326 has been re-scoped to exactly these 2 specs; the rest of the original cluster is tracked separately:

- #336 — bootstrap `FlowBuilderWelcome` overlay (`playground-output-*` / `run-flow`)
- #337 — restore `@stable` on the 4 `traces-*` specs
- #338 — upstream null-default
- #327 — parallelism / `cleanAllFlows` races

## References

- Issue #326 (re-scoped to this PR's 2 specs)
- Weekly run that triggered investigation: https://github.com/oriontech-me/langflow-e2e/actions/runs/26395631563
- Split-out issues: #336, #337, #338, #327
