### PR TITLE
test(model-provider): add Ollama provider spec (#498)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,16 @@ OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 GOOGLE_API_KEY=
 
+# Local Ollama instance (ollama-provider.spec.ts). Tests skip with a reason
+# when unreachable. OLLAMA_BASE_URL is probed FROM THE TEST HOST;
+# OLLAMA_BASE_URL_FROM_LANGFLOW is the URL typed INTO Langflow (a dockerized
+# Langflow reaches the host via host.docker.internal — that hostname must be
+# in the container's LANGFLOW_SSRF_ALLOWED_HOSTS). OLLAMA_TEST_MODEL must be
+# pulled on the instance. Defaults shown.
+OLLAMA_BASE_URL=
+OLLAMA_BASE_URL_FROM_LANGFLOW=
+OLLAMA_TEST_MODEL=
+
 # Model/provider test strategy (auto-detected by priority):
 # 1. MODEL_TEST_ID set    → runs only the specified model (e.g. gpt-4o-mini)
 # 2. MODEL_TEST_PROVIDER set → runs all models for the specified provider (e.g. openai | anthropic | google)

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -407,7 +407,7 @@
 - [x] Disabling a model in Settings removes it from a component model dropdown; re-enabling restores it → `llm-agents/model-provider-model-toggle.spec.ts`
 
 #### 7.6 Open-Source Providers
-- [ ] Configure and execute flow with Ollama (local model)
+- [x] Configure and execute flow with Ollama (local model) → `model-provider/ollama-provider.spec.ts`
 - [ ] Configure and execute flow with Groq
 - [ ] Configure and execute flow with Mistral
 

--- a/docs/core-functionality/model-provider/ollama-provider.md
+++ b/docs/core-functionality/model-provider/ollama-provider.md
@@ -1,0 +1,147 @@
+# Ollama provider — configure and execute a flow on the local instance
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+QA-CHECKLIST §7.6 "Configure and execute flow with Ollama (local model)" as a
+provider-centric journey, mirroring `openai-provider.spec.ts` /
+`google-provider.spec.ts` for the one provider that is a LOCAL SERVICE rather
+than a keyed cloud API:
+
+1. **Configure** — Ollama appears in Settings → Model Providers; saving its
+   base URL validates against the LIVE local instance (`validate-provider`
+   2xx) and persists (variables save 2xx). Request-level asserts, same
+   false-positive guard as the sibling specs: a no-op save cannot pass.
+2. **Execute** — a canvas flow (Chat Input → **Ollama** component → Chat
+   Output) pointed at the local instance lists the locally pulled model in
+   its LIVE model dropdown (the component queries the instance — a
+   deterministic connectivity proof, independent of Langflow's static Ollama
+   catalog), selects it, and a Playground run returns a non-empty reply
+   produced by that model. A per-run sentinel is sent and logged
+   (soft, family pattern — small local models don't reliably echo).
+
+Surface note (verified live on the 1.11 nightly): Langflow's Settings
+catalog for Ollama is STATIC (`/api/v1/models?provider=Ollama` lists
+llama3.3, qwq, …) and does not reflect what the local instance actually
+serves — so the execution half drives the **Ollama component**, whose
+`model_name` dropdown is refreshed from `base_url` live. This keeps every
+assert deterministic and independent of catalog drift.
+
+If this test fails, the Ollama provider path is broken: the base URL no
+longer validates/persists, the component can't reach the local instance, or
+a selected local model no longer executes.
+
+---
+
+## Tags *(required)*
+
+Test 1: `@stable` `@model-provider` `@settings`
+Test 2: `@stable` `@regression` `@model-provider` `@components` `@playground`
+
+`@stable` added after 4 clean `--retries=0` runs against the local Ollama
+(issue #498's "Done when"). In environments without a local Ollama (e.g. the
+daily-stable CI), both tests `test.skip` with an explicit reason — the same
+missing-dependency skip contract the keyed providers use for absent env keys.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` (fresh nightly).
+- A **local Ollama instance** with at least one pulled chat model:
+  - `OLLAMA_BASE_URL` — reachability probe from the TEST host
+    (default `http://localhost:11434`);
+  - `OLLAMA_BASE_URL_FROM_LANGFLOW` — the URL typed INTO Langflow, i.e. how
+    the Langflow container reaches the instance (default
+    `http://host.docker.internal:11434` for the dockerized nightly);
+  - `OLLAMA_TEST_MODEL` — the pulled model (default `llama3.2:1b`).
+  - Provisioning used for validation:
+    `docker run -d --name ollama-e2e -p 11434:11434 ollama/ollama` +
+    `docker exec ollama-e2e ollama pull llama3.2:1b`.
+- **SSRF allowlist (dockerized Langflow):** the nightly's SSRF protection
+  rejects `host.docker.internal` (private IP) with a 400 on the component's
+  model-list fetch — start the Langflow container with
+  `-e LANGFLOW_SSRF_ALLOWED_HOSTS=host.docker.internal` (discovered live on
+  1.11.0.dev36 while authoring this spec).
+- If the probe fails, both tests skip with the reason — no false red.
+- No collect-models / cloud key needed (local provider).
+
+---
+
+## Step by step *(required)*
+
+**Test 1 — Ollama base URL is configured via Settings → Model Providers (§7.6 configure half)**
+
+1. Probe `OLLAMA_BASE_URL` (`/api/tags`); skip with reason if unreachable.
+2. Open Settings → Model Providers → provider item **Ollama**.
+3. Fill the provider's base-URL field with `OLLAMA_BASE_URL_FROM_LANGFLOW`
+   (real field scouted live — never invented).
+4. Arm response waiters BEFORE clicking Save (validate-provider POST +
+   variables save), click Save.
+5. **Assert:** both requests resolve 2xx — the URL authenticated against the
+   LIVE local instance and was persisted.
+
+**Test 2 — the Ollama component lists the local model live and executes (§7.6 execute half)**
+
+1. Probe + skip as above.
+2. Open a blank flow; add **Chat Input**, **Ollama**, **Chat Output** from
+   the sidebar; connect ChatInput → Ollama (input) and Ollama → ChatOutput.
+3. On the Ollama node: set `base_url = OLLAMA_BASE_URL_FROM_LANGFLOW`,
+   refresh/open the `model_name` dropdown.
+4. **Assert (configure/connectivity):** the dropdown lists
+   `OLLAMA_TEST_MODEL` — the component genuinely enumerated the local
+   instance's models. Select it.
+5. Open the Playground, send a per-run sentinel prompt, wait for the run.
+6. **Assert (execute):** the AI reply is non-empty (hard); log whether the
+   sentinel round-tripped (soft, family pattern — model obedience is not the
+   contract).
+7. No `allowFlowErrors`.
+
+---
+
+## Validation criterion *(required)*
+
+Configure half: saving the Ollama base URL fires `validate-provider` and the
+variables persistence, BOTH 2xx, proving Langflow validated the URL against
+the live local instance and stored it. Execute half: the Ollama component's
+live model dropdown contains the locally pulled model (deterministic
+connectivity proof), and a Playground run through that model returns a
+non-empty AI reply. All asserts are request statuses, dropdown contents, and
+reply presence — never model wording.
+
+## Guarding against false positives *(how)*
+
+- **Waiters armed before Save (test 1)** — the pass is caused by THIS save,
+  not by a pre-existing configured state (family pattern).
+- **Live dropdown assert (test 2)** — a broken base URL yields an empty /
+  catalog-only dropdown and fails BEFORE any model runs; passing requires
+  the component to have enumerated the real local instance.
+- **Per-run sentinel** — logged (soft) to correlate the reply with THIS run;
+  the hard assert is reply presence, immune to small-model obedience flake.
+- **Skip ≠ pass** — missing local Ollama surfaces as an explicit skip with
+  reason, never as a silent green.
+- **Force-failure checks** (CONTRIBUTING §2): M1 — test 1 expects a 4xx
+  validate-provider (inverted) ⇒ must fail; M2 — test 2 expects a
+  never-pulled model name in the live dropdown ⇒ must fail; M3 — test 2
+  asserts the reply is empty (inverted) ⇒ must fail.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Agent-surface selection of Ollama models (the Agent's options come from
+  Langflow's static catalog, which is independent of the local instance —
+  asserting it would test the catalog, not the provider path).
+- Ollama embeddings component; tool calling on local models.
+- Model quality/wording (soft sentinel only).
+
+---
+
+## External dependencies *(required)*
+
+- **Local Ollama instance** with `OLLAMA_TEST_MODEL` pulled (no cloud key,
+  no external network) — see Preconditions for the provisioning commands and
+  env vars; absent ⇒ explicit skip.

--- a/tests/tests-automations/regression/core-functionality/model-provider/ollama-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/ollama-provider.spec.ts
@@ -1,0 +1,295 @@
+import * as dotenv from "dotenv";
+import path from "path";
+import type { APIRequestContext, Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { SettingsPage } from "../../../../pages";
+import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
+import { zoomOut } from "../../../../helpers/ui/zoom-out";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+
+/**
+ * Ollama provider path (QA-CHECKLIST §7.6 "Configure and execute flow with
+ * Ollama (local model)") as a provider-centric journey, mirroring
+ * openai-provider / google-provider for the one provider that is a LOCAL
+ * SERVICE instead of a keyed cloud API:
+ *
+ *   Test 1 — configure the Ollama base URL in Settings → Model Providers;
+ *            assert the save REQUESTS succeed (validate-provider + variables
+ *            persistence, both 2xx) so a no-op save cannot pass.
+ *   Test 2 — a canvas flow (Chat Input → Ollama → Chat Output) pointed at
+ *            the local instance lists the locally pulled model in the
+ *            component's LIVE model dropdown (deterministic connectivity
+ *            proof — Langflow's static Ollama catalog is independent of the
+ *            instance), selects it, and a Playground run returns a
+ *            non-empty reply. The per-run sentinel is logged, not asserted
+ *            (small local models don't reliably echo — family pattern).
+ *
+ * Requires a local Ollama instance (see the spec doc for the provisioning
+ * commands). When Langflow runs in Docker, its container must be started
+ * with LANGFLOW_SSRF_ALLOWED_HOSTS=host.docker.internal — the nightly's
+ * SSRF protection otherwise rejects the private address with a 400
+ * (discovered live; documented in the spec doc). Without a reachable
+ * instance both tests skip with an explicit reason — the same
+ * missing-dependency contract the keyed providers use for absent env keys.
+ */
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
+}
+
+// Reachability probe from the TEST host.
+const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL ?? "http://localhost:11434";
+// The URL typed INTO Langflow — how the (dockerized) Langflow reaches the
+// instance; host.docker.internal resolves to the host from the container.
+const OLLAMA_BASE_URL_FROM_LANGFLOW =
+  process.env.OLLAMA_BASE_URL_FROM_LANGFLOW ?? "http://host.docker.internal:11434";
+const OLLAMA_TEST_MODEL = process.env.OLLAMA_TEST_MODEL ?? "llama3.2:1b";
+
+interface OllamaProbe {
+  reachable: boolean;
+  models: string[];
+  reason: string;
+}
+
+// One probe per worker: GET /api/tags from the test host. Unreachable or
+// model-less instances surface as an explicit skip, never a silent green.
+async function probeOllama(request: APIRequestContext): Promise<OllamaProbe> {
+  try {
+    const res = await request.get(`${OLLAMA_BASE_URL}/api/tags`, { timeout: 5000 });
+    if (res.status() !== 200) {
+      return {
+        reachable: false,
+        models: [],
+        reason: `local Ollama at ${OLLAMA_BASE_URL} answered ${res.status()}`,
+      };
+    }
+    const body = (await res.json()) as { models?: Array<{ name?: string }> };
+    const models = (body.models ?? []).map((m) => m.name ?? "").filter(Boolean);
+    if (!models.includes(OLLAMA_TEST_MODEL)) {
+      return {
+        reachable: false,
+        models,
+        reason: `model "${OLLAMA_TEST_MODEL}" not pulled on the local Ollama (has: ${models.join(", ") || "none"})`,
+      };
+    }
+    return { reachable: true, models, reason: "" };
+  } catch {
+    return {
+      reachable: false,
+      models: [],
+      reason: `local Ollama not reachable at ${OLLAMA_BASE_URL} — see the spec doc's provisioning commands`,
+    };
+  }
+}
+
+// Delete a previously persisted OLLAMA_BASE_URL variable so the test always
+// exercises a REAL first-time configure: with the saved value pre-filled the
+// Save button stays disabled (no change to save) and the request-level
+// asserts could never fire on a re-run.
+async function resetOllamaProviderVariable(request: APIRequestContext): Promise<void> {
+  const bearer = await getAuthToken(request);
+  const headers = { Authorization: bearer };
+  const res = await request.get("/api/v1/variables/", { headers });
+  if (res.status() !== 200) return;
+  const variables = (await res.json()) as Array<{ id: string; name: string }>;
+  for (const v of variables) {
+    if (v.name === "OLLAMA_BASE_URL") {
+      await request.delete(`/api/v1/variables/${v.id}`, { headers }).catch(() => {});
+    }
+  }
+}
+
+async function waitForRunToFinish(page: Page): Promise<void> {
+  const stopButton = page.getByRole("button", { name: "Stop" });
+  const stopVisible = await stopButton.isVisible({ timeout: 10000 }).catch(() => false);
+  if (stopVisible) {
+    // Local CPU inference is slow — allow the small model a wide window.
+    await expect(stopButton).toBeHidden({ timeout: 180000 });
+  }
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Ollama Provider", () => {
+  test(
+    "Ollama base URL is configured via Settings → Model Providers",
+    { tag: ["@stable", "@model-provider", "@settings"] },
+    async ({ page, request }) => {
+      const probe = await probeOllama(request);
+      test.skip(!probe.reachable, probe.reason);
+
+      await resetOllamaProviderVariable(request);
+      await awaitBootstrapTest(page, { skipModal: true });
+
+      await test.step("open Settings → Model Providers → Ollama", async () => {
+        await new SettingsPage(page).navigate();
+        await page.getByTestId("sidebar-nav-Model Providers").click();
+        await expect(page.getByTestId("settings_menu_header").last()).toContainText(
+          "Model Providers",
+          { timeout: 10000 },
+        );
+        await page.getByTestId("provider-item-Ollama").click();
+      });
+
+      await test.step("enter the base URL and save — assert the save requests succeed", async () => {
+        const urlInput = page.getByTestId("provider-variable-input-OLLAMA_BASE_URL");
+        await expect(urlInput).toBeVisible({ timeout: 10000 });
+        await urlInput.fill(OLLAMA_BASE_URL_FROM_LANGFLOW);
+
+        // Arm both waiters BEFORE clicking so the pass is caused by THIS
+        // save, not a state a prior configuration left behind (family
+        // pattern from openai/google-provider).
+        const validatePromise = page.waitForResponse(
+          (r) =>
+            r.url().includes("/api/v1/models/validate-provider") &&
+            r.request().method() === "POST",
+          { timeout: 60000 },
+        );
+        const persistPromise = page.waitForResponse(
+          (r) =>
+            r.url().includes("/api/v1/variables") &&
+            ["POST", "PATCH"].includes(r.request().method()),
+          { timeout: 60000 },
+        );
+
+        await page.getByRole("button", { name: /Save|Replace/i }).first().click();
+
+        const [validateResp, persistResp] = await Promise.all([
+          validatePromise,
+          persistPromise,
+        ]);
+        // validate-provider 2xx = Langflow validated the URL against the
+        // LIVE local instance; variables 2xx = the URL is persisted.
+        expect(validateResp.ok()).toBe(true);
+        expect(persistResp.ok()).toBe(true);
+      });
+    },
+  );
+
+  test(
+    "the Ollama component lists the local model live and executes the flow",
+    { tag: ["@stable", "@regression", "@model-provider", "@components", "@playground"] },
+    async ({ page, request }) => {
+      const probe = await probeOllama(request);
+      test.skip(!probe.reachable, probe.reason);
+
+      // Per-run sentinel: logged (soft) — model obedience is not the contract.
+      const token = `OLLAMA-${Date.now()}`;
+      let flowId = "";
+
+      try {
+        await test.step("create a blank flow with Chat Input → Ollama → Chat Output", async () => {
+          await awaitBootstrapTest(page);
+          await page.waitForSelector('[data-testid="blank-flow"]', { timeout: 30000 });
+          const flowCreation = page.waitForResponse(
+            (r) =>
+              r.url().includes("/api/v1/flows") &&
+              r.request().method() === "POST" &&
+              r.status() === 201,
+            { timeout: 15000 },
+          );
+          await page.getByTestId("blank-flow").click();
+          flowId = ((await (await flowCreation).json()) as { id: string }).id;
+
+          await expect(page.getByTestId("sidebar-search-input")).toBeVisible({ timeout: 30000 });
+
+          await page.getByTestId("sidebar-search-input").fill("chat output");
+          await page.waitForSelector('[data-testid="input_outputChat Output"]', { timeout: 30000 });
+          await page.getByTestId("input_outputChat Output").hover();
+          await page.getByTestId("add-component-button-chat-output").click();
+          await zoomOut(page, 2);
+
+          await page.getByTestId("sidebar-search-input").fill("chat input");
+          await page.waitForSelector('[data-testid="input_outputChat Input"]', { timeout: 30000 });
+          await page
+            .getByTestId("input_outputChat Input")
+            .dragTo(page.locator('//*[@id="react-flow-id"]'), {
+              targetPosition: { x: 100, y: 100 },
+            });
+
+          await page.getByTestId("sidebar-search-input").fill("ollama");
+          await page.waitForSelector('[data-testid="ollamaOllama"]', { timeout: 30000 });
+          await page.getByTestId("ollamaOllama").hover();
+          await page.getByTestId("add-component-button-ollama").click();
+
+          await adjustScreenView(page);
+          await expect(page.locator(".react-flow__node")).toHaveCount(3, { timeout: 10000 });
+
+          // Connect by clicking source handle then target handle
+          // (setup-playground pattern).
+          await page.getByTestId("handle-chatinput-noshownode-chat message-source").click();
+          await page.getByTestId("handle-chatollamacomponent-shownode-input-left").click();
+          await page.getByTestId("handle-chatollamacomponent-shownode-text-right").click();
+          await page.getByTestId("handle-chatoutput-noshownode-inputs-target").click();
+          await expect(page.locator(".react-flow__edge")).toHaveCount(2, { timeout: 8000 });
+        });
+
+        await test.step("point the Ollama node at the local instance", async () => {
+          const baseUrl = page.getByTestId("popover-anchor-input-base_url");
+          await expect(baseUrl).toBeVisible({ timeout: 15000 });
+          // The blur triggers a custom_component/update round-trip that
+          // re-fetches the model list from the NEW url — wait for it to
+          // resolve 2xx before trusting the dropdown (an SSRF-blocked or
+          // unreachable URL answers 400 here).
+          const updatePromise = page.waitForResponse(
+            (r) =>
+              r.url().includes("/api/v1/custom_component/update") &&
+              r.request().method() === "POST" &&
+              r.status() === 200,
+            { timeout: 30000 },
+          );
+          await baseUrl.fill(OLLAMA_BASE_URL_FROM_LANGFLOW);
+          await baseUrl.blur();
+          await updatePromise;
+        });
+
+        await test.step("the LIVE model dropdown lists the locally pulled model — select it", async () => {
+          await page.getByTestId("dropdown_str_model_name").click();
+          const option = page
+            .locator('[data-testid$="-option"]')
+            .filter({ hasText: OLLAMA_TEST_MODEL })
+            .first();
+          // THE connectivity assert: passing requires the component to have
+          // enumerated the real local instance (the static catalog does not
+          // contain the pulled model's tag).
+          await expect(option).toBeVisible({ timeout: 15000 });
+          await option.click();
+          await expect(page.getByTestId("value-dropdown-dropdown_str_model_name")).toContainText(
+            OLLAMA_TEST_MODEL,
+            { timeout: 10000 },
+          );
+          await waitForFlowSaveSettled(page);
+        });
+
+        await test.step("execute the flow through the Playground", async () => {
+          await page.getByTestId("playground-btn-flow-io").click();
+          const chatInput = page.getByTestId("input-chat-playground").last();
+          await expect(chatInput).toBeVisible({ timeout: 30000 });
+          await chatInput.fill(`Repeat this token exactly and nothing else: ${token}`);
+          await page.getByTestId("button-send").last().click();
+          await waitForRunToFinish(page);
+
+          const aiMessage = page.getByTestId("div-chat-message").last();
+          await expect(aiMessage).toBeVisible({ timeout: 60000 });
+          const reply = (await aiMessage.innerText()).trim();
+          // Hard: the selected local model executed and returned output.
+          expect(reply.length).toBeGreaterThan(0);
+          // Soft (family pattern): log whether the sentinel round-tripped.
+          console.log(
+            reply.includes(token)
+              ? `sentinel echoed: input reached the local model (${token})`
+              : `sentinel not echoed (small-model obedience); reply: ${reply.slice(0, 80)}`,
+          );
+        });
+      } finally {
+        if (flowId) {
+          const bearer = await getAuthToken(request);
+          await deleteFlow(request, flowId, { headers: { Authorization: bearer } }).catch(() => {});
+        }
+      }
+    },
+  );
+});


### PR DESCRIPTION
Closes #498

## What this adds

`ollama-provider.spec.ts` + spec doc — QA-CHECKLIST §7.6 "Configure and execute flow with Ollama (local model)", as a provider-centric journey mirroring `openai-provider.spec.ts` / `google-provider.spec.ts` for the one provider that is a **local service** instead of a keyed cloud API. The issue flagged the infra as not provisioned; validation ran against a locally provisioned instance (`docker run -d --name ollama-e2e -p 11434:11434 ollama/ollama` + `ollama pull llama3.2:1b` — commands in the spec doc).

- **Test 1 — configure (Settings).** Settings → Model Providers → Ollama, fill the base URL, save. Asserts the save **requests**: `validate-provider` POST + `/variables` persistence, both 2xx, with waiters armed before the click (family pattern — a no-op save cannot pass). An API reset of the `OLLAMA_BASE_URL` variable runs first so every run is a real first-time configure (found via burst: the pre-filled saved value leaves Save disabled on re-runs).
- **Test 2 — execute (canvas).** Blank flow, Chat Input → **Ollama** → Chat Output connected via handles; `base_url` pointed at the local instance (waits for the `custom_component/update` 200 that re-fetches the model list); the component's **live** model dropdown must list `llama3.2:1b` — the deterministic connectivity assert (Langflow's static Ollama catalog does not contain the pulled tag, so passing requires enumerating the real instance). Select it, run the Playground, assert a non-empty reply; the per-run sentinel is logged, not asserted (small-model obedience is not the contract — same softness as the google sibling).

