### PR TITLE
fix: allow pre-releases when installing nightly in migration test

### DIFF
--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -161,7 +161,16 @@ jobs:
 
       - name: Install Langflow nightly
         run: |
-          uv pip install "langflow[postgresql]==$NIGHTLY_VERSION"
+          # The nightly is the latest pre-release of the `langflow` PyPI package
+          # (e.g. 1.11.0.dev26). That release pins its transitive dependency
+          # `langflow-base[complete]==<same dev version>`. uv does NOT consider
+          # pre-release versions for transitive dependencies by default, so the
+          # exact-pinned dev `langflow-base` is reported as "no version found"
+          # and resolution fails ("No solution found … requirements are
+          # unsatisfiable"). `--prerelease=allow` lets uv consider pre-releases
+          # for the whole resolution; stable deps are still preferred where a
+          # stable version satisfies the constraint.
+          uv pip install --prerelease=allow "langflow[postgresql]==$NIGHTLY_VERSION"
           echo "Installed Langflow $NIGHTLY_VERSION (nightly)"
 
       - name: Start Langflow nightly (same database)
@@ -220,7 +229,7 @@ jobs:
             echo "| Workflow | \`${{ github.workflow }}\` |"
             echo "| Job | \`${{ github.job }}\` (pip-based) |"
             echo "| Source | \`langflow==${LATEST_VERSION:-?}\` via \`uv pip install \"langflow[postgresql]\"\` |"
-            echo "| Target | \`langflow==${NIGHTLY_VERSION:-?}\` via \`uv pip install \"langflow[postgresql]==<version>\"\` |"
+            echo "| Target | \`langflow==${NIGHTLY_VERSION:-?}\` via \`uv pip install --prerelease=allow \"langflow[postgresql]==<version>\"\` |"
             echo "| Database | PostgreSQL 16 (GHA service) |"
             echo "| OPENAI_API_KEY | auto-imported as Credential on each Langflow startup |"
             echo ""


### PR DESCRIPTION
## What this fixes

The **Langflow Migration Test: Latest → Nightly** workflow (`migration-test.yml`) was failing on every scheduled run at the **Install Langflow nightly** step. Failing run: https://github.com/oriontech-me/langflow-e2e/actions/runs/28437523025

## Root cause

The step resolves the latest pre-release of the `langflow` PyPI package (e.g. `1.11.0.dev26`) and installs it:

```
uv pip install "langflow[postgresql]==1.11.0.dev26"
```

That dev release pins its **transitive** dependency `langflow-base[complete]==1.11.0.dev26`. The package and the `complete` extra both exist on PyPI — but **uv does not consider pre-release versions for transitive dependencies by default**, so it treats the exact-pinned dev `langflow-base` as unavailable and aborts:

```
× No solution found when resolving dependencies:
╰─▶ Because there is no version of langflow-base[complete]==1.11.0.dev26 ...
    requirements are unsatisfiable.
hint: pre-releases weren't enabled (try: `--prerelease=allow`)
```

The companion `migration-test-compose` job is unaffected because it migrates via the `langflowai/langflow-nightly:latest` Docker image, not pip.

## Fix

Add `--prerelease=allow` to the nightly install so uv considers pre-releases across the whole resolution. Stable dependencies are still preferred where a stable version satisfies the constraint. The summary string that documents the install command was updated to match.

## How it was validated

Reproduced and verified locally with uv 0.9.17:

- **Before** (`uv pip install "langflow[postgresql]==1.11.0.dev26"`) → `No solution found ... unsatisfiable` (matches CI).
- **After** (`uv pip install --prerelease=allow "langflow[postgresql]==1.11.0.dev26"`) → `Resolved 639 packages`; installs `langflow==1.11.0.dev26` + `langflow-base==1.11.0.dev26` + `psycopg`/`psycopg2-binary` (postgresql extra), with all other deps still on stable versions.
- `python -c "yaml.safe_load(...)"` confirms the workflow YAML is still valid.

## Scope / not covered

- Only `migration-test.yml` had the pip-based nightly install. `migration-fresh-install.yml` and `migration-upgrade-with-flows.yml` use the nightly Docker image and are not affected.
- The downstream steps (Start nightly / Wait for migration / Verify API / Verify UI) could not run while install was failing, so they are exercised for the first time by this fix's next scheduled run; the parallel docker-compose job passing is a strong signal the migration itself is healthy.
