### PR TITLE
test(#384): harden weekly flaky set (autosave races + MCP auth)

### DIFF
--- a/tests/tests-automations/regression/core-components/chat-input-files-field-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/chat-input-files-field-regression.spec.ts
@@ -4,6 +4,7 @@ import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { zoomOut } from "../../../helpers/ui/zoom-out";
+import { waitForFlowSaveSettled } from "../../../helpers/flows/wait-for-flow-save-settled";
 import {
   closeAdvancedOptions,
   openAdvancedOptions,
@@ -39,7 +40,13 @@ async function expandFocusedNode(page: Page) {
 // in expanded (non-minimized) state.
 async function addChatInputComponent(page: Page) {
   await awaitBootstrapTest(page);
+  await expect(page.getByTestId("blank-flow")).toBeAttached({ timeout: 30000 });
   await page.getByTestId("blank-flow").click();
+
+  // Gate the sidebar search before filling it. Filling without first waiting
+  // for the input to be actionable raced under nightly backend load into a
+  // `locator.fill: Timeout` — the flake observed in the weekly run (issue #384).
+  await page.getByTestId("sidebar-search-input").click();
   await page.getByTestId("sidebar-search-input").fill("chat input");
   await expect(page.getByTestId("input_outputChat Input")).toBeVisible({
     timeout: 30000,
@@ -52,6 +59,11 @@ async function addChatInputComponent(page: Page) {
   });
   await page.getByTestId("title-Chat Input").click();
   await expandFocusedNode(page);
+
+  // Let the node-add / viewport autosaves settle before the caller fires its
+  // next flow-mutating action (exposing Files, uploading via the inspector),
+  // so that mutation cannot race a still-in-flight autosave PATCH.
+  await waitForFlowSaveSettled(page);
 }
 
 // Helper: drag the Chat Output component onto the canvas and expand it.

--- a/tests/tests-automations/regression/flow-functionality/export-import-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/export-import-flow.spec.ts
@@ -4,6 +4,7 @@ import { expect, test } from "../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { simulateDragAndDrop } from "../../../helpers/ui/simulate-drag-and-drop";
+import { waitForFlowSaveSettled } from "../../../helpers/flows/wait-for-flow-save-settled";
 
 // Force serial execution within this file so the diff-based cleanup remains
 // safe — the snapshot/diff pattern is racy across workers when multiple tests
@@ -87,6 +88,13 @@ test.describe("Export and Import Flow (IDs 173 + 120)", () => {
         .then(async () => {
           await page.getByTestId("add-component-button-chat-input").click();
         });
+
+      // Wait for the node-add autosave (debounced `PATCH /api/v1/flows/{id}`)
+      // to persist before leaving the editor. The export reads the *persisted*
+      // flow, so navigating back/exporting while the PATCH is still in flight
+      // produces an empty file (`parsed.data.nodes.length === 0`) — the flake
+      // observed in the weekly run (issue #384).
+      await waitForFlowSaveSettled(page);
 
       await page.getByTestId("icon-ChevronLeft").click();
 

--- a/tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts
@@ -1,42 +1,19 @@
-import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { cleanAllFlows } from "../../../../helpers/flows/clean-all-flows";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { zoomOut } from "../../../../helpers/ui/zoom-out";
 
-/**
- * Resolve an API auth token that works in both auth modes.
- *
- * The suite starts Langflow with `LANGFLOW_AUTO_LOGIN=true`, where
- * `POST /api/v1/login` with username/password is rejected ("Incorrect username
- * or password") and `GET /api/v1/auto_login` issues the token instead. The
- * previous inline `/api/v1/login` calls silently returned `undefined` on such
- * instances, so the follow-up DELETE ran with a bad token and the MCP-server
- * pre-clean never actually removed a leftover server. The next registration
- * then hit a *pre-existing* server, which the backend rejects with HTTP 500
- * ("Server already exists.", `api/v2/mcp.py`), failing the test (#384).
- *
- * Tries auto-login first, then falls back to password login so the helper keeps
- * working on instances that do require credentials. Returns the raw access
- * token (callers build the `Bearer` header).
- */
-async function getMcpAuthToken(page: Page): Promise<string> {
-  const auto = await page.request.get("/api/v1/auto_login");
-  if (auto.ok()) {
-    const body = await auto.json().catch(() => ({}));
-    if (body?.access_token) return body.access_token as string;
-  }
-
-  const login = await page.request.post("/api/v1/login", {
-    form: { username: "langflow", password: "langflow" },
-  });
-  if (login.ok()) {
-    const body = await login.json().catch(() => ({}));
-    if (body?.access_token) return body.access_token as string;
-  }
-
-  return "";
-}
+// MCP-server pre-clean/verification calls authenticate via the shared
+// `getAuthToken` helper (which uses `GET /api/v1/auto_login`). The suite starts
+// Langflow with `LANGFLOW_AUTO_LOGIN=true`, under which `POST /api/v1/login`
+// with username/password can be rejected — the previous inline login calls
+// silently yielded an undefined token, so the follow-up DELETE ran
+// unauthenticated and the pre-clean never removed a leftover server. A stale
+// server then makes the next registration hit a pre-existing name, which the
+// backend rejects with HTTP 500 ("Server already exists.", `api/v2/mcp.py`) —
+// see the investigation in #396. `getAuthToken` returns a ready-to-use
+// `Authorization` header value (or "" when the instance has no auth).
 
 // Worker- and timestamp-suffixed name prevents cross-file races: this spec and
 // mcp-client-agent.spec.ts both register an MCP "everything" server, and
@@ -64,10 +41,10 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
   test.afterEach(async ({ page }) => {
     const serversToClean = [MCP_SERVER_NAME, BAD_SERVER_NAME, HTTP_FORM_SERVER_NAME];
     try {
-      const token = await getMcpAuthToken(page);
+      const authHeader = await getAuthToken(page.request);
       for (const name of serversToClean) {
         await page.request.delete(`/api/v2/mcp/servers/${name}`, {
-          headers: { Authorization: `Bearer ${token}` },
+          headers: { Authorization: authHeader },
         });
       }
     } catch {
@@ -95,9 +72,9 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
       });
 
       await test.step("Delete existing MCP server and re-add via JSON", async () => {
-        const token = await getMcpAuthToken(page);
+        const authHeader = await getAuthToken(page.request);
         await page.request.delete(`/api/v2/mcp/servers/${MCP_SERVER_NAME}`, {
-          headers: { Authorization: `Bearer ${token}` },
+          headers: { Authorization: authHeader },
         });
 
         await expect(page.getByTestId("sidebar-nav-mcp")).toBeVisible({
@@ -201,9 +178,9 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
       });
 
       await test.step("Pre-clean: delete bad-server if it exists", async () => {
-        const token = await getMcpAuthToken(page);
+        const authHeader = await getAuthToken(page.request);
         await page.request.delete(`/api/v2/mcp/servers/${BAD_SERVER}`, {
-          headers: { Authorization: `Bearer ${token}` },
+          headers: { Authorization: authHeader },
         });
       });
 
@@ -290,9 +267,9 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
       });
 
       await test.step("Pre-clean: delete http-form-server if it exists", async () => {
-        const token = await getMcpAuthToken(page);
+        const authHeader = await getAuthToken(page.request);
         await page.request.delete(`/api/v2/mcp/servers/${HTTP_SERVER}`, {
-          headers: { Authorization: `Bearer ${token}` },
+          headers: { Authorization: authHeader },
         });
       });
 
@@ -327,10 +304,10 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
       });
 
       await test.step("Verify server is persisted in the database", async () => {
-        const token = await getMcpAuthToken(page);
+        const authHeader = await getAuthToken(page.request);
 
         const resp = await page.request.get("/api/v2/mcp/servers", {
-          headers: { Authorization: `Bearer ${token}` },
+          headers: { Authorization: authHeader },
         });
         expect(resp.status()).toBe(200);
 
@@ -355,9 +332,9 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
       });
 
       await test.step("Register everything server via JSON and wait for tools", async () => {
-        const token = await getMcpAuthToken(page);
+        const authHeader = await getAuthToken(page.request);
         await page.request.delete(`/api/v2/mcp/servers/${MCP_SERVER_NAME}`, {
-          headers: { Authorization: `Bearer ${token}` },
+          headers: { Authorization: authHeader },
         });
 
         await expect(page.getByTestId("sidebar-nav-mcp")).toBeVisible({

--- a/tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts
@@ -1,7 +1,42 @@
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { cleanAllFlows } from "../../../../helpers/flows/clean-all-flows";
 import { zoomOut } from "../../../../helpers/ui/zoom-out";
+
+/**
+ * Resolve an API auth token that works in both auth modes.
+ *
+ * The suite starts Langflow with `LANGFLOW_AUTO_LOGIN=true`, where
+ * `POST /api/v1/login` with username/password is rejected ("Incorrect username
+ * or password") and `GET /api/v1/auto_login` issues the token instead. The
+ * previous inline `/api/v1/login` calls silently returned `undefined` on such
+ * instances, so the follow-up DELETE ran with a bad token and the MCP-server
+ * pre-clean never actually removed a leftover server. The next registration
+ * then hit a *pre-existing* server, which the backend rejects with HTTP 500
+ * ("Server already exists.", `api/v2/mcp.py`), failing the test (#384).
+ *
+ * Tries auto-login first, then falls back to password login so the helper keeps
+ * working on instances that do require credentials. Returns the raw access
+ * token (callers build the `Bearer` header).
+ */
+async function getMcpAuthToken(page: Page): Promise<string> {
+  const auto = await page.request.get("/api/v1/auto_login");
+  if (auto.ok()) {
+    const body = await auto.json().catch(() => ({}));
+    if (body?.access_token) return body.access_token as string;
+  }
+
+  const login = await page.request.post("/api/v1/login", {
+    form: { username: "langflow", password: "langflow" },
+  });
+  if (login.ok()) {
+    const body = await login.json().catch(() => ({}));
+    if (body?.access_token) return body.access_token as string;
+  }
+
+  return "";
+}
 
 // Worker- and timestamp-suffixed name prevents cross-file races: this spec and
 // mcp-client-agent.spec.ts both register an MCP "everything" server, and
@@ -29,12 +64,7 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
   test.afterEach(async ({ page }) => {
     const serversToClean = [MCP_SERVER_NAME, BAD_SERVER_NAME, HTTP_FORM_SERVER_NAME];
     try {
-      const token = await page.request
-        .post("/api/v1/login", {
-          form: { username: "langflow", password: "langflow" },
-        })
-        .then((r) => r.json())
-        .then((d) => d.access_token as string);
+      const token = await getMcpAuthToken(page);
       for (const name of serversToClean) {
         await page.request.delete(`/api/v2/mcp/servers/${name}`, {
           headers: { Authorization: `Bearer ${token}` },
@@ -65,12 +95,7 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
       });
 
       await test.step("Delete existing MCP server and re-add via JSON", async () => {
-        const token = await page.request
-          .post("/api/v1/login", {
-            form: { username: "langflow", password: "langflow" },
-          })
-          .then((r) => r.json())
-          .then((d) => d.access_token as string);
+        const token = await getMcpAuthToken(page);
         await page.request.delete(`/api/v2/mcp/servers/${MCP_SERVER_NAME}`, {
           headers: { Authorization: `Bearer ${token}` },
         });
@@ -176,12 +201,7 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
       });
 
       await test.step("Pre-clean: delete bad-server if it exists", async () => {
-        const token = await page.request
-          .post("/api/v1/login", {
-            form: { username: "langflow", password: "langflow" },
-          })
-          .then((r) => r.json())
-          .then((d) => d.access_token as string);
+        const token = await getMcpAuthToken(page);
         await page.request.delete(`/api/v2/mcp/servers/${BAD_SERVER}`, {
           headers: { Authorization: `Bearer ${token}` },
         });
@@ -270,12 +290,7 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
       });
 
       await test.step("Pre-clean: delete http-form-server if it exists", async () => {
-        const token = await page.request
-          .post("/api/v1/login", {
-            form: { username: "langflow", password: "langflow" },
-          })
-          .then((r) => r.json())
-          .then((d) => d.access_token as string);
+        const token = await getMcpAuthToken(page);
         await page.request.delete(`/api/v2/mcp/servers/${HTTP_SERVER}`, {
           headers: { Authorization: `Bearer ${token}` },
         });
@@ -312,12 +327,7 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
       });
 
       await test.step("Verify server is persisted in the database", async () => {
-        const token = await page.request
-          .post("/api/v1/login", {
-            form: { username: "langflow", password: "langflow" },
-          })
-          .then((r) => r.json())
-          .then((d) => d.access_token as string);
+        const token = await getMcpAuthToken(page);
 
         const resp = await page.request.get("/api/v2/mcp/servers", {
           headers: { Authorization: `Bearer ${token}` },
@@ -345,12 +355,7 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
       });
 
       await test.step("Register everything server via JSON and wait for tools", async () => {
-        const token = await page.request
-          .post("/api/v1/login", {
-            form: { username: "langflow", password: "langflow" },
-          })
-          .then((r) => r.json())
-          .then((d) => d.access_token as string);
+        const token = await getMcpAuthToken(page);
         await page.request.delete(`/api/v2/mcp/servers/${MCP_SERVER_NAME}`, {
           headers: { Authorization: `Bearer ${token}` },
         });


### PR DESCRIPTION
## Summary

Hardens the test-side fragility behind the weekly `@stable` flaky set triaged in #384, after an investigation that ran each affected test locally against `langflowai/langflow-nightly:latest` (`1.10.0.dev69`).

The 7 flaky tests split into three buckets; this PR fixes the three that have a real, test-side root cause and leaves the rest documented:

| Test | Bucket | Action |
|---|---|---|
| `export-import-flow:65` | autosave race | **fixed** |
| `chat-input-files:233` | autosave race | **fixed** |
| `mcp-client:260` | auth + backend 500 | **fixed** (test side) |
| `agent:145` (openai) | ambient model/backend latency | no in-test fix — kept `@stable`, retries cover |
| `api-request GET:217` | external httpbin dependency | deferred (tracked in the api-request issue) |
| `prompt-template:109`, `flow-rename:13` | already hardened (#357/#358) | no change — residual is backend load |

## Changes

- **Autosave races (Group 2).** Adding a node schedules a debounced `PATCH /api/v1/flows/{id}`; acting before it settles is fragile. Apply the proven `waitForFlowSaveSettled` remedy (#357/#358):
  - `export-import-flow`: wait for the node-add autosave to persist before navigating back/exporting, so the export cannot read an empty flow (`parsed.data.nodes.length === 0`).
  - `chat-input-files` (`addChatInputComponent`): gate `sidebar-search-input` before `fill` (fixes the `locator.fill` timeout), assert `blank-flow` attached, and settle the autosave before subsequent flow-mutating actions.
- **MCP auth (Group 1).** `mcp-client-regression` authenticated its pre-clean/verification calls via a hardcoded `POST /api/v1/login` (`langflow/langflow`) in 6 places. Under the suite's `LANGFLOW_AUTO_LOGIN=true` mode that can silently yield no token, so the pre-clean DELETE ran unauthenticated and never removed a leftover server — and a stale server makes the next registration hit the backend's HTTP 500 on duplicate names. Routed all six calls through the shared `getAuthToken(page.request)` (auto_login) helper.

## Validation (local, nightly `1.10.0.dev69`)

- `export-import:65` and `chat-input:233`: pass (these did not reproduce the flake locally — the fix is preventive, same root cause/remedy as #357/#358).
- `mcp-client:260`: hard-failed **3/3** before (stale server → 500), passes **3/3** with `--repeat-each=3` after.
- `npm run typecheck` clean; ESLint 0 errors (pre-existing warnings only).
- Independent review performed before opening; its findings (reuse shared auth helper, accurate rationale) are addressed in commit `75c2222`.

## Follow-ups (out of scope, tracked separately)

- **#396** — investigate the backend returning HTTP 500 (not 409) on duplicate MCP-server registration; decide whether to report upstream.
- **#397** — standardize the sibling MCP specs (`mcp-client-agent`, `mcp-server`) on the same shared auth helper.
- `agent:145` gemini variant fails locally at template-load (`setup-google.ts`), but is skipped in CI (no `GOOGLE_API_KEY`); out of #384 scope.

`@stable` kept on all touched tests. Spec docs present and `Last validated: 1.10.x` (current cycle).

Closes #384.
