### PR TITLE
feat(triage): GitHub-automated daily triage (propose → comment-approve → execute)

### DIFF
--- a/.claude/skills/langflow-e2e-triage/SKILL.md
+++ b/.claude/skills/langflow-e2e-triage/SKILL.md
@@ -248,6 +248,59 @@ Report back to the user in PT-BR with the final list of issue numbers/URLs
 created or enriched, each `@stable`-removal PR opened (and any removal left
 pending), and whether the umbrella was closed or intentionally left open.
 
+## Headless / CI mode
+
+When invoked with a `--phase` argument (from
+`.github/workflows/triage-dispatch.yml`, running via
+`anthropics/claude-code-action@v1`), the skill runs **non-interactively**. The
+human gate here is **not** an `AskUserQuestion` — it is a GitHub issue comment.
+Two rules override the interactive flow:
+
+- **Never call `AskUserQuestion`** and never block on human input. The CI job
+  has no interactive channel; a prompt would hang the run.
+- **Never edit code.** The CI job runs with `--allowedTools "Read,Bash"` (no
+  `Edit`/`Write`) and `contents: read`. `@stable` removal is therefore **out of
+  the automated path** — it stays a manual/local PR (list it, never do it here).
+
+The invocation carries the umbrella issue number as `--issue <n>`.
+
+### `--phase propose` (scheduled, unattended)
+
+Run **Phase 0–6** exactly as documented, with one substitution at Phase 6:
+instead of presenting the plan and waiting for "pode abrir", **post the plan as
+a comment on the umbrella issue** and stop.
+
+- Build the same Phase-6 table plus the `@stable`-removal block.
+- Post it with `gh issue comment <n>`, whose **first line is the exact marker**
+  `<!-- triage-proposal -->` so Phase execute finds it deterministically.
+- End the comment with: *"A triage-team member: reply `pode abrir` on this
+  issue to create/enrich the dedicated issues. `@stable` removals listed above
+  are manual/local TODOs — they are NOT performed by the automation."*
+- Then **STOP**. Create nothing, enrich nothing, close nothing, edit nothing.
+- If Phase 0–1 find no red run or the history is stale, post a one-line
+  "nothing to triage / history stale" comment instead, and stop.
+
+### `--phase execute` (triggered by an approved "pode abrir" comment)
+
+The workflow's `if:` gate already verified the approval (open umbrella,
+`daily-failure` label, phrase present, whitelisted commenter) — treat the
+trigger itself as the authorization; do not re-ask.
+
+- Read the **latest** `<!-- triage-proposal -->` comment on the umbrella
+  (`gh issue view <n> --json comments`). Act on that reviewed plan — do not
+  silently re-derive a different one.
+- Re-run the **Phase 2 dedup** pass before creating, so a re-approval enriches
+  instead of duplicating.
+- Run **Phase 7 steps 1, 2, 4, 5** (create / enrich / link-on-umbrella /
+  close-if-complete). **Skip step 3** (`@stable` removal — manual/local).
+- **Umbrella closure:** close only if the triage is complete **and** no
+  criterion-required `@stable` removal is pending. If a recurrent-flake removal
+  is required, leave the umbrella **open** and post a checklist comment listing
+  the pending manual/local removals (`spec/path.spec.ts:line` + a ready-to-run
+  command), so a human finishes them locally.
+- Post a final comment summarizing the issues created/enriched and the umbrella
+  state (closed, or left open with N pending removals).
+
 ## Relationship to sibling skills
 
 - **`langflow-e2e-triage`** (this skill) — **producer**: turns one red daily

--- a/.claude/skills/langflow-e2e-triage/SKILL.md
+++ b/.claude/skills/langflow-e2e-triage/SKILL.md
@@ -262,7 +262,12 @@ Two rules override the interactive flow:
   `Edit`/`Write`) and `contents: read`. `@stable` removal is therefore **out of
   the automated path** — it stays a manual/local PR (list it, never do it here).
 
-The invocation carries the umbrella issue number as `--issue <n>`.
+The invocation may carry the umbrella issue number as `--issue <n>` (manual
+`workflow_dispatch`). When `--issue` is absent (the `workflow_run` auto-trigger),
+**self-discover** the umbrella: use the umbrella the Phase-1 dataset already
+matched (`gh issue list --repo oriontech-me/langflow-e2e --state open --label
+daily-failure`). If no open umbrella is found, post nothing and stop with a
+logged note.
 
 ### `--phase propose` (scheduled, unattended)
 
@@ -288,7 +293,10 @@ trigger itself as the authorization; do not re-ask.
 
 - Read the **latest** `<!-- triage-proposal -->` comment on the umbrella
   (`gh issue view <n> --json comments`). Act on that reviewed plan — do not
