### PR TITLE
test(flow-functionality): cover running a flow from the canvas

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -60,7 +60,7 @@
 - [ ] Configure an MCP
 - [ ] Configure a Custom Component
 - [ ] Delete a component
-- [ ] Run a flow
+- [x] Run a flow → `helpers/flows/run-flow.ts`
 - [ ] Pause a flow
 - [ ] Send a chat input
 - [ ] Verify the chat output
@@ -630,7 +630,8 @@
 
 #### 12.6 Flow Execution
 - [x] Run Flow component executes another flow → `flow-functionality/run-flow.spec.ts`
-- [-] Stop building flow → `core/features/stop-building.spec.ts`
+- [x] Run a flow from the canvas — terminal-node run builds the whole graph; all nodes reach build success and output is produced → `flow-functionality/flow-execution-canvas.spec.ts`
+- [-] Stop building flow → `flow-functionality/stop-building.spec.ts`
 - [!] Playground button disabled with empty flow — needs review → `regression/flow-functionality/generalBugs-shard-3.spec.ts` (**test skipped: assertion was a no-op, current Langflow behavior to confirm**)
 
 ---
@@ -761,12 +762,12 @@
 | `core-functionality/playground/` | 48 | 43 | 3 | 1 | 1 |
 | `core-functionality/project-management/` | 11 | 4 | 6 | 1 | 0 |
 | `core-functionality/templates/` | 41 | 2 | 39 | 0 | 0 |
-| `flow-functionality/` | 27 | 12 | 13 | 2 | 0 |
+| `flow-functionality/` | 28 | 13 | 13 | 2 | 0 |
 | `mcp/client/` | 9 | 0 | 7 | 0 | 2 |
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 44 | 7 | 36 | 1 | 0 |
 | `ui-ux/` — Settings | 7 | 3 | 3 | 1 | 0 |
