### PR TITLE
docs(checklist): mark handle_parsing_errors bullet not implementable on 1.11 (#496)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -362,7 +362,7 @@
 - [x] Input via direct field vs handle (ChatInput) — both work → `core-functionality/llm-agents/agent-input-sources.spec.ts`
 - [x] Empty response or model refusal — component does not crash → `core-functionality/llm-agents/agent-empty-refusal-response.spec.ts`
 - [ ] Toggle add_current_date_tool works (enables/disables date tool) → `agent-current-date-tool.spec.ts`
-- [ ] handle_parsing_errors=False fails explicitly vs True auto-corrects → `agent-parse-error-behavior.spec.ts`
+- [ ] handle_parsing_errors=False fails explicitly vs True auto-corrects → `agent-parse-error-behavior.spec.ts` (**not implementable on 1.11**: the field now only toggles `ToolRetryMiddleware`, and component-tool failures are converted to content by the hardcoded `handle_tool_error=True` before the middleware can observe them — True/False proven behaviorally identical; the only live trigger (LLM-emitted malformed args) is non-deterministic; pending re-scope, see #496)
 - [x] Image passed via input handle is processed correctly → `core-functionality/llm-agents/agent-multimodal-image-input.spec.ts`
 
 ---


### PR DESCRIPTION
**Closes #496.**

## Summary

Annotates the §6.5 checklist bullet as **not implementable on 1.11 — pending re-scope**, mirroring the #484/#540 precedent. No spec is shipped; full evidence (live experiment + source audit, including the design-space table) is on the issue: https://github.com/oriontech-me/langflow-e2e/issues/496#issuecomment-4909482560

Key facts (details on the issue):
- On 1.11 the Agent runs on `create_agent`; `handle_parsing_errors` no longer controls parse-retry — it only toggles `ToolRetryMiddleware(max_retries=2)`, which retries tool **exceptions**.
- Every Langflow component tool is built with hardcoded `handle_tool_error=True`, converting tool runtime failures to ToolMessage content before the middleware can observe an exception — **`True` and `False` proven behaviorally identical** in a live experiment (always-raising custom tool with an execution counter: 1 execution, `attempt=1`, both settings).
- The flag's only live trigger (LLM-emitted malformed args → `ValidationError`) is model behavior — non-deterministic, unshippable as `@stable`.
- MCP, flow-as-tool, BaseException and backend-internal observables audited and ruled out (table on the issue).

## Validation

- Docs-only change (one checklist bullet annotation); `npm run coverage:summary` idempotent (no generated-block changes — the bullet stays `[ ]`).
- typecheck ✅ · eslint 0 errors ✅ (no code touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
