### PR TITLE
fix(llm-agents): migrate chat sender-name spec + drop dead inspect-panel helpers (#818)

### DIFF
--- a/docs/core-functionality/llm-agents/chatInputOutputUser-shard-2.md
+++ b/docs/core-functionality/llm-agents/chatInputOutputUser-shard-2.md
@@ -1,0 +1,99 @@
+# Spec: Chat Input/Output — Playground Interaction with Custom Sender Names
+
+**Test file:** `tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-2.spec.ts`
+
+**Last validated:** Langflow 1.11.x (nightly `1.11.0.dev46`)
+
+---
+
+## What this test validates
+
+End-to-end Playground interaction on the Basic Prompting flow, plus the
+**custom sender name** feature of the Chat Input / Chat Output components:
+
+1. A first Playground turn ("Hello, how are you?") echoes the user message and
+   produces a non-empty AI reply — the default sender labels (`User` / `AI`).
+2. After exposing and setting a custom `sender_name` on both Chat Input
+   (`TestSenderNameUser`) and Chat Output (`TestSenderNameAI`), a second turn
+   ("Are you doing ok?") renders the messages tagged with the **custom** sender
+   names — `chat-message-TestSenderNameUser` / `chat-message-TestSenderNameAI`.
+
+### dev46 node-inspector model
+
+The nightly removed the inspect-panel on/off toggle and the old `show<field>`
+toggles. The advanced `sender_name` field is exposed on each node body via the
+inspector: `openAdvancedOptions` (`parameters-button`) → `inspector-add-sender_name`
+→ `closeAdvancedOptions`. The field's input (`popover-anchor-input-sender_name`)
+then renders on the node body (the Basic Prompting Chat Input/Output nodes are
+expanded, so the input is directly fillable).
+
+---
+
+## Tags
+
+`@release` `@components` `@agents`
+
+---
+
+## Step by step
+
+1. `test.skip` unless `OPENAI_API_KEY` is set. Bootstrap; open the **Basic
+   Prompting** template; `initialGPTsetup`. Every flow created is captured from
+   its `POST /api/v1/flows → 201` and deleted id-scoped in `afterEach`.
+2. Open the Playground; send "Hello, how are you?"; wait for the build to finish;
+   assert the user message text and a non-empty AI reply. Close the Playground.
+3. Select **Chat Input**, `openAdvancedOptions`, `inspector-add-sender_name`,
+   `closeAdvancedOptions`. Repeat for **Chat Output**.
+4. Fill `popover-anchor-input-sender_name` nth 0 = `TestSenderNameUser`, nth 1 =
+   `TestSenderNameAI`.
+5. Open the Playground; send "Are you doing ok?"; wait for the build.
+6. Assert `chat-message-TestSenderNameUser` has the sent text and
+   `chat-message-TestSenderNameAI` is non-empty. Close the Playground.
+
+---
+
+## Validation criterion
+
+| Turn | Criterion |
+|---|---|
+| Default sender names | `chat-message-User` = "Hello, how are you?"; `chat-message-AI` non-empty |
+| Custom sender names | `chat-message-TestSenderNameUser` = "Are you doing ok?"; `chat-message-TestSenderNameAI` non-empty |
+
+The custom-sender assertions fail if `sender_name` was not exposed/applied — the
+messages would fall back to the default `User`/`AI` labels.
+
+---
+
+## External dependencies
+
+- **OpenAI** — `test.skip` without `OPENAI_API_KEY`; the flow runs an OpenAI model
+  via `initialGPTsetup`.
+- Basic Prompting starter template (Chat Input → … → Chat Output).
+- `tests/helpers/ui/open-advanced-options.ts` — `openAdvancedOptions` /
+  `closeAdvancedOptions` (dev46 inspector).
+- `tests/helpers/other/initialGPTsetup.ts` — provider/model setup.
+
+---
+
+## What this test does not cover
+
+- The AI reply's content (only that it is non-empty).
+- Providers other than OpenAI.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`; `OPENAI_API_KEY` set.
+
+---
+
+## Notes
+
+- dev46 migration (issue #818): removed the dead `enable`/`disableInspectPanel`
+  calls (the inspect-panel toggle feature was removed upstream) and swapped
+  `showsender_name` → `inspector-add-sender_name` on both Chat Input and Chat
+  Output. Added id-scoped `afterEach` flow cleanup (the spec had none).
+- Validated on `1.11.0.dev46` (2026-07-20): 3/3 green (~59s), `--workers=1
+  --retries=0`, 0 orphan flows. Force-fail: breaking `inspector-add-sender_name`
+  fails the custom-sender-name assertions.

--- a/tests/helpers/ui/open-advanced-options.ts
+++ b/tests/helpers/ui/open-advanced-options.ts
@@ -15,31 +15,3 @@ export const openAdvancedOptions = async (page: Page) => {
 export const closeAdvancedOptions = async (page: Page) => {
   await page.getByTestId("inspection-panel-close").click();
 };
-
-export const enableInspectPanel = async (page: Page) => {
-  await page.getByTestId("canvas_controls_dropdown_help").click();
-  if (
-    !(await page
-      .getByTestId("canvas_controls_dropdown_toggle_inspector-toggle")
-      .isChecked())
-  ) {
-    await page.getByTestId("canvas_controls_dropdown_toggle_inspector").click();
-  }
-  await page
-    .getByTestId("canvas_controls_dropdown_help")
-    .click({ force: true });
-};
-
-export const disableInspectPanel = async (page: Page) => {
-  await page.getByTestId("canvas_controls_dropdown_help").click();
-  if (
-    await page
-      .getByTestId("canvas_controls_dropdown_toggle_inspector-toggle")
-      .isChecked()
-  ) {
-    await page.getByTestId("canvas_controls_dropdown_toggle_inspector").click();
-  }
-  await page
-    .getByTestId("canvas_controls_dropdown_help")
-    .click({ force: true });
-};

--- a/tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-2.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-2.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from "@playwright/test";
 import * as dotenv from "dotenv";
 import path from "path";
 import { expect, test } from "../../../../fixtures/fixtures";
@@ -5,10 +6,41 @@ import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-te
 import { initialGPTsetup } from "../../../../helpers/other/initialGPTsetup";
 import {
   closeAdvancedOptions,
-  disableInspectPanel,
-  enableInspectPanel,
   openAdvancedOptions,
 } from "../../../../helpers/ui/open-advanced-options";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+
+// Capture every flow THIS page creates from its POST /api/v1/flows → 201
+// responses and delete them id-scoped in afterEach (repo convention, #490/#681).
+const createdFlowIds: string[] = [];
+
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {});
+    }
+  });
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, {
+      headers: { Authorization: bearer },
+    }).catch(() => {});
+  }
+});
 
 test(
   "user must interact with chat with Input/Output",
@@ -23,6 +55,7 @@ test(
       dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
     }
 
+    trackCreatedFlows(page);
     await awaitBootstrapTest(page);
 
     await page.getByTestId("side_nav_options_all-templates").click();
@@ -66,15 +99,16 @@ test(
     // close the playground (fullscreen covers the toolbar, use the close button)
     await page.getByTestId("playground-close-button").click();
 
-    await disableInspectPanel(page);
+    // dev46: expose the advanced sender_name field on each node body via the
+    // inspector (replaces the old show<field> toggle).
     await page.getByText("Chat Input", { exact: true }).click();
     await openAdvancedOptions(page);
-    await page.getByTestId("showsender_name").click();
+    await page.getByTestId("inspector-add-sender_name").click();
     await closeAdvancedOptions(page);
 
     await page.getByText("Chat Output", { exact: true }).click();
     await openAdvancedOptions(page);
-    await page.getByTestId("showsender_name").click();
+    await page.getByTestId("inspector-add-sender_name").click();
     await closeAdvancedOptions(page);
 
     await page
@@ -115,6 +149,5 @@ test(
     ).not.toBeEmpty();
 
     await page.getByTestId("playground-close-button").click();
-    await enableInspectPanel(page);
   },
 );


### PR DESCRIPTION
Part of #818 — daily-failure cluster, dev46 testid drift (@release). Follow-up to merged #837–#845.

## Problem

`chatInputOutputUser-shard-2` used the removed inspect-panel toggle and the old `show<field>` toggle — and it was the **last caller** of the `enable`/`disableInspectPanel` helpers.

## Changes

- Drop the dead `enable`/`disableInspectPanel` calls (feature removed upstream).
- Swap `showsender_name` → `inspector-add-sender_name` on both Chat Input and Chat Output (expose the advanced `sender_name` field on the node body via the inspector). The Basic Prompting template nodes are expanded, so `popover-anchor-input-sender_name` renders and is fillable.
- Add id-scoped `afterEach` flow cleanup (the spec had none) and the missing spec doc.
- **Remove `enableInspectPanel`/`disableInspectPanel` from `open-advanced-options.ts`** — no callers remain (the `canvas_controls_dropdown_toggle_inspector` testid was removed in dev46; grep confirms zero references repo-wide).

## Validation (1.11.0.dev46, one runner on a local backend, OpenAI active)

- **3/3 green** — `--workers=1 --retries=0` (~59s each).
- `npm run typecheck` + `npm run lint` — 0 errors.
- 0 orphan flows (id-scoped `afterEach`).
- **Force-fail:** breaking `inspector-add-sender_name` fails the custom-sender-name assertions.

```bash
npx playwright test tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-2.spec.ts --workers=1 --retries=0
```

Part of #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)