### PR TITLE
test(ui-ux): use global variable in component (api_key secret field)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -284,7 +284,7 @@
 
 #### 4.3 Global Variables (API Keys)
 - [x] Create global variable
-- [ ] Use global variable in component (API key)
+- [-] Use global variable in component (API key) → `ui-ux/use-global-variable-in-component.spec.ts`
 - [x] Edit existing global variable → `ui-ux/global-variable-edit.spec.ts`
 - [x] Delete global variable
 - [x] Create global variable of type "Generic"

--- a/QA-SCENARIOS-GUIDE.md
+++ b/QA-SCENARIOS-GUIDE.md
@@ -1234,6 +1234,37 @@
 
 ---
 
+### 16.6 Use (bind) a Credential global variable in a component secret field `[-]`
+
+**File:** `ui-ux/use-global-variable-in-component.spec.ts`
+
+**Objective:** Confirm the consumption side of global variables — a Credential-typed variable can be selected and bound to a component's secret field (OpenAI `api_key`, a `SecretStrInput`) via the field's Globe dropdown, and that the bound value shows the variable **name** while never exposing the secret value.
+
+**Step by step:**
+1. Add the OpenAI component to the canvas; open its `api_key` field.
+2. Open the field's global-variable dropdown (if the field is auto-bound to an existing Credential variable it renders a badge; the dropdown trigger is still reachable).
+3. Create a Credential variable with a distinctive sentinel value (Credential tab before save).
+4. Select the variable from the dropdown to bind it to the field.
+
+**Validation:** the field displays the variable **name** as its bound value; `getByText(sentinelValue)` has count 0 (the secret never renders as visible text).
+
+---
+
+### 16.7 Component secret-field global-variable binding persists across reload `[-]`
+
+**File:** `ui-ux/use-global-variable-in-component.spec.ts`
+
+**Objective:** Confirm that a global-variable binding on a component secret field survives a full page reload (rehydrated from the saved flow), and that auto-bind never overrides an explicit binding.
+
+**Step by step:**
+1. Add OpenAI, create and bind a Credential variable to `api_key` (as in 16.6).
+2. Wait for the flow to autosave, then reload the page.
+3. Reopen the OpenAI node.
+
+**Validation:** the `api_key` field still shows the same variable name as its bound value after reload.
+
+---
+
 ---
 
 ## 17. File Upload and Processing

