### PR TITLE
test(core-components): add singleton/mutually-exclusive components spec

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -166,6 +166,8 @@
 - [x] Uploading a file via the Chat Input inspector populates the Files field → `core-components/chat-input-files-field-regression.spec.ts`
 - [x] Inspector-attached file is rendered in the Playground after running ChatInput → ChatOutput → `core-components/chat-input-files-field-regression.spec.ts`
 - [x] Dismiss button on the Files field clears the value → `core-components/chat-input-files-field-regression.spec.ts`
+- [x] Chat Input is a singleton — adding one removes both the Chat Input and Webhook `+` buttons from the sidebar (mutual exclusion) → `core-components/singleton-components.spec.ts`
+- [x] Chat Input cannot be duplicated (`Cmd/Ctrl+D`) or copy/pasted (`Cmd/Ctrl+C`+`V`) — blocked with the "components were not pasted" toast → `core-components/singleton-components.spec.ts`
 
 #### 3.2 Prompt Template
 - [x] Prompt Template renders on canvas with output handle → `core-components/prompt-template-component-regression.spec.ts`
@@ -218,6 +220,8 @@
 - [x] GET `/api/v1/monitor/messages` retorna 200 com array → `core-components/webhook-component-regression.spec.ts`
 - [x] Payload JSON recebido é propagado corretamente como saída Data do componente → `core-components/webhook-component-regression.spec.ts`
 - [x] Payload inválido (não-JSON) é encapsulado em `{"payload": "..."}` na saída → `core-components/webhook-component-regression.spec.ts`
+- [x] Webhook is a singleton — adding one removes both the Webhook and Chat Input `+` buttons from the sidebar (mutual exclusion) → `core-components/singleton-components.spec.ts`
+- [x] Webhook cannot be duplicated (`Cmd/Ctrl+D`) or copy/pasted (`Cmd/Ctrl+C`+`V`) — blocked with the "components were not pasted" toast → `core-components/singleton-components.spec.ts`
 
 #### 3.5 Agent (Component)
 - [-] Agent component displayed on canvas with default settings

