### PR TITLE
fix(agents): decouple multi-tool URL fetch from httpbin availability (#631)

### DIFF
--- a/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
+++ b/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
@@ -60,6 +60,26 @@ usefulness contract of multi-tool agents.
 the agent's toolset; `@agents` — agent tool-calling behavior; `@playground` —
 the run and the reply observable live in the Playground.
 
+**@stable removed then restored (#631).** On the 2026-07-10 daily the fetch test
+hard-failed because `httpbin.org` returned sustained 503s/timeouts — the tool
+executed and Langflow surfaced the upstream error correctly (no product bug), but
+the deterministic-title assert cannot pass when the third-party endpoint is down.
+The daily's `auto-remove-stable` stripped `@stable` from the fetch test only.
+Root cause (verified live on `1.11.0.dev38`): httpbin.org was reachable only
+~1 in 3 attempts *from the Langflow container's network*, so the `fetch_content`
+tool hung/timed out and the run ended with an empty reply (the "Message empty."
+placeholder) — the same symptom as #634, but here driven by endpoint
+unavailability, not a UI-only race. Two-part fix: (1) route the fetch through
+the daily's self-hosted go-httpbin via `ECHO_BASE_URL` (see External
+dependencies); (2) assert the deterministic title on the **persisted
+`fetch_content` tool output** (monitor API) instead of the live bubble (which
+shows the empty placeholder mid-run) or the model's prose (recitable from
+memory) — the tool output proves the real fetch and fails when the endpoint is
+unreachable. The completed-but-empty final turn is left to #634 (not asserted
+here). Validated on `1.11.0.dev38`: clean `--retries=0` runs via go-httpbin on
+`gpt-4o-mini` + force-fail M2. Then `@stable` restored. The search test was
+unaffected (never depended on httpbin).
+
 ---
 
 ## Preconditions *(optional)*
@@ -94,11 +114,25 @@ describe with two tests:
    finish (Stop button hidden).
 5. **Selection assert (API):** poll `GET /api/v1/monitor/messages` — find the
    user message with the nonce, take its `session_id`, find the session's AI
-   message; its `tool_use` blocks must include `fetch_content` and must NOT
-   include `perform_search`.
-6. **Execution assert (UI):** the final AI bubble (`div-chat-message`)
-   contains `Sample Slide Show` — the deterministic title served by
-   httpbin.org/json (proves the tool ran and its output reached the answer).
+   message; its **first** `tool_use` block must be `fetch_content` (first call is
+   the selection decision; extra follow-up calls are tolerated — see the
+   first-call note above).
+6. **Execution assert:** a reply bubble renders in the Playground
+   (`div-chat-message` visible), and — asserted on the **persisted** run (monitor
+   API, same nonce-keyed session lookup as step 5) — the `fetch_content`
+   `tool_use` block's **OUTPUT** contains `Sample Slide Show`, the deterministic
+   title served by the `/json` endpoint. This proves the tool actually fetched
+   the real payload (the #631 root cause was the endpoint unreachable from the
+   backend → the tool returned an error/nothing, never the slideshow). Two
+   deliberate choices: (a) assert the persisted tool output, **not** the live
+   bubble, which shows the empty placeholder ("Message empty.") mid-run and races
+   the stream (#631); (b) assert the tool **OUTPUT**, **not** the model's prose —
+   the slideshow title is a famous httpbin fixture a model can recite from
+   memory, so a prose check could false-pass even if the fetch failed. A
+   completed-but-empty final reply ("Message empty.") is NOT asserted here: it is
+   a rare model-side behavior tracked as a flake in #634, and this test's
+   contract (tool selection + execution) is fully proven by step 5 + this output
+   assert without coupling to it.
 7. No `allowFlowErrors` — any flow error fails the test via the fixture.
 
 **Test 2 — search prompt selects the Web Search tool (§6.4)**
@@ -108,8 +142,8 @@ describe with two tests:
    framework and summarize one headline. (probe `<nonce>`)"*.
 4. Open the Playground, send, wait for the run to finish.
 5. **Selection assert (API):** same nonce-keyed monitor lookup; the AI
-   message's `tool_use` blocks must include `perform_search` and must NOT
-   include `fetch_content`.
+   message's **first** `tool_use` block must be `perform_search` (first-call
+   design; extra follow-up calls tolerated).
 6. **Execution assert (UI):** the final AI bubble is visible and non-empty
    (search result content is inherently non-deterministic — the selection
    assert in step 5 is the concrete observable; see false-positive notes).
@@ -122,8 +156,10 @@ describe with two tests:
 Per prompt, the **first** `tool_use` block persisted for the run's
 nonce-keyed session names the expected tool (`fetch_content` for the fetch
 prompt, `perform_search` for the search prompt) — plus, for the fetch
