### PR TITLE
test(core-components): Show Legacy Components toggle spec + helper improvement

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -142,7 +142,7 @@
 - [-] Outdated component notification
 - [-] Update component action
 - [ ] Update with breaking change — should alert user
-- [ ] Legacy component visible via configuration
+- [x] Legacy component visible via configuration → `core-components/legacy-components-toggle-regression.spec.ts`
 - [x] Re-saving code removes handles from previously-toggled advanced fields → `core-components/general-bugs-delete-handle-advanced-input.spec.ts`
 
 #### 2.4 Code Editing

--- a/docs/core-components/legacy-components-toggle-regression.md
+++ b/docs/core-components/legacy-components-toggle-regression.md
@@ -24,9 +24,15 @@ The behaviour is proven by a **count transition**, in a single `test()` with fou
 
 1. **Open a blank flow** (Arrange).
 2. **Baseline (toggle OFF):** searching `"Python REPL"` yields `toHaveCount(0)` —
-   the legacy component is not rendered. The search narrows the list so the `0`
-   is a strong statement ("asked for it by name, absent"), not a side effect of
-   list virtualization.
+   the legacy component is not rendered. A **positive control** runs first: the
+   non-legacy substitute **Python Interpreter** (`utilitiesPython Interpreter`)
+   always matches this search — its internal name is `PythonREPLComponent`, so
+   the sidebar surfaces it even when searching `"Python REPL"` — and asserting it
+   `toBeVisible()` proves the list actually rendered before the `0` is asserted.
+   Without it, `toHaveCount(0)` could resolve against a momentarily empty list
+   (filter not yet applied) and pass for the wrong reason. The search narrows the
+   list so the `0` is a strong statement ("asked for it by name, absent"), not a
+   side effect of list virtualization.
 3. **Act:** enable the toggle via the `addLegacyComponents(page)` helper (the
    search is cleared first, because an active search renders a second
    `sidebar-options-trigger` that would trip Playwright strict mode).
@@ -48,6 +54,7 @@ the assertion changes result if and only if the behaviour changes.
 
 | State | Locator | Expected |
 |---|---|---|
+| Toggle OFF (positive control) | `getByTestId("utilitiesPython Interpreter")` after searching `"Python REPL"` | `toBeVisible()` (proves the search rendered) |
 | Toggle OFF (baseline) | `getByTestId("toolsPython REPL")` after searching `"Python REPL"` | `toHaveCount(0)` |
 | Toggle acted on | `getByTestId("sidebar-legacy-switch")` | `toBeChecked()` (asserted inside `addLegacyComponents`) |
 | Toggle ON | `getByTestId("toolsPython REPL")` after searching `"Python REPL"` | `toHaveCount(1)` |
@@ -62,6 +69,7 @@ The test passes only if the count moves from `0` to `1` across the toggle action
 - `src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/featureTogglesComponent.tsx` — owns the `sidebar-legacy-switch` toggle (Radix `Switch`, `role="switch"`/`aria-checked`).
 - `src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarHeader.tsx` — owns the `sidebar-options-trigger` button that opens the options panel.
 - Python REPL component (`display_name = "Python REPL"`, `legacy = True`, category `tools`) — the target legacy component; its `legacy` flag is what the toggle filters on.
+- Python Interpreter component (`display_name = "Python Interpreter"`, internal name `PythonREPLComponent`, `legacy = False`, category `utilities`) — the positive-control anchor; it matches a `"Python REPL"` search (via its internal name) regardless of toggle state, so its visibility proves the search rendered.
 - `tests/helpers/flows/add-legacy-components.ts` — `addLegacyComponents(page)`, the shared helper that opens the options panel, flips the legacy switch, asserts `toBeChecked()`, and closes the panel.
 
 ---
@@ -83,10 +91,12 @@ The test passes only if the count moves from `0` to `1` across the toggle action
 
 ## Notes
 
-- **Force-fail probe (validation step, pending):** temporarily flip the baseline
-  `toHaveCount(0)` to `toHaveCount(1)`, or comment out the `addLegacyComponents(page)`
-  call, to confirm the test fails at the expected step (no false positive), then
-  revert. The strongest probe is removing the Act: if the final `toHaveCount(1)`
-  still passes without toggling, the test would be meaningless.
+- **Force-fail probe (validation step, done):** commenting out the
+  `addLegacyComponents(page)` Act made the test fail exactly at the final step
+  ("Python REPL is visible while the toggle is ON", `toHaveCount(1)`) with
+  `Expected: 1 / Received: 0` — the legacy component stays hidden when the toggle
+  is never flipped. The first three steps still passed, so the failure isolates
+  to the behaviour under test: no false positive. Restoring the Act returns the
+  test to green.
 - The helper asserts the switch state via `expect(...).toBeChecked()` (semantic,
   web-first) rather than the Radix `data-state` attribute.

