### PR TITLE
test(core-components): add float + slider to Parameters Panel field-type matrix (#795)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -130,13 +130,13 @@
 - [x] Edit dropdown → `core-components/parameters-panel-field-types.spec.ts`
 - [x] Edit text area (textarea) → `core-components/parameters-panel-field-types.spec.ts`
 - [-] Edit code field
-- [-] Edit float field
+- [x] Edit float field → `core-components/parameters-panel-field-types.spec.ts`
 - [x] Edit int field → `core-components/parameters-panel-field-types.spec.ts`
 - [x] Edit toggle field → `core-components/parameters-panel-field-types.spec.ts`
 - [-] Edit key-pair list
 - [-] Edit input list
 - [-] Edit table input
-- [-] Edit slider
+- [x] Edit slider → `core-components/parameters-panel-field-types.spec.ts`
 - [x] Edit tab component → `core-components/parameters-panel-field-types.spec.ts`
 
 #### 2.2 Tool Mode

--- a/docs/core-components/parameters-panel-field-types.md
+++ b/docs/core-components/parameters-panel-field-types.md
@@ -45,18 +45,18 @@ matches what a reload would load.
 
 | # | Field type (checklist) | Input type | Component | Field | Edit mechanism | Phase |
 |---|---|---|---|---|---|---|
-| 1 | Edit text field (input) | `MessageTextInput` | API Request | `url_input` | fill `popover-anchor-input-url_input` | **this PR** |
-| 2 | Edit dropdown | `DropdownInput` | API Request | `method` | click `dropdown_str_method` → `POST-1-option` | **this PR** |
-| 3 | Edit text area (textarea) | `MultilineInput` | API Request | `curl_input` | fill `textarea_str_curl_input` (cURL tab) | **this PR** |
-| 4 | Edit int field | `IntInput` | API Request | `timeout` | fill `int_int_timeout` | **this PR** |
-| 5 | Edit tab component | `TabInput` | API Request | `mode` | click `tab_1_curl` | **this PR** |
-| 6 | Edit toggle field | `BoolInput` | Save File | `append_mode` | click `toggle_bool_append_mode` | **this PR** |
-| 7 | Edit slider | `SliderInput` | Language Model | `temperature` | drag `slider_thumb` | follow-up |
-| 8 | Edit code field | `CodeInput` | Python Function | `function_code` | code editor modal | follow-up |
-| 9 | Edit table input | `TableInput` | API Request | `headers` | table modal → cell | follow-up |
-| 10 | Edit key-pair list | `NestedDictInput` | Alter Metadata | `metadata` | key/value row | follow-up |
-| 11 | Edit input list | `SortableListInput` | Read File | `storage_location` | list item | follow-up |
-| 12 | Edit float field | `FloatInput` | Semantic Text Splitter | `breakpoint_threshold_amount` | numeric input | follow-up |
+| 1 | Edit text field (input) | `MessageTextInput` | API Request | `url_input` | fill `popover-anchor-input-url_input` | phase 1 ✓ |
+| 2 | Edit dropdown | `DropdownInput` | API Request | `method` | click `dropdown_str_method` → `POST-1-option` | phase 1 ✓ |
+| 3 | Edit text area (textarea) | `MultilineInput` | API Request | `curl_input` | fill `textarea_str_curl_input` (cURL tab) | phase 1 ✓ |
+| 4 | Edit int field | `IntInput` | API Request | `timeout` | fill `int_int_timeout` | phase 1 ✓ |
+| 5 | Edit tab component | `TabInput` | API Request | `mode` | click `tab_1_curl` | phase 1 ✓ |
+| 6 | Edit toggle field | `BoolInput` | Save File | `append_mode` | click `toggle_bool_append_mode` | phase 1 ✓ |
+| 7 | Edit slider | `SliderInput` | Language Model | `temperature` | click `slider_thumb` + `ArrowRight` | **phase 2 (this PR)** |
+| 8 | Edit code field | `CodeInput` | Python Function | `function_code` | ace code editor modal | deferred (frágil) |
+| 9 | Edit table input | `TableInput` | API Request | `headers` | table modal → cell | deferred |
+| 10 | Edit key-pair list | `NestedDictInput` | Alter Metadata | `metadata` | key/value row | deferred |
+| 11 | Edit input list | `SortableListInput` | Read File | `storage_location` | list item | deferred |
+| 12 | Edit float field | `FloatInput` | Semantic Text Splitter | `breakpoint_threshold_amount` | fill `float_float_breakpoint_threshold_amount` | **phase 2 (this PR)** |
 
 > The checklist's *key-pair list* and *input list* correspond to the checklist-era
 > `KeypairInput` / `ListInput`, which no longer exist in the current registry;

--- a/tests/tests-automations/regression/core-components/parameters-panel-field-types.spec.ts
+++ b/tests/tests-automations/regression/core-components/parameters-panel-field-types.spec.ts
@@ -209,4 +209,60 @@ test.describe("Parameters Panel — field-type edit matrix", () => {
       await expectPersisted(request, bearer, flowId, "append_mode", true);
     },
   );
+
+  // ---- Phase 2 (#795): float + slider ----
+
+  test(
+    "float field edit persists",
+    { tag: ["@stable", "@components", "@regression"] },
+    async ({ page, request }) => {
+      const bearer = await getAuthToken(request);
+      const flowId = await openFlowWithComponent(
+        page,
+        request,
+        bearer,
+        "Semantic Text Splitter",
+        "add-component-button-semantic-text-splitter",
+        "title-breakpoint threshold amount",
+      );
+      await page
+        .getByTestId("float_float_breakpoint_threshold_amount")
+        .fill("0.42");
+      await page.getByTestId("float_float_breakpoint_threshold_amount").blur();
+      await expectPersisted(
+        request,
+        bearer,
+        flowId,
+        "breakpoint_threshold_amount",
+        0.42,
+      );
+    },
+  );
+
+  test(
+    "slider field edit persists",
+    { tag: ["@stable", "@components", "@regression"] },
+    async ({ page, request }) => {
+      const bearer = await getAuthToken(request);
+      const flowId = await openFlowWithComponent(
+        page,
+        request,
+        bearer,
+        "Language Model",
+        "add-component-button-language-model",
+        "title-temperature",
+      );
+      // temperature defaults to 0.1; focus the thumb and step it up with the
+      // keyboard (deterministic, unlike a pixel drag). Assert it increased —
+      // step-agnostic so a future step change does not false-fail.
+      await page.getByTestId("slider_thumb").click();
+      for (let i = 0; i < 3; i++) await page.keyboard.press("ArrowRight");
+      await expect
+        .poll(
+          () => readFieldValue(request, bearer, flowId, "temperature"),
+          { timeout: 15000 },
+        )
+        .toBeGreaterThan(0.1);
+    },
+  );
 });


