### PR TITLE
qa-infra(daily): warm MCP server-everything before suite, re-stable get-sum (#463)

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -213,6 +213,56 @@ jobs:
           done
           echo "::warning::go-httpbin at $IP:8080 did not answer; ECHO_BASE_URL left unset (specs use postman-echo.com)."
 
+      # Warm the `@modelcontextprotocol/server-everything` npm package inside the
+      # LANGFLOW container BEFORE any test runs, so the cold `npx` fetch happens
+      # here — outside every test's poll budget — instead of during the test
+      # (#463). The MCP stdio server is spawned by the Langflow backend, so the
+      # npm/npx cache we need to warm lives in the langflow service container, not
+      # in this test-runner container: we can only reach it through Langflow's API.
+      # Registering a throwaway server and hitting `action_count=true` forces the
+      # backend to spawn `npx`, which fetches + caches the package; once cached,
+      # the test's own registration finds tools within its (120s) budget.
+      # Fail-soft: a warm-up failure only logs a warning and deletes the temp
+      # server — the test then falls back to its own budget, no worse than before.
+      - name: Warm MCP server-everything package
+        continue-on-error: true
+        shell: bash
+        run: |
+          BASE="http://localhost:7860"
+          WARM_NAME="warmup-everything"
+          # AUTO_LOGIN is on, but the v2 MCP endpoints still expect a bearer token;
+          # /api/v1/auto_login mints one. Parse with node (no jq in this image).
+          TOKEN="$(curl -sf --max-time 15 "$BASE/api/v1/auto_login" \
+            | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{try{process.stdout.write((JSON.parse(d).access_token||"").toString())}catch{process.stdout.write("")}})')"
+          if [ -z "$TOKEN" ]; then
+            echo "::warning::Could not obtain auth token; skipping MCP warm-up (test uses its own budget)."
+            exit 0
+          fi
+          AUTH="Authorization: Bearer $TOKEN"
+          # Register the throwaway server (same package the test uses).
+          curl -sf --max-time 15 -X POST "$BASE/api/v2/mcp/servers/$WARM_NAME" \
+            -H "$AUTH" -H "Content-Type: application/json" \
+            --data '{"command":"npx","args":["@modelcontextprotocol/server-everything"]}' \
+            >/dev/null || echo "::warning::MCP warm-up registration returned non-2xx (continuing)."
+          # Poll action_count=true (this is what makes the backend actually spawn
+          # npx and count tools) until toolsCount is non-null. Generous 240s budget
+          # — this is the cold fetch we are deliberately paying up front, once.
+          WARMED=0
+          for i in $(seq 1 80); do
+            COUNT="$(curl -sf --max-time 15 "$BASE/api/v2/mcp/servers?action_count=true" -H "$AUTH" \
+              | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{try{const s=JSON.parse(d).find(x=>x.name==="'"$WARM_NAME"'");process.stdout.write(s&&s.toolsCount!=null?String(s.toolsCount):"")}catch{process.stdout.write("")}})')"
+            if [ -n "$COUNT" ]; then
+              echo "MCP server-everything warmed: toolsCount=$COUNT after ~$((i*3))s."
+              WARMED=1
+              break
+            fi
+            sleep 3
+          done
+          [ "$WARMED" -eq 1 ] || echo "::warning::MCP server-everything did not warm within 240s; test falls back to its own budget."
+          # Remove the throwaway server so it never interferes with the specs
+          # (which poll only their own uniquified server name, but keep it clean).
+          curl -sf --max-time 15 -X DELETE "$BASE/api/v2/mcp/servers/$WARM_NAME" -H "$AUTH" >/dev/null || true
+
       - name: Collect models
         run: npx playwright test tests/collect-models.spec.ts --reporter=line
         continue-on-error: true

--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -228,6 +228,11 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
+          # `shell: bash` runs with `-eo pipefail`; disable errexit for this
+          # best-effort step so a transient curl/node failure in a command
+          # substitution (TOKEN/COUNT) doesn't abort the poll loop mid-warm or
+          # skip the final DELETE. Emptiness is checked explicitly below.
+          set +e
           BASE="http://localhost:7860"
           WARM_NAME="warmup-everything"
           # AUTO_LOGIN is on, but the v2 MCP endpoints still expect a bearer token;

--- a/docs/mcp/client/mcp-client-regression.md
+++ b/docs/mcp/client/mcp-client-regression.md
@@ -12,9 +12,11 @@ Validates the full MCP client configuration and tool execution path — without 
 
 ## Tags *(required)*
 
-All tests: `@mcp` `@regression`. Tests 2 (echo tool execution) and 3 (HTTP form registration) additionally carry `@stable`.
+All tests: `@mcp` `@regression`. Tests 2 (unreachable HTTP server), 3 (HTTP form registration), and 4 (numeric `get-sum`) additionally carry `@stable`.
 
-Test 4 (numeric `get-sum`) does **not** carry `@stable` — it was removed in the #461 daily-triage PR because the test depends on the `npx server-everything` MCP server registering its tools in time, which hard-fails the daily suite on cold startup (see #463). Re-add once server startup is reliable in CI.
+Test 4 (numeric `get-sum`) had `@stable` temporarily removed in the #461 daily-triage PR because it depends on the `npx server-everything` MCP server registering its tools in time, which hard-failed the daily suite on cold startup (#463). `@stable` was **re-added** once the daily-stable workflow started warming the `server-everything` package in the Langflow container before the suite runs (the cold `npx` fetch now happens outside the test's poll budget), and the test's poll budget was raised 90s → 120s to cover warm startup with margin.
+
+Test 1 (JSON config → echo tool) shares the same `npx server-everything` dependency and is intentionally **not** `@stable` — it was not in scope for #463.
 
 ---
 
@@ -91,7 +93,7 @@ Test 4 (numeric `get-sum`) does **not** carry `@stable` — it was removed in th
 
 ## Notes *(optional)*
 
-- The npx process takes 5–30 seconds to start. Tests 1 and 4 poll `GET /api/v2/mcp/servers?action_count=true` (up to 90s) until `toolsCount` is non-null before interacting with the canvas node.
+- The npx process takes 5–30 seconds to start once the package is cached. Tests 1 and 4 poll `GET /api/v2/mcp/servers?action_count=true` until `toolsCount` is non-null before interacting with the canvas node — Test 1 up to 90s, Test 4 up to 120s. The daily-stable workflow pre-warms the `server-everything` package in the Langflow container (registering a throwaway server and hitting `action_count=true` before the suite), so the cold `npx` fetch is paid once up front rather than inside a test's budget (#463).
 - Tool dropdown interactions use `page.evaluate((el) => el.click())` instead of Playwright's `.click()` to avoid viewport and overlay constraints.
 - The `get-sum` tool option testid is `get-sum-6-option` — index 6 reflects its position in `server-everything`'s tool list and may shift if the package reorders tools in a future release.
 - Test 2 uses `page.waitForFunction` to confirm the dropdown is genuinely open before asserting zero options, preventing a false-positive where the evaluate click fails silently.

--- a/tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts
@@ -356,11 +356,13 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
   );
 
   test(
-    // @stable removed pending #463 — depends on the `npx server-everything` MCP
-    // server registering its tools in time, which hard-failed the daily suite
-    // (2026-07-01) on cold startup. Re-add once server startup is reliable in CI.
+    // Re-added @stable (#463): the daily-stable workflow now warms the
+    // `npx server-everything` package in the Langflow container before the suite
+    // runs, so the cold npm fetch no longer happens inside this test's poll
+    // budget (which was the 2026-07-01 hard failure). Budget also raised to 120s
+    // below to cover warm startup with margin.
     "selects get-sum tool, provides numeric inputs, and verifies sum in output",
-    { tag: ["@mcp", "@regression"] },
+    { tag: ["@mcp", "@regression", "@stable"] },
     async ({ page }) => {
       // Allow backend errors — npx server may return transient errors while starting
       (page as any).allowFlowErrors();
@@ -411,7 +413,10 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
                 await resp.json();
               return servers.find((s) => s.name === MCP_SERVER_NAME)?.toolsCount ?? null;
             },
-            { timeout: 90000, intervals: [3000] },
+            // 120s (raised from 90s, #463): the daily workflow pre-warms the
+            // server-everything package, so this only needs to cover warm
+            // startup, but the extra margin absorbs a slow re-spawn without flaking.
+            { timeout: 120000, intervals: [3000] },
           )
           .not.toBeNull();
       });


