### PR TITLE
chore(export-import-flow): remove @stable from empty-export flake (refs #518)

### DIFF
--- a/tests/tests-automations/regression/flow-functionality/export-import-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/export-import-flow.spec.ts
@@ -63,9 +63,11 @@ test.describe("Export and Import Flow (IDs 173 + 120)", () => {
     }
   });
 
+  // @stable temporarily removed — flake regressed into a suspected real bug
+  // (export reads an empty flow, `nodes: []`); tracked in #518. Restore once fixed.
   test(
     "export flow to JSON triggers success toast and produces a valid file",
-    { tag: ["@stable", "@release", "@workspace", "@api", "@regression"] },
+    { tag: ["@release", "@workspace", "@api", "@regression"] },
     async ({ page }) => {
       await awaitBootstrapTest(page);
 


### PR DESCRIPTION
## What

Removes `@stable` from the `export-import-flow.spec.ts` "export flow to JSON" test (line 66) as a **temporary mitigation** — nothing else.

## Why

The test regressed into a suspected real bug: the exported JSON comes back with `data.nodes: []` (empty flow), failing `expect(parsed.data.nodes.length).toBeGreaterThan(0)`. It has been flaky on consecutive daily-stable runs (2026-07-02, 2026-07-03), and this exact symptom was already "fixed" and closed under #384 — so the current `waitForFlowSaveSettled` guard does not fully close the autosave→export race.

Keeping `@stable` means the test keeps producing false-green in the daily-stable workflow. Removing it stops that until the root cause is fixed.

## Scope

This PR **only** removes the tag (plus an explanatory comment). It does **not** fix the bug and does **not** close any issue. The root-cause fix and the restoration of `@stable` are tracked in #518.

## Diff

```diff
+  // @stable temporarily removed — flake regressed into a suspected real bug
+  // (export reads an empty flow, `nodes: []`); tracked in #518. Restore once fixed.
   test(
     "export flow to JSON triggers success toast and produces a valid file",
-    { tag: ["@stable", "@release", "@workspace", "@api", "@regression"] },
+    { tag: ["@release", "@workspace", "@api", "@regression"] },
```

Refs #518
