### PR TITLE
ci(daily-stable): open the umbrella failure issue on scheduled runs only

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -291,15 +291,18 @@ jobs:
           max_auto_remove: "5"
           run_label: "daily #${{ github.run_id }}"
 
-      # Open a triage issue on failure for BOTH scheduled and manual runs — a
-      # manual re-run of a red build should also surface a tracked issue. (The
-      # history steps above stay schedule-only; only issue-opening is broadened.)
+      # Open the umbrella triage issue on failure — scheduled runs ONLY, aligned
+      # with the history / auto-remove steps above. A manual dispatch is itself a
+      # triage/experiment run: if it surfaces something real we open a specific
+      # issue by hand following the triage rule (a hard failure, or a flaky that
+      # recurs 2+ times), so an auto-umbrella on manual runs would just be noise.
       - name: Create issue on failure
-        if: failure()
+        if: failure() && github.event_name == 'schedule'
         uses: actions/github-script@v7
         env:
           IMAGE: ${{ inputs.langflow_image || 'langflowai/langflow-nightly' }}:${{ inputs.langflow_image_tag || 'latest' }}
-          # Empty on manual dispatch (the auto-remove step is schedule-only).
+          # Set by the (schedule-only) auto-remove step above; empty only if that
+          # step errored or its mass-failure guard left everything untouched.
           AUTO_REMOVE_STATUS: ${{ steps.auto_remove.outputs.status }}
           AUTO_REMOVE_SUMMARY: ${{ steps.auto_remove.outputs.summary_md }}
         with:
@@ -308,8 +311,9 @@ jobs:
             const image = process.env.IMAGE;
             const arStatus = process.env.AUTO_REMOVE_STATUS || '';
             const arSummary = process.env.AUTO_REMOVE_SUMMARY || '';
-            // On scheduled runs the auto-remove step already acted; show what it
-            // did. On manual runs it never ran, so fall back to manual triage.
+            // The auto-remove step above normally already acted; show what it
+            // did. If it produced no status (it errored, or its mass-failure
+            // guard left everything untouched), fall back to manual triage.
             const section = arStatus
               ? ['### `@stable` auto-removal', '', arSummary]
               : [


### PR DESCRIPTION
## What

Gate the `Create issue on failure` step on scheduled runs only, so a **manual
dispatch** (`workflow_dispatch`) no longer auto-opens the umbrella
`[Daily Failure]` triage issue.

## Why

The step was `if: failure()` — unlike the history and auto-remove steps above it,
which are `if: ... && github.event_name == 'schedule'`. A manual re-run of a red
build therefore auto-created an umbrella issue (e.g. #536 for run 28802767398).

A manual dispatch is itself a triage/experiment run. When it surfaces something
real, we open a **specific** issue by hand following the triage rule — a **hard
failure**, or a **flaky that recurs 2+ times** (e.g. #537). An auto-opened
umbrella on manual runs is just noise.

## Change

- `if: failure()` → `if: failure() && github.event_name == 'schedule'`, aligning
  this step with the history / auto-remove steps.
- Refresh the now-stale comments that described the manual-dispatch path (the
  step can no longer run on a manual dispatch).

No change to scheduled-run behavior: the umbrella issue still opens on every
scheduled failure.
