### PR TITLE
test(knowledge-ingestion): harden & promote file-size-limit @stable (#670)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -298,7 +298,7 @@
 #### 5.1 File Upload
 - [x] Upload file via component → `core-functionality/knowledge-ingestion-management/upload-via-component.spec.ts`
 - [-] Upload files of different types (txt, pdf, json, py, wav)
-- [-] File size limit
+- [x] File size limit → `core-functionality/knowledge-ingestion-management/limit-file-size-upload.spec.ts`
 - [-] File management page
 
 #### 5.2 Processing and Vectorization

--- a/docs/core-functionality/knowledge-ingestion-management/limit-file-size-upload.md
+++ b/docs/core-functionality/knowledge-ingestion-management/limit-file-size-upload.md
@@ -1,0 +1,100 @@
+# File Size Limit on Playground Upload — §5.1 File Upload
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+Validates that the playground **rejects a file larger than the configured upload
+limit** and tells the user the exact ceiling. The limit is driven by
+`max_file_size_upload` from `GET /api/v1/config`; the check is enforced
+**client-side** before any send, so an oversized file never reaches the backend.
+
+The test mocks the config to a tiny limit (`0.001` MB ≈ 1.02 KB) and attempts to
+upload a ~32 KB image — the UI must surface the size error with the computed
+ceiling.
+
+If this breaks, users can attach files that exceed the server limit — the upload
+fails later (or silently), instead of being caught with a clear message up front.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@api` `@files`
+
+`@api` — mocks `/api/v1/config`. `@files` — file upload surface.
+
+---
+
+## Step by step *(required)*
+
+1. Mock `GET /api/v1/config` → `{ max_file_size_upload: 0.001 }` (≈ 1.02 KB)
+2. Bootstrap the app (`awaitBootstrapTest`), open a **blank flow**, add a **Chat
+   Input** component (the playground's file-upload affordance comes from Chat
+   Input)
+3. Open the playground (`playground-btn-flow-io`); wait for
+   `input-chat-playground`
+4. Set an oversized file (`tests/assets/media/chain.png`, ~32 KB) on the
+   playground's `input[type="file"]`
+5. Assert the error **"The file size is too large. Please select a file smaller
+   than 1.02 KB."** is visible (ceiling = `max_file_size_upload * 1024`, 2 dp)
+
+Every flow this page creates is captured from its `POST /api/v1/flows → 201`
+response and deleted id-scoped in `afterEach`.
+
+---
+
+## Validation criterion *(required)*
+
+- After setting an oversized file, the exact text **"The file size is too large.
+  Please select a file smaller than 1.02 KB."** renders — the ceiling is computed
+  from the mocked `max_file_size_upload`, so the assertion is tied to the config
+  value, not a hardcoded string.
+
+A mutated assertion (wrong ceiling, or expecting success) fails deterministically.
+
+---
+
+## External dependencies *(required)*
+
+- `GET /api/v1/config` — mocked with a tiny `max_file_size_upload` (the surface
+  under test).
+- `data-testid="input_outputChat Input"` / `input_output_chat input_draggable` /
+  `add-component-button-chat-input` / `sidebar-search-input` — add Chat Input.
+- `data-testid="playground-btn-flow-io"` / `input-chat-playground` — open
+  playground.
+- `input[type="file"]` — the playground upload input.
+- `tests/assets/media/chain.png` (~32 KB) — the oversized fixture.
+- **No API key / no LLM** — the file is rejected client-side before any run, so
+  no provider is exercised (the prior spec's OpenAI setup + `test.skip` on
+  `OPENAI_API_KEY` were removed — see Notes).
+
+---
+
+## What this test does not cover *(optional)*
+
+- Server-side enforcement of the size limit (this asserts the client-side guard).
+- The Read File / Write File component upload path (covered by
+  `upload-via-component.spec.ts`).
+- Files at or just under the limit (only the over-limit rejection is asserted).
+
+---
+
+## Notes *(optional)*
+
+- **Removed the OpenAI dependency (hardening for promotion).** The pre-promotion
+  spec loaded the **Basic Prompting** template + `initialGPTsetup` (OpenAI model
+  pinning) and guarded with `test.skip(!OPENAI_API_KEY)`. The file-size check is
+  purely client-side (config-driven) and never runs the flow, so the model setup
+  was unnecessary coupling — and the skip meant the `@stable` daily run would
+  **silently skip** (blinding §5.1 coverage) whenever the OpenAI secret was
+  absent. Redesigned to a blank flow + Chat Input: hermetic, no key, never skips.
+  Confirmed live on 1.11.0.dev41 (message "smaller than 1.02 KB").
+- **Flow cleanup.** ids captured from `POST /api/v1/flows → 201` (Pattern-A
+  accumulator; `page.url()` races the bootstrap flow id — #490/#681) and deleted
+  in `afterEach`. The prior spec left a Basic Prompting flow behind.
+- **No inspect-panel toggling.** The prior spec disabled/enabled the inspect
+  panel around advanced-options clicks that are irrelevant to the size check;
+  the redesign drops them.

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/limit-file-size-upload.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/limit-file-size-upload.spec.ts
@@ -1,20 +1,48 @@
-import * as dotenv from "dotenv";
-import path from "path";
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { resolveAssetPath } from "../../../../helpers/filesystem/resolve-asset-path";
-import { initialGPTsetup } from "../../../../helpers/other/initialGPTsetup";
-import {
-  closeAdvancedOptions,
-  disableInspectPanel,
-  enableInspectPanel,
-  openAdvancedOptions,
-} from "../../../../helpers/ui/open-advanced-options";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+
+// Capture every flow THIS page creates from its POST /api/v1/flows → 201
+// responses and delete them id-scoped in afterEach. awaitBootstrapTest runs
+// first, so a bare page.url() capture races the bootstrap flow's stale id
+// (#490/#681); the response ids are authoritative and worker-safe.
+const createdFlowIds: string[] = [];
+
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {});
+    }
+  });
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, {
+      headers: { Authorization: bearer },
+    }).catch(() => {});
+  }
+});
 
 test(
   "user should not be able to upload a file larger than the limit",
-  { tag: ["@release", "@api", "@database", "@files"] },
+  { tag: ["@stable", "@release", "@api", "@files"] },
   async ({ page }) => {
+    // A tiny upload ceiling (0.001 MB ≈ 1.02 KB) so any real asset is rejected.
     const maxFileSizeUpload = 0.001;
     await page.route("**/api/v1/config", (route) => {
       route.fulfill({
@@ -29,53 +57,56 @@ test(
         },
       });
     });
-    test.skip(
-      !process?.env?.OPENAI_API_KEY,
-      "OPENAI_API_KEY required to run this test",
-    );
 
-    if (!process.env.CI) {
-      dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
-    }
-
+    trackCreatedFlows(page);
     await awaitBootstrapTest(page);
 
-    await page.getByTestId("side_nav_options_all-templates").click();
-    await page.getByRole("heading", { name: "Basic Prompting" }).click();
-    await initialGPTsetup(page);
+    await test.step("open a blank flow and add a Chat Input", async () => {
+      await expect(page.getByTestId("blank-flow")).toBeVisible({
+        timeout: 30000,
+      });
+      await page.getByTestId("blank-flow").click();
 
-    await page.waitForSelector("text=Chat Input", { timeout: 30000 });
+      await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
+        timeout: 30000,
+      });
+      await page.getByTestId("sidebar-search-input").fill("chat input");
+      await expect(
+        page.getByTestId("input_outputChat Input"),
+      ).toBeVisible({ timeout: 30000 });
 
-    await disableInspectPanel(page);
-    await page.getByText("Chat Input", { exact: true }).click();
-    await openAdvancedOptions(page);
-    await closeAdvancedOptions(page);
-
-    await page.getByRole("button", { name: "Playground", exact: true }).click();
-
-    await page.waitForSelector('[data-testid="input-chat-playground"]', {
-      timeout: 100000,
+      // The Chat Input row briefly toggles pointer-events-none; hover its
+      // draggable wrapper (which always takes pointer events) and add via the
+      // button (chained so the hover holds).
+      await page
+        .getByTestId("input_output_chat input_draggable")
+        .hover()
+        .then(async () => {
+          await page.getByTestId("add-component-button-chat-input").click();
+        });
     });
 
-    // Use Playwright's native setInputFiles() for reliable file upload
-    const filePath = resolveAssetPath("chain.png");
-    const fileInput = page.locator('input[type="file"]');
-    await fileInput.setInputFiles(filePath);
-
-    await page.waitForSelector("text=The file size is too large", {
-      timeout: 10000,
+    await test.step("open the playground", async () => {
+      await page.getByTestId("playground-btn-flow-io").click();
+      await expect(page.getByTestId("input-chat-playground")).toBeVisible({
+        timeout: 30000,
+      });
     });
 
-    await expect(
-      page.getByText(
-        `The file size is too large. Please select a file smaller than ${(
-          maxFileSizeUpload * 1024
-        ).toFixed(2)} KB`,
-      ),
-    ).toBeVisible();
+    await test.step("an oversized file is rejected with the computed ceiling", async () => {
+      // The file-size guard is client-side (driven by the mocked config), so no
+      // flow run — and no provider — is needed. chain.png (~32 KB) is well over
+      // the 1.02 KB ceiling.
+      await page
+        .locator('input[type="file"]')
+        .setInputFiles(resolveAssetPath("chain.png"));
 
-    await page.getByTestId("playground-close-button").click();
-
-    await enableInspectPanel(page);
+      const ceilingKb = (maxFileSizeUpload * 1024).toFixed(2);
+      await expect(
+        page.getByText(
+          `The file size is too large. Please select a file smaller than ${ceilingKb} KB`,
+        ),
+      ).toBeVisible({ timeout: 10000 });
+    });
   },
 );


### PR DESCRIPTION
Closes #670

## What & why

Validate & promote §5.1 **"File size limit"** to `@stable` (#670) — the
oversized-upload rejection spec
(`knowledge-ingestion-management/limit-file-size-upload.spec.ts`).

The upload size guard is **client-side**: the UI reads `max_file_size_upload`
from `GET /api/v1/config` and rejects an over-limit file before any send. The
pre-promotion spec loaded the **Basic Prompting** template + `initialGPTsetup`
(OpenAI model pinning) and guarded with `test.skip(!OPENAI_API_KEY)` — none of
which the client-side check needs, and the skip would make the `@stable` daily
run **silently skip** (blinding §5.1) whenever the OpenAI secret was absent.

## What changed

- **Removed the OpenAI dependency.** Basic Prompting + `initialGPTsetup` +
  `test.skip(!OPENAI_API_KEY)` → a hermetic **blank flow + Chat Input** (the
  playground's file-upload affordance comes from Chat Input). No key, never
  skips. Scouted live on 1.11.0.dev41: the identical error fires.
- **Cleanup** — id-scoped `POST /api/v1/flows → 201` accumulator + `afterEach`
  delete (Pattern A; `page.url()` races the bootstrap id — #490/#681). The prior
  spec left a Basic Prompting flow behind.
- Dropped the inspect-panel toggling (irrelevant to the size check) and the
  `@database` tag (nothing is persisted).
- Spec doc: `docs/core-functionality/knowledge-ingestion-management/limit-file-size-upload.md`.
- QA-CHECKLIST §5.1 bullet flipped to `[x]`.

## Validation

- Langflow nightly **1.11.0.dev41** (instance == latest).
- Deterministic burst `--retries=0 --workers=1`: **3/3 passed**
  (`expected=1 unexpected=0 flaky=0`); 0 leaked flows.
- `tsc --noEmit`: 0 errors. `eslint`: 0 errors.
- **Force-fail**: asserted a bogus ceiling (`9999.00 KB`) instead of the
  computed `1.02 KB` → failed as expected; reverted; final green.

## Note

The size limit is a **global** upload guard, exercised here via the playground
chat attachment (the surface the original spec used). A follow-up could assert
the same guard on the knowledge-ingestion File component / Files page — the more
representative §5.1 surface — since both share `max_file_size_upload`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
