### PR TITLE
fix(core-components): migrate api-request spec to dev46 inspector model (#818)

### DIFF
--- a/docs/core-components/api-request-component-regression.md
+++ b/docs/core-components/api-request-component-regression.md
@@ -1,6 +1,6 @@
 # API Request Component — Rendering, Inspector, HTTP Methods, cURL Mode and Error Paths
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.11.x (nightly `1.11.0.dev46`)
 
 ---
 
@@ -61,6 +61,10 @@ For each of GET, POST, PUT, PATCH, DELETE:
 - Fills `https://postman-echo.com/get?e2e_param=functional_test_value`, runs, asserts the parameter key/value appear in the parsed response and the response status is `200`.
 
 ### 11. `inspector headers table accepts key + value cell entries`
+- dev46: `headers` is an advanced field, so it is added to the node body first
+  via the inspector (`addTableFieldToBody(page, "headers")`: select node →
+  `parameters-button` → `inspector-add-headers` → `inspection-panel-close`). The
+  `div-table_headers` widget then renders on the node body.
 - Opens `div-table_headers` → `Open table` button → table dialog opens.
 - Adds a row, then fills BOTH the `[col-id="key"]` cell with `X-E2E-Header` and the `[col-id="value"]` cell with `test-header-value` via the `fillViewTextCell` helper. The helper asserts each cell value renders as a button inside the table dialog after Save (this is the in-session validation; the test does not assert table-modal-level persistence — see "What this test does not cover").
 - Closes the dialog with `btn-cancel-modal` and asserts canvas integrity.
@@ -75,7 +79,7 @@ For each of GET, POST, PUT, PATCH, DELETE:
 - Runs the component and asserts the output Data contains `200`, the echoed URL, and the structural keys.
 
 ### 14. `body table accepts key + value cell entries when method is POST`
-- The body field is marked `advanced=True` AND the InspectionPanel has a hardcoded filter that hides `body` whenever `method.value === "GET"` (see `InspectionPanelFields.tsx` lines 58-60 and 92-94 — the filter is keyed off `data.type === "APIRequest"` + field name `"body"`). The test switches the method dropdown to `POST` first so the body table renders in the inspector. **Note:** there is no "Show Advanced" or `edit-button-modal` step — the inspector exposes the body table directly once method is POST.
+- The body field is marked `advanced=True` AND is hidden whenever `method.value === "GET"`. The test switches the method dropdown to `POST` first so `body` becomes available in the inspector. dev46: `body` is then added to the node body via `addTableFieldToBody(page, "body")` (select node → `parameters-button` → `inspector-add-body` → `inspection-panel-close`), which makes the `div-table_body` widget render on the node body.
 - The method switch triggers a `real_time_refresh` round-trip (`POST /api/v1/custom_component/update`). The test waits for that response BEFORE opening the body table so the `[value]` useEffect in `TableNodeComponent` finishes resetting `tempValue`. Without this wait, a click on `add-row-button` can land during the reset window and the new row is immediately wiped.
 - Finds `div-table_body`, clicks `Open table`, adds a row, then fills BOTH the `[col-id="key"]` cell with `payload` and the `[col-id="value"]` cell with `e2e-body-value` via the `fillViewTextCell` helper. The helper asserts each cell value renders as a button INSIDE that specific cell after Save (cell-scoped — not dialog-wide).
 - Closes the dialog with `btn-cancel-modal` — this test asserts in-session edit behavior only. End-to-end body persistence through reload is intentionally NOT covered (see "What this test does not cover").
@@ -85,7 +89,7 @@ For each of GET, POST, PUT, PATCH, DELETE:
 - Like test 14, waits for the `POST /api/v1/custom_component/update` response after the method switch so the headers `[value]` useEffect settles before adding a new row.
 - Clicks the dialog-level **Save** button (not Cancel, which discards `tempValue` via `handleCancel` in `TableNodeComponent`) so the row commits before autosave fires.
 - Polls `GET /api/v1/flows/{id}` (using `page.request` which inherits the session cookie) until the autosave has written the URL, method and matching header row into the saved flow JSON. Polling the API directly proves the autosave reached the database — not just in-memory React state. The match key is `node.data.type === "APIRequest"` (Python class name, not the `"API Request"` display name).
-- Reloads the page and re-asserts: URL field still holds the saved URL, method dropdown still reads `POST`, and reopening the headers table (after clicking the canvas node and toggling `canvas_controls_toggle_inspector` if needed) still shows the saved key/value buttons. The reload check covers UI rehydration end-to-end.
+- Reloads the page and re-asserts: URL field still holds the saved URL, method dropdown still reads `POST`, and reopening the headers table still shows the saved key/value buttons. dev46: the headers field added to the node body in step 1 persists across the reload, so `div-table_headers` renders directly (no inspector re-open needed); the test just clicks the canvas node to focus it. The reload check covers UI rehydration end-to-end.
 
 ---
 
@@ -100,7 +104,7 @@ The suite must:
 - For each verb test, hit an endpoint that returns a non-2xx for any other verb (postman-echo returns `404`; httpbin returned `405`) — this guarantees the test fails if the wrong verb is sent (e.g. POST sent as GET), because the assertion requires `200`.
 - For the cURL execution test, switch to the cURL tab *before* configuring the URL — and assert the parser auto-populates `url_input`. Asserting only the run output would let the test pass even if cURL parsing was broken.
 - For the headers and body table tests, fill both KEY and VALUE cells (not key only) — filling only the key cell would still pass even if the value column was non-functional or rejected entries.
-- For the body table test, switch method to POST before searching for `div-table_body` — the `InspectionPanelFields` filter hides `body` while method is GET. (There is no Controls-modal / `edit-button-modal` step — the field renders directly in the inspector once method is POST.)
+- For the body table test, switch method to POST before searching for `div-table_body` — `body` is hidden while method is GET. dev46: after the switch, add `body` to the node body via the inspector (`inspector-add-body`) so the `div-table_body` widget renders — an advanced field is not on the node body until added.
 - For tests 14 and 15, wait for the `POST /api/v1/custom_component/update` response after the method switch so the `[value]` useEffect in `TableNodeComponent` settles before adding a row. Without the wait, `add-row-button` can race the refresh that re-pushes the table's `value` (the freshly-added row is wiped by the useEffect reset).
 - `fillViewTextCell`'s post-Save assertion is **cell-scoped** (`cellLocator.getByRole("button", { name: value })`) — a dialog-wide match would pass even if the value landed on the wrong row.
 - For the persistence test, poll `GET /api/v1/flows/{id}` directly through `page.request` and *also* reload the page to verify the UI rehydrates URL, method AND the saved header row via the reopened table. Verifying only the in-memory state would let the test pass even if autosave was broken.
@@ -156,6 +160,16 @@ The suite must:
 
 ## Notes *(optional)*
 
+- **dev46 inspector migration (issue #818).** The nightly removed the always-on
+  inspect-panel toggle (`canvas_controls_dropdown_toggle_inspector`) and made the
+  `headers` / `body` table fields **advanced** — their `div-table_<field>` widget
+  is no longer on the node body by default. The `addTableFieldToBody` helper now
+  adds the field via the inspector (select node → `parameters-button` →
+  `inspector-add-<field>` → `inspection-panel-close`) before tests 11, 14 and 15
+  touch the table; the add persists across the reload in test 15, so the old
+  `enableInspectPanel` re-open step there was dropped. Also added id-scoped
+  `afterEach` flow cleanup (the 15-test serial file previously had none).
+  Re-validated on `1.11.0.dev46`.
 - **Duplicate coverage with legacy specs.** `tests/tests-automations/regression/api/flows/api-request-component-ui.spec.ts` (4 tests: canvas render, URL field, method dropdown, headers field) is fully superseded by tests 1, 2, and 11 of this spec — its 4th test uses anti-patterns (`.catch(() => false)`, conditional advanced-button click) that this consolidated spec replaces with deterministic locators. `tests/tests-automations/regression/api/flows/api-component-regression.spec.ts` (5 tests: GET, cURL POST + JSON body with auto-fill URL, `include_httpx_metadata`, timeout 500, URL-mode POST via dropdown) is partially duplicated by tests 4, 5, and 13 here, but contains 3 unique tests (`include_httpx_metadata`, timeout, cURL POST + body). A follow-up PR should migrate those 3 unique tests here and retire both legacy specs.
 - **`(page as any).allowFlowErrors()` cast.** The fixture injects `allowFlowErrors` onto the page object via `(page as any).allowFlowErrors = () => {...}`, without extending the `Page` type. Removing the cast at the call site requires extending the type signature in `fixtures.ts`. The pattern is project-wide (`loop-component-regression.spec.ts` uses the same cast).
 - **Why one verb per endpoint.** `/get`, `/post`, `/put`, `/patch`, `/delete` each reject any other verb with a non-2xx (`404` on postman-echo, `405` on httpbin/go-httpbin). Since the verb tests assert the output contains `200`, the test fails if the component sends the wrong method — there's no way to silently pass with a misconfigured verb.

--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -2,10 +2,46 @@ import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
-import { enableInspectPanel } from "../../../helpers/ui/open-advanced-options";
+import {
+  closeAdvancedOptions,
+  openAdvancedOptions,
+} from "../../../helpers/ui/open-advanced-options";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
 
 // Run tests serially to avoid "flow must be unique" 400 errors from parallel autosaves
 test.describe.configure({ mode: "serial" });
+
+// Capture every flow each test's page creates from its POST /api/v1/flows → 201
+// responses and delete them id-scoped in afterEach (repo convention, #490/#681).
+const createdFlowIds: string[] = [];
+
+test.beforeEach(({ page }) => {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {});
+    }
+  });
+});
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, {
+      headers: { Authorization: bearer },
+    }).catch(() => {});
+  }
+});
 
 // Echo endpoint base for the HTTP-execution tests. Defaults to postman-echo.com.
 //
