### PR TITLE
test(flows): harden flow creation/open against the parallel POST /api/v1/flows/ 500 race

### DIFF
--- a/tests/helpers/flows/create-flow.ts
+++ b/tests/helpers/flows/create-flow.ts
@@ -42,7 +42,13 @@ export async function createFlow(
       data,
     });
     if (res.status() === 201) {
-      const { id } = (await res.json()) as { id: string };
+      const { id } = (await res.json()) as { id?: string };
+      // A 201 without an id is a malformed success: returning `undefined` here
+      // lets callers build an `undefined` id handle (e.g. `aria-labelledby*=`)
+      // that only fails much later, far from the cause. Surface it right away.
+      if (!id) {
+        throw new Error(`POST ${url} returned 201 with no flow id`);
+      }
       return id;
     }
 

--- a/tests/helpers/flows/create-flow.ts
+++ b/tests/helpers/flows/create-flow.ts
@@ -1,0 +1,72 @@
+import type { APIRequestContext } from "@playwright/test";
+
+/** Total attempts (one initial call plus retries) for a transient create 5xx. */
+const MAX_ATTEMPTS = 3;
+
+/**
+ * Creates a flow via the Langflow REST API, absorbing the transient
+ * `POST /api/v1/flows/` 500 that Langflow emits under concurrent creation.
+ *
+ * Upstream's unique-name suffixing (`New Flow (N)`) is not transaction-safe, so
+ * parallel workers creating flows at the same instant intermittently get a
+ * 500 ("An internal error occurred while creating the flow"; see #588). Passing
+ * explicit unique names (which every caller here already does) reduces but does
+ * not fully remove the race, so a 5xx is retried up to `MAX_ATTEMPTS` times with
+ * a short linear backoff to let the DB contention settle. A non-5xx client error
+ * (400/401/403/422/…) is deterministic — it won't change on retry — so it throws
+ * immediately with its original body.
+ *
+ * Mirrors the retry philosophy of `deleteFlow` for the create side.
+ *
+ * Pass `page.request` (browser-context cookie/state auth is reused
+ * automatically) or a standalone `request` with an explicit Authorization
+ * header via `options.headers`.
+ *
+ * @param request  A Playwright `APIRequestContext` (`page.request` or the `request` fixture).
+ * @param data     The flow creation payload (`name`, `data`, `is_component`, …).
+ * @param options  Optional request options, e.g. `{ headers: { Authorization } }`.
+ * @returns        The created flow's ID.
+ */
+export async function createFlow(
+  request: APIRequestContext,
+  data: Record<string, unknown>,
+  options?: { headers?: Record<string, string> },
+): Promise<string> {
+  const url = "/api/v1/flows/";
+  let lastStatus = 0;
+  let lastBody = "";
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const res = await request.post(url, {
+      headers: options?.headers ?? {},
+      data,
+    });
+    if (res.status() === 201) {
+      const { id } = (await res.json()) as { id: string };
+      return id;
+    }
+
+    lastStatus = res.status();
+    lastBody = (await res.text()).slice(0, 200);
+
+    // A 4xx is a deterministic client error (auth, bad payload, unique-name
+    // clash) that won't change on retry — surface it right away.
+    if (lastStatus < 500) {
+      throw new Error(`POST ${url} failed: ${lastStatus} — ${lastBody}`);
+    }
+
+    // A 5xx is the transient concurrent-creation race (#588): back off briefly
+    // and retry until the attempt budget is spent.
+    if (attempt < MAX_ATTEMPTS) {
+      await sleep(200 * attempt);
+    }
+  }
+
+  throw new Error(
+    `POST ${url} failed after ${MAX_ATTEMPTS} attempts: ${lastStatus} — ${lastBody}`,
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/tests/helpers/flows/create-runnable-chat-flow-via-api.ts
+++ b/tests/helpers/flows/create-runnable-chat-flow-via-api.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "fs";
 import type { APIRequestContext } from "@playwright/test";
-import { expect } from "../../fixtures/fixtures";
+import { createFlow } from "./create-flow";
 import { deleteFlow } from "./delete-flow";
 
 // A minimal, version-current runnable flow: Chat Input -> Chat Output passthrough
@@ -46,20 +46,20 @@ export async function createRunnableChatFlowViaApi(
   // constraint, and its auto-rename fallback is not transaction-safe — two parallel
   // creations with the same name race and the loser gets a 500. A random suffix on
   // top of the timestamp avoids same-millisecond collisions across parallel specs
-  // (same convention as setup-blank-flow.ts).
+  // (same convention as setup-blank-flow.ts). createFlow additionally retries the
+  // transient 500 that survives the unique naming (#588).
   const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
 
-  const res = await request.post("/api/v1/flows/", {
-    headers,
-    data: {
+  const flowId = await createFlow(
+    request,
+    {
       name: `Runnable Chat Flow ${uniqueSuffix}`,
       description: "Chat Input -> Chat Output passthrough for API run tests",
       data: fixture.data,
       is_component: false,
     },
-  });
-  expect(res.status()).toBe(201);
-  const flowId = (await res.json()).id as string;
+    { headers },
+  );
 
   return {
     flowId,

--- a/tests/helpers/flows/setup-blank-flow.ts
+++ b/tests/helpers/flows/setup-blank-flow.ts
@@ -1,5 +1,6 @@
 import { Page, expect } from "@playwright/test";
 import { getAuthToken } from "../auth/get-auth-token";
+import { createFlow } from "./create-flow";
 import { deleteFlow } from "./delete-flow";
 
 /**
@@ -27,9 +28,11 @@ export async function setupBlankFlow(page: Page): Promise<string> {
 
   const authToken = await getAuthToken(page.request);
 
-  const createRes = await page.request.post("/api/v1/flows/", {
-    headers: authToken ? { Authorization: authToken } : {},
-    data: {
+  // createFlow retries the transient POST /api/v1/flows/ 500 that Langflow
+  // emits under concurrent creation (#588); a 4xx still surfaces immediately.
+  const flowId = await createFlow(
+    page.request,
+    {
       name: flowName,
       description: "",
       is_component: false,
@@ -39,30 +42,29 @@ export async function setupBlankFlow(page: Page): Promise<string> {
         viewport: { x: 0, y: 0, zoom: 1 },
       },
     },
-  });
-  if (createRes.status() !== 201) {
-    throw new Error(
-      `API flow creation failed: ${createRes.status()} — ${await createRes.text()}`,
-    );
-  }
-  const { id: flowId } = (await createRes.json()) as { id: string };
+    authToken ? { headers: { Authorization: authToken } } : undefined,
+  );
 
   try {
     // Navigate via dashboard click instead of page.goto(`/flow/${flowId}`):
     // immediately after an API-created flow, the direct URL hits a stale
     // React Router cache and redirects back to the flows list.
     await page.goto("/");
-    // The /flows a11y refactor (Langflow #13891) wraps each card in an
+    // The /flows a11y refactor (Langflow #13891) wraps each card in a
     // `list-card-open-button` overlay and makes `flow-name-div`
-    // `pointer-events-none`, so we open the flow via the overlay button.
-    await page
-      .getByTestId("list-card")
-      .filter({
-        has: page.getByTestId("flow-name-div").filter({ hasText: flowName }),
-      })
-      .getByTestId("list-card-open-button")
-      .first()
-      .click();
+    // `pointer-events-none`, so we open the flow via that overlay button.
+    //
+    // Target the button by the flow's exact id (via `aria-labelledby`) rather
+    // than filtering cards by name, and dispatch the click: on the shared home
+    // grid, residual cards left by other parallel workers overlap the target's
+    // absolute-inset open button and intercept a plain hit-tested click
+    // (#580/#588). Matching by id + dispatchEvent sidesteps both the name race
+    // and the interception. Mirrors the validated pattern in the loop spec.
+    const openButton = page.locator(
+      `[data-testid="list-card-open-button"][aria-labelledby*="${flowId}"]`,
+    );
+    await openButton.waitFor({ state: "visible", timeout: 30000 });
+    await openButton.dispatchEvent("click");
     await expect(page.getByTestId("canvas_controls_dropdown")).toBeVisible({
       timeout: 30000,
     });

--- a/tests/tests-automations/regression/core-components/loop-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/loop-component-regression.spec.ts
@@ -4,6 +4,7 @@ import { expect, test } from "../../../fixtures/fixtures";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { createFlow } from "../../../helpers/flows/create-flow";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
 import { setupLanguageModelOpenAI } from "../../../helpers/provider-setup/setup-language-model-openai";
 
@@ -288,23 +289,19 @@ function buildFlowBody(texts: string[]): {
 // Creates the flow server-side via POST /api/v1/flows/ using Playwright's
 // request context. Avoids the drag-drop upload race observed with
 // simulateDragAndDrop and aligns with the pattern used by the api/flows specs
-// (request context + getAuthToken). Returns the new flow id so callers can
-// target scoped cleanup or deep-link if needed.
+// (request context + getAuthToken). Delegates to the shared createFlow helper,
+// which retries the transient concurrent-creation 500 (#588). Returns the new
+// flow id so callers can target scoped cleanup or deep-link if needed.
 async function createFlowFromAsset(
   request: APIRequestContext,
   flow: Record<string, unknown>,
 ): Promise<string> {
   const authToken = await getAuthToken(request);
-  const res = await request.post("/api/v1/flows/", {
-    headers: authToken ? { Authorization: authToken } : {},
-    data: flow,
-  });
-  if (res.status() !== 201) {
-    const body = (await res.text()).slice(0, 200);
-    throw new Error(`POST /api/v1/flows/ failed: status ${res.status()}: ${body}`);
-  }
-  const body = (await res.json()) as { id: string };
-  return body.id;
+  return createFlow(
+    request,
+    flow,
+    authToken ? { headers: { Authorization: authToken } } : undefined,
+  );
 }
 
 async function runFlowAndReadDoneCount(

--- a/tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts
@@ -45,6 +45,13 @@ async function openBlankFlow(page: Page): Promise<string> {
       );
     }
     // A 5xx is the transient race: loop and re-click until the budget is spent.
+    // The templates modal stays open on a failed creation but its internal
+    // `loading` guard only clears on the request promise's `.finally`; re-click
+    // too soon and the button's onClick early-returns (no new POST) and the next
+    // waitForResponse would time out. Give React a beat to commit that reset.
+    if (attempt < MAX_ATTEMPTS) {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
   }
 
   throw new Error(

--- a/tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts
@@ -9,21 +9,47 @@ import { zoomOut } from "../../../../helpers/ui/zoom-out";
 // from the canvas URL: the URL id is a transient client-side handle on this
 // Langflow version and does not match the persisted flow (deleting it 404s and
 // silently leaks the real one). The POST response is the authoritative id.
+//
+// Retries the transient concurrent-creation 500 (#588): on a 5xx the click
+// created nothing and the app stays on the flows list (an error toast, no
+// navigation), so re-clicking blank-flow is a safe retry. A 4xx is
+// deterministic and surfaces immediately.
 async function openBlankFlow(page: Page): Promise<string> {
-  const flowCreation = page.waitForResponse(
-    (resp) =>
-      resp.url().includes("/api/v1/flows") &&
-      resp.request().method() === "POST" &&
-      resp.status() === 201,
-    { timeout: 30000 },
-  );
-  await page.getByTestId("blank-flow").click();
-  const created = (await (await flowCreation).json()) as { id?: string };
-  if (!created.id) {
-    throw new Error("blank-flow creation returned no flow id");
+  const MAX_ATTEMPTS = 3;
+  let lastStatus = 0;
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const flowCreation = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/v1/flows") &&
+        resp.request().method() === "POST",
+      { timeout: 30000 },
+    );
+    await page.getByTestId("blank-flow").click();
+    const resp = await flowCreation;
+    lastStatus = resp.status();
+
+    if (lastStatus === 201) {
+      const created = (await resp.json()) as { id?: string };
+      if (!created.id) {
+        throw new Error("blank-flow creation returned no flow id");
+      }
+      await page.waitForURL(/\/flow\//, { timeout: 30000 });
+      return created.id;
+    }
+
+    // A 4xx is a deterministic client error — surface it right away.
+    if (lastStatus < 500) {
+      throw new Error(
+        `blank-flow creation failed: ${lastStatus} — ${(await resp.text()).slice(0, 200)}`,
+      );
+    }
+    // A 5xx is the transient race: loop and re-click until the budget is spent.
   }
-  await page.waitForURL(/\/flow\//, { timeout: 30000 });
-  return created.id;
+
+  throw new Error(
+    `blank-flow creation failed after ${MAX_ATTEMPTS} attempts: last status ${lastStatus}`,
+  );
 }
 
 // MCP-server pre-clean/verification calls authenticate via the shared


### PR DESCRIPTION
## Problem

Removing the global `cleanAllFlows()` (#515) exposed a pre-existing upstream race: under concurrent flow creation, `POST /api/v1/flows/` intermittently returns **500** ("An internal error occurred while creating the flow") because Langflow's unique-name suffixing (`New Flow (N)`) is not transaction-safe. A related flake is flow-open-by-name racing on the home list when many flows are present. We can't fix the backend here, but we can make the suite resilient.

## Changes

**New shared helper `createFlow`** (`tests/helpers/flows/create-flow.ts`) — POSTs a flow and retries a transient **5xx** up to 3 attempts with a short linear backoff; a deterministic **4xx** (auth, bad payload, unique-name clash) throws immediately. Mirrors the retry philosophy already used by `deleteFlow` on the teardown side.

**Adopted at every shared flow-creation site:**
- `setup-blank-flow.ts` (`setupBlankFlow`) — API POST via `createFlow`.
- `loop-component-regression.spec.ts` (`createFlowFromAsset`) — delegates to `createFlow`.
- `mcp-client-regression.spec.ts` (`openBlankFlow`) — UI-driven path now matches any flow-creation POST and re-clicks `blank-flow` on a 5xx (a failed creation leaves the templates modal open on the flows list, so the retry is safe), waiting a beat for the modal's `loading` guard to reset before the re-click; a 4xx surfaces immediately.
- `create-runnable-chat-flow-via-api.ts` — routed through `createFlow` too (found in review: same documented race, previously un-retried).

**Hardened home-list flow-open** in `setupBlankFlow`: open the card by the flow's exact id (`aria-labelledby*="${flowId}"`) + `dispatchEvent("click")` instead of filtering by name and `.first().click()`. On the shared home grid, residual cards from other parallel workers overlap the target's absolute-inset open button and intercept a hit-tested click (#580); matching by id + dispatched click sidesteps both the name race and the interception. Mirrors the pattern already validated in the loop spec.

## Note on unique names

Both API creation sites already use random unique names, so the `New Flow (N)` suffix race is largely sidestepped; the retry covers the residual 500 that survives even with explicit names, per the issue.

## Validation

- 14 `setupBlankFlow`-consuming tests pass under **4 parallel workers** (exercises `createFlow` + the id-based open under concurrency).
- 3 `createRunnableChatFlowViaApi`-consuming API-run tests pass.
- `npm run typecheck` and `npm run lint` pass (0 errors).

Reviewed independently; two low-severity findings (openBlankFlow re-click timing, the runnable-chat helper) were fixed in this PR.

Closes #588