### PR TITLE
fix(observability): refresh trace fixture to current schema + restore @stable (#747)

### DIFF
--- a/tests/assets/flows/basic-prompting-trace-fixture.json
+++ b/tests/assets/flows/basic-prompting-trace-fixture.json
@@ -1,6 +1,6 @@
 {
   "name": "Basic Prompting Trace Fixture",
-  "description": "Fixture used by observability-monitoring traces test to generate trace entries via API. Run will fail with \"A model selection is required\" \u2014 that is intentional; the failure still emits a trace.",
+  "description": "Fixture used by observability-monitoring traces test to generate trace entries via API. Run will fail with \"A model selection is required\" — that is intentional; the failure still emits a trace.",
   "data": {
     "edges": [
       {
@@ -24,12 +24,12 @@
             "type": "str"
           }
         },
-        "id": "reactflow__edge-ChatInput-b6UCc{\u0153dataType\u0153:\u0153ChatInput\u0153,\u0153id\u0153:\u0153ChatInput-b6UCc\u0153,\u0153name\u0153:\u0153message\u0153,\u0153output_types\u0153:[\u0153Message\u0153]}-LanguageModelComponent-FLeYF{\u0153fieldName\u0153:\u0153input_value\u0153,\u0153id\u0153:\u0153LanguageModelComponent-FLeYF\u0153,\u0153inputTypes\u0153:[\u0153Message\u0153],\u0153type\u0153:\u0153str\u0153}",
+        "id": "reactflow__edge-ChatInput-b6UCc{œdataTypeœ:œChatInputœ,œidœ:œChatInput-b6UCcœ,œnameœ:œmessageœ,œoutput_typesœ:[œMessageœ]}-LanguageModelComponent-FLeYF{œfieldNameœ:œinput_valueœ,œidœ:œLanguageModelComponent-FLeYFœ,œinputTypesœ:[œMessageœ],œtypeœ:œstrœ}",
         "selected": false,
         "source": "ChatInput-b6UCc",
-        "sourceHandle": "{\u0153dataType\u0153: \u0153ChatInput\u0153, \u0153id\u0153: \u0153ChatInput-b6UCc\u0153, \u0153name\u0153: \u0153message\u0153, \u0153output_types\u0153: [\u0153Message\u0153]}",
+        "sourceHandle": "{œdataTypeœ: œChatInputœ, œidœ: œChatInput-b6UCcœ, œnameœ: œmessageœ, œoutput_typesœ: [œMessageœ]}",
         "target": "LanguageModelComponent-FLeYF",
-        "targetHandle": "{\u0153fieldName\u0153: \u0153input_value\u0153, \u0153id\u0153: \u0153LanguageModelComponent-FLeYF\u0153, \u0153inputTypes\u0153: [\u0153Message\u0153], \u0153type\u0153: \u0153str\u0153}"
+        "targetHandle": "{œfieldNameœ: œinput_valueœ, œidœ: œLanguageModelComponent-FLeYFœ, œinputTypesœ: [œMessageœ], œtypeœ: œstrœ}"
       },
       {
         "animated": false,
@@ -52,12 +52,12 @@
             "type": "str"
           }
         },
-        "id": "reactflow__edge-Prompt-t2oaK{\u0153dataType\u0153:\u0153Prompt\u0153,\u0153id\u0153:\u0153Prompt-t2oaK\u0153,\u0153name\u0153:\u0153prompt\u0153,\u0153output_types\u0153:[\u0153Message\u0153]}-LanguageModelComponent-FLeYF{\u0153fieldName\u0153:\u0153system_message\u0153,\u0153id\u0153:\u0153LanguageModelComponent-FLeYF\u0153,\u0153inputTypes\u0153:[\u0153Message\u0153],\u0153type\u0153:\u0153str\u0153}",
+        "id": "reactflow__edge-Prompt-t2oaK{œdataTypeœ:œPromptœ,œidœ:œPrompt-t2oaKœ,œnameœ:œpromptœ,œoutput_typesœ:[œMessageœ]}-LanguageModelComponent-FLeYF{œfieldNameœ:œsystem_messageœ,œidœ:œLanguageModelComponent-FLeYFœ,œinputTypesœ:[œMessageœ],œtypeœ:œstrœ}",
         "selected": false,
         "source": "Prompt-t2oaK",
-        "sourceHandle": "{\u0153dataType\u0153: \u0153Prompt\u0153, \u0153id\u0153: \u0153Prompt-t2oaK\u0153, \u0153name\u0153: \u0153prompt\u0153, \u0153output_types\u0153: [\u0153Message\u0153]}",
+        "sourceHandle": "{œdataTypeœ: œPromptœ, œidœ: œPrompt-t2oaKœ, œnameœ: œpromptœ, œoutput_typesœ: [œMessageœ]}",
         "target": "LanguageModelComponent-FLeYF",
-        "targetHandle": "{\u0153fieldName\u0153: \u0153system_message\u0153, \u0153id\u0153: \u0153LanguageModelComponent-FLeYF\u0153, \u0153inputTypes\u0153: [\u0153Message\u0153], \u0153type\u0153: \u0153str\u0153}"
+        "targetHandle": "{œfieldNameœ: œsystem_messageœ, œidœ: œLanguageModelComponent-FLeYFœ, œinputTypesœ: [œMessageœ], œtypeœ: œstrœ}"
       },
       {
         "animated": false,
@@ -84,12 +84,12 @@
             "type": "str"
           }
         },
