### PR TITLE
ci(pr-validation): collect models before impacted specs so agent specs resolve an accessible model (#873)

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -141,11 +141,37 @@ jobs:
       - name: Install Playwright browsers
         uses: ./.github/actions/setup-playwright
 
+      # Collect provider/model data BEFORE the impacted specs, mirroring
+      # daily-stable.yml. Without this, `models.json` is absent (it is
+      # git-ignored) and an agent/LLM spec's `getTestTargets` falls back to
+      # picking a model straight from the live agent dropdown by name — without
+      # validating that the key can access it. On some nightly builds that
+      # resolves to a model the CI OPENAI_API_KEY's project cannot use (e.g.
+      # `gpt-4.1-nano`), so the Agent build 403s and the spec dies on setup,
+      # unrelated to the PR (#873). `collect-models` probes each key with a real
+      # ~1-token completion and writes only ACCESSIBLE models, so agent specs
+      # resolve a usable model — matching what the daily validates (no
+      # divergence). Same provider keys as daily-stable.yml.
+      - name: Collect models
+        env:
+          CI: "true"
+          PLAYWRIGHT_BASE_URL: "http://localhost:7860/"
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+        run: npx playwright test tests/collect-models.spec.ts --reporter=line
+
       - name: Run impacted specs
         env:
           CI: "true"
           PLAYWRIGHT_BASE_URL: "http://localhost:7860/"
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
           SPECS: ${{ needs.detect-specs.outputs.specs }}
         run: |
           echo "Running specs: $SPECS"


### PR DESCRIPTION
**Closes #873.**

## Problem

The `pr-validation.yml` **Run impacted E2E specs** gate goes red on PRs that touch an agent/LLM spec. The `e2e` job ran the impacted specs without a `collect-models` step, and `tests/helpers/provider-setup/data/models.json` is git-ignored (absent in CI). So an agent spec's `getTestTargets` took the fallback branch and let `SimpleAgentTemplatePage` pick a model straight from the live agent dropdown **by name preference, without validating key access**. On some nightly builds that resolves to `gpt-4.1-nano`, which the CI `OPENAI_API_KEY`'s project cannot use:

```
ComponentBuildError: Error building Component Agent:
Error code: 403 - {'error': {'message': 'Project `proj_...` does not have access to model `gpt-4.1-nano`'}}
```

The agent test then dies on setup, unrelated to the PR (observed on #872).

## Fix

Add a **Collect models** step before the impacted specs, mirroring `daily-stable.yml` (same 5 provider keys: OpenAI/Google/Anthropic/Groq/Mistral). `collect-models` probes each key with a real ~1-token completion and writes **only accessible models** to `models.json`, so `getTestTargets` resolves a usable model (e.g. `gpt-4o-mini`) instead of an inaccessible dropdown pick. The same provider keys are wired into the run step.

This is **Option 1** from the issue — mirror the daily so there is **no divergence** in model selection between the PR gate and `daily-stable.yml`.

## Tradeoff (accepted)

`collect-models` now runs on every PR that touches any `.spec.ts` (even non-LLM specs) — ~1 min + real API probes to 5 providers per such PR. Bounded to spec-touching PRs. If cost becomes a concern, the step can later be gated on the impacted specs including an LLM area (`llm-agents`/`model-provider`/`mcp`).

## Validation

- YAML parses; `e2e` steps are in order: checkout → setup-node → npm ci → Install Playwright → **Collect models** → **Run impacted specs** → uploads.
- Logic is identical to `daily-stable.yml`'s proven `collect-models` step (models.json → accessible model).
- **Remaining deliverable (cannot self-validate here):** this PR changes only the workflow, so its own `e2e` job is skipped (no changed spec). End-to-end proof is the **next PR touching an agent spec** going green through the gate.

## Relationship to #871

Same gate, the other structural red-cause (quarantine paradox). Independent fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)