### PR TITLE
chore(ci): run daily-stable on weekdays only (Mon–Fri)

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -8,7 +8,7 @@ run-name: "Daily Stable E2E — ${{ github.event_name == 'schedule' && 'schedule
 
 on:
   schedule:
-    - cron: "0 8 * * *" # 05:00 BRT (UTC-3), every day
+    - cron: "0 8 * * 1-5" # 05:00 BRT (UTC-3), Monday–Friday
   workflow_dispatch:
     inputs:
       langflow_image:
@@ -211,7 +211,7 @@ jobs:
       # recurring breakage is recorded, not just clean runs.
       # Gated on `schedule` only — manual dispatches (workflow_dispatch) do not
       # write to the history file, to keep the series predictable for
-      # longitudinal analysis (one entry per day, same trigger, same cadence).
+      # longitudinal analysis (one entry per scheduled run, same trigger, same cadence).
       - name: Append daily history
         if: always() && github.event_name == 'schedule'
         # Reuses the shared appender unchanged; the HISTORY_FILE / WORKFLOW env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ GitHub Actions workflows:
 
 - **`pr-validation.yml`** — Runs on every PR to `main`; two parallel jobs: TypeScript check (`tsc --noEmit`) and ESLint. Both must pass before merge.
 - **`nightly.yml`** — Runs daily at 03:00 BRT against `langflowai/langflow-nightly:latest`; opens a GitHub issue on failure assigned to @Victor-w-Madeira.
-- **`daily-stable.yml`** — Runs daily at 05:00 BRT against `langflowai/langflow-nightly:latest`; runs only `@stable` tests; opens a GitHub issue on failure for triage (`daily-failure` label); appends one entry to `reports/daily-history.jsonl` and commits it back to `main` with `[skip ci]` (runs on success and failure). **This is the active stable workflow.**
+- **`daily-stable.yml`** — Runs on weekdays (Mon–Fri) at 05:00 BRT against `langflowai/langflow-nightly:latest`; runs only `@stable` tests; opens a GitHub issue on failure for triage (`daily-failure` label); appends one entry to `reports/daily-history.jsonl` and commits it back to `main` with `[skip ci]` (runs on success and failure). **This is the active stable workflow.**
 - **`weekly-stable.yml`** — **Disabled** (kept as a fallback, superseded by `daily-stable.yml`). When enabled it runs every Monday with the same machinery, writing to `reports/weekly-history.jsonl`.
 - **`manual.yml`** — Parameterized manual run; accepts a Docker tag or full URL, a specific test suite, and an optional grep filter.
 - **`file-watcher.yml`** — Detects upstream Langflow changes in critical paths and opens a GitHub issue with the exact `--grep` command needed to revalidate affected areas.

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ tests/
 |---|---|---|
 | `pr-validation.yml` | Every PR to `main` | TypeScript check (`tsc --noEmit`) + ESLint in parallel — both must pass before merge |
 | `nightly.yml` | Daily 03:00 BRT + manual | Runs everything against `langflow-nightly:latest`, opens an issue on failure |
-| `daily-stable.yml` | Daily 05:00 BRT + manual | Runs `@stable` tests against `langflow-nightly:latest`; opens a triage issue on failure and uploads a navigable HTML report. **Active stable workflow.** |
+| `daily-stable.yml` | Mon–Fri 05:00 BRT + manual | Runs `@stable` tests against `langflow-nightly:latest`; opens a triage issue on failure and uploads a navigable HTML report. **Active stable workflow.** |
 | `weekly-stable.yml` | Disabled (fallback) | Superseded by `daily-stable.yml`; kept in the repo, disabled. Same `@stable` machinery on a weekly cron when enabled |
 | `manual.yml` | Manual | Runs against any Docker tag or external URL, filters by suite/tag |
 | `file-watcher.yml` | Daily 05:00 BRT | Monitors changes in Langflow source and opens a review issue |


### PR DESCRIPTION
Changes the `daily-stable.yml` schedule from every day (`0 8 * * *`) to **weekdays only** (`0 8 * * 1-5`, Mon–Fri 05:00 BRT). Schedule descriptions in `CLAUDE.md` and `README.md` updated; workflow name and `daily-*` identifiers unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)