### PR TITLE
fix(llm-agents): make max_tokens causal control model-agnostic (#866)

### DIFF
--- a/docs/core-functionality/llm-agents/agent-max-tokens.md
+++ b/docs/core-functionality/llm-agents/agent-max-tokens.md
@@ -15,9 +15,10 @@ token-usage tooltip as the observable:
 1. **Limit enforced** — `max_tokens = 50` with a prompt requesting a ~500-word
    essay: the response's **Output** token count is **≤ 50**.
 2. **Causal control** — same prompt with `max_tokens` unset (saved as `0` =
-   unlimited): the response is a real essay (hundreds of words) and its Output
-   token count is **> 50**. Only `max_tokens` differs, so Test 1's cap is
-   attributable to the parameter.
+   unlimited): the response's Output token count is **> 50**. Only `max_tokens`
+   differs, so Test 1's cap is attributable to the parameter. The proof is
+   **token-level only** — the visible reply text is deliberately not asserted
+   (see the causal-control note below).
 
 > **Scope note — §7.7 "Temperature parameter (verify via network payload)" is
 > NOT covered.** On nightly 1.11.0.dev33 the Agent has **no temperature
@@ -103,18 +104,23 @@ Shared setup per test:
 **Test 2 — causal control: unset max_tokens generates freely** (§6.2, §7.7)
 
 - `max_tokens` cleared (saved as `0` = no limit), identical prompt.
-- **Validation:** tooltip **Output > 50** and the reply contains a real essay
-  (> 200 words). Only `max_tokens` differs from Test 1, so Test 1's cap is
-  caused by the parameter, not by the model choosing to answer briefly.
+- **Validation:** tooltip **Output > 50**. Only `max_tokens` differs from Test 1,
+  so Test 1's cap is caused by the parameter, not by the model choosing to
+  answer briefly. **The visible reply text is NOT asserted** (no word-count
+  floor): a thinking model spends the unbounded budget on reasoning and can
+  legitimately return a terse visible reply while its Output token count is
+  well above 50 — exactly Test 1's rationale, applied symmetrically here. The
+  token count is the observable of the `max_tokens` contract; visible verbosity
+  is a model trait, not part of it.
 
 ---
 
 ## Validation criterion *(required)*
 
 - **Limit enforced (Test 1):** `max_tokens=50` → response Output tokens ≤ 50.
-- **Causal control (Test 2):** `max_tokens` unset → Output tokens > 50 and a
-  multi-hundred-word reply. The pair proves generation is bounded by
-  `max_tokens` and causally so.
+- **Causal control (Test 2):** `max_tokens` unset → Output tokens > 50 (no
+  reply-text assertion). The pair proves generation is bounded by `max_tokens`
+  and causally so at the token level.
 
 ## Guarding against false positives *(how)*
 
@@ -126,8 +132,12 @@ Shared setup per test:
 - **Token-level assertion, not text-length:** reply text length varies with
   model verbosity; the provider-enforced output-token cap does not.
 - **Causal pair:** identical prompt, only `max_tokens` differs.
-- **Test 2 lower bound (> 50 tokens, > 200 words):** an aborted/empty run
-  cannot pass the control.
+- **Test 2 lower bound (> 50 Output tokens):** an aborted/empty run yields
+  Output `0` (≤ 50) and cannot pass the control — the token floor subsumes the
+  anti-empty guard, so no reply-word-count floor is needed. A word-count floor
+  was intentionally **removed** (see the model-agnostic note below): it
+  measured model verbosity, not the `max_tokens` contract, and produced a
+  false negative on thinking models.
 - **Force-failure check** (CONTRIBUTING §2) run during VERIFY on each hard
   assertion before `@stable`.
 
@@ -184,6 +194,20 @@ Shared setup per test:
 - **Tooltip Output may be empty** when the whole budget is consumed by
   reasoning before any visible token (observed with `max_tokens=1`); the
   parser treats missing/empty as `0`, which still satisfies `≤ 50`.
+- **Model-agnostic by design — no reply-word-count floor (#866).** Test 2
+  originally asserted the reply had `> 200` words on top of `Output > 50`. That
+  word-count floor measured **model verbosity**, not the `max_tokens` contract,
+  and was a latent false negative for thinking models. It stayed dormant from
+  the spec's creation (#483, 2026-07-06) because the collected `google` model
+  was `gemini-omni-flash-preview` (Interactions-API-only → the variant
+  **skipped**); when `collect-models` began selecting the available
+  `gemini-2.5-flash` (~2026-07-14) the variant executed and the model — a
+  thinking model — spent the unbounded budget on reasoning (Output `> 50` ✓)
+  yet returned a terse visible reply (8–36 words), failing the floor on 4
+  dailies (07-14/15/16/21) while `openai`/`anthropic` passed under identical
+  load. The floor was removed so the causal proof is token-level and holds for
+  any collected model. `openai`/`anthropic` remain a real essay; that is a
+  model trait, not a contract the suite pins.
 - **Runtime honors the parameter** (verified two ways on dev33: an API run
   with a `max_tokens: 50` tweak returned an empty reply, and the UI-saved
   value produced Output = 46 ≤ 50), so unlike #481/#482 there is no

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-max-tokens.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-max-tokens.spec.ts
@@ -5,6 +5,8 @@ import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import {
   closeAdvancedOptions,
   openAdvancedOptions,
@@ -134,9 +136,23 @@ function getTestTargets(): TestTarget[] {
   }));
 }
 