--- a/docs/ui-ux/use-global-variable-in-component.md
+++ b/docs/ui-ux/use-global-variable-in-component.md
@@ -1,0 +1,156 @@
+# Use Global Variable in Component (API key)
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+Validates that a Credential-typed global variable can be **selected and bound** to a
+component's secret field (OpenAI `api_key`, a `SecretStrInput`) via the field's Globe
+dropdown, and that the binding **persists across a page reload**.
+
+This is the consumption side of global variables — distinct from the CRUD/secrecy
+coverage in `global-variables-crud.spec.ts`, whose spec doc explicitly lists "using a
+global variable inside a component" as out of scope. Closes QA-CHECKLIST.md §4.3
+"Use global variable in component (API key)".
+
+1. **Bind** — after creating a Credential variable, selecting it from the `api_key`
+   field's Globe dropdown puts the field into "global variable" mode: the variable
+   **name** is shown as the field's bound value, and the secret value entered at
+   creation is never rendered as visible text.
+2. **Persistence** — the binding survives a full page reload: reopening the OpenAI
+   node shows the `api_key` field still bound to the same variable name.
+
+If this breaks, users who store API keys as Credential global variables cannot wire
+them into components, or the wiring silently drops on reload — forcing plaintext keys
+typed directly into fields.
+
+---
+
+## Tags *(required)*
+
+`@release` `@workspace` `@regression`
+
+> `@stable` intentionally withheld until the full 7-step validation pipeline
+> (typecheck, lint, run `--retries=0`, force-fail, `--trace=on`, backend-error audit)
+> has been executed and the team has reviewed the spec.
+
+---
+
+## Step by step *(required)*
+
+**Shared setup (both tests):**
+1. Set viewport to 1920×1080 (the Globe dropdown/variable modal can overflow smaller screens)
+2. Bootstrap app, create blank flow
+3. Add the OpenAI component via sidebar hover + `add-component-button-openai`
+4. Open the OpenAI node so the `api_key` field (`anchor-popover-anchor-input-api_key`) is visible
+
+**Opening the api_key variable dropdown (state-aware helper):**
+The `api_key` field is a secret field (`SecretStrInput`). When a Credential variable
+whose `default_fields` include "OpenAI API Key" already exists, Langflow **auto-binds**
+it: the field renders a value badge (the variable name) and shows **no** Globe trigger.
+Clicking the field anchor switches it back to the editable input, which exposes the
+`icon-Globe` trigger. The helper therefore: if the field's Globe is not visible, click
+the anchor to reveal the editable input; then click the field's `icon-Globe` (scoped via
+the `popover-anchor-input-api_key` input so the non-secret "OpenAI API Base" field's Globe
+is never selected).
+
+**Test 1 — bind a Credential variable to the API key field**
+1. Run setup
+2. Open the `api_key` variable dropdown (helper above) → "Add New Variable"
+3. Create a Credential variable `gv-api-key-{timestamp}` with a distinctive secret
+   sentinel value `SECRET-SENTINEL-{timestamp}` (switch to the `credential-tab` before save)
+4. Back in the still-open dropdown, click `option-gv-api-key-{timestamp}` to **select/bind** it
+5. Assert the field is bound: the variable **name** is displayed as the field's value badge
+   (an `OptionBadge` rendered as `button "gv-api-key-{timestamp}"` inside the field)
+6. Assert the secret sentinel value never appears as visible text anywhere on the page
+   (`getByText(sentinel)` substring match → `toHaveCount(0)`)
+7. Cleanup: delete the variable via `DELETE /api/v1/variables/{id}` in a `finally` block
+
+**Test 2 — binding persists across reload**
+1. Run setup + create + bind the Credential variable (same as Test 1)
+2. Wait for autosave, then `page.reload()`
+3. Reopen the OpenAI node
+4. Assert the `api_key` field still shows the same variable name as its bound value
+   (rehydrated from the saved flow — auto-bind never overrides an explicit binding)
+5. Cleanup: delete the variable via `DELETE /api/v1/variables/{id}` in a `finally` block
+
+---
+
+## Validation criterion *(required)*
+
+- **Test 1:** after selection, the `api_key` field displays the variable name as its
+  bound global-variable value; the secret sentinel has visible-text count 0 on the page.
+- **Test 2:** after a full page reload and reopening the node, the `api_key` field is
+  still bound to the same variable name.
+
+---
+
+## External dependencies *(required)*
+
+- `src/frontend/src/components/core/parameterRenderComponent/components/inputGlobalComponent/`
+  — the input that renders global-variable options and performs selection/binding
+  (`handleVariableSelect` sets `value=<name>`, `load_from_db=true`)
+- `.../inputComponent/components/popover/index.tsx` — renders the option rows
+  (`option-<name>` when selectable, `disabled-option-<name>` for Credential vars in
+  non-secret fields) and the selected-value `OptionBadge`
+- `src/backend/base/langflow/api/v1/variable.py` — global variable CRUD endpoints
+  (`GET /api/v1/variables/` → `[{id, name, type, ...}]`, `DELETE /api/v1/variables/{id}`)
+
+Confirmed testids (verified against the live DOM):
+- `anchor-popover-anchor-input-api_key` — the api_key field wrapper (role=button); click
+  to switch an auto-bound field back to editable mode
+- `popover-anchor-input-api_key` — the editable secret input (only present in edit mode)
+- `icon-Globe` — opens the field's global-variable dropdown (scope via the field's input,
+  because the non-secret "OpenAI API Base" field also renders an `icon-Globe`)
+- `option-<name>` — a selectable variable row in the dropdown; clicking it binds the var
+- `credential-tab` — switches the variable-creation modal to Credential type
+- `remove-icon-badge` — unbinds the currently bound variable from the field
+
+---
+
+## What this test does not cover *(optional)*
+
+- **Gating:** Credential variables appear disabled (with an explanatory tooltip) in
+  non-secret fields — not exercised here.
+- **Auto-cleanup:** deleting a bound variable clears the field — not exercised here.
+- **Runtime resolution:** actually running the flow so the backend resolves the secret
+  value from the variable — out of scope (no real API key, component is never run).
+- CRUD and secrecy-in-list guarantees — covered by `global-variables-crud.spec.ts`.
+- Editing an existing variable's value — covered by `global-variable-edit.spec.ts`.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`
+- OpenAI component available in the sidebar
+- No API key required — the component is added and configured but never executed
+
+---
+
+## Notes *(optional)*
+
+- Selecting a global variable stores the variable **name** in the field (not the secret
+  value) plus `load_from_db: true`; the real secret is resolved backend-side only at run
+  time. The assertions therefore check for the variable **name** as the bound value and
+  confirm the secret sentinel never surfaces as visible text.
+- Credential variables are only selectable in secret fields (`SecretStrInput` /
+  `MultilineSecretInput`). The OpenAI `api_key` field qualifies, which is why it is the
+  chosen target.
+- **Auto-bind:** a Credential variable whose `default_fields` include "OpenAI API Key"
+  auto-binds to the field on node add (the field starts in badge mode with no Globe). The
+  state-aware dropdown helper handles both the auto-bound and the empty (clean CI) states.
+  This is also why the test binds to its **own** uniquely-named variable and asserts that
+  exact name — it never depends on which variable (if any) the instance auto-bound first.
+- `try/finally` cleanup deletes the created variable via the REST API (looked up by name),
+  so it runs even when assertions fail mid-test, preventing cross-run pollution. Uses the
+  `request` fixture with a Bearer token from `getAuthToken`.
+- **Indirect mechanism justified:** in the auto-bound state the field's dropdown-trigger
+  button (the next sibling of the badge wrapper) has its icon fail to render — an upstream
+  Langflow gap — leaving it a zero-width/zero-height but fully attached, click-functional
+  element. `toBeVisible()`/coordinate-based `click()` can't target a zero-box element, so
+  the helper asserts `toBeAttached()` and fires `dispatchEvent("click")` (Playwright's
+  documented geometry-independent click). The clean/empty-field path (no pre-existing
+  variable, as on fresh CI) uses the normal visible `icon-Globe` + `.click()`.

