### PR TITLE
feat(daily-stable): report resolved Langflow version + stamp run date in BRT

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -164,8 +164,12 @@ jobs:
         id: lfver
         continue-on-error: true
         run: |
-          V="$(curl -sf http://localhost:7860/api/v1/version \
-            | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{try{process.stdout.write((JSON.parse(d).version||"").toString())}catch{process.stdout.write("")}})')"
+          # --connect-timeout/--max-time so a slow/hung service can't stall the
+          # job; tr strips any CR/LF so the value stays a single line and never
+          # corrupts the key=value $GITHUB_OUTPUT format.
+          V="$(curl -sf --connect-timeout 5 --max-time 15 http://localhost:7860/api/v1/version \
+            | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{try{process.stdout.write((JSON.parse(d).version||"").toString())}catch{process.stdout.write("")}})' \
+            | tr -d '\r\n')"
           echo "Resolved Langflow version: '${V:-<none>}'"
           echo "version=$V" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -153,6 +153,22 @@ jobs:
           echo "stable=$(npx ts-node scripts/stable-tests.ts --count)" >> "$GITHUB_OUTPUT"
           echo "total=$(grep -rE '^\s*test\s*\(' tests/tests-automations/regression --include='*.spec.ts' | wc -l | tr -d ' ')" >> "$GITHUB_OUTPUT"
 
+      # Resolve the ACTUAL Langflow version running in the service container.
+      # The image tag is just `:latest` (or an RC/stable tag), so it never
+      # carries the concrete nightly build (e.g. 1.11.0.dev25). Ask the running
+      # service via its public /api/v1/version endpoint (AUTO_LOGIN is on, so it
+      # needs no auth) and feed it into the payload so the QA Platform's Run
+      # Summary can show the exact version tested. Best-effort: never fail the run.
+      - name: Resolve Langflow version
+        if: always()
+        id: lfver
+        continue-on-error: true
+        run: |
+          V="$(curl -sf http://localhost:7860/api/v1/version \
+            | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{try{process.stdout.write((JSON.parse(d).version||"").toString())}catch{process.stdout.write("")}})')"
+          echo "Resolved Langflow version: '${V:-<none>}'"
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+
       - name: Build run payload
         if: always()
         env:
@@ -161,6 +177,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           LANGFLOW_IMAGE: ${{ inputs.langflow_image || 'langflowai/langflow-nightly' }}:${{ inputs.langflow_image_tag || 'latest' }}
+          LANGFLOW_VERSION: ${{ steps.lfver.outputs.version }}
           STABLE_COUNT: ${{ steps.cov.outputs.stable }}
           TOTAL_COUNT:  ${{ steps.cov.outputs.total }}
           EVIDENCE_URL: ${{ steps.upload_report.outputs.artifact-url }}

--- a/scripts/build-run-payload.mjs
+++ b/scripts/build-run-payload.mjs
@@ -34,14 +34,28 @@ const coverage = (process.env.STABLE_COUNT || process.env.TOTAL_COUNT)
   ? { stable_count: num(process.env.STABLE_COUNT), total_count: num(process.env.TOTAL_COUNT) } : undefined;
 
 const now = new Date();
