### PR TITLE
fix(llm-invalid-api-key): mock POST /api/v2/workflows for playground run

### DIFF
--- a/docs/core-functionality/llm-agents/llm-invalid-api-key-ui.md
+++ b/docs/core-functionality/llm-agents/llm-invalid-api-key-ui.md
@@ -1,12 +1,12 @@
 # LLM Invalid API Key UI Error Display
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.11.x
 
 ---
 
 ## What this test validates *(required)*
 
-Validates that the Langflow Playground surfaces a visible error to the user when the execution endpoint returns HTTP 500 (simulating an invalid API key), and that the chat input remains fully usable after the error — no stuck loading state, no disabled input. Both scenarios are covered using `page.route` to mock `/api/v1/build/{flowId}/flow` (the endpoint the Playground uses for execution), so no real LLM call or API key is required.
+Validates that the Langflow Playground surfaces a visible error to the user when the execution endpoint returns HTTP 500 (simulating an invalid API key), and that the chat input remains fully usable after the error — no stuck loading state, no disabled input. Both scenarios are covered using `page.route` to mock `POST /api/v2/workflows` (the endpoint the Playground uses for execution on 1.11.x+), so no real LLM call or API key is required.
 
 ---
 
@@ -22,7 +22,7 @@ Validates that the Langflow Playground surfaces a visible error to the user when
 
 1. `setupPlayground(page)` — creates a blank flow with Chat Input and Chat Output connected, and navigates to the flow editor
 2. Click `playground-btn-flow-io` and wait for `input-chat-playground` (playground fully loaded)
-3. Register a `page.route` intercept for `**/api/v1/build/**` that fulfills the `/flow` sub-path with status 500 and body `{ detail: "Invalid API key…" }`, and lets all other build calls pass through
+3. Register a `page.route` intercept for `**/api/v2/workflows**` that fulfills the `POST` with status 500 and body `{ detail: "Invalid API key…" }`, and lets non-POST calls pass through
 4. Fill input with "trigger error" and click `button-send`
 5. Poll up to 10 s for any of: text matching `/error|invalid|api key|failed/i`, an element with `class*="error"` / `role="alert"`, or a `data-testid*="error"` element
 6. Assert `errorVisible === true`
@@ -30,11 +30,13 @@ Validates that the Langflow Playground surfaces a visible error to the user when
 **Test 2 — playground input remains usable after API error**
 
 1. Same setup as Test 1 (separate flow, same mock)
-2. Register `page.waitForResponse` for a response whose URL contains `/api/v1/build/` and `/flow` before triggering the request
+2. Register `page.waitForResponse` for a `POST` response whose URL contains `/api/v2/workflows` before triggering the request
 3. Send "trigger error" and click `button-send`
 4. Await the `waitForResponse` promise — confirms the full mocked 500 cycle completed
 5. Assert `input-chat-playground` is visible (timeout 5 s) and enabled (timeout 5 s)
 6. Fill input with "follow-up message" and assert `toHaveValue("follow-up message")` — confirms the input is fully interactive
+
+Both tests call `page.allowFlowErrors()` because they intentionally inject a 500 on the run endpoint.
 
 ---
 
@@ -50,7 +52,7 @@ Validates that the Langflow Playground surfaces a visible error to the user when
 
 - `src/frontend/src/components/core/playgroundComponent/` — renders `input-chat-playground`, `button-send`, and the error/toast UI; renaming or removing these `data-testid` attributes breaks both tests
 - `src/frontend/src/components/core/flowToolbarComponent/` — `playground-btn-flow-io` button; changes break the Playground open step
-- `src/backend/base/langflow/api/v1/endpoints.py` — the `/api/v1/build/{flow_id}/flow` endpoint being mocked; structural URL changes would require updating the route pattern
+- `src/backend/base/langflow/api/v2/` — the `POST /api/v2/workflows` execution endpoint being mocked; structural URL changes would require updating the route pattern (this endpoint replaced `/api/v1/build/{flow_id}/flow` in 1.11.x)
 
 ---
 
@@ -72,7 +74,8 @@ Validates that the Langflow Playground surfaces a visible error to the user when
 ## Notes *(optional)*
 
 - `page.route` intercepts before the request leaves the browser, so no real HTTP call reaches the Langflow backend. The 500 response is synthesized entirely in the browser process.
-- The mock targets `/api/v1/build/**` with a `/flow` URL filter. Other build calls (e.g. vertices ordering) are passed through with `route.continue()` so the playground initializes normally.
-- The mock is registered AFTER the playground is fully open (`input-chat-playground` visible) to avoid intercepting initialization build calls.
+- The mock targets `**/api/v2/workflows**` and only fulfills the `POST` (the run call); other methods are passed through with `route.continue()` so the playground initializes normally.
+- The mock is registered AFTER the playground is fully open (`input-chat-playground` visible) to avoid intercepting initialization calls.
 - Test 1 uses a flexible multi-locator check (`errorIndicators`) to be resilient to different error-surface implementations (text node, toast, alert element, or CSS class).
