### PR TITLE
test(#393): standardize toggle specs on setupBlankFlow + afterEach cleanup

### DIFF
--- a/tests/tests-automations/regression/core-components/beta-components-toggle-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/beta-components-toggle-regression.spec.ts
@@ -1,54 +1,69 @@
 import { expect, test } from "../../../fixtures/fixtures";
-import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
 
-test(
-  "Show Beta Components toggle controls visibility of beta components in the sidebar",
-  { tag: ["@stable", "@regression", "@components"] },
-  async ({ page }) => {
-    await test.step("Open a blank flow", async () => {
-      await awaitBootstrapTest(page);
-      await page.getByTestId("blank-flow").click();
-      await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
-        timeout: 10000,
+test.describe("Show Beta Components toggle", () => {
+  let createdFlowId: string | null = null;
+
+  test.beforeEach(async ({ page }) => {
+    // setupBlankFlow creates the flow via API (avoids the UI-creation 500 race)
+    // and returns its id so afterEach can clean it up.
+    createdFlowId = await setupBlankFlow(page);
+    await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (createdFlowId) {
+      // Leave the editor first: staying on it while the flow is deleted makes
+      // background polling 404, which the fixture's error monitor would flag.
+      await page.goto("/").catch(() => {});
+      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      createdFlowId = null;
+    }
+  });
+
+  test(
+    "Show Beta Components toggle controls visibility of beta components in the sidebar",
+    { tag: ["@stable", "@regression", "@components"] },
+    async ({ page }) => {
+      await test.step("Amazon Bedrock Converse is visible while the toggle is ON (baseline)", async () => {
+        // The beta toggle defaults to ON (showBeta = true), so the beta
+        // component is visible without any interaction. This is the baseline
+        // the OFF state is compared against.
+        await page.getByTestId("sidebar-search-input").fill("Amazon Bedrock");
+        await expect(
+          page.getByTestId("amazonAmazon Bedrock Converse"),
+        ).toBeVisible();
       });
-    });
 
-    await test.step("Amazon Bedrock Converse is visible while the toggle is ON (baseline)", async () => {
-      // The beta toggle defaults to ON (showBeta = true), so the beta
-      // component is visible without any interaction. This is the baseline
-      // the OFF state is compared against.
-      await page.getByTestId("sidebar-search-input").fill("Amazon Bedrock");
-      await expect(
-        page.getByTestId("amazonAmazon Bedrock Converse"),
-      ).toBeVisible();
-    });
+      await test.step("Disable the Show Beta Components toggle", async () => {
+        // Clear the search first: an active search renders a second
+        // 'sidebar-options-trigger', which would break Playwright strict mode.
+        await page.getByTestId("sidebar-search-input").fill("");
+        await page.getByTestId("sidebar-options-trigger").click();
+        // Confirm the toggle is ON before flipping it — makes the baseline's
+        // precondition explicit and gives a clear failure if the default changes.
+        await expect(page.getByTestId("sidebar-beta-switch")).toBeChecked();
+        await page.getByTestId("sidebar-beta-switch").click();
+        await expect(page.getByTestId("sidebar-beta-switch")).not.toBeChecked();
+        await page.getByTestId("sidebar-options-trigger").click();
+      });
 
-    await test.step("Disable the Show Beta Components toggle", async () => {
-      // Clear the search first: an active search renders a second
-      // 'sidebar-options-trigger', which would break Playwright strict mode.
-      await page.getByTestId("sidebar-search-input").fill("");
-      await page.getByTestId("sidebar-options-trigger").click();
-      // Confirm the toggle is ON before flipping it — makes the baseline's
-      // precondition explicit and gives a clear failure if the default changes.
-      await expect(page.getByTestId("sidebar-beta-switch")).toBeChecked();
-      await page.getByTestId("sidebar-beta-switch").click();
-      await expect(page.getByTestId("sidebar-beta-switch")).not.toBeChecked();
-      await page.getByTestId("sidebar-options-trigger").click();
-    });
-
-    await test.step("Amazon Bedrock Converse is hidden while the toggle is OFF", async () => {
-      // Same search term as the baseline; only the toggle changed.
-      await page.getByTestId("sidebar-search-input").fill("Amazon Bedrock");
-      // Positive control: Amazon Bedrock Embeddings is neither beta nor legacy,
-      // so it always matches this search. Asserting it first proves the list
-      // rendered, so the toHaveCount(0) below means "filtered out by the
-      // toggle", not "the list hadn't rendered yet".
-      await expect(
-        page.getByTestId("amazonAmazon Bedrock Embeddings"),
-      ).toBeVisible();
-      await expect(
-        page.getByTestId("amazonAmazon Bedrock Converse"),
-      ).toHaveCount(0);
-    });
-  },
-);
+      await test.step("Amazon Bedrock Converse is hidden while the toggle is OFF", async () => {
+        // Same search term as the baseline; only the toggle changed.
+        await page.getByTestId("sidebar-search-input").fill("Amazon Bedrock");
+        // Positive control: Amazon Bedrock Embeddings is neither beta nor legacy,
+        // so it always matches this search. Asserting it first proves the list
+        // rendered, so the toHaveCount(0) below means "filtered out by the
+        // toggle", not "the list hadn't rendered yet".
+        await expect(
+          page.getByTestId("amazonAmazon Bedrock Embeddings"),
+        ).toBeVisible();
+        await expect(
+          page.getByTestId("amazonAmazon Bedrock Converse"),
+        ).toHaveCount(0);
+      });
+    },
+  );
+});

--- a/tests/tests-automations/regression/core-components/legacy-components-toggle-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/legacy-components-toggle-regression.spec.ts
@@ -1,44 +1,59 @@
 import { expect, test } from "../../../fixtures/fixtures";
 import { addLegacyComponents } from "../../../helpers/flows/add-legacy-components";
-import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
 
-test(
-  "Show Legacy Components toggle controls visibility of legacy components in the sidebar",
-  { tag: ["@stable", "@regression", "@components"] },
-  async ({ page }) => {
-    await test.step("Open a blank flow", async () => {
-      await awaitBootstrapTest(page);
-      await page.getByTestId("blank-flow").click();
-      await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
-        timeout: 10000,
+test.describe("Show Legacy Components toggle", () => {
+  let createdFlowId: string | null = null;
+
+  test.beforeEach(async ({ page }) => {
+    // setupBlankFlow creates the flow via API (avoids the UI-creation 500 race)
+    // and returns its id so afterEach can clean it up.
+    createdFlowId = await setupBlankFlow(page);
+    await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (createdFlowId) {
+      // Leave the editor first: staying on it while the flow is deleted makes
+      // background polling 404, which the fixture's error monitor would flag.
+      await page.goto("/").catch(() => {});
+      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      createdFlowId = null;
+    }
+  });
+
+  test(
+    "Show Legacy Components toggle controls visibility of legacy components in the sidebar",
+    { tag: ["@stable", "@regression", "@components"] },
+    async ({ page }) => {
+      await test.step("Python REPL is hidden while the toggle is OFF (baseline)", async () => {
+        await page.getByTestId("sidebar-search-input").fill("Python REPL");
+        // Positive control: the non-legacy substitute (Python Interpreter, whose
+        // internal name is PythonREPLComponent) always matches this search, so its
+        // presence proves the sidebar actually rendered results. Asserting it
+        // first kills the "empty list resolves toHaveCount(0) before the filter
+        // applied" race — the 0 below now means "filtered out", not "not rendered".
+        await expect(
+          page.getByTestId("utilitiesPython Interpreter"),
+        ).toBeVisible();
+        await expect(page.getByTestId("toolsPython REPL")).toHaveCount(0);
       });
-    });
 
-    await test.step("Python REPL is hidden while the toggle is OFF (baseline)", async () => {
-      await page.getByTestId("sidebar-search-input").fill("Python REPL");
-      // Positive control: the non-legacy substitute (Python Interpreter, whose
-      // internal name is PythonREPLComponent) always matches this search, so its
-      // presence proves the sidebar actually rendered results. Asserting it
-      // first kills the "empty list resolves toHaveCount(0) before the filter
-      // applied" race — the 0 below now means "filtered out", not "not rendered".
-      await expect(
-        page.getByTestId("utilitiesPython Interpreter"),
-      ).toBeVisible();
-      await expect(page.getByTestId("toolsPython REPL")).toHaveCount(0);
-    });
+      await test.step("Enable the Show Legacy Components toggle", async () => {
+        // Clear the search first: an active search renders a second
+        // 'sidebar-options-trigger', which would break Playwright strict mode.
+        await page.getByTestId("sidebar-search-input").fill("");
+        await addLegacyComponents(page);
+      });
 
-    await test.step("Enable the Show Legacy Components toggle", async () => {
-      // Clear the search first: an active search renders a second
-      // 'sidebar-options-trigger', which would break Playwright strict mode.
-      await page.getByTestId("sidebar-search-input").fill("");
-      await addLegacyComponents(page);
-    });
-
-    await test.step("Python REPL is visible while the toggle is ON", async () => {
-      // Same search as the baseline; only the toggle changed — so the legacy
-      // component must now appear (count goes from 0 to 1).
-      await page.getByTestId("sidebar-search-input").fill("Python REPL");
-      await expect(page.getByTestId("toolsPython REPL")).toHaveCount(1);
-    });
-  },
-);
+      await test.step("Python REPL is visible while the toggle is ON", async () => {
+        // Same search as the baseline; only the toggle changed — so the legacy
+        // component must now appear (count goes from 0 to 1).
+        await page.getByTestId("sidebar-search-input").fill("Python REPL");
+        await expect(page.getByTestId("toolsPython REPL")).toHaveCount(1);
+      });
+    },
+  );
+});


### PR DESCRIPTION
## What

Migrates the two component-toggle specs off the `awaitBootstrapTest` + `blank-flow` click pattern (which created flows via the UI — subject to the documented `POST /api/v1/flows/` 500 race — and never deleted them, leaving orphan flows in the DB) onto the established `setupBlankFlow` + `afterEach` cleanup pattern used by `componentDelete.spec.ts`.

- `legacy-components-toggle-regression.spec.ts`
- `beta-components-toggle-regression.spec.ts`

Both now create the flow via `setupBlankFlow(page)` (API creation, returns the `flowId`) in `beforeEach` and delete it via `page.request.delete(\`/api/v1/flows/\${flowId}\`)` in `afterEach`.

## Acceptance criteria

- [x] Both specs use `setupBlankFlow` instead of `awaitBootstrapTest` + `blank-flow` click
- [x] Both specs delete their created flow in `afterEach`
- [x] Both specs re-validated (`--retries=0`, zero backend errors) and still pass
- [x] `@stable` preserved on both

Test behavior and assertions are unchanged — only flow setup/teardown was standardized.

Closes #393