### PR TITLE
test(flow-functionality): harden & promote import-invalid-JSON error to @stable (#683)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -617,7 +617,7 @@
 - [x] Exported JSON contains valid data.nodes structure → `flow-functionality/export-import-flow.spec.ts`
 - [x] Import flow via JSON file upload (drag-drop + upload button) → `flow-functionality/export-import-flow.spec.ts`
 - [~] Import flow with outdated components
-- [-] Import invalid JSON — should display error message
+- [x] Import invalid JSON — should display error message → `flow-functionality/import-invalid-json.spec.ts`
 
 #### 12.5 Flow Operations
 - [-] Lock flow — prevents editing
@@ -762,12 +762,12 @@
 | `core-functionality/playground/` | 48 | 46 | 0 | 1 | 1 |
 | `core-functionality/project-management/` | 11 | 4 | 6 | 1 | 0 |
 | `core-functionality/templates/` | 41 | 2 | 39 | 0 | 0 |
-| `flow-functionality/` | 28 | 21 | 5 | 2 | 0 |
+| `flow-functionality/` | 28 | 22 | 4 | 2 | 0 |
 | `mcp/client/` | 11 | 2 | 7 | 0 | 2 |
 | `mcp/server/` | 7 | 0 | 3 | 0 | 4 |
 | `ui-ux/` — Canvas | 44 | 7 | 36 | 1 | 0 |
 | `ui-ux/` — Settings | 7 | 3 | 3 | 1 | 0 |
-| **TOTAL** | **451** | **286 (63%)** | **137 (30%)** | **8 (2%)** | **20 (4%)** |
+| **TOTAL** | **451** | **287 (64%)** | **136 (30%)** | **8 (2%)** | **20 (4%)** |
 
 > Note: `Validated [x]` counts checklist bullets, not `test()` calls. The
 > `@stable` tag is per-`test()`, and a single `@stable` test may map to
@@ -783,7 +783,7 @@
 
 ### 🟢 Phase 0 — Validated
 
-> 315 `test()` calls carrying the `@stable` tag, distributed across 126 spec
+> 318 `test()` calls carrying the `@stable` tag, distributed across 127 spec
 > files. Run weekly by the stable workflow. New specs are merged with all
 > tests tagged `@stable`; the tag is removed per-test during weekly triage
 > when a failure is classified as a test bug — so a spec may end up with a
@@ -1101,6 +1101,9 @@
 - [x] 3 - the chat input and chat output are visible in the Playground → `flow-execution-canvas.spec.ts`
 - [x] flow can be renamed via the header edit → `flow-rename-header.spec.ts`
 - [x] flow name persists after rename via API PATCH and GET → `flow-rename-header.spec.ts`
+- [x] import invalid JSON must show error message → `import-invalid-json.spec.ts`
+- [x] import non-JSON file must show error message → `import-invalid-json.spec.ts`
+- [x] import JSON with missing data field must show error → `import-invalid-json.spec.ts`
 - [x] user can publish a flow and access it via shareable URL, then unpublish to revoke access → `publish-flow.spec.ts`
 - [x] publish flow via API toggles access_type between PUBLIC and PRIVATE → `publish-flow.spec.ts`
 - [x] user can copy a valid Python requests snippet from the API access modal → `pythonApiGeneration.spec.ts`
@@ -1157,7 +1160,7 @@
 |--------|-----------------|---------------|
 | `core-functionality/observability-monitoring/` | 4 | 0 |
 | `core-functionality/knowledge-ingestion/` | 1 | 4 |
-| `flow-functionality/` | 5 | 0 |
+| `flow-functionality/` | 4 | 0 |
 | `core-functionality/project-management/` | 6 | 0 |
 | `core-functionality/templates/` | 39 | 0 |
 | `ui-ux/` — Settings | 3 | 0 |

--- a/docs/flow-functionality/import-invalid-json.md
+++ b/docs/flow-functionality/import-invalid-json.md
@@ -1,0 +1,141 @@
+# Import Invalid Flow File — Error Notification (§12.4 Export / Import Flow)
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+Validates that when a user drops an **unimportable file** onto the flows page
+(the `cards-wrapper` drop zone), Langflow rejects it and surfaces an explicit,
+user-visible error — it never silently creates a broken flow or swallows the
+failure. Three rejection modes, each proven by the **persistent** notification
+entry (not the auto-dismissing toast):
+
+1. **Malformed JSON syntax (`@stable`, §12.4 "Import invalid JSON — should
+   display error message")** — dropping `{ this is not valid json !!!`. The
+   notification reads **"Error occurred while uploading file"** with the JSON
+   parser detail **"Expected property name or '}' in JSON at position 2 (line 1
+   column 3)"** — the distinctive signal that the file failed to parse as JSON.
+2. **Non-JSON file type** — dropping a `.txt` file. The notification reads
+   **"Error occurred while uploading file"** with detail **"Invalid file type"**.
+3. **Valid JSON, invalid flow shape** — dropping well-formed JSON that lacks the
+   required `data` field. The notification reads **"Error occurred while
+   uploading file"** with detail **"Invalid flow data"** — parseable JSON, but
+   not a valid flow.
+
+If this breaks, an unimportable file would fail silently — the user gets no
+feedback and cannot tell a rejected import from a successful one, or Langflow
+would persist a malformed flow.
+
+---
+
+## Tags *(required)*
+
+All three tests: `@stable` `@release` `@workspace` `@regression`
+
+The `@stable` promotion (this issue, #683) covers the §12.4 bullet. The two
+sibling negative cases (non-JSON, invalid flow shape) share the same file and
+the same import-rejection surface; all three now assert a distinctive persistent
+observable, so all three are promoted together.
+
+---
+
+## Step by step *(required)*
+
+Shared setup: bootstrap the app (`awaitBootstrapTest(page, { skipModal: true })`)
+and wait for `mainpage_title`. Any flow this page creates is captured from its
+`POST /api/v1/flows → 201` response and deleted id-scoped in `afterEach`
+(defensive — a rejected import creates no flow, so the tracker normally captures
+nothing). No `page.allowFlowErrors()` is needed: all three rejections are
+100% client-side (verified live — zero `/api/` calls fire on the drop), so
+neither the fixture's backend-HTTP monitor nor its flow-error monitor trips.
+
+Each test drops one crafted `File` onto `cards-wrapper` via a synthetic
+`DataTransfer` (`dispatchEvent("drop", { dataTransfer })`), then:
+
+**Malformed JSON (`@stable`):**
+1. Drop `{ this is not valid json !!!` as `invalid.json`
+   (`application/json`)
+2. Assert the toast **"Error occurred while uploading file"** is visible
+3. Open the notifications dropdown (`notification_button`)
+4. Assert `notification-dropdown-content` contains **"Error occurred while
+   uploading file"** AND the JSON parser detail **"Expected property name or
+   '}'..."**
+5. Assert no **"uploaded successfully"** message appeared
+
+**Non-JSON file:**
+1. Drop plain text as `notaflow.txt` (`text/plain`)
+2–3. Same toast + open dropdown
+4. Assert `notification-dropdown-content` contains **"Error occurred while
+   uploading file"** AND **"Invalid file type"**
+5. Assert no success message
+
+**Invalid flow shape:**
+1. Drop `{"name":...,"description":...}` (no `data`) as `incomplete.json`
+   (`application/json`)
+2–3. Same toast + open dropdown
+4. Assert `notification-dropdown-content` contains **"Error occurred while
+   uploading file"** AND **"Invalid flow data"**
+5. Assert no success message
+
+---
+
+## Validation criterion *(required)*
+
+For each of the three files, after the drop:
+
+- The transient toast **"Error occurred while uploading file"** is visible, AND
+- The **persistent** `notification-dropdown-content` contains **"Error occurred
+  while uploading file"** together with the case-specific detail — **"Expected
+  property name or '}'..."** (malformed JSON) / **"Invalid file type"**
+  (non-JSON) / **"Invalid flow data"** (invalid shape), AND
+- No **"uploaded successfully"** message appears.
+
+Each assertion targets a single, distinctive observable — no fuzzy
+`invalid|error|failed` OR-chain, no `.catch(() => false)` swallow, no
+"app didn't crash" tautology. A mutated assertion (wrong detail text, or
+expecting success) fails deterministically. Asserting the **persistent**
+dropdown entry rather than the fading toast makes the detail check race-free.
+
+---
+
+## External dependencies *(required)*
+
+- `data-testid="cards-wrapper"` — the flows-page drop zone that receives imports
+- `data-testid="notification_button"` — header notification bell
+- `data-testid="notification-dropdown-content"` — persistent notifications list
+- `data-testid="mainpage_title"` — flows page loaded marker
+- No API key or provider required — the file is rejected client/ingestion-side
+  before any flow run.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Successfully importing a valid exported flow (the happy path — separate bullet)
+- Importing via the file-picker button (only the drag-and-drop drop zone here)
+- Dismissing / clearing the notification entry
+- Oversized-file rejection (§5.1 — separate spec)
+
+---
+
+## Notes *(optional)*
+
+- **Hardening (root cause of the promotion work).** The original file had two
+  dead tests: the non-JSON case asserted only `successVisible === false` after a
+  fixed wait (a silent no-op passed), and the invalid-shape case asserted only
+  that `mainpage_title` was still visible ("app didn't crash" — always true).
+  Both were rewritten against the scouted persistent observable so they can
+  actually fail. The malformed-JSON case's fuzzy `getByText(/invalid|error|...)`
+  regex was replaced with the exact toast + dropdown detail.
+- **Assert the persistent dropdown, not the toast.** The slide-in upload-error
+  toast auto-dismisses; the `notification-dropdown-content` entry persists.
+  Asserting the dropdown avoids the toast-fade race (same lesson as #693/#695).
+- **Observables verified live on 1.11.0.dev41** via `playwright-cli`: all three
+  drops produced the toast "Error occurred while uploading file" plus the
+  case-specific detail listed above, and none created a flow.
+- **Flow cleanup.** A rejected import creates no flow, but the spec still tracks
+  `POST /api/v1/flows → 201` ids and deletes them id-scoped in `afterEach` per
+  the repo convention (#490/#681) — a no-op here, present so a future
+  behavior change that starts persisting cannot silently leak.

--- a/tests/tests-automations/regression/flow-functionality/import-invalid-json.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/import-invalid-json.spec.ts
@@ -1,119 +1,139 @@
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+
+// A rejected import creates no flow, but track POST /api/v1/flows → 201 ids
+// defensively and delete them id-scoped in afterEach (repo convention,
+// #490/#681) — a no-op here, present so a future behavior change that starts
+// persisting a dropped file cannot silently leak.
+const createdFlowIds: string[] = [];
+
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {});
+    }
+  });
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, {
+      headers: { Authorization: bearer },
+    }).catch(() => {});
+  }
+});
+
+// Drop one crafted File onto the flows-page drop zone (cards-wrapper) via a
+// synthetic DataTransfer — the same event an OS drag-and-drop fires.
+async function dropFile(
+  page: Page,
+  content: string,
+  name: string,
+  type: string,
+): Promise<void> {
+  const dataTransfer = await page.evaluateHandle(
+    (d: { content: string; name: string; type: string }) => {
+      const dt = new DataTransfer();
+      dt.items.add(new File([d.content], d.name, { type: d.type }));
+      return dt;
+    },
+    { content, name, type },
+  );
+  await page.getByTestId("cards-wrapper").dispatchEvent("drop", { dataTransfer });
+}
+
+// After a drop, assert the transient toast AND the persistent notification
+// dropdown entry carry the upload error + the case-specific detail, and that no
+// success message appeared. The persistent dropdown entry is race-free (the
+// slide-in toast auto-dismisses) — same lesson as #693/#695.
+async function expectUploadError(page: Page, detail: string): Promise<void> {
+  await expect(
+    page.getByText("Error occurred while uploading file").first(),
+  ).toBeVisible({ timeout: 10000 });
+
+  await page.getByTestId("notification_button").click();
+  const dropdown = page.getByTestId("notification-dropdown-content");
+  await expect(dropdown).toBeVisible({ timeout: 10000 });
+  await expect(dropdown).toContainText("Error occurred while uploading file");
+  await expect(dropdown).toContainText(detail);
+
+  await expect(page.getByText("uploaded successfully")).toHaveCount(0);
+}
+
+async function openFlowsPage(page: Page): Promise<void> {
+  await awaitBootstrapTest(page, { skipModal: true });
+  await page.waitForSelector('[data-testid="mainpage_title"]', {
+    timeout: 30000,
+  });
+}
 
 test(
   "import invalid JSON must show error message",
-  { tag: ["@release", "@workspace", "@regression"] },
+  { tag: ["@stable", "@release", "@workspace", "@regression", "@ui-ux"] },
   async ({ page }) => {
-    await awaitBootstrapTest(page, { skipModal: true });
+    trackCreatedFlows(page);
+    await openFlowsPage(page);
 
-    await page.waitForSelector('[data-testid="mainpage_title"]', {
-      timeout: 30000,
-    });
+    await dropFile(
+      page,
+      "{ this is not valid json !!!",
+      "invalid.json",
+      "application/json",
+    );
 
-    // Simulate drag-and-drop of an invalid JSON file
-    const invalidJsonContent = "{ this is not valid json !!!";
-
-    const dataTransfer = await page.evaluateHandle((data) => {
-      const dt = new DataTransfer();
-      const file = new File([data], "invalid.json", {
-        type: "application/json",
-      });
-      dt.items.add(file);
-      return dt;
-    }, invalidJsonContent);
-
-    await page
-      .getByTestId("cards-wrapper")
-      .dispatchEvent("drop", { dataTransfer });
-
-    // Must display an error or warning — not silently fail
-    // Use a single reliable regex-based wait (comma-separated text= is invalid Playwright syntax)
-    const errorLocator = page.getByText(/invalid|error|failed|could not/i).first();
-    await expect(errorLocator).toBeVisible({ timeout: 10000 });
-
-    // No new flow should be created (we can verify by checking that no success message appears)
-    const successVisible = await page
-      .getByText("uploaded successfully")
-      .isVisible({ timeout: 3000 })
-      .catch(() => false);
-    expect(successVisible).toBeFalsy();
+    // Malformed JSON: the parser rejects it before it is even a candidate flow.
+    await expectUploadError(page, "Expected property name or '}'");
   },
 );
 
 test(
   "import non-JSON file must show error message",
-  { tag: ["@release", "@workspace", "@regression"] },
+  { tag: ["@stable", "@release", "@workspace", "@regression", "@ui-ux"] },
   async ({ page }) => {
-    await awaitBootstrapTest(page, { skipModal: true });
+    trackCreatedFlows(page);
+    await openFlowsPage(page);
 
-    await page.waitForSelector('[data-testid="mainpage_title"]', {
-      timeout: 30000,
-    });
+    await dropFile(
+      page,
+      "This is a plain text file, not a flow.",
+      "notaflow.txt",
+      "text/plain",
+    );
 
-    // Simulate drop of a plain text file (not JSON)
-    const textContent = "This is a plain text file, not a flow.";
-
-    const dataTransfer = await page.evaluateHandle((data) => {
-      const dt = new DataTransfer();
-      const file = new File([data], "notaflow.txt", { type: "text/plain" });
-      dt.items.add(file);
-      return dt;
-    }, textContent);
-
-    await page
-      .getByTestId("cards-wrapper")
-      .dispatchEvent("drop", { dataTransfer });
-
-    await page.waitForTimeout(3000);
-
-    // No flow should be created successfully
-    const successVisible = await page
-      .getByText("uploaded successfully")
-      .isVisible({ timeout: 3000 })
-      .catch(() => false);
-    expect(successVisible).toBeFalsy();
+    // Non-JSON MIME type: rejected on file type, not content.
+    await expectUploadError(page, "Invalid file type");
   },
 );
 
 test(
   "import JSON with missing data field must show error",
-  { tag: ["@release", "@workspace", "@regression"] },
+  { tag: ["@stable", "@release", "@workspace", "@regression", "@ui-ux"] },
   async ({ page }) => {
-    await awaitBootstrapTest(page, { skipModal: true });
+    trackCreatedFlows(page);
+    await openFlowsPage(page);
 
-    await page.waitForSelector('[data-testid="mainpage_title"]', {
-      timeout: 30000,
-    });
-
-    // Valid JSON but missing required "data" field for a flow
     const incompleteFlow = JSON.stringify({
       name: "Incomplete Flow",
       description: "This flow is missing the data field",
       // no "data" property
     });
+    await dropFile(page, incompleteFlow, "incomplete.json", "application/json");
 
-    const dataTransfer = await page.evaluateHandle((data) => {
-      const dt = new DataTransfer();
-      const file = new File([data], "incomplete.json", {
-        type: "application/json",
-      });
-      dt.items.add(file);
-      return dt;
-    }, incompleteFlow);
-
-    await page
-      .getByTestId("cards-wrapper")
-      .dispatchEvent("drop", { dataTransfer });
-
-    await page.waitForTimeout(3000);
-
-    // Either shows error or uploads without nodes (both are acceptable behaviors)
-    // The key assertion is that the app doesn't crash
-    const appStillVisible = await page
-      .getByTestId("mainpage_title")
-      .isVisible({ timeout: 5000 })
-      .catch(() => false);
-    expect(appStillVisible).toBeTruthy();
+    // Well-formed JSON, but not a valid flow shape (no "data").
+    await expectUploadError(page, "Invalid flow data");
   },
 );


