### PR TITLE
test(provider-setup): harden and promote collect-models to @stable (#501)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -373,11 +373,11 @@
 > See `helpers/provider-setup/` for the setup helpers of each provider.
 
 #### 7.1 Provider Collection and Validation
-- [-] Validate API keys of all providers via real call → `collect-models.spec.ts`
-- [-] Collect available models per provider via UI → `collect-models.spec.ts`
+- [x] Validate API keys of all providers via real call → `collect-models.spec.ts`
+- [x] Collect available models per provider via UI → `collect-models.spec.ts`
 - [x] Inactive providers appear as skipped in tests with reason → `agent-component-regression.spec.ts`
-- [-] Configure provider API key via Save Configuration (first setup) → `collect-models.spec.ts`
-- [-] Replace provider API key via Replace Configuration (existing key) → `collect-models.spec.ts`
+- [x] Configure provider API key via Save Configuration (first setup) → `collect-models.spec.ts`
+- [x] Replace provider API key via Replace Configuration (existing key) → `collect-models.spec.ts`
 
 #### 7.2 OpenAI
 - [x] Configure OpenAI API key in Settings → Model Providers → `core-functionality/model-provider/openai-provider.spec.ts`

--- a/docs/collect-models.md
+++ b/docs/collect-models.md
@@ -1,6 +1,6 @@
 # Collect Models
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.11.x
 
 ---
 
@@ -17,7 +17,15 @@ If this spec is not run before the LLM agent specs, those specs fall back to a h
 
 ## Tags *(required)*
 
-_(none — this is a setup helper, not a validation test)_
+`@stable` `@model-provider` `@settings`
+
+Promoted by issue #501 (QA-CHECKLIST §7.1 ×4: key validation via real call,
+model collection via UI, Save Configuration, Replace/Disconnect state).
+Historically untagged as "just a setup helper" — promotion required a
+force-failability hardening pass (see Validation criterion): the previous
+contract ("never throws") meant a fully broken Model Providers UI still
+produced a green run with empty JSONs, which would blind the daily on this
+surface (the #505 lesson).
 
 ---
 
@@ -37,9 +45,23 @@ _(none — this is a setup helper, not a validation test)_
 
 ## Validation criterion *(required)*
 
-- `data/models.json` is written with at least one model per provider whose API key is set in the environment
-- `data/providers.json` is written with one record per provider; `status` is `"active"` if the direct API call returned 2xx, `"inactive"` otherwise
-- No unhandled exception is thrown; providers whose key is missing are recorded as `inactive` without failing the test
+Hard asserts in the spec, executed AFTER `collectAll` (the helper itself
+stays tolerant — writing "inactive" records instead of throwing is its
+contract; the SPEC now verifies the outcome):
+
+- `data/providers.json` exists and contains exactly one record per known
+  provider (`openai`, `anthropic`, `google`), each with
+  `status ∈ {active, inactive}` and a `checkedAt` timestamp;
+- every provider recorded `active` contributed **at least one model** to
+  `data/models.json` (an active key with an empty model collection means the
+  Settings UI collection broke — the exact silent failure the old contract
+  hid);
+- every provider with its env key set that came back `inactive` carries a
+  non-empty `error` (the probe's reason is visible, never silently dropped).
+
+A provider with a key that genuinely fails its probe (e.g. a model the
+account cannot access) is a legitimate `inactive` — recorded, logged, not a
+test failure.
 
 ---
 
@@ -75,6 +97,7 @@ _(none — this is a setup helper, not a validation test)_
 
 ## Notes *(optional)*
 
-- In CI (`weekly-stable.yml`) this spec runs as a dedicated **Collect models** step before the `@stable` suite, ensuring `models.json` is on disk before Playwright's collection phase. The step uses `continue-on-error: true` so a missing API key does not block the rest of the run.
+- In CI (`daily-stable.yml`) this spec runs as a dedicated **Collect models** step before the `@stable` suite, ensuring `models.json` is on disk before Playwright's collection phase. The step uses `continue-on-error: true` so a missing API key does not block the rest of the run.
+- **Double-run in the daily (analyzed, benign):** with `@stable` the spec ALSO runs inside the suite. The in-suite run re-saves the same keys (the exact flow `openai-provider`/`google-provider` test 1 already exercise in-suite) and rewrites the JSONs with equivalent content; workers read the files at module load, so a mid-suite rewrite does not change already-collected test targets.
 - Run this spec locally before any LLM agent or model-provider specs: `npx playwright test tests/collect-models.spec.ts`
 - If `models.json` is empty after running, check that the provider panel animates in before the form is read and that button labels match (`Save` / `Replace`)

--- a/tests/collect-models.spec.ts
+++ b/tests/collect-models.spec.ts
@@ -1,15 +1,82 @@
 import * as dotenv from "dotenv";
 import path from "path";
-import { test } from "./fixtures/fixtures";
+import fs from "fs";
+import { expect, test } from "./fixtures/fixtures";
 import { collectAll } from "./helpers/provider-setup/collect-models";
+import type { ProviderRecord } from "./helpers/provider-setup/collect-models";
+import { providerConfigMap, type Provider } from "./helpers/provider-setup";
+
+/**
+ * Utility spec that populates the provider data files every LLM spec depends
+ * on (QA-CHECKLIST §7.1: key validation via real call, model collection via
+ * the Settings UI, Save/Replace configuration) — promoted to @stable by #501.
+ *
+ * The collectAll helper stays TOLERANT by contract (a provider whose key is
+ * missing or fails its probe is recorded "inactive", never thrown). The
+ * asserts below are the force-failability hardening the promotion required:
+ * before them, a fully broken Model Providers UI still produced a green run
+ * with empty JSONs (the #505 class of blind spot).
+ */
 
 if (!process.env.CI) {
   dotenv.config({ path: path.resolve(__dirname, "../.env") });
 }
 
-test("collect providers status and models from UI", async ({ page }) => {
-  await page.goto("/");
-  await page.waitForSelector('[data-testid="mainpage_title"]', { timeout: 30000 });
+const DATA_DIR = path.resolve(__dirname, "helpers/provider-setup/data");
+const PROVIDERS_PATH = path.join(DATA_DIR, "providers.json");
+const MODELS_PATH = path.join(DATA_DIR, "models.json");
 
-  await collectAll(page);
-});
+interface ModelRecord {
+  provider: string;
+  model: string;
+}
+
+test(
+  "collect providers status and models from UI",
+  { tag: ["@stable", "@model-provider", "@settings"] },
+  async ({ page }) => {
+    await page.goto("/");
+    await page.waitForSelector('[data-testid="mainpage_title"]', { timeout: 30000 });
+
+    await collectAll(page);
+
+    await test.step("providers.json has exactly one valid record per known provider", async () => {
+      expect(fs.existsSync(PROVIDERS_PATH), `${PROVIDERS_PATH} was written`).toBe(true);
+      const providers = JSON.parse(fs.readFileSync(PROVIDERS_PATH, "utf-8")) as ProviderRecord[];
+      const known = Object.keys(providerConfigMap).sort();
+      expect(providers.map((p) => p.provider).sort()).toEqual(known);
+      for (const p of providers) {
+        expect(["active", "inactive"], `status of ${p.provider}`).toContain(p.status);
+        expect(p.checkedAt, `checkedAt of ${p.provider}`).toBeTruthy();
+      }
+    });
+
+    await test.step("every ACTIVE provider contributed at least one model", async () => {
+      expect(fs.existsSync(MODELS_PATH), `${MODELS_PATH} was written`).toBe(true);
+      const models = JSON.parse(fs.readFileSync(MODELS_PATH, "utf-8")) as ModelRecord[];
+      const providers = JSON.parse(fs.readFileSync(PROVIDERS_PATH, "utf-8")) as ProviderRecord[];
+      for (const p of providers.filter((r) => r.status === "active")) {
+        // An active key with an empty model collection means the Settings UI
+        // collection silently broke — the exact failure the old "never
+        // throws" contract hid.
+        expect(
+          models.filter((m) => m.provider === p.provider).length,
+          `models collected for active provider "${p.provider}"`,
+        ).toBeGreaterThan(0);
+      }
+    });
+
+    await test.step("an env-keyed provider that probed inactive carries the probe error", async () => {
+      const providers = JSON.parse(fs.readFileSync(PROVIDERS_PATH, "utf-8")) as ProviderRecord[];
+      for (const p of providers.filter((r) => r.status === "inactive")) {
+        const envKeys = providerConfigMap[p.provider as Provider]?.envKeys ?? [];
+        const hasEnvKey = envKeys.some((k: string) => !!process.env[k]);
+        if (hasEnvKey) {
+          // Legitimate inactive (e.g. an account without access to the probe
+          // model) — but the REASON must be recorded, never silently dropped.
+          expect(p.error, `probe error recorded for env-keyed inactive provider "${p.provider}"`).toBeTruthy();
+        }
+      }
+    });
+  },
+);

--- a/tests/helpers/provider-setup/collect-models.ts
+++ b/tests/helpers/provider-setup/collect-models.ts
@@ -126,7 +126,7 @@ function firstModelFor(models: ModelRecord[], provider: string): string {
 }
 
 async function collectProviders(models: ModelRecord[]): Promise<ProviderRecord[]> {
-  console.log("Validando provedores via API...");
+  console.log("Validating providers via API...");
 
   const results = await Promise.all([
     validateOpenAI(firstModelFor(models, "openai")),
@@ -208,7 +208,7 @@ async function collectModelsForProvider(
     }
   }
 
-  console.log(`Modelos encontrados (${providerName}):`, models.map((m) => m.model));
+  console.log(`Models found (${providerName}):`, models.map((m) => m.model));
 
   await page.getByTestId("sidebar-nav-Model Providers").click();
 
@@ -247,10 +247,10 @@ export async function collectAll(page: Page): Promise<void> {
   // Step 1: Collect models from UI via Settings
   const models = await collectModels(page);
   fs.writeFileSync(MODELS_PATH, JSON.stringify(models, null, 2), "utf-8");
-  console.log(`models.json salvo com ${models.length} modelos.`);
+  console.log(`models.json saved with ${models.length} models.`);
 
   // Step 2: Validate providers via API using the first model of each provider
   const providers = await collectProviders(models);
   fs.writeFileSync(PROVIDERS_PATH, JSON.stringify(providers, null, 2), "utf-8");
-  console.log(`providers.json salvo com ${providers.length} provedores.`);
+  console.log(`providers.json saved with ${providers.length} providers.`);
 }


### PR DESCRIPTION
Closes #501

## What this does

Promotes `tests/collect-models.spec.ts` — the utility spec that populates `models.json`/`providers.json` for the whole LLM family — to `@stable`, covering QA-CHECKLIST §7.1 ×4 (key validation via real call, model collection via the Settings UI, Save Configuration, Replace Configuration).

## Force-failability hardening (required by the promotion)

The baseline audit failed: the spec's contract was "never throws" (`.catch(() => {})` throughout the helper), so a fully broken Model Providers UI still produced a **green** run with empty JSONs — promoting that as-is would blind the daily on this surface (the #505 lesson; hardening weak tests is in a validate-&-promote issue's scope). The fix keeps the **helper** tolerant (recording keyless/failed providers as `inactive` is its contract) and adds hard asserts to the **spec** on the outcome:

- `providers.json` has exactly one record per known provider (`openai`, `anthropic`, `google`), each with `status ∈ {active, inactive}` and `checkedAt`;
- every **active** provider contributed ≥1 model to `models.json` — an active key with an empty collection means the UI collection silently broke (the exact hole the old contract hid);
- every env-keyed provider that probed **inactive** carries a non-empty `error` — the probe's reason is visible, never dropped (e.g. the current org key probing `gpt-5.5-pro` without access: recorded inactive with the API's message, legitimately not a failure).

Also: the helper's four Portuguese `console.log` strings translated to English (repo language rule), and the spec doc updated (Tags section, hardened Validation criterion, `Last validated: 1.11.x`).

## Daily double-run (analyzed in the spec doc — benign)

`daily-stable.yml` already runs this spec as a pre-suite step; with `@stable` it also runs inside the suite. The in-suite run re-saves the same keys (the flow `openai-provider`/`google-provider` test 1 already exercise in-suite) and rewrites the JSONs with equivalent content; workers read the files at module load, so a mid-suite rewrite does not change already-collected targets.

## Validation

- Langflow nightly **1.11.0.dev36** (confirmed latest at validation time)
- 4 clean `--retries=0` runs (pipeline 3-burst + post-FF final), JSON-reporter stats; user also validated manually (65 models / 3 providers, google active, openai+anthropic inactive with recorded reasons)
- Force-fail executed (all red; revert proven: 0 `FF-MUTATION` markers + final green):
  - M1 — phantom provider added to the required set → failed
  - M2 — model presence required for INACTIVE providers too → failed
  - M3 — behavioral: `models.json` deleted after `collectAll` → the existence assert caught the lost write → failed
- `npm run typecheck` ✓, `npm run lint` 0 errors ✓, zero `🚨 Backend Error`
- QA-CHECKLIST §7.1 bullets ×4 flipped `[-]` → `[x]`; generated blocks untouched
- No flows created by this spec (Settings-only); data files regenerated on every run by design

🤖 Generated with [Claude Code](https://claude.com/claude-code)