### PR TITLE
fix(bootstrap): handle 1.10.0 FlowBuilderWelcome overlay in New Flow path (closes #336)

### DIFF
--- a/tests/helpers/flows/add-flow-to-test-on-empty-langflow.ts
+++ b/tests/helpers/flows/add-flow-to-test-on-empty-langflow.ts
@@ -2,6 +2,22 @@ import type { Page } from "@playwright/test";
 
 export const addFlowToTestOnEmptyLangflow = async (page: Page) => {
   await page.getByTestId("new_project_btn_empty_page").click();
+
+  // Langflow 1.10.0: the empty-page CTA usually opens the templates modal
+  // directly, but a fresh instance can race the FlowBuilderWelcome overlay
+  // instead. Wait for whichever mounts; if the overlay surfaces, dismiss it
+  // via "Browse more templates" to reach the templates modal.
+  const modalSelector = '[data-testid="modal-title"]';
+  const welcomeSelector = '[data-testid="flow-builder-welcome-panel"]';
+  await Promise.race([
+    page.waitForSelector(modalSelector, { timeout: 30000 }),
+    page.waitForSelector(welcomeSelector, { timeout: 30000 }),
+  ]);
+  if ((await page.locator(welcomeSelector).count()) > 0) {
+    await page.getByTestId("flow-builder-welcome-browse-more").click();
+    await page.waitForSelector(modalSelector, { timeout: 30000 });
+  }
+
   await page.getByTestId("side_nav_options_all-templates").click();
   await page.getByRole("heading", { name: "Basic Prompting" }).click();
   await page.getByTestId("icon-ChevronLeft").click();

--- a/tests/helpers/flows/add-flow-to-test-on-empty-langflow.ts
+++ b/tests/helpers/flows/add-flow-to-test-on-empty-langflow.ts
@@ -1,22 +1,13 @@
 import type { Page } from "@playwright/test";
+import { dismissWelcomeOverlayAndWaitForModal } from "./open-new-flow-templates-modal";
 
 export const addFlowToTestOnEmptyLangflow = async (page: Page) => {
   await page.getByTestId("new_project_btn_empty_page").click();
 
-  // Langflow 1.10.0: the empty-page CTA usually opens the templates modal
-  // directly, but a fresh instance can race the FlowBuilderWelcome overlay
-  // instead. Wait for whichever mounts; if the overlay surfaces, dismiss it
-  // via "Browse more templates" to reach the templates modal.
-  const modalSelector = '[data-testid="modal-title"]';
-  const welcomeSelector = '[data-testid="flow-builder-welcome-panel"]';
-  await Promise.race([
-    page.waitForSelector(modalSelector, { timeout: 30000 }),
-    page.waitForSelector(welcomeSelector, { timeout: 30000 }),
-  ]);
-  if ((await page.locator(welcomeSelector).count()) > 0) {
-    await page.getByTestId("flow-builder-welcome-browse-more").click();
-    await page.waitForSelector(modalSelector, { timeout: 30000 });
-  }
+  // The empty-page CTA usually opens the templates modal directly, but on a
+  // fresh Langflow 1.10.0 instance it can surface the FlowBuilderWelcome
+  // overlay first — reconcile both via the shared helper.
+  await dismissWelcomeOverlayAndWaitForModal(page);
 
   await page.getByTestId("side_nav_options_all-templates").click();
   await page.getByRole("heading", { name: "Basic Prompting" }).click();

--- a/tests/helpers/flows/open-new-flow-templates-modal.ts
+++ b/tests/helpers/flows/open-new-flow-templates-modal.ts
@@ -1,31 +1,42 @@
 import type { Page } from "@playwright/test";
 
+const WELCOME_PANEL = '[data-testid="flow-builder-welcome-panel"]';
+const MODAL_TITLE = '[data-testid="modal-title"]';
+
 /**
- * Clicks the "New Flow" button (`new-project-btn`) and lands on the templates
- * modal.
+ * After an action that should open the templates modal (the header "New Flow"
+ * button or the empty-page CTA), reconcile the Langflow 1.10.0
+ * `FlowBuilderWelcome` overlay: those entry points may navigate to a
+ * freshly-created flow and surface the welcome overlay instead of the modal.
  *
- * Langflow 1.10.0 changed this button: instead of opening the templates modal
- * directly, it creates a fresh empty flow and surfaces the FlowBuilderWelcome
- * overlay. Race the overlay against the modal; if the overlay surfaces, dismiss
- * it via "Browse more templates" to reach the templates modal. On older builds
- * (or the empty-page CTA path) the modal opens directly and the overlay branch
- * is skipped — so this is backward-compatible.
+ * Race the overlay against the modal; if the overlay surfaces, dismiss it via
+ * "Browse more templates", then wait for the modal. When the modal opens
+ * directly (older builds, or the empty-page CTA) the overlay branch is skipped
+ * — so this is backward-compatible. Shared between the two entry points so the
+ * selector/timeout logic can't drift.
+ */
+export const dismissWelcomeOverlayAndWaitForModal = async (page: Page) => {
+  await Promise.race([
+    page.waitForSelector(WELCOME_PANEL, { timeout: 30000 }),
+    page.waitForSelector(MODAL_TITLE, { timeout: 30000 }),
+  ]);
+
+  if ((await page.locator(WELCOME_PANEL).count()) > 0) {
+    await page.getByTestId("flow-builder-welcome-browse-more").click();
+  }
+
+  await page.waitForSelector(MODAL_TITLE, { timeout: 30000 });
+};
+
+/**
+ * Clicks the header "New Flow" button (`new-project-btn`) and lands on the
+ * templates modal, handling the 1.10.0 welcome overlay (see
+ * `dismissWelcomeOverlayAndWaitForModal`).
  *
  * Single source of truth for the "New Flow → templates modal" flow, used by
  * `awaitBootstrapTest` and any spec that opens the modal mid-test.
  */
 export const openNewFlowTemplatesModal = async (page: Page) => {
   await page.getByTestId("new-project-btn").click();
-
-  const welcomeSelector = '[data-testid="flow-builder-welcome-panel"]';
-  await Promise.race([
-    page.waitForSelector(welcomeSelector, { timeout: 30000 }),
-    page.waitForSelector('[data-testid="modal-title"]', { timeout: 30000 }),
-  ]);
-
-  if ((await page.locator(welcomeSelector).count()) > 0) {
-    await page.getByTestId("flow-builder-welcome-browse-more").click();
-  }
-
-  await page.waitForSelector('[data-testid="modal-title"]', { timeout: 30000 });
+  await dismissWelcomeOverlayAndWaitForModal(page);
 };

--- a/tests/helpers/flows/open-new-flow-templates-modal.ts
+++ b/tests/helpers/flows/open-new-flow-templates-modal.ts
@@ -1,0 +1,31 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Clicks the "New Flow" button (`new-project-btn`) and lands on the templates
+ * modal.
+ *
+ * Langflow 1.10.0 changed this button: instead of opening the templates modal
+ * directly, it creates a fresh empty flow and surfaces the FlowBuilderWelcome
+ * overlay. Race the overlay against the modal; if the overlay surfaces, dismiss
+ * it via "Browse more templates" to reach the templates modal. On older builds
+ * (or the empty-page CTA path) the modal opens directly and the overlay branch
+ * is skipped — so this is backward-compatible.
+ *
+ * Single source of truth for the "New Flow → templates modal" flow, used by
+ * `awaitBootstrapTest` and any spec that opens the modal mid-test.
+ */
+export const openNewFlowTemplatesModal = async (page: Page) => {
+  await page.getByTestId("new-project-btn").click();
+
+  const welcomeSelector = '[data-testid="flow-builder-welcome-panel"]';
+  await Promise.race([
+    page.waitForSelector(welcomeSelector, { timeout: 30000 }),
+    page.waitForSelector('[data-testid="modal-title"]', { timeout: 30000 }),
+  ]);
+
+  if ((await page.locator(welcomeSelector).count()) > 0) {
+    await page.getByTestId("flow-builder-welcome-browse-more").click();
+  }
+
+  await page.waitForSelector('[data-testid="modal-title"]', { timeout: 30000 });
+};

--- a/tests/helpers/other/await-bootstrap-test.ts
+++ b/tests/helpers/other/await-bootstrap-test.ts
@@ -53,7 +53,14 @@ export const awaitBootstrapTest = async (
             `Failed to open modal after ${maxAttempts} attempts: ${error}`,
           );
         }
-        // Wait a bit before retrying
+        // openNewFlowTemplatesModal clicks "New Flow", which on 1.10.0
+        // navigates to a freshly-created flow. Return home before retrying so
+        // new-project-btn is present again — otherwise the retry clicks into
+        // the canvas and times out.
+        await page.goto("/");
+        await page.waitForSelector('[id="new-project-btn"]', {
+          timeout: 30000,
+        });
         await page.waitForTimeout(1000);
       }
     }

