### PR TITLE
test(core-components): add componentDelete spec (delete from canvas)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -677,14 +677,15 @@
 - [-] Reconnect existing edge
 
 #### 15.4 Node Manipulation
-- [-] Delete component from canvas
+- [x] Delete component from canvas via Backspace key → `core-components/componentDelete.spec.ts`
+- [x] Delete component from canvas via node options (...) menu → `core-components/componentDelete.spec.ts`
 - [x] Copy and paste ChatOutput component (Ctrl+C / Ctrl+V) → `flow-functionality/canvas-copy-paste.spec.ts`
 - [x] Copy and paste Prompt Template (component with dynamic ports) (Ctrl+C / Ctrl+V) → `flow-functionality/canvas-copy-paste.spec.ts`
 - [-] Canvas keyboard shortcuts
 - [-] Minimize component on canvas
 - [-] Move component within canvas
 - [-] Select multiple components via box selection
-- [-] Delete multiple selected components
+- [x] Delete multiple selected components (marquee box selection) → `core-components/componentDelete.spec.ts`
 - [-] Deselect node by clicking on empty canvas area
 - [-] Deselect node via Escape
 

--- a/docs/core-components/component-delete.md
+++ b/docs/core-components/component-delete.md
@@ -1,0 +1,98 @@
+# Spec: Delete a Component from the Canvas
+
+**Test file:** `tests/tests-automations/regression/core-components/componentDelete.spec.ts`
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates
+
+Confirms that components placed on the canvas can be removed by the user, through every supported deletion path, leaving the flow without the deleted node(s). This is the canvas node-lifecycle counterpart of `componentHoverAdd` (which validates adding a component) and the foundation for graph-manipulation coverage.
+
+The spec is a `test.describe` block of three tests, one per deletion mechanism:
+
+1. **Backspace key** — with one node on the canvas, selecting it and pressing `Backspace` removes it (count `1 → 0`).
+2. **Node options menu** — with one node on the canvas, opening the node's options (`...`) menu and clicking **Delete** removes it (count `1 → 0`).
+3. **Marquee box selection (multiple nodes)** — with two nodes on the canvas, a Shift+drag selection marquee selects all of them and `Backspace` removes them at once (count `2 → 0`).
+
+A shared `beforeEach` opens a blank flow via `setupBlankFlow` and asserts the canvas starts empty; a shared `afterEach` deletes the created flow via the REST API so no orphan flows are left behind.
+
+---
+
+## Tags
+
+`@release` `@stable` `@workspace` `@components`
+
+---
+
+## Step by step
+
+**beforeEach (all tests)**
+1. `setupBlankFlow(page)` — create a blank flow via the REST API and open it (avoids the UI-creation 500 race; returns the flow id for cleanup).
+2. Assert the canvas starts empty: `.react-flow__node` has count `0`.
+
+**Test 1 — Backspace key**
+1. Add a Chat Input via the sidebar (`sidebar-search-input` + `add-component-button-chat-input`); assert one `.react-flow__node`.
+2. Click the node to select it, press `Backspace`, assert zero `.react-flow__node`.
+
+**Test 2 — node options menu**
+1. Add a Chat Input (same as above); assert one `.react-flow__node`.
+2. Click `icon-MoreHorizontal` (the node's `...` button), then `icon-Delete` (the menu's Delete item), assert zero `.react-flow__node`.
+
+**Test 3 — marquee box selection**
+1. Add a Chat Input and a Chat Output; assert count goes `1` then `2`.
+2. Click `.react-flow__pane` to deselect (the last-added node is auto-selected, which would skew the marquee).
+3. Compute the bounding box that encloses all nodes; Shift+drag a marquee (padded by 60 px so it starts on empty canvas) across them with `page.mouse` + `page.keyboard.down("Shift")`.
+4. Press `Backspace`, assert zero `.react-flow__node`.
+
+**afterEach (all tests)**
+1. Navigate to `/` (so background polling does not 404 on the deleted flow), then `DELETE /api/v1/flows/{id}`.
+
+---
+
+## Validation criterion
+
+| Test | Criterion |
+|---|---|
+| beforeEach | Canvas has `0` `.react-flow__node` after the blank flow opens |
+| Backspace | `1` node after add; `0` nodes after select + `Backspace` |
+| Options menu | `1` node after add; `0` nodes after `...` → Delete |
+| Marquee | `2` nodes after adding both; `0` nodes after marquee-select + `Backspace` |
+
+---
+
+## External dependencies
+
+- React Flow canvas — `.react-flow__node` (every node) and `.react-flow__pane` (empty-canvas background). Renaming or restructuring these breaks node counting and the deselect click.
+- Sidebar add affordance — `sidebar-search-input` and `add-component-button-<name>` (`chat-input`, `chat-output`). Used to seed the nodes to delete.
+- Node options menu — `icon-MoreHorizontal` (the `...` button) and `icon-Delete` (the Delete menu item). Neither the button nor the menu item exposes a dedicated test ID, so the test targets these inner icons.
+- Keyboard deletion — React Flow's delete handler must accept `Backspace`/`Delete` on selected nodes; multi-selection must respond to the Shift+drag marquee (`selectionKeyCode = Shift`).
+- `tests/helpers/flows/setup-blank-flow.ts` — API-based flow creation and the `flowId` used for cleanup.
+
+---
+
+## What this test does not cover
+
+- Deleting an edge/connection between components (separate concern).
+- Deleting a node that participates in an edge (edge cleanup on node removal).
+- Undo/redo of a deletion.
+- Multi-selection by individually Shift+clicking nodes (the components added via the `+` button stack at the same position, so only marquee selection is exercised here).
+- Multi-selection followed by copy/paste — exercised only by the inherited, unvalidated `flow-functionality/canvas-multiselect.spec.ts` (a cleanup/consolidation candidate).
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- No model provider credentials required (deterministic, no LLM).
+- Default Playwright Desktop Chrome viewport.
+
+---
+
+## Notes
+
+- Sibling references: `core-components/componentHoverAdd.spec.ts` and `customComponentAdd.spec.ts` (adding a component to the canvas).
+- The "add a component" mechanic is a small local helper (`addComponent`) inside the spec — kept local because here the component is incidental; promoting it to a shared helper is deferred until a real cross-spec need.
+- Each test creates its own flow and deletes it in `afterEach`, so the suite leaves no orphan flows.
+- Validated by stepping through `--debug`; node-count assertions (`1 → 0`, `2 → 0`) confirm the delete actually removed nodes rather than passing on an already-empty canvas.

