### PR TITLE
ci(daily-stable): grant packages: read so the ollama service image pulls

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -23,6 +23,10 @@ on:
 permissions:
   issues: write
   contents: write
+  # Pull the private ollama-e2e service image from GHCR with GITHUB_TOKEN.
+  # An explicit permissions block defaults every unlisted scope to `none`,
+  # so without this the container pull is denied (see #594).
+  packages: read
 
 jobs:
   e2e-daily-stable:


### PR DESCRIPTION
## What

Add `packages: read` to the `permissions:` block in `.github/workflows/daily-stable.yml`.

```diff
 permissions:
   issues: write
   contents: write
+  packages: read
```

## Why

The scheduled `daily-stable` run fails at **Initialize containers** — the `ollama` service image cannot be pulled from GHCR (`Error response from daemon: denied`). Because the workflow declares an explicit `permissions:` block, every unlisted scope defaults to `none`, leaving `GITHUB_TOKEN` without `packages: read`. The private `ollama-e2e` image pull is therefore denied, the `@stable` tests are skipped, and no entry is written to `reports/daily-history.jsonl`.

`nightly.yml` has no `permissions:` block, so its token inherits the repo default (which includes `packages: read`) and pulls the same image fine.

The ollama service was added in #583; the 2026-07-09 run is the first scheduled daily-stable to include it, which is why this surfaced now. It recurs on every scheduled run until fixed.

## Validation

Config-only change to a workflow file — no test source touched, so `tsc`/ESLint CI are unaffected. Effective validation is the next `daily-stable` run (or a manual dispatch) reaching the tests instead of failing at Initialize.

Closes #594