### PR TITLE
docs: reconcile daily-triage protocol (CONTRIBUTING ↔ triage skill)

### DIFF
--- a/.claude/skills/langflow-e2e-triage/SKILL.md
+++ b/.claude/skills/langflow-e2e-triage/SKILL.md
@@ -20,9 +20,14 @@ follow-up issues** — then closes the umbrella triage issue.
 This skill is the **producer** of the dedicated issues that the sibling
 `langflow-e2e-issues` / `langflow-e2e-issue-deterministic` skills later
 **consume** to drive to a fix PR. No overlap: **triage dispatches, resolution
-fixes.** This skill never investigates a failure's root cause and never
-touches test code — it reads a run, groups symptoms, and opens issues that
-direct someone else to investigate.
+fixes.** This skill never investigates a failure's root cause — it reads a
+run, groups symptoms, and opens issues that direct someone else to
+investigate. It is **non-mutating by default**: it never edits test code as a
+side effect of opening issues. The single exception is retiring `@stable` as
+prevention (recurrent flakes; hard failures are already auto-removed by the
+workflow), and that happens **only behind its own explicit authorization**
+(see the hard gate) — never bundled into issue creation, and it never restores
+a tag.
 
 Repo: `oriontech-me/langflow-e2e`.
 
@@ -40,12 +45,21 @@ Talk to the user in **Portuguese (PT-BR)**; produce every GitHub artifact
   abrir"). Do all analysis and grouping first; the gate is the only thing
   standing between plan and execution — don't erode it by creating "just the
   obvious one" early.
-- **Issue-dispatch only.** This skill never removes or restores `@stable`,
-  and never edits test code, spec docs, or `QA-CHECKLIST.md`. When a
-  recurrent flake needs manual `@stable` removal, the skill only **signals**
-  it in the dedicated issue's body (spec path, line, ready-to-run command) —
-  it never runs that removal itself. That PR belongs to a human or a
-  resolution skill.
+- **`@stable` removal: separate gate, never inadvertent.** Retiring `@stable`
+  is **prevention** — a broken test must stop running in the daily until it is
+  worked — so it is a **mandatory part of the triage**. But it is a
+  code-mutating action, so it is **never a side effect of opening issues**: it
+  requires its **own explicit authorization**, distinct from the issue-dispatch
+  approval, and the **exact diff (`spec:line`) is shown before** anything is
+  edited. Hard failures are already auto-removed by the workflow; only
+  **recurrent flakes** need a removal here (flake removal is never automatic).
+  The skill **never restores** a tag and never edits test *logic*, spec docs,
+  or `QA-CHECKLIST.md` — restoration is a deliverable of the dedicated issue.
+- **The triage does not close until the tags are gone.** The umbrella is closed
+  only after every criterion-required removal is **verified done** (tag absent
+  on `main` / its removal PR open and linked). If a removal was not authorized
+  or not completed, leave the umbrella **open** and report exactly what is
+  pending — never close on a half-done triage.
 - **Report faithfully.** Everything reported — panorama counts, recurrence,
   guard state, dedup matches — comes from the dataset the CLI emits or from
   live `gh` output. Never invent a count, a recurrence, or a signature; if the
@@ -167,11 +181,13 @@ each time) is **only noted** in the panorama — the retry budget absorbs
 single-run noise, and opening an issue for it would be triage noise of its
 own.
 
-For each actionable flake: the dedicated issue **signals** that `@stable`
-must be removed manually (list the exact spec path + line + a ready-to-run
-command) — **never remove it yourself**. Manual `@stable` removal for flakes
-is explicitly out of scope for this skill; it belongs to a follow-up PR from
-a human or a resolution skill.
+For each actionable flake, `@stable` must be retired **as prevention** (so the
+flake stops running in the daily until it is worked) — part of the triage, not
+a deferred follow-up. But the removal is a code change: **record the exact spec
+path + line here** and carry it into the plan (Phase 6) as its own row; it is
+executed only in Phase 7, behind its **own authorization** with the diff shown
+(never restore it here). The dedicated issue then carries **restoring
+`@stable`** as an explicit deliverable.
 
 ### Phase 5 — SKIPS
 
