### PR TITLE
test(core-components): add tool-mode-group spec — group a Tool-Mode component (#663)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -141,7 +141,7 @@
 
 #### 2.2 Tool Mode
 - [x] Enable Tool Mode on a component
-- [-] Group components in Tool Mode
+- [x] Group components in Tool Mode → `core-components/tool-mode-group.spec.ts`
 - [-] Edit tools (edit-tools)
 
 #### 2.3 Component Updates

--- a/docs/core-components/tool-mode-group.md
+++ b/docs/core-components/tool-mode-group.md
@@ -1,0 +1,137 @@
+# Group Components in Tool Mode (§2.2 Tool Mode)
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+Validates that a component in **Tool Mode** can be **grouped** together with its
+consumer into a single **Group** node — the §2.2 "Group components in Tool Mode"
+behavior. Grouping is Langflow's "collapse a connected sub-graph into one
+reusable component" feature (`Ctrl/Cmd+G`); the test proves a tool-mode
+component participates in a group without being rejected or stripped, and that
+the created group absorbs it.
+
+Concretely: a **URL** component is switched to Tool Mode (its output becomes a
+`toolset` handle), connected to an **Agent**'s `tools` input, both are selected,
+and grouped. The result is a single **Group** node — Langflow does not raise the
+"Invalid selection" guard (which fires for ungroupable selections), the two
+nodes collapse into one, and the group exposes the tool-mode component's own
+input (`urls`) as a group input, proving the URL was absorbed into the group
+with its wiring intact.
+
+If this breaks, users could no longer package a tool-mode component + its Agent
+into a reusable group — either the group action would be rejected or the
+tool-mode component would be dropped/mis-wired on grouping.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@components`
+
+---
+
+## Preconditions *(required)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- No model provider credentials required — the flow is assembled and grouped but
+  never run (grouping is a client-side graph operation).
+
+---
+
+## Step by step *(required)*
+
+1. Bootstrap the app and open a blank flow.
+2. Open **Data Sources**, add the **URL** component, focus it, and drag it into
+   the canvas.
+3. Enable Tool Mode on it (`Ctrl/Cmd+Shift+M`) → assert the `toolset` output
+   appears.
+4. Open **Models & Agents**, drag an **Agent** onto the canvas.
+5. Connect the URL's `handle-urlcomponent-shownode-toolset-right` to the Agent's
+   `handle-agent-shownode-tools-left`; assert an edge exists.
+6. Shift+drag a selection box over the canvas to select both nodes; assert two
+   `.react-flow__node.selected`.
+7. Press `Ctrl/Cmd+G` to group.
+8. Assert the group materialized (below).
+
+Every flow this page creates is captured from its `POST /api/v1/flows → 201`
+response and deleted id-scoped in `afterEach`.
+
+---
+
+## Validation criterion *(required)*
+
+After `Ctrl/Cmd+G`, all of the following hold:
+
+- a **Group** node exists — `title-Group` is visible and `button_run_group` is
+  present;
+- **no** "Invalid selection" error toast appeared (the selection was a valid,
+  connected, single-free-output group — a tool-mode component did not block it);
+- the two original nodes collapsed into one — `div-generic-node` count is 1;
+- the group absorbed the tool-mode component — the group exposes its `urls`
+  input handle (`handle-groupnode-shownode-urls-left`), which only exists
+  because the URL component (in Tool Mode) is now inside the group.
+
+Each assertion targets a distinctive observable; a mutated assertion (expecting
+the group to be absent, or the nodes not to collapse) fails deterministically.
+
+---
+
+## External dependencies *(required)*
+
+- `data-testid="data_sourceURL"` / `add-component-button-url` — sidebar URL
+  component + its quick-add button.
+- `generic-node-title-arrangement` — node header (focus/drag target).
+- `Ctrl/Cmd+Shift+M` — Tool Mode toggle shortcut; `text=toolset` — the tool-mode
+  output marker.
+- `handle-urlcomponent-shownode-toolset-right` / `handle-agent-shownode-tools-left`
+  — the toolset→tools connection handles.
+- `Ctrl/Cmd+G` — the Group shortcut (`GroupSelection`).
+- `title-Group` / `button_run_group` / `handle-groupnode-shownode-urls-left` —
+  the created group node's title, run button, and absorbed URL input handle.
+
+---
+
+## What this test does not cover *(optional)*
+
+- **Ungrouping** the created group and asserting the internal URL is still in
+  Tool Mode. The ungroup action could not be driven reliably from the UI
+  (neither the toolbar Ungroup icon nor `Ctrl+Shift+G` fired the ungroup with
+  the group node selected — scouted extensively on 1.11.0.dev43); the test
+  therefore validates that a tool-mode component is groupable and absorbed, not
+  the ungroup round-trip. If Langflow exposes a stable ungroup affordance later,
+  extend this spec with a group→ungroup→`toolset`-returns round-trip.
+- Grouping **two disconnected tool-mode components**. Langflow rejects that with
+  "Invalid selection — Select only one component with free outputs · Select only
+  connected components" (two free `toolset` outputs). A valid group needs the
+  tool-mode component(s) connected to a single-free-output consumer (the Agent).
+- Running the grouped flow (needs a provider).
+
+---
+
+## Notes *(optional)*
+
+- **Why a tool-component → Agent pair (not two bare tool components).** The Group
+  action requires a connected selection with exactly one free output. Two
+  tool-mode components each expose a free `toolset` output → "Invalid selection".
+  Wiring the tool-mode URL into the Agent's `tools` leaves the Agent's `Response`
+  as the single free output, making the selection groupable while still
+  containing a Tool-Mode component. Verified live on 1.11.0.dev43.
+- **Distinct from `tool-mode.spec.ts`.** That spec covers §2.2 "Enable Tool Mode
+  on a component" (toggle + toolset inspection). This one covers the separate
+  §2.2 bullet "Group components in Tool Mode".
+- **Expected "Error while updating the Component" toast.** Because the Agent
+  used as the tools sink has **no model provider configured**, Langflow shows an
+  *"Error while updating the Component"* toast during the group operation. It is
+  benign here: no HTTP 4xx/5xx fires (the fixture backend monitor is not
+  tripped), no JS console error, and the group is still created — the spec runs
+  green and deterministic. Configuring a provider would silence it but couple the
+  spec to an LLM (collect-models, model strategy, `--workers=1`, the
+  model-selection-drop race) for zero added coverage of the grouping behavior, so
+  the provider-less design is intentional. Do not "fix" this by weakening an
+  assertion — the toast is app-side, not a test failure.
+- **Flow cleanup.** The assembled flow's id is captured from
+  `POST /api/v1/flows → 201` (a bare `page.url()` races the bootstrap flow's
+  stale id — #490/#681) and deleted in `afterEach`.

--- a/tests/tests-automations/regression/core-components/tool-mode-group.spec.ts
+++ b/tests/tests-automations/regression/core-components/tool-mode-group.spec.ts
@@ -1,0 +1,162 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+
+// Capture every flow THIS page creates from its POST /api/v1/flows → 201
+// responses and delete them id-scoped in afterEach. awaitBootstrapTest runs
+// first, so a bare page.url() capture races the bootstrap flow's stale id
+// (#490/#681); the response ids are authoritative and worker-safe.
+const createdFlowIds: string[] = [];
+
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {});
+    }
+  });
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, {
+      headers: { Authorization: bearer },
+    }).catch(() => {});
+  }
+});
+
+test(
+  "a component in Tool Mode can be grouped with its Agent consumer",
+  { tag: ["@stable", "@release", "@components"] },
+  async ({ page }) => {
+    trackCreatedFlows(page);
+
+    await awaitBootstrapTest(page);
+    await page.getByTestId("blank-flow").click();
+
+    await test.step("add a URL component and enable Tool Mode", async () => {
+      await page.waitForSelector('[data-testid="disclosure-data sources"]', {
+        timeout: 10000,
+        state: "visible",
+      });
+      await page.getByTestId("disclosure-data sources").click();
+      await page.waitForSelector('[data-testid="data_sourceURL"]', {
+        timeout: 10000,
+        state: "visible",
+      });
+      await page
+        .getByTestId("data_sourceURL")
+        .hover()
+        .then(async () => {
+          await page.getByTestId("add-component-button-url").click();
+        });
+
+      await page.getByTestId("generic-node-title-arrangement").click();
+      await page
+        .getByTestId("generic-node-title-arrangement")
+        .dragTo(page.locator('//*[@id="react-flow-id"]'));
+
+      // Tool Mode: the component's output collapses into a single `toolset` handle.
+      await page.keyboard.press("ControlOrMeta+Shift+m");
+      await page.waitForSelector("text=toolset", {
+        timeout: 10000,
+        state: "visible",
+      });
+      expect(await page.getByText("toolset").count()).toBeGreaterThan(0);
+    });
+
+    await test.step("add an Agent and wire the toolset into its tools input", async () => {
+      await page.getByTestId("disclosure-data sources").click();
+      await page.getByTestId("disclosure-models & agents").click();
+      await adjustScreenView(page, { numberOfZoomOut: 4 });
+      await page.waitForSelector('[data-testid="models_and_agentsAgent"]', {
+        timeout: 10000,
+        state: "visible",
+      });
+      await page
+        .getByTestId("models_and_agentsAgent")
+        .dragTo(page.locator('//*[@id="react-flow-id"]'), {
+          targetPosition: { x: 50, y: 500 },
+        });
+      await adjustScreenView(page);
+
+      await page
+        .getByTestId("handle-urlcomponent-shownode-toolset-right")
+        .first()
+        .click();
+      await page
+        .getByTestId("handle-agent-shownode-tools-left")
+        .first()
+        .click();
+      expect(await page.locator(".react-flow__edge").count()).toBeGreaterThan(0);
+    });
+
+    await test.step("select both nodes and group them", async () => {
+      await adjustScreenView(page, { numberOfZoomOut: 2 });
+      // Shift+drag a rubber-band selection over the whole canvas (a plain drag
+      // pans; Shift makes it a box-select — the §7.2 "Select all (Shift+drag)").
+      const rf = await page
+        .locator('//*[@id="react-flow-id"]')
+        .boundingBox();
+      if (!rf) throw new Error("react-flow canvas not found");
+      await page.keyboard.down("Shift");
+      await page.mouse.move(rf.x + 8, rf.y + 8);
+      await page.mouse.down();
+      await page.mouse.move(rf.x + rf.width - 8, rf.y + rf.height - 8, {
+        steps: 15,
+      });
+      await page.mouse.up();
+      await page.keyboard.up("Shift");
+
+      await expect
+        .poll(
+          async () =>
+            page.evaluate(
+              () =>
+                document.querySelectorAll(".react-flow__node.selected").length,
+            ),
+          { timeout: 5000 },
+        )
+        .toBe(2);
+
+      await page.keyboard.press("ControlOrMeta+g");
+    });
+
+    await test.step("a single Group node is created without an invalid-selection error", async () => {
+      // The group materialized: title + run button.
+      await expect(page.getByTestId("title-Group")).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(page.getByTestId("button_run_group")).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Grouping was accepted — the "Invalid selection" guard did NOT fire.
+      await expect(
+        page.getByText("Invalid selection", { exact: false }),
+      ).toHaveCount(0);
+
+      // The two nodes collapsed into the single group node.
+      await expect(page.getByTestId("div-generic-node")).toHaveCount(1);
+
+      // The group absorbed the Tool-Mode component: its `urls` input surfaces as
+      // a group input — it only exists because the URL component is inside.
+      await expect(
+        page.getByTestId("handle-groupnode-shownode-urls-left"),
+      ).toBeVisible({ timeout: 10000 });
+    });
+  },
+);


### PR DESCRIPTION
Closes #663

## What & why

Validate & promote to `@stable` the §2.2 Tool Mode bullet **"Group components in
Tool Mode"**. The pointer spec (`toolModeGroup.spec.ts`) did not exist and the
existing `tool-mode.spec.ts` covers a *different* bullet ("Enable Tool Mode on a
component"), so this is a new spec.

## Design (from live scouting on 1.11.0.dev43)

- **Grouping requires a connected selection with exactly one free output.** Two
  disconnected Tool-Mode components each expose a free `toolset` output →
  Langflow rejects the group with *"Invalid selection — Select only one
  component with free outputs · Select only connected components"*. So the spec
  wires the Tool-Mode **URL** into an **Agent**'s `tools` input (the Agent's
  `Response` is then the single free output) and groups the pair — a selection
  that genuinely contains a Tool-Mode component.
- **Validation** after `Ctrl/Cmd+G`: a **Group** node exists (`title-Group` +
  `button_run_group`), **no** "Invalid selection" toast, the two nodes collapse
  into one (`div-generic-node` count 1), and the group absorbed the Tool-Mode
  component — it exposes `handle-groupnode-shownode-urls-left` (the URL's own
  input), which only exists because the URL is now inside the group.

## Deliberate scope / notes

- **Provider-less (no LLM).** The flow is assembled and grouped but never run.
  The Agent (used only as the tools sink to satisfy the single-free-output
  grouping rule) has no provider configured, so Langflow shows a **benign**
  *"Error while updating the Component"* toast during grouping — **no HTTP
  4xx/5xx fires** (fixture backend monitor not tripped), no JS console error, and
  the group is still created. Configuring a provider would silence it but couple
  the spec to an LLM (collect-models, model strategy, `--workers=1`, the
  model-selection-drop race) for zero added coverage of the grouping behavior.
  Documented in the spec doc.
- **Ungroup round-trip not covered.** The UI ungroup action could not be driven
  reliably (neither the toolbar Ungroup icon nor `Ctrl+Shift+G` fired with the
  group node selected — scouted extensively). The spec validates that a
  Tool-Mode component is groupable and absorbed, not the ungroup round-trip.
- **Ambient finding (not this spec's defect):** the frontend fires a bulk
  `DELETE /api/v1/flows/` when navigating into a blank flow (pruning a temp
  flow) that intermittently returns `500 "An internal error occurred while
  deleting flows"` (~1/11). It reproduces with a bare `awaitBootstrapTest +
  blank-flow` and affects the whole suite (incl. existing `@stable` specs); the
  test passes (backend errors are logged, not thrown). Flagged for separate
  triage.

## Validation

- **Resolved Langflow version:** 1.11.0.dev43 (nightly).
- **Determinism:** burst 3/3 at `--retries=0 --workers=1` → expected=1,
  unexpected=0, flaky=0, backendErrors=false.
- **Force-fail (executed, reverted):** expected `title-Group` →
  `title-FF-Mutation-Group-Never` → unexpected=1; 0 `// FF-MUTATION` markers
  remain; final green run.
- `npm run typecheck` = 0 errors · `npm run lint` = 0 errors (spec clean).
- Pattern A id-scoped flow cleanup — 0 orphan flows after the run.

## Run it

```bash
npx playwright test tests/tests-automations/regression/core-components/tool-mode-group.spec.ts --workers=1 --retries=0
# expected: 1 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
