### PR TITLE
fix(llm-agents): migrate Message History field exposure to dev46 inspector (#818)

### DIFF
--- a/docs/core-functionality/llm-agents/agent-n-messages-limit.md
+++ b/docs/core-functionality/llm-agents/agent-n-messages-limit.md
@@ -88,10 +88,11 @@ Shared setup per test (all data is per-run unique):
    node renders as `rf__node-Memory-*`). Retrieval is **flow-scoped**
    (issue #13059 / PR #13087), so the component must live in the same flow that
    seeded the session.
-6. Expose the hidden fields via the node's **edit-fields** panel
-   (`edit-fields-button` → toggles `shown_messages`, `showsession_id`), then
-   fill `int_int_n_messages` and `popover-anchor-input-session_id`; wait for
-   the flow save to settle.
+6. Expose the hidden fields via the node **inspector** (dev46: `openAdvancedOptions`
+   → `inspector-add-n_messages`, `inspector-add-session_id` → `closeAdvancedOptions`;
+   replaces the old `edit-fields-button` + `show<field>` toggles), then fill
+   `int_int_n_messages` and `popover-anchor-input-session_id`; wait for the flow
+   save to settle.
 7. Run the node (`button_run_message history`, mode tab *Retrieve* is the
    default), wait for **built successfully**.
 8. Open the output inspector (`output-inspection-messages-memory`) and read the
@@ -164,8 +165,9 @@ Shared setup per test (all data is per-run unique):
   through the same helper.
 - `src/backend/base/langflow/api/v1/endpoints.py` — `POST /api/v1/run`
   (seeding) and `GET /api/v1/monitor/messages` (seed verification).
-- `src/frontend/src/CustomNodes/GenericNode/` — the node's edit-fields panel
-  (`edit-fields-button`, `shown_messages`, `showsession_id`) and field inputs.
+- `src/frontend/src/CustomNodes/GenericNode/` — the node inspector
+  (`parameters-button`, `inspector-add-n_messages`, `inspector-add-session_id`)
+  and field inputs.
 - `src/frontend/src/modals/` — the component output inspector
   (`output-inspection-*`, `textarea`).
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-continuity.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-continuity.spec.ts
@@ -6,6 +6,10 @@ import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import {
+  closeAdvancedOptions,
+  openAdvancedOptions,
+} from "../../../../helpers/ui/open-advanced-options";
 import { createRunnableChatFlowViaApi } from "../../../../helpers/flows/create-runnable-chat-flow-via-api";
 import { addComponentFromSidebar } from "../../../../helpers/flows/add-component-from-sidebar";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
@@ -391,11 +395,13 @@ async function retrieveViaMessageHistory(
   await expect(node).toBeVisible({ timeout: 15000 });
 
   await page.getByTestId("title-Message History").click();
-  await page.getByTestId("edit-fields-button").click();
-  await page.getByTestId("shown_messages").click();
-  await page.getByTestId("showsession_id").click();
-  await page.getByTestId("showcontext_id").click();
-  await page.keyboard.press("Escape");
+  // dev46: expose the advanced n_messages / session_id / context_id fields on the
+  // node body via the inspector (replaces the old edit-fields modal + show<field>).
+  await openAdvancedOptions(page);
+  await page.getByTestId("inspector-add-n_messages").click();
+  await page.getByTestId("inspector-add-session_id").click();
+  await page.getByTestId("inspector-add-context_id").click();
+  await closeAdvancedOptions(page);
 
   await page.getByTestId("int_int_n_messages").fill("100");
   await page.getByTestId("popover-anchor-input-session_id").fill(session);

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts
@@ -6,6 +6,10 @@ import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import {
+  closeAdvancedOptions,
+  openAdvancedOptions,
+} from "../../../../helpers/ui/open-advanced-options";
 import { createRunnableChatFlowViaApi } from "../../../../helpers/flows/create-runnable-chat-flow-via-api";
 import { addComponentFromSidebar } from "../../../../helpers/flows/add-component-from-sidebar";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
@@ -464,11 +468,13 @@ async function setupMessageHistoryNode(
   await expect(node).toBeVisible({ timeout: 15000 });
 
   await page.getByTestId("title-Message History").click();
-  await page.getByTestId("edit-fields-button").click();
-  await page.getByTestId("shown_messages").click();
-  await page.getByTestId("showsession_id").click();
-  await page.getByTestId("showcontext_id").click();
-  await page.keyboard.press("Escape");
+  // dev46: expose the advanced n_messages / session_id / context_id fields on the
+  // node body via the inspector (replaces the old edit-fields modal + show<field>).
+  await openAdvancedOptions(page);
+  await page.getByTestId("inspector-add-n_messages").click();
+  await page.getByTestId("inspector-add-session_id").click();
+  await page.getByTestId("inspector-add-context_id").click();
+  await closeAdvancedOptions(page);
 
   await page.getByTestId("int_int_n_messages").fill("100");
   await page.getByTestId("popover-anchor-input-session_id").fill(session);

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-n-messages-limit.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-n-messages-limit.spec.ts
@@ -4,6 +4,10 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { createRunnableChatFlowViaApi } from "../../../../helpers/flows/create-runnable-chat-flow-via-api";
 import { addComponentFromSidebar } from "../../../../helpers/flows/add-component-from-sidebar";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import {
+  closeAdvancedOptions,
+  openAdvancedOptions,
+} from "../../../../helpers/ui/open-advanced-options";
 
 /**
  * n_messages limits the number of retained messages (QA-CHECKLIST §6.3).
@@ -128,13 +132,13 @@ async function retrieveViaMessageHistory(
   const node = page.locator('[data-testid^="rf__node-Memory"]').first();
   await expect(node).toBeVisible({ timeout: 15000 });
 
-  // n_messages and session_id are hidden by default — expose them through the
-  // node's edit-fields panel, then fill them on the node.
+  // n_messages and session_id are hidden by default — expose them on the node
+  // body via the inspector (dev46 replaced the edit-fields modal + show<field>).
   await page.getByTestId("title-Message History").click();
-  await page.getByTestId("edit-fields-button").click();
-  await page.getByTestId("shown_messages").click();
-  await page.getByTestId("showsession_id").click();
-  await page.keyboard.press("Escape");
+  await openAdvancedOptions(page);
+  await page.getByTestId("inspector-add-n_messages").click();
+  await page.getByTestId("inspector-add-session_id").click();
+  await closeAdvancedOptions(page);
 
   await page.getByTestId("int_int_n_messages").fill(nMessages);
   await page.getByTestId("popover-anchor-input-session_id").fill(session);


### PR DESCRIPTION
Part of #818 — daily-failure cluster, dev46 testid drift (@stable). Follow-up to merged #837–#842.

## Problem

Three `@stable` agent specs exposed the **Message History** component's advanced fields through the old edit-fields modal, which the nightly removed:

| old | new |
|---|---|
| `edit-fields-button` | `parameters-button` (`openAdvancedOptions`) |
| `shown_messages` | `inspector-add-n_messages` |
| `showsession_id` | `inspector-add-session_id` |
| `showcontext_id` | `inspector-add-context_id` |
| `Escape` (close) | `closeAdvancedOptions` |

## Changes

Migrate the identical field-exposure block in all three specs:
- `agent-context-id-continuity` (n_messages, session_id, context_id)
- `agent-context-id-isolation` (n_messages, session_id, context_id)
- `agent-n-messages-limit` (n_messages, session_id)

Only the field-exposure mechanism changed — each test's seeding/retrieval logic and assertions are unchanged. Spec doc for `agent-n-messages-limit` updated.

## Validation (1.11.0.dev46, one runner on a local backend, OpenAI active)

- The **model-free retrieval tests** (which use the migrated block via `retrieveViaMessageHistory`) pass: `agent-n-messages-limit` **2/2** (~12s); `continuity` and `isolation` model-free tests pass.
- The `[openai / gpt-4o-mini]` **agent tests skip** via the pre-existing `getProviderSkipReasons` gate (`providers.json` marks providers inactive) — unrelated to this change; they do not use the Message History block.
- `npm run typecheck` + `npm run lint` — 0 errors.
- 0 orphan flows (all three have id-scoped cleanup).
- **Force-fail:** breaking `inspector-add-n_messages` fails both `agent-n-messages-limit` tests.

```bash
npx playwright test tests/tests-automations/regression/core-functionality/llm-agents/agent-n-messages-limit.spec.ts tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-continuity.spec.ts tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts --workers=1 --retries=0
```

Part of #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)