### PR TITLE
ci: bump GitHub Actions off deprecated Node 20 across all workflows

### DIFF
--- a/.github/workflows/adaptive-impacted.yml
+++ b/.github/workflows/adaptive-impacted.yml
@@ -37,8 +37,8 @@ jobs:
       baseSha: ${{ steps.delta.outputs.baseSha }}
       isBootstrap: ${{ steps.delta.outputs.isBootstrap }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -70,13 +70,13 @@ jobs:
       specs: ${{ steps.impact.outputs.specs }}
       summary: ${{ steps.impact.outputs.summary }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7
         with:
           repository: langflow-ai/langflow
           path: langflow-upstream
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -168,9 +168,9 @@ jobs:
           --health-start-period 90s
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -199,7 +199,7 @@ jobs:
           fi
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report-adaptive-${{ github.run_id }}
@@ -207,7 +207,7 @@ jobs:
           retention-days: 14
 
       - name: Upload test results on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: test-results-adaptive-${{ github.run_id }}
@@ -216,7 +216,7 @@ jobs:
 
       - name: Create issue on failure
         if: failure() && github.event_name == 'schedule'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const today = new Date().toISOString().split('T')[0];

--- a/.github/workflows/build-ollama-image.yml
+++ b/.github/workflows/build-ollama-image.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Log in to ghcr
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -128,7 +128,7 @@ jobs:
       OLLAMA_TEST_MODEL: llama3.2:1b
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # No actions/setup-node: the Playwright image already ships the Node
       # toolchain it was built against, so we use it directly instead of
@@ -239,7 +239,7 @@ jobs:
 
       - name: Upload Playwright report (full, heavy)
         id: upload_report                     # ← full report: index.html + data/ + trace/ attachments (~380 MB)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report-daily-${{ github.run_id }}
@@ -253,7 +253,7 @@ jobs:
       # and it gets the longest retention GitHub allows (90 days) since it's small.
       - name: Upload report index (lightweight, long-lived)
         id: upload_index                      # ← artifact-url fed to the QA Platform payload below
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report-index-daily-${{ github.run_id }}
@@ -269,7 +269,7 @@ jobs:
       # late/backfill import can still reach it long after the run; the JSON is
       # small, so the long window costs ~nothing.
       - name: Upload Playwright JSON report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-json-daily-${{ github.run_id }}
@@ -403,7 +403,7 @@ jobs:
       # recurs 2+ times), so an auto-umbrella on manual runs would just be noise.
       - name: Create issue on failure
         if: failure() && github.event_name == 'schedule'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           IMAGE: ${{ inputs.langflow_image || 'langflowai/langflow-nightly' }}:${{ inputs.langflow_image_tag || 'latest' }}
           # Set by the (schedule-only) auto-remove step above; empty only if that

--- a/.github/workflows/file-watcher.yml
+++ b/.github/workflows/file-watcher.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout langflow-e2e repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Checkout langflow upstream
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: langflow-ai/langflow
           path: langflow-upstream
@@ -128,7 +128,7 @@ jobs:
 
       - name: Create review issue if changes detected
         if: steps.detect.outputs.has_changes == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const today = new Date().toISOString().split('T')[0];

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -117,8 +117,8 @@ jobs:
       OLLAMA_TEST_MODEL: llama3.2:1b
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -148,8 +148,8 @@ jobs:
     timeout-minutes: 90
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/migration-fresh-install.yml
+++ b/.github/workflows/migration-fresh-install.yml
@@ -38,7 +38,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: fresh-install-${{ github.run_number }}
           path: |
@@ -95,7 +95,7 @@ jobs:
 
       - name: Close issue on success
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { data: existing } = await github.rest.issues.listForRepo({
@@ -128,7 +128,7 @@ jobs:
 
       - name: Create or update issue on failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -45,7 +45,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -258,7 +258,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: migration-test-${{ github.run_number }}
           path: |
@@ -273,7 +273,7 @@ jobs:
 
       - name: Close issue on success
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { data: existing } = await github.rest.issues.listForRepo({
@@ -306,7 +306,7 @@ jobs:
 
       - name: Create or update issue on failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -369,7 +369,7 @@ jobs:
       OFFICIAL_COMPOSE_URL: https://raw.githubusercontent.com/langflow-ai/langflow/main/docker_example/docker-compose.yml
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Verify OPENAI_API_KEY secret is configured
         env:
@@ -677,7 +677,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: migration-compose-${{ github.run_number }}
           path: |
@@ -690,7 +690,7 @@ jobs:
 
       - name: Close issue on success
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { data: existing } = await github.rest.issues.listForRepo({
@@ -723,7 +723,7 @@ jobs:
 
       - name: Create or update issue on failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { data: existing } = await github.rest.issues.listForRepo({

--- a/.github/workflows/migration-upgrade-with-flows.yml
+++ b/.github/workflows/migration-upgrade-with-flows.yml
@@ -39,7 +39,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -184,7 +184,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: upgrade-with-flows-${{ github.run_number }}
           path: |
@@ -200,7 +200,7 @@ jobs:
 
       - name: Close issue on success
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { data: existing } = await github.rest.issues.listForRepo({
@@ -233,7 +233,7 @@ jobs:
 
       - name: Create or update issue on failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,9 +67,9 @@ jobs:
       OLLAMA_TEST_MODEL: llama3.2:1b
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -93,7 +93,7 @@ jobs:
           PLAYWRIGHT_BASE_URL: "http://localhost:7860/"
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report-nightly-${{ github.run_id }}
@@ -101,7 +101,7 @@ jobs:
           retention-days: 14
 
       - name: Upload test results on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: test-results-nightly-${{ github.run_id }}
@@ -110,7 +110,7 @@ jobs:
 
       - name: Create issue on failure
         if: failure() && github.event_name == 'schedule'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const today = new Date().toISOString().split('T')[0];

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -11,9 +11,9 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -30,9 +30,9 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -51,7 +51,7 @@ jobs:
       specs: ${{ steps.diff.outputs.specs }}
       has_specs: ${{ steps.diff.outputs.has_specs }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -100,9 +100,9 @@ jobs:
           --health-start-period 90s
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -124,7 +124,7 @@ jobs:
           npx playwright test $SPECS --reporter=github
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report-pr-${{ github.run_id }}
@@ -132,7 +132,7 @@ jobs:
           retention-days: 14
 
       - name: Upload test results on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: test-results-pr-${{ github.run_id }}

--- a/.github/workflows/update-coverage-summary.yml
+++ b/.github/workflows/update-coverage-summary.yml
@@ -30,9 +30,9 @@ jobs:
     if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/weekly-stable.yml
+++ b/.github/workflows/weekly-stable.yml
@@ -57,7 +57,7 @@ jobs:
           --health-start-period 90s
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # No actions/setup-node: the Playwright image already ships the Node
       # toolchain it was built against, so we use it directly instead of
@@ -129,7 +129,7 @@ jobs:
 
       - name: Upload Playwright report
         id: upload_report                     # ← id to expose artifact-url to the payload step
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report-weekly-${{ github.run_id }}
@@ -230,7 +230,7 @@ jobs:
 
       - name: Create issue on failure
         if: failure() && github.event_name == 'schedule'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           IMAGE: ${{ inputs.langflow_image || 'langflowai/langflow-nightly' }}:${{ inputs.langflow_image_tag || 'latest' }}
           AUTO_REMOVE_STATUS: ${{ steps.auto_remove.outputs.status }}


### PR DESCRIPTION
## What

Bumps the pinned GitHub Actions to their current Node-24 majors so runs stop being force-run on Node 24 and no longer print the Node 20 deprecation warning.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | **v7** |
| `actions/upload-artifact` | v4 | **v7** |
| `actions/github-script` | v7 | **v9** |
| `actions/setup-node` | v4 | **v6** |

Applied across **all 12 workflow files** — the 11 listed in the issue plus `build-ollama-image.yml`, which also pinned `checkout@v4`. Pure 1:1 version swaps on the `uses:` lines; **no step logic changed** (58 insertions / 58 deletions). `actions/setup-python@v5` and `docker/login-action@v3` are left untouched (not implicated in the Node 20 warning).

## Validation

- All target major tags confirmed to exist as moving majors (`checkout@v7`, `upload-artifact@v7`, `github-script@v9`, `setup-node@v6`).
- All 12 workflow files re-parse as valid YAML; every changed line preserves its `uses:` prefix and indentation.
- No old pins left behind; no unrelated actions bumped.
- Breaking-change review: `upload-artifact` immutability break was the v3→v4 jump (already crossed; artifact names are per-run-unique). `github-script` scripts use only stable surface (`github.rest.issues.*`, `context`, `core`, `fs`). `checkout`/`setup-node` options in use (`fetch-depth`, `repository`, `path`, `node-version`, `cache`) are all still supported. Container jobs run on the Playwright `noble` image (glibc ≥2.28), satisfying Node 24.

The `github-script@v9` create-issue steps only fire on scheduled/failure runs and can't be exercised by PR CI; the `checkout`/`setup-node`/`upload-artifact` bumps are exercised directly by `pr-validation.yml` on this PR.

Closes #573