### PR TITLE
fix(flow): click Freeze via its toolbar button testid, not the intercepted label (#615)

### DIFF
--- a/tests/tests-automations/regression/flow-functionality/generalBugs-shard-10.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/generalBugs-shard-10.spec.ts
@@ -84,17 +84,27 @@ test(
     // await page.getByText("Close").last().click();
     await page.getByTestId("playground-close-button").click();
 
-    // Freeze the Chat Output node (not Prompt) so the entire response is cached
+    // Freeze the path feeding Chat Output so the entire response is cached. The
+    // freeze button runs FreezeAllVertices(stopNodeId=Chat Output), which caches
+    // the outputs of Chat Output and its upstream nodes — enough that a later
+    // prompt edit cannot change the re-run result.
     await page.getByText("Chat Output", { exact: true }).last().click();
 
-    await page.waitForSelector('[data-testid="more-options-modal"]', {
-      timeout: 1000,
-    });
-    await page.getByTestId("more-options-modal").click();
+    // On the 1.11 nightly the node toolbar was re-laid-out: Freeze is now a
+    // DIRECT toolbar button (`freeze-all-button-modal`) inside `toolbar-wrapper`,
+    // not a text item reached through the more-options dropdown. The old
+    // `getByText("Freeze")` resolved to that button's label but the click was
+    // swallowed by the `toolbar-wrapper` overlay that intercepts pointer events
+    // (#615). Clicking the button by its testid targets the interactive element
+    // directly and is layering-independent.
+    const freezeButton = page.getByTestId("freeze-all-button-modal").first();
+    await expect(freezeButton).toBeVisible({ timeout: 10000 });
+    await freezeButton.click();
 
-    await page.getByText("Freeze", { exact: true }).first().click();
-
-    await page.waitForSelector(".border-ring-frozen", { timeout: 3000 });
+    // `.border-ring-frozen` marks the SELECTED frozen node only (NodeStatus:
+    // `selected ? "border-ring-frozen" : "border-frozen"`), so the count is 1
+    // even if freezing cascades up the path.
+    await page.waitForSelector(".border-ring-frozen", { timeout: 5000 });
 
     await expect(page.locator(".border-ring-frozen")).toHaveCount(1);
 

--- a/tests/tests-automations/regression/flow-functionality/generalBugs-shard-10.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/generalBugs-shard-10.spec.ts
@@ -84,10 +84,9 @@ test(
     // await page.getByText("Close").last().click();
     await page.getByTestId("playground-close-button").click();
 
-    // Freeze the path feeding Chat Output so the entire response is cached. The
-    // freeze button runs FreezeAllVertices(stopNodeId=Chat Output), which caches
-    // the outputs of Chat Output and its upstream nodes — enough that a later
-    // prompt edit cannot change the re-run result.
+    // Freeze the path feeding Chat Output so the entire response is cached:
+    // freezing Chat Output caches its own output plus the outputs of its upstream
+    // nodes — enough that a later prompt edit cannot change the re-run result.
     await page.getByText("Chat Output", { exact: true }).last().click();
 
     // On the 1.11 nightly the node toolbar was re-laid-out: Freeze is now a
@@ -103,10 +102,11 @@ test(
 
     // `.border-ring-frozen` marks the SELECTED frozen node only (NodeStatus:
     // `selected ? "border-ring-frozen" : "border-frozen"`), so the count is 1
-    // even if freezing cascades up the path.
-    await page.waitForSelector(".border-ring-frozen", { timeout: 5000 });
-
-    await expect(page.locator(".border-ring-frozen")).toHaveCount(1);
+    // even if freezing cascades up the path. A single retrying assertion waits
+    // for the frozen ring to appear and pins the count in one step.
+    await expect(page.locator(".border-ring-frozen")).toHaveCount(1, {
+      timeout: 5000,
+    });
 
     await page.getByText("Prompt Template", { exact: true }).last().click();
 


### PR DESCRIPTION
## What this fixes

Closes #615.

`flow-functionality/generalBugs-shard-10.spec.ts:8` — **"freeze must work correctly"** (`@release`) — failed **deterministically** on the 1.11 nightly: the Freeze entry resolved and was visible, but `<div class="toolbar-wrapper">` intercepted the pointer click.

## Live scout (per the issue's ask)

Confirmed against the Langflow frontend source (`nodeToolbarComponent/index.tsx`) — the node toolbar was re-laid-out on 1.11:

- Freeze is now a **direct `ToolbarButton`** with `dataTestId="freeze-all-button-modal"` (icon `FreezeAll`, label `nodeToolbar.freeze` = "Freeze"), rendered inside `<div className="toolbar-wrapper">` when the node is **not** tool-capable (`!hasToolMode || inspectionPanelVisible`).
- **Chat Output is not tool-capable**, so it shows the direct button. The dropdown ("more-options-modal") freeze item only renders under `hasToolMode` — so the old flow (open more-options → click the `Freeze` **label**) had no freeze item to click and resolved to the direct button's label, whose click was swallowed by the `toolbar-wrapper` container.
- `.border-ring-frozen` is applied only to the **selected** frozen node (`NodeStatus`: `frozen ? (selected ? "border-ring-frozen" : "border-frozen") : …`) — so the count-1 assertion holds even though the button freeze-paths (`FreezeAllVertices({stopNodeId})`) the upstream nodes too.

## Fix

After selecting Chat Output, click `getByTestId("freeze-all-button-modal")` (the interactive `<button>`, targeting the element directly — layering-independent) and drop the stale more-options-open + `getByText("Freeze")`. Kept the `.border-ring-frozen` count-1 assertion (timeout 3s→5s).

## Validation

- Langflow: `langflowai/langflow-nightly:latest` = **1.11.0.dev38**
- Test **passes** `--retries=0` (run twice).
- **FF (executed):** commenting out the freeze click ⇒ **1 failed** at the `.border-ring-frozen` wait (the freeze is load-bearing; the later cached-output exact-match assertion also diverges without it).
- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors) · local orphan flows purged.
- **Independent review**: verdict **ship** — all findings LOW/optional; the frontend-source rationale verified against current code.

## Notes / scope

- **`@stable` absence**: intentional — this is a legacy `generalBugs` shard test tagged `@release` (happy-path), consistent with the shard family; #615 explicitly scopes it as not-`@stable`.
- **Out of scope (flagged for follow-up)**: this shard (and the `generalBugs` family generally) has **no per-test flow cleanup**, so each run leaks a "Basic Prompting" flow. Pre-existing and family-wide; not introduced here. Left for a dedicated qa-infra cleanup task rather than diverging one shard from the family in this focused fix.

## Run it

```bash
npx playwright test tests/tests-automations/regression/flow-functionality/generalBugs-shard-10.spec.ts --workers=1 --debug
```
