### PR TITLE
fix(ui-ux): update filterSidebar spec for dev46 inspector + compatible set (#818)

### DIFF
--- a/docs/ui-ux/filterSidebar.md
+++ b/docs/ui-ux/filterSidebar.md
@@ -1,0 +1,107 @@
+# Spec: Sidebar Connection Filter on Handle Click
+
+**Test file:** `tests/tests-automations/regression/ui-ux/filterSidebar.spec.ts`
+
+**Last validated:** Langflow 1.11.x (nightly `1.11.0.dev46`)
+
+---
+
+## What this test validates
+
+Clicking a node's **input handle** filters the component sidebar to only the
+components whose output is a compatible connection source for that input, and the
+**legacy** / **beta** sidebar toggles expand that set. Removing the filter
+(the `icon-X` on the filter chip) restores the normal sidebar.
+
+The test drives an **API Request** node and exercises two of its inputs:
+
+1. **`url` input handle** → the sidebar filters to string-compatible sources;
+   toggling **legacy** reveals legacy components (Chat Input/Output, Prompt
+   Template, CSV Agent, ConversationChain, Prompt Hub) and toggling **beta** off
+   hides beta-only ones (Prompt Hub).
+2. **`headers` input handle** (a `Data`-typed input) → the sidebar filters to
+   `Data`-compatible sources; under the beta filter it includes data sources
+   (API Request, Astra DB), flow control (Sub Flow), and processing components.
+
+---
+
+## Tags
+
+`@release` `@components` `@api`
+
+---
+
+## Step by step
+
+1. Bootstrap; open a blank flow; drag an **API Request** node onto the canvas.
+   The created flow is captured from `POST /api/v1/flows → 201` and deleted
+   id-scoped in `afterEach`.
+2. Click the `url` input handle → assert the filter chip (`icon-ListFilter`)
+   shows and the expected category disclosures are visible.
+3. Enable the **legacy** toggle → assert legacy components appear; disable the
+   **beta** toggle → assert the beta-only Prompt Hub disappears.
+4. Reset the filter (`sidebar-filter-reset`) → assert the filtered components are
+   no longer visible.
+5. Open the inspector, add the advanced `headers` field to the node body
+   (`inspector-add-headers`), close the inspector, and click the `headers` input
+   handle → assert the data-sources / llm-operations / processing disclosures and
+   representative compatible components are visible (API Request, Astra DB, Sub
+   Flow).
+6. Enable **beta** → assert Sub Flow and a processing component (`Create Data`)
+   remain visible.
+7. Remove the filter (`icon-X`) → assert the previously-filtered components are
+   hidden.
+
+---
+
+## Validation criterion
+
+| Step | Criterion |
+|---|---|
+| `url` handle clicked | `icon-ListFilter` visible; category disclosures visible |
+| legacy on / beta off | legacy components visible; `Prompt Hub` hidden with beta off |
+| `headers` handle clicked | `data_sourceAPI Request`, `datastaxAstra DB`, `flow_controlsSub Flow` visible |
+| beta on (headers filter) | `flow_controlsSub Flow` and `processingCreate Data` visible |
+| filter removed | the filtered components (`data_sourceAPI Request`, `datastaxAstra DB`, `flow_controlsSub Flow`, `processingSplit Text`) hidden |
+
+---
+
+## External dependencies
+
+- API Request component (its `url` and advanced `headers` inputs).
+- `tests/helpers/ui/open-advanced-options.ts` — `openAdvancedOptions` /
+  `closeAdvancedOptions` (dev46 inspector; `inspector-add-headers`).
+- Sidebar legacy/beta toggles (`sidebar-options-trigger`, `sidebar-legacy-switch`,
+  `sidebar-beta-switch`) and the filter chip (`icon-ListFilter`, `icon-X`,
+  `sidebar-filter-reset`).
+- No model provider credentials required.
+
+---
+
+## What this test does not cover
+
+- The actual creation of a connection from the filtered sidebar.
+- Every compatible component — it asserts representative ones per state.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+
+---
+
+## Notes
+
+- dev46 migration (issue #818): two drifts. (1) `showheaders` →
+  `inspector-add-headers` (the advanced `headers` field is now added to the node
+  body via the inspector). (2) The set of components compatible with the `headers`
+  `Data` input evolved — the monolithic **Data Operations** component was split
+  into granular ops (Create Data, Select Data, Update Data, …), so the stale
+  `processingData Operations` assertion was updated to `processingCreate Data`, a
+  representative compatible processing component present under the beta filter.
+  The connection-filtering behavior itself is unchanged; only the representative
+  component changed. Added id-scoped `afterEach` flow cleanup.
+- Validated on `1.11.0.dev46` (2026-07-20): 3/3 green (~52s), `--workers=1
+  --retries=0`, 0 orphan flows. Force-fail: asserting a component that is not in
+  the compatible set (`processingSplit Text`) fails.

--- a/tests/tests-automations/regression/ui-ux/filterSidebar.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/filterSidebar.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
@@ -5,12 +6,46 @@ import {
   closeAdvancedOptions,
   openAdvancedOptions,
 } from "../../../helpers/ui/open-advanced-options";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+
+// Capture every flow THIS page creates from its POST /api/v1/flows → 201
+// responses and delete them id-scoped in afterEach (repo convention, #490/#681).
+const createdFlowIds: string[] = [];
+
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {});
+    }
+  });
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, {
+      headers: { Authorization: bearer },
+    }).catch(() => {});
+  }
+});
 
 test(
   "user must see on handle click the possibility connections",
   { tag: ["@release", "@components", "@api"] },
 
   async ({ page }) => {
+    trackCreatedFlows(page);
     await awaitBootstrapTest(page);
 
     await page.waitForSelector('[data-testid="blank-flow"]', {
@@ -115,7 +150,9 @@ test(
 
     await openAdvancedOptions(page);
 
-    await page.getByTestId("showheaders").click();
+    // dev46: add the advanced `headers` field to the node body via the inspector
+    // (replaces the old show<field> toggle), then connect from its input handle.
+    await page.getByTestId("inspector-add-headers").click();
     await closeAdvancedOptions(page);
     await page.getByTestId("handle-apirequest-shownode-headers-left").click();
 
@@ -135,7 +172,10 @@ test(
 
     await expect(page.getByTestId("flow_controlsSub Flow")).toBeVisible();
 
-    await expect(page.getByTestId("processingData Operations")).toBeVisible();
+    // dev46 split the monolithic "Data Operations" component into granular ops;
+    // assert a processing component that is compatible with the Data-typed
+    // `headers` input and present under the beta filter.
+    await expect(page.getByTestId("processingCreate Data")).toBeVisible();
 
     await page.getByTestId("icon-X").first().click();
 


### PR DESCRIPTION
Part of #818 — daily-failure cluster, dev46 testid drift (@release). Follow-up to merged #837–#847. **Last spec in the cluster.**

## Problem

Two drifts:

1. **Mechanical:** `showheaders` → the advanced `headers` field is now added to the node body via the inspector.
2. **Behavioral (product changed):** the set of components compatible with the API Request `headers` (`Data`) input evolved — the monolithic **Data Operations** component was split into granular ops (Create Data, Select Data, Update Data, Type Convert, …). `processingData Operations` is no longer in the compatible set.

The connection-filtering behavior itself still works (the sidebar filters to a compatible subset) — only the specific representative component the test asserted dropped out of the set.

## Changes

- `showheaders` → `inspector-add-headers`.
- `processingData Operations` → `processingCreate Data` (a representative compatible processing component present under the beta filter). `Sub Flow` (L128/136) remains compatible in the test's legacy-on state and is unchanged.
- Add id-scoped `afterEach` flow cleanup and the missing spec doc.

## Validation (1.11.0.dev46, one runner on a local backend)

- **3/3 green** — `--workers=1 --retries=0` (~52s each).
- `npm run typecheck` + `npm run lint` — 0 errors.
- 0 orphan flows (id-scoped `afterEach`).
- **Force-fail:** asserting a component not in the compatible set (`processingSplit Text`) fails.

```bash
npx playwright test tests/tests-automations/regression/ui-ux/filterSidebar.spec.ts --workers=1 --retries=0
```

Part of #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)