### PR TITLE
fix(agent-images): load Simple Agent via canonical helper for Langflow 1.11.0

### DIFF
--- a/docs/core-functionality/llm-agents/general-bugs-agent-images-playground.md
+++ b/docs/core-functionality/llm-agents/general-bugs-agent-images-playground.md
@@ -1,6 +1,6 @@
 # Agent Component — Image Input in Playground
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.11.0
 
 ---
 
@@ -22,8 +22,8 @@ The spec contains **1 test** — `"user must be able to send images in the playg
 
 Requires `OPENAI_API_KEY` (vision-capable `gpt-4o-mini`); skips when the key is absent. OpenAI is used (not Anthropic) so the test actually runs in the weekly workflow, which provides `OPENAI_API_KEY`.
 
-1. Bootstrap and open `All Templates`, then load the **Simple Agent** template
-2. Wait for the agent node's provider entry point to render (`model_model` when a provider is configured, otherwise the `Setup Provider` button), then configure the OpenAI provider via `setupOpenAI(page)` — the centralized path: open `model_model` → `manage-model-providers` → select `provider-item-OpenAI` → fill the `sk-...` key → save → enable model toggles → select `gpt-4o-mini`
+1. Load the **Simple Agent** template via the canonical `SimpleAgentTemplatePage.load({ provider: "openai" })` — it clears existing flows, opens the templates modal through the correct entry point, waits for the canvas to actually load (`canvas_controls_dropdown`), then configures the OpenAI provider. With no explicit model it selects a resilient default (`gpt-4o-mini`, vision-capable on the Agent component)
+2. (Provider setup is part of step 1's `load()` — the centralized path: open `model_model` → `manage-model-providers` → select `provider-item-OpenAI` → fill the `sk-...` key → save → enable model toggles → select model)
 3. Open the Playground (`playground-btn-flow-io`) and wait for `input-chat-playground`
 4. Attach `tests/assets/media/chain.png` via the Playground file input (`[data-testid="input-wrapper"] input[type="file"]`) and confirm the `img[alt="chain.png"]` preview
 5. Clear the input and type `"what is this image?"` with real keystrokes (`pressSequentially`), then click `button-send`
@@ -78,4 +78,5 @@ Requires `OPENAI_API_KEY` (vision-capable `gpt-4o-mini`); skips when the key is 
 
 - **Fixed in issue #312**: the test previously configured the provider through removed in-component testids (`value-dropdown-dropdown_str_agent_llm`, `popover-anchor-input-api_key`). It now delegates to `setupOpenAI(page)`.
 - **Why OpenAI**: the test needs a vision-capable model. It originally used Anthropic, but the weekly workflow only provides `OPENAI_API_KEY`, so an Anthropic-keyed test would always skip in CI and give no weekly signal. `gpt-4o-mini` is vision-capable and runs in the weekly.
-- **1.10.x quirks handled**: (1) the image is attached via `setInputFiles` because the old manual `DataTransfer` drop no longer renders the attachment; (2) the chat input is pre-filled with a sample prompt and the send action reads the component's internal state, so the prompt is typed with `pressSequentially` (a programmatic `.fill()` is ignored); (3) `setupOpenAI` is called only after the agent node's provider entry point renders, so it does not silently no-op on a still-loading canvas.
+- **1.11.0 template-load fix**: the test previously loaded the template with a manual `awaitBootstrapTest` + `side_nav_options_all-templates` + heading click. On Langflow 1.11.0 that path landed on the projects list instead of the flow canvas (post-create navigation race), so the provider entry point never appeared and the test failed at the 30s `model_model`/`Setup Provider` wait. It now uses the canonical `SimpleAgentTemplatePage.load()` (same helper as the other agent/memory specs), which waits for `canvas_controls_dropdown` before returning.
+- **1.10.x quirks handled**: (1) the image is attached via `setInputFiles` because the old manual `DataTransfer` drop no longer renders the attachment; (2) the chat input is pre-filled with a sample prompt and the send action reads the component's internal state, so the prompt is typed with `pressSequentially` (a programmatic `.fill()` is ignored).

--- a/tests/tests-automations/regression/core-functionality/llm-agents/general-bugs-agent-images-playground.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/general-bugs-agent-images-playground.spec.ts
@@ -1,8 +1,7 @@
 import dotenv from "dotenv";
 import path from "path";
 import { expect, test } from "../../../../fixtures/fixtures";
-import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
-import { setupOpenAI } from "../../../../helpers/provider-setup/setup-openai";
+import { SimpleAgentTemplatePage } from "../../../../pages";
 
 test(
   "user must be able to send images in the playground with the agent component",
@@ -16,25 +15,17 @@ test(
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
     }
-    await awaitBootstrapTest(page);
-
-    await page.getByTestId("side_nav_options_all-templates").click();
-    await page.getByRole("heading", { name: "Simple Agent" }).first().click();
-
-    // Wait for the agent node's provider entry point to render before
-    // configuring the provider — otherwise setupOpenAI runs against a
-    // still-loading canvas, finds neither entry point, and silently no-ops.
-    // Unconfigured instance → "Setup Provider" button; configured → model_model.
-    await expect(
-      page
-        .getByTestId("model_model")
-        .or(page.getByRole("button", { name: "Setup Provider" })),
-    ).toBeVisible({ timeout: 30000 });
-
-    // OpenAI gpt-4o-mini (setupOpenAI's default) is vision-capable, so the
-    // multimodal assertion below holds. OpenAI is used (not Anthropic) so the
-    // test actually runs in the weekly workflow, which provides OPENAI_API_KEY.
-    await setupOpenAI(page);
+    // Load the Simple Agent template via the canonical helper, which clears
+    // existing flows, opens the templates modal through the correct entry point,
+    // and waits for the canvas to actually load. The previous manual
+    // side-nav + heading click landed on the projects list (no canvas) on
+    // Langflow 1.11.0, so the provider entry point never appeared.
+    //
+    // load() also runs setupOpenAI; with no explicit model it selects a resilient
+    // default (gpt-4o-mini, vision-capable on the Agent component), so the
+    // multimodal assertion below holds. OpenAI is used (not Anthropic) so the test
+    // runs in the weekly workflow, which provides OPENAI_API_KEY.
+    await new SimpleAgentTemplatePage(page).load({ provider: "openai" });
 
     await page.getByTestId("playground-btn-flow-io").click();
 


### PR DESCRIPTION
## Summary

The `@stable` Agent image/vision test (`general-bugs-agent-images-playground.spec.ts`) **hard-fails on Langflow 1.11.0** — surfaced while validating the 1.11.0 line.

### Root cause
The test loaded the Simple Agent template manually:
```ts
await awaitBootstrapTest(page);
await page.getByTestId("side_nav_options_all-templates").click();
await page.getByRole("heading", { name: "Simple Agent" }).first().click();
```
On 1.11.0 this lands on the **projects list** instead of the flow canvas (post-create navigation race). The agent node's provider entry point (`model_model` / `Setup Provider`) never renders, so the test fails at the 30s wait on line 32 — **before** `setupOpenAI` runs. The error snapshot confirms the projects list (flow cards for "Simple Agent", "Basic Prompting", …), not a canvas.

This is **not** a model-selection problem — the Agent component's dropdown on 1.11.0 still lists `gpt-4o-mini`.

### Fix
Use the canonical `SimpleAgentTemplatePage.load({ provider: "openai" })` — the same helper the other agent/memory specs use. It clears existing flows, opens the templates modal through the correct entry point, and waits for `canvas_controls_dropdown` before returning. `load()` also runs the provider setup; with no explicit model it selects `gpt-4o-mini` (vision-capable on the Agent component), so the multimodal assertion is unchanged.

- Removes the now-unused `awaitBootstrapTest` / `setupOpenAI` imports.
- Updates the spec doc (Last validated: Langflow 1.11.0; documents the template-load fix).

## Validation (Langflow 1.11.0)
- typecheck ✅ · lint ✅ (0 errors) · zero `🚨 Backend Error`
- `--retries=0`: **4/4 passes** (1 + repeat-each=3), ~14s each
- force-fail ✅ — broke the vision regex (`/chain|inkscape|logo/i` → impossible token); failed exactly at the `toContainText` assertion (line 74), reverted, re-passed