### PR TITLE
chore(skills): scope triage verdicts to dedicated issues

### DIFF
--- a/.claude/skills/langflow-e2e-issue-deterministic/pipeline/instructions.ts
+++ b/.claude/skills/langflow-e2e-issue-deterministic/pipeline/instructions.ts
@@ -117,7 +117,8 @@ export function instructionFor(s: PipelineState): string {
 
     case 'DISPATCH':
       return [
-        `This is a triage dispatcher, not a fix. Per CONTRIBUTING § @stable lifecycle: open one dedicated issue per problem, classify each (hard-failure vs recurrent-flake vs transient vs wiper), and do NOT fix anything on this branch.`,
+        `This is a triage dispatcher, not a fix — CONTRIBUTING § Triage protocol governs and outranks this skill. Shallow & descriptive: open one dedicated issue per problem in order hard-failure → flake → skip, dedup against open issues, and do NOT fix anything on this branch.`,
+        `hard-failure vs recurrent-flake vs transient vs wiper here is a routing bucket noted DESCRIPTIVELY — never a closing verdict. The verdict + evidence framework runs on the dedicated issues (DEBUG phase), not here. If the mass-failure guard tripped, add one descriptive call — was the day environmental? — and only if NOT, remove @stable manually from the real hard failures.`,
         done('DISPATCH', '{"createdIssues":["#NNN"]}'),
       ].join('\n')
 

--- a/.claude/skills/langflow-e2e-issue-deterministic/pipeline/instructions.ts
+++ b/.claude/skills/langflow-e2e-issue-deterministic/pipeline/instructions.ts
@@ -118,7 +118,7 @@ export function instructionFor(s: PipelineState): string {
     case 'DISPATCH':
       return [
         `This is a triage dispatcher, not a fix — CONTRIBUTING § Triage protocol governs and outranks this skill. Shallow & descriptive: open one dedicated issue per problem in order hard-failure → flake → skip, dedup against open issues, and do NOT fix anything on this branch.`,
-        `hard-failure vs recurrent-flake vs transient vs wiper here is a routing bucket noted DESCRIPTIVELY — never a closing verdict. The verdict + evidence framework runs on the dedicated issues (DEBUG phase), not here. If the mass-failure guard tripped, add one descriptive call — was the day environmental? — and only if NOT, remove @stable manually from the real hard failures.`,
+        `The hard-failure / recurrent-flake / transient / wiper labels here are routing buckets noted DESCRIPTIVELY — never closing verdicts. The verdict + evidence framework runs on the dedicated issues (DEBUG phase), not here. If the mass-failure guard tripped, add one descriptive call — was the day environmental? — and only if NOT, remove @stable manually from the real hard failures.`,
         done('DISPATCH', '{"createdIssues":["#NNN"]}'),
       ].join('\n')
 

--- a/.claude/skills/langflow-e2e-issues/SKILL.md
+++ b/.claude/skills/langflow-e2e-issues/SKILL.md
@@ -166,15 +166,19 @@ it as, before touching code.
 |---|---|---|
 | **new-spec** | `test-automation` label, "Create `<name>.spec.ts` — …" | Full SDD: author spec doc → build POM/helpers → write `.spec.ts` → tag → validate. |
 | **validate-&-promote** | "Validate & promote …", "Promote … to `@stable`" | The spec/test usually **already exists** — locate it. Validate it runs green (see Promotion below), then add `@stable`. Author a spec doc only if missing. |
-| **daily-failure triage** | `daily-failure` label, "triage", lists multiple removed tests | This is a **dispatcher**, not a fix. Per `CONTRIBUTING.md` § @stable lifecycle: fan it out into one **dedicated issue per problem**, classify each (hard-failure vs recurrent-flake), then work them separately. Don't fix everything on one branch. |
+| **daily-failure triage** | `daily-failure` label, "triage", lists multiple removed tests | **Dispatch only — `CONTRIBUTING.md` → *Triage protocol* governs and outranks this skill.** Shallow & descriptive: read the run, fan out one **dedicated issue per problem** in order **hard-failure → flake → skip**, note environment signals *descriptively — never as a verdict*, dedup against open issues, then **close the triage**. Do NOT reach a verdict, "prove on 3 environments", or fix anything here — `triage-verdicts.md` runs on the **dedicated issues** this spawns, not on the triage. If the mass-failure guard tripped, the one extra deliverable is a *descriptive* environmental call deciding whether to manually remove `@stable` from the real hard failures. |
 | **fix (dedicated)** | "Fixes #…", single hard-failure/flake | `systematic-debugging` → root-cause → fix → prove N clean `--retries=0` runs → **restore `@stable`** via PR on resolve. |
 | **community regression** | `community` label (+ `high`/`medium`/`low`) | Lives outside the wave milestone; work in severity order. Becomes a named `@regression` spec + `QA-CHECKLIST.md` bullet. |
 | **file-watcher** | opened by `file-watcher.yml`, lists upstream commits + a `--grep` table | Read the listed commits, run the indicated tests, fix any drift, close the issue (`CONTRIBUTING.md` § file-watcher). |
 
-**Failure triage — decide with evidence before "fixing" anything.** Not every
-failing test means the test is wrong; the verdict routes the work. Whenever a
-failure/behavior looks broken — in the issue body, during reproduction, or on
-a previously-green spec — read
+**Failure triage — decide with evidence before "fixing" anything (on a DEDICATED
+issue).** Not every failing test means the test is wrong; the verdict routes the
+work. **This applies when working a dedicated `fix` / `community` / `file-watcher`
+issue — NOT the daily-failure triage dispatcher**, which stays shallow and
+descriptive per `CONTRIBUTING.md` → *Triage protocol* (see the CLASSIFY row
+above); the verdicts run on the dedicated issues a triage spawns, never on the
+triage itself. Whenever a failure/behavior looks broken — in the issue body,
+during reproduction, or on a previously-green spec — read
 **`references/triage-verdicts.md`** and classify into one of the six
 verdicts before touching code:
 
@@ -184,7 +188,7 @@ verdicts before touching code:
 3. **Product changed intentionally** → not-implementable / re-scope closure
    (steelman every trigger path first).
 4. **Transient (CI saturation)** → prove on 3 environments; restore @stable
-   with no test change.
+   with no test change. *(Concluded on the dedicated issue, never at triage.)*
 5. **Cross-worker destructive cleanup** → fix the WIPER (hunt transitively
    through POMs), never the victim.
 6. **Stale "confirmed bug"** → reproduce on the live nightly FIRST; if fixed,
@@ -343,6 +347,14 @@ Only when the user authorizes, follow `langflow-e2e/references/pr-guide.md`:
   user had to ask on #503 and #597; never a third time.
 
 ## Boundaries
+
+**`CONTRIBUTING.md` is the repository's convention and outranks this skill.**
+Skills are tools that assist; the convention is the rule. On any conflict
+between a skill instruction and `CONTRIBUTING.md`, follow `CONTRIBUTING.md` and
+fix the skill. Concretely: the daily-failure **triage issue** follows
+`CONTRIBUTING.md` → *Triage protocol* (dispatch — shallow, descriptive); the
+verdicts framework in `references/triage-verdicts.md` is for the **dedicated
+issues** it spawns, not for the triage.
 
 This skill is versioned in the repo (`.claude/skills/`) and shared with the team
 — keep it accurate and English-only, like any tracked file. It orchestrates; the

--- a/.claude/skills/langflow-e2e-issues/references/triage-verdicts.md
+++ b/.claude/skills/langflow-e2e-issues/references/triage-verdicts.md
@@ -18,7 +18,9 @@ routing a failing/suspicious behavior before "fixing" anything.
 > The origin case for the TRANSIENT verdict (#549) was itself a **dedicated
 > issue** derived from triage #548 — proof of where this framework belongs.
 
-**Test defect vs Langflow regression — decide with evidence, at ANY phase.**
+**Test defect vs Langflow regression — decide with evidence, at any resolution
+phase** (while working a dedicated issue, SPECIFY→VERIFY or during reproduction —
+never at triage; see the SCOPE banner above).
 Not every failing test means the test is wrong: the product itself regresses
 (this suite exists to catch exactly that). Whenever a failure/behavior looks
 broken — in the issue body, during reproduction, or when a previously-green

--- a/.claude/skills/langflow-e2e-issues/references/triage-verdicts.md
+++ b/.claude/skills/langflow-e2e-issues/references/triage-verdicts.md
@@ -3,6 +3,21 @@
 Loaded on demand from SKILL.md → CLASSIFY. Full decision framework for
 routing a failing/suspicious behavior before "fixing" anything.
 
+> **SCOPE — this is a DEDICATED-issue tool, not the initial-triage protocol.**
+> `CONTRIBUTING.md` → *Triage protocol — working the triage issue* is the
+> repository's convention and **outranks this file**. Skills are tools that
+> assist; the convention is the rule — on any conflict, follow `CONTRIBUTING.md`
+> and fix the skill. Use the verdicts below only when working a **dedicated
+> issue** (root-cause → fix → restore `@stable`). When working the
+> **daily-failure triage issue itself**, do NOT run this framework: the triage
+> is *dispatch — shallow and descriptive*. Read the run, fan out one dedicated
+> issue per problem (order: hard-failure → flake → skip), note environment
+> signals *descriptively — never as a verdict*, dedup against open issues, and
+> close the triage. Reaching a verdict (especially TRANSIENT) or "proving on 3
+> environments" at the triage stage overrides `CONTRIBUTING.md` and is wrong.
+> The origin case for the TRANSIENT verdict (#549) was itself a **dedicated
+> issue** derived from triage #548 — proof of where this framework belongs.
+
 **Test defect vs Langflow regression — decide with evidence, at ANY phase.**
 Not every failing test means the test is wrong: the product itself regresses
 (this suite exists to catch exactly that). Whenever a failure/behavior looks
@@ -47,7 +62,8 @@ Route by the verdict:
   in-protocol vs transport, flow-as-tool, BaseException classes) and give
   each a source-level or empirical verdict before flagging
   not-implementable — the audit table IS the issue-closure evidence.
-- **Third verdict for daily-failure triage: TRANSIENT (CI saturation).** When
+- **TRANSIENT (CI saturation) — a DEDICATED-issue verdict, never concluded at
+  triage** (see SCOPE banner). When
   the failing daily had MANY simultaneous unrelated failures + backend 500s
   on unrelated endpoints, suspect the shared Langflow container saturated
   under the full parallel suite. Prove it on three environments: (1) local


### PR DESCRIPTION
## Type

- [x] `chore` — CI, checklist, dependencies, internal refactoring

## Roadmap linkage

- [x] **Exception** — follow-up spawned from the #704 daily-failure triage. Issue #719

## What this PR does

Enforces the **supremacy of `CONTRIBUTING.md`** over the skills and fixes a phase-scoping bug that surfaced while triaging #704: the `langflow-e2e-issues` skill pushed the analyst toward a **closed verdict** (`TRANSIENT`) + a "prove on 3 environments" plan **at the initial triage stage**, contradicting `CONTRIBUTING.md` → *Triage protocol*, which requires the triage to stay **dispatch-only — shallow and descriptive**, with root-cause verdicts happening on the **dedicated issues** the triage spawns.

Principle now stated explicitly across the skills: **skills are tools that assist; `CONTRIBUTING.md` is the rule.** On any conflict, follow `CONTRIBUTING.md` and fix the skill.

Changes:

- **`langflow-e2e-issues/references/triage-verdicts.md`** — SCOPE banner at the top (dedicated-issue tool; CONTRIBUTING outranks it; no verdict / 3-environment proof at triage). Reworded the misleading label *"Third verdict for daily-failure triage: TRANSIENT"* → *"a DEDICATED-issue verdict, never concluded at triage"*. Cites the origin case (#549 = dedicated issue derived from triage #548) as proof of where the framework belongs.
- **`langflow-e2e-issues/SKILL.md`** — CLASSIFY `daily-failure` row rewritten as dispatch-only (order hard→flake→skip, descriptive environment notes, the guard's manual-@stable call as the only extra deliverable). Gated the verdict block to dedicated issues. Annotated verdict 4 (`Transient`) as "concluded on the dedicated issue, never at triage". Added a CONTRIBUTING-supremacy paragraph to Boundaries.
- **`langflow-e2e-issue-deterministic/pipeline/instructions.ts`** — the pipeline already models the phases correctly (triage spine `DISPATCH → DISPATCHED`; verdict taxonomy only on the `fix` `DEBUG` phase). Reinforced the `DISPATCH` text so the hard-failure / flake / transient / wiper buckets read as **descriptive routing, never a closing verdict**.

## What this PR does not cover

Does not change any test behavior, spec, or product code — docs/tooling only. Does not re-triage #704 itself (tracked separately).

## Validation

- [x] `npx tsx --test *.test.ts` on the deterministic pipeline — **58 passed, 0 failed**
- [x] `tsc --noEmit` on the pipeline tsconfig — clean
- [x] The DISPATCH instruction test still asserts the required `one dedicated issue per problem` phrasing — green

Closes #719