### PR TITLE
ci(daily-stable): upload raw Playwright JSON report as artifact

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -155,6 +155,22 @@ jobs:
           path: playwright-report/index.html
           retention-days: 90
 
+      # Raw Playwright JSON report (the --reporter=json output already produced
+      # by the "Run @stable tests" step above). Uploaded UNMODIFIED — no
+      # transform, no enrichment — as the machine-readable source of truth for
+      # downstream per-test import/analysis: each test's status, duration,
+      # retries (results[]), error, annotations and projectName plus the run's
+      # stats.startTime. 90-day retention (matching the lightweight index) so a
+      # late/backfill import can still reach it long after the run; the JSON is
+      # small, so the long window costs ~nothing.
+      - name: Upload Playwright JSON report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-json-daily-${{ github.run_id }}
+          path: results.json
+          retention-days: 90
+
       # ── Record in the QA Platform DB: EVERY run (scheduled + manual dispatch).
       # Not gated on `schedule`, so manual runs are recorded too. Coverage is
       # best-effort; the POST is warning-only so a platform outage never fails


### PR DESCRIPTION
## What

Publish the raw Playwright JSON report (`results.json`) produced by the daily
stable run as a downloadable workflow artifact.

## Why

The JSON reporter output is already generated on every run (`--reporter=json` +
`PLAYWRIGHT_JSON_OUTPUT_NAME` in the `Run @stable tests` step) and is consumed
internally by `build-run-payload.mjs`, `append-weekly-history.mjs` and the
`auto-remove-stable` action — but it is never exposed as an artifact. The QA
Platform only receives a derived payload (counts, version, evidence URL), not
the raw per-test data. This exposes the file as-is so downstream tooling can
consume the raw per-test detail (status, duration, retries, error, annotations,
projectName + run `stats.startTime`).

## Change

A single `Upload Playwright JSON report` step, next to the existing report
uploads:

- `path: results.json` — the file as produced, **unmodified** (no transform, no
  enrichment).
- `retention-days: 90` — matching the lightweight index, so a late/backfill
  import can still reach it long after the run; the JSON is small, so the long
  window costs ~nothing.
- `if: always()` — uploads on scheduled, manual and failing runs.

No behavior change to the suite, existing artifacts, history, payload or issue
steps — this only surfaces a file that was already produced.
