### PR TITLE
fix(model-provider): match POST or PATCH for provider-key persist waiter (#636)

### DIFF
--- a/docs/core-functionality/model-provider/google-provider.md
+++ b/docs/core-functionality/model-provider/google-provider.md
@@ -60,11 +60,14 @@ nightly. `@model-provider` (area) · `@settings` (Test 1 navigates Settings) ·
    unconfigured, `Replace` when a key is already stored — match `/Save|Replace/`).
 5. **Validation (causal — no pre-existing-state false positive):** the save click
    must produce **both** a `POST /api/v1/models/validate-provider` → **2xx** (the
-   key authenticates against Google live) **and** a `PATCH /api/v1/variables/{id}`
-   → **2xx** (the key is persisted). Asserting the request outcomes — not the
-   "Disconnect"/"Replace" state, which pre-exists when the global key was already
-   configured — ties the pass to *this* save. Idempotent: re-saving the same valid
-   key is a success; the shared global key is deliberately not wiped. (Google
+   key authenticates against Google live) **and** a persist to
+   `/api/v1/variables/` → **2xx**. The persist is a **`POST` (create, 201)** when
+   the `GOOGLE_API_KEY` global variable does not yet exist and a **`PATCH`
+   (update, 200)** when it does — the frontend branches on existence — so the
+   waiter matches **either method** (#636). Asserting the request outcomes — not
+   the "Disconnect"/"Replace" state, which pre-exists when the global key was
+   already configured — ties the pass to *this* save. Idempotent across states:
+   the first save on a fresh instance creates, later saves update. (Google
    validation can be slow on a cold provider — the waiters use a 60 s timeout.)
 
 ---
@@ -101,9 +104,10 @@ nightly. `@model-provider` (area) · `@settings` (Test 1 navigates Settings) ·
 ## Validation criterion *(required)*
 
 - **Configure:** clicking Save on the Google key produces a 2xx
-  `validate-provider` (key authenticates against Google) and a 2xx
-  `PATCH /variables/{id}` (key persisted) — the pass is caused by this save, not
-  a pre-existing configured state.
+  `validate-provider` (key authenticates against Google) and a 2xx persist to
+  `/variables/` (key persisted) — `POST` create or `PATCH` update depending on
+  whether the global key already exists (#636) — the pass is caused by this save,
+  not a pre-existing configured state.
 - **Select + execute:** the Agent's model dropdown shows a Gemini model, and
   running the flow returns a non-empty AI response (the per-run sentinel is a soft
   signal — Gemini doesn't always echo it verbatim).
@@ -111,8 +115,8 @@ nightly. `@model-provider` (area) · `@settings` (Test 1 navigates Settings) ·
 ## Guarding against false positives *(how)*
 
 - **Test 1** asserts the *save requests succeed* (`validate-provider` +
-  `PATCH /variables` both 2xx), not a UI state that pre-exists from an earlier
-  configuration — so a no-op save cannot pass.
+  `POST`/`PATCH /variables` both 2xx), not a UI state that pre-exists from an
+  earlier configuration — so a no-op save cannot pass.
 - **Test 2** asserts a **Gemini** model is selected
   (`value-dropdown-model_model` ~ `/gemini|gemma/i`, causal) and that execution
   returns a non-empty response; the per-run sentinel is a soft signal (Gemini
@@ -182,3 +186,13 @@ nightly. `@model-provider` (area) · `@settings` (Test 1 navigates Settings) ·
 - **Per-run sentinel** proves *this* execution produced the output.
 - **Shared global key:** the Google key is global and persists across runs. Test 1
   is idempotent — it re-saves and asserts the request outcomes, not a fresh start.
+- **#636 flake (fixed 2026-07-14):** the persist waiter matched `PATCH` only, but
+  the frontend fires `POST /variables/` (create, 201) when the key does not yet
+  exist and `PATCH /variables/{id}` (update, 200) when it does. On a fresh CI
+  container — or a run where no earlier test configured the provider first — the
+  save takes the create path, so the PATCH-only waiter timed out on a request that
+  never fired (intermittent because prior test order decides which path runs).
+  Network repro (deleted-var, live): `validate-provider` → **200**, persist →
+  **POST 201**, PATCH-only waiter → timeout. Backend healthy (no hang/5xx): a
+  **test defect**, not a product bug. Fix: match `POST` **or** `PATCH`. Same fix
+  in `openai-provider.spec.ts`.

--- a/docs/core-functionality/model-provider/openai-provider.md
+++ b/docs/core-functionality/model-provider/openai-provider.md
@@ -60,12 +60,15 @@ Settings) · `@agents` + `@playground` (Test 2 executes an agent).
    unconfigured, `Replace` when a key is already stored — match `/Save|Replace/`).
 5. **Validation (causal — no pre-existing-state false positive):** the save click
    must produce **both** a `POST /api/v1/models/validate-provider` → **2xx** (the
-   key authenticates against OpenAI live) **and** a `PATCH /api/v1/variables/{id}`
-   → **2xx** (the key is persisted). Asserting the request outcomes — not the
-   "Replace" button, which is already present when the global key was configured
-   by an earlier test — ties the pass to *this* save action. Idempotent: re-saving
-   the same valid key is a success; the shared global key is deliberately not
-   wiped.
+   key authenticates against OpenAI live) **and** a persist to
+   `/api/v1/variables/` → **2xx**. The persist is a **`POST` (create, 201)** when
+   the `OPENAI_API_KEY` global variable does not yet exist and a **`PATCH`
+   (update, 200)** when it does — the frontend branches on existence — so the
+   waiter matches **either method** (#636). Asserting the request outcomes — not
+   the "Replace" button, which is already present when the global key was
+   configured by an earlier test — ties the pass to *this* save action.
+   Idempotent across states: the first save on a fresh instance creates, later
+   saves update.
 
 ---
 
@@ -106,17 +109,18 @@ Settings) · `@agents` + `@playground` (Test 2 executes an agent).
 ## Validation criterion *(required)*
 
 - **Configure:** clicking Save on the OpenAI key produces a 2xx
