### PR TITLE
chore(skills): document custom-components flag + editor-entry/flake conventions

### DIFF
--- a/.claude/skills/langflow-e2e/SKILL.md
+++ b/.claude/skills/langflow-e2e/SKILL.md
@@ -220,10 +220,21 @@ An instance must be up (default `http://localhost:7860`) before running.
 > docker run -d --name langflow-e2e-runner -p 7860:7860 \
 >   -e LANGFLOW_AUTO_LOGIN=true -e LANGFLOW_SUPERUSER=langflow \
 >   -e LANGFLOW_SUPERUSER_PASSWORD=langflow123 -e LANGFLOW_DEACTIVATE_TRACING=true \
+>   -e LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true \
 >   langflowai/langflow-nightly:latest
 > ```
 > Always confirm with `curl -s localhost:7860/api/v1/version` — the nightly package
 > reports `"package":"Langflow Nightly"` and a `.devNN` version.
+>
+> **Trap — the nightly image ships `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false`.** With
+> the flag off (the image default, seen from ~1.11.0.dev42), custom-component
+> creation is disabled: the sidebar **"New Custom Component"** button
+> (`sidebar-custom-component-button`) does not render (the footer shows "Discover
+> more components"/Bundles) and `POST /api/v1/custom_component` returns `403`. That
+> silently breaks EVERY spec that adds a custom component. The `-e
+> LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true` above is REQUIRED; the CI service
+> containers and `scripts/start-langflow-docker.sh` set it too (#668/#746).
+> Verify: `docker exec langflow-e2e-runner sh -c "env | grep CUSTOM_COMPONENTS"`.
 
 ### Daily — confirm the instance is on the latest nightly (before testing)
 
@@ -247,8 +258,13 @@ docker rm -f langflow-e2e-runner
 docker run -d --name langflow-e2e-runner -p 7860:7860 \
   -e LANGFLOW_AUTO_LOGIN=true -e LANGFLOW_SUPERUSER=langflow \
   -e LANGFLOW_SUPERUSER_PASSWORD=langflow123 -e LANGFLOW_DEACTIVATE_TRACING=true \
+  -e LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true \
   langflowai/langflow-nightly:latest
 ```
+
+`-e LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true` is required — the nightly image
+defaults it to `false`, which hides `sidebar-custom-component-button` and makes
+`POST /api/v1/custom_component` return 403 (see the trap above).
 
 Then re-run `tests/collect-models.spec.ts` if provider/model data may have moved.
 Record the resolved version in the PR **Validation** block (the CI does this

--- a/.claude/skills/langflow-e2e/references/authoring-conventions.md
+++ b/.claude/skills/langflow-e2e/references/authoring-conventions.md
@@ -64,6 +64,25 @@ bullets** — the Coverage Summary table and Phase 0 block auto-regenerate.
 
 ## Behavioral conventions
 
+- **Entering the flow editor — gate on the editor, not just the POST.** After a
+  `blank-flow`/template click, `page.waitForResponse(POST /api/v1/flows → 201)`
+  confirms the flow exists server-side but NOT that the SPA finished routing into
+  the editor. An occasional navigation race leaves the app on the flows list, and
+  a wait for an editor-only element (`sidebar-search-input`, `canvas_controls_dropdown`)
+  then times out with a misleading message. Gate on the destination state:
+  `await page.waitForURL(/\/flow\/[^/?#]+/)` + `expect(canvas_controls_dropdown).toBeVisible()`
+  before touching editor elements (fixed in `helpers/flows/setup-playground.ts`, #746).
+- **Custom components are OFF by default on the nightly image.** The nightly ships
+  `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false` (from ~1.11.0.dev42): the sidebar
+  **"New Custom Component"** button (`sidebar-custom-component-button`) is not
+  rendered (footer shows "Discover more components"/Bundles) and
+  `POST /api/v1/custom_component` returns 403. The E2E instance must set the flag
+  `true` (SKILL.md docker run, `scripts/start-langflow-docker.sh`, all CI service
+  containers — #668/#746). Even with the flag on, that button lives in the
+  Components sidebar section and is occasionally hidden on flow entry (~9% flake);
+  use `helpers/ui/ensure-custom-component-button.ts` (`ensureCustomComponentButton(page)`)
+  — it waits for the button, re-activating the Components nav only if still hidden,
+  before you click it.
 - **Flow cleanup is id-scoped — never a pre-test wipe.** Create your flow,
   keep the id from the creation `POST /api/v1/flows/` 201 response
   (`loadTemplateByName` returns it; the canvas URL id is transient on 1.11),
@@ -412,6 +431,18 @@ deployment-attachment prune) degrade the UI (element timeouts, then raw
 i18n keys in the DOM — the symptom MUTATES with degradation depth). Restart
 the container fresh and re-baseline before debugging the spec; and check
 `docker logs` for the lock signature when element waits time out en masse.
+
+That `database is locked` 500 on the bulk `DELETE /api/v1/flows/` (the frontend
+prunes a temp flow on blank-flow entry) trips the fixture's backend-error
+monitor as LOGGED noise (~9%) — it does NOT fail the test (only flowErrors
+throw). The `@stable` bar is **per-spec determinism** (a `--retries=0` burst of
+that one spec, which the pipeline VALIDATE runs), NOT a clean back-to-back run of
+many heavy specs at `--retries=0` on one stressed instance — that surfaces a
+DIFFERENT ambient flake per run (nav race, build-stop timing, the lock) that all
+pass in isolation and that the daily's parallel + `retries=2` execution absorbs.
+Don't chase per-run cluster flakes as test defects; harden only the ones with a
+concrete, reproducible mechanism (e.g. the hidden custom-component button, the
+editor-nav race above).
 
 ## `.env.example` convention for new providers
 


### PR DESCRIPTION
Encodes learnings from the #668/#746/#748 sessions into the versioned
`langflow-e2e` skill so future runs don't re-discover them.

## SKILL.md — `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true`

Both documented nightly `docker run` blocks now pass the flag, with a trap note.
The nightly image ships it **`false`** (from ~1.11.0.dev42): the sidebar "New
Custom Component" button doesn't render and `POST /api/v1/custom_component`
returns 403, silently breaking every custom-component spec — the root cause of
the 2026-07-14 daily cluster (#746) and #748. Enabled in CI + `start-langflow-docker.sh`
by #668/#746; the skill's manual run command was the last place missing it.

## authoring-conventions.md

- **Entering the flow editor** — gate on `waitForURL(/\/flow\/…/)` + canvas
  before touching editor-only elements; `waitForResponse(POST 201)` alone races
  the SPA nav (fixed in `setup-playground.ts`, #746).
- **Custom components OFF by default** — the flag + the new
  `ensureCustomComponentButton` helper for the ~9% hidden-button flake.
- **Instance-state degradation** — the `database is locked` 500 on bulk
  `DELETE /api/v1/flows/` is logged fixture noise (doesn't fail tests); the
  `@stable` bar is per-spec determinism (the pipeline `--retries=0` burst), not a
  clean back-to-back many-spec cluster run; don't chase ambient flakes as defects.

Docs-only; no test or config behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
