### PR TITLE
fix(ci): stop migration-test jobs from closing each other's failure issues

### DIFF
--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -279,7 +279,7 @@ jobs:
             const { data: existing } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: 'migration-test',
+              labels: 'migration-test-api',
               state: 'open',
             });
             if (existing.length > 0) {
@@ -320,7 +320,7 @@ jobs:
             const { data: existing } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: 'migration-test',
+              labels: 'migration-test-api',
               state: 'open',
             });
 
@@ -345,9 +345,9 @@ jobs:
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                title: `Langflow Migration Test Failed (latest → nightly)`,
+                title: `Langflow Migration Test Failed — API script (latest → nightly)`,
                 body,
-                labels: ['migration-test', 'automated'],
+                labels: ['migration-test-api', 'migration-test', 'automated'],
               });
             }
 
@@ -696,7 +696,7 @@ jobs:
             const { data: existing } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: 'migration-test',
+              labels: 'migration-test-compose',
               state: 'open',
             });
             if (existing.length > 0) {
@@ -729,7 +729,7 @@ jobs:
             const { data: existing } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: 'migration-test',
+              labels: 'migration-test-compose',
               state: 'open',
             });
             const body = [
@@ -754,8 +754,8 @@ jobs:
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                title: 'Langflow Migration Test Failed (latest → nightly)',
+                title: 'Langflow Migration Test Failed — docker-compose (latest → nightly)',
                 body,
-                labels: ['migration-test', 'automated'],
+                labels: ['migration-test-compose', 'migration-test', 'automated'],
               });
             }


### PR DESCRIPTION
## Summary
- `migration-test` (API-script job) and `migration-test-compose` (docker-compose job) both open/close their failure-tracking issue using the same `migration-test` label.
- Because the two jobs run in parallel, a pass in one job's "Close issue on success" step can close the issue the *other* job just filed on failure — silently marking a real regression as resolved.
- Confirmed on [run #101](https://github.com/oriontech-me/langflow-e2e/actions/runs/29485977654): `migration-test-compose` failed at 09:10:46 UTC with an outdated-component `HTTP 400` on the migrated witness flow and filed/updated issue #770; `migration-test` passed at 09:12:20 UTC and its "Close issue on success" step closed #770 right after, even though the compose failure was never addressed.
- Fix: give each job its own tracking label (`migration-test-api` / `migration-test-compose`, both created in the repo) while keeping `migration-test` as a shared label on new issues for cross-job queries. Each job's success/failure logic now only ever touches its own issue.

## Test plan
- [ ] Next scheduled `migration-test.yml` run: confirm the compose-job failure (if it recurs) opens/keeps open its own issue independent of the API job's result
- [ ] Confirm a genuine pass in both jobs still closes both issues correctly

Note: the compose job's underlying failure (outdated OpenAI component blocking flow execution post-migration) is a separate, real issue — the flow_validation guard in `lfx/utils/flow_validation.py` intentionally blocks running components whose code hash differs from the server's, and nightly rebuilds daily. That's left out of scope for this PR, which only fixes the issue-tracking collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)