### PR TITLE
fix(history): record error_signature on flaky entries

### DIFF
--- a/reports/README.md
+++ b/reports/README.md
@@ -58,7 +58,8 @@ The series is **not continuous**. Document any missing weeks here rather than ba
       "file": "...",
       "line": 78,
       "tags": [...],
-      "attempts": 2                          // result entries; >1 means at least one retry happened
+      "attempts": 2,                         // result entries; >1 means at least one retry happened
+      "error_signature": "..."               // first line of the FIRST failed attempt (before the passing retry)
     }
   ]
 }
@@ -67,8 +68,8 @@ The series is **not continuous**. Document any missing weeks here rather than ba
 ### Field semantics
 
 - `tags` reflects the **state at the moment of the run**, not the current state in the repo. A test that was `@stable` at run time and has since had `@stable` removed will still show `@stable` in its historical entries.
-- `error_signature` is the first non-empty line of the last failed result's error message, truncated to 240 chars. Stack frames and locator details are stripped — enough to cluster recurring failures, not enough to debug from history alone.
-- `failures` are tests where Playwright's final `test.status === "unexpected"`. `flaky` are tests where final status is `"flaky"` (failed and then passed on retry).
+- `error_signature` is the first non-empty line of a failed result's error message, truncated to 240 chars. Stack frames and locator details are stripped — enough to cluster recurring failures, not enough to debug from history alone. For `failures[]` it is taken from the **last** failed result (the one that made the test fail for good); for `flaky[]` it is taken from the **first** failed attempt (the one that triggered the retry that later passed). Falls back to `"unknown"` when no message is available.
+- `failures` are tests where Playwright's final `test.status === "unexpected"`. `flaky` are tests where final status is `"flaky"` (failed and then passed on retry). Both carry `error_signature`, so the 30-day same-signature flake-recurrence criterion in `CONTRIBUTING.md` applies mechanically to either array.
 
 ---
 

--- a/scripts/append-weekly-history.mjs
+++ b/scripts/append-weekly-history.mjs
@@ -49,7 +49,10 @@ function firstErrorMessage(result) {
   const err = result?.error || result?.errors?.[0];
   if (!err) return null;
   const raw = err.message || err.value || "";
-  return raw.split("\n")[0].slice(0, 240);
+  // First *non-empty* line (some messages lead with a blank line), trimmed and
+  // capped so equal causes cluster to an equal signature.
+  const line = raw.split("\n").map((l) => l.trim()).find((l) => l.length > 0);
+  return line ? line.slice(0, 240) : null;
 }
 
 function specRelFile(spec) {
@@ -86,15 +89,19 @@ function visit(node) {
         // Surface that first failed attempt's message through the same
         // normaliser used for hard failures, so the flake-recurrence criterion
         // in CONTRIBUTING.md (same signature within 30 days) can be applied
-        // mechanically to `.flaky[]` rows too.
-        const firstFailed = (test.results || []).find((r) => r.status !== "passed");
+        // mechanically to `.flaky[]` rows too. Pick the first result that
+        // actually carries a message — skipping any interrupted/no-message
+        // attempt that may precede the real failure.
+        const firstFailedSignature = (test.results || [])
+          .map((r) => firstErrorMessage(r))
+          .find((m) => m);
         flaky.push({
           test: title,
           file,
           line,
           tags,
           attempts,
-          error_signature: firstErrorMessage(firstFailed) || "unknown",
+          error_signature: firstFailedSignature || "unknown",
         });
         continue;
       }

--- a/scripts/append-weekly-history.mjs
+++ b/scripts/append-weekly-history.mjs
@@ -22,7 +22,7 @@
 //   "duration_ms": 0,
 //   "totals": { "passed": 0, "failed": 0, "flaky": 0, "skipped": 0 },
 //   "failures": [ { test, file, line, tags, attempts, error_signature } ],
-//   "flaky":    [ { test, file, line, tags, attempts } ]
+//   "flaky":    [ { test, file, line, tags, attempts, error_signature } ]
 // }
 
 import { readFileSync, appendFileSync, mkdirSync, existsSync } from "node:fs";
@@ -82,7 +82,20 @@ function visit(node) {
       }
       if (status === "flaky") {
         totals.flaky++;
-        flaky.push({ test: title, file, line, tags, attempts });
+        // A flaky test failed on an earlier attempt and passed on a retry.
+        // Surface that first failed attempt's message through the same
+        // normaliser used for hard failures, so the flake-recurrence criterion
+        // in CONTRIBUTING.md (same signature within 30 days) can be applied
+        // mechanically to `.flaky[]` rows too.
+        const firstFailed = (test.results || []).find((r) => r.status !== "passed");
+        flaky.push({
+          test: title,
+          file,
+          line,
+          tags,
+          attempts,
+          error_signature: firstErrorMessage(firstFailed) || "unknown",
+        });
         continue;
       }
       // unexpected (or anything else) → failure


### PR DESCRIPTION
## What

The history appender (`scripts/append-weekly-history.mjs`) recorded `error_signature` only for **hard failures** (`.failures[]`), leaving **flaky** rows (`.flaky[]`) without it. This blocked the flake-recurrence criterion in `CONTRIBUTING.md`, which keys on **same signature within a 30-day window**: without a signature on flaky rows, recurrence could only be judged by test identity — unable to distinguish one sustained cause from two unrelated blips on the same test (the exact caveat that #704 triage had to carry).

## Changes

- **`scripts/append-weekly-history.mjs`** — flaky entries now record `error_signature`, taken from the **first failed attempt** (the one that triggered the retry that later passed), reusing the same `firstErrorMessage` normaliser used for hard failures. Falls back to `"unknown"` when no message is available. Additive field → **no schema `version` bump**, per `reports/README.md`.
- **`reports/README.md`** — documents the field on `flaky[]` rows; clarifies that `failures[]` uses the **last** failed result while `flaky[]` uses the **first**, and that both arrays now carry `error_signature` so the 30-day criterion applies mechanically to either.
- **`CONTRIBUTING.md`** — no change needed: the triage query already used `(.failures + .flaky)[]` with a `// "flaky"` fallback. The fallback still covers old (pre-fix) rows; new rows now carry the real signature.

## Verification

- Ran the appender against a synthetic report: flaky row got the first-attempt signature (`TimeoutError: ... Timeout 5000ms exceeded`), hard failure kept its last-result signature.
- The 30-day same-signature recurrence query now groups flakes by signature in `.flaky[]` (count ≥ 2 → recurrent).
- ESLint passes.

## Acceptance (from #728)

- [x] New flaky rows include `error_signature`.
- [x] The 30-day same-signature recurrence query works against `.flaky[]` as well as `.failures[]`.
- [x] `reports/README.md` notes the field is now present on flaky rows.

Closes #728