### PR TITLE
test(core): restore @stable on the sidebar/canvas-entry cluster + harden entry flakes (#746)

### DIFF
--- a/tests/helpers/flows/setup-playground.ts
+++ b/tests/helpers/flows/setup-playground.ts
@@ -28,6 +28,16 @@ export async function setupPlayground(page: Page): Promise<string> {
   }
 
   try {
+    // POST /api/v1/flows → 201 only confirms the flow exists server-side — it
+    // does NOT confirm the SPA finished routing into the flow editor. Gate on
+    // the destination state (editor URL + canvas) before reaching for
+    // editor-only elements; otherwise an occasional navigation race leaves the
+    // app on the flows list and the sidebar wait times out (flaky).
+    await page.waitForURL(/\/flow\/[^/?#]+/, { timeout: 30000 });
+    await expect(page.getByTestId("canvas_controls_dropdown")).toBeVisible({
+      timeout: 30000,
+    });
+
     // The flow editor sidebar mounts after the POST /api/v1/flows response
     // resolves; wait for sidebar-search-input before interacting (see #278).
     await expect(page.getByTestId("sidebar-search-input")).toBeVisible({

--- a/tests/helpers/ui/ensure-custom-component-button.ts
+++ b/tests/helpers/ui/ensure-custom-component-button.ts
@@ -1,0 +1,34 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Ensure the flow-editor "New Custom Component" sidebar button
+ * (`sidebar-custom-component-button`) is visible before a spec interacts with
+ * it.
+ *
+ * The button lives inside the **Components** sidebar section. On flow entry the
+ * sidebar can occasionally load with a different section active (the section
+ * selection can persist), leaving the button present in the DOM but hidden
+ * (`display:none` section wrapper) — a ~9% flake that times out any
+ * `waitForSelector`/`click` waiting for it to become visible.
+ *
+ * Strategy: first wait for the button to appear normally (covers the sidebar
+ * mount, which is the common case). Only if it is still hidden after that grace
+ * period do we re-activate the Components nav (a safe, non-navigating click that
+ * re-reveals the section) and wait again. Waiting FIRST is essential — an
+ * immediate visibility check races the initial render and would fire the
+ * recovery click mid-mount, which itself breaks the subsequent interaction.
+ */
+export async function ensureCustomComponentButton(page: Page): Promise<void> {
+  const button = page.getByTestId("sidebar-custom-component-button");
+
+  try {
+    await button.waitFor({ state: "visible", timeout: 15000 });
+    return;
+  } catch {
+    // Still hidden after the grace period — the Components section is likely not
+    // the active one. Re-activate it, then wait again.
+  }
+
+  await page.getByTestId("sidebar-nav-components").click().catch(() => {});
+  await button.waitFor({ state: "visible", timeout: 15000 });
+}

--- a/tests/tests-automations/regression/core-components/customComponentAdd.spec.ts
+++ b/tests/tests-automations/regression/core-components/customComponentAdd.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { ensureCustomComponentButton } from "../../../helpers/ui/ensure-custom-component-button";
 
 // Capture every flow THIS page creates from its POST /api/v1/flows → 201
 // responses and delete them id-scoped in afterEach. awaitBootstrapTest runs
@@ -40,7 +41,7 @@ test.afterEach(async ({ request }) => {
 
 test(
   "custom component code button should be pink when adding custom component",
-  { tag: ["@release", "@components"] },
+  { tag: ["@release", "@components", "@stable"] },
 
   async ({ page }) => {
     trackCreatedFlows(page);
@@ -55,6 +56,7 @@ test(
       timeout: 10000,
     });
 
+    await ensureCustomComponentButton(page);
     await page.getByTestId("sidebar-custom-component-button").click();
 
     const codeButton = page.getByTestId("code-button-modal").last();

--- a/tests/tests-automations/regression/core-components/edit-name-description-node.spec.ts
+++ b/tests/tests-automations/regression/core-components/edit-name-description-node.spec.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../helpers/ui/open-advanced-options";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { ensureCustomComponentButton } from "../../../helpers/ui/ensure-custom-component-button";
 
 // Capture every flow THIS page creates from its POST /api/v1/flows → 201
 // responses and delete them id-scoped in afterEach. awaitBootstrapTest runs
@@ -44,7 +45,7 @@ test.afterEach(async ({ request }) => {
 
 test(
   "user should be able to edit name and description of a node",
-  { tag: ["@release", "@workspace", "@components"] },
+  { tag: ["@stable", "@release", "@workspace", "@components"] },
 
   async ({ page }) => {
     trackCreatedFlows(page);
@@ -67,15 +68,7 @@ test(
     });
     await page.getByTestId("blank-flow").click();
 
-    await page.waitForSelector(
-      '[data-testid="sidebar-custom-component-button"]',
-      {
-        timeout: 30000,
-      },
-    );
-
-    await page.waitForTimeout(500);
-
+    await ensureCustomComponentButton(page);
     await page.getByTestId("sidebar-custom-component-button").click();
 
     await page.getByTestId("div-generic-node").click();
@@ -162,7 +155,7 @@ test(
 
 test(
   "user should be able to edit name and description of a node with inspect panel disabled",
-  { tag: ["@release", "@workspace", "@components"] },
+  { tag: ["@stable", "@release", "@workspace", "@components"] },
 
   async ({ page }) => {
     trackCreatedFlows(page);
@@ -185,20 +178,14 @@ test(
     });
     await page.getByTestId("blank-flow").click();
 
-    await page.waitForSelector(
-      '[data-testid="sidebar-custom-component-button"]',
-      {
-        timeout: 30000,
-      },
-    );
-
-    await page.waitForTimeout(500);
+    await ensureCustomComponentButton(page);
 
     await disableInspectPanel(page);
 
     // Restore the global inspect-panel setting even if an assertion below
     // fails, so a mid-test failure cannot leave the inspector off for siblings.
     try {
+      await ensureCustomComponentButton(page);
       await page.getByTestId("sidebar-custom-component-button").click();
 
       await page.getByTestId("div-generic-node").click();

--- a/tests/tests-automations/regression/core-components/general-bugs-delete-handle-advanced-input.spec.ts
+++ b/tests/tests-automations/regression/core-components/general-bugs-delete-handle-advanced-input.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
@@ -7,11 +8,45 @@ import {
   enableInspectPanel,
   openAdvancedOptions,
 } from "../../../helpers/ui/open-advanced-options";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+
+// Capture every flow THIS page creates from its POST /api/v1/flows → 201
+// responses and delete them id-scoped in afterEach (repo convention, #490/#681).
+const createdFlowIds: string[] = [];
+
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {});
+    }
+  });
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, {
+      headers: { Authorization: bearer },
+    }).catch(() => {});
+  }
+});
 
 test(
   "the system must delete the handles from advanced fields when the code is updated",
-  { tag: ["@release", "@components"] },
+  { tag: ["@stable", "@release", "@components"] },
   async ({ page }) => {
+    trackCreatedFlows(page);
     await awaitBootstrapTest(page);
 
     await page.getByTestId("blank-flow").click();

--- a/tests/tests-automations/regression/core-components/tool-mode.spec.ts
+++ b/tests/tests-automations/regression/core-components/tool-mode.spec.ts
@@ -1,11 +1,47 @@
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { ensureCustomComponentButton } from "../../../helpers/ui/ensure-custom-component-button";
+
+// Capture every flow THIS page creates from its POST /api/v1/flows → 201
+// responses and delete them id-scoped in afterEach (repo convention, #490/#681).
+const createdFlowIds: string[] = [];
+
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {});
+    }
+  });
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, {
+      headers: { Authorization: bearer },
+    }).catch(() => {});
+  }
+});
 
 test(
   "User should be able to use components as tool",
-  { tag: ["@release", "@components"] },
+  { tag: ["@release", "@stable", "@components"] },
   async ({ page }) => {
+    trackCreatedFlows(page);
     await awaitBootstrapTest(page);
     await page.getByTestId("blank-flow").click();
     await page.waitForSelector('[data-testid="disclosure-data sources"]', {
@@ -154,6 +190,7 @@ test(
     expect(await page.getByTestId("tool_tags").count()).toBeGreaterThan(0);
     await page.getByText("Close").last().click();
 
+    await ensureCustomComponentButton(page);
     await page.getByTestId("sidebar-custom-component-button").click();
 
     await page.getByTestId("title-Custom Component").click();

--- a/tests/tests-automations/regression/core-functionality/playground/playground-input-text-prefill.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-input-text-prefill.spec.ts
@@ -96,7 +96,7 @@ test.describe("Playground – Input Text Pre-fill Behavior", () => {
 
   test(
     "playground opens with chat textarea pre-filled from ChatInput Input Text",
-    { tag: ["@regression", "@playground"] },
+    { tag: ["@stable", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step("set up flow with Input Text and open playground", async () => {
         createdFlowId = await setupFlowWithPrefill(page);

--- a/tests/tests-automations/regression/core-functionality/playground/stop-button-playground.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/stop-button-playground.spec.ts
@@ -1,27 +1,57 @@
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { ensureCustomComponentButton } from "../../../../helpers/ui/ensure-custom-component-button";
+
+// Capture every flow THIS page creates from its POST /api/v1/flows → 201
+// responses and delete them id-scoped in afterEach (repo convention, #490/#681).
+const createdFlowIds: string[] = [];
+
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {});
+    }
+  });
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, {
+      headers: { Authorization: bearer },
+    }).catch(() => {});
+  }
+});
 
 test(
   "User must be able to stop building from inside Playground",
-  { tag: ["@release", "@api", "@playground"] },
+  { tag: ["@stable", "@release", "@api", "@playground"] },
   async ({ page }) => {
+    trackCreatedFlows(page);
     await awaitBootstrapTest(page);
 
     await test.step("open blank flow and add custom component to canvas", async () => {
       await page.getByTestId("blank-flow").click();
 
-      await page.waitForSelector(
-        '[data-testid="sidebar-custom-component-button"]',
-        {
-          timeout: 3000,
-        },
-      );
-
       await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
-        timeout: 3000,
+        timeout: 10000,
       });
 
+      await ensureCustomComponentButton(page);
       await page.getByTestId("sidebar-custom-component-button").click();
       await adjustScreenView(page);
     });

--- a/tests/tests-automations/regression/flow-functionality/publish-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/publish-flow.spec.ts
@@ -12,7 +12,7 @@ const FLOW_BASE = {
 
 test(
   "user can publish a flow and access it via shareable URL, then unpublish to revoke access",
-  { tag: ["@release", "@workspace", "@playground"] },
+  { tag: ["@release", "@workspace", "@playground", "@stable"] },
   async ({ page, browser, request }) => {
     await awaitBootstrapTest(page);
 

--- a/tests/tests-automations/regression/flow-functionality/stop-building.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/stop-building.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { ensureCustomComponentButton } from "../../../helpers/ui/ensure-custom-component-button";
 
 // Flow created by the test (blank-flow → /flow/{id}); captured so afterEach can
 // delete only this one via the API. Targeted (not cleanAllFlows) so the teardown
@@ -21,7 +22,7 @@ test.afterEach(async ({ page }) => {
 });
 
 test("user must be able to stop a building from the canvas",
-  { tag: ["@release", "@workspace", "@components"] },
+  { tag: ["@stable", "@release", "@workspace", "@components"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 
@@ -45,6 +46,7 @@ test("user must be able to stop a building from the canvas",
       await page.waitForURL(/\/flow\/[^/?#]+/, { timeout: 10000 });
       createdFlowId = page.url().split("/flow/")[1]?.split(/[/?#]/)[0];
 
+      await ensureCustomComponentButton(page);
       await page.getByTestId("sidebar-custom-component-button").click();
       await adjustScreenView(page);
     });


### PR DESCRIPTION
Closes #746

## Root cause (corrects the preliminary lead)

The cluster of `@stable` specs quarantined by Daily #744 all blocked on the
flow-editor **sidebar/canvas entry surface**. The dev38 lead suspected a sidebar
restructure with removed testids — that is **wrong**. The real cause:

**The nightly image ships `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false`**, so
`sidebar-custom-component-button` does not render (and `POST /api/v1/custom_component`
returns 403). `blank-flow`, `canvas_controls_dropdown` and `sidebar-search-input`
all **exist and work** on `1.11.0.dev43` (verified live). The flag is enabled on
every E2E instance by merged #752; with it on, the whole cluster passes.

This also fully resolves **#748** (same flag → the API custom-component 403).

## Changes

- **Restore `@stable`** on the 9 quarantined tests across 8 specs
  (`customComponentAdd`, `edit-name-description-node` ×2,
  `general-bugs-delete-handle-advanced-input`, `tool-mode`,
  `playground-input-text-prefill`, `stop-button-playground`, `publish-flow`,
  `stop-building`) — exact pre-quarantine tag arrays from `cc5e4bf`.
- **Id-scoped Pattern A flow cleanup** added to the three cluster specs that
  leaked a "New Flow" per run (`general-bugs-delete-handle-advanced-input`,
  `tool-mode`, `stop-button-playground`) — verified 0 orphans after runs.
- **New helper `ensureCustomComponentButton`**: the button lives in the
  Components sidebar section and is occasionally hidden on flow entry (~9%
  flake); the helper waits for it, re-activating the Components nav only if still
  hidden after a grace period (waiting first is essential — an immediate check
  races the mount). Applied to the five button-using specs.
- **`setup-playground` hardening**: gate on the editor URL (`/flow/{id}`) +
  canvas before reaching for `sidebar-search-input`. `waitForResponse(POST 201)`
  confirms the flow exists server-side but not that the SPA routed into the
  editor — an occasional navigation race left the helper on the flows list.

## Validation

- **Resolved Langflow version:** 1.11.0.dev43 (nightly), `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true`.
- **Determinism:** VALIDATE burst 3/3 at `--retries=0 --workers=1` for all 8
  specs (edit-name — which flaked 1/3 initially on the sidebar-hidden race — is
  3/3 after the helper).
- **Force-fail (executed, reverted):** all 12 tests in the touched files failed
  under an early guaranteed-fail assertion (unexpected=1 each); the
  `setup-playground` helper got a behavioral FF (waitForURL mutated to a
  never-matching regex → prefill setup fails); 0 `// FF-MUTATION` markers remain;
  final green runs.
- `npm run typecheck` = 0 · `npm run lint` = 0 (touched files clean).
- Sanity: representative non-cluster `setupPlayground` users
  (`create-blank-flow`, `playground-session-nav`) still pass — the helper change
  is additive.
- **Note:** each spec is deterministic in isolation; residual flakiness when
  running all 8 back-to-back single-worker at `--retries=0` is ambient instance
  stress (a different test fails per run; all pass isolated), absorbed by the
  daily's parallel + `retries=2` execution.

## Run it

```bash
# instance needs LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true (default in start script / CI now)
npx playwright test tests/tests-automations/regression/core-components/tool-mode.spec.ts --workers=1 --retries=0
# expected: 1 passed  (run any cluster spec individually)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