+// Stamp date/time in BRT (America/Sao_Paulo), NOT UTC. run_date is what the QA
+// Platform's Trend view filters on and the Run Summary labels "BRT"; stamping in
+// UTC rolled a run started after 21:00 BRT (00:00 UTC) onto the next calendar
+// day, so it fell outside the Trend's default "last N days" window while Run
+// Summary (no date filter) still showed it. See qa-platform spec 001.
+const brtParts = new Intl.DateTimeFormat("en-CA", {
+  timeZone: "America/Sao_Paulo",
+  year: "numeric", month: "2-digit", day: "2-digit",
+  hour: "2-digit", minute: "2-digit", hourCycle: "h23",
+}).formatToParts(now);
+const brt = t => brtParts.find(p => p.type === t)?.value ?? "";
+const runDate = `${brt("year")}-${brt("month")}-${brt("day")}`;
+const runTime = `${brt("hour")}:${brt("minute")}`;
 const payload = {
   version: 1,
-  date: now.toISOString().slice(0,10),
-  time: now.toISOString().slice(11,16),                 // HH:MM UTC — real run time, disambiguates same-day runs
+  date: runDate,
+  time: runTime,                                        // HH:MM BRT — real run time, disambiguates same-day runs
   workflow: process.env.WORKFLOW || "weekly-stable",
   run_id: process.env.GITHUB_RUN_ID || "local",
   run_url: process.env.RUN_URL || null,
   langflow_image: process.env.LANGFLOW_IMAGE || null,   // the nightly build (or RC/stable on a manual run)
+  langflow_version: process.env.LANGFLOW_VERSION || null, // resolved version from GET /api/v1/version (e.g. 1.11.0.dev25)
   langflow_commit_sha: process.env.LANGFLOW_COMMIT_SHA || null,
   duration_ms: Math.round(report?.stats?.duration ?? 0),
   ...(coverage ? { coverage } : {}),

--- a/scripts/build-run-payload.mjs
+++ b/scripts/build-run-payload.mjs
@@ -39,14 +39,24 @@ const now = new Date();
 // UTC rolled a run started after 21:00 BRT (00:00 UTC) onto the next calendar
 // day, so it fell outside the Trend's default "last N days" window while Run
 // Summary (no date filter) still showed it. See qa-platform spec 001.
-const brtParts = new Intl.DateTimeFormat("en-CA", {
-  timeZone: "America/Sao_Paulo",
-  year: "numeric", month: "2-digit", day: "2-digit",
-  hour: "2-digit", minute: "2-digit", hourCycle: "h23",
-}).formatToParts(now);
-const brt = t => brtParts.find(p => p.type === t)?.value ?? "";
-const runDate = `${brt("year")}-${brt("month")}-${brt("day")}`;
-const runTime = `${brt("hour")}:${brt("minute")}`;
+let runDate, runTime;
+try {
+  const brtParts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/Sao_Paulo",
+    year: "numeric", month: "2-digit", day: "2-digit",
+    hour: "2-digit", minute: "2-digit", hourCycle: "h23",
+  }).formatToParts(now);
+  const brt = t => brtParts.find(p => p.type === t)?.value ?? "";
+  runDate = `${brt("year")}-${brt("month")}-${brt("day")}`;
+  runTime = `${brt("hour")}:${brt("minute")}`;
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(runDate) || !/^\d{2}:\d{2}$/.test(runTime)) throw new Error("unexpected BRT parts");
+} catch (e) {
+  // ICU/TZ data missing or malformed — fall back to UTC so the payload step
+  // never hard-fails on date formatting (it has no continue-on-error).
+  console.error(`[payload] BRT stamp failed (${e?.message || e}); falling back to UTC`);
+  runDate = now.toISOString().slice(0, 10);
+  runTime = now.toISOString().slice(11, 16);
+}
 const payload = {
   version: 1,
   date: runDate,


### PR DESCRIPTION
## O quê
Duas mudanças no workflow `daily-stable` para alimentar o **Workflow Report** do QA Platform (langflow.works/e2e-tests/dashboard):

1. **Versão real da nightly.** Novo step *"Resolve Langflow version"* lê `GET /api/v1/version` do serviço Langflow em execução e injeta `LANGFLOW_VERSION` no payload. Hoje só a tag `:latest` era enviada, então a barra meta do Run Summary não tinha como mostrar o build concreto (ex.: `1.11.0.dev25`). Best-effort (`continue-on-error`), nunca derruba o run.
2. **Carimbo de data em BRT.** `build-run-payload.mjs` passa a carimbar `date`/`time` em `America/Sao_Paulo` em vez de UTC, e emite `langflow_version`.

## Por quê o BRT
`run_date` era gravado em UTC (`now.toISOString()`). Um run iniciado depois das 21:00 BRT (00:00 UTC) rolava para o dia seguinte no calendário → caía fora da janela padrão ("last N days") do Trend do QA Platform, que ficava vazio enquanto o Run Summary (sem filtro de data) mostrava o run. Carimbar em BRT alinha `run_date` ao rótulo "BRT" que a UI já exibe.

> O lado do QA Platform (coluna `langflow_version`, célula "Version" no Summary, fix de janela no Trend, aba "Workflow Report") já foi para a `main` do quality-platform. Ref: spec local `001-workflow-report-daily-stable`.

## Validação
- `node --check scripts/build-run-payload.mjs` ok; parser de versão e carimbo BRT testados localmente.
- YAML validado (`yaml.safe_load`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)