### PR TITLE
fix(weekly): resolve Cluster 2 — flow editor / template fails to load (#363)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -764,7 +764,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 185 `test()` calls carrying the `@stable` tag, distributed across 61 spec
+> 191 `test()` calls carrying the `@stable` tag, distributed across 64 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -813,6 +813,7 @@
 - [x] API Request component — PUT method executes PUT verb and returns 200 → `api-request-component-regression.spec.ts`
 - [x] API Request component — PATCH method executes PATCH verb and returns 200 → `api-request-component-regression.spec.ts`
 - [x] API Request component — DELETE method executes DELETE verb and returns 200 → `api-request-component-regression.spec.ts`
+- [x] API Request component — non-2xx HTTP response propagates status_code without crashing → `api-request-component-regression.spec.ts`
 - [x] API Request component — query parameters embedded in URL are sent and echoed → `api-request-component-regression.spec.ts`
 - [x] API Request component — inspector headers table accepts key + value cell entries → `api-request-component-regression.spec.ts`
 - [x] API Request component — cURL tab switches mode and field accepts a cURL command → `api-request-component-regression.spec.ts`
@@ -882,9 +883,13 @@
 - [x] after logout, reload must stay on login page → `logout-flow.spec.ts`
 
 #### core-functionality/llm-agents/
+- [x] agent interaction suite → `agent-component-regression.spec.ts`
 - [x] user must be able to send images in the playground with the agent component → `general-bugs-agent-images-playground.spec.ts`
 - [x] playground shows error when LLM run endpoint returns 500 (mocked invalid API key) → `llm-invalid-api-key-ui.spec.ts`
 - [x] playground input remains usable after API error (mocked) → `llm-invalid-api-key-ui.spec.ts`
+- [x] memory chatbot template loads with correct node structure → `memory-history-regression.spec.ts`
+- [x] message history context retention suite → `memory-history-regression.spec.ts`
+- [x] session isolation: new session has no context from previous session → `memory-history-regression.spec.ts`
 
 #### core-functionality/observability-monitoring/
 - [x] DELETE /api/v1/monitor/traces returns 404 for an unknown flow_id → `traces-delete.spec.ts`
@@ -963,6 +968,7 @@
 - [x] user can copy a valid Python requests snippet from the API access modal → `pythonApiGeneration.spec.ts`
 
 #### mcp/client/
+- [x] agent calls echo MCP tool and returns echoed message → `mcp-client-agent.spec.ts`
 - [x] unreachable HTTP server results in empty tool dropdown → `mcp-client-regression.spec.ts`
 - [x] configures MCP server via HTTP form tab and verifies registration → `mcp-client-regression.spec.ts`
 - [x] selects get-sum tool, provides numeric inputs, and verifies sum in output → `mcp-client-regression.spec.ts`

--- a/tests/pages/SimpleAgentTemplatePage.ts
+++ b/tests/pages/SimpleAgentTemplatePage.ts
@@ -1,6 +1,7 @@
 import type { Page } from "@playwright/test";
 import { BasePage } from "./BasePage";
 import { adjustScreenView } from "../helpers/ui/adjust-screen-view";
+import { dismissWelcomeOverlayAndWaitForModal } from "../helpers/flows/open-new-flow-templates-modal";
 import {
   providerSetupMap,
   hasProviderEnvKeys,
@@ -54,20 +55,20 @@ export class SimpleAgentTemplatePage extends BasePage {
       console.warn(`[SimpleAgentTemplatePage] ${deletedFlowsCount} flow(s) deletado(s) antes de carregar o template.`);
     }
 
-    // Step 3: Open new project modal (empty page has a different button)
+    // Step 3: Open a new flow via whichever entry point the home page exposes:
+    // the header "New Flow" button (when flows exist) or the empty-page CTA
+    // (after the deletion loop above). `.or()` + the auto-waiting click absorbs
+    // the brief window where the just-closed delete-confirmation modal's
+    // backdrop is still fading and would intercept a premature click.
     const newProjectBtn = this.page.getByTestId("new-project-btn");
     const emptyBtn = this.page.getByTestId("new_project_btn_empty_page");
+    await newProjectBtn.or(emptyBtn).first().click({ timeout: 15000 });
 
-    if (await newProjectBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
-      await newProjectBtn.click();
-    } else {
-      await emptyBtn.click();
-    }
-
-    // Step 4: Select the Simple Agent template
-    await this.page.waitForSelector('[data-testid="modal-title"]', {
-      timeout: 10000,
-    });
+    // Step 4: Select the Simple Agent template.
+    // Clicking "New Flow" on 1.10.0 may navigate to a freshly-created flow and
+    // surface the FlowBuilderWelcome overlay instead of the templates modal —
+    // reconcile both via the shared helper before reading the modal.
+    await dismissWelcomeOverlayAndWaitForModal(this.page);
     await this.page.getByTestId("side_nav_options_all-templates").click();
     await this.page.getByRole("heading", { name: "Simple Agent" }).first().click();
 

--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -368,9 +368,7 @@ test(
 
 test(
   "API Request component — non-2xx HTTP response propagates status_code without crashing",
-  // @stable removed: flow editor/template fails to load on the weekly nightly run. Tracked in #363;
-  // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
-  { tag: ["@regression", "@components"] },
+  { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
@@ -144,9 +144,7 @@ for (const { label, options, skipReason } of targets) {
 
     test(
       "agent interaction suite",
-      // @stable removed: flow editor/template fails to load on the weekly nightly run. Tracked in #363;
-      // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
-      { tag: ["@release", "@components", "@agents", "@playground"] },
+      { tag: ["@stable", "@release", "@components", "@agents", "@playground"] },
       async ({ page }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(

--- a/tests/tests-automations/regression/core-functionality/llm-agents/memory-history-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/memory-history-regression.spec.ts
@@ -4,6 +4,7 @@ import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { updateOldComponents } from "../../../../helpers/flows/update-old-components";
+import { dismissWelcomeOverlayAndWaitForModal } from "../../../../helpers/flows/open-new-flow-templates-modal";
 import { PlaygroundPage } from "../../../../pages";
 import { setupLanguageModelOpenAI } from "../../../../helpers/provider-setup/setup-language-model-openai";
 
@@ -26,15 +27,19 @@ async function loadMemoryChatbot(page: Page): Promise<void> {
     await page.waitForTimeout(500);
   }
 
+  // Open a new flow via whichever entry point the home page exposes: the header
+  // "New Flow" button (when flows exist) or the empty-page CTA (after the
+  // deletion loop above). `.or()` + the auto-waiting click absorbs the brief
+  // window where the just-closed delete-confirmation modal's backdrop is still
+  // fading and would intercept a premature click.
   const newProjectBtn = page.getByTestId("new-project-btn");
   const emptyBtn = page.getByTestId("new_project_btn_empty_page");
-  if (await newProjectBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
-    await newProjectBtn.click();
-  } else {
-    await emptyBtn.click();
-  }
+  await newProjectBtn.or(emptyBtn).first().click({ timeout: 15000 });
 
-  await page.waitForSelector('[data-testid="modal-title"]', { timeout: 10000 });
+  // Clicking "New Flow" on 1.10.0 may navigate to a freshly-created flow and
+  // surface the FlowBuilderWelcome overlay instead of the templates modal —
+  // reconcile both via the shared helper before reading the modal.
+  await dismissWelcomeOverlayAndWaitForModal(page);
   await page.getByTestId("side_nav_options_all-templates").click();
   await page.getByRole("heading", { name: "Memory Chatbot" }).first().click();
   await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', { timeout: 30000 });
@@ -55,9 +60,7 @@ async function waitForChatResponse(page: Page): Promise<void> {
 test.describe("Memory Chatbot Regression", () => {
   test(
     "memory chatbot template loads with correct node structure",
-    // @stable removed: flow editor/template fails to load on the weekly nightly run. Tracked in #363;
-    // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
-    { tag: ["@release", "@agents", "@playground"] },
+    { tag: ["@stable", "@release", "@agents", "@playground"] },
     async ({ page }) => {
       await loadMemoryChatbot(page);
 
@@ -79,9 +82,7 @@ test.describe("Memory Chatbot Regression", () => {
 
   test(
     "message history context retention suite",
-    // @stable removed: flow editor/template fails to load on the weekly nightly run. Tracked in #363;
-    // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
-    { tag: ["@release", "@agents", "@playground"] },
+    { tag: ["@stable", "@release", "@agents", "@playground"] },
     async ({ page }) => {
       test.skip(
         !process.env.OPENAI_API_KEY,
@@ -131,9 +132,7 @@ test.describe("Memory Chatbot Regression", () => {
 
   test(
     "session isolation: new session has no context from previous session",
-    // @stable removed: flow editor/template fails to load on the weekly nightly run. Tracked in #363;
-    // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
-    { tag: ["@release", "@agents", "@playground"] },
+    { tag: ["@stable", "@release", "@agents", "@playground"] },
     async ({ page }) => {
       test.skip(
         !process.env.OPENAI_API_KEY,

--- a/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
@@ -162,9 +162,7 @@ for (const { label, options, skipReason } of targets) {
 
     test(
       "agent calls echo MCP tool and returns echoed message",
-      // @stable removed: flow editor/template fails to load on the weekly nightly run. Tracked in #363;
-      // tag to be restored on resolution. See @stable lifecycle in CONTRIBUTING.md.
-      { tag: ["@mcp", "@agents", "@regression"] },
+      { tag: ["@stable", "@mcp", "@agents", "@regression"] },
       async ({ page }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(


### PR DESCRIPTION
## Summary

Cluster 2 of the weekly triage (#363): six `@stable` tests timed out waiting for the templates modal / a template element that never appeared, with the editor stuck on **"Loading…"**.

**Root cause** (reproduced against `langflow-nightly:latest` = `1.10.0.dev69`, image reproducible locally): the Langflow 1.10.0 **`FlowBuilderWelcome` overlay** — *not* the `500`s speculated in the issue. Clicking "New Flow" now navigates into a freshly-created flow and surfaces the welcome overlay instead of opening the templates modal.

The repo already had a canonical helper for this (`dismissWelcomeOverlayAndWaitForModal`), but two helpers used **bespoke navigation** that bypassed it:

- `SimpleAgentTemplatePage.load()` — used by `agent-component-regression` and `mcp-client-agent`
- `loadMemoryChatbot()` — used by the three `memory-history-regression` tests

Both did `click(new-project-btn) → waitForSelector(modal-title)` directly, so the overlay surfaced and they timed out. The `api-request-component-regression` test already routed through `awaitBootstrapTest` (which handles the overlay) and passed locally — its CI failure was a manifestation of the same overlay timing.

## Changes

- Route `SimpleAgentTemplatePage.load()` and `loadMemoryChatbot()` through the shared `dismissWelcomeOverlayAndWaitForModal` helper (single source of truth for the New Flow → templates modal path).
- Harden the new-flow entry click: after the flow-deletion loop, the just-closed delete-confirmation modal's fading backdrop intermittently intercepted a premature click on the empty-page CTA. Replaced the `isVisible(2000)` race with `newProjectBtn.or(emptyBtn).first().click()`, which auto-waits for actionability. This fixed flakiness observed under `--retries=0`.
- Restored `@stable` on all six tests and removed the `// @stable removed … #363` tracking comments.
- Regenerated the QA-CHECKLIST Phase 0 block (185 → 191 `@stable` `test()` calls).

## Validation

Local, nightly `1.10.0.dev69`, `--retries=0`:

| Test | Result |
|---|---|
| `memory-history-regression` ×3 | ✅ |
| `agent-component-regression` — agent interaction suite (gpt-4o-mini) | ✅ |
| `mcp-client-agent` — echo MCP tool (gpt-4o-mini) | ✅ |
| `api-request-component-regression` — non-2xx | ✅ |

`npm run typecheck` ✅ · `npm run lint` 0 errors.

Closes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)