--- a/docs/core-components/singleton-components.md
+++ b/docs/core-components/singleton-components.md
@@ -1,0 +1,106 @@
+# Spec: Singleton and Mutually-Exclusive Components (Chat Input ↔ Webhook)
+
+**Test file:** `tests/tests-automations/regression/core-components/singleton-components.spec.ts`
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates
+
+Confirms the canvas constraint that **Chat Input and Webhook are singletons and mutually exclusive**: a flow may contain at most one of them, and while either is present neither can be added again. The rule is enforced across every path a user could take to create a second one:
+
+1. **Sidebar `+` button** — adding the component removes the `+` affordance for *both* Chat Input and Webhook from the sidebar (silent, preventive — there is no toast).
+2. **Duplicate shortcut (`Cmd/Ctrl+D`)** — duplicating the selected node is blocked with a toast ("…components were not pasted…").
+3. **Copy + paste (`Cmd/Ctrl+C` then `Cmd/Ctrl+V`)** — pasting the copied node is blocked with the same toast.
+
+The behavior is symmetric, so the spec is a `test.describe` block of eight tests: four for Chat Input and four mirroring them for Webhook (singleton, mutual exclusion, duplicate, copy/paste).
+
+A shared `beforeEach` opens a blank flow via `setupBlankFlow` and waits for the sidebar search input; a shared `afterEach` deletes the created flow via the REST API so no orphan flows are left behind.
+
+---
+
+## Tags
+
+`@stable` `@regression` `@components`
+
+---
+
+## Step by step
+
+**beforeEach (all tests)**
+1. `setupBlankFlow(page)` — create a blank flow via the REST API and open it (avoids the UI-creation 500 race; returns the flow id for cleanup).
+2. Assert the sidebar search input is visible.
+
+**Singleton tests (`allow only one …`)**
+1. Search the component; assert its `add-component-button-<name>` has count `1` (baseline — the affordance exists).
+2. Add it to the canvas (`addToCanvas`); assert `title-<name>` is visible and `.react-flow__node` count is `1`.
+3. Search the same component again; assert its `+` button now has count `0`.
+
+**Mutual-exclusion tests (`should not allow adding X while Y is on the canvas`)**
+1. Search the *blocked* component (X); assert its `+` button has count `1` on the empty canvas (baseline).
+2. Add the *other* component (Y) to the canvas.
+3. Search X again; assert its `+` button now has count `0`.
+
+**Duplicate tests (`should not allow duplicating …`)**
+1. Add the component to the canvas.
+2. Select the node and press `ControlOrMeta+d`; assert the "components were not pasted" toast is visible.
+
+**Copy/paste tests (`should not allow copying and pasting …`)**
+1. Add the component to the canvas.
+2. Select the node, press `ControlOrMeta+c` then `ControlOrMeta+v`; assert the "components were not pasted" toast is visible.
+
+**afterEach (all tests)**
+1. Navigate to `/` (so background polling does not 404 on the deleted flow), then `DELETE /api/v1/flows/{id}`.
+
+---
+
+## Validation criterion
+
+| Test | Criterion |
+|---|---|
+| allow only one Chat Input | `add-component-button-chat-input` count `1` before add, `0` after add |
+| not allow adding a Webhook while a Chat Input is present | `add-component-button-webhook` count `1` on empty canvas, `0` after adding a Chat Input |
+| not allow duplicating a Chat Input | "components were not pasted" toast visible after `Cmd/Ctrl+D` |
+| not allow copying and pasting a Chat Input | "components were not pasted" toast visible after `Cmd/Ctrl+C` + `Cmd/Ctrl+V` |
+| allow only one Webhook | `add-component-button-webhook` count `1` before add, `0` after add |
+| not allow adding a Chat Input while a Webhook is present | `add-component-button-chat-input` count `1` on empty canvas, `0` after adding a Webhook |
+| not allow duplicating a Webhook | "components were not pasted" toast visible after `Cmd/Ctrl+D` |
+| not allow copying and pasting a Webhook | "components were not pasted" toast visible after `Cmd/Ctrl+C` + `Cmd/Ctrl+V` |
+
+---
+
+## External dependencies
+
+- Sidebar add affordance — `sidebar-search-input` and `add-component-button-<name>` (`chat-input`, `webhook`). The oracle for the `+`-button path is the *absence* of these (`toHaveCount(0)`); the search term must match the component being checked, otherwise the sidebar filter hides it and the assertion becomes a false positive.
+- Node title — `title-<display_name>` (`title-Chat Input`, `title-Webhook`), rendered by `CustomNodes/GenericNode/components/NodeName`. Used to confirm the node landed on the canvas.
+- React Flow canvas — `.react-flow__node` for node counting and node selection before the keyboard shortcuts.
+- Keyboard shortcuts — `ControlOrMeta+d` (duplicate) and `ControlOrMeta+c` / `ControlOrMeta+v` (copy/paste). Clipboard permissions are granted by the Playwright config.
+- Toast copy — the i18n strings `flow.duplicateComponentsNotPasted` / `flow.exclusiveComponentsNotPasted` (both contain "components were not pasted"). The test matches on that shared substring.
+- `tests/helpers/flows/setup-blank-flow.ts` — API-based flow creation and the `flowId` used for cleanup.
+
+---
+
+## What this test does not cover
+
+- The same constraint for other component types — the rule is Chat Input/Webhook-specific here.
+- Importing a flow JSON that already contains two singletons (constraint applies at load/paste rather than add).
+- Which specific toast message fires (duplicate vs exclusive) — the assertion only checks the shared substring, not the full localized string.
+- Undo/redo after a blocked duplicate or paste.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- No model provider credentials required (deterministic, no LLM).
+- Default Playwright Desktop Chrome viewport with clipboard permissions (from `playwright.config.ts`).
+
+---
+
+## Notes
+
+- Sibling references: `core-components/componentDelete.spec.ts` and `componentHoverAdd.spec.ts` (canvas node lifecycle).
+- A single source of truth (`CHAT_INPUT` / `WEBHOOK` descriptors holding name + testids) plus local helpers (`addToCanvas`, `expectAddButtonCount`, `duplicateSelectedNode`, `copyPasteSelectedNode`) keep the eight tests DRY and prevent the testid copy/paste class of bug. Helpers are kept local to the spec.
+- The `+`-button path is asserted by *absence of the affordance*, not by an error message — Langflow removes the button rather than showing a toast. The duplicate/paste paths are the opposite: they *do* surface a toast.
+- Validated by running the full suite against a live instance (`8 passed`).

