### PR TITLE
fix(core-components): migrate delete-handle spec to dev46 inspector model (#818)

### DIFF
--- a/docs/core-components/general-bugs-delete-handle-advanced-input.md
+++ b/docs/core-components/general-bugs-delete-handle-advanced-input.md
@@ -2,19 +2,27 @@
 
 **Test file:** `tests/tests-automations/regression/core-components/general-bugs-delete-handle-advanced-input.spec.ts`
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.11.x (nightly `1.11.0.dev46`)
 
 ---
 
 ## What this test validates
 
-Regression test for a bug where dynamic handles tied to **advanced fields** lingered on the canvas after the component's code was re-saved. Toggling an advanced field exposes an input handle on the node; re-saving the component code should re-evaluate the field config and drop the now-orphaned handle (and the lock icon decorating connected upstream edges).
+Regression test for a bug where dynamic handles tied to **advanced fields** lingered on the canvas after the component's code was re-saved. Adding an advanced field to the node body exposes an input handle on the node; re-saving the component code should re-evaluate the field config and drop the now-orphaned handle (along with its connected edge and the lock icon decorating it).
 
-The test exercises the **If-Else** component because it has a togglable `true_case_message` advanced field that historically left a dangling handle after the user re-saved the code. The contract under test:
+The test exercises the **If-Else** component because it has an advanced `true_case_message` field that historically left a dangling handle after the user re-saved the code. The contract under test:
 
-1. Toggling `showtrue_case_message` exposes a "Receiving input" placeholder.
-2. Connecting Chat Input → If-Else's `case true` produces a locked handle (visible in Advanced view as another "Receiving input" placeholder + a lock icon).
-3. After clicking **Check & Save** in the code modal with the default code, the advanced field config is re-evaluated and both the "Receiving input" placeholders and the lock icon are removed (`count === 0`).
+1. Adding `true_case_message` to the node body exposes the `case true` input handle.
+2. Connecting Chat Input → If-Else's `case true` produces a connected (locked) handle: the field widget switches to a read-only `Receiving input` placeholder and shows a lock icon.
+3. After clicking **Check & Save** in the code modal with the default code, the advanced field config is re-evaluated and the `case true` handle, its edge, the `Receiving input` placeholder, and the lock icon are all removed (`count === 0`).
+
+### dev46 node-inspector model (why this spec changed)
+
+The nightly (~dev46) replaced the old "Controls" edit **modal** with a node **inspector side-panel**:
+
+- The old canvas control that toggled an always-on inspect panel (`canvas_controls_dropdown_toggle_inspector`) was **removed** — the help dropdown now only holds docs / shortcuts / report-a-bug / desktop / smart-guides. There is no longer an inspect-panel on/off feature, so the spec no longer disables/re-enables it.
+- Selecting a node exposes a `parameters-button` that opens the inspector panel. Each input renders as an `inspector-param-<field>` row; advanced fields not yet on the node body gain an `inspector-add-<field>` toggle (the modern equivalent of the old `show<field>` toggle). The panel closes via `inspection-panel-close`.
+- The inspector panel **does not duplicate** the node's field widgets (the old modal did). Consequently the `Receiving input` placeholder and the lock icon now render **only once**, on the node body — the historic `toHaveCount(2)` (node + modal copy) is now `toHaveCount(1)`, and the field-state assertions no longer require the panel to be open.
 
 ---
 
@@ -28,16 +36,12 @@ The test exercises the **If-Else** component because it has a togglable `true_ca
 
 1. Bootstrap and open a blank flow.
 2. Add the **If-Else** component from the sidebar.
-3. Disable the inspect panel, open Advanced Options.
-4. Toggle `showtrue_case_message`, then close Advanced Options.
-5. Add a **Chat Input** component (drag onto canvas).
-6. Connect Chat Input's collapsed `noshownode` "Chat Message" output handle to If-Else's `case true` input handle (the node stays minimized — it is used only as a connection source).
-7. Click the If-Else title and open Advanced Options again — assert exactly 2 "Receiving input" placeholders are visible.
-8. Close Advanced Options.
-9. Click the If-Else title, open the code modal, click **Check & Save** (resaves the default code).
-10. Open Advanced Options.
-11. Assert exactly 0 "Receiving input" placeholders **and** exactly 0 `icon-lock` icons.
-12. Close Advanced Options and re-enable the inspect panel.
+3. Select the node, open the inspector (`parameters-button`), click `inspector-add-true_case_message` to add the advanced field to the node body, then close the inspector (`inspection-panel-close`).
+4. Add a **Chat Input** component (drag onto canvas).
+5. Connect Chat Input's collapsed `noshownode` "Chat Message" output handle to If-Else's `case true` input handle (the Chat Input node stays minimized — it is used only as a connection source).
+6. On the node body (no panel open) assert the connected state: the `case true` handle exists, exactly 1 `Receiving input` placeholder is visible, and exactly 1 `icon-lock` icon is visible.
+7. Click the If-Else title, open the code modal (`code-button-modal`), click **Check & Save** (`checkAndSaveBtn`) — resaves the default code.
+8. On the node body assert the handle was dropped: the `case true` handle, the `Receiving input` placeholder, and the `icon-lock` icon are all `count === 0`.
 
 ---
 
@@ -45,19 +49,22 @@ The test exercises the **If-Else** component because it has a togglable `true_ca
 
 | Step | Criterion |
 |---|---|
-| After connecting Chat Input → If-Else | Advanced view shows `toHaveCount(2)` `Receiving input` placeholders |
-| After Check & Save on code modal | Advanced view shows `toHaveCount(0)` `Receiving input` placeholders |
-| After Check & Save on code modal | Advanced view shows `toHaveCount(0)` `icon-lock` icons |
+| After adding `true_case_message` to the node body | `handle-conditionalrouter-shownode-case true-left` exists (`toHaveCount(1)`) |
+| After connecting Chat Input → If-Else `case true` | node body shows `toHaveCount(1)` `Receiving input` placeholder **and** `toHaveCount(1)` `icon-lock` |
+| After Check & Save on code modal | `handle-conditionalrouter-shownode-case true-left` is gone (`toHaveCount(0)`) |
+| After Check & Save on code modal | node body shows `toHaveCount(0)` `Receiving input` placeholders **and** `toHaveCount(0)` `icon-lock` icons |
+
+The handle-presence assertion (`case true-left` 1 → 0) is the primary, most direct observable of the bug — the placeholder/lock counts corroborate it.
 
 ---
 
 ## External dependencies
 
-- `src/backend/base/langflow/components/logic/conditional_router.py` — If-Else component. The `true_case_message` advanced field and its `show` toggle must exist for step 4 to find `showtrue_case_message` test ID.
-- `src/frontend/src/CustomNodes/GenericNode/components/parameterRenderComponent/index.tsx` — emits the `Receiving input` placeholder for unconnected handles.
-- `src/frontend/src/modals/codeAreaModal/index.tsx` — Check & Save flow. The post-save handle cleanup happens here (or in the store that handles the resulting reducer call).
+- `src/backend/base/langflow/components/logic/conditional_router.py` — If-Else component. The `true_case_message` advanced field must exist as an addable inspector field for step 3 to find `inspector-add-true_case_message`.
+- `src/frontend/src/CustomNodes/GenericNode/components/parameterRenderComponent/index.tsx` — emits the `Receiving input` placeholder for connected handles and the field widget on the node body.
+- `src/frontend/src/modals/codeAreaModal/index.tsx` — Check & Save flow. The post-save handle cleanup happens here (or in the store reducer it triggers).
 - `src/frontend/src/components/genericIconComponent/index.tsx` — emits the `icon-lock` test ID consumed by the spec.
-- `tests/helpers/ui/open-advanced-options.ts` — `openAdvancedOptions`, `closeAdvancedOptions`, `enableInspectPanel`, `disableInspectPanel`. Renaming these helpers breaks the spec.
+- `tests/helpers/ui/open-advanced-options.ts` — `openAdvancedOptions` (opens the inspector via `parameters-button`), `closeAdvancedOptions` (`inspection-panel-close`). Renaming these helpers breaks the spec. The `enableInspectPanel` / `disableInspectPanel` helpers are **no longer used** by this spec (the inspect-panel toggle feature was removed in dev46).
 
 ---
 
@@ -78,7 +85,6 @@ The test exercises the **If-Else** component because it has a togglable `true_ca
 
 ## Notes
 
-- Refactored from `waitForSelector` (with one 100 s timeout) to `expect().toBeVisible(...)` and `toHaveCount`. The first appearance check after canvas bootstrap uses a 30 s timeout (`canvas_controls_dropdown` settles slower on cold workers); subsequent sidebar visibility checks use 10 s.
-- Replaced `.hover().then(...)` chain with sequential awaits.
-- Stability: 3 / 3 PASS across consecutive runs (~10–12 s each).
-- Force-fail probe on the post-save `toHaveCount(0)` assertion confirms the test catches real regressions.
+- Migrated to the dev46 node-inspector model (issue #818): removed the `disableInspectPanel` / `enableInspectPanel` calls (feature removed upstream), swapped `showtrue_case_message` → `inspector-add-true_case_message`, and moved the field-state assertions to the node body (no modal duplication). `Receiving input` / `icon-lock` counts dropped from 2 → 1. Added the `case true` handle-presence assertion as the primary observable.
+- Live-scouted against `1.11.0.dev46` (2026-07-19): field add → handle appears; connect → `Receiving input` = 1, `icon-lock` = 1; Check & Save → handle, placeholder, lock, and edge all removed.
+- Flow cleanup: id-scoped `afterEach` deletes every flow this spec's page created (POST `/api/v1/flows` → 201), per repo convention (#490/#681).

--- a/tests/tests-automations/regression/core-components/general-bugs-delete-handle-advanced-input.spec.ts
+++ b/tests/tests-automations/regression/core-components/general-bugs-delete-handle-advanced-input.spec.ts
@@ -4,8 +4,6 @@ import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import {
   closeAdvancedOptions,
-  disableInspectPanel,
-  enableInspectPanel,
   openAdvancedOptions,
 } from "../../../helpers/ui/open-advanced-options";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
@@ -66,11 +64,14 @@ test(
 
     await adjustScreenView(page, { numberOfZoomOut: 3 });
 
-    await disableInspectPanel(page);
-
+    // dev46 node-inspector model: select the node, open the inspector panel
+    // (parameters-button), and add the advanced `true_case_message` field to the
+    // node body via `inspector-add-<field>` (the modern equivalent of the old
+    // `show<field>` toggle). The inspect-panel on/off feature was removed
+    // upstream, so there is nothing to disable/re-enable anymore.
+    await page.getByTestId("title-If-Else").click();
     await openAdvancedOptions(page);
-
-    await page.getByTestId("showtrue_case_message").click();
+    await page.getByTestId("inspector-add-true_case_message").click();
     await closeAdvancedOptions(page);
 
     await page.getByTestId("sidebar-search-input").click();
@@ -97,27 +98,29 @@ test(
       .getByTestId("handle-conditionalrouter-shownode-case true-left")
       .click();
 
-    await page.getByTestId("title-If-Else").click();
+    // Connected state, read directly off the node body (the dev46 inspector
+    // panel does not duplicate field widgets): the case-true handle exists, its
+    // field widget shows one read-only "Receiving input" placeholder, and one
+    // lock icon decorates the connected edge.
+    await expect(
+      page.getByTestId("handle-conditionalrouter-shownode-case true-left"),
+    ).toHaveCount(1);
+    await expect(page.getByPlaceholder("Receiving input")).toHaveCount(1);
+    await expect(page.getByTestId("icon-lock")).toHaveCount(1);
 
-    await openAdvancedOptions(page);
-
-    await expect(page.getByPlaceholder("Receiving input")).toHaveCount(2);
-
-    await closeAdvancedOptions(page);
-
+    // Re-save the component's default code; the advanced field config is
+    // re-evaluated and the now-orphaned handle (with its edge, placeholder, and
+    // lock icon) is dropped.
     await page.getByTestId("title-If-Else").click();
 
     await page.getByTestId("code-button-modal").last().click();
 
     await page.getByTestId("checkAndSaveBtn").last().click();
 
-    await openAdvancedOptions(page);
-
+    await expect(
+      page.getByTestId("handle-conditionalrouter-shownode-case true-left"),
+    ).toHaveCount(0);
     await expect(page.getByPlaceholder("Receiving input")).toHaveCount(0);
     await expect(page.getByTestId("icon-lock")).toHaveCount(0);
-
-    await closeAdvancedOptions(page);
-
-    await enableInspectPanel(page);
   },
 );


### PR DESCRIPTION
Part of #818 — daily-failure cluster, testid drift on dev46 (follow-up to merged #837).

## Problem

The `@stable` `general-bugs-delete-handle-advanced-input` spec broke on the daily against `langflowai/langflow-nightly:latest` (dev46). Root cause is **testid drift, not a product regression** — the dev46 nightly:

1. **Removed** the inspect-panel on/off toggle (`canvas_controls_dropdown_toggle_inspector`); the help dropdown now only holds docs / shortcuts / report-a-bug / desktop / smart-guides.
2. **Replaced** the "Controls" edit modal with a node **inspector side-panel** (`parameters-button` → `inspector-param-<field>` rows, `inspector-add-<field>` toggles, `inspection-panel-close`).

Live-scouted on `1.11.0.dev46`: the underlying bug the spec guards — advanced-field handles lingering after a component code re-save — **still reproduces correctly**.

## Changes

- Drop `enableInspectPanel` / `disableInspectPanel` calls (feature removed upstream, no replacement).
- `showtrue_case_message` → `inspector-add-true_case_message` (add the advanced field to the node body via the inspector panel).
- Move field-state assertions to the **node body** — the new side-panel does not duplicate field widgets, so `Receiving input` / `icon-lock` drop from `count(2)` (node + old modal copy) to `count(1)`.
- Add the `case true` **handle-presence** assertion (`count 1 → 0`) as the primary, most direct observable of the handle deletion.
- Rework the spec doc for the dev46 inspector model.

The `enableInspectPanel` / `disableInspectPanel` helpers are left in `open-advanced-options.ts` for now — 5 other (also-broken) callers remain and will be migrated in follow-up work on this cluster.

## Validation (1.11.0.dev46, one runner on a local backend)

- **3/3 green** — `--workers=1 --retries=0`, ~50s each.
- `npm run typecheck` + `npm run lint` — 0 errors.
- 0 orphan flows (id-scoped `afterEach` cleanup verified via `GET /api/v1/flows/`).
- **Force-fail (behavioral, executed):**
  - Neutralize `checkAndSaveBtn` click → handle survives → post-save deletion asserts FAIL.
  - Neutralize the connect click → placeholder/lock never appear → connected-state asserts FAIL.
  - (A `toHaveCount(0)→(1)` flip was rejected — it passes on a transient because the retrying assertion catches the handle before removal; hence the behavioral FF.)

```bash
npx playwright test tests/tests-automations/regression/core-components/general-bugs-delete-handle-advanced-input.spec.ts --workers=1 --retries=0
```

Part of #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)