### PR TITLE
fix(ui-ux): migrate notifications spec to Chat Input and validate it

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -425,7 +425,7 @@
 - [x] Trace list filter `?session_id` filters by the session passed at run time → `traces-list-filters.spec.ts`
 
 #### 8.2 Notifications
-- [-] System notifications
+- [x] System notifications — build-success entry shows in the notifications tab → `notifications.spec.ts`
 - [-] Execution error notification
 - [-] Outdated component notification
 
@@ -739,7 +739,7 @@
 | `core-functionality/knowledge-ingestion/` | 8 | 0 | 4 | 0 | 4 |
 | `core-functionality/llm-agents/` | 40 | 13 | 2 | 0 | 25 |
 | `core-functionality/model-provider/` | 31 | 4 | 18 | 0 | 9 |
-| `core-functionality/observability-monitoring/` | 22 | 13 | 8 | 0 | 1 |
+| `core-functionality/observability-monitoring/` | 22 | 14 | 7 | 0 | 1 |
 | `core-functionality/playground/` | 48 | 43 | 3 | 1 | 1 |
 | `core-functionality/project-management/` | 11 | 0 | 10 | 1 | 0 |
 | `core-functionality/templates/` | 41 | 2 | 39 | 0 | 0 |
@@ -748,7 +748,7 @@
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 43 | 3 | 38 | 1 | 1 |
 | `ui-ux/` — Settings | 5 | 1 | 3 | 1 | 0 |
