### PR TITLE
fix(ci): re-declare safe.directory in weekly history commit step

### DIFF
--- a/.github/workflows/weekly-stable.yml
+++ b/.github/workflows/weekly-stable.yml
@@ -149,6 +149,14 @@ jobs:
       - name: Commit weekly history
         if: always() && github.event_name == 'schedule'
         run: |
+          # The job runs inside the Playwright container as root, while the
+          # workspace is owned by the host runner uid. git 2.43 then refuses to
+          # operate on the repo ("dubious ownership"). actions/checkout works
+          # around this by writing safe.directory to a git global config under a
+          # temporary HOME, which is gone by the time this step runs — so we
+          # re-declare it here, or git reports "fatal: not in a git directory"
+          # and the commit/push back to main never happens (see issue #385).
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           if git diff --quiet reports/weekly-history.jsonl 2>/dev/null; then
             echo "No history change to commit."
             exit 0

--- a/reports/README.md
+++ b/reports/README.md
@@ -14,6 +14,14 @@ Files in this directory are **machine-written and human-read only**. Do not hand
 
 Each line is one [JSON object](#schema-version-1) terminated by `\n`. The file is JSONL (newline-delimited JSON), not a JSON array — append-only, diff-friendly.
 
+### Known gaps
+
+The series is **not continuous**. Document any missing weeks here rather than back-filling entries by hand (which would violate the machine-written invariant above, and is unrecoverable anyway — `results.json` is not retained as an artifact).
+
+| Missing weeks | Cause | Resolution |
+|---|---|---|
+| 2026-06-01, 2026-06-08, 2026-06-15 | The "Commit weekly history" step failed with `fatal: not in a git directory` — git refused the root-owned-vs-host-uid workspace inside the container, and the `safe.directory` that `actions/checkout` set under a temporary HOME was gone by commit time. The "Append weekly history" step succeeded, so the file was written in-job but never committed back to `main`. | Fixed forward in #385 (re-declare `safe.directory` in the commit step). The runs themselves are recoverable from GitHub Actions run history, but their per-test `results.json` is not, so these weeks stay absent from the JSONL. |
+
 ---
 
 ## Schema (version 1)


### PR DESCRIPTION
## Problem

The **"Commit weekly history"** step of `weekly-stable.yml` has failed on every scheduled run since the job moved into a container, with:

```
fatal: not in a git directory
##[error]Process completed with exit code 128.
```

Confirmed on the 2026-06-08 (`27133642480`) and 2026-06-15 (`27546448127`) runs. As a result `reports/weekly-history.jsonl` has been frozen at **2026-05-25** — the 06-01, 06-08 and 06-15 entries were written in-job but never committed back to `main`. This silently undermines our triage convention, which treats that JSONL as the source of truth for recurrence.

## Root cause

The job runs inside the Playwright container (`mcr.microsoft.com/playwright:v1.58.2-noble`) as **root**, while the workspace is owned by the host runner uid. git 2.43 then refuses to operate on the repo under its *dubious ownership* protection. `actions/checkout@v4` works around this by writing `safe.directory` to a git **global** config under a *temporary* `HOME`, which is discarded by the time the commit step runs — so git no longer recognizes the repository and `git config user.name` (the first non-suppressed git command) reports `fatal: not in a git directory`, killing the step under `set -e`.

This is a "worked on host, broke in container" regression: the job moved into a `container:` in `abc7203` (2026-06-01), right after the last successful history commit (05-25). On native `ubuntu-latest` there was no dubious-ownership check, so the step worked.

## Fix

Re-declare `safe.directory` at the start of the commit step:

```yaml
git config --global --add safe.directory "$GITHUB_WORKSPACE"
```

- `$GITHUB_WORKSPACE` resolves to `/__w/langflow-e2e/langflow-e2e` inside the container (matches the checkout log) — preferred over a hardcoded path or the broader `safe.directory '*'`.
- Push authentication is unaffected: `actions/checkout@v4` persists the token via the `http.<url>.extraheader` in the **local** `.git/config`, which survives within the job. The `fatal` fired *before* any auth negotiation, so once git recognizes the repo again the push authenticates as designed.

## Gap documentation

Per `reports/README.md`'s machine-written / never-hand-edit / fix-forward convention, the missing weeks are **documented**, not back-filled — the per-test `results.json` for those runs is not retained as an artifact and is unrecoverable. Added a *Known gaps* table covering 2026-06-01 / 06-08 / 06-15.

## Validation

Cannot be validated end-to-end without an actual scheduled run in the container (the commit step is gated on `github.event_name == 'schedule'`). The mechanism is standard and well-documented; confirm on the next Monday run (**2026-06-22**) that the history entry lands.

Closes #385