### PR TITLE
test(infra): add shared deleteFlow() cleanup helper that surfaces failed deletions

### DIFF
--- a/tests/helpers/flows/clean-all-flows.ts
+++ b/tests/helpers/flows/clean-all-flows.ts
@@ -1,4 +1,5 @@
 import type { Page } from "@playwright/test";
+import { deleteFlow } from "./delete-flow";
 
 /**
  * Deletes all user-created flows via the Langflow REST API.
@@ -33,7 +34,20 @@ export const cleanAllFlows = async (page: Page) => {
   const flows: Array<{ id: string }> = Array.isArray(raw) ? raw : (raw.flows ?? []);
   if (flows.length === 0) return;
 
+  // Best-effort bulk sweep: keep deleting the rest even if one fails, then
+  // surface any failures at the end so a silently-incomplete cleanup is visible.
+  const failures: string[] = [];
   for (const flow of flows) {
-    await page.request.delete(`/api/v1/flows/${flow.id}`, { headers });
+    try {
+      await deleteFlow(page.request, flow.id, { headers });
+    } catch (err) {
+      failures.push(`${flow.id}: ${(err as Error).message}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(
+      `cleanAllFlows: ${failures.length} of ${flows.length} flow deletion(s) failed:\n${failures.join("\n")}`,
+    );
   }
 };

--- a/tests/helpers/flows/create-runnable-chat-flow-via-api.ts
+++ b/tests/helpers/flows/create-runnable-chat-flow-via-api.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "fs";
 import type { APIRequestContext } from "@playwright/test";
 import { expect } from "../../fixtures/fixtures";
+import { deleteFlow } from "./delete-flow";
 
 // A minimal, version-current runnable flow: Chat Input -> Chat Output passthrough
 // (single edge, no LLM or external provider key required). Chat Output echoes
@@ -63,9 +64,7 @@ export async function createRunnableChatFlowViaApi(
   return {
     flowId,
     deleteFlow: async () => {
-      await request
-        .delete(`/api/v1/flows/${flowId}`, { headers })
-        .catch(() => {});
+      await deleteFlow(request, flowId, { headers }).catch(() => {});
     },
   };
 }

--- a/tests/helpers/flows/create-runnable-chat-flow-via-api.ts
+++ b/tests/helpers/flows/create-runnable-chat-flow-via-api.ts
@@ -64,10 +64,15 @@ export async function createRunnableChatFlowViaApi(
   return {
     flowId,
     // Surfaces a genuinely-failed deletion (404 already counts as done). Callers
-    // that compose this into multi-step cleanup should wrap with .catch() so a
-    // failure here does not skip their remaining teardown.
-    deleteFlow: async () => {
-      await deleteFlow(request, flowId, { headers });
+    // that compose this into multi-step cleanup should wrap with .catch() (or a
+    // try/finally) so a failure here does not skip their remaining teardown.
+    //
+    // Pass `reqOverride` when deleting from a different fixture scope than the
+    // one this flow was created in: Playwright forbids reusing a `beforeAll`
+    // `request` after beforeAll, so a `beforeAll`-created flow deleted in
+    // `afterAll` must be given the afterAll's own live `request`.
+    deleteFlow: async (reqOverride?: APIRequestContext) => {
+      await deleteFlow(reqOverride ?? request, flowId, { headers });
     },
   };
 }

--- a/tests/helpers/flows/delete-flow.ts
+++ b/tests/helpers/flows/delete-flow.ts
@@ -1,0 +1,40 @@
+import type { APIRequestContext } from "@playwright/test";
+
+/**
+ * Deletes a flow via the Langflow REST API and surfaces a failed deletion.
+ *
+ * Playwright's `APIRequestContext.delete()` resolves to an `APIResponse` even
+ * on 4xx/5xx and never throws, so an unchecked cleanup call lets a failed
+ * deletion pass silently — the flow stays behind and the suite quietly starts
+ * re-accumulating leftover flows (the buildup #545 set out to stop). This
+ * helper checks the response and throws on failure so cleanup regressions are
+ * visible instead of silent.
+ *
+ * A single transient teardown 5xx (e.g. under parallel load) is absorbed by one
+ * retry before throwing, so a genuinely-failed deletion still surfaces without
+ * an otherwise-green test being failed by a one-off blip.
+ *
+ * Pass `page.request` (browser-context cookie/state auth is reused
+ * automatically) or a standalone `request` with an explicit Authorization
+ * header via `options.headers`.
+ *
+ * @param request  A Playwright `APIRequestContext` (`page.request` or the `request` fixture).
+ * @param id       The flow ID to delete.
+ * @param options  Optional request options, e.g. `{ headers: { Authorization } }`.
+ */
+export async function deleteFlow(
+  request: APIRequestContext,
+  id: string,
+  options?: { headers?: Record<string, string> },
+): Promise<void> {
+  const res = await request.delete(`/api/v1/flows/${id}`, options);
+  if (res.ok()) return;
+
+  // One retry to absorb a transient teardown 5xx under parallel load.
+  const retry = await request.delete(`/api/v1/flows/${id}`, options);
+  if (!retry.ok()) {
+    throw new Error(
+      `Flow cleanup failed: ${retry.status()} — ${await retry.text()}`,
+    );
+  }
+}

