### PR TITLE
refactor(helpers): consolidate template loading into a single canonical path

### DIFF
--- a/tests/helpers/flows/load-template-by-name.ts
+++ b/tests/helpers/flows/load-template-by-name.ts
@@ -1,0 +1,41 @@
+import type { Page } from "@playwright/test";
+import { cleanAllFlows } from "./clean-all-flows";
+import { openNewFlowTemplatesModal } from "./open-new-flow-templates-modal";
+
+/**
+ * Canonical "load a starter template by name" flow, shared by every spec that
+ * needs a template on the canvas.
+ *
+ * Steps: clear any user-created flows (so re-loading the same template can't
+ * 400 on a duplicate name) → open the templates modal via whichever New Flow
+ * entry point exists → switch to the All Templates tab → pick the template
+ * whose heading matches `templateName`. Returns once the canvas controls are
+ * visible; callers run their own post-load steps (provider setup, component
+ * migration, assertions).
+ *
+ * Flow deletion uses the API (`cleanAllFlows`) rather than the home dropdown
+ * menu: that Radix portal detaches from the DOM mid-click under re-renders, so
+ * the old per-spec UI deletion loops were a recurring flake source.
+ */
+export const loadTemplateByName = async (
+  page: Page,
+  templateName: string,
+): Promise<void> => {
+  // Clear flows via the API first, then load home — so the page reflects the
+  // real backend state (empty page vs. populated) when we pick an entry point.
+  await cleanAllFlows(page);
+
+  await page.goto("/");
+  await page.waitForSelector('[data-testid="mainpage_title"]', {
+    timeout: 30000,
+  });
+
+  await openNewFlowTemplatesModal(page);
+
+  await page.getByTestId("side_nav_options_all-templates").click();
+  await page.getByRole("heading", { name: templateName }).first().click();
+
+  await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
+    timeout: 30000,
+  });
+};

--- a/tests/helpers/flows/open-new-flow-templates-modal.ts
+++ b/tests/helpers/flows/open-new-flow-templates-modal.ts
@@ -29,14 +29,24 @@ export const dismissWelcomeOverlayAndWaitForModal = async (page: Page) => {
 };
 
 /**
- * Clicks the header "New Flow" button (`new-project-btn`) and lands on the
- * templates modal, handling the 1.10.0 welcome overlay (see
+ * Clicks whichever "New Flow" entry point the home page exposes and lands on
+ * the templates modal, handling the 1.10.0 welcome overlay (see
  * `dismissWelcomeOverlayAndWaitForModal`).
  *
+ * Both the header button (`new-project-btn`, present when flows exist) and the
+ * empty-page CTA (`new_project_btn_empty_page`, shown on a flowless home) open
+ * the same modal — `.or().first()` picks whichever is in the DOM (the header is
+ * DOM-first when both render, which is harmless since both trigger the same
+ * action). The auto-waiting click also absorbs the brief window where a
+ * just-closed confirmation modal's backdrop is still fading.
+ *
  * Single source of truth for the "New Flow → templates modal" flow, used by
- * `awaitBootstrapTest` and any spec that opens the modal mid-test.
+ * `awaitBootstrapTest`, `loadTemplateByName`, and any spec that opens the modal
+ * mid-test.
  */
 export const openNewFlowTemplatesModal = async (page: Page) => {
-  await page.getByTestId("new-project-btn").click();
+  const newProjectBtn = page.getByTestId("new-project-btn");
+  const emptyBtn = page.getByTestId("new_project_btn_empty_page");
+  await newProjectBtn.or(emptyBtn).first().click({ timeout: 15000 });
   await dismissWelcomeOverlayAndWaitForModal(page);
 };

--- a/tests/pages/SimpleAgentTemplatePage.ts
+++ b/tests/pages/SimpleAgentTemplatePage.ts
@@ -1,7 +1,7 @@
 import type { Page } from "@playwright/test";
 import { BasePage } from "./BasePage";
 import { adjustScreenView } from "../helpers/ui/adjust-screen-view";
