### PR TITLE
test(mcp): guard Gemini × MCP tool-calling regression (upstream #440)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -651,6 +651,7 @@
 - [x] Duplicate MCP server registration returns 409 Conflict → `mcp/client/mcp-server-registration-status-codes.spec.ts`
 - [x] Deleting a non-existent MCP server returns 404 Not Found → `mcp/client/mcp-server-registration-status-codes.spec.ts`
 - [-] Agent uses MCPTools as tool and calls echo via MCP → `mcp/client/mcp-client-agent.spec.ts`
+- [-] Gemini × MCP tool-calling regression — agent runs but invokes no echo MCP tool (guards upstream #440) → `mcp/client/mcp-client-agent-gemini-tool-regression.spec.ts`
 - [ ] List available resources via MCP protocol
 - [ ] Consume resource URI and inject content into flow
 

--- a/docs/mcp/client/mcp-client-agent-gemini-tool-regression.md
+++ b/docs/mcp/client/mcp-client-agent-gemini-tool-regression.md
@@ -1,0 +1,135 @@
+# MCP Client – Gemini Tool-Calling Regression (#440)
+
+**Last validated:** Langflow 1.11.x
+**Tracking issue:** oriontech-me/langflow-e2e #858 · **Upstream bug:** langflow-ai/langflow #440
+
+---
+
+## What this test validates *(required)*
+
+Guards the **Gemini × MCP tool-calling** path in isolation: a Google/Gemini
+agent connected to an MCP tool must actually **invoke** that tool, not answer
+from memory. This is the exact behavior broken by upstream bug **#440** — on
+1.11.0 `gemini-2.5-flash` calls native Langflow tools (URL, Web Search,
+Calculator) but silently does **not** call MCP tools (`echo`).
+
+The behavior was invisible to the existing suite for three compounding reasons,
+all confirmed against `reports/daily-history.jsonl`:
+
+1. **Serial-skip cascade.** `mcp-client-agent.spec.ts` runs its three provider
+   variants (openai → anthropic → google) under a single file-scope
+   `mode: "serial"` group. The OpenAI variant runs first and flakes almost
+   daily on an unrelated `toBeHidden` (Stop button) timeout; in serial mode a
+   failure **skips every later test**, so the Gemini variant — the only one that
+   exercises #440 — is skipped before it runs (matches the 46–53 daily skips).
+2. **No provider label in the signal.** The daily history records only the bare
+   `test()` title (no `[provider/model]`), so even the one day the true #440
+   signature fired (2026-07-13, `"agent answered without invoking any tool"`) it
+   was indistinguishable from a generic/OpenAI failure.
+3. **Signal drowned in flake noise.** The same test fails most days with a
+   different (`toBeHidden`) signature, so the real #440 line reads as "that
+   flaky MCP test again."
+
+This guard neutralizes all three: its own file (no shared serial group),
+Gemini pinned and named in the test title (self-attributing signal), and a
+unique assertion read from the monitor API (backend truth, immune to frontend
+selector drift and to the `toBeHidden` flake).
+
+**Direction of the assert.** While #440 is **open upstream**, the test asserts
+the **currently-broken** behavior — the agent runs and answers but invokes **no**
+`echo` MCP tool — and therefore **passes** today. It **flips red the moment
+Langflow fixes #440** (an `echo` tool_use block starts being persisted): a red
+here is the promote signal — remove this guard and fold Gemini back into
+`mcp-client-agent`'s coverage.
+
+`test.fail()` was deliberately **rejected**. It converts *any* failure (a broken
+bootstrap, a down instance, an unregistered MCP server) into a green "expected
+failure" — proven live during authoring, where the test went green without ever
+reaching the #440 assertion because the template load timed out. That reproduces
+the very signal-masking this guard exists to escape. Instead, all setup asserts
+stay **loud** (infra breakage goes genuinely red), and only the final monitor-API
+check encodes the expected #440 state.
+
+---
+
+## Tags *(required)*
+
+`@mcp` `@agents` `@regression` `@model-provider`
+
+> **No `@stable` yet (intentional).** The test genuinely passes while #440 is
+> open (it asserts the broken state), so it is `@stable`-eligible in principle —
+> but it is held out of `@stable` until team-validated against a nightly with the
+> UI served, since authoring could only validate it statically (typecheck + lint)
+> against an API-only local instance. Promote after one green nightly run.
+> Absence tracked by upstream #440.
+
+---
+
+## Step by step *(required)*
+
+1. Pin the Gemini model via `resolveGeminiModel()`; `test.skip` on
+   `MODEL_NOT_AVAILABLE` or missing Google env key. All setup steps below use
+   loud asserts — infra breakage fails the test genuinely.
+2. Load Simple Agent template via `SimpleAgentTemplatePage` with
+   `{ provider: "google", model: <resolved gemini> }`.
+3. Delete any existing `everything` MCP server via API, then register via the
+   JSON tab; poll `GET /api/v2/mcp/servers?action_count=true` until `toolsCount`
+   is non-null.
+4. Add MCPTools to canvas; enable tool mode (`tool-mode-button`) — verify a new
+   "toolset" badge appears.
+5. Connect MCPTools toolset output handle → Agent tools input handle.
+6. Open Playground and send `"Use the 'echo' tool to echo: hello mcp (<nonce>)"`
+   (atomic set-value + send, per the #226 prefill-race hardening).
+7. Wait for the agent to finish; poll `GET /api/v1/monitor/messages` until the
+   agent turn for this session (keyed by the nonce) is persisted.
+8. Assert (pipeline ran): the final reply contains the echoed payload
+   (`hello mcp`).
+9. Assert (**the #440 flip**): the count of persisted `tool_use` blocks named
+   `/echo/i` for the session is **0** — Gemini invoked no `echo` MCP tool.
+
+---
+
+## Validation criterion *(required)*
+
+- **While #440 open:** step 8 passes (a reply with `hello mcp` is produced) **and**
+  step 9's `echoToolUseCount === 0` holds → the test **passes**, documenting the
+  bug. A false pass — the count reading 0 because the pipeline never ran — is
+  prevented by step 8 (the persisted reply proves the agent completed a turn, so
+  a tool call was genuinely possible) and by the loud setup asserts (a broken
+  bootstrap / MCP registration fails before reaching step 9).
+- **When #440 is fixed:** an `echo` `tool_use` block is persisted →
+  `echoToolUseCount > 0` → step 9 **fails loudly**, signalling that the guard
+  must be removed and Gemini folded back into `mcp-client-agent` coverage.
+
+---
+
+## External dependencies *(required)*
+
+- `tests/pages/SimpleAgentTemplatePage.ts` — loads Simple Agent template with configured provider/model
+- `tests/helpers/provider-setup/resolve-gemini-model.ts` — pins a deterministic Gemini flash model
+- `tests/helpers/provider-setup/` — provider env-key validation (`hasProviderEnvKeys`)
+- `src/frontend/src/modals/addMcpServerModal/index.tsx` — JSON tab; testids `json-tab`, `json-input`, `add-mcp-server-button`
+- `src/backend/base/langflow/api/v2/mcp.py` — `GET /api/v2/mcp/servers?action_count=true`, `DELETE /api/v2/mcp/servers/{name}`
+- `src/frontend/src/components/core/parameterRenderComponent/components/mcpComponent/index.tsx` — tool mode toggle and toolset handle
+- `GET /api/v1/monitor/messages` — persisted session messages; `content_blocks[].contents[]` with `type: "tool_use"` is the #440 observable
+- npm package `@modelcontextprotocol/server-everything` — launched via `npx` (provides `echo`)
+- **Upstream bug #440** — Langflow: Gemini does not invoke MCP tools (the behavior under guard)
+
+---
+
+## What this test does not cover *(optional)*
+
+- Native tool calling with Gemini (URL / Web Search / Calculator) — already green
+  in `agent-multi-tool-selection.spec.ts`; #440 is MCP-specific.
+- Other providers × MCP (OpenAI, Anthropic) — covered by `mcp-client-agent.spec.ts`.
+- Whether the Langflow fix is model-side or integration-side — the guard only
+  asserts the observable (tool invoked).
+
+---
+
+## Preconditions *(optional)*
+
+- `npx playwright test tests/collect-models.spec.ts` has populated
+  `models.json` with at least one Google/Gemini model.
+- `GOOGLE_API_KEY` present in the environment (daily provides it).
+- Run with `--workers=1` (agent specs create named flows).

--- a/tests/tests-automations/regression/mcp/client/mcp-client-agent-gemini-tool-regression.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-agent-gemini-tool-regression.spec.ts
@@ -1,0 +1,311 @@
+import * as dotenv from "dotenv";
+import path from "path";
+import fs from "fs";
+import type { Page, APIRequestContext } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
+import { hasProviderEnvKeys, missingProviderEnvKeys } from "../../../../helpers/provider-setup";
+import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+import { resolveGeminiModel } from "../../../../helpers/provider-setup/resolve-gemini-model";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+
+/**
+ * MCP Client – Gemini tool-calling regression (upstream Langflow #440).
+ *
+ * Guards the Gemini × MCP tool-calling path IN ISOLATION. On 1.11.0
+ * gemini-2.5-flash calls native Langflow tools (URL, Web Search, Calculator)
+ * but silently does NOT invoke MCP tools (`echo`) — bug #440. The generic
+ * mcp-client-agent.spec.ts could not surface this: its three provider variants
+ * share a file-scope `mode: "serial"` group, the OpenAI variant runs first and
+ * flakes daily on an unrelated `toBeHidden` timeout, and in serial mode a
+ * failure SKIPS every later test — so the Gemini variant (the only one that
+ * exercises #440) never ran. This file is deliberately standalone (no shared
+ * serial group), pins Gemini and names it in the title (self-attributing
+ * signal). See docs/mcp/client/mcp-client-agent-gemini-tool-regression.md.
+ *
+ * DIRECTION OF THE ASSERT (read before "fixing" this test):
+ * While #440 is OPEN, this test asserts the CURRENTLY-BROKEN behavior — the
+ * agent runs and answers but invokes NO `echo` MCP tool — via the monitor API
+ * (backend truth, immune to frontend selector drift). It therefore PASSES today
+ * and FLIPS RED the moment Langflow fixes #440 (an `echo` tool_use block starts
+ * being persisted). A red here is the promote signal: remove this guard, fold
+ * Gemini back into mcp-client-agent's coverage, promote to @stable.
+ * `test.fail()` was deliberately rejected: it converts ANY failure (a broken
+ * bootstrap, a down instance, an unregistered MCP server) into a green
+ * "expected failure", masking real breakage — proven live during authoring.
+ * Here the setup asserts stay LOUD: infra breakage goes genuinely red.
+ */
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
+}
+
+// Worker- and timestamp-suffixed name prevents cross-file races with the other
+// specs that also register an "everything" MCP server.
+const MCP_SERVER_NAME = `everything-gemini-${process.env.TEST_WORKER_INDEX ?? "0"}-${Date.now()}`;
+const MCP_JSON_CONFIG = JSON.stringify({
+  mcpServers: {
+    [MCP_SERVER_NAME]: {
+      command: "npx",
+      args: ["@modelcontextprotocol/server-everything"],
+    },
+  },
+});
+
+const PROVIDER = "google" as const;
+const ECHO_PAYLOAD = "hello mcp";
+
+// Google provider inactive-status reason from providers.json (collect-models),
+// mirroring the sibling specs' skip contract.
+function getGoogleSkipReason(): string | undefined {
+  const jsonPath = path.resolve(
+    __dirname,
+    "../../../../helpers/provider-setup/data/providers.json",
+  );
+  if (!fs.existsSync(jsonPath)) return undefined;
+  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
+  const record = records.find((r) => r.provider === PROVIDER);
+  return record?.status === "inactive"
+    ? `Provider "${PROVIDER}" inactive — ${record.error}`
+    : undefined;
+}
+
+let createdFlowId: string | undefined;
+
+async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
+  try {
+    createdFlowId = await new SimpleAgentTemplatePage(page).load(options);
+  } catch (e: any) {
+    if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
+    throw e;
+  }
+}
+
+async function waitForAgentToFinish(page: Page): Promise<void> {
+  const stopButton = page.getByRole("button", { name: "Stop" });
+  const stopVisible = await stopButton.isVisible({ timeout: 10000 }).catch(() => false);
+  if (stopVisible) {
+    await expect(stopButton).toBeHidden({ timeout: 120000 });
+  }
+}
+
+// Read the persisted agent turn for THIS run's session (keyed by the nonce in
+// the user message) from the monitor API — the backend truth, not the live
+// Playground bubble (which renders an empty placeholder mid-run and races the
+// stream). Returns null until the AI message is persisted, so callers poll on it.
+async function fetchPersistedAgentTurn(
+  request: APIRequestContext,
+  nonce: string,
+): Promise<{ replyText: string; echoToolUseCount: number } | null> {
+  const bearer = await getAuthToken(request);
+  const res = await request.get("/api/v1/monitor/messages", {
+    headers: { Authorization: bearer },
+  });
+  if (res.status() !== 200) return null;
+  const messages = await res.json();
+  if (!Array.isArray(messages)) return null;
+
+  const userMsg = messages.find(
+    (m: any) => m.sender !== "Machine" && (m.text ?? "").includes(nonce),
+  );
+  if (!userMsg) return null;
+
+  const aiMsgs = messages.filter(
+    (m: any) => m.sender === "Machine" && m.session_id === userMsg.session_id,
+  );
+  if (aiMsgs.length === 0) return null;
+
+  const echoToolUseCount = aiMsgs
+    .flatMap((m: any) => (m.content_blocks ?? []) as any[])
+    .flatMap((b: any) => (b.contents ?? []) as any[])
+    .filter((c: any) => c.type === "tool_use" && /echo/i.test(c.name ?? "")).length;
+
+  const replyText = aiMsgs.map((m: any) => m.text ?? "").join(" ");
+  return { replyText, echoToolUseCount };
+}
+
+const skipReason = getGoogleSkipReason();
+const geminiModel = resolveGeminiModel();
+
+test.describe(`MCP Client – Gemini tool regression (#440) [${PROVIDER} / ${geminiModel ?? "default"}]`, () => {
+  test.afterEach(async ({ page }) => {
+    const flowId = createdFlowId;
+    createdFlowId = undefined;
+
+    await page.goto("/");
+    const authHeader = await getAuthToken(page.request);
+    const opts = authHeader ? { headers: { Authorization: authHeader } } : undefined;
+
+    try {
+      await page.request.delete(`/api/v2/mcp/servers/${MCP_SERVER_NAME}`, opts);
+    } catch {
+      // best-effort
+    }
+    if (flowId) {
+      await deleteFlow(page.request, flowId, opts);
+    }
+  });
+
+  test(
+    "Gemini runs but invokes no echo MCP tool (guards upstream #440)",
+    { tag: ["@mcp", "@agents", "@regression", "@model-provider"] },
+    async ({ page, request }) => {
+      test.skip(!!skipReason, skipReason ?? "");
+      test.skip(
+        !hasProviderEnvKeys(PROVIDER),
+        `Missing env vars for provider "${PROVIDER}": ${missingProviderEnvKeys(PROVIDER).join(", ")}`,
+      );
+
+      // npx server may emit transient backend errors while starting.
+      (page as any).allowFlowErrors();
+
+      const nonce = `probe-${process.env.TEST_WORKER_INDEX ?? "0"}-${Date.now()}`;
+      const echoPrompt = `Use the 'echo' tool to echo: ${ECHO_PAYLOAD} (${nonce})`;
+
+      await test.step("Load Simple Agent template pinned to Gemini", async () => {
+        await loadAgent(page, { provider: PROVIDER, model: geminiModel });
+      });
+
+      await test.step("Register everything MCP server and wait for tools", async () => {
+        const authHeader = await getAuthToken(page.request);
+        await page.request.delete(`/api/v2/mcp/servers/${MCP_SERVER_NAME}`, {
+          headers: { Authorization: authHeader },
+        });
+
+        await page.getByTestId("sidebar-nav-mcp").click();
+        await expect(page.getByTestId("sidebar-add-mcp-server-button")).toBeVisible({
+          timeout: 15000,
+        });
+        await page.getByTestId("sidebar-add-mcp-server-button").click();
+        await expect(page.getByTestId("add-mcp-server-button")).toBeVisible({
+          timeout: 15000,
+        });
+        await page.getByTestId("json-tab").click();
+        await expect(page.getByTestId("json-input")).toBeVisible({ timeout: 5000 });
+        await page.getByTestId("json-input").fill(MCP_JSON_CONFIG);
+
+        await page.getByTestId("add-mcp-server-button").click();
+        await expect(page.getByTestId("add-mcp-server-button")).toBeHidden({
+          timeout: 10000,
+        });
+
+        await expect(
+          page.getByTestId(`add-component-button-${MCP_SERVER_NAME}`),
+        ).toBeVisible({ timeout: 30000 });
+
+        await expect
+          .poll(
+            async () => {
+              const resp = await page.request.get(
+                "/api/v2/mcp/servers?action_count=true",
+              );
+              const servers: Array<{ name: string; toolsCount: number | null }> =
+                await resp.json();
+              return servers.find((s) => s.name === MCP_SERVER_NAME)?.toolsCount ?? null;
+            },
+            { timeout: 90000, intervals: [3000] },
+          )
+          .not.toBeNull();
+      });
+
+      await test.step("Add MCPTools component to canvas", async () => {
+        await page.getByTestId(`add-component-button-${MCP_SERVER_NAME}`).click();
+        await expect(page.getByTestId("dropdown_str_tool")).toBeVisible({
+          timeout: 15000,
+        });
+        await adjustScreenView(page, { numberOfZoomOut: 3 });
+      });
+
+      await test.step("Enable tool mode on MCPTools", async () => {
+        const toolsetCountBefore = await page.getByText("toolset").count();
+        await page.getByTestId("tool-mode-button").last().click();
+        await expect(page.getByText("toolset")).toHaveCount(toolsetCountBefore + 1, {
+          timeout: 5000,
+        });
+      });
+
+      await test.step("Connect MCPTools toolset → Agent tools handle", async () => {
+        await page.getByTestId("handle-mcp-shownode-toolset-right").click();
+        await page.getByTestId("handle-agent-shownode-tools-left").first().click();
+        await expect(page.locator(".react-flow__edge").last()).toBeVisible({
+          timeout: 5000,
+        });
+      });
+
+      await test.step("Open Playground and send echo prompt", async () => {
+        await page.getByTestId("playground-btn-flow-io").click();
+        const playgroundInput = page.getByTestId("input-chat-playground").last();
+        await expect(playgroundInput).toBeVisible({ timeout: 30000 });
+        // Atomic set-value + send inside one page.evaluate — the #226 prefill
+        // useEffect can otherwise reset chatValue to the Chat Input template
+        // default between fill and click. Keep the prompt short and name the
+        // tool in single quotes (the reliable MCP-echo phrasing).
+        await playgroundInput.clear();
+        await playgroundInput.fill(echoPrompt);
+        await expect(playgroundInput).toHaveValue(echoPrompt);
+        await page.evaluate((value: string) => {
+          const inputs = document.querySelectorAll<HTMLTextAreaElement>(
+            '[data-testid="input-chat-playground"]',
+          );
+          const input = inputs[inputs.length - 1];
+          const sends = document.querySelectorAll<HTMLButtonElement>(
+            '[data-testid="button-send"]',
+          );
+          const send = sends[sends.length - 1];
+          const setter = Object.getOwnPropertyDescriptor(
+            HTMLTextAreaElement.prototype,
+            "value",
+          )?.set;
+          if (!setter || !input || !send) {
+            throw new Error("Playground input or send button not found in DOM");
+          }
+          setter.call(input, value);
+          input.dispatchEvent(new Event("input", { bubbles: true }));
+          send.click();
+        }, echoPrompt);
+        await expect(
+          page.getByText(echoPrompt, { exact: true }).first(),
+          "User message in chat must match the echo prompt (not the Chat Input template default)",
+        ).toBeVisible({ timeout: 10000 });
+      });
+
+      await test.step("#440: agent completes a turn but invokes no echo MCP tool", async () => {
+        await waitForAgentToFinish(page);
+
+        // Poll the monitor until the agent turn for this session is persisted —
+        // this is both the completion gate and a race-free source of truth.
+        let turn: { replyText: string; echoToolUseCount: number } | null = null;
+        await expect
+          .poll(
+            async () => {
+              turn = await fetchPersistedAgentTurn(request, nonce);
+              return turn ? "persisted" : "waiting";
+            },
+            { timeout: 60000, intervals: [2000] },
+          )
+          .toBe("persisted");
+
+        // The pipeline ran end-to-end: the agent produced a final reply that
+        // surfaced the echoed payload (proves setup + run + playground worked,
+        // so a tool call was genuinely possible — this is NOT the #440 flip).
+        expect(
+          turn!.replyText,
+          "Agent must produce a final reply containing the echoed payload",
+        ).toMatch(new RegExp(ECHO_PAYLOAD, "i"));
+
+        // The #440 flip (backend truth, no frontend selector drift): while the
+        // bug is OPEN, Gemini invokes NO `echo` MCP tool → count is 0 and this
+        // passes. When Langflow FIXES #440, an `echo` tool_use block starts
+        // being persisted → count > 0 → this FAILS. A red here means: #440 is
+        // fixed — remove this guard and promote Gemini into mcp-client-agent.
+        expect(
+          turn!.echoToolUseCount,
+          "EXPECTED while Langflow #440 is open: Gemini invoked NO 'echo' MCP tool. " +
+            "If this fails, #440 is FIXED — promote this guard (see spec doc).",
+        ).toBe(0);
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #858 · Guards upstream langflow-ai/langflow **#440**

## Summary

Adds a standalone regression guard for the **Gemini × MCP tool-calling** path,
which was effectively uncovered: on 1.11.0 `gemini-2.5-flash` calls native
Langflow tools but silently does **not** invoke MCP tools (`echo`).

## Why the suite never surfaced #440 (evidence: `reports/daily-history.jsonl`)

1. **Serial-skip cascade.** `mcp-client-agent.spec.ts` runs openai → anthropic →
   google under one file-scope `mode: "serial"` group. The OpenAI variant flakes
   first (#809, `toBeHidden`); serial-skip then **skips the Gemini variant** —
   the only one exercising #440 (matches the 46–53 daily skips).
2. **No provider label in the signal.** The daily history stores only the bare
   `test()` title, so the one day the true #440 signature fired (2026-07-13,
   `"answered without invoking any tool"`) it was indistinguishable from a
   generic failure.
3. **Signal drowned in flake noise.** Same test fails most days on the unrelated
   `toBeHidden` timeout, so the real #440 line read as "that flaky MCP test".

`agent-multi-tool-selection.spec.ts` does run Gemini, but only with **native**
tools (which Gemini calls fine) — reinforcing a false "Gemini OK".

## What this guard does

- Own file (no shared serial group), Gemini pinned + named in the title →
  self-attributing signal.
- Asserts the #440 observable via the **monitor API** (backend truth, immune to
  frontend selector drift). While #440 is open it asserts the broken state
  (`echoToolUseCount === 0`) and **flips red when Langflow fixes #440** — the
  promote signal.
- `test.fail()` was rejected: it masks infra failures as green (proven live
  during authoring — a bootstrap timeout produced a false "expected pass").
  Setup asserts stay **loud**.

## Validation status (honest)

- ✅ `tsc --noEmit` and ESLint (only idiomatic `any`/`skip` warnings, same as the
  sibling `mcp-client-agent.spec.ts`).
- ✅ QA-CHECKLIST guard: only the manual §13.1 bullet edited, no generated block.
- ✅ **Design behavior validated on a live nightly**: across repeated runs every
  setup/infra failure went loudly **red** (never a masked green) — confirming the
  inversion works.
- ⚠️ **The #440 assertion itself was not exercised end-to-end locally**: the
  local nightly container was unstable (flapping / connection-refused) and never
  stayed up long enough to reach the final step. Definitive validation is
  deferred to CI, where the nightly service is stable and the sibling MCP
  machinery already runs.

## Tags & @stable

`@mcp @agents @regression @model-provider` — **not `@stable` yet** (held until one
green nightly CI run confirms it passes documenting #440). Rationale in the spec
doc.

## Spec doc

`docs/mcp/client/mcp-client-agent-gemini-tool-regression.md`