--- a/tests/tests-automations/regression/core-components/componentDelete.spec.ts
+++ b/tests/tests-automations/regression/core-components/componentDelete.spec.ts
@@ -1,0 +1,148 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
+
+// Local helper, specific to this spec. Adds a component to the canvas by
+// searching the sidebar and clicking its "+" button.
+// Kept local (not promoted to tests/helpers/) on purpose: here the component is
+// incidental — we just need "something to delete". Other specs that add a
+// component do it for a different reason and should not couple to this one.
+async function addComponent(
+  page: Page,
+  searchTerm: string,
+  addButtonTestId: string,
+) {
+  await page.getByTestId("sidebar-search-input").fill(searchTerm);
+  await page.getByTestId(addButtonTestId).click();
+}
+
+test.describe("Delete a component from the canvas", () => {
+  let createdFlowId: string | null = null;
+
+  test.beforeEach(async ({ page }) => {
+    // setupBlankFlow creates the flow via API (avoids the UI-creation 500 race)
+    // and returns its id so afterEach can clean it up.
+    createdFlowId = await setupBlankFlow(page);
+    // Precondition: the canvas starts empty, so a later "count 0" proves the
+    // delete actually removed something rather than passing on an empty canvas.
+    await expect(page.locator(".react-flow__node")).toHaveCount(0);
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (createdFlowId) {
+      // Leave the editor first: staying on it while the flow is deleted makes
+      // background polling 404, which the fixture's error monitor would flag.
+      await page.goto("/").catch(() => {});
+      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      createdFlowId = null;
+    }
+  });
+
+  test(
+    "Should delete a single component with the Backspace key",
+    { tag: ["@release", "@stable", "@workspace", "@components"] },
+    async ({ page }) => {
+      await test.step("Add a Chat Input component to the canvas", async () => {
+        await addComponent(
+          page,
+          "Chat Input",
+          "add-component-button-chat-input",
+        );
+        await expect(page.locator(".react-flow__node")).toHaveCount(1);
+      });
+
+      await test.step("Select the node and delete it with Backspace", async () => {
+        // Clicking the node selects it; Backspace then deletes the selection.
+        await page.locator(".react-flow__node").click();
+        await page.keyboard.press("Backspace");
+        await expect(page.locator(".react-flow__node")).toHaveCount(0);
+      });
+    },
+  );
+
+  test(
+    "Should delete a single component via the node options menu",
+    { tag: ["@release", "@stable", "@workspace", "@components"] },
+    async ({ page }) => {
+      await test.step("Add a Chat Input component to the canvas", async () => {
+        await addComponent(
+          page,
+          "Chat Input",
+          "add-component-button-chat-input",
+        );
+        await expect(page.locator(".react-flow__node")).toHaveCount(1);
+      });
+
+      await test.step("Delete the node via its options (...) menu", async () => {
+        // Select the node first so its toolbar (the ... button) is shown —
+        // explicit instead of relying on the just-added node being auto-selected.
+        await page.locator(".react-flow__node").click();
+        // Neither the 3-dot button nor the "Delete" menu item has its own
+        // testid — target their inner icons instead.
+        await page.getByTestId("icon-MoreHorizontal").click();
+        await page.getByTestId("icon-Delete").click();
+        await expect(page.locator(".react-flow__node")).toHaveCount(0);
+      });
+    },
+  );
+
+  test(
+    "Should delete multiple selected components with a marquee selection",
+    { tag: ["@release", "@stable", "@workspace", "@components"] },
+    async ({ page }) => {
+      await test.step("Add two components to the canvas", async () => {
+        await addComponent(
+          page,
+          "Chat Input",
+          "add-component-button-chat-input",
+        );
+        await expect(page.locator(".react-flow__node")).toHaveCount(1);
+        await addComponent(
+          page,
+          "Chat Output",
+          "add-component-button-chat-output",
+        );
+        await expect(page.locator(".react-flow__node")).toHaveCount(2);
+      });
+
+      await test.step("Marquee-select all nodes and delete them", async () => {
+        // Components added via the "+" button stack at the same spot, so
+        // clicking each node individually is not reliable. A Shift+drag marquee
+        // selects every node regardless of overlap.
+
+        // Deselect first: the last-added node comes auto-selected, which would
+        // throw off the marquee selection.
+        await page.locator(".react-flow__pane").click();
+
+        // Compute a box that fully encloses every node on the canvas.
+        const nodes = page.locator(".react-flow__node");
+        const count = await nodes.count();
+        let minX = Infinity,
+          minY = Infinity,
+          maxX = -Infinity,
+          maxY = -Infinity;
+        for (let i = 0; i < count; i++) {
+          // Nodes were just asserted present and visible, so boundingBox is non-null.
+          const box = (await nodes.nth(i).boundingBox())!;
+          minX = Math.min(minX, box.x);
+          minY = Math.min(minY, box.y);
+          maxX = Math.max(maxX, box.x + box.width);
+          maxY = Math.max(maxY, box.y + box.height);
+        }
+
+        // Drag the marquee with Shift held, padding the box so it starts on
+        // empty canvas (not on a node, which would drag the node instead).
+        await page.keyboard.down("Shift");
+        await page.mouse.move(minX - 60, minY - 60);
+        await page.mouse.down();
+        await page.mouse.move(maxX + 60, maxY + 60, { steps: 10 });
+        await page.mouse.up();
+        await page.keyboard.up("Shift");
+
+        // Delete the selected nodes and assert the canvas is empty.
+        await page.keyboard.press("Backspace");
+        await expect(page.locator(".react-flow__node")).toHaveCount(0);
+      });
+    },
+  );
+});


