### PR TITLE
test(core-components): create prompt-template flows via API with afterEach cleanup (#545)

### DIFF
--- a/tests/helpers/ui/prompt-template.ts
+++ b/tests/helpers/ui/prompt-template.ts
@@ -1,5 +1,4 @@
 import { type Locator, type Page, expect } from "@playwright/test";
-import { awaitBootstrapTest } from "../other/await-bootstrap-test";
 import { waitForFlowSaveSettled } from "../flows/wait-for-flow-save-settled";
 import { addComponentFromSidebar } from "../flows/add-component-from-sidebar";
 import { adjustScreenView } from "./adjust-screen-view";
@@ -31,16 +30,22 @@ const MUSTACHE_OPEN_BUTTON = "button_open_mustache_prompt_modal";
 const MUSTACHE_TEXTAREA = "modal-mustachepromptarea_mustache_template";
 
 /**
- * Bootstraps a fresh blank flow, drops a Prompt Template node onto it via the
+ * Drops a Prompt Template node onto the currently-open blank flow via the
  * sidebar search/add path, and waits for exactly one node to render on the
  * canvas.
  *
+ * The caller is responsible for creating and opening the blank flow first —
+ * use `setupBlankFlow` (API creation + navigation), which returns the flow id
+ * for `afterEach` cleanup (issue #545). Creating the flow via the REST API
+ * instead of the UI avoids the `POST /api/v1/flows/` 500 race that made these
+ * specs flaky under load, and pairing it with a teardown stops the blank-flow
+ * accumulation the UI path left behind.
+ *
  * It waits for `sidebar-search-input` to be visible before interacting: the
  * flow editor's left sidebar re-renders as its component catalog streams in,
- * and touching the input too early detaches it mid-click, which hard-failed the
- * prompt-template specs under a slow CI cluster (issue #537). The search/add is
- * delegated to `addComponentFromSidebar` — a `fill` (no stability-sensitive
- * `click`) — mirroring the hardening already applied in `setupPlayground`
+ * and touching the input too early detaches it mid-click (issue #537). The
+ * search/add is delegated to `addComponentFromSidebar` — a `fill` (no
+ * stability-sensitive `click`) — mirroring the hardening in `setupPlayground`
  * (issue #278).
  *
  * Before returning, it waits for the node-add / viewport autosaves to settle
@@ -49,10 +54,6 @@ const MUSTACHE_TEXTAREA = "modal-mustachepromptarea_mustache_template";
  * autosave into a spurious "Failed to save flow" toast (issue #358).
  */
 export async function addPromptComponent(page: Page): Promise<void> {
-  await awaitBootstrapTest(page);
-  await expect(page.getByTestId("blank-flow")).toBeAttached({ timeout: 30000 });
-  await page.getByTestId("blank-flow").click();
-
   await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
     timeout: 30000,
   });

--- a/tests/tests-automations/regression/core-components/prompt-template-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/prompt-template-component-regression.spec.ts
@@ -4,19 +4,37 @@ import {
   dynamicHandlesLocator,
   fillPromptTemplate,
 } from "../../../helpers/ui/prompt-template";
+import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
 
-// Run serially to avoid 500 errors from concurrent POST /api/v1/flows/
-// when several workers create a blank flow at the same time.
+// Flows are created via the REST API (setupBlankFlow) and deleted in afterEach
+// (issue #545). Kept serial so the per-file flow lifecycle stays deterministic
+// under load.
 test.describe.configure({ mode: "serial" });