-        "id": "reactflow__edge-LanguageModelComponent-FLeYF{\u0153dataType\u0153:\u0153LanguageModelComponent\u0153,\u0153id\u0153:\u0153LanguageModelComponent-FLeYF\u0153,\u0153name\u0153:\u0153text_output\u0153,\u0153output_types\u0153:[\u0153Message\u0153]}-ChatOutput-yK0AU{\u0153fieldName\u0153:\u0153input_value\u0153,\u0153id\u0153:\u0153ChatOutput-yK0AU\u0153,\u0153inputTypes\u0153:[\u0153Data\u0153,\u0153JSON\u0153,\u0153DataFrame\u0153,\u0153Table\u0153,\u0153Message\u0153],\u0153type\u0153:\u0153str\u0153}",
+        "id": "reactflow__edge-LanguageModelComponent-FLeYF{œdataTypeœ:œLanguageModelComponentœ,œidœ:œLanguageModelComponent-FLeYFœ,œnameœ:œtext_outputœ,œoutput_typesœ:[œMessageœ]}-ChatOutput-yK0AU{œfieldNameœ:œinput_valueœ,œidœ:œChatOutput-yK0AUœ,œinputTypesœ:[œDataœ,œJSONœ,œDataFrameœ,œTableœ,œMessageœ],œtypeœ:œstrœ}",
         "selected": false,
         "source": "LanguageModelComponent-FLeYF",
-        "sourceHandle": "{\u0153dataType\u0153: \u0153LanguageModelComponent\u0153, \u0153id\u0153: \u0153LanguageModelComponent-FLeYF\u0153, \u0153name\u0153: \u0153text_output\u0153, \u0153output_types\u0153: [\u0153Message\u0153]}",
+        "sourceHandle": "{œdataTypeœ: œLanguageModelComponentœ, œidœ: œLanguageModelComponent-FLeYFœ, œnameœ: œtext_outputœ, œoutput_typesœ: [œMessageœ]}",
         "target": "ChatOutput-yK0AU",
-        "targetHandle": "{\u0153fieldName\u0153: \u0153input_value\u0153, \u0153id\u0153: \u0153ChatOutput-yK0AU\u0153, \u0153inputTypes\u0153: [\u0153Data\u0153, \u0153JSON\u0153, \u0153DataFrame\u0153, \u0153Table\u0153, \u0153Message\u0153], \u0153type\u0153: \u0153str\u0153}"
+        "targetHandle": "{œfieldNameœ: œinput_valueœ, œidœ: œChatOutput-yK0AUœ, œinputTypesœ: [œDataœ, œJSONœ, œDataFrameœ, œTableœ, œMessageœ], œtypeœ: œstrœ}"
       }
     ],
     "nodes": [
@@ -128,7 +128,7 @@
                 "dependencies": [
                   {
                     "name": "lfx",
-                    "version": null
+                    "version": "1.11.0.dev36"
                   }
                 ],
                 "total_dependencies": 1
@@ -337,7 +337,6 @@
           "type": "ChatInput"
         },
         "dragging": false,
