### PR TITLE
fix(flows): open flows via list-card-open-button after /flows a11y refactor

### DIFF
--- a/tests/helpers/flows/setup-blank-flow.ts
+++ b/tests/helpers/flows/setup-blank-flow.ts
@@ -52,9 +52,15 @@ export async function setupBlankFlow(page: Page): Promise<string> {
     // immediately after an API-created flow, the direct URL hits a stale
     // React Router cache and redirects back to the flows list.
     await page.goto("/");
+    // The /flows a11y refactor (Langflow #13891) wraps each card in an
+    // `list-card-open-button` overlay and makes `flow-name-div`
+    // `pointer-events-none`, so we open the flow via the overlay button.
     await page
-      .getByTestId("flow-name-div")
-      .filter({ hasText: flowName })
+      .getByTestId("list-card")
+      .filter({
+        has: page.getByTestId("flow-name-div").filter({ hasText: flowName }),
+      })
+      .getByTestId("list-card-open-button")
       .first()
       .click();
     await expect(page.getByTestId("canvas_controls_dropdown")).toBeVisible({

--- a/tests/tests-automations/regression/core-components/agent-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/agent-component-regression.spec.ts
@@ -105,7 +105,18 @@ test.describe("Agent Component — canvas regression", () => {
       await page.waitForSelector('[data-testid="mainpage_title"]', {
         timeout: 15000,
       });
-      await page.getByText(flowName, { exact: true }).click();
+      // The /flows a11y refactor (Langflow #13891) makes the card content
+      // pointer-events-none; open the flow via the card's overlay button.
+      await page
+        .getByTestId("list-card")
+        .filter({
+          has: page
+            .getByTestId("flow-name-div")
+            .filter({ hasText: flowName }),
+        })
+        .getByTestId("list-card-open-button")
+        .first()
+        .click();
 
       await expect(page.getByTestId("title-Agent")).toBeVisible({
         timeout: 15000,

--- a/tests/tests-automations/regression/core-components/nested-grouping-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/nested-grouping-regression.spec.ts
@@ -41,9 +41,14 @@ async function createTwoNodeFlow(page: Page): Promise<string> {
   // Going via the dashboard avoids the stale-cache redirect that
   // `page.goto("/flow/${id}")` triggers right after an API-created flow.
   await page.goto("/");
+  // The /flows a11y refactor (Langflow #13891) makes `flow-name-div`
+  // `pointer-events-none`; open the flow via the card's overlay button.
   await page
-    .getByTestId("flow-name-div")
-    .filter({ hasText: body.name })
+    .getByTestId("list-card")
+    .filter({
+      has: page.getByTestId("flow-name-div").filter({ hasText: body.name }),
+    })
+    .getByTestId("list-card-open-button")
     .first()
     .click();
   await expect(page.getByTestId("canvas_controls_dropdown")).toBeVisible({

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-config-persistence.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-config-persistence.spec.ts
@@ -159,7 +159,14 @@ test(
     await test.step("reopen the flow from the home page", async () => {
       await page.goto("/");
       await page.waitForSelector('[data-testid="mainpage_title"]', { timeout: 30000 });
-      await page.getByTestId(`flow-name-${flowId}`).click();
+      // The /flows a11y refactor (Langflow #13891) makes the card content
+      // pointer-events-none; open the flow via the card's overlay button.
+      await page
+        .getByTestId("list-card")
+        .filter({ has: page.getByTestId(`flow-name-${flowId}`) })
+        .getByTestId("list-card-open-button")
+        .first()
+        .click();
       await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
         timeout: 30000,
       });

--- a/tests/tests-automations/regression/core-functionality/project-management/edit-flow-name.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/edit-flow-name.spec.ts
@@ -36,7 +36,16 @@ test(
 
       // Re-open the flow by clicking its name in the listing — required so the next
       // iteration starts inside the editor with renameFlow() targeting the flow header.
-      await page.getByText(targetName).click();
+      // The /flows a11y refactor (Langflow #13891) makes the card content
+      // pointer-events-none; open the flow via the card's overlay button.
+      await page
+        .getByTestId("list-card")
+        .filter({
+          has: page.getByTestId("flow-name-div").filter({ hasText: targetName }),
+        })
+        .getByTestId("list-card-open-button")
+        .first()
+        .click();
     }
   },
 );

--- a/tests/tests-automations/regression/flow-functionality/auto-save-off.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/auto-save-off.spec.ts
@@ -74,14 +74,14 @@ test(
 
     // The /flows a11y refactor (Langflow #13891) makes `flow-name-div`
     // `pointer-events-none`; open the flow via the card's overlay button.
-    const newFlowDiv = page
+    const flowOpenButton = page
       .getByTestId("list-card")
       .filter({
         has: page.getByTestId("flow-name-div").filter({ hasText: "New Flow" }),
       })
       .getByTestId("list-card-open-button")
       .first();
-    await newFlowDiv.click();
+    await flowOpenButton.click();
 
     await page.waitForSelector('[data-testid="sidebar-search-input"]', {
       timeout: 5000,
@@ -126,14 +126,14 @@ test(
     await page.getByText("Save And Exit", { exact: true }).click();
 
     // See note above: open the flow via the card's overlay button.
-    const newFlow = page
+    const flowOpenButton2 = page
       .getByTestId("list-card")
       .filter({
         has: page.getByTestId("flow-name-div").filter({ hasText: "New Flow" }),
       })
       .getByTestId("list-card-open-button")
       .first();
-    await newFlow.click();
+    await flowOpenButton2.click();
 
     await page.waitForSelector("text=loading", {
       state: "hidden",
@@ -182,14 +182,14 @@ test(
     }
 
     // See note above: open the flow via the card's overlay button.
-    const newFlow2 = page
+    const flowOpenButton3 = page
       .getByTestId("list-card")
       .filter({
         has: page.getByTestId("flow-name-div").filter({ hasText: "New Flow" }),
       })
       .getByTestId("list-card-open-button")
       .first();
-    await newFlow2.click();
+    await flowOpenButton3.click();
 
     await page.waitForSelector('[data-testid="sidebar-search-input"]', {
       timeout: 5000,

--- a/tests/tests-automations/regression/flow-functionality/auto-save-off.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/auto-save-off.spec.ts
@@ -72,9 +72,14 @@ test(
       console.error("Warning text not visible, skipping dialog confirmation");
     }
 
-    const newFlowDiv = await page
-      .getByTestId("flow-name-div")
-      .filter({ hasText: "New Flow" })
+    // The /flows a11y refactor (Langflow #13891) makes `flow-name-div`
+    // `pointer-events-none`; open the flow via the card's overlay button.
+    const newFlowDiv = page
+      .getByTestId("list-card")
+      .filter({
+        has: page.getByTestId("flow-name-div").filter({ hasText: "New Flow" }),
+      })
+      .getByTestId("list-card-open-button")
       .first();
     await newFlowDiv.click();
 
@@ -120,9 +125,13 @@ test(
 
     await page.getByText("Save And Exit", { exact: true }).click();
 
-    const newFlow = await page
-      .getByTestId("flow-name-div")
-      .filter({ hasText: "New Flow" })
+    // See note above: open the flow via the card's overlay button.
+    const newFlow = page
+      .getByTestId("list-card")
+      .filter({
+        has: page.getByTestId("flow-name-div").filter({ hasText: "New Flow" }),
+      })
+      .getByTestId("list-card-open-button")
       .first();
     await newFlow.click();
 
@@ -172,9 +181,13 @@ test(
       await page.getByText("Save And Exit", { exact: true }).last().click();
     }
 
-    const newFlow2 = await page
-      .getByTestId("flow-name-div")
-      .filter({ hasText: "New Flow" })
+    // See note above: open the flow via the card's overlay button.
+    const newFlow2 = page
+      .getByTestId("list-card")
+      .filter({
+        has: page.getByTestId("flow-name-div").filter({ hasText: "New Flow" }),
+      })
+      .getByTestId("list-card-open-button")
       .first();
     await newFlow2.click();
 

--- a/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
@@ -784,9 +784,14 @@ test(
 
     await awaitBootstrapTest(page, { skipModal: true });
 
+    // The /flows a11y refactor (Langflow #13891) makes `flow-name-div`
+    // `pointer-events-none`; open the flow via the card's overlay button.
     const newFlowDiv = page
-      .getByTestId("flow-name-div")
-      .filter({ hasText: "New Flow" })
+      .getByTestId("list-card")
+      .filter({
+        has: page.getByTestId("flow-name-div").filter({ hasText: "New Flow" }),
+      })
+      .getByTestId("list-card-open-button")
       .first();
     await newFlowDiv.waitFor({ state: "visible", timeout: 10000 });
     await newFlowDiv.click();
@@ -894,9 +899,13 @@ test(
 
     await awaitBootstrapTest(page, { skipModal: true });
 
+    // See note above: open the flow via the card's overlay button.
     const newFlowDiv2 = page
-      .getByTestId("flow-name-div")
-      .filter({ hasText: "New Flow" })
+      .getByTestId("list-card")
+      .filter({
+        has: page.getByTestId("flow-name-div").filter({ hasText: "New Flow" }),
+      })
+      .getByTestId("list-card-open-button")
       .first();
     await newFlowDiv2.waitFor({ state: "visible", timeout: 10000 });
     await newFlowDiv2.click();

--- a/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
@@ -786,15 +786,15 @@ test(
 
     // The /flows a11y refactor (Langflow #13891) makes `flow-name-div`
     // `pointer-events-none`; open the flow via the card's overlay button.
-    const newFlowDiv = page
+    const flowOpenButton = page
       .getByTestId("list-card")
       .filter({
         has: page.getByTestId("flow-name-div").filter({ hasText: "New Flow" }),
       })
       .getByTestId("list-card-open-button")
       .first();
-    await newFlowDiv.waitFor({ state: "visible", timeout: 10000 });
-    await newFlowDiv.click();
+    await flowOpenButton.waitFor({ state: "visible", timeout: 10000 });
+    await flowOpenButton.click();
 
     // Wait for the MCP Tools component to be visible on canvas
     await page.waitForSelector('text="MCP Tools"', {
@@ -900,15 +900,15 @@ test(
     await awaitBootstrapTest(page, { skipModal: true });
 
     // See note above: open the flow via the card's overlay button.
-    const newFlowDiv2 = page
+    const flowOpenButton2 = page
       .getByTestId("list-card")
       .filter({
         has: page.getByTestId("flow-name-div").filter({ hasText: "New Flow" }),
       })
       .getByTestId("list-card-open-button")
       .first();
-    await newFlowDiv2.waitFor({ state: "visible", timeout: 10000 });
-    await newFlowDiv2.click();
+    await flowOpenButton2.waitFor({ state: "visible", timeout: 10000 });
+    await flowOpenButton2.click();
 
     // Wait for the MCP Tools component to be visible on canvas
     await page.waitForSelector('text="MCP Tools"', {


### PR DESCRIPTION
Closes #568

## Context

Langflow [#13891](https://github.com/langflow-ai/langflow/pull/13891)
(*"clear /flows page a11y debt"*, nightly-only, after `v1.10.2`) wrapped each
`/flows` card in a `<button data-testid="list-card-open-button">` overlay
(`absolute inset-0`, carries the navigation `onClick`) and made the card content
— including `flow-name-div` — `pointer-events-none`. Clicking `flow-name-div` to
open a flow no longer works; the overlay intercepts pointer events. This broke
the shared `setupBlankFlow` helper and caused a mass `@stable` failure in the
daily run (#566, 28 hard failures all rooted at `setup-blank-flow.ts`).

## Change

Migrate every open-flow click to filter the `list-card` by name and click its
`list-card-open-button`:

```ts
await page
  .getByTestId("list-card")
  .filter({ has: page.getByTestId("flow-name-div").filter({ hasText: flowName }) })
  .getByTestId("list-card-open-button")
  .first()
  .click();
```

Sites migrated:
- `tests/helpers/flows/setup-blank-flow.ts` — shared helper, root of the mass failure
- `core-components/nested-grouping-regression.spec.ts`
- `flow-functionality/auto-save-off.spec.ts` (3 sites)
- `mcp/server/mcp-server.spec.ts` (2 sites)

Read-only `flow-name-div` `toHaveText` assertions (e.g. `bulk-actions.spec.ts`)
still work and were left untouched.

## Product-regression verification (nightly `1.11.0.dev36`)

Confirmed against a running nightly instance — **benign a11y refactor, selector
update only**:
- Clicking a flow card opens the flow via the `list-card-open-button` overlay ✅
- Keyboard/focus (native `<button>` + Enter) opens the flow ✅
- Selection checkbox (`checkbox-<id>`) marks and shows the bulk-action toolbar ✅
- Per-card dropdown (`home-dropdown-menu`) opens Edit/Export/Duplicate/Delete + confirm modal ✅
- `flow-name-div` is `pointer-events:none` (root cause confirmed)

## Validation

| Spec | Result |
|---|---|
| `nested-grouping-regression` (2 `@stable`) | ✅ pass |
| `singleton-components` + `edit-sticky-note` (9 `@stable`, via `setupBlankFlow`) | ✅ pass |
| `auto-save-off` | ✅ pass |
| `npm run typecheck` / `npm run lint` | ✅ (0 errors) |

`@stable` retained on all affected specs.

## Note on `mcp-server.spec.ts`

The selector migration in this spec is correct and matches the pattern validated
green elsewhere, but the test (`:622`, `@release`) cannot be exercised
end-to-end on nightly due to a **separate, pre-existing test-logic bug** upstream
of the migrated lines: the `canvas_controls_dropdown` menu is left open and its
overlay intercepts the next click (`<html> intercepts pointer events`). Tracked
independently in #576.