## Environment requirements (documented in the spec doc + `.env.example`)

- `OLLAMA_BASE_URL` (test-host probe, default `http://localhost:11434`), `OLLAMA_BASE_URL_FROM_LANGFLOW` (URL typed into Langflow, default `http://host.docker.internal:11434`), `OLLAMA_TEST_MODEL` (default `llama3.2:1b`).
- **SSRF allowlist:** the nightly rejects `host.docker.internal` with a 400 on the component's model fetch — the dockerized Langflow needs `LANGFLOW_SSRF_ALLOWED_HOSTS=host.docker.internal` (discovered live while authoring; the local runner container was restarted with it).
- Unreachable instance / missing model ⇒ both tests **skip with an explicit reason** — proven in validation (dead URL → 2 skipped), never a silent green.

## CI note

The stable/nightly workflows have no Ollama service yet, so these tests skip there. Follow-up (separate issue/PR) provisions an `ollama` service container in the workflows (service-to-service hostname `ollama`, HTTP model pull step, `LANGFLOW_SSRF_ALLOWED_HOSTS=ollama`) and proves it via a scoped `manual.yml` dispatch before touching the daily.

## Validation

- Langflow nightly **1.11.0.dev36**; local Ollama `llama3.2:1b`
- 6 clean `--retries=0` runs (2 tests each: first run + 4-burst after the idempotency fix + final post-FF), `--workers=1`, JSON-reporter stats
- Skip-path proven: `OLLAMA_BASE_URL` pointed at a dead port → 2 skipped with reason
- Force-fail executed (all red, revert proven: 0 `FF-MUTATION` markers + final green):
  - M1 — inverted: `validate-provider` expected to fail → failed
  - M2 — never-pulled model (`never-pulled-model:99b`) expected in the live dropdown → failed
  - M3 — inverted: Playground reply expected empty → failed
- `npm run typecheck` ✓, `npm run lint` 0 errors ✓, zero `🚨 Backend Error`
- Flow deleted in `finally` via the `deleteFlow` helper; the Settings variable reset keeps the test idempotent
- `--trace=on` skipped — known local hang limitation (#518); covered by `--retries=0` bursts + executed force-fails
- QA-CHECKLIST bullet §7.6 (Ollama) flipped to `[x]`; generated blocks untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)