### PR TITLE
test(core-components): add update-component-action @stable spec (#666)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -146,7 +146,7 @@
 
 #### 2.3 Component Updates
 - [x] Outdated component notification → `core-components/outdated-component-notification.spec.ts`
-- [-] Update component action
+- [x] Update component action → `core-components/update-component-action.spec.ts`
 - [x] Update with breaking change — should alert user → `core-components/component-breaking-change-alert.spec.ts`
 - [x] Legacy component visible via configuration → `core-components/legacy-components-toggle-regression.spec.ts`
 - [x] Beta component visible via configuration → `core-components/beta-components-toggle-regression.spec.ts`

--- a/docs/core-components/update-component-action.md
+++ b/docs/core-components/update-component-action.md
@@ -1,0 +1,147 @@
+# Spec: Update component action
+
+**Test file:** `tests/tests-automations/regression/core-components/update-component-action.spec.ts`
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates
+
+A user can **apply** the update of an outdated component and the flow reacts
+correctly: the component is updated in place, the flow's outdated count drops by
+one, and — because the review dialog defaults to creating a backup — a
+**`<flow> (Backup)`** flow is persisted before the change.
+
+This is the §2.3 "Update component action" behaviour — the *apply* half of the
+component-updates story, distinct from its two siblings which never mutate the
+flow:
+
+- `outdated-component-notification.spec.ts` (#689) — asserts the outdated
+  **notification** only.
+- `component-breaking-change-alert.spec.ts` — opens the review dialog and asserts
+  the **alert** (warning, backup default, opt-in), then **cancels**.
+
+This spec is the only one that actually clicks **Update Component** and asserts
+the post-apply effects.
+
+---
+
+## Setup & determinism
+
+- A flow with outdated components is produced deterministically by importing the
+  fixture `tests/assets/flows/outdated_flow.json` (5 components pinned to a
+  1.4.0-era snapshot — all resolve to outdated updates on the current nightly)
+  via the REST API (`createFlow`, with the fixture's own `id`/`endpoint_name`
+  stripped so the backend mints a fresh id) and opening it at `/flow/<id>`.
+- A **one-time assistant onboarding tooltip** can overlay the canvas and
+  intercept clicks; the spec dismisses it defensively
+  (`getByLabel("Dismiss assistant onboarding tooltip")`) before interacting.
+- The **outdated count is emergent** (frozen fixture vs the running nightly), so
+  the spec never pins a literal count: it parses the banner number `N` before the
+  apply and asserts it becomes `N - 1` after (count-agnostic — see the caveat).
+
+### Tests
+
+1. **Applying a single component update refreshes it, decrements the outdated
+   count, and creates a backup.** Import the fixture and open it. Read the
+   outdated count `N` from the banner (`/\d+ components? needs? updates?/i`). Open
+   the first component's review dialog (`review-button`), confirm the backup
+   checkbox is checked by default (`backup-flow-checkbox`), and click
+   **Update Component**. Then assert:
+   - the banner count drops to `N - 1` (one fewer outdated component);
+   - the **per-node update indicators refresh**: the total on-canvas indicators
+     (`review-button` + `update-button`) also drop to `N - 1`, staying consistent
+     with the banner (the applied component no longer shows an update affordance).
+     Counted as the breaking-agnostic sum because applying an update can re-diff
+     the remaining nodes (a breaking `review-button` may become a non-breaking
+     `update-button`), so the durable invariant is the *total*, not a specific
+     button;
+   - a backup flow whose name ends with **"(Backup)"** now exists
+     (`GET /api/v1/flows/`), i.e. the update created a safety copy before
+     mutating. Its id is captured for id-scoped cleanup.
+
+---
+
+## Tags
+
+`@stable` `@regression` `@components` `@ui-ux`
+
+`@components` (canvas component update) + `@ui-ux` (functional). `@stable` is
+added on promotion after the deterministic-run and force-fail validation below.
+No prior test covered the apply action (the inherited conditional-bypass
+apply-update was removed in #689); this is a new dedicated spec.
+
+---
+
+## Validation criterion
+
+| # | State | Locator / call | Expected |
+|---|---|---|---|
+| 1 | Before apply | banner `/\d+ components? needs? updates?/i` → `N` | `N ≥ 1` |
+| 1 | Review dialog | `getByTestId("backup-flow-checkbox")` | `data-state="checked"` (backup default) |
+| 1 | After **Update Component** | banner count | `N - 1` (one fewer outdated component) |
+| 1 | After **Update Component** | `review-button` + `update-button` count | `N - 1` (per-node indicators refresh, consistent with banner) |
+| 1 | After apply | `GET /api/v1/flows/` → a flow whose name ends `"(Backup)"` | exists (safety copy created) |
+
+Each assertion fails if the apply-update action regresses: clicking Update
+Component no longer refreshes the component (count stays at `N`), or the
+default-on backup is not created.
+
+### Frozen-fixture caveat
+
+`outdated_flow.json` carries no per-node version (only `last_tested_version:
+"1.4.0"`); outdatedness is emergent from diffing it against the running nightly.
+The spec asserts a **relative** decrement (`N → N-1`), never a literal count, so
+a benign version bump that changes how many components are outdated does not
+false-fail it. If a future release makes every fixture component up-to-date,
+`N` becomes 0 and the `N ≥ 1` precondition legitimately fails — the cue to
+refresh the fixture, not a product bug.
+
+Scouted live against `langflow-nightly 1.11.0.dev44` before authoring: applying
+the first component's update moved the banner from "5 components need updates" to
+"4 components need updates" and created a `… (Backup)` flow.
+
+---
+
+## External dependencies
+
+- `tests/assets/flows/outdated_flow.json` — the outdated fixture (shared with the
+  notification and breaking-change specs).
+- `tests/helpers/flows/create-flow.ts` — API import;
+  `tests/helpers/flows/delete-flow.ts` — id-scoped cleanup;
+  `tests/helpers/auth/get-auth-token.ts` — auth.
+- Review/apply UI: `review-button` (per-node breaking update), the review dialog's
+  `backup-flow-checkbox` (default checked) and its **Update Component** button
+  (no testid — matched by role/name), `getByLabel("Dismiss assistant onboarding
+  tooltip")` for the one-time overlay.
+- No model-provider credentials required — no flow is executed.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` on a recent nightly (1.11.x).
+- Auth via `auto_login` (repo default).
+
+---
+
+## What this test does not cover
+
+- The **non-breaking** silent `update-button` path (the fixture is all-breaking;
+  a non-breaking apply would need a different fixture).
+- **Review All** / bulk apply of every outdated component at once — this spec
+  applies a single component to keep the count assertion precise.
+- The notification surface and the alert/dialog copy — owned by
+  `outdated-component-notification.spec.ts` and
+  `component-breaking-change-alert.spec.ts` respectively.
+
+---
+
+## Notes
+
+- **Force-fail probes (executed during validation):** documented in the PR
+  Validation block — one mutation per test, observed failing, then reverted.
+- Both created flows (the imported host flow and the `(Backup)` copy) are deleted
+  id-scoped in `afterEach` — applying the update mutates state and creates the
+  backup, so cleaning both is load-bearing.

--- a/tests/tests-automations/regression/core-components/update-component-action.spec.ts
+++ b/tests/tests-automations/regression/core-components/update-component-action.spec.ts
@@ -1,0 +1,172 @@
+import { readFileSync } from "fs";
+import path from "path";
+import type { APIRequestContext, Page } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { createFlow } from "../../../helpers/flows/create-flow";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+
+// A saved flow whose 5 components (Prompt, Chat Input, OpenAI, Chat Output, Chat
+// Memory) are pinned to a 1.4.0-era snapshot, old enough that all resolve to
+// outdated updates on the current nightly — the deterministic source of the
+// outdated state whose update we then apply. Shared with the notification and
+// breaking-change specs.
+const OUTDATED_FLOW = path.resolve(
+  __dirname,
+  "../../../assets/flows/outdated_flow.json",
+);
+
+// Ids of every flow created by a test — the imported host flow AND the "(Backup)"
+// copy the apply creates — deleted id-scoped in afterEach (repo convention,
+// #490/#681). Applying the update mutates state and creates the backup, so
+// cleaning both is load-bearing.
+const createdFlowIds: string[] = [];
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    // deleteFlow treats a 404 as done (#545), so a double-delete is harmless.
+    await deleteFlow(request, id, { headers: { Authorization: bearer } });
+  }
+});
+
+async function importOutdatedFlowAndOpen(
+  page: Page,
+  request: APIRequestContext,
+  bearer: string,
+  hostName: string,
+): Promise<void> {
+  // Strip the fixture's own id/endpoint_name (unique keys) so the backend mints
+  // a fresh id — parallel-safe, independent of prior cleanup (#689).
+  const raw = JSON.parse(readFileSync(OUTDATED_FLOW, "utf-8"));
+  delete raw.id;
+  delete raw.endpoint_name;
+  const flowId = await createFlow(
+    request,
+    { ...raw, name: hostName },
+    { headers: { Authorization: bearer } },
+  );
+  createdFlowIds.push(flowId);
+
+  await page.goto(`/flow/${flowId}`);
+  await expect(
+    page.getByText(/\d+ components? needs? updates?/i),
+  ).toBeVisible({ timeout: 30000 });
+}
+
+// Read the outdated total from the "N components need updates" banner.
+async function readOutdatedCount(page: Page): Promise<number> {
+  const text = await page
+    .getByText(/\d+ components? needs? updates?/i)
+    .first()
+    .textContent();
+  const match = text?.match(/(\d+)\s+components?\s+needs?\s+updates?/i);
+  return Number(match?.[1] ?? 0);
+}
+
+// Per-node update indicators: a breaking node renders review-button, a standard
+// node renders update-button. The total is the count of outdated components on
+// the canvas (breaking-agnostic on purpose).
+async function countNodeUpdateIndicators(page: Page): Promise<number> {
+  return (
+    (await page.getByTestId("review-button").count()) +
+    (await page.getByTestId("update-button").count())
+  );
+}
+
+test.describe("update component action", () => {
+  test(
+    "applying a single component update refreshes it, decrements the outdated count, and creates a backup",
+    { tag: ["@stable", "@regression", "@components", "@ui-ux"] },
+    async ({ page, request }) => {
+      const bearer = await getAuthToken(request);
+      // Unique per-run host name so the "(Backup)" copy this apply creates can be
+      // matched exactly — never a stray "(Backup)" from another run/worker, which
+      // would let the backup assertion pass without this apply creating one.
+      const hostName = `Update Component Action ${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+      let countBefore = 0;
+
+      await test.step("Import the outdated fixture and open it", async () => {
+        await importOutdatedFlowAndOpen(page, request, bearer, hostName);
+      });
+
+      await test.step("Dismiss the one-time assistant onboarding tooltip if present", async () => {
+        // The tooltip overlays the canvas and can intercept the review click.
+        const dismiss = page.getByLabel("Dismiss assistant onboarding tooltip");
+        if (await dismiss.isVisible({ timeout: 3000 }).catch(() => false)) {
+          await dismiss.click();
+        }
+      });
+
+      await test.step("Record the outdated count and open the first review dialog", async () => {
+        countBefore = await readOutdatedCount(page);
+        expect(
+          countBefore,
+          "the fixture should present at least one outdated component",
+        ).toBeGreaterThan(0);
+        // Per-node indicators must match the banner before we apply anything.
+        expect(await countNodeUpdateIndicators(page)).toBe(countBefore);
+
+        await page.getByTestId("review-button").first().click();
+        await expect(page.getByTestId("backup-flow-checkbox")).toBeVisible({
+          timeout: 15000,
+        });
+      });
+
+      await test.step("The review dialog defaults to creating a backup", async () => {
+        await expect(page.getByTestId("backup-flow-checkbox")).toHaveAttribute(
+          "data-state",
+          "checked",
+        );
+      });
+
+      await test.step("Apply the update via Update Component", async () => {
+        // The submit has no testid — match it by role/name (exact to avoid the
+        // "Update Components" bulk button).
+        await page
+          .getByRole("button", { name: "Update Component", exact: true })
+          .click();
+      });
+
+      await test.step("The outdated count and per-node indicators drop by one", async () => {
+        // The banner reflects one fewer outdated component after the apply.
+        await expect(
+          page.getByText(
+            new RegExp(`\\b${countBefore - 1}\\b components? needs? updates?`, "i"),
+          ),
+        ).toBeVisible({ timeout: 15000 });
+
+        // The per-node indicators refresh consistently with the banner. Applying
+        // an update can re-diff the remaining nodes (a breaking review-button may
+        // become a non-breaking update-button), so the durable invariant is the
+        // total (review + update), not a specific button.
+        await expect
+          .poll(() => countNodeUpdateIndicators(page), { timeout: 15000 })
+          .toBe(countBefore - 1);
+      });
+
+      await test.step("A backup flow was created before the update", async () => {
+        // The default-on backup persists a "<flow> (Backup)" copy — the safety
+        // net the apply action provides. Capture its id for id-scoped cleanup.
+        const res = await request.get(
+          "/api/v1/flows/?remove_example_flows=true&header_flows=true",
+          { headers: { Authorization: bearer } },
+        );
+        expect(res.status()).toBe(200);
+        const body = (await res.json()) as
+          | Array<{ id: string; name: string }>
+          | { flows?: Array<{ id: string; name: string }> };
+        const flows = Array.isArray(body) ? body : (body.flows ?? []);
+        const backup = flows.find((f) => f.name === `${hostName} (Backup)`);
+        expect(
+          backup,
+          "applying the update should create a '(Backup)' flow",
+        ).toBeTruthy();
+        if (backup?.id) createdFlowIds.push(backup.id);
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #666.

Covers the `[-] Update component action` bullet in `QA-CHECKLIST.md` §2.3 Component Updates — the **apply** half of the component-updates story, which had no test: #689 removed the inherited conditional-bypass apply-update (that spec is now notification-only) and `component-breaking-change-alert.spec.ts` deliberately cancels without applying. This is the only spec that actually clicks **Update Component** and asserts the post-apply effects.

## 1. Covered tests
| # | Test | What it validates |
|---|------|-------------------|
| 1 | `applying a single component update refreshes it, decrements the outdated count, and creates a backup` | Opening the first outdated component's review dialog and clicking **Update Component** (backup default on) drops the outdated banner count `N → N-1`, drops the per-node update indicators (`review-button` + `update-button`) to `N-1` consistently, and persists a `<flow> (Backup)` copy. Catches a regression where apply no longer refreshes the component or the default backup is not created. |

## 2. How the test was built
- **Setup:** imports `tests/assets/flows/outdated_flow.json` (5 components pinned to 1.4.0, all breaking on the current nightly) via the REST API (`createFlow`, fixture `id`/`endpoint_name` stripped) and opens it at `/flow/<id>`.
- **Live-confirmed selectors** (nightly 1.11.0.dev44): `review-button`, `update-button`, `backup-flow-checkbox` (`data-state="checked"` by default), the **Update Component** submit (no testid — matched by role/name, `exact` to avoid the bulk "Update Components"), and `getByLabel("Dismiss assistant onboarding tooltip")` for the one-time overlay that otherwise intercepts the click.
- **Apply effects discovered live:** applying the first component moved the banner "5 → 4 components need updates" and created a `… (Backup)` flow.
- **Assertion rationale:** the count is asserted as a **relative** `N → N-1` decrement (count-agnostic against the frozen fixture); the per-node indicator total is asserted breaking-agnostically (apply re-diffs remaining nodes, so a `review-button` can become an `update-button`); the backup is matched by the **unique host name** (`<host> (Backup)`), never a stray `(Backup)`, so it can't false-pass off another run's leftover.

## 3. Dependencies
- **none — pure UI/API** (no flow executed, no provider credentials).
- **Execution mode:** parallel-safe (fresh id per import, unique host name); both created flows (host + backup) deleted id-scoped in `afterEach`.

## Validation (nightly 1.11.0.dev44, `--retries=0`)
- typecheck ✅ · eslint ✅ (0 errors) · QA-CHECKLIST guard ✅
- 3/3 clean serial runs (`--workers=1`): `expected=1 unexpected=0 flaky=0` ✅
- force-fail ✅ — backup match `${hostName} (Backup)` → `${hostName} (NO_BACKUP_FF)` observed red, then reverted
- zero `🚨 Backend Error` ✅ · zero orphan flows ✅ (host + backup both cleaned, proven before/after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)