### PR TITLE
test(api): add polling-response event-delivery spec (#697)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -461,7 +461,7 @@
 - [x] Send text message → exercised by `playground-ux.spec.ts`, `playground-message-edit.spec.ts`, `playground-session-nav.spec.ts` and others
 - [x] Receive LLM response → exercised by all specs that send a message via ChatInput → ChatOutput echo flow
 - [-] Response streaming (SSE) → no dedicated spec; exercised implicitly by `playground-ux.spec.ts`
-- [-] Response polling → no dedicated spec
+- [x] Response polling → api/flows/api-build-polling-response.spec.ts
 - [-] Direct response → no dedicated spec
 - [x] Playground UX (playground-ux) → `playground/playground-ux.spec.ts`
 - [x] Send empty message — send button stays enabled by design (only disabled while a file upload is in progress) → `playground/playground-empty-message-send.spec.ts`
@@ -759,7 +759,7 @@
 | `core-functionality/llm-agents/` | 39 | 30 | 2 | 1 | 6 |
 | `core-functionality/model-provider/` | 31 | 31 | 0 | 0 | 0 |
 | `core-functionality/observability-monitoring/` | 24 | 16 | 7 | 0 | 1 |
-| `core-functionality/playground/` | 48 | 43 | 3 | 1 | 1 |
+| `core-functionality/playground/` | 48 | 44 | 2 | 1 | 1 |
 | `core-functionality/project-management/` | 11 | 4 | 6 | 1 | 0 |
 | `core-functionality/templates/` | 41 | 2 | 39 | 0 | 0 |
 | `flow-functionality/` | 28 | 13 | 13 | 2 | 0 |
@@ -767,7 +767,7 @@
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 44 | 7 | 36 | 1 | 0 |
 | `ui-ux/` — Settings | 7 | 3 | 3 | 1 | 0 |
-| **TOTAL** | **451** | **268 (59%)** | **154 (34%)** | **8 (2%)** | **21 (5%)** |
+| **TOTAL** | **451** | **269 (60%)** | **153 (34%)** | **8 (2%)** | **21 (5%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -783,13 +783,15 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 298 `test()` calls carrying the `@stable` tag, distributed across 111 spec
+> 300 `test()` calls carrying the `@stable` tag, distributed across 112 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
 > mix of tagged and untagged tests over time.
 
 #### api/flows/
+- [x] polling is the two-step path: POST returns a job_id shell (no inline events) → `api-build-polling-response.spec.ts`
+- [x] the poll loop drains the build to completion across repeated GET /events calls → `api-build-polling-response.spec.ts`
 - [x] POST /api/v1/custom_component returns valid component structure → `api-custom-component-creation.spec.ts`
 - [x] POST /api/v1/custom_component with invalid code returns error → `api-custom-component-creation.spec.ts`
 - [x] GET /api/v1/all includes component types → `api-custom-component-creation.spec.ts`
@@ -1123,7 +1125,7 @@
 | `core-functionality/auth/` | 13 | 0 |
 | `core-functionality/llm-agents/` | 2 | 6 |
 | `core-functionality/model-provider/` | 0 | 0 |
-| `core-functionality/playground/` | 3 | 1 |
+| `core-functionality/playground/` | 2 | 1 |
 | `mcp/client/` | 7 | 2 |
 | `mcp/server/` | 3 | 4 |
 | `ui-ux/` — Canvas | 36 | 0 |

--- a/docs/api/flows/api-build-polling-response.md
+++ b/docs/api/flows/api-build-polling-response.md
@@ -1,0 +1,102 @@
+# API Build — Polling Response Delivery
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+Validates the **polling** event-delivery path of the flow build API — the transport the Playground uses to receive a flow run's results when `GET /api/v1/config`'s `event_delivery` is `polling` (QA-CHECKLIST §9.1 → "Response polling"). It is the sibling of the direct path (`api-build-direct-response.spec.ts`, issue #698) and the streaming/SSE path (issue #696).
+
+The three delivery modes of `POST /api/v1/build/{flow_id}/flow` split into two transport families:
+
+- **`direct`** — one-step: the `POST` streams the full event body inline; no `job_id` (covered by #698).
+- **`streaming` / `polling`** — two-step: the `POST` returns `{ job_id }`, and the client then reads the events from `GET /api/v1/build/{job_id}/events`. The two differ in **how that events endpoint delivers**:
+  - **`streaming`** — a single long-lived `StreamingResponse` (SSE) pushes every event over one held-open connection (#696).
+  - **`polling`** — each `GET …?event_delivery=polling` returns a **discrete, bounded** `application/x-ndjson` response draining whatever events are currently queued, then closes. The client **polls in a loop**, issuing repeated GETs, until a batch carries the terminal `end` event. This mirrors the frontend's `customPollBuildEvents`.
+
+If this test fails, the polling contract has regressed: a Langflow instance configured with `event_delivery=polling` would leave the Playground unable to reconstruct a run from the incremental batches (client-driven progress), or the events endpoint would stop honoring the polling mode.
+
+The spec drives the endpoint at the **REST layer** (Playwright `request` fixture) with a deterministic **Chat Input → Chat Output** passthrough flow (no LLM, no provider key). The echoed value is a per-run sentinel, so "the flow actually ran and its output was delivered through the poll loop" cannot pass on a structurally valid but empty shell.
+
+---
+
+## Tags *(required)*
+
+`@api` `@regression` `@playground` `@stable`
+
+---
+
+## Step by step *(required)*
+
+The spec runs **2 independent tests** via Playwright's `request` fixture, sharing a single flow created in `beforeAll`. The `/build` endpoint authenticates with **Bearer** (`CurrentActiveUser`), so the flow is created with the same Bearer identity that builds it (owner must match).
+
+**Setup (`beforeAll`)**
+1. Obtain a valid Bearer token via `getAuthToken(request)`.
+2. Create a runnable Chat Input → Chat Output passthrough flow via `createRunnableChatFlowViaApi(request, { Authorization: bearer })`; store `flowId` and its `deleteFlow` teardown.
+
+**Teardown (`afterAll`)**
+1. `deleteFlow(request)` — `DELETE /api/v1/flows/{flowId}` with the Bearer. No orphan flows left on the backend.
+
+---
+
+**Test 1 — polling is the two-step path: `POST …?event_delivery=polling` returns a `job_id` shell (no inline events)**
+1. `POST /api/v1/build/{flowId}/flow?event_delivery=polling` with the Bearer and body `{ inputs: { input_value: "polling-handshake" } }`.
+2. Assert response status is `200`.
+3. Assert the body parses as a JSON object with a **string `job_id`** and carries **no inline `event`** — the run's events are NOT in the POST response; they are read from the separate events endpoint (unlike the direct path, whose POST streams the events inline).
+4. Best-effort `POST /api/v1/build/{job_id}/cancel` — this job's events are not drained in this test, so cancel it to avoid a lingering job. (A failed cancel must not fail the assertions above.)
+
+**Test 2 — the poll loop drains the build to completion across repeated `GET …/events?event_delivery=polling` calls**
+1. Build a per-run sentinel (e.g. `POLL-<timestamp>-<rand>`).
+2. `POST /api/v1/build/{flowId}/flow?event_delivery=polling` with `{ inputs: { input_value: <sentinel> } }`; read the `job_id`.
+3. **Poll loop** (bounded by a max-iteration guard): repeatedly `GET /api/v1/build/{job_id}/events?event_delivery=polling`. For each response:
+   - Assert status `200` and `Content-Type: application/x-ndjson`.
+   - Parse the body as NDJSON and accumulate the events.
+   - Stop once an accumulated event's `event` is `end`; sleep briefly between empty batches.
+4. Assert the accumulated events reconstruct the full lifecycle — they contain `vertices_sorted`, `build_start`, and a terminal `end` event — proving the batched, client-driven delivery reassembled the complete run.
+5. Assert the **Chat Output** message (an `add_message` event with `sender: "Machine"`) echoes the sentinel — the flow genuinely executed and its output arrived through the poll loop. (Matching any `add_message` would also be satisfied by the User input echo, so the output message is asserted specifically.)
+
+---
+
+## Validation criterion *(required)*
+
+- Setup creates one flow; teardown removes it. No orphans on the backend after the suite (verified via `GET /api/v1/flows/`).
+- Test 1: `POST …?event_delivery=polling` returns `200` and a JSON body with a string `job_id` and no inline event stream; the job is cancelled afterwards.
+- Test 2: repeated `GET …/events?event_delivery=polling` calls each return `200` + `application/x-ndjson`; the accumulated events contain `vertices_sorted`, `build_start` and a terminal `end`, and the `sender: "Machine"` output message echoes the per-run sentinel.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Direct delivery (`POST …?event_delivery=direct`, inline stream) → dedicated spec, issue #698.
+- Streaming/SSE delivery (`GET …/events?event_delivery=streaming`, single long-lived connection) → dedicated spec, issue #696.
+- The Playground **UI** rendering under each delivery mode (the `withEventDeliveryModes` config-interception path) — the visible chat is identical across modes; the distinguishing behavior lives at the transport layer asserted here.
+- The exact number of poll iterations (timing-dependent — the test asserts the loop reaches completion, not how many batches it took).
+- Correctness of the run's output content beyond the echoed sentinel (LLM semantics, tool calls, multi-component graphs).
+- Error/abort paths of the events endpoint (404 job, cancel mid-poll).
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and reachable at `PLAYWRIGHT_BASE_URL`.
+- Default superuser credentials available (`LANGFLOW_SUPERUSER` / `LANGFLOW_SUPERUSER_PASSWORD`) — used by `getAuthToken` to mint the Bearer.
+- No provider key required — the flow is a deterministic Chat Input → Chat Output echo.
+
+---
+
+## External dependencies *(required)*
+
+- `tests/helpers/auth/get-auth-token.ts` — issues a valid `Bearer` via `/api/v1/auto_login`; if its contract changes, `beforeAll` breaks.
+- `tests/helpers/flows/create-runnable-chat-flow-via-api.ts` — builds the runnable Chat Input → Chat Output flow from `tests/assets/flows/chat-io-ok-trace-fixture.json`; if the fixture goes stale against the current Langflow schema, `beforeAll` breaks (shared with `api-run-flow.spec.ts` and `api-build-direct-response.spec.ts`).
+- `src/backend/base/langflow/api/v1/chat.py` — `POST /api/v1/build/{flow_id}/flow` (returns `{ job_id }` for polling) and `GET /api/v1/build/{job_id}/events`.
+- `src/backend/base/langflow/api/build.py` — `get_flow_events_response`; the polling branch drains the queue non-blocking and returns a bounded `application/x-ndjson` `Response`. Changing this branch (media type, batching, the `end` sentinel) breaks Test 2.
+- `src/backend/base/langflow/api/v1/flows.py` — `POST /api/v1/flows/` used in setup and `DELETE /api/v1/flows/{id}` used in teardown.
+
+---
+
+## Notes *(optional)*
+
+- **Design choice — API layer over UI.** The three delivery modes are a backend transport contract; the Playground chat looks identical regardless of which mode delivered the events. Asserting the polling path at the REST layer gives a deterministic observable (a `job_id` handshake plus a client-driven poll loop that reassembles the run) that a UI test could only reach by inspecting network traffic, with added flake.
+- **Both polling and streaming events responses use `application/x-ndjson`** — the media type does NOT distinguish them. The distinction is the *response semantics*: polling returns a bounded batch per call and requires repeated GETs; streaming holds one connection open. This spec exercises the poll loop rather than asserting on a content-type contrast.
+- The events body is **NDJSON**, one event object per line — parse line-by-line; `response.json()` on it would throw.

--- a/tests/tests-automations/regression/api/flows/api-build-polling-response.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-build-polling-response.spec.ts
@@ -1,0 +1,167 @@
+import type { APIRequestContext } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { createRunnableChatFlowViaApi } from "../../../../helpers/flows/create-runnable-chat-flow-via-api";
+
+// Validates the `polling` event-delivery path of the flow build API — the
+// transport the Playground uses to receive a flow run's results when
+// event_delivery is `polling` (QA-CHECKLIST §9.1 → "Response polling").
+// Sibling of the direct path (api-build-direct-response.spec.ts, #698) and the
+// streaming/SSE path (#696).
+//
+// Polling is the two-step transport: POST /build/{flow_id}/flow?event_delivery=polling
+// returns { job_id }, and the client then reads events from
+// GET /build/{job_id}/events?event_delivery=polling. Each GET returns a discrete,
+// bounded application/x-ndjson batch draining the currently-queued events, then
+// closes — so the client POLLS IN A LOOP until a batch carries the terminal `end`
+// event (mirrors the frontend's customPollBuildEvents). This differs from
+// streaming, which pushes every event over a single long-lived connection.
+//
+// The flow is a deterministic Chat Input -> Chat Output passthrough (no LLM), and
+// the echoed value is a per-run sentinel, so "the flow ran and its output arrived
+// through the poll loop" cannot pass on a structurally valid but empty shell.
+// The /build endpoint authenticates with Bearer (CurrentActiveUser), so the flow
+// is created with the same Bearer identity that builds it.
+
+interface BuildEvent {
+  event?: string;
+  data?: { text?: string; sender?: string; sender_name?: string };
+}
+
+/** Parses an NDJSON body into one object per non-empty line. */
+function parseNdjson(body: string): BuildEvent[] {
+  return body
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line));
+}
+
+const POLL_MAX_ITERATIONS = 40;
+const POLL_EMPTY_DELAY_MS = 250;
+
+test.describe("POST /api/v1/build/{flow_id}/flow — polling response delivery", () => {
+  let flowId: string;
+  let bearerToken: string;
+  let deleteFlow: (reqOverride?: APIRequestContext) => Promise<void>;
+
+  test.beforeAll(async ({ request }) => {
+    bearerToken = await getAuthToken(request);
+
+    // Create the runnable flow under the same Bearer identity that will build it —
+    // /build authenticates with Bearer and the flow owner must match.
+    const flow = await createRunnableChatFlowViaApi(request, {
+      Authorization: bearerToken,
+    });
+    flowId = flow.flowId;
+    deleteFlow = flow.deleteFlow;
+  });
+
+  test.afterAll(async ({ request }) => {
+    // Delete flow with afterAll's OWN request — the beforeAll `request` that
+    // created it cannot be reused here (Playwright fixture-scope rule).
+    if (deleteFlow) {
+      await deleteFlow(request);
+    }
+  });
+
+  test(
+    "polling is the two-step path: POST returns a job_id shell (no inline events)",
+    { tag: ["@api", "@regression", "@playground", "@stable"] },
+    async ({ request }) => {
+      const response = await request.post(
+        `/api/v1/build/${flowId}/flow?event_delivery=polling`,
+        {
+          headers: { Authorization: bearerToken },
+          data: { inputs: { input_value: "polling-handshake" } },
+        },
+      );
+
+      expect(response.status()).toBe(200);
+
+      // The run's events are NOT in the POST response — polling is two-step: the
+      // POST only hands back a job_id, and events are read from the separate
+      // events endpoint. This is the contrast with the direct path (#698), whose
+      // POST streams the events inline.
+      const body = await response.json();
+      expect(typeof body.job_id).toBe("string");
+      expect(body.job_id.length).toBeGreaterThan(0);
+      expect(body.event).toBeUndefined();
+
+      // This job's events are not drained in this test — cancel it best-effort so
+      // it does not linger in the queue service (a failed cancel must not fail the
+      // assertions above).
+      await request
+        .post(`/api/v1/build/${body.job_id}/cancel`, {
+          headers: { Authorization: bearerToken },
+        })
+        .catch(() => {});
+    },
+  );
+
+  test(
+    "the poll loop drains the build to completion across repeated GET /events calls",
+    { tag: ["@api", "@regression", "@playground", "@stable"] },
+    async ({ request }) => {
+      // Per-run sentinel: the Chat Output echoes it, so its presence in the
+      // accumulated events proves the flow executed and its output was delivered
+      // through the poll loop, not a valid-but-empty shell.
+      const sentinel = `POLL-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+
+      const buildResponse = await request.post(
+        `/api/v1/build/${flowId}/flow?event_delivery=polling`,
+        {
+          headers: { Authorization: bearerToken },
+          data: { inputs: { input_value: sentinel } },
+        },
+      );
+      expect(buildResponse.status()).toBe(200);
+      const jobId = (await buildResponse.json()).job_id;
+      expect(typeof jobId).toBe("string");
+
+      // Poll loop: each GET returns a bounded application/x-ndjson batch of the
+      // currently-queued events, then closes. Repeat until a batch carries the
+      // terminal `end` event, accumulating everything (mirrors customPollBuildEvents).
+      const events: BuildEvent[] = [];
+      let reachedEnd = false;
+      for (let i = 0; i < POLL_MAX_ITERATIONS && !reachedEnd; i++) {
+        const pollResponse = await request.get(
+          `/api/v1/build/${jobId}/events?event_delivery=polling`,
+          { headers: { Authorization: bearerToken, Accept: "application/x-ndjson" } },
+        );
+        expect(pollResponse.status()).toBe(200);
+        expect(pollResponse.headers()["content-type"]).toContain(
+          "application/x-ndjson",
+        );
+
+        const batch = parseNdjson(await pollResponse.text());
+        events.push(...batch);
+        reachedEnd = events.some((e) => e.event === "end");
+
+        // The build is near-instant, but a batch can be empty while the next
+        // event is still being produced — back off briefly before polling again.
+        if (!reachedEnd && batch.length === 0) {
+          await new Promise((resolve) => setTimeout(resolve, POLL_EMPTY_DELAY_MS));
+        }
+      }
+
+      // The batched, client-driven delivery reassembled the complete run.
+      expect(reachedEnd).toBe(true);
+      const eventNames = events.map((e) => e.event);
+      expect(eventNames).toContain("vertices_sorted");
+      expect(eventNames).toContain("build_start");
+      expect(eventNames).toContain("end");
+
+      // The Chat Output genuinely executed and its output arrived through the poll
+      // loop. The stream carries two add_message events with the same text — the
+      // User input echo (sender "User") and the Chat Output response (sender
+      // "Machine"). Assert on the OUTPUT message specifically: matching any
+      // add_message would also be satisfied by the input echo alone.
+      const outputMessages = events.filter(
+        (e) => e.event === "add_message" && e.data?.sender === "Machine",
+      );
+      expect(outputMessages.length).toBeGreaterThan(0);
+      expect(outputMessages.some((e) => e.data?.text === sentinel)).toBe(true);
+    },
+  );
+});


### PR DESCRIPTION
## What & why

Adds a dedicated `@stable` spec for the **polling** event-delivery path of the flow build API — the transport the Playground uses to receive a flow run's results when `event_delivery=polling` (QA-CHECKLIST §9.1 → "Response polling"). Sibling of the direct path (#698) and the streaming/SSE path (#696).

The three delivery modes of `POST /api/v1/build/{flow_id}/flow` split into two families:
- **`direct`** — one-step: the `POST` streams the event body inline; no `job_id` (#698).
- **`streaming` / `polling`** — two-step: the `POST` returns `{ job_id }`; the client reads events from `GET /api/v1/build/{job_id}/events`. They differ in how that endpoint delivers:
  - **streaming** — a single long-lived `StreamingResponse` (SSE) over one connection (#696).
  - **polling** — each `GET …?event_delivery=polling` returns a **bounded** `application/x-ndjson` batch draining the currently-queued events, then closes; the client **polls in a loop** until a batch carries the terminal `end` (mirrors the frontend's `customPollBuildEvents`).

Tested at the REST layer (Playwright `request` fixture) with a deterministic Chat Input → Chat Output echo flow — no LLM, no provider key. The echoed value is a per-run sentinel, so "the flow ran and its output arrived through the poll loop" cannot pass on an empty shell.

## Tests

| # | Test | Concrete observable |
|---|---|---|
| 1 | `polling is the two-step path: POST returns a job_id shell (no inline events)` | `200`; JSON body with a string `job_id` and no inline `event` (two-step, unlike direct #698); the job is cancelled (best-effort) |
| 2 | `the poll loop drains the build to completion across repeated GET /events calls` | each poll → `200` + `application/x-ndjson`; accumulated events contain `vertices_sorted` + `build_start` + `end`; the output message (`sender: "Machine"`) echoes the per-run sentinel |

## Notes on design

- **Content-type does NOT distinguish polling from streaming** — both events responses are `application/x-ndjson`. The distinction is response *semantics*: polling returns a bounded batch per call and requires repeated GETs. Test 2 exercises the poll loop rather than asserting a content-type contrast.
- The poll loop is bounded by a max-iteration guard and paced by the server-side blocking `get`; the exact number of polls is timing-dependent and intentionally not asserted.
- The NDJSON parser + event type are duplicated from `api-build-direct-response.spec.ts` on purpose — extracting a shared helper now would couple this PR with #698 (still open). Follow-up: extract to `tests/helpers/other/` once both merge.

## Validation

- **Langflow**: Nightly `1.11.0.dev38` (`main_version` 1.11.0)
- `npm run typecheck` ✅ · `npm run lint` ✅
- `--workers=1 --retries=0`: **2 passed**, 0 flaky across 2 bursts
- **Force-fail (executed, per test)**:
  - Test 1 — `event_delivery=polling → direct` ⇒ `response.json()` throws on NDJSON ⇒ failed ✅
  - Test 2 — `sender "Machine" → "Bot"` ⇒ `outputMessages.length = 0` ⇒ failed ✅
- Independent code-review run before opening; 2 low findings, both acceptable as-is (helper duplication tracked as a post-merge follow-up)
- Flow cleanup verified: id-scoped `afterAll` delete + best-effort cancel of the undrained job; `GET /api/v1/flows/` shows **0 orphans**
- Spec doc under `docs/api/flows/api-build-polling-response.md`; QA-CHECKLIST §9.1 bullet flipped to `[x]` (auto-generated blocks regenerated)

Note: `--trace=on`/`--debug` are N/A for this API-only spec (no UI); step verification is via clean `--retries=0` bursts + executed force-fails + a live contract probe.

Closes #697
