### PR TITLE
test(mcp): MCP Server flow-file resources — list + read via MCP protocol (#828)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -652,8 +652,8 @@
 - [x] Deleting a non-existent MCP server returns 404 Not Found → `mcp/client/mcp-server-registration-status-codes.spec.ts`
 - [-] Agent uses MCPTools as tool and calls echo via MCP → `mcp/client/mcp-client-agent.spec.ts`
 - [-] Gemini × MCP tool-calling regression — agent runs but invokes no echo MCP tool (guards upstream #440) → `mcp/client/mcp-client-agent-gemini-tool-regression.spec.ts`
-- [ ] List available resources via MCP protocol
-- [ ] Consume resource URI and inject content into flow
+- [ ] List available resources via MCP protocol (client not-implementable on 1.11.x — MCPTools component and v2 client API expose tools only; server-side resources covered in §14.1 → `mcp/server/mcp-server-resources.spec.ts`)
+- [ ] Consume resource URI and inject content into flow (client not-implementable on 1.11.x — no client resource surface; server-side read covered in §14.1 → `mcp/server/mcp-server-resources.spec.ts`)
 
 ---
 
@@ -665,7 +665,7 @@
 - [-] Starter project with MCP
 - [-] Flow exposed as MCP server — verify generated endpoint → `mcp/server/mcp-server-protocol.spec.ts`
 - [-] Execute MCP server tool via MCP protocol → `mcp/server/mcp-server-protocol.spec.ts`
-- [ ] Resource exposed by server is accessible via URI (no product surface on 1.11.x — MCP server `resources/list` returns `[]`; #829)
+- [-] Resource exposed by server is accessible via URI — flow files are exposed as MCP resources (`resources/list` is `[]` only for a file-less flow; an uploaded flow file appears and is readable via `resources/read`) → `mcp/server/mcp-server-resources.spec.ts`
 - [ ] Prompt exposed by server returns correct template (no product surface on 1.11.x — MCP server `prompts/list` returns `[]`; #829)
 
 ---

--- a/docs/mcp/server/mcp-server-resources.md
+++ b/docs/mcp/server/mcp-server-resources.md
@@ -1,0 +1,169 @@
+# MCP Server – List and Read Flow-File Resources
+
+**Last validated:** Langflow 1.11.0
+
+---
+
+## What this test validates *(required)*
+
+Validates that a flow which holds an uploaded file surfaces that file as an
+**MCP resource** over the MCP protocol, and that a client can read the resource
+by its URI and receive the file's content. Exercises the two `resources/*`
+primitives of the MCP protocol against Langflow's project-scoped server
+endpoint (`/api/v1/mcp/project/{project_id}/streamable`):
+
+1. **`resources/list`** — a file uploaded into a project flow appears in the
+   resource list with the expected `name` and a URI of the form
+   `.../api/v1/files/download/{flow_id}/{filename}`.
+2. **`resources/read`** — reading that exact URI returns the file's content,
+   matching the per-run sentinel that was uploaded.
+
+If these fail, external MCP clients (Claude Desktop, IDE agents, …) cannot
+discover or consume files that a Langflow flow exposes — the **resource** half
+of Langflow's MCP-server contract is broken.
+
+### Why this is the companion of `mcp-server-protocol.spec.ts`
+
+`mcp-server-protocol.spec.ts` covers §14.1 **tools** (endpoint + `tools/call`)
+and notes that `resources/list` returns `[]` — true for a flow with **no
+files**: Langflow exposes each flow as a *tool*, not as a resource. A live scout
+of nightly `1.11.0` refined that: **flow files are exposed as resources**. When a
+project flow has an uploaded file, it appears in `resources/list` and is readable
+via `resources/read` (regardless of whether the flow is `mcp_enabled` — resources
+are file-scoped, not tool-scoped). This spec covers exactly that dimension.
+
+### Scope note — re-scoped from §13.1 (client) to §14.1 (server)
+
+Issue #828 was filed under §13.1 (MCP **Client**). A live scout proved the client
+does not expose resources: the MCPTools component and the v2 client API surface
+only ever deal with **tools** (no resource UI, endpoint, or schema field). The
+`list_resources`/`read_resource` capability exists **only on the server side**
+(`@server.list_resources()` / `@server.read_resource()` in `api/v1/mcp_projects.py`),
+so this spec validates the surface that actually implements the behavior. The
+§13.1 client-resource bullet stays open/not-implementable.
+
+---
+
+## Tags *(required)*
+
+All tests: `@api` `@mcp` `@regression` — pure MCP-protocol (JSON-RPC over HTTP);
+no UI page, no LLM/agent. Mirrors the tag set of the direct sibling
+`mcp-server-protocol.spec.ts`.
+
+**`@stable` is intentionally withheld.** Per issue #828 the promotion is gated:
+this MCP area is in the current flaky cluster (#773) and the clean non-guarded
+daily baseline (#818) has not yet been achieved. Add `@stable` only after that
+gate is met and the spec has demonstrated repeated clean `--retries=0` runs.
+
+---
+
+## Step by step *(required)*
+
+Setup (`beforeAll`): resolve the auth header via `getAuthToken`; take the default
+project id from `GET /api/v1/projects/`; create a flow via
+`createRunnableChatFlowViaApi`; upload a small text file carrying a per-run
+sentinel into that flow via `POST /api/v1/files/upload/{flowId}` (multipart), and
+capture the server-assigned (timestamp-prefixed) filename from the response
+`file_path`. Teardown (`afterAll`): delete the flow (removes its file too).
+
+**Test 1 — `resources/list` surfaces the uploaded flow file**
+
+1. Complete the MCP handshake (`initialize` + `notifications/initialized`) via
+   `mcpHandshake` against the project streamable endpoint.
+2. Call `resources/list`; **poll** it until a resource whose URI path ends with
+   `/api/v1/files/download/{flowId}/{uploadedName}` appears (the list can lag a
+   moment behind the upload) — up to a bounded timeout.
+3. Assert that resource's `name` equals the uploaded filename.
+
+**Test 2 — `resources/read` returns the file content by URI**
+
+1. Complete the handshake.
+2. Call `resources/read` with `params.uri` set to the resource URI
+   (`.../files/download/{flowId}/{uploadedName}`).
+3. Assert `result.contents[0].uri` matches the requested path and that its
+   content (decoding `blob`/`text`; see Notes on encoding) contains the exact
+   per-run sentinel — proving the byte content is served, not merely listed.
+
+---
+
+## Validation criterion *(required)*
+
+- **Test 1:** the `resources/list` result contains an entry whose `uri` path is
+  `/api/v1/files/download/{flowId}/{uploadedName}` and whose `name` equals the
+  uploaded filename — asserted against the specific created flow, not a generic
+  "≥1 resource" (the project list also contains other flows' files).
+- **Test 2:** the `resources/read` result's `contents[0]` carries the matching
+  URI and its decoded content contains the per-run sentinel string uploaded in
+  setup.
+
+---
+
+## External dependencies *(required)*
+
+- `src/backend/base/langflow/api/v1/mcp_projects.py` — project-scoped MCP server:
+  the `/{project_id}/streamable` route,
+  `StreamableHTTPSessionManager(..., stateless=True)`, and the
+  `@server.list_resources()` / `@server.read_resource()` handlers.
+- `src/backend/base/langflow/api/v1/mcp_utils.py` — `handle_list_resources`
+  (builds `Resource(uri=.../files/download/{flow_id}/{file}, name, mimeType)`
+  from `storage_service.list_files(flow_id)`) and `handle_read_resource`
+  (parses the URI's last two path segments, authorizes, returns file content).
+- `src/backend/base/langflow/api/v1/files.py` — `POST /api/v1/files/upload/{flow_id}`
+  (server prepends a `YYYY-MM-DD_HH-MM-SS_` prefix to the stored filename).
+- Helpers: `tests/helpers/auth/get-auth-token.ts`,
+  `tests/helpers/mcp/mcp-streamable-client.ts` (`mcpCall`, `mcpHandshake`),
+  `tests/helpers/flows/create-runnable-chat-flow-via-api.ts`,
+  `tests/helpers/flows/delete-flow.ts`.
+
+---
+
+## What this test does not cover *(optional)*
+
+- **Client-side resource consumption (§13.1)** — not implemented in the product
+  (see Scope note); no MCPTools resource UI or client API exists to test.
+- **MCP Server *tools*** (`tools/list`, `tools/call`) and the generated-endpoint
+  advertisement — covered by `mcp-server-protocol.spec.ts`.
+- **MCP Server UI** (exposing a flow via the MCP Server tab) — covered by
+  `mcp-server-regression.spec.ts` and `mcp-server.spec.ts`.
+- MCP prompts (`prompts/list`, `prompts/get`) — separate primitive, out of scope.
+- User-level files (uploaded via `/api/v2/files`) — only exposed on the global
+  (non-project) server; this spec scopes to project resources = flow files.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`, `auto_login` mode (the fixture's
+  `request` context is authenticated via `getAuthToken`).
+- No LLM or API key required.
+
+---
+
+## Notes *(optional)*
+
+- The streamable transport is **stateless** (`stateless=True`): each JSON-RPC
+  POST is independent, no `Mcp-Session-Id` is carried between calls. Confirmed
+  live — `initialize`, `resources/list`, `resources/read` each return `200` as
+  standalone POSTs. `mcpHandshake` still fires `notifications/initialized` to
+  mirror a real client.
+- **Content encoding:** for a `text/plain` upload the stored file's mimeType is
+  reported as `application/octet-stream`, so `resources/read` returns the content
+  in `contents[0].blob` (not `text`). On 1.11.0 the observed `blob` is
+  **double-base64** (the read handler base64-encodes the file bytes, then the MCP
+  framework base64-encodes the `blob` field). The assertion decodes defensively —
+  it looks for the sentinel at decode depth 0/1/2 — so it survives a future switch
+  to single-encoding or a plain `text` field without silently passing on garbage.
+- **Timing:** `resources/list` can momentarily lag behind the upload; Test 1
+  polls the list until the file appears rather than asserting on a single shot.
+- **Filename:** the upload API prepends a timestamp
+  (`2026-07-21_14-31-34_note.txt`); the resource `name`/`uri` use that stored
+  name, so read must target the server-assigned name (captured from the upload
+  response), not the original one.
+- **URI matching:** assert on the URI *path suffix*
+  (`/files/download/{flowId}/{file}`), not the absolute host — the server builds
+  the URI from its own host setting (`localhost`), which may differ from the
+  test's `PLAYWRIGHT_BASE_URL` host; `handle_read_resource` only consumes the last
+  two path segments.
+- Flow cleanup: the created flow is deleted in `afterAll` (id-scoped); the orphan
+  count is checked via `GET /api/v1/flows/` before reporting. The uploaded file is
+  removed with the flow.

--- a/tests/tests-automations/regression/mcp/server/mcp-server-resources.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-resources.spec.ts
@@ -1,0 +1,193 @@
+import { expect, test } from "../../../../fixtures/fixtures";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import {
+  createRunnableChatFlowViaApi,
+  type RunnableChatFlow,
+} from "../../../../helpers/flows/create-runnable-chat-flow-via-api";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { mcpCall, mcpHandshake } from "../../../../helpers/mcp/mcp-streamable-client";
+
+/**
+ * MCP Server — flow-file resources over the MCP protocol (QA-CHECKLIST §14.1
+ * resources, re-scoped from §13.1; see docs/mcp/server/mcp-server-resources.md).
+ *
+ * Companion to mcp-server-protocol.spec.ts (which covers §14.1 tools and notes
+ * resources/list is empty for a file-less flow). Langflow exposes a flow's
+ * uploaded files as MCP resources: a file uploaded into a project flow appears
+ * in resources/list and is readable via resources/read by its URI. This spec
+ * speaks the real MCP protocol to the project's generated streamable endpoint:
+ *   T1 — resources/list surfaces the uploaded file as a resource (name + URI).
+ *   T2 — resources/read returns that file's content (per-run sentinel).
+ *
+ * The client side (§13.1) is NOT covered — the MCPTools component / v2 client
+ * API expose tools only, no resource surface exists to test.
+ *
+ * `@stable` withheld — promotion gated (issue #828; MCP flaky cluster #773,
+ * clean-baseline gate #818, surface deps #809/#643).
+ */
+
+// A resource read can arrive base64-encoded (blob), and on 1.11.0 the blob is
+// double-base64. Decode defensively up to two levels so the assertion survives a
+// future switch to single-encoding or a plain-text field, without passing on
+// garbage (the sentinel is distinctive enough that a wrong decode can't match).
+function decodedContentContainsSentinel(
+  value: string | undefined,
+  sentinel: string,
+): boolean {
+  if (!value) return false;
+  let cur = value;
+  for (let depth = 0; depth <= 2; depth++) {
+    if (cur.includes(sentinel)) return true;
+    const next = Buffer.from(cur, "base64").toString("utf-8");
+    if (!next || next === cur) break;
+    cur = next;
+  }
+  return false;
+}
+
+// Shared project MCP surface is instance-wide; run serially so a sibling
+// project-MCP spec can't race this one, and so T2 can rely on T1's ordering.
+test.describe.configure({ mode: "serial" });
+
+test.describe("MCP Server — flow-file resources protocol", () => {
+  let authorization: string;
+  let projectId: string;
+  let streamableUrl: string;
+  let flow: RunnableChatFlow;
+  let uploadedName: string;
+  let expectedResourcePath: string;
+  let resourceUri: string;
+  const sentinel = `mcp-res-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  test.beforeAll(async ({ request }) => {
+    authorization = await getAuthToken(request);
+    const headers = { Authorization: authorization };
+
+    // Create the flow first, then scope to the project it actually lives in
+    // (its folder_id), so resources/list on that project is guaranteed to
+    // include this flow's file — instead of assuming projects[0].
+    flow = await createRunnableChatFlowViaApi(request, headers);
+
+    const flowRes = await request.get(`/api/v1/flows/${flow.flowId}`, { headers });
+    expect(flowRes.ok()).toBeTruthy();
+    projectId = ((await flowRes.json()).folder_id as string) ?? "";
+    if (!projectId) {
+      const projectsRes = await request.get("/api/v1/projects/", { headers });
+      const projects = await projectsRes.json();
+      const list = Array.isArray(projects) ? projects : projects.folders ?? [];
+      expect(list.length).toBeGreaterThan(0);
+      projectId = list[0].id;
+    }
+    streamableUrl = `/api/v1/mcp/project/${projectId}/streamable`;
+
+    // Upload a small text file carrying the per-run sentinel into the flow.
+    const uploadRes = await request.post(
+      `/api/v1/files/upload/${flow.flowId}`,
+      {
+        headers,
+        multipart: {
+          file: {
+            name: "resource-note.txt",
+            mimeType: "text/plain",
+            buffer: Buffer.from(sentinel, "utf-8"),
+          },
+        },
+      },
+    );
+    expect(uploadRes.ok(), `upload failed: ${uploadRes.status()}`).toBeTruthy();
+    // The server prepends a timestamp to the stored name — capture the real one.
+    const filePath = (await uploadRes.json()).file_path as string;
+    uploadedName = filePath.split("/").pop() ?? "";
+    expect(uploadedName, "upload response must carry a stored file name").toBeTruthy();
+
+    expectedResourcePath = `/api/v1/files/download/${flow.flowId}/${uploadedName}`;
+    // handle_read_resource only consumes the URI's last two path segments, so a
+    // host built from the test's base URL is accepted regardless of the host the
+    // server uses in the listed URI.
+    const baseUrl = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:7860/";
+    resourceUri = new URL(expectedResourcePath, baseUrl).toString();
+  });
+
+  test.afterAll(async ({ request }) => {
+    // Playwright forbids reusing the beforeAll request here; use this hook's own.
+    if (flow?.flowId) {
+      await deleteFlow(request, flow.flowId, {
+        headers: { Authorization: authorization },
+      }).catch(() => {});
+    }
+  });
+
+  test(
+    "resources/list surfaces the uploaded flow file as a resource",
+    { tag: ["@regression", "@api", "@mcp"] },
+    async ({ request }) => {
+      await mcpHandshake(request, streamableUrl, authorization);
+
+      // resources/list can lag a moment behind the upload — poll until this
+      // flow's file appears, matching on its exact URI path (the project list
+      // also contains other flows' files, so a generic count is not enough).
+      let matched: { name: string; uri: string } | undefined;
+      await expect
+        .poll(
+          async () => {
+            const resp = await mcpCall(
+              request,
+              streamableUrl,
+              authorization,
+              "resources/list",
+              {},
+              2,
+            );
+            const resources = (resp.result?.resources ?? []) as Array<{
+              name: string;
+              uri: string;
+            }>;
+            matched = resources.find(
+              (r) =>
+                decodeURIComponent(new URL(r.uri).pathname) ===
+                expectedResourcePath,
+            );
+            return Boolean(matched);
+          },
+          { timeout: 30000, intervals: [1000, 2000, 3000, 5000] },
+        )
+        .toBeTruthy();
+
+      expect(matched?.name).toBe(uploadedName);
+    },
+  );
+
+  test(
+    "resources/read returns the uploaded file content by URI",
+    { tag: ["@regression", "@api", "@mcp"] },
+    async ({ request }) => {
+      await mcpHandshake(request, streamableUrl, authorization);
+
+      const resp = await mcpCall(
+        request,
+        streamableUrl,
+        authorization,
+        "resources/read",
+        { uri: resourceUri },
+        3,
+      );
+
+      expect(resp.error, JSON.stringify(resp.error)).toBeUndefined();
+      const contents = (resp.result?.contents ?? []) as Array<{
+        uri: string;
+        text?: string;
+        blob?: string;
+      }>;
+      expect(contents.length).toBeGreaterThan(0);
+
+      const content = contents[0];
+      expect(decodeURIComponent(new URL(content.uri).pathname)).toBe(
+        expectedResourcePath,
+      );
+      expect(
+        decodedContentContainsSentinel(content.text ?? content.blob, sentinel),
+        "resource content must contain the uploaded sentinel",
+      ).toBe(true);
+    },
+  );
+});


### PR DESCRIPTION
Closes #828.

Covers the §14.1 **resources** gap in `QA-CHECKLIST.md` (re-scoped from §13.1 — see below). Companion to `mcp-server-protocol.spec.ts`: that spec covers §14.1 *tools* and notes `resources/list` is `[]` for a file-less flow. A live scout of nightly 1.11.0 refined that — **a flow's uploaded files ARE exposed as MCP resources** — which is the distinct journey validated here.

## Re-scope (§13.1 → §14.1)
Issue #828 was filed under §13.1 (MCP **Client**). A live surface scout proved the client does not expose resources: the MCPTools component and the v2 client API deal with **tools only** (no resource UI, endpoint, or schema field). `list_resources`/`read_resource` exist **only server-side** (`@server.list_resources()` / `@server.read_resource()` in `api/v1/mcp_projects.py`). The spec therefore validates the surface that actually implements the behavior. The §13.1 client bullets are annotated not-implementable; the §14.1:668 bullet — which wrongly claimed "no product surface" — is corrected and now points to this spec.

## 1. Covered tests
| # | Test | What it validates |
|---|------|-------------------|
| 1 | `resources/list surfaces the uploaded flow file as a resource` | A file uploaded into a project flow appears in `resources/list` with a URI path `/api/v1/files/download/{flowId}/{storedName}` and matching `name` — matched against the specific created flow (the project list also contains other flows' files), catching a regression where flow files stop being exposed as resources. |
| 2 | `resources/read returns the uploaded file content by URI` | `resources/read` on that URI returns `contents[0]` with the matching URI and content equal to a per-run sentinel — catching a regression where a resource is listed but its bytes are not served. |

## 2. How the test was built
- Pure MCP-protocol (JSON-RPC over the streamable HTTP transport), mirroring the direct sibling `mcp-server-protocol.spec.ts`; no UI page (MCP Server UI exposure is covered by `mcp-server-regression.spec.ts` / `mcp-server.spec.ts`).
- **Live-confirmed surface** (scouted against nightly 1.11.0): the transport is `stateless=True`, so each JSON-RPC POST is independent; `initialize` / `resources/list` / `resources/read` each return 200 standalone. Reuses `mcpCall` / `mcpHandshake`, `getAuthToken`, `createRunnableChatFlowViaApi`, `deleteFlow`.
- Setup uploads a small text file (per-run sentinel) into the flow via `POST /api/v1/files/upload/{flowId}`; the server prepends a timestamp to the stored name, captured from the response.
- Non-obvious behaviors encoded: `resources/list` can lag behind the upload → Test 1 **polls** the list; content returns as `blob` and is **double-base64** on 1.11.0 → the assertion decodes defensively (depth 0/1/2), surviving a future single-encoding/text switch without passing on garbage; URI matching is on the path suffix (host differs between server setting and test base).
- Project id is derived from the created flow's `folder_id` (not assumed `projects[0]`), guaranteeing the resource is in the queried project.

## 3. Dependencies
- None — no LLM / provider / API key. `auto_login` mode.
- Execution mode: `test.describe.configure({ mode: "serial" })` (shared project MCP surface is instance-wide; also lets Test 2 rely on setup ordering).

## Tags & promotion
`@api` `@mcp` `@regression`. **`@stable` intentionally withheld** — promotion gated per #828: MCP flaky cluster (#773) and clean-baseline gate (#818) not yet met; surface deps #809/#643.

## Validation (nightly 1.11.0, `--workers=1 --retries=0`)
- typecheck ✅ · eslint ✅ (0/0) · anti-pattern checklist ✅
- 3 clean runs, 2 passed each (~1.1–1.3s), no flake ✅
- force-fail ✅ — T1 (broke list path match → poll timeout), T2 (wrong sentinel → assert failed); both reverted, re-green
- `--trace=on` ✅ (1.2s, no hang) · zero `🚨 Backend Error` ✅
- flow cleanup verified: 0 leaked flows via `GET /api/v1/flows/` ✅
