### PR TITLE
test(observability): add flow-error-message @stable spec (#695)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -448,7 +448,7 @@
 
 #### 8.4 Error Handling and Edge Cases
 - [-] Component that raises Python error
-- [ ] Flow with error displays appropriate message
+- [x] Flow with error displays appropriate message → `core-functionality/observability-monitoring/flow-error-message.spec.ts`
 - [-] Network error during execution
 - [-] Execution timeout — clear message to user
 

--- a/docs/core-functionality/observability-monitoring/flow-error-message.md
+++ b/docs/core-functionality/observability-monitoring/flow-error-message.md
@@ -1,0 +1,119 @@
+# Spec: A misconfigured flow surfaces an appropriate build-error message (§8.4)
+
+**Test file:** `tests/tests-automations/regression/core-functionality/observability-monitoring/flow-error-message.spec.ts`
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates
+
+When a flow fails to build because a component is **misconfigured** (a required
+field left empty), Langflow surfaces an **appropriate, specific** error message
+that names the actual problem — not a generic "something went wrong". This is
+the §8.4 "Flow with error displays appropriate message" guarantee: the user is
+told *what* to fix.
+
+The vehicle is the **API Request** component with an empty **URL** field. Running
+it fails the build in ~0.3s (no network call — the validation happens before any
+request), and the UI shows both:
+
+- a **"Flow build failed"** banner (the generic failure signal), and
+- the **specific, actionable message "URL cannot be empty"** (the appropriate
+  part — it names the exact field/reason).
+
+## Why this scope (distinct from the §8.4 siblings)
+
+Two neighbouring specs already exist; this one deliberately does NOT overlap:
+
+- `core-components/validate-raise-errors-components.spec.ts` — a **Custom
+  Component that `raise`s a Python `ValueError`**; asserts the raised message
+  surfaces. That is the "Component that raises Python error" bullet.
+- `ui-ux/execution-error-notification.spec.ts` — a **mocked network 500 /
+  timeout**; asserts generic error feedback appears. That is the "Network error
+  during execution" bullet.
+
+This spec is the third, distinct case: a **configuration/validation error** (no
+Python raise, no network mock) where the value of the test is that the message
+is *appropriate* — it names the missing field. A generic "build failed" alone
+would not satisfy it.
+
+---
+
+## Tags
+
+`@stable` `@release` `@components` `@observability`
+
+(`@observability`: user-facing error surfacing is the subject. `@components`:
+the error originates from a component's field validation. Created `@stable` by
+#695 after deterministic validation.)
+
+---
+
+## Step by step
+
+1. Bootstrap to the templates modal and open a **blank flow**
+   (`awaitBootstrapTest` → `blank-flow`); wait for the sidebar
+   (`sidebar-search-input`) to be interactive.
+2. `page.allowFlowErrors()` — the build failure is intentional; without this
+   the fixture's flow-error monitor would fail the test itself.
+3. Add the **API Request** component (search "API Request" →
+   `add-component-button-api-request`). Leave the **URL** field empty.
+4. Run the component from its terminal run button (`button_run_api request`).
+5. Assert the **generic** failure banner "Flow build failed" is visible.
+6. Assert the **appropriate specific** message "URL cannot be empty" is visible
+   — this is the distinctive observable.
+
+---
+
+## Validation criterion
+
+| Step | Criterion |
+|---|---|
+| After running the URL-less API Request | "Flow build failed" banner visible |
+| Same | "URL cannot be empty" specific message visible (within a few seconds; the build fails in ~0.3s, no network) |
+
+The specific-message assertion is what makes this a §8.4 "appropriate message"
+test — a regression that degrades the message to a generic failure, or removes
+the field-level validation, fails the specific assertion while the banner may
+still pass.
+
+---
+
+## External dependencies
+
+- Component testids: `add-component-button-api-request`,
+  `button_run_api request` (scouted live on 1.11.0.dev41).
+- Error copy: "Flow build failed" (banner) and "URL cannot be empty"
+  (API Request URL validation) — both live on 1.11; a change to either breaks
+  the corresponding assertion.
+- **No external network or provider** — the empty-URL validation fails before
+  any HTTP request, so the test is hermetic and deterministic.
+
+---
+
+## What this test does not cover
+
+- Component-level Python `raise` errors (covered by
+  `validate-raise-errors-components.spec.ts`).
+- Network 500 / timeout during execution (covered by
+  `execution-error-notification.spec.ts`).
+- Execution-timeout messaging (separate §8.4 bullet).
+- The Retry/Dismiss affordances on the failure banner.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` (auto_login).
+
+---
+
+## Flow cleanup
+
+The test creates one blank flow. Its id is captured via the **Pattern A
+response accumulator** (`page.on("response")` collecting every `POST
+/api/v1/flows` 201 id) — never `page.url()`, since `awaitBootstrapTest` creates
+a competing bootstrap flow whose id the URL would carry (#681). `afterEach`
+deletes all captured ids (404-tolerant). Behavioral force-fail: no-op the
+cleanup and the flow count grows.

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/flow-error-message.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/flow-error-message.spec.ts
@@ -1,0 +1,94 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+
+// Capture the created flow's id from POST /api/v1/flows 201 responses (Pattern
+// A). Not page.url(): awaitBootstrapTest creates a competing bootstrap flow, so
+// the canvas URL carries the stale bootstrap id (#681). Only ids this page
+// created are captured, so cleanup stays parallel-safe.
+const createdFlowIds: string[] = [];
+
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {});
+    }
+  });
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, {
+      headers: { Authorization: bearer },
+    }).catch(() => {});
+  }
+});
+
+test(
+  "a misconfigured flow surfaces an appropriate build-error message",
+  { tag: ["@stable", "@release", "@components", "@observability"] },
+  async ({ page }) => {
+    trackCreatedFlows(page);
+    // The build failure below is intentional — without this the fixture's
+    // flow-error monitor would fail the test on the backend error itself.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (page as any).allowFlowErrors();
+
+    await awaitBootstrapTest(page);
+
+    await test.step("open a blank flow", async () => {
+      await expect(page.getByTestId("blank-flow")).toBeVisible({
+        timeout: 30000,
+      });
+      await page.getByTestId("blank-flow").click();
+      await page.waitForURL(/\/flow\/[^/?#]+/, { timeout: 30000 });
+      await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
+        timeout: 30000,
+      });
+    });
+
+    await test.step("add an API Request component and leave the URL empty", async () => {
+      await page.getByTestId("sidebar-search-input").click();
+      await page.getByTestId("sidebar-search-input").fill("API Request");
+      await expect(
+        page.getByTestId("add-component-button-api-request"),
+      ).toBeVisible({ timeout: 15000 });
+      await page.getByTestId("add-component-button-api-request").click();
+      await expect(page.getByTestId("button_run_api request")).toBeVisible({
+        timeout: 15000,
+      });
+    });
+
+    await test.step("running the misconfigured flow surfaces the appropriate message", async () => {
+      await page.getByTestId("button_run_api request").click();
+
+      // Generic failure signal.
+      await expect(page.getByText("Flow build failed")).toBeVisible({
+        timeout: 15000,
+      });
+      // The distinctive, appropriate message: it names the exact problem
+      // (the empty required field), not a generic failure. It renders in two
+      // places — a transient alert toast (role=alert, auto-dismisses) and the
+      // persistent inline error container on the failed build. `.first()`
+      // targets whichever copy is present without racing the toast's fade
+      // (scoping to role=alert flaked once the toast dismissed) and without a
+      // strict-mode violation while both are on screen.
+      await expect(
+        page.getByText("URL cannot be empty").first(),
+      ).toBeVisible({ timeout: 15000 });
+    });
+  },
+);


### PR DESCRIPTION
Closes #695

## What

New `@stable` spec for QA-CHECKLIST §8.4 "Flow with error displays appropriate message" — a misconfigured flow surfaces a **specific, actionable** error message, not just a generic failure. Wave 2 new-spec.

## The test

An **API Request** component with an empty **URL** is run. The build fails in ~0.3s (no network — the empty-field validation fires before any HTTP request) and the UI shows:
- the generic **"Flow build failed"** banner, and
- the appropriate, specific message **"URL cannot be empty"** (names the exact field — the distinctive observable).

## Distinct from the §8.4 siblings (no overlap)

- `core-components/validate-raise-errors-components.spec.ts` — a Custom Component that `raise`s a Python `ValueError` ("Component that raises Python error").
- `ui-ux/execution-error-notification.spec.ts` — a mocked network 500 / timeout ("Network error during execution").
- **This** — a config/validation error (no raise, no mock) whose value is that the message is *appropriate*: it names the missing field.

## Determinism (flake fixed)

The appropriate message renders in **two** places — a transient alert toast (`role=alert`, auto-dismisses) and the persistent inline error container on the failed build. Scoping the assertion to `role=alert` flaked once the toast dismissed (a review run caught it). Fixed to `page.getByText("URL cannot be empty").first()` — targets whichever copy is present without racing the toast fade or a strict-mode violation. **8/8 green burst** after the fix.

## Validation

- Nightly: **1.11.0.dev41**
- Burst: **8/8 green** (+ VALIDATE 3/3) with `--workers=1 --retries=0`, **0 orphan flows** after each run, zero unexpected `🚨 Backend Error` (the intentional build failure is gated by `allowFlowErrors()`)
- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors)
- **Force-fail executed:** message assert mutated (`"URL cannot be empty XYZ"`) → red run (unexpected=1); revert proven (0 markers) + final green
- Hermetic — no network or provider credentials
- Flow cleanup: `POST /api/v1/flows` 201 **response accumulator** (`page.url()` carries the stale bootstrap flow id, #681)

🤖 Generated with [Claude Code](https://claude.com/claude-code)