### PR TITLE
test(llm-agents): remove @stable from agent stop button test

### DIFF
--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
@@ -250,7 +250,9 @@ for (const { label, options, skipReason } of targets) {
 
     test(
       "agent stop button must halt execution mid-run",
-      { tag: ["@stable", "@release", "@components", "@agents", "@playground"] },
+      // @stable removed: hard-fails every weekly run (deterministic). Tracked in #355;
+      // tag to be restored in the correction PR. See @stable lifecycle in CONTRIBUTING.md.
+      { tag: ["@release", "@components", "@agents", "@playground"] },
       async ({ page }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(


### PR DESCRIPTION
## Why

Group B triage of #348. The test `agent stop button must halt execution mid-run` (`agent-component-regression.spec.ts:251`) **hard-fails on every attempt in both weekly container runs** — the only deterministic non-traces failure:

| Run | Result |
|---|---|
| [26785883674](https://github.com/oriontech-me/langflow-e2e/actions/runs/26785883674) | ❌ hard fail (all retries) |
| [26792654048](https://github.com/oriontech-me/langflow-e2e/actions/runs/26792654048) | ❌ hard fail (all retries) |

Per the `@stable` lifecycle in `CONTRIBUTING.md` (**Hard failure, 2nd consecutive → remove `@stable` in a PR referencing the issue**), this Analyst-step PR removes the tag so the test stops gating the weekly run while it is diagnosed and fixed.

## What changes

Drop `@stable` from this one `test()` (the other tests in the file keep theirs). An inline comment documents the reason and the tracking issue. No behavior change to the test logic.

## Not in scope

The rest of Group B (#348) **flaked and passed on retry**, so per the lifecycle they keep `@stable` and are tracked for the next weekly: #356 (loop), #357 (edit-flow-name), #358 (prompt-template), #354 (memory session-isolation). Only the deterministic hard failure is removed here.

## Follow-up

The correction PR (Dev step) fixes the test per the 5-step validation guide, **restores `@stable`**, and closes #355. This PR intentionally does not close it.

## Validation

`npm run typecheck` and `npm run lint` pass locally (0 errors). The `Phase 0 — Validated` / Coverage Summary blocks in `QA-CHECKLIST.md` regenerate automatically on merge to `main` (`update-coverage-summary.yml`) — no manual edit here.

Refs #355
Part of #348