### PR TITLE
fix(llm-agents): migrate agent-config-persistence to dev49 inspector (#818)

### DIFF
--- a/docs/core-functionality/llm-agents/agent-config-persistence.md
+++ b/docs/core-functionality/llm-agents/agent-config-persistence.md
@@ -7,9 +7,10 @@
 ## What this test validates *(required)*
 
 QA-CHECKLIST §6.2 "Flow with Agent saved and reopened → settings preserved".
-Agent settings edited through the node's **Controls** dialog must survive the
-full persistence round-trip: autosave writes them to the flow document, and
-reopening the flow from the home page renders them back.
+Agent settings edited on the node (advanced fields exposed via the node
+**inspector** side-panel) must survive the full persistence round-trip:
+autosave writes them to the flow document, and reopening the flow from the
+home page renders them back.
 
 One test drives three sentinels covering the template's three field
 serializations:
@@ -26,7 +27,8 @@ Both persistence halves are asserted:
 1. **Saved** — after `waitForFlowSaveSettled`, the flows API shows the three
    sentinel values in the Agent node's template.
 2. **Reopened preserved** — navigating home and reopening the flow from its
-   card, the Controls dialog renders the exact sentinels.
+   card, the node body renders the exact sentinels (the inspector-added
+   fields persist on the body across reload).
 
 If this fails, agent configuration silently reverts on reload — users lose
 prompt/limit/tool settings without any error.
@@ -65,33 +67,44 @@ Agent configuration surface; `@workspace` — flow save/reopen lifecycle.
    of existing flows (a wipe kills parallel workers' in-flight flows, #553;
    duplicate names auto-suffix) — the spec deletes its own flow by id in
    `afterEach`. No provider setup (model-free).
-2. Open the Agent's **Controls** dialog. The `edit-button-modal` toolbar
-   button only renders with the node selected AND the Inspector Panel hidden
-   (`hideInspectorPanel` first, then click the Agent node).
-3. Set the sentinels:
-   - `textarea_str_edit_system_prompt` → `PERSIST_PROBE_<nonce>` — **typed,
-     never `fill()`**: the dialog textarea is a controlled input that only
-     registers real keystrokes — a `fill()`ed edit passes the DOM check but
-     is silently dropped on close (~50% of runs), and the node-level
-     textarea + `fill()`/blur does not trigger autosave at all on 1.11
-     (0/5 runs persisted). Clear + `pressSequentially` in a retry loop with
-     a DOM verification between attempts (select-all fired before focus
-     settles selects nothing and the nonce lands in front of the default);
-   - `int_int_edit_max_iterations` → `7` — int fields reject `fill()` and
-     swallow fast keystrokes (see `agent-max-tokens.md`): click, settle,
-     clear, slow `pressSequentially`, verify the DOM value;
-   - `toggle_bool_edit_add_current_date_tool` — assert `aria-checked="true"`
+2. `adjustScreenView` to render the Agent node (the template loads with the
+   node outside the initial viewport, so its body fields do not mount until
+   the canvas is fit — the sibling agent specs get this for free from
+   `SimpleAgentTemplatePage.load`, which this model-free spec does not use),
+   then `waitForFlowSaveSettled` — the load + fit-view schedule an autosave
+   whose response would otherwise revert the first edit.
+3. Expose the advanced fields. dev49 replaced the old **Controls** dialog
+   (`edit-button-modal`) with the node **inspector** side-panel: select the
+   Agent node → `parameters-button` (`openAdvancedOptions`) → toggle
+   `inspector-add-max_iterations` and `inspector-add-add_current_date_tool`
+   to expose both on the node body → `inspection-panel-close`
+   (`closeAdvancedOptions`). Add both in ONE inspector session, then
+   `waitForFlowSaveSettled` — the add-autosave (debounced PATCH) must land
+   before any value is edited, or its response re-renders the node and
+   detaches the field mid-edit (the documented autosave race).
+4. Set the sentinels on the node body, `waitForFlowSaveSettled` after each so
+   the serialized edits never race one another's PATCH. On the body the field
+   testids drop the `_edit_` infix:
+   - `textarea_str_system_prompt` → `PERSIST_PROBE_<nonce>` — on the body by
+     default (no inspector-add). **Clear + typed, never `fill()`**: the
+     node-level textarea is a controlled input that `fill()` sets in the DOM
+     without marking the node dirty, so the edit never autosaves and is
+     reverted on the next re-render (0/5 persisted historically). Real
+     keystrokes (`pressSequentially`) commit it;
+   - `int_int_max_iterations` → `7` — body int field: `fill()` + blur (verify
+     the DOM value);
+   - `toggle_bool_add_current_date_tool` — assert `aria-checked="true"`
      (template default), click, assert `"false"`.
-4. Close (`edit-button-close`) and `waitForFlowSaveSettled`.
 5. **Saved assert (API):** fetch the flow by the id captured at creation
    (`GET /api/v1/flows/{id}` — the canvas URL id is transient on 1.11, so
    the id comes from the template-instantiation `POST` response, not the
    URL) and poll until the Agent template shows all three sentinel values.
 6. Navigate home (`page.goto("/")`), reopen the flow via its
-   `flow-name-<id>` card, wait for the canvas.
-7. Reopen the Controls dialog (same hide-inspector + select-node dance).
-8. **Reopened assert (UI):** the three dialog fields render the exact
-   sentinels (nonce string, `7`, `aria-checked="false"`).
+   `flow-name-<id>` card, wait for the canvas, `adjustScreenView`.
+7. **Reopened assert (UI):** the inspector-added fields persist on the body
+   across reload, so the three body fields render the exact sentinels
+   directly (nonce string, `7`, `aria-checked="false"`) — no re-open of the
+   inspector needed.
 
 ---
 
@@ -108,9 +121,9 @@ after a full home-navigation reopen. Any missing/reverted field fails.
 - **Pre-flip assertion** on the bool — proves the test wrote the value; a
   changed template default fails loudly instead of silently inverting the
   sentinel's meaning.
-- **Int-field write verified in the DOM** before closing the dialog (the
-  known fill/keystroke quirks would otherwise save a clamped value — which
-  the API assert would also catch, a double guard).
+- **Int-field write verified in the DOM** (`toHaveValue("7")`) before the
+  save assert — a clamped or dropped value fails here as well as in the API
+  assert, a double guard.
 - **API assert before the reload** — separates "was never saved" from "saved
   but not re-rendered", so a failure pinpoints the broken half.
 - **Force-failure checks** (CONTRIBUTING §2): M1 — expect a different int via

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-config-persistence.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-config-persistence.spec.ts
@@ -2,7 +2,11 @@ import type { Page } from "@playwright/test";
 import type { APIRequestContext } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { loadTemplateByName } from "../../../../helpers/flows/load-template-by-name";
-import { hideInspectorPanel } from "../../../../helpers/ui/hide-inspector-panel";
+import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
+import {
+  closeAdvancedOptions,
+  openAdvancedOptions,
+} from "../../../../helpers/ui/open-advanced-options";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 
@@ -19,35 +23,31 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
  *            asserted, so the flip is a proven write, not a default).
  *
  * Both persistence halves are asserted: the flows API after save settles
