### PR TITLE
fix(triage): make @stable auto-remove actually work (report paths resolved against rootDir) (#476)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ docs/superpowers/
 # Artefatos gerados localmente — cada dev gera via collect-models.spec.ts
 tests/helpers/provider-setup/data/models.json
 tests/helpers/provider-setup/data/providers.json
+
+# Transient spec fixtures written at runtime by remove-stable-from-failures.spec.ts
+tests/scripts/.auto-remove-fixture-*.ts

--- a/scripts/remove-stable-from-failures.ts
+++ b/scripts/remove-stable-from-failures.ts
@@ -60,7 +60,26 @@ interface Skipped {
 // Mirrors scripts/build-run-payload.mjs: only status "unexpected" counts as a
 // hard failure; "flaky"/"skipped"/"expected" are ignored.
 
-function collectHardFailures(reportFile: string): Failure[] {
+/**
+ * Base directories to try, in order, when resolving a non-absolute spec path
+ * from the report. The Playwright JSON reporter emits `spec.file` relative to
+ * the Playwright `rootDir` (`<repo>/tests`, from `testDir: "./tests"`), NOT the
+ * repo root — so `REPO_ROOT` alone never matches and every failure was silently
+ * skipped as "spec file not found" (issue #476). We prefer the report's own
+ * `config.rootDir` (absolute, correct in the run that produced it), then the
+ * conventional `<repo>/tests`, then `REPO_ROOT` as a last resort, and pick the
+ * first base under which the file actually exists on disk.
+ */
+function candidateBases(report: any): string[] {
+  const bases: string[] = [];
+  const rootDir = report?.config?.rootDir;
+  if (typeof rootDir === "string" && rootDir) bases.push(rootDir);
+  bases.push(path.join(REPO_ROOT, "tests"));
+  bases.push(REPO_ROOT);
+  return bases;
+}
+
+export function collectHardFailures(reportFile: string): Failure[] {
   if (!fs.existsSync(reportFile)) return [];
   let report: any;
   try {
@@ -69,9 +88,18 @@ function collectHardFailures(reportFile: string): Failure[] {
     return [];
   }
   const failures: Failure[] = [];
+  const bases = candidateBases(report);
   const resolveFile = (spec: any): string => {
     const f = spec?.file || spec?.location?.file || "";
-    return path.isAbsolute(f) ? f : path.resolve(REPO_ROOT, f);
+    if (!f) return "";
+    if (path.isAbsolute(f)) return f;
+    for (const base of bases) {
+      const candidate = path.resolve(base, f);
+      if (fs.existsSync(candidate)) return candidate;
+    }
+    // Nothing matched: return the tests/-rebased path (the correct base per
+    // testDir) so the downstream "spec file not found" skip is meaningful.
+    return path.resolve(path.join(REPO_ROOT, "tests"), f);
   };
   const visit = (node: any): void => {
     for (const spec of node.specs || []) {
@@ -281,7 +309,24 @@ function main(): void {
   }
 
   result.status = result.removed.length > 0 ? "removed" : "none";
+
+  // Fail louder: a "spec file not found" skip means path resolution is broken
+  // (the exact failure mode of #476) — the report has real hard failures we
+  // couldn't act on. Surface a GitHub Actions warning annotation on stderr so
+  // it's visible in the log instead of exiting quietly as `none`.
+  const notFound = result.skipped.filter((s) => s.reason === "spec file not found");
+  if (notFound.length > 0) {
+    process.stderr.write(
+      `::warning title=Auto-remove @stable::${notFound.length} hard failure(s) skipped because their spec file could not be resolved on disk — path resolution may be broken (see #476). Files: ${notFound
+        .map((s) => s.file)
+        .join(", ")}\n`,
+    );
+  }
+
   process.stdout.write(JSON.stringify(result));
 }
 
-main();
+// Only run when invoked as a script — keeps the module importable from tests.
+if (require.main === module) {
+  main();
+}

--- a/tests/scripts/remove-stable-from-failures.spec.ts
+++ b/tests/scripts/remove-stable-from-failures.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * Node-only regression test for `scripts/remove-stable-from-failures.ts`.
+ *
+ * This is NOT a browser test: it exercises a build/CI script, so it imports
+ * `test`/`expect` directly from `@playwright/test` rather than from
+ * `../fixtures/fixtures` (the fixtures wrapper adds page-based backend-error
+ * monitoring that is meaningless here and requires a running Langflow).
+ *
+ * Guards the path-resolution contract that broke in #476: the Playwright JSON
+ * reporter emits `spec.file` relative to the Playwright `rootDir`
+ * (`<repo>/tests`), NOT the repo root. The old code resolved against
+ * `REPO_ROOT`, so every hard failure was silently skipped as "spec file not
+ * found" and the auto-remove feature never removed a single tag.
+ */
+import { execFileSync } from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import type { TestInfo } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+import { collectHardFailures } from "../../scripts/remove-stable-from-failures";
+
+const REPO_ROOT = path.resolve(__dirname, "../..");
+const TESTS_ROOT = path.join(REPO_ROOT, "tests");
+const FIXTURE_TITLE = "auto-remove fixture: sample stable test";
+
+const FIXTURE_SOURCE = `import { test } from "@playwright/test";
+
+test(
+  "${FIXTURE_TITLE}",
+  { tag: ["@release", "@stable"] },
+  async () => {
+    // Fixture for scripts/remove-stable-from-failures — never run as a real test.
+  },
+);
+`;
+
+/**
+ * Absolute path to this test's throwaway spec. Placed under `tests/` so the
+ * script's relative-path resolution can find it, and keyed to `testInfo.testId`
+ * so the fullyParallel tests never share (and race on) the same file. Matches
+ * the `.auto-remove-fixture-*.ts` pattern git-ignored at the repo root.
+ */
+function fixturePath(testInfo: TestInfo): string {
+  return path.join(__dirname, `.auto-remove-fixture-${testInfo.testId}.ts`);
+}
+
+/** Write the fixture spec for this test and return { abs, rel } (rel = reporter-style). */
+function writeFixture(testInfo: TestInfo): { abs: string; rel: string } {
+  const abs = fixturePath(testInfo);
+  fs.writeFileSync(abs, FIXTURE_SOURCE);
+  return { abs, rel: path.relative(TESTS_ROOT, abs) };
+}
+
+/** Build a minimal Playwright JSON report carrying one hard failure for FIXTURE. */
+function makeReport(specFile: string, opts?: { rootDir?: string }): unknown {
+  return {
+    config: opts?.rootDir ? { rootDir: opts.rootDir } : {},
+    suites: [
+      {
+        specs: [
+          {
+            title: FIXTURE_TITLE,
+            file: specFile,
+            line: 3,
+            tests: [{ status: "unexpected" }],
+          },
+        ],
+        suites: [],
+      },
+    ],
+  };
+}
+
+function writeReport(report: unknown): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "auto-remove-"));
+  const p = path.join(dir, "results.json");
+  fs.writeFileSync(p, JSON.stringify(report));
+  return p;
+}
+
+test.afterEach(({}, testInfo) => {
+  const abs = fixturePath(testInfo);
+  if (fs.existsSync(abs)) fs.unlinkSync(abs);
+});
+
+test.describe("remove-stable-from-failures path resolution (@stable auto-remove, #476)", () => {
+  test("resolves rootDir-relative report paths against tests/, not repo root", ({}, testInfo) => {
+    const { abs, rel } = writeFixture(testInfo);
+
+    // No config.rootDir → must fall back to <repo>/tests (the regression from #476).
+    const reportPath = writeReport(makeReport(rel));
+    const failures = collectHardFailures(reportPath);
+
+    expect(failures).toHaveLength(1);
+    expect(path.isAbsolute(failures[0].file)).toBe(true);
+    expect(failures[0].file).toBe(abs);
+    expect(fs.existsSync(failures[0].file)).toBe(true);
+  });
+
+  test("prefers the report's config.rootDir when present", ({}, testInfo) => {
+    const { abs, rel } = writeFixture(testInfo);
+
+    const reportPath = writeReport(makeReport(rel, { rootDir: TESTS_ROOT }));
+    const failures = collectHardFailures(reportPath);
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0].file).toBe(abs);
+  });
+
+  test("end-to-end: hard failure is resolved and @stable is spliced out", ({}, testInfo) => {
+    const { abs, rel } = writeFixture(testInfo);
+
+    const reportPath = writeReport(makeReport(rel));
+    const stdout = execFileSync(
+      "npx",
+      ["ts-node", "scripts/remove-stable-from-failures.ts"],
+      { cwd: REPO_ROOT, env: { ...process.env, PLAYWRIGHT_JSON: reportPath }, encoding: "utf8" },
+    );
+
+    const result = JSON.parse(stdout);
+    expect(result.status).toBe("removed");
+    expect(result.removed).toHaveLength(1);
+    expect(result.removed[0].title).toBe(FIXTURE_TITLE);
+    expect(result.skipped).toHaveLength(0);
+
+    // @stable removed, sibling @release preserved.
+    const after = fs.readFileSync(abs, "utf8");
+    expect(after).not.toContain("@stable");
+    expect(after).toContain("@release");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the auto-removal of `@stable` on hard failures, which has been **inoperative since it shipped (#473)**: it silently skipped 100% of real hard failures as `spec file not found`, so it never removed a single tag.

## Root cause

`scripts/remove-stable-from-failures.ts` resolved report spec paths against `REPO_ROOT`:

```ts
return path.isAbsolute(f) ? f : path.resolve(REPO_ROOT, f);
```

But the Playwright JSON reporter emits `spec.file` relative to the Playwright `rootDir` — with `testDir: "./tests"` that's `<repo>/tests`, not `<repo>`. So `tests-automations/regression/.../foo.spec.ts` resolved to `<repo>/tests-automations/...` (no `tests/`), which doesn't exist → `fs.existsSync` false → every failure pushed to `skipped[]`. The AST/splice logic and mass-failure guard were never reached, and the step exited quietly as `none`.

## Changes

- **Candidate-base resolution**: resolve non-absolute report paths against, in order, the report's own `config.rootDir`, then `<repo>/tests`, then `REPO_ROOT` — picking the first base under which the file exists on disk.
- **Fail louder**: emit a `::warning::` GitHub Actions annotation when a failure is skipped as `spec file not found`, so a broken resolution surfaces in the log instead of hiding behind status `none`.
- **Testability**: export `collectHardFailures`; guard `main()` with `require.main === module`.
- **Regression test** (`tests/scripts/remove-stable-from-failures.spec.ts`): node-only spec covering the path-resolution contract (rootDir-relative → `tests/`; prefers `config.rootDir`) plus an end-to-end run of the real script asserting `@stable` is spliced out while sibling `@release` is preserved. Fixtures are keyed per `testInfo.testId` to avoid a `fullyParallel` race, and git-ignored.

## Verification

- `npm run typecheck` ✅ · lint of changed files ✅
- New test: 24/24 under stress (`--repeat-each=8 --retries=0`) ✅
- Reproduced against a real repo spec path: it now resolves (no more `spec file not found`).

## Acceptance criteria (#476)

- [x] Given a report with a hard failure, the script resolves the spec file, finds `@stable`, and reports it under `removed[]` (subject to the mass-failure guard).
- [x] A unit/integration test covers the path-resolution contract.
- [x] Skipped-not-found is surfaced loudly rather than exiting quietly.

Closes #476