--- a/docs/core-components/legacy-components-toggle-regression.md
+++ b/docs/core-components/legacy-components-toggle-regression.md
@@ -1,0 +1,92 @@
+# Spec: Show Legacy Components toggle — sidebar visibility
+
+**Test file:** `tests/tests-automations/regression/core-components/legacy-components-toggle-regression.spec.ts`
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates
+
+The sidebar **Show Legacy Components** toggle (`sidebar-legacy-switch`, under the
+`sidebar-options-trigger` options panel) controls whether legacy components are
+listed in the components sidebar.
+
+The test uses **Python REPL** as its target component because it is a clean
+legacy case: `legacy = True`, category `tools`, and — crucially — its non-legacy
+substitute has a different display name (**Python Interpreter**, category
+`utilities`), so searching for `"Python REPL"` cannot accidentally match the
+replacement. The component's item testid in the sidebar is `toolsPython REPL`
+(built as `sectionName + display_name` in `sidebarDraggableComponent.tsx`).
+
+The behaviour is proven by a **count transition**, in a single `test()` with four
+`test.step()`s (state flows across steps — the same `page`):
+
+1. **Open a blank flow** (Arrange).
+2. **Baseline (toggle OFF):** searching `"Python REPL"` yields `toHaveCount(0)` —
+   the legacy component is not rendered. The search narrows the list so the `0`
+   is a strong statement ("asked for it by name, absent"), not a side effect of
+   list virtualization.
+3. **Act:** enable the toggle via the `addLegacyComponents(page)` helper (the
+   search is cleared first, because an active search renders a second
+   `sidebar-options-trigger` that would trip Playwright strict mode).
+4. **Assert (toggle ON):** the same search now yields `toHaveCount(1)`.
+
+The only thing that changes between step 2 and step 4 is the toggle acted on in
+step 3, so the `0 → 1` transition is what proves the toggle controls visibility —
+the assertion changes result if and only if the behaviour changes.
+
+---
+
+## Tags
+
+`@stable` `@regression` `@components`
+
+---
+
+## Validation criterion
+
+| State | Locator | Expected |
+|---|---|---|
+| Toggle OFF (baseline) | `getByTestId("toolsPython REPL")` after searching `"Python REPL"` | `toHaveCount(0)` |
+| Toggle acted on | `getByTestId("sidebar-legacy-switch")` | `toBeChecked()` (asserted inside `addLegacyComponents`) |
+| Toggle ON | `getByTestId("toolsPython REPL")` after searching `"Python REPL"` | `toHaveCount(1)` |
+
+The test passes only if the count moves from `0` to `1` across the toggle action.
+
+---
+
+## External dependencies
+
+- `src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarDraggableComponent.tsx` — emits the per-item testid `sectionName + display_name` (`toolsPython REPL`) consumed by the count assertions.
+- `src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/featureTogglesComponent.tsx` — owns the `sidebar-legacy-switch` toggle (Radix `Switch`, `role="switch"`/`aria-checked`).
+- `src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarHeader.tsx` — owns the `sidebar-options-trigger` button that opens the options panel.
+- Python REPL component (`display_name = "Python REPL"`, `legacy = True`, category `tools`) — the target legacy component; its `legacy` flag is what the toggle filters on.
+- `tests/helpers/flows/add-legacy-components.ts` — `addLegacyComponents(page)`, the shared helper that opens the options panel, flips the legacy switch, asserts `toBeChecked()`, and closes the panel.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- No model provider credentials required — the test only filters/searches the sidebar.
+
+---
+
+## What this test does not cover
+
+- The **Beta** toggle (`sidebar-beta-switch`) — a sibling toggle with the same mechanics; candidate for its own spec.
+- Round-trip (toggle ON → OFF re-hides the component). The `0 → 1` transition already proves the control; the reverse is a nice-to-have, not required for this checklist item.
+- Dragging the legacy component onto the canvas / executing it. Out of scope: this spec is about sidebar visibility, not component behaviour.
+
+---
+
+## Notes
+
+- **Force-fail probe (validation step, pending):** temporarily flip the baseline
+  `toHaveCount(0)` to `toHaveCount(1)`, or comment out the `addLegacyComponents(page)`
+  call, to confirm the test fails at the expected step (no false positive), then
+  revert. The strongest probe is removing the Act: if the final `toHaveCount(1)`
+  still passes without toggling, the test would be meaningless.
+- The helper asserts the switch state via `expect(...).toBeChecked()` (semantic,
+  web-first) rather than the Radix `data-state` attribute.

