### PR TITLE
test(agent): add model connection-isolation spec for Langflow 1.11

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -222,7 +222,7 @@
 #### 3.5 Agent (Component)
 - [-] Agent component displayed on canvas with default settings
 - [ ] Configure system prompt in Agent component → `agent-system-prompt.spec.ts`
-- [ ] Configure model provider directly in Agent component → `agent-provider-field-isolation.spec.ts`
+- [ ] Configure model provider directly in Agent component
 
 #### 3.6 Loop Component
 - [x] Loop component renders on canvas with title and run button → `core-components/loop-component-regression.spec.ts`
@@ -323,7 +323,7 @@
 - [ ] Agent stops when maximum number of iterations is reached → `agent-max-iterations.spec.ts`
 - [ ] Agent with multiple configured tools executes correctly → `agent-multi-tool-selection.spec.ts`
 - [ ] Agent with configured timeout respects the limit
-- [ ] Switch provider in Agent → previous provider fields do not persist → `agent-provider-field-isolation.spec.ts`
+- [x] Connecting an external model in Agent drops the prior model selection (connection-mode isolation, prevents stale provider config) → `llm-agents/agent-model-connection-isolation.spec.ts`
 - [ ] Flow with Agent saved and reopened → settings preserved → `agent-config-persistence.spec.ts`
 - [ ] max_tokens truncates response as configured → `agent-max-tokens.spec.ts`
 - [ ] reasoning_effort field appears/disappears based on selected model → `agent-reasoning-effort.spec.ts`

--- a/QA-SCENARIOS-GUIDE.md
+++ b/QA-SCENARIOS-GUIDE.md
@@ -699,7 +699,7 @@
 
 ## 13. Core Components — Agent
 
-**Files:** `agent-reasoning-steps.spec.ts`, `agent-system-prompt.spec.ts`, `agent-provider-field-isolation.spec.ts`, `agent-config-persistence.spec.ts`, `agent-max-iterations.spec.ts`, `agent-max-tokens.spec.ts`, `agent-reasoning-effort.spec.ts`, `agent-input-sources.spec.ts`, `agent-structured-output.spec.ts`, `agent-empty-refusal-response.spec.ts`, `agent-current-date-tool.spec.ts`, `agent-parse-error-behavior.spec.ts`, `agent-multimodal-image-input.spec.ts`
+**Files:** `agent-reasoning-steps.spec.ts`, `agent-system-prompt.spec.ts`, `agent-model-connection-isolation.spec.ts`, `agent-config-persistence.spec.ts`, `agent-max-iterations.spec.ts`, `agent-max-tokens.spec.ts`, `agent-reasoning-effort.spec.ts`, `agent-input-sources.spec.ts`, `agent-structured-output.spec.ts`, `agent-empty-refusal-response.spec.ts`, `agent-current-date-tool.spec.ts`, `agent-parse-error-behavior.spec.ts`, `agent-multimodal-image-input.spec.ts`
 
 ---
 
@@ -718,21 +718,19 @@
 
 ---
 
-### 13.2 Switch provider in Agent — previous provider fields do not persist `[ ]`
+### 13.2 Connecting an external model in Agent drops the prior model selection `[x]`
 
-**File:** `agent-provider-field-isolation.spec.ts`
+**File:** `agent-model-connection-isolation.spec.ts`
 
