### PR TITLE
test(llm-agents): add agent current-date tool toggle spec (#495)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -361,7 +361,7 @@
 - [x] Agent Instructions (system prompt) is respected in the model response → `agent-system-prompt.spec.ts`
 - [x] Input via direct field vs handle (ChatInput) — both work → `core-functionality/llm-agents/agent-input-sources.spec.ts`
 - [x] Empty response or model refusal — component does not crash → `core-functionality/llm-agents/agent-empty-refusal-response.spec.ts`
-- [ ] Toggle add_current_date_tool works (enables/disables date tool) → `agent-current-date-tool.spec.ts`
+- [x] Toggle add_current_date_tool works (enables/disables date tool) → `agent-current-date-tool.spec.ts`
 - [ ] handle_parsing_errors=False fails explicitly vs True auto-corrects → `agent-parse-error-behavior.spec.ts` (**not implementable on 1.11**: the field now only toggles `ToolRetryMiddleware`, and component-tool failures are converted to content by the hardcoded `handle_tool_error=True` before the middleware can observe them — True/False proven behaviorally identical; the only live trigger (LLM-emitted malformed args) is non-deterministic; pending re-scope, see #496)
 - [x] Image passed via input handle is processed correctly → `core-functionality/llm-agents/agent-multimodal-image-input.spec.ts`
 

--- a/docs/core-functionality/llm-agents/agent-current-date-tool.md
+++ b/docs/core-functionality/llm-agents/agent-current-date-tool.md
@@ -1,0 +1,161 @@
+# Agent current-date tool — add_current_date_tool toggle
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+QA-CHECKLIST §6.5 "Toggle add_current_date_tool works (enables/disables date
+tool)". `add_current_date_tool` is an **advanced** BoolInput on the Agent
+(default `true`, display "Current Date" — `agent.py`): when true, the agent's
+toolkit gains the CurrentDateComponent tool (`get_current_date`); when false,
+the tool is never appended, so the model **cannot** call it.
+
+Causal pair, one test per side of the toggle:
+
+1. **ON (template default)** — a date question must produce a
+   `get_current_date` `tool_use` block whose persisted **output contains
+   today's UTC date** (`YYYY-MM-DD`, computed at assert time) — the tool
+   exists AND returns the real date.
+2. **OFF (toggle flipped in the controls dialog)** — the same question must
+   persist **zero** `get_current_date` `tool_use` blocks for the run's
+   session: with the toggle off the tool is not in the toolkit, so its
+   absence is deterministic, independent of what the model answers.
+
+> **Trap — the default system prompt leaks the date.** The Simple Agent
+> template's default `system_prompt` contains the `{current_date}`
+> placeholder, which `agent.py` substitutes with the real UTC datetime at
+> run time — with the toggle OFF the model would still "know" the date via
+> the prompt, and a naive "does it know the date?" design would pass either
+> way. Both tests therefore set a **custom system prompt without the
+> placeholder**; the observable is the `tool_use` block, never the model's
+> knowledge.
+
+Naming the date tool in the instructions is legitimate here (unlike
+`agent-multi-tool-selection`, where free choice IS the contract): this
+bullet's contract is tool **availability** — instructing "use the date tool
+if available" maximizes the ON signal without affecting OFF, where the tool
+simply doesn't exist.
+
+If this test fails, the toggle either doesn't wire the tool in (ON broken)
+or doesn't remove it (OFF broken) — a config surface lying to the user.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@agents` `@playground`
+
+`@stable` added after 4 clean `--retries=0` runs on 1.11.0.dev34, revalidated
+with 3 more on 1.11.0.dev36 after the 2026-07-08 gemini drift event (the
+assertions are drift-resilient by design: presence-anywhere on ON, structural
+absence on OFF — see agent-multi-tool-selection's "Why first-call" note for
+the event; issue #495's "Done when" includes `@stable`). `@regression` —
+guards the toggle→toolkit wiring; `@agents` — agent tool configuration;
+`@playground` — the run happens through the Playground.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` (fresh nightly).
+- `models.json` / `providers.json` generated via
+  `npx playwright test tests/collect-models.spec.ts`.
+- At least one active provider API key in `.env`.
+- Run with `--workers=1` — area rule for agent specs (shared instance state).
+  Each test captures its flow id from the template-instantiation
+  `POST /api/v1/flows/` response and deletes exactly that id in `afterEach`
+  (`loadTemplateByName` does no cleanup — post-#553 contract).
+
+---
+
+## Step by step *(required)*
+
+The spec generates tests per active model via the `getTestTargets()`
+machinery (family standard). Per model, a serial describe with two tests:
+
+**Test 1 — toggle ON (default): the date tool exists and returns today (§6.5)**
+
+1. Load the Simple Agent template (provider/model from `models.json`/`.env`).
+2. Set Agent Instructions (`textarea_str_system_prompt`) to a prompt
+   **without `{current_date}`**: *"If a date/time tool is available you MUST
+   use it to answer date questions — never answer date questions from
+   memory. If no such tool is available, reply that you cannot verify the
+   date."*
+3. Seed the task on the ChatInput node (`textarea_str_input_value`):
+   *"What is the current date? (probe `<nonce>`)"*.
+4. Open the Playground (`playground-btn-flow-io`), send, wait for the run to
+   finish (Stop button hidden).
+5. **Tool assert (API):** poll `GET /api/v1/monitor/messages` — nonce →
+   `session_id` → the session's AI message must have a `get_current_date`
+   `tool_use` block whose `output` contains today's **UTC** date
+   (`YYYY-MM-DD` computed at assert time; the day-boundary edge accepts
+   today-or-yesterday UTC to survive a midnight flip mid-run).
+6. No `allowFlowErrors` — any flow error fails via the fixture.
+
+**Test 2 — toggle OFF: the date tool is removed from the toolkit (§6.5)**
+
+1–2. Same template load and Instructions (fresh load; new nonce).
+3. Open the Agent controls dialog (`edit-button-modal`), assert the
+   pre-flip default is ON (`toggle_bool_edit_add_current_date_tool` has
+   `aria-checked="true"` — a changed template default fails loudly instead
+   of silently inverting the test), click it, assert `aria-checked="false"`,
+   close (`edit-button-close`), wait for the flow save to settle.
+4. Seed the same task (new nonce); open the Playground, send, wait.
+5. **Absence assert (API):** the session's AI message(s) must contain
+   **zero** `get_current_date` `tool_use` blocks. The final AI bubble must
+   be visible and non-empty (the run completed; what the model *says*
+   about the date is deliberately not asserted).
+6. No `allowFlowErrors`.
+
+---
+
+## Validation criterion *(required)*
+
+Toggle ON: a `get_current_date` `tool_use` block persisted for the run's
+nonce-keyed session, with its output containing today's UTC `YYYY-MM-DD`.
+Toggle OFF (after a proven `aria-checked` true→false flip): zero
+`get_current_date` `tool_use` blocks in that run's session, with the run
+still completing normally. The pair is causal — only the toggle differs
+between the tests, so a regression on either side of the wiring flips
+exactly one of them.
+
+## Guarding against false positives *(how)*
+
+- **Prompt controls the date leak** — custom system prompt without
+  `{current_date}` in BOTH tests; otherwise OFF passes/fails on model
+  phrasing instead of toolkit contents.
+- **Nonce-keyed session lookup** — monitor messages persist across flow
+  wipes; the nonce pins assertions to THIS run (family technique).
+- **Tool OUTPUT asserted, not model prose** — the ON assert reads the
+  tool block's persisted output (backend-generated date string), so model
+  formatting/hallucination can't fake it; the reply text is not the
+  observable.
+- **Proven write on the flip** — asserting `aria-checked` before AND after
+  the click makes the OFF test fail loudly if the template default ever
+  changes (pattern from `agent-config-persistence`).
+- **Force-failure checks** (CONTRIBUTING §2): M1 — ON test expects an
+  impossible date sentinel in the tool output ⇒ must fail; M2 — OFF test
+  inverted to require a `get_current_date` block ⇒ must fail.
+
+---
+
+## What this test does not cover *(optional)*
+
+- The CurrentDateComponent's timezone input (tool default; standalone
+  component behavior is a §"utilities" concern).
+- The `{current_date}` system-prompt placeholder substitution (separate
+  surface — deliberately excluded from both prompts here).
+- Free tool *selection* among peers (`agent-multi-tool-selection.spec.ts`).
+- The sibling `add_calculator_tool` toggle (same wiring, own bullet).
+
+---
+
+## External dependencies *(required)*
+
+- **LLM provider API** (per `models.json` target): one completion with at
+  most one tool round-trip per test.
+- `tests/helpers/provider-setup/data/models.json` + `providers.json`
+  (collect-models).
+- No external network beyond the provider — the date tool is local.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-current-date-tool.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-current-date-tool.spec.ts
@@ -1,0 +1,412 @@
+import * as dotenv from "dotenv";
+import path from "path";
+import fs from "fs";
+import type { Page } from "@playwright/test";
+import type { APIRequestContext } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
+import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import {
+  hasProviderEnvKeys,
+  missingProviderEnvKeys,
+  providerConfigMap,
+  type Provider,
+} from "../../../../helpers/provider-setup";
+import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+
+/**
+ * Agent current-date tool toggle (QA-CHECKLIST §6.5 "Toggle
+ * add_current_date_tool works (enables/disables date tool)").
+ *
+ * Causal pair — only the toggle differs between the two tests:
+ *   ON (template default): a date question persists a `get_current_date`
+ *   tool_use block whose OUTPUT contains today's UTC date (backend-generated
+ *   string — model prose is never the observable).
+ *   OFF (flipped in the controls dialog, aria-checked write proven): zero
+ *   `get_current_date` tool_use blocks in the run's session — the tool is
+ *   not in the toolkit, so its absence is deterministic.
+ *
+ * Trap disarmed: the template's DEFAULT system prompt contains the
+ * `{current_date}` placeholder, substituted with the real date at run time —
+ * with the toggle OFF the model would still "know" the date via the prompt.
+ * Both tests set a custom prompt WITHOUT the placeholder (spec doc, Trap
+ * note). Naming the date tool in the instructions is deliberate: this
+ * bullet's contract is tool AVAILABILITY, not free selection (that is
+ * agent-multi-tool-selection.spec.ts).
+ */
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
+}
+
+const DATE_TOOL = "get_current_date";
+const SYSTEM_PROMPT =
+  "If a date/time tool is available you MUST use it to answer date questions - " +
+  "never answer date questions from memory. " +
+  "If no such tool is available, reply that you cannot verify the date.";
+
+// Today's UTC date, with yesterday accepted to survive a midnight flip
+// between the tool call and the assert (spec doc, Step by step).
+function acceptedUtcDates(): string[] {
+  const now = new Date();
+  const today = now.toISOString().slice(0, 10);
+  const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  return [today, yesterday];
+}
+
+interface ModelRecord {
+  provider: string;
+  model: string;
+}
+
+interface TestTarget {
+  label: string;
+  options: LoadSimpleAgentOptions;
+  skipReason?: string;
+}
+
+function getProviderSkipReasons(): Map<string, string> {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/providers.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
+    return new Map();
+  }
+  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
+  const reasons = new Map<string, string>();
+  for (const r of records) {
+    if (r.status === "inactive") {
+      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
+    }
+  }
+  return reasons;
+}
+
+function getModelsFromJson(): ModelRecord[] {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/models.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("models.json not found — run collect-models.spec.ts first.");
+    return [];
+  }
+  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
+}
+
+function getTestTargets(): TestTarget[] {
+  const skipReasons = getProviderSkipReasons();
+
+  if (process.env.MODEL_TEST_ID) {
+    const model = process.env.MODEL_TEST_ID;
+    const allModels = getModelsFromJson();
+    const record = allModels.find((m) => m.model === model);
+    if (!record) {
+      console.warn(`MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred.`);
+      return [{ label: `model:${model}`, options: { model } }];
+    }
+    const provider = record.provider as Provider;
+    return [{
+      label: `${provider} / ${model}`,
+      options: { provider, model },
+      skipReason: skipReasons.get(provider),
+    }];
+  }
+
+  const allModels = getModelsFromJson();
+  if (allModels.length === 0) {
+    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
+    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
+    return [{
+      label: `provider:${fallbackProvider} (fallback)`,
+      options: { provider: fallbackProvider },
+      skipReason: skipReasons.get(fallbackProvider),
+    }];
+  }
+
+  let models = allModels;
+  if (process.env.MODEL_TEST_PROVIDER) {
+    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
+  } else if (process.env.ALL_MODELS !== "true") {
+    const seen = new Set<string>();
+    models = models.filter((m) => {
+      if (seen.has(m.provider)) return false;
+      seen.add(m.provider);
+      return true;
+    });
+  }
+
+  return models.map((m) => ({
+    label: `${m.provider} / ${m.model}`,
+    options: { provider: m.provider as Provider, model: m.model },
+    skipReason: skipReasons.get(m.provider),
+  }));
+}
+
+// Flows created by each test are tracked here and deleted by id in
+// afterEach — loadTemplateByName does NO cleanup (post-#553 contract), and
+// SimpleAgentTemplatePage.load() discards the id, so it is re-captured from
+// the template-instantiation POST response in parallel with the load.
+const createdFlowIds: string[] = [];
+
+async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
+  // Collect EVERY flow id this page creates (POST /api/v1/flows 201): the
+  // app can fire more than one flows POST during template load, and only
+  // one of them is the flow that persists — deleting all collected ids is
+  // still id-scoped (only THIS test's creations), and a 404 on an already-
+  // gone transient id is harmless.
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {}); // non-JSON / batch payloads
+    }
+  });
+  try {
+    await new SimpleAgentTemplatePage(page).load(options);
+  } catch (e: any) {
+    if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
+    throw e;
+  }
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    // deleteFlow throws on real failures and treats 404 as done — a
+    // transient id the app already discarded is the desired end state.
+    await deleteFlow(request, id, { headers: { Authorization: bearer } });
+  }
+});
+
+// Set the Agent Instructions (system prompt) on the node.
+async function setSystemPrompt(page: Page, prompt: string): Promise<void> {
+  const field = page.getByTestId("textarea_str_system_prompt");
+  await expect(field).toBeVisible({ timeout: 15000 });
+  await field.click();
+  await field.fill(prompt);
+  await field.blur();
+}
+
+// Set the task on the ChatInput node (the Playground prompt pre-fills from it;
+// typing into the Playground races an async default re-injection).
+async function setChatInputText(page: Page, text: string): Promise<void> {
+  const field = page.locator(
+    '[data-testid^="rf__node-ChatInput"] [data-testid="textarea_str_input_value"]',
+  );
+  await expect(field).toBeVisible({ timeout: 15000 });
+  await field.click();
+  await field.fill(text);
+  await field.blur();
+}
+
+// Flip add_current_date_tool OFF in the Agent controls dialog. Asserting the
+// pre-flip default makes this a proven WRITE — a changed template default
+// fails loudly instead of silently inverting the test's meaning (pattern
+// from agent-config-persistence.spec.ts).
+async function setCurrentDateToggleOff(page: Page): Promise<void> {
+  await page.getByTestId("edit-button-modal").click();
+  const toggle = page.getByTestId("toggle_bool_edit_add_current_date_tool");
+  await expect(toggle).toBeVisible({ timeout: 15000 });
+  await toggle.scrollIntoViewIfNeeded();
+  await expect(toggle).toHaveAttribute("aria-checked", "true");
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-checked", "false");
+  await page.getByTestId("edit-button-close").click();
+}
+
+async function waitForAgentToFinish(page: Page): Promise<void> {
+  const stopButton = page.getByRole("button", { name: "Stop" });
+  const stopVisible = await stopButton.isVisible({ timeout: 10000 }).catch(() => false);
+  if (stopVisible) {
+    await expect(stopButton).toBeHidden({ timeout: 120000 });
+  }
+}
+
+// Open the Playground with the pre-seeded task and send it.
+async function openPlaygroundAndSend(page: Page, task: string): Promise<void> {
+  await page.getByTestId("playground-btn-flow-io").click();
+  const chatInput = page.getByTestId("input-chat-playground").last();
+  await expect(chatInput).toBeVisible({ timeout: 30000 });
+  await expect(chatInput).toHaveValue(task, { timeout: 15000 });
+  await page.getByTestId("button-send").last().click();
+  await waitForAgentToFinish(page);
+}
+
+// Collect the tool_use blocks of every AI message in the nonce-keyed
+// session. Returns null while the session's AI reply is not persisted yet
+// (poll-friendly); after that, the block list (possibly empty).
+async function getSessionToolBlocks(
+  request: APIRequestContext,
+  bearer: string,
+  nonce: string,
+): Promise<{ name: string; output: unknown }[] | null> {
+  const res = await request.get("/api/v1/monitor/messages", {
+    headers: { Authorization: bearer },
+  });
+  if (res.status() !== 200) return null;
+  const messages = await res.json();
+  if (!Array.isArray(messages)) return null;
+
+  const userMsg = messages.find(
+    (m: any) => m.sender !== "Machine" && (m.text ?? "").includes(nonce),
+  );
+  if (!userMsg) return null;
+
+  const aiMsgs = messages.filter(
+    (m: any) => m.sender === "Machine" && m.session_id === userMsg.session_id,
+  );
+  if (aiMsgs.length === 0) return null;
+
+  return aiMsgs.flatMap((m: any) =>
+    ((m.content_blocks ?? []) as any[])
+      .flatMap((b: any) => b.contents ?? [])
+      .filter((c: any) => c.type === "tool_use")
+      .map((c: any) => ({ name: c.name as string, output: c.output })),
+  );
+}
+
+// ON assert: a get_current_date block exists and its backend-generated
+// output contains today's UTC date — model prose is never the observable.
+async function expectDateToolReturnedToday(
+  request: APIRequestContext,
+  nonce: string,
+): Promise<void> {
+  const bearer = await getAuthToken(request);
+  await expect
+    .poll(
+      async () => {
+        const blocks = await getSessionToolBlocks(request, bearer, nonce);
+        if (blocks === null) return "session messages not persisted yet";
+        const dateBlocks = blocks.filter((b) => b.name === DATE_TOOL);
+        if (dateBlocks.length === 0) {
+          return `no ${DATE_TOOL} tool_use block; called: ${JSON.stringify(blocks.map((b) => b.name))}`;
+        }
+        const accepted = acceptedUtcDates();
+        return dateBlocks.some((b) => {
+          const out = JSON.stringify(b.output ?? "");
+          return accepted.some((d) => out.includes(d));
+        })
+          ? "date-tool-returned-today"
+          : `${DATE_TOOL} output has no accepted UTC date ${JSON.stringify(accepted)}: ${JSON.stringify(dateBlocks[0].output).slice(0, 120)}`;
+      },
+      { timeout: 30000 },
+    )
+    .toBe("date-tool-returned-today");
+}
+
+// OFF assert: the session's AI reply is persisted and carries ZERO
+// get_current_date blocks — the toggle removed the tool from the toolkit.
+async function expectNoDateToolBlocks(
+  request: APIRequestContext,
+  nonce: string,
+): Promise<void> {
+  const bearer = await getAuthToken(request);
+  await expect
+    .poll(
+      async () => {
+        const blocks = await getSessionToolBlocks(request, bearer, nonce);
+        if (blocks === null) return "session messages not persisted yet";
+        const dateBlocks = blocks.filter((b) => b.name === DATE_TOOL);
+        return dateBlocks.length === 0
+          ? "no-date-tool-blocks"
+          : `unexpected ${DATE_TOOL} block(s): ${dateBlocks.length}`;
+      },
+      { timeout: 30000 },
+    )
+    .toBe("no-date-tool-blocks");
+}
+
+const targets = getTestTargets();
+
+// Serial mode + --workers=1 keeps the shared instance state deterministic
+// (area rule for agent specs). Cleanup is id-scoped in afterEach — nothing
+// here wipes flows, so parallel neighbors are never victims.
+test.describe.configure({ mode: "serial" });
+
+for (const { label, options, skipReason } of targets) {
+  const provider = options.provider ?? (Object.keys(providerConfigMap)[0] as Provider);
+
+  test.describe(`Agent Current Date Tool [${label}]`, () => {
+    test(
+      "toggle ON (default): agent's date tool returns today's date",
+      { tag: ["@stable", "@regression", "@agents", "@playground"] },
+      async ({ page, request }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        const nonce = `probe-${Date.now()}`;
+        const task = `What is the current date? (${nonce})`;
+
+        await loadAgent(page, options);
+
+        await test.step("set a prompt WITHOUT {current_date}, seed the date question", async () => {
+          await setSystemPrompt(page, SYSTEM_PROMPT);
+          await setChatInputText(page, task);
+          await waitForFlowSaveSettled(page);
+        });
+
+        await test.step("run — no allowFlowErrors: a crashed run fails via the fixture", async () => {
+          await openPlaygroundAndSend(page, task);
+        });
+
+        await test.step("date tool called and its output contains today's UTC date", async () => {
+          await expectDateToolReturnedToday(request, nonce);
+        });
+      },
+    );
+
+    test(
+      "toggle OFF: the date tool is removed from the agent's toolkit",
+      { tag: ["@stable", "@regression", "@agents", "@playground"] },
+      async ({ page, request }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        const nonce = `probe-${Date.now()}`;
+        const task = `What is the current date? (${nonce})`;
+
+        await loadAgent(page, options);
+
+        await test.step("set a prompt WITHOUT {current_date}, flip add_current_date_tool OFF (proven write)", async () => {
+          await setSystemPrompt(page, SYSTEM_PROMPT);
+          await setCurrentDateToggleOff(page);
+          await setChatInputText(page, task);
+          await waitForFlowSaveSettled(page);
+        });
+
+        await test.step("run — no allowFlowErrors: a crashed run fails via the fixture", async () => {
+          await openPlaygroundAndSend(page, task);
+        });
+
+        await test.step("run completed with a final, non-empty reply", async () => {
+          const bubble = page.getByTestId("div-chat-message").last();
+          await expect(bubble).toBeVisible({ timeout: 30000 });
+          await expect(bubble).not.toHaveText("", { timeout: 30000 });
+        });
+
+        await test.step("zero get_current_date tool_use blocks persisted for this run", async () => {
+          await expectNoDateToolBlocks(request, nonce);
+        });
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #495

Closes the `[ ]` gap in `QA-CHECKLIST.md` §6.5 ("Toggle add_current_date_tool works — enables/disables date tool"). Distinct from `agent-multi-tool-selection.spec.ts` (free tool *selection* among peers): this spec covers tool **availability** — the toggle wiring the tool in and out of the agent's toolkit.

## 1. Covered tests
| # | Test | What it validates |
|---|------|-------------------|
| 1 | `toggle ON (default): agent's date tool returns today's date` | The nonce-keyed session persists a `get_current_date` `tool_use` block whose backend-generated OUTPUT contains today's UTC `YYYY-MM-DD` (computed at assert time; midnight flip tolerated). Catches the toggle failing to wire the tool in. |
| 2 | `toggle OFF: the date tool is removed from the agent's toolkit` | After a **proven** `aria-checked` true→false flip in the controls dialog, the run's session persists ZERO `get_current_date` blocks — with the toggle off the tool is not in the toolkit, so absence is deterministic. Catches the toggle failing to remove the tool. |

Causal pair: only the toggle differs between the tests, so a regression on either side of the wiring flips exactly one of them.

## 2. How the test was built
- **Trap found in the nightly source before implementation**: the Simple Agent template's default system prompt contains the `{current_date}` placeholder, substituted with the real UTC datetime at run time — with the toggle OFF the model would still "know" the date via the prompt, making a naive "does it know the date?" design pass either way. Both tests set a custom prompt WITHOUT the placeholder; the observable is always the `tool_use` block, never model prose.
- Naming the date tool in the instructions is deliberate: this bullet's contract is availability, not free selection — and it makes the assertions drift-resilient (presence-anywhere on ON, structural absence on OFF; no sibling-tool-absent predicate of the kind the 2026-07-08 gemini drift broke in #571).
- **Live-confirmed selectors**: playground/prompt selectors reused from the merged `@stable` family; the toggle testid `toggle_bool_edit_add_current_date_tool` + `edit-button-modal`/`edit-button-close` and the pre-flip `aria-checked` assertion follow the merged `agent-config-persistence.spec.ts` pattern (a changed template default fails loudly instead of silently inverting the test).
- Assertions via monitor API (`GET /api/v1/monitor/messages`), nonce-keyed to the run's session.
- Flow cleanup is id-scoped: a response listener collects every flow id the test creates and `afterEach` deletes them via the canonical `deleteFlow` helper (#547) — behavioral force-fail confirmed the leak with cleanup disabled and 0 orphans with it enabled.

## 3. Dependencies
- LLM provider API per `models.json` target (validated on google/gemini-3.5-flash). No external network beyond the provider — the date tool is local.
- Execution: `--workers=1` serial (agent-area rule — shared instance state).

## Validation (`--retries=0 --workers=1`)
- typecheck ✅ · eslint ✅
- 7 clean runs on nightly 1.11.0.dev34 + 3 on 1.11.0.dev36 (post gemini-drift event), no flake, zero `🚨 Backend Error` ✅
- force-fail ✅ executed per test: M1 — impossible date sentinel (`9999-12-31`) in the ON assert → failed (`unexpected=1`); M2 — OFF assert inverted to require the block → failed (`unexpected=1`); cleanup disabled → 1 orphan flow observed, re-enabled → 0 orphans; reverts proven (`grep FF-MUTATION` = 0 hits) + final green
- `--trace=on` ⚠️ skipped — known local hang on Simple Agent–template specs (documented limitation)
- `@stable` added after the clean-run evidence above; QA-CHECKLIST §6.5 bullet flipped to `[x]` (bullet only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)