### PR TITLE
chore(triage): remove @stable from two recurrent flakes (#726, #727)

### DIFF
--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-error-handling.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-error-handling.spec.ts
@@ -291,9 +291,11 @@ for (const { label, options, skipReason } of targets) {
   const provider = options.provider ?? (Object.keys(providerConfigMap)[0] as Provider);
 
   test.describe(`Agent Tool Error Handling [${label}]`, () => {
+    // @stable removed by daily triage #704 — recurrent flake on healthy days
+    // (07-07, 07-10; see reports/daily-history.jsonl). Restore once fixed — #726.
     test(
       "agent handles a tool error and continues execution",
-      { tag: ["@stable", "@regression", "@agents", "@playground"] },
+      { tag: ["@regression", "@agents", "@playground"] },
       async ({ page, request }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(

--- a/tests/tests-automations/regression/core-functionality/project-management/edit-flow-name.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/edit-flow-name.spec.ts
@@ -2,9 +2,11 @@ import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { renameFlow } from "../../../../helpers/flows/rename-flow";
 
+// @stable removed by daily triage #704 — recurrent flake on healthy days
+// (07-03, 07-10; see reports/daily-history.jsonl). Restore once fixed — #727.
 test(
   "user should be able to edit flow name and see it reflected in the main page listing",
-  { tag: ["@release", "@workspace", "@regression", "@stable"] },
+  { tag: ["@release", "@workspace", "@regression"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 


### PR DESCRIPTION
## What

Removes `@stable` from two recurrent flakes surfaced by daily triage #704:

- `agent-tool-error-handling.spec.ts` — `agent handles a tool error and continues execution`
- `edit-flow-name.spec.ts` — `user should be able to edit flow name and see it reflected in the main page listing`

No test logic changes — only the `@stable` tag is dropped.

## Why

Both tests flaked on **healthy dailies**, not only on the environmental days (07-08 mass-failure, 07-13 guard-tripped):

| Test | Flaky/hard days | Healthy-day recurrence |
|---|---|---|
| agent-tool-error-handling | 07-07, 07-08, 07-10, 07-13 | 07-07, 07-10 |
| edit-flow-name | 07-03, 07-08, 07-10, 07-13 | 07-03, 07-10 |

That sustained recurrence on healthy days is not explained by instance health, so each is quarantined from the daily `@stable` workflow until fixed. Flake removal is always manual (the workflow only auto-removes hard failures).

Batched into one PR — mirroring how the daily `auto-remove-stable` action removes a run's failures in a single commit. Each `@stable` is restored in its own fix PR.

**Note:** the signature-based recurrence criterion in `CONTRIBUTING.md` could not be applied mechanically because the history appender omits `error_signature` for flaky rows — filed as #728. Recurrence here was judged by test identity across healthy days.

`QA-CHECKLIST.md` regenerates on merge (`update-coverage-summary.yml`) — not hand-edited.

Closes #726
Closes #727