--- a/tests/tests-automations/regression/core-components/singleton-components.spec.ts
+++ b/tests/tests-automations/regression/core-components/singleton-components.spec.ts
@@ -1,0 +1,227 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
+
+// Single source of truth for each component under test. Keeping the search
+// term and the testids together here is what prevents the copy/paste class of
+// bug (e.g. a Webhook test accidentally using the Chat Input testid).
+type ComponentDescriptor = {
+  name: string;
+  addButton: string;
+  title: string;
+};
+
+const CHAT_INPUT: ComponentDescriptor = {
+  name: "Chat Input",
+  addButton: "add-component-button-chat-input",
+  title: "title-Chat Input",
+};
+
+const WEBHOOK: ComponentDescriptor = {
+  name: "Webhook",
+  addButton: "add-component-button-webhook",
+  title: "title-Webhook",
+};
+
+// Substring of the i18n toast shown when a singleton/mutually-exclusive
+// component cannot be duplicated or pasted (en.json: duplicateComponentsNotPasted).
+const NOT_PASTED_TOAST = "components were not pasted";
+
+// Low-level: search the sidebar and click a component's "+" button.
+async function addComponent(
+  page: Page,
+  searchTerm: string,
+  addButtonTestId: string,
+) {
+  await page.getByTestId("sidebar-search-input").fill(searchTerm);
+  await page.getByTestId(addButtonTestId).click();
+}
+
+// Add a component via the sidebar and confirm it landed on the canvas.
+async function addToCanvas(page: Page, component: ComponentDescriptor) {
+  await addComponent(page, component.name, component.addButton);
+  await expect(page.getByTestId(component.title)).toBeVisible();
+  await expect(page.locator(".react-flow__node")).toHaveCount(1);
+}
+
+// Search for a component and assert whether its "+" button is present (1) or
+// gone (0). The search term must match the component being checked, otherwise
+// the sidebar filter hides it and the assertion becomes a false positive.
+async function expectAddButtonCount(
+  page: Page,
+  component: ComponentDescriptor,
+  count: number,
+) {
+  await page.getByTestId("sidebar-search-input").fill(component.name);
+  await expect(page.getByTestId(component.addButton)).toHaveCount(count);
+}
+
+// Select the single canvas node and trigger the duplicate shortcut.
+async function duplicateSelectedNode(page: Page) {
+  await page.locator(".react-flow__node").click();
+  await page.keyboard.press("ControlOrMeta+d");
+}
+
+// Select the single canvas node and trigger the copy + paste shortcuts.
+async function copyPasteSelectedNode(page: Page) {
+  await page.locator(".react-flow__node").click();
+  await page.keyboard.press("ControlOrMeta+c");
+  await page.keyboard.press("ControlOrMeta+v");
+}
+
+async function expectNotPastedToast(page: Page) {
+  await expect(page.getByText(NOT_PASTED_TOAST)).toBeVisible();
+}
+
+test.describe("Singleton and mutually-exclusive components (Chat Input ↔ Webhook)", () => {
+  let createdFlowId: string | null = null;
+
+  test.beforeEach(async ({ page }) => {
+    // setupBlankFlow creates the flow via API (avoids the UI-creation 500 race)
+    // and returns its id so afterEach can clean it up.
+    createdFlowId = await setupBlankFlow(page);
+    await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (createdFlowId) {
+      // Leave the editor first: staying on it while the flow is deleted makes
+      // background polling 404, which the fixture's error monitor would flag.
+      await page.goto("/").catch(() => {});
+      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      createdFlowId = null;
+    }
+  });
+
+  // --- Chat Input ---
+
+  test(
+    "should allow only one Chat Input on the canvas",
+    { tag: ["@stable", "@regression", "@components"] },
+    async ({ page }) => {
+      await test.step("Add a Chat Input to the canvas", async () => {
+        await expectAddButtonCount(page, CHAT_INPUT, 1);
+        await addToCanvas(page, CHAT_INPUT);
+      });
+
+      await test.step("The Chat Input add button is no longer available", async () => {
+        await expectAddButtonCount(page, CHAT_INPUT, 0);
+      });
+    },
+  );
+
+  test(
+    "should not allow adding a Webhook while a Chat Input is on the canvas",
+    { tag: ["@stable", "@regression", "@components"] },
+    async ({ page }) => {
+      await test.step("A Webhook can be added to an empty canvas", async () => {
+        await expectAddButtonCount(page, WEBHOOK, 1);
+      });
+
+      await test.step("Add a Chat Input to the canvas", async () => {
+        await addToCanvas(page, CHAT_INPUT);
+      });
+
+      await test.step("The Webhook add button is no longer available", async () => {
+        await expectAddButtonCount(page, WEBHOOK, 0);
+      });
+    },
+  );
+
+  test(
+    "should not allow duplicating a Chat Input",
+    { tag: ["@stable", "@regression", "@components"] },
+    async ({ page }) => {
+      await test.step("Add a Chat Input to the canvas", async () => {
+        await addToCanvas(page, CHAT_INPUT);
+      });
+
+      await test.step("Duplicating the Chat Input is blocked", async () => {
+        await duplicateSelectedNode(page);
+        await expectNotPastedToast(page);
+      });
+    },
+  );
+
+  test(
+    "should not allow copying and pasting a Chat Input",
+    { tag: ["@stable", "@regression", "@components"] },
+    async ({ page }) => {
+      await test.step("Add a Chat Input to the canvas", async () => {
+        await addToCanvas(page, CHAT_INPUT);
+      });
+
+      await test.step("Copying and pasting the Chat Input is blocked", async () => {
+        await copyPasteSelectedNode(page);
+        await expectNotPastedToast(page);
+      });
+    },
+  );
+
+  // --- Webhook ---
+
+  test(
+    "should allow only one Webhook on the canvas",
+    { tag: ["@stable", "@regression", "@components"] },
+    async ({ page }) => {
+      await test.step("Add a Webhook to the canvas", async () => {
+        await expectAddButtonCount(page, WEBHOOK, 1);
+        await addToCanvas(page, WEBHOOK);
+      });
+
+      await test.step("The Webhook add button is no longer available", async () => {
+        await expectAddButtonCount(page, WEBHOOK, 0);
+      });
+    },
+  );
+
+  test(
+    "should not allow adding a Chat Input while a Webhook is on the canvas",
+    { tag: ["@stable", "@regression", "@components"] },
+    async ({ page }) => {
+      await test.step("A Chat Input can be added to an empty canvas", async () => {
+        await expectAddButtonCount(page, CHAT_INPUT, 1);
+      });
+
+      await test.step("Add a Webhook to the canvas", async () => {
+        await addToCanvas(page, WEBHOOK);
+      });
+
+      await test.step("The Chat Input add button is no longer available", async () => {
+        await expectAddButtonCount(page, CHAT_INPUT, 0);
+      });
+    },
+  );
+
+  test(
+    "should not allow duplicating a Webhook",
+    { tag: ["@stable", "@regression", "@components"] },
+    async ({ page }) => {
+      await test.step("Add a Webhook to the canvas", async () => {
+        await addToCanvas(page, WEBHOOK);
+      });
+
+      await test.step("Duplicating the Webhook is blocked", async () => {
+        await duplicateSelectedNode(page);
+        await expectNotPastedToast(page);
+      });
+    },
+  );
+
+  test(
+    "should not allow copying and pasting a Webhook",
+    { tag: ["@stable", "@regression", "@components"] },
+    async ({ page }) => {
+      await test.step("Add a Webhook to the canvas", async () => {
+        await addToCanvas(page, WEBHOOK);
+      });
+
+      await test.step("Copying and pasting the Webhook is blocked", async () => {
+        await copyPasteSelectedNode(page);
+        await expectNotPastedToast(page);
+      });
+    },
+  );
+});


