### PR TITLE
test(model-providers): add model enable/disable toggle spec

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -393,6 +393,8 @@
 - [-] Model Input component
 - [-] Add new provider via modal
 - [-] Remove API key from existing provider
+- [x] Per-model enable/disable toggle changes immediately and persists across reopen → `llm-agents/model-provider-model-toggle.spec.ts`
+- [x] Disabling a model in Settings removes it from a component model dropdown; re-enabling restores it → `llm-agents/model-provider-model-toggle.spec.ts`
 
 #### 7.6 Open-Source Providers
 - [ ] Configure and execute flow with Ollama (local model)

--- a/docs/core-functionality/llm-agents/model-provider-model-toggle.md
+++ b/docs/core-functionality/llm-agents/model-provider-model-toggle.md
@@ -1,0 +1,91 @@
+# Model Provider Model Toggle
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+Validates the per-model **enable/disable toggles** in **Settings → Model Providers** (the `ModelSelection` UI, shared by the settings page and the provider modal through `ModelProvidersContent`). Two behaviors are covered:
+
+1. **Immediate change + persistence** — toggling a model updates the switch optimistically (immediately) and the change is persisted by the debounced `POST /api/v1/models/enabled_models` write (`useUpdateEnabledModels`, debounced ~1s by `useModelToggleQueue`). Leaving and reopening Model Providers reflects the persisted state (read back from `useGetEnabledModels`).
+2. **Propagation to component dropdowns** — disabling a model in Settings removes it from the model dropdown of an intelligent component (the Agent's `model_model` picker) on the canvas; re-enabling brings it back. This is the cross-cutting effect driven by `useRefreshModelInputs`.
+
+Both are pure UI/state assertions — no LLM call is made. No prior spec covered these toggles: `model-provider-modal-actions.spec.ts` only covers entering/removing API keys, and the only existing toggle tests are upstream Langflow unit tests, not this suite.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@components` `@agents` `@model-provider`
+
+- Test 1 (settings-only): `@stable` `@regression` `@components` `@model-provider`
+- Test 2 (canvas propagation): adds `@agents`
+
+---
+
+## Step-by-step *(required)*
+
+Both tests resolve a single provider — `MODEL_TEST_PROVIDER` when its env keys are set, otherwise the first provider in `providerConfigMap` with env keys configured. The file skips with an accurate reason when no provider has its env keys configured. The provider's display name (`provider-item-OpenAI`, etc.) comes from `provider-config.ts`.
+
+### Test 1 — toggle changes immediately and persists across reopen
+
+1. `SimpleAgentTemplatePage.load({ provider })` — configures the provider's API key globally and enables all its models (the known baseline). `MODEL_NOT_AVAILABLE` is caught and turned into a skip.
+2. Navigate to **Settings → Model Providers**, expand the provider (`provider-item-...`), and wait for `model-provider-selection` and `llm-models-section`.
+3. Read the first visible `llm-toggle-<model>` to derive a model name, filter the list to it via `model-search-input`, and assert it is enabled (`aria-checked="true"`).
+4. Disable it: click the toggle, assert `aria-checked="false"` immediately (optimistic), and wait for the `POST .../enabled_models` response (debounced persistence flush).
+5. Reload the app, reopen Model Providers, re-expand the provider, search for the same model and assert its toggle is still `aria-checked="false"` (persisted).
+6. Restore the baseline: re-enable the model and assert `aria-checked="true"`.
+
+### Test 2 — disabling a model removes it from a component dropdown
+
+1. `SimpleAgentTemplatePage.load({ provider })` — same baseline (all models enabled, a model selected on the Agent). Capture the flow URL.
+2. Open the Agent's `model_model` picker, collect the option names (`[data-testid$="-option"]`), and pick a model that is **not** the currently selected one (avoids entangling with selection-reset logic). Skip if the provider exposes only one model.
+3. In **Settings → Model Providers**, disable that target model (immediate + persisted, as in Test 1).
+4. Return to the flow (`page.goto(flowUrl)`), open the `model_model` picker, and assert the target model option has count `0` (anchored exact-match regex so substrings like `gpt-4o` vs `gpt-4o-mini` don't collide).
+5. Re-enable the target model in Settings, return to the flow, and assert the option reappears (count `1`).
+
+---
+
+## Validation criteria *(required)*
+
+- Toggling a model flips `aria-checked` immediately (optimistic update).
+- A `POST /api/v1/models/enabled_models` is sent after the debounce; reopening Model Providers reflects the persisted state.
+- A disabled model disappears from the Agent's `model_model` dropdown; re-enabling restores it.
+- The baseline is restored at the end of each test (model left enabled) so sibling specs are unaffected.
+
+---
+
+## External dependencies *(required)*
+
+- `src/frontend/src/modals/modelProviderModal/components/ModelSelection.tsx` — renders the `llm-toggle-<model_name>` / `embeddings-toggle-<model_name>` switches, the `llm-models-section` / `embeddings-models-section` containers, and `model-search-input`. Renaming these `data-testid` attributes breaks the test.
+- `src/frontend/src/modals/modelProviderModal/components/ModelProvidersContent.tsx` and `pages/SettingsPage/pages/ModelProvidersPage/index.tsx` — host the model selection panel and the `provider-item-...` / `model-provider-selection` testids.
+- `src/frontend/src/modals/modelProviderModal/hooks/useModelToggleQueue.ts` — the optimistic queue + ~1s debounced `POST .../enabled_models` write under test. Changing the endpoint or debounce affects the persistence wait.
+- `src/frontend/src/hooks/use-refresh-model-inputs.ts` — refreshes component model dropdowns when toggles change (the propagation behavior in Test 2).
+- `src/frontend/src/components/core/parameterRenderComponent/components/modelInputComponent/` — renders the Agent's `model_model` trigger, `value-dropdown-model_model` value span, and the `-option` dropdown entries.
+- `tests/helpers/provider-setup/` and `data/models.json` — provider setup and model source of truth (populated by `collect-models`).
+
+---
+
+## What this test does not cover *(optional)*
+
+- Embedding-model toggles (`embeddings-toggle-...`) — only LLM toggles are exercised.
+- The provider modal entry point (`ModelProviderModal` with `onFlushRef`) — only the Settings page entry point is tested, where persistence relies on the debounce rather than a flush-on-close.
+- Backend correctness of the enabled-models payload beyond the round-trip UI assertion.
+- Deprecated-model rows (collapsed under `*-deprecated-disclosure`).
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and accessible at `PLAYWRIGHT_BASE_URL`.
+- At least one provider has its env keys set (e.g. `OPENAI_API_KEY`). A real API key is required to configure the provider so models are listed, but no LLM call is made.
+- Run with `--workers=1`: `SimpleAgentTemplatePage.load()` deletes all flows before loading the template, so parallel agent specs would wipe each other's flows. The spec also sets file-level serial mode.
+
+---
+
+## Notes *(optional)*
+
+- Models are only listed once the provider has an API key configured — the spec cannot run standalone without provider setup.
+- The `model-search-input` filter is used before reading a toggle so the target row is always rendered on-screen, regardless of how many models the provider exposes.
+- The Settings page mounts `ModelProvidersContent` without `onFlushRef`, so persistence depends on the ~1s debounce; the test waits for the `POST` response rather than a fixed timeout.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-model-toggle.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-model-toggle.spec.ts
@@ -1,0 +1,244 @@
+import * as dotenv from "dotenv";
+import path from "path";
+import type { Locator, Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { SimpleAgentTemplatePage } from "../../../../pages";
+import { navigateSettingsPages } from "../../../../helpers/ui/go-to-settings";
+import {
+  hasProviderEnvKeys,
+  missingProviderEnvKeys,
+  providerConfigMap,
+  type Provider,
+} from "../../../../helpers/provider-setup";
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
+}
+
+// Resolve the provider to drive the test. The behavior under test (per-model
+// enable/disable toggles in Settings → Model Providers) is provider-agnostic,
+// so a single env-configured provider is enough. Priority: MODEL_TEST_PROVIDER
+// (when its env keys are set) > first provider in providerConfigMap with env
+// keys configured.
+const envProvider = process.env.MODEL_TEST_PROVIDER as Provider | undefined;
+const provider: Provider | undefined =
+  envProvider && hasProviderEnvKeys(envProvider)
+    ? envProvider
+    : (Object.keys(providerConfigMap) as Provider[]).find(hasProviderEnvKeys);
+
+const skipReason = provider
+  ? undefined
+  : `No provider has its env keys configured (need one of: ${Object.keys(
+      providerConfigMap,
+    )
+      .map((p) => missingProviderEnvKeys(p as Provider).join("/"))
+      .join(" | ")})`;
+
+// The `provider-item-...` testid carries the provider's display name
+// ("OpenAI", "Anthropic", …), which is the single source of truth in
+// provider-config.ts.
+const providerItemTestId = provider
+  ? providerConfigMap[provider].providerTestId
+  : "";
+
+const ENABLED_MODELS_ENDPOINT = "/api/v1/models/enabled_models";
+
+// Load the Simple Agent template with the configured provider. This configures
+// the provider's API key globally and enables all of its models — the known
+// baseline both tests start from. MODEL_NOT_AVAILABLE (a model present in
+// models.json but absent from the picker) is turned into a skip.
+async function loadAgentWithProvider(page: Page): Promise<void> {
+  try {
+    await new SimpleAgentTemplatePage(page).load({ provider });
+  } catch (e: any) {
+    if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
+    throw e;
+  }
+}
+
+// Navigate to Settings → Model Providers and expand the configured provider so
+// its model toggles render. Clicking the provider item toggles its selection,
+// so this assumes the panel was freshly navigated (nothing selected yet).
+async function openProviderModelList(page: Page): Promise<void> {
+  await navigateSettingsPages(page, "Settings", "Model Providers");
+  await expect(page.getByTestId("settings_menu_header").last()).toContainText(
+    "Model Providers",
+    { timeout: 10000 },
+  );
+  const providerItem = page.getByTestId(providerItemTestId);
+  await providerItem.waitFor({ state: "visible", timeout: 10000 });
+  await providerItem.click();
+  await page
+    .getByTestId("model-provider-selection")
+    .waitFor({ state: "visible", timeout: 10000 });
+  await page
+    .getByTestId("llm-models-section")
+    .waitFor({ state: "visible", timeout: 10000 });
+}
+
+// Filter the model list down to a single model via the search field so its
+// toggle is always rendered and on-screen (long provider lists otherwise push
+// rows below the scroll fold). Returns the toggle locator.
+async function toggleForModel(page: Page, modelName: string): Promise<Locator> {
+  const search = page.getByTestId("model-search-input");
+  await search.fill(modelName);
+  const toggle = page.getByTestId(`llm-toggle-${modelName}`);
+  await toggle.waitFor({ state: "visible", timeout: 10000 });
+  return toggle;
+}
+
+// Flip a toggle and wait for the optimistic UI change plus the debounced POST
+// that persists it (useModelToggleQueue debounces the write by 1000ms).
+async function setToggle(
+  page: Page,
+  toggle: Locator,
+  enabled: boolean,
+): Promise<void> {
+  const current = (await toggle.getAttribute("aria-checked")) === "true";
+  if (current === enabled) return;
+  const save = page.waitForResponse(
+    (resp) =>
+      resp.url().includes(ENABLED_MODELS_ENDPOINT) &&
+      resp.request().method() === "POST",
+    { timeout: 15000 },
+  );
+  await toggle.click();
+  // Optimistic update — the switch reflects the new state immediately.
+  await expect(toggle).toHaveAttribute("aria-checked", String(enabled));
+  await save;
+}
+
+// SimpleAgentTemplatePage.load() deletes all flows before loading the template,
+// so sibling agent specs that also wipe flows must not run concurrently — this
+// file is serial and the folder is run with --workers=1.
+test.describe.configure({ mode: "serial" });
+
+test.describe("Model Provider Model Toggle", () => {
+  test(
+    "model toggle changes immediately and persists across reopen",
+    {
+      tag: ["@stable", "@regression", "@components", "@model-provider"],
+    },
+    async ({ page }) => {
+      test.skip(!!skipReason, skipReason ?? "");
+
+      await test.step("configure provider and enable all its models", async () => {
+        await loadAgentWithProvider(page);
+      });
+
+      let modelName = "";
+      let toggle: Locator;
+
+      await test.step("open Model Providers and pick an enabled model", async () => {
+        await openProviderModelList(page);
+        const firstToggle = page
+          .locator('[data-testid^="llm-toggle-"]:visible')
+          .first();
+        await firstToggle.waitFor({ state: "visible", timeout: 10000 });
+        const testId = await firstToggle.getAttribute("data-testid");
+        modelName = (testId ?? "").replace("llm-toggle-", "");
+        expect(modelName.length).toBeGreaterThan(0);
+        toggle = await toggleForModel(page, modelName);
+        await expect(toggle).toHaveAttribute("aria-checked", "true");
+      });
+
+      await test.step("disable the model — change is immediate and persisted", async () => {
+        await setToggle(page, toggle, false);
+      });
+
+      await test.step("reopen Model Providers — disabled state persisted", async () => {
+        await page.goto("/");
+        await openProviderModelList(page);
+        const reopened = await toggleForModel(page, modelName);
+        await expect(reopened).toHaveAttribute("aria-checked", "false");
+
+        // Restore the baseline so the model stays enabled for other specs.
+        await setToggle(page, reopened, true);
+        await expect(reopened).toHaveAttribute("aria-checked", "true");
+      });
+    },
+  );
+
+  test(
+    "disabling a model removes it from a component model dropdown",
+    {
+      tag: ["@stable", "@regression", "@components", "@agents", "@model-provider"],
+    },
+    async ({ page }) => {
+      test.skip(!!skipReason, skipReason ?? "");
+
+      const modelTrigger = page.getByTestId("model_model");
+      const modelValue = page.getByTestId("value-dropdown-model_model");
+      const optionLocator = '[data-testid$="-option"]';
+
+      let flowUrl = "";
+      let targetModel = "";
+
+      await test.step("load Agent with configured provider and capture model options", async () => {
+        await loadAgentWithProvider(page);
+        await expect(modelTrigger).toBeVisible({ timeout: 30000 });
+        flowUrl = page.url();
+
+        const selectedModel = (await modelValue.innerText()).trim();
+        await modelTrigger.click();
+        const options = page.locator(optionLocator);
+        await options.first().waitFor({ state: "visible", timeout: 10000 });
+        const names = (await options.allInnerTexts())
+          .map((t) => t.trim())
+          .filter((t) => t.length > 0);
+        // Pick a model that is NOT the currently selected one — disabling the
+        // active selection would entangle the test with selection-reset logic.
+        targetModel = names.find((n) => n !== selectedModel) ?? "";
+        test.skip(
+          targetModel.length === 0,
+          "Provider exposes only one model in the dropdown — cannot test removal of a non-selected model.",
+        );
+        await page.keyboard.press("Escape");
+      });
+
+      await test.step("disable the target model in Settings → Model Providers", async () => {
+        await openProviderModelList(page);
+        const toggle = await toggleForModel(page, targetModel);
+        await setToggle(page, toggle, false);
+      });
+
+      await test.step("target model no longer appears in the component dropdown", async () => {
+        await page.goto(flowUrl);
+        await expect(modelTrigger).toBeVisible({ timeout: 30000 });
+        await modelTrigger.click();
+        await page
+          .locator(optionLocator)
+          .first()
+          .waitFor({ state: "visible", timeout: 10000 });
+        await expect(
+          page.locator(optionLocator, {
+            hasText: new RegExp(`^${escapeRegExp(targetModel)}$`),
+          }),
+        ).toHaveCount(0);
+        await page.keyboard.press("Escape");
+      });
+
+      await test.step("re-enabling the model brings it back to the dropdown", async () => {
+        await openProviderModelList(page);
+        const toggle = await toggleForModel(page, targetModel);
+        await setToggle(page, toggle, true);
+
+        await page.goto(flowUrl);
+        await expect(modelTrigger).toBeVisible({ timeout: 30000 });
+        await modelTrigger.click();
+        await expect(
+          page.locator(optionLocator, {
+            hasText: new RegExp(`^${escapeRegExp(targetModel)}$`),
+          }),
+        ).toHaveCount(1, { timeout: 10000 });
+        await page.keyboard.press("Escape");
+      });
+    },
+  );
+});
+
+// Escape a model name for safe use inside an anchored RegExp (model ids can
+// contain regex metacharacters such as "." in "gpt-4.1").
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-model-toggle.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-model-toggle.spec.ts
@@ -183,9 +183,18 @@ test.describe("Model Provider Model Toggle", () => {
         await modelTrigger.click();
         const options = page.locator(optionLocator);
         await options.first().waitFor({ state: "visible", timeout: 10000 });
-        const names = (await options.allInnerTexts())
-          .map((t) => t.trim())
-          .filter((t) => t.length > 0);
+        // Derive model names from the `${name}-option` testid rather than the
+        // option's innerText — deprecated options also render a "Deprecated"
+        // badge, so innerText would yield a malformed name. This mirrors how
+        // Test 1 reads the model name from the toggle's testid.
+        const names = (
+          await options.evaluateAll((els) =>
+            els.map(
+              (el) =>
+                el.getAttribute("data-testid")?.replace(/-option$/, "") ?? "",
+            ),
+          )
+        ).filter((n) => n.length > 0);
         // Pick a model that is NOT the currently selected one — disabling the
         // active selection would entangle the test with selection-reset logic.
         targetModel = names.find((n) => n !== selectedModel) ?? "";


### PR DESCRIPTION
## What this PR does

Adds an E2E spec for the per-model **enable/disable toggles** in **Settings → Model Providers** (`ModelSelection` / `ModelProvidersContent`), previously uncovered by this suite — only API-key entry/removal was covered, and the existing toggle tests live in upstream Langflow unit tests.

## Tests (both validated against a local Langflow 1.11 instance)

1. **Toggle changes immediately and persists across reopen** — toggling a model flips `aria-checked` immediately (optimistic), the debounced `POST /api/v1/models/enabled_models` persists it, and reopening Model Providers reflects the persisted state. Restores the baseline at the end.
2. **Disabling a model removes it from a component model dropdown** — disabling a non-selected model in Settings removes it from the Agent's `model_model` dropdown; re-enabling restores it (the disable→count 0 / re-enable→count 1 round-trip proves the assertion isn't constant-true).

Both are pure UI/state assertions — no LLM call.

## Notes

- Provider-agnostic via `providerConfigMap` (resolves the first env-configured provider; OpenAI here), reusing `SimpleAgentTemplatePage.load()` for a known baseline (all models enabled).
- Waits on the `POST` response rather than a fixed timeout — the Settings page mounts `ModelProvidersContent` without `onFlushRef`, so persistence relies on the ~1s debounce in `useModelToggleQueue`.
- The dropdown target model is derived from the `${name}-option` testid (not innerText) so a "Deprecated" badge can't corrupt the name; anchored exact-match (`^name$`) so `gpt-4o` doesn't collide with `gpt-4o-mini`.
- Serial + `--workers=1` (folder convention — `load()` wipes all flows).

## Validation

- `npm run typecheck` clean; `npm run lint` 0 errors.
- Ran with `--trace=on` (2 passed); forced-failure check confirms no false positives; no backend errors logged.

## Files

- `tests/.../llm-agents/model-provider-model-toggle.spec.ts`
- `docs/.../llm-agents/model-provider-model-toggle.md`
- `QA-CHECKLIST.md` — 2 items under 7.5 Provider Management

Tags: `@stable @regression @components @model-provider` (+`@agents` on the propagation test).

Closes #430
