### PR TITLE
feat(ci): auto-remove @stable on hard failures + manual workflow fixes + triage docs

### DIFF
--- a/.github/actions/auto-remove-stable/action.yml
+++ b/.github/actions/auto-remove-stable/action.yml
@@ -1,0 +1,78 @@
+name: "Auto-remove @stable from hard failures"
+description: >-
+  On a scheduled stable run, remove the @stable tag from tests that hard-failed
+  (failed every retry), regenerate QA-CHECKLIST.md, and commit the change back
+  to main — no human review (leadership decision; restoring the tag is the
+  human-gated step). A mass-failure guard leaves everything untouched when too
+  many tests fail at once (treated as infra, not per-test rot). Shared by
+  daily-stable.yml and weekly-stable.yml. Assumes checkout + npm ci already ran.
+
+inputs:
+  playwright_json:
+    description: "Path to the Playwright JSON report."
+    required: false
+    default: "results.json"
+  max_auto_remove:
+    description: "Mass-failure guard: if more than this many tests hard-fail, remove nothing."
+    required: false
+    default: "5"
+  run_label:
+    description: "Human label for the commit message, e.g. 'daily #123'."
+    required: true
+
+outputs:
+  status:
+    description: "removed | none | guard_tripped"
+    value: ${{ steps.remove.outputs.status }}
+  removed_count:
+    description: "Number of tests the @stable tag was removed from."
+    value: ${{ steps.remove.outputs.removed_count }}
+  summary_md:
+    description: "Markdown summary for the triage issue body."
+    value: ${{ steps.remove.outputs.summary_md }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Detect and remove @stable from hard failures
+      id: remove
+      shell: bash
+      env:
+        PLAYWRIGHT_JSON: ${{ inputs.playwright_json }}
+        MAX_AUTO_REMOVE: ${{ inputs.max_auto_remove }}
+      run: |
+        set -euo pipefail
+        npx ts-node scripts/remove-stable-from-failures.ts > auto-remove-result.json
+        echo "Script result:"; cat auto-remove-result.json; echo
+        {
+          echo "status=$(node -p "require('./auto-remove-result.json').status")"
+          echo "removed_count=$(node -p "require('./auto-remove-result.json').removed.length")"
+        } >> "$GITHUB_OUTPUT"
+        # Multi-line markdown value via a heredoc delimiter (GitHub Actions format).
+        SUMMARY="$(node scripts/format-auto-remove-summary.mjs auto-remove-result.json)"
+        {
+          echo "summary_md<<__AUTOREMOVE_EOF__"
+          echo "$SUMMARY"
+          echo "__AUTOREMOVE_EOF__"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Commit @stable removals to main
+      if: steps.remove.outputs.status == 'removed'
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Same "dubious ownership" workaround as the history commit step: the job
+        # runs as root in the Playwright container over a host-owned workspace, so
+        # re-declare safe.directory or git refuses to operate (see issue #385).
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        # Removing @stable changes the auto-generated Phase 0 / Coverage blocks in
+        # QA-CHECKLIST.md — regenerate them so the commit stays self-consistent.
+        npm run coverage:summary
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        # Stage ONLY spec edits + the regenerated checklist. Never `git add -A`:
+        # results.json / payload.json / auto-remove-result.json at repo root are
+        # not git-ignored and must not be committed.
+        git add tests/tests-automations/regression QA-CHECKLIST.md
+        git commit -m "chore(triage): auto-remove @stable from ${{ steps.remove.outputs.removed_count }} hard-failing test(s) (${{ inputs.run_label }}) [skip ci]"
+        git push

--- a/.github/actions/run-e2e/action.yml
+++ b/.github/actions/run-e2e/action.yml
@@ -1,0 +1,61 @@
+name: "Run E2E tests"
+description: >-
+  Run the Playwright suite (optionally filtered by tag and/or name regex),
+  produce a navigable HTML report, and upload it as an artifact. Shared by the
+  two manual.yml jobs (Docker service vs. external URL) so the run/upload logic
+  lives in one place. Assumes checkout + npm ci + Playwright browser install
+  already ran in the calling job.
+
+inputs:
+  base_url:
+    description: "PLAYWRIGHT_BASE_URL for the run (Docker service or external URL)."
+    required: true
+  test_tag:
+    description: "Playwright tag to run (e.g. @stable, @release, @api). Empty = all tags."
+    required: false
+    default: ""
+  test_grep:
+    description: "Additional name/regex filter, ANDed with test_tag when both are set. Empty = no name filter."
+    required: false
+    default: ""
+  openai_api_key:
+    description: "OpenAI key for model-dependent specs (agents, playground). Optional."
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Run tests
+      shell: bash
+      env:
+        CI: "true"
+        PLAYWRIGHT_BASE_URL: ${{ inputs.base_url }}
+        # Inputs are passed through env (never interpolated into the script body)
+        # so a value like "; rm -rf" cannot break out of the string — the shell
+        # only ever sees them as variable contents.
+        TEST_TAG: ${{ inputs.test_tag }}
+        TEST_GREP: ${{ inputs.test_grep }}
+        OPENAI_API_KEY: ${{ inputs.openai_api_key }}
+      run: |
+        # Build the arg list as an array (no eval) so quoting is safe. Playwright
+        # only honors one --grep, so to run "tag AND name" we combine them into a
+        # single lookahead regex; a single filter is passed verbatim.
+        ARGS=(--pass-with-no-tests --reporter=html,github)
+        if [ -n "$TEST_TAG" ] && [ -n "$TEST_GREP" ]; then
+          ARGS+=(--grep "(?=.*${TEST_TAG})(?=.*${TEST_GREP})")
+        elif [ -n "$TEST_TAG" ]; then
+          ARGS+=(--grep "$TEST_TAG")
+        elif [ -n "$TEST_GREP" ]; then
+          ARGS+=(--grep "$TEST_GREP")
+        fi
+        echo "Running: npx playwright test ${ARGS[*]}"
+        npx playwright test "${ARGS[@]}"
+
+    - name: Upload Playwright report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report-manual-${{ github.run_id }}
+        path: playwright-report/
+        retention-days: 14

--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -261,6 +261,20 @@ jobs:
           git commit -m "chore(history): record daily run ${{ github.run_id }} [skip ci]"
           git push
 
+      # Auto-remove @stable from hard-failing tests and commit it back to main
+      # (leadership decision — no human review; restoring the tag is manual). The
+      # mass-failure guard inside the action leaves everything untouched when too
+      # many tests fail at once (infra, not per-test rot). Scheduled runs only —
+      # a manual dispatch must never mutate the test source.
+      - name: Auto-remove @stable from hard failures
+        id: auto_remove
+        if: failure() && github.event_name == 'schedule'
+        uses: ./.github/actions/auto-remove-stable
+        with:
+          playwright_json: results.json
+          max_auto_remove: "5"
+          run_label: "daily #${{ github.run_id }}"
+
       # Open a triage issue on failure for BOTH scheduled and manual runs — a
       # manual re-run of a red build should also surface a tracked issue. (The
       # history steps above stay schedule-only; only issue-opening is broadened.)
@@ -269,10 +283,26 @@ jobs:
         uses: actions/github-script@v7
         env:
           IMAGE: ${{ inputs.langflow_image || 'langflowai/langflow-nightly' }}:${{ inputs.langflow_image_tag || 'latest' }}
+          # Empty on manual dispatch (the auto-remove step is schedule-only).
+          AUTO_REMOVE_STATUS: ${{ steps.auto_remove.outputs.status }}
+          AUTO_REMOVE_SUMMARY: ${{ steps.auto_remove.outputs.summary_md }}
         with:
           script: |
             const today = new Date().toISOString().split('T')[0];
             const image = process.env.IMAGE;
+            const arStatus = process.env.AUTO_REMOVE_STATUS || '';
+            const arSummary = process.env.AUTO_REMOVE_SUMMARY || '';
+            // On scheduled runs the auto-remove step already acted; show what it
+            // did. On manual runs it never ran, so fall back to manual triage.
+            const section = arStatus
+              ? ['### `@stable` auto-removal', '', arSummary]
+              : [
+                  '### Next steps',
+                  '1. Open the Playwright report in the artifact from the run above',
+                  '2. Determine if the failure is a test bug or a Langflow regression',
+                  '3. If the test is incorrect or outdated: remove the `@stable` tag from the test and open a fix PR',
+                  '4. If it is a Langflow regression: flag it to the team and monitor upstream',
+                ];
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -284,13 +314,9 @@ jobs:
                 `- **Langflow version:** \`${image}\``,
                 `- **Run:** [${context.runId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
                 '',
-                '### Next steps',
-                '1. Open the Playwright report in the artifact from the run above',
-                '2. Determine if the failure is a test bug or a Langflow regression',
-                '3. If the test is incorrect or outdated: remove the `@stable` tag from the test and open a fix PR',
-                '4. If it is a Langflow regression: flag it to the team and monitor upstream',
+                ...section,
                 '',
-                '/cc @Victor-w-Madeira @daniellicnerski1',
+                '/cc @Victor-w-Madeira @daniellicnerski1 @rafaelgiln',
               ].join('\n'),
               labels: ['daily-failure', 'needs-triage'],
             });

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -18,12 +18,15 @@ on:
           - nightly
           - stable
         default: "nightly"
-      test_suite:
-        description: "Test suite: all | core | extended | features | integrations | unit | regression"
+      test_tag:
+        description: |
+          Playwright tag to run. Empty = every test. Common tags:
+            @stable @release @regression @api @components @workspace
+            @agents @mcp @playground @auth @model-provider @files @ui-ux
         required: false
-        default: "all"
+        default: ""
       test_grep:
-        description: "Additional filter (regex, e.g. 'login|logout')"
+        description: "Additional name/regex filter, ANDed with the tag above (e.g. 'login|logout')"
         required: false
         default: ""
 
@@ -73,7 +76,11 @@ jobs:
           LANGFLOW_AUTO_LOGIN: "true"
           LANGFLOW_SUPERUSER: langflow
           LANGFLOW_SUPERUSER_PASSWORD: langflow
-          LANGFLOW_DEACTIVATE_TRACING: "true"
+          # Keep tracing ON: the observability/traces specs probe
+          # /api/v1/monitor/traces, populated by the internal native tracer whose
+          # worker never starts when tracing is deactivated — disabling it makes
+          # those specs fail deterministically (see #352). Matches daily/weekly.
+          LANGFLOW_DEACTIVATE_TRACING: "false"
         options: >-
           --health-cmd "curl -f http://localhost:7860/health_check || exit 1"
           --health-interval 15s
@@ -90,31 +97,13 @@ jobs:
       - run: npm ci
       - name: Install Playwright browsers
         uses: ./.github/actions/setup-playwright
-      - name: Run tests
-        run: |
-          SUITE="${{ github.event.inputs.test_suite }}"
-          GREP="${{ github.event.inputs.test_grep }}"
-          case "$SUITE" in
-            core)       DIR="tests/core/" ;;
-            extended)   DIR="tests/extended/" ;;
-            features)   DIR="tests/core/features/ tests/extended/features/" ;;
-            integrations) DIR="tests/core/integrations/" ;;
-            unit)       DIR="tests/core/unit/" ;;
-            regression) DIR="tests/core/regression/ tests/extended/regression/" ;;
-            *)          DIR="" ;;
-          esac
-          CMD="npx playwright test $DIR --reporter=github"
-          [ -n "$GREP" ] && CMD="$CMD --grep '$GREP'"
-          eval $CMD
-        env:
-          CI: "true"
-          PLAYWRIGHT_BASE_URL: ${{ needs.detect-target.outputs.base_url }}
-      - uses: actions/upload-artifact@v4
-        if: always()
+      - name: Run tests and upload report
+        uses: ./.github/actions/run-e2e
         with:
-          name: playwright-report-manual-${{ github.run_id }}
-          path: playwright-report/
-          retention-days: 14
+          base_url: ${{ needs.detect-target.outputs.base_url }}
+          test_tag: ${{ github.event.inputs.test_tag }}
+          test_grep: ${{ github.event.inputs.test_grep }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
 
   e2e-url:
     name: E2E via URL (${{ github.event.inputs.langflow_target }})
@@ -132,28 +121,10 @@ jobs:
       - run: npm ci
       - name: Install Playwright browsers
         uses: ./.github/actions/setup-playwright
-      - name: Run tests
-        run: |
-          SUITE="${{ github.event.inputs.test_suite }}"
-          GREP="${{ github.event.inputs.test_grep }}"
-          case "$SUITE" in
-            core)       DIR="tests/core/" ;;
-            extended)   DIR="tests/extended/" ;;
-            features)   DIR="tests/core/features/ tests/extended/features/" ;;
-            integrations) DIR="tests/core/integrations/" ;;
-            unit)       DIR="tests/core/unit/" ;;
-            regression) DIR="tests/core/regression/ tests/extended/regression/" ;;
-            *)          DIR="" ;;
-          esac
-          CMD="npx playwright test $DIR --reporter=github"
-          [ -n "$GREP" ] && CMD="$CMD --grep '$GREP'"
-          eval $CMD
-        env:
-          CI: "true"
-          PLAYWRIGHT_BASE_URL: ${{ needs.detect-target.outputs.base_url }}
-      - uses: actions/upload-artifact@v4
-        if: always()
+      - name: Run tests and upload report
+        uses: ./.github/actions/run-e2e
         with:
-          name: playwright-report-manual-${{ github.run_id }}
-          path: playwright-report/
-          retention-days: 14
+          base_url: ${{ needs.detect-target.outputs.base_url }}
+          test_tag: ${{ github.event.inputs.test_tag }}
+          test_grep: ${{ github.event.inputs.test_grep }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/weekly-stable.yml
+++ b/.github/workflows/weekly-stable.yml
@@ -215,15 +215,41 @@ jobs:
           git commit -m "chore(history): record weekly run ${{ github.run_id }} [skip ci]"
           git push
 
+      # Auto-remove @stable from hard-failing tests and commit it back to main
+      # (leadership decision — no human review; restoring the tag is manual). The
+      # mass-failure guard inside the action leaves everything untouched when too
+      # many tests fail at once (infra, not per-test rot). Scheduled runs only.
+      - name: Auto-remove @stable from hard failures
+        id: auto_remove
+        if: failure() && github.event_name == 'schedule'
+        uses: ./.github/actions/auto-remove-stable
+        with:
+          playwright_json: results.json
+          max_auto_remove: "5"
+          run_label: "weekly #${{ github.run_id }}"
+
       - name: Create issue on failure
         if: failure() && github.event_name == 'schedule'
         uses: actions/github-script@v7
         env:
           IMAGE: ${{ inputs.langflow_image || 'langflowai/langflow-nightly' }}:${{ inputs.langflow_image_tag || 'latest' }}
+          AUTO_REMOVE_STATUS: ${{ steps.auto_remove.outputs.status }}
+          AUTO_REMOVE_SUMMARY: ${{ steps.auto_remove.outputs.summary_md }}
         with:
           script: |
             const today = new Date().toISOString().split('T')[0];
             const image = process.env.IMAGE;
+            const arStatus = process.env.AUTO_REMOVE_STATUS || '';
+            const arSummary = process.env.AUTO_REMOVE_SUMMARY || '';
+            const section = arStatus
+              ? ['### `@stable` auto-removal', '', arSummary]
+              : [
+                  '### Next steps',
+                  '1. Open the Playwright report in the artifact from the run above',
+                  '2. Determine if the failure is a test bug or a Langflow regression',
+                  '3. If the test is incorrect or outdated: remove the `@stable` tag from the test and open a fix PR',
+                  '4. If it is a Langflow regression: flag it to the team and monitor upstream',
+                ];
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -235,13 +261,9 @@ jobs:
                 `- **Langflow version:** \`${image}\``,
                 `- **Run:** [${context.runId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
                 '',
-                '### Next steps',
-                '1. Open the Playwright report in the artifact from the run above',
-                '2. Determine if the failure is a test bug or a Langflow regression',
-                '3. If the test is incorrect or outdated: remove the `@stable` tag from the test and open a fix PR',
-                '4. If it is a Langflow regression: flag it to the team and monitor upstream',
+                ...section,
                 '',
-                '/cc @Victor-w-Madeira @daniellicnerski1',
+                '/cc @Victor-w-Madeira @daniellicnerski1 @rafaelgiln',
               ].join('\n'),
               labels: ['weekly-failure', 'needs-triage'],
             });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -510,14 +510,14 @@ State persistence requires the secret `GH_PAT_VARIABLES` (a PAT with `Variables:
 
 ### What it is
 
-`@stable` identifies tests that have been reviewed by the team and confirmed as correct and reliable. Only these tests run in the weekly workflow (`weekly-stable.yml`). A failure in this workflow automatically opens an issue for triage.
+`@stable` identifies tests that have been reviewed by the team and confirmed as correct and reliable. Only these tests run in the stable workflow (`daily-stable.yml`, every weekday; `weekly-stable.yml` is a disabled fallback). A hard failure there **automatically removes `@stable`** from the offending test and opens an issue for triage — restoring the tag is the only human-gated step (see lifecycle below).
 
 ### Standard: every new test enters with @stable
 
 `@stable` is the default for any new test. The test **enters with the tag in the PR itself**, together with the documentation file in `docs/` (see step 7 of the guide above). The reviewer, upon approving the merge, is confirming that:
 
 1. The test passed all 5 steps of the validation guide (trace, forced failure, debug, no backend errors, checklist)
-2. The validated behavior is real and relevant for weekly monitoring
+2. The validated behavior is real and relevant for daily monitoring
 3. The documentation file in `docs/` is present with the mandatory sections filled in
 
 If any of these points is absent or incomplete, the reviewer must **request changes** before approving.
@@ -534,36 +534,47 @@ Three cases where the tag is intentionally absent:
 
 1. **Inherited tests not yet reviewed** — they exist in the repository but have not yet gone through the validation and documentation process.
 2. **Tests temporarily removed while failing** — the tag was removed while the test awaits correction (see lifecycle below).
-3. **Utility specs** — scripts that collect data or configure infrastructure rather than asserting product behavior (e.g. `collect-models.spec.ts`). These are not regression tests and must never enter the weekly workflow.
+3. **Utility specs** — scripts that collect data or configure infrastructure rather than asserting product behavior (e.g. `collect-models.spec.ts`). These are not regression tests and must never enter the stable workflow.
 
 **When `@stable` is permanently absent** (case 3): state the reason in the spec doc's **Tags** section so it is visible without reading PR history.
 
-**When `@stable` is temporarily absent** (cases 1 and 2): no spec doc update is required — the absence is tracked via the GitHub issue and the PR that removed the tag.
+**When `@stable` is temporarily absent** (cases 1 and 2): no spec doc update is required — the absence is tracked via the GitHub issue and the commit that removed the tag (auto-removed by the workflow on a hard failure, or a manual PR for inherited tests).
 
-### @stable lifecycle when a weekly failure occurs
+### @stable lifecycle: from the triage issue to restoration
+
+On a red scheduled `daily-stable.yml` run, the workflow does two things **automatically**:
+
+1. Removes `@stable` from **every hard failure** (a test that failed all retries), regenerates `QA-CHECKLIST.md`, and commits it to `main` with `[skip ci]` — no PR, no approval. If the mass-failure guard trips (too many at once → treated as infra), nothing is removed.
+2. Opens a single **triage issue** for the run, listing what was removed.
+
+The triage issue is the analyst's **inbox and dispatcher** — not the tracking issue for each problem. The analyst fans it out into one **dedicated issue per problem**; each tag is restored, per problem, once resolved. The human steps are the fan-out, the manual removal for recurrent flakes, and the restoration.
 
 ```
-@stable present
+daily-stable.yml run goes red
       │
-      │  weekly-stable.yml opens a failure issue
+      │  AUTOMATIC:
+      │   • @stable removed from each hard failure + committed to main [skip ci]
+      │     (unless the mass-failure guard trips → nothing removed)
+      │   • one TRIAGE ISSUE opened for the run, listing what was removed
       ▼
-Evaluate: did the product break, or is the test wrong?
+Analyst works the triage issue (dispatcher):
       │
-      ├─► Product broke (test is correct)
-      │       Flag the issue to the product team.
-      │       Monitor upstream. The tag remains.
+      ├─► per HARD FAILURE  (tag already auto-removed)
+      │        → open a DEDICATED issue, classify (criteria table below),
+      │          then fix the test or flag the regression upstream
       │
-      └─► Test is wrong or behavior changed
-              │
-              ▼
-          @stable removed  ◄── PR references the issue; tag removed; test exits weekly workflow
-              │
-              │  Test is corrected and re-validated (5-step guide)
-              ▼
-          @stable restored  ◄── Same correction PR restores the tag; issue is closed
+      └─► per RECURRENT FLAKE  (same test flaky in 2 consecutive dailies,
+      │        confirmed in reports/daily-history.jsonl)
+      │        → open a DEDICATED issue AND remove @stable via PR (manual)
+      ▼
+Problem resolved → @stable RESTORED via PR; the dedicated issue is closed
 ```
 
-**Criteria for deciding "product broke" vs "test wrong":**
+> **Mass-failure guard.** The threshold is the `max_auto_remove` input of the `auto-remove-stable` action (default `5`). Above it, the workflow assumes an environment-wide failure and removes nothing, so a bad infra day cannot strip `@stable` off the whole suite. When it trips, the triage issue says so and the tags are still in place — investigate the environment; there is nothing to restore.
+
+> **Trade-off.** Auto-removal does not distinguish a product regression from a test bug before removing — a hard failure quarantines the test either way, and the classification happens afterwards on the dedicated issue. Accepted trade-off: a genuine regression stops being tracked by the stable suite until a human restores the tag, but the daily stops going red immediately.
+
+**Criteria for deciding "product broke" vs "test wrong" (for hard failures):**
 
 | Observation | Classification |
 |---|---|
@@ -572,44 +583,42 @@ Evaluate: did the product break, or is the test wrong?
 | Assertion fails but the UI works correctly in manual testing | Test wrong — fix assertion logic |
 | Assertion fails and manual testing confirms the same failure | Product broke — flag upstream |
 
-**Step 1 — Analyst (upon receiving the workflow issue):**
-1. Identify the failing test and classify the failure using the table above
-2. Open a PR removing the `@stable` tag from the test; reference the issue in the PR body
-3. After merge, the test immediately stops running in the weekly workflow
-4. Update the issue with the classification and the name of the test that needs correction
+**Step 1 — Analyst (working the triage issue):**
+1. **Hard failures** — the tag is already auto-removed. For each one, open a **dedicated issue**, classify it with the table above, and either fix the test or flag the regression upstream.
+2. **Flakes** — check `reports/daily-history.jsonl`. If the same test is flaky in **2 consecutive dailies**, open a **dedicated issue** and remove `@stable` from it via PR (flake removal is manual — the workflow never auto-removes flakes). A first-time flake is only noted; the retry budget absorbs single-run noise.
+3. **Mass-failure guard tripped** — nothing was removed; investigate the environment first. The tags are still in place, so no restoration is owed.
+4. Once every problem is dispatched into its dedicated issue, the triage issue can be closed.
 
-**Step 2 — Dev (upon fixing the test):**
-1. Fix the test following the validation guide (all 5 steps)
-2. Restore the `@stable` tag in the same correction PR
-3. Reference the issue in the PR body; close the issue upon merge
+**Step 2 — Restoration (upon fixing the problem):**
+1. Fix the test following the validation guide (all 5 steps), or confirm the Langflow regression is resolved.
+2. **Re-add the `@stable` tag** in the correction PR — restoration is always manual, for both hard failures and flakes.
+3. Reference the dedicated issue in the PR body; close it upon merge.
 
-The spec doc is **not updated** during this cycle — the issue and the two PRs are the traceability record.
+The spec doc is **not updated** during this cycle — the auto-removal commit, the dedicated issue, and the restoration PR are the traceability record.
 
 ### Monitoring rules driven by run history
 
-Triage decisions should be informed by `reports/weekly-history.jsonl` rather than by gut feel — the file makes recurrence visible. Before deciding whether to act on a failure, check the last 4 weekly entries for the same test:
+Hard failures are now handled automatically (removed on the first red day — see the lifecycle above), so these history-driven rules are mostly about **flakes**, which are never auto-removed. Triage decisions should be informed by `reports/daily-history.jsonl` rather than by gut feel — the file makes recurrence visible. Before deciding whether to act on a flake, check the last few daily entries for the same test:
 
 ```bash
 jq -r --arg t "<full test title>" \
   '. as $row | (.failures + .flaky)[] | select(.test == $t) | "\($row.date)  \($row.workflow)  \(.error_signature // "flaky")"' \
-  reports/weekly-history.jsonl | tail -4
+  reports/daily-history.jsonl | tail -4
 ```
 
-The action depends on **what kind** of failure recurred and **how many** consecutive weekly runs it appeared in:
+The action depends on **what kind** of failure recurred and **how many** consecutive daily runs it appeared in:
 
-| Symptom in the latest weekly run | History context | Action |
+| Symptom in the latest daily run | History context | Action |
 |---|---|---|
-| Hard failure (all retries failed) | First occurrence | Open a fix issue. Remove `@stable` only if the root cause is upstream and won't be fixed before the next weekly. |
-| Hard failure | 2nd consecutive | Remove `@stable` in a PR that references the existing issue. Re-add when fixed. |
-| Flake (passed on retry) | First occurrence | Note in the triage; **do not** open an issue yet. The retry budget exists to absorb single-run noise. |
-| Flake | 2nd consecutive | Open a dedicated issue with `bug` + `area:<...>` labels. Cite both run ids. Do not remove `@stable` yet. |
-| Flake | 3rd consecutive | Remove `@stable` in a PR that references the issue from the previous step. The test is no longer stable enough for weekly. |
-| Mix (failed one week, flaky the next) | 2+ weeks | Treat as the "Flake 2nd consecutive" row above — open the issue; the alternation between hard fail and flake is itself a signal worth tracking. |
+| Hard failure (all retries failed) | any | `@stable` was already auto-removed (or the mass-failure guard tripped and left it in place). No manual removal — classify on the issue and restore the tag when the test is fixed. |
+| Flake (passed on retry) | First occurrence | Note in the triage; **do not** open an issue yet. The retry budget absorbs single-run noise. |
+| Flake (recurrent) | 2nd consecutive daily | Open a **dedicated issue** (`bug` + `area:<...>`, cite both run ids) **and remove `@stable` via PR**. Flake removal is manual — the workflow never auto-removes flakes. Restore the tag once the flakiness is fixed. |
+| Mix (hard-failed one day, flaky later) | 2+ days | The hard-fail day already auto-removed `@stable`; once restored, apply the flake rows above if the flakiness persists. |
 
-**Examples from issue #206 (2026-05-11):**
+**Historical examples (issue #206, 2026-05-11) — these predate auto-removal; the hard-fail removal below is now automatic, the flake handling still applies:**
 
 - `Webhook component — flow is saved to database…` (line 60) — Hard fail, 2nd consecutive (first in 25441253323). → `@stable` removed in this PR; #180 remains open until upstream fixes the bundle.
-- `Memory Chatbot Regression › message history retains context within same session` (line 78) — Flake, first occurrence. → No action yet; if it flakes again in the next weekly, open an issue.
+- `Memory Chatbot Regression › message history retains context within same session` (line 78) — Flake, first occurrence. → No action yet; if it flakes again in the next daily, open an issue.
 - `Playground Message Edit — hover reveals edit button…` (line 98) — Flake, first occurrence. → Same: monitor; act only on the second occurrence.
 
 **Why "consecutive" and not "in the last N runs":**

--- a/scripts/format-auto-remove-summary.mjs
+++ b/scripts/format-auto-remove-summary.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Turn the JSON output of remove-stable-from-failures.ts into a Markdown block
-// for the triage issue body. Usage: node format-auto-remove-summary.mjs <json>
+// for the triage issue body. Usage: node format-auto-remove-summary.mjs <json-file>
 import { readFileSync } from "node:fs";
 
 const r = JSON.parse(readFileSync(process.argv[2], "utf8"));

--- a/scripts/format-auto-remove-summary.mjs
+++ b/scripts/format-auto-remove-summary.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+// Turn the JSON output of remove-stable-from-failures.ts into a Markdown block
+// for the triage issue body. Usage: node format-auto-remove-summary.mjs <json>
+import { readFileSync } from "node:fs";
+
+const r = JSON.parse(readFileSync(process.argv[2], "utf8"));
+const lines = [];
+
+if (r.status === "guard_tripped") {
+  lines.push(
+    `⚠️ **Mass-failure guard tripped** — ${r.hardFailures} hard failures exceed the ` +
+      `threshold of ${r.threshold}, so \`@stable\` was **left untouched**. A run where ` +
+      `this many stable tests fail at once is almost always infra (Langflow didn't boot, ` +
+      `network/model outage), not per-test rot. Triage manually.`,
+  );
+} else if (r.status === "removed") {
+  lines.push(`🔻 **Auto-removed \`@stable\`** from ${r.removed.length} hard-failing test(s):`);
+  lines.push("");
+  for (const t of r.removed) {
+    const note = t.soleTag
+      ? " — _`@stable` was the only tag; the array was left empty, please review_"
+      : "";
+    lines.push(`- \`${t.file}\` — ${t.title}${note}`);
+  }
+  lines.push("");
+  lines.push("These were committed to `main` automatically. **Restoring `@stable` is manual**: once the test or Langflow is fixed, re-add the tag via PR.");
+} else {
+  lines.push("No per-test `@stable` hard failures were auto-removed.");
+}
+
+if (r.skipped && r.skipped.length) {
+  lines.push("");
+  lines.push(`⏭️ **Skipped ${r.skipped.length}** (needs manual review):`);
+  for (const s of r.skipped) lines.push(`- \`${s.file}\` — ${s.title} _(${s.reason})_`);
+}
+
+process.stdout.write(lines.join("\n"));

--- a/scripts/remove-stable-from-failures.ts
+++ b/scripts/remove-stable-from-failures.ts
@@ -1,0 +1,287 @@
+/**
+ * Auto-remove the `@stable` tag from tests that hard-failed in a stable run.
+ *
+ * Leadership decision: on a hard failure (a test that failed ALL retries in a
+ * scheduled daily/weekly run), the `@stable` tag is removed automatically, with
+ * NO human review. Restoring the tag is the human-gated step (a later PR once
+ * the test or Langflow is fixed). This script performs the removal.
+ *
+ * Run: `PLAYWRIGHT_JSON=results.json npx ts-node scripts/remove-stable-from-failures.ts`
+ *
+ * Safety:
+ *  - Only `failures[]` (status "unexpected" = failed every retry) are targeted;
+ *    flaky tests (passed on a retry) keep `@stable`, per the triage policy.
+ *  - Mass-failure guard: if the number of hard failures exceeds MAX_AUTO_REMOVE
+ *    (or the report is missing/empty — the suite never really ran), NOTHING is
+ *    removed. A red day where everything fails is almost always infra (Langflow
+ *    container didn't boot, network/model outage), not per-test rot, and must
+ *    not quarantine the whole stable suite.
+ *
+ * Editing is AST-located + text-spliced: the TypeScript compiler API finds the
+ * exact `"@stable"` element inside the `test(...)` `{ tag: [...] }` array, and
+ * only that element (plus one adjacent comma) is removed from the raw source,
+ * so all other formatting/comments are preserved.
+ *
+ * Output: a single JSON object on stdout describing what happened, for the
+ * caller (workflow / composite action) to build the commit message + issue body.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import * as ts from "typescript";
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const STABLE_TAG = "@stable";
+
+const reportPath = process.env.PLAYWRIGHT_JSON || "results.json";
+const MAX_AUTO_REMOVE = Number.parseInt(process.env.MAX_AUTO_REMOVE || "5", 10);
+
+interface Failure {
+  title: string;
+  file: string; // absolute path
+  line: number; // 1-based test() line, as Playwright reports it
+}
+
+interface Removed {
+  file: string; // repo-relative
+  title: string;
+  line: number;
+  soleTag: boolean; // true if @stable was the ONLY tag (array left empty)
+}
+
+interface Skipped {
+  file: string; // repo-relative
+  title: string;
+  line: number;
+  reason: string;
+}
+
+// ─── Parse hard failures out of the Playwright JSON report ───────────────────
+// Mirrors scripts/build-run-payload.mjs: only status "unexpected" counts as a
+// hard failure; "flaky"/"skipped"/"expected" are ignored.
+
+function collectHardFailures(reportFile: string): Failure[] {
+  if (!fs.existsSync(reportFile)) return [];
+  let report: any;
+  try {
+    report = JSON.parse(fs.readFileSync(reportFile, "utf8"));
+  } catch {
+    return [];
+  }
+  const failures: Failure[] = [];
+  const resolveFile = (spec: any): string => {
+    const f = spec?.file || spec?.location?.file || "";
+    return path.isAbsolute(f) ? f : path.resolve(REPO_ROOT, f);
+  };
+  const visit = (node: any): void => {
+    for (const spec of node.specs || []) {
+      const file = resolveFile(spec);
+      const line = spec?.line || spec?.location?.line || 0;
+      for (const t of spec.tests || []) {
+        if (t.status === "unexpected") {
+          failures.push({ title: spec.title, file, line });
+        }
+      }
+    }
+    for (const child of node.suites || []) visit(child);
+  };
+  for (const s of report.suites || []) visit(s);
+  return failures;
+}
+
+// ─── AST: find the `"@stable"` element inside a matching test()'s tag array ──
+
+function literalText(node: ts.Node): string | null {
+  if (ts.isStringLiteral(node)) return node.text;
+  if (ts.isNoSubstitutionTemplateLiteral(node)) return node.text;
+  if (ts.isTemplateExpression(node)) {
+    let s = node.head.text;
+    for (const span of node.templateSpans) {
+      s += "${" + span.expression.getText() + "}" + span.literal.text;
+    }
+    return s;
+  }
+  return null;
+}
+
+function isPlainTestCall(call: ts.CallExpression): boolean {
+  return ts.isIdentifier(call.expression) && call.expression.text === "test";
+}
+
+/** The `@stable` string element node within `test()`'s tag array, if present. */
+function findStableElement(
+  call: ts.CallExpression,
+): ts.ArrayLiteralExpression["elements"][number] | null {
+  if (call.arguments.length < 2) return null;
+  const opts = call.arguments[1];
+  if (!ts.isObjectLiteralExpression(opts)) return null;
+  for (const prop of opts.properties) {
+    if (
+      !ts.isPropertyAssignment(prop) ||
+      !ts.isIdentifier(prop.name) ||
+      prop.name.text !== "tag"
+    ) {
+      continue;
+    }
+    if (!ts.isArrayLiteralExpression(prop.initializer)) return null;
+    for (const el of prop.initializer.elements) {
+      if (literalText(el) === STABLE_TAG) return el;
+    }
+  }
+  return null;
+}
+
+interface Match {
+  element: ts.ArrayLiteralExpression["elements"][number];
+  array: ts.ArrayLiteralExpression;
+  line: number; // 1-based line of the test() call
+}
+
+/** All test() calls in `source` that carry `@stable`, with their line + element. */
+function stableTestMatches(source: ts.SourceFile): Map<string, Match[]> {
+  // keyed by title so we can match a failure by title (+ line as tiebreaker)
+  const byTitle = new Map<string, Match[]>();
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && isPlainTestCall(node)) {
+      const title = node.arguments.length >= 1 ? literalText(node.arguments[0]) : null;
+      const element = findStableElement(node);
+      if (title !== null && element) {
+        const array = element.parent as ts.ArrayLiteralExpression;
+        const line =
+          source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
+        const list = byTitle.get(title) || [];
+        list.push({ element, array, line });
+        byTitle.set(title, list);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return byTitle;
+}
+
+/** Character range [start, end) to delete to drop one array element cleanly. */
+function spliceRange(
+  match: Match,
+  source: ts.SourceFile,
+): { start: number; end: number; soleTag: boolean } {
+  const elements = match.array.elements;
+  const idx = elements.indexOf(match.element);
+  const el = match.element;
+  if (elements.length === 1) {
+    // Only tag: leave `[]`. Rare — @stable is normally paired with @release etc.
+    return { start: el.getStart(source), end: el.getEnd(), soleTag: true };
+  }
+  if (idx < elements.length - 1) {
+    // Not last: eat element + trailing comma + whitespace up to the next element.
+    return {
+      start: el.getStart(source),
+      end: elements[idx + 1].getStart(source),
+      soleTag: false,
+    };
+  }
+  // Last element: eat leading comma + whitespace + element.
+  return {
+    start: elements[idx - 1].getEnd(),
+    end: el.getEnd(),
+    soleTag: false,
+  };
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+function main(): void {
+  const failures = collectHardFailures(reportPath);
+
+  const result: {
+    status: "removed" | "none" | "guard_tripped";
+    threshold: number;
+    hardFailures: number;
+    removed: Removed[];
+    skipped: Skipped[];
+  } = {
+    status: "none",
+    threshold: MAX_AUTO_REMOVE,
+    hardFailures: failures.length,
+    removed: [],
+    skipped: [],
+  };
+
+  if (failures.length === 0) {
+    process.stdout.write(JSON.stringify(result));
+    return;
+  }
+
+  // Mass-failure guard: too many hard failures => treat as infra, remove nothing.
+  if (failures.length > MAX_AUTO_REMOVE) {
+    result.status = "guard_tripped";
+    process.stdout.write(JSON.stringify(result));
+    return;
+  }
+
+  // Group failures by file so each file is parsed + written once.
+  const byFile = new Map<string, Failure[]>();
+  for (const f of failures) {
+    const list = byFile.get(f.file) || [];
+    list.push(f);
+    byFile.set(f.file, list);
+  }
+
+  for (const [file, fileFailures] of byFile) {
+    const rel = path.relative(REPO_ROOT, file);
+    if (!fs.existsSync(file)) {
+      for (const f of fileFailures)
+        result.skipped.push({ file: rel, title: f.title, line: f.line, reason: "spec file not found" });
+      continue;
+    }
+    let text = fs.readFileSync(file, "utf8");
+    const source = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true);
+    const matches = stableTestMatches(source);
+
+    // Resolve each failure to a single @stable test() element, then splice from
+    // the END of the file backwards so earlier offsets stay valid.
+    const ranges: Array<{ start: number; end: number; removed: Removed }> = [];
+    for (const f of fileFailures) {
+      const candidates = matches.get(f.title) || [];
+      let match: Match | undefined;
+      if (candidates.length === 1) {
+        match = candidates[0];
+      } else if (candidates.length > 1) {
+        // Duplicate titles in one file: disambiguate by the reported line.
+        match = candidates.find((c) => c.line === f.line);
+      }
+      if (!match) {
+        // No @stable in the test()'s own tag array. Either it's inherited from a
+        // describe block (not per-test removable) or the title didn't resolve.
+        result.skipped.push({
+          file: rel,
+          title: f.title,
+          line: f.line,
+          reason: candidates.length
+            ? "ambiguous title, no line match"
+            : "no per-test @stable (describe-level tag or title mismatch)",
+        });
+        continue;
+      }
+      const { start, end, soleTag } = spliceRange(match, source);
+      ranges.push({
+        start,
+        end,
+        removed: { file: rel, title: f.title, line: match.line, soleTag },
+      });
+    }
+
+    if (ranges.length === 0) continue;
+    ranges.sort((a, b) => b.start - a.start); // splice back-to-front
+    for (const r of ranges) {
+      text = text.slice(0, r.start) + text.slice(r.end);
+      result.removed.push(r.removed);
+    }
+    fs.writeFileSync(file, text);
+  }
+
+  result.status = result.removed.length > 0 ? "removed" : "none";
+  process.stdout.write(JSON.stringify(result));
+}
+
+main();


### PR DESCRIPTION
## What

Three related changes to the stable-suite triage machinery, delivered together.

### 1. Auto-remove `@stable` from hard failures (daily + weekly)
Per leadership decision: a **hard failure** (a test that failed every retry) in a scheduled `daily-stable.yml` / `weekly-stable.yml` run now removes `@stable` from that test **automatically** and commits it back to `main` with `[skip ci]` — no PR, no review. Restoring the tag stays the manual, human-gated step.

- `scripts/remove-stable-from-failures.ts` — reads `results.json`, targets only `failures[]` (flaky tests keep `@stable`), and removes just the `"@stable"` element from each `test()`'s tag array. Editing is **AST-located + text-spliced**, so formatting/comments are preserved.
- **Mass-failure guard** (`max_auto_remove`, default `5`): if more tests hard-fail than the threshold, nothing is removed — a run where that many stable tests fail at once is treated as infra, not per-test rot, so a bad infra day can't strip `@stable` off the whole suite.
- `scripts/format-auto-remove-summary.mjs` + `.github/actions/auto-remove-stable/` — regenerates `QA-CHECKLIST.md`, commits spec edits + checklist (explicit `git add` paths, never `-A`), and reports what was removed in the failure issue.
- `@rafaelgiln` added to the failure-issue `/cc`.

### 2. Fix the manual workflow (`manual.yml`)
It had drifted and was effectively broken:
- Dead `test_suite` directory switch (`tests/core/`, `tests/extended/`… no longer exist) → replaced with a first-class **`test_tag`** input plus `test_grep`, combined via a lookahead regex.
- Reporter was `github` only (produced no `playwright-report/`, so the uploaded artifact was empty) → now `html,github`.
- Tracing turned back on for the docker service (observability specs need it — see #352).
- Duplicated run+upload step of both jobs factored into a `.github/actions/run-e2e/` composite action; `OPENAI_API_KEY` passed through so tag runs that hit model specs work.

### 3. Triage docs (`CONTRIBUTING.md`)
Rewrote the `@stable` lifecycle to match the new cycle: the workflow opens a **triage issue** (dispatcher) and auto-removes hard-failure tags; the analyst fans it out into a **dedicated issue per hard failure**, and for **recurrent flakes** (same test flaky in 2 consecutive dailies, confirmed via `reports/daily-history.jsonl`) opens a dedicated issue and removes `@stable` manually. Restoration is always manual. History-driven rules table aligned; stale "weekly" references updated to the active daily workflow.

## Not in scope (deliberate)
- No change to the failure **signal** (no `--fail-on-flaky-tests`; trigger untouched).
- Manual workflow runner stays on `ubuntu-latest` (not migrated to the Playwright container).
- `package.json` `test:*` scripts still reference the same dead paths — separate, shared-file cleanup.

## Validation
- `npm run typecheck` clean; `npm run lint` 0 errors.
- Removal script tested locally: splice at every array position, mass-failure guard, describe-level tags skipped, flaky/passing tests untouched, missing report → no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)