### PR TITLE
test(llm-agents): n_messages limits retained messages via deterministic count (#482)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -343,7 +343,7 @@
 - [x] Message History retains context between messages in the same Playground session → `llm-agents/memory-history-regression.spec.ts`
 - [x] Session isolation: distinct session IDs have independent histories → `llm-agents/memory-history-regression.spec.ts`
 - [x] Without Message History, LLM does not retain context between messages → `llm-agents/memory-history-regression.spec.ts`
-- [ ] n_messages parameter limits the number of retained messages → `agent-n-messages-limit.spec.ts` (**confirmed bug**: value saved correctly by frontend but ignored in backend execution)
+- [x] n_messages parameter limits the number of retained messages → `llm-agents/agent-n-messages-limit.spec.ts` (bug reported fixed on 1.11.0.dev33 — parameter now respected; validated by deterministic message count)
 - [ ] Agent uses custom `context_id` — continuity between session messages → `agent-context-id-continuity.spec.ts`
 - [ ] Switching `context_id` isolates history between distinct sessions → `agent-context-id-isolation.spec.ts`
 
@@ -756,7 +756,7 @@
 | `core-components/` — Core Components | 82 | 79 | 0 | 1 | 2 |
 | `core-functionality/auth/` | 21 | 8 | 13 | 0 | 0 |
 | `core-functionality/knowledge-ingestion/` | 8 | 0 | 4 | 0 | 4 |
-| `core-functionality/llm-agents/` | 40 | 19 | 2 | 0 | 19 |
+| `core-functionality/llm-agents/` | 40 | 20 | 2 | 0 | 18 |
 | `core-functionality/model-provider/` | 33 | 12 | 13 | 0 | 8 |
 | `core-functionality/observability-monitoring/` | 23 | 15 | 7 | 0 | 1 |
 | `core-functionality/playground/` | 48 | 43 | 3 | 1 | 1 |
@@ -767,7 +767,7 @@
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 44 | 7 | 36 | 1 | 0 |
 | `ui-ux/` — Settings | 7 | 3 | 3 | 1 | 0 |
-| **TOTAL** | **451** | **235 (52%)** | **167 (37%)** | **7 (2%)** | **42 (9%)** |
+| **TOTAL** | **451** | **236 (52%)** | **167 (37%)** | **7 (2%)** | **41 (9%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -783,7 +783,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 246 `test()` calls carrying the `@stable` tag, distributed across 88 spec
+> 248 `test()` calls carrying the `@stable` tag, distributed across 89 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -939,6 +939,8 @@
 - [x] selecting 'Connect other models' clears the previously selected model → `agent-model-connection-isolation.spec.ts`
 - [x] image via input handle is described by the agent → `agent-multimodal-image-input.spec.ts`
 - [x] negative control — no image, no image-specific description → `agent-multimodal-image-input.spec.ts`
+- [x] a small n_messages truncates retrieval to the most recent messages → `agent-n-messages-limit.spec.ts`
+- [x] causal control — a large n_messages retrieves the full seeded history → `agent-n-messages-limit.spec.ts`
 - [x] Agent Instructions are respected in the model response → `agent-system-prompt.spec.ts`
 - [x] negative control — sentinel is absent without the instruction → `agent-system-prompt.spec.ts`
 - [x] user must be able to send images in the playground with the agent component → `general-bugs-agent-images-playground.spec.ts`
@@ -1069,7 +1071,7 @@
 | `core-components/` — Component Config | 18 | 1 |
 | `core-components/` — Core Components | 0 | 2 |
 | `core-functionality/auth/` | 13 | 0 |
-| `core-functionality/llm-agents/` | 2 | 19 |
+| `core-functionality/llm-agents/` | 2 | 18 |
 | `core-functionality/model-provider/` | 13 | 8 |
 | `core-functionality/playground/` | 3 | 1 |
 | `mcp/client/` | 7 | 2 |

--- a/docs/core-functionality/llm-agents/agent-n-messages-limit.md
+++ b/docs/core-functionality/llm-agents/agent-n-messages-limit.md
@@ -1,0 +1,199 @@
+# n_messages — limits the number of retained messages
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+The **Number of Messages** control (`n_messages`) limits how many past chat
+messages are retrieved from a session's memory (QA-CHECKLIST §6.3, "n_messages
+parameter limits the number of retained messages"). The limit is proven by a
+**deterministic count**, not by model recall:
+
+1. Seed a session with a known number of messages (5 chat runs → 10 stored
+   messages: one `User` + one `AI` per run) via `POST /api/v1/run`.
+2. Point a **Message History** component (mode *Retrieve*) at that session and
+   run it on the canvas.
+3. Count the messages in its output: with `n_messages = 2` exactly the **2 most
+   recent** messages come back; with `n_messages = 100` all **10** come back.
+
+Two tests form a **causal pair** — only `n_messages` differs between them, so
+the truncation in Test 1 is attributable to the limit and nothing else.
+
+> **Design note — why Message History and not Agent recall (issue #482):** the
+> issue targets the Agent's `n_messages`, whose only observable through the
+> Agent is *model recall* of an old message. Reproduction on nightly
+> 1.11.0.dev33 showed recall at the window threshold is genuinely
+> non-deterministic (the retained window's effect on model answers varies
+> run-to-run — three sentinel placements all flaked at spec level), making an
+> `@stable` recall test untenable. Both the Agent and the Message History
+> component resolve memory through the same backend retrieval
+> (`aget_messages` with `limit=n_messages`, flow-scoped), so counting the
+> Message History output validates the same §6.3 contract deterministically.
+> The unit shift is flagged on the issue/PR.
+
+> **Bug status (2026-07-06, nightly 1.11.0.dev33):** issue #482 flagged a
+> "confirmed backend bug — value saved by frontend but ignored in backend
+> execution" and asked to gate the spec as *expected-fail*. Reproduction on
+> dev33 shows the parameter is now **respected** (n=2 → 2 messages; n=100 →
+> all 10; Agent recall with n=100 also recalls). The bug appears **fixed**, so
+> this is authored as a normal passing `@stable` test, not an expected-fail.
+> Flagged on the issue/PR.
+
+If this fails, memory retrieval no longer bounds its history — a memory/cost
+regression (and a re-opening of the #482 bug).
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@agents` `@components`
+
+`@stable` added only after multiple clean `--retries=0` runs on the fresh
+nightly. `@regression` — guards the `n_messages` enforcement from regressing
+(the bug #482 documented); `@agents` — the §6.3 agent-memory contract this
+covers; `@components` — the behavior is exercised through canvas component
+configuration (Message History fields + node run).
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- **No provider API key required** — the flow is a Chat Input → Chat Output
+  passthrough and the Message History retrieval is model-free.
+- No `--workers=1` requirement: each test creates its own uniquely-named flow
+  via the API and deletes it afterwards (no template wipe, no shared state).
+
+---
+
+## Step by step *(required)*
+
+Shared setup per test (all data is per-run unique):
+
+1. Create a temporary API key (`POST /api/v1/api_key/`) — the `/run` endpoint
+   requires `x-api-key` auth.
+2. Create a Chat Input → Chat Output passthrough flow via
+   `createRunnableChatFlowViaApi` (unique name, torn down after the test).
+3. **Seed** the session: 5 × `POST /api/v1/run/{flowId}` with
+   `input_value = "<sentinel>-<i>"` (i = 1…5) and a per-run
+   `session_id = nmsg-<Date.now()>-<rand>`. Each run stores 2 messages (User +
+   Machine echo) → **10 messages** total.
+4. **Verify the seed** via `GET /api/v1/monitor/messages?session_id=…` — the
+   count must be exactly 10 before any retrieval assertion (a failed seed must
+   fail here, not silently pass an empty-output check later).
+5. Open the same flow in the UI (`/flow/{flowId}`) and add the **Message
+   History** component from the sidebar (`add-component-button-message-history`;
+   node renders as `rf__node-Memory-*`). Retrieval is **flow-scoped**
+   (issue #13059 / PR #13087), so the component must live in the same flow that
+   seeded the session.
+6. Expose the hidden fields via the node's **edit-fields** panel
+   (`edit-fields-button` → toggles `shown_messages`, `showsession_id`), then
+   fill `int_int_n_messages` and `popover-anchor-input-session_id`; wait for
+   the flow save to settle.
+7. Run the node (`button_run_message history`, mode tab *Retrieve* is the
+   default), wait for **built successfully**.
+8. Open the output inspector (`output-inspection-messages-memory`) and read the
+   retrieved text from its `textarea`. The default template renders one line
+   per message (`{sender_name}: {text}`), so occurrences of the sentinel
+   prefix count the retrieved messages exactly.
+
+---
+
+**Test 1 — a small n_messages truncates retrieval to the most recent messages** (§6.3)
+
+- `n_messages = 2`.
+- **Validation:** the inspector text contains **exactly 2** sentinel
+  occurrences; it contains the newest seed value (`<sentinel>-5`) and does
+  **not** contain the oldest (`<sentinel>-1`) — the limit keeps the most
+  recent slice, and only that slice.
+
+---
+
+**Test 2 — causal control: a large n_messages retrieves the full history** (§6.3)
+
+- `n_messages = 100`, identical seed (its own fresh flow/session).
+- **Validation:** the inspector text contains **exactly 10** sentinel
+  occurrences — every seeded message is retrieved. Only `n_messages` differs
+  from Test 1, so Test 1's truncation is caused by the limit.
+
+---
+
+## Validation criterion *(required)*
+
+- **Limit enforced (Test 1):** `n_messages=2` → exactly 2 of the 10 seeded
+  messages are retrieved (newest present, oldest absent).
+- **Causal control (Test 2):** `n_messages=100` → exactly 10 retrieved. The
+  pair proves the retrieved-message count is bounded by `n_messages` and
+  causal, not coincidental.
+
+## Guarding against false positives *(how)*
+
+- **Exact counts (`=== 2`, `=== 10`)**, never `>=` — an unbounded retrieval
+  (the #482 bug) fails Test 1 with count 10; an empty retrieval fails both.
+- **Seed pre-verification:** the monitor API must report exactly 10 stored
+  messages before retrieval is asserted — an incomplete seed cannot masquerade
+  as a working limit.
+- **Per-run sentinel prefix** (`NMSG-<Date.now()>-<rand>`): occurrences cannot
+  come from another session, another test, or leftover data.
+- **Causal pair:** the only difference between the tests is `n_messages`.
+- **Force-failure check** (CONTRIBUTING §2) run during VERIFY on each hard
+  assertion before `@stable`.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Model-visible recall through the **Agent** (recall at the window threshold is
+  non-deterministic — see the design note; the Agent path shares the same
+  backend retrieval).
+- Exact windowing semantics beyond most-recent-N (sender filters, ordering
+  options, `context_id`).
+- External memory backends (Redis, Mem0, …) — only Langflow's internal tables.
+- Session isolation / persistence across reopen (see
+  `memory-history-regression.spec.ts`).
+
+---
+
+## External dependencies *(required)*
+
+- `src/lfx/components/models_and_agents/memory.py` — the Message History
+  (`Memory`) component: `retrieve_messages` applies `limit=n_messages` and the
+  flow-scoped retrieval this spec depends on; the Agent's memory resolves
+  through the same helper.
+- `src/backend/base/langflow/api/v1/endpoints.py` — `POST /api/v1/run`
+  (seeding) and `GET /api/v1/monitor/messages` (seed verification).
+- `src/frontend/src/CustomNodes/GenericNode/` — the node's edit-fields panel
+  (`edit-fields-button`, `shown_messages`, `showsession_id`) and field inputs.
+- `src/frontend/src/modals/` — the component output inspector
+  (`output-inspection-*`, `textarea`).
+
+---
+
+## When to review this test *(optional)*
+
+- If the Message History node type id changes from `Memory` (selector
+  `rf__node-Memory-*`) or the sidebar testid
+  `add-component-button-message-history` changes.
+- If the default retrieve template stops rendering one line per message.
+- If message retrieval stops being flow-scoped (the seed strategy relies on
+  same-flow visibility).
+- If the `/run` endpoint auth model changes (currently `x-api-key` only).
+
+---
+
+## Notes *(optional)*
+
+- **Flow-scoped retrieval is load-bearing:** seeding a session from a
+  *different* flow yields an empty retrieval (cross-flow leak fix, PR #13087)
+  and a disabled inspector button. Seed and retrieve in the same flow.
+- **The output inspector button is disabled until the selected output has
+  non-empty data** — asserting it becomes enabled is itself a signal the
+  retrieval returned content.
+- **`n_messages` keeps the most recent slice** (fetches `DESC` with
+  `limit=n_messages`, then re-orders) — hence Test 1 asserts newest-present /
+  oldest-absent, not an arbitrary window end. This matches the Agent-recall
+  observations from the option-1 investigation (n=100 always recalled).
+- Scouted stability: the full scenario ran 3/3 green at ~10s per run (vs
+  ~2–3 min per LLM recall run), with zero model dependency.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-n-messages-limit.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-n-messages-limit.spec.ts
@@ -1,0 +1,208 @@
+import type { APIRequestContext, Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { createRunnableChatFlowViaApi } from "../../../../helpers/flows/create-runnable-chat-flow-via-api";
+import { addComponentFromSidebar } from "../../../../helpers/flows/add-component-from-sidebar";
+import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+
+/**
+ * n_messages limits the number of retained messages (QA-CHECKLIST §6.3).
+ *
+ * Proven by a deterministic COUNT, not by model recall: seed a session with a
+ * known number of messages (5 API chat runs -> 10 stored messages), point a
+ * Message History component (mode Retrieve) at that session in the SAME flow
+ * (retrieval is flow-scoped — cross-flow leak fix, PR #13087), run the node,
+ * and count the messages in its output inspector.
+ *
+ *   Test 1 — n_messages=2:  exactly the 2 MOST RECENT messages come back.
+ *   Test 2 — causal control, n_messages=100: all 10 come back. Only
+ *            n_messages differs, so Test 1's truncation is caused by the limit.
+ *
+ * Issue #482 flagged a backend bug (value ignored) and asked to gate this
+ * expected-fail. Reproduction on 1.11.0.dev33 shows the parameter is RESPECTED,
+ * so this is a normal passing @stable test. The Agent-recall observable the
+ * issue implies is non-deterministic at the window threshold (three sentinel
+ * designs flaked at spec level); the Agent resolves memory through the same
+ * backend retrieval this component uses, so the count validates the same
+ * contract — deviation flagged on the issue/PR.
+ *
+ * No provider API key and no --workers=1 needed: the flow is a Chat Input ->
+ * Chat Output passthrough created via API with a unique name and deleted after.
+ */
+
+const SEED_RUNS = 5;
+const SEEDED_MESSAGES = SEED_RUNS * 2; // each run stores User + Machine
+
+interface SeededFlow {
+  flowId: string;
+  session: string;
+  sentinel: string;
+  cleanup: () => Promise<void>;
+}
+
+// Create a passthrough flow and seed its session with SEEDED_MESSAGES messages
+// via POST /api/v1/run (x-api-key auth), then verify the exact stored count via
+// the monitor API — a failed seed must fail here, not silently pass an
+// empty-output check later.
+async function seedFlowSession(request: APIRequestContext): Promise<SeededFlow> {
+  const bearer = await getAuthToken(request);
+
+  const keyRes = await request.post("/api/v1/api_key/", {
+    headers: { Authorization: bearer },
+    data: { name: `nmsg-limit-${Date.now()}-${Math.random().toString(36).slice(2, 7)}` },
+  });
+  expect(keyRes.status()).toBe(200);
+  const { api_key: apiKey, id: apiKeyId } = await keyRes.json();
+
+  const { flowId, deleteFlow } = await createRunnableChatFlowViaApi(request, {
+    Authorization: bearer,
+  });
+
+  const sentinel = `NMSG-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const session = `${sentinel}-session`;
+
+  for (let i = 1; i <= SEED_RUNS; i++) {
+    const runRes = await request.post(`/api/v1/run/${flowId}`, {
+      headers: { "x-api-key": apiKey },
+      data: {
+        input_value: `${sentinel}-${i}`,
+        input_type: "chat",
+        output_type: "chat",
+        session_id: session,
+      },
+    });
+    expect(runRes.status()).toBe(200);
+  }
+
+  // Persistence can lag the run response slightly — poll to the exact count.
+  await expect
+    .poll(
+      async () => {
+        const res = await request.get(
+          `/api/v1/monitor/messages?session_id=${session}`,
+          { headers: { Authorization: bearer } },
+        );
+        if (res.status() !== 200) return -1;
+        return ((await res.json()) as unknown[]).length;
+      },
+      { timeout: 15000 },
+    )
+    .toBe(SEEDED_MESSAGES);
+
+  return {
+    flowId,
+    session,
+    sentinel,
+    cleanup: async () => {
+      await deleteFlow();
+      await request
+        .delete(`/api/v1/api_key/${apiKeyId}`, { headers: { Authorization: bearer } })
+        .catch(() => {});
+    },
+  };
+}
+
+// In the seeded flow: add a Message History node, expose its hidden
+// n_messages/session_id fields, point it at the session, run it, and return
+// the retrieved text from the output inspector. The default retrieve template
+// renders one "{sender_name}: {text}" line per message, so sentinel
+// occurrences in the returned text count the retrieved messages exactly.
+async function retrieveViaMessageHistory(
+  page: Page,
+  flowId: string,
+  session: string,
+  nMessages: string,
+): Promise<string> {
+  await page.goto(`/flow/${flowId}`);
+  await page
+    .getByTestId("sidebar-search-input")
+    .waitFor({ state: "visible", timeout: 60000 });
+
+  await addComponentFromSidebar(
+    page,
+    "message history",
+    "add-component-button-message-history",
+  );
+  const node = page.locator('[data-testid^="rf__node-Memory"]').first();
+  await expect(node).toBeVisible({ timeout: 15000 });
+
+  // n_messages and session_id are hidden by default — expose them through the
+  // node's edit-fields panel, then fill them on the node.
+  await page.getByTestId("title-Message History").click();
+  await page.getByTestId("edit-fields-button").click();
+  await page.getByTestId("shown_messages").click();
+  await page.getByTestId("showsession_id").click();
+  await page.keyboard.press("Escape");
+
+  await page.getByTestId("int_int_n_messages").fill(nMessages);
+  await page.getByTestId("popover-anchor-input-session_id").fill(session);
+  await waitForFlowSaveSettled(page);
+
+  await page.getByTestId("button_run_message history").click();
+  await page.waitForSelector("text=built successfully", { timeout: 30000 });
+
+  // The inspector button stays disabled until the selected output has
+  // non-empty data — it becoming enabled already signals a non-empty retrieval.
+  const inspectButton = page.getByTestId("output-inspection-messages-memory");
+  await expect(inspectButton).toBeEnabled({ timeout: 20000 });
+  await inspectButton.click();
+
+  const dialog = page.locator('[role="dialog"]').last();
+  const textarea = dialog.getByTestId("textarea");
+  await expect(textarea).toBeVisible({ timeout: 15000 });
+  return textarea.inputValue();
+}
+
+function countOccurrences(text: string, needle: string): number {
+  return text.split(needle).length - 1;
+}
+
+test.describe("Message History n_messages limit", () => {
+  test(
+    "a small n_messages truncates retrieval to the most recent messages",
+    { tag: ["@stable", "@regression", "@agents", "@components"] },
+    async ({ page, request }) => {
+      const seeded = await seedFlowSession(request);
+      try {
+        const retrieved = await test.step(
+          "retrieve the seeded session with n_messages=2",
+          () => retrieveViaMessageHistory(page, seeded.flowId, seeded.session, "2"),
+        );
+
+        await test.step("assert exactly the 2 most recent messages came back", async () => {
+          // Exact count — an unbounded retrieval (the #482 bug) returns all 10.
+          expect(countOccurrences(retrieved, seeded.sentinel)).toBe(2);
+          // The limit keeps the most recent slice: newest present, oldest absent.
+          expect(retrieved).toContain(`${seeded.sentinel}-${SEED_RUNS}`);
+          expect(retrieved).not.toContain(`${seeded.sentinel}-1`);
+        });
+      } finally {
+        await seeded.cleanup();
+      }
+    },
+  );
+
+  test(
+    "causal control — a large n_messages retrieves the full seeded history",
+    { tag: ["@stable", "@regression", "@agents", "@components"] },
+    async ({ page, request }) => {
+      const seeded = await seedFlowSession(request);
+      try {
+        const retrieved = await test.step(
+          "retrieve the seeded session with n_messages=100",
+          () => retrieveViaMessageHistory(page, seeded.flowId, seeded.session, "100"),
+        );
+
+        await test.step("assert all 10 seeded messages came back", async () => {
+          // Only n_messages differs from Test 1, so Test 1's truncation is
+          // attributable to the limit, not to a broken seed or retrieval.
+          expect(countOccurrences(retrieved, seeded.sentinel)).toBe(SEEDED_MESSAGES);
+          expect(retrieved).toContain(`${seeded.sentinel}-1`);
+          expect(retrieved).toContain(`${seeded.sentinel}-${SEED_RUNS}`);
+        });
+      } finally {
+        await seeded.cleanup();
+      }
+    },
+  );
+});


### PR DESCRIPTION
Closes #482.

Closes the `[ ] n_messages parameter limits the number of retained messages` gap in `QA-CHECKLIST.md` § 6.3 (Memory and Context). Distinct from `memory-history-regression.spec.ts` siblings: those prove memory *works* (retention, session isolation); this proves retrieval is *bounded* by `n_messages`.

## ⚠️ Two deviations from the issue — for maintainer review

**1. Expected-fail NOT used (bug appears fixed).** The issue flags a "confirmed backend bug — value saved by frontend but ignored in backend execution" and asks to gate the spec as expected-fail. Reproduction on nightly **1.11.0.dev33** shows `n_messages` is now **respected** (n=2 → 2 messages retrieved; n=100 → all 10; Agent recall with n=100 also recalls). A `test.fail()` gate would report an immediate misleading "unexpected pass", so this ships as a normal passing `@stable` test that guards the fix against regression.

**2. Unit shift: Message History count instead of Agent recall.** The Agent's only observable for `n_messages` is model recall of an old message, and recall at the window threshold proved genuinely **non-deterministic** on dev33: three sentinel placements (oldest turn, recent turn, middle turn with fillers on both sides) all passed isolated scouts (3/3) yet flaked at spec level (bursts: 0/4, 0/4, 1/5 with `--retries=0`) — the retained window's effect on the model's answer varies run-to-run. Untenable for `@stable`. Both the Agent and the Message History component resolve memory through the same backend retrieval (`aget_messages` with `limit=n_messages`, flow-scoped — `lfx/components/models_and_agents/memory.py`), so counting the Message History output validates the same §6.3 contract deterministically. Evidence from the recall investigation is available on request.

## 1. Covered tests
| # | Test | What it validates |
|---|------|-------------------|
| 1 | `a small n_messages truncates retrieval to the most recent messages` | Seed exactly 10 messages in a session; `n_messages=2` retrieves **exactly 2** — the most recent (newest sentinel present, oldest absent). Catches the #482 regression (limit ignored → all 10 come back). |
| 2 | `causal control — a large n_messages retrieves the full seeded history` | Same seed, `n_messages=100` → **exactly 10** retrieved. Only `n_messages` differs, so Test 1's truncation is attributable to the limit — not a broken seed or empty retrieval. |

## 2. How the test was built
- **Seed via API, count via UI:** 5 × `POST /api/v1/run` (Chat Input → Chat Output passthrough from `createRunnableChatFlowViaApi`, temp `x-api-key`) store exactly 10 messages under a per-run session; the count is then read through real canvas interaction (add component → expose fields → run node → output inspector).
- **Seed pre-verified:** `GET /api/v1/monitor/messages` must report exactly 10 before any retrieval assertion — a failed seed fails loudly instead of passing an empty-output check.
- **Live-confirmed selectors** (scouted on dev33): `add-component-button-message-history`, node `rf__node-Memory-*`, `edit-fields-button` → `shown_messages`/`showsession_id` toggles, `int_int_n_messages`, `popover-anchor-input-session_id`, `button_run_message history`, `output-inspection-messages-memory`, inspector `textarea`.
- **Non-obvious constraint encoded:** message retrieval is **flow-scoped** (cross-flow leak fix, upstream PR #13087) — seeding from a different flow yields an empty retrieval and a disabled inspector button. Seed and retrieve share one flow.
- **Assertion rationale:** exact counts (`=== 2`, `=== 10`), never `>=`; per-run sentinel prefix so occurrences cannot come from another session or leftover data; newest-present/oldest-absent proves the limit keeps the most-recent slice.

## 3. Dependencies
- **None** — no LLM, no provider API key (retrieval is model-free; the passthrough flow echoes input).
- **Parallel-safe** — each test creates its own uniquely-named flow via API and deletes it (plus its temp API key) in `finally`; no template wipe, no `--workers=1`.

## Validation (nightly 1.11.0.dev33, `--retries=0`)
- typecheck ✅ (0 errors) · eslint ✅ (0 errors)
- 6 clean runs, no flake ✅ (~8s per run)
- force-fail ✅ (both count assertions falsified → 2 failed, then restored)
- zero `🚨 Backend Error` ✅
- `QA-CHECKLIST.md` §6.3 bullet flipped to `[x]` + `npm run coverage:summary` regenerated ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
