### PR TITLE
fix(collect-models): validate providers via candidate list, lead with validated model (#570)

### DIFF
--- a/tests/helpers/provider-setup/collect-models.ts
+++ b/tests/helpers/provider-setup/collect-models.ts
@@ -121,17 +121,96 @@ async function validateGoogle(model: string): Promise<ProviderRecord> {
   }
 }
 
-function firstModelFor(models: ModelRecord[], provider: string): string {
-  return models.find((m) => m.provider === provider)?.model ?? "";
+// Cheap/small models to try first (fast + inexpensive validation calls).
+const CHEAP_HINT = /nano|mini|flash|haiku|lite|small/i;
+// Gated or non-chat models to try last: reasoning "pro" tiers, the o-series,
+// codex, preview/image/embedding/audio variants. These lead the nightly provider
+// panel (e.g. `gpt-5.5-pro`, `gpt-image-2`) but are commonly access-gated, so they
+// must not be the sole basis for marking a provider inactive (issue #570).
+const GATED_OR_NON_CHAT =
+  /(^|[-\s])pro([-\s]|$)|(^|[-\s])o[1-9]([-\s]|$)|reasoning|codex|preview|image|embedding|audio|tts|realtime|vision|deep-research|moderation|transcribe/i;
+// Cap the number of real validation calls per provider.
+const MAX_CANDIDATES = 6;
+
+// Ordered list of models to try when validating a provider: cheap/small first,
+// then normal chat models, then gated/non-chat last — so a gated lead model does not
+// disable the whole provider when an accessible model exists (issue #570).
+function candidateModelsFor(models: ModelRecord[], provider: string): string[] {
+  const all = models.filter((m) => m.provider === provider).map((m) => m.model);
+  const cheap = all.filter((m) => CHEAP_HINT.test(m) && !GATED_OR_NON_CHAT.test(m));
+  const normal = all.filter((m) => !CHEAP_HINT.test(m) && !GATED_OR_NON_CHAT.test(m));
+  const gated = all.filter((m) => GATED_OR_NON_CHAT.test(m));
+  return [...new Set([...cheap, ...normal, ...gated])].slice(0, MAX_CANDIDATES);
+}
+
+// Validates a provider against its candidate models in order, stopping at the first
+// that succeeds. Returns that active record, or the last inactive one (with its real
+// error) if none validate. Logs each attempt so CI shows what was tried and settled on.
+async function validateWithCandidates(
+  provider: string,
+  candidates: string[],
+  validateOne: (model: string) => Promise<ProviderRecord>,
+): Promise<ProviderRecord> {
+  let last: ProviderRecord | null = null;
+  for (const model of candidates) {
+    const rec = await validateOne(model);
+    if (rec.status === "active") {
+      console.log(`   ${provider}: settled on ${model}`);
+      return rec;
+    }
+    console.log(`   ${provider}: ${model} unavailable — ${rec.error ?? "unknown"}`);
+    last = rec;
+  }
+  return (
+    last ?? {
+      provider,
+      model: null,
+      status: "inactive",
+      error: "no candidate models found",
+      checkedAt: new Date().toISOString(),
+    }
+  );
+}
+
+// Reorders models.json so each active provider's *validated* model leads its group.
+// getTestTargets picks the first model per provider, so without this the agent specs
+// would still parametrize on the gated lead (e.g. `gpt-5.5-pro`) even though the
+// provider validated on an accessible model — running (not skipping) but then failing
+// on a no-access/reasoning model (issue #570). Provider grouping and intra-group order
+// are otherwise preserved.
+function reorderModelsByValidated(
+  models: ModelRecord[],
+  providers: ProviderRecord[],
+): ModelRecord[] {
+  const validated = new Map<string, string>();
+  for (const p of providers) {
+    if (p.status === "active" && p.model) validated.set(p.provider, p.model);
+  }
+
+  const byProvider = new Map<string, ModelRecord[]>();
+  for (const m of models) {
+    const list = byProvider.get(m.provider) ?? [];
+    list.push(m);
+    byProvider.set(m.provider, list);
+  }
+
+  const result: ModelRecord[] = [];
+  for (const [provider, list] of byProvider) {
+    const lead = validated.get(provider);
+    const leadEntries = lead ? list.filter((m) => m.model === lead) : [];
+    const rest = list.filter((m) => !(lead && m.model === lead));
+    result.push(...leadEntries, ...rest);
+  }
+  return result;
 }
 
 async function collectProviders(models: ModelRecord[]): Promise<ProviderRecord[]> {
   console.log("Validando provedores via API...");
 
   const results = await Promise.all([
-    validateOpenAI(firstModelFor(models, "openai")),
-    validateAnthropic(firstModelFor(models, "anthropic")),
-    validateGoogle(firstModelFor(models, "google")),
+    validateWithCandidates("openai", candidateModelsFor(models, "openai"), validateOpenAI),
+    validateWithCandidates("anthropic", candidateModelsFor(models, "anthropic"), validateAnthropic),
+    validateWithCandidates("google", candidateModelsFor(models, "google"), validateGoogle),
   ]);
 
   for (const r of results) {
@@ -246,11 +325,17 @@ export async function collectAll(page: Page): Promise<void> {
 
   // Step 1: Collect models from UI via Settings
   const models = await collectModels(page);
-  fs.writeFileSync(MODELS_PATH, JSON.stringify(models, null, 2), "utf-8");
-  console.log(`models.json salvo com ${models.length} modelos.`);
 
-  // Step 2: Validate providers via API using the first model of each provider
+  // Step 2: Validate providers via API, trying candidate models until one works
+  // (a gated lead model must not disable the whole provider — issue #570).
   const providers = await collectProviders(models);
+
+  // Step 3: Lead each provider's group with its validated model so getTestTargets
+  // parametrizes agent specs on an accessible model, not the gated lead (issue #570).
+  const orderedModels = reorderModelsByValidated(models, providers);
+
+  fs.writeFileSync(MODELS_PATH, JSON.stringify(orderedModels, null, 2), "utf-8");
+  console.log(`models.json salvo com ${orderedModels.length} modelos.`);
   fs.writeFileSync(PROVIDERS_PATH, JSON.stringify(providers, null, 2), "utf-8");
   console.log(`providers.json salvo com ${providers.length} provedores.`);
 }


### PR DESCRIPTION
## Issue

Closes #570 (`daily-failure` — approved exception).

`collect-models` validated each provider using **only the first model** (`firstModelFor`), so a single access-gated lead model marked the whole provider `inactive` and every provider-variant agent test skipped itself. On nightly:

- OpenAI lead = `gpt-5.5-pro` → CI project has no access → **16 OpenAI `@stable` agent tests silently skipped**.
- Anthropic lead = `claude-fable-5` → "not available" → Anthropic disabled too (same bug).
- Google lead = `gemini-3.5-flash` → happened to be accessible (lucky).

## Fix (proposal (a) + the necessary companion)

**1. Candidate-list validation** — `collectProviders` now tries an ordered candidate list per provider (cheap/small first, gated/non-chat like `pro`/`o1-o4`/`codex`/`preview`/`image` last), stopping at the first that validates, and logs the settled model. A gated lead no longer disables the whole provider when an accessible model exists.

**2. Lead models.json with the validated model** — `getTestTargets` (in the agent specs) picks the **first model per provider** from `models.json`, so provider-active alone would still parametrize the tests on `gpt-5.5-pro` and turn 16 silent skips into 16 **failures** (no access / reasoning). `reorderModelsByValidated` moves each active provider's validated model to the front of its group, so the agent specs run on an accessible model (`gpt-5.4-nano`) without touching the ~15 duplicated `getTestTargets` copies.

## Validation (local)

`collect-models` run:
```
✅ openai (gpt-5.4-nano)      settled on gpt-5.4-nano
✅ anthropic (claude-haiku-4-5)  settled on claude-haiku-4-5
✅ google (gemini-3.1-flash-lite) settled on gemini-3.1-flash-lite
```
`models.json` now leads each provider with the validated model. `agent-system-prompt` re-run:
- `[openai / gpt-5.4-nano]` — **runs and passes** (was skipping on inactive openai; would have failed on `gpt-5.5-pro`).
- `[anthropic / claude-haiku-4-5]` — runs and passes.

`tsc --noEmit` clean; `eslint` 0 errors (warnings pre-existing). `providers.json`/`models.json` are gitignored (CI-regenerated) — not committed.

## Acceptance criteria

- [x] A gated lead model no longer marks the whole provider `inactive` when another accessible model exists
- [x] The OpenAI-variant agent tests run (not skip) — and on an accessible model, so they pass
- [x] `collect-models` logs which model it settled on per provider
- [x] `npm run typecheck` / `npm run lint` pass

## Out of scope (separate, pre-existing flake)

`agent-system-prompt [google / gemini-3.1-flash-lite]` intermittently fails with a `page.waitForResponse` 15s timeout at "wait for autosave" — a UI-autosave timing flake on the google run, model-agnostic and independent of this change (google was already parametrized before). Candidate for its own follow-up.
