### PR TITLE
fix(playground): sequence session rename against server-side message persistence (#637)

### DIFF
--- a/docs/core-functionality/playground/playground-session-rename.md
+++ b/docs/core-functionality/playground/playground-session-rename.md
@@ -9,7 +9,7 @@
 Verifies the session rename availability rule enforced by the Playground:
 
 ```
-canRenameSession = !isDefaultSession && hasMessages
+canRenameSession = canModifySession && hasMessages   // canModifySession === !isDefaultSession
 ```
 
 When `canRenameSession` is false the rename option is not rendered in the DOM at all (not just hidden). Three scenarios are covered:
@@ -91,4 +91,4 @@ When `canRenameSession` is false the rename option is not rendered in the DOM at
 ## Notes *(optional)*
 
 - Radix `SelectContent` is conditionally rendered — the more-menu must be opened before querying `rename-session-option`; `count()` is used instead of `isVisible()` to assert DOM absence rather than visibility.
-- **Rename-404 race (why Test 3 waits for persistence):** the rename option is enabled from the client message cache, which the build stream fills *before* the messages are committed to the DB. Sending a message and waiting only for the input to clear leaves a window where `PATCH /monitor/messages/session/{old}` runs before any row exists for `{old}` → 404 → the frontend silently keeps the old name and the "renamed label visible" assertion times out. This is the flake tracked in issue #637 (daily #629; recurring 2026-07-02 and 2026-07-10). The fix is not a wider timeout — it polls `GET /monitor/messages` (the same table the PATCH reads) so the rename is sequenced against real persistence, making the test deterministic. The endpoint's 404 itself is correct behavior; the underlying UI enabling rename ahead of the DB commit is a minor client-side robustness gap, handled gracefully (toast) and out of scope for this test.
+- **Rename-404 race (why Test 3 waits for persistence):** the rename option is enabled from the client message cache, which the build stream fills *before* the messages are committed to the DB. Sending a message and waiting only for the input to clear leaves a window where `PATCH /monitor/messages/session/{old}` runs before any row exists for `{old}` → 404 → the frontend silently keeps the old name and the "renamed label visible" assertion times out. This is the flake tracked in issue #637 (daily #629; recurring 2026-07-02 and 2026-07-10). The fix is not a wider timeout — it polls `GET /api/v1/monitor/messages` (the same table the PATCH reads) so the rename is sequenced against real persistence, making the test deterministic. The endpoint's 404 itself is correct behavior; the underlying UI enabling rename ahead of the DB commit is a minor client-side robustness gap, handled gracefully (toast) and out of scope for this test.

--- a/docs/core-functionality/playground/playground-session-rename.md
+++ b/docs/core-functionality/playground/playground-session-rename.md
@@ -1,6 +1,6 @@
 # Playground Session — Rename Availability
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.11.x
 
 ---
 
@@ -43,7 +43,11 @@ When `canRenameSession` is false the rename option is not rendered in the DOM at
 **Test 3 — User-created session with messages: rename must be present and functional**
 
 1. Open the Playground, click `new-chat`, and send a message in the new session
-2. Wait for the bot response
+2. Wait until the new session's message is **durably persisted server-side** —
+   poll `GET /api/v1/monitor/messages?flow_id={flowId}` until at least one
+   message carries a `session_id` other than the flow id (the new session). This
+   gates the rename against the exact table the rename endpoint reads and
+   removes the rename-404 race (see Notes)
 3. Click the more-menu trigger for the session
 4. Assert `rename-session-option` is visible
 5. Click `rename-session-option`, type a new name, and press Enter
@@ -63,7 +67,8 @@ When `canRenameSession` is false the rename option is not rendered in the DOM at
 
 ## External dependencies *(required)*
 
-- `src/frontend/src/components/core/chatComponents/sessionSelector/session-selector.tsx` — `canRenameSession` logic and `data-testid="rename-session-option"`; any change to this conditional or to these testids will break the tests
+- `src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/session-selector.tsx` — `canRenameSession = canModifySession && hasMessages` logic and `data-testid="rename-session-option"`; any change to this conditional or to these testids will break the tests
+- `hasMessages` (`.../chat-header/hooks/use-session-has-messages.ts`) is derived from the **client-side React Query message cache**, which is populated by the build stream — so the rename option becomes available before the messages are committed to the DB. The rename endpoint (`PATCH /api/v1/monitor/messages/session/{old}?new_session_id={new}`) queries the DB and **404s when no rows exist for `{old}` yet**; on 404 the frontend keeps the old name (toast only). Test 3 must therefore wait for server-side persistence before renaming
 - Radix `SelectContent` only renders children when the dropdown is open — the more-menu must be clicked before asserting the absence of `rename-session-option`
 
 ---
@@ -86,3 +91,4 @@ When `canRenameSession` is false the rename option is not rendered in the DOM at
 ## Notes *(optional)*
 
 - Radix `SelectContent` is conditionally rendered — the more-menu must be opened before querying `rename-session-option`; `count()` is used instead of `isVisible()` to assert DOM absence rather than visibility.
+- **Rename-404 race (why Test 3 waits for persistence):** the rename option is enabled from the client message cache, which the build stream fills *before* the messages are committed to the DB. Sending a message and waiting only for the input to clear leaves a window where `PATCH /monitor/messages/session/{old}` runs before any row exists for `{old}` → 404 → the frontend silently keeps the old name and the "renamed label visible" assertion times out. This is the flake tracked in issue #637 (daily #629; recurring 2026-07-02 and 2026-07-10). The fix is not a wider timeout — it polls `GET /monitor/messages` (the same table the PATCH reads) so the rename is sequenced against real persistence, making the test deterministic. The endpoint's 404 itself is correct behavior; the underlying UI enabling rename ahead of the DB commit is a minor client-side robustness gap, handled gracefully (toast) and out of scope for this test.

--- a/docs/core-functionality/playground/playground-session-rename.md
+++ b/docs/core-functionality/playground/playground-session-rename.md
@@ -67,7 +67,7 @@ When `canRenameSession` is false the rename option is not rendered in the DOM at
 
 ## External dependencies *(required)*
 
-- `src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/session-selector.tsx` — `canRenameSession = canModifySession && hasMessages` logic and `data-testid="rename-session-option"`; any change to this conditional or to these testids will break the tests
+- `src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/session-selector.tsx` — `canRenameSession = canModifySession && hasMessages` logic (where `canModifySession === !isDefaultSession`, as noted above) and `data-testid="rename-session-option"`; any change to this conditional or to these testids will break the tests
 - `hasMessages` (`.../chat-header/hooks/use-session-has-messages.ts`) is derived from the **client-side React Query message cache**, which is populated by the build stream — so the rename option becomes available before the messages are committed to the DB. The rename endpoint (`PATCH /api/v1/monitor/messages/session/{old}?new_session_id={new}`) queries the DB and **404s when no rows exist for `{old}` yet**; on 404 the frontend keeps the old name (toast only). Test 3 must therefore wait for server-side persistence before renaming
 - Radix `SelectContent` only renders children when the dropdown is open — the more-menu must be clicked before asserting the absence of `rename-session-option`
 

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-rename.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-rename.spec.ts
@@ -144,10 +144,11 @@ test.describe("Playground – Session Rename (B2)", () => {
           // 404s when no rows exist for {old} yet — on 404 the frontend keeps
           // the old name (toast only), so the renamed label never appears and
           // the assertion below times out. This is the #637 flake. Poll the
-          // SAME table the PATCH reads (GET /monitor/messages) until the new
-          // session's message is queryable, sequencing the rename against real
-          // persistence instead of widening a timeout. The new session's rows
-          // carry a session_id other than the flow id (the Default Session).
+          // SAME table the PATCH reads (GET /api/v1/monitor/messages) until the
+          // new session's message is queryable, sequencing the rename against
+          // real persistence instead of widening a timeout. The new session's
+          // rows carry a session_id other than the flow id (the Default
+          // Session).
           await expect
             .poll(
               async () => {

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-rename.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-rename.spec.ts
@@ -135,6 +135,40 @@ test.describe("Playground – Session Rename (B2)", () => {
       );
 
       await test.step(
+        "Wait until the new session's message is durably persisted server-side",
+        async () => {
+          // The rename option is enabled from the client-side React Query
+          // message cache, which the build stream fills BEFORE the messages are
+          // committed to the DB. The rename endpoint
+          // (PATCH /api/v1/monitor/messages/session/{old}) reads the DB and
+          // 404s when no rows exist for {old} yet — on 404 the frontend keeps
+          // the old name (toast only), so the renamed label never appears and
+          // the assertion below times out. This is the #637 flake. Poll the
+          // SAME table the PATCH reads (GET /monitor/messages) until the new
+          // session's message is queryable, sequencing the rename against real
+          // persistence instead of widening a timeout. The new session's rows
+          // carry a session_id other than the flow id (the Default Session).
+          await expect
+            .poll(
+              async () => {
+                const resp = await page.request.get(
+                  `/api/v1/monitor/messages?flow_id=${createdFlowId}`,
+                );
+                if (!resp.ok()) return 0;
+                const messages = (await resp.json()) as Array<{
+                  session_id: string;
+                }>;
+                return messages.filter(
+                  (m) => m.session_id !== createdFlowId,
+                ).length;
+              },
+              { timeout: 15000, intervals: [250, 500, 1000] },
+            )
+            .toBeGreaterThan(0);
+        },
+      );
+
+      await test.step(
         "Open the session more-menu and verify rename option is available",
         async () => {
           await page

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-rename.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-rename.spec.ts
@@ -144,7 +144,8 @@ test.describe("Playground – Session Rename (B2)", () => {
           // 404s when no rows exist for {old} yet — on 404 the frontend keeps
           // the old name (toast only), so the renamed label never appears and
           // the assertion below times out. This is the #637 flake. Poll the
-          // SAME table the PATCH reads (GET /api/v1/monitor/messages) until the
+          // SAME table the PATCH reads (GET
+          // /api/v1/monitor/messages?flow_id=...) until the
           // new session's message is queryable, sequencing the rename against
           // real persistence instead of widening a timeout. The new session's
           // rows carry a session_id other than the flow id (the Default


### PR DESCRIPTION
**Fixes #637.**

## Problem
The 3rd test of `playground-session-rename.spec.ts` — *"rename option must be available and functional for a session with messages"* — flaked (recovered on retry) in the daily-stable workflow on **2026-07-02** and **2026-07-10** (umbrella #629). The renamed label `"my renamed session"` failed to appear (5s timeout), with a **correlated backend 404** on `PATCH /api/v1/monitor/messages/session/New%20Session%200?new_session_id=my+renamed+session`.

**Root cause — client-side persistence race, not a broken endpoint.** The rename endpoint is correct (`monitor.py:359-375`): it queries `MessageTable` by `session_id` and returns a legitimate 404 when no rows exist. But:
- `createSession()` creates the session **local-only** (`New Session 0`) — no server round-trip (`use-session-manager.ts`).
- The rename option is gated by `hasMessages`, read from the **client-side React Query message cache** (`use-session-has-messages.ts`), which the build stream fills **before** the messages are committed to the DB.
- Renaming in that window makes the PATCH run before any row exists for `{old}` → 404 → `renameSession` catches, shows a toast, and does **not** update the store (keeps the old name) → the label never changes → the assertion times out.

Causation is direct (same endpoint as the rename call → old name retained), confirmed by source reading and reproduced locally (1 failure on the first isolated run; passes otherwise). It is a **test-side race**: the test renamed right after the input cleared, a signal of submit — not of persistence.

## Fix
Add a step between sending the message and renaming that **polls `GET /api/v1/monitor/messages` — the same table the PATCH reads** — until the new session's message is queryable server-side. This sequences the rename against real persistence and is deterministic by construction.

- **Rejected alternative:** widening the assertion timeout — it does not address the 404 and would risk blessing a truly-broken rename path (per the issue mandate).
- The endpoint's 404 is correct; the underlying UI enabling rename ahead of the DB commit is a minor client-side robustness gap, handled gracefully (toast) and out of scope here. Documented in the spec doc in case we want to flag it upstream.

## Scope note
Tests 1 and 2 (rename absent for Default Session / no-message session) are unchanged. Test 3's assertions (Enter confirms, Escape cancels) are unchanged — only the persistence gate was added. `@stable` retained (flaky, per the daily triage policy). No `QA-CHECKLIST.md` change (auto-generated `@stable` block unchanged).

## Validation (Langflow 1.11.0, `--retries=0`)
- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors)
- Test #3 burst: **10/10 clean, no flake, zero `🚨 Backend Error`** ✅
- Full file (3 tests, serial): **3 passed (22.5s)** ✅
- **Force-fail (all executed, observed failing, reverted — 0 mutation markers in diff):**
  - Default Session `toHaveCount(0)`→`(1)` → failed ✅
  - No-message session `toHaveCount(0)`→`(1)` → failed ✅
  - Renamed-label assertion → wrong text → timeout/fail ✅
  - Persistence gate `toBeGreaterThan(0)`→`(999)` → gate step timed out (proves it executes and blocks) ✅
- id-scoped `afterEach` cleanup verified — no orphan flows leaked (the only `New Flow` present is an unmodified Langflow example flow).

> Note: `--trace=on` skipped per the documented local-hang limitation on playground/flow-canvas specs; step verification covered by the `--retries=0` bursts + force-fails. Validated against the running **1.11.0** build (docker not reachable in this shell to refresh nightly); the rename logic in `release-1.11.0` is identical to source and the fix is version-agnostic (gates on the backend contract).