### PR TITLE
test(core-components): promote save-components-as-template to @stable (#686)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -624,7 +624,7 @@
 - [x] Unlock flow → `flow-functionality/flow-lock.spec.ts`
 - [x] Move flow between folders via API → `api/flows/api-folders-crud.spec.ts`
 - [x] Publish flow → `flow-functionality/publish-flow.spec.ts`
-- [-] Save flow components as template
+- [x] Save flow components as template → `core-components/saveComponents.spec.ts`
 
 #### 12.6 Flow Execution
 - [x] Run Flow component executes another flow → `flow-functionality/run-flow.spec.ts`

--- a/docs/core-components/saveComponents.md
+++ b/docs/core-components/saveComponents.md
@@ -1,0 +1,147 @@
+# Spec: Save flow components as template
+
+**Test file:** `tests/tests-automations/regression/core-components/saveComponents.spec.ts`
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates
+
+A user can **save a component from the canvas as a reusable template**: after
+adding a component to a flow, selecting it and choosing **Save** (the
+`SaveAll` action in the node's more-options menu) persists it as a saved
+component that (a) shows up in the sidebar's **Saved** section as a draggable
+item and (b) is stored as a flow with `is_component = true`, so it can be reused
+in any flow.
+
+This is the §12.5 "Save flow components as template" behaviour. The action is
+driven off the node more-options menu (`more-options-modal` → `icon-SaveAll`) and
+surfaces in the sidebar under the `disclosure-saved` disclosure.
+
+---
+
+## Setup & determinism
+
+- A **blank flow** is created via the REST API (`createFlow`, `is_component:
+  false`) and opened at `/flow/<id>` — deterministic, no empty-page bootstrap
+  race.
+- A **Chat Input** component is added from the sidebar. The add button is scoped
+  to the built-in Input & Output entry
+  (`input_outputChat Input` → `add-component-button-chat-input`) because when a
+  saved component named "Chat Input" also exists, a homonymous
+  `add-component-button-chat-input` renders under it and the bare testid is
+  ambiguous. The node is then selected (`title-Chat Input`) and saved via
+  `more-options-modal` → `icon-SaveAll`.
+- **Saving does not replace a same-named component — it suffixes it**
+  ("Chat Input" → "Chat Input (1)") and opens a modal, which would break a clean
+  save. The Saved-components namespace is global per user, and the node's inline
+  title is not editable (`node-name` carries the `nodoubleclick` class;
+  more-options has no rename), so the saved name cannot be made per-run unique on
+  the canvas. Instead, the spec **pre-cleans** any leftover "Chat Input"/"Chat
+  Input (N)" saved components (id-scoped) as a deterministic precondition — this
+  is the only spec that saves a "Chat Input" component and it is a single,
+  non-self-parallel test, so that name family is exclusively its own.
+- The saved component created by the save is identified by **diffing the
+  saved-component id set** before and after the save (exactly one new id),
+  captured for id-scoped cleanup, and the sidebar draggable testid is derived
+  from that flow's actual name. Both created flows (host + saved component) are
+  deleted id-scoped in `afterEach`.
+
+### Tests
+
+1. **Saving a canvas component as a template makes it reusable from the
+   sidebar.** Pre-clean stale "Chat Input" saved components, add Chat Input to a
+   blank flow, select it, and Save via `more-options-modal` → `icon-SaveAll`.
+   Then assert:
+   - **API:** exactly one new saved component appears (id-diff vs the pre-save
+     set) and it has `is_component === true` — the persisted, reusable template.
+     Its id is captured for id-scoped cleanup.
+   - **UI:** the sidebar **Saved** disclosure (`disclosure-saved`) is visible and
+     the saved component renders as a draggable item
+     (`saved_components_<name>_draggable`, name derived from the created flow) —
+     the reuse affordance.
+
+---
+
+## Tags
+
+`@stable` `@regression` `@components` `@ui-ux`
+
+`@components` (canvas/sidebar component configuration) + `@ui-ux` (functional).
+`@stable` is added on promotion after the deterministic-run and force-fail
+validation below. The inherited spec was a disabled `test.skip` with fake
+`expect(true).toBeTruthy()` assertions referencing a missing fixture
+(`flow_group_test.json`) — replaced wholesale.
+
+---
+
+## Validation criterion
+
+| # | State | Locator / call | Expected |
+|---|---|---|---|
+| 1 | After Save | new saved components (id-diff vs pre-save set) | exactly `1`, with `is_component === true` (persisted template) |
+| 1 | After Save | `getByTestId("disclosure-saved")` | `toBeVisible()` — Saved section present |
+| 1 | After Save | `getByTestId("saved_components_<name>_draggable")` | `toBeVisible()` — saved component draggable (reuse affordance) |
+
+Each assertion fails if the save-as-template behaviour regresses: the Save action
+no longer persists the component, the Saved sidebar section stops rendering the
+item, or the saved entity is not stored as an `is_component` flow.
+
+---
+
+## External dependencies
+
+- `tests/helpers/flows/create-flow.ts` — API blank-flow creation;
+  `tests/helpers/flows/delete-flow.ts` — id-scoped cleanup / pre-clean;
+  `tests/helpers/auth/get-auth-token.ts` — auth.
+- Sidebar add (scoped): `input_outputChat Input` → `add-component-button-chat-input`.
+- Node more-options save affordance: `more-options-modal`, `icon-SaveAll`.
+- Sidebar Saved section: `disclosure-saved`, `saved_components_<name>_draggable`.
+- Saved-component API: `GET /api/v1/flows/?components_only=true` (list, diff, cleanup).
+- No model-provider credentials required — no flow is executed.
+
+Testids were confirmed live against `langflow-nightly 1.11.0.dev44` via a
+throwaway scout before authoring (`disclosure-saved`,
+`saved_components_chat input_draggable`, `saved_componentsChat Input`, and the
+`components_only=true` API returning the `is_component` flow).
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` on a recent nightly (1.11.x).
+- Auth via `auto_login` (repo default).
+
+---
+
+## Relationship to existing coverage
+
+Replaces the inherited `saveComponents.spec.ts` "save group component tests",
+which was `test.skip`ped, asserted nothing real (`expect(true).toBeTruthy()`
+inside `if (count > 0)` guards), and depended on a fixture that no longer exists.
+The **group**-save variant (select multiple, Group, then Save the group) is not
+reintroduced here — this spec covers the single-component save-as-template path,
+which is the §12.5 bullet.
+
+---
+
+## What this test does not cover
+
+- **Group** component save (multi-select → Group → Save) — a separate variant.
+- **Dragging** the saved component back onto a canvas and running it — the
+  draggable's presence in the Saved section is asserted as the reuse affordance,
+  but a full drag-and-run is out of scope (flaky, and a distinct behaviour).
+- Overwriting/replacing an existing saved component (the suffix-and-modal path
+  when a same-named component already exists) — the spec pre-cleans that state
+  instead of exercising it.
+
+---
+
+## Notes
+
+- **Force-fail probes (executed during validation):** documented in the PR
+  Validation block — one mutation per test, observed failing, then reverted.
+- Both created flows (the blank flow and the saved component) are deleted
+  id-scoped in `afterEach` — the saved component is itself an `is_component` flow
+  and must be removed so it does not pollute the global Saved namespace.

--- a/tests/tests-automations/regression/core-components/saveComponents.spec.ts
+++ b/tests/tests-automations/regression/core-components/saveComponents.spec.ts
@@ -1,115 +1,159 @@
-import { readFileSync } from "fs";
+import type { APIRequestContext } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { createFlow } from "../../../helpers/flows/create-flow";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
-import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
-import { zoomOut } from "../../../helpers/ui/zoom-out";
+
+// Ids of every flow created by a test — the blank host flow AND the saved
+// component (itself an is_component flow) — deleted id-scoped in afterEach (repo
+// convention, #490/#681). The saved component lives in a global, per-user
+// namespace, so leaving it behind would pollute the instance; cleaning it is
+// load-bearing.
+const createdFlowIds: string[] = [];
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    // deleteFlow treats a 404 as done (#545), so a double-delete is harmless.
+    await deleteFlow(request, id, { headers: { Authorization: bearer } });
+  }
+});
+
+// The component to save and the display name Langflow gives its saved copy.
+const COMPONENT_SEARCH = "chat input";
+const COMPONENT_TITLE = "Chat Input";
+
+// List the saved components (is_component flows).
+async function listSavedComponents(
+  request: APIRequestContext,
+  bearer: string,
+): Promise<Array<{ id: string; name: string; is_component: boolean }>> {
+  const res = await request.get(
+    "/api/v1/flows/?remove_example_flows=true&header_flows=true&components_only=true",
+    { headers: { Authorization: bearer } },
+  );
+  expect(res.status()).toBe(200);
+  const body = (await res.json()) as
+    | Array<{ id: string; name: string; is_component: boolean }>
+    | { flows?: Array<{ id: string; name: string; is_component: boolean }> };
+  return Array.isArray(body) ? body : (body.flows ?? []);
+}
+
+// Pre-clean any saved "Chat Input"/"Chat Input (N)" left by a previous failed
+// run. Saving a component whose name already exists does NOT replace it — the
+// backend suffixes the name and opens a modal — which would break the clean
+// diff-and-assert below. This spec is the only place that saves a "Chat Input"
+// component (and it is a single, non-self-parallel test), so id-scoped deletion
+// of that name family is a safe, deterministic precondition, not a global wipe.
+async function cleanupSavedChatInputs(
+  request: APIRequestContext,
+  bearer: string,
+): Promise<void> {
+  const stale = (await listSavedComponents(request, bearer)).filter((f) =>
+    f.name?.startsWith(COMPONENT_TITLE),
+  );
+  for (const f of stale) {
+    await deleteFlow(request, f.id, { headers: { Authorization: bearer } });
+  }
+}
 
 test.describe("save component tests", () => {
-  /// <reference lib="dom"/>
-  test.skip(
-    "save group component tests",
-    { tag: ["@release", "@workspace", "@api"] },
+  test(
+    "saving a canvas component as a template makes it reusable from the sidebar",
+    { tag: ["@stable", "@regression", "@components", "@ui-ux"] },
+    async ({ page, request }) => {
+      const bearer = await getAuthToken(request);
+      let savedBefore = new Set<string>();
 
-    async ({ page }) => {
-      await awaitBootstrapTest(page);
+      await test.step("Open a blank flow created via the API", async () => {
+        // Deterministic precondition: remove any saved Chat Input left by a
+        // previous failed run so this save creates a clean, unsuffixed one.
+        await cleanupSavedChatInputs(request, bearer);
 
-      await page.waitForSelector('[data-testid="blank-flow"]', {
-        timeout: 30000,
+        const flowId = await createFlow(
+          request,
+          {
+            name: `Save Component Host ${Date.now()}-${Math.random()
+              .toString(36)
+              .slice(2, 8)}`,
+            description: "",
+            data: { nodes: [], edges: [] },
+            is_component: false,
+          },
+          { headers: { Authorization: bearer } },
+        );
+        createdFlowIds.push(flowId);
+        await page.goto(`/flow/${flowId}`);
+        await page
+          .getByTestId("sidebar-search-input")
+          .waitFor({ state: "visible", timeout: 60000 });
       });
-      await page.getByTestId("blank-flow").click();
 
-      // Read your file into a buffer.
-      const jsonContent = readFileSync(
-        "tests/assets/flow_group_test.json",
-        "utf-8",
-      );
+      await test.step("Add a Chat Input component to the canvas", async () => {
+        // Baseline the saved-component set before we create ours, so the new one
+        // can be identified by id-diff regardless of the (possibly suffixed) name.
+        savedBefore = new Set(
+          (await listSavedComponents(request, bearer)).map((f) => f.id),
+        );
 
-      // Create the DataTransfer and File
-      const dataTransfer = await page.evaluateHandle((data) => {
-        const dt = new DataTransfer();
-        // Convert the buffer to a hex array
-        const file = new File([data], "flow_group_test.json", {
-          type: "application/json",
+        await page.getByTestId("sidebar-search-input").fill("chat input");
+        // Scope the add button to the official Input & Output entry: when a
+        // saved component named "Chat Input" already exists (a prior/parallel
+        // run), a homonymous `add-component-button-chat-input` also renders under
+        // `saved_componentsChat Input`, so the bare testid is ambiguous. The
+        // `input_outputChat Input` container disambiguates to the built-in one.
+        await page
+          .getByTestId("input_outputChat Input")
+          .getByTestId("add-component-button-chat-input")
+          .click();
+        await adjustScreenView(page);
+        await expect(page.getByTestId("title-Chat Input")).toBeVisible({
+          timeout: 15000,
         });
-        dt.items.add(file);
-        return dt;
-      }, jsonContent);
-
-      // Now dispatch
-      await page.dispatchEvent(
-        "//*[@data-testid='rf__wrapper']/div[1]/div",
-        "drop",
-        {
-          dataTransfer,
-        },
-      );
-
-      const genericNoda = page.getByTestId("div-generic-node");
-      const elementCount = await genericNoda?.count();
-      if (elementCount > 0) {
-        expect(true).toBeTruthy();
-      }
-
-      await adjustScreenView(page, { numberOfZoomOut: 2 });
-
-      await page.getByTestId("title-Agent Initializer").click({
-        modifiers: ["Control"],
       });
 
-      await page.getByRole("button", { name: "Group" }).click();
+      await test.step("Save the selected component as a template", async () => {
+        // Select the node, open its more-options menu, and Save (SaveAll).
+        await page.getByTestId("title-Chat Input").click();
+        await page.getByTestId("more-options-modal").click();
+        await page.getByTestId("icon-SaveAll").first().click();
+      });
 
-      await page
-        .locator('//*[@id="react-flow-id"]')
-        .first()
-        .click({ button: "left" });
+      let savedComponent: { id: string; name: string; is_component: boolean };
 
-      let textArea = page.getByTestId("div-textarea-description");
-      let elementCountText = await textArea?.count();
-      if (elementCountText > 0) {
-        expect(true).toBeTruthy();
-      }
+      await test.step("The save persists a new is_component flow (the reusable template)", async () => {
+        // Identify the flow this save created by id-diff against the baseline —
+        // exactly one new saved component must appear. Capture its id for
+        // id-scoped cleanup FIRST (before UI assertions) so a later failure still
+        // tears it down. The durable backend signal is is_component=true.
+        const created = (await listSavedComponents(request, bearer)).filter(
+          (f) => !savedBefore.has(f.id),
+        );
+        expect(
+          created.length,
+          "exactly one new saved component should be created by the save",
+        ).toBe(1);
+        savedComponent = created[0];
+        createdFlowIds.push(savedComponent.id);
+        expect(savedComponent.is_component).toBe(true);
+      });
 
-      let groupNode = page.getByTestId("title-Group");
-      let elementGroup = await groupNode?.count();
-      if (elementGroup > 0) {
-        expect(true).toBeTruthy();
-      }
-
-      await page.getByTestId("title-Group").click();
-      await page.getByTestId("more-options-modal").click();
-
-      await page.getByTestId("icon-SaveAll").click();
-      // timeout to handle case where there is already a saved component with the same name
-      await page.waitForTimeout(1000);
-
-      const replaceButton = await page
-        .getByTestId("replace-button")
-        .isVisible();
-
-      if (replaceButton) {
-        await page.getByTestId("replace-button").click();
-      }
-      await page.getByTestId("sidebar-search-input").click();
-      await page.getByTestId("sidebar-search-input").fill("group");
-
-      await page
-        .getByText("Group")
-        .first()
-        .dragTo(page.locator('//*[@id="react-flow-id"]'));
-      await page.mouse.up();
-      await page.mouse.down();
-      await page.getByTestId("fit_view").click();
-      textArea = page.getByTestId("div-textarea-description");
-      elementCountText = await textArea?.count();
-      if (elementCountText > 0) {
-        expect(true).toBeTruthy();
-      }
-
-      groupNode = page.getByTestId("title-Group");
-      elementGroup = await groupNode?.count();
-      if (elementGroup > 0) {
-        expect(true).toBeTruthy();
-      }
+      await test.step("The saved component appears in the sidebar Saved section", async () => {
+        // The Saved disclosure plus the draggable saved item are the user-facing
+        // reuse affordance. The draggable testid is derived from the saved
+        // component's ACTUAL name (which may be suffixed), lowercased — matching
+        // the `saved_components_<name>_draggable` shape confirmed live.
+        await expect(page.getByTestId("disclosure-saved")).toBeVisible({
+          timeout: 15000,
+        });
+        await expect(
+          page.getByTestId(
+            `saved_components_${savedComponent.name.toLowerCase()}_draggable`,
+          ),
+        ).toBeVisible({ timeout: 15000 });
+      });
     },
   );
 });


### PR DESCRIPTION
Closes #686.

Closes the `[-] Save flow components as template` gap in `QA-CHECKLIST.md` §12.5 Flow Operations (mirrored in §2.3 Component Updates). Replaces the disabled `saveComponents.spec.ts` "save group component tests" — a `test.skip` that asserted nothing real (`expect(true).toBeTruthy()` inside `if (count > 0)` guards) and depended on a fixture that no longer exists (`flow_group_test.json`).

## 1. Covered tests
| # | Test | What it validates |
|---|------|-------------------|
| 1 | `saving a canvas component as a template makes it reusable from the sidebar` | Adding a Chat Input and Saving it via `more-options-modal` → `icon-SaveAll` persists **exactly one new `is_component` flow** (id-diff vs the pre-save set) and surfaces it in the sidebar **Saved** section (`disclosure-saved` + `saved_components_<name>_draggable`) as a reusable template. Catches a regression where Save stops persisting the component or the Saved sidebar affordance disappears. |

## 2. How the test was built
- **Setup:** blank flow via REST API (`createFlow`) opened at `/flow/<id>` (deterministic, no empty-page bootstrap race). Chat Input added from the sidebar with the add button **scoped to `input_outputChat Input`** — when a saved "Chat Input" already exists, a homonymous `add-component-button-chat-input` renders under it, so the bare testid is ambiguous.
- **Live-confirmed selectors** (nightly 1.11.0.dev44): `more-options-modal`, `icon-SaveAll`, `disclosure-saved`, `saved_components_chat input_draggable`, and `GET /api/v1/flows/?components_only=true` returning the `is_component` flow.
- **Save semantics discovered live:** saving a same-named component does **not** replace it — it suffixes the name ("Chat Input (1)") and opens a modal. So the spec (a) **pre-cleans** stale "Chat Input" saved components (this is the only spec that creates that name family, and it is a single non-self-parallel test), and (b) identifies the created component by **id-diff**, never by a fixed name, deriving the sidebar draggable testid from the actual name.
- **Assertion rationale:** `is_component === true` on the newly created flow is the durable backend proof of a reusable template; `disclosure-saved` + the derived draggable is the user-facing reuse affordance.

## 3. Dependencies
- **none — pure UI/API** (no flow executed, no provider credentials).
- **Execution mode:** id-scoped cleanup of both created flows (host + saved component) in `afterEach`; deterministic via pre-clean (self-recovers from a prior failed run — verified by injecting a stale "Chat Input" saved component and re-running green).

## Validation (nightly 1.11.0.dev44, `--retries=0`)
- typecheck ✅ · eslint ✅ (0 errors) · QA-CHECKLIST guard ✅
- 3/3 clean serial runs (`--workers=1`): `expected=1 unexpected=0 flaky=0` ✅
- force-fail ✅ — `is_component` `.toBe(true)` → `.toBe(false)` observed red, then reverted
- zero `🚨 Backend Error` ✅ · zero orphan flows ✅ (host + saved component both cleaned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)