### PR TITLE
fix(llm-agents): migrate Agent Controls editing to dev49 inspector (#818)

### DIFF
--- a/docs/core-functionality/llm-agents/agent-current-date-tool.md
+++ b/docs/core-functionality/llm-agents/agent-current-date-tool.md
@@ -97,11 +97,11 @@ machinery (family standard). Per model, a serial describe with two tests:
 **Test 2 — toggle OFF: the date tool is removed from the toolkit (§6.5)**
 
 1–2. Same template load and Instructions (fresh load; new nonce).
-3. Open the Agent controls dialog (`edit-button-modal`), assert the
-   pre-flip default is ON (`toggle_bool_edit_add_current_date_tool` has
+3. Open the Agent node inspector (`parameters-button`), assert the
+   pre-flip default is ON (`toggle_bool_add_current_date_tool` has
    `aria-checked="true"` — a changed template default fails loudly instead
    of silently inverting the test), click it, assert `aria-checked="false"`,
-   close (`edit-button-close`), wait for the flow save to settle.
+   close (`inspection-panel-close`), wait for the flow save to settle.
 4. Seed the same task (new nonce); open the Playground, send, wait.
 5. **Absence assert (API):** the session's AI message(s) must contain
    **zero** `get_current_date` `tool_use` blocks. The final AI bubble must

--- a/docs/core-functionality/llm-agents/agent-max-iterations.md
+++ b/docs/core-functionality/llm-agents/agent-max-iterations.md
@@ -67,8 +67,8 @@ Shared setup per test (identical except `max_iterations`):
 - Set the Agent Instructions (`textarea_str_system_prompt`) to force use of the
   URL fetch tool for any URL question, so the agent **attempts a tool call** —
   which needs more than one model call — instead of answering in one shot.
-- Open the Agent **Controls** dialog (`edit-button-modal`); set
-  `int_int_edit_max_iterations`; close (`edit-button-close`).
+- Open the Agent node inspector (`parameters-button`); set
+  `int_int_max_iterations`; close (`inspection-panel-close`).
 - Set the task on the **ChatInput node** (`textarea_str_input_value`) and
   `waitForFlowSaveSettled` (the Playground prompt pre-fills from the node —
   typing into the Playground races an async default re-injection; see
@@ -143,8 +143,8 @@ flaky). The fetch is SSRF-blocked backend-side, but that is irrelevant — the
 
 - `src/backend/base/langflow/components/agents/` — the Agent executor and its
   `max_iterations` enforcement; the fix this spec guards lives here.
-- `src/frontend/src/CustomNodes/GenericNode/` — the Agent **Controls** dialog
-  (`int_int_edit_max_iterations`).
+- `src/frontend/src/CustomNodes/GenericNode/` — the Agent node inspector
+  (`int_int_max_iterations`).
 - `src/frontend/src/components/core/playgroundComponent/` — Playground I/O and
   the AI message bubble carrying the `Model call limits exceeded` message.
 - The Simple Agent template's **URL fetch tool** — the forcer that makes the
@@ -158,8 +158,8 @@ flaky). The fetch is SSRF-blocked backend-side, but that is irrelevant — the
 
 - If the terminal message wording changes from `Model call limits exceeded: run
   limit (N/N)`.
-- If the Agent Controls field testids change
-  (`int_int_edit_max_iterations`, `toggle_bool_edit_add_calculator_tool`).
+- If the Agent node field testids change
+  (`int_int_max_iterations`, `toggle_bool_edit_add_calculator_tool`).
 - If the Simple Agent template or the calculator tool is renamed/rewired.
 
 ---

--- a/docs/core-functionality/llm-agents/agent-max-tokens.md
+++ b/docs/core-functionality/llm-agents/agent-max-tokens.md
@@ -66,8 +66,8 @@ The spec generates **2 tests per active model** via `getTestTargets()`
 
 Shared setup per test:
 1. Load the Simple Agent template.
-2. Set **Max Tokens** in the Agent **Controls** dialog
-   (`edit-button-modal` → `int_int_edit_max_tokens` → `edit-button-close`).
+2. Set **Max Tokens** in the Agent node inspector
+   (`parameters-button` → `int_int_max_tokens` → `inspection-panel-close`).
    **The int field rejects Playwright's `fill()`** (the controlled input keeps
    an empty DOM value) and swallows the first keystroke of an immediate
    `pressSequentially` (a typed "50" becomes a clamped "1") — the setter must
