### PR TITLE
fix(agents): rescope persisted-tool-name check to the test's own flow, restore @stable (#632)

### DIFF
--- a/docs/core-functionality/llm-agents/agent-tool-name-validation.md
+++ b/docs/core-functionality/llm-agents/agent-tool-name-validation.md
@@ -59,8 +59,8 @@ Playground.
 - `models.json` / `providers.json` generated via
   `npx playwright test tests/collect-models.spec.ts`.
 - At least one active provider API key in `.env`.
-- Run with `--workers=1` — the spec is serial
-  (`SimpleAgentTemplatePage.load()` wipes all flows).
+- Run with `--workers=1` — the spec is serial (named template loads collide
+  under parallelism; agent-family convention).
 
 ---
 
@@ -71,8 +71,11 @@ The spec generates **2 tests per active model** via `getTestTargets()`
 `agent-max-iterations.spec.ts`).
 
 Shared setup per test:
-1. Load the Simple Agent template (`SimpleAgentTemplatePage.load()` — wipes
-   existing flows, configures the target provider/model).
+1. Load the Simple Agent template (`SimpleAgentTemplatePage.load()` —
+   configures the target provider/model and returns the created flow's id
+   from the template-instantiation `POST /api/v1/flows/` 201 response; the
+   canvas URL id is transient on 1.11, so this returned id is the only
+   reliable handle).
 2. Open the URL tool's actions modal: the button is scoped to the node —
    `[data-testid^="rf__node-URLComponent"]` → `button_open_actions` — and the
    modal is ready when `btn_close_tools_modal` renders.
@@ -81,11 +84,15 @@ Shared setup per test:
    press `Enter` to commit, and assert the slug cell
    (`.ag-cell[col-id="name_1"]`) reflects the new value before closing
    (`Escape`).
-4. **Verify the persisted name via the API** (`GET /api/v1/flows/{id}` → URL
-   node → `template.tools_metadata.value[0].name`) before running — the modal
+4. **Verify the persisted name via the API** (`GET /api/v1/flows/{id}` with
+   the id returned by `load()` → the flow's single URL node →
+   `template.tools_metadata.value[0].name`) before running — the modal
    normalizes case/spaces, so the assertion targets the normalized form; a
    silently unsaved rename must fail the setup step, not produce a
-   false-positive run.
+   false-positive run. The check is scoped to the test's own flow — it must
+   NOT assume anything about other flows on the instance (#632: a global
+   "exactly 1 URLComponent flow" invariant broke under the daily run, where
+   sibling specs leave their own template flows).
 5. Open the Playground and send a fixed message.
 
 ---
@@ -96,8 +103,11 @@ Shared setup per test:
   `!` characters violate every provider's function-name pattern).
 - `page.allowFlowErrors()` — the failure is intentional.
 - **Validation:** the Playground surfaces an error state for the run and its
