### PR TITLE
fix(core-components): restore @stable on tool-mode after transient daily failure (#549)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -783,7 +783,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 269 `test()` calls carrying the `@stable` tag, distributed across 96 spec
+> 270 `test()` calls carrying the `@stable` tag, distributed across 97 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -912,6 +912,7 @@
 - [x] should not allow adding a Chat Input while a Webhook is on the canvas → `singleton-components.spec.ts`
 - [x] should not allow duplicating a Webhook → `singleton-components.spec.ts`
 - [x] should not allow copying and pasting a Webhook → `singleton-components.spec.ts`
+- [x] User should be able to use components as tool → `tool-mode.spec.ts`
 - [x] Webhook component — HTTP POST accepts JSON and plain-text bodies returning 202 → `webhook-component-regression.spec.ts`
 - [x] Webhook component — cURL command in inspector shows valid POST URL with flow ID → `webhook-component-regression.spec.ts`
 - [x] Webhook component — empty data field returns empty Data object → `webhook-component-regression.spec.ts`

--- a/tests/tests-automations/regression/core-components/tool-mode.spec.ts
+++ b/tests/tests-automations/regression/core-components/tool-mode.spec.ts
@@ -4,7 +4,7 @@ import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 
 test(
   "User should be able to use components as tool",
-  { tag: ["@release", "@components"] },
+  { tag: ["@release", "@stable", "@components"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
     await page.getByTestId("blank-flow").click();


### PR DESCRIPTION
## What

Closes #549 (`daily-failure`, high priority — derived from #548).

Restores `@stable` on `tool-mode.spec.ts` — "User should be able to use components as tool" — after the triage investigation concluded the daily #28860759001 failure was **transient CI-instance degradation**, not a product regression and not a test defect.

## Root-cause conclusion (deliverable 1)

**Transient — saturated shared Langflow container during the full-suite daily run.**

| Environment | Result |
|---|---|
| Local, fresh nightly **1.11.0.dev34**, 6× `--retries=0` | 6/6 green (~13s; duration badge renders in ~2s vs the 30s budget) |
| **Same CI environment** (GitHub runner + `langflow-nightly:latest`), scoped run via `manual.yml` — [run 28868087246](https://github.com/oriontech-me/langflow-e2e/actions/runs/28868087246) | 1 passed (58.5s) |
| Daily #28860759001 (full parallel suite) | failed alongside 17 other tests |

Supporting evidence:
- The failing daily had **18 problematic tests at once** (5 hard + 13 flaky) with unrelated backend 500s (`DELETE /flows`, `validate/prompt`, `monitor/messages`) — correlated failure across independent specs points to a common environmental cause: the whole suite hammering one Langflow container on one runner. `node_duration_url` only renders when the component build completes; under a saturated backend the build did not finish within 30s.
- First failure of this test in 5 recorded dailies (`reports/daily-history.jsonl`).
- The `node_duration_<name>` testid still exists in the current frontend source (issue pre-verification).
- Isolated CI took 58.5s vs ~13s locally (~4× slower runner) — fine alone, tight when sharing the runner with the full parallel suite.

## Fix (deliverable 2)

None applicable to the test or product: assertions and the 30s budget are correct locally and in isolated CI; loosening them would mask real regressions. A **follow-up worth considering** (separate from this PR): cap `--workers` in `daily-stable.yml` to reduce concurrent pressure on the single Langflow container, then measure via `reports/daily-history.jsonl` before considering a larger runner.

## Restore (deliverable 3)

- `@stable` back on the `test()` (the spec doc `docs/core-components/tool-mode.md` already lists it — unchanged).
- `npm run coverage:summary` regenerated (269 `@stable` tests across 97 spec files).
- `npm run typecheck` and `npm run lint`: 0 errors.
- Note: `manual.yml` was temporarily enabled for the same-environment proof run and re-disabled afterwards (original state restored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)