### PR TITLE
test(flow-functionality): rewrite canvas stop-building spec + add teardown

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -61,7 +61,7 @@
 - [ ] Configure a Custom Component
 - [x] Delete a component → `helpers/flows/delete-component.ts`
 - [x] Run a flow → `helpers/flows/run-flow.ts`
-- [ ] Pause a flow
+- [-] Pause a flow → `flow-functionality/stop-building.spec.ts`
 - [x] Send a chat input → `flow-functionality/flow-execution-canvas.spec.ts`
 - [x] Verify the chat output → `flow-functionality/flow-execution-canvas.spec.ts`
 

--- a/docs/flow-functionality/stop-building.md
+++ b/docs/flow-functionality/stop-building.md
@@ -1,0 +1,113 @@
+# Spec: Stop (pause) a running flow build from the canvas
+
+**Test file:** `tests/tests-automations/regression/flow-functionality/stop-building.spec.ts`
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates
+
+Confirms a user can **cancel an in-progress flow build from the canvas** — the
+"pause a flow" capability. While a build is running, the run control on the
+terminal node is replaced by a stop control (`stop_building_button`); clicking it
+must abort the build and surface a **"build stopped"** confirmation.
+
+This is the canvas counterpart to `stop-button-playground.spec.ts` (which stops
+from inside the Playground via `button-stop`). Both exercise the same backend
+cancel path; this one asserts the cancel affordance exposed on the graph itself.
+
+The guarantee matters because long-running or stuck builds must be interruptible
+without reloading — losing the canvas stop button would strand the user on a
+spinning build.
+
+---
+
+## Tags
+
+`@release` `@workspace` `@components`
+
+`@stable` is added only after team validation (see CONTRIBUTING.md). This spec
+replaces the previous fragile version (5 dragged legacy components + manual
+connections + text/timeout waits, flagged `// TODO: fix this test`) with the
+proven custom-component + `sleep(60)` recipe from `stop-button-playground.spec.ts`.
+
+---
+
+## Step by step
+
+1. Bootstrap and open a blank flow.
+2. Add a **Custom Component** via `sidebar-custom-component-button`.
+3. Add a **Chat Output** via the sidebar search + drag.
+4. Open the custom component code editor and replace the body with a minimal,
+   valid Component whose `build_output` calls `sleep(60)` — long enough that the
+   build is reliably still running when we click stop. Check & Save.
+5. Connect the custom component output handle to the Chat Output input handle.
+6. Run the flow from the terminal node (`button_run_chat output`).
+7. Assert the canvas stop control `stop_building_button` becomes visible (build
+   is running).
+8. Click it.
+9. Assert the **"build stopped"** confirmation is visible.
+
+---
+
+## Validation criterion
+
+| Step | Criterion |
+|---|---|
+| After connecting | exactly 1 `.react-flow__edge` exists |
+| After run | `stop_building_button` is visible within 30 s (build running) |
+| After stop | text **"build stopped"** is visible within 30 s |
+
+---
+
+## External dependencies
+
+- `sidebar-custom-component-button` — sidebar control that drops a Custom
+  Component; renaming breaks step 2.
+- `code-button-modal` / `.ace_content` / Check & Save — code editor round-trip,
+  shared with `customComponentAdd.spec.ts` and the playground stop spec.
+- `button_run_{terminalNode}` — per-node run control (Langflow 1.11 has no global
+  run button); `stop_building_button` is the stop control that replaces it while
+  running.
+- `src/backend/base/langflow/api/v1/chat.py` (build/cancel endpoints) — owns the
+  cancel path that emits "build stopped". A change there breaks step 9.
+
+---
+
+## What this test does not cover
+
+- Stopping from inside the Playground — covered by `stop-button-playground.spec.ts`.
+- Resuming a stopped build (Langflow has no resume; stop is terminal).
+- Partial-result inspection after a stop.
+- The stale `FlowEditorPage.stopFlow()` POM method (uses the non-existent
+  `stop-building-button` hyphen testid and `button_run_flow`) — this spec targets
+  the real `stop_building_button` directly. A one-line click does not warrant a
+  helper (unlike `run-flow.ts`/`delete-component.ts`, which encapsulate real
+  branching); extract one only if a second canvas-stop caller appears.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- No model provider credentials required (the sleep is pure Python).
+
+---
+
+## Notes
+
+- **Teardown:** the test captures the created flow's id from the `/flow/{id}` URL
+  and an `afterEach` deletes only that flow via the API (auto_login token). It is a
+  targeted delete (not `cleanAllFlows`), so it is safe under parallel runs and does
+  not leak flows across repeated runs. The one-time `Basic Prompting` flow created
+  by the shared `awaitBootstrapTest` on a *freshly empty* instance is not owned by
+  this spec and is left in place.
+- The custom component's `sleep(60)` guarantees the build is still in flight when
+  we assert/click stop — no race on a fast-completing build.
+- Anchoring the stop affordance on `stop_building_button` (underscore) matches the
+  live nightly and `chatInputOutputUser-shard-2.spec.ts`; the hyphenated POM
+  variant is stale.
+- Supersedes the stale-handle break tracked in issue #298 (connections wired to a
+  removed `ParseData` component after `Data to Message` superseded it). The rewrite
+  drops that component chain entirely, so the stale-handle failure mode is gone.