--- a/tests/tests-automations/regression/ui-ux/use-global-variable-in-component.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/use-global-variable-in-component.spec.ts
@@ -1,0 +1,199 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+
+// Consumption side of global variables: binding a Credential-typed variable to a
+// component's secret field (OpenAI `api_key`, a SecretStrInput) via the field's
+// Globe dropdown, and confirming the binding persists across a full page reload.
+// CRUD/secrecy-in-list guarantees live in `global-variables-crud.spec.ts`; this
+// spec is strictly about wiring a variable into a component and its persistence.
+
+const API_KEY_ANCHOR = "anchor-popover-anchor-input-api_key";
+const API_KEY_INPUT = "popover-anchor-input-api_key";
+
+/**
+ * Blank flow + OpenAI component on the canvas with its `api_key` field visible.
+ */
+async function addOpenAiComponent(page: Page): Promise<void> {
+  await page.setViewportSize({ width: 1920, height: 1080 });
+  await awaitBootstrapTest(page);
+  await page.waitForSelector('[data-testid="blank-flow"]', { timeout: 30000 });
+  await page.getByTestId("blank-flow").click();
+
+  await page.getByTestId("sidebar-search-input").click();
+  await page.getByTestId("sidebar-search-input").fill("openai");
+  await page.waitForSelector('[data-testid="openaiOpenAI"]', { timeout: 30000 });
+  await page
+    .getByTestId("openaiOpenAI")
+    .hover()
+    .then(async () => {
+      await page.getByTestId("add-component-button-openai").last().click();
+    });
+
+  // The OpenAI node renders expanded, so its primary `api_key` field is on the canvas.
+  await expect(page.getByTestId(API_KEY_ANCHOR)).toBeVisible({ timeout: 15000 });
+}
+
+/**
+ * Opens the `api_key` field's global-variable dropdown, handling both render
+ * states. Empty/editable: click the visible `icon-Globe`. Auto-bound (a matching
+ * Credential variable already exists): the field shows a badge and the trigger
+ * button's icon fails to render (zero-size but click-functional), so we assert it
+ * attached and fire a geometry-independent `dispatchEvent("click")`. See the spec
+ * doc's "Indirect mechanism justified" note.
+ */
+async function openApiKeyVariableDropdown(page: Page): Promise<void> {
+  const globe = page
+    .getByTestId(API_KEY_INPUT)
+    .locator("xpath=following::*[@data-testid='icon-Globe'][1]");
+
+  if ((await globe.count()) > 0) {
+    await expect(globe).toBeVisible({ timeout: 10000 });
+    await globe.click();
+    return;
+  }
+
+  // Scoped structurally off the anchor testid; distinct from the badge's own
+  // "remove" (X) icon, which unbinds instead of opening the dropdown.
+  const boundTrigger = page
+    .getByTestId(API_KEY_ANCHOR)
+    .locator("xpath=/parent::div/following-sibling::*[1]//button");
+
+  await expect(boundTrigger).toBeAttached({ timeout: 10000 });
+  await boundTrigger.dispatchEvent("click");
+}
+
+/**
+ * Creates a Credential global variable from the open `api_key` dropdown and binds
+ * it to the field. Returns once the field shows the variable name as its value.
+ */
+async function createAndBindCredentialVariable(
+  page: Page,
+  varName: string,
+  sentinelValue: string,
+): Promise<void> {
+  await openApiKeyVariableDropdown(page);
+
+  // "Add New Variable" can render outside the viewport when the dropdown overflows,
+  // so trigger it via a DOM click (mirrors global-variables-crud.spec.ts).
+  await page.evaluate(() => {
+    const el = Array.from(document.querySelectorAll("button, span")).find(
+      (e) => e.textContent?.trim() === "Add New Variable",
+    ) as HTMLElement | undefined;
+    if (el) el.click();
+    else throw new Error("Add New Variable button not found in DOM");
+  });
+
+  await page.getByPlaceholder("Enter a name for the variable...").fill(varName);
+  // Switch to Credential BEFORE saving — otherwise a Generic variable is created.
+  await page.getByTestId("credential-tab").click();
+  await page
+    .getByPlaceholder("Enter a value for the variable...")
+    .fill(sentinelValue);
+  await page.getByText("Save Variable", { exact: true }).click();
+
+  const boundValue = page
+    .getByTestId(API_KEY_ANCHOR)
+    .getByText(varName, { exact: true });
+  const optionRow = page.getByTestId(`option-${varName}`);
+
+  // After creation the variable is either left selectable in the still-open
+  // dropdown or auto-bound to the referencing field. Wait for whichever occurs,
+  // then bind explicitly only when it isn't bound yet.
+  await expect(boundValue.or(optionRow)).toBeVisible({ timeout: 10000 });
+  if ((await optionRow.count()) > 0) {
+    await optionRow.click();
+  }
+  await expect(boundValue).toBeVisible({ timeout: 10000 });
+}
+
+/**
+ * Best-effort deletion of a global variable by name via the REST API.
+ */
+async function deleteVariableByName(
+  request: import("@playwright/test").APIRequestContext,
+  varName: string,
+): Promise<void> {
+  const authToken = await getAuthToken(request);
+  const listRes = await request.get("/api/v1/variables/", {
+    headers: { Authorization: authToken },
+  });
+  if (!listRes.ok()) return;
+  const variables = (await listRes.json()) as Array<{ id: string; name: string }>;
+  const match = variables.find((v) => v.name === varName);
+  if (match) {
+    await request.delete(`/api/v1/variables/${match.id}`, {
+      headers: { Authorization: authToken },
+    });
+  }
+}
+
+test(
+  "bind a Credential global variable to a component secret field",
+  { tag: ["@release", "@workspace", "@regression"] },
+  async ({ page, request }) => {
+    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const varName = `gv-api-key-${stamp}`;
+    const sentinelValue = `SECRET-SENTINEL-${stamp}`;
+
+    try {
+      await test.step("Add an OpenAI component with an api_key secret field", async () => {
+        await addOpenAiComponent(page);
+      });
+
+      await test.step("Create a Credential variable and bind it to the api_key field", async () => {
+        await createAndBindCredentialVariable(page, varName, sentinelValue);
+      });
+
+      await test.step("Field shows the variable name and never leaks the secret value", async () => {
+        // The field displays the variable NAME as its bound value.
+        await expect(
+          page.getByTestId(API_KEY_ANCHOR).getByText(varName, { exact: true }),
+        ).toBeVisible({ timeout: 10000 });
+
+        // The secret value is never rendered as visible text anywhere on the page.
+        // Substring match (no `exact`) also catches a leak embedded in a longer string.
+        await expect(page.getByText(sentinelValue)).toHaveCount(0, {
+          timeout: 5000,
+        });
+      });
+    } finally {
+      await deleteVariableByName(request, varName);
+    }
+  },
+);
+
+test(
+  "component secret-field global-variable binding persists across reload",
+  { tag: ["@release", "@workspace", "@regression"] },
+  async ({ page, request }) => {
+    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const varName = `gv-api-key-${stamp}`;
+    const sentinelValue = `SECRET-SENTINEL-${stamp}`;
+
+    try {
+      await test.step("Add an OpenAI component and bind a Credential variable to api_key", async () => {
+        await addOpenAiComponent(page);
+        await createAndBindCredentialVariable(page, varName, sentinelValue);
+      });
+
+      await test.step("Reload the page and confirm the binding survived", async () => {
+        // Let the flow autosave the binding, then reload from scratch.
+        await page.waitForTimeout(2000);
+        await page.reload();
+
+        // The rehydrated node still shows the same variable as its bound value —
+        // auto-bind never overrides an explicit binding saved in the flow.
+        await expect(page.getByTestId(API_KEY_ANCHOR)).toBeVisible({
+          timeout: 30000,
+        });
+        await expect(
+          page.getByTestId(API_KEY_ANCHOR).getByText(varName, { exact: true }),
+        ).toBeVisible({ timeout: 15000 });
+      });
+    } finally {
+      await deleteVariableByName(request, varName);
+    }
+  },
+);