-| **TOTAL** | **450** | **223 (50%)** | **171 (38%)** | **7 (2%)** | **49 (11%)** |
+| **TOTAL** | **451** | **224 (50%)** | **171 (38%)** | **7 (2%)** | **49 (11%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -782,7 +783,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 230 `test()` calls carrying the `@stable` tag, distributed across 80 spec
+> 231 `test()` calls carrying the `@stable` tag, distributed across 81 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -1015,6 +1016,7 @@
 - [x] export flow to JSON triggers success toast and produces a valid file → `export-import-flow.spec.ts`
 - [x] imported JSON flow must load all components on canvas → `export-import-flow.spec.ts`
 - [x] import flow from JSON via upload button must load flow on canvas → `export-import-flow.spec.ts`
+- [x] user can run a flow from the canvas; every node reaches build success and output is produced → `flow-execution-canvas.spec.ts`
 - [x] flow can be renamed via the header edit → `flow-rename-header.spec.ts`
 - [x] flow name persists after rename via API PATCH and GET → `flow-rename-header.spec.ts`
 - [x] user can publish a flow and access it via shareable URL, then unpublish to revoke access → `publish-flow.spec.ts`

--- a/docs/flow-functionality/flow-execution-canvas.md
+++ b/docs/flow-functionality/flow-execution-canvas.md
@@ -1,0 +1,141 @@
+# Flow Functionality — Flow Execution via Canvas
+
+**Last validated:** Langflow 1.11.x (nightly `1.11.0.dev29`)
+
+**Test file:** `tests/tests-automations/regression/flow-functionality/flow-execution-canvas.spec.ts`
+**Reusable helper:** `tests/helpers/flows/run-flow.ts` (`runFlow`)
+
+---
+
+## What this test validates *(required)*
+
+The generic **"run a flow"** journey on the canvas: triggering a run from a
+terminal node builds the **entire upstream graph**, every node reaches
+build-success, the output is produced, and a second run is **idempotent**
+(re-running rebuilds cleanly).
+
+This is deliberately distinct from the two specs that look adjacent:
+
+- `run-flow.spec.ts` validates the **RunFlow *component*** (a node that executes
+  *another* flow) — a different feature.
+- `chat-input-output-component-regression.spec.ts` validates the **components'**
+  handles, fields and value propagation. Here the subject is the **run/build
+  orchestration itself** — that clicking run drives the whole graph to success
+  and that the run is repeatable — not any single component's plumbing.
+
+Langflow (1.11) has **no global "run flow" button**; a flow is run by triggering
+a terminal node's run control (`button_run_<node>`), which builds all upstream
+dependencies. (Confirmed live: `button_run_flow` does not exist in the DOM; the
+`FlowEditorPage.runFlow()` POM method referencing it is dead code.) This spec
+codifies that real journey and ships a reusable `runFlow` helper for it — the
+PART I "Run a flow" checklist item.
+
+No LLM / provider / API key required (ChatInput → ChatOutput echo).
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@workspace` `@regression`
+
+> Note: `flow-functionality` specs carry `@workspace` (cross-cutting) and no
+> functional tag — the tag taxonomy in `CLAUDE.md` has no functional tag for
+> "flow execution" (functional tags are provider/agents/mcp/playground/auth/
+> observability/files/templates/settings/ui-ux). This matches the sibling
+> `run-flow.spec.ts` (`@release @workspace @api @regression`). `@stable` is added
+> only after team validation.
+
+---
+
+## Step by step *(required)*
+
+### Test 1 — `user can run a flow from the canvas; every node reaches build success and output is produced`
+
+1. Create a ChatInput → ChatOutput flow via `POST /api/v1/flows/` using the
+   `chat-io-ok-trace-fixture.json` fixture (via `createRunnableChatFlowViaApi`,
+   which applies a unique name — deterministic, avoids the UI unique-name race).
+2. Navigate to `/flow/{id}` and wait for the canvas (`sidebar-search-input`).
+   No zoom/screen adjustment — the fixture's nodes render in a runnable position.
+3. Gate on the terminal node's run control (`button_run_chat output`) being
+   visible before running — a readiness wait so the run does not race canvas
+   hydration (this replaces the sync that `adjustScreenView` implicitly provided).
+4. Trigger the run from the terminal node via the reusable `runFlow(page, "chat output")`
+   helper (clicks `button_run_chat output`, expanding the node first if minimized).
+5. Assert the `built successfully` toast appears (whole-graph build completed).
+6. Assert **both** nodes reached success — each shows its duration badge
+   (`node_duration_chat input`, `node_duration_chat output`) after the run
+   (confirmed live in the running nightly).
+7. Open the Chat Output inspection (`output-inspection-output message-chatoutput`)
+   and assert the echoed input value (`Hello`) is present.
+8. `finally`: `DELETE /api/v1/flows/{id}`.
+
+---
+
+## Validation criterion *(required)*
+
+The spec must:
+
+- Trigger the run from a **terminal node** and assert the `built successfully`
+  toast — proving the run drove the whole graph, not a single node in isolation.
+- Assert **every** node reached success (both duration badges present), not only
+  the output value — a regression where an upstream node silently fails but the
+  output node still renders stale data would be caught.
+- Assert the Chat Output inspection contains the echoed value — proves the run
+  actually produced output end-to-end.
+- Use the reusable `runFlow` helper (not an inline click) so the PART I "Run a
+  flow" building block is exercised by a real test.
+- Delete the flow in `finally` — no workspace artifact accumulation across runs.
+- Log zero `🚨 Backend Error` (the fixture's monitor must stay clean; this is a
+  happy-path run).
+
+---
+
+## External dependencies *(required)*
+
+- `tests/assets/flows/chat-io-ok-trace-fixture.json` — the ChatInput → ChatOutput
+  fixture (1 edge, no LLM); the flow under test.
+- `tests/helpers/auth/get-auth-token.ts` — Bearer token for the API create/delete.
+- `tests/helpers/flows/run-flow.ts` — **new** reusable `runFlow` helper (generalizes
+  the existing `run-chat-output.ts` to any terminal node).
+- Langflow node run control testid `button_run_{node display name}` and the
+  per-node duration badge `node_duration_{node}` — the test breaks if these are
+  renamed upstream.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Component-level handles/fields/propagation — covered by
+  `chat-input-output-component-regression.spec.ts`.
+- Stopping/pausing a run — covered by `flow-functionality/stop-building.spec.ts`
+  and `core-functionality/playground/stop-button-playground.spec.ts`.
+- Running via the Playground send action — exercised by playground specs.
+- Running flows that require an LLM/provider — this is the deterministic,
+  provider-free baseline.
+- The RunFlow component (running one flow from another) — `run-flow.spec.ts`.
+- **Idempotent re-run (running the same flow twice in one session)** — descoped.
+  After the first build, the terminal node's run control sits under a
+  right-anchored `react-flow__panel` (and, transiently, the success toast),
+  which intercepts the second click. A `force` click works but would bypass real
+  actionability and could mask a genuine regression, so a reliable re-run
+  assertion is deferred rather than shipped flaky. Reopen if Langflow exposes a
+  stable re-run affordance (e.g. a global run button).
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` (latest nightly).
+- `LANGFLOW_SUPERUSER` / `LANGFLOW_SUPERUSER_PASSWORD` for the API auth token.
+- No LLM required.
+
+---
+
+## When to review this test *(optional)*
+
+- Langflow introduces a global "run flow" button — the spec should then target
+  it directly (and the dead `FlowEditorPage.runFlow()` / `button_run_flow` becomes
+  live).
+- The per-node run testid pattern `button_run_{node}` or the success badge
+  `node_duration_{node}` is renamed.
+- The `built successfully` toast text changes.

--- a/tests/helpers/flows/run-flow.ts
+++ b/tests/helpers/flows/run-flow.ts
@@ -1,0 +1,31 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Runs a flow by triggering a terminal node's run control, which builds the
+ * whole upstream graph.
+ *
+ * Langflow (1.11) has no global "run flow" button — a flow is run from a
+ * terminal node (`button_run_{node}`), and the build cascades to every upstream
+ * dependency. This generalizes `run-chat-output.ts` to any terminal node.
+ *
+ * If the node is minimized (its run control is not in the DOM), the node is
+ * expanded first, then the run control is clicked. Idempotent w.r.t. expansion:
+ * a node that already exposes its run button is clicked directly.
+ *
+ * @param page          Playwright page positioned on the flow canvas.
+ * @param terminalNode  Lowercased node display name, e.g. "chat output".
+ */
+export async function runFlow(page: Page, terminalNode = "chat output") {
+  const runButton = page.getByTestId(`button_run_${terminalNode}`);
+  // Expand only when the node is minimized (run control absent from the DOM) —
+  // decided by presence, not by a click timeout. On a re-run the button is
+  // present but briefly non-clickable while the prior build settles, so the
+  // click below relies on Playwright's actionability auto-wait rather than a
+  // tight timeout + (wrong) expand fallback.
+  if ((await runButton.count()) === 0) {
+    await page.getByTestId("generic-node-title-arrangement").last().click();
+    await page.getByTestId("more-options-modal").last().click();
+    await page.getByTestId("expand-button-modal").last().click();
+  }
+  await runButton.click({ timeout: 15000 });
+}

--- a/tests/tests-automations/regression/flow-functionality/flow-execution-canvas.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/flow-execution-canvas.spec.ts
@@ -1,0 +1,104 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import {
+  createRunnableChatFlowViaApi,
+  RUNNABLE_CHAT_FLOW_DEFAULT_INPUT,
+} from "../../../helpers/flows/create-runnable-chat-flow-via-api";
+import { runFlow } from "../../../helpers/flows/run-flow";
+
+/**
+ * Flow execution via the canvas — the generic "run a flow" journey.
+ *
+ * Langflow (1.11) has no global run button: a flow is run by triggering a
+ * terminal node's run control (`button_run_{node}`), which builds the whole
+ * upstream graph. This test asserts that journey end to end — the build reaches
+ * EVERY node (both duration badges) and the output is produced — exercising the
+ * reusable `runFlow` helper.
+ *
+ * Distinct from sibling specs (intentionally not duplicated here):
+ *   - `run-flow.spec.ts` covers the RunFlow *component* (one flow invoking another).
+ *   - `chat-input-output-component-regression.spec.ts` covers the components'
+ *     handles/fields/propagation.
+ *   - `stop-building.spec.ts` / `stop-button-playground.spec.ts` cover stopping a run.
+ *
+ * Idempotent re-run is intentionally not covered — after the first build the
+ * terminal node's run control sits under a right-anchored react-flow panel that
+ * intercepts a second click; see the spec doc's "does not cover" section.
+ *
+ * Deterministic: ChatInput -> ChatOutput echo, no LLM / provider / API key.
+ */
+
+// Open the Chat Output inspection dialog and return its full text. Reading the
+// whole dialog (not one inner node) mirrors the chat-input-output spec: the
+// Message output renders as a structured view that may mix labeled sections
+// with a JSON-style preview.
+async function readChatOutputInspection(page: Page) {
+  const inspect = page.getByTestId("output-inspection-output message-chatoutput");
+  await expect(inspect).toBeAttached({ timeout: 10000 });
+  await inspect.click();
+  // Scope out the first-run `assistant-onboarding-tooltip`, which also carries
+  // role="dialog" and would otherwise make this locator strict-mode-ambiguous.
+  const dialog = page.locator(
+    '[role="dialog"]:not([data-testid="assistant-onboarding-tooltip"])',
+  );
+  await expect(dialog).toBeVisible({ timeout: 10000 });
+  const text =
+    (await dialog.evaluate((el: HTMLElement) => el.textContent ?? "")) ?? "";
+  // No need to close the dialog — reading the output is the last assertion of
+  // the test; the flow is deleted in `finally`. (Test 2 runs on its own flow.)
+  return text;
+}
+
+test("user can run a flow from the canvas; every node reaches build success and output is produced",
+  { tag: ["@stable", "@release", "@workspace", "@regression"] },
+  async ({ page, request }) => {
+    const authToken = await getAuthToken(request);
+    const { flowId, deleteFlow } = await createRunnableChatFlowViaApi(request, {
+      Authorization: authToken,
+    });
+
+    try {
+      await test.step("Open the created flow on the canvas", async () => {
+        await page.goto(`/flow/${flowId}`);
+        await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
+          timeout: 30000,
+        });
+      });
+
+      await test.step("Run the flow from the terminal node", async () => {
+        // Gate on the terminal node's run control being rendered before running,
+        // so runFlow does not race canvas hydration (previously masked by
+        // adjustScreenView, removed by request).
+        await expect(page.getByTestId("button_run_chat output")).toBeVisible({
+          timeout: 30000,
+        });
+        await runFlow(page, "chat output");
+        await expect(page.getByText("built successfully").last()).toBeVisible({
+          timeout: 45000,
+        });
+      });
+
+      await test.step("Every node reached build success (duration badge)", async () => {
+        await expect(page.getByTestId("node_duration_chat input")).toBeVisible({
+          timeout: 15000,
+        });
+        await expect(
+          page.getByTestId("node_duration_chat output"),
+        ).toBeVisible({ timeout: 15000 });
+      });
+
+      await test.step("Output was produced (echoed input value)", async () => {
+        const text = await readChatOutputInspection(page);
+        expect(text).toContain(RUNNABLE_CHAT_FLOW_DEFAULT_INPUT);
+      });
+    } finally {
+      // Unmount the editor before deleting: it keeps a GET /flows/{id}/events
+      // subscription polling build state; deleting mid-poll yields a benign but
+      // log-dirtying 404 "Flow not found" (same teardown race fixed in
+      // publish-flow.spec.ts / triage #364).
+      await page.goto("/").catch(() => {});
+      await deleteFlow();
+    }
+  },
+);


