### PR TITLE
test(ui-ux): harden search-flows and redesign search-components against the live surface (#706)

### DIFF
--- a/docs/ui-ux/actionsMainPage-shard-1.md
+++ b/docs/ui-ux/actionsMainPage-shard-1.md
@@ -18,24 +18,46 @@ from the home grid, and the flow is gone from the backend.
    target another worker's card), delete it through the confirmation modal,
    and prove removal three ways: success toast, card gone from the grid,
    `GET /api/v1/flows/{id}` → 404.
-2. **search flows** — the home search filters the flow grid by name
-   *(known-weak: assertions are dead `isVisible()`/`isHidden()` booleans —
-   NOT hardened here, out of #682's scope; do not promote as-is)*.
-3. **search components** — sidebar component search after saving components
-   *(known-weak: whole body inside an `if (visible)` guard, the #505
-   conditional-bypass class — NOT hardened here, do not promote as-is.
-   PROVEN vacuous on 1.11.0.dev41 during #682's force-fail pass: the
-   `components-btn` guard is false, the body never executes, and an
-   in-guard mutation cannot make the test fail)*.
+2. **search flows** *(hardened by #706)* — the home search filters the flow
+   grid by name: with two template flows created (Basic Prompting + Memory
+   Chatbot, both tracked by POST-201 id), searching "Memory Chatbot" leaves
+   the memory flow's card (`flow-name-{id}`) visible and removes the basic
+   flow's card (count 0); clearing the search restores both. Id-anchored
+   asserts — the pre-#706 version discarded its `isVisible()`/`isHidden()`
+   booleans and could not fail.
+3. **search components** *(redesigned by #706 — old premise DEAD)* — the
+   home `components-btn` tab the old test guarded on no longer exists on
+   1.11 (proven vacuous during #682's force-fail pass: the guard was false
+   and the body never executed). Saved components now live in the CANVAS
+   sidebar under the **`disclosure-saved`** category (scouted live on
+   1.11.0.dev41). The redesigned test saves the Chat Input node as a
+   component (node → `more-options-modal` → `icon-SaveAll`), then proves
+   the sidebar search exposes it. **Assert order is part of the contract**
+   (both searches are debounced — a positive assert evaluated first
+   resolves on the pre-filter DOM and can pass vacuously, an FF finding of
+   #706): first the causal negative — searching "Prompt", a component that
+   exists but was NOT saved, must remove `disclosure-saved` once the filter
+   settles — then searching "Chat Input" must bring `disclosure-saved`
+   back, a 0→1 transition that necessarily observes the post-filter
+   sidebar. The same negative-first ordering applies to Test 2's grid
+   asserts.
 
-## What broke the old Test 1 contract *(hardening rationale)*
+## What broke the old contracts *(hardening rationale)*
 
-The pre-#682 test could never fail: both its "assertions" were bare
+The pre-#682 Test 1 could never fail: both its "assertions" were bare
 `locator.isVisible()` calls whose boolean result was discarded (a fully
 broken delete flow still produced a green run), the dropdown was targeted
 with `.first()` (parallel-unsafe), and nothing verified the flow actually
 disappeared. Hardening these is the required force-failability work of a
 validate-&-promote issue (see #505 precedent).
+
+Tests 2–3 (hardened by the #706 follow-up) had the same disease: dead
+boolean asserts in Test 2, and Test 3's whole body inside an
+`if (components-btn visible)` guard whose home-tab surface left the
+product — green in seconds while executing nothing. The saved-components
+feature itself survives (node menu → Save As Component; canvas sidebar
+`disclosure-saved`), so Test 3 was redesigned against the live surface
+rather than re-scoped away.
 
 ---
 
@@ -43,8 +65,11 @@ validate-&-promote issue (see #505 precedent).
 
 - Test 1: `@stable` `@release` `@workspace` `@mainpage` (promoted by #682;
   `@workspace` added — flow lifecycle management is the subject)
-- Tests 2–3: `@release` `@mainpage` (unchanged; not promoted — see
-  known-weak notes)
+- Test 2: `@release` `@mainpage` `@workspace` (hardened by #706; promotion
+  is a separate decision after soak)
+- Test 3: `@release` `@components` `@ui-ux` (redesigned by #706 — the
+  observable moved to the canvas sidebar, so `@mainpage` no longer applies;
+  promotion after soak)
 
 ---
 

--- a/tests/tests-automations/regression/ui-ux/actionsMainPage-shard-1.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/actionsMainPage-shard-1.spec.ts
@@ -1,8 +1,6 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
-import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
-import { openNewFlowTemplatesModal } from "../../../helpers/flows/open-new-flow-templates-modal";
 import { loadTemplateByName } from "../../../helpers/flows/load-template-by-name";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
@@ -83,103 +81,91 @@ test(
   },
 );
 
-test("search flows", { tag: ["@release", "@mainpage"] }, async ({ page }) => {
-  trackCreatedFlows(page);
-  await awaitBootstrapTest(page);
+test(
+  "search flows",
+  { tag: ["@release", "@mainpage", "@workspace"] },
+  async ({ page }) => {
+    trackCreatedFlows(page);
 
-  await page.getByTestId("side_nav_options_all-templates").click();
-  await page.getByRole("heading", { name: "Basic Prompting" }).click();
+    // Two flows with known ids — search assertions are anchored to
+    // flow-name-{id} cards, never to template display names (which other
+    // workers' flows can duplicate).
+    const basicId = await loadTemplateByName(page, "Basic Prompting");
+    const memoryId = await loadTemplateByName(page, "Memory Chatbot");
 
-  await page.waitForSelector('[data-testid="sidebar-search-input"]', {
-    timeout: 100000,
-  });
+    await page.goto("/");
+    await expect(page.getByTestId(`flow-name-${basicId}`)).toBeVisible({
+      timeout: 15000,
+    });
+    await expect(page.getByTestId(`flow-name-${memoryId}`)).toBeVisible({
+      timeout: 15000,
+    });
 
-  await page.getByTestId("icon-ChevronLeft").first().click();
+    // Searching filters the grid down to matching names only. The search is
+    // debounced: assert the NEGATIVE first (it only passes once the filter
+    // actually applied — the non-matching card left the grid), and only
+    // then the positive, so it is evaluated against the POST-filter grid.
+    // Positive-first would resolve on the first poll, before the debounce,
+    // and pass even for a search that matches nothing (#706 FF finding).
+    await page.getByPlaceholder("Search flows").fill("Memory Chatbot");
+    await expect(page.getByTestId(`flow-name-${basicId}`)).toHaveCount(0, {
+      timeout: 10000,
+    });
+    await expect(page.getByTestId(`flow-name-${memoryId}`)).toBeVisible({
+      timeout: 10000,
+    });
 
-  await openNewFlowTemplatesModal(page);
-  await page.getByTestId("side_nav_options_all-templates").click();
-  await page.getByRole("heading", { name: "Memory Chatbot" }).click();
-
-  await page.waitForSelector('[data-testid="sidebar-search-input"]', {
-    timeout: 100000,
-  });
-
-  await page.getByTestId("icon-ChevronLeft").first().click();
-  await openNewFlowTemplatesModal(page);
-  await page.getByTestId("side_nav_options_all-templates").click();
-  await page.getByRole("heading", { name: "Document Q&A" }).click();
-
-  await page.waitForSelector('[data-testid="sidebar-search-input"]', {
-    timeout: 100000,
-  });
-
-  await page.getByTestId("icon-ChevronLeft").first().click();
-  await page.getByPlaceholder("Search flows").fill("Memory Chatbot");
-  await page.getByText("Memory Chatbot", { exact: true }).isVisible();
-  await page.getByText("Document Q&A", { exact: true }).isHidden();
-  await page.getByText("Basic Prompting", { exact: true }).isHidden();
-});
+    // Clearing the search restores the full grid.
+    await page.getByPlaceholder("Search flows").clear();
+    await expect(page.getByTestId(`flow-name-${basicId}`)).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByTestId(`flow-name-${memoryId}`)).toBeVisible({
+      timeout: 10000,
+    });
+  },
+);
 
 test(
   "search components",
-  { tag: ["@release", "@mainpage"] },
+  { tag: ["@release", "@components", "@ui-ux"] },
   async ({ page }) => {
     trackCreatedFlows(page);
-    await awaitBootstrapTest(page);
 
-    if (await page.getByTestId("components-btn").isVisible()) {
-      await page.getByTestId("side_nav_options_all-templates").click();
-      await page.getByRole("heading", { name: "Basic Prompting" }).click();
+    // The old home "components-btn" tab left the product on 1.11 (the
+    // pre-#706 test guarded its whole body on it and ran nothing). Saved
+    // components now surface in the CANVAS sidebar under the "saved"
+    // category — this is the live surface, scouted on 1.11.0.dev41.
+    await loadTemplateByName(page, "Basic Prompting");
+    await adjustScreenView(page, { numberOfZoomOut: 2 });
 
-      await adjustScreenView(page, { numberOfZoomOut: 2 });
+    // Save the Chat Input node as a component. The save itself is a
+    // POST /api/v1/flows (is_component) — the tracker above captures it,
+    // so afterEach also removes the saved component.
+    await page.getByText("Chat Input").first().click();
+    await page.getByTestId("more-options-modal").click();
+    await page.getByTestId("icon-SaveAll").first().click();
+    await page.keyboard.press("Escape");
 
-      await page.getByText("Chat Input").first().click();
-      await page.waitForSelector('[data-testid="more-options-modal"]', {
-        timeout: 1000,
-      });
-      await page.getByTestId("more-options-modal").click();
+    // Order matters (debounced search, same trap as the flows grid): run
+    // the NEGATIVE first — "Prompt" exists as a regular component (renders
+    // under "models & agents", scouted live) but was NOT saved, so once the
+    // filter settles the saved category must be gone. Only then search the
+    // saved name: the saved category reappearing is a 0→1 transition, so
+    // the positive assert necessarily observes the POST-filter sidebar.
+    const sidebarSearch = page.getByTestId("sidebar-search-input");
+    await sidebarSearch.fill("Prompt");
+    await expect(page.getByTestId("disclosure-saved")).toHaveCount(0, {
+      timeout: 10000,
+    });
+    await expect(page.getByTestId("disclosure-models & agents")).toBeVisible({
+      timeout: 10000,
+    });
 
-      await page.getByTestId("icon-SaveAll").first().click();
-      await page.keyboard.press("Escape");
-      await page
-        .getByText("Prompt", {
-          exact: true,
-        })
-        .first()
-        .click();
-      await page.getByTestId("more-options-modal").click();
-
-      await page.getByTestId("icon-SaveAll").first().click();
-      await page.keyboard.press("Escape");
-
-      await page
-        .getByText("OpenAI", {
-          exact: true,
-        })
-        .first()
-        .click();
-      await page.getByTestId("more-options-modal").click();
-
-      await page.getByTestId("icon-SaveAll").first().click();
-      await page.keyboard.press("Escape");
-
-      await page.waitForSelector('[data-testid="sidebar-search-input"]', {
-        timeout: 100000,
-      });
-
-      await page.getByTestId("icon-ChevronLeft").first().click();
-
-      const exitButton = await page.getByText("Exit", { exact: true }).count();
-
-      if (exitButton > 0) {
-        await page.getByText("Exit", { exact: true }).click();
-      }
-
-      await page.getByTestId("components-btn").click();
-      await page.getByPlaceholder("Search components").fill("Chat Input");
-      await page.getByText("Chat Input", { exact: true }).isVisible();
-      await page.getByText("Prompt", { exact: true }).isHidden();
-      await page.getByText("OpenAI", { exact: true }).isHidden();
-    }
+    // Searching the saved name surfaces the "saved" category again.
+    await sidebarSearch.fill("Chat Input");
+    await expect(page.getByTestId("disclosure-saved")).toBeVisible({
+      timeout: 10000,
+    });
   },
 );


### PR DESCRIPTION
Closes #706 (`qa-infra` / `follow-up` — approved exception issue, follow-up of #682 / PR #705).

## What

Hardens the two known-weak siblings of the delete test in `ui-ux/actionsMainPage-shard-1.spec.ts`, both documented (and deliberately skipped) during #682:

1. **"search flows"** — every assertion was a bare `isVisible()`/`isHidden()` with the boolean discarded: broken filtering still passed. Now: two template flows created via `loadTemplateByName` (POST-201 ids tracked), asserts anchored to `flow-name-{id}` cards — searching "Memory Chatbot" removes the basic card (count 0) and keeps the memory card; clearing the search restores both. `+@workspace`.
2. **"search components"** — old premise DEAD: the whole body guarded on the home `components-btn` tab, which left the product on 1.11 (proven vacuous during #682's force-fail pass — the body never executed). Redesigned against the live surface (scouted on 1.11.0.dev41): saved components now surface in the **canvas sidebar** under `disclosure-saved`. The test saves Chat Input via node menu → `icon-SaveAll`, then asserts the search: negative first (searching "Prompt" — never saved — removes the saved category once the filter settles), then positive (searching "Chat Input" brings `disclosure-saved` back). Tags → `@components`/`@ui-ux` (`@mainpage` no longer applies — the observable moved to the canvas).

## Design finding encoded in the spec doc

Both searches are **debounced**, and assert ORDER is part of the contract: a positive assert evaluated first resolves against the pre-filter DOM and passes vacuously — two force-fail mutations survived exactly this way during validation. The negative-first / 0→1-transition ordering is what makes both tests genuinely force-failable.

## Validation

- **Langflow:** `langflowai/langflow-nightly:latest` → **1.11.0.dev41**.
- **Determinism:** final burst **3× (3/3)** `--retries=0 --workers=1` + intermediate green runs; zero backend errors.
- **Force-fails (all executed, all red):**
  - `search flows` — no-match search term → **failed** ✓ (after the debounce-order fix; the pre-fix positive-first version survived this mutation — that's the finding above)
  - `search components` — unsaved component name in the positive assert → **failed** ✓
  - `select and delete a flow` — backend-404 assert flipped to 200 → **failed** ✓ (file re-touched, so re-verified)
  - Behavioral cleanup FF — `afterEach` no-op'd → **+2 orphans (1 flow + 1 saved component** — the tracker captures the save's POST too) ✓
  - Reverts proven: `grep FF-MUTATION` → 0 + final green burst.
- **Flow cleanup:** orphan count 0 after every green run (including the saved component).
- `npm run typecheck` / `npm run lint`: 0 errors (warnings are the pre-existing baseline).
- No `@stable` added — promotion after soak, separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)