### PR TITLE
test(api): validate & promote move-flow-between-folders to @stable (#685)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -622,7 +622,7 @@
 #### 12.5 Flow Operations
 - [-] Lock flow — prevents editing
 - [-] Unlock flow
-- [-] Move flow between folders via API
+- [x] Move flow between folders via API → `api/flows/api-folders-crud.spec.ts`
 - [x] Publish flow → `flow-functionality/publish-flow.spec.ts`
 - [-] Save flow components as template
 

--- a/docs/api/flows/api-folders-crud.md
+++ b/docs/api/flows/api-folders-crud.md
@@ -1,0 +1,85 @@
+# API Folders (Projects) CRUD
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+Validates the CRUD contract of the folders endpoint family, exposed at `/api/v1/projects/` (the current path; "folder" is the legacy alias kept for backward compatibility). Folders/projects are the top-level organizational unit in the UI sidebar — every flow belongs to exactly one folder, and moving a flow between folders is done by patching its `folder_id`.
+
+A regression here silently breaks the sidebar (folders disappear or cannot be created), the "move flow to folder" affordance in the UI, and any external consumer that programmatically organizes flows. The spec exercises create, list, delete, and — the item tracked by QA-CHECKLIST §12.5 — **moving a flow between folders via `PATCH /api/v1/flows/{id}` with a new `folder_id`**.
+
+If any of these tests fail against `langflowai/langflow-nightly:latest`, the folder persistence layer, the projects router, or the flow↔folder association has regressed and the next release is at risk.
+
+---
+
+## Tags *(required)*
+`@stable` `@release` `@api` `@regression`
+
+---
+
+## Step by step *(required)*
+
+The spec runs **4 independent tests** against `/api/v1/projects/` and `/api/v1/flows/` via Playwright's `request` fixture. Each test obtains a Bearer token through `getAuthToken()` (auto-login) and creates its own ephemeral folder(s)/flow with a `Date.now()`-suffixed name to avoid collisions. Cleanup is **id-scoped in `afterEach`**: every test pushes the ids it creates (from the `POST` 201 response) into a tracker, and `afterEach` deletes exactly those — so a mid-test assertion failure never leaks folders/flows. Deletes are targeted by id (never a global wipe), which under the suite's parallelism would remove concurrent workers' data. No pre-test cleanup, no global setup.
+
+---
+
+**Test 1 — `POST creates folder and returns ID and name`**
+1. `POST /api/v1/projects/` with `{ name, description }`
+2. Assert HTTP status is `201`
+3. Assert response body has a non-empty string `id` and matching `name`
+4. Cleanup via `DELETE`
+
+**Test 2 — `GET lists folders and includes the created one`**
+1. Create a folder via `POST`
+2. `GET /api/v1/projects/`
+3. Assert HTTP status is `200` and the response is iterable (array or `{ folders: [...] }`)
+4. Assert the freshly created `id` is present in the list with the correct name
+5. Cleanup
+
+**Test 3 — `DELETE removes folder and it no longer appears in listing`**
+1. Create a folder via `POST`
+2. `DELETE /api/v1/projects/{id}`
+3. Assert HTTP status is `204` (No Content)
+4. `GET /api/v1/projects/` and assert the deleted `id` is absent from the list
+
+**Test 4 — `moving flow between folders via PATCH folder_id updates association`** *(QA-CHECKLIST §12.5)*
+1. Create two folders (A and B) via `POST /api/v1/projects/`
+2. Create a flow via `POST /api/v1/flows/` with `folder_id` = folder A's id
+3. Assert the created flow's `folder_id` equals folder A's id
+4. `PATCH /api/v1/flows/{id}` with `{ folder_id: <folder B id> }`; assert HTTP status is `200`
+5. `GET /api/v1/flows/{id}` and assert the persisted `folder_id` now equals folder B's id
+6. Cleanup: delete the flow and both folders
+
+---
+
+## Validation criterion *(required)*
+- All 4 tests pass 5× in a row against `langflowai/langflow-nightly:latest`.
+- Status codes match: folder `POST` returns `201`; folder `GET` returns `200`; folder `DELETE` returns `204`; flow `PATCH`/`GET` return `200`.
+- **Move is durable and observable**: after `PATCH /api/v1/flows/{id}` with a new `folder_id`, a fresh `GET /api/v1/flows/{id}` reports the new `folder_id` — proving the association moved and persisted, not just that the request was accepted.
+- Deleted folders disappear from `GET /api/v1/projects/`.
+- Each test cleans up after itself — no orphan folders or flows remain after the suite completes.
+
+---
+
+## What this test does not cover *(optional)*
+- Folder **rename** and delete-with-flows-inside — covered by the UI spec `core-functionality/project-management/folder-crud.spec.ts`.
+- Cascade behavior when a folder holding flows is deleted (do the flows move to root, or are they deleted?) — out of scope here.
+- Multi-user isolation of folders — out of scope; would require seeding a second user.
+- The UI drag-drop affordance for moving a flow between folders — this spec covers the API contract only.
+
+---
+
+## Preconditions *(optional)*
+- Langflow running and reachable at `PLAYWRIGHT_BASE_URL` (default `http://localhost:7860`).
+- Auto-login enabled (the default in nightly) so `getAuthToken()` can mint a Bearer token. If auth is reconfigured, the helper at `tests/helpers/auth/get-auth-token.ts` must be updated first.
+
+---
+
+## External dependencies *(required)*
+<!-- Files from the Langflow repository that, if changed, could break this test. -->
+
+- `src/backend/base/langflow/api/v1/projects.py` — router that exposes `POST/GET/DELETE /api/v1/projects/`; any signature, status code (notably the `204` on DELETE), or response shape change here directly affects the folder tests.
+- `src/backend/base/langflow/api/v1/folders.py` — legacy folders router / alias kept for compatibility; changes to how folders and projects share models can shift behavior.
+- `src/backend/base/langflow/api/v1/flows.py` — exposes `PATCH /api/v1/flows/{id}`; the move-flow test depends on `folder_id` being an accepted, persisted field on this endpoint.
+- `src/backend/base/langflow/services/database/models/flow/model.py` — flow schema including the `folder_id` foreign key; renaming/removing it breaks the move assertion.

--- a/tests/tests-automations/regression/api/flows/api-folders-crud.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-folders-crud.spec.ts
@@ -4,35 +4,56 @@ import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 // Folders use the /api/v1/projects/ endpoint (legacy alias kept for compatibility)
 test.describe("Folder (Projects) CRUD via API", () => {
+  // Id-scoped cleanup: each test pushes the ids it creates from the POST 201
+  // response, and afterEach deletes exactly those. Inline cleanup at the end of
+  // a test never runs when an assertion throws first, leaking folders/flows —
+  // afterEach always runs. Targeted delete only (never a global wipe), which
+  // under the suite's parallelism would nuke concurrent workers' data.
+  const createdFolderIds: string[] = [];
+  const createdFlowIds: string[] = [];
+
+  test.afterEach(async ({ request }) => {
+    const authToken = await getAuthToken(request);
+    // Flows first — a folder holding flows may refuse deletion otherwise.
+    for (const id of createdFlowIds) {
+      await deleteFlow(request, id, { headers: { Authorization: authToken } });
+    }
+    for (const id of createdFolderIds) {
+      // request.delete resolves on any status and 404 (already gone) is the
+      // desired idempotent end state, so no throw/catch is needed here.
+      await request.delete(`/api/v1/projects/${id}`, {
+        headers: { Authorization: authToken },
+      });
+    }
+    createdFlowIds.length = 0;
+    createdFolderIds.length = 0;
+  });
+
   test(
     "POST creates folder and returns ID and name",
-    { tag: ["@release", "@api", "@regression"] },
+    { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
       const authToken = await getAuthToken(request);
       const folderName = `Test Folder ${Date.now()}`;
 
       const createRes = await request.post("/api/v1/projects/", {
         headers: { Authorization: authToken },
-        data: { name: folderName, description: "Folder criado pelo teste" },
+        data: { name: folderName, description: "Folder created by the test" },
       });
 
       expect(createRes.status()).toBe(201);
 
       const folder = await createRes.json();
+      createdFolderIds.push(folder.id);
       expect(folder).toHaveProperty("id");
       expect(typeof folder.id).toBe("string");
       expect(folder.name).toBe(folderName);
-
-      // Cleanup
-      await request.delete(`/api/v1/projects/${folder.id}`, {
-        headers: { Authorization: authToken },
-      });
     },
   );
 
   test(
     "GET lists folders and includes the created one",
-    { tag: ["@release", "@api", "@regression"] },
+    { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
       const authToken = await getAuthToken(request);
       const folderName = `List Folder ${Date.now()}`;
@@ -43,6 +64,7 @@ test.describe("Folder (Projects) CRUD via API", () => {
       });
       expect(createRes.status()).toBe(201);
       const { id } = await createRes.json();
+      createdFolderIds.push(id);
 
       const listRes = await request.get("/api/v1/projects/", {
         headers: { Authorization: authToken },
@@ -54,17 +76,12 @@ test.describe("Folder (Projects) CRUD via API", () => {
       const found = folderList.find((f: any) => f.id === id);
       expect(found).toBeDefined();
       expect(found.name).toBe(folderName);
-
-      // Cleanup
-      await request.delete(`/api/v1/projects/${id}`, {
-        headers: { Authorization: authToken },
-      });
     },
   );
 
   test(
     "DELETE removes folder and it no longer appears in listing",
-    { tag: ["@release", "@api", "@regression"] },
+    { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
       const authToken = await getAuthToken(request);
       const folderName = `Delete Folder ${Date.now()}`;
@@ -75,6 +92,7 @@ test.describe("Folder (Projects) CRUD via API", () => {
       });
       expect(createRes.status()).toBe(201);
       const { id } = await createRes.json();
+      createdFolderIds.push(id);
 
       const deleteRes = await request.delete(`/api/v1/projects/${id}`, {
         headers: { Authorization: authToken },
@@ -96,7 +114,7 @@ test.describe("Folder (Projects) CRUD via API", () => {
 
   test(
     "moving flow between folders via PATCH folder_id updates association",
-    { tag: ["@release", "@api", "@regression"] },
+    { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
       const authToken = await getAuthToken(request);
 
@@ -107,6 +125,7 @@ test.describe("Folder (Projects) CRUD via API", () => {
       });
       expect(folder1Res.status()).toBe(201);
       const folder1 = await folder1Res.json();
+      createdFolderIds.push(folder1.id);
 
       const folder2Res = await request.post("/api/v1/projects/", {
         headers: { Authorization: authToken },
@@ -114,6 +133,7 @@ test.describe("Folder (Projects) CRUD via API", () => {
       });
       expect(folder2Res.status()).toBe(201);
       const folder2 = await folder2Res.json();
+      createdFolderIds.push(folder2.id);
 
       // Create a flow in folder 1
       const flowRes = await request.post("/api/v1/flows/", {
@@ -127,6 +147,7 @@ test.describe("Folder (Projects) CRUD via API", () => {
       });
       expect(flowRes.status()).toBe(201);
       const flow = await flowRes.json();
+      createdFlowIds.push(flow.id);
 
       // Verify flow is in folder 1
       expect(flow.folder_id).toBe(folder1.id);
@@ -145,17 +166,6 @@ test.describe("Folder (Projects) CRUD via API", () => {
       expect(getRes.status()).toBe(200);
       const updatedFlow = await getRes.json();
       expect(updatedFlow.folder_id).toBe(folder2.id);
-
-      // Cleanup
-      await deleteFlow(request, flow.id, {
-        headers: { Authorization: authToken },
-      });
-      await request.delete(`/api/v1/projects/${folder1.id}`, {
-        headers: { Authorization: authToken },
-      });
-      await request.delete(`/api/v1/projects/${folder2.id}`, {
-        headers: { Authorization: authToken },
-      });
     },
   );
 });


### PR DESCRIPTION
Closes #685.

Closes the `[ ] Move flow between folders via API` gap in `QA-CHECKLIST.md` §12.5 Flow Operations. The spec already existed (`api/flows/api-folders-crud.spec.ts`) but was untagged and had no spec doc; this validates it on the fresh nightly and promotes the whole file to `@stable`.

## 1. Covered tests
| # | Test | What it validates |
|---|------|-------------------|
| 1 | `POST creates folder and returns ID and name` | `POST /api/v1/projects/` → `201`, body has non-empty string `id` and matching `name`. |
| 2 | `GET lists folders and includes the created one` | `GET /api/v1/projects/` → `200`; the created `id` is present with the correct `name`. |
| 3 | `DELETE removes folder and it no longer appears in listing` | `DELETE /api/v1/projects/{id}` → `204`; the `id` is absent from a subsequent listing. |
| 4 | `moving flow between folders via PATCH folder_id updates association` | `PATCH /api/v1/flows/{id}` with a new `folder_id` → `200`; a fresh `GET /api/v1/flows/{id}` reports the new `folder_id` (move persisted, not just accepted). This is the §12.5 item. |

## 2. How the test was built
- Pure REST API via Playwright's `request` fixture; Bearer token from `getAuthToken()` (auto-login). No UI.
- **Cleanup is id-scoped in `afterEach`** — each test tracks the ids it creates from the `POST` 201 response and `afterEach` deletes exactly those (flows before folders), so a mid-test assertion failure no longer leaks orphans. Targeted delete only, never a global wipe (parallel-safe).
- Endpoint note: folders use the current `/api/v1/projects/` path ("folder" is the legacy alias); `DELETE` returns `204`.
- Assertion rationale: the move test re-`GET`s the flow after the PATCH and asserts the persisted `folder_id`, proving the association actually moved rather than that the request was merely accepted.

## 3. Dependencies
- None — no LLM/provider/API key; auto-login only.
- Execution mode: parallel-safe (each test isolates its own ids; no cross-test global state).

## Validation (nightly 1.11.0.dev38, `--retries=0`)
- typecheck ✅ · eslint ✅ (0 errors) · zero `🚨 Backend Error` ✅
- 5× clean runs, 4/4 passed each, no flake ✅
- force-fail ✅ — one mutation per test (all placed after id-tracking), each observed `1 failed` isolated via `--grep`; after the force-fail runs, an API check confirmed **0 orphan folders / 0 orphan flows**, proving the `afterEach` cleanup works even on failure (before the fix the same runs leaked 4 folders).
- `--trace=on` not applicable — pure API spec (no canvas/screenshots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
