### PR TITLE
fix(agents): assert refusal marker on persisted reply, not live bubble (#757)

### DIFF
--- a/docs/core-functionality/llm-agents/agent-empty-refusal-response.md
+++ b/docs/core-functionality/llm-agents/agent-empty-refusal-response.md
@@ -75,9 +75,13 @@ The spec generates **2 tests per active model** via `getTestTargets()` (default:
    (`What is the capital of France?`); wait for the agent to finish
    (`waitForAgentToFinish`).
 4. **Validation:**
-   - **hard** — the last `div-chat-message` (AI bubble) **contains**
-     `REFUSE-<marker>`: proves the model actually produced the induced refusal
-     (not a helpful answer), so a pass is not coincidental.
+   - **hard** — the **persisted** reply (polled from `GET
+     /api/v1/monitor/messages`, not the live bubble) contains `REFUSE-<marker>`:
+     proves the model actually produced the induced refusal (not a helpful
+     answer), so a pass is not coincidental. The marker is unique per run, so a
+     Machine message carrying it can only be this run's refusal. Asserting on the
+     persisted state (not the live `div-chat-message`) avoids the streaming
+     placeholder race (#757 — see Notes).
    - **hard (via fixture)** — zero `🚨 Backend Error` (4xx/5xx) and zero flow
      execution errors: the component processed the refusal without crashing. A
      component crash on the refusal path would raise a backend error the fixture
@@ -121,9 +125,12 @@ The spec generates **2 tests per active model** via `getTestTargets()` (default:
 
 ## Guarding against false positives *(how)*
 
-- **Test 1** asserts the reply **contains the per-run refusal marker**, so it
-  cannot pass on a normal helpful answer or on stale/coincidental text — a pass
-  means the model actually refused and the component handled it.
+- **Test 1** asserts the **persisted** reply (monitor API) **contains the
+  per-run refusal marker**, so it cannot pass on a normal helpful answer or on
+  stale/coincidental text — a pass means the model actually refused and the
+  component handled it. Asserting on the settled persisted state (not the live
+  bubble) removes the streaming-placeholder false failure (#757) without
+  weakening the check.
 - **Test 2**'s completion is asserted structurally (bubble visible + Stop gone +
   no error), not from the presence of text, so it holds whether the reply is
   empty or not; the emptiness itself is only logged (never a hard/soft assertion)
@@ -184,6 +191,18 @@ The spec generates **2 tests per active model** via `getTestTargets()` (default:
   a component crash on the degenerate output fails the test automatically — no
   `allowFlowErrors()` is used (an empty/refusal response is not itself an error).
 - **Per-run refusal marker** proves *this* run induced the refusal.
+- **#757 live-bubble race (fixed 2026-07-14):** Test 1 originally hard-asserted
+  the marker on the live `div-chat-message` bubble read right after
+  `waitForAgentToFinish`. The bubble can still show the streaming placeholder
+  `Message empty.` when the finish signal fires before the final text lands, so
+  the assertion intermittently read the placeholder and failed (flaky on the
+  daily 07-13/07-14; the #634 class). Fix: assert the marker on the **persisted**
+  reply (`expectMarkerInPersistedReply`, polling `GET /api/v1/monitor/messages`),
+  which is the settled state and cannot see the transient placeholder. Confirmed
+  the race (not model non-adherence): with the old live-bubble assert the google
+  run failed on `Message empty.`, and with the persisted-reply assert the same
+  model passed 3/3 `--retries=0`. Only Test 1 changed — Test 2 already treats the
+  placeholder as a soft signal. Same pattern as `openai-provider.spec.ts`.
 - **Empty renders as a placeholder (observed on 1.11.0.dev30):** when the model
   actually returns an empty completion, Langflow does **not** crash — the
   Playground bubble shows the friendly placeholder `Message empty.`. That

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-empty-refusal-response.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-empty-refusal-response.spec.ts
@@ -1,7 +1,7 @@
 import * as dotenv from "dotenv";
 import path from "path";
 import fs from "fs";
-import type { Page } from "@playwright/test";
+import type { APIRequestContext, Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
 import {
@@ -11,6 +11,7 @@ import {
   type Provider,
 } from "../../../../helpers/provider-setup";
 import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 
 /**
  * Agent robustness on a degenerate model output (QA-CHECKLIST §6.5,
@@ -190,6 +191,43 @@ async function askAndGetReplyBubble(page: Page, message: string) {
   return { bubble, text: (await bubble.innerText()).trim() };
 }
 
+// Assert the per-run marker on the PERSISTED reply (monitor API), NOT the live
+// playground bubble (#757). The bubble renders the "Message empty." placeholder
+// (EMPTY_OUTPUT_SEND_MESSAGE) while the model is still streaming, and
+// `waitForAgentToFinish` can return before the final text lands — so reading the
+// live bubble races the stream and intermittently sees the placeholder instead
+// of the refusal (the #634 class). The marker is globally unique per run, so a
+// Machine message carrying it can only be THIS run's refusal — no session
+// keying needed. A genuinely non-adherent run (no marker anywhere) still fails
+// here, so the refusal is proven, not assumed. Same pattern as
+// openai-provider.spec.ts's `expectReplyContainsToken`.
+async function expectMarkerInPersistedReply(
+  request: APIRequestContext,
+  marker: string,
+): Promise<void> {
+  const bearer = await getAuthToken(request);
+  await expect
+    .poll(
+      async () => {
+        const res = await request.get("/api/v1/monitor/messages", {
+          headers: { Authorization: bearer },
+        });
+        if (res.status() !== 200) return `GET monitor -> ${res.status()}`;
+        const messages = await res.json();
+        if (!Array.isArray(messages)) return "monitor payload not a list";
+        const machineReplies = messages
+          .filter((m: any) => m.sender === "Machine")
+          .map((m: any) => ((m.text as string) ?? "").trim());
+        if (machineReplies.length === 0) return "no Machine reply persisted yet";
+        return machineReplies.some((t) => t.includes(marker))
+          ? "marker-persisted"
+          : "marker not yet in any persisted Machine reply";
+      },
+      { timeout: 60000, intervals: [500, 1000, 2000] },
+    )
+    .toBe("marker-persisted");
+}
+
 const targets = getTestTargets();
 
 // SimpleAgentTemplatePage.load() deletes all flows before loading the template.
@@ -204,7 +242,7 @@ for (const { label, options, skipReason } of targets) {
     test(
       "model refusal does not crash the component",
       { tag: ["@stable", "@regression", "@agents", "@playground"] },
-      async ({ page }) => {
+      async ({ page, request }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(
           !hasProviderEnvKeys(provider),
@@ -224,12 +262,18 @@ for (const { label, options, skipReason } of targets) {
         });
 
         await test.step("run a message and assert the component refuses without crashing", async () => {
-          const { text } = await askAndGetReplyBubble(page, USER_MESSAGE);
-          // Hard: the model produced the induced refusal (not a helpful answer),
-          // so the pass is not coincidental. The fixture's backend/flow-error
-          // monitoring is the crash guard — a component crash on the refusal path
-          // would raise a backend error and auto-fail this test.
-          expect(text).toContain(marker);
+          // Drive the run through the Playground (send + wait for finish); the
+          // returned live-bubble text is intentionally ignored for the content
+          // assert — it races the stream and can read the "Message empty."
+          // placeholder (#757).
+          await askAndGetReplyBubble(page, USER_MESSAGE);
+          // Hard: the induced refusal marker reached the PERSISTED reply, so the
+          // model actually refused (not a helpful answer) and it is this run's
+          // refusal — asserted on the settled monitor state, not the racy live
+          // bubble. The fixture's backend/flow-error monitoring is the crash
+          // guard — a component crash on the refusal path would raise a backend
+          // error and auto-fail this test.
+          await expectMarkerInPersistedReply(request, marker);
         });
       },
     );


### PR DESCRIPTION
**Fixes #757.**

## Problem
`agent-empty-refusal-response.spec.ts` → **"model refusal does not crash the component"** (Test 1) intermittently failed at the hard content assertion:

```
Expected substring: "REFUSE-<marker>"
Received string:    "Message empty."
expect(text).toContain(marker);
```

Flaky on the daily (2026-07-13 / 07-14) and reproduced locally on `[google / gemini-2.5-flash]`. The assertion read the **live** Playground bubble (`div-chat-message`) right after `waitForAgentToFinish`, which can return before the final streamed text lands — so the bubble still shows the frontend placeholder `Message empty.` (`EMPTY_OUTPUT_SEND_MESSAGE`). A live-bubble read race, not model non-adherence, not a product bug (the #634 class).

## Fix
Assert the marker on the **persisted** reply (`expectMarkerInPersistedReply`, polling `GET /api/v1/monitor/messages`) — the settled state, which cannot observe the transient placeholder. The marker is unique per run, so a Machine message carrying it is unambiguously this run's refusal (no session keying needed). Same pattern `openai-provider.spec.ts` already uses (`expectReplyContainsToken`).

## Scope note
Only Test 1's content assertion changed (plus a small helper + two imports). `setAgentInstructions` is **not** touched here — its separate autosave hardening is #608 (PR #758); the two PRs overlap only on this file's import block. Test 2 (empty response) already treats `Message empty.` as a soft signal and is unchanged. `@stable` retained.

## Validation (nightly 1.11.0.dev38, `--retries=0`)
- typecheck ✅ · eslint ✅ (0 errors)
- **Confirmed the race, not non-adherence:** old live-bubble assert failed on `Message empty.`; new persisted-reply assert passed **3/3** on the same google model
- force-fail ✅ (bogus marker `+"__FF_NEVER"` → the poll never matches, test fails at 60s; reverted)
- no `🚨 Backend Error` on the clean runs

Related: #634 (closed — same "Message empty." race for anthropic + openai), #608 (the sibling autosave flake in the same file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
