### PR TITLE
test(project-management): harden & promote flowSettings to @stable (#681)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -603,7 +603,7 @@
 - [x] Rename flow and verify on main page listing → `core-functionality/project-management/edit-flow-name.spec.ts`
 - [-] Edit flow name and description
 - [-] Flow auto-save on changes
-- [-] Flow settings
+- [x] Flow settings → `core-functionality/project-management/flowSettings.spec.ts`
 
 #### 12.3 Delete Flow
 - [x] Delete individual flow → `ui-ux/actionsMainPage-shard-1.spec.ts`

--- a/docs/core-functionality/project-management/flowSettings.md
+++ b/docs/core-functionality/project-management/flowSettings.md
@@ -1,0 +1,125 @@
+# Spec: Flow settings — name & description edit with character limits (§12.2 View and Edit Flow)
+
+**Test file:** `tests/tests-automations/regression/core-functionality/project-management/flowSettings.spec.ts`
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates
+
+The flow-settings modal (opened from the flow header `flow_name`) lets a user
+edit a flow's **name** and **description**, enforces a **character limit** on
+each field, persists the saved values, and reopens showing exactly what was
+saved. This is the "edit flow metadata" half of §12.2.
+
+Concretely:
+
+1. Both fields **cap input at their maximum length** — filling past the limit
+   truncates the value in place and surfaces a **"Character limit reached"**
+   message (description cap is **250** characters on 1.11).
+2. Saving a valid name + a (truncated) description **succeeds** — the modal
+   closes (upstream `handleSubmit` only closes on a resolved save; the error
+   path keeps it open, so a closed modal is the deterministic success signal).
+3. Reopening the modal shows the **persisted** name and description — proving
+   the save round-tripped through the backend, not just the local form.
+
+## Hardening rationale (why a rewrite, not a bare promotion)
+
+The pre-#681 test could pass without validating anything: every gate in its
+body was a **non-awaiting `locator.isVisible()` / `isEnabled()` whose boolean
+was discarded** (`flow_name`, "Character limit reached", `save-flow-settings`,
+"Changes saved successfully" — lines 16/28/39/43), it **clicked a fading toast**
+as its success signal (racing the toast's own auto-dismiss), used the weak
+`expect(a == b).toBeTruthy()` pattern (a comparison bug hides as a pass), and
+**left its flow behind** (no cleanup). Those are exactly the conditions a
+validate-&-promote issue must fix before `@stable`. The rewrite replaces every
+discarded query with a real auto-waiting `expect`, uses modal-closed as the
+save signal (matching the already-hardened `renameFlow` helper, #357), captures
+the truncated values from the fields rather than trusting a hand-typed 250-char
+literal, and adds id-scoped flow cleanup.
+
+---
+
+## Tags
+
+`@stable` `@release` `@workspace`
+
+(`@release` `@workspace`: flow lifecycle/metadata management. `@api` dropped —
+the test drives the UI modal, not the REST API directly. `@stable` applied by
+#681 after deterministic burst validation.)
+
+---
+
+## Step by step
+
+1. Bootstrap and open a blank flow; capture the flow id from `/flow/{id}` for
+   cleanup. Let the editor's autosave settle (`waitForFlowSaveSettled`) before
+   touching the modal, so an in-flight `PATCH` does not re-render it mid-edit.
+2. Open the settings modal (`flow_name`).
+3. **Name limit:** fill `input-flow-name` with an overlong string; assert
+   "Character limit reached" is visible and the field value was truncated
+   (shorter than the input).
+4. Fill `input-flow-name` with a valid random name.
+5. **Description limit:** fill `input-flow-description` with a ~1000-char
+   string; capture the truncated value and assert it is **250** characters
+   (the enforced cap).
+6. Assert `save-flow-settings` is enabled; click it; assert the modal closed
+   (`input-flow-name` hidden) — the save succeeded.
+7. Reopen the modal via `renameFlow(page)` with no edits (reads the persisted
+   values, asserts save is disabled with no change, cancels).
+8. Assert the persisted name equals the random name and the persisted
+   description equals the captured 250-char truncation.
+
+---
+
+## Validation criterion
+
+| Step | Criterion |
+|---|---|
+| Overlong name | "Character limit reached" visible; field value truncated |
+| Overlong description | field value capped at exactly 250 chars |
+| Save | `save-flow-settings` enabled → click → modal (`input-flow-name`) closes |
+| Reopen | persisted name == the random name; persisted description == the 250-char truncation |
+| No-change reopen | `save-flow-settings` disabled (nothing to save) |
+
+Each assertion is a real auto-waiting `expect`; a regression in the limit
+enforcement, the save round-trip, or the persistence fails a specific step.
+
+---
+
+## External dependencies
+
+- Modal testids: `flow_name`, `input-flow-name`, `input-flow-description`,
+  `save-flow-settings`, `cancel-flow-settings` (scouted live; renaming breaks
+  the test).
+- "Character limit reached" copy (`flow.characterLimitReached`).
+- Description max length = 250 (1.11 nightly); a change to the cap changes the
+  captured length assertion.
+- `renameFlow` helper (already hardened, #357) for the reopen/read/cancel path.
+- `waitForFlowSaveSettled` helper (avoids the autosave-vs-modal re-render race).
+
+---
+
+## What this test does not cover
+
+- The REST `PATCH /api/v1/flows/{id}` path directly (covered by API specs);
+  this asserts the UI modal round-trip.
+- Endpoint-name / other flow-settings fields beyond name + description.
+- Duplicate-name rejection (`flow.nameAlreadyExists`).
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- No model provider credentials required.
+
+---
+
+## Flow cleanup
+
+The test creates one blank flow; its id is captured from the canvas URL and an
+`afterEach` deletes it id-scoped (404-tolerant) via the API, so the instance is
+not polluted across runs. Behavioral force-fail: no-op the cleanup and the flow
+count grows.

--- a/tests/tests-automations/regression/core-functionality/project-management/flowSettings.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/flowSettings.spec.ts
@@ -1,61 +1,134 @@
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { renameFlow } from "../../../../helpers/flows/rename-flow";
+import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+
+// Capture every flow THIS page creates from its POST /api/v1/flows → 201
+// responses, and delete them id-scoped in afterEach. The canvas URL id races
+// the bootstrap flow's stale id (blank-flow opens behind the templates modal),
+// so a bare page.url() capture deleted the wrong flow and leaked the renamed
+// one; the response ids are authoritative. Only ids this page created are
+// captured, so it stays safe under parallel workers.
+const createdFlowIds: string[] = [];
+
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {});
+    }
+  });
+}
+
+const OVERLONG = "Flow Name Test ".repeat(70); // > every field cap on 1.11
+const DESCRIPTION_CAP = 250; // enforced maxLength of input-flow-description
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, {
+      headers: { Authorization: bearer },
+    }).catch(() => {});
+  }
+});
 
 test(
-  "flowSettings",
-  { tag: ["@release", "@api", "@workspace"] },
+  "flow settings enforce character limits and persist name & description",
+  { tag: ["@stable", "@release", "@workspace"] },
   async ({ page }) => {
+    trackCreatedFlows(page);
     await awaitBootstrapTest(page);
 
-    await page.waitForSelector('[data-testid="blank-flow"]', {
-      timeout: 30000,
-    });
-    await page.getByTestId("blank-flow").click();
-
-    await page.getByTestId("flow_name").isVisible({ timeout: 3000 });
-    await page.getByTestId("flow_name").click();
-    await page.waitForTimeout(500);
-
-    await page.getByTestId("input-flow-name").click();
-
-    await page
-      .getByTestId("input-flow-name")
-      .fill(
-        "Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test",
-      );
-
-    await page.getByText("Character limit reached").isVisible();
-
-    await page.getByTestId("input-flow-name").click();
-    const randomName = Math.random().toString(36).substring(2);
-    await page.getByTestId("input-flow-name").fill(randomName);
-    await page
-      .getByTestId("input-flow-description")
-      .fill(
-        "Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test",
-      );
-
-    await page.getByTestId("save-flow-settings").isEnabled({ timeout: 3000 });
-    await page.getByTestId("save-flow-settings").click();
-
-    await page
-      .getByText("Changes saved successfully")
-      .last()
-      .isVisible({ timeout: 3000 });
-    await page.getByText("Changes saved successfully").last().click();
-
-    await page.waitForSelector('[data-testid="sidebar-search-input"]', {
-      timeout: 30000,
+    await test.step("open a blank flow", async () => {
+      await expect(page.getByTestId("blank-flow")).toBeVisible({
+        timeout: 30000,
+      });
+      await page.getByTestId("blank-flow").click();
+      await page.waitForURL(/\/flow\/[^/?#]+/, { timeout: 30000 });
+      await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
+        timeout: 30000,
+      });
     });
 
-    const { flowName, flowDescription } = await renameFlow(page);
+    const randomName = `flow-${Math.random().toString(36).substring(2)}`;
+    let truncatedDescription = "";
 
-    expect(flowName == randomName).toBeTruthy();
+    await test.step("modal enforces the name and description character limits", async () => {
+      // Let the entry autosave settle before opening the modal, or an in-flight
+      // PATCH re-renders the dialog and detaches its inputs mid-edit (#357).
+      await waitForFlowSaveSettled(page);
+      await expect(page.getByTestId("flow_name")).toBeVisible({
+        timeout: 15000,
+      });
+      await page.getByTestId("flow_name").click();
 
-    expect(
-      flowDescription ==
-        "Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name Test Flow Name ",
-    ).toBeTruthy();
+      const nameInput = page.getByTestId("input-flow-name");
+      await expect(nameInput).toBeVisible({ timeout: 15000 });
+
+      // Overlong name: the cap message appears and the field truncates in place.
+      await nameInput.fill(OVERLONG);
+      await expect(page.getByText("Character limit reached")).toBeVisible({
+        timeout: 15000,
+      });
+      const cappedName = await nameInput.inputValue();
+      expect(
+        cappedName.length,
+        "name field must cap below the overlong input",
+      ).toBeLessThan(OVERLONG.length);
+
+      // Replace with a valid short name.
+      await nameInput.fill(randomName);
+      await expect(nameInput).toHaveValue(randomName);
+
+      // Overlong description: the field truncates to its enforced cap.
+      const descriptionInput = page.getByTestId("input-flow-description");
+      await expect(descriptionInput).toBeVisible({ timeout: 15000 });
+      await descriptionInput.fill(OVERLONG);
+      truncatedDescription = await descriptionInput.inputValue();
+      expect(
+        truncatedDescription.length,
+        "description must cap at its enforced maxLength",
+      ).toBe(DESCRIPTION_CAP);
+    });
+
+    await test.step("saving succeeds (the modal closes on a resolved save)", async () => {
+      const saveButton = page.getByTestId("save-flow-settings");
+      await expect(saveButton).toBeEnabled({ timeout: 15000 });
+      await saveButton.click();
+      // Modal-closed is the deterministic success signal: handleSubmit only
+      // closes after the save resolves (the error path keeps it open). This is
+      // race-free unlike asserting the auto-dismissing "Changes saved" toast.
+      await expect(page.getByTestId("input-flow-name")).toBeHidden({
+        timeout: 15000,
+      });
+      await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
+        timeout: 30000,
+      });
+    });
+
+    await test.step("reopening shows the persisted name and description", async () => {
+      // No-edit reopen: renameFlow reads the current (persisted) values and,
+      // with nothing changed, asserts save is disabled and cancels.
+      const { flowName, flowDescription } = await renameFlow(page);
+      expect(flowName, "persisted name must match the saved name").toBe(
+        randomName,
+      );
+      expect(
+        flowDescription,
+        "persisted description must match the saved (truncated) description",
+      ).toBe(truncatedDescription);
+    });
   },
 );


