### PR TITLE
fix(provider-setup): resolve agent model by preference list instead of hardcoded gpt-4o-mini fallback

### DIFF
--- a/tests/helpers/provider-setup/setup-openai.ts
+++ b/tests/helpers/provider-setup/setup-openai.ts
@@ -99,19 +99,28 @@ export async function setupOpenAI(
     const options = page.locator('[data-testid$="-option"]');
     await options.first().waitFor({ state: "visible", timeout: 10000 });
     const count = await options.count();
+    // Lower-case each label so matching is case-insensitive: textContent may
+    // carry display casing (e.g. "GPT-4o Mini") that plain includes() would miss.
     const labels: string[] = [];
     for (let i = 0; i < count; i++) {
-      labels.push(((await options.nth(i).textContent()) ?? "").trim());
+      labels.push(((await options.nth(i).textContent()) ?? "").trim().toLowerCase());
     }
 
-    // Ordered most- to least-preferred. All target small multimodal chat models
-    // and exclude search-preview / nano variants; anything not matched (pro,
-    // reasoning, codex) is only reached via the first-available fallback.
+    // Reject families that are NOT general-purpose vision chat models: reasoning
+    // (o1/o3/o4…), audio/realtime/tts/transcribe, search-preview and nano
+    // variants. Substring "gpt-4o-mini" alone would otherwise match e.g.
+    // "gpt-4o-mini-tts" or rank a text-only "o3-mini" as a fallback, breaking
+    // callers like the agent image test that need real vision output.
+    const nonChat = /\bo\d|audio|realtime|tts|transcribe|search|nano/;
+
+    // Ordered most- to least-preferred. All target small multimodal chat models;
+    // anything not matched (pro, reasoning, codex) is only reached via the
+    // first-available fallback.
     const preferences: Array<(m: string) => boolean> = [
-      (m) => m.includes("gpt-4o-mini") && !m.includes("search"),
-      (m) => m.includes("-mini") && !m.includes("nano") && !m.includes("search"),
-      (m) => m.includes("gpt-4o") && !m.includes("search"),
-      (m) => m.includes("gpt-4.1") && !m.includes("search"),
+      (m) => m.includes("gpt-4o-mini") && !nonChat.test(m),
+      (m) => m.includes("-mini") && !nonChat.test(m),
+      (m) => m.includes("gpt-4o") && !nonChat.test(m),
+      (m) => m.includes("gpt-4.1") && !nonChat.test(m),
     ];
 
     let chosenIndex = -1;

--- a/tests/helpers/provider-setup/setup-openai.ts
+++ b/tests/helpers/provider-setup/setup-openai.ts
@@ -88,7 +88,42 @@ export async function setupOpenAI(
     }
     await modelOption.click();
   } else {
-    await page.locator('[data-testid$="-option"]', { hasText: "gpt-4o-mini" }).first().waitFor({ state: "visible", timeout: 10000 });
-    await page.locator('[data-testid$="-option"]', { hasText: "gpt-4o-mini" }).first().click();
+    // No explicit model requested — pick a fast, general-purpose model from the
+    // enabled dropdown. Hardcoding a single name (previously "gpt-4o-mini")
+    // breaks whenever that model leaves the lineup on gpt-5.x nightlies. Instead
+    // we rank the available options by a preference list and only fall back to
+    // the first available if none match. This keeps the default cheap and
+    // vision-capable — callers like the agent image test rely on that — while
+    // surviving model-family churn and skipping the slow/expensive
+    // "pro"/reasoning models that tend to top the dropdown.
+    const options = page.locator('[data-testid$="-option"]');
+    await options.first().waitFor({ state: "visible", timeout: 10000 });
+    const count = await options.count();
+    const labels: string[] = [];
+    for (let i = 0; i < count; i++) {
+      labels.push(((await options.nth(i).textContent()) ?? "").trim());
+    }
+
+    // Ordered most- to least-preferred. All target small multimodal chat models
+    // and exclude search-preview / nano variants; anything not matched (pro,
+    // reasoning, codex) is only reached via the first-available fallback.
+    const preferences: Array<(m: string) => boolean> = [
+      (m) => m.includes("gpt-4o-mini") && !m.includes("search"),
+      (m) => m.includes("-mini") && !m.includes("nano") && !m.includes("search"),
+      (m) => m.includes("gpt-4o") && !m.includes("search"),
+      (m) => m.includes("gpt-4.1") && !m.includes("search"),
+    ];
+
+    let chosenIndex = -1;
+    for (const matches of preferences) {
+      const idx = labels.findIndex(matches);
+      if (idx !== -1) {
+        chosenIndex = idx;
+        break;
+      }
+    }
+    if (chosenIndex === -1) chosenIndex = 0; // no preferred match — first available
+
+    await options.nth(chosenIndex).click();
   }
 }

--- a/tests/tests-automations/regression/core-functionality/llm-agents/general-bugs-agent-images-playground.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/general-bugs-agent-images-playground.spec.ts
@@ -22,9 +22,11 @@ test(
     // Langflow 1.11.0, so the provider entry point never appeared.
     //
     // load() also runs setupOpenAI; with no explicit model it selects a resilient
-    // default (gpt-4o-mini, vision-capable on the Agent component), so the
-    // multimodal assertion below holds. OpenAI is used (not Anthropic) so the test
-    // runs in the weekly workflow, which provides OPENAI_API_KEY.
+    // default — a fast, vision-capable chat model (preferring gpt-4o-mini and
+    // similar "-mini" variants over slow "pro"/reasoning models), so the
+    // multimodal assertion below holds even as model families change on
+    // nightlies. OpenAI is used (not Anthropic) so the test runs in the weekly
+    // workflow, which provides OPENAI_API_KEY.
     await new SimpleAgentTemplatePage(page).load({ provider: "openai" });
 
     await page.getByTestId("playground-btn-flow-io").click();


### PR DESCRIPTION
## Problem

`tests/helpers/provider-setup/setup-openai.ts` hardcoded a `gpt-4o-mini`
selection in the no-`modelTestId` fallback path. On gpt-5.x nightlies where
`gpt-4o-mini` leaves the lineup, that step times out and breaks any agent spec
that calls the helper without an explicit model.

## Fix

Rank the enabled dropdown options (Step 5 enables all provider models) by a
preference list and pick the first match, falling back to first-available only
if none match:

`gpt-4o-mini` → any `*-mini` (excluding nano/search) → `gpt-4o` → `gpt-4.1`

This keeps the default **fast and vision-capable** while surviving model-family
churn, and avoids the slow/expensive `pro`/reasoning models.

### Why not pure "first available"

Verified live against a running nightly: pure first-available selects
**`gpt-5.5-pro`** (top of the dropdown), which returned `Message empty.` for an
image prompt and **broke the `@stable` image test**
(`general-bugs-agent-images-playground.spec.ts`). The preference list keeps that
test green.

## Verification (live nightly)

- `general-bugs-agent-images-playground.spec.ts` → **1 passed** (previously failed on gpt-5.5-pro)
- `model-provider-model-toggle.spec.ts` → **2 passed**
- `npm run typecheck` clean; `npm run lint` no errors in changed files

Also updated the stale comment in the image spec that referenced the exact
`gpt-4o-mini` fallback.

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)
