### PR TITLE
fix(mcp): tag-agnostic 'Called tool' selector, restore @stable (#552)

### DIFF
--- a/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
@@ -174,7 +174,7 @@ for (const { label, options, skipReason } of targets) {
 
     test(
       "agent calls echo MCP tool and returns echoed message",
-      { tag: ["@mcp", "@agents", "@regression"] },
+      { tag: ["@mcp", "@agents", "@regression", "@stable"] },
       async ({ page }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(
@@ -342,9 +342,9 @@ for (const { label, options, skipReason } of targets) {
               return text.includes("Finished") || text.includes("Steps");
             });
             for (const row of rows) {
-              const chevron = row.querySelector<HTMLElement>(
-                "div.cursor-pointer",
-              );
+              // Tag-agnostic: the accordion trigger is a <div> on older builds
+              // and a <button> on 1.11.0.dev38+ (see NOTE below).
+              const chevron = row.querySelector<HTMLElement>(".cursor-pointer");
               chevron?.click();
             }
           });
@@ -354,12 +354,13 @@ for (const { label, options, skipReason } of targets) {
           // This DOM only exists after the agent invoked a tool — if the LLM hallucinated
           // a response without using any tool, the row is absent.
           //
-          // NOTE: Langflow's `AccordionTrigger` (src/frontend/src/components/ui/accordion.tsx)
-          // passes `asChild` to Radix and wraps a <div className="cursor-pointer ...">,
-          // NOT a <button>. Selector must therefore not constrain by tag name.
+          // NOTE: Langflow's `AccordionTrigger` markup has flipped between a
+          // <div className="cursor-pointer ..."> (pre-1.11 nightlies) and a real
+          // <button className="... cursor-pointer ..."> (1.11.0.dev38+). Selector
+          // must therefore not constrain by tag name — match the class only.
           // Ref: src/frontend/src/components/core/chatComponents/ContentBlockDisplay.tsx
           const calledToolTrigger = page
-            .locator("div.cursor-pointer")
+            .locator(".cursor-pointer")
             .filter({ hasText: "Called tool" });
           await expect(
             calledToolTrigger.last(),


### PR DESCRIPTION
**Fixes #552.**

## Problem

`mcp-client-agent.spec.ts` failed every daily since #548 (first failure 2026-07-07). Root cause was two stacked defects:

1. **Product/image (Defect A):** the nightly image shipped a root-owned npm cache (`/opt/app-root/src/.npm`, regression from the ubi10 base change langflow-ai/langflow#13893) → `npx` MCP servers died with `EACCES` → `toolsCount` stayed `null` for the whole 90s poll. Reported upstream, fixed by langflow-ai/langflow#13992 (merged 2026-07-09, validated independently by us on the PR). **Present in today's nightly** (`1.11.0.dev38`): fresh container, zero manual workaround → `toolsCount=13` in 5s, zero `EACCES` in logs.
2. **Our selector drift (the "Defect B" correction in #552):** the Playground accordion trigger changed from `<div class="cursor-pointer">` to `<button class="... cursor-pointer">` on dev38, so the `'Called tool'` proof (`div.cursor-pointer` locator) reported a false negative ("agent answered without invoking any tool") even though the indicator was present. Confirmed via an instrumented run dumping the live DOM around the "Called tool" text node.

## Fix

Tag-agnostic locator: `div.cursor-pointer` → `.cursor-pointer` in both places that assumed the tag (the Proof #1/#2 trigger locator and the best-effort accordion expander), plus updated comments documenting the `<div>`↔`<button>` flip between builds. No product-behavior assertion changed.

Rejected alternative: `getByRole("button")` — would break again on older builds where the trigger is a `<div>`; the spec's own NOTE already mandated not constraining by tag.

`@stable` restored on the `test(...)` call (removed during #548 triage); the generated `QA-CHECKLIST.md` blocks regenerate on merge.

## Scope note

All three proofs unchanged in substance: (1) "Called tool" indicator must render, (2) the tool must be `echo`, (3) the response must contain `hello mcp`. Setup, teardown (id-scoped flow delete, MCP server delete), serial mode, and provider resolution untouched.

Note: the benign `Legacy reference 'MCP' is not in the migration table` warning still fires on dev38 (17× in today's logs, including on all passing runs) — cosmetic upstream issue, does not affect the test (per the #552 investigation).

## Validation (nightly 1.11.0.dev38, `--retries=0`, model `claude-sonnet-5`/anthropic)

- typecheck ✅ · eslint ✅ (0 errors; file warnings pre-existing) · anti-pattern checklist ✅
- 6 clean runs, no flake (15.8–19.5s each) ✅
- force-fail ×2 ✅ — Proof #1 mutated (`"Called toolz-bogus"`) → failed with "Playground must show a 'Called tool' indicator"; Proof #2 mutated (`/zzz-nonexistent-tool/i`) → failed with "The MCP tool invoked must be 'echo'"
- `--trace=on` skipped — known limitation: tracing hangs Simple Agent–template specs (>600s, documented in #490); step verification covered by the green `--retries=0` runs + force-fail mutations + the instrumented DOM dump
- zero orphan flows after the burst (flows endpoint returns 0) ✅; `allowFlowErrors()` remains active by design (transient npx startup errors)
- Model deviation: validated on `anthropic/claude-sonnet-5` instead of google — on dev38 the collect-models probe hits `gemini-omni-flash-preview` ("only supports Interactions API") and marks the google provider inactive (probe friction, tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