@@ -149,8 +149,8 @@ Shared setup per test:
   `_get_max_tokens_value()` (empty/`0` ⇒ `None` ⇒ unlimited).
 - `src/lfx/base/models/unified_models/instantiation.py` — provider-specific
   mapping via `max_tokens_field_name` (Google ⇒ `max_output_tokens`).
-- `src/frontend/src/CustomNodes/GenericNode/` — the Agent Controls dialog
-  (`int_int_edit_max_tokens`) and its int-field input handling.
+- `src/frontend/src/CustomNodes/GenericNode/` — the Agent node inspector
+  (`int_int_max_tokens`) and its int-field input handling.
 - `src/frontend/src/components/core/playgroundComponent/` — the
   `chat-message-token-usage` badge and its Input/Output tooltip.
 - Provider LLM API — a live key; real model calls.
@@ -159,7 +159,7 @@ Shared setup per test:
 
 ## When to review this test *(optional)*
 
-- If the Controls field testid changes from `int_int_edit_max_tokens`.
+- If the node field testid changes from `int_int_max_tokens`.
 - If the token-usage tooltip format changes (`Output:` label, `N.NK`
   abbreviation).
 - If the Agent regains a temperature/reasoning parameter (re-scope the §7.7
@@ -169,7 +169,7 @@ Shared setup per test:
 
 ## Notes *(optional)*
 
-- **Int fields in the Controls dialog reject `fill()`** — Playwright's
+- **Int fields in the node inspector reject `fill()`** — Playwright's
   programmatic set never reaches the controlled component (DOM value stays
   `""`), and fast typing loses the first keystroke to a re-render, after which
   the remainder is clamped to the field's `range_spec` min (typed "50" →

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-current-date-tool.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-current-date-tool.spec.ts
@@ -6,6 +6,10 @@ import type { APIRequestContext } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import {
+  closeAdvancedOptions,
+  openAdvancedOptions,
+} from "../../../../helpers/ui/open-advanced-options";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import {
@@ -217,14 +221,19 @@ async function setChatInputText(page: Page, text: string): Promise<void> {
 // fails loudly instead of silently inverting the test's meaning (pattern
 // from agent-config-persistence.spec.ts).
 async function setCurrentDateToggleOff(page: Page): Promise<void> {
-  await page.getByTestId("edit-button-modal").click();
-  const toggle = page.getByTestId("toggle_bool_edit_add_current_date_tool");
+  // dev49: add_current_date_tool is an advanced field — expose it on the node
+  // body via the inspector (replaces the old Controls dialog / edit-button-modal),
+  // then flip its toggle on the body.
+  await page.locator('[data-testid^="rf__node-Agent"]').first().click();
+  await openAdvancedOptions(page);
+  await page.getByTestId("inspector-add-add_current_date_tool").click();
+  await closeAdvancedOptions(page);
+  const toggle = page.getByTestId("toggle_bool_add_current_date_tool");
   await expect(toggle).toBeVisible({ timeout: 15000 });
   await toggle.scrollIntoViewIfNeeded();
   await expect(toggle).toHaveAttribute("aria-checked", "true");
   await toggle.click();
   await expect(toggle).toHaveAttribute("aria-checked", "false");
-  await page.getByTestId("edit-button-close").click();
 }
 
 async function waitForAgentToFinish(page: Page): Promise<void> {

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-max-iterations.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-max-iterations.spec.ts
@@ -6,6 +6,10 @@ import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
 import {
+  closeAdvancedOptions,
+  openAdvancedOptions,
+} from "../../../../helpers/ui/open-advanced-options";
+import {
   hasProviderEnvKeys,
   missingProviderEnvKeys,
   providerConfigMap,
@@ -168,12 +172,18 @@ async function setSystemPrompt(page: Page, prompt: string): Promise<void> {
 // Open the Agent Controls dialog, set max_iterations, and close. The template's
 // URL tool (default) is the forcer — no extra tool needs enabling.
 async function setMaxIterations(page: Page, maxIterations: string): Promise<void> {
-  await page.getByTestId("edit-button-modal").click();
-  const maxIter = page.getByTestId("int_int_edit_max_iterations");
+  // dev49: max_iterations is an advanced field — expose it on the node body via
+  // the inspector (replaces the old Controls dialog / edit-button-modal), then
+  // fill it on the body.
+  await page.locator('[data-testid^="rf__node-Agent"]').first().click();
+  await openAdvancedOptions(page);
+  await page.getByTestId("inspector-add-max_iterations").click();
+  await closeAdvancedOptions(page);
+  const maxIter = page.getByTestId("int_int_max_iterations");
   await expect(maxIter).toBeVisible({ timeout: 15000 });
   await maxIter.scrollIntoViewIfNeeded();
   await maxIter.fill(maxIterations);
-  await page.getByTestId("edit-button-close").click();
+  await maxIter.blur();
 }
 
 // Set the task on the ChatInput node (the Playground prompt pre-fills from it;

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-max-tokens.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-max-tokens.spec.ts
@@ -6,6 +6,10 @@ import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
 import {
+  closeAdvancedOptions,
+  openAdvancedOptions,
+} from "../../../../helpers/ui/open-advanced-options";
+import {
   hasProviderEnvKeys,
   missingProviderEnvKeys,
   providerConfigMap,
@@ -148,9 +152,16 @@ async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<v
 // actually PERSISTED via the flows API — reopening the dialog and retrying the
 // whole cycle when it did not.
 async function setMaxTokens(page: Page, value: string): Promise<void> {
+  // dev49: max_tokens is an advanced field — expose it on the node body via the
+  // inspector once (replaces the old Controls dialog / edit-button-modal), then
+  // fill it on the body. The int field still rejects fill() and swallows a fast
+  // first keystroke, so keep the slow-type + DOM-verify + persistence retry.
+  await page.locator('[data-testid^="rf__node-Agent"]').first().click();
+  await openAdvancedOptions(page);
+  await page.getByTestId("inspector-add-max_tokens").click();
+  await closeAdvancedOptions(page);
+  const field = page.getByTestId("int_int_max_tokens");
   for (let attempt = 1; attempt <= 3; attempt++) {
-    await page.getByTestId("edit-button-modal").click();
-    const field = page.getByTestId("int_int_edit_max_tokens");
     await expect(field).toBeVisible({ timeout: 15000 });
     await field.scrollIntoViewIfNeeded();
     for (let typeTry = 0; typeTry < 3; typeTry++) {
@@ -164,7 +175,6 @@ async function setMaxTokens(page: Page, value: string): Promise<void> {
     await expect(field).toHaveValue(value);
     await field.press("Tab");
     await page.waitForTimeout(800);
-    await page.getByTestId("edit-button-close").click();
     await waitForFlowSaveSettled(page);
     if ((await getSavedMaxTokens(page)) === Number(value)) return;
     console.warn(`setMaxTokens: value did not persist (attempt ${attempt}) — retrying`);


### PR DESCRIPTION
Part of #818 — testid-drift cluster. **Today's daily failures on dev49.** Follow-up to merged #837–#848.

## Problem

The dev49 nightly removed the Agent **Controls** dialog (`edit-button-modal`); its advanced int/bool fields are now edited on the node body after exposing them through the inspector. Three `@stable` `@agents` specs failed on today's daily:

| old | new |
|---|---|
| `edit-button-modal` | `parameters-button` (`openAdvancedOptions`) |
| *(expose advanced field)* | `inspector-add-<field>` |
| `int_int_edit_max_iterations` | `int_int_max_iterations` |
| `int_int_edit_max_tokens` | `int_int_max_tokens` |
| `toggle_bool_edit_add_current_date_tool` | `toggle_bool_add_current_date_tool` |
| `edit-button-close` | `closeAdvancedOptions` |

## Changes

- **agent-max-iterations** — `setMaxIterations` exposes + fills `max_iterations`.
- **agent-max-tokens** — `setMaxTokens` exposes `max_tokens` once, keeps the slow-type + DOM-verify + persistence retry (the int field still rejects `fill()`).
- **agent-current-date-tool** — `setCurrentDateToggleOff` exposes + flips the toggle.

Only the field-access mechanism changed; each test's run/assert logic is intact. Spec docs updated.

## Validation (1.11.0.dev49, one runner on a local backend, providers active)

- **iterations 2/2** (~31s), **tokens 2/2** (~45s), **current-date 2/2** (~66s).
- `npm run typecheck` + `npm run lint` — 0 errors.
- 0 orphan flows.
- **Force-fail:** breaking each spec's `inspector-add-<field>` fails it (iterations, tokens, and the current-date "toggle OFF" test all fail on the mutation).

```bash
npx playwright test tests/tests-automations/regression/core-functionality/llm-agents/agent-max-iterations.spec.ts tests/tests-automations/regression/core-functionality/llm-agents/agent-max-tokens.spec.ts tests/tests-automations/regression/core-functionality/llm-agents/agent-current-date-tool.spec.ts --workers=1 --retries=0
```

## Not included

`agent-config-persistence` (the 4th `edit-button-modal` spec) — its `loadTemplateByName` loads the Agent node collapsed, so the body field inputs don't render without a reliable expand step; handled in a focused follow-up.

Part of #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)