### PR TITLE
chore(ci): shorten daily-stable full report retention 14 → 7 days

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -139,7 +139,7 @@ jobs:
         with:
           name: playwright-report-daily-${{ github.run_id }}
           path: playwright-report/
-          retention-days: 14
+          retention-days: 7
 
       # Lightweight, self-contained report: index.html embeds the whole test tree,
       # statuses, errors and steps inline (playwrightReportBase64), so it opens


### PR DESCRIPTION
The heavy full report artifact (`playwright-report-daily-<run_id>`: index + `data/` + `trace/`, ~380 MB) now expires after **7 days** instead of 14. The lightweight index-only artifact (`playwright-report-index-daily-<run_id>`) keeps its **90-day** retention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)