### PR TITLE
ci(impacted): enable tracing when observability specs are impacted

### DIFF
--- a/.github/workflows/adaptive-impacted.yml
+++ b/.github/workflows/adaptive-impacted.yml
@@ -154,7 +154,12 @@ jobs:
           LANGFLOW_AUTO_LOGIN: "true"
           LANGFLOW_SUPERUSER: langflow
           LANGFLOW_SUPERUSER_PASSWORD: langflow123
-          LANGFLOW_DEACTIVATE_TRACING: "true"
+          # Tracing is OFF by default (cuts startup time / backend noise for the
+          # majority of specs). Turn it ON when the full suite runs or when
+          # observability/traces specs are impacted — they need the SUT to emit
+          # traces + spans, and without it their setup times out. Mirrors
+          # daily-stable.yml, which keeps tracing ON for exactly these specs.
+          LANGFLOW_DEACTIVATE_TRACING: ${{ (needs.compute-impact.outputs.run_full == 'true' || contains(needs.compute-impact.outputs.specs, 'observability-monitoring')) && 'false' || 'true' }}
         options: >-
           --health-cmd "curl -f http://localhost:7860/health_check || exit 1"
           --health-interval 15s

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -86,7 +86,12 @@ jobs:
           LANGFLOW_AUTO_LOGIN: "true"
           LANGFLOW_SUPERUSER: langflow
           LANGFLOW_SUPERUSER_PASSWORD: langflow123
-          LANGFLOW_DEACTIVATE_TRACING: "true"
+          # Tracing is OFF by default (cuts startup time / backend noise for the
+          # majority of specs). Turn it ON only when observability/traces specs
+          # are impacted — they need the SUT to emit traces + spans, and without
+          # it their setup times out. Mirrors daily-stable.yml, which keeps
+          # tracing ON for exactly these specs.
+          LANGFLOW_DEACTIVATE_TRACING: ${{ contains(needs.detect-specs.outputs.specs, 'observability-monitoring') && 'false' || 'true' }}
         options: >-
           --health-cmd "curl -f http://localhost:7860/health_check || exit 1"
           --health-interval 15s


### PR DESCRIPTION
## Problem

The impacted-spec jobs in `pr-validation.yml` (**Run impacted E2E specs**) and `adaptive-impacted.yml` launch the Langflow SUT with `LANGFLOW_DEACTIVATE_TRACING: "true"`. With tracing off, no traces/spans are emitted, so **any observability/traces spec times out in setup** (nothing to poll).

This surfaced on #625: `traces-delete-cascade.spec.ts` — the first trace-dependent spec to run through the impacted path — failed in `beforeAll` polling for a span tree that could never appear. The sibling `traces-detail-*` specs never hit this because they only run on `daily-stable`, which deliberately keeps tracing **ON** (see its inline comment) and where they pass every day.

## Fix

Make the flag conditional instead of always-on:

- **`pr-validation.yml`** — tracing ON when the impacted set contains an `observability-monitoring` spec, else OFF.
- **`adaptive-impacted.yml`** — tracing ON for full-suite runs **or** when observability specs are impacted, else OFF.

All other impacted runs keep tracing OFF, preserving the original startup-time / backend-noise intent. Uses the same `${{ … && 'false' || 'true' }}` expression pattern already used for `FORCE_RUN` in `adaptive-impacted.yml`.

## Validation

- YAML structure matches the surrounding blocks; the ternary mirrors the existing `FORCE_RUN` expression in the same file.
- **Note:** this PR touches only workflow files (no specs), so its own impacted-E2E job is skipped — the conditional can't be exercised by this PR's CI. It will be exercised by the next PR that touches an observability spec (expected: tracing ON → green, vs the red on #625). The behaviour it enables is the same one `daily-stable` runs successfully every day.