### PR TITLE
test(playground): add dedicated SSE response-streaming spec (#696)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -460,7 +460,7 @@
 - [x] Open Playground → exercised by every `@stable` playground spec via `playground-btn-flow-io`
 - [x] Send text message → exercised by `playground-ux.spec.ts`, `playground-message-edit.spec.ts`, `playground-session-nav.spec.ts` and others
 - [x] Receive LLM response → exercised by all specs that send a message via ChatInput → ChatOutput echo flow
-- [-] Response streaming (SSE) → no dedicated spec; exercised implicitly by `playground-ux.spec.ts`
+- [x] Response streaming (SSE) → `core-functionality/playground/playground-response-streaming-sse.spec.ts`
 - [x] Response polling → api/flows/api-build-polling-response.spec.ts
 - [-] Direct response → no dedicated spec
 - [x] Playground UX (playground-ux) → `playground/playground-ux.spec.ts`

--- a/docs/core-functionality/playground/playground-response-streaming-sse.md
+++ b/docs/core-functionality/playground/playground-response-streaming-sse.md
@@ -1,0 +1,105 @@
+# Playground — Response Streaming (SSE)
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+Validates that a Playground run is delivered over Server-Sent Events (SSE): the
+browser consumes a `text/event-stream` response from the workflow-execution
+endpoint, the user message renders immediately, and the run completes. If this
+transport breaks, the Playground silently falls back to a non-streaming path (or
+hangs), degrading the progressive-response experience that §9.1 promises.
+Streaming was previously exercised only *implicitly* by `playground-ux.spec.ts`,
+which never asserts the SSE transport itself — this is the dedicated,
+transport-level proof.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@regression` `@playground`
+
+---
+
+## Step by step *(required)*
+
+1. Use `setupPlayground(page)` to create a blank flow with ChatInput → ChatOutput
+   connected and capture the created `flowId` (deterministic echo flow — no LLM).
+2. Register a `page.on("response")` collector that records the `content-type` of
+   every response whose URL matches the workflow-execution endpoint
+   (`/api/v2/workflows`, or legacy `/build/.../events`), installed **before** the
+   run is triggered. This scoping excludes the editor's own
+   `/api/v1/flows/{id}/events` JSON polling.
+3. Click `playground-btn-flow-io` and wait for `input-chat-playground` to be
+   visible (confirms the Playground is open).
+4. Send a message: fill `input-chat-playground`, click `button-send`.
+5. Assert the user message renders in the chat (its text is visible), matching
+   the proven pattern in `playground-ux.spec.ts`.
+6. Wait for the run to complete — `input-chat-playground` re-enabled (robust
+   completion signal; token/usage badges are model-dependent and fragile).
+7. Assert at least one collected run-endpoint response carried
+   `content-type: text/event-stream` — proving the run was delivered over SSE.
+
+`afterEach` navigates to `/` and deletes the flow created by the helper via
+`DELETE /api/v1/flows/{id}` (id-scoped cleanup, never a wipe).
+
+---
+
+## Validation criterion *(required)*
+
+- The Playground run consumes **at least one** `text/event-stream` (SSE) response
+  on the workflow-execution endpoint, **and** the user message renders **and** the
+  run completes (input re-enabled). All three must hold — the SSE observation
+  alone, without a completed run, does not pass.
+
+---
+
+## External dependencies *(required)*
+
+- `POST /api/v2/workflows` — the workflow-execution endpoint the Playground run
+  hits on 1.11; returns a `text/event-stream` (SSE) response under streaming mode
+  (verified live on nightly 1.11.0.dev). Legacy fallback: `GET
+  /api/v1/build/{job_id}/events` (`text/event-stream` on v1). The test matches
+  the transport (content-type on the run endpoint), not a URL, so an upstream
+  path move does not silently defeat it.
+- `data-testid="playground-btn-flow-io"` — opens the Playground from the editor.
+- `data-testid="input-chat-playground"` — chat input; readiness + completion
+  signal.
+- `data-testid="button-send"` — sends the message.
+- `setupPlayground` helper — builds the ChatInput → ChatOutput flow and returns
+  the created flow id.
+
+---
+
+## What this test does not cover *(optional)*
+
+- **Progressive token-by-token rendering** of an LLM response (the "message grows
+  over multiple frames" experience) — that needs a real model and is intentionally
+  out of scope to keep this spec deterministic and `@stable`. Covered implicitly by
+  the LLM/agent playground specs.
+- **Polling and direct** event-delivery modes — this spec asserts the streaming
+  transport only; the `withEventDeliveryModes` helper exercises all three for
+  behavior-level tests elsewhere.
+- The general Playground UX (instant user echo, auto-scroll, input readiness) —
+  covered by `playground-ux.spec.ts`.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` (validated on nightly 1.11.0.dev).
+- No LLM / provider key required — the ChatInput → ChatOutput flow echoes the
+  input, so the run is deterministic and the SSE transport is exercised without
+  any external model.
+
+---
+
+## Notes *(optional)*
+
+- Runs in `serial` mode for consistency with the sibling playground specs and to
+  keep the id-scoped cleanup contract simple.
+- The SSE assertion is transport-level (content-type on the build-events
+  response), not URL-exact, so an upstream path rename does not silently defeat
+  it as long as the events endpoint keeps the `text/event-stream` contract.

--- a/tests/tests-automations/regression/core-functionality/playground/playground-response-streaming-sse.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-response-streaming-sse.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from "../../../../fixtures/fixtures";
+import { setupPlayground } from "../../../../helpers/flows/setup-playground";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+
+/**
+ * Transport-level proof that a Playground run is delivered over Server-Sent
+ * Events (SSE): the browser consumes a `text/event-stream` response from the
+ * workflow-execution endpoint, the user message renders, and the run completes.
+ *
+ * Streaming was previously exercised only implicitly by `playground-ux.spec.ts`,
+ * which asserts UX behaviors (instant user echo, auto-scroll, input readiness)
+ * but never the SSE transport itself. This spec is the dedicated transport proof
+ * for QA-CHECKLIST §9.1 "Response streaming (SSE)".
+ *
+ * Deterministic by design: a ChatInput → ChatOutput echo flow (no LLM) exercises
+ * the streaming transport without any provider key. On 1.11 the Playground run
+ * hits `POST /api/v2/workflows`, which streams the result as `text/event-stream`
+ * (legacy fallback: `/api/v1/build/{job_id}/events`). The transport is matched by
+ * content-type, not a fixed URL, so an upstream path move does not silently
+ * defeat the assertion. Progressive token-by-token LLM rendering is out of scope.
+ */
+test.describe("Playground — Response Streaming (SSE)", () => {
+  test.describe.configure({ mode: "serial" });
+
+  let createdFlowId: string | null = null;
+
+  test.afterEach(async ({ page }) => {
+    if (createdFlowId) {
+      await page.goto("/");
+      await deleteFlow(page.request, createdFlowId);
+      createdFlowId = null;
+    }
+  });
+
+  test("Playground run is delivered over an SSE (text/event-stream) response",
+    { tag: ["@stable", "@release", "@regression", "@playground"] },
+    async ({ page }) => {
+      // The Playground run is streamed over SSE from the workflow-execution
+      // endpoint (POST /api/v2/workflows on 1.11; legacy /build/{job}/events on
+      // v1). Match the run endpoint transport-level, not URL-exact — the editor's
+      // own /api/v1/flows/{id}/events polling (JSON) must not match here.
+      const runSseEndpoint = /\/api\/v2\/workflows\b|\/build\/.*\/events/;
+      const runContentTypes: string[] = [];
+
+      await test.step("Set up ChatInput → ChatOutput flow and open playground", async () => {
+        createdFlowId = await setupPlayground(page);
+
+        // Install the SSE collector before triggering the run.
+        page.on("response", (response) => {
+          if (runSseEndpoint.test(response.url())) {
+            runContentTypes.push(response.headers()["content-type"] ?? "");
+          }
+        });
+
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(
+          page.getByTestId("input-chat-playground").last(),
+        ).toBeVisible({ timeout: 15000 });
+      });
+
+      await test.step("Send message and confirm it renders in chat", async () => {
+        const userMessage = "Streaming SSE transport check";
+        await page.getByTestId("input-chat-playground").last().fill(userMessage);
+        await page.getByTestId("button-send").last().click();
+
+        await expect(page.getByText(userMessage).last()).toBeVisible({
+          timeout: 5000,
+        });
+      });
+
+      await test.step("Wait for the run to complete", async () => {
+        await expect(
+          page.getByTestId("input-chat-playground").last(),
+        ).toBeEnabled({ timeout: 15000 });
+      });
+
+      await test.step("Assert the run was delivered over an SSE (text/event-stream) response", async () => {
+        await expect
+          .poll(
+            () =>
+              runContentTypes.some((ct) => ct.includes("text/event-stream")),
+            { timeout: 10000 },
+          )
+          .toBe(true);
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #696.

Closes the `[-] Response streaming (SSE)` gap in `QA-CHECKLIST.md` §9.1 Chat Interactions. Streaming was previously exercised only *implicitly* by `playground-ux.spec.ts`, which asserts UX behaviors (instant user echo, auto-scroll, input readiness) but never the SSE transport itself. This is the dedicated transport-level proof.

## 1. Covered tests
| # | Test | What it validates |
|---|------|-------------------|
| 1 | `Playground run is delivered over an SSE (text/event-stream) response` | Triple observable (all required): the user message renders, the run completes (input re-enabled), and **at least one `text/event-stream` response is captured on the run endpoint**. Catches a regression where the Playground run silently drops to a non-streaming transport. |

## 2. How the test was built
- **Setup:** `setupPlayground(page)` builds a ChatInput → ChatOutput echo flow (deterministic, **no LLM / no provider key**) and returns the created flow id — same helper the sibling `playground-ux.spec.ts` uses.
- **Live-confirmed transport (not source):** capturing the network during a real run on nightly 1.11.0.dev36 showed the Playground run hits `POST /api/v2/workflows` returning `text/event-stream`, **not** the `/api/v1/build/{job}/events` path the v1 source suggests. The editor's own `/api/v1/flows/{id}/events` polling is JSON and is deliberately excluded by the endpoint regex.
- **Assertion rationale:** the SSE content-type on the run endpoint is the transport-level proof of §9.1 "Response streaming (SSE)"; it is matched by content-type (not a fixed URL), so an upstream path move does not silently defeat it. Completion is anchored on `input-chat-playground` being re-enabled (robust; token/usage badges are model-dependent and fragile).
- **Rejected alternative:** an earlier draft intercepted `/api/v1/config` to force `event_delivery: "streaming"`. A force-fail proved the v2 workflows run streams SSE regardless of that config, so the intercept was dead code and was removed.
- **Cleanup:** id-scoped `afterEach` delete of the flow created by the helper (never a wipe). Verified 0 orphan flows after the run bursts.

## 3. Dependencies
- **None** — pure UI, deterministic echo flow, no LLM/provider key.
- Execution: `serial` describe (consistent with sibling playground specs and the id-scoped cleanup contract).

## Validation (nightly 1.11.0.dev36, `--retries=0`)
- typecheck ✅ · eslint ✅ · anti-pattern checklist ✅
- 4 clean runs (8–9s), no flake ✅
- force-fail ✅ (run-endpoint regex → non-existent path ⇒ SSE assert fails; reverted, `grep -c FF-MUTATION` = 0)
- `--trace=on` ✅ (11.4s, no hang) · zero `🚨 Backend Error` ✅ · 0 orphan flows ✅