### PR TITLE
fix(api-request): retry transient httpbin.org 5xx, restore @stable on POST

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,17 @@ PLAYWRIGHT_BASE_URL=http://localhost:7860/
 LANGFLOW_SUPERUSER=langflow
 LANGFLOW_SUPERUSER_PASSWORD=langflow
 
+# Echo endpoint for the API Request component tests. Leave empty to use the
+# public https://httpbin.org (the default). Resilience to transient httpbin.org
+# 5xx outages is handled by a retry in the test (issue #383), so this override
+# is optional — set it only to point the tests at a different echo endpoint
+# (e.g. a locally self-hosted go-httpbin). The value must be reachable BY
+# LANGFLOW — the component's backend makes the request, not the test runner.
+# Note: a self-hosted host on a private IP must also be added to Langflow's
+# LANGFLOW_SSRF_ALLOWED_HOSTS, and the component's URL validator rejects
+# single-label hostnames (use a dotted host or an IP).
+HTTPBIN_BASE_URL=
+
 # API keys for integration tests (optional)
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=

--- a/docs/core-components/api-request-component-regression.md
+++ b/docs/core-components/api-request-component-regression.md
@@ -1,6 +1,6 @@
 # API Request Component — Rendering, Inspector, HTTP Methods, cURL Mode and Error Paths
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.11.x
 
 ---
 
@@ -9,7 +9,7 @@
 Validates the **API Request** component end-to-end via 15 scenarios grouped into five categories:
 
 1. **Canvas rendering and inspector fields** — the node renders with the correct URL/API Response handles, and the inspector accepts URL + HTTP method input.
-2. **Execution per HTTP verb** — GET, POST, PUT, PATCH, DELETE each round-trip to a `httpbin.org` endpoint that **only** accepts that verb (any other verb returns 405). The output Data is asserted to contain `200`, the echoed URL, and the expected structural keys (`source`, `status_code`, `response_headers`, `result`).
+2. **Execution per HTTP verb** — GET, POST, PUT, PATCH, DELETE each round-trip to an echo endpoint that **only** accepts that verb (any other verb returns 405). The output Data is asserted to contain `200`, the echoed URL host, and the expected structural keys (`source`, `status_code`, `response_headers`, `result`). The endpoint defaults to public `httpbin.org` (overridable via `HTTPBIN_BASE_URL`); a transient upstream 5xx is absorbed by a retry in `runAndOpenOutput` so it does not fail the suite — see "Validation criterion" and issue #383.
 3. **Error and edge paths** — invalid URL shows the build-error notification, non-2xx responses (404) propagate as `status_code` without raising, query parameters embedded in the URL are sent and echoed back.
 4. **Inspector tables and cURL mode** — the headers key-value table accepts both key and value cell entries via the View Text editor; the body key-value table is accessed through the Controls modal (the body field is `advanced=True`) and accepts both key and value cell entries via the same editor; the cURL tab switches mode and the cURL parser auto-populates the URL field with the URL extracted from the cURL command, after which the run executes the GET successfully.
 5. **Persistence to flow JSON** — configuring URL, method and a headers row triggers an autosave that persists into the flow's saved state (verified by polling `GET /api/v1/flows/{id}`), and a full page reload rehydrates the inspector with the same values.
@@ -91,7 +91,9 @@ For each of GET, POST, PUT, PATCH, DELETE:
 
 The suite must:
 
