### PR TITLE
fix(ci): open daily-stable failure issue on manual runs too

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -245,8 +245,11 @@ jobs:
           git commit -m "chore(history): record daily run ${{ github.run_id }} [skip ci]"
           git push
 
+      # Open a triage issue on failure for BOTH scheduled and manual runs — a
+      # manual re-run of a red build should also surface a tracked issue. (The
+      # history steps above stay schedule-only; only issue-opening is broadened.)
       - name: Create issue on failure
-        if: failure() && github.event_name == 'schedule'
+        if: failure()
         uses: actions/github-script@v7
         env:
           IMAGE: ${{ inputs.langflow_image || 'langflowai/langflow-nightly' }}:${{ inputs.langflow_image_tag || 'latest' }}


### PR DESCRIPTION
## What

The daily-stable `Create issue on failure` step was gated on `github.event_name == 'schedule'`, so a manual `workflow_dispatch` run that failed opened **no** triage issue (the scheduled run correctly created #461). This broadens the gate to `failure()` so **both scheduled and manual runs** open a triage issue on failure.

## Scope

- Only the **issue-creation gate** changes. History `Append`/`Commit` steps stay `schedule`-only (manual runs must not pollute the longitudinal series); the QA Platform POST already runs on every run.
- This intentionally diverges from `nightly.yml` / `weekly-stable.yml` (which stay schedule-only for issue creation), per request — a manually re-run red build should surface a tracked issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)