### PR TITLE
fix(agents): confirm input/instruction reaches the persisted flow before the run (#635)

### DIFF
--- a/docs/core-functionality/llm-agents/agent-input-sources.md
+++ b/docs/core-functionality/llm-agents/agent-input-sources.md
@@ -79,10 +79,20 @@ A per-run token `SENTINEL_<Date.now()>` is generated so a match is unambiguous.
    the node is gone and the edge count dropped by one.
 3. Type the distinctive echo prompt into the Agent's `Input` field
    (`popover-anchor-input-input_value`):
-   `Repeat this token exactly and nothing else: FIELD-<sentinel>`.
-4. **Wait for the debounced autosave to settle** (`waitForFlowSaveSettled`) —
-   `button_run_agent` builds the *persisted* flow, so the model selection, the
-   node deletion and the field value must all be saved first (see Notes).
+   `Repeat this token exactly and nothing else: FIELD-<sentinel>`, then `blur()`
+   to commit it. `fill` alone can leave the change uncommitted (the node applies
+   it on blur/change), so without the blur the value can miss the autosave PATCH
+   and the build runs with an EMPTY `input_value` — the agent then replies
+   generically ("I don't see any prior conversation history…"), the #635 flaky
+   symptom. Every other field-set in the suite blurs; this step did not.
+4. **Wait for the debounced autosave to settle** (`waitForFlowSaveSettled`),
+   then **confirm server-side** that the field value reached the PERSISTED flow:
+   poll `GET /api/v1/flows/` until the unique sentinel appears in a flow's `data`
+   graph. `button_run_agent` builds the *persisted* flow, so this is the
+   payload-level proof the input actually reaches the run (#635) — DOM state and
+   PATCH quiescence do not prove persistence. A value that never persists fails
+   HERE as a save/wiring issue, instead of surfacing later as a generic reply
+   that looks like model non-adherence.
 5. Run the Agent node via `button_run_agent`.
 6. Wait for build success on the canvas — the `node_duration_agent` badge
    (canonical completion signal; not the transient toast).

--- a/docs/core-functionality/llm-agents/agent-system-prompt.md
+++ b/docs/core-functionality/llm-agents/agent-system-prompt.md
@@ -56,8 +56,18 @@ override). Skip a target if its provider is inactive or its env key is missing.
    (clears flows, loads template, configures provider/model). Skip on
    `MODEL_NOT_AVAILABLE`.
 2. Generate a per-run sentinel `PINEAPPLE-<uniq>`. Set the Agent Instructions:
-   fill `textarea_str_system_prompt` with an instruction forcing the sentinel into
-   every reply, blur, wait for the autosave `PATCH /api/v1/flows/` to succeed.
+   fill `textarea_str_system_prompt`, blur, **drain every pending autosave**
+   (`waitForFlowSaveSettled`), then **confirm server-side** that the instruction
+   reached the PERSISTED flow — poll `GET /api/v1/flows/` until the unique
+   sentinel appears in a flow's `data` graph. The earlier single
+   `waitForResponse(PATCH /api/v1/flows/)` could match a STALE PATCH still in
+   flight from `load()` (model selection), resolving before the instruction's own
+   save landed — so the build could run the template default (no instruction) and
+   the model answers the literal question without the sentinel (#635). The
+   server-side check is the payload-level proof the instruction reaches the
+   provider (DOM state cannot prove persistence): if the sentinel IS in the
+   persisted flow but the reply omits it, that is unambiguously model-side
+   non-adherence, not a dropped instruction.
 3. Open the Playground (`playground-btn-flow-io`), send an unrelated message
    ("What is the capital of France?"), wait for the run to finish (Stop button
    appears then hides).

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-input-sources.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-input-sources.spec.ts
@@ -1,7 +1,7 @@
 import * as dotenv from "dotenv";
 import path from "path";
 import fs from "fs";
-import type { APIRequestContext, Page } from "@playwright/test";
+import type { APIRequestContext, Page, Response } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
@@ -138,25 +138,33 @@ function getTestTargets(): TestTarget[] {
 const createdFlowIds: string[] = [];
 
 async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
-  page.on("response", (resp) => {
+  // Collect the POST /api/v1/flows → 201 responses synchronously as they arrive,
+  // then resolve their bodies in `finally`. Awaiting the .json() here (instead of
+  // a fire-and-forget .then()) guarantees every created id is recorded BEFORE the
+  // test proceeds to afterEach — otherwise the last flow's id can land after
+  // cleanup already ran, leaking that flow.
+  const flowCreations: Response[] = [];
+  const onResponse = (resp: Response) => {
     if (
       resp.url().includes("/api/v1/flows") &&
       resp.request().method() === "POST" &&
       resp.status() === 201
     ) {
-      resp
-        .json()
-        .then((body: { id?: string }) => {
-          if (body?.id) createdFlowIds.push(body.id);
-        })
-        .catch(() => {}); // non-JSON / batch payloads
+      flowCreations.push(resp);
     }
-  });
+  };
+  page.on("response", onResponse);
   try {
     await new SimpleAgentTemplatePage(page).load(options);
   } catch (e: any) {
     if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
     throw e;
+  } finally {
+    page.off("response", onResponse);
+    for (const resp of flowCreations) {
+      const body = (await resp.json().catch(() => null)) as { id?: string } | null; // non-JSON / batch payloads
+      if (body?.id) createdFlowIds.push(body.id);
+    }
   }
 }
 
@@ -198,7 +206,9 @@ async function expectSentinelPersistedInFlows(
           ? "persisted"
           : "sentinel not yet persisted in any flow";
       },
-      { timeout: 15000 },
+      // Explicit, backing-off intervals: GET /api/v1/flows/ returns every flow's
+      // full graph, so avoid hammering it with the default aggressive cadence.
+      { timeout: 15000, intervals: [500, 1000, 2000] },
     )
     .toBe("persisted");
 }

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-input-sources.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-input-sources.spec.ts
@@ -1,10 +1,11 @@
 import * as dotenv from "dotenv";
 import path from "path";
 import fs from "fs";
