### PR TITLE
test(model-provider): groq provider component configure/execute spec (#499)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,12 @@ OLLAMA_BASE_URL=
 OLLAMA_BASE_URL_FROM_LANGFLOW=
 OLLAMA_TEST_MODEL=
 
+# Groq provider (groq-provider.spec.ts). The test probes the Groq API
+# directly and skips with a reason when the key is missing/invalid or
+# GROQ_TEST_MODEL (default: llama-3.1-8b-instant) is not in the live catalog.
+GROQ_API_KEY=
+GROQ_TEST_MODEL=
+
 # Model/provider test strategy (auto-detected by priority):
 # 1. MODEL_TEST_ID set    → runs only the specified model (e.g. gpt-4o-mini)
 # 2. MODEL_TEST_PROVIDER set → runs all models for the specified provider (e.g. openai | anthropic | google)

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -408,7 +408,7 @@
 
 #### 7.6 Open-Source Providers
 - [x] Configure and execute flow with Ollama (local model) → `model-provider/ollama-provider.spec.ts`
-- [ ] Configure and execute flow with Groq
+- [x] Configure and execute flow with Groq → `model-provider/groq-provider.spec.ts`
 - [ ] Configure and execute flow with Mistral
 
 #### 7.7 Model Parameters (Agent)

--- a/docs/core-functionality/model-provider/groq-provider.md
+++ b/docs/core-functionality/model-provider/groq-provider.md
@@ -1,0 +1,176 @@
+# Groq Provider — configure key on the component, execute flow
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+The Groq provider path (QA-CHECKLIST §7.6 "Configure and execute flow with
+Groq") as a single component-centric journey, mirroring the §7.6 sibling
+`ollama-provider.spec.ts`:
+
+A blank canvas flow (Chat Input → Groq → Chat Output) is configured with the
+Groq API key **on the component**, a model is selected from the component's
+live-refreshed catalog, and a Playground run returns a non-empty reply —
+proving the configured provider performs a real cloud inference.
+
+**Why not a Settings → Model Providers test (premise change, found live):**
+on the 1.11 nightly the Settings page does NOT list Groq ("No providers match
+your search"), even though `GET /api/v1/models/providers` includes it. The
+key has no Settings surface; the component's `api_key` field is the configure
+surface. This UI/API divergence is flagged on the PR as a product
+observation.
+
+If this fails, Groq can no longer be configured or executed — the first
+OpenAI-compatible alt-cloud provider covered by the suite.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@components` `@model-provider` `@playground`
+
+`@stable` added only after multiple clean `--retries=0` runs on the fresh
+nightly. `@components` (cross-cutting — canvas component configuration) ·
+`@model-provider` (area) · `@playground` (executes via Playground).
+No `@settings`: the Settings surface does not exist for Groq (see above).
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- `GROQ_API_KEY` set in `.env` (valid, live key — the test probes the Groq
+  API directly and **skips with an explicit reason** when the key is missing,
+  invalid, or the API is unreachable; never a silent green).
+- Optional `GROQ_TEST_MODEL` (default `llama-3.1-8b-instant`) — must exist in
+  the live Groq catalog; the probe skips with a reason if it doesn't.
+- Run with `--workers=1` (the test creates a flow; file is serial).
+
+---
+
+## Step by step *(required)*
+
+**Probe:** `GET https://api.groq.com/openai/v1/models` with the key from the
+env. Missing key / non-200 / test model absent from the catalog →
+`test.skip` with the concrete reason. This turns an unfunded or revoked key
+into an explicit skip instead of a mid-test failure (zero-credit lesson from
+the Anthropic sibling, #503).
+
+**Test — a canvas flow configures the Groq key and executes** (§7.6)
+
+1. Create a **blank flow**; capture the flow id from the `POST /api/v1/flows`
+   201 response (transient-id-safe; deleted in `finally`).
+2. Add **Chat Output**, **Chat Input**, and the **Groq** component
+   (`groqGroq` → `add-component-button-groq`); connect Chat Input → Groq
+   (`handle-groqmodel-shownode-input-left`) and Groq
+   (`handle-groqmodel-shownode-model response-right`) → Chat Output
+   (click-source-then-target handle pattern; expect 2 edges).
+3. **Configure the API key on the Groq node** — fill
+   `popover-anchor-input-api_key` with `GROQ_API_KEY`. The field is
+   `real_time_refresh`: the fill/blur triggers a
+   `POST /api/v1/custom_component/update` that re-fetches the model catalog
+   **live from the Groq API** (live-verified: the refreshed dropdown contains
+   live-only models absent from the static fallback constants) — wait for it
+   to resolve **200** before trusting the dropdown.
+4. **Select the test model** in `dropdown_str_model_name` (option with the
+   exact `GROQ_TEST_MODEL` text); assert
+   `value-dropdown-dropdown_str_model_name` shows it; wait for the debounced
+   autosave to settle (`waitForFlowSaveSettled`) so the Playground builds the
+   persisted flow.
+5. Open the Playground; send
+   `Repeat this token exactly and nothing else: GROQ-<per-run sentinel>`;
+   wait for the run to finish.
+6. **Validation:** the last `div-chat-message` (AI bubble) is **non-empty**
+   (hard — the Groq cloud inference executed with the configured key; there
+   is no keyless path to a reply). The sentinel echo is **logged, not
+   asserted** (family convention).
+7. **Cleanup:** delete the flow by id in `finally` (`deleteFlow`, 404-safe).
+
+---
+
+## Validation criterion *(required)*
+
+With the key configured on the component: the `custom_component/update`
+triggered by **this** key fill resolves 2xx, the `model_name` dropdown offers
+the test model and the selection shows its exact name, and the Playground run
+returns a non-empty AI reply — a real Groq inference, impossible without a
+valid key.
+
+## Guarding against false positives *(how)*
+
+- **Probe-gated skips:** missing/invalid key or absent model → explicit
+  `test.skip` reason, never a silent pass.
+- The `custom_component/update` **200** waiter is armed around the key fill —
+  a rejected or ignored key cannot satisfy it causally.
+- The model assert uses the **exact** `GROQ_TEST_MODEL` text in the selected
+  value — a stale or fallback selection fails.
+- The non-empty reply requires a genuine authenticated inference — Groq has
+  no anonymous path.
+- **Force-failure check** (CONTRIBUTING §2) runs during VERIFY: each assertion
+  broken on purpose once, confirmed red, before `@stable`.
+
+---
+
+## What this test does not cover *(optional)*
+
+- A Settings → Model Providers journey — the surface does not exist for Groq
+  on 1.11 (see the premise-change note; product observation flagged on the PR).
+- Groq models inside the **Agent**'s model dropdown.
+- Invalid-key error UI (see `provider-invalid-auth-error.spec.ts` pattern).
+- Groq-specific parameters (temperature, max tokens, tool models).
+- Mistral (§7.6 sibling bullet — #500, own spec).
+
+---
+
+## External dependencies *(required)*
+
+- `lfx_bundles/groq/groq.py` (Groq component) — `api_key`
+  (`real_time_refresh`), `model_name` dropdown fed by `get_groq_models`;
+  moved from `lfx.components.groq` to the `lfx-bundles` distribution (shim in
+  place on 1.11; the deprecation window closes at M4).
+- `src/frontend/` canvas — sidebar search (`sidebar-search-input`,
+  `groqGroq`, `add-component-button-groq`), node handles
+  (`handle-groqmodel-shownode-*`), component inputs
+  (`popover-anchor-input-api_key`, `dropdown_str_model_name`).
+- `src/frontend/src/components/core/playgroundComponent/` — Playground I/O.
+- Groq API (`api.groq.com`) — probe, live catalog refresh, and the real
+  inference. A live `GROQ_API_KEY` is required; **CI note:** the workflows
+  don't carry a `GROQ_API_KEY` secret yet — in CI the test skips with the
+  probe reason until the secret is added (same degradation contract as
+  Ollama-less runs).
+
+---
+
+## When to review this test *(optional)*
+
+- If Groq gains a Settings → Model Providers surface (add the Settings
+  configure test back — family pattern in
+  `anthropic-provider.spec.ts` Test 1).
+- If the Groq component's fields (`api_key`, `model_name`) or its bundle
+  location change.
+- If the Groq catalog drops `llama-3.1-8b-instant` (override via
+  `GROQ_TEST_MODEL`).
+
+---
+
+## Notes *(optional)*
+
+- **Premise change vs the issue (found by live scout during PLAN):** the
+  issue and the first draft of this doc assumed the keyed-provider family
+  shape (Settings Test 1 + execution Test 2). The Settings page on the 1.11
+  nightly does not list Groq — search returns "No providers match your
+  search" — while the backend `GET /api/v1/models/providers` DOES list it.
+  The spec was re-scoped to the component-only journey (which fully satisfies
+  the §7.6 bullet "Configure and execute flow with Groq"); the UI/API
+  divergence goes on the PR as a product observation for upstream triage.
+- **Live-catalog observable:** the static fallback catalog overlaps the live
+  one on the test model, so dropdown *presence* alone can't prove the key
+  works — the causal `custom_component/update` 200 wait plus the real
+  inference carry that proof. (Scout evidence: with the key set, the dropdown
+  lists live-only models such as `meta-llama/llama-4-scout-17b-16e-instruct`,
+  absent from `groq_constants.py`.)
+- **Per-run sentinel** logged, not asserted (family convention).
+- **`.env.example`** gains `GROQ_API_KEY` (+ optional `GROQ_TEST_MODEL`)
+  alongside the existing provider keys.

--- a/tests/tests-automations/regression/core-functionality/model-provider/groq-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/groq-provider.spec.ts
@@ -1,0 +1,214 @@
+import * as dotenv from "dotenv";
+import path from "path";
+import type { APIRequestContext, Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
+import { zoomOut } from "../../../../helpers/ui/zoom-out";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+
+/**
+ * Groq provider path (QA-CHECKLIST §7.6 "Configure and execute flow with
+ * Groq") as a single component-centric journey, mirroring the §7.6 sibling
+ * ollama-provider.spec.ts:
+ *
+ *   A blank flow (Chat Input → Groq → Chat Output) is configured with the
+ *   Groq API key ON THE COMPONENT, a model is selected from the component's
+ *   live-refreshed catalog, and a Playground run returns a non-empty reply —
+ *   a real cloud inference, impossible without a valid key.
+ *
+ * Why no Settings → Model Providers test (premise change, found live): the
+ * 1.11 nightly's Settings page does NOT list Groq ("No providers match your
+ * search") even though GET /api/v1/models/providers includes it — the
+ * component's api_key field is the configure surface. The UI/API divergence
+ * is flagged on the PR as a product observation.
+ *
+ * False-positive guards: a probe against the Groq API turns a missing or
+ * invalid key into an explicit skip; the custom_component/update 200 waiter
+ * is armed around THIS key fill (a rejected key cannot satisfy it causally);
+ * the model assert requires the exact GROQ_TEST_MODEL text; the reply assert
+ * requires a genuine authenticated inference.
+ */
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
+}
+
+const GROQ_API_KEY = process.env.GROQ_API_KEY ?? "";
+const GROQ_TEST_MODEL = process.env.GROQ_TEST_MODEL ?? "llama-3.1-8b-instant";
+const GROQ_API_BASE = "https://api.groq.com/openai/v1";
+
+interface GroqProbe {
+  reachable: boolean;
+  reason: string;
+}
+
+// One probe per test: GET /models straight against the Groq API. Missing or
+// invalid keys and a catalog without the test model surface as an explicit
+// skip, never a silent green or a mid-test failure (zero-credit lesson from
+// the Anthropic sibling, #503).
+async function probeGroq(request: APIRequestContext): Promise<GroqProbe> {
+  if (!GROQ_API_KEY) {
+    return { reachable: false, reason: "GROQ_API_KEY not set in the environment" };
+  }
+  try {
+    const res = await request.get(`${GROQ_API_BASE}/models`, {
+      headers: { Authorization: `Bearer ${GROQ_API_KEY}` },
+      timeout: 10000,
+    });
+    if (res.status() !== 200) {
+      return {
+        reachable: false,
+        reason: `Groq API answered ${res.status()} for the configured key`,
+      };
+    }
+    const body = (await res.json()) as { data?: Array<{ id?: string }> };
+    const models = (body.data ?? []).map((m) => m.id ?? "").filter(Boolean);
+    if (!models.includes(GROQ_TEST_MODEL)) {
+      return {
+        reachable: false,
+        reason: `model "${GROQ_TEST_MODEL}" not in the live Groq catalog (override via GROQ_TEST_MODEL)`,
+      };
+    }
+    return { reachable: true, reason: "" };
+  } catch {
+    return { reachable: false, reason: "Groq API not reachable from the test host" };
+  }
+}
+
+async function waitForRunToFinish(page: Page): Promise<void> {
+  const stopButton = page.getByRole("button", { name: "Stop" });
+  const stopVisible = await stopButton.isVisible({ timeout: 10000 }).catch(() => false);
+  if (stopVisible) {
+    await expect(stopButton).toBeHidden({ timeout: 120000 });
+  }
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Groq Provider", () => {
+  test(
+    "the Groq component configures the API key and executes the flow",
+    { tag: ["@stable", "@components", "@model-provider", "@playground"] },
+    async ({ page, request }) => {
+      const probe = await probeGroq(request);
+      test.skip(!probe.reachable, probe.reason);
+
+      // Per-run sentinel: logged (soft) — model obedience is not the contract.
+      const token = `GROQ-${Date.now()}`;
+      let flowId = "";
+
+      try {
+        await test.step("create a blank flow with Chat Input → Groq → Chat Output", async () => {
+          await awaitBootstrapTest(page);
+          await page.waitForSelector('[data-testid="blank-flow"]', { timeout: 30000 });
+          const flowCreation = page.waitForResponse(
+            (r) =>
+              r.url().includes("/api/v1/flows") &&
+              r.request().method() === "POST" &&
+              r.status() === 201,
+            { timeout: 15000 },
+          );
+          await page.getByTestId("blank-flow").click();
+          flowId = ((await (await flowCreation).json()) as { id: string }).id;
+
+          await expect(page.getByTestId("sidebar-search-input")).toBeVisible({ timeout: 30000 });
+
+          await page.getByTestId("sidebar-search-input").fill("chat output");
+          await page.waitForSelector('[data-testid="input_outputChat Output"]', { timeout: 30000 });
+          await page.getByTestId("input_outputChat Output").hover();
+          await page.getByTestId("add-component-button-chat-output").click();
+          await zoomOut(page, 2);
+
+          await page.getByTestId("sidebar-search-input").fill("chat input");
+          await page.waitForSelector('[data-testid="input_outputChat Input"]', { timeout: 30000 });
+          await page
+            .getByTestId("input_outputChat Input")
+            .dragTo(page.locator('//*[@id="react-flow-id"]'), {
+              targetPosition: { x: 100, y: 100 },
+            });
+
+          await page.getByTestId("sidebar-search-input").fill("groq");
+          await page.waitForSelector('[data-testid="groqGroq"]', { timeout: 30000 });
+          await page.getByTestId("groqGroq").hover();
+          await page.getByTestId("add-component-button-groq").click();
+
+          await adjustScreenView(page);
+          await expect(page.locator(".react-flow__node")).toHaveCount(3, { timeout: 10000 });
+
+          // Connect by clicking source handle then target handle
+          // (setup-playground pattern; testids live-scouted).
+          await page.getByTestId("handle-chatinput-noshownode-chat message-source").click();
+          await page.getByTestId("handle-groqmodel-shownode-input-left").click();
+          await page.getByTestId("handle-groqmodel-shownode-model response-right").click();
+          await page.getByTestId("handle-chatoutput-noshownode-inputs-target").click();
+          await expect(page.locator(".react-flow__edge")).toHaveCount(2, { timeout: 8000 });
+        });
+
+        await test.step("configure the API key on the Groq node — the catalog refreshes live", async () => {
+          const keyInput = page.getByTestId("popover-anchor-input-api_key");
+          await expect(keyInput).toBeVisible({ timeout: 15000 });
+          // api_key is real_time_refresh: the fill/blur triggers a
+          // custom_component/update round-trip that re-fetches the model
+          // catalog LIVE from the Groq API — wait for it to resolve 2xx
+          // before trusting the dropdown (a rejected key cannot satisfy
+          // this causally).
+          const updatePromise = page.waitForResponse(
+            (r) =>
+              r.url().includes("/api/v1/custom_component/update") &&
+              r.request().method() === "POST" &&
+              r.status() === 200,
+            { timeout: 30000 },
+          );
+          await keyInput.fill(GROQ_API_KEY);
+          await keyInput.blur();
+          await updatePromise;
+        });
+
+        await test.step("select the test model in the component dropdown", async () => {
+          await page.getByTestId("dropdown_str_model_name").click();
+          const option = page
+            .locator('[data-testid$="-option"]')
+            .filter({ hasText: GROQ_TEST_MODEL })
+            .first();
+          await expect(option).toBeVisible({ timeout: 15000 });
+          await option.click();
+          await expect(page.getByTestId("value-dropdown-dropdown_str_model_name")).toContainText(
+            GROQ_TEST_MODEL,
+            { timeout: 10000 },
+          );
+          // Playground builds the PERSISTED flow — the selection must be saved.
+          await waitForFlowSaveSettled(page);
+        });
+
+        await test.step("execute the flow through the Playground", async () => {
+          await page.getByTestId("playground-btn-flow-io").click();
+          const chatInput = page.getByTestId("input-chat-playground").last();
+          await expect(chatInput).toBeVisible({ timeout: 30000 });
+          await chatInput.fill(`Repeat this token exactly and nothing else: ${token}`);
+          await page.getByTestId("button-send").last().click();
+          await waitForRunToFinish(page);
+
+          const aiMessage = page.getByTestId("div-chat-message").last();
+          await expect(aiMessage).toBeVisible({ timeout: 60000 });
+          const reply = (await aiMessage.innerText()).trim();
+          // Hard: the Groq cloud inference executed with the configured key.
+          expect(reply.length).toBeGreaterThan(0);
+          // Soft (family pattern): log whether the sentinel round-tripped.
+          console.log(
+            reply.includes(token)
+              ? `sentinel echoed: input reached the Groq model (${token})`
+              : `sentinel not echoed (model obedience); reply: ${reply.slice(0, 80)}`,
+          );
+        });
+      } finally {
+        if (flowId) {
+          const bearer = await getAuthToken(request);
+          await deleteFlow(request, flowId, { headers: { Authorization: bearer } }).catch(() => {});
+        }
+      }
+    },
+  );
+});


### PR DESCRIPTION
Closes #499.

Closes the `[ ]` "Configure and execute flow with Groq" gap in `QA-CHECKLIST.md` §7.6 as a component-centric journey mirroring the §7.6 sibling `ollama-provider.spec.ts` — distinct from the keyed-provider family (§7.2–§7.4): Groq has **no Settings → Model Providers surface** on the 1.11 nightly, so the component's `api_key` field is the configure surface.

> **Product observation (upstream triage candidate):** `GET /api/v1/models/providers` lists `Groq` (and `Azure OpenAI`), but the Settings → Model Providers page does not render it — searching "groq" returns "No providers match your search" (1.11.0.dev36). The issue assumed the Settings shape; the spec was re-scoped to the component journey, which fully satisfies the §7.6 bullet.

## 1. Covered tests
| # | Test | What it validates |
|---|------|-------------------|
| 1 | `the Groq component configures the API key and executes the flow` | Filling the component's `api_key` causally produces a `POST /api/v1/custom_component/update` → **200** (live catalog re-fetch — a rejected key cannot satisfy the armed waiter); the `model_name` selection shows the **exact** `GROQ_TEST_MODEL` text; the Playground run returns a non-empty AI reply — a real authenticated Groq inference (no anonymous path exists). Sentinel logged, not asserted (family convention). |

## 2. How the test was built
- Skeleton reused from `ollama-provider.spec.ts` (blank flow via `blank-flow`, click-source-then-target handle wiring, `waitForFlowSaveSettled`, Playground run, id-scoped `finally` cleanup).
- **Live-confirmed selectors** (scouted on the running nightly): `groqGroq` / `add-component-button-groq`, `handle-groqmodel-shownode-input-left`, `handle-groqmodel-shownode-model response-right`, `popover-anchor-input-api_key`, `dropdown_str_model_name` / `value-dropdown-dropdown_str_model_name`.
- **Live-catalog behavior verified during scout:** with the key set, the dropdown lists live-only models (e.g. `meta-llama/llama-4-scout-17b-16e-instruct`) absent from the static `groq_constants.py` fallback — the static catalog overlaps the live one on the test model, so the causal `update` 200 wait + the real inference carry the key-works proof, not dropdown presence.
- **Probe-gated skips:** `GET api.groq.com/openai/v1/models` with the env key before any UI — missing/invalid key or absent `GROQ_TEST_MODEL` (default `llama-3.1-8b-instant`, overridable) ⇒ explicit `test.skip` reason (zero-credit lesson from #503).
- `.env.example` gains `GROQ_API_KEY` / `GROQ_TEST_MODEL`.

## 3. Dependencies
- Live `GROQ_API_KEY` (free tier works). **CI note:** no `GROQ_API_KEY` secret in the workflows yet — in CI the test skips with the probe reason until the secret is added (same degradation contract as Ollama-less runs).
- Groq component ships via `lfx-bundles` (`lfx_bundles/groq/groq.py`; shim in `lfx.components.groq` until M4).
- `--workers=1` serial — the test creates a flow.

## Validation (nightly 1.11.0.dev36, `--retries=0`)
- typecheck ✅ · eslint ✅ (0 errors)
- 4 clean runs (3-burst + post-FF final green), no flake ✅ · zero `🚨 Backend Error` ✅
- force-fail executed via the pipeline ff-run gate (records only real failures) ✅ — M1 garbage key (`gsk_invalid_FF`) → red · M2 exact-name model assert on a nonexistent name → red; reverts proven (0 `FF-MUTATION` markers) + final green ✅
- skip path: probe-gated (missing/invalid key ⇒ explicit skip) ✅
- flow cleanup proven: 0 orphan flows on the instance after all runs ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
