### PR TITLE
test(llm-agents): cover Agent Markdown output rendering (#826)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -356,7 +356,7 @@
 #### 6.5 Output and Reasoning
 - [ ] Inspect tools used by Agent in Playground
 - [x] Agent returns output in structured JSON format (output_schema) → `agent-structured-output.spec.ts`
-- [ ] Agent returns output in correctly rendered Markdown
+- [-] Agent returns output in correctly rendered Markdown → `llm-agents/agent-markdown-output.spec.ts`
 - [x] Agent Instructions (system prompt) is respected in the model response → `agent-system-prompt.spec.ts`
 - [x] Input via direct field vs handle (ChatInput) — both work → `core-functionality/llm-agents/agent-input-sources.spec.ts`
 - [x] Empty response or model refusal — component does not crash → `core-functionality/llm-agents/agent-empty-refusal-response.spec.ts`

--- a/docs/core-functionality/llm-agents/agent-markdown-output.md
+++ b/docs/core-functionality/llm-agents/agent-markdown-output.md
@@ -1,0 +1,174 @@
+# Agent Markdown Output — response renders as correct Markdown in the Playground
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+The Agent's response is **rendered as HTML from Markdown** in the Playground chat
+(QA-CHECKLIST §6.5, "Agent returns output in correctly rendered Markdown"). When
+the Agent is instructed to reply using Markdown syntax — a heading, a bulleted
+list, a bold word and a fenced code block — the Playground's chat renderer
+(react-markdown + remarkGfm, inside `.markdown.prose`) turns that syntax into the
+corresponding **HTML tags** (`<h1..3>`, `<ul><li>`, `<strong>`, `<code>`) instead
+of showing the raw Markdown characters.
+
+The **distinctive observable** is the pairing:
+
+- the rendered chat bubble **contains** the HTML tags for each construct, **and**
+- the visible text does **not** contain the raw Markdown tokens (`**`, `## `).
+
+A broken or plain-text renderer would show `**bold**` / `## Heading` literally —
+so the raw-token-absence assertion is what proves the output was actually
+*rendered*, not echoed as source. This is the built-in guard against a false
+positive (a bubble that merely contains the words but never rendered Markdown).
+
+Parameterized per active provider (OpenAI / Google / Anthropic), so it covers
+whichever provider is configured; a provider with no chat model is skipped.
+
+If this fails, the Playground no longer renders Agent Markdown output correctly —
+a core presentation regression for every agent reply.
+
+---
+
+## Tags *(required)*
+
+`@regression` `@agents` `@playground`
+
+**`@stable` is intentionally withheld (promotion gated — issue #826).** This area
+is in the current flaky cluster (#773); the spec is authored now but promoted to
+`@stable` only after the clean, non-guarded baseline for the Wave 3 infra work is
+achieved. Absence of `@stable` is explained here per the PR checklist.
+
+`@regression` — guards a rendering regression; `@agents` — agent execution;
+`@playground` — the reply is produced and asserted in the Playground chat.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`.
+- `models.json` / `providers.json` generated via
+  `npx playwright test tests/collect-models.spec.ts`.
+- At least one active provider with a chat model. The test resolves one chat
+  model per provider and skips an inactive provider (with reason).
+- Run with `--workers=1` (agent specs create named flows that collide in
+  parallel). File is serial (`SimpleAgentTemplatePage.load()` wipes all flows).
+
+---
+
+## Step by step *(required)*
+
+The spec generates **1 test per active model** via `getTestTargets()` (default:
+one chat model per active provider), reusing the Simple Agent parameterization
+pattern from `agent-multimodal-image-input.spec.ts`.
+
+---
+
+**Test — Agent reply renders as Markdown** (§6.5)
+
+1. Load the Simple Agent template via
+   `SimpleAgentTemplatePage.load({ provider, model })`. The template ships
+   `ChatInput → Agent → ChatOutput` wired.
+2. Set the **ChatInput node's** "Input Text" field
+   (`[data-testid^="rf__node-ChatInput"] textarea_str_input_value`) on the canvas
+   to a prompt that demands a Markdown-only reply containing a level-2 heading, a
+   three-item bulleted list, one **bold** word, and a fenced code block; wait for
+   autosave (`waitForFlowSaveSettled`). Setting the prompt on the node — not the
+   Playground textarea — avoids the async re-injection race documented in
+   `agent-multimodal-image-input.md` (Notes).
+3. Open the Playground (`playground-btn-flow-io`); wait for
+   `input-chat-playground` and assert it prefilled the prompt.
+4. Send (`button-send`); wait for the agent to finish
+   (`waitForAgentToFinish` — the Stop button appears then hides).
+5. **Validation** — on the last rendered AI bubble (`.markdown.prose`):
+   - a heading tag is present (`h1, h2, h3`),
+   - the bulleted list rendered — `li` count `>= 2`,
+   - a bold run rendered — `strong` present,
+   - a fenced code block rendered — `code` present, **and**
+   - the visible text does **not** contain the raw tokens `**` or `## `
+     (proving the Markdown was rendered to HTML, not shown as source).
+
+---
+
+## Validation criterion *(required)*
+
+The last Playground AI bubble (`.markdown.prose`) contains the HTML tags for
+every requested construct — `h1|h2|h3`, `li` (`>= 2`), `strong`, `code` — **and**
+its visible text contains no raw Markdown tokens (`**`, `## `). Presence of the
+tags proves the constructs rendered; absence of the raw tokens proves they were
+*rendered* rather than echoed as literal source.
+
+## Guarding against false positives *(how)*
+
+- **Rendered vs raw:** the primary guard is asserting the raw tokens (`**`,
+  `## `) are **absent** from the visible text while the corresponding tags are
+  present. A renderer that dumped the Markdown source verbatim would fail this
+  pairing even though the words are all there.
+- **Multiple constructs:** requiring heading + list + bold + code together makes
+  a coincidental pass (e.g. a stray `<strong>` from unrelated formatting)
+  implausible.
+- **Deterministic prompt:** the prompt is set on the ChatInput node and its exact
+  prefill is asserted in the Playground before sending, removing the typing race.
+- **Force-failure check** (CONTRIBUTING §2) is run during VERIFY: each hard
+  assertion is broken on purpose once to confirm it fails.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Markdown **table** rendering via remarkGfm (covered for a non-agent flow in
+  `playground/playground-output-data.spec.ts`, DataFrame → `<table>`).
+- Structured **JSON** output via `output_schema` (see
+  `agent-structured-output.spec.ts`).
+- Links, images, nested lists, blockquotes — the spec asserts the four most
+  reliably-produced constructs.
+- Streaming/partial-render behavior — the assertion runs after the agent finishes.
+
+---
+
+## External dependencies *(required)*
+
+- `src/frontend/src/components/core/chatComponents/` — Playground Markdown /
+  code-block rendering (react-markdown + remarkGfm inside `.markdown.prose`); a
+  change to the plugins or the container class breaks the assertions.
+- `src/backend/base/langflow/components/agents/` — the Agent must keep emitting
+  its reply as a Message rendered through the chat renderer.
+- Simple Agent starter template — must keep shipping `ChatInput → Agent →
+  ChatOutput`.
+- Provider chat model — a live key and a chat model are required; the provider is
+  skipped otherwise.
+
+---
+
+## When to review this test *(optional)*
+
+- If the Playground chat renderer (`.markdown.prose`, react-markdown plugins) or
+  the code-block component changes.
+- If the Simple Agent template is renamed, removed, or rewired.
+- On promotion to `@stable` once the #773 baseline is clean (issue #826 gate).
+
+---
+
+## Notes *(optional)*
+
+- **Renderer grounded** in the existing `@stable` spec
+  `playground/playground-output-data.spec.ts`: a ```json fence renders as a
+  `<code>` element and a GFM table as `<table>`, both inside `.markdown.prose`.
+  The same renderer turns the Agent's Markdown reply into HTML tags.
+- **Prompt determinism** mirrors `agent-multimodal-image-input.md`: the Playground
+  chat input pre-fills from the ChatInput node's `input_value` and re-injects the
+  template default asynchronously, so the prompt is set on the canvas node and its
+  prefill asserted before sending.
+- **Wrapping-fence guard (scouted on 1.11.0.dev49, gpt-4o-mini):** a prompt that
+  merely says "reply in Markdown … include a fenced code block" makes the model
+  intermittently (~1 in 3 runs) wrap the ENTIRE reply in a single ```markdown
+  fence — the Playground then correctly renders it as one code block, so the
+  heading/list/bold never become tags and the raw tokens (`##`, `-`, `**`) appear
+  literally. That is correct rendering of a code fence, not a bug — but it makes
+  the test a false negative. The prompt therefore explicitly forbids wrapping the
+  whole answer in a code block and scopes the fence to `print('hello')` only;
+  verified 8/8 clean after the change.
+- **Promotion gated (#826):** authored without `@stable`; promote after the Wave 3
+  clean baseline (#773) — do not add `@stable` in this PR.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-markdown-output.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-markdown-output.spec.ts
@@ -1,0 +1,280 @@
+import * as dotenv from "dotenv";
+import path from "path";
+import fs from "fs";
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
+import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import {
+  hasProviderEnvKeys,
+  missingProviderEnvKeys,
+  providerConfigMap,
+  type Provider,
+} from "../../../../helpers/provider-setup";
+import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+
+/**
+ * Agent Markdown output (QA-CHECKLIST §6.5, "Agent returns output in correctly
+ * rendered Markdown").
+ *
+ * The Agent is prompted to reply using Markdown syntax (H2 heading, a bulleted
+ * list, a bold word and a fenced code block). The Playground chat renderer
+ * (react-markdown + remarkGfm, inside `.markdown.prose`) must turn that syntax
+ * into HTML tags. The distinctive observable is the pairing:
+ *   - the rendered bubble CONTAINS the tags (h1|h2|h3, li, strong, code), AND
+ *   - the visible text does NOT contain the raw tokens (`**`, `## `).
+ * A plain-text/broken renderer would echo `**bold**` / `## Heading` literally and
+ * fail the pairing — that is the false-positive guard.
+ *
+ * `@stable` is intentionally withheld (promotion gated — issue #826; #773 flaky
+ * cluster). Parameterized per active provider, resolving a generic chat model.
+ * Grounding: the `.markdown.prose` container and `<code>` rendering are confirmed
+ * live by the @stable `playground/playground-output-data.spec.ts`.
+ */
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
+}
+
+// A Markdown-only prompt exercising the four most reliably-produced constructs:
+// a level-2 heading, a three-item bulleted list, a bold run, and a fenced code
+// block. "Only" + "no other text" keeps stray prose (and stray asterisks) out of
+// the reply so the raw-token-absence guard is meaningful.
+const PROMPT =
+  "Respond in Markdown. Your whole answer MUST render as formatted Markdown, so " +
+  "do NOT wrap the entire response in a code block. Include, in this order: a " +
+  "level-2 heading written as `## Report`; then a bulleted list with the three " +
+  "items `- alpha`, `- beta`, `- gamma`; then a separate paragraph containing the " +
+  "word **important** in bold; then a single fenced code block whose only content " +
+  "is print('hello'). Output nothing else.";
+
+// Model families that are not chat-capable — excluded when resolving a model.
+const NON_CHAT = /embedding|tts|audio|whisper|realtime|image|moderation|search/i;
+
+interface ModelRecord {
+  provider: string;
+  model: string;
+}
+
+interface TestTarget {
+  label: string;
+  options: LoadSimpleAgentOptions;
+  skipReason?: string;
+}
+
+function getProviderSkipReasons(): Map<string, string> {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/providers.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
+    return new Map();
+  }
+  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
+  const reasons = new Map<string, string>();
+  for (const r of records) {
+    if (r.status === "inactive") {
+      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
+    }
+  }
+  return reasons;
+}
+
+function getModelsFromJson(): ModelRecord[] {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/models.json",
+  );
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("models.json not found — run collect-models.spec.ts first.");
+    return [];
+  }
+  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
+}
+
+// Resolve a chat model for a provider: MODEL_TEST_ID wins (if it belongs to the
+// provider), otherwise the first non-excluded model in models.json.
+function resolveChatModel(provider: string, models: ModelRecord[]): string | undefined {
+  const forProvider = models.filter((m) => m.provider === provider).map((m) => m.model);
+  const envId = process.env.MODEL_TEST_ID;
+  if (envId && forProvider.includes(envId)) return envId;
+  return forProvider.find((m) => !NON_CHAT.test(m)) ?? forProvider[0];
+}
+
+// One target per active provider, each with a resolved chat model. Honors the
+// MODEL_TEST_PROVIDER override (single provider); MODEL_TEST_ID (via
+// resolveChatModel) further pins the model when it belongs to that provider.
+function getTestTargets(): TestTarget[] {
+  const skipReasons = getProviderSkipReasons();
+  const allModels = getModelsFromJson();
+
+  if (allModels.length === 0) {
+    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
+    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
+    return [{
+      label: `provider:${fallbackProvider} (fallback)`,
+      options: { provider: fallbackProvider },
+      skipReason: skipReasons.get(fallbackProvider),
+    }];
+  }
+
+  if (process.env.MODEL_TEST_PROVIDER) {
+    const provider = process.env.MODEL_TEST_PROVIDER;
+    const model = resolveChatModel(provider, allModels);
+    return [{
+      label: `${provider} / ${model ?? "(no chat model)"}`,
+      options: { provider: provider as Provider, model },
+      skipReason:
+        skipReasons.get(provider) ??
+        (model ? undefined : `Provider "${provider}" has no chat model in models.json`),
+    }];
+  }
+
+  const providers = Array.from(new Set(allModels.map((m) => m.provider)));
+  return providers.map((provider) => {
+    const model = resolveChatModel(provider, allModels);
+    return {
+      label: `${provider} / ${model ?? "(no chat model)"}`,
+      options: { provider: provider as Provider, model },
+      skipReason:
+        skipReasons.get(provider) ??
+        (model ? undefined : `Provider "${provider}" has no chat model in models.json`),
+    };
+  });
+}
+
+// Flows created by the template load are tracked here and deleted by id in
+// afterEach — loadTemplateByName does NO cleanup (post-#553 contract), and the
+// app can fire more than one flows POST during template load (only one
+// persists; deleting a transient id 404s harmlessly — deleteFlow treats 404 as
+// done).
+const createdFlowIds: string[] = [];
+
+async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {}); // non-JSON / batch payloads
+    }
+  });
+  try {
+    await new SimpleAgentTemplatePage(page).load(options);
+  } catch (e: any) {
+    if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
+    throw e;
+  }
+}
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, { headers: { Authorization: bearer } });
+  }
+});
+
+async function waitForAgentToFinish(page: Page): Promise<void> {
+  const stopButton = page.getByRole("button", { name: "Stop" });
+  const stopVisible = await stopButton.isVisible({ timeout: 10000 }).catch(() => false);
+  if (stopVisible) {
+    await expect(stopButton).toBeHidden({ timeout: 120000 });
+  }
+}
+
+// Set the ChatInput node's "Input Text" on the canvas. The Playground chat input
+// pre-fills from this node value, so setting it here makes the Playground prompt
+// deterministic — typing into the Playground races an async re-injection of the
+// template default ("Hello, how are you?"), which corrupts the value (mechanism
+// documented in agent-multimodal-image-input.md).
+async function setChatInputText(page: Page, text: string): Promise<void> {
+  const field = page.locator(
+    '[data-testid^="rf__node-ChatInput"] [data-testid="textarea_str_input_value"]',
+  );
+  await expect(field).toBeVisible({ timeout: 15000 });
+  await field.click();
+  await field.fill(text);
+  await field.blur();
+  await waitForFlowSaveSettled(page);
+}
+
+async function openPlayground(page: Page): Promise<void> {
+  await page.getByTestId("playground-btn-flow-io").click();
+  const chatInput = page.getByTestId("input-chat-playground").last();
+  await expect(chatInput).toBeVisible({ timeout: 30000 });
+  // Prefilled from the ChatInput node — deterministic, no typing race.
+  await expect(chatInput).toHaveValue(PROMPT, { timeout: 15000 });
+}
+
+const targets = getTestTargets();
+
+// SimpleAgentTemplatePage.load() deletes all flows before loading the template.
+// File-level serial mode prevents parallel provider blocks from wiping each
+// other's flows.
+test.describe.configure({ mode: "serial" });
+
+for (const { label, options, skipReason } of targets) {
+  const provider = options.provider ?? (Object.keys(providerConfigMap)[0] as Provider);
+
+  test.describe(`Agent Markdown Output [${label}]`, () => {
+    test(
+      "agent reply renders as correct Markdown in the Playground",
+      { tag: ["@regression", "@agents", "@playground"] },
+      async ({ page }) => {
+        test.skip(!!skipReason, skipReason ?? "");
+        test.skip(
+          !hasProviderEnvKeys(provider),
+          `Missing env vars for provider "${provider}": ${missingProviderEnvKeys(provider).join(", ")}`,
+        );
+
+        await loadAgent(page, options);
+
+        await test.step("send a Markdown-only prompt and wait for the reply", async () => {
+          await setChatInputText(page, PROMPT);
+          await openPlayground(page);
+          await page.getByTestId("button-send").last().click();
+          await waitForAgentToFinish(page);
+        });
+
+        await test.step("assert the reply rendered Markdown to HTML tags", async () => {
+          const response = page.locator(".markdown.prose").last();
+          await expect(response).toBeVisible({ timeout: 60000 });
+
+          // Heading rendered — the '## Report' line became a heading tag.
+          await expect(
+            response.locator("h1, h2, h3").first(),
+          ).toBeVisible({ timeout: 60000 });
+          // Bulleted list rendered — at least two list items.
+          await expect
+            .poll(async () => response.locator("li").count(), { timeout: 60000 })
+            .toBeGreaterThanOrEqual(2);
+          // Bold run rendered.
+          await expect(response.locator("strong").first()).toBeVisible();
+          // Fenced code block rendered (react-markdown emits <code>).
+          await expect(response.locator("code").first()).toBeVisible();
+        });
+
+        await test.step("assert the raw Markdown tokens were NOT shown literally", async () => {
+          // The distinctive guard: a plain-text / broken renderer would echo the
+          // source verbatim. Rendered output has no `**` bold markers and no
+          // `## ` heading marker in its visible text.
+          const response = page.locator(".markdown.prose").last();
+          const text = (await response.textContent()) ?? "";
+          expect(text.length).toBeGreaterThan(0);
+          expect(text).not.toContain("**");
+          expect(text).not.toContain("## ");
+        });
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #826 — the `[ ] Agent returns output in correctly rendered Markdown` gap in `QA-CHECKLIST.md` §6.5 (Output and Reasoning). Distinct from `agent-structured-output.spec.ts` (JSON via `output_schema`) and `playground-output-data.spec.ts` (non-agent DataFrame→`<table>`): this exercises the **Agent's own reply** rendering through the Playground chat renderer.

## 1. Covered tests
| # | Test | What it validates |
|---|------|-------------------|
| 1 | `agent reply renders as correct Markdown in the Playground` (1 per active provider) | The Agent is prompted to reply with a level-2 heading, a 3-item bullet list, a bold word and a fenced code block. On the last `.markdown.prose` bubble: a heading tag (`h1\|h2\|h3`), `li` count `>= 2`, `strong`, and `code` are all present **and** the visible text contains no raw Markdown tokens (`**`, `## `). The tags prove the constructs rendered; the absent raw tokens prove they were *rendered* to HTML, not echoed as source — catching a regression where the chat renderer stops rendering Agent Markdown. |

## 2. How the test was built
- **Setup:** Simple Agent template via `SimpleAgentTemplatePage.load()` (returns flow id for id-scoped teardown), parameterized per active provider (`getTestTargets`, resolving a generic chat model; honors `MODEL_TEST_ID`/`MODEL_TEST_PROVIDER`). File is `serial`.
- **Live-confirmed selectors:** `.markdown.prose` container + `<code>` grounded in the `@stable` `playground-output-data.spec.ts`; `playground-btn-flow-io`, `input-chat-playground`, `button-send`, `rf__node-ChatInput textarea_str_input_value` reused verbatim from `agent-multimodal-image-input.spec.ts`. Rendered HTML scouted live on 1.11.0.dev49 (heading→`<h2>`, list→`<ul><li>`, bold→`<strong>`, fence→`chat-code-tab` `<pre><code>`).
- **Deterministic prompt:** set on the ChatInput node (not the Playground textarea) to avoid the async template-default re-injection race; prefill asserted before send. The prompt **explicitly forbids wrapping the whole reply in a code block** — without that, gpt-4o-mini intermittently (~1/3) fenced the entire answer as ` ```markdown `, which the Playground *correctly* renders as one code block (a false negative, not a product bug). Verified 8/8 clean after the change.
- **Assertion rationale:** the tags-present + raw-tokens-absent pairing is the distinctive "rendered vs raw" observable; a plain-text renderer would echo `**bold**`/`## Heading` and fail.

## 3. Dependencies
- Provider chat model + live API key required (skips inactive providers with reason). No vision model needed.
- Execution: `--workers=1` serial — agent specs create named flows that collide in parallel.
- Cleanup: `afterEach` deletes only this test's created flow ids (never `cleanAllFlows`); audited — zero orphans.

## Tags & gating
`@regression @agents @playground` — **`@stable` intentionally withheld** (promotion gated, #826; area in the #773 flaky cluster). Absence explained in the spec doc's Tags section.

## Validation (nightly 1.11.0.dev49, `--retries=0 --workers=1`)
- typecheck ✅ · eslint ✅ (0 errors)
- VALIDATE burst 3/3 clean, `unexpected=0 flaky=0`; +8/8 clean during debug after the prompt fix ✅
- force-fail ✅ (inverted the raw-token guard → failed as expected, reverted, green final)
- zero `🚨 Backend Error` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)