### PR TITLE
fix(core-components): migrate webhook api-key spec to dev46 inspector model (#818)

### DIFF
--- a/docs/core-components/general-bugs-component-webhook-api-key-display.md
+++ b/docs/core-components/general-bugs-component-webhook-api-key-display.md
@@ -1,0 +1,107 @@
+# Spec: Webhook Component — API Key Display in the Generated cURL
+
+**Test file:** `tests/tests-automations/regression/core-components/general-bugs-component-webhook-api-key-display.spec.ts`
+
+**Last validated:** Langflow 1.11.x (nightly `1.11.0.dev46`)
+
+---
+
+## What this test validates
+
+The Webhook component generates a ready-to-use cURL command. Whether that command
+includes the `x-api-key` header depends on the instance's webhook-auth config:
+
+1. **Webhook auth enabled** (`webhook_auth_enable: true`, auto-login disabled) —
+   the generated cURL **must** contain `x-api-key` so the user knows an API key
+   is required to call the webhook.
+2. **Webhook auth disabled** (`webhook_auth_enable: false`) — the cURL **must
+   not** contain `x-api-key` (no key is needed).
+
+Both cases are driven by mocking `GET /api/v1/config` (and, for case 1, forcing
+`auto_login` off), then reading the generated cURL out of the component's cURL
+text-area modal.
+
+### dev46 node-inspector model
+
+The nightly removed the inspect-panel on/off toggle and made the generated cURL
+an **advanced** field. To read it: select the node, open the inspector
+(`parameters-button`), add the cURL field to the node body
+(`inspector-add-curl`), close the inspector (`inspection-panel-close`), then open
+the cURL text-area modal from the node body via
+`button_open_text_area_modal_str_curl` (previously
+`button_open_text_area_modal_str_edit_curl_advanced`).
+
+---
+
+## Tags
+
+`@release`
+
+---
+
+## Step by step
+
+Both tests bootstrap the app, open a blank flow, and add the **Webhook**
+component. Every flow the page creates is captured from its
+`POST /api/v1/flows → 201` response and deleted id-scoped in `afterEach`.
+
+**Test 1 — auth enabled → key shown:**
+1. Route `GET /api/v1/auto_login` to `500` (auto-login off) and `GET /api/v1/config`
+   to `{ webhook_auth_enable: true }`; `loginLangflow`.
+2. Open a blank flow, add the Webhook component, select it.
+3. Open the inspector, `inspector-add-curl`, close the inspector.
+4. Open the cURL modal (`button_open_text_area_modal_str_curl`), read the
+   text-area value, assert it **contains** `x-api-key`, close the modal.
+
+**Test 2 — auth disabled → key hidden:**
+1. Route `GET /api/v1/config` to `{ webhook_auth_enable: false }`.
+2–4. Same as test 1, but assert the cURL **does not contain** `x-api-key`.
+
+---
+
+## Validation criterion
+
+| Case | Criterion |
+|---|---|
+| `webhook_auth_enable: true` | the generated cURL (`text-area-modal` value) contains `x-api-key` |
+| `webhook_auth_enable: false` | the generated cURL does **not** contain `x-api-key` |
+
+---
+
+## External dependencies
+
+- `src/backend/base/langflow/components/data/webhook.py` — Webhook component; the
+  generated cURL and the `curl` advanced field.
+- `GET /api/v1/config` (`webhook_auth_enable`) and `GET /api/v1/auto_login` — both
+  mocked via `page.route`, so no real auth config is required.
+- `tests/helpers/ui/open-advanced-options.ts` — `openAdvancedOptions` /
+  `closeAdvancedOptions` (the dev46 inspector panel).
+- `tests/helpers/auth/login-langflow.ts` — `loginLangflow` (test 1).
+
+---
+
+## What this test does not cover
+
+- Actually invoking the webhook endpoint with/without the key.
+- The API key rotation / regeneration flow.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`. No real API key required — config is
+  mocked.
+
+---
+
+## Notes
+
+- dev46 migration (issue #818): removed the dead `enable`/`disableInspectPanel`
+  calls (the inspect-panel toggle feature was removed upstream), added the
+  `inspector-add-curl` step (the cURL field became advanced), and renamed the
+  modal-open testid `button_open_text_area_modal_str_edit_curl_advanced` →
+  `button_open_text_area_modal_str_curl`. Added id-scoped `afterEach` flow
+  cleanup (the spec had none).
+- Validated on `1.11.0.dev46` (2026-07-19): 2 passed (~1.6m), `--workers=1
+  --retries=0`, 0 orphan flows. Force-fail: the pre-fix run fails at the removed
+  `canvas_controls_dropdown_toggle_inspector` testid (old `disableInspectPanel`).

--- a/tests/tests-automations/regression/core-components/general-bugs-component-webhook-api-key-display.spec.ts
+++ b/tests/tests-automations/regression/core-components/general-bugs-component-webhook-api-key-display.spec.ts
@@ -1,18 +1,51 @@
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { loginLangflow } from "../../../helpers/auth/login-langflow";
 import {
   closeAdvancedOptions,
-  disableInspectPanel,
-  enableInspectPanel,
   openAdvancedOptions,
 } from "../../../helpers/ui/open-advanced-options";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+
+// Capture every flow THIS page creates from its POST /api/v1/flows → 201
+// responses and delete them id-scoped in afterEach (repo convention, #490/#681).
+const createdFlowIds: string[] = [];
+
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {});
+    }
+  });
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, {
+      headers: { Authorization: bearer },
+    }).catch(() => {});
+  }
+});
 
 test(
   "user must be able to see api key in webhook component when auto login is disabled",
   { tag: ["@release"] },
   async ({ page }) => {
+    trackCreatedFlows(page);
     await page.route("**/api/v1/auto_login", (route) => {
       route.fulfill({
         status: 500,
@@ -65,23 +98,19 @@ test(
 
     await page.getByTestId("title-Webhook").click();
 
-    await disableInspectPanel(page);
-
+    // dev46: the generated cURL command is an advanced field — add it to the
+    // node body via the inspector, then open its text-area modal from the body.
     await openAdvancedOptions(page);
+    await page.getByTestId("inspector-add-curl").click();
+    await closeAdvancedOptions(page);
 
-    await page
-      .getByTestId("button_open_text_area_modal_str_edit_curl_advanced")
-      .click();
+    await page.getByTestId("button_open_text_area_modal_str_curl").click();
 
     const curl = await page.getByTestId("text-area-modal").inputValue();
 
     expect(curl).toContain("x-api-key");
 
     await page.getByText("Close", { exact: true }).last().click();
-
-    await closeAdvancedOptions(page);
-
-    await enableInspectPanel(page);
   },
 );
 
@@ -89,6 +118,7 @@ test(
   "user must be able to not see api key in webhook component when auto login is enabled",
   { tag: ["@release"] },
   async ({ page }) => {
+    trackCreatedFlows(page);
     await page.route("**/api/v1/config", (route) => {
       route.fulfill({
         status: 200,
@@ -129,22 +159,18 @@ test(
 
     await page.getByTestId("title-Webhook").click();
 
-    await disableInspectPanel(page);
-
+    // dev46: the generated cURL command is an advanced field — add it to the
+    // node body via the inspector, then open its text-area modal from the body.
     await openAdvancedOptions(page);
+    await page.getByTestId("inspector-add-curl").click();
+    await closeAdvancedOptions(page);
 
-    await page
-      .getByTestId("button_open_text_area_modal_str_edit_curl_advanced")
-      .click();
+    await page.getByTestId("button_open_text_area_modal_str_curl").click();
 
     const curl = await page.getByTestId("text-area-modal").inputValue();
 
     expect(curl).not.toContain("x-api-key");
 
     await page.getByText("Close", { exact: true }).last().click();
-
-    await closeAdvancedOptions(page);
-
-    await enableInspectPanel(page);
   },
 );


### PR DESCRIPTION
Part of #818 — daily-failure cluster, dev46 testid drift (@release). Follow-up to merged #837–#841.

## Problem

The nightly removed the inspect-panel on/off toggle (`canvas_controls_dropdown_toggle_inspector`) and made the Webhook component's generated cURL an **advanced** field, so `general-bugs-component-webhook-api-key-display` failed on both the removed toggle and the now-advanced cURL field.

## Changes

- Drop the dead `enable`/`disableInspectPanel` calls (feature removed upstream).
- Add the cURL field to the node body via the inspector (`openAdvancedOptions` → `inspector-add-curl` → `closeAdvancedOptions`) before opening its text-area modal.
- Rename the modal-open testid `button_open_text_area_modal_str_edit_curl_advanced` → `button_open_text_area_modal_str_curl`.
- Add id-scoped `afterEach` flow cleanup (the spec had none).
- Add the missing spec doc.

The two tests still verify the same contract: the generated cURL contains `x-api-key` when `webhook_auth_enable: true` (config mocked) and omits it when `false`.

## Validation (1.11.0.dev46, one runner on a local backend)

- **3/3 green** — `--workers=1 --retries=0` (~1.6m each).
- `npm run typecheck` + `npm run lint` — 0 errors.
- 0 orphan flows (verified via `GET /api/v1/flows/`).
- **Force-fail:** the pre-fix run fails at the removed `canvas_controls_dropdown_toggle_inspector` testid (old `disableInspectPanel`).

```bash
npx playwright test tests/tests-automations/regression/core-components/general-bugs-component-webhook-api-key-display.spec.ts --workers=1 --retries=0
```

Part of #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)