### PR TITLE
test(core-components): add Parameters Panel field-type matrix — phase 3 (modal/complex types) (#798)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -129,13 +129,13 @@
 - [x] Edit text field (input) → `core-components/parameters-panel-field-types.spec.ts`
 - [x] Edit dropdown → `core-components/parameters-panel-field-types.spec.ts`
 - [x] Edit text area (textarea) → `core-components/parameters-panel-field-types.spec.ts`
-- [-] Edit code field
+- [x] Edit code field → `core-components/parameters-panel-field-types.spec.ts`
 - [x] Edit float field → `core-components/parameters-panel-field-types.spec.ts`
 - [x] Edit int field → `core-components/parameters-panel-field-types.spec.ts`
 - [x] Edit toggle field → `core-components/parameters-panel-field-types.spec.ts`
-- [-] Edit key-pair list
-- [-] Edit input list
-- [-] Edit table input
+- [x] Edit key-pair list → `core-components/parameters-panel-field-types.spec.ts`
+- [x] Edit input list → `core-components/parameters-panel-field-types.spec.ts`
+- [x] Edit table input → `core-components/parameters-panel-field-types.spec.ts`
 - [x] Edit slider → `core-components/parameters-panel-field-types.spec.ts`
 - [x] Edit tab component → `core-components/parameters-panel-field-types.spec.ts`
 

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -134,7 +134,7 @@
 - [x] Edit int field → `core-components/parameters-panel-field-types.spec.ts`
 - [x] Edit toggle field → `core-components/parameters-panel-field-types.spec.ts`
 - [x] Edit key-pair list → `core-components/parameters-panel-field-types.spec.ts`
-- [x] Edit input list → `core-components/parameters-panel-field-types.spec.ts`
+- [-] Edit input list
 - [x] Edit table input → `core-components/parameters-panel-field-types.spec.ts`
 - [x] Edit slider → `core-components/parameters-panel-field-types.spec.ts`
 - [x] Edit tab component → `core-components/parameters-panel-field-types.spec.ts`

--- a/docs/core-components/parameters-panel-field-types.md
+++ b/docs/core-components/parameters-panel-field-types.md
@@ -63,9 +63,9 @@ matches what a reload would load.
 | 6 | Edit toggle field | `BoolInput` | Save File | `append_mode` | click `toggle_bool_append_mode` | phase 1 ✓ |
 | 7 | Edit slider | `SliderInput` | Language Model | `temperature` | click `slider_thumb` + `ArrowRight` | **phase 2 (this PR)** |
 | 8 | Edit code field | `CodeInput` | Python Function *(legacy)* | `function_code` | open `codearea_code_function_code` → set ACE value → `checkAndSaveBtn` | **phase 3 (this PR)** |
-| 9 | Edit table input | `TableInput` | API Request | `headers` | reveal via `inspector-add-headers` → settle (method→POST refresh) → Open table → `add-row-button` → fill key/value cells | **phase 3 (this PR)** |
+| 9 | Edit table input | `TableInput` | API Request | `headers` *(advanced)* | show-or-reveal `div-table_headers` → settle (method→POST refresh) → Open table → `add-row-button` → fill key/value cells | **phase 3 (this PR)** |
 | 10 | Edit key-pair list | `NestedDictInput` | Alter Metadata *(legacy)* | `metadata` | `dict_nesteddict_metadata` → Edit Dictionary (text mode) → fill JSON → Save | **phase 3 (this PR)** |
-| 11 | Edit input list | `SortableListInput` | Read File | `storage_location` *(advanced)* | reveal via `inspector-add-storage_location` → remove Local → `button_open_list_selection_…` → `list_item_aws` | **phase 3 (this PR)** |
+| 11 | Edit input list | `SortableListInput` | Read File | `storage_location` *(advanced)* | show-or-reveal the field → remove Local → `button_open_list_selection_…` → `list_item_aws` | **phase 3 (this PR)** |
 | 12 | Edit float field | `FloatInput` | Semantic Text Splitter | `breakpoint_threshold_amount` | fill `float_float_breakpoint_threshold_amount` | **phase 2 (this PR)** |
 
 > The checklist's *key-pair list* and *input list* correspond to the checklist-era

--- a/docs/core-components/parameters-panel-field-types.md
+++ b/docs/core-components/parameters-panel-field-types.md
@@ -17,24 +17,26 @@ A **parametrized matrix** — one `test()` per field type — sharing a common
 setup/verify shape, so a regression in any single input type is isolated to its
 own test.
 
-> **Phased delivery (complete).** The matrix is delivered in three phases, all
-> sharing the same setup/verify shape:
+> **Phased delivery.** The matrix is delivered in phases, all sharing the same
+> setup/verify shape:
 > - **Phase 1 (#662):** the 6 simple-mechanic types (text, dropdown, textarea,
 >   int, tab, toggle) — plain click/fill edits, scalar/string persisted values.
 > - **Phase 2 (#795):** float and slider — a numeric fill and a keyboard-stepped
 >   slider.
-> - **Phase 3 (#798, this PR):** the 4 modal/complex types (code editor, table
->   modal, key-pair NestedDict, input-list SortableList). Each needs its own
->   modal/reveal mechanic, and two (`KeypairInput`/`ListInput` from the checklist
->   era) no longer exist as those input types — they map to today's
->   `NestedDictInput` / `SortableListInput`.
+> - **Phase 3 (#798, this PR):** 3 modal/complex types — code editor, table
+>   modal, key-pair NestedDict. (`KeypairInput` from the checklist era no longer
+>   exists as that input type — it maps to today's `NestedDictInput`.)
 >
-> With phase 3 the matrix covers all **12 live input types**. Two phase-3
-> components (**Python Function**, **Alter Metadata**) are `legacy` and hidden
-> from the sidebar by default, and **Read File**'s `storage_location` is an
-> `advanced` field — the tests enable legacy and reveal the advanced field
-> explicitly (see the matrix and External dependencies). The matrix below marks
-> each type's phase.
+> With phase 3 the matrix covers **11 of the 12 live input types**. The 12th —
+> **input list** (`SortableListInput`, Read File `storage_location`) — is
+> deferred to a follow-up: its remove-chip → open-selection → pick mechanic
+> renders differently across nightly builds (the remove control is `icon-x` on
+> some, absent on others) and could not be validated on the build the daily runs.
+> Two phase-3 components (**Python Function**, **Alter Metadata**) are `legacy`
+> and hidden from the sidebar by default, and API Request's `headers` is an
+> `advanced` field — the tests enable legacy and show-or-reveal the advanced
+> field (see the matrix and External dependencies). The matrix below marks each
+> type's phase.
 
 ### Verification model (uniform across types)
 
@@ -65,7 +67,7 @@ matches what a reload would load.
 | 8 | Edit code field | `CodeInput` | Python Function *(legacy)* | `function_code` | open `codearea_code_function_code` → set ACE value → `checkAndSaveBtn` | **phase 3 (this PR)** |
 | 9 | Edit table input | `TableInput` | API Request | `headers` *(advanced)* | show-or-reveal `div-table_headers` → settle (method→POST refresh) → Open table → `add-row-button` → fill key/value cells | **phase 3 (this PR)** |
 | 10 | Edit key-pair list | `NestedDictInput` | Alter Metadata *(legacy)* | `metadata` | `dict_nesteddict_metadata` → Edit Dictionary (text mode) → fill JSON → Save | **phase 3 (this PR)** |
-| 11 | Edit input list | `SortableListInput` | Read File | `storage_location` *(advanced)* | show-or-reveal the field → remove Local → `button_open_list_selection_…` → `list_item_aws` | **phase 3 (this PR)** |
+| 11 | Edit input list | `SortableListInput` | Read File | `storage_location` *(advanced)* | show-or-reveal the field → remove Local → `button_open_list_selection_…` → `list_item_aws` | deferred (build-divergent) |
 | 12 | Edit float field | `FloatInput` | Semantic Text Splitter | `breakpoint_threshold_amount` | fill `float_float_breakpoint_threshold_amount` | **phase 2 (this PR)** |
 
 > The checklist's *key-pair list* and *input list* correspond to the checklist-era

--- a/docs/core-components/parameters-panel-field-types.md
+++ b/docs/core-components/parameters-panel-field-types.md
@@ -17,13 +17,23 @@ A **parametrized matrix** — one `test()` per field type — sharing a common
 setup/verify shape, so a regression in any single input type is isolated to its
 own test.
 
-> **Phased delivery.** This spec ships the **6 simple-mechanic types** first
-> (text, int, dropdown, tab, textarea, toggle) — all with a plain click/fill edit
-> and a scalar/string persisted value. The **6 complex/modal types** (slider drag,
-> code editor, table modal, key-pair NestedDict, input-list SortableList, float)
-> are deferred to a follow-up because each needs a distinct modal/drag mechanic
-> and two (`KeypairInput`/`ListInput` from the checklist era) no longer exist as
-> those input types — mapping them is tracked separately. The matrix below marks
+> **Phased delivery (complete).** The matrix is delivered in three phases, all
+> sharing the same setup/verify shape:
+> - **Phase 1 (#662):** the 6 simple-mechanic types (text, dropdown, textarea,
+>   int, tab, toggle) — plain click/fill edits, scalar/string persisted values.
+> - **Phase 2 (#795):** float and slider — a numeric fill and a keyboard-stepped
+>   slider.
+> - **Phase 3 (#798, this PR):** the 4 modal/complex types (code editor, table
+>   modal, key-pair NestedDict, input-list SortableList). Each needs its own
+>   modal/reveal mechanic, and two (`KeypairInput`/`ListInput` from the checklist
+>   era) no longer exist as those input types — they map to today's
+>   `NestedDictInput` / `SortableListInput`.
+>
+> With phase 3 the matrix covers all **12 live input types**. Two phase-3
+> components (**Python Function**, **Alter Metadata**) are `legacy` and hidden
+> from the sidebar by default, and **Read File**'s `storage_location` is an
+> `advanced` field — the tests enable legacy and reveal the advanced field
+> explicitly (see the matrix and External dependencies). The matrix below marks
 > each type's phase.
 
 ### Verification model (uniform across types)
@@ -52,10 +62,10 @@ matches what a reload would load.
 | 5 | Edit tab component | `TabInput` | API Request | `mode` | click `tab_1_curl` | phase 1 ✓ |
 | 6 | Edit toggle field | `BoolInput` | Save File | `append_mode` | click `toggle_bool_append_mode` | phase 1 ✓ |
 | 7 | Edit slider | `SliderInput` | Language Model | `temperature` | click `slider_thumb` + `ArrowRight` | **phase 2 (this PR)** |
-| 8 | Edit code field | `CodeInput` | Python Function | `function_code` | ace code editor modal | deferred (frágil) |
-| 9 | Edit table input | `TableInput` | API Request | `headers` | table modal → cell | deferred |
-| 10 | Edit key-pair list | `NestedDictInput` | Alter Metadata | `metadata` | key/value row | deferred |
-| 11 | Edit input list | `SortableListInput` | Read File | `storage_location` | list item | deferred |
+| 8 | Edit code field | `CodeInput` | Python Function *(legacy)* | `function_code` | open `codearea_code_function_code` → set ACE value → `checkAndSaveBtn` | **phase 3 (this PR)** |
+| 9 | Edit table input | `TableInput` | API Request | `headers` | reveal via `inspector-add-headers` → settle (method→POST refresh) → Open table → `add-row-button` → fill key/value cells | **phase 3 (this PR)** |
+| 10 | Edit key-pair list | `NestedDictInput` | Alter Metadata *(legacy)* | `metadata` | `dict_nesteddict_metadata` → Edit Dictionary (text mode) → fill JSON → Save | **phase 3 (this PR)** |
+| 11 | Edit input list | `SortableListInput` | Read File | `storage_location` *(advanced)* | reveal via `inspector-add-storage_location` → remove Local → `button_open_list_selection_…` → `list_item_aws` | **phase 3 (this PR)** |
 | 12 | Edit float field | `FloatInput` | Semantic Text Splitter | `breakpoint_threshold_amount` | fill `float_float_breakpoint_threshold_amount` | **phase 2 (this PR)** |
 
 > The checklist's *key-pair list* and *input list* correspond to the checklist-era
@@ -91,24 +101,33 @@ the panel's handling of that specific field type.
 - dropdown / tab: the selected string in `value`.
 - toggle: boolean `value` flipped from its default.
 - slider: numeric `value` within the field's range.
-- table: `value` is an array of row objects; the edited cell is asserted.
-- key-pair (NestedDict): `value` is an object; the edited key→value asserted.
-- input list (SortableList): `value` is a list; the edited item asserted.
+- code (`function_code`): scalar string `value` — the saved Python source, asserted to contain a unique sentinel. Save runs a Python syntax check, so the edited code must be valid.
+- table (`headers`): `value` is an array of `{key, value}` row objects; the edited row is found and asserted.
+- key-pair (NestedDict `metadata`): `value` is an object; the edited `{key: value}` pair is asserted.
+- input list (SortableList `storage_location`): `value` is a list of `{name, icon, …}` objects (`limit=1`); after switching from the default `Local` to `AWS`, `value[0].name === "AWS"` is asserted (the react-sortablejs `chosen`/`selected` keys are ignored).
 
 ---
 
 ## External dependencies
 
-- `tests/helpers/flows/create-flow.ts`, `delete-flow.ts`, `auth/get-auth-token.ts`.
-- Representative components (all core, non-bundle): API Request, Python Function,
-  Semantic Text Splitter, Alter Metadata, Read File, Language Model.
+- `tests/helpers/flows/create-flow.ts`, `delete-flow.ts`, `auth/get-auth-token.ts`,
+  `add-component-from-sidebar.ts`.
+- `tests/helpers/flows/add-legacy-components.ts` — phase 3's code and key-pair
+  tests add `legacy` components (Python Function, Alter Metadata), hidden from the
+  sidebar unless the **Legacy** feature toggle is on; this helper flips it.
+- Representative components (all core, non-bundle): API Request, Python Function
+  *(legacy)*, Semantic Text Splitter, Alter Metadata *(legacy)*, Read File,
+  Language Model.
 - **No model-provider credentials required** — no flow is executed; edits are
   read back via the flows API.
 
-Field testids confirmed live on `langflow-nightly 1.11.0.dev45` during authoring
+Field testids confirmed live on `langflow 1.11.0` during authoring — phase 1/2
 (`popover-anchor-input-url_input`, `dropdown_str_method`, `int_int_timeout`,
-`title-mode` + `tab_0_url`/`tab_1_curl`, `div-table_headers` + `icon-Table`, …);
-the remaining per-type testids are harvested in the PLAN/IMPLEMENT scout.
+`tab_1_curl`, `float_float_breakpoint_threshold_amount`, `slider_thumb`) and
+phase 3 (`codearea_code_function_code` + `checkAndSaveBtn`, `div-table_headers` +
+`add-row-button`, `dict_nesteddict_metadata`, `inspector-add-storage_location` +
+`button_open_list_selection_sortablelist_sortablelist_storage_location` +
+`list_item_aws`).
 
 ---
 
@@ -124,8 +143,12 @@ the remaining per-type testids are harvested in the PLAN/IMPLEMENT scout.
 - Field **validation** (rejecting out-of-range/invalid input) — this matrix
   asserts accepted edits persist, not the rejection path.
 - Executing the components — persistence is asserted via the flows API, not a run.
-- Advanced-field visibility toggling and connection handles — covered elsewhere
-  (§2.1 "open advanced", handle specs).
+- Advanced-field visibility toggling and connection handles as behaviors —
+  covered elsewhere (§2.1 "open advanced", handle specs). Phase 3's input-list
+  test reveals `storage_location` only as a setup step to reach the field; it
+  asserts the edited value, not the visibility toggle itself.
+- The Python syntax validation on code save — the code test uses valid code so
+  the save succeeds; the rejection path is not asserted here.
 
 ---
 

--- a/tests/tests-automations/regression/core-components/parameters-panel-field-types.spec.ts
+++ b/tests/tests-automations/regression/core-components/parameters-panel-field-types.spec.ts
@@ -257,8 +257,11 @@ test.describe("Parameters Panel — field-type edit matrix", () => {
         bearer,
         "API Request",
         "add-component-button-api-request",
-        "title-timeout",
+        "title-API Request",
       );
+      // `timeout` is advanced — shown by default on some nightly builds, hidden
+      // on others; reveal it when hidden.
+      await ensureAdvancedFieldVisible(page, "int_int_timeout", "timeout");
       await page.getByTestId("int_int_timeout").fill("77");
       await page.getByTestId("int_int_timeout").blur();
       await expectPersisted(request, bearer, flowId, "timeout", 77);
@@ -343,11 +346,13 @@ test.describe("Parameters Panel — field-type edit matrix", () => {
         bearer,
         "Language Model",
         "add-component-button-language-model",
-        "title-temperature",
+        "title-Language Model",
       );
-      // temperature defaults to 0.1; focus the thumb and step it up with the
-      // keyboard (deterministic, unlike a pixel drag). Assert it increased —
-      // step-agnostic so a future step change does not false-fail.
+      // temperature is advanced — shown by default on some nightly builds, hidden
+      // on others; reveal it when hidden. It defaults to 0.1; focus the thumb and
+      // step it up with the keyboard (deterministic, unlike a pixel drag). Assert
+      // it increased — step-agnostic so a future step change does not false-fail.
+      await ensureAdvancedFieldVisible(page, "slider_thumb", "temperature");
       await page.getByTestId("slider_thumb").click();
       for (let i = 0; i < 3; i++) await page.keyboard.press("ArrowRight");
       await expect

--- a/tests/tests-automations/regression/core-components/parameters-panel-field-types.spec.ts
+++ b/tests/tests-automations/regression/core-components/parameters-panel-field-types.spec.ts
@@ -520,56 +520,9 @@ test.describe("Parameters Panel — field-type edit matrix", () => {
     },
   );
 
-  test(
-    "input list field edit persists",
-    { tag: ["@stable", "@components", "@regression"] },
-    async ({ page, request }) => {
-      const bearer = await getAuthToken(request);
-      const flowId = await openFlowWithComponent(
-        page,
-        request,
-        bearer,
-        "Read File",
-        "add-component-button-read-file",
-        "title-Read File",
-      );
-      // storage_location is an advanced SortableList (limit 1, default "Local").
-      // Ensure the field is shown (reveal it if this build hides advanced
-      // fields). With one item selected the open-selection button is hidden —
-      // remove the pre-selected "Local" chip (its x button has no dedicated
-      // testid; scope it to the node) to reveal the selection dialog, then AWS.
-      await ensureAdvancedFieldVisible(
-        page,
-        "title-storage location",
-        "storage_location",
-      );
-      const node = page.locator('[data-testid^="rf__node-File"]');
-      await node.getByTestId("icon-x").click();
-      await page
-        .getByTestId(
-          "button_open_list_selection_sortablelist_sortablelist_storage_location",
-        )
-        .click();
-      await page.getByTestId("list_item_aws").click();
-
-      // storage_location.value is a list of {name,icon,…}; assert the selection
-      // (react-sortablejs adds chosen/selected keys, so match on name only).
-      await expect
-        .poll(
-          async () => {
-            const v = await readFieldValue(
-              request,
-              bearer,
-              flowId,
-              "storage_location",
-            );
-            return Array.isArray(v)
-              ? (v as Array<{ name?: string }>)[0]?.name
-              : undefined;
-          },
-          { timeout: 15000 },
-        )
-        .toBe("AWS");
-    },
-  );
+  // Input list (`SortableListInput` — Read File `storage_location`) is deferred:
+  // its edit mechanic (remove the pre-selected chip → open selection → pick a new
+  // option) diverges across nightly builds — the remove control renders as
+  // `icon-x` on some and is absent on others — and could not be validated on the
+  // build the daily currently runs. Tracked as a follow-up.
 });

--- a/tests/tests-automations/regression/core-components/parameters-panel-field-types.spec.ts
+++ b/tests/tests-automations/regression/core-components/parameters-panel-field-types.spec.ts
@@ -1,19 +1,23 @@
-import type { APIRequestContext, Page } from "@playwright/test";
+import type { APIRequestContext, Locator, Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { createFlow } from "../../../helpers/flows/create-flow";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
 import { addComponentFromSidebar } from "../../../helpers/flows/add-component-from-sidebar";
+import { addLegacyComponents } from "../../../helpers/flows/add-legacy-components";
 
 // §2.1 Parameters Panel — field-type edit matrix. For each input type, a
 // representative component is added, the field is edited in the panel, and the
 // new value is proven to PERSIST by reading it back from the saved flow via the
 // REST API (template.<field>.value) — reload-proof, uniform across types.
 //
-// Phase 1 (this spec): the six simple-mechanic types (text, dropdown, textarea,
-// int, tab, toggle). The complex/modal types (slider drag, code editor, table
-// modal, key-pair NestedDict, input-list SortableList, float) are a tracked
-// follow-up — see docs/core-components/parameters-panel-field-types.md.
+// Phase 1 (#662): six simple-mechanic types (text, dropdown, textarea, int, tab,
+// toggle). Phase 2 (#795): float + slider. Phase 3 (#798, below): the four
+// modal/complex types — code (ACE editor), table (modal), key-pair (NestedDict
+// editor) and input list (SortableList). Two phase-3 components (Python Function,
+// Alter Metadata) are `legacy` and need the sidebar Legacy toggle enabled; Read
+// File's `storage_location` is an `advanced` field revealed via the parameters
+// panel. See docs/core-components/parameters-panel-field-types.md.
 
 // Ids of flows created by each test — deleted id-scoped in afterEach (repo
 // convention #490/#681).
@@ -36,6 +40,7 @@ async function openFlowWithComponent(
   searchTerm: string,
   addButtonTestId: string,
   titleTestId: string,
+  opts: { enableLegacy?: boolean } = {},
 ): Promise<string> {
   const flowId = await createFlow(
     request,
@@ -53,9 +58,71 @@ async function openFlowWithComponent(
   await page
     .getByTestId("sidebar-search-input")
     .waitFor({ state: "visible", timeout: 60000 });
+  // Legacy components (Python Function, Alter Metadata) are hidden from the
+  // sidebar until the Legacy toggle is on — flip it before searching.
+  if (opts.enableLegacy) await addLegacyComponents(page);
   await addComponentFromSidebar(page, searchTerm, addButtonTestId);
   await expect(page.getByTestId(titleTestId)).toBeVisible({ timeout: 15000 });
   return flowId;
+}
+
+// Locate a modal (Radix Dialog) by its heading — several dialogs render
+// role="dialog" into body-level portals, so scope by the DialogTitle to pin the
+// identity. Mirrors the tableDialog helper in api-request-component-regression.
+function dialogByHeading(page: Page, title: string): Locator {
+  return page
+    .locator('[role="dialog"]')
+    .filter({ has: page.getByRole("heading", { name: title, exact: true }) });
+}
+
+// Fill an ag-grid table cell via the "View Text" editor, then assert the value
+// renders back in that same cell. Coordinate-clicking the cell is required —
+// the grid cell is not a plain input. Mirrors api-request-component-regression.
+async function fillTableTextCell(
+  page: Page,
+  cellLocator: Locator,
+  value: string,
+): Promise<void> {
+  await expect(async () => {
+    if (!(await page.getByTestId("textarea").isVisible())) {
+      let coords: { x: number; y: number } | null = null;
+      try {
+        coords = await cellLocator.evaluate((el: Element) => {
+          const rect = el.getBoundingClientRect();
+          return rect.width
+            ? { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 }
+            : null;
+        });
+      } catch {
+        coords = null;
+      }
+      if (!coords) throw new Error("Cell not found or not rendered");
+      await page.mouse.click(coords.x, coords.y);
+      await expect(page.getByTestId("textarea")).toBeAttached({ timeout: 2000 });
+    }
+    await page.getByTestId("textarea").fill(value, { timeout: 2000 });
+    const saveCoords = await page.evaluate(() => {
+      const dialogs = Array.from(document.querySelectorAll('[role="dialog"]'));
+      const vt = dialogs.find((d) =>
+        d.querySelector('[data-testid="textarea"]'),
+      );
+      if (!vt) return null;
+      const btn = Array.from(vt.querySelectorAll("button")).find((b) =>
+        b.textContent?.includes("Save"),
+      );
+      if (!btn) return null;
+      const rect = (btn as HTMLElement).getBoundingClientRect();
+      return rect.width
+        ? { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 }
+        : null;
+    });
+    if (!saveCoords) throw new Error("Save button not found in View Text dialog");
+    await page.mouse.click(saveCoords.x, saveCoords.y);
+    await expect(page.getByTestId("textarea")).toHaveCount(0, { timeout: 3000 });
+    await expect(
+      cellLocator.getByRole("button", { name: value, exact: true }),
+    ).toBeVisible({ timeout: 5000 });
+  }).toPass({ timeout: 40000 });
 }
 
 // Read a field's persisted value from the saved flow (single-node flows, so
@@ -263,6 +330,221 @@ test.describe("Parameters Panel — field-type edit matrix", () => {
           { timeout: 15000 },
         )
         .toBeGreaterThan(0.1);
+    },
+  );
+
+  // ---- Phase 3 (#798): code, table, key-pair, input list ----
+
+  test(
+    "code field edit persists",
+    { tag: ["@stable", "@components", "@regression"] },
+    async ({ page, request }) => {
+      const bearer = await getAuthToken(request);
+      const flowId = await openFlowWithComponent(
+        page,
+        request,
+        bearer,
+        "Python Function",
+        "add-component-button-python-function",
+        "title-Python Function",
+        { enableLegacy: true },
+      );
+      // CodeInput opens an ACE editor modal; fill() does not reach ACE, so set
+      // the value through ACE's API, then Save (which runs a Python syntax
+      // check — the code must be valid).
+      const code =
+        'def python_function() -> str:\n    return "E2E_CODE_SENTINEL"\n';
+      await page.getByTestId("codearea_code_function_code").click();
+      await expect(page.getByTestId("checkAndSaveBtn")).toBeVisible({
+        timeout: 15000,
+      });
+      await page
+        .locator(".ace_editor")
+        .waitFor({ state: "visible", timeout: 10000 });
+      await page.evaluate((value) => {
+        const w = window as unknown as {
+          ace: {
+            edit: (el: Element | null) => {
+              setValue: (v: string, cursor: number) => void;
+            };
+          };
+        };
+        w.ace.edit(document.querySelector(".ace_editor")).setValue(value, -1);
+      }, code);
+      await page.getByTestId("checkAndSaveBtn").click();
+      await expectPersisted(request, bearer, flowId, "function_code", code);
+    },
+  );
+
+  test(
+    "table field edit persists",
+    { tag: ["@stable", "@components", "@regression"] },
+    async ({ page, request }) => {
+      const bearer = await getAuthToken(request);
+      const flowId = await openFlowWithComponent(
+        page,
+        request,
+        bearer,
+        "API Request",
+        "add-component-button-api-request",
+        "title-API Request",
+      );
+      // `headers` is an advanced TableInput — reveal it on the node via the
+      // component-parameters panel.
+      await page.getByTestId("parameters-button").click();
+      await page.getByTestId("inspector-add-headers").click();
+      await page.getByTestId("parameters-button").click(); // close the panel
+
+      // Settle the node's TableNodeComponent `[value]` effects before touching
+      // the grid: switch method to POST and wait for the component-refresh POST.
+      // Without this, the grid drops the add-row click / fails to commit cells
+      // (mirrors the settle in api-request-component-regression).
+      await page.getByTestId("dropdown_str_method").click();
+      const refresh = page.waitForResponse(
+        (r) =>
+          r.url().includes("/api/v1/custom_component/update") &&
+          r.request().method() === "POST",
+        { timeout: 15000 },
+      );
+      await page.getByTestId("POST-1-option").click();
+      await refresh;
+
+      const headersDiv = page.getByTestId("div-table_headers");
+      await expect(headersDiv).toBeVisible({ timeout: 15000 });
+      await headersDiv.getByRole("button", { name: "Open table" }).click();
+
+      const dialog = dialogByHeading(page, "Headers");
+      await expect(dialog).toBeVisible({ timeout: 10000 });
+      const dataRows = dialog.locator('[role="treegrid"] [role="row"][row-id]');
+      await expect(dataRows).toHaveCount(1, { timeout: 10000 });
+      await dialog.getByTestId("add-row-button").click();
+      await expect(dataRows).toHaveCount(2, { timeout: 5000 });
+
+      const newRow = dataRows.last();
+      await fillTableTextCell(
+        page,
+        newRow.locator('[col-id="key"]'),
+        "X-E2E-Header",
+      );
+      await fillTableTextCell(
+        page,
+        newRow.locator('[col-id="value"]'),
+        "e2e-header-value",
+      );
+      // Save (not Cancel) commits the edited rows so autosave persists them.
+      await dialog.getByRole("button", { name: "Save", exact: true }).click();
+      await expect(dialog).not.toBeVisible({ timeout: 5000 });
+
+      // headers.value is an array of {key,value} rows — assert the new row landed.
+      await expect
+        .poll(
+          async () => {
+            const v = await readFieldValue(request, bearer, flowId, "headers");
+            return (
+              Array.isArray(v) &&
+              (v as Array<{ key?: string; value?: string }>).some(
+                (h) =>
+                  h.key === "X-E2E-Header" && h.value === "e2e-header-value",
+              )
+            );
+          },
+          { timeout: 15000 },
+        )
+        .toBe(true);
+    },
+  );
+
+  test(
+    "key-pair field edit persists",
+    { tag: ["@stable", "@components", "@regression"] },
+    async ({ page, request }) => {
+      const bearer = await getAuthToken(request);
+      const flowId = await openFlowWithComponent(
+        page,
+        request,
+        bearer,
+        "Alter Metadata",
+        "add-component-button-alter-metadata",
+        "title-Alter Metadata",
+        { enableLegacy: true },
+      );
+      // NestedDictInput opens an "Edit Dictionary" editor; set the JSON in text
+      // mode (fill avoids the code editor's bracket auto-close) and Save.
+      await page
+        .locator('button[data-testid="dict_nesteddict_metadata"]')
+        .click();
+      const dictDialog = dialogByHeading(page, "Edit Dictionary");
+      await expect(dictDialog).toBeVisible({ timeout: 10000 });
+      // Fill the JSON in text mode, then switch to tree mode BEFORE saving —
+      // the mode switch parses and commits the text into the editor's model, so
+      // Save persists it (filling alone leaves the model on its "{}" default and
+      // Save writes an empty object).
+      const editor = dictDialog.getByRole("textbox");
+      await editor.fill('{"e2e_key": "E2E_META_SENTINEL"}');
+      await dictDialog
+        .locator('button[title^="Switch to tree mode"]')
+        .click();
+      await expect(dictDialog.getByText("e2e_key", { exact: true })).toBeVisible({
+        timeout: 5000,
+      });
+      await dictDialog.getByRole("button", { name: "Save", exact: true }).click();
+      await expect(dictDialog).not.toBeVisible({ timeout: 5000 });
+      // metadata.value is an object — assert the edited key→value pair.
+      await expectPersisted(request, bearer, flowId, "metadata", {
+        e2e_key: "E2E_META_SENTINEL",
+      });
+    },
+  );
+
+  test(
+    "input list field edit persists",
+    { tag: ["@stable", "@components", "@regression"] },
+    async ({ page, request }) => {
+      const bearer = await getAuthToken(request);
+      const flowId = await openFlowWithComponent(
+        page,
+        request,
+        bearer,
+        "Read File",
+        "add-component-button-read-file",
+        "title-Read File",
+      );
+      // storage_location is an advanced SortableList (limit 1, default "Local").
+      // Reveal it via the component-parameters panel.
+      await page.getByTestId("parameters-button").click();
+      await page.getByTestId("inspector-add-storage_location").click();
+      await page.getByTestId("parameters-button").click(); // close the panel
+
+      // With one item selected the open-selection button is hidden — remove the
+      // pre-selected "Local" chip (its x button has no dedicated testid; scope it
+      // to the node) to reveal the selection dialog, then pick AWS.
+      const node = page.locator('[data-testid^="rf__node-File"]');
+      await node.getByTestId("icon-x").click();
+      await page
+        .getByTestId(
+          "button_open_list_selection_sortablelist_sortablelist_storage_location",
+        )
+        .click();
+      await page.getByTestId("list_item_aws").click();
+
+      // storage_location.value is a list of {name,icon,…}; assert the selection
+      // (react-sortablejs adds chosen/selected keys, so match on name only).
+      await expect
+        .poll(
+          async () => {
+            const v = await readFieldValue(
+              request,
+              bearer,
+              flowId,
+              "storage_location",
+            );
+            return Array.isArray(v)
+              ? (v as Array<{ name?: string }>)[0]?.name
+              : undefined;
+          },
+          { timeout: 15000 },
+        )
+        .toBe("AWS");
     },
   );
 });

--- a/tests/tests-automations/regression/core-components/parameters-panel-field-types.spec.ts
+++ b/tests/tests-automations/regression/core-components/parameters-panel-field-types.spec.ts
@@ -15,9 +15,10 @@ import { addLegacyComponents } from "../../../helpers/flows/add-legacy-component
 // toggle). Phase 2 (#795): float + slider. Phase 3 (#798, below): the four
 // modal/complex types — code (ACE editor), table (modal), key-pair (NestedDict
 // editor) and input list (SortableList). Two phase-3 components (Python Function,
-// Alter Metadata) are `legacy` and need the sidebar Legacy toggle enabled; Read
-// File's `storage_location` is an `advanced` field revealed via the parameters
-// panel. See docs/core-components/parameters-panel-field-types.md.
+// Alter Metadata) are `legacy` and need the sidebar Legacy toggle enabled;
+// `headers` and `storage_location` are `advanced` fields — shown by default on
+// some nightly builds, hidden on others, so the tests reveal them when hidden
+// (ensureAdvancedFieldVisible). See docs/core-components/parameters-panel-field-types.md.
 
 // Ids of flows created by each test — deleted id-scoped in afterEach (repo
 // convention #490/#681).
@@ -123,6 +124,31 @@ async function fillTableTextCell(
       cellLocator.getByRole("button", { name: value, exact: true }),
     ).toBeVisible({ timeout: 5000 });
   }).toPass({ timeout: 40000 });
+}
+
+// Advanced fields render on the node by default on some nightly builds and are
+// hidden (opt-in via the component-parameters panel) on others — the nightly
+// flip-flops this. Make the field present regardless: use it directly when
+// already shown, otherwise reveal it via the panel's "Add <field>" control.
+async function ensureAdvancedFieldVisible(
+  page: Page,
+  checkTestId: string,
+  fieldName: string,
+): Promise<void> {
+  try {
+    await page
+      .getByTestId(checkTestId)
+      .waitFor({ state: "visible", timeout: 4000 });
+    return; // already shown on this build
+  } catch {
+    // hidden on this build — reveal it below
+  }
+  await page.getByTestId("parameters-button").click();
+  await page.getByTestId(`inspector-add-${fieldName}`).click();
+  await page.getByTestId("parameters-button").click(); // close the panel
+  await page
+    .getByTestId(checkTestId)
+    .waitFor({ state: "visible", timeout: 10000 });
 }
 
 // Read a field's persisted value from the saved flow (single-node flows, so
@@ -389,11 +415,9 @@ test.describe("Parameters Panel — field-type edit matrix", () => {
         "add-component-button-api-request",
         "title-API Request",
       );
-      // `headers` is an advanced TableInput — reveal it on the node via the
-      // component-parameters panel.
-      await page.getByTestId("parameters-button").click();
-      await page.getByTestId("inspector-add-headers").click();
-      await page.getByTestId("parameters-button").click(); // close the panel
+      // `headers` is an advanced TableInput — ensure it is shown (reveal it if
+      // this build hides advanced fields).
+      await ensureAdvancedFieldVisible(page, "div-table_headers", "headers");
 
       // Settle the node's TableNodeComponent `[value]` effects before touching
       // the grid: switch method to POST and wait for the component-refresh POST.
@@ -510,14 +534,15 @@ test.describe("Parameters Panel — field-type edit matrix", () => {
         "title-Read File",
       );
       // storage_location is an advanced SortableList (limit 1, default "Local").
-      // Reveal it via the component-parameters panel.
-      await page.getByTestId("parameters-button").click();
-      await page.getByTestId("inspector-add-storage_location").click();
-      await page.getByTestId("parameters-button").click(); // close the panel
-
-      // With one item selected the open-selection button is hidden — remove the
-      // pre-selected "Local" chip (its x button has no dedicated testid; scope it
-      // to the node) to reveal the selection dialog, then pick AWS.
+      // Ensure the field is shown (reveal it if this build hides advanced
+      // fields). With one item selected the open-selection button is hidden —
+      // remove the pre-selected "Local" chip (its x button has no dedicated
+      // testid; scope it to the node) to reveal the selection dialog, then AWS.
+      await ensureAdvancedFieldVisible(
+        page,
+        "title-storage location",
+        "storage_location",
+      );
       const node = page.locator('[data-testid^="rf__node-File"]');
       await node.getByTestId("icon-x").click();
       await page


### PR DESCRIPTION
Closes #798

## What & why

Phase 3 of the §2.1 **Parameters Panel field-type edit matrix**, extending
`parameters-panel-field-types.spec.ts`. Ships **3 of the 4** modal/complex input
types as `@stable`; the matrix now covers **11 of 12 live input types**.

| # | Type | Input | Component | Field | Edit mechanic |
|---|---|---|---|---|---|
| 8 | code | `CodeInput` | Python Function *(legacy)* | `function_code` | ACE editor modal → `window.ace…setValue` → `checkAndSaveBtn` |
| 9 | table | `TableInput` | API Request | `headers` *(advanced)* | show-or-reveal → settle (method→POST refresh) → Open table → add row → fill cells → Save |
| 10 | key-pair | `NestedDictInput` | Alter Metadata *(legacy)* | `metadata` | Edit Dictionary → fill JSON (text) → tree mode → Save |

**Input list (`SortableListInput`, row 11) is deferred → #806** — its remove-chip
mechanic renders differently across nightly builds and couldn't be validated on
the daily's build.

Each test edits the field on the canvas, waits for autosave, then reads
`GET /api/v1/flows/{id}` → `template.<field>.value` (reload-proof). id-scoped
`afterEach` cleanup; **0 orphan flows**.

## Also hardened (same file, same root cause)

The nightly **flip-flops advanced-field visibility** (`headers`, `timeout`,
`temperature`, … shown on some builds, hidden on others). This PR adds
`ensureAdvancedFieldVisible` (use the field directly when shown; reveal it via the
component-parameters panel when hidden) and applies it to the phase-3 `table` plus
the **phase-1 `int`** and **phase-2 `slider`** tests, which were red on the current
nightly (advanced fields hidden) at the field-render step. The whole spec is now
robust to the flip.

## Validation

- **Instance:** `langflowai/langflow-nightly:latest` (current build hides advanced fields), custom components enabled.
- **typecheck / lint:** ✅ clean (0 errors; only pre-existing `expect-expect` warnings)
- **run `--workers=1 --retries=0`:** ✅ whole file 11/11; phase-3 bursts clean; validated on both the shown- and hidden-advanced-field nightly states
- **force-fail:** ✅ code / table / key-pair / int / slider each mutated → FAIL → reverted (0 `FF-MUTATION` markers, final green)
- **`--trace=on`:** ✅ passed, trace generated, no hang
- **backend errors (`🚨`):** ✅ zero · **orphan flows:** ✅ zero
- **CI:** ✅ all PR checks green (TypeScript, ESLint, QA-CHECKLIST guard, Run impacted E2E specs)
