### PR TITLE
test: remove @stable from two weekly hard-failure tests (#382)

### DIFF
--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -246,7 +246,7 @@ test(
 
 test(
   "API Request component — POST method executes POST verb and returns 200",
-  { tag: ["@stable", "@release", "@regression", "@components"] },
+  { tag: ["@release", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
 

--- a/tests/tests-automations/regression/core-functionality/project-management/edit-flow-name.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/edit-flow-name.spec.ts
@@ -4,7 +4,7 @@ import { renameFlow } from "../../../../helpers/flows/rename-flow";
 
 test(
   "user should be able to edit flow name and see it reflected in the main page listing",
-  { tag: ["@stable", "@release", "@workspace", "@regression"] },
+  { tag: ["@release", "@workspace", "@regression"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 


### PR DESCRIPTION
## What

Removes the `@stable` tag from the **two tests that hard-failed** in the weekly run [27546448127](https://github.com/oriontech-me/langflow-e2e/actions/runs/27546448127) (2026-06-15), pulling them out of the weekly `@stable` suite per the lifecycle table in `CONTRIBUTING.md`.

| Test | Reason | Recurrence | Tracking |
|---|---|---|---|
| `core-functionality/project-management/edit-flow-name.spec.ts:5` | Fragile `rename-flow.ts` helper (3000ms timeouts, detached `input-flow-name`, `save-flow-settings` never enabled). Save/refresh timing race. | Hard fail **2nd consecutive** (06-08 + 06-15) | #357 |
| `core-components/api-request-component-regression.spec.ts:247` (POST) | External dependency outage — `httpbin.org` returned **503** (AWS ELB). Not a test logic bug nor a confirmed Langflow regression. | Hard fail this week; suite chronically coupled to httpbin | #383 |

## What this is NOT

No logic, helper, or selector changes — **only the tag arrays** are edited. Per project convention a *temporary* `@stable` removal is tracked via its GitHub issue and requires no spec-doc change. The `@stable` tag is to be restored in the respective follow-up once each root cause is addressed (helper hardening for #357; external-dependency hardening for #383).

The **7 flaky** tests of the same run keep `@stable` (absorbed by the retry budget) and are investigated separately in #384.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — 0 errors

## Scope

This PR is the **triage action only** (removing `@stable`). It does **not** close any issue: #357 and #383 are triage follow-ups and stay open until each root cause is attacked individually (the correction PR that fixes the cause restores `@stable` and closes the issue). The umbrella #382 was the only issue to close, and is already closed.

Refs #382, #357, #383
