### PR TITLE
chore(ci): integrate Flakiness.io Playwright reporter

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -27,6 +27,8 @@ permissions:
   # An explicit permissions block defaults every unlisted scope to `none`,
   # so without this the container pull is denied (see #594).
   packages: read
+  # Authenticate the Flakiness.io Playwright reporter via GitHub OIDC.
+  id-token: write
 
 jobs:
   e2e-daily-stable:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "dotenv": "^16.4.5"
       },
       "devDependencies": {
+        "@flakiness/playwright": "^1.18.0",
         "@playwright/test": "1.58.2",
         "@types/node": "^25.5.0",
         "eslint": "^10.1.0",
@@ -139,6 +140,20 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@flakiness/playwright": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@flakiness/playwright/-/playwright-1.18.0.tgz",
+      "integrity": "sha512-ZYf2H1ykTO6vC6o3seSKyEc8urj06/KZ5gEIEtZCvyvs73U9sWfpz/995UvVuk3SKz6qwIKBf8BlvY/DLmf+4g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "flakiness-playwright-shard": "lib/flakiness-playwright-shard.js",
+        "flakiness-playwright-timings": "lib/flakiness-playwright-timings.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dotenv": "^16.4.5"
   },
   "devDependencies": {
+    "@flakiness/playwright": "^1.18.0",
     "@playwright/test": "1.58.2",
     "@types/node": "^25.5.0",
     "eslint": "^10.1.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,7 +17,10 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 3,
   workers: process.env.CI ? 2 : undefined,
   timeout: 5 * 60 * 1000, // 5 minutes per test
-  reporter: process.env.CI ? "blob" : "html",
+  reporter: [
+    [process.env.CI ? "blob" : "html"],
+    ["@flakiness/playwright", { flakinessProject: "Orion/langflow-e2e" }],
+  ],
 
   use: {
     baseURL: BASE_URL,


### PR DESCRIPTION
## What this does

Wires up the [Flakiness.io](https://flakiness.io) Playwright reporter so E2E runs upload their results to the dashboard (project **`Orion/langflow-e2e`**). This lets us track flaky `@stable` tests over time from the `daily-stable` workflow instead of eyeballing red runs.

## Why

The Flakiness.io wiring previously existed **only in a local working tree** — it was never committed or pushed. Because GitHub Actions always runs from the committed ref (never a contributor's local changes), CI runs used the old config, the reporter package was never installed, and **nothing was ever uploaded to Flakiness.io**. This PR promotes exactly those changes so CI actually reports.

## Changes

| File | Change |
|---|---|
| `playwright.config.ts` | `reporter` becomes an array so the existing `blob`/`html` reporter keeps running **alongside** the new `@flakiness/playwright` reporter (`flakinessProject: "Orion/langflow-e2e"`). |
| `package.json` / `package-lock.json` | Add the `@flakiness/playwright` devDependency (`^1.18.0`). |
| `.github/workflows/daily-stable.yml` | Grant `id-token: write` so the reporter can authenticate to Flakiness.io via **GitHub OIDC**. |

## Scope note

This PR is intentionally **flakiness-only**. Unrelated local experiments (multi-browser `firefox`/`webkit` projects, `test:chrome/firefox/webkit` scripts) were deliberately left out and are **not** part of this branch.

## Validation

- `npm run typecheck` ✅ (passes — the reporter is referenced as a string, no type resolution needed)
- The reporter only activates on runs that install deps via the committed lockfile, i.e. `daily-stable.yml` on `main`.

## Follow-ups / open questions

- Confirm the `@flakiness/playwright` reporter authenticates purely via OIDC (`id-token: write`) or whether it also needs a project token/secret in the workflow `env`.
- If we want reporting on `nightly.yml` too, the same `reporter` config already covers it — only the `id-token: write` permission would need to be added there.