-  silently re-derive a different one.
+  silently re-derive a different one. If **no** `<!-- triage-proposal -->`
+  comment exists on the umbrella, do **not** re-derive a plan — post a short
+  comment ("No triage proposal found on this issue — run `--phase propose`
+  first.") and stop.
 - Re-run the **Phase 2 dedup** pass before creating, so a re-approval enriches
   instead of duplicating.
 - Run **Phase 7 steps 1, 2, 4, 5** (create / enrich / link-on-umbrella /

--- a/.github/workflows/triage-dispatch.yml
+++ b/.github/workflows/triage-dispatch.yml
@@ -1,19 +1,23 @@
 # Human-gated GitHub automation for the daily triage.
-# Phase 1 (propose): when the daily-stable umbrella issue opens, run the
-# triage skill non-interactively and post the plan as a comment. Creates
-# nothing on its own.
+# Phase 1 (propose): after the daily-stable run finishes red, run the triage
+# skill non-interactively and post the plan as a comment on the umbrella issue.
+# Creates nothing on its own. (workflow_run is used, NOT issues.opened: the
+# umbrella issue is created by daily-stable's GITHUB_TOKEN, and GitHub suppresses
+# workflow runs for GITHUB_TOKEN-raised events — an issues trigger would never
+# fire. workflow_run is exempt from that suppression.)
 # Phase 2 (execute): when a triage-team member replies "pode abrir" on that
 # umbrella, run the skill again to create/enrich the dedicated issues.
-# No code is mutated from CI: allowedTools is Read,Bash only and contents is
-# read-only, so @stable removal stays a manual/local PR (the skill's 2nd gate).
-# NOTE: issues / issue_comment triggers only fire from the workflow file on the
-# DEFAULT branch — the auto-triggers are live only after this merges to main.
-# Pre-merge, use the workflow_dispatch entry to test `propose` on the branch.
+# No code is mutated from CI: contents is read-only, so @stable removal stays a
+# manual/local PR (the skill's 2nd gate); allowedTools is Read,Bash.
+# NOTE: workflow_run / issue_comment triggers only fire from the workflow file
+# on the DEFAULT branch — the auto-triggers are live only after this merges to
+# main. Pre-merge, use the workflow_dispatch entry to test `propose` on a branch.
 name: Triage Dispatch
 
 on:
-  issues:
-    types: [opened]
+  workflow_run:
+    workflows: ["Daily Stable E2E"]
+    types: [completed]
   issue_comment:
     types: [created]
   workflow_dispatch:
@@ -31,8 +35,9 @@ jobs:
     name: Propose triage plan
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'issues' &&
-       contains(github.event.issue.labels.*.name, 'daily-failure'))
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'failure' &&
+       github.event.workflow_run.event == 'schedule')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -42,7 +47,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          prompt: "/langflow-e2e-triage --phase propose --issue ${{ github.event.issue.number || inputs.issue }}"
+          prompt: "/langflow-e2e-triage --phase propose ${{ inputs.issue && format('--issue {0}', inputs.issue) || '' }}"
           claude_args: '--allowedTools "Read,Bash" --max-turns 30'
 
   execute:
