### PR TITLE
test(ui-ux): validate & promote execution-error notification to @stable (#688)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -439,7 +439,7 @@
 
 #### 8.2 Notifications
 - [x] System notifications — build-success entry shows in the notifications tab → `notifications.spec.ts`
-- [-] Execution error notification
+- [x] Execution error notification → `ui-ux/execution-error-notification.spec.ts`
 - [-] Outdated component notification
 
 #### 8.3 User State

--- a/docs/ui-ux/execution-error-notification.md
+++ b/docs/ui-ux/execution-error-notification.md
@@ -18,9 +18,12 @@ silent hang. Three failure modes, each against the real execution endpoint
    failed"** with detail **"Failed to fetch"** (the browser's transport-error
    message — the distinctive signal that separates a network failure from a
    server-side failure).
-2. **Server error (5xx)** — the execution request returns an HTTP 5xx (503). The
-   UI must report **"Workflow run failed"** (server-detail path, distinct from
-   the transport "Failed to fetch" message).
+2. **Server error (5xx) (`@stable`, §8.2 "Execution error notification")** — the
+   execution request returns an HTTP 5xx (503). The UI must report **"Workflow
+   run failed"** in the persistent notification center (server-detail path,
+   distinct from the transport "Failed to fetch" message). This is the §8.2
+   execution-error notification: a genuine run failure produces a notification
+   entry.
 3. **Loading state** — while a delayed execution is in flight, the UI must show
    an in-progress affordance (stop button / disabled send / spinner) so the user
    knows work is happening.
@@ -34,12 +37,21 @@ one.
 ## Tags *(required)*
 
 - **Network-error test:** `@stable` `@release` `@workspace` `@observability`
-- **Server-error & loading-state tests:** `@release` `@workspace` `@observability`
+- **Server-error test:** `@stable` `@release` `@workspace` `@observability`
+- **Loading-state test:** `@release` `@workspace` `@observability`
 
-Only the network-error test is promoted to `@stable` under #693 (its §8.4
-bullet). The two sibling tests share the same file and the same
-endpoint-migration fix (see Notes) but remain `@release` — they map to separate
-§8.4 bullets not in this issue's scope.
+Two tests are `@stable`, promoted under separate checklist bullets:
+- The **network-error** test maps to §8.4 "Network error during execution"
+  (promoted under #693).
+- The **server-error** test maps to §8.2 Notifications → "Execution error
+  notification" (promoted under #688): a genuine server-side execution failure
+  (5xx) surfaces a persistent notification entry. This is the distinctive
+  §8.2 observable — the error notification itself, independent of the transport
+  layer.
+
+The **loading-state** test remains `@release`: it validates the in-progress
+affordance, not an error notification, so it maps to neither §8.2 nor a
+promotion bullet in scope.
 
 ---
 

--- a/tests/tests-automations/regression/ui-ux/execution-error-notification.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/execution-error-notification.spec.ts
@@ -136,7 +136,7 @@ test.describe("Execution Error Notifications", () => {
 
   test(
     "executing flow with server error shows error feedback",
-    { tag: ["@release", "@workspace", "@observability"] },
+    { tag: ["@stable", "@release", "@workspace", "@observability"] },
     async ({ page }) => {
       (page as any).allowFlowErrors();
       trackCreatedFlows(page);


### PR DESCRIPTION
Closes #688

Promotes the **§8.2 "Execution error notification"** bullet in `QA-CHECKLIST.md` to `@stable`. The behavior — a genuine server-side execution failure surfaces a persistent notification entry — is a distinct journey from the sibling network-error test (§8.4, transport layer), so §8.2 gets its own `@stable` guard.

## 1. Covered tests
| # | Test | What it validates |
|---|------|-------------------|
| 1 | `executing flow with server error shows error feedback` | Mock 503 on `POST /api/v2/workflows`; the persistent notifications dropdown (`notification-dropdown-content`) shows **"Workflow run failed"** — the §8.2 execution-error notification. Catches a regression where a server-side run failure would fail silently. |

Sibling tests in the same file stay as-is: `network error` (already `@stable`, §8.4) and `loading state` (`@release`).

## 2. How the test was built
- **No code logic changed** — promotion only. Sole diff to the spec is adding `@stable` to the server-error test's tag array (keeps `@release @workspace @observability`).
- Spec was already live-confirmed on 1.11.0.dev41 (asserts the persistent dropdown, not the auto-dismissing toast — avoids the toast-fade race, #695).
- Uses **503** (not 500) so the fixture's global backend-error monitor (400/404/422/500) is not tripped on the shared instance.
- Flow cleanup: ids captured from `POST /api/v1/flows → 201` and deleted id-scoped in `afterEach`.

## 3. Dependencies
- **None** — pure UI; the execution endpoint is mocked before reaching any provider (no API key).
- Execution mode: parallel-safe (each test self-contained; id-scoped cleanup).

## Validation (nightly 1.11.0.dev44, `--retries=0 --workers=1`)
- typecheck ✅ (0 errors) · eslint ✅ (0 errors) · QA-CHECKLIST diff ✅
- 3/3 clean burst runs — `expected=3 unexpected=0 flaky=0`, zero backend errors ✅
- force-fail ✅ — all 3 `test()` in the file mutated → `unexpected=1` each, reverted, final green run ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)