### PR TITLE
qa-infra(daily): fix go-httpbin service tag v2.23.1 -> 2.23.1 (#639)

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -110,8 +110,12 @@ jobs:
       # tag; pulled anonymously (no Docker Hub rate limits). No healthcheck: the
       # scratch-based image ships only the Go binary (no shell/curl), so the
       # "Resolve go-httpbin endpoint" step below both waits for and verifies it.
+      # Tag has NO `v` prefix: mccutchen/go-httpbin dropped the `v` from its GHCR
+      # tags at 2.17 (the `v`-prefixed series stops at v2.16.1), so `v2.23.1`
+      # returns `manifest unknown` and fails container init before any test runs.
+      # The pullable tag is the unprefixed `2.23.1` (#639).
       go-httpbin:
-        image: ghcr.io/mccutchen/go-httpbin:v2.23.1
+        image: ghcr.io/mccutchen/go-httpbin:2.23.1
         ports:
           - 8080:8080
 


### PR DESCRIPTION
## What

Fix the go-httpbin echo service pin in `daily-stable.yml`: `v2.23.1` → `2.23.1` (drop the `v`).

## Why

`ghcr.io/mccutchen/go-httpbin:v2.23.1` **does not exist** — the maintainer dropped the `v` prefix from their GHCR tags at `2.17` (the `v`-prefixed series stops at `v2.16.1`). The pull returns `manifest unknown` and fails the `Initialize containers` step **before any test runs**, so the whole daily suite never starts.

The go-httpbin service was added by #630 (issue #462), which merged **after** the last scheduled daily — so no scheduled run had exercised the pin yet, and the next scheduled daily would have hard-failed at container init.

Verified against the GHCR registry:

| Tag | Manifest |
|---|---|
| `ghcr.io/mccutchen/go-httpbin:v2.23.1` | HTTP 404 |
| `ghcr.io/mccutchen/go-httpbin:2.23.1` | HTTP 200 |

## Evidence

Two `workflow_dispatch` runs both failed at `Initialize containers`, retrying the go-httpbin pull 3× with `manifest unknown`:
- https://github.com/oriontech-me/langflow-e2e/actions/runs/29101099301
- https://github.com/oriontech-me/langflow-e2e/actions/runs/29101496495

## Scope

CI-config only — one line (plus an explanatory comment). No test or product-path changes. Discovered while validating #463 via a `daily-stable` dispatch; unrelated root cause, tracked separately per 1-issue/1-PR.

Closes #639
