### PR TITLE
test(core-components): harden Prompt Template sidebar setup against re-render flake (#537)

### DIFF
--- a/tests/helpers/ui/prompt-template.ts
+++ b/tests/helpers/ui/prompt-template.ts
@@ -1,6 +1,7 @@
 import { type Locator, type Page, expect } from "@playwright/test";
 import { awaitBootstrapTest } from "../other/await-bootstrap-test";
 import { waitForFlowSaveSettled } from "../flows/wait-for-flow-save-settled";
+import { addComponentFromSidebar } from "../flows/add-component-from-sidebar";
 import { adjustScreenView } from "./adjust-screen-view";
 
 // `waitForFlowSaveSettled` now lives in the flows domain (autosave is a flow
@@ -34,6 +35,14 @@ const MUSTACHE_TEXTAREA = "modal-mustachepromptarea_mustache_template";
  * sidebar search/add path, and waits for exactly one node to render on the
  * canvas.
  *
+ * It waits for `sidebar-search-input` to be visible before interacting: the
+ * flow editor's left sidebar re-renders as its component catalog streams in,
+ * and touching the input too early detaches it mid-click, which hard-failed the
+ * prompt-template specs under a slow CI cluster (issue #537). The search/add is
+ * delegated to `addComponentFromSidebar` — a `fill` (no stability-sensitive
+ * `click`) — mirroring the hardening already applied in `setupPlayground`
+ * (issue #278).
+ *
  * Before returning, it waits for the node-add / viewport autosaves to settle
  * (`waitForFlowSaveSettled`) so the next flow-save the caller triggers — e.g.
  * saving the prompt modal — runs on its own and cannot race a still-in-flight
@@ -44,12 +53,14 @@ export async function addPromptComponent(page: Page): Promise<void> {
   await expect(page.getByTestId("blank-flow")).toBeAttached({ timeout: 30000 });
   await page.getByTestId("blank-flow").click();
 
-  await page.getByTestId("sidebar-search-input").click();
-  await page.getByTestId("sidebar-search-input").fill("prompt");
-  await expect(
-    page.getByTestId("add-component-button-prompt-template"),
-  ).toBeAttached({ timeout: 30000 });
-  await page.getByTestId("add-component-button-prompt-template").click();
+  await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
+    timeout: 30000,
+  });
+  await addComponentFromSidebar(
+    page,
+    "prompt",
+    "add-component-button-prompt-template",
+  );
 
   await adjustScreenView(page);
   await expect(page.locator(".react-flow__node")).toHaveCount(1, {


### PR DESCRIPTION
Closes #537

## Problem

The daily `@stable` run [28802767398](https://github.com/oriontech-me/langflow-e2e/actions/runs/28802767398) hard-failed `prompt-template-invalid-patterns-regression.spec.ts` (`{}` empty-braces and `{1var}` cases). The trace shows the failure is **not** in the parser assertions — it's the shared setup helper `addPromptComponent`:

```
TimeoutError: locator.click: Timeout 20000ms exceeded.
  - waiting for getByTestId('sidebar-search-input')
  - element is not visible / element is not stable
  - element was detached from the DOM, retrying
```

## Root cause

After clicking `blank-flow`, the flow editor's left sidebar mounts and then re-renders (briefly detaching its subtree) as the component catalog streams in. `addPromptComponent` clicked `sidebar-search-input` immediately — and `click` requires a positionally *stable* target, which the re-rendering sidebar can't provide, so every attempt exhausted the action timeout. A slow CI cluster in this run widened the race into a hard failure; the same signature hit unrelated specs (`If-Else`, `clear chat`) in the same run, confirming it is a shared-setup timing issue, not a parser defect.

## Fix

Align `addPromptComponent` with the already-hardened `setupPlayground` pattern (#278): wait for `sidebar-search-input` to be visible before interacting, and delegate the search/add to the existing `addComponentFromSidebar` primitive — a `fill` (no stability check) instead of the fragile `click`. This also removes the hand-rolled duplication of the sidebar-add mechanism.

## Shared-file note

`addPromptComponent` is consumed by the ~6 prompt-template specs. The change is purely additive robustness — the removed `.click()` only focused the input, which `.fill()` already does — so no consumer behavior changes. No spec doc change: the validated behavior is unchanged and the tests keep `@stable`.

## Validation

- `npm run typecheck` and `npm run lint` pass.
- Reproduced the original failure locally with the pre-fix helper (detach at `prompt-template.ts:47`); after the fix that signature no longer occurs.

## Follow-up (out of scope)

While reproducing, the local instance surfaced heavy flow accumulation (~1.5k flows) because these specs create blank flows via the UI and never delete them. Migrating the prompt-template cluster to API-based flow creation + `afterEach` cleanup (the `setupBlankFlow` pattern already used by `singleton-components`, `componentDelete`, etc.) would remove both the UI-creation race and the accumulation — tracked separately, not in this flake fix.

Related: #278 (sibling pattern), #358 (prior flake tracking), #536 (umbrella run issue).