### PR TITLE
test(mcp): add MCP v2 registration status-code watchdog (409/404)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -3,7 +3,7 @@
 > **Repository:** `C:/QAx/langflow-playwright/langflow-e2e`
 > **Tests:** `tests/tests-automations/regression/`
 > **Config:** `playwright.config.ts`
-> **Last updated:** 2026-07-09
+> **Last updated:** 2026-07-10
 
 ---
 
@@ -650,6 +650,8 @@
 - [-] MCP server connection error — unreachable server produces empty tool dropdown → `mcp/client/mcp-client-regression.spec.ts`
 - [-] Configure connection via HTTP form tab → `mcp/client/mcp-client-regression.spec.ts`
 - [-] Execute numeric tool with inputs and verify result → `mcp/client/mcp-client-regression.spec.ts`
+- [x] Duplicate MCP server registration returns 409 Conflict → `mcp/client/mcp-server-registration-status-codes.spec.ts`
+- [x] Deleting a non-existent MCP server returns 404 Not Found → `mcp/client/mcp-server-registration-status-codes.spec.ts`
 - [-] Agent uses MCPTools as tool and calls echo via MCP → `mcp/client/mcp-client-agent.spec.ts`
 - [ ] List available resources via MCP protocol
 - [ ] Consume resource URI and inject content into flow
@@ -763,11 +765,11 @@
 | `core-functionality/project-management/` | 11 | 4 | 6 | 1 | 0 |
 | `core-functionality/templates/` | 41 | 2 | 39 | 0 | 0 |
 | `flow-functionality/` | 28 | 13 | 13 | 2 | 0 |
-| `mcp/client/` | 9 | 0 | 7 | 0 | 2 |
+| `mcp/client/` | 11 | 2 | 7 | 0 | 2 |
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 44 | 7 | 36 | 1 | 0 |
 | `ui-ux/` — Settings | 7 | 3 | 3 | 1 | 0 |
