### PR TITLE
test(model-provider): mistral provider component configure/execute spec (#500)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,12 @@ OLLAMA_TEST_MODEL=
 GROQ_API_KEY=
 GROQ_TEST_MODEL=
 
+# Mistral provider (mistral-provider.spec.ts). Same probe/skip contract as
+# Groq; MISTRAL_TEST_MODEL (default: mistral-small-latest) must be in both
+# the component's static dropdown options and the live Mistral catalog.
+MISTRAL_API_KEY=
+MISTRAL_TEST_MODEL=
+
 # Model/provider test strategy (auto-detected by priority):
 # 1. MODEL_TEST_ID set    → runs only the specified model (e.g. gpt-4o-mini)
 # 2. MODEL_TEST_PROVIDER set → runs all models for the specified provider (e.g. openai | anthropic | google)

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -409,7 +409,7 @@
 #### 7.6 Open-Source Providers
 - [x] Configure and execute flow with Ollama (local model) → `model-provider/ollama-provider.spec.ts`
 - [x] Configure and execute flow with Groq → `model-provider/groq-provider.spec.ts`
-- [ ] Configure and execute flow with Mistral
+- [x] Configure and execute flow with Mistral → `model-provider/mistral-provider.spec.ts`
 
 #### 7.7 Model Parameters (Agent)
 - [ ] Temperature parameter (verify via network payload) → `agent-max-tokens.spec.ts` (**not implementable on 1.11**: the Agent no longer has a temperature parameter — left with the model-bundle refactor; bullet pending re-scope)

--- a/docs/core-functionality/model-provider/mistral-provider.md
+++ b/docs/core-functionality/model-provider/mistral-provider.md
@@ -1,0 +1,162 @@
+# Mistral Provider — configure key on the component, execute flow
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+The Mistral provider path (QA-CHECKLIST §7.6 "Configure and execute flow with
+Mistral") as a single component-centric journey, mirroring the §7.6 siblings
+`ollama-provider.spec.ts` and `groq-provider.spec.ts`:
+
+A blank canvas flow (Chat Input → MistralAI → Chat Output) is configured with
+the Mistral API key **on the component**, a model is selected from the
+component's dropdown, and a Playground run returns a non-empty reply —
+proving the configured provider performs a real cloud inference.
+
+**Why component-centric:** like Groq (#499), Mistral has no Settings → Model
+Providers surface on 1.11 — `GET /api/v1/models/providers` does not list it
+at all. The component's `api_key` field is the configure surface.
+
+If this fails, Mistral can no longer be configured or executed in a flow.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@components` `@model-provider` `@playground`
+
+`@stable` added only after multiple clean `--retries=0` runs on the fresh
+nightly. `@components` (cross-cutting — canvas component configuration) ·
+`@model-provider` (area) · `@playground` (executes via Playground).
+No `@settings`: the Settings surface does not exist for Mistral.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- `MISTRAL_API_KEY` set in `.env` (valid, live key — the test probes the
+  Mistral API directly and **skips with an explicit reason** when the key is
+  missing, invalid, or the API is unreachable; never a silent green).
+- Optional `MISTRAL_TEST_MODEL` (default `mistral-small-latest`) — must be
+  one of the component's static dropdown options AND in the live Mistral
+  catalog; the probe skips with a reason if absent from the catalog.
+- Run with `--workers=1` (the test creates a flow; file is serial).
+
+---
+
+## Step by step *(required)*
+
+**Probe:** `GET https://api.mistral.ai/v1/models` with the key from the env.
+Missing key / non-200 / test model absent from the catalog → `test.skip`
+with the concrete reason (zero-credit lesson from #503; free-tier keys can
+also be rate-limited — a 429 surfaces as an explicit skip reason, not a
+mid-test mystery).
+
+**Test — a canvas flow configures the Mistral key and executes** (§7.6)
+
+1. Create a **blank flow**; capture the flow id from the `POST /api/v1/flows`
+   201 response (transient-id-safe; deleted in `finally`).
+2. Add **Chat Output**, **Chat Input**, and the **MistralAI** component
+   (`mistralMistralAI` → `add-component-button-mistralai`); connect Chat
+   Input → MistralAI (`handle-mistralaimodelcomponent-shownode-input-left`)
+   and MistralAI (`handle-mistralaimodelcomponent-shownode-model
+   response-right`) → Chat Output (click-source-then-target handle pattern;
+   expect 2 edges).
+3. **Configure the API key on the MistralAI node** — fill
+   `popover-anchor-input-api_key` with `MISTRAL_API_KEY`. Unlike Groq, the
+   field is NOT `real_time_refresh` and the `model_name` dropdown is a
+   **static list** (6 options hardcoded in `lfx_bundles/mistral/mistral.py`)
+   — there is no live-catalog request to await; the execution carries the
+   key-works proof.
+4. **Select the test model** in `dropdown_str_model_name` (option with the
+   exact `MISTRAL_TEST_MODEL` text); assert
+   `value-dropdown-dropdown_str_model_name` shows it; wait for the debounced
+   autosave to settle (`waitForFlowSaveSettled`) so the Playground builds the
+   persisted flow.
+5. Open the Playground; send
+   `Repeat this token exactly and nothing else: MISTRAL-<per-run sentinel>`;
+   wait for the run to finish.
+6. **Validation:** the last `div-chat-message` (AI bubble) is **non-empty**
+   (hard — the Mistral cloud inference executed with the configured key;
+   there is no keyless path to a reply). The sentinel echo is **logged, not
+   asserted** (family convention).
+7. **Cleanup:** delete the flow by id in `finally` (`deleteFlow`, 404-safe).
+
+---
+
+## Validation criterion *(required)*
+
+With the key configured on the component: the `model_name` selection shows
+the exact `MISTRAL_TEST_MODEL` text, and the Playground run returns a
+non-empty AI reply — a real authenticated Mistral inference, impossible
+without a valid key (the fixture also fails the test on any flow-execution
+error event, so an auth failure cannot pass silently).
+
+## Guarding against false positives *(how)*
+
+- **Probe-gated skips:** missing/invalid key or absent model → explicit
+  `test.skip` reason, never a silent pass.
+- The model assert uses the **exact** `MISTRAL_TEST_MODEL` text in the
+  selected value — a stale or default (`codestral-latest`) selection fails.
+- The non-empty reply requires a genuine authenticated inference — Mistral
+  has no anonymous path; the fixtures' flow-error monitor fails the test if
+  the build errors instead.
+- **Force-failure check** (CONTRIBUTING §2) runs during VERIFY: each
+  assertion broken on purpose once, confirmed red, before `@stable`.
+
+---
+
+## What this test does not cover *(optional)*
+
+- A Settings → Model Providers journey — the surface does not exist for
+  Mistral on 1.11 (not even in `GET /api/v1/models/providers`).
+- Live model-catalog refresh — the component's dropdown is static by design
+  (unlike Groq); catalog drift is caught by the probe, not the dropdown.
+- Mistral embeddings (`MistralAI Embeddings` is a separate component).
+- Mistral-specific parameters (temperature, top-p, max tokens, retries).
+- Global-variable binding for the key (the `api_key` field defaults to the
+  `MISTRAL_API_KEY` global variable name; this spec fills the raw key —
+  deterministic and family-consistent).
+
+---
+
+## External dependencies *(required)*
+
+- `lfx_bundles/mistral/mistral.py` (MistralAI component) — `api_key`
+  (SecretStrInput, required), static `model_name` dropdown; shim in
+  `lfx.components.mistral` until the lfx-bundles deprecation window closes.
+- `src/frontend/` canvas — sidebar search (`sidebar-search-input`,
+  `mistralMistralAI`, `add-component-button-mistralai`), node handles
+  (`handle-mistralaimodelcomponent-shownode-*`), component inputs
+  (`popover-anchor-input-api_key`, `dropdown_str_model_name`).
+- `src/frontend/src/components/core/playgroundComponent/` — Playground I/O.
+- Mistral API (`api.mistral.ai`) — probe and the real inference. A live
+  `MISTRAL_API_KEY` is required; **CI note:** the workflows don't carry a
+  `MISTRAL_API_KEY` secret yet — in CI the test skips with the probe reason
+  until the secret is added (same degradation contract as Groq/Ollama).
+
+---
+
+## When to review this test *(optional)*
+
+- If Mistral gains a Settings → Model Providers surface (add the Settings
+  configure test — family pattern in `anthropic-provider.spec.ts` Test 1).
+- If the MistralAI component's fields or its static model list change
+  (`mistral-small-latest` leaving the options breaks the selection step —
+  override via `MISTRAL_TEST_MODEL` only works within the static list).
+- If the component's bundle location changes (lfx-bundles M4 window).
+
+---
+
+## Notes *(optional)*
+
+- **Static dropdown caveat:** `MISTRAL_TEST_MODEL` must satisfy BOTH the
+  component's hardcoded option list and the live catalog. The probe checks
+  the live catalog; the dropdown-selection step inherently checks the static
+  list (a model absent from the options fails the exact-name assert).
+- **Per-run sentinel** logged, not asserted (family convention).
+- **`.env.example`** gains `MISTRAL_API_KEY` (+ optional `MISTRAL_TEST_MODEL`)
+  alongside the Groq block.

--- a/tests/tests-automations/regression/core-functionality/model-provider/mistral-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/mistral-provider.spec.ts
@@ -1,0 +1,206 @@
+import * as dotenv from "dotenv";
+import path from "path";
+import type { APIRequestContext, Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
+import { zoomOut } from "../../../../helpers/ui/zoom-out";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+
+/**
+ * Mistral provider path (QA-CHECKLIST §7.6 "Configure and execute flow with
+ * Mistral") as a single component-centric journey, mirroring the §7.6
+ * siblings ollama-provider.spec.ts and groq-provider.spec.ts:
+ *
+ *   A blank flow (Chat Input → MistralAI → Chat Output) is configured with
+ *   the Mistral API key ON THE COMPONENT, a model is selected, and a
+ *   Playground run returns a non-empty reply — a real cloud inference,
+ *   impossible without a valid key.
+ *
+ * Why component-centric: like Groq (#499), Mistral has no Settings → Model
+ * Providers surface on 1.11 — GET /api/v1/models/providers does not list it
+ * at all. Unlike Groq, the component's model_name dropdown is a STATIC list
+ * (no real_time_refresh on api_key), so there is no live-catalog request to
+ * await — the authenticated execution carries the key-works proof, and the
+ * fixture's flow-error monitor fails the test on an auth error.
+ *
+ * False-positive guards: a probe against the Mistral API turns a missing or
+ * invalid key into an explicit skip; the model assert requires the exact
+ * MISTRAL_TEST_MODEL text (the component defaults to codestral-latest — a
+ * skipped selection fails); the reply assert requires a genuine inference.
+ */
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
+}
+
+const MISTRAL_API_KEY = process.env.MISTRAL_API_KEY ?? "";
+const MISTRAL_TEST_MODEL = process.env.MISTRAL_TEST_MODEL ?? "mistral-small-latest";
+const MISTRAL_API_BASE = "https://api.mistral.ai/v1";
+
+interface MistralProbe {
+  reachable: boolean;
+  reason: string;
+}
+
+// One probe per test: GET /models straight against the Mistral API. Missing
+// or invalid keys and a catalog without the test model surface as an explicit
+// skip, never a silent green or a mid-test failure (zero-credit lesson from
+// the Anthropic sibling, #503).
+async function probeMistral(request: APIRequestContext): Promise<MistralProbe> {
+  if (!MISTRAL_API_KEY) {
+    return { reachable: false, reason: "MISTRAL_API_KEY not set in the environment" };
+  }
+  try {
+    const res = await request.get(`${MISTRAL_API_BASE}/models`, {
+      headers: { Authorization: `Bearer ${MISTRAL_API_KEY}` },
+      timeout: 10000,
+    });
+    if (res.status() !== 200) {
+      return {
+        reachable: false,
+        reason: `Mistral API answered ${res.status()} for the configured key`,
+      };
+    }
+    const body = (await res.json()) as { data?: Array<{ id?: string }> };
+    const models = (body.data ?? []).map((m) => m.id ?? "").filter(Boolean);
+    if (!models.includes(MISTRAL_TEST_MODEL)) {
+      return {
+        reachable: false,
+        reason: `model "${MISTRAL_TEST_MODEL}" not in the live Mistral catalog (override via MISTRAL_TEST_MODEL)`,
+      };
+    }
+    return { reachable: true, reason: "" };
+  } catch {
+    return { reachable: false, reason: "Mistral API not reachable from the test host" };
+  }
+}
+
+async function waitForRunToFinish(page: Page): Promise<void> {
+  const stopButton = page.getByRole("button", { name: "Stop" });
+  const stopVisible = await stopButton.isVisible({ timeout: 10000 }).catch(() => false);
+  if (stopVisible) {
+    await expect(stopButton).toBeHidden({ timeout: 120000 });
+  }
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Mistral Provider", () => {
+  test(
+    "the MistralAI component configures the API key and executes the flow",
+    { tag: ["@stable", "@components", "@model-provider", "@playground"] },
+    async ({ page, request }) => {
+      const probe = await probeMistral(request);
+      test.skip(!probe.reachable, probe.reason);
+
+      // Per-run sentinel: logged (soft) — model obedience is not the contract.
+      const token = `MISTRAL-${Date.now()}`;
+      let flowId = "";
+
+      try {
+        await test.step("create a blank flow with Chat Input → MistralAI → Chat Output", async () => {
+          await awaitBootstrapTest(page);
+          await page.waitForSelector('[data-testid="blank-flow"]', { timeout: 30000 });
+          const flowCreation = page.waitForResponse(
+            (r) =>
+              r.url().includes("/api/v1/flows") &&
+              r.request().method() === "POST" &&
+              r.status() === 201,
+            { timeout: 15000 },
+          );
+          await page.getByTestId("blank-flow").click();
+          flowId = ((await (await flowCreation).json()) as { id: string }).id;
+
+          await expect(page.getByTestId("sidebar-search-input")).toBeVisible({ timeout: 30000 });
+
+          await page.getByTestId("sidebar-search-input").fill("chat output");
+          await page.waitForSelector('[data-testid="input_outputChat Output"]', { timeout: 30000 });
+          await page.getByTestId("input_outputChat Output").hover();
+          await page.getByTestId("add-component-button-chat-output").click();
+          await zoomOut(page, 2);
+
+          await page.getByTestId("sidebar-search-input").fill("chat input");
+          await page.waitForSelector('[data-testid="input_outputChat Input"]', { timeout: 30000 });
+          await page
+            .getByTestId("input_outputChat Input")
+            .dragTo(page.locator('//*[@id="react-flow-id"]'), {
+              targetPosition: { x: 100, y: 100 },
+            });
+
+          await page.getByTestId("sidebar-search-input").fill("mistral");
+          await page.waitForSelector('[data-testid="mistralMistralAI"]', { timeout: 30000 });
+          await page.getByTestId("mistralMistralAI").hover();
+          await page.getByTestId("add-component-button-mistralai").click();
+
+          await adjustScreenView(page);
+          await expect(page.locator(".react-flow__node")).toHaveCount(3, { timeout: 10000 });
+
+          // Connect by clicking source handle then target handle
+          // (setup-playground pattern; testids live-scouted).
+          await page.getByTestId("handle-chatinput-noshownode-chat message-source").click();
+          await page.getByTestId("handle-mistralaimodelcomponent-shownode-input-left").click();
+          await page.getByTestId("handle-mistralaimodelcomponent-shownode-model response-right").click();
+          await page.getByTestId("handle-chatoutput-noshownode-inputs-target").click();
+          await expect(page.locator(".react-flow__edge")).toHaveCount(2, { timeout: 8000 });
+        });
+
+        await test.step("configure the API key on the MistralAI node", async () => {
+          const keyInput = page.getByTestId("popover-anchor-input-api_key");
+          await expect(keyInput).toBeVisible({ timeout: 15000 });
+          // No real_time_refresh on this field (unlike Groq) — the model
+          // dropdown is a static list; the authenticated execution below is
+          // what proves the key works.
+          await keyInput.fill(MISTRAL_API_KEY);
+          await keyInput.blur();
+        });
+
+        await test.step("select the test model in the component dropdown", async () => {
+          await page.getByTestId("dropdown_str_model_name").click();
+          const option = page
+            .locator('[data-testid$="-option"]')
+            .filter({ hasText: MISTRAL_TEST_MODEL })
+            .first();
+          await expect(option).toBeVisible({ timeout: 15000 });
+          await option.click();
+          // Exact-name assert: the component defaults to codestral-latest, so
+          // a silently skipped selection cannot pass.
+          await expect(page.getByTestId("value-dropdown-dropdown_str_model_name")).toContainText(
+            MISTRAL_TEST_MODEL,
+            { timeout: 10000 },
+          );
+          // Playground builds the PERSISTED flow — key + selection must be saved.
+          await waitForFlowSaveSettled(page);
+        });
+
+        await test.step("execute the flow through the Playground", async () => {
+          await page.getByTestId("playground-btn-flow-io").click();
+          const chatInput = page.getByTestId("input-chat-playground").last();
+          await expect(chatInput).toBeVisible({ timeout: 30000 });
+          await chatInput.fill(`Repeat this token exactly and nothing else: ${token}`);
+          await page.getByTestId("button-send").last().click();
+          await waitForRunToFinish(page);
+
+          const aiMessage = page.getByTestId("div-chat-message").last();
+          await expect(aiMessage).toBeVisible({ timeout: 60000 });
+          const reply = (await aiMessage.innerText()).trim();
+          // Hard: the Mistral cloud inference executed with the configured key.
+          expect(reply.length).toBeGreaterThan(0);
+          // Soft (family pattern): log whether the sentinel round-tripped.
+          console.log(
+            reply.includes(token)
+              ? `sentinel echoed: input reached the Mistral model (${token})`
+              : `sentinel not echoed (model obedience); reply: ${reply.slice(0, 80)}`,
+          );
+        });
+      } finally {
+        if (flowId) {
+          const bearer = await getAuthToken(request);
+          await deleteFlow(request, flowId, { headers: { Authorization: bearer } }).catch(() => {});
+        }
+      }
+    },
+  );
+});


### PR DESCRIPTION
Closes #500.

Closes the `[ ]` "Configure and execute flow with Mistral" gap in `QA-CHECKLIST.md` §7.6, **completing the §7.6 Open-Source Providers family** (Ollama #498, Groq #499, Mistral) as a component-centric journey: Mistral has no Settings → Model Providers surface on 1.11 — it is absent even from `GET /api/v1/models/providers` — so the component's `api_key` field is the configure surface.

## 1. Covered tests
| # | Test | What it validates |
|---|------|-------------------|
| 1 | `the MistralAI component configures the API key and executes the flow` | The `model_name` selection shows the **exact** `MISTRAL_TEST_MODEL` text (the component defaults to `codestral-latest`, so a silently skipped selection fails), and the Playground run returns a non-empty AI reply — a real authenticated Mistral inference (no anonymous path; the fixture's flow-error monitor fails the test on an auth error). Sentinel logged, not asserted (family convention). |

## 2. How the test was built
- Skeleton reused from `groq-provider.spec.ts` / `ollama-provider.spec.ts` (blank flow, click-source-then-target handle wiring, `waitForFlowSaveSettled`, Playground run, id-scoped `finally` cleanup).
- **Live-confirmed selectors** (scouted on the running nightly): `mistralMistralAI` / `add-component-button-mistralai`, `handle-mistralaimodelcomponent-shownode-input-left`, `handle-mistralaimodelcomponent-shownode-model response-right`, `popover-anchor-input-api_key`, `dropdown_str_model_name` / `value-dropdown-dropdown_str_model_name`.
- **Deviation from the Groq sibling, from the component source** (`lfx_bundles/mistral/mistral.py`): `api_key` is NOT `real_time_refresh` and the `model_name` dropdown is a **static 6-option list** — there is no live-catalog request to await; the authenticated execution carries the key-works proof.
- **Probe-gated skips:** `GET api.mistral.ai/v1/models` with the env key before any UI — missing/invalid key or `MISTRAL_TEST_MODEL` (default `mistral-small-latest`, overridable) absent from the live catalog ⇒ explicit `test.skip` reason (zero-credit lesson from #503).
- `.env.example` gains `MISTRAL_API_KEY` / `MISTRAL_TEST_MODEL`.

## 3. Dependencies
- Live `MISTRAL_API_KEY` (free tier works). **CI note:** no `MISTRAL_API_KEY` secret in the workflows yet — in CI the test skips with the probe reason until the secret is added (same degradation contract as Groq/Ollama).
- MistralAI component ships via `lfx-bundles` (`lfx_bundles/mistral/mistral.py`; shim until M4).
- `--workers=1` serial — the test creates a flow.

## Validation (nightly 1.11.0.dev36, `--retries=0`)
- typecheck ✅ · eslint ✅ (0 errors)
- 4 clean runs (~11-13s each), sentinel echoed in all, no flake ✅ · zero `🚨 Backend Error` ✅
- force-fail executed ✅ — M1 garbage key → red (inference fails) · M2 exact-name model assert on a nonexistent name → red · M3 behavioral cleanup no-op → 1 surviving orphan observed, reverted → 0 orphans; reverts proven (0 `FF-MUTATION` markers) + final green ✅
- skip path: probe-gated (missing/invalid key ⇒ explicit skip) ✅
- flow cleanup proven: 0 orphan flows on the instance after all runs ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