-  text matches `/invalid function name|does not match pattern|INVALID_ARGUMENT/i`
-  (covers Google and OpenAI wording). No agent answer is produced.
+  text matches
+  `/invalid function name|does not match pattern|should match pattern|INVALID_ARGUMENT/i`
+  (covers Google, OpenAI and Anthropic wording — Anthropic rejects with
+  `tools.N.custom.name: String should match pattern '^[a-zA-Z0-9_-]{1,128}$'`,
+  probed live on claude-sonnet-5, #632). No agent answer is produced.
 
 ---
 
@@ -132,6 +142,16 @@ Shared setup per test:
   validity differs.
 - **Force-failure check** (CONTRIBUTING §2) run during VERIFY on each hard
   assertion before `@stable`.
+
+---
+
+## Flow cleanup *(required)*
+
+Both tests create a flow via `SimpleAgentTemplatePage.load()`, which does NO
+cleanup (post-#553 contract). The spec tracks every `POST /api/v1/flows` →
+201 id fired during load and deletes them by id in `test.afterEach`
+(id-scoped — never name-based or delete-all). Behavioral force-fail
+contract: no-op the cleanup and the flow count grows.
 
 ---
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-name-validation.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-name-validation.spec.ts
@@ -7,6 +7,7 @@ import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import {
   hasProviderEnvKeys,
   missingProviderEnvKeys,
@@ -43,8 +44,11 @@ const VALID_TOOL_NAME = "fetch_content_renamed";
 // any model call regardless; Test 2 completes in a single cheap turn.
 const TASK = "Reply with exactly: hello from the control test";
 // Provider wording for a rejected function name — Google ("Invalid function
-// name…", INVALID_ARGUMENT) and OpenAI ("string does not match pattern").
-const INVALID_NAME_ERROR = /invalid function name|does not match pattern|INVALID_ARGUMENT/i;
+// name…", INVALID_ARGUMENT), OpenAI ("string does not match pattern") and
+// Anthropic ("tools.N.custom.name: String should match pattern '^[a-zA-Z0-9_-]…'",
+// probed live on claude-sonnet-5 — #632).
+const INVALID_NAME_ERROR =
+  /invalid function name|does not match pattern|should match pattern|INVALID_ARGUMENT/i;
 
 interface ModelRecord {
   provider: string;
@@ -137,9 +141,40 @@ function getTestTargets(): TestTarget[] {
   }));
 }
 
-async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
+// SimpleAgentTemplatePage.load() does NO cleanup (post-#553 contract) — track
+// every flow the load actually creates (POST /api/v1/flows → 201) and delete
+// those ids in afterEach (#605 pattern; this file previously leaked its flows,
+// feeding the daily-run accumulation behind #632).
+const createdFlowIds: string[] = [];
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, { headers: { Authorization: bearer } }).catch(() => {});
+  }
+});
+
+// Loads the Simple Agent template and returns the created flow's id (from the
+// template-instantiation POST 201 response — the canvas URL id is transient
+// on 1.11, so this is the only reliable handle for by-id API reads).
+async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<string> {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {}); // non-JSON / batch payloads
+    }
+  });
   try {
-    await new SimpleAgentTemplatePage(page).load(options);
+    return await new SimpleAgentTemplatePage(page).load(options);
   } catch (e: any) {
     if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
     throw e;
@@ -182,11 +217,11 @@ async function renameUrlTool(page: Page, newName: string): Promise<void> {
 // The rename only matters if it reached the persisted flow document — a lost
 // edit would make the control test vacuous. Polls the flows API for the URL
 // node's tools_metadata name (autosave may lag the UI commit).
-// The canvas URL's flow id can be TRANSIENT on 1.11 (GET by that id 404s), so
-// the flow is resolved from the flows list instead — SimpleAgentTemplatePage
-// wipes all flows on load, so exactly one flow with a URLComponent exists.
+// Scoped to the flow this test created (GET by the id load() returned) — a
+// global "exactly 1 URLComponent flow instance-wide" invariant broke in the
+// daily run, where sibling specs leave their own template flows (#632).
 async function expectPersistedToolName(
-  _page: Page,
+  flowId: string,
   request: APIRequestContext,
   expected: string,
 ): Promise<void> {
@@ -194,15 +229,17 @@ async function expectPersistedToolName(
   await expect
     .poll(
       async () => {
-        const res = await request.get(`/api/v1/flows/?remove_example_flows=true&header_flows=false`, {
+        const res = await request.get(`/api/v1/flows/${flowId}`, {
           headers: { Authorization: bearer },
         });
-        if (res.status() !== 200) return `GET flows -> ${res.status()}`;
-        const flows = await res.json();
-        const urlNodes = (Array.isArray(flows) ? flows : [])
-          .flatMap((f: any) => f.data?.nodes ?? [])
-          .filter((n: any) => n.data?.type === "URLComponent");
-        if (urlNodes.length !== 1) return `expected 1 URLComponent flow, found ${urlNodes.length}`;
+        if (res.status() !== 200) return `GET flow ${flowId} -> ${res.status()}`;
+        const flow = await res.json();
+        const urlNodes = (flow.data?.nodes ?? []).filter(
+          (n: any) => n.data?.type === "URLComponent",
+        );
+        if (urlNodes.length !== 1) {
+          return `expected 1 URLComponent node in flow, found ${urlNodes.length}`;
+        }
         return urlNodes[0]?.data?.node?.template?.tools_metadata?.value?.[0]?.name;
       },
       { timeout: 15000 },
@@ -242,8 +279,8 @@ async function openPlaygroundAndSend(page: Page): Promise<void> {
 
 const targets = getTestTargets();
 
-// SimpleAgentTemplatePage.load() deletes all flows before loading the template;
-// serial mode + --workers=1 keeps the shared instance state deterministic.
+// Named template loads collide under parallelism — this file is serial and
+// the folder is run with --workers=1 (agent-family convention).
 test.describe.configure({ mode: "serial" });
 
 for (const { label, options, skipReason } of targets) {
@@ -252,7 +289,7 @@ for (const { label, options, skipReason } of targets) {
   test.describe(`Agent Tool Name Validation [${label}]`, () => {
     test(
       "an invalid tool name blocks execution with a clear message",
-      { tag: ["@regression", "@agents", "@playground"] },
+      { tag: ["@stable", "@regression", "@agents", "@playground"] },
       async ({ page, request }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(
@@ -260,13 +297,13 @@ for (const { label, options, skipReason } of targets) {
           `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
         );
 
-        await loadAgent(page, options);
+        const flowId = await loadAgent(page, options);
 
         await test.step("rename the URL tool to an invalid function name", async () => {
           await renameUrlTool(page, INVALID_TOOL_NAME);
           await setChatInputText(page, TASK);
           await waitForFlowSaveSettled(page);
-          await expectPersistedToolName(page, request, "invalid_tool_name!!");
+          await expectPersistedToolName(flowId, request, "invalid_tool_name!!");
         });
 
         await test.step("run and assert the clear invalid-name error", async () => {
@@ -291,13 +328,13 @@ for (const { label, options, skipReason } of targets) {
           `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
         );
 
-        await loadAgent(page, options);
+        const flowId = await loadAgent(page, options);
 
         await test.step("rename the URL tool to a valid custom name", async () => {
           await renameUrlTool(page, VALID_TOOL_NAME);
           await setChatInputText(page, TASK);
           await waitForFlowSaveSettled(page);
-          await expectPersistedToolName(page, request, VALID_TOOL_NAME);
+          await expectPersistedToolName(flowId, request, VALID_TOOL_NAME);
         });
 
         await test.step("run and assert a normal answer with no error", async () => {


### PR DESCRIPTION
Fixes #632 (split from daily triage umbrella #629 — approved exception issue, `daily-failure`).

## Root cause

**Product bug ruled out first, per the issue's investigation mandate:**

1. **FK-enforcement hypothesis: disproven.** Commit `668f276` does not exist in upstream `langflow-ai/langflow`, and the installed nightly (1.11.0.dev38) contains **no** `PRAGMA foreign_keys` anywhere in the langflow/lfx packages (only third-party chromadb/bigquery). Flow deletes work on a healthy instance (create + bulk delete probe → 200).
2. **The run's `/api/v1/flows/` 500s are real but orthogonal.** Reproduced deterministically: 6 concurrent bulk deletes → 5×500, container traceback = `sqlite3.OperationalError: database is locked` in `cascade_delete_flow` — the known #599 SQLite lock-contention class under parallel load, not a new regression. They don't cause the accumulation: the leaking specs never attempt deletion at all.
3. **Actual cause — two test defects:**
   - `expectPersistedToolName` asserted a **global invariant** ("exactly 1 URLComponent flow instance-wide") that died with the post-#553 contract: `SimpleAgentTemplatePage.load()` no longer wipes flows, and ~12 sibling llm-agents specs load the Simple Agent template without cleanup, so the daily run accumulates 20+ URLComponent flows (count climbed 20 → 22 → 23 across the three attempts).
   - **Latent second failure CI never reached:** `INVALID_NAME_ERROR` only covered Google/OpenAI wording. Anthropic — which debuted in the daily with the new CI secrets (#600/PR #604) and was the failing target (`[anthropic / claude-sonnet-5]`) — rejects with `tools.N.custom.name: String should match pattern '^[a-zA-Z0-9_-]{1,128}$'` (probed live against the Anthropic API; the Playground surfaces this exact text).

## Fix

- `expectPersistedToolName` rescoped to `GET /api/v1/flows/{id}` with the id `load()` returns (the authoritative `POST /api/v1/flows/` 201 id — the canvas URL id is transient on 1.11). This realigns the code with the spec doc, which already contracted the by-id check.
- `INVALID_NAME_ERROR` broadened with `should match pattern` (Anthropic wording).
- Id-scoped flow cleanup added (`createdFlowIds` listener + `afterEach` `deleteFlow`) — this file previously leaked its flows, feeding the very accumulation that broke it.
- `@stable` restored on "an invalid tool name blocks execution with a clear message" (auto-removed by `4044c74`).
- Stale "load() wipes all flows" comments replaced; spec doc updated (by-id step, Flow cleanup section, Anthropic wording).

## Validation

- **Langflow:** `langflowai/langflow-nightly:latest` → **1.11.0.dev38** (`Langflow Nightly`).
- **Target:** `anthropic / claude-sonnet-5` (the exact failing CI target; google/openai are inactive in collect-models both locally and in CI).
- **CI condition reproduced locally:** a decoy URLComponent flow seeded before running — the old helper fails with "found 2", the rescoped helper passes.
- **Determinism:** 6 green runs `--retries=0 --workers=1` (4-run burst with the decoy present, 1 post-revert, 1 re-verification) — 12/12 test passes, zero flakes.
- **Force-fails (all executed, all failed as expected):**
  - FF1 — error regex mutated to impossible text → Test 1 failed ✓
  - FF2 — control answer assert mutated → Test 2 failed ✓
  - FF3 — helper given a nonexistent flow id → failed with `GET flow → 404` ✓
  - FF4 (behavioral) — cleanup no-op'd → orphan flow count grew +2 ✓
  - Revert proven: `grep FF-MUTATION` → 0 hits + final green run.
- **Flow cleanup verified:** orphan count 0 after every green run (cleanup on = delta 0; cleanup off = +2).
- `npm run typecheck` / `npm run lint`: 0 errors (warnings are the pre-existing baseline).

## Notes

- The `database is locked` bulk-delete 500s remain a product-side robustness issue on the SQLite backend under concurrency (same class as #599); flagged here with reproduction evidence, deliberately not "fixed" test-side.
- `--trace=on` skipped per the known hang on Simple Agent template specs; determinism proven via `--retries=0` bursts + executed force-fails instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)