### PR TITLE
test(components): add configure-MCP + configure-custom-component helpers & spec (#821)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -57,8 +57,8 @@
 
 ### To implement
 
-- [ ] Configure an MCP
-- [ ] Configure a Custom Component
+- [-] Configure an MCP → `helpers/mcp/configure-mcp-server.ts`
+- [-] Configure a Custom Component → `helpers/flows/configure-custom-component.ts`
 - [x] Delete a component → `helpers/flows/delete-component.ts`
 - [x] Run a flow → `helpers/flows/run-flow.ts`
 - [-] Pause a flow → `flow-functionality/stop-building.spec.ts`

--- a/docs/core-components/configure-mcp-and-custom-component.md
+++ b/docs/core-components/configure-mcp-and-custom-component.md
@@ -1,0 +1,163 @@
+# Configure an MCP server & Configure a Custom Component — reusable config helpers
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+Delivers the two uncovered **helper** items from the QA-CHECKLIST "To implement"
+list (the suite's helper inventory):
+
+- **Configure an MCP** → `helpers/mcp/configure-mcp-server.ts`
+- **Configure a Custom Component** → `helpers/flows/configure-custom-component.ts`
+
+Each item becomes a **reusable helper** that performs the configuration
+end-to-end through the UI, plus a spec that exercises the helper and asserts a
+**distinctive observable** proving the configuration actually took effect. The
+config flows themselves are already exercised inline by
+`mcp/client/mcp-client-regression.spec.ts` (HTTP-form registration, `@stable`)
+and `core-components/full-custom-component.spec.ts` (`@stable`); this issue
+extracts them into named helpers (per the checklist) and validates them in one
+place.
+
+1. **configureMcpServer(page, { name, url })** — from a flow canvas, opens the
+   MCP sidebar, adds an MCP server via the **HTTP form tab**, fills name + URL,
+   submits. The spec asserts the server appears in the sidebar as an
+   `add-component-button-{name}` **and** is persisted (`GET /api/v2/mcp/servers`
+   contains it). A dummy unreachable URL (`http://localhost:1/mcp`) is used — the
+   test validates *registration/configuration*, not connectivity, so it needs no
+   live MCP server and stays deterministic.
+2. **configureCustomComponent(page, code)** — adds a Custom Component to the
+   canvas, opens its code editor, replaces the scaffold with the given Python
+   code, and runs **Check & Save**. The spec asserts the node materializes the
+   **code-declared interface** (a display name, input, output handle, and run
+   button whose strings exist only in THAT code) — proving Check & Save compiled
+   the code into a real component.
+
+If either fails, the corresponding configuration flow regressed — MCP server
+registration or custom-component compilation.
+
+---
+
+## Tags *(required)*
+
+- MCP test: `@regression` `@mcp`
+- Custom Component test: `@regression` `@components`
+
+**`@stable` withheld initially** — added only after multiple clean `--retries=0`
+runs on the fresh nightly (the source specs are already `@stable`; these
+helper-validating variants earn it after their own clean runs). MCP is in the
+current flaky cluster (#773).
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`; auto-login superuser.
+- **`LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true`** — the nightly image defaults it to
+  `false`, which hides `sidebar-custom-component-button` and 403s custom-component
+  creation (#668). The CI service containers and the start scripts set it.
+- No LLM / provider key required — both flows are pure UI/config.
+
+---
+
+## Step by step *(required)*
+
+**Test 1 — configure an MCP server (helper: configureMcpServer)**
+
+1. Bootstrap, open a blank flow (capture its id from the creation POST for
+   scoped teardown).
+2. Pre-clean any leftover server with the test's unique name via
+   `DELETE /api/v2/mcp/servers/{name}`.
+3. Call `configureMcpServer(page, { name, url: "http://localhost:1/mcp" })`
+   (unique name per run).
+4. **Validation:**
+   - `add-component-button-{name}` is visible in the MCP sidebar, **and**
+   - `GET /api/v2/mcp/servers` returns a server whose `name` equals the unique
+     name — registered and persisted.
+
+**Test 2 — configure a Custom Component (helper: configureCustomComponent)**
+
+1. Bootstrap, open a blank flow (capture id).
+2. Call `configureCustomComponent(page, FULL_COMPONENT_CODE)` — a component that
+   declares `display_name "My Full Component"`, input `"My Input"`, output
+   `"My Output"` (strings absent from the default scaffold).
+3. **Validation:** on the canvas —
+   - `title-My Full Component` visible (declared display name),
+   - `title-my input` visible (declared input field),
+   - `handle-myfullcomponent-shownode-my output-right` visible (declared output
+     handle),
+   - `button_run_my full component` visible (compiled component is runnable).
+
+---
+
+## Validation criterion *(required)*
+
+- **MCP (T1):** the uniquely-named server the helper configured is present both in
+  the sidebar (`add-component-button-{name}`) and in `GET /api/v2/mcp/servers` —
+  configuration persisted, not merely a transient UI state.
+- **Custom Component (T2):** the node exposes the interface declared *only* in the
+  supplied code (display name, input label, output handle, run button) — Check &
+  Save compiled THIS code into the node.
+
+## Guarding against false positives *(how)*
+
+- **Unique server name (T1):** keyed on a per-run name in both the UI and API
+  assertions, so a stale server from another test cannot satisfy it.
+- **Code-only strings (T2):** the asserted testids derive from names that do not
+  exist in the default scaffold, so a pass requires the supplied code to have
+  compiled — a blank/unmodified component would not render them.
+- **Deterministic inputs:** dummy unreachable MCP URL (no live server dependency)
+  and a fixed component source (no LLM) — a failure is a real config regression.
+- **Force-failure check** (CONTRIBUTING §2) is run during VERIFY on each hard
+  assertion.
+
+---
+
+## What this test does not cover *(optional)*
+
+- MCP server **execution** (calling a tool) — covered by
+  `mcp/client/mcp-client-regression.spec.ts` (JSON/echo) and
+  `mcp/server/mcp-server-protocol.spec.ts`.
+- MCP **stdio** transport (needs an npx subprocess) — the HTTP form is used for
+  determinism.
+- Editing/removing an existing custom component; the pink code-button indicator
+  (`core-components/customComponentAdd.spec.ts`).
+- Running the configured custom component's output (only its declared interface
+  is asserted).
+
+---
+
+## External dependencies *(required)*
+
+- `src/frontend/src/.../mcpServerTab` (or equivalent) — the MCP sidebar,
+  `sidebar-add-mcp-server-button`, `http-tab`, `http-name-input`,
+  `http-url-input`, `add-mcp-server-button`.
+- `POST/GET/DELETE /api/v2/mcp/servers` — MCP server registration + persistence.
+- Custom Component feature — `sidebar-custom-component-button`,
+  `code-button-modal`, the Ace editor, **Check & Save**; requires
+  `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true`.
+
+---
+
+## When to review this test *(optional)*
+
+- If the MCP add-server modal / HTTP form testids change.
+- If the custom-component code editor or Check & Save flow changes.
+- If custom components change their default enable flag or 403 behavior.
+
+---
+
+## Notes *(optional)*
+
+- **Helpers extracted, not duplicated:** the MCP HTTP-form steps mirror the
+  `@stable` `mcp-client-regression.spec.ts` HTTP-form test; the custom-component
+  steps mirror the `@stable` `full-custom-component.spec.ts`. This spec calls the
+  new helpers so the checklist "To implement" helper items point at real,
+  test-exercised code.
+- **Cleanup:** `afterEach` deletes the created flow by id (scoped, never
+  `cleanAllFlows`) and DELETEs the test's MCP server by name — no orphans.
+- **Placement:** one spec under `core-components/` (the custom-component home)
+  hosts both tests, per #821 which bundles the two helper items; the MCP test
+  carries `@mcp`.

--- a/tests/helpers/flows/configure-custom-component.ts
+++ b/tests/helpers/flows/configure-custom-component.ts
@@ -1,0 +1,32 @@
+import { expect, type Page } from "@playwright/test";
+
+/**
+ * Configure a Custom Component end-to-end: add one to the canvas, open its code
+ * editor, replace the scaffold with `code`, and run Check & Save so Langflow
+ * compiles the code into a real node.
+ *
+ * Precondition: a flow canvas is open and `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true`
+ * (the nightly image defaults it to `false`, which hides
+ * `sidebar-custom-component-button` and 403s creation — #668). Asserting the
+ * resulting node's declared interface is the caller's job.
+ *
+ * Mirrors the flow validated by
+ * `core-components/full-custom-component.spec.ts`.
+ */
+export async function configureCustomComponent(
+  page: Page,
+  code: string,
+): Promise<void> {
+  await page.getByTestId("sidebar-custom-component-button").click();
+
+  const codeButton = page.getByTestId("code-button-modal").last();
+  await expect(codeButton).toBeVisible({ timeout: 10000 });
+  await codeButton.click();
+
+  // Select all scaffold code in the Ace editor and replace it.
+  await page.locator(".ace_content").click();
+  await page.keyboard.press("ControlOrMeta+A");
+  await page.locator("textarea").fill(code);
+
+  await page.getByText("Check & Save").last().click();
+}

--- a/tests/helpers/mcp/configure-mcp-server.ts
+++ b/tests/helpers/mcp/configure-mcp-server.ts
@@ -1,0 +1,50 @@
+import { expect, type Page } from "@playwright/test";
+
+export interface ConfigureMcpServerOptions {
+  /** Unique server name (used as the registration key and sidebar testid). */
+  name: string;
+  /**
+   * MCP server URL. A dummy unreachable URL (e.g. `http://localhost:1/mcp`) is
+   * fine when validating configuration/registration rather than connectivity.
+   */
+  url: string;
+}
+
+/**
+ * Configure (register) an MCP server end-to-end via the sidebar's HTTP form tab.
+ *
+ * Precondition: a flow canvas is open (the MCP sidebar nav is reachable).
+ * Leaves the modal closed on success. Verifying registration (sidebar entry /
+ * `GET /api/v2/mcp/servers`) is the caller's job — this helper only performs the
+ * configuration steps.
+ *
+ * Mirrors the HTTP-form flow validated by
+ * `mcp/client/mcp-client-regression.spec.ts`.
+ */
+export async function configureMcpServer(
+  page: Page,
+  { name, url }: ConfigureMcpServerOptions,
+): Promise<void> {
+  await expect(page.getByTestId("sidebar-nav-mcp")).toBeVisible({ timeout: 15000 });
+  await page.getByTestId("sidebar-nav-mcp").click();
+
+  await expect(page.getByTestId("sidebar-add-mcp-server-button")).toBeVisible({
+    timeout: 15000,
+  });
+  await page.getByTestId("sidebar-add-mcp-server-button").click();
+
+  await expect(page.getByTestId("add-mcp-server-button")).toBeVisible({
+    timeout: 15000,
+  });
+
+  await page.getByTestId("http-tab").click();
+  await expect(page.getByTestId("http-name-input")).toBeVisible({ timeout: 5000 });
+  await page.getByTestId("http-name-input").fill(name);
+  await page.getByTestId("http-url-input").fill(url);
+
+  await page.getByTestId("add-mcp-server-button").click();
+  // The modal closes once registration is accepted.
+  await expect(page.getByTestId("add-mcp-server-button")).toBeHidden({
+    timeout: 10000,
+  });
+}

--- a/tests/tests-automations/regression/core-components/configure-mcp-and-custom-component.spec.ts
+++ b/tests/tests-automations/regression/core-components/configure-mcp-and-custom-component.spec.ts
@@ -1,0 +1,170 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { configureMcpServer } from "../../../helpers/mcp/configure-mcp-server";
+import { configureCustomComponent } from "../../../helpers/flows/configure-custom-component";
+
+/**
+ * Validates the two "To implement" config helpers (QA-CHECKLIST helper
+ * inventory): configureMcpServer and configureCustomComponent (#821).
+ *
+ *   T1 — configure an MCP server via the HTTP form and verify it registered
+ *        (sidebar entry + persisted in GET /api/v2/mcp/servers).
+ *   T2 — configure a custom component from code and verify the node
+ *        materializes the code-declared interface.
+ *
+ * Deterministic, no LLM. T2 requires LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true.
+ */
+
+// Track flows this page creates (POST /api/v1/flows -> 201) for id-scoped
+// teardown — awaitBootstrapTest makes a bare page.url() capture race the
+// bootstrap flow's stale id (#490/#681); response ids are authoritative.
+const createdFlowIds: string[] = [];
+
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {});
+    }
+  });
+}
+
+// Unique per run so the UI + API assertions cannot be satisfied by a stale
+// server, and cross-worker registrations do not collide.
+const MCP_SERVER_NAME = `configure-mcp-${process.env.TEST_WORKER_INDEX ?? "0"}-${Date.now()}`;
+
+// A custom component whose declared strings are absent from the default
+// scaffold — the on-canvas assertions can only pass if Check & Save compiled
+// THIS code.
+const FULL_COMPONENT_CODE = `
+from langflow.custom import Component
+from langflow.io import MessageTextInput, Output
+from langflow.schema.message import Message
+
+
+class CustomComponent(Component):
+    display_name = "My Full Component"
+    description = "A fully authored custom component."
+    icon = "custom_components"
+    name = "MyFullComponent"
+
+    inputs = [
+        MessageTextInput(name="input_value", display_name="My Input", value="Hello, World!"),
+    ]
+    outputs = [
+        Output(display_name="My Output", name="output", method="build_output"),
+    ]
+
+    def build_output(self) -> Message:
+        return Message(text=self.input_value)`;
+
+// Serial: shared MCP server namespace + custom-component flow naming.
+test.describe.configure({ mode: "serial" });
+
+test.afterEach(async ({ request }) => {
+  const bearer = await getAuthToken(request);
+  const opts = bearer ? { headers: { Authorization: bearer } } : undefined;
+  // Best-effort MCP server cleanup by name.
+  await request.delete(`/api/v2/mcp/servers/${MCP_SERVER_NAME}`, opts).catch(() => {});
+  // Scoped flow cleanup by id (never a global wipe).
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, opts).catch(() => {});
+  }
+});
+
+test(
+  "configureMcpServer registers an MCP server via the HTTP form",
+  { tag: ["@regression", "@mcp"] },
+  async ({ page, request }) => {
+    trackCreatedFlows(page);
+
+    await test.step("open a blank flow", async () => {
+      await awaitBootstrapTest(page);
+      await expect(page.getByTestId("blank-flow")).toBeVisible({ timeout: 30000 });
+      await page.getByTestId("blank-flow").click();
+      await expect(page.getByTestId("canvas_controls_dropdown")).toBeVisible({
+        timeout: 15000,
+      });
+    });
+
+    await test.step("pre-clean any leftover server with this name", async () => {
+      const bearer = await getAuthToken(request);
+      await request
+        .delete(`/api/v2/mcp/servers/${MCP_SERVER_NAME}`, {
+          headers: { Authorization: bearer },
+        })
+        .catch(() => {});
+    });
+
+    await test.step("configure the MCP server via helper", async () => {
+      await configureMcpServer(page, {
+        name: MCP_SERVER_NAME,
+        url: "http://localhost:1/mcp",
+      });
+    });
+
+    await test.step("server appears in the sidebar and is persisted", async () => {
+      await expect(
+        page.getByTestId(`add-component-button-${MCP_SERVER_NAME}`),
+      ).toBeVisible({ timeout: 30000 });
+
+      const bearer = await getAuthToken(request);
+      const resp = await request.get("/api/v2/mcp/servers", {
+        headers: { Authorization: bearer },
+      });
+      expect(resp.status()).toBe(200);
+      const servers: Array<{ name: string }> = await resp.json();
+      expect(
+        servers.find((s) => s.name === MCP_SERVER_NAME),
+        `Server "${MCP_SERVER_NAME}" not found in GET /api/v2/mcp/servers`,
+      ).toBeTruthy();
+    });
+  },
+);
+
+test(
+  "configureCustomComponent compiles code into a node with its declared interface",
+  { tag: ["@regression", "@components"] },
+  async ({ page }) => {
+    trackCreatedFlows(page);
+
+    await test.step("open a blank flow", async () => {
+      await awaitBootstrapTest(page);
+      await expect(page.getByTestId("blank-flow")).toBeVisible({ timeout: 30000 });
+      await page.getByTestId("blank-flow").click();
+      await expect(page.getByTestId("canvas_controls_dropdown")).toBeVisible({
+        timeout: 15000,
+      });
+    });
+
+    await test.step("configure the custom component via helper", async () => {
+      await configureCustomComponent(page, FULL_COMPONENT_CODE);
+    });
+
+    await test.step("node materializes the code-declared interface", async () => {
+      await expect(page.getByTestId("title-My Full Component")).toBeVisible({
+        timeout: 15000,
+      });
+      await expect(page.getByTestId("title-my input")).toBeVisible({
+        timeout: 15000,
+      });
+      await expect(
+        page.getByTestId("handle-myfullcomponent-shownode-my output-right"),
+      ).toBeVisible({ timeout: 15000 });
+      await expect(
+        page.getByTestId("button_run_my full component"),
+      ).toBeVisible({ timeout: 15000 });
+    });
+  },
+);


