### PR TITLE
test(workspace): harden bulk-actions + auto-save-off against CI-load flakes (#790)

### DIFF
--- a/docs/core-functionality/project-management/bulk-actions.md
+++ b/docs/core-functionality/project-management/bulk-actions.md
@@ -75,6 +75,8 @@ This spec used to create its 3 flows through the UI (opening the templates modal
 
 Both modes lived entirely in the incidental UI scaffolding, never in the bulk-action assertions under test. #723 **eliminated the whole class** by creating the 3 flows via `POST /api/v1/flows/` and loading the listing with a single `page.goto("/")` — no templates modal, no editor↔home round-trips. The remaining positional risk (a sibling worker's flow interleaving at the top of the recency-sorted listing) is caught by the top-3 name guard before any destructive selection.
 
+**#790 (load-collateral, top-3 guard hardened).** On load-degraded / guard-tripped dailies (2026-07-09/13/15/16, all recurring on saturated days) the top-3 name guard failed with `expect(received).toEqual(expected) // deep equality`. Root cause is not a product regression — the spec passes 5/5 clean at `--retries=0` on the current nightly (`1.11.0.dev45`); under CI saturation the recency-sorted listing simply had not yet floated the 3 freshly-created flows to the top when the guard read the card names **once** (`evaluateAll` → `toEqual`). Hardened by wrapping that read in `expect.poll(...).toEqual(...)`, so the guard retries until the listing settles instead of asserting on the first (stale) snapshot. `@stable` kept.
+
 ---
 
 ## Preconditions *(optional)*

--- a/docs/flow-functionality/auto-save-off.md
+++ b/docs/flow-functionality/auto-save-off.md
@@ -116,6 +116,18 @@ fails if either save did not persist (see Notes on the hardening).
 
 ## Notes *(optional)*
 
+- **#790 (load-collateral, critical clicks hardened).** On load-degraded /
+  guard-tripped dailies (2026-07-15/16) the spec failed with
+  `locator.click: Timeout 20000ms exceeded` on a manual-save click target. Not a
+  product regression — the spec passes 5/5 clean at `--retries=0` on the current
+  nightly (`1.11.0.dev45`) and manual save resolves correctly with
+  `auto_saving=false`. This is the suite's heaviest workspace test (two full
+  bootstraps + repeated exit/re-open cycles, ~54s cold), so under CI saturation a
+  20s default action timeout (`playwright.config.ts` `actionTimeout`) is the first
+  thing to blow. Hardened by giving the load-sensitive clicks (the on-canvas
+  `save-flow-button` and the card `list-card-open-button` re-open) an explicit
+  longer timeout, so transient saturation no longer trips the default. `@stable`
+  kept.
 - **Hardening for promotion.** The pre-promotion spec left `New Flow` behind
   (no cleanup — confirmed 4 leaked flows on the instance) and used silent
   bypasses: a `try/catch` that logged "skipping dialog confirmation" and

--- a/tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts
@@ -55,12 +55,27 @@ test(
       // and bulk-delete is destructive, so if a sibling worker's flow interleaved
       // at the top of the recency-sorted listing under `fullyParallel`, fail fast
       // here rather than risk deleting someone else's flow.
-      const topThreeNames = await page
-        .locator("[data-testid='flow-name-div'] span")
-        .evaluateAll((els) =>
-          els.slice(0, 3).map((e) => e.textContent?.trim() ?? ""),
-        );
-      expect([...topThreeNames].sort()).toEqual([...createdNames].sort());
+      // Poll rather than read once: on load-degraded dailies the recency-sorted
+      // listing has not yet floated the 3 freshly-created flows to the top when a
+      // single snapshot is taken, so a one-shot `evaluateAll → toEqual` flaked
+      // with a deep-equality mismatch (#790). Polling retries until the listing
+      // settles; it still fails fast if a sibling worker's flow genuinely sits in
+      // the top 3.
+      await expect
+        .poll(
+          async () =>
+            (
+              await page
+                .locator("[data-testid='flow-name-div'] span")
+                .evaluateAll((els) =>
+                  els.slice(0, 3).map((e) => e.textContent?.trim() ?? ""),
+                )
+            )
+              .slice()
+              .sort(),
+          { timeout: 30000 },
+        )
+        .toEqual([...createdNames].sort());
 
       // Test shift selection
       await page.keyboard.down("Shift");

--- a/tests/tests-automations/regression/flow-functionality/auto-save-off.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/auto-save-off.spec.ts
@@ -42,6 +42,10 @@ test.afterEach(async ({ request }) => {
 // The /flows a11y refactor (Langflow #13891) makes `flow-name-div`
 // `pointer-events-none`; open the flow via the card's overlay button.
 async function reopenNewFlow(page: Page): Promise<void> {
+  // Explicit timeout above the 20s default actionTimeout: this heavy spec (two
+  // bootstraps + repeated exit/re-open cycles) blew the default card-open click
+  // under CI saturation on load-degraded dailies (#790). The extra headroom
+  // absorbs transient load without masking a real regression.
   await page
     .getByTestId("list-card")
     .filter({
@@ -49,7 +53,7 @@ async function reopenNewFlow(page: Page): Promise<void> {
     })
     .getByTestId("list-card-open-button")
     .first()
-    .click();
+    .click({ timeout: 45000 });
 }
 
 test(
@@ -201,7 +205,9 @@ test(
     // otherwise the unsaved-changes dialog appears and "Save And Exit" persists.
     // Either path is fine — the node count === 2 below is the gate that proves
     // both nodes persisted server-side, regardless of which path ran.
-    await page.getByTestId("save-flow-button").click();
+    // Explicit timeout above the 20s default: the manual-save click was the
+    // signature that blew the default action timeout under CI saturation (#790).
+    await page.getByTestId("save-flow-button").click({ timeout: 45000 });
     await page.getByTestId("icon-ChevronLeft").last().click();
     const saveAndExit2 = page.getByText("Save And Exit", { exact: true }).last();
     if (


### PR DESCRIPTION
## What

Harden two `@stable` workspace specs that recur as **flakes** on load-degraded / guard-tripped dailies (spun out of triage #788). No coverage change; `@stable` kept on both.

## Root cause

**Not a product regression.** Investigated product-first on the current nightly (`1.11.0.dev46`):

- `bulk-actions.spec.ts` — 5/5 clean at `--retries=0`; bulk selection yields the expected flow set.
- `auto-save-off.spec.ts` — 5/5 clean; manual save resolves correctly under `auto_saving=false`.

Neither reproduces in a clean, single-worker environment; both fail only on saturated (guard-tripped) days. Consistent with **transient CI-load collateral**, not durable per-test rot.

## Hardening

| Spec | Flake signature | Fix |
|---|---|---|
| `bulk-actions.spec.ts` | `expect(received).toEqual(expected) // deep equality` on the top-3 name guard | The guard read the card names **once** (`evaluateAll → toEqual`); under load the recency-sorted listing had not yet floated the 3 created flows to the top. Wrapped in `expect.poll(...).toEqual(...)` so it retries until the listing settles (still fails fast on a genuine sibling-flow intrusion). |
| `auto-save-off.spec.ts` | `locator.click: Timeout 20000ms exceeded` on a manual-save click | This heavy spec (two bootstraps + exit/reopen cycles, ~54s cold) blew the 20s default `actionTimeout` under saturation. Gave the `save-flow-button` and `list-card-open-button` clicks an explicit 45s timeout. |

## Validation

- **Nightly:** `1.11.0.dev46` (= latest).
- **Determinism:** burst 3/3 each → expected=1, unexpected=0, flaky=0; plus a confirmation run each on dev46.
- **Force-fail:** bulk-actions poll guard mutated to expect a nonexistent flow name; auto-save-off node-count gate mutated to 99 — both observed red, then reverted; final green.
- **Gates:** typecheck 0 errors, lint 0 errors; 0 orphan flows.

## `@stable` decision

**Kept** on both — the cluster did not reproduce in a clean environment, so removal (per the issue's prevention clause) does not apply; the hardening reduces the load-collateral flake surface.

## Docs

- `docs/core-functionality/project-management/bulk-actions.md` + `docs/flow-functionality/auto-save-off.md` — #790 flake note added.

Closes #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)