### PR TITLE
test(knowledge-ingestion): add Split Text chunking spec (#673)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -302,7 +302,7 @@
 - [-] File management page
 
 #### 5.2 Processing and Vectorization
-- [ ] Document ingestion via Split Text + Embeddings component
+- [x] Split Text chunking of an ingested document → `core-functionality/knowledge-ingestion-management/split-text-chunking.spec.ts`
 - [ ] Indexing in Vector Store — document available for query
 - [ ] Vector Store query returns relevant chunks for the prompt
 - [ ] Complete RAG pipeline (ingest → embed → store → retrieve → answer)

--- a/docs/core-functionality/knowledge-ingestion-management/split-text-chunking.md
+++ b/docs/core-functionality/knowledge-ingestion-management/split-text-chunking.md
@@ -1,0 +1,131 @@
+# Spec: Split Text chunking of an ingested document (§5.2 Processing and Vectorization)
+
+**Test file:** `tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/split-text-chunking.spec.ts`
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates
+
+The **processing** step of RAG ingestion, on a running flow: a document
+(delivered as a `Message` by **Chat Input**) is fed into the **Split Text**
+component and **split into the expected number of chunks** for a known
+`Chunk Size`. This is the deterministic, standalone-observable part of §5.2.1.
+
+### Scope boundary — why embeddings are not here
+
+The §5.2 bullet names "Split Text **+ Embeddings** component", but the two do not
+form a runnable data pipeline on their own: Split Text emits a chunk DataFrame,
+while an embeddings component (OpenAI Embeddings, the core **Embedding Model**,
+etc.) emits a *model object*, not vectors. They only connect **through a vector
+store**, which is where the chunks actually get embedded and indexed.
+
+Every vector store in Langflow is a **bundle** (`ext:…@official`), not a core
+component — and bundles may in future require explicit installation, which would
+make a bundle-dependent `@stable` test fail on packaging changes rather than on
+real regressions. The only core, non-legacy way to observe embeddings is
+therefore *nonexistent* (the `Text Embedder` that could is `legacy`). So real
+embedding execution is deliberately **out of scope here** and belongs to the
+Vector Store spec (**#674**, §5.2.2 "Indexing in Vector Store") and the full RAG
+pipeline spec (**#675**, §5.2.4), where the bundle dependency is inherent and
+handled with a presence guard. This spec stays on core, bundle-free components
+so it never yields a false failure on a packaging change.
+
+### Why these components
+
+- **Chat Input** is the source: `Text Input` became `legacy` and is hidden from
+  the sidebar, so Chat Input is the current non-legacy `Message` source. Its
+  static `input_value` makes the document deterministic (no upload lifecycle).
+- **Split Text** (`processing/SplitText`, non-legacy, core) is the chunking
+  component under test.
+
+## Validation criterion (concrete, distinctive)
+
+Opening the pre-wired fixture flow and running the Split Text node:
+
+- after `button_run_split text` succeeds (`node_duration_split text` badge), the
+  **Chunks** output inspector (`output-inspection-chunks-splittext`) renders an
+  ag-Grid with **exactly 5 data rows** (`[row-index]` count === 5), and
+  **exactly one** of those rows carries a distinctive verbatim phrase from the
+  ingested document (`embedding vector`) — scoped to the grid, since the
+  document is also echoed in the playground preview.
+
+The document is 5 newline-separated sentences, each 91–97 chars, with
+`Chunk Size = 100` and `Chunk Overlap = 0`; since no adjacent pair fits in 100
+chars, each sentence becomes its own chunk → deterministically 5. A regression
+in the split logic changes the row count; a broken component fails the run — both
+are specific, causal observables, not a vague "the node rendered".
+
+---
+
+## Tags
+
+`@stable` `@release` `@components` `@files`
+
+(`@files`: knowledge-ingestion surface — functional. `@components`:
+canvas-component configuration + `@stable`/`@release` cross-cutting. First-mover
+RAG/§5.2 spec; created `@stable` after deterministic validation on the fresh
+nightly.)
+
+---
+
+## Step by step
+
+One test, one fixture flow (Chat Input → Split Text), imported via the API.
+
+**Setup:** create the fixture flow via `POST /api/v1/flows/` (`createFlow`,
+unique name per run), capture its id for scoped cleanup, navigate to
+`/flow/{id}`, wait for the Split Text node title, then call `adjustScreenView`
+so the node run control is not occluded by the bottom react-flow toolbar panel.
+
+1. Run Split Text: click `button_run_split text`.
+2. Assert the successful build badge `node_duration_split text` is visible
+   (Chat Input builds as its upstream dependency).
+3. Open the Chunks output inspector `output-inspection-chunks-splittext`.
+4. Assert the ag-Grid shows **exactly 5 rows** (`locator('[row-index]')` count
+   === 5) and that **exactly one** row contains the sentinel phrase.
+
+---
+
+## External dependencies
+
+- Fixture asset `tests/assets/flows/split-text-chunking-fixture.json` —
+  Chat Input (`input_value` = the 5-line sentinel document) →
+  Split Text (`chunk_size = 100`, `chunk_overlap = 0`, `separator = "\n"`).
+  Built and validated on 1.11.0.dev38.
+- Component/UI testids (scouted live on 1.11.0.dev38):
+  `title-Split Text`, `button_run_split text`, `node_duration_split text`,
+  `output-inspection-chunks-splittext`; chunk rows via `[row-index]`.
+- Flows API: `POST /api/v1/flows/` (fixture create), `DELETE /api/v1/flows/{id}`
+  (scoped cleanup).
+- No model provider credentials required (pure text split, no LLM/embeddings).
+
+---
+
+## What this test does not cover
+
+- Embedding the chunks / vector-store indexing (§5.2.2 — #674, requires a
+  bundle vector store).
+- Vector-store query / relevant-chunk retrieval (§5.2.3 — #674).
+- The complete RAG pipeline with an LLM answer (§5.2.4 — #675).
+- File upload as the document source (§5.1 — `upload-via-component.spec.ts`,
+  `file-types-upload.spec.ts`); this spec sources the document from Chat Input
+  to stay hermetic.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` (auto_login).
+
+---
+
+## Flow cleanup
+
+The fixture flow is created via the API, so its id is known up front. The test
+records the created id and deletes exactly that flow in `afterEach`
+(`deleteFlow`, 404-tolerant, scoped — never a global `cleanAllFlows`, which
+wipes flows other parallel workers are building, #515). No files are uploaded,
+so there is no file-store artifact to clean. Orphan count is checked via
+`GET /api/v1/flows/` before reporting.

--- a/tests/assets/flows/split-text-chunking-fixture.json
+++ b/tests/assets/flows/split-text-chunking-fixture.json
@@ -1,0 +1,593 @@
+{
+  "name": "Split Text Chunking",
+  "description": "Chunking fixture: Chat Input -> Split Text. §5.2.1 (processing).",
+  "data": {
+    "nodes": [
+      {
+        "data": {
+          "id": "ChatInput-doc01",
+          "node": {
+            "base_classes": [
+              "Message"
+            ],
+            "beta": false,
+            "conditional_paths": [],
+            "custom_fields": {},
+            "description": "Get chat inputs from the Playground.",
+            "display_name": "Chat Input",
+            "documentation": "",
+            "edited": false,
+            "field_order": [
+              "input_value",
+              "should_store_message",
+              "sender",
+              "sender_name",
+              "session_id",
+              "context_id",
+              "files"
+            ],
+            "frozen": false,
+            "icon": "MessagesSquare",
+            "legacy": false,
+            "lf_version": "1.6.0",
+            "metadata": {
+              "module": "lfx.components.input_output.chat.ChatInput",
+              "code_hash": "7a26c54d89ed",
+              "dependencies": {
+                "total_dependencies": 1,
+                "dependencies": [
+                  {
+                    "name": "lfx",
+                    "version": "1.11.0.dev38"
+                  }
+                ]
+              }
+            },
+            "minimized": true,
+            "output_types": [],
+            "outputs": [
+              {
+                "types": [
+                  "Message"
+                ],
+                "selected": "Message",
+                "name": "message",
+                "display_name": "Chat Message",
+                "method": "message_response",
+                "value": "__UNDEFINED__",
+                "cache": true,
+                "allows_loop": false,
+                "group_outputs": false,
+                "tool_mode": true
+              }
+            ],
+            "pinned": false,
+            "template": {
+              "_type": "Component",
+              "code": {
+                "type": "code",
+                "required": true,
+                "placeholder": "",
+                "list": false,
+                "show": true,
+                "multiline": true,
+                "value": "from lfx.base.data.utils import IMG_FILE_TYPES, TEXT_FILE_TYPES\nfrom lfx.base.io.chat import ChatComponent\nfrom lfx.inputs.inputs import BoolInput\nfrom lfx.io import (\n    DropdownInput,\n    FileInput,\n    MessageTextInput,\n    MultilineInput,\n    Output,\n)\nfrom lfx.schema.message import Message\nfrom lfx.utils.constants import (\n    MESSAGE_SENDER_AI,\n    MESSAGE_SENDER_NAME_USER,\n    MESSAGE_SENDER_USER,\n)\n\n\nclass ChatInput(ChatComponent):\n    display_name = \"Chat Input\"\n    description = \"Get chat inputs from the Playground.\"\n    documentation: str = \"https://docs.langflow.org/chat-input-and-output\"\n    icon = \"MessagesSquare\"\n    name = \"ChatInput\"\n    minimized = True\n\n    inputs = [\n        MultilineInput(\n            name=\"input_value\",\n            display_name=\"Input Text\",\n            value=\"\",\n            info=\"Message to be passed as input.\",\n            input_types=[],\n        ),\n        BoolInput(\n            name=\"should_store_message\",\n            display_name=\"Store Messages\",\n            info=\"Store the message in the history.\",\n            value=True,\n            advanced=True,\n        ),\n        DropdownInput(\n            name=\"sender\",\n            display_name=\"Sender Type\",\n            options=[MESSAGE_SENDER_AI, MESSAGE_SENDER_USER],\n            value=MESSAGE_SENDER_USER,\n            info=\"Type of sender.\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"sender_name\",\n            display_name=\"Sender Name\",\n            info=\"Name of the sender.\",\n            value=MESSAGE_SENDER_NAME_USER,\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"session_id\",\n            display_name=\"Session ID\",\n            info=\"The session ID of the chat. If empty, the current session ID parameter will be used.\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"context_id\",\n            display_name=\"Context ID\",\n            info=\"The context ID of the chat. Adds an extra layer to the local memory.\",\n            value=\"\",\n            advanced=True,\n        ),\n        FileInput(\n            name=\"files\",\n            display_name=\"Files\",\n            file_types=TEXT_FILE_TYPES + IMG_FILE_TYPES,\n            info=\"Files to be sent with the message.\",\n            advanced=True,\n            is_list=True,\n            temp_file=True,\n        ),\n    ]\n    outputs = [\n        Output(display_name=\"Chat Message\", name=\"message\", method=\"message_response\"),\n    ]\n\n    async def message_response(self) -> Message:\n        # Ensure files is a list and filter out empty/None values\n        files = self.files if self.files else []\n        if files and not isinstance(files, list):\n            files = [files]\n        # Filter out None/empty values\n        files = [f for f in files if f is not None and f != \"\"]\n\n        session_id = self.session_id or self.graph.session_id or \"\"\n        message = await Message.create(\n            text=self.input_value,\n            sender=self.sender,\n            sender_name=self.sender_name,\n            session_id=session_id,\n            context_id=self.context_id,\n            files=files,\n        )\n        if session_id and isinstance(message, Message) and self.should_store_message:\n            stored_message = await self.send_message(\n                message,\n            )\n            self.message.value = stored_message\n            message = stored_message\n\n        self.status = message\n        return message\n",
+                "fileTypes": [],
+                "file_path": "",
+                "password": false,
+                "name": "code",
+                "advanced": true,
+                "dynamic": true,
+                "info": "",
+                "load_from_db": false,
+                "title_case": false
+              },
+              "context_id": {
+                "_input_type": "MessageTextInput",
+                "advanced": true,
+                "display_name": "Context ID",
+                "dynamic": false,
+                "info": "The context ID of the chat. Adds an extra layer to the local memory.",
+                "input_types": [
+                  "Message"
+                ],
+                "list": false,
+                "list_add_label": "Add More",
+                "load_from_db": false,
+                "name": "context_id",
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "type": "str",
+                "value": ""
+              },
+              "files": {
+                "_input_type": "FileInput",
+                "advanced": true,
+                "display_name": "Files",
+                "dynamic": false,
+                "fileTypes": [
+                  "csv",
+                  "json",
+                  "pdf",
+                  "txt",
+                  "md",
+                  "mdx",
+                  "yaml",
+                  "yml",
+                  "xml",
+                  "html",
+                  "htm",
+                  "docx",
+                  "py",
+                  "sh",
+                  "sql",
+                  "js",
+                  "ts",
+                  "tsx",
+                  "jpg",
+                  "jpeg",
+                  "png",
+                  "bmp",
+                  "image"
+                ],
+                "file_path": "",
+                "info": "Files to be sent with the message.",
+                "list": true,
+                "list_add_label": "Add More",
+                "name": "files",
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "temp_file": true,
+                "title_case": false,
+                "trace_as_metadata": true,
+                "type": "file",
+                "value": ""
+              },
+              "input_value": {
+                "_input_type": "MultilineInput",
+                "advanced": false,
+                "copy_field": false,
+                "display_name": "Input Text",
+                "dynamic": false,
+                "info": "Message to be passed as input.",
+                "input_types": [],
+                "list": false,
+                "list_add_label": "Add More",
+                "load_from_db": false,
+                "multiline": true,
+                "name": "input_value",
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "type": "str",
+                "value": "Langflow lets you build agentic pipelines by wiring visual components together on a canvas.\nThe Split Text component divides an ingested document into smaller overlapping textual chunks.\nEach chunk is then converted into a numerical embedding vector by an embeddings model provider.\nThose embeddings are indexed inside a vector store so semantically similar text can be retrieved.\nA retrieval augmented generation flow finally grounds the language model answer on those chunks."
+              },
+              "sender": {
+                "_input_type": "DropdownInput",
+                "advanced": true,
+                "combobox": false,
+                "dialog_inputs": {},
+                "display_name": "Sender Type",
+                "dynamic": false,
+                "info": "Type of sender.",
+                "name": "sender",
+                "options": [
+                  "Machine",
+                  "User"
+                ],
+                "options_metadata": [],
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "type": "str",
+                "value": "User"
+              },
+              "sender_name": {
+                "_input_type": "MessageTextInput",
+                "advanced": true,
+                "display_name": "Sender Name",
+                "dynamic": false,
+                "info": "Name of the sender.",
+                "input_types": [
+                  "Message"
+                ],
+                "list": false,
+                "list_add_label": "Add More",
+                "load_from_db": false,
+                "name": "sender_name",
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "type": "str",
+                "value": "User"
+              },
+              "session_id": {
+                "_input_type": "MessageTextInput",
+                "advanced": true,
+                "display_name": "Session ID",
+                "dynamic": false,
+                "info": "The session ID of the chat. If empty, the current session ID parameter will be used.",
+                "input_types": [
+                  "Message"
+                ],
+                "list": false,
+                "list_add_label": "Add More",
+                "load_from_db": false,
+                "name": "session_id",
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "type": "str",
+                "value": ""
+              },
+              "should_store_message": {
+                "_input_type": "BoolInput",
+                "advanced": true,
+                "display_name": "Store Messages",
+                "dynamic": false,
+                "info": "Store the message in the history.",
+                "list": false,
+                "list_add_label": "Add More",
+                "name": "should_store_message",
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "type": "bool",
+                "value": true
+              }
+            },
+            "tool_mode": false
+          },
+          "selected_output": "message",
+          "showNode": false,
+          "type": "ChatInput"
+        },
+        "dragging": false,
+        "id": "ChatInput-doc01",
+        "measured": {
+          "height": 52,
+          "width": 192
+        },
+        "position": {
+          "x": 100,
+          "y": 200
+        },
+        "positionAbsolute": {
+          "x": 420,
+          "y": 760
+        },
+        "selected": false,
+        "type": "genericNode"
+      },
+      {
+        "id": "SplitText-doc01",
+        "type": "genericNode",
+        "position": {
+          "x": 600,
+          "y": 200
+        },
+        "data": {
+          "node": {
+            "template": {
+              "_type": "Component",
+              "data_inputs": {
+                "trace_as_metadata": true,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": true,
+                "placeholder": "",
+                "show": true,
+                "name": "data_inputs",
+                "value": "",
+                "display_name": "Input",
+                "advanced": false,
+                "input_types": [
+                  "Data",
+                  "JSON",
+                  "DataFrame",
+                  "Table",
+                  "Message"
+                ],
+                "dynamic": false,
+                "info": "The data with texts to split in chunks.",
+                "title_case": false,
+                "track_in_telemetry": false,
+                "type": "other",
+                "_input_type": "HandleInput"
+              },
+              "chunk_overlap": {
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "chunk_overlap",
+                "value": 0,
+                "display_name": "Chunk Overlap",
+                "advanced": false,
+                "dynamic": false,
+                "info": "Number of characters to overlap between chunks.",
+                "title_case": false,
+                "track_in_telemetry": true,
+                "type": "int",
+                "_input_type": "IntInput"
+              },
+              "chunk_size": {
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "chunk_size",
+                "value": 100,
+                "display_name": "Chunk Size",
+                "advanced": false,
+                "dynamic": false,
+                "info": "The maximum length of each chunk. Text is first split by separator, then chunks are merged up to this size. Individual splits larger than this won't be further divided.",
+                "title_case": false,
+                "track_in_telemetry": true,
+                "type": "int",
+                "_input_type": "IntInput"
+              },
+              "clean_output": {
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "clean_output",
+                "value": false,
+                "display_name": "Clean Output",
+                "advanced": true,
+                "dynamic": false,
+                "info": "When enabled, only the text column is included in the output. Metadata columns are removed.",
+                "title_case": false,
+                "track_in_telemetry": true,
+                "type": "bool",
+                "_input_type": "BoolInput"
+              },
+              "code": {
+                "type": "code",
+                "required": true,
+                "placeholder": "",
+                "list": false,
+                "show": true,
+                "multiline": true,
+                "value": "from langchain_text_splitters import CharacterTextSplitter\n\nfrom lfx.custom.custom_component.component import Component\nfrom lfx.io import BoolInput, DropdownInput, HandleInput, IntInput, MessageTextInput, Output\nfrom lfx.schema.data import Data\nfrom lfx.schema.dataframe import DataFrame\nfrom lfx.schema.message import Message\nfrom lfx.utils.util import unescape_string\n\n\nclass SplitTextComponent(Component):\n    display_name: str = \"Split Text\"\n    description: str = \"Split text into chunks based on specified criteria.\"\n    documentation: str = \"https://docs.langflow.org/split-text\"\n    icon = \"scissors-line-dashed\"\n    name = \"SplitText\"\n\n    inputs = [\n        HandleInput(\n            name=\"data_inputs\",\n            display_name=\"Input\",\n            info=\"The data with texts to split in chunks.\",\n            input_types=[\"Data\", \"JSON\", \"DataFrame\", \"Table\", \"Message\"],\n            required=True,\n        ),\n        IntInput(\n            name=\"chunk_overlap\",\n            display_name=\"Chunk Overlap\",\n            info=\"Number of characters to overlap between chunks.\",\n            value=200,\n        ),\n        IntInput(\n            name=\"chunk_size\",\n            display_name=\"Chunk Size\",\n            info=(\n                \"The maximum length of each chunk. Text is first split by separator, \"\n                \"then chunks are merged up to this size. \"\n                \"Individual splits larger than this won't be further divided.\"\n            ),\n            value=1000,\n        ),\n        MessageTextInput(\n            name=\"separator\",\n            display_name=\"Separator\",\n            info=(\n                \"The character to split on. Use \\\\n for newline. \"\n                \"Examples: \\\\n\\\\n for paragraphs, \\\\n for lines, . for sentences\"\n            ),\n            value=\"\\n\",\n        ),\n        MessageTextInput(\n            name=\"text_key\",\n            display_name=\"Text Key\",\n            info=\"The key to use for the text column.\",\n            value=\"text\",\n            advanced=True,\n        ),\n        DropdownInput(\n            name=\"keep_separator\",\n            display_name=\"Keep Separator\",\n            info=\"Whether to keep the separator in the output chunks and where to place it.\",\n            options=[\"False\", \"True\", \"Start\", \"End\"],\n            value=\"False\",\n            advanced=True,\n        ),\n        BoolInput(\n            name=\"clean_output\",\n            display_name=\"Clean Output\",\n            info=\"When enabled, only the text column is included in the output. Metadata columns are removed.\",\n            value=False,\n            advanced=True,\n        ),\n    ]\n\n    outputs = [\n        Output(display_name=\"Chunks\", name=\"dataframe\", method=\"split_text\"),\n    ]\n\n    def _docs_to_data(self, docs, *, clean: bool = False) -> list[Data]:\n        return [\n            Data(text=doc.page_content) if clean else Data(text=doc.page_content, data=doc.metadata) for doc in docs\n        ]\n\n    def _fix_separator(self, separator: str) -> str:\n        \"\"\"Fix common separator issues and convert to proper format.\"\"\"\n        if separator == \"/n\":\n            return \"\\n\"\n        if separator == \"/t\":\n            return \"\\t\"\n        return separator\n\n    def split_text_base(self):\n        separator = self._fix_separator(self.separator)\n        separator = unescape_string(separator)\n\n        if isinstance(self.data_inputs, DataFrame):\n            if not len(self.data_inputs):\n                msg = \"DataFrame is empty\"\n                raise TypeError(msg)\n\n            self.data_inputs.text_key = self.text_key\n            try:\n                documents = self.data_inputs.to_lc_documents()\n            except Exception as e:\n                msg = f\"Error converting DataFrame to documents: {e}\"\n                raise TypeError(msg) from e\n        elif isinstance(self.data_inputs, Message):\n            self.data_inputs = [self.data_inputs.to_data()]\n            return self.split_text_base()\n        else:\n            if not self.data_inputs:\n                msg = \"No data inputs provided\"\n                raise TypeError(msg)\n\n            documents = []\n            if isinstance(self.data_inputs, Data):\n                self.data_inputs.text_key = self.text_key\n                documents = [self.data_inputs.to_lc_document()]\n            else:\n                try:\n                    documents = [input_.to_lc_document() for input_ in self.data_inputs if isinstance(input_, Data)]\n                    if not documents:\n                        msg = f\"No valid Data inputs found in {type(self.data_inputs)}\"\n                        raise TypeError(msg)\n                except AttributeError as e:\n                    msg = f\"Invalid input type in collection: {e}\"\n                    raise TypeError(msg) from e\n        try:\n            # Convert string 'False'/'True' to boolean\n            keep_sep = self.keep_separator\n            if isinstance(keep_sep, str):\n                if keep_sep.lower() == \"false\":\n                    keep_sep = False\n                elif keep_sep.lower() == \"true\":\n                    keep_sep = True\n                # 'start' and 'end' are kept as strings\n\n            splitter = CharacterTextSplitter(\n                chunk_overlap=self.chunk_overlap,\n                chunk_size=self.chunk_size,\n                separator=separator,\n                keep_separator=keep_sep,\n            )\n            return splitter.split_documents(documents)\n        except Exception as e:\n            msg = f\"Error splitting text: {e}\"\n            raise TypeError(msg) from e\n\n    def split_text(self) -> DataFrame:\n        docs = self.split_text_base()\n        df = DataFrame(self._docs_to_data(docs, clean=self.clean_output))\n        return df if self.clean_output else df.smart_column_order()\n",
+                "fileTypes": [],
+                "file_path": "",
+                "password": false,
+                "name": "code",
+                "advanced": true,
+                "dynamic": true,
+                "info": "",
+                "load_from_db": false,
+                "title_case": false
+              },
+              "keep_separator": {
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "options": [
+                  "False",
+                  "True",
+                  "Start",
+                  "End"
+                ],
+                "options_metadata": [],
+                "combobox": false,
+                "dialog_inputs": {},
+                "toggle": false,
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "keep_separator",
+                "value": "False",
+                "display_name": "Keep Separator",
+                "advanced": true,
+                "dynamic": false,
+                "info": "Whether to keep the separator in the output chunks and where to place it.",
+                "title_case": false,
+                "track_in_telemetry": true,
+                "external_options": {},
+                "type": "str",
+                "_input_type": "DropdownInput"
+              },
+              "separator": {
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "load_from_db": false,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "separator",
+                "value": "\n",
+                "display_name": "Separator",
+                "advanced": false,
+                "input_types": [
+                  "Message"
+                ],
+                "dynamic": false,
+                "info": "The character to split on. Use \\n for newline. Examples: \\n\\n for paragraphs, \\n for lines, . for sentences",
+                "title_case": false,
+                "track_in_telemetry": false,
+                "type": "str",
+                "_input_type": "MessageTextInput"
+              },
+              "text_key": {
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "load_from_db": false,
+                "list": false,
+                "list_add_label": "Add More",
+                "override_skip": false,
+                "required": false,
+                "placeholder": "",
+                "show": true,
+                "name": "text_key",
+                "value": "text",
+                "display_name": "Text Key",
+                "advanced": true,
+                "input_types": [
+                  "Message"
+                ],
+                "dynamic": false,
+                "info": "The key to use for the text column.",
+                "title_case": false,
+                "track_in_telemetry": false,
+                "type": "str",
+                "_input_type": "MessageTextInput"
+              }
+            },
+            "description": "Split text into chunks based on specified criteria.",
+            "icon": "scissors-line-dashed",
+            "base_classes": [
+              "Table"
+            ],
+            "display_name": "Split Text",
+            "documentation": "https://docs.langflow.org/split-text",
+            "minimized": false,
+            "custom_fields": {},
+            "output_types": [],
+            "pinned": false,
+            "conditional_paths": [],
+            "frozen": false,
+            "outputs": [
+              {
+                "types": [
+                  "Table"
+                ],
+                "selected": "Table",
+                "name": "dataframe",
+                "display_name": "Chunks",
+                "method": "split_text",
+                "value": "__UNDEFINED__",
+                "cache": true,
+                "allows_loop": false,
+                "group_outputs": false,
+                "tool_mode": true
+              }
+            ],
+            "field_order": [
+              "data_inputs",
+              "chunk_overlap",
+              "chunk_size",
+              "separator",
+              "text_key",
+              "keep_separator",
+              "clean_output"
+            ],
+            "beta": false,
+            "legacy": false,
+            "edited": false,
+            "metadata": {
+              "module": "lfx.components.processing.split_text.SplitTextComponent",
+              "code_hash": "859adebdf672",
+              "dependencies": {
+                "total_dependencies": 2,
+                "dependencies": [
+                  {
+                    "name": "langchain_text_splitters",
+                    "version": "1.1.2"
+                  },
+                  {
+                    "name": "lfx",
+                    "version": "1.11.0.dev38"
+                  }
+                ]
+              }
+            },
+            "tool_mode": false
+          },
+          "showNode": true,
+          "type": "SplitText",
+          "id": "SplitText-doc01"
+        },
+        "selected": false,
+        "measured": {
+          "width": 320,
+          "height": 415
+        }
+      }
+    ],
+    "edges": [
+      {
+        "source": "ChatInput-doc01",
+        "target": "SplitText-doc01",
+        "sourceHandle": "{œdataTypeœ: œChatInputœ, œidœ: œChatInput-doc01œ, œnameœ: œmessageœ, œoutput_typesœ: [œMessageœ]}",
+        "targetHandle": "{œfieldNameœ: œdata_inputsœ, œidœ: œSplitText-doc01œ, œinputTypesœ: [œDataœ, œJSONœ, œDataFrameœ, œTableœ, œMessageœ], œtypeœ: œotherœ}",
+        "data": {
+          "sourceHandle": {
+            "dataType": "ChatInput",
+            "id": "ChatInput-doc01",
+            "name": "message",
+            "output_types": [
+              "Message"
+            ]
+          },
+          "targetHandle": {
+            "fieldName": "data_inputs",
+            "id": "SplitText-doc01",
+            "inputTypes": [
+              "Data",
+              "JSON",
+              "DataFrame",
+              "Table",
+              "Message"
+            ],
+            "type": "other"
+          }
+        },
+        "id": "reactflow__edge-ChatInput-doc01-SplitText-doc01",
+        "animated": false,
+        "className": "",
+        "selected": false
+      }
+    ],
+    "viewport": {
+      "x": 0,
+      "y": 0,
+      "zoom": 1
+    }
+  },
+  "is_component": false
+}

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/split-text-chunking.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/split-text-chunking.spec.ts
@@ -1,0 +1,127 @@
+import { readFileSync } from "fs";
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { createFlow } from "../../../../helpers/flows/create-flow";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
+
+// §5.2.1 — the *processing* step of RAG ingestion: a document (delivered by
+// Chat Input) is split into chunks by Split Text. Embedding the chunks requires
+// a vector store (all of which are bundles, not core) and is covered by the
+// Vector Store spec (#674, §5.2.2) — it is deliberately out of scope here so
+// this spec stays on core, non-legacy, bundle-free components. Spec doc:
+// docs/core-functionality/knowledge-ingestion-management/split-text-chunking.md
+
+// Pre-wired fixture flow: Chat Input(input_value = the 5-line sentinel doc) ->
+// Split Text(chunk_size=100, chunk_overlap=0, separator="\n"). Built and
+// validated live on 1.11.0.dev38.
+const FIXTURE_PATH = "tests/assets/flows/split-text-chunking-fixture.json";
+
+// The document is 5 newline-separated sentences, each 91–97 chars, with
+// Chunk Size 100 / Overlap 0. No adjacent pair fits in 100 chars, so each
+// sentence becomes its own chunk → deterministically 5 chunks.
+const EXPECTED_CHUNKS = 5;
+
+// A distinctive phrase that lives inside exactly one chunk, so the grid match
+// cannot be coincidental (it is verbatim text from the ingested document).
+const CHUNK_SENTINEL = "embedding vector";
+
+// Ids of the flows each test creates; teardown deletes only these via the API
+// (scoped) — never a global cleanAllFlows, which wipes flows other parallel
+// workers are actively building mid-run (#515).
+const createdFlowIds: string[] = [];
+
+// Named flows created via the API race on unique-name suffixing under
+// parallelism; run the file serially (same rationale as the sibling
+// core-components specs).
+test.describe.configure({ mode: "serial" });
+
+/**
+ * Creates the chunking fixture flow via the API (unique name per run) and opens
+ * it on the canvas, ready for a node run. The created id is pushed to
+ * `createdFlowIds` for scoped teardown.
+ */
+async function openChunkingFlow(page: Page): Promise<void> {
+  const fixture = JSON.parse(readFileSync(FIXTURE_PATH, "utf-8"));
+  const authHeader = await getAuthToken(page.request);
+  const headers: Record<string, string> = authHeader
+    ? { Authorization: authHeader }
+    : {};
+
+  const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+  const flowId = await createFlow(
+    page.request,
+    {
+      name: `Split Text Chunking ${uniqueSuffix}`,
+      description: fixture.description,
+      data: fixture.data,
+      is_component: false,
+    },
+    { headers },
+  );
+  createdFlowIds.push(flowId);
+
+  await page.goto(`/flow/${flowId}`);
+  // The imported flow loads with its nodes wired; wait for the canvas to render
+  // the Split Text node before interacting.
+  await expect(page.getByTestId("title-Split Text")).toBeVisible({
+    timeout: 30000,
+  });
+
+  // Fit the view so the node run controls are not occluded by the bottom
+  // react-flow toolbar panel (which intercepts the run-button click otherwise).
+  await adjustScreenView(page);
+}
+
+test.afterEach(async ({ page }) => {
+  const ids = createdFlowIds.splice(0);
+  if (ids.length === 0) return;
+  // Navigate off the editor first so the unmounted flow page stops polling a
+  // flow we are about to delete, then pass an explicit auth header —
+  // page.request is unauthenticated under AUTO_LOGIN and would 401 otherwise.
+  await page.goto("/");
+  const authHeader = await getAuthToken(page.request);
+  const opts = authHeader
+    ? { headers: { Authorization: authHeader } }
+    : undefined;
+  for (const id of ids) {
+    await deleteFlow(page.request, id, opts);
+  }
+});
+
+test(
+  "Split Text splits an ingested document into the expected number of chunks",
+  { tag: ["@stable", "@release", "@components", "@files"] },
+  async ({ page }) => {
+    await test.step("open the pre-wired chunking fixture flow", async () => {
+      await openChunkingFlow(page);
+    });
+
+    await test.step("run the Split Text component", async () => {
+      await page.getByTestId("button_run_split text").click({ timeout: 15000 });
+      // Successful build badge — the deterministic completion signal (Chat Input
+      // builds too, as the upstream dependency).
+      await expect(page.getByTestId("node_duration_split text")).toBeVisible({
+        timeout: 60000,
+      });
+    });
+
+    await test.step("the Chunks output holds exactly the expected chunks", async () => {
+      await page.getByTestId("output-inspection-chunks-splittext").click();
+      // The Chunks DataFrame renders as an ag-Grid; each chunk is one data row
+      // (carrying a `row-index`) inside the grid's center-columns viewport.
+      // Scope to that viewport so the count cannot be inflated by any other row
+      // element on the page (e.g. the playground preview). Exactly 5 rows for
+      // this document + chunk size.
+      const chunkRows = page.locator(".ag-center-cols-container [row-index]");
+      await expect(chunkRows).toHaveCount(EXPECTED_CHUNKS, { timeout: 15000 });
+      // Exactly one chunk row carries this verbatim phrase from the document,
+      // proving the rows are the real chunks.
+      await expect(chunkRows.filter({ hasText: CHUNK_SENTINEL })).toHaveCount(
+        1,
+        { timeout: 15000 },
+      );
+    });
+  },
+);


### PR DESCRIPTION
Closes #673.

Closes the `[ ] Document ingestion via Split Text + Embeddings component` gap in `QA-CHECKLIST.md` §5.2 (Processing and Vectorization). First-mover RAG/§5.2 spec — distinct from the §5.1 upload specs (which cover getting a file *in*); this covers the *processing* step (chunking) of ingestion.

**Scope note (deliberate):** the bullet names "Split Text **+ Embeddings**", but the two only form a runnable pipeline *through a vector store*, and every vector store in Langflow is a **bundle** (`ext:…@official`), not core — a bundle-dependent `@stable` test would fail on packaging changes, not real regressions (the only core-observable path, `Text Embedder`, is `legacy`). So real embedding execution is kept on the Vector Store / RAG specs (#674 §5.2.2, #675 §5.2.4), where the bundle dependency is inherent and guarded. This spec stays on core, bundle-free components. Design notes for the embeddings work were added as a comment on #674.

## 1. Covered tests
| # | Test | What it validates |
|---|------|-------------------|
| 1 | `Split Text splits an ingested document into the expected number of chunks` | Running Split Text on a known document (5 sentences, `chunk_size=100`/`overlap=0`) produces **exactly 5 chunks** in the Chunks ag-Grid, with **exactly one** row carrying a verbatim document phrase (`embedding vector`). A regression in the split logic changes the row count; a broken component fails the run. |

## 2. How the test was built
- **Setup:** a pre-wired fixture flow (`Chat Input → Split Text`) is created via `POST /api/v1/flows/` (`createFlow`, unique name per run) and opened at `/flow/{id}`; `adjustScreenView` fits the graph so the node run control is not occluded by the bottom react-flow toolbar. Chat Input is the source because `Text Input` is now `legacy`/hidden; its static `input_value` keeps the document deterministic (no upload lifecycle).
- **Live-confirmed selectors (scouted on 1.11.0.dev38):** `title-Split Text`, `button_run_split text`, `node_duration_split text`, `output-inspection-chunks-splittext`; chunk rows read from `.ag-center-cols-container [row-index]` (scoped to the grid so no other page row element can inflate the count).
- **Assertion rationale:** the exact chunk count is deterministic (no adjacent sentence pair fits in 100 chars → each becomes its own chunk = 5); the verbatim-phrase row makes the match non-coincidental.

## 3. Dependencies
- None — pure UI text split, no LLM/provider/API key.
- Execution mode: `--workers=1` serial (`test.describe.configure({ mode: "serial" })`) — API-created named flows race on unique-name suffixing under parallelism.
- Scoped `afterEach` cleanup (`deleteFlow` by captured id; never `cleanAllFlows`, #515).

## Validation (nightly 1.11.0.dev38, `--retries=0`)
- `npm run typecheck` ✅ · `npm run lint` ✅ (no warnings)
- 4 clean serial runs, no flake ✅ (~4–5s each)
- force-fail ✅ (`EXPECTED_CHUNKS` 5→6 → `toHaveCount` fails: Expected 6, Received 5)
- zero `🚨 Backend Error` ✅ · 0 orphan flows after runs ✅
- independent code-review run; the one robustness finding (unscoped `[row-index]`) was applied (now scoped to `.ag-center-cols-container`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
