### PR TITLE
test(llm-agents): max_tokens caps agent output at token level (#483)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -335,7 +335,7 @@
 - [ ] Agent with configured timeout respects the limit
 - [x] Connecting an external model in Agent drops the prior model selection (connection-mode isolation, prevents stale provider config) → `llm-agents/agent-model-connection-isolation.spec.ts`
 - [ ] Flow with Agent saved and reopened → settings preserved → `agent-config-persistence.spec.ts`
-- [ ] max_tokens truncates response as configured → `agent-max-tokens.spec.ts`
+- [x] max_tokens truncates response as configured → `llm-agents/agent-max-tokens.spec.ts` (validated at token level via the Playground token-usage tooltip)
 - [ ] reasoning_effort field appears/disappears based on selected model → `agent-reasoning-effort.spec.ts`
 
 #### 6.3 Memory and Context
@@ -412,9 +412,9 @@
 - [ ] Configure and execute flow with Mistral
 
 #### 7.7 Model Parameters (Agent)
-- [ ] Temperature parameter (verify via network payload) → `agent-max-tokens.spec.ts`
+- [ ] Temperature parameter (verify via network payload) → `agent-max-tokens.spec.ts` (**not implementable on 1.11**: the Agent no longer has a temperature parameter — left with the model-bundle refactor; bullet pending re-scope)
 - [ ] Reasoning effort parameter — conditional field based on model → `agent-reasoning-effort.spec.ts`
-- [ ] Maximum token count — response truncated as configured → `agent-max-tokens.spec.ts`
+- [x] Maximum token count — response truncated as configured → `llm-agents/agent-max-tokens.spec.ts`
 - [x] Maximum agent iterations → `core-functionality/llm-agents/agent-max-iterations.spec.ts`
 - [ ] Use of custom `context_id` for memory isolation → `agent-context-id-isolation.spec.ts`
 - [ ] Output formatting (JSON via output_schema, Markdown, plain text) → `agent-structured-output.spec.ts`
@@ -756,8 +756,8 @@
 | `core-components/` — Core Components | 82 | 79 | 0 | 1 | 2 |
 | `core-functionality/auth/` | 21 | 8 | 13 | 0 | 0 |
 | `core-functionality/knowledge-ingestion/` | 8 | 0 | 4 | 0 | 4 |
-| `core-functionality/llm-agents/` | 40 | 20 | 2 | 0 | 18 |
-| `core-functionality/model-provider/` | 33 | 12 | 13 | 0 | 8 |
+| `core-functionality/llm-agents/` | 40 | 21 | 2 | 0 | 17 |
+| `core-functionality/model-provider/` | 33 | 13 | 13 | 0 | 7 |
 | `core-functionality/observability-monitoring/` | 23 | 15 | 7 | 0 | 1 |
 | `core-functionality/playground/` | 48 | 43 | 3 | 1 | 1 |
 | `core-functionality/project-management/` | 11 | 4 | 6 | 1 | 0 |
@@ -767,7 +767,7 @@
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 44 | 7 | 36 | 1 | 0 |
 | `ui-ux/` — Settings | 7 | 3 | 3 | 1 | 0 |
-| **TOTAL** | **451** | **236 (52%)** | **167 (37%)** | **7 (2%)** | **41 (9%)** |
+| **TOTAL** | **451** | **238 (53%)** | **167 (37%)** | **7 (2%)** | **39 (9%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -783,7 +783,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 248 `test()` calls carrying the `@stable` tag, distributed across 89 spec
+> 250 `test()` calls carrying the `@stable` tag, distributed across 90 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -936,6 +936,8 @@
 - [x] input via the Agent's direct field drives the agent response → `agent-input-sources.spec.ts`
 - [x] agent stops when max iterations is reached → `agent-max-iterations.spec.ts`
 - [x] causal control — a high max iterations does not hit the limit → `agent-max-iterations.spec.ts`
+- [x] max_tokens=50 caps the response's output tokens → `agent-max-tokens.spec.ts`
+- [x] causal control — unset max_tokens generates freely → `agent-max-tokens.spec.ts`
 - [x] selecting 'Connect other models' clears the previously selected model → `agent-model-connection-isolation.spec.ts`
 - [x] image via input handle is described by the agent → `agent-multimodal-image-input.spec.ts`
 - [x] negative control — no image, no image-specific description → `agent-multimodal-image-input.spec.ts`
@@ -1071,8 +1073,8 @@
 | `core-components/` — Component Config | 18 | 1 |
 | `core-components/` — Core Components | 0 | 2 |
 | `core-functionality/auth/` | 13 | 0 |
-| `core-functionality/llm-agents/` | 2 | 18 |
-| `core-functionality/model-provider/` | 13 | 8 |
+| `core-functionality/llm-agents/` | 2 | 17 |
+| `core-functionality/model-provider/` | 13 | 7 |
 | `core-functionality/playground/` | 3 | 1 |
 | `mcp/client/` | 7 | 2 |
 | `mcp/server/` | 3 | 4 |

--- a/docs/core-functionality/llm-agents/agent-max-tokens.md
+++ b/docs/core-functionality/llm-agents/agent-max-tokens.md
@@ -1,0 +1,191 @@
+# Agent max_tokens — caps generated output as configured
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+The Agent's **Max Tokens** control (`max_tokens`) caps how many tokens the
+model may generate (QA-CHECKLIST §6.2 "max_tokens truncates response as
+configured" and §7.7 "Maximum token count — response truncated as configured").
+The cap is proven at the **token level**, using the Playground's per-response
+token-usage tooltip as the observable:
+
+1. **Limit enforced** — `max_tokens = 50` with a prompt requesting a ~500-word
+   essay: the response's **Output** token count is **≤ 50**.
+2. **Causal control** — same prompt with `max_tokens` unset (saved as `0` =
+   unlimited): the response is a real essay (hundreds of words) and its Output
+   token count is **> 50**. Only `max_tokens` differs, so Test 1's cap is
+   attributable to the parameter.
+
+> **Scope note — §7.7 "Temperature parameter (verify via network payload)" is
+> NOT covered.** On nightly 1.11.0.dev33 the Agent has **no temperature
+> parameter at all**: zero occurrences in the saved flow JSON, absent from
+> `agent.py`'s inputs, and `update_build_config` injects no dynamic
+> temperature field (the parameter left the Agent with the model-bundle
+> refactor; the standalone Language Model component still has it). The bullet
+> is left `[ ]` and flagged on the issue/PR for re-scoping — a test against a
+> parameter that does not exist cannot be written, and covering the Language
+> Model component instead would validate a different surface than the
+> section's "(Agent)" scope. (The same applies to `reasoning_effort` — issue
+> #484 — noted for later.)
+
+If Test 1 fails, the Agent no longer bounds generation — a cost/latency
+regression.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@agents` `@playground`
+
+`@stable` added only after multiple clean `--retries=0` runs on the fresh
+nightly. `@regression` — guards the `max_tokens` passthrough (Agent →
+provider's `max_tokens_field_name`, e.g. Google's `max_output_tokens`) from
+regressing; `@agents` — Agent parameter behavior; `@playground` — the runs and
+the token-usage observable live in the Playground.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- `models.json` / `providers.json` generated via
+  `npx playwright test tests/collect-models.spec.ts`.
+- At least one active provider API key in `.env`.
+- Run with `--workers=1` — the spec is serial
+  (`SimpleAgentTemplatePage.load()` wipes all flows).
+
+---
+
+## Step by step *(required)*
+
+The spec generates **2 tests per active model** via `getTestTargets()`
+(default: 1 model per active provider).
+
+Shared setup per test:
+1. Load the Simple Agent template.
+2. Set **Max Tokens** in the Agent **Controls** dialog
+   (`edit-button-modal` → `int_int_edit_max_tokens` → `edit-button-close`).
+   **The int field rejects Playwright's `fill()`** (the controlled input keeps
+   an empty DOM value) and swallows the first keystroke of an immediate
+   `pressSequentially` (a typed "50" becomes a clamped "1") — the setter must
+   click, let the field settle, type slowly, and **verify the DOM value**,
+   retrying once if it diverges.
+3. **Verify the saved value via the API** (`GET /api/v1/flows/{id}` →
+   Agent node → `template.max_tokens.value`) before running — a silently
+   unsaved value must fail the setup step, not corrupt the causal pair.
+4. Seed the prompt on the **ChatInput node** (Playground prefill re-injection
+   race — see `agent-multimodal-image-input.md`): *"Write a detailed 500-word
+   essay about the history of the ocean. Do not use any tools — answer
+   directly."*
+5. Open the Playground, send, and wait for completion on the
+   `chat-message-token-usage` badge count.
+6. Hover the badge and read the **Output** token count from its tooltip
+   (`Input: 1.0K / Output: 46` format; values may be plain integers, `N.NK`,
+   or empty ⇒ 0).
+
+---
+
+**Test 1 — max_tokens=50 caps the output tokens** (§6.2, §7.7)
+
+- `max_tokens = 50`.
+- **Validation:** tooltip **Output ≤ 50**. The response *text* is NOT asserted:
+  with a thinking model (e.g. `gemini-3.5-flash`) the 50-token budget is
+  consumed by reasoning and the visible reply may legitimately be empty
+  (rendered as the "Message empty." placeholder — graceful handling covered by
+  `agent-empty-refusal-response.spec.ts`). The token cap itself is the
+  contract.
+
+---
+
+**Test 2 — causal control: unset max_tokens generates freely** (§6.2, §7.7)
+
+- `max_tokens` cleared (saved as `0` = no limit), identical prompt.
+- **Validation:** tooltip **Output > 50** and the reply contains a real essay
+  (> 200 words). Only `max_tokens` differs from Test 1, so Test 1's cap is
+  caused by the parameter, not by the model choosing to answer briefly.
+
+---
+
+## Validation criterion *(required)*
+
+- **Limit enforced (Test 1):** `max_tokens=50` → response Output tokens ≤ 50.
+- **Causal control (Test 2):** `max_tokens` unset → Output tokens > 50 and a
+  multi-hundred-word reply. The pair proves generation is bounded by
+  `max_tokens` and causally so.
+
+## Guarding against false positives *(how)*
+
+- **Saved-value API check before each run:** the int field's fill quirks make
+  a silent `0` (no limit) possible; verifying
+  `template.max_tokens.value === 50` via the API makes Test 1's setup
+  trustworthy (and a saved `0` in Test 1 would also fail its `≤ 50` assertion
+  — the guard is double).
+- **Token-level assertion, not text-length:** reply text length varies with
+  model verbosity; the provider-enforced output-token cap does not.
+- **Causal pair:** identical prompt, only `max_tokens` differs.
+- **Test 2 lower bound (> 50 tokens, > 200 words):** an aborted/empty run
+  cannot pass the control.
+- **Force-failure check** (CONTRIBUTING §2) run during VERIFY on each hard
+  assertion before `@stable`.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Temperature (parameter absent from the Agent on 1.11 — see Scope note).
+- Reasoning effort (same — issue #484).
+- Exact truncation semantics of the visible text (thinking models may produce
+  an empty reply under a tight cap).
+- The Language Model component's own `max_tokens`/`temperature`.
+
+---
+
+## External dependencies *(required)*
+
+- `src/lfx/components/models_and_agents/agent.py` — `max_tokens` IntInput and
+  `_get_max_tokens_value()` (empty/`0` ⇒ `None` ⇒ unlimited).
+- `src/lfx/base/models/unified_models/instantiation.py` — provider-specific
+  mapping via `max_tokens_field_name` (Google ⇒ `max_output_tokens`).
+- `src/frontend/src/CustomNodes/GenericNode/` — the Agent Controls dialog
+  (`int_int_edit_max_tokens`) and its int-field input handling.
+- `src/frontend/src/components/core/playgroundComponent/` — the
+  `chat-message-token-usage` badge and its Input/Output tooltip.
+- Provider LLM API — a live key; real model calls.
+
+---
+
+## When to review this test *(optional)*
+
+- If the Controls field testid changes from `int_int_edit_max_tokens`.
+- If the token-usage tooltip format changes (`Output:` label, `N.NK`
+  abbreviation).
+- If the Agent regains a temperature/reasoning parameter (re-scope the §7.7
+  bullets and extend this spec).
+
+---
+
+## Notes *(optional)*
+
+- **Int fields in the Controls dialog reject `fill()`** — Playwright's
+  programmatic set never reaches the controlled component (DOM value stays
+  `""`), and fast typing loses the first keystroke to a re-render, after which
+  the remainder is clamped to the field's `range_spec` min (typed "50" →
+  saved "1"). Slow `pressSequentially` after click + settle, with DOM-value
+  verification and one retry, is reliable (scouted on dev33).
+- **Closing the dialog can race the field's commit debounce** — even with the
+  DOM showing "50", the persisted value came out `0` in ~half the burst runs.
+  The setter blurs the field (`Tab` + settle) before closing AND verifies the
+  persisted value via the flows API, reopening the dialog and retrying the
+  whole cycle when the save was lost (observed: 3/5 burst failures before the
+  persist-retry; 5/5 green after).
+- **Tooltip Output may be empty** when the whole budget is consumed by
+  reasoning before any visible token (observed with `max_tokens=1`); the
+  parser treats missing/empty as `0`, which still satisfies `≤ 50`.
+- **Runtime honors the parameter** (verified two ways on dev33: an API run
+  with a `max_tokens: 50` tweak returned an empty reply, and the UI-saved
+  value produced Output = 46 ≤ 50), so unlike #481/#482 there is no
+  fixed-bug/expected-fail question here — the risk this spec guards is the
+  UI save path and the provider mapping.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-max-tokens.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-max-tokens.spec.ts
@@ -1,0 +1,307 @@
+import * as dotenv from "dotenv";
+import path from "path";
+import fs from "fs";
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
+import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import {
+  hasProviderEnvKeys,
+  missingProviderEnvKeys,
+  providerConfigMap,
+  type Provider,
+} from "../../../../helpers/provider-setup";
+import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+
+/**
+ * Agent max_tokens (QA-CHECKLIST §6.2 "max_tokens truncates response as
+ * configured", §7.7 "Maximum token count — response truncated as configured").
+ * The cap is proven at the TOKEN level via the Playground token-usage tooltip:
+ *
+ *   Test 1 — max_tokens=50 + a ~500-word essay prompt: the response's Output
+ *            token count is <= 50. The reply TEXT is not asserted — a thinking
+ *            model may spend the whole budget on reasoning and legitimately
+ *            render an empty reply ("Message empty." placeholder).
+ *   Test 2 — causal control: max_tokens unset (0 = unlimited), same prompt —
+ *            Output > 50 and a real essay comes back. Only max_tokens differs.
+ *
+ * §7.7 "Temperature parameter (verify via network payload)" is NOT covered:
+ * the Agent has no temperature parameter on 1.11 (absent from agent.py inputs
+ * and from the saved flow; it left with the model-bundle refactor). Flagged on
+ * the issue/PR — see the spec doc's Scope note.
+ */
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
+}
+
+const TOKEN_LIMIT = 50;
+const ESSAY_PROMPT =
+  "Write a detailed 500-word essay about the history of the ocean. Do not use any tools — answer directly.";
+
+interface ModelRecord {
+  provider: string;
+  model: string;
+}
+
+interface TestTarget {
+  label: string;
+  options: LoadSimpleAgentOptions;
+  skipReason?: string;
+}
+
+function getProviderSkipReasons(): Map<string, string> {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/providers.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
+    return new Map();
+  }
+  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
+  const reasons = new Map<string, string>();
+  for (const r of records) {
+    if (r.status === "inactive") {
+      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
+    }
+  }
+  return reasons;
+}
+
+function getModelsFromJson(): ModelRecord[] {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/models.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("models.json not found — run collect-models.spec.ts first.");
+    return [];
+  }
+  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
+}
+
+function getTestTargets(): TestTarget[] {
+  const skipReasons = getProviderSkipReasons();
+
+  if (process.env.MODEL_TEST_ID) {
+    const model = process.env.MODEL_TEST_ID;
+    const allModels = getModelsFromJson();
+    const record = allModels.find((m) => m.model === model);
+    if (!record) {
+      console.warn(`MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred.`);
+      return [{ label: `model:${model}`, options: { model } }];
+    }
+    const provider = record.provider as Provider;
+    return [{
+      label: `${provider} / ${model}`,
+      options: { provider, model },
+      skipReason: skipReasons.get(provider),
+    }];
+  }
+
+  const allModels = getModelsFromJson();
+  if (allModels.length === 0) {
+    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
+    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
+    return [{
+      label: `provider:${fallbackProvider} (fallback)`,
+      options: { provider: fallbackProvider },
+      skipReason: skipReasons.get(fallbackProvider),
+    }];
+  }
+
+  let models = allModels;
+  if (process.env.MODEL_TEST_PROVIDER) {
+    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
+  } else if (process.env.ALL_MODELS !== "true") {
+    const seen = new Set<string>();
+    models = models.filter((m) => {
+      if (seen.has(m.provider)) return false;
+      seen.add(m.provider);
+      return true;
+    });
+  }
+
+  return models.map((m) => ({
+    label: `${m.provider} / ${m.model}`,
+    options: { provider: m.provider as Provider, model: m.model },
+    skipReason: skipReasons.get(m.provider),
+  }));
+}
+
+async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
+  try {
+    await new SimpleAgentTemplatePage(page).load(options);
+  } catch (e: any) {
+    if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
+    throw e;
+  }
+}
+
+// Set the Agent's max_tokens in the Controls dialog. Two scouted quirks
+// (dev33): (a) the int field rejects Playwright's fill() outright and swallows
+// the first keystroke of an immediate pressSequentially — a typed "50" becomes
+// a range_spec-clamped "1"; (b) closing the dialog can race the field's commit
+// debounce, persisting 0 even though the DOM showed the typed value. So: type
+// slowly and verify the DOM, blur to force the commit, and verify the value
+// actually PERSISTED via the flows API — reopening the dialog and retrying the
+// whole cycle when it did not.
+async function setMaxTokens(page: Page, value: string): Promise<void> {
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    await page.getByTestId("edit-button-modal").click();
+    const field = page.getByTestId("int_int_edit_max_tokens");
+    await expect(field).toBeVisible({ timeout: 15000 });
+    await field.scrollIntoViewIfNeeded();
+    for (let typeTry = 0; typeTry < 3; typeTry++) {
+      await field.click();
+      await page.waitForTimeout(600);
+      await field.press("ControlOrMeta+a");
+      await field.press("Backspace");
+      await field.pressSequentially(value, { delay: 150 });
+      if ((await field.inputValue()) === value) break;
+    }
+    await expect(field).toHaveValue(value);
+    await field.press("Tab");
+    await page.waitForTimeout(800);
+    await page.getByTestId("edit-button-close").click();
+    await waitForFlowSaveSettled(page);
+    if ((await getSavedMaxTokens(page)) === Number(value)) return;
+    console.warn(`setMaxTokens: value did not persist (attempt ${attempt}) — retrying`);
+  }
+  expect(await getSavedMaxTokens(page)).toBe(Number(value));
+}
+
+// Read the Agent node's persisted max_tokens straight from the flows API. The
+// int field's quirks make a silently unsaved value possible — the causal pair
+// is only trustworthy when the saved value is verified before each run.
+async function getSavedMaxTokens(page: Page): Promise<unknown> {
+  await page.waitForURL(/\/flow\/[^/?#]+/);
+  const flowId = page.url().split("/flow/")[1].split(/[/?#]/)[0];
+  const res = await page.request.get(`/api/v1/flows/${flowId}`);
+  expect(res.status()).toBe(200);
+  const flow = await res.json();
+  const agent = flow.data.nodes.find((n: any) => n.id.startsWith("Agent"));
+  return agent?.data?.node?.template?.max_tokens?.value;
+}
+
+// Seed the prompt on the ChatInput node (the Playground prefill re-injects the
+// template default asynchronously and would corrupt typed text — see
+// agent-multimodal-image-input.md), then send it and wait for the response to
+// complete (token-usage badge renders only on completion).
+async function runPrompt(page: Page): Promise<string> {
+  const node = page.locator(
+    '[data-testid^="rf__node-ChatInput"] [data-testid="textarea_str_input_value"]',
+  );
+  await expect(node).toBeVisible({ timeout: 15000 });
+  await node.click();
+  await node.fill(ESSAY_PROMPT);
+  await node.blur();
+  await waitForFlowSaveSettled(page);
+
+  await page.getByTestId("playground-btn-flow-io").click();
+  await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({ timeout: 30000 });
+  await page.getByTestId("button-send").last().click();
+
+  const stop = page.getByRole("button", { name: "Stop" });
+  if (await stop.isVisible({ timeout: 8000 }).catch(() => false)) {
+    await stop.waitFor({ state: "hidden", timeout: 120000 }).catch(() => {});
+  }
+  await expect(page.getByTestId("chat-message-token-usage")).toHaveCount(1, { timeout: 120000 });
+
+  return (await page.getByTestId("div-chat-message").last().innerText()).trim();
+}
+
+// "1.9K" -> 1900, "46" -> 46, missing/empty -> 0 (a tight cap can be fully
+// consumed by reasoning before any visible token — observed with max_tokens=1).
+function parseTokenCount(raw: string | undefined): number {
+  if (!raw) return 0;
+  const n = parseFloat(raw);
+  if (Number.isNaN(n)) return 0;
+  return raw.trim().toUpperCase().endsWith("K") ? Math.round(n * 1000) : n;
+}
+
+// Hover the token-usage badge and read the response's Output token count from
+// its tooltip ("Input: 1.0K / Output: 46" layout).
+async function readOutputTokens(page: Page): Promise<number> {
+  const badge = page.getByTestId("chat-message-token-usage").last();
+  await badge.hover();
+  const tooltip = page
+    .locator('[role="tooltip"], [data-radix-popper-content-wrapper]')
+    .first();
+  await expect(tooltip).toBeVisible({ timeout: 10000 });
+  const text = await tooltip.innerText();
+  const match = text.match(/Output:\s*([\d.]+K?)?/i);
+  expect(match, `token tooltip must contain an Output entry — got: ${text}`).toBeTruthy();
+  return parseTokenCount(match?.[1]);
+}
+
+const targets = getTestTargets();
+
+// SimpleAgentTemplatePage.load() deletes all flows before loading the template;
+// serial mode + --workers=1 keeps the shared instance state deterministic.
+test.describe.configure({ mode: "serial" });
+
+for (const { label, options, skipReason } of targets) {
+  const provider = options.provider ?? (Object.keys(providerConfigMap)[0] as Provider);
+
+  test.describe(`Agent max_tokens [${label}]`, () => {
+    test(
+      "max_tokens=50 caps the response's output tokens",
+      { tag: ["@stable", "@regression", "@agents", "@playground"] },
+      async ({ page }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        await loadAgent(page, options);
+
+        await test.step(`cap max_tokens at ${TOKEN_LIMIT}`, async () => {
+          await setMaxTokens(page, String(TOKEN_LIMIT));
+          expect(await getSavedMaxTokens(page)).toBe(TOKEN_LIMIT);
+        });
+
+        await test.step("run the essay prompt and assert Output tokens <= limit", async () => {
+          await runPrompt(page);
+          const outputTokens = await readOutputTokens(page);
+          // The provider enforces the cap server-side; the reply text is NOT
+          // asserted — a thinking model may spend the whole budget on
+          // reasoning and render an empty reply, which is still a correct cap.
+          expect(outputTokens).toBeLessThanOrEqual(TOKEN_LIMIT);
+        });
+      },
+    );
+
+    test(
+      "causal control — unset max_tokens generates freely",
+      { tag: ["@stable", "@regression", "@agents", "@playground"] },
+      async ({ page }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        await loadAgent(page, options);
+
+        await test.step("verify max_tokens is unset (0/empty = unlimited)", async () => {
+          // The fresh template ships without a limit; _get_max_tokens_value()
+          // maps ""/0 to None (unlimited). Verify instead of assuming.
+          const saved = await getSavedMaxTokens(page);
+          expect([0, "", null, undefined]).toContain(saved as never);
+        });
+
+        await test.step("run the essay prompt and assert unbounded output", async () => {
+          const reply = await runPrompt(page);
+          const outputTokens = await readOutputTokens(page);
+          // Only max_tokens differs from Test 1, so its cap is attributable to
+          // the parameter, not to the model choosing to answer briefly.
+          expect(outputTokens).toBeGreaterThan(TOKEN_LIMIT);
+          expect(reply.split(/\s+/).length).toBeGreaterThan(200);
+        });
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #483.

Closes the `[ ] max_tokens truncates response as configured` gap in `QA-CHECKLIST.md` § 6.2 and `[ ] Maximum token count — response truncated as configured` in § 7.7. Distinct from `agent-max-iterations.spec.ts` (bounds the TOOL loop); this bounds token GENERATION.

## ⚠️ Scope deviation — for maintainer review

**§7.7 "Temperature parameter (verify via network payload)" is NOT covered — the parameter does not exist on the Agent in 1.11.** Verified three ways on nightly **1.11.0.dev33**: zero `temperature` occurrences in a saved Simple Agent flow, absent from `agent.py`'s input list, and `update_build_config` injects no dynamic temperature field (the parameter left the Agent with the model-bundle refactor; the standalone Language Model component still has it, but that is a different surface than the section's "(Agent)" scope). The bullet stays `[ ]` with a `not implementable on 1.11 — pending re-scope` annotation. **Heads-up:** `reasoning_effort` is also absent from the Agent, which likely obsoletes issue #484 the same way.

## 1. Covered tests
| # | Test | What it validates |
|---|------|-------------------|
| 1 | `max_tokens=50 caps the response's output tokens` | With a ~500-word essay prompt, the response's **Output** token count (Playground token-usage tooltip) is **≤ 50**. Asserted at the token level — with a thinking model the budget can be spent on reasoning and the visible reply may legitimately be a fragment or empty ("Message empty." placeholder). |
| 2 | `causal control — unset max_tokens generates freely` | Same prompt, `max_tokens` unset (0 = unlimited): Output **> 50** and a real essay (> 200 words). Only `max_tokens` differs, so Test 1's cap is attributable to the parameter. |

## 2. How the test was built
- **Token-level observable:** the `chat-message-token-usage` badge tooltip (`Input: 1.0K / Output: 46` layout); parser handles plain integers, `N.NK`, and empty (⇒ 0, seen when the whole budget goes to reasoning).
- **Two real frontend quirks found while scouting (dev33), both worked around and documented in the spec doc:**
  1. The Controls-dialog int field **rejects Playwright's `fill()`** (controlled input keeps an empty DOM value) and swallows the first keystroke of fast typing — a typed "50" became a range_spec-clamped "1". Setter: click + settle + slow `pressSequentially` + DOM-value verify with retry.
  2. **Closing the dialog races the field's commit debounce** — the DOM showed "50" but the flow persisted `0` in 3/5 burst runs. Setter blurs (`Tab`) before closing AND verifies the persisted value via `GET /api/v1/flows/{id}`, reopening the dialog and retrying the cycle when the save was lost. 5/5 green after.
- **Runtime honor pre-verified two ways** before authoring: an API run with a `max_tokens: 50` tweak returned an empty reply, and the UI-saved value produced Output = 46 ≤ 50 (Google mapping `max_tokens_field_name` → `max_output_tokens` confirmed in `lfx/base/models/unified_models/instantiation.py`). No expected-fail question here — the guarded risk is the UI save path and provider mapping.
- Prompt seeded on the **ChatInput node** (Playground prefill re-injection race), standard `getTestTargets()` parameterization (one describe per active provider model).

## 3. Dependencies
- Live provider API key (real model calls); model strategy via `.env` / `models.json`.
- `--workers=1` serial — `SimpleAgentTemplatePage.load()` wipes all flows.

## Validation (nightly 1.11.0.dev33, `--retries=0`)
- typecheck ✅ (0 errors) · eslint ✅ (0 errors)
- 5/5 clean burst runs post-fix + 1 post-restore run, ~33s each ✅
- force-fail ✅ (each test falsified in isolation via `--grep` → 1 failed each, then restored)
- zero `🚨 Backend Error` ✅
- §6.2 + §7.7 (max tokens) bullets flipped to `[x]`, temperature bullet annotated; `npm run coverage:summary` regenerated ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