-- Test 2 uses `page.waitForResponse` on the build/flow URL to confirm the full 500 cycle completed before asserting input recovery, making the assertion deterministic.
+- Test 2 uses `page.waitForResponse` on the `POST /api/v2/workflows` URL to confirm the full 500 cycle completed before asserting input recovery, making the assertion deterministic.
+- History: the Playground execution path migrated from `POST /api/v1/build/{flow_id}/flow` to `POST /api/v2/workflows` in Langflow 1.11.x; the mock + waiter were updated accordingly (issue #444).

--- a/tests/tests-automations/regression/core-functionality/llm-agents/llm-invalid-api-key-ui.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/llm-invalid-api-key-ui.spec.ts
@@ -16,6 +16,9 @@ test.describe("LLM Invalid API Key UI Error Display", () => {
     "playground shows error when LLM run endpoint returns 500 (mocked invalid API key)",
     { tag: ["@stable", "@release", "@workspace", "@regression", "@agents", "@playground"] },
     async ({ page }) => {
+      // This test intentionally injects an HTTP 500 on the run endpoint, so the
+      // fixture's backend-error monitor will see it — allow it explicitly.
+      (page as any).allowFlowErrors();
       createdFlowId = await setupPlayground(page);
 
       // Open Playground first so initialization build calls are not intercepted
@@ -24,10 +27,11 @@ test.describe("LLM Invalid API Key UI Error Display", () => {
         timeout: 15000,
       });
 
-      // Langflow's playground uses /api/v1/build/{flowId}/flow for execution (not /run).
-      // Mock only the /flow call; let other build calls (e.g. vertices order) pass through.
-      await page.route("**/api/v1/build/**", async (route) => {
-        if (route.request().url().includes("/flow")) {
+      // Langflow's playground executes the flow via POST /api/v2/workflows
+      // (replaced the older /api/v1/build/{flowId}/flow path in 1.11.x). Mock the
+      // POST with a 500 to simulate an invalid-API-key run failure.
+      await page.route("**/api/v2/workflows**", async (route) => {
+        if (route.request().method() === "POST") {
           await route.fulfill({
             status: 500,
             contentType: "application/json",
@@ -72,8 +76,11 @@ test.describe("LLM Invalid API Key UI Error Display", () => {
 
   test(
     "playground input remains usable after API error (mocked)",
-    { tag: ["@release", "@workspace", "@regression", "@agents", "@playground"] },
+    { tag: ["@stable", "@release", "@workspace", "@regression", "@agents", "@playground"] },
     async ({ page }) => {
+      // This test intentionally injects an HTTP 500 on the run endpoint, so the
+      // fixture's backend-error monitor will see it — allow it explicitly.
+      (page as any).allowFlowErrors();
       createdFlowId = await setupPlayground(page);
 
       // Open Playground first so initialization build calls are not intercepted
@@ -82,9 +89,9 @@ test.describe("LLM Invalid API Key UI Error Display", () => {
         timeout: 15000,
       });
 
-      // Mock only the /flow execution call; let other build calls pass through
-      await page.route("**/api/v1/build/**", async (route) => {
-        if (route.request().url().includes("/flow")) {
+      // Mock the playground execution call (POST /api/v2/workflows) with a 500
+      await page.route("**/api/v2/workflows**", async (route) => {
+        if (route.request().method() === "POST") {
           await route.fulfill({
             status: 500,
             contentType: "application/json",
@@ -101,7 +108,8 @@ test.describe("LLM Invalid API Key UI Error Display", () => {
       // confirm the full mocked 500 cycle completed before asserting recovery
       const runResponsePromise = page.waitForResponse(
         (resp) =>
-          resp.url().includes("/api/v1/build/") && resp.url().includes("/flow"),
+          resp.url().includes("/api/v2/workflows") &&
+          resp.request().method() === "POST",
         { timeout: 10000 },
       );
 


### PR DESCRIPTION
## Summary

Fixes the de-stabled test **LLM Invalid API Key UI Error Display › playground input remains usable after API error (mocked)** from the weekly triage. **Closes #444.**

## Root cause (captured live on nightly 1.11.0.dev25)

A network trace of a real Playground send shows the run now goes to **`POST /api/v2/workflows`** — it replaced the older `POST /api/v1/build/{flow_id}/flow`. So:
- the test's mock (`**/api/v1/build/**` → 500) never intercepted the run, and
- `page.waitForResponse(/build/.../flow)` timed out after 10 s.

## Fix

- Mock **`**/api/v2/workflows**`** (POST → 500) in both tests, and point Test 2's `waitForResponse` at the same endpoint.
- Add `page.allowFlowErrors()` to both — the 500 is injected on purpose.
- Restore `@stable` on Test 2.
- Spec doc updated to match (endpoint, steps, external deps, Last validated → 1.11.x).

## Validation (nightly 1.11.0.dev25, `--retries=0`)

- typecheck ✅ · ESLint ✅ (no new findings)
- Both tests pass; the `waitForResponse` for `/api/v2/workflows` resolves every time the run executes.
- One run flaked in `setupPlayground` (drag-and-drop building the flow) — a pre-existing, separate flakiness unrelated to this fix; CI retries cover it.

Part of the weekly triage for #441.