### PR TITLE
fix(provider-setup): close node Inspector Panel before clicking model_model

### DIFF
--- a/tests/helpers/provider-setup/setup-anthropic.ts
+++ b/tests/helpers/provider-setup/setup-anthropic.ts
@@ -1,4 +1,5 @@
 import type { Page } from "@playwright/test";
+import { hideInspectorPanel } from "../ui/hide-inspector-panel";
 
 export async function setupAnthropic(
   page: Page,
@@ -21,6 +22,9 @@ export async function setupAnthropic(
 
   // Step 2: Open the model provider management panel
   if (hasModelDropdown) {
+    // A selected node opens a right-side Inspector Panel that overlaps the
+    // model dropdown on 1.11.x+ — close it so the click is not intercepted.
+    await hideInspectorPanel(page);
     await modelDropdown.click();
     await page.getByTestId("manage-model-providers").click();
   } else {
@@ -77,6 +81,7 @@ export async function setupAnthropic(
   await page.getByRole("button", { name: "Close" }).click();
 
   // Step 7: Select model — uses modelTestId if provided, otherwise selects the first available
+  await hideInspectorPanel(page);
   await page.getByTestId("model_model").click();
   if (modelTestId) {
     const modelOption = page.locator('[data-testid$="-option"]', { hasText: new RegExp(`^${modelTestId}$`) });

--- a/tests/helpers/provider-setup/setup-google.ts
+++ b/tests/helpers/provider-setup/setup-google.ts
@@ -1,4 +1,5 @@
 import type { Page } from "@playwright/test";
+import { hideInspectorPanel } from "../ui/hide-inspector-panel";
 
 export async function setupGoogle(
   page: Page,
@@ -21,6 +22,9 @@ export async function setupGoogle(
 
   // Step 2: Open the model provider management panel
   if (hasModelDropdown) {
+    // A selected node opens a right-side Inspector Panel that overlaps the
+    // model dropdown on 1.11.x+ — close it so the click is not intercepted.
+    await hideInspectorPanel(page);
     await modelDropdown.click();
     await page.getByTestId("manage-model-providers").click();
   } else {
@@ -78,6 +82,7 @@ export async function setupGoogle(
   await page.getByRole("button", { name: "Close" }).click();
 
   // Step 7: Select model — uses modelTestId if provided, otherwise selects the first available
+  await hideInspectorPanel(page);
   await page.getByTestId("model_model").click();
   if (modelTestId) {
     const modelOption = page.locator('[data-testid$="-option"]', { hasText: new RegExp(`^${modelTestId}$`) });

--- a/tests/helpers/provider-setup/setup-openai.ts
+++ b/tests/helpers/provider-setup/setup-openai.ts
@@ -1,4 +1,5 @@
 import type { Page } from "@playwright/test";
+import { hideInspectorPanel } from "../ui/hide-inspector-panel";
 
 export async function setupOpenAI(
   page: Page,
@@ -21,6 +22,9 @@ export async function setupOpenAI(
 
   // Step 2: Open the model provider management panel
   if (hasModelDropdown) {
+    // A selected node opens a right-side Inspector Panel that overlaps the
+    // model dropdown on 1.11.x+ — close it so the click is not intercepted.
+    await hideInspectorPanel(page);
     await modelDropdown.click();
     await page.getByTestId("manage-model-providers").click();
   } else {
@@ -66,6 +70,7 @@ export async function setupOpenAI(
   await page.getByRole("button", { name: "Close" }).click();
 
   // Step 7: Select model — uses modelTestId if provided, otherwise selects the first available
+  await hideInspectorPanel(page);
   await page.getByTestId("model_model").click();
   if (modelTestId) {
     const modelOption = page.locator('[data-testid$="-option"]', { hasText: new RegExp(`^${modelTestId}$`) });

--- a/tests/helpers/ui/hide-inspector-panel.ts
+++ b/tests/helpers/ui/hide-inspector-panel.ts
@@ -1,0 +1,20 @@
+import type { Page } from "@playwright/test";
+
+// Langflow 1.11.x (nightly) opens a right-side node Inspector Panel when a node
+// is selected. The panel overlaps the node's `model_model` dropdown and
+// intercepts the click ("subtree intercepts pointer events"), intermittently
+// failing every helper that opens the model picker on the canvas. Neither
+// Escape nor clicking the canvas pane closes it — only the canvas-control
+// toggle does.
+//
+// Hiding is idempotent: the "Hide Inspector Panel" accessible name only matches
+// when the panel is open, so this never re-opens a closed panel. It is a no-op
+// on Langflow builds without the panel (the button is absent), so it is safe to
+// call unconditionally before any `model_model` click.
+export async function hideInspectorPanel(page: Page): Promise<void> {
+  const hide = page.getByRole("button", { name: "Hide Inspector Panel" });
+  if (await hide.isVisible({ timeout: 1000 }).catch(() => false)) {
+    await hide.click();
+    await hide.waitFor({ state: "hidden", timeout: 5000 }).catch(() => {});
+  }
+}


### PR DESCRIPTION
## Summary

Weekly run #441 surfaced intermittent `model_model` click timeouts on agent tests (`model-provider-model-toggle`, `general-bugs-agent-images-playground`). On Langflow 1.11.x (nightly) a **right-side node Inspector Panel** opens when a node is selected and **overlaps the agent node's `model_model` dropdown**, intercepting the click (`subtree intercepts pointer events`).

## Root cause (reproduced live on nightly 1.11.0.dev25)

- The Inspector Panel (`react-flow__panel … w-[340px]`, inner `w-[320px] … pointer-events-auto`) covers the `model_model` button when a node is selected.
- Neither `Escape` nor clicking the canvas pane closes it — only the canvas-control toggle (`canvas_controls_toggle_inspector`, accessible name **"Hide Inspector Panel"**) does.
- It is intermittent (~50% of runs) because whether the node is selected — and thus the panel open — depends on render timing.

## Fix

- New helper `tests/helpers/ui/hide-inspector-panel.ts` — clicks the "Hide Inspector Panel" toggle. Guarded by the accessible name, which only matches when the panel is **open**, so it is idempotent (never re-opens) and a **no-op** on builds without the panel (e.g. released 1.11.0).
- Called before each `model_model` click in `setup-openai.ts`, `setup-google.ts`, `setup-anthropic.ts` (both the Step 2 "manage providers" open and the Step 7 model selection).

These two tests were **not** de-stabled by #447 (they were judged flaky); this fix makes them reliable and keeps `@stable`.

## Validation (nightly 1.11.0.dev25, `--retries=0`, clean provider state)

- `model-provider-model-toggle`: **3/3 green** (both tests each run)
- `general-bugs-agent-images-playground`: **2/2 green**
- **0 `model_model` interceptions** across ~8 runs (was ~50% before)
- typecheck ✅ · ESLint ✅ (0 findings)

Part of the weekly triage for #441.