### PR TITLE
fix(core-components): migrate Prompt Template double-brackets to dev49 inspector (#807)

### DIFF
--- a/docs/core-components/prompt-template-double-brackets-regression.md
+++ b/docs/core-components/prompt-template-double-brackets-regression.md
@@ -1,6 +1,6 @@
 # Prompt Template Component — `use_double_brackets` Toggle Regression
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.11.x (nightly `1.11.0.dev49`)
 
 ---
 
@@ -8,7 +8,7 @@
 
 Validates the **Prompt Template** component's `use_double_brackets` toggle and the mustache code path it activates, end-to-end via 5 scenarios:
 
-1. **Toggle is exposed in the InspectionPanel with its upstream display name** — the upstream field carries `advanced=True`, which only filters it from the on-canvas node body; the right-hand InspectionPanel still renders the bool control directly (`toggle_bool_use_double_brackets`) along with the literal display name "Use Double Brackets", confirming the upstream `BoolInput(display_name=...)` wiring is intact. (The `info` string is rendered as a hover-tooltip icon when the panel is narrow, so it is not asserted directly.)
+1. **Field is exposed in the InspectionPanel with its upstream display name** — the upstream field carries `advanced=True`. dev49: it no longer renders on the on-canvas node body by default and the auto-opening InspectionPanel is gone; the field is listed in the on-demand inspector side-panel (open via `parameters-button`) as `inspector-param-use_double_brackets`, carrying the literal display name "Use Double Brackets" — confirming the upstream `BoolInput(display_name=...)` wiring is intact. (Its actual `toggle_bool_use_double_brackets` control renders on the node body once exposed via `inspector-add-use_double_brackets`; the mode-switch tests drive it through the `setUseDoubleBrackets` helper, which handles that exposure.)
 2. **Default toggle state is `False` (f-string mode)** — saving `Hello {single} and {{double}}!` extracts only `single` and treats `{{double}}` as a literal `{double}` per f-string escape semantics; exactly one dynamic handle is rendered.
 3. **Enabling the toggle switches the parser to mustache mode** — after flipping the toggle ON, saving `Hello {single} and {{double}}!` extracts only `double`; `{single}` is ignored by the mustache parser.
 4. **Disabling the toggle reverts to f-string mode and variables are re-extracted under the new parser** — a template saved in mustache mode (`Hello {{name}}!`) keeps its `name` handle past the toggle alone (the rendered handle set is only fully reconciled after the next save), but re-saving the same template after switching back to f-string drops the now-literal `{{name}}` handle, and a fresh `{var}` template then recreates a handle.
@@ -38,9 +38,9 @@ Every test starts with `addPromptComponent(page)` which:
 5. Calls `adjustScreenView(page)`
 6. Asserts exactly one node is on the canvas
 
-Tests 3–5 use the helper `flipDoubleBrackets(page, expectMustache)` which:
-1. Clicks `toggle_bool_use_double_brackets` in the InspectionPanel
-2. Waits for `button_open_mustache_prompt_modal` (when `expectMustache=true`) or `button_open_prompt_modal` (when `expectMustache=false`) — the type swap in `update_build_config` re-renders the modal-open button under the matching testid, which is a reliable signal that the field-type switch has landed
+Tests 3–5 use the helper `setUseDoubleBrackets(page, enabled)` which:
+1. dev49: ensures the `toggle_bool_use_double_brackets` control is on the node body — the advanced field is exposed via the inspector (`title-Prompt Template` → `parameters-button` → `inspector-add-use_double_brackets` → close) on first use, then the on-body toggle is clicked
+2. Waits for `button_open_mustache_prompt_modal` (when `enabled=true`) or `button_open_prompt_modal` (when `enabled=false`) — the type swap in `update_build_config` re-renders the modal-open button under the matching testid, which is a reliable signal that the field-type switch has landed
 
 Tests 2–4 use the helper `setPromptTemplate(page, value, mode)` which is parameterised on `mode`:
 - `"fstring"` → opens `button_open_prompt_modal` and fills `modal-promptarea_prompt_template`
@@ -49,7 +49,7 @@ Tests 2–4 use the helper `setPromptTemplate(page, value, mode)` which is param
 Both modes share the post-save preview (`edit-prompt-sanitized`) and the save button (`genericModalBtnSave`). The helper detects the preview state and re-enters edit mode automatically, so it is safe to call multiple times in a row.
 
 ### 1. `toggle is exposed in the InspectionPanel with its upstream display name`
-- Asserts `toggle_bool_use_double_brackets` is visible after the node is added to the canvas — the InspectionPanel renders advanced fields directly (`isCanvasVisible()` only filters the canvas node body, not the side panel).
+- dev49: opens the on-demand inspector (`title-Prompt Template` → `parameters-button`) and asserts `inspector-param-use_double_brackets` is visible — the advanced field is listed in the side-panel (the old auto-opening panel that rendered the bool control directly on canvas is gone).
 - Asserts the display name `"Use Double Brackets"` is visible — this string is the upstream `BoolInput(display_name=...)` value, so the assertion catches an accidental rename at the source. The `info` string ("Use `{{variable}}` syntax instead of `{variable}`.") is rendered as a hover-tooltip icon when the panel is narrow, so the visible rendering depends on layout state and is intentionally not asserted.
 
 ### 2. `default toggle state is OFF; f-string mode extracts {var} and treats {{var}} as literal`
@@ -81,7 +81,7 @@ Both modes share the post-save preview (`edit-prompt-sanitized`) and the save bu
 
 ## Validation criterion *(required)*
 
-- `toggle_bool_use_double_brackets` is visible in the InspectionPanel after the Prompt Template is added to a blank flow, alongside the display name "Use Double Brackets"
+- `inspector-param-use_double_brackets` is visible in the on-demand inspector (opened via `parameters-button`) after the Prompt Template is added to a blank flow, alongside the display name "Use Double Brackets"
 - In default (OFF) state, `{var}` produces a dynamic handle and `{{var}}` is treated as a literal escape
 - In ON state, `{{var}}` produces a dynamic handle and `{var}` is ignored by the parser
 - Flipping the toggle swaps the modal-open button (and underlying parser) between the f-string and mustache variants; saving the template under the new mode reconciles the rendered handle set to the new parser's output
@@ -132,7 +132,7 @@ Both modes share the post-save preview (`edit-prompt-sanitized`) and the save bu
 
 ## Notes *(optional)*
 
-- The InspectionPanel renders advanced fields directly: although `use_double_brackets` is `advanced=True`, the toggle is interactable without first opening any "show advanced options" UI. The upstream `isCanvasVisible()` filter only hides the field from the on-canvas node body, not from the side panel.
+- dev49: `use_double_brackets` is `advanced=True`, so its `toggle_bool_use_double_brackets` control is NOT on the node body by default and the old auto-opening InspectionPanel (which rendered advanced fields directly) is gone. The field must be exposed via the on-demand inspector (`parameters-button` → `inspector-add-use_double_brackets`) before the toggle can be driven — the shared `setUseDoubleBrackets` helper does this. The field is still listed in the inspector side-panel as `inspector-param-use_double_brackets`.
 - `flipDoubleBrackets` waits for the modal-open button to re-render under the testid that matches the target mode (`button_open_prompt_modal` ↔ `button_open_mustache_prompt_modal`). This is more robust than waiting for an arbitrary timeout — the testid swap is driven by `template.type` flipping between PROMPT and MUSTACHE_PROMPT in `update_build_config`, which is exactly the contract we want to verify is wired through.
 - Test 4 verifies the parser-switch contract end-to-end: toggling OFF swaps the modal-open button (proving the field-type change landed) and the subsequent f-string save reconciles the rendered handle set. We do **not** assert that handles disappear from the toggle alone, because empirically the rendered handle set lingers past `update_build_config` until the next save in the active mode.
 - All assertions use the literal node-type slug `"prompt template"` (with space) in the testid, matching how the frontend renders the type. The leading space inside `handle-prompt template-...` is intentional and not a typo.

--- a/docs/core-components/prompt-template-invalid-mustache-patterns-regression.md
+++ b/docs/core-components/prompt-template-invalid-mustache-patterns-regression.md
@@ -1,6 +1,6 @@
 # Prompt Template — Invalid Mustache Patterns Regression
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.11.x (nightly `1.11.0.dev49`)
 
 ---
 
@@ -36,7 +36,7 @@ None carry `@release` — these are defensive contract assertions, not happy-pat
 
 ## Step by step *(required)*
 
-Every test starts with the same `addPromptComponent(page)` helper used in the sibling specs (blank flow → sidebar search → add → adjust view → assert 1 node), followed by `enableMustacheMode(page)`, which clicks the `toggle_bool_use_double_brackets` toggle and waits for `button_open_mustache_prompt_modal` to mount (the re-render is the reliable signal that the validator switch has landed).
+Every test starts with the same `addPromptComponent(page)` helper used in the sibling specs (blank flow → sidebar search → add → adjust view → assert 1 node), followed by `setUseDoubleBrackets(page, true)`. dev49: `use_double_brackets` is an advanced field, so the helper first exposes its `toggle_bool_use_double_brackets` control on the node body via the inspector (`parameters-button` → `inspector-add-use_double_brackets` → close), then clicks the toggle and waits for `button_open_mustache_prompt_modal` to mount (the re-render is the reliable signal that the validator switch has landed).
 
 All four rejection cases then run the same step sequence via the `runMustacheRejectionContract` helper:
 

--- a/tests/helpers/ui/prompt-template.ts
+++ b/tests/helpers/ui/prompt-template.ts
@@ -2,6 +2,10 @@ import { type Locator, type Page, expect } from "@playwright/test";
 import { waitForFlowSaveSettled } from "../flows/wait-for-flow-save-settled";
 import { addComponentFromSidebar } from "../flows/add-component-from-sidebar";
 import { adjustScreenView } from "./adjust-screen-view";
+import {
+  closeAdvancedOptions,
+  openAdvancedOptions,
+} from "./open-advanced-options";
 
 // `waitForFlowSaveSettled` now lives in the flows domain (autosave is a flow
 // concern) and is shared with the rename helper (issues #358, #357). Re-export
@@ -87,6 +91,27 @@ export function dynamicHandlesLocator(page: Page): Locator {
 }
 
 /**
+ * Ensure the `use_double_brackets` toggle is present on the node body.
+ *
+ * dev49: `use_double_brackets` carries `advanced=True`, so it no longer renders
+ * on the node body by default and the auto-opening right-hand InspectionPanel
+ * (which used to surface advanced fields directly) is gone — the inspector is
+ * now the on-demand `parameters-button` side-panel. Expose the field on the
+ * body via `inspector-add-use_double_brackets` so its `toggle_bool_use_double_brackets`
+ * can be driven. Idempotent: if the toggle is already on the body (a prior
+ * call added it), this is a no-op.
+ */
+async function ensureDoubleBracketsToggleOnBody(page: Page): Promise<void> {
+  const toggle = page.getByTestId("toggle_bool_use_double_brackets");
+  if (await toggle.isVisible({ timeout: 500 }).catch(() => false)) return;
+  await page.getByTestId("title-Prompt Template").click();
+  await openAdvancedOptions(page);
+  await page.getByTestId("inspector-add-use_double_brackets").click();
+  await closeAdvancedOptions(page);
+  await expect(toggle).toBeVisible({ timeout: 10000 });
+}
+
+/**
  * Drive the `use_double_brackets` toggle to the given state. Idempotent — if
  * the UI is already in the requested mode the toggle is left alone; otherwise
  * the toggle is clicked once. Either way, the post-condition is that the
@@ -105,6 +130,7 @@ export async function setUseDoubleBrackets(
   page: Page,
   enabled: boolean,
 ): Promise<void> {
+  await ensureDoubleBracketsToggleOnBody(page);
   const expectedOpenButton = enabled
     ? MUSTACHE_OPEN_BUTTON
     : FSTRING_OPEN_BUTTON;

--- a/tests/tests-automations/regression/core-components/prompt-template-double-brackets-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/prompt-template-double-brackets-regression.spec.ts
@@ -8,6 +8,10 @@ import {
 } from "../../../helpers/ui/prompt-template";
 import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import {
+  closeAdvancedOptions,
+  openAdvancedOptions,
+} from "../../../helpers/ui/open-advanced-options";
 
 // Flows are created via the REST API (setupBlankFlow) and deleted in afterEach
 // (issue #545). Kept serial so the per-file flow lifecycle stays deterministic
@@ -44,11 +48,18 @@ test(
   "Prompt Template — use_double_brackets toggle is exposed in the InspectionPanel with its upstream display name",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
+    // dev49: `use_double_brackets` is an advanced field, so it no longer
+    // renders on the node body by default and the auto-opening InspectionPanel
+    // is gone. Open the on-demand inspector (parameters-button) where the
+    // advanced field is listed as `inspector-param-use_double_brackets`.
+    await page.getByTestId("title-Prompt Template").click();
+    await openAdvancedOptions(page);
+
     await test.step(
-      "Toggle is visible in the InspectionPanel by default",
+      "Field is exposed in the InspectionPanel",
       async () => {
         await expect(
-          page.getByTestId("toggle_bool_use_double_brackets"),
+          page.getByTestId("inspector-param-use_double_brackets"),
         ).toBeVisible({ timeout: 10000 });
       },
     );
@@ -60,26 +71,24 @@ test(
         // `BoolInput(..., display_name="Use Double Brackets", ...)` declaration —
         // asserting it catches an accidental rename at the source.
         //
-        // The assertion is anchored on the toggle: XPath climbs the ancestor
-        // axis from the toggle and picks the closest ancestor whose subtree
-        // contains the label string. If the label is renamed and no ancestor
-        // of the toggle has the text anymore, the locator resolves to zero
-        // elements and `toBeVisible()` fails — proving the label-toggle
-        // wiring regressed. A bare `getByText(...).first()` would match the
-        // string anywhere on the page and could be satisfied by an unrelated
-        // tooltip elsewhere, masking the same regression.
-        //
-        // The `info` text ("Use {{variable}} syntax …") is intentionally not
-        // asserted — the InspectionPanel collapses it into a hover-tooltip
-        // icon when the panel is narrow.
+        // The assertion is anchored on the field row: XPath climbs the
+        // ancestor-or-self axis from `inspector-param-use_double_brackets` and
+        // picks the closest node whose subtree contains the label string. If
+        // the label is renamed and the field row no longer carries the text,
+        // the locator resolves to zero elements and `toBeVisible()` fails —
+        // proving the label-field wiring regressed. A bare `getByText(...)`
+        // would match the string anywhere on the page and could be satisfied
+        // by an unrelated tooltip, masking the same regression.
         const labelOwner = page
-          .getByTestId("toggle_bool_use_double_brackets")
+          .getByTestId("inspector-param-use_double_brackets")
           .locator(
-            "xpath=ancestor::*[contains(., 'Use Double Brackets')][1]",
+            "xpath=ancestor-or-self::*[contains(., 'Use Double Brackets')][1]",
           );
         await expect(labelOwner).toBeVisible();
       },
     );
+
+    await closeAdvancedOptions(page);
   },
 );
 


### PR DESCRIPTION
## What & why

Resolves #807. The Prompt Template `use_double_brackets` toggle stopped being reachable on the nightly.

`use_double_brackets` carries `advanced=True`. **Previously** the node was auto-selected on add and the right-hand InspectionPanel auto-opened, rendering the advanced bool toggle directly on the canvas. **dev49 removed that auto-opening panel** (part of the `edit-button-modal` → `parameters-button` inspector change), so `toggle_bool_use_double_brackets` is no longer on the node body by default — the click timed out.

This surfaced as **two** daily-failure signatures:
- #807's named test — `prompt-template-invalid-mustache-patterns-regression.spec.ts` (`locator.click` timeout on the toggle, via the shared helper).
- `prompt-template-double-brackets-regression.spec.ts` — the "toggle is exposed in the InspectionPanel" assertion.

Reproduced **isolated** on `1.11.0.dev49` → real testid/DOM drift, not the daily's contention.

## Fix — expose the advanced field via the on-demand inspector before driving it

- **Shared helper `setUseDoubleBrackets`** (`tests/helpers/ui/prompt-template.ts`): added an idempotent `ensureDoubleBracketsToggleOnBody` step (`title-Prompt Template` → `parameters-button` → `inspector-add-use_double_brackets` → close) before toggling. This fixes **both** specs — the invalid-mustache spec is unchanged and inherits the fix through the helper.
- **double-brackets spec** "toggle is exposed in the InspectionPanel" test: reworked to open the inspector (`parameters-button`) and assert the field row `inspector-param-use_double_brackets` + its "Use Double Brackets" display name, instead of expecting the bool control on the canvas by default.

## Validation

- Instance `1.11.0.dev49`, `--workers=1 --retries=0`, single backend.
- Both specs: **9 passed / 0 failed / 0 skipped**.
- **Force-fail** confirmed: a bogus `inspector-add-use_double_brackets` in the helper and a bogus `inspector-param-use_double_brackets` in the test both fail as designed, then reverted.
- `npm run typecheck` 0 errors · `npm run lint` clean.
- **0 orphaned flows**.
- Spec docs updated to match (SDD), `Last validated` → 1.11.x (dev49).

Note: run with a single Langflow backend — this class of test times out at random setup points under multi-container CPU saturation (cf. #833).

🤖 Generated with [Claude Code](https://claude.com/claude-code)