### PR TITLE
fix(llm-agents): guard Google LM test against model-selection drop race, restore @stable (#596)

### DIFF
--- a/docs/core-functionality/llm-agents/language-model-regression.md
+++ b/docs/core-functionality/llm-agents/language-model-regression.md
@@ -1,0 +1,121 @@
+# Language Model Component Regression
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+The **Language Model** component on the Basic Prompting template
+(QA-CHECKLIST §7.5 "Language Model component — configuration"): it executes
+with a configured provider, a provider switch persists, and the provider
+management dialog opens from the node.
+
+| Test | Contract |
+|---|---|
+| `language model must respond with OpenAI provider` | Component configured with OpenAI builds (`built successfully`) and the Playground answers `2+2` with `4` |
+| `language model must respond with Google provider` | Same journey with Google: build completes and the Playground returns a non-empty reply |
+| `language model provider switch from OpenAI to Google must persist` | After OpenAI → Google setup, the node's `model_model` trigger shows a Gemini model |
+| `model provider dialog opens from the Language Model node` | The node's model dropdown opens `manage-model-providers` and lists `provider-item-OpenAI` |
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@components` `@model-provider` (+`@workspace` on the
+dialog test).
+
+`@stable` was removed from the Google test by the daily-failure triage for
+#596 (flaky 07-07/07-08 → hard fail 07-09) and **restored by the #596 fix**
+(explicit model + pre-run widget gate — see Step by step and Notes).
+
+---
+
+## Preconditions *(optional)*
+
+- `OPENAI_API_KEY` / `GOOGLE_API_KEY` in the env (each test self-skips
+  without its key).
+- `models.json` fresh (`collect-models.spec.ts`) for the setup helpers.
+- `--workers=1` (template loads create named flows; id-scoped afterEach
+  cleanup is in place).
+
+---
+
+## Step by step *(required)*
+
+Common: open the Basic Prompting template (flow id captured from the page's
+own `POST /api/v1/flows/` response; deleted in `afterEach`).
+
+**OpenAI test:** `initialGPTsetup` → `waitForFlowSaveSettled` (autosave
+debounce — building earlier runs the template's DEFAULT model) → run the
+Chat Output node → wait `built successfully` (30s) → Playground → send
+`What is 2+2?` → last AI bubble contains `4`.
+
+**Google test:** `setupGoogle(page, resolveGeminiModel())` — a deterministic
+Gemini **flash** model pinned from `models.json` (never "first gemini in the
+dropdown") → save-settle guard → **pre-run widget gate (#596/#491 class):**
+if the node's `model_model` widget does not show `/gemini/i`, the selection
+was silently reverted to the workspace-default model by a
+`custom_component/update` race — re-apply the selection (bounded, 3
+attempts), then hard-assert the widget shows a Gemini model → run → wait
+`built successfully` (30s, untouched) → Playground → send `Say hello.` →
+last AI bubble non-empty.
+
+**Switch test:** `initialGPTsetup` + `setupGoogle` → save settle → the
+page-level `model_model` trigger shows `/gemini/i`.
+
+**Dialog test:** select the Language Model node → `hideInspectorPanel` →
+open `model_model` → `manage-model-providers` → `provider-item-OpenAI`
+visible → Escape.
+
+---
+
+## Validation criterion *(required)*
+
+- Build completion is observed via the `built successfully` toast within
+  30s; the Playground reply is the end-to-end proof the selected provider
+  executed.
+- **Fix #596 exit criterion:** the Google test's root cause is identified
+  with evidence (test defect vs product vs environment — triage verdicts),
+  the fix does NOT weaken asserts (no timeout inflation to mask latency),
+  and the test proves N clean `--retries=0` runs on the fresh nightly before
+  `@stable` is restored on the `test()` call.
+
+---
+
+## External dependencies *(required)*
+
+- Basic Prompting starter template (Language Model node, `model_model`
+  trigger, `button_run_chat output`).
+- `setup-google.ts` / `initialGPTsetup` helpers — **model choice happens
+  here**: `setupGoogle(page)` with no argument selects the FIRST Gemini
+  option in the dropdown, so the Google catalog's ordering directly affects
+  which model builds (see #596 investigation).
+- OpenAI / Google APIs — real inference; funded keys.
+- `built successfully` toast markup.
+
+---
+
+## Notes *(optional)*
+
+- File predates the spec-doc convention; this doc was authored during #596
+  (daily-failure fix) to satisfy the PR checklist and record the fix's exit
+  criterion.
+- History (from `reports/daily-history.jsonl`): the Google test was flaky
+  (attempts=2) on 2026-07-07 and 07-08 dailies and hard-failed on 07-09;
+  the 07-07/07-08 dailies also show a broad flaky background (10-13 tests),
+  so environment saturation is part of the verdict space.
+- **#596 root cause (2026-07-09):** model-selection drop race, the #491
+  class. The node's default resolves through a missing internal
+  `__default_language_model__` variable (backend `ValueError` on every canvas
+  load) and falls back to the first configured provider's model; a
+  `custom_component/update` racing the selection reverts the node to that
+  fallback. Locally the fallback (claude-sonnet-5) fails with Anthropic
+  `400 — 'temperature' is deprecated for this model`; on CI the fallback is
+  an inaccessible OpenAI model. Both product observations are documented on
+  the fix PR; per the user's decision the resolution is test-side only
+  (explicit model + re-apply gate), no upstream ask — the race is not
+  reproducible at manual UI speed.
+- **Latent sibling:** the OpenAI tests go through `initialGPTsetup` →
+  `setupOpenAI(page)` with no explicit model (same latent class); out of
+  #596's scope, noted for a follow-up if the daily flags them.

--- a/tests/helpers/provider-setup/resolve-gemini-model.ts
+++ b/tests/helpers/provider-setup/resolve-gemini-model.ts
@@ -1,0 +1,31 @@
+import path from "path";
+import fs from "fs";
+
+// Resolve a Gemini flash chat model from models.json, preferring fast, cheap,
+// non-image/non-tts/non-preview ones. Returns undefined if none/absent — then
+// setup-google picks its default (first gemini option in the dropdown).
+// Extracted verbatim from google-provider.spec.ts (§7.4) for reuse by
+// language-model-regression.spec.ts (#596): tests must pin a deterministic
+// Gemini model instead of depending on catalog/dropdown ordering.
+export function resolveGeminiModel(): string | undefined {
+  const jsonPath = path.resolve(__dirname, "data/models.json");
+  if (!fs.existsSync(jsonPath)) return undefined;
+  const models = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as Array<{
+    provider: string;
+    model: string;
+  }>;
+  const google = models.filter((m) => m.provider === "google").map((m) => m.model);
+  const bad = /image|tts|audio|preview|embedding|customtools/;
+  const prefs = [
+    (m: string) => /^gemini-2\.5-flash$/.test(m),
+    (m: string) => /^gemini-3\.5-flash$/.test(m),
+    (m: string) => /^gemini-flash-latest$/.test(m),
+    (m: string) => /gemini.*flash/.test(m) && !bad.test(m),
+    (m: string) => /gemini/.test(m) && !bad.test(m),
+  ];
+  for (const pref of prefs) {
+    const hit = google.find(pref);
+    if (hit) return hit;
+  }
+  return google[0];
+}

--- a/tests/tests-automations/regression/core-functionality/llm-agents/language-model-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/language-model-regression.spec.ts
@@ -5,6 +5,7 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { initialGPTsetup } from "../../../../helpers/other/initialGPTsetup";
 import { setupGoogle } from "../../../../helpers/provider-setup/setup-google";
+import { resolveGeminiModel } from "../../../../helpers/provider-setup/resolve-gemini-model";
 import { hideInspectorPanel } from "../../../../helpers/ui/hide-inspector-panel";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
@@ -109,7 +110,7 @@ test.describe("Language Model Component Regression", () => {
 
   test(
     "language model must respond with Google provider",
-    { tag: ["@release", "@components", "@model-provider"] },
+    { tag: ["@stable", "@release", "@components", "@model-provider"] },
     async ({ page }) => {
       test.skip(
         !process?.env?.GOOGLE_API_KEY,
@@ -118,9 +119,36 @@ test.describe("Language Model Component Regression", () => {
 
       await openBasicPrompting(page);
 
-      await setupGoogle(page);
+      // Pin a deterministic Gemini flash model instead of "first gemini in
+      // the dropdown" — the dropdown order follows the catalog and the node's
+      // default follows the first configured provider (#596).
+      const geminiModel = resolveGeminiModel();
+      try {
+        await setupGoogle(page, geminiModel);
+      } catch (e: any) {
+        if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
+        throw e;
+      }
       // Same autosave-debounce guard as the OpenAI test above.
       await waitForFlowSaveSettled(page);
+
+      // Pre-run widget gate (#596, same class as #491): a custom_component/
+      // update racing the selection can silently revert the node to the
+      // workspace-default model (an unrelated provider — the build then fails
+      // and "built successfully" never fires). If the selection dropped,
+      // re-apply it; the race becomes a re-select instead of a wrong-model
+      // build. Bounded — three drops in a row is a real failure.
+      const modelWidget = page.locator('[data-testid="model_model"]').first();
+      for (let attempt = 0; attempt < 3; attempt++) {
+        const shown = await modelWidget.innerText().catch(() => "");
+        if (/gemini/i.test(shown)) break;
+        console.log(
+          `model selection dropped to "${shown.trim()}" — re-applying (attempt ${attempt + 1}/3, see #596)`,
+        );
+        await setupGoogle(page, geminiModel);
+        await waitForFlowSaveSettled(page);
+      }
+      await expect(modelWidget).toContainText(/gemini/i, { timeout: 10000 });
 
       await page.getByTestId("button_run_chat output").click();
       await page.waitForSelector("text=built successfully", { timeout: 30000 });