-  `validate-provider` (key authenticates against OpenAI) and a 2xx
-  `PATCH /variables/{id}` (key persisted) — the pass is caused by this save, not
-  a pre-existing configured state.
+  `validate-provider` (key authenticates against OpenAI) and a 2xx persist to
+  `/variables/` (key persisted) — `POST` create or `PATCH` update depending on
+  whether the global key already exists (#636) — the pass is caused by this save,
+  not a pre-existing configured state.
 - **Select + execute:** the Agent's model dropdown shows a GPT model, and running
   the flow returns the per-run sentinel in the AI response.
 
 ## Guarding against false positives *(how)*
 
 - **Test 1** asserts the *save requests succeed* (`validate-provider` +
-  `PATCH /variables` both 2xx), not a UI state that pre-exists from an earlier
-  test's global key — so a no-op save cannot pass.
+  `POST`/`PATCH /variables` both 2xx), not a UI state that pre-exists from an
+  earlier test's global key — so a no-op save cannot pass.
 - **Test 2** asserts a **GPT** model is selected (`value-dropdown-model_model`
   ~ `/gpt/i`) and round-trips a **per-run sentinel**, so the response can't be
   stale, cached, or produced by a different provider.
@@ -177,6 +181,16 @@ Settings) · `@agents` + `@playground` (Test 2 executes an agent).
   runs (not deleted by `cleanAllFlows`). Test 1 is therefore idempotent — it
   re-saves the same key and asserts the configured state rather than assuming a
   fresh, unconfigured start.
+- **#636 flake (fixed 2026-07-14):** the persist waiter matched `PATCH` only, but
+  the frontend fires `POST /variables/` (create, 201) when the key does not yet
+  exist and `PATCH /variables/{id}` (update, 200) when it does. On a fresh CI
+  container — or a run where no earlier test configured the provider first — the
+  save takes the create path, so the PATCH-only waiter timed out on a request that
+  never fired (intermittent because prior test order decides which path runs;
+  openai flaked 07-09/07-10). Network repro (deleted-var, live): `validate-provider`
+  → **200**, persist → **POST 201**, PATCH-only waiter → timeout. Backend healthy:
+  a **test defect**, not a product bug. Fix: match `POST` **or** `PATCH`. Same fix
+  in `google-provider.spec.ts`.
 - **Per-run sentinel** over a generic non-empty check: proves *this* execution
   produced the output, so the "execute with OpenAI" bullet can't pass on stale
   text.

