### PR TITLE
fix(ui-ux): stabilize global-variables-crud flake — readiness gates, flow cleanup, race-free modal wait (#599)

### DIFF
--- a/docs/ui-ux/global-variables-crud.md
+++ b/docs/ui-ux/global-variables-crud.md
@@ -1,6 +1,6 @@
 # Global Variables — CRUD via Component
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.11.x
 
 ---
 
@@ -26,9 +26,16 @@ If these break, users cannot manage global variables (API keys, shared values) t
 
 **All three tests share the same setup:**
 1. Set viewport to 1920×1080 (modal can overflow on smaller screens)
-2. Bootstrap app, create blank flow, add OpenAI component
-3. Click the OpenAI component header, then click the Globe icon
-4. Wait for Global Variables modal to open
+2. Bootstrap app, create blank flow (id captured from the page's own
+   `POST /api/v1/flows/` response for the id-scoped `afterEach` cleanup — #599),
+   add OpenAI component
+3. **Readiness gates (#599):** wait for `sidebar-search-input` to be visible
+   before clicking it (canvas mount), and for `icon-Globe` to be visible
+   before clicking it (node panel render) — both 30s, matching the file's
+   other page-transition waits. Under CI load these transitions exceed the
+   20s implicit action timeout; the behavior asserts are unchanged.
+4. Click the OpenAI component header, then click the Globe icon
+5. Wait for Global Variables modal to open
 
 **Test 1 — create Generic variable**
 
@@ -103,3 +110,19 @@ If these break, users cannot manage global variables (API keys, shared values) t
 
 - `page.evaluate()` is used to click "Add New Variable" because the modal can render outside the viewport on smaller screens. The JS click bypasses the viewport boundary.
 - `try/finally` cleanup ensures variables are deleted even when assertions fail mid-test — preventing test pollution between runs.
+- **#599 flake verdict (transient / instance load, not a regression):** the
+  `sidebar-search-input` 20s click timeout flaked on 2026-07-02 and
+  2026-07-09, both times inside correlated collapses (10 and 7 simultaneous
+  unrelated flakes; the daily baseline is 4–13). Reproduced locally: a fresh
+  instance runs the file green in ~24s; an instance with accumulated state
+  degrades progressively (element-visibility timeouts, then raw i18n keys in
+  the DOM), with the backend logging
+  `sqlite3.OperationalError: database is locked` in `delete_multiple_flows`
+  during the deployment-attachment prune — UI waits on a locked backend and
+  element timeouts follow. Stabilization: readiness gates (above) + the
+  id-scoped flow cleanup (the file previously leaked 3 blank flows per run,
+  feeding the degradation). No assert was weakened; `@stable` stays.
+- Verified on a fresh 1.11 instance: a pre-existing global
+  `OPENAI_API_KEY` credential (created by provider specs in the same CI run)
+  does NOT remove the Globe icon — no ordering hazard with the provider
+  specs.

--- a/tests/helpers/flows/open-new-flow-templates-modal.ts
+++ b/tests/helpers/flows/open-new-flow-templates-modal.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 
 const WELCOME_PANEL = '[data-testid="flow-builder-welcome-panel"]';
 const MODAL_TITLE = '[data-testid="modal-title"]';
@@ -16,12 +16,26 @@ const MODAL_TITLE = '[data-testid="modal-title"]';
  * selector/timeout logic can't drift.
  */
 export const dismissWelcomeOverlayAndWaitForModal = async (page: Page) => {
-  await Promise.race([
-    page.waitForSelector(WELCOME_PANEL, { timeout: 30000 }),
-    page.waitForSelector(MODAL_TITLE, { timeout: 30000 }),
-  ]);
+  // expect.poll instead of Promise.race(waitForSelector×2): the race's losing
+  // wait survives as a spurious red ✗ step in every trace that goes through
+  // the overlay branch, reading like a recurring failure (#599). Not
+  // locator.or().first() either — .first() picks by DOM order, so an
+  // attached-but-hidden welcome panel sitting before the modal in the DOM
+  // pins the visibility wait to the full timeout.
+  const welcomePanel = page.locator(WELCOME_PANEL);
+  const modalTitle = page.locator(MODAL_TITLE);
+  await expect
+    .poll(
+      async () =>
+        (await modalTitle.isVisible().catch(() => false)) ||
+        (await welcomePanel.isVisible().catch(() => false)),
+      { timeout: 30000 },
+    )
+    .toBe(true);
 
-  if ((await page.locator(WELCOME_PANEL).count()) > 0) {
+  // isVisible, not count() — an attached-but-hidden panel must not trigger a
+  // click on the (equally hidden) "Browse more templates" button.
+  if (await welcomePanel.isVisible().catch(() => false)) {
     await page.getByTestId("flow-builder-welcome-browse-more").click();
   }
 

--- a/tests/tests-automations/regression/ui-ux/global-variables-crud.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/global-variables-crud.spec.ts
@@ -1,32 +1,77 @@
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+
+// Each test creates a blank flow it never deleted — 3 leaked flows per run,
+// feeding the instance-state degradation behind the #599 flake. Track the ids
+// the page actually creates (POST /api/v1/flows → 201; the canvas URL id is
+// transient on 1.11) and delete them in afterEach.
+const createdFlowIds: string[] = [];
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, { headers: { Authorization: bearer } }).catch(() => {});
+  }
+});
+
+// Shared setup: blank flow → OpenAI component → Global Variables modal.
+// The sidebar-search-input and icon-Globe clicks come right after heavy page
+// transitions (canvas mount; node panel render). Under CI load those exceed
+// the 20s implicit action timeout — the recurring #599 flake — so each click
+// is gated on visibility with the file's standard 30s transition timeout.
+// Behavior asserts are untouched.
+async function openGlobalVariablesModal(page: Page): Promise<void> {
+  // Use large viewport so the global variables modal is fully visible
+  await page.setViewportSize({ width: 1920, height: 1080 });
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {}); // non-JSON / batch payloads
+    }
+  });
+  await awaitBootstrapTest(page);
+  await page.waitForSelector('[data-testid="blank-flow"]', { timeout: 30000 });
+  await page.getByTestId("blank-flow").click();
+
+  const searchInput = page.getByTestId("sidebar-search-input");
+  await expect(searchInput).toBeVisible({ timeout: 30000 }); // readiness gate (#599)
+  await searchInput.click();
+  await searchInput.fill("openai");
+  await page.waitForSelector('[data-testid="openaiOpenAI"]', {
+    timeout: 30000,
+  });
+  await page
+    .getByTestId("openaiOpenAI")
+    .hover()
+    .then(async () => {
+      await page.getByTestId("add-component-button-openai").last().click();
+    });
+
+  await page.waitForTimeout(1000);
+  await page.getByText("OpenAI", { exact: true }).last().click();
+  const globeIcon = page.getByTestId("icon-Globe").first();
+  await expect(globeIcon).toBeVisible({ timeout: 30000 }); // readiness gate (#599)
+  await globeIcon.click();
+  await page.waitForTimeout(500);
+}
 
 test(
   "create a Generic type global variable",
   { tag: ["@stable", "@release", "@workspace", "@regression"] },
   async ({ page }) => {
-    // Use large viewport so the global variables modal is fully visible
-    await page.setViewportSize({ width: 1920, height: 1080 });
-    await awaitBootstrapTest(page);
-    await page.waitForSelector('[data-testid="blank-flow"]', { timeout: 30000 });
-    await page.getByTestId("blank-flow").click();
-
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("openai");
-    await page.waitForSelector('[data-testid="openaiOpenAI"]', {
-      timeout: 30000,
-    });
-    await page
-      .getByTestId("openaiOpenAI")
-      .hover()
-      .then(async () => {
-        await page.getByTestId("add-component-button-openai").last().click();
-      });
-
-    await page.waitForTimeout(1000);
-    await page.getByText("OpenAI", { exact: true }).last().click();
-    await page.getByTestId("icon-Globe").nth(0).click();
-    await page.waitForTimeout(500);
+    await openGlobalVariablesModal(page);
 
     const varName = `test-generic-${Date.now()}`;
 
@@ -80,27 +125,7 @@ test(
   "delete a global variable removes it from the list",
   { tag: ["@stable", "@release", "@workspace", "@regression"] },
   async ({ page }) => {
-    await page.setViewportSize({ width: 1920, height: 1080 });
-    await awaitBootstrapTest(page);
-    await page.waitForSelector('[data-testid="blank-flow"]', { timeout: 30000 });
-    await page.getByTestId("blank-flow").click();
-
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("openai");
-    await page.waitForSelector('[data-testid="openaiOpenAI"]', {
-      timeout: 30000,
-    });
-    await page
-      .getByTestId("openaiOpenAI")
-      .hover()
-      .then(async () => {
-        await page.getByTestId("add-component-button-openai").last().click();
-      });
-
-    await page.waitForTimeout(1000);
-    await page.getByText("OpenAI", { exact: true }).last().click();
-    await page.getByTestId("icon-Globe").nth(0).click();
-    await page.waitForTimeout(500);
+    await openGlobalVariablesModal(page);
 
     const varName = `delete-me-${Date.now()}`;
     let varCreated = false;
@@ -161,27 +186,7 @@ test(
   "Credential variable value is hidden from the variable list",
   { tag: ["@stable", "@release", "@workspace", "@regression"] },
   async ({ page }) => {
-    await page.setViewportSize({ width: 1920, height: 1080 });
-    await awaitBootstrapTest(page);
-    await page.waitForSelector('[data-testid="blank-flow"]', { timeout: 30000 });
-    await page.getByTestId("blank-flow").click();
-
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("openai");
-    await page.waitForSelector('[data-testid="openaiOpenAI"]', {
-      timeout: 30000,
-    });
-    await page
-      .getByTestId("openaiOpenAI")
-      .hover()
-      .then(async () => {
-        await page.getByTestId("add-component-button-openai").last().click();
-      });
-
-    await page.waitForTimeout(1000);
-    await page.getByText("OpenAI", { exact: true }).last().click();
-    await page.getByTestId("icon-Globe").nth(0).click();
-    await page.waitForTimeout(500);
+    await openGlobalVariablesModal(page);
 
     const varName = `credential-${Date.now()}`;
     // Distinctive sentinel — if this string surfaces anywhere as visible text


### PR DESCRIPTION
Closes #599

## Verdict

**Transient / instance load — not a product regression, not broken test logic.**

- **CI:** both flaky occurrences (2026-07-02, 2026-07-09) sat inside correlated collapses — 10 and 7 simultaneous unrelated flakes (the daily baseline is 4–13 flakes/run).
- **Local reproduction:** a fresh instance runs the file green in ~25s; an instance with accumulated state degrades progressively (element-visibility timeouts, then raw i18n keys rendering in the DOM).
- **Backend evidence:** `sqlite3.OperationalError: database is locked` in `delete_multiple_flows` during the deployment-attachment prune (new 1.11 subsystem) — the UI waits on a locked backend and element timeouts follow. *Product observation only — documented here, no upstream ask (same policy as #596).*
- **Spec cofactor:** the file leaked **6 blank flows per run** (bootstrap "New Flow" + blank-flow per test), feeding the local degradation.
- **Ordering hazard ruled out by experiment:** a pre-existing global `OPENAI_API_KEY` credential (which provider specs will now create in CI runs) does NOT remove the Globe icon on a healthy instance.

## Stabilization (no assert weakened, `@stable` stays)

- **Shared `openGlobalVariablesModal()` setup with readiness gates:** `sidebar-search-input` (canvas mount) and `icon-Globe` (node panel render) are gated on visibility (30s, the file's standard transition timeout) before clicking — under load these transitions exceed the 20s implicit action timeout, which is exactly the flake signature.
- **Id-scoped flow cleanup:** track `POST /api/v1/flows` → 201 ids, delete in `afterEach` (pattern from #605).
- **`open-new-flow-templates-modal.ts`:** replaced `Promise.race(waitForSelector×2)` with `expect.poll` — the race's losing wait shows as a spurious red ✗ step in every trace through the welcome-overlay branch, reading like a recurring failure. Deliberately NOT `locator.or().first()`: `.first()` resolves by DOM order, and an attached-but-hidden panel pins the visibility wait to the full timeout (measured live: 26s → 96s per run before switching to the poll). The overlay branch now keys on `isVisible()`, not `count()` (a hidden panel must not trigger a click on the equally hidden button).

## Validation

Langflow nightly **1.11.0.dev36**, fresh instance, all `--retries=0`.

- **12 consecutive clean runs** (8× burst post-fix + 3× after the helper change + final green): 3/3 each, stable 25.6–27.6s, zero flake, flow count frozen throughout (pre-fix: +6 flows/run and progressive degradation from run 2).
- Control run on clean main on the same instance isolated every duration/behavior delta to this diff.
- Helper consumers checked: `refresh-dropdown-list` 9.9s green (baseline).
- **Force-fails (5/5 failed as expected, reverts proven — 0 `FF-MUTATION` markers + final green 3/3):**
  - T1 — impossible variable name (`varName + "-FF-NOPE"`)
  - T2 — post-delete `toHaveCount(0)` → `toHaveCount(1)`
  - T3 — hidden-value sentinel `toHaveCount(0)` → `toHaveCount(1)`
  - Behavioral — `afterEach` no-op → 6 orphan flows vs 0
  - Helper — poll forced unsatisfiable → test fails
- `npm run typecheck` 0 errors · `npm run lint` 0 errors (pre-existing warning baseline).
- QA-CHECKLIST untouched (fix-only; `@stable` retained per the flaky policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)