### PR TITLE
fix(agents): assert playground reply on the persisted message, not the racy live bubble (#634)

### DIFF
--- a/docs/core-functionality/llm-agents/agent-tool-error-handling.md
+++ b/docs/core-functionality/llm-agents/agent-tool-error-handling.md
@@ -86,7 +86,14 @@ machinery as `agent-max-iterations.spec.ts` / `agent-tool-name-validation.spec.t
    version value it returns. (probe `<nonce>`)"* — the per-run nonce keys the
    monitor-API lookup to THIS run's session.
 4. Open the Playground, send, wait for the run to finish.
-5. **Continuation assert (UI):** the final AI bubble contains `TOOL_FAILED`.
+5. **Continuation assert (two-stage):** first gate on the **persisted** final
+   reply (monitor API, nonce-keyed session) containing `TOOL_FAILED` — a
+   race-free completion signal, because the live bubble shows the empty
+   placeholder ("Message empty.") mid-run and a run can outlast the assert window
+   (the #634 flaky symptom). **Then**, with the run confirmed complete,
+   re-assert the live bubble also contains `TOOL_FAILED` — this keeps end-to-end
+   UI coverage (a bubble stuck on "Message empty." while the reply persisted is a
+   real frontend bug and must still fail) without reintroducing the stream race.
 6. **Tool-error assert (API):** poll `GET /api/v1/monitor/messages` — find
    the user message containing the nonce, take its `session_id`, find that
    session's AI message, and assert its `fetch_content` `tool_use` block's

--- a/docs/core-functionality/model-provider/openai-provider.md
+++ b/docs/core-functionality/model-provider/openai-provider.md
@@ -88,9 +88,18 @@ Settings) · `@agents` + `@playground` (Test 2 executes an agent).
    `input-chat-playground`.
 5. Send `Repeat this token exactly and nothing else: OPENAI-<sentinel>`; wait for
    the agent to finish (`waitForAgentToFinish`).
-6. **Validation:** the last `div-chat-message` (AI bubble) **contains**
-   `OPENAI-<sentinel>` — the configured OpenAI provider, on a selected GPT model,
-   executed the flow to produce this run's token (bullet §7.2.3).
+6. **Validation (two-stage):** first gate on the **persisted** reply (monitor
+   API — the token is unique per run and appears in both the user prompt and the
+   echoed reply, so it keys the session lookup and is the content assert)
+   **containing** `OPENAI-<sentinel>` — a race-free completion signal, because
+   the live bubble shows the empty placeholder ("Message empty.") while the model
+   streams and `waitForAgentToFinish` can return before the final text lands (the
+   #634 flaky symptom). **Then**, with the run confirmed complete, re-assert the
+   live bubble also echoes the token — keeping end-to-end UI coverage (a bubble
+   stuck on "Message empty." while the reply persisted is a real frontend bug and
+   must still fail) without the stream race. This proves the configured OpenAI
+   provider, on a selected GPT model, executed the flow to produce this run's
+   token (bullet §7.2.3).
 
 ---
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-error-handling.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-error-handling.spec.ts
@@ -233,6 +233,54 @@ async function expectToolErrorPersisted(
     .toBe("tool-error-persisted");
 }
 
+// Assert the agent's continuation reply carries `expected` on the PERSISTED
+// message (monitor API, nonce-keyed session), NOT the live playground bubble.
+// The bubble renders the empty placeholder ("Message empty.", the frontend's
+// EMPTY_OUTPUT_SEND_MESSAGE) while the agent is mid-execution, and a run can
+// outlast the old 30s bubble window / return between phases from
+// `waitForAgentToFinish` — so reading the live bubble races the stream, which
+// was the #634 flaky "Message empty." symptom (verified: no backend 5xx, monitor
+// state=complete; the empty bubble is a streaming/empty-turn artifact, not a
+// product error). The persisted reply appears only once the run completes, so
+// polling it is a race-free completion gate. A genuinely empty final turn (rare,
+// model-side, tracked in #634) still fails here rather than silently passing.
+async function expectReplyContainsPersisted(
+  request: APIRequestContext,
+  nonce: string,
+  expected: RegExp,
+): Promise<void> {
+  const bearer = await getAuthToken(request);
+  await expect
+    .poll(
+      async () => {
+        const res = await request.get("/api/v1/monitor/messages", {
+          headers: { Authorization: bearer },
+        });
+        if (res.status() !== 200) return `GET monitor -> ${res.status()}`;
+        const messages = await res.json();
+        if (!Array.isArray(messages)) return "monitor payload not a list";
+
+        const userMsg = messages.find(
+          (m: any) => m.sender !== "Machine" && (m.text ?? "").includes(nonce),
+        );
+        if (!userMsg) return "user message with nonce not persisted yet";
+
+        const replies = messages
+          .filter((m: any) => m.sender === "Machine" && m.session_id === userMsg.session_id)
+          .map((m: any) => ((m.text as string) ?? "").trim());
+        if (replies.length === 0) return "AI message for the session not persisted yet";
+        if (replies.every((t) => t === ""))
+          return "AI reply persisted but still empty (run not finished / empty final turn)";
+
+        return replies.some((t) => expected.test(t))
+          ? "reply-contains-expected"
+          : `reply did not match ${expected}: ${JSON.stringify(replies.map((t) => t.slice(0, 120)))}`;
+      },
+      { timeout: 60000 },
+    )
+    .toBe("reply-contains-expected");
+}
+
 const targets = getTestTargets();
 
 // SimpleAgentTemplatePage.load() deletes all flows before loading the template;
@@ -273,7 +321,15 @@ for (const { label, options, skipReason } of targets) {
         await test.step("agent continued: final reply carries the TOOL_FAILED sentinel", async () => {
           const bubble = page.getByTestId("div-chat-message").last();
           await expect(bubble).toBeVisible({ timeout: 30000 });
-          await expect(bubble).toContainText(CONTINUATION_SENTINEL, { timeout: 30000 });
+          // Gate on the PERSISTED reply first — race-free completion signal; the
+          // live bubble shows the empty placeholder mid-run (#634 "Message
+          // empty." race), so it must not be the primary observable.
+          await expectReplyContainsPersisted(request, nonce, CONTINUATION_SENTINEL);
+          // The run is now complete, so the user-visible bubble must ALSO carry
+          // the sentinel. Re-asserting it here (after the gate, so no stream race)
+          // keeps end-to-end UI coverage: a bubble stuck on "Message empty." while
+          // the reply persisted would be a real frontend bug and must still fail.
+          await expect(bubble).toContainText(CONTINUATION_SENTINEL, { timeout: 15000 });
         });
 
         await test.step("tool really errored: persisted tool output carries the SSRF rejection", async () => {

--- a/tests/tests-automations/regression/core-functionality/model-provider/openai-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/openai-provider.spec.ts
@@ -1,6 +1,6 @@
 import * as dotenv from "dotenv";
 import path from "path";
-import type { Page } from "@playwright/test";
+import type { APIRequestContext, Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SettingsPage, SimpleAgentTemplatePage } from "../../../../pages";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
@@ -83,6 +83,52 @@ async function waitForAgentToFinish(page: Page): Promise<void> {
   }
 }
 
+// Assert the echoed sentinel on the PERSISTED reply (monitor API), NOT the live
+// playground bubble. The bubble renders the empty placeholder ("Message empty.",
+// the frontend's EMPTY_OUTPUT_SEND_MESSAGE) while the model is streaming, and
+// `waitForAgentToFinish` can return before the final text lands — so reading the
+// live bubble races the stream, the #634 flaky "Message empty." symptom (no
+// backend 5xx; monitor state=complete — a streaming/empty-turn artifact, not a
+// product error). The token is unique per run and appears in BOTH the user
+// prompt and the expected reply, so it keys the session lookup and is the
+// content assert. A genuinely empty final turn (rare, model-side, #634) fails
+// here rather than passing on the placeholder.
+async function expectReplyContainsToken(
+  request: APIRequestContext,
+  token: string,
+): Promise<void> {
+  const bearer = await getAuthToken(request);
+  await expect
+    .poll(
+      async () => {
+        const res = await request.get("/api/v1/monitor/messages", {
+          headers: { Authorization: bearer },
+        });
+        if (res.status() !== 200) return `GET monitor -> ${res.status()}`;
+        const messages = await res.json();
+        if (!Array.isArray(messages)) return "monitor payload not a list";
+
+        const userMsg = messages.find(
+          (m: any) => m.sender !== "Machine" && (m.text ?? "").includes(token),
+        );
+        if (!userMsg) return "user message with token not persisted yet";
+
+        const replies = messages
+          .filter((m: any) => m.sender === "Machine" && m.session_id === userMsg.session_id)
+          .map((m: any) => ((m.text as string) ?? "").trim());
+        if (replies.length === 0) return "AI reply for the session not persisted yet";
+        if (replies.every((t) => t === ""))
+          return "AI reply persisted but still empty (run not finished / empty final turn)";
+
+        return replies.some((t) => t.includes(token))
+          ? "reply-contains-token"
+          : `reply did not echo the token: ${JSON.stringify(replies.map((t) => t.slice(0, 80)))}`;
+      },
+      { timeout: 60000 },
+    )
+    .toBe("reply-contains-token");
+}
+
 // Serial mode + --workers=1 keeps the shared instance state deterministic
 // (agent-family convention — named template loads collide under parallelism).
 test.describe.configure({ mode: "serial" });
@@ -146,7 +192,7 @@ test.describe("OpenAI Provider", () => {
   test(
     "configured OpenAI selects a GPT model in the Agent and executes the flow",
     { tag: ["@stable", "@model-provider", "@agents", "@playground"] },
-    async ({ page }) => {
+    async ({ page, request }) => {
       test.skip(
         !hasProviderEnvKeys(PROVIDER),
         `Missing env vars for provider "${PROVIDER}": ${missingProviderEnvKeys(PROVIDER).join(", ")}`,
@@ -199,6 +245,13 @@ test.describe("OpenAI Provider", () => {
 
         const aiMessage = page.getByTestId("div-chat-message").last();
         await expect(aiMessage).toBeVisible({ timeout: 30000 });
+        // Gate on the PERSISTED reply first — race-free completion signal; the
+        // live bubble shows the empty placeholder mid-stream (#634 race).
+        await expectReplyContainsToken(request, token);
+        // The run is now complete, so the user-visible bubble must ALSO echo the
+        // token. Re-asserting it here (after the gate, no stream race) keeps
+        // end-to-end UI coverage: a bubble stuck on "Message empty." while the
+        // reply persisted would be a real frontend bug and must still fail.
         expect(await aiMessage.innerText()).toContain(token);
       });
     },

--- a/tests/tests-automations/regression/core-functionality/model-provider/openai-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/openai-provider.spec.ts
@@ -252,7 +252,9 @@ test.describe("OpenAI Provider", () => {
         // token. Re-asserting it here (after the gate, no stream race) keeps
         // end-to-end UI coverage: a bubble stuck on "Message empty." while the
         // reply persisted would be a real frontend bug and must still fail.
-        expect(await aiMessage.innerText()).toContain(token);
+        // Use the retrying locator assertion (not innerText()) — even post-gate
+        // the bubble can lag briefly from placeholder to final text.
+        await expect(aiMessage).toContainText(token, { timeout: 15000 });
       });
     },
   );


### PR DESCRIPTION
## What this fixes

Closes #634.

Two `@stable` agent tests flaked intermittently with the playground bubble rendering the literal `"Message empty."` instead of the expected content, on **both anthropic and openai** runs:

- `agent-tool-error-handling.spec.ts:246` — "agent handles a tool error and continues execution" (expected `/TOOL_FAILED/i`)
- `openai-provider.spec.ts:146` — "configured OpenAI selects a GPT model in the Agent and executes the flow" (expected the echoed `OPENAI-<ts>` token)

`@stable` is **retained** (per the daily flaky-tracking policy) — this PR corrects the tests.

## Root cause (investigated — no product bug)

Following the issue's two-axis mandate:

- **Axis 1 (product bug): ruled out.** `"Message empty."` is the frontend `EMPTY_OUTPUT_SEND_MESSAGE` placeholder, rendered while the agent is **mid tool-execution/streaming**, before the final reply lands. An 18-run reproduction produced a real reply **every time**, with **no 4xx/5xx** and monitor messages `state: complete` / `error: null` — not a swallowed backend error.
- **Axis 2 (test timing): the cause.** The local `waitForAgentToFinish` returns early when the "Stop" button isn't seen within 10s or hides between tool phases; the subsequent **30s live-bubble** assertion then races the stream and reads the empty placeholder.
- **Cross-provider** because it is the shared **playground streaming path + test timing**, not model-specific (consistent with hits on both providers).

## Fix

Both tests now assert in **two stages**:

1. **Gate on the persisted reply** (monitor API, nonce/token-keyed session) — a race-free completion signal that only resolves once the final reply is persisted. A genuinely empty final turn (rare, model-side) still fails here rather than passing on the placeholder.
2. **Then re-assert the live bubble content** — with the run confirmed complete, the user-visible bubble must also carry the sentinel/token. This keeps end-to-end UI coverage: a bubble stuck on `"Message empty."` while the reply persisted is a real frontend bug and must still fail — without reintroducing the stream race.

New local helpers: `expectReplyContainsPersisted` (agent-tool-error) and `expectReplyContainsToken` (openai-provider). `waitForAgentToFinish` is left as a best-effort pre-wait; the persisted poll is the real barrier. Spec docs updated.

## Tests

| # | Teste | O que faz | O que valida (observável concreto) |
|---|---|---|---|
| 1 | `agent handles a tool error and continues execution` | Fetch de URL SSRF-bloqueada → tool erra; agente deve continuar | (a) output persistido do `fetch_content` contém `SSRF Protection`; (b) **reply persistido** contém `TOOL_FAILED`; (c) balão live re-confirma `TOOL_FAILED` |
| 2 | `configured OpenAI selects a GPT model in the Agent and executes the flow` | OpenAI configurado, modelo GPT, echo de token no Playground | (a) modelo GPT selecionado; (b) **reply persistido** contém `OPENAI-<ts>`; (c) balão live re-confirma o token |

**FF (executados):**
- `agent-tool-error`: `CONTINUATION_SENTINEL` → `/TOOL_FAILED_FORCEFAIL_XYZ/i` ⇒ **1 failed** (assert falsificável).
- `openai test 2`: token → `token + "_FORCEFAIL_XYZ"` ⇒ **1 failed** (assert falsificável).

## Validation

- Langflow: `langflowai/langflow-nightly:latest` = **1.11.0.dev38**
- Both tests pass `--retries=0` (`gpt-4o-mini`); `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors)
- Flow cleanup verified: id-scoped `afterEach`, no orphans left (`GET /api/v1/flows/`).

## Out of scope (heads-up, not fixed here)

`openai-provider.spec.ts` **Test 1** ("OpenAI API key is configured via Settings", `@settings`) has a **pre-existing** failure on a fresh instance where `collect-models` already set the `OPENAI_API_KEY` global variable: the save flow becomes a no-op and the guarded `waitForResponse(PATCH /variables)` times out. Unrelated to this diff (Test 1 is untouched) and to the #634 symptom — flagging so it can get its own issue.

`agent-multi-tool-selection.spec.ts:292` (also listed in #634) is the hard-failure tracked and fixed in #631 / PR #653 — not touched here.

## Run it

```bash
MODEL_TEST_ID=gpt-4o-mini npx playwright test tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-error-handling.spec.ts --workers=1 --grep "agent handles a tool error" --debug
npx playwright test tests/tests-automations/regression/core-functionality/model-provider/openai-provider.spec.ts --workers=1 --grep "configured OpenAI selects a GPT model" --debug
```
