### PR TITLE
test(api): add /api/v1/version spec (closes #246)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -81,7 +81,7 @@
 
 #### 1.1 Health Check
 - [x] GET `/health_check` → status 200, db ok → `api-health-check.spec.ts`
-- [-] GET `/api/v1/health` → returns uptime and version
+- [x] GET `/api/v1/version` → returns version, main_version, package → `api-version.spec.ts`
 
 #### 1.2 Flow CRUD via API
 - [x] POST `/api/v1/flows/` → creates flow, returns ID → `api/flows/api-flows-crud.spec.ts`

--- a/QA-SCENARIOS-GUIDE.md
+++ b/QA-SCENARIOS-GUIDE.md
@@ -74,6 +74,7 @@
 1. Make a `GET /api/v1/version` request without authentication.
 2. Verify that the status is `200`.
 3. Verify that the body contains `version`, `main_version` and `package` fields.
+4. Make a `POST /api/v1/version` request; verify that the status is `405`.
 
 **Validation:** Version information is present; `package` is `Langflow`. `POST` is rejected with `405`.
 

--- a/QA-SCENARIOS-GUIDE.md
+++ b/QA-SCENARIOS-GUIDE.md
@@ -66,16 +66,16 @@
 
 ---
 
-### 1.1.b GET `/api/v1/health` → returns uptime and version `[-]`
+### 1.1.b GET `/api/v1/version` → returns version, main_version, package `[x]`
 
-**Objective:** Verify that the extended health endpoint returns instance metadata.
+**Objective:** Verify that the version endpoint returns instance metadata.
 
 **Step by step:**
-1. Make a `GET /api/v1/health` request without authentication.
+1. Make a `GET /api/v1/version` request without authentication.
 2. Verify that the status is `200`.
-3. Verify that the body contains `uptime` and `version` fields.
+3. Verify that the body contains `version`, `main_version` and `package` fields.
 
-**Validation:** Version and uptime information are present in the response.
+**Validation:** Version information is present; `package` is `Langflow`. `POST` is rejected with `405`.
 
 ---
 

--- a/docs/api/flows/api-health-check.md
+++ b/docs/api/flows/api-health-check.md
@@ -57,7 +57,7 @@ The spec runs **4 independent tests**, each issuing a single `GET /health_check`
 
 ## What this test does not cover *(optional)*
 - The `chat` field of the body (returned but not asserted on)
-- The unauthenticated `/api/v1/health` endpoint (uptime/version) — covered by a separate spec when added
+- The version endpoint `/api/v1/version` — covered by `api-version.spec.ts`
 - Behavior under degraded states (e.g., DB down) — would require a fixture that intentionally breaks the database
 
 ---

--- a/docs/api/flows/api-version.md
+++ b/docs/api/flows/api-version.md
@@ -32,7 +32,7 @@ The spec runs **5 independent tests**, each issuing a single request to `/api/v1
 1. `GET /api/v1/version`
 2. Assert HTTP status is `200`
 3. Assert `main_version` is a non-empty string
-4. Assert `package === "Langflow"`
+4. Assert `package` is a string containing `langflow` (case-insensitive — accepts both `Langflow` and `Langflow Base`)
 
 **Test 3 — `GET /api/v1/version` response has `content-type: application/json`**
 1. `GET /api/v1/version`
@@ -55,7 +55,7 @@ The spec runs **5 independent tests**, each issuing a single request to `/api/v1
 ## Validation criterion *(required)*
 - All assertions must succeed against a freshly started Langflow instance.
 - The endpoint path is `/api/v1/version` — **not** `/api/v1/health` (which does not exist) and **not** `/health_check` (the uptime probe, covered by `api-health-check.spec.ts`).
-- The exact version value is not asserted (it changes per release); only its shape and the stable `package` identifier are checked.
+- The exact version value is not asserted (it changes per release); only its shape and the `package` identifier (which must contain `langflow`) are checked.
 
 ---
 

--- a/docs/api/flows/api-version.md
+++ b/docs/api/flows/api-version.md
@@ -1,0 +1,77 @@
+# API Version
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+Validates that Langflow's `/api/v1/version` endpoint is available and returns a stable version contract. The endpoint is the canonical way clients, tooling, and this test suite discover which Langflow release is running, so its contract — status code, response body keys, content type, and latency — must remain stable across releases.
+
+If any of these tests fail, version-gated logic (feature detection, release reporting, upgrade checks) breaks silently.
+
+---
+
+## Tags *(required)*
+`@stable` `@release` `@api` `@regression`
+
+---
+
+## Step by step *(required)*
+
+The spec runs **5 independent tests**, each issuing a single request to `/api/v1/version` via Playwright's `request` fixture. No authentication is needed — the endpoint is public.
+
+---
+
+**Test 1 — `GET /api/v1/version` returns 200 with a non-empty `version` string**
+1. `GET /api/v1/version`
+2. Assert HTTP status is `200`
+3. Assert response body has property `version`
+4. Assert `version` is a non-empty string matching `^\d+\.\d+` (semantic-version shape)
+
+**Test 2 — `GET /api/v1/version` reports the Langflow package and `main_version`**
+1. `GET /api/v1/version`
+2. Assert HTTP status is `200`
+3. Assert `main_version` is a non-empty string
+4. Assert `package === "Langflow"`
+
+**Test 3 — `GET /api/v1/version` response has `content-type: application/json`**
+1. `GET /api/v1/version`
+2. Assert HTTP status is `200`
+3. Assert `content-type` header contains `application/json`
+
+**Test 4 — `GET /api/v1/version` responds within 5 seconds**
+1. Capture `start = Date.now()`
+2. `GET /api/v1/version`
+3. Capture elapsed = `Date.now() - start`
+4. Assert HTTP status is `200`
+5. Assert `elapsed < 5000`
+
+**Test 5 — `POST /api/v1/version` returns 405 Method Not Allowed**
+1. `POST /api/v1/version`
+2. Assert HTTP status is `405` (the route is read-only)
+
+---
+
+## Validation criterion *(required)*
+- All assertions must succeed against a freshly started Langflow instance.
+- The endpoint path is `/api/v1/version` — **not** `/api/v1/health` (which does not exist) and **not** `/health_check` (the uptime probe, covered by `api-health-check.spec.ts`).
+- The exact version value is not asserted (it changes per release); only its shape and the stable `package` identifier are checked.
+
+---
+
+## What this test does not cover *(optional)*
+- The specific version number returned (intentionally — it changes every release)
+- The `/api/v1/config` endpoint (feature flags, upload limits) — would be a separate spec
+- Authenticated variants — the endpoint is public and takes no credentials
+
+---
+
+## Preconditions *(optional)*
+- Langflow running and reachable at `PLAYWRIGHT_BASE_URL` (default `http://localhost:7860`)
+- No authentication, API key, or environment variables required
+
+---
+
+## External dependencies *(required)*
+- The Langflow backend route serving `/api/v1/version` — if the path or response keys (`version`, `main_version`, `package`) change, the spec breaks
+- The Langflow process serving the route — the test does not start it

--- a/tests/tests-automations/regression/api/flows/api-version.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-version.spec.ts
@@ -37,7 +37,9 @@ test.describe("API Version", () => {
       expect(body.main_version.length).toBeGreaterThan(0);
 
       expect(body).toHaveProperty("package");
-      expect(body.package).toBe("Langflow");
+      // Accept both distributions: "Langflow" (full) and "Langflow Base"
+      expect(typeof body.package).toBe("string");
+      expect(body.package.toLowerCase()).toContain("langflow");
     },
   );
 

--- a/tests/tests-automations/regression/api/flows/api-version.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-version.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "../../../../fixtures/fixtures";
+
+// The version endpoint is at /api/v1/version and is public (no auth required).
+// It returns: { "version": "1.11.0", "main_version": "1.11.0", "package": "Langflow" }
+// Note: there is no /api/v1/health endpoint — the uptime probe lives at /health_check
+// (covered by api-health-check.spec.ts). This spec covers the version contract.
+
+test.describe("API Version", () => {
+  test(
+    "GET /api/v1/version returns 200 with a non-empty version string",
+    { tag: ["@stable", "@release", "@api", "@regression"] },
+    async ({ request }) => {
+      const response = await request.get("/api/v1/version");
+
+      expect(response.status()).toBe(200);
+
+      const body = await response.json();
+      expect(body).toHaveProperty("version");
+      expect(typeof body.version).toBe("string");
+      expect(body.version.length).toBeGreaterThan(0);
+      // Sanity-check it looks like a semantic version (e.g. 1.11.0)
+      expect(body.version).toMatch(/^\d+\.\d+/);
+    },
+  );
+
+  test(
+    "GET /api/v1/version reports the Langflow package and main_version",
+    { tag: ["@stable", "@release", "@api", "@regression"] },
+    async ({ request }) => {
+      const response = await request.get("/api/v1/version");
+
+      expect(response.status()).toBe(200);
+
+      const body = await response.json();
+      expect(body).toHaveProperty("main_version");
+      expect(typeof body.main_version).toBe("string");
+      expect(body.main_version.length).toBeGreaterThan(0);
+
+      expect(body).toHaveProperty("package");
+      expect(body.package).toBe("Langflow");
+    },
+  );
+
+  test(
+    "GET /api/v1/version response has correct content-type",
+    { tag: ["@stable", "@release", "@api", "@regression"] },
+    async ({ request }) => {
+      const response = await request.get("/api/v1/version");
+
+      expect(response.status()).toBe(200);
+      expect(response.headers()["content-type"]).toContain("application/json");
+    },
+  );
+
+  test(
+    "GET /api/v1/version responds within 5 seconds",
+    { tag: ["@stable", "@release", "@api", "@regression"] },
+    async ({ request }) => {
+      const start = Date.now();
+      const response = await request.get("/api/v1/version");
+      const elapsed = Date.now() - start;
+
+      expect(response.status()).toBe(200);
+      expect(elapsed).toBeLessThan(5000);
+    },
+  );
+
+  test(
+    "POST /api/v1/version returns 405 Method Not Allowed",
+    { tag: ["@stable", "@api", "@regression"] },
+    async ({ request }) => {
+      const response = await request.post("/api/v1/version");
+
+      expect(response.status()).toBe(405);
+    },
+  );
+});


### PR DESCRIPTION
## What & why

Closes #246.

Issue #246 tracked the last `[-]` bullet in **1.1 Health Check** of `QA-CHECKLIST.md`:

> - [-] GET `/api/v1/health` → returns uptime and version

While implementing it I found the bullet's premise is wrong: **`/api/v1/health` does not exist** in Langflow (it returns `{"detail":"Not Found"}`), and **no endpoint returns an `uptime` field**. The real, uncovered endpoint carrying instance metadata is **`GET /api/v1/version`**, which returns:

```json
{ "version": "1.11.0", "main_version": "1.11.0", "package": "Langflow" }
```

So instead of extending `api-health-check.spec.ts` against a non-existent route, this PR covers the real version contract in a dedicated spec. The `/health_check` uptime probe stays covered by `api-health-check.spec.ts` as before.

## Changes

- **New** `tests/tests-automations/regression/api/flows/api-version.spec.ts` — 5 `@stable` tests:
  - `GET /api/v1/version` → 200 + non-empty `version` string (semver shape `^\d+\.\d+`)
  - reports `main_version` (string) and `package` (contains `langflow`, case-insensitive — accepts both `Langflow` and `Langflow Base`)
  - `content-type: application/json`
  - responds within 5s
  - `POST /api/v1/version` → `405` (route is read-only)
- **New** `docs/api/flows/api-version.md` — spec doc, all mandatory sections, `Last validated: 1.11.x`
- `QA-CHECKLIST.md` + `QA-SCENARIOS-GUIDE.md` — retarget the `1.1` item from `/api/v1/health` to `/api/v1/version`, flip `[-]` → `[x]`
- `docs/api/flows/api-health-check.md` — "not covered" note now points to the new spec

## Divergence from issue scope

The issue's deliverables named `api-health-check.spec.ts` and an `uptime` field. Both are dropped on purpose: there is no `/api/v1/health` and no uptime field to assert. The underlying goal — cover the instance-metadata endpoint and close the `1.1` bullet — is met.

## Validation

Followed the full validation process (CONTRIBUTING.md):
- Ran with `--trace=on` — 5/5 pass
- Forced-failure check: a negative copy with all 5 assertions inverted failed 5/5 (no false positives), then deleted
- No `🚨 Backend Error` / `🚨 Flow Error` logged
- `tsc --noEmit` clean, ESLint 0 errors
- Checklist bullet flipped to `[x]`
