### PR TITLE
test(observability): restore @stable on 4 traces-* specs (closes #337)

### DIFF
--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-delete.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-delete.spec.ts
@@ -141,7 +141,7 @@ test.describe("Bulk delete traces — seeded flow", () => {
 
   test(
     "DELETE /api/v1/monitor/traces?flow_id=... clears all traces, and a second DELETE on the empty owned flow still returns 204",
-    { tag: ["@release", "@api", "@regression", "@observability"] },
+    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       // Anchor: the seeded flow MUST have traces before DELETE. Without this,
       // a post-DELETE empty envelope could come from a degraded GET (the

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-single.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-single.spec.ts
@@ -153,7 +153,7 @@ test.describe("Single trace shape — seeded flow", () => {
 
   test(
     "GET /api/v1/monitor/traces/{trace_id} returns the full TraceRead contract with a non-empty span tree",
-    { tag: ["@release", "@api", "@regression", "@observability"] },
+    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       const res = await request.get(`/api/v1/monitor/traces/${traceId}`, {
         headers: { Authorization: bearerToken },

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-latency-tokens.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-latency-tokens.spec.ts
@@ -94,7 +94,7 @@ test.describe("Flow Activity / Traces — latency and tokens", () => {
   test(
     "GET /api/v1/monitor/traces returns totalLatencyMs and totalTokens for a flow run",
     {
-      tag: ["@release", "@api", "@regression", "@observability"],
+      tag: ["@stable", "@release", "@api", "@regression", "@observability"],
     },
     async ({ request }) => {
       const res = await request.get(

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-list-filters.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-list-filters.spec.ts
@@ -183,7 +183,7 @@ test.describe("Trace list filters — status / start_time / query / session_id",
 
   test(
     "GET /api/v1/monitor/traces?status=error returns only the failing trace; rejects unknown values",
-    { tag: ["@release", "@api", "@regression", "@observability"] },
+    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       const matchRes = await request.get(
         `/api/v1/monitor/traces?flow_id=${errorFlowId}&status=error`,


### PR DESCRIPTION
## Summary

Restores `@stable` on the 4 `traces-*` specs whose tag was removed in #328 as a precautionary CI-noise mitigation during the #326 weekly cluster.

The original triage assumed they were broken by the upstream `LanguageModelComponent` null-default. Re-validation against Langflow `1.10.0` nightly shows they are **not** broken — they use direct API fixtures (`basic-prompting-trace-fixture.json`, `chat-io-ok-trace-fixture.json`), tolerate `status=error` traces (they verify trace shape, not flow success), and never touch the Language Model component nor the bootstrap path that breaks the other specs.

## Specs restored (4)

- `traces-delete.spec.ts:142`
- `traces-detail-single.spec.ts:154`
- `traces-latency-tokens.spec.ts:94`
- `traces-list-filters.spec.ts:184`

## Validation

The open question in #337 was whether their original weekly failure was CI parallelism noise rather than a defect. Re-validated under CI-like load:

- `--workers=2 --retries=0`, **two consecutive rounds**, all 12 tests in the 4 files passed (~14s each round) against Langflow `1.10.0` nightly
- `npm run typecheck` — passes
- `npm run lint` — 0 errors (pre-existing warnings only)
- No `🚨 Backend Error` in the run output

Diff is surgical: 4 lines, each adding `@stable` to the front of an existing tag array. No test logic changed.

## Notes

- Per CONTRIBUTING.md "@stable lifecycle", the spec docs are not updated during this cycle — the issue and PR are the traceability record.
- The `QA-CHECKLIST.md` Phase 0 / Coverage Note regenerate automatically on merge (`update-coverage-summary.yml`); no manual edit here.

Closes #337
