### PR TITLE
test(flow-functionality): harden & promote user-flow-state-cleanup @stable (#691)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -444,7 +444,7 @@
 
 #### 8.3 User State
 - [x] Track user progress → `core-functionality/project-management/user-progress-track.spec.ts`
-- [-] User flow state cleanup
+- [x] User flow state cleanup → `flow-functionality/user-flow-state-cleanup.spec.ts`
 
 #### 8.4 Error Handling and Edge Cases
 - [-] Component that raises Python error

--- a/docs/flow-functionality/user-flow-state-cleanup.md
+++ b/docs/flow-functionality/user-flow-state-cleanup.md
@@ -1,0 +1,121 @@
+# User Flow-State Isolation Between Users — §8.3 User State
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+Validates that flow state is **scoped per user**: a flow created by one user is
+visible to its owner and **not** to any other user (including the superuser).
+This is the backend guarantee behind "user flow state cleanup" — one user's
+work never leaks into another user's workspace.
+
+The check is performed at the **REST API** layer (the source of truth the UI
+flow list renders from):
+
+1. The superuser creates and activates a second user (User A).
+2. User A authenticates and creates a flow.
+3. `GET /api/v1/flows/` with the **superuser** token does **not** include User
+   A's flow.
+4. `GET /api/v1/flows/` with **User A's** token **does** include it.
+
+If this breaks, per-user isolation is compromised — flows leak across accounts,
+a data-separation/privacy regression.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@api` `@database`
+
+`@api` — drives the users/login/flows REST endpoints directly. `@database` —
+asserts server-side per-user persistence and isolation.
+
+---
+
+## Step by step *(required)*
+
+All steps run through the Playwright `request` fixture (no browser UI — see
+Notes on why the prior UI login was dropped).
+
+1. Obtain the superuser token via `GET /api/v1/auto_login` (the instance runs in
+   auto-login mode) — no `POST /login`, so it does not consume the login rate
+   budget
+2. Create User A (`POST /api/v1/users/`, unique random username) → User A id
+3. Activate User A (`PATCH /api/v1/users/{id}` `{ is_active: true }`) — new users
+   are created inactive and cannot log in otherwise
+4. Log in as User A (`POST /api/v1/login`) → User A token
+5. Create a flow as User A (`POST /api/v1/flows/`, unique random name) → flow id
+6. Assert `GET /api/v1/flows/?get_all=true` with the **admin** token contains
+   **no** flow whose name matches User A's flow
+7. Assert `GET /api/v1/flows/?get_all=true` with **User A's** token contains the
+   flow
+8. Cleanup (`afterEach`): delete the flow with User A's token, delete User A with
+   the admin token
+
+---
+
+## Validation criterion *(required)*
+
+- The admin flow list (`GET /api/v1/flows/`) **excludes** User A's flow (isolation
+  holds).
+- User A's flow list **includes** it (owner sees their own flow).
+
+Both are hard assertions on the parsed API response. Mutating either (asserting
+the admin sees it, or User A does not) fails deterministically. There is no UI
+timing or mocked-auth race left in the test.
+
+---
+
+## External dependencies *(required)*
+
+- `GET /api/v1/auto_login` — superuser token (auto-login mode).
+- `POST /api/v1/login` — token for User A (bounded backoff-retry on HTTP 429,
+  Langflow's login rate limit).
+- `POST /api/v1/users/` — create User A (superuser only).
+- `PATCH /api/v1/users/{id}` — activate User A (`is_active: true`).
+- `POST /api/v1/flows/` — create User A's flow (User A token).
+- `GET /api/v1/flows/?get_all=true` — per-user flow list (isolation assertion).
+- `DELETE /api/v1/flows/{id}` (User A token) / `DELETE /api/v1/users/{id}` (admin
+  token) — cleanup.
+- Superuser credentials from `helpers/auth/credentials` (env-driven).
+- No provider API key — no flow is executed.
+
+---
+
+## What this test does not cover *(optional)*
+
+- The UI flow-list rendering itself (covered indirectly — the list is driven by
+  `GET /flows`).
+- Session/cookie cleanup on logout in the browser.
+- Sharing / explicit cross-user flow grants (not a feature under test here).
+
+---
+
+## Notes *(optional)*
+
+- **Redesigned from a flaky UI test (the reason for the API rewrite).** The
+  pre-promotion spec drove the whole scenario through the browser: it mocked
+  `/api/v1/auto_login` to `500` and toggled a `testMockAutoLogin` sessionStorage
+  flag to force the login page (the instance runs `LANGFLOW_AUTO_LOGIN=true`),
+  then logged in/out as admin and User A through the UI. That mocked-auth dance
+  is irreducibly racy — a `--retries=0` baseline burst failed **1 of 3** at the
+  admin sign-in (`mainpage_title` never appeared). The flake is a **test
+  mechanism** defect, not a product regression: the isolation itself always
+  held. Because the instance is auto-login, any manual UI login here requires
+  the fragile mock, so the browser layer was removed and the same isolation
+  contract is asserted at the API layer — deterministic and hermetic. Confirmed
+  live on 1.11.0.dev41 (admin list excludes User A's flow; User A list includes
+  it).
+- **Cleanup.** The created flow and user are deleted in `afterEach`. The flow is
+  deleted with **User A's** token — the superuser cannot see or delete another
+  user's flow (a `DELETE` via the admin token returns 404, itself a corollary of
+  the isolation under test).
+- **New users are inactive by default** — the activation `PATCH` is mandatory or
+  User A's login returns 401.
+- **Login rate limit (HTTP 429).** Langflow rate-limits `POST /api/v1/login`.
+  The admin token is taken from `GET /api/v1/auto_login` (a different endpoint)
+  to avoid it, and User A's single login rides out a transient 429 with a bounded
+  backoff-retry. This is explicit infra backpressure, not a masked product
+  failure — the isolation assertions remain hard.

--- a/tests/tests-automations/regression/flow-functionality/user-flow-state-cleanup.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/user-flow-state-cleanup.spec.ts
@@ -1,150 +1,147 @@
+import type { APIRequestContext } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
-import {
-  SUPERUSER_PASSWORD,
-  SUPERUSER_USERNAME,
-} from "../../../helpers/auth/credentials";
-import { renameFlow } from "../../../helpers/flows/rename-flow";
-import { openNewFlowTemplatesModal } from "../../../helpers/flows/open-new-flow-templates-modal";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+
+// Log in via the REST API and return a Bearer token. The login endpoint takes
+// application/x-www-form-urlencoded (same shape as helpers/auth/auth-helpers.ts).
+// Langflow rate-limits POST /api/v1/login (HTTP 429); tolerate that transient
+// backpressure with a bounded backoff-retry — this is explicit infra rate
+// limiting, not a product failure, and the isolation assertions stay hard.
+async function loginApi(
+  request: APIRequestContext,
+  username: string,
+  password: string,
+): Promise<string> {
+  const form = new URLSearchParams();
+  form.append("username", username);
+  form.append("password", password);
+
+  const MAX_ATTEMPTS = 5;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const res = await request.post("/api/v1/login", {
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      data: form.toString(),
+    });
+    if (res.status() === 200) {
+      return `Bearer ${(await res.json()).access_token}`;
+    }
+    if (res.status() === 429 && attempt < MAX_ATTEMPTS) {
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+      continue;
+    }
+    expect(res.status(), "login should succeed").toBe(200);
+  }
+  throw new Error("login did not succeed within retry budget");
+}
+
+async function flowNames(
+  request: APIRequestContext,
+  bearer: string,
+): Promise<string[]> {
+  const res = await request.get("/api/v1/flows/?get_all=true&header_flows=true", {
+    headers: { Authorization: bearer },
+  });
+  expect(res.status(), "flow list should return 200").toBe(200);
+  const flows: Array<{ name?: string }> = await res.json();
+  return flows.map((f) => f.name ?? "");
+}
 
 test(
   "flow state should be properly cleaned up between user sessions",
-  { tag: ["@release", "@api", "@database"] },
-  async ({ page }) => {
-    // Disable auto login
-    await page.route("**/api/v1/auto_login", (route) => {
-      route.fulfill({
-        status: 500,
-        contentType: "application/json",
-        body: JSON.stringify({
-          detail: { auto_login: false },
-        }),
+  { tag: ["@stable", "@release", "@api", "@database"] },
+  async ({ request }) => {
+    const suffix = Math.random().toString(36).substring(2);
+    const userAName = `user_a_${suffix}`;
+    const userAPassword = `pass_a_${suffix}`;
+    const userAFlowName = `flow_a_${suffix}`;
+
+    let adminToken = "";
+    let userAId = "";
+    let userAToken = "";
+    let userAFlowId = "";
+
+    try {
+      await test.step("superuser creates and activates User A", async () => {
+        // Admin token via /api/v1/auto_login (the instance is auto-login mode,
+        // so this returns the superuser token) — avoids a second POST /login and
+        // its rate limit.
+        adminToken = await getAuthToken(request);
+        expect(adminToken, "admin token must be present").not.toBe("");
+
+        const createRes = await request.post("/api/v1/users/", {
+          headers: {
+            Authorization: adminToken,
+            "Content-Type": "application/json",
+          },
+          data: { username: userAName, password: userAPassword },
+        });
+        expect(createRes.status(), "user creation should return 201").toBe(201);
+        userAId = (await createRes.json()).id;
+
+        // New users are created inactive and cannot log in until activated.
+        const activateRes = await request.patch(`/api/v1/users/${userAId}`, {
+          headers: {
+            Authorization: adminToken,
+            "Content-Type": "application/json",
+          },
+          data: { is_active: true },
+        });
+        expect(activateRes.status(), "user activation should return 200").toBe(
+          200,
+        );
       });
-    });
 
-    await page.addInitScript(() => {
-      window.process = window.process || {};
-      const newEnv = {
-        ...window.process.env,
-        LANGFLOW_AUTO_LOGIN: "false",
-        LANGFLOW_NEW_USER_IS_ACTIVE: "true",
-      };
-      Object.defineProperty(window.process, "env", {
-        value: newEnv,
-        writable: true,
-        configurable: true,
+      await test.step("User A logs in and creates a flow", async () => {
+        userAToken = await loginApi(request, userAName, userAPassword);
+
+        const flowRes = await request.post("/api/v1/flows/", {
+          headers: {
+            Authorization: userAToken,
+            "Content-Type": "application/json",
+          },
+          data: {
+            name: userAFlowName,
+            description: "",
+            data: { nodes: [], edges: [] },
+          },
+        });
+        expect(flowRes.status(), "flow creation should return 201").toBe(201);
+        userAFlowId = (await flowRes.json()).id;
       });
-      sessionStorage.setItem("testMockAutoLogin", "true");
-    });
 
-    // Create random usernames, passwords and flow names for the test
-    const userAName = "user_a_" + Math.random().toString(36).substring(5);
-    const userAPassword = "pass_a_" + Math.random().toString(36).substring(5);
-    const userAFlowName = "flow_a_" + Math.random().toString(36).substring(5);
+      await test.step("the superuser cannot see User A's flow", async () => {
+        const adminFlows = await flowNames(request, adminToken);
+        expect(
+          adminFlows,
+          "superuser flow list must NOT contain User A's flow",
+        ).not.toContain(userAFlowName);
+      });
 
-    // Log in as admin and create test user
-    await page.goto("/");
-    await page.waitForSelector("text=sign in to langflow", { timeout: 30000 });
-    await page.getByPlaceholder("Username").fill(SUPERUSER_USERNAME);
-    await page.getByPlaceholder("Password").fill(SUPERUSER_PASSWORD);
-    await page.evaluate(() => {
-      sessionStorage.removeItem("testMockAutoLogin");
-    });
-    await page.getByRole("button", { name: "Sign In" }).click();
-
-    // Create User A
-    await page.waitForSelector('[data-testid="mainpage_title"]', {
-      timeout: 30000,
-    });
-    await page.getByTestId("user-profile-settings").click();
-    await page.getByText("Admin Page", { exact: true }).click();
-    await page.getByText("New User", { exact: true }).click();
-    await page.getByPlaceholder("Username").last().fill(userAName);
-    await page.locator('input[name="password"]').fill(userAPassword);
-    await page.locator('input[name="confirmpassword"]').fill(userAPassword);
-    await page.waitForSelector("#is_active", { timeout: 1500 });
-    await page.locator("#is_active").click();
-    await expect(page.locator("#is_active")).toBeChecked();
-    await page.getByText("Save", { exact: true }).click();
-    await page.waitForSelector("text=new user added", { timeout: 30000 });
-
-    // Log out from admin
-    await page.getByTestId("icon-ChevronLeft").first().click();
-    await page.waitForSelector("[data-testid='user-profile-settings']", {
-      timeout: 1500,
-    });
-    await page.getByTestId("user-profile-settings").click();
-    await page.evaluate(() => {
-      sessionStorage.setItem("testMockAutoLogin", "true");
-    });
-    await page.getByText("Logout", { exact: true }).click();
-
-    // ---- USER A SESSION ----
-
-    // Log in as User A
-    await page.waitForSelector("text=sign in to langflow", { timeout: 30000 });
-    await page.getByPlaceholder("Username").fill(userAName);
-    await page.getByPlaceholder("Password").fill(userAPassword);
-    await page.evaluate(() => {
-      sessionStorage.removeItem("testMockAutoLogin");
-    });
-    await page.getByRole("button", { name: "Sign In" }).click();
-
-    // Create a flow for User A
-    await page.waitForSelector('[id="new-project-btn"]', { timeout: 30000 });
-    // Check that User A starts with an empty flows list
-    await expect(page.getByText("Welcome to LangFlow")).toBeVisible({
-      timeout: 30000,
-    });
-
-    await page.waitForSelector('[data-testid="mainpage_title"]', {
-      timeout: 30000,
-    });
-
-    await openNewFlowTemplatesModal(page);
-    await page.getByRole("heading", { name: "Basic Prompting" }).click();
-    await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
-      timeout: 30000,
-    });
-
-    await renameFlow(page, { flowName: userAFlowName });
-
-    await page.getByTestId("icon-ChevronLeft").first().click();
-
-    // Verify User A can see their flow
-    await page.waitForSelector('[data-testid="search-store-input"]:enabled', {
-      timeout: 30000,
-    });
-    await expect(page.getByText(userAFlowName, { exact: true })).toBeVisible({
-      timeout: 2000,
-    });
-
-    // Log out User A
-    await page.getByTestId("user-profile-settings").click();
-    await page.evaluate(() => {
-      sessionStorage.setItem("testMockAutoLogin", "true");
-    });
-    await page.getByText("Logout", { exact: true }).click();
-
-    // ---- ADMIN SESSION AGAIN ----
-
-    // Log in as admin again
-    await page.waitForSelector("text=sign in to langflow", { timeout: 30000 });
-    await page.getByPlaceholder("Username").fill(SUPERUSER_USERNAME);
-    await page.getByPlaceholder("Password").fill(SUPERUSER_PASSWORD);
-    await page.evaluate(() => {
-      sessionStorage.removeItem("testMockAutoLogin");
-    });
-    await page.getByRole("button", { name: "Sign In" }).click();
-
-    // Verify admin can't see User A's flow
-    await expect(page.getByText(userAFlowName, { exact: true })).toBeVisible({
-      timeout: 2000,
-      visible: false,
-    });
-
-    // Cleanup
-    await page.evaluate(() => {
-      sessionStorage.removeItem("testMockAutoLogin");
-    });
+      await test.step("User A can see their own flow", async () => {
+        const userAFlows = await flowNames(request, userAToken);
+        expect(
+          userAFlows,
+          "User A flow list must contain their own flow",
+        ).toContain(userAFlowName);
+      });
+    } finally {
+      // Cleanup: the flow is deleted with User A's token (the superuser cannot
+      // see or delete another user's flow — a corollary of the isolation under
+      // test), then User A is removed with the admin token.
+      if (userAFlowId && userAToken) {
+        await request
+          .delete(`/api/v1/flows/${userAFlowId}`, {
+            headers: { Authorization: userAToken },
+          })
+          .catch(() => {});
+      }
+      if (userAId && adminToken) {
+        await request
+          .delete(`/api/v1/users/${userAId}`, {
+            headers: { Authorization: adminToken },
+          })
+          .catch(() => {});
+      }
+    }
   },
 );


### PR DESCRIPTION
Closes #691

## What & why

Validate & promote §8.3 **"User flow state cleanup"** to `@stable` (#691) — the
per-user flow-state isolation check
(`flow-functionality/user-flow-state-cleanup.spec.ts`).

The existing UI spec was **flaky (2/3 baseline)**: it forced a manual login by
mocking `/api/v1/auto_login → 500` and toggling a `testMockAutoLogin`
sessionStorage flag (the instance runs `LANGFLOW_AUTO_LOGIN=true`), then logged
in/out as admin and User A through the browser. A `--retries=0` burst failed 1
of 3 at the admin sign-in (`mainpage_title` never appeared). The flake is a test
mechanism defect — the isolation itself always held.

## What changed

- **UI → REST-API rewrite.** Assert the same contract deterministically: a flow
  created by User A is **absent** from the superuser's `GET /flows` list and
  **present** in User A's. No browser, no mocked-auth race.
- **Login rate limit (429).** `POST /api/v1/login` is rate-limited; a burst trips
  it. The admin token now comes from `GET /api/v1/auto_login` (a different
  endpoint), and User A's single login rides out a transient 429 with a bounded
  backoff-retry. Explicit infra backpressure — the isolation asserts stay hard.
- **Cleanup** — `afterEach` deletes the flow with User A's token (the superuser
  cannot delete another user's flow — 404, a corollary of the isolation) and
  User A with the admin token. New users are created inactive, so an activation
  `PATCH` is required before login.
- Spec doc: `docs/flow-functionality/user-flow-state-cleanup.md`.
- QA-CHECKLIST §8.3 bullet flipped to `[x]`.

## Validation

- Langflow nightly **1.11.0.dev41** (instance == latest).
- Deterministic burst `--retries=0 --workers=1`: **3/3 passed** (~1.7s each,
  pure API) + extra fresh runs; **0 leaked users/flows** after cleanup.
- `tsc --noEmit`: 0 errors. `eslint`: 0 errors.
- **Force-fail**: inverted the isolation assert (`.not.toContain` →
  `.toContain`) → failed as expected (admin does not see User A's flow);
  reverted; final green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
