### PR TITLE
fix(flow-functionality): make run-flow deterministic and legacy-free

### DIFF
--- a/docs/flow-functionality/run-flow.md
+++ b/docs/flow-functionality/run-flow.md
@@ -1,12 +1,14 @@
 # Flow Functionality — Run Flow
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.11.x
 
 ---
 
 ## What this test validates *(required)*
 
-Validates the **Run Flow** component end-to-end: a pipeline flow (ChatInput → TextOutput → ChatOutput) is built, then a second flow uses the Run Flow component to invoke the pipeline. The test verifies that the output of the pipeline matches the input text — confirming that the Run Flow component correctly chains flows together.
+Validates the **Run Flow** component end-to-end: a pipeline flow (ChatInput → ChatOutput) is built, then a second flow uses the Run Flow component to invoke the pipeline. The test verifies that the output of the pipeline matches the input text — confirming that the Run Flow component correctly chains flows together.
+
+The built flow is renamed to a unique name so it can be selected deterministically by name in the Run Flow "Flow Name" dropdown, rather than by the fragile first-option (`dropdown-option-0`) position that failed when the instance held other flows (issue #340).
 
 If this breaks, users cannot compose flows via the Run Flow component — a core Langflow orchestration feature.
 
@@ -21,17 +23,18 @@ If this breaks, users cannot compose flows via the Run Flow component — a core
 ## Step by step *(required)*
 
 1. Bootstrap the app and create a blank flow
-2. Add ChatOutput, ChatInput, and TextOutput components to the canvas
-3. Connect: ChatInput → TextOutput (inputs) → TextOutput (output) → ChatOutput
-4. Return to main page and create a second blank flow
-5. Add the Run Flow component to the second flow
-6. Open the flow name dropdown in Run Flow and refresh the list
-7. Select the first flow (pipeline) from the dropdown
-8. Fill the `chatinput` textarea with `"THIS IS A TEST FOR RUN FLOW COMPONENT"`
-9. Click `button_run_run flow`
-10. Wait for "built successfully" notification
-11. Click the output inspection button (`output-inspection-*`)
-12. Assert the "Empty" placeholder input value equals `"THIS IS A TEST FOR RUN FLOW COMPONENT"`
+2. Add ChatOutput and ChatInput components to the canvas
+3. Connect: ChatInput → ChatOutput
+4. Rename the built flow to a unique name (for deterministic selection later)
+5. Return to main page and create a second blank flow
+6. Add the Run Flow component to the second flow
+7. Open the flow name dropdown in Run Flow and refresh the list
+8. Select the built flow by its unique name from the dropdown
+9. Fill the `chatinput` textarea with `"THIS IS A TEST FOR RUN FLOW COMPONENT"`
+10. Click `button_run_run flow`
+11. Wait for "built successfully" notification
+12. Click the output inspection button (`output-inspection-*`)
+13. Assert the "Empty" placeholder input value equals `"THIS IS A TEST FOR RUN FLOW COMPONENT"`
 
 ---
 
@@ -61,7 +64,7 @@ If this breaks, users cannot compose flows via the Run Flow component — a core
 ## Preconditions *(optional)*
 
 - Langflow running at `PLAYWRIGHT_BASE_URL`
-- No LLM required — ChatInput → TextOutput echo requires no AI calls
+- No LLM required — ChatInput → ChatOutput echo requires no AI calls
 
 ---
 

--- a/tests/tests-automations/regression/flow-functionality/run-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/run-flow.spec.ts
@@ -6,10 +6,12 @@ import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test"
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { zoomOut } from "../../../helpers/ui/zoom-out";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { renameFlow } from "../../../helpers/flows/rename-flow";
+import { openNewFlowTemplatesModal } from "../../../helpers/flows/open-new-flow-templates-modal";
 
 test(
   "user should be able to use Run Flow without any issues",
-  { tag: ["@release", "@workspace", "@api", "@regression"] },
+  { tag: ["@stable", "@release", "@workspace", "@api", "@regression"] },
   async ({ page, request }) => {
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
@@ -21,6 +23,10 @@ test(
     // those via the API, not example/starter flows or flows belonging to
     // sibling specs running in parallel.
     const createdFlowIds: string[] = [];
+
+    // Unique name for the sub-flow we build so the Run Flow "Flow Name" dropdown
+    // can pick it deterministically by name instead of by position (issue #340).
+    const targetFlowName = `Run Flow Target ${Date.now()}`;
     const captureFlowIdFromUrl = async () => {
       // `waitForURL` enforces the URL matches, so the subsequent match() is
       // guaranteed — no need for a runtime null check.
@@ -64,37 +70,27 @@ test(
           targetPosition: { x: 100, y: 100 },
         });
 
-      await page.getByTestId("sidebar-search-input").click();
-      await page.getByTestId("sidebar-search-input").fill("text output");
-      await page.waitForSelector('[data-testid="input_outputText Output"]', {
-        timeout: 30000,
-      });
-
-      await page
-        .getByTestId("input_outputText Output")
-        .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-          targetPosition: { x: 300, y: 300 },
-        });
-
       await adjustScreenView(page);
 
+      // Connect Chat Input → Chat Output directly. The intermediate Text Output
+      // was dropped: Langflow flipped Text Input/Output to legacy and hides them
+      // from the sidebar (see CONTRIBUTING "Do not build on legacy components"),
+      // and this shorter pipeline still echoes the input, so the assertion below
+      // is unchanged.
       await page
         .getByTestId("handle-chatinput-noshownode-chat message-source")
-        .click();
-
-      await page.getByTestId("handle-textoutput-shownode-inputs-left").click();
-
-      await page
-        .getByTestId("handle-textoutput-shownode-output text-right")
         .click();
       await page
         .getByTestId("handle-chatoutput-noshownode-inputs-target")
         .click();
 
+      // Rename the built flow to a unique name so the Run Flow dropdown below can
+      // select it deterministically by name (issue #340).
+      await renameFlow(page, { flowName: targetFlowName });
+
       await page.getByTestId("icon-ChevronLeft").click();
 
-      await expect(page.getByText("New Flow")).toBeVisible({ timeout: 10000 });
-      await page.getByTestId("new-project-btn").click();
+      await openNewFlowTemplatesModal(page);
 
       await page.getByTestId("blank-flow").click();
       await captureFlowIdFromUrl();
@@ -125,7 +121,10 @@ test(
         .getByTestId("value-dropdown-dropdown_str_flow_name_selected")
         .click();
 
-      await page.getByTestId("dropdown-option-0-container").click();
+      await page
+        .getByTestId(/^dropdown-option-\d+-container$/)
+        .filter({ hasText: targetFlowName })
+        .click();
 
       await page.getByTestId(/^textarea_str_chatinput.*/).click();
       await page

--- a/tests/tests-automations/regression/flow-functionality/run-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/run-flow.spec.ts
@@ -26,7 +26,12 @@ test(
 
     // Unique name for the sub-flow we build so the Run Flow "Flow Name" dropdown
     // can pick it deterministically by name instead of by position (issue #340).
-    const targetFlowName = `Run Flow Target ${Date.now()}`;
+    // The worker index + a random suffix keep it collision-free across parallel
+    // workers/projects sharing one Langflow instance, where a bare millisecond
+    // timestamp could repeat and make the dropdown locator match >1 option.
+    const targetFlowName = `Run Flow Target ${test.info().workerIndex}-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2, 8)}`;
     const captureFlowIdFromUrl = async () => {
       // `waitForURL` enforces the URL matches, so the subsequent match() is
       // guaranteed — no need for a runtime null check.


### PR DESCRIPTION
## Context

`run-flow.spec.ts` (`@stable` removed in #328) accumulated **three independent blockers**, all consolidated under #340. This PR fixes all three and restores `@stable`.

## Changes

**1. Inline `new-project-btn` → shared helper**
Replaced the inline `new-project-btn` click (and the ad-hoc "New Flow" visibility wait) with `openNewFlowTemplatesModal(page)`, which handles the 1.10.0 `FlowBuilderWelcome` overlay (helper introduced in #336).

**2. Deterministic sub-flow selection**
The test picked `dropdown-option-0-container` (first option) in the Run Flow "Flow Name" dropdown, which resolved to the wrong flow whenever the instance held other flows (the deterministic root cause of the #328 weekly failure). Now the built flow is renamed to a unique name via `renameFlow(...)` and selected by name:
```ts
await page.getByTestId(/^dropdown-option-\d+-container$/).filter({ hasText: targetFlowName }).click();
```

**3. Drop the legacy Text Output**
The pipeline was `Chat Input → Text Output → Chat Output`. Langflow flipped Text Input/Output to `legacy: true` and hides them from the sidebar, breaking the `input_outputText Output` search. Per the CONTRIBUTING "Do not build on legacy components" rule, the middle Text Output is dropped and the flow is wired `Chat Input → Chat Output` directly — the minimal valid pipeline; the input-echo assertion is unchanged.

**4. Restore `@stable`** (removed in #328) and refresh the spec doc (pipeline description, step list, `Last validated` → 1.11.x).

## Validation

- Ran locally against Langflow 1.11.0 (`--workers=1`): **1 passed**
- `--repeat-each=3`: **3 passed** (no flakiness)
- `npm run typecheck` — clean; `npm run lint` — 0 errors (pre-existing warnings only)

Closes #340