### PR TITLE
fix(llm-agents): update Model Providers icon testid to icon-BrainCircuit

### DIFF
--- a/docs/core-functionality/llm-agents/provider-invalid-auth-error.md
+++ b/docs/core-functionality/llm-agents/provider-invalid-auth-error.md
@@ -1,6 +1,6 @@
 # Provider Invalid API Key Error
 
-**Last validated:** Langflow 1.11.x (nightly `1.11.0`)
+**Last validated:** Langflow 1.11.x
 
 ---
 

--- a/docs/core-functionality/llm-agents/provider-invalid-auth-error.md
+++ b/docs/core-functionality/llm-agents/provider-invalid-auth-error.md
@@ -1,6 +1,6 @@
 # Provider Invalid API Key Error
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.11.x (nightly `1.11.0`)
 
 ---
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/provider-invalid-auth-error.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/provider-invalid-auth-error.spec.ts
@@ -82,7 +82,7 @@ async function navigateAndFillProviderApiKey(
   const settingsPage = new SettingsPage(page);
   await settingsPage.navigate();
 
-  await page.getByTestId("icon-Brain").click();
+  await page.getByTestId("icon-BrainCircuit").click();
   await page.getByTestId(providerTestId).click();
 
   // Wait for the provider form to finish loading before filling
@@ -105,7 +105,7 @@ for (const {
   test.describe.serial(`Invalid Auth Error — ${provider}`, () => {
     test(
       `should display error message when using invalid authentication for provider ${provider}`,
-      { tag: ["@regression", "@model-provider", "@agents"] },
+      { tag: ["@stable", "@regression", "@model-provider", "@agents"] },
       async ({ page }) => {
 
         await page.goto("/");


### PR DESCRIPTION
## Context

Detected by weekly-stable failure #232. The test `Invalid Auth Error — <provider>` in `provider-invalid-auth-error.spec.ts` failed because `getByTestId("icon-Brain").click()` timed out — the element no longer exists.

## Root cause (upstream)

Langflow PR langflow-ai/langflow#13111 (`fix(ui): distinguish Memory and Model icons`) renamed the Settings → **Model Providers** sidebar icon from `Brain` to `BrainCircuit`. Confirmed against the current source: `src/frontend/src/pages/SettingsPage/index.tsx:78` renders `name="BrainCircuit"`, so the derived data-testid is now `icon-BrainCircuit`.

## Changes

- `provider-invalid-auth-error.spec.ts:85` — `icon-Brain` → `icon-BrainCircuit` (only match in the repo; verified via `grep -rn "icon-Brain" tests/`)
- Re-added `@stable` to the `test()` (removed in triage via #232) now that the fix is validated
- Spec doc `Last validated` bumped to `1.11.x (nightly 1.11.0)`

## Validation

- Ran locally against `langflow 1.11.0` (`--workers=1`): **2 passed** (openai + google; no anthropic key configured locally)
- `npm run typecheck` — clean
- `npm run lint` — 0 errors

Closes #270