--- a/tests/tests-automations/regression/flow-functionality/stop-building.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/stop-building.spec.ts
@@ -1,128 +1,87 @@
 import { expect, test } from "../../../fixtures/fixtures";
-import { addLegacyComponents } from "../../../helpers/flows/add-legacy-components";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 
-import { clearApiKeyBadges } from "../../../helpers/ui/clear-api-key-badges";
-import { updateOldComponents } from "../../../helpers/flows/update-old-components";
-import { zoomOut } from "../../../helpers/ui/zoom-out";
+// Flow created by the test (blank-flow → /flow/{id}); captured so afterEach can
+// delete only this one via the API. Targeted (not cleanAllFlows) so the teardown
+// is safe under parallel runs, and idempotent if capture never happened.
+let createdFlowId: string | undefined;
 
-// TODO: fix this test
-test(
-  "user must be able to stop a building",
-  { tag: ["@release", "@workspace", "@api"] },
+test.afterEach(async ({ page }) => {
+  if (!createdFlowId) return;
+  const login = await page.request.get("/api/v1/auto_login");
+  const headers: Record<string, string> = {};
+  if (login.ok()) {
+    const body = await login.json();
+    if (body?.access_token) headers.Authorization = `Bearer ${body.access_token}`;
+  }
+  await page.request.delete(`/api/v1/flows/${createdFlowId}`, { headers });
+  createdFlowId = undefined;
+});
+
+test("user must be able to stop a building from the canvas",
+  { tag: ["@release", "@workspace", "@components"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
-    await page.getByTestId("blank-flow").click();
 
-    await addLegacyComponents(page);
+    await test.step("open blank flow and add custom component to canvas", async () => {
+      await expect(page.getByTestId("blank-flow")).toBeVisible({
+        timeout: 10000,
+      });
+      await page.getByTestId("blank-flow").click();
 
-    //first component
-
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("text input");
-
-    await page
-      .getByTestId("input_outputText Input")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-        targetPosition: { x: 50, y: 50 },
+      // Readiness gate: the canvas controls confirm the editor has mounted
+      // before we reach for the sidebar. Anchoring on this (instead of a tight
+      // waitForSelector) lets the button click auto-wait for visibility and
+      // avoids the "sidebar-custom-component-button hidden" flake.
+      await expect(page.getByTestId("canvas_controls_dropdown")).toBeVisible({
+        timeout: 10000,
       });
 
-    await zoomOut(page, 3);
-    //second component
+      // Canvas mounted at /flow/{id} — wait for the URL to settle before
+      // reading it, so teardown reliably captures the id (a bare page.url()
+      // here can race the navigation and miss it, leaking the flow).
+      await page.waitForURL(/\/flow\/[^/?#]+/, { timeout: 10000 });
+      createdFlowId = page.url().split("/flow/")[1]?.split(/[/?#]/)[0];
 
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("url");
+      await page.getByTestId("sidebar-custom-component-button").click();
+      await adjustScreenView(page);
+    });
 
-    await page
-      .getByTestId("data_sourceURL")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-        targetPosition: { x: 50, y: 300 },
+    await test.step("add chat output component via sidebar", async () => {
+      await page.getByTestId("sidebar-search-input").fill("chat output");
+
+      await expect(page.getByTestId("input_outputChat Output")).toBeVisible({
+        timeout: 10000,
       });
 
-    //third component
+      await page
+        .getByTestId("input_outputChat Output")
+        .dragTo(page.locator('//*[@id="react-flow-id"]'), {
+          targetPosition: { x: 400, y: 400 },
+        });
 
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("split text");
+      await adjustScreenView(page);
+    });
 
-    await page
-      .getByTestId("processingSplit Text")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-        targetPosition: { x: 300, y: 500 },
-      });
+    await test.step("inject 60-second sleep into custom component code", async () => {
+      await page.getByTestId("div-generic-node").nth(1).click();
 
-    //fourth component
+      await page.getByTestId("more-options-modal").click();
 
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("data to message");
+      await page.getByTestId("expand-button-modal").click();
 
-    await page
-      .getByTestId("processingData to Message")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-        targetPosition: { x: 100, y: 500 },
-      });
+      await page.getByTestId("div-generic-node").nth(0).click();
 
-    //fifth component
+      await page.getByTestId("code-button-modal").nth(0).click();
 
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("chat output");
-
-    await page
-      .getByTestId("input_outputChat Output")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-        targetPosition: { x: 600, y: 300 },
-      });
-
-    await updateOldComponents(page);
-    await clearApiKeyBadges(page);
-
-    await adjustScreenView(page, { numberOfZoomOut: 3 });
-
-    //connection 1
-    await page
-      .getByTestId("handle-urlcomponent-shownode-extracted pages-right")
-      .click();
-    await page.getByTestId("handle-splittext-shownode-input-left").click();
-
-    //connection 2
-    await page
-      .getByTestId("handle-textinput-shownode-output text-right")
-      .click();
-    await page.getByTestId("handle-splittext-shownode-separator-left").click();
-
-    //connection 3
-    await page.getByTestId("handle-splittext-shownode-chunks-right").click();
-    await page.getByTestId("handle-parsedata-shownode-data-left").click();
-
-    //connection 4
-    await page.getByTestId("handle-parsedata-shownode-message-right").click();
-    await page
-      .getByTestId("handle-chatoutput-noshownode-inputs-target")
-      .click();
-
-    await adjustScreenView(page);
-
-    await page.getByText("Text Input", { exact: true }).click();
-
-    await page.getByTestId("textarea_str_input_value").first().fill(",");
-
-    await page.getByText("URL", { exact: true }).click();
-
-    await page
-      .getByTestId("inputlist_str_urls_0")
-      .fill("https://www.nature.com/articles/d41586-023-02870-5");
-
-    await page.getByText("Split Text", { exact: true }).click();
-
-    await page.getByTestId("int_int_chunk_size").fill("2");
-    await page.getByTestId("int_int_chunk_overlap").fill("1");
-
-    const timerCode = `
+      const waitTimeoutCode = `
 # from langflow.field_typing import Data
 from langflow.custom import Component
 from langflow.io import MessageTextInput, Output
 from langflow.schema import Data
-import time
+from time import sleep
+from langflow.schema.message import Message
 
 class CustomComponent(Component):
     display_name = "Custom Component"
@@ -132,55 +91,61 @@ class CustomComponent(Component):
     name = "CustomComponent"
 
     inputs = [
-        MessageTextInput(name="input_value", display_name="Input Value", value="Hello, World!", tool_mode=True),
+        MessageTextInput(name="input_value", display_name="Input Value", value="Hello, World!"),
     ]
 
     outputs = [
         Output(display_name="Output", name="output", method="build_output"),
     ]
 
-    def build_output(self) -> Data:
-        time.sleep(10000)
+    def build_output(self) -> Message:
         data = Data(value=self.input_value)
         self.status = data
-        return data
-  `;
+        sleep(60)
+        return data`;
 
-    await page.getByTestId("sidebar-custom-component-button").click();
-    await adjustScreenView(page, { numberOfZoomOut: 2 });
+      await page.locator(".ace_content").click();
+      await page.keyboard.press(`ControlOrMeta+A`);
+      await page.locator("textarea").fill(waitTimeoutCode);
 
-    await page.getByTestId("title-Custom Component").first().click();
-
-    await expect(page.getByTestId("code-button-modal").last()).toBeVisible({
-      timeout: 3000,
+      await page.getByText("Check & Save").last().click();
+      await adjustScreenView(page, { numberOfZoomOut: 2 });
     });
 
-    await page.getByTestId("code-button-modal").last().click();
-
-    await page.waitForSelector('[id="checkAndSaveBtn"]', {
-      timeout: 3000,
+    await test.step("connect custom component output to chat output input", async () => {
+      await page
+        .getByTestId("handle-customcomponent-shownode-output-right")
+        .first()
+        .click();
+      await page
+        .getByTestId("handle-chatoutput-shownode-inputs-left")
+        .first()
+        .click();
+      await expect(page.locator(".react-flow__edge")).toHaveCount(1, {
+        timeout: 8000,
+      });
     });
 
-    await page.locator("textarea").last().press(`ControlOrMeta+a`);
-    await page.keyboard.press("Backspace");
-    await page.locator("textarea").last().fill(timerCode);
-    await page.locator('//*[@id="checkAndSaveBtn"]').click();
-    await page.waitForTimeout(500);
+    await test.step("run the flow from the canvas terminal node", async () => {
+      await expect(page.getByTestId("button_run_chat output")).toBeVisible({
+        timeout: 10000,
+      });
 
-    await page.getByTestId("button_run_custom component").click();
-
-    await page.waitForSelector("text=running", {
-      timeout: 100000,
+      await page.getByTestId("button_run_chat output").click();
     });
 
-    await page.waitForSelector('[data-testid="stop_building_button"]', {
-      timeout: 100000,
+    await test.step("stop the build from the canvas", async () => {
+      await expect(page.getByTestId("stop_building_button").last()).toBeVisible({
+        timeout: 30000,
+      });
+
+      await page.getByTestId("stop_building_button").last().click();
     });
 
-    await page.getByTestId("stop_building_button").last().click();
-
-    await page.waitForSelector("text=build stopped", {
-      timeout: 100000,
+    await test.step("assert build stopped confirmation", async () => {
+      await expect(page.getByText("build stopped")).toBeVisible({
+        timeout: 30000,
+      });
     });
   },
 );


### PR DESCRIPTION
## What & why

`stop-building.spec.ts` was flagged `// TODO: fix this test`, was **not `@stable`**, and **failed on main**: it dragged five legacy components and wired `handle-parsedata-*` handles for a `ParseData` component that no longer exists (superseded by `Data to Message`), timing out on connection 3. This is the stale-handle break diagnosed in **#298** — which was closed without the fix landing, leaving the "stop a build from the canvas" behavior silently uncovered.

This rewrite uses the proven custom-component + `sleep(60)` recipe from the `@stable` `stop-button-playground.spec.ts`, but stops from the **canvas** (`stop_building_button`) instead of the Playground, asserting the **"build stopped"** confirmation. It drops the entire fragile legacy-component chain.

## Changes

- **Determinism:** readiness gate on `canvas_controls_dropdown` + auto-waiting clicks (removes the "sidebar-custom-component-button hidden" flake); `waitForSelector`/`waitForTimeout` → `expect().toBeVisible` (0 lint warnings).
- **Teardown:** capture the created flow id from the `/flow/{id}` URL and delete only that flow via the API in `afterEach` (targeted, parallel-safe). The old spec leaked a flow per run.
- Same-line `test(` title per repo convention.
- Spec doc added: `docs/flow-functionality/stop-building.md`.
- QA-CHECKLIST: **Pause a flow** now points to this spec.

## Tags

`@release @workspace @components` — no `@stable` yet (awaits team validation).

## Validation

- Deterministic across headless and headed-with-retries runs.
- Force-fail probe on the final assertion → confirms no false positive.
- Zero backend errors (`🚨`).
- No flow accumulation across repeated runs (verified before/after via API).
- Langflow nightly `1.11.0.dev30`.

Supersedes the stale-handle break tracked in #298.

🤖 Generated with [Claude Code](https://claude.com/claude-code)