### PR TITLE
test(core-components): add full-custom-component spec + enable custom components in E2E instance (#668)

### DIFF
--- a/.github/workflows/adaptive-impacted.yml
+++ b/.github/workflows/adaptive-impacted.yml
@@ -154,6 +154,10 @@ jobs:
           LANGFLOW_AUTO_LOGIN: "true"
           LANGFLOW_SUPERUSER: langflow
           LANGFLOW_SUPERUSER_PASSWORD: langflow123
+          # Nightly image defaults LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false
+          # (custom-component creation disabled → sidebar button hidden, API
+          # 403). Enable it so the custom-component specs exercise the feature.
+          LANGFLOW_ALLOW_CUSTOM_COMPONENTS: "true"
           # Tracing is OFF by default (cuts startup time / backend noise for the
           # majority of specs). Turn it ON when the full suite runs or when
           # observability/traces specs are impacted — they need the SUT to emit

--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -51,6 +51,14 @@ jobs:
           LANGFLOW_AUTO_LOGIN: "true"
           LANGFLOW_SUPERUSER: langflow
           LANGFLOW_SUPERUSER_PASSWORD: langflow123
+          # The nightly image ships LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false (a
+          # security default): custom-component creation is disabled, which
+          # hides the sidebar "New Custom Component" button and makes
+          # POST /api/v1/custom_component return 403. Enable it so the
+          # custom-component @stable specs (full-custom-component,
+          # customComponentAdd, api-custom-component-creation) exercise the
+          # feature instead of failing on the disabled surface.
+          LANGFLOW_ALLOW_CUSTOM_COMPONENTS: "true"
           # Keep tracing ON: the @stable observability/traces specs probe
           # /api/v1/monitor/traces, which is populated by the internal native
           # tracer. That tracer's worker never starts when tracing is

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -76,6 +76,10 @@ jobs:
           LANGFLOW_AUTO_LOGIN: "true"
           LANGFLOW_SUPERUSER: langflow
           LANGFLOW_SUPERUSER_PASSWORD: langflow123
+          # Nightly image defaults LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false
+          # (custom-component creation disabled → sidebar button hidden, API
+          # 403). Enable it so the custom-component specs exercise the feature.
+          LANGFLOW_ALLOW_CUSTOM_COMPONENTS: "true"
           # Keep tracing ON: the observability/traces specs probe
           # /api/v1/monitor/traces, populated by the internal native tracer whose
           # worker never starts when tracing is deactivated — disabling it makes

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,6 +31,10 @@ jobs:
           LANGFLOW_AUTO_LOGIN: "true"
           LANGFLOW_SUPERUSER: langflow
           LANGFLOW_SUPERUSER_PASSWORD: langflow123
+          # Nightly image defaults LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false
+          # (custom-component creation disabled → sidebar button hidden, API
+          # 403). Enable it so the custom-component specs exercise the feature.
+          LANGFLOW_ALLOW_CUSTOM_COMPONENTS: "true"
           LANGFLOW_DEACTIVATE_TRACING: "true"
           # Ollama runs as a sibling service; without the allowlist the
           # nightly's SSRF protection 400s the Ollama component's model-list

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -111,6 +111,10 @@ jobs:
           LANGFLOW_AUTO_LOGIN: "true"
           LANGFLOW_SUPERUSER: langflow
           LANGFLOW_SUPERUSER_PASSWORD: langflow123
+          # Nightly image defaults LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false
+          # (custom-component creation disabled → sidebar button hidden, API
+          # 403). Enable it so the custom-component specs exercise the feature.
+          LANGFLOW_ALLOW_CUSTOM_COMPONENTS: "true"
           # Tracing is OFF by default (cuts startup time / backend noise for the
           # majority of specs). Turn it ON only when observability/traces specs
           # are impacted — they need the SUT to emit traces + spans, and without

--- a/.github/workflows/weekly-stable.yml
+++ b/.github/workflows/weekly-stable.yml
@@ -42,6 +42,10 @@ jobs:
           LANGFLOW_AUTO_LOGIN: "true"
           LANGFLOW_SUPERUSER: langflow
           LANGFLOW_SUPERUSER_PASSWORD: langflow123
+          # Nightly image defaults LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false
+          # (custom-component creation disabled → sidebar button hidden, API
+          # 403). Enable it so the custom-component specs exercise the feature.
+          LANGFLOW_ALLOW_CUSTOM_COMPONENTS: "true"
           # Keep tracing ON: the @stable observability/traces specs probe
           # /api/v1/monitor/traces, which is populated by the internal native
           # tracer. That tracer's worker never starts when tracing is

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -154,7 +154,7 @@
 
 #### 2.4 Code Editing
 - [x] Edit Python code of custom component — Check & Save clears the pulse-pink indicator → `core-components/customComponentAdd.spec.ts`
-- [-] Full custom component
+- [x] Full custom component → `core-components/full-custom-component.spec.ts`
 
 ---
 

--- a/docs/core-components/full-custom-component.md
+++ b/docs/core-components/full-custom-component.md
@@ -1,0 +1,143 @@
+# Full Custom Component — Build a Component From Code (§2.4 Code Editing)
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+Validates that a **fully-authored Custom Component** — Python code that declares
+its own `display_name`, a named input, and a named output — is compiled by
+**Check & Save** into a working node whose on-canvas interface matches what the
+code declared. This is the "full custom component" contract (§2.4): not just
+that the code saves (that is the sibling pulse-pink spec), but that the saved
+code actually **produces a component with the declared surface**.
+
+After adding a Custom Component and replacing the scaffold with code declaring
+`display_name = "My Full Component"`, an input `display_name="My Input"`, and an
+output `display_name="My Output"`, the node must render:
+
+1. its declared title — `title-My Full Component`;
+2. its declared input field — labeled **"My Input"** with an editable value
+   control;
+3. its declared output handle — `handle-myfullcomponent-shownode-my output-right`;
+4. a run affordance — `button_run_my full component`.
+
+If this breaks, user-authored component code could Check-&-Save "successfully"
+yet not materialize the declared inputs/outputs — a silently broken component
+that fails only later when wired into a flow.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@components`
+
+---
+
+## Preconditions *(required)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` with **`LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true`**.
+  The nightly image ships this flag **`false`** by default (a security default
+  — custom-component creation is disabled), which hides the
+  `sidebar-custom-component-button` and makes `POST /api/v1/custom_component`
+  return `403 "Custom component creation is disabled"`. The E2E instance (local
+  scripts + CI service) sets the flag `true` so the feature is exercised — see
+  Notes.
+- No model provider credentials required — the component is a pure
+  `MessageTextInput → Message` passthrough; nothing calls an LLM.
+
+---
+
+## Step by step *(required)*
+
+1. Bootstrap the app (`awaitBootstrapTest`) and open a blank flow.
+2. Click `sidebar-custom-component-button` to drop a Custom Component.
+3. Open the code editor (`code-button-modal`), select all, and fill the Ace
+   editor with a full Custom Component class declaring `display_name =
+   "My Full Component"`, an input `MessageTextInput(name="input_value",
+   display_name="My Input")`, and an output `Output(display_name="My Output",
+   name="output", method="build_output")` returning a `Message`.
+4. Click **Check & Save**.
+5. Assert the node materialized its declared interface (below).
+
+The flow this page creates is captured from its `POST /api/v1/flows → 201`
+response and deleted id-scoped in `afterEach`.
+
+---
+
+## Validation criterion *(required)*
+
+After Check & Save, all of the following are visible / present within 10 s,
+each derived directly from the submitted code:
+
+| Observable | Proves |
+|---|---|
+| `title-My Full Component` | the declared `display_name` drove the node title |
+| text **"My Input"** (`title-my input`) | the declared input rendered as a field |
+| `handle-myfullcomponent-shownode-my output-right` | the declared output produced a real output handle |
+| `button_run_my full component` | the compiled component is runnable |
+
+Each assertion targets a distinctive, code-derived identifier — none of these
+strings exist in the default scaffold, so a component that failed to adopt the
+submitted code fails the assertions deterministically. This is strictly
+stronger than, and distinct from, the pulse-pink save-round-trip spec
+(`customComponentAdd.spec.ts`).
+
+---
+
+## External dependencies *(required)*
+
+- `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true` on the running instance (see
+  Preconditions / Notes).
+- `data-testid="sidebar-custom-component-button"` — sidebar footer "New Custom
+  Component" button (present only when the flag is on).
+- `data-testid="code-button-modal"` — the node's code editor trigger.
+- `.ace_content` + `textarea` — the Ace editor and its textarea mirror inside
+  the code modal.
+- **"Check & Save"** button text — compiles and saves the code.
+- `title-<display_name>` / `title-<input display_name>` /
+  `handle-<name>-shownode-<output display_name>-right` /
+  `button_run_<display_name>` — node interface testids, all keyed off the
+  code-declared names (lower-cased for input/handle/run testids).
+
+---
+
+## What this test does not cover *(optional)*
+
+- The pulse-pink unsaved-code indicator round-trip — covered by
+  `customComponentAdd.spec.ts`.
+- Executing the component and asserting the output value. The node preserves the
+  scaffold's field value across a code edit (it does not adopt the new code's
+  default `value=`), so a run's output value is not a deterministic observable;
+  the interface materialization is asserted instead.
+- Connecting the custom component to other nodes / running a full flow.
+- Code validation errors (invalid Python) — a separate negative case.
+- Behavior when `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false` (feature disabled) — the
+  spec runs with the feature enabled.
+
+---
+
+## Notes *(optional)*
+
+- **Feature-flag dependency (root cause of the infra change shipped with this
+  spec).** On nightly `1.11.0.dev42` the image sets
+  `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false` by default. With it off: the sidebar
+  "New Custom Component" button is not rendered (its footer slot shows "Discover
+  more components"/Bundles), and `POST /api/v1/custom_component` returns
+  `403 "Custom component creation is disabled"`. This silently broke two
+  existing `@stable` specs on the daily (`customComponentAdd.spec.ts`,
+  `api-custom-component-creation.spec.ts`). This spec's PR adds
+  `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true` to the E2E instance (CI service
+  containers + `scripts/start-langflow-docker.sh`) so the custom-component
+  surface is exercised, restoring the two broken specs and enabling this one.
+  Verified live on 1.11.0.dev42: with the flag on, the button returns, the
+  component materializes with the declared interface, and
+  `customComponentAdd.spec.ts` passes 1/1.
+- **Field value is not asserted.** Scouted live: after Check & Save of new code,
+  the node keeps the scaffold's `input_value` ("Hello, World!") rather than the
+  new code's `value=`; the declared *names* (title/input/output) do update. The
+  criterion therefore asserts the declared interface, not the value.
+- **Flow cleanup.** The added component lives in a flow whose id is captured from
+  `POST /api/v1/flows → 201` (a bare `page.url()` races the bootstrap flow's
+  stale id — #490/#681) and deleted in `afterEach`.

--- a/scripts/start-langflow-docker.sh
+++ b/scripts/start-langflow-docker.sh
@@ -22,6 +22,7 @@ docker run -d \
   -e LANGFLOW_SUPERUSER="${LANGFLOW_SUPERUSER:-langflow}" \
   -e LANGFLOW_SUPERUSER_PASSWORD="${LANGFLOW_SUPERUSER_PASSWORD:-langflow123}" \
   -e LANGFLOW_DEACTIVATE_TRACING=true \
+  -e LANGFLOW_ALLOW_CUSTOM_COMPONENTS="${LANGFLOW_ALLOW_CUSTOM_COMPONENTS:-true}" \
   "${IMAGE}"
 
 echo "Waiting for Langflow to be ready (up to 120s)..."

--- a/tests/tests-automations/regression/core-components/customComponentAdd.spec.ts
+++ b/tests/tests-automations/regression/core-components/customComponentAdd.spec.ts
@@ -1,11 +1,49 @@
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+
+// Capture every flow THIS page creates from its POST /api/v1/flows → 201
+// responses and delete them id-scoped in afterEach. awaitBootstrapTest runs
+// first, so a bare page.url() capture races the bootstrap flow's stale id
+// (#490/#681); the response ids are authoritative and worker-safe. Without this
+// each run leaked a "New Flow".
+const createdFlowIds: string[] = [];
+
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {});
+    }
+  });
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, {
+      headers: { Authorization: bearer },
+    }).catch(() => {});
+  }
+});
 
 test(
   "custom component code button should be pink when adding custom component",
   { tag: ["@release", "@components", "@stable"] },
 
   async ({ page }) => {
+    trackCreatedFlows(page);
     await awaitBootstrapTest(page);
 
     await expect(page.getByTestId("blank-flow")).toBeVisible({

--- a/tests/tests-automations/regression/core-components/full-custom-component.spec.ts
+++ b/tests/tests-automations/regression/core-components/full-custom-component.spec.ts
@@ -1,0 +1,117 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+
+// Capture every flow THIS page creates from its POST /api/v1/flows → 201
+// responses and delete them id-scoped in afterEach. awaitBootstrapTest runs
+// first, so a bare page.url() capture races the bootstrap flow's stale id
+// (#490/#681); the response ids are authoritative and worker-safe.
+const createdFlowIds: string[] = [];
+
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {});
+    }
+  });
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, {
+      headers: { Authorization: bearer },
+    }).catch(() => {});
+  }
+});
+
+// A full custom component: declares its own display_name, a named input, and a
+// named output. None of these strings exist in the default scaffold, so the
+// on-canvas assertions below can only pass if Check & Save compiled THIS code
+// into the node.
+const FULL_COMPONENT_CODE = `
+from langflow.custom import Component
+from langflow.io import MessageTextInput, Output
+from langflow.schema.message import Message
+
+
+class CustomComponent(Component):
+    display_name = "My Full Component"
+    description = "A fully authored custom component."
+    icon = "custom_components"
+    name = "MyFullComponent"
+
+    inputs = [
+        MessageTextInput(name="input_value", display_name="My Input", value="Hello, World!"),
+    ]
+    outputs = [
+        Output(display_name="My Output", name="output", method="build_output"),
+    ]
+
+    def build_output(self) -> Message:
+        return Message(text=self.input_value)`;
+
+test(
+  "a full custom component built from code exposes its declared interface",
+  { tag: ["@stable", "@release", "@components"] },
+  async ({ page }) => {
+    trackCreatedFlows(page);
+
+    await awaitBootstrapTest(page);
+
+    await expect(page.getByTestId("blank-flow")).toBeVisible({ timeout: 10000 });
+    await page.getByTestId("blank-flow").click();
+
+    await expect(page.getByTestId("canvas_controls_dropdown")).toBeVisible({
+      timeout: 10000,
+    });
+
+    await test.step("add a custom component and open its code editor", async () => {
+      // Requires LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true — with the feature off
+      // (the nightly image default) this button is not rendered. See spec doc.
+      await page.getByTestId("sidebar-custom-component-button").click();
+
+      const codeButton = page.getByTestId("code-button-modal").last();
+      await expect(codeButton).toBeVisible({ timeout: 10000 });
+      await codeButton.click();
+    });
+
+    await test.step("replace the scaffold with a full component and save", async () => {
+      await page.locator(".ace_content").click();
+      await page.keyboard.press("ControlOrMeta+A");
+      await page.locator("textarea").fill(FULL_COMPONENT_CODE);
+      await page.getByText("Check & Save").last().click();
+    });
+
+    await test.step("the node materializes the code-declared interface", async () => {
+      // Declared display_name drives the node title.
+      await expect(page.getByTestId("title-My Full Component")).toBeVisible({
+        timeout: 10000,
+      });
+      // Declared input rendered as a labeled field.
+      await expect(page.getByTestId("title-my input")).toBeVisible({
+        timeout: 10000,
+      });
+      // Declared output produced a real output handle.
+      await expect(
+        page.getByTestId("handle-myfullcomponent-shownode-my output-right"),
+      ).toBeVisible({ timeout: 10000 });
+      // The compiled component is runnable.
+      await expect(
+        page.getByTestId("button_run_my full component"),
+      ).toBeVisible({ timeout: 10000 });
+    });
+  },
+);


