### PR TITLE
fix(triage): recurrence count/dates count only same-signature occurrences (closes #803)

### DIFF
--- a/.claude/skills/langflow-e2e-triage/SKILL.md
+++ b/.claude/skills/langflow-e2e-triage/SKILL.md
@@ -114,6 +114,16 @@ JSON: `run{run_id,run_url,date,langflow_image,duration_ms}`,
 `umbrella_issue`, `guard_tripped`, `totals`, `hard_failures[]`, `flakes[]`
 (each carrying `recurrence` and an `actionable` flag), `skips[]`.
 
+**Citing recurrence faithfully:** `recurrence.count` / `recurrence.dates`
+report only the **same-signature** (same-cause) occurrences — this is the
+recurrence to cite in the proposal ("recurrent 3× on 07-13/15/16"). The same
+test can also appear under its title for a *different* cause; those are
+excluded from `count`/`dates` and surfaced separately as
+`recurrence.total_count` / `total_dates` for context only. Never quote the raw
+`total_count` as the recurrence figure — it overstates same-cause recurrence
+(the report-faithfully gate). `actionable` is driven by `same_signature`
+(≥ 2 same-signature hits), unchanged.
+
 If a local Playwright report exists for that run (downloaded or already on
 disk), pass it for richer per-skip detail — the history file only carries
 skip totals, not the per-test reason:

--- a/.claude/skills/langflow-e2e-triage/scripts/lib/triage-core.mjs
+++ b/.claude/skills/langflow-e2e-triage/scripts/lib/triage-core.mjs
@@ -46,21 +46,37 @@ export function rowsWithinDays(rows, asOfDate, windowDays) {
   });
 }
 
-/** Occurrences of `item.test` across rowsInWindow (failures + flaky), with
- *  same-signature detection. rowsInWindow must already include the latest run. */
+/** Occurrences of `item.test` across rowsInWindow (failures + flaky).
+ *  rowsInWindow must already include the latest run.
+ *
+ *  Recurrence is about the *same cause*, so `count`/`dates` report only the
+ *  occurrences whose normalized error signature matches the item's — this is
+ *  what the proposal should cite. A test can recur under the same title for
+ *  different causes (different signatures); those inflate a raw title tally
+ *  without being same-cause recurrence, so they are excluded from count/dates
+ *  and surfaced separately as `total_count`/`total_dates` for context only.
+ *  `same_signature` (>= 2 same-signature hits) is unchanged and still drives
+ *  the actionable decision. */
 export function computeRecurrence(item, rowsInWindow) {
   const target = normalizeSignature(item.error_signature);
-  const dates = [];
-  let sameSig = 0;
+  const allDates = [];
+  const sameDates = [];
   for (const row of rowsInWindow) {
     const entries = [...(row.failures || []), ...(row.flaky || [])];
     const hit = entries.find((e) => e.test === item.test);
     if (!hit) continue;
-    dates.push(row.date);
-    if (normalizeSignature(hit.error_signature) === target) sameSig++;
+    allDates.push(row.date);
+    if (normalizeSignature(hit.error_signature) === target) sameDates.push(row.date);
   }
-  dates.sort();
-  return { count: dates.length, dates, same_signature: sameSig >= 2 };
+  allDates.sort();
+  sameDates.sort();
+  return {
+    count: sameDates.length,
+    dates: sameDates,
+    same_signature: sameDates.length >= 2,
+    total_count: allDates.length,
+    total_dates: allDates,
+  };
 }
 
 /** True when the run had more hard failures than the auto-remove guard allows. */

--- a/.claude/skills/langflow-e2e-triage/scripts/lib/triage-core.test.mjs
+++ b/.claude/skills/langflow-e2e-triage/scripts/lib/triage-core.test.mjs
@@ -71,6 +71,26 @@ test('computeRecurrence returns count 1 for a first-seen failure', () => {
   assert.equal(r.same_signature, false);
 });
 
+test('computeRecurrence count/dates cover only same-signature occurrences (mixed signatures)', () => {
+  // Same test title recurs 4x, but the first two flaked with an empty (different)
+  // signature and only the last two share today's signature. count/dates must
+  // report same-cause recurrence (2x), not the all-signature tally — that raw
+  // tally lives in total_count/total_dates for context. (Models the
+  // global-variables 4x->2x case from run #802 / issue #803.)
+  const rows = [
+    { date: '2026-07-02', flaky: [{ test: 'cred hidden', error_signature: '' }] },
+    { date: '2026-07-09', flaky: [{ test: 'cred hidden', error_signature: '' }] },
+    { date: '2026-07-15', failures: [{ test: 'cred hidden', error_signature: 'Error: toBe' }] },
+    { date: '2026-07-17', failures: [{ test: 'cred hidden', error_signature: 'Error: toBe' }] },
+  ];
+  const r = computeRecurrence({ test: 'cred hidden', error_signature: 'Error: toBe' }, rows);
+  assert.equal(r.count, 2);
+  assert.deepEqual(r.dates, ['2026-07-15', '2026-07-17']);
+  assert.equal(r.same_signature, true);
+  assert.equal(r.total_count, 4);
+  assert.deepEqual(r.total_dates, ['2026-07-02', '2026-07-09', '2026-07-15', '2026-07-17']);
+});
+
 test('detectGuard trips above the threshold', () => {
   assert.equal(detectGuard({ totals: { failed: 6 } }, 5), true);
   assert.equal(detectGuard({ totals: { failed: 5 } }, 5), false);


### PR DESCRIPTION
## What
`computeRecurrence` now reports `count`/`dates` over only the **same-signature** (same-cause) occurrences of a test, and moves the raw all-signature title tally to `total_count`/`total_dates` (context only).

Closes #803.

## Why
`count`/`dates` matched a test by **title** and counted **every** occurrence regardless of error signature — only the `same_signature` boolean checked the cause. The proposal cites those numbers, so same-cause recurrence was overstated. Found auditing run `29571647123` / umbrella #802 against ground truth: `global-variables` was cited as "recurrent **4x** (07-02/09/15/17)" but 07-02/09 flaked with an **empty (different)** signature — same-cause recurrence is **2x** (07-15/17). Same pattern inflated MCP (6x→~4x), bulk-actions (5x→3x), loop (5x→3x).

## How
- `count`/`dates` → same-signature occurrences only (what the proposal cites).
- `total_count`/`total_dates` → raw title tally, for context.
- `same_signature` (≥ 2) unchanged → **`actionable` decision is unaffected**; only the cited figure gets honest.
- `SKILL.md`: cite the same-signature figure; never quote `total_count` as the recurrence (report-faithfully gate).

## Tests
- New `node:test` case: a title recurring 4× with mixed signatures (2 same) asserts `count=2`, `dates=[same-sig]`, `total_count=4`.
- Full core suite green: **20/20** (`node --test .../triage-core.test.mjs`).

## Impact
No re-grouping, no phantom/missed issues — this only stops the proposal from overstating recurrence. The one borderline breakout it affects (global-variables "4x"→2x) now reads honestly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)