### PR TITLE
test(core-components): Parameters Panel field-type matrix — phase 1 (#662)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -126,18 +126,18 @@
 
 #### 2.1 Parameters Panel
 - [-] Open component advanced options
-- [-] Edit text field (input)
-- [-] Edit dropdown
-- [-] Edit text area (textarea)
+- [x] Edit text field (input) → `core-components/parameters-panel-field-types.spec.ts`
+- [x] Edit dropdown → `core-components/parameters-panel-field-types.spec.ts`
+- [x] Edit text area (textarea) → `core-components/parameters-panel-field-types.spec.ts`
 - [-] Edit code field
 - [-] Edit float field
-- [-] Edit int field
-- [-] Edit toggle field
+- [x] Edit int field → `core-components/parameters-panel-field-types.spec.ts`
+- [x] Edit toggle field → `core-components/parameters-panel-field-types.spec.ts`
 - [-] Edit key-pair list
 - [-] Edit input list
 - [-] Edit table input
 - [-] Edit slider
-- [-] Edit tab component
+- [x] Edit tab component → `core-components/parameters-panel-field-types.spec.ts`
 
 #### 2.2 Tool Mode
 - [x] Enable Tool Mode on a component

--- a/docs/core-components/parameters-panel-field-types.md
+++ b/docs/core-components/parameters-panel-field-types.md
@@ -1,0 +1,137 @@
+# Spec: Parameters Panel — field-type edit matrix
+
+**Test file:** `tests/tests-automations/regression/core-components/parameters-panel-field-types.spec.ts`
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates
+
+The component **Parameters Panel** accepts edits across every field-type input
+and **persists** each edited value. This is the §2.1 field-type matrix: for each
+distinct input type, a representative component is added to a flow, the field is
+edited on the canvas, and the new value is proven to persist in the saved flow.
+
+A **parametrized matrix** — one `test()` per field type — sharing a common
+setup/verify shape, so a regression in any single input type is isolated to its
+own test.
+
+> **Phased delivery.** This spec ships the **6 simple-mechanic types** first
+> (text, int, dropdown, tab, textarea, toggle) — all with a plain click/fill edit
+> and a scalar/string persisted value. The **6 complex/modal types** (slider drag,
+> code editor, table modal, key-pair NestedDict, input-list SortableList, float)
+> are deferred to a follow-up because each needs a distinct modal/drag mechanic
+> and two (`KeypairInput`/`ListInput` from the checklist era) no longer exist as
+> those input types — mapping them is tracked separately. The matrix below marks
+> each type's phase.
+
+### Verification model (uniform across types)
+
+Each test:
+1. Creates a blank flow via the API and opens it.
+2. Adds the representative component from the sidebar.
+3. Edits the target field in the Parameters Panel (mechanism per type — see
+   matrix).
+4. Waits for autosave, then reads back the value via
+   `GET /api/v1/flows/{id}` and asserts `data.nodes[].data.node.template.<field>.value`
+   equals the edited value.
+
+Reading the persisted template value (not just the on-screen widget) is the
+durable proof the edit was accepted **and** saved — it survives re-render and
+matches what a reload would load.
+
+### Field-type matrix (13 bullets → 12 live input types)
+
+| # | Field type (checklist) | Input type | Component | Field | Edit mechanism | Phase |
+|---|---|---|---|---|---|---|
+| 1 | Edit text field (input) | `MessageTextInput` | API Request | `url_input` | fill `popover-anchor-input-url_input` | **this PR** |
+| 2 | Edit dropdown | `DropdownInput` | API Request | `method` | click `dropdown_str_method` → `POST-1-option` | **this PR** |
+| 3 | Edit text area (textarea) | `MultilineInput` | API Request | `curl_input` | fill `textarea_str_curl_input` (cURL tab) | **this PR** |
+| 4 | Edit int field | `IntInput` | API Request | `timeout` | fill `int_int_timeout` | **this PR** |
+| 5 | Edit tab component | `TabInput` | API Request | `mode` | click `tab_1_curl` | **this PR** |
+| 6 | Edit toggle field | `BoolInput` | Save File | `append_mode` | click `toggle_bool_append_mode` | **this PR** |
+| 7 | Edit slider | `SliderInput` | Language Model | `temperature` | drag `slider_thumb` | follow-up |
+| 8 | Edit code field | `CodeInput` | Python Function | `function_code` | code editor modal | follow-up |
+| 9 | Edit table input | `TableInput` | API Request | `headers` | table modal → cell | follow-up |
+| 10 | Edit key-pair list | `NestedDictInput` | Alter Metadata | `metadata` | key/value row | follow-up |
+| 11 | Edit input list | `SortableListInput` | Read File | `storage_location` | list item | follow-up |
+| 12 | Edit float field | `FloatInput` | Semantic Text Splitter | `breakpoint_threshold_amount` | numeric input | follow-up |
+
+> The checklist's *key-pair list* and *input list* correspond to the checklist-era
+> `KeypairInput` / `ListInput`, which no longer exist in the current registry;
+> they map to today's `NestedDictInput` and `SortableListInput` respectively — the
+> spec asserts the live equivalents. The 13th checklist bullet ("Edit tab
+> component") is the `TabInput` row.
+
+---
+
+## Tags
+
+`@stable` `@components` `@regression`
+
+`@components` (canvas/parameters-panel configuration) is the functional area.
+`@stable` is added after the deterministic-run + force-fail validation.
+
+---
+
+## Validation criterion
+
+For each field type: after editing its field in the Parameters Panel and waiting
+for autosave, `GET /api/v1/flows/{id}` returns the target node's
+`template.<field>.value` (or the type's persisted shape — a selected option, a
+boolean, a numeric, a table row, a code string) **equal to the edited value**.
+
+Each test fails if editing that input type does not persist — a regression in
+the panel's handling of that specific field type.
+
+### Type-specific persisted shapes (confirmed live during authoring)
+
+- text / textarea / int / float / code: scalar `value`.
+- dropdown / tab: the selected string in `value`.
+- toggle: boolean `value` flipped from its default.
+- slider: numeric `value` within the field's range.
+- table: `value` is an array of row objects; the edited cell is asserted.
+- key-pair (NestedDict): `value` is an object; the edited key→value asserted.
+- input list (SortableList): `value` is a list; the edited item asserted.
+
+---
+
+## External dependencies
+
+- `tests/helpers/flows/create-flow.ts`, `delete-flow.ts`, `auth/get-auth-token.ts`.
+- Representative components (all core, non-bundle): API Request, Python Function,
+  Semantic Text Splitter, Alter Metadata, Read File, Language Model.
+- **No model-provider credentials required** — no flow is executed; edits are
+  read back via the flows API.
+
+Field testids confirmed live on `langflow-nightly 1.11.0.dev45` during authoring
+(`popover-anchor-input-url_input`, `dropdown_str_method`, `int_int_timeout`,
+`title-mode` + `tab_0_url`/`tab_1_curl`, `div-table_headers` + `icon-Table`, …);
+the remaining per-type testids are harvested in the PLAN/IMPLEMENT scout.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` on a recent nightly (1.11.x).
+- Auth via `auto_login` (repo default).
+
+---
+
+## What this test does not cover
+
+- Field **validation** (rejecting out-of-range/invalid input) — this matrix
+  asserts accepted edits persist, not the rejection path.
+- Executing the components — persistence is asserted via the flows API, not a run.
+- Advanced-field visibility toggling and connection handles — covered elsewhere
+  (§2.1 "open advanced", handle specs).
+
+---
+
+## Notes
+
+- **Force-fail probes (executed during validation):** one mutation per `test()`
+  (per field type), each observed failing then reverted — documented in the PR
+  Validation block.
+- Every test creates exactly one flow and deletes it id-scoped in `afterEach`.

--- a/tests/tests-automations/regression/core-components/parameters-panel-field-types.spec.ts
+++ b/tests/tests-automations/regression/core-components/parameters-panel-field-types.spec.ts
@@ -1,0 +1,212 @@
+import type { APIRequestContext, Page } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { createFlow } from "../../../helpers/flows/create-flow";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { addComponentFromSidebar } from "../../../helpers/flows/add-component-from-sidebar";
+
+// §2.1 Parameters Panel — field-type edit matrix. For each input type, a
+// representative component is added, the field is edited in the panel, and the
+// new value is proven to PERSIST by reading it back from the saved flow via the
+// REST API (template.<field>.value) — reload-proof, uniform across types.
+//
+// Phase 1 (this spec): the six simple-mechanic types (text, dropdown, textarea,
+// int, tab, toggle). The complex/modal types (slider drag, code editor, table
+// modal, key-pair NestedDict, input-list SortableList, float) are a tracked
+// follow-up — see docs/core-components/parameters-panel-field-types.md.
+
+// Ids of flows created by each test — deleted id-scoped in afterEach (repo
+// convention #490/#681).
+const createdFlowIds: string[] = [];
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, { headers: { Authorization: bearer } });
+  }
+});
+
+// Create a blank flow via the API (parallel-safe unique name), open it, and add
+// the component under test from the sidebar. Returns the flow id.
+async function openFlowWithComponent(
+  page: Page,
+  request: APIRequestContext,
+  bearer: string,
+  searchTerm: string,
+  addButtonTestId: string,
+  titleTestId: string,
+): Promise<string> {
+  const flowId = await createFlow(
+    request,
+    {
+      name: `Params Panel ${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      description: "",
+      data: { nodes: [], edges: [] },
+      is_component: false,
+    },
+    { headers: { Authorization: bearer } },
+  );
+  createdFlowIds.push(flowId);
+
+  await page.goto(`/flow/${flowId}`);
+  await page
+    .getByTestId("sidebar-search-input")
+    .waitFor({ state: "visible", timeout: 60000 });
+  await addComponentFromSidebar(page, searchTerm, addButtonTestId);
+  await expect(page.getByTestId(titleTestId)).toBeVisible({ timeout: 15000 });
+  return flowId;
+}
+
+// Read a field's persisted value from the saved flow (single-node flows, so
+// nodes[0]). The durable proof the edit was accepted AND autosaved.
+async function readFieldValue(
+  request: APIRequestContext,
+  bearer: string,
+  flowId: string,
+  field: string,
+): Promise<unknown> {
+  const res = await request.get(`/api/v1/flows/${flowId}`, {
+    headers: { Authorization: bearer },
+  });
+  expect(res.status()).toBe(200);
+  const body = (await res.json()) as {
+    data: { nodes: Array<{ data: { node: { template: Record<string, { value: unknown }> } } }> };
+  };
+  return body.data.nodes[0]?.data?.node?.template?.[field]?.value;
+}
+
+// Poll the saved flow until the field reflects the edit (autosave is debounced).
+async function expectPersisted(
+  request: APIRequestContext,
+  bearer: string,
+  flowId: string,
+  field: string,
+  expected: unknown,
+): Promise<void> {
+  await expect
+    .poll(() => readFieldValue(request, bearer, flowId, field), {
+      timeout: 15000,
+    })
+    .toEqual(expected);
+}
+
+test.describe("Parameters Panel — field-type edit matrix", () => {
+  test(
+    "text input field edit persists",
+    { tag: ["@stable", "@components", "@regression"] },
+    async ({ page, request }) => {
+      const bearer = await getAuthToken(request);
+      const flowId = await openFlowWithComponent(
+        page,
+        request,
+        bearer,
+        "API Request",
+        "add-component-button-api-request",
+        "title-url",
+      );
+      const url = "https://httpbin.org/get";
+      await page.getByTestId("popover-anchor-input-url_input").fill(url);
+      await page.getByTestId("popover-anchor-input-url_input").blur();
+      await expectPersisted(request, bearer, flowId, "url_input", url);
+    },
+  );
+
+  test(
+    "dropdown field edit persists",
+    { tag: ["@stable", "@components", "@regression"] },
+    async ({ page, request }) => {
+      const bearer = await getAuthToken(request);
+      const flowId = await openFlowWithComponent(
+        page,
+        request,
+        bearer,
+        "API Request",
+        "add-component-button-api-request",
+        "title-method",
+      );
+      await page.getByTestId("dropdown_str_method").click();
+      await page.getByTestId("POST-1-option").click();
+      await expectPersisted(request, bearer, flowId, "method", "POST");
+    },
+  );
+
+  test(
+    "textarea field edit persists",
+    { tag: ["@stable", "@components", "@regression"] },
+    async ({ page, request }) => {
+      const bearer = await getAuthToken(request);
+      const flowId = await openFlowWithComponent(
+        page,
+        request,
+        bearer,
+        "API Request",
+        "add-component-button-api-request",
+        "title-method",
+      );
+      // The cURL multiline field only renders under the cURL tab.
+      await page.getByTestId("tab_1_curl").click();
+      const curl = "curl https://httpbin.org/post -X POST";
+      await page.getByTestId("textarea_str_curl_input").fill(curl);
+      await page.getByTestId("textarea_str_curl_input").blur();
+      await expectPersisted(request, bearer, flowId, "curl_input", curl);
+    },
+  );
+
+  test(
+    "int field edit persists",
+    { tag: ["@stable", "@components", "@regression"] },
+    async ({ page, request }) => {
+      const bearer = await getAuthToken(request);
+      const flowId = await openFlowWithComponent(
+        page,
+        request,
+        bearer,
+        "API Request",
+        "add-component-button-api-request",
+        "title-timeout",
+      );
+      await page.getByTestId("int_int_timeout").fill("77");
+      await page.getByTestId("int_int_timeout").blur();
+      await expectPersisted(request, bearer, flowId, "timeout", 77);
+    },
+  );
+
+  test(
+    "tab field edit persists",
+    { tag: ["@stable", "@components", "@regression"] },
+    async ({ page, request }) => {
+      const bearer = await getAuthToken(request);
+      const flowId = await openFlowWithComponent(
+        page,
+        request,
+        bearer,
+        "API Request",
+        "add-component-button-api-request",
+        "title-mode",
+      );
+      // Default tab is "URL" (mode="URL"); switch to the cURL tab.
+      await page.getByTestId("tab_1_curl").click();
+      await expectPersisted(request, bearer, flowId, "mode", "cURL");
+    },
+  );
+
+  test(
+    "toggle field edit persists",
+    { tag: ["@stable", "@components", "@regression"] },
+    async ({ page, request }) => {
+      const bearer = await getAuthToken(request);
+      const flowId = await openFlowWithComponent(
+        page,
+        request,
+        bearer,
+        "Save File",
+        "add-component-button-write-file",
+        "title-append",
+      );
+      // append_mode defaults to false; clicking the switch flips it to true.
+      await page.getByTestId("toggle_bool_append_mode").click();
+      await expectPersisted(request, bearer, flowId, "append_mode", true);
+    },
+  );
+});


