### PR TITLE
test(llm-agents): agent stops at configured max iterations (#481)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -330,7 +330,7 @@
 - [x] Playground shows error when LLM run endpoint returns 500 (mocked invalid API key) → `llm-agents/llm-invalid-api-key-ui.spec.ts`
 - [x] Playground input remains usable after API error (mocked) → `llm-agents/llm-invalid-api-key-ui.spec.ts`
 - [ ] Agent stops when configured stop condition is reached
-- [ ] Agent stops when maximum number of iterations is reached → `agent-max-iterations.spec.ts`
+- [x] Agent stops when maximum number of iterations is reached → `core-functionality/llm-agents/agent-max-iterations.spec.ts`
 - [ ] Agent with multiple configured tools executes correctly → `agent-multi-tool-selection.spec.ts`
 - [ ] Agent with configured timeout respects the limit
 - [x] Connecting an external model in Agent drops the prior model selection (connection-mode isolation, prevents stale provider config) → `llm-agents/agent-model-connection-isolation.spec.ts`
@@ -415,7 +415,7 @@
 - [ ] Temperature parameter (verify via network payload) → `agent-max-tokens.spec.ts`
 - [ ] Reasoning effort parameter — conditional field based on model → `agent-reasoning-effort.spec.ts`
 - [ ] Maximum token count — response truncated as configured → `agent-max-tokens.spec.ts`
-- [ ] Maximum agent iterations → `agent-max-iterations.spec.ts`
+- [x] Maximum agent iterations → `core-functionality/llm-agents/agent-max-iterations.spec.ts`
 - [ ] Use of custom `context_id` for memory isolation → `agent-context-id-isolation.spec.ts`
 - [ ] Output formatting (JSON via output_schema, Markdown, plain text) → `agent-structured-output.spec.ts`
 
@@ -756,8 +756,8 @@
 | `core-components/` — Core Components | 82 | 79 | 0 | 1 | 2 |
 | `core-functionality/auth/` | 21 | 8 | 13 | 0 | 0 |
 | `core-functionality/knowledge-ingestion/` | 8 | 0 | 4 | 0 | 4 |
-| `core-functionality/llm-agents/` | 40 | 18 | 2 | 0 | 20 |
-| `core-functionality/model-provider/` | 33 | 11 | 13 | 0 | 9 |
+| `core-functionality/llm-agents/` | 40 | 19 | 2 | 0 | 19 |
+| `core-functionality/model-provider/` | 33 | 12 | 13 | 0 | 8 |
 | `core-functionality/observability-monitoring/` | 23 | 15 | 7 | 0 | 1 |
 | `core-functionality/playground/` | 48 | 43 | 3 | 1 | 1 |
 | `core-functionality/project-management/` | 11 | 4 | 6 | 1 | 0 |
@@ -767,7 +767,7 @@
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 44 | 7 | 36 | 1 | 0 |
 | `ui-ux/` — Settings | 7 | 3 | 3 | 1 | 0 |
-| **TOTAL** | **451** | **233 (52%)** | **167 (37%)** | **7 (2%)** | **44 (10%)** |
+| **TOTAL** | **451** | **235 (52%)** | **167 (37%)** | **7 (2%)** | **42 (9%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -783,7 +783,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 244 `test()` calls carrying the `@stable` tag, distributed across 87 spec
+> 246 `test()` calls carrying the `@stable` tag, distributed across 88 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -934,6 +934,8 @@
 - [x] empty response does not crash the component → `agent-empty-refusal-response.spec.ts`
 - [x] input via ChatInput handle drives the agent response → `agent-input-sources.spec.ts`
 - [x] input via the Agent's direct field drives the agent response → `agent-input-sources.spec.ts`
+- [x] agent stops when max iterations is reached → `agent-max-iterations.spec.ts`
+- [x] causal control — a high max iterations does not hit the limit → `agent-max-iterations.spec.ts`
 - [x] selecting 'Connect other models' clears the previously selected model → `agent-model-connection-isolation.spec.ts`
 - [x] image via input handle is described by the agent → `agent-multimodal-image-input.spec.ts`
 - [x] negative control — no image, no image-specific description → `agent-multimodal-image-input.spec.ts`
@@ -1067,8 +1069,8 @@
 | `core-components/` — Component Config | 18 | 1 |
 | `core-components/` — Core Components | 0 | 2 |
 | `core-functionality/auth/` | 13 | 0 |
-| `core-functionality/llm-agents/` | 2 | 20 |
-| `core-functionality/model-provider/` | 13 | 9 |
+| `core-functionality/llm-agents/` | 2 | 19 |
+| `core-functionality/model-provider/` | 13 | 8 |
 | `core-functionality/playground/` | 3 | 1 |
 | `mcp/client/` | 7 | 2 |
 | `mcp/server/` | 3 | 4 |

--- a/docs/core-functionality/llm-agents/agent-max-iterations.md
+++ b/docs/core-functionality/llm-agents/agent-max-iterations.md
@@ -1,0 +1,190 @@
+# Agent Max Iterations — agent stops at the configured limit
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+The Agent's **Max Iterations** control caps the agent's model-call loop
+(QA-CHECKLIST §6.2 "Agent stops when maximum number of iterations is reached" and
+§7.7 "Maximum agent iterations"). When the loop reaches the configured limit, the
+agent stops and returns the terminal message **`Model call limits exceeded: run
+limit (N/N)`** instead of completing the task.
+
+Two tests establish this **causally**:
+
+1. **Limit enforced** — with `max_iterations = 1` and a task that requires
+   several tool-calling iterations, the agent stops at the limit and returns
+   `Model call limits exceeded: run limit (1/1)`.
+2. **Causal control** — with a **high** `max_iterations` and the *same* task, the
+   agent completes and returns the correct final answer (no limit message). This
+   proves the stop in Test 1 was caused by the low limit, not an unrelated
+   failure.
+
+> **Bug status (2026-07-06, nightly 1.11.0.dev33):** issue #481 flagged a
+> "confirmed backend bug — parameter ignored in backend execution" and asked to
+> gate the spec as *expected-fail*. Reproduction on dev33 shows the parameter is
+> now **respected** (`max_iterations=1` → `run limit (1/1)`; `max_iterations=8` →
+> completes). The bug appears **fixed**, so this is authored as a normal passing
+> `@stable` test, not an expected-fail. Flagged on the issue/PR.
+
+If this fails, the agent no longer honours its iteration cap — a regression in a
+core safety/cost control.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@agents` `@playground`
+
+`@stable` added only after multiple clean `--retries=0` runs on the fresh nightly.
+`@regression` — guards the max-iterations enforcement from regressing (the bug
+#481 documented); `@agents` — agent execution; `@playground` — the flow is run
+through the Playground.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- `models.json` / `providers.json` generated via
+  `npx playwright test tests/collect-models.spec.ts`.
+- At least one active provider API key in `.env`.
+- Run with `--workers=1` (agent specs create named flows that collide in
+  parallel). File is serial (`SimpleAgentTemplatePage.load()` wipes all flows).
+
+---
+
+## Step by step *(required)*
+
+The spec generates **2 tests per active model** via `getTestTargets()` (default:
+1 model per active provider). The limit message and the arithmetic answer are
+provider-agnostic (Langflow-level), so any chat model works.
+
+Shared setup per test (identical except `max_iterations`):
+- Load the Simple Agent template (ships a URL fetch tool).
+- Set the Agent Instructions (`textarea_str_system_prompt`) to force use of the
+  URL fetch tool for any URL question, so the agent **attempts a tool call** —
+  which needs more than one model call — instead of answering in one shot.
+- Open the Agent **Controls** dialog (`edit-button-modal`); set
+  `int_int_edit_max_iterations`; close (`edit-button-close`).
+- Set the task on the **ChatInput node** (`textarea_str_input_value`) and
+  `waitForFlowSaveSettled` (the Playground prompt pre-fills from the node —
+  typing into the Playground races an async default re-injection; see
+  `agent-multimodal-image-input.md`).
+- Open the Playground and send; wait for the agent to finish.
+
+The task targets the running instance's own version endpoint
+(`http://localhost:7860/api/v1/version`): the model cannot know the exact nightly
+version, so it always **attempts** the fetch (a famous page like example.com is
+memorised and answered inline; arithmetic is computed inline — both verified
+flaky). The fetch is SSRF-blocked backend-side, but that is irrelevant — the
+**attempt consumes an iteration**, which is what proves the cap.
+
+---
+
+**Test 1 — agent stops when max iterations is reached** (§6.2 / §7.7)
+
+1. Shared setup with `max_iterations = 1`.
+2. **Validation:** the AI message contains `Model call limits exceeded` **and**
+   the cap `(1/1)` — the tool-call attempt exceeds the limit of 1 and the agent
+   stops.
+
+---
+
+**Test 2 — causal control: a high limit does not hit the cap** (§6.2 / §7.7)
+
+1. Shared setup, identical task, with a **high** `max_iterations` (`20`).
+2. **Validation:** the run finishes with a non-empty AI message that does **not**
+   contain `Model call limits exceeded` — with headroom the agent completes (a
+   few attempts, well under 20) without hitting the cap. Only `max_iterations`
+   differs between the two tests, so Test 1's stop is attributable to the cap.
+
+---
+
+## Validation criterion *(required)*
+
+- **Limit enforced (Test 1):** `max_iterations=1` → the AI response is
+  `Model call limits exceeded: run limit (1/1)` (the `(1/1)` ties the stop to the
+  configured value).
+- **Causal control (Test 2):** a high `max_iterations` → the run finishes without
+  the limit message. Same task, only the cap differs — so the pair proves the cap
+  is respected and causal, not coincidental.
+
+## Guarding against false positives *(how)*
+
+- **Causal pair:** the only difference between Test 1 (stops) and Test 2
+  (completes) is the `max_iterations` value — so the stop is attributable to the
+  parameter, not to a flaky failure. Test 1 also asserts the exact cap `(1/1)`.
+- **Unbypassable tool forcing:** the task targets the instance's own version
+  endpoint, whose value the model cannot know, so it must attempt the URL tool —
+  guaranteeing more than one model call, so a limit of 1 genuinely trips (a
+  calculator task and a famous page like example.com are answered inline —
+  verified flaky; see Notes).
+- **Non-empty completion:** Test 2 asserts a non-empty final message without the
+  limit marker, so a blank/aborted run cannot silently pass the negative check.
+- **Force-failure check** (CONTRIBUTING §2) run during VERIFY on each hard
+  assertion before `@stable`.
+
+---
+
+## What this test does not cover *(optional)*
+
+- The numeric count of individual tool invocations (Langflow does not surface a
+  reliable per-iteration counter in the UI; the `run limit (N/N)` message is the
+  observable used instead).
+- `max_tokens` / other agent controls (separate specs).
+- Tool execution correctness (see `agent-component-regression.spec.ts`).
+
+---
+
+## External dependencies *(required)*
+
+- `src/backend/base/langflow/components/agents/` — the Agent executor and its
+  `max_iterations` enforcement; the fix this spec guards lives here.
+- `src/frontend/src/CustomNodes/GenericNode/` — the Agent **Controls** dialog
+  (`int_int_edit_max_iterations`).
+- `src/frontend/src/components/core/playgroundComponent/` — Playground I/O and
+  the AI message bubble carrying the `Model call limits exceeded` message.
+- The Simple Agent template's **URL fetch tool** — the forcer that makes the
+  agent enter its tool loop (no external network needed — the target is the
+  instance's own SSRF-blocked version endpoint; the attempt is what matters).
+- Provider LLM API — a live key; the agent makes real model calls.
+
+---
+
+## When to review this test *(optional)*
+
+- If the terminal message wording changes from `Model call limits exceeded: run
+  limit (N/N)`.
+- If the Agent Controls field testids change
+  (`int_int_edit_max_iterations`, `toggle_bool_edit_add_calculator_tool`).
+- If the Simple Agent template or the calculator tool is renamed/rewired.
+
+---
+
+## Notes *(optional)*
+
+- **Observable found during reproduction:** setting `max_iterations=1` yields the
+  AI message `Model call limits exceeded: run limit (1/1)`; a high limit
+  completes. This is a clean, deterministic signal — far more robust than
+  counting reasoning steps in the DOM.
+- **Why a URL-fetch task to an unknowable endpoint, not a calculator or a famous
+  page:** "iterations" count the agent's **tool-calling loop**, not the final
+  answer, so the cap only trips when the agent actually enters the loop. A capable
+  model (Gemini) bypasses a calculator by computing inline (~40% of runs), and
+  answers a famous page like example.com from memory (its heading is memorised) —
+  both verified flaky, and `max_iterations=0` does not trip a directly-answerable
+  task. Targeting the instance's own `/api/v1/version` (an unknowable nightly
+  string) forces the model to **attempt** the fetch every time (verified 2/2 trip
+  at limit 1). The fetch is SSRF-blocked backend-side, but that is irrelevant: the
+  attempt consumes the iteration. At the high limit the agent tries a few address
+  variants and gives up well under 20, so it never hits the cap (verified 2/2).
+- **Prompt via the ChatInput node:** the Playground re-injects the template
+  default asynchronously; setting the task on the ChatInput node (then
+  `waitForFlowSaveSettled`) makes the prompt deterministic (see
+  `agent-multimodal-image-input.md`).
+- **Expected-fail deliberately NOT used:** #481 requested it for a backend bug
+  that reproduction shows is fixed on dev33; a `test.fail()` gate would report an
+  immediate unexpected pass. Documented on the issue/PR.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-max-iterations.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-max-iterations.spec.ts
@@ -1,0 +1,277 @@
+import * as dotenv from "dotenv";
+import path from "path";
+import fs from "fs";
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
+import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import {
+  hasProviderEnvKeys,
+  missingProviderEnvKeys,
+  providerConfigMap,
+  type Provider,
+} from "../../../../helpers/provider-setup";
+import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+
+/**
+ * Agent Max Iterations (QA-CHECKLIST §6.2 "Agent stops when maximum number of
+ * iterations is reached" and §7.7 "Maximum agent iterations").
+ *
+ *   Test 1 — max_iterations=1 on a task that makes the agent attempt a tool call:
+ *            the attempt exceeds the limit and the agent returns
+ *            "Model call limits exceeded: run limit (1/1)".
+ *   Test 2 — causal control: the SAME task with a high max_iterations finishes
+ *            WITHOUT the limit message — only the cap differs, so Test 1's stop
+ *            is attributable to the cap, not an unrelated failure.
+ *
+ * Issue #481 flagged a backend bug (parameter ignored) and asked to gate this
+ * expected-fail. Reproduction on 1.11.0.dev33 shows the parameter is RESPECTED
+ * (1 → run limit (1/1); high → finishes), so this is a normal passing @stable test.
+ */
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
+}
+
+// Force a real tool-calling loop with data the model CANNOT fabricate, so it must
+// call the URL tool — guaranteeing more than one model call, so a limit of 1 is
+// genuinely exceeded. The target is the running instance's own version endpoint:
+// the model cannot know the exact nightly version, so it always attempts the
+// fetch (unlike a famous page like example.com, whose contents it has memorised,
+// or an arithmetic task it computes inline). The fetch itself is SSRF-blocked
+// backend-side, but that is irrelevant — the *attempt* consumes the iteration,
+// which is what proves the cap. See the spec doc for the full rationale.
+const TARGET_URL = "http://localhost:7860/api/v1/version";
+const SYSTEM_PROMPT =
+  "You have web tools. To answer any question about a URL you MUST call the URL fetch tool. Never guess or invent responses.";
+const TASK = `Fetch ${TARGET_URL} and tell me the exact "version" value it returns.`;
+const LIMIT_MESSAGE = /model call limits exceeded/i;
+const HIGH_LIMIT = "20";
+
+interface ModelRecord {
+  provider: string;
+  model: string;
+}
+
+interface TestTarget {
+  label: string;
+  options: LoadSimpleAgentOptions;
+  skipReason?: string;
+}
+
+function getProviderSkipReasons(): Map<string, string> {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/providers.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
+    return new Map();
+  }
+  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
+  const reasons = new Map<string, string>();
+  for (const r of records) {
+    if (r.status === "inactive") {
+      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
+    }
+  }
+  return reasons;
+}
+
+function getModelsFromJson(): ModelRecord[] {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/models.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("models.json not found — run collect-models.spec.ts first.");
+    return [];
+  }
+  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
+}
+
+function getTestTargets(): TestTarget[] {
+  const skipReasons = getProviderSkipReasons();
+
+  if (process.env.MODEL_TEST_ID) {
+    const model = process.env.MODEL_TEST_ID;
+    const allModels = getModelsFromJson();
+    const record = allModels.find((m) => m.model === model);
+    if (!record) {
+      console.warn(`MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred.`);
+      return [{ label: `model:${model}`, options: { model } }];
+    }
+    const provider = record.provider as Provider;
+    return [{
+      label: `${provider} / ${model}`,
+      options: { provider, model },
+      skipReason: skipReasons.get(provider),
+    }];
+  }
+
+  const allModels = getModelsFromJson();
+  if (allModels.length === 0) {
+    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
+    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
+    return [{
+      label: `provider:${fallbackProvider} (fallback)`,
+      options: { provider: fallbackProvider },
+      skipReason: skipReasons.get(fallbackProvider),
+    }];
+  }
+
+  let models = allModels;
+  if (process.env.MODEL_TEST_PROVIDER) {
+    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
+  } else if (process.env.ALL_MODELS !== "true") {
+    const seen = new Set<string>();
+    models = models.filter((m) => {
+      if (seen.has(m.provider)) return false;
+      seen.add(m.provider);
+      return true;
+    });
+  }
+
+  return models.map((m) => ({
+    label: `${m.provider} / ${m.model}`,
+    options: { provider: m.provider as Provider, model: m.model },
+    skipReason: skipReasons.get(m.provider),
+  }));
+}
+
+async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
+  try {
+    await new SimpleAgentTemplatePage(page).load(options);
+  } catch (e: any) {
+    if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
+    throw e;
+  }
+}
+
+async function waitForAgentToFinish(page: Page): Promise<void> {
+  const stopButton = page.getByRole("button", { name: "Stop" });
+  const stopVisible = await stopButton.isVisible({ timeout: 10000 }).catch(() => false);
+  if (stopVisible) {
+    await expect(stopButton).toBeHidden({ timeout: 120000 });
+  }
+}
+
+// Set the Agent Instructions (system prompt) on the node.
+async function setSystemPrompt(page: Page, prompt: string): Promise<void> {
+  const field = page.getByTestId("textarea_str_system_prompt");
+  await expect(field).toBeVisible({ timeout: 15000 });
+  await field.click();
+  await field.fill(prompt);
+  await field.blur();
+}
+
+// Open the Agent Controls dialog, set max_iterations, and close. The template's
+// URL tool (default) is the forcer — no extra tool needs enabling.
+async function setMaxIterations(page: Page, maxIterations: string): Promise<void> {
+  await page.getByTestId("edit-button-modal").click();
+  const maxIter = page.getByTestId("int_int_edit_max_iterations");
+  await expect(maxIter).toBeVisible({ timeout: 15000 });
+  await maxIter.scrollIntoViewIfNeeded();
+  await maxIter.fill(maxIterations);
+  await page.getByTestId("edit-button-close").click();
+}
+
+// Set the task on the ChatInput node (the Playground prompt pre-fills from it;
+// typing into the Playground races an async default re-injection).
+async function setChatInputText(page: Page, text: string): Promise<void> {
+  const field = page.locator(
+    '[data-testid^="rf__node-ChatInput"] [data-testid="textarea_str_input_value"]',
+  );
+  await expect(field).toBeVisible({ timeout: 15000 });
+  await field.click();
+  await field.fill(text);
+  await field.blur();
+}
+
+// Run the configured flow through the Playground and return the AI message
+// bubble locator. Callers assert with toContainText (auto-retrying) — reading
+// innerText once can catch a partially-streamed message right after the run ends.
+async function runAndGetBubble(page: Page) {
+  await page.getByTestId("playground-btn-flow-io").click();
+  const chatInput = page.getByTestId("input-chat-playground").last();
+  await expect(chatInput).toBeVisible({ timeout: 30000 });
+  await expect(chatInput).toHaveValue(TASK, { timeout: 15000 });
+  await page.getByTestId("button-send").last().click();
+  await waitForAgentToFinish(page);
+  const bubble = page.getByTestId("div-chat-message").last();
+  await expect(bubble).toBeVisible({ timeout: 30000 });
+  return bubble;
+}
+
+const targets = getTestTargets();
+
+// SimpleAgentTemplatePage.load() deletes all flows before loading the template;
+// serial mode + --workers=1 keeps the shared instance state deterministic.
+test.describe.configure({ mode: "serial" });
+
+for (const { label, options, skipReason } of targets) {
+  const provider = options.provider ?? (Object.keys(providerConfigMap)[0] as Provider);
+
+  test.describe(`Agent Max Iterations [${label}]`, () => {
+    test(
+      "agent stops when max iterations is reached",
+      { tag: ["@stable", "@regression", "@agents", "@playground"] },
+      async ({ page }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        await loadAgent(page, options);
+
+        await test.step("force a tool call, cap max_iterations at 1, set the task", async () => {
+          await setSystemPrompt(page, SYSTEM_PROMPT);
+          await setMaxIterations(page, "1");
+          await setChatInputText(page, TASK);
+          await waitForFlowSaveSettled(page);
+        });
+
+        await test.step("run and assert the agent stops at the limit", async () => {
+          const bubble = await runAndGetBubble(page);
+          // Limit enforced: the agent stopped at the configured cap of 1.
+          await expect(bubble).toContainText(LIMIT_MESSAGE, { timeout: 30000 });
+          // run limit (1/1) ties the stop to max_iterations=1.
+          await expect(bubble).toContainText(/\(\s*1\s*\/\s*1\s*\)/, { timeout: 10000 });
+        });
+      },
+    );
+
+    test(
+      "causal control — a high max iterations does not hit the limit",
+      { tag: ["@stable", "@regression", "@agents", "@playground"] },
+      async ({ page }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        await loadAgent(page, options);
+
+        await test.step("force a tool call, allow a high max_iterations, set the task", async () => {
+          await setSystemPrompt(page, SYSTEM_PROMPT);
+          await setMaxIterations(page, HIGH_LIMIT);
+          await setChatInputText(page, TASK);
+          await waitForFlowSaveSettled(page);
+        });
+
+        await test.step("run and assert the run finishes without hitting the limit", async () => {
+          const bubble = await runAndGetBubble(page);
+          const reply = (await bubble.innerText()).trim();
+          // Same task as Test 1, but with headroom to iterate: the agent finishes
+          // (a few attempts, well under the high limit) WITHOUT the limit message.
+          // Only max_iterations differs between the two tests — so the stop in
+          // Test 1 is attributable to the cap, not an unrelated failure.
+          expect(reply.length).toBeGreaterThan(0);
+          expect(reply).not.toMatch(LIMIT_MESSAGE);
+        });
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #481 — Wave 1 (Milestone 5: Agents & providers).

## What this validates

QA-CHECKLIST **§6.2** ("Agent stops when maximum number of iterations is reached") and **§7.7** ("Maximum agent iterations"). The Agent's **Max Iterations** control (`int_int_edit_max_iterations`) caps its model-call loop; when reached, the agent returns the terminal message **`Model call limits exceeded: run limit (N/N)`**.

New spec `agent-max-iterations.spec.ts` (+ mirrored spec doc), parameterized per active provider.

### Test 1 — agent stops when max iterations is reached
`max_iterations=1` on a task that makes the agent **attempt** a URL tool call → the attempt exceeds the cap.
- **hard:** the AI message contains `Model call limits exceeded` **and** the cap `(1/1)` (the `(1/1)` ties the stop to the configured value).

### Test 2 — causal control: a high limit does not hit the cap
The **same task**, `max_iterations=20`.
- **hard:** a non-empty AI message that does **not** contain the limit message. Only `max_iterations` differs between the two tests, so Test 1's stop is attributable to the cap, not an unrelated failure.

## ⚠️ Deviation from the issue: expected-fail → passing test

The issue asked to gate this **expected-fail** for a "confirmed backend bug — parameter ignored in backend execution." **Reproduction on `1.11.0.dev33` shows the parameter is now RESPECTED** (`max_iterations=1` → `run limit (1/1)`; high limit → finishes). The bug appears **fixed**, so a `test.fail()` gate would report an immediate *unexpected pass*. This is therefore authored as a normal passing `@stable` test. Please confirm the bug is considered resolved.

## Determinism note (why this specific task)

"Iterations" count the agent's **tool-calling loop**, not the final answer, so the cap only trips when the agent actually enters the loop. Reproduction found two flaky forcers: a capable model (Gemini) **computes arithmetic inline** (~40% of runs) and **answers a famous page like example.com from memory** — neither reliably enters the loop. The task therefore targets the instance's own `/api/v1/version` (an **unknowable** nightly string), so the model always **attempts** the fetch. The fetch is SSRF-blocked backend-side, but that is irrelevant — the *attempt* consumes the iteration, which is what proves the cap. No external network dependency (httpbin was rejected as flaky — 503s).

**Tags:** `@stable @regression @agents @playground`.

## Validation

- **Resolved Langflow version:** `1.11.0.dev33` (Langflow Nightly), model `google / gemini-3.5-flash` (`--workers=1`, `--retries=0`).
- **Clean burst: 5/5 green** (2 passed each) — after root-causing and eliminating the forcer flake.
- **Force-failure check** (CONTRIBUTING §2): broke Test 1's limit-message assertion → `1 failed`; broke Test 2's negative assertion in isolation → `1 failed` (serial mode skips Test 2 after Test 1 fails, so verified via `--grep`). Both reverted.
- `npm run typecheck`: **0 errors**; lint: pre-existing warnings only.
- `QA-CHECKLIST.md` §6.2 and §7.7 bullets flipped to `[x]`; Coverage Summary + Phase 0 regenerated via `npm run coverage:summary`.

> Note: default target resolves to one model per **active** provider. OpenAI is flagged `inactive` by `collect-models` (probe model `gpt-5.5-pro` has no project access) and Anthropic has no key, so validation ran on Google/Gemini.

## Manual run (debug)

\`\`\`bash
MODEL_TEST_ID=gemini-3.5-flash MODEL_TEST_PROVIDER=google \
npx playwright test tests/tests-automations/regression/core-functionality/llm-agents/agent-max-iterations.spec.ts \
  --workers=1 --debug
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)