### PR TITLE
test(ci): add pre-flight fail-fast gate — backend health + Langflow credentials (#884)

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -229,6 +229,10 @@ jobs:
         env:
           CI: "true"
           PLAYWRIGHT_BASE_URL: "http://localhost:7860/"
+          # This run is what IMPORTS the provider credentials into Langflow, so
+          # the pre-flight credential check (globalSetup, #884) must not fire
+          # here — it would fail on the very keys this step is about to set.
+          PREFLIGHT_SKIP_CREDENTIALS: "1"
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
     video: process.env.CI ? "on-first-retry" : "off",
   },
 
+  globalSetup: require.resolve("./tests/globalSetup.ts"),
   globalTeardown: require.resolve("./tests/globalTeardown.ts"),
 
   projects: [

--- a/tests/globalSetup.ts
+++ b/tests/globalSetup.ts
@@ -1,0 +1,155 @@
+import {
+  request as playwrightRequest,
+  type APIRequestContext,
+} from "@playwright/test";
+import * as dotenv from "dotenv";
+import { getAuthToken } from "./helpers/auth/get-auth-token";
+
+dotenv.config();
+
+/**
+ * Pre-flight fail-fast gate (issue #884).
+ *
+ * Runs once before the suite. Its job is NOT to fix environment saturation
+ * (that is #833 sharding / #882 lane isolation) but to remove the
+ * **misclassification tax**: when the environment is misconfigured, a spec
+ * would otherwise fail deep inside with a misleading signature that is
+ * indistinguishable from a saturation timeout — costing a whole triage cycle
+ * chasing a phantom product regression (the exact trap root-caused in #880,
+ * where GOOGLE_API_KEY was set in the env but never imported into Langflow, so
+ * KB ingest surfaced only as a 90s node_duration timeout).
+ *
+ * Checks, in order:
+ *  1. Backend reachable + version (hard fail always — nothing can run if the
+ *     instance is down; the poll also warms the HTTP path so the first real
+ *     spec doesn't eat cold-start latency).
+ *  2. Provider credentials actually configured in Langflow, not merely present
+ *     in the environment. For each known provider key present in `process.env`,
+ *     it must exist as a Langflow global variable. In CI this is a hard fail
+ *     (the daily must not run misconfigured); locally it is a warning, so a
+ *     partial-key setup that legitimately skips those specs is never blocked.
+ *     Skipped entirely when `PREFLIGHT_SKIP_CREDENTIALS` is set — the
+ *     collect-models step sets it, because that run is what *imports* the
+ *     credentials (chicken-and-egg).
+ */
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:7860";
+
+// Provider keys the suite may depend on. Present-in-env-but-absent-in-Langflow
+// is the misconfiguration this gate catches (see #880).
+const PROVIDER_KEYS = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"];
+
+// The backend can still be starting when the suite launches; poll briefly.
+const HEALTH_TIMEOUT_MS = 30_000;
+const HEALTH_INTERVAL_MS = 2_000;
+
+const truthy = (v: string | undefined): boolean =>
+  !!v && v !== "0" && v.toLowerCase() !== "false";
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Polls /api/v1/version until the instance answers or the timeout elapses. */
+async function assertBackendHealthy(ctx: APIRequestContext): Promise<void> {
+  const deadline = Date.now() + HEALTH_TIMEOUT_MS;
+  let lastError = "";
+  for (;;) {
+    try {
+      const res = await ctx.get("/api/v1/version");
+      if (res.ok()) {
+        const body = (await res.json()) as {
+          version?: string;
+          package?: string;
+        };
+        const version = body.version ?? "unknown";
+        console.log(
+          `[preflight] backend healthy at ${BASE_URL} — ${body.package ?? "Langflow"} ${version}`,
+        );
+        const expected = process.env.EXPECTED_LANGFLOW_VERSION;
+        if (expected && version !== expected) {
+          console.warn(
+            `[preflight] WARNING: version ${version} != expected ${expected} — results may not reflect the intended build.`,
+          );
+        }
+        return;
+      }
+      lastError = `HTTP ${res.status()}`;
+    } catch (e) {
+      lastError = String(e);
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `[preflight] Langflow backend at ${BASE_URL} is not reachable ` +
+          `after ${HEALTH_TIMEOUT_MS}ms (last: ${lastError}). Start the instance ` +
+          `before running the suite (see the langflow-e2e skill: run the nightly image).`,
+      );
+    }
+    await sleep(HEALTH_INTERVAL_MS);
+  }
+}
+
+/**
+ * For every provider key present in the environment, verify it is configured as
+ * a Langflow global variable. Hard fail in CI, warn locally.
+ */
+async function checkProviderCredentials(ctx: APIRequestContext): Promise<void> {
+  const envKeys = PROVIDER_KEYS.filter((k) => truthy(process.env[k]));
+  if (envKeys.length === 0) return;
+
+  const authHeader = await getAuthToken(ctx);
+  if (!authHeader) {
+    console.warn(
+      "[preflight] could not obtain an auth token — skipping the credential check.",
+    );
+    return;
+  }
+
+  const res = await ctx.get("/api/v1/variables/", {
+    headers: { Authorization: authHeader },
+  });
+  if (!res.ok()) {
+    console.warn(
+      `[preflight] could not read Langflow variables (HTTP ${res.status()}) — skipping the credential check.`,
+    );
+    return;
+  }
+
+  const variables = (await res.json()) as Array<{ name?: string }>;
+  const configured = new Set(variables.map((v) => v.name).filter(Boolean));
+  const missing = envKeys.filter((k) => !configured.has(k));
+  if (missing.length === 0) {
+    console.log(
+      `[preflight] provider credentials configured in Langflow: ${envKeys.join(", ")}`,
+    );
+    return;
+  }
+
+  const message =
+    `[preflight] provider key(s) set in the environment but NOT configured as a ` +
+    `Langflow global variable: ${missing.join(", ")}. Specs resolve credentials ` +
+    `from Langflow, not the env var, so they would fail with a misleading ` +
+    `error (e.g. a node_duration/build timeout). Run ` +
+    `\`npx playwright test tests/collect-models.spec.ts\` first to import them ` +
+    `(the daily-stable CI does this automatically).`;
+
+  if (process.env.CI) {
+    throw new Error(message);
+  }
+  console.warn(`${message}\n(local run — warning only, not blocking.)`);
+}
+
+export default async function globalSetup(): Promise<void> {
+  const ctx = await playwrightRequest.newContext({ baseURL: BASE_URL });
+  try {
+    await assertBackendHealthy(ctx);
+    if (truthy(process.env.PREFLIGHT_SKIP_CREDENTIALS)) {
+      console.log(
+        "[preflight] PREFLIGHT_SKIP_CREDENTIALS set — skipping the credential check (credential-importing run).",
+      );
+    } else {
+      await checkProviderCredentials(ctx);
+    }
+  } finally {
+    await ctx.dispose();
+  }
+}


