### PR TITLE
fix(core-components): modernize node-UI selectors for dev46 testid drift (#818)

### DIFF
--- a/ISSUE-818-HANDOFF.md
+++ b/ISSUE-818-HANDOFF.md
@@ -1,0 +1,76 @@
+# Issue #818 — Handoff for a dedicated session
+
+**Goal:** achieve ≥1 clean, non-guarded daily by **modernizing test selectors/steps** that drifted against a nightly node-UI overhaul. This is the entry gate for #773 and the wave's agent/MCP test promotions.
+
+**Branch:** `fix/issue-818-testid-drift-baseline` (off `main`; no spec touched yet — investigation only).
+
+---
+
+## Verdict already established (do not re-investigate from scratch)
+
+The daily's ~29 failures are **UI testid DRIFT**, NOT a Langflow product regression. This **corrects #816/#830** ("product regression, flag upstream"). The nightly restructured the node interaction surface (menu / expand / rename) between `dev40` and `dev46`; our specs still use the old testids. Features work; the DOM changed.
+
+Evidence: of 11 distinct testids that timed out across the failing specs, **10 are gone** from the dev46 frontend (only `add-mcp-server-button` survives → that one is behavior/flow, investigate separately).
+
+**Therefore:**
+- ❌ Do NOT flag upstream. ❌ Do NOT remove `@stable`. ❌ Do NOT pin the daily image.
+- ✅ DO modernize the selectors/steps to the new DOM (keeps coverage). ✅ Verify each fix against a local nightly.
+
+## Environment (the nightly the daily runs — NOT what the start script pulls)
+
+`scripts/start-langflow-docker.sh` pulls **stable** (`langflow:latest`), not nightly. Start the nightly explicitly:
+
+```bash
+docker run -d --rm --name lf-nightly -p 7860:7860 \
+  -e LANGFLOW_AUTO_LOGIN=true -e LANGFLOW_SUPERUSER=langflow -e LANGFLOW_SUPERUSER_PASSWORD=langflow123 \
+  -e LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true \
+  langflowai/langflow-nightly:latest
+# wait for: curl -sf http://localhost:7860/api/v1/version
+```
+
+Run a spec against it: `PLAYWRIGHT_BASE_URL=http://localhost:7860/ npx playwright test <file> --workers=1 --retries=0`.
+
+## Confirmed mapping — node name/description rename (biggest cluster)
+
+Old flow (our specs) → new flow (dev46), verified live:
+
+| Old | New |
+|---|---|
+| hover `panel-description` wrapper | **removed** — no hover step |
+| `edit-name-description-button` | `node-edit-name-description-button` |
+| `inspection-panel-name` | `input-title-<currentName>` (DYNAMIC — scope to the focused node; duplicate node names → strict-mode hazard) |
+| `save-name-description-button` | `node-save-name-description-button` |
+| description display | `generic-node-desc` (a DIV; the description-EDIT input testid still needs a live check for `edit-name-description-node.spec`) |
+
+New rename sequence: click `generic-node-title-arrangement` → click `node-edit-name-description-button` → fill `input-title-<name>` → click `node-save-name-description-button`.
+
+Also drifted in the node-menu/expand flow: **`expand-button-modal`** (used by the local `expandFocusedNode` helper in `if-else-component-regression.spec.ts`) is gone; `more-options-modal` still opens the menu (`icon-Expand` seen). Map the new expand item live before fixing.
+
+## Remaining clusters to map live (each: reproduce → read live DOM → find new testid)
+
+Timed-out testids still needing their new-name map:
+`edit-button-modal`, `expand-button-modal`, `edit-fields-button`, `toggle_bool_use_double_brackets`, `tweaks-button`, `icon-lock`, `div-table_headers`, `canvas_controls_dropdown_toggle_inspector-toggle`.
+Plus `add-mcp-server-button` (EXISTS in bundle → not a rename; investigate its flow/behavior separately).
+
+Mapping technique:
+- **Static testids:** grep the container bundle — `docker exec lf-nightly sh -c "grep -rhoE '\"TESTID\"' /app/.venv/lib/python3.14/site-packages/langflow/frontend/assets/"`. Reliable only for literal testids.
+- **Dynamic testids** (runtime-composed): grep gives false-MISSING → drive the UI with `playwright-cli` and `page.evaluate(() => [...document.querySelectorAll('[data-testid]')].map(e=>e.getAttribute('data-testid')))`.
+
+## Footprint (files using the drifted node-rename testids)
+
+`if-else-component-regression.spec.ts` (8 fails), `edit-name-description-node.spec.ts` (2), `general-bugs-reset-flow-run.spec.ts`, `group.spec.ts`, `langflowShortcuts.spec.ts`. Other clusters live in the agent/*, prompt-template, webhook, api-request, chat-input, auth/logout, mcp-client specs (see the #816 failing-set list).
+
+## Approach (recommended)
+
+1. **Helper-first for leverage:** fix the shared node-UI interaction (rename flow, `expandFocusedNode`, and any node-menu POM/helper) → cascades to many specs. Check `tests/helpers/` + `tests/pages/` for shared node-menu/rename helpers before editing specs one-by-one.
+2. Fix cluster → **verify green against local nightly** (`--workers=1 --retries=0`) before moving on.
+3. Repeat per cluster until the failing set is empty.
+4. **Force-fail** each touched `test()` (repo rule) + **id-scoped flow cleanup** on any spec touched (repo rule — audit `afterEach`/`deleteFlow`).
+5. Clean up any flow created during live scouting (DELETE via API; the browser-created "Basic Prompting" starter from the last session may still exist on the local instance).
+6. PR only after explicit user authorization.
+
+## Reference material from the investigation session
+
+- Memory: `daily-failures-are-testid-drift.md` (+ `daily-slowdown-verdict.md`, `issue-817-runner-sizing.md`).
+- #818 issue comment (2026-07-19) has the verdict + mapping table.
+- Non-sharded reference failing set: run `29658914382`; sharded (dev48) reference: run `29674263823`.

--- a/tests/helpers/ui/expand-focused-node.ts
+++ b/tests/helpers/ui/expand-focused-node.ts
@@ -1,0 +1,39 @@
+import { type Page, expect } from "@playwright/test";
+import { dismissOnboardingIfPresent } from "./dismiss-onboarding";
+
+// Expand the currently focused node from minimized to full view. Chat Input,
+// Chat Output and If-Else all default to `minimized = True` (see their component
+// Python sources); while minimized, the run button and the body-rendered input
+// handles are not present in the DOM. Idempotent: if the node is already expanded
+// (no `hide-node-content` in the DOM) this is a no-op, which future-proofs callers
+// against an upstream change to the `minimized` default.
+//
+// The `more-options-modal` menu can fail to render on the first click when the
+// single Langflow backend is under load — many flow-builds in one session degrade
+// it (issue #816/#817), so the menu-open is retried before failing instead of
+// timing out on `expand-button-modal`.
+export async function expandFocusedNode(page: Page): Promise<void> {
+  // The dev46 assistant-onboarding dialog opens over the flow editor on entry and
+  // its overlay steals node selection / intercepts canvas clicks, so the node
+  // toolbar (`more-options-modal`) never mounts. Dismiss it before interacting.
+  await dismissOnboardingIfPresent(page);
+
+  if ((await page.getByTestId("hide-node-content").count()) === 0) return;
+
+  // Drive open-menu → expand → settle as ONE retried unit. Under backend load the
+  // menu can fail to open OR the expand click can be dropped mid-transition; when
+  // that happens the node stays minimized (`hide-node-content` lingers), so we
+  // re-drive the whole sequence rather than retrying only the menu-open. `toPass`
+  // re-runs the body until the node has actually left the minimized state,
+  // replacing the manual attempt loop + fixed `waitForTimeout` (Playwright
+  // anti-patterns) with a web-first assertion. The onboarding dialog can reappear
+  // a beat after mount, so it is re-dismissed inside the retry.
+  await expect(async () => {
+    await dismissOnboardingIfPresent(page);
+    await page.getByTestId("more-options-modal").click({ timeout: 5000 });
+    await page.getByTestId("expand-button-modal").click({ timeout: 5000 });
+    await expect(page.getByTestId("hide-node-content")).toHaveCount(0, {
+      timeout: 5000,
+    });
+  }).toPass({ timeout: 30000 });
+}

--- a/tests/helpers/ui/open-advanced-options.ts
+++ b/tests/helpers/ui/open-advanced-options.ts
@@ -1,25 +1,19 @@
 import type { Page } from "@playwright/test";
 
-export const openAdvancedOptions = async (
-  page: Page,
-  skipEnableFields = false,
-) => {
-  if ((await page.getByTestId("edit-button-modal").count()) > 0) {
-    await page.getByTestId("edit-button-modal").click();
-  } else if (!skipEnableFields) {
-    await page.getByTestId("edit-fields-button").click();
-  }
+// The nightly (~dev46) replaced the "Controls" edit modal with a node inspector
+// side-panel. Selecting a node exposes a `parameters-button` in its toolbar that
+// opens the panel; every input renders as `inspector-param-<field>` and gains an
+// add-to-node toggle `inspector-add-<field>` (the modern equivalent of the old
+// `show<field>` toggles). The panel closes via `inspection-panel-close`.
+// Callers must select the target node before calling (unchanged contract). The
+// `parameters-button` only mounts for the currently-selected node, so it is
+// unique as long as the more-options dropdown is not open.
+export const openAdvancedOptions = async (page: Page) => {
+  await page.getByTestId("parameters-button").click();
 };
 
-export const closeAdvancedOptions = async (
-  page: Page,
-  skipEnableFields = false,
-) => {
-  if ((await page.getByTestId("edit-button-close").count()) > 0) {
-    await page.getByTestId("edit-button-close").click();
-  } else if (!skipEnableFields) {
-    await page.getByTestId("edit-fields-button").click();
-  }
+export const closeAdvancedOptions = async (page: Page) => {
+  await page.getByTestId("inspection-panel-close").click();
 };
 
 export const enableInspectPanel = async (page: Page) => {

--- a/tests/tests-automations/regression/core-components/chat-input-files-field-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/chat-input-files-field-regression.spec.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { expandFocusedNode } from "../../../helpers/ui/expand-focused-node";
 import { zoomOut } from "../../../helpers/ui/zoom-out";
 import { waitForFlowSaveSettled } from "../../../helpers/flows/wait-for-flow-save-settled";
 import {
@@ -18,23 +19,6 @@ const IMAGE_PATH = path.resolve(
   __dirname,
   "../../../assets/media/chain.png",
 );
-
-// Helper: expand the currently focused node from minimized to full view.
-// ChatInput defaults to `minimized = True` (src/lfx/src/lfx/components/input_output/chat.py);
-// without expanding, the inspector fields rendered on the node body are not in
-// the DOM. Idempotent: no-op if the node is already expanded — that future-proofs
-// the spec against an upstream change to the `minimized` default.
-async function expandFocusedNode(page: Page) {
-  if ((await page.getByTestId("hide-node-content").count()) === 0) return;
-  await page.getByTestId("more-options-modal").click();
-  await expect(page.getByTestId("expand-button-modal")).toBeVisible({
-    timeout: 10000,
-  });
-  await page.getByTestId("expand-button-modal").click();
-  await expect(page.getByTestId("hide-node-content")).toHaveCount(0, {
-    timeout: 5000,
-  });
-}
 
 // Helper: create a blank flow and add the Chat Input component to the canvas
 // in expanded (non-minimized) state.
@@ -103,7 +87,7 @@ async function connectChatInputToChatOutput(page: Page) {
 // Mirrors the `showsender_name` toggle pattern in chat-input-output-component-regression.
 async function toggleFilesFieldVisible(page: Page) {
   await openAdvancedOptions(page);
-  await page.getByTestId("showfiles").click();
+  await page.getByTestId("inspector-add-files").click();
   await closeAdvancedOptions(page);
 }
 

--- a/tests/tests-automations/regression/core-components/chat-input-output-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/chat-input-output-component-regression.spec.ts
@@ -2,6 +2,7 @@ import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { expandFocusedNode } from "../../../helpers/ui/expand-focused-node";
 import { zoomOut } from "../../../helpers/ui/zoom-out";
 import {
   closeAdvancedOptions,
@@ -11,31 +12,17 @@ import {
 // Run tests serially to avoid "flow must be unique" 400 errors from parallel autosaves
 test.describe.configure({ mode: "serial" });
 
-// Helper: expand the currently focused node from minimized to full view.
-// ChatInput / ChatOutput both default to `minimized = True` (see
-// lfx/components/input_output/chat.py); without expanding, the run button and
-// inspector fields rendered on the node body are not present in the DOM.
-// Idempotent: if the node is already expanded (no `hide-node-content` in the
-// DOM), the helper is a no-op — that future-proofs the spec against an
-// upstream change to the `minimized` default.
-async function expandFocusedNode(page: Page) {
-  if ((await page.getByTestId("hide-node-content").count()) === 0) return;
-  await page.getByTestId("more-options-modal").click();
-  await expect(page.getByTestId("expand-button-modal")).toBeVisible({
-    timeout: 10000,
-  });
-  await page.getByTestId("expand-button-modal").click();
-  // Sanity: after expanding, hide-node-content is removed from the DOM
-  await expect(page.getByTestId("hide-node-content")).toHaveCount(0, {
-    timeout: 5000,
-  });
-}
-
 // Helper: create a blank flow and add the Chat Input component to the canvas
 // in expanded (non-minimized) state.
 async function addChatInputComponent(page: Page) {
   await awaitBootstrapTest(page);
   await page.getByTestId("blank-flow").click();
+  // Wait for the sidebar to settle before typing — filling the search input
+  // immediately after the blank-flow transition can time out while the canvas
+  // is still mounting (same guard as if-else-component-regression).
+  await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
+    timeout: 15000,
+  });
   await page.getByTestId("sidebar-search-input").fill("chat input");
   await expect(page.getByTestId("input_outputChat Input")).toBeVisible({
     timeout: 30000,
@@ -258,7 +245,7 @@ test(
 
     // sender_name is advanced=True — toggle it visible via the inspector controls
     await openAdvancedOptions(page);
-    await page.getByTestId("showsender_name").click();
+    await page.getByTestId("inspector-add-sender_name").click();
     await closeAdvancedOptions(page);
 
     // Scope the sender_name field to the Chat Input node container so the
@@ -316,7 +303,7 @@ test(
     // Toggle the advanced "sender_name" field visible on Chat Input and
     // assert it contains the default "User"
     await openAdvancedOptions(page);
-    await page.getByTestId("showsender_name").click();
+    await page.getByTestId("inspector-add-sender_name").click();
     await closeAdvancedOptions(page);
 
     // Scope the field to the Chat Input node container so the assertion
@@ -334,7 +321,7 @@ test(
     // Focus the Chat Output node so the inspector targets it
     await page.getByTestId("title-Chat Output").click();
     await openAdvancedOptions(page);
-    await page.getByTestId("showsender_name").click();
+    await page.getByTestId("inspector-add-sender_name").click();
     await closeAdvancedOptions(page);
 
     // Scope each assertion to its node container — using the React Flow

--- a/tests/tests-automations/regression/core-components/if-else-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/if-else-component-regression.spec.ts
@@ -2,31 +2,12 @@ import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { expandFocusedNode } from "../../../helpers/ui/expand-focused-node";
 import {
   closeAdvancedOptions,
   openAdvancedOptions,
 } from "../../../helpers/ui/open-advanced-options";
 import { zoomOut } from "../../../helpers/ui/zoom-out";
-
-// Expand the currently focused node from minimized to full view. Chat Output
-// defaults to `minimized = True` (see lfx/components/input_output/chat_output.py);
-// without expanding, the run button and the `shownode` input handle rendered on
-// the node body are not present in the DOM. Idempotent: if the node is already
-// expanded (no `hide-node-content` in the DOM) the helper is a no-op.
-async function expandFocusedNode(page: Page): Promise<void> {
-  if ((await page.getByTestId("hide-node-content").count()) === 0) return;
-  await page.getByTestId("more-options-modal").click();
-  await expect(page.getByTestId("expand-button-modal")).toBeVisible({
-    timeout: 10000,
-  });
-  await page.getByTestId("expand-button-modal").click();
-  // Settle: confirm the node finished expanding before callers interact with the
-  // freshly-mounted body (rename inspector, `shownode` handles) — guards against
-  // a mid-transition return flaking under CI parallelism.
-  await expect(page.getByTestId("hide-node-content")).toHaveCount(0, {
-    timeout: 5000,
-  });
-}
 
 async function selectOperator(
   page: Page,
@@ -49,8 +30,10 @@ async function selectOperator(
 }
 
 async function exposeCaseSensitive(page: Page): Promise<void> {
+  // In the dev46 inspector panel the per-field "add to node" toggle is
+  // `inspector-add-<field>` (was `show<field>` — here `showcase_sensitive`).
   await openAdvancedOptions(page);
-  await page.getByTestId("showcase_sensitive").click();
+  await page.getByTestId("inspector-add-case_sensitive").click();
   await closeAdvancedOptions(page);
 }
 
@@ -123,18 +106,15 @@ async function buildIfElseRoutingFlow(page: Page): Promise<void> {
   await page.getByTestId("title-Chat Output").last().click();
   await expandFocusedNode(page);
 
-  // Rename the second Chat Output to `chatoutputfalse`
+  // Rename the second Chat Output to `chatoutputfalse`. The node-title edit flow
+  // was restructured in the nightly (~dev46): the `panel-description` hover
+  // wrapper is gone; the edit/save controls gained a `node-` prefix and the
+  // title field is now a dynamic `input-title-<currentName>` (still "Chat Output"
+  // here, since the fill hasn't landed when the testid is resolved).
   await page.getByTestId("generic-node-title-arrangement").last().click();
-  await page.getByTestId("panel-description").hover();
-  await page
-    .getByTestId("panel-description")
-    .getByTestId("edit-name-description-button")
-    .click();
-  await page.getByTestId("inspection-panel-name").fill("chatoutputfalse");
-  await page
-    .getByTestId("panel-description")
-    .getByTestId("save-name-description-button")
-    .click();
+  await page.getByTestId("node-edit-name-description-button").click();
+  await page.getByTestId("input-title-Chat Output").fill("chatoutputfalse");
+  await page.getByTestId("node-save-name-description-button").click();
 
   // Connect True → first Chat Output
   await page
@@ -301,18 +281,25 @@ test(
       await page.getByTestId("title-If-Else").click();
 
       await openAdvancedOptions(page);
-      await expect(page.getByTestId("showcase_sensitive")).toHaveCount(1);
+      // In the inspector panel each input is a `inspector-param-<field>` row;
+      // its presence is the modern signal that the field exists in the build
+      // config (was the `showcase_sensitive` show-toggle count).
+      await expect(
+        page.getByTestId("inspector-param-case_sensitive"),
+      ).toHaveCount(1);
       await closeAdvancedOptions(page);
     });
 
     await test.step("Switch to regex and assert case_sensitive toggle disappears", async () => {
       // After switching to regex, `update_build_config` removes case_sensitive
-      // from the build config — the toggle should disappear.
+      // from the build config — the inspector row should disappear.
       await selectOperator(page, "regex");
 
       await page.getByTestId("title-If-Else").click();
       await openAdvancedOptions(page);
-      await expect(page.getByTestId("showcase_sensitive")).toHaveCount(0);
+      await expect(
+        page.getByTestId("inspector-param-case_sensitive"),
+      ).toHaveCount(0);
       await closeAdvancedOptions(page);
     });
   },


### PR DESCRIPTION
**Part of #818** (Wave 3 — *Achieve one clean, non-guarded baseline daily*). Modernizes drifted `@stable` core-component specs so the daily's node-UI failures — misattributed to a product regression in #816 — are removed at the source: they were **testid drift**, not a Langflow regression.

## Problem
The nightly restructured the node interaction surface between `dev40` and `dev46`; our specs still used the old DOM:
- Node-title **rename** flow: `panel-description` hover wrapper removed; edit/save controls gained a `node-` prefix; title field is now the dynamic `input-title-<currentName>`.
- **Advanced options**: the `edit-button-modal` / `showcase_<field>` edit modal was replaced by a node **inspector side-panel**.
- The **assistant-onboarding** dialog (`assistant-onboarding-tooltip`) now overlays the editor on flow entry, stealing node selection so the `more-options-modal` toolbar fails to mount.

## Fix
- **`openAdvancedOptions` / `closeAdvancedOptions`** → inspector model: select node → `parameters-button` → panel; close via `inspection-panel-close`. Field toggles `show<field>` → `inspector-add-<field>`; presence assert → `inspector-param-<field>`.
- **Rename block** (if-else): `node-edit-name-description-button` → `input-title-<name>` → `node-save-name-description-button` (no more `panel-description` hover).
- **Extract `expandFocusedNode`** (was duplicated in 3 specs) → shared `tests/helpers/ui/expand-focused-node.ts`: dismisses the onboarding overlay and drives open-menu → expand → settle as one `expect().toPass()` unit (removes a manual retry loop + fixed `waitForTimeout`).
- Added a `sidebar-search-input` visibility gate after `blank-flow` in chat-input-output (pre-existing race).

Rejected: pinning the image / removing `@stable` / flagging upstream — the DOM changed, the features work.

## Scope note
Coverage unchanged — same behaviors, same assertions (branch routing, sender_name defaults/override, Files field, case_sensitive visibility). Only selectors/steps modernized. No `@stable` tag added or removed; `QA-CHECKLIST.md` untouched.

## Validation (local nightly `1.11.0.dev46`, `--workers=1 --retries=0`, one runner at a time)
- `if-else-component-regression` — **8/8** ✅
- `chat-input-output-component-regression` — **6/6** ✅
- `chat-input-files-field-regression` — **4/4** ✅
- typecheck ✅ · eslint 0 errors ✅ · zero `🚨 Backend Error` ✅
- Residual failures appear **only** when multiple runners share the single local backend (#816/#817/#833 saturation); CI sharding + `retries=2` absorb these.

## Not in this PR (follow-up, needs SDD spec rework)
`enable/disableInspectPanel` reference `canvas_controls_dropdown_toggle_inspector`, **removed** in dev46 (the inspection-panel on/off feature is gone) — affects `general-bugs-delete-handle-advanced-input` (@stable) + the inspect-panel family; plus the `@release` mechanical renames (filterSidebar, general-bugs-shard-3836, chatInputOutputUser-shard-0/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)