### PR TITLE
test(triage): remove @stable from 4 tests hard-failing on 2026-07-09 daily

### DIFF
--- a/tests/tests-automations/regression/core-components/loop-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/loop-component-regression.spec.ts
@@ -149,7 +149,7 @@ test(
 
 test(
   "Loop component — Research Translation Loop template: full wiring and iterates over 2 ArXiv papers",
-  { tag: ["@stable", "@release", "@components", "@templates", "@playground"] },
+  { tag: ["@release", "@components", "@templates", "@playground"] },
   async ({ page }) => {
     test.skip(
       !process.env.OPENAI_API_KEY,

--- a/tests/tests-automations/regression/core-functionality/llm-agents/language-model-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/language-model-regression.spec.ts
@@ -109,7 +109,7 @@ test.describe("Language Model Component Regression", () => {
 
   test(
     "language model must respond with Google provider",
-    { tag: ["@stable", "@release", "@components", "@model-provider"] },
+    { tag: ["@release", "@components", "@model-provider"] },
     async ({ page }) => {
       test.skip(
         !process?.env?.GOOGLE_API_KEY,

--- a/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-model-toggle.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-model-toggle.spec.ts
@@ -162,7 +162,7 @@ test.describe("Model Provider Model Toggle", () => {
   test(
     "disabling a model removes it from a component model dropdown",
     {
-      tag: ["@stable", "@regression", "@components", "@agents", "@model-provider"],
+      tag: ["@regression", "@components", "@agents", "@model-provider"],
     },
     async ({ page }) => {
       test.skip(!!skipReason, skipReason ?? "");

--- a/tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts
@@ -7,7 +7,7 @@ import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 test(
   "user should be able to select flows with different methods and perform bulk actions",
-  { tag: ["@stable", "@release", "@workspace", "@mainpage", "@regression"] },
+  { tag: ["@release", "@workspace", "@mainpage", "@regression"] },
   async ({ page, request }) => {
     await awaitBootstrapTest(page);
 


### PR DESCRIPTION
## What

Removes `@stable` from the four tests that hard-failed on the **2026-07-09** daily run:

| Test | File | Tracking issue |
|---|---|---|
| Loop — Research Translation Loop template | `loop-component-regression.spec.ts:150` | #580 |
| language model — Google provider | `language-model-regression.spec.ts:110` | #596 |
| disabling a model removes it from a component model dropdown | `model-provider-model-toggle.spec.ts:162` | #597 |
| select + bulk actions | `bulk-actions.spec.ts:8` | #420 |

Only the `@stable` tag is removed from each `test()`; no other tags, test logic, or spec docs change.

## Why

This is the **manual equivalent of the daily workflow's auto-remove step**. This cycle the scheduled `daily-stable` run was cancelled at the queue stage (GitHub failed to allocate a runner), and the fix run (#594) executed via `workflow_dispatch`, whose auto-remove/issue steps are gated on `schedule` — so nothing fired automatically. Each failure was triaged and tracked:

- **#580** (existing) — loop `model_model` click intercepted by the api_key popover. Recurrence logged.
- **#596** (new) — Google provider flow never reaches `built successfully` (flaky 07-07/08 → hard fail 07-09).
- **#597** (new, high priority) — `llm-toggle-gemini-3.5-flash` never renders in Model Providers settings (3 consecutive daily hard fails).
- **#420** (existing) — bulk-actions empty-state/welcome-panel; new facet folded in.

## Deliverable / restoration

Restoring `@stable` to each test is human-gated and tracked as a deliverable on the respective issue — re-add the tag only after the root cause is fixed and the test is confirmed green.

## Notes

- No spec-doc change: per the tag policy, temporary `@stable` removals are tracked via a GitHub issue, not a spec-doc edit.
- `QA-CHECKLIST.md` Phase 0 / stable block is auto-generated — `update-coverage-summary.yml` regenerates it on merge with `[skip ci]`; not hand-edited here.

Refs #580, #596, #597, #420