### PR TITLE
test(core-components): breaking-change update alert spec (#667)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -147,7 +147,7 @@
 #### 2.3 Component Updates
 - [-] Outdated component notification
 - [-] Update component action
-- [ ] Update with breaking change — should alert user
+- [x] Update with breaking change — should alert user → `core-components/component-breaking-change-alert.spec.ts`
 - [x] Legacy component visible via configuration → `core-components/legacy-components-toggle-regression.spec.ts`
 - [x] Beta component visible via configuration → `core-components/beta-components-toggle-regression.spec.ts`
 - [x] Re-saving code removes handles from previously-toggled advanced fields → `core-components/general-bugs-delete-handle-advanced-input.spec.ts`

--- a/docs/core-components/component-breaking-change-alert.md
+++ b/docs/core-components/component-breaking-change-alert.md
@@ -32,11 +32,13 @@ same event an OS drag-and-drop fires — the same import mechanism used by the
 ### Tests
 
 1. **Breaking-change outdated components alert with a Review action, not a
-   silent Update.** Import the fixture, open it, and assert the canvas banner
-   reads **"5 components need updates"**, that there are **5 `review-button`s and
-   0 `update-button`s** (every outdated component is breaking → all routed to
-   Review, none to a silent Update), and that the toolbar action reads
-   **"Review All"**.
+   silent Update.** Import the fixture, open it, and assert that **at least one
+   `review-button`** is present (a breaking update is surfaced for Review rather
+   than via the one-click silent `update-button`), that the canvas banner reports
+   the outdated total (`/\d+ components? need updates?/`), and that the toolbar
+   action reads **"Review All"** (which renders only when a breaking update is
+   present). The count is asserted as `> 0`, not a pinned literal — see the
+   *frozen-fixture* caveat below.
 
 2. **Reviewing a single breaking change warns about disconnection and defaults
    to a backup.** Click the first `review-button`; the review dialog must show
@@ -47,8 +49,9 @@ same event an OS drag-and-drop fires — the same import mechanism used by the
    mutated.
 
 3. **"Review All" flags every outdated component as breaking and pre-selects
-   none.** Click the "Review All" toolbar button; the multi-component dialog must
-   show **5 "Breaking"** update-type tags (one per component), the
+   none.** Capture the breaking count from the canvas (`review-button` count),
+   click the "Review All" toolbar button; the multi-component dialog must show
+   that many **"Breaking"** update-type tags (one per breaking component), the
    `backup-flow-checkbox` checked by default, and the submit button **"Update
    Components" disabled** — because breaking components are intentionally *not*
    pre-selected, the user must explicitly opt each one in before the update can
@@ -70,19 +73,32 @@ by id (from `POST /api/v1/flows/ → 201`) and deleted id-scoped in `afterEach`.
 
 | # | State | Locator | Expected |
 |---|---|---|---|
-| 1 | After import + open | `getByText("5 components need updates")` | `toBeVisible()` |
-| 1 | After import + open | `getByTestId("review-button")` | `toHaveCount(5)` |
-| 1 | After import + open | `getByTestId("update-button")` | `toHaveCount(0)` |
+| 1 | After import + open | `getByTestId("review-button")` | `≥ 1` (breaking surfaced for Review) |
+| 1 | After import + open | `getByText(/\d+ components? need updates?/i)` | `toBeVisible()` |
 | 1 | After import + open | `getByTestId("update-all-button")` | text `Review All` |
 | 2 | Single review dialog | warning copy `/disconnect this component .* review or reconnect/i` | `toBeVisible()` |
 | 2 | Single review dialog | `getByTestId("backup-flow-checkbox")` | visible and `toBeChecked()` |
-| 3 | Review All dialog | `getByText("Breaking")` | `toHaveCount(5)` |
+| 3 | Review All dialog | `getByText("Breaking", { exact: true })` | `toHaveCount(breakingCount)` (== canvas `review-button` count) |
 | 3 | Review All dialog | `getByTestId("backup-flow-checkbox")` | `toBeChecked()` |
 | 3 | Review All dialog | `getByRole("button", { name: "Update Components" })` | `toBeDisabled()` |
 
-Each assertion fails if the breaking-change alert regresses: e.g. a breaking
-component routed to a silent `update-button`, the warning copy removed, the
-backup default flipped off, or a breaking component pre-selected (submit enabled).
+Each assertion fails if the breaking-change alert regresses: e.g. every breaking
+component routed to a silent `update-button` (no `review-button` left, toolbar
+falls back to "Update All"), the warning copy removed, the backup default flipped
+off, or a breaking component pre-selected (submit enabled).
+
+### Frozen-fixture caveat
+
+`outdated_flow.json` carries no per-node version — only a top-level
+`last_tested_version: "1.4.0"`. "Outdated" and "breaking" are therefore
+**emergent** from diffing that 1.4.0-era snapshot against whatever the running
+nightly ships, not pinned by the fixture. The assertions deliberately avoid a
+literal component count (they use `≥ 1` and the live `review-button` count) so a
+benign, unrelated version bump of one of the five components does **not**
+false-fail this `@stable` test as a product regression. If a future Langflow
+release ever makes *every* one of these components up-to-date or non-breaking,
+the durable signals (`review-button ≥ 1`, `Review All`) will legitimately fail —
+that is the cue to refresh the fixture to an older snapshot, not a product bug.
 
 ---
 

--- a/docs/core-components/component-breaking-change-alert.md
+++ b/docs/core-components/component-breaking-change-alert.md
@@ -1,0 +1,151 @@
+# Spec: Component update with a breaking change — should alert the user
+
+**Test file:** `tests/tests-automations/regression/core-components/component-breaking-change-alert.spec.ts`
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates
+
+When a saved flow contains components whose stored version is **behind** the
+current backend version **in a breaking way** (the update may change
+inputs/outputs or disconnect the node), Langflow must **alert the user** rather
+than silently updating: it surfaces a **"Review"** action (not the plain
+"Update"), warns that the update may disconnect the component, defaults to
+creating a backup, and refuses to pre-select the breaking components for update.
+
+The behaviour is driven off the frontend's outdated-component diff
+(`NodeUpdateComponent` and `UpdateComponentModal`). `hasBreakingChange`
+switches the node's action button between `data-testid="update-button"`
+(standard, safe) and `data-testid="review-button"` (breaking, must be reviewed),
+and the toolbar "update all" button between "Update All" and **"Review All"**.
+
+The state is produced deterministically by importing a fixture flow,
+`tests/assets/flows/outdated_flow.json` — 5 components (Prompt, Chat Input,
+OpenAI, Chat Output, Chat Memory) pinned to a version old enough that all 5
+resolve to **breaking** updates on the current nightly. The flow is dropped onto
+the flows-page drop zone (`cards-wrapper`) via a synthetic `DataTransfer` — the
+same event an OS drag-and-drop fires — the same import mechanism used by the
+`@stable` `import-invalid-json` spec.
+
+### Tests
+
+1. **Breaking-change outdated components alert with a Review action, not a
+   silent Update.** Import the fixture, open it, and assert the canvas banner
+   reads **"5 components need updates"**, that there are **5 `review-button`s and
+   0 `update-button`s** (every outdated component is breaking → all routed to
+   Review, none to a silent Update), and that the toolbar action reads
+   **"Review All"**.
+
+2. **Reviewing a single breaking change warns about disconnection and defaults
+   to a backup.** Click the first `review-button`; the review dialog must show
+   the breaking-change warning copy (it may *disconnect this component from your
+   flow, requiring you to review or reconnect it afterward*) and the
+   `backup-flow-checkbox` must be **present and checked by default**. The dialog
+   is then cancelled — the test never applies an update, so no flow state is
+   mutated.
+
+3. **"Review All" flags every outdated component as breaking and pre-selects
+   none.** Click the "Review All" toolbar button; the multi-component dialog must
+   show **5 "Breaking"** update-type tags (one per component), the
+   `backup-flow-checkbox` checked by default, and the submit button **"Update
+   Components" disabled** — because breaking components are intentionally *not*
+   pre-selected, the user must explicitly opt each one in before the update can
+   be applied. The dialog is cancelled without applying.
+
+No test applies the update (no "Update Component(s)" click), so the imported flow
+is never mutated and no `(Backup)` flow is created. Each imported flow is tracked
+by id (from `POST /api/v1/flows/ → 201`) and deleted id-scoped in `afterEach`.
+
+---
+
+## Tags
+
+`@stable` `@components` `@regression` `@ui-ux`
+
+---
+
+## Validation criterion
+
+| # | State | Locator | Expected |
+|---|---|---|---|
+| 1 | After import + open | `getByText("5 components need updates")` | `toBeVisible()` |
+| 1 | After import + open | `getByTestId("review-button")` | `toHaveCount(5)` |
+| 1 | After import + open | `getByTestId("update-button")` | `toHaveCount(0)` |
+| 1 | After import + open | `getByTestId("update-all-button")` | text `Review All` |
+| 2 | Single review dialog | warning copy `/disconnect this component .* review or reconnect/i` | `toBeVisible()` |
+| 2 | Single review dialog | `getByTestId("backup-flow-checkbox")` | visible and `toBeChecked()` |
+| 3 | Review All dialog | `getByText("Breaking")` | `toHaveCount(5)` |
+| 3 | Review All dialog | `getByTestId("backup-flow-checkbox")` | `toBeChecked()` |
+| 3 | Review All dialog | `getByRole("button", { name: "Update Components" })` | `toBeDisabled()` |
+
+Each assertion fails if the breaking-change alert regresses: e.g. a breaking
+component routed to a silent `update-button`, the warning copy removed, the
+backup default flipped off, or a breaking component pre-selected (submit enabled).
+
+---
+
+## External dependencies
+
+- `src/frontend/src/CustomNodes/GenericNode/components/NodeUpdateComponent/index.tsx`
+  — owns the per-node update bar; `hasBreakingChange` selects
+  `data-testid="review-button"` (label "Review") vs `"update-button"` (label
+  "Update") and the warning-dot colour / "Update available" label.
+- `src/frontend/src/modals/updateComponentModal/index.tsx` — the review dialog:
+  the breaking warning copy, the `backup-flow-checkbox` (default checked), the
+  "Breaking"/"Standard" update-type column, and the submit disabled when
+  `isMultiple && selectedComponents.size === 0` (breaking components start
+  unselected).
+- `tests/assets/flows/outdated_flow.json` — the fixture flow whose 5 components
+  are pinned behind the current version so all resolve to breaking updates.
+- No model-provider credentials required — the fixture's OpenAI node carries a
+  dummy key and no flow is executed.
+
+Testids, labels, banner text, the disabled-submit state and the 5×"Breaking"
+tags were confirmed live against `langflow-nightly 1.11.0.dev38` via a throwaway
+scout before authoring.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` on a recent nightly (1.11.x).
+- Auth via `auto_login` (repo default).
+
+---
+
+## Relationship to existing coverage
+
+`core-components/outdated-component-notification.spec.ts` is an inherited,
+non-`@stable`, conditional-bypass "documentation test": it adds a *fresh*
+component and only checks for an outdated indicator *if one happens to appear*
+(it never does on a current nightly), so it validates nothing deterministically.
+This spec is the dedicated, deterministic, `@stable` home for the **breaking**
+half of §2.3 — it forces the outdated+breaking state via a fixture import and
+asserts the concrete Review/warning/backup/opt-in alert surface. It does not
+duplicate the inherited spec's logic; consolidating that inherited spec is out of
+scope here.
+
+---
+
+## What this test does not cover
+
+- **Applying** the update (clicking "Update Component(s)") and asserting the node
+  refreshes / the backup flow is created — deliberately out of scope so no flow
+  state is mutated; that is the "Update component action" bullet, tracked
+  separately.
+- The **non-breaking** ("Update", green, auto-selected) path — this spec is about
+  the breaking alert. A non-breaking fixture would be a separate case.
+- The ag-grid row-checkbox internals — the user-facing "Update Components
+  disabled" state is asserted instead of `input[data-ref="eInput"]` indices.
+
+---
+
+## Notes
+
+- **Force-fail probes (executed during validation):** documented in the PR
+  Validation block — one mutation per test, each observed failing, then reverted.
+- The fixture is renamed with a unique per-run suffix before import so the test
+  waits for *its own* dropped card (avoids racing bootstrap-seeded cards), the
+  same pattern as the upstream `outdated-actions` reference.

--- a/docs/core-components/component-breaking-change-alert.md
+++ b/docs/core-components/component-breaking-change-alert.md
@@ -35,7 +35,7 @@ same event an OS drag-and-drop fires — the same import mechanism used by the
    silent Update.** Import the fixture, open it, and assert that **at least one
    `review-button`** is present (a breaking update is surfaced for Review rather
    than via the one-click silent `update-button`), that the canvas banner reports
-   the outdated total (`/\d+ components? need updates?/`), and that the toolbar
+   the outdated total (`/\d+ components? needs? updates?/`), and that the toolbar
    action reads **"Review All"** (which renders only when a breaking update is
    present). The count is asserted as `> 0`, not a pinned literal — see the
    *frozen-fixture* caveat below.
@@ -51,11 +51,16 @@ same event an OS drag-and-drop fires — the same import mechanism used by the
 3. **"Review All" flags every outdated component as breaking and pre-selects
    none.** Capture the breaking count from the canvas (`review-button` count),
    click the "Review All" toolbar button; the multi-component dialog must show
-   that many **"Breaking"** update-type tags (one per breaking component), the
-   `backup-flow-checkbox` checked by default, and the submit button **"Update
-   Components" disabled** — because breaking components are intentionally *not*
-   pre-selected, the user must explicitly opt each one in before the update can
-   be applied. The dialog is cancelled without applying.
+   that many **"Breaking"** update-type tags (one per breaking component) and the
+   `backup-flow-checkbox` checked by default. Because breaking components are
+   intentionally *not* pre-selected (the dialog seeds its selection with the
+   non-breaking components only), the user must explicitly opt each breaking one
+   in before it can be applied — with the current all-breaking fixture nothing is
+   pre-selected, so the submit **"Update Components"** button is **disabled**.
+   This is the one assertion that relies on the fixture being all-breaking, so
+   the precondition is asserted explicitly (`nonBreakingCount === 0`, captured
+   from the canvas): a future drift to a mixed fixture fails there with a clear
+   refresh cue rather than silently. The dialog is cancelled without applying.
 
 No test applies the update (no "Update Component(s)" click), so the imported flow
 is never mutated and no `(Backup)` flow is created. Each imported flow is tracked
@@ -74,13 +79,14 @@ by id (from `POST /api/v1/flows/ → 201`) and deleted id-scoped in `afterEach`.
 | # | State | Locator | Expected |
 |---|---|---|---|
 | 1 | After import + open | `getByTestId("review-button")` | `≥ 1` (breaking surfaced for Review) |
-| 1 | After import + open | `getByText(/\d+ components? need updates?/i)` | `toBeVisible()` |
+| 1 | After import + open | `getByText(/\d+ components? needs? updates?/i)` | `toBeVisible()` (also the shared import gate) |
 | 1 | After import + open | `getByTestId("update-all-button")` | text `Review All` |
 | 2 | Single review dialog | warning copy `/disconnect this component .* review or reconnect/i` | `toBeVisible()` |
 | 2 | Single review dialog | `getByTestId("backup-flow-checkbox")` | visible and `toBeChecked()` |
 | 3 | Review All dialog | `getByText("Breaking", { exact: true })` | `toHaveCount(breakingCount)` (== canvas `review-button` count) |
 | 3 | Review All dialog | `getByTestId("backup-flow-checkbox")` | `toBeChecked()` |
-| 3 | Review All dialog | `getByRole("button", { name: "Update Components" })` | `toBeDisabled()` |
+| 3 | Review All dialog | `nonBreakingCount` (canvas `update-button` count) | `toBe(0)` — explicit all-breaking precondition |
+| 3 | Review All dialog | `getByRole("button", { name: "Update Components" })` | `toBeDisabled()` — nothing pre-selected, opt-in required |
 
 Each assertion fails if the breaking-change alert regresses: e.g. every breaking
 component routed to a silent `update-button` (no `review-button` left, toolbar
@@ -92,13 +98,19 @@ off, or a breaking component pre-selected (submit enabled).
 `outdated_flow.json` carries no per-node version — only a top-level
 `last_tested_version: "1.4.0"`. "Outdated" and "breaking" are therefore
 **emergent** from diffing that 1.4.0-era snapshot against whatever the running
-nightly ships, not pinned by the fixture. The assertions deliberately avoid a
-literal component count (they use `≥ 1` and the live `review-button` count) so a
-benign, unrelated version bump of one of the five components does **not**
-false-fail this `@stable` test as a product regression. If a future Langflow
-release ever makes *every* one of these components up-to-date or non-breaking,
-the durable signals (`review-button ≥ 1`, `Review All`) will legitimately fail —
-that is the cue to refresh the fixture to an older snapshot, not a product bug.
+nightly ships, not pinned by the fixture. **Every** count-dependent check avoids
+a literal — including the shared import gate (a count-agnostic banner regex, not
+`"5 components need updates"`), the `≥ 1` / live `review-button` count, the
+`"Breaking"`-tag count (tracks the live `review-button` count), and the
+submit enabled/disabled branch (a function of the captured non-breaking count).
+So a benign, unrelated version bump of one of the five components — whether it
+becomes up-to-date (fewer outdated) or non-breaking (a mix) — does **not**
+false-fail this `@stable` test as a product regression.
+
+If a future Langflow release ever makes *every* one of these components
+up-to-date or non-breaking, the durable signals (`review-button ≥ 1`,
+`Review All`, the banner) will legitimately fail — that is the cue to refresh the
+fixture to an older snapshot, not a product bug.
 
 ---
 

--- a/tests/tests-automations/regression/core-components/component-breaking-change-alert.spec.ts
+++ b/tests/tests-automations/regression/core-components/component-breaking-change-alert.spec.ts
@@ -1,0 +1,182 @@
+import { readFileSync } from "fs";
+import path from "path";
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+
+// A saved flow whose 5 components (Prompt, Chat Input, OpenAI, Chat Output, Chat
+// Memory) are pinned behind the current backend version in a *breaking* way, so
+// every component resolves to a "Review"-gated breaking update on import. This is
+// the deterministic way to produce the outdated+breaking state the §2.3 bullet
+// ("Update with breaking change — should alert user") is about — a freshly-added
+// component is never outdated on a current nightly.
+const OUTDATED_FLOW = path.resolve(
+  __dirname,
+  "../../../assets/flows/outdated_flow.json",
+);
+
+// Track flows created by the drop-import so afterEach deletes them id-scoped
+// (repo convention, #490/#681) — never a global cleanAllFlows that would wipe a
+// concurrent worker's flow (#465/#515).
+const createdFlowIds: string[] = [];
+
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {});
+    }
+  });
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, { headers: { Authorization: bearer } }).catch(
+      () => {},
+    );
+  }
+});
+
+// Drop the fixture onto the flows-page drop zone (cards-wrapper) via a synthetic
+// DataTransfer — the same event an OS drag-and-drop fires, and the same import
+// mechanism the @stable import-invalid-json spec uses. The flow is renamed with a
+// unique per-run suffix so we wait for THIS dropped card, not a bootstrap-seeded
+// or sibling-test card.
+async function importOutdatedFlowAndOpen(page: Page): Promise<void> {
+  await awaitBootstrapTest(page, { skipModal: true });
+  await expect(page.getByTestId("mainpage_title")).toBeVisible({
+    timeout: 30000,
+  });
+
+  const raw = readFileSync(OUTDATED_FLOW, "utf-8");
+  const flowName = `Breaking Change Alert ${Date.now()}`;
+  const content = JSON.stringify({ ...JSON.parse(raw), name: flowName });
+
+  const dataTransfer = await page.evaluateHandle((d: string) => {
+    const dt = new DataTransfer();
+    dt.items.add(new File([d], "outdated_flow.json", { type: "application/json" }));
+    return dt;
+  }, content);
+  await page.getByTestId("cards-wrapper").dispatchEvent("drop", { dataTransfer });
+
+  const card = page.getByTestId("list-card").filter({ hasText: flowName });
+  await card.waitFor({ state: "visible", timeout: 30000 });
+  await card.click();
+
+  // The outdated banner is the frontend's signal that the diff finished computing.
+  await expect(page.getByText("5 components need updates")).toBeVisible({
+    timeout: 30000,
+  });
+}
+
+test(
+  "breaking-change outdated components alert with a Review action, not a silent Update",
+  { tag: ["@stable", "@components", "@regression", "@ui-ux"] },
+  async ({ page }) => {
+    trackCreatedFlows(page);
+
+    await test.step("Import the outdated fixture and open it", async () => {
+      await importOutdatedFlowAndOpen(page);
+    });
+
+    await test.step("Every outdated component is routed to Review (breaking), none to a silent Update", async () => {
+      // 5 breaking components → 5 Review buttons, 0 plain Update buttons. This
+      // is the crux of "alert the user": a breaking update is never applied via
+      // the one-click Update affordance.
+      await expect(page.getByTestId("review-button")).toHaveCount(5, {
+        timeout: 15000,
+      });
+      await expect(page.getByTestId("update-button")).toHaveCount(0);
+    });
+
+    await test.step('The toolbar action reads "Review All", not "Update All"', async () => {
+      await expect(page.getByTestId("update-all-button")).toHaveText(
+        "Review All",
+      );
+    });
+  },
+);
+
+test(
+  "reviewing a single breaking change warns about disconnection and defaults to a backup",
+  { tag: ["@stable", "@components", "@regression", "@ui-ux"] },
+  async ({ page }) => {
+    trackCreatedFlows(page);
+
+    await test.step("Import the outdated fixture and open it", async () => {
+      await importOutdatedFlowAndOpen(page);
+    });
+
+    await test.step("Open the review dialog for a single breaking component", async () => {
+      await page.getByTestId("review-button").first().click();
+      await expect(page.getByTestId("backup-flow-checkbox")).toBeVisible({
+        timeout: 15000,
+      });
+    });
+
+    await test.step("The dialog warns the update may disconnect the component", async () => {
+      await expect(
+        page.getByText(
+          /disconnect this component from your flow, requiring you to review or reconnect/i,
+        ),
+      ).toBeVisible();
+    });
+
+    await test.step("Creating a backup is offered and checked by default", async () => {
+      await expect(page.getByTestId("backup-flow-checkbox")).toBeVisible();
+      await expect(page.getByTestId("backup-flow-checkbox")).toBeChecked();
+    });
+
+    // Cancel without applying — this spec asserts the alert, never mutates the flow.
+    await page.keyboard.press("Escape");
+  },
+);
+
+test(
+  "Review All flags every outdated component as breaking and pre-selects none",
+  { tag: ["@stable", "@components", "@regression", "@ui-ux"] },
+  async ({ page }) => {
+    trackCreatedFlows(page);
+
+    await test.step("Import the outdated fixture and open it", async () => {
+      await importOutdatedFlowAndOpen(page);
+    });
+
+    await test.step("Open the Review All dialog", async () => {
+      await page.getByTestId("update-all-button").click();
+      await expect(page.getByTestId("backup-flow-checkbox")).toBeVisible({
+        timeout: 15000,
+      });
+    });
+
+    await test.step("Every component is tagged Breaking and a backup is default-on", async () => {
+      // One "Breaking" update-type tag per outdated component.
+      await expect(page.getByText("Breaking", { exact: true })).toHaveCount(5);
+      await expect(page.getByTestId("backup-flow-checkbox")).toBeChecked();
+    });
+
+    await test.step("The update cannot be applied until the user opts a breaking component in", async () => {
+      // Breaking components start unselected, so the submit is disabled — the
+      // user must explicitly opt each one in. This is the strongest form of the
+      // alert: the system refuses to auto-apply a breaking update.
+      await expect(
+        page.getByRole("button", { name: "Update Components" }),
+      ).toBeDisabled();
+    });
+
+    // Cancel without applying — no flow state is mutated.
+    await page.keyboard.press("Escape");
+  },
+);

--- a/tests/tests-automations/regression/core-components/component-breaking-change-alert.spec.ts
+++ b/tests/tests-automations/regression/core-components/component-breaking-change-alert.spec.ts
@@ -77,10 +77,14 @@ async function importOutdatedFlowAndOpen(page: Page): Promise<void> {
   await card.waitFor({ state: "visible", timeout: 30000 });
   await card.click();
 
-  // The outdated banner is the frontend's signal that the diff finished computing.
-  await expect(page.getByText("5 components need updates")).toBeVisible({
-    timeout: 30000,
-  });
+  // The outdated banner is the frontend's signal that the diff finished
+  // computing. Gate on the count-agnostic regex (not a pinned literal) so the
+  // shared helper does not silently re-pin the component count the tests
+  // deliberately relaxed — matches both the _one ("component needs updates")
+  // and _other ("components need updates") i18n plurals.
+  await expect(
+    page.getByText(/\d+ components? needs? updates?/i),
+  ).toBeVisible({ timeout: 30000 });
 }
 
 test(
@@ -108,7 +112,7 @@ test(
 
       // The banner reports the outdated total to the user.
       await expect(
-        page.getByText(/\d+ components? need updates?/i),
+        page.getByText(/\d+ components? needs? updates?/i),
       ).toBeVisible();
     });
 
@@ -164,13 +168,15 @@ test(
     trackCreatedFlows(page);
 
     let breakingCount = 0;
+    let nonBreakingCount = 0;
 
     await test.step("Import the outdated fixture and open it", async () => {
       await importOutdatedFlowAndOpen(page);
-      // Breaking components on the canvas = Review buttons. Capture the count
-      // (emergent from the frozen fixture vs the nightly) so the dialog
-      // assertions track it instead of a pinned literal.
+      // Breaking components on the canvas = Review buttons; non-breaking =
+      // Update buttons. Capture both (emergent from the frozen fixture vs the
+      // nightly) so the dialog assertions track them instead of a pinned literal.
       breakingCount = await page.getByTestId("review-button").count();
+      nonBreakingCount = await page.getByTestId("update-button").count();
       expect(breakingCount).toBeGreaterThan(0);
     });
 
@@ -191,10 +197,18 @@ test(
       await expect(page.getByTestId("backup-flow-checkbox")).toBeChecked();
     });
 
-    await test.step("The update cannot be applied until the user opts a breaking component in", async () => {
-      // Breaking components start unselected, so the submit is disabled — the
-      // user must explicitly opt each one in. This is the strongest form of the
-      // alert: the system refuses to auto-apply a breaking update.
+    await test.step("A breaking component is never pre-selected — the user must opt in", async () => {
+      // The dialog seeds its selection with the NON-breaking components only
+      // (updateComponentModal seeds `components.filter(c => !c.breakingChange)`),
+      // so the submit is disabled *exactly when* nothing is pre-selected — the
+      // all-breaking case, which forces an explicit opt-in for every update.
+      //
+      // This assertion is the one place the spec relies on the fixture being
+      // ALL breaking; we make that precondition explicit rather than silent, so
+      // a future drift to a mixed fixture fails HERE with a clear signal (refresh
+      // the fixture — see the frozen-fixture caveat) instead of confusingly at
+      // the disabled check.
+      expect(nonBreakingCount).toBe(0);
       await expect(
         page.getByRole("button", { name: "Update Components" }),
       ).toBeDisabled();

--- a/tests/tests-automations/regression/core-components/component-breaking-change-alert.spec.ts
+++ b/tests/tests-automations/regression/core-components/component-breaking-change-alert.spec.ts
@@ -43,9 +43,11 @@ test.afterEach(async ({ request }) => {
   if (createdFlowIds.length === 0) return;
   const bearer = await getAuthToken(request);
   for (const id of createdFlowIds.splice(0)) {
-    await deleteFlow(request, id, { headers: { Authorization: bearer } }).catch(
-      () => {},
-    );
+    // deleteFlow throws on a failed delete (repo convention #545) so a leak
+    // surfaces loudly instead of quietly accumulating. Cleanup is load-bearing
+    // here — unlike the rejected-import case, every test creates a real flow —
+    // so the throw is intentionally NOT swallowed.
+    await deleteFlow(request, id, { headers: { Authorization: bearer } });
   }
 });
 
@@ -91,17 +93,28 @@ test(
       await importOutdatedFlowAndOpen(page);
     });
 
-    await test.step("Every outdated component is routed to Review (breaking), none to a silent Update", async () => {
-      // 5 breaking components → 5 Review buttons, 0 plain Update buttons. This
-      // is the crux of "alert the user": a breaking update is never applied via
-      // the one-click Update affordance.
-      await expect(page.getByTestId("review-button")).toHaveCount(5, {
+    await test.step("At least one outdated component is a breaking change surfaced for Review", async () => {
+      // The fixture is a frozen 1.4.0 snapshot with no per-node version; the
+      // exact count of outdated/breaking components is emergent from diffing it
+      // against the running nightly. So we assert the DURABLE invariant — a
+      // breaking update is surfaced via Review, never a one-click silent Update —
+      // rather than a pinned count that would false-fail on any benign version
+      // bump. `review-button` (vs `update-button`) is the breaking affordance.
+      await expect(page.getByTestId("review-button").first()).toBeVisible({
         timeout: 15000,
       });
-      await expect(page.getByTestId("update-button")).toHaveCount(0);
+      const breakingCount = await page.getByTestId("review-button").count();
+      expect(breakingCount).toBeGreaterThan(0);
+
+      // The banner reports the outdated total to the user.
+      await expect(
+        page.getByText(/\d+ components? need updates?/i),
+      ).toBeVisible();
     });
 
-    await test.step('The toolbar action reads "Review All", not "Update All"', async () => {
+    await test.step('The toolbar action reads "Review All" (a breaking update is present), not "Update All"', async () => {
+      // "Review All" renders iff breakingChanges.length > 0, so it is the
+      // toolbar-level signal that the user is being alerted to a breaking update.
       await expect(page.getByTestId("update-all-button")).toHaveText(
         "Review All",
       );
@@ -150,8 +163,15 @@ test(
   async ({ page }) => {
     trackCreatedFlows(page);
 
+    let breakingCount = 0;
+
     await test.step("Import the outdated fixture and open it", async () => {
       await importOutdatedFlowAndOpen(page);
+      // Breaking components on the canvas = Review buttons. Capture the count
+      // (emergent from the frozen fixture vs the nightly) so the dialog
+      // assertions track it instead of a pinned literal.
+      breakingCount = await page.getByTestId("review-button").count();
+      expect(breakingCount).toBeGreaterThan(0);
     });
 
     await test.step("Open the Review All dialog", async () => {
@@ -161,9 +181,13 @@ test(
       });
     });
 
-    await test.step("Every component is tagged Breaking and a backup is default-on", async () => {
-      // One "Breaking" update-type tag per outdated component.
-      await expect(page.getByText("Breaking", { exact: true })).toHaveCount(5);
+    await test.step("Every breaking component is tagged Breaking and a backup is default-on", async () => {
+      // One "Breaking" update-type tag per breaking component. `exact: true` is
+      // load-bearing: the dialog's warning paragraph contains lowercase
+      // "breaking" inside a sentence, which a non-exact match would also catch.
+      await expect(page.getByText("Breaking", { exact: true })).toHaveCount(
+        breakingCount,
+      );
       await expect(page.getByTestId("backup-flow-checkbox")).toBeChecked();
     });
 


### PR DESCRIPTION
Closes #667.

Closes the `[ ] Update with breaking change — should alert user` gap in
`QA-CHECKLIST.md` §2.3 Component Updates. Distinct from the inherited
`outdated-component-notification.spec.ts`, which is a non-`@stable`
conditional-bypass "documentation test" (it adds a *fresh* component and only
checks for an indicator *if one happens to appear* — it never does on a current
nightly, so it validates nothing). This spec forces the outdated **breaking**
state deterministically via a fixture import and asserts the concrete alert
surface.

## 1. Covered tests
| # | Test | What it validates |
|---|------|-------------------|
| 1 | `breaking-change outdated components alert with a Review action, not a silent Update` | Importing a flow with breaking-outdated components surfaces a **Review** affordance, not a one-click silent Update: ≥1 `review-button` present, outdated banner shown, toolbar reads **"Review All"**. Catches a regression that would route a breaking update through the silent `update-button`. |
| 2 | `reviewing a single breaking change warns about disconnection and defaults to a backup` | The single-component review dialog warns the update *may disconnect this component … requiring you to review or reconnect*, and `backup-flow-checkbox` is present and **checked by default**. Catches removal of the warning copy or a flipped backup default. |
| 3 | `Review All flags every outdated component as breaking and pre-selects none` | The "Review All" dialog tags every breaking component **"Breaking"** (count tracks the live `review-button` count), keeps backup default-on, and — because breaking components are never pre-selected — leaves **"Update Components" disabled** (all-breaking fixture ⇒ nothing pre-selected). Catches a breaking component being silently pre-selected/auto-applied. |

No test applies the update (no "Update Component(s)" click), so no flow state is
mutated and no `(Backup)` flow is created.

## 2. How the test was built
- **Setup:** imports `tests/assets/flows/outdated_flow.json` (a previously-orphan
  fixture — no spec consumed it) via a synthetic `DataTransfer` drop on
  `cards-wrapper`, the same import mechanism as the `@stable`
  `import-invalid-json` spec. The flow is renamed with a unique per-run suffix so
  the test waits for its own dropped card, not a bootstrap-seeded one.
- **Live-confirmed selectors** (verified against the running nightly and the
  frontend source): `review-button`/`update-button` (`NodeUpdateComponent`,
  ternary on `hasBreakingChange`), `update-all-button` → "Review All"
  (`breakingChanges.length > 0`), `backup-flow-checkbox` (default checked),
  the "Breaking" update-type tag, and the `singleUpdateDesc` warning copy.
- **Frozen-fixture robustness:** the fixture has no per-node version — "outdated"
  and "breaking" are emergent from diffing the 1.4.0-era snapshot against the
  running nightly. Every count-dependent check avoids a literal (count-agnostic
  banner regex, `≥ 1` / live `review-button` count, "Breaking"-tag count tracking
  it) so a benign version bump doesn't false-fail this `@stable` test. The one
  all-breaking assumption (submit disabled) is asserted **explicitly**
  (`nonBreakingCount === 0`) so a drift to a mixed fixture fails with a clear
  refresh cue rather than silently. Documented in the spec doc's frozen-fixture
  caveat.
- **Cleanup:** each imported flow is tracked by id (`POST /api/v1/flows/ → 201`)
  and deleted id-scoped in `afterEach`; the `deleteFlow` throw is not swallowed,
  so a cleanup leak surfaces loudly (#545).

## 3. Dependencies
- **None** — pure UI/import. The fixture's OpenAI node carries a dummy key and no
  flow is executed, so no provider credentials are needed.
- **Execution:** parallel-safe (id-scoped cleanup, unique per-run flow names); run
  with `--workers=1` locally for a clean single-worker trace.

## Validation (nightly 1.11.0.dev38, `--retries=0`)
- `npm run typecheck` ✅ · `eslint` on the spec ✅ (0 warnings) · fixture-import
  cleanup verified (0 orphan / `(Backup)` flows via `GET /api/v1/flows/`) ✅
- 3/3 green; repeat-each=2 burst 6/6, no flake ✅
- **force-fail executed for every test, then reverted** ✅:
  - T1 `review-button` `>0`→`>999` ⇒ failed (received 5)
  - T2 backup `toBeChecked()`→`not.toBeChecked()` ⇒ failed (received checked)
  - T3 `nonBreakingCount toBe(0)`→`toBe(1)` ⇒ failed (received 0); "Breaking" count `+1` ⇒ failed (6≠5)
- zero `🚨 Backend Error` during import+open ✅
- `--trace=on` skipped (known local hang limitation); covered via `--retries=0`
  bursts + force-fail + a live scout instead.

Spec doc: `docs/core-components/component-breaking-change-alert.md`.