### PR DESCRIPTION
Closes #683

## What & why

Validate & promote to `@stable` the §12.4 Export / Import Flow bullet
**"Import invalid JSON — should display error message"**.

The spec already existed but two of its three tests could not fail:
- **non-JSON case** asserted only `successVisible === false` after a fixed
  `waitForTimeout(3000)` — a silent no-op passed.
- **missing-data case** asserted only that `mainpage_title` was still visible
  ("the app doesn't crash") — always true.
- **malformed-JSON case** used a fuzzy `getByText(/invalid|error|failed|could not/i)`
  regex that matches incidental page text.

Promoting those as-is would blind the daily-stable workflow on this surface.

## What changed

All three tests rewritten against a **live-scouted, deterministic observable**:
each drop surfaces the toast **"Error occurred while uploading file"** plus a
distinct detail in the **persistent** `notification-dropdown-content`
(asserted instead of the fading toast → race-free):

| Drop | Detail asserted |
|---|---|
| `{ this is not valid json !!!` | `Expected property name or '}'...` |
| plain `.txt` (`text/plain`) | `Invalid file type` |
| valid JSON, no `data` field | `Invalid flow data` |

Each test also asserts **no** `"uploaded successfully"` message appears.

- Added the missing **functional** tag `@ui-ux` (the file previously had only
  cross-cutting tags).
