### PR TITLE
fix(ci): harden triage-dispatch gates (#819)

### DIFF
--- a/.github/workflows/triage-dispatch.yml
+++ b/.github/workflows/triage-dispatch.yml
@@ -42,8 +42,13 @@ permissions:
 jobs:
   propose:
     name: Propose triage plan
+    # workflow_dispatch is gated on a trusted actor: without this, any collaborator
+    # who can dispatch a workflow could run the triage skill against an arbitrary
+    # issue number. The workflow_run path needs no actor guard — it only fires from
+    # the real Daily Stable E2E run and is already narrowed to schedule + failure.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_dispatch' &&
+       contains(fromJSON('["rafaelgiln","Victor-w-Madeira","daniellicnerski1"]'), github.actor)) ||
       (github.event_name == 'workflow_run' &&
        github.event.workflow_run.conclusion == 'failure' &&
        github.event.workflow_run.event == 'schedule')
@@ -83,7 +88,7 @@ jobs:
       github.event.issue.pull_request == null &&
       github.event.issue.state == 'open' &&
       contains(github.event.issue.labels.*.name, 'daily-failure') &&
-      contains(github.event.comment.body, 'pode abrir') &&
+      startsWith(github.event.comment.body, 'pode abrir') &&
       contains(fromJSON('["rafaelgiln","Victor-w-Madeira","daniellicnerski1"]'), github.event.comment.user.login)
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION
Closes #819. Deferred hardening from the triage-automation review (#785/#786/#787). Two gate tightenings in `triage-dispatch.yml`; no behavior change for legitimate use.

## 1. `execute` — anchor the approval phrase
`contains(comment.body, 'pode abrir')` → `startsWith(comment.body, 'pode abrir')`.

The substring match false-triggered when a whitelisted author merely *quoted* the phrase mid-sentence or in a markdown quote. Anchoring requires the comment to lead with the approval.

| Comment | before | after |
|---|---|---|
| `pode abrir` | ✅ | ✅ |
| `pode abrir todas` | ✅ | ✅ |
| `não sei se pode abrir isso` | ✅ (false trigger) | ❌ |
| `> pode abrir` (quote) | ✅ (false trigger) | ❌ |

Still whitelist-gated → precision, not security. `startsWith` is case-insensitive (no regression vs `contains`).

## 2. `propose` — actor guard on the dispatch path
The `workflow_dispatch` path had no actor check — any collaborator who can dispatch could run the triage skill against an arbitrary issue number. Now gated on the same trusted-actor whitelist as `execute`:

```
(github.event_name == 'workflow_dispatch' &&
 contains(fromJSON('["rafaelgiln","Victor-w-Madeira","daniellicnerski1"]'), github.actor)) || ...
```

The `workflow_run` path is unchanged (only fires from the real Daily Stable E2E run, already narrowed to schedule + failure).

## Verification
- `actionlint` clean.
- Expression truth-tables reviewed for both gates (table above + actor cases).
- Live auto-trigger validation is inherently post-merge: `issue_comment`/`workflow_run` triggers only fire from the default branch (documented in the workflow header, lines 12-14) — matches how this automation was validated in #785/#786/#787.

Note: the whitelist literal is duplicated across the two gates (matching the pre-existing `execute` gate); GitHub job-level `if:` can't reference `env`, so a shared constant isn't available without a larger refactor — out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)