+// Ids of flows created by loadAgent — deleted id-scoped in afterEach.
+// SimpleAgentTemplatePage.load() no longer wipes existing flows (the cross-worker
+// wipe was removed in #553), so each loaded template persists until cleaned up.
+const createdFlowIds: string[] = [];
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, { headers: { Authorization: bearer } });
+  }
+});
+
 async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
   try {
-    await new SimpleAgentTemplatePage(page).load(options);
+    const flowId = await new SimpleAgentTemplatePage(page).load(options);
+    createdFlowIds.push(flowId);
   } catch (e: any) {
     if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
     throw e;
@@ -248,8 +264,10 @@ async function readOutputTokens(page: Page): Promise<number> {
 
 const targets = getTestTargets();
 
-// SimpleAgentTemplatePage.load() deletes all flows before loading the template;
-// serial mode + --workers=1 keeps the shared instance state deterministic.
+// Each test loads the Simple Agent template (creating a flow) and runs it in the
+// shared Playground; serial mode + --workers=1 keeps that shared instance state
+// deterministic and avoids named-flow collisions. Flows are deleted id-scoped in
+// afterEach (load() no longer wipes them — see #553).
 test.describe.configure({ mode: "serial" });
 
 for (const { label, options, skipReason } of targets) {
@@ -286,7 +304,7 @@ for (const { label, options, skipReason } of targets) {
 
     test(
       "causal control — unset max_tokens generates freely",
-      { tag: ["@regression", "@agents", "@playground"] },
+      { tag: ["@stable", "@regression", "@agents", "@playground"] },
       async ({ page }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(
@@ -304,12 +322,17 @@ for (const { label, options, skipReason } of targets) {
         });
 
         await test.step("run the essay prompt and assert unbounded output", async () => {
-          const reply = await runPrompt(page);
+          await runPrompt(page);
           const outputTokens = await readOutputTokens(page);
           // Only max_tokens differs from Test 1, so its cap is attributable to
-          // the parameter, not to the model choosing to answer briefly.
+          // the parameter, not to the model choosing to answer briefly. The
+          // proof is token-level only: a thinking model spends the unbounded
+          // budget on reasoning (Output > 50) yet may return a terse visible
+          // reply, so the reply TEXT is deliberately NOT asserted — a word-count
+          // floor measured model verbosity, not the max_tokens contract, and
+          // was a false negative on gemini-2.5-flash (#866). The token floor
+          // also subsumes the anti-empty guard: an aborted run yields Output 0.
           expect(outputTokens).toBeGreaterThan(TOKEN_LIMIT);
-          expect(reply.split(/\s+/).length).toBeGreaterThan(200);
         });
       },
     );


### PR DESCRIPTION
**Closes #866.**

## Problem

`agent-max-tokens.spec.ts` Test 2 (`causal control — unset max_tokens generates freely`) hard-failed on 4 dailies with the same signature — **2026-07-14, 07-15, 07-16, 07-21** (final, after 2 CI retries). Forensics on the daily JSON artifacts show it failed **only** on the `google / gemini-2.5-flash` variant; `openai / gpt-4o-mini` and `anthropic / claude-sonnet-5` passed 3/3 under identical daily 2-worker load, so this is **not** parallel-load collateral.

The failing assertion is the word-count floor (`reply.split(/\s+/).length > 200`), **not** the token-level one. The token assertion (`outputTokens > 50`) **passed** on the failing runs — `gemini-2.5-flash` is a thinking model that spends the unbounded budget on reasoning (Output > 50 ✓) yet returns a terse visible reply (Received 8 / 12 / 23 / 36 words). The word count measures model verbosity, not the `max_tokens` contract.

**Why it only started 07-14:** the floor has been fragile since the spec's creation (#483, 2026-07-06) but stayed dormant because the collected `google` model was `gemini-omni-flash-preview` (Interactions-API-only → the variant was **skipped**, reason "Provider google inactive"). When `collect-models` began selecting the available `gemini-2.5-flash` (~07-14), the variant executed and exposed the latent floor. Root cause is a **test defect**, not a Langflow regression — `max_tokens` works (token-level cap + uncap correct across all 3 providers).

## Fix

Remove the `> 200` word-count assertion from Test 2; keep `outputTokens > TOKEN_LIMIT` as the causal proof. The token floor **subsumes** the anti-empty guard — an aborted/empty run yields Output `0` (≤ 50) and fails the control — so no reply-text floor is needed. This makes the assertion model-agnostic and aligns Test 2 with the spec doc's own stated principle ("token-level assertion, not text-length; reply length varies with model verbosity") and with Test 1, which already skips text assertions for thinking models. The spec doc's validation criterion is reconciled accordingly.

**Rejected alternative:** hardening the test against load / retrying — rejected because the failure is deterministic on a single model under load others pass, i.e. not load-driven; and gating the word-count to non-thinking models would re-encode the same verbosity dependency.

## Scope note

- Token-level assertions (Test 1 `≤ 50`, Test 2 `> 50`) unchanged — the actual `max_tokens` contract.
- `@stable` restored on Test 2 (auto-removed at triage as prevention).
- Added id-scoped `afterEach` cleanup: `SimpleAgentTemplatePage.load()` no longer wipes flows (#553), so the spec was leaking one flow per test; now each created flow is deleted via the API.

## Validation (nightly 1.11.0.dev50, `--workers=1 --retries=0`)

- typecheck ✅ · eslint ✅ (0 errors)
- Burst 3/3 clean (`expected=2 unexpected=0 flaky=0` each), zero `🚨 Backend Error` ✅
- force-fail ✅ both tests (invert `toBeLessThanOrEqual→toBeGreaterThan` and `toBeGreaterThan→toBeLessThan(0)` → red, then reverted → green)
- Orphan flows after burst: 0 user-owned ✅
- google variant re-validated locally on `gemini-3.5-flash` (current catalog; `gemini-2.5-flash` no longer offered) → 2 passed ✅