-import { dismissWelcomeOverlayAndWaitForModal } from "../helpers/flows/open-new-flow-templates-modal";
+import { loadTemplateByName } from "../helpers/flows/load-template-by-name";
 import {
   providerSetupMap,
   hasProviderEnvKeys,
@@ -28,55 +28,11 @@ export class SimpleAgentTemplatePage extends BasePage {
       );
     }
 
-    // Step 1: Navigate to Langflow home
-    await this.page.goto("/");
-    await this.page.waitForSelector('[data-testid="mainpage_title"]', {
-      timeout: 30000,
-    });
+    // Load the Simple Agent template onto the canvas (clears existing flows,
+    // opens the templates modal, handles the 1.10.0 welcome overlay).
+    await loadTemplateByName(this.page, "Simple Agent");
 
-    // Step 2: Delete all existing flows to avoid "flow must be unique" 400 error
-    const emptyPageDescription = this.page.getByTestId("empty_page_description");
-    let deletedFlowsCount = 0;
-    while ((await emptyPageDescription.count()) === 0) {
-      const dropdown = this.page.getByTestId("home-dropdown-menu").first();
-      if (!(await dropdown.isVisible({ timeout: 2000 }).catch(() => false)))
-        break;
-      await dropdown.click();
-      await this.page.getByTestId("btn_delete_dropdown_menu").first().waitFor({ state: "visible", timeout: 5000 });
-      await this.page.getByTestId("btn_delete_dropdown_menu").first().click();
-      await this.page
-        .getByTestId("btn_delete_delete_confirmation_modal")
-        .first()
-        .click();
-      await this.page.waitForTimeout(500);
-      deletedFlowsCount++;
-    }
-    if (deletedFlowsCount > 0) {
-      console.warn(`[SimpleAgentTemplatePage] ${deletedFlowsCount} flow(s) deletado(s) antes de carregar o template.`);
-    }
-
-    // Step 3: Open a new flow via whichever entry point the home page exposes:
-    // the header "New Flow" button (when flows exist) or the empty-page CTA
-    // (after the deletion loop above). `.or()` + the auto-waiting click absorbs
-    // the brief window where the just-closed delete-confirmation modal's
-    // backdrop is still fading and would intercept a premature click.
-    const newProjectBtn = this.page.getByTestId("new-project-btn");
-    const emptyBtn = this.page.getByTestId("new_project_btn_empty_page");
-    await newProjectBtn.or(emptyBtn).first().click({ timeout: 15000 });
-
-    // Step 4: Select the Simple Agent template.
-    // Clicking "New Flow" on 1.10.0 may navigate to a freshly-created flow and
-    // surface the FlowBuilderWelcome overlay instead of the templates modal —
-    // reconcile both via the shared helper before reading the modal.
-    await dismissWelcomeOverlayAndWaitForModal(this.page);
-    await this.page.getByTestId("side_nav_options_all-templates").click();
-    await this.page.getByRole("heading", { name: "Simple Agent" }).first().click();
-
-    await this.page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
-      timeout: 30000,
-    });
-
-    // Step 5: Adjust canvas view and configure the provider
+    // Adjust canvas view and configure the provider.
     // JSON stores model names (e.g. "claude-opus-4-6") — passed directly to setup for hasText matching
     await adjustScreenView(this.page);
     await providerSetupMap[provider](this.page, model);

--- a/tests/tests-automations/regression/core-functionality/llm-agents/memory-history-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/memory-history-regression.spec.ts
@@ -4,7 +4,7 @@ import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { updateOldComponents } from "../../../../helpers/flows/update-old-components";
-import { dismissWelcomeOverlayAndWaitForModal } from "../../../../helpers/flows/open-new-flow-templates-modal";
+import { loadTemplateByName } from "../../../../helpers/flows/load-template-by-name";
 import { PlaygroundPage } from "../../../../pages";
 import { setupLanguageModelOpenAI } from "../../../../helpers/provider-setup/setup-language-model-openai";
 
