### PR TITLE
fix(flow-functionality): export the created flow's own card, not nth(0) (#518)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -783,7 +783,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 273 `test()` calls carrying the `@stable` tag, distributed across 98 spec
+> 274 `test()` calls carrying the `@stable` tag, distributed across 98 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -1057,6 +1057,7 @@
 - [x] user can copy a valid macOS/Linux curl command from the API access modal → `curlApiGeneration.spec.ts`
 - [x] user can duplicate a flow from the home page dropdown menu → `duplicate-flow.spec.ts`
 - [x] duplicate flow via API auto-suffixes the name on collision → `duplicate-flow.spec.ts`
+- [x] export flow to JSON triggers success toast and produces a valid file → `export-import-flow.spec.ts`
 - [x] imported JSON flow must load all components on canvas → `export-import-flow.spec.ts`
 - [x] import flow from JSON via upload button must load flow on canvas → `export-import-flow.spec.ts`
 - [x] 1 - runs the flow from the canvas terminal node → `flow-execution-canvas.spec.ts`

--- a/docs/flow-functionality/export-import-flow.md
+++ b/docs/flow-functionality/export-import-flow.md
@@ -1,6 +1,6 @@
 # Flow Functionality — Export and Import Flow
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.11.x
 
 ---
 
@@ -26,12 +26,23 @@ If these break, users cannot share flows, back them up, or restore previously ex
 
 **Test 1 — export produces a valid downloadable file with success feedback**
 