@@ -188,10 +204,16 @@ it to the user in PT-BR:
 |---|---|---|---|---|
 | 1 | ... | hard-failure / flake / skip | create / enrich / note | new issue title, or existing #NNN |
 
-Then **wait for explicit approval** ("pode abrir" or equivalent). Do not
-create, comment, or close anything until the user responds. If the user asks
-for changes to the grouping or wording, revise the plan and present it again
-— the gate re-applies to the revised plan too.
+Below the table, list the **`@stable` removals the triage requires** as a
+separate block — one line per recurrent flake (`spec/path.spec.ts:line`). Hard
+failures are already auto-removed by the workflow, so do **not** list them.
+
+Then **wait for explicit approval of the issue plan** ("pode abrir" or
+equivalent). This approval covers issue create/enrich/close **only** — it does
+**not** authorize any `@stable` removal; each removal gets its own confirmation
+in Phase 7. Do not create, comment, close, or edit anything until the user
+responds. If the user asks for changes to the grouping or wording, revise the
+plan and present it again — the gate re-applies to the revised plan too.
 
 ### Phase 7 — EXECUTE (post-approval only)
 
@@ -202,12 +224,29 @@ Only after the user approves the plan:
    `references/issue-templates.md`.
 2. For each **enrich** row: `gh issue comment` on the matched existing issue,
    per the same reference's *Enrich vs Create Rule*.
-3. Comment on the umbrella issue linking every dedicated issue just
+3. **`@stable` removals — separate authorization, one at a time.** For each
+   recurrent flake in the removals block: show the **exact diff** (the
+   `@stable` tag to drop, at `spec:line`) and ask for a **distinct**
+   confirmation (e.g. "pode remover a tag do teste X?"). Only on an explicit
+   yes, open the removal PR (branch off `main`, drop the tag, reference the
+   dedicated issue in the body — restoration is that issue's deliverable, never
+   done here). If the user declines or defers, **do not edit** — record the
+   removal as still pending. (Hard failures were already auto-removed by the
+   workflow; on a guard-tripped mass-failure day the tag is **kept** — no
+   removal in either case.)
+4. Comment on the umbrella issue linking every dedicated issue just
    created/enriched (so the umbrella's history stays a readable index).
-4. Close the umbrella: `gh issue close <umbrella_issue>`.
+5. **Close the umbrella only when the triage is truly complete:** every needed
+   dedicated issue created/enriched **and** every criterion-required `@stable`
+   removal **verified done** (tag absent on `main`, or its removal PR open and
+   linked). If any required removal is still pending (not authorized, not
+   opened), **leave the umbrella open** and tell the user exactly what remains
+   — never close on a half-done triage. Only when all are satisfied:
+   `gh issue close <umbrella_issue>`.
 
 Report back to the user in PT-BR with the final list of issue numbers/URLs
-created or enriched, and confirm the umbrella was closed.
+created or enriched, each `@stable`-removal PR opened (and any removal left
+pending), and whether the umbrella was closed or intentionally left open.
 
 ## Relationship to sibling skills
 

--- a/.claude/skills/langflow-e2e-triage/SKILL.md
+++ b/.claude/skills/langflow-e2e-triage/SKILL.md
@@ -251,7 +251,10 @@ pending), and whether the umbrella was closed or intentionally left open.
 ## Relationship to sibling skills
 
 - **`langflow-e2e-triage`** (this skill) — **producer**: turns one red daily