@@ -43,8 +79,21 @@ const ECHO_BASE = (
 ).replace(/\/$/, "");
 const ECHO_HOST = new URL(ECHO_BASE).host;
 
+// dev46: headers / body are advanced fields, so their table widget
+// (`div-table_<field>`) is not on the node body by default. Select the node,
+// open the inspector (parameters-button), toggle `inspector-add-<field>` to add
+// the field to the node body, then close the inspector — the table then renders
+// on the node body. `body` only appears in the inspector once the method is a
+// verb that carries a payload (e.g. POST), so switch the method first for it.
+async function addTableFieldToBody(page: Page, field: "headers" | "body") {
+  await page.getByTestId("title-API Request").click();
+  await openAdvancedOptions(page);
+  await page.getByTestId(`inspector-add-${field}`).click();
+  await closeAdvancedOptions(page);
+}
+
 // Helper: create a blank flow and add the API Request component to the canvas.
-// After this call the component node is visible and its inspector is open.
+// After this call the component node is visible on the canvas.
 async function addApiRequestComponent(page: Page) {
   await awaitBootstrapTest(page);
   await page.getByTestId("blank-flow").click();
@@ -564,6 +613,8 @@ test(
   async ({ page }) => {
     await addApiRequestComponent(page);
 
+    await addTableFieldToBody(page, "headers");
+
     const headersDiv = page.getByTestId("div-table_headers");
     await expect(headersDiv).toBeVisible({ timeout: 10000 });
     await headersDiv.getByRole("button", { name: "Open table" }).click();
@@ -648,13 +699,28 @@ test(
     const curlTextarea = page.getByTestId("textarea_str_curl_input");
     await expect(curlTextarea).toBeVisible({ timeout: 10000 });
 
+    // Filling the cURL command triggers the parser, which re-renders the
+    // component template via `POST /api/v1/custom_component/update`. Wait for that
+    // round-trip so the parsed URL has been written into the field state before we
+    // read it — otherwise switching tabs races the parse and the URL input mounts
+    // empty.
+    const curlRefresh = page.waitForResponse(
+      (r) =>
+        r.url().includes("/api/v1/custom_component/update") &&
+        r.request().method() === "POST",
+      { timeout: 15000 },
+    );
     await curlTextarea.fill(
       `curl -X GET ${ECHO_BASE}/get -H 'Accept: application/json'`,
     );
+    await curlRefresh;
 
-    // The cURL parser must auto-populate url_input with the URL extracted from the command.
-    // Asserting this directly proves the parser ran and is the precondition the run relies on
-    // (without it the backend would receive an empty URL and validation would fail).
+    // The cURL parser must auto-populate url_input with the URL extracted from the
+    // command. dev46 unmounts the URL-tab input while the cURL tab is active, so
+    // switch to the URL tab to observe the parsed value — this still proves the
+    // parser ran (the cURL fill above is what populated it). Asserting it directly
+    // is the precondition the run relies on (an empty URL would fail validation).
+    await page.getByTestId("tab_0_url").click();
     await page.waitForFunction(
       (expectedUrl) => {
         const el = document.getElementById(
@@ -665,6 +731,9 @@ test(
       `${ECHO_BASE}/get`,
       { timeout: 10000 },
     );
+
+    // Switch back to the cURL tab so the run exercises the cURL-mode path.
+    await page.getByTestId("tab_1_curl").click();
 
     const output = await runAndOpenOutput(page);
 
@@ -704,6 +773,10 @@ test(
     await expect(
       page.getByTestId("value-dropdown-dropdown_str_method"),
     ).toHaveText("POST");
+
+    // Body only appears in the inspector once the method is POST — add it to the
+    // node body now so its table widget renders.
+    await addTableFieldToBody(page, "body");
 
     const bodyDiv = page.getByTestId("div-table_body");
     await expect(bodyDiv).toBeVisible({ timeout: 10000 });
@@ -791,6 +864,10 @@ test(
       await expect(
         page.getByTestId("value-dropdown-dropdown_str_method"),
       ).toHaveText("POST");
+
+      // dev46: headers is an advanced field — add it to the node body so its
+      // table widget renders (it also persists across the reload in step 3).
+      await addTableFieldToBody(page, "headers");
 
       const headersDiv = page.getByTestId("div-table_headers");
       await expect(headersDiv).toBeVisible({ timeout: 10000 });
@@ -903,12 +980,11 @@ test(
           page.getByTestId("value-dropdown-dropdown_str_method"),
         ).toHaveText("POST");
 
-        // After reload, the InspectionPanel may not be auto-open and the node
-        // is not selected. Select the node, then use the existing helper to
-        // open the panel idempotently (the helper no-ops if already open),
-        // so `div-table_headers` renders.
+        // After reload the headers field stays on the node body (it was added
+        // there in step 1 and the add persisted), so `div-table_headers` renders
+        // directly — no inspector action needed. Select the node first so the
+        // canvas is focused on it.
         await page.locator(".react-flow__node").first().click();
-        await enableInspectPanel(page);
 
         // Reopen the headers table — same locator pattern as test 11. Asserting
         // the saved key + value render as buttons inside the dialog confirms


### PR DESCRIPTION
Part of #818 — daily-failure cluster, dev46 testid drift. Follow-up to merged #837 / #838 / #839 / #840.

## Problem

`api-request-component-regression` (15 `@stable` tests) had **two independent dev46 drifts**:

1. **Inspector table fields.** The nightly made `headers` and `body` advanced fields — their table widget (`div-table_<field>`) is no longer on the node body by default; it only renders after the field is added to the body via the inspector.
2. **cURL tab.** dev46 unmounts the URL-tab input (`popover-anchor-input-url_input`) while the cURL tab is active, so the parser-auto-fill check (`getElementById` on `url_input`) never found the element and timed out.

## Changes

- Add helper **`addTableFieldToBody(page, field)`** — select node → `parameters-button` → `inspector-add-<field>` → `inspection-panel-close`. Used in the headers (test 11), body (test 14, after the POST switch), and persistence (test 15 step 1) tests so `div-table_<field>` renders.
- Persistence test: the added headers field **persists across the reload**, so the removed inspect-panel toggle (`enableInspectPanel`) is dropped — the field renders directly after reload.
- cURL test (13): wait for the parse round-trip (`POST /api/v1/custom_component/update`), switch to the URL tab to read the parser's auto-filled value, then switch **back** to the cURL tab so the run still exercises cURL mode. (The parser works — the input was just unmounted.)
- Add id-scoped `afterEach` flow cleanup (the 15-test serial file had none).
- Update the spec doc for the dev46 model.

## Validation (1.11.0.dev46, one runner on a local backend)

- **15/15 green** — `--workers=1 --retries=0` (~11.8m).
- `npm run typecheck` + `npm run lint` — 0 errors.
- 0 orphan flows (verified via `GET /api/v1/flows/` after the run — cleanup works).
- **Force-fail:** the pre-fix runs fail at `div-table_headers` / `div-table_body` (not found without the inspector-add step) and at the cURL `waitForFunction` timeout — old code is the mutation.
- Note: the persistence test's DB poll (20s) can flake only under heavy serial backend contention; green isolated and in the full run. CI `retries=2` absorbs it.

```bash
npx playwright test tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts --workers=1 --retries=0
```

Part of #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)