### PR TITLE
fix(bulk-actions): create flows via API to remove setup flake (#723)

### DIFF
--- a/docs/core-functionality/project-management/bulk-actions.md
+++ b/docs/core-functionality/project-management/bulk-actions.md
@@ -1,6 +1,6 @@
 # Project Management – Bulk Actions on Flows
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.11.x
 
 ---
 
@@ -14,7 +14,7 @@ Validates multi-select and bulk operations on the home flow listing:
 4. **Ctrl/Cmd selection** — Ctrl/Cmd-clicking the first and third cards selects exactly those two, leaving the second unchecked (proves per-item, not range, selection).
 5. **Bulk delete** — `delete-bulk-btn` followed by the confirmation removes the selected flows; the deleted flow names disappear from the listing while the unselected one remains.
 
-The test creates its 3 flows from starter templates and captures each flow ID from the URL, so cleanup deletes only the IDs it created via the API — never sibling specs' flows, which is required for safety under `fullyParallel`.
+The test creates its 3 flows directly via the REST API (`POST /api/v1/flows/`, empty `nodes`/`edges`) and captures each returned flow ID, so cleanup deletes only the IDs it created — never sibling specs' flows, which is required for safety under `fullyParallel`. Creating via the API (rather than clicking through the templates modal three times) also removes the sole source of this spec's historical CI flake — see **Known flakiness**.
 
 ---
 
@@ -26,16 +26,17 @@ The test creates its 3 flows from starter templates and captures each flow ID fr
 
 ## Step by step *(required)*
 
-1. Bootstrap the test session (`awaitBootstrapTest`).
-2. Create 3 flows by opening the templates modal and picking, in order, **Basic Prompting**, **Document Q&A**, **Basic Prompting**; after each, capture the `/flow/<id>` URL and return to the home listing.
-3. Shift-click list card 1 then list card 3; assert all 3 checkboxes are checked.
-4. Click `download-bulk-btn`; assert the "downloaded successfully" notification.
-5. Shift-click list card 1 again; assert all 3 checkboxes are unchecked.
-6. Ctrl/Cmd-click list card 1 and list card 3; assert cards 1 and 3 checked, card 2 unchecked.
-7. Capture the three flow names from `flow-name-div` (asserting non-empty text first).
-8. Click `delete-bulk-btn`, confirm in the "This can't be undone." dialog; assert "Flows deleted successfully".
-9. Assert the first and third flow names are hidden and the second is still visible.
-10. **Cleanup (finally):** delete each captured flow ID via `DELETE /api/v1/flows/{id}` (404s on already-deleted flows are ignored).
+1. Bootstrap the test session (`awaitBootstrapTest(page, { skipModal: true })` — no templates modal is needed since flows are created via the API).
+2. Create 3 flows via `POST /api/v1/flows/` (`createFlow` helper) with unique names (`bulk-actions-<suffix>-1..3`) and empty `data`; capture each returned ID.
+3. Navigate to the home listing (`page.goto("/")`); the 3 just-created flows sort to the top by recency. **Guard:** assert the top 3 list cards' names are exactly the 3 created names — selection is positional (shift/ctrl-click by index) and bulk-delete is destructive, so a sibling worker's flow interleaving at the top must fail fast rather than risk a cross-worker delete.
+4. Shift-click list card 1 then list card 3; assert all 3 checkboxes are checked.
+5. Click `download-bulk-btn`; assert the "downloaded successfully" notification.
+6. Shift-click list card 1 again; assert all 3 checkboxes are unchecked.
+7. Ctrl/Cmd-click list card 1 and list card 3; assert cards 1 and 3 checked, card 2 unchecked.
+8. Capture the three flow names from `flow-name-div` (asserting non-empty text first).
+9. Click `delete-bulk-btn`, confirm in the "This can't be undone." dialog; assert "Flows deleted successfully".
+10. Assert the first and third flow names are hidden and the second is still visible.
+11. **Cleanup (finally):** delete each captured flow ID via `DELETE /api/v1/flows/{id}` (404s on already-deleted flows are ignored).
 
 ---
 
@@ -51,10 +52,9 @@ The test creates its 3 flows from starter templates and captures each flow ID fr
 
 ## External dependencies *(required)*
 
-- Home listing UI testids: `side_nav_options_all-templates`, `new-project-btn` / `new_project_btn_empty_page`, `modal-title`, `flow-builder-welcome-panel` / `flow-builder-welcome-browse-more` (the 1.10.x welcome overlay), `sidebar-search-input`, `icon-ChevronLeft`, `home-dropdown-menu`, `list-card`, `checkbox-*`, `flow-name-div`, `download-bulk-btn`, `delete-bulk-btn`.
-- Starter templates **Basic Prompting** and **Document Q&A** must exist.
-- REST API `DELETE /api/v1/flows/{id}` for ID-scoped cleanup (auth via `getAuthToken`).
-- No LLM or provider API key required.
+- Home listing UI testids: `list-card`, `checkbox-*`, `flow-name-div`, `download-bulk-btn`, `delete-bulk-btn`.
+- REST API `POST /api/v1/flows/` (via the `createFlow` helper) for flow creation and `DELETE /api/v1/flows/{id}` for ID-scoped cleanup (auth via `getAuthToken`).
+- No starter template or LLM/provider API key required — flows are created empty via the API.
 
 ---
 
@@ -68,12 +68,12 @@ The test creates its 3 flows from starter templates and captures each flow ID fr
 
 ## Known flakiness *(optional)*
 
-Under `fullyParallel` CI load this is a heavy test (it creates 3 flows and navigates editor↔home repeatedly). Two load-induced flake modes have been observed on the weekly run:
+This spec used to create its 3 flows through the UI (opening the templates modal three times and navigating editor↔home after each), which was the sole source of its CI flake. Two load-induced modes recurred on the daily-stable workflow (#723):
 
-- The home listing taking >10s to render after returning from the editor (the `Projects` visibility wait). **Mitigated** by raising that wait to 30s.
-- Clicking the "New Flow" entry point not opening the templates modal ("swallowed click": the button is actionable but its React handler is not wired yet under load), inside the shared `openNewFlowTemplatesModal` helper — **mitigated** in #420 by a click-and-probe retry loop in that helper (re-clicks the entry point if neither the templates modal nor the welcome overlay surfaces within a short budget).
+- The home listing taking >30s to render after returning from the editor (`page.waitForSelector` timeout in the navigation — daily 2026-07-09).
+- Clicking the "New Flow" entry point not opening the templates modal ("swallowed click": the button is actionable but its React handler is not wired yet under load), inside the shared `openNewFlowTemplatesModal` helper — this survived the #420 click-and-probe retry loop under severe contention (`expect(...).toBe(true)` in `dismissWelcomeOverlayAndWaitForModal` — daily 2026-07-13).
 
-Both reproduce only under contention; a single isolated run against a fresh instance passes consistently.
+Both modes lived entirely in the incidental UI scaffolding, never in the bulk-action assertions under test. #723 **eliminated the whole class** by creating the 3 flows via `POST /api/v1/flows/` and loading the listing with a single `page.goto("/")` — no templates modal, no editor↔home round-trips. The remaining positional risk (a sibling worker's flow interleaving at the top of the recency-sorted listing) is caught by the top-3 name guard before any destructive selection.
 
 ---
 

--- a/docs/core-functionality/project-management/bulk-actions.md
+++ b/docs/core-functionality/project-management/bulk-actions.md
@@ -26,9 +26,9 @@ The test creates its 3 flows directly via the REST API (`POST /api/v1/flows/`, e
 
 ## Step by step *(required)*
 
-1. Bootstrap the test session (`awaitBootstrapTest(page, { skipModal: true })` — no templates modal is needed since flows are created via the API).
-2. Create 3 flows via `POST /api/v1/flows/` (`createFlow` helper) with unique names (`bulk-actions-<suffix>-1..3`) and empty `data`; capture each returned ID.
-3. Navigate to the home listing (`page.goto("/")`); the 3 just-created flows sort to the top by recency. **Guard:** assert the top 3 list cards' names are exactly the 3 created names — selection is positional (shift/ctrl-click by index) and bulk-delete is destructive, so a sibling worker's flow interleaving at the top must fail fast rather than risk a cross-worker delete.
+1. Create 3 flows via `POST /api/v1/flows/` (`createFlow` helper) with unique names (`bulk-actions-<suffix>-1..3`) and empty `data`; capture each returned ID. This runs **before** bootstrap so the instance is non-empty.
+2. Bootstrap the test session onto the home listing (`awaitBootstrapTest(page, { skipModal: true })`). `skipModal` skips opening the templates modal; seeding the flows first also skips the empty-page branch (`addFlowToTestOnEmptyLangflow`, which drives the same templates-modal helper), so no part of the historically flaky modal path is exercised. The 3 just-created flows sort to the top by recency.
+3. **Guard:** assert the top 3 list cards' names are exactly the 3 created names — selection is positional (shift/ctrl-click by index) and bulk-delete is destructive, so a sibling worker's flow interleaving at the top must fail fast rather than risk a cross-worker delete.
 4. Shift-click list card 1 then list card 3; assert all 3 checkboxes are checked.
 5. Click `download-bulk-btn`; assert the "downloaded successfully" notification.
 6. Shift-click list card 1 again; assert all 3 checkboxes are unchecked.

--- a/tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts
@@ -8,12 +8,6 @@ test(
   "user should be able to select flows with different methods and perform bulk actions",
   { tag: ["@stable", "@release", "@workspace", "@mainpage", "@regression"] },
   async ({ page, request }) => {
-    // Land on the home listing without opening the templates modal — flows are
-    // created via the API below, so the (historically flaky) modal path is not
-    // needed. skipModal avoids `openNewFlowTemplatesModal`, which was the sole
-    // source of this spec's CI flake (#723).
-    await awaitBootstrapTest(page, { skipModal: true });
-
     // Track the IDs of the 3 flows we create so cleanup can delete ONLY those
     // via the API, not sibling specs' flows. Under `fullyParallel`, a positional
     // bulk-delete on the shared listing would otherwise be able to hit a flow
@@ -31,6 +25,12 @@ test(
       // assertions under test. `createFlow` retries the transient concurrent
       // 500 (#588); empty `data` is enough — the test only selects/downloads/
       // deletes the cards, it never runs the flows.
+      //
+      // Seed via the API BEFORE bootstrapping the browser: this leaves the
+      // instance non-empty, so `awaitBootstrapTest`'s empty-page seeding branch
+      // (`addFlowToTestOnEmptyLangflow`, which itself drives the flaky templates
+      // modal via `dismissWelcomeOverlayAndWaitForModal`) is never taken. Getting
+      // the token uses `request` and is independent of the browser session.
       const headers = { Authorization: await getAuthToken(request) };
       for (const name of createdNames) {
         const id = await createFlow(
@@ -41,10 +41,13 @@ test(
         createdFlowIds.push(id);
       }
 
-      // Load the home listing; the 3 just-created flows sort to the top by
-      // recency (verified live — API-created empty flows select via shift/ctrl
-      // click exactly like template-created ones).
-      await page.goto("/");
+      // Bootstrap onto the home listing. `skipModal` skips opening the templates
+      // modal, and because the 3 flows above already exist the empty-page
+      // seeding branch is skipped too — so no part of the historically flaky
+      // modal path (#723) is exercised. The 3 flows sort to the top by recency
+      // (verified live — API-created empty flows select via shift/ctrl click
+      // exactly like template-created ones).
+      await awaitBootstrapTest(page, { skipModal: true });
       await expect(page.getByTestId("list-card").first()).toBeVisible({ timeout: 30000 });
 
       // Safety + determinism guard: the top 3 cards must be exactly the flows we

--- a/tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts
@@ -1,78 +1,63 @@
 import { expect, test } from "../../../../fixtures/fixtures";
-import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
-import { openNewFlowTemplatesModal } from "../../../../helpers/flows/open-new-flow-templates-modal";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { createFlow } from "../../../../helpers/flows/create-flow";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 test(
   "user should be able to select flows with different methods and perform bulk actions",
   { tag: ["@stable", "@release", "@workspace", "@mainpage", "@regression"] },
   async ({ page, request }) => {
-    await awaitBootstrapTest(page);
+    // Land on the home listing without opening the templates modal — flows are
+    // created via the API below, so the (historically flaky) modal path is not
+    // needed. skipModal avoids `openNewFlowTemplatesModal`, which was the sole
+    // source of this spec's CI flake (#723).
+    await awaitBootstrapTest(page, { skipModal: true });
 
-    // Track the IDs of the 3 flows we create so cleanup can delete ONLY
-    // those via the API, not sibling specs' flows. Bulk-delete via UI on
-    // first→last list-card would nuke any flow created by another worker
-    // under `fullyParallel`.
+    // Track the IDs of the 3 flows we create so cleanup can delete ONLY those
+    // via the API, not sibling specs' flows. Under `fullyParallel`, a positional
+    // bulk-delete on the shared listing would otherwise be able to hit a flow
+    // created by another worker (guarded against below).
     const createdFlowIds: string[] = [];
-    const captureFlowIdFromUrl = async () => {
-      // `waitForURL` enforces the URL matches the regex — once it returns,
-      // the subsequent `match()` is guaranteed to succeed, so the non-null
-      // assertion is safe and lets the rule against test-side conditionals
-      // stay clean.
-      await page.waitForURL(/\/flow\/[0-9a-f-]+/i, { timeout: 15000 });
-      const id = page.url().match(/\/flow\/([0-9a-f-]+)/i)![1];
-      createdFlowIds.push(id);
-    };
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+    const createdNames = [1, 2, 3].map((n) => `bulk-actions-${suffix}-${n}`);
 
     try {
-      // Add some flows to test with
-      await page.getByTestId("side_nav_options_all-templates").click();
-      await page.getByRole("heading", { name: "Basic Prompting" }).click();
-      await captureFlowIdFromUrl();
-      await adjustScreenView(page);
+      // Create the 3 flows directly via the REST API instead of clicking through
+      // the templates modal three times. The UI path (open modal → pick template
+      // → navigate editor↔home, ×3) was heavy and load-sensitive; both recurring
+      // daily failures (#723: modal never opened / home-return waitForSelector
+      // timeout) lived entirely in that scaffolding, never in the bulk-action
+      // assertions under test. `createFlow` retries the transient concurrent
+      // 500 (#588); empty `data` is enough — the test only selects/downloads/
+      // deletes the cards, it never runs the flows.
+      const headers = { Authorization: await getAuthToken(request) };
+      for (const name of createdNames) {
+        const id = await createFlow(
+          request,
+          { name, description: "", data: { nodes: [], edges: [] }, is_component: false },
+          { headers },
+        );
+        createdFlowIds.push(id);
+      }
 
-      // Go back to main page
-      await page.waitForSelector('[data-testid="sidebar-search-input"]', {
-        timeout: 30000,
-      });
-      await page.getByTestId("icon-ChevronLeft").first().click();
+      // Load the home listing; the 3 just-created flows sort to the top by
+      // recency (verified live — API-created empty flows select via shift/ctrl
+      // click exactly like template-created ones).
+      await page.goto("/");
+      await expect(page.getByTestId("list-card").first()).toBeVisible({ timeout: 30000 });
 
-      // 30s (not 10s): returning from the editor to home under `fullyParallel`
-      // CI load can take longer than 10s to render the home listing. The 10s
-      // wait was the outlier that flaked here (see weekly run on 1.10.1rc3).
-      await expect(page.getByText("Projects").first()).toBeVisible({ timeout: 30000 });
-      await openNewFlowTemplatesModal(page);
-      await page.getByTestId("side_nav_options_all-templates").click();
-      await page.getByRole("heading", { name: "Document Q&A" }).click();
-      await captureFlowIdFromUrl();
-      await page.waitForSelector('[data-testid="sidebar-search-input"]', {
-        timeout: 30000,
-      });
-      await page.getByTestId("icon-ChevronLeft").first().click();
-
-      // 30s (not 10s): returning from the editor to home under `fullyParallel`
-      // CI load can take longer than 10s to render the home listing. The 10s
-      // wait was the outlier that flaked here (see weekly run on 1.10.1rc3).
-      await expect(page.getByText("Projects").first()).toBeVisible({ timeout: 30000 });
-      await openNewFlowTemplatesModal(page);
-      await page.getByTestId("side_nav_options_all-templates").click();
-      await page.getByRole("heading", { name: "Basic Prompting" }).click();
-      await captureFlowIdFromUrl();
-      await page.waitForSelector('[data-testid="sidebar-search-input"]', {
-        timeout: 30000,
-      });
-      await page.getByTestId("icon-ChevronLeft").first().click();
-
-      // 30s (not 10s): returning from the editor to home under `fullyParallel`
-      // CI load can take longer than 10s to render the home listing. The 10s
-      // wait was the outlier that flaked here (see weekly run on 1.10.1rc3).
-      await expect(page.getByText("Projects").first()).toBeVisible({ timeout: 30000 });
-      await page.waitForSelector('[data-testid="home-dropdown-menu"]', {
-        timeout: 30000,
-      });
-      await expect(page.getByTestId("list-card").first()).toBeVisible({ timeout: 10000 });
+      // Safety + determinism guard: the top 3 cards must be exactly the flows we
+      // created. Selection below is positional (shift/ctrl-click by card index)
+      // and bulk-delete is destructive, so if a sibling worker's flow interleaved
+      // at the top of the recency-sorted listing under `fullyParallel`, fail fast
+      // here rather than risk deleting someone else's flow.
+      const topThreeNames = await page
+        .locator("[data-testid='flow-name-div'] span")
+        .evaluateAll((els) =>
+          els.slice(0, 3).map((e) => e.textContent?.trim() ?? ""),
+        );
+      expect([...topThreeNames].sort()).toEqual([...createdNames].sort());
 
       // Test shift selection
       await page.keyboard.down("Shift");


### PR DESCRIPTION
Closes #723

## Problem

`bulk-actions.spec.ts` hard-failed on two dailies (2026-07-09 and 2026-07-13) with two different signatures. Both live entirely in the **flow-creation scaffolding**, never in the bulk-action assertions under test:

| Daily | Signature | Where |
|---|---|---|
| 2026-07-09 (calm day) | `TimeoutError: page.waitForSelector: Timeout 30000ms` | editor→home navigation |
| 2026-07-13 (broad bad-nightly day) | `expect(...).toBe(true)` | `openNewFlowTemplatesModal` → `dismissWelcomeOverlayAndWaitForModal` (modal never opened; survived the #420 retry loop under load) |

The spec created its 3 flows by opening the templates modal three times with editor↔home round-trips — heavy and load-sensitive. Run against a fresh nightly (`1.11.0.dev38`) it passes green, so there is **no product regression / UI drift** — the recurrence is CI-load flake in the incidental setup.

## Fix

- Create the 3 flows via `POST /api/v1/flows/` (`createFlow` helper, empty `data`) and load the listing with a single `page.goto("/")` — no templates modal, no editor↔home round-trips.
- `awaitBootstrapTest(page, { skipModal: true })` so the flaky helper is not exercised at all.
- **Top-3 name guard**: assert the first 3 cards are exactly the created flows before any positional/destructive selection — converts the latent cross-worker bulk-delete hazard under `fullyParallel` into a fast, safe failure.
- All bulk-action assertions (shift-click range, ctrl-click per-item, bulk download, bulk delete) are unchanged.
- Isolating via the search box was rejected — filtering the listing breaks shift-click selection (verified live).

Runtime: **~54s → ~5s**. `@stable` was left in place (guard never removed it).

## Validation

Nightly `langflowai/langflow-nightly:latest` = `1.11.0.dev38`.

- 6× `--retries=0 --workers=1` green (~5s each).
- Force-fail (executed, then reverted):
  - **FF-A** (top-3 guard): expected side mutated to `["FF-A-mutant"]` → failed `toEqual` (received the 3 real names).
  - **FF-B** (ctrl-click per-item): `secondCheckbox.not.toBeChecked()` → `.toBeChecked()` → failed `Expected: checked / Received: unchecked`.
- `tsc --noEmit`: 0 errors. `eslint` on the spec: clean.
- 0 orphan flows (`bulk-actions-*`) left in the listing after runs (id-scoped `finally` cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)