- Defensive **Pattern A** flow cleanup (`POST /flows → 201` id capture +
  id-scoped `deleteFlow` in `afterEach`) — a rejected import creates no flow
  (verified: **zero** `/api/` calls fire on the drop), so it is a no-op here,
  present so a future behavior change cannot silently leak. `allowFlowErrors`
  removed as dead code (rejection is 100% client-side).
- New spec doc `docs/flow-functionality/import-invalid-json.md` mirroring the
  test path; `QA-CHECKLIST.md` §12.4 bullet flipped to `[x]`.

## Validation

- **Resolved Langflow version:** 1.11.0.dev42 (nightly)
- **Determinism:** burst 3/3 at `--retries=0 --workers=1` →
  expected=3, unexpected=0, flaky=0, backendErrors=false; re-confirmed 3/3
  green after the dev41→dev42 nightly bump.
- **Force-fail:** each of the 3 tests mutated (expected detail →
  `FF_MUTATION_NEVER_MATCHES`), each failed as expected (unexpected=1), all
  reverted (0 `// FF-MUTATION` markers remain) + final green run.
- `npm run typecheck` = 0 errors · `npm run lint` = 0 errors.
- Observables verified live via `playwright-cli` on 1.11.0.dev42.

## Run it

```bash
npx playwright test tests/tests-automations/regression/flow-functionality/import-invalid-json.spec.ts --workers=1 --retries=0
# expected: 3 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
