### PR TITLE
test(flow-functionality): add dedicated create-flow-from-template spec (#677)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -594,7 +594,7 @@
 
 #### 12.1 Create Flow
 - [-] Create blank flow
-- [-] Create flow from template
+- [x] Create flow from template → `flow-functionality/create-flow-from-template.spec.ts`
 - [x] Create flow by duplicating an existing one → `flow-functionality/duplicate-flow.spec.ts`
 - [-] Create flow via JSON file import
 

--- a/docs/flow-functionality/create-flow-from-template.md
+++ b/docs/flow-functionality/create-flow-from-template.md
@@ -1,0 +1,103 @@
+# Flow Functionality — Create Flow from Template
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+Validates the "create a flow from a starter template" journey (QA-CHECKLIST
+§12.1): from the New Flow → templates modal, picking a template (**Basic
+Prompting**) instantiates a new flow **pre-populated with that template's
+components**, opens its editor, and persists a **non-empty graph** named after
+the template. This is the template entry point into the editor. It is exercised
+implicitly as a setup step across the suite (via `loadTemplateByName`) but had no
+dedicated spec asserting the behavior itself; this is that dedicated proof,
+promoted to `@stable`.
+
+Distinct from the §12.1 siblings: `create-blank-flow.spec.ts` (empty creation —
+asserts a graph with **zero** nodes) and `duplicate-flow.spec.ts` (clone an
+existing flow). This spec is the mirror of the blank case: it proves the created
+flow arrives **with** the template's content.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@regression` `@workspace`
+
+---
+
+## Step by step *(required)*
+
+1. `loadTemplateByName(page, "Basic Prompting")` — opens the templates modal via
+   the New Flow entry point (handling the welcome overlay), switches to the All
+   Templates tab, clicks the **Basic Prompting** template, and returns the real
+   `flowId` captured from the template-instantiation `POST /api/v1/flows/` `201`
+   (the canvas URL id is transient on 1.11). It resolves once
+   `canvas_controls_dropdown` is visible (editor open).
+2. Assert the returned `flowId` is truthy.
+3. Assert the canvas is populated — `.react-flow__node` count `> 0` (the template
+   loaded its components onto the canvas).
+4. Assert the persisted flow matches the template — poll `GET /api/v1/flows/{flowId}`
+   (Bearer) until its `data.nodes` is **non-empty** and its `name` contains
+   "Basic Prompting".
+
+`afterEach` navigates to `/` and deletes the captured `flowId` via
+`DELETE /api/v1/flows/{id}` (id-scoped cleanup, never a wipe).
+
+---
+
+## Validation criterion *(required)*
+
+- Picking the Basic Prompting template yields a `POST /api/v1/flows/` `201` (real
+  id captured via the helper), **and** the editor opens, **and** the canvas shows
+  `> 0` nodes, **and** the persisted flow (`GET /api/v1/flows/{id}`) has a
+  non-empty `data.nodes` with a `name` matching `Basic Prompting`. All must hold —
+  a flow that opens empty (template not applied) fails the criterion, which is
+  exactly what separates this from the blank-flow path.
+
+---
+
+## External dependencies *(required)*
+
+- `loadTemplateByName` / `openNewFlowTemplatesModal` helpers — the canonical
+  New-Flow → All-Templates → pick-by-name path; returns the created flow id.
+- `POST /api/v1/flows/` — template instantiation; returns `201` with the id.
+- `GET /api/v1/flows/{id}` (Bearer) — confirms the persisted graph + name.
+- `data-testid="canvas_controls_dropdown"` — editor-open readiness (awaited by
+  the helper).
+- `.react-flow__node` — canvas node elements (count `> 0` for a template flow).
+- `getAuthToken`, `deleteFlow` helpers.
+- Starter template **Basic Prompting** present in the running Langflow (used by
+  `duplicate-flow.spec.ts` too).
+
+---
+
+## What this test does not cover *(optional)*
+
+- Creating an **empty** flow — `create-blank-flow.spec.ts` (#676).
+- Creating a flow **via JSON import** — `export-import-flow.spec.ts`.
+- Duplicating an existing flow — `duplicate-flow.spec.ts`.
+- Running the template's flow or asserting its exact component set — out of
+  scope; the check is "template content arrived", not per-node structure (which
+  drifts across Langflow releases).
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` (validated on nightly 1.11.0.dev).
+- No LLM / provider key required — the flow is created from the template but not
+  executed.
+
+---
+
+## Notes *(optional)*
+
+- Uses `Basic Prompting` (not the Agent templates) so the load stays a light,
+  deterministic canvas render — avoids the heavy Simple-Agent template that
+  hangs `--trace=on` (repo convention #490).
+- The non-empty-graph + template-name assertion is the distinctive check: it
+  separates "a flow was created from THIS template" from "some flow opened",
+  mirroring the blank-flow spec's zero-node assertion.

--- a/tests/tests-automations/regression/flow-functionality/create-flow-from-template.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/create-flow-from-template.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "../../../fixtures/fixtures";
+import { loadTemplateByName } from "../../../helpers/flows/load-template-by-name";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+
+/**
+ * Dedicated proof of the "create a flow from a starter template" journey
+ * (QA-CHECKLIST §12.1): picking a template in the New Flow modal instantiates a
+ * flow pre-populated with the template's components, opens its editor, and
+ * persists a non-empty graph named after the template.
+ *
+ * Exercised implicitly as a setup step across the suite (via loadTemplateByName)
+ * but no spec asserted the behavior itself. Mirror of create-blank-flow.spec.ts
+ * (#676): blank asserts a ZERO-node graph, this asserts the template's content
+ * ARRIVED. Distinct from duplicate-flow.spec.ts (clone) and the JSON-import path.
+ *
+ * Uses "Basic Prompting" (not the Agent templates) to keep the canvas render
+ * light and deterministic and avoid the Simple-Agent trace hang (#490). The real
+ * flow id comes from the template-instantiation POST 201 (the canvas URL id is
+ * transient on 1.11 — #505); loadTemplateByName returns it.
+ */
+const TEMPLATE_NAME = "Basic Prompting";
+
+test.describe("Flow Functionality — Create Flow from Template", () => {
+  let createdFlowId: string | null = null;
+
+  test.afterEach(async ({ page, request }) => {
+    if (createdFlowId) {
+      await page.goto("/");
+      await deleteFlow(request, createdFlowId, {
+        headers: { Authorization: await getAuthToken(request) },
+      });
+      createdFlowId = null;
+    }
+  });
+
+  test("user can create a flow from a starter template",
+    { tag: ["@stable", "@release", "@regression", "@workspace"] },
+    async ({ page, request }) => {
+      await test.step("Open the templates modal and pick the Basic Prompting template", async () => {
+        // loadTemplateByName captures the real flow id from the POST 201 and
+        // resolves once canvas_controls_dropdown is visible (editor open).
+        createdFlowId = await loadTemplateByName(page, TEMPLATE_NAME);
+        expect(createdFlowId).toBeTruthy();
+      });
+
+      await test.step("Confirm the template's components loaded on the canvas", async () => {
+        await expect(page.locator(".react-flow__node").first()).toBeVisible({
+          timeout: 15000,
+        });
+        expect(
+          await page.locator(".react-flow__node").count(),
+        ).toBeGreaterThan(0);
+      });
+
+      await test.step("Confirm the persisted flow has the template's content and name", async () => {
+        const authToken = await getAuthToken(request);
+        await expect
+          .poll(
+            async () => {
+              const res = await request.get(`/api/v1/flows/${createdFlowId}`, {
+                headers: { Authorization: authToken },
+              });
+              if (res.status() !== 200) return null;
+              const flow = (await res.json()) as {
+                name?: string;
+                data?: { nodes?: unknown[] };
+              };
+              return {
+                hasNodes: (flow.data?.nodes?.length ?? 0) > 0,
+                nameMatches: (flow.name ?? "").includes(TEMPLATE_NAME),
+              };
+            },
+            { timeout: 10000, intervals: [500, 1000, 2000] },
+          )
+          .toEqual({ hasNodes: true, nameMatches: true });
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #677.

Closes the `[-] Create flow from template` gap in `QA-CHECKLIST.md` §12.1 Create Flow. Template instantiation is exercised implicitly across the suite (via `loadTemplateByName`) but had no dedicated spec asserting the behavior. Mirror of `create-blank-flow.spec.ts` (#676): blank asserts a **zero-node** graph, this asserts the template's content **arrived**.

## 1. Covered tests
| # | Test | What it validates |
|---|------|-------------------|
| 1 | `user can create a flow from a starter template` | Quadruple observable (all required): the template-instantiation `POST /api/v1/flows/` `201` (real id captured), the editor opens, the canvas shows **> 0 nodes**, and the persisted flow (`GET /api/v1/flows/{id}`) has a non-empty `data.nodes` with a `name` containing `Basic Prompting`. Catches a regression where picking a template opens an empty flow (template not applied). |

## 2. How the test was built
- **Setup:** reuses the battle-tested `loadTemplateByName(page, "Basic Prompting")` helper — opens the New Flow modal (handling the 1.10 welcome overlay), All Templates tab, picks by heading, returns the real flow id from the `POST 201`.
- **Template choice:** `Basic Prompting` (not the Agent templates) keeps the canvas render light/deterministic and avoids the Simple-Agent `--trace=on` hang (#490). Same template `duplicate-flow.spec.ts` (@stable) uses.
- **Real id from the creation POST, not `page.url()`** — the canvas URL id is transient on 1.11 (#505); the helper captures the persisted id.
- **Assertion rationale:** non-empty persisted graph + template name is the distinctive check — it separates "created from THIS template" from "some flow opened", mirroring the blank-flow spec's zero-node assertion.
- **Cleanup:** id-scoped `afterEach` delete with Bearer auth. Verified 0 orphan flows after the run bursts.

## 3. Dependencies
- **None** — pure workspace operation, no LLM / provider key.
- Execution: parallel-safe (id-scoped, no shared named state).

## Validation (nightly 1.11.0.dev36, `--retries=0`)
- typecheck ✅ · eslint ✅ · anti-pattern checklist ✅
- 4 clean runs (6–11s), no flake ✅
- force-fail ✅ (persisted-graph expected → `hasNodes: false` ⇒ fails; reverted, `grep -c FF-MUTATION` = 0)
- `--trace=on` ✅ (6.9s, no hang) · zero `🚨 Backend Error` ✅ · 0 orphan flows ✅