### PR TITLE
fix(flows): scope flow teardown off global cleanAllFlows (#515)

### DIFF
--- a/docs/core-components/loop-component-regression.md
+++ b/docs/core-components/loop-component-regression.md
@@ -54,7 +54,7 @@ If any of these tests fails, the Loop component is broken in the product: either
 11. Assert the message **contains** "title" (case-insensitive) via `toContainText(/title/i, { timeout: 240000 })`. `toContainText` re-evaluates as tokens stream in, so it never samples a partially-streamed response — this is what makes the assertion robust against the streaming race tracked in #356 (the earlier code read the text once, on the first streamed token, and intermittently saw no "title" yet). Matching ≥ 1 occurrence confirms at least one complete loop iteration (Parser → LLM → done)
 
 **Test 4 — stops after exhausting input DataFrame and emits aggregated done**
-1. `awaitBootstrapTest` and `cleanAllFlows`
+1. `awaitBootstrapTest` (each created flow's id is tracked and deleted in `afterEach` — scoped teardown, #515 — never a global `cleanAllFlows`, which races concurrent workers)
 2. Build a flow body in-memory from `tests/assets/flows/loop-exit-condition.json` with the Create List node's `texts.value` set to a 3-element list and a randomized flow name
 3. `POST /api/v1/flows/` with the body to create the flow server-side
 4. Navigate to "/" and click the flow card matching the randomized name (the home navigation triggers a full owned-flows re-fetch, avoiding the deep-link cache race)

--- a/docs/core-components/webhook-component-regression.md
+++ b/docs/core-components/webhook-component-regression.md
@@ -38,8 +38,8 @@ If any of these tests fails, the Webhook component is broken in one of its core 
 ## Step by step *(required)*
 
 **Setup helper — `addWebhookComponent`** (shared by tests 1–9)
-1. Call `awaitBootstrapTest` and `cleanAllFlows` to ensure a clean state
-2. Click `blank-flow`
+1. Call `awaitBootstrapTest`
+2. Click `blank-flow`, then capture the created flow id from the `/flow/{id}` URL so `afterEach` can delete only that flow (scoped teardown, #515 — never a global `cleanAllFlows`, which races concurrent workers)
 3. Search "webhook" in the sidebar and wait for `input_outputWebhook` to appear
 4. Hover over the result and click `add-component-button-webhook`
 5. Call `adjustScreenView`

--- a/docs/core-components/webhook-component-regression.md
+++ b/docs/core-components/webhook-component-regression.md
@@ -39,7 +39,7 @@ If any of these tests fails, the Webhook component is broken in one of its core 
 
 **Setup helper — `addWebhookComponent`** (shared by tests 1–9)
 1. Call `awaitBootstrapTest`
-2. Click `blank-flow`, then capture the created flow id from the `/flow/{id}` URL so `afterEach` can delete only that flow (scoped teardown, #515 — never a global `cleanAllFlows`, which races concurrent workers)
+2. Click `blank-flow`, then capture the created flow id from the `POST /api/v1/flows/` response so `afterEach` can delete only that flow (scoped teardown, #515 — never a global `cleanAllFlows`, which races concurrent workers). The canvas `/flow/{id}` URL id is a transient client-side handle here and 404s on delete; the tests still read it for their own webhook-endpoint assertions, which resolve fine by that id
 3. Search "webhook" in the sidebar and wait for `input_outputWebhook` to appear
 4. Hover over the result and click `add-component-button-webhook`
 5. Call `adjustScreenView`

--- a/tests/pages/SimpleAgentTemplatePage.ts
+++ b/tests/pages/SimpleAgentTemplatePage.ts
@@ -19,7 +19,13 @@ export class SimpleAgentTemplatePage extends BasePage {
     super(page);
   }
 
-  async load(options: LoadSimpleAgentOptions = {}): Promise<void> {
+  /**
+   * Loads the Simple Agent template and configures the provider. Returns the
+   * created flow's id (from `loadTemplateByName`) so callers can delete only
+   * that flow in their teardown — never a global `cleanAllFlows`, which races
+   * concurrent tests in the fully-parallel suite (#515).
+   */
+  async load(options: LoadSimpleAgentOptions = {}): Promise<string> {
     const { provider = "openai", model } = options;
 
     if (!hasProviderEnvKeys(provider)) {
@@ -28,13 +34,16 @@ export class SimpleAgentTemplatePage extends BasePage {
       );
     }
 
-    // Load the Simple Agent template onto the canvas (clears existing flows,
-    // opens the templates modal, handles the 1.10.0 welcome overlay).
-    await loadTemplateByName(this.page, "Simple Agent");
+    // Load the Simple Agent template onto the canvas (opens the templates modal,
+    // handles the 1.10.0 welcome overlay). Deliberately does NOT clear existing
+    // flows — the cross-worker wipe was removed in #553.
+    const flowId = await loadTemplateByName(this.page, "Simple Agent");
 
     // Adjust canvas view and configure the provider.
     // JSON stores model names (e.g. "claude-opus-4-6") — passed directly to setup for hasText matching
     await adjustScreenView(this.page);
     await providerSetupMap[provider](this.page, model);
+
+    return flowId;
   }
 }

--- a/tests/tests-automations/regression/core-components/agent-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/agent-component-regression.spec.ts
@@ -2,17 +2,37 @@ import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
-import { cleanAllFlows } from "../../../helpers/flows/clean-all-flows";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { renameFlow } from "../../../helpers/flows/rename-flow";
 
 // Each test creates a flow that autosaves to the backend. Serial mode prevents
-// parallel autosave races and keeps cleanAllFlows deterministic between tests.
+// parallel autosave races within this file.
 test.describe.configure({ mode: "serial" });
+
+// Id of the flow the running test created; teardown deletes only this one via
+// the API (scoped) — never a global cleanAllFlows, which wipes flows other
+// parallel workers are actively building mid-run (#515).
+let createdFlowId: string | undefined;
 
 async function addAgentToBlankFlow(page: Page): Promise<void> {
   await awaitBootstrapTest(page);
   await page.waitForSelector('[data-testid="blank-flow"]', { timeout: 30000 });
+  // Capture the id from the flow-creation POST, NOT from the canvas URL: the URL
+  // id is a transient client-side handle on this Langflow version and does not
+  // match the persisted flow (deleting it 404s and silently leaks the real one).
+  // The POST response is the authoritative id (same pattern as setup-blank-flow
+  // and load-template-by-name).
+  const flowCreation = page.waitForResponse(
+    (resp) =>
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201,
+    { timeout: 30000 },
+  );
   await page.getByTestId("blank-flow").click();
+  createdFlowId = ((await (await flowCreation).json()) as { id?: string }).id;
+  await page.waitForURL(/\/flow\//, { timeout: 30000 });
 
   await page.getByTestId("disclosure-models & agents").click();
   await page.waitForSelector('[data-testid="models_and_agentsAgent"]', {
@@ -31,12 +51,21 @@ async function addAgentToBlankFlow(page: Page): Promise<void> {
 
 test.describe("Agent Component — canvas regression", () => {
   test.afterEach(async ({ page }) => {
-    try {
-      await page.goto("/");
-      await cleanAllFlows(page);
-    } catch {
-      // best-effort cleanup
-    }
+    const flowId = createdFlowId;
+    createdFlowId = undefined;
+    if (!flowId) return;
+    // Delete ONLY the flow this test created (scoped teardown, #515). Navigate
+    // off the editor first so the unmounted flow page stops polling the flow we
+    // are about to delete, then pass an explicit auth header — page.request is
+    // unauthenticated under AUTO_LOGIN and would 401 otherwise. Not swallowed: a
+    // failed cleanup surfaces instead of silently leaking the flow (#547).
+    await page.goto("/");
+    const authHeader = await getAuthToken(page.request);
+    await deleteFlow(
+      page.request,
+      flowId,
+      authHeader ? { headers: { Authorization: authHeader } } : undefined,
+    );
   });
 
   test(

--- a/tests/tests-automations/regression/core-components/agent-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/agent-component-regression.spec.ts
@@ -31,7 +31,11 @@ async function addAgentToBlankFlow(page: Page): Promise<void> {
     { timeout: 30000 },
   );
   await page.getByTestId("blank-flow").click();
-  createdFlowId = ((await (await flowCreation).json()) as { id?: string }).id;
+  const created = (await (await flowCreation).json()) as { id?: string };
+  if (!created.id) {
+    throw new Error("blank-flow creation returned no flow id");
+  }
+  createdFlowId = created.id;
   await page.waitForURL(/\/flow\//, { timeout: 30000 });
 
   await page.getByTestId("disclosure-models & agents").click();

--- a/tests/tests-automations/regression/core-components/loop-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/loop-component-regression.spec.ts
@@ -4,17 +4,53 @@ import { expect, test } from "../../../fixtures/fixtures";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
-import { cleanAllFlows } from "../../../helpers/flows/clean-all-flows";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
 import { setupLanguageModelOpenAI } from "../../../helpers/provider-setup/setup-language-model-openai";
 
 // Run tests serially to avoid "flow must be unique" 400 errors from parallel autosaves
 test.describe.configure({ mode: "serial" });
 
+// Ids of the flows each test creates; teardown deletes only these via the API
+// (scoped) — never a global cleanAllFlows, which wipes flows other parallel
+// workers are actively building mid-run (#515).
+const createdFlowIds: string[] = [];
+
+test.afterEach(async ({ page }) => {
+  const ids = createdFlowIds.splice(0);
+  if (ids.length === 0) return;
+  // Delete ONLY the flows this test created (scoped teardown, #515). Navigate
+  // off the editor first so the unmounted flow page stops polling a flow we are
+  // about to delete, then pass an explicit auth header — page.request is
+  // unauthenticated under AUTO_LOGIN and would 401 otherwise. Not swallowed: a
+  // failed cleanup surfaces instead of silently leaking the flow (#547).
+  await page.goto("/");
+  const authHeader = await getAuthToken(page.request);
+  const opts = authHeader
+    ? { headers: { Authorization: authHeader } }
+    : undefined;
+  for (const id of ids) {
+    await deleteFlow(page.request, id, opts);
+  }
+});
+
 // Helper: create a blank flow and add the Loop component to the canvas.
 // After this call the component node is visible and the inspector is open.
 async function addLoopComponent(page: Page) {
   await awaitBootstrapTest(page);
+  // Capture the id from the flow-creation POST, NOT from the canvas URL: the URL
+  // id is a transient client-side handle on this Langflow version and does not
+  // match the persisted flow (deleting it 404s and silently leaks the real one).
+  const flowCreation = page.waitForResponse(
+    (resp) =>
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201,
+    { timeout: 30000 },
+  );
   await page.getByTestId("blank-flow").click();
+  const id = ((await (await flowCreation).json()) as { id?: string }).id;
+  if (id) createdFlowIds.push(id);
+  await page.waitForURL(/\/flow\//, { timeout: 30000 });
   await page.getByTestId("sidebar-search-input").fill("Loop");
   await page.waitForSelector('[data-testid="add-component-button-loop"]', {
     timeout: 10000,
@@ -134,7 +170,18 @@ test(
     await page.waitForSelector('[data-testid="template-research-translation-loop"]', {
       timeout: 10000,
     });
+    // Capture the id from the template-instantiation POST so teardown can delete
+    // only this flow (scoped, #515).
+    const flowCreation = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/v1/flows") &&
+        resp.request().method() === "POST" &&
+        resp.status() === 201,
+      { timeout: 30000 },
+    );
     await page.getByTestId("template-research-translation-loop").click();
+    const createdId = ((await (await flowCreation).json()) as { id?: string }).id;
+    if (createdId) createdFlowIds.push(createdId);
     await page.waitForSelector('[data-testid="title-Loop"]', { timeout: 15000 });
     await adjustScreenView(page);
 
@@ -234,9 +281,9 @@ function buildFlowBody(texts: string[]): {
 
 // Creates the flow server-side via POST /api/v1/flows/ using Playwright's
 // request context. Avoids the drag-drop upload race observed with
-// simulateDragAndDrop and aligns with the pattern used by cleanAllFlows and
-// the api/flows specs (request context + getAuthToken). Returns the new flow
-// id so callers can target cleanup or deep-link if needed.
+// simulateDragAndDrop and aligns with the pattern used by the api/flows specs
+// (request context + getAuthToken). Returns the new flow id so callers can
+// target scoped cleanup or deep-link if needed.
 async function createFlowFromAsset(
   request: APIRequestContext,
   flow: Record<string, unknown>,
@@ -260,7 +307,8 @@ async function runFlowAndReadDoneCount(
   texts: string[],
 ): Promise<number> {
   const { flow, name } = buildFlowBody(texts);
-  await createFlowFromAsset(request, flow);
+  const flowId = await createFlowFromAsset(request, flow);
+  createdFlowIds.push(flowId);
 
   // Click the flow card on the home page — matches user behavior and is more
   // reliable than deep-linking /flow/{id}, which intermittently redirects to
@@ -308,13 +356,11 @@ test(
 
     await test.step("N=3: loop iterates 3 times and done aggregates 3 items", async () => {
       await awaitBootstrapTest(page, { skipModal: true });
-      await cleanAllFlows(page);
       count = await runFlowAndReadDoneCount(page, request, ["a", "b", "c"]);
       expect(count).toBe(3);
     });
 
     await test.step("N=1: edge case — single iteration aggregates 1 item", async () => {
-      await cleanAllFlows(page);
       count = await runFlowAndReadDoneCount(page, request, ["only"]);
       expect(count).toBe(1);
     });

--- a/tests/tests-automations/regression/core-components/loop-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/loop-component-regression.spec.ts
@@ -48,8 +48,11 @@ async function addLoopComponent(page: Page) {
     { timeout: 30000 },
   );
   await page.getByTestId("blank-flow").click();
-  const id = ((await (await flowCreation).json()) as { id?: string }).id;
-  if (id) createdFlowIds.push(id);
+  const created = (await (await flowCreation).json()) as { id?: string };
+  if (!created.id) {
+    throw new Error("blank-flow creation returned no flow id");
+  }
+  createdFlowIds.push(created.id);
   await page.waitForURL(/\/flow\//, { timeout: 30000 });
   await page.getByTestId("sidebar-search-input").fill("Loop");
   await page.waitForSelector('[data-testid="add-component-button-loop"]', {
@@ -180,8 +183,11 @@ test(
       { timeout: 30000 },
     );
     await page.getByTestId("template-research-translation-loop").click();
-    const createdId = ((await (await flowCreation).json()) as { id?: string }).id;
-    if (createdId) createdFlowIds.push(createdId);
+    const createdTemplate = (await (await flowCreation).json()) as { id?: string };
+    if (!createdTemplate.id) {
+      throw new Error("template instantiation returned no flow id");
+    }
+    createdFlowIds.push(createdTemplate.id);
     await page.waitForSelector('[data-testid="title-Loop"]', { timeout: 15000 });
     await adjustScreenView(page);
 

--- a/tests/tests-automations/regression/core-components/webhook-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/webhook-component-regression.spec.ts
@@ -1,21 +1,55 @@
 import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
-import { cleanAllFlows } from "../../../helpers/flows/clean-all-flows";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 
-// Run tests serially because addWebhookComponent calls cleanAllFlows() —
-// without serial mode, parallel tests delete each other's flows mid-run,
-// turning the webhook POST into a 404 race.
+// Run tests serially to avoid 400 "flow must be unique" errors from parallel
+// autosaves of blank flows created within this file.
 test.describe.configure({ mode: "serial" });
+
+// Id of the flow the running test created; teardown deletes only this one via
+// the API (scoped) — never a global cleanAllFlows, which wipes flows other
+// parallel workers are actively building mid-run (#515).
+let createdFlowId: string | undefined;
+
+test.afterEach(async ({ page }) => {
+  const flowId = createdFlowId;
+  createdFlowId = undefined;
+  if (!flowId) return;
+  // Delete ONLY the flow this test created (scoped teardown, #515). Navigate off
+  // the editor first so the unmounted flow page stops polling the flow we are
+  // about to delete, then pass an explicit auth header — page.request is
+  // unauthenticated under AUTO_LOGIN and would 401 otherwise. Not swallowed: a
+  // failed cleanup surfaces instead of silently leaking the flow (#547).
+  await page.goto("/");
+  const authHeader = await getAuthToken(page.request);
+  await deleteFlow(
+    page.request,
+    flowId,
+    authHeader ? { headers: { Authorization: authHeader } } : undefined,
+  );
+});
 
 // Reusable helper: create blank flow and add the Webhook component.
 // After this call the component is visible on the canvas and the inspector is open.
 async function addWebhookComponent(page: any) {
   await awaitBootstrapTest(page);
-  // Clean existing flows first to avoid 400 "flow must be unique" under parallelism
-  await cleanAllFlows(page);
+  // Capture the teardown id from the flow-creation POST, NOT from the canvas URL:
+  // the URL id is a transient client-side handle on this Langflow version and
+  // does not match the persisted flow (deleting it 404s and silently leaks the
+  // real one). Tests still read the URL id for their own webhook-endpoint
+  // assertions — that id resolves fine for the webhook route, just not for DELETE.
+  const flowCreation = page.waitForResponse(
+    (resp: any) =>
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201,
+    { timeout: 30000 },
+  );
   await page.getByTestId("blank-flow").click();
+  createdFlowId = ((await (await flowCreation).json()) as { id?: string }).id;
+  await page.waitForURL(/\/flow\//, { timeout: 30000 });
   await page.getByTestId("sidebar-search-input").click();
   await page.getByTestId("sidebar-search-input").fill("webhook");
   await page.waitForSelector('[data-testid="input_outputWebhook"]', {

--- a/tests/tests-automations/regression/core-components/webhook-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/webhook-component-regression.spec.ts
@@ -48,7 +48,11 @@ async function addWebhookComponent(page: any) {
     { timeout: 30000 },
   );
   await page.getByTestId("blank-flow").click();
-  createdFlowId = ((await (await flowCreation).json()) as { id?: string }).id;
+  const created = (await (await flowCreation).json()) as { id?: string };
+  if (!created.id) {
+    throw new Error("blank-flow creation returned no flow id");
+  }
+  createdFlowId = created.id;
   await page.waitForURL(/\/flow\//, { timeout: 30000 });
   await page.getByTestId("sidebar-search-input").click();
   await page.getByTestId("sidebar-search-input").fill("webhook");

--- a/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
@@ -11,7 +11,7 @@ import {
   type Provider,
 } from "../../../../helpers/provider-setup";
 import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
-import { cleanAllFlows } from "../../../../helpers/flows/clean-all-flows";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 
@@ -112,9 +112,14 @@ function getTestTargets(): TestTarget[] {
   }));
 }
 
+// Id of the flow the running test created; teardown deletes only this one via
+// the API (scoped) — never a global cleanAllFlows, which wipes flows other
+// parallel workers are actively building mid-run (#515).
+let createdFlowId: string | undefined;
+
 async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
   try {
-    await new SimpleAgentTemplatePage(page).load(options);
+    createdFlowId = await new SimpleAgentTemplatePage(page).load(options);
   } catch (e: any) {
     if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
     throw e;
@@ -131,8 +136,9 @@ async function waitForAgentToFinish(page: Page): Promise<void> {
 
 const targets = getTestTargets();
 
-// SimpleAgentTemplatePage.load() deletes all flows before loading the template.
-// Serial mode prevents parallel provider blocks from wiping each other's flows.
+// Serial mode prevents parallel provider blocks from racing autosaves of the
+// template flow. (load() no longer deletes all flows — that cross-worker wipe
+// was removed in #553; teardown is now scoped per created flow, #515.)
 test.describe.configure({ mode: "serial" });
 
 for (const { label, options, skipReason } of targets) {
@@ -140,19 +146,29 @@ for (const { label, options, skipReason } of targets) {
 
   test.describe(`MCP Client – Agent using MCPTools [${label}]`, () => {
     test.afterEach(async ({ page }) => {
+      const flowId = createdFlowId;
+      createdFlowId = undefined;
+
+      // Navigate off the editor first so the unmounted flow page stops polling
+      // the flow we are about to delete. The auth header is reused for both the
+      // MCP server cleanup and the flow deletion — page.request is
+      // unauthenticated under AUTO_LOGIN and would 401 otherwise.
+      await page.goto("/");
+      const authHeader = await getAuthToken(page.request);
+      const opts = authHeader
+        ? { headers: { Authorization: authHeader } }
+        : undefined;
+
       try {
-        const authHeader = await getAuthToken(page.request);
-        await page.request.delete(`/api/v2/mcp/servers/${MCP_SERVER_NAME}`, {
-          headers: { Authorization: authHeader },
-        });
+        await page.request.delete(`/api/v2/mcp/servers/${MCP_SERVER_NAME}`, opts);
       } catch {
         // best-effort
       }
-      try {
-        await page.goto("/");
-        await cleanAllFlows(page);
-      } catch {
-        // best-effort
+
+      // Delete ONLY the flow this test created (scoped teardown, #515). Not
+      // swallowed: a failed cleanup surfaces instead of silently leaking (#547).
+      if (flowId) {
+        await deleteFlow(page.request, flowId, opts);
       }
     });
 

--- a/tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts
@@ -1,8 +1,27 @@
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
-import { cleanAllFlows } from "../../../../helpers/flows/clean-all-flows";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { zoomOut } from "../../../../helpers/ui/zoom-out";
+
+// Clicks the blank-flow card and returns the id from the flow-creation POST, NOT
+// from the canvas URL: the URL id is a transient client-side handle on this
+// Langflow version and does not match the persisted flow (deleting it 404s and
+// silently leaks the real one). The POST response is the authoritative id.
+async function openBlankFlow(page: Page): Promise<string | undefined> {
+  const flowCreation = page.waitForResponse(
+    (resp) =>
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201,
+    { timeout: 30000 },
+  );
+  await page.getByTestId("blank-flow").click();
+  const id = ((await (await flowCreation).json()) as { id?: string }).id;
+  await page.waitForURL(/\/flow\//, { timeout: 30000 });
+  return id;
+}
 
 // MCP-server pre-clean/verification calls authenticate via the shared
 // `getAuthToken` helper (which uses `GET /api/v1/auto_login`). The suite starts
@@ -37,24 +56,39 @@ test.describe.configure({ mode: "serial" });
 const BAD_SERVER_NAME = "bad-server";
 const HTTP_FORM_SERVER_NAME = "http-form-server";
 
+// Id of the flow the running test created; teardown deletes only this one via
+// the API (scoped) — never a global cleanAllFlows, which wipes flows other
+// parallel workers are actively building mid-run (#515).
+let createdFlowId: string | undefined;
+
 test.describe("MCP Client – Configure and Execute Tool", () => {
   test.afterEach(async ({ page }) => {
+    const flowId = createdFlowId;
+    createdFlowId = undefined;
+
+    // Navigate off the editor first so the unmounted flow page stops polling the
+    // flow we are about to delete. The auth header is reused for both the MCP
+    // server cleanup and the flow deletion — page.request is unauthenticated
+    // under AUTO_LOGIN and would 401 otherwise.
+    await page.goto("/");
+    const authHeader = await getAuthToken(page.request);
+    const opts = authHeader
+      ? { headers: { Authorization: authHeader } }
+      : undefined;
+
     const serversToClean = [MCP_SERVER_NAME, BAD_SERVER_NAME, HTTP_FORM_SERVER_NAME];
     try {
-      const authHeader = await getAuthToken(page.request);
       for (const name of serversToClean) {
-        await page.request.delete(`/api/v2/mcp/servers/${name}`, {
-          headers: { Authorization: authHeader },
-        });
+        await page.request.delete(`/api/v2/mcp/servers/${name}`, opts);
       }
     } catch {
       // best-effort
     }
-    try {
-      await page.goto("/");
-      await cleanAllFlows(page);
-    } catch {
-      // best-effort
+
+    // Delete ONLY the flow this test created (scoped teardown, #515). Not
+    // swallowed: a failed cleanup surfaces instead of silently leaking (#547).
+    if (flowId) {
+      await deleteFlow(page.request, flowId, opts);
     }
   });
 
@@ -68,7 +102,7 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
       await test.step("Open blank flow", async () => {
         await awaitBootstrapTest(page);
         await expect(page.getByTestId("blank-flow")).toBeVisible({ timeout: 30000 });
-        await page.getByTestId("blank-flow").click();
+        createdFlowId = await openBlankFlow(page);
       });
 
       await test.step("Delete existing MCP server and re-add via JSON", async () => {
@@ -174,7 +208,7 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
       await test.step("Open blank flow", async () => {
         await awaitBootstrapTest(page);
         await expect(page.getByTestId("blank-flow")).toBeVisible({ timeout: 30000 });
-        await page.getByTestId("blank-flow").click();
+        createdFlowId = await openBlankFlow(page);
       });
 
       await test.step("Pre-clean: delete bad-server if it exists", async () => {
@@ -263,7 +297,7 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
       await test.step("Open blank flow", async () => {
         await awaitBootstrapTest(page);
         await expect(page.getByTestId("blank-flow")).toBeVisible({ timeout: 30000 });
-        await page.getByTestId("blank-flow").click();
+        createdFlowId = await openBlankFlow(page);
       });
 
       await test.step("Pre-clean: delete http-form-server if it exists", async () => {
@@ -331,7 +365,7 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
       await test.step("Open blank flow", async () => {
         await awaitBootstrapTest(page);
         await expect(page.getByTestId("blank-flow")).toBeVisible({ timeout: 30000 });
-        await page.getByTestId("blank-flow").click();
+        createdFlowId = await openBlankFlow(page);
       });
 
       await test.step("Register everything server via JSON and wait for tools", async () => {

--- a/tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts
@@ -9,7 +9,7 @@ import { zoomOut } from "../../../../helpers/ui/zoom-out";
 // from the canvas URL: the URL id is a transient client-side handle on this
 // Langflow version and does not match the persisted flow (deleting it 404s and
 // silently leaks the real one). The POST response is the authoritative id.
-async function openBlankFlow(page: Page): Promise<string | undefined> {
+async function openBlankFlow(page: Page): Promise<string> {
   const flowCreation = page.waitForResponse(
     (resp) =>
       resp.url().includes("/api/v1/flows") &&
@@ -18,9 +18,12 @@ async function openBlankFlow(page: Page): Promise<string | undefined> {
     { timeout: 30000 },
   );
   await page.getByTestId("blank-flow").click();
-  const id = ((await (await flowCreation).json()) as { id?: string }).id;
+  const created = (await (await flowCreation).json()) as { id?: string };
+  if (!created.id) {
+    throw new Error("blank-flow creation returned no flow id");
+  }
   await page.waitForURL(/\/flow\//, { timeout: 30000 });
-  return id;
+  return created.id;
 }
 
 // MCP-server pre-clean/verification calls authenticate via the shared


### PR DESCRIPTION
## What & why

Closes #515.

`cleanAllFlows(page)` deletes **every** flow of the shared `auto_login` user. In the `fullyParallel` suite it wipes flows other workers are actively building mid-run — the victim's canvas 404s ("Flow not found"), the run "does not settle", and it only goes green on retry. `mode: serial` does not help (it only orders tests within one file; the global delete still reaches across workers).

This migrates the **five validated (`@stable`) specs** to **scoped teardown**: each test captures the id of the flow(s) it created and deletes only those — the pattern already proven in `playground-output-data.spec.ts` (#465), `stop-building.spec.ts`, and `load-template-by-name.ts` (#553).

## Changes

- **`SimpleAgentTemplatePage.load()`** now returns the flow id from `loadTemplateByName` (`void` → `string`, backwards-compatible).
- **agent / loop / webhook / mcp-client-regression / mcp-client-agent**: track created ids; delete per-id in `afterEach`; dropped the global `cleanAllFlows` calls. (Loop tests 1–3 previously leaked their flows — now cleaned up too.)
- Spec docs for loop/webhook updated to describe the scoped teardown.

## Hardening learned during verification

- The **canvas URL id is a transient client-side handle** on current Langflow and does not match the persisted flow — deleting it 404s and silently leaks the real one. All UI-`blank-flow` paths now capture the id from the **creation `POST /api/v1/flows/` response** instead.
- **`page.request` is anonymous under AUTO_LOGIN** — teardown passes an explicit `Authorization` header (via `getAuthToken`) and no longer swallows `deleteFlow` failures, so a failed cleanup surfaces (#547).

## Verification

- `npm run typecheck` ✅ / `npm run lint` ✅ (0 errors).
- Isolated (serial): create/delete nets to **zero** — no leaks.
- Combined parallel `--repeat-each=2` across the three flow-heavy specs: **no empty-state wipe** (the #515 hazard is gone); the pre-existing 5 unrelated flows survive.
- Remaining failures under that artificial over-concurrency are the pre-existing parallel-create backend 500 race + clipboard flakiness — tracked separately, out of scope.

## Follow-ups

- #588 — harden flow creation/open against the parallel `POST /api/v1/flows/` 500 race (exposed, not caused, by this change).
- #589 — migrate the 2 remaining non-validated specs and evaluate per-worker user isolation / `cleanAllFlows` deprecation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)