### PR TITLE
fix(project-management): isolate bulk-actions in a dedicated folder (#869)

### DIFF
--- a/docs/core-functionality/project-management/bulk-actions.md
+++ b/docs/core-functionality/project-management/bulk-actions.md
@@ -14,7 +14,7 @@ Validates multi-select and bulk operations on the home flow listing:
 4. **Ctrl/Cmd selection** — Ctrl/Cmd-clicking the first and third cards selects exactly those two, leaving the second unchecked (proves per-item, not range, selection).
 5. **Bulk delete** — `delete-bulk-btn` followed by the confirmation removes the selected flows; the deleted flow names disappear from the listing while the unselected one remains.
 
-The test creates its 3 flows directly via the REST API (`POST /api/v1/flows/`, empty `nodes`/`edges`) and captures each returned flow ID, so cleanup deletes only the IDs it created — never sibling specs' flows, which is required for safety under `fullyParallel`. Creating via the API (rather than clicking through the templates modal three times) also removes the sole source of this spec's historical CI flake — see **Known flakiness**.
+The test creates its 3 flows in a **dedicated project/folder** via the REST API (`POST /api/v1/projects/` for the folder, then `POST /api/v1/flows/` with that `folder_id`, empty `nodes`/`edges`) and captures each returned ID, so cleanup deletes only the IDs it created — never sibling specs' flows, which is required for safety under `fullyParallel`. It then navigates to that folder's listing, which shows **only** those 3 flows, so the positional selection (shift/ctrl-click by card index) and destructive bulk-delete operate on an isolated set — a sibling worker's concurrently-created flow lands in the **default** project and can no longer interleave into this test's listing (the recurrent `#869` cross-worker flake). Creating via the API (rather than clicking through the templates modal three times) also removes the sole source of this spec's historical CI flake — see **Known flakiness**.
 
 ---
 
@@ -26,9 +26,9 @@ The test creates its 3 flows directly via the REST API (`POST /api/v1/flows/`, e
 
 ## Step by step *(required)*
 
-1. Create 3 flows via `POST /api/v1/flows/` (`createFlow` helper) with unique names (`bulk-actions-<suffix>-1..3`) and empty `data`; capture each returned ID. This runs **before** bootstrap so the instance is non-empty.
-2. Bootstrap the test session onto the home listing (`awaitBootstrapTest(page, { skipModal: true })`). `skipModal` skips opening the templates modal; seeding the flows first also skips the empty-page branch (`addFlowToTestOnEmptyLangflow`, which drives the same templates-modal helper), so no part of the historically flaky modal path is exercised. The 3 just-created flows sort to the top by recency.
-3. **Guard:** assert the top 3 list cards' names are exactly the 3 created names — selection is positional (shift/ctrl-click by index) and bulk-delete is destructive, so a sibling worker's flow interleaving at the top must fail fast rather than risk a cross-worker delete.
+1. Create a dedicated folder via `POST /api/v1/projects/` with a unique name; capture its ID. Then create 3 flows via `POST /api/v1/flows/` (`createFlow` helper) with unique names (`bulk-actions-<suffix>-1..3`), empty `data`, and `folder_id` set to that folder; capture each returned ID. This runs **before** bootstrap so the instance is non-empty.
+2. Bootstrap the test session (`awaitBootstrapTest(page, { skipModal: true })`), then navigate to the dedicated folder's listing via its sidebar entry so **only** the 3 created flows are shown. `skipModal` skips opening the templates modal; seeding the flows first also skips the empty-page branch (`addFlowToTestOnEmptyLangflow`, which drives the same templates-modal helper), so no part of the historically flaky modal path is exercised.
+3. **Guard:** assert the folder listing contains exactly the 3 created names — selection is positional (shift/ctrl-click by index) and bulk-delete is destructive. Because the listing is folder-scoped, a sibling worker's flow (created in the default project) cannot interleave; the guard confirms isolation before any destructive selection.
 4. Shift-click list card 1 then list card 3; assert all 3 checkboxes are checked.
 5. Click `download-bulk-btn`; assert the "downloaded successfully" notification.
 6. Shift-click list card 1 again; assert all 3 checkboxes are unchecked.
@@ -36,7 +36,7 @@ The test creates its 3 flows directly via the REST API (`POST /api/v1/flows/`, e
 8. Capture the three flow names from `flow-name-div` (asserting non-empty text first).
 9. Click `delete-bulk-btn`, confirm in the "This can't be undone." dialog; assert "Flows deleted successfully".
 10. Assert the first and third flow names are hidden and the second is still visible.
-11. **Cleanup (finally):** delete each captured flow ID via `DELETE /api/v1/flows/{id}` (404s on already-deleted flows are ignored).
+11. **Cleanup (finally):** delete each captured flow ID via `DELETE /api/v1/flows/{id}` (404s on already-deleted flows are ignored), then delete the dedicated folder via `DELETE /api/v1/projects/{id}`.
 
 ---
 
@@ -52,15 +52,14 @@ The test creates its 3 flows directly via the REST API (`POST /api/v1/flows/`, e
 
 ## External dependencies *(required)*
 
-- Home listing UI testids: `list-card`, `checkbox-*`, `flow-name-div`, `download-bulk-btn`, `delete-bulk-btn`.
-- REST API `POST /api/v1/flows/` (via the `createFlow` helper) for flow creation and `DELETE /api/v1/flows/{id}` for ID-scoped cleanup (auth via `getAuthToken`).
+- Home listing UI testids: `list-card`, `checkbox-*`, `flow-name-div`, `download-bulk-btn`, `delete-bulk-btn`, and the folder sidebar entry (`sidebar-nav-<folderName>`).
+- REST API `POST /api/v1/projects/` + `DELETE /api/v1/projects/{id}` for the dedicated folder, `POST /api/v1/flows/` (via the `createFlow` helper, with `folder_id`) for flow creation, and `DELETE /api/v1/flows/{id}` for ID-scoped cleanup (auth via `getAuthToken`).
 - No starter template or LLM/provider API key required — flows are created empty via the API.
 
 ---
 
 ## What this test does not cover *(optional)*
 
-- Bulk operations across folders/projects other than the default listing.
 - Drag-select or keyboard-only selection.
 - Verifying the actual downloaded file contents (only the success notification is asserted).
 
@@ -75,7 +74,9 @@ This spec used to create its 3 flows through the UI (opening the templates modal
 
 Both modes lived entirely in the incidental UI scaffolding, never in the bulk-action assertions under test. #723 **eliminated the whole class** by creating the 3 flows via `POST /api/v1/flows/` and loading the listing with a single `page.goto("/")` — no templates modal, no editor↔home round-trips. The remaining positional risk (a sibling worker's flow interleaving at the top of the recency-sorted listing) is caught by the top-3 name guard before any destructive selection.
 
-**#790 (load-collateral, top-3 guard hardened).** On load-degraded / guard-tripped dailies (2026-07-09/13/15/16, all recurring on saturated days) the top-3 name guard failed with `expect(received).toEqual(expected) // deep equality`. Root cause is not a product regression — the spec passes 5/5 clean at `--retries=0` on the current nightly (`1.11.0.dev45`); under CI saturation the recency-sorted listing simply had not yet floated the 3 freshly-created flows to the top when the guard read the card names **once** (`evaluateAll` → `toEqual`). Hardened by wrapping that read in `expect.poll(...).toEqual(...)`, so the guard retries until the listing settles instead of asserting on the first (stale) snapshot. `@stable` kept.
+**#790 (load-collateral, top-3 guard hardened — superseded by #869).** On load-degraded / guard-tripped dailies (2026-07-09/13/15/16) the top-3 name guard failed with `expect(received).toEqual(expected) // deep equality`. It was first hardened by wrapping the card-name read in `expect.poll(...).toEqual(...)` so the guard retried until the listing settled. That reduced but did not eliminate the flake.
+
+**#869 (root-caused and fixed by folder isolation).** The deep-equality guard kept recurring (2026-07-15/16/17/21). Root cause is **not** a product regression and **not** pure saturation — it is cross-worker data interference: under `fullyParallel`, a sibling spec's freshly-created flow floats into the **shared** recency-sorted home listing's top 3 and stays there past the 30s poll window, so this spec's positional guard (top 3 must be exactly its 3 flows) legitimately fails. Fixed deterministically by creating the 3 flows in a **dedicated project/folder** (`folder_id` on create) and running the whole positional flow against that folder's listing, where a sibling's default-project flow can never appear. This removes the interference at the source rather than polling around it; the poll was kept as a settle-wait on the now-isolated listing. `@stable` restored on the fix.
 
 ---
 

--- a/tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts
@@ -6,25 +6,34 @@ import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
 test(
   "user should be able to select flows with different methods and perform bulk actions",
-  { tag: ["@release", "@workspace", "@mainpage", "@regression"] },
+  { tag: ["@stable", "@release", "@workspace", "@mainpage", "@regression"] },
   async ({ page, request }) => {
-    // Track the IDs of the 3 flows we create so cleanup can delete ONLY those
-    // via the API, not sibling specs' flows. Under `fullyParallel`, a positional
-    // bulk-delete on the shared listing would otherwise be able to hit a flow
-    // created by another worker (guarded against below).
+    // Track the IDs of the 3 flows + the dedicated folder we create so cleanup
+    // deletes ONLY those via the API, never sibling specs' flows.
     const createdFlowIds: string[] = [];
+    let folderId: string | null = null;
     const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+    const folderName = `bulk-actions-folder-${suffix}`;
     const createdNames = [1, 2, 3].map((n) => `bulk-actions-${suffix}-${n}`);
 
     try {
-      // Create the 3 flows directly via the REST API instead of clicking through
-      // the templates modal three times. The UI path (open modal → pick template
-      // → navigate editor↔home, ×3) was heavy and load-sensitive; both recurring
-      // daily failures (#723: modal never opened / home-return waitForSelector
+      // Create the 3 flows directly via the REST API, inside a DEDICATED
+      // project/folder. The UI path (open modal → pick template → navigate
+      // editor↔home, ×3) was heavy and load-sensitive; both recurring daily
+      // failures (#723: modal never opened / home-return waitForSelector
       // timeout) lived entirely in that scaffolding, never in the bulk-action
       // assertions under test. `createFlow` retries the transient concurrent
       // 500 (#588); empty `data` is enough — the test only selects/downloads/
       // deletes the cards, it never runs the flows.
+      //
+      // The dedicated folder is the fix for #869: the positional selection
+      // (shift/ctrl-click by card index) and destructive bulk-delete below
+      // require the listing to hold EXACTLY these 3 flows. On the shared home
+      // listing under `fullyParallel`, a sibling worker's freshly-created flow
+      // floats into the recency-sorted top 3 and lingers past any poll window
+      // (#790/#869 deep-equality flake). Scoping the whole flow to this folder's
+      // listing — where a sibling's default-project flow can never appear —
+      // removes that interference at the source.
       //
       // Seed via the API BEFORE bootstrapping the browser: this leaves the
       // instance non-empty, so `awaitBootstrapTest`'s empty-page seeding branch
@@ -32,50 +41,52 @@ test(
       // modal via `dismissWelcomeOverlayAndWaitForModal`) is never taken. Getting
       // the token uses `request` and is independent of the browser session.
       const headers = { Authorization: await getAuthToken(request) };
+      const folderRes = await request.post("/api/v1/projects/", {
+        headers,
+        data: { name: folderName },
+      });
+      expect(folderRes.status()).toBe(201);
+      folderId = ((await folderRes.json()) as { id: string }).id;
       for (const name of createdNames) {
         const id = await createFlow(
           request,
-          { name, description: "", data: { nodes: [], edges: [] }, is_component: false },
+          {
+            name,
+            description: "",
+            data: { nodes: [], edges: [] },
+            is_component: false,
+            folder_id: folderId,
+          },
           { headers },
         );
         createdFlowIds.push(id);
       }
 
-      // Bootstrap onto the home listing. `skipModal` skips opening the templates
-      // modal, and because the 3 flows above already exist the empty-page
-      // seeding branch is skipped too — so no part of the historically flaky
-      // modal path (#723) is exercised. The 3 flows sort to the top by recency
-      // (verified live — API-created empty flows select via shift/ctrl click
-      // exactly like template-created ones).
+      // Bootstrap, then navigate to the dedicated folder's listing via its
+      // sidebar entry. `skipModal` skips opening the templates modal, and because
+      // the 3 flows above already exist the empty-page seeding branch is skipped
+      // too — so no part of the historically flaky modal path (#723) is
+      // exercised. The folder view (`/all/folder/<id>`) shows ONLY these 3 flows.
       await awaitBootstrapTest(page, { skipModal: true });
-      await expect(page.getByTestId("list-card").first()).toBeVisible({ timeout: 30000 });
+      await page.getByTestId(`sidebar-nav-${folderName}`).click();
 
-      // Safety + determinism guard: the top 3 cards must be exactly the flows we
-      // created. Selection below is positional (shift/ctrl-click by card index)
-      // and bulk-delete is destructive, so if a sibling worker's flow interleaved
-      // at the top of the recency-sorted listing under `fullyParallel`, fail fast
-      // here rather than risk deleting someone else's flow.
-      // Poll rather than read once: on load-degraded dailies the recency-sorted
-      // listing has not yet floated the 3 freshly-created flows to the top when a
-      // single snapshot is taken, so a one-shot `evaluateAll → toEqual` flaked
-      // with a deep-equality mismatch (#790). Polling retries until the listing
-      // settles; it still fails fast if a sibling worker's flow genuinely sits in
-      // the top 3.
+      // Determinism guard: the folder listing must hold exactly the 3 flows we
+      // created — nothing else can be here, so this confirms isolation before any
+      // destructive selection. Poll to absorb the listing's initial render/settle.
       await expect
         .poll(
           async () =>
             (
               await page
                 .locator("[data-testid='flow-name-div'] span")
-                .evaluateAll((els) =>
-                  els.slice(0, 3).map((e) => e.textContent?.trim() ?? ""),
-                )
+                .evaluateAll((els) => els.map((e) => e.textContent?.trim() ?? ""))
             )
               .slice()
               .sort(),
           { timeout: 30000 },
         )
         .toEqual([...createdNames].sort());
+      await expect(page.getByTestId("list-card")).toHaveCount(3);
 
       // Test shift selection
       await page.keyboard.down("Shift");
@@ -177,6 +188,12 @@ test(
           } catch {
             // Best-effort per-flow — do not mask the original test failure.
           }
+        }
+        // Delete the dedicated folder last (its flows are already gone above).
+        if (folderId) {
+          await request
+            .delete(`/api/v1/projects/${folderId}`, { headers })
+            .catch(() => {});
         }
       } catch {
         // Cleanup is best-effort — do not mask the original test failure.


### PR DESCRIPTION
**Closes #869.**

## Problem

`bulk-actions.spec.ts` (`user should be able to select flows with different methods and perform bulk actions`) flaked on the daily with `expect(received).toEqual(expected) // deep equality` at the top-3 name guard — **recurrent 4×** (2026-07-15/16/17/21; outcome flaky: failed, failed, passed on 07-21).

The spec selects flows **positionally** (shift/ctrl-click by card index) and bulk-deletes, so it needs the listing to hold exactly its 3 flows. On the **shared** home listing under `fullyParallel`, a sibling spec's freshly-created flow floats into the recency-sorted top 3 and lingers past the 30s poll window, so the guard legitimately fails. The earlier #790 poll-hardening only reduced the window, not the cause.

## Root cause

Cross-worker **data** interference — **not** a product regression and **not** pure saturation. Confirmed on nightly 1.11.0.dev50: the spec passes clean at `--workers=1`; the flake is the sibling-flow-in-shared-listing race under parallelism.

## Fix

Isolate the spec in a **dedicated project/folder**:
- `POST /api/v1/projects/` (unique name) → `folder_id`; create the 3 flows with that `folder_id`.
- Navigate to the folder's listing via its sidebar entry (`sidebar-nav-<folderName>` → `/all/folder/<id>`), which shows **only** those 3 flows.
- The positional selection flow is otherwise unchanged; a sibling's default-project flow can never appear in this listing, so the interference is removed **at the source** rather than polled around.
- Cleanup (`finally`) deletes the 3 flow IDs (`DELETE /api/v1/flows/{id}`) then the folder (`DELETE /api/v1/projects/{id}`).

**Rejected alternative:** selecting cards by name instead of index — would change what the test validates (shift-range / ctrl per-item selection are inherently positional). Folder isolation keeps the positional test intact.

## Scope note

Selection/download/delete assertions unchanged. `@stable` restored (removed at triage #864 as prevention). Spec doc updated (folder isolation replaces the poll-guard reliance; #869 documented under Known flakiness).

## Validation (nightly 1.11.0.dev50, `--workers=1 --retries=0`)

- typecheck ✅ · eslint ✅ (0 errors; 1 pre-existing-style warning on the cleanup guard)
- Burst 3/3 clean (`expected=1 unexpected=0 flaky=0` each), zero `🚨 Backend Error` ✅
- force-fail ✅ (`firstCheckbox toBeChecked → not.toBeChecked` → red, then reverted → green)
- Live scout confirmed the folder view renders **exactly 3** list-cards (isolation by construction — the parallel case is fixed structurally, not just by the workers=1 burst)
- 0 orphan `bulk-actions-*` flows / folders after runs (id-scoped flow + folder cleanup) ✅
