### PR TITLE
feat(payload): emit full per-test results for native QA Platform rendering

### DIFF
--- a/scripts/build-run-payload.mjs
+++ b/scripts/build-run-payload.mjs
@@ -61,7 +61,7 @@ function extractSteps(steps) {
 }
 
 // Read the failure screenshot for a result: prefer an inline body, else the file
-// on disk. Returns { contentType, base64 } or null. Bounded by MAX_SCREENSHOT_BYTES.
+// on disk. Returns { content_type, base64 } or null. Bounded by MAX_SCREENSHOT_BYTES.
 function readScreenshot(result) {
   if (!result) return null;
   const att = (result.attachments || []).find(

--- a/scripts/build-run-payload.mjs
+++ b/scripts/build-run-payload.mjs
@@ -1,6 +1,11 @@
 #!/usr/bin/env node
 // Build the e2e_automation_runs payload from a Playwright JSON report + env metadata.
-// Writes JSON to stdout. Mirrors append-weekly-history.mjs parsing; adds v2 fields.
+// Writes JSON to stdout. Mirrors append-weekly-history.mjs parsing; adds the v2
+// coverage block AND a per-test `tests[]` array (every test: name/file/status/
+// duration/tags/steps; failures also carry the full error + a base64 screenshot)
+// so the QA Platform can render the full run natively — incl. skipped tests —
+// instead of only counts. The screenshot rides in the POST as base64; the edge
+// function uploads it to Storage and stores only the URL (the DB keeps no base64).
 import { readFileSync, existsSync } from "node:fs";
 import { relative, resolve } from "node:path";
 
@@ -8,28 +13,112 @@ const reportPath = process.env.PLAYWRIGHT_JSON || "results.json";
 if (!existsSync(reportPath)) { console.error(`[payload] no ${reportPath}`); process.exit(1); }
 const report = JSON.parse(readFileSync(reportPath, "utf8"));
 
+// Caps keep the POST body bounded — screenshots ride in the payload, and a huge
+// report must never break run ingestion. Only the first N failed tests carry a
+// screenshot; oversized single shots and over-long error text are dropped/trimmed.
+const MAX_SCREENSHOTS = 25;
+const MAX_SCREENSHOT_BYTES = 3_000_000;
+const MAX_ERROR_CHARS = 8000;
+let screenshotCount = 0;
+
 const totals = { passed: 0, failed: 0, flaky: 0, skipped: 0 };
-const failures = [], flaky = [];
-const firstErr = r => { const e = r?.error || r?.errors?.[0]; return e ? (e.message||e.value||"").split("\n")[0].slice(0,240) : null; };
-const relFile = s => { try { return relative(process.cwd(), resolve(s?.file||s?.location?.file||"")); } catch { return s?.file||""; } };
-function visit(node){
-  for (const spec of node.specs||[]) {
-    const file = relFile(spec), line = spec?.line||spec?.location?.line||0;
-    for (const t of spec.tests||[]) {
-      const tags = t.tags||spec.tags||[], attempts=(t.results||[]).length, title=spec.title;
-      if (t.status==="skipped"){totals.skipped++;continue;}
-      if (t.status==="expected"){totals.passed++;continue;}
-      if (t.status==="flaky"){totals.flaky++;flaky.push({test:title,file,line,tags,attempts});continue;}
-      totals.failed++;
-      const last=[...(t.results||[])].reverse().find(r=>r.status!=="passed");
-      failures.push({test:title,file,line,tags,attempts,error_signature:firstErr(last)||"unknown"});
+const failures = [], flaky = [], tests = [];
+
+const stripAnsi = (s) => (s || "").replace(/\[[0-9;]*m/g, "");
+const firstErr = (r) => {
+  const e = r?.error || r?.errors?.[0];
+  return e ? stripAnsi(e.message || e.value || "").split("\n")[0].slice(0, 240) : null;
+};
+const fullErr = (r) => {
+  const e = r?.error || r?.errors?.[0];
+  if (!e) return null;
+  const msg = stripAnsi(e.message || e.value || "");
+  const stack = stripAnsi(e.stack || "");
+  const combined = stack && !msg.includes(stack) ? `${msg}\n\n${stack}` : (msg || stack);
+  return combined.slice(0, MAX_ERROR_CHARS) || null;
+};
+const relFile = (s) => {
+  try { return relative(process.cwd(), resolve(s?.file || s?.location?.file || "")); }
+  catch { return s?.file || ""; }
+};
+
+// Keep only the human-authored test.step() steps (recursively), dropping the
+// noisy built-in pw:api / expect / hook internals — that's what a person wants
+// to see when expanding a test, and it keeps the JSONB compact.
+function extractSteps(steps) {
+  const out = [];
+  for (const st of steps || []) {
+    if (st?.category === "test.step") {
+      const node = { title: st.title, duration_ms: Math.round(st.duration ?? 0) };
+      const children = extractSteps(st.steps);
+      if (children.length) node.steps = children;
+      out.push(node);
+    } else if (st?.steps?.length) {
+      out.push(...extractSteps(st.steps)); // pull test.step children out of a wrapper
     }
   }
-  for (const c of node.suites||[]) visit(c);
+  return out;
 }
-for (const s of report.suites||[]) visit(s);
 
-const num = v => { const n = parseInt(v,10); return Number.isFinite(n) ? n : null; };
+// Read the failure screenshot for a result: prefer an inline body, else the file
+// on disk. Returns { contentType, base64 } or null. Bounded by MAX_SCREENSHOT_BYTES.
+function readScreenshot(result) {
+  if (!result) return null;
+  const att = (result.attachments || []).find(
+    (a) => a?.name === "screenshot" || a?.contentType === "image/png",
+  );
+  if (!att) return null;
+  try {
+    let buf;
+    if (att.body) buf = Buffer.from(att.body, "base64");
+    else if (att.path && existsSync(att.path)) buf = readFileSync(att.path);
+    else return null;
+    if (buf.length > MAX_SCREENSHOT_BYTES) return null;
+    return { content_type: att.contentType || "image/png", base64: buf.toString("base64") };
+  } catch { return null; }
+}
+
+// Playwright test.status → normalized status the QA Platform renders.
+const normStatus = (s) => (s === "expected" ? "passed" : s === "unexpected" ? "failed" : s);
+
+function visit(node) {
+  for (const spec of node.specs || []) {
+    const file = relFile(spec), line = spec?.line || spec?.location?.line || 0;
+    for (const t of spec.tests || []) {
+      const tags = t.tags || spec.tags || [];
+      const attempts = (t.results || []).length;
+      const title = spec.title;
+      const status = normStatus(t.status);
+      const results = t.results || [];
+      const last = results[results.length - 1];
+      const lastFailed = [...results].reverse().find((r) => r.status !== "passed" && r.status !== "skipped");
+      const duration_ms = Math.round(last?.duration ?? 0);
+
+      const entry = { test: title, file, line, status, duration_ms, tags, attempts };
+      const steps = extractSteps((last || {}).steps);
+      if (steps.length) entry.steps = steps;
+      if (status === "failed") {
+        entry.error = fullErr(lastFailed || last);
+        if (screenshotCount < MAX_SCREENSHOTS) {
+          const shot = readScreenshot(lastFailed || last);
+          if (shot) { entry.screenshot = shot; screenshotCount++; }
+        }
+      }
+      tests.push(entry);
+
+      // Existing aggregate arrays — unchanged contract (also feed the JSONL script).
+      if (t.status === "skipped") { totals.skipped++; continue; }
+      if (t.status === "expected") { totals.passed++; continue; }
+      if (t.status === "flaky") { totals.flaky++; flaky.push({ test: title, file, line, tags, attempts }); continue; }
+      totals.failed++;
+      failures.push({ test: title, file, line, tags, attempts, error_signature: firstErr(lastFailed) || "unknown" });
+    }
+  }
+  for (const c of node.suites || []) visit(c);
+}
+for (const s of report.suites || []) visit(s);
+
+const num = (v) => { const n = parseInt(v, 10); return Number.isFinite(n) ? n : null; };
 const coverage = (process.env.STABLE_COUNT || process.env.TOTAL_COUNT)
   ? { stable_count: num(process.env.STABLE_COUNT), total_count: num(process.env.TOTAL_COUNT) } : undefined;
 
@@ -46,7 +135,7 @@ try {
     year: "numeric", month: "2-digit", day: "2-digit",
     hour: "2-digit", minute: "2-digit", hourCycle: "h23",
   }).formatToParts(now);
-  const brt = t => brtParts.find(p => p.type === t)?.value ?? "";
+  const brt = (t) => brtParts.find((p) => p.type === t)?.value ?? "";
   runDate = `${brt("year")}-${brt("month")}-${brt("day")}`;
   runTime = `${brt("hour")}:${brt("minute")}`;
   if (!/^\d{4}-\d{2}-\d{2}$/.test(runDate) || !/^\d{2}:\d{2}$/.test(runTime)) throw new Error("unexpected BRT parts");
@@ -72,5 +161,9 @@ const payload = {
   ...(process.env.EVIDENCE_URL ? { evidence_artifact_url: process.env.EVIDENCE_URL } : {}),
   ...(process.env.EVIDENCE_EXPIRES_AT ? { evidence_expires_at: process.env.EVIDENCE_EXPIRES_AT } : {}),
   totals, failures, flaky,
+  // Optional, backwards-compatible addition (version stays 1): the full per-test
+  // list. The currently-deployed edge function ignores unknown fields, so this is
+  // a no-op until the QA Platform is updated to persist it.
+  tests,
 };
 process.stdout.write(JSON.stringify(payload));

--- a/scripts/build-run-payload.mjs
+++ b/scripts/build-run-payload.mjs
@@ -24,7 +24,7 @@ let screenshotCount = 0;
 const totals = { passed: 0, failed: 0, flaky: 0, skipped: 0 };
 const failures = [], flaky = [], tests = [];
 
-const stripAnsi = (s) => (s || "").replace(/\[[0-9;]*m/g, "");
+const stripAnsi = (s) => (s || "").replace(/\u001b\[[0-9;]*m/g, "");
 const firstErr = (r) => {
   const e = r?.error || r?.errors?.[0];
   return e ? stripAnsi(e.message || e.value || "").split("\n")[0].slice(0, 240) : null;


### PR DESCRIPTION
## What

Extends `build-run-payload.mjs` to POST a `tests[]` array to the QA Platform — the first step of rendering the full Playwright run natively (part 1 of 2; the QA Platform side follows separately).

Each test carries: `test`, `file`, `line`, `status` (passed/failed/flaky/skipped), `duration_ms`, `tags`, and the human-authored `test.step()` steps. **Failed** tests also carry the full `error` and a base64 `screenshot`. This closes the gaps you flagged — **skipped tests are now listed** (were counts-only), plus per-test steps/errors/screenshots.

## Safe by construction

- **`version` stays `1`.** `tests[]` is a backwards-compatible optional field; the currently-deployed edge function ignores unknown fields (verified), so this is a **no-op until the QA Platform is updated** — no coordination or downtime between this and the Lovable deploy.
- **Bounded payload:** only `test.step()` steps are kept (pw:api/expect internals dropped); errors capped at 8 KB; screenshots only for the first 25 failures and skipped if a single shot exceeds 3 MB. A huge report can never break run ingestion.
- **JSONL history untouched** — it stays lean; the rich data + screenshots live only in the POST payload.

Verified locally against a mock `results.json` (passed/failed/flaky/skipped): correct statuses, step filtering, nested steps, and screenshot passthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)