### PR TITLE
fix(api): harden custom_component spec auth acquisition against transient 403 (#748)

### DIFF
--- a/docs/api/flows/api-custom-component-creation.md
+++ b/docs/api/flows/api-custom-component-creation.md
@@ -1,6 +1,6 @@
 # API Custom Component Creation
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.11.x
 
 ---
 
@@ -21,10 +21,12 @@ If either endpoint regresses on shape, status code, or auth contract, both the C
 
 ## Step by step *(required)*
 
-The spec runs **4 independent tests** via Playwright's `request` fixture. Tests 1–3 mint a Bearer token via `getAuthToken(request)`; Test 4 deliberately sends no `Authorization` header. No shared `beforeAll`/`afterAll` state.
+The spec runs **4 independent tests** via Playwright's `request` fixture. Tests 1–3 mint a Bearer token via a local **fail-fast** helper `getBearerToken(request)`; Test 4 deliberately sends no `Authorization` header. No shared `beforeAll`/`afterAll` state.
+
+**Token acquisition (`getBearerToken`) — fail-fast, resilient.** Tests 1–3 must never send an unauthenticated request. The helper first tries `GET /api/v1/auto_login`; if that yields no `access_token` (a transient 5xx / timing hiccup during container startup), it falls back to a deterministic credential login (`POST /api/v1/login` with the superuser from `credentials.ts`), which does not depend on `LANGFLOW_AUTO_LOGIN`. If **neither** path returns a token, the helper **throws** with a clear message, so the test fails fast instead of silently sending `Authorization: ""` (an empty header) — which the endpoint answers with `403 {"detail":"No authentication credentials provided"}`. This is the exact failure mode that produced the intermittent daily `403` (issue #748): the previous shared `get-auth-token.ts` helper swallowed a transient auto_login failure and returned an empty string.
 
 **Test 1 — `POST /api/v1/custom_component` returns valid component structure**
-1. Obtain a Bearer token via `getAuthToken(request)`.
+1. Obtain a Bearer token via `getBearerToken(request)`.
 2. `POST /api/v1/custom_component` with `Authorization: Bearer …` and a body containing the source of a minimal valid component (`MessageTextInput` input, single `Output`, `build_output` method returning `Data`).
 3. Accept `200` or `201` for a parsed component, and tolerate `422` for environments that reject the snippet at the validation layer — the test logs the rejection body and exits without failing, documenting the looser contract.
 4. On `200`/`201`: parse JSON and assert that at least one of `display_name`, `name`, `type`, or `template` is present.
@@ -71,12 +73,13 @@ Test 4 was migrated from the now-deleted `api-custom-component.spec.ts` to conso
 
 ## Preconditions *(optional)*
 - Langflow running and reachable at `PLAYWRIGHT_BASE_URL`.
-- Backend running with auto-login enabled (`LANGFLOW_AUTO_LOGIN=true`, the default in the supplied Docker/pip scripts) — `getAuthToken` mints the Bearer via `GET /api/v1/auto_login`. The test fixture does not read `LANGFLOW_SUPERUSER` / `LANGFLOW_SUPERUSER_PASSWORD` directly.
+- A reachable auth surface: either `LANGFLOW_AUTO_LOGIN=true` (the default in the supplied Docker/pip scripts, so `GET /api/v1/auto_login` mints the Bearer) **or** valid superuser credentials (`LANGFLOW_SUPERUSER` / `LANGFLOW_SUPERUSER_PASSWORD`) for the credential-login fallback. `getBearerToken` needs only one of the two to succeed.
 - Backend has the standard component catalog loaded (default install satisfies this).
 
 ---
 
 ## External dependencies *(required)*
-- `tests/helpers/auth/get-auth-token.ts` — issues a valid `Bearer` via `/api/v1/auto_login`; if its contract changes, every test in this spec breaks.
+- `tests/helpers/auth/credentials.ts` — supplies the superuser username/password used by the credential-login fallback in `getBearerToken`; it reads `LANGFLOW_SUPERUSER` / `LANGFLOW_SUPERUSER_PASSWORD` (non-legacy defaults).
+- `GET /api/v1/auto_login` and `POST /api/v1/login` — the two token sources `getBearerToken` tries, in that order. The test tolerates either being unavailable individually; it fails fast only if **both** fail to yield a token.
 - `src/backend/base/langflow/api/v1/endpoints.py` — implementation of `POST /api/v1/custom_component` and `GET /api/v1/all`. Dropping `template`/`display_name`/`name`/`type` on the POST response breaks Test 1's shape check. For the GET, the test only enforces "non-empty object" — a list response would currently still pass the JSON-object check (`typeof === "object"`) if it carried entries, so a switch to list would degrade coverage silently rather than fail the test.
 - `src/backend/base/langflow/custom/custom_component/component.py` — the `Component` base class consumed by the inline test source. If its public surface (`MessageTextInput`, `Output`, `Data`) changes name or import path, Test 1's snippet stops parsing and the test flips to the `422` documentation branch.

--- a/tests/tests-automations/regression/api/flows/api-custom-component-creation.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-custom-component-creation.spec.ts
@@ -1,5 +1,54 @@
+import type { APIRequestContext } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
-import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import {
+  SUPERUSER_PASSWORD,
+  SUPERUSER_USERNAME,
+} from "../../../../helpers/auth/credentials";
+
+/**
+ * Fail-fast Bearer acquisition for the authenticated tests below.
+ *
+ * The daily failure in issue #748 was an intermittent 403: the shared
+ * get-auth-token helper swallowed a transient /auto_login failure and returned
+ * an empty string, so the spec sent `Authorization: ""` and the endpoint
+ * answered `403 {"detail":"No authentication credentials provided"}`.
+ *
+ * This helper NEVER returns an empty token. It tries /auto_login first, then
+ * falls back to a deterministic credential login (independent of
+ * LANGFLOW_AUTO_LOGIN); if neither yields a token it throws, so the test fails
+ * fast instead of issuing an unauthenticated request.
+ */
+async function getBearerToken(request: APIRequestContext): Promise<string> {
+  // 1) auto_login (works when LANGFLOW_AUTO_LOGIN=true, the default).
+  const autoRes = await request.get("/api/v1/auto_login");
+  if (autoRes.ok()) {
+    const body = await autoRes.json().catch(() => null);
+    if (body?.access_token) {
+      return `Bearer ${body.access_token}`;
+    }
+  }
+
+  // 2) Fallback: credential login (does not depend on auto_login).
+  const formData = new URLSearchParams();
+  formData.append("username", SUPERUSER_USERNAME);
+  formData.append("password", SUPERUSER_PASSWORD);
+  const loginRes = await request.post("/api/v1/login", {
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    data: formData.toString(),
+  });
+  if (loginRes.ok()) {
+    const body = await loginRes.json().catch(() => null);
+    if (body?.access_token) {
+      return `Bearer ${body.access_token}`;
+    }
+  }
+
+  // 3) Fail fast — never send an unauthenticated request.
+  throw new Error(
+    `Failed to acquire a Bearer token: /api/v1/auto_login → ${autoRes.status()}, ` +
+      `/api/v1/login → ${loginRes.status()}. Refusing to send an unauthenticated request.`,
+  );
+}
 
 const VALID_COMPONENT_CODE = `
 from langflow.custom import Component
@@ -27,7 +76,7 @@ test.describe("Custom Component Creation API", () => {
     "POST /api/v1/custom_component returns valid component structure",
     { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
-      const authToken = await getAuthToken(request);
+      const authToken = await getBearerToken(request);
 
       const res = await request.post("/api/v1/custom_component", {
         headers: { Authorization: authToken },
@@ -71,7 +120,7 @@ test.describe("Custom Component Creation API", () => {
     "POST /api/v1/custom_component with invalid code returns error",
     { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
-      const authToken = await getAuthToken(request);
+      const authToken = await getBearerToken(request);
 
       const res = await request.post("/api/v1/custom_component", {
         headers: { Authorization: authToken },
@@ -92,7 +141,7 @@ test.describe("Custom Component Creation API", () => {
     "GET /api/v1/all includes component types",
     { tag: ["@stable", "@release", "@api", "@regression"] },
     async ({ request }) => {
-      const authToken = await getAuthToken(request);
+      const authToken = await getBearerToken(request);
 
       const res = await request.get("/api/v1/all", {
         headers: { Authorization: authToken },


### PR DESCRIPTION
Closes #748

## Problem

Both authenticated tests in `api/flows/api-custom-component-creation.spec.ts` hard-failed on the 2026-07-14 daily ([run 29323509096](https://github.com/oriontech-me/langflow-e2e/actions/runs/29323509096)) with **403 regardless of payload**.

## Verdict — test defect (endpoint contract intact)

Verified live on `langflowai/langflow-nightly:latest` (`1.11.0.dev38`):

| Request | Status |
|---|---|
| `POST /custom_component` authenticated, valid code | **200** (within Test 1's `[200,201]`) |
| `POST /custom_component` authenticated, invalid code | **400** (within Test 2's `[400,422,500]`) |
| `POST /custom_component` with an **empty** `Authorization` header | **403** `{"detail":"No authentication credentials provided"}` — the exact daily symptom |

`LANGFLOW_AUTO_LOGIN=true` both in CI (`daily-stable.yml`) and live, so this is **not** an upstream auth-contract change nor a config change.

## Root cause (test-side)

The shared `tests/helpers/auth/get-auth-token.ts` helper swallows a **transient** `/api/v1/auto_login` failure and returns an empty string. The spec then sends `Authorization: ""` (anonymous) and the endpoint answers 403. Intermittent because auto_login almost always succeeds.

## Fix (scoped to this spec)

Replaced the fragile acquisition with a local **fail-fast** `getBearerToken`:
1. try `/api/v1/auto_login`;
2. fall back to a deterministic credential login (`POST /api/v1/login`, independent of `LANGFLOW_AUTO_LOGIN`);
3. **throw** with a clear message if neither yields a token — so an unauthenticated request is never sent.

The shared helper is intentionally left untouched (used by ~8 other API specs — hardening it globally is a candidate for a dedicated issue). Spec doc updated (Step-by-step, External dependencies, Preconditions, `Last validated → 1.11.x`).

## Validation

- Instance: `langflowai/langflow-nightly:latest` → `1.11.0.dev38`
- `npm run typecheck` clean; `npm run lint` 0 errors
- 3 clean bursts `--workers=1 --retries=0` → 4 passed each (~0.8s)
- Force-fail executed for every test in the file (all failed under mutation, reverted):
  - Test 1 `[200,201]`→`[201]`; Test 2 `[400,422,500]`→`[422,500]`; Test 3 `toBe(200)`→`toBe(201)`; Test 4 `[401,403]`→`[200]`
  - Mechanism FF: broke both token endpoints → `getBearerToken` threw `"Failed to acquire a Bearer token: … Refusing to send an unauthenticated request."` instead of sending anonymously
- Zero `🚨 Backend Error`
- No flows created by this spec (POST only parses, never persists) → no cleanup needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)