### PR TITLE
fix(llm-agents): pin Agent model + robust playground waits in memory-history (#569)

### DIFF
--- a/docs/core-functionality/llm-agents/memory-history-regression.md
+++ b/docs/core-functionality/llm-agents/memory-history-regression.md
@@ -1,6 +1,6 @@
 # Memory Chatbot — History and Memory Regression
 
-**Last validated:** Langflow 1.11.0
+**Last validated:** Langflow 1.11.x (1.11.0.dev36)
 
 ---
 
@@ -48,12 +48,13 @@ Does not require an API key. Validates only the canvas structure.
 Requires `OPENAI_API_KEY`. Groups behavior validations in `test.step` with `expect.soft`.
 
 1. Load the Memory Chatbot template and configure OpenAI via `setupLanguageModelOpenAI`:
-   - If `model_model` is not visible (providers not configured): click the "Setup Provider" button (no data-testid) → select `provider-item-OpenAI` → fill the API key with `pressSequentially` → click "Save" → wait for the "Replace" button to appear → enable `[data-testid^="llm-toggle"]` toggles → close with Escape → wait for `model_model` to appear
-   - Click `model_model` and select a chat model **resiliently**: `MODEL_TEST_ID` (env) if set → first available preferred cheap chat model (`gpt-4o-mini`, then `gpt-5.4-nano`, `gpt-5.4-mini`, …) → first option that is not a non-chat model (image/embedding/audio). This adapts to builds where `gpt-4o-mini` was dropped from the OpenAI bundle (1.11.0 ships `gpt-5.x` instead) and avoids slow/expensive models that would reintroduce the LLM-response timeout
-2. Open the Playground (`playground-btn-flow-io`) and wait for `input-chat-playground`
-3. *Step: context retention* — Send `"My name is Alice..."`, wait for the response to **complete** (`waitForChatResponse` counts `chat-message-token-usage` badges, which render once per finished response), send `"What is my name?"` and assert the latest `div-chat-message` contains "Alice"
-4. *Step: multiple messages* — web-first `expect.poll` on `div-chat-message` count asserting `>= 2` (testid is present only on bot responses). Not an exact count: the classic template is a linear flow (exactly 2 responses), but the agent-based Memory Chatbot template on nightly emits extra intermediate tool/memory-retrieval bubbles, so the bubble count is non-deterministic (`>= 2`). An exact `toHaveCount(2)` false-failed on the agent variant when it settled on 3 (issue #466)
-5. *Step: persistence* — close the Playground via `playground-close-button` (wait for `input-chat-playground` to hide), reopen it, and web-first assert `div-chat-message` count is restored to the previous value
+   - If `model_model` is not visible (providers not configured): click the "Setup Provider" button (no data-testid) → select `provider-item-OpenAI` → fill the API key with `pressSequentially` → click "Save" → wait for the "Replace" button to appear → enable a **single** preferred model toggle (`llm-toggle-{model}`, with `scrollIntoViewIfNeeded`) → close with Escape → wait for `model_model` to appear. Enabling only one model (not every toggle) is deliberate: the OpenAI bundle now lists 45+ models and the trailing toggles render off the scroll viewport, so clicking each one timed out on a non-visible element (issue #569); one enabled model is all the dropdown needs
+   - Click `model_model` and select a chat model **resiliently**: `MODEL_TEST_ID` (env) if set → first available preferred cheap chat model (`gpt-4o-mini`, then `gpt-5.4-nano`, `gpt-5.4-mini`, …) → first option that is neither a non-chat model (image/embedding/audio) **nor an avoided slow/expensive one** (`-pro` reasoning tiers, the `o1`/`o3`/`o4` series, `codex`, `deep-research`, `search-preview`). The dropdown lists `gpt-5.5-pro` first, so this guard keeps a slow reasoning model from being picked. After selecting, the helper asserts `model_model` actually shows the chosen model — a silently-intercepted click (the `api_key` popover can steal it) would otherwise leave the node on its `gpt-5.5-pro` default and mask assertions downstream
+2. **Pin the Agent's executable model via API** (`setAgentModelViaApi`): the Agent template defaults `model` to `gpt-5.5-pro` — a restricted (keys without access get *"Project does not have access to model gpt-5.5-pro"*), expensive reasoning model — and the in-canvas model widget does **not** persist a UI selection to the executed graph, so a plain UI click leaves the flow running gpt-5.5-pro. The helper GETs the flow, picks a cheap chat model from the Agent node's `model.options` (same resolution as the UI selector), sets `model.value`, and PATCHes it; the test then `page.reload()`s so the Playground build uses the pinned model. This is the concrete #569 fix — running gpt-5.5-pro was both the hard failure (no access) and the original flake (slow reasoning replies / missing token-usage badge)
+4. Open the Playground (`playground-btn-flow-io`) and wait for `input-chat-playground`
+5. *Step: context retention* — Send `"My name is Alice..."`, wait for the response to **complete** (`waitForChatResponse`: `div-chat-message` reaches the expected count so the new turn has started, then the generating indicator clears — `button-stop` hidden and `button-send` back), send `"What is my name?"` and assert the latest `div-chat-message` contains "Alice"
+6. *Step: multiple messages* — web-first `expect.poll` on `div-chat-message` count asserting `>= 2` (testid is present only on bot responses). Not an exact count: the classic template is a linear flow (exactly 2 responses), but the agent-based Memory Chatbot template on nightly emits extra intermediate tool/memory-retrieval bubbles, so the bubble count is non-deterministic (`>= 2`). An exact `toHaveCount(2)` false-failed on the agent variant when it settled on 3 (issue #466)
+7. *Step: persistence* — close the Playground via `playground-close-button` (wait for `input-chat-playground` to hide), reopen it, and web-first assert `div-chat-message` count is restored to the previous value
 
 ---
 
@@ -61,12 +62,12 @@ Requires `OPENAI_API_KEY`. Groups behavior validations in `test.step` with `expe
 
 Requires `OPENAI_API_KEY`. Kept separate because it is destructive (creates a new session).
 
-1. Load the template and configure the API key (same flow as Test 2)
+1. Load the template, configure the API key **and pin the Agent model via API** (same `openConfiguredPlayground` path as Test 2 — see Test 2 step 2)
 2. Open the Playground, send `"My name is Bob..."`
-3. Wait for the response to complete (`waitForChatResponse` — counts `chat-message-token-usage`)
+3. Wait for the response to complete (`waitForChatResponse` — new bubble mounted, then generating indicator cleared)
 4. Click `new-chat` (the "+" button in the sessions sidebar)
 5. Web-first assert `div-chat-message` `toHaveCount(0)` — auto-retries until the session reset settles, so a reset slower than a fixed wait cannot false-fail (replaced the old `waitForTimeout(500)` + hard count)
-6. *Backend-isolation probe:* send `"What is my name?"` in the NEW session and assert the response does **not** match `/Bob/i` — the UI-reset check alone (step 5) would still pass if the backend leaked memory across sessions; only a model answer proves the new session's context is really empty (inverted mirror of Test 2's positive `/Alice/i` assert). Fail-safe: a leak surfaces "Bob" and fails; a model that answers "I don't know" passes
+6. *Backend-isolation probe:* send `"What is my name?"` in the NEW session, assert the response is **non-empty** and then that it does **not** match `/Bob/i` — the UI-reset check alone (step 5) would still pass if the backend leaked memory across sessions; only a model answer proves the new session's context is really empty (inverted mirror of Test 2's positive `/Alice/i` assert). The non-empty gate closes the vacuous pass: an empty/errored response (e.g. a reasoning model returning no content) would otherwise satisfy `not.toMatch(/Bob/)` and mask a broken run. Fail-safe: a leak surfaces "Bob" and fails; a model that answers "I don't know" passes
 
 ---
 
@@ -85,7 +86,7 @@ Requires `OPENAI_API_KEY`. Kept separate because it is destructive (creates a ne
 - `src/backend/base/langflow/initial_setup/starter_projects/Memory Chatbot.json` — defines the template graph at runtime (overrides the `.py`); changes to nodes or edges break Test 1
 - `initial_setup/starter_projects/Memory Chatbot.json` — the shipped template (Agent + Memory Base since 1.11.0.dev34); node renames/additions there break Test 1
 - The Agent node's `model_model` field — `setupLanguageModelOpenAI` resolves it on the Agent (the helper predates the redesign; it targets whatever node exposes `model_model`); changes there affect Tests 2 and 3
-- `src/frontend/src/components/core/playgroundComponent/` — `input-chat-playground`, `div-chat-message`, `chat-message-token-usage`, `playground-close-button`, `new-chat` — any rename breaks Tests 2 and 3. `chat-message-token-usage` is the completion signal used by `waitForChatResponse`; if a future build stops rendering it (or a provider returns no token usage), the response wait must switch to another per-response completion marker
+- `src/frontend/src/components/core/playgroundComponent/` — `input-chat-playground`, `div-chat-message`, `button-send`, `button-stop`, `playground-close-button`, `new-chat` — any rename breaks Tests 2 and 3. `button-stop`/`button-send` are the completion signal used by `waitForChatResponse` (present-while-generating / present-when-idle); if those testids change, the response wait must switch to another per-response completion marker
 - `src/frontend/src/CustomNodes/GenericNode/components/NodeName/index.tsx` — `data-testid="title-{display_name}"` — a change to this testid pattern breaks Test 1
 - `src/frontend/src/modals/modelProviderModal/components/ProviderConfigurationForm.tsx` — "Save" button (exact text to save the API key); changing it breaks `setupLanguageModelOpenAI`
 
@@ -95,7 +96,7 @@ Requires `OPENAI_API_KEY`. Kept separate because it is destructive (creates a ne
 
 - Memory Chatbot behavior with other providers (Anthropic, Google) — `setupLanguageModelOpenAI` configures OpenAI only
 - Validation of AI response content beyond the name reference ("Alice")
-- Verification that, without the `Message History` node connected, context is lost
+- Verification that, without the `Memory Base` component connected to the Agent, context is lost
 - History persistence after a Langflow server restart
 
 ---
@@ -111,7 +112,7 @@ Requires `OPENAI_API_KEY`. Kept separate because it is destructive (creates a ne
 ## When to review this test *(optional)*
 
 - If the "Memory Chatbot" template is removed or renamed in `starter_projects`
-- If the `LanguageModelComponent` changes its `display_name` or the default session behavior changes
+- If the `Agent` / `Memory Base` component changes its `display_name` or the default session behavior changes
 - If the "Save" button in the provider modal changes its text (breaks `setupLanguageModelOpenAI`)
 - If the `new-chat` button in the sessions sidebar is renamed (breaks Test 3)
 - If the Playground adds a confirmation modal when creating a new session (Test 3 will need an extra step)
@@ -120,10 +121,12 @@ Requires `OPENAI_API_KEY`. Kept separate because it is destructive (creates a ne
 
 ## Notes *(optional)*
 
-- **Template structure at runtime**: the template loads from `Memory Chatbot.json` (not the `.py`), with 6 nodes: Chat Input, Chat Output, Prompt Template, Message History, Language Model (not OpenAI directly), note/README.
-- **`div-chat-message`**: testid present only on bot responses (`bot-message.tsx`), not on user messages. 2 exchanges → count = 2 (not 4). **Its count is unreliable as a "response arrived" signal** — while a response streams in, the bubble mounts, unmounts on a re-render, then settles, so the count flickers. `waitForChatResponse` therefore counts `chat-message-token-usage` (rendered only once a response *completes*) instead. This was the root cause of the flaky history/isolation assertions in issue #354.
-- **Model selection is resilient**: `setupLanguageModelOpenAI` no longer hardcodes `gpt-4o-mini`. It resolves `MODEL_TEST_ID` (env) → first available preferred cheap chat model → first non-image/embedding/audio option. Validated on Langflow 1.11.0, where the OpenAI bundle exposes `gpt-5.x` (e.g. `gpt-5.4-nano`) and no longer lists `gpt-4o-mini`.
-- **Residual flake**: Tests 2 and 3 make live OpenAI calls, so an occasional response slower than the 120s budget can still time out — this is the inherent external-dependency flake described in issue #354, absorbed by the CI retry budget, not a test-logic bug.
+- **Template structure at runtime**: the template loads from `Memory Chatbot.json` (not the `.py`), which since 1.11.0.dev34 is an **Agent-based** flow with 5 nodes: Chat Input → Agent → Chat Output, plus the `Memory Base` component and a note/README (issue #550).
+- **Agent model default is `gpt-5.5-pro`**: the Agent node's `model` field defaults to `gpt-5.5-pro` (a restricted, expensive reasoning model). The in-canvas model widget (`model_model`) does **not** persist a UI selection into the executed graph — the `model.value` on the node stays at the default — so Tests 2/3 pin it via the flows API (`setAgentModelViaApi`: GET flow → pick a cheap model from the node's `model.options` → set `model.value` → PATCH), then reload so the Playground build uses it. This is the concrete #569 fix; running gpt-5.5-pro caused both the hard failure (*"Project does not have access to model gpt-5.5-pro"* on restricted keys) and the original flake (slow reasoning replies, inconsistent token-usage badge).
+- **Completion signal (`waitForChatResponse`)**: waits in two gates — first `div-chat-message` reaches the expected count (the bot bubble mounts when the turn starts, guarding against checking completion before generation began — the #354 start-race), then the generating indicator clears (`button-stop` hidden, `button-send` visible). The previous signal counted `chat-message-token-usage` badges, but not every model/response emits that badge, so the count could sit below the expected value for the full 120s even though the response had rendered — the **root cause of the #569 flake**. `button-stop`/`button-send` are model-agnostic. `div-chat-message` alone is unreliable (its count flickers while streaming — mount/unmount/settle), which is why it is only the *turn-started* gate, never the completion gate.
+- **Model selection is resilient**: `setupLanguageModelOpenAI` no longer hardcodes `gpt-4o-mini`. It resolves `MODEL_TEST_ID` (env) → first available preferred cheap chat model → first option that is neither non-chat nor an avoided slow/expensive model (`-pro`/`o1`/`o3`/`o4`/`codex`/`deep-research`/`search-preview`), enables that single model's toggle (not all 45+ — issue #569), and verifies `model_model` reflects the choice after selecting. The last two guards matter because the dropdown lists `gpt-5.5-pro` first: without them a silently-failed selection would leave the node on that pro tier, whose slow/empty reasoning replies reintroduce timeouts and mask assertions. Validated on Langflow 1.11.x, where the OpenAI bundle exposes `gpt-5.x` (e.g. `gpt-5.4-nano`) alongside `gpt-4o-mini`.
+- **Live OpenAI calls**: Tests 2 and 3 make real OpenAI calls, so an occasional response slower than the 120s budget can still time out — an inherent external-dependency limit, absorbed by the CI retry budget, not a test-logic bug. With the #569 completion-signal fix a full 3-test run settles in ~31s (previously it could hang at the 120s token-usage timeout).
+- **Teardown**: `afterEach` navigates home (`page.goto("/")`) before deleting the flow by id, so the open playground stops polling the flow's `/events` endpoint and the delete no longer races those requests into 404 ("Flow not found") teardown noise.
 - **`setupLanguageModelOpenAI`**: local function in the spec that configures OpenAI via the "Setup Provider" modal. Uses `pressSequentially` (not `fill`) to ensure keyboard events on React controlled inputs. Waits for the "Replace" button to appear to confirm the save completed.
 - **`new-chat`**: the "+" button in the sessions sidebar (`chat-sidebar.tsx`). Functional equivalent of "New Session" in the `session-selector-trigger` dropdown (which may be hidden by animation in certain builds).
 - **Test 1 without API key**: pure structure validation — useful in CI without configured keys.

--- a/tests/helpers/provider-setup/setup-language-model-openai.ts
+++ b/tests/helpers/provider-setup/setup-language-model-openai.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test";
+import { type Page, expect } from "@playwright/test";
 
 // Cheap, fast chat models in priority order. `gpt-4o-mini` is kept first so older
 // Langflow builds still match; the `gpt-5.x` entries cover newer builds (1.11.0+)
@@ -20,13 +20,23 @@ const PREFERRED_CHAT_MODELS = [
 // Substrings marking a non-chat model (image, embeddings, audio, …) — never select these.
 const NON_CHAT_MODEL = /image|embedding|audio|tts|realtime|whisper|dall-?e|moderation|transcribe/i;
 
+// Chat-capable but too slow/expensive for a fast regression run: reasoning "pro"
+// tiers, the o-series reasoning models, codex, deep-research and search-preview
+// variants. Never auto-selected — the OpenAI dropdown lists `gpt-5.5-pro` first, so
+// without this guard the fallback (or a silently-failed selection) lands on it and a
+// slow/empty reasoning response reintroduces the 120s timeout and masks assertions.
+const AVOID_MODEL = /(^|[-\s])(pro|o1|o3|o4)([-\s]|$)|codex|deep-research|search-preview/i;
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 // Selects a usable OpenAI chat model from the already-open `model_model` dropdown.
 // Resolution order: MODEL_TEST_ID env override → first available preferred model →
-// first option that is not a non-chat model. Throws with the observed options if none fit.
+// first option that is neither a non-chat nor an avoided (pro/reasoning) model.
+// Throws with the observed options if none fit. After selecting, verifies the trigger
+// actually reflects the choice — a silently-intercepted click (the api_key popover can
+// steal the click) would otherwise leave the node on its default (`gpt-5.5-pro`).
 async function selectPreferredChatModel(page: Page): Promise<void> {
   const options = page.locator('[data-testid$="-option"]');
   await options.first().waitFor({ state: "visible", timeout: 15000 });
@@ -39,7 +49,7 @@ async function selectPreferredChatModel(page: Page): Promise<void> {
   const chosen =
     (envModel && labels.find((label) => label === envModel)) ||
     PREFERRED_CHAT_MODELS.find((model) => labels.includes(model)) ||
-    labels.find((label) => !NON_CHAT_MODEL.test(label));
+    labels.find((label) => !NON_CHAT_MODEL.test(label) && !AVOID_MODEL.test(label));
 
   if (!chosen) {
     await page.keyboard.press("Escape");
@@ -52,6 +62,47 @@ async function selectPreferredChatModel(page: Page): Promise<void> {
     .filter({ hasText: new RegExp(`^${escapeRegExp(chosen)}$`) })
     .first()
     .click();
+
+  await expect(page.getByTestId("model_model")).toContainText(chosen, { timeout: 10000 });
+}
+
+// Enables a single chat model toggle inside the provider modal so the model
+// dropdown has at least one option. Resolution mirrors selectPreferredChatModel:
+// MODEL_TEST_ID (env) → first available preferred cheap model → first toggle.
+// scrollIntoViewIfNeeded handles the long, scrollable model list (issue #569).
+async function enablePreferredModelToggle(page: Page): Promise<void> {
+  const toggles = page.locator('[data-testid^="llm-toggle-"]');
+  await toggles.first().waitFor({ state: "attached", timeout: 15000 }).catch(() => {});
+
+  const envModel = process.env.MODEL_TEST_ID?.trim();
+  const candidates = [envModel, ...PREFERRED_CHAT_MODELS].filter(Boolean) as string[];
+
+  for (const model of candidates) {
+    const toggle = page.getByTestId(`llm-toggle-${model}`);
+    if ((await toggle.count()) === 0) continue;
+    await toggle.scrollIntoViewIfNeeded();
+    if (!(await toggle.isChecked())) {
+      await toggle.click();
+    }
+    return;
+  }
+
+  // Fallback: no preferred model is offered by this build — enable the first
+  // offered model that is neither a non-chat nor an avoided (pro/reasoning) model,
+  // so the dropdown resolves to a cheap chat model rather than `gpt-5.5-pro`.
+  const ids = await toggles.evaluateAll((els) =>
+    els.map((el) => el.getAttribute("data-testid") || ""),
+  );
+  for (const id of ids) {
+    const model = id.replace(/^llm-toggle-/, "");
+    if (!model || NON_CHAT_MODEL.test(model) || AVOID_MODEL.test(model)) continue;
+    const toggle = page.getByTestId(id);
+    await toggle.scrollIntoViewIfNeeded();
+    if (!(await toggle.isChecked())) {
+      await toggle.click();
+    }
+    return;
+  }
 }
 
 // Requires the Language Model node to be clicked before calling so its fields are in the viewport.
@@ -91,14 +142,11 @@ export async function setupLanguageModelOpenAI(page: Page): Promise<void> {
         .catch(() => {});
     }
 
-    // Enable any model toggles that are off
-    const toggles = page.locator('[data-testid^="llm-toggle"]');
-    const toggleCount = await toggles.count();
-    for (let i = 0; i < toggleCount; i++) {
-      if (!(await toggles.nth(i).isChecked())) {
-        await toggles.nth(i).click();
-      }
-    }
+    // Enable exactly one preferred chat model. Enabling every toggle is fragile:
+    // the OpenAI bundle now lists 45+ models and the trailing toggles render off
+    // the scroll viewport, so clicking each one eventually times out on a
+    // non-visible element (issue #569). One enabled model is all the dropdown needs.
+    await enablePreferredModelToggle(page);
 
     // Escape closes the Dialog and triggers refreshAllModelInputs on the node
     await page.keyboard.press("Escape");
@@ -107,4 +155,51 @@ export async function setupLanguageModelOpenAI(page: Page): Promise<void> {
 
   await modelDropdown.click();
   await selectPreferredChatModel(page);
+}
+
+// Forces the Agent node's *executable* model to a cheap chat model via the flows API.
+// The Agent template ships `model` defaulting to `gpt-5.5-pro` — a restricted,
+// expensive reasoning model — and its in-canvas model widget does not reliably
+// persist a UI selection to the executed graph, so a plain UI click leaves the flow
+// running gpt-5.5-pro (rejected by keys without access, and slow/reasoning — the #569
+// flake). Resolution mirrors selectPreferredChatModel: MODEL_TEST_ID → first preferred
+// → first non-chat/non-avoided option offered by the node. Returns the chosen name.
+// Caller must reload the flow afterwards so the playground build uses the patched model.
+export async function setAgentModelViaApi(page: Page, flowId: string): Promise<string> {
+  const flow = await (await page.request.get(`/api/v1/flows/${flowId}`)).json();
+  const nodes = flow?.data?.nodes ?? [];
+  const agent = nodes.find((n: any) => n?.data?.type === "Agent");
+  if (!agent) {
+    throw new Error("setAgentModelViaApi: Agent node not found in the flow");
+  }
+
+  const modelField = agent.data.node.template.model;
+  const options = (modelField?.options ?? []) as any[];
+  const names: string[] = options
+    .map((o) => (typeof o === "string" ? o : o?.name))
+    .filter(Boolean);
+
+  const envModel = process.env.MODEL_TEST_ID?.trim();
+  const chosenName =
+    (envModel && names.includes(envModel) && envModel) ||
+    PREFERRED_CHAT_MODELS.find((m) => names.includes(m)) ||
+    names.find((n) => !NON_CHAT_MODEL.test(n) && !AVOID_MODEL.test(n));
+
+  if (!chosenName) {
+    throw new Error(
+      `setAgentModelViaApi: no usable cheap chat model in Agent options: ${names.join(", ")}`,
+    );
+  }
+
+  const chosenOption = options.find((o) => (typeof o === "string" ? o : o?.name) === chosenName);
+  modelField.value = [chosenOption];
+
+  const res = await page.request.patch(`/api/v1/flows/${flowId}`, {
+    data: { name: flow.name, data: flow.data },
+  });
+  if (!res.ok()) {
+    throw new Error(`setAgentModelViaApi: PATCH failed (${res.status()}): ${await res.text()}`);
+  }
+
+  return chosenName;
 }

--- a/tests/tests-automations/regression/core-functionality/llm-agents/memory-history-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/memory-history-regression.spec.ts
@@ -6,7 +6,10 @@ import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { updateOldComponents } from "../../../../helpers/flows/update-old-components";
 import { loadTemplateByName } from "../../../../helpers/flows/load-template-by-name";
 import { PlaygroundPage } from "../../../../pages";
-import { setupLanguageModelOpenAI } from "../../../../helpers/provider-setup/setup-language-model-openai";
+import {
+  setupLanguageModelOpenAI,
+  setAgentModelViaApi,
+} from "../../../../helpers/provider-setup/setup-language-model-openai";
 
 if (!process.env.CI) {
   dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
@@ -22,18 +25,43 @@ async function loadMemoryChatbot(page: Page): Promise<string> {
   return flowId;
 }
 
+// Configures the provider (UI) and pins the Agent's executable model to a cheap chat
+// model (API), then opens the Playground. The model pin is why this goes through the
+// API: the Agent template defaults `model` to `gpt-5.5-pro` and the in-canvas widget
+// does not persist a UI selection to the executed graph, so without this the flow runs
+// gpt-5.5-pro (rejected by keys without access; slow reasoning model — issue #569).
+// The reload makes the frontend/playground build pick up the patched model.
+async function openConfiguredPlayground(page: Page, flowId: string): Promise<PlaygroundPage> {
+  await setupLanguageModelOpenAI(page);
+  await setAgentModelViaApi(page, flowId);
+  await page.reload();
+
+  const playground = new PlaygroundPage(page);
+  await playground.waitForLoad();
+  await page.getByTestId("playground-btn-flow-io").click();
+  await page.waitForSelector('[data-testid="input-chat-playground"]', { timeout: 30000 });
+  return playground;
+}
+
 // Waits until `expectedResponses` bot responses have *fully completed*.
 //
-// A response's `chat-message-token-usage` badge is rendered only once that response
-// finishes, so its count is a stable completion signal. The `div-chat-message` element
-// is NOT usable for this: its count flickers while a response streams in (the bubble
-// mounts, unmounts on a re-render, then settles), so waiting on it can return on a
-// transient peak before the new response actually arrives — the root cause of the flaky
-// history/isolation assertions in issue #354. The 120s budget covers live LLM latency.
+// Two gates, in order:
+//  1. `div-chat-message` reaches the expected count — the bot bubble mounts when the
+//     turn begins, so this confirms the new turn actually started before we look at
+//     the generating indicator (guards the "checked completion before generation
+//     started" race that made the old stop-button wait return early — issue #354).
+//  2. The generating indicator clears: `button-stop` hidden and `button-send` back.
+//     This is the completion signal because it is *model-agnostic*. The previous
+//     signal — counting `chat-message-token-usage` badges — was the root cause of the
+//     #569 flake: not every model/response emits the badge, so the count could sit
+//     below the expected value for the full 120s even though the response had already
+//     rendered. The 120s budget covers live LLM latency.
 async function waitForChatResponse(page: Page, expectedResponses: number): Promise<void> {
-  await expect(page.getByTestId("chat-message-token-usage")).toHaveCount(expectedResponses, {
+  await expect(page.getByTestId("div-chat-message")).toHaveCount(expectedResponses, {
     timeout: 120000,
   });
+  await expect(page.getByTestId("button-stop")).toBeHidden({ timeout: 120000 });
+  await expect(page.getByTestId("button-send")).toBeVisible({ timeout: 10000 });
 }
 
 test.describe("Memory Chatbot Regression", () => {
@@ -43,6 +71,10 @@ test.describe("Memory Chatbot Regression", () => {
   // would kill parallel workers' in-flight flows (#553).
   test.afterEach(async ({ page }) => {
     if (createdFlowId) {
+      // Navigate home first so the flow editor / open playground stops polling
+      // this flow's /events endpoint; otherwise the delete below races those
+      // in-flight requests, which then 404 ("Flow not found") as teardown noise.
+      await page.goto("/").catch(() => {});
       await page.request.delete(`/api/v1/flows/${createdFlowId}`).catch(() => {});
       createdFlowId = null;
     }
@@ -82,17 +114,11 @@ test.describe("Memory Chatbot Regression", () => {
       );
 
       createdFlowId = await loadMemoryChatbot(page);
-      await setupLanguageModelOpenAI(page);
-
-      const playground = new PlaygroundPage(page);
-
-      await page.getByTestId("playground-btn-flow-io").click();
-      await page.waitForSelector('[data-testid="input-chat-playground"]', { timeout: 30000 });
+      const playground = await openConfiguredPlayground(page, createdFlowId);
 
       await test.step("message history retains context within same session", async () => {
         await playground.sendMessage("My name is Alice. Please confirm you received my name.");
         await waitForChatResponse(page, 1);
-        await expect.soft(page.getByTestId("div-chat-message").last()).toBeVisible({ timeout: 30000 });
 
         await playground.sendMessage("What is my name?");
         await waitForChatResponse(page, 2);
@@ -134,16 +160,10 @@ test.describe("Memory Chatbot Regression", () => {
       );
 
       createdFlowId = await loadMemoryChatbot(page);
-      await setupLanguageModelOpenAI(page);
-
-      const playground = new PlaygroundPage(page);
-
-      await page.getByTestId("playground-btn-flow-io").click();
-      await page.waitForSelector('[data-testid="input-chat-playground"]', { timeout: 30000 });
+      const playground = await openConfiguredPlayground(page, createdFlowId);
 
       await playground.sendMessage("My name is Bob. Please confirm you received my name.");
       await waitForChatResponse(page, 1);
-      await expect(page.getByTestId("div-chat-message").last()).toBeVisible({ timeout: 30000 });
 
       // "new-chat" button is in the sessions sidebar (data-testid="new-chat")
       await page.getByTestId("new-chat").click();
@@ -162,7 +182,11 @@ test.describe("Memory Chatbot Regression", () => {
       // fails; a model that answers "I don't know your name" passes.
       await playground.sendMessage("What is my name?");
       await waitForChatResponse(page, 1);
-      const response = await page.getByTestId("div-chat-message").last().innerText();
+      const response = (await page.getByTestId("div-chat-message").last().innerText()).trim();
+      // Require a real answer first: an empty/errored response (e.g. a reasoning model
+      // that returns no content) would pass `not.toMatch(/Bob/)` vacuously and mask a
+      // broken run as a green isolation result.
+      expect(response.length).toBeGreaterThan(0);
       expect(response).not.toMatch(/Bob/i);
     },
   );


### PR DESCRIPTION
## Issue

Closes #569 (`daily-failure` — approved exception).

The `memory-history` **"message history context retention suite"** flaked and hard-failed on the daily `@stable` run.

## Root cause

The agent-based Memory Chatbot template runs the Agent's **default model `gpt-5.5-pro`** — a restricted, expensive reasoning model. The in-canvas model widget (`model_model`) does **not** persist a UI selection into the executed graph, so the flow ran `gpt-5.5-pro` regardless of what the UI selected. This caused **both**:

- the **hard failure** — `Project does not have access to model gpt-5.5-pro` on keys without access;
- the **original flake** — slow reasoning replies and an inconsistent `chat-message-token-usage` badge that left `waitForChatResponse` timing out at 120s.

## Changes

- **`setAgentModelViaApi`** — pins the Agent's executable `model.value` to a cheap chat model via the flows API (GET → pick from the node's `model.options` → PATCH), then `reload()` so the Playground build uses it. Verified the executed model is `gpt-4o-mini`, never `gpt-5.5-pro`.
- **`waitForChatResponse`** — waits on a **model-agnostic** completion signal (`button-stop` hidden / `button-send` visible) once the bot bubble has mounted, instead of counting `token-usage` badges that not every model emits.
- **`setupLanguageModelOpenAI`** — enables a **single** preferred model toggle instead of all 45+ (trailing toggles render off the scroll viewport and timed the click out); excludes `pro`/`o1`/`o3`/`o4`/`codex`/`deep-research`/`search-preview` from selection and verifies the choice took.
- **session isolation** — asserts a non-empty response **before** `not.toMatch(/Bob/)`, so an empty/errored reply cannot pass the isolation check vacuously.
- **`afterEach`** — navigates home before deleting the flow so the open Playground stops polling `/events`, removing the 404 (`Flow not found`) teardown noise.
- **Spec doc** updated (agent-based template, model pin, completion signal); `Last validated` → Langflow 1.11.x.

The `setupLanguageModelOpenAI` change is shared and also unblocks `loop-component-regression` from the 45-toggle hard failure.

## Validation

- `tsc --noEmit`: clean
- `eslint` (changed files): 0 errors (warnings only in categories that pre-exist in the project)
- `--workers=1 --retries=0`: 3/3 green across multiple consecutive runs (~37s; previously hung at the 120s token-usage timeout)
- Force-fail confirmed on the retention (`/Alice/`) and isolation (`/Bob/`) assertions
- Zero `🚨 Backend Error`; executed model confirmed `gpt-4o-mini`
- `@stable` kept (per #569 triage policy)

## Notes

- `loop-component-regression.spec.ts` has a **separate, pre-existing** failure on the current nightly (the `api_key` popover intercepting the `model_model` click) — reproduces identically on `origin/main`, unrelated to this change. Candidate for its own `daily-failure` issue.
