### PR TITLE
fix(llm-agents): restore @stable on model-toggle after transient daily failure (#551)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -783,7 +783,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 272 `test()` calls carrying the `@stable` tag, distributed across 98 spec
+> 273 `test()` calls carrying the `@stable` tag, distributed across 98 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -965,6 +965,7 @@
 - [x] an invalid API key is rejected and does not enable the provider → `model-provider-modal-actions.spec.ts`
 - [x] selecting another provider switches the visible detail panel → `model-provider-modal-actions.spec.ts`
 - [x] model toggle changes immediately and persists across reopen → `model-provider-model-toggle.spec.ts`
+- [x] disabling a model removes it from a component model dropdown → `model-provider-model-toggle.spec.ts`
 - [x] the Language Model node renders its model selector → `modelInputComponent.spec.ts`
 - [x] opening the model dropdown lists model options → `modelInputComponent.spec.ts`
 - [x] the model dropdown exposes the Manage Model Providers entry → `modelInputComponent.spec.ts`

--- a/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-model-toggle.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-model-toggle.spec.ts
@@ -162,7 +162,7 @@ test.describe("Model Provider Model Toggle", () => {
   test(
     "disabling a model removes it from a component model dropdown",
     {
-      tag: ["@regression", "@components", "@agents", "@model-provider"],
+      tag: ["@stable", "@regression", "@components", "@agents", "@model-provider"],
     },
     async ({ page }) => {
       test.skip(!!skipReason, skipReason ?? "");


### PR DESCRIPTION
## What

Closes #551 (`daily-failure`, medium priority — derived from #548).

Restores `@stable` on `model-provider-model-toggle.spec.ts` — "disabling a model removes it from a component model dropdown" — after concluding the daily #28860759001 failure was **transient CI saturation**, the same collapse already root-caused in #549/#550.

## Root-cause conclusion (deliverable 1)

| Environment | Result |
|---|---|
| Local, fresh nightly **1.11.0.dev34**, 4× `--retries=0` | `2 passed` each — toggle renders in ~2s vs the 10s budget |
| Daily #28860759001 (full parallel suite) | failed alongside 17 other tests, unrelated backend 500s |

- Same correlated-collapse signature as #549 (which also produced the **same-environment CI proof**: scoped `manual.yml` run on the same runner + image, green — not repeated here for the same failure class).
- `gemini-3.5-flash` exists and the `llm-toggle-<model>` testid is unchanged (issue pre-verification).
- Third transient verdict from the same run (#549, #550-partial, #551) — strengthens the case for the follow-up: cap `--workers` in `daily-stable.yml` and measure via `reports/daily-history.jsonl`.

## Fix (deliverable 2)

None applicable — loosening the 10s wait would mask a real toggle-rendering regression.

## Restore (deliverable 3)

- `@stable` back on the `test()`; `npm run coverage:summary` regenerated (273 `@stable` / 98 files).
- `npm run typecheck` / `npm run lint`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)