### PR DESCRIPTION
## What this PR does

Adds an E2E spec for the canvas constraint that **Chat Input and Webhook are singletons and mutually exclusive** — a flow may contain at most one of them, and while either is present neither can be added again. Previously uncovered by this suite (existing Chat Input / Webhook specs cover payload propagation and the Files field, not this rule).

## Tests (8, all validated against a local Langflow 1.11 instance)

Four for Chat Input, four mirroring them for Webhook, covering every path to a second instance:

1. **Singleton** — adding the component drops its sidebar `+` button to count `0`.
2. **Mutual exclusion** — adding one drops the *other's* `+` button to count `0`.
3. **Duplicate (`Cmd/Ctrl+D`)** — blocked with the "components were not pasted" toast.
4. **Copy + paste (`Cmd/Ctrl+C`+`V`)** — blocked with the same toast.

All deterministic — no LLM, no provider credentials.

## Notes

- Single source of truth: `CHAT_INPUT` / `WEBHOOK` descriptors hold name + testids, with local helpers (`addToCanvas`, `expectAddButtonCount`, `duplicateSelectedNode`, `copyPasteSelectedNode`) — prevents the testid copy/paste class of bug and keeps the eight tests DRY.
- The `+`-button path is asserted by *absence of the affordance* (`toHaveCount(0)`); the sidebar search term is matched to the component being checked so the filter can't produce a false positive.
- Toast match is on the shared substring "components were not pasted", common to both `flow.duplicateComponentsNotPasted` and `flow.exclusiveComponentsNotPasted` (verified against `en.json`).
- `beforeEach` creates a blank flow via the REST API (`setupBlankFlow`, avoids the UI-creation 500 race); `afterEach` navigates away then `DELETE`s the flow so no orphans remain.

## Validation

- `npm run typecheck` clean; `npm run lint` 0 errors.
- Testids verified against Langflow source (`NodeName/index.tsx:95` → `title-<display_name>`, capitalized).
- Full spec run against a live instance: **8 passed (17.5s)**; no backend errors logged.

## Files

- `tests/tests-automations/regression/core-components/singleton-components.spec.ts`
- `docs/core-components/singleton-components.md`
- `QA-CHECKLIST.md` — 2 items under 3.1 Chat Input, 2 under 3.4 Webhook

Tags: `@stable @regression @components`

Closes #436