-1. Create blank flow, add ChatInput component, return to main page
-2. Arm `page.waitForEvent("download")` BEFORE clicking export (Promise-based capture to avoid race with modal interaction)
-3. Open three-dot menu → `btn-download-json` → confirm "Export" modal text → click `modal-export-button`
-4. Assert toast matching `.*exported successfully` is visible
-5. Await the download event (hard-fails if it doesn't fire within 30s)
-6. Read file, `JSON.parse`, assert `data.nodes` is a non-empty array
+1. Create blank flow (capturing the flow id from the `POST /api/v1/flows/` 201
+   response) and add a ChatInput component
+2. Poll `GET /api/v1/flows/{id}` until `data.nodes.length > 0` — server-truth
+   proof the node-add autosave persisted, replacing the quiet-window guard
+   (`waitForFlowSaveSettled` resolves after 700 ms of silence even when the
+   debounced PATCH hasn't fired yet — the #384 loophole)
+3. Return to main page and open the three-dot menu **of the created flow's own
+   card**: `list-card` filtered by `flow-name-{id}` → `home-dropdown-menu`
+   inside it. Never `nth(0)`: the home sorts by `updated_at` DESC, so under
+   parallel CI the first card is whatever flow a neighbor worker touched last
+   — exporting it produced the `nodes: []` failures (#518; export serializes
+   the card's client-side data, no server fetch)
+4. Arm `page.waitForEvent("download")` BEFORE clicking export (Promise-based capture to avoid race with modal interaction)
+5. `btn-download-json` → confirm "Export" modal text → click `modal-export-button`
+6. Assert toast matching `.*exported successfully` is visible
+7. Await the download event (hard-fails if it doesn't fire within 30s)
+8. Read file, `JSON.parse`, assert `data.nodes` is a non-empty array
 
 **Test 2 — imported JSON loads on canvas**
 
@@ -90,4 +101,5 @@ If these break, users cannot share flows, back them up, or restore previously ex
 - Test 1 sets up the download event listener via `page.waitForEvent("download")` BEFORE clicking the export button — a race-condition-avoidance pattern. The test hard-fails if the download event doesn't fire and also asserts the visible toast, so both the user-facing signal and the actual file artifact are validated in one run (the toast-only variant was consolidated into this test to avoid redundant blank-flow setup).
 - Test 3 hard-asserts `upload-project-button` is visible before importing and then actually exercises it via `filechooser` + `setFiles` — distinct from Test 2's drag-and-drop path.
 - The 2-minute timeout on "uploaded successfully" in Test 2 is intentional: large collections can take time to process on slow machines.
-- The describe is configured `mode: "serial"` so the diff-based cleanup (`beforeEach` snapshot of existing flow IDs, `afterEach` delete-the-diff) runs without cross-worker races within this file. The list calls use `get_all=true&remove_example_flows=true` to match the existing `cleanAllFlows` helper. A null sentinel on snapshot failure skips cleanup entirely so a hiccup on the list endpoint can never delete the whole workspace.
+- Cleanup tracks the ids returned by this page's own flow-creating responses (`POST` under `/api/v1/flows`) and deletes exactly those in `afterEach`. The previous diff-based cleanup (snapshot → delete-the-difference) deleted any flow created by PARALLEL workers during the test window — the destructive-cleanup class from #553 — and is gone. The describe stays `mode: "serial"` so the three tests share the tracker safely within the file.
+- The exported JSON is serialized client-side from the home card's store data (`ExportModal` → `downloadFlow`; no server fetch on download) — which is why exporting the wrong (fresh, empty) card yields `nodes: []` with a perfectly healthy backend.

--- a/tests/tests-automations/regression/flow-functionality/export-import-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/export-import-flow.spec.ts
@@ -1,80 +1,80 @@
 import { readFileSync } from "fs";
 import path from "path";
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { simulateDragAndDrop } from "../../../helpers/ui/simulate-drag-and-drop";
-import { waitForFlowSaveSettled } from "../../../helpers/flows/wait-for-flow-save-settled";
 
-// Force serial execution within this file so the diff-based cleanup remains
-// safe — the snapshot/diff pattern is racy across workers when multiple tests
-// run concurrently against the same backend.
+// Serial so the three tests share the created-flow tracker safely within
+// this file.
 test.describe.configure({ mode: "serial" });
 
 test.describe("Export and Import Flow (IDs 173 + 120)", () => {
-  const LIST_PARAMS = { get_all: "true", remove_example_flows: "true" };
+  // Ids of flows created by THIS page's own requests, collected from the
+  // flow-creating POST responses and deleted one by one in afterEach. The
+  // previous diff-based cleanup (snapshot the list, delete the difference)
+  // deleted any flow a PARALLEL worker created during the test window — the
+  // cross-worker destructive-cleanup class from #553.
+  let createdFlowIds: string[] = [];
 
-  // `null` is a sentinel meaning "snapshot failed — skip cleanup this run" so
-  // we never delete the entire workspace if the list endpoint hiccups.
-  let preTestFlowIds: Set<string> | null = null;
-
-  test.beforeEach(async ({ request }) => {
-    preTestFlowIds = null;
-    try {
-      const headers = { Authorization: await getAuthToken(request) };
-      const listRes = await request.get("/api/v1/flows/", {
-        headers,
-        params: LIST_PARAMS,
-      });
-      if (listRes.ok()) {
-        const body = await listRes.json();
-        const flows: Array<{ id: string }> = Array.isArray(body)
-          ? body
-          : (body?.flows ?? []);
-        preTestFlowIds = new Set(flows.map((f) => f.id));
+  const trackFlowCreations = (page: Page) => {
+    page.on("response", async (resp) => {
+      if (
+        !resp.url().includes("/api/v1/flows") ||
+        resp.request().method() !== "POST" ||
+        !resp.ok()
+      ) {
+        return;
       }
-    } catch {
-      // Leave sentinel as null so afterEach skips cleanup.
-    }
+      try {
+        const body = await resp.json();
+        const items = Array.isArray(body) ? body : (body?.flows ?? [body]);
+        for (const item of items) {
+          if (item?.id) createdFlowIds.push(item.id);
+        }
+      } catch {
+        // Non-JSON response — nothing to track.
+      }
+    });
+  };
+
+  test.beforeEach(async ({ page }) => {
+    createdFlowIds = [];
+    trackFlowCreations(page);
   });
 
   test.afterEach(async ({ request }) => {
-    if (preTestFlowIds === null) return;
-    const snapshot = preTestFlowIds;
-    try {
-      const headers = { Authorization: await getAuthToken(request) };
-      const listRes = await request.get("/api/v1/flows/", {
-        headers,
-        params: LIST_PARAMS,
-      });
-      if (listRes.ok()) {
-        const body = await listRes.json();
-        const flows: Array<{ id: string }> = Array.isArray(body)
-          ? body
-          : (body?.flows ?? []);
-        for (const f of flows) {
-          if (!snapshot.has(f.id)) {
-            await request.delete(`/api/v1/flows/${f.id}`, { headers });
-          }
-        }
-      }
-    } catch {
-      // Cleanup is best-effort.
+    const headers = { Authorization: await getAuthToken(request) };
+    for (const id of createdFlowIds) {
+      await request.delete(`/api/v1/flows/${id}`, { headers }).catch(() => {});
     }
+    createdFlowIds = [];
   });
 
-  // @stable temporarily removed — flake regressed into a suspected real bug
-  // (export reads an empty flow, `nodes: []`); tracked in #518. Restore once fixed.
   test(
     "export flow to JSON triggers success toast and produces a valid file",
-    { tag: ["@release", "@workspace", "@api", "@regression"] },
-    async ({ page }) => {
+    { tag: ["@stable", "@release", "@workspace", "@api", "@regression"] },
+    async ({ page, request }) => {
       await awaitBootstrapTest(page);
 
       await page.waitForSelector('[data-testid="blank-flow"]', {
         timeout: 30000,
       });
+
+      // Capture the created flow's id from the creation response — the only
+      // reliable handle for picking the right home card later (#518).
+      const flowCreationPromise = page.waitForResponse(
+        (resp) =>
+          resp.url().includes("/api/v1/flows") &&
+          resp.request().method() === "POST" &&
+          resp.status() === 201,
+        { timeout: 15000 },
+      );
       await page.getByTestId("blank-flow").click();
+      const flowId = ((await flowCreationPromise.then((r) => r.json())) as { id?: string })
+        .id;
+      expect(flowId, "flow creation response must include an id").toBeTruthy();
 
       await page.waitForSelector('[data-testid="sidebar-search-input"]', {
         timeout: 30000,
@@ -91,12 +91,23 @@ test.describe("Export and Import Flow (IDs 173 + 120)", () => {
           await page.getByTestId("add-component-button-chat-input").click();
         });
 
-      // Wait for the node-add autosave (debounced `PATCH /api/v1/flows/{id}`)
-      // to persist before leaving the editor. The export reads the *persisted*
-      // flow, so navigating back/exporting while the PATCH is still in flight
-      // produces an empty file (`parsed.data.nodes.length === 0`) — the flake
-      // observed in the weekly run (issue #384).
-      await waitForFlowSaveSettled(page);
+      // Server-truth guard: poll the flow by id until the node-add autosave is
+      // PERSISTED. The previous quiet-window guard (`waitForFlowSaveSettled`,
+      // #384) resolves after 700ms of network silence even when the debounced
+      // PATCH hasn't fired yet — under CI load that let the test leave the
+      // editor before the node ever reached the backend.
+      const headers = { Authorization: await getAuthToken(request) };
+      await expect
+        .poll(
+          async () => {
+            const res = await request.get(`/api/v1/flows/${flowId}`, { headers });
+            if (!res.ok()) return -1;
+            const flow = await res.json();
+            return flow?.data?.nodes?.length ?? 0;
+          },
+          { timeout: 15000 },
+        )
+        .toBeGreaterThan(0);
 
       await page.getByTestId("icon-ChevronLeft").click();
 
@@ -108,7 +119,15 @@ test.describe("Export and Import Flow (IDs 173 + 120)", () => {
       // race between the download event and modal interaction.
       const downloadPromise = page.waitForEvent("download", { timeout: 30000 });
 
-      await page.getByTestId("home-dropdown-menu").nth(0).click();
+      // Export from the created flow's OWN card. The home list sorts by
+      // `updated_at` DESC, so `.nth(0)` picks whatever flow ANY parallel
+      // worker touched last — in the daily that exported a neighbor's empty
+      // flow (`nodes: []`, #518): the export modal serializes the card's
+      // client-side data with no server fetch.
+      const ownCard = page
+        .getByTestId("list-card")
+        .filter({ has: page.getByTestId(`flow-name-${flowId}`) });
+      await ownCard.getByTestId("home-dropdown-menu").click();
       await page.getByTestId("btn-download-json").last().click();
 
       await expect(page.getByText("Export").first()).toBeVisible({


### PR DESCRIPTION
**Fixes #518.**

## Problem

`export-import-flow.spec.ts:66` ("export flow to JSON triggers success toast and produces a valid file") flaked on consecutive dailies (2026-07-02 run 28583683001, 2026-07-03 run 28654917894) with the exported JSON containing `data.nodes: []`. The issue suspected a real product bug (export reading a not-yet-persisted flow) regressing #384.

**Root cause — test defect (selection), product innocent:**

- The export modal serializes the clicked card's **client-side** data (`ExportModal` → `downloadFlow` in the upstream frontend) — no server fetch on download.
- The home list sorts by **`updated_at` DESC** (upstream `sort-flows.ts`).
- The test clicked `home-dropdown-menu.nth(0)` — the card of whatever flow ANY parallel worker touched last. In the fully-parallel daily that is frequently a neighbor's just-created empty blank flow, so the test exported a healthy-but-empty foreign flow: `nodes: []`, successful download, no backend errors — exactly the CI signature (the failing attempt's screenshot even shows the home page full of other workers' flows and a "Flow saved successfully!" toast landing during export).
- Reproduced deterministically on nightly `1.11.0.dev34`: a parallel loop creating blank flows every 300ms makes the ORIGINAL spec fail 3/3 with the identical `Received: 0` at `nodes.length`.

Secondary defect closed in passing: `waitForFlowSaveSettled` (the #384 guard) resolves after 700ms of network **silence** even when the debounced PATCH hasn't fired yet — under CI load it could release before the node ever reached the backend.

## Fix

1. **Export the created flow's OWN card**: capture the flow id from the `POST /api/v1/flows/` 201 creation response, then `getByTestId("list-card").filter({ has: getByTestId("flow-name-<id>") })` → `home-dropdown-menu` inside it (testids confirmed live + in the upstream source). Never `nth(0)`.
2. **Server-truth persistence guard**: poll `GET /api/v1/flows/{id}` until `data.nodes.length > 0` before leaving the editor — replaces the quiet-window guard and closes the #384 race for good.
3. **Cross-worker-safe cleanup**: the old diff-based cleanup (snapshot the list, delete the difference) deleted any flow a PARALLEL worker created during the test window — the destructive-cleanup class from #553/#560. Replaced with a tracker that collects ids from this page's own flow-creating POST responses and deletes exactly those.
4. **`@stable` restored** on the export test (explicit issue deliverable).

Rejected alternative: keeping `nth(0)` with a longer/looser wait — the selection is nondeterministic under parallelism regardless of timing.

## Scope note

- Tests 2 and 3 (imports) keep their behavior and assertions; they only gain the safer cleanup.
- Spec doc updated (steps, notes, `Last validated` 1.11.x); QA-CHECKLIST bullets already pointed at this spec — only the generated Phase 0 block changed (regenerated, 274 @stable).
- Other specs still using `nth(0)` on `home-dropdown-menu` (`actionsMainPage-shard-*`) are a follow-up candidate, out of scope here.

## Validation (nightly `1.11.0.dev34`, `--retries=0`, JSON-reporter counted)

- typecheck ✅ · eslint 0 errors ✅
- Baseline 3/3 + burst 3×3/3 ✅
- **Adversarial**: flow-seeder (blank flow every 300ms, ~25 per run) — pre-fix 3/3 FAILED, post-fix 3/3 PASSED ✅
- Force-fail, all 5 mutations failed as expected and were reverted (final grep clean + 3/3 green): wrong card id → click timeout; poll threshold 99 → `Received: 1`; pre-fix code under seeder → 3/3; impossible toast text on test 2 → failed; same on test 3 run isolated (serial skips it when test 2 fails) → failed ✅
- Flow-leak check: 0 flows left after bursts (tracker cleanup) ✅
- `--trace=on` skipped: hangs locally on this spec too (>7min vs ~17s normal; broader than the Simple Agent family noted in #490) — covered via bursts + force-fail + adversarial runs; CI's trace-on-first-retry captures traces fine for this spec (the #518 evidence itself came from them)
- Post-merge: confirm no recurrence across subsequent dailies

🤖 Generated with [Claude Code](https://claude.com/claude-code)
