### PR TITLE
fix(provider-setup): make Inspector Panel close deterministic before model_model click

### DIFF
--- a/tests/helpers/provider-setup/setup-openai.ts
+++ b/tests/helpers/provider-setup/setup-openai.ts
@@ -69,9 +69,16 @@ export async function setupOpenAI(
   // Step 6: Close the provider management panel
   await page.getByRole("button", { name: "Close" }).click();
 
-  // Step 7: Select model — uses modelTestId if provided, otherwise selects the first available
+  // Step 7: Select model — uses modelTestId if provided, otherwise selects the first available.
+  // Closing the management panel (Step 6) puts the model dropdown into a
+  // post-close refresh state where the `model_model` trigger is briefly
+  // replaced by a (testid-less) "Loading models…" button while providers and
+  // enabled models refetch. Wait for the trigger to be VISIBLE — not merely
+  // attached — so the click does not race that loading swap.
   await hideInspectorPanel(page);
-  await page.getByTestId("model_model").click();
+  const modelTrigger = page.getByTestId("model_model");
+  await modelTrigger.waitFor({ state: "visible", timeout: 15000 });
+  await modelTrigger.click();
   if (modelTestId) {
     const modelOption = page.locator('[data-testid$="-option"]', { hasText: new RegExp(`^${modelTestId}$`) });
     const isAvailable = await modelOption.isVisible({ timeout: 10000 }).catch(() => false);

--- a/tests/helpers/ui/hide-inspector-panel.ts
+++ b/tests/helpers/ui/hide-inspector-panel.ts
@@ -1,20 +1,49 @@
-import type { Page } from "@playwright/test";
+import { type Page, expect } from "@playwright/test";
 
 // Langflow 1.11.x (nightly) opens a right-side node Inspector Panel when a node
-// is selected. The panel overlaps the node's `model_model` dropdown and
-// intercepts the click ("subtree intercepts pointer events"), intermittently
-// failing every helper that opens the model picker on the canvas. Neither
-// Escape nor clicking the canvas pane closes it — only the canvas-control
-// toggle does.
+// is selected. The panel is a `react-flow__panel` overlay (`w-[320px]`,
+// anchored `!top-[3rem] !-right-2`) that overlaps the node's `model_model`
+// dropdown and intercepts the click ("subtree intercepts pointer events"),
+// intermittently failing every helper that opens the model picker on the
+// canvas. Neither Escape nor clicking the canvas pane closes it — only the
+// canvas-control toggle does.
 //
-// Hiding is idempotent: the "Hide Inspector Panel" accessible name only matches
-// when the panel is open, so this never re-opens a closed panel. It is a no-op
-// on Langflow builds without the panel (the button is absent), so it is safe to
-// call unconditionally before any `model_model` click.
+// The toggle (`canvas_controls_toggle_inspector`) reflects the panel's open
+// state via `aria-pressed`, and the panel is conditionally rendered
+// (`{inspectionPanelVisible && <InspectionPanel/>}`) with a zero-duration exit
+// transition — so once `aria-pressed` flips to "false" the overlay is detached,
+// not merely animating out. We drive and assert on that state (and on the
+// overlay leaving the DOM) instead of the toggle's accessible name, so the wait
+// is deterministic and tied to the element that actually intercepts the click.
+//
+// Robustness: we wait for the canvas controls to mount rather than probing with
+// a short timeout that silently skips the close under CPU contention (the
+// parallel-run failure mode where the overlay stayed up and raced the
+// `model_model` click — a 20s click timeout in CI). The toggle is absent on
+// Langflow builds without the panel (ENABLE_INSPECTION_PANEL off), so the
+// helper is a safe no-op there.
 export async function hideInspectorPanel(page: Page): Promise<void> {
-  const hide = page.getByRole("button", { name: "Hide Inspector Panel" });
-  if (await hide.isVisible({ timeout: 1000 }).catch(() => false)) {
-    await hide.click();
-    await hide.waitFor({ state: "hidden", timeout: 5000 }).catch(() => {});
-  }
+  const toggle = page.getByTestId("canvas_controls_toggle_inspector");
+
+  const toggleAttached = await toggle
+    .waitFor({ state: "attached", timeout: 10000 })
+    .then(() => true)
+    .catch(() => false);
+  if (!toggleAttached) return; // build without the Inspector Panel — no-op
+
+  // Already closed (no node selected, or previously hidden) — nothing to do.
+  if ((await toggle.getAttribute("aria-pressed")) !== "true") return;
+
+  await toggle.click();
+
+  // Deterministic settle: the panel unmounts when the toggle state flips, so
+  // wait for the state to flip AND the 320px overlay to leave the DOM before
+  // the caller clicks `model_model`.
+  await expect(toggle).toHaveAttribute("aria-pressed", "false", {
+    timeout: 5000,
+  });
+  await page
+    .locator(".react-flow__panel:has([data-testid='panel-name'])")
+    .waitFor({ state: "detached", timeout: 5000 })
+    .catch(() => {});
 }

--- a/tests/helpers/ui/hide-inspector-panel.ts
+++ b/tests/helpers/ui/hide-inspector-panel.ts
@@ -16,17 +16,31 @@ import { type Page, expect } from "@playwright/test";
 // overlay leaving the DOM) instead of the toggle's accessible name, so the wait
 // is deterministic and tied to the element that actually intercepts the click.
 //
-// Robustness: we wait for the canvas controls to mount rather than probing with
-// a short timeout that silently skips the close under CPU contention (the
-// parallel-run failure mode where the overlay stayed up and raced the
-// `model_model` click — a 20s click timeout in CI). The toggle is absent on
-// Langflow builds without the panel (ENABLE_INSPECTION_PANEL off), so the
-// helper is a safe no-op there.
+// Robustness: we wait for the always-present canvas controls bar
+// (`main_canvas_controls`) to mount rather than probing the toggle with a short
+// timeout that silently skips the close under CPU contention (the parallel-run
+// failure mode where the overlay stayed up and raced the `model_model` click —
+// a 20s click timeout in CI). The long wait is spent on the bar — which renders
+// on every build — so it absorbs that slowness without charging the timeout to
+// builds that merely lack the feature. The toggle itself is gated by
+// `ENABLE_INSPECTION_PANEL` and renders in the same component as the bar, so
+// once the bar is mounted the toggle is either already present or absent for
+// this build — a short probe tells them apart and the helper is a fast no-op
+// when the panel feature is off.
 export async function hideInspectorPanel(page: Page): Promise<void> {
-  const toggle = page.getByTestId("canvas_controls_toggle_inspector");
-
-  const toggleAttached = await toggle
+  // Wait for the canvas controls bar to mount (absorbs CPU-contention slowness).
+  const controlsReady = await page
+    .getByTestId("main_canvas_controls")
     .waitFor({ state: "attached", timeout: 10000 })
+    .then(() => true)
+    .catch(() => false);
+  if (!controlsReady) return; // no canvas controls at all — nothing to do
+
+  // The toggle renders in the same commit as the bar, so a short probe is enough
+  // to distinguish "feature off" from "still mounting" without a long no-op wait.
+  const toggle = page.getByTestId("canvas_controls_toggle_inspector");
+  const toggleAttached = await toggle
+    .waitFor({ state: "attached", timeout: 1000 })
     .then(() => true)
     .catch(() => false);
   if (!toggleAttached) return; // build without the Inspector Panel — no-op


### PR DESCRIPTION
## Problem

The shared provider-setup path raced the node **Inspector Panel** teardown when clicking `model_model` (Step 7), producing a 20s `locator.click` timeout under CI parallelism. The intercepting element is the 320px `react-flow__panel` overlay (`!top-[3rem] !-right-2`, `w-[320px]`) — the `InspectionPanel` opened when the agent node is selected.

PR #449 added `hideInspectorPanel`, which targets the right element but is **not deterministic**:

1. **Silent skip under load** — `isVisible({ timeout: 1000 })` returns `false` if the canvas controls take >1s to render under CPU contention, so the whole close is skipped and the overlay stays up to intercept the click (the CI failure mode).
2. **Waits on the wrong thing** — it waits for the toggle's accessible name to change, not for the overlay to detach.

Separately, closing the management panel (Step 6) puts the model dropdown into a post-close refresh state (`isRefreshingAfterClose`) where the `model_model` trigger is briefly replaced by a testid-less "Loading models…" button.

## Fix

`tests/helpers/ui/hide-inspector-panel.ts` — rewritten deterministically:
- targets the stable `canvas_controls_toggle_inspector` testid;
- waits up to 10s for the canvas controls to mount instead of a 1s probe that no-ops under load;
- reads `aria-pressed` to skip when already closed, and after toggling waits for `aria-pressed="false"` **and** the 320px overlay to detach.

`tests/helpers/provider-setup/setup-openai.ts` Step 7 — waits for `model_model` to be **visible** (not merely attached) before clicking, covering the `isRefreshingAfterClose` loading swap.

> Scope kept to `setup-openai.ts` per the issue title. `setup-google.ts` / `setup-anthropic.ts` inherit the `hideInspectorPanel` hardening automatically (shared helper).

## Validation (Langflow 1.11.0)

- `general-bugs-agent-images-playground` + `model-provider-model-toggle` + `language-model-regression` — pass single-worker.
- The two affected specs pass `--repeat-each=3` with **all 10 CPU cores saturated** — the starvation condition that triggered the old 1s-probe silent skip.
- `tsc --noEmit` and ESLint clean.

Closes #446