### PR TITLE
test(flow-functionality): promote stop-building spec to @stable (#687)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -629,7 +629,7 @@
 #### 12.6 Flow Execution
 - [x] Run Flow component executes another flow → `flow-functionality/run-flow.spec.ts`
 - [x] Run a flow from the canvas — terminal-node run builds the whole graph; all nodes reach build success and output is produced → `flow-functionality/flow-execution-canvas.spec.ts`
-- [-] Stop building flow → `flow-functionality/stop-building.spec.ts`
+- [x] Stop building flow → `flow-functionality/stop-building.spec.ts`
 - [!] Playground button disabled with empty flow — needs review → `regression/flow-functionality/generalBugs-shard-3.spec.ts` (**test skipped: assertion was a no-op, current Langflow behavior to confirm**)
 
 ---

--- a/docs/flow-functionality/stop-building.md
+++ b/docs/flow-functionality/stop-building.md
@@ -25,9 +25,10 @@ spinning build.
 
 ## Tags
 
-`@release` `@workspace` `@components`
+`@stable` `@release` `@workspace` `@components`
 
-`@stable` is added only after team validation (see CONTRIBUTING.md). This spec
+`@stable` added by #687 after deterministic validation on the 1.11 nightly
+(burst runs with `--retries=0` + executed force-fail per assert). This spec
 replaces the previous fragile version (5 dragged legacy components + manual
 connections + text/timeout waits, flagged `// TODO: fix this test`) with the
 proven custom-component + `sleep(60)` recipe from `stop-button-playground.spec.ts`.

--- a/tests/tests-automations/regression/flow-functionality/stop-building.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/stop-building.spec.ts
@@ -21,7 +21,7 @@ test.afterEach(async ({ page }) => {
 });
 
 test("user must be able to stop a building from the canvas",
-  { tag: ["@release", "@workspace", "@components"] },
+  { tag: ["@stable", "@release", "@workspace", "@components"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 


### PR DESCRIPTION
Closes #687

## What

Promotes `tests/tests-automations/regression/flow-functionality/stop-building.spec.ts` ("Stop building flow", QA-CHECKLIST §12.6) to `@stable`. Wave 2 validate-&-promote item.

## Why

The spec was rewritten in a previous wave (custom component with `sleep(60)` + Chat Output, canvas stop via `stop_building_button`) but never promoted. Force-failability audit found no conditional bypasses or dead assertions — every step is a hard `expect` (edge count, stop control visible, "build stopped" confirmation), and the id-scoped `afterEach` cleanup was already in place. No hardening required; promotion only.

## Changes

- `stop-building.spec.ts` — add `@stable` to the test tags (only code change)
- `docs/flow-functionality/stop-building.md` — Tags section now lists `@stable` + validation note
- `QA-CHECKLIST.md` — §12.6 bullet "Stop building flow" `[-]` → `[x]` (summary tables regenerate in CI)

## Validation

- Nightly: **1.11.0.dev41** (latest at validation time)
- Burst: **3/3 green** with `--workers=1 --retries=0` (pipeline-parsed JSON stats), zero `🚨 Backend Error`
- `npm run typecheck` ✅ · `npm run lint` ✅
- **Force-fail executed**: final assert mutated to impossible text `"build stopped FF-NEVER"` → red run (unexpected=1, timed out at the 30s assert); revert proven (0 mutation markers in diff) + final green run (1 passed, ~10s)
- **Failed-run cleanup probe**: forced one red run and confirmed the `afterEach` still deleted the created flow (instance flow count unchanged); no flows leaked after all runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)