### PR TITLE
fix(flow-functionality): collapse hidden-input-edges spec to dev46 inspector (#818)

### DIFF
--- a/docs/flow-functionality/general-bugs-hidden-input-edges.md
+++ b/docs/flow-functionality/general-bugs-hidden-input-edges.md
@@ -1,0 +1,106 @@
+# Spec: Connected Inputs Cannot Be Hidden
+
+**Test file:** `tests/tests-automations/regression/flow-functionality/general-bugs-hidden-input-edges.spec.ts`
+
+**Last validated:** Langflow 1.11.x (nightly `1.11.0.dev46`)
+
+---
+
+## What this test validates
+
+Regression test guarding the rule that **a node input with a connected edge
+cannot be hidden**. Hiding a connected input would orphan its edge (a "hidden
+input edge"), so the UI disables the visibility toggle for any field whose handle
+is currently wired, and re-enables it once the edge is removed.
+
+The test exercises the **Language Model** node's `input_value` field (wired in the
+Basic Prompting template):
+
+1. While `input_value` is connected, its inspector visibility toggle
+   (`inspector-remove-input_value`) is **present but disabled**, and hovering its
+   wrapper shows the tooltip *"Cannot change visibility of connected handles"*.
+2. After the edge is deleted, the toggle becomes **enabled** and the field can be
+   hidden — which removes it from the node body.
+
+### dev46 node-inspector model
+
+The nightly removed the inspect-panel on/off toggle and the old edit-fields modal
++ `show<field>` toggles. Field visibility is now driven from the node inspector:
+`openAdvancedOptions` (`parameters-button`) opens it, a shown field carries an
+`inspector-remove-<field>` toggle (and a hidden one an `inspector-add-<field>`),
+and the disabled toggle's tooltip lives on the `inspector-remove-wrapper-<field>`
+span (the disabled button itself has `pointer-events-none`).
+
+---
+
+## Tags
+
+`@release` `@api` `@database`
+
+---
+
+## Step by step
+
+1. Bootstrap; open the **Basic Prompting** template (`side_nav_options_all-templates`
+   → *Basic Prompting*). Every flow created is captured from its
+   `POST /api/v1/flows → 201` and deleted id-scoped in `afterEach`.
+2. Select the **Language Model** node; open the inspector (`openAdvancedOptions`).
+3. Assert `inspector-remove-input_value` is visible **and disabled**; hover
+   `inspector-remove-wrapper-input_value` → the tooltip *"Cannot change
+   visibility of connected handles"* is visible. Close the inspector.
+4. Delete the `input_value` edge (`.react-flow__edge` nth 0 → Delete); assert the
+   edge count drops to 2 (Basic Prompting wires 3).
+5. Re-select the node; open the inspector; assert `inspector-remove-input_value`
+   is now **enabled**; click it to hide the field. Close the inspector.
+6. `unselectNodes`; assert the `Input` label is no longer on the node body.
+
+---
+
+## Validation criterion
+
+| State | Criterion |
+|---|---|
+| `input_value` connected | `inspector-remove-input_value` visible + `toBeDisabled()`; wrapper hover shows *"Cannot change visibility of connected handles"* |
+| after deleting the edge | edge count `toHaveCount(2)`; `inspector-remove-input_value` `toBeEnabled()` |
+| after hiding the field | `getByText("Input", { exact: true })` `toBeHidden()` |
+
+---
+
+## External dependencies
+
+- Basic Prompting starter template (Language Model with a wired `input_value`).
+- `tests/helpers/ui/open-advanced-options.ts` — `openAdvancedOptions` /
+  `closeAdvancedOptions` (dev46 inspector).
+- `tests/helpers/ui/unselect-nodes.ts` — `unselectNodes`.
+- No model provider credentials required — no flow execution, only inspector
+  state + edge editing.
+
+---
+
+## What this test does not cover
+
+- Other input fields / components (Language Model `input_value` is the canonical
+  case).
+- Persistence of the hidden/shown state across reload.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+
+---
+
+## Notes
+
+- dev46 migration (issue #818): collapsed from two tests to one. The nightly
+  removed the inspect-panel on/off toggle, so the former "…when inspection panel
+  is disabled" variant no longer describes a distinct scenario. The single
+  surviving behavior (connected → toggle visible **but disabled** + tooltip) is
+  what dev46 renders; the old "hidden when connected" assertion no longer holds.
+  Migrated `showinput_value` → `inspector-remove-input_value` (+ its
+  `-wrapper-` tooltip trigger), `edit-fields`/`show<field>` → the inspector, and
+  added id-scoped `afterEach` flow cleanup.
+- Validated on `1.11.0.dev46` (2026-07-20): 3/3 green (~49s), `--workers=1
+  --retries=0`, 0 orphan flows. Force-fail: flipping the connected-state
+  `toBeDisabled()` to `toBeEnabled()` fails.

--- a/tests/tests-automations/regression/flow-functionality/general-bugs-hidden-input-edges.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/general-bugs-hidden-input-edges.spec.ts
@@ -1,20 +1,50 @@
-import * as dotenv from "dotenv";
-import path from "path";
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
-import { initialGPTsetup } from "../../../helpers/other/initialGPTsetup";
 import {
   closeAdvancedOptions,
-  disableInspectPanel,
-  enableInspectPanel,
   openAdvancedOptions,
 } from "../../../helpers/ui/open-advanced-options";
 import { unselectNodes } from "../../../helpers/ui/unselect-nodes";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+
+// Capture every flow THIS page creates from its POST /api/v1/flows → 201
+// responses and delete them id-scoped in afterEach (repo convention, #490/#681).
+const createdFlowIds: string[] = [];
+
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {});
+    }
+  });
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, {
+      headers: { Authorization: bearer },
+    }).catch(() => {});
+  }
+});
 
 test(
   "user should not be able to hide connected inputs",
   { tag: ["@release", "@api", "@database"] },
   async ({ page }) => {
+    trackCreatedFlows(page);
     await awaitBootstrapTest(page);
 
     await page.getByTestId("side_nav_options_all-templates").click();
@@ -28,75 +58,27 @@ test(
       .click();
     await openAdvancedOptions(page);
 
-    const input_value = page.getByTestId("showinput_value");
+    // dev46: the field's visibility toggle is `inspector-remove-<field>` (the
+    // field is on the node body by default). While its handle is connected the
+    // toggle is present but DISABLED — a connected input cannot be hidden — and
+    // hovering surfaces the reason.
+    const inputValueToggle = page.getByTestId("inspector-remove-input_value");
+    await expect(inputValueToggle).toBeVisible();
+    await expect(inputValueToggle).toBeDisabled();
 
-    // Connected fields should not appear in edit mode
-    await expect(input_value).toBeHidden();
-
-    await closeAdvancedOptions(page);
-
-    await page.locator(".react-flow__edge").nth(0).click();
-
-    await page.keyboard.press("Delete");
-
-    await expect(page.locator(".react-flow__edge")).toHaveCount(2);
-
-    await page
-      .getByTestId("div-generic-node")
-      .getByText("Language Model", { exact: true })
-      .click();
-    await openAdvancedOptions(page);
-
-    // After disconnecting, the field should appear and be enabled
-    await expect(input_value).toBeVisible();
-    await expect(input_value).toBeEnabled();
-
-    await input_value.click();
-
-    await closeAdvancedOptions(page);
-
-    await unselectNodes(page);
-
-    await expect(page.getByText("Input", { exact: true })).toBeHidden();
-  },
-);
-
-test(
-  "user should not be able to hide connected inputs when inspection panel is disabled",
-  { tag: ["@release", "@api", "@database"] },
-  async ({ page }) => {
-    await awaitBootstrapTest(page);
-
-    await page.getByTestId("side_nav_options_all-templates").click();
-    await page.getByRole("heading", { name: "Basic Prompting" }).click();
-
-    await disableInspectPanel(page);
-
-    await page.waitForSelector("text=Language Model", { timeout: 30000 });
-
-    await page
-      .getByTestId("div-generic-node")
-      .getByText("Language Model", { exact: true })
-      .click();
-    await openAdvancedOptions(page);
-
-    const input_value = page.getByTestId("showinput_value");
-    await expect(input_value).toBeVisible();
-
-    await expect(input_value).toBeDisabled();
-
-    await input_value.hover();
-
+    // The disabled button has `pointer-events-none`; its wrapper span is the
+    // tooltip trigger, so hover the wrapper to surface the reason.
+    await page.getByTestId("inspector-remove-wrapper-input_value").hover();
     await expect(
       page.getByText("Cannot change visibility of connected handles"),
     ).toBeVisible();
 
     await closeAdvancedOptions(page);
 
+    // Disconnect the input by deleting its edge (Basic Prompting wires 3 edges;
+    // removing one leaves 2).
     await page.locator(".react-flow__edge").nth(0).click();
-
     await page.keyboard.press("Delete");
-
     await expect(page.locator(".react-flow__edge")).toHaveCount(2);
 
     await page
@@ -105,14 +87,15 @@ test(
       .click();
     await openAdvancedOptions(page);
 
-    await expect(input_value).toBeEnabled();
-
-    await input_value.click();
+    // Once disconnected the toggle is enabled and the field can be hidden.
+    await expect(inputValueToggle).toBeEnabled();
+    await inputValueToggle.click();
 
     await closeAdvancedOptions(page);
 
-    await expect(page.getByText("Input", { exact: true })).toBeHidden();
+    await unselectNodes(page);
 
-    await enableInspectPanel(page);
+    // Hiding the (now-disconnected) input removes it from the node body.
+    await expect(page.getByText("Input", { exact: true })).toBeHidden();
   },
 );


### PR DESCRIPTION
Part of #818 — daily-failure cluster, dev46 testid drift (@release). Follow-up to merged #837–#844.

## Problem

The nightly removed the inspect-panel on/off toggle and the edit-fields modal + `show<field>` toggles, so `general-bugs-hidden-input-edges` failed on both testids. Its two tests, post-dev46, describe the **same** behavior — the former "…when inspection panel is disabled" variant no longer exists as a distinct scenario.

## Changes

Collapse to one test:
- Keep the canonical **"user should not be able to hide connected inputs"**.
- Migrate to the dev46 inspector: `showinput_value` → `inspector-remove-input_value` (the field's visibility toggle). A connected input renders the toggle **visible but disabled**, with the *"Cannot change visibility of connected handles"* tooltip on the `inspector-remove-wrapper-input_value` span (the disabled button has `pointer-events-none`, so hover the wrapper). After deleting the edge the toggle is enabled and hiding the field removes it from the node body.
- The old "hidden when connected" assertion no longer holds (dev46 shows the toggle **disabled**, not hidden).
- Add id-scoped `afterEach` flow cleanup and the missing spec doc.

## Validation (1.11.0.dev46, one runner on a local backend)

- **3/3 green** — `--workers=1 --retries=0` (~49s each).
- `npm run typecheck` + `npm run lint` — 0 errors.
- 0 orphan flows (id-scoped `afterEach`).
- **Force-fail:** flipping the connected-state `toBeDisabled()` to `toBeEnabled()` fails.

```bash
npx playwright test tests/tests-automations/regression/flow-functionality/general-bugs-hidden-input-edges.spec.ts --workers=1 --retries=0
```

Part of #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)