### PR TITLE
fix(agents): settle autosave in empty-refusal setAgentInstructions (#608)

### DIFF
--- a/docs/core-functionality/llm-agents/agent-empty-refusal-response.md
+++ b/docs/core-functionality/llm-agents/agent-empty-refusal-response.md
@@ -69,8 +69,9 @@ The spec generates **2 tests per active model** via `getTestTargets()` (default:
 1. Load the Simple Agent template via `SimpleAgentTemplatePage.load(options)`.
 2. Set the Agent Instructions (`textarea_str_system_prompt`) to force a refusal:
    `You must refuse every request. Regardless of what the user asks, reply with
-   exactly this and nothing else: REFUSE-<marker>`, and wait for the autosave
-   `PATCH /api/v1/flows/{id}` (so the build runs the instruction we set).
+   exactly this and nothing else: REFUSE-<marker>`, and wait for the debounced
+   autosave to settle (`waitForFlowSaveSettled`) so the build runs the
+   instruction we set — see Notes (#608).
 3. Open the Playground and send an unrelated message
    (`What is the capital of France?`); wait for the agent to finish
    (`waitForAgentToFinish`).
@@ -90,7 +91,8 @@ The spec generates **2 tests per active model** via `getTestTargets()` (default:
 1. Load the Simple Agent template.
 2. Set the Agent Instructions to force an empty response:
    `Reply with an empty response. Output nothing at all — no text, no
-   punctuation, no whitespace.`, and wait for the autosave PATCH.
+   punctuation, no whitespace.`, and wait for the debounced autosave to settle
+   (`waitForFlowSaveSettled`, #608).
 3. Open the Playground and send `What is the capital of France?`; wait for the
    agent to finish.
 4. **Validation:**
@@ -184,6 +186,17 @@ The spec generates **2 tests per active model** via `getTestTargets()` (default:
   a component crash on the degenerate output fails the test automatically — no
   `allowFlowErrors()` is used (an empty/refusal response is not itself an error).
 - **Per-run refusal marker** proves *this* run induced the refusal.
+- **#608 autosave hardening (2026-07-14):** `setAgentInstructions` previously
+  raced a single `waitForResponse(PATCH && ok(), 15s)` after `blur()`, which
+  flaked on the google run three ways — debounce > 15s under load, a stale
+  load()-time PATCH resolving before the instruction's own save, or a transient
+  non-ok PATCH never matching `ok()`. It now waits for the debounced autosave to
+  settle via `waitForFlowSaveSettled` (quiet-period, any status), matching the
+  hardened `agent-system-prompt.spec.ts` helper (#635). This fix is only about
+  the autosave wait; the separate live-bubble "Message empty." read race (Test 1
+  hard-asserts the marker on the live bubble, which can render the streaming
+  placeholder before the final text lands — the #634 class) is tracked
+  separately.
 - **Empty renders as a placeholder (observed on 1.11.0.dev30):** when the model
   actually returns an empty completion, Langflow does **not** crash — the
   Playground bubble shows the friendly placeholder `Message empty.`. That

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-empty-refusal-response.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-empty-refusal-response.spec.ts
@@ -11,6 +11,7 @@ import {
   type Provider,
 } from "../../../../helpers/provider-setup";
 import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
 
 /**
  * Agent robustness on a degenerate model output (QA-CHECKLIST §6.5,
@@ -152,24 +153,26 @@ async function waitForAgentToFinish(page: Page): Promise<void> {
   }
 }
 
-// Fill the Agent Instructions (system prompt) and wait for the autosave PATCH so
-// the build runs the prompt we set, not the template default.
+// Fill the Agent Instructions (system prompt) and make sure the debounced
+// autosave has settled before the build, so the run uses the prompt we set, not
+// the template default.
 async function setAgentInstructions(page: Page, prompt: string): Promise<void> {
   const promptField = page.getByTestId("textarea_str_system_prompt");
   await expect(promptField).toBeVisible({ timeout: 15000 });
 
-  const patchPromise = page.waitForResponse(
-    (resp) =>
-      resp.url().includes("/api/v1/flows/") &&
-      resp.request().method() === "PATCH" &&
-      resp.ok(),
-    { timeout: 15000 },
-  );
-
   await promptField.click();
   await promptField.fill(prompt);
   await promptField.blur();
-  await patchPromise;
+  // Drain ALL debounced autosave PATCHes instead of racing a single
+  // `waitForResponse(PATCH && ok(), 15s)` (#608). The old waiter flaked three
+  // ways on the google run: (a) the autosave debounce could exceed 15s under
+  // load; (b) a stale PATCH still in flight from load() (model selection) could
+  // resolve it BEFORE the instruction's own save landed; (c) a transient
+  // non-ok PATCH never matched `resp.ok()`, so it waited out the full timeout.
+  // `waitForFlowSaveSettled` waits for a quiet period after the last flow-save
+  // PATCH (any status), which is robust to all three. Matches the hardened
+  // `agent-system-prompt.spec.ts` helper (#635).
+  await waitForFlowSaveSettled(page);
 }
 
 // Open the Playground, send a message, wait for the run to finish, return the


### PR DESCRIPTION
**Fixes #608.**

## Problem
`#608` reported `setAgentInstructions` racing a single `waitForResponse(PATCH && ok(), 15s)` after `blur()`, timing out on the google run. The helper is duplicated: `agent-system-prompt.spec.ts` was already hardened by #635 (it now uses `waitForFlowSaveSettled` + server-side persistence confirmation), but the **duplicate in `agent-empty-refusal-response.spec.ts` still carried the fragile pattern** — the last remaining copy. The issue's own action item: "apply consistently wherever `setAgentInstructions` is duplicated".

The fragile waiter flaked three ways on the google run:
- the autosave debounce could exceed 15s under load;
- a stale load()-time PATCH (model selection) could resolve it before the instruction's own save landed;
- a transient non-ok PATCH never matched `resp.ok()`, so it waited out the full timeout.

## Fix
Replace it with `waitForFlowSaveSettled` (quiet-period drain of all flow-save PATCHes, any status), matching the hardened `agent-system-prompt.spec.ts` helper. Budgets and downstream assertions unchanged.

## Scope note
Only the `setAgentInstructions` autosave wait changed. **A separate, pre-existing flake in the same file** — Test 1 hard-asserts the refusal marker on the **live** Playground bubble, which can render the streaming placeholder `Message empty.` before the final text lands (the #634 live-bubble race) — is **out of scope** for #608 and tracked in #757 (fix: assert on the persisted monitor reply, as `openai-provider.spec.ts` already does).

## Validation (nightly 1.11.0.dev38, `--retries=0`)
- typecheck ✅ · eslint ✅ (0 errors)
- google parametrization run: `setAgentInstructions` completed with **zero autosave `waitForResponse` timeouts** and **zero `🚨 Backend Error`** — the #608 symptom is gone. (The run then hit the unrelated #757 live-bubble race downstream, not the autosave step.)
- Force-fail note: a full green `--retries=0` cycle on this test is blocked by the deferred #757 race; the #608 fix is validated at the step level (the previously-flaking `setAgentInstructions` no longer times out) and is code-identical to the already-force-failed #635 hardening of the sibling helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
