### PR TITLE
fix(mcp): close canvas-controls menu before opening MCP server modal

### DIFF
--- a/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
@@ -645,7 +645,14 @@ test(
     await page.getByTestId("fit_view").click();
 
     await zoomOut(page, 3);
-    await page.getByTestId("canvas_controls_dropdown").click({ force: true });
+
+    // zoomOut() already toggles the canvas-controls menu closed. The previous
+    // extra click({ force: true }) here re-opened it, leaving the Radix zoom
+    // menu overlay on screen where it intercepted the mcp-server-dropdown click
+    // ("<html> intercepts pointer events"). Ensure the menu is fully closed
+    // before interacting with the MCP node.
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("zoom_out")).toBeHidden();
 
     await openAddMcpServerModal(page);
 


### PR DESCRIPTION
## Problem

`mcp server tools should be refreshed when editing a server` (`mcp-server.spec.ts:622`, `@release`) failed deterministically against `langflowai/langflow-nightly:latest`:

```
TimeoutError: locator.click: Timeout 3000ms exceeded.
  - waiting for getByTestId('mcp-server-dropdown')
  - <html lang="en"> intercepts pointer events
```

## Root cause — test logic, not a product regression

The MCP-server testids are intact and clickable. The click was intercepted because the **canvas-controls Radix zoom menu was left open**, and its full-viewport overlay swallowed the pointer event.

`zoomOut()` already toggles that menu **closed** at the end of every run (verified against `tests/helpers/ui/zoom-out.ts`). The extra `canvas_controls_dropdown.click({ force: true })` that followed it toggled the already-closed menu **back open**, and nothing closed it before `openAddMcpServerModal(page)`.

## Fix

- Remove the unbalanced re-open toggle.
- Add an explicit close guard before the MCP step: `Escape` + assert the zoom menu is hidden (`zoom_out` is only mounted while the menu is open, so `toBeHidden()` is a reliable closed-menu invariant — the same invariant `zoomOut()` keys off).

## Validation

- Ran the test green against `langflowai/langflow-nightly:latest` (1 passed, ~1.2m).
- `npm run typecheck` and `npm run lint` pass (0 errors).

## Notes

- This test is tagged `@release` (happy-path, not `@stable`): it is intentionally **not** in the daily `@stable` workflow because it carries a hard external dependency (`uvx mcp-server-fetch` — network + tool install) that is unsuitable for the unattended daily run. This matches the issue's own framing and is a pre-existing condition, unchanged by this PR.
- No spec doc exists under `docs/` for `mcp/server` (inherited spec predating the spec-doc requirement); none is added here as this is a scoped triage fix.

Closes #576