### PR DESCRIPTION
Closes #668

## What & why

Validate & promote to `@stable` the §2.4 Code Editing bullet **"Full custom
component"** — a fully-authored Custom Component (code declaring its own
`display_name`, a named input, and a named output) that Check & Save compiles
into a working node whose on-canvas interface matches the code. This is
distinct from the sibling pulse-pink save-round-trip spec
(`customComponentAdd.spec.ts`).

## Root cause found while scouting (blocked the issue + broke 2 @stable specs)

On nightly `1.11.0.dev42+` the image ships **`LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false`**
(a security default). With the flag off, custom-component creation is disabled:

- the sidebar **"New Custom Component"** button is not rendered (its footer slot
  shows "Discover more components" / Bundles);
- `POST /api/v1/custom_component` returns **403 "Custom component creation is disabled"**.

This silently broke two existing `@stable` specs on the daily
(`customComponentAdd.spec.ts`, `api-custom-component-creation.spec.ts`) and
blocked this issue. The feature was **not removed** — it is a config default.
Verified live: with the flag on, the button returns, the component
materializes, and the two broken specs pass again.

## What changed

- **New spec** `full-custom-component.spec.ts` (`@stable @release @components`):
  adds a Custom Component, replaces the scaffold with code declaring
  `display_name="My Full Component"`, input `"My Input"`, output `"My Output"`,
  Check & Save, then asserts the **code-declared** interface materialized
  (strings absent from the default scaffold): `title-My Full Component`, the
  `"My Input"` field, the `handle-myfullcomponent-shownode-my output-right`
  output handle, and `button_run_my full component`. Pattern A id-scoped flow
  cleanup.
