### PR TITLE
chore(test-infra): pin browser locale to en-US in playwright.config.ts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,14 @@ Use the maintained core equivalents instead. The canonical case:
 
 ---
 
+## Browser locale is pinned to `en-US`
+
+`playwright.config.ts` pins the browser context locale (and the `Accept-Language` header) to `en-US` for every test in every project. The suite asserts on English strings throughout — toast titles, button labels, status messages, upstream error text — so the locale must stay fixed regardless of host machine settings, CI runner defaults, or future i18n locale detection in Langflow.
+
+Do **not** override `locale` per test or per project. If a test ever needs a non-English locale (e.g. deliberate multi-locale coverage), that is a separate, parameterised concern — raise it as its own issue rather than editing the shared default.
+
+---
+
 ## Creating tests with LLM (agents, providers, MCP)
 
 Tests that execute an agent with an LLM require a specific setup. **Do not hardcode provider, API key or model** — use the project infrastructure.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,6 +21,10 @@ export default defineConfig({
 
   use: {
     baseURL: BASE_URL,
+    // Pin the browser context locale (and Accept-Language header) so the
+    // English-string assertions throughout the suite stay stable regardless
+    // of host machine settings or future i18n locale detection. See issue #225.
+    locale: "en-US",
     actionTimeout: 20000,
     trace: "on-first-retry",
     screenshot: process.env.CI ? "only-on-failure" : "off",


### PR DESCRIPTION
## What

Pin the browser context locale (and `Accept-Language` header) to `en-US` in `playwright.config.ts`'s `use` block, applied to every test in every project.

## Why

The regression suite asserts on English strings throughout — toast titles, button labels, status messages, upstream error text. Today those pass because both the Langflow frontend default and the test runner's default locale happen to be English. Any of these could change and break the affected specs with hard-to-diagnose i18n mismatches:

1. Langflow adds `Accept-Language` locale detection and CI runners report a non-English locale
2. The project starts supporting a non-English default
3. A future Playwright update changes the default `locale`

Pinning `en-US` removes that dependency on ambient defaults.

## Changes

- `playwright.config.ts` — add `locale: "en-US"` to the `use` block (with a comment pointing to this issue)
- `CONTRIBUTING.md` — new section documenting the convention so future tests don't override the shared locale default for unrelated reasons

## Validation

- `npm run typecheck` — clean
- `npm run lint` — 0 errors (pre-existing warnings only; none introduced)
- One-line config change; full-suite green is verified via the nightly/daily-stable runs

Closes #225