### PR TITLE
fix(llm-agents): poll selected model value not serialized field (#724)

### DIFF
--- a/docs/core-functionality/llm-agents/agent-structured-output.md
+++ b/docs/core-functionality/llm-agents/agent-structured-output.md
@@ -1,6 +1,6 @@
 # Agent structured output — output_schema returns schema-shaped JSON
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.11.x (re-validated on 1.11.0.dev38, #724)
 
 ---
 
@@ -127,16 +127,25 @@ persisted output — never on the model's wording.
   asserts fail on that shape (no key `name`/`colors`), so an errored run
   cannot pass silently.
 - **Model-selection guards (setup stabilization, found via live flake
-  hunt).** The node run builds from the frontend's in-memory graph, and the
-  canvas's `custom_component/update` storm intermittently DROPS the Agent's
-  model selection (`__default_language_model__ variable not found` in the
-  backend log) — the build then falls back to the legacy default model of an
-  inactive provider and never reports success (~1/5 observed). Two guards:
-  the API PATCH polls the flow until the POM's model selection is autosaved
-  before writing (write-clobber race), and the run helper re-checks the
-  node's model widget right before running, reloading (bounded ×3) until the
-  selection is present. Product-bug candidate — flagged on the PR; the
-  structured-output asserts are untouched by both guards.
+  hunt).** The Agent's model choice lands via ASYNC autosave; a GET+PATCH
+  that races it re-writes the template default (the leader/default provider's
+  model, e.g. `claude-sonnet-5`) back over the selection. Two guards: the API
+  PATCH polls the flow until the POM's model selection is autosaved before
+  writing (write-clobber race), and the run helper re-checks the node's model
+  widget right before running, reloading (bounded ×3) until the selection is
+  present. The structured-output asserts are untouched by both guards.
+  - **#724 fix — the poll must check the SELECTED value, not the serialized
+    field.** `template.model` embeds an `options` list of every enabled model
+    (~59 on a multi-provider nightly), so the original substring check over
+    the stringified field matched `expectedModel` inside `options` regardless
+    of what was actually selected — the poll returned "ready" on the first
+    GET even before the autosave, and the PATCH clobbered the selection with
+    the leader model (daily #704 hard failure). The poll now inspects
+    `template.model.value` (the array of selected model objects) only.
+  - **Not a product bug (re-confirmed live on #724).** Selecting a non-leader
+    model in the widget, waiting for autosave, and reloading persists the
+    selection correctly on the nightly; the flake was entirely the test's own
+    write-clobber, now fixed.
 - **Force-failure checks** (CONTRIBUTING §2): M1 — test 1 expects a key
   absent from the schema (`city`) ⇒ must fail; M2 — test 1 expects `age` to
   be a string (wrong type) ⇒ must fail; M3 — test 2 expects `colors` NOT to

--- a/docs/core-functionality/llm-agents/agent-structured-output.md
+++ b/docs/core-functionality/llm-agents/agent-structured-output.md
@@ -132,8 +132,9 @@ persisted output — never on the model's wording.
   model, e.g. `claude-sonnet-5`) back over the selection. Two guards: the API
   PATCH polls the flow until the POM's model selection is autosaved before
   writing (write-clobber race), and the run helper re-checks the node's model
-  widget right before running, reloading (bounded ×3) until the selection is
-  present. The structured-output asserts are untouched by both guards.
+  widget right before running, reloading (bounded — 3 checks, at most 2
+  reloads) until the selection is present. The structured-output asserts are
+  untouched by both guards.
   - **#724 fix — the poll must check the SELECTED value, not the serialized
     field.** `template.model` embeds an `options` list of every enabled model
     (~59 on a multi-provider nightly), so the original substring check over

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-structured-output.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-structured-output.spec.ts
@@ -206,6 +206,15 @@ interface SchemaRow {
 // races it writes the stale default model back (observed live: the agent
 // then built with the inactive provider's default and the run hung — ~1/5
 // failure rate before this guard).
+//
+// The poll MUST inspect the model field's selected `value`, not the whole
+// serialized field: `template.model` embeds an `options` list of every
+// enabled model (~59 on a multi-provider nightly), so a substring check over
+// the stringified field matched `expectedModel` in `options` regardless of
+// what was actually selected — returning "flow-ready" on the FIRST GET even
+// when `value` was still the template default. That let a pre-autosave GET
+// through, and the PATCH wrote the default (the leader/default provider's
+// model, e.g. "claude-sonnet-5") back over the selection (#724).
 async function patchStructuredOutputSetup(
   request: APIRequestContext,
   bearer: string,
@@ -225,11 +234,20 @@ async function patchStructuredOutputSetup(
           (n: any) => n.data?.type === "Agent",
         );
         if (!agentNode) return "no Agent node";
-        if (
-          expectedModel &&
-          !JSON.stringify(agentNode.data.node?.template?.model ?? "").includes(expectedModel)
-        ) {
-          return "model selection not autosaved yet";
+        if (expectedModel) {
+          // The model field's `value` is the array of SELECTED model objects
+          // ({ name, provider, ... }); `options` (all enabled models) is
+          // deliberately excluded from this check — see the note above.
+          // Exact-match on `name`: expectedModel comes from models.json (the
+          // model id) and equals the option's `name`; a divergence there would
+          // burn the full poll timeout rather than pass on a stale value.
+          const selected = agentNode.data.node?.template?.model?.value;
+          const selectedNames = Array.isArray(selected)
+            ? selected.map((m: any) => m?.name)
+            : [selected];
+          if (!selectedNames.includes(expectedModel)) {
+            return "model selection not autosaved yet";
+          }
         }
         return "flow-ready";
       },
@@ -285,14 +303,15 @@ async function setChatInputText(page: Page, text: string): Promise<void> {
 // slices the dialog text from the first "{" to the last "}".
 //
 // The node run builds from the FRONTEND's in-memory graph (the v2 workflows
-// payload embeds data.nodes), and the canvas's custom_component/update storm
-// intermittently drops the Agent's model selection from that state — the
-// build then silently falls back to the legacy default model of an inactive
-// provider and hangs the success toast (observed ~1/5 pre-guard; product-bug
-// candidate flagged on the PR). The gate below re-checks the node's model
-// widget right before running and reloads (bounded) until the selection is
-// present — setup stabilization only; the structured-output asserts are
-// untouched.
+// payload embeds data.nodes). #724 traced the "reverts to leader" flake to the
+// test's own write-clobber (see patchStructuredOutputSetup) — NOT a product
+// bug: selecting a non-leader model, autosaving, and reloading persists the
+// selection correctly live. When the persisted model.value is empty/stale the
+// product legitimately auto-picks the first enabled model (the leader). With
+// the poll fixed the correct value is written back, so this gate below is now
+// a defensive safety net: it re-reads the node's model widget right before
+// running and reloads (bounded) until the selection is present. Setup
+// stabilization only — the structured-output asserts are untouched.
 async function runAgentAndParseStructuredOutput(
   page: Page,
   expectedModel: string | undefined,
@@ -306,7 +325,7 @@ async function runAgentAndParseStructuredOutput(
       if (widget.includes(expectedModel)) break;
       expect(
         attempt,
-        `Agent model widget lost the selection (shows "${widget}", expected "${expectedModel}") after 3 reloads`,
+        `Agent model widget lost the selection (shows "${widget}", expected "${expectedModel}") after 2 reloads`,
       ).toBeLessThan(3);
       await page.reload();
       await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', { timeout: 30000 });


### PR DESCRIPTION
Closes #724

## Problem

Daily #704 hard failure on `agent-structured-output.spec.ts` (`openai / gpt-4o-mini`): the Agent model widget reverted to `claude-sonnet-5` (the collect-models leader) instead of persisting the selected `gpt-4o-mini`, exhausting the run helper's reload guard (3/3 attempts).

## Root cause — test defect (not a product bug)

The setup poll in `patchStructuredOutputSetup` checked `JSON.stringify(template.model).includes(expectedModel)`. The `model` field embeds an `options` list of **every enabled model** (~59 on a multi-provider nightly), and `setup-openai.ts` enables them all — so `expectedModel` was always present in `options`, and the poll returned `flow-ready` on the **first GET, before the UI autosave landed**. The subsequent PATCH then wrote the stale/empty `model.value` back. On reload the product legitimately auto-picks the first enabled model (the leader) when `value` is empty — hence the "reverts to `claude-sonnet-5`" symptom.

Verified live on the nightly that **model-selection persistence is a working product behavior**: selecting a non-leader model, waiting for autosave, and reloading keeps the selection. The flake was entirely the test's own write-clobber.

Concrete proof of the defective predicate on the real flow field:
```
value = [claude-sonnet-5] | options has gpt-4o-mini: True
OLD predicate -> ready? True   (WRONG: PATCHes stale default back)
NEW predicate -> ready? False  (correct: keeps waiting for the real autosave)
```

## Fix

- The poll now inspects `template.model.value` (array of selected model objects) via exact `name` match — it genuinely waits for the autosave, so the PATCH preserves the selection. Handles `value` shapes `[{name}]` / `""` / `undefined` / `[]` safely.
- Doc + code comments reconciled: the model-drop is not a product bug; the run helper's reload guard is now a defensive safety net.

`@stable` was retained throughout (the daily guard left it in place) — nothing to restore.

## Validation

- Nightly: `1.11.0.dev38`
- `npm run typecheck` — 0 errors; `npm run lint` — 0 errors (pre-existing warnings only)
- `--workers=1 --retries=0`: **4 passed** across 3 consecutive clean runs (openai/gpt-4o-mini + google/gemini-2.5-flash), ~53–60s each
- Force-fail (executed):
  - test 1 (M2): expect `typeof age === "string"` → **failed** ✓
  - test 2 (M3): expect `Array.isArray(colors) === false` → **failed** ✓
  - helper/fix (behavioral): old predicate returns ready on stale `value=claude-sonnet-5`; new predicate correctly keeps polling ✓
- Flow cleanup: id-scoped `afterEach` verified — 0 new orphan flows after all runs
- Independent adversarial review confirmed the root cause and fix against the live instance and Langflow frontend source

🤖 Generated with [Claude Code](https://claude.com/claude-code)