### PR TITLE
fix(triage): propose always posts an observable comment (no silent no-op)

### DIFF
--- a/.claude/skills/langflow-e2e-triage/SKILL.md
+++ b/.claude/skills/langflow-e2e-triage/SKILL.md
@@ -282,8 +282,22 @@ a comment on the umbrella issue** and stop.
   issue to create/enrich the dedicated issues. `@stable` removals listed above
   are manual/local TODOs — they are NOT performed by the automation."*
 - Then **STOP**. Create nothing, enrich nothing, close nothing, edit nothing.
-- If Phase 0–1 find no red run or the history is stale, post a one-line
-  "nothing to triage / history stale" comment instead, and stop.
+
+**Always leave an observable trace — never a silent no-op.** Propose must end
+by posting exactly one comment on the umbrella, whatever the outcome. A silent
+run is indistinguishable from a broken post, so every terminal path posts:
+
+- **Actionable clusters found** → post the full plan comment (the marker
+  `<!-- triage-proposal -->` case above).
+- **Nothing new to triage** (Phase-2 dedup shows every cluster already has a
+  dedicated issue, or the run's umbrella is already closed/triaged) → post a
+  one-line note `<!-- triage-proposal -->` + "Nothing new to triage — every
+  cluster from run `<run_id>` is already dispatched." and stop.
+- **No red run found, or the history is stale** → post a one-line
+  "Nothing to triage — no red run found / history stale." note and stop.
+- **Guard-tripped mass-failure day** → still post the plan, but state
+  descriptively in the comment that the guard tripped (count + threshold) and
+  that `@stable` was left in place (see the guard rule in `references/issue-templates.md`).
 
 ### `--phase execute` (triggered by an approved "pode abrir" comment)
 


### PR DESCRIPTION
## What
The CI-mode `--phase propose` section now guarantees exactly one comment on the umbrella on **every** terminal path — full plan, "nothing new to triage", "no red run / stale", or the guard-tripped plan variant.

## Why
Live `workflow_dispatch` validation against the already-triaged umbrella #771 (run [29469965443](https://github.com/oriontech-me/langflow-e2e/actions/runs/29469965443)) succeeded (8 turns, no error) but posted **nothing** — because Phase-2 dedup found every cluster already dispatched and the old instruction only posted a note on the narrow "no red run / stale" path. A silent no-op is indistinguishable from a broken `gh issue comment` and invisible to the operator.

## Effect
Also makes the automation self-validating: re-dispatching against a triaged umbrella now posts a visible "nothing new to triage" note, proving the comment-posting mechanic end-to-end.

Docs-only (skill markdown). No code, no workflow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)