### PR TITLE
fix(loop-component): poll streamed response instead of one-shot read (#356)

### DIFF
--- a/docs/core-components/loop-component-regression.md
+++ b/docs/core-components/loop-component-regression.md
@@ -50,8 +50,8 @@ If any of these tests fails, the Loop component is broken in the product: either
 7. Change `int_int_max_results` to `2` (limit ArXiv to 2 results)
 8. Open the Playground via `playground-btn-flow-io`
 9. Type "transformer neural networks" in `input-chat-playground` and send
-10. Wait for `chat-message-AI-*` to appear (timeout 240 s)
-11. Extract the text of the last AI message and count occurrences of "title" (case-insensitive); must be ≥ 1
+10. Wait for the last `chat-message-AI-*` message to be visible (timeout 240 s — the ArXiv fetch and first LLM call can take a while)
+11. Assert the message **contains** "title" (case-insensitive) via `toContainText(/title/i, { timeout: 240000 })`. `toContainText` re-evaluates as tokens stream in, so it never samples a partially-streamed response — this is what makes the assertion robust against the streaming race tracked in #356 (the earlier code read the text once, on the first streamed token, and intermittently saw no "title" yet). Matching ≥ 1 occurrence confirms at least one complete loop iteration (Parser → LLM → done)
 
 **Test 4 — stops after exhausting input DataFrame and emits aggregated done**
 1. `awaitBootstrapTest` and `cleanAllFlows`
@@ -119,7 +119,7 @@ If any of these tests fails, the Loop component is broken in the product: either
 ## Notes *(optional)*
 
 - Test 3 configures the Language Model component before running the Playground — the template ships without a provider selected, causing "A model selection is required" if the setup step is skipped
-- The timeout in Test 3 is 240 s for the LLM response and the test-level timeout is set to 8 minutes via `test.setTimeout` — the template makes 2 sequential model calls (one per ArXiv article) which can take 3-4 minutes on CI infrastructure; the global 5-minute cap is insufficient for this flow
+- Test 3 reads the streamed response with `toContainText(/title/i, { timeout: 240000 })` rather than a one-shot `textContent()` read — `toContainText` re-evaluates as tokens stream in, so it never samples a partially-streamed message. The earlier one-shot read fired on the first streamed token and made the "title" assertion intermittently fail (flake tracked in #356). The test-level timeout is set to 8 minutes via `test.setTimeout` — the template makes 2 sequential model calls (one per ArXiv article) which can take 3-4 minutes on CI infrastructure; the global 5-minute cap is insufficient for this flow
 - The test is skipped automatically (not failed) when `OPENAI_API_KEY` is absent, so it does not block local runs without API keys
 - The validation criterion counts occurrences of "title" (case-insensitive) in the aggregated LLM response; the threshold is ≥ 1 because the LLM produces a free-form output and may echo "title" in only one of the N responses — checking ≥ N would couple the assertion to non-deterministic LLM formatting
 - `allowFlowErrors()` is required in Test 2 to disable the automatic flow error monitor injected by the fixture

--- a/tests/tests-automations/regression/core-components/loop-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/loop-component-regression.spec.ts
@@ -185,24 +185,26 @@ test(
     await page.getByTestId("input-chat-playground").fill("transformer neural networks");
     await page.getByTestId("button-send").click();
 
-    // The AI response element appears as soon as the flow starts streaming.
-    // Testid pattern: "chat-message-AI-{content}"
-    await page.waitForSelector('[data-testid^="chat-message-AI-"]', {
-      timeout: 240000,
-    });
-
-    // Verify the loop ran and produced LLM output.
-    // The Parser feeds "Title: {title}\nSummary: {summary}" as input to the LLM;
-    // the LLM returns a free-form response. Checking >= 1 occurrence of "title"
-    // confirms at least one full iteration completed (Parser → LLM → Loop done).
-    // Checking >= 2 would depend on the LLM echoing "title" in every response,
-    // which is non-deterministic.
+    // The AI response streams into a "chat-message-AI-{content}" element. Wait for
+    // it to appear (the ArXiv fetch + first LLM call can take a while), then poll
+    // its text until the aggregated output mentions "title".
+    //
+    // `toContainText` RE-EVALUATES as tokens stream in, so it never samples a
+    // partially-streamed response — the root cause of the flake tracked in #356.
+    // Previously the test read `textContent()` once, right after the message first
+    // became non-empty (i.e. on the first streamed token), and intermittently saw
+    // 0 occurrences of "title" before the rest of the response had arrived. The
+    // 240s budget covers 2 sequential LLM calls plus live ArXiv fetches; `.last()`
+    // re-resolves on each poll, so it tracks the final aggregated message.
+    //
+    // The Parser feeds "Title: {title}\nSummary: {summary}" into the LLM; finding
+    // "title" at least once confirms a full iteration completed (Parser → LLM →
+    // Loop done). We match >= 1 occurrence (not >= 2) because the LLM response is
+    // free-form and may echo "title" in only one of the N responses — the
+    // deterministic per-iteration count is covered by the exit-condition test below.
     const botMessage = page.locator('[data-testid^="chat-message-AI-"]').last();
-    await expect(botMessage).toBeVisible();
-    await expect(botMessage).not.toBeEmpty({ timeout: 240000 });
-    const responseText = await botMessage.textContent() ?? "";
-    const titleCount = (responseText.match(/title/gi) ?? []).length;
-    expect(titleCount).toBeGreaterThanOrEqual(1);
+    await expect(botMessage).toBeVisible({ timeout: 240000 });
+    await expect(botMessage).toContainText(/title/i, { timeout: 240000 });
   },
 );
 


### PR DESCRIPTION
## Summary

Hardens the flaky `loop-component-regression.spec.ts:111` test — *"Research Translation Loop template: full wiring and iterates over 2 ArXiv papers"* — tracked in #356 (flaky across multiple weekly runs, always passed on retry).

## Root cause

The test read the streamed AI response with a **single `textContent()` call** right after the message first became non-empty (i.e. on the **first streamed token**), then matched `/title/gi` on that one snapshot. On slower CI streams this sampled a **partially-streamed** response and saw 0 occurrences of "title", failing the `>= 1` assertion. External ArXiv/LLM latency widened the window but the race was in the read, not just the network.

## Fix

Replace the one-shot read with:

```ts
const botMessage = page.locator('[data-testid^="chat-message-AI-"]').last();
await expect(botMessage).toBeVisible({ timeout: 240000 });
await expect(botMessage).toContainText(/title/i, { timeout: 240000 });
```

`toContainText` **re-evaluates as tokens stream in**, so it never samples a partial response; `.last()` re-resolves on each poll and tracks the final aggregated message. No dependency on transient UI state (an earlier attempt gated on `button-stop` visibility, but the `gpt-4o-mini` run is fast — `button-stop` is not reliably observable — so that approach was dropped).

Spec doc (`docs/core-components/loop-component-regression.md`) updated to match.

## Validation (live Langflow instance, `OPENAI_API_KEY` set)

- `typecheck` clean; `lint` 0 errors (pre-existing warnings only)
- Full file **4/4 green** (`--retries=0 --workers=1 --trace=on`), no `🚨` backend errors
- **Forced failure** confirmed: swapping `/title/i` for an impossible token fails the assertion against a real, populated message — not a false positive
- Independent adversarial review performed on the diff; the streaming-race finding it surfaced is resolved by this change

## Known follow-up (not in this PR)

The `>= 1 "title"` check on free-form LLM prose is intentionally relaxed (documented in the spec) and does not by itself prove the *2-iteration* claim in the test title — deterministic per-iteration counting is already covered by the exit-condition test (N=3, N=1) in the same file. Strengthening test 3 to assert the loop `done`-output row count is a worthwhile follow-up; tracking separately to keep this PR scoped to the #356 flake.

Closes #356