### PR TITLE
test(llm-agents): add agent multi-tool selection spec (#486)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -331,7 +331,7 @@
 - [x] Playground input remains usable after API error (mocked) → `llm-agents/llm-invalid-api-key-ui.spec.ts`
 - [ ] Agent stops when configured stop condition is reached
 - [x] Agent stops when maximum number of iterations is reached → `core-functionality/llm-agents/agent-max-iterations.spec.ts`
-- [ ] Agent with multiple configured tools executes correctly → `agent-multi-tool-selection.spec.ts`
+- [x] Agent with multiple configured tools executes correctly → `agent-multi-tool-selection.spec.ts`
 - [ ] Agent with configured timeout respects the limit
 - [x] Connecting an external model in Agent drops the prior model selection (connection-mode isolation, prevents stale provider config) → `llm-agents/agent-model-connection-isolation.spec.ts`
 - [x] Flow with Agent saved and reopened → settings preserved → `core-functionality/llm-agents/agent-config-persistence.spec.ts`
@@ -351,7 +351,7 @@
 - [ ] Agent with integrated external MCP tool executes action and returns result
 - [ ] Agent executes multiple tools in sequence
 - [x] Tool returns error — agent handles it and continues execution → `core-functionality/llm-agents/agent-tool-error-handling.spec.ts`
-- [ ] Multiple connected tools — agent selects the correct one for each prompt → `agent-multi-tool-selection.spec.ts`
+- [x] Multiple connected tools — agent selects the correct one for each prompt → `agent-multi-tool-selection.spec.ts`
 - [x] Tool with invalid name — validation prevents execution with clear message → `core-functionality/llm-agents/agent-tool-name-validation.spec.ts`
 
 #### 6.5 Output and Reasoning

--- a/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
+++ b/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
@@ -1,0 +1,162 @@
+# Agent multi-tool selection — correct tool per prompt
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+QA-CHECKLIST §6.2 "Agent with multiple configured tools executes correctly"
+and §6.4 "Multiple connected tools — agent selects the correct one for each
+prompt". The Simple Agent template ships with **two tools already connected**
+to the Agent — URL (`URLComponent`, tool `fetch_content`) and Web Search
+(`UnifiedWebSearch`, tool `perform_search`), confirmed in the nightly's
+`starter_projects/Simple Agent.json` — making it the canonical multi-tool
+surface.
+
+The contract: given a prompt that unambiguously calls for one capability, the
+agent must invoke **that tool and not the other**. Two prompts, two tests:
+
+1. **Fetch prompt → URL tool.** "Fetch https://httpbin.org/json …" must
+   produce a `fetch_content` `tool_use` block and **no** `perform_search`
+   block in the persisted AI message; the reply must contain the
+   deterministic content of that endpoint (`Sample Slide Show`).
+2. **Search prompt → Web Search tool.** "Search the web for …" must produce
+   a `perform_search` `tool_use` block and **no** `fetch_content` block.
+
+The Agent Instructions force tool use for every question **without naming any
+tool** ("you MUST call exactly one tool… choose the tool that fits") — tool
+*use* is instructed so the model can't answer from memory (which would make
+the test flaky), but tool *choice* is left entirely to the agent, which is
+exactly the behavior under test.
+
+Both runs finishing with zero flow errors (fixture, no `allowFlowErrors`)
+with both tools wired is what proves §6.2's "executes correctly".
+
+If this test fails, agents mis-route prompts across their toolset — the core
+usefulness contract of multi-tool agents.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@agents` `@playground`
+
+`@stable` added after 4 clean `--retries=0` runs on the fresh nightly
+(1.11.0.dev34; issue #486's "Done when" includes `@stable`). `@regression` — guards tool routing across
+the agent's toolset; `@agents` — agent tool-calling behavior; `@playground` —
+the run and the reply observable live in the Playground.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` (fresh nightly).
+- `models.json` / `providers.json` generated via
+  `npx playwright test tests/collect-models.spec.ts`.
+- At least one active provider API key in `.env`.
+- Run with `--workers=1` — area rule for agent specs (shared instance state).
+  Each test captures its flow id from the template-instantiation
+  `POST /api/v1/flows/` response and deletes exactly that id in `afterEach`
+  (`loadTemplateByName` does no cleanup — post-#553 contract).
+
+---
+
+## Step by step *(required)*
+
+The spec generates tests per active model via the `getTestTargets()`
+machinery (same as `agent-tool-error-handling.spec.ts`). Per model, a serial
+describe with two tests:
+
+**Test 1 — fetch prompt selects the URL tool (§6.4 + §6.2)**
+
+1. Load the Simple Agent template (provider/model from `models.json`/`.env`).
+2. Set Agent Instructions (`textarea_str_system_prompt`): *"For every user
+   question you MUST call exactly one tool to obtain the answer — never
+   answer from memory or refuse. Choose the tool that fits the question."*
+3. Seed the task on the ChatInput node (`textarea_str_input_value`; prefill
+   re-injection race): *"Fetch https://httpbin.org/json and tell me the
+   exact slideshow title it returns. (probe `<nonce>`)"*.
+4. Open the Playground (`playground-btn-flow-io`), send, wait for the run to
+   finish (Stop button hidden).
+5. **Selection assert (API):** poll `GET /api/v1/monitor/messages` — find the
+   user message with the nonce, take its `session_id`, find the session's AI
+   message; its `tool_use` blocks must include `fetch_content` and must NOT
+   include `perform_search`.
+6. **Execution assert (UI):** the final AI bubble (`div-chat-message`)
+   contains `Sample Slide Show` — the deterministic title served by
+   httpbin.org/json (proves the tool ran and its output reached the answer).
+7. No `allowFlowErrors` — any flow error fails the test via the fixture.
+
+**Test 2 — search prompt selects the Web Search tool (§6.4)**
+
+1–2. Same template load and Agent Instructions (fresh load; new nonce).
+3. Seed the task: *"Search the web for recent news about the Playwright test
+   framework and summarize one headline. (probe `<nonce>`)"*.
+4. Open the Playground, send, wait for the run to finish.
+5. **Selection assert (API):** same nonce-keyed monitor lookup; the AI
+   message's `tool_use` blocks must include `perform_search` and must NOT
+   include `fetch_content`.
+6. **Execution assert (UI):** the final AI bubble is visible and non-empty
+   (search result content is inherently non-deterministic — the selection
+   assert in step 5 is the concrete observable; see false-positive notes).
+7. No `allowFlowErrors`.
+
+---
+
+## Validation criterion *(required)*
+
+Per prompt, the persisted AI message's `tool_use` blocks name **the expected
+tool and not the sibling tool** (`fetch_content` without `perform_search` for
+the fetch prompt; `perform_search` without `fetch_content` for the search
+prompt), keyed to the run's session via a per-run nonce — plus, for the fetch
+prompt, the reply contains the endpoint's deterministic `Sample Slide Show`
+title. The positive+negative pair per prompt is the distinctive observable:
+a wrong-tool run fails the negative half even when the model salvages a
+correct-looking answer.
+
+## Guarding against false positives *(how)*
+
+- **Nonce-keyed session lookup** — monitor messages persist across flow
+  wipes; the per-run nonce pins every API assertion to THIS run (same
+  technique as `agent-tool-error-handling`).
+- **Negative assert is mandatory** — asserting only "expected tool present"
+  would pass a run that called BOTH tools indiscriminately; the
+  "sibling tool absent" half is what proves *selection*.
+- **Tool use is forced, tool choice is not** — instructions demand exactly
+  one tool call but never name a tool; a model that answers from memory
+  produces zero `tool_use` blocks and fails the positive half (not a silent
+  pass).
+- **Search output content is NOT asserted** — live search results vary; the
+  deterministic observable for test 2 is the tool_use block pair. If the
+  search tool errors at runtime (rate limit), `handle_tool_error=True` turns
+  it into tool output — the selection evidence still persists and the run
+  produces no flow error, so the test still measures what it claims.
+- **Force-failure checks** (CONTRIBUTING §2): M1 — swap the expected/negative
+  tool names in test 1 ⇒ selection assert must fail; M2 — assert an
+  impossible title (e.g. `Sample Slide Show XYZ`) ⇒ execution assert must
+  fail; M3 — swap the expected/negative names in test 2 ⇒ must fail.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Tool *failure* handling (covered by `agent-tool-error-handling.spec.ts`).
+- Ambiguous prompts where either tool is defensible (not a contract).
+- Tools added manually beyond the template's two (Custom Component probe
+  tools are covered by other §6.4 bullets).
+- The transient "Executed …" streaming headers — assertions target persisted
+  monitor data and the final reply only.
+
+---
+
+## External dependencies *(required)*
+
+- **LLM provider API** (per `models.json` target): one completion with one
+  tool round-trip per test.
+- **httpbin.org** (test 1) — repo-standard deterministic HTTP endpoint
+  (`/json` → fixed `Sample Slide Show` payload).
+- **Web search backend** (test 2) — the `UnifiedWebSearch` component's live
+  search; only tool *selection* is asserted, never result content.
+- `tests/helpers/provider-setup/data/models.json` + `providers.json`
+  (collect-models).

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-multi-tool-selection.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-multi-tool-selection.spec.ts
@@ -1,0 +1,370 @@
+import * as dotenv from "dotenv";
+import path from "path";
+import fs from "fs";
+import type { Page } from "@playwright/test";
+import type { APIRequestContext } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
+import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import {
+  hasProviderEnvKeys,
+  missingProviderEnvKeys,
+  providerConfigMap,
+  type Provider,
+} from "../../../../helpers/provider-setup";
+import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+
+/**
+ * Agent multi-tool selection (QA-CHECKLIST §6.2 "Agent with multiple
+ * configured tools executes correctly" + §6.4 "Multiple connected tools —
+ * agent selects the correct one for each prompt").
+ *
+ * The Simple Agent template ships with TWO tools wired to the Agent — URL
+ * (tool `fetch_content`) and Web Search (tool `perform_search`) — the
+ * canonical multi-tool surface. Per prompt, the persisted AI message's
+ * tool_use blocks (monitor API, nonce-keyed to this run's session) must name
+ * the EXPECTED tool and NOT the sibling: the positive+negative pair is what
+ * proves *selection*, not just use.
+ *
+ * The Agent Instructions force exactly one tool call per question WITHOUT
+ * naming any tool: tool USE is instructed (a from-memory answer would flake
+ * the positive half), tool CHOICE is the agent's — the behavior under test.
+ * Search result content is never asserted (non-deterministic); the fetch
+ * prompt additionally asserts httpbin.org/json's fixed "Sample Slide Show"
+ * title reached the reply.
+ */
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
+}
+
+const FETCH_URL = "https://httpbin.org/json";
+const URL_TOOL = "fetch_content";
+const SEARCH_TOOL = "perform_search";
+const EXPECTED_TITLE = /Sample Slide Show/i;
+const SYSTEM_PROMPT =
+  "For every user question you MUST call exactly one tool to obtain the answer - " +
+  "never answer from memory and never refuse. Choose the tool that fits the question.";
+
+interface ModelRecord {
+  provider: string;
+  model: string;
+}
+
+interface TestTarget {
+  label: string;
+  options: LoadSimpleAgentOptions;
+  skipReason?: string;
+}
+
+function getProviderSkipReasons(): Map<string, string> {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/providers.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
+    return new Map();
+  }
+  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
+  const reasons = new Map<string, string>();
+  for (const r of records) {
+    if (r.status === "inactive") {
+      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
+    }
+  }
+  return reasons;
+}
+
+function getModelsFromJson(): ModelRecord[] {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/models.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("models.json not found — run collect-models.spec.ts first.");
+    return [];
+  }
+  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
+}
+
+function getTestTargets(): TestTarget[] {
+  const skipReasons = getProviderSkipReasons();
+
+  if (process.env.MODEL_TEST_ID) {
+    const model = process.env.MODEL_TEST_ID;
+    const allModels = getModelsFromJson();
+    const record = allModels.find((m) => m.model === model);
+    if (!record) {
+      console.warn(`MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred.`);
+      return [{ label: `model:${model}`, options: { model } }];
+    }
+    const provider = record.provider as Provider;
+    return [{
+      label: `${provider} / ${model}`,
+      options: { provider, model },
+      skipReason: skipReasons.get(provider),
+    }];
+  }
+
+  const allModels = getModelsFromJson();
+  if (allModels.length === 0) {
+    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
+    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
+    return [{
+      label: `provider:${fallbackProvider} (fallback)`,
+      options: { provider: fallbackProvider },
+      skipReason: skipReasons.get(fallbackProvider),
+    }];
+  }
+
+  let models = allModels;
+  if (process.env.MODEL_TEST_PROVIDER) {
+    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
+  } else if (process.env.ALL_MODELS !== "true") {
+    const seen = new Set<string>();
+    models = models.filter((m) => {
+      if (seen.has(m.provider)) return false;
+      seen.add(m.provider);
+      return true;
+    });
+  }
+
+  return models.map((m) => ({
+    label: `${m.provider} / ${m.model}`,
+    options: { provider: m.provider as Provider, model: m.model },
+    skipReason: skipReasons.get(m.provider),
+  }));
+}
+
+// Flows created by each test are tracked here and deleted by id in
+// afterEach — loadTemplateByName does NO cleanup (post-#553 contract), and
+// SimpleAgentTemplatePage.load() discards the id, so it is re-captured from
+// the template-instantiation POST response in parallel with the load.
+const createdFlowIds: string[] = [];
+
+async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
+  // Collect EVERY flow id this page creates (POST /api/v1/flows 201): the
+  // app can fire more than one flows POST during template load, and only
+  // one of them is the flow that persists — deleting all collected ids is
+  // still id-scoped (only THIS test's creations), and a 404 on an already-
+  // gone transient id is harmless.
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {}); // non-JSON / batch payloads
+    }
+  });
+  try {
+    await new SimpleAgentTemplatePage(page).load(options);
+  } catch (e: any) {
+    if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
+    throw e;
+  }
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    const res = await request.delete(`/api/v1/flows/${id}`, {
+      headers: { Authorization: bearer },
+    });
+    // 404 = transient flow the app already discarded — expected noise.
+    if (!res.ok() && res.status() !== 404) {
+      console.warn(`flow cleanup: DELETE ${id} -> ${res.status()}`);
+    }
+  }
+});
+
+// Set the Agent Instructions (system prompt) on the node.
+async function setSystemPrompt(page: Page, prompt: string): Promise<void> {
+  const field = page.getByTestId("textarea_str_system_prompt");
+  await expect(field).toBeVisible({ timeout: 15000 });
+  await field.click();
+  await field.fill(prompt);
+  await field.blur();
+}
+
+// Set the task on the ChatInput node (the Playground prompt pre-fills from it;
+// typing into the Playground races an async default re-injection).
+async function setChatInputText(page: Page, text: string): Promise<void> {
+  const field = page.locator(
+    '[data-testid^="rf__node-ChatInput"] [data-testid="textarea_str_input_value"]',
+  );
+  await expect(field).toBeVisible({ timeout: 15000 });
+  await field.click();
+  await field.fill(text);
+  await field.blur();
+}
+
+async function waitForAgentToFinish(page: Page): Promise<void> {
+  const stopButton = page.getByRole("button", { name: "Stop" });
+  const stopVisible = await stopButton.isVisible({ timeout: 10000 }).catch(() => false);
+  if (stopVisible) {
+    await expect(stopButton).toBeHidden({ timeout: 120000 });
+  }
+}
+
+// Open the Playground with the pre-seeded task and send it.
+async function openPlaygroundAndSend(page: Page, task: string): Promise<void> {
+  await page.getByTestId("playground-btn-flow-io").click();
+  const chatInput = page.getByTestId("input-chat-playground").last();
+  await expect(chatInput).toBeVisible({ timeout: 30000 });
+  await expect(chatInput).toHaveValue(task, { timeout: 15000 });
+  await page.getByTestId("button-send").last().click();
+  await waitForAgentToFinish(page);
+}
+
+// Monitor-API check of tool SELECTION: the AI message persisted for THIS
+// run's session (keyed by the nonce in the user message) must carry a
+// tool_use block named `expectedTool` and NONE named `forbiddenTool`.
+// The negative half is what proves selection — a run that calls both tools
+// indiscriminately fails here even if the final answer looks right.
+async function expectToolSelectionPersisted(
+  request: APIRequestContext,
+  nonce: string,
+  expectedTool: string,
+  forbiddenTool: string,
+): Promise<void> {
+  const bearer = await getAuthToken(request);
+  await expect
+    .poll(
+      async () => {
+        const res = await request.get("/api/v1/monitor/messages", {
+          headers: { Authorization: bearer },
+        });
+        if (res.status() !== 200) return `GET monitor -> ${res.status()}`;
+        const messages = await res.json();
+        if (!Array.isArray(messages)) return "monitor payload not a list";
+
+        const userMsg = messages.find(
+          (m: any) => m.sender !== "Machine" && (m.text ?? "").includes(nonce),
+        );
+        if (!userMsg) return "user message with nonce not persisted yet";
+
+        const aiMsg = messages.find(
+          (m: any) =>
+            m.sender === "Machine" &&
+            m.session_id === userMsg.session_id &&
+            (m.content_blocks?.length ?? 0) > 0,
+        );
+        if (!aiMsg) return "AI message for the session not persisted yet";
+
+        const toolNames = (aiMsg.content_blocks as any[])
+          .flatMap((b: any) => b.contents ?? [])
+          .filter((c: any) => c.type === "tool_use")
+          .map((c: any) => c.name as string);
+        if (toolNames.length === 0) return "no tool_use blocks persisted yet";
+
+        if (!toolNames.includes(expectedTool)) {
+          return `expected tool "${expectedTool}" not called; called: ${JSON.stringify(toolNames)}`;
+        }
+        if (toolNames.includes(forbiddenTool)) {
+          return `forbidden tool "${forbiddenTool}" was also called; called: ${JSON.stringify(toolNames)}`;
+        }
+        return "correct-tool-selected";
+      },
+      { timeout: 30000 },
+    )
+    .toBe("correct-tool-selected");
+}
+
+const targets = getTestTargets();
+
+// Serial mode + --workers=1 keeps the shared instance state deterministic
+// (area rule for agent specs). Cleanup is id-scoped in afterEach — nothing
+// here wipes flows, so parallel neighbors are never victims.
+test.describe.configure({ mode: "serial" });
+
+for (const { label, options, skipReason } of targets) {
+  const provider = options.provider ?? (Object.keys(providerConfigMap)[0] as Provider);
+
+  test.describe(`Agent Multi-Tool Selection [${label}]`, () => {
+    test(
+      "agent selects the URL tool for a fetch prompt",
+      { tag: ["@stable", "@regression", "@agents", "@playground"] },
+      async ({ page, request }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        const nonce = `probe-${Date.now()}`;
+        const task = `Fetch ${FETCH_URL} and tell me the exact slideshow title it returns. (${nonce})`;
+
+        await loadAgent(page, options);
+
+        await test.step("force tool use (not tool choice), seed the fetch task", async () => {
+          await setSystemPrompt(page, SYSTEM_PROMPT);
+          await setChatInputText(page, task);
+          await waitForFlowSaveSettled(page);
+        });
+
+        await test.step("run — no allowFlowErrors: a crashed run fails via the fixture", async () => {
+          await openPlaygroundAndSend(page, task);
+        });
+
+        await test.step("execution: the reply carries httpbin's deterministic slideshow title", async () => {
+          const bubble = page.getByTestId("div-chat-message").last();
+          await expect(bubble).toBeVisible({ timeout: 30000 });
+          await expect(bubble).toContainText(EXPECTED_TITLE, { timeout: 30000 });
+        });
+
+        await test.step("selection: fetch_content called, perform_search NOT called", async () => {
+          await expectToolSelectionPersisted(request, nonce, URL_TOOL, SEARCH_TOOL);
+        });
+      },
+    );
+
+    test(
+      "agent selects the Web Search tool for a search prompt",
+      { tag: ["@stable", "@regression", "@agents", "@playground"] },
+      async ({ page, request }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        const nonce = `probe-${Date.now()}`;
+        const task = `Search the web for recent news about the Playwright test framework and summarize one headline. (${nonce})`;
+
+        await loadAgent(page, options);
+
+        await test.step("force tool use (not tool choice), seed the search task", async () => {
+          await setSystemPrompt(page, SYSTEM_PROMPT);
+          await setChatInputText(page, task);
+          await waitForFlowSaveSettled(page);
+        });
+
+        await test.step("run — no allowFlowErrors: a crashed run fails via the fixture", async () => {
+          await openPlaygroundAndSend(page, task);
+        });
+
+        await test.step("execution: the run produced a final, non-empty reply", async () => {
+          // Search result content is inherently non-deterministic — the
+          // selection assert below is the concrete observable (spec doc,
+          // "Guarding against false positives").
+          const bubble = page.getByTestId("div-chat-message").last();
+          await expect(bubble).toBeVisible({ timeout: 30000 });
+          await expect(bubble).not.toHaveText("", { timeout: 30000 });
+        });
+
+        await test.step("selection: perform_search called, fetch_content NOT called", async () => {
+          await expectToolSelectionPersisted(request, nonce, SEARCH_TOOL, URL_TOOL);
+        });
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #486

Closes the `[ ]` gaps in `QA-CHECKLIST.md` §6.2 ("Agent with multiple configured tools executes correctly") and §6.4 ("Multiple connected tools — agent selects the correct one for each prompt"). Distinct from `agent-tool-error-handling.spec.ts` (tool *failure* path) and `agent-current-date-tool` (tool *availability* toggle): this spec covers tool **selection** among peers.

## 1. Covered tests
| # | Test | What it validates |
|---|------|-------------------|
| 1 | `agent selects the URL tool for a fetch prompt` | The nonce-keyed session's persisted AI message has a `fetch_content` `tool_use` block and **no** `perform_search` block, and the reply contains httpbin.org/json's fixed `Sample Slide Show` title. Catches mis-routing of fetch prompts and broken tool wiring. |
| 2 | `agent selects the Web Search tool for a search prompt` | Same session lookup: `perform_search` block present, `fetch_content` absent; final reply non-empty. Search result content deliberately not asserted (non-deterministic). |

The positive+negative pair per prompt is what proves *selection* — a run that calls both tools indiscriminately fails the negative half even when the answer looks right.

## 2. How the test was built
- Surface: the Simple Agent template already ships with two tools wired to the Agent — URL (`fetch_content`) and Web Search (`perform_search`) — confirmed in the nightly's `starter_projects/Simple Agent.json`; tool names confirmed in the component sources (`URLComponent`, `UnifiedWebSearch` → output methods).
- Agent Instructions force **exactly one tool call** per question WITHOUT naming any tool: tool *use* is instructed (a from-memory answer would flake the positive half), tool *choice* stays with the agent — the behavior under test.
- **Live-confirmed selectors**: all reused from the merged `@stable` sibling `agent-tool-error-handling.spec.ts` (`textarea_str_system_prompt`, ChatInput `textarea_str_input_value`, `playground-btn-flow-io`, `input-chat-playground`, `button-send`, `div-chat-message`).
- Assertions read the monitor API (`GET /api/v1/monitor/messages`), keyed to the run's session via a per-run nonce in the user message — persisted `tool_use` blocks, immune to streaming/UI transients.
- Flow cleanup is id-scoped per authoring conventions: a response listener collects every flow id this test creates (`POST /api/v1/flows` 201) and `afterEach` deletes exactly those ids (`loadTemplateByName` does no cleanup post-#553; behavioral force-fail confirmed the leak when cleanup is disabled and 0 orphans across 4 runs with it enabled).

## 3. Dependencies
- LLM provider API per `models.json` target (validated on google/gemini-3.5-flash); httpbin.org (test 1, repo-standard endpoint); the Web Search backend is exercised but its output is never asserted.
- Execution: `--workers=1` serial (agent-area rule — shared instance state).

## Validation (nightly 1.11.0.dev34, `--retries=0 --workers=1`)
- typecheck ✅ · eslint ✅
- 9 clean runs total, no flake ✅ (1 initial + 3 burst + 1 post-FF green + 1 FF-scoped + 3 after the cleanup change; every run `2 passed`, zero `🚨 Backend Error`)
- force-fail ✅ executed per test: M1 swapped expected/forbidden tools in test 1 → failed (`unexpected=1`); M3 same swap in test 2 → failed (`unexpected=1`); cleanup disabled → 1 orphan flow observed, re-enabled → 0 orphans across 4 runs; reverts proven (`grep FF-MUTATION` = 0 hits) + final green run
- `--trace=on` ⚠️ skipped — known local hang on Simple Agent–template specs (documented limitation; step verification covered by the retries=0 bursts + force-fail mutations)
- `@stable` added after the clean-run evidence above; QA-CHECKLIST §6.2/§6.4 bullets flipped to `[x]` (bullets only — generated blocks untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)