### PR TITLE
chore(pages-helpers): migrate inline new-project-btn clicks to openNewFlowTemplatesModal

### DIFF
--- a/tests/tests-automations/regression/core-functionality/auth/autoLogin.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/auth/autoLogin.spec.ts
@@ -1,5 +1,6 @@
 import { test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { openNewFlowTemplatesModal } from "../../../../helpers/flows/open-new-flow-templates-modal";
 
 test.describe(
   "Auto_login tests",
@@ -13,7 +14,7 @@ test.describe(
         await awaitBootstrapTest(page, {
           skipModal: true,
         });
-        await page.getByTestId("new-project-btn").click();
+        await openNewFlowTemplatesModal(page);
       },
     );
 
@@ -24,27 +25,15 @@ test.describe(
         await awaitBootstrapTest(page, {
           skipModal: true,
         });
-        await page.getByTestId("new-project-btn").click();
-        await page.waitForSelector('[data-testid="modal-title"]', {
-          timeout: 5000,
-        });
+        await openNewFlowTemplatesModal(page);
 
         await page.goto("/login");
-        await page.getByTestId("new-project-btn").click();
-        await page.waitForSelector('[data-testid="modal-title"]', {
-          timeout: 5000,
-        });
+        await openNewFlowTemplatesModal(page);
         await page.goto("/admin");
-        await page.getByTestId("new-project-btn").click();
-        await page.waitForSelector('[data-testid="modal-title"]', {
-          timeout: 5000,
-        });
+        await openNewFlowTemplatesModal(page);
 
         await page.goto("/admin/login");
-        await page.getByTestId("new-project-btn").click();
-        await page.waitForSelector('[data-testid="modal-title"]', {
-          timeout: 5000,
-        });
+        await openNewFlowTemplatesModal(page);
       },
     );
   },

--- a/tests/tests-automations/regression/flow-functionality/user-flow-state-cleanup.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/user-flow-state-cleanup.spec.ts
@@ -4,6 +4,7 @@ import {
   SUPERUSER_USERNAME,
 } from "../../../helpers/auth/credentials";
 import { renameFlow } from "../../../helpers/flows/rename-flow";
+import { openNewFlowTemplatesModal } from "../../../helpers/flows/open-new-flow-templates-modal";
 
 test(
   "flow state should be properly cleaned up between user sessions",
@@ -99,15 +100,7 @@ test(
       timeout: 30000,
     });
 
-    try {
-      await page.getByTestId("new_project_btn_empty_page").click();
-    } catch (_error) {
-      await page.getByTestId("new-project-btn").click();
-    }
-
-    await page.waitForSelector('[data-testid="modal-title"]', {
-      timeout: 3000,
-    });
+    await openNewFlowTemplatesModal(page);
     await page.getByRole("heading", { name: "Basic Prompting" }).click();
     await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
       timeout: 30000,

--- a/tests/tests-automations/regression/ui-ux/actionsMainPage-shard-1.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/actionsMainPage-shard-1.spec.ts
@@ -1,6 +1,7 @@
 import { test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { openNewFlowTemplatesModal } from "../../../helpers/flows/open-new-flow-templates-modal";
 
 test(
   "select and delete a flow",
@@ -50,8 +51,7 @@ test("search flows", { tag: ["@release", "@mainpage"] }, async ({ page }) => {
 
   await page.getByTestId("icon-ChevronLeft").first().click();
 
-  await page.getByText("New Flow").isVisible();
-  await page.getByTestId("new-project-btn").click();
+  await openNewFlowTemplatesModal(page);
   await page.getByTestId("side_nav_options_all-templates").click();
   await page.getByRole("heading", { name: "Memory Chatbot" }).click();
 
@@ -60,7 +60,7 @@ test("search flows", { tag: ["@release", "@mainpage"] }, async ({ page }) => {
   });
 
   await page.getByTestId("icon-ChevronLeft").first().click();
-  await page.getByTestId("new-project-btn").click();
+  await openNewFlowTemplatesModal(page);
   await page.getByTestId("side_nav_options_all-templates").click();
   await page.getByRole("heading", { name: "Document Q&A" }).click();
 


### PR DESCRIPTION
## Context

Several specs clicked `getByTestId("new-project-btn")` **inline** and then expected the templates modal (`blank-flow` / `side_nav_options_all-templates` / `modal-title`). On Langflow `1.10.0` the "New Flow" button no longer opens the modal directly — it navigates to a fresh flow with the `FlowBuilderWelcome` overlay (root cause: #336). This routes those call sites through the shared `openNewFlowTemplatesModal` helper (single source of truth, handles the overlay).

## Changes

- **`ui-ux/actionsMainPage-shard-1.spec.ts`** — "search flows" test: 2 inline call sites → helper.
- **`core-functionality/auth/autoLogin.spec.ts`** — 5 call sites → helper (drops the now-redundant `modal-title` waits the helper already performs).
- **`flow-functionality/user-flow-state-cleanup.spec.ts`** — 1 call site → helper (replaces the `new_project_btn_empty_page`/`new-project-btn` try-catch the helper already covers via `.or()`).

### Note on the 4th spec in #341

`flow-functionality/generalBugs-shard-13.spec.ts` (listed in the issue) **no longer exists** — it was a store-dependent spec removed in `48c8f65` (store feature dropped upstream). Nothing to migrate there.

## Validation

Ran locally against Langflow 1.11.0 (`--workers=1`):
- `actionsMainPage-shard-1.spec.ts` — **3 passed** (incl. "search flows", both migrated call sites)
- `autoLogin.spec.ts` — **2 passed** (all 5 migrated call sites)
- `user-flow-state-cleanup.spec.ts` — fails at line ~55 during the **User A admin-panel creation** (`mainpage_title` timeout). Confirmed **pre-existing and identical on `main`** (stashed the change, reran: same `TimeoutError` at the same line): the test needs a multi-user, non-auto-login instance and cannot run on the local `AUTO_LOGIN` instance. The failure is **upstream of** the migrated call site (line ~95), so the migration itself is unreached here and is covered by `tsc`.

- `npm run typecheck` — clean
- `npm run lint` — 0 errors (pre-existing warnings only)

Behavior-preserving cleanup; none of these specs are `@stable`.

Closes #341