### PR DESCRIPTION
## What

Phase 2 of the §2.1 **Parameters Panel field-type edit matrix**. Extends the existing matrix spec (`parameters-panel-field-types.spec.ts`) with two more input types:

| # | Type | Input | Component | Field | Edit | Persisted assert |
|---|---|---|---|---|---|---|
| 7 | slider | `SliderInput` | Language Model | `temperature` | focus `slider_thumb` + 3× `ArrowRight` | `template.temperature.value > 0.1` (step-agnostic) |
| 12 | float | `FloatInput` | Semantic Text Splitter | `breakpoint_threshold_amount` | fill `0.42` | `template.breakpoint_threshold_amount.value == 0.42` |

Both follow the phase-1 verification model: edit on canvas → wait autosave → `GET /api/v1/flows/{id}` → assert `data.nodes[0].data.node.template.<field>.value` (reload-proof). id-scoped `afterEach` cleanup (one flow per test, deleted by id).

## Scope

Closes #795. The 4 **modal/complex** types stay deferred to **phase 3** (tracked in a follow-up issue): code (`CodeInput`, Ace modal), table (`TableInput`, table modal), key-pair (`NestedDictInput`), input list (`SortableListInput`) — each needs a distinct modal/drag mechanic and its own selector scout, kept out to keep this PR deterministic.

## Validation

- **Determinism (VALIDATE burst):** 3/3 runs at `--workers=1 --retries=0` → expected=8, unexpected=0, flaky=0.
- **Force-fail:** all 8 `test()` in the touched file force-failed (one mutation each, `// FF-MUTATION`), observed red, then reverted; final run green.
- **Cleanup:** 0 orphan flows (`GET /api/v1/flows/` verified before report).
- **Langflow:** `langflow-nightly 1.11.0.dev45`.

## Docs / checklist

- `docs/core-components/parameters-panel-field-types.md` — matrix phasing updated (rows 7 & 12 → phase 2).
- `QA-CHECKLIST.md` §2.1 — float + slider bullets → `[x]` (manual bullets only; generated blocks untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)