### PR TITLE
test(api): extract shared NDJSON build-event parser (#703)

### DIFF
--- a/tests/helpers/other/parse-ndjson.ts
+++ b/tests/helpers/other/parse-ndjson.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared NDJSON build-event reader for the §9.1 build event-delivery specs
+ * (direct-response, polling-response). The `POST /api/v1/build/{flow_id}/flow`
+ * response body is `application/x-ndjson`: one JSON build event per line.
+ *
+ * Extracted from the duplicated per-spec copies (issue #703) so every
+ * build-event-delivery spec shares a single definition.
+ */
+
+export interface BuildEvent {
+  event?: string;
+  data?: { text?: string; sender?: string; sender_name?: string };
+  /** Present only on the two-step job path's shell response, never on a direct event. */
+  job_id?: string;
+}
+
+/** Parses an NDJSON body into one object per non-empty line. */
+export function parseNdjson(body: string): BuildEvent[] {
+  return body
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line));
+}

--- a/tests/tests-automations/regression/api/flows/api-build-direct-response.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-build-direct-response.spec.ts
@@ -2,6 +2,7 @@ import type { APIRequestContext } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { createRunnableChatFlowViaApi } from "../../../../helpers/flows/create-runnable-chat-flow-via-api";
+import { parseNdjson } from "../../../../helpers/other/parse-ndjson";
 
 // Validates the `direct` event-delivery path of POST /api/v1/build/{flow_id}/flow —
 // the transport the Playground uses to receive a flow run's results
@@ -18,22 +19,6 @@ import { createRunnableChatFlowViaApi } from "../../../../helpers/flows/create-r
 // single response" cannot pass on a structurally valid but empty shell.
 // The /build endpoint authenticates with Bearer (CurrentActiveUser), so the flow
 // is created with the same Bearer identity that builds it.
-
-interface BuildEvent {
-  event?: string;
-  data?: { text?: string; sender?: string; sender_name?: string };
-  /** Present only on the two-step job path's shell response, never on a direct event. */
-  job_id?: string;
-}
-
-/** Parses an NDJSON body into one object per non-empty line. */
-function parseNdjson(body: string): BuildEvent[] {
-  return body
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0)
-    .map((line) => JSON.parse(line));
-}
 
 test.describe("POST /api/v1/build/{flow_id}/flow — direct response delivery", () => {
   let flowId: string;

--- a/tests/tests-automations/regression/api/flows/api-build-polling-response.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-build-polling-response.spec.ts
@@ -2,6 +2,10 @@ import type { APIRequestContext } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { createRunnableChatFlowViaApi } from "../../../../helpers/flows/create-runnable-chat-flow-via-api";
+import {
+  parseNdjson,
+  type BuildEvent,
+} from "../../../../helpers/other/parse-ndjson";
 
 // Validates the `polling` event-delivery path of the flow build API — the
 // transport the Playground uses to receive a flow run's results when
@@ -22,20 +26,6 @@ import { createRunnableChatFlowViaApi } from "../../../../helpers/flows/create-r
 // through the poll loop" cannot pass on a structurally valid but empty shell.
 // The /build endpoint authenticates with Bearer (CurrentActiveUser), so the flow
 // is created with the same Bearer identity that builds it.
-
-interface BuildEvent {
-  event?: string;
-  data?: { text?: string; sender?: string; sender_name?: string };
-}
-
-/** Parses an NDJSON body into one object per non-empty line. */
-function parseNdjson(body: string): BuildEvent[] {
-  return body
-    .split("\n")
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0)
-    .map((line) => JSON.parse(line));
-}
 
 const POLL_MAX_ITERATIONS = 40;
 const POLL_EMPTY_DELAY_MS = 250;


### PR DESCRIPTION
Closes #703.

Tech-debt follow-up from the §9.1 build event-delivery specs. The direct-response (#701/#698) and polling-response (#702/#697) specs each carried an identical `BuildEvent` interface + `parseNdjson(body)` helper — duplicated intentionally while both PRs were open (a shared file touched by both would have coupled them, against the repo's one-issue/one-PR + shared-file caution). Both are now merged, so the copies are folded into one shared module.

## What changed
- **New** `tests/helpers/other/parse-ndjson.ts` — a single `parseNdjson` + `BuildEvent` (the superset, keeping the direct path's optional `job_id`).
- `api-build-direct-response.spec.ts` — removed the local copy, imports `parseNdjson`.
- `api-build-polling-response.spec.ts` — removed the local copy, imports `parseNdjson` + `type BuildEvent`.
- No duplicated NDJSON parsing left under `regression/api/flows/`.

(#696 SSE closed without landing an NDJSON reader, so this is 2 copies → 1, not 3.)

## Acceptance
- ✅ Single `parseNdjson` / `BuildEvent` definition, imported by both build-event-delivery specs.
- ✅ No duplicated NDJSON parsing under `regression/api/flows/`.

## Validation (nightly 1.11.0.dev44)
- **Pure refactor, no behavior change.**
- typecheck ✅ · eslint ✅ (0 errors; the 3 warnings on the polling spec are pre-existing poll-loop conditionals, not introduced here)
- 3× deterministic burst `--workers=1 --retries=0`: `expected=4 unexpected=0 flaky=0` each ✅
- Shared helper is exercised: mutating `parseNdjson` to `return []` failed the two content-consuming tests (direct *echo input*, polling *drain to end*); reverted ✅
- zero orphan flows ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)