### PR TITLE
test(llm-agents): agent processes image passed via input handle (#497)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -363,7 +363,7 @@
 - [x] Empty response or model refusal — component does not crash → `core-functionality/llm-agents/agent-empty-refusal-response.spec.ts`
 - [ ] Toggle add_current_date_tool works (enables/disables date tool) → `agent-current-date-tool.spec.ts`
 - [ ] handle_parsing_errors=False fails explicitly vs True auto-corrects → `agent-parse-error-behavior.spec.ts`
-- [ ] Image passed via input handle is processed correctly → `agent-multimodal-image-input.spec.ts`
+- [x] Image passed via input handle is processed correctly → `core-functionality/llm-agents/agent-multimodal-image-input.spec.ts`
 
 ---
 
@@ -756,7 +756,7 @@
 | `core-components/` — Core Components | 82 | 79 | 0 | 1 | 2 |
 | `core-functionality/auth/` | 21 | 8 | 13 | 0 | 0 |
 | `core-functionality/knowledge-ingestion/` | 8 | 0 | 4 | 0 | 4 |
-| `core-functionality/llm-agents/` | 40 | 17 | 2 | 0 | 21 |
+| `core-functionality/llm-agents/` | 40 | 18 | 2 | 0 | 20 |
 | `core-functionality/model-provider/` | 33 | 11 | 13 | 0 | 9 |
 | `core-functionality/observability-monitoring/` | 23 | 15 | 7 | 0 | 1 |
 | `core-functionality/playground/` | 48 | 43 | 3 | 1 | 1 |
@@ -767,7 +767,7 @@
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 44 | 7 | 36 | 1 | 0 |
 | `ui-ux/` — Settings | 7 | 3 | 3 | 1 | 0 |
-| **TOTAL** | **451** | **232 (51%)** | **167 (37%)** | **7 (2%)** | **45 (10%)** |
+| **TOTAL** | **451** | **233 (52%)** | **167 (37%)** | **7 (2%)** | **44 (10%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -783,7 +783,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 242 `test()` calls carrying the `@stable` tag, distributed across 86 spec
+> 244 `test()` calls carrying the `@stable` tag, distributed across 87 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -935,6 +935,8 @@
 - [x] input via ChatInput handle drives the agent response → `agent-input-sources.spec.ts`
 - [x] input via the Agent's direct field drives the agent response → `agent-input-sources.spec.ts`
 - [x] selecting 'Connect other models' clears the previously selected model → `agent-model-connection-isolation.spec.ts`
+- [x] image via input handle is described by the agent → `agent-multimodal-image-input.spec.ts`
+- [x] negative control — no image, no image-specific description → `agent-multimodal-image-input.spec.ts`
 - [x] Agent Instructions are respected in the model response → `agent-system-prompt.spec.ts`
 - [x] negative control — sentinel is absent without the instruction → `agent-system-prompt.spec.ts`
 - [x] user must be able to send images in the playground with the agent component → `general-bugs-agent-images-playground.spec.ts`
@@ -1065,7 +1067,7 @@
 | `core-components/` — Component Config | 18 | 1 |
 | `core-components/` — Core Components | 0 | 2 |
 | `core-functionality/auth/` | 13 | 0 |
-| `core-functionality/llm-agents/` | 2 | 21 |
+| `core-functionality/llm-agents/` | 2 | 20 |
 | `core-functionality/model-provider/` | 13 | 9 |
 | `core-functionality/playground/` | 3 | 1 |
 | `mcp/client/` | 7 | 2 |

--- a/docs/core-functionality/llm-agents/agent-multimodal-image-input.md
+++ b/docs/core-functionality/llm-agents/agent-multimodal-image-input.md
@@ -1,0 +1,190 @@
+# Agent Multimodal Image Input — image via input handle processed
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+The Agent processes an **image passed via its input handle** (QA-CHECKLIST §6.5,
+"Image passed via input handle is processed correctly"). An image attached to the
+chat input travels through the `ChatInput.message → Agent.input` handle (the
+template's default wiring) to a **vision-capable** model, and the agent's response
+**describes the image content** — proving the image was actually received and
+processed, not dropped.
+
+A **negative control** (same prompt, no image attached) proves the description
+keyword only appears when the image is present, so the positive assertion cannot
+pass on a coincidental or prompt-driven word.
+
+Parameterized per active provider (resolving a vision-capable chat model), so it
+covers whichever provider is configured (OpenAI / Google / Anthropic).
+
+If this fails, the Agent can no longer consume image input through its canonical
+input handle — a core multimodal regression.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@agents` `@playground`
+
+`@stable` added only after multiple clean `--retries=0` runs on the fresh nightly.
+`@regression` — guards a multimodal input regression; `@agents` — agent
+execution; `@playground` — the image is attached and the flow run through the
+Playground.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- `models.json` / `providers.json` generated via
+  `npx playwright test tests/collect-models.spec.ts`.
+- At least one active provider with a **vision-capable** chat model (OpenAI
+  `gpt-4o*`, Google `gemini-*-flash`, Anthropic `claude-3.5-*`). The test resolves
+  such a model per provider and skips a provider that has none.
+- Test image `tests/assets/media/chain.png` (a chain/links graphic).
+- Run with `--workers=1` (agent specs create named flows that collide in
+  parallel). File is serial (`SimpleAgentTemplatePage.load()` wipes all flows).
+
+---
+
+## Step by step *(required)*
+
+The spec generates **2 tests per active model** via `getTestTargets()` (default:
+1 vision model per active provider). It resolves a vision-capable model for the
+target provider; if none is available the provider is skipped.
+
+---
+
+**Test 1 — image via input handle is described by the agent** (§6.5)
+
+1. Load the Simple Agent template via
+   `SimpleAgentTemplatePage.load({ provider, model })` with a resolved
+   vision-capable model. The template ships `ChatInput → Agent(input) →
+   ChatOutput` wired (edge `ChatInput.message → Agent.input_value`, the input
+   handle).
+2. Open the Playground (`playground-btn-flow-io`); wait for
+   `input-chat-playground`.
+3. Attach `chain.png` via the chat input's file widget
+   (`[data-testid="input-wrapper"] input[type="file"]`, `setInputFiles`) — the
+   only UI path to attach an image; it flows through the `ChatInput → Agent.input`
+   handle.
+4. Confirm the attachment rendered: `img[alt="chain.png"]` is visible.
+5. Set the prompt deterministically: fill the **ChatInput node's** "Input Text"
+   field (`textarea_str_input_value`) with `what is this image? describe it` on
+   the canvas and wait for autosave (`waitForFlowSaveSettled`); the Playground
+   chat input pre-fills from this node value (see Notes — typing into the
+   Playground races an async re-injection of the template default).
+6. Send (`button-send`); wait for the agent to finish
+   (`waitForAgentToFinish` — Stop button appears then hides).
+7. **Validation:** the last rendered AI response (`.markdown.prose` / chat
+   bubble) **matches** `/chain|link|logo|inkscape/i` **and** its length is
+   `> 50` — the vision model described the image content, proving the image was
+   received via the input handle and processed.
+
+---
+
+**Test 2 — negative control: no image, no image-specific description** (§6.5)
+
+1. Load the Simple Agent template with the same resolved model.
+2. Open the Playground; wait for `input-chat-playground`.
+3. Type the **same** prompt `what is this image? describe it` **without attaching
+   any image**.
+4. Send; wait for the agent to finish.
+5. **Validation:** the response does **not** match `/chain/i` — with no image the
+   model cannot describe a chain, so the keyword only appears in Test 1 because
+   the image was actually processed. This eliminates the false positive that the
+   Test 1 keyword came from the prompt or coincidence rather than the image.
+
+---
+
+## Validation criterion *(required)*
+
+- **Positive:** with `chain.png` attached, the agent's response mentions the
+  image content (`/chain|link|logo|inkscape/i`) and is non-trivial (`> 50`
+  chars) — the image reached the vision model through the `ChatInput → Agent`
+  input handle and was processed.
+- **Negative control:** with no image and the same prompt, the response does not
+  mention `chain` — proving the positive match is caused by the image, not the
+  prompt.
+
+## Guarding against false positives *(how)*
+
+- **Content keyword + length:** Test 1 asserts the reply describes the *actual*
+  image (chain/link/logo) and is substantive, not a generic acknowledgement.
+- **Negative control (Test 2):** the same prompt without the image must NOT
+  produce the keyword — this is the primary guard, mirroring the positive /
+  negative pattern in `agent-system-prompt.spec.ts`. Together they prove the
+  keyword is caused by the processed image, not the prompt or chance.
+- **Force-failure check** (CONTRIBUTING §2) is run during VERIFY: each hard
+  assertion is broken on purpose once to confirm it fails, before `@stable`.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Non-image file input (PDF/CSV/docs) into the Agent.
+- Attaching an image on a canvas node (no ChatInput file field exists on the
+  canvas — the only attach path is the chat input widget; see Notes).
+- OpenAI-specific playground image regression — kept in
+  `general-bugs-agent-images-playground.spec.ts` (the bug's regression origin);
+  this spec is the §6.5 home and adds active-provider (e.g. Gemini) coverage.
+- Agent tool execution, streaming, reasoning (see
+  `agent-component-regression.spec.ts`).
+
+---
+
+## External dependencies *(required)*
+
+- `src/backend/base/langflow/components/agents/` — Agent multimodal input
+  handling; a regression in how image messages are consumed breaks this spec.
+- `src/frontend/src/components/core/playgroundComponent/` — the
+  `input-wrapper` file input, `input-chat-playground`, `button-send`, and the
+  attachment `img` preview.
+- `src/backend/base/langflow/components/inputs/` (ChatInput) — must keep emitting
+  a Message carrying attached files on its `chat message` output.
+- Simple Agent starter template — must keep shipping `ChatInput → Agent →
+  ChatOutput`; a rewire changes the input-handle path.
+- Provider vision model — a live key and a vision-capable model are required; the
+  provider is skipped otherwise.
+
+---
+
+## When to review this test *(optional)*
+
+- If the chat input file-attach widget (`input-wrapper` / `input[type=file]`) or
+  the attachment preview changes.
+- If the Simple Agent template is renamed, removed, or rewired.
+- If `chain.png` is replaced (update the description keywords).
+- If a canvas-node image-attach path is introduced (would enable a stronger
+  handle-only variant).
+
+---
+
+## Notes *(optional)*
+
+- **Mechanism (scouted on 1.11.0.dev33):** the Agent's message input handle is
+  `handle-agent-shownode-input-left` (`input_value`, `inputTypes [Message]`), fed
+  by `ChatInput.message`. The ChatInput **node** on the canvas exposes only a text
+  field (`textarea_str_input_value`) — **no file-attach field**. The only UI path
+  to attach an image is the chat input widget (`input-wrapper` file input, which
+  accepts `image/png,image/jpeg,…`); the attached image flows through the
+  confirmed `ChatInput → Agent.input` handle. Hence the image is attached via the
+  Playground input and the handle carries it to the agent.
+- **Vision model required:** `SimpleAgentTemplatePage.load()` with no explicit
+  model selects the *first available* model, which may not be vision-capable
+  (e.g. a `gemma-*`). The spec therefore resolves a vision-capable model per
+  provider and skips a provider with none.
+- **Prompt via the ChatInput node, not the Playground textarea:** the Playground
+  chat input pre-fills from the ChatInput node's `input_value`, and it
+  **re-injects the template default (`Hello, how are you?`) asynchronously** —
+  which races and corrupts any text typed directly into the Playground (observed:
+  the default reappears mid-type). Setting the node's "Input Text" on the canvas
+  (then `waitForFlowSaveSettled`) makes the Playground prompt deterministic; the
+  test asserts the Playground prefilled exactly the prompt before sending.
+- **Overlap acknowledged:** the image→agent mechanism is shared with
+  `general-bugs-agent-images-playground.spec.ts` (OpenAI-only bug regression).
+  This spec is the named §6.5 home, is provider-parameterized (adds Gemini/active
+  provider coverage), and adds the negative control.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-multimodal-image-input.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-multimodal-image-input.spec.ts
@@ -1,0 +1,283 @@
+import * as dotenv from "dotenv";
+import path from "path";
+import fs from "fs";
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
+import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import {
+  hasProviderEnvKeys,
+  missingProviderEnvKeys,
+  providerConfigMap,
+  type Provider,
+} from "../../../../helpers/provider-setup";
+import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+
+/**
+ * Agent multimodal image input (QA-CHECKLIST §6.5, "Image passed via input
+ * handle is processed correctly").
+ *
+ *   Test 1 — an image attached to the chat input flows through the
+ *            ChatInput.message → Agent.input handle to a vision-capable model,
+ *            and the agent's response describes the image content.
+ *   Test 2 — negative control: the same prompt with NO image must not produce
+ *            the image-specific keyword, proving Test 1's match is caused by the
+ *            processed image (not the prompt or chance).
+ *
+ * Parameterized per active provider, resolving a vision-capable chat model
+ * (skips a provider with none). Mechanism scouted on 1.11.0.dev33: the ChatInput
+ * node has no canvas file field — the only image-attach path is the chat input
+ * widget (`input-wrapper` file input), which feeds the confirmed input handle.
+ */
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
+}
+
+const IMAGE_PATH = "tests/assets/media/chain.png";
+const IMAGE_ALT = "chain.png";
+const PROMPT = "what is this image? describe it";
+// chain.png is a chain/links graphic; a vision model describes it with one of
+// these tokens. `chain` is the most image-specific — the negative control keys
+// on it.
+const DESCRIBES_IMAGE = /chain|link|logo|inkscape/i;
+const IMAGE_SPECIFIC = /chain/i;
+
+interface ModelRecord {
+  provider: string;
+  model: string;
+}
+
+interface TestTarget {
+  label: string;
+  options: LoadSimpleAgentOptions;
+  skipReason?: string;
+}
+
+// Non-vision / non-chat model families to exclude when resolving a vision model.
+const NON_VISION = /gemma|embedding|tts|audio|whisper|realtime|image|customtools|moderation|search/i;
+
+// Per-provider preference for a fast, vision-capable chat model.
+const VISION_PREFS: Record<string, RegExp[]> = {
+  openai: [/^gpt-4o-mini$/, /^gpt-4o$/, /^gpt-4\.1(-mini)?$/, /gpt-4o/, /^gpt-5.*mini$/, /^gpt-5/],
+  google: [/^gemini-2\.5-flash$/, /^gemini-3\.5-flash$/, /^gemini-flash-latest$/, /gemini.*flash/, /gemini/],
+  anthropic: [/^claude-3-5-sonnet/, /^claude-3-5-haiku/, /^claude-3-7/, /claude-3\.?5/, /claude-3/, /claude/],
+};
+
+// Resolve a vision-capable model for a provider from its models.json entries.
+function resolveVisionModel(provider: string, models: ModelRecord[]): string | undefined {
+  const candidates = models
+    .filter((m) => m.provider === provider)
+    .map((m) => m.model)
+    .filter((m) => !NON_VISION.test(m));
+  const prefs = VISION_PREFS[provider] ?? [/.*/];
+  for (const pref of prefs) {
+    const hit = candidates.find((m) => pref.test(m));
+    if (hit) return hit;
+  }
+  return candidates[0];
+}
+
+function getProviderSkipReasons(): Map<string, string> {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/providers.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
+    return new Map();
+  }
+  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
+  const reasons = new Map<string, string>();
+  for (const r of records) {
+    if (r.status === "inactive") {
+      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
+    }
+  }
+  return reasons;
+}
+
+function getModelsFromJson(): ModelRecord[] {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/models.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("models.json not found — run collect-models.spec.ts first.");
+    return [];
+  }
+  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
+}
+
+// One target per active provider, each with a resolved vision-capable model.
+// A provider with no vision model is skipped with a reason.
+function getTestTargets(): TestTarget[] {
+  const skipReasons = getProviderSkipReasons();
+  const allModels = getModelsFromJson();
+
+  if (allModels.length === 0) {
+    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
+    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
+    return [{
+      label: `provider:${fallbackProvider} (fallback)`,
+      options: { provider: fallbackProvider },
+      skipReason: skipReasons.get(fallbackProvider),
+    }];
+  }
+
+  // Explicit single-provider override.
+  if (process.env.MODEL_TEST_PROVIDER) {
+    const provider = process.env.MODEL_TEST_PROVIDER;
+    const model = resolveVisionModel(provider, allModels);
+    return [{
+      label: `${provider} / ${model ?? "(no vision model)"}`,
+      options: { provider: provider as Provider, model },
+      skipReason:
+        skipReasons.get(provider) ??
+        (model ? undefined : `Provider "${provider}" has no vision-capable model in models.json`),
+    }];
+  }
+
+  // One vision model per provider present in models.json.
+  const providers = Array.from(new Set(allModels.map((m) => m.provider)));
+  return providers.map((provider) => {
+    const model = resolveVisionModel(provider, allModels);
+    return {
+      label: `${provider} / ${model ?? "(no vision model)"}`,
+      options: { provider: provider as Provider, model },
+      skipReason:
+        skipReasons.get(provider) ??
+        (model ? undefined : `Provider "${provider}" has no vision-capable model in models.json`),
+    };
+  });
+}
+
+async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
+  try {
+    await new SimpleAgentTemplatePage(page).load(options);
+  } catch (e: any) {
+    if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
+    throw e;
+  }
+}
+
+async function waitForAgentToFinish(page: Page): Promise<void> {
+  const stopButton = page.getByRole("button", { name: "Stop" });
+  const stopVisible = await stopButton.isVisible({ timeout: 10000 }).catch(() => false);
+  if (stopVisible) {
+    await expect(stopButton).toBeHidden({ timeout: 120000 });
+  }
+}
+
+// Set the ChatInput node's "Input Text" on the canvas. The Playground chat input
+// pre-fills from this node value, so setting it here makes the Playground prompt
+// deterministic — typing into the Playground races an async re-injection of the
+// template default ("Hello, how are you?"), which corrupts the value.
+async function setChatInputText(page: Page, text: string): Promise<void> {
+  const field = page.locator(
+    '[data-testid^="rf__node-ChatInput"] [data-testid="textarea_str_input_value"]',
+  );
+  await expect(field).toBeVisible({ timeout: 15000 });
+  await field.click();
+  await field.fill(text);
+  await field.blur();
+  // Playground builds/reads the persisted flow — the new value must be saved.
+  await waitForFlowSaveSettled(page);
+}
+
+// Open the Playground and (optionally) attach an image through the chat input
+// widget (`input-wrapper` file input) — the only UI path to attach an image; it
+// feeds the ChatInput → Agent input handle. The prompt is prefilled from the
+// ChatInput node value set via setChatInputText().
+async function openPlayground(page: Page, attachImage: boolean): Promise<void> {
+  await page.getByTestId("playground-btn-flow-io").click();
+  const chatInput = page.getByTestId("input-chat-playground").last();
+  await expect(chatInput).toBeVisible({ timeout: 30000 });
+  // Prefilled from the ChatInput node — deterministic, no typing race.
+  await expect(chatInput).toHaveValue(PROMPT, { timeout: 15000 });
+
+  if (attachImage) {
+    await page
+      .locator('[data-testid="input-wrapper"] input[type="file"]')
+      .setInputFiles(IMAGE_PATH);
+    // Attachment renders as an <img alt="chain.png"> preview, not literal text.
+    await expect(page.locator(`img[alt="${IMAGE_ALT}"]`).first()).toBeVisible({
+      timeout: 30000,
+    });
+  }
+}
+
+const targets = getTestTargets();
+
+// SimpleAgentTemplatePage.load() deletes all flows before loading the template.
+// File-level serial mode prevents parallel provider blocks from wiping each
+// other's flows.
+test.describe.configure({ mode: "serial" });
+
+for (const { label, options, skipReason } of targets) {
+  const provider = options.provider ?? (Object.keys(providerConfigMap)[0] as Provider);
+
+  test.describe(`Agent Multimodal Image Input [${label}]`, () => {
+    test(
+      "image via input handle is described by the agent",
+      { tag: ["@stable", "@regression", "@agents", "@playground"] },
+      async ({ page }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        await loadAgent(page, options);
+
+        await test.step("attach the image and send it through the input handle", async () => {
+          await setChatInputText(page, PROMPT);
+          await openPlayground(page, /* attachImage */ true);
+          await page.getByTestId("button-send").last().click();
+          await waitForAgentToFinish(page);
+        });
+
+        await test.step("assert the vision model described the image content", async () => {
+          // The image reached the model via ChatInput → Agent.input: the reply
+          // describes the actual image (chain/links), not a generic answer.
+          const response = page.locator(".markdown.prose").last();
+          await expect(response).toContainText(DESCRIBES_IMAGE, { timeout: 60000 });
+          const text = await response.textContent();
+          // Secondary guard against a one-word answer.
+          expect((text ?? "").length).toBeGreaterThan(50);
+        });
+      },
+    );
+
+    test(
+      "negative control — no image, no image-specific description",
+      { tag: ["@stable", "@regression", "@agents", "@playground"] },
+      async ({ page }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        await loadAgent(page, options);
+
+        await test.step("run the same prompt with NO image attached", async () => {
+          await setChatInputText(page, PROMPT);
+          await openPlayground(page, /* attachImage */ false);
+          await page.getByTestId("button-send").last().click();
+          await waitForAgentToFinish(page);
+        });
+
+        await test.step("assert the response does not describe a chain", async () => {
+          // With no image the model cannot describe the chain — so the keyword
+          // only appears in Test 1 because the image was actually processed.
+          const response = page.locator(".markdown.prose").last();
+          await expect(response).toBeVisible({ timeout: 60000 });
+          const text = (await response.textContent()) ?? "";
+          expect(text.length).toBeGreaterThan(0);
+          expect(text).not.toMatch(IMAGE_SPECIFIC);
+        });
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #497 — Wave 1 (Milestone 5: Agents & providers).

## What this validates

QA-CHECKLIST **§6.5** — *"Image passed via input handle is processed correctly."* An image attached to the chat input travels through the `ChatInput.message → Agent.input` handle (the template's default wiring) to a **vision-capable** model, and the agent's response **describes the image content** — proving the image was received and processed.

New spec `agent-multimodal-image-input.spec.ts` (+ mirrored spec doc). Parameterized per active provider, resolving a vision-capable chat model (`resolveVisionModel`, skips a provider with none).

### Test 1 — image via input handle is described by the agent
Attach `chain.png` through the chat input widget (`input-wrapper` file input — the only UI image-attach path), which feeds the confirmed `ChatInput → Agent.input` handle.
- **hard:** the reply matches `/chain|link|logo|inkscape/i` **and** is `> 50` chars — the vision model described the actual image.

### Test 2 — negative control: no image, no image-specific description
Same prompt, no image attached.
- **hard:** the reply does **not** match `/chain/i` — with no image the model cannot describe the chain, so Test 1's match is caused by the processed image, not the prompt or chance (positive/negative pattern from `agent-system-prompt.spec.ts`).

**Tags:** `@stable @regression @agents @playground`.

## Notes / scouting (1.11.0.dev33)

- **Mechanism:** the ChatInput **node** on the canvas has only a text field — **no file-attach field**. The only UI path to attach an image is the chat input widget (`input-wrapper`, accepts `image/*`), which flows through the `ChatInput → Agent.input` handle (`handle-agent-shownode-input-left`, `inputTypes [Message]`).
- **Deterministic prompt:** the Playground re-injects the template default (`Hello, how are you?`) **asynchronously**, corrupting text typed directly into the Playground. The prompt is therefore set on the **ChatInput node** (`textarea_str_input_value`) with `waitForFlowSaveSettled`, and the test asserts the Playground prefilled it before sending.
- **Overlap acknowledged:** the image→agent mechanism is shared with `general-bugs-agent-images-playground.spec.ts` (OpenAI-only bug regression). This spec is the named §6.5 home, is provider-parameterized (adds Gemini/active-provider coverage), and adds the negative control.

## Validation

- **Resolved Langflow version:** `1.11.0.dev33` (Langflow Nightly), model `google / gemini-3.5-flash` (`--workers=1`, `--retries=0`).
- **Clean burst: 3/3 green** (2 passed each).
- **Force-failure check** (CONTRIBUTING §2): broke Test 1's content assertion → `1 failed`; broke Test 2's negative-control assertion in isolation → `1 failed` (serial mode skips Test 2 after Test 1 fails, so it was verified via `--grep`). Both reverted.
- `npm run typecheck`: **0 errors**; lint: pre-existing warnings only.
- `QA-CHECKLIST.md` §6.5 bullet flipped to `[x]`; Coverage Summary + Phase 0 regenerated via `npm run coverage:summary`.

> Note: default target resolves to one vision model per **active** provider. In this environment OpenAI is flagged `inactive` by `collect-models` (its probe model `gpt-5.5-pro` has no project access) and Anthropic has no key, so validation ran on Google/Gemini; `resolveVisionModel` covers OpenAI/Anthropic when active.

## Manual run (debug)

\`\`\`bash
MODEL_TEST_ID=gemini-3.5-flash MODEL_TEST_PROVIDER=google \
npx playwright test tests/tests-automations/regression/core-functionality/llm-agents/agent-multimodal-image-input.spec.ts \
  --workers=1 --debug
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)