### PR DESCRIPTION
**Closes #884.**

## Problem
When the environment is misconfigured, a spec fails **deep inside with a misleading signature indistinguishable from a saturation timeout** — costing a whole triage cycle chasing a phantom product regression. Root-caused case: #880, where `GOOGLE_API_KEY` was set in the env but never imported into Langflow, so KB ingest surfaced only as a 90s `node_duration` timeout (the same shape as an execution-under-load timeout). This inflates the apparent `transient-saturation` count and blurs the signal the environment-saturation work (#833 / #882 / #773) is trying to read.

## Fix
Add a `globalSetup` pre-flight (`tests/globalSetup.ts`), wired in `playwright.config.ts`, that runs once before the suite:

1. **Backend reachable + version** — hard fail always (nothing can run if the instance is down; the poll also warms the HTTP path so the first real spec doesn't eat cold-start latency). Logs the resolved nightly; warns on an `EXPECTED_LANGFLOW_VERSION` mismatch.
2. **Provider credentials configured in Langflow, not merely in the env** — for each known provider key present in `process.env`, it must exist as a Langflow global variable. **Hard fail in CI** (the daily must not run misconfigured); **warn locally** so a partial-key local setup that legitimately skips those specs is never blocked. Generalises the `assertEmbeddingCredentialConfigured` helper from #880 to the whole suite. Skipped entirely when `PREFLIGHT_SKIP_CREDENTIALS` is set — the `collect-models` daily step sets it, because that run is what *imports* the credentials (chicken-and-egg); this PR adds the env to that step.

**Rejected/deferred:** a `LANGFLOW_ALLOW_CUSTOM_COMPONENTS` flag probe — there is no clean external API to read it; left as a follow-up noted on #884. Scope kept to health + credentials, which directly address the #880 root cause.

## Scope note
Additive only — no existing test or assertion touched. Local runs are never blocked by the credential check (warn only); the only hard fails are a down backend (always) and a credential set-in-env-but-missing-in-Langflow **in CI**. No `.spec.ts` added, so no spec doc / `QA-CHECKLIST` change.

## Validation (nightly 1.11.0.dev50)
Five behaviours exercised live:
- Happy path (creds configured, `CI=true`): `[preflight] backend healthy … 1.11.0.dev50` + `provider credentials configured: OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_API_KEY` → spec passed ✅
- Backend down (`PLAYWRIGHT_BASE_URL=:9999`): hard fail with the "not reachable" message ✅
- Credential missing in CI (deleted the Langflow `GOOGLE_API_KEY` var): hard fail with the "run collect-models" message ✅
- `PREFLIGHT_SKIP_CREDENTIALS=1` + `CI=true` + missing var: credential check skipped, suite proceeds ✅
- Local (no `CI`) + missing var: warn only, not blocking, spec passed ✅
- typecheck ✅ · eslint ✅ (0 errors)
- Langflow `GOOGLE_API_KEY` variable restored via `collect-models` after the test.

Interim relief toward the environment-saturation programme (#833 sharding, #882 lane isolation, #883 selective mocking); this issue sharpens the saturation signal by keeping misconfiguration out of the transient-timeout bucket.