### PR DESCRIPTION
Fills the `[ ] Run a flow` gap in `QA-CHECKLIST.md` (PART I helper + § 12.6 Flow Execution). Distinct from `run-flow.spec.ts` (the RunFlow **component** — one flow invoking another) and `chat-input-output-component-regression.spec.ts` (the components' handles/fields/propagation): here the subject is the **run/build orchestration** — triggering a terminal node's run builds the whole upstream graph.

Langflow 1.11 has **no global run button** (confirmed live: `button_run_flow` is not in the DOM); a flow runs from a terminal node's `button_run_{node}`, which cascades the build upstream. This codifies that real journey and ships a reusable `runFlow` helper (the PART I "Run a flow" building block).

## 1. Covered tests

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `user can run a flow from the canvas; every node reaches build success and output is produced` | Running from the terminal node builds the whole graph — the `built successfully` toast fires, **both** nodes show their duration badge (`node_duration_chat input` + `node_duration_chat output`, not just the output node), and the Chat Output inspection echoes the input value. Catches a regression where an upstream node silently fails while the output still renders stale data. |

## 2. How the test was built

- **Flow created via API** (`createRunnableChatFlowViaApi`, ChatInput → ChatOutput echo fixture) with a unique name — deterministic, no LLM/provider/key, avoids the UI unique-name race.
- **Live-confirmed selectors** against the running nightly (`1.11.0.dev29`): `button_run_chat output`, `built successfully` toast, `node_duration_chat input/output`, `output-inspection-output message-chatoutput`. Confirmed `button_run_flow` does **not** exist (the `FlowEditorPage.runFlow()` POM method is dead code).
- **Reusable `runFlow` helper** (`helpers/flows/run-flow.ts`) generalizes `run-chat-output.ts` to any terminal node; expands the node first only when its run control is absent from the DOM.
- **Readiness gate** on `button_run_chat output` before running, so the run does not race canvas hydration (no `adjustScreenView` — per request).
- **Teardown**: editor is navigated to `/` before the API `DELETE`, to unmount the `GET /flows/{id}/events` subscription and avoid the benign log-dirtying `404 Flow not found` (same race fixed in `publish-flow.spec.ts` / triage #364).
- **Dialog scoping**: the output-inspection `[role="dialog"]` locator excludes the first-run `assistant-onboarding-tooltip` (also `role="dialog"`) to avoid strict-mode ambiguity.

Also fixes the stale `12.6` checklist pointer for stop-building (`core/features/` → `flow-functionality/`).

## 3. Dependencies

- **No LLM / provider / API key** — pure canvas UI on a ChatInput → ChatOutput echo.
- **Execution mode:** parallel-safe (each run creates and deletes its own uniquely-named flow).

## Validation (nightly `1.11.0.dev29`, `--retries=0`)

- typecheck ✅ · eslint ✅ (0 errors)
- **6/6 clean runs** (`--repeat-each=6`), no flake ✅
- force-fail ✅ (bogus output sentinel → fails at the output assertion; reverted, re-passes)
- `--trace=on` ✅ · zero `🚨 Backend Error` (events-poll 404 eliminated) ✅

## Out of scope (documented in the spec doc)

- Idempotent re-run — after the first build the terminal node's run control sits under a right-anchored `react-flow__panel` that intercepts a second click; a `force` click would mask real actionability, so it is deferred rather than shipped flaky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)