### PR TITLE
test-infra: centralize error-toast locator behind errorToastLocator (#224)

### DIFF
--- a/tests/helpers/ui/error-toast.ts
+++ b/tests/helpers/ui/error-toast.ts
@@ -1,0 +1,11 @@
+import { type Locator, type Page } from "@playwright/test";
+
+// Single anchor for the error toast rendered by `ErrorAlert`
+// (src/frontend/src/alerts/error/index.tsx). The upstream component exposes no
+// `data-testid`, so the `.error-build-message` CSS class is the only stable
+// hook. Centralizing it here means an upstream CSS rename — or the arrival of a
+// `data-testid` (issue #224) — is a one-line change instead of a sweep across
+// every spec that waits on an error toast.
+export function errorToastLocator(page: Page): Locator {
+  return page.locator(".error-build-message");
+}

--- a/tests/helpers/ui/prompt-template.ts
+++ b/tests/helpers/ui/prompt-template.ts
@@ -8,6 +8,10 @@ import { adjustScreenView } from "./adjust-screen-view";
 // it here so existing importers of this module keep working unchanged.
 export { waitForFlowSaveSettled };
 
+// `errorToastLocator` now lives in its own module so every spec that waits on an
+// error toast shares one anchor (issue #224). Re-exported for existing importers.
+export { errorToastLocator } from "./error-toast";
+
 // Shared testids and selectors for the Prompt Template component, sourced
 // from live UI inspection and the upstream Langflow frontend source:
 //   add button:               "add-component-button-prompt-template"
@@ -80,15 +84,6 @@ export function dynamicHandlesLocator(page: Page): Locator {
   return page.locator(
     '[data-testid^="handle-prompt template-shownode-"][data-testid$="-left"]',
   );
-}
-
-/**
- * Locator for the error toast rendered by `ErrorAlert` when the prompt modal's
- * `onError` callback fires (no `data-testid` is exposed by the upstream alert
- * component, so the CSS class is the stable anchor).
- */
-export function errorToastLocator(page: Page): Locator {
-  return page.locator(".error-build-message");
 }
 
 /**

--- a/tests/tests-automations/regression/core-functionality/llm-agents/provider-invalid-auth-error.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/provider-invalid-auth-error.spec.ts
@@ -7,6 +7,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
+import { errorToastLocator } from "../../../../helpers/ui/error-toast";
 
 if (!process.env.CI) {
   dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
@@ -121,7 +122,7 @@ for (const {
 
         try {
           await test.step("Validate that the invalid authentication error is displayed", async () => {
-            const errorBox = page.locator(".error-build-message");
+            const errorBox = errorToastLocator(page);
             await expect(
               errorBox.getByText(/Invalid API key/i),
             ).toBeVisible({ timeout: 30000 });

--- a/tests/tests-automations/regression/ui-ux/execution-error-notification.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/execution-error-notification.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { zoomOut } from "../../../helpers/ui/zoom-out";
+import { errorToastLocator } from "../../../helpers/ui/error-toast";
 
 async function setupChatFlow(page: any) {
   await awaitBootstrapTest(page);
@@ -91,8 +92,7 @@ test.describe("Execution Error Notifications", () => {
         .isVisible({ timeout: 8000 })
         .catch(() => false);
 
-      const errorToast = await page
-        .locator(".error-build-message")
+      const errorToast = await errorToastLocator(page)
         .first()
         .isVisible({ timeout: 3000 })
         .catch(() => false);
@@ -148,8 +148,7 @@ test.describe("Execution Error Notifications", () => {
         .isVisible({ timeout: 10000 })
         .catch(() => false);
 
-      const errorToast = await page
-        .locator(".error-build-message")
+      const errorToast = await errorToastLocator(page)
         .first()
         .isVisible({ timeout: 5000 })
         .catch(() => false);


### PR DESCRIPTION
## Issue

Addresses #224 (downstream part) — five regression specs anchoring on the `.error-build-message` CSS class of the upstream `ErrorAlert`, which has no `data-testid`.

## Validation of the problem (before touching anything)

- **Not a Langflow regression.** `ErrorAlert` still renders with `className="error-build-message"` on `origin/main` upstream — the class persists and is load-bearing.
- **The upstream `data-testid` does not exist yet** (zero `data-testid` in `src/frontend/src/alerts/error/index.tsx`). Refactoring to `getByTestId("error-toast")` now would break the specs — there is nothing to anchor on. That part stays blocked on an upstream Langflow PR.
- **The issue's scope is stale:** of the five specs, `api-request-component-regression` no longer references the class; the real usage was **3 sites**.

## Change (downstream mitigation, executable now)

Consolidate every error-toast lookup behind one helper so a future CSS rename — or the arrival of the `data-testid` — is a one-line change instead of a sweep:

- **new** `tests/helpers/ui/error-toast.ts` — `errorToastLocator(page)`, the **sole** `.error-build-message` reference in the repo.
- `helpers/ui/prompt-template.ts` re-exports it (its two specs keep importing unchanged).
- `execution-error-notification.spec.ts` (2 uses) and `provider-invalid-auth-error.spec.ts` (1 use) migrated to the helper.

No behavior change — the helper returns the same locator.

## Validation

- **typecheck** ✅ · **lint** ✅ (0 errors) · **static checklist** ✅
- **run of the 4 affected specs** (nightly `1.10.0.dev56`, local): 12 passed / 4 failed — **all 4 failures pre-existing / environment**, not caused by this refactor:
  - 3× `provider-invalid-auth`: fail at `icon-Brain` (line 85, **before** the migrated locator on line 125) — known broken, issue #232.
  - 1× `execution-error-notification:51`: **confirmed by a control run** — the un-refactored `origin/main` file fails identically (`Received: false`), so it's an environment/behavior issue on this build, not the refactor.
  - the 8 prompt-template tests that exercise the helper affirmatively: **pass**.
- **force-fail** ✅ — breaking the helper's selector makes a consumer spec fail at `toBeVisible` (proves the helper is load-bearing and propagates to all consumers); restored → passes.

## Still pending for full #224 acceptance (upstream-blocked)

- `data-testid` on `ErrorAlert` upstream, then swap the one line in `error-toast.ts` from `.error-build-message` to `getByTestId(...)`.