### PR TITLE
test(llm-agents): Agent settings preserved on save & reopen (#485)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -334,7 +334,7 @@
 - [ ] Agent with multiple configured tools executes correctly → `agent-multi-tool-selection.spec.ts`
 - [ ] Agent with configured timeout respects the limit
 - [x] Connecting an external model in Agent drops the prior model selection (connection-mode isolation, prevents stale provider config) → `llm-agents/agent-model-connection-isolation.spec.ts`
-- [ ] Flow with Agent saved and reopened → settings preserved → `agent-config-persistence.spec.ts`
+- [x] Flow with Agent saved and reopened → settings preserved → `core-functionality/llm-agents/agent-config-persistence.spec.ts`
 - [x] max_tokens truncates response as configured → `llm-agents/agent-max-tokens.spec.ts` (validated at token level via the Playground token-usage tooltip)
 - [ ] reasoning_effort field appears/disappears based on selected model → `agent-reasoning-effort.spec.ts` (**not implementable on 1.11**: no reasoning_effort field exists in the Agent UI, backend, or frontend — left with the model-bundle refactor; pending re-scope, see #484)
 
@@ -756,7 +756,7 @@
 | `core-components/` — Core Components | 82 | 79 | 0 | 1 | 2 |
 | `core-functionality/auth/` | 21 | 8 | 13 | 0 | 0 |
 | `core-functionality/knowledge-ingestion/` | 8 | 0 | 4 | 0 | 4 |
-| `core-functionality/llm-agents/` | 40 | 23 | 2 | 0 | 15 |
+| `core-functionality/llm-agents/` | 40 | 24 | 2 | 0 | 14 |
 | `core-functionality/model-provider/` | 33 | 19 | 7 | 0 | 7 |
 | `core-functionality/observability-monitoring/` | 23 | 15 | 7 | 0 | 1 |
 | `core-functionality/playground/` | 48 | 43 | 3 | 1 | 1 |
@@ -767,7 +767,7 @@
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 44 | 7 | 36 | 1 | 0 |
 | `ui-ux/` — Settings | 7 | 3 | 3 | 1 | 0 |
-| **TOTAL** | **451** | **246 (55%)** | **161 (36%)** | **7 (2%)** | **37 (8%)** |
+| **TOTAL** | **451** | **247 (55%)** | **161 (36%)** | **7 (2%)** | **36 (8%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -783,7 +783,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 267 `test()` calls carrying the `@stable` tag, distributed across 95 spec
+> 268 `test()` calls carrying the `@stable` tag, distributed across 96 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -929,6 +929,7 @@
 
 #### core-functionality/llm-agents/
 - [x] agent interaction suite → `agent-component-regression.spec.ts`
+- [x] Agent settings survive save and reopen → `agent-config-persistence.spec.ts`
 - [x] model refusal does not crash the component → `agent-empty-refusal-response.spec.ts`
 - [x] empty response does not crash the component → `agent-empty-refusal-response.spec.ts`
 - [x] input via ChatInput handle drives the agent response → `agent-input-sources.spec.ts`
@@ -1090,7 +1091,7 @@
 | `core-components/` — Component Config | 18 | 1 |
 | `core-components/` — Core Components | 0 | 2 |
 | `core-functionality/auth/` | 13 | 0 |
-| `core-functionality/llm-agents/` | 2 | 15 |
+| `core-functionality/llm-agents/` | 2 | 14 |
 | `core-functionality/model-provider/` | 7 | 7 |
 | `core-functionality/playground/` | 3 | 1 |
 | `mcp/client/` | 7 | 2 |

--- a/docs/core-functionality/llm-agents/agent-config-persistence.md
+++ b/docs/core-functionality/llm-agents/agent-config-persistence.md
@@ -1,0 +1,131 @@
+# Agent config persistence — settings preserved on save & reopen
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+QA-CHECKLIST §6.2 "Flow with Agent saved and reopened → settings preserved".
+Agent settings edited through the node's **Controls** dialog must survive the
+full persistence round-trip: autosave writes them to the flow document, and
+reopening the flow from the home page renders them back.
+
+One test drives three sentinels covering the template's three field
+serializations:
+
+- **string** — `system_prompt` set to `PERSIST_PROBE <nonce>` (per-run nonce:
+  a default or residue from an earlier run can never satisfy the assert);
+- **int** — `max_iterations` set to `7` (non-default);
+- **bool** — `add_current_date_tool` flipped `true → false` (asserting the
+  pre-flip state is `true` first, so the flip is proven a real write, not a
+  read-back of a default).
+
+Both persistence halves are asserted:
+
+1. **Saved** — after `waitForFlowSaveSettled`, the flows API shows the three
+   sentinel values in the Agent node's template.
+2. **Reopened preserved** — navigating home and reopening the flow from its
+   card, the Controls dialog renders the exact sentinels.
+
+If this fails, agent configuration silently reverts on reload — users lose
+prompt/limit/tool settings without any error.
+
+**Model-free by design** (area rule): persistence is a backend/autosave
+contract — no LLM call, no provider key, no Playground. The template is
+loaded WITHOUT provider setup and nothing is executed.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@agents` `@workspace`
+
+`@stable` added only after multiple clean `--retries=0` runs on the fresh
+nightly. `@regression` — guards the autosave→reload round-trip; `@agents` —
+Agent configuration surface; `@workspace` — flow save/reopen lifecycle.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- No provider key or `models.json` needed (model-free).
+- Run with `--workers=1` — the spec is serial (`loadTemplateByName` wipes all
+  flows).
+
+---
+
+## Step by step *(required)*
+
+**Test — Agent settings survive save and reopen** (§6.2)
+
+1. Load the Simple Agent template via `loadTemplateByName` (wipes flows; no
+   provider setup).
+2. Open the Agent's **Controls** dialog. The `edit-button-modal` toolbar
+   button only renders with the node selected AND the Inspector Panel hidden
+   (`hideInspectorPanel` first, then click the Agent node).
+3. Set the sentinels:
+   - `textarea_str_edit_system_prompt` → `PERSIST_PROBE_<nonce>` — **typed,
+     never `fill()`**: the dialog textarea is a controlled input that only
+     registers real keystrokes — a `fill()`ed edit passes the DOM check but
+     is silently dropped on close (~50% of runs), and the node-level
+     textarea + `fill()`/blur does not trigger autosave at all on 1.11
+     (0/5 runs persisted). Clear + `pressSequentially` in a retry loop with
+     a DOM verification between attempts (select-all fired before focus
+     settles selects nothing and the nonce lands in front of the default);
+   - `int_int_edit_max_iterations` → `7` — int fields reject `fill()` and
+     swallow fast keystrokes (see `agent-max-tokens.md`): click, settle,
+     clear, slow `pressSequentially`, verify the DOM value;
+   - `toggle_bool_edit_add_current_date_tool` — assert `aria-checked="true"`
+     (template default), click, assert `"false"`.
+4. Close (`edit-button-close`) and `waitForFlowSaveSettled`.
+5. **Saved assert (API):** resolve the flow from the flows list (the canvas
+   URL id is transient on 1.11; the wipe guarantees a single flow) and poll
+   until the Agent template shows all three sentinel values.
+6. Navigate home (`page.goto("/")`), reopen the flow via its
+   `flow-name-<id>` card, wait for the canvas.
+7. Reopen the Controls dialog (same hide-inspector + select-node dance).
+8. **Reopened assert (UI):** the three dialog fields render the exact
+   sentinels (nonce string, `7`, `aria-checked="false"`).
+
+---
+
+## Validation criterion *(required)*
+
+All three sentinels — string, int and bool — must appear BOTH in the
+persisted flow document (API, after save settles) and in the Controls dialog
+after a full home-navigation reopen. Any missing/reverted field fails.
+
+## Guarding against false positives *(how)*
+
+- **Per-run nonce** in the string sentinel — defaults or residue can never
+  match.
+- **Pre-flip assertion** on the bool — proves the test wrote the value; a
+  changed template default fails loudly instead of silently inverting the
+  sentinel's meaning.
+- **Int-field write verified in the DOM** before closing the dialog (the
+  known fill/keystroke quirks would otherwise save a clamped value — which
+  the API assert would also catch, a double guard).
+- **API assert before the reload** — separates "was never saved" from "saved
+  but not re-rendered", so a failure pinpoints the broken half.
+- **Force-failure checks** (CONTRIBUTING §2): M1 — expect a different int via
+  the API ⇒ saved-assert must fail; M2 — expect a different nonce in the UI ⇒
+  reopened-assert must fail.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Persistence of model/provider selection (`model_model`) — requires a
+  configured provider; provider-management specs cover that surface (#505).
+- Tool rename persistence (`tools_metadata`) — covered by
+  `agent-tool-name-validation.spec.ts` (#490).
+- Version-history restore or flow export/import round-trips.
+
+---
+
+## External dependencies *(required)*
+
+- None beyond the running Langflow instance (model-free: no provider API, no
+  collect-models data).

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-config-persistence.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-config-persistence.spec.ts
@@ -1,0 +1,168 @@
+import type { Page } from "@playwright/test";
+import type { APIRequestContext } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { loadTemplateByName } from "../../../../helpers/flows/load-template-by-name";
+import { hideInspectorPanel } from "../../../../helpers/ui/hide-inspector-panel";
+import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+
+/**
+ * Agent config persistence (QA-CHECKLIST §6.2 "Flow with Agent saved and
+ * reopened → settings preserved").
+ *
+ * Model-free by design (area rule): persistence is a backend/autosave
+ * contract — no LLM call, no provider key, no Playground. Three sentinels
+ * cover the template's three field serializations:
+ *   string — system_prompt = "PERSIST_PROBE <nonce>" (per-run nonce);
+ *   int    — max_iterations = 7 (non-default);
+ *   bool   — add_current_date_tool flipped true → false (pre-flip state
+ *            asserted, so the flip is a proven write, not a default).
+ *
+ * Both persistence halves are asserted: the flows API after save settles
+ * (saved), and the Controls dialog after a full home-navigation reopen
+ * (re-rendered). See the spec doc for the false-positive guards.
+ */
+
+const MAX_ITERATIONS_SENTINEL = "7";
+
+// The Controls dialog trigger (edit-button-modal) only renders with the node
+// selected AND the Inspector Panel hidden.
+async function openAgentControls(page: Page): Promise<void> {
+  await hideInspectorPanel(page);
+  await page.locator('[data-testid^="rf__node-Agent"]').first().click();
+  const trigger = page.getByTestId("edit-button-modal");
+  await expect(trigger).toBeVisible({ timeout: 15000 });
+  await trigger.click();
+  await expect(page.getByTestId("int_int_edit_max_iterations")).toBeVisible({
+    timeout: 15000,
+  });
+}
+
+// Int fields reject fill() and swallow fast keystrokes (see
+// agent-max-tokens.md): click, settle, clear, slow-type, verify the DOM.
+async function setIntField(page: Page, testId: string, value: string): Promise<void> {
+  const field = page.getByTestId(testId);
+  await field.click();
+  await page.waitForTimeout(600);
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("Backspace");
+  await field.pressSequentially(value, { delay: 150 });
+  await expect(field).toHaveValue(value, { timeout: 5000 });
+}
+
+// Resolve the single post-wipe flow from the flows list (the canvas URL id is
+// transient on 1.11) and return the Agent node's template.
+async function getPersistedAgentTemplate(
+  request: APIRequestContext,
+): Promise<any> {
+  const bearer = await getAuthToken(request);
+  const res = await request.get(
+    "/api/v1/flows/?remove_example_flows=true&header_flows=false",
+    { headers: { Authorization: bearer } },
+  );
+  expect(res.status()).toBe(200);
+  const flows = await res.json();
+  const agentNodes = (Array.isArray(flows) ? flows : [])
+    .flatMap((f: any) => f.data?.nodes ?? [])
+    .filter((n: any) => n.data?.type === "Agent");
+  expect(agentNodes.length, "exactly one Agent flow must exist post-wipe").toBe(1);
+  return agentNodes[0].data.node.template;
+}
+
+test.describe.configure({ mode: "serial" });
+
+test(
+  "Agent settings survive save and reopen",
+  { tag: ["@stable", "@regression", "@agents", "@workspace"] },
+  async ({ page, request }) => {
+    const nonce = `PERSIST_PROBE_${Date.now()}`;
+
+    await test.step("load the Simple Agent template (no provider setup — model-free)", async () => {
+      await loadTemplateByName(page, "Simple Agent");
+    });
+
+    await test.step("set string, int and bool sentinels in the Controls dialog", async () => {
+      await openAgentControls(page);
+
+      // The dialog's fields are controlled inputs that only register REAL
+      // keystrokes: fill() sets the DOM value but the edit is silently
+      // dropped on close (node-level fill+blur doesn't trigger autosave at
+      // all on 1.11 — 0/5 runs persisted). Clear + type is the only path
+      // that reliably commits the textarea.
+      const prompt = page.getByTestId("textarea_str_edit_system_prompt");
+      // Select-all fired before focus settles selects nothing and the typed
+      // nonce lands IN FRONT of the default text — clear+type is retried
+      // with a DOM verification between attempts (same family as the int
+      // field's swallowed-first-event quirk).
+      for (let attempt = 0; attempt < 3; attempt++) {
+        await prompt.click();
+        await page.waitForTimeout(600);
+        await page.keyboard.press("ControlOrMeta+a");
+        await page.keyboard.press("Backspace");
+        await prompt.pressSequentially(nonce, { delay: 20 });
+        if ((await prompt.inputValue()) === nonce) break;
+      }
+      await expect(prompt).toHaveValue(nonce, { timeout: 5000 });
+      await page.keyboard.press("Tab");
+      await page.waitForTimeout(800);
+
+      await setIntField(page, "int_int_edit_max_iterations", MAX_ITERATIONS_SENTINEL);
+
+      // Assert the pre-flip default so the flip below is a proven WRITE — a
+      // changed template default fails loudly here instead of silently
+      // inverting the sentinel's meaning.
+      const toggle = page.getByTestId("toggle_bool_edit_add_current_date_tool");
+      await expect(toggle).toHaveAttribute("aria-checked", "true");
+      await toggle.click();
+      await expect(toggle).toHaveAttribute("aria-checked", "false");
+
+      await page.waitForTimeout(800);
+      await page.getByTestId("edit-button-close").click();
+      await waitForFlowSaveSettled(page);
+    });
+
+    await test.step("saved: the flows API shows all three sentinels", async () => {
+      await expect
+        .poll(
+          async () => {
+            const t = await getPersistedAgentTemplate(request);
+            return {
+              system_prompt: t.system_prompt?.value,
+              max_iterations: t.max_iterations?.value,
+              add_current_date_tool: t.add_current_date_tool?.value,
+            };
+          },
+          { timeout: 15000 },
+        )
+        .toEqual({
+          system_prompt: nonce,
+          max_iterations: Number(MAX_ITERATIONS_SENTINEL),
+          add_current_date_tool: false,
+        });
+    });
+
+    await test.step("reopen the flow from the home page", async () => {
+      await page.goto("/");
+      await page.waitForSelector('[data-testid="mainpage_title"]', { timeout: 30000 });
+      await page.locator('[data-testid^="flow-name-"]').first().click();
+      await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
+        timeout: 30000,
+      });
+    });
+
+    await test.step("reopened: node and Controls dialog render the exact sentinels", async () => {
+      await openAgentControls(page);
+
+      await expect(page.getByTestId("textarea_str_edit_system_prompt")).toHaveValue(
+        nonce,
+        { timeout: 10000 },
+      );
+      await expect(page.getByTestId("int_int_edit_max_iterations")).toHaveValue(
+        MAX_ITERATIONS_SENTINEL,
+      );
+      await expect(
+        page.getByTestId("toggle_bool_edit_add_current_date_tool"),
+      ).toHaveAttribute("aria-checked", "false");
+    });
+  },
+);


### PR DESCRIPTION
## What

Closes #485 (Wave 1 — Agents & providers).

New spec `tests/tests-automations/regression/core-functionality/llm-agents/agent-config-persistence.spec.ts` + spec doc `docs/core-functionality/llm-agents/agent-config-persistence.md`, covering QA-CHECKLIST **§6.2 — "Flow with Agent saved and reopened → settings preserved"** (bullet flipped to `[x]`).

**Model-free by design** (area rule): persistence is a backend/autosave contract — no LLM call, no provider key, no Playground; ~13s per run.

| # | Test | What it does | What it validates |
|---|---|---|---|
| 1 | `Agent settings survive save and reopen` | Loads Simple Agent (no provider setup); sets three sentinels in the Controls dialog — `system_prompt = PERSIST_PROBE_<nonce>` (string, typed with retry), `max_iterations = 7` (int, anti-quirk convention), `add_current_date_tool` flipped `true→false` (bool, pre-flip default asserted); closes + settles; navigates home and reopens the flow from its card | **(a) saved** — flows API shows all three sentinel values in the Agent template (flow resolved from the list — unique post-wipe) · **(b) reopened preserved** — the Controls dialog re-renders the exact nonce, `7`, and `aria-checked="false"` |

## Frontend quirks root-caused during stabilization (documented in the spec doc)

- **The dialog textarea is a controlled input that only registers real keystrokes** — a `fill()`ed edit passes the DOM check but is silently dropped on close (~50% of runs). Clear + `pressSequentially` is the only reliable commit path.
- **The node-level textarea + `fill()`/blur does not trigger autosave at all on 1.11** (0/5 runs persisted). Older specs that set it this way only persist it because a subsequent build/run flushes the flow — worth noting for future spec authors (and a possible upstream report).
- **Select-all fired before focus settles selects nothing** — the typed value lands in front of the default text. The setter runs clear+type in a retry loop with DOM verification between attempts (same family as the int field's swallowed-first-keystroke quirk from #483).

## Validation

- Langflow nightly **1.11.0.dev34** (fresh image pulled and container recreated before final validation; also green throughout development on dev33).
- **Final version: 12 green `--retries=0` runs** (8-run burst + post-mutation-revert run + 3 on fresh dev34), ~13s each.
- **Force-failure verified on the final version** (mutations confirmed applied before each run):
  - M1 — API expected `max_iterations: 99` → test **failed** showing `Received: 7` (the assert reads the real persisted value).
  - M2 — wrong expected nonce in the reopened-UI assert → test **failed**.
- `npm run typecheck` and `npm run lint`: 0 errors.
- `npm run coverage:summary` regenerated.
- `--trace=on` skipped: known environment limitation for Simple Agent–template specs (see PR #542's Validation notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)