### PR TITLE
fix(ci): regenerate-retry the coverage-summary push (concurrent-main-advance race)

### DIFF
--- a/.github/workflows/update-coverage-summary.yml
+++ b/.github/workflows/update-coverage-summary.yml
@@ -53,4 +53,29 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add QA-CHECKLIST.md
           git commit -m "chore(checklist): auto-update coverage summary [skip ci]"
-          git push
+          # Push with regenerate-retry. A bare push loses the fast-forward race
+          # when another commit lands on main first (concurrent merge, or a
+          # parallel run of this same workflow), dying "! [rejected] (fetch
+          # first)" and dropping the regenerated table. Because the Coverage
+          # Summary is a DETERMINISTIC function of source, the safe retry is to
+          # re-sync onto the newest main and regenerate on top of it (a plain
+          # rebase could conflict inside the generated block). Same
+          # concurrent-push class as the daily-history fix (#818).
+          for attempt in 1 2 3 4 5; do
+            if git push; then
+              echo "Coverage summary pushed (attempt $attempt)."
+              exit 0
+            fi
+            echo "::warning::push rejected (attempt $attempt) — re-syncing onto origin/main, regenerating, retrying."
+            git fetch origin main
+            git reset --hard origin/main
+            npm run coverage:summary
+            if git diff --quiet QA-CHECKLIST.md; then
+              echo "Coverage Summary already up to date on the new main — nothing to commit."
+              exit 0
+            fi
+            git add QA-CHECKLIST.md
+            git commit -m "chore(checklist): auto-update coverage summary [skip ci]"
+          done
+          echo "::error::Could not push coverage summary after 5 attempts."
+          exit 1


### PR DESCRIPTION
## What & why

Follow-up to #849. The `update-coverage-summary.yml` **Commit and push if changed** step did a bare `git push`. When another commit lands on `main` first — a concurrent PR merge, or a parallel run of this same push-triggered workflow — the push is rejected `! [rejected] (fetch first)` and the regenerated Coverage Summary is silently dropped. Same concurrent-push class as the daily-history bug fixed in #849.

## Change

Wrap the push in a 5-attempt retry loop. Because the Coverage Summary is a **deterministic function of source**, on rejection we re-sync onto the newest `main` (`fetch` + `reset --hard origin/main`) and **regenerate** on top of it, rather than rebasing a stale generated diff (a plain rebase could conflict inside the generated block). If the fresh regeneration is a no-op (someone else already updated it), the step exits clean.

## Verification

- `actionlint .github/workflows/update-coverage-summary.yml` → exit 0 (no warnings)
- YAML parses clean

Refs #818.

🤖 Generated with [Claude Code](https://claude.com/claude-code)