### PR TITLE
test(core-components): cover If-Else remaining numeric operators (#822)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -255,7 +255,7 @@
 - [x] `case_sensitive` ON (default) treats mixed case as no-match → `core-components/if-else-component-regression.spec.ts`
 - [x] `case_sensitive` OFF treats mixed case as a match → `core-components/if-else-component-regression.spec.ts`
 - [x] `operator=greater than` numeric routing → `core-components/if-else-component-regression.spec.ts`
-- [ ] Other numeric operators (`less than`, `less than or equal`, `greater than or equal`) — share the same `float(...)` cast as `greater than`, not separately covered
+- [x] Other numeric operators (`less than`, `less than or equal`, `greater than or equal`) — share the same `float(...)` cast as `greater than` → `core-components/if-else-component-regression.spec.ts`
 - [ ] `max_iterations` + `default_route` cycle break
 
 ---

--- a/docs/core-components/if-else-component-regression.md
+++ b/docs/core-components/if-else-component-regression.md
@@ -2,13 +2,15 @@
 
 **Test file:** `tests/tests-automations/regression/core-components/if-else-component-regression.spec.ts`
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.11.x
 
 ---
 
 ## What this test validates
 
-Covers the routing contract of the **If-Else** (ConditionalRouter) component across the operator surface: every text operator (equals, contains, regex), the `case_sensitive` toggle (default ON / explicit OFF), and one representative numeric operator (`greater than`). Each scenario is a separate `test()` so a failure pinpoints the exact behavior that regressed.
+Covers the routing contract of the **If-Else** (ConditionalRouter) component across the operator surface: every text operator (equals, contains, regex), the `case_sensitive` toggle (default ON / explicit OFF), and all four numeric operators (`greater than`, `less than`, `less than or equal`, `greater than or equal`) — which share the same `float(...)` cast in `evaluate_condition`. Each scenario is a separate `test()` so a failure pinpoints the exact behavior that regressed.
+
+The two "or equal" numeric scenarios deliberately use **equal operands** (`5` vs `5`): that boundary is the distinctive case that separates `<=`/`>=` from their strict counterparts (`5 < 5` and `5 > 5` are both `False`), so a regression that swaps an inclusive operator for a strict one flips the routed branch and fails the assertion. The `less than` scenario uses a decimal operand (`2.5`) to exercise the `float(...)` parse on a non-integer, distinct from `greater than`'s integer inputs (scenario 8).
 
 For every scenario except the regex side-effect test, the assertion surface is the canvas node status: `node_duration_<name>` testid for the branch that built (active) and `node_status_icon_<name>_inactive` testid for the branch that was skipped. This is the same surface used by `flow-functionality/general-bugs-reset-flow-run.spec.ts` and is more reliable than message-content assertions because the component returns an empty Message on the inactive branch (so message presence alone cannot distinguish the routes).
 
@@ -38,8 +40,11 @@ The one exception is the regex side-effect test: when `operator=regex`, the comp
 | 6 | `case_sensitive` ON (default) → no-match on mixed case | equals | HELLO | hello | ON (default) | False | True |
 | 7 | `case_sensitive` OFF → match on mixed case | equals | HELLO | hello | OFF (toggled) | True | False |
 | 8 | `greater than` (numeric) match | greater than | 10 | 5 | default | True | False |
+| 9 | `less than` (numeric, decimal) match | less than | 2.5 | 10 | default | True | False |
+| 10 | `less than or equal` equality boundary | less than or equal | 5 | 5 | default | True | False |
+| 11 | `greater than or equal` equality boundary | greater than or equal | 5 | 5 | default | True | False |
 
-All eight scenarios are introduced in this spec; there is no pre-existing implementation elsewhere.
+All eleven scenarios are introduced in this spec; there is no pre-existing implementation elsewhere. Scenarios 9–11 were added under issue #822 (Wave 3 coverage) to close the "other numeric operators" gap in `QA-CHECKLIST.md` §3.8.
 
 ---
 
@@ -47,7 +52,7 @@ All eight scenarios are introduced in this spec; there is no pre-existing implem
 
 `buildIfElseRoutingFlow(page)` (defined in the spec):
 
-1. Bootstrap and open a blank flow.
+1. Bootstrap and open a blank flow, **capturing the created flow id** from the `POST /api/v1/flows` 201 response (not the transient canvas-URL id) so each test's flow can be deleted id-scoped in `afterEach`.
 2. Add the **If-Else** component from the sidebar.
 3. Zoom out so two more components fit.
 4. Drop two **Chat Output** components onto the canvas (positions: `{100, 100}` and `{200, 400}`), expanding each one after it is added (Chat Output is added minimized).
@@ -82,6 +87,9 @@ Test #7 (case_sensitive OFF) does not use a dedicated helper to flip the switch 
 | 6 | `node_duration_chatoutputfalse` | `node_status_icon_chat output_inactive` | — |
 | 7 | `node_duration_chat output` | `node_status_icon_chatoutputfalse_inactive` | — |
 | 8 | `node_duration_chat output` | `node_status_icon_chatoutputfalse_inactive` | — |
+| 9 | `node_duration_chat output` | `node_status_icon_chatoutputfalse_inactive` | `2.5 < 10` → True branch builds |
+| 10 | `node_duration_chat output` | `node_status_icon_chatoutputfalse_inactive` | `5 <= 5` → True branch builds (strict `<` would route False) |
+| 11 | `node_duration_chat output` | `node_status_icon_chatoutputfalse_inactive` | `5 >= 5` → True branch builds (strict `>` would route False) |
 
 ---
 
@@ -97,9 +105,9 @@ Test #7 (case_sensitive OFF) does not use a dedicated helper to flip the switch 
 
 ## What this test does not cover
 
-- Operators `not equals`, `starts with`, `ends with`, `less than`, `less than or equal`, `greater than or equal`. The text operators all share `evaluate_condition` plumbing covered by tests 1–4 + 6–7; the remaining numeric operators are skipped because they all use the same `float(...)` cast covered by test 8.
+- Operators `not equals`, `starts with`, `ends with`. These text operators all share the `evaluate_condition` plumbing already covered by tests 1–4 + 6–7. (The numeric operators `less than`, `less than or equal`, `greater than or equal` ARE now covered — scenarios 9–11.)
 - Non-numeric input to a numeric operator (the Python `ValueError` fallback returning `False`). Documented in the source but not exposed in the public docs; tracked as `[ ]` in QA-CHECKLIST.md §3.8.
-- `max_iterations` and `default_route` cycle-handling behavior. Requires a flow with a cycle which is out of scope for a single-step regression.
+- `max_iterations` and `default_route` cycle-break behavior. This lives on the **If-Else** component (not the Loop — confirmed against `conditional_router.py` on nightly `1.11.0.dev50`) and only fires when the router sits inside a **graph cycle**. Deferred to a dedicated follow-up issue after an #822 scout established it is not exercisable by a hand-built flow asset on the current nightly: three cyclic topologies (self-loop, field-seeded, and external-seed-plus-feedback mirroring the Loop's `data`/`item` port split) all failed to iterate the router across every run path tried — `POST /api/v1/build/{id}/flow`, `POST /api/v2/workflows` (playground), and `POST /api/v1/run` each ran only the seed vertex and finished, with no `"You must specify a max_iterations if the graph is cyclic"` error, i.e. the graph was not treated as cyclic (`find_cycle_vertices` did not detect the SCC). Building the cycle entirely in the UI (the only guaranteed-valid path, which also settles whether this is a product limitation) is tracked in the follow-up. This is why the original author flagged the behavior as "out of scope for a single-step regression".
 - Playground end-to-end (`ChatInput → If-Else → ChatOutput`). The routing assertion does not depend on which input source feeds `input_text`, and tests 1–8 already prove the routing logic.
 - Advanced field `true_case_message` / `false_case_message`: left empty for every scenario. Their custom-message routing is a separate behavior tested elsewhere.
 
@@ -119,6 +127,10 @@ Test #7 (case_sensitive OFF) does not use a dedicated helper to flip the switch 
 - The two Chat Output components are dragged via `dragTo` to avoid the default-stack issue noted in the project memory (two sidebar `+` clicks land in the same position).
 - Operator dropdown options are selected via `getByRole("option", { name: operatorName, exact: true })` — the dropdown is Radix Select, which exposes stable accessible names. Selecting by `role` instead of testid avoids depending on the option's index suffix in the DOM, which historically drifts as new operators are added.
 - The `case_sensitive` BoolInput uses testid `toggle_bool_case_sensitive` with `role="switch"`; toggling once flips from ON to OFF.
+
+### Flow cleanup (added under #822)
+
+Every test builds a flow on a blank canvas, which Langflow autosaves. The spec now captures each flow's id from its creation `POST /api/v1/flows` 201 response and deletes ONLY that id in an `afterEach` (scoped teardown), navigating to `/` first and passing an explicit `Authorization` header via `getAuthToken(page.request)` — `page.request` is unauthenticated under AUTO_LOGIN and would 401 otherwise. Never `cleanAllFlows` / name-scoped / diff-based wipes: they kill flows other parallel workers are actively driving (#553). Reference implementation: `loop-component-regression.spec.ts`.
 
 ### Reliability decisions (independent review, @stable promotion)
 

--- a/tests/tests-automations/regression/core-components/if-else-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/if-else-component-regression.spec.ts
@@ -1,5 +1,7 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { expandFocusedNode } from "../../../helpers/ui/expand-focused-node";
@@ -8,6 +10,29 @@ import {
   openAdvancedOptions,
 } from "../../../helpers/ui/open-advanced-options";
 import { zoomOut } from "../../../helpers/ui/zoom-out";
+
+// Ids of the flows each test creates on the blank canvas (Langflow autosaves
+// them). Teardown deletes ONLY these via the API (scoped, #515/#553) — never a
+// global cleanAllFlows / name-scoped / diff-based wipe, which races flows other
+// parallel workers are actively driving.
+const createdFlowIds: string[] = [];
+
+test.afterEach(async ({ page }) => {
+  const ids = createdFlowIds.splice(0);
+  if (ids.length === 0) return;
+  // Navigate off the editor first so the unmounted flow page stops polling a
+  // flow we are about to delete, then pass an explicit auth header — page.request
+  // is unauthenticated under AUTO_LOGIN and would 401 otherwise. Not swallowed:
+  // a failed cleanup surfaces instead of silently leaking the flow (#547).
+  await page.goto("/");
+  const authHeader = await getAuthToken(page.request);
+  const opts = authHeader
+    ? { headers: { Authorization: authHeader } }
+    : undefined;
+  for (const id of ids) {
+    await deleteFlow(page.request, id, opts);
+  }
+});
 
 async function selectOperator(
   page: Page,
@@ -48,7 +73,22 @@ async function exposeCaseSensitive(page: Page): Promise<void> {
 async function buildIfElseRoutingFlow(page: Page): Promise<void> {
   await awaitBootstrapTest(page);
   await expect(page.getByTestId("blank-flow")).toBeVisible({ timeout: 30000 });
+  // Capture the id from the flow-creation POST (NOT the transient canvas-URL id,
+  // which does not match the persisted flow on this Langflow version) so the
+  // afterEach can delete exactly this flow (scoped teardown, #515).
+  const flowCreation = page.waitForResponse(
+    (resp) =>
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201,
+    { timeout: 30000 },
+  );
   await page.getByTestId("blank-flow").click();
+  const created = (await (await flowCreation).json()) as { id?: string };
+  if (!created.id) {
+    throw new Error("blank-flow creation returned no flow id");
+  }
+  createdFlowIds.push(created.id);
 
   // Wait for the canvas/sidebar to settle before interacting — clicking the
   // search input immediately after the blank-flow transition can resolve a
@@ -387,6 +427,110 @@ test(
 
       // Numeric: 10 > 5 → True.
       await page.getByTestId("popover-anchor-input-input_text").fill("10");
+      await page.getByTestId("popover-anchor-input-match_text").fill("5");
+
+      await page.getByTestId("button_run_chat output").click();
+      await expect(page.locator("text=built successfully")).toBeVisible({
+        timeout: 30000,
+      });
+    });
+
+    await test.step("Assert True branch built and False branch stayed inactive", async () => {
+      await expect(
+        page.getByTestId("node_duration_chat output"),
+      ).toHaveCount(1, { timeout: 30000 });
+      await expect(
+        page.getByTestId("node_status_icon_chatoutputfalse_inactive"),
+      ).toHaveCount(1, { timeout: 30000 });
+    });
+  },
+);
+
+test(
+  "If-Else operator=less than routes a numeric match (2.5 < 10) through the True branch",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    await test.step("Build If-Else flow with True/False Chat Output branches", async () => {
+      await buildIfElseRoutingFlow(page);
+    });
+
+    await test.step("Switch to 'less than', set a decimal numeric input, and run", async () => {
+      await selectOperator(page, "less than");
+
+      // Numeric (decimal): 2.5 < 10 → True. The decimal operand exercises the
+      // shared `float(...)` cast on a non-integer, distinct from `greater than`
+      // (integer inputs). If the operator were `greater than`, 2.5 > 10 is
+      // False, so the True-branch assertion would fail.
+      await page.getByTestId("popover-anchor-input-input_text").fill("2.5");
+      await page.getByTestId("popover-anchor-input-match_text").fill("10");
+
+      await page.getByTestId("button_run_chat output").click();
+      await expect(page.locator("text=built successfully")).toBeVisible({
+        timeout: 30000,
+      });
+    });
+
+    await test.step("Assert True branch built and False branch stayed inactive", async () => {
+      await expect(
+        page.getByTestId("node_duration_chat output"),
+      ).toHaveCount(1, { timeout: 30000 });
+      await expect(
+        page.getByTestId("node_status_icon_chatoutputfalse_inactive"),
+      ).toHaveCount(1, { timeout: 30000 });
+    });
+  },
+);
+
+test(
+  "If-Else operator=less than or equal routes an equal-operands match (5 <= 5) through the True branch",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    await test.step("Build If-Else flow with True/False Chat Output branches", async () => {
+      await buildIfElseRoutingFlow(page);
+    });
+
+    await test.step("Switch to 'less than or equal', set equal operands, and run", async () => {
+      await selectOperator(page, "less than or equal");
+
+      // Equality boundary: 5 <= 5 → True. This is the distinctive case that
+      // separates `<=` from the strict `<` (5 < 5 is False → would route
+      // False), so a regression swapping the inclusive operator for the strict
+      // one flips the routed branch and fails this assertion.
+      await page.getByTestId("popover-anchor-input-input_text").fill("5");
+      await page.getByTestId("popover-anchor-input-match_text").fill("5");
+
+      await page.getByTestId("button_run_chat output").click();
+      await expect(page.locator("text=built successfully")).toBeVisible({
+        timeout: 30000,
+      });
+    });
+
+    await test.step("Assert True branch built and False branch stayed inactive", async () => {
+      await expect(
+        page.getByTestId("node_duration_chat output"),
+      ).toHaveCount(1, { timeout: 30000 });
+      await expect(
+        page.getByTestId("node_status_icon_chatoutputfalse_inactive"),
+      ).toHaveCount(1, { timeout: 30000 });
+    });
+  },
+);
+
+test(
+  "If-Else operator=greater than or equal routes an equal-operands match (5 >= 5) through the True branch",
+  { tag: ["@stable", "@regression", "@components"] },
+  async ({ page }) => {
+    await test.step("Build If-Else flow with True/False Chat Output branches", async () => {
+      await buildIfElseRoutingFlow(page);
+    });
+
+    await test.step("Switch to 'greater than or equal', set equal operands, and run", async () => {
+      await selectOperator(page, "greater than or equal");
+
+      // Equality boundary: 5 >= 5 → True. Distinctive vs the strict `>`
+      // (5 > 5 is False → would route False); catches a regression swapping
+      // the inclusive operator for the strict one.
+      await page.getByTestId("popover-anchor-input-input_text").fill("5");
       await page.getByTestId("popover-anchor-input-match_text").fill("5");
 
       await page.getByTestId("button_run_chat output").click();


### PR DESCRIPTION
Closes #822 (numeric-operators half of the split).

Closes the `[x] Other numeric operators (less than, less than or equal, greater than or equal)` gap in `QA-CHECKLIST.md` §3.8. These live on the **If-Else** (ConditionalRouter) component and share the same `float(...)` cast in `evaluate_condition` as the already-covered `greater than` (scenario 8) — but the "or equal" boundary is a distinct journey that the strict operators do not cover.

> **Scope split (agreed with maintainer):** the issue bundled a second bullet — the `max_iterations`/`default_route` **cycle-break**. A scout established it is **not exercisable by a hand-built flow asset on nightly `1.11.0.dev50`**: three cyclic topologies (self-loop, field-seeded, external-seed+feedback mirroring the Loop's `data`/`item` split) all failed to iterate the router across every run path (`POST /api/v1/build/{id}/flow`, `POST /api/v2/workflows`, `POST /api/v1/run`) — each ran only the seed vertex and finished, with no `"must specify a max_iterations if the graph is cyclic"` error, i.e. `find_cycle_vertices` did not treat the graph as cyclic. Deferred to a dedicated follow-up issue (bullet stays `[ ]`). Findings are recorded in the spec doc's "What this test does not cover".

## 1. Covered tests
| # | Test | What it validates |
|---|------|-------------------|
| 9 | `If-Else operator=less than routes a numeric match (2.5 < 10) through the True branch` | `2.5 < 10` → True branch builds (`node_duration_chat output`), False stays inactive (`node_status_icon_chatoutputfalse_inactive`). Decimal operand exercises `float()` on a non-integer; a `>` regression (`2.5 > 10` = False) would route False and fail. |
| 10 | `If-Else operator=less than or equal routes an equal-operands match (5 <= 5) through the True branch` | `5 <= 5` → True branch builds. Equality boundary: strict `<` (`5 < 5` = False) would route False — catches an inclusive→strict regression. |
| 11 | `If-Else operator=greater than or equal routes an equal-operands match (5 >= 5) through the True branch` | `5 >= 5` → True branch builds. Equality boundary: strict `>` (`5 > 5` = False) would route False. |

## 2. How the test was built
- **Reuses the existing in-file helpers** `buildIfElseRoutingFlow` (blank flow via UI + If-Else + two Chat Output branches, the second renamed `chatoutputfalse`) and `selectOperator` — no new helper/POM.
- **Operator display strings** (`less than`, `less than or equal`, `greater than or equal`) confirmed against the component source `conditional_router.py` on nightly `1.11.0.dev50`; the `selectOperator` mechanism (Radix option by exact accessible name + dispatched click) is already proven by scenario 8 (`greater than`).
- **Assertion surface** is the canvas node status (`node_duration_<name>` active + `node_status_icon_<name>_inactive` skipped) — the same reliable dual-sided check the other 8 scenarios use.
- **New id-scoped cleanup**: `buildIfElseRoutingFlow` now captures the flow id from the `POST /api/v1/flows` 201, and an `afterEach` deletes only that id (`getAuthToken` + explicit `Authorization`), matching `loop-component-regression.spec.ts`. The legacy file previously leaked a flow per test.

## 3. Dependencies
- **None** — If-Else is pure text/number comparison; no LLM / provider / API key.
- Execution: parallel-safe (each test builds its own flow, id-scoped teardown).

## Validation (nightly 1.11.0.dev50, `--retries=0 --workers=1`)
- typecheck ✅ · eslint ✅
- 3× clean burst: each run `expected=11 unexpected=0 flaky=0` ✅
- force-fail ✅ — all 11 `test()` mutated (`toHaveCount(1)`→`toHaveCount(99)`), each failed as expected (`unexpected=1`), reverted
- QA-CHECKLIST guard ✅ (only the manual §3.8 bullet edited; generated blocks untouched)
- Note: an intermittent, fixture-non-fatal `🚨 Backend Error: 500` on `POST /api/v1/flows/` (ambient SQLite contention on flow creation, documented in the spec doc) can appear during a run; it does not fail any test (`unexpected=0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)