### PR TITLE
fix(provider-setup): stop resolveGeminiModel selecting the retired gemini-2.5-flash (#886)

### DIFF
--- a/tests/helpers/provider-setup/resolve-gemini-model.ts
+++ b/tests/helpers/provider-setup/resolve-gemini-model.ts
@@ -14,12 +14,23 @@ export function resolveGeminiModel(): string | undefined {
     provider: string;
     model: string;
   }>;
-  const google = models.filter((m) => m.provider === "google").map((m) => m.model);
+  const google = models
+    .filter((m) => m.provider === "google")
+    .map((m) => m.model)
+    // Google retired `gemini-2.5-flash` for new users — it 404s ("no longer
+    // available to new users") at call time, so the Agent build fails and the
+    // spec times out waiting for a reply. Exclude the exact retired id from
+    // every preference below so it can never be selected, even as a fallback
+    // (same model-lifecycle trap as the RAG answer model in #880).
+    .filter((m) => m !== "gemini-2.5-flash");
   const bad = /image|tts|audio|preview|embedding|customtools/;
   const prefs = [
-    (m: string) => /^gemini-2\.5-flash$/.test(m),
-    (m: string) => /^gemini-3\.5-flash$/.test(m),
+    // Prefer the floating alias first: it always resolves to Google's current
+    // flash model, so the resolver tracks the provider's lifecycle instead of
+    // pinning a dated id that gets retired (the #880 lesson). Then the live
+    // dated flash models, then any non-excluded gemini flash / gemini.
     (m: string) => /^gemini-flash-latest$/.test(m),
+    (m: string) => /^gemini-3\.\d+-flash$/.test(m),
     (m: string) => /gemini.*flash/.test(m) && !bad.test(m),
     (m: string) => /gemini/.test(m) && !bad.test(m),
   ];


### PR DESCRIPTION
**Closes #886.** Refs #773 (extracted as the one durable, non-load failure of that cluster).

## Problem
`google-provider.spec.ts:155` and `language-model-regression.spec.ts:130` fail **durably** (reproduced in isolation on nightly 1.11.0.dev50 against a healthy backend — not saturation): the agent/model never replies, so the awaited message times out. Backend log:
```
ComponentBuildError: Error calling model 'gemini-2.5-flash' (Not Found): 404
"models/gemini-2.5-flash is no longer available to new users."
```
`tests/helpers/provider-setup/resolve-gemini-model.ts` preferred `gemini-2.5-flash` **first**. Google retired that id for new users, so it 404s at call time. `models.json` lists it next to the live models (`gemini-flash-latest`, `gemini-3.x-flash`), and the resolver picked the dead one. Both specs share this resolver, so both fail on the same cause. Recurs across dailies (surfaced in the #773 cluster and #879 collateral).

## Fix
Exclude the exact retired id from selection and prefer the floating `gemini-flash-latest` alias first (then live dated `gemini-3.x-flash`), so the resolver tracks Google's model lifecycle instead of pinning a dated id that gets retired — the same lesson applied to the RAG answer model in #880.

## Scope note
Only the resolver's preference order + one exclusion changed. No assertion, selector, or timeout touched. `@stable` retained on both specs (diagnosed and fixed in the same cycle — never removed).

## Validation (nightly 1.11.0.dev50, `--retries=0 --workers=1`)
- resolver now returns `gemini-flash-latest`
- `google-provider.spec.ts` → **2 passed** (was failing)
- `language-model-regression.spec.ts` → **4 passed** (was failing)
- typecheck ✅ · eslint ✅