### PR TITLE
fix(settings): repair message-history spec for 1.11 grid drift (#616)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -738,7 +738,7 @@
 
 #### 15.10 Settings and UI Configuration
 - [-] Access Settings page
-- [-] Message history settings
+- [-] Message history settings → `ui-ux/settings-message-history.spec.ts`
 - [x] Change appearance/theme settings — dark/light toggle updates #body.dark class → `ui-ux/settings-theme-toggle.spec.ts`
 - [-] Keyboard shortcuts work in editor
 - [~] All documented shortcuts work

--- a/docs/ui-ux/settings-message-history.md
+++ b/docs/ui-ux/settings-message-history.md
@@ -1,0 +1,127 @@
+# Settings → Messages — history shows sent messages in order with working filters
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+The message-history table on **Settings → Messages** is the operator's audit
+surface for everything exchanged in the Playground. After a two-message agent
+conversation, the test validates that:
+
+1. **The table's column contract holds** — every column the history feature
+   promises (`timestamp`, `text`, `sender`, `sender_name`, `session_id`,
+   `files`, `id`, `flow_id`, `properties`, `category`, `content_blocks`) is
+   present in the grid. The check is **superset-tolerant**: upstream adding
+   new columns (1.11 added `context_id`, `edit`, `duration`,
+   `session_metadata`) must not fail the test; a promised column *removed*
+   must.
+2. **Messages appear newest first** — the backend orders by timestamp DESC
+   by design (`monitor.py` `get_messages` always applies `.desc()`; verified
+   in the 1.11 nightly source) and the grid renders the API order. The old
+   spec asserted ascending ("oldest first"), a premise that no longer holds.
+3. **Content integrity** — both sent prompts appear verbatim in the `text`
+   column; `sender` distinguishes `User` from the machine/agent side.
+4. **Column filters work** — filtering `sender` by "Equals User" leaves only
+   User rows; clearing the filter restores the full row set.
+
+## Virtualization note *(what broke in #616)*
+
+AG Grid **virtualizes columns horizontally**: header cells outside the
+scrolled-into-view region are NOT in the DOM, so
+`expect(locator).toBeVisible()` on a fixed `col-id` fails as "element(s) not
+found" the moment the column set grows wide enough to push that column off
+the initial viewport. That is exactly what happened on the 1.11 nightly — the
+`id` column was never removed (the original 11 columns all still exist; 15
+render in total); four new upstream columns widened the grid past the
+viewport. The column contract is therefore asserted by **collecting all
+`col-id`s while sweeping the grid's horizontal scroll**, never by
+per-column DOM visibility.
+
+---
+
+## Tags *(required)*
+
+`@release` `@workspace` `@api` `@settings`
+
+No `@stable`: the spec was broken on clean main when triaged (#616) and is
+restored under its original tag set; promotion is a separate
+validate-&-promote decision after the fix has soaked.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- `OPENAI_API_KEY` set — the flow is the Simple Agent template driven through
+  `initialGPTsetup` (the test skips without the key).
+- Run with `--workers=1` for local validation (agent-family convention —
+  named template loads collide under parallelism).
+
+---
+
+## Step by step *(required)*
+
+1. Bootstrap to the templates modal, load the **Simple Agent** template, run
+   `initialGPTsetup` (model pinned via `resolveGptModel`, in-dropdown ranking
+   fallback).
+2. Open the Playground; send `Hello, how are you?`; wait for the agent to
+   finish (Stop button appears → hidden) and assert a non-empty response.
+3. Send `What is 2+2?`; same wait + non-empty assertion.
+4. Close the Playground; navigate **Settings → Messages**.
+5. **Column contract:** sweep the grid horizontally collecting every
+   `.ag-header-cell` `col-id`; assert the collected set contains all 11
+   promised columns (superset-tolerant).
+6. **Order:** read all `timestamp` cells (≥ 4 rows expected: 2 user + 2
+   agent); parse and assert descending (newest-first) order.
+7. **Content:** `sender` column contains `User` and a machine/agent value;
+   `text` column contains both prompts verbatim.
+8. **Filter:** click the `sender` header's dedicated filter button
+   (`.ag-header-cell-filter-button` — the old `.ag-icon-menu` + "Filter" tab
+   flow no longer exists on 1.11); pick "Equals", type `User`; assert every
+   remaining row's sender is `User`; clear the value; assert the row count
+   is restored (> filtered, ≥ 4).
+
+---
+
+## Validation criterion *(required)*
+
+- The collected column-id set ⊇ the 11 promised columns.
+- Timestamps render in descending (newest-first) order; ≥ 4 rows after two
+  exchanges.
+- Both prompts present verbatim; `User` and machine senders both present.
+- "Equals User" filter yields only User rows; clearing restores the full set.
+
+---
+
+## Flow cleanup *(required)*
+
+The test creates one flow (Simple Agent template). Every `POST
+/api/v1/flows` → 201 id is tracked and deleted in `test.afterEach`
+(id-scoped — never name-based or delete-all). Deleting the flow also
+cascades its messages, leaving the shared instance clean. Behavioral
+force-fail contract: no-op the cleanup and the flow count grows.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Message editing / deleting through the table (`edit` column actions).
+- Session-scoped views (`session_metadata`, session rename) — covered by the
+  playground session specs.
+- Exact set equality of columns (new upstream columns are tolerated by
+  design — only removals of promised columns fail).
+
+---
+
+## External dependencies *(required)*
+
+- **OpenAI API** — two real agent completions (the conversation whose
+  history is asserted).
+- `tests/helpers/other/initialGPTsetup.ts` + `resolveGptModel` +
+  `data/models.json` (collect-models).
+- AG Grid rendering of the messages table (`.ag-header-cell[col-id]`,
+  `.ag-cell[col-id]`, `.ag-center-cols-viewport` for the horizontal sweep,
+  column-menu filter UI) — Settings → Messages page
+  (`src/frontend/src/pages/SettingsPage/pages/messagesPage/`).

--- a/tests/tests-automations/regression/ui-ux/settings-message-history.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/settings-message-history.spec.ts
@@ -9,7 +9,9 @@
  *
  * Expected Results:
  * - All sent and received messages appear in the message history
- * - Messages are displayed in chronological order (oldest first)
+ * - Messages are displayed newest first (the backend orders by
+ *   timestamp DESC by design — monitor.py get_messages always applies
+ *   .desc(); verified in the 1.11 nightly source, #616)
  * - All columns display correct information: timestamp, text, sender, sender_name,
  *   session_id, files, id, flow_id, properties, category, content_blocks
  * - Message content matches what was sent/received in Playground
@@ -26,11 +28,17 @@ import { expect, test } from "../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { initialGPTsetup } from "../../../helpers/other/initialGPTsetup";
 import { navigateSettingsPages } from "../../../helpers/ui/go-to-settings";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
 import { FlowEditorPage, PlaygroundPage } from "../../../pages";
 
 const FIRST_MESSAGE = "Hello, how are you?";
 const SECOND_MESSAGE = "What is 2+2?";
 
+// The columns the message-history feature promises. Asserted as a REQUIRED
+// SUBSET of the rendered set — upstream adding columns (1.11 added
+// context_id, edit, duration, session_metadata) must not fail the test;
+// removing one of these must (#616).
 const EXPECTED_COLUMNS = [
   "timestamp",
   "text",
@@ -44,6 +52,20 @@ const EXPECTED_COLUMNS = [
   "category",
   "content_blocks",
 ];
+
+// The test creates one flow (Simple Agent template); track every
+// POST /api/v1/flows → 201 id and delete them in afterEach (id-scoped —
+// deleting the flow also cascades its messages, leaving the shared
+// instance clean).
+const createdFlowIds: string[] = [];
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, { headers: { Authorization: bearer } }).catch(() => {});
+  }
+});
 
 test(
   "Settings > Messages displays sent messages in correct order with working filters",
@@ -60,6 +82,22 @@ test(
 
     const flowEditor = new FlowEditorPage(page);
     const playground = new PlaygroundPage(page);
+
+    // Track the flow the template click creates so afterEach can delete it.
+    page.on("response", (resp) => {
+      if (
+        resp.url().includes("/api/v1/flows") &&
+        resp.request().method() === "POST" &&
+        resp.status() === 201
+      ) {
+        resp
+          .json()
+          .then((body: { id?: string }) => {
+            if (body?.id) createdFlowIds.push(body.id);
+          })
+          .catch(() => {}); // non-JSON / batch payloads
+      }
+    });
 
     // Steps 1-2: Create flow from "Simple Agent" template and open Playground
     await awaitBootstrapTest(page);
@@ -107,22 +145,50 @@ test(
       page.getByTestId("settings_menu_header"),
     ).toContainText("Messages");
 
-    // Step 10: Verify the messages table has all required columns
+    // Step 10: Verify the messages table has all required columns.
+    // AG Grid VIRTUALIZES columns horizontally — header cells outside the
+    // scrolled-into-view region are not in the DOM, so per-column
+    // toBeVisible() breaks as soon as upstream adds enough columns to push
+    // one past the viewport (#616: `id` was never removed; four new 1.11
+    // columns pushed it off-screen). Sweep the horizontal scroll collecting
+    // every col-id, then assert the promised set is contained.
+    await expect(page.locator(".ag-header-cell").first()).toBeVisible({
+      timeout: 10000,
+    });
+    const renderedColumnIds = await page.evaluate(async () => {
+      const viewport = document.querySelector(".ag-center-cols-viewport");
+      const seen = new Set<string>();
+      const collect = () => {
+        document.querySelectorAll(".ag-header-cell").forEach((h) => {
+          const id = h.getAttribute("col-id");
+          if (id) seen.add(id);
+        });
+      };
+      collect();
+      const maxScroll = viewport?.scrollWidth ?? 0;
+      for (let x = 0; x <= maxScroll; x += 300) {
+        if (viewport) viewport.scrollLeft = x;
+        await new Promise((r) => setTimeout(r, 100));
+        collect();
+      }
+      if (viewport) viewport.scrollLeft = 0;
+      return [...seen];
+    });
     for (const column of EXPECTED_COLUMNS) {
-      await expect(
-        page.locator(`.ag-header-cell[col-id="${column}"]`),
-      ).toBeVisible({ timeout: 10000 });
+      expect(renderedColumnIds, `column "${column}" missing from the messages grid`).toContain(column);
     }
 
-    // Steps 11-13: Verify chronological order — find user messages and check timestamps
-    // AG Grid rows are rendered as .ag-row elements; timestamp column contains the time values
+    // Steps 11-13: Verify display order — newest first. The backend orders
+    // messages by timestamp DESC by design (monitor.py get_messages always
+    // applies .desc(); verified in the 1.11 nightly source — #616), and the
+    // grid renders the API order.
     const timestampCells = page.locator('.ag-cell[col-id="timestamp"]');
     await expect(timestampCells.first()).toBeVisible({ timeout: 10000 });
 
     const rowCount = await timestampCells.count();
     expect(rowCount).toBeGreaterThanOrEqual(4); // at least: 2 user msgs + 2 agent responses
 
-    // Collect timestamps and verify ascending (chronological) order
+    // Collect timestamps and verify descending (newest-first) order
     const timestamps: number[] = [];
     for (let i = 0; i < rowCount; i++) {
       const rawTimestamp = await timestampCells.nth(i).textContent();
@@ -134,7 +200,7 @@ test(
       }
     }
     for (let i = 1; i < timestamps.length; i++) {
-      expect(timestamps[i]).toBeGreaterThanOrEqual(timestamps[i - 1]);
+      expect(timestamps[i]).toBeLessThanOrEqual(timestamps[i - 1]);
     }
 
     // Step 14: Verify sender values — "User" rows and "Machine"/"AI" rows exist
@@ -166,14 +232,16 @@ test(
     expect(joinedTexts).toContain(SECOND_MESSAGE);
 
     // Steps 16-18: Filter by sender "Equals User"
-    // Hover over the sender column header to reveal the menu icon, then open filter
+    // The header renders a dedicated filter button (.ag-header-cell-filter-button)
+    // that opens the filter popup directly — the old .ag-icon-menu +
+    // "Filter" tab flow no longer exists on the 1.11 nightly (#616).
     await page.hover('.ag-header-cell[col-id="sender"]');
     await page
-      .locator('.ag-header-cell[col-id="sender"] .ag-icon-menu')
+      .locator('.ag-header-cell[col-id="sender"] .ag-header-cell-filter-button')
       .click({ timeout: 5000 });
-
-    // Click the "Filter" tab in the column menu popup
-    await page.getByRole("tab", { name: "Filter" }).click({ timeout: 5000 });
+    await expect(page.locator(".ag-filter").first()).toBeVisible({
+      timeout: 5000,
+    });
 
     // Select "Equals" in the filter type dropdown
     const filterTypeSelect = page.locator(
@@ -185,25 +253,30 @@ test(
     // Type "User" in the filter input
     const filterInput = page.locator('.ag-filter input[type="text"]').first();
     await filterInput.fill("User");
-    await page.waitForTimeout(500); // allow AG Grid to apply debounced filter
 
-    // Step 18: Verify only User messages are displayed
-    const filteredSenderCells = page.locator('.ag-cell[col-id="sender"]');
-    const filteredCount = await filteredSenderCells.count();
+    // Step 18: Verify only User messages are displayed. AG Grid applies the
+    // filter after a debounce and re-renders asynchronously — poll until the
+    // row set settles instead of sleeping a fixed amount (a fixed 500ms read
+    // the grid mid-transition and caught a leftover Machine row).
+    const senderCellLocator = page.locator('.ag-cell[col-id="sender"]');
+    await expect
+      .poll(
+        async () => {
+          const texts = await senderCellLocator.allTextContents();
+          return texts.length > 0 && texts.every((t) => t.trim() === "User");
+        },
+        { timeout: 10000 },
+      )
+      .toBe(true);
+    const filteredCount = await senderCellLocator.count();
     expect(filteredCount).toBeGreaterThan(0);
-
-    for (let i = 0; i < filteredCount; i++) {
-      const senderText = await filteredSenderCells.nth(i).textContent();
-      expect(senderText?.trim()).toBe("User");
-    }
 
     // Steps 19-20: Remove filter value → all messages restored
     await filterInput.clear();
-    await page.waitForTimeout(500); // allow AG Grid to clear the filter
-
-    const restoredSenderCells = page.locator('.ag-cell[col-id="sender"]');
-    const restoredCount = await restoredSenderCells.count();
-    expect(restoredCount).toBeGreaterThan(filteredCount); // should have more rows than filtered
+    await expect
+      .poll(async () => senderCellLocator.count(), { timeout: 10000 })
+      .toBeGreaterThan(filteredCount); // more rows than the filtered set
+    const restoredCount = await senderCellLocator.count();
     expect(restoredCount).toBeGreaterThanOrEqual(4); // back to at least 4 rows
   },
 );


### PR DESCRIPTION
Fixes #616 (`follow-up` — approved exception issue, from the 6-broken-@release batch found during #606).

## Root cause

**The issue's premise was wrong — the `id` column was never removed.** Live scout of the 1.11 nightly grid found all 11 promised columns still present (15 render in total). Three accumulated UI drifts broke the spec:

1. **AG Grid virtualizes columns horizontally** (the reported failure): four new 1.11 columns (`context_id`, `edit`, `duration`, `session_metadata`) widened the grid to ~3000px against a ~990px viewport, pushing `id` outside the rendered region — off-viewport headers are **not in the DOM**, so per-column `toBeVisible()` fails as "element(s) not found".
2. **Display order is newest-first by design**: the backend always applies `.desc()` to the order column (`monitor.py` `get_messages`, verified in the nightly's installed source). The spec asserted ascending ("oldest first") — a dead premise.
3. **The filter UI changed**: the old `.ag-icon-menu` + "Filter" tab flow no longer exists; the header renders a dedicated `.ag-header-cell-filter-button` that opens the filter popup directly.

## Fix

- **Column contract (the decision #616 asked for):** sweep the grid's horizontal scroll collecting every `col-id`, then assert the promised 11 columns as a **required subset** — removals of promised columns fail (drift detection preserved); upstream additions don't (additions are exactly what broke the old exact-inventory check).
- **Order:** assert descending (newest-first), matching the product's deliberate contract.
- **Filter:** dedicated filter button + `expect.poll` for the filtered/restored row sets (the old fixed 500ms sleep read the grid mid-transition and caught a leftover `Machine` row).
- **Flow cleanup:** id-scoped `createdFlowIds` + `afterEach` `deleteFlow` — the spec previously leaked 3 flows per run (proven via behavioral force-fail).
- **New spec doc** `docs/ui-ux/settings-message-history.md` (none existed); QA-CHECKLIST §15.10 bullet updated with the spec path.

## Validation

- **Langflow:** `langflowai/langflow-nightly:latest` → **1.11.0.dev38** (`Langflow Nightly`).
- **Determinism:** 4 green runs `--retries=0 --workers=1` + final post-revert green run + user-side verification.
- **Force-fails (all executed, all failed as expected):**
  - FF1 — fake required column added to the promised set → failed ✓
  - FF2 — order assertion flipped to ascending → failed ✓
  - FF3 — filter poll expecting an impossible sender value → failed ✓
  - FF4 (behavioral) — cleanup no-op'd → orphan flow count grew **+3** ✓
  - Revert proven: `grep FF-MUTATION` → 0 hits + final green run.
- **Flow cleanup verified:** orphan count 0 after every green run.
- `npm run typecheck` / `npm run lint`: 0 errors (warnings are the pre-existing baseline).
- No `@stable` added: the spec keeps its original tags (`@release` `@workspace` `@api` `@settings`); promotion is a separate validate-&-promote decision after the fix has soaked.

## Notes

- All scout/probe residue (flows, messages, API keys' flows) was deleted; instance left at 0 user flows.
- Test consumes 2 real OpenAI completions per run (unchanged from the original design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)