### PR TITLE
chore(weekly): remove @stable from 17 tests failing in run 27133642480 (triage clusters #362–#364)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -3,7 +3,7 @@
 > **Repository:** `C:/QAx/langflow-playwright/langflow-e2e`
 > **Tests:** `tests/tests-automations/regression/`
 > **Config:** `playwright.config.ts`
-> **Last updated:** 2026-06-02
+> **Last updated:** 2026-06-08
 
 ---
 
@@ -764,7 +764,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 192 `test()` calls carrying the `@stable` tag, distributed across 64 spec
+> 175 `test()` calls carrying the `@stable` tag, distributed across 58 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -813,7 +813,6 @@
 - [x] API Request component — PUT method executes PUT verb and returns 200 → `api-request-component-regression.spec.ts`
 - [x] API Request component — PATCH method executes PATCH verb and returns 200 → `api-request-component-regression.spec.ts`
 - [x] API Request component — DELETE method executes DELETE verb and returns 200 → `api-request-component-regression.spec.ts`
-- [x] API Request component — non-2xx HTTP response propagates status_code without crashing → `api-request-component-regression.spec.ts`
 - [x] API Request component — query parameters embedded in URL are sent and echoed → `api-request-component-regression.spec.ts`
 - [x] API Request component — inspector headers table accepts key + value cell entries → `api-request-component-regression.spec.ts`
 - [x] API Request component — cURL tab switches mode and field accepts a cURL command → `api-request-component-regression.spec.ts`
@@ -832,15 +831,6 @@
 - [x] Chat Input/Output — default sender_name is 'User' on input and 'AI' on output → `chat-input-output-component-regression.spec.ts`
 - [x] user can add components by hovering and clicking the plus icon → `componentHoverAdd.spec.ts`
 - [x] custom component code button should be pink when adding custom component → `customComponentAdd.spec.ts`
-- [x] the system must delete the handles from advanced fields when the code is updated → `general-bugs-delete-handle-advanced-input.spec.ts`
-- [x] If-Else routes matching input through the True branch and skips the False branch → `if-else-component-regression.spec.ts`
-- [x] If-Else routes non-matching input through the False branch and skips the True branch → `if-else-component-regression.spec.ts`
-- [x] If-Else operator=contains routes a substring match through the True branch → `if-else-component-regression.spec.ts`
-- [x] If-Else operator=regex routes a valid pattern match through the True branch → `if-else-component-regression.spec.ts`
-- [x] If-Else operator=regex hides the case_sensitive advanced field → `if-else-component-regression.spec.ts`
-- [x] If-Else case_sensitive defaults to ON — mixed-case inputs route to the False branch → `if-else-component-regression.spec.ts`
-- [x] If-Else with case_sensitive=OFF treats mixed-case inputs as a match (True branch) → `if-else-component-regression.spec.ts`
-- [x] If-Else operator=greater than routes a numeric match (10 > 5) through the True branch → `if-else-component-regression.spec.ts`
 - [x] Show Legacy Components toggle controls visibility of legacy components in the sidebar → `legacy-components-toggle-regression.spec.ts`
 - [x] Loop component — renders correctly with all handles and output inspection buttons → `loop-component-regression.spec.ts`
 - [x] Loop component — run without connections shows build failed notification → `loop-component-regression.spec.ts`
@@ -883,13 +873,9 @@
 - [x] after logout, reload must stay on login page → `logout-flow.spec.ts`
 
 #### core-functionality/llm-agents/
-- [x] agent interaction suite → `agent-component-regression.spec.ts`
 - [x] user must be able to send images in the playground with the agent component → `general-bugs-agent-images-playground.spec.ts`
 - [x] playground shows error when LLM run endpoint returns 500 (mocked invalid API key) → `llm-invalid-api-key-ui.spec.ts`
 - [x] playground input remains usable after API error (mocked) → `llm-invalid-api-key-ui.spec.ts`
-- [x] memory chatbot template loads with correct node structure → `memory-history-regression.spec.ts`
-- [x] message history context retention suite → `memory-history-regression.spec.ts`
-- [x] session isolation: new session has no context from previous session → `memory-history-regression.spec.ts`
 
 #### core-functionality/observability-monitoring/
 - [x] DELETE /api/v1/monitor/traces returns 404 for an unknown flow_id → `traces-delete.spec.ts`
@@ -910,7 +896,6 @@
 - [x] should be able to see and interact with Traces → `traces.spec.ts`
 
 #### core-functionality/playground/
-- [x] copy button copies Text Input output and toggles Check icon → `output-modal-copy-button.spec.ts`
 - [x] playground must show one compact preview per attached image when two images are attached → `playground-attachments-management.spec.ts`
 - [x] playground must keep the remaining preview when one of two attachments is removed → `playground-attachments-management.spec.ts`
 - [x] playground must render both attached images in the user message after sending → `playground-attachments-management.spec.ts`
@@ -964,12 +949,10 @@
 - [x] import flow from JSON via upload button must load flow on canvas → `export-import-flow.spec.ts`
 - [x] flow can be renamed via the header edit → `flow-rename-header.spec.ts`
 - [x] flow name persists after rename via API PATCH and GET → `flow-rename-header.spec.ts`
-- [x] user can publish a flow and access it via shareable URL, then unpublish to revoke access → `publish-flow.spec.ts`
 - [x] publish flow via API toggles access_type between PUBLIC and PRIVATE → `publish-flow.spec.ts`
 - [x] user can copy a valid Python requests snippet from the API access modal → `pythonApiGeneration.spec.ts`
 
 #### mcp/client/
-- [x] agent calls echo MCP tool and returns echoed message → `mcp-client-agent.spec.ts`
 - [x] unreachable HTTP server results in empty tool dropdown → `mcp-client-regression.spec.ts`
 - [x] configures MCP server via HTTP form tab and verifies registration → `mcp-client-regression.spec.ts`
 - [x] selects get-sum tool, provides numeric inputs, and verifies sum in output → `mcp-client-regression.spec.ts`

--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -368,7 +368,9 @@ test(
 
 test(
   "API Request component — non-2xx HTTP response propagates status_code without crashing",
-  { tag: ["@stable", "@regression", "@components"] },
+  // @stable removed: flow editor/template fails to load on the weekly nightly run. Tracked in #363;
+  // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
+  { tag: ["@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
 

--- a/tests/tests-automations/regression/core-components/general-bugs-delete-handle-advanced-input.spec.ts
+++ b/tests/tests-automations/regression/core-components/general-bugs-delete-handle-advanced-input.spec.ts
@@ -10,7 +10,9 @@ import {
 
 test(
   "the system must delete the handles from advanced fields when the code is updated",
-  { tag: ["@release", "@components", "@stable"] },
+  // @stable removed: Text Input/Output are now legacy and hidden from the sidebar (deterministic). Tracked in #362;
+  // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
+  { tag: ["@release", "@components"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 

--- a/tests/tests-automations/regression/core-components/if-else-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/if-else-component-regression.spec.ts
@@ -128,7 +128,9 @@ async function buildIfElseRoutingFlow(page: Page): Promise<void> {
 
 test(
   "If-Else routes matching input through the True branch and skips the False branch",
-  { tag: ["@stable", "@regression", "@components"] },
+  // @stable removed: Text Input/Output are now legacy and hidden from the sidebar (deterministic). Tracked in #362;
+  // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
+  { tag: ["@regression", "@components"] },
   async ({ page }) => {
     await test.step("Build If-Else flow with True/False Text Output branches", async () => {
       await buildIfElseRoutingFlow(page);
@@ -158,7 +160,9 @@ test(
 
 test(
   "If-Else routes non-matching input through the False branch and skips the True branch",
-  { tag: ["@stable", "@regression", "@components"] },
+  // @stable removed: Text Input/Output are now legacy and hidden from the sidebar (deterministic). Tracked in #362;
+  // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
+  { tag: ["@regression", "@components"] },
   async ({ page }) => {
     await test.step("Build If-Else flow with True/False Text Output branches", async () => {
       await buildIfElseRoutingFlow(page);
@@ -188,7 +192,9 @@ test(
 
 test(
   "If-Else operator=contains routes a substring match through the True branch",
-  { tag: ["@stable", "@regression", "@components"] },
+  // @stable removed: Text Input/Output are now legacy and hidden from the sidebar (deterministic). Tracked in #362;
+  // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
+  { tag: ["@regression", "@components"] },
   async ({ page }) => {
     await test.step("Build If-Else flow with True/False Text Output branches", async () => {
       await buildIfElseRoutingFlow(page);
@@ -222,7 +228,9 @@ test(
 
 test(
   "If-Else operator=regex routes a valid pattern match through the True branch",
-  { tag: ["@stable", "@regression", "@components"] },
+  // @stable removed: Text Input/Output are now legacy and hidden from the sidebar (deterministic). Tracked in #362;
+  // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
+  { tag: ["@regression", "@components"] },
   async ({ page }) => {
     await test.step("Build If-Else flow with True/False Text Output branches", async () => {
       await buildIfElseRoutingFlow(page);
@@ -259,7 +267,9 @@ test(
 
 test(
   "If-Else operator=regex hides the case_sensitive advanced field",
-  { tag: ["@stable", "@regression", "@components"] },
+  // @stable removed: Text Input/Output are now legacy and hidden from the sidebar (deterministic). Tracked in #362;
+  // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
+  { tag: ["@regression", "@components"] },
   async ({ page }) => {
     await test.step("Build If-Else flow with True/False Text Output branches", async () => {
       await buildIfElseRoutingFlow(page);
@@ -291,7 +301,9 @@ test(
 
 test(
   "If-Else case_sensitive defaults to ON — mixed-case inputs route to the False branch",
-  { tag: ["@stable", "@regression", "@components"] },
+  // @stable removed: Text Input/Output are now legacy and hidden from the sidebar (deterministic). Tracked in #362;
+  // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
+  { tag: ["@regression", "@components"] },
   async ({ page }) => {
     await test.step("Build If-Else flow with True/False Text Output branches", async () => {
       await buildIfElseRoutingFlow(page);
@@ -322,7 +334,9 @@ test(
 
 test(
   "If-Else with case_sensitive=OFF treats mixed-case inputs as a match (True branch)",
-  { tag: ["@stable", "@regression", "@components"] },
+  // @stable removed: Text Input/Output are now legacy and hidden from the sidebar (deterministic). Tracked in #362;
+  // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
+  { tag: ["@regression", "@components"] },
   async ({ page }) => {
     await test.step("Build If-Else flow with True/False Text Output branches", async () => {
       await buildIfElseRoutingFlow(page);
@@ -360,7 +374,9 @@ test(
 
 test(
   "If-Else operator=greater than routes a numeric match (10 > 5) through the True branch",
-  { tag: ["@stable", "@regression", "@components"] },
+  // @stable removed: Text Input/Output are now legacy and hidden from the sidebar (deterministic). Tracked in #362;
+  // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
+  { tag: ["@regression", "@components"] },
   async ({ page }) => {
     await test.step("Build If-Else flow with True/False Text Output branches", async () => {
       await buildIfElseRoutingFlow(page);

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
@@ -144,7 +144,9 @@ for (const { label, options, skipReason } of targets) {
 
     test(
       "agent interaction suite",
-      { tag: ["@stable", "@release", "@components", "@agents", "@playground"] },
+      // @stable removed: flow editor/template fails to load on the weekly nightly run. Tracked in #363;
+      // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
+      { tag: ["@release", "@components", "@agents", "@playground"] },
       async ({ page }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(

--- a/tests/tests-automations/regression/core-functionality/llm-agents/memory-history-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/memory-history-regression.spec.ts
@@ -55,7 +55,9 @@ async function waitForChatResponse(page: Page): Promise<void> {
 test.describe("Memory Chatbot Regression", () => {
   test(
     "memory chatbot template loads with correct node structure",
-    { tag: ["@stable", "@release", "@agents", "@playground"] },
+    // @stable removed: flow editor/template fails to load on the weekly nightly run. Tracked in #363;
+    // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
+    { tag: ["@release", "@agents", "@playground"] },
     async ({ page }) => {
       await loadMemoryChatbot(page);
 
@@ -77,7 +79,9 @@ test.describe("Memory Chatbot Regression", () => {
 
   test(
     "message history context retention suite",
-    { tag: ["@stable", "@release", "@agents", "@playground"] },
+    // @stable removed: flow editor/template fails to load on the weekly nightly run. Tracked in #363;
+    // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
+    { tag: ["@release", "@agents", "@playground"] },
     async ({ page }) => {
       test.skip(
         !process.env.OPENAI_API_KEY,
@@ -127,7 +131,9 @@ test.describe("Memory Chatbot Regression", () => {
 
   test(
     "session isolation: new session has no context from previous session",
-    { tag: ["@stable", "@release", "@agents", "@playground"] },
+    // @stable removed: flow editor/template fails to load on the weekly nightly run. Tracked in #363;
+    // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
+    { tag: ["@release", "@agents", "@playground"] },
     async ({ page }) => {
       test.skip(
         !process.env.OPENAI_API_KEY,

--- a/tests/tests-automations/regression/core-functionality/playground/output-modal-copy-button.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/output-modal-copy-button.spec.ts
@@ -19,7 +19,9 @@ test.describe("Output Modal — Copy Button", () => {
 
   test(
     "copy button copies Text Input output and toggles Check icon",
-    { tag: ["@stable", "@release", "@workspace", "@playground"] },
+    // @stable removed: Text Input/Output are now legacy and hidden from the sidebar (deterministic). Tracked in #362;
+    // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
+    { tag: ["@release", "@workspace", "@playground"] },
     async ({ page }) => {
       await test.step("create blank flow and capture flow id", async () => {
         await awaitBootstrapTest(page);

--- a/tests/tests-automations/regression/flow-functionality/publish-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/publish-flow.spec.ts
@@ -11,7 +11,9 @@ const FLOW_BASE = {
 
 test(
   "user can publish a flow and access it via shareable URL, then unpublish to revoke access",
-  { tag: ["@release", "@workspace", "@playground", "@stable"] },
+  // @stable removed: publish/share UI not reachable on the weekly nightly run. Tracked in #364;
+  // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
+  { tag: ["@release", "@workspace", "@playground"] },
   async ({ page, browser, request }) => {
     await awaitBootstrapTest(page);
 

--- a/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
@@ -162,7 +162,9 @@ for (const { label, options, skipReason } of targets) {
 
     test(
       "agent calls echo MCP tool and returns echoed message",
-      { tag: ["@mcp", "@agents", "@regression", "@stable"] },
+      // @stable removed: flow editor/template fails to load on the weekly nightly run. Tracked in #363;
+      // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
+      { tag: ["@mcp", "@agents", "@regression"] },
       async ({ page }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(


### PR DESCRIPTION
## What

Removes the `@stable` tag from the **17 tests that failed in weekly run [27133642480](https://github.com/oriontech-me/langflow-e2e/actions/runs/27133642480)** (2026-06-08, `langflow-nightly:latest`), so the weekly workflow stops flagging already-triaged issues. Each removal carries a tracking comment pointing to the cluster issue, per the `@stable` lifecycle in `CONTRIBUTING.md`. `@stable` is **restored on each cluster's fix PR**.

## Triage

The 17 failures were investigated (reproduced locally against the exact CI image digest `sha256:55a586eb…`) and split into three tracked clusters:

| Cluster | Issue | Tests | Status |
|---|---|---|---|
| **1 — Text Input/Output are now legacy & hidden from the sidebar** | #362 | 10 (if-else ×8, general-bugs-delete-handle, output-modal-copy) | **Root cause confirmed** (deterministic product change) |
| **2 — Flow editor / template fails to load** | #363 | 6 (api-request:369, agent:145, memory ×3, mcp-client:163) | Root cause **not yet confirmed** — needs investigation |
| **3 — publish-flow: publish/share UI not reachable** | #364 | 1 (publish-flow:12) | Root cause **not yet confirmed** |

Only the failing tests lose `@stable`; passing siblings in the same files keep it (e.g. `api-request` keeps 14, `publish-flow` keeps the `@api` test at line 144).

## Notes

- `QA-CHECKLIST.md` Phase 0 block regenerated via `npm run coverage:summary` (192 → 175 `@stable` `test()` calls). Auto-generated — not hand-edited.
- `tsc --noEmit` and `eslint` pass (0 errors).
- No spec-doc changes: per `CONTRIBUTING.md`, temporary `@stable` removals are tracked via GitHub issue, not a spec-doc edit.

Closes #361
