### PR TITLE
fix(flow-functionality): replace api-access diff cleanup with tracked-own-ids (#519)

### DIFF
--- a/docs/flow-functionality/api-access-modal-regression.md
+++ b/docs/flow-functionality/api-access-modal-regression.md
@@ -35,7 +35,7 @@ A shared `openApiAccessModal(page)` helper performs the common opening sequence 
 
 A second helper `selectUnixCurlTab(page)` clicks `api_tab_curl` then the `macOS/Linux` platform sub-tab, so the generated cURL is deterministic (the default platform follows `getOS()`, which can resolve to Windows/PowerShell on some runners).
 
-Cleanup is handled by a shared **snapshot/diff `afterEach`** (same pattern as the validated sibling `export-import-flow.spec.ts`), not by per-test `finally` blocks: `beforeEach` records the flow IDs that exist before the test, `afterEach` deletes any that appeared after it. A `null` sentinel means "snapshot failed — skip cleanup" so a list-endpoint hiccup never wipes the workspace; it also runs for tests that fail mid-way, so a flow created before an assertion failure is still swept.
+Cleanup tracks the ids returned by this page's own flow-creating responses (`POST` under `/api/v1/flows`) and deletes exactly those in `afterEach` (same pattern as `export-import-flow.spec.ts` post-#561). The previous snapshot/diff cleanup deleted any flow a PARALLEL worker created during the test window — the cross-worker destructive-cleanup class from #553; in the daily it was the wiper that killed `edit-flow-name`'s in-flight flows (#519). The tracker also runs for tests that fail mid-way, so a flow created before an assertion failure is still swept.
 
 ### Test 1 — `API access modal opens from the Publish dropdown exposing the Python, JavaScript and cURL tabs`
 
@@ -69,7 +69,7 @@ Cleanup is handled by a shared **snapshot/diff `afterEach`** (same pattern as th
 - Tab switching is proven by reading the clipboard after each tab's Copy click (the visible code is a tokenized `SyntaxHighlighter` tree, not a plain string) and asserting the snippets differ AND each matches its language signature
 - The endpoint URL assertion uses the **specific** captured `flowId` (`/api/v1/run/{flowId}`), not a generic UUID match — coherence with the open flow is the distinct concern of this spec
 - Both close paths (`Escape`, `Close` button) drive `api_tab_curl` to hidden — a partial close (overlay lingering) would fail
-- A shared snapshot/diff `afterEach` deletes any flow created during the test so repeated runs do not accumulate workspace artifacts; the `null` sentinel keeps a failed snapshot from wiping the workspace
+- A shared tracked-ids `afterEach` deletes exactly the flows this page created, so repeated runs do not accumulate workspace artifacts without ever touching parallel workers' flows (#519)
 
 ---
 

--- a/tests/tests-automations/regression/flow-functionality/api-access-modal-regression.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/api-access-modal-regression.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
@@ -8,58 +9,48 @@ import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 // creating the flow"). Serializing removes that self-collision and keeps the run free of backend errors.
 test.describe.configure({ mode: "serial" });
 
-const LIST_PARAMS = { get_all: "true", remove_example_flows: "true" };
+// Ids of flows created by THIS page's own requests, collected from the
+// flow-creating POST responses and deleted one by one in afterEach. The
+// previous diff-based cleanup (snapshot the list, delete the difference)
+// deleted any flow a PARALLEL worker created during the test window — the
+// cross-worker destructive-cleanup class from #553/#561; here it was the
+// wiper that killed edit-flow-name's in-flight flows in the daily (#519).
+// This also runs for tests that fail mid-way, so a flow created before an
+// assertion failure is still swept.
+let createdFlowIds: string[] = [];
 
-// Snapshot/diff cleanup — same pattern as the validated sibling export-import-flow.spec.ts in this
-// directory: record the flow IDs that exist before each test, then delete any that appeared after it.
-// `null` is a sentinel meaning "snapshot failed — skip cleanup this run" so a list-endpoint hiccup
-// never deletes the whole workspace. This also runs for tests that fail mid-way, so a flow created
-// before an assertion failure is still swept.
-let preTestFlowIds: Set<string> | null = null;
-
-test.beforeEach(async ({ request }) => {
-  preTestFlowIds = null;
-  try {
-    const headers = { Authorization: await getAuthToken(request) };
-    const listRes = await request.get("/api/v1/flows/", {
-      headers,
-      params: LIST_PARAMS,
-    });
-    if (listRes.ok()) {
-      const body = await listRes.json();
-      const flows: Array<{ id: string }> = Array.isArray(body)
-        ? body
-        : (body?.flows ?? []);
-      preTestFlowIds = new Set(flows.map((f) => f.id));
+const trackFlowCreations = (page: Page) => {
+  page.on("response", async (resp) => {
+    if (
+      !resp.url().includes("/api/v1/flows") ||
+      resp.request().method() !== "POST" ||
+      !resp.ok()
+    ) {
+      return;
     }
-  } catch {
-    // Leave sentinel as null so afterEach skips cleanup.
-  }
+    try {
+      const body = await resp.json();
+      const items = Array.isArray(body) ? body : (body?.flows ?? [body]);
+      for (const item of items) {
+        if (item?.id) createdFlowIds.push(item.id);
+      }
+    } catch {
+      // Non-JSON response — nothing to track.
+    }
+  });
+};
+
+test.beforeEach(async ({ page }) => {
+  createdFlowIds = [];
+  trackFlowCreations(page);
 });
 
 test.afterEach(async ({ request }) => {
-  if (preTestFlowIds === null) return;
-  const snapshot = preTestFlowIds;
-  try {
-    const headers = { Authorization: await getAuthToken(request) };
-    const listRes = await request.get("/api/v1/flows/", {
-      headers,
-      params: LIST_PARAMS,
-    });
-    if (listRes.ok()) {
-      const body = await listRes.json();
-      const flows: Array<{ id: string }> = Array.isArray(body)
-        ? body
-        : (body?.flows ?? []);
-      for (const f of flows) {
-        if (!snapshot.has(f.id)) {
-          await request.delete(`/api/v1/flows/${f.id}`, { headers });
-        }
-      }
-    }
-  } catch {
-    // Cleanup is best-effort.
+  const headers = { Authorization: await getAuthToken(request) };
+  for (const id of createdFlowIds) {
+    await request.delete(`/api/v1/flows/${id}`, { headers }).catch(() => {});
   }
+  createdFlowIds = [];
 });
 
 // Opens the Basic Prompting template (matching curlApiGeneration / pythonApiGeneration), then opens


### PR DESCRIPTION
**Fixes #519.**

## Problem

`flow-rename-header.spec.ts:13` flaked on consecutive dailies (2026-07-02 run 28583683001, 2026-07-03 run 28654917894) with the rename input staying visible. The issue also flagged `edit-flow-name.spec.ts:5` with a similar signature for fold-in if the root cause was shared — it is.

**Root cause — cross-worker destructive cleanup (the #553/#561 class), TWO wipers:**

- **`flow-rename-header` (victim 1):** both failing attempts' stdout show `404 "Flow not found"` on the test's own flow (07-02 additionally logged `500 "An internal error occurred while deleting flows"`). In both runs, `export-import-flow.spec.ts` ran concurrently in the exact window — its diff-based `afterEach` (snapshot the list, delete the difference) deleted the rename test's in-flight flow. That wiper was **already removed in #561** (this and #518 were literally the same event: export att0 failed exporting the wrong card, then its afterEach killed the rename neighbor).
- **`edit-flow-name` (victim 2, folded in):** same 404-on-own-flow signature on both of its failing attempts (2026-07-03). The collider in its window is `api-access-modal-regression.spec.ts` — which carried a **verbatim copy of the same diff-based cleanup** (its own comment: "same pattern as the validated sibling export-import-flow.spec.ts"). Repo census: it was the **last remaining** spec with this pattern.
- The "input stays visible" assertion failure was the symptom of the flow dying mid-rename, not a wait problem — the victims' code is untouched.

Deterministic pre-fix proof: a neighbor flow created via API 3s into an api-access test run was deleted by its `afterEach` (`404` after the run).

## Fix

`api-access-modal-regression.spec.ts` cleanup replaced with the tracked-own-ids pattern from #561: collect ids from this page's own flow-creating `POST` responses, delete exactly those in `afterEach`. Test logic and assertions unchanged; `@stable` kept everywhere (never removed). Spec doc updated.

With this PR the repo has **zero** diff-based cleanups; the remaining known wiper class is the 12 direct `cleanAllFlows` callers (separate follow-up, on hold).

## Validation (nightly `1.11.0.dev34`, `--retries=0`, JSON-reporter counted)

- typecheck ✅ · eslint 0 errors ✅
- MIDRUN neighbor experiment: pre-fix **404 (killed)** → post-fix **200 (survives)** ✅
- Burst 3× = 4/4 · flow-leak after runs = 0 ✅
- Parallel trio (wiper + both victims, `--workers=3`) = 6/6 across 2 rounds ✅
- Force-fail, executed for every test in the touched file + the new mechanism, all failed as expected and reverted (diff grep clean, final 4/4 green): test 1 nonexistent testid; test 2 impossible snippet regex (isolated run — serial skips siblings after a failure); test 3 wrong flow id in run URL (isolated); test 4 inverted visibility after Escape (isolated); tracker collecting nothing → leak count 6 (proves deletes are real); pre-fix cleanup code = natural mutation (MIDRUN 404) ✅
- `--trace=on` skipped per the known local hang (#490/#518); CI trace-on-first-retry covers it — the #519 evidence came from those artifacts
- Post-merge: confirm no recurrence of `flow-rename-header` / `edit-flow-name` across subsequent dailies

🤖 Generated with [Claude Code](https://claude.com/claude-code)
