### PR TITLE
test(#397): standardize MCP specs auth on shared getAuthToken

### DIFF
--- a/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
@@ -13,6 +13,7 @@ import {
 import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
 import { cleanAllFlows } from "../../../../helpers/flows/clean-all-flows";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 
 if (!process.env.CI) {
   dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
@@ -140,14 +141,9 @@ for (const { label, options, skipReason } of targets) {
   test.describe(`MCP Client – Agent using MCPTools [${label}]`, () => {
     test.afterEach(async ({ page }) => {
       try {
-        const token = await page.request
-          .post("/api/v1/login", {
-            form: { username: "langflow", password: "langflow" },
-          })
-          .then((r) => r.json())
-          .then((d) => d.access_token as string);
+        const authHeader = await getAuthToken(page.request);
         await page.request.delete(`/api/v2/mcp/servers/${MCP_SERVER_NAME}`, {
-          headers: { Authorization: `Bearer ${token}` },
+          headers: { Authorization: authHeader },
         });
       } catch {
         // best-effort
@@ -178,14 +174,9 @@ for (const { label, options, skipReason } of targets) {
         });
 
         await test.step("Register everything MCP server and wait for tools", async () => {
-          const token = await page.request
-            .post("/api/v1/login", {
-              form: { username: "langflow", password: "langflow" },
-            })
-            .then((r) => r.json())
-            .then((d) => d.access_token as string);
+          const authHeader = await getAuthToken(page.request);
           await page.request.delete(`/api/v2/mcp/servers/${MCP_SERVER_NAME}`, {
-            headers: { Authorization: `Bearer ${token}` },
+            headers: { Authorization: authHeader },
           });
 
           await page.getByTestId("sidebar-nav-mcp").click();

--- a/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
@@ -3,6 +3,7 @@ import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { openAddMcpServerModal } from "../../../../helpers/mcp/open-add-mcp-server-modal";
 import { zoomOut } from "../../../../helpers/ui/zoom-out";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 
 test(
   "user must be able to change mode of MCP tools without any issues",
@@ -1032,12 +1033,9 @@ test(
     expect(await toolOptions.count()).toBeGreaterThan(0);
 
     // Cleanup
-    const loginResp = await page.request.post("/api/v1/login", {
-      form: { username: "langflow", password: "langflow" },
-    });
-    const { access_token: token } = await loginResp.json();
+    const authHeader = await getAuthToken(page.request);
     await page.request.delete(`/api/v2/mcp/servers/${testName}`, {
-      headers: { Authorization: `Bearer ${token}` },
+      headers: { Authorization: authHeader },
     });
   },
 );


### PR DESCRIPTION
Closes #397

## What

Routes the MCP-server pre-clean / cleanup `DELETE` calls in the sibling MCP specs through `getAuthToken(page.request)` (`GET /api/v1/auto_login`) instead of a hardcoded `POST /api/v1/login` (`langflow`/`langflow`), matching the fix already applied in `mcp-client-regression.spec.ts` (#384).

## Why

Under the suite's standard `LANGFLOW_AUTO_LOGIN=true` mode the hardcoded login returns no token, so the `DELETE` ran unauthenticated and the pre-clean never removed a leftover server (HTTP 500 on a persistent backend, see #396).

## Files

- `mcp/server/mcp-server.spec.ts` (cleanup)
- `mcp/client/mcp-client-agent.spec.ts` (afterEach + registration step)

Net simplification: 8 insertions / 19 deletions.