### PR TITLE
ci(weekly): parametrize Langflow image repository for dispatch

### DIFF
--- a/.github/workflows/weekly-stable.yml
+++ b/.github/workflows/weekly-stable.yml
@@ -6,8 +6,12 @@ on:
     - cron: "0 6 * * 1" # 03:00 BRT (UTC-3), every Monday
   workflow_dispatch:
     inputs:
+      langflow_image:
+        description: "Langflow image repository (e.g. langflowai/langflow-nightly or langflowai/langflow)"
+        required: false
+        default: "langflowai/langflow-nightly"
       langflow_image_tag:
-        description: "Langflow nightly image tag (e.g. latest, 1.5.1.dev36)"
+        description: "Image tag (e.g. latest, 1.5.1.dev36, 1.10.1rc3). Use a multi-arch tag — runners are amd64, so do NOT pick an -arm64 variant."
         required: false
         default: "latest"
 
@@ -17,7 +21,7 @@ permissions:
 
 jobs:
   e2e-weekly-stable:
-    name: Weekly Stable E2E (langflow-nightly:${{ inputs.langflow_image_tag || 'latest' }})
+    name: Weekly Stable E2E (${{ inputs.langflow_image || 'langflowai/langflow-nightly' }}:${{ inputs.langflow_image_tag || 'latest' }})
     runs-on: ubuntu-latest
     timeout-minutes: 90
 
@@ -31,7 +35,7 @@ jobs:
 
     services:
       langflow:
-        image: langflowai/langflow-nightly:${{ inputs.langflow_image_tag || 'latest' }}
+        image: ${{ inputs.langflow_image || 'langflowai/langflow-nightly' }}:${{ inputs.langflow_image_tag || 'latest' }}
         ports:
           - 7860:7860
         env:
@@ -144,7 +148,7 @@ jobs:
         env:
           PLAYWRIGHT_JSON: results.json
           WORKFLOW: weekly-stable
-          LANGFLOW_IMAGE: langflowai/langflow-nightly:${{ inputs.langflow_image_tag || 'latest' }}
+          LANGFLOW_IMAGE: ${{ inputs.langflow_image || 'langflowai/langflow-nightly' }}:${{ inputs.langflow_image_tag || 'latest' }}
 
       - name: Commit weekly history
         if: always() && github.event_name == 'schedule'

--- a/.github/workflows/weekly-stable.yml
+++ b/.github/workflows/weekly-stable.yml
@@ -175,20 +175,20 @@ jobs:
         if: failure() && github.event_name == 'schedule'
         uses: actions/github-script@v7
         env:
-          IMAGE_TAG: ${{ inputs.langflow_image_tag || 'latest' }}
+          IMAGE: ${{ inputs.langflow_image || 'langflowai/langflow-nightly' }}:${{ inputs.langflow_image_tag || 'latest' }}
         with:
           script: |
             const today = new Date().toISOString().split('T')[0];
-            const tag = process.env.IMAGE_TAG;
+            const image = process.env.IMAGE;
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `[Weekly Failure] @stable tests failed on ${today} (langflow:${tag})`,
+              title: `[Weekly Failure] @stable tests failed on ${today} (${image})`,
               body: [
                 '## Weekly @stable E2E Failure',
                 '',
                 `- **Date:** ${today}`,
-                `- **Langflow version:** \`langflowai/langflow-nightly:${tag}\``,
+                `- **Langflow version:** \`${image}\``,
                 `- **Run:** [${context.runId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
                 '',
                 '### Next steps',


### PR DESCRIPTION
## What

Adds a \`langflow_image\` input to \`weekly-stable.yml\` so a manual `workflow_dispatch` can target **any** Langflow image repository (e.g. `langflowai/langflow`), instead of being hardcoded to `langflowai/langflow-nightly`.

## Why

We needed to run the `@stable` suite against a release-candidate image (`langflowai/langflow:1.10.1rc3`). The weekly job is the healthy execution path (official Playwright container, no browser download, port-forward already wired), but it only let us change the tag — not the repository. `manual.yml` supports the stable repo but is stale (test-suite directory mapping points at paths that no longer exist).

## Behavior

- **Scheduled run is unchanged**: `langflow_image` defaults to `langflowai/langflow-nightly`, and on `schedule` events the input is empty so the fallback resolves to the same nightly image.
- The history-append and issue-creation steps stay gated on `github.event_name == 'schedule'`, so manual dispatches never write to `reports/weekly-history.jsonl` nor open an issue.
- The tag input description now warns that runners are amd64 — use a multi-arch tag, not an `-arm64` variant.

## How to use

\`\`\`
gh workflow run weekly-stable.yml --ref <branch> \
  -f langflow_image=langflowai/langflow \
  -f langflow_image_tag=1.10.1rc3
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)