### PR TITLE
chore(triage): remove @stable from 2026-07-02 daily failures (#475)

### DIFF
--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -407,7 +407,7 @@ test(
 
 test(
   "API Request component — POST method executes POST verb and returns 200",
-  { tag: ["@stable", "@release", "@regression", "@components"] },
+  { tag: ["@release", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
 

--- a/tests/tests-automations/regression/core-functionality/auth/logout-flow.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/auth/logout-flow.spec.ts
@@ -26,7 +26,7 @@ function setupAutoLoginMock(page: any) {
 
 test(
   "logout must redirect user to login page",
-  { tag: ["@stable", "@release", "@api", "@regression", "@auth"] },
+  { tag: ["@release", "@api", "@regression", "@auth"] },
   async ({ page }) => {
     await setupAutoLoginMock(page);
 
@@ -77,7 +77,7 @@ test(
 
 test(
   "after logout, navigating to root must redirect to login",
-  { tag: ["@stable", "@release", "@api", "@regression", "@auth"] },
+  { tag: ["@release", "@api", "@regression", "@auth"] },
   async ({ page }) => {
     await setupAutoLoginMock(page);
 
@@ -121,7 +121,7 @@ test(
 
 test(
   "after logout, reload must stay on login page",
-  { tag: ["@stable", "@release", "@api", "@regression", "@auth"] },
+  { tag: ["@release", "@api", "@regression", "@auth"] },
   async ({ page }) => {
     await setupAutoLoginMock(page);
 

--- a/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
@@ -147,7 +147,7 @@ test.describe("Playground Output – Structured Data", () => {
 
   test(
     "playground must render DataFrame output as a markdown table",
-    { tag: ["@stable", "@release", "@regression", "@playground"] },
+    { tag: ["@release", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step(
         "Set up Mock Data (dataframe_output) → Chat Output flow and open playground",


### PR DESCRIPTION
## What

Manual `@stable` triage of the daily stable run [28583683001](https://github.com/oriontech-me/langflow-e2e/actions/runs/28583683001) (2026-07-02), reported in #475. The `@stable` auto-removal did not fire because of the path-resolution bug tracked in #476, so the tags are removed by hand here — a single atomic triage commit, mirroring what the auto-removal would have done.

## Removals

**Hard failures** (failed every retry):

| Spec | Test(s) | Signature | Issue |
|---|---|---|---|
| `logout-flow.spec.ts` | 3 tests (`:27`, `:78`, `:122`) | Sign In never reaches `mainpage_title` within 30s | #477 |
| `api-request-component-regression.spec.ts` | POST test (`:408`) | `/build/.../events` response times out after 45s | #478 |

**Recurrent flake** (never auto-removed — manual per policy):

| Spec | Test | Signature | Issue |
|---|---|---|---|
| `playground-output-data.spec.ts` | DataFrame test (`:148`) | flaky in 2 consecutive dailies (07-01, 07-02) | #465 |

Only the failing/flaky tests lose `@stable`; other `@stable` tests in the same files are untouched.

## Notes

- This PR does **not** close #477/#478/#465 — per `CONTRIBUTING.md`, `@stable` restoration is the human-gated step and happens in each issue's fix PR after re-validation.
- Same failure signature as #327 for the logout cluster (likely a shared `mainpage_title` mount regression, unconfirmed).
- `QA-CHECKLIST.md` is intentionally untouched — the auto-generated Phase 0 / Coverage blocks are regenerated by `update-coverage-summary.yml` on merge to `main`.
- typecheck (`tsc --noEmit`) and lint (0 errors) pass.
