### PR TITLE
fix(llm-agents): repair stale provider testids in agent-images-playground

### DIFF
--- a/docs/core-functionality/llm-agents/general-bugs-agent-images-playground.md
+++ b/docs/core-functionality/llm-agents/general-bugs-agent-images-playground.md
@@ -1,0 +1,80 @@
+# Agent Component — Image Input in Playground
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+Validates that the **Agent** component can receive an image attachment in the Playground and produce a meaningful response describing it. It loads the Simple Agent template, configures the Anthropic provider via the centralized model-provider modal, drops a PNG into the chat input, sends a prompt, and asserts that the attachment is rendered in the user message and that the model's reply references the image content. If this test fails, multimodal (vision) input through the Agent is broken for real use.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@components` `@agents`
+
+---
+
+## Step by step *(required)*
+
+The spec contains **1 test** — `"user must be able to send images in the playground with the agent component"`.
+
+Requires `ANTHROPIC_API_KEY` (vision-capable Claude model); skips when the key is absent.
+
+1. Bootstrap and open `All Templates`, then load the **Simple Agent** template
+2. Configure the Anthropic provider via `setupAnthropic(page)` — the centralized path: open `model_model` → `manage-model-providers` → select `provider-item-Anthropic` → fill the `sk-ant-...` key → save → enable model toggles → select a Claude model
+3. Open the Playground (`playground-btn-flow-io`) and wait for `input-chat-playground`
+4. Build a `DataTransfer` in the browser context from `tests/assets/chain.png` (base64 → `File`) and dispatch a `drop` event on the chat input
+5. Type `"what is this image?"` and click `button-send`
+6. Wait for `chain.png` to appear (attachment rendered in the user message)
+7. Read the last `.markdown.prose` block (the model reply) and assert it matches `/(chain|inkscape|logo)/` and is longer than 100 characters
+
+---
+
+## Validation criterion *(required)*
+
+- The dropped image (`chain.png`) is rendered in the sent user message
+- The model reply references the image content (matches `chain`, `inkscape`, or `logo`)
+- The reply is a substantive description (> 100 characters)
+
+---
+
+## External dependencies *(required)*
+
+- `src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json` — defines the Simple Agent template graph at runtime; changes to nodes break template load
+- `src/frontend/src/modals/modelProviderModal/` — `model_model`, `manage-model-providers`, `provider-item-Anthropic`, the `sk-ant-...` input, and the Save/Replace button — any rename breaks `setupAnthropic` (shared helper at `tests/helpers/provider-setup/setup-anthropic.ts`)
+- `src/frontend/src/components/core/playgroundComponent/` — `input-chat-playground`, `button-send` — any rename breaks the send flow
+- `tests/assets/chain.png` — the image fixture dropped into the chat
+
+---
+
+## What this test does not cover *(optional)*
+
+- Image input via providers other than Anthropic (`setupAnthropic` configures Anthropic only)
+- Multiple-image attachments (covered by `playground-attachments-management.spec.ts`)
+- Non-image attachments (covered by `playground-non-image-attachment.spec.ts`)
+- Image input via the Agent's direct input handle rather than the Playground drop zone
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
+- `ANTHROPIC_API_KEY` defined in `.env` — without it the test skips
+- Run with `--workers=1` to avoid flow conflicts
+
+---
+
+## When to review this test *(optional)*
+
+- If the Simple Agent template is removed or renamed in `starter_projects`
+- If the centralized model-provider modal changes its testids (breaks `setupAnthropic`) — this is what caused issue #312: the previous in-component provider testids (`value-dropdown-dropdown_str_agent_llm`, `popover-anchor-input-api_key`) were removed in 1.10.x
+- If the Playground drop/attachment rendering changes (`chain.png` no longer surfaced in the user message)
+
+---
+
+## Notes *(optional)*
+
+- **Fixed in issue #312**: the test previously configured the provider through removed in-component testids (`value-dropdown-dropdown_str_agent_llm`, `popover-anchor-input-api_key`). It now delegates to `setupAnthropic(page)`, matching the sibling spec `general-bugs-agent-sum-duplicate-message-playground.spec.ts`.
+- **Why Anthropic-only**: the test needs a vision-capable model; the historical fixture used Anthropic. Could be generalized to a multi-provider, multimodal target in a future change.