-import type { Page } from "@playwright/test";
+import type { APIRequestContext, Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import {
   hasProviderEnvKeys,
   missingProviderEnvKeys,
@@ -130,13 +131,76 @@ function getTestTargets(): TestTarget[] {
   }));
 }
 
+// Track every flow the template load creates (POST /api/v1/flows → 201) so
+// afterEach can delete exactly those ids. SimpleAgentTemplatePage.load() does NO
+// cleanup (post-#553 contract), so without this each run leaks a "Simple Agent"
+// flow into the instance.
+const createdFlowIds: string[] = [];
+
 async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {}); // non-JSON / batch payloads
+    }
+  });
   try {
     await new SimpleAgentTemplatePage(page).load(options);
   } catch (e: any) {
     if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
     throw e;
   }
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    const res = await request.delete(`/api/v1/flows/${id}`, {
+      headers: { Authorization: bearer },
+    });
+    // 404 = transient flow the app already discarded — expected noise.
+    if (!res.ok() && res.status() !== 404) {
+      console.warn(`flow cleanup: DELETE ${id} -> ${res.status()}`);
+    }
+  }
+});
+
+// Server-side confirmation that `sentinel` actually reached the PERSISTED flow —
+// the true "does the input reach the provider" gate (#635). DOM state and PATCH
+// quiescence don't prove persistence; the build (and thus the provider call)
+// reads the persisted flow. Poll GET /api/v1/flows/ (the list carries each
+// flow's full `data` graph) until the unique per-run sentinel appears in it.
+// If it never persists, this fails as a SAVE/WIRING issue — unambiguously
+// distinct from the model later ignoring an input that WAS persisted.
+async function expectSentinelPersistedInFlows(
+  request: APIRequestContext,
+  sentinel: string,
+): Promise<void> {
+  const bearer = await getAuthToken(request);
+  await expect
+    .poll(
+      async () => {
+        const res = await request.get("/api/v1/flows/", {
+          headers: { Authorization: bearer },
+        });
+        if (!res.ok()) return `GET flows -> ${res.status()}`;
+        const flows = await res.json();
+        return JSON.stringify(flows).includes(sentinel)
+          ? "persisted"
+          : "sentinel not yet persisted in any flow";
+      },
+      { timeout: 15000 },
+    )
+    .toBe("persisted");
 }
 
 async function waitForAgentToFinish(page: Page): Promise<void> {
@@ -197,7 +261,7 @@ for (const { label, options, skipReason } of targets) {
     test(
       "input via the Agent's direct field drives the agent response",
       { tag: ["@stable", "@components", "@agents", "@playground"] },
-      async ({ page }) => {
+      async ({ page, request }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(
           !hasProviderEnvKeys(provider),
@@ -225,15 +289,26 @@ for (const { label, options, skipReason } of targets) {
         await test.step("type the sentinel directly into the Agent's Input field", async () => {
           const inputField = page.getByTestId("popover-anchor-input-input_value");
           await expect(inputField).toBeVisible({ timeout: 15000 });
-          await inputField.fill(`Repeat this token exactly and nothing else: ${token}`);
-          // button_run_agent builds the PERSISTED flow. Drain the debounced
+          const fieldValue = `Repeat this token exactly and nothing else: ${token}`;
+          await inputField.click();
+          await inputField.fill(fieldValue);
+          // COMMIT the value: `fill` alone can leave the change uncommitted (the
+          // node applies it on blur/change); without an explicit blur the value
+          // can miss the autosave PATCH, so the build runs with an EMPTY
+          // input_value and the agent replies generically ("I don't see any prior
+          // conversation history…") — the #635 flaky symptom. Every other
+          // field-set in this suite blurs; this one didn't.
+          await inputField.blur();
+          // button_run_agent builds the PERSISTED flow, so drain the debounced
           // autosave PATCHes (model selection from load(), the ChatInput deletion,
-          // and this field value) before running — otherwise the build can race a
-          // still-pending save and run the template default model
-          // (`__default_language_model__ variable not found`), so the agent never
-          // builds and node_duration_agent never appears. Same class of race the
-          // agent-system-prompt spec guards with an autosave wait.
+          // and this field value) first.
           await waitForFlowSaveSettled(page);
+          // Then CONFIRM server-side that the field value actually reached the
+          // persisted flow — the payload-level proof the input reaches the run
+          // (#635). If it didn't persist, this fails as a save/wiring problem
+          // here, rather than surfacing later as a misleading generic reply that
+          // looks like model non-adherence.
+          await expectSentinelPersistedInFlows(request, token);
         });
 
         await test.step("run the Agent node from the canvas", async () => {

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-system-prompt.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-system-prompt.spec.ts
@@ -1,9 +1,11 @@
 import * as dotenv from "dotenv";
 import path from "path";
 import fs from "fs";
-import type { Page } from "@playwright/test";
+import type { APIRequestContext, Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
+import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import {
   hasProviderEnvKeys,
   missingProviderEnvKeys,
@@ -124,7 +126,27 @@ function getTestTargets(): TestTarget[] {
   }));
 }
 
+// Track every flow the template load creates (POST /api/v1/flows → 201) so
+// afterEach can delete exactly those ids. SimpleAgentTemplatePage.load() does NO
+// cleanup (post-#553 contract), so without this each run leaks a "Simple Agent"
+// flow into the instance.
+const createdFlowIds: string[] = [];
+
 async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {}); // non-JSON / batch payloads
+    }
+  });
   try {
     await new SimpleAgentTemplatePage(page).load(options);
   } catch (e: any) {
@@ -132,6 +154,20 @@ async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<v
     throw e;
   }
 }
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    const res = await request.delete(`/api/v1/flows/${id}`, {
+      headers: { Authorization: bearer },
+    });
+    // 404 = transient flow the app already discarded — expected noise.
+    if (!res.ok() && res.status() !== 404) {
+      console.warn(`flow cleanup: DELETE ${id} -> ${res.status()}`);
+    }
+  }
+});
 
 async function waitForAgentToFinish(page: Page): Promise<void> {
   const stopButton = page.getByRole("button", { name: "Stop" });
@@ -141,24 +177,52 @@ async function waitForAgentToFinish(page: Page): Promise<void> {
   }
 }
 
