### PR TITLE
test(llm-agents): agent instructions respected in the model response

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -358,7 +358,7 @@
 - [ ] Inspect tools used by Agent in Playground
 - [ ] Agent returns output in structured JSON format (output_schema) → `agent-structured-output.spec.ts`
 - [ ] Agent returns output in correctly rendered Markdown
-- [ ] Agent Instructions (system prompt) is respected in the model response → `agent-system-prompt.spec.ts`
+- [x] Agent Instructions (system prompt) is respected in the model response → `agent-system-prompt.spec.ts`
 - [ ] Input via direct field vs handle (ChatInput) — both work → `agent-input-sources.spec.ts`
 - [ ] Empty response or model refusal — component does not crash → `agent-empty-refusal-response.spec.ts`
 - [ ] Toggle add_current_date_tool works (enables/disables date tool) → `agent-current-date-tool.spec.ts`
@@ -756,7 +756,7 @@
 | `core-components/` — Core Components | 82 | 79 | 0 | 1 | 2 |
 | `core-functionality/auth/` | 21 | 8 | 12 | 0 | 1 |
 | `core-functionality/knowledge-ingestion/` | 8 | 0 | 4 | 0 | 4 |
-| `core-functionality/llm-agents/` | 40 | 14 | 2 | 0 | 24 |
+| `core-functionality/llm-agents/` | 40 | 15 | 2 | 0 | 23 |
 | `core-functionality/model-provider/` | 33 | 6 | 18 | 0 | 9 |
 | `core-functionality/observability-monitoring/` | 23 | 15 | 7 | 0 | 1 |
 | `core-functionality/playground/` | 48 | 43 | 3 | 1 | 1 |
@@ -767,7 +767,7 @@
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 44 | 7 | 36 | 1 | 0 |
 | `ui-ux/` — Settings | 7 | 3 | 3 | 1 | 0 |