-- Use `getByTestId("popover-anchor-input-url_input")`, `getByTestId("dropdown_str_method")`, `getByTestId("button_run_api request")` and the `output-inspection-api response-apirequest` testid — i18n-proof.
+- Use `getByTestId("popover-anchor-input-url_input")`, `getByTestId("dropdown_str_method")`, `getByTestId("button_run_api request")`, the `output-inspection-api response-apirequest` testid and (for reading the full output) `copy-output-button` — i18n-proof.
+- Read execution output via the dialog's copy button + clipboard, not the Monaco editor's `textContent`: the editor is virtualized, so `textContent` only returns lines in the viewport and silently truncates fields below the fold for a verbose response. The helper clears the clipboard first (it persists across the serial tests) and polls until the fresh output lands rather than waiting on the transient "Copied to clipboard" toast.
+- Retry past transient upstream outages: `runAndOpenOutput` re-runs the component (up to 3 attempts) when its own top-level `status_code` is `5xx` or when a run produces no readable output (build error / timeout). Each attempt anchors on its build event stream closing (not on the inspect button, which stays enabled across re-runs and would re-read stale output). No test here expects a 5xx, so retrying on one never masks a real assertion; once retries are exhausted on a still-5xx output it **throws loudly** rather than returning the 5xx, so a sustained outage or a regression surfacing as a 5xx fails clearly instead of slipping past a weak substring assertion (issue #383).
 - Run **serially** (`test.describe.configure({ mode: "serial" })`) — parallel autosaves on flow create cause `400 "flow must be unique"` errors that flag as backend errors in the fixture.
 - For each verb test, hit a `httpbin.org` endpoint that returns 405 for any other verb — this guarantees the test fails if the wrong verb is sent (e.g. POST sent as GET).
 - For the cURL execution test, switch to the cURL tab *before* configuring the URL — and assert the parser auto-populates `url_input`. Asserting only the run output would let the test pass even if cURL parsing was broken.
@@ -114,7 +116,7 @@ The suite must:
 - `src/frontend/src/CustomNodes/GenericNode/index.tsx` — owns the inspector layout that exposes `popover-anchor-input-url_input`, `dropdown_str_method`, `div-table_headers`, `tab_0_url`, `tab_1_curl`, etc.
 - `src/frontend/src/pages/FlowPage/components/InspectionPanel/components/InspectionPanelFields.tsx` — owns the `APIRequest` + `body` + GET filter that test 14 navigates around by switching method to POST
 - `src/frontend/src/components/core/parameterRenderComponent/components/TableNodeComponent/index.tsx` — owns the `[value]` useEffect that drives the `real_time_refresh` race in the body table (test 14's force+retry)
-- `httpbin.org` — external test target; if it is unreachable from CI, the 5 verb tests, the 404 test, and the query-parameter test all fail by external reason rather than by Langflow regression (see "Notes")
+- **Echo endpoint** (`HTTPBIN_BASE_URL`, default `https://httpbin.org`) — external test target for the 5 verb tests, the 404 test, the query-parameter test and the cURL-execute test. The request is made **by the Langflow backend**, so the URL must be reachable by Langflow, not by the Playwright runner. A transient upstream 5xx (httpbin.org sits behind an AWS ELB that intermittently returns 502/503/504) no longer hard-fails the suite: `runAndOpenOutput` retries on any 5xx output (issue #383). The spec derives `HTTPBIN_HOST` from the same base URL, so the echoed-host assertions hold for any configured endpoint. Self-hosting an echo endpoint in CI was evaluated and rejected: Langflow's SSRF protection blocks the service's private IP, and — decisively — the component's `validators.url()` check rejects the single-label service hostname (`http://httpbin:8080`) that a GitHub Actions service container is reachable by. To self-host **locally**, point `HTTPBIN_BASE_URL` at a dotted host or IP and add it to `LANGFLOW_SSRF_ALLOWED_HOSTS` on the Langflow process.
 
 ---
 
@@ -131,7 +133,7 @@ The suite must:
 ## Preconditions *(optional)*
 
 - Langflow running at `PLAYWRIGHT_BASE_URL`
-- Outbound HTTPS to `httpbin.org` reachable from the runner
+- An echo endpoint reachable **by Langflow** at `HTTPBIN_BASE_URL` (defaults to outbound HTTPS to `httpbin.org`); transient 5xx outages are absorbed by the retry in `runAndOpenOutput`
 - No LLM required
 
 ---
@@ -141,7 +143,7 @@ The suite must:
 - The API Request field schema changes in `api_request.py` (URL, method, headers, body, curl_input field names)
 - The inspector layout changes such that `popover-anchor-input-url_input`, `dropdown_str_method`, or `tab_0_url`/`tab_1_curl` testids are renamed or restructured
 - The cURL parser changes its auto-fill behavior (e.g., it stops auto-populating `url_input` from the cURL command, or moves to a different field)
-- `httpbin.org` becomes unavailable — switch the verb tests to a stable equivalent (e.g., a self-hosted echo server or `postman-echo.com`)
+- The default echo endpoint needs to change — set `HTTPBIN_BASE_URL` (no code change). Any httpbin-compatible echo server works (the spec relies only on the `/get`, `/post`, `/put`, `/patch`, `/delete`, `/status/{code}` paths, 405-on-wrong-verb, and the Host-echoing behavior). A self-hosted host on a private IP must be added to `LANGFLOW_SSRF_ALLOWED_HOSTS`, and the component's URL validator rejects single-label hostnames (use a dotted host or an IP)
 - `InspectionPanelFields.tsx` drops the `APIRequest` + `body` + GET filter (or makes it conditional on a different field) — at that point test 14 can drop the method-switch step and mirror the headers test directly
 - The `POST /api/v1/custom_component/update` endpoint is renamed or restructured — tests 14 and 15 both use `page.waitForResponse(...)` keyed on that URL substring
 - The autosave debounce interval is increased substantially — bump the persistence test's polling timeout (currently 20s) to match
@@ -153,6 +155,11 @@ The suite must:
 
 - **Duplicate coverage with legacy specs.** `tests/tests-automations/regression/api/flows/api-request-component-ui.spec.ts` (4 tests: canvas render, URL field, method dropdown, headers field) is fully superseded by tests 1, 2, and 11 of this spec — its 4th test uses anti-patterns (`.catch(() => false)`, conditional advanced-button click) that this consolidated spec replaces with deterministic locators. `tests/tests-automations/regression/api/flows/api-component-regression.spec.ts` (5 tests: GET, cURL POST + JSON body with auto-fill URL, `include_httpx_metadata`, timeout 500, URL-mode POST via dropdown) is partially duplicated by tests 4, 5, and 13 here, but contains 3 unique tests (`include_httpx_metadata`, timeout, cURL POST + body). A follow-up PR should migrate those 3 unique tests here and retire both legacy specs.
 - **`(page as any).allowFlowErrors()` cast.** The fixture injects `allowFlowErrors` onto the page object via `(page as any).allowFlowErrors = () => {...}`, without extending the `Page` type. Removing the cast at the call site requires extending the type signature in `fixtures.ts`. The pattern is project-wide (`loop-component-regression.spec.ts` uses the same cast).
-- **Why one verb per `httpbin.org` endpoint.** `httpbin.org/get`, `/post`, `/put`, `/patch`, `/delete` each return 405 if hit with any other verb. This means the test fails if the component sends the wrong method — there's no way to silently pass with a misconfigured verb.
+- **Why one verb per endpoint.** `/get`, `/post`, `/put`, `/patch`, `/delete` each return 405 if hit with any other verb (true for both httpbin.org and go-httpbin). This means the test fails if the component sends the wrong method — there's no way to silently pass with a misconfigured verb.
+- **Echo endpoint resilience (issue #383).** The verb/404/query/cURL tests originally hard-coded `https://httpbin.org/...`. A transient httpbin.org `503` (AWS ELB) hard-failed the POST test and flaked GET in the weekly run, opening #383. The fix makes the suite tolerate transient outages without masking a real regression:
+  - **Retry**, not self-hosting. `runAndOpenOutput` re-runs the component (up to 3 attempts) when the output carries any `5xx` `status_code` or a run produces no readable output. Self-hosting a `mccutchen/go-httpbin` service container in the weekly workflow was implemented and tested first, but rejected after a CI run surfaced a hard blocker: the component's `validators.url()` rejects the single-label service hostname (`http://httpbin:8080`) that a GitHub Actions service container is reachable by (it also requires an SSRF allowlist for the service's private IP). `validators.url` accepts dotted hosts and IPs but not bare labels — which is why local testing via `host.containers.internal` passed and CI did not.
+  - **Endpoint override kept.** URLs are built from `HTTPBIN_BASE_URL` (default `https://httpbin.org`) and the echoed-host assertions derive `HTTPBIN_HOST` from the same base, so a different endpoint can be configured without code changes.
+  - **Full-output read.** `runAndOpenOutput` reads the COMPLETE output via the dialog's copy button + clipboard (`copy-output-button`) instead of the truncation-prone virtualized Monaco `textContent` — a robustness fix kept from the self-hosting attempt (a verbose response can push asserted fields like `url` below the editor's viewport).
+  - Validated against nightly `1.11.0.dev8`, 15/15 green against public httpbin.org — no product regression behind the original failure, confirming it was purely the external outage. `@stable` was restored on the POST test in the same change.
 - **cURL pre-fill anti-pattern (fixed).** The previous version of test 13 pre-populated `url_input` before switching to the cURL tab. The run would then succeed via the URL-tab path even if the cURL parser was broken. The current test switches to the cURL tab first and waits for the parser to auto-populate `url_input` — the run is genuinely driven by the cURL command.
 - **Headers table value-cell gap (fixed).** The previous version of test 11 only filled the key cell and closed the dialog with Cancel. It would have passed even if the value column was non-functional. The current version fills both key and value cells via `fillViewTextCell`, which asserts each cell renders as a button after Save inside the table dialog — closing the gap.

--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -7,6 +7,25 @@ import { enableInspectPanel } from "../../../helpers/ui/open-advanced-options";
 // Run tests serially to avoid "flow must be unique" 400 errors from parallel autosaves
 test.describe.configure({ mode: "serial" });
 
+// Echo endpoint base for the HTTP-execution tests. Defaults to the public
+// httpbin.org. Resilience to a transient httpbin.org 5xx outage is handled by
+// the retry in `runAndOpenOutput` (see issue #383), not by self-hosting — the
+// component's URL validator rejects single-label hostnames, which rules out a
+// CI service-container reachable only by its bare service label.
+//
+// The override knob remains for anyone who wants to point the tests at a
+// different echo endpoint (e.g. a locally self-hosted go-httpbin, which is a
+// drop-in reimplementation of httpbin.org with the same paths, 405-on-wrong-verb
+// behavior and Host-echoing). The value must be reachable BY LANGFLOW — the
+// component's backend makes the request, not the Playwright runner — and a
+// self-hosted host on a private IP must be added to LANGFLOW_SSRF_ALLOWED_HOSTS.
+// HTTPBIN_HOST is derived from the same base URL so the echoed-host assertions
+// match whatever endpoint is configured.
+const HTTPBIN_BASE = (
+  process.env.HTTPBIN_BASE_URL ?? "https://httpbin.org"
+).replace(/\/$/, "");
+const HTTPBIN_HOST = new URL(HTTPBIN_BASE).host;
+
 // Helper: create a blank flow and add the API Request component to the canvas.
 // After this call the component node is visible and its inspector is open.
 async function addApiRequestComponent(page: Page) {
@@ -30,28 +49,145 @@ async function addApiRequestComponent(page: Page) {
   });
 }
 
-// Helper: run the component and return the raw text content from the output inspection dialog.
-// The output Data object is displayed in a Monaco editor — textContent gives the JSON string.
+// The output Data object the component returns is JSON. A transient upstream
+// failure surfaces as the component's OWN top-level `status_code` being 5xx
+// (httpbin.org sits behind an AWS ELB that intermittently returns 502/503/504;
+// an httpx transport blip surfaces as status_code 500 with an `error` field).
+// The component faithfully propagates the upstream status — this is not a
+// Langflow bug — so `runAndOpenOutput` re-runs rather than failing the
+// assertion (issue #383). Parse and check the TOP-LEVEL status_code only: a
+// 5xx echoed inside the response body (`result`) or a `redirection_history`
+// entry must NOT trigger a retry. No test under this spec expects a 5xx, so
+// retrying on the component's own 5xx is always safe.
+function isTransientOutput(output: string): boolean {
+  try {
+    const code = Number(
+      (JSON.parse(output) as { status_code?: unknown }).status_code,
+    );
+    return Number.isInteger(code) && code >= 500 && code <= 599;
+  } catch {
+    // Output was not parseable JSON (the component always emits a JSON Data
+    // object here, so this is not expected). We cannot confirm a TOP-LEVEL 5xx
+    // without parsing, and a regex would also match a 5xx nested in the body —
+    // violating the top-level-only contract — so do not retry.
+    return false;
+  }
+}
+
+// The output dialog and a Radix popover both render `role="dialog"` into
+// body-level portals (see tableDialog), so scope to the dialog that actually
+// holds the output copy button — an unscoped locator is non-deterministic.
+function outputDialog(page: Page): Locator {
+  return page
+    .locator('[role="dialog"]')
+    .filter({ has: page.getByTestId("copy-output-button") });
+}
+
+// Close the output dialog between runs and assert it actually closed, so a
+// stuck-open dialog surfaces here instead of as an obscured-click timeout on
+// the next run.
+async function closeOutputDialog(page: Page): Promise<void> {
+  const dialog = outputDialog(page);
+  if (!(await dialog.isVisible().catch(() => false))) return;
+  await page.keyboard.press("Escape");
+  await expect(dialog).toBeHidden({ timeout: 5000 });
+}
+
+// Helper: run the component once and return the COMPLETE output Data as a string.
 //
-// Anchors the build-finished signal on the inspect-output button becoming enabled —
-// this is the actual precondition for the next click. The previous version waited on
-// a "built successfully" toast, which matched any visible toast with that text and
-// could resolve against a stale node from a prior step before fading.
-async function runAndOpenOutput(page: Page): Promise<string> {
+// Anchors the build-finished signal on this run's build event stream closing
+// (NDJSON stream end = build complete), NOT on the inspect-output button being
+// enabled. The button stays enabled across re-runs because the prior output
+// persists in the flowPool, so on a retry `toBeEnabled` would resolve instantly
+// and we'd re-read the stale output instead of the fresh run (issue #383).
+//
+// Reads the output via the dialog's copy button + clipboard rather than the
+// Monaco editor's textContent: the editor is virtualized, so textContent only
+// returns the lines in the viewport and silently truncates fields below the
+// fold for long responses.
+async function runOnce(page: Page): Promise<string> {
   const inspectButton = page.getByTestId(
     "output-inspection-api response-apirequest",
   );
+  // Register the waiter before the click so we capture THIS run's build stream.
+  // Assumes streaming event delivery (the default for the nightly image under
+  // test — the build events come back as a single application/x-ndjson stream).
+  // If the instance is ever configured for POLLING event delivery, the events
+  // endpoint is fetched in a loop of short requests and `finished()` would
+  // resolve on the first poll rather than at build completion — the anchor
+  // below would then need to key off build completion differently.
+  const buildComplete = page.waitForResponse(
+    (r) => r.url().includes("/api/v1/build/") && r.url().includes("/events"),
+    { timeout: 45000 },
+  );
   await page.getByTestId("button_run_api request").click();
+  // `finished()` resolves when the NDJSON event stream closes — i.e. the build
+  // (with its fresh output) is complete and the flowPool has been updated.
+  await (await buildComplete).finished();
   await expect(inspectButton).toBeEnabled({ timeout: 45000 });
 
   await inspectButton.click();
-  const dialog = page.locator('[role="dialog"]');
+  const dialog = outputDialog(page);
   await expect(dialog).toBeVisible({ timeout: 10000 });
 
-  return await dialog
-    .locator("[role='textbox']")
-    .first()
-    .evaluate((el: HTMLElement) => el.textContent ?? "");
+  const copyButton = dialog.getByTestId("copy-output-button");
+  await expect(copyButton).toBeVisible({ timeout: 10000 });
+
+  // Clear the clipboard first: it persists across the serial tests, so without
+  // this the poll below could return a previous test's output immediately
+  // (length > 0) before the fresh copy lands. Then click copy and poll rather
+  // than waiting on the transient "Copied to clipboard" toast, which can fade
+  // before the assertion runs — re-click and re-read until the output lands.
+  await page.evaluate(() => navigator.clipboard.writeText(""));
+  let clipboard = "";
+  await expect(async () => {
+    await copyButton.click();
+    clipboard = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboard.length).toBeGreaterThan(0);
+  }).toPass({ timeout: 15000 });
+  return clipboard;
+}
+
+// Helper: run the component and return its output, retrying past transient
+// upstream 5xx outages and runs that produce no readable output (build error /
+// timeout). This decouples the suite from httpbin.org's intermittent
+// availability without masking a real Langflow regression — a persistent
+// failure exhausts the retries and the caller's assertion reports the actual
+// content (issue #383).
+async function runAndOpenOutput(page: Page): Promise<string> {
+  const maxAttempts = 3;
+  let output = "";
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      output = await runOnce(page);
+    } catch (error) {
+      // No readable output (build error / timeout). Re-run unless this was the
+      // last attempt, in which case surface the original failure. Best-effort
+      // close here — we are already in a degraded state.
+      if (attempt === maxAttempts) throw error;
+      await closeOutputDialog(page).catch(() => {});
+      continue;
+    }
+    if (!isTransientOutput(output)) {
+      return output;
+    }
+    // Still a transient upstream 5xx. Fail LOUDLY once retries are exhausted
+    // rather than returning the 5xx body: the caller's substring assertions
+    // (e.g. toContain("200")) are too weak to reliably distinguish a 5xx Data
+    // blob from a 200 one, so returning it could let a sustained outage — or a
+    // real regression that surfaces as a 5xx — pass silently (issue #383).
+    if (attempt === maxAttempts) {
+      throw new Error(
+        `API Request returned a transient upstream 5xx on all ${maxAttempts} ` +
+          `attempts (sustained outage or a regression surfacing as 5xx). ` +
+          `Last output: ${output.slice(0, 500)}`,
+      );
+    }
+    // Close the dialog and re-run the component.
+    await closeOutputDialog(page);
+  }
+  // Unreachable: the final attempt always returns or throws above.
+  return output;
 }
 
 // Helper: click an AG Grid cell, fill the resulting textarea editor, and save.
