### PR TITLE
test(#306): assert populated LLM-span values on single-trace API

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -3,7 +3,7 @@
 > **Repository:** `C:/QAx/langflow-playwright/langflow-e2e`
 > **Tests:** `tests/tests-automations/regression/`
 > **Config:** `playwright.config.ts`
-> **Last updated:** 2026-06-16
+> **Last updated:** 2026-06-17
 
 ---
 
@@ -417,6 +417,7 @@
 - [x] Trace displays tokens consumed
 - [x] Single-trace API returns 404 for an unknown trace_id → `traces-detail-single.spec.ts`
 - [x] Single-trace API returns the full TraceRead contract with a non-empty span tree → `traces-detail-single.spec.ts`
+- [x] Single-trace API returns populated tokenUsage + modelName on the LLM span (OpenAI) → `traces-detail-llm-span-populated.spec.ts`
 - [x] Bulk delete traces API returns 404 for an unknown flow_id → `traces-delete.spec.ts`
 - [x] Bulk delete traces API clears all traces for the flow (204 + empty list) → `traces-delete.spec.ts`
 - [x] Trace list filter `?status=error` returns only the failing trace; `?status=<unknown>` returns 422 → `traces-list-filters.spec.ts`
@@ -741,7 +742,7 @@
 | `core-functionality/knowledge-ingestion/` | 8 | 0 | 4 | 0 | 4 |
 | `core-functionality/llm-agents/` | 40 | 13 | 2 | 0 | 25 |
 | `core-functionality/model-provider/` | 31 | 4 | 18 | 0 | 9 |
-| `core-functionality/observability-monitoring/` | 22 | 14 | 7 | 0 | 1 |
+| `core-functionality/observability-monitoring/` | 23 | 15 | 7 | 0 | 1 |
 | `core-functionality/playground/` | 48 | 43 | 3 | 1 | 1 |
 | `core-functionality/project-management/` | 11 | 0 | 10 | 1 | 0 |
 | `core-functionality/templates/` | 41 | 2 | 39 | 0 | 0 |
@@ -750,7 +751,7 @@
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 44 | 6 | 36 | 1 | 1 |
 | `ui-ux/` — Settings | 5 | 1 | 3 | 1 | 0 |
-| **TOTAL** | **436** | **195 (45%)** | **181 (42%)** | **7 (2%)** | **53 (12%)** |
+| **TOTAL** | **437** | **196 (45%)** | **181 (41%)** | **7 (2%)** | **53 (12%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -766,7 +767,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 197 `test()` calls carrying the `@stable` tag, distributed across 67 spec
+> 198 `test()` calls carrying the `@stable` tag, distributed across 68 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -900,6 +901,7 @@
 #### core-functionality/observability-monitoring/
 - [x] DELETE /api/v1/monitor/traces returns 404 for an unknown flow_id → `traces-delete.spec.ts`
 - [x] DELETE /api/v1/monitor/traces?flow_id=... clears all traces, and a second DELETE on the empty owned flow still returns 204 → `traces-delete.spec.ts`
+- [x] GET /api/v1/monitor/traces/{trace_id} returns a populated tokenUsage + modelName on the LLM span → `traces-detail-llm-span-populated.spec.ts`
 - [x] GET /api/v1/monitor/traces/{trace_id} returns 404 for an unknown but well-formed UUID → `traces-detail-single.spec.ts`
 - [x] GET /api/v1/monitor/traces/{trace_id} returns the full TraceRead contract with a non-empty span tree → `traces-detail-single.spec.ts`
 - [x] GET /api/v1/monitor/transactions returns 200 with paginated result → `traces-detail.spec.ts`

--- a/docs/core-functionality/observability-monitoring/traces-detail-llm-span-populated.md
+++ b/docs/core-functionality/observability-monitoring/traces-detail-llm-span-populated.md
@@ -6,7 +6,7 @@
 
 ## What this test validates *(required)*
 
-`traces-detail-single.spec.ts` (PR #305 / closes #299) pins the wire **shape** of `GET /api/v1/monitor/traces/{trace_id}` — every `TraceRead` / `SpanReadResponse` key is asserted to exist and the `SpanType` / `SpanStatus` enums are pinned on every node. But it runs the shared no-provider fixture, which errors at the `LanguageModelComponent` before any LLM call, so `tokenUsage` and `modelName` always land as `null` and the issue-#299 acceptance text — *"On the LLM span: `tokenUsage.{promptTokens,completionTokens,totalTokens}`, `latencyMs`, `modelName`"* — was never **value**-asserted. A regression that dropped `promptTokens` would have passed there.
+`traces-detail-single.spec.ts` (PR #305 / #299) pins the wire **shape** of `GET /api/v1/monitor/traces/{trace_id}` — every `TraceRead` / `SpanReadResponse` key is asserted to exist and the `SpanType` / `SpanStatus` enums are pinned on every node. But it runs the shared no-provider fixture, which errors at the `LanguageModelComponent` before any LLM call, so `tokenUsage` and `modelName` always land as `null` and the issue-#299 acceptance text — *"On the LLM span: `tokenUsage.{promptTokens,completionTokens,totalTokens}`, `latencyMs`, `modelName`"* — was never **value**-asserted. A regression that dropped `promptTokens` would have passed there.
 
 This spec closes that gap. It seeds the same flow but injects a real **OpenAI** provider via run tweaks, runs it to a **successful** completion, then value-asserts the populated LLM span:
 

--- a/docs/core-functionality/observability-monitoring/traces-detail-llm-span-populated.md
+++ b/docs/core-functionality/observability-monitoring/traces-detail-llm-span-populated.md
@@ -1,0 +1,109 @@
+# Single-Trace API — populated LLM-span values on `GET /api/v1/monitor/traces/{trace_id}`
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+`traces-detail-single.spec.ts` (PR #305 / closes #299) pins the wire **shape** of `GET /api/v1/monitor/traces/{trace_id}` — every `TraceRead` / `SpanReadResponse` key is asserted to exist and the `SpanType` / `SpanStatus` enums are pinned on every node. But it runs the shared no-provider fixture, which errors at the `LanguageModelComponent` before any LLM call, so `tokenUsage` and `modelName` always land as `null` and the issue-#299 acceptance text — *"On the LLM span: `tokenUsage.{promptTokens,completionTokens,totalTokens}`, `latencyMs`, `modelName`"* — was never **value**-asserted. A regression that dropped `promptTokens` would have passed there.
+
+This spec closes that gap. It seeds the same flow but injects a real **OpenAI** provider via run tweaks, runs it to a **successful** completion, then value-asserts the populated LLM span:
+
+- `tokenUsage` is a non-null object; `promptTokens`, `completionTokens`, `totalTokens` are all numbers `> 0`
+- `totalTokens === promptTokens + completionTokens` (the derivation in `formatting.py:103`)
+- `modelName` is a non-empty string that contains the requested model id (`gpt-4o-mini`)
+- `latencyMs > 0`
+
+### Span topology note
+
+Langflow emits **two** spans of `type === "llm"` for a single model call:
+
+| Span name (this version)   | `type` | `tokenUsage` | `modelName`        | `latencyMs` |
+| -------------------------- | ------ | ------------ | ------------------ | ----------- |
+| `Language Model` (component) | `llm`  | populated    | `null`             | > 0         |
+| `ChatOpenAI gpt-4o-mini` (provider) | `llm`  | populated    | `gpt-4o-mini`      | > 0         |
+
+`modelName` is read from the `gen_ai.response.model` span attribute (`formatting.py:124`). Langflow sets that attribute from the request's invocation params on the inner **provider** span only — so its value is the **requested** model id (exactly `gpt-4o-mini` for this flow, with no date suffix), and it is `null` on the component span. The spec therefore targets the provider span — the only span carrying **all three** issue-#306 values. Selection is by `type === "llm"` + a non-null `modelName`, with a name-based fallback (`/(chatopenai|language model)/i`) guarding against a future version that stops tagging the model call with `type === "llm"`. The `modelName` assertion uses containment (not equality) so a future provider that echoes back a resolved id with a suffix still passes.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@api` `@regression` `@observability`
+
+---
+
+## Step by step *(required)*
+
+**`describe("Single trace — populated LLM span (OpenAI)")` — `mode: "serial"`**
+
+The whole describe block is `test.skip`-ped when `OPENAI_API_KEY` is absent — without a real LLM call the populated values can never exist.
+
+**`beforeAll` (shared setup)**
+1. Get a bearer token via `getAuthToken(request)`
+2. Create an API key (`POST /api/v1/api_key/` with Bearer auth, name `traces-detail-llm-span-test-<timestamp>`); capture `api_key` + `id`
+3. Create a flow (`POST /api/v1/flows/` with `x-api-key` auth) from `tests/assets/flows/basic-prompting-trace-fixture.json`, name suffixed with the timestamp; expect HTTP 201; capture `flowId`
+4. Run the flow (`POST /api/v1/run/{flowId}` with `x-api-key` auth) injecting the provider via `tweaks` on the `LanguageModelComponent` node (id resolved from the fixture at runtime): `model: [{ name: "gpt-4o-mini", provider: "OpenAI" }]` and `api_key: process.env.OPENAI_API_KEY`. Unlike the sibling shape spec, this run must **succeed** — assert HTTP **200** (a 500 means the LLM call failed and the span attributes would be empty)
+5. Poll `GET /api/v1/monitor/traces?flow_id=<flowId>` (Bearer auth) with intervals `[500, 1000, 2000]` ms up to 30 s until `body.traces[0].id` is not null; capture `traceId`
+
+**`afterAll`** — delete the flow (Bearer) and the API key (Bearer) via `Promise.allSettled`.
+
+**Test — `GET /api/v1/monitor/traces/{trace_id} returns a populated tokenUsage + modelName on the LLM span`**
+1. `GET /api/v1/monitor/traces/<traceId>` with Bearer auth; assert HTTP 200
+2. Flatten the span tree (root + recursive `children`) and select the LLM spans (`type === "llm"`, name fallback if none)
+3. Pick the provider span (the one with a non-null `modelName`); assert it exists
+4. Assert `tokenUsage` is a non-null object with `promptTokens` / `completionTokens` / `totalTokens` all numeric and `> 0`
+5. Assert `totalTokens === promptTokens + completionTokens`
+6. Assert `modelName` is a non-empty string whose lowercase form contains `gpt-4o-mini`
+7. Assert `latencyMs` is a number `> 0`
+
+---
+
+## Validation criterion *(required)*
+
+Pins the **populated** LLM-span contract that the Trace Details modal renders for a real model call — the value-level half of the #299 acceptance that `traces-detail-single.spec.ts` deliberately left out. A regression that dropped a token field, broke the `total = prompt + completion` derivation, stopped emitting `gen_ai.response.model` (→ `modelName === null` on every span), or zeroed per-span latency would surface here before the modal renders blank or wrong token counts. **Out of scope:** the shape contract (every key present, enum pinning on every node) — that is `traces-detail-single.spec.ts`.
+
+---
+
+## External dependencies *(required)*
+
+References in the **main Langflow repository** (compatible with Langflow 1.10.x):
+
+- `src/backend/base/langflow/services/tracing/formatting.py` (lines 97-124) — builds `tokenUsage` from `gen_ai.usage.input_tokens` / `output_tokens` (total derived as input + output) and `modelName` from `gen_ai.response.model`; both attributes are only present after a completed LLM call
+- `src/lfx/src/lfx/components/models_and_agents/language_model.py` — `LanguageModelComponent`; `build_model()` → `get_llm(model=self.model, api_key=self.api_key, …)`
+- `src/lfx/src/lfx/base/models/unified_models/instantiation.py` — `get_llm`; the `model` value is a one-element list of `{name, provider}` (model class derived from the provider mapping when metadata omits it), `api_key` overrides the global provider key
+- `src/backend/base/langflow/services/database/models/traces/model.py` — `SpanType` / `SpanStatus` enums and the `SpanReadResponse` / `TraceRead` Pydantic models
+
+References in this repository:
+
+- `tests/assets/flows/basic-prompting-trace-fixture.json` — the **shared** Basic Prompting flow; the provider is injected at run time via tweaks, so no provider-configured fixture file is added (see Notes)
+- `tests/helpers/auth/get-auth-token.ts` — issues a bearer token for the superuser
+- `tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-single.spec.ts` — the shape spec this one complements
+
+External services: **OpenAI** (`OPENAI_API_KEY`) — one `gpt-4o-mini` call per run.
+
+---
+
+## What this test does not cover *(optional)*
+
+- **Shape contract** (every `TraceRead` / `SpanReadResponse` key present, `SpanType` / `SpanStatus` enum pinning on every node) — covered by `traces-detail-single.spec.ts`.
+- **Non-OpenAI providers** — only OpenAI is exercised. The `gen_ai.usage.*` attributes follow OTel GenAI conventions across providers, so OpenAI is a representative pin.
+- **The component-level `Language Model` span's `modelName === null`** — not asserted; the spec targets the provider span where `modelName` is populated. The two-span split is documented above so a future single-span emission is understood, not mistaken for a regression.
+- **UI rendering of the populated cards** — `traces-latency-tokens.spec.ts` exercises the Trace Details modal, but against the unconfigured fixture (em-dash fallback). A UI spec pinning real token numbers is not in scope here.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
+- The configured superuser must be able to issue a token via `getAuthToken`
+- `OPENAI_API_KEY` set in the environment — the describe block skips entirely without it
+
+---
+
+## Notes *(optional)*
+
+- **Fixture-sharing decision (issue-#306 acceptance):** no new fixture file is added. The provider is injected at run time via `tweaks` on the existing shared `basic-prompting-trace-fixture.json`, keeping a single fixture for both the shape spec (no provider → intentional error) and this populated spec (provider injected → success). This avoids a second near-duplicate fixture to maintain and keeps the provider key out of any checked-in JSON. Future specs needing a populated trace can reuse the same tweak pattern.
+- The `LanguageModelComponent` node id carries a random suffix; the spec resolves it from the fixture at runtime (`languageModelNodeId()`) so the tweak survives a fixture regeneration.
+- The run uses the Bearer token for both deletes in `afterAll` so they can run concurrently without racing on `x-api-key` auth.

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-llm-span-populated.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-llm-span-populated.spec.ts
@@ -1,0 +1,242 @@
+import { readFileSync } from "fs";
+import path from "path";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+
+const TRACE_FIXTURE = JSON.parse(
+  readFileSync(
+    path.resolve(
+      __dirname,
+      "../../../../assets/flows/basic-prompting-trace-fixture.json",
+    ),
+    "utf8",
+  ),
+);
+
+// Cheap, fast OpenAI model — enough to emit a real LLM span with token usage.
+const MODEL_NAME = "gpt-4o-mini";
+
+type Span = { children?: Span[] } & Record<string, unknown>;
+
+function flattenSpans(spans: Span[]): Span[] {
+  const out: Span[] = [];
+  for (const span of spans) {
+    out.push(span);
+    const children = Array.isArray(span.children) ? span.children : [];
+    out.push(...flattenSpans(children));
+  }
+  return out;
+}
+
+// Langflow emits TWO spans of type "llm" for a single model call: the
+// component-level "Language Model" span (tokenUsage + latencyMs but
+// modelName === null) and the inner provider span (e.g. "ChatOpenAI
+// gpt-4o-mini") that carries gen_ai.response.model and therefore the only
+// populated `modelName`. The fallback to a name match guards against a future
+// version that stops tagging the model call with type === "llm".
+function findLlmSpans(allSpans: Span[]): Span[] {
+  const byType = allSpans.filter((s) => s.type === "llm");
+  if (byType.length > 0) return byType;
+  return allSpans.filter(
+    (s) =>
+      typeof s.name === "string" &&
+      /(chatopenai|language model)/i.test(s.name),
+  );
+}
+
+// The LanguageModelComponent node carries a random id suffix that could change
+// if the fixture is regenerated — resolve it from the fixture instead of
+// hardcoding so the run tweak always targets the right component.
+function languageModelNodeId(): string {
+  const nodes = TRACE_FIXTURE.data?.nodes ?? [];
+  const node = nodes.find(
+    (n: { data?: { type?: string } }) =>
+      n.data?.type === "LanguageModelComponent",
+  );
+  if (!node?.id) {
+    throw new Error(
+      "basic-prompting-trace-fixture.json no longer contains a LanguageModelComponent node",
+    );
+  }
+  return node.id;
+}
+
+test.describe("Single trace — populated LLM span (OpenAI)", () => {
+  test.describe.configure({ mode: "serial" });
+
+  // A real LLM call is the whole point of this spec — without a key the
+  // tokenUsage / modelName / latencyMs values can never populate.
+  test.skip(
+    !process?.env?.OPENAI_API_KEY,
+    "OPENAI_API_KEY required to run this test",
+  );
+
+  let bearerToken: string;
+  let apiKey: string;
+  let apiKeyId: string;
+  let flowId: string;
+  let traceId: string;
+
+  test.beforeAll(async ({ request }) => {
+    bearerToken = await getAuthToken(request);
+
+    const keyRes = await request.post("/api/v1/api_key/", {
+      headers: { Authorization: bearerToken },
+      data: { name: `traces-detail-llm-span-test-${Date.now()}` },
+    });
+    expect(keyRes.status()).toBe(200);
+    const keyBody = await keyRes.json();
+    apiKey = keyBody.api_key;
+    apiKeyId = keyBody.id;
+
+    const flowRes = await request.post("/api/v1/flows/", {
+      headers: { "x-api-key": apiKey },
+      data: {
+        ...TRACE_FIXTURE,
+        name: `${TRACE_FIXTURE.name} ${Date.now()}`,
+      },
+    });
+    expect(flowRes.status()).toBe(201);
+    flowId = (await flowRes.json()).id;
+
+    // Run the flow with the OpenAI provider injected via tweaks. Unlike the
+    // sibling shape spec (traces-detail-single.spec.ts), this run must SUCCEED:
+    // get_llm in Langflow only writes gen_ai.usage.* / gen_ai.response.model
+    // span attributes on a completed LLM call, and those are the source of
+    // tokenUsage and modelName. The model value mirrors the unified ModelInput
+    // wire format (a one-element list of {name, provider}); api_key overrides
+    // the (absent) global provider key.
+    const runRes = await request.post(`/api/v1/run/${flowId}`, {
+      headers: { "x-api-key": apiKey },
+      data: {
+        input_value: "Reply with the single word: pong",
+        input_type: "chat",
+        output_type: "chat",
+        tweaks: {
+          [languageModelNodeId()]: {
+            model: [{ name: MODEL_NAME, provider: "OpenAI" }],
+            api_key: process.env.OPENAI_API_KEY,
+          },
+        },
+      },
+    });
+    // A populated trace requires a successful run — a 500 here means the LLM
+    // call failed and the span attributes would be empty. Fail fast.
+    expect(runRes.status()).toBe(200);
+
+    // Trace writes are asynchronous: poll the list endpoint until a trace lands
+    // for this flow. Capture the id inside the poll closure to avoid a redundant
+    // re-fetch (and the row-shift race that comes with it).
+    let polledTraceId: string | null = null;
+    await expect
+      .poll(
+        async () => {
+          const res = await request.get(
+            `/api/v1/monitor/traces?flow_id=${flowId}`,
+            { headers: { Authorization: bearerToken } },
+          );
+          if (res.status() !== 200) return null;
+          const body = await res.json();
+          polledTraceId = body.traces?.[0]?.id ?? null;
+          return polledTraceId;
+        },
+        { timeout: 30000, intervals: [500, 1000, 2000] },
+      )
+      .not.toBeNull();
+
+    expect(polledTraceId).not.toBeNull();
+    traceId = polledTraceId!;
+  });
+
+  test.afterAll(async ({ request }) => {
+    // allSettled so a failed flow delete does not skip the key delete (and vice
+    // versa). Flow delete uses the bearer token (not the api_key) so the two
+    // deletes can run concurrently without racing on auth.
+    const cleanups: Promise<unknown>[] = [];
+    if (flowId) {
+      cleanups.push(
+        request.delete(`/api/v1/flows/${flowId}`, {
+          headers: { Authorization: bearerToken },
+        }),
+      );
+    }
+    if (apiKeyId) {
+      cleanups.push(
+        request.delete(`/api/v1/api_key/${apiKeyId}`, {
+          headers: { Authorization: bearerToken },
+        }),
+      );
+    }
+    await Promise.allSettled(cleanups);
+  });
+
+  test(
+    "GET /api/v1/monitor/traces/{trace_id} returns a populated tokenUsage + modelName on the LLM span",
+    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
+    async ({ request }) => {
+      const res = await request.get(`/api/v1/monitor/traces/${traceId}`, {
+        headers: { Authorization: bearerToken },
+      });
+      expect(res.status()).toBe(200);
+
+      const body = await res.json();
+      expect(Array.isArray(body.spans)).toBe(true);
+
+      // The provider span carries ALL three of the issue-#306 values
+      // (tokenUsage, modelName, latencyMs), so it is the one this spec pins.
+      const llmSpans = findLlmSpans(flattenSpans(body.spans));
+      expect(
+        llmSpans.length,
+        "no LLM span found in the trace tree",
+      ).toBeGreaterThan(0);
+
+      // The provider call span is the one carrying a populated modelName. A
+      // regression that dropped gen_ai.response.model from the provider span
+      // would leave every llm span with modelName === null and fail here.
+      const llmSpan = llmSpans.find(
+        (s) => typeof s.modelName === "string" && (s.modelName as string),
+      );
+      expect(
+        llmSpan,
+        "no LLM span carries a populated modelName",
+      ).toBeTruthy();
+
+      // tokenUsage is a non-null object with three numeric token counts > 0.
+      const tokenUsage = llmSpan!.tokenUsage as {
+        promptTokens: number;
+        completionTokens: number;
+        totalTokens: number;
+      } | null;
+      expect(tokenUsage).not.toBeNull();
+      expect(typeof tokenUsage).toBe("object");
+      expect(typeof tokenUsage!.promptTokens).toBe("number");
+      expect(typeof tokenUsage!.completionTokens).toBe("number");
+      expect(typeof tokenUsage!.totalTokens).toBe("number");
+      expect(tokenUsage!.promptTokens).toBeGreaterThan(0);
+      expect(tokenUsage!.completionTokens).toBeGreaterThan(0);
+      expect(tokenUsage!.totalTokens).toBeGreaterThan(0);
+
+      // total is derived as prompt + completion (formatting.py:103) — pin the
+      // arithmetic so a regression that drops one component surfaces here.
+      expect(tokenUsage!.totalTokens).toBe(
+        tokenUsage!.promptTokens + tokenUsage!.completionTokens,
+      );
+
+      // modelName is read from the gen_ai.response.model span attribute
+      // (formatting.py:124), which Langflow populates from the request's
+      // invocation params — so for this flow it is exactly the requested id
+      // ("gpt-4o-mini"). Assert containment rather than equality so a future
+      // provider that echoes back a resolved id with a suffix (e.g.
+      // "gpt-4o-mini-2024-07-18") still passes.
+      expect(typeof llmSpan!.modelName).toBe("string");
+      expect((llmSpan!.modelName as string).length).toBeGreaterThan(0);
+      expect((llmSpan!.modelName as string).toLowerCase()).toContain(
+        MODEL_NAME,
+      );
+
+      // A real LLM call always takes measurable wall-clock time.
+      expect(typeof llmSpan!.latencyMs).toBe("number");
+      expect(llmSpan!.latencyMs as number).toBeGreaterThan(0);
+    },
+  );
+});


### PR DESCRIPTION
## What

Adds `traces-detail-llm-span-populated.spec.ts` (+ spec doc) under `core-functionality/observability-monitoring/`, value-asserting the **populated** LLM span returned by `GET /api/v1/monitor/traces/{trace_id}`.

The sibling `traces-detail-single.spec.ts` (PR #305 / #299) pins only the wire **shape** — every `TraceRead` / `SpanReadResponse` key exists — but it runs the no-provider fixture, which errors before any LLM call, so `tokenUsage` and `modelName` always land as `null`. A regression that dropped `promptTokens` would pass there. This spec closes that gap with a real call.

## How

- Seeds the **shared** `basic-prompting-trace-fixture.json` (no new fixture file) and injects a real **OpenAI** provider at run time via `tweaks` on the `LanguageModelComponent` node (`model: [{ name: "gpt-4o-mini", provider: "OpenAI" }]` + `api_key`), so the provider key never enters checked-in JSON.
- Runs the flow to a **successful** completion (asserts HTTP 200 — the populated values only exist after a completed LLM call), polls until the trace lands, then targets the provider span.

### Assertions on the LLM span
- `tokenUsage` is a non-null object; `promptTokens` / `completionTokens` / `totalTokens` are numbers `> 0`
- `totalTokens === promptTokens + completionTokens` (the derivation in `formatting.py:103`)
- `modelName` is a non-empty string containing the requested model id (`gpt-4o-mini`)
- `latencyMs > 0`

### Span topology note
Langflow emits **two** `type === "llm"` spans: the component `Language Model` span (has `tokenUsage` + latency but `modelName: null`) and the inner provider `ChatOpenAI gpt-4o-mini` span (carries all three). The spec targets the provider span by selecting the `llm` span with a non-null `modelName`, with a name-based fallback. Documented in the spec doc's topology table.

## Validation
- `npm run typecheck` — clean
- `npx eslint` on the new file — 0 errors (one `playwright/no-skipped-test` warning on the `OPENAI_API_KEY` guard, matching the established repo pattern)
- Test run **3/3 passing** (`--repeat-each=3`) against a live nightly instance
- Independent review (separate agent, verified against Langflow `release-1.10.0` source): **ship-with-nits**; the one doc/comment inaccuracy it flagged (`modelName` source/date-suffix wording) is fixed in this branch

## Notes
- Tags: `@stable @release @api @regression @observability`
- **Fixture-sharing decision** (issue acceptance): no new fixture — provider injected via run tweaks on the existing shared fixture. Reusable pattern for future populated-trace specs.
- `weekly-stable.yml` passes `OPENAI_API_KEY`, so this `@stable` test makes one real `gpt-4o-mini` call per weekly run — intended, consistent with existing `@stable` OpenAI specs.
- QA-CHECKLIST table / Phase-0 counts are auto-generated; the bumped numbers here will be reconciled by `update-coverage-summary.yml` on merge.

Closes #306
