### PR TITLE
test(llm-agents): invalid tool name blocks execution with clear message (#490)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -352,7 +352,7 @@
 - [ ] Agent executes multiple tools in sequence
 - [ ] Tool returns error — agent handles it and continues execution → `agent-tool-error-handling.spec.ts`
 - [ ] Multiple connected tools — agent selects the correct one for each prompt → `agent-multi-tool-selection.spec.ts`
-- [ ] Tool with invalid name — validation prevents execution with clear message → `agent-tool-name-validation.spec.ts`
+- [x] Tool with invalid name — validation prevents execution with clear message → `core-functionality/llm-agents/agent-tool-name-validation.spec.ts`
 
 #### 6.5 Output and Reasoning
 - [ ] Inspect tools used by Agent in Playground
@@ -756,7 +756,7 @@
 | `core-components/` — Core Components | 82 | 79 | 0 | 1 | 2 |
 | `core-functionality/auth/` | 21 | 8 | 13 | 0 | 0 |
 | `core-functionality/knowledge-ingestion/` | 8 | 0 | 4 | 0 | 4 |
-| `core-functionality/llm-agents/` | 40 | 21 | 2 | 0 | 17 |
+| `core-functionality/llm-agents/` | 40 | 22 | 2 | 0 | 16 |
 | `core-functionality/model-provider/` | 33 | 19 | 7 | 0 | 7 |
 | `core-functionality/observability-monitoring/` | 23 | 15 | 7 | 0 | 1 |
 | `core-functionality/playground/` | 48 | 43 | 3 | 1 | 1 |
@@ -767,7 +767,7 @@
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 44 | 7 | 36 | 1 | 0 |
 | `ui-ux/` — Settings | 7 | 3 | 3 | 1 | 0 |
-| **TOTAL** | **451** | **244 (54%)** | **161 (36%)** | **7 (2%)** | **39 (9%)** |
+| **TOTAL** | **451** | **245 (54%)** | **161 (36%)** | **7 (2%)** | **38 (8%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -783,7 +783,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 269 `test()` calls carrying the `@stable` tag, distributed across 96 spec
+> 271 `test()` calls carrying the `@stable` tag, distributed across 97 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -945,6 +945,8 @@
 - [x] causal control — a large n_messages retrieves the full seeded history → `agent-n-messages-limit.spec.ts`
 - [x] Agent Instructions are respected in the model response → `agent-system-prompt.spec.ts`
 - [x] negative control — sentinel is absent without the instruction → `agent-system-prompt.spec.ts`
+- [x] an invalid tool name blocks execution with a clear message → `agent-tool-name-validation.spec.ts`
+- [x] causal control — a valid custom tool name executes normally → `agent-tool-name-validation.spec.ts`
 - [x] user must be able to send images in the playground with the agent component → `general-bugs-agent-images-playground.spec.ts`
 - [x] language model must respond with OpenAI provider → `language-model-regression.spec.ts`
 - [x] language model must respond with Google provider → `language-model-regression.spec.ts`
@@ -1092,7 +1094,7 @@
 | `core-components/` — Component Config | 18 | 1 |
 | `core-components/` — Core Components | 0 | 2 |
 | `core-functionality/auth/` | 13 | 0 |
-| `core-functionality/llm-agents/` | 2 | 17 |
+| `core-functionality/llm-agents/` | 2 | 16 |
 | `core-functionality/model-provider/` | 7 | 7 |
 | `core-functionality/playground/` | 3 | 1 |
 | `mcp/client/` | 7 | 2 |

--- a/docs/core-functionality/llm-agents/agent-tool-name-validation.md
+++ b/docs/core-functionality/llm-agents/agent-tool-name-validation.md
@@ -1,0 +1,154 @@
+# Agent tool name — invalid name blocks execution with a clear error
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+QA-CHECKLIST §6.4 "Tool with invalid name — validation prevents execution with
+clear message". A tool attached to the Agent can be renamed through the tool
+component's actions modal; the rename sets the **function name** sent to the
+LLM provider. When that name contains characters no provider accepts (e.g.
+`!`), the flow must **not** execute the agent — the run fails fast with a
+clear, user-visible error identifying the invalid function name.
+
+1. **Invalid name blocks execution** — rename the URL tool's slug to
+   `invalid tool name!!` and send a Playground message: the build fails and
+   the Playground shows an error whose text identifies the invalid function
+   name (provider 400, e.g. Google's *"Invalid function name. Must start with
+   a letter or an underscore…"*).
+2. **Causal control — a valid rename executes normally** — rename the same
+   tool to `fetch_content_renamed` and send the same message: the agent
+   answers with no error. The pair proves the failure in Test 1 is caused by
+   the invalid characters, not by the rename machinery itself.
+
+> **Scope note — where the "validation" actually lives on 1.11.** Langflow
+> performs **no edit-time validation** of tool names: the tools modal accepts
+> `invalid tool name!!` with no inline error or toast. The frontend only
+> normalizes case and spaces (persisted as `invalid_tool_name!!` — the `!!`
+> passes through), and the backend assigns the name verbatim to the LangChain
+> tool (`component_tool.py` → `update_tools_metadata`, no pattern check). The
+> rejection observed by the user comes from the **provider's request
+> validation** (deterministic HTTP 400 before any inference — Google
+> `INVALID_ARGUMENT`, OpenAI `string does not match pattern`). This satisfies
+> the checklist bullet's observable ("prevents execution with clear message"),
+> and the absence of edit-time validation is flagged on the PR as a potential
+> upstream improvement, not asserted against.
+
+If Test 1 fails, an invalid tool name silently reaches the provider with no
+clear error (or executes), leaving users with an undiagnosable broken agent.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@agents` `@playground`
+
+`@stable` added only after multiple clean `--retries=0` runs on the fresh
+nightly. `@regression` — guards the error surfacing path (tool rename →
+provider rejection → Playground error message); `@agents` — Agent tool-calling
+configuration; `@playground` — the runs and the error observable live in the
+Playground.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- `models.json` / `providers.json` generated via
+  `npx playwright test tests/collect-models.spec.ts`.
+- At least one active provider API key in `.env`.
+- Run with `--workers=1` — the spec is serial
+  (`SimpleAgentTemplatePage.load()` wipes all flows).
+
+---
+
+## Step by step *(required)*
+
+The spec generates **2 tests per active model** via `getTestTargets()`
+(default: 1 model per active provider — same machinery as
+`agent-max-iterations.spec.ts`).
+
+Shared setup per test:
+1. Load the Simple Agent template (`SimpleAgentTemplatePage.load()` — wipes
+   existing flows, configures the target provider/model).
+2. Open the URL tool's actions modal: the button is scoped to the node —
+   `[data-testid^="rf__node-URLComponent"]` → `button_open_actions` — and the
+   modal is ready when `btn_close_tools_modal` renders.
+3. Rename the tool: double-click the grid's name cell
+   (`[role="dialog"] .ag-cell[col-id="name"]`), fill `input_update_name`,
+   press `Enter` to commit, and assert the slug cell
+   (`.ag-cell[col-id="name_1"]`) reflects the new value before closing
+   (`Escape`).
+4. **Verify the persisted name via the API** (`GET /api/v1/flows/{id}` → URL
+   node → `template.tools_metadata.value[0].name`) before running — the modal
+   normalizes case/spaces, so the assertion targets the normalized form; a
+   silently unsaved rename must fail the setup step, not produce a
+   false-positive run.
+5. Open the Playground and send a fixed message.
+
+---
+
+**Test 1 — invalid tool name blocks execution with a clear message** (§6.4)
+
+- Rename to `invalid tool name!!` (persisted as `invalid_tool_name!!` — the
+  `!` characters violate every provider's function-name pattern).
+- `page.allowFlowErrors()` — the failure is intentional.
+- **Validation:** the Playground surfaces an error state for the run and its
+  text matches `/invalid function name|does not match pattern|INVALID_ARGUMENT/i`
+  (covers Google and OpenAI wording). No agent answer is produced.
+
+---
+
+**Test 2 — causal control: a valid rename executes normally** (§6.4)
+
+- Rename to `fetch_content_renamed` (valid pattern), identical message.
+- **Validation:** the agent produces a normal AI response and no build-error
+  surface appears. Only the name's validity differs from Test 1, so Test 1's
+  failure is attributable to the invalid characters.
+
+---
+
+## Validation criterion *(required)*
+
+- **Blocked (Test 1):** invalid tool name → run fails with a visible error
+  identifying the invalid function name; no AI answer.
+- **Control (Test 2):** valid custom tool name → run completes with an AI
+  answer and no error. The pair proves execution is gated by tool-name
+  validity and causally so.
+
+## Guarding against false positives *(how)*
+
+- **Persisted-name API check before each run:** proves the rename actually
+  reached the flow document; without it a lost rename would make Test 1 run a
+  valid flow (provider answers → assertion on the error would fail correctly)
+  but would make Test 2 vacuous.
+- **Message-content assertion, not just "an error happened":** the fixture
+  already fails tests on backend errors; Test 1 uses `allowFlowErrors()` and
+  asserts the *specific* invalid-function-name wording, so an unrelated crash
+  (auth, quota) cannot pass as this scenario.
+- **Causal pair:** identical flow, prompt, and rename flow — only name
+  validity differs.
+- **Force-failure check** (CONTRIBUTING §2) run during VERIFY on each hard
+  assertion before `@stable`.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Edit-time validation in the tools modal (does not exist on 1.11 — see Scope
+  note; flagged upstream rather than asserted).
+- Provider-specific error wording beyond the regex (the exact message text is
+  the provider's contract, not Langflow's).
+- Tool renames on components other than URL (same modal machinery).
+
+---
+
+## External dependencies *(required)*
+
+- **LLM provider API** (per `models.json` target): Test 1 consumes **zero
+  tokens** (the request is rejected at validation, before inference); Test 2
+  performs one real completion.
+- `tests/helpers/provider-setup/data/models.json` +
+  `providers.json` (collect-models).

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-name-validation.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-name-validation.spec.ts
@@ -1,0 +1,315 @@
+import * as dotenv from "dotenv";
+import path from "path";
+import fs from "fs";
+import type { Page } from "@playwright/test";
+import type { APIRequestContext } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
+import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import {
+  hasProviderEnvKeys,
+  missingProviderEnvKeys,
+  providerConfigMap,
+  type Provider,
+} from "../../../../helpers/provider-setup";
+import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+
+/**
+ * Agent tool name validation (QA-CHECKLIST §6.4 "Tool with invalid name —
+ * validation prevents execution with clear message").
+ *
+ *   Test 1 — rename the URL tool's slug to a name with characters no provider
+ *            accepts (`invalid tool name!!`): the run never executes — the
+ *            Playground surfaces a clear invalid-function-name error.
+ *   Test 2 — causal control: the SAME rename flow with a VALID custom name
+ *            executes normally, so Test 1's failure is attributable to the
+ *            invalid characters, not to the rename machinery.
+ *
+ * Where the "validation" lives on 1.11 (scouted on 1.11.0.dev33): Langflow has
+ * NO edit-time validation — the tools modal accepts the name (normalizing only
+ * case and spaces; `!` passes through) and the backend assigns it verbatim to
+ * the LangChain tool. The block comes from the provider's request validation
+ * (deterministic HTTP 400 before any inference). See the spec doc's Scope note.
+ */
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
+}
+
+const INVALID_TOOL_NAME = "invalid tool name!!";
+const VALID_TOOL_NAME = "fetch_content_renamed";
+// A task the agent answers directly — no tool call needed. Test 1 fails before
+// any model call regardless; Test 2 completes in a single cheap turn.
+const TASK = "Reply with exactly: hello from the control test";
+// Provider wording for a rejected function name — Google ("Invalid function
+// name…", INVALID_ARGUMENT) and OpenAI ("string does not match pattern").
+const INVALID_NAME_ERROR = /invalid function name|does not match pattern|INVALID_ARGUMENT/i;
+
+interface ModelRecord {
+  provider: string;
+  model: string;
+}
+
+interface TestTarget {
+  label: string;
+  options: LoadSimpleAgentOptions;
+  skipReason?: string;
+}
+
+function getProviderSkipReasons(): Map<string, string> {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/providers.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
+    return new Map();
+  }
+  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
+  const reasons = new Map<string, string>();
+  for (const r of records) {
+    if (r.status === "inactive") {
+      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
+    }
+  }
+  return reasons;
+}
+
+function getModelsFromJson(): ModelRecord[] {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/models.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("models.json not found — run collect-models.spec.ts first.");
+    return [];
+  }
+  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
+}
+
+function getTestTargets(): TestTarget[] {
+  const skipReasons = getProviderSkipReasons();
+
+  if (process.env.MODEL_TEST_ID) {
+    const model = process.env.MODEL_TEST_ID;
+    const allModels = getModelsFromJson();
+    const record = allModels.find((m) => m.model === model);
+    if (!record) {
+      console.warn(`MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred.`);
+      return [{ label: `model:${model}`, options: { model } }];
+    }
+    const provider = record.provider as Provider;
+    return [{
+      label: `${provider} / ${model}`,
+      options: { provider, model },
+      skipReason: skipReasons.get(provider),
+    }];
+  }
+
+  const allModels = getModelsFromJson();
+  if (allModels.length === 0) {
+    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
+    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
+    return [{
+      label: `provider:${fallbackProvider} (fallback)`,
+      options: { provider: fallbackProvider },
+      skipReason: skipReasons.get(fallbackProvider),
+    }];
+  }
+
+  let models = allModels;
+  if (process.env.MODEL_TEST_PROVIDER) {
+    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
+  } else if (process.env.ALL_MODELS !== "true") {
+    const seen = new Set<string>();
+    models = models.filter((m) => {
+      if (seen.has(m.provider)) return false;
+      seen.add(m.provider);
+      return true;
+    });
+  }
+
+  return models.map((m) => ({
+    label: `${m.provider} / ${m.model}`,
+    options: { provider: m.provider as Provider, model: m.model },
+    skipReason: skipReasons.get(m.provider),
+  }));
+}
+
+async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
+  try {
+    await new SimpleAgentTemplatePage(page).load(options);
+  } catch (e: any) {
+    if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
+    throw e;
+  }
+}
+
+// Rename the URL tool through its actions modal. The modal normalizes spaces
+// to underscores; the grid's slug cell displays the uppercased form and the
+// flow document persists the lowercased form.
+async function renameUrlTool(page: Page, newName: string): Promise<void> {
+  await page
+    .locator('[data-testid^="rf__node-URLComponent"]')
+    .getByTestId("button_open_actions")
+    .click();
+  await expect(page.getByTestId("btn_close_tools_modal")).toBeVisible({
+    timeout: 15000,
+  });
+
+  const nameCell = page.locator('[role="dialog"] .ag-cell[col-id="name"]').first();
+  await nameCell.dblclick();
+  const input = page.getByTestId("input_update_name");
+  await expect(input).toBeVisible({ timeout: 10000 });
+  await input.fill(newName);
+  await input.press("Enter");
+
+  // The slug cell reflecting the new value proves the grid committed the edit.
+  const normalized = newName.trim().replace(/\s+/g, "_");
+  const slugCell = page.locator('[role="dialog"] .ag-cell[col-id="name_1"]').first();
+  await expect(slugCell).toContainText(
+    new RegExp(normalized.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i"),
+    { timeout: 10000 },
+  );
+
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("btn_close_tools_modal")).toBeHidden({
+    timeout: 10000,
+  });
+}
+
+// The rename only matters if it reached the persisted flow document — a lost
+// edit would make the control test vacuous. Polls the flows API for the URL
+// node's tools_metadata name (autosave may lag the UI commit).
+// The canvas URL's flow id can be TRANSIENT on 1.11 (GET by that id 404s), so
+// the flow is resolved from the flows list instead — SimpleAgentTemplatePage
+// wipes all flows on load, so exactly one flow with a URLComponent exists.
+async function expectPersistedToolName(
+  _page: Page,
+  request: APIRequestContext,
+  expected: string,
+): Promise<void> {
+  const bearer = await getAuthToken(request);
+  await expect
+    .poll(
+      async () => {
+        const res = await request.get(`/api/v1/flows/?remove_example_flows=true&header_flows=false`, {
+          headers: { Authorization: bearer },
+        });
+        if (res.status() !== 200) return `GET flows -> ${res.status()}`;
+        const flows = await res.json();
+        const urlNodes = (Array.isArray(flows) ? flows : [])
+          .flatMap((f: any) => f.data?.nodes ?? [])
+          .filter((n: any) => n.data?.type === "URLComponent");
+        if (urlNodes.length !== 1) return `expected 1 URLComponent flow, found ${urlNodes.length}`;
+        return urlNodes[0]?.data?.node?.template?.tools_metadata?.value?.[0]?.name;
+      },
+      { timeout: 15000 },
+    )
+    .toBe(expected);
+}
+
+// Set the task on the ChatInput node (the Playground prompt pre-fills from it;
+// typing into the Playground races an async default re-injection).
+async function setChatInputText(page: Page, text: string): Promise<void> {
+  const field = page.locator(
+    '[data-testid^="rf__node-ChatInput"] [data-testid="textarea_str_input_value"]',
+  );
+  await expect(field).toBeVisible({ timeout: 15000 });
+  await field.click();
+  await field.fill(text);
+  await field.blur();
+}
+
+async function waitForAgentToFinish(page: Page): Promise<void> {
+  const stopButton = page.getByRole("button", { name: "Stop" });
+  const stopVisible = await stopButton.isVisible({ timeout: 10000 }).catch(() => false);
+  if (stopVisible) {
+    await expect(stopButton).toBeHidden({ timeout: 120000 });
+  }
+}
+
+// Open the Playground with the pre-seeded task and send it.
+async function openPlaygroundAndSend(page: Page): Promise<void> {
+  await page.getByTestId("playground-btn-flow-io").click();
+  const chatInput = page.getByTestId("input-chat-playground").last();
+  await expect(chatInput).toBeVisible({ timeout: 30000 });
+  await expect(chatInput).toHaveValue(TASK, { timeout: 15000 });
+  await page.getByTestId("button-send").last().click();
+  await waitForAgentToFinish(page);
+}
+
+const targets = getTestTargets();
+
+// SimpleAgentTemplatePage.load() deletes all flows before loading the template;
+// serial mode + --workers=1 keeps the shared instance state deterministic.
+test.describe.configure({ mode: "serial" });
+
+for (const { label, options, skipReason } of targets) {
+  const provider = options.provider ?? (Object.keys(providerConfigMap)[0] as Provider);
+
+  test.describe(`Agent Tool Name Validation [${label}]`, () => {
+    test(
+      "an invalid tool name blocks execution with a clear message",
+      { tag: ["@stable", "@regression", "@agents", "@playground"] },
+      async ({ page, request }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        await loadAgent(page, options);
+
+        await test.step("rename the URL tool to an invalid function name", async () => {
+          await renameUrlTool(page, INVALID_TOOL_NAME);
+          await setChatInputText(page, TASK);
+          await waitForFlowSaveSettled(page);
+          await expectPersistedToolName(page, request, "invalid_tool_name!!");
+        });
+
+        await test.step("run and assert the clear invalid-name error", async () => {
+          // The failure is the scenario under test — the provider rejects the
+          // request at validation, before any inference.
+          (page as any).allowFlowErrors();
+          await openPlaygroundAndSend(page);
+          await expect(page.getByText(INVALID_NAME_ERROR).first()).toBeVisible({
+            timeout: 60000,
+          });
+        });
+      },
+    );
+
+    test(
+      "causal control — a valid custom tool name executes normally",
+      { tag: ["@stable", "@regression", "@agents", "@playground"] },
+      async ({ page, request }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        await loadAgent(page, options);
+
+        await test.step("rename the URL tool to a valid custom name", async () => {
+          await renameUrlTool(page, VALID_TOOL_NAME);
+          await setChatInputText(page, TASK);
+          await waitForFlowSaveSettled(page);
+          await expectPersistedToolName(page, request, VALID_TOOL_NAME);
+        });
+
+        await test.step("run and assert a normal answer with no error", async () => {
+          // No allowFlowErrors here: any flow error fails the test via the
+          // fixture, which is itself half of the causal-pair guarantee.
+          await openPlaygroundAndSend(page);
+          const bubble = page.getByTestId("div-chat-message").last();
+          await expect(bubble).toBeVisible({ timeout: 30000 });
+          await expect(bubble).toContainText(/hello/i, { timeout: 30000 });
+          await expect(page.getByText(INVALID_NAME_ERROR)).toHaveCount(0);
+        });
+      },
+    );
+  });
+}


### PR DESCRIPTION
## What

Closes #490 (Wave 1 — Agents & providers).

New spec `tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-name-validation.spec.ts` + spec doc `docs/core-functionality/llm-agents/agent-tool-name-validation.md`, covering QA-CHECKLIST **§6.4 — "Tool with invalid name — validation prevents execution with clear message"** (bullet flipped to `[x]`).

| # | Test | What it does | What it validates |
|---|---|---|---|
| 1 | `an invalid tool name blocks execution with a clear message` | Loads Simple Agent, renames the URL tool's slug to `invalid tool name!!` in the tools modal, verifies the persisted name via the flows API, sends a Playground message | Execution is blocked: a visible Playground error matches `/invalid function name\|does not match pattern\|INVALID_ARGUMENT/i` (provider request-validation 400, before any inference — zero tokens) |
| 2 | `causal control — a valid custom tool name executes normally` | Identical flow, renamed to the valid `fetch_content_renamed` | The agent answers (no error surface; the fixture fails on any flow error) — proving Test 1's failure is caused by the invalid characters, not the rename machinery |

## Where the "validation" lives (scope note)

Scouted on the live nightly: Langflow **1.11 has no edit-time validation** of tool names — the tools modal accepts the name (normalizing only case/spaces; `!` passes through) and the backend assigns it verbatim to the LangChain tool (`component_tool.py` → `update_tools_metadata`). The block observed by the user is the provider's deterministic 400. The checklist observable ("prevents execution with clear message") holds; the **missing edit-time validation is flagged here as a potential upstream improvement**, not asserted against.

## Implementation notes

- The canvas URL flow id is **transient** on 1.11 (GET by that id 404s) — the persisted-rename check resolves the flow from the flows list instead (unique after the template wipe).
- Test 1 consumes **zero LLM tokens** (rejected at request validation); Test 2 performs one cheap completion.

## Validation

- Langflow nightly **1.11.0.dev33** (`langflowai/langflow-nightly:latest`, image current at time of validation).
- **7 clean `--retries=0` runs** (`--workers=1`): `2 passed` each, ~22–24s, zero `🚨 Backend Error`.
- **Force-failure verified in both directions** (mutations confirmed applied before each run):
  - M1 — a *valid* name in Test 1 → Test 1 **failed** (no false positive if nothing blocks execution).
  - M2 — an *invalid* name in Test 2 → Test 2 **failed** (control catches rename machinery breaking execution).
- `npm run typecheck` and `npm run lint`: 0 errors.
- `npm run coverage:summary` regenerated (271 `@stable` tests across 97 spec files).
- ⚠️ Environment limitation (not spec-specific): `--trace=on` hangs (>600s) for Simple Agent–template specs — reproduced on the already-merged `agent-max-iterations.spec.ts` too. Steps were verified via green runs, force-fail mutations, and live scouting instead. Follow-up candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)