--- a/docs/core-functionality/llm-agents/general-bugs-agent-images-playground.md
+++ b/docs/core-functionality/llm-agents/general-bugs-agent-images-playground.md
@@ -6,7 +6,7 @@
 
 ## What this test validates *(required)*
 
-Validates that the **Agent** component can receive an image attachment in the Playground and produce a meaningful response describing it. It loads the Simple Agent template, configures the Anthropic provider via the centralized model-provider modal, drops a PNG into the chat input, sends a prompt, and asserts that the attachment is rendered in the user message and that the model's reply references the image content. If this test fails, multimodal (vision) input through the Agent is broken for real use.
+Validates that the **Agent** component can receive an image attachment in the Playground and produce a meaningful response describing it. It loads the Simple Agent template, configures the OpenAI provider via the centralized model-provider modal, attaches a PNG to the chat input, sends a prompt, and asserts that the attachment is rendered in the user message and that the model's reply references the image content. If this test fails, multimodal (vision) input through the Agent is broken for real use.
 
 ---
 
@@ -20,48 +20,48 @@ Validates that the **Agent** component can receive an image attachment in the Pl
 
 The spec contains **1 test** — `"user must be able to send images in the playground with the agent component"`.
 
-Requires `ANTHROPIC_API_KEY` (vision-capable Claude model); skips when the key is absent.
+Requires `OPENAI_API_KEY` (vision-capable `gpt-4o-mini`); skips when the key is absent. OpenAI is used (not Anthropic) so the test actually runs in the weekly workflow, which provides `OPENAI_API_KEY`.
 
 1. Bootstrap and open `All Templates`, then load the **Simple Agent** template
-2. Configure the Anthropic provider via `setupAnthropic(page)` — the centralized path: open `model_model` → `manage-model-providers` → select `provider-item-Anthropic` → fill the `sk-ant-...` key → save → enable model toggles → select a Claude model
+2. Wait for the agent node's provider entry point to render (`model_model` when a provider is configured, otherwise the `Setup Provider` button), then configure the OpenAI provider via `setupOpenAI(page)` — the centralized path: open `model_model` → `manage-model-providers` → select `provider-item-OpenAI` → fill the `sk-...` key → save → enable model toggles → select `gpt-4o-mini`
 3. Open the Playground (`playground-btn-flow-io`) and wait for `input-chat-playground`
-4. Build a `DataTransfer` in the browser context from `tests/assets/chain.png` (base64 → `File`) and dispatch a `drop` event on the chat input
-5. Type `"what is this image?"` and click `button-send`
-6. Wait for `chain.png` to appear (attachment rendered in the user message)
-7. Read the last `.markdown.prose` block (the model reply) and assert it matches `/(chain|inkscape|logo)/` and is longer than 100 characters
+4. Attach `tests/assets/media/chain.png` via the Playground file input (`[data-testid="input-wrapper"] input[type="file"]`) and confirm the `img[alt="chain.png"]` preview
+5. Clear the input and type `"what is this image?"` with real keystrokes (`pressSequentially`), then click `button-send`
+6. Wait ~5s for the model reply
+7. Read the last `.markdown.prose` block (the model reply) and assert it matches `/(chain|inkscape|logo)/` and is longer than 50 characters
 
 ---
 
 ## Validation criterion *(required)*
 
-- The dropped image (`chain.png`) is rendered in the sent user message
+- The dropped image (`chain.png`) is attached and rendered as an `img[alt="chain.png"]` preview before sending
 - The model reply references the image content (matches `chain`, `inkscape`, or `logo`)
