### PR TITLE
test(flow-functionality): harden & promote auto-save-off @stable (#680)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -602,7 +602,7 @@
 - [x] Rename flow via editor header → `flow-functionality/flow-rename-header.spec.ts`
 - [x] Rename flow and verify on main page listing → `core-functionality/project-management/edit-flow-name.spec.ts`
 - [-] Edit flow name and description
-- [-] Flow auto-save on changes
+- [x] Flow auto-save on changes → `flow-functionality/auto-save-off.spec.ts`
 - [x] Flow settings → `core-functionality/project-management/flowSettings.spec.ts`
 
 #### 12.3 Delete Flow

--- a/docs/flow-functionality/auto-save-off.md
+++ b/docs/flow-functionality/auto-save-off.md
@@ -1,0 +1,140 @@
+# Manual Save With Auto-Save Disabled — §12.2 View and Edit Flow
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+Validates the flow persistence contract when **auto-saving is turned off**
+(`/api/v1/config` → `auto_saving: false`): unsaved graph edits are **discarded**
+on exit unless the user explicitly saves, and an explicit **save persists** the
+edits across an exit / re-open cycle.
+
+With auto-save off, the editor must:
+
+1. **Discard on "Exit Anyway"** — after adding a component without saving,
+   leaving the flow via the back button raises an unsaved-changes dialog;
+   choosing **Exit Anyway** discards the edit (the re-opened flow has zero
+   nodes).
+2. **Persist on save** — adding a component and then saving (via the on-canvas
+   **Save** button or the exit dialog's **Save And Exit**) persists it; the
+   re-opened flow shows the saved component.
+3. **Persist a subsequent edit** — adding a second core component (Chat Output)
+   and saving again persists both; the re-opened flow shows **two** nodes
+   (Chat Input + Chat Output).
+
+If this breaks, the auto-save-off workflow is unsafe — either edits are lost
+when the user meant to save, or discarded edits silently persist.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@api` `@database` `@components`
+
+`@api` — mocks `/api/v1/config`. `@database` — asserts server-side persistence
+across a full exit/re-open. `@components` — drives a canvas component.
+
+---
+
+## Step by step *(required)*
+
+Setup: mock `/api/v1/config` to `auto_saving: false`, bootstrap the app
+(`awaitBootstrapTest`), open a blank flow. Every flow this page creates is
+captured from its `POST /api/v1/flows → 201` response and deleted id-scoped in
+`afterEach`.
+
+1. Add a **Chat Input** component to the canvas (sidebar search → hover entry →
+   `add-component-button-chat-input`)
+2. Assert the on-canvas **`save-flow-button`** is enabled (auto-save off ⇒ manual
+   save is available)
+3. Leave via the back button (`icon-ChevronLeft`); the unsaved-changes dialog
+   ("Unsaved changes will be permanently lost.") appears — click **Exit Anyway**
+4. Re-open the flow (via the flow card's open button); assert the canvas has
+   **0** nodes (`div-generic-node` count = 0) — the edit was discarded
+5. Add the Chat Input component again (hover the sidebar entry →
+   `add-component-button-chat-input`)
+6. Leave via the back button; click **Save And Exit**
+7. Re-open the flow; assert **`title-Chat Input`** is visible — the edit persisted
+8. Add a **Chat Output** component (hover the sidebar entry →
+   `add-component-button-chat-output`), click **`save-flow-button`** (the
+   on-canvas manual save), leave via the back button. The exit-guard dialog is
+   timing-dependent here — if the manual save settled, the exit is clean;
+   otherwise **Save And Exit** appears and is clicked. Either path persists.
+9. Re-open the flow; assert both `title-Chat Input` and `title-Chat Output` are
+   visible and `div-generic-node` count = **2**
+
+---
+
+## Validation criterion *(required)*
+
+- After **Exit Anyway** on an unsaved change: the re-opened flow's
+  `div-generic-node` count is **0** (discard worked).
+- After a **save**: the re-opened flow shows `title-Chat Input`.
+- After the second save: both `title-Chat Input` and `title-Chat Output` are
+  visible and `div-generic-node` count is exactly **2** (both edits persisted
+  server-side).
+
+Each observable is a hard count/visibility on the re-opened flow — a mutated
+assertion (wrong count, wrong discard) fails deterministically. The only
+conditional (the third exit's dialog) handles a genuinely timing-optional
+confirmation and is gated by the `div-generic-node` count === 2 assert, which
+fails if either save did not persist (see Notes on the hardening).
+
+---
+
+## External dependencies *(required)*
+
+- `/api/v1/config` — mocked to `auto_saving: false` (the surface under test).
+- `data-testid="save-flow-button"` — on-canvas manual save (present only when
+  auto-save is off).
+- `data-testid="icon-ChevronLeft"` — back-to-list navigation.
+- Exit dialog: **"Exit Anyway"** (discard) / **"Save And Exit"** (persist; its
+  primary button carries `data-testid="replace-button"`).
+- `data-testid="input_outputChat Input"` / `add-component-button-chat-input` /
+  `input_outputChat Output` / `add-component-button-chat-output` /
+  `sidebar-search-input` — Chat Input / Chat Output sidebar entries, add buttons,
+  search. Adds use the draggable wrapper hover → add button (the sidebar row is
+  briefly `pointer-events-none`; dragging it is unreliable).
+- `data-testid="title-Chat Input"` / `div-generic-node` — node presence on canvas.
+- `data-testid="list-card"` / `flow-name-div` / `list-card-open-button` —
+  re-open a flow from the list (the `/flows` a11y refactor made `flow-name-div`
+  `pointer-events-none`; open via the card overlay button — Langflow #13891).
+- No API key — the Chat Input / Chat Output components are added to the graph,
+  never executed.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Auto-save **on** (the default) — a separate behavior.
+- Renaming / deleting flows.
+- Save via keyboard shortcut (Ctrl/Cmd+S).
+
+---
+
+## Notes *(optional)*
+
+- **Hardening for promotion.** The pre-promotion spec left `New Flow` behind
+  (no cleanup — confirmed 4 leaked flows on the instance) and used silent
+  bypasses: a `try/catch` that logged "skipping dialog confirmation" and
+  `if (replaceButton) {…}` / `if (saveExitButton) {…}` guards that could skip a
+  save/exit step without failing. Live scouting on 1.11.0.dev41 confirmed all
+  the first two exits are deterministic (the unsaved-changes dialog always
+  appears; the save button is `replace-button` with text "Save And Exit"), so
+  those guards became explicit asserts + clicks. The **third** exit is genuinely
+  timing-optional — the on-canvas `save-flow-button` sometimes settles the save
+  before the back-navigation, yielding a clean exit with no dialog — so it keeps
+  a single conditional for the optional dialog, gated by the final
+  `div-generic-node` count === 2 (the force-fail gate that proves persistence
+  regardless of path).
+- **Flow cleanup.** ids are captured from `POST /api/v1/flows → 201`
+  (Pattern-A accumulator; `page.url()` races the bootstrap flow id — #490/#681)
+  and deleted in `afterEach`.
+- **Core I/O components (Chat Input + Chat Output)** — they render on the canvas
+  without an API key and without a run, keeping the test hermetic; neutral core
+  components avoid the model-provider connotation of the pre-promotion NVIDIA
+  node they replaced. The second edit uses Chat Output rather than a second Chat
+  Input because Langflow hides a component's quick-add button once a copy is on
+  the canvas.

--- a/tests/tests-automations/regression/flow-functionality/auto-save-off.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/auto-save-off.spec.ts
@@ -1,11 +1,63 @@
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+
+// Capture every flow THIS page creates from its POST /api/v1/flows → 201
+// responses and delete them id-scoped in afterEach. awaitBootstrapTest runs
+// first, so a bare page.url() capture races the bootstrap flow's stale id
+// (#490/#681); the response ids are authoritative and worker-safe. Without this
+// the spec leaked a "New Flow" per run.
+const createdFlowIds: string[] = [];
+
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {});
+    }
+  });
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, {
+      headers: { Authorization: bearer },
+    }).catch(() => {});
+  }
+});
+
+// The /flows a11y refactor (Langflow #13891) makes `flow-name-div`
+// `pointer-events-none`; open the flow via the card's overlay button.
+async function reopenNewFlow(page: Page): Promise<void> {
+  await page
+    .getByTestId("list-card")
+    .filter({
+      has: page.getByTestId("flow-name-div").filter({ hasText: "New Flow" }),
+    })
+    .getByTestId("list-card-open-button")
+    .first()
+    .click();
+}
 
 test(
   "user should be able to manually save a flow when the auto_save is off",
-  { tag: ["@release", "@api", "@database", "@components"] },
+  { tag: ["@stable", "@release", "@api", "@database", "@components"] },
   async ({ page }) => {
+    trackCreatedFlows(page);
+
     await page.route("**/api/v1/config", (route) => {
       route.fulfill({
         status: 200,
@@ -31,131 +83,70 @@ test(
     await page.getByTestId("blank-flow").click();
 
     await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("NVIDIA");
+    await page.getByTestId("sidebar-search-input").fill("chat input");
 
-    await page.waitForSelector('[data-testid="nvidiaNVIDIA"]', {
+    await page.waitForSelector('[data-testid="input_outputChat Input"]', {
       timeout: 3000,
     });
 
+    // The Chat Input sidebar row briefly toggles `pointer-events-none`; hover its
+    // draggable wrapper (which always takes pointer events) to reveal the add
+    // button, then click the button (chained so the hover holds) — dragging the
+    // row is unreliable while it is pointer-events-none.
     await page
-      .getByTestId("nvidiaNVIDIA")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'));
-    await page.mouse.up();
-    await page.mouse.down();
-
-    await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
-      timeout: 5000,
-    });
-
-    await adjustScreenView(page);
-
-    expect(await page.getByTestId("save-flow-button").isEnabled()).toBeTruthy();
-
-    await page.waitForSelector("text=loading", {
-      state: "hidden",
-      timeout: 5000,
-    });
-
-    await page.getByTestId("icon-ChevronLeft").last().click();
-
-    try {
-      await page.waitForSelector(
-        'text="Unsaved changes will be permanently lost."',
-        {
-          state: "visible",
-          timeout: 2000,
-        },
-      );
-
-      await page.getByText("Exit Anyway", { exact: true }).click();
-    } catch (_error) {
-      console.error("Warning text not visible, skipping dialog confirmation");
-    }
-
-    // The /flows a11y refactor (Langflow #13891) makes `flow-name-div`
-    // `pointer-events-none`; open the flow via the card's overlay button.
-    const flowOpenButton = page
-      .getByTestId("list-card")
-      .filter({
-        has: page.getByTestId("flow-name-div").filter({ hasText: "New Flow" }),
-      })
-      .getByTestId("list-card-open-button")
-      .first();
-    await flowOpenButton.click();
-
-    await page.waitForSelector('[data-testid="sidebar-search-input"]', {
-      timeout: 5000,
-    });
-
-    const nvidiaNode = await page.getByTestId("div-generic-node").count();
-    expect(nvidiaNode).toBe(0);
-
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("NVIDIA");
-
-    await page.keyboard.press("Escape");
-    await page.locator('//*[@id="react-flow-id"]').click();
-
-    const lastNvidiaModel = page.getByTestId("nvidiaNVIDIA").last();
-    await lastNvidiaModel.scrollIntoViewIfNeeded();
-
-    try {
-      await lastNvidiaModel.hover({ timeout: 5000 });
-
-      // Wait for the add component button to appear
-      await page.getByTestId("add-component-button-nvidia").waitFor({
-        state: "visible",
-        timeout: 5000,
+      .getByTestId("input_output_chat input_draggable")
+      .hover()
+      .then(async () => {
+        await page.getByTestId("add-component-button-chat-input").click();
       });
 
-      await page.getByTestId("add-component-button-nvidia").click();
-    } catch (error) {
-      console.error("Failed to hover or find add component button:", error);
-      throw error;
-    }
-
-    // Wait for fit view button
     await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
       timeout: 5000,
     });
 
     await adjustScreenView(page);
 
-    await page.getByTestId("icon-ChevronLeft").last().click();
-
-    await page.getByText("Save And Exit", { exact: true }).click();
-
-    // See note above: open the flow via the card's overlay button.
-    const flowOpenButton2 = page
-      .getByTestId("list-card")
-      .filter({
-        has: page.getByTestId("flow-name-div").filter({ hasText: "New Flow" }),
-      })
-      .getByTestId("list-card-open-button")
-      .first();
-    await flowOpenButton2.click();
+    // With auto-save off, the manual save button is present and enabled.
+    await expect(page.getByTestId("save-flow-button")).toBeEnabled({
+      timeout: 5000,
+    });
 
     await page.waitForSelector("text=loading", {
       state: "hidden",
       timeout: 5000,
     });
 
-    await expect(page.getByTestId("title-NVIDIA").first()).toBeVisible({
+    // Exit without saving: the unsaved-changes dialog is deterministic here
+    // (auto-save off + an unsaved node). Discard via "Exit Anyway".
+    await page.getByTestId("icon-ChevronLeft").last().click();
+    await expect(
+      page.getByText("Unsaved changes will be permanently lost."),
+    ).toBeVisible({ timeout: 10000 });
+    await page.getByText("Exit Anyway", { exact: true }).click();
+
+    await reopenNewFlow(page);
+
+    await page.waitForSelector('[data-testid="sidebar-search-input"]', {
       timeout: 5000,
     });
 
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("NVIDIA");
+    // The unsaved node was discarded — the canvas is empty.
+    const chatInputNode = await page.getByTestId("div-generic-node").count();
+    expect(chatInputNode).toBe(0);
 
-    await page.waitForSelector('[data-testid="nvidiaNVIDIA"]', {
+    await page.getByTestId("sidebar-search-input").click();
+    await page.getByTestId("sidebar-search-input").fill("chat input");
+
+    await page.waitForSelector('[data-testid="input_outputChat Input"]', {
       timeout: 3000,
     });
 
     await page
-      .getByTestId("nvidiaNVIDIA")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'));
-    await page.mouse.up();
-    await page.mouse.down();
+      .getByTestId("input_output_chat input_draggable")
+      .hover()
+      .then(async () => {
+        await page.getByTestId("add-component-button-chat-input").click();
+      });
 
     await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
       timeout: 5000,
@@ -163,43 +154,76 @@ test(
 
     await adjustScreenView(page);
 
+    // Exit and persist via the exit dialog's "Save And Exit".
+    await page.getByTestId("icon-ChevronLeft").last().click();
+    const saveAndExit = page.getByText("Save And Exit", { exact: true }).last();
+    await expect(saveAndExit).toBeVisible({ timeout: 10000 });
+    await saveAndExit.click();
+
+    await reopenNewFlow(page);
+
+    await page.waitForSelector("text=loading", {
+      state: "hidden",
+      timeout: 5000,
+    });
+
+    // The saved node persisted across the exit/re-open.
+    await expect(page.getByTestId("title-Chat Input").first()).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Second edit uses a DIFFERENT core component (Chat Output): Langflow hides a
+    // component's quick-add button once a copy is on the canvas, so re-adding the
+    // same Chat Input via hover is not possible — a distinct component keeps the
+    // add reliable and still proves a subsequent edit persists.
+    await page.getByTestId("sidebar-search-input").click();
+    await page.getByTestId("sidebar-search-input").fill("chat output");
+
+    await page.waitForSelector('[data-testid="input_outputChat Output"]', {
+      timeout: 3000,
+    });
+
+    await page
+      .getByTestId("input_output_chat output_draggable")
+      .hover()
+      .then(async () => {
+        await page.getByTestId("add-component-button-chat-output").click();
+      });
+
+    await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
+      timeout: 5000,
+    });
+
+    await adjustScreenView(page);
+
+    // Exercise the on-canvas manual save button, then exit. The exit guard is
+    // timing-dependent here: if the manual save settled, the exit is clean;
+    // otherwise the unsaved-changes dialog appears and "Save And Exit" persists.
+    // Either path is fine — the node count === 2 below is the gate that proves
+    // both nodes persisted server-side, regardless of which path ran.
     await page.getByTestId("save-flow-button").click();
     await page.getByTestId("icon-ChevronLeft").last().click();
-
-    const replaceButton = await page.getByTestId("replace-button").isVisible();
-
-    if (replaceButton) {
-      await page.getByTestId("replace-button").click();
+    const saveAndExit2 = page.getByText("Save And Exit", { exact: true }).last();
+    if (
+      await saveAndExit2.isVisible({ timeout: 5000 }).catch(() => false)
+    ) {
+      await saveAndExit2.click();
     }
 
-    const saveExitButton = await page
-      .getByText("Save And Exit", { exact: true })
-      .last()
-      .isVisible();
-
-    if (saveExitButton) {
-      await page.getByText("Save And Exit", { exact: true }).last().click();
-    }
-
-    // See note above: open the flow via the card's overlay button.
-    const flowOpenButton3 = page
-      .getByTestId("list-card")
-      .filter({
-        has: page.getByTestId("flow-name-div").filter({ hasText: "New Flow" }),
-      })
-      .getByTestId("list-card-open-button")
-      .first();
-    await flowOpenButton3.click();
+    await reopenNewFlow(page);
 
     await page.waitForSelector('[data-testid="sidebar-search-input"]', {
       timeout: 5000,
     });
 
-    await expect(page.getByTestId("title-NVIDIA").first()).toBeVisible({
+    // Both saved nodes (Chat Input + Chat Output) persisted server-side.
+    await expect(page.getByTestId("title-Chat Input").first()).toBeVisible({
       timeout: 5000,
     });
-
-    const nvidiaNumber = await page.getByTestId("title-NVIDIA").count();
-    expect(nvidiaNumber).toBe(2);
+    await expect(page.getByTestId("title-Chat Output").first()).toBeVisible({
+      timeout: 5000,
+    });
+    const nodeCount = await page.getByTestId("div-generic-node").count();
+    expect(nodeCount).toBe(2);
   },
 );


### PR DESCRIPTION
Closes #680

## What & why

Validate & promote §12.2 **"Flow auto-save on changes"** to `@stable` (#680) —
the manual-save-with-auto-save-off spec (`flow-functionality/auto-save-off.spec.ts`).

The spec already existed and passed, but was not fit for `@stable`:

- **Leaked a flow per run** — created a `New Flow` with no cleanup (4 leaked
  flows found on the instance).
- **Silent bypasses** — a `try/catch` that logged "skipping dialog confirmation"
  and `if (replaceButton)` / `if (saveExitButton)` guards that could skip a
  save/exit step without failing.
- **Arbitrary NVIDIA node** — a model-provider component in a test that has
  nothing to do with providers, and slow to drag.

## What changed

- **Cleanup** — id-scoped `POST /api/v1/flows → 201` accumulator + `afterEach`
  delete (Pattern A; `page.url()` races the bootstrap id — #490/#681). No more
  `New Flow` leaks.
- **Deterministic asserts** (live-scouted on 1.11.0.dev41):
  - Exit 1 (discard) — assert the "Unsaved changes will be permanently lost."
    dialog, click **Exit Anyway**; re-open → `div-generic-node` count = 0.
  - Exit 2 (save) — assert + click **Save And Exit**; re-open → `title-Chat Input`
    visible.
  - Exit 3 — the on-canvas `save-flow-button` sometimes settles the save before
    the back-navigation (clean exit, no dialog), so the exit dialog is genuinely
    timing-optional; the single remaining conditional is gated by the final
    `div-generic-node` count === 2.
- **Core I/O components** — Chat Input for the first edit, **Chat Output** for
  the second (Langflow hides a component's quick-add button once a copy is on
  the canvas, so a second Chat Input can't be added via hover). Adds use the
  draggable-wrapper hover → add button (the sidebar row is briefly
  `pointer-events-none`).
- Spec doc: `docs/flow-functionality/auto-save-off.md`.
- QA-CHECKLIST §12.2 bullet flipped to `[x]`.

## Validation

- Langflow nightly **1.11.0.dev41** (instance == latest).
- Deterministic burst `--retries=0 --workers=1`: **3/3 passed** (~52s each).
- `tsc --noEmit`: 0 errors. `eslint`: 0 errors.
- **Force-fail**: asserted `div-generic-node` count === 99 instead of 2 →
  `Expected 99 / Received 2`, failed as expected; reverted; final green.
- 0 leaked `New Flow` flows after the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
