### PR TITLE
ci(weekly): run inside official Playwright image to bypass GCS browser download

### DIFF
--- a/.github/workflows/weekly-stable.yml
+++ b/.github/workflows/weekly-stable.yml
@@ -83,6 +83,9 @@ jobs:
       # so forward localhost:7860 -> langflow:7860 and keep PLAYWRIGHT_BASE_URL
       # on http://localhost:7860 — exactly as on ubuntu-latest. See issue #346.
       - name: Forward localhost:7860 to the Langflow service
+        # Force bash: inside the container the default shell is `sh` (dash),
+        # which lacks the `disown` builtin used below.
+        shell: bash
         run: |
           apt-get update -qq && apt-get install -y -qq socat
           nohup socat TCP-LISTEN:7860,fork,reuseaddr TCP:langflow:7860 >/tmp/socat.log 2>&1 &

--- a/.github/workflows/weekly-stable.yml
+++ b/.github/workflows/weekly-stable.yml
@@ -21,6 +21,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
 
+    # Run inside the official Playwright image: Chromium + all OS deps are
+    # pre-installed and pulled from mcr.microsoft.com (reachable from the
+    # runners), so we no longer download the browser from Google Cloud Storage
+    # — the leg that the runners cannot complete (see issue #346). The tag MUST
+    # match the pinned @playwright/test version in package.json.
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
+
     services:
       langflow:
         image: langflowai/langflow-nightly:${{ inputs.langflow_image_tag || 'latest' }}
@@ -49,22 +57,23 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Playwright browsers
-        uses: ./.github/actions/setup-playwright
+      # No "Install Playwright browsers" step: Chromium ships in the container
+      # image. npm ci still installs the @playwright/test runner, whose version
+      # is pinned to match the image tag so the browser revision lines up.
 
       - name: Collect models
         run: npx playwright test tests/collect-models.spec.ts --reporter=line
         continue-on-error: true
         env:
           CI: "true"
-          PLAYWRIGHT_BASE_URL: "http://localhost:7860/"
+          PLAYWRIGHT_BASE_URL: "http://langflow:7860/"
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Run @stable tests
         run: npx playwright test --grep "@stable" --pass-with-no-tests --reporter=html,github,json
         env:
           CI: "true"
-          PLAYWRIGHT_BASE_URL: "http://localhost:7860/"
+          PLAYWRIGHT_BASE_URL: "http://langflow:7860/"
           PLAYWRIGHT_JSON_OUTPUT_NAME: results.json
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 

--- a/.github/workflows/weekly-stable.yml
+++ b/.github/workflows/weekly-stable.yml
@@ -76,19 +76,41 @@ jobs:
       # pinned to EXACTLY 1.58.2 in package.json to match the image tag above,
       # so the browser revision lines up. Bump both together when upgrading.
 
+      # The async Clipboard API (and other secure-context-gated browser APIs)
+      # only exist on a secure context. Chromium treats http://localhost as
+      # secure but NOT the service hostname http://langflow. Inside a job
+      # container the Langflow service is only reachable as http://langflow:7860,
+      # so forward localhost:7860 -> langflow:7860 and keep PLAYWRIGHT_BASE_URL
+      # on http://localhost:7860 — exactly as on ubuntu-latest. See issue #346.
+      - name: Forward localhost:7860 to the Langflow service
+        run: |
+          apt-get update -qq && apt-get install -y -qq socat
+          nohup socat TCP-LISTEN:7860,fork,reuseaddr TCP:langflow:7860 >/tmp/socat.log 2>&1 &
+          disown
+          for i in $(seq 1 15); do
+            if curl -sf http://localhost:7860/health_check >/dev/null 2>&1; then
+              echo "Forward localhost:7860 -> langflow:7860 is up."
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Port forward to langflow:7860 did not come up"
+          cat /tmp/socat.log || true
+          exit 1
+
       - name: Collect models
         run: npx playwright test tests/collect-models.spec.ts --reporter=line
         continue-on-error: true
         env:
           CI: "true"
-          PLAYWRIGHT_BASE_URL: "http://langflow:7860/"
+          PLAYWRIGHT_BASE_URL: "http://localhost:7860/"
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
       - name: Run @stable tests
         run: npx playwright test --grep "@stable" --pass-with-no-tests --reporter=html,github,json
         env:
           CI: "true"
-          PLAYWRIGHT_BASE_URL: "http://langflow:7860/"
+          PLAYWRIGHT_BASE_URL: "http://localhost:7860/"
           PLAYWRIGHT_JSON_OUTPUT_NAME: results.json
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 

--- a/.github/workflows/weekly-stable.yml
+++ b/.github/workflows/weekly-stable.yml
@@ -49,17 +49,32 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "24"
-          cache: "npm"
-
+      # No actions/setup-node: the Playwright image already ships the Node
+      # toolchain it was built against, so we use it directly instead of
+      # layering a second Node on top.
       - name: Install dependencies
         run: npm ci
 