--- a/tests/helpers/flows/delete-flow.ts
+++ b/tests/helpers/flows/delete-flow.ts
@@ -28,11 +28,14 @@ export async function deleteFlow(
   options?: { headers?: Record<string, string> },
 ): Promise<void> {
   const res = await request.delete(`/api/v1/flows/${id}`, options);
-  if (res.ok()) return;
+  // 404 means the flow is already gone — for idempotent cleanup that IS the
+  // desired end state (e.g. a concurrent worker's sweep removed it first), not
+  // a failure. Only a genuine error (403/5xx/…) should surface.
+  if (res.ok() || res.status() === 404) return;
 
   // One retry to absorb a transient teardown 5xx under parallel load.
   const retry = await request.delete(`/api/v1/flows/${id}`, options);
-  if (!retry.ok()) {
+  if (!retry.ok() && retry.status() !== 404) {
     throw new Error(
       `Flow cleanup failed: ${retry.status()} — ${await retry.text()}`,
     );

--- a/tests/helpers/flows/setup-blank-flow.ts
+++ b/tests/helpers/flows/setup-blank-flow.ts
@@ -1,5 +1,6 @@
 import { Page, expect } from "@playwright/test";
 import { getAuthToken } from "../auth/get-auth-token";
+import { deleteFlow } from "./delete-flow";
 
 /**
  * Creates a new blank flow via the REST API and navigates to it through the
@@ -15,9 +16,9 @@ import { getAuthToken } from "../auth/get-auth-token";
  * that need a populated flow (ChatInput → ChatOutput), use `setupPlayground`.
  *
  * Returns the created flow's ID so the caller can clean up in `afterEach`
- * with `page.request.delete(\`/api/v1/flows/\${id}\`)`. The browser-context
- * auth (cookie/state) is reused automatically — no explicit Authorization
- * header is required on the cleanup call.
+ * with `deleteFlow(page.request, id)`. The browser-context auth (cookie/state)
+ * is reused automatically — no explicit Authorization header is required on
+ * the cleanup call.
  */
 export async function setupBlankFlow(page: Page): Promise<string> {
   const flowName = `e2e-blank-${Date.now()}-${Math.random()
@@ -60,7 +61,9 @@ export async function setupBlankFlow(page: Page): Promise<string> {
       timeout: 30000,
     });
   } catch (err) {
-    await page.request.delete(`/api/v1/flows/${flowId}`).catch(() => {});
+    // Best-effort rollback of the created flow — swallow so the original
+    // failure (err) is the one that surfaces, not a secondary cleanup error.
+    await deleteFlow(page.request, flowId).catch(() => {});
     throw err;
   }
 

--- a/tests/helpers/flows/setup-playground.ts
+++ b/tests/helpers/flows/setup-playground.ts
@@ -2,6 +2,7 @@ import { expect, Page } from "@playwright/test";
 import { adjustScreenView } from "../ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../other/await-bootstrap-test";
 import { zoomOut } from "../ui/zoom-out";
+import { deleteFlow } from "./delete-flow";
 
 export async function setupPlayground(page: Page): Promise<string> {
   await awaitBootstrapTest(page);
@@ -72,7 +73,9 @@ export async function setupPlayground(page: Page): Promise<string> {
       timeout: 8000,
     });
   } catch (err) {
-    await page.request.delete(`/api/v1/flows/${flowId}`).catch(() => {});
+    // Best-effort rollback of the created flow — swallow so the original
+    // failure (err) is the one that surfaces, not a secondary cleanup error.
+    await deleteFlow(page.request, flowId).catch(() => {});
     throw err;
   }
 

--- a/tests/tests-automations/regression/api/flows/api-flows-batch.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-flows-batch.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 const FLOW_BASE = {
   name: "",
@@ -62,11 +63,9 @@ test.describe("Batch/Bulk Flow API Operations", () => {
       } finally {
         // Cleanup any remaining flows (in case batch failed or was skipped)
         for (const id of flowIds) {
-          await request
-            .delete(`/api/v1/flows/${id}`, {
-              headers: { Authorization: authToken },
-            })
-            .catch(() => {});
+          await deleteFlow(request, id, {
+            headers: { Authorization: authToken },
+          }).catch(() => {});
         }
       }
     },
@@ -121,11 +120,9 @@ test.describe("Batch/Bulk Flow API Operations", () => {
         }
       } finally {
         for (const id of flowIds) {
-          await request
-            .delete(`/api/v1/flows/${id}`, {
-              headers: { Authorization: authToken },
-            })
-            .catch(() => {});
+          await deleteFlow(request, id, {
+            headers: { Authorization: authToken },
+          }).catch(() => {});
         }
       }
     },

--- a/tests/tests-automations/regression/api/flows/api-flows-crud.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-flows-crud.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 type Flow = { id: string; name: string; description?: string };
 
@@ -37,11 +38,9 @@ test.describe("CRUD /api/v1/flows", () => {
         });
       } finally {
         await test.step("cleanup created flow", async () => {
-          await request
-            .delete(`/api/v1/flows/${body.id}`, {
-              headers: { Authorization: authToken },
-            })
-            .catch(() => {});
+          await deleteFlow(request, body.id, {
+            headers: { Authorization: authToken },
+          }).catch(() => {});
         });
       }
     },
@@ -78,11 +77,9 @@ test.describe("CRUD /api/v1/flows", () => {
         });
       } finally {
         await test.step("cleanup created flow", async () => {
-          await request
-            .delete(`/api/v1/flows/${id}`, {
-              headers: { Authorization: authToken },
-            })
-            .catch(() => {});
+          await deleteFlow(request, id, {
+            headers: { Authorization: authToken },
+          }).catch(() => {});
         });
       }
     },
@@ -118,11 +115,9 @@ test.describe("CRUD /api/v1/flows", () => {
         });
       } finally {
         await test.step("cleanup created flow", async () => {
-          await request
-            .delete(`/api/v1/flows/${id}`, {
-              headers: { Authorization: authToken },
-            })
-            .catch(() => {});
+          await deleteFlow(request, id, {
+            headers: { Authorization: authToken },
+          }).catch(() => {});
         });
       }
     },
@@ -170,11 +165,9 @@ test.describe("CRUD /api/v1/flows", () => {
         });
       } finally {
         await test.step("cleanup created flow", async () => {
-          await request
-            .delete(`/api/v1/flows/${id}`, {
-              headers: { Authorization: authToken },
-            })
-            .catch(() => {});
+          await deleteFlow(request, id, {
+            headers: { Authorization: authToken },
+          }).catch(() => {});
         });
       }
     },

--- a/tests/tests-automations/regression/api/flows/api-folders-crud.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-folders-crud.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 // Folders use the /api/v1/projects/ endpoint (legacy alias kept for compatibility)
 test.describe("Folder (Projects) CRUD via API", () => {
@@ -146,7 +147,7 @@ test.describe("Folder (Projects) CRUD via API", () => {
       expect(updatedFlow.folder_id).toBe(folder2.id);
 
       // Cleanup
-      await request.delete(`/api/v1/flows/${flow.id}`, {
+      await deleteFlow(request, flow.id, {
         headers: { Authorization: authToken },
       });
       await request.delete(`/api/v1/projects/${folder1.id}`, {

--- a/tests/tests-automations/regression/api/flows/api-invalid-key.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-invalid-key.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 const FLOW_BASE = {
   name: "",
@@ -75,7 +76,7 @@ test.describe("API Invalid Key Handling", () => {
 
         expect([401, 403]).toContain(runRes.status());
       } finally {
-        await request.delete(`/api/v1/flows/${flowId}`, {
+        await deleteFlow(request, flowId, {
           headers: { Authorization: authToken },
         });
       }
@@ -127,7 +128,7 @@ test.describe("API Invalid Key Handling", () => {
         const flow = await getRes.json();
         expect(flow.name).toBe(flowName);
       } finally {
-        await request.delete(`/api/v1/flows/${flowId}`, {
+        await deleteFlow(request, flowId, {
           headers: { Authorization: authToken },
         });
       }

--- a/tests/tests-automations/regression/api/flows/api-key-expiry-enforcement.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-key-expiry-enforcement.spec.ts
@@ -4,6 +4,7 @@ import {
   SUPERUSER_PASSWORD,
   SUPERUSER_USERNAME,
 } from "../../../../helpers/auth/credentials";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 /**
  * Companion to the PR #13471 timezone-display regression: that fix proved the
@@ -99,9 +100,7 @@ test.describe("API key expiry enforcement (PR #13471 companion)", () => {
       });
     }
     if (flowId) {
-      await request.delete(`/api/v1/flows/${flowId}`, {
-        headers: { Authorization: bearer },
-      });
+      await deleteFlow(request, flowId, { headers: { Authorization: bearer } });
     }
   });
 

--- a/tests/tests-automations/regression/api/flows/api-run-flow.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-run-flow.spec.ts
@@ -1,3 +1,4 @@
+import type { APIRequestContext } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { createRunnableChatFlowViaApi } from "../../../../helpers/flows/create-runnable-chat-flow-via-api";
@@ -14,7 +15,7 @@ test.describe("POST /api/v1/run", () => {
   let apiKey: string;
   let apiKeyId: string;
   let bearerToken: string;
-  let deleteFlow: () => Promise<void>;
+  let deleteFlow: (reqOverride?: APIRequestContext) => Promise<void>;
 
   test.beforeAll(async ({ request }) => {
     bearerToken = await getAuthToken(request);
@@ -40,15 +41,19 @@ test.describe("POST /api/v1/run", () => {
   });
 
   test.afterAll(async ({ request }) => {
-    // Delete flow
-    if (deleteFlow) {
-      await deleteFlow();
-    }
-    // Delete temporary API key
-    if (apiKeyId) {
-      await request.delete(`/api/v1/api_key/${apiKeyId}`, {
-        headers: { Authorization: bearerToken },
-      });
+    try {
+      // Delete flow with afterAll's OWN request — the beforeAll `request` that
+      // created it cannot be reused here (Playwright fixture-scope rule).
+      if (deleteFlow) {
+        await deleteFlow(request);
+      }
+    } finally {
+      // Delete temporary API key — runs even if the flow delete surfaced a failure.
+      if (apiKeyId) {
+        await request.delete(`/api/v1/api_key/${apiKeyId}`, {
+          headers: { Authorization: bearerToken },
+        });
+      }
     }
   });
 

--- a/tests/tests-automations/regression/api/flows/api-run-with-tweaks.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-run-with-tweaks.spec.ts
@@ -1,3 +1,4 @@
+import type { APIRequestContext } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import {
@@ -46,7 +47,7 @@ test.describe("POST /api/v1/run with tweaks", () => {
   let apiKey: string;
   let apiKeyId: string;
   let flowId: string;
-  let deleteFlow: () => Promise<void>;
+  let deleteFlow: (reqOverride?: APIRequestContext) => Promise<void>;
 
   test.beforeAll(async ({ request }) => {
     bearerToken = await getAuthToken(request);
@@ -70,15 +71,21 @@ test.describe("POST /api/v1/run with tweaks", () => {
   });
 
   test.afterAll(async ({ request }) => {
-    if (deleteFlow) {
-      await deleteFlow();
-    }
-    if (apiKeyId) {
-      await request
-        .delete(`/api/v1/api_key/${apiKeyId}`, {
-          headers: { Authorization: bearerToken },
-        })
-        .catch(() => {});
+    try {
+      // Delete flow with afterAll's OWN request — the beforeAll `request` that
+      // created it cannot be reused here (Playwright fixture-scope rule).
+      if (deleteFlow) {
+        await deleteFlow(request);
+      }
+    } finally {
+      // Runs even if the flow delete surfaced a failure.
+      if (apiKeyId) {
+        await request
+          .delete(`/api/v1/api_key/${apiKeyId}`, {
+            headers: { Authorization: bearerToken },
+          })
+          .catch(() => {});
+      }
     }
   });
 

--- a/tests/tests-automations/regression/core-components/beta-components-toggle-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/beta-components-toggle-regression.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "../../../fixtures/fixtures";
 import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
 
 test.describe("Show Beta Components toggle", () => {
   let createdFlowId: string | null = null;
@@ -18,7 +19,7 @@ test.describe("Show Beta Components toggle", () => {
       // Leave the editor first: staying on it while the flow is deleted makes
       // background polling 404, which the fixture's error monitor would flag.
       await page.goto("/").catch(() => {});
-      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }
   });

--- a/tests/tests-automations/regression/core-components/componentDelete.spec.ts
+++ b/tests/tests-automations/regression/core-components/componentDelete.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "../../../fixtures/fixtures";
 import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
 import { addComponentFromSidebar } from "../../../helpers/flows/add-component-from-sidebar";
 import { deleteComponent } from "../../../helpers/flows/delete-component";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
 
 test.describe("Delete a component from the canvas", () => {
   let createdFlowId: string | null = null;
@@ -20,7 +21,7 @@ test.describe("Delete a component from the canvas", () => {
       // Leave the editor first: staying on it while the flow is deleted makes
       // background polling 404, which the fixture's error monitor would flag.
       await page.goto("/").catch(() => {});
-      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }
   });

--- a/tests/tests-automations/regression/core-components/legacy-components-toggle-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/legacy-components-toggle-regression.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "../../../fixtures/fixtures";
 import { addLegacyComponents } from "../../../helpers/flows/add-legacy-components";
 import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
 
 test.describe("Show Legacy Components toggle", () => {
   let createdFlowId: string | null = null;
@@ -19,7 +20,7 @@ test.describe("Show Legacy Components toggle", () => {
       // Leave the editor first: staying on it while the flow is deleted makes
       // background polling 404, which the fixture's error monitor would flag.
       await page.goto("/").catch(() => {});
-      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }
   });

--- a/tests/tests-automations/regression/core-components/nested-grouping-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/nested-grouping-regression.spec.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
 
 // Asset is a 2-node subset of the Basic Prompting starter template: a
 // Prompt Template wired into a Language Model. We use a custom flow (not a
@@ -125,7 +126,7 @@ test.describe("Nested / Grouping", () => {
 
   test.afterEach(async ({ page }) => {
     if (createdFlowId) {
-      await page.request.delete(`/api/v1/flows/${createdFlowId}`).catch(() => {});
+      await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }
   });

--- a/tests/tests-automations/regression/core-components/prompt-template-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/prompt-template-component-regression.spec.ts
@@ -5,6 +5,7 @@ import {
   fillPromptTemplate,
 } from "../../../helpers/ui/prompt-template";
 import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
 
 // Flows are created via the REST API (setupBlankFlow) and deleted in afterEach
 // (issue #545). Kept serial so the per-file flow lifecycle stays deterministic
@@ -26,7 +27,7 @@ test.afterEach(async ({ page }) => {
     // Leave the editor first: staying on it while the flow is deleted makes
     // background polling 404, which the fixture's error monitor would flag.
     await page.goto("/").catch(() => {});
-    await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+    await deleteFlow(page.request, createdFlowId);
     createdFlowId = null;
   }
 });

--- a/tests/tests-automations/regression/core-components/prompt-template-double-brackets-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/prompt-template-double-brackets-regression.spec.ts
@@ -7,6 +7,7 @@ import {
   setUseDoubleBrackets,
 } from "../../../helpers/ui/prompt-template";
 import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
 
 // Flows are created via the REST API (setupBlankFlow) and deleted in afterEach
 // (issue #545). Kept serial so the per-file flow lifecycle stays deterministic
@@ -28,7 +29,7 @@ test.afterEach(async ({ page }) => {
     // Leave the editor first: staying on it while the flow is deleted makes
     // background polling 404, which the fixture's error monitor would flag.
     await page.goto("/").catch(() => {});
-    await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+    await deleteFlow(page.request, createdFlowId);
     createdFlowId = null;
   }
 });

--- a/tests/tests-automations/regression/core-components/prompt-template-invalid-mustache-patterns-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/prompt-template-invalid-mustache-patterns-regression.spec.ts
@@ -8,6 +8,7 @@ import {
   setUseDoubleBrackets,
 } from "../../../helpers/ui/prompt-template";
 import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
 
 // Flows are created via the REST API (setupBlankFlow) and deleted in afterEach
 // (issue #545). Kept serial so the per-file flow lifecycle stays deterministic
@@ -29,7 +30,7 @@ test.afterEach(async ({ page }) => {
     // Leave the editor first: staying on it while the flow is deleted makes
     // background polling 404, which the fixture's error monitor would flag.
     await page.goto("/").catch(() => {});
-    await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+    await deleteFlow(page.request, createdFlowId);
     createdFlowId = null;
   }
 });

--- a/tests/tests-automations/regression/core-components/prompt-template-invalid-patterns-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/prompt-template-invalid-patterns-regression.spec.ts
@@ -7,6 +7,7 @@ import {
   fillPromptTemplate,
 } from "../../../helpers/ui/prompt-template";
 import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
 
 // Flows are created via the REST API (setupBlankFlow) and deleted in afterEach
 // (issue #545). Kept serial so the per-file flow lifecycle stays deterministic
@@ -28,7 +29,7 @@ test.afterEach(async ({ page }) => {
     // Leave the editor first: staying on it while the flow is deleted makes
     // background polling 404, which the fixture's error monitor would flag.
     await page.goto("/").catch(() => {});
-    await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+    await deleteFlow(page.request, createdFlowId);
     createdFlowId = null;
   }
 });

--- a/tests/tests-automations/regression/core-components/singleton-components.spec.ts
+++ b/tests/tests-automations/regression/core-components/singleton-components.spec.ts
@@ -2,6 +2,7 @@ import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
 import { addComponentFromSidebar } from "../../../helpers/flows/add-component-from-sidebar";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
 
 // Single source of truth for each component under test. Keeping the search
 // term and the testids together here is what prevents the copy/paste class of
@@ -81,7 +82,7 @@ test.describe("Singleton and mutually-exclusive components (Chat Input ↔ Webho
       // Leave the editor first: staying on it while the flow is deleted makes
       // background polling 404, which the fixture's error monitor would flag.
       await page.goto("/").catch(() => {});
-      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }
   });

--- a/tests/tests-automations/regression/core-functionality/llm-agents/language-model-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/language-model-regression.spec.ts
@@ -7,6 +7,7 @@ import { initialGPTsetup } from "../../../../helpers/other/initialGPTsetup";
 import { setupGoogle } from "../../../../helpers/provider-setup/setup-google";
 import { hideInspectorPanel } from "../../../../helpers/ui/hide-inspector-panel";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 // Language Model component execution and provider management (QA-CHECKLIST
 // §7.5 "Language Model component — configuration"). Hardened for @stable
@@ -58,9 +59,8 @@ test.describe("Language Model Component Regression", () => {
     const bearer = await getAuthToken(request);
     while (createdFlowIds.length > 0) {
       const id = createdFlowIds.pop();
-      await request
-        .delete(`/api/v1/flows/${id}`, { headers: { Authorization: bearer } })
-        .catch(() => {});
+      if (!id) continue;
+      await deleteFlow(request, id, { headers: { Authorization: bearer } }).catch(() => {});
     }
   });
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/llm-invalid-api-key-ui.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/llm-invalid-api-key-ui.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 test.describe("LLM Invalid API Key UI Error Display", () => {
   let createdFlowId: string | null = null;
@@ -7,7 +8,7 @@ test.describe("LLM Invalid API Key UI Error Display", () => {
   test.afterEach(async ({ page }) => {
     if (createdFlowId) {
       await page.goto("/");
-      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }
   });

--- a/tests/tests-automations/regression/core-functionality/llm-agents/modelInputComponent.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/modelInputComponent.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { addComponentFromSidebar } from "../../../../helpers/flows/add-component-from-sidebar";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 // The Model Input selector on the canonical Language Model component
 // (QA-CHECKLIST §7.5 "Model Input component"). Hardened for @stable (issue
@@ -54,9 +55,8 @@ test.describe("ModelInputComponent", () => {
     const bearer = await getAuthToken(request);
     while (createdFlowIds.length > 0) {
       const id = createdFlowIds.pop();
-      await request
-        .delete(`/api/v1/flows/${id}`, { headers: { Authorization: bearer } })
-        .catch(() => {});
+      if (!id) continue;
+      await deleteFlow(request, id, { headers: { Authorization: bearer } }).catch(() => {});
     }
   });
 

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-delete.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-delete.spec.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "fs";
 import path from "path";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 const TRACE_FIXTURE = JSON.parse(
   readFileSync(
@@ -124,7 +125,7 @@ test.describe("Bulk delete traces — seeded flow", () => {
     const cleanups: Promise<unknown>[] = [];
     if (flowId) {
       cleanups.push(
-        request.delete(`/api/v1/flows/${flowId}`, {
+        deleteFlow(request, flowId, {
           headers: { Authorization: bearerToken },
         }),
       );

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-llm-span-populated.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-llm-span-populated.spec.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "fs";
 import path from "path";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 const TRACE_FIXTURE = JSON.parse(
   readFileSync(
@@ -155,7 +156,7 @@ test.describe("Single trace — populated LLM span (OpenAI)", () => {
     const cleanups: Promise<unknown>[] = [];
     if (flowId) {
       cleanups.push(
-        request.delete(`/api/v1/flows/${flowId}`, {
+        deleteFlow(request, flowId, {
           headers: { Authorization: bearerToken },
         }),
       );

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-single.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-single.spec.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "fs";
 import path from "path";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 const TRACE_FIXTURE = JSON.parse(
   readFileSync(
@@ -136,7 +137,7 @@ test.describe("Single trace shape — seeded flow", () => {
     const cleanups: Promise<unknown>[] = [];
     if (flowId) {
       cleanups.push(
-        request.delete(`/api/v1/flows/${flowId}`, {
+        deleteFlow(request, flowId, {
           headers: { Authorization: bearerToken },
         }),
       );

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail.spec.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "fs";
 import path from "path";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 const TRACE_FIXTURE = JSON.parse(
   readFileSync(
@@ -139,7 +140,7 @@ test.describe("Transaction record shape — seeded flow", () => {
 
   test.afterAll(async ({ request }) => {
     if (flowId) {
-      await request.delete(`/api/v1/flows/${flowId}`, {
+      await deleteFlow(request, flowId, {
         headers: { "x-api-key": apiKey },
       });
     }

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-latency-tokens.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-latency-tokens.spec.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "fs";
 import path from "path";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 const TRACE_FIXTURE = JSON.parse(
   readFileSync(
@@ -80,7 +81,7 @@ test.describe("Flow Activity / Traces — latency and tokens", () => {
 
   test.afterAll(async ({ request }) => {
     if (flowId) {
-      await request.delete(`/api/v1/flows/${flowId}`, {
+      await deleteFlow(request, flowId, {
         headers: { "x-api-key": apiKey },
       });
     }

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-list-filters.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-list-filters.spec.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "fs";
 import path from "path";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 const ERROR_FIXTURE = JSON.parse(
   readFileSync(
@@ -159,14 +160,14 @@ test.describe("Trace list filters — status / start_time / query / session_id",
     const cleanups: Promise<unknown>[] = [];
     if (errorFlowId && apiKey) {
       cleanups.push(
-        request.delete(`/api/v1/flows/${errorFlowId}`, {
+        deleteFlow(request, errorFlowId, {
           headers: { "x-api-key": apiKey },
         }),
       );
     }
     if (okFlowId && apiKey) {
       cleanups.push(
-        request.delete(`/api/v1/flows/${okFlowId}`, {
+        deleteFlow(request, okFlowId, {
           headers: { "x-api-key": apiKey },
         }),
       );

--- a/tests/tests-automations/regression/core-functionality/playground/output-modal-copy-button.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/output-modal-copy-button.spec.ts
@@ -1,6 +1,7 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 // Expand the currently focused node from minimized to full view. Chat Input
 // defaults to `minimized = True` (see lfx/components/input_output/chat.py);
@@ -30,7 +31,7 @@ test.describe("Output Modal — Copy Button", () => {
       // for the current flow; without this, pending polling GETs complete
       // after the DELETE and trigger spurious 404 fixture errors.
       await page.goto("/");
-      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }
   });

--- a/tests/tests-automations/regression/core-functionality/playground/playground-attachments-management.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-attachments-management.spec.ts
@@ -2,6 +2,7 @@ import path from "path";
 import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 const IMAGE_A = path.resolve(
   __dirname,
@@ -31,7 +32,7 @@ test.describe("Playground — Chat Input Attachments Management", () => {
   test.afterEach(async ({ page }) => {
     if (createdFlowId) {
       await page.goto("/");
-      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }
   });

--- a/tests/tests-automations/regression/core-functionality/playground/playground-bulk-delete.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-bulk-delete.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 /**
  * Bulk session operations in the Playground sidebar.
@@ -21,7 +22,7 @@ test.describe("Playground – Bulk Session Operations", () => {
   test.afterEach(async ({ page }) => {
     if (createdFlowId) {
       await page.goto("/");
-      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }
   });

--- a/tests/tests-automations/regression/core-functionality/playground/playground-clear-history.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-clear-history.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "../../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { zoomOut } from "../../../../helpers/ui/zoom-out";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 /**
  * Session behavior confirmed from source (chat-header.tsx):
@@ -101,7 +102,7 @@ test.describe("Playground – Clear History & Session Delete", () => {
   test.afterEach(async ({ page }) => {
     if (createdFlowId) {
       await page.goto("/");
-      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }
   });

--- a/tests/tests-automations/regression/core-functionality/playground/playground-empty-message-send.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-empty-message-send.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 test.describe("Playground Empty-Message Send Behavior", () => {
   let createdFlowId: string | null = null;
@@ -7,7 +8,7 @@ test.describe("Playground Empty-Message Send Behavior", () => {
   test.afterEach(async ({ page }) => {
     if (createdFlowId) {
       await page.goto("/");
-      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }
   });

--- a/tests/tests-automations/regression/core-functionality/playground/playground-fullscreen.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-fullscreen.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 test.describe("Playground — open and close behavior", () => {
   test.describe.configure({ mode: "serial" });
@@ -12,7 +13,7 @@ test.describe("Playground — open and close behavior", () => {
       // for the current flow; without this, pending polling GETs complete
       // after the DELETE and trigger spurious 404 fixture errors.
       await page.goto("/");
-      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }
   });

--- a/tests/tests-automations/regression/core-functionality/playground/playground-history-persist.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-history-persist.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 test.describe("Playground — history persistence", () => {
   test.describe.configure({ mode: "serial" });
@@ -9,7 +10,7 @@ test.describe("Playground — history persistence", () => {
   test.afterEach(async ({ page }) => {
     if (createdFlowId) {
       await page.goto("/");
-      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }
   });

--- a/tests/tests-automations/regression/core-functionality/playground/playground-input-text-prefill.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-input-text-prefill.spec.ts
@@ -1,6 +1,7 @@
 import { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 /**
  * Pre-fill behavior of the Playground textarea driven by the ChatInput
@@ -88,7 +89,7 @@ test.describe("Playground – Input Text Pre-fill Behavior", () => {
     if (createdFlowId) {
       await page.unrouteAll({ behavior: "ignoreErrors" }).catch(() => {});
       await page.goto("/");
-      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }
   });

--- a/tests/tests-automations/regression/core-functionality/playground/playground-message-edit.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-message-edit.spec.ts
@@ -1,6 +1,7 @@
 import type { Route } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 async function openPlaygroundWithMessage(
   page: any,
@@ -90,7 +91,7 @@ test.describe("Playground Message Edit", () => {
   test.afterEach(async ({ page }) => {
     if (createdFlowId) {
       await page.goto("/");
-      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }
   });

--- a/tests/tests-automations/regression/core-functionality/playground/playground-message-logs.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-message-logs.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 /**
  * Message Logs are accessible via the session more-menu (message-logs-option).
@@ -33,7 +34,7 @@ test.describe("Playground – Message Logs", () => {
   test.afterEach(async ({ page }) => {
     if (createdFlowId) {
       await page.goto("/");
-      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }
   });

--- a/tests/tests-automations/regression/core-functionality/playground/playground-non-image-attachment.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-non-image-attachment.spec.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 const TXT_PATH = path.resolve(
   __dirname,
@@ -15,7 +16,7 @@ test.describe("Playground Output – Non-Image Attachment (#195)", () => {
   test.afterEach(async ({ page }) => {
     if (createdFlowId) {
       await page.goto("/");
-      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }
   });

--- a/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-output-data.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "../../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { zoomOut } from "../../../../helpers/ui/zoom-out";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 type SetupOptions = { selectDataOutput?: boolean };
 
@@ -159,9 +160,7 @@ test.describe("Playground Output – Structured Data", () => {
         headers = { Authorization: `Bearer ${body.access_token}` };
       }
     }
-    await page.request
-      .delete(`/api/v1/flows/${flowId}`, { headers })
-      .catch(() => {});
+    await deleteFlow(page.request, flowId, { headers });
   });
 
   test(

--- a/tests/tests-automations/regression/core-functionality/playground/playground-output-image.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-output-image.spec.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 // The server prefixes uploaded filenames with a timestamp, so alt becomes e.g.
 // "2026-03-22_20-09-16_chain.png". Match by src path instead of alt.
@@ -17,7 +18,7 @@ test.describe("Playground Output – Image Upload (ID B0c)", () => {
   test.afterEach(async ({ page }) => {
     if (createdFlowId) {
       await page.goto("/");
-      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }
   });

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-id.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-id.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 test.describe("Playground — Session ID input", () => {
   test.describe.configure({ mode: "serial" });
@@ -12,7 +13,7 @@ test.describe("Playground — Session ID input", () => {
       // for the current flow; without this, pending polling GETs complete
       // after the DELETE and trigger spurious 404 fixture errors.
       await page.goto("/");
-      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }
   });

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-nav.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-nav.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 // Overlap: playground.spec.ts also clicks new-chat but is a monolithic, non-@stable spec; this is the dedicated @stable coverage with independent assertions.
 // Session switching is tested via sidebar click (session-selector); the header dropdown (session-selector-trigger) only exists in the fullscreen playground, not in the IOModal.
@@ -12,7 +13,7 @@ test.describe("Playground – Session Creation and Navigation", () => {
   test.afterEach(async ({ page }) => {
     if (createdFlowId) {
       await page.goto("/");
-      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }
   });

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-rename.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-rename.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 /**
  * Rename availability is controlled server-side by:
@@ -22,7 +23,7 @@ test.describe("Playground – Session Rename (B2)", () => {
   test.afterEach(async ({ page }) => {
     if (createdFlowId) {
       await page.goto("/");
-      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }
   });

--- a/tests/tests-automations/regression/core-functionality/playground/playground-shareable-url.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-shareable-url.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 test.describe("Playground — Shareable URL Generation", () => {
   test.describe.configure({ mode: "serial" });
@@ -12,7 +13,7 @@ test.describe("Playground — Shareable URL Generation", () => {
       // for the current flow; without this, pending polling GETs complete
       // after the DELETE and trigger spurious 404 fixture errors.
       await page.goto("/");
-      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }
   });

--- a/tests/tests-automations/regression/core-functionality/playground/playground-ux.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-ux.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 test.describe("Playground UX", () => {
   test.describe.configure({ mode: "serial" });
@@ -9,7 +10,7 @@ test.describe("Playground UX", () => {
   test.afterEach(async ({ page }) => {
     if (createdFlowId) {
       await page.goto("/");
-      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }
   });

--- a/tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts
@@ -3,6 +3,7 @@ import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { openNewFlowTemplatesModal } from "../../../../helpers/flows/open-new-flow-templates-modal";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 test(
   "user should be able to select flows with different methods and perform bulk actions",
@@ -169,7 +170,7 @@ test(
         const headers = { Authorization: await getAuthToken(request) };
         for (const id of createdFlowIds) {
           try {
-            await request.delete(`/api/v1/flows/${id}`, { headers });
+            await deleteFlow(request, id, { headers });
           } catch {
             // Best-effort per-flow — do not mask the original test failure.
           }

--- a/tests/tests-automations/regression/core-functionality/project-management/flow-navigation-folders.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/flow-navigation-folders.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 test(
   "flows created via API appear on the home listing",
@@ -36,9 +37,7 @@ test(
 
       await expect(page.getByText(flowName)).toBeVisible({ timeout: 10000 });
     } finally {
-      await request.delete(`/api/v1/flows/${flowId}`, {
-        headers: { Authorization: authToken },
-      });
+      await deleteFlow(request, flowId, { headers: { Authorization: authToken } });
     }
   },
 );
@@ -97,12 +96,14 @@ test(
         timeout: 10000,
       });
     } finally {
-      await request.delete(`/api/v1/flows/${flow1Id}`, {
+      // Multi-step teardown: swallow so a failed first delete still lets the
+      // second run (a throw here would leak the sibling flow).
+      await deleteFlow(request, flow1Id, {
         headers: { Authorization: authToken },
-      });
-      await request.delete(`/api/v1/flows/${flow2Id}`, {
+      }).catch(() => {});
+      await deleteFlow(request, flow2Id, {
         headers: { Authorization: authToken },
-      });
+      }).catch(() => {});
     }
   },
 );

--- a/tests/tests-automations/regression/core-functionality/project-management/folder-crud.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/folder-crud.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { MainPage } from "../../../../pages/MainPage";
 
 /**
@@ -121,11 +122,9 @@ test(
       });
     } finally {
       if (flowId) {
-        await request
-          .delete(`/api/v1/flows/${flowId}`, {
-            headers: { Authorization: authToken },
-          })
-          .catch(() => {});
+        await deleteFlow(request, flowId, {
+          headers: { Authorization: authToken },
+        }).catch(() => {});
       }
       if (!folderDeleted) {
         await request

--- a/tests/tests-automations/regression/core-functionality/project-management/folder-drag-drop-flow.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/folder-drag-drop-flow.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 test(
   "creating a flow in a specific folder via API places it in that folder",
@@ -43,11 +44,9 @@ test(
       expect(flow.folder_id).toBe(folderId);
     } finally {
       if (flowId) {
-        await request
-          .delete(`/api/v1/flows/${flowId}`, {
-            headers: { Authorization: authToken },
-          })
-          .catch(() => {});
+        await deleteFlow(request, flowId, {
+          headers: { Authorization: authToken },
+        }).catch(() => {});
       }
       await request
         .delete(`/api/v1/folders/${folderId}`, {
@@ -118,11 +117,9 @@ test(
       expect(updated.folder_id).toBe(folder2Id);
     } finally {
       if (flowId) {
-        await request
-          .delete(`/api/v1/flows/${flowId}`, {
-            headers: { Authorization: authToken },
-          })
-          .catch(() => {});
+        await deleteFlow(request, flowId, {
+          headers: { Authorization: authToken },
+        }).catch(() => {});
       }
       await request
         .delete(`/api/v1/folders/${folder1Id}`, {
@@ -188,11 +185,9 @@ test(
       await expect(page.getByText(flowName)).toBeVisible({ timeout: 15000 });
     } finally {
       if (flowId) {
-        await request
-          .delete(`/api/v1/flows/${flowId}`, {
-            headers: { Authorization: authToken },
-          })
-          .catch(() => {});
+        await deleteFlow(request, flowId, {
+          headers: { Authorization: authToken },
+        }).catch(() => {});
       }
       await request
         .delete(`/api/v1/folders/${folderId}`, {

--- a/tests/tests-automations/regression/core-functionality/templates/save-flow-as-template.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/templates/save-flow-as-template.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "../../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 test(
   "Flow save button saves the current flow",
@@ -162,12 +163,13 @@ test(
     expect(importedFlow.name).toBe(`${templateName} (copy)`);
     expect(importedFlow.id).not.toBe(flowId);
 
-    // Cleanup
-    await request.delete(`/api/v1/flows/${flowId}`, {
+    // Multi-step cleanup: swallow so a failed first delete still lets the
+    // second run (a throw here would leak the sibling flow).
+    await deleteFlow(request, flowId, {
       headers: { Authorization: authToken },
-    });
-    await request.delete(`/api/v1/flows/${importedFlow.id}`, {
+    }).catch(() => {});
+    await deleteFlow(request, importedFlow.id, {
       headers: { Authorization: authToken },
-    });
+    }).catch(() => {});
   },
 );

--- a/tests/tests-automations/regression/flow-functionality/api-access-modal-regression.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/api-access-modal-regression.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
 
 // Run this file's tests serially. All four open the same "Basic Prompting" template, each creating a
 // fresh flow; running them in parallel within one worker pool makes the backend receive near-identical
@@ -53,7 +54,8 @@ test.afterEach(async ({ request }) => {
         : (body?.flows ?? []);
       for (const f of flows) {
         if (!snapshot.has(f.id)) {
-          await request.delete(`/api/v1/flows/${f.id}`, { headers });
+          // Best-effort per-flow so one failure does not abort the sweep.
+          await deleteFlow(request, f.id, { headers }).catch(() => {});
         }
       }
     }

--- a/tests/tests-automations/regression/flow-functionality/canvas-copy-paste.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/canvas-copy-paste.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
 
 test.describe("Canvas copy / paste", () => {
   let createdFlowId: string | null = null;
@@ -11,7 +12,7 @@ test.describe("Canvas copy / paste", () => {
       // flow is deleted causes background polling/WS requests to 404, which
       // the fixture's backend error monitor would flag as failures.
       await page.goto("/").catch(() => {});
-      await page.request.delete(`/api/v1/flows/${createdFlowId}`);
+      await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }
   });

--- a/tests/tests-automations/regression/flow-functionality/duplicate-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/duplicate-flow.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
 
 const FLOW_BASE = {
   description: "Flow duplicate test",
@@ -114,13 +115,15 @@ test(
       expect(flowList.some((f) => f.id === original.id)).toBe(true);
       expect(flowList.some((f) => f.id === duplicate.id)).toBe(true);
     } finally {
-      await request.delete(`/api/v1/flows/${original.id}`, {
+      // Multi-step teardown: swallow so a failed first delete still lets the
+      // second run (a throw here would leak the sibling flow).
+      await deleteFlow(request, original.id, {
         headers: { Authorization: authToken },
-      });
+      }).catch(() => {});
       if (duplicateId) {
-        await request.delete(`/api/v1/flows/${duplicateId}`, {
+        await deleteFlow(request, duplicateId, {
           headers: { Authorization: authToken },
-        });
+        }).catch(() => {});
       }
     }
   },

--- a/tests/tests-automations/regression/flow-functionality/export-import-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/export-import-flow.spec.ts
@@ -5,6 +5,7 @@ import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test"
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { simulateDragAndDrop } from "../../../helpers/ui/simulate-drag-and-drop";
 import { waitForFlowSaveSettled } from "../../../helpers/flows/wait-for-flow-save-settled";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
 
 // Force serial execution within this file so the diff-based cleanup remains
 // safe — the snapshot/diff pattern is racy across workers when multiple tests
@@ -54,7 +55,8 @@ test.describe("Export and Import Flow (IDs 173 + 120)", () => {
           : (body?.flows ?? []);
         for (const f of flows) {
           if (!snapshot.has(f.id)) {
-            await request.delete(`/api/v1/flows/${f.id}`, { headers });
+            // Best-effort per-flow so one failure does not abort the sweep.
+            await deleteFlow(request, f.id, { headers }).catch(() => {});
           }
         }
       }

--- a/tests/tests-automations/regression/flow-functionality/flow-execution-canvas.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/flow-execution-canvas.spec.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test";
+import type { APIRequestContext, Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import {
@@ -43,7 +43,7 @@ test.describe("Flow execution — run a ChatInput -> ChatOutput flow", () => {
 
   let page: Page;
   let flowId: string;
-  let deleteFlow: () => Promise<void>;
+  let deleteFlow: (reqOverride?: APIRequestContext) => Promise<void>;
 
   test.beforeAll(async ({ browser, request }) => {
     // Create the flow once via the API (deterministic, avoids the UI
@@ -60,13 +60,17 @@ test.describe("Flow execution — run a ChatInput -> ChatOutput flow", () => {
     });
   });
 
-  test.afterAll(async () => {
+  test.afterAll(async ({ request }) => {
     // Unmount the editor before deleting so its GET /flows/{id}/events poll does
     // not 404 mid-delete (same teardown race fixed in publish-flow / triage #364).
     await page.goto("/").catch(() => {});
-    // Swallow so a failed delete still lets page.close() run below.
-    await deleteFlow().catch(() => {});
-    await page.close();
+    try {
+      // Delete with afterAll's OWN request — the beforeAll `request` that created
+      // the flow cannot be reused here (Playwright fixture-scope rule).
+      await deleteFlow(request);
+    } finally {
+      await page.close();
+    }
   });
 
   test("1 - runs the flow from the canvas terminal node",

--- a/tests/tests-automations/regression/flow-functionality/flow-rename-header.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/flow-rename-header.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { renameFlow } from "../../../helpers/flows/rename-flow";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
 
 const FLOW_BASE = {
   description: "Flow rename test",
@@ -72,9 +73,7 @@ test.describe("Flow Rename via Header", () => {
         expect(getBody.name).not.toBe(originalName);
       } finally {
         // Cleanup
-        await request.delete(`/api/v1/flows/${id}`, {
-          headers: { Authorization: authToken },
-        });
+        await deleteFlow(request, id, { headers: { Authorization: authToken } });
       }
     },
   );

--- a/tests/tests-automations/regression/flow-functionality/publish-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/publish-flow.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
 
 const FLOW_BASE = {
   description: "Publish flow test",
@@ -140,7 +141,7 @@ test(
       await page.goto("/").catch(() => {});
 
       // Clean up the flow so repeated runs do not accumulate workspace artifacts
-      await request.delete(`/api/v1/flows/${flowId}`, {
+      await deleteFlow(request, flowId, {
         headers: { Authorization: authToken },
       });
     }
@@ -192,7 +193,7 @@ test(
       expect(getPrivate.status()).toBe(200);
       expect((await getPrivate.json()).access_type).toBe("PRIVATE");
     } finally {
-      await request.delete(`/api/v1/flows/${flowId}`, {
+      await deleteFlow(request, flowId, {
         headers: { Authorization: authToken },
       });
     }

--- a/tests/tests-automations/regression/flow-functionality/run-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/run-flow.spec.ts
@@ -5,6 +5,7 @@ import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { zoomOut } from "../../../helpers/ui/zoom-out";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
 
 test(
   "user should be able to use Run Flow without any issues",
@@ -161,7 +162,7 @@ test(
         const headers = { Authorization: await getAuthToken(request) };
         for (const id of createdFlowIds) {
           try {
-            await request.delete(`/api/v1/flows/${id}`, { headers });
+            await deleteFlow(request, id, { headers });
           } catch {
             // Best-effort per-flow — do not mask the original test failure.
           }

--- a/tests/tests-automations/regression/flow-functionality/stop-building.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/stop-building.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
 
 // Flow created by the test (blank-flow → /flow/{id}); captured so afterEach can
 // delete only this one via the API. Targeted (not cleanAllFlows) so the teardown
@@ -15,7 +16,7 @@ test.afterEach(async ({ page }) => {
     const body = await login.json();
     if (body?.access_token) headers.Authorization = `Bearer ${body.access_token}`;
   }
-  await page.request.delete(`/api/v1/flows/${createdFlowId}`, { headers });
+  await deleteFlow(page.request, createdFlowId, { headers });
   createdFlowId = undefined;
 });
 

--- a/tests/tests-automations/regression/mcp/server/mcp-server-regression.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-regression.spec.ts
@@ -1,13 +1,14 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 test.describe("MCP Server – Flow Exposed as MCP Tool", () => {
   let flowId = "";
 
   test.afterEach(async ({ page }) => {
     if (flowId) {
-      await page.request.delete(`/api/v1/flows/${flowId}`).catch(() => {});
+      await deleteFlow(page.request, flowId);
       flowId = "";
     }
   });

--- a/tests/tests-automations/regression/ui-ux/edit-sticky-note-text.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/edit-sticky-note-text.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "../../../fixtures/fixtures";
 import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
 
 test.describe("Sticky Note — Edit Text", () => {
   let flowId = "";
@@ -10,7 +11,7 @@ test.describe("Sticky Note — Edit Text", () => {
     // Delete the flow created during this test so it does not pollute the
     // instance for subsequent runs.
     if (flowId) {
-      await page.request.delete(`/api/v1/flows/${flowId}`).catch(() => {});
+      await deleteFlow(page.request, flowId);
     }
   });
 


### PR DESCRIPTION
## What & why

Playwright's `APIRequestContext.delete()` resolves an `APIResponse` even on 4xx/5xx and **never throws**. Flow-teardown code across the suite (`await page.request.delete(\`/api/v1/flows/${id}\`)`) never checked the result, so a **failed deletion passed silently** — the flow stayed behind and the suite could quietly re-accumulate leftover flows (~1.5k observed on a long-lived instance), regressing the anti-accumulation guarantee #545 set out to protect.

Introduces `tests/helpers/flows/delete-flow.ts` — `deleteFlow(request, id, options?)` — and adopts it everywhere flows are cleaned up.

## Design decisions

- **Throw on failure, with one retry** to absorb a transient teardown 5xx under parallel load, then throw. Cleanup failures become visible instead of silently regressing.
- **`404 is treated as success**: for idempotent cleanup a 404 means the flow is already gone — the desired end state (e.g. a concurrent worker's sweep removed it first). Genuine errors (403/5xx/…) still surface. *(This edge case was found by running the real workflow against the branch — see below.)*
- **Signature accepts any `APIRequestContext`** so both `page.request` (cookie auth) and the `request` fixture (explicit bearer headers) are covered.
- **Multi-step / loop cleanups keep `.catch(() => {})`** per call (two flows in one `finally`, flow + folder, `for`/`while` sweeps) so one failed delete does not skip sibling cleanups. Setup-helper rollback paths keep `.catch` so the original failure is not masked. `clean-all-flows` collects failures and throws at the end (sweeps all, still surfaces).

## Scope

- ~60 files migrated to `deleteFlow()`.
- **Left untouched** (subject-under-test — they assert the DELETE endpoint itself): `api-flows-crud` DELETE/GET-404 scenarios and `api-invalid-key` DELETE-without-auth. All non-flow deletes (`api_key`/`projects`/`folders`/`variables`/`mcp`) untouched.
- No product/UI behavior change; teardown-only. Retains `@stable`; no spec-doc changes.

## Real-run validation

Ran `daily-stable` against this branch (manual dispatch — does not mutate `main`, `@stable`, or open issues):

- **Run 1** surfaced `deleteFlow()` throwing `Flow cleanup failed: 404 — Flow not found` in two `afterEach` blocks, turning `loop-component-regression` and `prompt-template-double-brackets-regression` flaky. Root cause: 404-as-failure meeting the concurrent-sweep race (#515). Fixed by treating 404 as success.
- **Run 2** (with the fix): **0** `deleteFlow` throws, both induced flaky gone. 256 passed / 1 hard fail / 13 flaky — the hard fail and all flaky are the usual model-dependent agent/playground tests, also present on the `main` baseline of the same day (256 / 5 / 13). No regression introduced.

Relates to #465 / #515 (flow accumulation) and follows #545.

Closes #547