### PR TITLE
fix(ci): provision Anthropic, Groq and Mistral API keys in daily-stable (#600)

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -156,6 +156,9 @@ jobs:
           PLAYWRIGHT_BASE_URL: "http://localhost:7860/"
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
 
       - name: Run @stable tests
         run: npx playwright test --grep "@stable" --pass-with-no-tests --reporter=html,github,json
@@ -165,6 +168,9 @@ jobs:
           PLAYWRIGHT_JSON_OUTPUT_NAME: results.json
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
 
       - name: Upload Playwright report (full, heavy)
         id: upload_report                     # ← full report: index.html + data/ + trace/ attachments (~380 MB)


### PR DESCRIPTION
Fixes #600

## What

Adds `ANTHROPIC_API_KEY`, `GROQ_API_KEY` and `MISTRAL_API_KEY` to **both** env blocks of `daily-stable.yml` (*Collect models* and *Run @stable tests*), mirroring the existing `OPENAI_API_KEY` / `GOOGLE_API_KEY` wiring.

The three matching **repository secrets are already provisioned** (`gh secret set`, 2026-07-09).

## Why

- #600: the 3 `anthropic-provider.spec.ts` `@stable` tests skip on every daily run (`Missing env vars for provider "anthropic": ANTHROPIC_API_KEY`), plus the multi-provider `agent-component-regression` test — dead coverage marked green.
- Same class for the newly merged provider specs: `groq-provider.spec.ts` (PR #601) and `mistral-provider.spec.ts` (PR #602) both skip in CI without their keys — the CI gap was flagged on those PRs.

No `*_TEST_MODEL` secrets needed: the specs default to `llama-3.1-8b-instant` (Groq) and `mistral-small-latest` (Mistral), overridable via env if the catalogs move.

## Deliberately out of scope

`nightly.yml` passes **no** provider keys at all (not even OpenAI/Google) — a pre-existing gap noted in #600 as "e.g. nightly". Wiring keys there would add daily API cost + failure-issue noise to the full-suite run; left for a separate decision.

## Validation

- YAML lint passes on the edited workflow.
- Effect is only observable in the next daily-stable run (2026-07-10, 05:00 BRT): acceptance is the 3 anthropic-provider tests + groq + mistral executing (pass/fail) instead of skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)