### PR DESCRIPTION
## What

Adds `tests/tests-automations/regression/core-components/componentDelete.spec.ts` — three `@stable` tests covering component deletion from the canvas:

1. **Backspace key** — select a node, press `Backspace`, canvas empties (count 1 → 0).
2. **Node options (...) menu** — open the node menu, click Delete (count 1 → 0).
3. **Marquee multi-delete** — Shift+drag box-selects two stacked nodes, `Backspace` removes both (count 2 → 0).

## How it's structured

- Shared `beforeEach` opens a blank flow via `setupBlankFlow` (API creation, avoids the UI 500 race) and asserts an empty canvas.
- Shared `afterEach` deletes the created flow via the REST API — no orphan flows.
- Node-count oracles (`1 → 0`, `2 → 0`) with a baseline assertion confirm the delete actually removed nodes.
- A small local `addComponent` helper (kept local — the component is incidental here).

## Validation

- `tsc --noEmit` clean, ESLint clean on the file.
- 3 passed with `--trace=on --retries=0` (parallel, no backend errors).
- Force-fail probe: disabling the delete makes the assertion fail → no false positive.

## Docs & checklist

- Spec doc: `docs/core-components/component-delete.md`.
- QA-CHECKLIST `15.4 Node Manipulation`: marked delete-via-Backspace, delete-via-options-menu (new item), and multi-delete.

## Notes

- The marquee multi-delete overlaps the **inherited, unvalidated** `flow-functionality/canvas-multiselect.spec.ts` (no `@stable`, not in the checklist); this PR provides the first validated coverage. That inherited spec remains a separate cleanup candidate.