### PR DESCRIPTION
Closes #681

## What

Hardens and promotes `flowSettings.spec.ts` ("Flow settings", QA-CHECKLIST §12.2) to `@stable`. Wave 2 validate-&-promote.

## Why a rewrite, not a bare promotion

The existing spec **passed vacuously**: every gate in its body was a non-awaiting `locator.isVisible()` / `isEnabled()` whose boolean was **discarded** (`flow_name`, "Character limit reached", `save-flow-settings`, "Changes saved successfully" — lines 16/28/39/43), it **clicked the auto-dismissing toast** as its success signal (racing its own timeout), used the weak `expect(a == b).toBeTruthy()` pattern (a comparison bug hides as a pass), and **left its flow behind** (no cleanup). Force-failability + cleanup are the required scope of a validate-&-promote issue.

## Changes

- **Real `await expect`** for the character-limit message, save-enabled gate, and the save signal = **modal closed** (matches the already-hardened `renameFlow` helper, #357; the error path keeps the modal open, so a closed modal is the deterministic success signal — unlike the fading toast).
- **Capture the truncated field values** from the inputs instead of a hand-typed 250-char literal; assert the description caps at **250** and the name truncates when overlong.
- **Persistence** proven by reopening (`renameFlow` no-edit reads the saved values and asserts save is disabled with nothing changed).
- **id-scoped cleanup** via `POST /flows` 201 response ids. A bare `page.url()` capture deleted the wrong flow and leaked the renamed one — the canvas URL id races the bootstrap flow's stale id (blank-flow opens behind the templates modal). The response ids are authoritative; only ids this page created are captured (parallel-safe).

## Deviations

- Dropped `@api` — the test drives the UI modal, not the REST API directly.

## Validation

- Nightly: **1.11.0.dev41**
- Burst: **3/3 green** with `--workers=1 --retries=0`, **0 orphan flows** after each run, zero `🚨 Backend Error`
- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors)
- **Force-fail executed:** persisted-name assert mutated to `randomName + "FF-NEVER"` → red run (unexpected=1); revert proven (0 markers) + final green

🤖 Generated with [Claude Code](https://claude.com/claude-code)