### PR TITLE
fix(flows): harden openNewFlowTemplatesModal against swallowed clicks under load (#420)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -785,7 +785,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 294 `test()` calls carrying the `@stable` tag, distributed across 109 spec
+> 295 `test()` calls carrying the `@stable` tag, distributed across 110 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -1062,6 +1062,7 @@
 - [x] User must be able to stop building from inside Playground → `stop-button-playground.spec.ts`
 
 #### core-functionality/project-management/
+- [x] user should be able to select flows with different methods and perform bulk actions → `bulk-actions.spec.ts`
 - [x] user should be able to edit flow name and see it reflected in the main page listing → `edit-flow-name.spec.ts`
 - [x] creates, renames and deletes an empty project folder via the UI → `folder-crud.spec.ts`
 - [x] deleting a folder that contains a flow removes the flow with it → `folder-crud.spec.ts`

--- a/docs/core-functionality/project-management/bulk-actions.md
+++ b/docs/core-functionality/project-management/bulk-actions.md
@@ -71,7 +71,7 @@ The test creates its 3 flows from starter templates and captures each flow ID fr
 Under `fullyParallel` CI load this is a heavy test (it creates 3 flows and navigates editor↔home repeatedly). Two load-induced flake modes have been observed on the weekly run:
 
 - The home listing taking >10s to render after returning from the editor (the `Projects` visibility wait). **Mitigated** by raising that wait to 30s.
-- Clicking the "New Flow" entry point not opening the templates modal within 30s, inside the shared `openNewFlowTemplatesModal` helper — **tracked in #420** (not yet mitigated).
+- Clicking the "New Flow" entry point not opening the templates modal ("swallowed click": the button is actionable but its React handler is not wired yet under load), inside the shared `openNewFlowTemplatesModal` helper — **mitigated** in #420 by a click-and-probe retry loop in that helper (re-clicks the entry point if neither the templates modal nor the welcome overlay surfaces within a short budget).
 
 Both reproduce only under contention; a single isolated run against a fresh instance passes consistently.
 

--- a/tests/helpers/flows/open-new-flow-templates-modal.ts
+++ b/tests/helpers/flows/open-new-flow-templates-modal.ts
@@ -15,6 +15,29 @@ const MODAL_TITLE = '[data-testid="modal-title"]';
  * — so this is backward-compatible. Shared between the two entry points so the
  * selector/timeout logic can't drift.
  */
+/**
+ * Manual, assertion-free probe: resolves `true` as soon as the templates modal
+ * OR the welcome overlay becomes visible, `false` if neither shows within
+ * `timeoutMs`. Deliberately NOT `expect.poll` — a caught poll timeout survives
+ * as a spurious red ✗ step in the trace (#599), and here the "nothing opened"
+ * outcome is an expected, recoverable branch (the retry below), not a failure.
+ * A `timeoutMs` of 0 performs a single immediate check.
+ */
+const overlayOrModalAppeared = async (
+  page: Page,
+  timeoutMs: number,
+): Promise<boolean> => {
+  const welcomePanel = page.locator(WELCOME_PANEL);
+  const modalTitle = page.locator(MODAL_TITLE);
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await modalTitle.isVisible().catch(() => false)) return true;
+    if (await welcomePanel.isVisible().catch(() => false)) return true;
+    if (Date.now() >= deadline) return false;
+    await page.waitForTimeout(200);
+  }
+};
+
 export const dismissWelcomeOverlayAndWaitForModal = async (page: Page) => {
   // expect.poll instead of Promise.race(waitForSelector×2): the race's losing
   // wait survives as a spurious red ✗ step in every trace that goes through
@@ -61,6 +84,26 @@ export const dismissWelcomeOverlayAndWaitForModal = async (page: Page) => {
 export const openNewFlowTemplatesModal = async (page: Page) => {
   const newProjectBtn = page.getByTestId("new-project-btn");
   const emptyBtn = page.getByTestId("new_project_btn_empty_page");
-  await newProjectBtn.or(emptyBtn).first().click({ timeout: 15000 });
+  const entryPoint = newProjectBtn.or(emptyBtn).first();
+
+  // Retry the open under `fullyParallel` CI load (#420): the entry point is in
+  // the DOM and actionable, but its React handler may not be wired yet, so the
+  // click registers without opening anything ("swallowed click"). Click, probe
+  // for the overlay/modal on a short budget, and re-click if nothing surfaced.
+  // The leading probe skips re-clicking when a prior attempt's open just landed
+  // as the probe expired — clicking through a just-opened modal's backdrop
+  // would otherwise deadlock on actionability. Backward-compatible: when the
+  // first click opens the modal directly (the common case for every other
+  // caller), the loop breaks on attempt 1 with no extra clicks.
+  const PROBE_TIMEOUT = 8000;
+  const MAX_ATTEMPTS = 3;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    if (await overlayOrModalAppeared(page, 0)) break;
+    await entryPoint.click({ timeout: 15000 });
+    if (await overlayOrModalAppeared(page, PROBE_TIMEOUT)) break;
+  }
+
+  // Authoritative wait: reconciles the overlay and raises the real error with a
+  // meaningful message if, after the retries, nothing opened.
   await dismissWelcomeOverlayAndWaitForModal(page);
 };

--- a/tests/helpers/flows/open-new-flow-templates-modal.ts
+++ b/tests/helpers/flows/open-new-flow-templates-modal.ts
@@ -4,24 +4,14 @@ const WELCOME_PANEL = '[data-testid="flow-builder-welcome-panel"]';
 const MODAL_TITLE = '[data-testid="modal-title"]';
 
 /**
- * After an action that should open the templates modal (the header "New Flow"
- * button or the empty-page CTA), reconcile the Langflow 1.10.0
- * `FlowBuilderWelcome` overlay: those entry points may navigate to a
- * freshly-created flow and surface the welcome overlay instead of the modal.
- *
- * Race the overlay against the modal; if the overlay surfaces, dismiss it via
- * "Browse more templates", then wait for the modal. When the modal opens
- * directly (older builds, or the empty-page CTA) the overlay branch is skipped
- * — so this is backward-compatible. Shared between the two entry points so the
- * selector/timeout logic can't drift.
- */
-/**
  * Manual, assertion-free probe: resolves `true` as soon as the templates modal
  * OR the welcome overlay becomes visible, `false` if neither shows within
  * `timeoutMs`. Deliberately NOT `expect.poll` — a caught poll timeout survives
  * as a spurious red ✗ step in the trace (#599), and here the "nothing opened"
- * outcome is an expected, recoverable branch (the retry below), not a failure.
- * A `timeoutMs` of 0 performs a single immediate check.
+ * outcome is an expected, recoverable branch (the retry in
+ * `openNewFlowTemplatesModal`), not a failure. A `timeoutMs` of 0 performs a
+ * single immediate check. Single source of truth for the "did anything open?"
+ * predicate — `dismissWelcomeOverlayAndWaitForModal` polls it too.
  */
 const overlayOrModalAppeared = async (
   page: Page,
@@ -38,6 +28,18 @@ const overlayOrModalAppeared = async (
   }
 };
 
+/**
+ * After an action that should open the templates modal (the header "New Flow"
+ * button or the empty-page CTA), reconcile the Langflow 1.10.0
+ * `FlowBuilderWelcome` overlay: those entry points may navigate to a
+ * freshly-created flow and surface the welcome overlay instead of the modal.
+ *
+ * Race the overlay against the modal; if the overlay surfaces, dismiss it via
+ * "Browse more templates", then wait for the modal. When the modal opens
+ * directly (older builds, or the empty-page CTA) the overlay branch is skipped
+ * — so this is backward-compatible. Shared between the two entry points so the
+ * selector/timeout logic can't drift.
+ */
 export const dismissWelcomeOverlayAndWaitForModal = async (page: Page) => {
   // expect.poll instead of Promise.race(waitForSelector×2): the race's losing
   // wait survives as a spurious red ✗ step in every trace that goes through
@@ -46,14 +48,8 @@ export const dismissWelcomeOverlayAndWaitForModal = async (page: Page) => {
   // attached-but-hidden welcome panel sitting before the modal in the DOM
   // pins the visibility wait to the full timeout.
   const welcomePanel = page.locator(WELCOME_PANEL);
-  const modalTitle = page.locator(MODAL_TITLE);
   await expect
-    .poll(
-      async () =>
-        (await modalTitle.isVisible().catch(() => false)) ||
-        (await welcomePanel.isVisible().catch(() => false)),
-      { timeout: 30000 },
-    )
+    .poll(() => overlayOrModalAppeared(page, 0), { timeout: 30000 })
     .toBe(true);
 
   // isVisible, not count() — an attached-but-hidden panel must not trigger a
@@ -88,17 +84,30 @@ export const openNewFlowTemplatesModal = async (page: Page) => {
 
   // Retry the open under `fullyParallel` CI load (#420): the entry point is in
   // the DOM and actionable, but its React handler may not be wired yet, so the
-  // click registers without opening anything ("swallowed click"). Click, probe
-  // for the overlay/modal on a short budget, and re-click if nothing surfaced.
-  // The leading probe skips re-clicking when a prior attempt's open just landed
-  // as the probe expired — clicking through a just-opened modal's backdrop
-  // would otherwise deadlock on actionability. Backward-compatible: when the
-  // first click opens the modal directly (the common case for every other
-  // caller), the loop breaks on attempt 1 with no extra clicks.
+  // click registers without opening anything ("swallowed click", the dominant
+  // flake mode — the page stays on home). Click, probe for the overlay/modal on
+  // a short budget, and re-click ONLY while still on the home page.
+  //
+  // Two guards keep the retry from misfiring:
+  //  - Leading `overlayOrModalAppeared(page, 0)`: skip re-clicking when a prior
+  //    attempt's open just landed as the probe expired (clicking through a
+  //    just-opened modal's backdrop would deadlock on actionability).
+  //  - Entry-point visibility (retries only): on 1.10 the click navigates to a
+  //    freshly-created flow, so a slow-but-successful welcome overlay leaves the
+  //    home entry point gone. Re-clicking there would hit a page without the
+  //    button and time out (15s). Bail instead and let the authoritative 30s
+  //    wait below reconcile the overlay — exactly the pre-#420 behavior for that
+  //    path. The check is guarded to attempts > 1 so the first click keeps its
+  //    15s auto-wait, which covers a home page still rendering the button.
+  //
+  // Backward-compatible: when the first click opens the modal directly (the
+  // common case for every other caller), the loop breaks on attempt 1 with no
+  // extra clicks.
   const PROBE_TIMEOUT = 8000;
   const MAX_ATTEMPTS = 3;
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     if (await overlayOrModalAppeared(page, 0)) break;
+    if (attempt > 1 && !(await entryPoint.isVisible().catch(() => false))) break;
     await entryPoint.click({ timeout: 15000 });
     if (await overlayOrModalAppeared(page, PROBE_TIMEOUT)) break;
   }

--- a/tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts
@@ -7,7 +7,7 @@ import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 test(
   "user should be able to select flows with different methods and perform bulk actions",
-  { tag: ["@release", "@workspace", "@mainpage", "@regression"] },
+  { tag: ["@stable", "@release", "@workspace", "@mainpage", "@regression"] },
   async ({ page, request }) => {
     await awaitBootstrapTest(page);
 


### PR DESCRIPTION
Closes #420

## Problem

`bulk-actions.spec.ts` (`@stable`) flakes under `fullyParallel` CI load: after clicking the **New Flow** entry point inside the shared `openNewFlowTemplatesModal` helper, neither the templates modal nor the welcome overlay surfaces within 30s. The button is in the DOM and actionable, but its React handler is not wired yet under load, so the click registers without opening anything (a "swallowed click"). The page snapshot at failure shows we are still on the home page. It reproduces only under contention — a single isolated run against a fresh instance passes consistently.

## Fix

Harden `openNewFlowTemplatesModal` (shared helper — used by `awaitBootstrapTest`, `loadTemplateByName`, `bulk-actions`, and others) with a **click-and-probe retry loop**:

1. Click the entry point, then probe for the templates modal **or** welcome overlay on a short budget (8s); re-click if neither surfaced (up to 3 attempts).
2. **Leading zero-budget probe** — skips re-clicking when a prior attempt's open just landed as the probe expired (clicking through a just-opened modal's backdrop would deadlock on actionability).
3. **Entry-point guard (retries only)** — on Langflow 1.10 the click navigates to a freshly-created flow, so a slow-but-successful welcome overlay leaves the home entry point gone. Re-clicking there would hit a page without the button and time out. The retry bails when the entry point is absent and lets the authoritative 30s wait reconcile the overlay — the pre-existing behavior for that path. Guarded to attempts > 1 so the first click keeps its 15s auto-wait for a still-rendering home.

The probe is an **assertion-free manual poll** (not `expect.poll`), so the recoverable "nothing opened" branch leaves no spurious red step in the trace (#599). `dismissWelcomeOverlayAndWaitForModal` is preserved as the authoritative 30s wait and now delegates its visibility predicate to the shared `overlayOrModalAppeared`, so every other caller stays backward-compatible.

Also restores `@stable` on `bulk-actions.spec.ts` (removed during daily-failure triage — restoration is the human-gated acceptance criterion for this issue) and refreshes the spec doc's Known flakiness note. The QA-CHECKLIST Phase 0 block regenerated automatically from the restored tag.

## Validation

Full internal validation guide (CONTRIBUTING.md) run against `bulk-actions.spec.ts`:

- **Run + trace** — 1 passed (~14s), trace captured.
- **Force failure** — inverting the core checkbox-selection assertion fails the test (not a false positive). Additionally verified the helper throws loudly (bounded, no infinite hang) when the modal genuinely never opens.
- **Backend/flow logs** — zero `🚨 Backend Error` / `🚨 Flow Error`.
- **Checklist** — Phase 0 `@stable` block regenerated via `npm run coverage:summary`.
- **typecheck** clean; **lint** 0 errors.

An independent code review (high effort) was run on the diff; its findings (navigation-during-retry regression, predicate duplication, orphaned JSDoc) were applied before this PR.

## Notes

- The flake reproduces only under CI contention, so the fix is validated for correctness and backward-compatibility locally; the load behavior is confirmed by the daily `@stable` workflow after merge.
- Two pre-existing, out-of-scope observations in `bulk-actions.spec.ts` (no `test.step()` blocks; a weak transient-toast assertion) were noted for a possible follow-up — not addressed here to keep the diff scoped to #420.
