### PR TITLE
test(mcp): cover flow-as-MCP-server endpoint + tool execution over protocol (#829)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -662,10 +662,10 @@
 - [-] MCP Server tab in flow
 - [-] Add MCP server via modal
 - [-] Starter project with MCP
-- [ ] Flow exposed as MCP server — verify generated endpoint
-- [ ] Execute MCP server tool via MCP protocol
-- [ ] Resource exposed by server is accessible via URI
-- [ ] Prompt exposed by server returns correct template
+- [-] Flow exposed as MCP server — verify generated endpoint → `mcp/server/mcp-server-protocol.spec.ts`
+- [-] Execute MCP server tool via MCP protocol → `mcp/server/mcp-server-protocol.spec.ts`
+- [ ] Resource exposed by server is accessible via URI (no product surface on 1.11.x — MCP server `resources/list` returns `[]`; #829)
+- [ ] Prompt exposed by server returns correct template (no product surface on 1.11.x — MCP server `prompts/list` returns `[]`; #829)
 
 ---
 

--- a/docs/mcp/server/mcp-server-protocol.md
+++ b/docs/mcp/server/mcp-server-protocol.md
@@ -1,0 +1,193 @@
+# MCP Server — flow-as-server endpoint & tool execution over the MCP protocol
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+Covers the two **coverable** items of QA-CHECKLIST §14.1 that concern a Langflow
+**project exposed as an MCP server** (flow-as-server), exercised over the real
+**MCP protocol** (JSON-RPC over the streamable-HTTP transport), not the UI:
+
+1. **Flow exposed as MCP server — generated endpoint** (§14.1). A flow enabled as
+   an MCP tool in a project is reachable at the project's generated MCP server
+   endpoint, which correctly advertises itself and lists the enabled flow.
+2. **Execute MCP server tool via MCP protocol** (§14.1). Calling that tool via
+   `tools/call` runs the flow and returns its output through the protocol.
+
+The tool under test is a **ChatInput → ChatOutput passthrough** flow (no LLM, no
+provider key), so its output is a deterministic **echo** of the input — the test
+sends a unique sentinel and asserts the tool result echoes exactly that sentinel.
+This makes the execution assertion deterministic and proves the call actually
+round-tripped through the MCP server (not a cached or canned response).
+
+**Distinct from the existing `mcp/server/mcp-server*.spec.ts`**, which drive the
+**UI** for *registering an external MCP server as a tool* (client-side, the
+"Add MCP server" modal / MCP tab). This spec is the **server-side, protocol-level**
+counterpart: Langflow *is* the MCP server and a client speaks the protocol to it.
+
+If this fails, Langflow no longer exposes project flows as MCP-server tools, or no
+longer executes them over the protocol — a core MCP-server regression.
+
+### Scope decision — §14.1 items 667/668 are NOT covered (no product surface)
+
+Scouted live on **1.11.0.dev49**: the project MCP server **advertises**
+`resources` and `prompts` capabilities on `initialize`, but `resources/list` and
+`prompts/list` both return **`[]`** — Langflow's MCP server exposes flows only as
+**tools**; there is no UI or API to expose a resource-by-URI or a prompt template.
+Therefore:
+
+- §14.1 "Resource exposed by server is accessible via URI" — **no product surface**;
+  left `[ ]` with a note (not a hollow test).
+- §14.1 "Prompt exposed by server returns correct template" — **no product surface**;
+  left `[ ]` with a note.
+
+A comment recording this is posted on issue #829. Writing an assertion that these
+lists are empty was rejected: it would be a false regression the moment Langflow
+implements either primitive.
+
+---
+
+## Tags *(required)*
+
+`@regression` `@api` `@mcp`
+
+**`@stable` intentionally withheld (promotion gated — issue #829).** MCP is in the
+current flaky cluster (#773) and the issue also flags MCP surface-health
+dependencies (#809 / #643); promote only after the Wave 3 clean baseline.
+`@api` — the MCP protocol is exercised over HTTP JSON-RPC; `@mcp` — MCP server
+area; `@regression` — guards a server-exposure/execution regression.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`; auto-login superuser.
+- A default project exists (`GET /api/v1/projects/` → the "Starter Project"); its
+  id is the MCP project id.
+- Passthrough fixture `tests/assets/flows/chat-io-ok-trace-fixture.json`
+  (ChatInput → ChatOutput; echoes its input). No provider key / LLM required.
+- Parallel-safe **per created flow** (unique flow name + unique action name), but
+  the project MCP settings are shared state — see Notes; run `--workers=1` if the
+  suite ever adds a second project-MCP spec.
+
+---
+
+## Step by step *(required)*
+
+**Setup (API only)**
+
+1. Resolve the default project id (`GET /api/v1/projects/`).
+2. Create a passthrough runnable flow via `createRunnableChatFlowViaApi(request, headers)`
+   — ChatInput → ChatOutput, echoes `input_value`.
+3. Expose it as an MCP tool: `PATCH /api/v1/mcp/project/{projectId}` with
+   `{ settings: [{ id: <flowId>, mcp_enabled: true, action_name: <unique>, action_description }] }`.
+   The action name is unique per run (`e2e_echo_<suffix>`) to avoid colliding with
+   other tools in the shared project.
+
+---
+
+**Test 1 — generated endpoint exposes the enabled flow** (§14.1)
+
+1. `GET /api/v1/mcp/project/{projectId}/composer-url`.
+2. **Validation:**
+   - `streamable_http_url` equals `${baseURL}/api/v1/mcp/project/{projectId}/streamable`
+     and `legacy_sse_url` ends with `/api/v1/mcp/project/{projectId}/sse` (the
+     endpoint is generated for this project).
+   - MCP `initialize` on the streamable endpoint returns
+     `serverInfo.name === "langflow-mcp-project-{projectId}"`.
+   - `tools/list` includes a tool whose `name` equals the unique `action_name`
+     just enabled — the flow is exposed by the generated server.
+
+---
+
+**Test 2 — execute the exposed tool over the MCP protocol** (§14.1)
+
+1. MCP handshake (`initialize` → `notifications/initialized`) on the streamable
+   endpoint.
+2. `tools/call` the unique `action_name` with
+   `arguments: { input_value: "<unique sentinel>" }`.
+3. **Validation:** the JSON-RPC result has `isError === false` and
+   `content[0].text === "<the same sentinel>"` — the passthrough flow ran and
+   echoed the exact input back through the protocol.
+
+---
+
+## Validation criterion *(required)*
+
+- **Endpoint (T1):** the project's composer-url yields the correctly-shaped
+  streamable/SSE URLs for `{projectId}`, `initialize` reports
+  `serverInfo.name = langflow-mcp-project-{projectId}`, and `tools/list` contains
+  the just-enabled unique action name.
+- **Execute (T2):** `tools/call <action_name> { input_value: S }` returns
+  `isError:false` and `content[0].text === S` for a unique sentinel `S` — proving
+  the flow executed over the MCP protocol and returned its output.
+
+## Guarding against false positives *(how)*
+
+- **Unique sentinel echo:** the execute assertion keys on a per-run random
+  sentinel, so a canned/empty/cached response cannot pass — the exact string must
+  survive the round-trip through the passthrough flow.
+- **Unique action name:** T1 asserts the *specific* enabled tool appears (not
+  merely "some tool"), so a stale `simple_agent` in the shared project can't
+  satisfy it.
+- **Deterministic tool (no LLM):** the passthrough flow removes model
+  non-determinism entirely, so a failure is a real protocol/exposure regression.
+- **Force-failure check** (CONTRIBUTING §2) is run during VERIFY on each hard
+  assertion.
+
+---
+
+## What this test does not cover *(optional)*
+
+- §14.1 resource-by-URI and prompt-template — no product surface (see Scope
+  decision above).
+- The MCP Server **UI** tab / add-server modal — covered by
+  `mcp/server/mcp-server*.spec.ts`.
+- MCP server **auth** settings (`auth_settings`) and the OAuth/composer path.
+- Executing a flow that requires an LLM as an MCP tool (kept out for determinism).
+- The legacy SSE transport execution path (only its URL shape is asserted; the
+  streamable-HTTP transport carries the protocol interaction).
+
+---
+
+## External dependencies *(required)*
+
+- `src/backend/base/langflow/api/v1/mcp*` (MCP server routes:
+  `/api/v1/mcp/project/{id}`, `/composer-url`, `/streamable`, `/sse`) — the
+  generated endpoint and the protocol handlers.
+- `src/backend/base/langflow/services/mcp*` (or equivalent) — the MCP server
+  implementation that maps enabled flows to tools and executes `tools/call`.
+- ChatInput / ChatOutput components — the passthrough must keep echoing its input.
+- `tests/assets/flows/chat-io-ok-trace-fixture.json` — the passthrough fixture.
+
+---
+
+## When to review this test *(optional)*
+
+- If the MCP server endpoint scheme (`/api/v1/mcp/project/{id}/streamable|sse`) or
+  the `composer-url` payload changes.
+- If the `serverInfo.name` convention changes.
+- If Langflow starts exposing **resources** or **prompts** via the MCP server —
+  then items 667/668 become coverable and this spec should be extended.
+- On promotion to `@stable` once the #773 baseline is clean (issue #829 gate).
+
+---
+
+## Notes *(optional)*
+
+- **Mechanism scouted on 1.11.0.dev49:** `GET .../composer-url` →
+  `{ streamable_http_url, legacy_sse_url, uses_composer:false }`. `initialize` over
+  the streamable transport is **stateless here** (no `mcp-session-id` header
+  required); the response is an SSE frame `event: message\ndata: {json}`. The tool
+  input schema for a flow is `{ input_value, session_id }`. Enabling a flow:
+  `PATCH /api/v1/mcp/project/{id}` with `settings:[{id,mcp_enabled,action_name,action_description}]`
+  (merges, does not wipe other enabled tools). `tools/call` returns
+  `{ content:[{type:"text", text:<output>}], isError:false }`.
+- **Shared-state caveat:** the project's MCP settings and its tool namespace are
+  shared across the instance. The spec uses a unique `action_name` per run and
+  deletes its own flow in teardown; it does not reset the whole project settings.
+- **Cleanup:** the created flow is deleted by id in `afterAll`
+  (`RunnableChatFlow.deleteFlow`); disabling it from the project follows from the
+  flow no longer existing.

--- a/tests/helpers/mcp/mcp-streamable-client.ts
+++ b/tests/helpers/mcp/mcp-streamable-client.ts
@@ -1,0 +1,89 @@
+import type { APIRequestContext } from "@playwright/test";
+
+/**
+ * Minimal MCP client over the streamable-HTTP transport, backed by Playwright's
+ * `APIRequestContext`. Enough to drive Langflow's project MCP server for E2E
+ * assertions — NOT a full MCP SDK.
+ *
+ * Langflow's streamable endpoint (`/api/v1/mcp/project/{id}/streamable`) answers
+ * each JSON-RPC POST with a single Server-Sent-Events frame:
+ *
+ *     event: message
+ *     data: {"jsonrpc":"2.0","id":1,"result":{...}}
+ *
+ * On 1.11.0.dev49 the transport is stateless (no `mcp-session-id` header is
+ * required between calls), so each request is independent. We send
+ * `Accept: application/json, text/event-stream` (the transport requires the SSE
+ * media type) and parse the `data:` line back into the JSON-RPC object.
+ */
+
+export interface JsonRpcResponse {
+  jsonrpc: string;
+  id?: number;
+  result?: any;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+const MCP_HEADERS = {
+  "Content-Type": "application/json",
+  Accept: "application/json, text/event-stream",
+};
+
+/** Extract the JSON payload from the `data:` line of an SSE frame. */
+function parseSseData(body: string): JsonRpcResponse {
+  const line = body
+    .split(/\r?\n/)
+    .find((l) => l.startsWith("data:"));
+  if (!line) {
+    throw new Error(`MCP response is not an SSE frame with a data line:\n${body}`);
+  }
+  return JSON.parse(line.replace(/^data:\s*/, "")) as JsonRpcResponse;
+}
+
+/**
+ * Send one JSON-RPC request to a streamable MCP endpoint and return the parsed
+ * response. `authorization` is the full header value (e.g. `Bearer <token>`).
+ */
+export async function mcpCall(
+  request: APIRequestContext,
+  url: string,
+  authorization: string,
+  method: string,
+  params?: Record<string, unknown>,
+  id = 1,
+): Promise<JsonRpcResponse> {
+  const res = await request.post(url, {
+    headers: { ...MCP_HEADERS, Authorization: authorization },
+    data: { jsonrpc: "2.0", id, method, ...(params ? { params } : {}) },
+  });
+  if (!res.ok()) {
+    throw new Error(`MCP ${method} HTTP ${res.status()}: ${await res.text()}`);
+  }
+  return parseSseData(await res.text());
+}
+
+/**
+ * Complete the MCP handshake: `initialize` then the `notifications/initialized`
+ * notification. Returns the `initialize` result (carries `serverInfo` and
+ * advertised `capabilities`).
+ */
+export async function mcpHandshake(
+  request: APIRequestContext,
+  url: string,
+  authorization: string,
+): Promise<any> {
+  const init = await mcpCall(request, url, authorization, "initialize", {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: { name: "langflow-e2e", version: "0.1" },
+  });
+  // Notification: no id, no response expected. The transport still answers with
+  // an (empty) SSE frame or 202 — fire it and ignore the body.
+  await request
+    .post(url, {
+      headers: { ...MCP_HEADERS, Authorization: authorization },
+      data: { jsonrpc: "2.0", method: "notifications/initialized" },
+    })
+    .catch(() => {});
+  return init.result;
+}

--- a/tests/tests-automations/regression/mcp/server/mcp-server-protocol.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-protocol.spec.ts
@@ -1,0 +1,152 @@
+import { expect, test } from "../../../../fixtures/fixtures";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import {
+  createRunnableChatFlowViaApi,
+  type RunnableChatFlow,
+} from "../../../../helpers/flows/create-runnable-chat-flow-via-api";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { mcpCall, mcpHandshake } from "../../../../helpers/mcp/mcp-streamable-client";
+
+/**
+ * MCP Server — flow-as-server endpoint & tool execution over the MCP protocol
+ * (QA-CHECKLIST §14.1, the two coverable items: "Flow exposed as MCP server —
+ * verify generated endpoint" and "Execute MCP server tool via MCP protocol").
+ *
+ * A ChatInput -> ChatOutput passthrough flow is created via API and enabled as
+ * an MCP tool on the default project. The test then speaks the real MCP protocol
+ * to the project's generated streamable endpoint:
+ *   T1 — the generated endpoint advertises this project and lists the enabled
+ *        flow (composer-url shapes + initialize serverInfo + tools/list).
+ *   T2 — tools/call runs the flow and echoes a unique sentinel back through the
+ *        protocol (deterministic, no LLM).
+ *
+ * §14.1 resource-by-URI and prompt-template are NOT covered: Langflow's MCP
+ * server exposes flows only as tools — resources/list and prompts/list return []
+ * on 1.11.0.dev49 (no product surface). See docs/mcp/server/mcp-server-protocol.md.
+ *
+ * `@stable` withheld — promotion gated (#829; MCP flaky cluster #773, surface
+ * deps #809/#643).
+ */
+
+// Shared project MCP settings are instance-wide; run serially so a second
+// project-MCP spec (if added) can't race this one's tool namespace.
+test.describe.configure({ mode: "serial" });
+
+test.describe("MCP Server — flow-as-server protocol", () => {
+  let authorization: string;
+  let projectId: string;
+  let streamableUrl: string;
+  let flow: RunnableChatFlow;
+  const actionName = `e2e_echo_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
+
+  test.beforeAll(async ({ request }) => {
+    authorization = await getAuthToken(request);
+    const headers = { Authorization: authorization };
+
+    // Default project ("Starter Project") — its id is the MCP project id.
+    const projectsRes = await request.get("/api/v1/projects/", { headers });
+    expect(projectsRes.ok()).toBeTruthy();
+    const projects = await projectsRes.json();
+    const list = Array.isArray(projects) ? projects : projects.items ?? [];
+    expect(list.length).toBeGreaterThan(0);
+    projectId = list[0].id;
+    streamableUrl = `/api/v1/mcp/project/${projectId}/streamable`;
+
+    // Deterministic passthrough flow (ChatInput -> ChatOutput, echoes input).
+    flow = await createRunnableChatFlowViaApi(request, headers);
+
+    // Expose it as an MCP tool on the project (merges into existing settings).
+    const patchRes = await request.patch(`/api/v1/mcp/project/${projectId}`, {
+      headers,
+      data: {
+        settings: [
+          {
+            id: flow.flowId,
+            mcp_enabled: true,
+            action_name: actionName,
+            action_description: "E2E passthrough echo tool",
+          },
+        ],
+      },
+    });
+    expect(patchRes.ok()).toBeTruthy();
+  });
+
+  test.afterAll(async ({ request }) => {
+    // Deleting the flow removes it from the project's exposed tools. Use the
+    // afterAll's own live `request` (Playwright forbids reusing the beforeAll
+    // one) and the id captured at setup.
+    if (flow?.flowId) {
+      await deleteFlow(request, flow.flowId, {
+        headers: { Authorization: authorization },
+      }).catch(() => {});
+    }
+  });
+
+  test(
+    "generated endpoint advertises the project and lists the enabled flow",
+    { tag: ["@regression", "@api", "@mcp"] },
+    async ({ request }) => {
+      await test.step("composer-url returns the generated endpoint URLs", async () => {
+        const res = await request.get(
+          `/api/v1/mcp/project/${projectId}/composer-url`,
+          { headers: { Authorization: authorization } },
+        );
+        expect(res.ok()).toBeTruthy();
+        const body = await res.json();
+        expect(body.streamable_http_url).toContain(
+          `/api/v1/mcp/project/${projectId}/streamable`,
+        );
+        expect(body.legacy_sse_url).toContain(
+          `/api/v1/mcp/project/${projectId}/sse`,
+        );
+      });
+
+      await test.step("initialize identifies this project's MCP server", async () => {
+        const info = await mcpHandshake(request, streamableUrl, authorization);
+        expect(info.serverInfo.name).toBe(`langflow-mcp-project-${projectId}`);
+      });
+
+      await test.step("tools/list exposes the enabled flow", async () => {
+        const resp = await mcpCall(
+          request,
+          streamableUrl,
+          authorization,
+          "tools/list",
+          undefined,
+          2,
+        );
+        const names: string[] = (resp.result?.tools ?? []).map(
+          (t: { name: string }) => t.name,
+        );
+        expect(names).toContain(actionName);
+      });
+    },
+  );
+
+  test(
+    "execute the exposed tool over the MCP protocol echoes the input",
+    { tag: ["@regression", "@api", "@mcp"] },
+    async ({ request }) => {
+      // Unique sentinel: a canned/empty/cached response cannot echo this exact
+      // string, so a pass proves the call round-tripped through the flow.
+      const sentinel = `mcp-echo-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+      await mcpHandshake(request, streamableUrl, authorization);
+
+      const resp = await mcpCall(
+        request,
+        streamableUrl,
+        authorization,
+        "tools/call",
+        { name: actionName, arguments: { input_value: sentinel } },
+        3,
+      );
+
+      expect(resp.error, JSON.stringify(resp.error)).toBeUndefined();
+      expect(resp.result?.isError).toBe(false);
+      const text: string = resp.result?.content?.[0]?.text ?? "";
+      expect(text).toBe(sentinel);
+    },
+  );
+});


### PR DESCRIPTION
Closes #829 — covers the two coverable items of `QA-CHECKLIST.md` §14.1 for a Langflow **project exposed as an MCP server** (flow-as-server), exercised over the real **MCP protocol** (JSON-RPC / streamable-HTTP), not the UI.

Distinct from the existing `mcp/server/mcp-server*.spec.ts` (which drive the **UI**: the MCP Server tab, config/SSE-URL display, tool dropdown). This is the **server-side, protocol-level** counterpart: Langflow *is* the MCP server and a client speaks the protocol to it — something no UI test can do.

## 1. Covered tests
| # | Test | What it validates |
|---|------|-------------------|
| 1 | `generated endpoint advertises the project and lists the enabled flow` | Enables a passthrough flow as an MCP tool (`PATCH /api/v1/mcp/project/{id}` settings), then: `composer-url` returns `streamable_http_url`/`legacy_sse_url` shaped `/api/v1/mcp/project/{id}/streamable\|/sse`; MCP `initialize` reports `serverInfo.name === langflow-mcp-project-{id}`; `tools/list` contains the unique enabled `action_name`. Catches the flow no longer being exposed at the generated endpoint. |
| 2 | `execute the exposed tool over the MCP protocol echoes the input` | `tools/call` the enabled tool with `input_value` = a unique random sentinel; asserts `isError === false` and `content[0].text === sentinel`. The tool is a ChatInput→ChatOutput passthrough (no LLM), so the exact echo proves the call round-tripped through the MCP server. Catches a broken protocol-execution path. |

## 2. How the test was built
- **Setup (API only):** resolve the default project (`GET /api/v1/projects/`); create a deterministic ChatInput→ChatOutput passthrough via `createRunnableChatFlowViaApi` (fixture `chat-io-ok-trace-fixture.json`, echoes its input, no provider key); expose it as a tool via `PATCH` with a unique `action_name` (merges into the shared project settings).
- **New helper** `tests/helpers/mcp/mcp-streamable-client.ts` — minimal MCP client over streamable-HTTP backed by Playwright's `APIRequestContext`: `mcpCall` POSTs one JSON-RPC request and parses the SSE `data:` frame; `mcpHandshake` does `initialize` + `notifications/initialized`. Scouted live on 1.11.0.dev49: the transport is **stateless** (no `mcp-session-id`), each POST answers one `event: message\ndata:{json}` frame.
- **Assertion rationale:** unique action name (T1) + unique sentinel echo (T2) make a canned/stale/empty response impossible to pass; the passthrough removes LLM non-determinism.

## 3. Scope decision — §14.1 items 667/668 NOT covered (no product surface)
Scouted on 1.11.0.dev49: the MCP server **advertises** `resources`/`prompts` capabilities on `initialize`, but `resources/list` and `prompts/list` both return `[]`. Langflow exposes flows **only as tools**; there is no UI/API to author a resource-by-URI or a prompt template. The two items are left `[ ]` in the checklist with a note — writing an assert-empty test was rejected (false regression the moment the feature ships). Recorded below.

## 4. Dependencies
- No LLM / provider / API key — pure protocol over the passthrough flow.
- Execution: `--workers=1` serial (the project's MCP settings and tool namespace are instance-wide shared state).
- Cleanup: `afterAll` deletes the created flow by id (removes it from the exposed tools). Audited — zero orphans.

## Tags & gating
`@regression @api @mcp` — **`@stable` intentionally withheld** (promotion gated, #829; MCP flaky cluster #773; surface deps #809/#643). Absence explained in the spec doc's Tags section.

## Validation (nightly 1.11.0.dev49, `--retries=0 --workers=1`)
- typecheck ✅ · eslint ✅ (0 errors)
- VALIDATE burst 3/3 clean, `expected=2 unexpected=0 flaky=0`, zero backend errors ✅
- force-fail ✅ both tests (T1 tools/list required a non-existent name; T2 echo expected sentinel+"_WRONG") → each failed as expected, reverted, green final ✅
- zero `🚨 Backend Error` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)