+
+let createdFlowId: string | null = null;
+
+test.beforeEach(async ({ page }) => {
+  // setupBlankFlow creates the flow via API (no UI-creation 500 race) and
+  // returns its id so afterEach can delete it. Capturing the id before the
+  // component add means a failure in addPromptComponent still cleans up.
+  createdFlowId = await setupBlankFlow(page);
+  await addPromptComponent(page);
+});
+
+test.afterEach(async ({ page }) => {
+  if (createdFlowId) {
+    // Leave the editor first: staying on it while the flow is deleted makes
+    // background polling 404, which the fixture's error monitor would flag.
+    await page.goto("/").catch(() => {});
+    await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+    createdFlowId = null;
+  }
+});
 
 test(
   "Prompt Template component — renders on canvas with output handle",
   { tag: ["@stable", "@release", "@regression", "@components"] },
   async ({ page }) => {
-    await test.step("Add Prompt Template to a blank flow", async () => {
-      await addPromptComponent(page);
-    });
-
     await test.step("Node title is visible on the canvas", async () => {
       await expect(page.getByTestId("title-Prompt Template")).toBeVisible({
         timeout: 10000,
@@ -42,10 +60,6 @@ test(
   "Prompt Template component — variables in curly braces generate dynamic input handles",
   { tag: ["@stable", "@release", "@regression", "@components"] },
   async ({ page }) => {
-    await test.step("Add Prompt Template to a blank flow", async () => {
-      await addPromptComponent(page);
-    });
-
     await test.step(
       "Save template with two {variable} placeholders",
       async () => {
@@ -82,10 +96,6 @@ test(
       "handle-prompt template-shownode-name-left",
     );
 
-    await test.step("Add Prompt Template to a blank flow", async () => {
-      await addPromptComponent(page);
-    });
-
     await test.step(
       "Save template `Hello {name}!` — expect 1 dynamic handle for {name}",
       async () => {
@@ -110,10 +120,6 @@ test(
   "Prompt Template component — replacing a variable updates handles accordingly",
   { tag: ["@stable", "@release", "@regression", "@components"] },
   async ({ page }) => {
-    await test.step("Add Prompt Template to a blank flow", async () => {
-      await addPromptComponent(page);
-    });
-
     await test.step(
       "Save template `Hello {name}, you are {role}.` — both handles render",
       async () => {
@@ -149,10 +155,6 @@ test(
   "Prompt Template component — clearing the template removes all dynamic handles",
   { tag: ["@stable", "@release", "@regression", "@components"] },
   async ({ page }) => {
-    await test.step("Add Prompt Template to a blank flow", async () => {
-      await addPromptComponent(page);
-    });
-
     await test.step(
       "Save template with 3 variables — expect 3 dynamic handles",
       async () => {
@@ -180,13 +182,10 @@ test(
   { tag: ["@stable", "@release", "@regression", "@components"] },
   async ({ page }) => {
     const expected = "Persisted prompt text {topic}.";
-    let flowId = "";
-
-    await test.step("Add Prompt Template to a blank flow", async () => {
-      await addPromptComponent(page);
-      flowId = page.url().split("/").slice(-1)[0];
-      expect(flowId).toMatch(/^[0-9a-f-]{36}$/);
-    });
+    // The flow is created in beforeEach; `createdFlowId` is its authoritative
+    // API id — assert its shape here to keep the original UUID sanity check.
+    expect(createdFlowId).toMatch(/^[0-9a-f-]{36}$/);
+    const flowId = createdFlowId as string;
 
     await test.step(
       "Save template — the {topic} handle confirms save was applied",

--- a/tests/tests-automations/regression/core-components/prompt-template-double-brackets-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/prompt-template-double-brackets-regression.spec.ts
@@ -6,10 +6,32 @@ import {
   fillPromptTemplate,
   setUseDoubleBrackets,
 } from "../../../helpers/ui/prompt-template";
+import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
 
-// Run serially to avoid 500 errors from concurrent POST /api/v1/flows/
-// when several workers create a blank flow at the same time.
+// Flows are created via the REST API (setupBlankFlow) and deleted in afterEach
+// (issue #545). Kept serial so the per-file flow lifecycle stays deterministic
+// under load.
 test.describe.configure({ mode: "serial" });
+
+let createdFlowId: string | null = null;
+
+test.beforeEach(async ({ page }) => {
+  // setupBlankFlow creates the flow via API (no UI-creation 500 race) and
+  // returns its id so afterEach can delete it. Capturing the id before the
+  // component add means a failure in addPromptComponent still cleans up.
+  createdFlowId = await setupBlankFlow(page);
+  await addPromptComponent(page);
+});
+
+test.afterEach(async ({ page }) => {
+  if (createdFlowId) {
+    // Leave the editor first: staying on it while the flow is deleted makes
+    // background polling 404, which the fixture's error monitor would flag.
+    await page.goto("/").catch(() => {});
+    await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+    createdFlowId = null;
+  }
+});
 
 // `use_double_brackets` carries `advanced=True` upstream, which only filters the
 // field from the on-canvas node body via `isCanvasVisible()`. The right-hand
@@ -21,10 +43,6 @@ test(
   "Prompt Template — use_double_brackets toggle is exposed in the InspectionPanel with its upstream display name",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    await test.step("Add Prompt Template to a blank flow", async () => {
-      await addPromptComponent(page);
-    });
-
     await test.step(
       "Toggle is visible in the InspectionPanel by default",
       async () => {
@@ -68,10 +86,6 @@ test(
   "Prompt Template — default toggle state is OFF; f-string mode extracts {var} and treats {{var}} as literal",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    await test.step("Add Prompt Template to a blank flow", async () => {
-      await addPromptComponent(page);
-    });
-
     await test.step(
       "Save template `Hello {single} and {{double}}!` in default (f-string) mode",
       async () => {
@@ -98,10 +112,6 @@ test(
   "Prompt Template — enabling toggle switches parser to mustache mode; {{var}} creates handle and {var} is ignored",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    await test.step("Add Prompt Template to a blank flow", async () => {
-      await addPromptComponent(page);
-    });
-
     await test.step("Enable double brackets — switches to mustache mode", async () => {
       await setUseDoubleBrackets(page, true);
     });
@@ -134,10 +144,6 @@ test(
   "Prompt Template — disabling toggle reverts to f-string mode and variables are re-extracted under the new parser",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    await test.step("Add Prompt Template to a blank flow", async () => {
-      await addPromptComponent(page);
-    });
-
     await test.step(
       "Enable mustache mode and save `Hello {{name}}!` — `name` handle appears",
       async () => {
@@ -217,13 +223,10 @@ test(
   "Prompt Template — use_double_brackets value persists in the autosaved flow",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    let flowId = "";
-
-    await test.step("Add Prompt Template to a blank flow", async () => {
-      await addPromptComponent(page);
-      flowId = page.url().split("/").slice(-1)[0];
-      expect(flowId).toMatch(/^[0-9a-f-]{36}$/);
-    });
+    // The flow is created in beforeEach; `createdFlowId` is its authoritative
+    // API id — assert its shape here to keep the original UUID sanity check.
+    expect(createdFlowId).toMatch(/^[0-9a-f-]{36}$/);
+    const flowId = createdFlowId as string;
 
     await test.step(
       "Baseline — `template.use_double_brackets.value` starts as `false`",

--- a/tests/tests-automations/regression/core-components/prompt-template-invalid-mustache-patterns-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/prompt-template-invalid-mustache-patterns-regression.spec.ts
@@ -7,10 +7,32 @@ import {
   fillPromptTemplate,
   setUseDoubleBrackets,
 } from "../../../helpers/ui/prompt-template";
+import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
 
-// Run serially to avoid 500 errors from concurrent POST /api/v1/flows/
-// when several workers create a blank flow at the same time.
+// Flows are created via the REST API (setupBlankFlow) and deleted in afterEach
+// (issue #545). Kept serial so the per-file flow lifecycle stays deterministic
+// under load.
 test.describe.configure({ mode: "serial" });
+
+let createdFlowId: string | null = null;
+
+test.beforeEach(async ({ page }) => {
+  // setupBlankFlow creates the flow via API (no UI-creation 500 race) and
+  // returns its id so afterEach can delete it. Capturing the id before the
+  // component add means a failure in addPromptComponent still cleans up.
+  createdFlowId = await setupBlankFlow(page);
+  await addPromptComponent(page);
+});
+
+test.afterEach(async ({ page }) => {
+  if (createdFlowId) {
+    // Leave the editor first: staying on it while the flow is deleted makes
+    // background polling 404, which the fixture's error monitor would flag.
+    await page.goto("/").catch(() => {});
+    await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+    createdFlowId = null;
+  }
+});
 
 // Backend contract — POST /api/v1/validate/prompt with `mustache: true` raises
 // HTTP 500 with `detail=str(ValueError(...))` when `validate_mustache_template`
@@ -106,8 +128,7 @@ test(
   "Prompt Template — mustache `{{ var }}` (spaces inside braces) is rejected with an error toast and creates no handle",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    await test.step("Add Prompt Template and enable mustache mode", async () => {
-      await addPromptComponent(page);
+    await test.step("Enable mustache mode", async () => {
       await setUseDoubleBrackets(page, true);
     });
 
@@ -131,8 +152,7 @@ test(
   "Prompt Template — mustache `{{var.attr}}` (dot notation) is rejected with an error toast and creates no handle",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    await test.step("Add Prompt Template and enable mustache mode", async () => {
-      await addPromptComponent(page);
+    await test.step("Enable mustache mode", async () => {
       await setUseDoubleBrackets(page, true);
     });
 
@@ -154,8 +174,7 @@ test(
   "Prompt Template — mustache `{{#section}}{{/section}}` is rejected with the complex-syntax message and creates no handle",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    await test.step("Add Prompt Template and enable mustache mode", async () => {
-      await addPromptComponent(page);
+    await test.step("Enable mustache mode", async () => {
       await setUseDoubleBrackets(page, true);
     });
 
@@ -176,8 +195,7 @@ test(
   "Prompt Template — mustache `{{{var}}}` (triple braces) is rejected with the complex-syntax message and creates no handle",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    await test.step("Add Prompt Template and enable mustache mode", async () => {
-      await addPromptComponent(page);
+    await test.step("Enable mustache mode", async () => {
       await setUseDoubleBrackets(page, true);
     });
 

--- a/tests/tests-automations/regression/core-components/prompt-template-invalid-patterns-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/prompt-template-invalid-patterns-regression.spec.ts
@@ -6,10 +6,32 @@ import {
   errorToastLocator,
   fillPromptTemplate,
 } from "../../../helpers/ui/prompt-template";
+import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
 
-// Run serially to avoid 500 errors from concurrent POST /api/v1/flows/
-// when several workers create a blank flow at the same time.
+// Flows are created via the REST API (setupBlankFlow) and deleted in afterEach
+// (issue #545). Kept serial so the per-file flow lifecycle stays deterministic
+// under load.
 test.describe.configure({ mode: "serial" });
+
+let createdFlowId: string | null = null;
+
+test.beforeEach(async ({ page }) => {
+  // setupBlankFlow creates the flow via API (no UI-creation 500 race) and
+  // returns its id so afterEach can delete it. Capturing the id before the
+  // component add means a failure in addPromptComponent still cleans up.
+  createdFlowId = await setupBlankFlow(page);
+  await addPromptComponent(page);
+});
+
+test.afterEach(async ({ page }) => {
+  if (createdFlowId) {
+    // Leave the editor first: staying on it while the flow is deleted makes
+    // background polling 404, which the fixture's error monitor would flag.
+    await page.goto("/").catch(() => {});
+    await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+    createdFlowId = null;
+  }
+});
 
 // Backend contract — POST /api/v1/validate/prompt raises HTTP 500 with
 // `detail=str(ValueError(...))` when the f-string parser flags an invalid
@@ -97,10 +119,6 @@ test(
   "Prompt Template — `{var.attr}` (dot notation) is rejected with an error toast and creates no handle",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    await test.step("Add Prompt Template to a blank flow", async () => {
-      await addPromptComponent(page);
-    });
-
     await runRejectionContract(page, "Hello {var.attr}", "var.attr");
 
     // Fourth piece of the rejection contract — kept at the test body level
@@ -114,10 +132,6 @@ test(
   "Prompt Template — `{var name}` (space inside identifier) is rejected with an error toast and creates no handle",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    await test.step("Add Prompt Template to a blank flow", async () => {
-      await addPromptComponent(page);
-    });
-
     await runRejectionContract(page, "Hello {var name}", "var name");
 
     await expect(dynamicHandlesLocator(page)).toHaveCount(0);
@@ -131,10 +145,6 @@ test(
     // Comma is in `_INVALID_CHARACTERS` and users sometimes mistakenly write
     // `{a,b}` thinking it declares multiple variables — this case catches a
     // regression where comma is silently dropped from the set.
-    await test.step("Add Prompt Template to a blank flow", async () => {
-      await addPromptComponent(page);
-    });
-
     await runRejectionContract(page, "Hello {var,name}", "var,name");
 
     await expect(dynamicHandlesLocator(page)).toHaveCount(0);
@@ -145,10 +155,6 @@ test(
   "Prompt Template — `{1var}` (leading digit) is rejected with an error toast and creates no handle",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
-    await test.step("Add Prompt Template to a blank flow", async () => {
-      await addPromptComponent(page);
-    });
-
     // Anchor on "Invalid variables: 1" instead of just "1" — the bare digit
     // could match incidental substrings in the toast (build numbers, icon
     // names, etc.); the full fragment proves the upstream `_fix_variable`
@@ -169,10 +175,6 @@ test(
     // out. The save succeeds without raising and no dynamic handle appears.
     // If a future change starts rejecting `{}` (or extracting it as a real
     // variable), this test breaks first.
-    await test.step("Add Prompt Template to a blank flow", async () => {
-      await addPromptComponent(page);
-    });
-
     await test.step(
       "Save `Plain {} text` — save closes the modal, no error toast, no handle",
       async () => {
@@ -199,10 +201,6 @@ test(
     // Documents the dedup behavior of `extract_input_variables_from_prompt`,
     // which tracks seen field names in a set — repeating `{name}` does not
     // duplicate the handle, even though the template has two placeholders.
-    await test.step("Add Prompt Template to a blank flow", async () => {
-      await addPromptComponent(page);
-    });
-
     await test.step(
       "Save `Hello {name}, goodbye {name}.` — both placeholders share the `name` slot",
       async () => {


### PR DESCRIPTION
Closes #545

Follow-up to #537 / #544.

## Problem

The prompt-template specs created their blank flow through the UI (`awaitBootstrapTest` + `blank-flow` click) and **never deleted it**. Two consequences, both surfaced while triaging #537:

1. The UI flow-creation path carries the documented `POST /api/v1/flows/` 500 race (the reason these specs run `mode: "serial"`) and, under load, could strand the test on the Projects home instead of the flow editor.
2. The missing teardown let blank flows accumulate on long-lived instances (a local instance had grown to ~1.5k leftover flows, which slows the dashboard and shifts the bootstrap navigation path).

## Change

Migrate the four prompt-template specs to the `setupBlankFlow` pattern already used by `singleton-components` / `componentDelete` / `beta-components-toggle`:

- `addPromptComponent` no longer bootstraps the flow — it only adds the node to the currently-open blank flow (sidebar-visible wait + `addComponentFromSidebar`).
- Each spec creates the flow via API in `beforeEach` (capturing the id **before** the component add, so a failure there still cleans up) and deletes it in `afterEach` (leaving the editor first to avoid the fixture flagging background-poll 404s).
- The two persistence tests now read the authoritative flow id returned by `setupBlankFlow` instead of parsing `page.url()`.

## Validation

- `npm run typecheck` and `npm run lint` pass.
- **All 21 tests pass across 3 consecutive no-retry runs**, including on a heavily-populated local instance — the exact condition that previously flaked. The `afterEach` also makes each run clean up its own flows.

## Notes

- Shared helper (`addPromptComponent`) + 4 specs migrated together, since the helper's contract changed (it no longer creates the flow).
- `@stable` retained on all tests; no spec-doc change (validated behavior is unchanged, only the setup mechanism).
- Reduces the blank-flow accumulation tracked in #465 / #515.