### PR TITLE
feat(triage): feed daily results.json into propose for per-skip reasons (closes #791)

### DIFF
--- a/.claude/skills/langflow-e2e-triage/SKILL.md
+++ b/.claude/skills/langflow-e2e-triage/SKILL.md
@@ -275,6 +275,12 @@ Run **Phase 0–6** exactly as documented, with one substitution at Phase 6:
 instead of presenting the plan and waiting for "pode abrir", **post the plan as
 a comment on the umbrella issue** and stop.
 
+- **Per-skip reasons:** the `workflow_run` job downloads the triggering daily's
+  `results.json` to the repo root (best-effort). In Phase 1, if `results.json`
+  is present, run the dataset builder with `--results results.json` so Phase 5
+  (SKIPS) sees real per-skip reasons; if it is absent (manual dispatch, or the
+  artifact expired), run history-only and **say so** in the proposal ("per-skip
+  detail unavailable — skips reported by total only").
 - Build the same Phase-6 table plus the `@stable`-removal block.
 - Post it with `gh issue comment <n>`, whose **first line is the exact marker**
   `<!-- triage-proposal -->` so Phase execute finds it deterministically.

--- a/.github/workflows/triage-dispatch.yml
+++ b/.github/workflows/triage-dispatch.yml
@@ -34,6 +34,10 @@ permissions:
   issues: write
   contents: read
   id-token: write
+  # actions: read lets the propose job download the triggering daily run's
+  # results.json artifact (playwright-json-daily-<run_id>) so Phase 5 can read
+  # per-skip reasons instead of only the history file's skip total (#791).
+  actions: read
 
 jobs:
   propose:
@@ -47,6 +51,23 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+      # Best-effort: pull the triggering daily's results.json so the skill's
+      # INTAKE can pass --results and Phase 5 (SKIPS) reads real per-skip
+      # reasons. Only the workflow_run path has a source run; a manual
+      # workflow_dispatch has none, so it runs history-only (as before). Never
+      # fails the job — if the artifact is missing/expired, propose degrades to
+      # history-only and says so in the proposal.
+      - name: Download triggering daily results.json (best-effort)
+        if: github.event_name == 'workflow_run'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DAILY_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          gh run download "$DAILY_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            -n "playwright-json-daily-$DAILY_RUN_ID" -D . \
+            || echo "::warning::results.json artifact unavailable for run $DAILY_RUN_ID — propose runs history-only."
+          if [ -f results.json ]; then echo "results.json present ($(wc -c < results.json) bytes)."; else echo "no results.json — history-only."; fi
       - uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## What
The `propose` job now downloads the triggering daily's `results.json` artifact and the skill passes `--results results.json` to the dataset builder, so **Phase 5 (SKIPS)** reads real per-skip reasons instead of only the history file's skip total.

Closes #791.

## Why
`propose` ran only against `daily-history.jsonl`, which carries the skip **total** but no per-skip **reason**. Phase 5 was therefore blind — it reached "no skip issue" by **default**, not by verification. A genuinely unexpected skip on a future daily would be missed silently. Found via the counter-proof audit of run `29489622983` / umbrella #788 (7 skips: 2 intentional + 5 collateral of already-dispatched hard failures — correct outcome, but unverified).

## How
- `propose` job (only the `workflow_run` path — it has a source run) downloads `playwright-json-daily-<run_id>` to `results.json`. **Best-effort** (`continue-on-error`): a missing/expired artifact or a manual `workflow_dispatch` degrades to history-only, and the skill states that in the proposal.
- Skill INTAKE passes `--results results.json` when the file is present.
- Adds `actions: read` (artifact download from another run). **Safety model unchanged**: `contents: read`, `--allowedTools "Read,Bash"` — CI still can't mutate code.

## Validation
- `actionlint` clean.
- Post-merge: next real red daily (or `workflow_dispatch`, which runs history-only) exercises the path; the proposal should now reason over per-skip reasons or explicitly state per-skip detail was unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)