### PR TITLE
test(workspace): harden and promote delete-individual-flow to @stable (#682)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -609,7 +609,7 @@
 - [-] Flow settings
 
 #### 12.3 Delete Flow
-- [-] Delete individual flow
+- [x] Delete individual flow → `ui-ux/actionsMainPage-shard-1.spec.ts`
 - [x] Delete multiple flows (bulk actions) → `core-functionality/project-management/bulk-actions.spec.ts`
 - [x] Shift-click range select + Ctrl/Cmd-click multi-select on main page → `core-functionality/project-management/bulk-actions.spec.ts`
 - [x] Bulk download selected flows → `core-functionality/project-management/bulk-actions.spec.ts`

--- a/docs/ui-ux/actionsMainPage-shard-1.md
+++ b/docs/ui-ux/actionsMainPage-shard-1.md
@@ -1,0 +1,117 @@
+# Main page actions (shard 1) — delete individual flow, search flows, search components
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+Three main-page (home) actions. The promotion target of #682 is **Test 1 —
+"select and delete a flow"** (QA-CHECKLIST §12.3 "Delete individual flow"):
+deleting a single flow through its card's dropdown menu removes it
+everywhere — the confirmation modal gates the action, the card disappears
+from the home grid, and the flow is gone from the backend.
+
+1. **select and delete a flow** *(promoted by #682)* — create a flow from
+   the Basic Prompting template, return to home, open THAT flow's card
+   dropdown (id-scoped — never `.first()`, which under parallel workers can
+   target another worker's card), delete it through the confirmation modal,
+   and prove removal three ways: success toast, card gone from the grid,
+   `GET /api/v1/flows/{id}` → 404.
+2. **search flows** — the home search filters the flow grid by name
+   *(known-weak: assertions are dead `isVisible()`/`isHidden()` booleans —
+   NOT hardened here, out of #682's scope; do not promote as-is)*.
+3. **search components** — sidebar component search after saving components
+   *(known-weak: whole body inside an `if (visible)` guard, the #505
+   conditional-bypass class — NOT hardened here, do not promote as-is.
+   PROVEN vacuous on 1.11.0.dev41 during #682's force-fail pass: the
+   `components-btn` guard is false, the body never executes, and an
+   in-guard mutation cannot make the test fail)*.
+
+## What broke the old Test 1 contract *(hardening rationale)*
+
+The pre-#682 test could never fail: both its "assertions" were bare
+`locator.isVisible()` calls whose boolean result was discarded (a fully
+broken delete flow still produced a green run), the dropdown was targeted
+with `.first()` (parallel-unsafe), and nothing verified the flow actually
+disappeared. Hardening these is the required force-failability work of a
+validate-&-promote issue (see #505 precedent).
+
+---
+
+## Tags *(required)*
+
+- Test 1: `@stable` `@release` `@workspace` `@mainpage` (promoted by #682;
+  `@workspace` added — flow lifecycle management is the subject)
+- Tests 2–3: `@release` `@mainpage` (unchanged; not promoted — see
+  known-weak notes)
+
+---
+
+## Step by step *(required — Test 1, the #682 target)*
+
+1. Track every `POST /api/v1/flows` → 201 id via a `page.on("response")`
+   listener (cleanup + the id handle for scoping; the canvas URL id is
+   transient on 1.11).
+2. Bootstrap to the templates modal and instantiate **Basic Prompting**;
+   wait for the canvas, then navigate back to home (`icon-ChevronLeft`).
+3. Locate the created flow's card: `list-card` containing
+   `flow-name-{flowId}` (scouted live on 1.11.0.dev38); open its
+   `home-dropdown-menu`.
+4. Click `btn_delete_dropdown_menu`; assert the confirmation modal renders
+   its warning (*"This will permanently delete the flow and its message
+   history."* / *"This can't be undone."*).
+5. Confirm via `btn_delete_delete_confirmation_modal`.
+6. **Prove removal (all hard asserts):**
+   - toast *"Selected items deleted successfully"* becomes visible;
+   - the `flow-name-{flowId}` card is gone from the grid (count 0);
+   - `GET /api/v1/flows/{flowId}` returns **404** (backend truth, not just
+     UI state).
+
+---
+
+## Validation criterion *(required)*
+
+- The confirmation modal gates the deletion and names the consequence.
+- After confirming: success toast visible, the specific flow's card no
+  longer renders, and the flows API returns 404 for its id. A regression in
+  any layer (menu action, modal wiring, backend delete, list refresh) fails
+  the test.
+
+---
+
+## Flow cleanup *(required)*
+
+Test 1 deletes its own flow as the behavior under test; the id-scoped
+`test.afterEach` (`createdFlowIds` + `deleteFlow`, which tolerates 404 as
+"already gone") covers the failure path — a run that dies before the delete
+still removes its flow. Tests 2–3 create up to 3 template flows each and
+previously leaked all of them; the same shared `afterEach` now cleans every
+tracked id. Behavioral force-fail contract: no-op the cleanup and the flow
+count grows.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Bulk deletion / multi-select (covered by
+  `project-management/bulk-actions.spec.ts`, §12.3 siblings).
+- Cancel path of the confirmation modal (`btn_cancel_delete_confirmation_modal`).
+- Deletion from inside the canvas or via API-only (API delete is exercised
+  by helpers throughout the suite).
+- Hardening of Tests 2–3's dead assertions (out of #682 scope — flagged in
+  their known-weak notes above).
+
+---
+
+## External dependencies *(required)*
+
+- None external to Langflow (no LLM call — Basic Prompting is only
+  instantiated, never run).
+- Home-page card markup: `list-card`, `flow-name-{id}`,
+  `home-dropdown-menu`, `btn_delete_dropdown_menu`,
+  `btn_delete_delete_confirmation_modal` /
+  `btn_cancel_delete_confirmation_modal` (scouted live on 1.11.0.dev38;
+  renaming these testids breaks the test).
+- Toast wording "Selected items deleted successfully" (shared with bulk
+  delete).

--- a/tests/tests-automations/regression/ui-ux/actionsMainPage-shard-1.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/actionsMainPage-shard-1.spec.ts
@@ -1,45 +1,90 @@
-import { test } from "../../../fixtures/fixtures";
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { openNewFlowTemplatesModal } from "../../../helpers/flows/open-new-flow-templates-modal";
+import { loadTemplateByName } from "../../../helpers/flows/load-template-by-name";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+
+// All three tests instantiate template flows; track every POST /api/v1/flows
+// → 201 id and delete them in afterEach (id-scoped — never name-based or
+// delete-all). Test 1 deletes its own flow as the behavior under test
+// (deleteFlow tolerates 404 = already gone); tests 2-3 previously leaked up
+// to 3 template flows each.
+const createdFlowIds: string[] = [];
+
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {}); // non-JSON / batch payloads
+    }
+  });
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, { headers: { Authorization: bearer } }).catch(() => {});
+  }
+});
 
 test(
   "select and delete a flow",
-  { tag: ["@release", "@mainpage"] },
-  async ({ page }) => {
-    await awaitBootstrapTest(page);
+  { tag: ["@stable", "@release", "@workspace", "@mainpage", "@ui-ux"] },
+  async ({ page, request }) => {
+    trackCreatedFlows(page);
 
-    await page.getByTestId("side_nav_options_all-templates").click();
-    await page.getByRole("heading", { name: "Basic Prompting" }).click();
+    // Create the flow to delete — loadTemplateByName returns the
+    // authoritative POST-201 flow id (the canvas URL id is transient on
+    // 1.11), which scopes every step below to THIS flow.
+    const flowId = await loadTemplateByName(page, "Basic Prompting");
 
-    await page.waitForSelector('[data-testid="sidebar-search-input"]', {
-      timeout: 100000,
+    await page.goto("/");
+    const flowCard = page
+      .getByTestId("list-card")
+      .filter({ has: page.getByTestId(`flow-name-${flowId}`) });
+    await expect(flowCard).toBeVisible({ timeout: 15000 });
+
+    // Open THIS card's dropdown — id-scoped, never .first(): under parallel
+    // workers the first card can belong to another worker's flow, and
+    // deleting it kills that test mid-flight (#553 class).
+    await flowCard.getByTestId("home-dropdown-menu").click();
+    await page.getByTestId("btn_delete_dropdown_menu").click();
+
+    // The confirmation modal gates the action and names the consequence.
+    await expect(
+      page.getByText("This will permanently delete the flow and its message history."),
+    ).toBeVisible({ timeout: 10000 });
+    await page.getByTestId("btn_delete_delete_confirmation_modal").click();
+
+    // Prove removal in all three layers: toast, grid, backend.
+    await expect(
+      page.getByText("Selected items deleted successfully"),
+    ).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId(`flow-name-${flowId}`)).toHaveCount(0, {
+      timeout: 10000,
     });
-
-    await page.getByTestId("icon-ChevronLeft").first().click();
-
-    await page.waitForSelector('[data-testid="home-dropdown-menu"]', {
-      timeout: 5000,
+    const bearer = await getAuthToken(request);
+    const res = await request.get(`/api/v1/flows/${flowId}`, {
+      headers: { Authorization: bearer },
     });
-
-    await page.getByTestId("home-dropdown-menu").first().click();
-    await page.waitForSelector('[data-testid="icon-Trash2"]', {
-      timeout: 1000,
-    });
-    // click on the delete button
-    await page.getByText("Delete").last().click();
-    await page.getByText("This can't be undone.").isVisible({
-      timeout: 1000,
-    });
-
-    //confirm the deletion in the modal
-    await page.getByText("Delete").last().click();
-
-    await page.getByText("Selected items deleted successfully").isVisible();
+    expect(res.status(), "deleted flow must be gone from the backend").toBe(404);
   },
 );
 
 test("search flows", { tag: ["@release", "@mainpage"] }, async ({ page }) => {
+  trackCreatedFlows(page);
   await awaitBootstrapTest(page);
 
   await page.getByTestId("side_nav_options_all-templates").click();
@@ -79,6 +124,7 @@ test(
   "search components",
   { tag: ["@release", "@mainpage"] },
   async ({ page }) => {
+    trackCreatedFlows(page);
     await awaitBootstrapTest(page);
 
     if (await page.getByTestId("components-btn").isVisible()) {


### PR DESCRIPTION
Closes #682 (Wave 2 — Components, RAG, flows & observability · QA-CHECKLIST §12.3 "Delete individual flow").

## What

Validate & promote the individual-flow-deletion coverage in `ui-ux/actionsMainPage-shard-1.spec.ts` ("select and delete a flow") to `@stable` — after the force-failability hardening the promotion required.

## Why the hardening (audit findings)

The pre-existing test **could never fail**:
- both "assertions" were bare `locator.isVisible()` calls with the boolean discarded — a fully broken delete flow still produced a green run;
- the card dropdown was targeted with `.first()` — under parallel workers the first card can belong to another worker's flow, and deleting it kills that test mid-flight (the #553 class);
- nothing verified the flow actually disappeared (no grid re-check, no API check);
- the file leaked up to 5 template flows per run (no cleanup in any of its 3 tests).

## Changes

- **Id-scoped targeting** (testids scouted live): the flow is created via `loadTemplateByName` (authoritative POST-201 id — the canvas URL id is transient on 1.11) and every step operates on `list-card` containing `flow-name-{id}` → `home-dropdown-menu` → `btn_delete_dropdown_menu`.
- **Removal proven in 3 layers**: confirmation-modal warning asserted; after `btn_delete_delete_confirmation_modal` — success toast visible, the flow's card gone (count 0), and `GET /api/v1/flows/{id}` → **404**.
- **Shared id-scoped cleanup** (`createdFlowIds` + `afterEach` `deleteFlow`, 404-tolerant) across the file's 3 tests — leak delta now 0.
- `@stable` + `@workspace`/`@ui-ux` tags on the promoted test; §12.3 bullet → `[x]` with spec path; new spec doc `docs/ui-ux/actionsMainPage-shard-1.md`.
- Siblings ("search flows", "search components") documented **known-weak** in the spec doc and deliberately NOT promoted — "search components" was proven fully **vacuous** on the current nightly during the force-fail pass (its `if (components-btn visible)` guard is false, so the body never executes). Hardening them is follow-up scope.

## Validation

- **Langflow:** `langflowai/langflow-nightly:latest` → **1.11.0.dev41** (instance recreated on the fresh image mid-validation when the pipeline flagged dev38 as stale).
- **Determinism:** pipeline burst 3× (3/3, dev38) + manual burst 3× (3/3, **dev41**), all `--retries=0 --workers=1`, zero `🚨 Backend Error`.
- **Force-fails (pipeline-verified, one per test):**
  - `select and delete a flow` — backend-404 assert flipped to 200 → **failed** ✓
  - `search flows` — essential template heading broken → **failed** ✓
  - `search components` — in-guard mutation did NOT fail (vacuity proof); pre-guard mutation → **failed** ✓
  - Behavioral cleanup FF — `afterEach` no-op'd → **+5 orphan flows** ✓
  - Reverts proven: `grep FF-MUTATION` → 0 + final green run (pipeline gate).
- **Flow cleanup:** orphan count 0 after every green run.
- `npm run typecheck` / `npm run lint`: 0 errors (warnings are the pre-existing baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)