### PR TITLE
fix(llm-agents): restore @stable on memory-history node-structure test (#445)

### DIFF
--- a/docs/core-functionality/llm-agents/memory-history-regression.md
+++ b/docs/core-functionality/llm-agents/memory-history-regression.md
@@ -1,6 +1,6 @@
 # Memory Chatbot — History and Memory Regression
 
-**Last validated:** Langflow 1.11.x (1.11.0.dev36)
+**Last validated:** Langflow 1.11.x (1.11.0)
 
 ---
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/memory-history-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/memory-history-regression.spec.ts
@@ -92,7 +92,7 @@ test.describe("Memory Chatbot Regression", () => {
 
   test(
     "memory chatbot template loads with correct node structure",
-    { tag: ["@release", "@agents", "@playground"] },
+    { tag: ["@stable", "@release", "@agents", "@playground"] },
     async ({ page }) => {
       createdFlowId = await loadMemoryChatbot(page);
 


### PR DESCRIPTION
## Summary

Restores `@stable` on Test 1 (`memory chatbot template loads with correct node structure`) of `memory-history-regression.spec.ts`, completing the last open deliverable of #445.

## Context

#445 tracked the Memory Chatbot template redesign (**6 → 5 nodes**: `Agent` + `Memory Base` replacing the `Message History` / `Language Model` / `Prompt Template` trio). Its deliverables:

1. Update assertions to the 5-node structure — **already done** by the sibling #550 fix (`855914a`), which touched this file for the token-usage flake and, since the template had changed, updated Test 1's assertions to 5 nodes. #550 restored `@stable` only on Tests 2 and 3 (its scope), leaving Test 1 to #445.
2. Re-validate — see below.
3. **Restore `@stable`** — this PR.

The issue's caveat ("don't update to 5 nodes until it ships in a release") is resolved: the redesign shipped in `1.11.0.dev34` and has reached the **1.11.0** release line.

## Validation

Re-ran Test 1 against the running **1.11.0** release instance — passes in ~6s with the 5-node structure (Chat Input, Chat Output, Agent, Memory Base, note). `tsc --noEmit` clean.

## Changes

- `memory-history-regression.spec.ts` — add `@stable` to Test 1's tag array.
- Spec doc — bump `Last validated` to `1.11.0`. Tags section already lists `@stable`.

Closes #445