### PR TITLE
chore(skills): stop redundant determinism bursts; harden flow-id capture guidance

### DIFF
--- a/.claude/skills/langflow-e2e-issue-deterministic/SKILL.md
+++ b/.claude/skills/langflow-e2e-issue-deterministic/SKILL.md
@@ -60,6 +60,15 @@ $PIPE authorize-pr <NNN> --quote "<user's exact words>"   # ONLY after explicit 
   `test()` in every touched `.spec.ts` gets a verified red run + revert proof
   (gate 3). No "the test obviously works" exception; if there's a spec change,
   it gets force-failed.
+- **VALIDATE's burst IS the determinism evidence — don't re-run it by hand.**
+  The VALIDATE phase already runs the spec `BURST` times (default 3) at
+  `--retries=0 --workers=1`, caches the clean runs, and gates on
+  `BURST` unexpected-free/flaky-free results. Those `run i/BURST …` lines ARE
+  the determinism proof to report. Do NOT hand-run extra `npx playwright test`
+  bursts before or after VALIDATE to "double-check" — it re-runs the same
+  slow spec for zero added signal (a real session ran a spec ~10× this way).
+  Scout runs to design/debug are fine; redundant confirmation bursts are not.
+  Need more/fewer runs? Set `PIPELINE_BURST`, don't loop manually.
 - **Never bypass the CLI**: no `gh pr create`, no commit/push, no phase
   skipping, no editing files under `.claude/issue-pipeline/`.
 - **Never fabricate evidence**: `userConfirmed: true` only after the user

--- a/.claude/skills/langflow-e2e/references/authoring-conventions.md
+++ b/.claude/skills/langflow-e2e/references/authoring-conventions.md
@@ -205,6 +205,15 @@ bullets** — the Coverage Summary table and Phase 0 block auto-regenerate.
      `page.waitForResponse(r => r.url().includes("/api/v1/flows/") &&
      r.request().method() === "POST" && r.status() < 300)` **before** the
      click that creates the flow, then `(await r.json()).id`.
+     **When `awaitBootstrapTest` (or any helper that itself creates a flow)
+     runs before the click, do NOT use `page.url()` AND do NOT tie capture to
+     a single `waitForResponse` — the bootstrap flow's own `POST /flows`
+     competes and the URL id is the STALE bootstrap id.** Use the Pattern A
+     accumulator below (`page.on("response")` collecting EVERY `POST /flows`
+     201 id, delete them all in `afterEach`) — it captures the real
+     just-created flow regardless of the bootstrap race. URL capture has now
+     bitten twice (#490, #681 — the latter deleted the bootstrap flow and
+     leaked the renamed one, 8 orphans).
   2. **`page.request` carries only browser cookies** — the flows API wants the
      Bearer token, so an `afterEach` delete via bare `page.request.delete(...)`
      401s and a trailing `.catch(() => {})` swallows it (flows leak silently).
@@ -307,7 +316,9 @@ harmlessly — `deleteFlow` treats 404 as done). Reference:
 **B — blank flow (id observable):** capture the id from the `blank-flow`
 click's `POST /flows` 201 response, delete in `finally` (runs even on
 failure). Reference: `ollama-provider.spec.ts`, `groq-provider.spec.ts`,
-`mistral-provider.spec.ts`.
+`mistral-provider.spec.ts`. **If `awaitBootstrapTest` runs first, use A, not
+B** — the bootstrap flow's `POST /flows` competes with the blank-flow click
+and `page.url()` returns the stale bootstrap id (#681).
 
 Validation contract (both patterns): (1) a **behavioral force-fail** of the
 cleanup itself — no-op the delete, run green, count surviving orphans (>0),


### PR DESCRIPTION
## What

Two quality-preserving process optimizations for the issue-resolution skills, distilled from the Wave 2 promotions (#687 / #690 / #681).

## 1 — Don't hand-run redundant determinism bursts

`langflow-e2e-issue-deterministic` SKILL.md gains a hard rule: the **VALIDATE phase already runs the spec `BURST` times** (default 3) at `--retries=0 --workers=1`, caches the clean runs, and gates on `BURST` unexpected-free/flaky-free results. Those `run i/BURST …` lines **are** the determinism evidence to report. Running extra `npx playwright test` bursts by hand adds zero signal and re-runs a slow spec — a session did this ~10× on one spec. Adjust `PIPELINE_BURST` instead of looping manually. (Scout/debug runs are still fine.)

## 2 — Harden flow-id capture guidance

`page.url()` flow-id capture has now bitten twice (#490, #681). When `awaitBootstrapTest` (or any helper that creates a flow) runs before the create click, the **bootstrap flow's `POST /flows` competes** and the canvas URL carries the **stale bootstrap id** — deleting it removes the wrong flow and leaks the real one (#681: 8 orphans). `authoring-conventions.md` now directs to the **Pattern A response accumulator** (`page.on("response")` collecting every `POST /flows` 201 id) in that case, which captures the real id regardless of the race.

## Scope

Docs/guidance only — no state-machine logic, no test changes. Burst count stays 3 (determinism floor untouched); FORCE_FAIL unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)