### PR TITLE
test(model-provider): anthropic provider configure/select/switch spec (#503)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -386,9 +386,9 @@
 - [x] Invalid API key error — display error message → `core-functionality/llm-agents/provider-invalid-auth-error.spec.ts`
 
 #### 7.3 Anthropic
-- [-] Configure Anthropic API key
-- [-] Select Claude model in agent
-- [-] Switch between Claude models (Sonnet, Haiku, Opus)
+- [x] Configure Anthropic API key in Settings → Model Providers → `core-functionality/model-provider/anthropic-provider.spec.ts`
+- [x] Select Claude model in agent → `core-functionality/model-provider/anthropic-provider.spec.ts`
+- [x] Switch between Claude models (Sonnet, Haiku, Opus) → `core-functionality/model-provider/anthropic-provider.spec.ts`
 - [x] Invalid Anthropic API key error → `core-functionality/llm-agents/provider-invalid-auth-error.spec.ts`
 
 #### 7.4 Google Generative AI

--- a/docs/core-functionality/model-provider/anthropic-provider.md
+++ b/docs/core-functionality/model-provider/anthropic-provider.md
@@ -1,0 +1,224 @@
+# Anthropic Provider — configure key, select Claude, switch models
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+The Anthropic (Claude) provider path (QA-CHECKLIST §7.3), as a **provider-centric
+journey** distinct from agent-behavior specs:
+
+1. **Configure the Anthropic API key** in `Settings → Model Providers` (in 1.11
+   the key is a global provider variable `ANTHROPIC_API_KEY`, set from this page).
+2. **Select a Claude model** in the Agent (the configured key makes Claude models
+   available in the Agent's model dropdown) and **execute the flow** to prove the
+   selection is genuinely usable, not merely picked in the UI.
+3. **Switch between Claude models** across families (Haiku → Sonnet → Opus): the
+   Agent's model dropdown re-selects across model families and the newly selected
+   model executes.
+
+If this fails, Anthropic can no longer be configured and its Claude models
+selected/switched in an Agent.
+
+Completes the provider-centric family: `openai-provider.spec.ts` (§7.2),
+`google-provider.spec.ts` (§7.4), `ollama-provider.spec.ts` (§7.6).
+
+---
+
+## Tags *(required)*
+
+`@stable` `@model-provider` `@settings` `@agents` `@playground`
+
+`@stable` added only after multiple clean `--retries=0` runs on the fresh
+nightly. `@model-provider` (area) · `@settings` (Test 1 navigates Settings) ·
+`@agents` + `@playground` (Tests 2–3 select models and execute).
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- `ANTHROPIC_API_KEY` set in `.env` with a **funded** account (all tests
+  self-skip without the env var; a zero-credit key configures fine but fails
+  execution with a billing error — see Notes).
+- `models.json` / `providers.json` generated via
+  `npx playwright test tests/collect-models.spec.ts` (Anthropic must be `active`).
+- Run with `--workers=1` (Tests 2–3 load a named template via
+  `SimpleAgentTemplatePage`, which wipes flows). File is serial.
+
+---
+
+## Step by step *(required)*
+
+---
+
+**Test 1 — configure the Anthropic API key in Settings → Model Providers** (§7.3.1)
+
+1. `SettingsPage.navigate()` → click `sidebar-nav-Model Providers`; wait for
+   `settings_menu_header` to read "Model Providers".
+2. Click `provider-item-Anthropic` to open its config panel.
+3. Fill `provider-variable-input-ANTHROPIC_API_KEY` with `ANTHROPIC_API_KEY`.
+4. Arm two response waiters, then click the save button (`Save` when
+   unconfigured, `Replace` when a key is already stored — match `/Save|Replace/`).
+5. **Validation (causal — no pre-existing-state false positive):** the save click
+   must produce **both** a `POST /api/v1/models/validate-provider` → **2xx** (the
+   key authenticates against Anthropic live) **and** a `POST|PATCH
+   /api/v1/variables/…` → **2xx** (the key is persisted — `POST` on first
+   configure, `PATCH` on re-save). Asserting the request outcomes — not the
+   "Disconnect"/"Replace" state, which pre-exists when the global key was already
+   configured — ties the pass to *this* save. Idempotent: re-saving the same
+   valid key is a success; the shared global key is deliberately not wiped.
+
+---
+
+**Test 2 — configured Anthropic selects a Claude model in the Agent and executes** (§7.3.2)
+
+1. `SimpleAgentTemplatePage.load({ provider: "anthropic", model })` — with the
+   key configured, this selects a **Claude** model in the Agent's `model_model`
+   dropdown. `model` resolves from `models.json`, preferring a current **Haiku**
+   (fast/cheap; e.g. `claude-haiku-4-5`).
+2. **Assert the selection is a Claude model** — `value-dropdown-model_model`
+   text matches `/claude/i`. Ties §7.3.2 to a concrete observable.
+3. **Remove the Web Search + URL tool nodes** — select each via its node
+   **title** (`title-Web Search`, `title-URL`) then press `Delete`, then wait
+   for the debounced autosave to settle (`waitForFlowSaveSettled`) so the
+   Playground builds the persisted tool-free flow (single deterministic LLM
+   call — same rationale as the OpenAI/Google siblings).
+4. Open the Playground (`playground-btn-flow-io`); wait for
+   `input-chat-playground`.
+5. Send `Repeat this token exactly and nothing else: ANTHROPIC-<sentinel>`;
+   wait for the agent to finish (`waitForAgentToFinish`).
+6. **Validation:** the last `div-chat-message` (AI bubble) is **non-empty**
+   (hard — proves the configured Claude model executed and returned output).
+   The per-run sentinel echo is **logged, not asserted** — family convention
+   (Gemini disobeys ~1/6; Claude is more obedient, but the hard non-empty
+   check plus the `/claude/i` selection assert already pin execution to
+   Anthropic, and keeping the family contract identical keeps the specs
+   comparable).
+
+---
+
+**Test 3 — switch between Claude model families (Haiku → Sonnet → Opus)** (§7.3.3)
+
+1. `SimpleAgentTemplatePage.load({ provider: "anthropic", model: <haiku> })` —
+   starting point, Haiku selected (asserted via `value-dropdown-model_model`).
+2. Remove the tool nodes (same as Test 2) and settle the autosave.
+3. **Switch Haiku → Sonnet:** click `model_model`, click the Sonnet option
+   (`[data-testid$="-option"]` with the exact model name from `models.json`);
+   assert `value-dropdown-model_model` now shows the Sonnet model; settle the
+   autosave.
+4. **Execute after the switch:** run the Playground with a fresh per-run
+   sentinel; assert the last AI bubble is **non-empty** — the switched-to
+   Sonnet model is genuinely usable, not just displayed.
+5. **Switch Sonnet → Opus (selection only):** click `model_model`, click the
+   Opus option; assert `value-dropdown-model_model` shows the Opus model.
+   No execution — see Notes (cost); the switch *mechanism* across all three
+   §7.3 families is proven, execution-after-switch is proven once in step 4.
+
+---
+
+## Validation criterion *(required)*
+
+- **Configure:** clicking Save on the Anthropic key produces a 2xx
+  `validate-provider` (key authenticates against Anthropic) and a 2xx
+  `POST|PATCH /variables` (key persisted) — the pass is caused by this save,
+  not a pre-existing configured state.
+- **Select + execute:** the Agent's model dropdown shows a Claude model, and
+  running the flow returns a non-empty AI response.
+- **Switch:** the dropdown value provably changes Haiku → Sonnet → Opus (three
+  distinct `value-dropdown-model_model` states within one test), and the
+  post-switch Sonnet execution returns a non-empty AI response.
+
+## Guarding against false positives *(how)*
+
+- **Test 1** asserts the *save requests succeed* (`validate-provider` +
+  `POST|PATCH /variables` both 2xx), not a UI state that pre-exists from an
+  earlier configuration — so a no-op save cannot pass.
+- **Test 2** asserts a **Claude** model is selected
+  (`value-dropdown-model_model` ~ `/claude/i`, causal) and that execution
+  returns a non-empty response.
+- **Test 3** asserts the dropdown value **changes** to the exact target model
+  name after each switch (a stale dropdown fails the assert), and that the
+  post-switch execution produces output — a switch that silently keeps the old
+  model selected cannot pass step 3's exact-name assert.
+- **Force-failure check** (CONTRIBUTING §2) is run during VERIFY: each
+  assertion is broken on purpose once to confirm it fails, before `@stable`
+  is added.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Removing / rotating the key (see `remove-provider-api-key.spec.ts`).
+- Invalid Anthropic key error (covered: §7.3 bullet 4 →
+  `provider-invalid-auth-error.spec.ts`).
+- Model enable/disable toggles (see `model-provider-model-toggle.spec.ts`).
+- Opus **execution** (selection only — cost; see Notes).
+- Agent behaviors — streaming, reasoning, tools (see
+  `agent-component-regression.spec.ts`).
+- Other providers (OpenAI §7.2, Google §7.4, Ollama §7.6 — own specs).
+
+---
+
+## External dependencies *(required)*
+
+- `src/frontend/src/pages/SettingsPage/` (Model Providers page) — renders
+  `provider-item-Anthropic`, `provider-variable-input-ANTHROPIC_API_KEY`,
+  the Save/Replace button; a rename breaks Test 1.
+- Provider-config storage — the global `ANTHROPIC_API_KEY` provider variable.
+- `src/backend/base/langflow/components/agents/` — Agent execution with the
+  selected Claude model (Tests 2–3).
+- `src/frontend/src/components/core/playgroundComponent/` — Playground I/O.
+- Anthropic API — Test 1 validates the key live; Tests 2–3 make real calls.
+  A live, **funded** `ANTHROPIC_API_KEY` is required.
+
+---
+
+## When to review this test *(optional)*
+
+- If the Model Providers settings page restructures (provider items, the
+  `provider-variable-input-*` inputs, or the Save/Replace button).
+- If the Agent's model dropdown (`model_model` / `value-dropdown-model_model` /
+  `*-option` items) or the Simple Agent template changes.
+- If Anthropic key storage moves off the global provider-variable model.
+- If the Claude model catalog renames families (Haiku/Sonnet/Opus regexes).
+
+---
+
+## Notes *(optional)*
+
+- **Dedicated spec (issue #503 delegated the choice):** the issue names
+  `llm-agents/model-provider-api-key.spec.ts` as the spec file, but its Notes
+  delegate "dedicated spec vs promotion of existing coverage" to the author.
+  The existing file only proves Anthropic is *listed*; the three §7.3 bullets
+  need configure + select + switch. A dedicated `anthropic-provider.spec.ts`
+  under `model-provider/` follows the family precedent (§7.2/§7.4/§7.6 all
+  chose dedicated specs) and gives §7.3 a provider-centric home.
+- **Model resolution from `models.json`:** Haiku/Sonnet/Opus are resolved by
+  family regex from the collected catalog (preferring current, non-deprecated
+  names, e.g. `claude-haiku-4-5`, `claude-sonnet-5`, `claude-opus-4-8`), so
+  catalog updates don't break the spec. A family missing from the catalog
+  skips with a reason.
+- **Why Opus is selection-only:** executing all three families triples LLM
+  cost per run (and Opus is the most expensive tier) for no extra mechanism
+  coverage — the switch mechanism is identical per family and
+  execution-after-switch is already proven on Sonnet.
+- **Zero-credit trap (found live during #503):** a valid-but-unfunded key
+  passes Langflow's configure/validate and lists all 12 Claude models, but
+  every real inference fails with "credit balance is too low". The spec
+  requires an *active* provider (`providers.json`), which collect-models
+  verifies with a real 1-token inference — that gate, not the configure step,
+  is what catches an unfunded key before the agent tests burn retries.
+- **Flow cleanup (id-scoped):** Tests 2–3 create a flow via
+  `SimpleAgentTemplatePage.load()`, which does NO cleanup (post-#553 contract —
+  the id is discarded by the POM). The spec tracks every
+  `POST /api/v1/flows` → 201 id fired during load and deletes them by id in
+  `test.afterEach` (transient ids 404 harmlessly — `deleteFlow` treats 404 as
+  done). Never a name-based or delete-all cleanup (cross-worker wiper class,
+  #553/#520).
+- **Per-run sentinel** proves *this* execution produced the output; echo is
+  logged, not asserted (family convention — see Test 2 step 6).
+- **Shared global key:** the Anthropic key is global and persists across runs.
+  Test 1 is idempotent — it re-saves and asserts the request outcomes, not a
+  fresh start.

--- a/tests/tests-automations/regression/core-functionality/model-provider/anthropic-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/anthropic-provider.spec.ts
@@ -1,0 +1,316 @@
+import * as dotenv from "dotenv";
+import path from "path";
+import fs from "fs";
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { SettingsPage, SimpleAgentTemplatePage } from "../../../../pages";
+import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import { hideInspectorPanel } from "../../../../helpers/ui/hide-inspector-panel";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import {
+  hasProviderEnvKeys,
+  missingProviderEnvKeys,
+} from "../../../../helpers/provider-setup";
+
+/**
+ * Anthropic (Claude) provider path (QA-CHECKLIST §7.3) as a provider-centric journey:
+ *   Test 1 — configure the Anthropic API key in Settings → Model Providers.
+ *   Test 2 — the configured provider selects a Claude model in the Agent and
+ *            executes a flow, round-tripping a per-run sentinel.
+ *   Test 3 — switch between Claude model families (Haiku → Sonnet → Opus); the
+ *            switched-to Sonnet executes, Opus is selection-only (cost).
+ *
+ * Completes the provider family: openai-provider.spec.ts (§7.2),
+ * google-provider.spec.ts (§7.4), ollama-provider.spec.ts (§7.6).
+ *
+ * False-positive guards: Test 1 asserts the save *requests* succeed
+ * (validate-provider + POST|PATCH /variables, both 2xx) rather than a
+ * pre-existing configured state, so a no-op save cannot pass. Test 2 asserts a
+ * Claude model is selected and the run returns output. Test 3 asserts the
+ * dropdown value changes to each exact target model name — a switch that
+ * silently keeps the previous model selected fails the exact-name assert.
+ */
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
+}
+
+const PROVIDER = "anthropic";
+
+type ClaudeFamily = "haiku" | "sonnet" | "opus";
+
+// Resolve a Claude model per family from models.json, preferring current
+// non-dated names. Returns undefined when the family is absent from the
+// collected catalog — callers skip with a reason.
+function resolveClaudeModel(family: ClaudeFamily): string | undefined {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/models.json",
+  );
+  if (!fs.existsSync(jsonPath)) return undefined;
+  const models = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as Array<{
+    provider: string;
+    model: string;
+  }>;
+  const claude = models
+    .filter((m) => m.provider === PROVIDER)
+    .map((m) => m.model)
+    .filter((m) => m.includes(family));
+  // Prefer undated names (claude-sonnet-5) over dated snapshots
+  // (claude-sonnet-4-20250514); within those, the catalog lists newest first.
+  return claude.find((m) => !/\d{8}/.test(m)) ?? claude[0];
+}
+
+// Flows created during template load are tracked here and deleted by id in
+// afterEach — SimpleAgentTemplatePage.load() does NO cleanup (post-#553
+// contract), and the app can fire more than one flows POST during load (only
+// one persists; deleting a transient id 404s harmlessly — deleteFlow treats
+// 404 as done).
+const createdFlowIds: string[] = [];
+
+async function loadAgent(page: Page, model?: string): Promise<void> {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {}); // non-JSON / batch payloads
+    }
+  });
+  try {
+    await new SimpleAgentTemplatePage(page).load({ provider: PROVIDER, model });
+  } catch (e: any) {
+    if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
+    throw e;
+  }
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, { headers: { Authorization: bearer } });
+  }
+});
+
+async function waitForAgentToFinish(page: Page): Promise<void> {
+  const stopButton = page.getByRole("button", { name: "Stop" });
+  const stopVisible = await stopButton.isVisible({ timeout: 10000 }).catch(() => false);
+  if (stopVisible) {
+    await expect(stopButton).toBeHidden({ timeout: 120000 });
+  }
+}
+
+// The template's Web Search + URL tool orchestration transiently fails
+// (backend ComponentBuildError) — incidental to §7.3. A tool-free agent is a
+// single deterministic LLM call; tool execution is covered by
+// agent-component-regression.spec.ts. Select via the node TITLE, not the body:
+// URLComponent's body center is an interactive element.
+async function removeToolNodes(page: Page): Promise<void> {
+  const tools = [
+    { title: "title-Web Search", node: "rf__node-UnifiedWebSearch" },
+    { title: "title-URL", node: "rf__node-URLComponent" },
+  ];
+  for (const t of tools) {
+    const node = page.locator(`[data-testid^="${t.node}"]`);
+    if ((await node.count()) === 0) continue;
+    await page.getByTestId(t.title).click();
+    await page.keyboard.press("Delete");
+    await expect(node).toHaveCount(0, { timeout: 10000 });
+  }
+  // Playground builds the PERSISTED flow — the deletion must be saved first.
+  await waitForFlowSaveSettled(page);
+}
+
+// Sends the sentinel prompt in the Playground and asserts a non-empty AI
+// reply. The sentinel echo is logged, not asserted (family convention — the
+// hard non-empty check plus the model-selection assert pin the execution).
+async function runPlaygroundSentinel(page: Page, token: string): Promise<void> {
+  await page.getByTestId("playground-btn-flow-io").click();
+  await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+    timeout: 30000,
+  });
+  await page
+    .getByTestId("input-chat-playground")
+    .last()
+    .fill(`Repeat this token exactly and nothing else: ${token}`);
+  await page.getByTestId("button-send").last().click();
+  await waitForAgentToFinish(page);
+
+  const aiMessage = page.getByTestId("div-chat-message").last();
+  await expect(aiMessage).toBeVisible({ timeout: 30000 });
+  const reply = (await aiMessage.innerText()).trim();
+  // Hard: the selected Claude model executed and returned output.
+  expect(reply.length).toBeGreaterThan(0);
+  console.log(
+    reply.includes(token)
+      ? `sentinel echoed: input reached the Claude model (${token})`
+      : `sentinel not echoed; reply: ${reply.slice(0, 80)}`,
+  );
+}
+
+// Switches the Agent's model via the model_model dropdown and asserts the
+// selected value shows the exact target model name (a stale dropdown fails).
+async function switchModel(page: Page, model: string): Promise<void> {
+  await hideInspectorPanel(page);
+  await page.getByTestId("model_model").click();
+  const option = page.locator('[data-testid$="-option"]', {
+    hasText: new RegExp(`^${model}$`),
+  });
+  await option.waitFor({ state: "visible", timeout: 10000 });
+  await option.click();
+  await expect(page.getByTestId("value-dropdown-model_model")).toContainText(
+    model,
+    { timeout: 10000 },
+  );
+}
+
+// SimpleAgentTemplatePage.load() deletes all flows before loading the template;
+// serial mode + --workers=1 keeps the shared instance state deterministic.
+test.describe.configure({ mode: "serial" });
+
+test.describe("Anthropic Provider", () => {
+  test(
+    "Anthropic API key is configured via Settings → Model Providers",
+    { tag: ["@stable", "@model-provider", "@settings"] },
+    async ({ page }) => {
+      test.skip(
+        !hasProviderEnvKeys(PROVIDER),
+        `Missing env vars for provider "${PROVIDER}": ${missingProviderEnvKeys(PROVIDER).join(", ")}`,
+      );
+
+      await awaitBootstrapTest(page, { skipModal: true });
+
+      await test.step("open Settings → Model Providers → Anthropic", async () => {
+        await new SettingsPage(page).navigate();
+        await page.getByTestId("sidebar-nav-Model Providers").click();
+        await expect(page.getByTestId("settings_menu_header").last()).toContainText(
+          "Model Providers",
+          { timeout: 10000 },
+        );
+        await page.getByTestId("provider-item-Anthropic").click();
+      });
+
+      await test.step("enter the key and save — assert the save requests succeed", async () => {
+        const keyInput = page.getByTestId(
+          "provider-variable-input-ANTHROPIC_API_KEY",
+        );
+        await expect(keyInput).toBeVisible({ timeout: 10000 });
+        await keyInput.fill(process.env.ANTHROPIC_API_KEY ?? "");
+
+        // Arm both waiters BEFORE clicking so the pass is caused by THIS save,
+        // not a "Disconnect"/"Replace" state a prior configuration left behind.
+        const validatePromise = page.waitForResponse(
+          (r) =>
+            r.url().includes("/api/v1/models/validate-provider") &&
+            r.request().method() === "POST",
+          { timeout: 60000 },
+        );
+        // POST on first configure, PATCH on re-save of the existing variable.
+        const persistPromise = page.waitForResponse(
+          (r) =>
+            r.url().includes("/api/v1/variables/") &&
+            ["POST", "PATCH"].includes(r.request().method()),
+          { timeout: 60000 },
+        );
+
+        await page.getByRole("button", { name: /Save|Replace/i }).first().click();
+
+        const [validateResp, persistResp] = await Promise.all([
+          validatePromise,
+          persistPromise,
+        ]);
+        // validate-provider 2xx = the key authenticates against Anthropic live;
+        // POST|PATCH /variables 2xx = the key is persisted globally.
+        expect(validateResp.ok()).toBe(true);
+        expect(persistResp.ok()).toBe(true);
+      });
+    },
+  );
+
+  test(
+    "configured Anthropic selects a Claude model in the Agent and executes the flow",
+    { tag: ["@stable", "@model-provider", "@agents", "@playground"] },
+    async ({ page }) => {
+      test.skip(
+        !hasProviderEnvKeys(PROVIDER),
+        `Missing env vars for provider "${PROVIDER}": ${missingProviderEnvKeys(PROVIDER).join(", ")}`,
+      );
+
+      // Per-run sentinel: a match proves THIS execution produced the output.
+      const token = `ANTHROPIC-${Date.now()}`;
+
+      await loadAgent(page, resolveClaudeModel("haiku"));
+
+      await test.step("Agent has a Claude model selected", async () => {
+        const modelValue = page.getByTestId("value-dropdown-model_model");
+        await expect(modelValue).toBeVisible({ timeout: 15000 });
+        await expect(modelValue).toContainText(/claude/i, { timeout: 10000 });
+      });
+
+      await test.step("remove the Web Search + URL tools so execution is a plain completion", async () => {
+        await removeToolNodes(page);
+      });
+
+      await test.step("execute the flow and echo the sentinel", async () => {
+        await runPlaygroundSentinel(page, token);
+      });
+    },
+  );
+
+  test(
+    "switches between Claude model families (Haiku → Sonnet → Opus)",
+    { tag: ["@stable", "@model-provider", "@agents", "@playground"] },
+    async ({ page }) => {
+      test.skip(
+        !hasProviderEnvKeys(PROVIDER),
+        `Missing env vars for provider "${PROVIDER}": ${missingProviderEnvKeys(PROVIDER).join(", ")}`,
+      );
+
+      const haiku = resolveClaudeModel("haiku");
+      const sonnet = resolveClaudeModel("sonnet");
+      const opus = resolveClaudeModel("opus");
+      test.skip(
+        !haiku || !sonnet || !opus,
+        `Claude family missing from models.json (haiku=${haiku}, sonnet=${sonnet}, opus=${opus}) — run collect-models.spec.ts`,
+      );
+
+      const token = `ANTHROPIC-SWITCH-${Date.now()}`;
+
+      await test.step("load the Agent with the Haiku model selected", async () => {
+        await loadAgent(page, haiku);
+        await expect(page.getByTestId("value-dropdown-model_model")).toContainText(
+          haiku!,
+          { timeout: 15000 },
+        );
+      });
+
+      await test.step("remove the Web Search + URL tools so execution is a plain completion", async () => {
+        await removeToolNodes(page);
+      });
+
+      await test.step("switch Haiku → Sonnet via the model dropdown", async () => {
+        await switchModel(page, sonnet!);
+        // The Playground builds the persisted flow — the switch must be saved.
+        await waitForFlowSaveSettled(page);
+      });
+
+      await test.step("execute after the switch — the Sonnet model responds", async () => {
+        await runPlaygroundSentinel(page, token);
+        await page.keyboard.press("Escape"); // close the playground modal
+      });
+
+      await test.step("switch Sonnet → Opus — selection only (cost)", async () => {
+        await switchModel(page, opus!);
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #503.

Closes the three `[-]` §7.3 Anthropic gaps in `QA-CHECKLIST.md` — configure key, select Claude model, switch between Claude families — as a dedicated provider-centric spec, completing the family: `openai-provider.spec.ts` (§7.2), `google-provider.spec.ts` (§7.4), `ollama-provider.spec.ts` (§7.6). The issue named `llm-agents/model-provider-api-key.spec.ts` as the spec file but delegated "dedicated spec vs promotion" to the author; that file only proves Anthropic is *listed*, which covers none of the three bullets.

## 1. Covered tests
| # | Test | What it validates |
|---|------|-------------------|
| 1 | `Anthropic API key is configured via Settings → Model Providers` | Clicking Save produces **both** `POST /api/v1/models/validate-provider` → 2xx (key authenticates against Anthropic live) and `POST\|PATCH /api/v1/variables/` → 2xx (key persisted). Waiters armed before the click — a pre-existing configured state cannot pass. |
| 2 | `configured Anthropic selects a Claude model in the Agent and executes the flow` | `value-dropdown-model_model` matches `/claude/i` (Haiku from `models.json`) and the Playground run returns a non-empty AI reply (per-run sentinel logged, not asserted — family convention). |
| 3 | `switches between Claude model families (Haiku → Sonnet → Opus)` | Dropdown value shows the **exact** model name after each switch (stale dropdown fails); post-switch Sonnet execution returns a non-empty reply; Opus is selection-only (cost — mechanism already proven). |

## 2. How the test was built
- Mirrors `google-provider.spec.ts` structure (Settings journey + Simple Agent template + tool-node removal so execution is a single deterministic LLM call).
- Claude models resolved per family from `models.json` by regex, preferring undated names (`claude-haiku-4-5`, `claude-sonnet-5`, `claude-opus-4-8`) — catalog updates don't break the spec; a missing family skips with a reason.
- **Live-confirmed selectors:** `provider-item-Anthropic`, `provider-variable-input-ANTHROPIC_API_KEY`, `model_model`, `value-dropdown-model_model`, `[data-testid$="-option"]` (mechanism shared with `setup-anthropic.ts`).
- **Flow cleanup (id-scoped):** every `POST /api/v1/flows` → 201 during template load is tracked and deleted by id in `afterEach` (post-#553 contract — `SimpleAgentTemplatePage.load()` discards the id; transient ids 404 harmlessly). Proven behaviorally: cleanup no-op'd → 2 orphans survive; reverted → 0 orphans. 12 pre-existing orphans purged from the shared instance.
- Zero-credit trap documented in the spec doc (found live): an unfunded key passes configure/validate and lists all models but fails inference — the active-provider gate in collect-models (real 1-token inference) is what catches it.

## 3. Dependencies
- Live, **funded** `ANTHROPIC_API_KEY` (all tests self-skip without the env var — skip path proven: 3 skipped with reason).
- `models.json`/`providers.json` via `collect-models.spec.ts` (Anthropic `active`).
- `--workers=1` serial — template load wipes/creates named flows.

## Validation (nightly 1.11.0.dev36, `--retries=0`)
- typecheck ✅ · eslint ✅ (0 errors)
- 6 clean full-file runs (3/3 each), no flake ✅
- force-fail executed ✅ — M1 garbage key → persist waiter timeout ✘ · M2 selection regex `/gpt-nonexistent/i` → ✘ · M3 stale-dropdown assert after switch → ✘ · M4 cleanup no-op → 2 surviving orphans observed; all reverted (0 markers) + final green
- skip path ✅ (`ANTHROPIC_API_KEY=""` → 3 skipped with reason)
- zero `🚨 Backend Error` ✅
- `--trace=on` skipped — known local hang on Simple Agent template specs (#490/#518); covered by `--retries=0` bursts + force-fail instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)
