### PR TITLE
test(#249): validate and tag @stable api-run-with-tweaks.spec.ts

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -93,7 +93,7 @@
 
 #### 1.3 Flow Execution via API
 - [x] POST `/api/v1/run/{flow_id}` with `input_value` → returns response → `api/flows/api-run-flow.spec.ts`
-- [-] POST with `tweaks` → parameters override flow configuration
+- [x] POST with `tweaks` → parameters override flow configuration → `api/flows/api-run-with-tweaks.spec.ts`
 - [x] POST with custom `session_id` → `api/flows/api-run-flow.spec.ts`
 - [x] POST with `input_type: "chat"` and `output_type: "chat"` → `api/flows/api-run-flow.spec.ts`
 - [x] POST with invalid API key → returns 401/403 → `api-invalid-key.spec.ts`

--- a/docs/api/flows/api-run-flow.md
+++ b/docs/api/flows/api-run-flow.md
@@ -23,7 +23,7 @@ The spec runs **3 independent tests** via Playwright's `request` fixture, sharin
 **Setup (`beforeAll`)**
 1. Obtain a valid Bearer token via `getAuthToken(request)`.
 2. `POST /api/v1/api_key/` with the Bearer token to mint a temporary API key (asserts `200` and that the response body contains `api_key` and `id` — gives an explicit failure if the API key response shape changes).
-3. `POST /api/v1/flows/` with the new `x-api-key` to create a minimal empty flow (`nodes: []`, `edges: []`), asserts `201`, and stores `flowId`. The empty-flow + structural-assertion convention is shared with `api-run-with-tweaks.spec.ts`; semantic assertions (non-empty `outputs`, message persistence) are tracked in issue #263.
+3. `POST /api/v1/flows/` with the new `x-api-key` to create a minimal empty flow (`nodes: []`, `edges: []`), asserts `201`, and stores `flowId`. These tests assert the structural contract only; semantic assertions (non-empty `outputs`, message persistence) are tracked in issue #263. (For an example of semantic output assertions on a runnable flow, see `api-run-with-tweaks.spec.ts`.)
 
 **Teardown (`afterAll`)**
 1. `DELETE /api/v1/flows/{flowId}` with the `x-api-key`.

--- a/docs/api/flows/api-run-with-tweaks.md
+++ b/docs/api/flows/api-run-with-tweaks.md
@@ -39,7 +39,7 @@ Both deletions are wrapped in `.catch(() => {})` so teardown never masks a test 
 
 **Test 1 — `tweaks` override a component field at runtime** *(`@stable @release @api @regression`)*
 1. Build a unique value `TWEAKED-<timestamp>` (so a passing assertion cannot accidentally match the default).
-2. `POST /api/v1/run/{flowId}` with `x-api-key` and payload `{ input_type: "chat", output_type: "chat", tweaks: { "Chat Input": { input_value: "<unique>" } } }`. Top-level `input_value` is intentionally omitted — the backend gives top-level input precedence over a tweak on the same field, so omitting it lets the tweak take effect.
+2. `POST /api/v1/run/{flowId}` with `x-api-key` and payload `{ input_type: "chat", output_type: "chat", tweaks: { "Chat Input": { input_value: "<unique>" } } }`. Top-level `input_value` is intentionally omitted — the backend **rejects with `400`** any request that passes both a top-level `input_value` and a Chat Input tweak on the same `input_value` field, so the value is driven purely through the tweak.
 3. Assert status `200` and `body.outputs` exists.
 4. Assert the echoed output text equals the tweaked value — the override is proven.
 
@@ -67,7 +67,7 @@ Both deletions are wrapped in `.catch(() => {})` so teardown never masks a test 
 ## What this test does not cover *(optional)*
 - Nested-field tweaks (`NestedDict`/`dict` template fields) and array/list-field tweaks — these need a component with such fields and are tracked as a follow-up issue.
 - Tweaking by node **id** (this spec tweaks by display name; the backend accepts both).
-- Top-level `input_value` precedence over a same-field tweak (asserted indirectly by omitting it, not tested head-to-head).
+- The `400` rejection when a top-level `input_value` and a same-field Chat Input tweak are sent together (the spec avoids this combination rather than asserting it; a dedicated negative test could cover it).
 - Code-field injection protection (the backend blocks tweaks on `code`-type fields).
 - Streaming responses, batch runs, multi-turn `session_id` threading → other specs / issues.
 

--- a/docs/api/flows/api-run-with-tweaks.md
+++ b/docs/api/flows/api-run-with-tweaks.md
@@ -1,0 +1,90 @@
+# API Run with Tweaks
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+Validates that the `tweaks` parameter of `POST /api/v1/run/{flow_id}` actually **overrides flow component configuration at runtime** — the contract external clients rely on to reconfigure a flow per request without editing and saving it first.
+
+The spec runs against a real `Chat Input -> Chat Output` passthrough flow (imported from a fixture, no LLM or external provider key required). Because `Chat Output` echoes whatever `Chat Input` emits, a tweak on `Chat Input.input_value` changes the response text deterministically — so the override is *observed*, not merely accepted. It also pins the two boundary behaviors confirmed against the Langflow backend: an empty `tweaks` object is a no-op, and a tweak targeting a component absent from the flow is silently ignored (still `200`).
+
+If these tests fail, the runtime-override contract has regressed: integrations that parameterize a shared flow via `tweaks` (per-tenant prompts, per-request model settings, dynamic inputs) would either stop taking effect or start erroring.
+
+---
+
+## Tags *(required)*
+`@stable` `@release` `@api` `@regression`
+
+`@release` is applied only to the override happy-path test (Test 1). The two boundary tests (no-op, non-existent component) are `@stable @api @regression` — they are not deploy-gating happy paths.
+
+---
+
+## Step by step *(required)*
+
+The spec runs **3 independent tests** via Playwright's `request` fixture, sharing a single flow created in `beforeAll`.
+
+**Setup (`beforeAll`)**
+1. Obtain a valid Bearer token via `getAuthToken(request)`.
+2. `POST /api/v1/api_key/` with the Bearer token to mint a temporary API key (asserts `200`); the run endpoint requires `x-api-key`, not Bearer.
+3. Read `tests/assets/flows/chat-io-ok-trace-fixture.json` and `POST /api/v1/flows/` with its `data` to create a runnable `Chat Input -> Chat Output` flow (asserts `201`), storing `flowId`. The fixture's `Chat Input` has a stored `input_value` default of `"Hello"`.
+
+**Teardown (`afterAll`)**
+1. `DELETE /api/v1/flows/{flowId}` with the Bearer token.
+2. `DELETE /api/v1/api_key/{apiKeyId}` with the Bearer token.
+
+Both deletions are wrapped in `.catch(() => {})` so teardown never masks a test failure.
+
+---
+
+**Test 1 — `tweaks` override a component field at runtime** *(`@stable @release @api @regression`)*
+1. Build a unique value `TWEAKED-<timestamp>` (so a passing assertion cannot accidentally match the default).
+2. `POST /api/v1/run/{flowId}` with `x-api-key` and payload `{ input_type: "chat", output_type: "chat", tweaks: { "Chat Input": { input_value: "<unique>" } } }`. Top-level `input_value` is intentionally omitted — the backend gives top-level input precedence over a tweak on the same field, so omitting it lets the tweak take effect.
+3. Assert status `200` and `body.outputs` exists.
+4. Assert the echoed output text equals the tweaked value — the override is proven.
+
+**Test 2 — empty `tweaks` is a no-op** *(`@stable @api @regression`)*
+1. Same request as Test 1 minus the tweak: `tweaks: {}`, no top-level `input_value`.
+2. Assert status `200` and `body.outputs` exists.
+3. Assert the output text equals the flow default `"Hello"`. This baseline is what makes Test 1's contrast meaningful — identical requests differing only by the tweak yield different outputs.
+
+**Test 3 — tweaks for a non-existent component are silently ignored** *(`@stable @api @regression`)*
+1. `POST /api/v1/run/{flowId}` with `tweaks: { "NonExistentComponent-999": { input_value: "..." } }`.
+2. Assert status `200` (no error) and `body.outputs` exists.
+3. Assert the output text is unchanged from the flow default `"Hello"` — confirming the bogus tweak had no effect.
+
+---
+
+## Validation criterion *(required)*
+- Setup creates one flow and one API key; teardown removes both. No orphans on the backend after the suite.
+- Test 1: output text equals the unique tweaked value — the tweak overrode the stored default.
+- Test 2: output text equals `"Hello"` — empty tweaks change nothing.
+- Test 3: status is `200` and output text equals `"Hello"` — an unmatched tweak is ignored, not errored.
+- The contrast between Test 1 (`TWEAKED-…`) and Tests 2/3 (`Hello`) is the evidence that tweaks override configuration rather than being merely accepted.
+
+---
+
+## What this test does not cover *(optional)*
+- Nested-field tweaks (`NestedDict`/`dict` template fields) and array/list-field tweaks — these need a component with such fields and are tracked as a follow-up issue.
+- Tweaking by node **id** (this spec tweaks by display name; the backend accepts both).
+- Top-level `input_value` precedence over a same-field tweak (asserted indirectly by omitting it, not tested head-to-head).
+- Code-field injection protection (the backend blocks tweaks on `code`-type fields).
+- Streaming responses, batch runs, multi-turn `session_id` threading → other specs / issues.
+
+---
+
+## Preconditions *(optional)*
+- Langflow running and reachable at `PLAYWRIGHT_BASE_URL`.
+- Default superuser credentials available (`LANGFLOW_SUPERUSER` / `LANGFLOW_SUPERUSER_PASSWORD`) — used by `getAuthToken` to mint the Bearer used in setup.
+- Backend allows API key creation via `POST /api/v1/api_key/` for the authenticated user.
+- `tests/assets/flows/chat-io-ok-trace-fixture.json` present and importable as a flow.
+
+---
+
+## External dependencies *(required)*
+- `tests/helpers/auth/get-auth-token.ts` — issues a valid `Bearer` via `/api/v1/auto_login`; if its contract changes, `beforeAll` breaks.
+- `tests/assets/flows/chat-io-ok-trace-fixture.json` — the `Chat Input -> Chat Output` fixture; renaming the `Chat Input` display name or changing its default `input_value` would break the tweak key or the baseline assertions.
+- `src/backend/base/langflow/api/v1/endpoints.py` — implementation of `POST /api/v1/run/{flow_id}` (`SimplifiedAPIRequest` schema, `RunResponse` shape).
+- `src/backend/base/langflow/processing/process.py` — `process_tweaks` / `apply_tweaks`; tweaks resolve by node id or display name and silently ignore unmatched references. A change here (e.g. erroring on unmatched tweaks, or changing precedence) breaks Tests 1 and 3.
+- `src/backend/base/langflow/api/v1/flows.py` — `POST /api/v1/flows/` (setup) and `DELETE /api/v1/flows/{id}` (teardown).
+- `src/backend/base/langflow/api/v1/api_key.py` — `POST /api/v1/api_key/` and `DELETE /api/v1/api_key/{id}` for the temporary key lifecycle.

--- a/tests/tests-automations/regression/api/flows/api-run-flow.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-run-flow.spec.ts
@@ -3,8 +3,9 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 
 // The /api/v1/run endpoint requires x-api-key authentication (not Bearer).
 // This test creates a temporary API key in beforeAll and deletes it in afterAll.
-// The flow is intentionally empty — matching the convention in api-run-with-tweaks.spec.ts.
-// A runnable-flow fixture for semantic output assertions belongs in a separate spec.
+// The flow is intentionally empty: these tests assert the structural contract
+// (status codes, response shape), not semantic output. Semantic output
+// assertions on a runnable flow are tracked in issue #263.
 
 test.describe("POST /api/v1/run", () => {
   let flowId: string;

--- a/tests/tests-automations/regression/api/flows/api-run-with-tweaks.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-run-with-tweaks.spec.ts
@@ -13,8 +13,10 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 //
 // Backend reference (Langflow): tweaks reference a component by node id OR by
 // display name, and tweaks targeting a non-existent component/field are
-// silently ignored (returns 200). Top-level `input_value` overrides a tweak on
-// the same field, so the tests below omit it to keep the override observable.
+// silently ignored (returns 200). Passing a top-level `input_value` together
+// with a Chat Input tweak on the same `input_value` field is rejected with 400
+// ("you cannot pass a tweak with the same name"), so the tests below omit the
+// top-level input and drive the value purely through the tweak.
 
 // The imported fixture is a Chat Input -> Chat Output flow whose Chat Input has
 // a stored `input_value` default of "Hello".
@@ -94,8 +96,9 @@ test.describe("POST /api/v1/run with tweaks", () => {
       // A unique value so the assertion cannot accidentally match the default.
       const tweakedValue = `TWEAKED-${Date.now()}`;
 
-      // No top-level input_value: top-level input would override the tweak,
-      // so omitting it lets the tweak on Chat Input.input_value take effect.
+      // No top-level input_value: passing both a top-level input_value and a
+      // tweak on Chat Input.input_value is rejected with 400, so we omit the
+      // top-level input and drive the value purely through the tweak.
       const res = await request.post(`/api/v1/run/${flowId}`, {
         headers: { "x-api-key": apiKey },
         data: {

--- a/tests/tests-automations/regression/api/flows/api-run-with-tweaks.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-run-with-tweaks.spec.ts
@@ -1,8 +1,40 @@
+import { readFileSync } from "fs";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 
-// Tests the POST /api/v1/run/{flow_id} endpoint with tweaks parameter,
-// which allows callers to override flow component configuration at runtime.
+// Tests the POST /api/v1/run/{flow_id} endpoint with the `tweaks` parameter,
+// which lets callers override flow component configuration at runtime.
+//
+// Unlike a structural smoke test, this spec runs against a real
+// Chat Input -> Chat Output passthrough flow so the override is observable:
+// Chat Output echoes whatever value Chat Input emits, so a tweak on
+// Chat Input.input_value changes the response text in a deterministic way —
+// no LLM or external provider key required.
+//
+// Backend reference (Langflow): tweaks reference a component by node id OR by
+// display name, and tweaks targeting a non-existent component/field are
+// silently ignored (returns 200). Top-level `input_value` overrides a tweak on
+// the same field, so the tests below omit it to keep the override observable.
+
+// The imported fixture is a Chat Input -> Chat Output flow whose Chat Input has
+// a stored `input_value` default of "Hello".
+const FIXTURE_PATH = "tests/assets/flows/chat-io-ok-trace-fixture.json";
+const CHAT_INPUT_DISPLAY_NAME = "Chat Input";
+const FIXTURE_DEFAULT_INPUT = "Hello";
+
+// Minimal shape of the run endpoint response needed to read the output text.
+interface RunResponseBody {
+  outputs?: Array<{
+    outputs?: Array<{
+      results?: { message?: { text?: string } };
+    }>;
+  }>;
+}
+
+// Extracts the Chat Output text from the run endpoint response.
+function getOutputText(body: RunResponseBody): string | undefined {
+  return body?.outputs?.[0]?.outputs?.[0]?.results?.message?.text;
+}
 
 test.describe("POST /api/v1/run with tweaks", () => {
   let bearerToken: string;
@@ -13,7 +45,7 @@ test.describe("POST /api/v1/run with tweaks", () => {
   test.beforeAll(async ({ request }) => {
     bearerToken = await getAuthToken(request);
 
-    // Create an API key for run endpoint (requires x-api-key, not Bearer)
+    // Create an API key for the run endpoint (requires x-api-key, not Bearer)
     const keyRes = await request.post("/api/v1/api_key/", {
       headers: { Authorization: bearerToken },
       data: { name: `tweaks-test-key-${Date.now()}` },
@@ -23,12 +55,14 @@ test.describe("POST /api/v1/run with tweaks", () => {
     apiKey = keyBody.api_key;
     apiKeyId = keyBody.id;
 
-    // Create an empty flow — run endpoint accepts empty flows and returns valid structure
+    // Import the Chat Input -> Chat Output fixture as a runnable flow
+    const fixture = JSON.parse(readFileSync(FIXTURE_PATH, "utf-8"));
     const flowRes = await request.post("/api/v1/flows/", {
       headers: { Authorization: bearerToken },
       data: {
         name: `Tweaks Test Flow ${Date.now()}`,
-        data: { nodes: [], edges: [], viewport: { x: 0, y: 0, zoom: 1 } },
+        description: "Chat Input -> Chat Output passthrough for tweaks override tests",
+        data: fixture.data,
         is_component: false,
       },
     });
@@ -54,62 +88,21 @@ test.describe("POST /api/v1/run with tweaks", () => {
   });
 
   test(
-    "POST /api/v1/run/{id} accepts tweaks parameter without error",
-    { tag: ["@release", "@api", "@regression"] },
+    "tweaks override a component field at runtime",
+    { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
-      // tweaks with empty object should be accepted and ignored (no components to tweak)
+      // A unique value so the assertion cannot accidentally match the default.
+      const tweakedValue = `TWEAKED-${Date.now()}`;
+
+      // No top-level input_value: top-level input would override the tweak,
+      // so omitting it lets the tweak on Chat Input.input_value take effect.
       const res = await request.post(`/api/v1/run/${flowId}`, {
         headers: { "x-api-key": apiKey },
         data: {
-          input_value: "hello from test",
-          input_type: "chat",
-          output_type: "chat",
-          tweaks: {},
-        },
-      });
-
-      // The run endpoint must accept the request — 200 regardless of flow output
-      expect(res.status()).toBe(200);
-      const body = await res.json();
-      expect(body).toHaveProperty("outputs");
-    },
-  );
-
-  test(
-    "POST /api/v1/run/{id} without tweaks also returns 200",
-    { tag: ["@release", "@api", "@regression"] },
-    async ({ request }) => {
-      const res = await request.post(`/api/v1/run/${flowId}`, {
-        headers: { "x-api-key": apiKey },
-        data: {
-          input_value: "hello",
-          input_type: "chat",
-          output_type: "chat",
-        },
-      });
-
-      expect(res.status()).toBe(200);
-      const body = await res.json();
-      expect(body).toHaveProperty("outputs");
-      expect(body).toHaveProperty("session_id");
-    },
-  );
-
-  test(
-    "POST /api/v1/run/{id} with tweaks referencing non-existent component is silently ignored",
-    { tag: ["@release", "@api", "@regression"] },
-    async ({ request }) => {
-      // Tweaks referencing non-existent component IDs are silently ignored — returns 200.
-      const res = await request.post(`/api/v1/run/${flowId}`, {
-        headers: { "x-api-key": apiKey },
-        data: {
-          input_value: "test",
           input_type: "chat",
           output_type: "chat",
           tweaks: {
-            "NonExistentComponent-999": {
-              some_field: "value",
-            },
+            [CHAT_INPUT_DISPLAY_NAME]: { input_value: tweakedValue },
           },
         },
       });
@@ -117,30 +110,57 @@ test.describe("POST /api/v1/run with tweaks", () => {
       expect(res.status()).toBe(200);
       const body = await res.json();
       expect(body).toHaveProperty("outputs");
+      // The override is proven: the echoed output is the tweaked value,
+      // not the fixture default ("Hello").
+      expect(getOutputText(body)).toBe(tweakedValue);
     },
   );
 
   test(
-    "POST /api/v1/run with input_type chat and output_type chat returns valid structure",
-    { tag: ["@release", "@api", "@regression"] },
+    "empty tweaks object is a no-op and leaves the flow default in effect",
+    { tag: ["@stable", "@api", "@regression"] },
     async ({ request }) => {
+      // Same request as the override test minus the tweak: the response must
+      // fall back to the flow's stored default, establishing the baseline that
+      // makes the override test meaningful.
       const res = await request.post(`/api/v1/run/${flowId}`, {
         headers: { "x-api-key": apiKey },
         data: {
-          input_value: "ping",
           input_type: "chat",
           output_type: "chat",
+          tweaks: {},
         },
       });
 
       expect(res.status()).toBe(200);
       const body = await res.json();
-
-      // Response must always include outputs and session_id
       expect(body).toHaveProperty("outputs");
-      expect(Array.isArray(body.outputs)).toBe(true);
-      expect(body).toHaveProperty("session_id");
-      expect(typeof body.session_id).toBe("string");
+      expect(getOutputText(body)).toBe(FIXTURE_DEFAULT_INPUT);
+    },
+  );
+
+  test(
+    "tweaks referencing a non-existent component are silently ignored",
+    { tag: ["@stable", "@api", "@regression"] },
+    async ({ request }) => {
+      // A tweak that targets a component not present in the flow must not error
+      // and must not change the output — it is silently ignored (200).
+      const res = await request.post(`/api/v1/run/${flowId}`, {
+        headers: { "x-api-key": apiKey },
+        data: {
+          input_type: "chat",
+          output_type: "chat",
+          tweaks: {
+            "NonExistentComponent-999": { input_value: "should be ignored" },
+          },
+        },
+      });
+
+      expect(res.status()).toBe(200);
+      const body = await res.json();
+      expect(body).toHaveProperty("outputs");
+      // Output is unchanged from the flow default — the bogus tweak had no effect.
+      expect(getOutputText(body)).toBe(FIXTURE_DEFAULT_INPUT);
     },
   );
 });


### PR DESCRIPTION
## What this PR does

Validates and tags `@stable` the tweaks-override coverage for `POST /api/v1/run/{flow_id}` (QA-CHECKLIST 1.3).

The spec previously ran against an **empty flow**, so it could only prove that tweaks were *accepted* — never that they *override* configuration (the actual checklist claim). It is now rewritten to run against a real `Chat Input → Chat Output` passthrough flow (fixture `chat-io-ok-trace-fixture.json`), where Chat Output echoes Chat Input, so a tweak on `Chat Input.input_value` changes the response text deterministically — no LLM or external provider key required.

## Behaviors validated

| # | Test | What would break in a regression |
|---|---|---|
| 1 | `tweaks` override a component field at runtime | A tweak no longer reconfigures the flow at run time (output stops reflecting the tweaked value) |
| 2 | empty `tweaks {}` is a no-op | An empty tweaks object unexpectedly alters execution instead of falling back to the flow default |
| 3 | tweak referencing a non-existent component is silently ignored | An unmatched tweak starts erroring (or silently mutating output) instead of being ignored with `200` |

Test 1 vs Tests 2/3 form the evidence of override: identical requests differing only by the tweak yield `TWEAKED-…` vs `Hello`.

## How it was validated (the 5 steps)

1. **Trace** — `--trace=on`: 3/3 pass.
2. **Steps documented** — per-block comments (API specs in this repo use comments, matching `api-run-flow.spec.ts`).
3. **Force-failure (no false positive)** —
   - Test 1: removed the tweak → `Expected "TWEAKED-…" / Received "Hello"` → **fails** ✔
   - Tests 2 & 3: wrong baseline → `Expected "WRONG…" / Received "Hello"` → **both fail** ✔
4. **Debug/trace walk-through** — covered by the trace run.
5. **Backend logs** — zero `🚨 Backend Error` / `🚨 Flow Error`.

Plus: passes **5×+ in a row** against `langflowai/langflow-nightly:latest`; `tsc --noEmit` and ESLint clean.

## What it does not cover

- Nested-field (`NestedDict`) and array/list-field tweaks → **follow-up issue** (a component with such fields is needed).
- The `400` rejection when a top-level `input_value` and a same-field Chat Input tweak are sent together (the spec avoids the combination; a dedicated negative test could cover it).
- Code-field injection protection; streaming; batch runs.

## Notes for the reviewer

- Independent review caught a factual error in the first commit: the "top-level input overrides a same-field tweak" rationale was wrong — the backend rejects that combination with `400`. Fixed in `05a66da`, verified against the running backend.
- Same commit refreshes now-stale cross-references in `api-run-flow.spec.ts` / `api-run-flow.md` (they described the empty-flow convention as "shared with api-run-with-tweaks.spec.ts", no longer true).
- `QA-CHECKLIST.md` 1.3 tweaks bullet flipped `[-]` → `[x]`. The Coverage Summary table is auto-generated — not hand-edited.

Closes #249
