### PR TITLE
chore(stable): quarantine @stable on OpenAI-bound specs (key out of quota) (#772)

### DIFF
--- a/tests/tests-automations/regression/core-functionality/llm-agents/general-bugs-agent-images-playground.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/general-bugs-agent-images-playground.spec.ts
@@ -5,7 +5,7 @@ import { SimpleAgentTemplatePage } from "../../../../pages";
 
 test(
   "user must be able to send images in the playground with the agent component",
-  { tag: ["@stable", "@release", "@components", "@agents"] },
+  { tag: ["@release", "@components", "@agents"] },
   async ({ page }) => {
     test.skip(
       !process?.env?.OPENAI_API_KEY,

--- a/tests/tests-automations/regression/core-functionality/llm-agents/language-model-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/language-model-regression.spec.ts
@@ -67,7 +67,7 @@ test.describe("Language Model Component Regression", () => {
 
   test(
     "language model must respond with OpenAI provider",
-    { tag: ["@stable", "@release", "@components", "@model-provider"] },
+    { tag: ["@release", "@components", "@model-provider"] },
     async ({ page }) => {
       test.skip(
         !process?.env?.OPENAI_API_KEY,

--- a/tests/tests-automations/regression/core-functionality/model-provider/openai-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/openai-provider.spec.ts
@@ -200,7 +200,7 @@ test.describe("OpenAI Provider", () => {
 
   test(
     "configured OpenAI selects a GPT model in the Agent and executes the flow",
-    { tag: ["@stable", "@model-provider", "@agents", "@playground"] },
+    { tag: ["@model-provider", "@agents", "@playground"] },
     async ({ page, request }) => {
       test.skip(
         !hasProviderEnvKeys(PROVIDER),


### PR DESCRIPTION
## What & why

Refs #772 (issue stays **open** — restoration is pending; see below).

The shared OpenAI key (CI secret `OPENAI_API_KEY` + local `.env`, OpenAI project `proj_vtkyNBz9ytVmv1HpewDvfUaL`) is **out of quota / billing** — every chat completion returns HTTP 429 *"exceeded your current quota"*. This is durable, not a transient infra blip: reproduced live on `1.11.0.dev38`, where `openai` probes inactive (all 49 candidate models fail validation) while `anthropic` and `google` probe active.

Surfaced by the #771 daily-failure triage (run [29406577514](https://github.com/oriontech-me/langflow-e2e/actions/runs/29406577514), 2026-07-15).

## Change

Removes `@stable` from the three OpenAI-only specs that run a real completion and therefore **hard-fail** (rather than skip) every daily until billing is restored:

| Spec | test |
|---|---|
| `language-model-regression.spec.ts` | "language model must respond with OpenAI provider" |
| `openai-provider.spec.ts` | "configured OpenAI selects a GPT model in the Agent and executes the flow" |
| `general-bugs-agent-images-playground.spec.ts` | "user must be able to send images in the playground with the agent component" |

**Deliberately unchanged:**
- `collect-models` keeps `@stable` — its whole purpose is to alert when a provider goes inactive, so it must stay red until the key is topped up.
- The loop "Research Translation" spec is owned by #722 (its fix is not yet merged) — left out to avoid collision.
- `openai-provider` "API key is configured via Settings" keeps `@stable` — it only configures the key (no completion) and passes regardless of quota.

## Restoration (why #772 stays open)

This PR only quarantines. Once the OpenAI account has quota again, a follow-up PR re-adds `@stable` to the three specs after confirming they pass on a fresh nightly, and closes #772.

## Validation

- `npm run typecheck` — pass
- `npm run lint` — pass (0 errors)
- Tag selection verified: the three tests no longer match `--grep @stable`; `collect-models` and `language-model` "Google provider" still do.
- No test logic changed (tag-only edit) — no force-fail applicable; `QA-CHECKLIST.md` untouched (specs still covered; the generated `Phase 0` block regenerates on merge).
