### PR TITLE
test(core-components): extract addComponentFromSidebar shared helper

### DIFF
--- a/tests/helpers/flows/add-component-from-sidebar.ts
+++ b/tests/helpers/flows/add-component-from-sidebar.ts
@@ -1,0 +1,22 @@
+import { type Page } from "@playwright/test";
+
+/**
+ * Adds a component to the canvas via the sidebar: types the search term to
+ * filter the list, then clicks the component's "+" button.
+ *
+ * Deliberately a "dumb" primitive — it performs the mechanism only and asserts
+ * nothing. The intent (why the component is being added, and what should be
+ * true afterwards) belongs to the calling spec, which is free to wrap this and
+ * add its own assertions (node count, title visibility, etc.).
+ *
+ * @param searchTerm        text typed into `sidebar-search-input` to filter the sidebar
+ * @param addButtonTestId   testid of the component's "+" button, e.g. `add-component-button-chat-input`
+ */
+export const addComponentFromSidebar = async (
+  page: Page,
+  searchTerm: string,
+  addButtonTestId: string,
+) => {
+  await page.getByTestId("sidebar-search-input").fill(searchTerm);
+  await page.getByTestId(addButtonTestId).click();
+}; 

--- a/tests/helpers/flows/add-component-from-sidebar.ts
+++ b/tests/helpers/flows/add-component-from-sidebar.ts
@@ -19,4 +19,4 @@ export const addComponentFromSidebar = async (
 ) => {
   await page.getByTestId("sidebar-search-input").fill(searchTerm);
   await page.getByTestId(addButtonTestId).click();
-}; 
+};

--- a/tests/tests-automations/regression/core-components/componentDelete.spec.ts
+++ b/tests/tests-automations/regression/core-components/componentDelete.spec.ts
@@ -1,20 +1,6 @@
-import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
-
-// Local helper, specific to this spec. Adds a component to the canvas by
-// searching the sidebar and clicking its "+" button.
-// Kept local (not promoted to tests/helpers/) on purpose: here the component is
-// incidental — we just need "something to delete". Other specs that add a
-// component do it for a different reason and should not couple to this one.
-async function addComponent(
-  page: Page,
-  searchTerm: string,
-  addButtonTestId: string,
-) {
-  await page.getByTestId("sidebar-search-input").fill(searchTerm);
-  await page.getByTestId(addButtonTestId).click();
-}
+import { addComponentFromSidebar } from "../../../helpers/flows/add-component-from-sidebar";
 
 test.describe("Delete a component from the canvas", () => {
   let createdFlowId: string | null = null;
@@ -43,11 +29,9 @@ test.describe("Delete a component from the canvas", () => {
     { tag: ["@release", "@stable", "@workspace", "@components"] },
     async ({ page }) => {
       await test.step("Add a Chat Input component to the canvas", async () => {
-        await addComponent(
-          page,
+        await addComponentFromSidebar(page,
           "Chat Input",
-          "add-component-button-chat-input",
-        );
+          "add-component-button-chat-input");
         await expect(page.locator(".react-flow__node")).toHaveCount(1);
       });
 
@@ -65,11 +49,9 @@ test.describe("Delete a component from the canvas", () => {
     { tag: ["@release", "@stable", "@workspace", "@components"] },
     async ({ page }) => {
       await test.step("Add a Chat Input component to the canvas", async () => {
-        await addComponent(
-          page,
+        await addComponentFromSidebar(page,
           "Chat Input",
-          "add-component-button-chat-input",
-        );
+          "add-component-button-chat-input");
         await expect(page.locator(".react-flow__node")).toHaveCount(1);
       });
 
@@ -91,17 +73,13 @@ test.describe("Delete a component from the canvas", () => {
     { tag: ["@release", "@stable", "@workspace", "@components"] },
     async ({ page }) => {
       await test.step("Add two components to the canvas", async () => {
-        await addComponent(
-          page,
+        await addComponentFromSidebar(page,
           "Chat Input",
-          "add-component-button-chat-input",
-        );
+          "add-component-button-chat-input");
         await expect(page.locator(".react-flow__node")).toHaveCount(1);
-        await addComponent(
-          page,
+        await addComponentFromSidebar(page,
           "Chat Output",
-          "add-component-button-chat-output",
-        );
+          "add-component-button-chat-output");
         await expect(page.locator(".react-flow__node")).toHaveCount(2);
       });
 

--- a/tests/tests-automations/regression/core-components/singleton-components.spec.ts
+++ b/tests/tests-automations/regression/core-components/singleton-components.spec.ts
@@ -1,6 +1,7 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
+import { addComponentFromSidebar } from "../../../helpers/flows/add-component-from-sidebar";
 
 // Single source of truth for each component under test. Keeping the search
 // term and the testids together here is what prevents the copy/paste class of
@@ -27,19 +28,9 @@ const WEBHOOK: ComponentDescriptor = {
 // component cannot be duplicated or pasted (en.json: duplicateComponentsNotPasted).
 const NOT_PASTED_TOAST = "components were not pasted";
 
-// Low-level: search the sidebar and click a component's "+" button.
-async function addComponent(
-  page: Page,
-  searchTerm: string,
-  addButtonTestId: string,
-) {
-  await page.getByTestId("sidebar-search-input").fill(searchTerm);
-  await page.getByTestId(addButtonTestId).click();
-}
-
 // Add a component via the sidebar and confirm it landed on the canvas.
 async function addToCanvas(page: Page, component: ComponentDescriptor) {
-  await addComponent(page, component.name, component.addButton);
+  await addComponentFromSidebar(page, component.name, component.addButton);
   await expect(page.getByTestId(component.title)).toBeVisible();
   await expect(page.locator(".react-flow__node")).toHaveCount(1);
 }


### PR DESCRIPTION
## What

Extracts the recurring "search the sidebar, click a component's **+** button" mechanism into a shared primitive and adopts it where it was duplicated.

- **New helper** `tests/helpers/flows/add-component-from-sidebar.ts` — `addComponentFromSidebar(page, searchTerm, addButtonTestId)`. Deliberately a "dumb" primitive: it performs the mechanism only and asserts nothing. Callers own the intent and their own assertions.
- **Adopted** in `componentDelete.spec.ts` and `singleton-components.spec.ts`, replacing each spec's local `addComponent` helper.

## Why

The same fill+click pattern was copy-pasted as a per-spec local helper. Centralizing it removes the duplication and gives future specs a single, documented entry point.

## Scope notes

- `expectAddButtonCount` in `singleton-components.spec.ts` is intentionally **left as-is** — it does `fill` + a button-count assertion, not a click, so it is not the helper's pattern.
- The `Page` type import was dropped from `componentDelete.spec.ts` (no longer used after removing the local helper) and **kept** in `singleton-components.spec.ts` (still used by other helper signatures).
- A follow-up to adopt the same helper in `setup-playground.ts` (a shared file) is deliberately **out of scope** here — it will be a dedicated branch/PR.

## Validation

- `npm run typecheck` — clean
- `npm run lint` — no errors (pre-existing `expect-expect` warnings in `singleton-components.spec.ts` are unrelated: assertions live inside helper functions)
- `componentDelete.spec.ts` — 3/3 passing
- `singleton-components.spec.ts` — 8/8 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)