### PR DESCRIPTION
## What

Make the MCP `server-everything` startup reliable in the daily suite, then re-add `@stable` to the `get-sum` test that #461 had temporarily de-stabled.

Three changes:
1. **`daily-stable.yml`** — new fail-soft **"Warm MCP server-everything package"** step that runs after the services are healthy and before the suite. It registers a throwaway MCP server (`warmup-everything`) via the API and polls `action_count=true` (up to 240s) until `toolsCount` is non-null, then deletes it.
2. **`mcp-client-regression.spec.ts`** — re-add `@stable` to the `get-sum` test and raise its tool-discovery poll budget **90s → 120s**.
3. **`docs/mcp/client/mcp-client-regression.md`** — update the **Tags** and **Notes** sections to reflect the warm-up and the re-stabling.

## Why

The `get-sum` test hard-failed the daily `@stable` run on **2026-07-01** (Langflow `1.11.0.dev26`), failing all 3 retries with `expect.poll` on `toolsCount` timing out at 90s (`Received: null`). This is **not a Langflow regression**.

Root cause: the MCP stdio server (`npx @modelcontextprotocol/server-everything`) is spawned **by the Langflow backend, inside its own container** — so the npm/npx cache it needs lives in the `langflow` service container, not in the test runner. On a cold container the first invocation must fetch the package before it can register tools, and a fetch killed mid-download at 90s leaves the cache incomplete, so each retry re-fetches cold. We don't build the Langflow image, so we can't bake the package in — the only lever is to trigger that fetch **once, up front, outside any test's poll budget**.

