### PR TITLE
fix(flow-functionality): repair OpenAI handle-testid drift in generalBugs-shard-3 (#614)

### DIFF
--- a/docs/flow-functionality/generalBugs-shard-3.md
+++ b/docs/flow-functionality/generalBugs-shard-3.md
@@ -1,0 +1,100 @@
+# Spec: Copy code from the playground / API-access modal — generalBugs-shard-3
+
+**Test file:** `tests/tests-automations/regression/flow-functionality/generalBugs-shard-3.spec.ts`
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates
+
+A user can wire a minimal **Chat Input → OpenAI → Chat Output** flow on the
+canvas, open the **Playground**, send a message, and **copy the generated API
+code** (Python tab) from the API-access modal — the copied snippet is non-empty
+and embeds the sent message.
+
+Active test in this file: **"should copy code from playground modal"** (`@release`).
+The second test ("playground button should be enabled or disabled") is
+`test.skip` (pre-existing TODO — out of scope for this fix).
+
+> **Fix (#614).** The spec failed deterministically on the 1.11 nightly because
+> the OpenAI model node's handle testids drifted: the node type id changed from
+> `openaimodel` to **`openaimodelcomponent`**, so
+> `handle-openaimodel-shownode-input-left` / `-model response-right` never
+> appeared and the wiring click timed out. The Chat Input / Chat Output handles
+> are unchanged. Fix = update the two OpenAI handle testids; no behavior change.
+
+### Verification model
+
+1. Blank flow → drag Chat Output, Chat Input, and the OpenAI model node.
+2. Configure the OpenAI node (`initialGPTsetup`), fill the API key.
+3. Wire Chat Input → OpenAI → Chat Output via the node handles (current testids).
+4. Open the Playground, send a message, open the API-access Python tab, click
+   **Copy code**.
+5. Assert the clipboard content is non-empty and contains "Hello" (the sent
+   message text embedded in the generated snippet).
+
+---
+
+## Tags
+
+`@release`
+
+`@release` (happy-path flow-wiring + playground code-copy). Not `@stable` — it
+depends on a live OpenAI key (see External dependencies); kept as a `@release`
+happy-path check.
+
+---
+
+## Validation criterion
+
+After wiring the flow with the **current** handle testids
+(`handle-openaimodelcomponent-shownode-input-left`,
+`handle-openaimodelcomponent-shownode-model response-right`,
+`handle-chatinput-noshownode-chat message-source`,
+`handle-chatoutput-noshownode-inputs-target`), sending a playground message and
+opening the API-access Python tab, the **Copy code** button yields clipboard
+content with length > 0 that contains "Hello".
+
+The test fails if any handle cannot be clicked (wiring drift) or the code cannot
+be copied.
+
+---
+
+## External dependencies
+
+- **`OPENAI_API_KEY`** — required; the test `test.skip`s without it. The flow is
+  run in the Playground, so the key must be **active** (not quota-exhausted —
+  cf. #772). On a quota-blocked key the send may error and the code-copy step can
+  still not be reachable.
+- Helpers: `initialGPTsetup`, `clearApiKeyBadges`, `adjustScreenView`,
+  `awaitBootstrapTest`.
+- Core I/O components (Chat Input / Chat Output) + the OpenAI model bundle node.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` on a recent nightly (1.11.x).
+- Auth via `auto_login` (repo default).
+- Active `OPENAI_API_KEY` in `.env` / CI secrets.
+
+---
+
+## What this test does not cover
+
+- The **second** test in the file (playground-button enabled/disabled) — it is
+  `test.skip` with a standing TODO.
+- Actual model-answer correctness — the assertion is on the copied API snippet,
+  not the model's chat response.
+
+---
+
+## Notes
+
+- **Handle testid drift (#614):** `openaimodel` → `openaimodelcomponent` on the
+  1.11 nightly; the Chat Input / Chat Output handles are unchanged. Confirmed
+  live on `1.11.0.dev46` during the fix scout.
+- The spec builds the flow via UI drag (legacy shard); it does not persist a
+  named flow beyond the bootstrap one — cleanup follows the file's existing
+  pattern.

--- a/tests/tests-automations/regression/flow-functionality/generalBugs-shard-3.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/generalBugs-shard-3.spec.ts
@@ -1,10 +1,46 @@
 import * as dotenv from "dotenv";
 import path from "path";
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { clearApiKeyBadges } from "../../../helpers/ui/clear-api-key-badges";
 import { initialGPTsetup } from "../../../helpers/other/initialGPTsetup";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+
+// Capture every flow THIS page creates from its POST /api/v1/flows → 201
+// responses and delete them id-scoped in afterEach — the legacy spec built a
+// flow via the blank-flow UI and leaked it every run (#490/#681 pattern; the
+// response ids are authoritative and worker-safe).
+const createdFlowIds: string[] = [];
+
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {});
+    }
+  });
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, {
+      headers: { Authorization: bearer },
+    }).catch(() => {});
+  }
+});
 
 test(
   "should copy code from playground modal",
@@ -12,6 +48,8 @@ test(
     tag: ["@release"],
   },
   async ({ page }) => {
+    trackCreatedFlows(page);
+
     test.skip(
       !process?.env?.OPENAI_API_KEY,
       "OPENAI_API_KEY required to run this test",
@@ -75,10 +113,12 @@ test(
     await page
       .getByTestId("handle-chatinput-noshownode-chat message-source")
       .click();
-    await page.getByTestId("handle-openaimodel-shownode-input-left").click();
+    await page
+      .getByTestId("handle-openaimodelcomponent-shownode-input-left")
+      .click();
 
     await page
-      .getByTestId("handle-openaimodel-shownode-model response-right")
+      .getByTestId("handle-openaimodelcomponent-shownode-model response-right")
       .click();
     await page
       .getByTestId("handle-chatoutput-noshownode-inputs-target")


### PR DESCRIPTION
## What

Repair the deterministically-broken `@release` test **"should copy code from playground modal"** (`generalBugs-shard-3.spec.ts`).

## Root cause (product-changed)

On the 1.11 nightly the OpenAI model node type id drifted upstream from `openaimodel` → **`openaimodelcomponent`**, so the wiring clicks on `handle-openaimodel-shownode-input-left` and `handle-openaimodel-shownode-model response-right` timed out (`locator.click: Timeout 20000ms` — the handles never appeared). Confirmed live on `1.11.0.dev46`: the Chat Input / Chat Output handles are unchanged; only the OpenAI node id renamed.

## Fix

- Update the two OpenAI handle testids to the `openaimodelcomponent` id.
- Add **id-scoped `afterEach` cleanup** — the legacy spec built a flow via the blank-flow UI and leaked it every run; now it captures `POST /api/v1/flows` 201 ids and deletes them via the API.
- Add the missing spec doc (`docs/flow-functionality/generalBugs-shard-3.md`).

No behavior change; the second test in the file remains `test.skip` (pre-existing TODO, out of scope).

## Validation

- **Nightly:** `1.11.0.dev46`.
- **Determinism:** burst 3/3 at `--workers=1 --retries=0` → expected=1, unexpected=0, flaky=0 (1 skipped = the pre-existing `test.skip`).
- **Force-fail:** the final clipboard assertion mutated to expect an absent token instead of "Hello" — observed red, then reverted; final green.
- **Gates:** typecheck 0 errors, lint 0 errors; 0 orphan flows.

## External dependency

Requires an **active** `OPENAI_API_KEY` (the flow runs in the Playground). Confirmed working on the current key; the test `test.skip`s without it.

Closes #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)