### PR TITLE
test(knowledge-ingestion): add full RAG pipeline spec (#675)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -305,7 +305,7 @@
 - [x] Split Text chunking of an ingested document → `core-functionality/knowledge-ingestion-management/split-text-chunking.spec.ts`
 - [x] Indexing in Vector Store — document available for query → `core-functionality/knowledge-ingestion-management/vector-store-index-query.spec.ts`
 - [x] Vector Store query returns relevant chunks for the prompt → `core-functionality/knowledge-ingestion-management/vector-store-index-query.spec.ts`
-- [ ] Complete RAG pipeline (ingest → embed → store → retrieve → answer)
+- [x] Complete RAG pipeline (ingest → embed → store → retrieve → answer) → `core-functionality/knowledge-ingestion-management/rag-pipeline.spec.ts`
 
 ---
 

--- a/docs/core-functionality/knowledge-ingestion-management/rag-pipeline.md
+++ b/docs/core-functionality/knowledge-ingestion-management/rag-pipeline.md
@@ -1,0 +1,235 @@
+# Spec: Full RAG pipeline — ingest → embed → store → retrieve → answer (§5.2 Processing and Vectorization)
+
+**Test file:** `tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/rag-pipeline.spec.ts`
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates
+
+The **complete RAG pipeline end-to-end** (§5.2.4), on a running flow. It is the
+final §5.2 step that the two sibling specs deliberately left out:
+
+- #673 (`split-text-chunking.spec.ts`) covers §5.2.1 — deterministic chunking.
+- #674 (`vector-store-index-query.spec.ts`) covers §5.2.2/§5.2.3 — embedding +
+  indexing into a native Knowledge Base and semantic retrieval of the relevant
+  chunk.
+
+This spec adds §5.2.4 — the **answer** step: the chunk retrieved from the vector
+store is fed to a language model, and the model's answer is proven to be
+**grounded on that retrieved chunk** rather than on the model's own parametric
+knowledge. That is the whole point of RAG, and the property this test is designed
+to make falsifiable.
+
+### The grounding observable (fabricated, unguessable fact)
+
+The ingested document contains a **fabricated fact that no language model could
+know from training**: sentence 3 states that each chunk is converted into an
+embedding vector *"by the internal **ZEPHYR-42** codec"*. `ZEPHYR-42` is an
+invented token; it exists only inside the document.
+
+The pipeline's static question asks exactly for that codec name, and the test
+asserts the Chat Output answer **contains `ZEPHYR-42`**. Because the token is
+fabricated:
+
+- If retrieval → context injection → the model answer all work, the answer echoes
+  the verbatim `ZEPHYR-42` from the retrieved chunk.
+- If retrieval is broken, the context empty, or the model answers from its own
+  knowledge, it **cannot** produce `ZEPHYR-42` — the assertion fails.
+
+The model runs at `temperature = 0`, so the grounded, verbatim token is
+deterministic. This is sharper than asserting a real phrase from the document
+(which a model could plausibly emit unaided) — a real-phrase check would carry a
+latent false-positive; the fabricated token removes it.
+
+### Topology (single fixture flow)
+
+```
+Ingest:  Chat Input(document) → Split Text → Knowledge[Ingest]
+Answer:  Knowledge[Retrieve] → Parser → Prompt{context} → Language Model → Chat Output
+```
+
+- **Ingest side** — reused verbatim from #674: the deterministic, bundle-free
+  Chat Input → Split Text → native Knowledge Base ingest. Split Text is required
+  (the Knowledge component ingests one chunk per input row; its `chunk_size` is
+  the embedding batch size, not a splitter), so the 5-sentence document yields
+  exactly 5 indexed chunks.
+- **Answer side** — `Knowledge[Retrieve]` (`mode = Retrieve`, `top_k = 1`, static
+  `search_query`) returns the relevant chunk as a **Table**; a **Parser** converts
+  that Table into a **Message** (the Retrieve output is JSON/Table, not a Message,
+  so the Parser is the required bridge to the Prompt); the **Prompt** injects it
+  into a single `{context}` variable and bakes the question into the template text
+  (no Chat Input on the answer side — the question is static); the **Language
+  Model** answers; **Chat Output** exposes the answer.
+
+### Why the native Knowledge Base + these components (bundle-free)
+
+Same rationale as #674: every drop-in vector store (FAISS, Chroma DB, …) is a
+**bundle** (`ext:…@official`), so a bundle-dependent `@stable` test would fail on
+a packaging change rather than a real regression. The **Knowledge** component
+(`files_and_knowledge/Knowledge`, non-legacy) is the **core**, ChromaDB-backed
+vector-store primitive; **Split Text**, **Parser**, **Prompt** and **Chat Output**
+are all core; the **Language Model** component is core. So the whole pipeline is
+bundle-free and never yields a false failure on a packaging change.
+
+### Embedding + answer model (single-key: Google)
+
+- **Embedding:** the KB is created with Google `gemini-embedding-001` (the
+  embedding model enabled out-of-the-box; `GOOGLE_API_KEY` is auto-imported as a
+  credential and injected in the daily-stable CI).
+- **Answer:** the Language Model uses Google **`gemini-2.5-flash`** at
+  `temperature = 0`. Its `api_key` resolves from the same `GOOGLE_API_KEY` global
+  variable (`load_from_db`), so the entire spec depends on **one** provider key —
+  one skip guard, aligned with the daily-stable CI. The unified model selector's
+  serialized value (`model` field, provider `Google Generative AI`) was captured
+  live from the UI; hand-crafting it is unreliable because it overrides the legacy
+  provider/model fields.
+
+### Key/bundle guard
+
+The components are all core, so **no bundle presence guard is needed**. The spec
+**skips** only when `GOOGLE_API_KEY` is not configured (embedding + answer both
+need a live Google key), matching the provider-key skips elsewhere in the suite.
+
+## Validation criterion (concrete, distinctive)
+
+Fixture flow as above. The ingested document is the #674 5-sentence document with
+sentence 3 rewritten to carry the fabricated fact:
+`"Each chunk is converted into a numerical embedding vector by the internal ZEPHYR-42 codec."`
+The static retrieve query targets that sentence
+(`"Which internal codec converts each chunk into a numerical embedding vector?"`),
+and the Prompt asks the model to answer *with the exact codec name only*.
+
+A **fresh, uniquely-named KB per run** (via the KB API) is created and deleted in
+teardown.
+
+**Single test — full pipeline (§5.2.4):**
+1. Run the **Knowledge (Ingest)** node; its success-build badge
+   `node_duration_knowledge` becomes visible, and `GET
+   /api/v1/knowledge_bases/{name}` reports **exactly 5 chunks** — a precondition
+   proof that the document is embedded + indexed (so a later answer failure is
+   unambiguously an answer-side failure, not a broken ingest).
+2. Run the **Chat Output** node (which pulls the whole answer chain
+   Retrieve → Parser → Prompt → Language Model → Chat Output; the ingest branch is
+   *not* upstream of Chat Output, so it does not re-run). Its
+   `node_duration_...` badge becomes visible.
+3. Open the Chat Output node's output inspector and read the answer; assert it
+   **contains `ZEPHYR-42`** (case-sensitive, verbatim).
+
+The answer observed live on 1.11.0.dev38 is exactly `ZEPHYR-42`.
+
+> **Why the pipeline is run node-by-node, not via `POST /api/v1/run`.** Running
+> the whole flow via the run/build API re-executes the ingest branch with an
+> empty Chat Input (the document is only present when the ingest node runs on the
+> canvas), which fails at `Knowledge[Ingest]` (`Column 'text' not found in
+> DataFrame`). Ingest and answer must be run as separate node runs — exactly the
+> #674 pattern. Running the **Chat Output** node builds only its upstream
+> (Retrieve → … → Chat Output); Retrieve reads the KB already populated by the
+> prior Ingest run.
+
+---
+
+## Tags
+
+`@stable` `@release` `@components` `@files`
+
+(`@files`: knowledge-ingestion surface — functional. `@components`:
+canvas-component configuration. `@stable`/`@release` cross-cutting. Third and
+final §5.2 RAG spec, builds on #673/#674; created `@stable` after deterministic
+end-to-end validation on the fresh nightly. All-core components — no bundle guard;
+skips cleanly only when `GOOGLE_API_KEY` is absent.)
+
+---
+
+## Step by step
+
+One test, one shared fixture flow, imported via the API with a unique flow name
+per run.
+
+**Guard:** skip if `GOOGLE_API_KEY` is unset.
+
+**Setup:**
+1. Create a fresh KB via `POST /api/v1/knowledge_bases` — unique name per run,
+   `embedding_provider = "Google Generative AI"`, `embedding_model =
+   "gemini-embedding-001"`, `backend_type = "chroma"`. Record the KB `dir_name`
+   for teardown.
+2. Load the fixture JSON and set `knowledge_base.value` **and**
+   `knowledge_base.options = [dir_name]` on **both** Knowledge nodes (both are
+   required for the DropdownInput to treat the value as a valid selection).
+3. Create the flow via `POST /api/v1/flows/` (`createFlow`, unique name), record
+   its id, navigate to `/flow/{id}`, wait for a Knowledge node title, then adjust
+   the canvas view so the target node run controls are rendered and clickable.
+
+**Test — full RAG pipeline:**
+1. Run Ingest: click `button_run_knowledge` scoped to `[data-id="Knowledge-ingest"]`;
+   assert its `node_duration_knowledge` badge is visible.
+2. Assert `GET /api/v1/knowledge_bases/{dir_name}` reports `chunks === 5`.
+3. Run the answer path: click the Chat Output run button
+   (`button_run_chat output`) scoped to `[data-id="ChatOutput-answer"]`; wait for
+   its build badge.
+4. Open the Chat Output output inspector
+   (`output-inspection-output message-chatoutput`, scoped to
+   `ChatOutput-answer`) and assert the answer text contains `ZEPHYR-42`.
+
+---
+
+## External dependencies
+
+- Fixture asset `tests/assets/flows/rag-pipeline-fixture.json` — Chat Input
+  (`input_value` = the 5-sentence document, sentence 3 carrying the fabricated
+  `ZEPHYR-42` codec fact) → Split Text (`chunk_size = 100`, `chunk_overlap = 0`,
+  `separator = "\n"`) → Knowledge (`mode = Ingest`); plus Knowledge
+  (`mode = Retrieve`, `top_k = 1`, `search_query` = the codec question) → Parser →
+  Prompt (`{context}` + baked question) → Language Model (Google `gemini-2.5-flash`,
+  `temperature = 0`, `api_key` from the `GOOGLE_API_KEY` global variable) → Chat
+  Output. Both Knowledge nodes' `knowledge_base` is a placeholder (`__KB_NAME__`)
+  the spec replaces per run. Built + configured live on the canvas and validated
+  end-to-end on 1.11.0.dev38.
+- `GOOGLE_API_KEY` — required (embeds each chunk with `gemini-embedding-001` and
+  answers with `gemini-2.5-flash`).
+- Knowledge Base API: `POST /api/v1/knowledge_bases` (create),
+  `GET /api/v1/knowledge_bases/{name}` (chunk count),
+  `DELETE /api/v1/knowledge_bases/{name}` (scoped cleanup).
+- Flows API: `POST /api/v1/flows/` (fixture create), `DELETE /api/v1/flows/{id}`
+  (scoped cleanup).
+- Component/UI testids (scouted live on 1.11.0.dev38): node ids `Knowledge-ingest`,
+  `Knowledge-retrieve`, `Parser-answer`, `Prompt-answer`, `LanguageModel-answer`,
+  `ChatOutput-answer`; `button_run_knowledge`, `node_duration_knowledge` (scoped by
+  Knowledge node `data-id`); `button_run_chat output`,
+  `output-inspection-output message-chatoutput` (scoped by `ChatOutput-answer`);
+  the answer text is the `textarea` inside the Component Output dialog.
+
+---
+
+## What this test does not cover
+
+- Split Text chunking itself (§5.2.1 — #673, `split-text-chunking.spec.ts`).
+- Vector-store indexing + retrieval in isolation (§5.2.2/§5.2.3 — #674,
+  `vector-store-index-query.spec.ts`). This spec re-asserts the 5-chunk index only
+  as a precondition, not as new coverage.
+- Drop-in vector-store bundles (FAISS, Chroma DB component, …) — the core
+  Knowledge base is used precisely to stay bundle-free.
+- File upload as the document source (§5.1); this spec sources the document from
+  Chat Input to stay hermetic and deterministic.
+- Multi-turn / conversational RAG, re-ranking, and multi-document retrieval.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` (auto_login).
+- `GOOGLE_API_KEY` configured in `.env` (else the test skips).
+
+---
+
+## Flow cleanup
+
+Both the flow and the KB are created via the API, so both ids/names are known up
+front. The test records the created flow id and KB `dir_name` and, in
+`afterEach`, deletes exactly those (`deleteFlow` + `DELETE
+/api/v1/knowledge_bases/{name}`, both 404-tolerant, scoped — never a global wipe,
+which would delete resources other parallel workers are using, #515). The KB is a
+persistent instance resource, so its teardown is mandatory to avoid orphans.
+Orphan counts are checked via `GET /api/v1/flows/` and `GET
+/api/v1/knowledge_bases` before reporting.

--- a/tests/assets/flows/rag-pipeline-fixture.json
+++ b/tests/assets/flows/rag-pipeline-fixture.json
@@ -1,0 +1,3582 @@
+{
+ "name": "Vector Store Index Query",
+ "description": "Full RAG pipeline (#675 §5.2.4): Chat Input(doc) -> Split Text -> Knowledge[Ingest]; Knowledge[Retrieve] -> Parser -> Prompt{context} -> Language Model(Google) -> Chat Output. Answer must contain the fabricated fact ZEPHYR-42 grounded on the retrieved chunk. KB name (__KB_NAME__) is templated per run by the spec.",
+ "data": {
+  "nodes": [
+   {
+    "data": {
+     "id": "ChatInput-doc01",
+     "node": {
+      "base_classes": [
+       "Message"
+      ],
+      "beta": false,
+      "conditional_paths": [],
+      "custom_fields": {},
+      "description": "Get chat inputs from the Playground.",
+      "display_name": "Chat Input",
+      "documentation": "",
+      "edited": false,
+      "field_order": [
+       "input_value",
+       "should_store_message",
+       "sender",
+       "sender_name",
+       "session_id",
+       "context_id",
+       "files"
+      ],
+      "frozen": false,
+      "icon": "MessagesSquare",
+      "legacy": false,
+      "lf_version": "1.11.0.dev38",
+      "metadata": {
+       "module": "lfx.components.input_output.chat.ChatInput",
+       "code_hash": "7a26c54d89ed",
+       "dependencies": {
+        "total_dependencies": 1,
+        "dependencies": [
+         {
+          "name": "lfx",
+          "version": "1.11.0.dev38"
+         }
+        ]
+       }
+      },
+      "minimized": true,
+      "output_types": [],
+      "outputs": [
+       {
+        "types": [
+         "Message"
+        ],
+        "selected": "Message",
+        "name": "message",
+        "display_name": "Chat Message",
+        "method": "message_response",
+        "value": "__UNDEFINED__",
+        "cache": true,
+        "allows_loop": false,
+        "group_outputs": false,
+        "tool_mode": true
+       }
+      ],
+      "pinned": false,
+      "template": {
+       "_type": "Component",
+       "code": {
+        "type": "code",
+        "required": true,
+        "placeholder": "",
+        "list": false,
+        "show": true,
+        "multiline": true,
+        "value": "from lfx.base.data.utils import IMG_FILE_TYPES, TEXT_FILE_TYPES\nfrom lfx.base.io.chat import ChatComponent\nfrom lfx.inputs.inputs import BoolInput\nfrom lfx.io import (\n    DropdownInput,\n    FileInput,\n    MessageTextInput,\n    MultilineInput,\n    Output,\n)\nfrom lfx.schema.message import Message\nfrom lfx.utils.constants import (\n    MESSAGE_SENDER_AI,\n    MESSAGE_SENDER_NAME_USER,\n    MESSAGE_SENDER_USER,\n)\n\n\nclass ChatInput(ChatComponent):\n    display_name = \"Chat Input\"\n    description = \"Get chat inputs from the Playground.\"\n    documentation: str = \"https://docs.langflow.org/chat-input-and-output\"\n    icon = \"MessagesSquare\"\n    name = \"ChatInput\"\n    minimized = True\n\n    inputs = [\n        MultilineInput(\n            name=\"input_value\",\n            display_name=\"Input Text\",\n            value=\"\",\n            info=\"Message to be passed as input.\",\n            input_types=[],\n        ),\n        BoolInput(\n            name=\"should_store_message\",\n            display_name=\"Store Messages\",\n            info=\"Store the message in the history.\",\n            value=True,\n            advanced=True,\n        ),\n        DropdownInput(\n            name=\"sender\",\n            display_name=\"Sender Type\",\n            options=[MESSAGE_SENDER_AI, MESSAGE_SENDER_USER],\n            value=MESSAGE_SENDER_USER,\n            info=\"Type of sender.\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"sender_name\",\n            display_name=\"Sender Name\",\n            info=\"Name of the sender.\",\n            value=MESSAGE_SENDER_NAME_USER,\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"session_id\",\n            display_name=\"Session ID\",\n            info=\"The session ID of the chat. If empty, the current session ID parameter will be used.\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"context_id\",\n            display_name=\"Context ID\",\n            info=\"The context ID of the chat. Adds an extra layer to the local memory.\",\n            value=\"\",\n            advanced=True,\n        ),\n        FileInput(\n            name=\"files\",\n            display_name=\"Files\",\n            file_types=TEXT_FILE_TYPES + IMG_FILE_TYPES,\n            info=\"Files to be sent with the message.\",\n            advanced=True,\n            is_list=True,\n            temp_file=True,\n        ),\n    ]\n    outputs = [\n        Output(display_name=\"Chat Message\", name=\"message\", method=\"message_response\"),\n    ]\n\n    async def message_response(self) -> Message:\n        # Ensure files is a list and filter out empty/None values\n        files = self.files if self.files else []\n        if files and not isinstance(files, list):\n            files = [files]\n        # Filter out None/empty values\n        files = [f for f in files if f is not None and f != \"\"]\n\n        session_id = self.session_id or self.graph.session_id or \"\"\n        message = await Message.create(\n            text=self.input_value,\n            sender=self.sender,\n            sender_name=self.sender_name,\n            session_id=session_id,\n            context_id=self.context_id,\n            files=files,\n        )\n        if session_id and isinstance(message, Message) and self.should_store_message:\n            stored_message = await self.send_message(\n                message,\n            )\n            self.message.value = stored_message\n            message = stored_message\n\n        self.status = message\n        return message\n",
+        "fileTypes": [],
+        "file_path": "",
+        "password": false,
+        "name": "code",
+        "advanced": true,
+        "dynamic": true,
+        "info": "",
+        "load_from_db": false,
+        "title_case": false
+       },
+       "context_id": {
+        "_input_type": "MessageTextInput",
+        "advanced": true,
+        "display_name": "Context ID",
+        "dynamic": false,
+        "info": "The context ID of the chat. Adds an extra layer to the local memory.",
+        "input_types": [
+         "Message"
+        ],
+        "list": false,
+        "list_add_label": "Add More",
+        "load_from_db": false,
+        "name": "context_id",
+        "placeholder": "",
+        "required": false,
+        "show": true,
+        "title_case": false,
+        "tool_mode": false,
+        "trace_as_input": true,
+        "trace_as_metadata": true,
+        "type": "str",
+        "value": ""
+       },
+       "files": {
+        "_input_type": "FileInput",
+        "advanced": true,
+        "display_name": "Files",
+        "dynamic": false,
+        "fileTypes": [
+         "csv",
+         "json",
+         "pdf",
+         "txt",
+         "md",
+         "mdx",
+         "yaml",
+         "yml",
+         "xml",
+         "html",
+         "htm",
+         "docx",
+         "py",
+         "sh",
+         "sql",
+         "js",
+         "ts",
+         "tsx",
+         "jpg",
+         "jpeg",
+         "png",
+         "bmp",
+         "image"
+        ],
+        "file_path": "",
+        "info": "Files to be sent with the message.",
+        "list": true,
+        "list_add_label": "Add More",
+        "name": "files",
+        "placeholder": "",
+        "required": false,
+        "show": true,
+        "temp_file": true,
+        "title_case": false,
+        "trace_as_metadata": true,
+        "type": "file",
+        "value": ""
+       },
+       "input_value": {
+        "_input_type": "MultilineInput",
+        "advanced": false,
+        "copy_field": false,
+        "display_name": "Input Text",
+        "dynamic": false,
+        "info": "Message to be passed as input.",
+        "input_types": [],
+        "list": false,
+        "list_add_label": "Add More",
+        "load_from_db": false,
+        "multiline": true,
+        "name": "input_value",
+        "placeholder": "",
+        "required": false,
+        "show": true,
+        "title_case": false,
+        "tool_mode": false,
+        "trace_as_input": true,
+        "trace_as_metadata": true,
+        "type": "str",
+        "value": "Langflow lets you build agentic pipelines by wiring visual components together on a canvas.\nThe Split Text component divides an ingested document into smaller overlapping textual chunks.\nEach chunk is converted into a numerical embedding vector by the internal ZEPHYR-42 codec.\nThose embeddings are indexed inside a vector store so semantically similar text can be retrieved.\nA retrieval augmented generation flow finally grounds the language model answer on those chunks."
+       },
+       "sender": {
+        "_input_type": "DropdownInput",
+        "advanced": true,
+        "combobox": false,
+        "dialog_inputs": {},
+        "display_name": "Sender Type",
+        "dynamic": false,
+        "info": "Type of sender.",
+        "name": "sender",
+        "options": [
+         "Machine",
+         "User"
+        ],
+        "options_metadata": [],
+        "placeholder": "",
+        "required": false,
+        "show": true,
+        "title_case": false,
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "type": "str",
+        "value": "User"
+       },
+       "sender_name": {
+        "_input_type": "MessageTextInput",
+        "advanced": true,
+        "display_name": "Sender Name",
+        "dynamic": false,
+        "info": "Name of the sender.",
+        "input_types": [
+         "Message"
+        ],
+        "list": false,
+        "list_add_label": "Add More",
+        "load_from_db": false,
+        "name": "sender_name",
+        "placeholder": "",
+        "required": false,
+        "show": true,
+        "title_case": false,
+        "tool_mode": false,
+        "trace_as_input": true,
+        "trace_as_metadata": true,
+        "type": "str",
+        "value": "User"
+       },
+       "session_id": {
+        "_input_type": "MessageTextInput",
+        "advanced": true,
+        "display_name": "Session ID",
+        "dynamic": false,
+        "info": "The session ID of the chat. If empty, the current session ID parameter will be used.",
+        "input_types": [
+         "Message"
+        ],
+        "list": false,
+        "list_add_label": "Add More",
+        "load_from_db": false,
+        "name": "session_id",
+        "placeholder": "",
+        "required": false,
+        "show": true,
+        "title_case": false,
+        "tool_mode": false,
+        "trace_as_input": true,
+        "trace_as_metadata": true,
+        "type": "str",
+        "value": ""
+       },
+       "should_store_message": {
+        "_input_type": "BoolInput",
+        "advanced": true,
+        "display_name": "Store Messages",
+        "dynamic": false,
+        "info": "Store the message in the history.",
+        "list": false,
+        "list_add_label": "Add More",
+        "name": "should_store_message",
+        "placeholder": "",
+        "required": false,
+        "show": true,
+        "title_case": false,
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "type": "bool",
+        "value": true
+       }
+      },
+      "tool_mode": false
+     },
+     "selected_output": "message",
+     "showNode": false,
+     "type": "ChatInput"
+    },
+    "dragging": false,
+    "id": "ChatInput-doc01",
+    "measured": {
+     "height": 52,
+     "width": 192
+    },
+    "position": {
+     "x": 0,
+     "y": 80
+    },
+    "positionAbsolute": {
+     "x": 0,
+     "y": 80
+    },
+    "selected": false,
+    "type": "genericNode"
+   },
+   {
+    "id": "SplitText-doc01",
+    "type": "genericNode",
+    "position": {
+     "x": 450,
+     "y": 80
+    },
+    "data": {
+     "node": {
+      "template": {
+       "_type": "Component",
+       "data_inputs": {
+        "trace_as_metadata": true,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": true,
+        "placeholder": "",
+        "show": true,
+        "name": "data_inputs",
+        "value": "",
+        "display_name": "Input",
+        "advanced": false,
+        "input_types": [
+         "Data",
+         "JSON",
+         "DataFrame",
+         "Table",
+         "Message"
+        ],
+        "dynamic": false,
+        "info": "The data with texts to split in chunks.",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "other",
+        "_input_type": "HandleInput"
+       },
+       "chunk_overlap": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "chunk_overlap",
+        "value": 0,
+        "display_name": "Chunk Overlap",
+        "advanced": false,
+        "dynamic": false,
+        "info": "Number of characters to overlap between chunks.",
+        "title_case": false,
+        "track_in_telemetry": true,
+        "type": "int",
+        "_input_type": "IntInput"
+       },
+       "chunk_size": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "chunk_size",
+        "value": 100,
+        "display_name": "Chunk Size",
+        "advanced": false,
+        "dynamic": false,
+        "info": "The maximum length of each chunk. Text is first split by separator, then chunks are merged up to this size. Individual splits larger than this won't be further divided.",
+        "title_case": false,
+        "track_in_telemetry": true,
+        "type": "int",
+        "_input_type": "IntInput"
+       },
+       "clean_output": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "clean_output",
+        "value": false,
+        "display_name": "Clean Output",
+        "advanced": true,
+        "dynamic": false,
+        "info": "When enabled, only the text column is included in the output. Metadata columns are removed.",
+        "title_case": false,
+        "track_in_telemetry": true,
+        "type": "bool",
+        "_input_type": "BoolInput"
+       },
+       "code": {
+        "type": "code",
+        "required": true,
+        "placeholder": "",
+        "list": false,
+        "show": true,
+        "multiline": true,
+        "value": "from langchain_text_splitters import CharacterTextSplitter\n\nfrom lfx.custom.custom_component.component import Component\nfrom lfx.io import BoolInput, DropdownInput, HandleInput, IntInput, MessageTextInput, Output\nfrom lfx.schema.data import Data\nfrom lfx.schema.dataframe import DataFrame\nfrom lfx.schema.message import Message\nfrom lfx.utils.util import unescape_string\n\n\nclass SplitTextComponent(Component):\n    display_name: str = \"Split Text\"\n    description: str = \"Split text into chunks based on specified criteria.\"\n    documentation: str = \"https://docs.langflow.org/split-text\"\n    icon = \"scissors-line-dashed\"\n    name = \"SplitText\"\n\n    inputs = [\n        HandleInput(\n            name=\"data_inputs\",\n            display_name=\"Input\",\n            info=\"The data with texts to split in chunks.\",\n            input_types=[\"Data\", \"JSON\", \"DataFrame\", \"Table\", \"Message\"],\n            required=True,\n        ),\n        IntInput(\n            name=\"chunk_overlap\",\n            display_name=\"Chunk Overlap\",\n            info=\"Number of characters to overlap between chunks.\",\n            value=200,\n        ),\n        IntInput(\n            name=\"chunk_size\",\n            display_name=\"Chunk Size\",\n            info=(\n                \"The maximum length of each chunk. Text is first split by separator, \"\n                \"then chunks are merged up to this size. \"\n                \"Individual splits larger than this won't be further divided.\"\n            ),\n            value=1000,\n        ),\n        MessageTextInput(\n            name=\"separator\",\n            display_name=\"Separator\",\n            info=(\n                \"The character to split on. Use \\\\n for newline. \"\n                \"Examples: \\\\n\\\\n for paragraphs, \\\\n for lines, . for sentences\"\n            ),\n            value=\"\\n\",\n        ),\n        MessageTextInput(\n            name=\"text_key\",\n            display_name=\"Text Key\",\n            info=\"The key to use for the text column.\",\n            value=\"text\",\n            advanced=True,\n        ),\n        DropdownInput(\n            name=\"keep_separator\",\n            display_name=\"Keep Separator\",\n            info=\"Whether to keep the separator in the output chunks and where to place it.\",\n            options=[\"False\", \"True\", \"Start\", \"End\"],\n            value=\"False\",\n            advanced=True,\n        ),\n        BoolInput(\n            name=\"clean_output\",\n            display_name=\"Clean Output\",\n            info=\"When enabled, only the text column is included in the output. Metadata columns are removed.\",\n            value=False,\n            advanced=True,\n        ),\n    ]\n\n    outputs = [\n        Output(display_name=\"Chunks\", name=\"dataframe\", method=\"split_text\"),\n    ]\n\n    def _docs_to_data(self, docs, *, clean: bool = False) -> list[Data]:\n        return [\n            Data(text=doc.page_content) if clean else Data(text=doc.page_content, data=doc.metadata) for doc in docs\n        ]\n\n    def _fix_separator(self, separator: str) -> str:\n        \"\"\"Fix common separator issues and convert to proper format.\"\"\"\n        if separator == \"/n\":\n            return \"\\n\"\n        if separator == \"/t\":\n            return \"\\t\"\n        return separator\n\n    def split_text_base(self):\n        separator = self._fix_separator(self.separator)\n        separator = unescape_string(separator)\n\n        if isinstance(self.data_inputs, DataFrame):\n            if not len(self.data_inputs):\n                msg = \"DataFrame is empty\"\n                raise TypeError(msg)\n\n            self.data_inputs.text_key = self.text_key\n            try:\n                documents = self.data_inputs.to_lc_documents()\n            except Exception as e:\n                msg = f\"Error converting DataFrame to documents: {e}\"\n                raise TypeError(msg) from e\n        elif isinstance(self.data_inputs, Message):\n            self.data_inputs = [self.data_inputs.to_data()]\n            return self.split_text_base()\n        else:\n            if not self.data_inputs:\n                msg = \"No data inputs provided\"\n                raise TypeError(msg)\n\n            documents = []\n            if isinstance(self.data_inputs, Data):\n                self.data_inputs.text_key = self.text_key\n                documents = [self.data_inputs.to_lc_document()]\n            else:\n                try:\n                    documents = [input_.to_lc_document() for input_ in self.data_inputs if isinstance(input_, Data)]\n                    if not documents:\n                        msg = f\"No valid Data inputs found in {type(self.data_inputs)}\"\n                        raise TypeError(msg)\n                except AttributeError as e:\n                    msg = f\"Invalid input type in collection: {e}\"\n                    raise TypeError(msg) from e\n        try:\n            # Convert string 'False'/'True' to boolean\n            keep_sep = self.keep_separator\n            if isinstance(keep_sep, str):\n                if keep_sep.lower() == \"false\":\n                    keep_sep = False\n                elif keep_sep.lower() == \"true\":\n                    keep_sep = True\n                # 'start' and 'end' are kept as strings\n\n            splitter = CharacterTextSplitter(\n                chunk_overlap=self.chunk_overlap,\n                chunk_size=self.chunk_size,\n                separator=separator,\n                keep_separator=keep_sep,\n            )\n            return splitter.split_documents(documents)\n        except Exception as e:\n            msg = f\"Error splitting text: {e}\"\n            raise TypeError(msg) from e\n\n    def split_text(self) -> DataFrame:\n        docs = self.split_text_base()\n        df = DataFrame(self._docs_to_data(docs, clean=self.clean_output))\n        return df if self.clean_output else df.smart_column_order()\n",
+        "fileTypes": [],
+        "file_path": "",
+        "password": false,
+        "name": "code",
+        "advanced": true,
+        "dynamic": true,
+        "info": "",
+        "load_from_db": false,
+        "title_case": false
+       },
+       "keep_separator": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "options": [
+         "False",
+         "True",
+         "Start",
+         "End"
+        ],
+        "options_metadata": [],
+        "combobox": false,
+        "dialog_inputs": {},
+        "toggle": false,
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "keep_separator",
+        "value": "False",
+        "display_name": "Keep Separator",
+        "advanced": true,
+        "dynamic": false,
+        "info": "Whether to keep the separator in the output chunks and where to place it.",
+        "title_case": false,
+        "track_in_telemetry": true,
+        "external_options": {},
+        "type": "str",
+        "_input_type": "DropdownInput"
+       },
+       "separator": {
+        "tool_mode": false,
+        "trace_as_input": true,
+        "trace_as_metadata": true,
+        "load_from_db": false,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "separator",
+        "value": "\n",
+        "display_name": "Separator",
+        "advanced": false,
+        "input_types": [
+         "Message"
+        ],
+        "dynamic": false,
+        "info": "The character to split on. Use \\n for newline. Examples: \\n\\n for paragraphs, \\n for lines, . for sentences",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "str",
+        "_input_type": "MessageTextInput"
+       },
+       "text_key": {
+        "tool_mode": false,
+        "trace_as_input": true,
+        "trace_as_metadata": true,
+        "load_from_db": false,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "text_key",
+        "value": "text",
+        "display_name": "Text Key",
+        "advanced": true,
+        "input_types": [
+         "Message"
+        ],
+        "dynamic": false,
+        "info": "The key to use for the text column.",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "str",
+        "_input_type": "MessageTextInput"
+       }
+      },
+      "description": "Split text into chunks based on specified criteria.",
+      "icon": "scissors-line-dashed",
+      "base_classes": [
+       "Table"
+      ],
+      "display_name": "Split Text",
+      "documentation": "https://docs.langflow.org/split-text",
+      "minimized": false,
+      "custom_fields": {},
+      "output_types": [],
+      "pinned": false,
+      "conditional_paths": [],
+      "frozen": false,
+      "outputs": [
+       {
+        "types": [
+         "Table"
+        ],
+        "selected": "Table",
+        "name": "dataframe",
+        "display_name": "Chunks",
+        "method": "split_text",
+        "value": "__UNDEFINED__",
+        "cache": true,
+        "allows_loop": false,
+        "group_outputs": false,
+        "tool_mode": true
+       }
+      ],
+      "field_order": [
+       "data_inputs",
+       "chunk_overlap",
+       "chunk_size",
+       "separator",
+       "text_key",
+       "keep_separator",
+       "clean_output"
+      ],
+      "beta": false,
+      "legacy": false,
+      "edited": false,
+      "metadata": {
+       "module": "lfx.components.processing.split_text.SplitTextComponent",
+       "code_hash": "859adebdf672",
+       "dependencies": {
+        "total_dependencies": 2,
+        "dependencies": [
+         {
+          "name": "langchain_text_splitters",
+          "version": "1.1.2"
+         },
+         {
+          "name": "lfx",
+          "version": "1.11.0.dev38"
+         }
+        ]
+       }
+      },
+      "tool_mode": false,
+      "lf_version": "1.11.0.dev38"
+     },
+     "showNode": true,
+     "type": "SplitText",
+     "id": "SplitText-doc01"
+    },
+    "selected": false,
+    "measured": {
+     "width": 320,
+     "height": 415
+    }
+   },
+   {
+    "id": "Knowledge-ingest",
+    "type": "genericNode",
+    "position": {
+     "x": 900,
+     "y": 80
+    },
+    "data": {
+     "node": {
+      "template": {
+       "_type": "Component",
+       "input_df": {
+        "trace_as_metadata": true,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": true,
+        "placeholder": "",
+        "show": true,
+        "name": "input_df",
+        "value": "",
+        "display_name": "Input",
+        "advanced": false,
+        "input_types": [
+         "Message",
+         "Data",
+         "JSON",
+         "DataFrame",
+         "Table"
+        ],
+        "dynamic": true,
+        "info": "Table with all original columns (already chunked / processed). Accepts Message, Data, or DataFrame. If Message or Data is provided, it is converted to a DataFrame automatically.",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "other",
+        "_input_type": "HandleInput"
+       },
+       "allow_duplicates": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "allow_duplicates",
+        "value": false,
+        "display_name": "Allow Duplicates",
+        "advanced": true,
+        "dynamic": true,
+        "info": "Allow duplicate rows in the knowledge base",
+        "title_case": false,
+        "track_in_telemetry": true,
+        "type": "bool",
+        "_input_type": "BoolInput"
+       },
+       "api_key": {
+        "load_from_db": false,
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "api_key",
+        "value": "",
+        "display_name": "Embedding Provider API Key",
+        "advanced": true,
+        "input_types": [],
+        "dynamic": true,
+        "info": "Overrides global provider settings. Leave blank to use your pre-configured API Key.",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "password": true,
+        "type": "str",
+        "_input_type": "SecretStrInput"
+       },
+       "chunk_size": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "chunk_size",
+        "value": 1000,
+        "display_name": "Chunk Size",
+        "advanced": true,
+        "dynamic": true,
+        "info": "Batch size for processing embeddings",
+        "title_case": false,
+        "track_in_telemetry": true,
+        "type": "int",
+        "_input_type": "IntInput"
+       },
+       "code": {
+        "type": "code",
+        "required": true,
+        "placeholder": "",
+        "list": false,
+        "show": true,
+        "multiline": true,
+        "value": "\"\"\"Unified Knowledge component — ingest into or retrieve from a knowledge base.\n\nThis component merges what used to live in ``ingestion.py`` and\n``retrieval.py`` into a single, mode-driven component. A ``TabInput``\n(\"📥 Ingest\" / \"🔍 Retrieve\") drives which inputs and which output are\nvisible. The merged shape gives users one node per KB instead of two\nparallel ones that always shared the same ``knowledge_base`` picker,\nembedding-model metadata, and backend registry.\n\nBoth legacy classes (``KnowledgeIngestionComponent``,\n``KnowledgeBaseComponent``) remain importable as thin subclasses of\n``KnowledgeComponent`` — see the sibling ``ingestion.py`` / ``retrieval.py``\nmodules — so saved flows continue to load unchanged.\n\"\"\"\n\nfrom __future__ import annotations\n\nimport asyncio\nimport hashlib\nimport json\nimport re\nimport uuid\nfrom dataclasses import asdict, dataclass, field\nfrom datetime import datetime, timezone\nfrom typing import TYPE_CHECKING, Any\n\nimport pandas as pd\nfrom cryptography.fernet import InvalidToken\nfrom langchain_chroma import Chroma\nfrom langflow.services.auth.utils import decrypt_api_key, encrypt_api_key\n\nfrom lfx.base.knowledge_bases.backends import BackendType, BaseVectorStoreBackend, create_backend\nfrom lfx.base.knowledge_bases.ingestion_sources.base import (\n    IngestionItemResult,\n    IngestionItemStatus,\n    IngestionRunStatus,\n    IngestionSummary,\n)\nfrom lfx.base.knowledge_bases.ingestion_sources.flow_component import FlowComponentSource\nfrom lfx.base.knowledge_bases.knowledge_base_utils import get_knowledge_bases\nfrom lfx.base.models.unified_models import get_embedding_model_options, get_embeddings\nfrom lfx.base.vectorstores.chroma_security import chroma_langchain_collection_kwargs\nfrom lfx.components.files_and_knowledge._kb_paths import (\n    get_knowledge_bases_root_path as _get_knowledge_bases_root_path,\n)\nfrom lfx.components.files_and_knowledge._kb_paths import (\n    load_kb_metadata,\n)\nfrom lfx.components.processing.converter import convert_to_dataframe\nfrom lfx.custom import Component\nfrom lfx.io import (\n    BoolInput,\n    DBProviderInput,\n    DropdownInput,\n    HandleInput,\n    IntInput,\n    MessageTextInput,\n    ModelInput,\n    Output,\n    SecretStrInput,\n    StrInput,\n    TabInput,\n    TableInput,\n)\nfrom lfx.log.logger import logger\nfrom lfx.schema.data import Data\nfrom lfx.schema.dataframe import DataFrame\nfrom lfx.schema.dotdict import dotdict\nfrom lfx.schema.table import EditMode\nfrom lfx.services.deps import (\n    get_settings_service,\n    session_scope,\n)\nfrom lfx.utils.component_utils import set_current_fields, set_field_display\nfrom lfx.utils.validate_cloud import raise_error_if_astra_cloud_disable_component\n\n\ndef _inputs_for_mode(default_mode: str) -> list:\n    \"\"\"Return a fresh copy of the canonical inputs list with show flags set for the given mode.\n\n    Used by the legacy subclasses so a saved flow keyed on\n    ``KnowledgeIngestion`` / ``KnowledgeBase`` lands on a node template\n    whose default visibility already matches the pinned mode — no\n    \"wait for the user to click the mode tab\" UX gap on load.\n    \"\"\"\n    always_visible = set(KnowledgeComponent.default_keys) | set(KnowledgeComponent.mode_config[default_mode])\n    inputs_copy = []\n    for inp in KnowledgeComponent.inputs:\n        clone = inp.model_copy(deep=True) if hasattr(inp, \"model_copy\") else inp\n        if clone.name == \"mode\":\n            clone.value = default_mode\n        else:\n            clone.show = clone.name in always_visible\n        inputs_copy.append(clone)\n    return inputs_copy\n\n\nif TYPE_CHECKING:\n    from pathlib import Path\n\n# Mode constants. Plain-text labels (no emoji) for consistency with the rest of\n# Langflow's TabInput palette — see ``MemoryComponent`` for the same convention.\nMODE_INGEST = \"Ingest\"\nMODE_RETRIEVE = \"Retrieve\"\n\n\ndef _is_retrieve_mode(value: Any) -> bool:\n    \"\"\"Lenient mode check: treats any label containing 'Retrieve' as retrieve mode.\n\n    Older saved flows may carry the emoji-prefixed labels (\"📥 Ingest\" /\n    \"🔍 Retrieve\") this component used to ship with; substring matching\n    keeps those loading without forcing a flow rewrite.\n    \"\"\"\n    return isinstance(value, str) and \"Retrieve\" in value\n\n\n# Error message used by both the ingest and retrieve paths when the user is\n# running against an Astra cloud environment that disables these flows.\nastra_error_msg = \"Knowledge ingestion and retrieval are not supported in Astra cloud environment.\"\n\n_DEFAULT_OPENSEARCH_CONFIG = {\n    \"url_variable\": \"OPENSEARCH_URL\",\n    \"username_variable\": \"OPENSEARCH_USERNAME\",\n    \"password_variable\": \"OPENSEARCH_PASSWORD\",  # pragma: allowlist secret\n    \"index_name\": \"\",\n    \"vector_field\": \"vector_field\",\n    \"text_field\": \"text\",\n}\n\n_DEFAULT_CHROMA_CLOUD_CONFIG = {\n    \"mode\": \"cloud\",\n    \"tenant_variable\": \"CHROMA_TENANT\",\n    \"database_variable\": \"CHROMA_DATABASE\",\n    \"api_key_variable\": \"CHROMA_API_KEY\",  # pragma: allowlist secret\n}\n\n\nclass KnowledgeComponent(Component):\n    \"\"\"One component for both writing into and reading from a Langflow knowledge base.\n\n    A ``TabInput`` switches between ingestion and retrieval. The\n    ``update_build_config`` / ``update_outputs`` hooks hide the inputs\n    and the output that don't apply to the current mode so the canvas\n    node stays focused.\n    \"\"\"\n\n    display_name = \"Knowledge\"\n    description = \"Ingest into or retrieve from a Langflow knowledge base.\"\n    icon = \"database\"\n    name = \"Knowledge\"\n\n    # ------ Mode → visible-fields wiring ---------------------------------\n    # ``default_keys`` are inputs always visible regardless of mode.\n    # ``mode_config`` lists the inputs unique to each mode; everything outside\n    # this set is hidden when its mode is not selected.\n    default_keys: list[str] = [\"mode\", \"knowledge_base\"]\n    mode_config: dict[str, list[str]] = {\n        MODE_INGEST: [\n            \"input_df\",\n            \"column_config\",\n            \"chunk_size\",\n            \"api_key\",\n            \"allow_duplicates\",\n            \"metadata_json\",\n        ],\n        MODE_RETRIEVE: [\n            \"search_query\",\n            \"top_k\",\n            \"include_metadata\",\n            \"include_embeddings\",\n            \"metadata_filter\",\n        ],\n    }\n\n    def __init__(self, *args, **kwargs) -> None:\n        super().__init__(*args, **kwargs)\n        self._cached_kb_path: Path | None = None\n\n    @dataclass\n    class NewKnowledgeBaseInput:\n        functionality: str = \"create\"\n        fields: dict[str, dict] = field(\n            default_factory=lambda: {\n                \"data\": {\n                    \"node\": {\n                        \"name\": \"create_knowledge_base\",\n                        \"description\": \"Create new knowledge in Langflow.\",\n                        \"display_name\": \"Create new Knowledge Base\",\n                        \"field_order\": [\n                            \"01_new_kb_name\",\n                            \"02_embedding_model\",\n                            \"03_knowledge_backend\",\n                        ],\n                        \"template\": {\n                            \"01_new_kb_name\": StrInput(\n                                name=\"new_kb_name\",\n                                display_name=\"Knowledge Name\",\n                                info=\"Name of the new knowledge to create.\",\n                                required=True,\n                            ),\n                            \"02_embedding_model\": ModelInput(\n                                name=\"embedding_model\",\n                                display_name=\"Choose Embedding Model\",\n                                info=(\n                                    \"Select the embedding model to use for this knowledge base. \"\n                                    \"Langflow uses the configured credentials for that model provider.\"\n                                ),\n                                required=True,\n                                model_type=\"embedding\",\n                            ),\n                            \"03_knowledge_backend\": DBProviderInput(\n                                name=\"knowledge_backend\",\n                                display_name=\"DB Provider\",\n                                info=(\n                                    \"Select where this knowledge base stores vectors. \"\n                                    \"OpenSearch uses the global DB Providers settings.\"\n                                ),\n                                required=True,\n                            ),\n                        },\n                    },\n                }\n            }\n        )\n\n    # ------ Inputs --------------------------------------------------------\n    # ``knowledge_base`` is kept at position 0 so legacy tests that check\n    # ``component.inputs[0].dialog_inputs`` continue to work.\n    inputs = [\n        DropdownInput(\n            name=\"knowledge_base\",\n            display_name=\"Knowledge\",\n            info=\"Select the knowledge to load data from.\",\n            required=True,\n            options=[],\n            refresh_button=True,\n            real_time_refresh=True,\n            dialog_inputs=asdict(NewKnowledgeBaseInput()),\n        ),\n        TabInput(\n            name=\"mode\",\n            display_name=\"Mode\",\n            options=[MODE_INGEST, MODE_RETRIEVE],\n            value=MODE_INGEST,\n            info=\"Switch between writing new data into the knowledge base and querying it.\",\n            real_time_refresh=True,\n            tool_mode=True,\n        ),\n        # --- Ingest-only inputs (default-shown; hidden when mode == Retrieve) -\n        HandleInput(\n            name=\"input_df\",\n            display_name=\"Input\",\n            info=(\n                \"Table with all original columns (already chunked / processed). \"\n                \"Accepts Message, Data, or DataFrame. If Message or Data is provided, \"\n                \"it is converted to a DataFrame automatically.\"\n            ),\n            input_types=[\"Message\", \"Data\", \"JSON\", \"DataFrame\", \"Table\"],\n            required=True,\n            dynamic=True,\n            show=True,\n        ),\n        TableInput(\n            name=\"column_config\",\n            display_name=\"Column Configuration\",\n            info=\"Configure column behavior for the knowledge base.\",\n            required=True,\n            table_schema=[\n                {\n                    \"name\": \"column_name\",\n                    \"display_name\": \"Column Name\",\n                    \"type\": \"str\",\n                    \"description\": \"Name of the column in the source DataFrame\",\n                    \"edit_mode\": EditMode.INLINE,\n                },\n                {\n                    \"name\": \"vectorize\",\n                    \"display_name\": \"Vectorize\",\n                    \"type\": \"boolean\",\n                    \"description\": \"Create embeddings for this column\",\n                    \"default\": False,\n                    \"edit_mode\": EditMode.INLINE,\n                },\n                {\n                    \"name\": \"identifier\",\n                    \"display_name\": \"Identifier\",\n                    \"type\": \"boolean\",\n                    \"description\": \"Use this column as unique identifier\",\n                    \"default\": False,\n                    \"edit_mode\": EditMode.INLINE,\n                },\n            ],\n            value=[\n                {\n                    \"column_name\": \"text\",\n                    \"vectorize\": True,\n                    \"identifier\": True,\n                },\n            ],\n            dynamic=True,\n            show=True,\n        ),\n        IntInput(\n            name=\"chunk_size\",\n            display_name=\"Chunk Size\",\n            info=\"Batch size for processing embeddings\",\n            advanced=True,\n            value=1000,\n            dynamic=True,\n            show=True,\n        ),\n        SecretStrInput(\n            name=\"api_key\",\n            display_name=\"Embedding Provider API Key\",\n            info=\"Overrides global provider settings. Leave blank to use your pre-configured API Key.\",\n            advanced=True,\n            required=False,\n            dynamic=True,\n            show=True,\n        ),\n        BoolInput(\n            name=\"allow_duplicates\",\n            display_name=\"Allow Duplicates\",\n            info=\"Allow duplicate rows in the knowledge base\",\n            advanced=True,\n            value=False,\n            dynamic=True,\n            show=True,\n        ),\n        StrInput(\n            name=\"metadata_json\",\n            display_name=\"Metadata\",\n            info=(\n                \"Optional JSON object of user metadata applied to every chunk produced by this \"\n                'run (e.g. {\"tag\": \"invoice\", \"year\": \"2026\"}). Same shape as the upload modal '\n                \"Metadata section so chunks browser filters + Knowledge retrieval metadata_filter \"\n                \"work uniformly across upload, folder, and flow-driven ingestion. Malformed JSON is \"\n                \"ignored with a warning rather than failing the run.\"\n            ),\n            advanced=True,\n            required=False,\n            dynamic=True,\n            show=True,\n        ),\n        # --- Retrieve-only inputs (default-hidden; shown when mode == Retrieve) -\n        MessageTextInput(\n            name=\"search_query\",\n            display_name=\"Search Query\",\n            info=\"Optional search query to filter knowledge base data.\",\n            tool_mode=True,\n            dynamic=True,\n            show=False,\n        ),\n        IntInput(\n            name=\"top_k\",\n            display_name=\"Top K Results\",\n            info=\"Number of top results to return from the knowledge base.\",\n            value=5,\n            advanced=True,\n            required=False,\n            dynamic=True,\n            show=False,\n        ),\n        BoolInput(\n            name=\"include_metadata\",\n            display_name=\"Include Metadata\",\n            info=\"Whether to include all metadata in the output. If false, only content is returned.\",\n            value=True,\n            advanced=False,\n            dynamic=True,\n            show=False,\n        ),\n        BoolInput(\n            name=\"include_embeddings\",\n            display_name=\"Include Embeddings\",\n            info=\"Whether to include embeddings in the output. Only applicable if 'Include Metadata' is enabled.\",\n            value=False,\n            advanced=True,\n            dynamic=True,\n            show=False,\n        ),\n        MessageTextInput(\n            name=\"metadata_filter\",\n            display_name=\"Metadata Filter\",\n            info=(\n                \"Optional JSON object of user-metadata key/value pairs. Only chunks \"\n                'whose source_metadata matches every key are returned (e.g. {\"tag\": \"invoice\"} '\n                'or {\"tag\": [\"invoice\", \"audit\"]} for OR-of-values). Backends without '\n                \"native filtering apply the match client-side after retrieval.\"\n            ),\n            advanced=True,\n            dynamic=True,\n            show=False,\n        ),\n    ]\n\n    # ------ Outputs -------------------------------------------------------\n    # Both outputs are declared at the class level so the runtime can\n    # dispatch to either method depending on which one the saved flow has\n    # wired up. ``update_outputs`` filters the canvas-visible output per\n    # selected mode; see ``TypeConverterComponent`` and ``MemoryComponent``\n    # for the same pattern.\n    #\n    # Output names match the legacy ``KnowledgeIngestionComponent``\n    # (``dataframe_output``) and ``KnowledgeBaseComponent``\n    # (``retrieve_data``) so saved flow edges keyed on those names resolve\n    # cleanly against the merged component.\n    outputs = [\n        Output(\n            display_name=\"Results\",\n            name=\"dataframe_output\",\n            method=\"build_kb_info\",\n            types=[\"JSON\"],\n            selected=\"JSON\",\n        ),\n        Output(\n            display_name=\"Results\",\n            name=\"retrieve_data\",\n            method=\"retrieve_data\",\n            info=\"Returns the data from the selected knowledge base.\",\n            types=[\"Table\"],\n            selected=\"Table\",\n        ),\n    ]\n\n    # ------ Mode-driven UI updates ---------------------------------------\n    async def update_frontend_node(self, new_frontend_node: dict, current_frontend_node: dict):\n        \"\"\"Sync the visible output with the current ``mode`` value on canvas load.\n\n        Saved flows hit this path: ``update_outputs`` is normally only triggered\n        by ``real_time_refresh`` field edits, so without this re-sync the\n        canvas could land with both outputs visible.\n        \"\"\"\n        await super().update_frontend_node(new_frontend_node, current_frontend_node)\n        mode_value = new_frontend_node.get(\"template\", {}).get(\"mode\", {}).get(\"value\", MODE_INGEST)\n        self.update_outputs(new_frontend_node, \"mode\", mode_value)\n        return new_frontend_node\n\n    def update_outputs(self, frontend_node: dict, field_name: str, field_value: Any) -> dict:\n        \"\"\"Filter visible outputs to match the selected mode.\n\n        Triggered by the ``mode`` ``TabInput`` ``real_time_refresh`` flag.\n        The class-level ``outputs`` list always carries both entries so the\n        runtime can resolve either ``build_kb_info`` or ``retrieve_data``\n        regardless of canvas visibility — we just hide the unused one here.\n        \"\"\"\n        if field_name != \"mode\":\n            return frontend_node\n        if _is_retrieve_mode(field_value):\n            frontend_node[\"outputs\"] = [\n                Output(\n                    display_name=\"Results\",\n                    name=\"retrieve_data\",\n                    method=\"retrieve_data\",\n                    info=\"Returns the data from the selected knowledge base.\",\n                    types=[\"Table\"],\n                    selected=\"Table\",\n                )\n            ]\n        else:\n            frontend_node[\"outputs\"] = [\n                Output(\n                    display_name=\"Results\",\n                    name=\"dataframe_output\",\n                    method=\"build_kb_info\",\n                    types=[\"JSON\"],\n                    selected=\"JSON\",\n                )\n            ]\n        return frontend_node\n\n    async def update_build_config(\n        self,\n        build_config,\n        field_value: Any,\n        field_name: str | None = None,\n    ):\n        \"\"\"Refresh KB options, drive the create-KB dialog, and hide off-mode fields.\"\"\"\n        # Astra-cloud gate covers both ingest and retrieve paths.\n        raise_error_if_astra_cloud_disable_component(astra_error_msg)\n\n        # Always populate the create-KB dialog's embedding-model options so the\n        # ModelInput renders correctly regardless of which input triggered the\n        # refresh.\n        try:\n            dialog_template = (\n                build_config[\"knowledge_base\"]\n                .get(\"dialog_inputs\", {})\n                .get(\"fields\", {})\n                .get(\"data\", {})\n                .get(\"node\", {})\n                .get(\"template\", {})\n            )\n            if \"02_embedding_model\" in dialog_template:\n                embedding_options = get_embedding_model_options(user_id=self.user_id)\n                dialog_template[\"02_embedding_model\"][\"options\"] = embedding_options\n        except Exception:  # noqa: BLE001\n            self.log(\"Failed to populate embedding model options in dialog\")\n\n        # KB-picker refresh + create-new-KB flow (lifted from the legacy ingestion\n        # component verbatim; relied on by both the canvas refresh button and the\n        # dialog-submit path).\n        if field_name == \"knowledge_base\":\n            # Lazy import keeps lfx importable without langflow installed.\n            from langflow.services.database.models.user.crud import get_user_by_id\n\n            async with session_scope() as db:\n                if not self.user_id:\n                    msg = \"User ID is required for fetching knowledge base list.\"\n                    raise ValueError(msg)\n                current_user = await get_user_by_id(db, self.user_id)\n                if not current_user:\n                    msg = f\"User with ID {self.user_id} not found.\"\n                    raise ValueError(msg)\n                kb_user = current_user.username\n            if isinstance(field_value, dict) and \"01_new_kb_name\" in field_value:\n                if not self.is_valid_collection_name(field_value[\"01_new_kb_name\"]):\n                    msg = f\"Invalid knowledge base name: {field_value['01_new_kb_name']}\"\n                    raise ValueError(msg)\n\n                model_selection = field_value[\"02_embedding_model\"]\n                if isinstance(model_selection, dict):\n                    model_selection = [model_selection]\n\n                backend_type, backend_config = self._normalize_backend_selection(\n                    field_value.get(\"03_knowledge_backend\")\n                )\n\n                embed_model = get_embeddings(\n                    model=model_selection,\n                    user_id=self.user_id,\n                )\n\n                try:\n                    await asyncio.wait_for(\n                        asyncio.to_thread(embed_model.embed_query, \"test\"),\n                        timeout=10,\n                    )\n                except TimeoutError as e:\n                    msg = \"Embedding validation timed out. Please verify network connectivity and key.\"\n                    raise ValueError(msg) from e\n                except Exception as e:\n                    msg = f\"Embedding validation failed: {e!s}\"\n                    raise ValueError(msg) from e\n\n                kb_path = _get_knowledge_bases_root_path() / kb_user / field_value[\"01_new_kb_name\"]\n                kb_path.mkdir(parents=True, exist_ok=True)\n\n                build_config[\"knowledge_base\"][\"value\"] = field_value[\"01_new_kb_name\"]\n                self._save_embedding_metadata(\n                    kb_path=kb_path,\n                    model_selection=model_selection,\n                    backend_type=backend_type,\n                    backend_config=backend_config,\n                )\n                await self._create_knowledge_base_record(\n                    user_id=self.user_id,\n                    name=field_value[\"01_new_kb_name\"],\n                    model_selection=model_selection,\n                    backend_type=backend_type,\n                    backend_config=backend_config,\n                )\n\n            build_config[\"knowledge_base\"][\"options\"] = await get_knowledge_bases(\n                _get_knowledge_bases_root_path(),\n                user_id=self.user_id,\n            )\n            if build_config[\"knowledge_base\"][\"value\"] not in build_config[\"knowledge_base\"][\"options\"]:\n                build_config[\"knowledge_base\"][\"value\"] = None\n\n        # Honor the current mode regardless of which field triggered the refresh.\n        # Falls back to MODE_INGEST when ``mode`` is missing (legacy nodes).\n        current_mode = build_config.get(\"mode\", {}).get(\"value\") if isinstance(build_config, dict) else None\n        if field_name == \"mode\":\n            current_mode = field_value\n        # Map legacy/emoji-prefixed labels onto the current canonical values so\n        # flows saved before the label change still toggle visibility correctly.\n        if _is_retrieve_mode(current_mode):\n            current_mode = MODE_RETRIEVE\n        elif current_mode not in self.mode_config:\n            current_mode = MODE_INGEST\n        return set_current_fields(\n            build_config=build_config if isinstance(build_config, dotdict) else dotdict(build_config),\n            action_fields=self.mode_config,\n            selected_action=current_mode,\n            default_fields=self.default_keys,\n            func=set_field_display,\n        )\n\n    # =====================================================================\n    #                       INGESTION CODE PATH\n    # =====================================================================\n    def _get_kb_root(self) -> Path:\n        \"\"\"Return the root directory for knowledge bases.\"\"\"\n        return _get_knowledge_bases_root_path()\n\n    @staticmethod\n    def _scalar_notna(value) -> bool:\n        \"\"\"Check if a value is not NA, safely handling arrays and sequences.\n\n        ``pd.notna`` returns an array when given an array-like input, which\n        cannot be used directly in a boolean context.  This helper collapses\n        the result to a single scalar ``bool``.\n        \"\"\"\n        result = pd.notna(value)\n        if hasattr(result, \"__iter__\") and not isinstance(result, str):\n            import numpy as np\n\n            arr = np.asarray(result)\n            return arr.size > 0 and arr.all()\n        return bool(result)\n\n    def _validate_column_config(self, df_source: pd.DataFrame) -> list[dict[str, Any]]:\n        \"\"\"Validate column configuration using Structured Output patterns.\"\"\"\n        if not self.column_config:\n            msg = \"Column configuration cannot be empty\"\n            raise ValueError(msg)\n\n        config_list = self.column_config if isinstance(self.column_config, list) else []\n\n        df_columns = set(df_source.columns)\n        for config in config_list:\n            col_name = config.get(\"column_name\")\n            if col_name not in df_columns:\n                msg = f\"Column '{col_name}' not found in DataFrame. Available columns: {sorted(df_columns)}\"\n                raise ValueError(msg)\n\n        return config_list\n\n    def _build_embedding_metadata(\n        self,\n        model_selection: list[dict[str, Any]],\n        api_key: str | None = None,\n        backend_type: str = BackendType.CHROMA.value,\n        backend_config: dict[str, Any] | None = None,\n    ) -> dict[str, Any]:\n        \"\"\"Build embedding model metadata from a model selection dict.\"\"\"\n        model_dict = model_selection[0] if isinstance(model_selection, list) else model_selection\n        embedding_model = model_dict.get(\"name\", \"\")\n        embedding_provider = model_dict.get(\"provider\", \"Unknown\")\n\n        api_key_to_save = None\n        if api_key and hasattr(api_key, \"get_secret_value\"):\n            api_key_to_save = api_key.get_secret_value()\n        elif isinstance(api_key, str):\n            api_key_to_save = api_key\n\n        encrypted_api_key = None\n        if api_key_to_save:\n            settings_service = get_settings_service()\n            try:\n                encrypted_api_key = encrypt_api_key(api_key_to_save, settings_service=settings_service)\n            except (TypeError, ValueError) as e:\n                self.log(f\"Could not encrypt API key: {e}\")\n\n        return {\n            \"embedding_provider\": embedding_provider,\n            \"embedding_model\": embedding_model,\n            \"model_selection\": model_dict,\n            \"api_key\": encrypted_api_key,\n            \"api_key_used\": bool(api_key),\n            \"chunk_size\": self.chunk_size,\n            \"backend_type\": backend_type,\n            \"backend_config\": backend_config or {},\n            \"created_at\": datetime.now(timezone.utc).isoformat(),\n        }\n\n    def _save_embedding_metadata(\n        self,\n        kb_path: Path,\n        model_selection: list[dict[str, Any]],\n        api_key: str | None = None,\n        backend_type: str | None = None,\n        backend_config: dict[str, Any] | None = None,\n    ) -> None:\n        \"\"\"Save embedding model metadata.\"\"\"\n        metadata_path = kb_path / \"embedding_metadata.json\"\n        existing_metadata: dict[str, Any] = {}\n        if metadata_path.exists():\n            try:\n                existing_metadata = json.loads(metadata_path.read_text())\n            except (OSError, json.JSONDecodeError):\n                existing_metadata = {}\n\n        embedding_metadata = self._build_embedding_metadata(\n            model_selection,\n            api_key,\n            backend_type=backend_type or existing_metadata.get(\"backend_type\") or BackendType.CHROMA.value,\n            backend_config=backend_config\n            if backend_config is not None\n            else existing_metadata.get(\"backend_config\") or {},\n        )\n        metadata_path.write_text(json.dumps(embedding_metadata, indent=2))\n\n    def _update_metadata_metrics(self, kb_path: Path, chroma: Chroma) -> None:\n        \"\"\"Update embedding_metadata.json with accurate chunk/word/character counts.\"\"\"\n        import chromadb.errors\n        from langflow.api.utils.kb_helpers import KBAnalysisHelper, KBStorageHelper\n\n        metadata_path = kb_path / \"embedding_metadata.json\"\n        if not metadata_path.exists():\n            return\n\n        try:\n            metadata = json.loads(metadata_path.read_text())\n            KBAnalysisHelper.update_text_metrics(kb_path, metadata, chroma)\n            metadata[\"size\"] = KBStorageHelper.get_directory_size(kb_path)\n            metadata_path.write_text(json.dumps(metadata, indent=2))\n        except (OSError, ValueError, TypeError, json.JSONDecodeError, chromadb.errors.ChromaError) as e:\n            self.log(f\"Warning: Could not update metadata metrics: {e}\")\n\n    @staticmethod\n    def _extract_source_types_from_df(df_source: pd.DataFrame) -> set[str]:\n        \"\"\"Pull file extensions out of common path/name columns on the source DataFrame.\n\n        The direct-upload ingestion path stores extensions in\n        ``embedding_metadata.json[source_types]`` so the KB list can render the\n        correct file-type icon. When ingestion happens via a connected\n        ``input_df`` (e.g. File → Knowledge) the same field stayed empty and\n        the icon defaulted to a blank tile. We look at the well-known columns\n        the File / S3 / cloud-storage components produce and collect any\n        plausible extension so the icon is consistent across both flows.\n        \"\"\"\n        candidate_columns = (\"file_path\", \"file_name\", \"filename\", \"source\", \"path\", \"mimetype\")\n        extensions: set[str] = set()\n        for col in candidate_columns:\n            if col not in df_source.columns:\n                continue\n            for value in df_source[col].dropna():\n                ext = KnowledgeComponent._extension_from_value(value)\n                # Drop anything that doesn't look like an extension (URL\n                # query strings, version segments, etc.) — the icon palette\n                # keys off short alphanumeric tokens like \"pdf\"/\"docx\".\n                if ext:\n                    extensions.add(ext)\n        return extensions\n\n    @staticmethod\n    def _extension_from_value(value: Any) -> str | None:\n        \"\"\"Return a normalized file-extension token from a path / filename / MIME string.\n\n        Accepts values like ``\"report.PDF\"``, ``\"/docs/notes.txt\"``, or\n        ``\"application/pdf\"`` and returns ``\"pdf\"`` / ``\"txt\"``. Returns\n        ``None`` if no plausible extension can be derived.\n        \"\"\"\n        extension_length_limit = 10\n        if value is None:\n            return None\n        text = str(value).strip()\n        if not text:\n            return None\n        # MIME types like ``application/pdf`` carry the canonical extension\n        # in the subtype slot — preserve them so File / S3 messages keyed\n        # only on ``mimetype`` still resolve to an icon.\n        if \"/\" in text and \".\" not in text.rsplit(\"/\", 1)[-1]:\n            subtype = text.rsplit(\"/\", 1)[-1].strip().lower()\n            return subtype if subtype and len(subtype) <= extension_length_limit and subtype.isalnum() else None\n        if \".\" not in text:\n            return None\n        ext = text.rsplit(\".\", 1)[-1].strip().lower()\n        if ext and len(ext) <= extension_length_limit and ext.isalnum():\n            return ext\n        return None\n\n    @classmethod\n    def _extract_source_types_from_mapping(cls, mapping: Any) -> set[str]:\n        \"\"\"Pull extensions from a Message/Data-style ``data`` dict or a plain dict.\"\"\"\n        if not isinstance(mapping, dict):\n            return set()\n        candidate_keys = (\"file_path\", \"file_name\", \"filename\", \"source\", \"path\", \"mimetype\")\n        extensions: set[str] = set()\n        for key in candidate_keys:\n            ext = cls._extension_from_value(mapping.get(key))\n            if ext:\n                extensions.add(ext)\n        return extensions\n\n    @classmethod\n    def _extract_source_types_from_input(cls, input_value: Any) -> set[str]:\n        \"\"\"Pull file extensions out of the raw component input.\n\n        ``convert_to_dataframe`` strips Message/Data fields down to ``text``\n        when projecting onto a DataFrame, so file metadata attached to a\n        File-component \"Raw Content\" output never reaches\n        ``_extract_source_types_from_df``. Looking at the raw input first\n        keeps the KB icon consistent with direct upload.\n        \"\"\"\n        if input_value is None:\n            return set()\n        if isinstance(input_value, list):\n            extensions: set[str] = set()\n            for item in input_value:\n                extensions |= cls._extract_source_types_from_input(item)\n            return extensions\n        if isinstance(input_value, pd.DataFrame):\n            return cls._extract_source_types_from_df(input_value)\n        # Message / Data / JSON all expose a ``data`` dict via the lfx schema.\n        mapping = getattr(input_value, \"data\", None)\n        if mapping is None and isinstance(input_value, dict):\n            mapping = input_value\n        return cls._extract_source_types_from_mapping(mapping)\n\n    def _merge_source_types(self, kb_path: Path, extensions: set[str]) -> None:\n        \"\"\"Merge newly observed extensions into the KB's ``source_types`` metadata.\n\n        Mirrors the direct-upload path in ``KBIngestionHelper`` so the icon\n        rendering on the Knowledge Bases list works regardless of which\n        ingestion route was used.\n        \"\"\"\n        if not extensions:\n            return\n        metadata_path = kb_path / \"embedding_metadata.json\"\n        if not metadata_path.exists():\n            return\n        try:\n            metadata = json.loads(metadata_path.read_text())\n            existing = set(metadata.get(\"source_types\") or [])\n            metadata[\"source_types\"] = sorted(existing | extensions)\n            metadata_path.write_text(json.dumps(metadata, indent=2))\n        except (OSError, ValueError, TypeError, json.JSONDecodeError) as e:\n            self.log(f\"Warning: Could not update source_types metadata: {e}\")\n\n    async def _update_backend_metadata_metrics(self, kb_path: Path, backend: BaseVectorStoreBackend) -> None:\n        \"\"\"Update metadata metrics for non-Chroma backends.\"\"\"\n        metadata_path = kb_path / \"embedding_metadata.json\"\n        if not metadata_path.exists():\n            return\n\n        try:\n            metadata = json.loads(metadata_path.read_text())\n            chunks = await backend.count()\n            characters = 0\n            words = 0\n            async for batch in backend.iter_documents():\n                for document in batch:\n                    characters += len(document.content)\n                    words += len(document.content.split())\n\n            metadata[\"chunks\"] = chunks\n            metadata[\"characters\"] = characters\n            metadata[\"words\"] = words\n            metadata[\"avg_chunk_size\"] = characters / chunks if chunks else 0.0\n            metadata[\"size\"] = await backend.storage_size_bytes()\n            metadata_path.write_text(json.dumps(metadata, indent=2))\n        except (OSError, ValueError, TypeError, json.JSONDecodeError) as e:\n            self.log(f\"Warning: Could not update backend metadata metrics: {e}\")\n\n    @staticmethod\n    def _normalize_backend_selection(value: Any) -> tuple[str, dict[str, Any]]:\n        \"\"\"Normalize a DBProviderInput value into backend type/config.\"\"\"\n        if not value:\n            return BackendType.CHROMA.value, {}\n\n        if isinstance(value, str):\n            backend_type = value if value == BackendType.OPENSEARCH.value else BackendType.CHROMA.value\n            return (\n                backend_type,\n                _DEFAULT_OPENSEARCH_CONFIG.copy() if backend_type == BackendType.OPENSEARCH.value else {},\n            )\n\n        if not isinstance(value, dict):\n            return BackendType.CHROMA.value, {}\n\n        backend_type = str(value.get(\"backend_type\") or value.get(\"id\") or BackendType.CHROMA.value)\n\n        if backend_type == BackendType.OPENSEARCH.value:\n            backend_config = value.get(\"backend_config\") or value.get(\"config\") or {}\n            if not isinstance(backend_config, dict):\n                backend_config = {}\n            return BackendType.OPENSEARCH.value, {**_DEFAULT_OPENSEARCH_CONFIG, **backend_config}\n\n        if backend_type == \"chroma_cloud\":\n            backend_config = value.get(\"backend_config\") or value.get(\"config\") or {}\n            if not isinstance(backend_config, dict):\n                backend_config = {}\n            return BackendType.CHROMA.value, {**_DEFAULT_CHROMA_CLOUD_CONFIG, **backend_config}\n\n        return BackendType.CHROMA.value, {}\n\n    @staticmethod\n    def _get_backend_from_metadata(kb_path: Path) -> tuple[str, dict[str, Any]]:\n        metadata_path = kb_path / \"embedding_metadata.json\"\n        if not metadata_path.exists():\n            return BackendType.CHROMA.value, {}\n        try:\n            metadata = json.loads(metadata_path.read_text())\n        except (OSError, json.JSONDecodeError):\n            return BackendType.CHROMA.value, {}\n\n        backend_type = str(metadata.get(\"backend_type\") or BackendType.CHROMA.value)\n        backend_config = metadata.get(\"backend_config\") or {}\n        if not isinstance(backend_config, dict):\n            backend_config = {}\n        return backend_type, backend_config\n\n    async def _create_knowledge_base_record(\n        self,\n        *,\n        user_id: Any,\n        name: str,\n        model_selection: list[dict[str, Any]],\n        backend_type: str,\n        backend_config: dict[str, Any],\n    ) -> None:\n        \"\"\"Persist the component-created KB in the DB when Langflow is available.\"\"\"\n        try:\n            from langflow.api.utils import knowledge_base_service\n        except ImportError:\n            return\n\n        try:\n            await knowledge_base_service.create_record(\n                user_id=user_id,\n                name=name,\n                model_selection=model_selection,\n                column_config=self.column_config if isinstance(self.column_config, list) else [],\n                backend_type=backend_type,\n                backend_config=backend_config,\n            )\n        except Exception as exc:  # noqa: BLE001\n            self.log(f\"Warning: could not persist knowledge base record: {exc}\")\n\n    def _save_kb_files(\n        self,\n        kb_path: Path,\n        config_list: list[dict[str, Any]],\n    ) -> None:\n        \"\"\"Save KB files using File Component storage patterns.\"\"\"\n        try:\n            kb_path.mkdir(parents=True, exist_ok=True)\n\n            cfg_path = kb_path / \"schema.json\"\n            if not cfg_path.exists():\n                cfg_path.write_text(json.dumps(config_list, indent=2))\n\n        except (OSError, TypeError, ValueError) as e:\n            self.log(f\"Error saving KB files: {e}\")\n\n    def _build_column_metadata(self, config_list: list[dict[str, Any]], df_source: pd.DataFrame) -> dict[str, Any]:\n        \"\"\"Build detailed column metadata.\"\"\"\n        metadata: dict[str, Any] = {\n            \"total_columns\": len(df_source.columns),\n            \"mapped_columns\": len(config_list),\n            \"unmapped_columns\": len(df_source.columns) - len(config_list),\n            \"columns\": [],\n            \"summary\": {\"vectorized_columns\": [], \"identifier_columns\": []},\n        }\n\n        for config in config_list:\n            col_name = config.get(\"column_name\")\n            vectorize = config.get(\"vectorize\") == \"True\" or config.get(\"vectorize\") is True\n            identifier = config.get(\"identifier\") == \"True\" or config.get(\"identifier\") is True\n\n            metadata[\"columns\"].append(\n                {\n                    \"name\": col_name,\n                    \"vectorize\": vectorize,\n                    \"identifier\": identifier,\n                }\n            )\n\n            if vectorize:\n                metadata[\"summary\"][\"vectorized_columns\"].append(col_name)\n            if identifier:\n                metadata[\"summary\"][\"identifier_columns\"].append(col_name)\n\n        return metadata\n\n    async def _create_vector_store(\n        self,\n        df_source: pd.DataFrame,\n        config_list: list[dict[str, Any]],\n        embedding_function,\n    ) -> BaseVectorStoreBackend:\n        \"\"\"Create vector store using the configured DB provider.\"\"\"\n        vector_store_dir = await self._kb_path()\n        if not vector_store_dir:\n            msg = \"Knowledge base path is not set. Please create a new knowledge base first.\"\n            raise ValueError(msg)\n        vector_store_dir.mkdir(parents=True, exist_ok=True)\n\n        backend_type, backend_config = self._get_backend_from_metadata(vector_store_dir)\n        backend = create_backend(\n            backend_type,\n            kb_name=self.knowledge_base,\n            kb_path=vector_store_dir,\n            backend_config=backend_config,\n            embedding_function=embedding_function,\n            user_id=self.user_id,\n        )\n        await backend.ensure_ready()\n\n        existing_ids = None\n        if backend_type != BackendType.CHROMA.value and not self.allow_duplicates:\n            existing_ids = set()\n            async for batch in backend.iter_documents():\n                for document in batch:\n                    doc_id = document.metadata.get(\"_id\")\n                    if doc_id:\n                        existing_ids.add(doc_id)\n\n        data_objects = await self._convert_df_to_data_objects(df_source, config_list, existing_ids=existing_ids)\n\n        user_metadata_tag = self._resolve_user_metadata_tag()\n\n        documents = []\n        for data_obj in data_objects:\n            doc = data_obj.to_lc_document()\n            if user_metadata_tag:\n                doc.metadata[\"source_metadata\"] = user_metadata_tag\n            documents.append(doc)\n\n        if documents:\n            await backend.add_documents(documents)\n            self.log(f\"Added {len(documents)} documents to vector store '{self.knowledge_base}'\")\n\n        return backend\n\n    async def _convert_df_to_data_objects(\n        self,\n        df_source: pd.DataFrame,\n        config_list: list[dict[str, Any]],\n        existing_ids: set[str] | None = None,\n    ) -> list[Data]:\n        \"\"\"Convert DataFrame to Data objects for vector store.\"\"\"\n        data_objects: list[Data] = []\n\n        if existing_ids is None:\n            kb_path = await self._kb_path()\n\n            chroma = Chroma(\n                persist_directory=str(kb_path),\n                collection_name=self.knowledge_base,\n                **chroma_langchain_collection_kwargs(),\n            )\n\n            all_docs = chroma.get()\n\n            existing_ids = {metadata.get(\"_id\") for metadata in all_docs[\"metadatas\"] if metadata.get(\"_id\")}\n\n        content_cols = []\n        identifier_cols = []\n\n        for config in config_list:\n            col_name = config.get(\"column_name\")\n            vectorize = config.get(\"vectorize\") == \"True\" or config.get(\"vectorize\") is True\n            identifier = config.get(\"identifier\") == \"True\" or config.get(\"identifier\") is True\n\n            if vectorize:\n                content_cols.append(col_name)\n            if identifier:\n                identifier_cols.append(col_name)\n\n        for _, row in df_source.iterrows():\n            identifier_parts = [str(row[col]) for col in content_cols if col in row and self._scalar_notna(row[col])]\n\n            page_content = \" \".join(identifier_parts)\n\n            data_dict = {\n                \"text\": page_content,\n            }\n\n            if identifier_cols:\n                identifier_parts = [\n                    str(row[col]) for col in identifier_cols if col in row and self._scalar_notna(row[col])\n                ]\n                page_content = \" \".join(identifier_parts)\n\n            for col in df_source.columns:\n                if col not in content_cols and col in row and self._scalar_notna(row[col]):\n                    value = row[col]\n                    data_dict[col] = str(value)\n\n            page_content_hash = hashlib.sha256(page_content.encode()).hexdigest()\n            data_dict[\"_id\"] = page_content_hash\n\n            if not self.allow_duplicates and page_content_hash in existing_ids:\n                self.log(f\"Skipping duplicate row with hash {page_content_hash}\")\n                continue\n\n            data_obj = Data(data=data_dict)\n            data_objects.append(data_obj)\n\n        return data_objects\n\n    def is_valid_collection_name(self, name, min_length: int = 3, max_length: int = 63) -> bool:\n        \"\"\"Validate collection name.\n\n        1. Contains 3-63 characters\n        2. Starts and ends with alphanumeric character\n        3. Contains only alphanumeric characters, underscores, or hyphens.\n        \"\"\"\n        if not (min_length <= len(name) <= max_length):\n            return False\n\n        if not (name[0].isalnum() and name[-1].isalnum()):\n            return False\n\n        return re.match(r\"^[a-zA-Z0-9_-]+$\", name) is not None\n\n    async def _kb_path(self) -> Path | None:\n        cached_path = getattr(self, \"_cached_kb_path\", None)\n        if cached_path is not None:\n            return cached_path\n\n        # Lazy import to keep ``lfx`` importable standalone — langflow's\n        # user/DB models are not always available at module load time.\n        from langflow.services.database.models.user.crud import get_user_by_id\n\n        async with session_scope() as db:\n            if not self.user_id:\n                msg = \"User ID is required for fetching knowledge base path.\"\n                raise ValueError(msg)\n            current_user = await get_user_by_id(db, self.user_id)\n            if not current_user:\n                msg = f\"User with ID {self.user_id} not found.\"\n                raise ValueError(msg)\n            kb_user = current_user.username\n\n        kb_root = self._get_kb_root()\n\n        self._cached_kb_path = kb_root / kb_user / self.knowledge_base\n\n        return self._cached_kb_path\n\n    def _resolve_user_metadata_tag(self) -> str:\n        \"\"\"Return the JSON-encoded user metadata tag for chunk writes.\"\"\"\n        raw = getattr(self, \"metadata_json\", None)\n        if not raw:\n            return \"\"\n        text = raw.strip() if isinstance(raw, str) else raw\n        if not text:\n            return \"\"\n        try:\n            decoded = json.loads(text)\n        except (TypeError, json.JSONDecodeError) as exc:\n            self.log(f\"KnowledgeComponent: metadata_json is not valid JSON ({exc}); skipping metadata stamp.\")\n            return \"\"\n        if not isinstance(decoded, dict):\n            self.log(\"KnowledgeComponent: metadata_json must decode to a JSON object; skipping metadata stamp.\")\n            return \"\"\n        return json.dumps(decoded, sort_keys=True)\n\n    async def build_kb_info(self) -> Data:\n        \"\"\"Main ingestion routine → returns a dict with KB metadata.\n\n        The annotation is intentionally narrowed to ``Data`` even though the\n        cross-mode fallback below may return a ``DataFrame`` from\n        ``retrieve_data``. The frontend builds React-Flow handle IDs from\n        this output's type list; widening it to ``Data | DataFrame`` makes\n        the API advertise ``[\"JSON\", \"Table\"]`` for the ingest output and\n        breaks every saved-edge sourceHandle that was generated against\n        a single-type handle (BUG-02). Python doesn't enforce return\n        annotations at runtime, so the rare fallback path keeps working.\n        \"\"\"\n        if _is_retrieve_mode(getattr(self, \"mode\", MODE_INGEST)):\n            return await self.retrieve_data()\n        raise_error_if_astra_cloud_disable_component(astra_error_msg)\n\n        run_id: uuid.UUID | None = None\n        run_job_id: uuid.UUID | None = None\n        run_summary: IngestionSummary | None = None\n        run_status: IngestionRunStatus = IngestionRunStatus.SUCCEEDED\n        run_error: str | None = None\n        kb_record_id: uuid.UUID | None = None\n        try:\n            input_value = self.input_df[0] if isinstance(self.input_df, list) else self.input_df\n            df_source: DataFrame = convert_to_dataframe(input_value, auto_parse=False)\n\n            config_list = self._validate_column_config(df_source)\n            column_metadata = self._build_column_metadata(config_list, df_source)\n\n            kb_path = await self._kb_path()\n            if not kb_path:\n                msg = \"Knowledge base path is not set. Please create a new knowledge base first.\"\n                raise ValueError(msg)\n            metadata_path = kb_path / \"embedding_metadata.json\"\n            api_key = None\n            model_selection = None\n\n            if metadata_path.exists():\n                settings_service = get_settings_service()\n                stored_metadata = json.loads(metadata_path.read_text())\n\n                model_selection = stored_metadata.get(\"model_selection\")\n                if model_selection:\n                    model_selection = [model_selection] if isinstance(model_selection, dict) else model_selection\n                else:\n                    embedding_model_name = stored_metadata.get(\"embedding_model\")\n                    embedding_provider = stored_metadata.get(\"embedding_provider\", \"Unknown\")\n                    if embedding_model_name:\n                        try:\n                            all_options = get_embedding_model_options(user_id=self.user_id)\n                            match = next(\n                                (o for o in all_options if o.get(\"name\") == embedding_model_name),\n                                None,\n                            )\n                            if match:\n                                model_selection = [match]\n                            else:\n                                self.log(\n                                    f\"Embedding model '{embedding_model_name}' (provider: {embedding_provider}) \"\n                                    \"from stored metadata is no longer available in the model registry. \"\n                                    \"Please re-create this knowledge base with a supported embedding model.\"\n                                )\n                                msg = (\n                                    f\"Embedding model '{embedding_model_name}' is no longer recognized. \"\n                                    \"The knowledge base was created with an older format and the model \"\n                                    \"is not available in the current registry. \"\n                                    \"Please re-create the knowledge base with a supported embedding model.\"\n                                )\n                                raise ValueError(msg)\n                        except ValueError:\n                            raise\n                        except Exception:  # noqa: BLE001\n                            self.log(\n                                f\"Failed to look up embedding model '{embedding_model_name}' in registry. \"\n                                \"Please re-create this knowledge base with a supported embedding model.\"\n                            )\n                            msg = (\n                                f\"Could not look up embedding model '{embedding_model_name}' \"\n                                f\"(provider: {embedding_provider}). \"\n                                \"Please re-create the knowledge base with a supported embedding model.\"\n                            )\n                            raise ValueError(msg)  # noqa: B904\n\n                encrypted_key = stored_metadata.get(\"api_key\")\n                if encrypted_key:\n                    try:\n                        api_key = decrypt_api_key(encrypted_key, settings_service)\n                    except (InvalidToken, TypeError, ValueError) as e:\n                        self.log(f\"Could not decrypt API key. Please provide it manually. Error: {e}\")\n\n            if self.api_key:\n                api_key = self.api_key\n                if model_selection:\n                    self._save_embedding_metadata(\n                        kb_path=kb_path,\n                        model_selection=model_selection,\n                        api_key=api_key,\n                    )\n\n            if not model_selection:\n                msg = \"No embedding model configuration found. Please create the knowledge base first.\"\n                raise ValueError(msg)\n\n            embedding_function = get_embeddings(\n                model=model_selection,\n                user_id=self.user_id,\n                api_key=api_key,\n                chunk_size=self.chunk_size,\n            )\n\n            run_id, run_job_id, run_summary, kb_record_id = await self._begin_ingestion_run(kb_path)\n            if kb_record_id is not None:\n                await self._record_kb_status(kb_record_id, \"ingesting\")\n\n            backend = await self._create_vector_store(df_source, config_list, embedding_function=embedding_function)\n\n            self._save_kb_files(kb_path, config_list)\n\n            try:\n                if not isinstance(backend, BaseVectorStoreBackend):\n                    pass\n                elif backend.backend_type == BackendType.CHROMA and hasattr(backend, \"raw_langchain_store\"):\n                    self._update_metadata_metrics(kb_path, backend.raw_langchain_store())\n                else:\n                    await self._update_backend_metadata_metrics(kb_path, backend)\n                # Stamp the KB with the file extensions we just ingested so\n                # the Knowledge Bases list renders the correct icon for\n                # flow-driven ingestion (input_df), matching direct upload.\n                # We look at the raw input first because ``convert_to_dataframe``\n                # drops Message/Data metadata fields (file_path, mimetype, …)\n                # when projecting onto the DataFrame.\n                source_types = self._extract_source_types_from_input(input_value)\n                source_types |= self._extract_source_types_from_df(df_source)\n                self._merge_source_types(kb_path, source_types)\n            finally:\n                if isinstance(backend, BaseVectorStoreBackend):\n                    await backend.teardown()\n\n            meta: dict[str, Any] = {\n                \"kb_id\": str(uuid.uuid4()),\n                \"kb_name\": self.knowledge_base,\n                \"rows\": len(df_source),\n                \"column_metadata\": column_metadata,\n                \"path\": str(kb_path),\n                \"config_columns\": len(config_list),\n                \"timestamp\": datetime.now(tz=timezone.utc).isoformat(),\n            }\n\n            if run_summary is not None:\n                run_summary.record_item(\n                    IngestionItemResult(\n                        item_id=self.knowledge_base,\n                        display_name=f\"{self.knowledge_base} ({len(df_source)} rows)\",\n                        status=IngestionItemStatus.SUCCEEDED,\n                        chunks_created=len(df_source),\n                    ),\n                )\n\n            if kb_record_id is not None:\n                await self._record_kb_stats(kb_record_id, kb_path)\n                await self._record_kb_status(kb_record_id, \"ready\")\n\n            self.status = f\"✅ KB **{self.knowledge_base}** saved · {len(df_source)} chunks.\"\n\n            return Data(data=meta)\n\n        except (OSError, ValueError, RuntimeError, KeyError) as e:\n            run_status = IngestionRunStatus.FAILED\n            run_error = str(e) or e.__class__.__name__\n            msg = f\"Error during KB ingestion: {e}\"\n            raise RuntimeError(msg) from e\n        except Exception as e:\n            run_status = IngestionRunStatus.FAILED\n            run_error = str(e) or e.__class__.__name__\n            raise\n        finally:\n            if run_id is not None and run_summary is not None:\n                await self._finalize_ingestion_run(\n                    run_id=run_id,\n                    job_id=run_job_id,\n                    summary=run_summary,\n                    status=run_status,\n                    error_message=run_error,\n                )\n            if kb_record_id is not None and run_status is IngestionRunStatus.FAILED:\n                await self._record_kb_status(kb_record_id, \"failed\", failure_reason=run_error)\n\n    async def _begin_ingestion_run(\n        self,\n        kb_path: Path,\n    ) -> tuple[uuid.UUID | None, uuid.UUID | None, IngestionSummary | None, uuid.UUID | None]:\n        \"\"\"Create a parent ``Job`` and seed an ingestion-run row.\"\"\"\n        if not self.user_id:\n            self.log(\"No user_id on component; skipping ingestion-run tracking.\")\n            return None, None, None, None\n\n        try:\n            user_uuid = uuid.UUID(str(self.user_id))\n        except (ValueError, TypeError) as exc:\n            self.log(f\"Could not coerce user_id={self.user_id!r} to UUID; skipping run tracking ({exc}).\")\n            return None, None, None, None\n\n        try:\n            from langflow.api.utils import ingestion_run_service, knowledge_base_service\n            from langflow.services.database.models.jobs.model import JobStatus, JobType\n            from langflow.services.deps import get_job_service\n        except ImportError as exc:\n            self.log(f\"Run-history wiring unavailable; ingestion will not be recorded ({exc}).\")\n            return None, None, None, None\n\n        try:\n            kb_record = await knowledge_base_service.get_by_user_and_name(user_uuid, self.knowledge_base)\n            kb_record_id = kb_record.id if kb_record is not None else None\n\n            user_metadata = self._parse_user_metadata_dict()\n\n            job_id = uuid.uuid4()\n            job_service = get_job_service()\n            raw_flow_id = getattr(self, \"flow_id\", None)\n            flow_id_uuid = uuid.UUID(str(raw_flow_id)) if raw_flow_id else job_id\n            await job_service.create_job(\n                job_id=job_id,\n                flow_id=flow_id_uuid,\n                job_type=JobType.INGESTION,\n                asset_id=kb_record_id,\n                asset_type=\"knowledge_base\",\n                user_id=user_uuid,\n            )\n            await job_service.update_job_status(job_id, JobStatus.IN_PROGRESS)\n\n            source = FlowComponentSource(\n                user_id=user_uuid,\n                source_config={\n                    \"knowledge_base\": self.knowledge_base,\n                    \"kb_path\": str(kb_path),\n                    \"flow_id\": str(flow_id_uuid),\n                },\n            )\n\n            run_id = await ingestion_run_service.create_run(\n                kb_name=self.knowledge_base,\n                source=source,\n                job_id=job_id,\n                user_id=user_uuid,\n                kb_id=kb_record_id,\n                user_metadata=user_metadata,\n            )\n            if run_id is None:\n                return None, job_id, None, kb_record_id\n            await ingestion_run_service.mark_running(run_id)\n\n            summary = IngestionSummary(\n                kb_name=self.knowledge_base,\n                source_type=source.source_type.value,\n                user_id=user_uuid,\n                job_id=job_id,\n                source_config=source.describe().get(\"config\") or {},\n                user_metadata=user_metadata,\n            )\n            self.log(f\"Started ingestion run job_id={job_id} kb_name={self.knowledge_base} kb_id={kb_record_id}\")\n        except Exception as exc:  # noqa: BLE001 — telemetry must never abort ingestion\n            self.log(f\"Could not begin ingestion-run tracking: {exc}\")\n            return None, None, None, None\n        else:\n            return run_id, job_id, summary, kb_record_id\n\n    async def _finalize_ingestion_run(\n        self,\n        *,\n        run_id: uuid.UUID,\n        job_id: uuid.UUID | None,\n        summary: IngestionSummary,\n        status: IngestionRunStatus,\n        error_message: str | None,\n    ) -> None:\n        \"\"\"Persist the final summary and transition the parent Job.\"\"\"\n        try:\n            from langflow.api.utils import ingestion_run_service\n            from langflow.services.database.models.jobs.model import JobStatus\n            from langflow.services.deps import get_job_service\n        except ImportError as exc:\n            self.log(f\"Run-history wiring unavailable; ingestion-run finalize skipped ({exc}).\")\n            return\n\n        try:\n            await ingestion_run_service.finalize_run(\n                run_id,\n                summary=summary,\n                status=status,\n                error_message=error_message,\n            )\n            if job_id is not None:\n                terminal_status = JobStatus.COMPLETED if status is not IngestionRunStatus.FAILED else JobStatus.FAILED\n                await get_job_service().update_job_status(job_id, terminal_status, finished_timestamp=True)\n        except Exception as exc:  # noqa: BLE001 — telemetry must never re-raise\n            self.log(f\"Could not finalize ingestion-run tracking: {exc}\")\n\n    async def _record_kb_status(\n        self,\n        kb_record_id: uuid.UUID,\n        status_value: str,\n        *,\n        failure_reason: str | None = None,\n    ) -> None:\n        \"\"\"Mirror Path A's KB-row status transitions.\"\"\"\n        try:\n            from langflow.api.utils import knowledge_base_service\n            from langflow.services.database.models.knowledge_base.model import KnowledgeBaseStatus\n        except ImportError:\n            return\n        try:\n            await knowledge_base_service.update_status(\n                kb_record_id,\n                status=KnowledgeBaseStatus(status_value),\n                failure_reason=failure_reason,\n            )\n        except Exception as exc:  # noqa: BLE001\n            self.log(f\"Could not update KB status to {status_value}: {exc}\")\n\n    async def _record_kb_stats(self, kb_record_id: uuid.UUID, kb_path: Path) -> None:\n        \"\"\"Push freshly-refreshed metrics from embedding_metadata.json onto the DB row.\"\"\"\n        try:\n            from langflow.api.utils import knowledge_base_service\n        except ImportError:\n            self.log(\"knowledge_base_service unavailable; KB stats will not sync to DB row.\")\n            return\n        metadata_path = kb_path / \"embedding_metadata.json\"\n        if not metadata_path.exists():\n            self.log(f\"No embedding_metadata.json at {metadata_path}; skipping KB stats sync.\")\n            return\n        try:\n            metadata = json.loads(metadata_path.read_text())\n        except (OSError, json.JSONDecodeError) as exc:\n            self.log(f\"Could not read KB metadata for stats sync: {exc}\")\n            return\n        chunks = int(metadata.get(\"chunks\", 0) or 0)\n        words = int(metadata.get(\"words\", 0) or 0)\n        characters = int(metadata.get(\"characters\", 0) or 0)\n        try:\n            await knowledge_base_service.update_stats(\n                kb_record_id,\n                chunks=chunks,\n                words=words,\n                characters=characters,\n                size_bytes=int(metadata.get(\"size\", 0) or 0),\n                source_types=list(metadata.get(\"source_types\") or []),\n                chunk_size=metadata.get(\"chunk_size\"),\n                chunk_overlap=metadata.get(\"chunk_overlap\"),\n                separator=metadata.get(\"separator\"),\n            )\n            self.log(f\"Synced KB stats to DB row {kb_record_id}: chunks={chunks} words={words} characters={characters}\")\n        except Exception as exc:  # noqa: BLE001\n            self.log(f\"Could not sync KB stats to DB row {kb_record_id}: {exc}\")\n\n    def _parse_user_metadata_dict(self) -> dict[str, Any]:\n        \"\"\"Decode ``metadata_json`` to a dict, or ``{}`` on any error.\"\"\"\n        raw = getattr(self, \"metadata_json\", None)\n        if not raw:\n            return {}\n        text = raw.strip() if isinstance(raw, str) else raw\n        if not text:\n            return {}\n        try:\n            decoded = json.loads(text)\n        except (TypeError, json.JSONDecodeError):\n            return {}\n        return decoded if isinstance(decoded, dict) else {}\n\n    # =====================================================================\n    #                       RETRIEVAL CODE PATH\n    # =====================================================================\n    @property\n    def _user_uuid(self) -> uuid.UUID | None:\n        \"\"\"Return self.user_id as a UUID, converting from str if necessary.\"\"\"\n        if not self.user_id:\n            return None\n        return self.user_id if isinstance(self.user_id, uuid.UUID) else uuid.UUID(self.user_id)\n\n    def _get_kb_metadata(self, kb_path: Path) -> dict:\n        \"\"\"Load the knowledge base's embedding metadata file.\"\"\"\n        raise_error_if_astra_cloud_disable_component(astra_error_msg)\n        return load_kb_metadata(kb_path, log_label=f\"knowledge base '{self.knowledge_base}'\")\n\n    async def _resolve_backend(self, *, kb_user: str) -> tuple[str, dict[str, Any]]:  # noqa: ARG002\n        \"\"\"Return ``(backend_type, backend_config)`` for this KB.\"\"\"\n        try:\n            from langflow.api.utils import knowledge_base_service\n\n            user_uuid = self._user_uuid\n            if user_uuid is None:\n                return BackendType.CHROMA.value, {}\n            record = await knowledge_base_service.get_by_user_and_name(user_uuid, self.knowledge_base)\n        except Exception as exc:  # noqa: BLE001\n            logger.debug(\"KB record lookup failed: %s\", exc)\n            return BackendType.CHROMA.value, {}\n\n        if record is None:\n            return BackendType.CHROMA.value, {}\n        return (\n            record.backend_type or BackendType.CHROMA.value,\n            record.backend_config or {},\n        )\n\n    def _resolve_model_selection(self, metadata: dict[str, Any]) -> list[dict[str, Any]]:\n        \"\"\"Resolve the ``get_embeddings``-compatible model selection from metadata.\"\"\"\n        model_selection = metadata.get(\"model_selection\")\n        if model_selection:\n            selection_list = [model_selection] if isinstance(model_selection, dict) else list(model_selection)\n            return [self._hydrate_model_metadata(entry) for entry in selection_list]\n\n        embedding_model_name = metadata.get(\"embedding_model\")\n        embedding_provider = metadata.get(\"embedding_provider\", \"Unknown\")\n        if not embedding_model_name:\n            msg = (\n                f\"Knowledge base '{self.knowledge_base}' has no embedding model recorded; \"\n                \"re-create it with a supported embedding model.\"\n            )\n            raise ValueError(msg)\n\n        match = self._find_catalog_entry(embedding_model_name)\n        if match is None:\n            msg = (\n                f\"Embedding model '{embedding_model_name}' (provider '{embedding_provider}') \"\n                \"recorded for this knowledge base is no longer available in the model registry. \"\n                \"Please re-create the knowledge base with a supported embedding model.\"\n            )\n            raise ValueError(msg)\n        return [match]\n\n    def _hydrate_model_metadata(self, entry: dict[str, Any]) -> dict[str, Any]:\n        \"\"\"Fill in ``metadata.embedding_class`` / ``param_mapping`` if missing.\"\"\"\n        entry_metadata = entry.get(\"metadata\") or {}\n        has_class = bool(entry_metadata.get(\"embedding_class\"))\n        has_mapping = bool(entry_metadata.get(\"param_mapping\"))\n        if has_class and has_mapping:\n            return entry\n\n        model_name = entry.get(\"name\")\n        if not model_name:\n            return entry\n\n        catalog_entry = self._find_catalog_entry(model_name)\n        if catalog_entry is None:\n            return entry\n\n        catalog_metadata = catalog_entry.get(\"metadata\") or {}\n        merged_metadata = {**catalog_metadata, **entry_metadata}\n        return {**entry, \"metadata\": merged_metadata}\n\n    def _find_catalog_entry(self, model_name: str) -> dict[str, Any] | None:\n        \"\"\"Look up an embedding model by name in the unified-models catalog.\"\"\"\n        options = get_embedding_model_options(user_id=self.user_id)\n        return next((o for o in options if o.get(\"name\") == model_name), None)\n\n    async def retrieve_data(self) -> DataFrame:\n        \"\"\"Retrieve data from the selected knowledge base.\n\n        Annotation narrowed to ``DataFrame`` to keep this output's handle\n        type list at ``[\"Table\"]`` only; widening to a union surfaces\n        ``[\"Table\", \"JSON\"]`` on the API and breaks every starter-project\n        edge whose sourceHandle was stored against a single-type handle\n        (BUG-02). The cross-mode defensive fallback may still return a\n        ``Data`` at runtime — Python ignores return annotations, so\n        nothing breaks.\n        \"\"\"\n        if not _is_retrieve_mode(getattr(self, \"mode\", MODE_INGEST)):\n            return await self.build_kb_info()\n        raise_error_if_astra_cloud_disable_component(astra_error_msg)\n\n        # Lazy import: langflow's user/DB models aren't part of lfx's\n        # standalone install, so ``lfx run <starter>.json`` can't resolve\n        # this symbol at module import time. Deferring to use keeps the\n        # component importable in both environments.\n        from langflow.services.database.models.user.crud import get_user_by_id\n\n        async with session_scope() as db:\n            if not self.user_id:\n                msg = \"User ID is required for fetching Knowledge Base data.\"\n                raise ValueError(msg)\n            current_user = await get_user_by_id(db, self.user_id)\n            if not current_user:\n                msg = f\"User with ID {self.user_id} not found.\"\n                raise ValueError(msg)\n            kb_user = current_user.username\n        kb_path = _get_knowledge_bases_root_path() / kb_user / self.knowledge_base\n\n        metadata = self._get_kb_metadata(kb_path)\n        if not metadata:\n            msg = f\"Metadata not found for knowledge base: {self.knowledge_base}. Ensure it has been indexed.\"\n            raise ValueError(msg)\n\n        model_selection = self._resolve_model_selection(metadata)\n        chunk_size = metadata.get(\"chunk_size\")\n        embedding_function = get_embeddings(\n            model=model_selection,\n            user_id=self.user_id,\n            chunk_size=chunk_size,\n        )\n\n        backend_type, backend_config = await self._resolve_backend(kb_user=kb_user)\n        backend = create_backend(\n            backend_type,\n            kb_name=self.knowledge_base,\n            kb_path=kb_path,\n            backend_config=backend_config,\n            embedding_function=embedding_function,\n            user_id=self.user_id,\n        )\n        try:\n            user_metadata_filter = _parse_metadata_filter(getattr(self, \"metadata_filter\", None))\n            use_scores = bool(self.search_query)\n            search_k = self.top_k * 4 if user_metadata_filter else self.top_k\n            results = await backend.similarity_search(\n                query=self.search_query or \"\",\n                k=search_k,\n                with_scores=use_scores,\n            )\n            if user_metadata_filter:\n                results = [\n                    (doc, score) for doc, score in results if _chunk_matches_filter(doc.metadata, user_metadata_filter)\n                ]\n                results = results[: self.top_k]\n\n            embeddings_by_key: dict[tuple[str, str], list[float]] = {}\n            if self.include_embeddings and results:\n                # Join each retrieved chunk to its stored embedding. We key on\n                # ``_id`` when present and fall back to page content otherwise,\n                # so KBs populated by direct file upload — whose chunks carry no\n                # ``_id`` — still resolve. See ``_embedding_match_key``.\n                wanted_keys = {_embedding_match_key(doc.page_content, doc.metadata) for doc, _score in results}\n                async for batch in backend.iter_documents(include_embeddings=True):\n                    for entry in batch:\n                        if entry.embedding is None:\n                            continue\n                        key = _embedding_match_key(entry.content, entry.metadata)\n                        if key in wanted_keys:\n                            embeddings_by_key[key] = entry.embedding\n                    if len(embeddings_by_key) == len(wanted_keys):\n                        break\n\n            data_list: list[Data] = []\n            for doc, score in results:\n                kwargs: dict[str, Any] = {\"content\": doc.page_content}\n                if use_scores:\n                    kwargs[\"_score\"] = -1 * score\n                if self.include_metadata:\n                    kwargs.update(doc.metadata)\n                if self.include_embeddings:\n                    kwargs[\"_embeddings\"] = embeddings_by_key.get(_embedding_match_key(doc.page_content, doc.metadata))\n                data_list.append(Data(**kwargs))\n\n            return DataFrame(data=data_list)\n        finally:\n            await backend.teardown()\n\n\ndef _embedding_match_key(content: str, metadata: dict[str, Any] | None) -> tuple[str, str]:\n    \"\"\"Build a stable key for aligning a retrieved chunk with its stored embedding.\n\n    Embeddings are gathered separately (via ``iter_documents``) and then joined\n    back onto the search results. Component-driven ingestion stamps a\n    content-hash ``_id`` on every chunk, but direct file-upload ingestion\n    (``KBIngestionHelper.perform_ingestion``) does not. Keying the join purely on\n    ``_id`` therefore left every upload-populated KB with ``_embeddings: None``.\n\n    We prefer ``_id`` when present (so legitimately distinct chunks that happen to\n    share text aren't collapsed) and fall back to the chunk's page content\n    otherwise. The content fallback is exact for the embedding use case: two\n    chunks with identical text necessarily share the same embedding vector. The\n    leading ``\"id\"`` / ``\"content\"`` tag namespaces the two key spaces so a mixed\n    KB (some chunks with ``_id``, some without) never cross-matches.\n    \"\"\"\n    doc_id = metadata.get(\"_id\") if metadata else None\n    if doc_id:\n        return (\"id\", str(doc_id))\n    return (\"content\", content or \"\")\n\n\ndef _parse_metadata_filter(raw: str | None) -> dict[str, list[str]]:\n    \"\"\"Decode the ``metadata_filter`` input into a {key: [values]} map.\n\n    Empty or malformed input maps to an empty filter so retrieval falls back\n    to the unfiltered path. JSON errors are swallowed here rather than raised:\n    surfacing component-config errors at the canvas node would break a flow\n    run for what is meant to be an optional refinement.\n    \"\"\"\n    if not raw:\n        return {}\n    text = raw.strip() if isinstance(raw, str) else raw\n    if not text:\n        return {}\n    try:\n        decoded = json.loads(text)\n    except (TypeError, json.JSONDecodeError):\n        logger.warning(\"KnowledgeComponent: metadata_filter is not valid JSON; ignoring filter.\")\n        return {}\n    if not isinstance(decoded, dict):\n        logger.warning(\"KnowledgeComponent: metadata_filter must be a JSON object; ignoring filter.\")\n        return {}\n    result: dict[str, list[str]] = {}\n    for key, value in decoded.items():\n        if not isinstance(key, str):\n            continue\n        if isinstance(value, list):\n            result[key] = [str(entry) for entry in value]\n        else:\n            result[key] = [str(value)]\n    return result\n\n\ndef _chunk_matches_filter(metadata: dict[str, Any] | None, filt: dict[str, list[str]]) -> bool:\n    \"\"\"AND across keys, OR within key values, mirroring the chunks endpoint.\"\"\"\n    if not filt:\n        return True\n    if not metadata:\n        return False\n    raw = metadata.get(\"source_metadata\")\n    if not raw:\n        return False\n    try:\n        stored = json.loads(raw) if isinstance(raw, str) else raw\n    except json.JSONDecodeError:\n        return False\n    if not isinstance(stored, dict):\n        return False\n    for key, expected_values in filt.items():\n        actual = stored.get(key)\n        if actual is None:\n            return False\n        actual_set = {str(entry) for entry in actual} if isinstance(actual, list) else {str(actual)}\n        if not actual_set & set(expected_values):\n            return False\n    return True\n",
+        "fileTypes": [],
+        "file_path": "",
+        "password": false,
+        "name": "code",
+        "advanced": true,
+        "dynamic": true,
+        "info": "",
+        "load_from_db": false,
+        "title_case": false
+       },
+       "column_config": {
+        "tool_mode": false,
+        "is_list": true,
+        "list_add_label": "Add More",
+        "table_schema": [
+         {
+          "name": "column_name",
+          "display_name": "Column Name",
+          "type": "str",
+          "description": "Name of the column in the source DataFrame",
+          "edit_mode": "inline",
+          "formatter": "text"
+         },
+         {
+          "name": "vectorize",
+          "display_name": "Vectorize",
+          "type": "boolean",
+          "description": "Create embeddings for this column",
+          "default": false,
+          "edit_mode": "inline",
+          "formatter": "text"
+         },
+         {
+          "name": "identifier",
+          "display_name": "Identifier",
+          "type": "boolean",
+          "description": "Use this column as unique identifier",
+          "default": false,
+          "edit_mode": "inline",
+          "formatter": "text"
+         }
+        ],
+        "trigger_text": "Open table",
+        "trigger_icon": "Table",
+        "table_icon": "Table",
+        "trace_as_metadata": true,
+        "override_skip": false,
+        "required": true,
+        "placeholder": "",
+        "show": true,
+        "name": "column_config",
+        "value": [
+         {
+          "column_name": "text",
+          "vectorize": true,
+          "identifier": true
+         }
+        ],
+        "display_name": "Column Configuration",
+        "advanced": false,
+        "input_types": [
+         "DataFrame",
+         "Table"
+        ],
+        "dynamic": true,
+        "info": "Configure column behavior for the knowledge base.",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "table",
+        "_input_type": "TableInput"
+       },
+       "include_embeddings": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": false,
+        "name": "include_embeddings",
+        "value": false,
+        "display_name": "Include Embeddings",
+        "advanced": true,
+        "dynamic": true,
+        "info": "Whether to include embeddings in the output. Only applicable if 'Include Metadata' is enabled.",
+        "title_case": false,
+        "track_in_telemetry": true,
+        "type": "bool",
+        "_input_type": "BoolInput"
+       },
+       "include_metadata": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": false,
+        "name": "include_metadata",
+        "value": true,
+        "display_name": "Include Metadata",
+        "advanced": false,
+        "dynamic": true,
+        "info": "Whether to include all metadata in the output. If false, only content is returned.",
+        "title_case": false,
+        "track_in_telemetry": true,
+        "type": "bool",
+        "_input_type": "BoolInput"
+       },
+       "knowledge_base": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "options": [
+         "__KB_NAME__"
+        ],
+        "options_metadata": [],
+        "combobox": false,
+        "dialog_inputs": {
+         "functionality": "create",
+         "fields": {
+          "data": {
+           "node": {
+            "name": "create_knowledge_base",
+            "description": "Create new knowledge in Langflow.",
+            "display_name": "Create new Knowledge Base",
+            "field_order": [
+             "01_new_kb_name",
+             "02_embedding_model",
+             "03_knowledge_backend"
+            ],
+            "template": {
+             "01_new_kb_name": {
+              "tool_mode": false,
+              "trace_as_metadata": true,
+              "load_from_db": false,
+              "list": false,
+              "list_add_label": "Add More",
+              "override_skip": false,
+              "required": true,
+              "placeholder": "",
+              "show": true,
+              "name": "new_kb_name",
+              "value": "",
+              "display_name": "Knowledge Name",
+              "advanced": false,
+              "dynamic": false,
+              "info": "Name of the new knowledge to create.",
+              "title_case": false,
+              "track_in_telemetry": false,
+              "type": "str",
+              "_input_type": "StrInput"
+             },
+             "02_embedding_model": {
+              "tool_mode": false,
+              "trace_as_input": true,
+              "list": false,
+              "list_add_label": "Add More",
+              "model_type": "embedding",
+              "external_options": {
+               "fields": {
+                "data": {
+                 "node": {
+                  "name": "connect_other_models",
+                  "display_name": "Connect other models",
+                  "icon": "CornerDownLeft"
+                 }
+                }
+               }
+              },
+              "override_skip": false,
+              "required": true,
+              "placeholder": "Setup Provider",
+              "show": true,
+              "name": "embedding_model",
+              "value": "",
+              "display_name": "Choose Embedding Model",
+              "advanced": false,
+              "input_types": [
+               "Embeddings"
+              ],
+              "dynamic": false,
+              "info": "Select the embedding model to use for this knowledge base. Langflow uses the configured credentials for that model provider.",
+              "refresh_button": true,
+              "title_case": false,
+              "track_in_telemetry": false,
+              "type": "model",
+              "_input_type": "ModelInput",
+              "options": [
+               {
+                "name": "gemini-embedding-001",
+                "icon": "GoogleGenerativeAI",
+                "category": "Google Generative AI",
+                "provider": "Google Generative AI",
+                "metadata": {
+                 "embedding_class": "GoogleGenerativeAIEmbeddings",
+                 "param_mapping": {
+                  "model": "model",
+                  "api_key": "google_api_key",
+                  "dimensions": "output_dimensionality",
+                  "request_timeout": "request_options",
+                  "model_kwargs": "client_options"
+                 },
+                 "model_type": "embeddings"
+                }
+               },
+               {
+                "name": "models/gemini-embedding-001",
+                "icon": "GoogleGenerativeAI",
+                "category": "Google Generative AI",
+                "provider": "Google Generative AI",
+                "metadata": {
+                 "embedding_class": "GoogleGenerativeAIEmbeddings",
+                 "param_mapping": {
+                  "model": "model",
+                  "api_key": "google_api_key",
+                  "dimensions": "output_dimensionality",
+                  "request_timeout": "request_options",
+                  "model_kwargs": "client_options"
+                 },
+                 "model_type": "embeddings"
+                }
+               }
+              ]
+             },
+             "03_knowledge_backend": {
+              "tool_mode": false,
+              "trace_as_input": true,
+              "override_skip": false,
+              "required": true,
+              "placeholder": "",
+              "show": true,
+              "name": "knowledge_backend",
+              "value": {},
+              "display_name": "DB Provider",
+              "advanced": false,
+              "input_types": [],
+              "dynamic": false,
+              "info": "Select where this knowledge base stores vectors. OpenSearch uses the global DB Providers settings.",
+              "title_case": false,
+              "track_in_telemetry": false,
+              "type": "knowledge_backend",
+              "_input_type": "DBProviderInput"
+             }
+            }
+           }
+          }
+         }
+        },
+        "toggle": false,
+        "override_skip": false,
+        "required": true,
+        "placeholder": "",
+        "show": true,
+        "name": "knowledge_base",
+        "value": "__KB_NAME__",
+        "display_name": "Knowledge",
+        "advanced": false,
+        "dynamic": false,
+        "info": "Select the knowledge to load data from.",
+        "real_time_refresh": true,
+        "refresh_button": true,
+        "title_case": false,
+        "track_in_telemetry": true,
+        "external_options": {},
+        "type": "str",
+        "_input_type": "DropdownInput"
+       },
+       "metadata_filter": {
+        "tool_mode": false,
+        "trace_as_input": true,
+        "trace_as_metadata": true,
+        "load_from_db": false,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": false,
+        "name": "metadata_filter",
+        "value": "",
+        "display_name": "Metadata Filter",
+        "advanced": true,
+        "input_types": [
+         "Message"
+        ],
+        "dynamic": true,
+        "info": "Optional JSON object of user-metadata key/value pairs. Only chunks whose source_metadata matches every key are returned (e.g. {\"tag\": \"invoice\"} or {\"tag\": [\"invoice\", \"audit\"]} for OR-of-values). Backends without native filtering apply the match client-side after retrieval.",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "str",
+        "_input_type": "MessageTextInput"
+       },
+       "metadata_json": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "load_from_db": false,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "metadata_json",
+        "value": "",
+        "display_name": "Metadata",
+        "advanced": true,
+        "dynamic": true,
+        "info": "Optional JSON object of user metadata applied to every chunk produced by this run (e.g. {\"tag\": \"invoice\", \"year\": \"2026\"}). Same shape as the upload modal Metadata section so chunks browser filters + Knowledge retrieval metadata_filter work uniformly across upload, folder, and flow-driven ingestion. Malformed JSON is ignored with a warning rather than failing the run.",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "str",
+        "_input_type": "StrInput"
+       },
+       "mode": {
+        "tool_mode": true,
+        "trace_as_metadata": true,
+        "options": [
+         "Ingest",
+         "Retrieve"
+        ],
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "mode",
+        "value": "Ingest",
+        "display_name": "Mode",
+        "advanced": false,
+        "dynamic": false,
+        "info": "Switch between writing new data into the knowledge base and querying it.",
+        "real_time_refresh": true,
+        "title_case": false,
+        "track_in_telemetry": true,
+        "type": "tab",
+        "_input_type": "TabInput"
+       },
+       "search_query": {
+        "tool_mode": true,
+        "trace_as_input": true,
+        "trace_as_metadata": true,
+        "load_from_db": false,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": false,
+        "name": "search_query",
+        "value": "",
+        "display_name": "Search Query",
+        "advanced": false,
+        "input_types": [
+         "Message"
+        ],
+        "dynamic": true,
+        "info": "Optional search query to filter knowledge base data.",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "str",
+        "_input_type": "MessageTextInput"
+       },
+       "top_k": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": false,
+        "name": "top_k",
+        "value": 5,
+        "display_name": "Top K Results",
+        "advanced": true,
+        "dynamic": true,
+        "info": "Number of top results to return from the knowledge base.",
+        "title_case": false,
+        "track_in_telemetry": true,
+        "type": "int",
+        "_input_type": "IntInput"
+       },
+       "_frontend_node_flow_id": {
+        "value": "31dfa8d2-d42f-4bd0-b04a-a3bbb96fc544"
+       },
+       "_frontend_node_folder_id": {
+        "value": "50c46771-d71e-47f4-b62a-068e2fe5ef85"
+       },
+       "is_refresh": false
+      },
+      "description": "Ingest into or retrieve from a Langflow knowledge base.",
+      "icon": "database",
+      "base_classes": [
+       "JSON",
+       "Table"
+      ],
+      "display_name": "Knowledge",
+      "documentation": "",
+      "minimized": false,
+      "custom_fields": {},
+      "output_types": [],
+      "pinned": false,
+      "conditional_paths": [],
+      "frozen": false,
+      "outputs": [
+       {
+        "types": [
+         "JSON"
+        ],
+        "selected": "JSON",
+        "name": "dataframe_output",
+        "display_name": "Results",
+        "method": "build_kb_info",
+        "value": "__UNDEFINED__",
+        "cache": true,
+        "required_inputs": null,
+        "allows_loop": false,
+        "loop_types": null,
+        "group_outputs": false,
+        "options": null,
+        "tool_mode": true
+       },
+       {
+        "types": [
+         "Table"
+        ],
+        "selected": "Table",
+        "name": "retrieve_data",
+        "display_name": "Results",
+        "method": "retrieve_data",
+        "value": "__UNDEFINED__",
+        "cache": true,
+        "required_inputs": null,
+        "allows_loop": false,
+        "loop_types": null,
+        "group_outputs": false,
+        "options": null,
+        "tool_mode": true
+       }
+      ],
+      "field_order": [
+       "knowledge_base",
+       "mode",
+       "input_df",
+       "column_config",
+       "chunk_size",
+       "api_key",
+       "allow_duplicates",
+       "metadata_json",
+       "search_query",
+       "top_k",
+       "include_metadata",
+       "include_embeddings",
+       "metadata_filter"
+      ],
+      "beta": false,
+      "legacy": false,
+      "edited": false,
+      "metadata": {
+       "module": "lfx.components.files_and_knowledge.knowledge.KnowledgeComponent",
+       "code_hash": "26a843069b81",
+       "dependencies": {
+        "total_dependencies": 7,
+        "dependencies": [
+         {
+          "name": "pandas",
+          "version": "2.3.3"
+         },
+         {
+          "name": "cryptography",
+          "version": "49.0.0"
+         },
+         {
+          "name": "langchain_chroma",
+          "version": "0.2.6"
+         },
+         {
+          "name": "langflow",
+          "version": "1.11.0.dev38"
+         },
+         {
+          "name": "lfx",
+          "version": "1.11.0.dev38"
+         },
+         {
+          "name": "numpy",
+          "version": "2.5.1"
+         },
+         {
+          "name": "chromadb",
+          "version": "1.5.9"
+         }
+        ]
+       }
+      },
+      "tool_mode": false,
+      "last_updated": "2026-07-14T17:31:32.561Z",
+      "lf_version": "1.11.0.dev38"
+     },
+     "showNode": true,
+     "type": "Knowledge",
+     "id": "Knowledge-ingest",
+     "selected_output": "dataframe_output"
+    },
+    "selected": true,
+    "measured": {
+     "width": 320,
+     "height": 431
+    }
+   },
+   {
+    "id": "Knowledge-retrieve",
+    "type": "genericNode",
+    "position": {
+     "x": 0,
+     "y": 650
+    },
+    "data": {
+     "node": {
+      "template": {
+       "_type": "Component",
+       "input_df": {
+        "trace_as_metadata": true,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": true,
+        "placeholder": "",
+        "show": false,
+        "name": "input_df",
+        "value": "",
+        "display_name": "Input",
+        "advanced": false,
+        "input_types": [
+         "Message",
+         "Data",
+         "JSON",
+         "DataFrame",
+         "Table"
+        ],
+        "dynamic": true,
+        "info": "Table with all original columns (already chunked / processed). Accepts Message, Data, or DataFrame. If Message or Data is provided, it is converted to a DataFrame automatically.",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "other",
+        "_input_type": "HandleInput"
+       },
+       "allow_duplicates": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": false,
+        "name": "allow_duplicates",
+        "value": false,
+        "display_name": "Allow Duplicates",
+        "advanced": true,
+        "dynamic": true,
+        "info": "Allow duplicate rows in the knowledge base",
+        "title_case": false,
+        "track_in_telemetry": true,
+        "type": "bool",
+        "_input_type": "BoolInput"
+       },
+       "api_key": {
+        "load_from_db": false,
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": false,
+        "name": "api_key",
+        "value": "",
+        "display_name": "Embedding Provider API Key",
+        "advanced": true,
+        "input_types": [],
+        "dynamic": true,
+        "info": "Overrides global provider settings. Leave blank to use your pre-configured API Key.",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "password": true,
+        "type": "str",
+        "_input_type": "SecretStrInput"
+       },
+       "chunk_size": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": false,
+        "name": "chunk_size",
+        "value": 1000,
+        "display_name": "Chunk Size",
+        "advanced": true,
+        "dynamic": true,
+        "info": "Batch size for processing embeddings",
+        "title_case": false,
+        "track_in_telemetry": true,
+        "type": "int",
+        "_input_type": "IntInput"
+       },
+       "code": {
+        "type": "code",
+        "required": true,
+        "placeholder": "",
+        "list": false,
+        "show": true,
+        "multiline": true,
+        "value": "\"\"\"Unified Knowledge component — ingest into or retrieve from a knowledge base.\n\nThis component merges what used to live in ``ingestion.py`` and\n``retrieval.py`` into a single, mode-driven component. A ``TabInput``\n(\"📥 Ingest\" / \"🔍 Retrieve\") drives which inputs and which output are\nvisible. The merged shape gives users one node per KB instead of two\nparallel ones that always shared the same ``knowledge_base`` picker,\nembedding-model metadata, and backend registry.\n\nBoth legacy classes (``KnowledgeIngestionComponent``,\n``KnowledgeBaseComponent``) remain importable as thin subclasses of\n``KnowledgeComponent`` — see the sibling ``ingestion.py`` / ``retrieval.py``\nmodules — so saved flows continue to load unchanged.\n\"\"\"\n\nfrom __future__ import annotations\n\nimport asyncio\nimport hashlib\nimport json\nimport re\nimport uuid\nfrom dataclasses import asdict, dataclass, field\nfrom datetime import datetime, timezone\nfrom typing import TYPE_CHECKING, Any\n\nimport pandas as pd\nfrom cryptography.fernet import InvalidToken\nfrom langchain_chroma import Chroma\nfrom langflow.services.auth.utils import decrypt_api_key, encrypt_api_key\n\nfrom lfx.base.knowledge_bases.backends import BackendType, BaseVectorStoreBackend, create_backend\nfrom lfx.base.knowledge_bases.ingestion_sources.base import (\n    IngestionItemResult,\n    IngestionItemStatus,\n    IngestionRunStatus,\n    IngestionSummary,\n)\nfrom lfx.base.knowledge_bases.ingestion_sources.flow_component import FlowComponentSource\nfrom lfx.base.knowledge_bases.knowledge_base_utils import get_knowledge_bases\nfrom lfx.base.models.unified_models import get_embedding_model_options, get_embeddings\nfrom lfx.base.vectorstores.chroma_security import chroma_langchain_collection_kwargs\nfrom lfx.components.files_and_knowledge._kb_paths import (\n    get_knowledge_bases_root_path as _get_knowledge_bases_root_path,\n)\nfrom lfx.components.files_and_knowledge._kb_paths import (\n    load_kb_metadata,\n)\nfrom lfx.components.processing.converter import convert_to_dataframe\nfrom lfx.custom import Component\nfrom lfx.io import (\n    BoolInput,\n    DBProviderInput,\n    DropdownInput,\n    HandleInput,\n    IntInput,\n    MessageTextInput,\n    ModelInput,\n    Output,\n    SecretStrInput,\n    StrInput,\n    TabInput,\n    TableInput,\n)\nfrom lfx.log.logger import logger\nfrom lfx.schema.data import Data\nfrom lfx.schema.dataframe import DataFrame\nfrom lfx.schema.dotdict import dotdict\nfrom lfx.schema.table import EditMode\nfrom lfx.services.deps import (\n    get_settings_service,\n    session_scope,\n)\nfrom lfx.utils.component_utils import set_current_fields, set_field_display\nfrom lfx.utils.validate_cloud import raise_error_if_astra_cloud_disable_component\n\n\ndef _inputs_for_mode(default_mode: str) -> list:\n    \"\"\"Return a fresh copy of the canonical inputs list with show flags set for the given mode.\n\n    Used by the legacy subclasses so a saved flow keyed on\n    ``KnowledgeIngestion`` / ``KnowledgeBase`` lands on a node template\n    whose default visibility already matches the pinned mode — no\n    \"wait for the user to click the mode tab\" UX gap on load.\n    \"\"\"\n    always_visible = set(KnowledgeComponent.default_keys) | set(KnowledgeComponent.mode_config[default_mode])\n    inputs_copy = []\n    for inp in KnowledgeComponent.inputs:\n        clone = inp.model_copy(deep=True) if hasattr(inp, \"model_copy\") else inp\n        if clone.name == \"mode\":\n            clone.value = default_mode\n        else:\n            clone.show = clone.name in always_visible\n        inputs_copy.append(clone)\n    return inputs_copy\n\n\nif TYPE_CHECKING:\n    from pathlib import Path\n\n# Mode constants. Plain-text labels (no emoji) for consistency with the rest of\n# Langflow's TabInput palette — see ``MemoryComponent`` for the same convention.\nMODE_INGEST = \"Ingest\"\nMODE_RETRIEVE = \"Retrieve\"\n\n\ndef _is_retrieve_mode(value: Any) -> bool:\n    \"\"\"Lenient mode check: treats any label containing 'Retrieve' as retrieve mode.\n\n    Older saved flows may carry the emoji-prefixed labels (\"📥 Ingest\" /\n    \"🔍 Retrieve\") this component used to ship with; substring matching\n    keeps those loading without forcing a flow rewrite.\n    \"\"\"\n    return isinstance(value, str) and \"Retrieve\" in value\n\n\n# Error message used by both the ingest and retrieve paths when the user is\n# running against an Astra cloud environment that disables these flows.\nastra_error_msg = \"Knowledge ingestion and retrieval are not supported in Astra cloud environment.\"\n\n_DEFAULT_OPENSEARCH_CONFIG = {\n    \"url_variable\": \"OPENSEARCH_URL\",\n    \"username_variable\": \"OPENSEARCH_USERNAME\",\n    \"password_variable\": \"OPENSEARCH_PASSWORD\",  # pragma: allowlist secret\n    \"index_name\": \"\",\n    \"vector_field\": \"vector_field\",\n    \"text_field\": \"text\",\n}\n\n_DEFAULT_CHROMA_CLOUD_CONFIG = {\n    \"mode\": \"cloud\",\n    \"tenant_variable\": \"CHROMA_TENANT\",\n    \"database_variable\": \"CHROMA_DATABASE\",\n    \"api_key_variable\": \"CHROMA_API_KEY\",  # pragma: allowlist secret\n}\n\n\nclass KnowledgeComponent(Component):\n    \"\"\"One component for both writing into and reading from a Langflow knowledge base.\n\n    A ``TabInput`` switches between ingestion and retrieval. The\n    ``update_build_config`` / ``update_outputs`` hooks hide the inputs\n    and the output that don't apply to the current mode so the canvas\n    node stays focused.\n    \"\"\"\n\n    display_name = \"Knowledge\"\n    description = \"Ingest into or retrieve from a Langflow knowledge base.\"\n    icon = \"database\"\n    name = \"Knowledge\"\n\n    # ------ Mode → visible-fields wiring ---------------------------------\n    # ``default_keys`` are inputs always visible regardless of mode.\n    # ``mode_config`` lists the inputs unique to each mode; everything outside\n    # this set is hidden when its mode is not selected.\n    default_keys: list[str] = [\"mode\", \"knowledge_base\"]\n    mode_config: dict[str, list[str]] = {\n        MODE_INGEST: [\n            \"input_df\",\n            \"column_config\",\n            \"chunk_size\",\n            \"api_key\",\n            \"allow_duplicates\",\n            \"metadata_json\",\n        ],\n        MODE_RETRIEVE: [\n            \"search_query\",\n            \"top_k\",\n            \"include_metadata\",\n            \"include_embeddings\",\n            \"metadata_filter\",\n        ],\n    }\n\n    def __init__(self, *args, **kwargs) -> None:\n        super().__init__(*args, **kwargs)\n        self._cached_kb_path: Path | None = None\n\n    @dataclass\n    class NewKnowledgeBaseInput:\n        functionality: str = \"create\"\n        fields: dict[str, dict] = field(\n            default_factory=lambda: {\n                \"data\": {\n                    \"node\": {\n                        \"name\": \"create_knowledge_base\",\n                        \"description\": \"Create new knowledge in Langflow.\",\n                        \"display_name\": \"Create new Knowledge Base\",\n                        \"field_order\": [\n                            \"01_new_kb_name\",\n                            \"02_embedding_model\",\n                            \"03_knowledge_backend\",\n                        ],\n                        \"template\": {\n                            \"01_new_kb_name\": StrInput(\n                                name=\"new_kb_name\",\n                                display_name=\"Knowledge Name\",\n                                info=\"Name of the new knowledge to create.\",\n                                required=True,\n                            ),\n                            \"02_embedding_model\": ModelInput(\n                                name=\"embedding_model\",\n                                display_name=\"Choose Embedding Model\",\n                                info=(\n                                    \"Select the embedding model to use for this knowledge base. \"\n                                    \"Langflow uses the configured credentials for that model provider.\"\n                                ),\n                                required=True,\n                                model_type=\"embedding\",\n                            ),\n                            \"03_knowledge_backend\": DBProviderInput(\n                                name=\"knowledge_backend\",\n                                display_name=\"DB Provider\",\n                                info=(\n                                    \"Select where this knowledge base stores vectors. \"\n                                    \"OpenSearch uses the global DB Providers settings.\"\n                                ),\n                                required=True,\n                            ),\n                        },\n                    },\n                }\n            }\n        )\n\n    # ------ Inputs --------------------------------------------------------\n    # ``knowledge_base`` is kept at position 0 so legacy tests that check\n    # ``component.inputs[0].dialog_inputs`` continue to work.\n    inputs = [\n        DropdownInput(\n            name=\"knowledge_base\",\n            display_name=\"Knowledge\",\n            info=\"Select the knowledge to load data from.\",\n            required=True,\n            options=[],\n            refresh_button=True,\n            real_time_refresh=True,\n            dialog_inputs=asdict(NewKnowledgeBaseInput()),\n        ),\n        TabInput(\n            name=\"mode\",\n            display_name=\"Mode\",\n            options=[MODE_INGEST, MODE_RETRIEVE],\n            value=MODE_INGEST,\n            info=\"Switch between writing new data into the knowledge base and querying it.\",\n            real_time_refresh=True,\n            tool_mode=True,\n        ),\n        # --- Ingest-only inputs (default-shown; hidden when mode == Retrieve) -\n        HandleInput(\n            name=\"input_df\",\n            display_name=\"Input\",\n            info=(\n                \"Table with all original columns (already chunked / processed). \"\n                \"Accepts Message, Data, or DataFrame. If Message or Data is provided, \"\n                \"it is converted to a DataFrame automatically.\"\n            ),\n            input_types=[\"Message\", \"Data\", \"JSON\", \"DataFrame\", \"Table\"],\n            required=True,\n            dynamic=True,\n            show=True,\n        ),\n        TableInput(\n            name=\"column_config\",\n            display_name=\"Column Configuration\",\n            info=\"Configure column behavior for the knowledge base.\",\n            required=True,\n            table_schema=[\n                {\n                    \"name\": \"column_name\",\n                    \"display_name\": \"Column Name\",\n                    \"type\": \"str\",\n                    \"description\": \"Name of the column in the source DataFrame\",\n                    \"edit_mode\": EditMode.INLINE,\n                },\n                {\n                    \"name\": \"vectorize\",\n                    \"display_name\": \"Vectorize\",\n                    \"type\": \"boolean\",\n                    \"description\": \"Create embeddings for this column\",\n                    \"default\": False,\n                    \"edit_mode\": EditMode.INLINE,\n                },\n                {\n                    \"name\": \"identifier\",\n                    \"display_name\": \"Identifier\",\n                    \"type\": \"boolean\",\n                    \"description\": \"Use this column as unique identifier\",\n                    \"default\": False,\n                    \"edit_mode\": EditMode.INLINE,\n                },\n            ],\n            value=[\n                {\n                    \"column_name\": \"text\",\n                    \"vectorize\": True,\n                    \"identifier\": True,\n                },\n            ],\n            dynamic=True,\n            show=True,\n        ),\n        IntInput(\n            name=\"chunk_size\",\n            display_name=\"Chunk Size\",\n            info=\"Batch size for processing embeddings\",\n            advanced=True,\n            value=1000,\n            dynamic=True,\n            show=True,\n        ),\n        SecretStrInput(\n            name=\"api_key\",\n            display_name=\"Embedding Provider API Key\",\n            info=\"Overrides global provider settings. Leave blank to use your pre-configured API Key.\",\n            advanced=True,\n            required=False,\n            dynamic=True,\n            show=True,\n        ),\n        BoolInput(\n            name=\"allow_duplicates\",\n            display_name=\"Allow Duplicates\",\n            info=\"Allow duplicate rows in the knowledge base\",\n            advanced=True,\n            value=False,\n            dynamic=True,\n            show=True,\n        ),\n        StrInput(\n            name=\"metadata_json\",\n            display_name=\"Metadata\",\n            info=(\n                \"Optional JSON object of user metadata applied to every chunk produced by this \"\n                'run (e.g. {\"tag\": \"invoice\", \"year\": \"2026\"}). Same shape as the upload modal '\n                \"Metadata section so chunks browser filters + Knowledge retrieval metadata_filter \"\n                \"work uniformly across upload, folder, and flow-driven ingestion. Malformed JSON is \"\n                \"ignored with a warning rather than failing the run.\"\n            ),\n            advanced=True,\n            required=False,\n            dynamic=True,\n            show=True,\n        ),\n        # --- Retrieve-only inputs (default-hidden; shown when mode == Retrieve) -\n        MessageTextInput(\n            name=\"search_query\",\n            display_name=\"Search Query\",\n            info=\"Optional search query to filter knowledge base data.\",\n            tool_mode=True,\n            dynamic=True,\n            show=False,\n        ),\n        IntInput(\n            name=\"top_k\",\n            display_name=\"Top K Results\",\n            info=\"Number of top results to return from the knowledge base.\",\n            value=5,\n            advanced=True,\n            required=False,\n            dynamic=True,\n            show=False,\n        ),\n        BoolInput(\n            name=\"include_metadata\",\n            display_name=\"Include Metadata\",\n            info=\"Whether to include all metadata in the output. If false, only content is returned.\",\n            value=True,\n            advanced=False,\n            dynamic=True,\n            show=False,\n        ),\n        BoolInput(\n            name=\"include_embeddings\",\n            display_name=\"Include Embeddings\",\n            info=\"Whether to include embeddings in the output. Only applicable if 'Include Metadata' is enabled.\",\n            value=False,\n            advanced=True,\n            dynamic=True,\n            show=False,\n        ),\n        MessageTextInput(\n            name=\"metadata_filter\",\n            display_name=\"Metadata Filter\",\n            info=(\n                \"Optional JSON object of user-metadata key/value pairs. Only chunks \"\n                'whose source_metadata matches every key are returned (e.g. {\"tag\": \"invoice\"} '\n                'or {\"tag\": [\"invoice\", \"audit\"]} for OR-of-values). Backends without '\n                \"native filtering apply the match client-side after retrieval.\"\n            ),\n            advanced=True,\n            dynamic=True,\n            show=False,\n        ),\n    ]\n\n    # ------ Outputs -------------------------------------------------------\n    # Both outputs are declared at the class level so the runtime can\n    # dispatch to either method depending on which one the saved flow has\n    # wired up. ``update_outputs`` filters the canvas-visible output per\n    # selected mode; see ``TypeConverterComponent`` and ``MemoryComponent``\n    # for the same pattern.\n    #\n    # Output names match the legacy ``KnowledgeIngestionComponent``\n    # (``dataframe_output``) and ``KnowledgeBaseComponent``\n    # (``retrieve_data``) so saved flow edges keyed on those names resolve\n    # cleanly against the merged component.\n    outputs = [\n        Output(\n            display_name=\"Results\",\n            name=\"dataframe_output\",\n            method=\"build_kb_info\",\n            types=[\"JSON\"],\n            selected=\"JSON\",\n        ),\n        Output(\n            display_name=\"Results\",\n            name=\"retrieve_data\",\n            method=\"retrieve_data\",\n            info=\"Returns the data from the selected knowledge base.\",\n            types=[\"Table\"],\n            selected=\"Table\",\n        ),\n    ]\n\n    # ------ Mode-driven UI updates ---------------------------------------\n    async def update_frontend_node(self, new_frontend_node: dict, current_frontend_node: dict):\n        \"\"\"Sync the visible output with the current ``mode`` value on canvas load.\n\n        Saved flows hit this path: ``update_outputs`` is normally only triggered\n        by ``real_time_refresh`` field edits, so without this re-sync the\n        canvas could land with both outputs visible.\n        \"\"\"\n        await super().update_frontend_node(new_frontend_node, current_frontend_node)\n        mode_value = new_frontend_node.get(\"template\", {}).get(\"mode\", {}).get(\"value\", MODE_INGEST)\n        self.update_outputs(new_frontend_node, \"mode\", mode_value)\n        return new_frontend_node\n\n    def update_outputs(self, frontend_node: dict, field_name: str, field_value: Any) -> dict:\n        \"\"\"Filter visible outputs to match the selected mode.\n\n        Triggered by the ``mode`` ``TabInput`` ``real_time_refresh`` flag.\n        The class-level ``outputs`` list always carries both entries so the\n        runtime can resolve either ``build_kb_info`` or ``retrieve_data``\n        regardless of canvas visibility — we just hide the unused one here.\n        \"\"\"\n        if field_name != \"mode\":\n            return frontend_node\n        if _is_retrieve_mode(field_value):\n            frontend_node[\"outputs\"] = [\n                Output(\n                    display_name=\"Results\",\n                    name=\"retrieve_data\",\n                    method=\"retrieve_data\",\n                    info=\"Returns the data from the selected knowledge base.\",\n                    types=[\"Table\"],\n                    selected=\"Table\",\n                )\n            ]\n        else:\n            frontend_node[\"outputs\"] = [\n                Output(\n                    display_name=\"Results\",\n                    name=\"dataframe_output\",\n                    method=\"build_kb_info\",\n                    types=[\"JSON\"],\n                    selected=\"JSON\",\n                )\n            ]\n        return frontend_node\n\n    async def update_build_config(\n        self,\n        build_config,\n        field_value: Any,\n        field_name: str | None = None,\n    ):\n        \"\"\"Refresh KB options, drive the create-KB dialog, and hide off-mode fields.\"\"\"\n        # Astra-cloud gate covers both ingest and retrieve paths.\n        raise_error_if_astra_cloud_disable_component(astra_error_msg)\n\n        # Always populate the create-KB dialog's embedding-model options so the\n        # ModelInput renders correctly regardless of which input triggered the\n        # refresh.\n        try:\n            dialog_template = (\n                build_config[\"knowledge_base\"]\n                .get(\"dialog_inputs\", {})\n                .get(\"fields\", {})\n                .get(\"data\", {})\n                .get(\"node\", {})\n                .get(\"template\", {})\n            )\n            if \"02_embedding_model\" in dialog_template:\n                embedding_options = get_embedding_model_options(user_id=self.user_id)\n                dialog_template[\"02_embedding_model\"][\"options\"] = embedding_options\n        except Exception:  # noqa: BLE001\n            self.log(\"Failed to populate embedding model options in dialog\")\n\n        # KB-picker refresh + create-new-KB flow (lifted from the legacy ingestion\n        # component verbatim; relied on by both the canvas refresh button and the\n        # dialog-submit path).\n        if field_name == \"knowledge_base\":\n            # Lazy import keeps lfx importable without langflow installed.\n            from langflow.services.database.models.user.crud import get_user_by_id\n\n            async with session_scope() as db:\n                if not self.user_id:\n                    msg = \"User ID is required for fetching knowledge base list.\"\n                    raise ValueError(msg)\n                current_user = await get_user_by_id(db, self.user_id)\n                if not current_user:\n                    msg = f\"User with ID {self.user_id} not found.\"\n                    raise ValueError(msg)\n                kb_user = current_user.username\n            if isinstance(field_value, dict) and \"01_new_kb_name\" in field_value:\n                if not self.is_valid_collection_name(field_value[\"01_new_kb_name\"]):\n                    msg = f\"Invalid knowledge base name: {field_value['01_new_kb_name']}\"\n                    raise ValueError(msg)\n\n                model_selection = field_value[\"02_embedding_model\"]\n                if isinstance(model_selection, dict):\n                    model_selection = [model_selection]\n\n                backend_type, backend_config = self._normalize_backend_selection(\n                    field_value.get(\"03_knowledge_backend\")\n                )\n\n                embed_model = get_embeddings(\n                    model=model_selection,\n                    user_id=self.user_id,\n                )\n\n                try:\n                    await asyncio.wait_for(\n                        asyncio.to_thread(embed_model.embed_query, \"test\"),\n                        timeout=10,\n                    )\n                except TimeoutError as e:\n                    msg = \"Embedding validation timed out. Please verify network connectivity and key.\"\n                    raise ValueError(msg) from e\n                except Exception as e:\n                    msg = f\"Embedding validation failed: {e!s}\"\n                    raise ValueError(msg) from e\n\n                kb_path = _get_knowledge_bases_root_path() / kb_user / field_value[\"01_new_kb_name\"]\n                kb_path.mkdir(parents=True, exist_ok=True)\n\n                build_config[\"knowledge_base\"][\"value\"] = field_value[\"01_new_kb_name\"]\n                self._save_embedding_metadata(\n                    kb_path=kb_path,\n                    model_selection=model_selection,\n                    backend_type=backend_type,\n                    backend_config=backend_config,\n                )\n                await self._create_knowledge_base_record(\n                    user_id=self.user_id,\n                    name=field_value[\"01_new_kb_name\"],\n                    model_selection=model_selection,\n                    backend_type=backend_type,\n                    backend_config=backend_config,\n                )\n\n            build_config[\"knowledge_base\"][\"options\"] = await get_knowledge_bases(\n                _get_knowledge_bases_root_path(),\n                user_id=self.user_id,\n            )\n            if build_config[\"knowledge_base\"][\"value\"] not in build_config[\"knowledge_base\"][\"options\"]:\n                build_config[\"knowledge_base\"][\"value\"] = None\n\n        # Honor the current mode regardless of which field triggered the refresh.\n        # Falls back to MODE_INGEST when ``mode`` is missing (legacy nodes).\n        current_mode = build_config.get(\"mode\", {}).get(\"value\") if isinstance(build_config, dict) else None\n        if field_name == \"mode\":\n            current_mode = field_value\n        # Map legacy/emoji-prefixed labels onto the current canonical values so\n        # flows saved before the label change still toggle visibility correctly.\n        if _is_retrieve_mode(current_mode):\n            current_mode = MODE_RETRIEVE\n        elif current_mode not in self.mode_config:\n            current_mode = MODE_INGEST\n        return set_current_fields(\n            build_config=build_config if isinstance(build_config, dotdict) else dotdict(build_config),\n            action_fields=self.mode_config,\n            selected_action=current_mode,\n            default_fields=self.default_keys,\n            func=set_field_display,\n        )\n\n    # =====================================================================\n    #                       INGESTION CODE PATH\n    # =====================================================================\n    def _get_kb_root(self) -> Path:\n        \"\"\"Return the root directory for knowledge bases.\"\"\"\n        return _get_knowledge_bases_root_path()\n\n    @staticmethod\n    def _scalar_notna(value) -> bool:\n        \"\"\"Check if a value is not NA, safely handling arrays and sequences.\n\n        ``pd.notna`` returns an array when given an array-like input, which\n        cannot be used directly in a boolean context.  This helper collapses\n        the result to a single scalar ``bool``.\n        \"\"\"\n        result = pd.notna(value)\n        if hasattr(result, \"__iter__\") and not isinstance(result, str):\n            import numpy as np\n\n            arr = np.asarray(result)\n            return arr.size > 0 and arr.all()\n        return bool(result)\n\n    def _validate_column_config(self, df_source: pd.DataFrame) -> list[dict[str, Any]]:\n        \"\"\"Validate column configuration using Structured Output patterns.\"\"\"\n        if not self.column_config:\n            msg = \"Column configuration cannot be empty\"\n            raise ValueError(msg)\n\n        config_list = self.column_config if isinstance(self.column_config, list) else []\n\n        df_columns = set(df_source.columns)\n        for config in config_list:\n            col_name = config.get(\"column_name\")\n            if col_name not in df_columns:\n                msg = f\"Column '{col_name}' not found in DataFrame. Available columns: {sorted(df_columns)}\"\n                raise ValueError(msg)\n\n        return config_list\n\n    def _build_embedding_metadata(\n        self,\n        model_selection: list[dict[str, Any]],\n        api_key: str | None = None,\n        backend_type: str = BackendType.CHROMA.value,\n        backend_config: dict[str, Any] | None = None,\n    ) -> dict[str, Any]:\n        \"\"\"Build embedding model metadata from a model selection dict.\"\"\"\n        model_dict = model_selection[0] if isinstance(model_selection, list) else model_selection\n        embedding_model = model_dict.get(\"name\", \"\")\n        embedding_provider = model_dict.get(\"provider\", \"Unknown\")\n\n        api_key_to_save = None\n        if api_key and hasattr(api_key, \"get_secret_value\"):\n            api_key_to_save = api_key.get_secret_value()\n        elif isinstance(api_key, str):\n            api_key_to_save = api_key\n\n        encrypted_api_key = None\n        if api_key_to_save:\n            settings_service = get_settings_service()\n            try:\n                encrypted_api_key = encrypt_api_key(api_key_to_save, settings_service=settings_service)\n            except (TypeError, ValueError) as e:\n                self.log(f\"Could not encrypt API key: {e}\")\n\n        return {\n            \"embedding_provider\": embedding_provider,\n            \"embedding_model\": embedding_model,\n            \"model_selection\": model_dict,\n            \"api_key\": encrypted_api_key,\n            \"api_key_used\": bool(api_key),\n            \"chunk_size\": self.chunk_size,\n            \"backend_type\": backend_type,\n            \"backend_config\": backend_config or {},\n            \"created_at\": datetime.now(timezone.utc).isoformat(),\n        }\n\n    def _save_embedding_metadata(\n        self,\n        kb_path: Path,\n        model_selection: list[dict[str, Any]],\n        api_key: str | None = None,\n        backend_type: str | None = None,\n        backend_config: dict[str, Any] | None = None,\n    ) -> None:\n        \"\"\"Save embedding model metadata.\"\"\"\n        metadata_path = kb_path / \"embedding_metadata.json\"\n        existing_metadata: dict[str, Any] = {}\n        if metadata_path.exists():\n            try:\n                existing_metadata = json.loads(metadata_path.read_text())\n            except (OSError, json.JSONDecodeError):\n                existing_metadata = {}\n\n        embedding_metadata = self._build_embedding_metadata(\n            model_selection,\n            api_key,\n            backend_type=backend_type or existing_metadata.get(\"backend_type\") or BackendType.CHROMA.value,\n            backend_config=backend_config\n            if backend_config is not None\n            else existing_metadata.get(\"backend_config\") or {},\n        )\n        metadata_path.write_text(json.dumps(embedding_metadata, indent=2))\n\n    def _update_metadata_metrics(self, kb_path: Path, chroma: Chroma) -> None:\n        \"\"\"Update embedding_metadata.json with accurate chunk/word/character counts.\"\"\"\n        import chromadb.errors\n        from langflow.api.utils.kb_helpers import KBAnalysisHelper, KBStorageHelper\n\n        metadata_path = kb_path / \"embedding_metadata.json\"\n        if not metadata_path.exists():\n            return\n\n        try:\n            metadata = json.loads(metadata_path.read_text())\n            KBAnalysisHelper.update_text_metrics(kb_path, metadata, chroma)\n            metadata[\"size\"] = KBStorageHelper.get_directory_size(kb_path)\n            metadata_path.write_text(json.dumps(metadata, indent=2))\n        except (OSError, ValueError, TypeError, json.JSONDecodeError, chromadb.errors.ChromaError) as e:\n            self.log(f\"Warning: Could not update metadata metrics: {e}\")\n\n    @staticmethod\n    def _extract_source_types_from_df(df_source: pd.DataFrame) -> set[str]:\n        \"\"\"Pull file extensions out of common path/name columns on the source DataFrame.\n\n        The direct-upload ingestion path stores extensions in\n        ``embedding_metadata.json[source_types]`` so the KB list can render the\n        correct file-type icon. When ingestion happens via a connected\n        ``input_df`` (e.g. File → Knowledge) the same field stayed empty and\n        the icon defaulted to a blank tile. We look at the well-known columns\n        the File / S3 / cloud-storage components produce and collect any\n        plausible extension so the icon is consistent across both flows.\n        \"\"\"\n        candidate_columns = (\"file_path\", \"file_name\", \"filename\", \"source\", \"path\", \"mimetype\")\n        extensions: set[str] = set()\n        for col in candidate_columns:\n            if col not in df_source.columns:\n                continue\n            for value in df_source[col].dropna():\n                ext = KnowledgeComponent._extension_from_value(value)\n                # Drop anything that doesn't look like an extension (URL\n                # query strings, version segments, etc.) — the icon palette\n                # keys off short alphanumeric tokens like \"pdf\"/\"docx\".\n                if ext:\n                    extensions.add(ext)\n        return extensions\n\n    @staticmethod\n    def _extension_from_value(value: Any) -> str | None:\n        \"\"\"Return a normalized file-extension token from a path / filename / MIME string.\n\n        Accepts values like ``\"report.PDF\"``, ``\"/docs/notes.txt\"``, or\n        ``\"application/pdf\"`` and returns ``\"pdf\"`` / ``\"txt\"``. Returns\n        ``None`` if no plausible extension can be derived.\n        \"\"\"\n        extension_length_limit = 10\n        if value is None:\n            return None\n        text = str(value).strip()\n        if not text:\n            return None\n        # MIME types like ``application/pdf`` carry the canonical extension\n        # in the subtype slot — preserve them so File / S3 messages keyed\n        # only on ``mimetype`` still resolve to an icon.\n        if \"/\" in text and \".\" not in text.rsplit(\"/\", 1)[-1]:\n            subtype = text.rsplit(\"/\", 1)[-1].strip().lower()\n            return subtype if subtype and len(subtype) <= extension_length_limit and subtype.isalnum() else None\n        if \".\" not in text:\n            return None\n        ext = text.rsplit(\".\", 1)[-1].strip().lower()\n        if ext and len(ext) <= extension_length_limit and ext.isalnum():\n            return ext\n        return None\n\n    @classmethod\n    def _extract_source_types_from_mapping(cls, mapping: Any) -> set[str]:\n        \"\"\"Pull extensions from a Message/Data-style ``data`` dict or a plain dict.\"\"\"\n        if not isinstance(mapping, dict):\n            return set()\n        candidate_keys = (\"file_path\", \"file_name\", \"filename\", \"source\", \"path\", \"mimetype\")\n        extensions: set[str] = set()\n        for key in candidate_keys:\n            ext = cls._extension_from_value(mapping.get(key))\n            if ext:\n                extensions.add(ext)\n        return extensions\n\n    @classmethod\n    def _extract_source_types_from_input(cls, input_value: Any) -> set[str]:\n        \"\"\"Pull file extensions out of the raw component input.\n\n        ``convert_to_dataframe`` strips Message/Data fields down to ``text``\n        when projecting onto a DataFrame, so file metadata attached to a\n        File-component \"Raw Content\" output never reaches\n        ``_extract_source_types_from_df``. Looking at the raw input first\n        keeps the KB icon consistent with direct upload.\n        \"\"\"\n        if input_value is None:\n            return set()\n        if isinstance(input_value, list):\n            extensions: set[str] = set()\n            for item in input_value:\n                extensions |= cls._extract_source_types_from_input(item)\n            return extensions\n        if isinstance(input_value, pd.DataFrame):\n            return cls._extract_source_types_from_df(input_value)\n        # Message / Data / JSON all expose a ``data`` dict via the lfx schema.\n        mapping = getattr(input_value, \"data\", None)\n        if mapping is None and isinstance(input_value, dict):\n            mapping = input_value\n        return cls._extract_source_types_from_mapping(mapping)\n\n    def _merge_source_types(self, kb_path: Path, extensions: set[str]) -> None:\n        \"\"\"Merge newly observed extensions into the KB's ``source_types`` metadata.\n\n        Mirrors the direct-upload path in ``KBIngestionHelper`` so the icon\n        rendering on the Knowledge Bases list works regardless of which\n        ingestion route was used.\n        \"\"\"\n        if not extensions:\n            return\n        metadata_path = kb_path / \"embedding_metadata.json\"\n        if not metadata_path.exists():\n            return\n        try:\n            metadata = json.loads(metadata_path.read_text())\n            existing = set(metadata.get(\"source_types\") or [])\n            metadata[\"source_types\"] = sorted(existing | extensions)\n            metadata_path.write_text(json.dumps(metadata, indent=2))\n        except (OSError, ValueError, TypeError, json.JSONDecodeError) as e:\n            self.log(f\"Warning: Could not update source_types metadata: {e}\")\n\n    async def _update_backend_metadata_metrics(self, kb_path: Path, backend: BaseVectorStoreBackend) -> None:\n        \"\"\"Update metadata metrics for non-Chroma backends.\"\"\"\n        metadata_path = kb_path / \"embedding_metadata.json\"\n        if not metadata_path.exists():\n            return\n\n        try:\n            metadata = json.loads(metadata_path.read_text())\n            chunks = await backend.count()\n            characters = 0\n            words = 0\n            async for batch in backend.iter_documents():\n                for document in batch:\n                    characters += len(document.content)\n                    words += len(document.content.split())\n\n            metadata[\"chunks\"] = chunks\n            metadata[\"characters\"] = characters\n            metadata[\"words\"] = words\n            metadata[\"avg_chunk_size\"] = characters / chunks if chunks else 0.0\n            metadata[\"size\"] = await backend.storage_size_bytes()\n            metadata_path.write_text(json.dumps(metadata, indent=2))\n        except (OSError, ValueError, TypeError, json.JSONDecodeError) as e:\n            self.log(f\"Warning: Could not update backend metadata metrics: {e}\")\n\n    @staticmethod\n    def _normalize_backend_selection(value: Any) -> tuple[str, dict[str, Any]]:\n        \"\"\"Normalize a DBProviderInput value into backend type/config.\"\"\"\n        if not value:\n            return BackendType.CHROMA.value, {}\n\n        if isinstance(value, str):\n            backend_type = value if value == BackendType.OPENSEARCH.value else BackendType.CHROMA.value\n            return (\n                backend_type,\n                _DEFAULT_OPENSEARCH_CONFIG.copy() if backend_type == BackendType.OPENSEARCH.value else {},\n            )\n\n        if not isinstance(value, dict):\n            return BackendType.CHROMA.value, {}\n\n        backend_type = str(value.get(\"backend_type\") or value.get(\"id\") or BackendType.CHROMA.value)\n\n        if backend_type == BackendType.OPENSEARCH.value:\n            backend_config = value.get(\"backend_config\") or value.get(\"config\") or {}\n            if not isinstance(backend_config, dict):\n                backend_config = {}\n            return BackendType.OPENSEARCH.value, {**_DEFAULT_OPENSEARCH_CONFIG, **backend_config}\n\n        if backend_type == \"chroma_cloud\":\n            backend_config = value.get(\"backend_config\") or value.get(\"config\") or {}\n            if not isinstance(backend_config, dict):\n                backend_config = {}\n            return BackendType.CHROMA.value, {**_DEFAULT_CHROMA_CLOUD_CONFIG, **backend_config}\n\n        return BackendType.CHROMA.value, {}\n\n    @staticmethod\n    def _get_backend_from_metadata(kb_path: Path) -> tuple[str, dict[str, Any]]:\n        metadata_path = kb_path / \"embedding_metadata.json\"\n        if not metadata_path.exists():\n            return BackendType.CHROMA.value, {}\n        try:\n            metadata = json.loads(metadata_path.read_text())\n        except (OSError, json.JSONDecodeError):\n            return BackendType.CHROMA.value, {}\n\n        backend_type = str(metadata.get(\"backend_type\") or BackendType.CHROMA.value)\n        backend_config = metadata.get(\"backend_config\") or {}\n        if not isinstance(backend_config, dict):\n            backend_config = {}\n        return backend_type, backend_config\n\n    async def _create_knowledge_base_record(\n        self,\n        *,\n        user_id: Any,\n        name: str,\n        model_selection: list[dict[str, Any]],\n        backend_type: str,\n        backend_config: dict[str, Any],\n    ) -> None:\n        \"\"\"Persist the component-created KB in the DB when Langflow is available.\"\"\"\n        try:\n            from langflow.api.utils import knowledge_base_service\n        except ImportError:\n            return\n\n        try:\n            await knowledge_base_service.create_record(\n                user_id=user_id,\n                name=name,\n                model_selection=model_selection,\n                column_config=self.column_config if isinstance(self.column_config, list) else [],\n                backend_type=backend_type,\n                backend_config=backend_config,\n            )\n        except Exception as exc:  # noqa: BLE001\n            self.log(f\"Warning: could not persist knowledge base record: {exc}\")\n\n    def _save_kb_files(\n        self,\n        kb_path: Path,\n        config_list: list[dict[str, Any]],\n    ) -> None:\n        \"\"\"Save KB files using File Component storage patterns.\"\"\"\n        try:\n            kb_path.mkdir(parents=True, exist_ok=True)\n\n            cfg_path = kb_path / \"schema.json\"\n            if not cfg_path.exists():\n                cfg_path.write_text(json.dumps(config_list, indent=2))\n\n        except (OSError, TypeError, ValueError) as e:\n            self.log(f\"Error saving KB files: {e}\")\n\n    def _build_column_metadata(self, config_list: list[dict[str, Any]], df_source: pd.DataFrame) -> dict[str, Any]:\n        \"\"\"Build detailed column metadata.\"\"\"\n        metadata: dict[str, Any] = {\n            \"total_columns\": len(df_source.columns),\n            \"mapped_columns\": len(config_list),\n            \"unmapped_columns\": len(df_source.columns) - len(config_list),\n            \"columns\": [],\n            \"summary\": {\"vectorized_columns\": [], \"identifier_columns\": []},\n        }\n\n        for config in config_list:\n            col_name = config.get(\"column_name\")\n            vectorize = config.get(\"vectorize\") == \"True\" or config.get(\"vectorize\") is True\n            identifier = config.get(\"identifier\") == \"True\" or config.get(\"identifier\") is True\n\n            metadata[\"columns\"].append(\n                {\n                    \"name\": col_name,\n                    \"vectorize\": vectorize,\n                    \"identifier\": identifier,\n                }\n            )\n\n            if vectorize:\n                metadata[\"summary\"][\"vectorized_columns\"].append(col_name)\n            if identifier:\n                metadata[\"summary\"][\"identifier_columns\"].append(col_name)\n\n        return metadata\n\n    async def _create_vector_store(\n        self,\n        df_source: pd.DataFrame,\n        config_list: list[dict[str, Any]],\n        embedding_function,\n    ) -> BaseVectorStoreBackend:\n        \"\"\"Create vector store using the configured DB provider.\"\"\"\n        vector_store_dir = await self._kb_path()\n        if not vector_store_dir:\n            msg = \"Knowledge base path is not set. Please create a new knowledge base first.\"\n            raise ValueError(msg)\n        vector_store_dir.mkdir(parents=True, exist_ok=True)\n\n        backend_type, backend_config = self._get_backend_from_metadata(vector_store_dir)\n        backend = create_backend(\n            backend_type,\n            kb_name=self.knowledge_base,\n            kb_path=vector_store_dir,\n            backend_config=backend_config,\n            embedding_function=embedding_function,\n            user_id=self.user_id,\n        )\n        await backend.ensure_ready()\n\n        existing_ids = None\n        if backend_type != BackendType.CHROMA.value and not self.allow_duplicates:\n            existing_ids = set()\n            async for batch in backend.iter_documents():\n                for document in batch:\n                    doc_id = document.metadata.get(\"_id\")\n                    if doc_id:\n                        existing_ids.add(doc_id)\n\n        data_objects = await self._convert_df_to_data_objects(df_source, config_list, existing_ids=existing_ids)\n\n        user_metadata_tag = self._resolve_user_metadata_tag()\n\n        documents = []\n        for data_obj in data_objects:\n            doc = data_obj.to_lc_document()\n            if user_metadata_tag:\n                doc.metadata[\"source_metadata\"] = user_metadata_tag\n            documents.append(doc)\n\n        if documents:\n            await backend.add_documents(documents)\n            self.log(f\"Added {len(documents)} documents to vector store '{self.knowledge_base}'\")\n\n        return backend\n\n    async def _convert_df_to_data_objects(\n        self,\n        df_source: pd.DataFrame,\n        config_list: list[dict[str, Any]],\n        existing_ids: set[str] | None = None,\n    ) -> list[Data]:\n        \"\"\"Convert DataFrame to Data objects for vector store.\"\"\"\n        data_objects: list[Data] = []\n\n        if existing_ids is None:\n            kb_path = await self._kb_path()\n\n            chroma = Chroma(\n                persist_directory=str(kb_path),\n                collection_name=self.knowledge_base,\n                **chroma_langchain_collection_kwargs(),\n            )\n\n            all_docs = chroma.get()\n\n            existing_ids = {metadata.get(\"_id\") for metadata in all_docs[\"metadatas\"] if metadata.get(\"_id\")}\n\n        content_cols = []\n        identifier_cols = []\n\n        for config in config_list:\n            col_name = config.get(\"column_name\")\n            vectorize = config.get(\"vectorize\") == \"True\" or config.get(\"vectorize\") is True\n            identifier = config.get(\"identifier\") == \"True\" or config.get(\"identifier\") is True\n\n            if vectorize:\n                content_cols.append(col_name)\n            if identifier:\n                identifier_cols.append(col_name)\n\n        for _, row in df_source.iterrows():\n            identifier_parts = [str(row[col]) for col in content_cols if col in row and self._scalar_notna(row[col])]\n\n            page_content = \" \".join(identifier_parts)\n\n            data_dict = {\n                \"text\": page_content,\n            }\n\n            if identifier_cols:\n                identifier_parts = [\n                    str(row[col]) for col in identifier_cols if col in row and self._scalar_notna(row[col])\n                ]\n                page_content = \" \".join(identifier_parts)\n\n            for col in df_source.columns:\n                if col not in content_cols and col in row and self._scalar_notna(row[col]):\n                    value = row[col]\n                    data_dict[col] = str(value)\n\n            page_content_hash = hashlib.sha256(page_content.encode()).hexdigest()\n            data_dict[\"_id\"] = page_content_hash\n\n            if not self.allow_duplicates and page_content_hash in existing_ids:\n                self.log(f\"Skipping duplicate row with hash {page_content_hash}\")\n                continue\n\n            data_obj = Data(data=data_dict)\n            data_objects.append(data_obj)\n\n        return data_objects\n\n    def is_valid_collection_name(self, name, min_length: int = 3, max_length: int = 63) -> bool:\n        \"\"\"Validate collection name.\n\n        1. Contains 3-63 characters\n        2. Starts and ends with alphanumeric character\n        3. Contains only alphanumeric characters, underscores, or hyphens.\n        \"\"\"\n        if not (min_length <= len(name) <= max_length):\n            return False\n\n        if not (name[0].isalnum() and name[-1].isalnum()):\n            return False\n\n        return re.match(r\"^[a-zA-Z0-9_-]+$\", name) is not None\n\n    async def _kb_path(self) -> Path | None:\n        cached_path = getattr(self, \"_cached_kb_path\", None)\n        if cached_path is not None:\n            return cached_path\n\n        # Lazy import to keep ``lfx`` importable standalone — langflow's\n        # user/DB models are not always available at module load time.\n        from langflow.services.database.models.user.crud import get_user_by_id\n\n        async with session_scope() as db:\n            if not self.user_id:\n                msg = \"User ID is required for fetching knowledge base path.\"\n                raise ValueError(msg)\n            current_user = await get_user_by_id(db, self.user_id)\n            if not current_user:\n                msg = f\"User with ID {self.user_id} not found.\"\n                raise ValueError(msg)\n            kb_user = current_user.username\n\n        kb_root = self._get_kb_root()\n\n        self._cached_kb_path = kb_root / kb_user / self.knowledge_base\n\n        return self._cached_kb_path\n\n    def _resolve_user_metadata_tag(self) -> str:\n        \"\"\"Return the JSON-encoded user metadata tag for chunk writes.\"\"\"\n        raw = getattr(self, \"metadata_json\", None)\n        if not raw:\n            return \"\"\n        text = raw.strip() if isinstance(raw, str) else raw\n        if not text:\n            return \"\"\n        try:\n            decoded = json.loads(text)\n        except (TypeError, json.JSONDecodeError) as exc:\n            self.log(f\"KnowledgeComponent: metadata_json is not valid JSON ({exc}); skipping metadata stamp.\")\n            return \"\"\n        if not isinstance(decoded, dict):\n            self.log(\"KnowledgeComponent: metadata_json must decode to a JSON object; skipping metadata stamp.\")\n            return \"\"\n        return json.dumps(decoded, sort_keys=True)\n\n    async def build_kb_info(self) -> Data:\n        \"\"\"Main ingestion routine → returns a dict with KB metadata.\n\n        The annotation is intentionally narrowed to ``Data`` even though the\n        cross-mode fallback below may return a ``DataFrame`` from\n        ``retrieve_data``. The frontend builds React-Flow handle IDs from\n        this output's type list; widening it to ``Data | DataFrame`` makes\n        the API advertise ``[\"JSON\", \"Table\"]`` for the ingest output and\n        breaks every saved-edge sourceHandle that was generated against\n        a single-type handle (BUG-02). Python doesn't enforce return\n        annotations at runtime, so the rare fallback path keeps working.\n        \"\"\"\n        if _is_retrieve_mode(getattr(self, \"mode\", MODE_INGEST)):\n            return await self.retrieve_data()\n        raise_error_if_astra_cloud_disable_component(astra_error_msg)\n\n        run_id: uuid.UUID | None = None\n        run_job_id: uuid.UUID | None = None\n        run_summary: IngestionSummary | None = None\n        run_status: IngestionRunStatus = IngestionRunStatus.SUCCEEDED\n        run_error: str | None = None\n        kb_record_id: uuid.UUID | None = None\n        try:\n            input_value = self.input_df[0] if isinstance(self.input_df, list) else self.input_df\n            df_source: DataFrame = convert_to_dataframe(input_value, auto_parse=False)\n\n            config_list = self._validate_column_config(df_source)\n            column_metadata = self._build_column_metadata(config_list, df_source)\n\n            kb_path = await self._kb_path()\n            if not kb_path:\n                msg = \"Knowledge base path is not set. Please create a new knowledge base first.\"\n                raise ValueError(msg)\n            metadata_path = kb_path / \"embedding_metadata.json\"\n            api_key = None\n            model_selection = None\n\n            if metadata_path.exists():\n                settings_service = get_settings_service()\n                stored_metadata = json.loads(metadata_path.read_text())\n\n                model_selection = stored_metadata.get(\"model_selection\")\n                if model_selection:\n                    model_selection = [model_selection] if isinstance(model_selection, dict) else model_selection\n                else:\n                    embedding_model_name = stored_metadata.get(\"embedding_model\")\n                    embedding_provider = stored_metadata.get(\"embedding_provider\", \"Unknown\")\n                    if embedding_model_name:\n                        try:\n                            all_options = get_embedding_model_options(user_id=self.user_id)\n                            match = next(\n                                (o for o in all_options if o.get(\"name\") == embedding_model_name),\n                                None,\n                            )\n                            if match:\n                                model_selection = [match]\n                            else:\n                                self.log(\n                                    f\"Embedding model '{embedding_model_name}' (provider: {embedding_provider}) \"\n                                    \"from stored metadata is no longer available in the model registry. \"\n                                    \"Please re-create this knowledge base with a supported embedding model.\"\n                                )\n                                msg = (\n                                    f\"Embedding model '{embedding_model_name}' is no longer recognized. \"\n                                    \"The knowledge base was created with an older format and the model \"\n                                    \"is not available in the current registry. \"\n                                    \"Please re-create the knowledge base with a supported embedding model.\"\n                                )\n                                raise ValueError(msg)\n                        except ValueError:\n                            raise\n                        except Exception:  # noqa: BLE001\n                            self.log(\n                                f\"Failed to look up embedding model '{embedding_model_name}' in registry. \"\n                                \"Please re-create this knowledge base with a supported embedding model.\"\n                            )\n                            msg = (\n                                f\"Could not look up embedding model '{embedding_model_name}' \"\n                                f\"(provider: {embedding_provider}). \"\n                                \"Please re-create the knowledge base with a supported embedding model.\"\n                            )\n                            raise ValueError(msg)  # noqa: B904\n\n                encrypted_key = stored_metadata.get(\"api_key\")\n                if encrypted_key:\n                    try:\n                        api_key = decrypt_api_key(encrypted_key, settings_service)\n                    except (InvalidToken, TypeError, ValueError) as e:\n                        self.log(f\"Could not decrypt API key. Please provide it manually. Error: {e}\")\n\n            if self.api_key:\n                api_key = self.api_key\n                if model_selection:\n                    self._save_embedding_metadata(\n                        kb_path=kb_path,\n                        model_selection=model_selection,\n                        api_key=api_key,\n                    )\n\n            if not model_selection:\n                msg = \"No embedding model configuration found. Please create the knowledge base first.\"\n                raise ValueError(msg)\n\n            embedding_function = get_embeddings(\n                model=model_selection,\n                user_id=self.user_id,\n                api_key=api_key,\n                chunk_size=self.chunk_size,\n            )\n\n            run_id, run_job_id, run_summary, kb_record_id = await self._begin_ingestion_run(kb_path)\n            if kb_record_id is not None:\n                await self._record_kb_status(kb_record_id, \"ingesting\")\n\n            backend = await self._create_vector_store(df_source, config_list, embedding_function=embedding_function)\n\n            self._save_kb_files(kb_path, config_list)\n\n            try:\n                if not isinstance(backend, BaseVectorStoreBackend):\n                    pass\n                elif backend.backend_type == BackendType.CHROMA and hasattr(backend, \"raw_langchain_store\"):\n                    self._update_metadata_metrics(kb_path, backend.raw_langchain_store())\n                else:\n                    await self._update_backend_metadata_metrics(kb_path, backend)\n                # Stamp the KB with the file extensions we just ingested so\n                # the Knowledge Bases list renders the correct icon for\n                # flow-driven ingestion (input_df), matching direct upload.\n                # We look at the raw input first because ``convert_to_dataframe``\n                # drops Message/Data metadata fields (file_path, mimetype, …)\n                # when projecting onto the DataFrame.\n                source_types = self._extract_source_types_from_input(input_value)\n                source_types |= self._extract_source_types_from_df(df_source)\n                self._merge_source_types(kb_path, source_types)\n            finally:\n                if isinstance(backend, BaseVectorStoreBackend):\n                    await backend.teardown()\n\n            meta: dict[str, Any] = {\n                \"kb_id\": str(uuid.uuid4()),\n                \"kb_name\": self.knowledge_base,\n                \"rows\": len(df_source),\n                \"column_metadata\": column_metadata,\n                \"path\": str(kb_path),\n                \"config_columns\": len(config_list),\n                \"timestamp\": datetime.now(tz=timezone.utc).isoformat(),\n            }\n\n            if run_summary is not None:\n                run_summary.record_item(\n                    IngestionItemResult(\n                        item_id=self.knowledge_base,\n                        display_name=f\"{self.knowledge_base} ({len(df_source)} rows)\",\n                        status=IngestionItemStatus.SUCCEEDED,\n                        chunks_created=len(df_source),\n                    ),\n                )\n\n            if kb_record_id is not None:\n                await self._record_kb_stats(kb_record_id, kb_path)\n                await self._record_kb_status(kb_record_id, \"ready\")\n\n            self.status = f\"✅ KB **{self.knowledge_base}** saved · {len(df_source)} chunks.\"\n\n            return Data(data=meta)\n\n        except (OSError, ValueError, RuntimeError, KeyError) as e:\n            run_status = IngestionRunStatus.FAILED\n            run_error = str(e) or e.__class__.__name__\n            msg = f\"Error during KB ingestion: {e}\"\n            raise RuntimeError(msg) from e\n        except Exception as e:\n            run_status = IngestionRunStatus.FAILED\n            run_error = str(e) or e.__class__.__name__\n            raise\n        finally:\n            if run_id is not None and run_summary is not None:\n                await self._finalize_ingestion_run(\n                    run_id=run_id,\n                    job_id=run_job_id,\n                    summary=run_summary,\n                    status=run_status,\n                    error_message=run_error,\n                )\n            if kb_record_id is not None and run_status is IngestionRunStatus.FAILED:\n                await self._record_kb_status(kb_record_id, \"failed\", failure_reason=run_error)\n\n    async def _begin_ingestion_run(\n        self,\n        kb_path: Path,\n    ) -> tuple[uuid.UUID | None, uuid.UUID | None, IngestionSummary | None, uuid.UUID | None]:\n        \"\"\"Create a parent ``Job`` and seed an ingestion-run row.\"\"\"\n        if not self.user_id:\n            self.log(\"No user_id on component; skipping ingestion-run tracking.\")\n            return None, None, None, None\n\n        try:\n            user_uuid = uuid.UUID(str(self.user_id))\n        except (ValueError, TypeError) as exc:\n            self.log(f\"Could not coerce user_id={self.user_id!r} to UUID; skipping run tracking ({exc}).\")\n            return None, None, None, None\n\n        try:\n            from langflow.api.utils import ingestion_run_service, knowledge_base_service\n            from langflow.services.database.models.jobs.model import JobStatus, JobType\n            from langflow.services.deps import get_job_service\n        except ImportError as exc:\n            self.log(f\"Run-history wiring unavailable; ingestion will not be recorded ({exc}).\")\n            return None, None, None, None\n\n        try:\n            kb_record = await knowledge_base_service.get_by_user_and_name(user_uuid, self.knowledge_base)\n            kb_record_id = kb_record.id if kb_record is not None else None\n\n            user_metadata = self._parse_user_metadata_dict()\n\n            job_id = uuid.uuid4()\n            job_service = get_job_service()\n            raw_flow_id = getattr(self, \"flow_id\", None)\n            flow_id_uuid = uuid.UUID(str(raw_flow_id)) if raw_flow_id else job_id\n            await job_service.create_job(\n                job_id=job_id,\n                flow_id=flow_id_uuid,\n                job_type=JobType.INGESTION,\n                asset_id=kb_record_id,\n                asset_type=\"knowledge_base\",\n                user_id=user_uuid,\n            )\n            await job_service.update_job_status(job_id, JobStatus.IN_PROGRESS)\n\n            source = FlowComponentSource(\n                user_id=user_uuid,\n                source_config={\n                    \"knowledge_base\": self.knowledge_base,\n                    \"kb_path\": str(kb_path),\n                    \"flow_id\": str(flow_id_uuid),\n                },\n            )\n\n            run_id = await ingestion_run_service.create_run(\n                kb_name=self.knowledge_base,\n                source=source,\n                job_id=job_id,\n                user_id=user_uuid,\n                kb_id=kb_record_id,\n                user_metadata=user_metadata,\n            )\n            if run_id is None:\n                return None, job_id, None, kb_record_id\n            await ingestion_run_service.mark_running(run_id)\n\n            summary = IngestionSummary(\n                kb_name=self.knowledge_base,\n                source_type=source.source_type.value,\n                user_id=user_uuid,\n                job_id=job_id,\n                source_config=source.describe().get(\"config\") or {},\n                user_metadata=user_metadata,\n            )\n            self.log(f\"Started ingestion run job_id={job_id} kb_name={self.knowledge_base} kb_id={kb_record_id}\")\n        except Exception as exc:  # noqa: BLE001 — telemetry must never abort ingestion\n            self.log(f\"Could not begin ingestion-run tracking: {exc}\")\n            return None, None, None, None\n        else:\n            return run_id, job_id, summary, kb_record_id\n\n    async def _finalize_ingestion_run(\n        self,\n        *,\n        run_id: uuid.UUID,\n        job_id: uuid.UUID | None,\n        summary: IngestionSummary,\n        status: IngestionRunStatus,\n        error_message: str | None,\n    ) -> None:\n        \"\"\"Persist the final summary and transition the parent Job.\"\"\"\n        try:\n            from langflow.api.utils import ingestion_run_service\n            from langflow.services.database.models.jobs.model import JobStatus\n            from langflow.services.deps import get_job_service\n        except ImportError as exc:\n            self.log(f\"Run-history wiring unavailable; ingestion-run finalize skipped ({exc}).\")\n            return\n\n        try:\n            await ingestion_run_service.finalize_run(\n                run_id,\n                summary=summary,\n                status=status,\n                error_message=error_message,\n            )\n            if job_id is not None:\n                terminal_status = JobStatus.COMPLETED if status is not IngestionRunStatus.FAILED else JobStatus.FAILED\n                await get_job_service().update_job_status(job_id, terminal_status, finished_timestamp=True)\n        except Exception as exc:  # noqa: BLE001 — telemetry must never re-raise\n            self.log(f\"Could not finalize ingestion-run tracking: {exc}\")\n\n    async def _record_kb_status(\n        self,\n        kb_record_id: uuid.UUID,\n        status_value: str,\n        *,\n        failure_reason: str | None = None,\n    ) -> None:\n        \"\"\"Mirror Path A's KB-row status transitions.\"\"\"\n        try:\n            from langflow.api.utils import knowledge_base_service\n            from langflow.services.database.models.knowledge_base.model import KnowledgeBaseStatus\n        except ImportError:\n            return\n        try:\n            await knowledge_base_service.update_status(\n                kb_record_id,\n                status=KnowledgeBaseStatus(status_value),\n                failure_reason=failure_reason,\n            )\n        except Exception as exc:  # noqa: BLE001\n            self.log(f\"Could not update KB status to {status_value}: {exc}\")\n\n    async def _record_kb_stats(self, kb_record_id: uuid.UUID, kb_path: Path) -> None:\n        \"\"\"Push freshly-refreshed metrics from embedding_metadata.json onto the DB row.\"\"\"\n        try:\n            from langflow.api.utils import knowledge_base_service\n        except ImportError:\n            self.log(\"knowledge_base_service unavailable; KB stats will not sync to DB row.\")\n            return\n        metadata_path = kb_path / \"embedding_metadata.json\"\n        if not metadata_path.exists():\n            self.log(f\"No embedding_metadata.json at {metadata_path}; skipping KB stats sync.\")\n            return\n        try:\n            metadata = json.loads(metadata_path.read_text())\n        except (OSError, json.JSONDecodeError) as exc:\n            self.log(f\"Could not read KB metadata for stats sync: {exc}\")\n            return\n        chunks = int(metadata.get(\"chunks\", 0) or 0)\n        words = int(metadata.get(\"words\", 0) or 0)\n        characters = int(metadata.get(\"characters\", 0) or 0)\n        try:\n            await knowledge_base_service.update_stats(\n                kb_record_id,\n                chunks=chunks,\n                words=words,\n                characters=characters,\n                size_bytes=int(metadata.get(\"size\", 0) or 0),\n                source_types=list(metadata.get(\"source_types\") or []),\n                chunk_size=metadata.get(\"chunk_size\"),\n                chunk_overlap=metadata.get(\"chunk_overlap\"),\n                separator=metadata.get(\"separator\"),\n            )\n            self.log(f\"Synced KB stats to DB row {kb_record_id}: chunks={chunks} words={words} characters={characters}\")\n        except Exception as exc:  # noqa: BLE001\n            self.log(f\"Could not sync KB stats to DB row {kb_record_id}: {exc}\")\n\n    def _parse_user_metadata_dict(self) -> dict[str, Any]:\n        \"\"\"Decode ``metadata_json`` to a dict, or ``{}`` on any error.\"\"\"\n        raw = getattr(self, \"metadata_json\", None)\n        if not raw:\n            return {}\n        text = raw.strip() if isinstance(raw, str) else raw\n        if not text:\n            return {}\n        try:\n            decoded = json.loads(text)\n        except (TypeError, json.JSONDecodeError):\n            return {}\n        return decoded if isinstance(decoded, dict) else {}\n\n    # =====================================================================\n    #                       RETRIEVAL CODE PATH\n    # =====================================================================\n    @property\n    def _user_uuid(self) -> uuid.UUID | None:\n        \"\"\"Return self.user_id as a UUID, converting from str if necessary.\"\"\"\n        if not self.user_id:\n            return None\n        return self.user_id if isinstance(self.user_id, uuid.UUID) else uuid.UUID(self.user_id)\n\n    def _get_kb_metadata(self, kb_path: Path) -> dict:\n        \"\"\"Load the knowledge base's embedding metadata file.\"\"\"\n        raise_error_if_astra_cloud_disable_component(astra_error_msg)\n        return load_kb_metadata(kb_path, log_label=f\"knowledge base '{self.knowledge_base}'\")\n\n    async def _resolve_backend(self, *, kb_user: str) -> tuple[str, dict[str, Any]]:  # noqa: ARG002\n        \"\"\"Return ``(backend_type, backend_config)`` for this KB.\"\"\"\n        try:\n            from langflow.api.utils import knowledge_base_service\n\n            user_uuid = self._user_uuid\n            if user_uuid is None:\n                return BackendType.CHROMA.value, {}\n            record = await knowledge_base_service.get_by_user_and_name(user_uuid, self.knowledge_base)\n        except Exception as exc:  # noqa: BLE001\n            logger.debug(\"KB record lookup failed: %s\", exc)\n            return BackendType.CHROMA.value, {}\n\n        if record is None:\n            return BackendType.CHROMA.value, {}\n        return (\n            record.backend_type or BackendType.CHROMA.value,\n            record.backend_config or {},\n        )\n\n    def _resolve_model_selection(self, metadata: dict[str, Any]) -> list[dict[str, Any]]:\n        \"\"\"Resolve the ``get_embeddings``-compatible model selection from metadata.\"\"\"\n        model_selection = metadata.get(\"model_selection\")\n        if model_selection:\n            selection_list = [model_selection] if isinstance(model_selection, dict) else list(model_selection)\n            return [self._hydrate_model_metadata(entry) for entry in selection_list]\n\n        embedding_model_name = metadata.get(\"embedding_model\")\n        embedding_provider = metadata.get(\"embedding_provider\", \"Unknown\")\n        if not embedding_model_name:\n            msg = (\n                f\"Knowledge base '{self.knowledge_base}' has no embedding model recorded; \"\n                \"re-create it with a supported embedding model.\"\n            )\n            raise ValueError(msg)\n\n        match = self._find_catalog_entry(embedding_model_name)\n        if match is None:\n            msg = (\n                f\"Embedding model '{embedding_model_name}' (provider '{embedding_provider}') \"\n                \"recorded for this knowledge base is no longer available in the model registry. \"\n                \"Please re-create the knowledge base with a supported embedding model.\"\n            )\n            raise ValueError(msg)\n        return [match]\n\n    def _hydrate_model_metadata(self, entry: dict[str, Any]) -> dict[str, Any]:\n        \"\"\"Fill in ``metadata.embedding_class`` / ``param_mapping`` if missing.\"\"\"\n        entry_metadata = entry.get(\"metadata\") or {}\n        has_class = bool(entry_metadata.get(\"embedding_class\"))\n        has_mapping = bool(entry_metadata.get(\"param_mapping\"))\n        if has_class and has_mapping:\n            return entry\n\n        model_name = entry.get(\"name\")\n        if not model_name:\n            return entry\n\n        catalog_entry = self._find_catalog_entry(model_name)\n        if catalog_entry is None:\n            return entry\n\n        catalog_metadata = catalog_entry.get(\"metadata\") or {}\n        merged_metadata = {**catalog_metadata, **entry_metadata}\n        return {**entry, \"metadata\": merged_metadata}\n\n    def _find_catalog_entry(self, model_name: str) -> dict[str, Any] | None:\n        \"\"\"Look up an embedding model by name in the unified-models catalog.\"\"\"\n        options = get_embedding_model_options(user_id=self.user_id)\n        return next((o for o in options if o.get(\"name\") == model_name), None)\n\n    async def retrieve_data(self) -> DataFrame:\n        \"\"\"Retrieve data from the selected knowledge base.\n\n        Annotation narrowed to ``DataFrame`` to keep this output's handle\n        type list at ``[\"Table\"]`` only; widening to a union surfaces\n        ``[\"Table\", \"JSON\"]`` on the API and breaks every starter-project\n        edge whose sourceHandle was stored against a single-type handle\n        (BUG-02). The cross-mode defensive fallback may still return a\n        ``Data`` at runtime — Python ignores return annotations, so\n        nothing breaks.\n        \"\"\"\n        if not _is_retrieve_mode(getattr(self, \"mode\", MODE_INGEST)):\n            return await self.build_kb_info()\n        raise_error_if_astra_cloud_disable_component(astra_error_msg)\n\n        # Lazy import: langflow's user/DB models aren't part of lfx's\n        # standalone install, so ``lfx run <starter>.json`` can't resolve\n        # this symbol at module import time. Deferring to use keeps the\n        # component importable in both environments.\n        from langflow.services.database.models.user.crud import get_user_by_id\n\n        async with session_scope() as db:\n            if not self.user_id:\n                msg = \"User ID is required for fetching Knowledge Base data.\"\n                raise ValueError(msg)\n            current_user = await get_user_by_id(db, self.user_id)\n            if not current_user:\n                msg = f\"User with ID {self.user_id} not found.\"\n                raise ValueError(msg)\n            kb_user = current_user.username\n        kb_path = _get_knowledge_bases_root_path() / kb_user / self.knowledge_base\n\n        metadata = self._get_kb_metadata(kb_path)\n        if not metadata:\n            msg = f\"Metadata not found for knowledge base: {self.knowledge_base}. Ensure it has been indexed.\"\n            raise ValueError(msg)\n\n        model_selection = self._resolve_model_selection(metadata)\n        chunk_size = metadata.get(\"chunk_size\")\n        embedding_function = get_embeddings(\n            model=model_selection,\n            user_id=self.user_id,\n            chunk_size=chunk_size,\n        )\n\n        backend_type, backend_config = await self._resolve_backend(kb_user=kb_user)\n        backend = create_backend(\n            backend_type,\n            kb_name=self.knowledge_base,\n            kb_path=kb_path,\n            backend_config=backend_config,\n            embedding_function=embedding_function,\n            user_id=self.user_id,\n        )\n        try:\n            user_metadata_filter = _parse_metadata_filter(getattr(self, \"metadata_filter\", None))\n            use_scores = bool(self.search_query)\n            search_k = self.top_k * 4 if user_metadata_filter else self.top_k\n            results = await backend.similarity_search(\n                query=self.search_query or \"\",\n                k=search_k,\n                with_scores=use_scores,\n            )\n            if user_metadata_filter:\n                results = [\n                    (doc, score) for doc, score in results if _chunk_matches_filter(doc.metadata, user_metadata_filter)\n                ]\n                results = results[: self.top_k]\n\n            embeddings_by_key: dict[tuple[str, str], list[float]] = {}\n            if self.include_embeddings and results:\n                # Join each retrieved chunk to its stored embedding. We key on\n                # ``_id`` when present and fall back to page content otherwise,\n                # so KBs populated by direct file upload — whose chunks carry no\n                # ``_id`` — still resolve. See ``_embedding_match_key``.\n                wanted_keys = {_embedding_match_key(doc.page_content, doc.metadata) for doc, _score in results}\n                async for batch in backend.iter_documents(include_embeddings=True):\n                    for entry in batch:\n                        if entry.embedding is None:\n                            continue\n                        key = _embedding_match_key(entry.content, entry.metadata)\n                        if key in wanted_keys:\n                            embeddings_by_key[key] = entry.embedding\n                    if len(embeddings_by_key) == len(wanted_keys):\n                        break\n\n            data_list: list[Data] = []\n            for doc, score in results:\n                kwargs: dict[str, Any] = {\"content\": doc.page_content}\n                if use_scores:\n                    kwargs[\"_score\"] = -1 * score\n                if self.include_metadata:\n                    kwargs.update(doc.metadata)\n                if self.include_embeddings:\n                    kwargs[\"_embeddings\"] = embeddings_by_key.get(_embedding_match_key(doc.page_content, doc.metadata))\n                data_list.append(Data(**kwargs))\n\n            return DataFrame(data=data_list)\n        finally:\n            await backend.teardown()\n\n\ndef _embedding_match_key(content: str, metadata: dict[str, Any] | None) -> tuple[str, str]:\n    \"\"\"Build a stable key for aligning a retrieved chunk with its stored embedding.\n\n    Embeddings are gathered separately (via ``iter_documents``) and then joined\n    back onto the search results. Component-driven ingestion stamps a\n    content-hash ``_id`` on every chunk, but direct file-upload ingestion\n    (``KBIngestionHelper.perform_ingestion``) does not. Keying the join purely on\n    ``_id`` therefore left every upload-populated KB with ``_embeddings: None``.\n\n    We prefer ``_id`` when present (so legitimately distinct chunks that happen to\n    share text aren't collapsed) and fall back to the chunk's page content\n    otherwise. The content fallback is exact for the embedding use case: two\n    chunks with identical text necessarily share the same embedding vector. The\n    leading ``\"id\"`` / ``\"content\"`` tag namespaces the two key spaces so a mixed\n    KB (some chunks with ``_id``, some without) never cross-matches.\n    \"\"\"\n    doc_id = metadata.get(\"_id\") if metadata else None\n    if doc_id:\n        return (\"id\", str(doc_id))\n    return (\"content\", content or \"\")\n\n\ndef _parse_metadata_filter(raw: str | None) -> dict[str, list[str]]:\n    \"\"\"Decode the ``metadata_filter`` input into a {key: [values]} map.\n\n    Empty or malformed input maps to an empty filter so retrieval falls back\n    to the unfiltered path. JSON errors are swallowed here rather than raised:\n    surfacing component-config errors at the canvas node would break a flow\n    run for what is meant to be an optional refinement.\n    \"\"\"\n    if not raw:\n        return {}\n    text = raw.strip() if isinstance(raw, str) else raw\n    if not text:\n        return {}\n    try:\n        decoded = json.loads(text)\n    except (TypeError, json.JSONDecodeError):\n        logger.warning(\"KnowledgeComponent: metadata_filter is not valid JSON; ignoring filter.\")\n        return {}\n    if not isinstance(decoded, dict):\n        logger.warning(\"KnowledgeComponent: metadata_filter must be a JSON object; ignoring filter.\")\n        return {}\n    result: dict[str, list[str]] = {}\n    for key, value in decoded.items():\n        if not isinstance(key, str):\n            continue\n        if isinstance(value, list):\n            result[key] = [str(entry) for entry in value]\n        else:\n            result[key] = [str(value)]\n    return result\n\n\ndef _chunk_matches_filter(metadata: dict[str, Any] | None, filt: dict[str, list[str]]) -> bool:\n    \"\"\"AND across keys, OR within key values, mirroring the chunks endpoint.\"\"\"\n    if not filt:\n        return True\n    if not metadata:\n        return False\n    raw = metadata.get(\"source_metadata\")\n    if not raw:\n        return False\n    try:\n        stored = json.loads(raw) if isinstance(raw, str) else raw\n    except json.JSONDecodeError:\n        return False\n    if not isinstance(stored, dict):\n        return False\n    for key, expected_values in filt.items():\n        actual = stored.get(key)\n        if actual is None:\n            return False\n        actual_set = {str(entry) for entry in actual} if isinstance(actual, list) else {str(actual)}\n        if not actual_set & set(expected_values):\n            return False\n    return True\n",
+        "fileTypes": [],
+        "file_path": "",
+        "password": false,
+        "name": "code",
+        "advanced": true,
+        "dynamic": true,
+        "info": "",
+        "load_from_db": false,
+        "title_case": false
+       },
+       "column_config": {
+        "tool_mode": false,
+        "is_list": true,
+        "list_add_label": "Add More",
+        "table_schema": [
+         {
+          "name": "column_name",
+          "display_name": "Column Name",
+          "type": "str",
+          "description": "Name of the column in the source DataFrame",
+          "edit_mode": "inline",
+          "formatter": "text"
+         },
+         {
+          "name": "vectorize",
+          "display_name": "Vectorize",
+          "type": "boolean",
+          "description": "Create embeddings for this column",
+          "default": false,
+          "edit_mode": "inline",
+          "formatter": "text"
+         },
+         {
+          "name": "identifier",
+          "display_name": "Identifier",
+          "type": "boolean",
+          "description": "Use this column as unique identifier",
+          "default": false,
+          "edit_mode": "inline",
+          "formatter": "text"
+         }
+        ],
+        "trigger_text": "Open table",
+        "trigger_icon": "Table",
+        "table_icon": "Table",
+        "trace_as_metadata": true,
+        "override_skip": false,
+        "required": true,
+        "placeholder": "",
+        "show": false,
+        "name": "column_config",
+        "value": [
+         {
+          "column_name": "text",
+          "vectorize": true,
+          "identifier": true
+         }
+        ],
+        "display_name": "Column Configuration",
+        "advanced": false,
+        "input_types": [
+         "DataFrame",
+         "Table"
+        ],
+        "dynamic": true,
+        "info": "Configure column behavior for the knowledge base.",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "table",
+        "_input_type": "TableInput"
+       },
+       "include_embeddings": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "include_embeddings",
+        "value": false,
+        "display_name": "Include Embeddings",
+        "advanced": true,
+        "dynamic": true,
+        "info": "Whether to include embeddings in the output. Only applicable if 'Include Metadata' is enabled.",
+        "title_case": false,
+        "track_in_telemetry": true,
+        "type": "bool",
+        "_input_type": "BoolInput"
+       },
+       "include_metadata": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "include_metadata",
+        "value": true,
+        "display_name": "Include Metadata",
+        "advanced": false,
+        "dynamic": true,
+        "info": "Whether to include all metadata in the output. If false, only content is returned.",
+        "title_case": false,
+        "track_in_telemetry": true,
+        "type": "bool",
+        "_input_type": "BoolInput"
+       },
+       "knowledge_base": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "options": [
+         "__KB_NAME__"
+        ],
+        "options_metadata": [],
+        "combobox": false,
+        "dialog_inputs": {
+         "functionality": "create",
+         "fields": {
+          "data": {
+           "node": {
+            "name": "create_knowledge_base",
+            "description": "Create new knowledge in Langflow.",
+            "display_name": "Create new Knowledge Base",
+            "field_order": [
+             "01_new_kb_name",
+             "02_embedding_model",
+             "03_knowledge_backend"
+            ],
+            "template": {
+             "01_new_kb_name": {
+              "tool_mode": false,
+              "trace_as_metadata": true,
+              "load_from_db": false,
+              "list": false,
+              "list_add_label": "Add More",
+              "override_skip": false,
+              "required": true,
+              "placeholder": "",
+              "show": true,
+              "name": "new_kb_name",
+              "value": "",
+              "display_name": "Knowledge Name",
+              "advanced": false,
+              "dynamic": false,
+              "info": "Name of the new knowledge to create.",
+              "title_case": false,
+              "track_in_telemetry": false,
+              "type": "str",
+              "_input_type": "StrInput"
+             },
+             "02_embedding_model": {
+              "tool_mode": false,
+              "trace_as_input": true,
+              "list": false,
+              "list_add_label": "Add More",
+              "model_type": "embedding",
+              "external_options": {
+               "fields": {
+                "data": {
+                 "node": {
+                  "name": "connect_other_models",
+                  "display_name": "Connect other models",
+                  "icon": "CornerDownLeft"
+                 }
+                }
+               }
+              },
+              "override_skip": false,
+              "required": true,
+              "placeholder": "Setup Provider",
+              "show": true,
+              "name": "embedding_model",
+              "value": "",
+              "display_name": "Choose Embedding Model",
+              "advanced": false,
+              "input_types": [
+               "Embeddings"
+              ],
+              "dynamic": false,
+              "info": "Select the embedding model to use for this knowledge base. Langflow uses the configured credentials for that model provider.",
+              "refresh_button": true,
+              "title_case": false,
+              "track_in_telemetry": false,
+              "type": "model",
+              "_input_type": "ModelInput",
+              "options": [
+               {
+                "name": "gemini-embedding-001",
+                "icon": "GoogleGenerativeAI",
+                "category": "Google Generative AI",
+                "provider": "Google Generative AI",
+                "metadata": {
+                 "embedding_class": "GoogleGenerativeAIEmbeddings",
+                 "param_mapping": {
+                  "model": "model",
+                  "api_key": "google_api_key",
+                  "dimensions": "output_dimensionality",
+                  "request_timeout": "request_options",
+                  "model_kwargs": "client_options"
+                 },
+                 "model_type": "embeddings"
+                }
+               },
+               {
+                "name": "models/gemini-embedding-001",
+                "icon": "GoogleGenerativeAI",
+                "category": "Google Generative AI",
+                "provider": "Google Generative AI",
+                "metadata": {
+                 "embedding_class": "GoogleGenerativeAIEmbeddings",
+                 "param_mapping": {
+                  "model": "model",
+                  "api_key": "google_api_key",
+                  "dimensions": "output_dimensionality",
+                  "request_timeout": "request_options",
+                  "model_kwargs": "client_options"
+                 },
+                 "model_type": "embeddings"
+                }
+               }
+              ]
+             },
+             "03_knowledge_backend": {
+              "tool_mode": false,
+              "trace_as_input": true,
+              "override_skip": false,
+              "required": true,
+              "placeholder": "",
+              "show": true,
+              "name": "knowledge_backend",
+              "value": {},
+              "display_name": "DB Provider",
+              "advanced": false,
+              "input_types": [],
+              "dynamic": false,
+              "info": "Select where this knowledge base stores vectors. OpenSearch uses the global DB Providers settings.",
+              "title_case": false,
+              "track_in_telemetry": false,
+              "type": "knowledge_backend",
+              "_input_type": "DBProviderInput"
+             }
+            }
+           }
+          }
+         }
+        },
+        "toggle": false,
+        "override_skip": false,
+        "required": true,
+        "placeholder": "",
+        "show": true,
+        "name": "knowledge_base",
+        "value": "__KB_NAME__",
+        "display_name": "Knowledge",
+        "advanced": false,
+        "dynamic": false,
+        "info": "Select the knowledge to load data from.",
+        "real_time_refresh": true,
+        "refresh_button": true,
+        "title_case": false,
+        "track_in_telemetry": true,
+        "external_options": {},
+        "type": "str",
+        "_input_type": "DropdownInput"
+       },
+       "metadata_filter": {
+        "tool_mode": false,
+        "trace_as_input": true,
+        "trace_as_metadata": true,
+        "load_from_db": false,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "metadata_filter",
+        "value": "",
+        "display_name": "Metadata Filter",
+        "advanced": true,
+        "input_types": [
+         "Message"
+        ],
+        "dynamic": true,
+        "info": "Optional JSON object of user-metadata key/value pairs. Only chunks whose source_metadata matches every key are returned (e.g. {\"tag\": \"invoice\"} or {\"tag\": [\"invoice\", \"audit\"]} for OR-of-values). Backends without native filtering apply the match client-side after retrieval.",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "str",
+        "_input_type": "MessageTextInput"
+       },
+       "metadata_json": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "load_from_db": false,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": false,
+        "name": "metadata_json",
+        "value": "",
+        "display_name": "Metadata",
+        "advanced": true,
+        "dynamic": true,
+        "info": "Optional JSON object of user metadata applied to every chunk produced by this run (e.g. {\"tag\": \"invoice\", \"year\": \"2026\"}). Same shape as the upload modal Metadata section so chunks browser filters + Knowledge retrieval metadata_filter work uniformly across upload, folder, and flow-driven ingestion. Malformed JSON is ignored with a warning rather than failing the run.",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "str",
+        "_input_type": "StrInput"
+       },
+       "mode": {
+        "tool_mode": true,
+        "trace_as_metadata": true,
+        "options": [
+         "Ingest",
+         "Retrieve"
+        ],
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "mode",
+        "value": "Retrieve",
+        "display_name": "Mode",
+        "advanced": false,
+        "dynamic": false,
+        "info": "Switch between writing new data into the knowledge base and querying it.",
+        "real_time_refresh": true,
+        "title_case": false,
+        "track_in_telemetry": true,
+        "type": "tab",
+        "_input_type": "TabInput"
+       },
+       "search_query": {
+        "tool_mode": true,
+        "trace_as_input": true,
+        "trace_as_metadata": true,
+        "load_from_db": false,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "search_query",
+        "value": "Which internal codec converts each chunk into a numerical embedding vector?",
+        "display_name": "Search Query",
+        "advanced": false,
+        "input_types": [
+         "Message"
+        ],
+        "dynamic": true,
+        "info": "Optional search query to filter knowledge base data.",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "str",
+        "_input_type": "MessageTextInput"
+       },
+       "top_k": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "top_k",
+        "value": 1,
+        "display_name": "Top K Results",
+        "advanced": true,
+        "dynamic": true,
+        "info": "Number of top results to return from the knowledge base.",
+        "title_case": false,
+        "track_in_telemetry": true,
+        "type": "int",
+        "_input_type": "IntInput"
+       },
+       "_frontend_node_flow_id": {
+        "value": "31dfa8d2-d42f-4bd0-b04a-a3bbb96fc544"
+       },
+       "_frontend_node_folder_id": {
+        "value": "50c46771-d71e-47f4-b62a-068e2fe5ef85"
+       },
+       "is_refresh": false
+      },
+      "description": "Ingest into or retrieve from a Langflow knowledge base.",
+      "icon": "database",
+      "base_classes": [
+       "JSON",
+       "Table"
+      ],
+      "display_name": "Knowledge",
+      "documentation": "",
+      "minimized": false,
+      "custom_fields": {},
+      "output_types": [],
+      "pinned": false,
+      "conditional_paths": [],
+      "frozen": false,
+      "outputs": [
+       {
+        "types": [
+         "JSON"
+        ],
+        "selected": "JSON",
+        "name": "dataframe_output",
+        "display_name": "Results",
+        "method": "build_kb_info",
+        "value": "__UNDEFINED__",
+        "cache": true,
+        "required_inputs": null,
+        "allows_loop": false,
+        "loop_types": null,
+        "group_outputs": false,
+        "options": null,
+        "tool_mode": true
+       },
+       {
+        "types": [
+         "Table"
+        ],
+        "selected": "Table",
+        "name": "retrieve_data",
+        "display_name": "Results",
+        "method": "retrieve_data",
+        "value": "__UNDEFINED__",
+        "cache": true,
+        "required_inputs": null,
+        "allows_loop": false,
+        "loop_types": null,
+        "group_outputs": false,
+        "options": null,
+        "tool_mode": true
+       }
+      ],
+      "field_order": [
+       "knowledge_base",
+       "mode",
+       "input_df",
+       "column_config",
+       "chunk_size",
+       "api_key",
+       "allow_duplicates",
+       "metadata_json",
+       "search_query",
+       "top_k",
+       "include_metadata",
+       "include_embeddings",
+       "metadata_filter"
+      ],
+      "beta": false,
+      "legacy": false,
+      "edited": false,
+      "metadata": {
+       "module": "lfx.components.files_and_knowledge.knowledge.KnowledgeComponent",
+       "code_hash": "26a843069b81",
+       "dependencies": {
+        "total_dependencies": 7,
+        "dependencies": [
+         {
+          "name": "pandas",
+          "version": "2.3.3"
+         },
+         {
+          "name": "cryptography",
+          "version": "49.0.0"
+         },
+         {
+          "name": "langchain_chroma",
+          "version": "0.2.6"
+         },
+         {
+          "name": "langflow",
+          "version": "1.11.0.dev38"
+         },
+         {
+          "name": "lfx",
+          "version": "1.11.0.dev38"
+         },
+         {
+          "name": "numpy",
+          "version": "2.5.1"
+         },
+         {
+          "name": "chromadb",
+          "version": "1.5.9"
+         }
+        ]
+       }
+      },
+      "tool_mode": false,
+      "last_updated": "2026-07-14T17:31:45.435Z",
+      "lf_version": "1.11.0.dev38"
+     },
+     "showNode": true,
+     "type": "Knowledge",
+     "id": "Knowledge-retrieve",
+     "selected_output": "retrieve_data"
+    },
+    "selected": false,
+    "measured": {
+     "width": 320,
+     "height": 428
+    }
+   },
+   {
+    "data": {
+     "node": {
+      "template": {
+       "_type": "Component",
+       "input_data": {
+        "trace_as_metadata": true,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": true,
+        "placeholder": "",
+        "show": true,
+        "name": "input_data",
+        "value": "",
+        "display_name": "JSON or Table",
+        "advanced": false,
+        "input_types": [
+         "DataFrame",
+         "Table",
+         "Data",
+         "JSON"
+        ],
+        "dynamic": false,
+        "info": "Accepts either a DataFrame or a Data object.",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "other",
+        "_input_type": "HandleInput"
+       },
+       "code": {
+        "type": "code",
+        "required": true,
+        "placeholder": "",
+        "list": false,
+        "show": true,
+        "multiline": true,
+        "value": "from lfx.custom.custom_component.component import Component\nfrom lfx.helpers.data import safe_convert\nfrom lfx.inputs.inputs import BoolInput, HandleInput, MessageTextInput, MultilineInput, TabInput\nfrom lfx.schema.data import Data\nfrom lfx.schema.dataframe import DataFrame\nfrom lfx.schema.message import Message\nfrom lfx.template.field.base import Output\n\n\nclass ParserComponent(Component):\n    display_name = \"Parser\"\n    description = \"Extracts text using a template.\"\n    documentation: str = \"https://docs.langflow.org/parser\"\n    icon = \"braces\"\n\n    inputs = [\n        HandleInput(\n            name=\"input_data\",\n            display_name=\"JSON or Table\",\n            input_types=[\"DataFrame\", \"Table\", \"Data\", \"JSON\"],\n            info=\"Accepts either a DataFrame or a Data object.\",\n            required=True,\n        ),\n        TabInput(\n            name=\"mode\",\n            display_name=\"Mode\",\n            options=[\"Parser\", \"Stringify\"],\n            value=\"Parser\",\n            info=\"Convert into raw string instead of using a template.\",\n            real_time_refresh=True,\n        ),\n        MultilineInput(\n            name=\"pattern\",\n            display_name=\"Template\",\n            info=(\n                \"Use variables within curly brackets to extract column values for DataFrames \"\n                \"or key values for Data.\"\n                \"For example: `Name: {Name}, Age: {Age}, Country: {Country}`\"\n            ),\n            value=\"Text: {text}\",  # Example default\n            dynamic=True,\n            show=True,\n            required=True,\n        ),\n        MessageTextInput(\n            name=\"sep\",\n            display_name=\"Separator\",\n            advanced=True,\n            value=\"\\n\",\n            info=\"String used to separate rows/items.\",\n        ),\n    ]\n\n    outputs = [\n        Output(\n            display_name=\"Parsed Text\",\n            name=\"parsed_text\",\n            info=\"Formatted text output.\",\n            method=\"parse_combined_text\",\n        ),\n    ]\n\n    def update_build_config(self, build_config, field_value, field_name=None):\n        \"\"\"Dynamically hide/show `template` and enforce requirement based on `stringify`.\"\"\"\n        if field_name == \"mode\":\n            build_config[\"pattern\"][\"show\"] = self.mode == \"Parser\"\n            build_config[\"pattern\"][\"required\"] = self.mode == \"Parser\"\n            if field_value:\n                clean_data = BoolInput(\n                    name=\"clean_data\",\n                    display_name=\"Clean Data\",\n                    info=(\n                        \"Enable to clean the data by removing empty rows and lines \"\n                        \"in each cell of the DataFrame/ Data object.\"\n                    ),\n                    value=True,\n                    advanced=True,\n                    required=False,\n                )\n                build_config[\"clean_data\"] = clean_data.to_dict()\n            else:\n                build_config.pop(\"clean_data\", None)\n\n        return build_config\n\n    def _clean_args(self):\n        \"\"\"Prepare arguments based on input type.\"\"\"\n        input_data = self.input_data\n\n        match input_data:\n            case list() if all(isinstance(item, Data) for item in input_data):\n                msg = \"List of Data objects is not supported.\"\n                raise ValueError(msg)\n            case DataFrame():\n                return input_data, None\n            case Data():\n                return None, input_data\n            case dict() if \"data\" in input_data:\n                try:\n                    if \"columns\" in input_data:  # Likely a DataFrame\n                        return DataFrame.from_dict(input_data), None\n                    # Likely a Data object\n                    return None, Data(**input_data)\n                except (TypeError, ValueError, KeyError) as e:\n                    msg = f\"Invalid structured input provided: {e!s}\"\n                    raise ValueError(msg) from e\n            case _:\n                msg = f\"Unsupported input type: {type(input_data)}. Expected DataFrame or Data.\"\n                raise ValueError(msg)\n\n    def parse_combined_text(self) -> Message:\n        \"\"\"Parse all rows/items into a single text or convert input to string if `stringify` is enabled.\"\"\"\n        # Early return for stringify option\n        if self.mode == \"Stringify\":\n            return self.convert_to_string()\n\n        df, data = self._clean_args()\n\n        lines = []\n        if df is not None:\n            for _, row in df.iterrows():\n                formatted_text = self.pattern.format(**row.to_dict())\n                lines.append(formatted_text)\n        elif data is not None:\n            # Use format_map with a dict that returns default_value for missing keys\n            class DefaultDict(dict):\n                def __missing__(self, key):\n                    return data.default_value or \"\"\n\n            formatted_text = self.pattern.format_map(DefaultDict(data.data))\n            lines.append(formatted_text)\n\n        combined_text = self.sep.join(lines)\n        self.status = combined_text\n        return Message(text=combined_text)\n\n    def convert_to_string(self) -> Message:\n        \"\"\"Convert input data to string with proper error handling.\"\"\"\n        result = \"\"\n        if isinstance(self.input_data, list):\n            result = \"\\n\".join([safe_convert(item, clean_data=self.clean_data or False) for item in self.input_data])\n        else:\n            result = safe_convert(self.input_data or False)\n        self.log(f\"Converted to string with length: {len(result)}\")\n\n        message = Message(text=result)\n        self.status = message\n        return message\n",
+        "fileTypes": [],
+        "file_path": "",
+        "password": false,
+        "name": "code",
+        "advanced": true,
+        "dynamic": true,
+        "info": "",
+        "load_from_db": false,
+        "title_case": false
+       },
+       "mode": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "options": [
+         "Parser",
+         "Stringify"
+        ],
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "mode",
+        "value": "Stringify",
+        "display_name": "Mode",
+        "advanced": false,
+        "dynamic": false,
+        "info": "Convert into raw string instead of using a template.",
+        "real_time_refresh": true,
+        "title_case": false,
+        "track_in_telemetry": true,
+        "type": "tab",
+        "_input_type": "TabInput"
+       },
+       "pattern": {
+        "tool_mode": false,
+        "trace_as_input": true,
+        "multiline": true,
+        "ai_enabled": false,
+        "trace_as_metadata": true,
+        "load_from_db": false,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": true,
+        "placeholder": "",
+        "show": true,
+        "name": "pattern",
+        "value": "Text: {text}",
+        "display_name": "Template",
+        "advanced": false,
+        "input_types": [
+         "Message"
+        ],
+        "dynamic": true,
+        "info": "Use variables within curly brackets to extract column values for DataFrames or key values for Data.For example: `Name: {Name}, Age: {Age}, Country: {Country}`",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "copy_field": false,
+        "password": false,
+        "type": "str",
+        "_input_type": "MultilineInput"
+       },
+       "sep": {
+        "tool_mode": false,
+        "trace_as_input": true,
+        "trace_as_metadata": true,
+        "load_from_db": false,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "sep",
+        "value": "\n",
+        "display_name": "Separator",
+        "advanced": true,
+        "input_types": [
+         "Message"
+        ],
+        "dynamic": false,
+        "info": "String used to separate rows/items.",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "str",
+        "_input_type": "MessageTextInput"
+       }
+      },
+      "description": "Extracts text using a template.",
+      "icon": "braces",
+      "base_classes": [
+       "Message"
+      ],
+      "display_name": "Parser",
+      "documentation": "https://docs.langflow.org/parser",
+      "minimized": false,
+      "custom_fields": {},
+      "output_types": [],
+      "pinned": false,
+      "conditional_paths": [],
+      "frozen": false,
+      "outputs": [
+       {
+        "types": [
+         "Message"
+        ],
+        "selected": "Message",
+        "name": "parsed_text",
+        "display_name": "Parsed Text",
+        "method": "parse_combined_text",
+        "value": "__UNDEFINED__",
+        "cache": true,
+        "allows_loop": false,
+        "group_outputs": false,
+        "tool_mode": true
+       }
+      ],
+      "field_order": [],
+      "beta": false,
+      "legacy": false,
+      "edited": false,
+      "metadata": {},
+      "tool_mode": false
+     },
+     "type": "ParserComponent",
+     "id": "Parser-answer"
+    },
+    "id": "Parser-answer",
+    "type": "genericNode",
+    "selected": false,
+    "position": {
+     "x": 450,
+     "y": 650
+    }
+   },
+   {
+    "data": {
+     "node": {
+      "template": {
+       "_type": "Component",
+       "code": {
+        "type": "code",
+        "required": true,
+        "placeholder": "",
+        "list": false,
+        "show": true,
+        "multiline": true,
+        "value": "from typing import Any\n\nfrom lfx.base.prompts.api_utils import process_prompt_template\nfrom lfx.custom.custom_component.component import Component\nfrom lfx.inputs.input_mixin import FieldTypes\nfrom lfx.inputs.inputs import DefaultPromptField\nfrom lfx.io import BoolInput, MessageTextInput, Output, PromptInput\nfrom lfx.log.logger import logger\nfrom lfx.schema.dotdict import dotdict\nfrom lfx.schema.message import Message\nfrom lfx.template.utils import update_template_values\nfrom lfx.utils.mustache_security import validate_mustache_template\n\n\nclass PromptComponent(Component):\n    display_name: str = \"Prompt Template\"\n    description: str = \"Create a prompt template with dynamic variables.\"\n    documentation: str = \"https://docs.langflow.org/components-prompts\"\n    icon = \"prompts\"\n    trace_type = \"prompt\"\n    name = \"Prompt Template\"\n\n    inputs = [\n        PromptInput(name=\"template\", display_name=\"Template\"),\n        BoolInput(\n            name=\"use_double_brackets\",\n            display_name=\"Use Double Brackets\",\n            value=False,\n            advanced=True,\n            info=\"Use {{variable}} syntax instead of {variable}.\",\n            real_time_refresh=True,\n        ),\n        MessageTextInput(\n            name=\"tool_placeholder\",\n            display_name=\"Tool Placeholder\",\n            tool_mode=True,\n            advanced=True,\n            show=False,\n            info=\"A placeholder input for tool mode.\",\n        ),\n    ]\n\n    outputs = [\n        Output(display_name=\"Prompt\", name=\"prompt\", method=\"build_prompt\"),\n    ]\n\n    def update_build_config(self, build_config: dotdict, field_value: Any, field_name: str | None = None) -> dotdict:\n        \"\"\"Update the template field type based on the selected mode.\"\"\"\n        if field_name == \"use_double_brackets\":\n            # Change the template field type based on mode\n            is_mustache = field_value is True\n            if is_mustache:\n                build_config[\"template\"][\"type\"] = FieldTypes.MUSTACHE_PROMPT.value\n            else:\n                build_config[\"template\"][\"type\"] = FieldTypes.PROMPT.value\n\n            # Re-process the template to update variables when mode changes\n            template_value = build_config.get(\"template\", {}).get(\"value\", \"\")\n            if template_value:\n                # Ensure custom_fields is properly initialized\n                if \"custom_fields\" not in build_config:\n                    build_config[\"custom_fields\"] = {}\n\n                # Clean up fields from the OLD mode before processing with NEW mode\n                # This ensures we don't keep fields with wrong syntax even if validation fails\n                old_custom_fields = build_config[\"custom_fields\"].get(\"template\", [])\n                for old_field in list(old_custom_fields):\n                    # Remove the field from custom_fields and template\n                    if old_field in old_custom_fields:\n                        old_custom_fields.remove(old_field)\n                    build_config.pop(old_field, None)\n\n                # Try to process template with new mode to add new variables\n                # If validation fails, at least we cleaned up old fields\n                try:\n                    # Validate mustache templates for security\n                    if is_mustache:\n                        validate_mustache_template(template_value)\n\n                    # Re-process template with new mode to add new variables\n                    _ = process_prompt_template(\n                        template=template_value,\n                        name=\"template\",\n                        custom_fields=build_config[\"custom_fields\"],\n                        frontend_node_template=build_config,\n                        is_mustache=is_mustache,\n                    )\n                except ValueError as e:\n                    # If validation fails, we still updated the mode and cleaned old fields\n                    # User will see error when they try to save\n                    logger.debug(f\"Template validation failed during mode switch: {e}\")\n        return build_config\n\n    async def build_prompt(self) -> Message:\n        use_double_brackets = self.use_double_brackets if hasattr(self, \"use_double_brackets\") else False\n        template_format = \"mustache\" if use_double_brackets else \"f-string\"\n        prompt = await Message.from_template_and_variables(template_format=template_format, **self._attributes)\n        self.status = prompt.text\n        return prompt\n\n    def _update_template(self, frontend_node: dict):\n        prompt_template = frontend_node[\"template\"][\"template\"][\"value\"]\n        use_double_brackets = frontend_node[\"template\"].get(\"use_double_brackets\", {}).get(\"value\", False)\n        is_mustache = use_double_brackets is True\n\n        try:\n            # Validate mustache templates for security\n            if is_mustache:\n                validate_mustache_template(prompt_template)\n\n            custom_fields = frontend_node[\"custom_fields\"]\n            frontend_node_template = frontend_node[\"template\"]\n            _ = process_prompt_template(\n                template=prompt_template,\n                name=\"template\",\n                custom_fields=custom_fields,\n                frontend_node_template=frontend_node_template,\n                is_mustache=is_mustache,\n            )\n        except ValueError as e:\n            # If validation fails, don't add variables but allow component to be created\n            logger.debug(f\"Template validation failed in _update_template: {e}\")\n        return frontend_node\n\n    async def update_frontend_node(self, new_frontend_node: dict, current_frontend_node: dict):\n        \"\"\"This function is called after the code validation is done.\"\"\"\n        frontend_node = await super().update_frontend_node(new_frontend_node, current_frontend_node)\n        template = frontend_node[\"template\"][\"template\"][\"value\"]\n        use_double_brackets = frontend_node[\"template\"].get(\"use_double_brackets\", {}).get(\"value\", False)\n        is_mustache = use_double_brackets is True\n\n        try:\n            # Validate mustache templates for security\n            if is_mustache:\n                validate_mustache_template(template)\n\n            # Kept it duplicated for backwards compatibility\n            _ = process_prompt_template(\n                template=template,\n                name=\"template\",\n                custom_fields=frontend_node[\"custom_fields\"],\n                frontend_node_template=frontend_node[\"template\"],\n                is_mustache=is_mustache,\n            )\n        except ValueError as e:\n            # If validation fails, don't add variables but allow component to be updated\n            logger.debug(f\"Template validation failed in update_frontend_node: {e}\")\n        # Now that template is updated, we need to grab any values that were set in the current_frontend_node\n        # and update the frontend_node with those values\n        update_template_values(new_template=frontend_node, previous_template=current_frontend_node[\"template\"])\n        return frontend_node\n\n    def _get_fallback_input(self, **kwargs):\n        return DefaultPromptField(**kwargs)\n",
+        "fileTypes": [],
+        "file_path": "",
+        "password": false,
+        "name": "code",
+        "advanced": true,
+        "dynamic": true,
+        "info": "",
+        "load_from_db": false,
+        "title_case": false
+       },
+       "context": {
+        "type": "str",
+        "required": false,
+        "placeholder": "",
+        "list": false,
+        "show": true,
+        "multiline": true,
+        "value": "",
+        "fileTypes": [],
+        "file_path": "",
+        "name": "context",
+        "display_name": "context",
+        "advanced": false,
+        "input_types": [
+         "Message"
+        ],
+        "dynamic": false,
+        "info": "",
+        "load_from_db": false,
+        "title_case": false
+       },
+       "template": {
+        "tool_mode": false,
+        "trace_as_input": true,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "template",
+        "value": "Use ONLY the context below to answer. Do not rely on any prior knowledge.\n\nContext:\n{context}\n\nQuestion: Which internal codec converts each chunk into a numerical embedding vector? Answer with the exact codec name only.\n\nAnswer:",
+        "display_name": "Template",
+        "advanced": false,
+        "dynamic": false,
+        "info": "",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "prompt",
+        "_input_type": "PromptInput"
+       },
+       "tool_placeholder": {
+        "tool_mode": true,
+        "trace_as_input": true,
+        "trace_as_metadata": true,
+        "load_from_db": false,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": false,
+        "name": "tool_placeholder",
+        "value": "",
+        "display_name": "Tool Placeholder",
+        "advanced": true,
+        "input_types": [
+         "Message"
+        ],
+        "dynamic": false,
+        "info": "A placeholder input for tool mode.",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "str",
+        "_input_type": "MessageTextInput"
+       },
+       "use_double_brackets": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "use_double_brackets",
+        "value": false,
+        "display_name": "Use Double Brackets",
+        "advanced": true,
+        "dynamic": false,
+        "info": "Use {{variable}} syntax instead of {variable}.",
+        "real_time_refresh": true,
+        "title_case": false,
+        "track_in_telemetry": true,
+        "type": "bool",
+        "_input_type": "BoolInput"
+       }
+      },
+      "description": "Create a prompt template with dynamic variables.",
+      "icon": "prompts",
+      "base_classes": [
+       "Message"
+      ],
+      "display_name": "Prompt Template",
+      "documentation": "https://docs.langflow.org/components-prompts",
+      "minimized": false,
+      "custom_fields": {
+       "template": [
+        "context"
+       ]
+      },
+      "output_types": [],
+      "pinned": false,
+      "conditional_paths": [],
+      "frozen": false,
+      "outputs": [
+       {
+        "types": [
+         "Message"
+        ],
+        "selected": "Message",
+        "name": "prompt",
+        "display_name": "Prompt",
+        "method": "build_prompt",
+        "value": "__UNDEFINED__",
+        "cache": true,
+        "allows_loop": false,
+        "group_outputs": false,
+        "tool_mode": true
+       }
+      ],
+      "field_order": [],
+      "beta": false,
+      "legacy": false,
+      "edited": false,
+      "metadata": {},
+      "tool_mode": false
+     },
+     "type": "Prompt Template",
+     "id": "Prompt-answer"
+    },
+    "id": "Prompt-answer",
+    "type": "genericNode",
+    "selected": false,
+    "position": {
+     "x": 900,
+     "y": 650
+    }
+   },
+   {
+    "data": {
+     "node": {
+      "template": {
+       "_type": "Component",
+       "api_key": {
+        "load_from_db": true,
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "api_key",
+        "value": "GOOGLE_API_KEY",
+        "display_name": "API Key",
+        "advanced": true,
+        "input_types": [],
+        "dynamic": false,
+        "info": "Falls back to GOOGLE_API_KEY environment variable",
+        "real_time_refresh": true,
+        "title_case": false,
+        "track_in_telemetry": false,
+        "password": true,
+        "type": "str",
+        "_input_type": "SecretStrInput"
+       },
+       "base_url_ibm_watsonx": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "options": [
+         "https://us-south.ml.cloud.ibm.com",
+         "https://eu-de.ml.cloud.ibm.com",
+         "https://eu-gb.ml.cloud.ibm.com",
+         "https://au-syd.ml.cloud.ibm.com",
+         "https://jp-tok.ml.cloud.ibm.com",
+         "https://ca-tor.ml.cloud.ibm.com"
+        ],
+        "options_metadata": [],
+        "combobox": true,
+        "dialog_inputs": {},
+        "toggle": false,
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": false,
+        "name": "base_url_ibm_watsonx",
+        "value": "https://us-south.ml.cloud.ibm.com",
+        "display_name": "watsonx API Endpoint",
+        "advanced": false,
+        "dynamic": false,
+        "info": "The base URL of the API (IBM watsonx.ai only)",
+        "real_time_refresh": true,
+        "title_case": false,
+        "track_in_telemetry": true,
+        "external_options": {},
+        "type": "str",
+        "_input_type": "DropdownInput"
+       },
+       "code": {
+        "type": "code",
+        "required": true,
+        "placeholder": "",
+        "list": false,
+        "show": true,
+        "multiline": true,
+        "value": "from lfx.base.models.model import LCModelComponent\nfrom lfx.base.models.unified_models import (\n    get_language_model_options,\n    get_llm,\n    handle_model_input_update,\n)\nfrom lfx.base.models.watsonx_constants import IBM_WATSONX_URLS\nfrom lfx.components.models_and_agents.model_selection import apply_model_overrides\nfrom lfx.field_typing.constants import LanguageModel\nfrom lfx.field_typing.range_spec import RangeSpec\nfrom lfx.inputs.inputs import BoolInput, DropdownInput, StrInput\nfrom lfx.io import IntInput, MessageInput, ModelInput, MultilineInput, SecretStrInput, SliderInput\n\nDEFAULT_OLLAMA_URL = \"http://localhost:11434\"\n\n\nclass LanguageModelComponent(LCModelComponent):\n    display_name = \"Language Model\"\n    description = \"Runs a language model given a specified provider.\"\n    documentation: str = \"https://docs.langflow.org/components-models\"\n    icon = \"brain-circuit\"\n    category = \"models\"\n\n    inputs = [\n        ModelInput(\n            name=\"model\",\n            display_name=\"Language Model\",\n            info=\"Select your model provider\",\n            real_time_refresh=True,\n            required=True,\n        ),\n        StrInput(\n            name=\"model_name\",\n            display_name=\"Model Name Override\",\n            info=(\n                \"Optional model name to use instead of the selected model. \"\n                \"Can be set from a global variable for runtime model selection.\"\n            ),\n            advanced=True,\n            load_from_db=False,\n        ),\n        StrInput(\n            name=\"provider\",\n            display_name=\"Provider Override\",\n            info=(\n                \"Optional provider to use with Model Name Override. Leave blank to use the selected model's provider.\"\n            ),\n            advanced=True,\n            load_from_db=False,\n        ),\n        SecretStrInput(\n            name=\"api_key\",\n            display_name=\"API Key\",\n            info=\"Overrides global provider settings. Leave blank to use your pre-configured API Key.\",\n            required=False,\n            show=True,\n            real_time_refresh=True,\n            advanced=True,\n        ),\n        DropdownInput(\n            name=\"base_url_ibm_watsonx\",\n            display_name=\"watsonx API Endpoint\",\n            info=\"The base URL of the API (IBM watsonx.ai only)\",\n            options=IBM_WATSONX_URLS,\n            value=IBM_WATSONX_URLS[0],\n            combobox=True,\n            show=False,\n            real_time_refresh=True,\n        ),\n        StrInput(\n            name=\"project_id\",\n            display_name=\"watsonx Project ID\",\n            info=\"The project ID associated with the foundation model (IBM watsonx.ai only)\",\n            show=False,\n            required=False,\n        ),\n        StrInput(\n            name=\"ollama_base_url\",\n            display_name=\"Ollama API URL\",\n            info=f\"Endpoint of the Ollama API (Ollama only). Defaults to {DEFAULT_OLLAMA_URL}\",\n            value=DEFAULT_OLLAMA_URL,\n            show=False,\n            real_time_refresh=True,\n        ),\n        MessageInput(\n            name=\"input_value\",\n            display_name=\"Input\",\n            info=\"The input text to send to the model\",\n        ),\n        MultilineInput(\n            name=\"system_message\",\n            display_name=\"System Message\",\n            info=\"A system message that helps set the behavior of the assistant\",\n            advanced=False,\n        ),\n        BoolInput(\n            name=\"stream\",\n            display_name=\"Stream\",\n            info=\"Whether to stream the response\",\n            value=False,\n            advanced=True,\n        ),\n        SliderInput(\n            name=\"temperature\",\n            display_name=\"Temperature\",\n            value=0.1,\n            info=\"Controls randomness in responses\",\n            range_spec=RangeSpec(min=0, max=1, step=0.01),\n            advanced=True,\n        ),\n        IntInput(\n            name=\"max_tokens\",\n            display_name=\"Max Tokens\",\n            info=\"Maximum number of tokens to generate. Field name varies by provider.\",\n            advanced=True,\n            range_spec=RangeSpec(min=1, max=128000, step=1, step_type=\"int\"),\n        ),\n    ]\n\n    def build_model(self) -> LanguageModel:\n        model = apply_model_overrides(\n            self.model,\n            model_name=getattr(self, \"model_name\", None),\n            provider=getattr(self, \"provider\", None),\n            user_id=self.user_id,\n            get_options=get_language_model_options,\n        )\n        return get_llm(\n            model=model,\n            user_id=self.user_id,\n            api_key=self.api_key,\n            temperature=self.temperature,\n            stream=self.stream,\n            max_tokens=getattr(self, \"max_tokens\", None),\n            watsonx_url=getattr(self, \"base_url_ibm_watsonx\", None),\n            watsonx_project_id=getattr(self, \"project_id\", None),\n            ollama_base_url=getattr(self, \"ollama_base_url\", None),\n        )\n\n    def update_build_config(self, build_config: dict, field_value: str, field_name: str | None = None):\n        \"\"\"Dynamically update build config with user-filtered model options.\"\"\"\n        return handle_model_input_update(self, build_config, field_value, field_name)\n",
+        "fileTypes": [],
+        "file_path": "",
+        "password": false,
+        "name": "code",
+        "advanced": true,
+        "dynamic": true,
+        "info": "",
+        "load_from_db": false,
+        "title_case": false
+       },
+       "input_value": {
+        "trace_as_input": true,
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "load_from_db": false,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "input_value",
+        "value": {
+         "text_key": "text",
+         "data": {
+          "text": "",
+          "files": [],
+          "sender": null,
+          "sender_name": null,
+          "session_id": "",
+          "context_id": "",
+          "run_id": null,
+          "timestamp": "2026-07-15 03:55:07.261020 UTC",
+          "flow_id": null,
+          "error": false,
+          "edit": false,
+          "properties": {
+           "edited": false,
+           "source": {
+            "id": null,
+            "display_name": null,
+            "source": null
+           },
+           "allow_markdown": false,
+           "state": "complete",
+           "targets": []
+          },
+          "category": "message",
+          "content_blocks": [],
+          "duration": null,
+          "session_metadata": null
+         },
+         "default_value": "",
+         "files": [],
+         "session_id": "",
+         "context_id": "",
+         "timestamp": "2026-07-15 03:55:07.261020 UTC",
+         "error": false,
+         "edit": false,
+         "properties": {
+          "edited": false,
+          "source": {
+           "id": null,
+           "display_name": null,
+           "source": null
+          },
+          "allow_markdown": false,
+          "state": "complete",
+          "targets": []
+         },
+         "category": "message",
+         "content_blocks": [],
+         "text": ""
+        },
+        "display_name": "Input",
+        "advanced": false,
+        "input_types": [
+         "Message"
+        ],
+        "dynamic": false,
+        "info": "The input text to send to the model",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "str",
+        "_input_type": "MessageInput"
+       },
+       "max_tokens": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "range_spec": {
+         "step_type": "int",
+         "min": 1,
+         "max": 128000,
+         "step": 1
+        },
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "max_tokens",
+        "value": 0,
+        "display_name": "Max Tokens",
+        "advanced": true,
+        "dynamic": false,
+        "info": "Maximum number of tokens to generate. Field name varies by provider.",
+        "title_case": false,
+        "track_in_telemetry": true,
+        "type": "int",
+        "_input_type": "IntInput"
+       },
+       "model": {
+        "tool_mode": false,
+        "trace_as_input": true,
+        "list": false,
+        "list_add_label": "Add More",
+        "model_type": "language",
+        "external_options": {
+         "fields": {
+          "data": {
+           "node": {
+            "name": "connect_other_models",
+            "display_name": "Connect other models",
+            "icon": "CornerDownLeft"
+           }
+          }
+         }
+        },
+        "override_skip": false,
+        "required": true,
+        "placeholder": "Setup Provider",
+        "show": true,
+        "name": "model",
+        "display_name": "Language Model",
+        "advanced": false,
+        "input_types": [
+         "LanguageModel"
+        ],
+        "dynamic": false,
+        "info": "Select your model provider",
+        "real_time_refresh": true,
+        "refresh_button": true,
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "model",
+        "_input_type": "ModelInput",
+        "options": [
+         {
+          "name": "claude-sonnet-5",
+          "icon": "Anthropic",
+          "category": "Anthropic",
+          "provider": "Anthropic",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatAnthropic",
+           "model_name_param": "model",
+           "api_key_param": "api_key",
+           "max_tokens_field_name": "max_tokens"
+          }
+         },
+         {
+          "name": "claude-fable-5",
+          "icon": "Anthropic",
+          "category": "Anthropic",
+          "provider": "Anthropic",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatAnthropic",
+           "model_name_param": "model",
+           "api_key_param": "api_key",
+           "max_tokens_field_name": "max_tokens"
+          }
+         },
+         {
+          "name": "claude-opus-4-8",
+          "icon": "Anthropic",
+          "category": "Anthropic",
+          "provider": "Anthropic",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatAnthropic",
+           "model_name_param": "model",
+           "api_key_param": "api_key",
+           "max_tokens_field_name": "max_tokens"
+          }
+         },
+         {
+          "name": "claude-opus-4-7",
+          "icon": "Anthropic",
+          "category": "Anthropic",
+          "provider": "Anthropic",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatAnthropic",
+           "model_name_param": "model",
+           "api_key_param": "api_key",
+           "max_tokens_field_name": "max_tokens"
+          }
+         },
+         {
+          "name": "claude-sonnet-4-6",
+          "icon": "Anthropic",
+          "category": "Anthropic",
+          "provider": "Anthropic",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatAnthropic",
+           "model_name_param": "model",
+           "api_key_param": "api_key",
+           "max_tokens_field_name": "max_tokens"
+          }
+         },
+         {
+          "name": "claude-opus-4-6",
+          "icon": "Anthropic",
+          "category": "Anthropic",
+          "provider": "Anthropic",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatAnthropic",
+           "model_name_param": "model",
+           "api_key_param": "api_key",
+           "max_tokens_field_name": "max_tokens"
+          }
+         },
+         {
+          "name": "claude-opus-4-5",
+          "icon": "Anthropic",
+          "category": "Anthropic",
+          "provider": "Anthropic",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatAnthropic",
+           "model_name_param": "model",
+           "api_key_param": "api_key",
+           "max_tokens_field_name": "max_tokens"
+          }
+         },
+         {
+          "name": "claude-haiku-4-5",
+          "icon": "Anthropic",
+          "category": "Anthropic",
+          "provider": "Anthropic",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatAnthropic",
+           "model_name_param": "model",
+           "api_key_param": "api_key",
+           "max_tokens_field_name": "max_tokens"
+          }
+         },
+         {
+          "name": "claude-sonnet-4-5",
+          "icon": "Anthropic",
+          "category": "Anthropic",
+          "provider": "Anthropic",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatAnthropic",
+           "model_name_param": "model",
+           "api_key_param": "api_key",
+           "max_tokens_field_name": "max_tokens"
+          }
+         },
+         {
+          "name": "claude-opus-4-1",
+          "icon": "Anthropic",
+          "category": "Anthropic",
+          "provider": "Anthropic",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatAnthropic",
+           "model_name_param": "model",
+           "api_key_param": "api_key",
+           "max_tokens_field_name": "max_tokens"
+          }
+         },
+         {
+          "name": "claude-opus-4-20250514",
+          "icon": "Anthropic",
+          "category": "Anthropic",
+          "provider": "Anthropic",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatAnthropic",
+           "model_name_param": "model",
+           "api_key_param": "api_key",
+           "max_tokens_field_name": "max_tokens"
+          }
+         },
+         {
+          "name": "claude-sonnet-4-20250514",
+          "icon": "Anthropic",
+          "category": "Anthropic",
+          "provider": "Anthropic",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatAnthropic",
+           "model_name_param": "model",
+           "api_key_param": "api_key",
+           "max_tokens_field_name": "max_tokens"
+          }
+         },
+         {
+          "name": "gpt-5.6",
+          "icon": "OpenAI",
+          "category": "OpenAI",
+          "provider": "OpenAI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatOpenAI",
+           "model_name_param": "model",
+           "api_key_param": "api_key",
+           "max_tokens_field_name": "max_tokens",
+           "reasoning_models": [
+            "gpt-5.6"
+           ]
+          }
+         },
+         {
+          "name": "gpt-5.6-luna",
+          "icon": "OpenAI",
+          "category": "OpenAI",
+          "provider": "OpenAI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatOpenAI",
+           "model_name_param": "model",
+           "api_key_param": "api_key",
+           "max_tokens_field_name": "max_tokens",
+           "reasoning_models": [
+            "gpt-5.6-luna"
+           ]
+          }
+         },
+         {
+          "name": "gpt-5.6-terra",
+          "icon": "OpenAI",
+          "category": "OpenAI",
+          "provider": "OpenAI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatOpenAI",
+           "model_name_param": "model",
+           "api_key_param": "api_key",
+           "max_tokens_field_name": "max_tokens",
+           "reasoning_models": [
+            "gpt-5.6-terra"
+           ]
+          }
+         },
+         {
+          "name": "gpt-5.6-sol",
+          "icon": "OpenAI",
+          "category": "OpenAI",
+          "provider": "OpenAI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatOpenAI",
+           "model_name_param": "model",
+           "api_key_param": "api_key",
+           "max_tokens_field_name": "max_tokens",
+           "reasoning_models": [
+            "gpt-5.6-sol"
+           ]
+          }
+         },
+         {
+          "name": "gpt-realtime-2.1",
+          "icon": "OpenAI",
+          "category": "OpenAI",
+          "provider": "OpenAI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatOpenAI",
+           "model_name_param": "model",
+           "api_key_param": "api_key",
+           "max_tokens_field_name": "max_tokens",
+           "reasoning_models": [
+            "gpt-realtime-2.1"
+           ]
+          }
+         },
+         {
+          "name": "gemini-omni-flash-preview",
+          "icon": "GoogleGenerativeAI",
+          "category": "Google Generative AI",
+          "provider": "Google Generative AI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatGoogleGenerativeAIFixed",
+           "model_name_param": "model",
+           "api_key_param": "google_api_key",
+           "max_tokens_field_name": "max_output_tokens"
+          }
+         },
+         {
+          "name": "gemini-3.5-flash",
+          "icon": "GoogleGenerativeAI",
+          "category": "Google Generative AI",
+          "provider": "Google Generative AI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatGoogleGenerativeAIFixed",
+           "model_name_param": "model",
+           "api_key_param": "google_api_key",
+           "max_tokens_field_name": "max_output_tokens"
+          }
+         },
+         {
+          "name": "gemini-3.1-flash-lite",
+          "icon": "GoogleGenerativeAI",
+          "category": "Google Generative AI",
+          "provider": "Google Generative AI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatGoogleGenerativeAIFixed",
+           "model_name_param": "model",
+           "api_key_param": "google_api_key",
+           "max_tokens_field_name": "max_output_tokens"
+          }
+         },
+         {
+          "name": "gemma-4-31b-it",
+          "icon": "GoogleGenerativeAI",
+          "category": "Google Generative AI",
+          "provider": "Google Generative AI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatGoogleGenerativeAIFixed",
+           "model_name_param": "model",
+           "api_key_param": "google_api_key",
+           "max_tokens_field_name": "max_output_tokens"
+          }
+         },
+         {
+          "name": "gemma-4-26b-a4b-it",
+          "icon": "GoogleGenerativeAI",
+          "category": "Google Generative AI",
+          "provider": "Google Generative AI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatGoogleGenerativeAIFixed",
+           "model_name_param": "model",
+           "api_key_param": "google_api_key",
+           "max_tokens_field_name": "max_output_tokens"
+          }
+         },
+         {
+          "name": "gemini-3.1-flash-lite-preview",
+          "icon": "GoogleGenerativeAI",
+          "category": "Google Generative AI",
+          "provider": "Google Generative AI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatGoogleGenerativeAIFixed",
+           "model_name_param": "model",
+           "api_key_param": "google_api_key",
+           "max_tokens_field_name": "max_output_tokens"
+          }
+         },
+         {
+          "name": "gemini-3.1-flash-image-preview",
+          "icon": "GoogleGenerativeAI",
+          "category": "Google Generative AI",
+          "provider": "Google Generative AI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatGoogleGenerativeAIFixed",
+           "model_name_param": "model",
+           "api_key_param": "google_api_key",
+           "max_tokens_field_name": "max_output_tokens"
+          }
+         },
+         {
+          "name": "gemini-3.1-pro-preview-customtools",
+          "icon": "GoogleGenerativeAI",
+          "category": "Google Generative AI",
+          "provider": "Google Generative AI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatGoogleGenerativeAIFixed",
+           "model_name_param": "model",
+           "api_key_param": "google_api_key",
+           "max_tokens_field_name": "max_output_tokens"
+          }
+         },
+         {
+          "name": "gemini-3.1-pro-preview",
+          "icon": "GoogleGenerativeAI",
+          "category": "Google Generative AI",
+          "provider": "Google Generative AI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatGoogleGenerativeAIFixed",
+           "model_name_param": "model",
+           "api_key_param": "google_api_key",
+           "max_tokens_field_name": "max_output_tokens"
+          }
+         },
+         {
+          "name": "gemini-3-flash-preview",
+          "icon": "GoogleGenerativeAI",
+          "category": "Google Generative AI",
+          "provider": "Google Generative AI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatGoogleGenerativeAIFixed",
+           "model_name_param": "model",
+           "api_key_param": "google_api_key",
+           "max_tokens_field_name": "max_output_tokens"
+          }
+         },
+         {
+          "name": "gemini-3-pro-image-preview",
+          "icon": "GoogleGenerativeAI",
+          "category": "Google Generative AI",
+          "provider": "Google Generative AI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatGoogleGenerativeAIFixed",
+           "model_name_param": "model",
+           "api_key_param": "google_api_key",
+           "max_tokens_field_name": "max_output_tokens"
+          }
+         },
+         {
+          "name": "gemini-3-pro-preview",
+          "icon": "GoogleGenerativeAI",
+          "category": "Google Generative AI",
+          "provider": "Google Generative AI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatGoogleGenerativeAIFixed",
+           "model_name_param": "model",
+           "api_key_param": "google_api_key",
+           "max_tokens_field_name": "max_output_tokens"
+          }
+         },
+         {
+          "name": "gemini-flash-lite-latest",
+          "icon": "GoogleGenerativeAI",
+          "category": "Google Generative AI",
+          "provider": "Google Generative AI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatGoogleGenerativeAIFixed",
+           "model_name_param": "model",
+           "api_key_param": "google_api_key",
+           "max_tokens_field_name": "max_output_tokens"
+          }
+         },
+         {
+          "name": "gemini-flash-latest",
+          "icon": "GoogleGenerativeAI",
+          "category": "Google Generative AI",
+          "provider": "Google Generative AI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatGoogleGenerativeAIFixed",
+           "model_name_param": "model",
+           "api_key_param": "google_api_key",
+           "max_tokens_field_name": "max_output_tokens"
+          }
+         },
+         {
+          "name": "gemini-2.5-flash-image",
+          "icon": "GoogleGenerativeAI",
+          "category": "Google Generative AI",
+          "provider": "Google Generative AI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatGoogleGenerativeAIFixed",
+           "model_name_param": "model",
+           "api_key_param": "google_api_key",
+           "max_tokens_field_name": "max_output_tokens"
+          }
+         },
+         {
+          "name": "gemini-2.5-pro",
+          "icon": "GoogleGenerativeAI",
+          "category": "Google Generative AI",
+          "provider": "Google Generative AI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatGoogleGenerativeAIFixed",
+           "model_name_param": "model",
+           "api_key_param": "google_api_key",
+           "max_tokens_field_name": "max_output_tokens"
+          }
+         },
+         {
+          "name": "gemini-2.5-flash",
+          "icon": "GoogleGenerativeAI",
+          "category": "Google Generative AI",
+          "provider": "Google Generative AI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatGoogleGenerativeAIFixed",
+           "model_name_param": "model",
+           "api_key_param": "google_api_key",
+           "max_tokens_field_name": "max_output_tokens"
+          }
+         },
+         {
+          "name": "gemini-2.5-flash-lite",
+          "icon": "GoogleGenerativeAI",
+          "category": "Google Generative AI",
+          "provider": "Google Generative AI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatGoogleGenerativeAIFixed",
+           "model_name_param": "model",
+           "api_key_param": "google_api_key",
+           "max_tokens_field_name": "max_output_tokens"
+          }
+         },
+         {
+          "name": "gemini-2.5-flash-preview-tts",
+          "icon": "GoogleGenerativeAI",
+          "category": "Google Generative AI",
+          "provider": "Google Generative AI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatGoogleGenerativeAIFixed",
+           "model_name_param": "model",
+           "api_key_param": "google_api_key",
+           "max_tokens_field_name": "max_output_tokens"
+          }
+         },
+         {
+          "name": "gemini-2.5-pro-preview-tts",
+          "icon": "GoogleGenerativeAI",
+          "category": "Google Generative AI",
+          "provider": "Google Generative AI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatGoogleGenerativeAIFixed",
+           "model_name_param": "model",
+           "api_key_param": "google_api_key",
+           "max_tokens_field_name": "max_output_tokens"
+          }
+         },
+         {
+          "name": "gemini-2.5-flash-preview-09-2025",
+          "icon": "GoogleGenerativeAI",
+          "category": "Google Generative AI",
+          "provider": "Google Generative AI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatGoogleGenerativeAIFixed",
+           "model_name_param": "model",
+           "api_key_param": "google_api_key",
+           "max_tokens_field_name": "max_output_tokens"
+          }
+         },
+         {
+          "name": "gemini-2.5-flash-lite-preview-09-2025",
+          "icon": "GoogleGenerativeAI",
+          "category": "Google Generative AI",
+          "provider": "Google Generative AI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatGoogleGenerativeAIFixed",
+           "model_name_param": "model",
+           "api_key_param": "google_api_key",
+           "max_tokens_field_name": "max_output_tokens"
+          }
+         }
+        ],
+        "value": [
+         {
+          "name": "gemini-2.5-flash",
+          "icon": "GoogleGenerativeAI",
+          "provider": "Google Generative AI",
+          "metadata": {
+           "context_length": 128000,
+           "model_class": "ChatGoogleGenerativeAIFixed",
+           "model_name_param": "model",
+           "api_key_param": "google_api_key",
+           "max_tokens_field_name": "max_output_tokens"
+          }
+         }
+        ]
+       },
+       "model_name": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "load_from_db": false,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "model_name",
+        "value": "gemini-2.5-flash",
+        "display_name": "Model Name Override",
+        "advanced": true,
+        "dynamic": false,
+        "info": "Optional model name to use instead of the selected model. Can be set from a global variable for runtime model selection.",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "str",
+        "_input_type": "StrInput",
+        "options": [
+         "gemini-2.5-flash"
+        ]
+       },
+       "ollama_base_url": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "load_from_db": false,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": false,
+        "name": "ollama_base_url",
+        "value": "http://localhost:11434",
+        "display_name": "Ollama API URL",
+        "advanced": false,
+        "dynamic": false,
+        "info": "Endpoint of the Ollama API (Ollama only). Defaults to http://localhost:11434",
+        "real_time_refresh": true,
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "str",
+        "_input_type": "StrInput"
+       },
+       "project_id": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "load_from_db": false,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": false,
+        "name": "project_id",
+        "value": "",
+        "display_name": "watsonx Project ID",
+        "advanced": false,
+        "dynamic": false,
+        "info": "The project ID associated with the foundation model (IBM watsonx.ai only)",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "str",
+        "_input_type": "StrInput"
+       },
+       "provider": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "load_from_db": false,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "provider",
+        "value": "Google Generative AI",
+        "display_name": "Provider Override",
+        "advanced": true,
+        "dynamic": false,
+        "info": "Optional provider to use with Model Name Override. Leave blank to use the selected model's provider.",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "str",
+        "_input_type": "StrInput",
+        "options": [
+         "Google Generative AI"
+        ]
+       },
+       "stream": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "stream",
+        "value": false,
+        "display_name": "Stream",
+        "advanced": true,
+        "dynamic": false,
+        "info": "Whether to stream the response",
+        "title_case": false,
+        "track_in_telemetry": true,
+        "type": "bool",
+        "_input_type": "BoolInput"
+       },
+       "system_message": {
+        "tool_mode": false,
+        "trace_as_input": true,
+        "multiline": true,
+        "ai_enabled": false,
+        "trace_as_metadata": true,
+        "load_from_db": false,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "system_message",
+        "value": "",
+        "display_name": "System Message",
+        "advanced": false,
+        "input_types": [
+         "Message"
+        ],
+        "dynamic": false,
+        "info": "A system message that helps set the behavior of the assistant",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "copy_field": false,
+        "password": false,
+        "type": "str",
+        "_input_type": "MultilineInput"
+       },
+       "temperature": {
+        "tool_mode": false,
+        "min_label": "",
+        "max_label": "",
+        "min_label_icon": "",
+        "max_label_icon": "",
+        "slider_buttons": false,
+        "slider_buttons_options": [],
+        "slider_input": false,
+        "range_spec": {
+         "step_type": "float",
+         "min": 0,
+         "max": 1,
+         "step": 0.01
+        },
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "temperature",
+        "value": 0,
+        "display_name": "Temperature",
+        "advanced": true,
+        "dynamic": false,
+        "info": "Controls randomness in responses",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "slider",
+        "_input_type": "SliderInput"
+       },
+       "_frontend_node_flow_id": {
+        "value": "5d00c69b-a893-44ab-80e8-fda8ae96188b"
+       },
+       "_frontend_node_folder_id": {
+        "value": "50c46771-d71e-47f4-b62a-068e2fe5ef85"
+       },
+       "is_refresh": false
+      },
+      "description": "Runs a language model given a specified provider.",
+      "icon": "brain-circuit",
+      "base_classes": [
+       "LanguageModel",
+       "Message"
+      ],
+      "display_name": "Language Model",
+      "documentation": "https://docs.langflow.org/components-models",
+      "minimized": false,
+      "custom_fields": {},
+      "output_types": [],
+      "pinned": false,
+      "conditional_paths": [],
+      "frozen": false,
+      "outputs": [
+       {
+        "types": [
+         "Message"
+        ],
+        "selected": "Message",
+        "name": "text_output",
+        "hidden": null,
+        "display_name": "Model Response",
+        "method": "text_response",
+        "value": "__UNDEFINED__",
+        "cache": true,
+        "required_inputs": null,
+        "allows_loop": false,
+        "loop_types": null,
+        "group_outputs": false,
+        "options": null,
+        "tool_mode": true
+       },
+       {
+        "types": [
+         "LanguageModel"
+        ],
+        "selected": "LanguageModel",
+        "name": "model_output",
+        "hidden": null,
+        "display_name": "Language Model",
+        "method": "build_model",
+        "value": "__UNDEFINED__",
+        "cache": true,
+        "required_inputs": null,
+        "allows_loop": false,
+        "loop_types": null,
+        "group_outputs": false,
+        "options": null,
+        "tool_mode": true
+       }
+      ],
+      "field_order": [],
+      "beta": false,
+      "legacy": false,
+      "edited": false,
+      "metadata": {
+       "keywords": [
+        "model",
+        "llm",
+        "language model",
+        "large language model"
+       ]
+      },
+      "tool_mode": false,
+      "last_updated": "2026-07-15T04:21:17.248Z"
+     },
+     "type": "LanguageModelComponent",
+     "id": "LanguageModel-answer",
+     "selected_output": "text_output",
+     "_connectionMode": false
+    },
+    "id": "LanguageModel-answer",
+    "type": "genericNode",
+    "selected": true,
+    "position": {
+     "x": 1350,
+     "y": 650
+    },
+    "measured": {
+     "width": 320,
+     "height": 371
+    }
+   },
+   {
+    "data": {
+     "node": {
+      "template": {
+       "_type": "Component",
+       "input_value": {
+        "trace_as_metadata": true,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": true,
+        "placeholder": "",
+        "show": true,
+        "name": "input_value",
+        "value": "",
+        "display_name": "Inputs",
+        "advanced": false,
+        "input_types": [
+         "Data",
+         "JSON",
+         "DataFrame",
+         "Table",
+         "Message"
+        ],
+        "dynamic": false,
+        "info": "Message to be passed as output.",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "other",
+        "_input_type": "HandleInput"
+       },
+       "clean_data": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "clean_data",
+        "value": true,
+        "display_name": "Basic Clean Data",
+        "advanced": true,
+        "dynamic": false,
+        "info": "Whether to clean data before converting to string.",
+        "title_case": false,
+        "track_in_telemetry": true,
+        "type": "bool",
+        "_input_type": "BoolInput"
+       },
+       "code": {
+        "type": "code",
+        "required": true,
+        "placeholder": "",
+        "list": false,
+        "show": true,
+        "multiline": true,
+        "value": "from collections.abc import Generator\nfrom typing import Any\n\nimport orjson\nfrom fastapi.encoders import jsonable_encoder\n\nfrom lfx.base.io.chat import ChatComponent\nfrom lfx.helpers.data import safe_convert\nfrom lfx.inputs.inputs import BoolInput, DropdownInput, HandleInput, MessageTextInput\nfrom lfx.schema.data import Data\nfrom lfx.schema.dataframe import DataFrame\nfrom lfx.schema.message import Message\nfrom lfx.schema.properties import Source\nfrom lfx.template.field.base import Output\nfrom lfx.utils.constants import (\n    MESSAGE_SENDER_AI,\n    MESSAGE_SENDER_NAME_AI,\n    MESSAGE_SENDER_USER,\n)\n\n\nclass ChatOutput(ChatComponent):\n    display_name = \"Chat Output\"\n    description = \"Display a chat message in the Playground.\"\n    documentation: str = \"https://docs.langflow.org/chat-input-and-output\"\n    icon = \"MessagesSquare\"\n    name = \"ChatOutput\"\n    minimized = True\n\n    inputs = [\n        HandleInput(\n            name=\"input_value\",\n            display_name=\"Inputs\",\n            info=\"Message to be passed as output.\",\n            input_types=[\"Data\", \"JSON\", \"DataFrame\", \"Table\", \"Message\"],\n            required=True,\n        ),\n        BoolInput(\n            name=\"should_store_message\",\n            display_name=\"Store Messages\",\n            info=\"Store the message in the history.\",\n            value=True,\n            advanced=True,\n        ),\n        DropdownInput(\n            name=\"sender\",\n            display_name=\"Sender Type\",\n            options=[MESSAGE_SENDER_AI, MESSAGE_SENDER_USER],\n            value=MESSAGE_SENDER_AI,\n            advanced=True,\n            info=\"Type of sender.\",\n        ),\n        MessageTextInput(\n            name=\"sender_name\",\n            display_name=\"Sender Name\",\n            info=\"Name of the sender.\",\n            value=MESSAGE_SENDER_NAME_AI,\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"session_id\",\n            display_name=\"Session ID\",\n            info=\"The session ID of the chat. If empty, the current session ID parameter will be used.\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"context_id\",\n            display_name=\"Context ID\",\n            info=\"The context ID of the chat. Adds an extra layer to the local memory.\",\n            value=\"\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"data_template\",\n            display_name=\"Data Template\",\n            value=\"{text}\",\n            advanced=True,\n            info=\"Template to convert Data to Text. If left empty, it will be dynamically set to the Data's text key.\",\n        ),\n        BoolInput(\n            name=\"clean_data\",\n            display_name=\"Basic Clean Data\",\n            value=True,\n            advanced=True,\n            info=\"Whether to clean data before converting to string.\",\n        ),\n    ]\n    outputs = [\n        Output(\n            display_name=\"Output Message\",\n            name=\"message\",\n            method=\"message_response\",\n        ),\n    ]\n\n    def _build_source(self, id_: str | None, display_name: str | None, source: str | None) -> Source:\n        source_dict = {}\n        if id_:\n            source_dict[\"id\"] = id_\n        if display_name:\n            source_dict[\"display_name\"] = display_name\n        if source:\n            # Handle case where source is a ChatOpenAI object\n            if hasattr(source, \"model_name\"):\n                source_dict[\"source\"] = source.model_name\n            elif hasattr(source, \"model\"):\n                source_dict[\"source\"] = str(source.model)\n            else:\n                source_dict[\"source\"] = str(source)\n        return Source(**source_dict)\n\n    async def message_response(self) -> Message:\n        # First convert the input to string if needed\n        text = self.convert_to_string()\n\n        # Get source properties\n        source, _, display_name, source_id = self.get_properties_from_source_component()\n\n        # Create or use existing Message object\n        if isinstance(self.input_value, Message) and not self.is_connected_to_chat_input():\n            message = self.input_value\n            # Update message properties\n            message.text = text\n            # Preserve existing session_id from the incoming message if it exists\n            existing_session_id = message.session_id\n        else:\n            message = Message(text=text)\n            existing_session_id = None\n\n        # Set message properties\n        message.sender = self.sender\n        message.sender_name = self.sender_name\n        # Preserve session_id from incoming message, or use component/graph session_id\n        message.session_id = (\n            self.session_id or existing_session_id or (self.graph.session_id if hasattr(self, \"graph\") else None) or \"\"\n        )\n        message.context_id = self.context_id\n        message.flow_id = self.graph.flow_id if hasattr(self, \"graph\") else None\n        message.properties.source = self._build_source(source_id, display_name, source)\n\n        # Store message if needed\n        if message.session_id and self.should_store_message:\n            stored_message = await self.send_message(message)\n            self.message.value = stored_message\n            message = stored_message\n\n        # Set accumulated token usage from all upstream LLM vertices.\n        # This must happen AFTER send_message() because streaming captures\n        # usage from chunks and would overwrite accumulated totals.\n        if hasattr(self, \"_vertex\") and self._vertex is not None:\n            accumulated_usage = self._vertex._accumulate_upstream_token_usage()  # noqa: SLF001\n            if accumulated_usage:\n                message.properties.usage = accumulated_usage\n                if self.should_store_message and message.get_id():\n                    message = await self._update_stored_message(message)\n                    await self._send_message_event(message, id_=message.get_id())\n\n        self.status = message\n        return message\n\n    def _serialize_data(self, data: Data) -> str:\n        \"\"\"Serialize Data object to JSON string.\"\"\"\n        # Convert data.data to JSON-serializable format\n        serializable_data = jsonable_encoder(data.data)\n        # Serialize with orjson, enabling pretty printing with indentation\n        json_bytes = orjson.dumps(serializable_data, option=orjson.OPT_INDENT_2)\n        # Convert bytes to string and wrap in Markdown code blocks\n        return \"```json\\n\" + json_bytes.decode(\"utf-8\") + \"\\n```\"\n\n    def _validate_input(self) -> None:\n        \"\"\"Validate the input data and raise ValueError if invalid.\"\"\"\n        if self.input_value is None:\n            msg = \"Input data cannot be None\"\n            raise ValueError(msg)\n        if isinstance(self.input_value, list) and not all(\n            isinstance(item, Message | Data | DataFrame | str) for item in self.input_value\n        ):\n            invalid_types = [\n                type(item).__name__\n                for item in self.input_value\n                if not isinstance(item, Message | Data | DataFrame | str)\n            ]\n            msg = f\"Expected Data or DataFrame or Message or str, got {invalid_types}\"\n            raise TypeError(msg)\n        if not isinstance(\n            self.input_value,\n            Message | Data | DataFrame | str | list | Generator | type(None),\n        ):\n            type_name = type(self.input_value).__name__\n            msg = f\"Expected Data or DataFrame or Message or str, Generator or None, got {type_name}\"\n            raise TypeError(msg)\n\n    def convert_to_string(self) -> str | Generator[Any, None, None]:\n        \"\"\"Convert input data to string with proper error handling.\"\"\"\n        self._validate_input()\n        if isinstance(self.input_value, list):\n            clean_data: bool = getattr(self, \"clean_data\", False)\n            return \"\\n\".join([safe_convert(item, clean_data=clean_data) for item in self.input_value])\n        if isinstance(self.input_value, Generator):\n            return self.input_value\n        return safe_convert(self.input_value)\n",
+        "fileTypes": [],
+        "file_path": "",
+        "password": false,
+        "name": "code",
+        "advanced": true,
+        "dynamic": true,
+        "info": "",
+        "load_from_db": false,
+        "title_case": false
+       },
+       "context_id": {
+        "tool_mode": false,
+        "trace_as_input": true,
+        "trace_as_metadata": true,
+        "load_from_db": false,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "context_id",
+        "value": "",
+        "display_name": "Context ID",
+        "advanced": true,
+        "input_types": [
+         "Message"
+        ],
+        "dynamic": false,
+        "info": "The context ID of the chat. Adds an extra layer to the local memory.",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "str",
+        "_input_type": "MessageTextInput"
+       },
+       "data_template": {
+        "tool_mode": false,
+        "trace_as_input": true,
+        "trace_as_metadata": true,
+        "load_from_db": false,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "data_template",
+        "value": "{text}",
+        "display_name": "Data Template",
+        "advanced": true,
+        "input_types": [
+         "Message"
+        ],
+        "dynamic": false,
+        "info": "Template to convert Data to Text. If left empty, it will be dynamically set to the Data's text key.",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "str",
+        "_input_type": "MessageTextInput"
+       },
+       "sender": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "options": [
+         "Machine",
+         "User"
+        ],
+        "options_metadata": [],
+        "combobox": false,
+        "dialog_inputs": {},
+        "toggle": false,
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "sender",
+        "value": "Machine",
+        "display_name": "Sender Type",
+        "advanced": true,
+        "dynamic": false,
+        "info": "Type of sender.",
+        "title_case": false,
+        "track_in_telemetry": true,
+        "external_options": {},
+        "type": "str",
+        "_input_type": "DropdownInput"
+       },
+       "sender_name": {
+        "tool_mode": false,
+        "trace_as_input": true,
+        "trace_as_metadata": true,
+        "load_from_db": false,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "sender_name",
+        "value": "AI",
+        "display_name": "Sender Name",
+        "advanced": true,
+        "input_types": [
+         "Message"
+        ],
+        "dynamic": false,
+        "info": "Name of the sender.",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "str",
+        "_input_type": "MessageTextInput"
+       },
+       "session_id": {
+        "tool_mode": false,
+        "trace_as_input": true,
+        "trace_as_metadata": true,
+        "load_from_db": false,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "session_id",
+        "value": "",
+        "display_name": "Session ID",
+        "advanced": true,
+        "input_types": [
+         "Message"
+        ],
+        "dynamic": false,
+        "info": "The session ID of the chat. If empty, the current session ID parameter will be used.",
+        "title_case": false,
+        "track_in_telemetry": false,
+        "type": "str",
+        "_input_type": "MessageTextInput"
+       },
+       "should_store_message": {
+        "tool_mode": false,
+        "trace_as_metadata": true,
+        "list": false,
+        "list_add_label": "Add More",
+        "override_skip": false,
+        "required": false,
+        "placeholder": "",
+        "show": true,
+        "name": "should_store_message",
+        "value": true,
+        "display_name": "Store Messages",
+        "advanced": true,
+        "dynamic": false,
+        "info": "Store the message in the history.",
+        "title_case": false,
+        "track_in_telemetry": true,
+        "type": "bool",
+        "_input_type": "BoolInput"
+       }
+      },
+      "description": "Display a chat message in the Playground.",
+      "icon": "MessagesSquare",
+      "base_classes": [
+       "Message"
+      ],
+      "display_name": "Chat Output",
+      "documentation": "https://docs.langflow.org/chat-input-and-output",
+      "minimized": true,
+      "custom_fields": {},
+      "output_types": [],
+      "pinned": false,
+      "conditional_paths": [],
+      "frozen": false,
+      "outputs": [
+       {
+        "types": [
+         "Message"
+        ],
+        "selected": "Message",
+        "name": "message",
+        "display_name": "Output Message",
+        "method": "message_response",
+        "value": "__UNDEFINED__",
+        "cache": true,
+        "allows_loop": false,
+        "group_outputs": false,
+        "tool_mode": true
+       }
+      ],
+      "field_order": [],
+      "beta": false,
+      "legacy": false,
+      "edited": false,
+      "metadata": {},
+      "tool_mode": false
+     },
+     "type": "ChatOutput",
+     "id": "ChatOutput-answer"
+    },
+    "id": "ChatOutput-answer",
+    "type": "genericNode",
+    "selected": false,
+    "position": {
+     "x": 1800,
+     "y": 650
+    }
+   }
+  ],
+  "edges": [
+   {
+    "source": "ChatInput-doc01",
+    "target": "SplitText-doc01",
+    "sourceHandle": "{œdataTypeœ:œChatInputœ,œidœ:œChatInput-doc01œ,œnameœ:œmessageœ,œoutput_typesœ:[œMessageœ]}",
+    "targetHandle": "{œfieldNameœ:œdata_inputsœ,œidœ:œSplitText-doc01œ,œinputTypesœ:[œDataœ,œJSONœ,œDataFrameœ,œTableœ,œMessageœ],œtypeœ:œotherœ}",
+    "data": {
+     "sourceHandle": {
+      "dataType": "ChatInput",
+      "id": "ChatInput-doc01",
+      "name": "message",
+      "output_types": [
+       "Message"
+      ]
+     },
+     "targetHandle": {
+      "fieldName": "data_inputs",
+      "id": "SplitText-doc01",
+      "inputTypes": [
+       "Data",
+       "JSON",
+       "DataFrame",
+       "Table",
+       "Message"
+      ],
+      "type": "other"
+     }
+    },
+    "id": "reactflow__edge-ChatInput-doc01{œdataTypeœ:œChatInputœ,œidœ:œChatInput-doc01œ,œnameœ:œmessageœ,œoutput_typesœ:[œMessageœ]}-SplitText-doc01{œfieldNameœ:œdata_inputsœ,œidœ:œSplitText-doc01œ,œinputTypesœ:[œDataœ,œJSONœ,œDataFrameœ,œTableœ,œMessageœ],œtypeœ:œotherœ}",
+    "animated": false,
+    "className": "",
+    "selected": false
+   },
+   {
+    "source": "SplitText-doc01",
+    "sourceHandle": "{œdataTypeœ:œSplitTextœ,œidœ:œSplitText-doc01œ,œnameœ:œdataframeœ,œoutput_typesœ:[œTableœ]}",
+    "target": "Knowledge-ingest",
+    "targetHandle": "{œfieldNameœ:œinput_dfœ,œidœ:œKnowledge-ingestœ,œinputTypesœ:[œMessageœ,œDataœ,œJSONœ,œDataFrameœ,œTableœ],œtypeœ:œotherœ}",
+    "data": {
+     "sourceHandle": {
+      "dataType": "SplitText",
+      "id": "SplitText-doc01",
+      "name": "dataframe",
+      "output_types": [
+       "Table"
+      ]
+     },
+     "targetHandle": {
+      "fieldName": "input_df",
+      "id": "Knowledge-ingest",
+      "inputTypes": [
+       "Message",
+       "Data",
+       "JSON",
+       "DataFrame",
+       "Table"
+      ],
+      "type": "other"
+     }
+    },
+    "id": "xy-edge__SplitText-doc01{œdataTypeœ:œSplitTextœ,œidœ:œSplitText-doc01œ,œnameœ:œdataframeœ,œoutput_typesœ:[œTableœ]}-Knowledge-ingest{œfieldNameœ:œinput_dfœ,œidœ:œKnowledge-ingestœ,œinputTypesœ:[œMessageœ,œDataœ,œJSONœ,œDataFrameœ,œTableœ],œtypeœ:œotherœ}",
+    "className": "",
+    "selected": false,
+    "animated": false
+   },
+   {
+    "source": "Knowledge-retrieve",
+    "target": "Parser-answer",
+    "sourceHandle": "{œdataTypeœ:œKnowledgeœ,œidœ:œKnowledge-retrieveœ,œnameœ:œretrieve_dataœ,œoutput_typesœ:[œTableœ]}",
+    "targetHandle": "{œfieldNameœ:œinput_dataœ,œidœ:œParser-answerœ,œinputTypesœ:[œDataFrameœ,œTableœ,œDataœ,œJSONœ],œtypeœ:œotherœ}",
+    "data": {
+     "sourceHandle": {
+      "dataType": "Knowledge",
+      "id": "Knowledge-retrieve",
+      "name": "retrieve_data",
+      "output_types": [
+       "Table"
+      ]
+     },
+     "targetHandle": {
+      "fieldName": "input_data",
+      "id": "Parser-answer",
+      "inputTypes": [
+       "DataFrame",
+       "Table",
+       "Data",
+       "JSON"
+      ],
+      "type": "other"
+     }
+    },
+    "id": "reactflow__edge-Knowledge-retrieve{œdataTypeœ:œKnowledgeœ,œidœ:œKnowledge-retrieveœ,œnameœ:œretrieve_dataœ,œoutput_typesœ:[œTableœ]}-Parser-answer{œfieldNameœ:œinput_dataœ,œidœ:œParser-answerœ,œinputTypesœ:[œDataFrameœ,œTableœ,œDataœ,œJSONœ],œtypeœ:œotherœ}",
+    "animated": false,
+    "className": "",
+    "selected": false
+   },
+   {
+    "source": "Parser-answer",
+    "target": "Prompt-answer",
+    "sourceHandle": "{œdataTypeœ:œParserComponentœ,œidœ:œParser-answerœ,œnameœ:œparsed_textœ,œoutput_typesœ:[œMessageœ]}",
+    "targetHandle": "{œfieldNameœ:œcontextœ,œidœ:œPrompt-answerœ,œinputTypesœ:[œMessageœ],œtypeœ:œstrœ}",
+    "data": {
+     "sourceHandle": {
+      "dataType": "ParserComponent",
+      "id": "Parser-answer",
+      "name": "parsed_text",
+      "output_types": [
+       "Message"
+      ]
+     },
+     "targetHandle": {
+      "fieldName": "context",
+      "id": "Prompt-answer",
+      "inputTypes": [
+       "Message"
+      ],
+      "type": "str"
+     }
+    },
+    "id": "reactflow__edge-Parser-answer{œdataTypeœ:œParserComponentœ,œidœ:œParser-answerœ,œnameœ:œparsed_textœ,œoutput_typesœ:[œMessageœ]}-Prompt-answer{œfieldNameœ:œcontextœ,œidœ:œPrompt-answerœ,œinputTypesœ:[œMessageœ],œtypeœ:œstrœ}",
+    "animated": false,
+    "className": "",
+    "selected": false
+   },
+   {
+    "source": "Prompt-answer",
+    "target": "LanguageModel-answer",
+    "sourceHandle": "{œdataTypeœ:œPrompt Templateœ,œidœ:œPrompt-answerœ,œnameœ:œpromptœ,œoutput_typesœ:[œMessageœ]}",
+    "targetHandle": "{œfieldNameœ:œinput_valueœ,œidœ:œLanguageModel-answerœ,œinputTypesœ:[œMessageœ],œtypeœ:œstrœ}",
+    "data": {
+     "sourceHandle": {
+      "dataType": "Prompt Template",
+      "id": "Prompt-answer",
+      "name": "prompt",
+      "output_types": [
+       "Message"
+      ]
+     },
+     "targetHandle": {
+      "fieldName": "input_value",
+      "id": "LanguageModel-answer",
+      "inputTypes": [
+       "Message"
+      ],
+      "type": "str"
+     }
+    },
+    "id": "reactflow__edge-Prompt-answer{œdataTypeœ:œPrompt Templateœ,œidœ:œPrompt-answerœ,œnameœ:œpromptœ,œoutput_typesœ:[œMessageœ]}-LanguageModel-answer{œfieldNameœ:œinput_valueœ,œidœ:œLanguageModel-answerœ,œinputTypesœ:[œMessageœ],œtypeœ:œstrœ}",
+    "animated": false,
+    "className": "",
+    "selected": false
+   },
+   {
+    "source": "LanguageModel-answer",
+    "target": "ChatOutput-answer",
+    "sourceHandle": "{œdataTypeœ:œLanguageModelComponentœ,œidœ:œLanguageModel-answerœ,œnameœ:œtext_outputœ,œoutput_typesœ:[œMessageœ]}",
+    "targetHandle": "{œfieldNameœ:œinput_valueœ,œidœ:œChatOutput-answerœ,œinputTypesœ:[œDataœ,œJSONœ,œDataFrameœ,œTableœ,œMessageœ],œtypeœ:œotherœ}",
+    "data": {
+     "sourceHandle": {
+      "dataType": "LanguageModelComponent",
+      "id": "LanguageModel-answer",
+      "name": "text_output",
+      "output_types": [
+       "Message"
+      ]
+     },
+     "targetHandle": {
+      "fieldName": "input_value",
+      "id": "ChatOutput-answer",
+      "inputTypes": [
+       "Data",
+       "JSON",
+       "DataFrame",
+       "Table",
+       "Message"
+      ],
+      "type": "other"
+     }
+    },
+    "id": "reactflow__edge-LanguageModel-answer{œdataTypeœ:œLanguageModelComponentœ,œidœ:œLanguageModel-answerœ,œnameœ:œtext_outputœ,œoutput_typesœ:[œMessageœ]}-ChatOutput-answer{œfieldNameœ:œinput_valueœ,œidœ:œChatOutput-answerœ,œinputTypesœ:[œDataœ,œJSONœ,œDataFrameœ,œTableœ,œMessageœ],œtypeœ:œotherœ}",
+    "animated": false,
+    "className": "",
+    "selected": false
+   }
+  ]
+ },
+ "is_component": false
+}

