### PR TITLE
test(llm-agents): agent survives empty/refusal model output without crashing (#494)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -360,7 +360,7 @@
 - [ ] Agent returns output in correctly rendered Markdown
 - [x] Agent Instructions (system prompt) is respected in the model response → `agent-system-prompt.spec.ts`
 - [x] Input via direct field vs handle (ChatInput) — both work → `core-functionality/llm-agents/agent-input-sources.spec.ts`
-- [ ] Empty response or model refusal — component does not crash → `agent-empty-refusal-response.spec.ts`
+- [x] Empty response or model refusal — component does not crash → `core-functionality/llm-agents/agent-empty-refusal-response.spec.ts`
 - [ ] Toggle add_current_date_tool works (enables/disables date tool) → `agent-current-date-tool.spec.ts`
 - [ ] handle_parsing_errors=False fails explicitly vs True auto-corrects → `agent-parse-error-behavior.spec.ts`
 - [ ] Image passed via input handle is processed correctly → `agent-multimodal-image-input.spec.ts`
@@ -756,7 +756,7 @@
 | `core-components/` — Core Components | 82 | 79 | 0 | 1 | 2 |
 | `core-functionality/auth/` | 21 | 8 | 13 | 0 | 0 |
 | `core-functionality/knowledge-ingestion/` | 8 | 0 | 4 | 0 | 4 |
-| `core-functionality/llm-agents/` | 40 | 16 | 2 | 0 | 22 |
+| `core-functionality/llm-agents/` | 40 | 17 | 2 | 0 | 21 |
 | `core-functionality/model-provider/` | 33 | 11 | 13 | 0 | 9 |
 | `core-functionality/observability-monitoring/` | 23 | 15 | 7 | 0 | 1 |
 | `core-functionality/playground/` | 48 | 43 | 3 | 1 | 1 |
@@ -767,7 +767,7 @@
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 44 | 7 | 36 | 1 | 0 |
 | `ui-ux/` — Settings | 7 | 3 | 3 | 1 | 0 |
-| **TOTAL** | **451** | **231 (51%)** | **167 (37%)** | **7 (2%)** | **46 (10%)** |
+| **TOTAL** | **451** | **232 (51%)** | **167 (37%)** | **7 (2%)** | **45 (10%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -783,7 +783,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 241 `test()` calls carrying the `@stable` tag, distributed across 85 spec
+> 243 `test()` calls carrying the `@stable` tag, distributed across 86 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -930,6 +930,8 @@
 
 #### core-functionality/llm-agents/
 - [x] agent interaction suite → `agent-component-regression.spec.ts`
+- [x] model refusal does not crash the component → `agent-empty-refusal-response.spec.ts`
+- [x] empty response does not crash the component → `agent-empty-refusal-response.spec.ts`
 - [x] input via ChatInput handle drives the agent response → `agent-input-sources.spec.ts`
 - [x] input via the Agent's direct field drives the agent response → `agent-input-sources.spec.ts`
 - [x] selecting 'Connect other models' clears the previously selected model → `agent-model-connection-isolation.spec.ts`
@@ -1064,7 +1066,7 @@
 | `core-components/` — Component Config | 18 | 1 |
 | `core-components/` — Core Components | 0 | 2 |
 | `core-functionality/auth/` | 13 | 0 |
-| `core-functionality/llm-agents/` | 2 | 22 |
+| `core-functionality/llm-agents/` | 2 | 21 |
 | `core-functionality/model-provider/` | 13 | 9 |
 | `core-functionality/playground/` | 3 | 1 |
 | `mcp/client/` | 7 | 2 |

--- a/docs/core-functionality/llm-agents/agent-empty-refusal-response.md
+++ b/docs/core-functionality/llm-agents/agent-empty-refusal-response.md
@@ -1,0 +1,194 @@
+# Agent Empty / Refusal Response — component does not crash
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+The Agent component **survives a degenerate model output** (QA-CHECKLIST §6.5,
+"Empty response or model refusal — component does not crash"). When the model
+either **refuses** the request or returns an **empty** response, the Agent must
+finish the run gracefully — no backend `5xx` / `ComponentBuildError`, no flow
+execution error, no stuck build.
+
+Two induced degenerate outputs, each proving the component does not crash:
+
+1. **Refusal (deterministic)** — Agent Instructions force the model to refuse
+   every request and reply with **only** a per-run refusal marker. The reply
+   contains that marker (proving we genuinely induced a refusal, not a helpful
+   answer) **and** the run completes with zero backend/flow errors.
+2. **Empty (best-effort)** — Agent Instructions force the model to output
+   nothing. The run **completes without crashing** (hard); whether the reply was
+   actually empty is model-obedience dependent, so it is **logged, not asserted**
+   (a `console.log`, not `expect.soft` — a soft assertion would still fail the
+   test).
+
+If this fails, the Agent component crashes on a degenerate LLM output — a
+robustness regression that would surface in production whenever a model refuses
+or returns nothing.
+
+Mirrors the structure of `agent-system-prompt.spec.ts` (same parameterization and
+`setAgentInstructions` / `askAndGetReply` machinery).
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@agents` `@playground`
+
+`@stable` added only after multiple clean `--retries=0` runs on the fresh nightly
+(per `CONTRIBUTING.md`). `@regression` — a negative/robustness guard against a
+crash regression; `@agents` — agent execution; `@playground` — both tests drive
+the model through the Playground.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and accessible at `PLAYWRIGHT_BASE_URL`.
+- `models.json` / `providers.json` generated via
+  `npx playwright test tests/collect-models.spec.ts`.
+- At least one active provider API key in `.env` (OpenAI, Anthropic, or Google).
+- Run with `--workers=1` (agent specs create named flows that collide in
+  parallel). File is serial (`SimpleAgentTemplatePage.load()` wipes all flows).
+
+---
+
+## Step by step *(required)*
+
+The spec generates **2 tests per active model** via `getTestTargets()` (default:
+1 model per active provider; `ALL_MODELS=true` runs all models in `models.json`;
+`MODEL_TEST_ID` / `MODEL_TEST_PROVIDER` narrow it). A per-run marker
+`REFUSE-<Date.now()>-<rand>` makes each refusal unambiguous.
+
+---
+
+**Test 1 — model refusal does not crash the component** (§6.5)
+
+1. Load the Simple Agent template via `SimpleAgentTemplatePage.load(options)`.
+2. Set the Agent Instructions (`textarea_str_system_prompt`) to force a refusal:
+   `You must refuse every request. Regardless of what the user asks, reply with
+   exactly this and nothing else: REFUSE-<marker>`, and wait for the autosave
+   `PATCH /api/v1/flows/{id}` (so the build runs the instruction we set).
+3. Open the Playground and send an unrelated message
+   (`What is the capital of France?`); wait for the agent to finish
+   (`waitForAgentToFinish`).
+4. **Validation:**
+   - **hard** — the last `div-chat-message` (AI bubble) **contains**
+     `REFUSE-<marker>`: proves the model actually produced the induced refusal
+     (not a helpful answer), so a pass is not coincidental.
+   - **hard (via fixture)** — zero `🚨 Backend Error` (4xx/5xx) and zero flow
+     execution errors: the component processed the refusal without crashing. A
+     component crash on the refusal path would raise a backend error the fixture
+     auto-fails on.
+
+---
+
+**Test 2 — empty response does not crash the component** (§6.5)
+
+1. Load the Simple Agent template.
+2. Set the Agent Instructions to force an empty response:
+   `Reply with an empty response. Output nothing at all — no text, no
+   punctuation, no whitespace.`, and wait for the autosave PATCH.
+3. Open the Playground and send `What is the capital of France?`; wait for the
+   agent to finish.
+4. **Validation:**
+   - **hard** — the run **completes**: the assistant message bubble
+     (`div-chat-message`) becomes visible and the Stop button is gone. Even an
+     empty completion renders a message row, so this is a deterministic
+     completion signal independent of the reply content.
+   - **hard (via fixture)** — zero `🚨 Backend Error` and zero flow errors: the
+     component did not crash on the empty-content path (the actual regression
+     this guards).
+   - **soft (logged, not asserted)** — whether the reply was actually
+     empty/whitespace vs. the model disobeying and answering. Emptiness is
+     model-obedience dependent, so requiring it would flake; the hard no-crash
+     check still proves the component survived this run's output.
+
+---
+
+## Validation criterion *(required)*
+
+- **Refusal:** with a refusal-forcing instruction, the AI bubble contains the
+  per-run refusal marker and the run finishes with no backend/flow error.
+- **Empty:** with an empty-forcing instruction, the run completes (bubble visible,
+  Stop gone) with no backend/flow error; the actual emptiness of the reply is a
+  logged soft signal (model-obedience dependent).
+- A component crash on either path raises a backend `5xx` /
+  `ComponentBuildError` that the fixture converts into a test failure — so a
+  green run genuinely proves "does not crash."
+
+## Guarding against false positives *(how)*
+
+- **Test 1** asserts the reply **contains the per-run refusal marker**, so it
+  cannot pass on a normal helpful answer or on stale/coincidental text — a pass
+  means the model actually refused and the component handled it.
+- **Test 2**'s completion is asserted structurally (bubble visible + Stop gone +
+  no error), not from the presence of text, so it holds whether the reply is
+  empty or not; the emptiness itself is only logged (never a hard/soft assertion)
+  precisely so an obedient-model dependency cannot produce a false failure.
+- **Force-failure check** (CONTRIBUTING §2) is run during VERIFY: each hard
+  assertion is broken on purpose once to confirm it fails, before `@stable`.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Deterministic *truly-empty* content on every model (inherently model-obedience
+  dependent — see the soft-signal note).
+- Refusals triggered by real content-policy violations (we induce a refusal via
+  instruction, not by sending disallowed content).
+- Instruction adherence in general (see `agent-system-prompt.spec.ts`).
+- Streaming, reasoning steps, duration, tool execution (see
+  `agent-component-regression.spec.ts`).
+
+---
+
+## External dependencies *(required)*
+
+- `src/backend/base/langflow/components/agents/` — Agent execution and its
+  handling of empty / refusal model output; a regression here (e.g. a `NoneType`
+  on empty content) breaks this spec.
+- `src/frontend/src/CustomNodes/GenericNode/` — renders the Agent's
+  `textarea_str_system_prompt` (Agent Instructions) field.
+- `src/frontend/src/components/core/playgroundComponent/` —
+  `input-chat-playground`, `button-send`, `div-chat-message`.
+- Simple Agent starter template — must keep shipping `ChatInput → Agent →
+  ChatOutput`; a rename/rewire changes the setup.
+- Provider LLM API — both tests make a real model call; a live key is required.
+
+---
+
+## When to review this test *(optional)*
+
+- If the Agent Instructions field testid changes from
+  `textarea_str_system_prompt`.
+- If the Simple Agent template is renamed, removed, or rewired.
+- If the Playground stops rendering an assistant bubble for empty content (Test 2
+  completion signal).
+
+---
+
+## Notes *(optional)*
+
+- **Why refusal is hard-asserted but empty is not:** capable models reliably obey
+  "reply with exactly this and nothing else", so a forced refusal (with a
+  distinctive marker) is deterministic. Genuinely-empty output is not — models
+  vary in whether they emit nothing, whitespace, or a short apology — so
+  requiring emptiness would flake. Both tests therefore rest their hard pass on
+  the **no-crash** guarantee (fixture backend/flow monitoring + run completion),
+  which is what §6.5 actually asks for.
+- **The fixture is the crash detector:** importing `test` from
+  `tests/fixtures/fixtures.ts` adds backend 4xx/5xx and flow-error monitoring, so
+  a component crash on the degenerate output fails the test automatically — no
+  `allowFlowErrors()` is used (an empty/refusal response is not itself an error).
+- **Per-run refusal marker** proves *this* run induced the refusal.
+- **Empty renders as a placeholder (observed on 1.11.0.dev30):** when the model
+  actually returns an empty completion, Langflow does **not** crash — the
+  Playground bubble shows the friendly placeholder `Message empty.`. That
+  placeholder is the graceful-handling signal §6.5 asks for, so Test 2's soft
+  log treats an empty string **or** `Message empty.` as "empty obeyed". Most
+  Gemini flash models obeyed the empty instruction (rendered the placeholder);
+  a few larger/tool variants answered the question instead — hence emptiness
+  stays a logged soft signal, never a hard assertion.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-empty-refusal-response.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-empty-refusal-response.spec.ts
@@ -1,0 +1,280 @@
+import * as dotenv from "dotenv";
+import path from "path";
+import fs from "fs";
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
+import {
+  hasProviderEnvKeys,
+  missingProviderEnvKeys,
+  providerConfigMap,
+  type Provider,
+} from "../../../../helpers/provider-setup";
+import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+
+/**
+ * Agent robustness on a degenerate model output (QA-CHECKLIST §6.5,
+ * "Empty response or model refusal — component does not crash").
+ *
+ *   Test 1 — a refusal-forcing instruction: the model refuses with a per-run
+ *            marker; the component finishes with no backend/flow error.
+ *   Test 2 — an empty-forcing instruction: the run completes without crashing;
+ *            whether the reply is actually empty is logged, not asserted (model
+ *            obedience varies — a soft assertion would still fail the test).
+ *
+ * The crash guard is the fixture: importing `test` from fixtures.ts adds backend
+ * 4xx/5xx and flow-error monitoring, so a component crash on the degenerate
+ * output fails the test automatically. A green run therefore proves the §6.5
+ * "does not crash" contract. Mirrors agent-system-prompt.spec.ts.
+ */
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
+}
+
+// The user message is unrelated to the instruction — a plain question the agent
+// would normally answer, so a refusal / empty reply can only come from the
+// instruction we set.
+const USER_MESSAGE = "What is the capital of France?";
+
+interface ModelRecord {
+  provider: string;
+  model: string;
+}
+
+interface TestTarget {
+  label: string;
+  options: LoadSimpleAgentOptions;
+  skipReason?: string;
+}
+
+function getProviderSkipReasons(): Map<string, string> {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/providers.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
+    return new Map();
+  }
+  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
+  const reasons = new Map<string, string>();
+  for (const r of records) {
+    if (r.status === "inactive") {
+      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
+    }
+  }
+  return reasons;
+}
+
+function getModelsFromJson(): ModelRecord[] {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/models.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("models.json not found — run collect-models.spec.ts first.");
+    return [];
+  }
+  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
+}
+
+function getTestTargets(): TestTarget[] {
+  const skipReasons = getProviderSkipReasons();
+
+  if (process.env.MODEL_TEST_ID) {
+    const model = process.env.MODEL_TEST_ID;
+    const allModels = getModelsFromJson();
+    const record = allModels.find((m) => m.model === model);
+
+    if (!record) {
+      console.warn(
+        `MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred. ` +
+        `Run collect-models.spec.ts first, or set MODEL_TEST_PROVIDER.`,
+      );
+      return [{ label: `model:${model}`, options: { model } }];
+    }
+
+    const provider = record.provider as Provider;
+    return [{
+      label: `${provider} / ${model}`,
+      options: { provider, model },
+      skipReason: skipReasons.get(provider),
+    }];
+  }
+
+  const allModels = getModelsFromJson();
+
+  if (allModels.length === 0) {
+    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
+    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
+    return [{
+      label: `provider:${fallbackProvider} (fallback)`,
+      options: { provider: fallbackProvider },
+      skipReason: skipReasons.get(fallbackProvider),
+    }];
+  }
+
+  let models = allModels;
+
+  if (process.env.MODEL_TEST_PROVIDER) {
+    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
+  } else if (process.env.ALL_MODELS !== "true") {
+    const seen = new Set<string>();
+    models = models.filter((m) => {
+      if (seen.has(m.provider)) return false;
+      seen.add(m.provider);
+      return true;
+    });
+  }
+
+  return models.map((m) => ({
+    label: `${m.provider} / ${m.model}`,
+    options: { provider: m.provider as Provider, model: m.model },
+    skipReason: skipReasons.get(m.provider),
+  }));
+}
+
+async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
+  try {
+    await new SimpleAgentTemplatePage(page).load(options);
+  } catch (e: any) {
+    if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
+    throw e;
+  }
+}
+
+async function waitForAgentToFinish(page: Page): Promise<void> {
+  const stopButton = page.getByRole("button", { name: "Stop" });
+  const stopVisible = await stopButton.isVisible({ timeout: 10000 }).catch(() => false);
+  if (stopVisible) {
+    await expect(stopButton).toBeHidden({ timeout: 120000 });
+  }
+}
+
+// Fill the Agent Instructions (system prompt) and wait for the autosave PATCH so
+// the build runs the prompt we set, not the template default.
+async function setAgentInstructions(page: Page, prompt: string): Promise<void> {
+  const promptField = page.getByTestId("textarea_str_system_prompt");
+  await expect(promptField).toBeVisible({ timeout: 15000 });
+
+  const patchPromise = page.waitForResponse(
+    (resp) =>
+      resp.url().includes("/api/v1/flows/") &&
+      resp.request().method() === "PATCH" &&
+      resp.ok(),
+    { timeout: 15000 },
+  );
+
+  await promptField.click();
+  await promptField.fill(prompt);
+  await promptField.blur();
+  await patchPromise;
+}
+
+// Open the Playground, send a message, wait for the run to finish, return the
+// latest chat message bubble locator + its text.
+async function askAndGetReplyBubble(page: Page, message: string) {
+  await page.getByTestId("playground-btn-flow-io").click();
+  await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+    timeout: 30000,
+  });
+
+  await page.getByTestId("input-chat-playground").last().fill(message);
+  await page.getByTestId("button-send").last().click();
+
+  await waitForAgentToFinish(page);
+
+  const bubble = page.getByTestId("div-chat-message").last();
+  await expect(bubble).toBeVisible({ timeout: 30000 });
+  return { bubble, text: (await bubble.innerText()).trim() };
+}
+
+const targets = getTestTargets();
+
+// SimpleAgentTemplatePage.load() deletes all flows before loading the template.
+// File-level serial mode prevents parallel provider blocks from wiping each
+// other's flows.
+test.describe.configure({ mode: "serial" });
+
+for (const { label, options, skipReason } of targets) {
+  const provider = options.provider ?? (Object.keys(providerConfigMap)[0] as Provider);
+
+  test.describe(`Agent Empty / Refusal Response [${label}]`, () => {
+    test(
+      "model refusal does not crash the component",
+      { tag: ["@stable", "@regression", "@agents", "@playground"] },
+      async ({ page }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        // Per-run marker: a passing assertion can only be caused by THIS run's
+        // refusal instruction reaching the model — never stale/coincidental text.
+        const uniq = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const marker = `REFUSE-${uniq}`;
+        const systemPrompt = `You must refuse every request. Regardless of what the user asks, reply with exactly this and nothing else: ${marker}`;
+
+        await loadAgent(page, options);
+
+        await test.step("set a refusal-forcing instruction and wait for autosave", async () => {
+          await setAgentInstructions(page, systemPrompt);
+        });
+
+        await test.step("run a message and assert the component refuses without crashing", async () => {
+          const { text } = await askAndGetReplyBubble(page, USER_MESSAGE);
+          // Hard: the model produced the induced refusal (not a helpful answer),
+          // so the pass is not coincidental. The fixture's backend/flow-error
+          // monitoring is the crash guard — a component crash on the refusal path
+          // would raise a backend error and auto-fail this test.
+          expect(text).toContain(marker);
+        });
+      },
+    );
+
+    test(
+      "empty response does not crash the component",
+      { tag: ["@stable", "@regression", "@agents", "@playground"] },
+      async ({ page }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        const systemPrompt =
+          "Reply with an empty response. Output nothing at all — no text, no punctuation, no whitespace.";
+
+        await loadAgent(page, options);
+
+        await test.step("set an empty-forcing instruction and wait for autosave", async () => {
+          await setAgentInstructions(page, systemPrompt);
+        });
+
+        await test.step("run a message and assert the component completes without crashing", async () => {
+          // Hard: the run completes — the assistant bubble renders (even for an
+          // empty completion) and the Stop button is gone. This is a
+          // deterministic completion signal independent of the reply content;
+          // combined with the fixture's backend/flow-error monitoring it proves
+          // the component did not crash on the empty-content path.
+          const { text } = await askAndGetReplyBubble(page, USER_MESSAGE);
+
+          // Optional signal — NOT asserted (expect.soft would still fail the
+          // test): whether the model actually obeyed and returned empty vs.
+          // answered anyway. Emptiness is model-obedience dependent. When the
+          // model DOES return an empty completion, Langflow renders the friendly
+          // placeholder "Message empty." in the bubble instead of crashing — that
+          // placeholder is itself the graceful-handling signal §6.5 asks for.
+          const isEmpty = text.length === 0 || /^message empty\.?$/i.test(text);
+          console.log(
+            isEmpty
+              ? `empty response obeyed: the component handled an empty completion without crashing (bubble: "${text}")`
+              : `model did not return empty (obedience); reply: ${text.slice(0, 80)}`,
+          );
+        });
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #494 — Wave 1 (Milestone 5: Agents & providers).

## What this validates

QA-CHECKLIST **§6.5** — *"Empty response or model refusal — component does not crash."* A robustness/negative guard: when the model **refuses** or returns an **empty** response, the Agent component must finish gracefully (no backend `5xx` / `ComponentBuildError`, no flow-execution error, no stuck build).

New spec `agent-empty-refusal-response.spec.ts` (+ mirrored spec doc). Structure mirrors `agent-system-prompt.spec.ts` (same `getTestTargets` parameterization and `setAgentInstructions` / `askAndGetReply` machinery).

### Test 1 — model refusal does not crash the component *(deterministic)*
A refusal-forcing Agent Instruction makes the model reply with **only** a per-run marker `REFUSE-<uniq>`.
- **hard:** the AI bubble contains the marker → proves a genuine induced refusal (not a helpful answer, not stale/coincidental text).
- **hard (fixture):** zero backend 4xx/5xx and zero flow errors → the component processed the refusal without crashing.

### Test 2 — empty response does not crash the component *(best-effort)*
An empty-forcing Agent Instruction.
- **hard:** the run completes — the assistant bubble renders and Stop is gone (deterministic completion signal, independent of reply content) + zero backend/flow errors.
- **soft (logged, not asserted):** whether the model actually returned empty. Emptiness is model-obedience dependent, so requiring it would flake. On `1.11.0.dev30` an empty completion renders the friendly placeholder **`Message empty.`** — the component handles it gracefully; the log treats empty string or that placeholder as "empty obeyed".

The crash detector is the fixture: importing `test` from `fixtures.ts` adds backend/flow-error monitoring, so a component crash on the degenerate output auto-fails the test. A green run therefore proves the §6.5 "does not crash" contract. No `allowFlowErrors()` (an empty/refusal reply is not itself an error).

**Tags:** `@stable @regression @agents @playground`.

## Validation

- **Resolved Langflow version:** `1.11.0.dev30` (Langflow Nightly), model `google / gemini-3.5-flash` (`--workers=1`, `--retries=0`).
- **Clean burst: 3/3 green** (2 passed each). Every run exercised the empty path (`"Message empty."`) and matched the refusal marker.
- **Plain run** (after resolving the local target): `2 passed`.
- **Force-failure check** (CONTRIBUTING §2): broke Test 1's marker assertion → `1 failed`, then reverted — confirms no false positive.
- `npm run typecheck` and `npm run lint`: **0 errors**.
- `QA-CHECKLIST.md` §6.5 bullet flipped to `[x]`; Coverage Summary + Phase 0 regenerated via `npm run coverage:summary`.

> Note: the default target resolves to one model per **active** provider. In this environment OpenAI is flagged `inactive` by `collect-models` (its probe model `gpt-5.5-pro` has no project access) and Anthropic has no key, so validation ran on Google/Gemini — the same active provider the `@stable` neighbor `agent-system-prompt.spec.ts` validates on.

## Manual run (debug)

\`\`\`bash
MODEL_TEST_ID=gemini-3.5-flash MODEL_TEST_PROVIDER=google \
npx playwright test tests/tests-automations/regression/core-functionality/llm-agents/agent-empty-refusal-response.spec.ts \
  --workers=1 --debug
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)