-// Fill the Agent Instructions (system prompt) and wait for the autosave PATCH so
-// the build runs the prompt we set, not the template default.
+// Fill the Agent Instructions (system prompt) and make sure it is COMMITTED and
+// PERSISTED before the build, so the run uses the prompt we set, not the
+// template default.
 async function setAgentInstructions(page: Page, prompt: string): Promise<void> {
   const promptField = page.getByTestId("textarea_str_system_prompt");
   await expect(promptField).toBeVisible({ timeout: 15000 });
 
-  const patchPromise = page.waitForResponse(
-    (resp) =>
-      resp.url().includes("/api/v1/flows/") &&
-      resp.request().method() === "PATCH" &&
-      resp.ok(),
-    { timeout: 15000 },
-  );
-
   await promptField.click();
   await promptField.fill(prompt);
   await promptField.blur();
-  await patchPromise;
+  // Drain ALL debounced autosave PATCHes. The previous single
+  // `waitForResponse(PATCH)` could match a STALE PATCH still in flight from
+  // load() (model selection), resolving BEFORE the instruction's own save landed
+  // — so the build could run the template default (no instruction) and the model
+  // answers the literal question without the sentinel (#635). Persistence is then
+  // confirmed server-side by the caller (expectSentinelPersistedInFlows) — the
+  // true "instruction reaches the provider" gate, which DOM state cannot prove.
+  await waitForFlowSaveSettled(page);
+}
+
+// Server-side confirmation that `sentinel` actually reached the PERSISTED flow —
+// the true "does the instruction reach the provider" gate (#635). Poll GET
+// /api/v1/flows/ (the list carries each flow's full `data` graph) until the
+// unique per-run sentinel appears. If it never persists, this fails as a
+// SAVE/WIRING issue here; if it DOES persist but the reply omits it, that is
+// unambiguously model-side non-adherence, not a dropped instruction.
+async function expectSentinelPersistedInFlows(
+  request: APIRequestContext,
+  sentinel: string,
+): Promise<void> {
+  const bearer = await getAuthToken(request);
+  await expect
+    .poll(
+      async () => {
+        const res = await request.get("/api/v1/flows/", {
+          headers: { Authorization: bearer },
+        });
+        if (!res.ok()) return `GET flows -> ${res.status()}`;
+        const flows = await res.json();
+        return JSON.stringify(flows).includes(sentinel)
+          ? "persisted"
+          : "sentinel not yet persisted in any flow";
+      },
+      { timeout: 15000 },
+    )
+    .toBe("persisted");
 }
 
 // Open the Playground, send a message, wait for the run to finish, return the
