### PR TITLE
fix(llm-agents): deterministic GPT model in initialGPTsetup + pre-run gate (#606)

### DIFF
--- a/docs/core-functionality/llm-agents/language-model-regression.md
+++ b/docs/core-functionality/llm-agents/language-model-regression.md
@@ -46,10 +46,16 @@ dialog test).
 Common: open the Basic Prompting template (flow id captured from the page's
 own `POST /api/v1/flows/` response; deleted in `afterEach`).
 
-**OpenAI test:** `initialGPTsetup` → `waitForFlowSaveSettled` (autosave
-debounce — building earlier runs the template's DEFAULT model) → run the
-Chat Output node → wait `built successfully` (30s) → Playground → send
-`What is 2+2?` → last AI bubble contains `4`.
+**OpenAI test:** `initialGPTsetup` — which pins a deterministic GPT model
+from `models.json` via `resolveGptModel()` (#606; UI preference-ranking is
+the fallback when `models.json` is absent or the pinned model left the
+lineup) → `waitForFlowSaveSettled` (autosave debounce — building earlier
+runs the template's DEFAULT model) → **pre-run widget gate (#596/#491
+class, #606):** if the node's `model_model` widget does not show `/gpt/i`,
+the selection was silently reverted by a `custom_component/update` race —
+re-apply (bounded, 3 attempts), then hard-assert → run the Chat Output
+node → wait `built successfully` (30s) → Playground → send `What is 2+2?`
+→ last AI bubble contains `4`.
 
 **Google test:** `setupGoogle(page, resolveGeminiModel())` — a deterministic
 Gemini **flash** model pinned from `models.json` (never "first gemini in the
@@ -116,6 +122,17 @@ visible → Escape.
   the fix PR; per the user's decision the resolution is test-side only
   (explicit model + re-apply gate), no upstream ask — the race is not
   reproducible at manual UI speed.
-- **Latent sibling:** the OpenAI tests go through `initialGPTsetup` →
-  `setupOpenAI(page)` with no explicit model (same latent class); out of
-  #596's scope, noted for a follow-up if the daily flags them.
+- **Latent sibling — resolved (#606):** the OpenAI tests went through
+  `initialGPTsetup` → `setupOpenAI(page)` with no explicit model.
+  `initialGPTsetup` now defaults the model to `resolveGptModel()`
+  (deterministic pick from `models.json`, extracted from
+  `openai-provider.spec.ts` into `tests/helpers/provider-setup/`), falling
+  back to `setupOpenAI`'s UI preference-ranking when `models.json` is
+  absent or the pinned model is not in the dropdown
+  (`fallbackToRanking: true` — the fallback happens in-dropdown, never via
+  close-and-retry, which races the providers refetch and clicks a detached
+  option; the 13 consumer specs never break on stale collected data).
+  Premise correction vs the issue text: the no-model branch of
+  `setupOpenAI` was already preference-ranked, not blind "first
+  available" — the nondeterminism was the last-resort fallback and the
+  missing race gate, both addressed.

--- a/tests/helpers/other/initialGPTsetup.ts
+++ b/tests/helpers/other/initialGPTsetup.ts
@@ -2,6 +2,7 @@ import type { Page } from "@playwright/test";
 import { adjustScreenView } from "../ui/adjust-screen-view";
 import { updateOldComponents } from "../flows/update-old-components";
 import { setupOpenAI } from "../provider-setup/setup-openai";
+import { resolveGptModel } from "../provider-setup/resolve-gpt-model";
 import { unselectNodes } from "../ui/unselect-nodes";
 
 export async function initialGPTsetup(
@@ -19,7 +20,13 @@ export async function initialGPTsetup(
     await updateOldComponents(page);
   }
   if (!options?.skipProviderSetup) {
-    await setupOpenAI(page);
+    // Pin a deterministic GPT model from models.json instead of relying on
+    // the dropdown's runtime contents (#606 — same class as #596: the
+    // catalog-order fallback silently changes which model every consumer
+    // runs). If the pinned model left the live lineup (stale models.json),
+    // setupOpenAI falls through to its UI preference-ranking in-dropdown
+    // rather than failing every consumer spec.
+    await setupOpenAI(page, resolveGptModel(), { fallbackToRanking: true });
   }
   if (!options?.skipAdjustScreenView) {
     await adjustScreenView(page);

--- a/tests/helpers/provider-setup/resolve-gpt-model.ts
+++ b/tests/helpers/provider-setup/resolve-gpt-model.ts
@@ -1,0 +1,25 @@
+import path from "path";
+import fs from "fs";
+
+// Resolve a GPT chat model from models.json, preferring small general-purpose
+// (vision-capable) ones. Returns undefined if none/absent — setup-openai then
+// falls back to its UI preference-ranking over the live dropdown.
+// Extracted verbatim from openai-provider.spec.ts (§7.2) for reuse by
+// initialGPTsetup (#606): consumers must pin a deterministic GPT model instead
+// of depending on catalog/dropdown ordering (same move as resolveGeminiModel
+// for #596).
+export function resolveGptModel(): string | undefined {
+  const jsonPath = path.resolve(__dirname, "data/models.json");
+  if (!fs.existsSync(jsonPath)) return undefined;
+  const models = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as Array<{
+    provider: string;
+    model: string;
+  }>;
+  const openai = models.filter((m) => m.provider === "openai").map((m) => m.model);
+  const prefs = [/^gpt-4o-mini$/, /^gpt-4o$/, /^gpt-4\.1(-mini|-nano)?$/, /^gpt-4/];
+  for (const pref of prefs) {
+    const hit = openai.find((m) => pref.test(m));
+    if (hit) return hit;
+  }
+  return openai[0];
+}

--- a/tests/helpers/provider-setup/setup-openai.ts
+++ b/tests/helpers/provider-setup/setup-openai.ts
@@ -4,6 +4,15 @@ import { hideInspectorPanel } from "../ui/hide-inspector-panel";
 export async function setupOpenAI(
   page: Page,
   modelTestId?: string,
+  opts?: {
+    // When the requested model is not in the live dropdown, fall through to
+    // the UI preference-ranking below instead of throwing MODEL_NOT_AVAILABLE.
+    // Used by initialGPTsetup (#606): its pin comes from models.json, which
+    // can be stale — its consumers must degrade, not fail. The in-dropdown
+    // fallback matters: closing (Escape) and re-opening the dropdown for a
+    // retry races the providers refetch and clicks a detached option.
+    fallbackToRanking?: boolean;
+  },
 ): Promise<void> {
   // Step 1: Find the entry point into the provider management panel.
   // "model_model" exists only when a provider is already configured.
@@ -79,15 +88,23 @@ export async function setupOpenAI(
   const modelTrigger = page.getByTestId("model_model");
   await modelTrigger.waitFor({ state: "visible", timeout: 15000 });
   await modelTrigger.click();
+  let pickByRanking = !modelTestId;
   if (modelTestId) {
     const modelOption = page.locator('[data-testid$="-option"]', { hasText: new RegExp(`^${modelTestId}$`) });
     const isAvailable = await modelOption.isVisible({ timeout: 10000 }).catch(() => false);
-    if (!isAvailable) {
+    if (isAvailable) {
+      await modelOption.click();
+    } else if (opts?.fallbackToRanking) {
+      console.log(
+        `pinned model "${modelTestId}" not in the live dropdown — falling back to UI preference-ranking (#606)`,
+      );
+      pickByRanking = true;
+    } else {
       await page.keyboard.press("Escape");
       throw new Error(`MODEL_NOT_AVAILABLE: "${modelTestId}" not found in dropdown — model may not be supported.`);
     }
-    await modelOption.click();
-  } else {
+  }
+  if (pickByRanking) {
     // No explicit model requested — pick a fast, general-purpose model from the
     // enabled dropdown. Hardcoding a single name (previously "gpt-4o-mini")
     // breaks whenever that model leaves the lineup on gpt-5.x nightlies. Instead

--- a/tests/tests-automations/regression/core-functionality/llm-agents/language-model-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/language-model-regression.spec.ts
@@ -82,6 +82,25 @@ test.describe("Language Model Component Regression", () => {
       // gpt-5.5-pro instead of the selected one).
       await waitForFlowSaveSettled(page);
 
+      // Pre-run widget gate (#606, same class as #596/#491): a
+      // custom_component/update racing the selection can silently revert the
+      // node to the workspace-default model. If the selection dropped,
+      // re-apply it; bounded — three drops in a row is a real failure.
+      const modelWidget = page.locator('[data-testid="model_model"]').first();
+      for (let attempt = 0; attempt < 3; attempt++) {
+        const shown = await modelWidget.innerText().catch(() => "");
+        if (/gpt/i.test(shown)) break;
+        console.log(
+          `model selection dropped to "${shown.trim()}" — re-applying (attempt ${attempt + 1}/3, see #606)`,
+        );
+        await initialGPTsetup(page, {
+          skipAdjustScreenView: true,
+          skipUpdateOldComponents: true,
+        });
+        await waitForFlowSaveSettled(page);
+      }
+      await expect(modelWidget).toContainText(/gpt/i, { timeout: 10000 });
+
       await page.getByTestId("button_run_chat output").click();
       await page.waitForSelector("text=built successfully", { timeout: 30000 });
 

--- a/tests/tests-automations/regression/core-functionality/model-provider/openai-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/openai-provider.spec.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import path from "path";
-import fs from "fs";
 import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SettingsPage, SimpleAgentTemplatePage } from "../../../../pages";
@@ -12,6 +11,7 @@ import {
 } from "../../../../helpers/provider-setup";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { resolveGptModel } from "../../../../helpers/provider-setup/resolve-gpt-model";
 
 /**
  * OpenAI provider happy path (QA-CHECKLIST §7.2) as a provider-centric journey:
@@ -36,27 +36,6 @@ if (!process.env.CI) {
 }
 
 const PROVIDER = "openai";
-
-// Resolve a GPT chat model from models.json, preferring small general-purpose
-// ones. Returns undefined if none/absent — setup-openai then picks a default.
-function resolveGptModel(): string | undefined {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/models.json",
-  );
-  if (!fs.existsSync(jsonPath)) return undefined;
-  const models = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as Array<{
-    provider: string;
-    model: string;
-  }>;
-  const openai = models.filter((m) => m.provider === PROVIDER).map((m) => m.model);
-  const prefs = [/^gpt-4o-mini$/, /^gpt-4o$/, /^gpt-4\.1(-mini|-nano)?$/, /^gpt-4/];
-  for (const pref of prefs) {
-    const hit = openai.find((m) => pref.test(m));
-    if (hit) return hit;
-  }
-  return openai[0];
-}
 
 // SimpleAgentTemplatePage.load() does NO cleanup (post-#553 contract) and the
 // canvas URL id is transient on 1.11 — track every flow the load actually


### PR DESCRIPTION
Closes #606

## What

`initialGPTsetup` called `setupOpenAI(page)` with no model, exposing its **13 consumer specs** to the #596-class selection-drop race and to the catalog-order last-resort fallback.

- **New `resolveGptModel()`** (`tests/helpers/provider-setup/resolve-gpt-model.ts`): deterministic GPT pick from `models.json` (`gpt-4o-mini` → `gpt-4o` → `gpt-4.1*` → `gpt-4*`), extracted verbatim from `openai-provider.spec.ts` — the same move as `resolveGeminiModel` in PR #603.
- **`initialGPTsetup`** now pins `resolveGptModel()` via `setupOpenAI(page, model, { fallbackToRanking: true })`.
- **`setupOpenAI`**: new `opts.fallbackToRanking` — when the pinned model is not in the live dropdown, log and fall through to the existing UI preference-ranking **in-dropdown** instead of throwing `MODEL_NOT_AVAILABLE`. In-dropdown is load-bearing: a close-and-retry races the providers refetch and clicks a detached option (caught live during validation — the first catch-and-retry version failed exactly this way).
- **Pre-run widget gate** on the OpenAI test in `language-model-regression.spec.ts` (mirror of the #596 Google gate): if `model_model` doesn't show `/gpt/i`, re-apply the selection (bounded ×3), then hard-assert. The 30s `built successfully` timeout is untouched.
- Spec doc updated, including a **premise correction**: `setup-openai`'s no-model branch was already preference-ranked, not blind "first available" — the real gaps were the last-resort fallback and the missing race gate.

## Validation

Langflow nightly **1.11.0.dev36**, local.

- `language-model-regression.spec.ts`: 8 clean runs today (5 consecutive at the end — 20 tests), `--retries=0`. `openai-provider.spec.ts`: 5 clean runs. Two intermittent environment flakes during the day did not reproduce (same latency class observed on clean main via freeze-path 2/4).
- **All 13 `initialGPTsetup` consumers executed.** 7 green with this change (language-model-regression, refresh-dropdown-list, chatInputOutputUser shards 1–2, generalBugs-shard-1, general-bugs-hidden-input-edges, freeze-path at its main-baseline rate). 6 fail **identically on clean main** (pre-existing, none `@stable`): settings-message-history, chatInputOutputUser-shard-0 (missing `chain.png` asset), limit-file-size-upload, general-bugs-shard-3836, generalBugs-shard-3, generalBugs-shard-10. Zero failures caused by this change; a triage issue for the pre-existing group is proposed separately.
- **Graceful-degradation probe:** forcing a fake pinned model (`gpt-fake-model-xyz`) → fallback log fires and the consumer passes.
- **Force-fails (6/6 failed as expected, `unexpected=1` each):** OpenAI gate → `/nonexistent-family/i`; Google gate → `/impossible-model-xyz/i`; switch assert → `/impossible-model-xyz/i`; dialog → `provider-item-NonexistentProvider`; openai T1 persist → `toBe(false)`; openai T2 regex → `/claude-nonexistent/i`. Reverts verified: 0 `FF-MUTATION` markers + final green run.
- `npm run typecheck` 0 errors · `npm run lint` 0 errors (pre-existing warning baseline).
- QA-CHECKLIST untouched (fix-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)