### PR TITLE
test(project-management): rewrite & promote user-progress-track to @stable (#690)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -443,7 +443,7 @@
 - [-] Outdated component notification
 
 #### 8.3 User State
-- [-] Track user progress
+- [x] Track user progress → `core-functionality/project-management/user-progress-track.spec.ts`
 - [-] User flow state cleanup
 
 #### 8.4 Error Handling and Edge Cases

--- a/docs/core-functionality/project-management/user-progress-track.md
+++ b/docs/core-functionality/project-management/user-progress-track.md
@@ -1,0 +1,155 @@
+# Spec: Track user progress — getting-started tracker (§8.3 User State)
+
+**Test file:** `tests/tests-automations/regression/core-functionality/project-management/user-progress-track.spec.ts`
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates
+
+Langflow tracks each user's "Get started" onboarding progress across three
+steps — star the GitHub repo, join the Discord server, create a flow — and
+surfaces it as a percentage widget in the home sidebar. The tracked state is
+**backend, per user** (`GET /api/v1/users/whoami` → `optins.github_starred` /
+`optins.discord_clicked`; the flow step derives from the user having ≥1 flow).
+The widget's percentage is the causal readout of those inputs
+(33% per completed step; 3/3 renders as 100%).
+
+One test drives the full causal chain on the auto_login superuser, from a
+provably-zero baseline:
+
+1. The user owns exactly the flow this test created (id-scoped), and both
+   outreach optins are reset to `false`. The widget reads **33%** — only the
+   flow step done — with neither outreach icon present.
+2. Clicking the widget's GitHub button opens the repo in a new tab and flips
+   `github_starred`; the widget advances to **66%** and the GitHub done-icon
+   appears.
+3. Clicking the widget's Discord button opens the invite and flips
+   `discord_clicked`; the widget advances to **100%** and the Discord done-icon
+   appears.
+4. `whoami` confirms both optins persisted `true` — the tracked state the UI
+   percentage is derived from.
+
+## Why the superuser, not a fresh user (design rationale)
+
+The pre-#690 spec had a superuser/admin variant and a normal-user variant, both
+failing 2/2 on the current nightly and structurally unpromotable:
+
+- **Parallel-suite wiper (#553/#520 class).** It called `cleanAllFlows` twice
+  on the shared superuser, deleting every other worker's in-flight flows.
+  `clean-all-flows.ts` documents the spec as "NOT safe under concurrent
+  neighbors". `@stable` runs fully parallel, so promoting it as-is would
+  reintroduce the wiper. This spec was `cleanAllFlows`'s **last legitimate
+  caller**; the redesign drops it, leaving no `@stable` spec that wipes flows
+  globally.
+- **Not repeatable.** `optins` persist per user across runs, so a second local
+  run of the old assertions yielded 100%, not 66%.
+- **Dead product path.** On the 1.11 nightly `new_project_btn_empty_page` opens
+  a blank canvas directly — the old templates-modal sequence times out.
+
+A **fresh-user** redesign (create a user via the Admin Page, log in, assert an
+isolated 0%→66% journey) was built and rejected: it was **flaky, 1-of-2 runs
+failing** in the multi-user creation/login flow itself
+(`addNewUserAndLogin` → `waitForSelector('mainpage_title')` timeouts; a full
+`page.goto` after the mocked-auto_login login logs the user back out to
+`/login`). Multi-user login is too fragile a foundation for an `@stable` test,
+and per-worker user isolation (#589 item 3) does not exist yet.
+
+The superuser design avoids both failure modes: the auto_login session is
+stable (no login step to flake), and the tracked state is **not contended** —
+no other spec touches the superuser's optins or the getting-started widget, and
+the flow step only needs ≥1 flow (this spec owns one; other workers' flows keep
+it true, never break it). The optin reset in `beforeEach`/`afterEach` makes it
+repeatable. The empty-page/0%-baseline assertions from the old spec are dropped
+because they require global flow-emptiness, which the parallel suite cannot
+promise; the tracker's core contract (optin → percentage causality) is what
+this validates.
+
+---
+
+## Tags
+
+`@stable` `@release` `@database` `@mainpage` `@ui-ux`
+
+(`@database`: asserts persistent per-user backend state via the users API.
+`@stable` applied by #690 after deterministic burst validation.)
+
+---
+
+## Step by step
+
+1. `beforeEach`: reset the superuser's optins (`github_starred`,
+   `discord_clicked`, `dialog_dismissed`) to `false` via
+   `PATCH /api/v1/users/{id}`.
+2. Create a flow via `POST /api/v1/flows/` (id-scoped, captured for cleanup) so
+   the flow step is done and the ≥1-flow home renders the sidebar widget.
+3. `page.goto("/")`; assert `get_started_progress_title` visible,
+   `get_started_progress_percentage` = **33%**, and neither
+   `github_starred_icon_get_started` nor `discord_joined_icon_get_started`
+   present.
+4. Click `github_starred_btn_get_started`; await + close the popup (repo URL);
+   assert percentage **66%** and `github_starred_icon_get_started` visible.
+5. Click `discord_joined_btn_get_started`; await + close the popup (invite URL);
+   assert percentage **100%** and `discord_joined_icon_get_started` visible.
+6. `GET /api/v1/users/whoami`; assert `optins.github_starred` and
+   `optins.discord_clicked` are both `true`.
+
+---
+
+## Validation criterion
+
+| Step | Criterion |
+|---|---|
+| Baseline (flow only, optins reset) | percentage = **33%**; no outreach icons |
+| After GitHub step | percentage = **66%**; GitHub done-icon visible |
+| After Discord step | percentage = **100%**; Discord done-icon visible |
+| Backend | `whoami.optins.github_starred` and `.discord_clicked` both `true` |
+
+Each transition is causal: exactly one tracked input changes and the percentage
+moves by one 33% step, from a provably-zero baseline. A regression in optin
+persistence, flow-step derivation, or widget rendering fails a specific step.
+
+---
+
+## External dependencies
+
+- Widget testids: `get_started_progress_title`,
+  `get_started_progress_percentage`, `github_starred_btn_get_started`,
+  `discord_joined_btn_get_started`, `github_starred_icon_get_started`,
+  `discord_joined_icon_get_started` (scouted live on 1.11.0.dev41).
+- `GET /api/v1/users/whoami` → `optins` (tracked state);
+  `PATCH /api/v1/users/{id}` accepts an `optins` reset;
+  `POST /api/v1/flows/` (via the `createFlow` helper, which absorbs the #588
+  concurrent-creation 500).
+- External `github.com` / `discord.com` open in the popup; assertions do not
+  require the external page to finish loading.
+
+---
+
+## What this test does not cover
+
+- The **empty-page 0% baseline** and **fresh-user isolation** — dropped: both
+  need global flow-emptiness / stable multi-user login, neither promotable
+  under the parallel suite today (see rationale).
+- The widget dismiss (`close_get_started_dialog` / `dialog_dismissed` optin).
+- The GitHub star **count** display (`githubStars` localStorage cache).
+- Non-superuser rendering of the widget (the tracker plumbing is identical
+  per user; the superuser is the parallel-safe stable session to assert on).
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` in auto_login mode (default
+  superuser session).
+- No model provider credentials required.
+
+---
+
+## Flow cleanup
+
+The test owns exactly one flow (created via API, id captured). `afterEach`
+deletes it id-scoped (404-tolerant) and resets the superuser optins, so neither
+flows nor tracked state accumulate across runs. No `cleanAllFlows` — this spec
+was its last caller; the helper can now be retired separately.

--- a/tests/tests-automations/regression/core-functionality/project-management/user-progress-track.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/user-progress-track.spec.ts
@@ -1,115 +1,135 @@
-import { BrowserContext, Page } from "@playwright/test";
-const DISCORD_URL = "https://discord.com/invite/EqksyE2EX9";
-const GITHUB_URL = "https://github.com/langflow-ai/langflow";
+import type { APIRequestContext } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
-import { addNewUserAndLogin } from "../../../../helpers/auth/add-new-user-and-loggin";
-import { cleanAllFlows } from "../../../../helpers/flows/clean-all-flows";
-import { cleanOldFolders } from "../../../../helpers/filesystem/clean-old-folders";
+import { createFlow } from "../../../../helpers/flows/create-flow";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
-test(
-  "admin user must be able to track their progress in getting started",
-  { tag: ["@release", "@api"] },
-  async ({ page, context }) => {
-    await page.goto("/");
-    await progressTrackTestFn(page, context);
-  },
-);
+// The getting-started tracker is per-user backend state (optins) plus a
+// flow-existence step, surfaced as a percentage in the home sidebar. This spec
+// drives the auto_login superuser — a stable session with no fragile multi-user
+// login (the previous fresh-user design was flaky: 1-of-2 runs died in the
+// Admin-Page user-creation/login flow) — and it is the ONLY spec that touches
+// the superuser's optins or the getting-started widget, so the shared state is
+// not contended under the parallel @stable suite. The flow step is satisfied by
+// a flow this spec owns and cleans up (id-scoped); other workers' flows only
+// keep the binary "has >=1 flow" true, never break it. Removing this spec as
+// the last cleanAllFlows caller means no @stable spec wipes flows globally.
 
-test(
-  "normal user must be able to track their progress in getting started",
-  { tag: ["@release", "@api"] },
-  async ({ page, context }) => {
-    await addNewUserAndLogin(page);
-    await progressTrackTestFn(page, context, true);
-  },
-);
+let createdFlowId: string | undefined;
 
-async function progressTrackTestFn(
-  page: Page,
-  context: BrowserContext,
-  isNormalUser: boolean = false,
-) {
-  // Wait for any loading text to disappear
-  await page.waitForSelector('text="Loading"', {
-    state: "hidden",
-    timeout: 30000,
-  });
-
-  await page.waitForTimeout(2000);
-
-  await cleanAllFlows(page);
-  await cleanOldFolders(page);
-
-  await expect(page.getByTestId("new_project_btn_empty_page")).toBeVisible();
-  await expect(page.getByTestId("mainpage_title").last()).toBeVisible();
-  await expect(page.getByTestId("empty_page_description")).toBeVisible();
-  await expect(page.getByTestId("empty_page_github_button")).toBeVisible();
-  await expect(page.getByTestId("empty_page_discord_button")).toBeVisible();
-  await expect(page.getByTestId("empty_page_drag_and_drop_text")).toBeVisible();
-  await expect(
-    page.getByTestId("get_started_progress_title"),
-  ).not.toBeVisible();
-
-  if (isNormalUser) {
-    await page.getByTestId("empty_page_github_button").click();
-
-    const pagePromiseGithub = context.waitForEvent("page");
-
-    const newPageGithub = await pagePromiseGithub;
-    await newPageGithub.waitForTimeout(3000);
-    const newUrlGithub = newPageGithub.url();
-
-    await expect(newUrlGithub).toContain(GITHUB_URL);
-
-    await newPageGithub.close();
-  } else {
-    await page.getByTestId("empty_page_discord_button").click();
-
-    const pagePromiseDiscord = context.waitForEvent("page");
-
-    const newPageDiscord = await pagePromiseDiscord;
-    await newPageDiscord.waitForTimeout(3000);
-    const newUrlDiscord = newPageDiscord.url();
-
-    await expect(newUrlDiscord).toContain(DISCORD_URL);
-
-    await newPageDiscord.close();
-  }
-
-  await expect(page.getByTestId("mainpage_title")).toBeVisible();
-  await expect(page.getByTestId("empty_page_description")).toBeVisible();
-
-  await page.getByTestId("new_project_btn_empty_page").click();
-
-  await page.getByTestId("side_nav_options_all-templates").click();
-  await page.getByRole("heading", { name: "Basic Prompting" }).click();
-
-  await page.waitForSelector('[data-testid="sidebar-search-input"]', {
-    timeout: 100000,
-  });
-
-  await page.getByTestId("icon-ChevronLeft").first().click();
-
-  await page.waitForSelector('[data-testid="home-dropdown-menu"]', {
-    timeout: 100000,
-  });
-
-  await expect(
-    page.getByTestId("get_started_progress_percentage").first(),
-  ).toHaveText("66%");
-
-  await cleanAllFlows(page);
-
-  await expect(
-    page.getByTestId("get_started_progress_title"),
-  ).not.toBeVisible();
-  await expect(
-    page.getByTestId("github_starred_icon_get_started"),
-  ).not.toBeVisible();
-  await expect(
-    page.getByTestId("create_flow_icon_get_started"),
-  ).not.toBeVisible();
-  await expect(
-    page.getByTestId("discord_joined_icon_get_started"),
-  ).not.toBeVisible();
+async function superuserAuth(request: APIRequestContext): Promise<string> {
+  const res = await request.get("/api/v1/auto_login");
+  const { access_token } = await res.json();
+  return `Bearer ${access_token}`;
 }
+
+async function resetOptins(
+  request: APIRequestContext,
+  bearer: string,
+): Promise<void> {
+  const who = await request.get("/api/v1/users/whoami", {
+    headers: { Authorization: bearer },
+  });
+  const { id } = await who.json();
+  await request.patch(`/api/v1/users/${id}`, {
+    headers: { Authorization: bearer },
+    data: {
+      optins: {
+        github_starred: false,
+        discord_clicked: false,
+        dialog_dismissed: false,
+      },
+    },
+  });
+}
+
+// Start every run from a provably-zero tracked state.
+test.beforeEach(async ({ request }) => {
+  await resetOptins(request, await superuserAuth(request));
+});
+
+// Delete the owned flow (id-scoped) and leave optins reset so repeat runs and
+// unrelated specs never see stale getting-started state.
+test.afterEach(async ({ request }) => {
+  const bearer = await superuserAuth(request);
+  if (createdFlowId) {
+    await deleteFlow(request, createdFlowId, {
+      headers: { Authorization: bearer },
+    }).catch(() => {});
+    createdFlowId = undefined;
+  }
+  await resetOptins(request, bearer);
+});
+
+test(
+  "getting-started progress increments as onboarding steps complete",
+  { tag: ["@stable", "@release", "@database", "@mainpage", "@ui-ux"] },
+  async ({ page, context, request }) => {
+    const bearer = await superuserAuth(request);
+
+    await test.step("own a flow so the flow step is done and the widget renders", async () => {
+      // API-created (id-scoped) rather than via the empty page: the empty page
+      // requires zero flows globally, which the parallel suite cannot promise.
+      createdFlowId = await createFlow(
+        request,
+        {
+          name: `progress-track-${Date.now()}`,
+          description: "",
+          data: { nodes: [], edges: [] },
+          is_component: false,
+        },
+        { headers: { Authorization: bearer } },
+      );
+    });
+
+    await test.step("baseline: widget shows 33% (flow step only)", async () => {
+      await page.goto("/");
+      await expect(
+        page.getByTestId("get_started_progress_title"),
+      ).toBeVisible({ timeout: 15000 });
+      // Causal 33%: exactly the flow step done, both optins reset to false.
+      await expect(
+        page.getByTestId("get_started_progress_percentage").first(),
+      ).toHaveText("33%");
+      await expect(
+        page.getByTestId("github_starred_icon_get_started"),
+      ).toHaveCount(0);
+      await expect(
+        page.getByTestId("discord_joined_icon_get_started"),
+      ).toHaveCount(0);
+    });
+
+    await test.step("completing the GitHub step advances to 66%", async () => {
+      const popup = context.waitForEvent("page");
+      await page.getByTestId("github_starred_btn_get_started").click();
+      await (await popup).close();
+      await expect(
+        page.getByTestId("get_started_progress_percentage").first(),
+      ).toHaveText("66%");
+      await expect(
+        page.getByTestId("github_starred_icon_get_started"),
+      ).toBeVisible();
+    });
+
+    await test.step("completing the Discord step advances to 100%", async () => {
+      const popup = context.waitForEvent("page");
+      await page.getByTestId("discord_joined_btn_get_started").click();
+      await (await popup).close();
+      await expect(
+        page.getByTestId("get_started_progress_percentage").first(),
+      ).toHaveText("100%");
+      await expect(
+        page.getByTestId("discord_joined_icon_get_started"),
+      ).toBeVisible();
+    });
+
+    await test.step("backend tracks both optins as done", async () => {
+      // The tracked state itself: the UI percentage is derived from these.
+      const who = await request.get("/api/v1/users/whoami", {
+        headers: { Authorization: bearer },
+      });
+      const { optins } = await who.json();
+      expect(optins.github_starred, "github optin must persist").toBe(true);
+      expect(optins.discord_clicked, "discord optin must persist").toBe(true);
+    });
+  },
+);


### PR DESCRIPTION
Closes #690

## What

Rewrites and promotes `user-progress-track.spec.ts` ("Track user progress", QA-CHECKLIST §8.3) to `@stable`. Wave 2 validate-&-promote.

## Why a rewrite, not a promotion

The existing spec **failed 2/2 on the current nightly** and was structurally unpromotable:

- **Parallel-suite wiper (#553/#520 class):** it called `cleanAllFlows` twice on the shared superuser — deleting other workers' in-flight flows. It was that helper's **last legitimate caller**; dropping it leaves no `@stable` spec that wipes flows globally.
- **Not repeatable:** `optins` persist per user, so a second run yielded 100%, not 66%.
- **Dead product path:** on 1.11 `new_project_btn_empty_page` opens a blank canvas directly; the old templates-modal sequence times out.

A **fresh-user** redesign was built and **rejected as flaky** — 1-of-2 runs died in the Admin-Page multi-user creation/login flow (`addNewUserAndLogin` → `mainpage_title` timeout; a full `page.goto` after the mocked-auto_login login logs the user back out to `/login`). Multi-user login is too fragile for `@stable`, and per-worker user isolation (#589 item 3) does not exist yet.

## Design (superuser, causal chain)

Drives the stable auto_login superuser and validates the tracker's core contract — optin/flow inputs → percentage:

- reset optins via API (`beforeEach`/`afterEach`) → repeatable
- own one API-created flow (id-scoped) → the flow step is done and the ≥1-flow home renders the sidebar widget, **without any global wipe**
- assert the causal chain: **33%** (flow only) → GitHub click **66%** → Discord click **100%**, each done-icon appearing, and `whoami` confirming both optins persist `true`

Parallel-safe: this is the only spec that touches the superuser's optins or the getting-started widget; other workers' flows only keep the binary "has ≥1 flow" true.

## Deviations (from the confirmed design)

1. Fresh-user → superuser (login flaky).
2. Dropped the empty-page 0% baseline and delete→empty steps — both need global flow-emptiness, not promotable under the parallel suite. The tracker's optin→% causality is covered.
3. Removed `cleanAllFlows` (last caller).

## Changes

- `user-progress-track.spec.ts` — full rewrite (single causal test, `@stable`)
- `docs/core-functionality/project-management/user-progress-track.md` — new spec doc with the design rationale
- `QA-CHECKLIST.md` — §8.3 "Track user progress" `[-]` → `[x]`

## Validation

- Nightly: **1.11.0.dev41**
- Burst: **5/5 green** with `--workers=1 --retries=0` (~4s), zero `🚨 Backend Error`
- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors)
- **Force-fail executed:** GitHub step asserted impossible `"66%FF"` → red run (unexpected=1); revert proven (0 markers) + final green
- Instance clean after runs: 0 user flows, only `langflow`, optins reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)