### PR TITLE
fix(api-request): migrate echo endpoint to postman-echo.com (#407)

### DIFF
--- a/docs/core-components/api-request-component-regression.md
+++ b/docs/core-components/api-request-component-regression.md
@@ -9,7 +9,7 @@
 Validates the **API Request** component end-to-end via 15 scenarios grouped into five categories:
 
 1. **Canvas rendering and inspector fields** — the node renders with the correct URL/API Response handles, and the inspector accepts URL + HTTP method input.
-2. **Execution per HTTP verb** — GET, POST, PUT, PATCH, DELETE each round-trip to an echo endpoint that **only** accepts that verb (any other verb returns 405). The output Data is asserted to contain `200`, the echoed URL host, and the expected structural keys (`source`, `status_code`, `response_headers`, `result`). The endpoint defaults to public `httpbin.org` (overridable via `HTTPBIN_BASE_URL`); a transient upstream 5xx is absorbed by a retry in `runAndOpenOutput` so it does not fail the suite — see "Validation criterion" and issue #383.
+2. **Execution per HTTP verb** — GET, POST, PUT, PATCH, DELETE each round-trip to an echo endpoint that **only** accepts that verb (any other verb returns a non-2xx — `404` on postman-echo, `405` on httpbin; either way it is not `200`, which is what the verb tests assert). The output Data is asserted to contain `200`, the echoed URL host, and the expected structural keys (`source`, `status_code`, `response_headers`, `result`). The endpoint defaults to `postman-echo.com` (overridable via `ECHO_BASE_URL`); a transient upstream 5xx is absorbed by a retry in `runAndOpenOutput` so it does not fail the suite — see "Validation criterion" and issues #383, #407.
 3. **Error and edge paths** — invalid URL shows the build-error notification, non-2xx responses (404) propagate as `status_code` without raising, query parameters embedded in the URL are sent and echoed back.
 4. **Inspector tables and cURL mode** — the headers key-value table accepts both key and value cell entries via the View Text editor; the body key-value table is accessed through the Controls modal (the body field is `advanced=True`) and accepts both key and value cell entries via the same editor; the cURL tab switches mode and the cURL parser auto-populates the URL field with the URL extracted from the cURL command, after which the run executes the GET successfully.
 5. **Persistence to flow JSON** — configuring URL, method and a headers row triggers an autosave that persists into the flow's saved state (verified by polling `GET /api/v1/flows/{id}`), and a full page reload rehydrates the inspector with the same values.
@@ -39,7 +39,7 @@ Every test starts with `addApiRequestComponent(page)` which:
 - Asserts exactly one node on the canvas (`react-flow__node` count === 1).
 
 ### 2. `inspector fields accept configured values`
-- Fills `popover-anchor-input-url_input` with `https://httpbin.org/get` and asserts the value.
+- Fills `popover-anchor-input-url_input` with `https://postman-echo.com/get` and asserts the value.
 - Opens the method dropdown, selects "POST" and asserts the displayed value matches.
 
 ### 3. `invalid URL is accepted by field and run shows error notification`
@@ -48,15 +48,15 @@ Every test starts with `addApiRequestComponent(page)` which:
 
 ### 4–8. `<METHOD> method executes <METHOD> verb and returns 200`
 For each of GET, POST, PUT, PATCH, DELETE:
-- Fills the URL with `https://httpbin.org/<verb>` (an endpoint that **only** accepts that verb)
+- Fills the URL with `https://postman-echo.com/<verb>` (an endpoint that **only** accepts that verb)
 - Selects the matching method in the dropdown
 - Runs the component and asserts the output Data contains `200`, the echoed URL, and the structural keys.
 
 ### 9. `non-2xx HTTP response propagates status_code without crashing`
-- Fills `https://httpbin.org/status/404`, runs, asserts the output Data contains `404` (not `200`, not `500`) and **does not** contain an `"error"` field (which only appears on httpx transport exceptions).
+- Fills `https://postman-echo.com/status/404`, runs, asserts the output Data contains `404` (not `200`, not `500`) and **does not** contain an `"error"` field (which only appears on httpx transport exceptions).
 
 ### 10. `query parameters embedded in URL are sent and echoed`
-- Fills `https://httpbin.org/get?e2e_param=functional_test_value`, runs, asserts the parameter key/value appear in the parsed response and the response status is `200`.
+- Fills `https://postman-echo.com/get?e2e_param=functional_test_value`, runs, asserts the parameter key/value appear in the parsed response and the response status is `200`.
 
 ### 11. `inspector headers table accepts key + value cell entries`
 - Opens `div-table_headers` → `Open table` button → table dialog opens.
@@ -69,7 +69,7 @@ For each of GET, POST, PUT, PATCH, DELETE:
 
 ### 13. `cURL mode parses command, auto-fills URL, executes GET and returns 200`
 - Switches to the cURL tab **before** touching the URL field (pre-filling `url_input` would mask a regression in the cURL parser by letting the run fall back to the URL-tab path).
-- Fills the cURL command and waits for the parser to auto-populate `url_input` with `https://httpbin.org/get`. The `waitForFunction` directly proves the parser ran.
+- Fills the cURL command and waits for the parser to auto-populate `url_input` with `https://postman-echo.com/get`. The `waitForFunction` directly proves the parser ran.
 - Runs the component and asserts the output Data contains `200`, the echoed URL, and the structural keys.
 
 ### 14. `body table accepts key + value cell entries when method is POST`
@@ -79,7 +79,7 @@ For each of GET, POST, PUT, PATCH, DELETE:
 - Closes the dialog with `btn-cancel-modal` — this test asserts in-session edit behavior only. End-to-end body persistence through reload is intentionally NOT covered (see "What this test does not cover").
 
 ### 15. `flow state persists in database after autosave (URL, method, headers)`
-- Configures URL (`https://httpbin.org/get?persist=true`), method (`POST`) and a headers row (`X-Persist-Header` / `persisted-value`) on a freshly created flow; captures the `flowId` from the URL.
+- Configures URL (`https://postman-echo.com/get?persist=true`), method (`POST`) and a headers row (`X-Persist-Header` / `persisted-value`) on a freshly created flow; captures the `flowId` from the URL.
 - Like test 14, waits for the `POST /api/v1/custom_component/update` response after the method switch so the headers `[value]` useEffect settles before adding a new row.
 - Clicks the dialog-level **Save** button (not Cancel, which discards `tempValue` via `handleCancel` in `TableNodeComponent`) so the row commits before autosave fires.
 - Polls `GET /api/v1/flows/{id}` (using `page.request` which inherits the session cookie) until the autosave has written the URL, method and matching header row into the saved flow JSON. Polling the API directly proves the autosave reached the database — not just in-memory React state. The match key is `node.data.type === "APIRequest"` (Python class name, not the `"API Request"` display name).
@@ -95,7 +95,7 @@ The suite must:
 - Read execution output via the dialog's copy button + clipboard, not the Monaco editor's `textContent`: the editor is virtualized, so `textContent` only returns lines in the viewport and silently truncates fields below the fold for a verbose response. The helper clears the clipboard first (it persists across the serial tests) and polls until the fresh output lands rather than waiting on the transient "Copied to clipboard" toast.
 - Retry past transient upstream outages: `runAndOpenOutput` re-runs the component (up to 3 attempts) when its own top-level `status_code` is `5xx` or when a run produces no readable output (build error / timeout). Each attempt anchors on its build event stream closing (not on the inspect button, which stays enabled across re-runs and would re-read stale output). No test here expects a 5xx, so retrying on one never masks a real assertion; once retries are exhausted on a still-5xx output it **throws loudly** rather than returning the 5xx, so a sustained outage or a regression surfacing as a 5xx fails clearly instead of slipping past a weak substring assertion (issue #383).
 - Run **serially** (`test.describe.configure({ mode: "serial" })`) — parallel autosaves on flow create cause `400 "flow must be unique"` errors that flag as backend errors in the fixture.
-- For each verb test, hit a `httpbin.org` endpoint that returns 405 for any other verb — this guarantees the test fails if the wrong verb is sent (e.g. POST sent as GET).
+- For each verb test, hit an endpoint that returns a non-2xx for any other verb (postman-echo returns `404`; httpbin returned `405`) — this guarantees the test fails if the wrong verb is sent (e.g. POST sent as GET), because the assertion requires `200`.
 - For the cURL execution test, switch to the cURL tab *before* configuring the URL — and assert the parser auto-populates `url_input`. Asserting only the run output would let the test pass even if cURL parsing was broken.
 - For the headers and body table tests, fill both KEY and VALUE cells (not key only) — filling only the key cell would still pass even if the value column was non-functional or rejected entries.
 - For the body table test, switch method to POST before searching for `div-table_body` — the `InspectionPanelFields` filter hides `body` while method is GET. (There is no Controls-modal / `edit-button-modal` step — the field renders directly in the inspector once method is POST.)
@@ -116,7 +116,7 @@ The suite must:
 - `src/frontend/src/CustomNodes/GenericNode/index.tsx` — owns the inspector layout that exposes `popover-anchor-input-url_input`, `dropdown_str_method`, `div-table_headers`, `tab_0_url`, `tab_1_curl`, etc.
 - `src/frontend/src/pages/FlowPage/components/InspectionPanel/components/InspectionPanelFields.tsx` — owns the `APIRequest` + `body` + GET filter that test 14 navigates around by switching method to POST
 - `src/frontend/src/components/core/parameterRenderComponent/components/TableNodeComponent/index.tsx` — owns the `[value]` useEffect that drives the `real_time_refresh` race in the body table (test 14's force+retry)
-- **Echo endpoint** (`HTTPBIN_BASE_URL`, default `https://httpbin.org`) — external test target for the 5 verb tests, the 404 test, the query-parameter test and the cURL-execute test. The request is made **by the Langflow backend**, so the URL must be reachable by Langflow, not by the Playwright runner. A transient upstream 5xx (httpbin.org sits behind an AWS ELB that intermittently returns 502/503/504) no longer hard-fails the suite: `runAndOpenOutput` retries on any 5xx output (issue #383). The spec derives `HTTPBIN_HOST` from the same base URL, so the echoed-host assertions hold for any configured endpoint. Self-hosting an echo endpoint in CI was evaluated and rejected: Langflow's SSRF protection blocks the service's private IP, and — decisively — the component's `validators.url()` check rejects the single-label service hostname (`http://httpbin:8080`) that a GitHub Actions service container is reachable by. To self-host **locally**, point `HTTPBIN_BASE_URL` at a dotted host or IP and add it to `LANGFLOW_SSRF_ALLOWED_HOSTS` on the Langflow process.
+- **Echo endpoint** (`ECHO_BASE_URL`, default `https://postman-echo.com`; the legacy `HTTPBIN_BASE_URL` is still honored as a fallback) — external test target for the 5 verb tests, the 404 test, the query-parameter test and the cURL-execute test. The request is made **by the Langflow backend**, so the URL must be reachable by Langflow, not by the Playwright runner. A transient upstream 5xx no longer hard-fails the suite: `runAndOpenOutput` retries on any 5xx output (issue #383). The default moved from `httpbin.org` to `postman-echo.com` after `httpbin.org` returned `503` (AWS ELB) on all retry attempts in three separate weekly runs (#383, #407) — postman-echo is a more reliable public echo with the same path surface; its only behavioral difference is returning `404` (not `405`) for a wrong verb, which is immaterial since the verb tests assert `200`. The spec derives `ECHO_HOST` from the same base URL, so the echoed-host assertions hold for any configured endpoint. Self-hosting an echo endpoint in CI was evaluated and rejected: Langflow's SSRF protection blocks the service's private IP, and — decisively — the component's `validators.url()` check rejects the single-label service hostname (`http://httpbin:8080`) that a GitHub Actions service container is reachable by. To self-host **locally**, point `ECHO_BASE_URL` at a dotted host or IP and add it to `LANGFLOW_SSRF_ALLOWED_HOSTS` on the Langflow process.
 
 ---
 
@@ -133,7 +133,7 @@ The suite must:
 ## Preconditions *(optional)*
 
 - Langflow running at `PLAYWRIGHT_BASE_URL`
-- An echo endpoint reachable **by Langflow** at `HTTPBIN_BASE_URL` (defaults to outbound HTTPS to `httpbin.org`); transient 5xx outages are absorbed by the retry in `runAndOpenOutput`
+- An echo endpoint reachable **by Langflow** at `ECHO_BASE_URL` (defaults to outbound HTTPS to `postman-echo.com`); transient 5xx outages are absorbed by the retry in `runAndOpenOutput`
 - No LLM required
 
 ---
@@ -143,7 +143,7 @@ The suite must:
 - The API Request field schema changes in `api_request.py` (URL, method, headers, body, curl_input field names)
 - The inspector layout changes such that `popover-anchor-input-url_input`, `dropdown_str_method`, or `tab_0_url`/`tab_1_curl` testids are renamed or restructured
 - The cURL parser changes its auto-fill behavior (e.g., it stops auto-populating `url_input` from the cURL command, or moves to a different field)
-- The default echo endpoint needs to change — set `HTTPBIN_BASE_URL` (no code change). Any httpbin-compatible echo server works (the spec relies only on the `/get`, `/post`, `/put`, `/patch`, `/delete`, `/status/{code}` paths, 405-on-wrong-verb, and the Host-echoing behavior). A self-hosted host on a private IP must be added to `LANGFLOW_SSRF_ALLOWED_HOSTS`, and the component's URL validator rejects single-label hostnames (use a dotted host or an IP)
+- The default echo endpoint needs to change — set `ECHO_BASE_URL` (no code change; the legacy `HTTPBIN_BASE_URL` is still honored). Any httpbin-/postman-echo-compatible echo server works (the spec relies only on the `/get`, `/post`, `/put`, `/patch`, `/delete`, `/status/{code}` paths, a non-2xx on the wrong verb, and the Host-echoing behavior). A self-hosted host on a private IP must be added to `LANGFLOW_SSRF_ALLOWED_HOSTS`, and the component's URL validator rejects single-label hostnames (use a dotted host or an IP)
 - `InspectionPanelFields.tsx` drops the `APIRequest` + `body` + GET filter (or makes it conditional on a different field) — at that point test 14 can drop the method-switch step and mirror the headers test directly
 - The `POST /api/v1/custom_component/update` endpoint is renamed or restructured — tests 14 and 15 both use `page.waitForResponse(...)` keyed on that URL substring
 - The autosave debounce interval is increased substantially — bump the persistence test's polling timeout (currently 20s) to match
@@ -155,11 +155,12 @@ The suite must:
 
 - **Duplicate coverage with legacy specs.** `tests/tests-automations/regression/api/flows/api-request-component-ui.spec.ts` (4 tests: canvas render, URL field, method dropdown, headers field) is fully superseded by tests 1, 2, and 11 of this spec — its 4th test uses anti-patterns (`.catch(() => false)`, conditional advanced-button click) that this consolidated spec replaces with deterministic locators. `tests/tests-automations/regression/api/flows/api-component-regression.spec.ts` (5 tests: GET, cURL POST + JSON body with auto-fill URL, `include_httpx_metadata`, timeout 500, URL-mode POST via dropdown) is partially duplicated by tests 4, 5, and 13 here, but contains 3 unique tests (`include_httpx_metadata`, timeout, cURL POST + body). A follow-up PR should migrate those 3 unique tests here and retire both legacy specs.
 - **`(page as any).allowFlowErrors()` cast.** The fixture injects `allowFlowErrors` onto the page object via `(page as any).allowFlowErrors = () => {...}`, without extending the `Page` type. Removing the cast at the call site requires extending the type signature in `fixtures.ts`. The pattern is project-wide (`loop-component-regression.spec.ts` uses the same cast).
-- **Why one verb per endpoint.** `/get`, `/post`, `/put`, `/patch`, `/delete` each return 405 if hit with any other verb (true for both httpbin.org and go-httpbin). This means the test fails if the component sends the wrong method — there's no way to silently pass with a misconfigured verb.
+- **Why one verb per endpoint.** `/get`, `/post`, `/put`, `/patch`, `/delete` each reject any other verb with a non-2xx (`404` on postman-echo, `405` on httpbin/go-httpbin). Since the verb tests assert the output contains `200`, the test fails if the component sends the wrong method — there's no way to silently pass with a misconfigured verb.
 - **Echo endpoint resilience (issue #383).** The verb/404/query/cURL tests originally hard-coded `https://httpbin.org/...`. A transient httpbin.org `503` (AWS ELB) hard-failed the POST test and flaked GET in the weekly run, opening #383. The fix makes the suite tolerate transient outages without masking a real regression:
   - **Retry**, not self-hosting. `runAndOpenOutput` re-runs the component (up to 3 attempts) when the output carries any `5xx` `status_code` or a run produces no readable output. Self-hosting a `mccutchen/go-httpbin` service container in the weekly workflow was implemented and tested first, but rejected after a CI run surfaced a hard blocker: the component's `validators.url()` rejects the single-label service hostname (`http://httpbin:8080`) that a GitHub Actions service container is reachable by (it also requires an SSRF allowlist for the service's private IP). `validators.url` accepts dotted hosts and IPs but not bare labels — which is why local testing via `host.containers.internal` passed and CI did not.
-  - **Endpoint override kept.** URLs are built from `HTTPBIN_BASE_URL` (default `https://httpbin.org`) and the echoed-host assertions derive `HTTPBIN_HOST` from the same base, so a different endpoint can be configured without code changes.
+  - **Endpoint override kept.** URLs are built from `ECHO_BASE_URL` (default `https://postman-echo.com`; legacy `HTTPBIN_BASE_URL` still honored) and the echoed-host assertions derive `ECHO_HOST` from the same base, so a different endpoint can be configured without code changes.
   - **Full-output read.** `runAndOpenOutput` reads the COMPLETE output via the dialog's copy button + clipboard (`copy-output-button`) instead of the truncation-prone virtualized Monaco `textContent` — a robustness fix kept from the self-hosting attempt (a verbose response can push asserted fields like `url` below the editor's viewport).
   - Validated against nightly `1.11.0.dev8`, 15/15 green against public httpbin.org — no product regression behind the original failure, confirming it was purely the external outage. `@stable` was restored on the POST test in the same change.
+- **Default endpoint moved to postman-echo.com (issue #407).** The retry above only survives a transient blip *within* a single test window. `httpbin.org` returned `503` (AWS ELB) on **all** retry attempts in the weekly runs of 2026-06-08, 2026-06-15 (#383) and 2026-06-22 (#407) — a sustained outage the retry cannot absorb. After the third recurrence the default echo endpoint moved from `httpbin.org` to `postman-echo.com`, empirically verified as a near drop-in: `/get`, `/post`, `/put`, `/patch`, `/delete` each 200 only for the matching verb, `/status/{code}` is a deliberate status endpoint, query params echo in `args`, and the response body echoes `host`/`url`. The one difference — a wrong verb returns `404` instead of httpbin's `405` — is immaterial to the verb tests, which assert the output contains `200` (and `404` is just as much "not 200"). The env knob was renamed `ECHO_BASE_URL` (the old `HTTPBIN_BASE_URL` is still honored as a fallback) and the constants are now `ECHO_BASE` / `ECHO_HOST`.
 - **cURL pre-fill anti-pattern (fixed).** The previous version of test 13 pre-populated `url_input` before switching to the cURL tab. The run would then succeed via the URL-tab path even if the cURL parser was broken. The current test switches to the cURL tab first and waits for the parser to auto-populate `url_input` — the run is genuinely driven by the cURL command.
 - **Headers table value-cell gap (fixed).** The previous version of test 11 only filled the key cell and closed the dialog with Cancel. It would have passed even if the value column was non-functional. The current version fills both key and value cells via `fillViewTextCell`, which asserts each cell renders as a button after Save inside the table dialog — closing the gap.

--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -7,24 +7,38 @@ import { enableInspectPanel } from "../../../helpers/ui/open-advanced-options";
 // Run tests serially to avoid "flow must be unique" 400 errors from parallel autosaves
 test.describe.configure({ mode: "serial" });
 
-// Echo endpoint base for the HTTP-execution tests. Defaults to the public
-// httpbin.org. Resilience to a transient httpbin.org 5xx outage is handled by
-// the retry in `runAndOpenOutput` (see issue #383), not by self-hosting — the
-// component's URL validator rejects single-label hostnames, which rules out a
-// CI service-container reachable only by its bare service label.
+// Echo endpoint base for the HTTP-execution tests. Defaults to postman-echo.com.
+//
+// History: the suite originally targeted httpbin.org, which proved chronically
+// unreliable — it returned HTTP 503 (AWS ELB) during the weekly runs of
+// 2026-06-08, 2026-06-15 (#383) and 2026-06-22 (#407). The retry-on-5xx in
+// `runAndOpenOutput` (added in #383) only survives a transient blip within a
+// single test window; a sustained outage exhausts all attempts and fails the
+// run. After the third recurrence the default was moved to postman-echo.com,
+// a more reliable public echo service that is a near drop-in for the paths this
+// suite uses: `/get`, `/post`, `/put`, `/patch`, `/delete` (each 200 only for
+// its matching verb), `/status/{code}` (deliberate status endpoint), query-param
+// echo, and Host/url echo in the response body.
+//
+// One behavioral difference from httpbin: postman-echo returns **404** for a
+// wrong verb where httpbin returned **405**. The per-verb guarantee is
+// unaffected — the verb tests assert the output contains `200`, and 404 is just
+// as much "not 200" as 405, so sending the wrong verb still fails the test.
 //
 // The override knob remains for anyone who wants to point the tests at a
-// different echo endpoint (e.g. a locally self-hosted go-httpbin, which is a
-// drop-in reimplementation of httpbin.org with the same paths, 405-on-wrong-verb
-// behavior and Host-echoing). The value must be reachable BY LANGFLOW — the
-// component's backend makes the request, not the Playwright runner — and a
-// self-hosted host on a private IP must be added to LANGFLOW_SSRF_ALLOWED_HOSTS.
-// HTTPBIN_HOST is derived from the same base URL so the echoed-host assertions
-// match whatever endpoint is configured.
-const HTTPBIN_BASE = (
-  process.env.HTTPBIN_BASE_URL ?? "https://httpbin.org"
+// different echo endpoint (e.g. a locally self-hosted go-httpbin). The value
+// must be reachable BY LANGFLOW — the component's backend makes the request, not
+// the Playwright runner — and a self-hosted host on a private IP must be added
+// to LANGFLOW_SSRF_ALLOWED_HOSTS. Note the component's URL validator rejects
+// single-label hostnames, so a CI service-container reachable only by its bare
+// service label will not work. ECHO_HOST is derived from the same base URL so
+// the echoed-host assertions match whatever endpoint is configured.
+const ECHO_BASE = (
+  process.env.ECHO_BASE_URL ??
+  process.env.HTTPBIN_BASE_URL ??
+  "https://postman-echo.com"
 ).replace(/\/$/, "");
-const HTTPBIN_HOST = new URL(HTTPBIN_BASE).host;
+const ECHO_HOST = new URL(ECHO_BASE).host;
 
 // Helper: create a blank flow and add the API Request component to the canvas.
 // After this call the component node is visible and its inspector is open.
@@ -51,8 +65,8 @@ async function addApiRequestComponent(page: Page) {
 
 // The output Data object the component returns is JSON. A transient upstream
 // failure surfaces as the component's OWN top-level `status_code` being 5xx
-// (httpbin.org sits behind an AWS ELB that intermittently returns 502/503/504;
-// an httpx transport blip surfaces as status_code 500 with an `error` field).
+// (a degraded echo service can return 502/503/504; an httpx transport blip
+// surfaces as status_code 500 with an `error` field).
 // The component faithfully propagates the upstream status — this is not a
 // Langflow bug — so `runAndOpenOutput` re-runs rather than failing the
 // assertion (issue #383). Parse and check the TOP-LEVEL status_code only: a
@@ -150,7 +164,7 @@ async function runOnce(page: Page): Promise<string> {
 
 // Helper: run the component and return its output, retrying past transient
 // upstream 5xx outages and runs that produce no readable output (build error /
-// timeout). This decouples the suite from httpbin.org's intermittent
+// timeout). This decouples the suite from the echo service's intermittent
 // availability without masking a real Langflow regression — a persistent
 // failure exhausts the retries and the caller's assertion reports the actual
 // content (issue #383).
@@ -300,8 +314,8 @@ test(
     // URL field — testid: popover-anchor-input-url_input
     const urlInput = page.getByTestId("popover-anchor-input-url_input");
     await expect(urlInput).toBeVisible({ timeout: 10000 });
-    await urlInput.fill(`${HTTPBIN_BASE}/get`);
-    await expect(urlInput).toHaveValue(`${HTTPBIN_BASE}/get`);
+    await urlInput.fill(`${ECHO_BASE}/get`);
+    await expect(urlInput).toHaveValue(`${ECHO_BASE}/get`);
 
     // Method dropdown — default is GET; confirm it can be changed to POST
     const methodDropdown = page.getByTestId("dropdown_str_method");
@@ -358,13 +372,13 @@ test(
 
     const urlInput = page.getByTestId("popover-anchor-input-url_input");
     await expect(urlInput).toBeVisible({ timeout: 10000 });
-    await urlInput.fill(`${HTTPBIN_BASE}/get`);
+    await urlInput.fill(`${ECHO_BASE}/get`);
 
     const output = await runAndOpenOutput(page);
 
     // HTTP response fields
     expect(output).toContain("200");
-    expect(output).toContain(HTTPBIN_HOST);
+    expect(output).toContain(ECHO_HOST);
 
     // Structural fields always present in Data output regardless of response content —
     // verifying all at once protects against regressions in make_request() output structure
@@ -389,7 +403,7 @@ test(
     const urlInput = page.getByTestId("popover-anchor-input-url_input");
     await expect(urlInput).toBeVisible({ timeout: 10000 });
     // /post only accepts POST — returns 405 for any other method
-    await urlInput.fill(`${HTTPBIN_BASE}/post`);
+    await urlInput.fill(`${ECHO_BASE}/post`);
 
     const methodDropdown = page.getByTestId("dropdown_str_method");
     await expect(methodDropdown).toBeVisible({ timeout: 10000 });
@@ -403,7 +417,7 @@ test(
 
     // A successful POST to /post returns 200 and echoes the request URL
     expect(output).toContain("200");
-    expect(output).toContain(`${HTTPBIN_HOST}/post`);
+    expect(output).toContain(`${ECHO_HOST}/post`);
 
     await page.keyboard.press("Escape");
   },
@@ -418,7 +432,7 @@ test(
     const urlInput = page.getByTestId("popover-anchor-input-url_input");
     await expect(urlInput).toBeVisible({ timeout: 10000 });
     // /put only accepts PUT — returns 405 for any other method
-    await urlInput.fill(`${HTTPBIN_BASE}/put`);
+    await urlInput.fill(`${ECHO_BASE}/put`);
 
     const methodDropdown = page.getByTestId("dropdown_str_method");
     await expect(methodDropdown).toBeVisible({ timeout: 10000 });
@@ -431,7 +445,7 @@ test(
     const output = await runAndOpenOutput(page);
 
     expect(output).toContain("200");
-    expect(output).toContain(`${HTTPBIN_HOST}/put`);
+    expect(output).toContain(`${ECHO_HOST}/put`);
     expect(output).toContain("status_code");
     expect(output).toContain("response_headers");
     expect(output).toContain("result");
@@ -449,7 +463,7 @@ test(
     const urlInput = page.getByTestId("popover-anchor-input-url_input");
     await expect(urlInput).toBeVisible({ timeout: 10000 });
     // /patch only accepts PATCH — returns 405 for any other method
-    await urlInput.fill(`${HTTPBIN_BASE}/patch`);
+    await urlInput.fill(`${ECHO_BASE}/patch`);
 
     const methodDropdown = page.getByTestId("dropdown_str_method");
     await expect(methodDropdown).toBeVisible({ timeout: 10000 });
@@ -462,7 +476,7 @@ test(
     const output = await runAndOpenOutput(page);
 
     expect(output).toContain("200");
-    expect(output).toContain(`${HTTPBIN_HOST}/patch`);
+    expect(output).toContain(`${ECHO_HOST}/patch`);
     expect(output).toContain("status_code");
     expect(output).toContain("response_headers");
     expect(output).toContain("result");
@@ -480,7 +494,7 @@ test(
     const urlInput = page.getByTestId("popover-anchor-input-url_input");
     await expect(urlInput).toBeVisible({ timeout: 10000 });
     // /delete only accepts DELETE — returns 405 for any other method
-    await urlInput.fill(`${HTTPBIN_BASE}/delete`);
+    await urlInput.fill(`${ECHO_BASE}/delete`);
 
     const methodDropdown = page.getByTestId("dropdown_str_method");
     await expect(methodDropdown).toBeVisible({ timeout: 10000 });
@@ -493,7 +507,7 @@ test(
     const output = await runAndOpenOutput(page);
 
     expect(output).toContain("200");
-    expect(output).toContain(`${HTTPBIN_HOST}/delete`);
+    expect(output).toContain(`${ECHO_HOST}/delete`);
     expect(output).toContain("status_code");
     expect(output).toContain("response_headers");
     expect(output).toContain("result");
@@ -512,7 +526,7 @@ test(
     await expect(urlInput).toBeVisible({ timeout: 10000 });
     // /status/404 responds with HTTP 404.
     // The component must NOT raise an exception — it returns Data(data={"status_code": 404, ...}).
-    await urlInput.fill(`${HTTPBIN_BASE}/status/404`);
+    await urlInput.fill(`${ECHO_BASE}/status/404`);
 
     const output = await runAndOpenOutput(page);
 
@@ -535,7 +549,7 @@ test(
     const urlInput = page.getByTestId("popover-anchor-input-url_input");
     await expect(urlInput).toBeVisible({ timeout: 10000 });
     // /get echoes all query parameters in the `args` key of the response body
-    await urlInput.fill(`${HTTPBIN_BASE}/get?e2e_param=functional_test_value`);
+    await urlInput.fill(`${ECHO_BASE}/get?e2e_param=functional_test_value`);
 
     const output = await runAndOpenOutput(page);
 
@@ -613,7 +627,7 @@ test(
     await expect(curlTextarea).toBeVisible({ timeout: 10000 });
 
     // Fill with a valid cURL command
-    const curlCommand = `curl -X GET ${HTTPBIN_BASE}/get -H 'Accept: application/json'`;
+    const curlCommand = `curl -X GET ${ECHO_BASE}/get -H 'Accept: application/json'`;
     await curlTextarea.fill(curlCommand);
     await expect(curlTextarea).toHaveValue(curlCommand);
 
@@ -643,7 +657,7 @@ test(
     await expect(curlTextarea).toBeVisible({ timeout: 10000 });
 
     await curlTextarea.fill(
-      `curl -X GET ${HTTPBIN_BASE}/get -H 'Accept: application/json'`,
+      `curl -X GET ${ECHO_BASE}/get -H 'Accept: application/json'`,
     );
 
     // The cURL parser must auto-populate url_input with the URL extracted from the command.
@@ -656,14 +670,14 @@ test(
         ) as HTMLInputElement | null;
         return el !== null && el.value === expectedUrl;
       },
-      `${HTTPBIN_BASE}/get`,
+      `${ECHO_BASE}/get`,
       { timeout: 10000 },
     );
 
     const output = await runAndOpenOutput(page);
 
     expect(output).toContain("200");
-    expect(output).toContain(HTTPBIN_HOST);
+    expect(output).toContain(ECHO_HOST);
     expect(output).toContain("status_code");
     expect(output).toContain("result");
 
@@ -746,7 +760,7 @@ test(
   "API Request component — flow state persists in database after autosave (URL, method, headers)",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    const expectedUrl = `${HTTPBIN_BASE}/get?persist=true`;
+    const expectedUrl = `${ECHO_BASE}/get?persist=true`;
     const headerKey = "X-Persist-Header";
     const headerValue = "persisted-value";
     let flowId = "";


### PR DESCRIPTION
## Context

Closes #409. The weekly `@stable` run of 2026-06-22 ([27952036517](https://github.com/oriontech-me/langflow-e2e/actions/runs/27952036517)) hard-failed:

> `API Request component — GET request returns 200 and output Data contains all required fields`

with `httpbin.org/get` returning **HTTP 503 (AWS ELB) on all 3 retry attempts**.

This is **not a Langflow regression and not a test-logic bug** — it is the **third recurrence** of the same external dependency outage:

| Date | Issue | What happened |
|---|---|---|
| 2026-06-08 | — | GET/PUT/non-2xx 503 |
| 2026-06-15 | #383 | `@stable` removed, then restored with retry-on-5xx |
| 2026-06-22 | #407 | retry-on-5xx exhausted — httpbin down the whole window |

The retry added in #383 only survives a transient blip *within* a single test window; a sustained outage exhausts every attempt and fails the run.

## What this PR does

Moves the default echo endpoint from `httpbin.org` to **`postman-echo.com`** (more reliable public echo). Verified empirically as a near drop-in before any code change:

- `/get`, `/post`, `/put`, `/patch`, `/delete` each return `200` only for the matching verb
- `/status/{code}` is a deliberate status endpoint (`/status/404` → 404)
- query params echo in `args`; the body echoes `host`/`url`

**One behavioral difference:** a wrong verb returns **404** on postman-echo vs **405** on httpbin. This is immaterial — the verb tests assert the output contains `200`, and `404` is just as much "not 200" as `405`, so the per-verb guarantee is preserved.

### Changes
- Default `ECHO_BASE` → `https://postman-echo.com`
- Rename constants `HTTPBIN_BASE`/`HTTPBIN_HOST` → `ECHO_BASE`/`ECHO_HOST`; override env var `ECHO_BASE_URL` (legacy `HTTPBIN_BASE_URL` still honored as a fallback)
- Update the spec doc, preserving the #383 history and adding the #407 record

No assertion logic changed; no `@stable` tag changed.

## Validation

Run against a live **Langflow 1.11.0** instance:

- ✅ All 8 endpoint-dependent tests pass: GET, POST, PUT, PATCH, DELETE, non-2xx (404), query params, cURL-execute
- ✅ typecheck clean; lint clean (0 errors)
- ✅ force-fail: breaking the echoed-host assertion failed exactly on that line; output showed `"source": "https://postman-echo.com/get"`, `"status_code": 200`; reverted and re-passed
- ✅ zero `🚨 Backend Error` occurrences

## Out of scope

A separate canvas-bootstrap flake (`sidebar-search-input` detaching during the Templates-modal dismiss) was observed **only on the local vite dev server**; it did not flake in the CI weekly run (#407 ran api-request 15/15 clean except the httpbin assertion). Hardening `addApiRequestComponent` is tracked separately to keep this PR focused on the endpoint migration.