### PR TITLE
test(api): runnable-flow fixture for /api/v1/run semantic assertions

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -95,6 +95,7 @@
 - [x] POST `/api/v1/run/{flow_id}` with `input_value` → returns response → `api/flows/api-run-flow.spec.ts`
 - [x] POST with `tweaks` → parameters override flow configuration → `api/flows/api-run-with-tweaks.spec.ts`
 - [x] POST with custom `session_id` → `api/flows/api-run-flow.spec.ts`
+- [x] POST with custom `session_id` persists messages retrievable via `GET /api/v1/monitor/messages?session_id` → `api/flows/api-run-flow.spec.ts`
 - [x] POST with `input_type: "chat"` and `output_type: "chat"` → `api/flows/api-run-flow.spec.ts`
 - [x] POST with invalid API key → returns 401/403 → `api-invalid-key.spec.ts`
 - [x] POST to non-existent flow → returns 404 → `api/flows/api-run-flow.spec.ts`

--- a/docs/api/flows/api-run-flow.md
+++ b/docs/api/flows/api-run-flow.md
@@ -1,6 +1,6 @@
 # API Run Flow
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.11.x
 
 ---
 
@@ -23,10 +23,10 @@ The spec runs **3 independent tests** via Playwright's `request` fixture, sharin
 **Setup (`beforeAll`)**
 1. Obtain a valid Bearer token via `getAuthToken(request)`.
 2. `POST /api/v1/api_key/` with the Bearer token to mint a temporary API key (asserts `200` and that the response body contains `api_key` and `id` — gives an explicit failure if the API key response shape changes).
-3. `POST /api/v1/flows/` with the new `x-api-key` to create a minimal empty flow (`nodes: []`, `edges: []`), asserts `201`, and stores `flowId`. These tests assert the structural contract only; semantic assertions (non-empty `outputs`, message persistence) are tracked in issue #263. (For an example of semantic output assertions on a runnable flow, see `api-run-with-tweaks.spec.ts`.)
+3. Create a runnable Chat Input → Chat Output passthrough flow via the shared helper `createRunnableChatFlowViaApi(request, { "x-api-key": apiKey })` (asserts `201`) and store `flowId` plus its `deleteFlow` teardown. The flow runs without an LLM, so the tests assert both the structural contract **and** semantic output (non-empty `outputs`, message persistence under a custom `session_id`).
 
 **Teardown (`afterAll`)**
-1. `DELETE /api/v1/flows/{flowId}` with the `x-api-key`.
+1. `deleteFlow()` (helper) — `DELETE /api/v1/flows/{flowId}` with the `x-api-key`.
 2. `DELETE /api/v1/api_key/{apiKeyId}` with the Bearer token.
 
 ---
@@ -35,14 +35,16 @@ The spec runs **3 independent tests** via Playwright's `request` fixture, sharin
 1. POST to `/api/v1/run/{flowId}` with `x-api-key` and payload `{ input_value, input_type: "chat", output_type: "chat" }`.
 2. Assert response status is `200`.
 3. Assert `body.outputs` exists and is an array.
+4. Assert `body.outputs.length > 0` — the runnable flow actually executed and produced output, not just a structurally valid empty shell.
 
 This test covers the QA-CHECKLIST 1.3 bullets for `input_value` and for `input_type: "chat"` / `output_type: "chat"` in a single call — both parameters are sent explicitly in the request payload.
 
-**Test 2 — `POST /api/v1/run/{flow_id}` with custom `session_id`**
-1. Generate a deterministic `session_id` (e.g. `test-session-<timestamp>`).
+**Test 2 — `POST /api/v1/run/{flow_id}` with custom `session_id`, asserting message persistence**
+1. Generate a deterministic `session_id` (e.g. `test-session-<timestamp>`) and a unique `input_value`.
 2. POST with payload including `session_id`.
 3. Assert response status is `200`.
 4. Assert `body.session_id` equals the value sent in the request.
+5. Poll `GET /api/v1/monitor/messages?session_id=<id>` (Bearer auth) until it returns at least one message, then assert every returned message carries that `session_id` and that one message's `text` equals the `input_value` sent — proving the run executed and persisted through the custom session.
 
 **Test 3 — `POST /api/v1/run/{non_existent_flow_id}` returns 404**
 1. POST to `/api/v1/run/00000000-0000-0000-0000-000000000000` with the valid `x-api-key`.
