### PR TITLE
fix(knowledge): track Google model-catalog changes in RAG/KB specs (#789)

### DIFF
--- a/docs/core-functionality/knowledge-ingestion-management/rag-pipeline.md
+++ b/docs/core-functionality/knowledge-ingestion-management/rag-pipeline.md
@@ -75,10 +75,10 @@ bundle-free and never yields a false failure on a packaging change.
 
 ### Embedding + answer model (single-key: Google)
 
-- **Embedding:** the KB is created with Google `gemini-embedding-001` (the
+- **Embedding:** the KB is created with Google `models/gemini-embedding-001` (the
   embedding model enabled out-of-the-box; `GOOGLE_API_KEY` is auto-imported as a
   credential and injected in the daily-stable CI).
-- **Answer:** the Language Model uses Google **`gemini-2.5-flash`** at
+- **Answer:** the Language Model uses Google **`gemini-flash-latest`** at
   `temperature = 0`. Its `api_key` resolves from the same `GOOGLE_API_KEY` global
   variable (`load_from_db`), so the entire spec depends on **one** provider key —
   one skip guard, aligned with the daily-stable CI. The unified model selector's
@@ -152,7 +152,7 @@ per run.
 **Setup:**
 1. Create a fresh KB via `POST /api/v1/knowledge_bases` — unique name per run,
    `embedding_provider = "Google Generative AI"`, `embedding_model =
-   "gemini-embedding-001"`, `backend_type = "chroma"`. Record the KB `dir_name`
+   "models/gemini-embedding-001"`, `backend_type = "chroma"`. Record the KB `dir_name`
    for teardown.
 2. Load the fixture JSON and set `knowledge_base.value` **and**
    `knowledge_base.options = [dir_name]` on **both** Knowledge nodes (both are
@@ -181,13 +181,13 @@ per run.
   `ZEPHYR-42` codec fact) → Split Text (`chunk_size = 100`, `chunk_overlap = 0`,
   `separator = "\n"`) → Knowledge (`mode = Ingest`); plus Knowledge
   (`mode = Retrieve`, `top_k = 1`, `search_query` = the codec question) → Parser →
-  Prompt (`{context}` + baked question) → Language Model (Google `gemini-2.5-flash`,
+  Prompt (`{context}` + baked question) → Language Model (Google `gemini-flash-latest`,
   `temperature = 0`, `api_key` from the `GOOGLE_API_KEY` global variable) → Chat
   Output. Both Knowledge nodes' `knowledge_base` is a placeholder (`__KB_NAME__`)
   the spec replaces per run. Built + configured live on the canvas and validated
   end-to-end on 1.11.0.dev38.
-- `GOOGLE_API_KEY` — required (embeds each chunk with `gemini-embedding-001` and
-  answers with `gemini-2.5-flash`).
+- `GOOGLE_API_KEY` — required (embeds each chunk with `models/gemini-embedding-001` and
+  answers with `gemini-flash-latest`).
 - Knowledge Base API: `POST /api/v1/knowledge_bases` (create),
   `GET /api/v1/knowledge_bases/{name}` (chunk count),
   `DELETE /api/v1/knowledge_bases/{name}` (scoped cleanup).

--- a/docs/core-functionality/knowledge-ingestion-management/vector-store-index-query.md
+++ b/docs/core-functionality/knowledge-ingestion-management/vector-store-index-query.md
@@ -53,7 +53,7 @@ a packaging change.
 - **Knowledge (Ingest)** — embeds + indexes the chunks into the KB.
 - **Knowledge (Retrieve)** — a second Knowledge node in the same flow, over the
   same KB, `mode = Retrieve`, `top_k = 1`, static `search_query`.
-- **Embedding**: the KB is created with Google `gemini-embedding-001` (the
+- **Embedding**: the KB is created with Google `models/gemini-embedding-001` (the
   embedding model enabled out-of-the-box on the instance; `GOOGLE_API_KEY` is
   auto-imported as a credential and is injected in the daily-stable CI). No
   bundle, no per-user model enablement needed — the KB create API takes just the
@@ -122,7 +122,7 @@ Two tests, one shared fixture flow (`Chat Input → Split Text → Knowledge[Ing
 **Setup (each test):**
 1. Create a fresh KB via `POST /api/v1/knowledge_bases` — unique name per run,
    `embedding_provider = "Google Generative AI"`, `embedding_model =
-   "gemini-embedding-001"`, `backend_type = "chroma"` (no `model_selection`
+   "models/gemini-embedding-001"`, `backend_type = "chroma"` (no `model_selection`
    needed — the KB resolves the embedding from provider + model at ingest time).
    Record the KB `dir_name` for teardown.
 2. Load the fixture JSON and set `knowledge_base.value` **and**
@@ -162,7 +162,7 @@ Two tests, one shared fixture flow (`Chat Input → Split Text → Knowledge[Ing
   `top_k = 1`, `search_query` = the embedding-topic query). Both Knowledge nodes'
   `knowledge_base` is a placeholder (`__KB_NAME__`) the spec replaces per run.
   Built live on the canvas and exported on 1.11.0.dev38.
-- `GOOGLE_API_KEY` — required (the KB embeds each chunk with `gemini-embedding-001`).
+- `GOOGLE_API_KEY` — required (the KB embeds each chunk with `models/gemini-embedding-001`).
 - Knowledge Base API: `POST /api/v1/knowledge_bases` (create),
   `GET /api/v1/knowledge_bases/{name}` (chunk count),
   `DELETE /api/v1/knowledge_bases/{name}` (scoped cleanup).

--- a/tests/helpers/knowledge/knowledge-base.ts
+++ b/tests/helpers/knowledge/knowledge-base.ts
@@ -26,7 +26,7 @@ export interface CreateKnowledgeBaseInput {
   name: string;
   /** Embedding provider, e.g. `"Google Generative AI"`. */
   embeddingProvider: string;
-  /** Embedding model id, e.g. `"gemini-embedding-001"`. */
+  /** Embedding model id, e.g. `"models/gemini-embedding-001"`. */
   embeddingModel: string;
 }
 

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/rag-pipeline.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/rag-pipeline.spec.ts
@@ -22,7 +22,7 @@ import {
 // end-to-end on 1.11.0.dev38:
 //   Chat Input(the 5-line document) -> Split Text(chunk_size=100, overlap=0) ->
 //   Knowledge[Ingest]; and Knowledge[Retrieve](top_k=1, static query) -> Parser ->
-//   Prompt{context} -> Language Model(Google gemini-2.5-flash, temperature=0) ->
+//   Prompt{context} -> Language Model(Google gemini-flash-latest, temperature=0) ->
 //   Chat Output. The KB name is a placeholder the spec replaces per run.
 const FIXTURE_PATH = "tests/assets/flows/rag-pipeline-fixture.json";
 
@@ -40,9 +40,15 @@ const GROUNDING_SENTINEL = "ZEPHYR-42";
 
 // The KB embeds with Google out-of-the-box; GOOGLE_API_KEY is auto-imported as a
 // credential and injected in the daily-stable CI. The same key backs the answer
-// model (gemini-2.5-flash), so the whole spec depends on one provider key.
+// model (gemini-flash-latest), so the whole spec depends on one provider key.
 const EMBEDDING_PROVIDER = "Google Generative AI";
-const EMBEDDING_MODEL = "gemini-embedding-001";
+const EMBEDDING_MODEL = "models/gemini-embedding-001";
+
+// The answer model. An alias (not a dated/pinned id) so the spec tracks Google's
+// current flash model: pinned ids like `gemini-2.5-flash` return 404 ("no longer
+// available to new users") on newer keys as Google retires them, while
+// `gemini-flash-latest` always resolves to the live flash model.
+const ANSWER_MODEL = "gemini-flash-latest";
 
 // Stable node ids baked into the fixture, so the shared run/duration/inspection
 // testids can be scoped to the right node.
@@ -62,7 +68,7 @@ test.describe.configure({ mode: "serial" });
 
 test.skip(
   !process?.env?.GOOGLE_API_KEY,
-  "GOOGLE_API_KEY required to embed the document and answer with gemini-2.5-flash",
+  "GOOGLE_API_KEY required to embed the document and answer with gemini-flash-latest",
 );
 
 async function authHeaders(page: Page): Promise<Record<string, string>> {
@@ -101,6 +107,23 @@ async function openRagFlow(page: Page): Promise<void> {
       kb.value = kbName;
       kb.options = [kbName];
     }
+    // Point the answer Language Model at ANSWER_MODEL (an alias). The fixture was
+    // captured pinned to a dated model that Google is retiring — pinned ids 404
+    // ("no longer available") on newer keys. The alias always resolves to the
+    // current flash model, so the spec follows Google's model lifecycle instead
+    // of false-failing on a retirement. Set the structured `model` selection
+    // (from the node's own options) AND the `model_name` string override.
+    if (node.data?.type === "LanguageModelComponent") {
+      const tmpl = node.data.node.template;
+      const modelOption = (tmpl.model?.options ?? []).find(
+        (o: { name?: string }) => o?.name === ANSWER_MODEL,
+      );
+      if (modelOption) tmpl.model.value = [modelOption];
+      if (tmpl.model_name) {
+        tmpl.model_name.value = ANSWER_MODEL;
+        tmpl.model_name.options = [ANSWER_MODEL];
+      }
+    }
   }
 
   const flowId = await createFlow(
@@ -131,6 +154,29 @@ async function openRagFlow(page: Page): Promise<void> {
       .locator(`[data-id="${ANSWER_OUTPUT_NODE}"]`)
       .getByTestId("button_run_chat output"),
   ).toBeVisible({ timeout: 30000 });
+
+  // Dismiss the outdated-update banner up front (present on load, persists once
+  // dismissed) so it never overlays a later node-output click.
+  await dismissUpdateBannerIfPresent(page);
+}
+
+// The fixture was captured on an older nightly, so on a newer build its
+// components resolve to outdated updates and a bottom-centered "N components need
+// updates" banner overlays the node output controls, intercepting the
+// output-inspection click. It is noise for this spec (outdated notifications are
+// covered by outdated-component-notification.spec.ts), so dismiss it before
+// reading a node's output.
+async function dismissUpdateBannerIfPresent(page: Page): Promise<void> {
+  // The outdated diff resolves asynchronously after the flow loads, so the banner
+  // can appear a beat late; wait briefly for it (the fixture is deliberately
+  // behind the nightly, so it always appears within this window) before
+  // dismissing. If a future fixture refresh removes the outdated state, this
+  // just times out and no-ops — the test still runs in full, never skips.
+  const dismissAll = page.getByRole("button", { name: "Dismiss All" });
+  if (await dismissAll.isVisible({ timeout: 6000 }).catch(() => false)) {
+    await dismissAll.click();
+    await expect(dismissAll).toBeHidden({ timeout: 5000 });
+  }
 }
 
 /** Runs a node (scoped by id) via its run button and waits for the success badge. */

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/vector-store-index-query.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/vector-store-index-query.spec.ts
@@ -40,7 +40,7 @@ const CHUNK_SENTINEL = "embedding vector";
 // the daily-stable CI. The KB API resolves the embedding at ingest time from
 // this provider/model + that credential.
 const EMBEDDING_PROVIDER = "Google Generative AI";
-const EMBEDDING_MODEL = "gemini-embedding-001";
+const EMBEDDING_MODEL = "models/gemini-embedding-001";
 
 // Stable node ids baked into the fixture, so the shared `button_run_knowledge` /
 // `node_duration_knowledge` / `output-inspection-results-knowledge` testids can
@@ -123,6 +123,29 @@ async function openVectorStoreFlow(page: Page): Promise<void> {
   // side/bottom react-flow panels (the right Inspector Panel intercepts the
   // run-button click on nodes near the right edge otherwise).
   await adjustScreenView(page, { numberOfZoomOut: 2 });
+
+  // Dismiss the outdated-update banner up front (present on load, persists once
+  // dismissed) so it never overlays a later node-output click.
+  await dismissUpdateBannerIfPresent(page);
+}
+
+// The fixture flow was captured on an older nightly, so on a newer build its
+// components resolve to outdated updates and the canvas shows a bottom-centered
+// "N components need updates" banner. That banner overlays the node output
+// controls and intercepts the output-inspection click. It is pure noise for this
+// spec (outdated notifications are covered by outdated-component-notification.spec.ts),
+// so dismiss it before interacting with a node's output.
+async function dismissUpdateBannerIfPresent(page: Page): Promise<void> {
+  // The outdated diff resolves asynchronously after the flow loads, so the banner
+  // can appear a beat late; wait briefly for it (the fixture is deliberately
+  // behind the nightly, so it always appears within this window) before
+  // dismissing. If a future fixture refresh removes the outdated state, this
+  // just times out and no-ops — the test still runs in full, never skips.
+  const dismissAll = page.getByRole("button", { name: "Dismiss All" });
+  if (await dismissAll.isVisible({ timeout: 6000 }).catch(() => false)) {
+    await dismissAll.click();
+    await expect(dismissAll).toBeHidden({ timeout: 5000 });
+  }
 }
 
 /** Runs a Knowledge node (scoped by id) and waits for its success-build badge. */


### PR DESCRIPTION
**Fixes #789.** Closes #789.

## Problem
Two `@stable` knowledge/RAG specs hard-failed (final, post-retry) in daily #788 — `rag-pipeline.spec.ts` and `vector-store-index-query.spec.ts` — with the same shape: the pipeline never completed and the expected output never rendered. Reproduced **deterministically at `--workers=1`** (not saturation).

Root cause = **two upstream Google model-catalog changes** (product-changed, not test rot):

1. **Embedding ids gained a `models/` prefix.** The current registry lists `models/gemini-embedding-001`; the specs used `gemini-embedding-001`, so ingest failed with `ComponentBuildError: embedding model 'gemini-embedding-001' is no longer recognized`.
2. **`gemini-2.5-flash` is being retired by Google** — `404 "This model … is no longer available to new users"` on newer API keys. This is the rag answer model.

Isolation confirms product-side: only embedding-dependent KB specs failed in #788; Google-LLM specs had no issue.

## Fix
- `EMBEDDING_MODEL` → `models/gemini-embedding-001` in both specs.
- rag answer model → `gemini-flash-latest` (alias), applied at runtime in `openRagFlow` (structured `model` selection + `model_name` override). An alias tracks Google's live flash model instead of a pinned id that gets retired.
- **Wait hardening:** the older fixture now resolves to outdated components on the current nightly, so the "N components need updates" banner overlays the output-inspection button and intercepts the click. Dismiss it once on open (bounded 6s wait; no-op — never a skip — if a future fixture refresh removes the outdated state).
- Spec docs + the `createKnowledgeBase` helper comment updated to the new model ids.

## Scope note
Assertions unchanged (grounded `ZEPHYR-42`, `kb.chunks === 5`, top-1 `embedding vector`). Only the model ids, the answer-model selection, and the banner-dismiss hardening changed. `@stable` kept in place (per the issue's mass-failure-day directive).

## Validation (nightly 1.11.0.dev45, `--retries=0 --workers=1`)
- typecheck ✅ · eslint ✅ (0 errors) · QA-CHECKLIST guard ✅
- `rag-pipeline` 3/3 clean · `vector-store-index-query` 3/3 clean ✅
- force-fail ✅ — one mutation per test, each observed red then reverted:
  - rag: grounding sentinel regex → `NONEXISTENT_SENTINEL_FF`
  - vector t1: `kb.chunks` `toBe(EXPECTED_CHUNKS)` → `+999`
  - vector t2: result filter `CHUNK_SENTINEL` → `NONEXISTENT_CHUNK_FF`
- zero `🚨 Backend Error` ✅ · zero orphan flows/KBs ✅ (proven before/after)

**Requires** a `GOOGLE_API_KEY` whose project can call `gemini-flash-latest` (the daily CI key qualifies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)