### PR TITLE
fix(llm-agents): pick model-toggle target from the provider intersection, restore @stable (#597)

### DIFF
--- a/docs/core-functionality/llm-agents/model-provider-model-toggle.md
+++ b/docs/core-functionality/llm-agents/model-provider-model-toggle.md
@@ -40,8 +40,17 @@ Both tests resolve a single provider — `MODEL_TEST_PROVIDER` when its env keys
 ### Test 2 — disabling a model removes it from a component dropdown
 
 1. `SimpleAgentTemplatePage.load({ provider })` — same baseline (all models enabled, a model selected on the Agent). Capture the flow URL.
-2. Open the Agent's `model_model` picker, collect the option names (`[data-testid$="-option"]`), and pick a model that is **not** the currently selected one (avoids entangling with selection-reset logic). Skip if the provider exposes only one model.
-3. In **Settings → Model Providers**, disable that target model (immediate + persisted, as in Test 1).
+2. Open the Agent's `model_model` picker and collect the option names
+   (`[data-testid$="-option"]`). **The dropdown mixes models from every
+   configured provider** (#597 — with Google configured by sibling specs it
+   listed `gemini-3.5-flash` first while the test's provider was OpenAI), so
+   the options alone cannot pick the target.
+3. In **Settings → Model Providers**, open the test's provider and read the
+   attached `llm-toggle-<model>` testids — the provider's own model set.
+   Pick the target as the first dropdown option that is **in that set** and
+   is **not** the currently selected model (avoids entangling with
+   selection-reset logic). Skip if the intersection is empty. Then disable
+   the target (immediate + persisted, as in Test 1).
 4. Return to the flow (`page.goto(flowUrl)`), open the `model_model` picker, and assert the target model option has count `0` (anchored exact-match regex so substrings like `gpt-4o` vs `gpt-4o-mini` don't collide).
 5. Re-enable the target model in Settings, return to the flow, and assert the option reappears (count `1`).
 
@@ -53,6 +62,17 @@ Both tests resolve a single provider — `MODEL_TEST_PROVIDER` when its env keys
 - A `POST /api/v1/models/enabled_models` is sent after the debounce; reopening Model Providers reflects the persisted state.
 - A disabled model disappears from the Agent's `model_model` dropdown; re-enabling restores it.
 - The baseline is restored at the end of each test (model left enabled) so sibling specs are unaffected.
+
+---
+
+## Flow cleanup *(required)*
+
+Both tests create a flow via `SimpleAgentTemplatePage.load()`, which does NO
+cleanup (post-#553 contract). The spec tracks every `POST /api/v1/flows` →
+201 id fired during load and deletes them by id in `test.afterEach`
+(id-scoped — never name-based or delete-all; the file previously leaked 2
+flows per run). Behavioral force-fail contract: no-op the cleanup and the
+flow count grows.
 
 ---
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-model-toggle.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-model-toggle.spec.ts
@@ -10,6 +10,8 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 if (!process.env.CI) {
   dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
@@ -43,11 +45,39 @@ const providerItemTestId = provider
 
 const ENABLED_MODELS_ENDPOINT = "/api/v1/models/enabled_models";
 
+// SimpleAgentTemplatePage.load() does NO cleanup (post-#553 contract) and the
+// canvas URL id is transient on 1.11 — track every flow the load actually
+// creates (POST /api/v1/flows → 201) and delete those ids in afterEach (#605
+// pattern; this file previously leaked 2 flows per run).
+const createdFlowIds: string[] = [];
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, { headers: { Authorization: bearer } }).catch(() => {});
+  }
+});
+
 // Load the Simple Agent template with the configured provider. This configures
 // the provider's API key globally and enables all of its models — the known
 // baseline both tests start from. MODEL_NOT_AVAILABLE (a model present in
 // models.json but absent from the picker) is turned into a skip.
 async function loadAgentWithProvider(page: Page): Promise<void> {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {}); // non-JSON / batch payloads
+    }
+  });
   try {
     await new SimpleAgentTemplatePage(page).load({ provider });
   } catch (e: any) {
@@ -108,9 +138,8 @@ async function setToggle(
   await save;
 }
 
-// SimpleAgentTemplatePage.load() deletes all flows before loading the template,
-// so sibling agent specs that also wipe flows must not run concurrently — this
-// file is serial and the folder is run with --workers=1.
+// Named template loads collide under parallelism — this file is serial and
+// the folder is run with --workers=1 (agent-family convention).
 test.describe.configure({ mode: "serial" });
 
 test.describe("Model Provider Model Toggle", () => {
@@ -162,7 +191,7 @@ test.describe("Model Provider Model Toggle", () => {
   test(
     "disabling a model removes it from a component model dropdown",
     {
-      tag: ["@regression", "@components", "@agents", "@model-provider"],
+      tag: ["@stable", "@regression", "@components", "@agents", "@model-provider"],
     },
     async ({ page }) => {
       test.skip(!!skipReason, skipReason ?? "");
@@ -173,6 +202,8 @@ test.describe("Model Provider Model Toggle", () => {
 
       let flowUrl = "";
       let targetModel = "";
+      let dropdownModels: string[] = [];
+      let dropdownSelected = "";
 
       await test.step("load Agent with configured provider and capture model options", async () => {
         await loadAgentWithProvider(page);
@@ -195,18 +226,46 @@ test.describe("Model Provider Model Toggle", () => {
             ),
           )
         ).filter((n) => n.length > 0);
-        // Pick a model that is NOT the currently selected one — disabling the
-        // active selection would entangle the test with selection-reset logic.
-        targetModel = names.find((n) => n !== selectedModel) ?? "";
-        test.skip(
-          targetModel.length === 0,
-          "Provider exposes only one model in the dropdown — cannot test removal of a non-selected model.",
-        );
+        dropdownModels = names;
+        dropdownSelected = selectedModel;
         await page.keyboard.press("Escape");
       });
 
       await test.step("disable the target model in Settings → Model Providers", async () => {
         await openProviderModelList(page);
+        // The component dropdown mixes models from EVERY configured provider
+        // (#597: with Google configured by sibling specs it listed
+        // gemini-3.5-flash first while this test's provider was OpenAI, and
+        // the toggle lookup below never resolves). Pick the target from the
+        // intersection of the dropdown options and THIS provider's own model
+        // list — the attached llm-toggle-* testids Settings just rendered —
+        // and never the currently selected model (disabling the active
+        // selection would entangle the test with selection-reset logic).
+        await page
+          .locator('[data-testid^="llm-toggle-"]')
+          .first()
+          .waitFor({ state: "attached", timeout: 10000 });
+        const providerModels = new Set(
+          (
+            await page
+              .locator('[data-testid^="llm-toggle-"]')
+              .evaluateAll((els) =>
+                els.map(
+                  (el) =>
+                    el.getAttribute("data-testid")?.replace(/^llm-toggle-/, "") ??
+                    "",
+                ),
+              )
+          ).filter((n) => n.length > 0),
+        );
+        targetModel =
+          dropdownModels.find(
+            (n) => providerModels.has(n) && n !== dropdownSelected,
+          ) ?? "";
+        test.skip(
+          targetModel.length === 0,
+          "No non-selected dropdown option belongs to the test's provider — cannot test removal.",
+        );
         const toggle = await toggleForModel(page, targetModel);
         await setToggle(page, toggle, false);
       });


### PR DESCRIPTION
Closes #597

## Verdict

**Test defect (cross-provider mismatch) — not a model removal, not a product bug.**

- The component's `model_model` dropdown **mixes models from every configured provider**; Test 2 assumed the first non-selected option belonged to its own provider and looked up that model's toggle in the provider's Settings list.
- Once sibling specs started configuring Google in the daily runs (matches the flaky→hard flip on 2026-07-06), the dropdown listed `gemini-3.5-flash` first while the test's provider was OpenAI — `llm-toggle-gemini-3.5-flash` can never resolve in OpenAI's Settings list → 3 consecutive daily hard failures.
- **Reproduced locally on the first try**: `MODEL_TEST_PROVIDER=openai` with Google configured produces the exact CI error.
- Hypotheses eliminated with evidence: `gemini-3.5-flash` is **alive** in Google's live catalog (direct API check), and the multi-provider dropdown is product behavior. No relation to #552.

## Fix (asserts untouched)

- Test 2 picks the target from the **intersection** of the dropdown options and the provider's own `llm-toggle-*` testids rendered in Settings, still excluding the currently selected model; skips with a clear reason when the intersection is empty.
- **`@stable` restored on Test 2** — the issue's human-gated deliverable (removed by the daily-failure triage).
- **Id-scoped flow cleanup added** (#605 pattern): the file leaked 2 flows per run; stale pre-#553 "deletes all flows" comment fixed. 219 accumulated orphans purged from the local instance.
- Spec doc updated (target-selection steps + Flow cleanup section).

## Validation

Langflow nightly **1.11.0.dev36**, all `--retries=0`.

- **Adversarial scenario (the one that killed CI):** 2× `MODEL_TEST_PROVIDER=openai` with Google configured — 2/2 green.
- Normal scenario: 3× default provider (google) — 2/2 green. Final green 2/2.
- **Flow-leak criterion:** flow count delta 0 across the burst (previously +2/run).
- **Force-fails (3/3, reverts proven — 0 markers + final green):**
  - T2 — target forced cross-provider (`claude-sonnet-5` against Google's list) → fails exactly like the CI (**the intersection is load-bearing**)
  - T1 — persisted-state assert inverted (`"false"` → `"true"`) → fails
  - Behavioral — cleanup no-op'd → flow count 217→219 (leak observed), reverted
- `npm run typecheck` 0 errors · `npm run lint` 0 errors (pre-existing warning baseline).
- QA-CHECKLIST: no bullet edits (the restored `@stable` regenerates the Phase 0 block on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)