### PR TITLE
chore(triage): remove @stable from two hard-failing specs (daily #461)

### DIFF
--- a/docs/core-components/api-request-component-regression.md
+++ b/docs/core-components/api-request-component-regression.md
@@ -20,8 +20,10 @@ If any of these tests fails, the API Request component is broken in the product 
 
 ## Tags *(required)*
 
-All 15 tests: `@stable` `@regression` `@components`
+14 of the 15 tests: `@stable` `@regression` `@components`
 8 of them additionally carry `@release` (the canvas/inspector/GET/POST/PUT/PATCH/DELETE happy paths).
+
+The **GET request returns 200** test (#4 below) does **not** carry `@stable` — it was removed in the #461 daily-triage PR because the test depends on the public `postman-echo` endpoint and hard-fails the daily suite during external outages (see #462). Re-add once a reliable echo endpoint is available in CI.
 
 ---
 

--- a/docs/mcp/client/mcp-client-regression.md
+++ b/docs/mcp/client/mcp-client-regression.md
@@ -12,7 +12,9 @@ Validates the full MCP client configuration and tool execution path — without 
 
 ## Tags *(required)*
 
-`@mcp` `@regression`
+All tests: `@mcp` `@regression`. Tests 2 (echo tool execution) and 3 (HTTP form registration) additionally carry `@stable`.
+
+Test 4 (numeric `get-sum`) does **not** carry `@stable` — it was removed in the #461 daily-triage PR because the test depends on the `npx server-everything` MCP server registering its tools in time, which hard-fails the daily suite on cold startup (see #463). Re-add once server startup is reliable in CI.
 
 ---
 

--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -372,8 +372,12 @@ test(
 // =============================================================================
 
 test(
+  // @stable removed pending #462 — this test depends on the public postman-echo
+  // endpoint, which hard-fails the daily suite during external outages (daily
+  // 2026-07-01, weekly 2026-06-22). Re-add once a reliable echo endpoint is
+  // provided in CI.
   "API Request component — GET request returns 200 and output Data contains all required fields",
-  { tag: ["@stable", "@release", "@regression", "@components"] },
+  { tag: ["@release", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
 

--- a/tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts
@@ -319,8 +319,11 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
   );
 
   test(
+    // @stable removed pending #463 — depends on the `npx server-everything` MCP
+    // server registering its tools in time, which hard-failed the daily suite
+    // (2026-07-01) on cold startup. Re-add once server startup is reliable in CI.
     "selects get-sum tool, provides numeric inputs, and verifies sum in output",
-    { tag: ["@mcp", "@regression", "@stable"] },
+    { tag: ["@mcp", "@regression"] },
     async ({ page }) => {
       // Allow backend errors — npx server may return transient errors while starting
       (page as any).allowFlowErrors();


### PR DESCRIPTION
## What

Triage of the daily `@stable` failure on **2026-07-01** (Langflow `1.11.0.dev26`, run [28514231353](https://github.com/oriontech-me/langflow-e2e/actions/runs/28514231353)). Removes `@stable` from the two tests that **hard-failed** (all 3 retries) so they no longer gate the daily suite.

Neither hard failure is a Langflow regression — both are external-dependency failures:

| Test | Cause | Dedicated issue |
|---|---|---|
| `api-request-component-regression.spec.ts` — GET returns 200 | build `/events` stream timed out; backend request to public `postman-echo` hung (also hard-failed 2026-06-22) | #462 |
| `mcp-client-regression.spec.ts` — get-sum | `npx server-everything` never registered tools within 90s on cold startup | #463 |

`@stable` restoration is listed as a deliverable in each issue, to be done once the dependency is made reliable in CI.

## Changes

- Remove `@stable` from both tests, with an inline comment pointing at the tracking issue.
- Update both spec docs' **Tags** sections to reflect the per-test state and explain the removal.

## Not changed (flaky, `@stable` kept)

The 4 flaky tests recovered on retry, so they keep `@stable`. Recurrence (2+) is tracked separately per the daily-cadence triage rule: #464 (tool-mode), #465 (playground-output-data), #466 (memory-history). `canvas-copy-paste` was a first-time flake — observing only.

Closes #461
