### PR TITLE
fix(project-management): web-first waits in edit-flow-name to kill recurring flaky (#410)

### DIFF
--- a/docs/core-functionality/project-management/edit-flow-name.md
+++ b/docs/core-functionality/project-management/edit-flow-name.md
@@ -1,0 +1,74 @@
+# Project Management – Edit Flow Name
+
+**Last validated:** Langflow 1.10.x
+
+---
+
+## What this test validates *(required)*
+
+Validates that renaming a flow from inside the flow editor is persisted and
+reflected in the home page listing. The test renames the same flow twice (two
+random names in sequence) via the `renameFlow` helper, and after each rename
+navigates back to the home listing and confirms the new name appears there
+exactly once before re-opening the flow for the next iteration.
+
+Renaming, returning to home, and seeing the updated name proves the rename is
+committed to the backend and surfaced by the flow-list refetch — not just held
+in editor-local state.
+
+---
+
+## Tags *(required)*
+
+`@release` `@workspace` `@regression` `@stable`
+
+---
+
+## Step by step *(required)*
+
+1. Bootstrap the session (`awaitBootstrapTest(page)`).
+2. Open the **Basic Prompting** starter flow.
+3. For each of two random target names:
+   1. `renameFlow(page, { flowName: targetName })` — rename via the flow header
+      settings modal; then `renameFlow(page)` (read-only) asserts the committed
+      header name equals `targetName`.
+   2. Click `icon-ChevronLeft` to return to the home listing.
+   3. Assert `home-dropdown-menu` is visible (home rendered) — web-first
+      assertion, 30 s.
+   4. Assert `getByText(targetName)` has count `1` — auto-waits for the flow-list
+      refetch + render (web-first, 30 s). This replaced a fixed 3 s
+      `waitForSelector` that raced the refetch under parallel load
+      (recurring flaky, issue #410).
+   5. Re-open the flow via the `list-card` `list-card-open-button` overlay button
+      (the `/flows` a11y refactor, Langflow #13891, made the card content
+      `pointer-events-none`), so the next iteration starts inside the editor.
+
+---
+
+## Validation criterion *(required)*
+
+- After each rename, the flow header reflects the new name.
+- Returning to the home listing shows the renamed flow exactly once
+  (`toHaveCount(1)`), proving the rename persisted through the flow-list refetch.
+
+---
+
+## External dependencies *(required)*
+
+- **Basic Prompting** starter template must be available on the fresh instance.
+- Testids: `icon-ChevronLeft`, `home-dropdown-menu`, `list-card`,
+  `flow-name-div`, `list-card-open-button`, and the flow-header rename controls
+  used by `renameFlow` (`flow_name`, flow-settings name input).
+- No LLM or provider API key required — the flow is never executed.
+
+---
+
+## Notes on stability *(optional)*
+
+The home-listing waits use web-first assertions (`toBeVisible` / `toHaveCount`
+with a 30 s timeout) instead of low-level fixed-timeout `waitForSelector` calls.
+The prior 3 s `waitForSelector` on dynamic text failed-then-passed-on-retry in
+multiple nightly runs because the return-to-home flow-list API refetch + render
+exceeds 3 s under parallel load (issue #410). The web-first assertions auto-retry
+until the renamed flow appears, so a genuine failure (flow never listed) still
+fails the test.

--- a/tests/tests-automations/regression/core-functionality/project-management/edit-flow-name.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/edit-flow-name.spec.ts
@@ -23,16 +23,16 @@ test(
 
       await page.getByTestId("icon-ChevronLeft").first().click();
 
-      await page.waitForSelector('[data-testid="home-dropdown-menu"]', {
-        timeout: 5000,
+      await expect(page.getByTestId("home-dropdown-menu").first()).toBeVisible({
+        timeout: 30000,
       });
 
-      await page.waitForSelector(`text=${targetName}`, {
-        timeout: 3000,
-        state: "visible",
+      // Auto-waits for the renamed flow to appear (home refetch + render).
+      // Web-first assertion instead of a fixed 3s waitForSelector, which raced
+      // the flow-list API refetch under parallel load (flaky, see issue #410).
+      await expect(page.getByText(targetName)).toHaveCount(1, {
+        timeout: 30000,
       });
-
-      await expect(page.getByText(targetName)).toHaveCount(1);
 
       // Re-open the flow by clicking its name in the listing — required so the next
       // iteration starts inside the editor with renameFlow() targeting the flow header.


### PR DESCRIPTION
## Problem

`edit-flow-name.spec.ts` renames a flow, returns to the home listing, and asserts the new name appears. The old wait was a fixed-timeout `waitForSelector` on dynamic text:

```ts
await page.waitForSelector(`text=${targetName}`, { timeout: 3000, state: "visible" });
```

Returning to home triggers a flow-list **API refetch + render**. Under parallel nightly load this render exceeds 3s, so the selector times out on the first attempt and passes on retry — a recurring flaky (failed-then-passed-on-retry in two weekly runs, see #410). The sibling `home-dropdown-menu` wait (5s) was similarly tight. This is a test-side anti-pattern (fixed short timeout on a backend-latency-dependent step), **not** a Langflow bug.

## Fix

Replace the fragile fixed-timeout `waitForSelector` calls with auto-retrying web-first assertions (30s), keeping `@stable`:

```ts
await expect(page.getByTestId("home-dropdown-menu").first()).toBeVisible({ timeout: 30000 });
await expect(page.getByText(targetName)).toHaveCount(1, { timeout: 30000 });
```

This does **not** mask a real regression: if the renamed flow never appears, the assertion still fails.

## Also

- Adds the missing spec doc `docs/core-functionality/project-management/edit-flow-name.md` (mirrors the test path; none existed before).

## Verification

- `npm run typecheck` — 0 errors.
- `npm run lint` — 0 errors (only pre-existing warnings, none in this file).
- Ran the spec against a local instance — **passed (14.3s)**.

## Acceptance (#410)

- [x] Fix applied, `@stable` retained.
- [x] Spec doc added.
- [ ] No further flaky occurrences in subsequent weekly runs — verifiable only by future CI runs.

Closes #410
