### PR TITLE
test(flow-functionality): migrate image-upload specs to dev46 inspector model (#818)

### DIFF
--- a/docs/core-functionality/llm-agents/chatInputOutputUser-shard-0.md
+++ b/docs/core-functionality/llm-agents/chatInputOutputUser-shard-0.md
@@ -1,0 +1,78 @@
+# Spec: Send an Image on Chat via the Playground File Upload
+
+**Test file:** `tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-0.spec.ts`
+
+**Last validated:** Langflow 1.11.x (nightly `1.11.0.dev46`)
+
+---
+
+## What this test validates
+
+End-to-end image-upload path through the **Playground** chat: with a Basic Prompting flow loaded, the user opens the Playground, uploads an image via the chat file input, sends it, and confirms the image renders in the chat messages.
+
+The contract under test:
+
+1. The Chat Input inspector panel opens and closes cleanly (dev46 node-inspector model) without disturbing the flow.
+2. The Playground exposes a file input that accepts an image (`chain.png`) and shows its preview before sending.
+3. After sending, the uploaded image renders in the chat messages (`img[alt$="chain.png"]` — the server prefixes the filename with a timestamp).
+
+---
+
+## Tags
+
+`@release` `@workspace` `@components`
+
+---
+
+## Step by step
+
+1. Bootstrap; open the **Basic Prompting** starter template and wait for the canvas controls.
+2. Run `initialGPTsetup` (configures the OpenAI provider/model).
+3. Select the **Chat Input** node, open the inspector panel (`parameters-button`) and close it (`inspection-panel-close`) — verifies the dev46 inspector opens/closes without breaking the flow.
+4. Open the Playground and wait for the chat input.
+5. Upload `chain.png` via the hidden file input; wait for the `img[alt="chain.png"]` preview.
+6. Click **Send**.
+7. Assert the image (`img[alt$="chain.png"]`) is visible in the chat messages.
+
+---
+
+## Validation criterion
+
+| Step | Criterion |
+|---|---|
+| After opening/closing the inspector | The Playground opens and the chat file input is available |
+| After uploading the image | `img[alt="chain.png"]` preview is visible before sending |
+| After sending | `img[alt$="chain.png"]` is visible in the chat messages |
+
+---
+
+## External dependencies
+
+- **OpenAI** — `test.skip` when `OPENAI_API_KEY` is absent. Runs the Basic Prompting flow through an OpenAI model (`initialGPTsetup`).
+- `tests/assets/media/chain.png` — the uploaded test image.
+- `tests/helpers/ui/open-advanced-options.ts` — `openAdvancedOptions` / `closeAdvancedOptions` (the dev46 inspector panel via `parameters-button` / `inspection-panel-close`).
+- `tests/helpers/other/initialGPTsetup.ts` — provider/model setup on the template.
+- `tests/helpers/filesystem/resolve-asset-path.ts` — resolves the image path.
+
+---
+
+## What this test does not cover
+
+- Non-image uploads.
+- The model's actual answer content (only that the uploaded image renders).
+- Providers other than OpenAI.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- `OPENAI_API_KEY` set (otherwise the test skips).
+
+---
+
+## Notes
+
+- No testid rename was needed for issue #818 — the spec only calls `openAdvancedOptions` / `closeAdvancedOptions`, which the shared helper already migrated to the dev46 inspector model. This spec is verified green on dev46 to confirm the migrated helper works here.
+- Added id-scoped `afterEach` flow cleanup (POST `/api/v1/flows` → 201 tracking), per repo convention (#490/#681) — the spec builds a flow from the Basic Prompting template.
+- Validated on `1.11.0.dev46` (2026-07-19): 1 passed (~1.4m), `--workers=1 --retries=0`, 0 orphan flows.

--- a/docs/flow-functionality/general-bugs-shard-3836.md
+++ b/docs/flow-functionality/general-bugs-shard-3836.md
@@ -1,0 +1,83 @@
+# Spec: Send an Image on Chat via the Chat Input Advanced `files` Field
+
+**Test file:** `tests/tests-automations/regression/flow-functionality/general-bugs-shard-3836.spec.ts`
+
+**Last validated:** Langflow 1.11.x (nightly `1.11.0.dev46`)
+
+---
+
+## What this test validates
+
+Regression test covering the end-to-end image-upload path through the **Chat Input** component's advanced `files` field. The user adds the advanced `files` input to the Chat Input node, uploads an image, removes and re-uploads it, runs the flow, and confirms the image and the user message render in the Playground.
+
+The contract under test:
+
+1. The advanced `files` field can be added to the Chat Input node body from the node inspector.
+2. An uploaded file (`chain.png`) shows on the upload button and can be removed (hovering reveals the `icon-X`, clicking removes it — the filename disappears).
+3. After re-uploading and running the flow, the Playground shows the uploaded image (`img[alt$="chain.png"]`) and the user message (`chat-message-User-<question>`).
+
+### dev46 node-inspector model
+
+The dev46 nightly replaced the old "Controls" edit modal with a node inspector side-panel: `openAdvancedOptions` opens it via `parameters-button`, and the advanced `files` field is added to the node body with `inspector-add-files` (the modern equivalent of the old `showfiles` toggle). `closeAdvancedOptions` closes it via `inspection-panel-close`.
+
+---
+
+## Tags
+
+`@release` `@components`
+
+---
+
+## Step by step
+
+1. Bootstrap; open the **Basic Prompting** starter template and run `initialGPTsetup` (configures the OpenAI provider/model).
+2. Select the **Chat Input** node, open the inspector, click `inspector-add-files` to add the advanced `files` field to the node body, then close the inspector.
+3. Fill the chat input text with the question `"What is this image?"`.
+4. Upload `chain.png`; hover the upload button, assert the `icon-X` is fully opaque, click it, and assert the filename is no longer visible (removal works).
+5. Re-upload `chain.png`.
+6. Run the Chat Output component and open the Playground.
+7. Assert the uploaded image (`img[alt$="chain.png"]`) is visible and the user message (`chat-message-User-What is this image?`) is present.
+
+---
+
+## Validation criterion
+
+| Step | Criterion |
+|---|---|
+| After adding `files` to the node body | The Chat Input file upload widget is available (upload succeeds) |
+| After removing the uploaded file | `chain.png` text is no longer visible |
+| After running the flow | Playground shows `img[alt$="chain.png"]` visible |
+| After running the flow | `chat-message-User-What is this image?` is present |
+
+---
+
+## External dependencies
+
+- **OpenAI** — `test.skip` when `OPENAI_API_KEY` is absent. Runs the Basic Prompting flow through an OpenAI model (`initialGPTsetup`).
+- `src/backend/base/langflow/components/input_output/chat.py` — Chat Input component; the advanced `files` field must exist as an addable inspector field for step 2 to find `inspector-add-files`.
+- `tests/assets/media/chain.png` — the uploaded test image.
+- `tests/helpers/ui/open-advanced-options.ts` — `openAdvancedOptions` / `closeAdvancedOptions` (the inspector panel).
+- `tests/helpers/other/initialGPTsetup.ts` — provider/model setup on the template.
+
+---
+
+## What this test does not cover
+
+- Non-image file uploads.
+- The multimodal model's actual answer content (only that the image + user message render).
+- Providers other than OpenAI.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- `OPENAI_API_KEY` set (otherwise the test skips).
+
+---
+
+## Notes
+
+- Migrated to the dev46 node-inspector model (issue #818): swapped `showfiles` → `inspector-add-files`.
+- Added id-scoped `afterEach` flow cleanup (POST `/api/v1/flows` → 201 tracking), per repo convention (#490/#681) — the spec builds a flow from the Basic Prompting template.
+- Validated on `1.11.0.dev46` (2026-07-19): 1 passed (~24s), `--workers=1 --retries=0`, 0 orphan flows.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-0.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-0.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from "@playwright/test";
 import * as dotenv from "dotenv";
 import path from "path";
 import { expect, test } from "../../../../fixtures/fixtures";
@@ -8,6 +9,39 @@ import {
   closeAdvancedOptions,
   openAdvancedOptions,
 } from "../../../../helpers/ui/open-advanced-options";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+
+// Capture every flow THIS page creates from its POST /api/v1/flows → 201
+// responses and delete them id-scoped in afterEach (repo convention, #490/#681).
+const createdFlowIds: string[] = [];
+
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {});
+    }
+  });
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, {
+      headers: { Authorization: bearer },
+    }).catch(() => {});
+  }
+});
 
 test(
   "user must be able to send an image on chat",
@@ -22,6 +56,7 @@ test(
       dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
     }
 
+    trackCreatedFlows(page);
     await awaitBootstrapTest(page);
 
     await page.getByTestId("side_nav_options_all-templates").click();

--- a/tests/tests-automations/regression/flow-functionality/general-bugs-shard-3836.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/general-bugs-shard-3836.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from "@playwright/test";
 import * as dotenv from "dotenv";
 import path from "path";
 import { expect, test } from "../../../fixtures/fixtures";
@@ -8,6 +9,39 @@ import {
   closeAdvancedOptions,
   openAdvancedOptions,
 } from "../../../helpers/ui/open-advanced-options";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+
+// Capture every flow THIS page creates from its POST /api/v1/flows → 201
+// responses and delete them id-scoped in afterEach (repo convention, #490/#681).
+const createdFlowIds: string[] = [];
+
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {});
+    }
+  });
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, {
+      headers: { Authorization: bearer },
+    }).catch(() => {});
+  }
+});
 
 test(
   "user must be able to send an image on chat using advanced tool on ChatInputComponent",
@@ -22,6 +56,7 @@ test(
       dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
     }
 
+    trackCreatedFlows(page);
     await awaitBootstrapTest(page);
 
     await page.getByTestId("side_nav_options_all-templates").click();
@@ -32,7 +67,7 @@ test(
 
     await page.getByText("Chat Input", { exact: true }).click();
     await openAdvancedOptions(page);
-    await page.getByTestId("showfiles").click();
+    await page.getByTestId("inspector-add-files").click();
     await closeAdvancedOptions(page);
     const userQuestion = "What is this image?";
     await page.getByTestId("textarea_str_input_value").fill(userQuestion);


### PR DESCRIPTION
Part of #818 — daily-failure cluster, dev46 testid drift (@release Tier A). Follow-up to merged #837 / #838.

## Problem

The dev46 nightly replaced the "Controls" edit modal with a node **inspector side-panel**. Adding an advanced field to the node body moved from the old `show<field>` toggle to `inspector-add-<field>` (live-scouted on `1.11.0.dev46`: `showfiles` → `inspector-add-files`).

## Changes

- **`general-bugs-shard-3836`** — swap `showfiles` → `inspector-add-files` (Chat Input advanced `files` field).
- **`chatInputOutputUser-shard-0`** — **no rename needed**: it only calls `openAdvancedOptions` / `closeAdvancedOptions`, which the shared `open-advanced-options.ts` helper already migrated (in #837). Verified green on dev46 to confirm the migrated helper works here.
- **Both** — add id-scoped `afterEach` flow cleanup (POST `/api/v1/flows` → 201 tracking). They build a flow from the Basic Prompting template and had **no** cleanup, leaking orphans (repo convention #490/#681).
- Add the missing spec docs for both.

`filterSidebar` (also drifted on `showheaders`) is **not** included: beyond the mechanical rename it has a second, behavioral drift (`processingData Operations` is no longer visible in the beta-filtered sidebar after connecting from the API Request `headers` input handle). That needs dedicated investigation and will be handled separately.

## Validation (1.11.0.dev46, one runner on a local backend, OpenAI active)

- `general-bugs-shard-3836`: **2/2 green** (~1.1m).
- `chatInputOutputUser-shard-0`: **green** (~53s).
- 0 orphan flows (verified via `GET /api/v1/flows/` after the runs — cleanup works).
- `npm run typecheck` + `npm run lint` — 0 errors.
- **Force-fail:** the pre-fix run of `shard-3836` fails at the old `showfiles` testid (old code is the mutation), proving the renamed assertion is falsifiable. `shard-0` has no rename (verifies the already-migrated helper).

```bash
npx playwright test tests/tests-automations/regression/flow-functionality/general-bugs-shard-3836.spec.ts --workers=1 --retries=0
npx playwright test tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-0.spec.ts --workers=1 --retries=0
```

Part of #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)