### PR TITLE
fix(components): migrate Text I/O specs to Chat Input/Output (#362)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -764,7 +764,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 175 `test()` calls carrying the `@stable` tag, distributed across 58 spec
+> 185 `test()` calls carrying the `@stable` tag, distributed across 61 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -831,6 +831,15 @@
 - [x] Chat Input/Output — default sender_name is 'User' on input and 'AI' on output → `chat-input-output-component-regression.spec.ts`
 - [x] user can add components by hovering and clicking the plus icon → `componentHoverAdd.spec.ts`
 - [x] custom component code button should be pink when adding custom component → `customComponentAdd.spec.ts`
+- [x] the system must delete the handles from advanced fields when the code is updated → `general-bugs-delete-handle-advanced-input.spec.ts`
+- [x] If-Else routes matching input through the True branch and skips the False branch → `if-else-component-regression.spec.ts`
+- [x] If-Else routes non-matching input through the False branch and skips the True branch → `if-else-component-regression.spec.ts`
+- [x] If-Else operator=contains routes a substring match through the True branch → `if-else-component-regression.spec.ts`
+- [x] If-Else operator=regex routes a valid pattern match through the True branch → `if-else-component-regression.spec.ts`
+- [x] If-Else operator=regex hides the case_sensitive advanced field → `if-else-component-regression.spec.ts`
+- [x] If-Else case_sensitive defaults to ON — mixed-case inputs route to the False branch → `if-else-component-regression.spec.ts`
+- [x] If-Else with case_sensitive=OFF treats mixed-case inputs as a match (True branch) → `if-else-component-regression.spec.ts`
+- [x] If-Else operator=greater than routes a numeric match (10 > 5) through the True branch → `if-else-component-regression.spec.ts`
 - [x] Show Legacy Components toggle controls visibility of legacy components in the sidebar → `legacy-components-toggle-regression.spec.ts`
 - [x] Loop component — renders correctly with all handles and output inspection buttons → `loop-component-regression.spec.ts`
 - [x] Loop component — run without connections shows build failed notification → `loop-component-regression.spec.ts`
@@ -896,6 +905,7 @@
 - [x] should be able to see and interact with Traces → `traces.spec.ts`
 
 #### core-functionality/playground/
+- [x] copy button copies Chat Input output and toggles Check icon → `output-modal-copy-button.spec.ts`
 - [x] playground must show one compact preview per attached image when two images are attached → `playground-attachments-management.spec.ts`
 - [x] playground must keep the remaining preview when one of two attachments is removed → `playground-attachments-management.spec.ts`
 - [x] playground must render both attached images in the user message after sending → `playground-attachments-management.spec.ts`

--- a/docs/core-components/general-bugs-delete-handle-advanced-input.md
+++ b/docs/core-components/general-bugs-delete-handle-advanced-input.md
@@ -13,7 +13,7 @@ Regression test for a bug where dynamic handles tied to **advanced fields** ling
 The test exercises the **If-Else** component because it has a togglable `true_case_message` advanced field that historically left a dangling handle after the user re-saved the code. The contract under test:
 
 1. Toggling `showtrue_case_message` exposes a "Receiving input" placeholder.
-2. Connecting Text Input → If-Else's `case true` produces a locked handle (visible in Advanced view as another "Receiving input" placeholder + a lock icon).
+2. Connecting Chat Input → If-Else's `case true` produces a locked handle (visible in Advanced view as another "Receiving input" placeholder + a lock icon).
 3. After clicking **Check & Save** in the code modal with the default code, the advanced field config is re-evaluated and both the "Receiving input" placeholders and the lock icon are removed (`count === 0`).
 
 ---
@@ -30,8 +30,8 @@ The test exercises the **If-Else** component because it has a togglable `true_ca
 2. Add the **If-Else** component from the sidebar.
 3. Disable the inspect panel, open Advanced Options.
 4. Toggle `showtrue_case_message`, then close Advanced Options.
-5. Add a **Text Input** component (drag onto canvas).
-6. Connect Text Input's output handle to If-Else's `case true` input handle.
+5. Add a **Chat Input** component (drag onto canvas).
+6. Connect Chat Input's collapsed `noshownode` "Chat Message" output handle to If-Else's `case true` input handle (the node stays minimized — it is used only as a connection source).
 7. Click the If-Else title and open Advanced Options again — assert exactly 2 "Receiving input" placeholders are visible.
 8. Close Advanced Options.
 9. Click the If-Else title, open the code modal, click **Check & Save** (resaves the default code).
@@ -45,7 +45,7 @@ The test exercises the **If-Else** component because it has a togglable `true_ca
 
 | Step | Criterion |
 |---|---|
-| After connecting Text Input → If-Else | Advanced view shows `toHaveCount(2)` `Receiving input` placeholders |
+| After connecting Chat Input → If-Else | Advanced view shows `toHaveCount(2)` `Receiving input` placeholders |
 | After Check & Save on code modal | Advanced view shows `toHaveCount(0)` `Receiving input` placeholders |
 | After Check & Save on code modal | Advanced view shows `toHaveCount(0)` `icon-lock` icons |
 

--- a/docs/core-components/if-else-component-regression.md
+++ b/docs/core-components/if-else-component-regression.md
@@ -12,6 +12,8 @@ Covers the routing contract of the **If-Else** (ConditionalRouter) component acr
 
 For every scenario except the regex side-effect test, the assertion surface is the canvas node status: `node_duration_<name>` testid for the branch that built (active) and `node_status_icon_<name>_inactive` testid for the branch that was skipped. This is the same surface used by `flow-functionality/general-bugs-reset-flow-run.spec.ts` and is more reliable than message-content assertions because the component returns an empty Message on the inactive branch (so message presence alone cannot distinguish the routes).
 
+> **Branch sinks use Chat Output (not the legacy Text Output).** Langflow marked Text Input/Output `legacy: true` and the sidebar hides legacy components by default, so the two terminal sinks were migrated to **Chat Output**. Chat Output is added minimized — the build helper expands each one (`expandFocusedNode`) so the run button and the `shownode` input handle are present in the DOM. See #362.
+
 The one exception is the regex side-effect test: when `operator=regex`, the component's `update_build_config` removes the `case_sensitive` field from the build config. The assertion there is that opening the edit-fields modal shows `toHaveCount(0)` for the `showcase_sensitive` testid (it is normally `1`).
 
 ---
@@ -48,10 +50,10 @@ All eight scenarios are introduced in this spec; there is no pre-existing implem
 1. Bootstrap and open a blank flow.
 2. Add the **If-Else** component from the sidebar.
 3. Zoom out so two more components fit.
-4. Drop two **Text Output** components onto the canvas (positions: `{100, 100}` and `{200, 400}`).
-5. Rename the second Text Output to `textoutputfalse` so its testid suffix is stable.
-6. Wire `handle-conditionalrouter-shownode-true-right` → first Text Output's `inputs-left` handle.
-7. Wire `handle-conditionalrouter-shownode-false-right` → `textoutputfalse`'s `inputs-left` handle.
+4. Drop two **Chat Output** components onto the canvas (positions: `{100, 100}` and `{200, 400}`), expanding each one after it is added (Chat Output is added minimized).
+5. Rename the second Chat Output to `chatoutputfalse` so its testid suffix is stable.
+6. Wire `handle-conditionalrouter-shownode-true-right` → first Chat Output's `inputs-left` handle.
+7. Wire `handle-conditionalrouter-shownode-false-right` → `chatoutputfalse`'s `inputs-left` handle.
 
 Each test calls this helper and then applies the scenario-specific configuration before running.
 
@@ -72,14 +74,14 @@ Test #7 (case_sensitive OFF) does not use a dedicated helper to flip the switch 
 
 | # | Active branch (`toHaveCount(1)`) | Inactive branch (`toHaveCount(1)`) | Additional |
 |---|---|---|---|
-| 1 | `node_duration_text output` | `node_status_icon_textoutputfalse_inactive` | — |
-| 2 | `node_duration_textoutputfalse` | `node_status_icon_text output_inactive` | — |
-| 3 | `node_duration_text output` | `node_status_icon_textoutputfalse_inactive` | — |
-| 4 | `node_duration_text output` | `node_status_icon_textoutputfalse_inactive` | — |
+| 1 | `node_duration_chat output` | `node_status_icon_chatoutputfalse_inactive` | — |
+| 2 | `node_duration_chatoutputfalse` | `node_status_icon_chat output_inactive` | — |
+| 3 | `node_duration_chat output` | `node_status_icon_chatoutputfalse_inactive` | — |
+| 4 | `node_duration_chat output` | `node_status_icon_chatoutputfalse_inactive` | — |
 | 5 | — | — | After switching to `regex`, opening edit-fields shows `toHaveCount(0)` for `showcase_sensitive`. With `equals`, count is `1`. |
-| 6 | `node_duration_textoutputfalse` | `node_status_icon_text output_inactive` | — |
-| 7 | `node_duration_text output` | `node_status_icon_textoutputfalse_inactive` | — |
-| 8 | `node_duration_text output` | `node_status_icon_textoutputfalse_inactive` | — |
+| 6 | `node_duration_chatoutputfalse` | `node_status_icon_chat output_inactive` | — |
+| 7 | `node_duration_chat output` | `node_status_icon_chatoutputfalse_inactive` | — |
+| 8 | `node_duration_chat output` | `node_status_icon_chatoutputfalse_inactive` | — |
 
 ---
 
@@ -114,7 +116,7 @@ Test #7 (case_sensitive OFF) does not use a dedicated helper to flip the switch 
 
 - Stability: 3 / 3 PASS for the original 2 tests (~16–23 s). New scenarios will be re-validated with the same pipeline (typecheck + lint + stability + force-fail + trace + backend audit) before commit.
 - Force-fail probe pattern: temporarily change the active-branch `node_duration_*` `toHaveCount(1)` to `toHaveCount(99)` for one representative scenario per setup variant (default, exposed case_sensitive, switched operator). Confirm failure at the expected line, revert, re-pass.
-- The two Text Output components are dragged via `dragTo` to avoid the default-stack issue noted in the project memory (two sidebar `+` clicks land in the same position).
+- The two Chat Output components are dragged via `dragTo` to avoid the default-stack issue noted in the project memory (two sidebar `+` clicks land in the same position).
 - Operator dropdown options are selected via `getByRole("option", { name: operatorName, exact: true })` — the dropdown is Radix Select, which exposes stable accessible names. Selecting by `role` instead of testid avoids depending on the option's index suffix in the DOM, which historically drifts as new operators are added.
 - The `case_sensitive` BoolInput uses testid `toggle_bool_case_sensitive` with `role="switch"`; toggling once flips from ON to OFF.
 

--- a/docs/core-functionality/playground/output-modal-copy-button.md
+++ b/docs/core-functionality/playground/output-modal-copy-button.md
@@ -25,8 +25,8 @@ If this breaks, users have no reliable way to grab the output of a component int
 ## Step by step *(required)*
 
 1. Open Langflow and create a blank flow; capture the flow id from the `POST /api/v1/flows` 201 response
-2. Add a **Text Input** component and fill its `textarea_str_input_value` with `"Test content to copy"`
-3. Run the component (`button_run_text input`) and wait for the "built successfully" toast
+2. Add a **Chat Input** component, expand it (it is added minimized), and fill its `textarea_str_input_value` with `"Test content to copy"`
+3. Run the component (`button_run_chat input`) and wait for the "built successfully" toast
 4. Click the first `output-inspection-*` button to open the Component Output modal
 5. Click `copy-output-button`
 6. Assert "Copied to clipboard" toast is visible
@@ -50,7 +50,7 @@ If this breaks, users have no reliable way to grab the output of a component int
 - `data-testid="copy-output-button"` — copy button rendered inside the Output Modal
 - `data-testid="icon-Check"` and `data-testid="icon-Copy"` — icon components inside the button
 - `data-testid="output-inspection-*"` — the inspector entry point that opens the Output Modal
-- `data-testid="textarea_str_input_value"` and `button_run_text input` — Text Input component fields
+- `data-testid="textarea_str_input_value"` and `button_run_chat input` — Chat Input component fields
 - Backend endpoints: `POST /api/v1/flows` (flow creation), `DELETE /api/v1/flows/{id}` (cleanup)
 
 ---
@@ -65,7 +65,7 @@ If this breaks, users have no reliable way to grab the output of a component int
 ## Preconditions *(optional)*
 
 - Langflow running at `PLAYWRIGHT_BASE_URL`
-- No LLM, no external HTTP calls — Text Input runs are local
+- No LLM, no external HTTP calls — Chat Input runs are local
 
 ---
 

--- a/tests/tests-automations/regression/core-components/general-bugs-delete-handle-advanced-input.spec.ts
+++ b/tests/tests-automations/regression/core-components/general-bugs-delete-handle-advanced-input.spec.ts
@@ -10,9 +10,7 @@ import {
 
 test(
   "the system must delete the handles from advanced fields when the code is updated",
-  // @stable removed: Text Input/Output are now legacy and hidden from the sidebar (deterministic). Tracked in #362;
-  // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
-  { tag: ["@release", "@components"] },
+  { tag: ["@stable", "@release", "@components"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 
@@ -41,20 +39,23 @@ test(
     await closeAdvancedOptions(page);
 
     await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("text input");
-    await expect(page.getByTestId("input_outputText Input")).toBeVisible({
+    await page.getByTestId("sidebar-search-input").fill("chat input");
+    await expect(page.getByTestId("input_outputChat Input")).toBeVisible({
       timeout: 10000,
     });
     await page
-      .getByTestId("input_outputText Input")
+      .getByTestId("input_outputChat Input")
       .dragTo(page.locator('//*[@id="react-flow-id"]'), {
         targetPosition: { x: 200, y: 100 },
       });
 
     await adjustScreenView(page);
 
+    // Chat Input is added minimized; connect from its collapsed "Chat Message"
+    // output handle (noshownode) — no need to expand the node, this test only
+    // uses it as a connection source for the If-Else `case true` input.
     await page
-      .getByTestId("handle-textinput-shownode-output text-right")
+      .getByTestId("handle-chatinput-noshownode-chat message-source")
       .click();
 
     await page

--- a/tests/tests-automations/regression/core-components/if-else-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/if-else-component-regression.spec.ts
@@ -8,6 +8,20 @@ import {
 } from "../../../helpers/ui/open-advanced-options";
 import { zoomOut } from "../../../helpers/ui/zoom-out";
 
+// Expand the currently focused node from minimized to full view. Chat Output
+// defaults to `minimized = True` (see lfx/components/input_output/chat_output.py);
+// without expanding, the run button and the `shownode` input handle rendered on
+// the node body are not present in the DOM. Idempotent: if the node is already
+// expanded (no `hide-node-content` in the DOM) the helper is a no-op.
+async function expandFocusedNode(page: Page): Promise<void> {
+  if ((await page.getByTestId("hide-node-content").count()) === 0) return;
+  await page.getByTestId("more-options-modal").click();
+  await expect(page.getByTestId("expand-button-modal")).toBeVisible({
+    timeout: 10000,
+  });
+  await page.getByTestId("expand-button-modal").click();
+}
+
 async function selectOperator(
   page: Page,
   operatorName: string,
@@ -34,8 +48,8 @@ async function exposeCaseSensitive(page: Page): Promise<void> {
   await closeAdvancedOptions(page);
 }
 
-// Builds: If-Else (operator=equals) + two Text Output components, one renamed
-// to `textoutputfalse` so the True/False branches can be inspected
+// Builds: If-Else (operator=equals) + two Chat Output components, one renamed
+// to `chatoutputfalse` so the True/False branches can be inspected
 // independently by testid. Direct-value path: `input_text` and `match_text`
 // are typed into the If-Else inspector popovers — no ChatInput/Playground
 // involved, mirroring `general-bugs-reset-flow-run.spec.ts` which validated
@@ -65,74 +79,81 @@ async function buildIfElseRoutingFlow(page: Page): Promise<void> {
 
   await zoomOut(page, 3);
 
-  // Text Output (will be wired to True branch — default name `text output`)
+  // Chat Output (will be wired to True branch — default name `chat output`).
+  // Chat Output is added minimized; expand it so the run button and the
+  // `shownode` input handle are present in the DOM.
   await page.getByTestId("sidebar-search-input").click();
-  await page.getByTestId("sidebar-search-input").fill("text output");
-  await expect(page.getByTestId("input_outputText Output")).toBeVisible({
+  await page.getByTestId("sidebar-search-input").fill("chat output");
+  await expect(page.getByTestId("input_outputChat Output")).toBeVisible({
     timeout: 10000,
   });
   await page
-    .getByTestId("input_outputText Output")
+    .getByTestId("input_outputChat Output")
     .dragTo(page.locator('//*[@id="react-flow-id"]'), {
       targetPosition: { x: 100, y: 100 },
     });
 
   await adjustScreenView(page);
 
-  // Second Text Output — will be wired to False branch and renamed to
-  // `textoutputfalse` so the False-branch status icon has a stable testid.
+  await page.getByTestId("title-Chat Output").click();
+  await expandFocusedNode(page);
+
+  // Second Chat Output — will be wired to False branch and renamed to
+  // `chatoutputfalse` so the False-branch status icon has a stable testid.
   await page.getByTestId("sidebar-search-input").click();
-  await page.getByTestId("sidebar-search-input").fill("text output");
-  await expect(page.getByTestId("input_outputText Output")).toBeVisible({
+  await page.getByTestId("sidebar-search-input").fill("chat output");
+  await expect(page.getByTestId("input_outputChat Output")).toBeVisible({
     timeout: 10000,
   });
   await page
-    .getByTestId("input_outputText Output")
+    .getByTestId("input_outputChat Output")
     .dragTo(page.locator('//*[@id="react-flow-id"]'), {
       targetPosition: { x: 200, y: 400 },
     });
 
   await adjustScreenView(page);
 
-  // Rename the second Text Output to `textoutputfalse`
+  // Focus and expand the newly added (second) Chat Output before renaming/wiring.
+  await page.getByTestId("title-Chat Output").last().click();
+  await expandFocusedNode(page);
+
+  // Rename the second Chat Output to `chatoutputfalse`
   await page.getByTestId("generic-node-title-arrangement").last().click();
   await page.getByTestId("panel-description").hover();
   await page
     .getByTestId("panel-description")
     .getByTestId("edit-name-description-button")
     .click();
-  await page.getByTestId("inspection-panel-name").fill("textoutputfalse");
+  await page.getByTestId("inspection-panel-name").fill("chatoutputfalse");
   await page
     .getByTestId("panel-description")
     .getByTestId("save-name-description-button")
     .click();
 
-  // Connect True → first Text Output
+  // Connect True → first Chat Output
   await page
     .getByTestId("handle-conditionalrouter-shownode-true-right")
     .click();
   await page
-    .getByTestId("handle-textoutput-shownode-inputs-left")
+    .getByTestId("handle-chatoutput-shownode-inputs-left")
     .first()
     .click();
 
-  // Connect False → second Text Output (textoutputfalse)
+  // Connect False → second Chat Output (chatoutputfalse)
   await page
     .getByTestId("handle-conditionalrouter-shownode-false-right")
     .click();
   await page
-    .getByTestId("handle-textoutput-shownode-inputs-left")
+    .getByTestId("handle-chatoutput-shownode-inputs-left")
     .last()
     .click();
 }
 
 test(
   "If-Else routes matching input through the True branch and skips the False branch",
-  // @stable removed: Text Input/Output are now legacy and hidden from the sidebar (deterministic). Tracked in #362;
-  // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
-  { tag: ["@regression", "@components"] },
+  { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    await test.step("Build If-Else flow with True/False Text Output branches", async () => {
+    await test.step("Build If-Else flow with True/False Chat Output branches", async () => {
       await buildIfElseRoutingFlow(page);
     });
 
@@ -141,7 +162,7 @@ test(
       await page.getByTestId("popover-anchor-input-input_text").fill("hello");
       await page.getByTestId("popover-anchor-input-match_text").fill("hello");
 
-      await page.getByTestId("button_run_text output").click();
+      await page.getByTestId("button_run_chat output").click();
       await expect(page.locator("text=built successfully")).toBeVisible({
         timeout: 30000,
       });
@@ -149,10 +170,10 @@ test(
 
     await test.step("Assert True branch built and False branch stayed inactive", async () => {
       await expect(
-        page.getByTestId("node_duration_text output"),
+        page.getByTestId("node_duration_chat output"),
       ).toHaveCount(1, { timeout: 30000 });
       await expect(
-        page.getByTestId("node_status_icon_textoutputfalse_inactive"),
+        page.getByTestId("node_status_icon_chatoutputfalse_inactive"),
       ).toHaveCount(1, { timeout: 30000 });
     });
   },
@@ -160,11 +181,9 @@ test(
 
 test(
   "If-Else routes non-matching input through the False branch and skips the True branch",
-  // @stable removed: Text Input/Output are now legacy and hidden from the sidebar (deterministic). Tracked in #362;
-  // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
-  { tag: ["@regression", "@components"] },
+  { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    await test.step("Build If-Else flow with True/False Text Output branches", async () => {
+    await test.step("Build If-Else flow with True/False Chat Output branches", async () => {
       await buildIfElseRoutingFlow(page);
     });
 
@@ -173,7 +192,7 @@ test(
       await page.getByTestId("popover-anchor-input-input_text").fill("world");
       await page.getByTestId("popover-anchor-input-match_text").fill("hello");
 
-      await page.getByTestId("button_run_textoutputfalse").click();
+      await page.getByTestId("button_run_chatoutputfalse").click();
       await expect(page.locator("text=built successfully")).toBeVisible({
         timeout: 30000,
       });
@@ -181,10 +200,10 @@ test(
 
     await test.step("Assert False branch built and True branch stayed inactive", async () => {
       await expect(
-        page.getByTestId("node_duration_textoutputfalse"),
+        page.getByTestId("node_duration_chatoutputfalse"),
       ).toHaveCount(1, { timeout: 30000 });
       await expect(
-        page.getByTestId("node_status_icon_text output_inactive"),
+        page.getByTestId("node_status_icon_chat output_inactive"),
       ).toHaveCount(1, { timeout: 30000 });
     });
   },
@@ -192,11 +211,9 @@ test(
 
 test(
   "If-Else operator=contains routes a substring match through the True branch",
-  // @stable removed: Text Input/Output are now legacy and hidden from the sidebar (deterministic). Tracked in #362;
-  // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
-  { tag: ["@regression", "@components"] },
+  { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    await test.step("Build If-Else flow with True/False Text Output branches", async () => {
+    await test.step("Build If-Else flow with True/False Chat Output branches", async () => {
       await buildIfElseRoutingFlow(page);
     });
 
@@ -209,7 +226,7 @@ test(
         .fill("langflow");
       await page.getByTestId("popover-anchor-input-match_text").fill("lang");
 
-      await page.getByTestId("button_run_text output").click();
+      await page.getByTestId("button_run_chat output").click();
       await expect(page.locator("text=built successfully")).toBeVisible({
         timeout: 30000,
       });
@@ -217,10 +234,10 @@ test(
 
     await test.step("Assert True branch built and False branch stayed inactive", async () => {
       await expect(
-        page.getByTestId("node_duration_text output"),
+        page.getByTestId("node_duration_chat output"),
       ).toHaveCount(1, { timeout: 30000 });
       await expect(
-        page.getByTestId("node_status_icon_textoutputfalse_inactive"),
+        page.getByTestId("node_status_icon_chatoutputfalse_inactive"),
       ).toHaveCount(1, { timeout: 30000 });
     });
   },
@@ -228,11 +245,9 @@ test(
 
 test(
   "If-Else operator=regex routes a valid pattern match through the True branch",
-  // @stable removed: Text Input/Output are now legacy and hidden from the sidebar (deterministic). Tracked in #362;
-  // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
-  { tag: ["@regression", "@components"] },
+  { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    await test.step("Build If-Else flow with True/False Text Output branches", async () => {
+    await test.step("Build If-Else flow with True/False Chat Output branches", async () => {
       await buildIfElseRoutingFlow(page);
     });
 
@@ -248,7 +263,7 @@ test(
         .getByTestId("popover-anchor-input-match_text")
         .fill("^abc\\d+$");
 
-      await page.getByTestId("button_run_text output").click();
+      await page.getByTestId("button_run_chat output").click();
       await expect(page.locator("text=built successfully")).toBeVisible({
         timeout: 30000,
       });
@@ -256,10 +271,10 @@ test(
 
     await test.step("Assert True branch built and False branch stayed inactive", async () => {
       await expect(
-        page.getByTestId("node_duration_text output"),
+        page.getByTestId("node_duration_chat output"),
       ).toHaveCount(1, { timeout: 30000 });
       await expect(
-        page.getByTestId("node_status_icon_textoutputfalse_inactive"),
+        page.getByTestId("node_status_icon_chatoutputfalse_inactive"),
       ).toHaveCount(1, { timeout: 30000 });
     });
   },
@@ -267,18 +282,16 @@ test(
 
 test(
   "If-Else operator=regex hides the case_sensitive advanced field",
-  // @stable removed: Text Input/Output are now legacy and hidden from the sidebar (deterministic). Tracked in #362;
-  // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
-  { tag: ["@regression", "@components"] },
+  { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    await test.step("Build If-Else flow with True/False Text Output branches", async () => {
+    await test.step("Build If-Else flow with True/False Chat Output branches", async () => {
       await buildIfElseRoutingFlow(page);
     });
 
     await test.step("Baseline: case_sensitive toggle is exposed with the default operator", async () => {
       // Focus the If-Else node — `openAdvancedOptions` operates on the
       // currently-focused node, and the build helper leaves focus on the last
-      // Text Output it renamed.
+      // Chat Output it renamed.
       await page.getByTestId("title-If-Else").click();
 
       await openAdvancedOptions(page);
@@ -301,11 +314,9 @@ test(
 
 test(
   "If-Else case_sensitive defaults to ON — mixed-case inputs route to the False branch",
-  // @stable removed: Text Input/Output are now legacy and hidden from the sidebar (deterministic). Tracked in #362;
-  // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
-  { tag: ["@regression", "@components"] },
+  { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    await test.step("Build If-Else flow with True/False Text Output branches", async () => {
+    await test.step("Build If-Else flow with True/False Chat Output branches", async () => {
       await buildIfElseRoutingFlow(page);
     });
 
@@ -315,7 +326,7 @@ test(
       await page.getByTestId("popover-anchor-input-input_text").fill("HELLO");
       await page.getByTestId("popover-anchor-input-match_text").fill("hello");
 
-      await page.getByTestId("button_run_textoutputfalse").click();
+      await page.getByTestId("button_run_chatoutputfalse").click();
       await expect(page.locator("text=built successfully")).toBeVisible({
         timeout: 30000,
       });
@@ -323,10 +334,10 @@ test(
 
     await test.step("Assert False branch built and True branch stayed inactive", async () => {
       await expect(
-        page.getByTestId("node_duration_textoutputfalse"),
+        page.getByTestId("node_duration_chatoutputfalse"),
       ).toHaveCount(1, { timeout: 30000 });
       await expect(
-        page.getByTestId("node_status_icon_text output_inactive"),
+        page.getByTestId("node_status_icon_chat output_inactive"),
       ).toHaveCount(1, { timeout: 30000 });
     });
   },
@@ -334,11 +345,9 @@ test(
 
 test(
   "If-Else with case_sensitive=OFF treats mixed-case inputs as a match (True branch)",
-  // @stable removed: Text Input/Output are now legacy and hidden from the sidebar (deterministic). Tracked in #362;
-  // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
-  { tag: ["@regression", "@components"] },
+  { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    await test.step("Build If-Else flow with True/False Text Output branches", async () => {
+    await test.step("Build If-Else flow with True/False Chat Output branches", async () => {
       await buildIfElseRoutingFlow(page);
     });
 
@@ -355,7 +364,7 @@ test(
       await page.getByTestId("popover-anchor-input-input_text").fill("HELLO");
       await page.getByTestId("popover-anchor-input-match_text").fill("hello");
 
-      await page.getByTestId("button_run_text output").click();
+      await page.getByTestId("button_run_chat output").click();
       await expect(page.locator("text=built successfully")).toBeVisible({
         timeout: 30000,
       });
@@ -363,10 +372,10 @@ test(
 
     await test.step("Assert True branch built and False branch stayed inactive", async () => {
       await expect(
-        page.getByTestId("node_duration_text output"),
+        page.getByTestId("node_duration_chat output"),
       ).toHaveCount(1, { timeout: 30000 });
       await expect(
-        page.getByTestId("node_status_icon_textoutputfalse_inactive"),
+        page.getByTestId("node_status_icon_chatoutputfalse_inactive"),
       ).toHaveCount(1, { timeout: 30000 });
     });
   },
@@ -374,11 +383,9 @@ test(
 
 test(
   "If-Else operator=greater than routes a numeric match (10 > 5) through the True branch",
-  // @stable removed: Text Input/Output are now legacy and hidden from the sidebar (deterministic). Tracked in #362;
-  // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
-  { tag: ["@regression", "@components"] },
+  { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    await test.step("Build If-Else flow with True/False Text Output branches", async () => {
+    await test.step("Build If-Else flow with True/False Chat Output branches", async () => {
       await buildIfElseRoutingFlow(page);
     });
 
@@ -389,7 +396,7 @@ test(
       await page.getByTestId("popover-anchor-input-input_text").fill("10");
       await page.getByTestId("popover-anchor-input-match_text").fill("5");
 
-      await page.getByTestId("button_run_text output").click();
+      await page.getByTestId("button_run_chat output").click();
       await expect(page.locator("text=built successfully")).toBeVisible({
         timeout: 30000,
       });
@@ -397,10 +404,10 @@ test(
 
     await test.step("Assert True branch built and False branch stayed inactive", async () => {
       await expect(
-        page.getByTestId("node_duration_text output"),
+        page.getByTestId("node_duration_chat output"),
       ).toHaveCount(1, { timeout: 30000 });
       await expect(
-        page.getByTestId("node_status_icon_textoutputfalse_inactive"),
+        page.getByTestId("node_status_icon_chatoutputfalse_inactive"),
       ).toHaveCount(1, { timeout: 30000 });
     });
   },

--- a/tests/tests-automations/regression/core-components/if-else-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/if-else-component-regression.spec.ts
@@ -20,6 +20,12 @@ async function expandFocusedNode(page: Page): Promise<void> {
     timeout: 10000,
   });
   await page.getByTestId("expand-button-modal").click();
+  // Settle: confirm the node finished expanding before callers interact with the
+  // freshly-mounted body (rename inspector, `shownode` handles) — guards against
+  // a mid-transition return flaking under CI parallelism.
+  await expect(page.getByTestId("hide-node-content")).toHaveCount(0, {
+    timeout: 5000,
+  });
 }
 
 async function selectOperator(

--- a/tests/tests-automations/regression/core-functionality/playground/output-modal-copy-button.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/output-modal-copy-button.spec.ts
@@ -1,5 +1,23 @@
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+
+// Expand the currently focused node from minimized to full view. Chat Input
+// defaults to `minimized = True` (see lfx/components/input_output/chat.py);
+// without expanding, the run button and inspector fields rendered on the node
+// body are not present in the DOM. Idempotent: if the node is already expanded
+// (no `hide-node-content` in the DOM) the helper is a no-op.
+async function expandFocusedNode(page: Page) {
+  if ((await page.getByTestId("hide-node-content").count()) === 0) return;
+  await page.getByTestId("more-options-modal").click();
+  await expect(page.getByTestId("expand-button-modal")).toBeVisible({
+    timeout: 10000,
+  });
+  await page.getByTestId("expand-button-modal").click();
+  await expect(page.getByTestId("hide-node-content")).toHaveCount(0, {
+    timeout: 5000,
+  });
+}
 
 test.describe("Output Modal — Copy Button", () => {
   test.describe.configure({ mode: "serial" });
@@ -18,10 +36,8 @@ test.describe("Output Modal — Copy Button", () => {
   });
 
   test(
-    "copy button copies Text Input output and toggles Check icon",
-    // @stable removed: Text Input/Output are now legacy and hidden from the sidebar (deterministic). Tracked in #362;
-    // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
-    { tag: ["@release", "@workspace", "@playground"] },
+    "copy button copies Chat Input output and toggles Check icon",
+    { tag: ["@stable", "@release", "@workspace", "@playground"] },
     async ({ page }) => {
       await test.step("create blank flow and capture flow id", async () => {
         await awaitBootstrapTest(page);
@@ -46,18 +62,23 @@ test.describe("Output Modal — Copy Button", () => {
         );
       });
 
-      await test.step("add Text Input and fill its value", async () => {
-        await page.getByTestId("sidebar-search-input").fill("text input");
+      await test.step("add Chat Input and fill its value", async () => {
+        await page.getByTestId("sidebar-search-input").fill("chat input");
         await page
-          .getByTestId("input_outputText Input")
+          .getByTestId("input_outputChat Input")
           .hover()
           .then(async () => {
-            await page.getByTestId("add-component-button-text-input").click();
+            await page.getByTestId("add-component-button-chat-input").click();
           });
 
         await expect(page.locator(".react-flow__node")).toHaveCount(1, {
           timeout: 10000,
         });
+
+        // Chat Input is added minimized — expand it so the Input Text field and
+        // run button rendered on the node body are present in the DOM.
+        await page.getByTestId("title-Chat Input").click();
+        await expandFocusedNode(page);
 
         await page
           .getByTestId("textarea_str_input_value")
@@ -65,7 +86,7 @@ test.describe("Output Modal — Copy Button", () => {
       });
 
       await test.step("run component and open output modal", async () => {
-        await page.getByTestId("button_run_text input").click();
+        await page.getByTestId("button_run_chat input").click();
         await expect(page.getByText("built successfully").last()).toBeVisible({
           timeout: 30000,
         });


### PR DESCRIPTION
## Summary

Langflow marked **Text Input/Output** as `legacy: true`; the component sidebar hides legacy components by default, so 10 `@stable` tests that drag these components broke deterministically on every weekly run (#362).

**Approach: migrate to Chat Input/Output**, not toggle `showLegacy`. Legacy components carry no maintenance commitment from upstream and are an unstable base for regression tests — the core `Chat Input`/`Chat Output` are the durable equivalents.

## Changes

| Spec | Migration |
|---|---|
| `output-modal-copy-button` | Text Input → **Chat Input** (expand the minimized node to reach `textarea_str_input_value` + run button) |
| `general-bugs-delete-handle-advanced-input` | Text Input → **Chat Input**, connected via the collapsed `noshownode` "Chat Message" output handle (node stays minimized — used only as a connection source) |
| `if-else-component-regression` | two Text Output → two **Chat Output** sinks, expanded after add; testids/handles updated across all 8 routing tests |

- Restored `@stable` on all 10 tests; removed the `// @stable removed …` #362 tracking comments.
- Updated the three corresponding spec docs under `docs/`.
- Added a small inline `expandFocusedNode` helper where the minimized Chat node must be expanded (same convention as the existing `@stable` `chat-input-output-component-regression` spec — no shared file touched).

## Validation

- `npm run typecheck` ✅  ·  `npm run lint` ✅ (0 errors)
- Ran against `langflow-nightly` **1.10.0.dev69**: **10/10 pass** (~46s, `--workers=2 --retries=1`).

## Scope

Limited to the 3 specs / 10 `@stable` tests in #362. The broader blast radius (11 other specs still referencing legacy Text I/O) is tracked in a separate follow-up issue.

Closes #362