### PR TITLE
fix(llm-agents): remove cross-worker flow wipe from template loading (#553)

### DIFF
--- a/docs/core-functionality/llm-agents/agent-config-persistence.md
+++ b/docs/core-functionality/llm-agents/agent-config-persistence.md
@@ -51,8 +51,8 @@ Agent configuration surface; `@workspace` — flow save/reopen lifecycle.
 
 - Langflow running at `PLAYWRIGHT_BASE_URL`.
 - No provider key or `models.json` needed (model-free).
-- Run with `--workers=1` — the spec is serial (`loadTemplateByName` wipes all
-  flows).
+- Run with `--workers=1` — the spec is serial (named template flows collide
+  under parallelism).
 
 ---
 
@@ -60,8 +60,11 @@ Agent configuration surface; `@workspace` — flow save/reopen lifecycle.
 
 **Test — Agent settings survive save and reopen** (§6.2)
 
-1. Load the Simple Agent template via `loadTemplateByName` (wipes flows; no
-   provider setup).
+1. Load the Simple Agent template via `loadTemplateByName`, capturing the
+   created flow's id from the `POST /api/v1/flows/` response. No pre-cleanup
+   of existing flows (a wipe kills parallel workers' in-flight flows, #553;
+   duplicate names auto-suffix) — the spec deletes its own flow by id in
+   `afterEach`. No provider setup (model-free).
 2. Open the Agent's **Controls** dialog. The `edit-button-modal` toolbar
    button only renders with the node selected AND the Inspector Panel hidden
    (`hideInspectorPanel` first, then click the Agent node).
@@ -80,9 +83,10 @@ Agent configuration surface; `@workspace` — flow save/reopen lifecycle.
    - `toggle_bool_edit_add_current_date_tool` — assert `aria-checked="true"`
      (template default), click, assert `"false"`.
 4. Close (`edit-button-close`) and `waitForFlowSaveSettled`.
-5. **Saved assert (API):** resolve the flow from the flows list (the canvas
-   URL id is transient on 1.11; the wipe guarantees a single flow) and poll
-   until the Agent template shows all three sentinel values.
+5. **Saved assert (API):** fetch the flow by the id captured at creation
+   (`GET /api/v1/flows/{id}` — the canvas URL id is transient on 1.11, so
+   the id comes from the template-instantiation `POST` response, not the
+   URL) and poll until the Agent template shows all three sentinel values.
 6. Navigate home (`page.goto("/")`), reopen the flow via its
    `flow-name-<id>` card, wait for the canvas.
 7. Reopen the Controls dialog (same hide-inspector + select-node dance).

--- a/docs/core-functionality/llm-agents/memory-history-regression.md
+++ b/docs/core-functionality/llm-agents/memory-history-regression.md
@@ -34,7 +34,7 @@ Does not require an API key. Validates only the canvas structure.
 > `initial_setup/starter_projects/Memory Chatbot.json`). Structure
 > assertions track the shipped template (issue #550).
 
-1. Delete existing flows and load the "Memory Chatbot" template from `All Templates`
+1. Load the "Memory Chatbot" template from `All Templates`, capturing the created flow's id (no pre-cleanup of existing flows — a wipe kills parallel workers' in-flight flows, #553; duplicate names auto-suffix; each test deletes its own flow by id in `afterEach`)
 2. Wait for `canvas_controls_dropdown` to appear; adjust view and update components
 3. *Step: canvas has all 5 required nodes* — `expect.soft` for each of the 5 nodes:
    - `title-Chat Input`, `title-Chat Output`, `title-Agent`

--- a/tests/helpers/flows/clean-all-flows.ts
+++ b/tests/helpers/flows/clean-all-flows.ts
@@ -9,6 +9,13 @@ import type { Page } from "@playwright/test";
  *
  * Works in the default auto_login mode; falls back gracefully if the token
  * endpoint is unavailable (flows simply won't be deleted in that case).
+ *
+ * WARNING: destructive across parallel workers. This deletes EVERY user
+ * flow on the shared instance, including flows another worker is actively
+ * using — in the fully-parallel CI suite that kills the neighbor's test
+ * mid-flight (its page starts 404ing "Flow not found"; see #553). Do NOT
+ * call this as pre-test cleanup in specs that run in the parallel suite;
+ * create your flow, keep its id, and delete only that id in your cleanup.
  */
 export const cleanAllFlows = async (page: Page) => {
   // Obtain a bearer token via auto_login (no credentials required in dev/test).

--- a/tests/helpers/flows/load-template-by-name.ts
+++ b/tests/helpers/flows/load-template-by-name.ts
@@ -1,30 +1,30 @@
 import type { Page } from "@playwright/test";
-import { cleanAllFlows } from "./clean-all-flows";
 import { openNewFlowTemplatesModal } from "./open-new-flow-templates-modal";
 
 /**
  * Canonical "load a starter template by name" flow, shared by every spec that
  * needs a template on the canvas.
  *
- * Steps: clear any user-created flows (so re-loading the same template can't
- * 400 on a duplicate name) → open the templates modal via whichever New Flow
- * entry point exists → switch to the All Templates tab → pick the template
- * whose heading matches `templateName`. Returns once the canvas controls are
- * visible; callers run their own post-load steps (provider setup, component
- * migration, assertions).
+ * Steps: open the templates modal via whichever New Flow entry point exists →
+ * switch to the All Templates tab → pick the template whose heading matches
+ * `templateName`. Returns the created flow's id (from the
+ * template-instantiation `POST /api/v1/flows/` response — the canvas URL id
+ * is transient on 1.11, so this is the only reliable handle) once the canvas
+ * controls are visible; callers run their own post-load steps (provider
+ * setup, component migration, assertions) and delete the flow by this id in
+ * their own cleanup.
  *
- * Flow deletion uses the API (`cleanAllFlows`) rather than the home dropdown
- * menu: that Radix portal detaches from the DOM mid-click under re-renders, so
- * the old per-spec UI deletion loops were a recurring flake source.
+ * Deliberately NO pre-cleanup of existing flows: this helper used to call
+ * `cleanAllFlows` first, which deletes flows other parallel workers are
+ * actively using and killed neighbor tests mid-flight in the fully-parallel
+ * CI suite (#553 — the victim's page starts 404ing "Flow not found").
+ * Duplicate names don't need it either: the backend auto-suffixes new copies
+ * ("Memory Chatbot (1)"), and callers hold the id, not the name.
  */
 export const loadTemplateByName = async (
   page: Page,
   templateName: string,
-): Promise<void> => {
-  // Clear flows via the API first, then load home — so the page reflects the
-  // real backend state (empty page vs. populated) when we pick an entry point.
-  await cleanAllFlows(page);
-
+): Promise<string> => {
   await page.goto("/");
   await page.waitForSelector('[data-testid="mainpage_title"]', {
     timeout: 30000,
@@ -33,9 +33,28 @@ export const loadTemplateByName = async (
   await openNewFlowTemplatesModal(page);
 
   await page.getByTestId("side_nav_options_all-templates").click();
+
+  // Picking a template instantiates the flow via POST /api/v1/flows/ —
+  // capture the response to return the authoritative flow id.
+  const flowCreationPromise = page.waitForResponse(
+    (resp) =>
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201,
+    { timeout: 30000 },
+  );
   await page.getByRole("heading", { name: templateName }).first().click();
+  const creationResponse = await flowCreationPromise;
+  const flowId = (await creationResponse.json()).id as string | undefined;
+  if (!flowId || flowId.trim() === "") {
+    throw new Error(
+      "Template flow creation response did not include a valid non-empty id.",
+    );
+  }
 
   await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
     timeout: 30000,
   });
+
+  return flowId;
 };

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-config-persistence.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-config-persistence.spec.ts
@@ -50,35 +50,50 @@ async function setIntField(page: Page, testId: string, value: string): Promise<v
   await expect(field).toHaveValue(value, { timeout: 5000 });
 }
 
-// Resolve the single post-wipe flow from the flows list (the canvas URL id is
-// transient on 1.11) and return the Agent node's template.
+// Fetch the flow by the id captured at template instantiation (the canvas URL
+// id is transient on 1.11) and return its Agent node's template. Resolving by
+// id — instead of scanning the whole flows list — keeps the assert immune to
+// flows created by other specs or parallel workers (#553).
 async function getPersistedAgentTemplate(
   request: APIRequestContext,
+  flowId: string,
 ): Promise<any> {
   const bearer = await getAuthToken(request);
-  const res = await request.get(
-    "/api/v1/flows/?remove_example_flows=true&header_flows=false",
-    { headers: { Authorization: bearer } },
-  );
+  const res = await request.get(`/api/v1/flows/${flowId}`, {
+    headers: { Authorization: bearer },
+  });
   expect(res.status()).toBe(200);
-  const flows = await res.json();
-  const agentNodes = (Array.isArray(flows) ? flows : [])
-    .flatMap((f: any) => f.data?.nodes ?? [])
-    .filter((n: any) => n.data?.type === "Agent");
-  expect(agentNodes.length, "exactly one Agent flow must exist post-wipe").toBe(1);
+  const flow = await res.json();
+  const agentNodes = (flow.data?.nodes ?? []).filter(
+    (n: any) => n.data?.type === "Agent",
+  );
+  expect(agentNodes.length, "the template flow must have exactly one Agent node").toBe(1);
   return agentNodes[0].data.node.template;
 }
 
 test.describe.configure({ mode: "serial" });
+
+let createdFlowId: string | null = null;
+
+// Delete only the flow this test created (by id) — a broad cleanup here
+// would kill parallel workers' in-flight flows (#553).
+test.afterEach(async ({ page }) => {
+  if (createdFlowId) {
+    await page.request.delete(`/api/v1/flows/${createdFlowId}`).catch(() => {});
+    createdFlowId = null;
+  }
+});
 
 test(
   "Agent settings survive save and reopen",
   { tag: ["@stable", "@regression", "@agents", "@workspace"] },
   async ({ page, request }) => {
     const nonce = `PERSIST_PROBE_${Date.now()}`;
+    let flowId = "";
 
     await test.step("load the Simple Agent template (no provider setup — model-free)", async () => {
-      await loadTemplateByName(page, "Simple Agent");
+      flowId = await loadTemplateByName(page, "Simple Agent");
+      createdFlowId = flowId;
     });
 
     await test.step("set string, int and bool sentinels in the Controls dialog", async () => {
@@ -125,7 +140,7 @@ test(
       await expect
         .poll(
           async () => {
-            const t = await getPersistedAgentTemplate(request);
+            const t = await getPersistedAgentTemplate(request, flowId);
             return {
               system_prompt: t.system_prompt?.value,
               max_iterations: t.max_iterations?.value,
@@ -144,7 +159,7 @@ test(
     await test.step("reopen the flow from the home page", async () => {
       await page.goto("/");
       await page.waitForSelector('[data-testid="mainpage_title"]', { timeout: 30000 });
-      await page.locator('[data-testid^="flow-name-"]').first().click();
+      await page.getByTestId(`flow-name-${flowId}`).click();
       await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
         timeout: 30000,
       });

--- a/tests/tests-automations/regression/core-functionality/llm-agents/memory-history-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/memory-history-regression.spec.ts
@@ -12,12 +12,14 @@ if (!process.env.CI) {
   dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
 }
 
-async function loadMemoryChatbot(page: Page): Promise<void> {
-  await loadTemplateByName(page, "Memory Chatbot");
+async function loadMemoryChatbot(page: Page): Promise<string> {
+  const flowId = await loadTemplateByName(page, "Memory Chatbot");
 
   await adjustScreenView(page);
   await updateOldComponents(page);
   await adjustScreenView(page);
+
+  return flowId;
 }
 
 // Waits until `expectedResponses` bot responses have *fully completed*.
@@ -35,11 +37,22 @@ async function waitForChatResponse(page: Page, expectedResponses: number): Promi
 }
 
 test.describe("Memory Chatbot Regression", () => {
+  let createdFlowId: string | null = null;
+
+  // Delete only the flow this test created (by id) — a broad cleanup here
+  // would kill parallel workers' in-flight flows (#553).
+  test.afterEach(async ({ page }) => {
+    if (createdFlowId) {
+      await page.request.delete(`/api/v1/flows/${createdFlowId}`).catch(() => {});
+      createdFlowId = null;
+    }
+  });
+
   test(
     "memory chatbot template loads with correct node structure",
     { tag: ["@release", "@agents", "@playground"] },
     async ({ page }) => {
-      await loadMemoryChatbot(page);
+      createdFlowId = await loadMemoryChatbot(page);
 
       // Template redesigned upstream (1.11.0.dev34): Agent + Memory Base
       // replaced the Message History / Language Model / Prompt Template trio
@@ -68,7 +81,7 @@ test.describe("Memory Chatbot Regression", () => {
         "OPENAI_API_KEY required to run this test",
       );
 
-      await loadMemoryChatbot(page);
+      createdFlowId = await loadMemoryChatbot(page);
       await setupLanguageModelOpenAI(page);
 
       const playground = new PlaygroundPage(page);
@@ -120,7 +133,7 @@ test.describe("Memory Chatbot Regression", () => {
         "OPENAI_API_KEY required to run this test",
       );
 
-      await loadMemoryChatbot(page);
+      createdFlowId = await loadMemoryChatbot(page);
       await setupLanguageModelOpenAI(page);
 
       const playground = new PlaygroundPage(page);


### PR DESCRIPTION
**Fixes #553. Fixes #520.**

> **#520 (memory-history session isolation flaky) shares this exact root cause** — see the evidence comment on #520: in both of its flaky dailies (2026-07-02 run 28583683001, 2026-07-03 run 28654917894) the failing attempt's stdout shows `404 "Flow not found"` on the test's own flow, and `model-provider-model-toggle` (a wiper via `SimpleAgentTemplatePage.load()` → `loadTemplateByName` → `cleanAllFlows`) starts inside the failure window in both runs. The issue's original theory (session-reset race on `toHaveCount(0)`) is disproven by the artifacts — the flow dies before the first message completes. This PR's removal of the wipe defuses ALL `SimpleAgentTemplatePage`-based specs (15 specs, 11 `@stable`) at the source. Validated: victim + that exact wiper in parallel (`--workers=2 --retries=0`), 5/5 across 2 rounds, JSON-counted.

## Problem

`llm-invalid-api-key-ui.spec.ts:77` ("playground input remains usable after API error") flaked on two consecutive dailies (2026-07-06 run 28790094596 — 3 attempts; 2026-07-07 run 28860759001 — 2 attempts). All three failing attempts share the exact same signature in the retry artifacts:

- the test times out on `page.waitForResponse` for the mocked `POST /api/v2/workflows` (10s), and
- the attempt's stdout shows **3× `404 "Flow not found"` on the test's own flow id** — the flow was deleted mid-test, and
- in every failure window, a `memory-history-regression.spec.ts` test **started concurrently** on another worker.

**Root cause (test infrastructure, not product):** `loadTemplateByName` began every call with `cleanAllFlows`, which deletes **every** user flow on the shared instance — including flows other parallel workers are actively driving. In the fully-parallel daily, whenever a template-based spec started while `llm-invalid-api-key-ui` was mid-run, the victim's flow was wiped, its page started 404ing, and the run request never fired.

Reproduced deterministically on nightly `1.11.0.dev34`: a parallel loop deleting user flows (simulating a neighbor's `cleanAllFlows`) makes the victim fail at exactly the same line with the same signature. Without it: 12/12 green (`--retries=0`).

**Not a regression of #444:** the passing-attempt trace confirms the playground still executes via `POST /api/v2/workflows`; the mock and waiter from #444 remain correct. Loosening the 10s timeout would NOT have fixed this — the flow is dead, the POST never comes.

## Fix

The victim spec is untouched. The collision source is removed:

- `loadTemplateByName` no longer wipes flows and now **returns the created flow's id** (captured from the template-instantiation `POST /api/v1/flows/` 201 — the canvas URL id is transient on 1.11). The wipe's original justification (400 on duplicate template name) no longer holds: the backend auto-suffixes duplicates ("Memory Chatbot (1)").
- Its two consumers (`memory-history-regression`, `agent-config-persistence`) now delete **only their own flow by id** in `afterEach`.
- `agent-config-persistence` also resolves its flow **by id** in the API assert (was: scan asserting "exactly one Agent flow" across the whole list, which only held because of the global wipe) and reopens via the exact `flow-name-<id>` card.
- `cleanAllFlows` keeps working for its 9 direct-caller specs but now carries an explicit WARNING JSDoc; migrating those callers is a systemic follow-up (they are all potential wipers of parallel neighbors, which likely explains part of the mass flakiness in saturated dailies).

Rejected alternative: an intermediate name-scoped cleanup (`delete flows named like the template`) still killed same-template siblings under parallelism — caught in local parallel rounds and replaced by the no-delete design.

## Scope note

- The flaky test itself (`llm-invalid-api-key-ui.spec.ts`) is unchanged — it was correct all along.
- All tags kept (`@stable` never removed, per the recurring-flaky policy).
- No behavior/assertion of the two consumer specs was weakened; their assertions are unchanged except flow resolution by id (strictly stronger under parallelism).

## Validation (nightly 1.11.0.dev34, `--retries=0`)

- typecheck ✅ · eslint 0 errors ✅
- Victim spec: 12/12 serial green; 12/12 across 6 parallel rounds with the former collider — zero flow-404s ✅
- `agent-config-persistence`: 4/4 green (serial) ✅
- `memory-history-regression`: 3/3 green (serial), repeated ✅
- Combined parallel rounds (3 files, `--workers=3`, JSON-reporter counted): 6/6, 6/6, 6/6, plus one round with a single `memory-history` t2 failure caused by LLM response latency under 3-worker load (120s badge timeout, **no flow-404** — pre-existing flake mode, unrelated to this change) ✅ reported honestly
- SURVIVOR experiment: seeded foreign flow + seeded "Memory Chatbot" leftover both survive a template-spec run; the spec's own flow is removed by its `afterEach`; duplicate-name load works via auto-suffix ✅
- Force-fail: (a) mutating the cleanup back to delete-all kills the seeded SURVIVOR (experiment falsifiable); (b) sabotaging the flow id makes the API assert fail on `expect(200)` ✅
- Flow-leak check: post-run leak = 0 flows for both modified specs (measured from a wiped baseline) ✅
- `--trace=on` skipped: known hang on template-family specs (heavy ReactFlow canvas, see #490 validation notes); covered via `--retries=0` bursts + force-fail mutations instead
- Remaining deliverable (issue item 3): confirm no recurrence across subsequent dailies after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