--- a/tests/tests-automations/regression/core-functionality/model-provider/google-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/google-provider.spec.ts
@@ -122,10 +122,19 @@ test.describe("Google Provider", () => {
             r.request().method() === "POST",
           { timeout: 60000 },
         );
+        // Persist is a CREATE (POST /variables/ 201) when the global key does
+        // not yet exist and an UPDATE (PATCH /variables/{id} 200) when it does
+        // — the frontend branches on existence (#636). Match BOTH: a fresh
+        // instance, or a run where no earlier test configured the provider
+        // first, takes the POST path, so a PATCH-only predicate waits forever
+        // on a request that never fires — the confirmed flake (POST 201
+        // observed live on a deleted-var repro; validate-provider itself
+        // returns 200, so the backend is healthy — a test defect, not a
+        // product hang).
         const persistPromise = page.waitForResponse(
           (r) =>
             r.url().includes("/api/v1/variables/") &&
-            r.request().method() === "PATCH",
+            (r.request().method() === "POST" || r.request().method() === "PATCH"),
           { timeout: 60000 },
         );
 
@@ -136,7 +145,7 @@ test.describe("Google Provider", () => {
           persistPromise,
         ]);
         // validate-provider 2xx = the key authenticates against Google live;
-        // PATCH /variables 2xx = the key is persisted globally.
+        // POST/PATCH /variables 2xx = the key is persisted globally.
         expect(validateResp.ok()).toBe(true);
         expect(persistResp.ok()).toBe(true);
       });

--- a/tests/tests-automations/regression/core-functionality/model-provider/openai-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/openai-provider.spec.ts
@@ -168,10 +168,19 @@ test.describe("OpenAI Provider", () => {
             r.request().method() === "POST",
           { timeout: 30000 },
         );
+        // Persist is a CREATE (POST /variables/ 201) when the global key does
+        // not yet exist and an UPDATE (PATCH /variables/{id} 200) when it does
+        // — the frontend branches on existence (#636). Match BOTH: a fresh
+        // instance, or a run where no earlier test configured the provider
+        // first, takes the POST path, so a PATCH-only predicate waits forever
+        // on a request that never fires — the confirmed flake (POST 201
+        // observed live on a deleted-var repro; validate-provider itself
+        // returns 200, so the backend is healthy — a test defect, not a
+        // product hang).
         const persistPromise = page.waitForResponse(
           (r) =>
             r.url().includes("/api/v1/variables/") &&
-            r.request().method() === "PATCH",
+            (r.request().method() === "POST" || r.request().method() === "PATCH"),
           { timeout: 30000 },
         );
 
@@ -182,7 +191,7 @@ test.describe("OpenAI Provider", () => {
           persistPromise,
         ]);
         // validate-provider 2xx = the key authenticates against OpenAI live;
-        // PATCH /variables 2xx = the key is persisted globally.
+        // POST/PATCH /variables 2xx = the key is persisted globally.
         expect(validateResp.ok()).toBe(true);
         expect(persistResp.ok()).toBe(true);
       });


### PR DESCRIPTION
**Fixes #636.**

## Problem
The "…API key is configured via Settings → Model Providers" tests (`google-provider.spec.ts`, `openai-provider.spec.ts`) are recurrent flakes (openai 2026-07-09 / 07-10; google first on 07-10) — `page.waitForResponse` times out (60s / 30s) while saving the provider key.

Root cause (network-level confirmed, both investigation axes):
- The frontend save (`useProviderConfiguration.ts`) branches on existence: `createGlobalVariable` → **POST /api/v1/variables/** (201) when the provider global variable does not yet exist, `updateGlobalVariable` → **PATCH /api/v1/variables/{id}** (200) when it does.
- The tests armed the persist waiter for **PATCH only**. On a fresh instance — or a run where no earlier test configured the provider first — the save takes the **create (POST)** path, so the PATCH-only waiter waits forever on a request that never fires. Intermittent because prior test order (across shards) decides which path runs.

Live repro (deleted the global var to force the fresh state):
```
POST /api/v1/models/validate-provider  -> 200
POST /api/v1/variables/                -> 201   (persist is a CREATE, not PATCH)
PATCH-only waiter                      -> NONE (timeout)  = the flake
```
`validate-provider` returns 200 and the persist returns 201 — the backend is healthy. **Verdict: test defect (stale method predicate), not a Langflow product bug.** Axis 1 (backend hang / 5xx) ruled out.

## Fix
Match **POST or PATCH** on `/api/v1/variables/` for the persist waiter (both 2xx), in both specs. Budgets unchanged — the bug was the method, not the timeout. Spec docs updated with the root cause and evidence.

## Scope note
Only Test 1 (the Settings save) changed in each file. Test 2 (agent execution) and the id-scoped flow cleanup are untouched. `@stable` retained (per the daily triage policy — these recovered on retry).

## Validation (nightly 1.11.0.dev38, `--retries=0`)
- typecheck ✅ · eslint ✅ (0 errors)
- fresh state (POST path): **2 passed** (old PATCH-only predicate would time out here — proven by the live network repro)
- update state (PATCH path): **3 runs × 2 = 6/6 passed**
- force-fail ✅ (pre-fix predicate = the mutation: PATCH-only → timeout on fresh state, captured live; fixed predicate → passes)
- no orphan flows (Test 1 only navigates Settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
