### PR TITLE
test(knowledge-ingestion): add file-types upload spec (txt/pdf/json/py/wav) (#672)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -297,7 +297,7 @@
 
 #### 5.1 File Upload
 - [x] Upload file via component → `core-functionality/knowledge-ingestion-management/upload-via-component.spec.ts`
-- [-] Upload files of different types (txt, pdf, json, py, wav)
+- [x] Upload files of different types (txt, pdf, json, py, wav) → `core-functionality/knowledge-ingestion-management/file-types-upload.spec.ts`
 - [-] File size limit
 - [-] File management page
 

--- a/docs/core-functionality/knowledge-ingestion-management/file-types-upload.md
+++ b/docs/core-functionality/knowledge-ingestion-management/file-types-upload.md
@@ -1,0 +1,127 @@
+# Spec: Upload files of different types via the Files page (§5.1 File Upload)
+
+**Test file:** `tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/file-types-upload.spec.ts`
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+A user can upload files of **different content types** into their global file
+store through the **My Files** page — the Files-page upload path (distinct from
+the canvas Read File component that `upload-via-component.spec.ts` exercises, and
+from the Chat Input / Playground upload of `limit-file-size-upload.spec.ts`).
+
+The §5.1 checklist bullet names five representative types — **txt, pdf, json,
+py, wav** — spanning plain text, a binary document (pdf), structured text
+(json), source code (py) and binary audio (wav). This mix is deliberate: the
+canvas **Read File** component only accepts its `VALID_EXTENSIONS` allow-list
+(`TEXT_FILE_TYPES` + Docling formats), which **excludes `wav`** — so wav/binary
+type coverage can only live on the Files page, whose `POST /api/v2/files`
+endpoint enforces no extension allow-list (only size and filename-safety
+checks). If the Files-page upload silently dropped, corrupted, or rejected one
+of these types, or lost the file's extension, this test fails on that specific
+type.
+
+One `test()` per type keeps each type independently falsifiable — a regression
+affecting only pdf or only wav fails exactly that row, not the whole suite.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@files`
+
+(`@stable` + `@release`: cross-cutting — happy-path upload coverage, run in the
+daily-stable workflow. `@files`: functional — file upload/ingestion surface.)
+
+---
+
+## Step by step *(required)*
+
+Parameterized per type over `{ txt, pdf, json, py, wav }`; each `test()`:
+
+1. Bootstrap to the home page (`awaitBootstrapTest(page, { skipModal: true })`,
+   which itself handles the empty-instance first-run by creating a Basic
+   Prompting flow); assert `mainpage_title` is visible.
+2. Open **My Files** (sidebar button labeled "My Files" — it carries no testid,
+   so click it by exact text); assert the page title contains "Files".
+3. Click `upload-file-btn`, which opens a native file chooser.
+4. Set a **uniquely-named** in-memory file on the chooser
+   (`<random-stem>.<ext>`, real asset bytes read from disk) and gate on the
+   upload completing server-side: `POST /api/v2/files` with a `< 300` status.
+5. From that upload response body, assert the stored record proves the type was
+   accepted and its extension preserved: `name === <random-stem>` (Langflow
+   strips the extension from `name`) and `path` ends with `.<ext>`.
+6. Assert the uploaded file appears in the Files list UI as
+   `<random-stem>.<ext>`.
+
+---
+
+## Validation criterion *(required)*
+
+For each of the five types, after uploading `<random-stem>.<ext>` through the
+My Files **Upload** button:
+
+- the `POST /api/v2/files` upload request returns a success status (`< 300`) —
+  the type was **accepted** by the store; and
+- the upload response record has `name === <random-stem>` and `path` ending in
+  `.<ext>` — the file's **extension was preserved** (the distinctive,
+  type-specific observable); and
+- a row labeled `<random-stem>.<ext>` is **visible** in the Files list — the UI
+  reflects the stored file.
+
+A regression that rejects a type, corrupts the upload, or drops the extension
+fails the specific type's row. The random stem makes an accidental match with a
+pre-existing file impossible and isolates parallel workers.
+
+---
+
+## External dependencies *(required)*
+
+- `src/frontend/src/pages/MainPage/**` (My Files page) — the `upload-file-btn`
+  control, the file-list rendering, and the "My Files" sidebar entry.
+- `src/backend/base/langflow/api/v2/files.py` — `POST /api/v2/files` (upload;
+  no extension allow-list — only size + filename-safety), `GET /api/v2/files`,
+  `DELETE /api/v2/files/{id}` (cleanup). If an extension allow-list is
+  introduced here, wav/pdf coverage must be revisited.
+- Assets (resolved via `resolveAssetPath`, which probes
+  `tests/assets/{media,files,flows}`): `test-file.txt`, `test-file.pdf`,
+  `test-file.json`, `test-file.py` (all under `files/`) and
+  `test_audio_file.wav` (under `media/`).
+- No model provider credentials required (pure upload/storage, no LLM).
+
+---
+
+## What this test does not cover *(optional)*
+
+- The canvas **Read File** component upload + content read-back (covered by
+  `upload-via-component.spec.ts`) — and note that surface **cannot** upload wav.
+- Chat Input / Playground file upload and the file-size limit (covered by
+  `limit-file-size-upload.spec.ts`).
+- Files-page CRUD beyond upload — drag-and-drop upload, search, bulk delete
+  (covered by `files-page.spec.ts`).
+- Whether each type is *parsed/ingested* downstream (Split Text, embeddings,
+  vector store) — that is §5.2 Processing and Vectorization.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` (auto_login).
+
+---
+
+## Flow & file cleanup *(notes)*
+
+Two classes of persistent artifact, both cleaned id-scoped in `afterEach`:
+
+- **Uploaded files:** each upload persists in the user's global file store, so
+  the id returned by each `POST /api/v2/files` is tracked and
+  `DELETE /api/v2/files/{id}` removes it. Behavioral force-fail: no-op the file
+  cleanup and orphan files accumulate across runs.
+- **Flow:** `awaitBootstrapTest` creates a Basic Prompting flow **only** on a
+  truly empty first-run instance; to stay safe, `POST /api/v1/flows` 201 ids are
+  captured via the Pattern A response accumulator and deleted with `deleteFlow`
+  (404-tolerant). Never `page.url()` (#681).

--- a/tests/assets/files/test-file.pdf
+++ b/tests/assets/files/test-file.pdf
@@ -1,0 +1,32 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 58 >>
+stream
+BT /F1 18 Tf 20 100 Td (Langflow e2e test PDF) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000349 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+420
+%%EOF

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/file-types-upload.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/file-types-upload.spec.ts
@@ -1,0 +1,127 @@
+import fs from "fs";
+import type { APIRequestContext, Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { resolveAssetPath } from "../../../../helpers/filesystem/resolve-asset-path";
+import { generateRandomFilename } from "../../../../helpers/filesystem/generate-filename";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+
+// §5.1 — Upload files of DIFFERENT types (txt, pdf, json, py, wav) through the
+// My Files page. The canvas Read File component enforces a VALID_EXTENSIONS
+// allow-list that excludes wav, so binary/audio type coverage can only live on
+// the Files page, whose POST /api/v2/files enforces no extension allow-list.
+// One test() per type keeps each type independently falsifiable.
+const FILE_TYPES = [
+  { ext: "txt", asset: "test-file.txt", mime: "text/plain" },
+  { ext: "pdf", asset: "test-file.pdf", mime: "application/pdf" },
+  { ext: "json", asset: "test-file.json", mime: "application/json" },
+  { ext: "py", asset: "test-file.py", mime: "text/x-python" },
+  { ext: "wav", asset: "test_audio_file.wav", mime: "audio/wav" },
+] as const;
+
+// Two persistent artifacts to clean up id-scoped: the uploaded file (it lands
+// in the user's global /api/v2/files store) and — only on a truly empty
+// first-run instance — the Basic Prompting flow that awaitBootstrapTest
+// creates. Flow ids come from POST /api/v1/flows 201 responses (Pattern A),
+// never page.url() (#681).
+const createdFileIds: string[] = [];
+const createdFlowIds: string[] = [];
+
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {});
+    }
+  });
+}
+
+test.afterEach(async ({ request }) => {
+  const bearer = await getAuthToken(request);
+  for (const id of createdFileIds.splice(0)) {
+    await request
+      .delete(`/api/v2/files/${id}`, { headers: { Authorization: bearer } })
+      .catch(() => {});
+  }
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, { headers: { Authorization: bearer } }).catch(
+      () => {},
+    );
+  }
+});
+
+for (const { ext, asset, mime } of FILE_TYPES) {
+  test(
+    `upload a ${ext} file through the Files page`,
+    { tag: ["@stable", "@release", "@files"] },
+    async ({ page }) => {
+      trackCreatedFlows(page);
+      // Unique stem so an accidental match with a pre-existing file is
+      // impossible and parallel workers never collide.
+      const stem = generateRandomFilename();
+      const buffer = fs.readFileSync(resolveAssetPath(asset));
+
+      await awaitBootstrapTest(page, { skipModal: true });
+
+      await test.step("open the My Files page", async () => {
+        await expect(page.getByTestId("mainpage_title")).toBeVisible({
+          timeout: 30000,
+        });
+        // The "My Files" sidebar entry carries no testid — click it by text.
+        await page.getByText("My Files").first().click();
+        await expect(page.getByTestId("mainpage_title")).toContainText(
+          "Files",
+          { timeout: 30000 },
+        );
+      });
+
+      let uploaded: { id?: string; name?: string; path?: string } = {};
+      await test.step(`upload the ${ext} file via the Upload button`, async () => {
+        // Gate on the upload completing server-side: the response body is the
+        // proof the type was accepted and its extension preserved.
+        const uploadDone = page.waitForResponse(
+          (r) =>
+            r.url().includes("/api/v2/files") &&
+            r.request().method() === "POST" &&
+            r.status() < 300,
+          { timeout: 30000 },
+        );
+        const [chooser] = await Promise.all([
+          page.waitForEvent("filechooser"),
+          page.getByTestId("upload-file-btn").click(),
+        ]);
+        await chooser.setFiles({
+          name: `${stem}.${ext}`,
+          mimeType: mime,
+          buffer,
+        });
+        const resp = await uploadDone;
+        uploaded = await resp.json();
+        if (uploaded?.id) createdFileIds.push(uploaded.id);
+      });
+
+      await test.step("the stored record preserves the file type/extension", async () => {
+        // Langflow strips the extension from `name` and keeps the full
+        // filename (with extension) in `path` — the distinctive, type-specific
+        // observable.
+        expect(uploaded.name).toBe(stem);
+        expect(uploaded.path ?? "").toMatch(new RegExp(`\\.${ext}$`));
+      });
+
+      await test.step("the uploaded file appears in the Files list", async () => {
+        await expect(
+          page.getByText(`${stem}.${ext}`).first(),
+        ).toBeVisible({ timeout: 15000 });
+      });
+    },
+  );
+}

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/file-types-upload.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/file-types-upload.spec.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import type { APIRequestContext, Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { resolveAssetPath } from "../../../../helpers/filesystem/resolve-asset-path";


### PR DESCRIPTION
Closes #672

Closes the `[-] Upload files of different types (txt, pdf, json, py, wav)` gap in `QA-CHECKLIST.md` § 5.1 File Upload — the canonical `@stable` spec for that bullet.

## Surface rationale
The scout on the running nightly established that the surface is **forced to the My Files page**:
- The canvas **Read File** component enforces a `VALID_EXTENSIONS` allow-list (`TEXT_FILE_TYPES` + Docling formats) that **excludes `wav`** — so wav/binary coverage cannot live on that surface.
- `POST /api/v2/files` (My Files upload) enforces **no extension allow-list** (only size + filename-safety), so it accepts all five types.

## 1. Covered tests
One `test()` per type (`@stable @release @files`), each independently falsifiable:

| Test | Asserts (concrete observable) |
|---|---|
| `upload a txt file through the Files page` | `POST /api/v2/files` < 300; response `name===stem` & `path` ends `.txt`; row `<stem>.txt` visible |
| `upload a pdf file …` (binary) | same, `path` ends `.pdf` |
| `upload a json file …` | same, `.json` |
| `upload a py file …` | same, `.py` |
| `upload a wav file …` (binary audio) | same, `.wav` |

The stored-record check (`name` = stem, `path` ends with the extension) is the distinctive, type-specific observable — proves the type was accepted **and** its extension preserved. A random stem per run makes accidental matches impossible and isolates parallel workers.

## 2. How the test was built
- Live scout (playwright) on the running nightly confirmed `upload-file-btn`, the file-list rendering, and that a binary PDF round-trips with `name=test-file` / `path=.../test-file.pdf`.
- Bootstrap via `awaitBootstrapTest(page, { skipModal: true })` → click the "My Files" sidebar entry by text (no testid).
- Upload gated on the `POST /api/v2/files` response; the response body is the causal assertion source.
- id-scoped `afterEach` cleanup: uploaded files (`DELETE /api/v2/files/{id}`) + any bootstrap flow (Pattern A `POST /api/v1/flows` 201 capture; never `page.url()`, #681).

## 3. Dependencies
- New asset `tests/assets/files/test-file.pdf` (minimal valid PDF); existing `test_audio_file.wav` under `media/`.
- Spec doc: `docs/core-functionality/knowledge-ingestion-management/file-types-upload.md`.
- No model provider credentials required.

## Validation (nightly 1.11.0.dev38, `--workers=1 --retries=0`)
- 3 clean bursts: **5/5 passed** each (~9.5s); **0 orphan files** left in the store afterwards.
- typecheck ✅ · eslint ✅ (0 errors)
- Force-fail (executed, both reverted):
  - mutation A (causal assert `name` → `stem+"_FFMUTANT"`) ⇒ **5/5 failed**
  - mutation B (UI row text → `${stem}.${ext}_FFMUTANT`) ⇒ **5/5 failed**
- `--trace=on` skipped (known local hang; covered by `--retries=0` bursts + force-fail + live scout).