### PR TITLE
fix(knowledge): assert embedding credential configured before KB ingest (#880)

### DIFF
--- a/tests/helpers/knowledge/knowledge-base.ts
+++ b/tests/helpers/knowledge/knowledge-base.ts
@@ -122,3 +122,47 @@ export async function deleteKnowledgeBase(
     }
   }
 }
+
+/**
+ * Asserts the embedding provider's API key is configured as a Langflow global
+ * variable — not merely present in the process environment.
+ *
+ * KB ingestion resolves its embedding function from the Langflow credential:
+ * `get_embedding_model_options(user_id)` is credential-gated, so with no global
+ * variable for the provider the embedding model is absent from the registry and
+ * ingest raises a misleading `ComponentBuildError` ("embedding model '<name>' is
+ * no longer recognized"). At the UI that surfaces only as the run's
+ * `node_duration` badge never rendering — a 90s `toBeVisible` timeout whose true
+ * cause (a missing credential) is invisible. The env-var-only `test.skip` guard
+ * does not catch this: the var can be set in `.env` while the Langflow credential
+ * was never imported (e.g. `collect-models` never ran, or its provider setup
+ * flaked). This precondition converts that opaque timeout into an immediate,
+ * actionable failure, without masking a genuine ingest regression (if the
+ * credential IS present and ingest still fails, the real assertions still fire).
+ */
+export async function assertEmbeddingCredentialConfigured(
+  request: APIRequestContext,
+  variableName: string,
+  options?: { headers?: Record<string, string> },
+): Promise<void> {
+  const url = "/api/v1/variables/";
+  const res = await request.get(url, { headers: options?.headers ?? {} });
+  if (!res.ok()) {
+    throw new Error(
+      `GET ${url} failed: ${res.status()} — ${(await res.text()).slice(0, 200)}`,
+    );
+  }
+  const variables = (await res.json()) as Array<{ name?: string }>;
+  const names = variables.map((v) => v.name).filter(Boolean);
+  if (!names.includes(variableName)) {
+    throw new Error(
+      `Embedding credential '${variableName}' is set in the environment but is NOT ` +
+        `configured as a Langflow global variable (present: ${names.join(", ") || "none"}). ` +
+        `Knowledge Base ingestion resolves embeddings from the Langflow credential, not the ` +
+        `env var, so ingest would fail with a misleading "embedding model no longer recognized" ` +
+        `error (a 90s node_duration timeout at the UI). Run ` +
+        `\`npx playwright test tests/collect-models.spec.ts\` first to import the credential ` +
+        `(the daily-stable CI does this automatically).`,
+    );
+  }
+}

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/rag-pipeline.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/rag-pipeline.spec.ts
@@ -5,6 +5,7 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { createFlow } from "../../../../helpers/flows/create-flow";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import {
+  assertEmbeddingCredentialConfigured,
   createKnowledgeBase,
   deleteKnowledgeBase,
   getKnowledgeBase,
@@ -83,6 +84,14 @@ async function authHeaders(page: Page): Promise<Record<string, string>> {
  */
 async function openRagFlow(page: Page): Promise<void> {
   const headers = await authHeaders(page);
+
+  // The embedding provider key must be a Langflow global variable (not just an
+  // env var) or the KB ingest fails with a misleading "embedding model no longer
+  // recognized" error surfacing as a 90s node_duration timeout — fail fast and
+  // actionably instead. The same GOOGLE_API_KEY also backs the answer model.
+  await assertEmbeddingCredentialConfigured(page.request, "GOOGLE_API_KEY", {
+    headers,
+  });
 
   const uniqueSuffix = `${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
   const kbName = await createKnowledgeBase(

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/vector-store-index-query.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/vector-store-index-query.spec.ts
@@ -5,6 +5,7 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { createFlow } from "../../../../helpers/flows/create-flow";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import {
+  assertEmbeddingCredentialConfigured,
   createKnowledgeBase,
   deleteKnowledgeBase,
   getKnowledgeBase,
@@ -76,6 +77,14 @@ async function authHeaders(page: Page): Promise<Record<string, string>> {
  */
 async function openVectorStoreFlow(page: Page): Promise<void> {
   const headers = await authHeaders(page);
+
+  // The embedding provider key must be a Langflow global variable (not just an
+  // env var) or the KB ingest fails with a misleading "embedding model no longer
+  // recognized" error surfacing as a 90s node_duration timeout — fail fast and
+  // actionably instead.
+  await assertEmbeddingCredentialConfigured(page.request, "GOOGLE_API_KEY", {
+    headers,
+  });
 
   const uniqueSuffix = `${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
   const kbName = await createKnowledgeBase(


### PR DESCRIPTION
**Closes #880.**

## Problem
Two `@stable` knowledge-ingestion specs (`vector-store-index-query.spec.ts:194/217`, `rag-pipeline.spec.ts:227`) hard-failed on the daily on **2026-07-16** and **2026-07-22** — `expect(node_duration).toBeVisible()` timing out at 90s ("output never renders"). Spun out of guard-day triage #879.

Root-caused live on the current nightly (`1.11.0.dev50`): **not a product regression.** `get_embedding_model_options(user_id)` is credential-gated, so when the Google provider key is not a Langflow global variable, KB ingest raises a misleading `ComponentBuildError: embedding model 'models/gemini-embedding-001' is no longer recognized`, which surfaces only as the run's `node_duration` badge never rendering — the same signature as an execution-under-load timeout. The `test.skip` guard checks `process.env.GOOGLE_API_KEY` but not the actual Langflow credential, so the env var can be set while the credential was never imported (`collect-models` never ran / its setup flaked). With the credential configured, both specs pass reliably in isolation (`3 passed`, ~27s, well under the 90s wait) — product and test are sound.

The CI failures (07-16 ran an older, non-guard nightly with 6 fails; 07-22 was a dev50 mass-failure day with 22) are **execution-under-parallel-load / provider-latency collateral** against the single serialized backend (see #773 / #833). Same-signature recurrence overstates same-cause across two different builds.

## Fix
Add a shared precondition helper `assertEmbeddingCredentialConfigured(request, "GOOGLE_API_KEY", …)` in `tests/helpers/knowledge/knowledge-base.ts` that `GET`s `/api/v1/variables/` and throws a clear, actionable error (run `collect-models` first) when the provider key is absent from Langflow — converting the opaque 90s timeout into an immediate diagnosable failure. Wired into `openVectorStoreFlow` and `openRagFlow` right after auth, before KB creation.

**Rejected alternative:** bumping the 90s `node_duration` wait — it would mask a real ingest/execution regression (hard rule: never add waits to go green), and the actual constraint is backend serialization (#833 sharding), not test-side fragility.

## Scope note
No assertion weakened; the 90s wait is unchanged; the grounding/chunks/row-count checks are untouched. If the credential IS configured and ingest still fails, the original assertions fire exactly as before. `@stable` **kept** (guard-day rule). Verdict: `transient-saturation` — this cluster folds into the #773 / #833 execution-under-load story; if it reproduces on a clean daily it becomes a quarantine candidate.

## Validation (nightly 1.11.0.dev50, `--retries=0 --workers=1`)
- typecheck ✅ · eslint ✅ (0 errors; 2 pre-existing `.skip()` warnings)
- burst 3/3 clean, no flake ✅ — `rag-pipeline` expected=1 unexpected=0 flaky=0; `vector-store-index-query` expected=2 unexpected=0 flaky=0
- force-fail ✅ all 3 tests (grounding sentinel / chunk count / row count mutations each failed red, reverted) · zero `🚨 Backend Error` ✅
- id-scoped cleanup verified: 0 orphan flows / KBs
