### PR TITLE
chore(triage): remove @stable from 3 recurrent flakes (triage #864)

### DIFF
--- a/tests/tests-automations/regression/core-components/chat-input-output-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/chat-input-output-component-regression.spec.ts
@@ -100,7 +100,7 @@ async function runFlowAndOpenChatOutputInspection(page: Page): Promise<string> {
 
 test(
   "Chat Input component — renders on canvas with Message output handle and Input Text field",
-  { tag: ["@stable", "@regression", "@components"] },
+  { tag: ["@regression", "@components"] },
   async ({ page }) => {
     await addChatInputComponent(page);
 

--- a/tests/tests-automations/regression/core-components/parameters-panel-field-types.spec.ts
+++ b/tests/tests-automations/regression/core-components/parameters-panel-field-types.spec.ts
@@ -409,7 +409,7 @@ test.describe("Parameters Panel — field-type edit matrix", () => {
 
   test(
     "table field edit persists",
-    { tag: ["@stable", "@components", "@regression"] },
+    { tag: ["@components", "@regression"] },
     async ({ page, request }) => {
       const bearer = await getAuthToken(request);
       const flowId = await openFlowWithComponent(

--- a/tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts
@@ -6,7 +6,7 @@ import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 test(
   "user should be able to select flows with different methods and perform bulk actions",
-  { tag: ["@stable", "@release", "@workspace", "@mainpage", "@regression"] },
+  { tag: ["@release", "@workspace", "@mainpage", "@regression"] },
   async ({ page, request }) => {
     // Track the IDs of the 3 flows we create so cleanup can delete ONLY those
     // via the API, not sibling specs' flows. Under `fullyParallel`, a positional


### PR DESCRIPTION
Prevention `@stable` removal dispatched from daily-failure triage #864 (run [29822019255](https://github.com/oriontech-me/langflow-e2e/actions/runs/29822019255), 2026-07-21).

Each spec below is a **recurrent same-signature flake**. `@stable` is removed so it stops running in the daily until its dedicated issue is worked. **Restoring `@stable` after the fix is a deliverable of each linked issue** — not this PR.

| Spec (test line) | Recurrence | Issue |
|---|---|---|
| `core-components/chat-input-output-component-regression.spec.ts:102` | 2× (07-20/21) | #867 |
| `core-components/parameters-panel-field-types.spec.ts:411` | 2× (07-20/21) | #868 |
| `core-functionality/project-management/bulk-actions.spec.ts:8` | 4× (07-15/16/17/21) | #869 |

Hard-failing tests from the same run were already auto-removed by the daily workflow (tracked in #865 / #866 / #809). This PR touches only the recurrent-flake removals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)