### PR TITLE
ci: provision a baked-model Ollama service in the e2e workflows (#583)

### DIFF
--- a/.github/workflows/build-ollama-image.yml
+++ b/.github/workflows/build-ollama-image.yml
@@ -1,0 +1,48 @@
+# Builds and pushes the Ollama-with-model CI image (issue #583).
+#
+# The image is consumed as a service container by the e2e workflows for
+# ollama-provider.spec.ts. Rebuilds are rare: only when docker/ollama-e2e/
+# changes (new model / base bump) or on manual dispatch. Runs on push so it
+# also works from feature branches (workflow_dispatch only resolves workflows
+# present on the default branch).
+name: Build Ollama E2E image
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "docker/ollama-e2e/**"
+      - ".github/workflows/build-ollama-image.yml"
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}/ollama-e2e
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to ghcr
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build
+        run: docker build -t "$IMAGE:llama3.2-1b" docker/ollama-e2e
+      - name: Smoke-test the baked model
+        run: |
+          docker run -d --name smoke -p 11434:11434 "$IMAGE:llama3.2-1b"
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:11434/api/tags && break; sleep 2;
+          done
+          curl -sf http://localhost:11434/api/tags | grep -q "llama3.2:1b"
+          echo "baked model present"
+          docker rm -f smoke
+      - name: Push
+        run: docker push "$IMAGE:llama3.2-1b"

--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -54,12 +54,40 @@ jobs:
           # (see #352). External tracers (LangSmith/Langfuse/etc.) stay dormant
           # here because their API keys are absent.
           LANGFLOW_DEACTIVATE_TRACING: "false"
+          # Ollama runs as a sibling service; without the allowlist the
+          # nightly's SSRF protection 400s the Ollama component's model-list
+          # fetch (private address) — see ollama-provider.spec.ts (#583).
+          LANGFLOW_SSRF_ALLOWED_HOSTS: "ollama"
         options: >-
           --health-cmd "curl -f http://localhost:7860/health_check || exit 1"
           --health-interval 15s
           --health-timeout 10s
           --health-retries 10
           --health-start-period 90s
+      # Local Ollama for ollama-provider.spec.ts (§7.6), test model BAKED
+      # into the image (build-ollama-image.yml) — no per-run model pull. The
+      # tests skip with a reason if the service is absent/unreachable.
+      ollama:
+        image: ghcr.io/${{ github.repository }}/ollama-e2e:llama3.2-1b
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        ports:
+          - 11434:11434
+        options: >-
+          --health-cmd "ollama list || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+          --health-start-period 20s
+
+    # This job runs INSIDE the Playwright container, so both the test process
+    # and Langflow reach Ollama via the job network's service hostname (no
+    # localhost port mapping in here — unlike manual.yml/nightly.yml).
+    env:
+      OLLAMA_BASE_URL: http://ollama:11434
+      OLLAMA_BASE_URL_FROM_LANGFLOW: http://ollama:11434
+      OLLAMA_TEST_MODEL: llama3.2:1b
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -91,11 +91,15 @@ jobs:
           --health-timeout 10s
           --health-retries 10
           --health-start-period 90s
-      # Local Ollama instance for ollama-provider.spec.ts (§7.6). The tests
-      # skip with a reason when it is absent, so other workflows are
-      # unaffected until they add the same service.
+      # Local Ollama instance for ollama-provider.spec.ts (§7.6), with the
+      # test model BAKED into the image (built by build-ollama-image.yml —
+      # no per-run model pull, no registry.ollama.ai dependency). The tests
+      # skip with a reason when the service is absent.
       ollama:
-        image: ollama/ollama
+        image: ghcr.io/${{ github.repository }}/ollama-e2e:llama3.2-1b
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         ports:
           - 11434:11434
         options: >-
@@ -121,16 +125,12 @@ jobs:
       - run: npm ci
       - name: Install Playwright browsers
         uses: ./.github/actions/setup-playwright
-      - name: Pull the Ollama test model
+      - name: Confirm the baked Ollama model is served
         run: |
-          # Readiness first (the service health check should have covered
-          # this; the retry is belt-and-braces), then a blocking pull via the
-          # HTTP API — no docker socket needed from the job.
+          # The model ships inside the image — cheap readiness/sanity check,
+          # not a pull.
           curl -sf --retry 10 --retry-delay 3 --retry-connrefused \
