### PR TITLE
test(llm-agents): tool error handled as observation, agent continues (#489)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -350,7 +350,7 @@
 #### 6.4 Tools and Integrations
 - [ ] Agent with integrated external MCP tool executes action and returns result
 - [ ] Agent executes multiple tools in sequence
-- [ ] Tool returns error — agent handles it and continues execution → `agent-tool-error-handling.spec.ts`
+- [x] Tool returns error — agent handles it and continues execution → `core-functionality/llm-agents/agent-tool-error-handling.spec.ts`
 - [ ] Multiple connected tools — agent selects the correct one for each prompt → `agent-multi-tool-selection.spec.ts`
 - [x] Tool with invalid name — validation prevents execution with clear message → `core-functionality/llm-agents/agent-tool-name-validation.spec.ts`
 
@@ -756,7 +756,7 @@
 | `core-components/` — Core Components | 82 | 79 | 0 | 1 | 2 |
 | `core-functionality/auth/` | 21 | 8 | 13 | 0 | 0 |
 | `core-functionality/knowledge-ingestion/` | 8 | 0 | 4 | 0 | 4 |
-| `core-functionality/llm-agents/` | 40 | 22 | 2 | 0 | 16 |
+| `core-functionality/llm-agents/` | 40 | 23 | 2 | 0 | 15 |
 | `core-functionality/model-provider/` | 33 | 19 | 7 | 0 | 7 |
 | `core-functionality/observability-monitoring/` | 23 | 15 | 7 | 0 | 1 |
 | `core-functionality/playground/` | 48 | 43 | 3 | 1 | 1 |
@@ -767,7 +767,7 @@
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 44 | 7 | 36 | 1 | 0 |
 | `ui-ux/` — Settings | 7 | 3 | 3 | 1 | 0 |
-| **TOTAL** | **451** | **245 (54%)** | **161 (36%)** | **7 (2%)** | **38 (8%)** |
+| **TOTAL** | **451** | **246 (55%)** | **161 (36%)** | **7 (2%)** | **37 (8%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -783,7 +783,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 271 `test()` calls carrying the `@stable` tag, distributed across 97 spec
+> 272 `test()` calls carrying the `@stable` tag, distributed across 98 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -945,6 +945,7 @@
 - [x] causal control — a large n_messages retrieves the full seeded history → `agent-n-messages-limit.spec.ts`
 - [x] Agent Instructions are respected in the model response → `agent-system-prompt.spec.ts`
 - [x] negative control — sentinel is absent without the instruction → `agent-system-prompt.spec.ts`
+- [x] agent handles a tool error and continues execution → `agent-tool-error-handling.spec.ts`
 - [x] an invalid tool name blocks execution with a clear message → `agent-tool-name-validation.spec.ts`
 - [x] causal control — a valid custom tool name executes normally → `agent-tool-name-validation.spec.ts`
 - [x] user must be able to send images in the playground with the agent component → `general-bugs-agent-images-playground.spec.ts`
@@ -1094,7 +1095,7 @@
 | `core-components/` — Component Config | 18 | 1 |
 | `core-components/` — Core Components | 0 | 2 |
 | `core-functionality/auth/` | 13 | 0 |
-| `core-functionality/llm-agents/` | 2 | 16 |
+| `core-functionality/llm-agents/` | 2 | 15 |
 | `core-functionality/model-provider/` | 7 | 7 |
 | `core-functionality/playground/` | 3 | 1 |
 | `mcp/client/` | 7 | 2 |

--- a/docs/core-functionality/llm-agents/agent-tool-error-handling.md
+++ b/docs/core-functionality/llm-agents/agent-tool-error-handling.md
@@ -1,0 +1,141 @@
+# Agent tool error — handled as an observation, execution continues
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+QA-CHECKLIST §6.4 "Tool returns error — agent handles it and continues
+execution". When a tool call fails at runtime, the Agent must not crash the
+flow: the error is converted into an observation for the model
+(`handle_tool_error=True` on every component tool —
+`component_tool.py` → `_build_tools`), the agent keeps executing, and the run
+ends with a normal AI answer that reports the failure.
+
+A single test proves both halves of the bullet in one run (the pair is
+intrinsic — error *and* continuation happen in the same execution):
+
+1. **The tool really errored** — the persisted AI message's `tool_use`
+   content block for `fetch_content` has an `output.content` containing the
+   backend's SSRF rejection (`"SSRF Protection: Hostname localhost resolves
+   to blocked IP address(es)…"`), asserted via the monitor API.
+2. **The agent handled it and continued** — the Playground shows a final AI
+   reply starting with the instructed `TOOL_FAILED:` sentinel, and the run
+   produces **no flow error** (the fixture fails the test on any — no
+   `allowFlowErrors`).
+
+> **Error generator — deliberate use of SSRF protection.** The tool failure
+> is produced by asking the agent to fetch
+> `http://localhost:7860/api/v1/version`: Langflow's SSRF protection (an
+> intentional security feature, not a bug) blocks fetches to internal IPs,
+> so the URL tool fails **always, instantly, offline, with a stable
+> message** — the most deterministic tool-error source available (same
+> technique validated in `agent-max-iterations`, #481). Any failing URL
+> would exercise the same `handle_tool_error` path; this one does it without
+> external network or DNS-timeout variance.
+
+> **Rendering note (scouted on 1.11.0.dev33).** The `Error using **tool**`
+> header (`events.py` → `handle_on_tool_error`) does NOT fire on this path:
+> with `handle_tool_error=True` the exception becomes a normal tool output,
+> so the chat block renders "Executed **fetch_content**" with the error text
+> as the tool's output. Assertions therefore target the tool output content
+> and the agent's final reply — not the transient error header.
+
+If this test fails, a failing tool crashes or silently ends agent runs — the
+core resilience contract of tool-calling agents.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@agents` `@playground`
+
+`@stable` added only after multiple clean `--retries=0` runs on the fresh
+nightly. `@regression` — guards the `handle_tool_error=True` wiring and the
+agent's continue-after-error loop; `@agents` — agent tool-calling behavior;
+`@playground` — the run and the reply observable live in the Playground.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- `models.json` / `providers.json` generated via
+  `npx playwright test tests/collect-models.spec.ts`.
+- At least one active provider API key in `.env`.
+- Run with `--workers=1` — the spec is serial
+  (`SimpleAgentTemplatePage.load()` wipes all flows).
+
+---
+
+## Step by step *(required)*
+
+The spec generates **1 test per active model** via `getTestTargets()` (same
+machinery as `agent-max-iterations.spec.ts` / `agent-tool-name-validation.spec.ts`).
+
+**Test — agent handles a tool error and continues execution** (§6.4)
+
+1. Load the Simple Agent template (provider/model from `models.json`/`.env`).
+2. Set the Agent Instructions: force the fetch tool for URL questions and
+   instruct the failure sentinel — *"If a tool call fails or returns an
+   error, reply with a message that starts with `TOOL_FAILED:` followed by
+   the reason."*
+3. Seed the task on the ChatInput node (Playground prefill re-injection
+   race): *"Fetch http://localhost:7860/api/v1/version and tell me the exact
+   version value it returns. (probe `<nonce>`)"* — the per-run nonce keys the
+   monitor-API lookup to THIS run's session.
+4. Open the Playground, send, wait for the run to finish.
+5. **Continuation assert (UI):** the final AI bubble contains `TOOL_FAILED`.
+6. **Tool-error assert (API):** poll `GET /api/v1/monitor/messages` — find
+   the user message containing the nonce, take its `session_id`, find that
+   session's AI message, and assert its `fetch_content` `tool_use` block's
+   output contains `SSRF Protection`.
+7. No `allowFlowErrors`: any flow error fails the test via the fixture —
+   that IS the "handled without crashing" guarantee.
+
+---
+
+## Validation criterion *(required)*
+
+In one run: the fetch tool's persisted output contains the SSRF rejection
+(the tool really failed) **and** the agent still produced a final reply
+carrying the `TOOL_FAILED` sentinel (it handled the error and continued),
+with zero flow errors. Both must hold; either alone is insufficient.
+
+## Guarding against false positives *(how)*
+
+- **Nonce-keyed session lookup:** monitor messages persist across wipes and
+  earlier runs of this very spec leave identical SSRF outputs behind — the
+  per-run nonce pins every API assertion to the current run's session.
+- **Two-layer pair:** the API assert alone could pass with a crashed UI run;
+  the UI sentinel alone could pass if the tool never errored (model
+  hallucinating a failure). Together they close both gaps.
+- **Sentinel-based continuation proof:** an instructed `TOOL_FAILED:` prefix
+  is model-followable and specific; a bare "bubble is non-empty" check would
+  pass on any reply. (Fallback if the sentinel proves flaky across models:
+  assert non-empty reply + `/SSRF|blocked|fail/i` content — weaker, noted
+  here so the deviation is a spec change, not a silent one.)
+- **Force-failure checks** (CONTRIBUTING §2): M1 — replace the target with a
+  fetchable public URL ⇒ the SSRF assert must fail; M2 — demand an
+  impossible sentinel ⇒ the continuation assert must fail.
+
+---
+
+## What this test does not cover *(optional)*
+
+- The transient `Error using` streaming header (does not fire on the
+  handled-error path — see Rendering note).
+- Agent behavior when ALL tool calls fail repeatedly across many iterations
+  (covered indirectly by `agent-max-iterations`).
+- `handle_parsing_errors` (LLM output parsing — separate bullet, #496).
+
+---
+
+## External dependencies *(required)*
+
+- **LLM provider API** (per `models.json` target): one completion with one
+  failed tool round-trip — no external network is reached (the fetch is
+  blocked before egress).
+- `tests/helpers/provider-setup/data/models.json` + `providers.json`
+  (collect-models).

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-error-handling.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-error-handling.spec.ts
@@ -1,0 +1,285 @@
+import * as dotenv from "dotenv";
+import path from "path";
+import fs from "fs";
+import type { Page } from "@playwright/test";
+import type { APIRequestContext } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
+import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import {
+  hasProviderEnvKeys,
+  missingProviderEnvKeys,
+  providerConfigMap,
+  type Provider,
+} from "../../../../helpers/provider-setup";
+import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+
+/**
+ * Agent tool error handling (QA-CHECKLIST §6.4 "Tool returns error — agent
+ * handles it and continues execution").
+ *
+ * One run proves both halves of the bullet (the pair is intrinsic):
+ *   (a) the fetch tool REALLY errored — its persisted tool_use output contains
+ *       the backend's SSRF rejection (monitor API, keyed to this run's session
+ *       via a per-run nonce);
+ *   (b) the agent handled it and CONTINUED — the final Playground reply carries
+ *       the instructed TOOL_FAILED sentinel, and the fixture (no
+ *       allowFlowErrors) fails the test on any flow error.
+ *
+ * The error generator is Langflow's own SSRF protection (an intentional
+ * security feature): fetching http://localhost:7860/... fails always,
+ * instantly and offline with a stable message — the most deterministic
+ * tool-error source available (same technique as agent-max-iterations, #481).
+ * Note: with handle_tool_error=True the exception becomes a normal tool
+ * output ("Executed **fetch_content**"), NOT an "Error using" header — see
+ * the spec doc's Rendering note.
+ */
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
+}
+
+const TARGET_URL = "http://localhost:7860/api/v1/version";
+const SYSTEM_PROMPT =
+  "You have web tools. To answer any question about a URL you MUST call the URL fetch tool - never guess or invent responses. " +
+  "If a tool call fails or returns an error, reply with a message that starts with TOOL_FAILED: followed by the reason.";
+const SSRF_MARKER = /SSRF Protection/i;
+const CONTINUATION_SENTINEL = /TOOL_FAILED/i;
+
+interface ModelRecord {
+  provider: string;
+  model: string;
+}
+
+interface TestTarget {
+  label: string;
+  options: LoadSimpleAgentOptions;
+  skipReason?: string;
+}
+
+function getProviderSkipReasons(): Map<string, string> {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/providers.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
+    return new Map();
+  }
+  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
+  const reasons = new Map<string, string>();
+  for (const r of records) {
+    if (r.status === "inactive") {
+      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
+    }
+  }
+  return reasons;
+}
+
+function getModelsFromJson(): ModelRecord[] {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/models.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("models.json not found — run collect-models.spec.ts first.");
+    return [];
+  }
+  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
+}
+
+function getTestTargets(): TestTarget[] {
+  const skipReasons = getProviderSkipReasons();
+
+  if (process.env.MODEL_TEST_ID) {
+    const model = process.env.MODEL_TEST_ID;
+    const allModels = getModelsFromJson();
+    const record = allModels.find((m) => m.model === model);
+    if (!record) {
+      console.warn(`MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred.`);
+      return [{ label: `model:${model}`, options: { model } }];
+    }
+    const provider = record.provider as Provider;
+    return [{
+      label: `${provider} / ${model}`,
+      options: { provider, model },
+      skipReason: skipReasons.get(provider),
+    }];
+  }
+
+  const allModels = getModelsFromJson();
+  if (allModels.length === 0) {
+    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
+    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
+    return [{
+      label: `provider:${fallbackProvider} (fallback)`,
+      options: { provider: fallbackProvider },
+      skipReason: skipReasons.get(fallbackProvider),
+    }];
+  }
+
+  let models = allModels;
+  if (process.env.MODEL_TEST_PROVIDER) {
+    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
+  } else if (process.env.ALL_MODELS !== "true") {
+    const seen = new Set<string>();
+    models = models.filter((m) => {
+      if (seen.has(m.provider)) return false;
+      seen.add(m.provider);
+      return true;
+    });
+  }
+
+  return models.map((m) => ({
+    label: `${m.provider} / ${m.model}`,
+    options: { provider: m.provider as Provider, model: m.model },
+    skipReason: skipReasons.get(m.provider),
+  }));
+}
+
+async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
+  try {
+    await new SimpleAgentTemplatePage(page).load(options);
+  } catch (e: any) {
+    if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
+    throw e;
+  }
+}
+
+// Set the Agent Instructions (system prompt) on the node.
+async function setSystemPrompt(page: Page, prompt: string): Promise<void> {
+  const field = page.getByTestId("textarea_str_system_prompt");
+  await expect(field).toBeVisible({ timeout: 15000 });
+  await field.click();
+  await field.fill(prompt);
+  await field.blur();
+}
+
+// Set the task on the ChatInput node (the Playground prompt pre-fills from it;
+// typing into the Playground races an async default re-injection).
+async function setChatInputText(page: Page, text: string): Promise<void> {
+  const field = page.locator(
+    '[data-testid^="rf__node-ChatInput"] [data-testid="textarea_str_input_value"]',
+  );
+  await expect(field).toBeVisible({ timeout: 15000 });
+  await field.click();
+  await field.fill(text);
+  await field.blur();
+}
+
+async function waitForAgentToFinish(page: Page): Promise<void> {
+  const stopButton = page.getByRole("button", { name: "Stop" });
+  const stopVisible = await stopButton.isVisible({ timeout: 10000 }).catch(() => false);
+  if (stopVisible) {
+    await expect(stopButton).toBeHidden({ timeout: 120000 });
+  }
+}
+
+// Open the Playground with the pre-seeded task and send it.
+async function openPlaygroundAndSend(page: Page, task: string): Promise<void> {
+  await page.getByTestId("playground-btn-flow-io").click();
+  const chatInput = page.getByTestId("input-chat-playground").last();
+  await expect(chatInput).toBeVisible({ timeout: 30000 });
+  await expect(chatInput).toHaveValue(task, { timeout: 15000 });
+  await page.getByTestId("button-send").last().click();
+  await waitForAgentToFinish(page);
+}
+
+// Monitor-API check that the fetch tool's persisted output carries the SSRF
+// rejection — proof the tool REALLY errored in THIS run. Messages persist
+// across flow wipes (earlier runs of this spec leave identical outputs
+// behind), so the lookup is keyed to the current run's session via the
+// nonce embedded in the user message.
+async function expectToolErrorPersisted(
+  request: APIRequestContext,
+  nonce: string,
+): Promise<void> {
+  const bearer = await getAuthToken(request);
+  await expect
+    .poll(
+      async () => {
+        const res = await request.get("/api/v1/monitor/messages", {
+          headers: { Authorization: bearer },
+        });
+        if (res.status() !== 200) return `GET monitor -> ${res.status()}`;
+        const messages = await res.json();
+        if (!Array.isArray(messages)) return "monitor payload not a list";
+
+        const userMsg = messages.find(
+          (m: any) => m.sender !== "Machine" && (m.text ?? "").includes(nonce),
+        );
+        if (!userMsg) return "user message with nonce not persisted yet";
+
+        const aiMsg = messages.find(
+          (m: any) =>
+            m.sender === "Machine" &&
+            m.session_id === userMsg.session_id &&
+            (m.content_blocks?.length ?? 0) > 0,
+        );
+        if (!aiMsg) return "AI message for the session not persisted yet";
+
+        const toolBlocks = (aiMsg.content_blocks as any[])
+          .flatMap((b: any) => b.contents ?? [])
+          .filter((c: any) => c.type === "tool_use" && c.name === "fetch_content");
+        if (toolBlocks.length === 0) return "no fetch_content tool_use block";
+
+        return toolBlocks.some((c: any) => SSRF_MARKER.test(JSON.stringify(c.output ?? "")))
+          ? "tool-error-persisted"
+          : `fetch_content output has no SSRF rejection: ${JSON.stringify(toolBlocks[0].output).slice(0, 120)}`;
+      },
+      { timeout: 30000 },
+    )
+    .toBe("tool-error-persisted");
+}
+
+const targets = getTestTargets();
+
+// SimpleAgentTemplatePage.load() deletes all flows before loading the template;
+// serial mode + --workers=1 keeps the shared instance state deterministic.
+test.describe.configure({ mode: "serial" });
+
+for (const { label, options, skipReason } of targets) {
+  const provider = options.provider ?? (Object.keys(providerConfigMap)[0] as Provider);
+
+  test.describe(`Agent Tool Error Handling [${label}]`, () => {
+    test(
+      "agent handles a tool error and continues execution",
+      { tag: ["@stable", "@regression", "@agents", "@playground"] },
+      async ({ page, request }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        const nonce = `probe-${Date.now()}`;
+        const task = `Fetch ${TARGET_URL} and tell me the exact "version" value it returns. (${nonce})`;
+
+        await loadAgent(page, options);
+
+        await test.step("force the fetch tool, instruct the failure sentinel, seed the task", async () => {
+          await setSystemPrompt(page, SYSTEM_PROMPT);
+          await setChatInputText(page, task);
+          await waitForFlowSaveSettled(page);
+        });
+
+        await test.step("run — the SSRF-blocked fetch makes the tool error deterministically", async () => {
+          // No allowFlowErrors: a crashed run fails here via the fixture,
+          // which is half of the "handled" guarantee.
+          await openPlaygroundAndSend(page, task);
+        });
+
+        await test.step("agent continued: final reply carries the TOOL_FAILED sentinel", async () => {
+          const bubble = page.getByTestId("div-chat-message").last();
+          await expect(bubble).toBeVisible({ timeout: 30000 });
+          await expect(bubble).toContainText(CONTINUATION_SENTINEL, { timeout: 30000 });
+        });
+
+        await test.step("tool really errored: persisted tool output carries the SSRF rejection", async () => {
+          await expectToolErrorPersisted(request, nonce);
+        });
+      },
+    );
+  });
+}


### PR DESCRIPTION
## What

Closes #489 (Wave 1 — Agents & providers).

New spec `tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-error-handling.spec.ts` + spec doc `docs/core-functionality/llm-agents/agent-tool-error-handling.md`, covering QA-CHECKLIST **§6.4 — "Tool returns error — agent handles it and continues execution"** (bullet flipped to `[x]`).

| # | Test | What it does | What it validates |
|---|---|---|---|
| 1 | `agent handles a tool error and continues execution` | Loads Simple Agent; system prompt forces the fetch tool and instructs a failure sentinel ("reply starting with `TOOL_FAILED:`"); the task asks to fetch `http://localhost:7860/api/v1/version` (SSRF-blocked ⇒ deterministic tool error) with a per-run nonce; runs in the Playground | **(a)** the tool really errored: monitor API — the nonce-keyed session's AI message has a `fetch_content` `tool_use` block whose output contains `SSRF Protection` · **(b)** the agent continued: the final bubble contains `TOOL_FAILED` · **(c)** zero flow errors (fixture active, no `allowFlowErrors`) = "handled" |

## Design notes

- **Error generator:** Langflow's own SSRF protection (an intentional security feature) — fetching an internal URL fails always, instantly, offline, with a stable message. No external network or DNS variance (same technique as `agent-max-iterations`, #481).
- **Nonce-keyed API assert:** monitor messages persist across flow wipes; earlier runs of this very spec leave identical SSRF outputs behind. The per-run nonce in the user message pins the lookup to the current run's session — no vacuous pass.
- **Rendering note (scouted live):** with `handle_tool_error=True` the exception becomes a normal tool output ("Executed **fetch_content**"); the `Error using` streaming header does not fire on this path. Assertions target the persisted output + final reply.
- **Determinism:** the tool error and both hard asserts are deterministic; the two LLM-dependent behaviors (calling the tool, obeying the sentinel) fail SAFE — disobedience fails the test, it can never pass falsely.

## Validation

- Langflow nightly **1.11.0.dev33** (`langflowai/langflow-nightly:latest`, image current at time of validation).
- **5 green `--retries=0` runs** (`--workers=1`), ~13s each; sentinel obeyed 6/6 including the live scout.
- **Force-failure verified in both directions** (mutations confirmed applied before each run):
  - M1 — a fetchable public URL instead of localhost → test **failed** (SSRF assert cannot pass without a real tool error).
  - M2 — an impossible continuation sentinel → test **failed** (continuation assert cannot pass vacuously).
- `npm run typecheck` and `npm run lint`: 0 errors.
- `npm run coverage:summary` regenerated (272 `@stable` tests across 98 spec files).
- `--trace=on` skipped: known environment limitation for Simple Agent–template specs (tracing hangs the run; reproduced on merged `agent-max-iterations.spec.ts` — see PR #542's Validation notes). Steps verified via green runs, force-fail mutations and live scouting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)