--- a/tests/assets/flows/rag-pipeline-fixture.json
+++ b/tests/assets/flows/rag-pipeline-fixture.json
@@ -1036,12 +1036,6 @@
         "type": "int",
         "_input_type": "IntInput"
        },
-       "_frontend_node_flow_id": {
-        "value": "31dfa8d2-d42f-4bd0-b04a-a3bbb96fc544"
-       },
-       "_frontend_node_folder_id": {
-        "value": "50c46771-d71e-47f4-b62a-068e2fe5ef85"
-       },
        "is_refresh": false
       },
       "description": "Ingest into or retrieve from a Langflow knowledge base.",
@@ -1650,12 +1644,6 @@
         "track_in_telemetry": true,
         "type": "int",
         "_input_type": "IntInput"
-       },
-       "_frontend_node_flow_id": {
-        "value": "31dfa8d2-d42f-4bd0-b04a-a3bbb96fc544"
-       },
-       "_frontend_node_folder_id": {
-        "value": "50c46771-d71e-47f4-b62a-068e2fe5ef85"
        },
        "is_refresh": false
       },
@@ -3034,12 +3022,6 @@
         "track_in_telemetry": false,
         "type": "slider",
         "_input_type": "SliderInput"
-       },
-       "_frontend_node_flow_id": {
-        "value": "5d00c69b-a893-44ab-80e8-fda8ae96188b"
-       },
-       "_frontend_node_folder_id": {
-        "value": "50c46771-d71e-47f4-b62a-068e2fe5ef85"
        },
        "is_refresh": false
       },

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/rag-pipeline.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/rag-pipeline.spec.ts
@@ -124,6 +124,13 @@ async function openRagFlow(page: Page): Promise<void> {
   // so every node run control is rendered and clickable. We deliberately do NOT
   // call adjustScreenView here — its extra zoom-out shifts nodes under the
   // right-hand react-flow panel, which then intercepts the run-button click.
+  // Gate on the far answer terminal being rendered too, so the fit-on-load has
+  // framed the whole flow before any node run (both ends must be clickable).
+  await expect(
+    page
+      .locator(`[data-id="${ANSWER_OUTPUT_NODE}"]`)
+      .getByTestId("button_run_chat output"),
+  ).toBeVisible({ timeout: 30000 });
 }
 
 /** Runs a node (scoped by id) via its run button and waits for the success badge. */