-            "$OLLAMA_BASE_URL/api/tags" > /dev/null
-          curl -s "$OLLAMA_BASE_URL/api/pull" \
-            -d "{\"name\":\"$OLLAMA_TEST_MODEL\"}" | tail -n 1
-          curl -sf "$OLLAMA_BASE_URL/api/tags" | grep -q "$OLLAMA_TEST_MODEL" \
+            "$OLLAMA_BASE_URL/api/tags" | grep -q "$OLLAMA_TEST_MODEL" \
             && echo "model $OLLAMA_TEST_MODEL ready"
       - name: Run tests and upload report
         uses: ./.github/actions/run-e2e

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -81,12 +81,36 @@ jobs:
           # worker never starts when tracing is deactivated — disabling it makes
           # those specs fail deterministically (see #352). Matches daily/weekly.
           LANGFLOW_DEACTIVATE_TRACING: "false"
+          # Ollama runs as a sibling service; without the allowlist the
+          # nightly's SSRF protection 400s the component's model-list fetch
+          # (private address) — see ollama-provider.spec.ts / its spec doc.
+          LANGFLOW_SSRF_ALLOWED_HOSTS: "ollama"
         options: >-
           --health-cmd "curl -f http://localhost:7860/health_check || exit 1"
           --health-interval 15s
           --health-timeout 10s
           --health-retries 10
           --health-start-period 90s
+      # Local Ollama instance for ollama-provider.spec.ts (§7.6). The tests
+      # skip with a reason when it is absent, so other workflows are
+      # unaffected until they add the same service.
+      ollama:
+        image: ollama/ollama
+        ports:
+          - 11434:11434
+        options: >-
+          --health-cmd "ollama list || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+          --health-start-period 20s
+
+    # Reaches the services two ways: the test host uses the mapped port
+    # (localhost), Langflow uses the job network's service hostname.
+    env:
+      OLLAMA_BASE_URL: http://localhost:11434
+      OLLAMA_BASE_URL_FROM_LANGFLOW: http://ollama:11434
+      OLLAMA_TEST_MODEL: llama3.2:1b
 
     steps:
       - uses: actions/checkout@v4
@@ -97,6 +121,17 @@ jobs:
       - run: npm ci
       - name: Install Playwright browsers
         uses: ./.github/actions/setup-playwright
+      - name: Pull the Ollama test model
+        run: |
+          # Readiness first (the service health check should have covered
+          # this; the retry is belt-and-braces), then a blocking pull via the
+          # HTTP API — no docker socket needed from the job.
+          curl -sf --retry 10 --retry-delay 3 --retry-connrefused \
+            "$OLLAMA_BASE_URL/api/tags" > /dev/null
+          curl -s "$OLLAMA_BASE_URL/api/pull" \
+            -d "{\"name\":\"$OLLAMA_TEST_MODEL\"}" | tail -n 1
+          curl -sf "$OLLAMA_BASE_URL/api/tags" | grep -q "$OLLAMA_TEST_MODEL" \
+            && echo "model $OLLAMA_TEST_MODEL ready"
       - name: Run tests and upload report
         uses: ./.github/actions/run-e2e
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,12 +32,39 @@ jobs:
           LANGFLOW_SUPERUSER: langflow
           LANGFLOW_SUPERUSER_PASSWORD: langflow123
           LANGFLOW_DEACTIVATE_TRACING: "true"
+          # Ollama runs as a sibling service; without the allowlist the
+          # nightly's SSRF protection 400s the Ollama component's model-list
+          # fetch (private address) — see ollama-provider.spec.ts (#583).
+          LANGFLOW_SSRF_ALLOWED_HOSTS: "ollama"
         options: >-
           --health-cmd "curl -f http://localhost:7860/health_check || exit 1"
           --health-interval 15s
           --health-timeout 10s
           --health-retries 10
           --health-start-period 90s
