### PR TITLE
fix(rename-flow): harden flow-settings modal helper against autosave race (#357)

### DIFF
--- a/tests/helpers/flows/rename-flow.ts
+++ b/tests/helpers/flows/rename-flow.ts
@@ -1,5 +1,30 @@
-import type { Page } from "@playwright/test";
+import { type Page, expect } from "@playwright/test";
+import { waitForFlowSaveSettled } from "./wait-for-flow-save-settled";
 
+// Generous, load-tolerant timeout for the modal interactions. The previous
+// hardcoded 3000ms waits were the fragile part flagged in issue #357: under
+// nightly backend load the flow-settings modal re-renders when an in-flight
+// autosave response lands, and 3s was not enough headroom for the inputs to
+// stabilise or for `save-flow-settings` to become enabled.
+const MODAL_TIMEOUT = 15000;
+
+/**
+ * Opens the flow-settings modal from the flow header, optionally edits the
+ * name and/or description, and saves (or cancels when nothing changed).
+ *
+ * Hardening (issue #357): every gate is now a real auto-waiting assertion
+ * (`expect(...).toBeVisible/toBeEnabled/toBeDisabled`) instead of the
+ * non-waiting `locator.isVisible()/isEnabled()/isDisabled()` queries, whose
+ * boolean results were discarded — they never actually waited. Before opening
+ * the modal we also wait for the editor's autosave to settle
+ * (`waitForFlowSaveSettled`): entering the editor fits the viewport and
+ * schedules a debounced `PATCH /api/v1/flows/{id}`, and if that response lands
+ * while the modal is open it re-renders the dialog, detaching `input-flow-name`
+ * mid-click and briefly disabling `save-flow-settings` — exactly the race that
+ * destabilised this helper.
+ *
+ * @returns the name/description present in the inputs *before* any edit.
+ */
 export const renameFlow = async (
   page: Page,
   {
@@ -7,38 +32,47 @@ export const renameFlow = async (
     flowDescription,
   }: { flowName?: string; flowDescription?: string } = {},
 ) => {
-  await page.getByTestId("flow_name").isVisible({ timeout: 3000 });
-  await page.getByTestId("flow_name").hover({ timeout: 3000 });
-  await page.getByTestId("flow_name").click({ timeout: 3000 });
+  // Let any in-flight editor autosave settle so opening/saving the modal does
+  // not race a PATCH that would re-render the dialog and detach its inputs.
+  await waitForFlowSaveSettled(page);
 
-  await page.waitForTimeout(500);
-  await page.getByTestId("input-flow-name").click({ timeout: 3000 });
+  // Open the flow-settings modal from the header.
+  await expect(page.getByTestId("flow_name")).toBeVisible({
+    timeout: MODAL_TIMEOUT,
+  });
+  await page.getByTestId("flow_name").hover();
+  await page.getByTestId("flow_name").click();
 
-  const flowNameInput = await page.getByTestId("input-flow-name").inputValue();
+  // Wait for the modal's name input to be present and interactable before
+  // reading/editing it (avoids acting on a half-rendered dialog).
+  const nameInput = page.getByTestId("input-flow-name");
+  await expect(nameInput).toBeVisible({ timeout: MODAL_TIMEOUT });
+  await expect(nameInput).toBeEnabled({ timeout: MODAL_TIMEOUT });
+
+  const flowNameInput = await nameInput.inputValue();
   if (flowName) {
-    await page.getByTestId("input-flow-name").fill(flowName);
+    await nameInput.fill(flowName);
   }
 
-  const flowDescriptionInput = await page
-    .getByTestId("input-flow-description")
-    .inputValue();
-
+  const descriptionInput = page.getByTestId("input-flow-description");
+  const flowDescriptionInput = await descriptionInput.inputValue();
   if (flowDescription) {
-    await page.getByTestId("input-flow-description").fill(flowDescription);
+    await descriptionInput.fill(flowDescription);
   }
-
-  await page.waitForTimeout(500);
 
   if (flowName || flowDescription) {
-    await page.getByTestId("save-flow-settings").isEnabled({ timeout: 3000 });
-    await page.getByTestId("save-flow-settings").click();
-    await page
-      .getByText("Changes saved successfully")
-      .last()
-      .isVisible({ timeout: 3000 });
-    await page.getByText("Changes saved successfully").last().click();
+    const saveButton = page.getByTestId("save-flow-settings");
+    await expect(saveButton).toBeEnabled({ timeout: MODAL_TIMEOUT });
+    await saveButton.click();
 
-    await page.waitForSelector('[data-testid="sidebar-search-input"]', {
+    // Confirm the save landed. The toast auto-dismisses, so we assert it
+    // appeared but do not depend on clicking it (which raced the dismissal).
+    await expect(
+      page.getByText("Changes saved successfully").last(),
+    ).toBeVisible({ timeout: MODAL_TIMEOUT });
+
+    // Modal closed → back in the editor.
+    await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
       timeout: 30000,
     });
 
@@ -53,9 +87,12 @@ export const renameFlow = async (
       );
     }
   } else {
-    await page.getByTestId("save-flow-settings").isDisabled({ timeout: 3000 });
-    await page.getByTestId("cancel-flow-settings").isEnabled({ timeout: 3000 });
-    await page.getByTestId("cancel-flow-settings").click();
+    await expect(page.getByTestId("save-flow-settings")).toBeDisabled({
+      timeout: MODAL_TIMEOUT,
+    });
+    const cancelButton = page.getByTestId("cancel-flow-settings");
+    await expect(cancelButton).toBeEnabled({ timeout: MODAL_TIMEOUT });
+    await cancelButton.click();
   }
 
   return {

--- a/tests/helpers/flows/rename-flow.ts
+++ b/tests/helpers/flows/rename-flow.ts
@@ -55,6 +55,9 @@ export const renameFlow = async (
   }
 
   const descriptionInput = page.getByTestId("input-flow-description");
+  // Guard the read symmetrically with the name input above: `inputValue()` does
+  // not auto-wait, so reading mid-render would throw or return a stale value.
+  await expect(descriptionInput).toBeVisible({ timeout: MODAL_TIMEOUT });
   const flowDescriptionInput = await descriptionInput.inputValue();
   if (flowDescription) {
     await descriptionInput.fill(flowDescription);
@@ -65,13 +68,16 @@ export const renameFlow = async (
     await expect(saveButton).toBeEnabled({ timeout: MODAL_TIMEOUT });
     await saveButton.click();
 
-    // Confirm the save landed. The toast auto-dismisses, so we assert it
-    // appeared but do not depend on clicking it (which raced the dismissal).
-    await expect(
-      page.getByText("Changes saved successfully").last(),
-    ).toBeVisible({ timeout: MODAL_TIMEOUT });
+    // Confirm the save succeeded by asserting the modal closed. Upstream
+    // `flowSettingsComponent.handleSubmit` only calls `close()` after the save
+    // resolves (the error path leaves the dialog open), so the name input
+    // disappearing is the deterministic success signal. Unlike the "Changes
+    // saved successfully" toast it does not auto-dismiss (asserting a fading
+    // toast races its own timeout), and unlike a bare sidebar check it cannot
+    // pass while the modal still overlays the editor.
+    await expect(nameInput).toBeHidden({ timeout: MODAL_TIMEOUT });
 
-    // Modal closed → back in the editor.
+    // Editor is interactive again.
     await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
       timeout: 30000,
     });

--- a/tests/helpers/flows/wait-for-flow-save-settled.ts
+++ b/tests/helpers/flows/wait-for-flow-save-settled.ts
@@ -1,0 +1,56 @@
+import type { Page, Response } from "@playwright/test";
+
+/**
+ * Block until the flow's debounced autosave has settled.
+ *
+ * Many editor actions mutate the flow and schedule a debounced (300 ms)
+ * `PATCH /api/v1/flows/{id}` autosave (upstream `use-autosave-flow.ts` /
+ * `SAVE_DEBOUNCE_TIME`): adding a node, fitting/zooming the canvas viewport,
+ * or simply opening a flow (the editor fits the view on mount). If such an
+ * autosave is still in flight when the next flow-mutating action fires its own
+ * PATCH — e.g. saving the prompt modal, or saving the flow-settings modal — the
+ * two requests race. With no retry or version check on that endpoint the
+ * backend can return a transient failure that the frontend renders as a
+ * "Failed to save flow" toast, and the in-flight response can re-render the
+ * open modal, detaching inputs mid-interaction.
+ *
+ * This surfaces as cross-test flake: a spurious error toast (issue #358) or a
+ * detached `input-flow-name` / never-enabled `save-flow-settings` in the rename
+ * helper (issue #357).
+ *
+ * Resolves once no flow-save PATCH has been observed for `quietMs` (chosen
+ * comfortably above the 300 ms autosave debounce), or after `timeout` as a
+ * safety cap so a quiet flow never hangs the caller.
+ */
+export async function waitForFlowSaveSettled(
+  page: Page,
+  { quietMs = 700, timeout = 10000 }: { quietMs?: number; timeout?: number } = {},
+): Promise<void> {
+  const isFlowSave = (resp: Response) =>
+    resp.url().includes("/api/v1/flows/") &&
+    resp.request().method() === "PATCH";
+
+  await new Promise<void>((resolve) => {
+    let quietTimer: ReturnType<typeof setTimeout>;
+
+    const finish = () => {
+      clearTimeout(quietTimer);
+      clearTimeout(cap);
+      page.off("response", onResponse);
+      resolve();
+    };
+
+    const arm = () => {
+      clearTimeout(quietTimer);
+      quietTimer = setTimeout(finish, quietMs);
+    };
+
+    const onResponse = (resp: Response) => {
+      if (isFlowSave(resp)) arm();
+    };
+
+    const cap = setTimeout(finish, timeout);
+    page.on("response", onResponse);
+    arm();
+  });
+}

--- a/tests/helpers/ui/prompt-template.ts
+++ b/tests/helpers/ui/prompt-template.ts
@@ -1,11 +1,12 @@
-import {
-  type Locator,
-  type Page,
-  type Response,
-  expect,
-} from "@playwright/test";
+import { type Locator, type Page, expect } from "@playwright/test";
 import { awaitBootstrapTest } from "../other/await-bootstrap-test";
+import { waitForFlowSaveSettled } from "../flows/wait-for-flow-save-settled";
 import { adjustScreenView } from "./adjust-screen-view";
+
+// `waitForFlowSaveSettled` now lives in the flows domain (autosave is a flow
+// concern) and is shared with the rename helper (issues #358, #357). Re-export
+// it here so existing importers of this module keep working unchanged.
+export { waitForFlowSaveSettled };
 
 // Shared testids and selectors for the Prompt Template component, sourced
 // from live UI inspection and the upstream Langflow frontend source:
@@ -27,56 +28,6 @@ const FSTRING_OPEN_BUTTON = "button_open_prompt_modal";
 const FSTRING_TEXTAREA = "modal-promptarea_prompt_template";
 const MUSTACHE_OPEN_BUTTON = "button_open_mustache_prompt_modal";
 const MUSTACHE_TEXTAREA = "modal-mustachepromptarea_mustache_template";
-
-/**
- * Block until the flow's debounced autosave has settled.
- *
- * Adding a node and fitting/zooming the canvas viewport each mutate the flow
- * and schedule a debounced (300 ms) `PATCH /api/v1/flows/{id}` autosave
- * (upstream `use-autosave-flow.ts` / `SAVE_DEBOUNCE_TIME`). If such an autosave
- * is still in flight when the next flow-mutating action fires its own PATCH —
- * e.g. saving the prompt modal — the two requests race, and with no retry or
- * version check on that endpoint the backend can return a transient failure
- * that the frontend renders as a "Failed to save flow" toast. That toast uses
- * the same `.error-build-message` class the rejection assertions key on, so the
- * race surfaces as cross-case flake (see issue #358).
- *
- * Resolves once no flow-save PATCH has been observed for `quietMs` (chosen
- * comfortably above the 300 ms autosave debounce), or after `timeout` as a
- * safety cap so a quiet flow never hangs the caller.
- */
-export async function waitForFlowSaveSettled(
-  page: Page,
-  { quietMs = 700, timeout = 10000 }: { quietMs?: number; timeout?: number } = {},
-): Promise<void> {
-  const isFlowSave = (resp: Response) =>
-    resp.url().includes("/api/v1/flows/") &&
-    resp.request().method() === "PATCH";
-
-  await new Promise<void>((resolve) => {
-    let quietTimer: ReturnType<typeof setTimeout>;
-
-    const finish = () => {
-      clearTimeout(quietTimer);
-      clearTimeout(cap);
-      page.off("response", onResponse);
-      resolve();
-    };
-
-    const arm = () => {
-      clearTimeout(quietTimer);
-      quietTimer = setTimeout(finish, quietMs);
-    };
-
-    const onResponse = (resp: Response) => {
-      if (isFlowSave(resp)) arm();
-    };
-
-    const cap = setTimeout(finish, timeout);
-    page.on("response", onResponse);
-    arm();
-  });
-}
 
 /**
  * Bootstraps a fresh blank flow, drops a Prompt Template node onto it via the

--- a/tests/tests-automations/regression/core-functionality/project-management/edit-flow-name.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/edit-flow-name.spec.ts
@@ -4,7 +4,7 @@ import { renameFlow } from "../../../../helpers/flows/rename-flow";
 
 test(
   "user should be able to edit flow name and see it reflected in the main page listing",
-  { tag: ["@release", "@workspace", "@regression"] },
+  { tag: ["@release", "@workspace", "@regression", "@stable"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 


### PR DESCRIPTION
## What

Hardens the shared `helpers/flows/rename-flow.ts` helper and **restores `@stable`** on `core-functionality/project-management/edit-flow-name.spec.ts:5`, which hard-failed two consecutive weeklies (triage in #386 removed the tag).

## Root cause

Two issues compounded into the *"detached `input-flow-name`"* / *"`save-flow-settings` never enabled within 3000ms"* failures:

1. **Non-waiting gates.** `locator.isVisible()/isEnabled()/isDisabled()` return a boolean *immediately* — they don't wait, and the helper discarded the result. It relied entirely on the auto-wait of the following `.click()`, with no headroom under nightly load.
2. **Autosave race.** Entering the editor fits the viewport → schedules a debounced `PATCH /api/v1/flows/{id}` autosave. When that response lands while the settings modal is open it re-renders the dialog, detaching `input-flow-name` mid-click and briefly disabling `save-flow-settings`. Same race fixed for the prompt modal in #388.

## Changes

- Replace every `isVisible/isEnabled/isDisabled` with real auto-waiting `expect(...).toBeVisible/toBeEnabled/toBeDisabled` assertions; `3000ms` → `15s`.
- Wait for autosave to settle (`waitForFlowSaveSettled`) **before** opening the modal.
- **Confirm save via the modal closing**, not the toast: upstream `flowSettingsComponent.handleSubmit` shows the "Changes saved successfully" toast *and* calls `close()` only after the save resolves (the error path leaves the dialog open). Asserting `input-flow-name` is hidden is the deterministic, race-free success signal — the toast auto-dismisses and asserting a fading toast races its own timeout. Works regardless of the autosave setting.
- Drop the arbitrary `waitForTimeout(500)` calls and the `waitForSelector`.
- **Extract** `waitForFlowSaveSettled` (added in #388 inside `helpers/ui/prompt-template.ts`) to `helpers/flows/wait-for-flow-save-settled.ts` — autosave is a flow concern, now shared by both helpers — and **re-export** it from `prompt-template.ts` so existing importers are unchanged (pure move, no behavior change).
- Restore `@stable` on `edit-flow-name.spec.ts:5`.

## Independent review + fixes

Reviewed via three independent finder angles (correctness / cross-file / cleanup-altitude), then verified:

- **Confirmed → fixed:** the success-toast assertion was a self-inflicted false-positive window (toast auto-dismisses). Replaced with the modal-closed assertion above.
- **Fixed:** symmetric `toBeVisible()` guard before reading `input-flow-description` (`inputValue()` does not auto-wait).
- **By design (kept):** the `>= quietMs` floor in `waitForFlowSaveSettled` is intentional — it catches the not-yet-fired debounced (300ms) autosave; resolving early reintroduces the race.
- **Cross-file:** zero regressions — re-export keeps all importers working, no circular import, `renameFlow`'s return contract unchanged.

## Validation

| Step | Result |
|---|---|
| `npm run typecheck` / `npm run lint` | clean / 0 errors |
| `edit-flow-name.spec.ts` (target) | **5/5** serial, no retries (+ full-trace pass) |
| `flow-rename-header.spec.ts` (`@stable` consumer) | **6/6** serial |
| Forced-failure check | test **fails** as expected → no false positive |
| Backend errors (4xx/5xx) | none (fixture auto-fails on any) |

## Blast radius

The helper backs **7 specs**. The other consumers (`auto-login-off`, `user-flow-state-cleanup`, `general-bugs-save-changes-on-node`, `flowSettings`) **fail identically on `main`** with these changes stashed — environmental (`auto_login=false` / multi-user config not present on the local instance), not a regression. `flowSettings.spec.ts` and `flow-lock.spec.ts` keep their own inline copy of the old modal pattern, but both are non-validated (`[-]`, no `@stable`) and out of the weekly suite — they should adopt the hardened helper if/when they are validated.

Closes #357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)