-        "height": 234,
         "id": "ChatInput-b6UCc",
         "measured": {
           "height": 234,
@@ -387,7 +386,7 @@
                 "dependencies": [
                   {
                     "name": "lfx",
-                    "version": null
+                    "version": "1.11.0.dev36"
                   }
                 ],
                 "total_dependencies": 1
@@ -500,7 +499,6 @@
           "type": "Prompt"
         },
         "dragging": false,
-        "height": 260,
         "id": "Prompt-t2oaK",
         "measured": {
           "height": 260,
@@ -521,7 +519,7 @@
         "data": {
           "id": "undefined-Ua7t1",
           "node": {
-            "description": "# \ud83d\udcd6 README\nThis template demonstrates a standard chat flow with additional instructions provided by a prompt. Prompts provide instructions and inputs for a Large Language Model (LLM) beyond the standard user-provided chat input. In this example, the prompt describes the LLM's role and persona.\n\n## Quick start\n1. Configure your **Model Provider** with your API credentials.\n2. Open the **Playground** to start the chat and run the flow.\n\n## Next steps\nChange the prompt template, model, or model settings, such as **Temperature**, and then see how the responses change with these different inputs.\n\ud83d\udca1 Some component settings are hidden by default; to view all settings click **Controls** in each component's header menu.\n\ud83d\udca1 You can use curly braces to create variables in your template, such as `{variable}`. These can be populated from other components, with Langflow global variables, or at runtime.",
+            "description": "# 📖 README\nThis template demonstrates a standard chat flow with additional instructions provided by a prompt. Prompts provide instructions and inputs for a Large Language Model (LLM) beyond the standard user-provided chat input. In this example, the prompt describes the LLM's role and persona.\n\n## Quick start\n1. Configure your **Model Provider** with your API credentials.\n2. Open the **Playground** to start the chat and run the flow.\n\n## Next steps\nChange the prompt template, model, or model settings, such as **Temperature**, and then see how the responses change with these different inputs.\n💡 Some component settings are hidden by default; to view all settings click **Controls** in each component's header menu.\n💡 You can use curly braces to create variables in your template, such as `{variable}`. These can be populated from other components, with Langflow global variables, or at runtime.",
             "display_name": "",
             "documentation": "",
             "i18n_key": "template_notes.basic_prompting.bd8ff52b",
@@ -626,15 +624,15 @@
                 "dependencies": [
                   {
                     "name": "orjson",
-                    "version": "3.11.8"
+                    "version": "3.11.9"
                   },
                   {
                     "name": "fastapi",
-                    "version": "0.136.1"
+                    "version": "0.139.0"
                   },
                   {
                     "name": "lfx",
-                    "version": null
+                    "version": "1.11.0.dev36"
                   }
                 ],
                 "total_dependencies": 3
@@ -854,7 +852,6 @@
           "type": "ChatOutput"
         },
         "dragging": false,
-        "height": 234,
         "id": "ChatOutput-yK0AU",
         "measured": {
           "height": 234,
@@ -869,8 +866,7 @@
           "y": 872.7273956769025
         },
         "selected": false,
-        "type": "genericNode",
-        "width": 320
+        "type": "genericNode"
       },
       {
         "data": {
@@ -889,6 +885,8 @@
             "edited": false,
             "field_order": [
               "model",
+              "model_name",
+              "provider",
               "api_key",
               "base_url_ibm_watsonx",
               "project_id",
@@ -905,7 +903,7 @@
             "legacy": false,
             "lf_version": "1.7.0",
             "metadata": {
-              "code_hash": "7fe3257f2169",
+              "code_hash": "4942994b24a6",
               "dependencies": {
                 "dependencies": [
                   {
@@ -1041,7 +1039,7 @@
                 "show": true,
                 "title_case": false,
                 "type": "code",
-                "value": "from lfx.base.models.model import LCModelComponent\nfrom lfx.base.models.unified_models import (\n    get_llm,\n    handle_model_input_update,\n)\nfrom lfx.base.models.watsonx_constants import IBM_WATSONX_URLS\nfrom lfx.field_typing.constants import LanguageModel\nfrom lfx.field_typing.range_spec import RangeSpec\nfrom lfx.inputs.inputs import BoolInput, DropdownInput, StrInput\nfrom lfx.io import IntInput, MessageInput, ModelInput, MultilineInput, SecretStrInput, SliderInput\n\nDEFAULT_OLLAMA_URL = \"http://localhost:11434\"\n\n\nclass LanguageModelComponent(LCModelComponent):\n    display_name = \"Language Model\"\n    description = \"Runs a language model given a specified provider.\"\n    documentation: str = \"https://docs.langflow.org/components-models\"\n    icon = \"brain-circuit\"\n    category = \"models\"\n\n    inputs = [\n        ModelInput(\n            name=\"model\",\n            display_name=\"Language Model\",\n            info=\"Select your model provider\",\n            real_time_refresh=True,\n            required=True,\n        ),\n        SecretStrInput(\n            name=\"api_key\",\n            display_name=\"API Key\",\n            info=\"Overrides global provider settings. Leave blank to use your pre-configured API Key.\",\n            required=False,\n            show=True,\n            real_time_refresh=True,\n            advanced=True,\n        ),\n        DropdownInput(\n            name=\"base_url_ibm_watsonx\",\n            display_name=\"watsonx API Endpoint\",\n            info=\"The base URL of the API (IBM watsonx.ai only)\",\n            options=IBM_WATSONX_URLS,\n            value=IBM_WATSONX_URLS[0],\n            combobox=True,\n            show=False,\n            real_time_refresh=True,\n        ),\n        StrInput(\n            name=\"project_id\",\n            display_name=\"watsonx Project ID\",\n            info=\"The project ID associated with the foundation model (IBM watsonx.ai only)\",\n            show=False,\n            required=False,\n        ),\n        StrInput(\n            name=\"ollama_base_url\",\n            display_name=\"Ollama API URL\",\n            info=f\"Endpoint of the Ollama API (Ollama only). Defaults to {DEFAULT_OLLAMA_URL}\",\n            value=DEFAULT_OLLAMA_URL,\n            show=False,\n            real_time_refresh=True,\n        ),\n        MessageInput(\n            name=\"input_value\",\n            display_name=\"Input\",\n            info=\"The input text to send to the model\",\n        ),\n        MultilineInput(\n            name=\"system_message\",\n            display_name=\"System Message\",\n            info=\"A system message that helps set the behavior of the assistant\",\n            advanced=False,\n        ),\n        BoolInput(\n            name=\"stream\",\n            display_name=\"Stream\",\n            info=\"Whether to stream the response\",\n            value=False,\n            advanced=True,\n        ),\n        SliderInput(\n            name=\"temperature\",\n            display_name=\"Temperature\",\n            value=0.1,\n            info=\"Controls randomness in responses\",\n            range_spec=RangeSpec(min=0, max=1, step=0.01),\n            advanced=True,\n        ),\n        IntInput(\n            name=\"max_tokens\",\n            display_name=\"Max Tokens\",\n            info=\"Maximum number of tokens to generate. Field name varies by provider.\",\n            advanced=True,\n            range_spec=RangeSpec(min=1, max=128000, step=1, step_type=\"int\"),\n        ),\n    ]\n\n    def build_model(self) -> LanguageModel:\n        return get_llm(\n            model=self.model,\n            user_id=self.user_id,\n            api_key=self.api_key,\n            temperature=self.temperature,\n            stream=self.stream,\n            max_tokens=getattr(self, \"max_tokens\", None),\n            watsonx_url=getattr(self, \"base_url_ibm_watsonx\", None),\n            watsonx_project_id=getattr(self, \"project_id\", None),\n            ollama_base_url=getattr(self, \"ollama_base_url\", None),\n        )\n\n    def update_build_config(self, build_config: dict, field_value: str, field_name: str | None = None):\n        \"\"\"Dynamically update build config with user-filtered model options.\"\"\"\n        return handle_model_input_update(self, build_config, field_value, field_name)\n"
+                "value": "from lfx.base.models.model import LCModelComponent\nfrom lfx.base.models.unified_models import (\n    get_language_model_options,\n    get_llm,\n    handle_model_input_update,\n)\nfrom lfx.base.models.watsonx_constants import IBM_WATSONX_URLS\nfrom lfx.components.models_and_agents.model_selection import apply_model_overrides\nfrom lfx.field_typing.constants import LanguageModel\nfrom lfx.field_typing.range_spec import RangeSpec\nfrom lfx.inputs.inputs import BoolInput, DropdownInput, StrInput\nfrom lfx.io import IntInput, MessageInput, ModelInput, MultilineInput, SecretStrInput, SliderInput\n\nDEFAULT_OLLAMA_URL = \"http://localhost:11434\"\n\n\nclass LanguageModelComponent(LCModelComponent):\n    display_name = \"Language Model\"\n    description = \"Runs a language model given a specified provider.\"\n    documentation: str = \"https://docs.langflow.org/components-models\"\n    icon = \"brain-circuit\"\n    category = \"models\"\n\n    inputs = [\n        ModelInput(\n            name=\"model\",\n            display_name=\"Language Model\",\n            info=\"Select your model provider\",\n            real_time_refresh=True,\n            required=True,\n        ),\n        StrInput(\n            name=\"model_name\",\n            display_name=\"Model Name Override\",\n            info=(\n                \"Optional model name to use instead of the selected model. \"\n                \"Can be set from a global variable for runtime model selection.\"\n            ),\n            advanced=True,\n            load_from_db=False,\n        ),\n        StrInput(\n            name=\"provider\",\n            display_name=\"Provider Override\",\n            info=(\n                \"Optional provider to use with Model Name Override. Leave blank to use the selected model's provider.\"\n            ),\n            advanced=True,\n            load_from_db=False,\n        ),\n        SecretStrInput(\n            name=\"api_key\",\n            display_name=\"API Key\",\n            info=\"Overrides global provider settings. Leave blank to use your pre-configured API Key.\",\n            required=False,\n            show=True,\n            real_time_refresh=True,\n            advanced=True,\n        ),\n        DropdownInput(\n            name=\"base_url_ibm_watsonx\",\n            display_name=\"watsonx API Endpoint\",\n            info=\"The base URL of the API (IBM watsonx.ai only)\",\n            options=IBM_WATSONX_URLS,\n            value=IBM_WATSONX_URLS[0],\n            combobox=True,\n            show=False,\n            real_time_refresh=True,\n        ),\n        StrInput(\n            name=\"project_id\",\n            display_name=\"watsonx Project ID\",\n            info=\"The project ID associated with the foundation model (IBM watsonx.ai only)\",\n            show=False,\n            required=False,\n        ),\n        StrInput(\n            name=\"ollama_base_url\",\n            display_name=\"Ollama API URL\",\n            info=f\"Endpoint of the Ollama API (Ollama only). Defaults to {DEFAULT_OLLAMA_URL}\",\n            value=DEFAULT_OLLAMA_URL,\n            show=False,\n            real_time_refresh=True,\n        ),\n        MessageInput(\n            name=\"input_value\",\n            display_name=\"Input\",\n            info=\"The input text to send to the model\",\n        ),\n        MultilineInput(\n            name=\"system_message\",\n            display_name=\"System Message\",\n            info=\"A system message that helps set the behavior of the assistant\",\n            advanced=False,\n        ),\n        BoolInput(\n            name=\"stream\",\n            display_name=\"Stream\",\n            info=\"Whether to stream the response\",\n            value=False,\n            advanced=True,\n        ),\n        SliderInput(\n            name=\"temperature\",\n            display_name=\"Temperature\",\n            value=0.1,\n            info=\"Controls randomness in responses\",\n            range_spec=RangeSpec(min=0, max=1, step=0.01),\n            advanced=True,\n        ),\n        IntInput(\n            name=\"max_tokens\",\n            display_name=\"Max Tokens\",\n            info=\"Maximum number of tokens to generate. Field name varies by provider.\",\n            advanced=True,\n            range_spec=RangeSpec(min=1, max=128000, step=1, step_type=\"int\"),\n        ),\n    ]\n\n    def build_model(self) -> LanguageModel:\n        model = apply_model_overrides(\n            self.model,\n            model_name=getattr(self, \"model_name\", None),\n            provider=getattr(self, \"provider\", None),\n            user_id=self.user_id,\n            get_options=get_language_model_options,\n        )\n        return get_llm(\n            model=model,\n            user_id=self.user_id,\n            api_key=self.api_key,\n            temperature=self.temperature,\n            stream=self.stream,\n            max_tokens=getattr(self, \"max_tokens\", None),\n            watsonx_url=getattr(self, \"base_url_ibm_watsonx\", None),\n            watsonx_project_id=getattr(self, \"project_id\", None),\n            ollama_base_url=getattr(self, \"ollama_base_url\", None),\n        )\n\n    def update_build_config(self, build_config: dict, field_value: str, field_name: str | None = None):\n        \"\"\"Dynamically update build config with user-filtered model options.\"\"\"\n        return handle_model_input_update(self, build_config, field_value, field_name)\n"
               },
               "input_value": {
                 "_input_type": "MessageInput",
@@ -1069,6 +1067,32 @@
                 "value": ""
               },
               "is_refresh": false,
+              "max_tokens": {
+                "_input_type": "IntInput",
+                "advanced": true,
+                "display_name": "Max Tokens",
+                "dynamic": false,
+                "info": "Maximum number of tokens to generate. Field name varies by provider.",
+                "list": false,
+                "list_add_label": "Add More",
+                "name": "max_tokens",
+                "override_skip": false,
+                "placeholder": "",
+                "range_spec": {
+                  "max": 128000.0,
+                  "min": 1.0,
+                  "step": 1.0,
+                  "step_type": "int"
+                },
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "track_in_telemetry": true,
+                "type": "int",
+                "value": 0
+              },
               "model": {
                 "_input_type": "ModelInput",
                 "advanced": false,
@@ -1107,15 +1131,34 @@
                 "type": "model",
                 "value": ""
               },
+              "model_name": {
+                "_input_type": "StrInput",
+                "advanced": true,
+                "display_name": "Model Name Override",
+                "dynamic": false,
+                "info": "Optional model name to use instead of the selected model. Can be set from a global variable for runtime model selection.",
+                "list": false,
+                "list_add_label": "Add More",
+                "load_from_db": false,
+                "name": "model_name",
+                "override_skip": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "track_in_telemetry": false,
+                "type": "str",
+                "value": ""
+              },
               "ollama_base_url": {
-                "_input_type": "MessageInput",
+                "_input_type": "StrInput",
                 "advanced": false,
                 "display_name": "Ollama API URL",
                 "dynamic": false,
                 "info": "Endpoint of the Ollama API (Ollama only). Defaults to http://localhost:11434",
-                "input_types": [
-                  "Message"
-                ],
+                "input_types": [],
                 "list": false,
                 "list_add_label": "Add More",
                 "load_from_db": false,
@@ -1131,7 +1174,7 @@
                 "trace_as_metadata": true,
                 "track_in_telemetry": false,
                 "type": "str",
-                "value": ""
+                "value": "http://localhost:11434"
               },
               "project_id": {
                 "_input_type": "StrInput",
@@ -1147,6 +1190,27 @@
                 "placeholder": "",
                 "required": false,
                 "show": false,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "track_in_telemetry": false,
+                "type": "str",
+                "value": ""
+              },
+              "provider": {
+                "_input_type": "StrInput",
+                "advanced": true,
+                "display_name": "Provider Override",
+                "dynamic": false,
+                "info": "Optional provider to use with Model Name Override. Leave blank to use the selected model's provider.",
+                "list": false,
+                "list_add_label": "Add More",
+                "load_from_db": false,
+                "name": "provider",
+                "override_skip": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
                 "title_case": false,
                 "tool_mode": false,
                 "trace_as_metadata": true,

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-delete-cascade.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-delete-cascade.spec.ts
@@ -156,7 +156,7 @@ test.describe("Clear traces with a populated span tree (regression #13955)", () 
 
   test(
     "Clearing traces for a flow whose trace has spans succeeds (cascade), leaving no traces behind",
-    { tag: ["@release", "@regression", "@api", "@observability"] },
+    { tag: ["@stable", "@release", "@regression", "@api", "@observability"] },
     async ({ request }) => {
       // Anchor: the seeded trace MUST have spans before DELETE. This is what
       // distinguishes the cascade path from the plain bulk-delete contract test.

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-delete.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-delete.spec.ts
@@ -142,7 +142,7 @@ test.describe("Bulk delete traces — seeded flow", () => {
 
   test(
     "DELETE /api/v1/monitor/traces?flow_id=... clears all traces, and a second DELETE on the empty owned flow still returns 204",
-    { tag: ["@release", "@api", "@regression", "@observability"] },
+    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       // Anchor: the seeded flow MUST have traces before DELETE. Without this,
       // a post-DELETE empty envelope could come from a degraded GET (the

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-llm-span-populated.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-llm-span-populated.spec.ts
@@ -173,7 +173,7 @@ test.describe("Single trace — populated LLM span (OpenAI)", () => {
 
   test(
     "GET /api/v1/monitor/traces/{trace_id} returns a populated tokenUsage + modelName on the LLM span",
-    { tag: ["@release", "@api", "@regression", "@observability"] },
+    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       const res = await request.get(`/api/v1/monitor/traces/${traceId}`, {
         headers: { Authorization: bearerToken },

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-single.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-single.spec.ts
@@ -154,7 +154,7 @@ test.describe("Single trace shape — seeded flow", () => {
 
   test(
     "GET /api/v1/monitor/traces/{trace_id} returns the full TraceRead contract with a non-empty span tree",
-    { tag: ["@release", "@api", "@regression", "@observability"] },
+    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       const res = await request.get(`/api/v1/monitor/traces/${traceId}`, {
         headers: { Authorization: bearerToken },

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail.spec.ts
@@ -153,7 +153,7 @@ test.describe("Transaction record shape — seeded flow", () => {
 
   test(
     "transaction records contain required fields when not empty",
-    { tag: ["@release", "@api", "@regression", "@observability"] },
+    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       const res = await request.get(
         `/api/v1/monitor/transactions?flow_id=${flowId}`,

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-latency-tokens.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-latency-tokens.spec.ts
@@ -95,7 +95,7 @@ test.describe("Flow Activity / Traces — latency and tokens", () => {
   test(
     "GET /api/v1/monitor/traces returns totalLatencyMs and totalTokens for a flow run",
     {
-      tag: ["@release", "@api", "@regression", "@observability"],
+      tag: ["@stable", "@release", "@api", "@regression", "@observability"],
     },
     async ({ request }) => {
       const res = await request.get(
@@ -125,6 +125,7 @@ test.describe("Flow Activity / Traces — latency and tokens", () => {
     "Flow Activity page shows latency and token columns for the run",
     {
       tag: [
+        "@stable",
         "@release",
         "@workspace",
         "@regression",
@@ -169,6 +170,7 @@ test.describe("Flow Activity / Traces — latency and tokens", () => {
     "Trace Details modal shows span tree and per-span latency",
     {
       tag: [
+        "@stable",
         "@release",
         "@workspace",
         "@regression",

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-list-filters.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-list-filters.spec.ts
@@ -184,7 +184,7 @@ test.describe("Trace list filters — status / start_time / query / session_id",
 
   test(
     "GET /api/v1/monitor/traces?status=error returns only the failing trace; rejects unknown values",
-    { tag: ["@release", "@api", "@regression", "@observability"] },
+    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       const matchRes = await request.get(
         `/api/v1/monitor/traces?flow_id=${errorFlowId}&status=error`,
@@ -219,7 +219,7 @@ test.describe("Trace list filters — status / start_time / query / session_id",
 
   test(
     "GET /api/v1/monitor/traces?status=ok returns only the successful trace",
-    { tag: ["@release", "@api", "@regression", "@observability"] },
+    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       const matchRes = await request.get(
         `/api/v1/monitor/traces?flow_id=${okFlowId}&status=ok`,
@@ -245,7 +245,7 @@ test.describe("Trace list filters — status / start_time / query / session_id",
 
   test(
     "GET /api/v1/monitor/traces?start_time pins the >= lower bound",
-    { tag: ["@release", "@api", "@regression", "@observability"] },
+    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       // Past cutoff: every seeded trace satisfies start_time >= past, so a
       // handler that flipped the comparator to <= would return 0 here. This
@@ -277,7 +277,7 @@ test.describe("Trace list filters — status / start_time / query / session_id",
 
   test(
     "GET /api/v1/monitor/traces?query=<substring> filters by trace name (incl. 50-char sanitize cap)",
-    { tag: ["@release", "@api", "@regression", "@observability"] },
+    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       // The handler ILIKEs on TraceTable.{name, id, session_id} (capped at
       // 50 chars by sanitize_query_string). In this setup the flow UUID is
@@ -327,7 +327,7 @@ test.describe("Trace list filters — status / start_time / query / session_id",
 
   test(
     "GET /api/v1/monitor/traces?session_id filters by the session passed at run time",
-    { tag: ["@release", "@api", "@regression", "@observability"] },
+    { tag: ["@stable", "@release", "@api", "@regression", "@observability"] },
     async ({ request }) => {
       const hitRes = await request.get(
         `/api/v1/monitor/traces?flow_id=${okFlowId}&session_id=${encodeURIComponent(okSessionId)}`,


### PR DESCRIPTION
**Fixes #747.**

## Problem
The daily-stable run [29323509096](https://github.com/oriontech-me/langflow-e2e/actions/runs/29323509096) (2026-07-14, `langflowai/langflow-nightly:latest`) hard-failed 7 traces specs. Their shared `test.beforeAll` seeds a fixture flow, runs it, and guards `expect([200,500]).toContain(runRes.status())`. In CI the run returned **HTTP 400**, so no trace was emitted and every downstream assertion failed. `@stable` was manually quarantined for this cluster by #749.

## Root cause (triaged live on nightly `1.11.0.dev36`)
**Not a run-endpoint contract change.** On a calm instance the run endpoint deterministically returns **500** (`"A model selection is required"`) and **emits an error trace** for this fixture (reproduced 5/5). Reading the source, the only 400 branches in `_run_flow_internal` (malformed UUID, `CustomComponentValidationError` — never raised in this version, `InvalidChatInputError` — needs a conflicting tweak) are unreachable for this input.

The CI 400 was a **transient CI-saturation** failure: that daily had **40 timeouts / 27 hard failures** at once (auth `auto_login` timing out at 20s), so the run died before reaching the graph executor → 400 → no trace → `[200,500]` guard failed. The guard failing on a non-executor status is itself the intended fail-fast behavior.

## Fix
Refresh the `LanguageModelComponent` node in `basic-prompting-trace-fixture.json` to the current component schema — it predated the unified ModelInput refactor:
- adds `provider` / `model_name` / `max_tokens`, updates the component `code` (4170→5226 chars);
- `model` stays empty (the intentional "model required" error → error trace is preserved);
- node ids (incl. `LanguageModelComponent-FLeYF`, hardcoded in `traces-detail.spec.ts`), edges, and the other components are unchanged.

Restore `@stable` on the 13 tests quarantined for this cluster by #749.

## Scope note
The fixture refresh is **behavior-neutral** — old and new fixtures produce identical status/trace/span output on the nightly (error run → 500 + error trace; OpenAI-tweak run → 200 + populated LLM span with `tokenUsage` and nested `ChatOpenAI gpt-4o-mini` span). No `.spec.ts` logic changed; only the `@stable` tag was re-added and the fixture's LanguageModel node refreshed. `chat-io-ok-trace-fixture.json` was left untouched (no drift). `QA-CHECKLIST.md` generated blocks regenerate on merge.

## Validation (nightly `1.11.0.dev36`, `--retries=0 --workers=1`)
- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors)
- **3 clean runs** of the full observability suite: 19 passed (1.1m / 54.4s / 45.1s), no flake ✅
- zero `🚨 Backend Error` ✅
- Force-fail: the `[200,500]` seeded-run guard is proven falsifiable by the originating daily itself (CI run returned 400 → guard failed). Remaining assertions are behavior-neutral vs the pre-refresh fixture (verified identical output old×new).
- `--trace=on` not run for the Flow-Activity UI tests (known local hang on ReactFlow-canvas specs); covered by the green `--retries=0` bursts.

Refs #744 #749