-- The reply is a substantive description (> 100 characters)
+- The reply is a substantive description (> 50 characters)
 
 ---
 
 ## External dependencies *(required)*
 
 - `src/backend/base/langflow/initial_setup/starter_projects/Simple Agent.json` — defines the Simple Agent template graph at runtime; changes to nodes break template load
-- `src/frontend/src/modals/modelProviderModal/` — `model_model`, `manage-model-providers`, `provider-item-Anthropic`, the `sk-ant-...` input, and the Save/Replace button — any rename breaks `setupAnthropic` (shared helper at `tests/helpers/provider-setup/setup-anthropic.ts`)
-- `src/frontend/src/components/core/playgroundComponent/` — `input-chat-playground`, `button-send` — any rename breaks the send flow
-- `tests/assets/chain.png` — the image fixture dropped into the chat
+- `src/frontend/src/modals/modelProviderModal/` — `model_model`, `manage-model-providers`, `provider-item-OpenAI`, the `sk-...` input, the Save/Replace button, and the `llm-toggle-*` switches — any rename breaks `setupOpenAI` (shared helper at `tests/helpers/provider-setup/setup-openai.ts`)
+- `src/frontend/src/components/core/playgroundComponent/` — `input-chat-playground`, `input-wrapper` file input, `button-send` — any rename breaks the attach/send flow
+- `tests/assets/media/chain.png` — the image fixture attached into the chat
 
 ---
 
 ## What this test does not cover *(optional)*
 
-- Image input via providers other than Anthropic (`setupAnthropic` configures Anthropic only)
+- Image input via providers other than OpenAI (`setupOpenAI` configures OpenAI only)
 - Multiple-image attachments (covered by `playground-attachments-management.spec.ts`)
 - Non-image attachments (covered by `playground-non-image-attachment.spec.ts`)
-- Image input via the Agent's direct input handle rather than the Playground drop zone
+- Image input via the Agent's direct input handle rather than the Playground
 
 ---
 
 ## Preconditions *(optional)*
 
 - Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
-- `ANTHROPIC_API_KEY` defined in `.env` — without it the test skips
+- `OPENAI_API_KEY` defined in `.env` — without it the test skips
 - Run with `--workers=1` to avoid flow conflicts
 
 ---
@@ -69,12 +69,13 @@ Requires `ANTHROPIC_API_KEY` (vision-capable Claude model); skips when the key i
 ## When to review this test *(optional)*
 
 - If the Simple Agent template is removed or renamed in `starter_projects`
-- If the centralized model-provider modal changes its testids (breaks `setupAnthropic`) — this is what caused issue #312: the previous in-component provider testids (`value-dropdown-dropdown_str_agent_llm`, `popover-anchor-input-api_key`) were removed in 1.10.x
-- If the Playground drop/attachment rendering changes (`chain.png` no longer surfaced in the user message)
+- If the centralized model-provider modal changes its testids (breaks `setupOpenAI`) — this is what caused issue #312: the previous in-component provider testids (`value-dropdown-dropdown_str_agent_llm`, `popover-anchor-input-api_key`) were removed in 1.10.x
+- If the Playground attachment rendering changes (`img[alt="chain.png"]` preview no longer surfaced) or the chat input stops accepting `pressSequentially` input
 
 ---
 
 ## Notes *(optional)*
 
