### PR TITLE
docs(api-keys): bump Last validated to 1.11.x after local validation

### DIFF
--- a/docs/api/flows/api-key-expiry-enforcement.md
+++ b/docs/api/flows/api-key-expiry-enforcement.md
@@ -1,6 +1,6 @@
 # API Key Expiry Enforcement
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.11.x
 
 ---
 

--- a/docs/ui-ux/api-keys-timezone-display.md
+++ b/docs/ui-ux/api-keys-timezone-display.md
@@ -1,6 +1,6 @@
 # API Keys — Timestamp Timezone Display
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.11.x
 
 ---
 


### PR DESCRIPTION
Follow-up to #360. Both specs were re-validated against a live **Langflow 1.11.0** instance and the spec docs' `Last validated` field is bumped `1.10.x` → `1.11.x` to reflect the current release cycle (per the CLAUDE.md PR review checklist).

## Validation (7-step pipeline, against running 1.11.0)

| Step | Result |
|---|---|
| typecheck / lint | ✅ (PR #360 CI) |
| run `--workers=1 --retries=0` | ✅ 4/4 pass, no retry |
| force-fail | ✅ both fail on the right assertion (403 enforcement; `20:59:59` local render), reverted, re-passed |
| `--trace=on` | ✅ 4 traces, steps coherent |
| backend errors | ✅ zero `🚨` |

Docs-only change — no test code touched.