### PR TITLE
test(llm-agents): add agent structured output spec (#491)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -356,7 +356,7 @@
 
 #### 6.5 Output and Reasoning
 - [ ] Inspect tools used by Agent in Playground
-- [ ] Agent returns output in structured JSON format (output_schema) → `agent-structured-output.spec.ts`
+- [x] Agent returns output in structured JSON format (output_schema) → `agent-structured-output.spec.ts`
 - [ ] Agent returns output in correctly rendered Markdown
 - [x] Agent Instructions (system prompt) is respected in the model response → `agent-system-prompt.spec.ts`
 - [x] Input via direct field vs handle (ChatInput) — both work → `core-functionality/llm-agents/agent-input-sources.spec.ts`
@@ -417,7 +417,7 @@
 - [x] Maximum token count — response truncated as configured → `llm-agents/agent-max-tokens.spec.ts`
 - [x] Maximum agent iterations → `core-functionality/llm-agents/agent-max-iterations.spec.ts`
 - [x] Use of custom `context_id` for memory isolation → `agent-context-id-isolation.spec.ts`
-- [ ] Output formatting (JSON via output_schema, Markdown, plain text) → `agent-structured-output.spec.ts`
+- [x] Output formatting (JSON via output_schema, Markdown, plain text) → `agent-structured-output.spec.ts`
 
 ---
 

--- a/docs/core-functionality/llm-agents/agent-structured-output.md
+++ b/docs/core-functionality/llm-agents/agent-structured-output.md
@@ -1,0 +1,163 @@
+# Agent structured output — output_schema returns schema-shaped JSON
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+QA-CHECKLIST §6.5 "Agent returns output in structured JSON format
+(output_schema)" and the JSON half of §7.7 "Output formatting (JSON via
+output_schema, Markdown, plain text)".
+
+The Agent component exposes an advanced `output_schema` TableInput (rows:
+`name`, `description`, `type` ∈ {str,int,float,bool,dict}, `multiple`) and a
+second output **`structured_response`** (`json_response` → `Data`). Verified
+live on the 1.11 nightly source (`agent.py`): with **no tools** attached the
+orchestrator takes the **native path** (`with_structured_output`,
+provider-validated JSON, agent loop bypassed); with tools it falls back to a
+schema-augmented prompt + parse. This spec pins the native path — the
+strongest, least model-dependent form of the contract — by disabling the
+Agent's built-in tool toggles (`add_current_date_tool`,
+`add_calculator_tool`).
+
+Two tests, both asserting **structure, never content quality**:
+
+1. **Schema fields come back as typed JSON keys.** Schema
+   `{name: str, age: int}` + an input whose extraction is trivial ("John is
+   25 years old."): the `structured_response` output parses as JSON and has
+   key `name` of type string and key `age` of type number. Values are the
+   model's extraction — asserted only for presence and type, not exact
+   content.
+2. **The schema knob causally drives the shape.** Same machinery, one schema
+   row with `multiple = true` (`colors: str`, As List) + "The flag is red,
+   white and blue.": the parsed `colors` key is an **array** (of strings).
+   Proves the returned shape follows the schema definition, not a fixed
+   JSON habit of the model.
+
+Determinism note: the model fills VALUES (non-deterministic), but the SHAPE
+is enforced by the provider's structured-output mode on the native path —
+the asserts touch only the shape (parse + key presence + typeof). Same
+class as the merged agent specs: LLM in the loop, deterministic observable.
+
+Boundary (flagged on the PR): §7.7 also names Markdown and plain-text
+formatting — those are model content choices with no schema contract to
+assert deterministically; this spec covers the bullet's `output_schema`/JSON
+contract only.
+
+If this test fails, `output_schema` no longer shapes the agent's structured
+output — the structured-output contract (§6.5) is broken.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@regression` `@agents` `@components`
+
+`@stable` added after 4 clean `--retries=0` runs on the fresh nightly (issue
+#491's "Done when" includes `@stable`). `@regression` — guards the
+output_schema → structured_response wiring; `@agents` — Agent surface;
+`@components` — the assert reads the node's output inspector on the canvas.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` (fresh nightly).
+- `models.json`/`providers.json` (collect-models) + an active provider key
+  (one completion per test).
+- Run with `--workers=1` — loads the Simple Agent template (agent-area
+  rule). Flows are id-scoped-deleted in cleanup (`deleteFlow` helper).
+
+---
+
+## Step by step *(required)*
+
+**Test 1 — output_schema fields return as typed JSON keys (§6.5)**
+
+1. Load the Simple Agent template (provider/model from `models.json`/`.env`).
+2. Via API PATCH on the Agent node template (advanced fields, same
+   mechanism as the context_id specs): set
+   `output_schema = [{name: "name", type: "str"}, {name: "age", type: "int"}]`,
+   set `add_current_date_tool = false` and `add_calculator_tool = false`
+   (no tools ⇒ native structured-output path). Reload.
+3. Set the Chat Input text to a trivially extractable sentence carrying a
+   per-run nonce ("John is 25 years old. (nonce)").
+4. Run the **Agent node** (node run button) and open the output inspector of
+   the **Structured Response** output.
+5. **Assert:** the inspector payload parses as JSON; the parsed object (or
+   first element, if the orchestrator returns a list) has key `name` with a
+   string value and key `age` with a number value.
+6. No `allowFlowErrors`.
+
+**Test 2 — a `multiple` (As List) schema row returns an array (§7.7 JSON shape)**
+
+1. Same template load + PATCH mechanism; schema
+   `[{name: "colors", type: "str", multiple: true}]`, tools off.
+2. Chat Input: "The flag is red, white and blue. (nonce)".
+3. Run the Agent node, open the Structured Response inspector.
+4. **Assert:** parsed JSON has key `colors` whose value is an **Array** with
+   length ≥ 1 and every element of type string.
+
+---
+
+## Validation criterion *(required)*
+
+The Structured Response output of an Agent configured with an
+`output_schema` parses as JSON whose keys and JS types match the schema rows
+exactly as defined (str → string, int → number, multiple → Array). The
+causal control is the schema itself: changing a row's `multiple` flag
+changes the returned shape. All asserts are parse/typeof checks on the
+persisted output — never on the model's wording.
+
+## Guarding against false positives *(how)*
+
+- **Shape-only asserts** — no expected VALUES from the model (no
+  `age === 25`), so a differently-phrased extraction cannot flake the test;
+  a missing/mistyped key always fails it.
+- **Native path pinned** — tools disabled via the same PATCH, so the
+  provider-validated structured output (not the looser prompt-fallback
+  parser) is under test; a silent fallback regression that stops honoring
+  the schema fails the typeof asserts.
+- **Trivial extraction inputs** — the sentence literally contains the
+  schema fields, removing extraction ambiguity as a flake source.
+- **Per-run nonce** in the input pins any monitor/debug lookup to THIS run.
+- **Error-shape guard** — `json_response` returns
+  `{content: "", error: …}` on orchestration failure; the key/typeof
+  asserts fail on that shape (no key `name`/`colors`), so an errored run
+  cannot pass silently.
+- **Model-selection guards (setup stabilization, found via live flake
+  hunt).** The node run builds from the frontend's in-memory graph, and the
+  canvas's `custom_component/update` storm intermittently DROPS the Agent's
+  model selection (`__default_language_model__ variable not found` in the
+  backend log) — the build then falls back to the legacy default model of an
+  inactive provider and never reports success (~1/5 observed). Two guards:
+  the API PATCH polls the flow until the POM's model selection is autosaved
+  before writing (write-clobber race), and the run helper re-checks the
+  node's model widget right before running, reloading (bounded ×3) until the
+  selection is present. Product-bug candidate — flagged on the PR; the
+  structured-output asserts are untouched by both guards.
+- **Force-failure checks** (CONTRIBUTING §2): M1 — test 1 expects a key
+  absent from the schema (`city`) ⇒ must fail; M2 — test 1 expects `age` to
+  be a string (wrong type) ⇒ must fail; M3 — test 2 expects `colors` NOT to
+  be an array ⇒ must fail.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Markdown / plain-text output formatting (the §7.7 remainder) — model
+  content choices without a schema contract; no deterministic observable.
+- The prompt-fallback path (tools attached) — weaker parser-based contract;
+  the native path is the schema contract proper.
+- Value correctness of the extraction (model judgment).
+- The Response (unstructured) output — covered by the playground specs.
+
+---
+
+## External dependencies *(required)*
+
+- **LLM provider API**: one completion per test (structured-output capable
+  model — gemini/openai class).
+- `tests/helpers/provider-setup/data/models.json` + `providers.json`
+  (collect-models).

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-structured-output.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-structured-output.spec.ts
@@ -1,0 +1,449 @@
+import * as dotenv from "dotenv";
+import path from "path";
+import fs from "fs";
+import type { APIRequestContext, Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
+import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import {
+  hasProviderEnvKeys,
+  missingProviderEnvKeys,
+  providerConfigMap,
+  type Provider,
+} from "../../../../helpers/provider-setup";
+import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+
+/**
+ * Agent structured output (QA-CHECKLIST §6.5 "Agent returns output in
+ * structured JSON format (output_schema)" + the JSON half of §7.7 "Output
+ * formatting").
+ *
+ * The Agent's advanced output_schema TableInput drives its second output,
+ * Structured Response (json_response -> Data). With NO tools attached the
+ * orchestrator takes the native path (with_structured_output — provider-
+ * validated JSON, agent loop bypassed); this spec pins that strongest form
+ * of the contract by stripping the template's tool edges and disabling the
+ * built-in tool toggles via API PATCH.
+ *
+ * Both tests assert STRUCTURE, never content quality: the model fills the
+ * values (non-deterministic), the provider's structured-output mode enforces
+ * the shape (deterministic). Asserts are JSON.parse + key presence + typeof,
+ * tolerant of extra keys the orchestrator may add (e.g. default_value —
+ * observed live on the 1.11 nightly).
+ *
+ *   Test 1 — schema {name: str, age: int}: parsed output has key `name` of
+ *   type string and key `age` of type number.
+ *   Test 2 — causal control on the schema knob: one row with multiple=true
+ *   ({colors: str, As List}) comes back as an Array of strings — the shape
+ *   follows the schema definition, not a fixed JSON habit of the model.
+ */
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
+}
+
+interface ModelRecord {
+  provider: string;
+  model: string;
+}
+
+interface TestTarget {
+  label: string;
+  options: LoadSimpleAgentOptions;
+  skipReason?: string;
+}
+
+function getProviderSkipReasons(): Map<string, string> {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/providers.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
+    return new Map();
+  }
+  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
+  const reasons = new Map<string, string>();
+  for (const r of records) {
+    if (r.status === "inactive") {
+      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
+    }
+  }
+  return reasons;
+}
+
+function getModelsFromJson(): ModelRecord[] {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/models.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("models.json not found — run collect-models.spec.ts first.");
+    return [];
+  }
+  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
+}
+
+function getTestTargets(): TestTarget[] {
+  const skipReasons = getProviderSkipReasons();
+
+  if (process.env.MODEL_TEST_ID) {
+    const model = process.env.MODEL_TEST_ID;
+    const allModels = getModelsFromJson();
+    const record = allModels.find((m) => m.model === model);
+    if (!record) {
+      console.warn(`MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred.`);
+      return [{ label: `model:${model}`, options: { model } }];
+    }
+    const provider = record.provider as Provider;
+    return [{
+      label: `${provider} / ${model}`,
+      options: { provider, model },
+      skipReason: skipReasons.get(provider),
+    }];
+  }
+
+  const allModels = getModelsFromJson();
+  if (allModels.length === 0) {
+    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
+    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
+    return [{
+      label: `provider:${fallbackProvider} (fallback)`,
+      options: { provider: fallbackProvider },
+      skipReason: skipReasons.get(fallbackProvider),
+    }];
+  }
+
+  let models = allModels;
+  if (process.env.MODEL_TEST_PROVIDER) {
+    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
+  } else if (process.env.ALL_MODELS !== "true") {
+    const seen = new Set<string>();
+    models = models.filter((m) => {
+      if (seen.has(m.provider)) return false;
+      seen.add(m.provider);
+      return true;
+    });
+  }
+
+  return models.map((m) => ({
+    label: `${m.provider} / ${m.model}`,
+    options: { provider: m.provider as Provider, model: m.model },
+    skipReason: skipReasons.get(m.provider),
+  }));
+}
+
+// Flows created by the template load are tracked here and deleted by id in
+// afterEach — loadTemplateByName does NO cleanup (post-#553 contract), and the
+// app can fire more than one flows POST during template load (only one
+// persists; deleting a transient id 404s harmlessly — deleteFlow treats 404
+// as done).
+const createdFlowIds: string[] = [];
+
+async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {}); // non-JSON / batch payloads
+    }
+  });
+  try {
+    await new SimpleAgentTemplatePage(page).load(options);
+  } catch (e: any) {
+    if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
+    throw e;
+  }
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, { headers: { Authorization: bearer } });
+  }
+});
+
+// The collect-listener records transient ids too — the LIVE flow is the one
+// the flows API still returns.
+async function resolveLiveFlowId(
+  request: APIRequestContext,
+  bearer: string,
+  ids: string[],
+): Promise<string> {
+  for (const id of [...ids].reverse()) {
+    const res = await request.get(`/api/v1/flows/${id}`, {
+      headers: { Authorization: bearer },
+    });
+    if (res.status() === 200) return id;
+  }
+  throw new Error(`none of the collected flow ids is live: ${JSON.stringify(ids)}`);
+}
+
+interface SchemaRow {
+  name: string;
+  description: string;
+  type: "str" | "int" | "float" | "bool" | "dict";
+  multiple: "True" | "False";
+}
+
+// Configure the Agent for the NATIVE structured-output path via API PATCH:
+// set the output_schema rows, disable the built-in tool toggles, and strip
+// the template's tool edges (URL / Web Search) — json_response only bypasses
+// the agent loop when NO tools are attached.
+//
+// The GET polls until the Agent node's template carries the model the POM
+// selected: the model choice lands via ASYNC autosave, and a GET+PATCH that
+// races it writes the stale default model back (observed live: the agent
+// then built with the inactive provider's default and the run hung — ~1/5
+// failure rate before this guard).
+async function patchStructuredOutputSetup(
+  request: APIRequestContext,
+  bearer: string,
+  flowId: string,
+  expectedModel: string | undefined,
+  schema: SchemaRow[],
+): Promise<void> {
+  const headers = { Authorization: bearer };
+  let flow: any;
+  await expect
+    .poll(
+      async () => {
+        const res = await request.get(`/api/v1/flows/${flowId}`, { headers });
+        if (res.status() !== 200) return `GET flow -> ${res.status()}`;
+        flow = await res.json();
+        const agentNode = (flow.data?.nodes ?? []).find(
+          (n: any) => n.data?.type === "Agent",
+        );
+        if (!agentNode) return "no Agent node";
+        if (
+          expectedModel &&
+          !JSON.stringify(agentNode.data.node?.template?.model ?? "").includes(expectedModel)
+        ) {
+          return "model selection not autosaved yet";
+        }
+        return "flow-ready";
+      },
+      { timeout: 20000 },
+    )
+    .toBe("flow-ready");
+
+  let patched = 0;
+  for (const node of flow.data?.nodes ?? []) {
+    if (node.data?.type === "Agent") {
+      const template = node.data.node?.template;
+      expect(template?.output_schema, "Agent node has an output_schema field").toBeTruthy();
+      template.output_schema.value = schema;
+      template.add_current_date_tool.value = false;
+      template.add_calculator_tool.value = false;
+      patched++;
+    }
+  }
+  expect(patched, "exactly one Agent node in the template").toBe(1);
+
+  const beforeEdges = (flow.data?.edges ?? []).length;
+  flow.data.edges = (flow.data?.edges ?? []).filter(
+    (e: { target?: string; data?: { targetHandle?: unknown } }) =>
+      !(e.target?.startsWith("Agent") && JSON.stringify(e.data?.targetHandle ?? "").includes("tools")),
+  );
+  expect(
+    flow.data.edges.length,
+    "the template's tool edges were found and removed",
+  ).toBeLessThan(beforeEdges);
+
+  const patchRes = await request.patch(`/api/v1/flows/${flowId}`, {
+    headers,
+    data: { data: flow.data },
+  });
+  expect(patchRes.status()).toBe(200);
+}
+
+// Set the task on the ChatInput node (the Agent's input_value resolves from
+// it when the node runs).
+async function setChatInputText(page: Page, text: string): Promise<void> {
+  const field = page.locator(
+    '[data-testid^="rf__node-ChatInput"] [data-testid="textarea_str_input_value"]',
+  );
+  await expect(field).toBeVisible({ timeout: 15000 });
+  await field.click();
+  await field.fill(text);
+  await field.blur();
+}
+
+// Switch the Agent node's visible output to Structured Response, run the
+// node, open the output inspector, and return the payload parsed as JSON.
+// The inspector renders the Data output as pretty-printed JSON — the parse
+// slices the dialog text from the first "{" to the last "}".
+//
+// The node run builds from the FRONTEND's in-memory graph (the v2 workflows
+// payload embeds data.nodes), and the canvas's custom_component/update storm
+// intermittently drops the Agent's model selection from that state — the
+// build then silently falls back to the legacy default model of an inactive
+// provider and hangs the success toast (observed ~1/5 pre-guard; product-bug
+// candidate flagged on the PR). The gate below re-checks the node's model
+// widget right before running and reloads (bounded) until the selection is
+// present — setup stabilization only; the structured-output asserts are
+// untouched.
+async function runAgentAndParseStructuredOutput(
+  page: Page,
+  expectedModel: string | undefined,
+): Promise<Record<string, unknown>> {
+  if (expectedModel) {
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      const widget = await page
+        .getByTestId("model_model")
+        .innerText()
+        .catch(() => "");
+      if (widget.includes(expectedModel)) break;
+      expect(
+        attempt,
+        `Agent model widget lost the selection (shows "${widget}", expected "${expectedModel}") after 3 reloads`,
+      ).toBeLessThan(3);
+      await page.reload();
+      await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', { timeout: 30000 });
+    }
+  }
+
+  await page.getByTestId("dropdown-output-undefined").click();
+  await page.getByTestId("dropdown-item-output-undefined-structured response").click();
+  await waitForFlowSaveSettled(page);
+
+  await page.getByTestId("button_run_agent").click();
+  try {
+    await page.waitForSelector("text=built successfully", { timeout: 120000 });
+  } catch (e) {
+    // Fail with WHAT the build reported instead of a bare toast timeout.
+    const toasts = await page
+      .$$eval("[data-sonner-toast], .Toastify__toast", (els) =>
+        els.map((el) => (el as HTMLElement).innerText.slice(0, 200)),
+      )
+      .catch(() => []);
+    throw new Error(
+      `Agent build did not report success; visible toasts: ${JSON.stringify(toasts)}`,
+      { cause: e },
+    );
+  }
+
+  const inspectButton = page.getByTestId("output-inspection-structured response-agent");
+  await expect(inspectButton).toBeEnabled({ timeout: 20000 });
+  await inspectButton.click();
+
+  const dialog = page.locator('[role="dialog"]').last();
+  await expect(dialog).toBeVisible({ timeout: 15000 });
+  const raw = await dialog.innerText();
+  const start = raw.indexOf("{");
+  const end = raw.lastIndexOf("}");
+  expect(start, `inspector payload contains JSON (got: ${raw.slice(0, 200)})`).toBeGreaterThanOrEqual(0);
+  const parsed = JSON.parse(raw.slice(start, end + 1)) as Record<string, unknown>;
+
+  await dialog.getByTestId("btn-close-modal").click();
+  await expect(dialog).toBeHidden({ timeout: 10000 });
+  return parsed;
+}
+
+const targets = getTestTargets();
+
+// Loads the Simple Agent template — serial + --workers=1 per the agent-area
+// rule. Cleanup is id-scoped; nothing here wipes flows.
+test.describe.configure({ mode: "serial" });
+
+for (const { label, options, skipReason } of targets) {
+  const provider = options.provider ?? (Object.keys(providerConfigMap)[0] as Provider);
+
+  test.describe(`Agent Structured Output [${label}]`, () => {
+    test(
+      "output_schema fields come back as typed JSON keys on the structured response",
+      { tag: ["@stable", "@regression", "@agents", "@components"] },
+      async ({ page, request }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        const nonce = `so-${Date.now()}`;
+
+        await loadAgent(page, options);
+        const bearer = await getAuthToken(request);
+        const flowId = await resolveLiveFlowId(request, bearer, createdFlowIds);
+
+        await test.step("configure output_schema {name: str, age: int} and strip tools via API", async () => {
+          await patchStructuredOutputSetup(request, bearer, flowId, options.model, [
+            { name: "name", description: "the person's name", type: "str", multiple: "False" },
+            { name: "age", description: "the person's age in years", type: "int", multiple: "False" },
+          ]);
+          await page.reload();
+          await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', { timeout: 30000 });
+        });
+
+        await test.step("seed a trivially extractable task", async () => {
+          await setChatInputText(page, `John is 25 years old. (${nonce})`);
+          await waitForFlowSaveSettled(page);
+        });
+
+        const parsed = await test.step("run the Agent node and parse the Structured Response", () =>
+          runAgentAndParseStructuredOutput(page, options.model));
+
+        await test.step("schema keys are present with the schema's types", async () => {
+          // Shape-only asserts — the model fills the values, the schema
+          // drives the keys and types. Extra keys are tolerated.
+          expect(typeof parsed.name, `key "name" is a string in ${JSON.stringify(parsed)}`).toBe("string");
+          expect((parsed.name as string).length).toBeGreaterThan(0);
+          expect(typeof parsed.age, `key "age" is a number in ${JSON.stringify(parsed)}`).toBe("number");
+        });
+      },
+    );
+
+    test(
+      "a multiple (As List) schema row returns an array of the row's type",
+      { tag: ["@stable", "@regression", "@agents", "@components"] },
+      async ({ page, request }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        const nonce = `so-list-${Date.now()}`;
+
+        await loadAgent(page, options);
+        const bearer = await getAuthToken(request);
+        const flowId = await resolveLiveFlowId(request, bearer, createdFlowIds);
+
+        await test.step("configure output_schema {colors: str, As List} and strip tools via API", async () => {
+          await patchStructuredOutputSetup(request, bearer, flowId, options.model, [
+            { name: "colors", description: "every color mentioned in the text", type: "str", multiple: "True" },
+          ]);
+          await page.reload();
+          await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', { timeout: 30000 });
+        });
+
+        await test.step("seed a task listing multiple values", async () => {
+          await setChatInputText(page, `The flag is red, white and blue. (${nonce})`);
+          await waitForFlowSaveSettled(page);
+        });
+
+        const parsed = await test.step("run the Agent node and parse the Structured Response", () =>
+          runAgentAndParseStructuredOutput(page, options.model));
+
+        await test.step("the As List key is an array of strings", async () => {
+          // The causal control on the schema knob: same machinery as test 1,
+          // only the row's `multiple` flag differs — the shape must follow.
+          expect(Array.isArray(parsed.colors), `key "colors" is an array in ${JSON.stringify(parsed)}`).toBe(true);
+          const colors = parsed.colors as unknown[];
+          expect(colors.length).toBeGreaterThan(0);
+          for (const c of colors) expect(typeof c).toBe("string");
+        });
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #491

## What this adds

`agent-structured-output.spec.ts` + spec doc — proves the Agent's `output_schema` TableInput drives its **Structured Response** output (`json_response` → `Data`) to schema-shaped JSON (QA-CHECKLIST §6.5 + the JSON half of §7.7).

- **Test 1 — typed keys.** Schema `{name: str, age: int}` + a trivially extractable input ("John is 25 years old."): the parsed Structured Response has key `name` of type string (non-empty) and key `age` of type number. Shape-only asserts — presence + `typeof`, never model values; extra orchestrator keys (e.g. `default_value`, observed live) tolerated.
- **Test 2 — causal control on the schema knob.** One row with `multiple = true` (`colors: str`, As List) + "The flag is red, white and blue.": `colors` comes back as an **Array** (length ≥ 1, all strings). Only the `multiple` flag differs from test 1's machinery, so the returned shape demonstrably follows the schema definition.

The spec pins the **native** structured-output path (`with_structured_output`, provider-validated JSON — verified in the container source) by stripping the template's tool edges (URL / Web Search) and disabling `add_current_date_tool`/`add_calculator_tool` via API PATCH. UI path scouted live: node output dropdown → Structured Response → node run → output inspector.

## Product-bug candidate found during stabilization (flagged, not papered over)

The node run builds from the **frontend's in-memory graph** (the `POST /api/v2/workflows` payload embeds `data.nodes`), and the canvas's `custom_component/update` storm intermittently **drops the Agent's model selection** (backend logs `ValueError: __default_language_model__ variable not found` on every canvas load). The build then silently falls back to the legacy default model (`gpt-5.5-pro`, inactive provider here) and never reports success (~1/5 before guards; root-caused via build-payload capture + container-log timestamp correlation on 1.11.0.dev36). Two setup-stabilization guards ship in the spec (asserts untouched):

1. The API PATCH polls the flow until the POM's model selection is autosaved before writing (write-clobber race).
2. The run helper re-checks the node's model widget right before running, reloading (bounded ×3) until the selection is present, and fails with the visible toasts' text instead of a bare toast timeout.

## Boundary / deviation

- §7.7 also names Markdown and plain-text formatting — model content choices with no schema contract to assert deterministically; this spec covers the bullet's `output_schema`/JSON contract, boundary documented in the spec doc.
- Residual: ~1/15 runs fail fast when the provider/orchestrator blips and `json_response` returns its error shape — the key asserts then fail **correctly** (an errored run cannot pass silently); CI retries absorb it.

## Validation

- Langflow nightly **1.11.0.dev36** (confirmed latest published image at validation time)
- 3 clean `--retries=0` full-file runs (pipeline-parsed JSON stats) + 12 consecutive green runs of test 2 isolated post-guards + final post-FF green, `--workers=1`
- Force-fail executed (all red, revert proven: 0 `FF-MUTATION` markers + final green):
  - M1 — key absent from the schema (`city`) expected present → failed
  - M2 — wrong type: the int row (`age`) expected as string → failed
  - M3 — inverted: the As List key (`colors`) expected NOT to be an array → failed
- `npm run typecheck` ✓, `npm run lint` 0 errors ✓, zero `🚨 Backend Error` in green runs
- 0 orphan flows after ~30 runs today (id-scoped cleanup via `deleteFlow` helper, including on intentional FF failures)
- `--trace=on` skipped — known limitation: tracing hangs Simple Agent–template specs locally; covered by `--retries=0` bursts + executed force-fails (CI captures trace on first retry)
- QA-CHECKLIST bullets §6.5 (line 359) and §7.7 (line 420) flipped to `[x]`; generated blocks untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)