### PR TITLE
fix(provider-setup): scope model toggles to :visible and harden Google save (#415)

### DIFF
--- a/tests/helpers/provider-setup/collect-models.ts
+++ b/tests/helpers/provider-setup/collect-models.ts
@@ -159,29 +159,40 @@ async function collectModelsForProvider(
   await apiKeyInput.waitFor({ state: "visible", timeout: 5000 }).catch(() => {});
 
   const apiKey = process.env[apiKeyEnvVar] ?? "";
-  if ((await apiKeyInput.count()) > 0 && apiKey) {
+  // Skip configuration when the provider is already set up: a configured provider
+  // shows a "Disconnect" button, and re-saving it would append to the masked key
+  // field or hit a "Variable name already exists" conflict.
+  const alreadyConfigured = await page
+    .getByRole("button", { name: "Disconnect", exact: true })
+    .isVisible({ timeout: 1000 })
+    .catch(() => false);
+
+  if (!alreadyConfigured && (await apiKeyInput.count()) > 0 && apiKey) {
     await apiKeyInput.click();
     await apiKeyInput.pressSequentially(apiKey, { delay: 0 });
 
     const saveBtn = page.getByRole("button", { name: "Save", exact: true });
-    const replaceBtn = page.getByRole("button", { name: "Replace", exact: true });
-
     if ((await saveBtn.count()) > 0) {
       await saveBtn.click();
-    } else if ((await replaceBtn.count()) > 0) {
-      await replaceBtn.click();
     }
 
-    // Wait for save to complete — button becomes "Replace" when provider is configured
-    await replaceBtn.waitFor({ state: "visible", timeout: 30000 });
-
-    // Wait for model toggles to load after provider is configured
-    await page.locator('[data-testid^="llm-toggle"]').first()
-      .waitFor({ state: "visible", timeout: 15000 })
+    // Provider validation can take ~35s (Google) — wait for the configured state
+    // (Disconnect button) rather than a fixed shorter timeout that would expire mid-validation.
+    await page
+      .getByRole("button", { name: "Disconnect", exact: true })
+      .waitFor({ state: "visible", timeout: 60000 })
       .catch(() => {});
   }
 
-  const toggles = page.locator('[data-testid^="llm-toggle"]');
+  // Wait for model toggles to load after provider is configured
+  await page.locator('[data-testid^="llm-toggle"]:visible').first()
+    .waitFor({ state: "visible", timeout: 15000 })
+    .catch(() => {});
+
+  // Scope to visible toggles only — the providers panel renders deprecated models
+  // in DOM but collapses them under a "Show N deprecated models" button. Iterating
+  // the hidden toggles makes `.click()` retry-loop until timeout (see PR #330).
+  const toggles = page.locator('[data-testid^="llm-toggle"]:visible');
   const toggleCount = await toggles.count();
   const models: ModelRecord[] = [];
 

--- a/tests/helpers/provider-setup/setup-anthropic.ts
+++ b/tests/helpers/provider-setup/setup-anthropic.ts
@@ -30,24 +30,38 @@ export async function setupAnthropic(
   // Step 3: Select the Anthropic provider
   await page.getByTestId("provider-item-Anthropic").click();
 
-  // Step 4: Save the API key if the config panel is visible.
-  // The config panel animates in (300ms) and requires a backend fetch after the provider
-  // is selected — use waitFor (retries) instead of isVisible (immediate snapshot).
-  // The save button was renamed from "Save Configuration" to "Save" / "Replace" / "Retry".
+  // Step 4: Configure the API key — but only if the provider is not already set up.
+  // A configured provider shows a "Disconnect" button with the key field masked;
+  // re-saving it would append to the masked value or hit a "Variable name already
+  // exists" conflict, so in that case skip straight to model selection.
+  // The config panel animates in (300ms) and requires a backend fetch after the
+  // provider is selected — use waitFor (retries) instead of isVisible.
   const apiKeyInput = page.getByPlaceholder("sk-ant-...");
-  const apiKeyInputVisible = await apiKeyInput
-    .waitFor({ state: "visible", timeout: 10000 })
-    .then(() => true)
+  await apiKeyInput.waitFor({ state: "visible", timeout: 10000 }).catch(() => {});
+
+  const alreadyConfigured = await page
+    .getByRole("button", { name: "Disconnect", exact: true })
+    .isVisible({ timeout: 1000 })
     .catch(() => false);
 
-  if (apiKeyInputVisible) {
+  if (!alreadyConfigured && (await apiKeyInput.count()) > 0) {
     await apiKeyInput.fill(process.env.ANTHROPIC_API_KEY ?? "");
     await page.getByRole("button", { name: /Save|Replace|Retry/i }).click();
+    // Provider validation can take tens of seconds — wait for the configured
+    // state (Disconnect button) so the model toggles have rendered before Step 5.
+    await page
+      .getByRole("button", { name: "Disconnect", exact: true })
+      .waitFor({ state: "visible", timeout: 60000 })
+      .catch(() => {});
   }
 
   // Step 5: Enable all available Anthropic models.
   // Toggles only render after the provider is authenticated — waitFor retries until visible.
-  const toggles = page.locator('[data-testid^="llm-toggle"]');
+  // The `:visible` filter excludes toggles inside the collapsed "deprecated
+  // models" section, which are mounted in the DOM but not displayed until the
+  // section's "Show N deprecated models" button is clicked. Without the
+  // filter, `.click()` on a hidden toggle retry-loops to a timeout.
+  const toggles = page.locator('[data-testid^="llm-toggle"]:visible');
   await toggles.first().waitFor({ state: "visible", timeout: 15000 }).catch(() => {});
   const toggleCount = await toggles.count();
 

--- a/tests/helpers/provider-setup/setup-google.ts
+++ b/tests/helpers/provider-setup/setup-google.ts
@@ -30,24 +30,39 @@ export async function setupGoogle(
   // Step 3: Select the Google Generative AI provider
   await page.getByTestId("provider-item-Google Generative AI").click();
 
-  // Step 4: Save the API key if the config panel is visible.
-  // The config panel animates in (300ms) and requires a backend fetch after the provider
-  // is selected — use waitFor (retries) instead of isVisible (immediate snapshot).
-  // The save button was renamed from "Save Configuration" to "Save" / "Replace" / "Retry".
+  // Step 4: Configure the API key — but only if the provider is not already set up.
+  // A configured provider shows a "Disconnect" button with the key field masked;
+  // re-saving it would append to the masked value or hit a "Variable name already
+  // exists" conflict, so in that case skip straight to model selection.
+  // The config panel animates in (300ms) and requires a backend fetch after the
+  // provider is selected — use waitFor (retries) instead of isVisible.
   const apiKeyInput = page.getByPlaceholder("AIza...");
-  const apiKeyInputVisible = await apiKeyInput
-    .waitFor({ state: "visible", timeout: 10000 })
-    .then(() => true)
+  await apiKeyInput.waitFor({ state: "visible", timeout: 10000 }).catch(() => {});
+
+  const alreadyConfigured = await page
+    .getByRole("button", { name: "Disconnect", exact: true })
+    .isVisible({ timeout: 1000 })
     .catch(() => false);
 
-  if (apiKeyInputVisible) {
+  if (!alreadyConfigured && (await apiKeyInput.count()) > 0) {
     await apiKeyInput.fill(process.env.GOOGLE_API_KEY ?? "");
     await page.getByRole("button", { name: /Save|Replace|Retry/i }).click();
+    // Google provider validation can take ~35s — wait for the configured state
+    // (Disconnect button) so the model toggles have rendered before Step 5.
+    await page
+      .getByRole("button", { name: "Disconnect", exact: true })
+      .waitFor({ state: "visible", timeout: 60000 })
+      .catch(() => {});
   }
 
   // Step 5: Enable all available Google Generative AI models.
   // Toggles only render after the provider is authenticated — waitFor retries until visible.
-  const toggles = page.locator('[data-testid^="llm-toggle"]');
+  // The `:visible` filter excludes toggles inside the collapsed "deprecated
+  // models" section, which are mounted in the DOM but not displayed until the
+  // section's "Show N deprecated models" button is clicked. Without the
+  // filter, `.click()` on a hidden toggle (e.g. gemini-2.0-flash on 1.11.x)
+  // retry-loops to a timeout.
+  const toggles = page.locator('[data-testid^="llm-toggle"]:visible');
   await toggles.first().waitFor({ state: "visible", timeout: 15000 }).catch(() => {});
   const toggleCount = await toggles.count();
 


### PR DESCRIPTION
## Summary

Fixes #415. On Langflow 1.11.x the Google provider model list grew long enough that the provider-setup helpers timed out while enabling model toggles, breaking the `@stable` Google MCP agent test.

## Root cause

The provider panel renders deprecated models inside a collapsed **"Show N deprecated models"** section. Those toggles are mounted in the DOM but `display:none`. The helpers iterated **every** `llm-toggle`, so `.click()` on a hidden toggle (e.g. `gemini-2.0-flash`) retry-looped to a `TimeoutError`. This is the same class of bug already fixed in `setup-openai.ts` (PR #330) via a `:visible` filter — `setup-google.ts`, `setup-anthropic.ts` and `collect-models.ts` were never updated to match.

## Changes

- **`setup-google.ts` / `setup-anthropic.ts` / `collect-models.ts`** — filter toggles with the `:visible` selector so collapsed deprecated toggles are skipped (mirrors `setup-openai.ts`).
- **Skip re-saving** the API key when the provider is already configured (a "Disconnect" button is shown). Re-saving appended to the masked key field and hit a `Variable name already exists` conflict.
- **Wait for the configured state** (Disconnect button) after saving instead of a fixed 30s window — Google provider validation can take ~35s in 1.11.x.

`setup-openai.ts` already carries the `:visible` fix and is intentionally left untouched.

## Verification (Langflow 1.11.0)

- **Reproduced the bug live**: the old locator `[data-testid^="llm-toggle"]` clicking the first hidden toggle (`gemini-2.0-flash`) → `TimeoutError`. The `:visible` locator iterates the 21 visible Google models and enables them with no error.
- DOM evidence: 27 total toggles, 21 visible, 6 hidden (`gemini-2.0-flash`, `gemini-2.0-flash-lite`, `gemini-1.5-pro`, `gemini-1.5-flash`, `gemini-1.5-flash-8b`, `gemini-2.0-flash-preview-image-generation`) under "Show 6 deprecated models".
- `collect-models.spec.ts` passes and collects 21 Google models.
- The Google MCP agent test now progresses through the entire provider-setup phase (the part #415 was about).
- `tsc --noEmit` and ESLint pass (no new findings).

## Out of scope / follow-up

With provider-setup fixed, the `@stable` Google MCP agent test now fails at a **separate, unrelated** step: `gemini-2.5-flash` does not invoke the `echo` MCP tool (deterministic across runs). This is a model/tool-calling concern, not a provider-setup defect — tracked separately.