### PR DESCRIPTION
Closes #821 — covers the two "To implement" helper-inventory items in `QA-CHECKLIST.md`: **Configure an MCP** and **Configure a Custom Component**. Each becomes a reusable helper (extracted from the existing `@stable` flows, not duplicated) plus one spec that exercises the helper and asserts a distinctive observable proving the configuration took effect.

## 1. Covered tests
| # | Test | What it validates |
|---|------|-------------------|
| 1 | `configureMcpServer registers an MCP server via the HTTP form` | Helper registers an MCP server via the sidebar HTTP form (unique name, dummy URL `http://localhost:1/mcp`). Asserts `add-component-button-{name}` appears in the sidebar **and** `GET /api/v2/mcp/servers` returns the unique name — configured + persisted, not transient UI. Validates *registration*, not connectivity (no live MCP server needed). |
| 2 | `configureCustomComponent compiles code into a node with its declared interface` | Helper adds a Custom Component, pastes Python code, runs Check & Save. Asserts the node exposes strings that exist only in THAT code: `title-My Full Component`, `title-my input`, `handle-myfullcomponent-shownode-my output-right`, `button_run_my full component` — proving Check & Save compiled the supplied code. |

## 2. How the test was built
- **New helpers:** `tests/helpers/mcp/configure-mcp-server.ts` (`configureMcpServer(page, {name, url})`) mirrors the `@stable` HTTP-form flow in `mcp-client-regression.spec.ts`; `tests/helpers/flows/configure-custom-component.ts` (`configureCustomComponent(page, code)`) mirrors the `@stable` `full-custom-component.spec.ts`. The checklist "To implement" bullets now point at real, test-exercised code.
- **Live-confirmed selectors:** all testids are used verbatim from the two `@stable` source specs (`sidebar-add-mcp-server-button`, `http-tab`, `http-name-input`, `http-url-input`, `add-mcp-server-button`; `sidebar-custom-component-button`, `code-button-modal`, Ace editor, Check & Save).
- **Assertion rationale:** unique server name (T1) + code-only interface strings (T2) make a coincidental/stale pass impossible; both flows are deterministic (dummy URL, fixed component source, no LLM).

## 3. Dependencies
- No LLM / provider key. **T2 requires `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true`** (the nightly image defaults it to `false`, hiding the sidebar button / 403ing creation — #668); CI service containers and start scripts set it.
- Execution: `--workers=1` serial (shared MCP server namespace + custom-component flow naming).
- Cleanup: `afterEach` deletes the created flow by id (scoped) and DELETEs the test's MCP server by name. Audited — zero orphans.

## Tags
`@regression @mcp` (T1) and `@regression @components` (T2). **`@stable` withheld initially** — added after the helper-validating variants get their own clean `--retries=0` runs (source specs are already `@stable`; MCP is in the #773 flaky cluster).

## Validation (nightly 1.11.0.dev49, `--retries=0 --workers=1`)
- typecheck ✅ · eslint ✅ (0 warnings)
- VALIDATE burst 3/3 clean, `expected=2 unexpected=0 flaky=0`, zero backend errors ✅
- force-fail ✅ both tests (T1 API lookup of a non-existent name; T2 asserts an undeclared node title) → each failed as expected, reverted, green final ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)