### PR TITLE
fix(prompt-template): wait for flow autosave to settle before modal save (#358)

### DIFF
--- a/docs/core-components/prompt-template-invalid-patterns-regression.md
+++ b/docs/core-components/prompt-template-invalid-patterns-regression.md
@@ -38,7 +38,9 @@ None carry `@release` — these are defensive contract assertions, not happy-pat
 
 ## Step by step *(required)*
 
-Every test starts with the same `addPromptComponent(page)` helper used in `prompt-template-component-regression.spec.ts` (blank flow → sidebar search → add → adjust view → assert 1 node).
+Every test starts with the same `addPromptComponent(page)` helper used in `prompt-template-component-regression.spec.ts` (blank flow → sidebar search → add → adjust view → assert 1 node → **wait for the flow autosave to settle**).
+
+The final autosave-settle wait (`waitForFlowSaveSettled`) is the fix for the recurring flake tracked in issue #358: adding the node and fitting the viewport each schedule a debounced (300 ms) `PATCH /api/v1/flows/{id}` autosave. If one is still in flight when the prompt-modal save fires its own PATCH, the two requests race and the backend can return a transient failure rendered as a "Failed to save flow" toast — which shares the `.error-build-message` class with the prompt-validation toast and so corrupted the rejection (strict-mode, two elements) and positive-path (`toHaveCount(0)`) assertions alike. Waiting until no flow-save PATCH has fired for a quiet window guarantees the next save runs on its own.
 
 ### Rejection tests (tests 1–4)
 
@@ -46,7 +48,7 @@ The four rejection cases all run the same step sequence via the `runRejectionCon
 
 1. `addPromptComponent(page)`.
 2. Open the prompt modal, fill the textarea with the invalid template, click `genericModalBtnSave` (helper `fillAndSavePromptTemplate`). The helper does **not** wait for modal close — the modal stays open on error.
-3. Assert the error toast (`.error-build-message`) is visible within 5 s (the toast auto-dismisses after 5 s — see `src/frontend/src/alerts/error/index.tsx:22`).
+3. Assert the error toast (`.error-build-message`, filtered to the prompt-validation title) is visible within 5 s (the toast auto-dismisses after 5 s — see `src/frontend/src/alerts/error/index.tsx:22`). The title filter is a belt-and-suspenders guard against a stray flow-save toast sharing the same class (see the autosave note above; issue #358).
 4. Assert the toast text contains:
    - The constant title `"There is something wrong with this prompt"` (from i18n `errors.prompt`).
    - The upstream-error fragment `"Input variables contain invalid characters or formats"`.

--- a/tests/helpers/ui/prompt-template.ts
+++ b/tests/helpers/ui/prompt-template.ts
@@ -1,4 +1,9 @@
-import { type Locator, type Page, expect } from "@playwright/test";
+import {
+  type Locator,
+  type Page,
+  type Response,
+  expect,
+} from "@playwright/test";
 import { awaitBootstrapTest } from "../other/await-bootstrap-test";
 import { adjustScreenView } from "./adjust-screen-view";
 
@@ -24,9 +29,64 @@ const MUSTACHE_OPEN_BUTTON = "button_open_mustache_prompt_modal";
 const MUSTACHE_TEXTAREA = "modal-mustachepromptarea_mustache_template";
 
 /**
+ * Block until the flow's debounced autosave has settled.
+ *
+ * Adding a node and fitting/zooming the canvas viewport each mutate the flow
+ * and schedule a debounced (300 ms) `PATCH /api/v1/flows/{id}` autosave
+ * (upstream `use-autosave-flow.ts` / `SAVE_DEBOUNCE_TIME`). If such an autosave
+ * is still in flight when the next flow-mutating action fires its own PATCH —
+ * e.g. saving the prompt modal — the two requests race, and with no retry or
+ * version check on that endpoint the backend can return a transient failure
+ * that the frontend renders as a "Failed to save flow" toast. That toast uses
+ * the same `.error-build-message` class the rejection assertions key on, so the
+ * race surfaces as cross-case flake (see issue #358).
+ *
+ * Resolves once no flow-save PATCH has been observed for `quietMs` (chosen
+ * comfortably above the 300 ms autosave debounce), or after `timeout` as a
+ * safety cap so a quiet flow never hangs the caller.
+ */
+export async function waitForFlowSaveSettled(
+  page: Page,
+  { quietMs = 700, timeout = 10000 }: { quietMs?: number; timeout?: number } = {},
+): Promise<void> {
+  const isFlowSave = (resp: Response) =>
+    resp.url().includes("/api/v1/flows/") &&
+    resp.request().method() === "PATCH";
+
+  await new Promise<void>((resolve) => {
+    let quietTimer: ReturnType<typeof setTimeout>;
+
+    const finish = () => {
+      clearTimeout(quietTimer);
+      clearTimeout(cap);
+      page.off("response", onResponse);
+      resolve();
+    };
+
+    const arm = () => {
+      clearTimeout(quietTimer);
+      quietTimer = setTimeout(finish, quietMs);
+    };
+
+    const onResponse = (resp: Response) => {
+      if (isFlowSave(resp)) arm();
+    };
+
+    const cap = setTimeout(finish, timeout);
+    page.on("response", onResponse);
+    arm();
+  });
+}
+
+/**
  * Bootstraps a fresh blank flow, drops a Prompt Template node onto it via the
  * sidebar search/add path, and waits for exactly one node to render on the
  * canvas.
+ *
+ * Before returning, it waits for the node-add / viewport autosaves to settle
+ * (`waitForFlowSaveSettled`) so the next flow-save the caller triggers — e.g.
+ * saving the prompt modal — runs on its own and cannot race a still-in-flight
+ * autosave into a spurious "Failed to save flow" toast (issue #358).
  */
 export async function addPromptComponent(page: Page): Promise<void> {
   await awaitBootstrapTest(page);
@@ -44,6 +104,8 @@ export async function addPromptComponent(page: Page): Promise<void> {
   await expect(page.locator(".react-flow__node")).toHaveCount(1, {
     timeout: 10000,
   });
+
+  await waitForFlowSaveSettled(page);
 }
 
 /**

--- a/tests/tests-automations/regression/core-components/prompt-template-invalid-patterns-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/prompt-template-invalid-patterns-regression.spec.ts
@@ -60,7 +60,14 @@ async function runRejectionContract(
       // The toast auto-dismisses after 5s — assert it before any other wait.
       // `errors.prompt` title is constant; the detail list carries the upstream
       // message that names the variable in question.
-      const toast = errorToastLocator(page);
+      //
+      // Scope to the prompt-validation toast by title: a transient flow-save
+      // race can briefly render a second `.error-build-message` ("Failed to
+      // save flow") with the same class, and an unfiltered locator would then
+      // resolve to two elements and fail strict mode. `addPromptComponent`
+      // already waits for autosave to settle to prevent that race; this filter
+      // is the belt-and-suspenders guard (issue #358).
+      const toast = errorToastLocator(page).filter({ hasText: ERROR_TOAST_TITLE });
       await expect(toast).toBeVisible({ timeout: 5000 });
       await expect(toast).toContainText(ERROR_TOAST_TITLE);
       await expect(toast).toContainText(ERROR_DETAIL_FRAGMENT);


### PR DESCRIPTION
## Context

Closes #358.

`prompt-template-invalid-patterns-regression.spec.ts` flaked across multiple weekly runs, on **different cases each time** (`:120` `{var,name}`, `:137` `{1var}`, `:155` `{}`). #348 noted the `:155` failure hit a strict-mode `Failed to save flow` error-build-message — a flow-save race, not a parser-contract problem.

## Root cause

Confirmed against the Langflow frontend source:

- The flow autosave is **debounced (300 ms)** and fires on `setNode`/`setNodes`/`setEdges`. Adding the Prompt Template node and `adjustScreenView` (fit/zoom mutates the viewport, part of the flow data) each schedule a `PATCH /api/v1/flows/{id}`.
- That endpoint has **no retry and no version/lock check**. Two near-simultaneous PATCHes can return a transient 500, which the frontend renders as a **"Failed to save flow"** toast using the **same `.error-build-message` class** as the prompt-validation toast.
- That extra toast broke assertions two ways:
  - **Rejection cases** (`onError` of `/validate/prompt` does *not* call `setNode`, so the second toast comes from the node-add/viewport autosaves racing): the unfiltered `.error-build-message` locator resolved to **two elements** → Playwright **strict-mode violation**.
  - **Positive `{}` case**: the transient toast made `toHaveCount(0)` fail.

## Fix (harden the save step, not per-case waits)

- **`addPromptComponent`** now ends with `waitForFlowSaveSettled(page)` — blocks until no flow-save PATCH has been observed for a quiet window (> the 300 ms debounce), so the next save the test triggers runs on its own. This is the shared bootstrap for all 6 tests, so it fixes every case at once.
- **Belt-and-suspenders:** the rejection toast assertion is scoped to the prompt-validation title, so a stray toast can never cause a strict-mode violation.

Both changes preserve correctness — the title filter still fails if the expected prompt toast is absent, and the wait only adds settle time.

## Blast radius

`addPromptComponent` is shared by the 4 prompt-template specs (`component`, `invalid-patterns`, `invalid-mustache`, `double-brackets`). The change is additive (a settle wait) and hardens all of them; no behavior change otherwise.

## Validation

- `npm run typecheck` — clean
- `npm run lint` — 0 errors
- `npx playwright test <spec> --repeat-each=5 --retries=0 --workers=1` → **30/30 passing** (3.3 min), including the previously-flaky cases.

`@stable` retained on all 6 tests (no lifecycle change). Spec doc updated to document the autosave race and the settle wait.