### PR TITLE
test(playground): restore @stable on "input field must be ready after flow responds"

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -783,7 +783,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 267 `test()` calls carrying the `@stable` tag, distributed across 95 spec
+> 268 `test()` calls carrying the `@stable` tag, distributed across 95 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -1033,6 +1033,7 @@
 - [x] Shareable playground URL is generated when publishing is enabled → `playground-shareable-url.spec.ts`
 - [x] user message must appear instantly in playground before AI responds → `playground-ux.spec.ts`
 - [x] playground must scroll to latest message after sending → `playground-ux.spec.ts`
+- [x] playground input field must be ready after flow responds → `playground-ux.spec.ts`
 - [x] User must be able to stop building from inside Playground → `stop-button-playground.spec.ts`
 
 #### core-functionality/project-management/

--- a/docs/core-functionality/playground/playground-ux.md
+++ b/docs/core-functionality/playground/playground-ux.md
@@ -1,6 +1,6 @@
 # Playground — Chat UX
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.11.x
 
 ---
 

--- a/tests/tests-automations/regression/core-functionality/playground/playground-ux.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-ux.spec.ts
@@ -80,7 +80,7 @@ test.describe("Playground UX", () => {
 
   test(
     "playground input field must be ready after flow responds",
-    { tag: ["@release", "@regression", "@playground"] },
+    { tag: ["@release", "@regression", "@playground", "@stable"] },
     async ({ page }) => {
       await test.step("Set up ChatInput → ChatOutput flow and open playground", async () => {
         createdFlowId = await setupPlayground(page);


### PR DESCRIPTION
Closes #531

## Context

The `@stable` test **"playground input field must be ready after flow responds"** (`playground-ux.spec.ts:81`) had its tag auto-removed after the 2026-07-06 daily hard failure (#529). This PR restores it after investigation.

## Investigation — environmental noise, not a test/product bug

- **Reproduction:** ran the hard-failed test and its flaky sibling (`playground-ux.spec.ts:17`) **5× each in isolation** against Langflow 1.11.0 → **10/10 passed**, zero backend errors.
- **History cross-check** (`reports/daily-history.jsonl`): line-81 was clean on 07-01/07-03, flaky-passed on 07-02, hard-failed only on 07-06, and its sibling ran clean again on 07-07.
- The 07-06 run was **not** a foundational outage — 226 tests passed that day; the failure was a narrow, transient, mid-run blip that exhausted the retries on this one test.

**Conclusion:** external environmental flake, not a defect in the test or the product. `setupPlayground` already guards with 30s waits and awaits the creation POST; adding retries would only mask genuine backend outages, so **no code hardening is warranted**. Per the issue, the restoration PR is required regardless.

## Changes

- Re-add `@stable` to the line-81 test (reverts auto-removal `993e78e`).
- Bump spec doc `Last validated` → `1.11.x` (validated against 1.11.0).
- Regenerate `QA-CHECKLIST.md` Phase 0 block (267 → 268 `@stable` tests).

## Validation

- `npm run typecheck` — clean
- `npm run lint` — 0 errors
- Target + sibling test: 10/10 passes in isolation