The warm-up step does exactly that: hitting `action_count=true` forces the backend to spawn `npx` and count tools, which fetches + caches the package. Once cached, the test's own registration finds tools well within budget. It's fail-soft — if warm-up can't get a token or times out, it only logs a warning and the test falls back to its own (now 120s) budget, no worse than before.

## Validation

Ran the full `daily-stable` workflow on this branch via `workflow_dispatch` (safe: dispatch does not write history, auto-remove `@stable`, or open issues):
**Run [29102482760](https://github.com/oriontech-me/langflow-e2e/actions/runs/29102482760)**

- ✅ `Initialize containers` succeeded (this branch is rebased on the go-httpbin pin fix — see below).
- ✅ **Warm-up step succeeded** — log: `MCP server-everything warmed: toolsCount=13`. The package was actually fetched and 13 tools were discovered before the suite ran.
- ✅ **`get-sum` passed on the first attempt** (no retries) — output dialog contained `The sum of 3 and 5 is 8.`
- ✅ All three `@stable` tests in `mcp-client-regression.spec.ts` passed (0 failures in this file).

The run's aggregate `@stable` result is red (22/348), but those failures are a broad, pre-existing mix (provider config, playground, agents, global variables) unrelated to this change — **0 failures in `mcp-client-regression`**.

## Dependency / rebase note

This branch is rebased on `main` including **#640** (`go-httpbin` service tag `v2.23.1` → `2.23.1`, closes #639). That fix was required just to get the daily past `Initialize containers` — without it the suite never starts. It was surfaced while validating this issue but tracked and merged separately per 1-issue/1-PR.

## Follow-up (not in scope)

`mcp-client-agent.spec.ts` (echo via an LLM agent, re-stabled in #638) shares the same `npx server-everything` dependency and benefits from this warm-up. In the validation run it was **flaky**: on the first attempt the agent's playground reply came back as `"Message empty."` instead of the echoed text, and the retry passed. That points at the agent response stage, not MCP tool discovery. Opened #643 as an agnostic investigative line (possible Langflow agent/MCP product behavior vs. model nondeterminism) — out of scope for #463.

Closes #463