@@ -208,7 +215,10 @@ test(
       // fabricated token can only be present if retrieval fed the chunk into the
       // prompt — proving the end-to-end RAG grounding (a model answering from its
       // own knowledge, or an empty/wrong retrieval, cannot produce ZEPHYR-42).
-      const answer = page.getByRole("dialog").locator("textarea");
+      // Scope past the onboarding tooltip, which also carries role="dialog".
+      const answer = page
+        .locator('[role="dialog"]:not([data-testid="assistant-onboarding-tooltip"])')
+        .locator("textarea");
       await expect(answer).toBeVisible({ timeout: 15000 });
       await expect(answer).toHaveValue(new RegExp(GROUNDING_SENTINEL), {
         timeout: 15000,

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/rag-pipeline.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/rag-pipeline.spec.ts
@@ -1,0 +1,218 @@
+import { readFileSync } from "fs";
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { createFlow } from "../../../../helpers/flows/create-flow";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import {
+  createKnowledgeBase,
+  deleteKnowledgeBase,
+  getKnowledgeBase,
+} from "../../../../helpers/knowledge/knowledge-base";
+
+// §5.2.4 — the *complete RAG pipeline* end-to-end. Builds on #673 (Split Text
+// chunking) and #674 (vector-store index + query) and adds the final "answer"
+// step: the chunk retrieved from a native (core, Chroma-backed) Knowledge Base is
+// fed through Parser -> Prompt -> Language Model, and the model's answer is proven
+// to be grounded on that retrieved chunk. Uses only core components (no
+// vector-store bundle), so it never yields a false failure on a packaging change.
+// Spec doc: docs/core-functionality/knowledge-ingestion-management/rag-pipeline.md
+
+// Pre-wired fixture flow, built + configured live on the canvas and validated
+// end-to-end on 1.11.0.dev38:
+//   Chat Input(the 5-line document) -> Split Text(chunk_size=100, overlap=0) ->
+//   Knowledge[Ingest]; and Knowledge[Retrieve](top_k=1, static query) -> Parser ->
+//   Prompt{context} -> Language Model(Google gemini-2.5-flash, temperature=0) ->
+//   Chat Output. The KB name is a placeholder the spec replaces per run.
+const FIXTURE_PATH = "tests/assets/flows/rag-pipeline-fixture.json";
+
+// The Knowledge component indexes one chunk per input row; Split Text turns the
+// 5-sentence document into exactly 5 rows -> 5 indexed chunks. Asserted after
+// ingest as a precondition so a later answer failure is unambiguously answer-side.
+const EXPECTED_CHUNKS = 5;
+
+// A fabricated, unguessable token that lives in exactly one chunk (sentence 3:
+// "...by the internal ZEPHYR-42 codec."). The static query + prompt ask for that
+// codec name. Because ZEPHYR-42 exists only inside the ingested document, the
+// answer can contain it ONLY if retrieval fed the chunk into the prompt — proving
+// the answer is grounded on the retrieved context, not the model's own knowledge.
+const GROUNDING_SENTINEL = "ZEPHYR-42";
+
+// The KB embeds with Google out-of-the-box; GOOGLE_API_KEY is auto-imported as a
+// credential and injected in the daily-stable CI. The same key backs the answer
+// model (gemini-2.5-flash), so the whole spec depends on one provider key.
+const EMBEDDING_PROVIDER = "Google Generative AI";
+const EMBEDDING_MODEL = "gemini-embedding-001";
+
+// Stable node ids baked into the fixture, so the shared run/duration/inspection
+// testids can be scoped to the right node.
+const INGEST_NODE = "Knowledge-ingest";
+const ANSWER_OUTPUT_NODE = "ChatOutput-answer";
+
+// Ids of the resources each test creates; teardown deletes only these via the API
+// (scoped) — never a global wipe, which would remove flows/KBs other parallel
+// workers are actively using (#515).
+const createdFlowIds: string[] = [];
+const createdKbNames: string[] = [];
+
+// Named flows created via the API race on unique-name suffixing under
+// parallelism; run the file serially (same rationale as the sibling
+// knowledge-ingestion specs).
+test.describe.configure({ mode: "serial" });
+
+test.skip(
+  !process?.env?.GOOGLE_API_KEY,
+  "GOOGLE_API_KEY required to embed the document and answer with gemini-2.5-flash",
+);
+
+async function authHeaders(page: Page): Promise<Record<string, string>> {
+  const authHeader = await getAuthToken(page.request);
+  return authHeader ? { Authorization: authHeader } : {};
+}
+
+/**
+ * Creates a fresh, uniquely-named Knowledge Base, imports the RAG fixture flow
+ * with both Knowledge nodes pointed at that KB, and opens it on the canvas ready
+ * for node runs. Records the created KB name and flow id for scoped teardown.
+ */
+async function openRagFlow(page: Page): Promise<void> {
+  const headers = await authHeaders(page);
+
+  const uniqueSuffix = `${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
+  const kbName = await createKnowledgeBase(
+    page.request,
+    {
+      name: `kb_rag_${uniqueSuffix}`,
+      embeddingProvider: EMBEDDING_PROVIDER,
+      embeddingModel: EMBEDDING_MODEL,
+    },
+    { headers },
+  );
+  createdKbNames.push(kbName);
+
+  const fixture = JSON.parse(readFileSync(FIXTURE_PATH, "utf-8"));
+  // Point both Knowledge nodes at the freshly-created KB. The DropdownInput only
+  // treats a value as a valid selection when it is also present in `options`, so
+  // set both — value alone leaves the node showing "Select an option" and it
+  // will not run.
+  for (const node of fixture.data.nodes) {
+    if (node.data?.type === "Knowledge") {
+      const kb = node.data.node.template.knowledge_base;
+      kb.value = kbName;
+      kb.options = [kbName];
+    }
+  }
+
+  const flowId = await createFlow(
+    page.request,
+    {
+      name: `RAG Pipeline ${uniqueSuffix}`,
+      description: fixture.description,
+      data: fixture.data,
+      is_component: false,
+    },
+    { headers },
+  );
+  createdFlowIds.push(flowId);
+
+  await page.goto(`/flow/${flowId}`);
+  await expect(
+    page.locator(`[data-id="${INGEST_NODE}"]`).getByTestId("title-knowledge"),
+  ).toBeVisible({ timeout: 30000 });
+
+  // Rely on Langflow's auto fit-on-load: it frames all 8 nodes within the viewport
+  // so every node run control is rendered and clickable. We deliberately do NOT
+  // call adjustScreenView here — its extra zoom-out shifts nodes under the
+  // right-hand react-flow panel, which then intercepts the run-button click.
+}
+
+/** Runs a node (scoped by id) via its run button and waits for the success badge. */
+async function runNode(
+  page: Page,
+  nodeId: string,
+  runButtonTestId: string,
+): Promise<void> {
+  const node = page.locator(`[data-id="${nodeId}"]`);
+  await node.getByTestId(runButtonTestId).click({ timeout: 15000 });
+  await expect(node.locator('[data-testid^="node_duration"]')).toBeVisible({
+    timeout: 90000,
+  });
+}
+
+test.afterEach(async ({ page }) => {
+  const flowIds = createdFlowIds.splice(0);
+  const kbNames = createdKbNames.splice(0);
+  if (flowIds.length === 0 && kbNames.length === 0) return;
+  // Navigate off the editor first so the unmounted flow page stops polling a flow
+  // we are about to delete, then pass an explicit auth header — page.request is
+  // unauthenticated under AUTO_LOGIN and would 401 otherwise.
+  await page.goto("/");
+  const headers = await authHeaders(page);
+  // Delete every resource independently and collect failures, so a throw while
+  // deleting one can never skip the rest — otherwise the KB, a persistent
+  // instance resource that MUST be deleted to avoid orphans, would leak.
+  const failures: string[] = [];
+  for (const id of flowIds) {
+    try {
+      await deleteFlow(page.request, id, { headers });
+    } catch (e) {
+      failures.push(String(e));
+    }
+  }
+  for (const name of kbNames) {
+    try {
+      await deleteKnowledgeBase(page.request, name, { headers });
+    } catch (e) {
+      failures.push(String(e));
+    }
+  }
+  if (failures.length > 0) {
+    throw new Error(`Teardown cleanup failed: ${failures.join("; ")}`);
+  }
+});
+
+test(
+  "Full RAG pipeline grounds the model answer on the retrieved chunk",
+  { tag: ["@stable", "@release", "@components", "@files"] },
+  async ({ page }) => {
+    await test.step("open the pre-wired RAG pipeline fixture flow", async () => {
+      await openRagFlow(page);
+    });
+
+    await test.step("run the Knowledge (Ingest) node", async () => {
+      await runNode(page, INGEST_NODE, "button_run_knowledge");
+    });
+
+    await test.step("the Knowledge Base holds exactly the expected chunks", async () => {
+      // Precondition proof the ingest embedded + indexed the document, so a later
+      // answer failure is unambiguously answer-side rather than a broken ingest.
+      const kbName = createdKbNames[createdKbNames.length - 1];
+      const headers = await authHeaders(page);
+      const kb = await getKnowledgeBase(page.request, kbName, { headers });
+      expect(kb.chunks).toBe(EXPECTED_CHUNKS);
+    });
+
+    await test.step("run the answer path via the Chat Output node", async () => {
+      // Running Chat Output builds only its upstream (Retrieve -> Parser -> Prompt
+      // -> Language Model -> Chat Output); the ingest branch is not upstream, so
+      // it does not re-run. Retrieve reads the KB just populated by the ingest.
+      await runNode(page, ANSWER_OUTPUT_NODE, "button_run_chat output");
+    });
+
+    await test.step("the answer is grounded on the retrieved chunk", async () => {
+      await page
+        .locator(`[data-id="${ANSWER_OUTPUT_NODE}"]`)
+        .getByTestId("output-inspection-output message-chatoutput")
+        .click();
+      // The Component Output dialog shows the answer in a textarea. The verbatim
+      // fabricated token can only be present if retrieval fed the chunk into the
+      // prompt — proving the end-to-end RAG grounding (a model answering from its
+      // own knowledge, or an empty/wrong retrieval, cannot produce ZEPHYR-42).
+      const answer = page.getByRole("dialog").locator("textarea");
+      await expect(answer).toBeVisible({ timeout: 15000 });
+      await expect(answer).toHaveValue(new RegExp(GROUNDING_SENTINEL), {
+        timeout: 15000,
+      });
+    });
+  },
+);


### PR DESCRIPTION
## What & why

Closes #675 — Wave 2, §5.2.4. Adds the final `@stable` spec of the §5.2 RAG
family: the **complete RAG pipeline end-to-end** (ingest → embed → store →
retrieve → **answer**), building on #673 (Split Text chunking) and #674
(vector-store index + query). This is the step those two deliberately left out:
proving the LLM answer is **grounded on the retrieved chunk**.

## Design

Single fixture flow, all core components (native Chroma-backed Knowledge Base —
no vector-store bundle, so no false failure on a packaging change):

```
Ingest:  Chat Input(document) → Split Text → Knowledge[Ingest]
Answer:  Knowledge[Retrieve] → Parser → Prompt{context} → Language Model → Chat Output
```

- **Grounding observable (false-positive-proof):** sentence 3 of the document
  carries a fabricated, unguessable fact — *"…by the internal **ZEPHYR-42**
  codec."* The token exists only inside the document; the answer can contain it
  **only** if retrieval fed the chunk into the prompt. Prompt enforces
  *"use ONLY the context"*, model runs at `temperature = 0`.
- **Single provider key:** Google (`gemini-embedding-001` for the KB +
  `gemini-2.5-flash` for the answer); `api_key` resolves from the `GOOGLE_API_KEY`
  global variable. One skip guard, aligned with daily-stable CI.
- **Node-by-node run:** ingest and answer are run as separate node runs (running
  the whole flow via the API re-executes ingest with an empty Chat Input and
  fails). Running Chat Output builds only its upstream; the ingest branch is not
  upstream, so it does not re-run.

Spec doc: `docs/core-functionality/knowledge-ingestion-management/rag-pipeline.md`.

## Test

| # | Test | Validates (concrete observable) |
|---|---|---|
| 1 | `Full RAG pipeline grounds the model answer on the retrieved chunk` | `GET /api/v1/knowledge_bases/{kb}` → `chunks === 5` (embed+index precondition); Chat Output text matches `/ZEPHYR-42/` (grounded answer) |

## Validation

- **Instance:** Langflow nightly `1.11.0.dev38` (`Langflow Nightly`).
- **Green:** 4× `--workers=1 --retries=0` clean (~11.1–11.9s each); typecheck
  passes; `eslint` 0 errors (only the accepted `playwright/no-skipped-test`
  warning, identical to the merged sibling).
- **Force-fail (executed):**
  - `GROUNDING_SENTINEL="ZEPHYR-999-NOTPRESENT"` → FAILS at the answer step
    (`Expected /ZEPHYR-999-NOTPRESENT/, Received "ZEPHYR-42"`).
  - `EXPECTED_CHUNKS=4` → FAILS at the chunk-count step (`Expected 4, Received 5`).
  - Reverted: 0 mutation markers, final green run.
- **Cleanup:** flow + KB deleted scoped in `afterEach`; 0 orphan flows/KBs verified
  via `GET /api/v1/flows/` and `GET /api/v1/knowledge_bases`.
- **Independent review:** a fresh reviewer read the full changeset + sibling spec +
  conventions, ran typecheck/lint, and executed the spec live → `APPROVE-WITH-NITS`;
  all nits applied (scoped answer-dialog selector, Chat Output readiness gate,
  stripped stray `_frontend_node_*` ids from the fixture) and re-validated.

> `--trace=on` skipped (known repo limitation — can hang); covered via
> `--retries=0` bursts + executed force-fails + live end-to-end run.

## Checklist

- [x] Links a current-wave item (#675, `roadmap`)
- [x] `@stable` present (+ `@release @components @files`)
- [x] Spec doc under `docs/` mirroring the test path, all mandatory sections filled
- [x] `Last validated` = 1.11.x
- [x] Only the manual §5.2 bullet edited in `QA-CHECKLIST.md` (no generated block)
