### PR TITLE
test(llm-agents): agent accepts input via direct field vs ChatInput handle (#493)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -359,7 +359,7 @@
 - [ ] Agent returns output in structured JSON format (output_schema) → `agent-structured-output.spec.ts`
 - [ ] Agent returns output in correctly rendered Markdown
 - [x] Agent Instructions (system prompt) is respected in the model response → `agent-system-prompt.spec.ts`
-- [ ] Input via direct field vs handle (ChatInput) — both work → `agent-input-sources.spec.ts`
+- [x] Input via direct field vs handle (ChatInput) — both work → `core-functionality/llm-agents/agent-input-sources.spec.ts`
 - [ ] Empty response or model refusal — component does not crash → `agent-empty-refusal-response.spec.ts`
 - [ ] Toggle add_current_date_tool works (enables/disables date tool) → `agent-current-date-tool.spec.ts`
 - [ ] handle_parsing_errors=False fails explicitly vs True auto-corrects → `agent-parse-error-behavior.spec.ts`
@@ -756,7 +756,7 @@
 | `core-components/` — Core Components | 82 | 79 | 0 | 1 | 2 |
 | `core-functionality/auth/` | 21 | 8 | 13 | 0 | 0 |
 | `core-functionality/knowledge-ingestion/` | 8 | 0 | 4 | 0 | 4 |
-| `core-functionality/llm-agents/` | 40 | 15 | 2 | 0 | 23 |
+| `core-functionality/llm-agents/` | 40 | 16 | 2 | 0 | 22 |
 | `core-functionality/model-provider/` | 33 | 6 | 18 | 0 | 9 |
 | `core-functionality/observability-monitoring/` | 23 | 15 | 7 | 0 | 1 |
 | `core-functionality/playground/` | 48 | 43 | 3 | 1 | 1 |
@@ -767,7 +767,7 @@
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 44 | 7 | 36 | 1 | 0 |
 | `ui-ux/` — Settings | 7 | 3 | 3 | 1 | 0 |
-| **TOTAL** | **451** | **225 (50%)** | **172 (38%)** | **7 (2%)** | **47 (10%)** |
+| **TOTAL** | **451** | **226 (50%)** | **172 (38%)** | **7 (2%)** | **46 (10%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -783,7 +783,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 235 `test()` calls carrying the `@stable` tag, distributed across 82 spec
+> 237 `test()` calls carrying the `@stable` tag, distributed across 83 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -930,6 +930,8 @@
 
 #### core-functionality/llm-agents/
 - [x] agent interaction suite → `agent-component-regression.spec.ts`
+- [x] input via ChatInput handle drives the agent response → `agent-input-sources.spec.ts`
+- [x] input via the Agent's direct field drives the agent response → `agent-input-sources.spec.ts`
 - [x] selecting 'Connect other models' clears the previously selected model → `agent-model-connection-isolation.spec.ts`
 - [x] Agent Instructions are respected in the model response → `agent-system-prompt.spec.ts`
 - [x] negative control — sentinel is absent without the instruction → `agent-system-prompt.spec.ts`
@@ -1056,7 +1058,7 @@
 | `core-components/` — Component Config | 18 | 1 |
 | `core-components/` — Core Components | 0 | 2 |
 | `core-functionality/auth/` | 13 | 0 |
-| `core-functionality/llm-agents/` | 2 | 23 |
+| `core-functionality/llm-agents/` | 2 | 22 |
 | `core-functionality/model-provider/` | 18 | 9 |
 | `core-functionality/playground/` | 3 | 1 |
 | `mcp/client/` | 7 | 2 |

--- a/docs/core-functionality/llm-agents/agent-input-sources.md
+++ b/docs/core-functionality/llm-agents/agent-input-sources.md
@@ -1,0 +1,175 @@
+# Agent Input Sources — direct field vs ChatInput handle
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+The Agent component accepts its user input (`input_value`) from **two
+interchangeable sources**, and both drive the agent's response:
+
+1. **Handle source** — a `ChatInput` component connected to the Agent's
+   `input` handle. Input typed in the Playground flows `ChatInput → Agent`.
+2. **Direct field source** — text typed directly into the Agent node's own
+   `Input` field, with no upstream connection. Running the Agent node uses that
+   field verbatim.
+
+Each test sends a **per-run sentinel token** and proves that exact token shaped
+the agent's output, so a pass cannot be coincidental and each source is proven
+independently. Parameterized by provider/model via `models.json`.
+
+If either test fails, the Agent can no longer be fed input through one of its two
+canonical authoring patterns — a core regression for anyone building agent flows.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@components` `@agents` `@playground`
+
+`@stable` is added only after the test runs clean multiple times with
+`--retries=0` on the fresh nightly (per `CONTRIBUTING.md`). `@components` — Agent
+node input configuration; `@agents` — agent execution; `@playground` — Test 1
+drives input through the Playground.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and accessible at `PLAYWRIGHT_BASE_URL`.
+- `models.json` / `providers.json` generated via
+  `npx playwright test tests/collect-models.spec.ts`.
+- At least one active provider API key in `.env` (OpenAI, Anthropic, or Google).
+- Run with `--workers=1` (agent specs create named flows that collide in
+  parallel). File is serial for the same reason (`SimpleAgentTemplatePage.load()`
+  wipes all flows before loading).
+
+---
+
+## Step by step *(required)*
+
+The spec generates **2 tests per active model** via `getTestTargets()` (default:
+1 model per active provider; `ALL_MODELS=true` runs all models in `models.json`).
+A per-run token `SENTINEL_<Date.now()>` is generated so a match is unambiguous.
+
+---
+
+**Test 1 — input via ChatInput handle**
+
+1. Load the Simple Agent template via `SimpleAgentTemplatePage.load(options)`.
+   The template ships `ChatInput → Agent(input) → ChatOutput` already wired.
+2. Open the Playground (`playground-btn-flow-io`); wait for
+   `input-chat-playground`.
+3. Send a distinctive echo prompt:
+   `Repeat this token exactly and nothing else: HANDLE-<sentinel>`.
+4. Wait for the agent to finish (`waitForAgentToFinish` — Stop button appears
+   then hides).
+5. **Validation:** the last `div-chat-message` (AI bubble) text **contains**
+   `HANDLE-<sentinel>` — proving the token typed in the Playground reached the
+   agent through the `ChatInput → input` handle.
+
+---
+
+**Test 2 — input via direct field**
+
+1. Load the Simple Agent template.
+2. Delete the `ChatInput` node (click `rf__node-ChatInput*`, press `Backspace`)
+   so the Agent's `input_value` is sourced **only** from its own field. Confirm
+   the node is gone and the edge count dropped by one.
+3. Type the distinctive echo prompt into the Agent's `Input` field
+   (`popover-anchor-input-input_value`):
+   `Repeat this token exactly and nothing else: FIELD-<sentinel>`.
+4. **Wait for the debounced autosave to settle** (`waitForFlowSaveSettled`) —
+   `button_run_agent` builds the *persisted* flow, so the model selection, the
+   node deletion and the field value must all be saved first (see Notes).
+5. Run the Agent node via `button_run_agent`.
+6. Wait for build success on the canvas — the `node_duration_agent` badge
+   (canonical completion signal; not the transient toast).
+7. Open the Agent's output inspector (`output-inspection-response-agent`); read
+   the `[role="dialog"]` (scoped `:not([data-testid="assistant-onboarding-tooltip"])`)
+   text content.
+8. **Validation:** the dialog text **contains** `FIELD-<sentinel>` — proving the
+   token typed into the Agent's own field drove the response with no ChatInput
+   present.
+
+---
+
+## Validation criterion *(required)*
+
+- **Handle:** with `ChatInput → Agent` connected, a token sent via the Playground
+  appears in the agent's AI response bubble.
+- **Direct field:** with `ChatInput` deleted, a token typed into the Agent's
+  `Input` field appears in the agent's output inspection after a canvas run.
+- Both use a fresh per-run sentinel, so neither can pass on stale or coincidental
+  text.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Runtime precedence when a handle is connected **and** the field is filled
+  (Langflow: the connection wins — out of scope here; each source is proven in
+  isolation).
+- Non-text input sources (files, structured data) into the Agent.
+- Tool-calling behavior (the template's Web Search / URL tools are not exercised;
+  the echo prompt is designed not to trigger them).
+- Streaming, reasoning steps, duration display — covered by
+  `agent-component-regression.spec.ts`.
+
+---
+
+## External dependencies *(required)*
+
+- `src/backend/base/langflow/components/agents/` — Agent execution and the
+  `input_value` input; a change to how the field vs. the connected handle is
+  resolved breaks this spec.
+- `src/frontend/src/CustomNodes/GenericNode/` — renders the Agent's
+  `popover-anchor-input-input_value` field, the `button_run_agent` control, and
+  the `output-inspection-response-agent` inspector.
+- `src/frontend/src/components/core/playgroundComponent/` —
+  `input-chat-playground`, `button-send`, `div-chat-message` used by Test 1.
+- Simple Agent starter template — must keep shipping `ChatInput → Agent →
+  ChatOutput`; a rename/rewire changes the setup.
+
+---
+
+## When to review this test *(optional)*
+
+- If the Simple Agent template is renamed, removed, or rewired.
+- If the Agent's `Input` field testid changes from
+  `popover-anchor-input-input_value`, or the run/inspection testids change.
+- If connecting a handle stops leaving the inline field editable, or the delete
+  gesture for a node changes.
+
+---
+
+## Notes *(optional)*
+
+- **Why a sentinel echo:** asserting a *distinctive per-run token* round-trips
+  through the agent proves the specific input source drove the output, far
+  stronger than a generic "non-empty response" check. `Repeat this token exactly`
+  is reliable for capable models; the assertion is a case-sensitive **substring**
+  match so minor wrapping by the model still passes.
+- **Two sources, one field:** the Agent's `input_value` renders as an editable
+  inline field (`popover-anchor-input-input_value`) that stays editable even when
+  the handle is connected — but at runtime a connected handle overrides it. Test 2
+  therefore deletes `ChatInput` so the field is the sole source; Test 1 keeps the
+  connection so the handle is the source.
+- **Test 2 reads the node inspector, not the Playground:** `button_run_agent`
+  builds the Agent (and upstream) but not the downstream `ChatOutput`, so the
+  response is read from `output-inspection-response-agent` rather than a chat
+  bubble.
+- **Autosave race (root-caused during authoring):** `button_run_agent` builds the
+  *persisted* flow, not the live canvas graph. When this test runs after another
+  agent test in the same serial file, the OpenAI provider is already configured
+  globally, so `SimpleAgentTemplatePage.load()` finishes model selection quickly
+  — fast enough that the model-selection autosave `PATCH /api/v1/flows/{id}` can
+  still be in flight when `button_run_agent` fires. The build then runs the
+  template's default model reference and the backend raises
+  `ValueError: __default_language_model__ variable not found`; the agent never
+  builds, so `node_duration_agent` never appears and the step times out. Run in
+  isolation it passed because the full provider setup (key + enabling every
+  model) took long enough for the save to land. `waitForFlowSaveSettled` before
+  the run removes the race deterministically — the same guard
+  `agent-system-prompt.spec.ts` uses.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-input-sources.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-input-sources.spec.ts
@@ -1,0 +1,259 @@
+import * as dotenv from "dotenv";
+import path from "path";
+import fs from "fs";
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
+import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import {
+  hasProviderEnvKeys,
+  missingProviderEnvKeys,
+  providerConfigMap,
+  type Provider,
+} from "../../../../helpers/provider-setup";
+import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+
+/**
+ * Validates that the Agent component accepts its `input_value` from either of
+ * its two canonical sources, and that each independently drives the response:
+ *   - the ChatInput handle (`ChatInput → Agent(input)`), fed via the Playground;
+ *   - the Agent's own inline `Input` field, with no upstream connection.
+ *
+ * Each test round-trips a fresh per-run sentinel so a pass can't be coincidental.
+ *
+ * Sibling coverage — NOT duplicated here:
+ *   - agent-component-regression.spec.ts: streaming, reasoning steps, duration,
+ *     multiple consecutive messages, stop button.
+ *   - agent-system-prompt.spec.ts: system prompt influence on the response.
+ * This spec owns only the "which input source reached the agent" contract (§6.5).
+ */
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
+}
+
+interface ModelRecord {
+  provider: string;
+  model: string;
+}
+
+interface TestTarget {
+  label: string;
+  options: LoadSimpleAgentOptions;
+  skipReason?: string;
+}
+
+function getProviderSkipReasons(): Map<string, string> {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/providers.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
+    return new Map();
+  }
+  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
+  const reasons = new Map<string, string>();
+  for (const r of records) {
+    if (r.status === "inactive") {
+      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
+    }
+  }
+  return reasons;
+}
+
+function getModelsFromJson(): ModelRecord[] {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/models.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("models.json not found — run collect-models.spec.ts first.");
+    return [];
+  }
+  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
+}
+
+function getTestTargets(): TestTarget[] {
+  const skipReasons = getProviderSkipReasons();
+
+  if (process.env.MODEL_TEST_ID) {
+    const model = process.env.MODEL_TEST_ID;
+    const allModels = getModelsFromJson();
+    const record = allModels.find((m) => m.model === model);
+
+    if (!record) {
+      console.warn(
+        `MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred. ` +
+        `Run collect-models.spec.ts first, or set MODEL_TEST_PROVIDER.`,
+      );
+      return [{ label: `model:${model}`, options: { model } }];
+    }
+
+    const provider = record.provider as Provider;
+    return [{
+      label: `${provider} / ${model}`,
+      options: { provider, model },
+      skipReason: skipReasons.get(provider),
+    }];
+  }
+
+  const allModels = getModelsFromJson();
+
+  if (allModels.length === 0) {
+    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
+    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
+    return [{
+      label: `provider:${fallbackProvider} (fallback)`,
+      options: { provider: fallbackProvider },
+      skipReason: skipReasons.get(fallbackProvider),
+    }];
+  }
+
+  let models = allModels;
+
+  if (process.env.MODEL_TEST_PROVIDER) {
+    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
+  } else if (process.env.ALL_MODELS !== "true") {
+    const seen = new Set<string>();
+    models = models.filter((m) => {
+      if (seen.has(m.provider)) return false;
+      seen.add(m.provider);
+      return true;
+    });
+  }
+
+  return models.map((m) => ({
+    label: `${m.provider} / ${m.model}`,
+    options: { provider: m.provider as Provider, model: m.model },
+    skipReason: skipReasons.get(m.provider),
+  }));
+}
+
+async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
+  try {
+    await new SimpleAgentTemplatePage(page).load(options);
+  } catch (e: any) {
+    if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
+    throw e;
+  }
+}
+
+async function waitForAgentToFinish(page: Page): Promise<void> {
+  const stopButton = page.getByRole("button", { name: "Stop" });
+  const stopVisible = await stopButton.isVisible({ timeout: 10000 }).catch(() => false);
+  if (stopVisible) {
+    await expect(stopButton).toBeHidden({ timeout: 120000 });
+  }
+}
+
+const targets = getTestTargets();
+
+// SimpleAgentTemplatePage.load() deletes all flows before loading the template.
+// File-level serial mode prevents parallel provider blocks from wiping each other's flows.
+test.describe.configure({ mode: "serial" });
+
+for (const { label, options, skipReason } of targets) {
+  const provider = options.provider ?? (Object.keys(providerConfigMap)[0] as Provider);
+
+  test.describe(`Agent Input Sources [${label}]`, () => {
+
+    test(
+      "input via ChatInput handle drives the agent response",
+      { tag: ["@stable", "@components", "@agents", "@playground"] },
+      async ({ page }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        // Per-run sentinel: a match on this exact token can't be coincidental.
+        const token = `HANDLE-${Date.now()}`;
+
+        // The Simple Agent template ships ChatInput → Agent(input) → ChatOutput.
+        await loadAgent(page, options);
+
+        await test.step("send the sentinel through the Playground (ChatInput handle)", async () => {
+          await page.getByTestId("playground-btn-flow-io").click();
+          await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({ timeout: 30000 });
+          await page
+            .getByTestId("input-chat-playground")
+            .last()
+            .fill(`Repeat this token exactly and nothing else: ${token}`);
+          await page.getByTestId("button-send").last().click();
+          await waitForAgentToFinish(page);
+        });
+
+        await test.step("agent response echoes the token routed through the handle", async () => {
+          const aiMessage = page.getByTestId("div-chat-message").last();
+          await expect(aiMessage).toBeVisible({ timeout: 30000 });
+          const text = await aiMessage.innerText();
+          expect(text).toContain(token);
+        });
+      },
+    );
+
+    test(
+      "input via the Agent's direct field drives the agent response",
+      { tag: ["@stable", "@components", "@agents", "@playground"] },
+      async ({ page }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        const token = `FIELD-${Date.now()}`;
+
+        await loadAgent(page, options);
+
+        await test.step("delete ChatInput so the Agent's own field is the only input source", async () => {
+          const edges = page.locator(".react-flow__edge");
+          const edgesBefore = await edges.count();
+
+          const chatInputNode = page.locator('[data-testid^="rf__node-ChatInput"]');
+          await expect(chatInputNode).toHaveCount(1);
+          await chatInputNode.click();
+          await page.keyboard.press("Backspace");
+
+          await expect(chatInputNode).toHaveCount(0, { timeout: 10000 });
+          // The single ChatInput → Agent edge is gone with the node.
+          await expect(edges).toHaveCount(edgesBefore - 1, { timeout: 10000 });
+        });
+
+        await test.step("type the sentinel directly into the Agent's Input field", async () => {
+          const inputField = page.getByTestId("popover-anchor-input-input_value");
+          await expect(inputField).toBeVisible({ timeout: 15000 });
+          await inputField.fill(`Repeat this token exactly and nothing else: ${token}`);
+          // button_run_agent builds the PERSISTED flow. Drain the debounced
+          // autosave PATCHes (model selection from load(), the ChatInput deletion,
+          // and this field value) before running — otherwise the build can race a
+          // still-pending save and run the template default model
+          // (`__default_language_model__ variable not found`), so the agent never
+          // builds and node_duration_agent never appears. Same class of race the
+          // agent-system-prompt spec guards with an autosave wait.
+          await waitForFlowSaveSettled(page);
+        });
+
+        await test.step("run the Agent node from the canvas", async () => {
+          await page.getByTestId("button_run_agent").click();
+          // Anchor completion on the persistent node badge, not the transient toast.
+          await expect(page.getByTestId("node_duration_agent")).toBeVisible({ timeout: 120000 });
+        });
+
+        await test.step("agent output echoes the token typed into the field", async () => {
+          await expect(page.getByTestId("output-inspection-response-agent")).toBeAttached({ timeout: 10000 });
+          await page.getByTestId("output-inspection-response-agent").click();
+          // [role="dialog"] is ambiguous — the onboarding tooltip also carries it.
+          const dialog = page.locator(
+            '[role="dialog"]:not([data-testid="assistant-onboarding-tooltip"])',
+          );
+          await expect(dialog).toBeVisible({ timeout: 10000 });
+          const text = (await dialog.evaluate((el: HTMLElement) => el.textContent ?? "")) ?? "";
+          expect(text).toContain(token);
+        });
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #493.

Closes the `[ ] Input via direct field vs handle (ChatInput) — both work` gap in `QA-CHECKLIST.md` §6.5. Distinct from `agent-component-regression.spec.ts` (streaming/duration/multi-message) and `agent-system-prompt.spec.ts` (system-prompt influence): this spec owns only the *which input source reached the agent* contract — proving both of the Agent's canonical input sources independently drive the response.

## 1. Covered tests
| # | Test | What it validates |
|---|------|-------------------|
| 1 | `input via ChatInput handle drives the agent response` | With `ChatInput → Agent(input)` wired, a per-run sentinel typed in the Playground reaches the agent through the handle and appears in the AI response bubble. |
| 2 | `input via the Agent's direct field drives the agent response` | With `ChatInput` deleted, a per-run sentinel typed into the Agent's own `Input` field (`popover-anchor-input-input_value`) drives a canvas run (`button_run_agent`) and appears in `output-inspection-response-agent`. |

Each test uses a fresh `Date.now()` sentinel (`HANDLE-…` / `FIELD-…`), so a pass can't be stale or coincidental.

## 2. How the test was built
- Loads the `Simple Agent` template via `SimpleAgentTemplatePage` + `models.json`; parameterized per model, serial file, `--workers=1`.
- **Live-confirmed selectors** (scouted in the running nightly, not invented): `popover-anchor-input-input_value` (Agent Input field — an editable `<input>`), `button_run_agent`, `node_duration_agent` (persistent build badge), `output-inspection-response-agent`, `input-chat-playground` / `div-chat-message`. Deleting `ChatInput` = select node + `Backspace` (confirmed: node gone, edge count −1).
- Test 2 reads the node inspector, not the Playground: `button_run_agent` builds the Agent (and upstream) but not the downstream `ChatOutput`.
- Dialog read scoped `:not([data-testid="assistant-onboarding-tooltip"])` (the onboarding tooltip also carries `role="dialog"`).

## 3. Autosave race — root-caused & fixed during authoring
First full run timed out on both tests. Backend log (docker) showed `ValueError: __default_language_model__ variable not found`, retried every ~10s. `button_run_agent` builds the **persisted** flow; when this runs after another agent test in the same serial file the OpenAI provider is already configured globally, so `load()` finishes model selection fast enough that its autosave `PATCH /api/v1/flows/{id}` is still in flight at run time → build uses the template default model → agent never builds → `node_duration_agent` never appears. Isolated it passed (full provider setup gave the save time to land). Fixed deterministically with `waitForFlowSaveSettled()` before the run — the same guard `agent-system-prompt.spec.ts` uses.

## 4. Dependencies
- Provider/API key: needs one active provider (`models.json`); OpenAI used for validation. Anthropic/Google `skipped` when unkeyed.
- Execution: `--workers=1` serial (named flows collide under parallelism; `SimpleAgentTemplatePage.load()` wipes flows).

## Validation (nightly 1.11.0.dev30, `--retries=0`)
- `npm run typecheck` ✅ 0 errors · `npm run lint` ✅ 0 errors (warnings match sibling agent specs)
- 3 consecutive clean full runs → `2 passed` each (34.2s / 18.1s / 18.1s) + isolated passes ✅
- zero `🚨 Backend Error` on green runs ✅
- false-positive guard = per-run unique sentinel + observed genuine hard-failure during debugging ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)