- **Enable `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true` on every E2E Langflow instance:**
  the six workflow service containers (`daily-stable`, `nightly`, `manual`,
  `pr-validation`, `weekly-stable`, `adaptive-impacted`) and
  `scripts/start-langflow-docker.sh`. Restores the two broken specs, enables the
  new one.
- **Add Pattern A id-scoped flow cleanup to `customComponentAdd.spec.ts`** — it
  leaked a "New Flow" per run and now runs again in CI via the flag.
- `QA-CHECKLIST.md` §2.4 "Full custom component" bullet flipped to `[x]`.

## Validation

- **Resolved Langflow version:** 1.11.0.dev43 (nightly), run with
  `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true`.
- **Determinism:** `full-custom-component` burst 3/3 at `--retries=0 --workers=1`
  → expected=1, unexpected=0, flaky=0, backendErrors=false; re-confirmed 1/1
  after the dev42→dev43 bump.
- **Un-break:** `customComponentAdd` + `api-custom-component-creation` → 5/5
  green with the flag on.
- **Force-fail (executed, reverted):**
  - `full-custom-component` — expected title testid → `title-FF-Mutation-Never-Exists`
    → unexpected=1.
  - `customComponentAdd` (assertion) — added a `getByTestId("ff-mutation-nonexistent")`
    visibility assert → unexpected=1.
  - `customComponentAdd` (behavioral cleanup) — neutered the flow-id tracker
    (no push) → test still passed but leaked 1 "New Flow" (orphan 0→1), proving
    the cleanup is real.
  - 0 `// FF-MUTATION` markers remain; final green runs.
- `npm run typecheck` = 0 errors · `npm run lint` = 0 errors (new/edited specs
  clean).

## Run it

```bash
# instance must have LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true (start script sets it now)
npx playwright test \
  tests/tests-automations/regression/core-components/full-custom-component.spec.ts \
  tests/tests-automations/regression/core-components/customComponentAdd.spec.ts \
  tests/tests-automations/regression/api/flows/api-custom-component-creation.spec.ts \
  --workers=1 --retries=0
# expected: 5 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