--- a/tests/tests-automations/regression/core-functionality/model-provider/google-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/google-provider.spec.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import path from "path";
-import fs from "fs";
 import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SettingsPage, SimpleAgentTemplatePage } from "../../../../pages";
@@ -10,6 +9,7 @@ import {
   hasProviderEnvKeys,
   missingProviderEnvKeys,
 } from "../../../../helpers/provider-setup";
+import { resolveGeminiModel } from "../../../../helpers/provider-setup/resolve-gemini-model";
 
 /**
  * Google (Gemini) provider path (QA-CHECKLIST §7.4) as a provider-centric journey:
@@ -33,35 +33,6 @@ if (!process.env.CI) {
 }
 
 const PROVIDER = "google";
-
-// Resolve a Gemini flash chat model from models.json, preferring fast, cheap,
-// non-image/non-tts/non-preview ones. Returns undefined if none/absent — then
-// setup-google picks a default.
-function resolveGeminiModel(): string | undefined {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/models.json",
-  );
-  if (!fs.existsSync(jsonPath)) return undefined;
-  const models = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as Array<{
-    provider: string;
-    model: string;
-  }>;
-  const google = models.filter((m) => m.provider === PROVIDER).map((m) => m.model);
-  const bad = /image|tts|audio|preview|embedding|customtools/;
-  const prefs = [
-    (m: string) => /^gemini-2\.5-flash$/.test(m),
-    (m: string) => /^gemini-3\.5-flash$/.test(m),
-    (m: string) => /^gemini-flash-latest$/.test(m),
-    (m: string) => /gemini.*flash/.test(m) && !bad.test(m),
-    (m: string) => /gemini/.test(m) && !bad.test(m),
-  ];
-  for (const pref of prefs) {
-    const hit = google.find(pref);
-    if (hit) return hit;
-  }
-  return google[0];
-}
 
 async function loadAgent(page: Page, model?: string): Promise<void> {
   try {


### PR DESCRIPTION
**Closes #596.**

## Problem

`language model must respond with Google provider` (`language-model-regression.spec.ts:110`) degraded on the daily: flaky on 2026-07-07 and 07-08 (attempts=2), hard fail on 07-09 — `built successfully` never appears within 30s. `@stable` was removed by the triage.

**Root cause (reproduced locally, bimodal 4/4 fail → 6/6 pass):** a model-selection drop race, the same class as #491 (documented on PR #578). The LM node's default model resolves through an internal `__default_language_model__` variable that does not exist (backend logs a `ValueError` on every canvas load — 55 hits in 2h) and falls back to the first configured provider's model. A `custom_component/update` racing the `setupGoogle` selection re-renders the node back to that fallback, so the build runs an unintended model:

- **locally** the fallback is `claude-sonnet-5` → Anthropic rejects with `400 — 'temperature' is deprecated for this model` → "Flow build failed" toast, never "built successfully";
- **on CI** (no Anthropic key) the fallback is an inaccessible OpenAI model — matching the daily's flaky→hard signature.

Manual UI-speed selection always sticks — the race only bites at automation speed. **Per the issue decision, the resolution is test-side only; both product observations (selection-drop race; fresh templates unexecutable out-of-the-box when the default model rejects `temperature`) are documented here for reference, with no upstream ask.**

## Fix

- **Pin a deterministic Gemini flash model:** `resolveGeminiModel()` (proven in `google-provider.spec.ts` §7.4) extracted verbatim to `tests/helpers/provider-setup/resolve-gemini-model.ts` and passed explicitly to `setupGoogle` — the test no longer depends on dropdown/catalog ordering (`MODEL_NOT_AVAILABLE` ⇒ explicit skip).
- **Bounded pre-run widget gate (the #491 guard pattern):** if the node's `model_model` widget does not show `/gemini/i` after save-settle, the selection was dropped — re-apply it (max 3 attempts, logged), then hard-assert the widget. The race becomes a re-select instead of a wrong-model build.
- `@stable` restored on the test.
- Spec doc authored (`docs/core-functionality/llm-agents/language-model-regression.md` — file predates the spec-doc convention) recording the root cause and exit criterion.

Rejected alternative: raising the 30s `built successfully` timeout — masks real regressions and doesn't address the wrong-model build.

## Scope note

- The other three tests in the file are behaviorally untouched (M1/M3/M4 force-fails prove their asserts still bite).
- `google-provider.spec.ts` touched only by the helper-extraction import swap (its own asserts re-proven via M5/M6).
- Latent sibling noted in the spec doc, out of scope: the OpenAI tests use `setupOpenAI(page)` with no explicit model (same latent class) — follow-up if the daily flags them.

## Validation (nightly 1.11.0.dev36, `--retries=0`)

- typecheck ✅ · eslint ✅ (0 errors)
- 3 bursts × (4/4 language-model + 2/2 google-provider) + post-FF final green = 8 clean runs, no flake ✅ (pre-fix control: 4 consecutive failures on the same environment)
- force-fail executed via the pipeline ff-run gate ✅ — M1 impossible response sentinel (OpenAI test) · M2 gate expects nonexistent model family · M3 switch assert impossible · M4 nonexistent provider item · M5 garbage Google key → causal save asserts · M6 google-provider selection assert — all red; reverts proven (0 `FF-MUTATION` markers) + final green ✅
- zero `🚨 Backend Error` from the fixture ✅
- `--trace=on` skipped — known local hang on template-family specs (#490/#518)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
