### PR TITLE
chore(skills): require per-test step-by-step + run command in every final report

### DIFF
--- a/.claude/skills/langflow-e2e-issue-deterministic/SKILL.md
+++ b/.claude/skills/langflow-e2e-issue-deterministic/SKILL.md
@@ -75,6 +75,12 @@ $PIPE authorize-pr <NNN> --quote "<user's exact words>"   # ONLY after explicit 
   flow created during a PLAN scout (id from the URL, DELETE via API) and any
   throwaway scout `.spec.ts` (the burst scan excludes `scout-*`/`*-tmp` globs
   as a backstop, but the file shouldn't survive the phase).
+- **The REPORT phase output always ends with two user-required items**
+  (besides whatever the phase instruction asks): a per-test step-by-step of
+  what each touched/created test does and validates (concrete observables,
+  not intents), and the copy-paste run command for the touched spec(s) —
+  env overrides, `--workers=1 --retries=0`, expected outcome — plus the
+  `--debug` variant. The user runs the spec before authorizing the PR.
 - **Every touched spec that creates flows ships id-scoped cleanup — always
   delete the flow at the end, never pollute the instance.** Audit `afterEach`
   + `deleteFlow` on ANY spec you touch (fixes/promotions included — legacy

--- a/.claude/skills/langflow-e2e-issues/SKILL.md
+++ b/.claude/skills/langflow-e2e-issues/SKILL.md
@@ -58,6 +58,14 @@ rule — see `CLAUDE.md`.
   has produced false "all passed" reports. If you already told the user a result
   and later find it wrong, correct it explicitly. (How to read output:
   `langflow-e2e` → Running tests.)
+- **Every final report ends with (user rule, asked explicitly):**
+  1. a **step-by-step of what each touched/created test does and validates**
+     (per-test table or list: setup → action → concrete observables asserted);
+  2. the **copy-paste run command** for the touched spec(s) — including any
+     env overrides needed locally, `--workers=1 --retries=0`, and the expected
+     outcome ("N passed, ~Xs") — plus the `--debug` variant. The user runs the
+     spec himself before authorizing the PR; a report without these two items
+     is incomplete.
 
 ## Companion skills — invoke when needed
 


### PR DESCRIPTION
Team-process change to the two shared orchestrator skills (versioned in-repo since PR #647).

## What

Every issue-resolution **final report** must now end with two items (requested explicitly by the team):

1. **Per-test step-by-step** — what each touched/created test does and validates, as concrete observables (setup → action → asserted outcomes), not intents.
2. **Copy-paste run command** for the touched spec(s) — env overrides when needed, `--workers=1 --retries=0`, the expected outcome ("N passed, ~Xs") — plus the `--debug` variant.

Rationale: the reviewer runs the spec locally before authorizing the PR; a report missing either item blocks that flow.

Encoded in both orchestrators so the rule survives regardless of which one drives the issue:
- `langflow-e2e-issues` → "Report faithfully" hard gate
- `langflow-e2e-issue-deterministic` → hard rules (REPORT phase)

No test or CI changes — docs-only within `.claude/skills/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)