### PR TITLE
fix(mcp): standardize spec auth on shared getAuthToken (auto_login) (#397)

### DIFF
--- a/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
@@ -13,6 +13,7 @@ import {
 import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
 import { cleanAllFlows } from "../../../../helpers/flows/clean-all-flows";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 
 if (!process.env.CI) {
   dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
@@ -140,14 +141,13 @@ for (const { label, options, skipReason } of targets) {
   test.describe(`MCP Client – Agent using MCPTools [${label}]`, () => {
     test.afterEach(async ({ page }) => {
       try {
-        const token = await page.request
-          .post("/api/v1/login", {
-            form: { username: "langflow", password: "langflow" },
-          })
-          .then((r) => r.json())
-          .then((d) => d.access_token as string);
+        // Authenticate via the shared getAuthToken helper (GET
+        // /api/v1/auto_login). Under LANGFLOW_AUTO_LOGIN=true a hardcoded POST
+        // /api/v1/login can yield no token, leaving this pre-clean DELETE
+        // unauthenticated so a leftover server survives (#397, #396).
+        const authHeader = await getAuthToken(page.request);
         await page.request.delete(`/api/v2/mcp/servers/${MCP_SERVER_NAME}`, {
-          headers: { Authorization: `Bearer ${token}` },
+          headers: { Authorization: authHeader },
         });
       } catch {
         // best-effort
@@ -178,14 +178,12 @@ for (const { label, options, skipReason } of targets) {
         });
 
         await test.step("Register everything MCP server and wait for tools", async () => {
-          const token = await page.request
-            .post("/api/v1/login", {
-              form: { username: "langflow", password: "langflow" },
-            })
-            .then((r) => r.json())
-            .then((d) => d.access_token as string);
+          // Shared getAuthToken helper (GET /api/v1/auto_login) — see the
+          // afterEach note: a hardcoded POST /api/v1/login can yield no token
+          // under LANGFLOW_AUTO_LOGIN=true (#397, #396).
+          const authHeader = await getAuthToken(page.request);
           await page.request.delete(`/api/v2/mcp/servers/${MCP_SERVER_NAME}`, {
-            headers: { Authorization: `Bearer ${token}` },
+            headers: { Authorization: authHeader },
           });
 
           await page.getByTestId("sidebar-nav-mcp").click();

--- a/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
@@ -3,6 +3,7 @@ import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { openAddMcpServerModal } from "../../../../helpers/mcp/open-add-mcp-server-modal";
 import { zoomOut } from "../../../../helpers/ui/zoom-out";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 
 test(
   "user must be able to change mode of MCP tools without any issues",
@@ -1031,13 +1032,13 @@ test(
     await expect(toolOptions.first()).toBeVisible({ timeout: 15000 });
     expect(await toolOptions.count()).toBeGreaterThan(0);
 
-    // Cleanup
-    const loginResp = await page.request.post("/api/v1/login", {
-      form: { username: "langflow", password: "langflow" },
-    });
-    const { access_token: token } = await loginResp.json();
+    // Cleanup — authenticate via the shared getAuthToken helper (GET
+    // /api/v1/auto_login). Under the suite's LANGFLOW_AUTO_LOGIN=true mode a
+    // hardcoded POST /api/v1/login can yield no token, leaving this DELETE
+    // unauthenticated so a leftover server is never removed (#397, #396).
+    const authHeader = await getAuthToken(page.request);
     await page.request.delete(`/api/v2/mcp/servers/${testName}`, {
-      headers: { Authorization: `Bearer ${token}` },
+      headers: { Authorization: authHeader },
     });
   },
 );


### PR DESCRIPTION
## Context

Closes #397. Follow-up from #384 (Group 1 hardening).

`mcp-client-regression.spec.ts` was already fixed to route its MCP-server pre-clean/verification calls through the shared `getAuthToken(page.request)` helper (`GET /api/v1/auto_login`). The sibling MCP specs still used the old hardcoded `POST /api/v1/login` (`langflow/langflow`), which under the suite's standard `LANGFLOW_AUTO_LOGIN=true` mode can silently return no token — leaving the follow-up `DELETE` unauthenticated so the pre-clean never removes a leftover server. A stale server then makes the next registration hit a pre-existing name, and the backend returns HTTP 500 (`"Server already exists."` — #396).

It does **not** break CI (fresh ephemeral backend each run) but bites on a **persistent** backend (local dev).

## What this PR does

Routes all three sites through `getAuthToken(page.request)`:

- [x] `mcp-server.spec.ts` — server-everything cleanup
- [x] `mcp-client-agent.spec.ts` — `afterEach` pre-clean
- [x] `mcp-client-agent.spec.ts` — in-test register step

No assertion logic or tags changed.

## Validation

- ✅ Empirically verified `GET /api/v1/auto_login` returns a valid `access_token` under `LANGFLOW_AUTO_LOGIN=true` (the mechanism the helper relies on)
- ✅ Pattern parity with `mcp-client-regression.spec.ts`, already exercised in CI (#384)
- ✅ `tsc --noEmit` clean; ESLint clean (no new warnings — the pre-existing warnings in these large files are unchanged)

### Note on `@stable` confirmation
The affected `@stable` test (`mcp-client-agent.spec.ts` → *agent calls echo MCP tool*) runs an LLM agent and only executes in `weekly-stable.yml` (which collects models + has provider secrets); `pr-validation.yml` runs only typecheck + ESLint, and `manual.yml` does not pass provider keys. A `manual.yml` dispatch was triggered against this branch to exercise the edited `mcp-server.spec.ts` server-everything cleanup in a fresh Docker backend; full `@stable` agent confirmation lands in the next weekly run.