### PR TITLE
fix(llm-agents): memory-history — track redesigned template, add isolation probe, restore @stable (#550)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -783,7 +783,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 270 `test()` calls carrying the `@stable` tag, distributed across 97 spec
+> 272 `test()` calls carrying the `@stable` tag, distributed across 98 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -956,6 +956,8 @@
 - [x] model provider dialog opens from the Language Model node → `language-model-regression.spec.ts`
 - [x] playground shows error when LLM run endpoint returns 500 (mocked invalid API key) → `llm-invalid-api-key-ui.spec.ts`
 - [x] playground input remains usable after API error (mocked) → `llm-invalid-api-key-ui.spec.ts`
+- [x] message history context retention suite → `memory-history-regression.spec.ts`
+- [x] session isolation: new session has no context from previous session → `memory-history-regression.spec.ts`
 - [x] OpenAI provider is listed in Model Providers settings → `model-provider-api-key.spec.ts`
 - [x] Anthropic provider is listed in Model Providers settings → `model-provider-api-key.spec.ts`
 - [x] a configured provider exposes the key edit surface (Replace, no raw input) → `model-provider-api-key.spec.ts`

--- a/docs/core-functionality/llm-agents/memory-history-regression.md
+++ b/docs/core-functionality/llm-agents/memory-history-regression.md
@@ -26,12 +26,20 @@ The spec contains **3 tests** inside `test.describe("Memory Chatbot Regression")
 
 Does not require an API key. Validates only the canvas structure.
 
+> **Template redesigned upstream (first shipped in 1.11.0.dev34):** the
+> Memory Chatbot starter project is now an **Agent + Memory Base** flow —
+> the previous `Message History` / `Language Model` / `Prompt Template`
+> trio was replaced by a single `Agent` node plus the new `Memory Base`
+> component (verified in the container's
+> `initial_setup/starter_projects/Memory Chatbot.json`). Structure
+> assertions track the shipped template (issue #550).
+
 1. Delete existing flows and load the "Memory Chatbot" template from `All Templates`
 2. Wait for `canvas_controls_dropdown` to appear; adjust view and update components
-3. *Step: canvas has all 6 required nodes* — `expect.soft` for each of the 6 nodes:
-   - `title-Chat Input`, `title-Chat Output`, `title-Message History`
-   - `title-Language Model`, `title-Prompt Template`, `note_node`
-4. *Step: canvas has exactly 6 nodes* — count `.react-flow__node` and assert `=== 6`
+3. *Step: canvas has all 5 required nodes* — `expect.soft` for each of the 5 nodes:
+   - `title-Chat Input`, `title-Chat Output`, `title-Agent`
+   - `title-Memory Base`, `note_node`
+4. *Step: canvas has exactly 5 nodes* — count `.react-flow__node` and assert `=== 5`
 
 ---
 
@@ -58,12 +66,13 @@ Requires `OPENAI_API_KEY`. Kept separate because it is destructive (creates a ne
 3. Wait for the response to complete (`waitForChatResponse` — counts `chat-message-token-usage`)
 4. Click `new-chat` (the "+" button in the sessions sidebar)
 5. Web-first assert `div-chat-message` `toHaveCount(0)` — auto-retries until the session reset settles, so a reset slower than a fixed wait cannot false-fail (replaced the old `waitForTimeout(500)` + hard count)
+6. *Backend-isolation probe:* send `"What is my name?"` in the NEW session and assert the response does **not** match `/Bob/i` — the UI-reset check alone (step 5) would still pass if the backend leaked memory across sessions; only a model answer proves the new session's context is really empty (inverted mirror of Test 2's positive `/Alice/i` assert). Fail-safe: a leak surfaces "Bob" and fails; a model that answers "I don't know" passes
 
 ---
 
 ## Validation criterion *(required)*
 
-- Template loads with exactly 6 nodes: Chat Input, Chat Output, Message History, Language Model, Prompt Template, note (README)
+- Template loads with exactly 5 nodes: Chat Input, Chat Output, Agent, Memory Base, note (README)
 - The LLM recalls the name provided in a previous message within the same session ("Alice")
 - Bot responses accumulate in the history (`div-chat-message` ≥ 2 after 2 exchanges)
 - History persists after closing and reopening the Playground
@@ -74,8 +83,8 @@ Requires `OPENAI_API_KEY`. Kept separate because it is destructive (creates a ne
 ## External dependencies *(required)*
 
 - `src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json` — defines the template graph at runtime (overrides the `.py`); changes to nodes or edges break Test 1
-- `src/lfx/src/lfx/components/models_and_agents/memory.py` — `MemoryComponent` (`display_name = "Message History"`); renaming or removing it breaks Tests 1 and 2
-- `src/lfx/src/lfx/components/models_and_agents/language_model.py` — `LanguageModelComponent` (`display_name = "Language Model"`); changes to the `model` field or `display_name` affect Tests 1, 2, and 3
+- `initial_setup/starter_projects/Memory Chatbot.json` — the shipped template (Agent + Memory Base since 1.11.0.dev34); node renames/additions there break Test 1
+- The Agent node's `model_model` field — `setupLanguageModelOpenAI` resolves it on the Agent (the helper predates the redesign; it targets whatever node exposes `model_model`); changes there affect Tests 2 and 3
 - `src/frontend/src/components/core/playgroundComponent/` — `input-chat-playground`, `div-chat-message`, `chat-message-token-usage`, `playground-close-button`, `new-chat` — any rename breaks Tests 2 and 3. `chat-message-token-usage` is the completion signal used by `waitForChatResponse`; if a future build stops rendering it (or a provider returns no token usage), the response wait must switch to another per-response completion marker
 - `src/frontend/src/CustomNodes/GenericNode/components/NodeName/index.tsx` — `data-testid="title-{display_name}"` — a change to this testid pattern breaks Test 1
 - `src/frontend/src/modals/modelProviderModal/components/ProviderConfigurationForm.tsx` — "Save" button (exact text to save the API key); changing it breaks `setupLanguageModelOpenAI`

--- a/tests/tests-automations/regression/core-functionality/llm-agents/memory-history-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/memory-history-regression.spec.ts
@@ -41,25 +41,27 @@ test.describe("Memory Chatbot Regression", () => {
     async ({ page }) => {
       await loadMemoryChatbot(page);
 
-      await test.step("canvas has all 6 required nodes", async () => {
+      // Template redesigned upstream (1.11.0.dev34): Agent + Memory Base
+      // replaced the Message History / Language Model / Prompt Template trio
+      // (issue #550; verified in the shipped starter-project JSON).
+      await test.step("canvas has all 5 required nodes", async () => {
         await expect.soft(page.getByTestId("title-Chat Input")).toBeVisible({ timeout: 10000 });
         await expect.soft(page.getByTestId("title-Chat Output")).toBeVisible({ timeout: 10000 });
-        await expect.soft(page.getByTestId("title-Message History")).toBeVisible({ timeout: 10000 });
-        await expect.soft(page.getByTestId("title-Language Model")).toBeVisible({ timeout: 10000 });
-        await expect.soft(page.getByTestId("title-Prompt Template")).toBeVisible({ timeout: 10000 });
+        await expect.soft(page.getByTestId("title-Agent")).toBeVisible({ timeout: 10000 });
+        await expect.soft(page.getByTestId("title-Memory Base")).toBeVisible({ timeout: 10000 });
         await expect.soft(page.getByTestId("note_node")).toBeVisible({ timeout: 10000 });
       });
 
-      await test.step("canvas has exactly 6 nodes", async () => {
+      await test.step("canvas has exactly 5 nodes", async () => {
         const nodeCount = await page.locator(".react-flow__node").count();
-        expect.soft(nodeCount).toBe(6);
+        expect.soft(nodeCount).toBe(5);
       });
     },
   );
 
   test(
     "message history context retention suite",
-    { tag: ["@release", "@agents", "@playground"] },
+    { tag: ["@stable", "@release", "@agents", "@playground"] },
     async ({ page }) => {
       test.skip(
         !process.env.OPENAI_API_KEY,
@@ -111,7 +113,7 @@ test.describe("Memory Chatbot Regression", () => {
 
   test(
     "session isolation: new session has no context from previous session",
-    { tag: ["@release", "@agents", "@playground"] },
+    { tag: ["@stable", "@release", "@agents", "@playground"] },
     async ({ page }) => {
       test.skip(
         !process.env.OPENAI_API_KEY,
@@ -140,6 +142,15 @@ test.describe("Memory Chatbot Regression", () => {
       await expect(page.getByTestId("div-chat-message")).toHaveCount(0, {
         timeout: 10000,
       });
+
+      // Backend-isolation probe: the UI-reset check above would still pass if
+      // the backend leaked memory across sessions — only a model answer proves
+      // the new session's context is really empty. A leak surfaces "Bob" and
+      // fails; a model that answers "I don't know your name" passes.
+      await playground.sendMessage("What is my name?");
+      await waitForChatResponse(page, 1);
+      const response = await page.getByTestId("div-chat-message").last().innerText();
+      expect(response).not.toMatch(/Bob/i);
     },
   );
 });


### PR DESCRIPTION
## What

Closes #550 (`daily-failure`, high priority — derived from #548).

## Root-cause conclusion (deliverable 1) — two distinct findings

**1. The daily failures on `:60`/`:112` were transient** — same saturated-run collapse as #549 (18 problem tests at once, unrelated backend 500s in run 28860759001). Both pass 3×3 clean `--retries=0` locally on fresh nightly **1.11.0.dev34**. The badge-based `waitForChatResponse` is deliberately **kept**: the issue suggested decoupling "response arrived" from the token-usage badge, but `div-chat-message` flickers during streaming — the documented root cause of flaky #354 — so switching signals would reintroduce that bug.

**2. Preventive catch — intentional upstream product change (first shipped in dev34):** the Memory Chatbot starter project was **redesigned to Agent + Memory Base** (the `Message History` / `Language Model` / `Prompt Template` trio is gone — verified in the shipped starter-project JSON in the container). The structure test (`:38`) failed deterministically against dev34 and would have opened tomorrow's triage issue. Assertions updated to the shipped template.

## Changes (deliverable 2)

| Test | Change | Now validates |
|---|---|---|
| `:38` structure | updated | 5 nodes: `title-Chat Input` / `title-Chat Output` / `title-Agent` / `title-Memory Base` / `note_node` + `.react-flow__node` count `=== 5` |
| `:60` context retention | `@stable` restored only | unchanged (transient verdict) |
| `:112` session isolation | `@stable` restored + **backend-isolation probe** | after `new-chat`, sends "What is my name?" and asserts the reply does **not** match `/Bob/i` — the UI-reset check alone would still pass if the backend leaked memory across sessions; a leak surfaces "Bob" and fails, "I don't know" passes (fail-safe) |

`setupLanguageModelOpenAI` keeps working unchanged — it resolves `model_model` on whatever node exposes it (now the Agent).

## Validation

- Langflow nightly **1.11.0.dev34**.
- 3×`3 passed` full-file bursts + 3×`1 passed` isolation-test bursts + final full run `3 passed` — all `--retries=0`, ~15 executions total, zero flake.
- **Force-fail verified on ALL three tests** (mutations confirmed applied, then reverted):
  - `:38` — nonexistent testid → failed; node count 9 → failed.
  - `:60` — expected `/ZELDA_NEVER_SAID/` → failed (proves `expect.soft` fails the test and the assert reads the real model reply).
  - `:112` — inverted probe (demand the leak) → failed.
- Determinism note: `:38` is 100% deterministic (no LLM); `:60`/`:112` have the model in the loop only in fail-safe direction (disobedience/leak fails the test, can never pass falsely) — the memory contract is only observable through the model's reply.
- `npm run typecheck` / `npm run lint`: 0 errors; `npm run coverage:summary` regenerated (272 @stable / 98 files).
- `--trace=on` skipped (known Simple Agent–family limitation, PR #542 notes; applies to template-canvas specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)