-| **TOTAL** | **434** | **190 (44%)** | **184 (42%)** | **7 (2%)** | **53 (12%)** |
+| **TOTAL** | **434** | **191 (44%)** | **183 (42%)** | **7 (2%)** | **53 (12%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -764,7 +764,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 191 `test()` calls carrying the `@stable` tag, distributed across 64 spec
+> 192 `test()` calls carrying the `@stable` tag, distributed across 65 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -979,6 +979,7 @@
 - [x] create a Generic type global variable → `global-variables-crud.spec.ts`
 - [x] delete a global variable removes it from the list → `global-variables-crud.spec.ts`
 - [x] Credential variable value is hidden from the variable list → `global-variables-crud.spec.ts`
+- [x] User should be able to interact notifications tab → `notifications.spec.ts`
 - [x] dark and light mode toggle correctly updates the body class → `settings-theme-toggle.spec.ts`
 
 ---
@@ -1008,7 +1009,7 @@
 
 | Module | Validate (`[-]`) | Create (`[ ]`) |
 |--------|-----------------|---------------|
-| `core-functionality/observability-monitoring/` | 8 | 1 |
+| `core-functionality/observability-monitoring/` | 7 | 1 |
 | `core-functionality/knowledge-ingestion/` | 4 | 4 |
 | `flow-functionality/` | 13 | 0 |
 | `core-functionality/project-management/` | 10 | 0 |

--- a/docs/ui-ux/notifications.md
+++ b/docs/ui-ux/notifications.md
@@ -1,0 +1,78 @@
+# Notifications — Build-Success Entry in the Notifications Tab
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+Validates that running a component surfaces a notification, and that the
+Notifications tab opened from the header bell renders that entry:
+
+1. A blank flow with a single **Chat Input** is built successfully.
+2. Clicking the notification bell (`notification_button`) opens the Notifications
+   tab, which shows the **"Flow built successfully"** entry alongside the
+   per-notification delete (Trash2) control.
+
+If this breaks, users lose visibility into build outcomes — the notification
+center either fails to open or does not record successful builds.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@ui-ux`
+
+---
+
+## Step by step *(required)*
+
+1. Bootstrap app (`awaitBootstrapTest`) and create a blank flow
+2. Search the sidebar for `chat input` and add the **Chat Input** component
+3. Assert the canvas has exactly 1 node
+4. Click the node title and expand it (Chat Input is added minimized, so the run
+   button is not in the DOM until expanded — `expandFocusedNode`)
+5. Click the component run button (`button_run_chat input`)
+6. Wait for the **"built successfully"** toast
+7. Click the notification bell (`notification_button`)
+8. Assert the Notifications tab shows the "Notifications" heading, a Trash2
+   delete icon, and the **"Flow built successfully"** entry
+
+---
+
+## Validation criterion *(required)*
+
+- The "built successfully" toast appears after running Chat Input
+- After opening the Notifications tab: the "Notifications" label, a `icon-Trash2`
+  control, and the exact text **"Flow built successfully"** are all visible
+
+---
+
+## External dependencies *(required)*
+
+- `src/frontend/src/components/core/` — notifications dropdown / alert center
+- `data-testid="notification_button"` — header notification bell
+- `data-testid="icon-Trash2"` — per-notification delete control
+- `data-testid="input_outputChat Input"` / `add-component-button-chat-input` /
+  `button_run_chat input` — Chat Input sidebar entry, add button, run button
+- No API key required — Chat Input builds without an LLM call
+
+---
+
+## What this test does not cover *(optional)*
+
+- Clearing/deleting notifications (the Trash2 control is asserted visible but not
+  clicked)
+- Error and warning notifications (only the build-success path is exercised)
+- Notification persistence across reload
+
+---
+
+## Notes *(optional)*
+
+- Migrated from **Text Input** to **Chat Input**: Langflow marked Text I/O as
+  `legacy: true` on 1.10.0 and the sidebar hides legacy components by default, so
+  the original trigger was unreachable. Chat Input is the durable equivalent
+  (same migration approach as #366).
+- Chat Input defaults to `minimized = True`; `expandFocusedNode` expands it so the
+  on-node run button is present in the DOM before the run click.

--- a/tests/tests-automations/regression/ui-ux/notifications.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/notifications.spec.ts
@@ -1,56 +1,68 @@
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 
+// Expand the currently focused node from minimized to full view. Chat Input
+// defaults to `minimized = True`; without expanding, the run button rendered on
+// the node body is not present in the DOM. Idempotent: if the node is already
+// expanded (no `hide-node-content` in the DOM) the helper is a no-op.
+async function expandFocusedNode(page: Page) {
+  if ((await page.getByTestId("hide-node-content").count()) === 0) return;
+  await page.getByTestId("more-options-modal").click();
+  await expect(page.getByTestId("expand-button-modal")).toBeVisible({
+    timeout: 10000,
+  });
+  await page.getByTestId("expand-button-modal").click();
+  await expect(page.getByTestId("hide-node-content")).toHaveCount(0, {
+    timeout: 5000,
+  });
+}
+
 test(
   "User should be able to interact notifications tab",
-  { tag: ["@release"] },
+  { tag: ["@stable", "@release", "@ui-ux"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
     await page.getByTestId("blank-flow").click();
-    await page.waitForSelector('[data-testid="disclosure-input & output"]', {
-      timeout: 3000,
-      state: "visible",
-    });
 
-    await page.getByTestId("disclosure-input & output").click();
-    await page.waitForSelector('[data-testid="input_outputText Input"]', {
-      timeout: 3000,
-      state: "visible",
-    });
+    // Add a Chat Input and run it to produce a "Flow built successfully"
+    // notification. Text Input (the original trigger) is `legacy` on 1.10.0 and
+    // hidden from the sidebar — Chat Input is the durable equivalent.
+    await page.getByTestId("sidebar-search-input").fill("chat input");
     await page
-      .getByTestId("input_outputText Input")
+      .getByTestId("input_outputChat Input")
       .hover()
       .then(async () => {
-        await page.getByTestId("add-component-button-text-input").click();
-        await page.getByTestId("button_run_text input").click();
+        await page.getByTestId("add-component-button-chat-input").click();
       });
-
-    await page.waitForSelector("text=Running", {
-      timeout: 30000,
-      state: "visible",
+    await expect(page.locator(".react-flow__node")).toHaveCount(1, {
+      timeout: 10000,
     });
 
-    await page.waitForSelector("text=built successfully", { timeout: 30000 });
+    // Chat Input is added minimized — expand it so the run button is in the DOM.
+    await page.getByTestId("title-Chat Input").click();
+    await expandFocusedNode(page);
+
+    await page.getByTestId("button_run_chat input").click();
+    await expect(page.getByText("built successfully").last()).toBeVisible({
+      timeout: 30000,
+    });
+
     await page.getByTestId("notification_button").click();
 
-    // Add explicit waits before checking visibility
-    await page.waitForSelector('[data-testid="icon-Trash2"]', {
-      timeout: 3000,
-      state: "visible",
+    await test.step("notifications tab shows the build-success entry", async () => {
+      const notificationsText = page
+        .getByText("Notifications", { exact: true })
+        .last();
+      await expect(notificationsText).toBeVisible({ timeout: 10000 });
+
+      const trashIcon = page.getByTestId("icon-Trash2").last();
+      await expect(trashIcon).toBeVisible();
+
+      const builtSuccessfullyText = page
+        .getByText("Flow built successfully", { exact: true })
+        .last();
+      await expect(builtSuccessfullyText).toBeVisible();
     });
-
-    // Then check visibility
-    const notificationsText = page
-      .getByText("Notifications", { exact: true })
-      .last();
-    await expect(notificationsText).toBeVisible();
-
-    const trashIcon = page.getByTestId("icon-Trash2").last();
-    await expect(trashIcon).toBeVisible();
-
-    const builtSuccessfullyText = page
-      .getByText("Flow built successfully", { exact: true })
-      .last();
-    await expect(builtSuccessfullyText).toBeVisible();
   },
 );


### PR DESCRIPTION
## Summary

`notifications.spec.ts` triggered a flow build via the legacy **Text Input** component, which Langflow marked `legacy: true` on 1.10.0 and hides from the sidebar by default — the test failed deterministically waiting for `input_outputText Input` (surfaced while validating #363's cluster).

Migrated the trigger to **Chat Input**, the durable equivalent — same approach as #366. This brings a previously **unvalidated** spec (`@release` only, no spec doc) through the full validation process; per the project rule that any spec touched must carry `@stable` + a spec doc, it lands validated.

## Changes

- **Migration**: search the sidebar → add **Chat Input** → expand it (Chat Input is added `minimized = True`, so the on-node run button isn't in the DOM until expanded — inline `expandFocusedNode` helper, same convention as the `chat-input-output-component-regression` spec) → run → assert the notifications tab shows the **"Flow built successfully"** entry. Replaced the brittle `waitForSelector("text=Running")` / `waitForSelector(...)` calls with web-first `expect()` assertions.
- **`@stable` + `@ui-ux`** added.
- **`docs/ui-ux/notifications.md`** created with all mandatory sections.
- **QA-CHECKLIST**: marked the *System notifications* bullet `[x]` → `notifications.spec.ts`; auto blocks regenerated (**192** `@stable` `test()` calls across **65** spec files).

## Validation

Internal validation process, `langflow-nightly` **1.10.0.dev69**, `--retries=0`:

| Step | Result |
|---|---|
| Test passes | ✅ (~6s) |
| Trace review | ✅ Chat Input path exercised (search → add → **expand** → run → notification bell → assertions) |
| Forced-failure (false-positive) | ✅ fails cleanly at the "Flow built successfully" assertion |
| Backend errors (explicit grep) | ✅ zero |
| `npm run typecheck` / `npm run lint` | ✅ / ✅ (0 errors) |

## Scope

One spec. The other 10 specs still referencing legacy Text I/O are unvalidated and will be migrated as each goes through its own validation — no umbrella issue, by design.