### PR TITLE
test(playground): cover send while a response is in progress (#823)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -465,7 +465,7 @@
 - [x] Direct response → `api/flows/api-build-direct-response.spec.ts`
 - [x] Playground UX (playground-ux) → `playground/playground-ux.spec.ts`
 - [x] Send empty message — send button stays enabled by design (only disabled while a file upload is in progress) → `playground/playground-empty-message-send.spec.ts`
-- [ ] Send message while response is in progress — should wait or queue
+- [-] Send message while response is in progress — should wait or queue → `playground/playground-send-while-in-progress.spec.ts`
 - [x] Attach image in chat — compact preview appears in input before sending → `core-functionality/playground/playground-output-image.spec.ts`
 - [x] Image rendered in user message bubble after sending → `core-functionality/playground/playground-output-image.spec.ts`
 - [x] Attach non-image file (.txt) in chat — preview tile renders (delete button visible, no `<img>`) → `core-functionality/playground/playground-non-image-attachment.spec.ts`

--- a/docs/core-functionality/playground/playground-send-while-in-progress.md
+++ b/docs/core-functionality/playground/playground-send-while-in-progress.md
@@ -1,0 +1,142 @@
+# Playground — send a message while a response is in progress (wait/queue)
+
+**Last validated:** Langflow 1.11.x
+
+---
+
+## What this test validates *(required)*
+
+Covers QA-CHECKLIST §9.1: sending a message **while a previous response is still
+in progress** must not corrupt state — the Playground makes a second send
+impossible until the in-flight run finishes.
+
+Scouted live on 1.11.0.dev49, the Playground's "wait" mechanism is:
+
+- **Idle:** the chat input (`input-chat-playground`) is enabled and `button-send`
+  is present.
+- **While a response is in progress:** `button-send` is **removed** and replaced
+  by `button-stop`, **and the chat input is `disabled`** — so the user physically
+  cannot type or submit a second message. This is the "wait" behavior (block the
+  input until the run settles), which prevents a second concurrent run from
+  corrupting the session.
+- **After the run completes:** `button-send` returns and the input re-enables;
+  exactly one response was produced.
+
+The **distinctive observable** is this tri-state transition of the input —
+**enabled → disabled (in progress) → enabled** — paired with the
+`button-send`↔`button-stop` swap, plus the fact that exactly **one** response is
+rendered (no duplicate/interleaved run from the blocked second send).
+
+The in-progress window is created **deterministically without an LLM**: the test
+intercepts the run request (`POST /api/v2/workflows`) and **holds** it open until
+the assertions run, then releases it. A passthrough ChatInput → ChatOutput flow
+is used, so no provider key is required.
+
+If this fails, the Playground no longer blocks input during a run — a regression
+that would let a second send corrupt or interleave the session.
+
+---
+
+## Tags *(required)*
+
+`@regression` `@playground`
+
+`@stable` withheld initially — added only after multiple clean `--retries=0`
+runs on the fresh nightly. `@regression` — guards the in-progress input-lock;
+`@playground` — the behavior lives entirely in the Playground chat.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`; auto-login superuser.
+- No LLM / provider key — a passthrough ChatInput → ChatOutput flow is used, and
+  the in-progress window is created by holding the run request, not by a slow
+  model.
+
+---
+
+## Step by step *(required)*
+
+1. Create a passthrough ChatInput → ChatOutput flow via API
+   (`createRunnableChatFlowViaApi`); open it in the editor (`/flow/{id}`) and open
+   the Playground.
+2. Assert the **baseline**: `input-chat-playground` is **enabled** and
+   `button-send` is visible.
+3. Install a route on `POST /api/v2/workflows` that **holds** the request until
+   the test releases it (a promise the test resolves later).
+4. Fill the input with the first message and click `button-send`.
+5. Assert **in progress**: `button-stop` is visible, `button-send` is hidden, and
+   `input-chat-playground` is **disabled**.
+6. Attempt to send a second message: the input is disabled, so it cannot be
+   filled or submitted — assert `input-chat-playground` `toBeDisabled()` (a second
+   run cannot be started).
+7. **Release** the held request and unroute so the run completes.
+8. Assert **recovery**: `button-send` is visible again, `input-chat-playground` is
+   **enabled**, and exactly one response (`div-chat-message`) is present — the
+   session is intact, with no duplicate/interleaved run from the blocked send.
+
+---
+
+## Validation criterion *(required)*
+
+The chat input is **enabled** before the send, **disabled** while the run is in
+progress (with `button-stop` shown and `button-send` hidden), and **enabled**
+again after the run completes — and exactly one response is rendered. The
+disabled state during the run is what blocks a second send; the return to enabled
+proves the block is tied to the in-progress state, not a permanent lock.
+
+## Guarding against false positives *(how)*
+
+- **Tri-state transition:** asserting enabled → disabled → enabled (not just
+  "disabled once") proves the block is caused by the in-progress run, not by an
+  input that is simply always disabled.
+- **Deterministic hold:** the run request is held by the test and released on
+  cue, so the in-progress window exists reliably without depending on model
+  latency — no flake from a fast/slow LLM.
+- **Single response:** asserting exactly one `div-chat-message` after completion
+  catches a regression where the blocked second send actually leaked a duplicate
+  or interleaved run.
+- **Force-failure check** (CONTRIBUTING §2) is run during VERIFY on the
+  in-progress `toBeDisabled` assertion.
+
+---
+
+## What this test does not cover *(optional)*
+
+- The Stop button actually aborting a build — covered by
+  `stop-button-playground.spec.ts`.
+- SSE streaming transport — covered by `playground-response-streaming-sse.spec.ts`.
+- Empty-message send behavior — covered by `playground-empty-message-send.spec.ts`.
+- A true server-side **queue** of the second message (the product blocks input
+  rather than queueing; this spec pins the block contract).
+
+---
+
+## External dependencies *(required)*
+
+- `src/frontend/src/.../playground` — the chat input disabled state and the
+  `button-send`/`button-stop` swap during a run.
+- `POST /api/v2/workflows` — the run endpoint held to create the in-progress
+  window (matched by path; an upstream move requires updating the route regex).
+- ChatInput / ChatOutput passthrough — must keep running without a provider.
+
+---
+
+## When to review this test *(optional)*
+
+- If the run endpoint path changes (`/api/v2/workflows`).
+- If the Playground changes how it gates input during a run (e.g. switches from
+  disabling the input to a real queue) — update the contract.
+
+---
+
+## Notes *(optional)*
+
+- **Scouted mechanism (1.11.0.dev49):** during a run, `document` shows no
+  `button-send` (replaced by `button-stop`) and `input-chat-playground.disabled
+  === true`; after completion both revert. The run streams from
+  `POST /api/v2/workflows`; holding that request keeps the UI in the in-progress
+  state for as long as needed.
+- **Cleanup:** the created flow is deleted by id in `afterEach` (scoped, never
+  `cleanAllFlows`).

--- a/tests/tests-automations/regression/core-functionality/playground/playground-send-while-in-progress.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-send-while-in-progress.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "../../../../fixtures/fixtures";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import {
+  createRunnableChatFlowViaApi,
+  type RunnableChatFlow,
+} from "../../../../helpers/flows/create-runnable-chat-flow-via-api";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+
+/**
+ * Playground — send a message while a response is in progress (QA-CHECKLIST
+ * §9.1). While a run is streaming, the Playground disables the chat input and
+ * swaps `button-send` for `button-stop`, so a second send is impossible until
+ * the run settles — a "wait" that prevents session corruption.
+ *
+ * The in-progress window is created deterministically (no LLM): the run request
+ * (`POST /api/v2/workflows`) is held open by the test until it releases it. The
+ * flow is a ChatInput -> ChatOutput passthrough, so no provider key is needed.
+ *
+ * Distinctive observable: the chat input goes enabled -> disabled (in progress)
+ * -> enabled, paired with the send/stop swap, and exactly one response is
+ * rendered (no duplicate/interleaved run from the blocked second send).
+ */
+
+const RUN_ENDPOINT = /\/api\/v2\/workflows\b/;
+
+// Serial: creates and runs a named playground flow.
+test.describe.configure({ mode: "serial" });
+
+test.describe("Playground — send while a response is in progress", () => {
+  let flow: RunnableChatFlow;
+
+  test.afterEach(async ({ request }) => {
+    if (!flow?.flowId) return;
+    const bearer = await getAuthToken(request);
+    // Scoped teardown by id — never a global cleanAllFlows.
+    await deleteFlow(request, flow.flowId, {
+      headers: { Authorization: bearer },
+    }).catch(() => {});
+  });
+
+  test(
+    "input is locked while a run is in progress and recovers after it completes",
+    { tag: ["@regression", "@playground"] },
+    async ({ page, request }) => {
+      const bearer = await getAuthToken(request);
+      flow = await createRunnableChatFlowViaApi(request, { Authorization: bearer });
+
+      await test.step("open the flow and its Playground", async () => {
+        await page.goto(`/flow/${flow.flowId}`);
+        await expect(page.getByTestId("playground-btn-flow-io")).toBeVisible({
+          timeout: 30000,
+        });
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(
+          page.getByTestId("input-chat-playground").last(),
+        ).toBeVisible({ timeout: 30000 });
+      });
+
+      const input = page.getByTestId("input-chat-playground").last();
+
+      await test.step("baseline — input enabled, send button present", async () => {
+        await expect(input).toBeEnabled();
+        await expect(page.getByTestId("button-send").last()).toBeVisible();
+      });
+
+      // Hold the run request open until we release it, creating a deterministic
+      // in-progress window without depending on model latency.
+      let release!: () => void;
+      const held = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      await page.route(RUN_ENDPOINT, async (route) => {
+        await held;
+        // The request may have been aborted (navigation/retry) while held; a
+        // stale route then throws "already handled" — swallow it.
+        await route.continue().catch(() => {});
+      });
+
+      await test.step("send the first message (run stays in progress)", async () => {
+        await input.fill("first message");
+        await page.getByTestId("button-send").last().click();
+      });
+
+      await test.step("in progress — input disabled, send hidden, stop shown", async () => {
+        await expect(page.getByTestId("button-stop").last()).toBeVisible({
+          timeout: 30000,
+        });
+        await expect(page.getByTestId("button-send")).toHaveCount(0);
+        // The disabled input is the block: a second message cannot be entered
+        // or submitted while the run is in progress.
+        await expect(input).toBeDisabled({ timeout: 10000 });
+      });
+
+      await test.step("release the run and let it complete", async () => {
+        // Releasing lets the held handler continue the request; the route stays
+        // registered so any subsequent run calls pass straight through.
+        release();
+      });
+
+      await test.step("recovery — input re-enabled, one response, state intact", async () => {
+        await expect(page.getByTestId("button-send").last()).toBeVisible({
+          timeout: 60000,
+        });
+        await expect(input).toBeEnabled({ timeout: 60000 });
+        // Exactly one response rendered — the blocked second send leaked no
+        // duplicate or interleaved run.
+        await expect(page.getByTestId("div-chat-message")).toHaveCount(1);
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #823 — covers the uncovered §9.1 item in `QA-CHECKLIST.md`: sending a message while a previous response is still in progress must **wait**, not corrupt state. Extends `core-functionality/playground/` (adjacent to `stop-button-playground`, `playground-empty-message-send`).

## 1. Covered tests
| # | Test | What it validates |
|---|------|-------------------|
| 1 | `input is locked while a run is in progress and recovers after it completes` | With a run held in progress: `button-stop` is visible, `button-send` is gone, and `input-chat-playground` is **disabled** — so a second send is impossible (the "wait"). After the run completes: `button-send` returns, the input re-enables, and exactly **one** `div-chat-message` is present (no duplicate/interleaved run leaked from the blocked send). The enabled → disabled → enabled tri-state is the distinctive observable. |

## 2. How the test was built
- **Setup:** a ChatInput → ChatOutput passthrough flow created via API (`createRunnableChatFlowViaApi`), opened at `/flow/{id}` → Playground. No provider key / LLM.
- **Deterministic in-progress window:** the run request (`POST /api/v2/workflows`, confirmed by `playground-response-streaming-sse.spec.ts`) is intercepted with `page.route` and **held** on a test-controlled promise until the assertions run, then released — no dependence on model latency. `route.continue()` is wrapped in `.catch()` (a held request can be aborted by a retry/navigation, which would otherwise throw "Route is already handled").
- **Live-confirmed selectors (scouted on 1.11.0.dev49):** during a run `document` shows no `button-send` (replaced by `button-stop`) and `input-chat-playground.disabled === true`; both revert on completion.
- **Assertion rationale:** the tri-state input transition + send/stop swap proves the block is tied to the in-progress state (not a permanent lock); the single `div-chat-message` proves no second run leaked.

## 3. Dependencies
- No LLM / provider key — pure passthrough + request hold.
- Execution: `--workers=1` serial (named playground flow).
- Cleanup: `afterEach` deletes the created flow by id (scoped). Audited — zero orphans.

## Tags
`@regression @playground`. **`@stable` withheld initially** — added after clean `--retries=0` runs on the fresh nightly (playground is in the #773 flaky cluster).

## Validation (nightly 1.11.0.dev49, `--retries=0 --workers=1`)
- typecheck ✅ · eslint ✅ (0 warnings)
- VALIDATE burst 3/3 clean, `unexpected=0 flaky=0`, zero backend errors ✅
- force-fail ✅ (inverted the in-progress lock assertion `toBeDisabled`→`toBeEnabled` → failed as expected, reverted, green final) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)