### PR TITLE
fix(triage): add id-token: write for claude-code-action OIDC

### DIFF
--- a/.github/workflows/triage-dispatch.yml
+++ b/.github/workflows/triage-dispatch.yml
@@ -26,9 +26,14 @@ on:
         description: "Umbrella issue number to (re)propose against"
         required: true
 
+# id-token: write is REQUIRED by anthropics/claude-code-action@v1 — it mints an
+# OIDC token to authenticate; without it the action fails fast with
+# "Could not fetch an OIDC token". It grants no repo write: contents stays read,
+# so @stable removal remains a manual/local PR.
 permissions:
   issues: write
   contents: read
+  id-token: write
 
 jobs:
   propose:


### PR DESCRIPTION
## What
Adds `id-token: write` to `triage-dispatch.yml` permissions.

## Why
Live `workflow_dispatch` validation against umbrella #771 (run [29469838195](https://github.com/oriontech-me/langflow-e2e/actions/runs/29469838195)) failed fast at the `anthropics/claude-code-action@v1` step:

> Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions? (`ACTIONS_ID_TOKEN_REQUEST_URL` unavailable)

The action mints an OIDC token to authenticate; the permission was missing. `execute` correctly **skipped** (gate intact) — only the action-auth permission was wrong.

## Safety
`id-token: write` grants no repo write — it only allows requesting an OIDC token. `contents: read` is unchanged, so `@stable` removal stays a manual/local PR (the skill's second gate).

## Validation
- `actionlint` clean.
- Re-validate live via `workflow_dispatch` against a past umbrella after merge (the trigger config is read from the default-branch copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)