### PR TITLE
docs(infra): diagnose CI runner sizing & parallelism (#817)

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -233,22 +233,6 @@ jobs:
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
 
-      # TEMP instrumentation for issue #817 (CI runner sizing). Samples host
-      # load average + memory at ~1 Hz for the whole test window into a CSV
-      # artifact, so we can correlate CPU saturation (loadavg > 2 cores) against
-      # the timeout failures in results.json. Detached + fail-soft; remove once
-      # the sizing decision is made.
-      - name: Start resource sampler (#817)
-        shell: bash
-        run: |
-          nproc || true
-          ( while true; do
-              echo "$(date -u +%FT%TZ),load=$(cut -d' ' -f1-3 /proc/loadavg | tr ' ' ';'),mem_used_total_mb=$(free -m | awk '/Mem:/{print $3"/"$2}')"
-              sleep 1
-            done ) >/tmp/resource-samples.csv 2>&1 &
-          disown
-          echo "Resource sampler started (cores: $(nproc))."
-
       - name: Run @stable tests
         run: npx playwright test --grep "@stable" --pass-with-no-tests --reporter=html,github,json
         env:
@@ -260,16 +244,6 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
-
-      # TEMP (#817): upload the resource sampler CSV for CPU/mem correlation.
-      - name: Upload resource samples (#817)
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: resource-samples-daily-${{ github.run_id }}
-          path: /tmp/resource-samples.csv
-          retention-days: 30
-          if-no-files-found: warn
 
       - name: Upload Playwright report (full, heavy)
         id: upload_report                     # ← full report: index.html + data/ + trace/ attachments (~380 MB)

--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -233,6 +233,22 @@ jobs:
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
 
+      # TEMP instrumentation for issue #817 (CI runner sizing). Samples host
+      # load average + memory at ~1 Hz for the whole test window into a CSV
+      # artifact, so we can correlate CPU saturation (loadavg > 2 cores) against
+      # the timeout failures in results.json. Detached + fail-soft; remove once
+      # the sizing decision is made.
+      - name: Start resource sampler (#817)
+        shell: bash
+        run: |
+          nproc || true
+          ( while true; do
+              echo "$(date -u +%FT%TZ),load=$(cut -d' ' -f1-3 /proc/loadavg | tr ' ' ';'),mem_used_total_mb=$(free -m | awk '/Mem:/{print $3"/"$2}')"
+              sleep 1
+            done ) >/tmp/resource-samples.csv 2>&1 &
+          disown
+          echo "Resource sampler started (cores: $(nproc))."
+
       - name: Run @stable tests
         run: npx playwright test --grep "@stable" --pass-with-no-tests --reporter=html,github,json
         env:
@@ -244,6 +260,16 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+
+      # TEMP (#817): upload the resource sampler CSV for CPU/mem correlation.
+      - name: Upload resource samples (#817)
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: resource-samples-daily-${{ github.run_id }}
+          path: /tmp/resource-samples.csv
+          retention-days: 30
+          if-no-files-found: warn
 
       - name: Upload Playwright report (full, heavy)
         id: upload_report                     # ← full report: index.html + data/ + trace/ attachments (~380 MB)

--- a/ISSUE-817-CI-RUNNER-SIZING.md
+++ b/ISSUE-817-CI-RUNNER-SIZING.md
@@ -26,16 +26,16 @@ the VM has spare cores — which is exactly why the failures are timeout-dominat
 uncorrelated with VM load. A share of the 34 hard failures is also genuine nightly
 product slowness/regressions, not infra at all.
 
-**Recommendation (revised after measurement):**
-1. **Cheapest lever first — raise the `langflow` *service's* own backend concurrency.**
-   If the service container runs a single backend worker, every request from both
-   Playwright workers serializes through it. Investigate the langflow worker/thread
-   setting and bump it. No matrix rework, no cost — targets the actual bottleneck.
-2. **If insufficient — shard the `@stable` suite across N standard runners**, each with
-   its **own dedicated `langflow`** stack. Standard runners are **free/unlimited on this
-   public repo**. Its value here is *one backend per shard* (kills the serialization),
-   not more CPU. Needs blob-merge + downstream-aggregation rework → own Wave impl issue
-   (#833).
+**Recommendation (revised after measurement + Option-0 investigation):**
+1. **Shard the `@stable` suite across N standard runners (#833) — primary fix.** Each
+   shard keeps the *known-good single-worker `langflow` + SQLite* config, so it removes
+   the single-backend serialization **without** Redis/Postgres, and cuts wall-clock ~N×.
+   Standard runners are **free/unlimited on this public repo**. Needs blob-merge +
+   downstream-aggregation rework → own Wave impl issue (#833).
+2. **Reject raising `LANGFLOW_WORKERS`** — investigated: multi-worker langflow needs a
+   Redis job queue (build path is per-process in-memory) **and** Postgres (SQLite locks
+   under concurrency). That is *more* new services/failure modes than sharding, and it
+   abandons the single-worker/SQLite config the suite was validated on.
 3. **Reject the "larger runner" option** — the runner is **already 4-core**, memory is at
    47 %, and failures don't track CPU saturation, so more cores/RAM won't help.
 4. **Reject** raising timeouts / dropping to `workers=1` as the primary lever (masks the
@@ -168,18 +168,25 @@ product slowness explain the timeout-dominated failures, consistent with §1 and
 
 ## 5. Options & trade-offs
 
-### Option 0 — Raise the `langflow` service's own backend concurrency (NEW, cheapest)
+### Option 0 — Raise the `langflow` service's own backend concurrency — **INVESTIGATED, NOT cheap**
 
-The §3 data points at the shared backend, not the VM. If the `langflow` service container
-runs a single backend worker, both Playwright workers' requests serialize through it.
-Investigate the langflow worker/thread setting (e.g. a `LANGFLOW_WORKERS`-style env or the
-container's uvicorn/gunicorn worker count) and raise it — the 4-core / 47 %-mem headroom
-measured in §3 can absorb it.
+The §3 data points at the shared backend, so the first idea was: bump the langflow service's
+own worker count so it stops serializing both Playwright workers' requests. The knob exists
+(**`LANGFLOW_WORKERS`**, default **1**; on Unix langflow runs Gunicorn pre-fork). **But
+multi-worker langflow is not a one-line env bump — it requires new stateful services:**
+
+- **Redis job queue is mandatory.** The build job queue is **in-memory per-process**: "a
+  flow build started on worker A cannot be polled or streamed from worker B." Multi-worker
+  requires `LANGFLOW_JOB_QUEUE_TYPE=redis` + `LANGFLOW_REDIS_QUEUE_URL` (a new Redis
+  service). The E2E suite is **playground/flow-build heavy** — exactly the pollable build
+  path that breaks across workers.
+- **SQLite locks under concurrent workers.** Docs recommend **Postgres**; we have already
+  hit a SQLite lock bug on concurrent writes (`LANGFLOW-BUG-bulk-flow-delete-sqlite-lock.md`).
 
 | | |
 |---|---|
-| ✅ Pro | **Free, no matrix rework, no test change**; targets the actual serialization point; keeps one runner + one report (all downstream steps untouched). |
-| ❌ Con | Needs verification that the nightly image exposes a worker knob and that concurrent requests are safe against the single SQLite DB (WAL is on). Must be proven with a repeat sampler + failure-count run, not assumed. |
+| ✅ Pro | Would relieve the serialization within a single instance. |
+| ❌ Con | **Not free / not one-line** — needs a Redis service *and* (realistically) Postgres, plus the `JOB_QUEUE_TYPE`/`REDIS_QUEUE_URL`/`WORKER_TIMEOUT` config. That is **more** new services + failure modes than Option B, and it abandons the known-good single-worker+SQLite config the whole suite was validated against. **Rejected as the cheap win.** |
 
 ### Option A — Larger runner — **REJECTED by §3**
 
@@ -196,7 +203,7 @@ Matrix of N jobs (`--shard=i/N`), each on a standard `ubuntu-latest` with its **
 
 | | |
 |---|---|
-| ✅ Pro | **Free** — standard runners are unlimited on this public repo; wall-clock drops ~N×; each shard gets a **dedicated `langflow`** (removes the single-backend serialization, the actual root cause per §1/§3); scales with suite growth by raising N. |
+| ✅ Pro | **Free** — standard runners are unlimited on this public repo; wall-clock drops ~N×; each shard gets a **dedicated single-worker `langflow` + SQLite** — the known-good config, so it removes the serialization **without** needing Redis/Postgres (unlike Option 0); scales with suite growth by raising N. |
 | ❌ Con | Real engineering: (1) merge N blob reports into one `results.json` before the downstream steps; (2) the **auto-remove-`@stable`**, **history append**, **QA-Platform POST**, and **failure-issue** steps all assume a single `results.json` → must run post-merge; (3) N× langflow boots (~90 s each) + N service stacks; (4) `@database` state-sharing tests must stay **within one shard** (shard by file with affinity, never split a dependent pair). → Own Wave implementation issue (#833). |
 
 ### Option C — Reduce per-instance load
@@ -204,13 +211,12 @@ Matrix of N jobs (`--shard=i/N`), each on a standard `ubuntu-latest` with its **
 - **`workers=1`**: ✅ removes the 2-workers-vs-1-backend contention, free, one line. ❌
   roughly doubles wall-clock — 67 min → ~2 h, breaching the 90 min job timeout. Wrong
   direction on the current single-runner setup.
-  **Note — `workers` is not an independent lever; it is coupled to the runner/shard
-  decision:** dropping to `workers=1` on today's single 2-core runner is the wrong
-  trade (doubles wall-clock). The clean design is **`workers=1` *per shard*** under
-  Option B — each shard gets one dedicated `langflow` and one worker, so cross-worker
-  backend contention disappears and parallelism comes from the shard count, not the
-  worker count. Under the Option A stopgap, `workers=2` stays fine (the 4-core doubles
-  the CPU headroom). Do not tune `workers` in isolation.
+  **Note — `workers` is not an independent lever; it is coupled to the shard decision:**
+  dropping to `workers=1` on today's single runner is the wrong trade (doubles
+  wall-clock). The clean design is **`workers=1` *per shard*** under Option B — each shard
+  gets one dedicated single-worker `langflow`, so the backend serialization disappears and
+  parallelism comes from the shard count, not the worker count. Do not tune `workers` in
+  isolation.
 - **Raise `actionTimeout`/test timeout**: ✅ trivial. ❌ masks the root cause, slows
   every test, and violates the repo rule *never add waits/retries to go green*. Reject
   as a primary lever.
@@ -223,15 +229,19 @@ Matrix of N jobs (`--shard=i/N`), each on a standard `ubuntu-latest` with its **
 
 Direct measurement (§3) reframed the whole issue: the runner is **already 4-core / 16 GB
 and not resource-starved**, and the timeout failures **do not correlate with CPU load**.
-The bottleneck is the **single shared `langflow` backend**, not runner sizing.
+The bottleneck is the **single shared `langflow` backend**, not runner sizing. Raising the
+backend's own worker count (Option 0) was investigated and is **not** the cheap lever it
+looked like — multi-worker langflow needs Redis + Postgres and abandons the known-good
+single-worker/SQLite config.
 
-1. **Try Option 0 first — raise the `langflow` service backend concurrency.** Cheapest,
-   free, no rework; targets the serialization point directly. Verify with a repeat
-   sampler + failure-count run.
-2. **If Option 0 is insufficient, implement sharding (Option B, #833)** — one dedicated
-   `langflow` per shard removes the serialization *and* cuts wall-clock; free on this
-   public repo. It carries the blob-merge + downstream-aggregation rework and the
-   `@database` shard-affinity rule.
+1. **Implement sharding (Option B, #833) as the primary fix.** It is the only option that
+   removes the single-backend serialization while keeping each shard on the *known-good
+   single-worker `langflow` + SQLite* config — no Redis, no Postgres, no new stateful
+   services. Free on this public repo; also cuts wall-clock ~N×. Carries the blob-merge +
+   downstream-aggregation rework and the `@database` shard-affinity rule.
+2. **Reject Option 0** (raise `LANGFLOW_WORKERS`) — it mandates a Redis job queue (the
+   build path is per-process in-memory) + Postgres (SQLite locks under concurrency), i.e.
+   *more* new services/failure modes than sharding.
 3. **Reject the larger runner (Option A)** — §3 shows more CPU/RAM won't help, and it is
    paid.
 4. **Do not** raise timeouts or drop to `workers=1` as the primary lever.

--- a/ISSUE-817-CI-RUNNER-SIZING.md
+++ b/ISSUE-817-CI-RUNNER-SIZING.md
@@ -1,0 +1,219 @@
+# Issue #817 — CI runner sizing & Playwright parallelism for the daily
+
+**Type:** infra investigation (`qa-infra`, Wave 3 — Infra stabilization & test coverage)
+**Status:** diagnosis + recommendation. **No infra change is made by this issue** — the
+milestone rule is explicit: *act only after diagnosis/isolation rule out a product
+regression.* Acting (changing the runner / sharding) is a separate follow-up.
+**Last updated:** 2026-07-18
+
+---
+
+## TL;DR
+
+The daily `@stable` suite runs on a **standard `ubuntu-latest` runner (2 vCPU / 7 GB)**
+with **`workers=2`**, sharing that single 2-core VM with the `langflow` backend, a
+CPU-inference `ollama`, and `go-httpbin`. That is heavy CPU oversubscription. The run
+history shows failures are **timeout-dominated** and their volume **scales with run
+duration / suite load** — the signature of CPU contention, not (mostly) product bugs.
+
+**Recommendation:**
+1. **Durable, cost-free fix — shard the `@stable` suite across N standard runners**
+   (each shard with its own dedicated `langflow`/`ollama`/`go-httpbin` stack). Standard
+   Linux runners are **free and unlimited on this public repo**; larger runners are
+   **paid even on public repos**. Sharding both removes per-worker backend contention
+   *and* keeps pace with suite growth. It needs real workflow rework (blob-report merge
+   + aggregation of history/auto-remove/QA-POST across shards) → **track as its own Wave
+   implementation issue.**
+2. **Immediate stopgap (optional, paid) — bump `runs-on` to a 4-core larger runner.**
+   One-line change, instant relief, keeps the single-`langflow` semantics that
+   state-sharing `@database` tests depend on. Billed per-minute; only worth it if relief
+   is needed before sharding lands.
+3. **Reject** raising timeouts or dropping to `workers=1` as the primary lever — the
+   first masks the root cause (repo rule: never add waits to go green), the second
+   roughly doubles wall-clock (already up to 67 min against a 90 min job timeout).
+
+The one gap: this analysis proves contention from **indirect** evidence (the run
+history). A **direct** CPU/mem measurement (Done-when #1) requires instrumenting the
+workflow and triggering one real run — proposed in §4, not yet executed.
+
+---
+
+## 1. Current configuration (as-is)
+
+Source: `.github/workflows/daily-stable.yml`, `playwright.config.ts`.
+
+| Dimension | Value | Source |
+|---|---|---|
+| Runner | `ubuntu-latest` — standard hosted Linux, **2 vCPU / 7 GB / 14 GB SSD** | `daily-stable.yml:34` |
+| Test container | `mcr.microsoft.com/playwright:v1.58.2-noble` | `daily-stable.yml:43` |
+| Workers | **2** in CI (`process.env.CI ? 2 : undefined`) | `playwright.config.ts:18` |
+| Per-test timeout | 5 min; `actionTimeout` 20 s | `playwright.config.ts:19,28` |
+| Retries | 2 in CI | `playwright.config.ts:17` |
+| Co-tenant services | `langflow` (single instance), `ollama` (llama3.2:1b, CPU inference), `go-httpbin` | `daily-stable.yml:45-128` |
+| `@stable` tests | **353** (`scripts/stable-tests.ts --count`) | live |
+
+**The core problem — CPU oversubscription on 2 vCPUs.** A single run concurrently loads:
+
+- 2 Playwright **worker processes** (Node) + 2 **Chromium** browsers (each browser is
+  several processes),
+- **1 shared `langflow`** backend (Python/uvicorn) serving *both* workers' requests —
+  graph execution, model calls, DB writes,
+- **`ollama`** running `llama3.2:1b` **inference on CPU** (pegs a core whenever an
+  agent/model spec fires),
+- **`go-httpbin`**.
+
+That is ~6–8 CPU-hungry processes contending for **2 cores**. When `ollama` infers or
+`langflow` executes a heavy graph, the browser's event loop starves; UI actions miss the
+20 s `actionTimeout` and `waitForSelector` windows → timeout failures.
+
+---
+
+## 2. Evidence of contention (indirect, from `reports/daily-history.jsonl`)
+
+13 scheduled runs, 2026-07-01 → 2026-07-17.
+
+### 2.1 Failures are timeout-dominated
+
+Clustered `error_signature` across all runs (`failures[]`, N = normalized digits):
+
+| Count | Signature | Contention-type? |
+|---|---|---|
+| 42 | `TimeoutError: locator.click: Timeout Nms exceeded` | ✅ |
+| 18 | `expect(locator).toBeVisible() failed` | ✅ (slow render) |
+| 15 | `TimeoutError: page.waitForSelector: Timeout Nms exceeded` | ✅ |
+| 8 | `TimeoutError: locator.hover: Timeout Nms exceeded` | ✅ |
+| 9 + 9 | `toContain` / `toBe` equality | mixed |
+| 3 | `locator.waitFor` timeout | ✅ |
+| 2 | `page.waitForResponse` timeout | ✅ |
+| … | (product-specific: MCP 4xx, provider probe, tool indicator) | ❌ real findings |
+
+**~86 of 142 hard-failure entries (≈60%) are timeout / slow-render** — plus 38 of 175
+flaky entries carry a timeout signature. A suite where the *dominant* failure mode is
+"the browser could not act within 20 s" is starved for CPU, not broadly broken.
+
+### 2.2 Timeout volume tracks run load / duration
+
+`date · duration · hard-failures(of which timeout) · flaky(of which timeout)`:
+
+```
+2026-07-01  31m  F=2(to=1)    FL=1(to=0)
+2026-07-02  25m  F=4(to=4)    FL=1(to=0)
+2026-07-03  21m  F=1(to=0)    FL=1(to=0)     ← short/clean
+2026-07-06  20m  F=1(to=0)    FL=1(to=0)     ← short/clean
+2026-07-07  38m  F=5(to=1)    FL=1(to=0)
+2026-07-08  41m  F=28(to=27)  FL=1(to=0)     ← heavy → 27 timeout fails
+2026-07-09  25m  F=4(to=4)    FL=1(to=0)
+2026-07-10  34m  F=4(to=0)    FL=1(to=0)
+2026-07-13  58m  F=12(to=1)   FL=1(to=0)
+2026-07-14  60m  F=27(to=9)   FL=27(to=12)   ← heavy → 21 timeout total
+2026-07-15  47m  F=15(to=2)   FL=29(to=14)
+2026-07-16  52m  F=6(to=0)    FL=13(to=8)
+2026-07-17  67m  F=34(to=24)  FL=10(to=4)    ← longest → 28 timeout total
+```
+
+Duration grew **20 → 67 min** as the passing count grew **214 → 373** (suite growth).
+The heaviest/longest runs (07-08, 07-14, 07-17) are exactly the timeout spikes; the
+short runs (07-03, 07-06) are clean. **Load ↑ → timeouts ↑** is the contention
+signature. The clean short runs also prove the infra *can* go green — so a large share
+of the failures is contention/transient, not a standing product regression.
+
+### 2.3 Isolation caveat (Done-when: "rule out a product regression")
+
+Not every timeout is contention: some entries are genuine product findings (MCP 4xx
+mismatches, provider-probe failures, "agent answered without invoking any tool"). Those
+must keep failing and be triaged on their own dedicated issues — they are **not** what a
+bigger runner fixes. The recommendation targets the ~60% contention-shaped bucket only.
+
+---
+
+## 3. What is NOT yet measured (Done-when #1, direct numbers)
+
+The history gives **indirect** evidence. It does **not** contain per-run CPU/mem
+samples, so we cannot yet state "langflow used X% CPU while a worker timed out." §4
+proposes the instrumentation to capture that directly.
+
+---
+
+## 4. Proposed instrumentation to close Done-when #1 (direct CPU/mem)
+
+Add a **background resource sampler** step to the daily (or a manual dispatch), writing
+a CSV artifact, then correlate spikes against the failure timestamps in `results.json`.
+Sketch (no product/test change; artifact-only):
+
+```yaml
+# Before "Run @stable tests": start a detached sampler.
+- name: Start resource sampler
+  shell: bash
+  run: |
+    ( while true; do
+        echo "$(date -u +%FT%TZ),$(cat /proc/loadavg | cut -d' ' -f1-3 | tr ' ' ';'),\
+$(free -m | awk '/Mem:/{print $3"/"$2}')"
+      done ) >/tmp/resource-samples.csv 2>&1 &   # ~1 Hz loadavg + mem
+    disown
+# After the test step: upload /tmp/resource-samples.csv as an artifact.
+```
+
+Load average > number of cores (2) sustained during the test window = CPU saturation.
+This is cheap (a few KB) and fail-soft. **Cost: one manual `workflow_dispatch` run
+(~60 min of runner time).** Only run it if the team wants the direct number before
+acting — the indirect evidence in §2 is already conclusive for the *direction*.
+
+---
+
+## 5. Options & trade-offs
+
+### Option A — Larger runner (4+ vCPU)
+
+Change `runs-on: ubuntu-latest` → a 4-core larger runner (single line).
+
+| | |
+|---|---|
+| ✅ Pro | Trivial one-line change; instant 2× CPU headroom; directly relieves oversubscription; **keeps the single shared `langflow`**, so `@database`/state-sharing tests are unaffected; no aggregation rework. |
+| ❌ Con | **Paid per-minute even on a public repo** (standard 2-core is the only free tier). Doesn't stop the growth curve — at ~4× the current suite it will contend again. A stopgap, not a ceiling. |
+
+### Option B — Shard the `@stable` suite across N standard runners
+
+Matrix of N jobs (`--shard=i/N`), each on a standard `ubuntu-latest` with its **own**
+`langflow`/`ollama`/`go-httpbin` services; merge the N blob reports at the end.
+
+| | |
+|---|---|
+| ✅ Pro | **Free** — standard runners are unlimited on this public repo; wall-clock drops ~N×; each shard gets a **dedicated `langflow`** (kills cross-worker backend contention, the actual root cause); scales with suite growth by raising N. |
+| ❌ Con | Real engineering: (1) merge N blob reports into one `results.json` before the downstream steps; (2) the **auto-remove-`@stable`**, **history append**, **QA-Platform POST**, and **failure-issue** steps all assume a single `results.json` → must run post-merge; (3) N× langflow boots (~90 s each) + N service stacks; (4) `@database` state-sharing tests must stay **within one shard** (shard by file with affinity, never split a dependent pair). → Deserves its own Wave implementation issue. |
+
+### Option C — Reduce per-instance load
+
+- **`workers=1`**: ✅ removes the 2-workers-vs-1-backend contention, free, one line. ❌
+  roughly doubles wall-clock — 67 min → ~2 h, breaching the 90 min job timeout. Wrong
+  direction on the current single-runner setup.
+  **Note — `workers` is not an independent lever; it is coupled to the runner/shard
+  decision:** dropping to `workers=1` on today's single 2-core runner is the wrong
+  trade (doubles wall-clock). The clean design is **`workers=1` *per shard*** under
+  Option B — each shard gets one dedicated `langflow` and one worker, so cross-worker
+  backend contention disappears and parallelism comes from the shard count, not the
+  worker count. Under the Option A stopgap, `workers=2` stays fine (the 4-core doubles
+  the CPU headroom). Do not tune `workers` in isolation.
+- **Raise `actionTimeout`/test timeout**: ✅ trivial. ❌ masks the root cause, slows
+  every test, and violates the repo rule *never add waits/retries to go green*. Reject
+  as a primary lever.
+- **Stagger heavy services** (e.g. gate ollama/agent specs to a separate window): partial
+  relief but fragile and doesn't address the shared-backend contention.
+
+---
+
+## 6. Recommendation
+
+1. **Adopt sharding (Option B) as the durable fix** — it is the only option that is both
+   *free on this public repo* and *removes the real root cause* (one `langflow` serving
+   two contending workers). Open a dedicated Wave implementation issue covering the
+   blob-merge + downstream-aggregation rework and the `@database` shard-affinity rule.
+2. **If relief is needed before B lands, apply Option A (4-core) as a paid stopgap** —
+   one line, reversible, keeps single-`langflow` semantics. Decommission once B is live.
+3. **Do not** raise timeouts or drop to `workers=1` as the primary lever.
+4. **Optionally run the §4 sampler once** (manual dispatch) to attach direct CPU/mem
+   numbers to this issue before committing budget to A.
+5. Keep triaging the genuine-product-finding failures (§2.3) on their own issues — they
+   are out of scope for runner sizing.
+
+**This issue delivers the diagnosis + recommendation only. No workflow file is changed
+here.**

--- a/ISSUE-817-CI-RUNNER-SIZING.md
+++ b/ISSUE-817-CI-RUNNER-SIZING.md
@@ -10,31 +10,37 @@ regression.* Acting (changing the runner / sharding) is a separate follow-up.
 
 ## TL;DR
 
-The daily `@stable` suite runs on a **standard `ubuntu-latest` runner (2 vCPU / 7 GB)**
-with **`workers=2`**, sharing that single 2-core VM with the `langflow` backend, a
-CPU-inference `ollama`, and `go-httpbin`. That is heavy CPU oversubscription. The run
-history shows failures are **timeout-dominated** and their volume **scales with run
-duration / suite load** — the signature of CPU contention, not (mostly) product bugs.
+> **The issue's premise is outdated, and a direct measurement disproves the CPU-contention
+> theory.** The daily does **not** run on a 2 vCPU / 7 GB VM — GitHub has upgraded the free
+> public-repo standard `ubuntu-latest` to **4 vCPU / 16 GB**. A resource sampler run
+> (§3, run [29658914382]) shows the VM is **not resource-starved**: load1 mean 2.80 / max
+> 5.42 on 4 cores, memory peak 47 %. Crucially, **the timeout failures do not correlate
+> with CPU saturation** — during the 107 failing test-results the load averaged 2.57/4
+> and only 16 of them were anywhere near saturation. So raw VM CPU/mem is **not** the root
+> cause.
 
-**Recommendation:**
-1. **Durable, cost-free fix — shard the `@stable` suite across N standard runners**
-   (each shard with its own dedicated `langflow`/`ollama`/`go-httpbin` stack). Standard
-   Linux runners are **free and unlimited on this public repo**; larger runners are
-   **paid even on public repos**. Sharding both removes per-worker backend contention
-   *and* keeps pace with suite growth. It needs real workflow rework (blob-report merge
-   + aggregation of history/auto-remove/QA-POST across shards) → **track as its own Wave
-   implementation issue.**
-2. **Immediate stopgap (optional, paid) — bump `runs-on` to a 4-core larger runner.**
-   One-line change, instant relief, keeps the single-`langflow` semantics that
-   state-sharing `@database` tests depend on. Billed per-minute; only worth it if relief
-   is needed before sharding lands.
-3. **Reject** raising timeouts or dropping to `workers=1` as the primary lever — the
-   first masks the root cause (repo rule: never add waits to go green), the second
-   roughly doubles wall-clock (already up to 67 min against a 90 min job timeout).
+The real bottleneck is the **single shared `langflow` backend**: `workers=2` sends two
+concurrent streams of requests to one Python backend, which serializes on graph
+execution / model calls. The browser then waits past the 20 s `actionTimeout` even though
+the VM has spare cores — which is exactly why the failures are timeout-dominated yet
+uncorrelated with VM load. A share of the 34 hard failures is also genuine nightly
+product slowness/regressions, not infra at all.
 
-The one gap: this analysis proves contention from **indirect** evidence (the run
-history). A **direct** CPU/mem measurement (Done-when #1) requires instrumenting the
-workflow and triggering one real run — proposed in §4, not yet executed.
+**Recommendation (revised after measurement):**
+1. **Cheapest lever first — raise the `langflow` *service's* own backend concurrency.**
+   If the service container runs a single backend worker, every request from both
+   Playwright workers serializes through it. Investigate the langflow worker/thread
+   setting and bump it. No matrix rework, no cost — targets the actual bottleneck.
+2. **If insufficient — shard the `@stable` suite across N standard runners**, each with
+   its **own dedicated `langflow`** stack. Standard runners are **free/unlimited on this
+   public repo**. Its value here is *one backend per shard* (kills the serialization),
+   not more CPU. Needs blob-merge + downstream-aggregation rework → own Wave impl issue
+   (#833).
+3. **Reject the "larger runner" option** — the runner is **already 4-core**, memory is at
+   47 %, and failures don't track CPU saturation, so more cores/RAM won't help.
+4. **Reject** raising timeouts / dropping to `workers=1` as the primary lever (masks the
+   root cause / doubles wall-clock).
+5. Keep triaging genuine product-finding failures separately (§2.3).
 
 ---
 
@@ -44,7 +50,7 @@ Source: `.github/workflows/daily-stable.yml`, `playwright.config.ts`.
 
 | Dimension | Value | Source |
 |---|---|---|
-| Runner | `ubuntu-latest` — standard hosted Linux, **2 vCPU / 7 GB / 14 GB SSD** | `daily-stable.yml:34` |
+| Runner | `ubuntu-latest` — **actually 4 vCPU / 16 GB** (measured `nproc`=4, mem total 15988 MB; GitHub upgraded the free public-repo standard runner. The issue's "2 vCPU / 7 GB" premise is outdated.) | `daily-stable.yml:34` + §3 |
 | Test container | `mcr.microsoft.com/playwright:v1.58.2-noble` | `daily-stable.yml:43` |
 | Workers | **2** in CI (`process.env.CI ? 2 : undefined`) | `playwright.config.ts:18` |
 | Per-test timeout | 5 min; `actionTimeout` 20 s | `playwright.config.ts:19,28` |
@@ -52,19 +58,15 @@ Source: `.github/workflows/daily-stable.yml`, `playwright.config.ts`.
 | Co-tenant services | `langflow` (single instance), `ollama` (llama3.2:1b, CPU inference), `go-httpbin` | `daily-stable.yml:45-128` |
 | `@stable` tests | **353** (`scripts/stable-tests.ts --count`) | live |
 
-**The core problem — CPU oversubscription on 2 vCPUs.** A single run concurrently loads:
-
-- 2 Playwright **worker processes** (Node) + 2 **Chromium** browsers (each browser is
-  several processes),
-- **1 shared `langflow`** backend (Python/uvicorn) serving *both* workers' requests —
-  graph execution, model calls, DB writes,
-- **`ollama`** running `llama3.2:1b` **inference on CPU** (pegs a core whenever an
-  agent/model spec fires),
-- **`go-httpbin`**.
-
-That is ~6–8 CPU-hungry processes contending for **2 cores**. When `ollama` infers or
-`langflow` executes a heavy graph, the browser's event loop starves; UI actions miss the
-20 s `actionTimeout` and `waitForSelector` windows → timeout failures.
+**The core problem — a single shared `langflow` backend, NOT VM CPU.** A run concurrently
+loads 2 Playwright workers + 2 Chromium browsers, **1 shared `langflow`** backend serving
+*both* workers, `ollama` (CPU inference), and `go-httpbin`. The original theory was that
+these oversubscribe the CPU. **The §3 measurement refutes that** — on 4 cores the VM runs
+at ~70 % mean load with spare headroom, and the timeout failures do not line up with the
+load peaks. The real serialization point is the **single `langflow` backend**: two workers
+issue concurrent graph-execution / model-call requests to one Python process, which
+handles them serially, so a worker's UI action can wait past the 20 s `actionTimeout`
+while the CPU sits idle. That is the timeout-dominated-yet-uncorrelated pattern §2/§3 show.
 
 ---
 
@@ -121,65 +123,81 @@ of the failures is contention/transient, not a standing product regression.
 
 Not every timeout is contention: some entries are genuine product findings (MCP 4xx
 mismatches, provider-probe failures, "agent answered without invoking any tool"). Those
-must keep failing and be triaged on their own dedicated issues — they are **not** what a
-bigger runner fixes. The recommendation targets the ~60% contention-shaped bucket only.
+must keep failing and be triaged on their own dedicated issues — they are **not** what an
+infra fix addresses. The recommendation targets the ~60% timeout/serialization bucket only.
 
 ---
 
-## 3. What is NOT yet measured (Done-when #1, direct numbers)
+## 3. Direct measurement (Done-when #1, DONE)
 
-The history gives **indirect** evidence. It does **not** contain per-run CPU/mem
-samples, so we cannot yet state "langflow used X% CPU while a worker timed out." §4
-proposes the instrumentation to capture that directly.
+A temporary resource sampler (loadavg + mem at ~1 Hz → CSV artifact) was added to
+`daily-stable.yml` and a manual `workflow_dispatch` run executed against
+`langflowai/langflow-nightly:latest`: **run 29658914382** (2026-07-18, 55 min, 324
+expected / **34 unexpected** / 7 flaky / 46 skipped — a normal heavy day). 3312 samples.
 
----
+### 3.1 The VM is NOT resource-starved
 
-## 4. Proposed instrumentation to close Done-when #1 (direct CPU/mem)
+| Metric | Value (4 cores / 16 GB) | Reading |
+|---|---|---|
+| `nproc` | **4** | runner is 4-core, not 2 |
+| load1 mean | **2.80** | ~70 % of 4 cores |
+| load1 max | **5.42** | brief 135 % bursts |
+| samples load1 > 4 (saturated) | **16 %** | saturation is the exception |
+| samples load1 > 6 | **0 %** | never severely pegged |
+| memory peak | **7.5 GB / 16 GB (47 %)** | never a constraint |
 
-Add a **background resource sampler** step to the daily (or a manual dispatch), writing
-a CSV artifact, then correlate spikes against the failure timestamps in `results.json`.
-Sketch (no product/test change; artifact-only):
+### 3.2 Failures do NOT correlate with CPU saturation
 
-```yaml
-# Before "Run @stable tests": start a detached sampler.
-- name: Start resource sampler
-  shell: bash
-  run: |
-    ( while true; do
-        echo "$(date -u +%FT%TZ),$(cat /proc/loadavg | cut -d' ' -f1-3 | tr ' ' ';'),\
-$(free -m | awk '/Mem:/{print $3"/"$2}')"
-      done ) >/tmp/resource-samples.csv 2>&1 &   # ~1 Hz loadavg + mem
-    disown
-# After the test step: upload /tmp/resource-samples.csv as an artifact.
-```
+Correlating the 107 failing test-*results'* `startTime`+`duration` windows against the
+sampler:
 
-Load average > number of cores (2) sustained during the test window = CPU saturation.
-This is cheap (a few KB) and fail-soft. **Cost: one manual `workflow_dispatch` run
-(~60 min of runner time).** Only run it if the team wants the direct number before
-acting — the indirect evidence in §2 is already conclusive for the *direction*.
+| Metric during failing tests | Value | vs overall |
+|---|---|---|
+| load1 mean while failing | **2.57** | ≈ overall 2.80 — no elevation |
+| failing-window samples > 4 cores | **12 %** | ≈ overall 16 % |
+| failures with any peak > 4 cores | **16 / 107** | most failed at normal load |
+
+If CPU contention drove the timeouts, the failing windows would sit at saturation. They
+don't — they sit at the *same* load as the passing ones. **Conclusion: raw VM CPU/mem is
+not the cause.** The single shared `langflow` backend (serialization) + genuine nightly
+product slowness explain the timeout-dominated failures, consistent with §1 and §2.3.
+
+*(The sampler step is temporary instrumentation — see PR #832; remove after the decision.)*
 
 ---
 
 ## 5. Options & trade-offs
 
-### Option A — Larger runner (4+ vCPU)
+### Option 0 — Raise the `langflow` service's own backend concurrency (NEW, cheapest)
 
-Change `runs-on: ubuntu-latest` → a 4-core larger runner (single line).
+The §3 data points at the shared backend, not the VM. If the `langflow` service container
+runs a single backend worker, both Playwright workers' requests serialize through it.
+Investigate the langflow worker/thread setting (e.g. a `LANGFLOW_WORKERS`-style env or the
+container's uvicorn/gunicorn worker count) and raise it — the 4-core / 47 %-mem headroom
+measured in §3 can absorb it.
 
 | | |
 |---|---|
-| ✅ Pro | Trivial one-line change; instant 2× CPU headroom; directly relieves oversubscription; **keeps the single shared `langflow`**, so `@database`/state-sharing tests are unaffected; no aggregation rework. |
-| ❌ Con | **Paid per-minute even on a public repo** (standard 2-core is the only free tier). Doesn't stop the growth curve — at ~4× the current suite it will contend again. A stopgap, not a ceiling. |
+| ✅ Pro | **Free, no matrix rework, no test change**; targets the actual serialization point; keeps one runner + one report (all downstream steps untouched). |
+| ❌ Con | Needs verification that the nightly image exposes a worker knob and that concurrent requests are safe against the single SQLite DB (WAL is on). Must be proven with a repeat sampler + failure-count run, not assumed. |
+
+### Option A — Larger runner — **REJECTED by §3**
+
+Was: bump `runs-on` to a bigger runner for more CPU.
+
+| | |
+|---|---|
+| ❌ Reject | The runner is **already 4-core / 16 GB**, memory peaks at 47 %, and failures do **not** correlate with CPU saturation (§3.2). More cores/RAM would not move the timeout rate — and larger runners are **paid** even on this public repo. No reason to pursue. |
 
 ### Option B — Shard the `@stable` suite across N standard runners
 
 Matrix of N jobs (`--shard=i/N`), each on a standard `ubuntu-latest` with its **own**
-`langflow`/`ollama`/`go-httpbin` services; merge the N blob reports at the end.
+`langflow`/`ollama`/`go-httpbin` services; merge the N blob reports at the end. (#833)
 
 | | |
 |---|---|
-| ✅ Pro | **Free** — standard runners are unlimited on this public repo; wall-clock drops ~N×; each shard gets a **dedicated `langflow`** (kills cross-worker backend contention, the actual root cause); scales with suite growth by raising N. |
-| ❌ Con | Real engineering: (1) merge N blob reports into one `results.json` before the downstream steps; (2) the **auto-remove-`@stable`**, **history append**, **QA-Platform POST**, and **failure-issue** steps all assume a single `results.json` → must run post-merge; (3) N× langflow boots (~90 s each) + N service stacks; (4) `@database` state-sharing tests must stay **within one shard** (shard by file with affinity, never split a dependent pair). → Deserves its own Wave implementation issue. |
+| ✅ Pro | **Free** — standard runners are unlimited on this public repo; wall-clock drops ~N×; each shard gets a **dedicated `langflow`** (removes the single-backend serialization, the actual root cause per §1/§3); scales with suite growth by raising N. |
+| ❌ Con | Real engineering: (1) merge N blob reports into one `results.json` before the downstream steps; (2) the **auto-remove-`@stable`**, **history append**, **QA-Platform POST**, and **failure-issue** steps all assume a single `results.json` → must run post-merge; (3) N× langflow boots (~90 s each) + N service stacks; (4) `@database` state-sharing tests must stay **within one shard** (shard by file with affinity, never split a dependent pair). → Own Wave implementation issue (#833). |
 
 ### Option C — Reduce per-instance load
 
@@ -203,17 +221,23 @@ Matrix of N jobs (`--shard=i/N`), each on a standard `ubuntu-latest` with its **
 
 ## 6. Recommendation
 
-1. **Adopt sharding (Option B) as the durable fix** — it is the only option that is both
-   *free on this public repo* and *removes the real root cause* (one `langflow` serving
-   two contending workers). Open a dedicated Wave implementation issue covering the
-   blob-merge + downstream-aggregation rework and the `@database` shard-affinity rule.
-2. **If relief is needed before B lands, apply Option A (4-core) as a paid stopgap** —
-   one line, reversible, keeps single-`langflow` semantics. Decommission once B is live.
-3. **Do not** raise timeouts or drop to `workers=1` as the primary lever.
-4. **Optionally run the §4 sampler once** (manual dispatch) to attach direct CPU/mem
-   numbers to this issue before committing budget to A.
-5. Keep triaging the genuine-product-finding failures (§2.3) on their own issues — they
-   are out of scope for runner sizing.
+Direct measurement (§3) reframed the whole issue: the runner is **already 4-core / 16 GB
+and not resource-starved**, and the timeout failures **do not correlate with CPU load**.
+The bottleneck is the **single shared `langflow` backend**, not runner sizing.
 
-**This issue delivers the diagnosis + recommendation only. No workflow file is changed
-here.**
+1. **Try Option 0 first — raise the `langflow` service backend concurrency.** Cheapest,
+   free, no rework; targets the serialization point directly. Verify with a repeat
+   sampler + failure-count run.
+2. **If Option 0 is insufficient, implement sharding (Option B, #833)** — one dedicated
+   `langflow` per shard removes the serialization *and* cuts wall-clock; free on this
+   public repo. It carries the blob-merge + downstream-aggregation rework and the
+   `@database` shard-affinity rule.
+3. **Reject the larger runner (Option A)** — §3 shows more CPU/RAM won't help, and it is
+   paid.
+4. **Do not** raise timeouts or drop to `workers=1` as the primary lever.
+5. Keep triaging the genuine-product-finding failures (§2.3, e.g. the nightly MCP 4xx /
+   provider-probe / tool-indicator failures) on their own issues — out of scope for
+   runner sizing.
+
+**This issue delivers the diagnosis + recommendation only. The only workflow change is
+the temporary §3 sampler (PR #832), to be removed once the fix path is chosen.**


### PR DESCRIPTION
Closes #817 (diagnosis + recommendation; no runner-sizing change made — the Wave 3 rule is *act only after diagnosis/isolation rule out a product regression*).

## What this delivers
- **`ISSUE-817-CI-RUNNER-SIZING.md`** — full analysis, including a **direct CPU/mem measurement**.
- **Temp CI resource sampler** in `daily-stable.yml` (loadavg + mem CSV artifact). To be removed once the fix path is chosen.

## Findings (direct measurement overturned the premise)
- The runner is **already 4 vCPU / 16 GB**, not 2 vCPU / 7 GB (GitHub upgraded the free public-repo `ubuntu-latest`).
- The VM is **not resource-starved**: load1 mean 2.80 / max 5.42 on 4 cores, mem peak 47 %.
- Timeout failures **do not correlate with CPU saturation** (load1 mean 2.57 during the 107 failing results; 16/107 near saturation). Raw VM CPU/mem is **not** the root cause.
- Reframed root cause: the **single shared `langflow` backend** serializing both `workers=2` streams, plus genuine nightly product slowness.

## Recommendation
0. **Raise the `langflow` service's own backend concurrency first** — cheapest, free, targets the serialization.
1. If insufficient — **shard `@stable`** (one dedicated langflow per shard), tracked in **#833**.
2. **Reject the larger runner** — already 4-core, CPU not the bottleneck, and it's paid.
3. Reject raising timeouts / `workers=1` as the primary lever.

Done-when: contention measured (direct, §3), options+trade-offs recorded (§5), recommendation recorded (§6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)