@@ -52,8 +54,8 @@ This test covers the QA-CHECKLIST 1.3 bullets for `input_value` and for `input_t
 
 ## Validation criterion *(required)*
 - Setup creates one flow and one API key; teardown removes both. No orphans on the backend after the suite.
-- Test 1 receives `200` and a body with an `outputs` array (content may be empty for an empty flow — the contract is structural, not semantic).
-- Test 2 receives `200` and the returned `session_id` is byte-identical to the value sent in the request.
+- Test 1 receives `200` and a body with a non-empty `outputs` array — the runnable flow executed and produced output.
+- Test 2 receives `200`, the returned `session_id` is byte-identical to the value sent, and `GET /api/v1/monitor/messages?session_id=<id>` surfaces the run's persisted messages (all scoped to that session, including the input text sent).
 - Test 3 receives `404` — confirming the router differentiates missing-flow from auth failure and from input-validation failure.
 
 ---
@@ -63,8 +65,7 @@ This test covers the QA-CHECKLIST 1.3 bullets for `input_value` and for `input_t
 - Invalid `x-api-key` → `api-invalid-key.spec.ts` (already `@stable`)
 - `GET /api/v1/all` (component listing) → `api-custom-component-creation.spec.ts` (issue #250)
 - Streaming responses, batch runs, file uploads, multi-turn conversations beyond a single `session_id` echo
-- Semantic correctness of `outputs` content (an empty flow produces a structurally valid but functionally empty response) → tracked in issue #263
-- Message persistence under the custom `session_id` (would require a runnable flow that actually emits chat messages) → tracked in issue #263
+- Correctness of `outputs` *content* beyond non-emptiness and the echoed input — semantic LLM output, tool calls, and multi-component graphs are out of scope here
 
 ---
 
@@ -77,6 +78,8 @@ This test covers the QA-CHECKLIST 1.3 bullets for `input_value` and for `input_t
 
 ## External dependencies *(required)*
 - `tests/helpers/auth/get-auth-token.ts` — issues a valid `Bearer` via `/api/v1/auto_login`; if its contract changes, `beforeAll` breaks
+- `tests/helpers/flows/create-runnable-chat-flow-via-api.ts` — builds the runnable Chat Input → Chat Output flow from `tests/assets/flows/chat-io-ok-trace-fixture.json`; if the fixture goes stale against the current Langflow schema, `beforeAll` breaks (shared with `api-run-with-tweaks.spec.ts`)
+- `src/backend/base/langflow/api/v1/monitor.py` — `GET /api/v1/monitor/messages`; Test 2's persistence assertion breaks if message storage or the `session_id` filter regresses
 - `src/backend/base/langflow/api/v1/endpoints.py` — implementation of `POST /api/v1/run/{flow_id}`; changing the response shape (e.g. dropping `outputs` or `session_id` from the body) breaks Tests 1 and 2
 - `src/backend/base/langflow/api/v1/flows.py` — `POST /api/v1/flows/` used in setup and `DELETE /api/v1/flows/{id}` used in teardown
 - `src/backend/base/langflow/api/v1/api_key.py` — `POST /api/v1/api_key/` and `DELETE /api/v1/api_key/{id}` for temporary key lifecycle

--- a/tests/helpers/flows/create-runnable-chat-flow-via-api.ts
+++ b/tests/helpers/flows/create-runnable-chat-flow-via-api.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from "fs";
+import type { APIRequestContext } from "@playwright/test";
+import { expect } from "../../fixtures/fixtures";
+
+// A minimal, version-current runnable flow: Chat Input -> Chat Output passthrough
+// (single edge, no LLM or external provider key required). Chat Output echoes
+// whatever value Chat Input emits, so callers can make deterministic semantic
+// assertions on the run output — unlike an empty flow, which only supports the
+// structural contract.
+const RUNNABLE_CHAT_FLOW_FIXTURE =
+  "tests/assets/flows/chat-io-ok-trace-fixture.json";
+
+// The `input_value` stored on the fixture's Chat Input node. With no top-level
+// `input_value` and no overriding tweak, Chat Output echoes this verbatim — so
+// it is the baseline value to assert against.
+export const RUNNABLE_CHAT_FLOW_DEFAULT_INPUT = "Hello";
+
+// The Chat Input node's display name, usable as a `tweaks` key to override the
+// input value at runtime (tweaks reference a component by node id OR display name).
+export const RUNNABLE_CHAT_FLOW_CHAT_INPUT_DISPLAY_NAME = "Chat Input";
+
+export interface RunnableChatFlow {
+  /** The id of the created flow, for use against `POST /api/v1/run/{flow_id}`. */
+  flowId: string;
+  /** Deletes the flow created by this helper. Safe to call in `afterAll`. */
+  deleteFlow: () => Promise<void>;
+}
+
+/**
+ * Creates a runnable Chat Input -> Chat Output flow via `POST /api/v1/flows/`
+ * and returns its id plus a teardown callback.
+ *
+ * `headers` carries the auth the caller already holds — pass `{ "x-api-key": key }`
+ * or `{ Authorization: bearer }`; in auto_login mode both map to the same
+ * superuser, so flow ownership matches either way. The same header is reused for
+ * teardown.
+ */
+export async function createRunnableChatFlowViaApi(
+  request: APIRequestContext,
+  headers: Record<string, string>,
+): Promise<RunnableChatFlow> {
+  const fixture = JSON.parse(readFileSync(RUNNABLE_CHAT_FLOW_FIXTURE, "utf-8"));
+
+  // The flow name must be unique per call: Langflow enforces a unique-name-per-user
+  // constraint, and its auto-rename fallback is not transaction-safe — two parallel
+  // creations with the same name race and the loser gets a 500. A random suffix on
+  // top of the timestamp avoids same-millisecond collisions across parallel specs
+  // (same convention as setup-blank-flow.ts).
+  const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+
+  const res = await request.post("/api/v1/flows/", {
+    headers,
+    data: {
+      name: `Runnable Chat Flow ${uniqueSuffix}`,
+      description: "Chat Input -> Chat Output passthrough for API run tests",
+      data: fixture.data,
+      is_component: false,
+    },
+  });
+  expect(res.status()).toBe(201);
+  const flowId = (await res.json()).id as string;
+
+  return {
+    flowId,
+    deleteFlow: async () => {
+      await request
+        .delete(`/api/v1/flows/${flowId}`, { headers })
+        .catch(() => {});
+    },
+  };
+}

--- a/tests/tests-automations/regression/api/flows/api-run-flow.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-run-flow.spec.ts
@@ -1,17 +1,20 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { createRunnableChatFlowViaApi } from "../../../../helpers/flows/create-runnable-chat-flow-via-api";
 
 // The /api/v1/run endpoint requires x-api-key authentication (not Bearer).
 // This test creates a temporary API key in beforeAll and deletes it in afterAll.
-// The flow is intentionally empty: these tests assert the structural contract
-// (status codes, response shape), not semantic output. Semantic output
-// assertions on a runnable flow are tracked in issue #263.
+// The flow is a runnable Chat Input -> Chat Output passthrough (no LLM required)
+// so the tests can assert both the structural contract (status codes, response
+// shape) AND semantic output: non-empty `outputs` and message persistence under
+// the custom `session_id`.
 
 test.describe("POST /api/v1/run", () => {
   let flowId: string;
   let apiKey: string;
   let apiKeyId: string;
   let bearerToken: string;
+  let deleteFlow: () => Promise<void>;
 
   test.beforeAll(async ({ request }) => {
     bearerToken = await getAuthToken(request);
@@ -28,27 +31,18 @@ test.describe("POST /api/v1/run", () => {
     apiKey = keyBody.api_key;
     apiKeyId = keyBody.id;
 
-    // Create a minimal flow using the API key (owner must match the API key)
-    const createRes = await request.post("/api/v1/flows/", {
-      headers: { "x-api-key": apiKey },
-      data: {
-        name: `Run Test Flow - ${Date.now()}`,
-        description: "Flow for API run tests",
-        data: { nodes: [], edges: [], viewport: { x: 0, y: 0, zoom: 1 } },
-        is_component: false,
-      },
+    // Create a runnable flow using the API key (owner must match the API key)
+    const flow = await createRunnableChatFlowViaApi(request, {
+      "x-api-key": apiKey,
     });
-    expect(createRes.status()).toBe(201);
-    const body = await createRes.json();
-    flowId = body.id;
+    flowId = flow.flowId;
+    deleteFlow = flow.deleteFlow;
   });
 
   test.afterAll(async ({ request }) => {
     // Delete flow
-    if (flowId) {
-      await request.delete(`/api/v1/flows/${flowId}`, {
-        headers: { "x-api-key": apiKey },
-      });
+    if (deleteFlow) {
+      await deleteFlow();
     }
     // Delete temporary API key
     if (apiKeyId) {
@@ -75,19 +69,26 @@ test.describe("POST /api/v1/run", () => {
       const body = await response.json();
       expect(body).toHaveProperty("outputs");
       expect(Array.isArray(body.outputs)).toBeTruthy();
+      // The flow is runnable (Chat Input -> Chat Output), so execution must
+      // produce at least one output group. An empty array would mean the
+      // backend accepted the request but did not actually run the flow.
+      expect(body.outputs.length).toBeGreaterThan(0);
     },
   );
 
   test(
-    "executes flow with custom session_id and returns it in response",
+    "executes flow with custom session_id and persists messages under it",
     { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
       const customSessionId = `test-session-${Date.now()}`;
+      // A unique value so the persistence assertion cannot accidentally match
+      // a message from another session or the flow's stored default.
+      const inputValue = `Test with session ${Date.now()}`;
 
       const response = await request.post(`/api/v1/run/${flowId}`, {
         headers: { "x-api-key": apiKey },
         data: {
-          input_value: "Test with session",
+          input_value: inputValue,
           input_type: "chat",
           output_type: "chat",
           session_id: customSessionId,
@@ -98,6 +99,39 @@ test.describe("POST /api/v1/run", () => {
       const body = await response.json();
       expect(body).toHaveProperty("session_id");
       expect(body.session_id).toBe(customSessionId);
+
+      // The run must persist its chat messages under the custom session_id, so
+      // GET /api/v1/monitor/messages?session_id=<id> returns them. Persistence
+      // can lag the run response slightly, so poll briefly. (The monitor
+      // endpoint authenticates with Bearer, not x-api-key.)
+      let messages: Array<{ session_id: string; text?: string }> = [];
+      let lastStatus = 0;
+      await expect
+        .poll(
+          async () => {
+            const res = await request.get(
+              `/api/v1/monitor/messages?session_id=${customSessionId}`,
+              { headers: { Authorization: bearerToken } },
+            );
+            lastStatus = res.status();
+            // Tolerate a transient non-200 by retrying (return 0) rather than
+            // throwing inside the poll, which would fail the test immediately.
+            if (lastStatus !== 200) return 0;
+            messages = await res.json();
+            return messages.length;
+          },
+          { timeout: 10_000 },
+        )
+        .toBeGreaterThan(0);
+      expect(lastStatus).toBe(200);
+
+      // Every persisted message belongs to the requested session, and the user
+      // input we sent was recorded — proving the run actually executed and wrote
+      // through this session_id rather than returning a structurally valid shell.
+      for (const msg of messages) {
+        expect(msg.session_id).toBe(customSessionId);
+      }
+      expect(messages.some((msg) => msg.text === inputValue)).toBe(true);
     },
   );
 

--- a/tests/tests-automations/regression/api/flows/api-run-with-tweaks.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-run-with-tweaks.spec.ts
@@ -1,6 +1,10 @@
-import { readFileSync } from "fs";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import {
+  createRunnableChatFlowViaApi,
+  RUNNABLE_CHAT_FLOW_CHAT_INPUT_DISPLAY_NAME,
+  RUNNABLE_CHAT_FLOW_DEFAULT_INPUT,
+} from "../../../../helpers/flows/create-runnable-chat-flow-via-api";
 
 // Tests the POST /api/v1/run/{flow_id} endpoint with the `tweaks` parameter,
 // which lets callers override flow component configuration at runtime.
@@ -18,11 +22,10 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 // ("you cannot pass a tweak with the same name"), so the tests below omit the
 // top-level input and drive the value purely through the tweak.
 
-// The imported fixture is a Chat Input -> Chat Output flow whose Chat Input has
-// a stored `input_value` default of "Hello".
-const FIXTURE_PATH = "tests/assets/flows/chat-io-ok-trace-fixture.json";
-const CHAT_INPUT_DISPLAY_NAME = "Chat Input";
-const FIXTURE_DEFAULT_INPUT = "Hello";
+// The shared runnable flow is a Chat Input -> Chat Output passthrough whose
+// Chat Input has a stored `input_value` default of "Hello".
+const CHAT_INPUT_DISPLAY_NAME = RUNNABLE_CHAT_FLOW_CHAT_INPUT_DISPLAY_NAME;
+const FIXTURE_DEFAULT_INPUT = RUNNABLE_CHAT_FLOW_DEFAULT_INPUT;
 
 // Minimal shape of the run endpoint response needed to read the output text.
 interface RunResponseBody {
@@ -43,6 +46,7 @@ test.describe("POST /api/v1/run with tweaks", () => {
   let apiKey: string;
   let apiKeyId: string;
   let flowId: string;
+  let deleteFlow: () => Promise<void>;
 
   test.beforeAll(async ({ request }) => {
     bearerToken = await getAuthToken(request);
@@ -57,28 +61,17 @@ test.describe("POST /api/v1/run with tweaks", () => {
     apiKey = keyBody.api_key;
     apiKeyId = keyBody.id;
 
-    // Import the Chat Input -> Chat Output fixture as a runnable flow
-    const fixture = JSON.parse(readFileSync(FIXTURE_PATH, "utf-8"));
-    const flowRes = await request.post("/api/v1/flows/", {
-      headers: { Authorization: bearerToken },
-      data: {
-        name: `Tweaks Test Flow ${Date.now()}`,
-        description: "Chat Input -> Chat Output passthrough for tweaks override tests",
-        data: fixture.data,
-        is_component: false,
-      },
+    // Create the shared Chat Input -> Chat Output passthrough as a runnable flow
+    const flow = await createRunnableChatFlowViaApi(request, {
+      Authorization: bearerToken,
     });
-    expect(flowRes.status()).toBe(201);
-    flowId = (await flowRes.json()).id;
+    flowId = flow.flowId;
+    deleteFlow = flow.deleteFlow;
   });
 
   test.afterAll(async ({ request }) => {
-    if (flowId) {
-      await request
-        .delete(`/api/v1/flows/${flowId}`, {
-          headers: { Authorization: bearerToken },
-        })
-        .catch(() => {});
+    if (deleteFlow) {
+      await deleteFlow();
     }
     if (apiKeyId) {
       await request


### PR DESCRIPTION
## Summary

Introduces a shared helper that creates a *runnable* Chat Input → Chat Output passthrough flow via the REST API, so the `/api/v1/run/{flow_id}` specs can make **semantic** assertions instead of only structural ones. Previously these specs ran an empty flow (`{ nodes: [], edges: [] }`) and could only assert that `outputs` was an array — a semantic regression (backend stops actually executing the flow) would have gone unnoticed.

The premise of the issue (no version-current runnable fixture exists) was already superseded: `chat-io-ok-trace-fixture.json` powers the `@stable` `api-run-with-tweaks.spec.ts`. This PR follows implementation path **(a) static fixture**, centralizing it in a reusable helper.

## Changes

- **New helper** `tests/helpers/flows/create-runnable-chat-flow-via-api.ts` — builds the flow from `chat-io-ok-trace-fixture.json` and returns `{ flowId, deleteFlow }`, plus exported constants for the default input and Chat Input display name. Flow names carry a random suffix to avoid same-millisecond unique-name collisions when parallel specs create flows.
- **`api-run-flow.spec.ts`** — Test 1 now asserts `outputs.length > 0`; Test 2 verifies message persistence under the custom `session_id` via `GET /api/v1/monitor/messages` (polled to tolerate persistence lag); `beforeAll`/`afterAll` use the helper.
- **`api-run-with-tweaks.spec.ts`** — refactored to consume the shared helper (removes duplicated fixture loading and constants).
- **Docs/checklist** — `docs/api/flows/api-run-flow.md` updated (setup, Test 1/2, validation, dependencies), the two "does not cover" bullets tracking this issue removed, `Last validated` bumped to `1.11.x`; new bullet added to `QA-CHECKLIST.md` §1.3.

## Validation

Against `langflowai/langflow-nightly:latest` (`1.11.0.dev19`):

- ✅ `tsc --noEmit` and ESLint clean
- ✅ Impacted specs pass `--repeat-each=5` (30/30)
- ✅ 10/10 clean parallel cross-file runs (stress-tested the unique-name race)
- ✅ False-positive check: deliberately breaking `outputs.length > 0` and the persistence assertion turns both red; reverted

## Review

An independent review caught a parallel-`beforeAll` race (duplicate flow name → HTTP 500) introduced by unifying the flow-name prefix during the refactor. Fixed by adding a random suffix to the flow name (same convention as `setup-blank-flow.ts`) and verified with the 10× parallel stress run above.

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)