### PR TITLE
chore(triage): de-stable three tests failing on nightly (#441)

### DIFF
--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -330,7 +330,7 @@ test(
 
 test(
   "API Request component — invalid URL is accepted by field and run shows error notification",
-  { tag: ["@stable", "@regression", "@components"] },
+  { tag: ["@regression", "@components"] },
   async ({ page }) => {
     // Invalid URLs are accepted by the input field but rejected by the Pydantic HttpUrl
     // validator on run — the component must not crash on either action.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/llm-invalid-api-key-ui.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/llm-invalid-api-key-ui.spec.ts
@@ -72,7 +72,7 @@ test.describe("LLM Invalid API Key UI Error Display", () => {
 
   test(
     "playground input remains usable after API error (mocked)",
-    { tag: ["@stable", "@release", "@workspace", "@regression", "@agents", "@playground"] },
+    { tag: ["@release", "@workspace", "@regression", "@agents", "@playground"] },
     async ({ page }) => {
       createdFlowId = await setupPlayground(page);
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/memory-history-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/memory-history-regression.spec.ts
@@ -37,7 +37,7 @@ async function waitForChatResponse(page: Page, expectedResponses: number): Promi
 test.describe("Memory Chatbot Regression", () => {
   test(
     "memory chatbot template loads with correct node structure",
-    { tag: ["@stable", "@release", "@agents", "@playground"] },
+    { tag: ["@release", "@agents", "@playground"] },
     async ({ page }) => {
       await loadMemoryChatbot(page);
 


### PR DESCRIPTION
## Summary

Triage of the weekly `@stable` failure in #441 (run 28368014401: 5 failed, 8 flaky, 203 passed). Each hard failure was reproduced locally against a Langflow **1.11.0** instance and cross-checked against `reports/weekly-history.jsonl`, following the matrix in `CONTRIBUTING.md` → *Monitoring rules driven by run history*. The full classification (fail vs flake, with evidence and history) is posted as a comment on #441.

This PR makes the only repo change the triage calls for: **removing `@stable`** from the three tests confirmed as true, deterministic failures, so they stop blocking the weekly run until their fixes land.

## Why `@stable` is being removed

Per `CONTRIBUTING.md`, a test that fails for a real upstream/behavior change is temporarily de-stabilized (it exits the weekly workflow) while it awaits correction. No spec-doc change is required — the absence is tracked by the linked fix issues and the correction PRs.

| Test | Reason | Tracking issue |
|---|---|---|
| `api-request-component-regression.spec.ts:331` | Langflow changed the invalid-URL error toast (now `"Invalid URL provided:"` with the URL as a link; the `"Error building Component API Request:"` header is gone). Reproduces on 1.11.0. | #443 |
| `llm-invalid-api-key-ui.spec.ts:73` | The playground "send" no longer hits `/api/v1/build/{id}/flow` the way the mock/waiter expects; `waitForResponse` times out. Reproduces on 1.11.0. | #444 |
| `memory-history-regression.spec.ts:38` | Memory Chatbot template changed from 6 to 5 nodes on nightly (missing Message History / Language Model / Prompt Template). Passes on 1.11.0 release — sustained upstream change not yet released. | #445 |

## Not changed here

- **`general-bugs-agent-images-playground.spec.ts:6`** and **`model-provider-model-toggle.spec.ts:117`** — CI-only race in the shared `setup-openai.ts` helper (pass locally single-worker). `@stable` **kept**; hardening tracked in #446.
- **`model-provider-model-toggle`** alone — first-occurrence flake; monitored only.

## Restoring the tags

The `@stable` tags removed here **must be restored** in the corresponding fix PRs (#443, #444, #445), once each test is corrected and re-validated per the 5-step guide. That is the explicit deliverable on each of those issues.

The `QA-CHECKLIST.md` Coverage/stable blocks regenerate automatically on merge via `update-coverage-summary.yml`.

Closes #441