-prompt, the reply contains the endpoint's deterministic `Sample Slide Show`
-title. First-call is the distinctive observable: a wrong-tool run fails on
+prompt, the `fetch_content` tool_use block's **output** contains the
+endpoint's deterministic `Sample Slide Show` title (asserted on the tool
+output, not the model prose, so a from-memory recitation cannot mask a failed
+fetch). First-call is the distinctive observable: a wrong-tool run fails on
 its very first block even when the model salvages a correct-looking answer
 later; extra follow-up calls (provider-side style drift) do not pass a
 wrong first choice.
@@ -149,8 +185,11 @@ wrong first choice.
   produces no flow error, so the test still measures what it claims.
 - **Force-failure checks** (CONTRIBUTING §2): M1 — expect the sibling tool
   as first call in test 1 ⇒ selection assert must fail; M2 — assert an
-  impossible title (e.g. `Sample Slide Show XYZ`) ⇒ execution assert must
-  fail; M3 — same first-call swap in test 2 ⇒ must fail.
+  impossible title (e.g. `Sample Slide Show XYZ`) ⇒ the `fetch_content`
+  tool-output execution assert must fail (verified against go-httpbin: the assert
+  surfaced the real tool output containing *"title": "Sample Slide Show"* and
+  failed the impossible pattern); M3 — same first-call swap in test 2 ⇒ must
+  fail.
 
 ---
 
@@ -169,8 +208,17 @@ wrong first choice.
 
 - **LLM provider API** (per `models.json` target): one completion with one
   tool round-trip per test.
