### PR TITLE
ci(weekly): enable tracing so @stable traces specs can run

### DIFF
--- a/.github/workflows/weekly-stable.yml
+++ b/.github/workflows/weekly-stable.yml
@@ -38,7 +38,13 @@ jobs:
           LANGFLOW_AUTO_LOGIN: "true"
           LANGFLOW_SUPERUSER: langflow
           LANGFLOW_SUPERUSER_PASSWORD: langflow
-          LANGFLOW_DEACTIVATE_TRACING: "true"
+          # Keep tracing ON: the @stable observability/traces specs probe
+          # /api/v1/monitor/traces, which is populated by the internal native
+          # tracer. That tracer's worker never starts when tracing is
+          # deactivated, so disabling it makes those specs fail deterministically
+          # (see #352). External tracers (LangSmith/Langfuse/etc.) stay dormant
+          # here because their API keys are absent.
+          LANGFLOW_DEACTIVATE_TRACING: "false"
         options: >-
           --health-cmd "curl -f http://localhost:7860/health_check || exit 1"
           --health-interval 15s


### PR DESCRIPTION
## Why

Triage of #348 — **Group A (observability / traces)**. Four `@stable` specs fail **deterministically every weekly run**:

- `traces-delete.spec.ts:142`
- `traces-detail-single.spec.ts:154`
- `traces-latency-tokens.spec.ts:94`
- `traces-list-filters.spec.ts:184`

## Root cause (confirmed in Langflow source)

`weekly-stable.yml` set `LANGFLOW_DEACTIVATE_TRACING: "true"`. That flag disables Langflow's internal tracer:

- `services/tracing/service.py:142` → `self.deactivated = settings.deactivate_tracing`
- `service.py:155` → `_start()` early-returns when `self.deactivated`, so the trace worker never starts and the `native` tracer that persists to the monitor table never writes.

Each traces spec's `beforeAll` runs a probe flow then `expect.poll`s `/api/v1/monitor/traces` until `length > 0` (30s). With tracing off the poll can never succeed → the whole serial file fails. **Not a test bug, not a Langflow regression** — an environment config issue. The line dated back to the original weekly workflow (#68), predating the traces specs.

## Fix

Set `LANGFLOW_DEACTIVATE_TRACING: "false"` (with an explanatory comment). Safe: external tracers (LangSmith/Langfuse/etc.) only activate with their own API keys, absent here, so only the internal monitor tracer is re-enabled. Specs stay `@stable`.

## Knock-on note

`nightly.yml`, `manual.yml`, and `adaptive-impacted.yml` also set this flag. Out of scope here (this PR targets the weekly run that surfaced the failures); propagate in a follow-up if they run the traces specs.

## Validation

Static change to a CI workflow — confirmation comes from the next weekly run (or a `workflow_dispatch`) showing the four traces specs green.

Closes #352