-| **TOTAL** | **451** | **224 (50%)** | **171 (38%)** | **7 (2%)** | **49 (11%)** |
+| **TOTAL** | **451** | **225 (50%)** | **171 (38%)** | **7 (2%)** | **48 (11%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -783,7 +783,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 233 `test()` calls carrying the `@stable` tag, distributed across 81 spec
+> 235 `test()` calls carrying the `@stable` tag, distributed across 82 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -931,6 +931,8 @@
 #### core-functionality/llm-agents/
 - [x] agent interaction suite → `agent-component-regression.spec.ts`
 - [x] selecting 'Connect other models' clears the previously selected model → `agent-model-connection-isolation.spec.ts`
+- [x] Agent Instructions are respected in the model response → `agent-system-prompt.spec.ts`
+- [x] negative control — sentinel is absent without the instruction → `agent-system-prompt.spec.ts`
 - [x] user must be able to send images in the playground with the agent component → `general-bugs-agent-images-playground.spec.ts`
 - [x] playground shows error when LLM run endpoint returns 500 (mocked invalid API key) → `llm-invalid-api-key-ui.spec.ts`
 - [x] playground input remains usable after API error (mocked) → `llm-invalid-api-key-ui.spec.ts`
@@ -1054,7 +1056,7 @@
 | `core-components/` — Component Config | 18 | 1 |
 | `core-components/` — Core Components | 0 | 2 |
 | `core-functionality/auth/` | 12 | 1 |
-| `core-functionality/llm-agents/` | 2 | 24 |
+| `core-functionality/llm-agents/` | 2 | 23 |
 | `core-functionality/model-provider/` | 18 | 9 |
 | `core-functionality/playground/` | 3 | 1 |
 | `mcp/client/` | 7 | 2 |

--- a/docs/core-functionality/llm-agents/agent-system-prompt.md
+++ b/docs/core-functionality/llm-agents/agent-system-prompt.md
@@ -1,0 +1,145 @@
+# Spec: Agent Instructions (system prompt) respected in the model response
+
+**Test file:** `tests/tests-automations/regression/core-functionality/llm-agents/agent-system-prompt.spec.ts`
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates
+
+Confirms that the **Agent Instructions** field (the agent's system prompt,
+`textarea_str_system_prompt`) actually reaches the model and shapes its output:
+a constraint written into the instructions is honoured in the agent's Playground
+response, regardless of what the user asks.
+
+The test sets a deterministic, model-agnostic instruction — the agent must
+include a **per-run sentinel code word** (`PINEAPPLE-<uniq>`) verbatim in every
+reply — then sends an unrelated user question and asserts the sentinel appears in
+the response. The sentinel is something the model would never emit on its own for
+that question, so its presence proves the system prompt was applied end to end
+(UI field → flow → backend → model call), not merely saved. The sentinel is
+generated fresh each run, so a pass can only be caused by *this* run's
+instruction reaching the model — never a cached, hardcoded or leaked value.
+
+A second **negative-control** test guards against a false positive: with a
+neutral instruction (no sentinel), it asserts the model does **not** emit the
+sentinel stem for the same question — proving the code word is not something the
+model produces spontaneously, so a match in the positive test is caused by the
+instruction, not coincidence.
+
+This is the §6.5 "Output and Reasoning" deliverable: instructions are a core
+agent contract; a regression that dropped the system prompt would silently
+un-steer every agent flow while still returning plausible text.
+
+---
+
+## Tags
+
+`@stable` `@release` `@agents` `@playground` — on both tests (positive +
+negative control). Validated against collected provider data (see the area
+`CLAUDE.md`).
+
+---
+
+## Step by step
+
+Both tests share the target resolution and helpers (`setAgentInstructions`,
+`askAndGetReply`); the file is serial (see Model strategy).
+
+Target resolution (both): resolve targets from `models.json` (one model per
+active provider by default; `MODEL_TEST_ID` / `MODEL_TEST_PROVIDER` / `ALL_MODELS`
+override). Skip a target if its provider is inactive or its env key is missing.
+
+**Test 1 — instructions respected (positive):**
+1. Load the **Simple Agent** template via `SimpleAgentTemplatePage.load(options)`
+   (clears flows, loads template, configures provider/model). Skip on
+   `MODEL_NOT_AVAILABLE`.
+2. Generate a per-run sentinel `PINEAPPLE-<uniq>`. Set the Agent Instructions:
+   fill `textarea_str_system_prompt` with an instruction forcing the sentinel into
+   every reply, blur, wait for the autosave `PATCH /api/v1/flows/` to succeed.
+3. Open the Playground (`playground-btn-flow-io`), send an unrelated message
+   ("What is the capital of France?"), wait for the run to finish (Stop button
+   appears then hides).
+4. Assert the latest `div-chat-message` contains the sentinel (case-insensitive).
+
+**Test 2 — negative control:**
+1. Load the template.
+2. Set a neutral instruction ("You are a helpful assistant.") + autosave.
+3. Send the same unrelated message, wait for finish.
+4. Assert the latest `div-chat-message` does **not** contain the sentinel stem
+   (`PINEAPPLE`).
+
+---
+
+## Validation criterion
+
+| Test | Criterion |
+|---|---|
+| Positive | after the run, latest `div-chat-message` **contains** the per-run sentinel |
+| Negative control | after the run with a neutral prompt, latest `div-chat-message` does **not** contain the sentinel stem |
+
+A positive that omits the sentinel means the system prompt did not reach the
+model (fail). A negative control that emits the stem means the sentinel is not a
+reliable signal (fail — invalidates the positive assertion).
+
+---
+
+## Model strategy
+
+- Parameterized per provider/model from `models.json` (inline `getTestTargets`,
+  mirroring `agent-component-regression.spec.ts` in this folder — there is no
+  shared export yet).
+- Requires `collect-models.spec.ts` to have run and at least one provider API key
+  in `.env`. Without keys/data, every target skips with a reason (no false pass).
+- Run with `--workers=1` (agent specs create named flows that collide in parallel).
+- File-level `test.describe.configure({ mode: "serial" })` — `load()` deletes all
+  flows before loading the template, so parallel provider blocks would wipe each
+  other.
+
+---
+
+## External dependencies
+
+- **A live provider API key** (e.g. `OPENAI_API_KEY`) in `.env` and collected
+  `providers.json` / `models.json`. This is a real model call — no mock.
+- `textarea_str_system_prompt` — Agent Instructions field on the Agent node.
+- `SimpleAgentTemplatePage` / `providerSetupMap` — template load + provider config.
+- Playground testids: `playground-btn-flow-io`, `input-chat-playground`,
+  `button-send`, `div-chat-message`; Stop button (`role=button name=Stop`).
+
+---
+
+## What this test does not cover
+
+- Instruction *persistence across reload* — covered by
+  `core-components/agent-component-regression.spec.ts` ("system prompt accepts
+  input and persists across flow reload").
+- Tool calling / reasoning steps — covered by the agent interaction suite.
+- Multi-turn instruction adherence (only a single user turn is asserted).
+- Exact response wording beyond the sentinel (models phrase freely; only the
+  enforced constraint is checked, to stay deterministic across models).
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` (nightly).
+- `collect-models.spec.ts` run; at least one active provider with a valid key.
+
+---
+
+## Notes
+
+- **Why a sentinel code word?** It is the strongest model-agnostic signal that
+  the instruction was applied: even small models comply with "always include this
+  word", and the assertion is a deterministic `contains`, not a fuzzy semantic
+  match. Asserting a persona/language/format would be flakier across models.
+- **Per-run sentinel + negative control** are the two false-positive guards:
+  randomising the sentinel each run rules out a cached/leaked match, and the
+  negative-control test rules out the model emitting the stem spontaneously.
+- `SimpleAgentTemplatePage.load()` deletes all flows before loading the template.
+  Under rapid repeated runs the bulk-delete endpoint can 500 intermittently
+  ("An internal error occurred while deleting flows") — a shared backend-under-load
+  artifact caught by the fixture, not this spec's logic; single runs are clean and
+  the config retries absorb it.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-system-prompt.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-system-prompt.spec.ts
@@ -1,0 +1,250 @@
+import * as dotenv from "dotenv";
+import path from "path";
+import fs from "fs";
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
+import {
+  hasProviderEnvKeys,
+  missingProviderEnvKeys,
+  providerConfigMap,
+  type Provider,
+} from "../../../../helpers/provider-setup";
+import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
+}
+
+// Distinctive stem for the sentinel code word. A model would never emit it on
+// its own for an unrelated question (the negative-control test asserts exactly
+// that), so its presence proves the Agent Instructions reached the model
+// (UI → flow → backend → call).
+const SENTINEL_BASE = "PINEAPPLE";
+
+// The user message is unrelated to the sentinel — the model has no reason to
+// produce the code word unless the system prompt instructed it.
+const USER_MESSAGE = "What is the capital of France?";
+
+interface ModelRecord {
+  provider: string;
+  model: string;
+}
+
+interface TestTarget {
+  label: string;
+  options: LoadSimpleAgentOptions;
+  skipReason?: string;
+}
+
+function getProviderSkipReasons(): Map<string, string> {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/providers.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
+    return new Map();
+  }
+  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
+  const reasons = new Map<string, string>();
+  for (const r of records) {
+    if (r.status === "inactive") {
+      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
+    }
+  }
+  return reasons;
+}
+
+function getModelsFromJson(): ModelRecord[] {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/models.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("models.json not found — run collect-models.spec.ts first.");
+    return [];
+  }
+  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
+}
+
+function getTestTargets(): TestTarget[] {
+  const skipReasons = getProviderSkipReasons();
+
+  if (process.env.MODEL_TEST_ID) {
+    const model = process.env.MODEL_TEST_ID;
+    const allModels = getModelsFromJson();
+    const record = allModels.find((m) => m.model === model);
+
+    if (!record) {
+      console.warn(
+        `MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred. ` +
+        `Run collect-models.spec.ts first, or set MODEL_TEST_PROVIDER.`,
+      );
+      return [{ label: `model:${model}`, options: { model } }];
+    }
+
+    const provider = record.provider as Provider;
+    return [{
+      label: `${provider} / ${model}`,
+      options: { provider, model },
+      skipReason: skipReasons.get(provider),
+    }];
+  }
+
+  const allModels = getModelsFromJson();
+
+  if (allModels.length === 0) {
+    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
+    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
+    return [{
+      label: `provider:${fallbackProvider} (fallback)`,
+      options: { provider: fallbackProvider },
+      skipReason: skipReasons.get(fallbackProvider),
+    }];
+  }
+
+  let models = allModels;
+
+  if (process.env.MODEL_TEST_PROVIDER) {
+    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
+  } else if (process.env.ALL_MODELS !== "true") {
+    const seen = new Set<string>();
+    models = models.filter((m) => {
+      if (seen.has(m.provider)) return false;
+      seen.add(m.provider);
+      return true;
+    });
+  }
+
+  return models.map((m) => ({
+    label: `${m.provider} / ${m.model}`,
+    options: { provider: m.provider as Provider, model: m.model },
+    skipReason: skipReasons.get(m.provider),
+  }));
+}
+
+async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
+  try {
+    await new SimpleAgentTemplatePage(page).load(options);
+  } catch (e: any) {
+    if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
+    throw e;
+  }
+}
+
+async function waitForAgentToFinish(page: Page): Promise<void> {
+  const stopButton = page.getByRole("button", { name: "Stop" });
+  const stopVisible = await stopButton.isVisible({ timeout: 10000 }).catch(() => false);
+  if (stopVisible) {
+    await expect(stopButton).toBeHidden({ timeout: 120000 });
+  }
+}
+
+// Fill the Agent Instructions (system prompt) and wait for the autosave PATCH so
+// the build runs the prompt we set, not the template default.
+async function setAgentInstructions(page: Page, prompt: string): Promise<void> {
+  const promptField = page.getByTestId("textarea_str_system_prompt");
+  await expect(promptField).toBeVisible({ timeout: 15000 });
+
+  const patchPromise = page.waitForResponse(
+    (resp) =>
+      resp.url().includes("/api/v1/flows/") &&
+      resp.request().method() === "PATCH" &&
+      resp.ok(),
+    { timeout: 15000 },
+  );
+
+  await promptField.click();
+  await promptField.fill(prompt);
+  await promptField.blur();
+  await patchPromise;
+}
+
+// Open the Playground, send a message, wait for the run to finish, return the
+// latest chat message text.
+async function askAndGetReply(page: Page, message: string): Promise<string> {
+  await page.getByTestId("playground-btn-flow-io").click();
+  await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+    timeout: 30000,
+  });
+
+  await page.getByTestId("input-chat-playground").last().fill(message);
+  await page.getByTestId("button-send").last().click();
+
+  await waitForAgentToFinish(page);
+
+  const chatMessage = page.getByTestId("div-chat-message").last();
+  await expect(chatMessage).toBeVisible({ timeout: 30000 });
+  return chatMessage.innerText();
+}
+
+const targets = getTestTargets();
+
+// SimpleAgentTemplatePage.load() deletes all flows before loading the template.
+// File-level serial mode prevents parallel provider blocks from wiping each
+// other's flows.
+test.describe.configure({ mode: "serial" });
+
+for (const { label, options, skipReason } of targets) {
+  const provider = options.provider ?? (Object.keys(providerConfigMap)[0] as Provider);
+
+  test.describe(`Agent System Prompt [${label}]`, () => {
+    test(
+      "Agent Instructions are respected in the model response",
+      { tag: ["@stable", "@release", "@agents", "@playground"] },
+      async ({ page }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        // Per-run sentinel: a passing assertion can only be caused by THIS run's
+        // instruction reaching the model — never a cached/hardcoded/leaked value.
+        const uniq = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const sentinel = `${SENTINEL_BASE}-${uniq}`;
+        const systemPrompt = `You are a test assistant. No matter what the user asks, you must always include the exact code word ${sentinel} verbatim somewhere in your reply.`;
+
+        await loadAgent(page, options);
+
+        await test.step("set the Agent Instructions and wait for autosave", async () => {
+          await setAgentInstructions(page, systemPrompt);
+        });
+
+        await test.step("run an unrelated message and assert the instruction is honoured", async () => {
+          const reply = await askAndGetReply(page, USER_MESSAGE);
+          expect(reply.toUpperCase()).toContain(sentinel.toUpperCase());
+        });
+      },
+    );
+
+    test(
+      "negative control — sentinel is absent without the instruction",
+      { tag: ["@stable", "@release", "@agents", "@playground"] },
+      async ({ page }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        await loadAgent(page, options);
+
+        // Guards the positive test against a false positive: with a neutral prompt
+        // (no sentinel instruction), the model must NOT emit the sentinel stem for
+        // the unrelated question — proving the code word is not something the model
+        // produces spontaneously, so a match in the positive test is caused by the
+        // instruction, not coincidence.
+        await test.step("set a neutral instruction and wait for autosave", async () => {
+          await setAgentInstructions(page, "You are a helpful assistant.");
+        });
+
+        await test.step("run the same message and assert the sentinel is absent", async () => {
+          const reply = await askAndGetReply(page, USER_MESSAGE);
+          expect(reply.toUpperCase()).not.toContain(SENTINEL_BASE);
+        });
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #492 · Wave 1 — Agents & providers

## What & why

New spec proving the **Agent Instructions** (system prompt, `textarea_str_system_prompt`) actually reach the model and shape its output. §6.5 "Output and Reasoning" had no coverage for this — a regression that dropped the system prompt would silently un-steer every agent flow while still returning plausible text.

## Strategy

A **per-run sentinel** code word (`PINEAPPLE-<uniq>`) is written into the Agent Instructions; an unrelated user message ("What is the capital of France?") is sent; the response must contain the sentinel. It is distinctive and randomised per run, so a pass can only be caused by *this* run's instruction reaching the model (UI → flow → backend → call) — never a cached/hardcoded/leaked value.

## Two tests (both `@stable`)

- **positive** — instruct the sentinel, assert the reply contains it.
- **negative control** — neutral prompt, assert the reply does **not** contain the sentinel stem. Proves the model does not emit the code word spontaneously, so the positive match is caused by the instruction, not coincidence.

These are the two false-positive guards (per-run randomisation + negative control), on top of the force-fail probe run during validation.

## Conventions

- `SimpleAgentTemplatePage.load()`, `getTestTargets` parameterization from `models.json` (skips inactive providers / missing keys), file-level serial mode, `--workers=1`.
- Shared local helpers `setAgentInstructions` / `askAndGetReply` keep the two tests DRY.
- Spec doc: `docs/core-functionality/llm-agents/agent-system-prompt.md`.
- QA-CHECKLIST §6.5 flipped to `[x]`; coverage summary regenerated.

## Validation

- typecheck + lint clean (only inherited `.skip()` / `e:any` warnings, matching the sibling spec).
- positive + negative pass deterministically with `--workers=1`.
- force-fail probe (neutral prompt) confirms no false positive.
- zero backend errors.
- Langflow nightly `1.11.0.dev30`, `openai/gpt-4o-mini`.

Depends on #480 (model-agnostic setup fallback — merged).

> Note: agent specs share `SimpleAgentTemplatePage.load()`, which cascade-deletes all flows on start. On the SQLite nightly this can intermittently `database is locked` under concurrent access — a shared backend-under-load artifact absorbed by the config retries, not this spec's logic. A retry-on-lock in the shared delete helper would harden the whole Wave 1 agent bucket (separate issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)