### PR TITLE
docs(agent-images): normalize Last validated to cycle format 1.11.x

### DIFF
--- a/docs/core-functionality/llm-agents/general-bugs-agent-images-playground.md
+++ b/docs/core-functionality/llm-agents/general-bugs-agent-images-playground.md
@@ -1,6 +1,6 @@
 # Agent Component — Image Input in Playground
 
-**Last validated:** Langflow 1.11.0
+**Last validated:** Langflow 1.11.x
 
 ---
 


### PR DESCRIPTION
## What this PR does

Normalizes the `Last validated` field in `docs/core-functionality/llm-agents/general-bugs-agent-images-playground.md` from the patch-pinned `Langflow 1.11.0` to the release-cycle format `Langflow 1.11.x`.

Per CLAUDE.md, the `Last validated` field must reflect the current **release cycle** (e.g. `1.10.x`). This doc was the only one in the repo pinned to a specific patch; this aligns it with the convention used by every other spec doc.

## Validation

Re-ran the companion spec against the running **Langflow 1.11.0** instance to back the field (not just a cosmetic edit):

```
general-bugs-agent-images-playground.spec.ts — 1 passed (34.9s), zero backend errors
```

## Scope

- Docs-only, single line. No test or helper changes.