-| **TOTAL** | **451** | **265 (59%)** | **154 (34%)** | **7 (2%)** | **25 (6%)** |
+| **TOTAL** | **453** | **267 (59%)** | **154 (34%)** | **7 (2%)** | **25 (6%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -783,7 +785,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 292 `test()` calls carrying the `@stable` tag, distributed across 108 spec
+> 294 `test()` calls carrying the `@stable` tag, distributed across 109 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -1090,6 +1092,8 @@
 #### mcp/client/
 - [x] unreachable HTTP server results in empty tool dropdown → `mcp-client-regression.spec.ts`
 - [x] configures MCP server via HTTP form tab and verifies registration → `mcp-client-regression.spec.ts`
+- [x] registering an already-existing MCP server returns 409 Conflict → `mcp-server-registration-status-codes.spec.ts`
+- [x] deleting a non-existent MCP server returns 404 Not Found → `mcp-server-registration-status-codes.spec.ts`
 
 #### ui-ux/
 - [x] serializes created_at/expires_at with UTC offset and no microseconds → `api-keys-timezone-display.spec.ts`

--- a/docs/mcp/client/mcp-server-registration-status-codes.md
+++ b/docs/mcp/client/mcp-server-registration-status-codes.md
@@ -1,0 +1,111 @@
+# MCP v2 Server Registration — HTTP Status Codes
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+Pure-API regression guard for the HTTP status codes returned by the MCP v2
+server-registration endpoints (`/api/v2/mcp/servers/{name}`). It asserts the
+**correct, spec-conformant** behavior:
+
+- `POST` an already-registered server name → **409 Conflict**
+- `DELETE` a non-existent server → **404 Not Found**
+
+> **This test is a known-defect watchdog (issue #396) and is EXPECTED TO FAIL
+> against current Langflow builds.** `api/v2/mcp.py` currently returns **500**
+> for both conditions ("Server already exists." / "Server not found."). The
+> intentional failure is the formal record — captured in `daily-history.jsonl`,
+> the QA Platform, and the `[Daily Failure]` issue — that the suite detected the
+> defect. On the first daily failure the workflow auto-removes `@stable` from
+> these tests (so they stop running); once upstream returns the correct codes,
+> restore `@stable` and they become forward regression guards. A reviewer should
+> **not** treat the red as a mistake — see the **Tags** section.
+
+Why 409/404 are the correct codes is not just REST theory — it is Langflow's own
+convention: 409 for uniqueness conflicts (`flows_helpers.py` "Name must be
+unique", `authz_*`, `deployments`, and the sibling project-scoped MCP endpoint
+`api/v1/projects_mcp_helpers.py` which already returns 409 for a duplicate server
+name), and 404 for missing resources (145+ call sites). The 500s in
+`api/v2/mcp.py` are the anomaly.
+
+---
+
+## Tags *(required)*
+
+Both tests: `@mcp` `@regression` `@api` `@stable`.
+
+`@stable` is intentional: these tests must run in the daily workflow so the
+defect is formally recorded and the eventual upstream fix is detected. Because
+the tests fail by design against the buggy nightly, the daily's
+`auto-remove-stable` step will strip `@stable` on the first run — that is the
+intended lifecycle, not a regression. Restore `@stable` once Langflow returns
+409/404 (tracked in #396).
+
+---
+
+## Step by step *(required)*
+
+**Test 1 — duplicate registration → 409**
+
+1. Get an auth token (`GET /api/v1/auto_login`)
+2. Pre-clean: `DELETE /api/v2/mcp/servers/{name}` (remove any leftover)
+3. `POST /api/v2/mcp/servers/{name}` with `{ "url": "http://localhost:1/mcp" }` → expect **200**
+4. `POST` the same name again → expect **409 Conflict** *(currently 500 — fails by design)*
+5. Cleanup: `DELETE` the server
+
+**Test 2 — delete missing → 404**
+
+1. Get an auth token
+2. Guard: `DELETE` the (unique, never-registered) name to ensure absence
+3. `DELETE /api/v2/mcp/servers/{name}` → expect **404 Not Found** *(currently 500 — fails by design)*
+
+---
+
+## Validation criterion *(required)*
+
+- Test 1: the second `POST` of an existing name returns HTTP `409`
+- Test 2: `DELETE` of a non-existent server returns HTTP `404`
+
+(Until upstream is fixed, both fail with `Expected 409/404, Received 500` — the
+intended, self-documenting failure signature.)
+
+---
+
+## External dependencies *(required)*
+
+- `src/backend/base/langflow/api/v2/mcp.py` — `add_server` (`POST`), `delete_server`
+  (`DELETE`), and the shared `update_server` helper that raises the status codes
+  under test (lines ~411/418/454 today return 500)
+- No frontend, LLM, `npx`, or external network required — pure API against the
+  running instance
+
+---
+
+## What this test does not cover *(optional)*
+
+- The `PATCH /servers/{name}` upsert path (idempotent `merge_existing`, already
+  returns 200 correctly)
+- The 403 auth-guard and 422 name-mismatch branches of the same endpoints
+- UI surfacing of the error (covered indirectly by `mcp-client-regression.spec.ts`)
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`
+- Auth via `LANGFLOW_AUTO_LOGIN=true` (the shared `getAuthToken` helper)
+
+---
+
+## Notes *(optional)*
+
+- Uses `page.request` (APIRequestContext) exclusively: it runs outside the
+  browser page, so the intentional 5xx does **not** trip the fixture's
+  `page.on("response")` backend-error monitor — no `allowFlowErrors()` needed.
+- Server names are worker- and timestamp-scoped to avoid collisions with sibling
+  MCP specs running in parallel.
+- Split out of the investigation in #396; the passing `mcp-client-regression.spec.ts`
+  Test 3 only exercises successful registration (it pre-cleans to avoid the
+  duplicate), so it never covered the 409 path — this spec fills that gap.

--- a/docs/mcp/client/mcp-server-registration-status-codes.md
+++ b/docs/mcp/client/mcp-server-registration-status-codes.md
@@ -16,7 +16,7 @@ server-registration endpoints (`/api/v2/mcp/servers/{name}`). It asserts the
 > **This test is a known-defect watchdog (issue #396) and is EXPECTED TO FAIL
 > against current Langflow builds.** `api/v2/mcp.py` currently returns **500**
 > for both conditions ("Server already exists." / "Server not found."). The
-> intentional failure is the formal record — captured in `daily-history.jsonl`,
+> intentional failure is the formal record — captured in `reports/daily-history.jsonl`,
 > the QA Platform, and the `[Daily Failure]` issue — that the suite detected the
 > defect. On the first daily failure the workflow auto-removes `@stable` from
 > these tests (so they stop running); once upstream returns the correct codes,

--- a/docs/mcp/client/mcp-server-registration-status-codes.md
+++ b/docs/mcp/client/mcp-server-registration-status-codes.md
@@ -65,11 +65,18 @@ intended lifecycle, not a regression. Restore `@stable` once Langflow returns
 
 ## Validation criterion *(required)*
 
-- Test 1: the second `POST` of an existing name returns HTTP `409`
-- Test 2: `DELETE` of a non-existent server returns HTTP `404`
+- Test 1: the second `POST` of an existing name returns HTTP `409` **and** a
+  `detail` matching `/already exists/i`
+- Test 2: `DELETE` of a non-existent server returns HTTP `404` **and** a `detail`
+  matching `/server not found/i`
 
-(Until upstream is fixed, both fail with `Expected 409/404, Received 500` — the
-intended, self-documenting failure signature.)
+Each assertion checks the `detail` in addition to the status so a status that is
+correct-by-accident does not pass — e.g. a renamed/removed route returning a bare
+`404 "Not Found"` must not masquerade as the resource-level `404`.
+
+(Until upstream is fixed, both fail at the status check with `Expected 409/404,
+Received 500` — the intended, self-documenting failure signature. The `detail`
+check only runs once the status is correct.)
 
 ---
 
@@ -104,8 +111,11 @@ intended, self-documenting failure signature.)
 - Uses `page.request` (APIRequestContext) exclusively: it runs outside the
   browser page, so the intentional 5xx does **not** trip the fixture's
   `page.on("response")` backend-error monitor — no `allowFlowErrors()` needed.
-- Server names are worker- and timestamp-scoped to avoid collisions with sibling
-  MCP specs running in parallel.
+- Server names are worker-, timestamp-, and UUID-scoped so neither parallel
+  workers nor two independent invocations sharing one backend can collide.
+- The empty-token path is guarded up front (`expect(authHeader).toBeTruthy()`) so
+  an auth misconfiguration fails with a clear signal rather than a misleading
+  status mismatch.
 - Split out of the investigation in #396; the passing `mcp-client-regression.spec.ts`
   Test 3 only exercises successful registration (it pre-cleans to avoid the
   duplicate), so it never covered the 409 path — this spec fills that gap.

--- a/tests/tests-automations/regression/mcp/client/mcp-server-registration-status-codes.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-server-registration-status-codes.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 
@@ -25,19 +26,45 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 //     `authz_*`, `deployments`, and notably the sibling project-scoped MCP
 //     endpoint `api/v1/projects_mcp_helpers.py` already returns 409 for a
 //     duplicate server name;
-//   • 404 for missing resources — 145+ call sites across the API.
+//   • 404 for missing resources — 145+ call sites across the API. (Langflow
+//     resolves a missing DELETE to 404, not an idempotent 204/200.)
 // The 500s in `api/v2/mcp.py` are the anomaly.
+//
+// Each assertion checks BOTH the status code AND the response `detail`: a status
+// alone can pass for the wrong reason — e.g. a renamed/removed route makes the
+// framework return a bare 404 "Not Found", which would masquerade as the
+// resource-level "Server not found." Matching the specific detail string ties the
+// pass to the intended code path.
 //
 // Pure `page.request` (APIRequestContext) is used deliberately: it runs outside
 // the browser page, so the intentional 5xx does NOT trip the fixture's
 // `page.on("response")` backend-error monitor — no `allowFlowErrors()` needed.
 
-// Unique, worker-scoped names so parallel workers / sibling MCP specs never
-// collide on a shared server name.
+// Unique, collision-proof names. Worker index + timestamp disambiguate parallel
+// workers; the random UUID also rules out two independent invocations sharing the
+// same backend colliding in the same millisecond (e.g. a local run against the
+// instance the daily is using).
 const WORKER = process.env.TEST_WORKER_INDEX ?? "0";
-const DUP_SERVER_NAME = `dup-status-${WORKER}-${Date.now()}`;
-const MISSING_SERVER_NAME = `missing-status-${WORKER}-${Date.now()}`;
+const UNIQUE = `${WORKER}-${Date.now()}-${randomUUID().slice(0, 8)}`;
+const DUP_SERVER_NAME = `dup-status-${UNIQUE}`;
+const MISSING_SERVER_NAME = `missing-status-${UNIQUE}`;
+// Registration is lazy — Langflow persists the config without probing the URL —
+// so an unreachable port-1 URL still registers successfully (matches the sibling
+// mcp-client-regression.spec.ts convention).
 const HTTP_URL = "http://localhost:1/mcp";
+
+// Reads the response `detail` field defensively (body may be non-JSON on some
+// error paths); returns "" so a failed parse never masks the status assertion.
+async function readDetail(resp: {
+  json: () => Promise<unknown>;
+}): Promise<string> {
+  try {
+    const body = (await resp.json()) as { detail?: unknown };
+    return typeof body?.detail === "string" ? body.detail : "";
+  } catch {
+    return "";
+  }
+}
 
 test.describe("MCP v2 server registration — HTTP status codes", () => {
   test(
@@ -45,23 +72,37 @@ test.describe("MCP v2 server registration — HTTP status codes", () => {
     { tag: ["@mcp", "@regression", "@api", "@stable"] },
     async ({ page }) => {
       const authHeader = await getAuthToken(page.request);
+      expect(
+        authHeader,
+        "Auth token is empty — the instance did not return an access_token; " +
+          "the status assertions below would fail for an auth reason, not the contract",
+      ).toBeTruthy();
       const headers = {
         Authorization: authHeader,
         "Content-Type": "application/json",
       };
       const path = `/api/v2/mcp/servers/${DUP_SERVER_NAME}`;
 
-      await test.step("Pre-clean: remove the server if a prior run left it", async () => {
+      await test.step("Pre-clean: delete any server this worker left from a prior attempt/retry", async () => {
+        // The name is stable within a worker process, so a Playwright retry that
+        // crashed after registering (before the finally below) would otherwise
+        // hit "already exists" on the first POST. Cross-invocation leftovers have
+        // a different name and are not the target here.
         await page.request.delete(path, { headers });
       });
 
       try {
-        await test.step("First registration succeeds (200)", async () => {
+        await test.step("First registration succeeds (2xx)", async () => {
           const first = await page.request.post(path, {
             headers,
             data: { url: HTTP_URL },
           });
-          expect(first.status()).toBe(200);
+          // Accept any 2xx: creation is conventionally 200 or 201, and the code
+          // under test is the duplicate 409 below — not the create status.
+          expect(
+            first.status(),
+            "First registration of a fresh name should succeed (2xx)",
+          ).toBeLessThan(300);
         });
 
         await test.step("Second registration of the same name is rejected with 409 Conflict", async () => {
@@ -74,6 +115,10 @@ test.describe("MCP v2 server registration — HTTP status codes", () => {
             "Duplicate MCP server registration must return 409 Conflict " +
               "(Langflow currently returns 500 — issue #396)",
           ).toBe(409);
+          expect(
+            await readDetail(second),
+            "409 must be the duplicate-name conflict, not an unrelated 409",
+          ).toMatch(/already exists/i);
         });
       } finally {
         await test.step("Cleanup: delete the registered server", async () => {
@@ -88,13 +133,15 @@ test.describe("MCP v2 server registration — HTTP status codes", () => {
     { tag: ["@mcp", "@regression", "@api", "@stable"] },
     async ({ page }) => {
       const authHeader = await getAuthToken(page.request);
+      expect(
+        authHeader,
+        "Auth token is empty — the instance did not return an access_token; " +
+          "the status assertion below would fail for an auth reason, not the contract",
+      ).toBeTruthy();
       const headers = { Authorization: authHeader };
+      // MISSING_SERVER_NAME is unique and never registered, so no guard/pre-clean
+      // is needed — the resource is absent by construction.
       const path = `/api/v2/mcp/servers/${MISSING_SERVER_NAME}`;
-
-      await test.step("Guard: ensure the target server does not exist", async () => {
-        // Idempotent — best effort; a 404/500 here does not affect the assertion.
-        await page.request.delete(path, { headers });
-      });
 
       await test.step("Deleting a missing server is rejected with 404 Not Found", async () => {
         const resp = await page.request.delete(path, { headers });
@@ -103,6 +150,13 @@ test.describe("MCP v2 server registration — HTTP status codes", () => {
           "Deleting a non-existent MCP server must return 404 Not Found " +
             "(Langflow currently returns 500 — issue #396)",
         ).toBe(404);
+        // Guard against a route-level 404 (bare "Not Found") masquerading as the
+        // resource-level "Server not found." — a renamed/removed endpoint would
+        // otherwise pass this test silently.
+        expect(
+          await readDetail(resp),
+          "404 must be the resource-not-found case, not a missing/renamed route",
+        ).toMatch(/server not found/i);
       });
     },
   );

--- a/tests/tests-automations/regression/mcp/client/mcp-server-registration-status-codes.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-server-registration-status-codes.spec.ts
@@ -14,7 +14,7 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 // return **500** for both conditions (`api/v2/mcp.py` — "Server already exists."
 // / "Server not found."), so these tests are EXPECTED TO FAIL against the
 // nightly until the defect is fixed upstream. That failure is intentional and is
-// the formal, dated record (daily-history.jsonl + QA Platform + daily-failure
+// the formal, dated record (reports/daily-history.jsonl + QA Platform + daily-failure
 // issue) that the suite detected the bug. On the first daily failure the daily
 // workflow auto-removes `@stable` from these tests; once upstream returns the
 // correct codes, restore `@stable` and the tests become forward regression

--- a/tests/tests-automations/regression/mcp/client/mcp-server-registration-status-codes.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-server-registration-status-codes.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "../../../../fixtures/fixtures";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+
+// ─── Purpose ────────────────────────────────────────────────────────────────
+//
+// Regression guard for the HTTP status codes of the MCP v2 server-registration
+// API (`/api/v2/mcp/servers/{name}`). These are pure-API assertions of the
+// CORRECT, spec-conformant behavior:
+//
+//   • POST an already-registered name  → 409 Conflict  (duplicate resource)
+//   • DELETE a non-existent server      → 404 Not Found
+//
+// KNOWN-DEFECT WATCHDOG (issue #396): on current Langflow builds these endpoints
+// return **500** for both conditions (`api/v2/mcp.py` — "Server already exists."
+// / "Server not found."), so these tests are EXPECTED TO FAIL against the
+// nightly until the defect is fixed upstream. That failure is intentional and is
+// the formal, dated record (daily-history.jsonl + QA Platform + daily-failure
+// issue) that the suite detected the bug. On the first daily failure the daily
+// workflow auto-removes `@stable` from these tests; once upstream returns the
+// correct codes, restore `@stable` and the tests become forward regression
+// guards.
+//
+// Why 409/404 are the correct codes (not just REST theory): Langflow itself uses
+//   • 409 for uniqueness conflicts — `flows_helpers.py` ("Name must be unique"),
+//     `authz_*`, `deployments`, and notably the sibling project-scoped MCP
+//     endpoint `api/v1/projects_mcp_helpers.py` already returns 409 for a
+//     duplicate server name;
+//   • 404 for missing resources — 145+ call sites across the API.
+// The 500s in `api/v2/mcp.py` are the anomaly.
+//
+// Pure `page.request` (APIRequestContext) is used deliberately: it runs outside
+// the browser page, so the intentional 5xx does NOT trip the fixture's
+// `page.on("response")` backend-error monitor — no `allowFlowErrors()` needed.
+
+// Unique, worker-scoped names so parallel workers / sibling MCP specs never
+// collide on a shared server name.
+const WORKER = process.env.TEST_WORKER_INDEX ?? "0";
+const DUP_SERVER_NAME = `dup-status-${WORKER}-${Date.now()}`;
+const MISSING_SERVER_NAME = `missing-status-${WORKER}-${Date.now()}`;
+const HTTP_URL = "http://localhost:1/mcp";
+
+test.describe("MCP v2 server registration — HTTP status codes", () => {
+  test(
+    "registering an already-existing MCP server returns 409 Conflict",
+    { tag: ["@mcp", "@regression", "@api", "@stable"] },
+    async ({ page }) => {
+      const authHeader = await getAuthToken(page.request);
+      const headers = {
+        Authorization: authHeader,
+        "Content-Type": "application/json",
+      };
+      const path = `/api/v2/mcp/servers/${DUP_SERVER_NAME}`;
+
+      await test.step("Pre-clean: remove the server if a prior run left it", async () => {
+        await page.request.delete(path, { headers });
+      });
+
+      try {
+        await test.step("First registration succeeds (200)", async () => {
+          const first = await page.request.post(path, {
+            headers,
+            data: { url: HTTP_URL },
+          });
+          expect(first.status()).toBe(200);
+        });
+
+        await test.step("Second registration of the same name is rejected with 409 Conflict", async () => {
+          const second = await page.request.post(path, {
+            headers,
+            data: { url: HTTP_URL },
+          });
+          expect(
+            second.status(),
+            "Duplicate MCP server registration must return 409 Conflict " +
+              "(Langflow currently returns 500 — issue #396)",
+          ).toBe(409);
+        });
+      } finally {
+        await test.step("Cleanup: delete the registered server", async () => {
+          await page.request.delete(path, { headers });
+        });
+      }
+    },
+  );
+
+  test(
+    "deleting a non-existent MCP server returns 404 Not Found",
+    { tag: ["@mcp", "@regression", "@api", "@stable"] },
+    async ({ page }) => {
+      const authHeader = await getAuthToken(page.request);
+      const headers = { Authorization: authHeader };
+      const path = `/api/v2/mcp/servers/${MISSING_SERVER_NAME}`;
+
+      await test.step("Guard: ensure the target server does not exist", async () => {
+        // Idempotent — best effort; a 404/500 here does not affect the assertion.
+        await page.request.delete(path, { headers });
+      });
+
+      await test.step("Deleting a missing server is rejected with 404 Not Found", async () => {
+        const resp = await page.request.delete(path, { headers });
+        expect(
+          resp.status(),
+          "Deleting a non-existent MCP server must return 404 Not Found " +
+            "(Langflow currently returns 500 — issue #396)",
+        ).toBe(404);
+      });
+    },
+  );
+});


### PR DESCRIPTION
## ⚠️ These tests are RED by design — do not treat the failure as a mistake

This PR adds a **known-defect watchdog** for issue #396. The two new tests assert the **correct** HTTP status codes of the MCP v2 server-registration API; Langflow currently returns **500** for both, so the tests **fail on purpose** against the nightly. That intentional failure is the deliverable: a formal, dated record (`daily-history.jsonl` + QA Platform + `[Daily Failure]` issue) that the suite detected a real bug.

## What

Pure-API regression guard on `/api/v2/mcp/servers/{name}`:

| Scenario | Correct | Langflow today |
|---|---|---|
| `POST` an already-registered name | **409 Conflict** | 500 "Server already exists." |
| `DELETE` a non-existent server | **404 Not Found** | 500 "Server not found." |

## Why 409/404 are correct (not just REST theory)

Langflow's own conventions, confirmed in the source:
- **409** for uniqueness conflicts — `flows_helpers.py` ("Name must be unique"), `authz_*`, `deployments`, and crucially the **sibling project-scoped MCP endpoint** `api/v1/projects_mcp_helpers.py` **already returns 409** for a duplicate server name.
- **404** for missing resources — 145+ call sites.

The 500s in `api/v2/mcp.py` (lines ~411/418/454) are the anomaly.

## Lifecycle (intentional, matches the daily machinery)

1. Merge → daily runs these `@stable` tests → **they fail** → recorded in `daily-history.jsonl` + QA Platform + a `[Daily Failure]` issue.
2. The daily `auto-remove-stable` step strips `@stable` on the first failure → they stop running (no recurring noise).
3. #396 is re-scoped to track the upstream report (grounded by this test) + the fix.
4. Once Langflow returns 409/404, **restore `@stable`** → the tests become forward regression guards.

## Validation

- Ran locally against Langflow 1.11.0: both fail with the intended, self-documenting signatures — `Expected: 409, Received: 500` and `Expected: 404, Received: 500`.
- Confirmed the first registration returns 200 (so Test 1 fails specifically on the duplicate 409 assertion) and that **no `🚨 Backend Error` fires** — pure `page.request` runs outside the browser page, so the intentional 5xx does not trip the fixture monitor (no `allowFlowErrors()` needed).
- `npm run typecheck` clean; `eslint` on the new spec: 0 problems.
- Spec doc added; QA-CHECKLIST + Phase 0/coverage regenerated (`@stable` 292→294).

## CI note

The **"Run impacted E2E specs"** check will be **red** for this PR — that is the by-design failure, not a regression in existing behavior. `pr-validation` (typecheck + lint) is green.

Refs #396 (kept open to track the upstream report + `@stable` restore).