@@ -164,8 +300,8 @@ test(
     // URL field — testid: popover-anchor-input-url_input
     const urlInput = page.getByTestId("popover-anchor-input-url_input");
     await expect(urlInput).toBeVisible({ timeout: 10000 });
-    await urlInput.fill("https://httpbin.org/get");
-    await expect(urlInput).toHaveValue("https://httpbin.org/get");
+    await urlInput.fill(`${HTTPBIN_BASE}/get`);
+    await expect(urlInput).toHaveValue(`${HTTPBIN_BASE}/get`);
 
     // Method dropdown — default is GET; confirm it can be changed to POST
     const methodDropdown = page.getByTestId("dropdown_str_method");
@@ -222,13 +358,13 @@ test(
 
     const urlInput = page.getByTestId("popover-anchor-input-url_input");
     await expect(urlInput).toBeVisible({ timeout: 10000 });
-    await urlInput.fill("https://httpbin.org/get");
+    await urlInput.fill(`${HTTPBIN_BASE}/get`);
 
     const output = await runAndOpenOutput(page);
 
     // HTTP response fields
     expect(output).toContain("200");
-    expect(output).toContain("httpbin.org");
+    expect(output).toContain(HTTPBIN_HOST);
 
     // Structural fields always present in Data output regardless of response content —
     // verifying all at once protects against regressions in make_request() output structure
@@ -237,7 +373,7 @@ test(
     expect(output).toContain("response_headers");
     expect(output).toContain("result");
 
-    // httpbin.org/get echoes the request URL inside `result`
+    // /get echoes the request URL inside `result`
     expect(output).toContain('"url"');
 
     await page.keyboard.press("Escape");
@@ -246,14 +382,14 @@ test(
 
 test(
   "API Request component — POST method executes POST verb and returns 200",
-  { tag: ["@release", "@regression", "@components"] },
+  { tag: ["@stable", "@release", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
 
     const urlInput = page.getByTestId("popover-anchor-input-url_input");
     await expect(urlInput).toBeVisible({ timeout: 10000 });
-    // httpbin.org/post only accepts POST — returns 405 for any other method
-    await urlInput.fill("https://httpbin.org/post");
+    // /post only accepts POST — returns 405 for any other method
+    await urlInput.fill(`${HTTPBIN_BASE}/post`);
 
     const methodDropdown = page.getByTestId("dropdown_str_method");
     await expect(methodDropdown).toBeVisible({ timeout: 10000 });
@@ -265,9 +401,9 @@ test(
 
     const output = await runAndOpenOutput(page);
 
-    // A successful POST to httpbin.org/post returns 200 and echoes the request URL
+    // A successful POST to /post returns 200 and echoes the request URL
     expect(output).toContain("200");
-    expect(output).toContain("httpbin.org/post");
+    expect(output).toContain(`${HTTPBIN_HOST}/post`);
 
     await page.keyboard.press("Escape");
   },
@@ -281,8 +417,8 @@ test(
 
     const urlInput = page.getByTestId("popover-anchor-input-url_input");
     await expect(urlInput).toBeVisible({ timeout: 10000 });
-    // httpbin.org/put only accepts PUT — returns 405 for any other method
-    await urlInput.fill("https://httpbin.org/put");
+    // /put only accepts PUT — returns 405 for any other method
+    await urlInput.fill(`${HTTPBIN_BASE}/put`);
 
     const methodDropdown = page.getByTestId("dropdown_str_method");
     await expect(methodDropdown).toBeVisible({ timeout: 10000 });
@@ -295,7 +431,7 @@ test(
     const output = await runAndOpenOutput(page);
 
     expect(output).toContain("200");
-    expect(output).toContain("httpbin.org/put");
+    expect(output).toContain(`${HTTPBIN_HOST}/put`);
     expect(output).toContain("status_code");
     expect(output).toContain("response_headers");
     expect(output).toContain("result");
@@ -312,8 +448,8 @@ test(
 
     const urlInput = page.getByTestId("popover-anchor-input-url_input");
     await expect(urlInput).toBeVisible({ timeout: 10000 });
-    // httpbin.org/patch only accepts PATCH — returns 405 for any other method
-    await urlInput.fill("https://httpbin.org/patch");
+    // /patch only accepts PATCH — returns 405 for any other method
+    await urlInput.fill(`${HTTPBIN_BASE}/patch`);
 
     const methodDropdown = page.getByTestId("dropdown_str_method");
     await expect(methodDropdown).toBeVisible({ timeout: 10000 });
@@ -326,7 +462,7 @@ test(
     const output = await runAndOpenOutput(page);
 
     expect(output).toContain("200");
-    expect(output).toContain("httpbin.org/patch");
+    expect(output).toContain(`${HTTPBIN_HOST}/patch`);
     expect(output).toContain("status_code");
     expect(output).toContain("response_headers");
     expect(output).toContain("result");
@@ -343,8 +479,8 @@ test(
 
     const urlInput = page.getByTestId("popover-anchor-input-url_input");
     await expect(urlInput).toBeVisible({ timeout: 10000 });
-    // httpbin.org/delete only accepts DELETE — returns 405 for any other method
-    await urlInput.fill("https://httpbin.org/delete");
+    // /delete only accepts DELETE — returns 405 for any other method
+    await urlInput.fill(`${HTTPBIN_BASE}/delete`);
 
     const methodDropdown = page.getByTestId("dropdown_str_method");
     await expect(methodDropdown).toBeVisible({ timeout: 10000 });
@@ -357,7 +493,7 @@ test(
     const output = await runAndOpenOutput(page);
 
     expect(output).toContain("200");
-    expect(output).toContain("httpbin.org/delete");
+    expect(output).toContain(`${HTTPBIN_HOST}/delete`);
     expect(output).toContain("status_code");
     expect(output).toContain("response_headers");
     expect(output).toContain("result");
@@ -374,9 +510,9 @@ test(
 
     const urlInput = page.getByTestId("popover-anchor-input-url_input");
     await expect(urlInput).toBeVisible({ timeout: 10000 });
-    // httpbin.org/status/404 responds with HTTP 404.
+    // /status/404 responds with HTTP 404.
     // The component must NOT raise an exception — it returns Data(data={"status_code": 404, ...}).
-    await urlInput.fill("https://httpbin.org/status/404");
+    await urlInput.fill(`${HTTPBIN_BASE}/status/404`);
 
     const output = await runAndOpenOutput(page);
 
@@ -398,10 +534,8 @@ test(
 
     const urlInput = page.getByTestId("popover-anchor-input-url_input");
     await expect(urlInput).toBeVisible({ timeout: 10000 });
-    // httpbin.org/get echoes all query parameters in the `args` key of the response body
-    await urlInput.fill(
-      "https://httpbin.org/get?e2e_param=functional_test_value",
-    );
+    // /get echoes all query parameters in the `args` key of the response body
+    await urlInput.fill(`${HTTPBIN_BASE}/get?e2e_param=functional_test_value`);
 
     const output = await runAndOpenOutput(page);
 
@@ -479,8 +613,7 @@ test(
     await expect(curlTextarea).toBeVisible({ timeout: 10000 });
 
     // Fill with a valid cURL command
-    const curlCommand =
-      "curl -X GET https://httpbin.org/get -H 'Accept: application/json'";
+    const curlCommand = `curl -X GET ${HTTPBIN_BASE}/get -H 'Accept: application/json'`;
     await curlTextarea.fill(curlCommand);
     await expect(curlTextarea).toHaveValue(curlCommand);
 
@@ -510,26 +643,27 @@ test(
     await expect(curlTextarea).toBeVisible({ timeout: 10000 });
 
     await curlTextarea.fill(
-      "curl -X GET https://httpbin.org/get -H 'Accept: application/json'",
+      `curl -X GET ${HTTPBIN_BASE}/get -H 'Accept: application/json'`,
     );
 
     // The cURL parser must auto-populate url_input with the URL extracted from the command.
     // Asserting this directly proves the parser ran and is the precondition the run relies on
     // (without it the backend would receive an empty URL and validation would fail).
     await page.waitForFunction(
-      () => {
+      (expectedUrl) => {
         const el = document.getElementById(
           "popover-anchor-input-url_input",
         ) as HTMLInputElement | null;
-        return el !== null && el.value === "https://httpbin.org/get";
+        return el !== null && el.value === expectedUrl;
       },
+      `${HTTPBIN_BASE}/get`,
       { timeout: 10000 },
     );
 
     const output = await runAndOpenOutput(page);
 
     expect(output).toContain("200");
-    expect(output).toContain("httpbin.org");
+    expect(output).toContain(HTTPBIN_HOST);
     expect(output).toContain("status_code");
     expect(output).toContain("result");
 
@@ -612,7 +746,7 @@ test(
   "API Request component — flow state persists in database after autosave (URL, method, headers)",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    const expectedUrl = "https://httpbin.org/get?persist=true";
+    const expectedUrl = `${HTTPBIN_BASE}/get?persist=true`;
     const headerKey = "X-Persist-Header";
     const headerValue = "persisted-value";
     let flowId = "";


### PR DESCRIPTION
## Summary

Closes #383.

httpbin.org sits behind an AWS ELB that intermittently returns 5xx; a transient `503` hard-failed the POST test and flaked GET in the weekly run. This makes the suite tolerate transient outages **without masking a real regression**, and restores `@stable` on the POST test.

Validated against nightly `1.11.0.dev8`: **15/15 green** against public httpbin.org. No product regression behind the original failure — purely the external outage, as the issue suspected.

## Changes (`api-request-component-regression.spec.ts`)

- **Retry on transient outages.** `runAndOpenOutput` re-runs the component (up to 3 attempts) when the output carries any `5xx` `status_code` **or** a run produces no readable output (build error / timeout). No test here expects a 5xx, so retrying never masks a real assertion; a persistent failure exhausts the retries and the caller's assertion reports the actual content.
- **Full-output read.** Reads the COMPLETE output via the dialog's `copy-output-button` + clipboard instead of the virtualized Monaco `textContent`, which truncates fields below the viewport for verbose responses (clears the clipboard first — it persists across the serial tests — and polls rather than waiting on the transient toast).
- **`HTTPBIN_BASE_URL` knob** (default `httpbin.org`) lets the tests point at a different echo endpoint; host assertions derive from the same base.
- **`@stable` restored** on the POST test.

`.env.example` + spec doc document the knob and the rationale.

## Why not self-host go-httpbin?

It was implemented and tested first, but a CI run on this branch surfaced a hard blocker: the component's `validators.url()` **rejects the single-label service hostname** (`http://httpbin:8080`) that a GitHub Actions service container is reachable by (it also needs an SSRF allowlist for the service's private IP). `validators.url` accepts dotted hosts and IPs but not bare labels — which is why local testing via `host.containers.internal` passed and CI did not. Retry achieves the issue's goal (stop weekly noise from transient outages) without that fragility, and the weekly workflow is left unchanged.

## Out of scope

The two legacy specs that also use httpbin (`api/flows/api-component-regression.spec.ts`, `api/flows/api-request-component-ui.spec.ts`) are not `@stable` / not validated, so they are intentionally untouched.