-- **httpbin.org** (test 1) — repo-standard deterministic HTTP endpoint
-  (`/json` → fixed `Sample Slide Show` payload).
+- **URL-tool fetch endpoint** (test 1) — `${ECHO_BASE_URL}/json`, defaulting to
+  `https://httpbin.org/json` (fixed `Sample Slide Show` payload). httpbin.org is
+  chronically unreliable (sustained 503s/timeouts hard-failed this test on the
+  2026-07-10 daily — #631), so the daily workflow self-hosts a go-httpbin service
+  and exports `ECHO_BASE_URL` to its container IP; go-httpbin's `/json` serves the
+  identical `Sample Slide Show` slideshow, keeping the content assert deterministic
+  while removing the third-party-availability dependency in CI. The env-var names
+  (`ECHO_BASE_URL` / `HTTPBIN_BASE_URL`) match the ones `daily-stable.yml` already
+  exports — no workflow change was needed. **Note the endpoint runs the fetch from
+  Langflow's backend, so a private-IP override must be in `LANGFLOW_SSRF_ALLOWED_HOSTS`
+  (the daily already allows the RFC-1918 CIDRs).**
 - **Web search backend** (test 2) — the `UnifiedWebSearch` component's live
   search; only tool *selection* is asserted, never result content.
 - `tests/helpers/provider-setup/data/models.json` + `providers.json`

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-multi-tool-selection.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-multi-tool-selection.spec.ts
@@ -34,15 +34,32 @@ import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-
  * naming any tool: tool USE is instructed (a from-memory answer would flake
  * the positive half), tool CHOICE is the agent's — the behavior under test.
  * Search result content is never asserted (non-deterministic); the fetch
- * prompt additionally asserts httpbin.org/json's fixed "Sample Slide Show"
- * title reached the reply.
+ * prompt additionally asserts the URL endpoint's fixed "Sample Slide Show"
+ * title reached the reply (see FETCH_URL — httpbin.org by default, go-httpbin
+ * in the daily; both serve the identical /json slideshow).
  */
 
 if (!process.env.CI) {
   dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
 }
 
-const FETCH_URL = "https://httpbin.org/json";
+// URL-tool fetch target. Defaults to the public httpbin.org, overridable via
+// ECHO_BASE_URL / HTTPBIN_BASE_URL. httpbin.org is chronically unreliable —
+// sustained 503s/timeouts hard-failed this test on the 2026-07-10 daily (#631),
+// and broke the API-request suite repeatedly (#383/#407/#462). The daily
+// workflow self-hosts a go-httpbin service and exports ECHO_BASE_URL to its
+// container IP (see daily-stable.yml + api-request-component-regression.spec.ts),
+// so CI fetches an in-network, httpbin-compatible endpoint instead of the flaky
+// public host. go-httpbin's /json serves the IDENTICAL "Sample Slide Show"
+// slideshow (httpbin/static/sample.json), so the deterministic-title assertion
+// below holds against either backend. The env-var names match the ones the daily
+// already exports, so no workflow change is needed to pick this up.
+const HTTPBIN_BASE = (
+  process.env.ECHO_BASE_URL ??
+  process.env.HTTPBIN_BASE_URL ??
+  "https://httpbin.org"
+).replace(/\/$/, "");
+const FETCH_URL = `${HTTPBIN_BASE}/json`;
 const URL_TOOL = "fetch_content";
 const SEARCH_TOOL = "perform_search";
 const EXPECTED_TITLE = /Sample Slide Show/i;
@@ -278,6 +295,72 @@ async function expectToolSelectionPersisted(
     .toBe("correct-tool-selected");
 }
 
+// Execution check via the persisted monitor messages (nonce-keyed), NOT the
+// live playground bubble. The bubble renders the empty placeholder
+// ("Message empty.", the frontend's EMPTY_OUTPUT_SEND_MESSAGE) while the agent is
+// mid-tool-execution, and a multi-tool run can take 40s+; asserting the live
+// bubble therefore races the stream and the run's own completion signal
+// (`waitForAgentToFinish` can return between tool phases) — the #631
+// "Message empty." failure mode. The persisted messages appear only once the run
+// completes, so polling them is both the completion gate AND a race-free assert.
+//
+// The observable is the `fetch_content` tool_use block's OUTPUT matching
+// `expectedOutput` — proving the tool actually fetched the real endpoint payload.
+// This is the sharp #631 signal: the root cause was httpbin unreachable from the
+// backend, so the tool returned an error/nothing, never the slideshow. Asserting
+// the tool OUTPUT, not the model's prose, is deliberate: the slideshow title is a
+// famous httpbin fixture a model can recite from memory, so a prose check could
+// false-pass even if Langflow dropped the tool output (the product-bug masking
+// #631's mandate warns against). Mirrors `agent-current-date-tool.spec.ts`
+// (assert the tool output, never prose). We deliberately do NOT also require a
+// non-empty final reply: a completed-but-empty final turn ("Message empty.") is a
+// rare, model-side behavior tracked separately as a flake in #634 — coupling it
+// here would re-import that flakiness into a test whose contract is tool
+// selection + execution, both fully proven by the selection assert + this one.
+async function expectFetchToolReturned(
+  request: APIRequestContext,
+  nonce: string,
+  toolName: string,
+  expectedOutput: RegExp,
+): Promise<void> {
+  const bearer = await getAuthToken(request);
+  await expect
+    .poll(
+      async () => {
+        const res = await request.get("/api/v1/monitor/messages", {
+          headers: { Authorization: bearer },
+        });
+        if (res.status() !== 200) return `GET monitor -> ${res.status()}`;
+        const messages = await res.json();
+        if (!Array.isArray(messages)) return "monitor payload not a list";
+
+        const userMsg = messages.find(
+          (m: any) => m.sender !== "Machine" && (m.text ?? "").includes(nonce),
+        );
+        if (!userMsg) return "user message with nonce not persisted yet";
+
+        const aiMsgs = messages.filter(
+          (m: any) => m.sender === "Machine" && m.session_id === userMsg.session_id,
+        );
+        if (aiMsgs.length === 0) return "AI message for the session not persisted yet";
+
+        const toolOutputs = aiMsgs
+          .flatMap((m: any) => (m.content_blocks ?? []) as any[])
+          .flatMap((b: any) => (b.contents ?? []) as any[])
+          .filter((c: any) => c.type === "tool_use" && c.name === toolName)
+          .map((c: any) => JSON.stringify(c.output ?? ""));
+        if (toolOutputs.length === 0)
+          return `no ${toolName} tool_use block persisted yet`;
+
+        return toolOutputs.some((o) => expectedOutput.test(o))
+          ? "fetch-tool-returned-expected"
+          : `${toolName} output did not contain ${expectedOutput}: ${toolOutputs[0].slice(0, 200)}`;
+      },
+      { timeout: 90000 },
+    )
+    .toBe("fetch-tool-returned-expected");
+}
+
 const targets = getTestTargets();
 
 // Serial mode + --workers=1 keeps the shared instance state deterministic
@@ -291,7 +374,7 @@ for (const { label, options, skipReason } of targets) {
   test.describe(`Agent Multi-Tool Selection [${label}]`, () => {
     test(
       "agent selects the URL tool for a fetch prompt",
-      { tag: ["@regression", "@agents", "@playground"] },
+      { tag: ["@stable", "@regression", "@agents", "@playground"] },
       async ({ page, request }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(
@@ -314,10 +397,14 @@ for (const { label, options, skipReason } of targets) {
           await openPlaygroundAndSend(page, task);
         });
 
-        await test.step("execution: the reply carries httpbin's deterministic slideshow title", async () => {
+        await test.step("execution: fetch_content's output carries the deterministic slideshow title", async () => {
+          // A reply bubble renders in the Playground (interaction observable)…
           const bubble = page.getByTestId("div-chat-message").last();
           await expect(bubble).toBeVisible({ timeout: 30000 });
-          await expect(bubble).toContainText(EXPECTED_TITLE, { timeout: 30000 });
+          // …but assert the title on the PERSISTED fetch tool OUTPUT (monitor),
+          // not the live bubble (empty placeholder mid-run, #631) nor the model's
+          // prose (recitable from memory): the tool output proves the real fetch.
+          await expectFetchToolReturned(request, nonce, URL_TOOL, EXPECTED_TITLE);
         });
 
         await test.step("selection: the FIRST tool call is fetch_content", async () => {


### PR DESCRIPTION
## What this fixes

Closes #631.

The `agent-multi-tool-selection.spec.ts` → **"agent selects the URL tool for a fetch prompt"** test hard-failed on the 2026-07-10 daily (attempt 1 rendered `"Message empty."`, attempts 2–3 reported an httpbin `503`) and had `@stable` auto-removed by `4044c74`.

## Root cause (verified live on `1.11.0.dev38`)

Following the issue's "distrust everything" mandate, a Langflow product bug was ruled out first:

- The Langflow **container** reached `https://httpbin.org/json` only **~1 of 3 attempts** (two 12s timeouts). When httpbin is unreachable from the backend network, the `fetch_content` tool hangs/times out and the run ends with an **empty reply** — which the frontend renders as the `"Message empty."` placeholder (`EMPTY_OUTPUT_SEND_MESSAGE`).
- No product bug: no 4xx/5xx on the run path, monitor messages persist `state: complete` / `error: null`, and when the tool *did* return the error, Langflow surfaced it correctly. The failure is the **live third-party dependency** plus a content assertion that **raced the stream** by reading the live playground bubble (which shows the empty placeholder mid-run).

## Fix

1. **Remove the httpbin-availability dependency in CI.** `FETCH_URL` now derives from `ECHO_BASE_URL` / `HTTPBIN_BASE_URL` (default `https://httpbin.org`) — the **exact env var `daily-stable.yml` already exports** for its self-hosted `go-httpbin` service. go-httpbin's `/json` serves the identical `Sample Slide Show` slideshow (`httpbin/static/sample.json`), so the daily fetches an in-network, reliable endpoint. **No workflow change needed.**
2. **Race-free, memory-proof content assertion.** The execution step now asserts the persisted **`fetch_content` tool_use OUTPUT** (monitor API) contains the title, instead of the live bubble. This proves the *real* fetch (the slideshow title is a famous httpbin fixture a model can recite from memory — a prose-only check could false-pass even if the fetch failed, the exact masking the mandate warns against) and fails when the endpoint is unreachable. Mirrors the sibling `agent-current-date-tool.spec.ts`.
3. The rare completed-but-empty final turn is left to **#634** (not coupled here, to avoid re-importing its flakiness).
4. `@stable` **restored** on the fetch test; spec doc updated.

## Tests

| # | Teste | O que faz | O que valida (observável concreto) |
|---|---|---|---|
| 1 | `agent selects the URL tool for a fetch prompt` | Carrega o Simple Agent, força uso de tool, manda "Fetch `${ECHO_BASE_URL}/json` …" no Playground | (a) 1º `tool_use` da sessão (nonce) é `fetch_content`; (b) o **output** desse `tool_use` contém `/Sample Slide Show/i` (via monitor) |
| 2 | `agent selects the Web Search tool for a search prompt` | (inalterado) manda prompt de busca | 1º `tool_use` é `perform_search`; balão final não-vazio |

**FF (executados):**
- `FF M1/M2`: mutando `EXPECTED_TITLE` → `/Sample Slide Show FORCEFAIL/i`, a asserção de execução **falhou** com `fetch_content output did not contain …: {"content": …}` (prova falsificável, lendo o output real do tool).
- Reliability: **3/3** runs limpas `--retries=0` via go-httpbin (`gpt-4o-mini`); sibling search test verde.

## Validation

- Langflow: `langflowai/langflow-nightly:latest` = **1.11.0.dev38**
- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors)
- Content asserted against a self-hosted `go-httpbin:2.23.1` reachable by the backend (SSRF-allowlisted RFC-1918), mirroring `daily-stable.yml`.
- Flow cleanup verified: id-scoped `afterEach` leaves no orphans (`GET /api/v1/flows/` — only shipped starter examples remain).

## Run it

```bash
ECHO_BASE_URL="http://<go-httpbin-ip>:8080" MODEL_TEST_ID=gpt-4o-mini \
  npx playwright test tests/tests-automations/regression/core-functionality/llm-agents/agent-multi-tool-selection.spec.ts \
  --workers=1 --grep "agent selects the URL tool for a fetch prompt" --debug
```
