### PR TITLE
docs(checklist): mark reasoning_effort bullets not implementable on 1.11 (#484)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -336,7 +336,7 @@
 - [x] Connecting an external model in Agent drops the prior model selection (connection-mode isolation, prevents stale provider config) → `llm-agents/agent-model-connection-isolation.spec.ts`
 - [ ] Flow with Agent saved and reopened → settings preserved → `agent-config-persistence.spec.ts`
 - [x] max_tokens truncates response as configured → `llm-agents/agent-max-tokens.spec.ts` (validated at token level via the Playground token-usage tooltip)
-- [ ] reasoning_effort field appears/disappears based on selected model → `agent-reasoning-effort.spec.ts`
+- [ ] reasoning_effort field appears/disappears based on selected model → `agent-reasoning-effort.spec.ts` (**not implementable on 1.11**: no reasoning_effort field exists in the Agent UI, backend, or frontend — left with the model-bundle refactor; pending re-scope, see #484)
 
 #### 6.3 Memory and Context
 - [x] Memory Chatbot template loads with correct node and edge structure → `llm-agents/memory-history-regression.spec.ts`
@@ -413,7 +413,7 @@
 
 #### 7.7 Model Parameters (Agent)
 - [ ] Temperature parameter (verify via network payload) → `agent-max-tokens.spec.ts` (**not implementable on 1.11**: the Agent no longer has a temperature parameter — left with the model-bundle refactor; bullet pending re-scope)
-- [ ] Reasoning effort parameter — conditional field based on model → `agent-reasoning-effort.spec.ts`
+- [ ] Reasoning effort parameter — conditional field based on model → `agent-reasoning-effort.spec.ts` (**not implementable on 1.11** — see #484)
 - [x] Maximum token count — response truncated as configured → `llm-agents/agent-max-tokens.spec.ts`
 - [x] Maximum agent iterations → `core-functionality/llm-agents/agent-max-iterations.spec.ts`
 - [ ] Use of custom `context_id` for memory isolation → `agent-context-id-isolation.spec.ts`


### PR DESCRIPTION
Refs #484 (intentionally NOT `Closes` — closing/re-scoping the issue is the maintainer's call; full evidence in [this comment](https://github.com/oriontech-me/langflow-e2e/issues/484#issuecomment-4895347358)).

## What

Annotates the two `reasoning_effort` checklist bullets (§6.2, §7.7) as **not implementable on 1.11 — pending re-scope**, mirroring the temperature annotation shipped in #539.

## Why

Issue #484 asks for a spec proving the `reasoning_effort` field appears/disappears based on the selected model. On nightly **1.11.0.dev33** that field does not exist anywhere:

- **UI:** no reasoning/effort control on the Agent node or in its Controls dialog, even with a reasoning-capable model (`gemini-3.5-flash`, catalog `reasoning: true`) selected.
- **Backend:** zero `reasoning_effort` occurrences across the installed `lfx` package; "reasoning" is only a catalog filter tag plus the OpenAI `reasoning_models` list used to null out `temperature` at instantiation.
- **Frontend bundles:** only the catalog tag and the reasoning message-streaming role — no field, no conditional rendering.

Same root cause as the temperature parameter (#483/#539): removed from the Agent with the model-bundle refactor. No equivalent backend contract exists to shift the test to, so an honest spec cannot be written.

## Validation
- `npm run coverage:summary` — idempotent, no counter changes (annotation only touches bullet text, both stay `[ ]`).
- typecheck ✅ · eslint ✅ (no code changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
