### PR TITLE
fix(model-provider): id-scoped flow cleanup in google/openai provider specs (#605)

### DIFF
--- a/docs/core-functionality/model-provider/anthropic-provider.md
+++ b/docs/core-functionality/model-provider/anthropic-provider.md
@@ -45,7 +45,7 @@ nightly. `@model-provider` (area) · `@settings` (Test 1 navigates Settings) ·
 - `models.json` / `providers.json` generated via
   `npx playwright test tests/collect-models.spec.ts` (Anthropic must be `active`).
 - Run with `--workers=1` (Tests 2–3 load a named template via
-  `SimpleAgentTemplatePage`, which wipes flows). File is serial.
+  `SimpleAgentTemplatePage`; agent-family convention). File is serial.
 
 ---
 

--- a/docs/core-functionality/model-provider/google-provider.md
+++ b/docs/core-functionality/model-provider/google-provider.md
@@ -42,7 +42,7 @@ nightly. `@model-provider` (area) · `@settings` (Test 1 navigates Settings) ·
 - `models.json` / `providers.json` generated via
   `npx playwright test tests/collect-models.spec.ts` (Google must be `active`).
 - Run with `--workers=1` (Test 2 loads a named template via
-  `SimpleAgentTemplatePage`, which wipes flows). File is serial.
+  `SimpleAgentTemplatePage`; agent-family convention). File is serial.
 
 ---
 
@@ -172,6 +172,13 @@ nightly. `@model-provider` (area) · `@settings` (Test 1 navigates Settings) ·
   completion. Tool execution stays covered by `agent-component-regression.spec.ts`.
   The Playground builds the *persisted* flow, so the deletion is followed by
   `waitForFlowSaveSettled`.
+- **Flow cleanup (id-scoped, issue #605):** Test 2 creates a flow via
+  `SimpleAgentTemplatePage.load()`, which does NO cleanup (post-#553 contract).
+  The spec tracks every `POST /api/v1/flows` → 201 id fired during load and
+  deletes them by id in `test.afterEach` (transient ids 404 harmlessly —
+  `deleteFlow` treats 404 as done). Never a name-based or delete-all cleanup
+  (cross-worker wiper class, #553/#520). Same pattern as
+  `anthropic-provider.spec.ts`.
 - **Per-run sentinel** proves *this* execution produced the output.
 - **Shared global key:** the Google key is global and persists across runs. Test 1
   is idempotent — it re-saves and asserts the request outcomes, not a fresh start.

--- a/docs/core-functionality/model-provider/openai-provider.md
+++ b/docs/core-functionality/model-provider/openai-provider.md
@@ -42,7 +42,7 @@ Settings) · `@agents` + `@playground` (Test 2 executes an agent).
 - `models.json` / `providers.json` generated via
   `npx playwright test tests/collect-models.spec.ts`.
 - Run with `--workers=1` (Test 2 loads a named template via
-  `SimpleAgentTemplatePage`, which wipes flows). File is serial.
+  `SimpleAgentTemplatePage`; agent-family convention). File is serial.
 
 ---
 
@@ -171,6 +171,13 @@ Settings) · `@agents` + `@playground` (Test 2 executes an agent).
 - **Per-run sentinel** over a generic non-empty check: proves *this* execution
   produced the output, so the "execute with OpenAI" bullet can't pass on stale
   text.
+- **Flow cleanup (id-scoped, issue #605):** Test 2 creates a flow via
+  `SimpleAgentTemplatePage.load()`, which does NO cleanup (post-#553 contract).
+  The spec tracks every `POST /api/v1/flows` → 201 id fired during load and
+  deletes them by id in `test.afterEach` (transient ids 404 harmlessly —
+  `deleteFlow` treats 404 as done). Never a name-based or delete-all cleanup
+  (cross-worker wiper class, #553/#520). Same pattern as
+  `anthropic-provider.spec.ts`.
 - **Why the tools are removed before executing (root-caused during validation):**
   the Simple Agent template ships with Web Search + URL tools. Executing it with
   those tools on `gpt-4o-mini` failed ~1 in 5 runs (even spaced ~60s apart) with a

--- a/tests/tests-automations/regression/core-functionality/model-provider/google-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/google-provider.spec.ts
@@ -5,6 +5,8 @@ import { expect, test } from "../../../../fixtures/fixtures";
 import { SettingsPage, SimpleAgentTemplatePage } from "../../../../pages";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import {
   hasProviderEnvKeys,
   missingProviderEnvKeys,
@@ -34,7 +36,26 @@ if (!process.env.CI) {
 
 const PROVIDER = "google";
 
+// SimpleAgentTemplatePage.load() does NO cleanup (post-#553 contract) and the
+// canvas URL id is transient on 1.11 — track every flow the load actually
+// creates (POST /api/v1/flows → 201) and delete those ids in afterEach (#605).
+const createdFlowIds: string[] = [];
+
 async function loadAgent(page: Page, model?: string): Promise<void> {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {}); // non-JSON / batch payloads
+    }
+  });
   try {
     await new SimpleAgentTemplatePage(page).load({ provider: PROVIDER, model });
   } catch (e: any) {
@@ -42,6 +63,16 @@ async function loadAgent(page: Page, model?: string): Promise<void> {
     throw e;
   }
 }
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  // page.request carries only browser cookies — the flows API wants the
+  // Bearer token, so authenticate explicitly (a silent 401 here leaks flows).
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, { headers: { Authorization: bearer } });
+  }
+});
 
 async function waitForAgentToFinish(page: Page): Promise<void> {
   const stopButton = page.getByRole("button", { name: "Stop" });
@@ -51,8 +82,8 @@ async function waitForAgentToFinish(page: Page): Promise<void> {
   }
 }
 