@@ -13,36 +13,7 @@ if (!process.env.CI) {
 }
 
 async function loadMemoryChatbot(page: Page): Promise<void> {
-  await page.goto("/");
-  await page.waitForSelector('[data-testid="mainpage_title"]', { timeout: 30000 });
-
-  const emptyPageDescription = page.getByTestId("empty_page_description");
-  while ((await emptyPageDescription.count()) === 0) {
-    const dropdown = page.getByTestId("home-dropdown-menu").first();
-    if (!(await dropdown.isVisible({ timeout: 2000 }).catch(() => false))) break;
-    await dropdown.click();
-    await page.getByTestId("btn_delete_dropdown_menu").first().waitFor({ state: "visible", timeout: 5000 });
-    await page.getByTestId("btn_delete_dropdown_menu").first().click();
-    await page.getByTestId("btn_delete_delete_confirmation_modal").first().click();
-    await page.waitForTimeout(500);
-  }
-
-  // Open a new flow via whichever entry point the home page exposes: the header
-  // "New Flow" button (when flows exist) or the empty-page CTA (after the
-  // deletion loop above). `.or()` + the auto-waiting click absorbs the brief
-  // window where the just-closed delete-confirmation modal's backdrop is still
-  // fading and would intercept a premature click.
-  const newProjectBtn = page.getByTestId("new-project-btn");
-  const emptyBtn = page.getByTestId("new_project_btn_empty_page");
-  await newProjectBtn.or(emptyBtn).first().click({ timeout: 15000 });
-
-  // Clicking "New Flow" on 1.10.0 may navigate to a freshly-created flow and
-  // surface the FlowBuilderWelcome overlay instead of the templates modal —
-  // reconcile both via the shared helper before reading the modal.
-  await dismissWelcomeOverlayAndWaitForModal(page);
-  await page.getByTestId("side_nav_options_all-templates").click();
-  await page.getByRole("heading", { name: "Memory Chatbot" }).first().click();
-  await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', { timeout: 30000 });
+  await loadTemplateByName(page, "Memory Chatbot");
 
   await adjustScreenView(page);
   await updateOldComponents(page);


### PR DESCRIPTION
## Summary

Follow-up to #369. As flagged in that PR's review, `SimpleAgentTemplatePage.load()` and `loadMemoryChatbot()` duplicated the identical template-load sequence (delete all flows → open templates modal → All Templates tab → pick heading by name), so the #369 welcome-overlay fix had to be applied in two bespoke paths.

## Changes

- **New `loadTemplateByName(page, name)`** (`tests/helpers/flows/load-template-by-name.ts`) — the single canonical path for "load a starter template by name". Deletes flows via the **API** (`cleanAllFlows`) instead of the home-dropdown UI loop, which detached mid-click under re-renders and was a recurring flake source (it's also what `cleanAllFlows`' own docstring warns against).
- **Extended `openNewFlowTemplatesModal`** to click the header button **or** the empty-page CTA via `.or().first()`, covering both entry points so the inline `.or()` click no longer has to be duplicated per caller. Backward compatible with `awaitBootstrapTest` and `bulk-actions` (the header is DOM-first when both render, and both buttons trigger the same action).
- **Migrated** `SimpleAgentTemplatePage.load()` and `loadMemoryChatbot()` onto the shared helper; each keeps only its post-load steps (provider setup / `updateOldComponents`).

The bespoke UI deletion loop (`btn_delete_dropdown_menu`) now exists in **zero** specs. Net **−22 lines**.

## Validation

Local, nightly `1.10.0.dev69`, `--retries=0`:

| Path | Result |
|---|---|
| memory-history ×3 (`loadTemplateByName`) | ✅ |
| agent interaction suite (`SimpleAgentTemplatePage`) | ✅ |
| mcp-client-agent (`SimpleAgentTemplatePage`) | ✅ |
| api-request non-2xx (`awaitBootstrapTest` → `openNewFlowTemplatesModal`) | ✅ |
| bulk-actions (direct `openNewFlowTemplatesModal` caller) | ✅ |
| global-variables-crud (`awaitBootstrapTest`) | ✅ |

Covered both the empty-home and populated-home states of the entry-point click. `npm run typecheck` ✅, `npm run lint` 0 errors.

> Note: `notifications.spec.ts` (`@release`, not `@stable`) fails on the legacy `Text Input` component (cluster #362) — it reaches the editor past the bootstrap path and breaks downstream, so it is unaffected by this refactor.

Closes #370