@@ -56,6 +61,9 @@ jobs:
       contains(fromJSON('["rafaelgiln","Victor-w-Madeira","daniellicnerski1"]'), github.event.comment.user.login)
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    concurrency:
+      group: triage-execute-${{ github.event.issue.number }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
       - uses: anthropics/claude-code-action@v1

--- a/.github/workflows/triage-dispatch.yml
+++ b/.github/workflows/triage-dispatch.yml
@@ -49,6 +49,7 @@ jobs:
     name: Execute approved triage
     if: >-
       github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request == null &&
       github.event.issue.state == 'open' &&
       contains(github.event.issue.labels.*.name, 'daily-failure') &&
       contains(github.event.comment.body, 'pode abrir') &&

--- a/.github/workflows/triage-dispatch.yml
+++ b/.github/workflows/triage-dispatch.yml
@@ -1,0 +1,66 @@
+# Human-gated GitHub automation for the daily triage.
+# Phase 1 (propose): when the daily-stable umbrella issue opens, run the
+# triage skill non-interactively and post the plan as a comment. Creates
+# nothing on its own.
+# Phase 2 (execute): when a triage-team member replies "pode abrir" on that
+# umbrella, run the skill again to create/enrich the dedicated issues.
+# No code is mutated from CI: allowedTools is Read,Bash only and contents is
+# read-only, so @stable removal stays a manual/local PR (the skill's 2nd gate).
+# NOTE: issues / issue_comment triggers only fire from the workflow file on the
+# DEFAULT branch — the auto-triggers are live only after this merges to main.
+# Pre-merge, use the workflow_dispatch entry to test `propose` on the branch.
+name: Triage Dispatch
+
+on:
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: "Umbrella issue number to (re)propose against"
+        required: true
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  propose:
+    name: Propose triage plan
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issues' &&
+       contains(github.event.issue.labels.*.name, 'daily-failure'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: "/langflow-e2e-triage --phase propose --issue ${{ github.event.issue.number || inputs.issue }}"
+          claude_args: '--allowedTools "Read,Bash" --max-turns 30'
+
+  execute:
+    name: Execute approved triage
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.state == 'open' &&
+      contains(github.event.issue.labels.*.name, 'daily-failure') &&
+      contains(github.event.comment.body, 'pode abrir') &&
+      contains(fromJSON('["rafaelgiln","Victor-w-Madeira","daniellicnerski1"]'), github.event.comment.user.login)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: "/langflow-e2e-triage --phase execute --issue ${{ github.event.issue.number }}"
+          claude_args: '--allowedTools "Read,Bash" --max-turns 40'


### PR DESCRIPTION
## What

Runs the `langflow-e2e-triage` skill on GitHub after a red daily, gating issue creation behind a **"pode abrir" comment** instead of a terminal prompt. Two changes, no test code:

1. **`.claude/skills/langflow-e2e-triage/SKILL.md`** — new **"Headless / CI mode"** section making the skill phase-aware (`--phase propose|execute`). `propose` runs the analysis and posts the Phase-6 plan as a comment on the umbrella issue, then stops; `execute` (after approval) reads that comment and creates/enriches the dedicated issues. The local interactive path is unchanged (additions-only).
2. **`.github/workflows/triage-dispatch.yml`** — new workflow: `propose` job (triggered by `workflow_run` after "Daily Stable E2E" finishes red on a schedule, or manual `workflow_dispatch`) and `execute` job (triggered by an `issue_comment` matching the gate).

## Why

The triage skill's hard gate (propose → confirm → create) was terminal-only. This moves the *analysis* to GitHub while keeping the *decision* human — the terminal gate becomes a GitHub issue-comment approval.

## Design

`daily-stable` fails → creates umbrella → `workflow_run` fires `propose` → posts plan comment (marker `<!-- triage-proposal -->`) → a triage-team member replies `pode abrir` → `issue_comment` fires `execute` → dedicated issues created, umbrella linked/closed.

## Safety

- **CI cannot mutate code.** Jobs run `--allowedTools "Read,Bash"` and `permissions: { issues: write, contents: read }`. The `contents: read` token cannot push or open a PR, so **`@stable` removal stays a manual/local PR** (the skill's second gate) — deliberately out of the automated path.
- **`execute` gate fails closed:** `issue_comment` + non-PR + open issue + `daily-failure` label + `pode abrir` phrase + commenter in the triage-team whitelist (`rafaelgiln`, `Victor-w-Madeira`, `daniellicnerski1`). Verified no bypass in review.
- **No injection surface:** only numeric issue IDs are interpolated into prompts; comment body is used only inside `contains()`.

## Trigger note (why `workflow_run`, not `issues.opened`)

The umbrella is created by `daily-stable.yml` via `GITHUB_TOKEN`, and GitHub suppresses workflow runs for `GITHUB_TOKEN`-raised events. `workflow_run` is exempt, so the auto-`propose` actually fires. The skill self-discovers the umbrella when no `--issue` is passed.

## Validation

- `actionlint` clean; skill coherence checks pass; `tsc`/eslint unaffected (no TS changed).
- Reviewed via subagent-driven-development: per-task reviews + final whole-branch review, all clean after fixes.
- **`workflow_run` / `issue_comment` triggers go live only after merge to `main`** (they fire from the default-branch copy). Pre-merge, only `propose` is testable via `workflow_dispatch` on the branch.

### Post-merge validation TODO
On a scratch open issue labeled `daily-failure` carrying a `<!-- triage-proposal -->` comment, a whitelisted user replies `pode abrir` and confirms `execute` creates/enriches the dedicated issues and closes/leaves-open the umbrella per the removal rule. Confirm a non-whitelisted commenter and a wrong phrase do NOT trigger it.

## Deferred follow-ups (low/nit, from review)

- `pode abrir` is a substring match — a whitelisted user quoting the phrase could false-trigger `execute` (bounded to `issues:write`, whitelist-gated).
- `propose` has no actor check beyond the `daily-failure` label (applying that label requires triage role).
- Self-discover could post onto a stale prior-day umbrella if a scheduled run fails *before* umbrella creation (human-gated; low harm).
- No `concurrency` guard on `propose` (double-post possible; `execute` is guarded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