### PR DESCRIPTION
## What this validates

Closes **QA-CHECKLIST §4.3 — "Use global variable in component (API key)"**, the *consumption* side of global variables (CRUD/secrecy live in `global-variables-crud.spec.ts`).

Two tests on the OpenAI `api_key` secret field (`SecretStrInput`):
1. **Bind** — create a Credential variable and select it from the field's Globe dropdown; the field then shows the variable **name** as its bound value and the secret sentinel never renders as visible text (`toHaveCount(0)`).
2. **Persistence** — the binding survives a full page reload (rehydrated from the saved flow; auto-bind never overrides an explicit binding).

Maps to QA-SCENARIOS-GUIDE **16.6 / 16.7**.

## Why it matters

If this breaks, users who store API keys as Credential global variables can't wire them into components, or the wiring silently drops on reload — forcing plaintext keys typed directly into fields.

## Notable implementation decisions

- **State-aware dropdown helper.** The `api_key` field is bimodal: empty/editable (visible `icon-Globe`) vs auto-bound (a matching Credential var exists → badge, no Globe). Fresh CI hits the clean `icon-Globe` path.
- **Indirect mechanism justified (per CONTRIBUTING).** In the auto-bound state the dropdown-trigger button's icon fails to render (upstream Langflow gap), leaving a zero-width/zero-height but click-functional element. `toBeVisible()`/coordinate `click()` can't target it, so the helper asserts `toBeAttached()` and fires `dispatchEvent("click")` (Playwright's geometry-independent click). Documented in the spec doc.
- **No real API key / no flow run** — component is added and configured but never executed.
- **Cleanup** deletes the created variable via `DELETE /api/v1/variables/{id}` in a `finally` block.

## Validation

- typecheck ✅ · lint ✅ (0 errors) · run `--workers=1 --retries=0` → 2 passed ✅
- force-fail confirmed (broke the bind assertion → failed exactly there; reverted → passed)
- `--trace=on` steps coherent · zero `🚨 Backend Error`
- `Last validated: 1.11.x`

`@stable` intentionally withheld pending team review (explained in the spec doc's Tags section).