### PR TITLE
test(llm-agents): add agent context_id isolation spec (#488)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -345,7 +345,7 @@
 - [x] Without Message History, LLM does not retain context between messages → `llm-agents/memory-history-regression.spec.ts`
 - [x] n_messages parameter limits the number of retained messages → `llm-agents/agent-n-messages-limit.spec.ts` (bug reported fixed on 1.11.0.dev33 — parameter now respected; validated by deterministic message count)
 - [x] Agent uses custom `context_id` — continuity between session messages → `agent-context-id-continuity.spec.ts`
-- [ ] Switching `context_id` isolates history between distinct sessions → `agent-context-id-isolation.spec.ts`
+- [x] Switching `context_id` isolates history between distinct sessions → `agent-context-id-isolation.spec.ts`
 
 #### 6.4 Tools and Integrations
 - [ ] Agent with integrated external MCP tool executes action and returns result
@@ -416,7 +416,7 @@
 - [ ] Reasoning effort parameter — conditional field based on model → `agent-reasoning-effort.spec.ts` (**not implementable on 1.11** — see #484)
 - [x] Maximum token count — response truncated as configured → `llm-agents/agent-max-tokens.spec.ts`
 - [x] Maximum agent iterations → `core-functionality/llm-agents/agent-max-iterations.spec.ts`
-- [ ] Use of custom `context_id` for memory isolation → `agent-context-id-isolation.spec.ts`
+- [x] Use of custom `context_id` for memory isolation → `agent-context-id-isolation.spec.ts`
 - [ ] Output formatting (JSON via output_schema, Markdown, plain text) → `agent-structured-output.spec.ts`
 
 ---

--- a/docs/core-functionality/llm-agents/agent-context-id-isolation.md
+++ b/docs/core-functionality/llm-agents/agent-context-id-isolation.md
@@ -1,0 +1,156 @@
+# Agent context_id — switching isolates history between contexts
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+QA-CHECKLIST §6.3 "Switching `context_id` isolates history between distinct
+sessions" and §7.7 "Use of custom `context_id` for memory isolation".
+`context_id` is an advanced MessageTextInput on the Agent (and on
+ChatInput/ChatOutput/Message History) that "adds an extra layer to the local
+memory": stored messages are tagged with it, and history retrieval resolves
+through `aget_agent_chat_history(session_id, flow_id, context_id, n_messages)`
+— the context-scoped layer proven for continuity by
+`agent-context-id-continuity.spec.ts` (#487). This spec proves the OTHER half
+of the contract: two different `context_id` values are **mutually invisible**.
+
+Two halves, one test each — both **deterministic** (no model-recall
+assertion; lesson from #482):
+
+1. **Read-side isolation (model-free).** One session seeded under TWO
+   contexts (`CTX-A` then `CTX-B`, sentinels `A-1..3` / `B-1..3`); a
+   context-scoped Message History retrieval with `CTX-A` returns every `A-*`
+   and **zero** `B-*`, and the mirrored retrieval with `CTX-B` returns every
+   `B-*` and **zero** `A-*`. The negatives are symmetric — a leak in either
+   direction fails.
+2. **Write-side isolation on the Agent (switching).** A Simple Agent run
+   with `context_id = CTX-A`, then the SAME flow **switched** to `CTX-B` and
+   run again in the same playground session: every message persisted by turn
+   1 carries exactly `CTX-A`, every message persisted by turn 2 carries
+   exactly `CTX-B` (monitor API, nonce-keyed) — switching re-tags the write
+   path with no cross-tagging.
+
+> **Unit-shift note (same deviation class as #482/#487, flagged on the PR).**
+> The Agent's prompt-side consumption of retrieved history is invisible
+> post-run (injected into the prompt, never persisted), so read-side
+> isolation is observed through Message History's Retrieve — which resolves
+> through the same context-scoped backend retrieval as the Agent's
+> `get_memory_data`. Test 2 keeps the Agent itself in the loop on the write
+> side, where switching is directly observable in persisted tags.
+
+Boundary: continuity WITHIN one context (multi-turn accumulation +
+default-vs-custom negative) is #487's spec
+(`agent-context-id-continuity.spec.ts`) — this spec proves the wall between
+two custom contexts.
+
+If this test fails, distinct `context_id` values share history — the memory
+isolation contract dies and "context as a memory layer" is a fiction.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@agents` `@components` (test 1)
+`@stable` `@regression` `@agents` `@playground` (test 2)
+
+`@stable` added after 4 clean `--retries=0` runs on the fresh nightly
+(issue #488's "Done when" includes `@stable`). `@regression` — guards the
+context tagging + scoped-retrieval isolation wiring; `@agents` — Agent memory
+surface; `@components` — Message History node drives the read-side assert;
+`@playground` — test 2 switches contexts across live playground turns.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` (fresh nightly).
+- Test 2 needs `models.json`/`providers.json` (collect-models) + an active
+  provider key; test 1 is model-free (passthrough seeding).
+- Run with `--workers=1` — test 2 loads the Simple Agent template (agent-area
+  rule). Flows are id-scoped-deleted in cleanup (`deleteFlow` helper).
+
+---
+
+## Step by step *(required)*
+
+**Test 1 — mirrored context-scoped retrievals are mutually blind (§6.3/§7.7 read half; model-free)**
+
+1. Create a passthrough Chat Input → Chat Output flow via API
+   (`createRunnableChatFlowViaApi`), PATCH its ChatInput/ChatOutput nodes to
+   set `context_id = CTX-A`.
+2. Seed 3 runs via `POST /api/v1/run` with a fixed custom `session_id` and
+   sentinels `A-1..A-3`; poll the monitor API to the exact expected count.
+3. PATCH the flow's `context_id` to `CTX-B`; seed 3 more runs, sentinels
+   `B-1..B-3`; poll to the new exact total (12 stored messages).
+4. On the flow canvas, add a Message History node (Retrieve), expose and set
+   `session_id` = the custom session, `context_id = CTX-A`, `n_messages=100`;
+   run the node, read the output inspector.
+5. **Assert (A side):** retrieval contains `A-1`, `A-2`, `A-3` and does NOT
+   contain any `B-*` sentinel.
+6. Update the node's `context_id` field to `CTX-B`, run again, read output.
+7. **Assert (B side):** retrieval contains `B-1`, `B-2`, `B-3` and does NOT
+   contain any `A-*` sentinel.
+
+**Test 2 — switching the Agent's context_id re-tags persisted messages with no cross-tagging (§6.3 switching half)**
+
+1. Load the Simple Agent template (provider/model from `models.json`/`.env`).
+2. Set `context_id = CTX-A` (unique per run) on the **Agent**, **Chat Input**
+   and **Chat Output** nodes (same advanced-field path as #487).
+3. Seed the ChatInput with nonce N1; open the Playground, send, wait.
+4. Switch `context_id` to `CTX-B` on the same three nodes; seed nonce N2;
+   send a second turn in the same playground session.
+5. **Assert (monitor API):** N1 → its session's turn-1 messages ALL carry
+   `context_id === CTX-A` and none carry `CTX-B`; N2 → turn-2 messages ALL
+   carry `CTX-B` and none carry `CTX-A`. Message sets are keyed by nonce, so
+   the two turns are disjoint by construction.
+6. No `allowFlowErrors`.
+
+---
+
+## Validation criterion *(required)*
+
+Read half: a Message History retrieval scoped to `CTX-A` over a session
+seeded under both contexts returns **all** `A-*` sentinels and **no** `B-*`
+sentinel, and the `CTX-B` retrieval mirrors it exactly. Write half: after
+switching the Agent's `context_id` between two turns, each turn's persisted
+messages carry **exactly** the context active at that turn, with zero
+cross-tagging. Containment and tag equality are exact string checks on
+persisted/rendered data — no model judgment anywhere.
+
+## Guarding against false positives *(how)*
+
+- **No model-recall asserts** — the #482 lesson applied at design time; the
+  model runs only in test 2's agent turns and is never the observable.
+- **Symmetric negatives (test 1)** — a retrieve-everything bug returns both
+  sentinel families and fails BOTH directions; a retrieve-nothing bug fails
+  the positives. Either defect is caught.
+- **Seed verified before retrieval** — exact monitor-count polls after each
+  seeding block separate "seed failed" from "isolation broken".
+- **Unique CTX-A/CTX-B/session per run** — monitor rows persist across flow
+  deletion; per-run identifiers pin every lookup to THIS run.
+- **Force-failure checks** (CONTRIBUTING §2): M1 — test 1 asserts a `B-*`
+  sentinel present in the `CTX-A` retrieval (inverted negative) ⇒ must fail;
+  M2 — test 1 expects a never-seeded sentinel ⇒ must fail; M3 — test 2
+  expects turn-2 messages tagged `CTX-A` (stale context) ⇒ must fail.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Multi-turn continuity WITHIN one context and the default-vs-custom
+  negative — `agent-context-id-continuity.spec.ts` (#487).
+- The Agent's prompt-side consumption of retrieved history (not persisted,
+  not observable post-run — see the unit-shift note).
+- `n_messages` interaction with the context layer
+  (`agent-n-messages-limit.spec.ts`).
+
+---
+
+## External dependencies *(required)*
+
+- **LLM provider API** (test 2 only): two completions.
+- `tests/helpers/provider-setup/data/models.json` + `providers.json`
+  (collect-models) — test 2.
+- No external network for test 1 (API passthrough + local retrieval).

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts
@@ -1,0 +1,607 @@
+import * as dotenv from "dotenv";
+import path from "path";
+import fs from "fs";
+import type { APIRequestContext, Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
+import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { createRunnableChatFlowViaApi } from "../../../../helpers/flows/create-runnable-chat-flow-via-api";
+import { addComponentFromSidebar } from "../../../../helpers/flows/add-component-from-sidebar";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import {
+  hasProviderEnvKeys,
+  missingProviderEnvKeys,
+  providerConfigMap,
+  type Provider,
+} from "../../../../helpers/provider-setup";
+import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+
+/**
+ * Agent context_id isolation (QA-CHECKLIST §6.3 "Switching context_id
+ * isolates history between distinct sessions" + §7.7 "Use of custom
+ * context_id for memory isolation").
+ *
+ * context_id "adds an extra layer to the local memory": stored messages are
+ * tagged with it, and history retrieval resolves through
+ * aget_agent_chat_history(session, flow, context_id, n). Continuity WITHIN
+ * one context is agent-context-id-continuity.spec.ts (#487) — this spec
+ * proves the wall BETWEEN two custom contexts.
+ *
+ * Both tests are DETERMINISTIC — no model-recall assertion (three recall
+ * designs flaked at spec level in #482; the unit-shift to the shared backend
+ * retrieval is the same deviation class, flagged on the PR):
+ *
+ *   Test 1 (read half, model-free): one session seeded under CTX-A then
+ *   CTX-B; the CTX-A-scoped Message History retrieval returns every A-*
+ *   sentinel and zero B-*, and the mirrored CTX-B retrieval returns every
+ *   B-* and zero A-*. Symmetric negatives — a leak in either direction fails.
+ *   Test 2 (write half, agent in the loop): a Simple Agent turn under CTX-A
+ *   then a second turn after SWITCHING to CTX-B persist their messages
+ *   tagged with exactly the context active at that turn (monitor API,
+ *   id-partitioned per turn) — and the switch does not re-tag turn 1.
+ *
+ * context_id is set via API PATCH on the flow nodes (the /api/v1/run payload
+ * does not carry it) — the contract is the memory layer's behavior, not the
+ * input widget.
+ */
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
+}
+
+interface ModelRecord {
+  provider: string;
+  model: string;
+}
+
+interface TestTarget {
+  label: string;
+  options: LoadSimpleAgentOptions;
+  skipReason?: string;
+}
+
+function getProviderSkipReasons(): Map<string, string> {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/providers.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
+    return new Map();
+  }
+  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
+  const reasons = new Map<string, string>();
+  for (const r of records) {
+    if (r.status === "inactive") {
+      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
+    }
+  }
+  return reasons;
+}
+
+function getModelsFromJson(): ModelRecord[] {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/models.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("models.json not found — run collect-models.spec.ts first.");
+    return [];
+  }
+  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
+}
+
+function getTestTargets(): TestTarget[] {
+  const skipReasons = getProviderSkipReasons();
+
+  if (process.env.MODEL_TEST_ID) {
+    const model = process.env.MODEL_TEST_ID;
+    const allModels = getModelsFromJson();
+    const record = allModels.find((m) => m.model === model);
+    if (!record) {
+      console.warn(`MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred.`);
+      return [{ label: `model:${model}`, options: { model } }];
+    }
+    const provider = record.provider as Provider;
+    return [{
+      label: `${provider} / ${model}`,
+      options: { provider, model },
+      skipReason: skipReasons.get(provider),
+    }];
+  }
+
+  const allModels = getModelsFromJson();
+  if (allModels.length === 0) {
+    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
+    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
+    return [{
+      label: `provider:${fallbackProvider} (fallback)`,
+      options: { provider: fallbackProvider },
+      skipReason: skipReasons.get(fallbackProvider),
+    }];
+  }
+
+  let models = allModels;
+  if (process.env.MODEL_TEST_PROVIDER) {
+    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
+  } else if (process.env.ALL_MODELS !== "true") {
+    const seen = new Set<string>();
+    models = models.filter((m) => {
+      if (seen.has(m.provider)) return false;
+      seen.add(m.provider);
+      return true;
+    });
+  }
+
+  return models.map((m) => ({
+    label: `${m.provider} / ${m.model}`,
+    options: { provider: m.provider as Provider, model: m.model },
+    skipReason: skipReasons.get(m.provider),
+  }));
+}
+
+// Flows created by test 2 are tracked here and deleted by id in afterEach —
+// loadTemplateByName does NO cleanup (post-#553 contract), and the app can
+// fire more than one flows POST during template load (only one persists;
+// deleting a transient id 404s harmlessly — deleteFlow treats 404 as done).
+const createdFlowIds: string[] = [];
+
+async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {}); // non-JSON / batch payloads
+    }
+  });
+  try {
+    await new SimpleAgentTemplatePage(page).load(options);
+  } catch (e: any) {
+    if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
+    throw e;
+  }
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, { headers: { Authorization: bearer } });
+  }
+});
+
+// The collect-listener records transient ids too — the LIVE flow is the one
+// the flows API still returns.
+async function resolveLiveFlowId(
+  request: APIRequestContext,
+  bearer: string,
+  ids: string[],
+): Promise<string> {
+  for (const id of [...ids].reverse()) {
+    const res = await request.get(`/api/v1/flows/${id}`, {
+      headers: { Authorization: bearer },
+    });
+    if (res.status() === 200) return id;
+  }
+  throw new Error(`none of the collected flow ids is live: ${JSON.stringify(ids)}`);
+}
+
+// Set context_id on the given node types via API PATCH — the run payload
+// cannot carry it; the value lives in the flow's node templates.
+async function patchContextId(
+  request: APIRequestContext,
+  bearer: string,
+  flowId: string,
+  nodeTypes: string[],
+  contextId: string,
+): Promise<void> {
+  const headers = { Authorization: bearer };
+  const res = await request.get(`/api/v1/flows/${flowId}`, { headers });
+  expect(res.status()).toBe(200);
+  const flow = await res.json();
+  let patched = 0;
+  for (const node of flow.data?.nodes ?? []) {
+    if (nodeTypes.includes(node.data?.type) && node.data?.node?.template?.context_id) {
+      node.data.node.template.context_id.value = contextId;
+      patched++;
+    }
+  }
+  expect(patched, `nodes with a context_id field among ${JSON.stringify(nodeTypes)}`).toBe(nodeTypes.length);
+  const patchRes = await request.patch(`/api/v1/flows/${flowId}`, {
+    headers,
+    data: { data: flow.data },
+  });
+  expect(patchRes.status()).toBe(200);
+}
+
+// Set the task on the ChatInput node (the Playground prompt pre-fills from it;
+// typing into the Playground races an async default re-injection).
+async function setChatInputText(page: Page, text: string): Promise<void> {
+  const field = page.locator(
+    '[data-testid^="rf__node-ChatInput"] [data-testid="textarea_str_input_value"]',
+  );
+  await expect(field).toBeVisible({ timeout: 15000 });
+  await field.click();
+  await field.fill(text);
+  await field.blur();
+}
+
+async function waitForAgentToFinish(page: Page): Promise<void> {
+  const stopButton = page.getByRole("button", { name: "Stop" });
+  const stopVisible = await stopButton.isVisible({ timeout: 10000 }).catch(() => false);
+  if (stopVisible) {
+    await expect(stopButton).toBeHidden({ timeout: 120000 });
+  }
+}
+
+async function openPlaygroundAndSend(page: Page, task: string): Promise<void> {
+  await page.getByTestId("playground-btn-flow-io").click();
+  const chatInput = page.getByTestId("input-chat-playground").last();
+  await expect(chatInput).toBeVisible({ timeout: 30000 });
+  // On a REOPEN the playground keeps the previous turn's draft instead of
+  // re-reading the ChatInput node — fill explicitly. The node holds the same
+  // string, so a late default re-injection converges on the same value.
+  await chatInput.fill(task);
+  await expect(chatInput).toHaveValue(task, { timeout: 15000 });
+  await page.getByTestId("button-send").last().click();
+  await waitForAgentToFinish(page);
+}
+
+interface MonitorMessage {
+  id: string;
+  sender: string;
+  text?: string;
+  session_id: string;
+  context_id?: string;
+}
+
+async function getMonitorMessages(
+  request: APIRequestContext,
+  bearer: string,
+): Promise<MonitorMessage[] | string> {
+  const res = await request.get("/api/v1/monitor/messages", {
+    headers: { Authorization: bearer },
+  });
+  if (res.status() !== 200) return `GET monitor -> ${res.status()}`;
+  const messages = await res.json();
+  return Array.isArray(messages) ? (messages as MonitorMessage[]) : "monitor payload not a list";
+}
+
+// Turn-1 check: every message persisted for the nonce's session carries
+// context_id === expected. Returns the turn's message ids + session, so the
+// turn-2 check can partition new messages from old by id (message counts per
+// agent turn are not fixed — id partition beats counting).
+async function expectTurnTaggedAndCollect(
+  request: APIRequestContext,
+  nonce: string,
+  expectedContext: string,
+): Promise<{ sessionId: string; messageIds: string[] }> {
+  const bearer = await getAuthToken(request);
+  let sessionId = "";
+  let messageIds: string[] = [];
+  await expect
+    .poll(
+      async () => {
+        const messages = await getMonitorMessages(request, bearer);
+        if (typeof messages === "string") return messages;
+
+        const userMsg = messages.find(
+          (m) => m.sender !== "Machine" && (m.text ?? "").includes(nonce),
+        );
+        if (!userMsg) return "user message with nonce not persisted yet";
+
+        const sessionMsgs = messages.filter((m) => m.session_id === userMsg.session_id);
+        if (sessionMsgs.length < 2) return `only ${sessionMsgs.length} session message(s) persisted yet`;
+
+        const badly = sessionMsgs.filter((m) => m.context_id !== expectedContext);
+        if (badly.length > 0) {
+          return `message(s) with wrong context_id: ${JSON.stringify(badly.map((m) => ({ sender: m.sender, context_id: m.context_id })))}`;
+        }
+        sessionId = userMsg.session_id;
+        messageIds = sessionMsgs.map((m) => m.id);
+        return "all-turn-messages-tagged";
+      },
+      { timeout: 30000 },
+    )
+    .toBe("all-turn-messages-tagged");
+  return { sessionId, messageIds };
+}
+
+// Turn-2 check: in the SAME session, every message NOT belonging to turn 1
+// carries the switched context, and every turn-1 message still carries the
+// original one (the switch must not re-tag history).
+async function expectSwitchedTurnTagging(
+  request: APIRequestContext,
+  turn1: { sessionId: string; messageIds: string[] },
+  nonce2: string,
+  turn1Context: string,
+  turn2Context: string,
+): Promise<void> {
+  const bearer = await getAuthToken(request);
+  const turn1Ids = new Set(turn1.messageIds);
+  await expect
+    .poll(
+      async () => {
+        const messages = await getMonitorMessages(request, bearer);
+        if (typeof messages === "string") return messages;
+
+        const sessionMsgs = messages.filter((m) => m.session_id === turn1.sessionId);
+        const newMsgs = sessionMsgs.filter((m) => !turn1Ids.has(m.id));
+
+        const user2 = newMsgs.find(
+          (m) => m.sender !== "Machine" && (m.text ?? "").includes(nonce2),
+        );
+        if (!user2) return "turn-2 user message not persisted yet";
+        if (newMsgs.length < 2) return `only ${newMsgs.length} turn-2 message(s) persisted yet`;
+
+        const badNew = newMsgs.filter((m) => m.context_id !== turn2Context);
+        if (badNew.length > 0) {
+          return `turn-2 message(s) with wrong context_id: ${JSON.stringify(badNew.map((m) => ({ sender: m.sender, context_id: m.context_id })))}`;
+        }
+        const badOld = sessionMsgs.filter(
+          (m) => turn1Ids.has(m.id) && m.context_id !== turn1Context,
+        );
+        return badOld.length === 0
+          ? "turns-tagged-with-their-own-context"
+          : `turn-1 message(s) re-tagged: ${JSON.stringify(badOld.map((m) => ({ sender: m.sender, context_id: m.context_id })))}`;
+      },
+      { timeout: 30000 },
+    )
+    .toBe("turns-tagged-with-their-own-context");
+}
+
+// ---------- test 1 machinery (model-free; mirrors agent-context-id-continuity) ----------
+
+const SEED_RUNS = 3;
+
+interface SeededTwoContextFlow {
+  flowId: string;
+  session: string;
+  sentinel: string;
+  contextA: string;
+  contextB: string;
+  cleanup: () => Promise<void>;
+}
+
+// Passthrough flow whose ChatInput/ChatOutput are PATCHed to CTX-A for 3
+// seeded runs (sentinels A-1..3), then to CTX-B for 3 more (B-1..3) — one
+// session, two context layers. Each seeding block is verified to the exact
+// stored count so a failed seed fails HERE, not as a silent empty retrieval.
+async function seedTwoContextSession(request: APIRequestContext): Promise<SeededTwoContextFlow> {
+  const bearer = await getAuthToken(request);
+
+  const keyRes = await request.post("/api/v1/api_key/", {
+    headers: { Authorization: bearer },
+    data: { name: `ctx-iso-${Date.now()}-${Math.random().toString(36).slice(2, 7)}` },
+  });
+  expect(keyRes.status()).toBe(200);
+  const { api_key: apiKey, id: apiKeyId } = await keyRes.json();
+
+  const { flowId, deleteFlow: deleteSeededFlow } = await createRunnableChatFlowViaApi(request, {
+    Authorization: bearer,
+  });
+
+  const sentinel = `CTXISO-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const session = `${sentinel}-session`;
+  const contextA = `${sentinel}-ctx-A`;
+  const contextB = `${sentinel}-ctx-B`;
+
+  const runOnce = async (text: string) => {
+    const runRes = await request.post(`/api/v1/run/${flowId}`, {
+      headers: { "x-api-key": apiKey },
+      data: { input_value: text, input_type: "chat", output_type: "chat", session_id: session },
+    });
+    expect(runRes.status()).toBe(200);
+  };
+  const expectStoredCount = async (count: number) => {
+    await expect
+      .poll(
+        async () => {
+          const res = await request.get(
+            `/api/v1/monitor/messages?session_id=${session}`,
+            { headers: { Authorization: bearer } },
+          );
+          if (res.status() !== 200) return -1;
+          return ((await res.json()) as unknown[]).length;
+        },
+        { timeout: 15000 },
+      )
+      .toBe(count);
+  };
+
+  await patchContextId(request, bearer, flowId, ["ChatInput", "ChatOutput"], contextA);
+  for (let i = 1; i <= SEED_RUNS; i++) await runOnce(`${sentinel}-A-${i}`);
+  await expectStoredCount(SEED_RUNS * 2);
+
+  await patchContextId(request, bearer, flowId, ["ChatInput", "ChatOutput"], contextB);
+  for (let i = 1; i <= SEED_RUNS; i++) await runOnce(`${sentinel}-B-${i}`);
+  await expectStoredCount(SEED_RUNS * 4);
+
+  return {
+    flowId,
+    session,
+    sentinel,
+    contextA,
+    contextB,
+    cleanup: async () => {
+      // Multi-step teardown: swallow so a failed flow delete still lets the
+      // API-key cleanup below run.
+      await deleteSeededFlow().catch(() => {});
+      await request
+        .delete(`/api/v1/api_key/${apiKeyId}`, { headers: { Authorization: bearer } })
+        .catch(() => {});
+    },
+  };
+}
+
+// Add a Message History node once, expose its hidden n_messages/session_id/
+// context_id fields, and pin it to the seeded session. Retrievals for the two
+// contexts then reuse the SAME node via runRetrievalScopedTo.
+async function setupMessageHistoryNode(
+  page: Page,
+  flowId: string,
+  session: string,
+): Promise<void> {
+  await page.goto(`/flow/${flowId}`);
+  await page
+    .getByTestId("sidebar-search-input")
+    .waitFor({ state: "visible", timeout: 60000 });
+
+  await addComponentFromSidebar(
+    page,
+    "message history",
+    "add-component-button-message-history",
+  );
+  const node = page.locator('[data-testid^="rf__node-Memory"]').first();
+  await expect(node).toBeVisible({ timeout: 15000 });
+
+  await page.getByTestId("title-Message History").click();
+  await page.getByTestId("edit-fields-button").click();
+  await page.getByTestId("shown_messages").click();
+  await page.getByTestId("showsession_id").click();
+  await page.getByTestId("showcontext_id").click();
+  await page.keyboard.press("Escape");
+
+  await page.getByTestId("int_int_n_messages").fill("100");
+  await page.getByTestId("popover-anchor-input-session_id").fill(session);
+}
+
+// Point the already-set-up Message History node at contextId, run it, and
+// return the retrieved text from the output inspector (default template
+// renders one line per message). Closes the inspector before returning so the
+// next scoped run starts from the canvas.
+async function runRetrievalScopedTo(page: Page, contextId: string): Promise<string> {
+  await page.getByTestId("popover-anchor-input-context_id").fill(contextId);
+  await waitForFlowSaveSettled(page);
+
+  // The success toast of a previous run must be gone before waiting on the
+  // next one, or the stale toast satisfies the wait immediately.
+  await page.waitForSelector("text=built successfully", { state: "hidden", timeout: 15000 });
+  await page.getByTestId("button_run_message history").click();
+  await page.waitForSelector("text=built successfully", { timeout: 30000 });
+
+  const inspectButton = page.getByTestId("output-inspection-messages-memory");
+  await expect(inspectButton).toBeEnabled({ timeout: 20000 });
+  await inspectButton.click();
+
+  const dialog = page.locator('[role="dialog"]').last();
+  const textarea = dialog.getByTestId("textarea");
+  await expect(textarea).toBeVisible({ timeout: 15000 });
+  const text = await textarea.inputValue();
+
+  // Escape does not close the output inspector — use its Close button.
+  await dialog.getByText("Close").last().click();
+  await expect(dialog).toBeHidden({ timeout: 10000 });
+  return text;
+}
+
+const targets = getTestTargets();
+
+// Test 2 loads the Simple Agent template — serial + --workers=1 per the
+// agent-area rule. Cleanup is id-scoped; nothing here wipes flows.
+test.describe.configure({ mode: "serial" });
+
+test.describe("Context ID isolation — retrieval layer (model-free)", () => {
+  test(
+    "mirrored context-scoped retrievals return only their own context's messages",
+    { tag: ["@stable", "@regression", "@agents", "@components"] },
+    async ({ page, request }) => {
+      const seeded = await seedTwoContextSession(request);
+      try {
+        await test.step("add a Message History node pinned to the seeded session", () =>
+          setupMessageHistoryNode(page, seeded.flowId, seeded.session));
+
+        const retrievedA = await test.step(
+          "retrieve the session scoped to CTX-A",
+          () => runRetrievalScopedTo(page, seeded.contextA),
+        );
+
+        await test.step("CTX-A retrieval: all A-* present, zero B-*", async () => {
+          for (let i = 1; i <= SEED_RUNS; i++) {
+            expect(retrievedA).toContain(`${seeded.sentinel}-A-${i}`);
+          }
+          // The symmetric negative: an unfiltered retrieve-everything bug
+          // returns the other context's sentinels too.
+          expect(retrievedA).not.toContain(`${seeded.sentinel}-B-`);
+        });
+
+        const retrievedB = await test.step(
+          "retrieve the same session scoped to CTX-B",
+          () => runRetrievalScopedTo(page, seeded.contextB),
+        );
+
+        await test.step("CTX-B retrieval: all B-* present, zero A-*", async () => {
+          for (let i = 1; i <= SEED_RUNS; i++) {
+            expect(retrievedB).toContain(`${seeded.sentinel}-B-${i}`);
+          }
+          expect(retrievedB).not.toContain(`${seeded.sentinel}-A-`);
+        });
+      } finally {
+        await seeded.cleanup();
+      }
+    },
+  );
+});
+
+for (const { label, options, skipReason } of targets) {
+  const provider = options.provider ?? (Object.keys(providerConfigMap)[0] as Provider);
+
+  test.describe(`Agent Context ID Isolation [${label}]`, () => {
+    test(
+      "switching the agent's context_id re-tags new turns without touching previous ones",
+      { tag: ["@stable", "@regression", "@agents", "@playground"] },
+      async ({ page, request }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        const nonce1 = `probe-A-${Date.now()}`;
+        const nonce2 = `probe-B-${Date.now()}`;
+        const contextA = `ctx-A-${nonce1}`;
+        const contextB = `ctx-B-${nonce1}`;
+        const task1 = `Reply with a short greeting. (${nonce1})`;
+        const task2 = `Reply with a short farewell. (${nonce2})`;
+
+        await loadAgent(page, options);
+
+        const bearer = await getAuthToken(request);
+        const flowId = await resolveLiveFlowId(request, bearer, createdFlowIds);
+
+        await test.step("set context_id = CTX-A on Agent + Chat Input + Chat Output, run turn 1", async () => {
+          await patchContextId(request, bearer, flowId, ["Agent", "ChatInput", "ChatOutput"], contextA);
+          await page.reload();
+          await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', { timeout: 30000 });
+          await setChatInputText(page, task1);
+          await waitForFlowSaveSettled(page);
+          await openPlaygroundAndSend(page, task1);
+        });
+
+        const turn1 = await test.step("turn-1 messages all tagged CTX-A", () =>
+          expectTurnTaggedAndCollect(request, nonce1, contextA));
+
+        await test.step("switch context_id to CTX-B, run turn 2 in the same session", async () => {
+          await page.keyboard.press("Escape"); // close the playground modal
+          await patchContextId(request, bearer, flowId, ["Agent", "ChatInput", "ChatOutput"], contextB);
+          await page.reload();
+          await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', { timeout: 30000 });
+          await setChatInputText(page, task2);
+          await waitForFlowSaveSettled(page);
+          await openPlaygroundAndSend(page, task2);
+        });
+
+        await test.step("turn-2 messages all tagged CTX-B; turn 1 still CTX-A", () =>
+          expectSwitchedTurnTagging(request, turn1, nonce2, contextA, contextB));
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #488

## What this adds

`agent-context-id-isolation.spec.ts` + spec doc — proves that switching `context_id` isolates history between contexts (QA-CHECKLIST §6.3 + §7.7). Sibling of #487 (`agent-context-id-continuity`): that spec proved continuity WITHIN one context; this one proves the wall BETWEEN two custom contexts, on both sides of the contract.

- **Test 1 — read half (model-free).** One session seeded under `CTX-A` (sentinels `A-1..3`) then `CTX-B` (`B-1..3`) via API passthrough runs, each seeding block verified to the exact stored count. Mirrored Message History retrievals: the `CTX-A`-scoped retrieval contains every `A-*` and zero `B-*`; the `CTX-B` retrieval mirrors it. Symmetric negatives — a leak in either direction fails.
- **Test 2 — write half (agent in the loop).** Simple Agent turn under `CTX-A`, then a second turn after switching all three nodes (Agent, Chat Input, Chat Output) to `CTX-B` in the same playground session. Monitor-API assert partitions turns by message id: turn-1 messages all tagged `CTX-A`, turn-2 (new ids) all tagged `CTX-B`, and turn-1 ids are NOT re-tagged by the switch.

## Deviation (flagged, same class as #482/#487)

The Agent's prompt-side consumption of retrieved history is not persisted and not observable post-run, so the read half is observed through Message History's Retrieve — which resolves through the same context-scoped backend retrieval (`aget_agent_chat_history(session, flow, context_id, n)`) as the Agent's `get_memory_data`. No model-recall assertion anywhere. Documented in the spec doc's unit-shift note.

## Validation

- Langflow nightly **1.11.0.dev36** (confirmed latest published image at validation time)
- 4 clean `--retries=0` runs per test (isolated greens + 3 full-file bursts + final post-FF green), `--workers=1`; results confirmed via JSON reporter stats
- Force-fail executed (all red, revert proven with 0 `FF-MUTATION` markers + final green):
  - M1 — inverted negative: `B-1` expected present in the `CTX-A` retrieval → failed
  - M2 — never-seeded sentinel (`B-4`) expected present → failed
  - M3 — stale context: turn 2 expected tagged `CTX-A` → failed (poll reported the real `ctx-B-…` tag)
- `npm run typecheck` ✓, `npm run lint` 0 errors ✓, zero `🚨 Backend Error`
- 0 orphan flows after 9 runs (id-scoped cleanup via `deleteFlow` helper, including on the FF failure paths)
- `--trace=on` skipped — known limitation: tracing hangs Simple Agent–template specs locally; covered by `--retries=0` bursts + executed force-fails (CI captures trace on first retry)
- Implementation fixes found via red runs: output inspector needs its Close button (Escape does not close it); a reopened playground keeps the previous turn's draft instead of re-reading the ChatInput node — explicit `fill`
- QA-CHECKLIST bullets §6.3 (line 348) and §7.7 (line 419) flipped to `[x]`; generated blocks untouched (regenerate on merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)