+      # Local Ollama for ollama-provider.spec.ts (§7.6), test model BAKED
+      # into the image (build-ollama-image.yml) — no per-run model pull. The
+      # tests skip with a reason if the service is absent/unreachable.
+      ollama:
+        image: ghcr.io/${{ github.repository }}/ollama-e2e:llama3.2-1b
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        ports:
+          - 11434:11434
+        options: >-
+          --health-cmd "ollama list || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+          --health-start-period 20s
+
+    # The job runs on the runner host: it reaches Ollama via the mapped port;
+    # Langflow reaches it via the job network's service hostname.
+    env:
+      OLLAMA_BASE_URL: http://localhost:11434
+      OLLAMA_BASE_URL_FROM_LANGFLOW: http://ollama:11434
+      OLLAMA_TEST_MODEL: llama3.2:1b
 
     steps:
       - uses: actions/checkout@v4

--- a/docker/ollama-e2e/Dockerfile
+++ b/docker/ollama-e2e/Dockerfile
@@ -1,0 +1,27 @@
+# Ollama with the e2e test model baked in — used as a CI service container by
+# ollama-provider.spec.ts (QA-CHECKLIST §7.6, issue #583).
+#
+# Baking the weights into the image removes the per-run 1.3GB pull from
+# registry.ollama.ai (a recurring flake source) and pins the model: CI pulls
+# only from ghcr, the same infra GitHub Actions runs on.
+#
+# Rebuild + push happens via .github/workflows/build-ollama-image.yml (on
+# changes to this file or manual dispatch). To change the model, update
+# OLLAMA_E2E_MODEL here AND OLLAMA_TEST_MODEL in the workflows/.env.
+FROM ollama/ollama:latest
+
+ARG OLLAMA_E2E_MODEL=llama3.2:1b
+
+# `ollama pull` needs the server up; run both in one layer so the downloaded
+# weights (/root/.ollama) are committed into the image.
+RUN ollama serve & \
+    SERVER_PID=$!; \
+    for i in $(seq 1 30); do \
+      ollama list >/dev/null 2>&1 && break; \
+      sleep 1; \
+    done && \
+    ollama pull "$OLLAMA_E2E_MODEL" && \
+    ollama list && \
+    kill "$SERVER_PID"
+
+# Same entrypoint/port as the base image (ollama serve on 11434).


### PR DESCRIPTION
Closes #583

## What this adds

CI provisioning so `ollama-provider.spec.ts` (QA-CHECKLIST §7.6, merged in #582) **executes** in the workflows instead of skipping — using a dedicated Docker image with the test model baked in, per review discussion.

- **`docker/ollama-e2e/Dockerfile`** — `FROM ollama/ollama` with the `llama3.2:1b` weights pulled at BUILD time. CI never downloads from `registry.ollama.ai` at run time (a recurring flake source) — it pulls only `ghcr.io/oriontech-me/langflow-e2e/ollama-e2e:llama3.2-1b`, the same infra Actions runs on.
- **`.github/workflows/build-ollama-image.yml`** — builds, smoke-tests (starts the image, asserts the model is served) and pushes the image. Triggers only on changes to `docker/ollama-e2e/**` or manual dispatch.
- **`manual.yml` / `nightly.yml`** — `ollama` service (ghcr image + `GITHUB_TOKEN` credentials), `LANGFLOW_SSRF_ALLOWED_HOSTS: ollama` on the langflow service (its SSRF protection otherwise 400s the component's model fetch — root-caused in #582), and the `OLLAMA_*` env (test host via mapped port, Langflow via service hostname).
- **`daily-stable.yml`** — same service; this job runs INSIDE the Playwright container, so the test process also reaches Ollama via the job-network hostname (comment in the diff). Tests run in the normal daily job.

## Risk containment

- No run-time model downloads — the only external dependency left is the ghcr pull, pinned to our own image.
- If the service is ever absent/unreachable, the spec **skips with an explicit reason** (proven in #582) — provisioning failure degrades to the pre-#583 behavior, not a red daily.
- `manual.yml` was re-disabled after the validation dispatches (repo convention).

## Validation (scoped `manual.yml` dispatches from this branch)

1. Service + HTTP pull variant: run 28969352048 — `2 passed (29.7s)`, real CPU inference on the runner (sentinel logged), SSRF allowlist effective (Langflow fetched the model list from `http://ollama:11434`).
2. Baked ghcr image (final variant): run 28970759480 — `model llama3.2:1b ready` from the image (no pull step) + `2 passed (29.5s)`.
3. `build-ollama-image.yml` run 28970497920 — build + smoke test + push green.

Evidence also posted on #583.

🤖 Generated with [Claude Code](https://claude.com/claude-code)