### PR DESCRIPTION
Closes #662. Phase 2 (complex/modal types) tracked in #795.

Closes the §2.1 Parameters Panel field-type gap with a **parametrized matrix**: for each input type a representative component is added, the field edited in the panel, and the new value proven to persist by reading it back from the saved flow via the REST API (`template.<field>.value`) — reload-proof and uniform across types.

## 1. Covered tests (phase 1 — 6 simple-mechanic types)
| # | Test | Component / field | What it validates |
|---|------|------|-------------------|
| 1 | `text input field edit persists` | API Request `url_input` | filled URL persists as `url_input.value` |
| 2 | `dropdown field edit persists` | API Request `method` | selecting `POST-1-option` persists `method.value === "POST"` |
| 3 | `textarea field edit persists` | API Request `curl_input` (cURL tab) | filled cURL text persists |
| 4 | `int field edit persists` | API Request `timeout` | `timeout.value === 77` |
| 5 | `tab field edit persists` | API Request `mode` | clicking `tab_1_curl` persists `mode.value === "cURL"` |
| 6 | `toggle field edit persists` | Save File `append_mode` | clicking `toggle_bool_append_mode` flips `append_mode.value` to `true` |

## 2. How the test was built
- Common harness: `createFlow` (blank, API) → open `/flow/<id>` → `addComponentFromSidebar` → edit field → `expect.poll` on `GET /api/v1/flows/{id}` until `template.<field>.value` reflects the edit (absorbs the debounced autosave).
- **Live-confirmed testids** (nightly 1.11.0.dev45): `popover-anchor-input-url_input`, `dropdown_str_method` + `POST-1-option`, `textarea_str_curl_input`, `int_int_timeout`, `tab_1_curl`, `toggle_bool_append_mode`.
- Verifying the persisted template value (not just the widget) proves the edit was accepted **and** saved.

## 3. Scope / phasing
- **Phase 2 (#795):** slider (drag), code (editor modal), table (modal), key-pair (`NestedDictInput`), input list (`SortableListInput`), float — each needs a distinct modal/drag mechanic. Split to keep phase 1 stable and mergeable.
- **Product-changed note:** the checklist-era `KeypairInput`/`ListInput` input types no longer exist; phase 2 maps them to `NestedDictInput`/`SortableListInput`.

## 4. Dependencies
- **none — pure UI/API** (no flow executed, no provider credentials).
- **Execution mode:** parallel-safe (unique flow name per test); each test deletes its flow id-scoped in `afterEach`.

## Validation (nightly 1.11.0.dev45, `--retries=0 --workers=1`)
- typecheck ✅ · eslint ✅ (0 errors) · QA-CHECKLIST guard ✅
- 3/3 clean burst — `expected=6 unexpected=0 flaky=0` each ✅ (22+ additional clean executions while chasing a one-off transient flake, which did not reproduce)
- force-fail ✅ — one mutation per test (`expected` value wrong), each observed red then reverted
- zero `🚨 Backend Error` ✅ · zero orphan flows ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)