### PR TITLE
test(#252): add API access modal regression spec

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -110,7 +110,7 @@
 #### 1.6 Integration Code Generation
 - [x] Generate curl for API execution → `flow-functionality/curlApiGeneration.spec.ts`
 - [x] Generate Python code for integration → `flow-functionality/pythonApiGeneration.spec.ts`
-- [-] API access modal
+- [x] API access modal → `flow-functionality/api-access-modal-regression.spec.ts`
 
 ---
 

--- a/docs/flow-functionality/api-access-modal-regression.md
+++ b/docs/flow-functionality/api-access-modal-regression.md
@@ -1,0 +1,124 @@
+# Flow Functionality — API Access Modal
+
+**Last validated:** Langflow 1.11.x (nightly `1.11.0.dev12`)
+
+---
+
+## What this test validates *(required)*
+
+Validates the **API access modal** itself — the surface that exposes a flow's integration snippets — rather than the contents of any single generated snippet (those are covered by `curlApiGeneration.spec.ts` and `pythonApiGeneration.spec.ts`). Four `test()` cases, all opening the **Basic Prompting** template and the modal from the Publish dropdown:
+
+1. **Opens and renders** — the modal opens from `publish-button` → `api-access-item`, shows the `API access` title, the Input Schema (`tweaks-button`) entry point, all three language tabs (`api_tab_python`, `api_tab_javascript`, `api_tab_curl`), and a copyable snippet (`btn-copy-code`).
+2. **Tab switching** — clicking each language tab swaps the rendered snippet (Python `import requests` vs. cURL `curl --request POST`), and the two snippets differ — proving `setSelectedTab` re-renders the code block.
+3. **Flow ID coherence** — the generated cURL command targets `/api/v1/run/{currentFlowId}` where `currentFlowId` is the ID parsed from the editor URL. This is stricter than the sibling specs, which only match any `[0-9a-f-]{36}` UUID; it proves the modal reflects *the open flow*, not a stale or hard-coded ID.
+4. **Close behavior** — the modal dismisses cleanly via `Escape` and via the `Close` (X) button.
+
+If this breaks, users lose the documented entry point to a flow's API — the modal could fail to open, render the wrong flow's endpoint, or trap the user (no clean close).
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@api` `@workspace`
+
+---
+
+## Step by step *(required)*
+
+A shared `openApiAccessModal(page)` helper performs the common opening sequence and returns the `flowId`:
+
+1. Bootstrap the app (`awaitBootstrapTest`)
+2. Open the Templates page (`side_nav_options_all-templates`)
+3. Open the `Basic Prompting` template
+4. Click `publish-button`, then `api-access-item`; wait for `api_tab_curl` to be visible
+5. Capture `flowId` from `page.url()` (matches `/flow/{flowId}`) **only now** — `awaitBootstrapTest` already leaves the page on a flow, and opening the template creates and navigates to a *new* flow; reading the URL before the modal renders races that navigation and can capture the stale bootstrap flow
+
+A second helper `selectUnixCurlTab(page)` clicks `api_tab_curl` then the `macOS/Linux` platform sub-tab, so the generated cURL is deterministic (the default platform follows `getOS()`, which can resolve to Windows/PowerShell on some runners).
+
+Cleanup is handled by a shared **snapshot/diff `afterEach`** (same pattern as the validated sibling `export-import-flow.spec.ts`), not by per-test `finally` blocks: `beforeEach` records the flow IDs that exist before the test, `afterEach` deletes any that appeared after it. A `null` sentinel means "snapshot failed — skip cleanup" so a list-endpoint hiccup never wipes the workspace; it also runs for tests that fail mid-way, so a flow created before an assertion failure is still swept.
+
+### Test 1 — `API access modal opens from the Publish dropdown exposing the Python, JavaScript and cURL tabs`
+
+6. Assert `API access` title (scoped to the open `dialog`, since the Publish dropdown's force-mounted menu item carries the same exact text) and `tweaks-button` are visible
+7. Assert `api_tab_python`, `api_tab_javascript`, `api_tab_curl` are visible
+8. Assert `btn-copy-code` is visible
+
+### Test 2 — `API access modal switches the displayed snippet when changing language tabs`
+
+6. Click `api_tab_python`, copy via `btn-copy-code`, read clipboard — assert it starts with `import requests`
+7. `selectUnixCurlTab` (cURL tab + macOS/Linux), copy, read clipboard — assert it starts with `curl --request POST`
+8. Assert the cURL snippet differs from the Python snippet
+
+### Test 3 — `API access modal embeds the current flow ID in the generated run endpoint URL`
+
+6. `selectUnixCurlTab` (cURL tab + macOS/Linux), copy, read clipboard
+7. Assert the snippet starts with `curl --request POST` (proves we read the cURL snippet, not a stale Python one — both embed the run URL, so without this guard the tab selection would be cosmetic)
+8. Assert the snippet contains `/api/v1/run/{flowId}` (the captured flow ID)
+
+### Test 4 — `API access modal closes cleanly via Escape and via the close button`
+
+6. Assert `api_tab_curl` is visible, press `Escape`, assert `api_tab_curl` is hidden
+7. Reopen the modal (`publish-button` → `api-access-item`), assert `api_tab_curl` visible
+8. Click the `Close` (X) button, assert `api_tab_curl` is hidden
+
+---
+
+## Validation criterion *(required)*
+
+- The modal is detected by the **language tabs** (`api_tab_*`) and the `API access` title — i18n-tolerant on the testids, exact-text on the title
+- Tab switching is proven by reading the clipboard after each tab's Copy click (the visible code is a tokenized `SyntaxHighlighter` tree, not a plain string) and asserting the snippets differ AND each matches its language signature
+- The endpoint URL assertion uses the **specific** captured `flowId` (`/api/v1/run/{flowId}`), not a generic UUID match — coherence with the open flow is the distinct concern of this spec
+- Both close paths (`Escape`, `Close` button) drive `api_tab_curl` to hidden — a partial close (overlay lingering) would fail
+- A shared snapshot/diff `afterEach` deletes any flow created during the test so repeated runs do not accumulate workspace artifacts; the `null` sentinel keeps a failed snapshot from wiping the workspace
+
+---
+
+## External dependencies *(required)*
+
+- `tests/helpers/other/await-bootstrap-test.ts` — app bootstrap
+- `tests/helpers/auth/get-auth-token.ts` — Bearer token for the cleanup `DELETE`
+- `src/frontend/src/components/core/flowToolbarComponent/components/deploy-dropdown.tsx` — registers `publish-button` and `api-access-item`; mounts `ApiModal`
+- `src/frontend/src/modals/apiModal/codeTabs/code-tabs.tsx` — renders the `api_tab_${title}` language tabs and `btn-copy-code`; owns the `setSelectedTab` switch
+- `src/frontend/src/modals/apiModal/index.tsx` — modal shell; renders the `API access` title (`modal.api.title`) and the `tweaks-button`
+- `src/frontend/src/components/ui/dialog.tsx` — the `Close` (X) button with the `Close` accessible name
+- `src/frontend/src/modals/apiModal/utils/get-curl-code.tsx` / `get-python-api-code.tsx` — build the snippets whose `/api/v1/run/{flowId}` URL the flow-ID test asserts
+- `src/backend/base/langflow/api/v1/endpoints.py` — owns `/api/v1/run/{flow_id}`; the URL shape encoded in the snippet must keep matching this route
+
+---
+
+## What this test does not cover *(optional)*
+
+- The full structural shape of each snippet (headers, payload, session_id) — owned by `curlApiGeneration.spec.ts` and `pythonApiGeneration.spec.ts`
+- The macOS/Linux ↔ Windows cURL platform sub-tabs (covered by `curlApiGeneration.spec.ts`)
+- The Input Schema (tweaks) modal behind `tweaks-button` — only its presence is asserted, not its tweak-editing flow
+- Outside-click dismissal — `Escape` and the `Close` button are the two close paths exercised
+- Actually executing the generated snippet against the backend (covered by API tests under `api/flows/`)
+- The JavaScript snippet's structural shape — only that selecting its tab produces a snippet distinct from Python/cURL
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`
+- `LANGFLOW_SUPERUSER` / `LANGFLOW_SUPERUSER_PASSWORD` configured for the cleanup token
+- No LLM credentials required — only the snippet generator and modal are exercised
+- `clipboard-read` permission is granted globally in `playwright.config.ts`
+
+---
+
+## When to review this test *(optional)*
+
+- A language tab is added/removed or `api_tab_${title}` testid scheme changes
+- The `API access` title text (`modal.api.title`) changes — the exact-text assertion must track it
+- `btn-copy-code` is renamed or the simple (no-files) snippet gains an upload-steps layout (`btn-copy-step1`)
+- The `/api/v1/run/{flow_id}` route is renamed or namespaced — the flow-ID assertion must update
+- The modal's close affordances change (e.g., the X button loses its `Close` accessible name)
+- The default flow that opens from the Basic Prompting template stops embedding the flow ID in the run URL (e.g., it starts using `endpoint_name` instead)
+
+---
+
+## Notes *(optional)*
+
+- The modal exposes **Python, JavaScript and cURL** tabs only. The issue's mention of separate "API endpoint URL" and "Bearer key" tabs does not match the current modal — those concepts live *inside* the generated snippets (the run URL and the `x-api-key` header), so the spec asserts them there rather than as standalone tabs.
+- The endpoint URL uses `endpoint_name || flowId`. The Basic Prompting template carries no `endpoint_name`, so the flow ID appears verbatim — which is what Test 3 asserts. If a future template default sets an `endpoint_name`, that test must change.
+- The file runs in **serial mode** (`test.describe.configure({ mode: "serial" })`). All four tests open the same Basic Prompting template and each creates a fresh flow; running them in parallel made the backend receive near-identical concurrent `POST /api/v1/flows/` requests, which intermittently returned `500 — An internal error occurred while creating the flow`. Serializing the file removes that self-collision so the run stays free of backend errors.

--- a/tests/tests-automations/regression/flow-functionality/api-access-modal-regression.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/api-access-modal-regression.spec.ts
@@ -1,0 +1,221 @@
+import { expect, test } from "../../../fixtures/fixtures";
+import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+
+// Run this file's tests serially. All four open the same "Basic Prompting" template, each creating a
+// fresh flow; running them in parallel within one worker pool makes the backend receive near-identical
+// concurrent flow-creation requests, which intermittently 500s ("An internal error occurred while
+// creating the flow"). Serializing removes that self-collision and keeps the run free of backend errors.
+test.describe.configure({ mode: "serial" });
+
+const LIST_PARAMS = { get_all: "true", remove_example_flows: "true" };
+
+// Snapshot/diff cleanup — same pattern as the validated sibling export-import-flow.spec.ts in this
+// directory: record the flow IDs that exist before each test, then delete any that appeared after it.
+// `null` is a sentinel meaning "snapshot failed — skip cleanup this run" so a list-endpoint hiccup
+// never deletes the whole workspace. This also runs for tests that fail mid-way, so a flow created
+// before an assertion failure is still swept.
+let preTestFlowIds: Set<string> | null = null;
+
+test.beforeEach(async ({ request }) => {
+  preTestFlowIds = null;
+  try {
+    const headers = { Authorization: await getAuthToken(request) };
+    const listRes = await request.get("/api/v1/flows/", {
+      headers,
+      params: LIST_PARAMS,
+    });
+    if (listRes.ok()) {
+      const body = await listRes.json();
+      const flows: Array<{ id: string }> = Array.isArray(body)
+        ? body
+        : (body?.flows ?? []);
+      preTestFlowIds = new Set(flows.map((f) => f.id));
+    }
+  } catch {
+    // Leave sentinel as null so afterEach skips cleanup.
+  }
+});
+
+test.afterEach(async ({ request }) => {
+  if (preTestFlowIds === null) return;
+  const snapshot = preTestFlowIds;
+  try {
+    const headers = { Authorization: await getAuthToken(request) };
+    const listRes = await request.get("/api/v1/flows/", {
+      headers,
+      params: LIST_PARAMS,
+    });
+    if (listRes.ok()) {
+      const body = await listRes.json();
+      const flows: Array<{ id: string }> = Array.isArray(body)
+        ? body
+        : (body?.flows ?? []);
+      for (const f of flows) {
+        if (!snapshot.has(f.id)) {
+          await request.delete(`/api/v1/flows/${f.id}`, { headers });
+        }
+      }
+    }
+  } catch {
+    // Cleanup is best-effort.
+  }
+});
+
+// Opens the Basic Prompting template (matching curlApiGeneration / pythonApiGeneration), then opens
+// the API access modal from the Publish dropdown. Returns the flow ID parsed from the editor URL.
+//
+// The flow ID is read only AFTER the modal is open: awaitBootstrapTest already leaves the page on a
+// flow, and clicking the Basic Prompting heading then creates a *new* flow and navigates to it.
+// Reading the URL right after the heading click races that navigation (the URL may still show the
+// bootstrap flow), so we wait until the modal is rendered — by then the editor has fully settled on
+// the template's flow and page.url() reflects it.
+async function openApiAccessModal(page: import("@playwright/test").Page) {
+  await awaitBootstrapTest(page);
+  await page.getByTestId("side_nav_options_all-templates").click();
+  await page.getByRole("heading", { name: "Basic Prompting" }).click();
+
+  await page.getByTestId("publish-button").click();
+  await page.getByTestId("api-access-item").click();
+  await expect(page.getByTestId("api_tab_curl")).toBeVisible({
+    timeout: 10000,
+  });
+
+  // Editor URL pattern is /flow/{flowId}; read it now that the modal (and thus the flow) has settled
+  expect(page.url()).toMatch(/\/flow\/[0-9a-f-]+/);
+  return page.url().match(/\/flow\/([0-9a-f-]+)/)![1];
+}
+
+// Forces the cURL tab onto the macOS/Linux platform variant. getOS() seeds the default platform from
+// navigator.platform, which differs between local Chromium and CI runners (Windows/PowerShell would
+// otherwise be selected), so the generated snippet is non-deterministic without this — the same guard
+// curlApiGeneration.spec.ts uses.
+async function selectUnixCurlTab(page: import("@playwright/test").Page) {
+  await page.getByTestId("api_tab_curl").click();
+  await page.getByRole("tab", { name: "macOS/Linux" }).click();
+}
+
+test(
+  "API access modal opens from the Publish dropdown exposing the Python, JavaScript and cURL tabs",
+  { tag: ["@stable", "@regression", "@api", "@workspace"] },
+  async ({ page }) => {
+    await test.step("Open the API access modal from the Publish dropdown", async () => {
+      await openApiAccessModal(page);
+    });
+
+    await test.step("Modal surface is rendered", async () => {
+      // Scope to the dialog: the Publish dropdown's "API access" menu item is force-mounted and could
+      // otherwise match the same exact text, so we anchor the title assertion inside the open modal.
+      await expect(
+        page.getByRole("dialog").getByText("API access", { exact: true }),
+      ).toBeVisible({ timeout: 10000 });
+      // The Input Schema (tweaks) entry point is part of the modal header
+      await expect(page.getByTestId("tweaks-button")).toBeVisible();
+    });
+
+    await test.step("All three language tabs are present", async () => {
+      await expect(page.getByTestId("api_tab_python")).toBeVisible();
+      await expect(page.getByTestId("api_tab_javascript")).toBeVisible();
+      await expect(page.getByTestId("api_tab_curl")).toBeVisible();
+    });
+
+    await test.step("A copyable code snippet is shown", async () => {
+      await expect(page.getByTestId("btn-copy-code")).toBeVisible();
+    });
+  },
+);
+
+test(
+  "API access modal switches the displayed snippet when changing language tabs",
+  { tag: ["@stable", "@regression", "@api", "@workspace"] },
+  async ({ page }) => {
+    await test.step("Open the API access modal", async () => {
+      await openApiAccessModal(page);
+    });
+
+    // Reading the clipboard after each tab's Copy click is the reliable way to capture what the
+    // modal renders — the visible code is a tokenized SyntaxHighlighter tree, not a plain string.
+    const copyVisibleSnippet = async () => {
+      await page.getByTestId("btn-copy-code").click();
+      return page.evaluate(() => navigator.clipboard.readText());
+    };
+
+    let pythonSnippet = "";
+    let curlSnippet = "";
+
+    await test.step("Python tab yields a requests snippet", async () => {
+      await page.getByTestId("api_tab_python").click();
+      pythonSnippet = await copyVisibleSnippet();
+      expect(pythonSnippet).toMatch(/^import requests/);
+    });
+
+    await test.step("cURL tab (macOS/Linux) yields a curl command", async () => {
+      await selectUnixCurlTab(page);
+      curlSnippet = await copyVisibleSnippet();
+      expect(curlSnippet).toMatch(/^curl --request POST/);
+    });
+
+    await test.step("Switching tabs changes the rendered snippet", async () => {
+      expect(curlSnippet).not.toBe(pythonSnippet);
+    });
+  },
+);
+
+test(
+  "API access modal embeds the current flow ID in the generated run endpoint URL",
+  { tag: ["@stable", "@regression", "@api", "@workspace"] },
+  async ({ page }) => {
+    let flowId: string;
+
+    await test.step("Open the API access modal", async () => {
+      flowId = await openApiAccessModal(page);
+    });
+
+    await test.step("Generated cURL command targets /api/v1/run/{currentFlowId}", async () => {
+      await selectUnixCurlTab(page);
+      await page.getByTestId("btn-copy-code").click();
+      const snippet = await page.evaluate(() =>
+        navigator.clipboard.readText(),
+      );
+      // Assert we are reading the cURL snippet (not a stale Python one): both snippets embed the run
+      // URL, so without this guard the tab selection above would be cosmetic and the test would pass
+      // on any tab.
+      expect(snippet).toMatch(/^curl --request POST/);
+      // The endpoint must reference THIS flow, not just any UUID — that coherence with the open
+      // flow is what the sibling curl/python specs (which only match `[0-9a-f-]{36}`) do not assert.
+      expect(snippet).toContain(`/api/v1/run/${flowId!}`);
+    });
+  },
+);
+
+test(
+  "API access modal closes cleanly via Escape and via the close button",
+  { tag: ["@stable", "@regression", "@api", "@workspace"] },
+  async ({ page }) => {
+    await test.step("Open the API access modal", async () => {
+      await openApiAccessModal(page);
+    });
+
+    await test.step("Escape dismisses the modal", async () => {
+      await expect(page.getByTestId("api_tab_curl")).toBeVisible({
+        timeout: 10000,
+      });
+      await page.keyboard.press("Escape");
+      await expect(page.getByTestId("api_tab_curl")).toBeHidden({
+        timeout: 10000,
+      });
+    });
+
+    await test.step("Reopen and dismiss via the close (X) button", async () => {
+      await page.getByTestId("publish-button").click();
+      await page.getByTestId("api-access-item").click();
+      await expect(page.getByTestId("api_tab_curl")).toBeVisible({
+        timeout: 10000,
+      });
+      await page.getByRole("button", { name: "Close" }).click();
+      await expect(page.getByTestId("api_tab_curl")).toBeHidden({
+        timeout: 10000,
+      });
+    });
+  },
+);


### PR DESCRIPTION
Closes #252

## What

Adds `flow-functionality/api-access-modal-regression.spec.ts` — a regression spec for the **API access modal** opened from the Publish dropdown. It validates the modal *surface and coherence*, complementing the sibling specs that validate snippet *structure* (`curlApiGeneration` / `pythonApiGeneration`).

Four `test()` cases (all open the Basic Prompting template):

1. **Opens & renders** — title, Input Schema entry point, all three language tabs (Python / JavaScript / cURL), and a copyable snippet.
2. **Tab switching** — Python (`import requests`) vs. cURL (`curl --request POST`) snippets differ.
3. **Flow ID coherence** — the generated cURL targets `/api/v1/run/{currentFlowId}`, stricter than the siblings' generic UUID match (asserts the curl signature first so the tab selection is meaningful).
4. **Close behavior** — dismisses cleanly via Escape and the X button.

## Notes

- Runs **serially** (`test.describe.configure({ mode: "serial" })`): the four tests open the same template and creating those flows concurrently intermittently 500s on the backend ("An internal error occurred while creating the flow"). Serializing removes that self-collision.
- Cleanup uses the **snapshot/diff `afterEach`** pattern from the validated `export-import-flow.spec.ts` (same directory) — deletes only flows created during the test, with a `null` sentinel so a list-endpoint hiccup never wipes the workspace.
- The title assertion is scoped to the open `dialog` (the Publish dropdown's force-mounted menu item carries the same text).
- All tests tagged `@stable @regression @api @workspace`. Spec doc added under `docs/flow-functionality/`. QA-CHECKLIST item marked `[x]`.

## Validation

- `npm run typecheck` ✅ · `npm run lint` ✅ (no warnings on the new file)
- Spec run: **4 passed**, zero `🚨 Backend Error`, zero 500s
- Cleanup verified: clean slate → run → zero leftover flows
- Validated against Langflow nightly `1.11.0.dev12`