-  run into dedicated follow-up issues. Stops there.
+  run into dedicated follow-up issues and, as prevention, retires `@stable`
+  from recurrent flakes (behind its own gate — see the hard gates). It never
+  investigates a root cause, fixes a test, or restores a tag — restoration is
+  the consumer's deliverable.
 - **`langflow-e2e-issues`** / **`langflow-e2e-issue-deterministic`** —
   **consumers**: pick up a dedicated issue this skill spawned and drive it to
   a fix PR (their `daily-failure triage` classify-row explicitly says

--- a/.claude/skills/langflow-e2e-triage/references/issue-templates.md
+++ b/.claude/skills/langflow-e2e-triage/references/issue-templates.md
@@ -85,16 +85,18 @@ A checkbox list of concrete acceptance criteria. Format:
 ```markdown
 ## Deliverables (Done when)
 
-- [ ] Root cause confirmed per spec (regression vs. provider/latency vs. wait-strategy) with evidence on the current nightly.
+- [ ] Root cause confirmed per spec (product regression vs. test/wait-strategy vs. environment) with evidence on the current nightly.
 - [ ] Each spec passes reliably (multiple clean `--retries=0` runs), fixing waits/flow as needed.
-- [ ] `@stable` was **left in place** (not confirmed a durable break; likely wave collateral) — if any is later fixed with a code change, re-validate per `CONTRIBUTING.md`.
+- [ ] **`@stable` restored** in the fix PR — the tag was removed at triage as prevention (hard failures and recurrent flakes); re-validate per `CONTRIBUTING.md` before restoring. *(On a guard-tripped mass-failure day the tag is instead **kept** — then there is nothing to restore unless the cluster later reproduces on a clean daily and the tag is removed.)*
+- [ ] If the root cause is a **product (Langflow) regression**: recorded as such here, and this issue stays **open** until the upstream fix lands in `langflowai/langflow-nightly:latest` (or the `release-1.x.x` branch), is re-validated there, and `@stable` is restored — not on a test-side mute.
 ```
 
 Rules:
 - Boxes are checkable (`- [ ]`)
 - Each item is a single, verifiable outcome
 - Include validation steps from `CONTRIBUTING.md` if the fix touches product code
-- Explicitly state the `@stable` decision (leave in place, quarantine, or restore)
+- **Restoring `@stable` is always a deliverable** whenever the tag was removed at triage (the normal case) — "done" includes putting it back after the fix. Only a guard-tripped day, where the tag was kept, has nothing to restore.
+- A **product regression** closes only when the product is fixed where the suite runs (nightly / release branch), not on a test-side workaround
 
 ---
 
@@ -181,18 +183,18 @@ When an issue is opened to track a **recurrent flake** (a test failing on multip
 ```markdown
 ## Flake signal
 
-This test is confirmed recurrent (failed on dailies 2026-07-08, 2026-07-09, 2026-07-13). To prevent recurring false triage, `@stable` must be manually removed from:
+This test is confirmed recurrent (failed on dailies 2026-07-08, 2026-07-09, 2026-07-13). As prevention, `@stable` was removed at triage (PR #NNN) so it stops running in the daily until this issue is worked:
 
 - `tests/tests-automations/regression/core-functionality/playground/playground-input-text-prefill.spec.ts` (test at line 97)
 
-Removal should occur in a separate PR after root cause is confirmed and the fix is verified.
+Restoring `@stable` after the fix is a deliverable of this issue.
 ```
 
 Rules:
 - Include only when the failure appears across multiple independent daily runs
 - List **exact spec file paths** and test line numbers
-- State that `@stable` removal is manual and **out of scope** for the triage skill (it requires a code PR)
-- Do not suggest what to remove from — let the investigator decide based on the root cause
+- `@stable` removal is manual (the workflow never auto-removes flakes) and happens **at triage as prevention** — it is not deferred until after the fix; link the removal PR (`#NNN`)
+- Restoring `@stable` after the fix is an explicit **deliverable** of this issue
 
 ---
 
@@ -255,6 +257,6 @@ Every dedicated issue embodies this philosophy:
 - **Description before diagnosis:** symptom table + preliminary observations, no verdict
 - **Investigation as independent branches:** test the product first, then environment, then test design
 - **Deliverables as checkboxes:** done when all items are ticked
-- **`@stable` decisions are explicit:** leave in place, restore, or quarantine — always documented
+- **`@stable` decisions are explicit:** removed at triage as prevention (or kept on a guard-tripped day), and **restored as a deliverable** after the fix — always documented
 
 This ensures investigators inherit not just a failure, but the context and constraints needed to fix it efficiently.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -556,7 +556,7 @@ On a red scheduled `daily-stable.yml` run, the workflow does two things **automa
 1. Removes `@stable` from **every hard failure** (a test that failed all retries), regenerates `QA-CHECKLIST.md`, and commits it to `main` with `[skip ci]` — no PR, no approval. If the mass-failure guard trips (too many at once → treated as infra), nothing is removed.
 2. Opens a single **triage issue** for the run, listing what was removed.
 
-The triage issue is the analyst's **inbox and dispatcher** — not the tracking issue for each problem. Its only deliverable is the **triage itself**: read the run, route each occurrence into a dedicated issue (or enrich an existing one), and then **close the triage issue**. It never carries an investigation or a fix. When the mass-failure guard trips (see below), the triage gains one extra deliverable: **decide whether the day was environmental** and, if not, **manually remove `@stable`** from the real hard failures. The human steps are the fan-out, the manual removal for recurrent flakes, and the restoration.
+The triage issue is the analyst's **inbox and dispatcher** — not the tracking issue for each problem. Its only deliverable is the **triage itself**: read the run, route each occurrence into a dedicated issue (or enrich an existing one), and then **close the triage issue**. It never carries an investigation or a fix. The triage issue is closed **only once the triage is complete** — every needed dedicated issue created or enriched (hard failure / flake / skip, per the criteria below) **and** `@stable` removed from every test the criteria require (hard failures: auto-removed by the workflow; recurrent flakes: removed via PR at this point, as prevention). When the mass-failure guard trips (see below), the triage gains one extra deliverable: **decide whether the day was environmental** and, if not, **manually remove `@stable`** from the real hard failures. The human steps are the fan-out, the manual removal for recurrent flakes, and the restoration.
 
 The runbook — order, dedup, analysis depth, and how the follow-up issue must be written — is in **[Triage protocol — working the triage issue](#triage-protocol--working-the-triage-issue)** below.
 
@@ -602,7 +602,7 @@ The triage is **dispatch, not solution**. Its analysis is **preliminary and desc
 
 **2. Flakes (second).** Consult `reports/daily-history.jsonl`.
 - Open an issue **only for a recurrent flake**. A first occurrence is **only noted** in the triage — the retry budget absorbs single-run noise.
-- **Recurrence window: 30 days.** The criterion is the **cause, not the count**: it is not enough that the test flaked 2+ times in the window — the occurrences must share the **same `error_signature`** (the cheap, descriptive proxy for "same cause" at triage time). Same signature within the window → recurrent → open a **dedicated issue and remove `@stable` via PR** (flake removal is always manual; the workflow never auto-removes flakes). *(30 days is a revisable convention, not an absolute.)*
+- **Recurrence window: 30 days.** The criterion is the **cause, not the count**: it is not enough that the test flaked 2+ times in the window — the occurrences must share the **same `error_signature`** (the cheap, descriptive proxy for "same cause" at triage time). Same signature within the window → recurrent → open a **dedicated issue and remove `@stable` via PR as prevention** (flake removal is always manual; the workflow never auto-removes flakes) — so the flaky test stops running in the daily until it is worked. Restoring the tag is a **deliverable of that issue**, done after the fix. *(30 days is a revisable convention, not an absolute.)*
 
 **3. Skips (third).**
 - Analyse the **reason** for each skip.
@@ -632,10 +632,12 @@ The dedicated issue spun out of the triage must be **clear and agnostic**:
 | Assertion fails but the UI works correctly in manual testing | Test wrong — fix assertion logic |
 | Assertion fails and manual testing confirms the same failure | Product broke — flag upstream |
 
-**Restoration (upon fixing the problem):**
+**Restoration is a deliverable of the dedicated issue (upon fixing the problem):**
 1. Fix the test following the validation guide (all 5 steps), or confirm the Langflow regression is resolved.
-2. **Re-add the `@stable` tag** in the correction PR — restoration is always manual, for both hard failures and flakes.
+2. **Re-add the `@stable` tag** in the correction PR — restoration is always manual, for both hard failures and flakes. The tag was removed as prevention (so the broken test stopped running in the daily); putting it back is an **explicit deliverable** of the dedicated issue, not an optional follow-up.
 3. Reference the dedicated issue in the PR body; close it upon merge.
+
+**When the root cause is a product (Langflow) regression:** record it explicitly in the dedicated issue and **do not close the issue on a test-side workaround**. The issue stays **open** until the upstream fix has landed in the `langflowai/langflow-nightly:latest` image (or the corresponding `release-1.x.x` branch), the behavior is re-validated against it, and `@stable` is restored. A product regression is only "done" when the product is fixed where the suite runs — not when the test is muted.
 
 The spec doc is **not updated** during this cycle — the auto-removal commit, the dedicated issue, and the restoration PR are the traceability record.
 
@@ -655,7 +657,7 @@ Then compare the signatures — the action depends on **what** recurred (same ca
 |---|---|---|
 | Hard failure (all retries failed) | any | `@stable` was already auto-removed (or the mass-failure guard tripped and left it in place). No manual removal — classify on the dedicated issue and restore the tag when the test is fixed. |
 | Flake (passed on retry) | No matching signature in the last 30 days | Note in the triage; **do not** open an issue yet. The retry budget absorbs single-run noise. |
-| Flake (recurrent) | **Same `error_signature`** seen before within 30 days | Open a **dedicated issue** (`bug` + `area:<...>`, cite the run ids) **and remove `@stable` via PR**. Flake removal is manual — the workflow never auto-removes flakes. Restore the tag once the flakiness is fixed. |
+| Flake (recurrent) | **Same `error_signature`** seen before within 30 days | Open a **dedicated issue** (`daily-failure` + `area:<...>`, cite the run ids) **and remove `@stable` via PR as prevention**. Flake removal is manual — the workflow never auto-removes flakes. Restoring the tag is a **deliverable of that dedicated issue**. |
 | Flake with a **different** signature | Prior flake on the same test, but a different signature | Treat as a first occurrence of a **new cause** — note it; the raw count alone does not trigger an issue. |
 | Mix (hard-failed one day, flaky later) | 2+ days | The hard-fail day already auto-removed `@stable`; once restored, apply the flake rows above if the flakiness persists. |
 


### PR DESCRIPTION
## What

Reconciles `CONTRIBUTING.md` → *Triage protocol* with the `langflow-e2e-triage` skill (added in #774) so the two state **one** protocol. Docs + skill only — no test code.

## Why

Reviewing #774 (*"feat(triage): langflow-e2e-triage skill — automate daily-run triage dispatch"*, by @rafaelgiln) surfaced four points where the newly added skill and the docs disagreed. This PR reconciles them. Verified against real dedicated issues (#751/#747/#722/#748) and against Langflow's daily-stable workflow.

## Changes

**1. Dedicated-issue label: `bug` → `daily-failure`**
`CONTRIBUTING.md` told the analyst to open the recurrent-flake issue with `bug` + `area:`, but every real dedicated issue uses `daily-failure` + `area:` — never `bug`. The doc now matches the standing practice (and the skill).

**2. `@stable` removal is prevention at triage time — not deferred**
The tag comes off **at triage**, as prevention, so a broken test stops running in the daily until it is worked. The skill was reframed:
- **Non-mutating by default** — it never edits `.spec.ts` as a side effect of opening issues.
- Removal is a **first-class action behind its own explicit authorization**, distinct from the issue-dispatch approval, with the exact `spec:line` diff shown before any edit.
- **The umbrella cannot close** until every criterion-required removal is verified done; otherwise it stays open with the pending items reported. This keeps the workflow invariant ("triage isn't done until the tags are gone") without any inadvertent code edit.

**3. Restoration is an explicit deliverable; product regressions gate closure**
Re-establishing `@stable` is now stated (skill + docs) as a **deliverable** of the dedicated issue. When the root cause is a **product (Langflow) regression**, the issue stays **open** until the upstream fix lands in `langflowai/langflow-nightly:latest` (or the `release-1.x.x` branch), is re-validated there, and the tag is restored — never closed on a test-side mute.

**4. When the umbrella closes**
Stated explicitly: the umbrella is closed once triage is **complete** — every needed dedicated issue created/enriched (hard failure / flake / skip per the criteria) **and** every `@stable` tag removed where the criteria require it.

Bonus: the dedicated-issue Deliverables template now covers **both** variants — normal day (tag removed → restore) and guard-tripped mass-failure day (tag kept) — closing a gap where only the guard-tripped example existed.

Closes #777