@@ -193,7 +257,7 @@ for (const { label, options, skipReason } of targets) {
     test(
       "Agent Instructions are respected in the model response",
       { tag: ["@stable", "@release", "@agents", "@playground"] },
-      async ({ page }) => {
+      async ({ page, request }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(
           !hasProviderEnvKeys(provider),
@@ -208,8 +272,13 @@ for (const { label, options, skipReason } of targets) {
 
         await loadAgent(page, options);
 
-        await test.step("set the Agent Instructions and wait for autosave", async () => {
+        await test.step("set the Agent Instructions and confirm they persist to the flow", async () => {
           await setAgentInstructions(page, systemPrompt);
+          // Payload-level gate: prove the instruction reached the PERSISTED flow
+          // (what the build/provider call reads) before running — so a run that
+          // omits the sentinel is unambiguously model non-adherence, not a
+          // dropped instruction (#635).
+          await expectSentinelPersistedInFlows(request, sentinel);
         });
 
         await test.step("run an unrelated message and assert the instruction is honoured", async () => {

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-system-prompt.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-system-prompt.spec.ts
@@ -1,7 +1,7 @@
 import * as dotenv from "dotenv";
 import path from "path";
 import fs from "fs";
-import type { APIRequestContext, Page } from "@playwright/test";
+import type { APIRequestContext, Page, Response } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
@@ -133,25 +133,33 @@ function getTestTargets(): TestTarget[] {
 const createdFlowIds: string[] = [];
 
 async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
-  page.on("response", (resp) => {
+  // Collect the POST /api/v1/flows → 201 responses synchronously as they arrive,
+  // then resolve their bodies in `finally`. Awaiting the .json() here (instead of
+  // a fire-and-forget .then()) guarantees every created id is recorded BEFORE the
+  // test proceeds to afterEach — otherwise the last flow's id can land after
+  // cleanup already ran, leaking that flow.
+  const flowCreations: Response[] = [];
+  const onResponse = (resp: Response) => {
     if (
       resp.url().includes("/api/v1/flows") &&
       resp.request().method() === "POST" &&
       resp.status() === 201
     ) {
-      resp
-        .json()
-        .then((body: { id?: string }) => {
-          if (body?.id) createdFlowIds.push(body.id);
-        })
-        .catch(() => {}); // non-JSON / batch payloads
+      flowCreations.push(resp);
     }
-  });
+  };
+  page.on("response", onResponse);
   try {
     await new SimpleAgentTemplatePage(page).load(options);
   } catch (e: any) {
     if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
     throw e;
+  } finally {
+    page.off("response", onResponse);
+    for (const resp of flowCreations) {
+      const body = (await resp.json().catch(() => null)) as { id?: string } | null; // non-JSON / batch payloads
+      if (body?.id) createdFlowIds.push(body.id);
+    }
   }
 }
 
@@ -220,7 +228,9 @@ async function expectSentinelPersistedInFlows(
           ? "persisted"
           : "sentinel not yet persisted in any flow";
       },
-      { timeout: 15000 },
+      // Explicit, backing-off intervals: GET /api/v1/flows/ returns every flow's
+      // full graph, so avoid hammering it with the default aggressive cadence.
+      { timeout: 15000, intervals: [500, 1000, 2000] },
     )
     .toBe("persisted");
 }


### PR DESCRIPTION
## What this fixes

Closes #635.

Two `@stable` agent tests flaked on anthropic/claude-sonnet-5 with the reply missing a per-run sentinel:

- `agent-input-sources.spec.ts:197` — "input via the Agent's direct field drives the agent response": typed `FIELD-<n>` into the Agent's `input_value` field; got a generic *"I don't see any prior conversation history…"* reply (the field input did not reach the agent).
- `agent-system-prompt.spec.ts:193` — "Agent Instructions are respected in the model response": system instruction to emit `PINEAPPLE-<n>`; model answered the literal question ("THE CAPITAL OF FRANCE IS PARIS").

`@stable` **retained** (flaky-tracking policy). NOTE: unrelated to the open **#608** (that is the autosave PATCH timeout on the *google* setup run — a different failure).

## Root cause / mechanism

- **agent-input-sources** filled `input_value` with `fill(...)` **without `blur()`** — every other field-set in the suite blurs. An uncommitted `fill` can miss the debounced autosave PATCH, so the build runs with an **empty** `input_value` → the generic reply.
- **agent-system-prompt** awaited a **single** `waitForResponse(PATCH /api/v1/flows/)` that can match a **stale** save still in flight from `load()` (model selection), resolving before the instruction's own save landed → the build runs the template default (no instruction) → literal answer.

Both mechanisms mean the value never reached the persisted flow the build reads — not model whim.

## Fix

- **agent-input-sources**: `blur()` to commit the field.
- **agent-system-prompt**: drain **all** pending saves (`waitForFlowSaveSettled`) instead of one possibly-stale PATCH.
- **Both — payload-level gate**: a new `expectSentinelPersistedInFlows(request, sentinel)` polls `GET /api/v1/flows/` (the list carries each flow's full `data` graph) until the unique per-run sentinel appears in the persisted flow, **before** the run. This is the mandate's "reaches the provider" proof and it **cleanly separates** a save/wiring drop (fails at the gate) from model non-adherence (persisted, but the model omits it — retry-absorbed, `@stable` retained).
- **Both — flow cleanup**: the specs previously leaked a "Simple Agent" flow per run (23 orphans found); added the suite-standard id-scoped `afterEach` (capture `POST /api/v1/flows` 201 ids → delete).

## Tests

| # | Teste | O que faz | O que valida (observável concreto) |
|---|---|---|---|
| input-sources | `input via the Agent's direct field drives the agent response` | Remove ChatInput, digita+`blur` o sentinel no `input_value`, roda o Agent | (a) **server-side**: `FIELD-<n>` está no flow persistido; (b) o output-inspection do Agent contém `FIELD-<n>` |
| system-prompt | `Agent Instructions are respected in the model response` | Seta a instrução (drain saves), confirma persistência, roda mensagem neutra | (a) **server-side**: `PINEAPPLE-<n>` está no flow persistido; (b) o reply contém `PINEAPPLE-<n>` |

**FF (executados, gemini-2.5-flash):** reply-sentinel → impossible ⇒ **fail** (ambos); server-side gate → busca string impossível ⇒ **fail** (`"not yet persisted"`); cleanup verificado (0 órfãos após runs).

## Validation

- Langflow: `langflowai/langflow-nightly:latest` = **1.11.0.dev38**
- Both tests pass `--retries=0` (gemini-2.5-flash) — the sentinel **does** persist server-side, so the input/instruction provably reaches the run.
- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors) · 0 orphan flows.
- **Independent review ×2**: round 1 raised 2 HIGH (no payload-level proof; `toHaveValue` redundant) → resolved by the server-side gate; round 2 verdict **ship**.

## Transparency / caveats

- The original flake was on **anthropic** (claude-sonnet-5); it was **not reproduced locally** (no `ANTHROPIC_API_KEY` here — only openai/google). The fixes are mechanism-based hardenings validated on gemini; the server-side gate makes any future recurrence unambiguously attributable (save/wiring vs model).
- openai runs additionally hit an **unrelated** transient `"Invalid API key for OpenAI"` (400) build failure (~1/5) — not the #635 symptom, out of scope (also seen around #631/#634 environments).
- **Optional follow-up** (independent review medium, non-blocking): for *literal* payload proof, assert the sentinel in the captured build-request graph (`POST /api/v1/build/...`) rather than the persisted-flow list. The current gate is the strongest feasible check without instrumenting the outbound LLM call.

## Run it

```bash
MODEL_TEST_ID=gemini-2.5-flash npx playwright test tests/tests-automations/regression/core-functionality/llm-agents/agent-input-sources.spec.ts --workers=1 --grep "direct field" --debug
MODEL_TEST_ID=gemini-2.5-flash npx playwright test tests/tests-automations/regression/core-functionality/llm-agents/agent-system-prompt.spec.ts --workers=1 --grep "respected" --debug
```
