### PR TITLE
chore(ci): run Flakiness.io reporter alongside the HTML report in the daily

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -236,7 +236,11 @@ jobs:
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
 
       - name: Run @stable tests
-        run: npx playwright test --grep "@stable" --pass-with-no-tests --reporter=html,github,json
+        # No --reporter override here: the reporter list (html + github + json +
+        # the Flakiness.io uploader) is defined in playwright.config.ts. A CLI
+        # --reporter flag would replace the config list entirely and drop the
+        # Flakiness.io reporter (whose flakinessProject option can't be set via CLI).
+        run: npx playwright test --grep "@stable" --pass-with-no-tests
         env:
           CI: "true"
           PLAYWRIGHT_BASE_URL: "http://localhost:7860/"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,10 +17,24 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 3,
   workers: process.env.CI ? 2 : undefined,
   timeout: 5 * 60 * 1000, // 5 minutes per test
-  reporter: [
-    [process.env.CI ? "blob" : "html"],
-    ["@flakiness/playwright", { flakinessProject: "Orion/langflow-e2e" }],
-  ],
+  // Reporters run side by side: the standard Playwright HTML report (kept as
+  // the CI artifact / local view) PLUS the Flakiness.io reporter, which uploads
+  // to the dashboard. In CI we also keep `github` (annotations) and `json`
+  // (results.json — consumed by the QA Platform payload and run history). The
+  // Flakiness.io reporter MUST live here, not on the CLI `--reporter` flag,
+  // because its `flakinessProject` option (required for GitHub OIDC upload)
+  // cannot be passed via the command line.
+  reporter: process.env.CI
+    ? [
+        ["html"],
+        ["github"],
+        ["json"],
+        ["@flakiness/playwright", { flakinessProject: "Orion/langflow-e2e" }],
+      ]
+    : [
+        ["html"],
+        ["@flakiness/playwright", { flakinessProject: "Orion/langflow-e2e" }],
+      ],
 
   use: {
     baseURL: BASE_URL,


### PR DESCRIPTION
## Problem

After #874 wired the `@flakiness/playwright` reporter into `playwright.config.ts`, the daily still uploaded **nothing** to Flakiness.io.

Root cause: the `daily-stable` "Run @stable tests" step ran

```
npx playwright test --grep "@stable" --pass-with-no-tests --reporter=html,github,json
```

A CLI `--reporter=` flag **replaces the `reporter` list from the config entirely** — so the Flakiness.io reporter never ran and no report was generated or uploaded. (Confirmed every test-running workflow passes `--reporter=` on the CLI, so the config list was being overridden across CI.)

The reporter also **cannot** simply be appended to the CLI flag: CLI reporters carry no options, and the reporter's `flakinessProject` option — required for GitHub OIDC upload — has no env-var fallback (verified in the package source: OIDC upload is skipped when `flakinessProject` is unset). It must be configured in `playwright.config.ts`.

## Change

Move the reporter list into the config so **all reporters run side by side**, and drop the CLI override from the daily step.

| File | Change |
|---|---|
| `playwright.config.ts` | In CI emit `html` + `github` + `json` + `@flakiness/playwright`; locally emit `html` + `@flakiness/playwright`. |
| `.github/workflows/daily-stable.yml` | Remove `--reporter=html,github,json` from the `@stable` step so the config-defined list (incl. the Flakiness.io uploader) takes effect. |

**Nothing is removed** — the standard HTML report is kept in both CI and local runs; `github` and `json` are kept in CI.

## Preserved behavior

- **`results.json` (load-bearing)** — the `json` reporter still honors `PLAYWRIGHT_JSON_OUTPUT_NAME=results.json` (set in the step env), so the QA Platform payload (`build-run-payload.mjs`), the run POST, and `reports/daily-history.jsonl` are unaffected.
- **HTML artifact** — `["html"]` with no `outputFolder` writes `playwright-report/`, exactly what the upload steps expect.
- **OIDC auth** — `id-token: write` (added in #874) is in place and the Flakiness.io project `Orion/langflow-e2e` is bound to this repository, so uploads authenticate with no access token.

No workflow uses the `blob` reporter / `merge-reports` / `--shard`, so dropping the former CI `blob` default (overridden by every workflow anyway) is safe.

## Scope

Daily only, as requested. `nightly.yml` / `pr-validation.yml` / `adaptive-impacted.yml` still use `--reporter=github` and are intentionally left unchanged.