--- a/tests/helpers/other/await-bootstrap-test.ts
+++ b/tests/helpers/other/await-bootstrap-test.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { addFlowToTestOnEmptyLangflow } from "../flows/add-flow-to-test-on-empty-langflow";
+import { openNewFlowTemplatesModal } from "../flows/open-new-flow-templates-modal";
 
 export const awaitBootstrapTest = async (
   page: Page,
@@ -44,10 +45,7 @@ export const awaitBootstrapTest = async (
     while (modalCount === 0 && attempts < maxAttempts) {
       attempts++;
       try {
-        await page.getByTestId("new-project-btn").click();
-        await page.waitForSelector('[data-testid="modal-title"]', {
-          timeout: 5000,
-        });
+        await openNewFlowTemplatesModal(page);
         modalCount = await page.getByTestId("modal-title")?.count();
       } catch (error) {
         if (attempts >= maxAttempts) {

--- a/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
@@ -147,7 +147,7 @@ test.describe("Playground Output – Structured Data", () => {
 
   test(
     "playground must render DataFrame output as a markdown table",
-    { tag: ["@release", "@regression", "@playground"] },
+    { tag: ["@stable", "@release", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step(
         "Set up Mock Data (dataframe_output) → Chat Output flow and open playground",

--- a/tests/tests-automations/regression/core-functionality/playground/playground-output-image.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-output-image.spec.ts
@@ -54,7 +54,7 @@ test.describe("Playground Output – Image Upload (ID B0c)", () => {
 
   test(
     "playground must display uploaded image in user message after sending",
-    { tag: ["@regression", "@playground"] },
+    { tag: ["@stable", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step(
         "Set up ChatInput → ChatOutput echo flow and open playground",

--- a/tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { openNewFlowTemplatesModal } from "../../../../helpers/flows/open-new-flow-templates-modal";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 
 test(
@@ -38,7 +39,7 @@ test(
       await page.getByTestId("icon-ChevronLeft").first().click();
 
       await expect(page.getByText("Projects").first()).toBeVisible({ timeout: 10000 });
-      await page.getByTestId("new-project-btn").click();
+      await openNewFlowTemplatesModal(page);
       await page.getByTestId("side_nav_options_all-templates").click();
       await page.getByRole("heading", { name: "Document Q&A" }).click();
       await captureFlowIdFromUrl();
@@ -48,7 +49,7 @@ test(
       await page.getByTestId("icon-ChevronLeft").first().click();
 
       await expect(page.getByText("Projects").first()).toBeVisible({ timeout: 10000 });
-      await page.getByTestId("new-project-btn").click();
+      await openNewFlowTemplatesModal(page);
       await page.getByTestId("side_nav_options_all-templates").click();
       await page.getByRole("heading", { name: "Basic Prompting" }).click();
       await captureFlowIdFromUrl();


### PR DESCRIPTION
## Summary

Fixes the Langflow `1.10.0` bootstrap regression behind issue #336. The header **"New Flow"** button (`new-project-btn`) and the empty-page CTA no longer open the templates modal directly — they navigate to a freshly-created flow and surface the `FlowBuilderWelcome` overlay. Every call site that clicks `new-project-btn` expecting a `modal-title` modal broke.

This hit the **shared `awaitBootstrapTest` helper** (used by 145 specs, ~25 of them `@stable`) on both its paths.

## Changes

- **New helper `openNewFlowTemplatesModal`** — single source of truth (mirrors upstream `openTemplatesModal`): click `new-project-btn` → race the welcome overlay against the modal → dismiss via `flow-builder-welcome-browse-more` if it surfaces → wait for the modal. Backward-compatible (overlay branch skipped when the modal opens directly).
- `awaitBootstrapTest` modal loop → uses the helper.
- `addFlowToTestOnEmptyLangflow` → same overlay handling after the empty-page CTA.
- `bulk-actions.spec.ts` (inline `new-project-btn`, `@stable`) → migrated to the helper.
- **Restored `@stable`** on `playground-output-data:148` and `playground-output-image:55`.

## Blast radius

The helper fix also un-breaks the other ~25 `@stable` specs that use the modal-loop path — they keep their tag and simply go green again on 1.10.0. Change is additive/backward-compatible.

## Validation (Langflow 1.10.0 nightly, `--retries=0`)

- `playground-output-data` (2), `playground-output-image` (2), `bulk-actions`, `duplicate-flow`, `edit-flow-name` — all pass (modal-loop path)
- Empty-page path validated: a 0-flow `run-flow` run now clears bootstrap (it fails later for an unrelated reason — #340)
- `npm run typecheck` — passes
- `npm run lint` — 0 errors

## Split out of the original cluster

- #340 — `run-flow`: clears bootstrap with this fix but fails at line 130 (Run Flow component sub-flow selection), a distinct deterministic 1.10.0 issue. `@stable` restored there.
- #341 — cleanup: 4 non-`@stable` specs with the same inline `new-project-btn` pattern.

Closes #336