-// SimpleAgentTemplatePage.load() deletes all flows before loading the template;
-// serial mode + --workers=1 keeps the shared instance state deterministic.
+// Serial mode + --workers=1 keeps the shared instance state deterministic
+// (agent-family convention — named template loads collide under parallelism).
 test.describe.configure({ mode: "serial" });
 
 test.describe("Google Provider", () => {

--- a/tests/tests-automations/regression/core-functionality/model-provider/openai-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/openai-provider.spec.ts
@@ -10,6 +10,8 @@ import {
   hasProviderEnvKeys,
   missingProviderEnvKeys,
 } from "../../../../helpers/provider-setup";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 /**
  * OpenAI provider happy path (QA-CHECKLIST §7.2) as a provider-centric journey:
@@ -56,7 +58,26 @@ function resolveGptModel(): string | undefined {
   return openai[0];
 }
 
+// SimpleAgentTemplatePage.load() does NO cleanup (post-#553 contract) and the
+// canvas URL id is transient on 1.11 — track every flow the load actually
+// creates (POST /api/v1/flows → 201) and delete those ids in afterEach (#605).
+const createdFlowIds: string[] = [];
+
 async function loadAgent(page: Page, model?: string): Promise<void> {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {}); // non-JSON / batch payloads
+    }
+  });
   try {
     await new SimpleAgentTemplatePage(page).load({ provider: PROVIDER, model });
   } catch (e: any) {
@@ -64,6 +85,16 @@ async function loadAgent(page: Page, model?: string): Promise<void> {
     throw e;
   }
 }
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  // page.request carries only browser cookies — the flows API wants the
+  // Bearer token, so authenticate explicitly (a silent 401 here leaks flows).
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, { headers: { Authorization: bearer } });
+  }
+});
 
 async function waitForAgentToFinish(page: Page): Promise<void> {
   const stopButton = page.getByRole("button", { name: "Stop" });
@@ -73,8 +104,8 @@ async function waitForAgentToFinish(page: Page): Promise<void> {
   }
 }
 
-// SimpleAgentTemplatePage.load() deletes all flows before loading the template;
-// serial mode + --workers=1 keeps the shared instance state deterministic.
+// Serial mode + --workers=1 keeps the shared instance state deterministic
+// (agent-family convention — named template loads collide under parallelism).
 test.describe.configure({ mode: "serial" });
 
 test.describe("OpenAI Provider", () => {


### PR DESCRIPTION
Closes #605

## What

`google-provider.spec.ts` and `openai-provider.spec.ts` discarded the flow id returned by `SimpleAgentTemplatePage.load()` and had no teardown — since #553 removed the global pre-cleanup from `loadTemplateByName`, every execution leaked one Simple Agent flow (**6 orphans observed live** on the local instance).

- Both specs now track every `POST /api/v1/flows` → 201 id fired during load (`createdFlowIds` response listener) and delete those ids in `test.afterEach` with an explicit Bearer token (`getAuthToken` + `deleteFlow`) — the exact pattern already merged in `anthropic-provider.spec.ts` (PR #592) and `language-model-regression.spec.ts` (PR #603). Id-scoped, never name-based or delete-all (cross-worker wiper class, #553/#520).
- Fixed the stale `"SimpleAgentTemplatePage.load() deletes all flows before loading"` comments in both specs (false since #553).
- Spec docs: added the **Flow cleanup (id-scoped, issue #605)** note to `google-provider.md` / `openai-provider.md`; fixed the stale "wipes flows" precondition line in all three provider docs (anthropic included).
- Purged the 6 pre-existing orphans by id.

No assertion was touched — cleanup only.

## Validation

Langflow nightly **1.11.0.dev36**, local run.

- Burst 3× `--retries=0` per spec (pipeline-run, JSON stats): `expected=2 unexpected=0 flaky=0 backendErrors=false` on all 6 runs.
- **Leak criterion:** flow count stayed at baseline across all burst runs (cleanup deletes each run's flow); before the fix each run leaked one.
- **Behavioral force-fail:** no-op'ing the `afterEach` (`return; // FF-MUTATION`) made the flow count grow 6→7 — the orphan survived, proving the cleanup is load-bearing.
- **Assert force-fails (4/4 failed as expected, `unexpected=1`):**
  - google T1 — `expect(persistResp.ok()).toBe(false)`
  - google T2 — model regex → `/gpt-nonexistent/i`
  - openai T1 — `expect(persistResp.ok()).toBe(false)`
  - openai T2 — model regex → `/claude-nonexistent/i`
- Reverts verified: 0 `FF-MUTATION` markers in the diff + final green run.
- `npm run typecheck` 0 errors · `npm run lint` 0 errors (warnings are the pre-existing baseline).
- QA-CHECKLIST untouched (fix-only, no coverage change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)