### PR TITLE
fix(llm-agents): de-flake memory-history regression on Langflow 1.11.0 (#354)

### DIFF
--- a/docs/core-functionality/llm-agents/memory-history-regression.md
+++ b/docs/core-functionality/llm-agents/memory-history-regression.md
@@ -1,6 +1,6 @@
 # Memory Chatbot — History and Memory Regression
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.11.0
 
 ---
 
@@ -41,11 +41,11 @@ Requires `OPENAI_API_KEY`. Groups behavior validations in `test.step` with `expe
 
 1. Load the Memory Chatbot template and configure OpenAI via `setupLanguageModelOpenAI`:
    - If `model_model` is not visible (providers not configured): click the "Setup Provider" button (no data-testid) → select `provider-item-OpenAI` → fill the API key with `pressSequentially` → click "Save" → wait for the "Replace" button to appear → enable `[data-testid^="llm-toggle"]` toggles → close with Escape → wait for `model_model` to appear
-   - Click `model_model` and select `gpt-4o-mini`
+   - Click `model_model` and select a chat model **resiliently**: `MODEL_TEST_ID` (env) if set → first available preferred cheap chat model (`gpt-4o-mini`, then `gpt-5.4-nano`, `gpt-5.4-mini`, …) → first option that is not a non-chat model (image/embedding/audio). This adapts to builds where `gpt-4o-mini` was dropped from the OpenAI bundle (1.11.0 ships `gpt-5.x` instead) and avoids slow/expensive models that would reintroduce the LLM-response timeout
 2. Open the Playground (`playground-btn-flow-io`) and wait for `input-chat-playground`
-3. *Step: context retention* — Send `"My name is Alice..."`, wait for response, send `"What is my name?"` and assert the response contains "Alice"
-4. *Step: multiple messages* — count `div-chat-message` ≥ 2 (testid is present only on bot responses)
-5. *Step: persistence* — close the Playground via `playground-close-button`, reopen it, confirm the message count is ≥ the previous value
+3. *Step: context retention* — Send `"My name is Alice..."`, wait for the response to **complete** (`waitForChatResponse` counts `chat-message-token-usage` badges, which render once per finished response), send `"What is my name?"` and assert the latest `div-chat-message` contains "Alice"
+4. *Step: multiple messages* — web-first `toHaveCount(2)` on `div-chat-message` (testid is present only on bot responses)
+5. *Step: persistence* — close the Playground via `playground-close-button` (wait for `input-chat-playground` to hide), reopen it, and web-first assert `div-chat-message` count is restored to the previous value
 
 ---
 
@@ -55,10 +55,9 @@ Requires `OPENAI_API_KEY`. Kept separate because it is destructive (creates a ne
 
 1. Load the template and configure the API key (same flow as Test 2)
 2. Open the Playground, send `"My name is Bob..."`
-3. Wait for the response to appear
+3. Wait for the response to complete (`waitForChatResponse` — counts `chat-message-token-usage`)
 4. Click `new-chat` (the "+" button in the sessions sidebar)
-5. Wait 500ms for session state reset
-6. Assert that `div-chat-message` count is `=== 0` (session starts empty)
+5. Web-first assert `div-chat-message` `toHaveCount(0)` — auto-retries until the session reset settles, so a reset slower than a fixed wait cannot false-fail (replaced the old `waitForTimeout(500)` + hard count)
 
 ---
 
@@ -77,7 +76,7 @@ Requires `OPENAI_API_KEY`. Kept separate because it is destructive (creates a ne
 - `src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json` — defines the template graph at runtime (overrides the `.py`); changes to nodes or edges break Test 1
 - `src/lfx/src/lfx/components/models_and_agents/memory.py` — `MemoryComponent` (`display_name = "Message History"`); renaming or removing it breaks Tests 1 and 2
 - `src/lfx/src/lfx/components/models_and_agents/language_model.py` — `LanguageModelComponent` (`display_name = "Language Model"`); changes to the `model` field or `display_name` affect Tests 1, 2, and 3
-- `src/frontend/src/components/core/playgroundComponent/` — `input-chat-playground`, `div-chat-message`, `playground-close-button`, `new-chat` — any rename breaks Tests 2 and 3
+- `src/frontend/src/components/core/playgroundComponent/` — `input-chat-playground`, `div-chat-message`, `chat-message-token-usage`, `playground-close-button`, `new-chat` — any rename breaks Tests 2 and 3. `chat-message-token-usage` is the completion signal used by `waitForChatResponse`; if a future build stops rendering it (or a provider returns no token usage), the response wait must switch to another per-response completion marker
 - `src/frontend/src/CustomNodes/GenericNode/components/NodeName/index.tsx` — `data-testid="title-{display_name}"` — a change to this testid pattern breaks Test 1
 - `src/frontend/src/modals/modelProviderModal/components/ProviderConfigurationForm.tsx` — "Save" button (exact text to save the API key); changing it breaks `setupLanguageModelOpenAI`
 
@@ -113,7 +112,9 @@ Requires `OPENAI_API_KEY`. Kept separate because it is destructive (creates a ne
 ## Notes *(optional)*
 
 - **Template structure at runtime**: the template loads from `Memory Chatbot.json` (not the `.py`), with 6 nodes: Chat Input, Chat Output, Prompt Template, Message History, Language Model (not OpenAI directly), note/README.
-- **`div-chat-message`**: testid present only on bot responses (`bot-message.tsx`), not on user messages. 2 exchanges → count = 2 (not 4).
+- **`div-chat-message`**: testid present only on bot responses (`bot-message.tsx`), not on user messages. 2 exchanges → count = 2 (not 4). **Its count is unreliable as a "response arrived" signal** — while a response streams in, the bubble mounts, unmounts on a re-render, then settles, so the count flickers. `waitForChatResponse` therefore counts `chat-message-token-usage` (rendered only once a response *completes*) instead. This was the root cause of the flaky history/isolation assertions in issue #354.
+- **Model selection is resilient**: `setupLanguageModelOpenAI` no longer hardcodes `gpt-4o-mini`. It resolves `MODEL_TEST_ID` (env) → first available preferred cheap chat model → first non-image/embedding/audio option. Validated on Langflow 1.11.0, where the OpenAI bundle exposes `gpt-5.x` (e.g. `gpt-5.4-nano`) and no longer lists `gpt-4o-mini`.
+- **Residual flake**: Tests 2 and 3 make live OpenAI calls, so an occasional response slower than the 120s budget can still time out — this is the inherent external-dependency flake described in issue #354, absorbed by the CI retry budget, not a test-logic bug.
 - **`setupLanguageModelOpenAI`**: local function in the spec that configures OpenAI via the "Setup Provider" modal. Uses `pressSequentially` (not `fill`) to ensure keyboard events on React controlled inputs. Waits for the "Replace" button to appear to confirm the save completed.
 - **`new-chat`**: the "+" button in the sessions sidebar (`chat-sidebar.tsx`). Functional equivalent of "New Session" in the `session-selector-trigger` dropdown (which may be hidden by animation in certain builds).
 - **Test 1 without API key**: pure structure validation — useful in CI without configured keys.

--- a/tests/helpers/provider-setup/setup-language-model-openai.ts
+++ b/tests/helpers/provider-setup/setup-language-model-openai.ts
@@ -1,5 +1,59 @@
 import type { Page } from "@playwright/test";
 
+// Cheap, fast chat models in priority order. `gpt-4o-mini` is kept first so older
+// Langflow builds still match; the `gpt-5.x` entries cover newer builds (1.11.0+)
+// where `gpt-4o-mini` was dropped from the OpenAI bundle. Reasoning-/image-/audio-heavy
+// models are deliberately excluded so the memory test stays fast and deterministic
+// (a slow model would reintroduce the 120s-response timeout flake from issue #354).
+const PREFERRED_CHAT_MODELS = [
+  "gpt-4o-mini",
+  "gpt-5.4-nano",
+  "gpt-5-nano",
+  "gpt-5.4-mini",
+  "gpt-5-mini",
+  "gpt-4.1-mini",
+  "gpt-4o",
+  "gpt-5.4",
+  "gpt-5.5",
+];
+
+// Substrings marking a non-chat model (image, embeddings, audio, …) — never select these.
+const NON_CHAT_MODEL = /image|embedding|audio|tts|realtime|whisper|dall-?e|moderation|transcribe/i;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Selects a usable OpenAI chat model from the already-open `model_model` dropdown.
+// Resolution order: MODEL_TEST_ID env override → first available preferred model →
+// first option that is not a non-chat model. Throws with the observed options if none fit.
+async function selectPreferredChatModel(page: Page): Promise<void> {
+  const options = page.locator('[data-testid$="-option"]');
+  await options.first().waitFor({ state: "visible", timeout: 15000 });
+
+  const labels = (await options.allInnerTexts())
+    .map((label) => label.trim())
+    .filter(Boolean);
+
+  const envModel = process.env.MODEL_TEST_ID?.trim();
+  const chosen =
+    (envModel && labels.find((label) => label === envModel)) ||
+    PREFERRED_CHAT_MODELS.find((model) => labels.includes(model)) ||
+    labels.find((label) => !NON_CHAT_MODEL.test(label));
+
+  if (!chosen) {
+    await page.keyboard.press("Escape");
+    throw new Error(
+      `No usable OpenAI chat model found in the model dropdown. Options: ${labels.join(", ")}`,
+    );
+  }
+
+  await options
+    .filter({ hasText: new RegExp(`^${escapeRegExp(chosen)}$`) })
+    .first()
+    .click();
+}
+
 // Requires the Language Model node to be clicked before calling so its fields are in the viewport.
 export async function setupLanguageModelOpenAI(page: Page): Promise<void> {
   const modelDropdown = page.getByTestId("model_model");
@@ -52,9 +106,5 @@ export async function setupLanguageModelOpenAI(page: Page): Promise<void> {
   }
 
   await modelDropdown.click();
-  const gpt4oMiniOption = page
-    .locator('[data-testid$="-option"]', { hasText: "gpt-4o-mini" })
-    .first();
-  await gpt4oMiniOption.waitFor({ state: "visible", timeout: 10000 });
-  await gpt4oMiniOption.click();
+  await selectPreferredChatModel(page);
 }

--- a/tests/tests-automations/regression/core-functionality/llm-agents/memory-history-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/memory-history-regression.spec.ts
@@ -20,12 +20,18 @@ async function loadMemoryChatbot(page: Page): Promise<void> {
   await adjustScreenView(page);
 }
 
-async function waitForChatResponse(page: Page): Promise<void> {
-  await page.waitForSelector('[data-testid="div-chat-message"]', { timeout: 120000 });
-  const stopButton = page.getByRole("button", { name: "Stop" });
-  if (await stopButton.isVisible({ timeout: 3000 }).catch(() => false)) {
-    await expect(stopButton).toBeHidden({ timeout: 120000 });
-  }
+// Waits until `expectedResponses` bot responses have *fully completed*.
+//
+// A response's `chat-message-token-usage` badge is rendered only once that response
+// finishes, so its count is a stable completion signal. The `div-chat-message` element
+// is NOT usable for this: its count flickers while a response streams in (the bubble
+// mounts, unmounts on a re-render, then settles), so waiting on it can return on a
+// transient peak before the new response actually arrives — the root cause of the flaky
+// history/isolation assertions in issue #354. The 120s budget covers live LLM latency.
+async function waitForChatResponse(page: Page, expectedResponses: number): Promise<void> {
+  await expect(page.getByTestId("chat-message-token-usage")).toHaveCount(expectedResponses, {
+    timeout: 120000,
+  });
 }
 
 test.describe("Memory Chatbot Regression", () => {
@@ -70,33 +76,35 @@ test.describe("Memory Chatbot Regression", () => {
 
       await test.step("message history retains context within same session", async () => {
         await playground.sendMessage("My name is Alice. Please confirm you received my name.");
-        await waitForChatResponse(page);
+        await waitForChatResponse(page, 1);
         await expect.soft(page.getByTestId("div-chat-message").last()).toBeVisible({ timeout: 30000 });
 
         await playground.sendMessage("What is my name?");
-        await waitForChatResponse(page);
+        await waitForChatResponse(page, 2);
 
         const response = await page.getByTestId("div-chat-message").last().innerText();
         expect.soft(response).toMatch(/Alice/i);
       });
 
       await test.step("multiple consecutive messages accumulate in history", async () => {
-        // div-chat-message marks bot responses only; 2 exchanges → 2 bot responses
-        const count = await page.getByTestId("div-chat-message").count();
-        expect.soft(count).toBeGreaterThanOrEqual(2);
+        // div-chat-message marks bot responses only; 2 exchanges → 2 bot responses.
+        // Web-first count so a still-settling message list cannot false-fail.
+        await expect.soft(page.getByTestId("div-chat-message")).toHaveCount(2, { timeout: 10000 });
       });
 
       await test.step("messages persist after closing and reopening playground", async () => {
         const messagesBefore = await page.getByTestId("div-chat-message").count();
 
         await page.getByTestId("playground-close-button").click();
-        await page.waitForTimeout(500);
+        await expect(page.getByTestId("input-chat-playground")).toBeHidden({ timeout: 10000 });
 
         await page.getByTestId("playground-btn-flow-io").click();
-        await page.waitForSelector('[data-testid="input-chat-playground"]', { timeout: 30000 });
+        await expect(page.getByTestId("input-chat-playground")).toBeVisible({ timeout: 30000 });
 
-        const messagesAfter = await page.getByTestId("div-chat-message").count();
-        expect.soft(messagesAfter).toBeGreaterThanOrEqual(messagesBefore);
+        // History reloads asynchronously on reopen; web-first wait for it to restore.
+        await expect.soft(page.getByTestId("div-chat-message")).toHaveCount(messagesBefore, {
+          timeout: 30000,
+        });
       });
     },
   );
@@ -119,16 +127,19 @@ test.describe("Memory Chatbot Regression", () => {
       await page.waitForSelector('[data-testid="input-chat-playground"]', { timeout: 30000 });
 
       await playground.sendMessage("My name is Bob. Please confirm you received my name.");
-      await waitForChatResponse(page);
+      await waitForChatResponse(page, 1);
       await expect(page.getByTestId("div-chat-message").last()).toBeVisible({ timeout: 30000 });
 
       // "new-chat" button is in the sessions sidebar (data-testid="new-chat")
       await page.getByTestId("new-chat").click();
-      // Brief wait for session state to reset
-      await page.waitForTimeout(500);
 
-      const messagesInNewSession = await page.getByTestId("div-chat-message").count();
-      expect(messagesInNewSession).toBe(0);
+      // Web-first: a fresh session must contain zero bot messages. toHaveCount(0)
+      // auto-retries until the session reset settles, so a reset slower than a
+      // fixed wait no longer false-fails (replaces waitForTimeout(500) + a hard
+      // count assertion — issue #354 secondary latent risk).
+      await expect(page.getByTestId("div-chat-message")).toHaveCount(0, {
+        timeout: 10000,
+      });
     },
   );
 });


### PR DESCRIPTION
## Summary

Fixes #354. The `memory-history-regression.spec.ts` session-isolation and history tests were **hard-broken on Langflow 1.11.0**, not just flaky. Validated by standing up Langflow 1.11.0 and reproducing the failure.

### Root causes found
1. **Hardcoded `gpt-4o-mini`** — dropped from the OpenAI bundle in 1.11.0 (the dropdown now exposes `gpt-5.x`, e.g. `gpt-5.4-nano`). The `waitFor` on the `gpt-4o-mini` option timed out before the test could run.
2. **`waitForChatResponse` counted `div-chat-message`** — that element's count flickers while a response streams in (mount → unmount on re-render → settle), so the wait returned on a transient peak before the new response actually arrived. This was the real source of the flaky history/isolation assertions described in #354.
3. **Secondary risk from #354** — `waitForTimeout(500)` + a hard count for the session-reset check.

### Changes
- `setup-language-model-openai.ts`: resolve the OpenAI model **resiliently** — `MODEL_TEST_ID` (env) → first available preferred cheap chat model → first option that is not an image/embedding/audio model. Adapts to builds with/without `gpt-4o-mini` and avoids slow/expensive models that would reintroduce the response-timeout flake.
- `waitForChatResponse`: count `chat-message-token-usage` (rendered once per **completed** response) instead of `div-chat-message`.
- Replace one-shot `.count()` history assertions with web-first `toHaveCount`, including the session-reset check.
- Update the spec doc; **Last validated: Langflow 1.11.0**.

## Validation (Langflow 1.11.0)
- typecheck ✅ · lint ✅ (0 errors; 2 pre-existing warnings removed) · backend errors ✅ zero
- `--retries=0`: isolation 100%, history ~13/14 across repeated runs; final full-file run 3/3 (52s)
- force-fail ✅ (broke `toHaveCount(0)`→999, failed at the exact assertion, reverted)
- `--trace=on` ✅ steps coherent

The residual ~1/14 history failure is the **external LLM-latency flake** that #354 itself documents as inherent (absorbed by the CI retry budget), not a test-logic bug. Both logic root causes are eliminated.

## Note / follow-up
The same hardcoded-`gpt-4o-mini` bug still exists in `setup-openai.ts` (used by the agent tests) and will break on 1.11.0 the same way — left out of this PR to keep it focused on #354; tracked for a separate follow-up.