### PR TITLE
chore(stable): quarantine @stable on specs broken by 2026-07-14 daily (#744)

### DIFF
--- a/tests/tests-automations/regression/core-components/customComponentAdd.spec.ts
+++ b/tests/tests-automations/regression/core-components/customComponentAdd.spec.ts
@@ -3,7 +3,7 @@ import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test"
 
 test(
   "custom component code button should be pink when adding custom component",
-  { tag: ["@release", "@components", "@stable"] },
+  { tag: ["@release", "@components"] },
 
   async ({ page }) => {
     await awaitBootstrapTest(page);

--- a/tests/tests-automations/regression/core-components/edit-name-description-node.spec.ts
+++ b/tests/tests-automations/regression/core-components/edit-name-description-node.spec.ts
@@ -44,7 +44,7 @@ test.afterEach(async ({ request }) => {
 
 test(
   "user should be able to edit name and description of a node",
-  { tag: ["@stable", "@release", "@workspace", "@components"] },
+  { tag: ["@release", "@workspace", "@components"] },
 
   async ({ page }) => {
     trackCreatedFlows(page);
@@ -162,7 +162,7 @@ test(
 
 test(
   "user should be able to edit name and description of a node with inspect panel disabled",
-  { tag: ["@stable", "@release", "@workspace", "@components"] },
+  { tag: ["@release", "@workspace", "@components"] },
 
   async ({ page }) => {
     trackCreatedFlows(page);

--- a/tests/tests-automations/regression/core-components/general-bugs-delete-handle-advanced-input.spec.ts
+++ b/tests/tests-automations/regression/core-components/general-bugs-delete-handle-advanced-input.spec.ts
@@ -10,7 +10,7 @@ import {
 
 test(
   "the system must delete the handles from advanced fields when the code is updated",
-  { tag: ["@stable", "@release", "@components"] },
+  { tag: ["@release", "@components"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 

--- a/tests/tests-automations/regression/core-components/tool-mode.spec.ts
+++ b/tests/tests-automations/regression/core-components/tool-mode.spec.ts
@@ -4,7 +4,7 @@ import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 
 test(
   "User should be able to use components as tool",
-  { tag: ["@release", "@stable", "@components"] },
+  { tag: ["@release", "@components"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
     await page.getByTestId("blank-flow").click();

--- a/tests/tests-automations/regression/core-functionality/llm-agents/language-model-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/language-model-regression.spec.ts
@@ -129,7 +129,7 @@ test.describe("Language Model Component Regression", () => {
 
   test(
     "language model must respond with Google provider",
-    { tag: ["@stable", "@release", "@components", "@model-provider"] },
+    { tag: ["@release", "@components", "@model-provider"] },
     async ({ page }) => {
       test.skip(
         !process?.env?.GOOGLE_API_KEY,

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-delete-cascade.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-delete-cascade.spec.ts
@@ -156,7 +156,7 @@ test.describe("Clear traces with a populated span tree (regression #13955)", () 
 
   test(
     "Clearing traces for a flow whose trace has spans succeeds (cascade), leaving no traces behind",
-    { tag: ["@stable", "@release", "@regression", "@api", "@observability"] },
+    { tag: ["@release", "@regression", "@api", "@observability"] },
     async ({ request }) => {
       // Anchor: the seeded trace MUST have spans before DELETE. This is what
       // distinguishes the cascade path from the plain bulk-delete contract test.

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-delete.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-delete.spec.ts
@@ -142,7 +142,7 @@ test.describe("Bulk delete traces — seeded flow", () => {
 
   test(
     "DELETE /api/v1/monitor/traces?flow_id=... clears all traces, and a second DELETE on the empty owned flow still returns 204",
-    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
+    { tag: ["@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       // Anchor: the seeded flow MUST have traces before DELETE. Without this,
       // a post-DELETE empty envelope could come from a degraded GET (the

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-llm-span-populated.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-llm-span-populated.spec.ts
@@ -173,7 +173,7 @@ test.describe("Single trace — populated LLM span (OpenAI)", () => {
 
   test(
     "GET /api/v1/monitor/traces/{trace_id} returns a populated tokenUsage + modelName on the LLM span",
-    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
+    { tag: ["@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       const res = await request.get(`/api/v1/monitor/traces/${traceId}`, {
         headers: { Authorization: bearerToken },

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-single.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-single.spec.ts
@@ -154,7 +154,7 @@ test.describe("Single trace shape — seeded flow", () => {
 
   test(
     "GET /api/v1/monitor/traces/{trace_id} returns the full TraceRead contract with a non-empty span tree",
-    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
+    { tag: ["@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       const res = await request.get(`/api/v1/monitor/traces/${traceId}`, {
         headers: { Authorization: bearerToken },

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail.spec.ts
@@ -153,7 +153,7 @@ test.describe("Transaction record shape — seeded flow", () => {
 
   test(
     "transaction records contain required fields when not empty",
-    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
+    { tag: ["@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       const res = await request.get(
         `/api/v1/monitor/transactions?flow_id=${flowId}`,

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-latency-tokens.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-latency-tokens.spec.ts
@@ -95,7 +95,7 @@ test.describe("Flow Activity / Traces — latency and tokens", () => {
   test(
     "GET /api/v1/monitor/traces returns totalLatencyMs and totalTokens for a flow run",
     {
-      tag: ["@stable", "@release", "@api", "@regression", "@observability"],
+      tag: ["@release", "@api", "@regression", "@observability"],
     },
     async ({ request }) => {
       const res = await request.get(
@@ -125,7 +125,6 @@ test.describe("Flow Activity / Traces — latency and tokens", () => {
     "Flow Activity page shows latency and token columns for the run",
     {
       tag: [
-        "@stable",
         "@release",
         "@workspace",
         "@regression",
@@ -170,7 +169,6 @@ test.describe("Flow Activity / Traces — latency and tokens", () => {
     "Trace Details modal shows span tree and per-span latency",
     {
       tag: [
-        "@stable",
         "@release",
         "@workspace",
         "@regression",

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-list-filters.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-list-filters.spec.ts
@@ -184,7 +184,7 @@ test.describe("Trace list filters — status / start_time / query / session_id",
 
   test(
     "GET /api/v1/monitor/traces?status=error returns only the failing trace; rejects unknown values",
-    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
+    { tag: ["@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       const matchRes = await request.get(
         `/api/v1/monitor/traces?flow_id=${errorFlowId}&status=error`,
@@ -219,7 +219,7 @@ test.describe("Trace list filters — status / start_time / query / session_id",
 
   test(
     "GET /api/v1/monitor/traces?status=ok returns only the successful trace",
-    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
+    { tag: ["@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       const matchRes = await request.get(
         `/api/v1/monitor/traces?flow_id=${okFlowId}&status=ok`,
@@ -245,7 +245,7 @@ test.describe("Trace list filters — status / start_time / query / session_id",
 
   test(
     "GET /api/v1/monitor/traces?start_time pins the >= lower bound",
-    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
+    { tag: ["@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       // Past cutoff: every seeded trace satisfies start_time >= past, so a
       // handler that flipped the comparator to <= would return 0 here. This
@@ -277,7 +277,7 @@ test.describe("Trace list filters — status / start_time / query / session_id",
 
   test(
     "GET /api/v1/monitor/traces?query=<substring> filters by trace name (incl. 50-char sanitize cap)",
-    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
+    { tag: ["@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       // The handler ILIKEs on TraceTable.{name, id, session_id} (capped at
       // 50 chars by sanitize_query_string). In this setup the flow UUID is
@@ -327,7 +327,7 @@ test.describe("Trace list filters — status / start_time / query / session_id",
 
   test(
     "GET /api/v1/monitor/traces?session_id filters by the session passed at run time",
-    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
+    { tag: ["@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       const hitRes = await request.get(
         `/api/v1/monitor/traces?flow_id=${okFlowId}&session_id=${encodeURIComponent(okSessionId)}`,

--- a/tests/tests-automations/regression/core-functionality/playground/playground-input-text-prefill.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-input-text-prefill.spec.ts
@@ -96,7 +96,7 @@ test.describe("Playground – Input Text Pre-fill Behavior", () => {
 
   test(
     "playground opens with chat textarea pre-filled from ChatInput Input Text",
-    { tag: ["@stable", "@regression", "@playground"] },
+    { tag: ["@regression", "@playground"] },
     async ({ page }) => {
       await test.step("set up flow with Input Text and open playground", async () => {
         createdFlowId = await setupFlowWithPrefill(page);
@@ -116,7 +116,7 @@ test.describe("Playground – Input Text Pre-fill Behavior", () => {
 
   test(
     "creating a new session re-applies the Input Text pre-fill",
-    { tag: ["@stable", "@regression", "@playground"] },
+    { tag: ["@regression", "@playground"] },
     async ({ page }) => {
       await test.step("set up flow with Input Text and open playground", async () => {
         createdFlowId = await setupFlowWithPrefill(page);
@@ -150,7 +150,7 @@ test.describe("Playground – Input Text Pre-fill Behavior", () => {
 
   test(
     "pre-filled value is sent as the first message of the session",
-    { tag: ["@stable", "@regression", "@playground"] },
+    { tag: ["@regression", "@playground"] },
     async ({ page }) => {
       await test.step("set up flow with Input Text and open playground", async () => {
         createdFlowId = await setupFlowWithPrefill(page);

--- a/tests/tests-automations/regression/core-functionality/playground/stop-button-playground.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/stop-button-playground.spec.ts
@@ -4,7 +4,7 @@ import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-te
 
 test(
   "User must be able to stop building from inside Playground",
-  { tag: ["@stable", "@release", "@api", "@playground"] },
+  { tag: ["@release", "@api", "@playground"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 

--- a/tests/tests-automations/regression/flow-functionality/publish-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/publish-flow.spec.ts
@@ -12,7 +12,7 @@ const FLOW_BASE = {
 
 test(
   "user can publish a flow and access it via shareable URL, then unpublish to revoke access",
-  { tag: ["@release", "@workspace", "@playground", "@stable"] },
+  { tag: ["@release", "@workspace", "@playground"] },
   async ({ page, browser, request }) => {
     await awaitBootstrapTest(page);
 

--- a/tests/tests-automations/regression/flow-functionality/stop-building.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/stop-building.spec.ts
@@ -21,7 +21,7 @@ test.afterEach(async ({ page }) => {
 });
 
 test("user must be able to stop a building from the canvas",
-  { tag: ["@stable", "@release", "@workspace", "@components"] },
+  { tag: ["@release", "@workspace", "@components"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 


### PR DESCRIPTION
## What

Manually quarantines `@stable` from the specs that hard-failed in daily run [29323509096](https://github.com/oriontech-me/langflow-e2e/actions/runs/29323509096) (2026-07-14) due to **confirmed, durable breaks** — so the daily-stable workflow stops going red on them while the fixes land.

The mass-failure guard tripped (27 hard failures > threshold 5) and left every `@stable` tag in place. Triage (#744) reproduced the failures live against nightly `1.11.0.dev38` and found the driver is **not environmental** — it is upstream product drift + a stale fixture. Per `CONTRIBUTING.md` → *Mass-failure guard* ("if it turns out not to be environmental, remove `@stable` manually from the real hard failures"), this PR does the manual removal.

## Scope — only durable breaks

`@stable` removed from **25 tests across 16 files**, grouped by root cause:

- **Sidebar / canvas entry surface (UI drift)** → tracked in #746
  `customComponentAdd`, `edit-name-description-node` (×2), `general-bugs-delete-handle-advanced-input`, `tool-mode`, `stop-button-playground`, `stop-building`, `publish-flow` (line 13 only), `playground-input-text-prefill` (×3, serial).
- **traces seeded-run returns 400 (outdated fixture / run behavior)** → tracked in #747
  `traces-delete-cascade`, `traces-delete` (line 143 only), `traces-detail-llm-span-populated`, `traces-detail-single` (line 155 only), `traces-detail` (line 154 only), `traces-latency-tokens` (×3, serial), `traces-list-filters` (×5, serial).

- **Recurrent flake (30-day same-signature rule)** → tracked in #750
  `language-model-regression.spec.ts` → "language model must respond with Google provider" (line 130). `waitForSelector` timeout recurring on a clean day (2026-07-09) and again 2026-07-14 — independent of the mass-failure wave. Removed per `CONTRIBUTING.md` → Triage protocol (recurrent flake ⇒ dedicated issue + manual `@stable` removal).

**Left in place (not quarantined):**
- Intermittent auth/session failure on `api-custom-component-creation` (passes when authenticated) → tracked in #748, `@stable` kept.
- Agent/playground execution flakes (recovered on retry) and MCP — tracked via #636 / #608 / #643.
- Tests in the touched files that **passed** in the run (e.g. `publish-flow:151`, `traces-delete:17`, `traces-detail-single:40`, `traces-detail:17/48`) keep `@stable`.

## Restoration

`@stable` restoration is a **required deliverable** of the tracking issues #746 and #747 — the tag comes back in the fix PR once each cluster is resolved and validated on the current nightly. This PR does **not** close those issues.

## Validation

- Only `@stable` strings removed — no other tag or code touched (`git diff`: 25 removals, 0 additions of `@stable`).
- `npm run typecheck` ✅
- `npm run lint` ✅

Refs #744 #746 #747 #750
