### PR TITLE
fix(scripts): cap local Langflow to 1 worker to prevent OOM under heavy specs

### DIFF
--- a/.claude/skills/langflow-e2e/SKILL.md
+++ b/.claude/skills/langflow-e2e/SKILL.md
@@ -220,9 +220,16 @@ An instance must be up (default `http://localhost:7860`) before running.
 > docker run -d --name langflow-e2e-runner -p 7860:7860 \
 >   -e LANGFLOW_AUTO_LOGIN=true -e LANGFLOW_SUPERUSER=langflow \
 >   -e LANGFLOW_SUPERUSER_PASSWORD=langflow123 -e LANGFLOW_DEACTIVATE_TRACING=true \
->   -e LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true \
+>   -e LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true -e LANGFLOW_WORKERS=1 \
 >   langflowai/langflow-nightly:latest
 > ```
+> `-e LANGFLOW_WORKERS=1` caps the backend to one worker. Langflow defaults to
+> `(2*cpu)+1` workers, each inheriting the full in-memory state; on a small local
+> Docker VM (~4 GB, no per-container limit) several heavy workers exhaust memory
+> and the kernel SIGKILLs one mid-build — surfacing as `ERR_EMPTY_RESPONSE` / a
+> node run that never completes when running the knowledge/agent specs (#773).
+> One worker is plenty locally (heavy specs run `--workers=1`); drop the flag /
+> raise it on a beefier box.
 > Always confirm with `curl -s localhost:7860/api/v1/version` — the nightly package
 > reports `"package":"Langflow Nightly"` and a `.devNN` version.
 >
@@ -258,7 +265,7 @@ docker rm -f langflow-e2e-runner
 docker run -d --name langflow-e2e-runner -p 7860:7860 \
   -e LANGFLOW_AUTO_LOGIN=true -e LANGFLOW_SUPERUSER=langflow \
   -e LANGFLOW_SUPERUSER_PASSWORD=langflow123 -e LANGFLOW_DEACTIVATE_TRACING=true \
-  -e LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true \
+  -e LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true -e LANGFLOW_WORKERS=1 \
   langflowai/langflow-nightly:latest
 ```
 

--- a/scripts/start-langflow-docker.sh
+++ b/scripts/start-langflow-docker.sh
@@ -23,7 +23,18 @@ docker run -d \
   -e LANGFLOW_SUPERUSER_PASSWORD="${LANGFLOW_SUPERUSER_PASSWORD:-langflow123}" \
   -e LANGFLOW_DEACTIVATE_TRACING=true \
   -e LANGFLOW_ALLOW_CUSTOM_COMPONENTS="${LANGFLOW_ALLOW_CUSTOM_COMPONENTS:-true}" \
+  -e LANGFLOW_WORKERS="${LANGFLOW_WORKERS:-1}" \
   "${IMAGE}"
+
+# LANGFLOW_WORKERS defaults to 1 here on purpose. Langflow's own default is
+# (2 * cpu_count) + 1 gunicorn workers, each inheriting the full in-memory
+# state (graphs, model catalog, chroma). On a small local Docker Desktop VM
+# (commonly ~4 GB with no per-container limit), several heavy workers — each
+# growing unbounded across requests with no recycling — exhaust the VM and the
+# kernel SIGKILLs a worker mid-build, surfacing as ERR_EMPTY_RESPONSE / a
+# node run that never completes (observed running the knowledge/agent specs
+# locally; see #773). One worker is plenty locally, where the heavy specs run
+# --workers=1 anyway. Override for a beefier box: LANGFLOW_WORKERS=4 ./scripts/...
 
 echo "Waiting for Langflow to be ready (up to 120s)..."
 for i in $(seq 1 24); do

--- a/scripts/start-langflow-pip.sh
+++ b/scripts/start-langflow-pip.sh
@@ -24,7 +24,12 @@ LANGFLOW_AUTO_LOGIN=true \
 LANGFLOW_SUPERUSER="${LANGFLOW_SUPERUSER:-langflow}" \
 LANGFLOW_SUPERUSER_PASSWORD="${LANGFLOW_SUPERUSER_PASSWORD:-langflow123}" \
 LANGFLOW_DEACTIVATE_TRACING=true \
-  langflow run --host 0.0.0.0 --port "${PORT}" --no-open-browser &
+  langflow run --host 0.0.0.0 --port "${PORT}" --no-open-browser \
+    --workers "${LANGFLOW_WORKERS:-1}" &
+# --workers defaults to 1: Langflow's own default is (2*cpu)+1 workers, each
+# holding the full in-memory state, which exhausts memory on a constrained dev
+# box and gets a worker SIGKILLed mid-build (ERR_EMPTY_RESPONSE / node run never
+# completes — see #773). Override with LANGFLOW_WORKERS on a beefier machine.
 echo $! > "${PID_FILE}"
 
 echo "Waiting for Langflow to be ready (up to 120s)..."


### PR DESCRIPTION
Refs #773 (found during that investigation). Local-only — CI untouched.

## Problem
Running the knowledge/agent specs locally, the Langflow backend worker was **OOM-killed** mid-build:
```
Worker (pid:3401) was sent SIGKILL! Perhaps out of memory?
```
surfacing to the spec as `net::ERR_EMPTY_RESPONSE` / a node run that never completes (a `node_duration` toBeVisible timeout).

Root cause: Langflow defaults to `(2*cpu)+1` gunicorn workers (`__main__.get_number_of_workers`), each inheriting the full in-memory state (graphs, model catalog, chroma) and growing unbounded across requests with no recycling. On a local Docker Desktop VM (~4 GB, **no per-container memory limit** — `docker inspect … .HostConfig.Memory == 0`), several heavy workers exhaust the VM (measured one worker at ~1.2 GB) and the kernel SIGKILLs one during a heavy build.

## Fix
Default `LANGFLOW_WORKERS=1` where the local instance is launched:
- `scripts/start-langflow-docker.sh`
- `scripts/start-langflow-pip.sh` (`langflow run --workers`)
- the `langflow-e2e` skill's direct-nightly `docker run` block

Overridable via the `LANGFLOW_WORKERS` env for a beefier box. One worker is plenty locally, where the heavy specs run `--workers=1` anyway.

## Scope note
**Local only.** The CI daily runs on a 16 GB runner and is **not** touched here — a CI worker OOM is unconfirmed (the langflow service container's logs are not captured in the workflow log), so pinning CI workers should be driven by an actual CI memory metric, not this local observation. No test code changed.

## Validation (nightly 1.11.0.dev50)
- `bash -n` clean on both scripts.
- Restarted nightly with `LANGFLOW_WORKERS=1` → backend collapses to a single process (was master + 2 workers).
- Heavy sequential batch (vector-store + rag + agent specs, `--workers=1`): **no SIGKILL**, backend memory stable at ~1.7 GiB (previously a worker ballooned to ~1.2 GiB and the VM OOM'd). One unrelated agent tool-selection flake (model non-determinism, already in the #773 transient bucket).