### PR TITLE
docs(roadmap): add ROADMAP.md and size waves to the 50-60 band

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,185 @@
+# ROADMAP.md
+
+> **Source of truth for direction:** where we are and what comes next, in time-boxed
+> waves. This document **schedules** work that is already decided elsewhere — it does
+> not invent tests, describe what a test validates, or teach process.
+
+---
+
+## Scope — what this document owns (and what it doesn't)
+
+This file answers exactly one question:
+
+> Until `yyyy-mm-dd` we run **Wave N**. Wave N requires `x`, `p`, `t`, `o`. With that, coverage converges to `w%`. → Next: **Wave N+1**.
+
+It owns only what no other document owns: **the order of the waves, their deadlines,
+and the per-wave convergence target.** Everything else is a pointer.
+
+| Document | Owns the truth about | This file… |
+|---|---|---|
+| `QA-CHECKLIST.md` | **what** is covered (coverage matrix, %) | reads `w%` from its Coverage Summary |
+| spec docs under `docs/` | **what** each test validates | points to the file |
+| `CONTRIBUTING.md` | **how** to write / validate / triage | links only |
+| **`ROADMAP.md`** | **when** and **in what order** | — |
+
+**Rules**
+
+1. A wave never introduces a test idea that does not already exist as a backlog
+   item (a `[ ]`/`[-]` bullet in `QA-CHECKLIST.md`, a named-but-unwritten spec, a
+   skipped test, or an open issue). Wave items are **pointers**, never restated
+   descriptions.
+2. The convergence metric is the **Coverage Summary of `QA-CHECKLIST.md`**
+   (`Validated [x]` / `Total`). It is auto-generated, so the number is verifiable.
+3. The target `%` is a **directional goal, not a contract.** The denominator grows
+   over time (new items added, unplanned tests written mid-wave). A wave can close
+   "below target" purely because the denominator moved — handling that is the
+   **team's** concern, not this document's.
+
+---
+
+## Where we are
+
+> Snapshot — refresh from `QA-CHECKLIST.md` when it changes. Do not hand-maintain.
+
+- **Coverage (validated `[x]` / total):** ~49% (222 / 450 checklist bullets)
+- **`@stable` `test()` calls:** ~240 across the suite
+- **Total `test()` calls:** ~500 in ~211 spec files
+- **Disabled tests:** 53 `test.skip` (32 files) + 1 `test.fixme` (`webhook-component-regression.spec.ts`)
+- **Spec-doc coverage:** ~39% of specs have a matching doc under `docs/`
+- **Langflow version last validated against:** `1.10.x`
+
+**Biggest structural gaps** (where coverage is near-zero relative to product value):
+
+- **RAG / knowledge ingestion** — full pipeline uncovered (0 validated of 8 bullets).
+- **Agent behavior backlog** — ~24 not-automated bullets, most with spec filenames already named.
+- **Templates** — 41 bullets, 2 validated; the product showcase is almost untested.
+- **MCP** (client + server) — files exist but almost entirely `[-]` (unvalidated).
+- **Inherited `ui-ux` canvas specs** — ~36 `[-]` carried from upstream, never validated.
+- **Spec-doc debt** — ~129 specs without a doc (worst in `flow-functionality` and `ui-ux`).
+
+---
+
+## Cadence & review
+
+- **Each wave is a fixed 2-week timebox.** Lock the time, flex the scope: if a wave
+  runs heavy, drop items from it — never extend the deadline.
+- **Capacity band: 18–21 new specs per wave** (≈9–10/week against a raw throughput
+  of 10–15/week). The band sits *below* raw capacity on purpose: maintaining the
+  growing validated suite competes for the same hours, so new-spec throughput
+  declines as the suite grows. Treat 18–21 as the current ceiling, revisited at
+  every review — later waves carry fewer new specs and more maintenance.
+- A wave is filled only with **decided** backlog items. If the decided new-spec
+  backlog runs short of the band, the wave is smaller — we do **not** invent specs
+  to hit the number.
+- **Every wave ends with a review** (the `Review (date)` line). At that checkpoint
+  the team reassesses what was actually delivered vs. the target, and replenishes
+  the dated horizon by promoting the next item from the pool.
+- **Rolling horizon of ~3 dated waves.** Only the near term is dated, on purpose —
+  dating waves months out would be invention, and reality (denominator growth,
+  unplanned tests, n_messages-style surprises) reshapes the order anyway. New waves
+  are coined at each review, not fixed up front.
+
+---
+
+## The full horizon — how many waves total?
+
+The dated creation waves below are **not** the whole journey. The backlog splits
+into three blocks of different *nature*, only the first of which is pure creation:
+
+| Block | Nature | Est. waves | Dated? |
+|---|---|---|---|
+| **A — Creation (decided)** | Write new specs from the already-decided backlog (~50 specs) | **3** | ✅ Waves 1–3 |
+| **B — Validation track** | Promote existing `[-]` / skipped specs to `@stable` — little to no new code | ~2–3 | ⬜ pool |
+| **C — Scoped creation** | Areas too vague to schedule yet (templates, remaining ui-ux); need a scoping session to become a concrete spec list first | ~2–3 | ⬜ pool |
+| **Continuous** | Spec-doc backfill (~129 missing) — runs alongside, not a wave | — | ⬜ track |
+
+So the realistic horizon is **~8–9 waves (~4 months)**, not 3. Block A is dated now;
+Blocks B and C stay in the pool with a known shape and get coined at each review.
+New-spec volume is highest in Block A and tapers across B/C as maintenance grows —
+exactly the declining capacity the band anticipates.
+
+---
+
+## Block A — Creation waves (dated)
+
+> Sized to the 18–21 capacity band; items are pointers to decided backlog.
+
+### Wave 1 — Agent backlog (full)  ·  2026-06-30 → 2026-07-14
+
+The deepest decided bucket — fills a band-wave on its own, all items already named
+in the checklist (`llm-agents/` §6.2–6.5).
+
+Requires (pointers to named-but-unwritten specs):
+- Parameters: `agent-max-iterations`, `agent-max-tokens`, `agent-reasoning-effort`, `agent-n-messages-limit` (**confirmed backend bug** — gate as expected-fail)
+- Behavior & output: `agent-structured-output`, `agent-system-prompt`, `agent-config-persistence`, `agent-empty-refusal-response`, `agent-input-sources`, `agent-current-date-tool`, `agent-parse-error-behavior`, `agent-multimodal-image-input`
+- Tools: `agent-tool-error-handling`, `agent-multi-tool-selection`, `agent-tool-name-validation`
+- Memory: `agent-context-id-continuity`, `agent-context-id-isolation`
+
+Convergence: ~49% → **~54%**
+Exit: agent parameter, behavior, tool and memory surfaces validated under `@stable`.
+Review (2026-07-14): reassess delivered vs. target; promote the next pool item into a dated wave.
+
+### Wave 2 — RAG, ingestion & providers  ·  2026-07-14 → 2026-07-28
+
+Highest product-value gap (RAG, 0% covered) bundled with provider management to
+reach the band.
+
+Requires:
+- `knowledge-ingestion-management/` §5.1 — upload via component; file types (txt, pdf, json, py, wav); file size limit; file management page
+- §5.2 — ingestion via Split Text + Embeddings; Vector Store index + query; full RAG pipeline (ingest → embed → store → retrieve → answer)
+- `model-provider/` §7.5 — Manage Providers modal; add provider; remove key; Language Model & Model Input components
+- §7.6 — open-source providers (Ollama, Groq, Mistral)
+
+Convergence: ~54% → **~58%**
+Exit: a RAG flow is validated end-to-end; provider management surface covered.
+Review (2026-07-28): reassess delivered vs. target; promote the next pool item into a dated wave.
+
+### Wave 3 — Component configuration  ·  2026-07-28 → 2026-08-11
+
+Requires (`core-components/` §2.1–2.4):
+- Parameters Panel field-type matrix: text, dropdown, textarea, code, float, int, toggle, key-pair list, input list, table, slider, tab
+- Tool Mode: group components, edit-tools
+- Component updates: outdated notification, update action, breaking-change alert
+- Full custom component
+
+Convergence: ~58% → **~62%**
+Exit: the component configuration surface is validated.
+Review (2026-08-11): reassess delivered vs. target; promote a Block B/C item into a dated wave.
+
+---
+
+## Block B — Validation track (pool, no dates)
+
+> Existing specs/skipped tests promoted to `@stable`. Different unit from Block A —
+> measured in bullets cleared, not new specs. A validation wave can clear more
+> bullets than a creation wave because the code already exists.
+
+- **MCP** — validate the 8 existing specs: `mcp-client-regression`, `mcp-client-agent`, `mcp-server`, `mcp-server-tab`, `mcp-server-regression`, `mcp-server-starter-projects` (§13–14, `[-]` → `[x]`).
+- **`ui-ux` canvas (inherited)** — connections, node manipulation, zoom/navigation, grouping, sticky notes, sidebar (§15.1–15.9, ~36 `[-]`). Large — split when scheduled.
+- **Template integration specs** — validate the existing `core/integrations/*` specs (Basic Prompting, Simple Agent, Vector Store, …) referenced under §11.
+- **Auth & user management** — admin user lifecycle, session/auto-login states (`auth/` §4.1–4.2).
+- **Disabled-test triage** — audit the 53 `test.skip` / 1 `test.fixme`: re-enable real ones, delete dead stubs (e.g. `voice-assistant.spec.ts`, `generalBugs-shard-3` no-op), resolve the webhook `fixme` (#165).
+
+## Block C — Scoped creation (pool, needs scoping first)
+
+> Too vague to date. Each requires a scoping pass that turns the checklist area into
+> a concrete spec list **before** it can be promoted to a dated wave (Rule 1 — no
+> inventing inside a wave).
+
+- **Templates** — load + run coverage across starter-project categories (`templates/` §11, 41 bullets). Decide depth (smoke vs. full execution) per category.
+- **Remaining `ui-ux` net-new** — anything in §15 not covered by the inherited specs validated in Block B.
+
+## Continuous track — spec-doc backfill
+
+> Not a wave. Runs alongside every wave per `CONTRIBUTING.md`.
+
+- Close the ~129 specs without a matching doc under `docs/` (worst: `flow-functionality` ~39, `ui-ux` ~28). New specs ship with docs by policy; this clears the inherited debt.
+
+---
+
+## How to update this file
+
+- At each wave's **Review** checkpoint: record what was delivered vs. target, move the wave to a short **Done** log line (date + final coverage), and promote the next backlog item into a dated wave to keep the ~3-wave horizon full.
+- Refresh the **Where we are** snapshot from `QA-CHECKLIST.md`; never hand-edit the numbers into a different value than the checklist reports.
+- Keep wave items as pointers. If a wave needs a test that does not yet exist as a backlog item, add it to `QA-CHECKLIST.md` **first**, then point to it here.
+- A Block C area cannot become a dated wave until its scoping pass has turned it into concrete backlog items.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,14 +63,18 @@ and the per-wave convergence target.** Everything else is a pointer.
 
 - **Each wave is a fixed 2-week timebox.** Lock the time, flex the scope: if a wave
   runs heavy, drop items from it — never extend the deadline.
-- **Capacity band: 18–21 new specs per wave** (≈9–10/week against a raw throughput
-  of 10–15/week). The band sits *below* raw capacity on purpose: maintaining the
-  growing validated suite competes for the same hours, so new-spec throughput
-  declines as the suite grows. Treat 18–21 as the current ceiling, revisited at
-  every review — later waves carry fewer new specs and more maintenance.
-- A wave is filled only with **decided** backlog items. If the decided new-spec
-  backlog runs short of the band, the wave is smaller — we do **not** invent specs
-  to hit the number.
+- **Capacity band: 50–60 validated checklist bullets per wave** — the target set by
+  leadership for this cycle (up from the previous 18–21 net-new specs). A wave hits
+  the band by moving 50–60 `QA-CHECKLIST.md` bullets to validated `[x]`, blending two
+  kinds of work: **writing new specs** (`[ ]` → `[x]`) and **promoting existing
+  unvalidated specs** to `@stable` (`[-]` → `[x]`). Both count, because both advance
+  the convergence metric. Net-new creation alone (~50 `[ ]` bullets in the whole
+  backlog) cannot sustain the band; the ~171 `[-]` promotions are what make 50–60/wave
+  reachable. Treat 50–60 as the target band, revisited at every review.
+- A wave is filled only with **decided** backlog items — real `QA-CHECKLIST.md`
+  bullets (`[ ]` to create, `[-]` to validate). If the decided backlog for an area
+  runs short of the band, the wave is smaller — we do **not** invent items to hit the
+  number.
 - **Every wave ends with a review** (the `Review (date)` line). At that checkpoint
   the team reassesses what was actually delivered vs. the target, and replenishes
   the dated horizon by promoting the next item from the pool.
@@ -83,105 +87,131 @@ and the per-wave convergence target.** Everything else is a pointer.
 
 ## The full horizon — how many waves total?
 
-The dated creation waves below are **not** the whole journey. The backlog splits
-into three blocks of different *nature*, only the first of which is pure creation:
+`QA-CHECKLIST.md` holds **228 non-validated bullets** (50 `[ ]` to create, 171 `[-]`
+to validate, 7 `[~]`/`[!]`). That backlog is the fuel for every wave. At 50–60 bullets
+per wave, three dated waves absorb the ~169 bullets that are **decided and ready to
+schedule now**; the remaining ~59 stay in the pool because they need a scoping pass
+before they can become concrete wave items.
 
-| Block | Nature | Est. waves | Dated? |
+| Source | Nature | Bullets | Dated? |
 |---|---|---|---|
-| **A — Creation (decided)** | Write new specs from the already-decided backlog (~50 specs) | **3** | ✅ Waves 1–3 |
-| **B — Validation track** | Promote existing `[-]` / skipped specs to `@stable` — little to no new code | ~2–3 | ⬜ pool |
-| **C — Scoped creation** | Areas too vague to schedule yet (templates, remaining ui-ux); need a scoping session to become a concrete spec list first | ~2–3 | ⬜ pool |
+| **Dated waves 1–3** | Blend of net-new specs (`[ ]`→`[x]`) and validation promotions (`[-]`→`[x]`), by product axis | ~169 | ✅ Waves 1–3 |
+| **Pool — needs scoping** | Templates (§11, 39 bullets — depth per category undecided) + auth & project-management tail (~20) | ~59 | ⬜ pool |
 | **Continuous** | Spec-doc backfill (~129 missing) — runs alongside, not a wave | — | ⬜ track |
 
-So the realistic horizon is **~8–9 waves (~4 months)**, not 3. Block A is dated now;
-Blocks B and C stay in the pool with a known shape and get coined at each review.
-New-spec volume is highest in Block A and tapers across B/C as maintenance grows —
-exactly the declining capacity the band anticipates.
+So the realistic horizon is **~4 dated waves (~2 months)** to converge the schedulable
+backlog, then templates once a scoping session turns §11 into a concrete list. Each
+dated wave leans on both creation and validation: early waves carry the deepest
+net-new bucket (agent backlog), later waves are validation-heavy (inherited canvas &
+MCP specs promoted to `@stable`).
 
 ---
 
-## Block A — Creation waves (dated)
+## Dated waves
 
-> Sized to the 18–21 capacity band; items are pointers to decided backlog.
+> Sized to the 50–60 capacity band; items are pointers to decided `QA-CHECKLIST.md`
+> backlog (created `[ ]`→`[x]` and validated `[-]`→`[x]`).
 
-| Wave | Axis (focus) | New specs (planned) | Coverage target | Delivery date |
-|---|---|---|---|---|
-| **1** | Agent backlog (params · behavior · tools · memory) | ~20 | ~54% | 2026-07-14 |
-| **2** | RAG, ingestion & providers | ~18 | ~58% | 2026-07-28 |
-| **3** | Component configuration | ~19 | ~62% | 2026-08-11 |
+| Wave | Axis (focus) | Bullets (planned) | Sources in `QA-CHECKLIST.md` | Coverage target | Delivery date |
+|---|---|---|---|---|---|
+| **1** | Agents & providers | ~53 | llm-agents §6.2–6.5 & §7.7 (26) + model-provider §7.1–7.6 (27) | ~61% | 2026-07-14 |
+| **2** | Components, RAG, flows & observability | ~58 | core-components §2 (22) + knowledge-ingestion §5 (8) + flow-functionality §12 (15) + observability §8 (8) + playground §9 (5) | ~74% | 2026-07-28 |
+| **3** | Canvas UI/UX & MCP | ~58 | ui-ux §15 (42) + mcp §13–14 (16) | ~87% | 2026-08-11 |
 
-> Spec counts and `%` are planned targets (`~`), not contracts — see **Cadence & review**.
+> Bullet counts and `%` are planned targets (`~`), not contracts — see **Cadence & review**.
+> Each wave mixes creation (`[ ]`→`[x]`) and validation (`[-]`→`[x]`): Wave 1 is
+> creation-heavy (agent backlog), Wave 3 is validation-heavy (inherited specs).
 
-### Wave 1 — Agent backlog (full)  ·  2026-06-30 → 2026-07-14
+### Wave 1 — Agents & providers  ·  2026-06-30 → 2026-07-14
 
-The deepest decided bucket — fills a band-wave on its own, all items already named
-in the checklist (`llm-agents/` §6.2–6.5).
-
-Requires (pointers to named-but-unwritten specs):
-- Parameters: `agent-max-iterations`, `agent-max-tokens`, `agent-reasoning-effort`, `agent-n-messages-limit` (**confirmed backend bug** — gate as expected-fail)
-- Behavior & output: `agent-structured-output`, `agent-system-prompt`, `agent-config-persistence`, `agent-empty-refusal-response`, `agent-input-sources`, `agent-current-date-tool`, `agent-parse-error-behavior`, `agent-multimodal-image-input`
-- Tools: `agent-tool-error-handling`, `agent-multi-tool-selection`, `agent-tool-name-validation`
-- Memory: `agent-context-id-continuity`, `agent-context-id-isolation`
-
-Convergence: ~49% → **~54%**
-Exit: agent parameter, behavior, tool and memory surfaces validated under `@stable`.
-Review (2026-07-14): reassess delivered vs. target; promote the next pool item into a dated wave.
-
-### Wave 2 — RAG, ingestion & providers  ·  2026-07-14 → 2026-07-28
-
-Highest product-value gap (RAG, 0% covered) bundled with provider management to
-reach the band.
+The deepest decided **creation** bucket (agent backlog, all named in `llm-agents/`
+§6.2–6.5 & §7.7) paired with the **provider-management validation** backlog (§7,
+mostly `[-]` specs awaiting `@stable`). Together they fill a 50–60 band-wave.
 
 Requires:
-- `knowledge-ingestion-management/` §5.1 — upload via component; file types (txt, pdf, json, py, wav); file size limit; file management page
-- §5.2 — ingestion via Split Text + Embeddings; Vector Store index + query; full RAG pipeline (ingest → embed → store → retrieve → answer)
-- `model-provider/` §7.5 — Manage Providers modal; add provider; remove key; Language Model & Model Input components
-- §7.6 — open-source providers (Ollama, Groq, Mistral)
+- **Create** (named-but-unwritten specs, §6.2–6.5 & §7.7): `agent-max-iterations` (**confirmed backend bug** — gate as expected-fail), `agent-max-tokens`, `agent-reasoning-effort`, `agent-n-messages-limit`, `agent-structured-output`, `agent-system-prompt`, `agent-config-persistence`, `agent-empty-refusal-response`, `agent-input-sources`, `agent-current-date-tool`, `agent-parse-error-behavior`, `agent-multimodal-image-input`, `agent-tool-error-handling`, `agent-multi-tool-selection`, `agent-tool-name-validation`, `agent-context-id-continuity`, `agent-context-id-isolation`; open-source providers `Ollama`/`Groq`/`Mistral` (§7.6).
+- **Validate** (`[-]` → `@stable`, §7.1–7.5): `collect-models` key/model collection & Save/Replace Configuration; OpenAI/Anthropic/Google configure + select + execute; "Manage Model Providers" modal, provider count, Language Model & Model Input components, add/remove provider key.
 
-Convergence: ~54% → **~58%**
-Exit: a RAG flow is validated end-to-end; provider management surface covered.
+Convergence: ~49% → **~61%**
+Exit: agent parameter/behavior/tool/memory surfaces validated under `@stable`; provider-management surface promoted.
+Review (2026-07-14): reassess delivered vs. target; promote the next pool item into a dated wave.
+
+### Wave 2 — Components, RAG, flows & observability  ·  2026-07-14 → 2026-07-28
+
+Bundles the component-configuration backlog with the highest product-value gap
+(RAG, 0% covered) plus the flow-lifecycle and observability tails.
+
+Requires:
+- **Create**: `knowledge-ingestion-management/` §5.1–5.2 — upload via component; file types (txt, pdf, json, py, wav); size limit; file management page; ingestion via Split Text + Embeddings; Vector Store index + query; full RAG pipeline (ingest → embed → store → retrieve → answer).
+- **Validate** (`[-]` → `@stable`): `core-components/` §2.1–2.4 — Parameters Panel field-type matrix (text, dropdown, textarea, code, float, int, toggle, key-pair, input list, table, slider, tab), Tool Mode grouping + edit-tools, component-update notification/action, full custom component; `flow-functionality/` §12 — create blank/from-template/import, edit name & description, auto-save, settings, lock/unlock, move-between-folders, save-as-template; `observability-monitoring/` §8.2–8.4 — execution-error & outdated notifications, user-state tracking, Python-error/network-error/timeout handling; `playground/` §9 — streaming/polling/direct-response paths.
+
+Convergence: ~61% → **~74%**
+Exit: a RAG flow is validated end-to-end; the component-configuration, flow-lifecycle and observability surfaces are promoted.
 Review (2026-07-28): reassess delivered vs. target; promote the next pool item into a dated wave.
 
-### Wave 3 — Component configuration  ·  2026-07-28 → 2026-08-11
+### Wave 3 — Canvas UI/UX & MCP  ·  2026-07-28 → 2026-08-11
 
-Requires (`core-components/` §2.1–2.4):
-- Parameters Panel field-type matrix: text, dropdown, textarea, code, float, int, toggle, key-pair list, input list, table, slider, tab
-- Tool Mode: group components, edit-tools
-- Component updates: outdated notification, update action, breaking-change alert
-- Full custom component
+Validation-heavy: the ~36 inherited `ui-ux` canvas specs and the 8 existing MCP
+specs already have code — this wave promotes them to `@stable` and fills the few
+named `[ ]` gaps.
 
-Convergence: ~58% → **~62%**
-Exit: the component configuration surface is validated.
-Review (2026-08-11): reassess delivered vs. target; promote a Block B/C item into a dated wave.
+Requires:
+- **Validate** (`[-]` → `@stable`): `ui-ux/` §15.1–15.10 — component sidebar (search, tooltip, filter), add-to-canvas, connections (compatible/incompatible, delete, reconnect), node manipulation (move, minimize, box-select, deselect), zoom & navigation, grouping, freeze/state, sticky notes, right-click menus, settings/shortcuts; `mcp/` §13–14 — client (configure stdio/HTTP, list tools, execute, error handling, agent-uses-MCP) and server (tab, add via modal, starter project).
+- **Create** (`[ ]`): MCP resources — list/consume resource URI; server-exposed resource & prompt via URI/template.
+
+Convergence: ~74% → **~87%**
+Exit: the inherited canvas surface and MCP client/server are validated under `@stable`.
+Review (2026-08-11): reassess delivered vs. target; promote a pool item (templates, once scoped) into a dated wave.
 
 ---
 
-## Block B — Validation track (pool, no dates)
+## Pool — not yet dated
 
-> Existing specs/skipped tests promoted to `@stable`. Different unit from Block A —
-> measured in bullets cleared, not new specs. A validation wave can clear more
-> bullets than a creation wave because the code already exists.
+> What's left after the dated waves absorb the ~169 schedulable bullets. Most of the
+> validation track (providers, components, flows, observability, canvas, MCP) is folded
+> **into** Waves 1–3 to reach the 50–60 band — it is no longer a separate pool. What
+> remains here is either a smaller decided tail or an area that needs scoping first.
 
-- **MCP** — validate the 8 existing specs: `mcp-client-regression`, `mcp-client-agent`, `mcp-server`, `mcp-server-tab`, `mcp-server-regression`, `mcp-server-starter-projects` (§13–14, `[-]` → `[x]`).
-- **`ui-ux` canvas (inherited)** — connections, node manipulation, zoom/navigation, grouping, sticky notes, sidebar (§15.1–15.9, ~36 `[-]`). Large — split when scheduled.
-- **Template integration specs** — validate the existing `core/integrations/*` specs (Basic Prompting, Simple Agent, Vector Store, …) referenced under §11.
-- **Auth & user management** — admin user lifecycle, session/auto-login states (`auth/` §4.1–4.2).
+**Ready to date (decided tail — coin at a review):**
+
+- **Auth & user management** — login/logout states, admin user lifecycle, auto-login, session isolation (`auth/` §4.1–4.2, ~13 `[-]`).
+- **Project-management tail** — deletion integrity, move/drag flows, folder navigation & search (`project-management/` §10, ~7 `[-]`/`[~]`).
 - **Disabled-test triage** — audit the 53 `test.skip` / 1 `test.fixme`: re-enable real ones, delete dead stubs (e.g. `voice-assistant.spec.ts`, `generalBugs-shard-3` no-op), resolve the webhook `fixme` (#165).
 
-## Block C — Scoped creation (pool, needs scoping first)
+**Needs scoping first (Rule 1 — no inventing inside a wave):**
 
-> Too vague to date. Each requires a scoping pass that turns the checklist area into
-> a concrete spec list **before** it can be promoted to a dated wave (Rule 1 — no
-> inventing inside a wave).
-
-- **Templates** — load + run coverage across starter-project categories (`templates/` §11, 41 bullets). Decide depth (smoke vs. full execution) per category.
-- **Remaining `ui-ux` net-new** — anything in §15 not covered by the inherited specs validated in Block B.
+- **Templates** — load + run coverage across starter-project categories (`templates/` §11, 39 bullets, incl. the `core/integrations/*` specs). A scoping pass must decide depth (smoke vs. full execution) per category before this becomes a dated wave.
 
 ## Continuous track — spec-doc backfill
 
 > Not a wave. Runs alongside every wave per `CONTRIBUTING.md`.
 
 - Close the ~129 specs without a matching doc under `docs/` (worst: `flow-functionality` ~39, `ui-ux` ~28). New specs ship with docs by policy; this clears the inherited debt.
+
+## Intake — community regression issues (proposed)
+
+> **Status: proposed — flow still being designed (owner: Alice).** This section
+> reserves the slot; the exact routing is not decided yet. Do not treat it as active
+> process until the flow lands.
+
+A second inflow of work, alongside the existing checklist backlog: **regressions
+observed by the community land as GitHub issues**, and a triage flow routes them into
+the suite. Two candidate paths (to be decided during the design):
+
+- **Via the checklist (default assumption).** A triaged regression issue becomes a new
+  `QA-CHECKLIST.md` bullet — a named `@regression` spec — which is then scheduled into
+  a wave like any other item. This keeps a single backlog of record and preserves the
+  convergence metric. Rule 1 already admits "an open issue" as a valid backlog pointer,
+  so no rule changes are needed for this path.
+- **Directly into the ROADMAP (possible shortcut).** A high-severity regression may be
+  inserted into the current or next wave without waiting for a checklist pass —
+  displacing lower-priority items to hold the 2-week timebox ("lock the time, flex the
+  scope"). If this path is adopted, the item must still be **back-filled into
+  `QA-CHECKLIST.md`** so the coverage metric and Rule 1 stay honest.
+
+Open questions for the design: who triages and on what SLA; the severity bar for the
+direct-into-wave shortcut; how these items are tagged/labeled on the issue and in the
+suite (`@regression`); and whether they count toward or on top of the 50–60 band.
 
 ---
 
@@ -190,4 +220,4 @@ Review (2026-08-11): reassess delivered vs. target; promote a Block B/C item int
 - At each wave's **Review** checkpoint: record what was delivered vs. target, move the wave to a short **Done** log line (date + final coverage), and promote the next backlog item into a dated wave to keep the ~3-wave horizon full.
 - Refresh the **Where we are** snapshot from `QA-CHECKLIST.md`; never hand-edit the numbers into a different value than the checklist reports.
 - Keep wave items as pointers. If a wave needs a test that does not yet exist as a backlog item, add it to `QA-CHECKLIST.md` **first**, then point to it here.
-- A Block C area cannot become a dated wave until its scoping pass has turned it into concrete backlog items.
+- A "needs scoping first" pool area (e.g. templates) cannot become a dated wave until its scoping pass has turned it into concrete backlog items.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -104,6 +104,14 @@ exactly the declining capacity the band anticipates.
 
 > Sized to the 18–21 capacity band; items are pointers to decided backlog.
 
+| Wave | Axis (focus) | New specs (planned) | Coverage target | Delivery date |
+|---|---|---|---|---|
+| **1** | Agent backlog (params · behavior · tools · memory) | ~20 | ~54% | 2026-07-14 |
+| **2** | RAG, ingestion & providers | ~18 | ~58% | 2026-07-28 |
+| **3** | Component configuration | ~19 | ~62% | 2026-08-11 |
+
+> Spec counts and `%` are planned targets (`~`), not contracts — see **Cadence & review**.
+
 ### Wave 1 — Agent backlog (full)  ·  2026-06-30 → 2026-07-14
 
 The deepest decided bucket — fills a band-wave on its own, all items already named


### PR DESCRIPTION
## What

Adds `ROADMAP.md` as the single **direction source of truth** — where we are and what comes next, in time-boxed 2-week waves — and sizes the dated waves to leadership's requested **50–60 per wave** band.

## Why

The roadmap answers one question no other doc owns: *when* and *in what order* work happens. It reads coverage from `QA-CHECKLIST.md`, points to spec docs for *what*, and links `CONTRIBUTING.md` for *how* — it schedules, it does not invent tests.

Leadership set the per-wave target to **50–60** (up from 18–21). Because net-new creation alone (~50 `[ ]` bullets in the whole backlog) can't sustain that, the capacity-band unit is redefined from *net-new specs* to **validated checklist bullets per wave**, blending creation (`[ ]`→`[x]`) and validation promotions (`[-]`→`[x]`). This is honestly reachable from the real backlog (228 non-validated bullets: 50 to create, 171 to validate) and keeps Rule 1 intact.

## Highlights

- **3 dated waves** (~53 / ~58 / ~58 bullets), each pointing to `QA-CHECKLIST.md` sections; coverage targets ~61% → ~74% → ~87%.
  - Wave 1 — Agents & providers (creation-heavy)
  - Wave 2 — Components, RAG, flows & observability
  - Wave 3 — Canvas UI/UX & MCP (validation-heavy)
- **Block A/B/C-as-separate-waves dissolved** into *Dated waves* + *Pool* (decided tail + needs-scoping templates).
- **Proposed "Intake — community regression issues"** section (owner: Alice, flow still being designed): community regressions land as GitHub issues and route in via the checklist, or as a direct-into-wave shortcut with checklist back-fill.

## Scope

Docs only — `ROADMAP.md`. No test or config changes.