### PR TITLE
chore(triage): remove @stable from provider-count test (#721)

### DIFF
--- a/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-modal-actions.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-modal-actions.spec.ts
@@ -23,9 +23,12 @@ async function openModelProviders(page: any): Promise<void> {
 }
 
 test.describe("Model Provider Modal Actions", () => {
+  // @stable removed by daily triage #704 — provider count assertion fails
+  // deterministically (hardcoded 8, live catalog now 9 on 1.11.0.dev41).
+  // Restore once reconciled — see #721.
   test(
     "page opens with its description and the available provider count",
-    { tag: ["@stable", "@release", "@workspace", "@regression", "@model-provider"] },
+    { tag: ["@release", "@workspace", "@regression", "@model-provider"] },
     async ({ page }) => {
       await openModelProviders(page);
 


### PR DESCRIPTION
## What

Removes `@stable` from the `page opens with its description and the available provider count` test in `model-provider-modal-actions.spec.ts`. The sibling invalid-key test in the same file did not fail and keeps `@stable`.

## Why

Spun out of daily-failure triage #704 (run [29244611612](https://github.com/oriontech-me/langflow-e2e/actions/runs/29244611612), 2026-07-13, Langflow `1.11.0.dev41`). The test asserts an **exact** provider count of 8 (`toHaveCount(MIN_PROVIDER_COUNT)`), but the live catalog now renders **9**:

```
expect(locator).toHaveCount(expected) failed
Locator: locator('[data-testid^="provider-item-"]')
Expected: 8
Received: 9
```

That run tripped the daily **mass-failure guard** (12 hard failures > 5), so the workflow's auto-removal skipped every failing test. Unlike the day's dominant environmental cluster (agent/playground runs not completing across providers), this failure is **deterministic and non-environmental** — it will recur every daily until reconciled. Per `CONTRIBUTING.md` → *Triage protocol* ("if it turns out not to be environmental, remove `@stable` manually from the real hard failures"), the tag is removed here manually.

This only quarantines the test from the daily `@stable` workflow — no test logic changes. Investigation and the fix (regression vs. exact-count vs. `>= MIN` matcher) happen on #721; `@stable` is restored in the fix PR.

The `QA-CHECKLIST.md` Phase 0 / Validated blocks regenerate automatically on merge (`update-coverage-summary.yml`) — not hand-edited here.

Closes #721
