### PR TITLE
test(model-provider): OpenAI provider happy path — configure key, select GPT, execute (#502)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -380,9 +380,9 @@
 - [-] Replace provider API key via Replace Configuration (existing key) → `collect-models.spec.ts`
 
 #### 7.2 OpenAI
-- [-] Configure OpenAI API key via GlobalVariables
-- [-] Select GPT model in agent
-- [-] Execute flow with OpenAI
+- [x] Configure OpenAI API key in Settings → Model Providers → `core-functionality/model-provider/openai-provider.spec.ts`
+- [x] Select GPT model in agent → `core-functionality/model-provider/openai-provider.spec.ts`
+- [x] Execute flow with OpenAI → `core-functionality/model-provider/openai-provider.spec.ts`
 - [x] Invalid API key error — display error message → `core-functionality/llm-agents/provider-invalid-auth-error.spec.ts`
 
 #### 7.3 Anthropic
@@ -757,7 +757,7 @@
 | `core-functionality/auth/` | 21 | 8 | 13 | 0 | 0 |
 | `core-functionality/knowledge-ingestion/` | 8 | 0 | 4 | 0 | 4 |
 | `core-functionality/llm-agents/` | 40 | 16 | 2 | 0 | 22 |
-| `core-functionality/model-provider/` | 33 | 6 | 18 | 0 | 9 |
+| `core-functionality/model-provider/` | 33 | 9 | 15 | 0 | 9 |
 | `core-functionality/observability-monitoring/` | 23 | 15 | 7 | 0 | 1 |
 | `core-functionality/playground/` | 48 | 43 | 3 | 1 | 1 |
 | `core-functionality/project-management/` | 11 | 4 | 6 | 1 | 0 |
@@ -767,7 +767,7 @@
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 44 | 7 | 36 | 1 | 0 |
 | `ui-ux/` — Settings | 7 | 3 | 3 | 1 | 0 |
-| **TOTAL** | **451** | **226 (50%)** | **172 (38%)** | **7 (2%)** | **46 (10%)** |
+| **TOTAL** | **451** | **229 (51%)** | **169 (37%)** | **7 (2%)** | **46 (10%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -783,7 +783,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 237 `test()` calls carrying the `@stable` tag, distributed across 83 spec
+> 239 `test()` calls carrying the `@stable` tag, distributed across 84 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -943,6 +943,10 @@
 - [x] model toggle changes immediately and persists across reopen → `model-provider-model-toggle.spec.ts`
 - [x] disabling a model removes it from a component model dropdown → `model-provider-model-toggle.spec.ts`
 
+#### core-functionality/model-provider/
+- [x] OpenAI API key is configured via Settings → Model Providers → `openai-provider.spec.ts`
+- [x] configured OpenAI selects a GPT model in the Agent and executes the flow → `openai-provider.spec.ts`
+
 #### core-functionality/observability-monitoring/
 - [x] DELETE /api/v1/monitor/traces returns 404 for an unknown flow_id → `traces-delete.spec.ts`
 - [x] DELETE /api/v1/monitor/traces?flow_id=... clears all traces, and a second DELETE on the empty owned flow still returns 204 → `traces-delete.spec.ts`
@@ -1059,7 +1063,7 @@
 | `core-components/` — Core Components | 0 | 2 |
 | `core-functionality/auth/` | 13 | 0 |
 | `core-functionality/llm-agents/` | 2 | 22 |
-| `core-functionality/model-provider/` | 18 | 9 |
+| `core-functionality/model-provider/` | 15 | 9 |
 | `core-functionality/playground/` | 3 | 1 |
 | `mcp/client/` | 7 | 2 |
 | `mcp/server/` | 3 | 4 |

--- a/docs/core-functionality/model-provider/openai-provider.md
+++ b/docs/core-functionality/model-provider/openai-provider.md
@@ -1,0 +1,186 @@
+# OpenAI Provider — configure key, select GPT, execute
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+The OpenAI provider happy path (QA-CHECKLIST §7.2), as a **provider-centric
+journey** distinct from agent-behavior specs:
+
+1. **Configure the OpenAI API key** in `Settings → Model Providers` (in 1.11 the
+   key is a global provider variable `OPENAI_API_KEY`, set from this page — not
+   the legacy Variables screen).
+2. **Select a GPT model** in the Agent (the configured key makes GPT models
+   available in the Agent's model dropdown).
+3. **Execute a flow with OpenAI** and get a real response.
+
+A per-run sentinel is round-tripped through the executed agent, so the "execute"
+assertion proves the configured OpenAI provider actually produced the output —
+not a cached or coincidental value.
+
+If this fails, OpenAI can no longer be configured and used end-to-end — the most
+common provider setup in Langflow.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@model-provider` `@settings` `@agents` `@playground`
+
+`@stable` added only after multiple clean `--retries=0` runs on the fresh
+nightly. `@model-provider` (area, all tests) · `@settings` (Test 1 navigates
+Settings) · `@agents` + `@playground` (Test 2 executes an agent).
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- `OPENAI_API_KEY` set in `.env` (both tests self-skip without it).
+- `models.json` / `providers.json` generated via
+  `npx playwright test tests/collect-models.spec.ts`.
+- Run with `--workers=1` (Test 2 loads a named template via
+  `SimpleAgentTemplatePage`, which wipes flows). File is serial.
+
+---
+
+## Step by step *(required)*
+
+---
+
+**Test 1 — configure the OpenAI API key in Settings → Model Providers** (§7.2.1)
+
+1. `SettingsPage.navigate()` → click `sidebar-nav-Model Providers`; wait for
+   `settings_menu_header` to read "Model Providers".
+2. Click `provider-item-OpenAI` to open its config panel.
+3. Fill `provider-variable-input-OPENAI_API_KEY` with `OPENAI_API_KEY`.
+4. Arm two response waiters, then click the save button (`Save` when
+   unconfigured, `Replace` when a key is already stored — match `/Save|Replace/`).
+5. **Validation (causal — no pre-existing-state false positive):** the save click
+   must produce **both** a `POST /api/v1/models/validate-provider` → **2xx** (the
+   key authenticates against OpenAI live) **and** a `PATCH /api/v1/variables/{id}`
+   → **2xx** (the key is persisted). Asserting the request outcomes — not the
+   "Replace" button, which is already present when the global key was configured
+   by an earlier test — ties the pass to *this* save action. Idempotent: re-saving
+   the same valid key is a success; the shared global key is deliberately not
+   wiped.
+
+---
+
+**Test 2 — configured OpenAI is selectable in the Agent and executes** (§7.2.2 + §7.2.3)
+
+1. `SimpleAgentTemplatePage.load({ provider: "openai", model })` — with the key
+   configured, this selects a **GPT** model in the Agent's `model_model`
+   dropdown (bullet §7.2.2). `model` resolves from `models.json` (a GPT chat
+   model; `setup-openai` prefers `gpt-4o-mini`/`gpt-4o`/`gpt-4.1`).
+2. **Assert the selection is a GPT model** — `value-dropdown-model_model` text
+   matches `/gpt/i`. Ties §7.2.2 to a concrete observable instead of leaving it
+   implicit, and closes the "some other provider answered" gap in step 5.
+3. **Remove the Web Search + URL tool nodes** — select each via its node **title**
+   (`title-Web Search`, `title-URL`) then press `Delete` (a body click doesn't
+   select URLComponent — its center is interactive), then wait for the debounced
+   autosave to settle (`waitForFlowSaveSettled`) so the Playground build runs the
+   persisted tool-free flow. The agent then executes as a **plain LLM
+   completion** — see Notes for why.
+4. Open the Playground (`playground-btn-flow-io`); wait for
+   `input-chat-playground`.
+5. Send `Repeat this token exactly and nothing else: OPENAI-<sentinel>`; wait for
+   the agent to finish (`waitForAgentToFinish`).
+6. **Validation:** the last `div-chat-message` (AI bubble) **contains**
+   `OPENAI-<sentinel>` — the configured OpenAI provider, on a selected GPT model,
+   executed the flow to produce this run's token (bullet §7.2.3).
+
+---
+
+## Validation criterion *(required)*
+
+- **Configure:** clicking Save on the OpenAI key produces a 2xx
+  `validate-provider` (key authenticates against OpenAI) and a 2xx
+  `PATCH /variables/{id}` (key persisted) — the pass is caused by this save, not
+  a pre-existing configured state.
+- **Select + execute:** the Agent's model dropdown shows a GPT model, and running
+  the flow returns the per-run sentinel in the AI response.
+
+## Guarding against false positives *(how)*
+
+- **Test 1** asserts the *save requests succeed* (`validate-provider` +
+  `PATCH /variables` both 2xx), not a UI state that pre-exists from an earlier
+  test's global key — so a no-op save cannot pass.
+- **Test 2** asserts a **GPT** model is selected (`value-dropdown-model_model`
+  ~ `/gpt/i`) and round-trips a **per-run sentinel**, so the response can't be
+  stale, cached, or produced by a different provider.
+- **Force-failure check** (CONTRIBUTING §2) is run during VERIFY: each assertion
+  is broken on purpose once to confirm it fails, before `@stable` is added.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Removing / rotating the key (see `remove-provider-api-key.spec.ts`).
+- The provider-listing / modal-open UI (see `model-provider-api-key.spec.ts`,
+  `model-provider-modal-actions.spec.ts`).
+- Model enable/disable toggles (see `model-provider-model-toggle.spec.ts`).
+- Agent behaviors — streaming, reasoning, duration, multi-message (see
+  `agent-component-regression.spec.ts`). This spec's execution step is a
+  provider-config end-to-end check, not an agent-behavior check.
+- Other providers (Anthropic → #503, Google → #504).
+
+---
+
+## External dependencies *(required)*
+
+- `src/frontend/src/pages/SettingsPage/` (Model Providers page) — renders
+  `provider-item-OpenAI`, `provider-variable-input-OPENAI_API_KEY`, and the
+  Save/Replace button; a rename breaks Test 1.
+- `src/backend/base/langflow/api/.../variables` + provider-config storage — the
+  global `OPENAI_API_KEY` provider variable the key is saved into.
+- `src/backend/base/langflow/components/agents/` — Agent execution with the
+  selected GPT model (Test 2).
+- `src/frontend/src/components/core/playgroundComponent/` — Playground I/O used
+  by Test 2.
+- OpenAI API — Test 2 makes a real call; a live `OPENAI_API_KEY` is required.
+
+---
+
+## When to review this test *(optional)*
+
+- If the Model Providers settings page restructures (provider items, the
+  `provider-variable-input-*` inputs, or the Save/Replace button).
+- If the Agent's model dropdown or the Simple Agent template changes.
+- If OpenAI key storage moves off the global provider-variable model.
+
+---
+
+## Notes *(optional)*
+
+- **Why a dedicated spec (issue #502 delegated the choice):** the §7.2 happy path
+  is exercised implicitly by `agent-component-regression`, but only as a
+  precondition inside `SimpleAgentTemplatePage`. This spec gives §7.2 a named,
+  provider-centric home that asserts the **Settings-page key configuration**
+  explicitly (Test 1) and proves the configured provider **executes** (Test 2).
+- **Stale bullet wording:** the checklist said "Configure OpenAI API key via
+  GlobalVariables". In 1.11 the key is configured on `Settings → Model Providers`
+  (stored as the `OPENAI_API_KEY` provider variable), so the bullet is reworded
+  to match the current build.
+- **Shared global key:** the OpenAI key is global and persists across tests /
+  runs (not deleted by `cleanAllFlows`). Test 1 is therefore idempotent — it
+  re-saves the same key and asserts the configured state rather than assuming a
+  fresh, unconfigured start.
+- **Per-run sentinel** over a generic non-empty check: proves *this* execution
+  produced the output, so the "execute with OpenAI" bullet can't pass on stale
+  text.
+- **Why the tools are removed before executing (root-caused during validation):**
+  the Simple Agent template ships with Web Search + URL tools. Executing it with
+  those tools on `gpt-4o-mini` failed ~1 in 5 runs (even spaced ~60s apart) with a
+  backend `ComponentBuildError` in the agent's tool / structured-output
+  orchestration — a transient that has nothing to do with the provider-config
+  contract §7.2 asks about. Deleting the tool nodes makes the agent a single-call
+  plain LLM completion, which validates "execute with OpenAI" deterministically.
+  Agent execution **with** tools is already covered by
+  `agent-component-regression.spec.ts`; this spec deliberately trades that
+  incidental coverage for a stable provider-config signal.
+- **Autosave before Playground execution:** the Playground build runs the
+  *persisted* flow, so the tool-node deletion must be saved first
+  (`waitForFlowSaveSettled`) — otherwise the build still includes the tools.

--- a/tests/tests-automations/regression/core-functionality/model-provider/openai-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/openai-provider.spec.ts
@@ -1,0 +1,196 @@
+import * as dotenv from "dotenv";
+import path from "path";
+import fs from "fs";
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { SettingsPage, SimpleAgentTemplatePage } from "../../../../pages";
+import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import {
+  hasProviderEnvKeys,
+  missingProviderEnvKeys,
+} from "../../../../helpers/provider-setup";
+
+/**
+ * OpenAI provider happy path (QA-CHECKLIST §7.2) as a provider-centric journey:
+ *   Test 1 — configure the OpenAI API key in Settings → Model Providers.
+ *   Test 2 — the configured provider selects a GPT model in the Agent and
+ *            executes a flow, round-tripping a per-run sentinel.
+ *
+ * Distinct from `agent-component-regression.spec.ts` (agent behaviors, which take
+ * the provider config as a POM precondition) and from the settings-UI presence
+ * specs (`model-provider-api-key`, `model-provider-modal-actions`). This spec
+ * owns the "configure → select GPT → execute" contract.
+ *
+ * False-positive guards: Test 1 asserts the save *requests* succeed
+ * (validate-provider + PATCH /variables, both 2xx) rather than a "Replace" button
+ * that pre-exists when an earlier test already set the global key — so a no-op
+ * save cannot pass. Test 2 asserts a GPT model is selected and echoes a per-run
+ * sentinel, so the response can't be stale or from another provider.
+ */
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
+}
+
+const PROVIDER = "openai";
+
+// Resolve a GPT chat model from models.json, preferring small general-purpose
+// ones. Returns undefined if none/absent — setup-openai then picks a default.
+function resolveGptModel(): string | undefined {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/models.json",
+  );
+  if (!fs.existsSync(jsonPath)) return undefined;
+  const models = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as Array<{
+    provider: string;
+    model: string;
+  }>;
+  const openai = models.filter((m) => m.provider === PROVIDER).map((m) => m.model);
+  const prefs = [/^gpt-4o-mini$/, /^gpt-4o$/, /^gpt-4\.1(-mini|-nano)?$/, /^gpt-4/];
+  for (const pref of prefs) {
+    const hit = openai.find((m) => pref.test(m));
+    if (hit) return hit;
+  }
+  return openai[0];
+}
+
+async function loadAgent(page: Page, model?: string): Promise<void> {
+  try {
+    await new SimpleAgentTemplatePage(page).load({ provider: PROVIDER, model });
+  } catch (e: any) {
+    if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
+    throw e;
+  }
+}
+
+async function waitForAgentToFinish(page: Page): Promise<void> {
+  const stopButton = page.getByRole("button", { name: "Stop" });
+  const stopVisible = await stopButton.isVisible({ timeout: 10000 }).catch(() => false);
+  if (stopVisible) {
+    await expect(stopButton).toBeHidden({ timeout: 120000 });
+  }
+}
+
+// SimpleAgentTemplatePage.load() deletes all flows before loading the template;
+// serial mode + --workers=1 keeps the shared instance state deterministic.
+test.describe.configure({ mode: "serial" });
+
+test.describe("OpenAI Provider", () => {
+  test(
+    "OpenAI API key is configured via Settings → Model Providers",
+    { tag: ["@stable", "@model-provider", "@settings"] },
+    async ({ page }) => {
+      test.skip(
+        !hasProviderEnvKeys(PROVIDER),
+        `Missing env vars for provider "${PROVIDER}": ${missingProviderEnvKeys(PROVIDER).join(", ")}`,
+      );
+
+      await awaitBootstrapTest(page, { skipModal: true });
+
+      await test.step("open Settings → Model Providers → OpenAI", async () => {
+        await new SettingsPage(page).navigate();
+        await page.getByTestId("sidebar-nav-Model Providers").click();
+        await expect(page.getByTestId("settings_menu_header").last()).toContainText(
+          "Model Providers",
+          { timeout: 10000 },
+        );
+        await page.getByTestId("provider-item-OpenAI").click();
+      });
+
+      await test.step("enter the key and save — assert the save requests succeed", async () => {
+        const keyInput = page.getByTestId("provider-variable-input-OPENAI_API_KEY");
+        await expect(keyInput).toBeVisible({ timeout: 10000 });
+        await keyInput.fill(process.env.OPENAI_API_KEY ?? "");
+
+        // Arm both waiters BEFORE clicking so the pass is caused by THIS save,
+        // not the "Replace" state a prior test's global key left behind.
+        const validatePromise = page.waitForResponse(
+          (r) =>
+            r.url().includes("/api/v1/models/validate-provider") &&
+            r.request().method() === "POST",
+          { timeout: 30000 },
+        );
+        const persistPromise = page.waitForResponse(
+          (r) =>
+            r.url().includes("/api/v1/variables/") &&
+            r.request().method() === "PATCH",
+          { timeout: 30000 },
+        );
+
+        await page.getByRole("button", { name: /Save|Replace/i }).first().click();
+
+        const [validateResp, persistResp] = await Promise.all([
+          validatePromise,
+          persistPromise,
+        ]);
+        // validate-provider 2xx = the key authenticates against OpenAI live;
+        // PATCH /variables 2xx = the key is persisted globally.
+        expect(validateResp.ok()).toBe(true);
+        expect(persistResp.ok()).toBe(true);
+      });
+    },
+  );
+
+  test(
+    "configured OpenAI selects a GPT model in the Agent and executes the flow",
+    { tag: ["@stable", "@model-provider", "@agents", "@playground"] },
+    async ({ page }) => {
+      test.skip(
+        !hasProviderEnvKeys(PROVIDER),
+        `Missing env vars for provider "${PROVIDER}": ${missingProviderEnvKeys(PROVIDER).join(", ")}`,
+      );
+
+      // Per-run sentinel: a match proves THIS execution produced the output.
+      const token = `OPENAI-${Date.now()}`;
+
+      await loadAgent(page, resolveGptModel());
+
+      await test.step("Agent has a GPT model selected", async () => {
+        const modelValue = page.getByTestId("value-dropdown-model_model");
+        await expect(modelValue).toBeVisible({ timeout: 15000 });
+        await expect(modelValue).toContainText(/gpt/i, { timeout: 10000 });
+      });
+
+      await test.step("remove the Web Search + URL tools so execution is a plain completion", async () => {
+        // The template's tool-orchestration on gpt-4o-mini transiently fails
+        // (~1/5, backend ComponentBuildError) — incidental to §7.2. A tool-free
+        // agent is a single deterministic LLM call. Tool execution is covered by
+        // agent-component-regression.spec.ts.
+        // Select via the node TITLE, not the body: URLComponent's body center is
+        // an interactive element, so a body click doesn't select the node.
+        const tools = [
+          { title: "title-Web Search", node: "rf__node-UnifiedWebSearch" },
+          { title: "title-URL", node: "rf__node-URLComponent" },
+        ];
+        for (const t of tools) {
+          const node = page.locator(`[data-testid^="${t.node}"]`);
+          if ((await node.count()) === 0) continue;
+          await page.getByTestId(t.title).click();
+          await page.keyboard.press("Delete");
+          await expect(node).toHaveCount(0, { timeout: 10000 });
+        }
+        // Playground builds the PERSISTED flow — the deletion must be saved first.
+        await waitForFlowSaveSettled(page);
+      });
+
+      await test.step("execute the flow and echo the sentinel", async () => {
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+          timeout: 30000,
+        });
+        await page
+          .getByTestId("input-chat-playground")
+          .last()
+          .fill(`Repeat this token exactly and nothing else: ${token}`);
+        await page.getByTestId("button-send").last().click();
+        await waitForAgentToFinish(page);
+
+        const aiMessage = page.getByTestId("div-chat-message").last();
+        await expect(aiMessage).toBeVisible({ timeout: 30000 });
+        expect(await aiMessage.innerText()).toContain(token);
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #502.

Validates QA-CHECKLIST §7.2 (OpenAI provider happy path) as a **provider-centric** journey, distinct from `agent-component-regression.spec.ts` (agent behaviors, which take provider config as a POM precondition) and the settings-UI presence specs (`model-provider-api-key`, `model-provider-modal-actions`). The issue delegated "dedicated spec vs promotion"; a dedicated spec was chosen because the named `model-provider-api-key.spec.ts` only checks provider listing/config-open, not the §7.2 configure→select→execute path.

## 1. Covered tests
| # | Test | What it validates |
|---|------|-------------------|
| 1 | `OpenAI API key is configured via Settings → Model Providers` | Entering the key on the Model Providers page and saving succeeds (§7.2.1). |
| 2 | `configured OpenAI selects a GPT model in the Agent and executes the flow` | A GPT model is selected in the Agent (§7.2.2) and the flow executes with OpenAI, echoing a per-run sentinel (§7.2.3). |

## 2. How the test was built
- **Live-confirmed selectors** (scouted on the running nightly): `provider-item-OpenAI`, `provider-variable-input-OPENAI_API_KEY`, `value-dropdown-model_model`, tool node titles `title-Web Search` / `title-URL`. Nav via `SettingsPage` + `sidebar-nav-Model Providers` (per the area `CLAUDE.md`).
- Reuses `SimpleAgentTemplatePage` (GPT selection) and `waitForFlowSaveSettled`.
- Bullet reworded: "via GlobalVariables" → "in Settings → Model Providers" (1.11 path; the key is stored as the `OPENAI_API_KEY` provider variable, but configured from that page).

## 3. False-positive guards
- **Test 1** asserts the save *requests* succeed — `POST /api/v1/models/validate-provider` **2xx** (key authenticates against OpenAI) + `PATCH /api/v1/variables/{id}` **2xx** (persisted) — **not** the "Replace" button, which pre-exists when an earlier test already set the global key. So a no-op save cannot pass.
- **Test 2** asserts a **GPT** model is selected (`value-dropdown-model_model` ~ `/gpt/i`) and round-trips a **per-run sentinel**, so the response can't be stale, cached, or from another provider.
- **Force-failure** (CONTRIBUTING §2) run during validation: flipping the Test 1 request assertion and using a wrong sentinel in Test 2 both fail as expected.

## 4. Stability note (why Test 2 removes the template tools)
The Simple Agent template ships with Web Search + URL tools. Executing with those tools on `gpt-4o-mini` transiently failed ~1/5 runs (backend `ComponentBuildError` in the tool / structured-output orchestration), even spaced ~60s apart — incidental to the §7.2 provider contract. Test 2 deletes the tool nodes so the agent is a deterministic single-call completion. Agent execution **with** tools stays covered by `agent-component-regression.spec.ts`. The Playground builds the persisted flow, so the deletion is followed by `waitForFlowSaveSettled`.

## 5. Dependencies
- Requires `OPENAI_API_KEY` in env (both tests self-skip without it) and `models.json` (`tests/collect-models.spec.ts`).
- Execution: `--workers=1`, file serial (`SimpleAgentTemplatePage.load()` wipes flows).

## Validation (nightly 1.11.0.dev30, `--retries=0`)
- **6/6 consecutive tight-burst runs → `2 passed` each** (15–30s, no timeouts) — the harshest condition; the pre-rework tool version failed ~5/6 here.
- Force-failure of both guards ✅ · typecheck ✅ · eslint ✅ 0 errors · zero `🚨 Backend Error`.
- QA-CHECKLIST §7.2 bullets flipped to `[x]`; auto-blocks regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)