- * (saved), and the Controls dialog after a full home-navigation reopen
+ * (saved), and the node body after a full home-navigation reopen
  * (re-rendered). See the spec doc for the false-positive guards.
+ *
+ * dev49: the old Controls dialog (edit-button-modal) is gone. max_iterations
+ * and add_current_date_tool are advanced fields exposed on the node body via
+ * the inspector side-panel (select node → parameters-button → inspector-add
+ * → inspection-panel-close); system_prompt is on the body by default. Body
+ * inputs accept fill() (the controlled-dialog typing quirk left with the
+ * modal). The inspector-added fields persist on the body across reload, so
+ * the reopened assert reads them directly.
  */
 
 const MAX_ITERATIONS_SENTINEL = "7";
 
-// The Controls dialog trigger (edit-button-modal) only renders with the node
-// selected AND the Inspector Panel hidden.
-async function openAgentControls(page: Page): Promise<void> {
-  await hideInspectorPanel(page);
+// Expose the given advanced Agent fields on the node body in ONE inspector
+// session, then close. Doing all the adds before touching any value keeps the
+// add-autosave (debounced PATCH) from re-rendering the node mid-edit and
+// detaching a field being filled (waitForFlowSaveSettled's documented race).
+async function addAgentFieldsToBody(page: Page, fields: string[]): Promise<void> {
   await page.locator('[data-testid^="rf__node-Agent"]').first().click();
-  const trigger = page.getByTestId("edit-button-modal");
-  await expect(trigger).toBeVisible({ timeout: 15000 });
-  await trigger.click();
-  await expect(page.getByTestId("int_int_edit_max_iterations")).toBeVisible({
-    timeout: 15000,
-  });
-}
-
-// Int fields reject fill() and swallow fast keystrokes (see
-// agent-max-tokens.md): click, settle, clear, slow-type, verify the DOM.
-async function setIntField(page: Page, testId: string, value: string): Promise<void> {
-  const field = page.getByTestId(testId);
-  await field.click();
-  await page.waitForTimeout(600);
-  await page.keyboard.press("ControlOrMeta+a");
-  await page.keyboard.press("Backspace");
-  await field.pressSequentially(value, { delay: 150 });
-  await expect(field).toHaveValue(value, { timeout: 5000 });
+  await openAdvancedOptions(page);
+  for (const field of fields) {
+    await page.getByTestId(`inspector-add-${field}`).click();
+  }
+  await closeAdvancedOptions(page);
 }
 
 // Fetch the flow by the id captured at template instantiation (the canvas URL
@@ -94,45 +94,62 @@ test(
     await test.step("load the Simple Agent template (no provider setup — model-free)", async () => {
       flowId = await loadTemplateByName(page, "Simple Agent");
       createdFlowId = flowId;
+      // Fit the canvas so the Agent node (loaded outside the initial viewport)
+      // mounts its body fields — SimpleAgentTemplatePage does this for the
+      // sibling agent specs; this model-free spec must do it itself.
+      await adjustScreenView(page);
+      // The template load + fit-view schedule a debounced autosave PATCH.
+      // Editing before it lands lets its response re-render the node from
+      // server state and revert the edit — settle it FIRST (the sibling specs
+      // get this settle from provider setup, which this spec skips).
+      await waitForFlowSaveSettled(page);
     });
 
-    await test.step("set string, int and bool sentinels in the Controls dialog", async () => {
-      await openAgentControls(page);
+    await test.step("expose the two advanced fields on the node body", async () => {
+      // Add both advanced fields in one inspector session, then let the
+      // add-autosave settle BEFORE editing any value — otherwise the PATCH
+      // response detaches the just-filled field mid-edit.
+      await addAgentFieldsToBody(page, ["max_iterations", "add_current_date_tool"]);
+      await waitForFlowSaveSettled(page);
+    });
 
-      // The dialog's fields are controlled inputs that only register REAL
-      // keystrokes: fill() sets the DOM value but the edit is silently
-      // dropped on close (node-level fill+blur doesn't trigger autosave at
-      // all on 1.11 — 0/5 runs persisted). Clear + type is the only path
-      // that reliably commits the textarea.
-      const prompt = page.getByTestId("textarea_str_edit_system_prompt");
-      // Select-all fired before focus settles selects nothing and the typed
-      // nonce lands IN FRONT of the default text — clear+type is retried
-      // with a DOM verification between attempts (same family as the int
-      // field's swallowed-first-event quirk).
-      for (let attempt = 0; attempt < 3; attempt++) {
-        await prompt.click();
-        await page.waitForTimeout(600);
-        await page.keyboard.press("ControlOrMeta+a");
-        await page.keyboard.press("Backspace");
-        await prompt.pressSequentially(nonce, { delay: 20 });
-        if ((await prompt.inputValue()) === nonce) break;
-      }
+    await test.step("set string, int and bool sentinels on the node body", async () => {
+      // system_prompt is on the body by default. Clear + type (never fill()):
+      // the node-level textarea is a controlled input that fill() sets in the
+      // DOM without marking the node dirty, so the edit never autosaves and is
+      // reverted on the next re-render (0/5 persisted historically). Real
+      // keystrokes commit it.
+      const prompt = page.locator(
+        '[data-testid^="rf__node-Agent"] [data-testid="textarea_str_system_prompt"]',
+      );
+      await expect(prompt).toBeVisible({ timeout: 15000 });
+      await prompt.scrollIntoViewIfNeeded();
+      await prompt.click();
+      await page.keyboard.press("ControlOrMeta+a");
+      await page.keyboard.press("Backspace");
+      await prompt.pressSequentially(nonce, { delay: 20 });
       await expect(prompt).toHaveValue(nonce, { timeout: 5000 });
-      await page.keyboard.press("Tab");
-      await page.waitForTimeout(800);
+      await prompt.blur();
+      await waitForFlowSaveSettled(page);
 
-      await setIntField(page, "int_int_edit_max_iterations", MAX_ITERATIONS_SENTINEL);
+      // max_iterations (int) — body int fields accept fill() + blur.
+      const maxIter = page.getByTestId("int_int_max_iterations");
+      await expect(maxIter).toBeVisible({ timeout: 15000 });
+      await maxIter.scrollIntoViewIfNeeded();
+      await maxIter.fill(MAX_ITERATIONS_SENTINEL);
+      await expect(maxIter).toHaveValue(MAX_ITERATIONS_SENTINEL, { timeout: 5000 });
+      await maxIter.blur();
+      await waitForFlowSaveSettled(page);
 
-      // Assert the pre-flip default so the flip below is a proven WRITE — a
-      // changed template default fails loudly here instead of silently
-      // inverting the sentinel's meaning.
-      const toggle = page.getByTestId("toggle_bool_edit_add_current_date_tool");
+      // add_current_date_tool (bool) — assert the pre-flip default so the flip
+      // is a proven WRITE (a changed template default fails loudly instead of
+      // silently inverting the sentinel).
+      const toggle = page.getByTestId("toggle_bool_add_current_date_tool");
+      await expect(toggle).toBeVisible({ timeout: 15000 });
+      await toggle.scrollIntoViewIfNeeded();
       await expect(toggle).toHaveAttribute("aria-checked", "true");
       await toggle.click();
       await expect(toggle).toHaveAttribute("aria-checked", "false");
-
-      await page.waitForTimeout(800);
-      await page.getByTestId("edit-button-close").click();
       await waitForFlowSaveSettled(page);
     });
 
@@ -170,20 +187,22 @@ test(
       await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
         timeout: 30000,
       });
+      await adjustScreenView(page);
     });
 
-    await test.step("reopened: node and Controls dialog render the exact sentinels", async () => {
-      await openAgentControls(page);
-
-      await expect(page.getByTestId("textarea_str_edit_system_prompt")).toHaveValue(
-        nonce,
-        { timeout: 10000 },
-      );
-      await expect(page.getByTestId("int_int_edit_max_iterations")).toHaveValue(
+    await test.step("reopened: node body renders the exact sentinels", async () => {
+      // The inspector-added fields persist on the body across reload — read
+      // them directly (no inspector re-open needed).
+      await expect(
+        page.locator(
+          '[data-testid^="rf__node-Agent"] [data-testid="textarea_str_system_prompt"]',
+        ),
+      ).toHaveValue(nonce, { timeout: 10000 });
+      await expect(page.getByTestId("int_int_max_iterations")).toHaveValue(
         MAX_ITERATIONS_SENTINEL,
       );
       await expect(
-        page.getByTestId("toggle_bool_edit_add_current_date_tool"),
+        page.getByTestId("toggle_bool_add_current_date_tool"),
       ).toHaveAttribute("aria-checked", "false");
     });
   },


### PR DESCRIPTION
## What & why

Migrates `agent-config-persistence.spec.ts` (`@stable @regression @agents @workspace`) to the dev49 node **inspector** model. **Last item of the edit-button-modal cluster** under #818 — that sub-cluster is now **4/4 complete** (agent-max-iterations, agent-max-tokens, agent-current-date-tool merged in #852; this closes config-persistence).

dev49 removed the Controls dialog (`edit-button-modal`). Advanced Agent fields are now exposed on the node body via the inspector side-panel (`parameters-button` → `inspector-add-<field>` → `inspection-panel-close`), and on-body field testids drop the `_edit_` infix:

- `int_int_edit_max_iterations` → `int_int_max_iterations`
- `toggle_bool_edit_add_current_date_tool` → `toggle_bool_add_current_date_tool`
- `textarea_str_edit_system_prompt` → `textarea_str_system_prompt`

## The tricky part (root cause)

The earlier "collapsed node" symptom was actually a **non-settled node**. This spec is model-free (`loadTemplateByName`, no provider setup), so it edited before the load/fit-view debounced autosave PATCH landed — the response re-rendered the node from server state, **reverting the edit and detaching just-added fields** (the same race `waitForFlowSaveSettled` documents). The sibling agent specs dodge it because `SimpleAgentTemplatePage.load` settles the node via provider setup.

**Fix:**
1. `adjustScreenView` + `waitForFlowSaveSettled` after load (initial settle).
2. `inspector-add` **both** advanced fields in one panel session → close → settle **before** editing values.
3. Edit each value serialized with `waitForFlowSaveSettled` between.
4. `system_prompt` (on-body default) is **clear + typed, never `fill()`** — the body textarea sets the DOM without marking the node dirty, so `fill()` never autosaves and is reverted on the next re-render (the historical 0/5 note still holds on the dev49 body). Int fields accept `fill()`.

## Validation

- Instance: `1.11.0.dev49` (nightly).
- `npx playwright test .../agent-config-persistence.spec.ts --workers=1 --retries=0` → **1 passed (~16s)**.
- **Force-fail**: wrote `5` into `max_iterations` → the saved-assert failed reading the truly-persisted `5 ≠ 7`, proving it detects a real persistence regression (no false positive).
- `npm run typecheck` 0 errors · `npm run lint` 0 errors (pre-existing warnings only).
- **0 orphaned flows** (id-scoped `afterEach` cleanup verified).
- Spec doc updated to match (SDD gate — doc written/reconciled with the test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)