-- **Fixed in issue #312**: the test previously configured the provider through removed in-component testids (`value-dropdown-dropdown_str_agent_llm`, `popover-anchor-input-api_key`). It now delegates to `setupAnthropic(page)`, matching the sibling spec `general-bugs-agent-sum-duplicate-message-playground.spec.ts`.
-- **Why Anthropic-only**: the test needs a vision-capable model; the historical fixture used Anthropic. Could be generalized to a multi-provider, multimodal target in a future change.
+- **Fixed in issue #312**: the test previously configured the provider through removed in-component testids (`value-dropdown-dropdown_str_agent_llm`, `popover-anchor-input-api_key`). It now delegates to `setupOpenAI(page)`.
+- **Why OpenAI**: the test needs a vision-capable model. It originally used Anthropic, but the weekly workflow only provides `OPENAI_API_KEY`, so an Anthropic-keyed test would always skip in CI and give no weekly signal. `gpt-4o-mini` is vision-capable and runs in the weekly.
+- **1.10.x quirks handled**: (1) the image is attached via `setInputFiles` because the old manual `DataTransfer` drop no longer renders the attachment; (2) the chat input is pre-filled with a sample prompt and the send action reads the component's internal state, so the prompt is typed with `pressSequentially` (a programmatic `.fill()` is ignored); (3) `setupOpenAI` is called only after the agent node's provider entry point renders, so it does not silently no-op on a still-loading canvas.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/general-bugs-agent-images-playground.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/general-bugs-agent-images-playground.spec.ts
@@ -3,10 +3,11 @@ import { readFileSync } from "fs";
 import path from "path";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { setupAnthropic } from "../../../../helpers/provider-setup/setup-anthropic";
 
 test(
   "user must be able to send images in the playground with the agent component",
-  { tag: ["@release", "@components", "@agents"] },
+  { tag: ["@stable", "@release", "@components", "@agents"] },
   async ({ page }) => {
     test.skip(
       !process?.env?.ANTHROPIC_API_KEY,
@@ -21,15 +22,7 @@ test(
     await page.getByTestId("side_nav_options_all-templates").click();
     await page.getByRole("heading", { name: "Simple Agent" }).first().click();
 
-    await page.getByTestId("value-dropdown-dropdown_str_agent_llm").click();
-
-    await page.waitForTimeout(200);
-
-    await page.getByText("Anthropic").last().click();
-
-    await page
-      .getByTestId("popover-anchor-input-api_key")
-      .fill(process.env.ANTHROPIC_API_KEY || "");
+    await setupAnthropic(page);
 
     await page.getByTestId("playground-btn-flow-io").click();
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/general-bugs-agent-images-playground.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/general-bugs-agent-images-playground.spec.ts
@@ -1,17 +1,16 @@
 import dotenv from "dotenv";
-import { readFileSync } from "fs";
 import path from "path";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
-import { setupAnthropic } from "../../../../helpers/provider-setup/setup-anthropic";
+import { setupOpenAI } from "../../../../helpers/provider-setup/setup-openai";
 
 test(
   "user must be able to send images in the playground with the agent component",
   { tag: ["@stable", "@release", "@components", "@agents"] },
   async ({ page }) => {
     test.skip(
-      !process?.env?.ANTHROPIC_API_KEY,
-      "ANTHROPIC_API_KEY required to run this test",
+      !process?.env?.OPENAI_API_KEY,
+      "OPENAI_API_KEY required to run this test",
     );
 
     if (!process.env.CI) {
@@ -22,52 +21,59 @@ test(
     await page.getByTestId("side_nav_options_all-templates").click();
     await page.getByRole("heading", { name: "Simple Agent" }).first().click();
 
-    await setupAnthropic(page);
+    // Wait for the agent node's provider entry point to render before
+    // configuring the provider — otherwise setupOpenAI runs against a
+    // still-loading canvas, finds neither entry point, and silently no-ops.
+    // Unconfigured instance → "Setup Provider" button; configured → model_model.
+    await expect(
+      page
+        .getByTestId("model_model")
+        .or(page.getByRole("button", { name: "Setup Provider" })),
+    ).toBeVisible({ timeout: 30000 });
+
+    // OpenAI gpt-4o-mini (setupOpenAI's default) is vision-capable, so the
+    // multimodal assertion below holds. OpenAI is used (not Anthropic) so the
+    // test actually runs in the weekly workflow, which provides OPENAI_API_KEY.
+    await setupOpenAI(page);
 
     await page.getByTestId("playground-btn-flow-io").click();
-
-    // Read the image file as a binary string
-    const filePath = "tests/assets/chain.png";
-    const fileContent = readFileSync(filePath, "base64");
-
-    // Create the DataTransfer and File objects within the browser context
-    const dataTransfer = await page.evaluateHandle(
-      ({ fileContent }) => {
-        const dt = new DataTransfer();
-        const byteCharacters = atob(fileContent);
-        const byteNumbers = new Array(byteCharacters.length);
-        for (let i = 0; i < byteCharacters.length; i++) {
-          byteNumbers[i] = byteCharacters.charCodeAt(i);
-        }
-        const byteArray = new Uint8Array(byteNumbers);
-        const file = new File([byteArray], "chain.png", { type: "image/png" });
-        dt.items.add(file);
-        return dt;
-      },
-      { fileContent },
-    );
 
     await page.waitForSelector('[data-testid="input-chat-playground"]', {
       timeout: 100000,
     });
 
-    // Locate the target element
-    const element = await page.getByTestId("input-chat-playground");
+    // Attach the image via the Playground file input. The manual DataTransfer
+    // drop the test used before no longer renders the attachment on Langflow
+    // 1.10.0; setInputFiles matches the working playground attachment specs.
+    await page
+      .locator('[data-testid="input-wrapper"] input[type="file"]')
+      .setInputFiles("tests/assets/media/chain.png");
 
-    // Dispatch the drop event on the target element
-    await element.dispatchEvent("drop", { dataTransfer });
+    // Confirm the image attached before sending. The attachment renders as an
+    // <img alt="chain.png"> preview, not as literal "chain.png" text.
+    await expect(page.locator('img[alt="chain.png"]').first()).toBeVisible({
+      timeout: 30000,
+    });
 
-    await page.getByTestId("input-chat-playground").fill("what is this image?");
+    // Langflow 1.10.0 pre-fills a sample prompt ("Hello, how are you?") into
+    // the chat input shortly after the playground mounts, and the send action
+    // reads the component's internal state — not the raw textarea value — so a
+    // programmatic .fill() is ignored and the default prompt is sent instead
+    // (the model then never sees our question). Wait for the default to settle,
+    // then clear and type with real keystrokes so the component's onChange runs.
+    const chatInput = page.getByTestId("input-chat-playground");
+    await chatInput.click();
+    await expect(chatInput).not.toHaveValue("", { timeout: 10000 }).catch(() => {});
+    await chatInput.press("ControlOrMeta+a");
+    await chatInput.press("Delete");
+    await chatInput.pressSequentially("what is this image?");
+    await expect(chatInput).toHaveValue("what is this image?");
 
     await page.waitForSelector('[data-testid="button-send"]', {
       timeout: 100000,
     });
 
     await page.getByTestId("button-send").click();
-
-    await page.waitForSelector("text=chain.png", { timeout: 30000 });
-
-    await page.getByText("chain.png").isVisible();
 
     await page.waitForTimeout(5000);
 
@@ -76,8 +82,12 @@ test(
       .last()
       .textContent();
 
+    // The regex above is the real signal that the model saw and described the
+    // image. The length check is a secondary guard against a one-word answer;
+    // keep it modest since gpt-4o-mini replies are terser than the Anthropic
+    // model this test was originally calibrated for.
     expect(textFromLlm?.toLowerCase()).toMatch(/(chain|inkscape|logo)/);
     const lengthOfTextFromLlm = textFromLlm?.length;
-    expect(lengthOfTextFromLlm).toBeGreaterThan(100);
+    expect(lengthOfTextFromLlm).toBeGreaterThan(50);
   },
 );

--- a/tests/tests-automations/regression/core-functionality/llm-agents/general-bugs-agent-images-playground.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/general-bugs-agent-images-playground.spec.ts
@@ -75,19 +75,18 @@ test(
 
     await page.getByTestId("button-send").click();
 
-    await page.waitForTimeout(5000);
+    // Wait for the streamed response to actually describe the image instead of
+    // sleeping a fixed interval: toContainText retries until the markdown
+    // renders, adapting to however long the model takes. This regex is the real
+    // signal that the model saw and described the image.
+    const llmResponse = page.locator(".markdown.prose").last();
+    await expect(llmResponse).toContainText(/chain|inkscape|logo/i, {
+      timeout: 60000,
+    });
 
-    const textFromLlm = await page
-      .locator(".markdown.prose")
-      .last()
-      .textContent();
-
-    // The regex above is the real signal that the model saw and described the
-    // image. The length check is a secondary guard against a one-word answer;
-    // keep it modest since gpt-4o-mini replies are terser than the Anthropic
-    // model this test was originally calibrated for.
-    expect(textFromLlm?.toLowerCase()).toMatch(/(chain|inkscape|logo)/);
-    const lengthOfTextFromLlm = textFromLlm?.length;
-    expect(lengthOfTextFromLlm).toBeGreaterThan(50);
+    // Secondary guard against a one-word answer; kept modest since gpt-4o-mini
+    // replies are terser than the Anthropic model this test was first calibrated for.
+    const textFromLlm = await llmResponse.textContent();
+    expect(textFromLlm?.length).toBeGreaterThan(50);
   },
 );


### PR DESCRIPTION
## Summary

`general-bugs-agent-images-playground.spec.ts` referenced two testids removed from the Agent component in Langflow 1.10.x:

- `value-dropdown-dropdown_str_agent_llm` — the in-component provider dropdown (gone)
- `popover-anchor-input-api_key` — the inline API-key popover (gone)

Provider configuration in 1.10.x is centralized via the `model_model` dropdown → `manage-model-providers`. The stale block is replaced with the project's provider setup helper, and the test was repaired for several other 1.10.0 breakages along the way.

The spec was **not** `@stable`, so the breakage went unnoticed (it does not run in the weekly). It was found during the selector audit for #186. This PR re-establishes `@stable` so the test runs weekly and any future selector breakage opens an issue automatically.

## Provider: OpenAI vision (not Anthropic)

The test uses **`setupOpenAI`** with the default **`gpt-4o-mini`** (a vision-capable model), not Anthropic. Rationale: the weekly workflow provides `OPENAI_API_KEY`, so an OpenAI-based test actually **runs** in CI; an Anthropic-based one would be skipped there. The multimodal assertion (the model describing `chain.png`) holds for `gpt-4o-mini`.

## 1.10.0 repairs beyond the testids

- **Provider entry point race** — wait for `model_model` (configured) **or** the `Setup Provider` button (unconfigured) before running `setupOpenAI`, so it doesn't no-op against a still-loading canvas.
- **Image attachment** — manual `DataTransfer` drop no longer renders the attachment on 1.10.0; switched to `setInputFiles` (matches the working playground attachment specs) and assert the `<img alt="chain.png">` preview.
- **Pre-filled prompt** — 1.10.0 pre-fills a sample prompt and the send action reads the component's internal state, so a programmatic `.fill()` is ignored; clear and `pressSequentially` with real keystrokes.
- **Response wait** — replaced a fixed `waitForTimeout(5000)` after send with a web-first `toContainText(/chain|inkscape|logo/i)` on the response markdown, so the assertion adapts to the model's latency.

## Dependency

The end-to-end run was blocked by a broken `llm-toggle` locator in `setup-openai.ts`. That is fixed by **#330** (`scope llm-toggle locator to visible elements only`, merged). This branch now includes that fix (via `main`), which unblocks the E2E.

## Validation

- `npm run typecheck` ✅
- `npm run lint` ✅ (0 errors)
- Full end-to-end run on a live Langflow **1.10.0** instance with image send → **passing** (`1 passed`), with `OPENAI_API_KEY` from `.env`.
- DOM verification: old testids absent; new path `model_model` → `manage-model-providers` → present.

## Changes

- `tests/.../general-bugs-agent-images-playground.spec.ts` — centralized provider path via `setupOpenAI`; 1.10.0 repairs above; re-add `@stable`
- `docs/.../general-bugs-agent-images-playground.md` — spec doc

Closes #312