-**Objective:** Ensure that when switching providers, fields exclusive to the previous provider (e.g.: `project_id` from WatsonX) disappear and the API key is not pre-filled with the previous value.
+**Objective:** Ensure connection-mode isolation in the Langflow 1.11 unified model picker: choosing "Connect other models" clears the previously selected model (and the node's secret fields), so a stale provider configuration cannot reach a backend run. The 1.11 Agent has no inline per-provider credential fields (credentials are global, under Settings → Model Providers), so the older "switch provider → provider-specific fields disappear" scenario no longer applies.
 
 **Step by step:**
-1. Load "Simple Agent" template.
-2. Select WatsonX provider in the Agent — verify that `base_url_ibm_watsonx` and `project_id` are visible.
-3. Switch to OpenAI provider.
-4. Verify that `base_url_ibm_watsonx` and `project_id` are **not visible**.
-5. Verify that the `api_key` field is empty (not pre-filled).
-6. Switch back to WatsonX — verify that the previous `project_id` value **does not persist**.
+1. Load "Simple Agent" template with a configured provider/model (resolved from `models.json` / `MODEL_TEST_ID`).
+2. Confirm the model picker (`model_model`) shows a concrete model name in `value-dropdown-model_model` (not the "Select a model" placeholder).
+3. Open the picker and click the `connect-other-models` footer button.
+4. Verify `value-dropdown-model_model` now reads "Connect other models" — the connection-mode label that replaces the prior model selection.
 
-**Validation:** Provider-specific fields appear and disappear correctly; no value leakage between providers.
+**Validation:** The previously selected model is dropped and the trigger reflects connection mode; the prior provider selection cannot leak into execution.
 
 ---
 

--- a/docs/core-functionality/llm-agents/agent-model-connection-isolation.md
+++ b/docs/core-functionality/llm-agents/agent-model-connection-isolation.md
@@ -22,7 +22,7 @@ This is a pure UI/state assertion — no LLM call is made.
 
 ## Step-by-step *(required)*
 
-1. Resolve a single `{ provider, model }` target: `MODEL_TEST_ID` wins; otherwise the first model of `MODEL_TEST_PROVIDER` (or of the first env-configured provider) is read from `helpers/provider-setup/data/models.json`. Skip the test if no provider has its env keys configured.
+1. Resolve a single `{ provider, model }` target: `MODEL_TEST_ID` wins (its provider is inferred from `models.json`, falling back to `MODEL_TEST_PROVIDER`); otherwise the first model of `MODEL_TEST_PROVIDER` (or of the first env-configured provider) is read from `helpers/provider-setup/data/models.json`. The test skips with an accurate reason when no provider resolves — either no provider has its env keys configured, or a given `MODEL_TEST_ID` could not be mapped to a provider.
 2. `SimpleAgentTemplatePage.load({ provider, model })` — loads the Simple Agent template, configures the provider via the unified model picker (Manage Model Providers → API key → enable models) and selects the resolved model. `MODEL_NOT_AVAILABLE` is caught and turned into a skip.
 3. Assert the picker trigger `model_model` is visible.
 4. Capture the selected model label from `value-dropdown-model_model` and assert it is non-empty and not the `"Select a model"` placeholder (a concrete model is selected — the precondition).

--- a/docs/core-functionality/llm-agents/agent-model-connection-isolation.md
+++ b/docs/core-functionality/llm-agents/agent-model-connection-isolation.md
@@ -1,0 +1,71 @@
+# Agent Model Connection Isolation
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+Validates that selecting **"Connect other models"** in the Agent component's model picker isolates the node from its previously selected provider/model — the node drops the concrete model selection and enters connection mode, so a stale provider configuration cannot be used in a backend run when an external `LanguageModel` is meant to be wired in instead.
+
+In Langflow 1.11 the Agent no longer exposes inline per-provider credential fields on the node (provider credentials are global, managed under **Settings → Model Providers** via the unified model picker). The only node-level "provider field isolation" left is the connection-mode clear performed by `useModelConnectionLogic`: it resets the `model` field value to `[]` and wipes every `password` / `SecretStrInput` field on the node. The visible effect is that the picker trigger stops showing the previously selected model name and instead shows the "Connect other models" connection-mode label.
+
+This is a pure UI/state assertion — no LLM call is made.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@components` `@agents` `@model-provider`
+
+---
+
+## Step-by-step *(required)*
+
+1. Resolve a single `{ provider, model }` target: `MODEL_TEST_ID` wins; otherwise the first model of `MODEL_TEST_PROVIDER` (or of the first env-configured provider) is read from `helpers/provider-setup/data/models.json`. Skip the test if no provider has its env keys configured.
+2. `SimpleAgentTemplatePage.load({ provider, model })` — loads the Simple Agent template, configures the provider via the unified model picker (Manage Model Providers → API key → enable models) and selects the resolved model. `MODEL_NOT_AVAILABLE` is caught and turned into a skip.
+3. Assert the picker trigger `model_model` is visible.
+4. Capture the selected model label from `value-dropdown-model_model` and assert it is non-empty and not the `"Select a model"` placeholder (a concrete model is selected — the precondition).
+5. Open the picker (`model_model`) and click the `connect-other-models` footer button. If that option is not present (no compatible external `LanguageModel` type registered), skip.
+6. Assert `value-dropdown-model_model` now reads `"Connect other models"` and no longer contains the previously selected model name.
+
+---
+
+## Validation criteria *(required)*
+
+- Before the action, the Agent's model picker shows a concrete model name (not the placeholder).
+- After choosing "Connect other models", the picker trigger displays the `"Connect other models"` connection-mode label.
+- The previously selected model name is no longer present in the trigger, confirming the prior selection was dropped (and, per `useModelConnectionLogic`, the model value and secret fields were cleared).
+
+---
+
+## External dependencies *(required)*
+
+- `src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/` — renders the `model_model` trigger, the `value-dropdown-model_model` value span, and the `connect-other-models` footer button. Renaming these `data-testid` attributes breaks the test.
+- `src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/hooks/useModelConnectionLogic.ts` — the connection-mode clear logic under test (resets `model` to `[]`, wipes `password`/`SecretStrInput` fields). Changing this behavior changes the expected outcome.
+- `src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/components/ModelTrigger.tsx` — derives the displayed label; the `"Connect other models"` label in connection mode is the assertion's anchor.
+- `tests/helpers/provider-setup/` and `data/models.json` — provider setup and the model source of truth (populated by `collect-models`).
+
+---
+
+## What this test does not cover *(optional)*
+
+- Actually wiring an external `LanguageModel` component and running the flow with it.
+- Backend-level verification that the cleared secret fields are absent from the persisted/executed config (asserted only indirectly via the UI label change).
+- Provider credential configuration correctness (covered by the provider-setup helpers and provider-management specs).
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and accessible at `PLAYWRIGHT_BASE_URL`.
+- At least one provider has its env keys set (e.g. `OPENAI_API_KEY`). A real API key is needed to configure the provider so the picker lists models, but no LLM call is made.
+- `models.json` populated by `collect-models` (otherwise the resolved model may be `undefined` and `setup-openai`'s default is used).
+
+---
+
+## Notes *(optional)*
+
+- In connection mode, `selectedModel` is intentionally overridden to `{ name: "Connect other models" }` in `modelInputComponent/index.tsx`, which is why the trigger shows that label rather than the empty `"Select a model"` placeholder.
+- Run with `--workers=1`: `SimpleAgentTemplatePage.load()` deletes all flows before loading the template, so parallel agent specs would wipe each other's flows. The spec also sets file-level serial mode.
+- The spec is provider-agnostic and runs a single target on purpose — the connection-mode clear does not vary by provider, so looping every model would add cost without coverage.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-model-connection-isolation.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-model-connection-isolation.spec.ts
@@ -59,10 +59,20 @@ function resolveTarget(): LoadSimpleAgentOptions | undefined {
 const options = resolveTarget();
 const provider = options?.provider;
 
-// Build an accurate skip reason: a MODEL_TEST_ID that maps to no provider is a
-// different (and more confusing) failure than simply having no env keys set.
+// Build an accurate skip reason. Each case gets its own message so a skip is
+// never mistaken for a different failure:
+//   1. provider resolved but its env keys are missing — without this it would
+//      hard-fail in SimpleAgentTemplatePage.load() ("Missing env vars for
+//      provider"); this happens when MODEL_TEST_ID maps to a provider that has
+//      no key configured, since resolveTarget() does not gate that branch on
+//      hasProviderEnvKeys.
+//   2. a MODEL_TEST_ID that maps to no provider (absent from models.json and
+//      MODEL_TEST_PROVIDER unset) — more confusing than simply having no keys.
+//   3. no provider has its env keys configured at all.
 const skipReason = provider
-  ? undefined
+  ? hasProviderEnvKeys(provider)
+    ? undefined
+    : `Provider "${provider}" is missing env vars: ${missingProviderEnvKeys(provider).join(", ")}`
   : process.env.MODEL_TEST_ID
     ? `MODEL_TEST_ID="${process.env.MODEL_TEST_ID}" could not be mapped to a provider — ` +
       `it is absent from models.json and MODEL_TEST_PROVIDER is unset.`
@@ -81,8 +91,10 @@ async function loadAgent(page: Page): Promise<void> {
   }
 }
 
-// SimpleAgentTemplatePage.load() deletes all flows before loading the template,
-// so file-level serial mode keeps this from racing with sibling specs.
+// SimpleAgentTemplatePage.load() deletes all flows before loading the template.
+// Serial mode only serializes the blocks within this file; isolation from
+// sibling agent specs that also wipe flows relies on running with --workers=1
+// (required by this folder's CLAUDE.md).
 test.describe.configure({ mode: "serial" });
 
 test.describe("Agent Model Connection Isolation", () => {

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-model-connection-isolation.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-model-connection-isolation.spec.ts
@@ -59,6 +59,17 @@ function resolveTarget(): LoadSimpleAgentOptions | undefined {
 const options = resolveTarget();
 const provider = options?.provider;
 
+// Build an accurate skip reason: a MODEL_TEST_ID that maps to no provider is a
+// different (and more confusing) failure than simply having no env keys set.
+const skipReason = provider
+  ? undefined
+  : process.env.MODEL_TEST_ID
+    ? `MODEL_TEST_ID="${process.env.MODEL_TEST_ID}" could not be mapped to a provider — ` +
+      `it is absent from models.json and MODEL_TEST_PROVIDER is unset.`
+    : `No provider has its env keys configured (need one of: ${Object.keys(providerConfigMap)
+        .map((p) => missingProviderEnvKeys(p as Provider).join("/"))
+        .join(" | ")})`;
+
 async function loadAgent(page: Page): Promise<void> {
   try {
     // `options` is guaranteed defined here — the test skips earlier when no
@@ -79,12 +90,7 @@ test.describe("Agent Model Connection Isolation", () => {
     "selecting 'Connect other models' clears the previously selected model",
     { tag: ["@stable", "@regression", "@components", "@agents", "@model-provider"] },
     async ({ page }) => {
-      test.skip(
-        !provider,
-        `No provider has its env keys configured (need one of: ${Object.keys(providerConfigMap)
-          .map((p) => missingProviderEnvKeys(p as Provider).join("/"))
-          .join(" | ")})`,
-      );
+      test.skip(!!skipReason, skipReason ?? "");
 
       const modelTrigger = page.getByTestId("model_model");
       const modelValue = page.getByTestId("value-dropdown-model_model");
@@ -125,12 +131,11 @@ test.describe("Agent Model Connection Isolation", () => {
         // useModelConnectionLogic resets the model field value to [] and wipes
         // any provider-specific credential fields. The trigger then reflects
         // connection mode by displaying the "Connect other models" label
-        // instead of the previously selected concrete model — so the prior
-        // provider selection cannot leak into a backend run.
+        // instead of the previously selected concrete model (`initialModel`) —
+        // so the prior provider selection cannot leak into a backend run.
         await expect(modelValue).toHaveText("Connect other models", {
           timeout: 10000,
         });
-        expect(await modelValue.innerText()).not.toContain(initialModel);
       });
     },
   );

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-model-connection-isolation.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-model-connection-isolation.spec.ts
@@ -1,0 +1,137 @@
+import * as dotenv from "dotenv";
+import path from "path";
+import fs from "fs";
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
+import {
+  hasProviderEnvKeys,
+  missingProviderEnvKeys,
+  providerConfigMap,
+  type Provider,
+} from "../../../../helpers/provider-setup";
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
+}
+
+interface ModelRecord {
+  provider: string;
+  model: string;
+}
+
+// Resolve a single { provider, model } to drive the test. The behavior under
+// test (connection-mode isolation) is provider-agnostic, so one configured
+// provider is enough — there is no value in looping every model. Priority:
+// MODEL_TEST_ID > first model of MODEL_TEST_PROVIDER in models.json >
+// first model of the first env-configured provider in models.json. The model
+// is taken from models.json (populated by collect-models) so the spec follows
+// the same source of truth as the rest of the folder, rather than relying on
+// setup-openai's hardcoded default. MODEL_NOT_AVAILABLE is handled at load.
+function resolveTarget(): LoadSimpleAgentOptions | undefined {
+  let models: ModelRecord[] = [];
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/models.json",
+  );
+  if (fs.existsSync(jsonPath)) {
+    models = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
+  }
+
+  if (process.env.MODEL_TEST_ID) {
+    const record = models.find((m) => m.model === process.env.MODEL_TEST_ID);
+    const provider = (record?.provider ??
+      process.env.MODEL_TEST_PROVIDER) as Provider | undefined;
+    return { provider, model: process.env.MODEL_TEST_ID };
+  }
+
+  const envProvider = process.env.MODEL_TEST_PROVIDER as Provider | undefined;
+  const provider =
+    envProvider && hasProviderEnvKeys(envProvider)
+      ? envProvider
+      : (Object.keys(providerConfigMap) as Provider[]).find(hasProviderEnvKeys);
+  if (!provider) return undefined;
+
+  const model = models.find((m) => m.provider === provider)?.model;
+  return { provider, model };
+}
+
+const options = resolveTarget();
+const provider = options?.provider;
+
+async function loadAgent(page: Page): Promise<void> {
+  try {
+    // `options` is guaranteed defined here — the test skips earlier when no
+    // provider resolves. The `?? {}` only satisfies the type checker.
+    await new SimpleAgentTemplatePage(page).load(options ?? {});
+  } catch (e: any) {
+    if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
+    throw e;
+  }
+}
+
+// SimpleAgentTemplatePage.load() deletes all flows before loading the template,
+// so file-level serial mode keeps this from racing with sibling specs.
+test.describe.configure({ mode: "serial" });
+
+test.describe("Agent Model Connection Isolation", () => {
+  test(
+    "selecting 'Connect other models' clears the previously selected model",
+    { tag: ["@stable", "@regression", "@components", "@agents", "@model-provider"] },
+    async ({ page }) => {
+      test.skip(
+        !provider,
+        `No provider has its env keys configured (need one of: ${Object.keys(providerConfigMap)
+          .map((p) => missingProviderEnvKeys(p as Provider).join("/"))
+          .join(" | ")})`,
+      );
+
+      const modelTrigger = page.getByTestId("model_model");
+      const modelValue = page.getByTestId("value-dropdown-model_model");
+
+      await test.step("load Simple Agent with a configured provider and model", async () => {
+        await loadAgent(page);
+        // The provider setup helper selects a concrete model, so the picker
+        // trigger must be present with a real model name as its value.
+        await expect(modelTrigger).toBeVisible({ timeout: 30000 });
+      });
+
+      let initialModel = "";
+
+      await test.step("capture the selected model as the precondition", async () => {
+        initialModel = (await modelValue.innerText()).trim();
+        expect(
+          initialModel.length,
+          "Agent should have a model selected before the test acts",
+        ).toBeGreaterThan(0);
+        expect(initialModel).not.toBe("Select a model");
+      });
+
+      await test.step("choose 'Connect other models' from the model picker", async () => {
+        await modelTrigger.click();
+        const connectOption = page.getByTestId("connect-other-models");
+        const optionVisible = await connectOption
+          .waitFor({ state: "visible", timeout: 10000 })
+          .then(() => true)
+          .catch(() => false);
+        test.skip(
+          !optionVisible,
+          "'Connect other models' option is not available — no compatible external LanguageModel type registered",
+        );
+        await connectOption.click();
+      });
+
+      await test.step("the previous model is dropped for connection mode (isolation)", async () => {
+        // useModelConnectionLogic resets the model field value to [] and wipes
+        // any provider-specific credential fields. The trigger then reflects
+        // connection mode by displaying the "Connect other models" label
+        // instead of the previously selected concrete model — so the prior
+        // provider selection cannot leak into a backend run.
+        await expect(modelValue).toHaveText("Connect other models", {
+          timeout: 10000,
+        });
+        expect(await modelValue.innerText()).not.toContain(initialModel);
+      });
+    },
+  );
+});


### PR DESCRIPTION
## Type

- [x] `feat` — new test or new helper/page object

---

## What this PR does

Adds an E2E spec validating **connection-mode isolation** in the Langflow 1.11 Agent model picker.

The checklist item this came from (`6.2`: *"Switch provider in Agent → previous provider fields do not persist"*) was written for the **old** Agent design, where the node exposed inline per-provider credential fields. In 1.11 the Agent uses the unified model picker and credentials are global (Settings → Model Providers), so there are no inline provider fields to leak. The only node-level isolation left is what `useModelConnectionLogic` does when you choose **"Connect other models"**: it resets the `model` value to `[]` and wipes every `password` / `SecretStrInput` field, so a stale provider config can't reach a backend run. The picker trigger then shows the `"Connect other models"` connection-mode label instead of the previously selected model.

This PR reframes that checklist item to the current behavior and validates it.

---

## Tests covered

| # | Test | What it validates |
|---|---|---|
| 1 | `agent-model-connection-isolation.spec.ts` | Choosing "Connect other models" in the Agent model picker drops the previously selected concrete model (and, per `useModelConnectionLogic`, clears the node's secret fields) — the trigger flips from the model name to the `"Connect other models"` connection-mode label. Guards against a regression where a stale provider/model selection could survive into execution. |

---

## How the tests were built

Pure UI assertion, no LLM call. The spec resolves a single `{ provider, model }` target from `models.json` (`MODEL_TEST_ID` / `MODEL_TEST_PROVIDER` aware) rather than relying on `setup-openai`'s hardcoded default — the connection-mode clear is provider-agnostic, so one configured provider is enough and looping every model would add cost without coverage. The assertion anchors on the i18n label `"Connect other models"` that `modelInputComponent` deliberately renders as `selectedModel` while in connection mode.

---

## Dependencies

- One provider with its env keys set (e.g. `OPENAI_API_KEY`) so the picker lists models — a real key is needed to configure the provider, but **no LLM call is made**.
- `models.json` populated by `collect-models`.
- Runs `--workers=1` / file-level serial mode: `SimpleAgentTemplatePage.load()` deletes all flows before loading the template.

---

## What this PR does not cover

- Actually wiring an external `LanguageModel` and running the flow with it.
- Backend-level verification that the cleared secret fields are absent from the executed config (asserted indirectly via the UI label change).
- The model-toggle behavior in Settings → Model Providers (tracked separately as a future spec).

---

## Known limitations

- `setup-openai.ts` falls back to a hardcoded `gpt-4o-mini` when no model is supplied; on current nightlies (`gpt-5.5-*`) that model no longer exists. This spec sidesteps it by resolving the model from `models.json`, but the shared helper's hardcoded default is a pre-existing fragility for the whole agent suite — out of scope here, worth a dedicated fix.

---

## Validation

Followed the full validation process (CONTRIBUTING.md):

- [x] Ran the test in isolation with `--trace=on` and verified steps in the report
- [x] Forced a failure to confirm it is not a false positive (skipped the "Connect other models" click → trigger stayed `gpt-5.4`, assertion failed `Expected: "Connect other models", Received: "gpt-5.4"`; reverted)
- [ ] Ran in `--debug` mode — substituted by the `--trace=on` walkthrough (interactive inspector not run)
- [x] Confirmed there are no backend errors (`🚨 Backend Error:`) in the output
- [x] Updated `QA-CHECKLIST.md` (bullet `[x]`; derived Coverage Summary / Phase 0 left for the `update-coverage-summary.yml` workflow)
- [x] Updated `QA-SCENARIOS-GUIDE.md` with the scenario in human language (§13.2 reframed to 1.11 behavior)

`tsc --noEmit` clean; ESLint 0 errors (4 warnings, identical to the sibling `agent-component-regression.spec.ts` accepted patterns).