+      # Guard: the @playwright/test version (from npm) MUST equal the container
+      # image tag, or the runner looks for a browser revision the image doesn't
+      # ship and every test fails at launch with a cryptic error. Fail fast with
+      # a clear message instead. Keep PLAYWRIGHT_VERSION in sync with the
+      # container: image tag above.
+      - name: Verify Playwright version matches the container image
+        env:
+          PLAYWRIGHT_VERSION: "1.58.2"
+        run: |
+          NPM_VERSION="$(node -p "require('@playwright/test/package.json').version")"
+          if [ "$NPM_VERSION" != "$PLAYWRIGHT_VERSION" ]; then
+            echo "::error::@playwright/test is $NPM_VERSION but the job runs in mcr.microsoft.com/playwright:v$PLAYWRIGHT_VERSION. Bump the container image tag and package.json together."
+            exit 1
+          fi
+          echo "Playwright $NPM_VERSION matches the container image v$PLAYWRIGHT_VERSION."
+
       # No "Install Playwright browsers" step: Chromium ships in the container
-      # image. npm ci still installs the @playwright/test runner, whose version
-      # is pinned to match the image tag so the browser revision lines up.
+      # image. npm ci installs the @playwright/test runner, whose version is
+      # pinned to EXACTLY 1.58.2 in package.json to match the image tag above,
+      # so the browser revision lines up. Bump both together when upgrading.
 
       - name: Collect models
         run: npx playwright test tests/collect-models.spec.ts --reporter=line

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,11 @@
         "dotenv": "^16.4.5"
       },
       "devDependencies": {
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "1.58.2",
         "@types/node": "^25.5.0",
         "eslint": "^10.1.0",
         "eslint-plugin-playwright": "^2.10.1",
-        "playwright": "^1.57.0",
+        "playwright": "1.58.2",
         "ts-node": "^10.9.2",
         "typescript": "^5.4.5",
         "typescript-eslint": "^8.57.2"

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
     "dotenv": "^16.4.5"
   },
   "devDependencies": {
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "1.58.2",
     "@types/node": "^25.5.0",
     "eslint": "^10.1.0",
     "eslint-plugin-playwright": "^2.10.1",
-    "playwright": "^1.57.0",
+    "playwright": "1.58.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5",
     "typescript-eslint": "^8.57.2"


### PR DESCRIPTION
## Why

Follow-up to #344 / PR #345. The timeout+retry hardening works exactly as designed — it now **fails fast (~17 min)** with clear warnings instead of hanging the full 90 min — but it cannot make the download succeed. The real problem is infra:

- `cdn.playwright.dev` returns a **307 redirect** to **Google Cloud Storage** (`storage.googleapis.com/chrome-for-testing-public/...`).
- From the public internet that chain is healthy (HEAD 200, ~3 MB/s).
- On the runners, `apt` downloads fine (`Fetched 21.1 MB in 0s (45.7 MB/s)`), but the **browser download from GCS stalls at zero progress on all 3 attempts** ([run 26784289589](https://github.com/oriontech-me/langflow-e2e/actions/runs/26784289589)).

So the failing leg is runner→Google Cloud Storage, not the test code. Possibly correlated with the private→public switch (separate runner pools / egress), unproven.

## Fix

Run the job inside the official Playwright image **`mcr.microsoft.com/playwright:v1.58.2-noble`** — Chromium + OS deps pre-installed, pulled from the Microsoft/Azure registry (reachable from the runners). No GCS download at all. The tag matches the pinned `@playwright/test` version (1.58.2), so the browser revision lines up. The `Install Playwright browsers` step is dropped (browser is in the image).

**Knock-on change:** inside a job container the Langflow service is reached by its service hostname, so `PLAYWRIGHT_BASE_URL` changes `http://localhost:7860/` → `http://langflow:7860/`.

## Static review done

- `playwright.config.ts` honors `PLAYWRIGHT_BASE_URL` (env wins over the `localhost` fallback); no `webServer` block.
- No test hardcodes `localhost:7860` — the only reference (`mcp-server.spec.ts`) reads the env var with localhost merely as a fallback. The Python `localhost` refs belong to `migration-test`, untouched here.
- The networking change (`langflow:7860`) is the one thing only a live run can confirm — hence this PR is **weekly-stable only**.

## Rollout

1. **This PR:** `weekly-stable.yml` only → validate live.
2. **Follow-up:** apply the proven pattern to `nightly`, `manual` (both jobs), `adaptive-impacted`. `migration-test` (Python, unpinned) tracked separately. The `setup-playwright` composite action stays until those are migrated.

Closes #346