--- a/tests/helpers/flows/add-legacy-components.ts
+++ b/tests/helpers/flows/add-legacy-components.ts
@@ -1,14 +1,9 @@
-import { type Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
+
 
 export const addLegacyComponents = async (page: Page) => {
   await page.getByTestId("sidebar-options-trigger").click();
-  await page.getByTestId("sidebar-legacy-switch").isVisible({ timeout: 5000 });
   await page.getByTestId("sidebar-legacy-switch").click();
-  await page.waitForSelector(
-    '[data-testid="sidebar-legacy-switch"][data-state="checked"]',
-    {
-      timeout: 5000,
-    },
-  );
+  await expect(page.getByTestId("sidebar-legacy-switch")).toBeChecked();
   await page.getByTestId("sidebar-options-trigger").click();
 };

--- a/tests/tests-automations/regression/core-components/legacy-components-toggle-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/legacy-components-toggle-regression.spec.ts
@@ -16,6 +16,14 @@ test(
 
     await test.step("Python REPL is hidden while the toggle is OFF (baseline)", async () => {
       await page.getByTestId("sidebar-search-input").fill("Python REPL");
+      // Positive control: the non-legacy substitute (Python Interpreter, whose
+      // internal name is PythonREPLComponent) always matches this search, so its
+      // presence proves the sidebar actually rendered results. Asserting it
+      // first kills the "empty list resolves toHaveCount(0) before the filter
+      // applied" race — the 0 below now means "filtered out", not "not rendered".
+      await expect(
+        page.getByTestId("utilitiesPython Interpreter"),
+      ).toBeVisible();
       await expect(page.getByTestId("toolsPython REPL")).toHaveCount(0);
     });
 

--- a/tests/tests-automations/regression/core-components/legacy-components-toggle-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/legacy-components-toggle-regression.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "../../../fixtures/fixtures";
+import { addLegacyComponents } from "../../../helpers/flows/add-legacy-components";
+import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+
+test(
+  "Show Legacy Components toggle controls visibility of legacy components in the sidebar",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    await test.step("Open a blank flow", async () => {
+      await awaitBootstrapTest(page);
+      await page.getByTestId("blank-flow").click();
+      await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
+        timeout: 10000,
+      });
+    });
+
+    await test.step("Python REPL is hidden while the toggle is OFF (baseline)", async () => {
+      await page.getByTestId("sidebar-search-input").fill("Python REPL");
+      await expect(page.getByTestId("toolsPython REPL")).toHaveCount(0);
+    });
+
+    await test.step("Enable the Show Legacy Components toggle", async () => {
+      // Clear the search first: an active search renders a second
+      // 'sidebar-options-trigger', which would break Playwright strict mode.
+      await page.getByTestId("sidebar-search-input").fill("");
+      await addLegacyComponents(page);
+    });
+
+    await test.step("Python REPL is visible while the toggle is ON", async () => {
+      // Same search as the baseline; only the toggle changed — so the legacy
+      // component must now appear (count goes from 0 to 1).
+      await page.getByTestId("sidebar-search-input").fill("Python REPL");
+      await expect(page.getByTestId("toolsPython REPL")).toHaveCount(1);
+    });
+  },
+);


### PR DESCRIPTION
## What

**New spec** — `legacy-components-toggle-regression.spec.ts`
Validates that the sidebar **Show Legacy Components** toggle controls the visibility of legacy components. Target: **Python REPL** (`legacy = True`, category `tools`; no name collision with its non-legacy substitute *Python Interpreter*, which lives in `utilities`). The test proves the behaviour via the count transition **0** (toggle OFF) → **1** (toggle ON).
Tags: `@stable @regression @components`.

**Helper improvement** — `addLegacyComponents`
- Asserts the switch state with `expect(...).toBeChecked()` (semantic, web-first) instead of `waitForSelector` on the Radix `data-state` attribute.
- Drops the redundant `isVisible()` call (a non-waiting query whose result was discarded; `.click()` already auto-waits for actionability).

## Why spec + shared helper in a single PR

The helper has 6 existing consumers, but all of them are **inherited specs** (not `@stable`, not validated, not in production), so they are not a baseline worth validating against. This spec is the **first `@stable` consumer** of the helper — it validates the helper change by validating itself. `npm run typecheck` and `npm run lint` are clean (0 errors).

## Done

- [x] Forced-failure check — two force-fail probes: removing the Act fails at the ON step (`Expected 1 / Received 0`); a bogus testid fails at the new positive control. No false positives.
- [x] Spec doc under `docs/core-components/legacy-components-toggle-regression.md` (mirrors the test path).
- [x] Marked the corresponding item in `QA-CHECKLIST.md`.

## Review follow-up

- **#2 (baseline race):** fixed in `9688c21` — added a positive control (`utilitiesPython Interpreter` `toBeVisible()`) before the `toHaveCount(0)`, so the baseline runs against a rendered list.
- **#1 (helper duplicate `sidebar-options-trigger`):** out of scope here (the spec clears the search before calling the shared helper, so it never trips strict mode). Split to #351 for a header-scoped helper fix.
