### PR TITLE
refactor(core-components): extract reusable deleteComponent helper

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -59,7 +59,7 @@
 
 - [ ] Configure an MCP
 - [ ] Configure a Custom Component
-- [ ] Delete a component
+- [x] Delete a component → `helpers/flows/delete-component.ts`
 - [x] Run a flow → `helpers/flows/run-flow.ts`
 - [ ] Pause a flow
 - [x] Send a chat input → `flow-functionality/flow-execution-canvas.spec.ts`

--- a/tests/helpers/flows/delete-component.ts
+++ b/tests/helpers/flows/delete-component.ts
@@ -1,0 +1,33 @@
+import type { Page } from "@playwright/test";
+
+export type DeleteMethod = "backspace" | "menu";
+
+/**
+ * Deletes a single component from the canvas.
+ *
+ * Selects the node (clicking it activates its selection/toolbar) and removes it
+ * either with the Backspace key or via the node options (...) menu. Neither the
+ * 3-dot button nor the "Delete" item has its own testid, so the menu path
+ * targets their inner icons (`icon-MoreHorizontal` → `icon-Delete`).
+ *
+ * For a single-node canvas by default; pass a `node` locator to target a
+ * specific one. Multi-node marquee deletion is a distinct selection flow and is
+ * not covered by this helper.
+ *
+ * @param page    Playwright page positioned on the flow canvas.
+ * @param method  `"backspace"` (default) or `"menu"`.
+ * @param node    Optional node locator; defaults to the first `.react-flow__node`.
+ */
+export async function deleteComponent(
+  page: Page,
+  method: DeleteMethod = "backspace",
+  node = page.locator(".react-flow__node").first(),
+) {
+  await node.click();
+  if (method === "menu") {
+    await page.getByTestId("icon-MoreHorizontal").click();
+    await page.getByTestId("icon-Delete").click();
+  } else {
+    await page.keyboard.press("Backspace");
+  }
+}

--- a/tests/tests-automations/regression/core-components/componentDelete.spec.ts
+++ b/tests/tests-automations/regression/core-components/componentDelete.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "../../../fixtures/fixtures";
 import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
 import { addComponentFromSidebar } from "../../../helpers/flows/add-component-from-sidebar";
+import { deleteComponent } from "../../../helpers/flows/delete-component";
 
 test.describe("Delete a component from the canvas", () => {
   let createdFlowId: string | null = null;
@@ -24,8 +25,7 @@ test.describe("Delete a component from the canvas", () => {
     }
   });
 
-  test(
-    "Should delete a single component with the Backspace key",
+  test("Should delete a single component with the Backspace key",
     { tag: ["@release", "@stable", "@workspace", "@components"] },
     async ({ page }) => {
       await test.step("Add a Chat Input component to the canvas", async () => {
@@ -36,16 +36,13 @@ test.describe("Delete a component from the canvas", () => {
       });
 
       await test.step("Select the node and delete it with Backspace", async () => {
-        // Clicking the node selects it; Backspace then deletes the selection.
-        await page.locator(".react-flow__node").click();
-        await page.keyboard.press("Backspace");
+        await deleteComponent(page, "backspace");
         await expect(page.locator(".react-flow__node")).toHaveCount(0);
       });
     },
   );
 
-  test(
-    "Should delete a single component via the node options menu",
+  test("Should delete a single component via the node options menu",
     { tag: ["@release", "@stable", "@workspace", "@components"] },
     async ({ page }) => {
       await test.step("Add a Chat Input component to the canvas", async () => {
@@ -56,20 +53,13 @@ test.describe("Delete a component from the canvas", () => {
       });
 
       await test.step("Delete the node via its options (...) menu", async () => {
-        // Select the node first so its toolbar (the ... button) is shown —
-        // explicit instead of relying on the just-added node being auto-selected.
-        await page.locator(".react-flow__node").click();
-        // Neither the 3-dot button nor the "Delete" menu item has its own
-        // testid — target their inner icons instead.
-        await page.getByTestId("icon-MoreHorizontal").click();
-        await page.getByTestId("icon-Delete").click();
+        await deleteComponent(page, "menu");
         await expect(page.locator(".react-flow__node")).toHaveCount(0);
       });
     },
   );
 
-  test(
-    "Should delete multiple selected components with a marquee selection",
+  test("Should delete multiple selected components with a marquee selection",
     { tag: ["@release", "@stable", "@workspace", "@components"] },
     async ({ page }) => {
       await test.step("Add two components to the canvas", async () => {


### PR DESCRIPTION
Closes the `[ ] Delete a component` PART I helper item in `QA-CHECKLIST.md`. The **behavior** was already fully covered by `componentDelete.spec.ts` (3 `@stable` tests: Backspace, options menu, marquee); this extracts the reusable building block rather than duplicating those scenarios.

## What changed

- **New helper** `tests/helpers/flows/delete-component.ts` — `deleteComponent(page, method)` where `method` is `"backspace"` (default) or `"menu"`; selects a single node and deletes it (the menu path targets `icon-MoreHorizontal` → `icon-Delete`, since neither has its own testid). Optional `node` locator param.
- **Refactor** — the Backspace and options-menu tests now call the helper (DRY). The marquee multi-select test keeps its bespoke selection flow (a distinct selection mechanism, not a single-node delete).
- **No behavior change** — the three `@stable` tests assert exactly the same outcomes (`.react-flow__node` count 1 → 0).
- **Convention** — the three `test()` titles are standardized onto the same line as `test(` (repo convention; CI is eslint + tsc, not Prettier, so it isn't reformatted).
- **QA-CHECKLIST** — PART I "Delete a component" → `[x]` pointing to the helper.

## Validation (nightly `1.11.0.dev29`, `--retries=0`)

- typecheck ✅ · eslint ✅ (0 errors)
- `componentDelete.spec.ts`: **6/6** (`--repeat-each=2`), no flake ✅ — the `@stable` tests are unaffected by the refactor
- zero `🚨 Backend Error` ✅

## Notes

- `componentDelete.spec.ts` has no mirrored spec doc under `docs/` (pre-existing debt, not introduced here) — can be added retroactively in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)