### PR TITLE
ci(daily-stable): enforce SQLite foreign keys on the SUT

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -58,6 +58,13 @@ jobs:
           # (see #352). External tracers (LangSmith/Langfuse/etc.) stay dormant
           # here because their API keys are absent.
           LANGFLOW_DEACTIVATE_TRACING: "false"
+          # Enforce SQLite foreign keys (OFF by default in Langflow). Without
+          # this, cascade/orphan bugs like #13955 (bulk trace delete vs. the
+          # span->trace FK) are invisible — the raw DELETE "succeeds" leaving
+          # orphaned rows, so traces-delete-cascade.spec.ts and any future
+          # cascade guard would pass for the wrong reason. The dict replaces the
+          # product default wholesale, so the default pragmas are repeated here.
+          LANGFLOW_SQLITE_PRAGMAS: '{"synchronous": "NORMAL", "journal_mode": "WAL", "busy_timeout": 30000, "foreign_keys": "ON"}'
           # Ollama runs as a sibling service; without the allowlist the
           # nightly's SSRF protection 400s the Ollama component's model-list
           # fetch (private address) — see ollama-provider.spec.ts (#583).


### PR DESCRIPTION
## What

Enable `LANGFLOW_SQLITE_PRAGMAS` with `foreign_keys=ON` on the `daily-stable.yml` Langflow service.

## Why

SQLite does **not** enforce foreign keys by default, and Langflow's default `sqlite_pragmas` omit them. With FK off, cascade/orphan bugs like `langflow-ai/langflow#13955` (bulk trace delete vs. the `span→trace` FK) are **invisible** — the raw `DELETE` "succeeds" leaving orphaned rows, so `traces-delete-cascade.spec.ts` (and any future cascade guard) passes for the wrong reason.

Turning FK on:
- gives the cascade guard real teeth on the daily, and
- turns the whole `@stable` suite into a detector for latent cascade/orphan bugs in any delete path (a red here = a real data-integrity bug surfaced, not noise).

Flip-global on the single SUT service is the only clean option for `daily-stable`, since the job is monolithic (one service, one `results.json` feeding history / `@stable` auto-remove / issue creation) — a second FK-on job would not plug into that machinery.

## Blast radius — measured empirically

Dispatched this workflow against the branch (`workflow_dispatch`, which skips all destructive side-effects — history commit, `@stable` auto-remove, and issue creation are gated on `github.event_name == 'schedule'`):

**Run:** https://github.com/oriontech-me/langflow-e2e/actions/runs/29069411049 — 286 passed, 10 flaky (all passed on retry), 49 skipped, 5 hard failures.

**FK-on caused zero of the 5 failures.** A full scan of every error / stdout / stderr found:
- `foreign key` violations: **0**
- `DELETE … 500`: **0**
- `IntegrityError` / `constraint failed`: **0**
- teardown / `Flow cleanup failed`: **0** (so `deleteFlow` cleanup worked throughout under FK-on)

The 5 hard failures are all pre-existing, non-FK issues (would fail under FK-off too):
- `agent-multi-tool-selection`, `agent-tool-error-handling`, `agent-tool-name-validation` — LLM/agent behaviour + parallel test-data accumulation (`found 19 flows` — the known `cleanAllFlows` isolation hazard, not a cleanup 500).
- `mcp-server-registration-status-codes` (×2) — **unique-constraint / client-error-as-500 (#396)**, which the `foreign_keys` pragma does not affect; the upstream #396 fix appears absent from the current nightly.

`traces-delete-cascade.spec.ts` and `traces-delete.spec.ts` both **passed** under FK enforcement.

## Note

Two orthogonal signals the run surfaced (not addressed here): #396 red on the current nightly, and the agent-tool cluster failing — both worth watching on the next scheduled daily to tell a real regression from flake.