### PR TITLE
ci(pr-validation): set PREFLIGHT_SKIP_CREDENTIALS on Collect models step (#892)

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -155,6 +155,11 @@ jobs:
       - name: Collect models
         env:
           CI: "true"
+          # This run is what IMPORTS the provider credentials into Langflow, so
+          # the pre-flight credential check (globalSetup, #884) must not fire
+          # here — it would fail on the very keys this step is about to set
+          # (chicken-and-egg). Matches daily-stable.yml's Collect models step.
+          PREFLIGHT_SKIP_CREDENTIALS: "1"
           PLAYWRIGHT_BASE_URL: "http://localhost:7860/"
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}


### PR DESCRIPTION
**Fixes #892.**

## Problem
Every PR's `Run impacted E2E specs` job dies at the **Collect models** step:

```
Error: [preflight] provider key(s) set in the environment but NOT configured as a Langflow global variable: OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_API_KEY. ...
    at checkProviderCredentials (tests/globalSetup.ts:136:11)
```
First seen on PR #890: https://github.com/oriontech-me/langflow-e2e/actions/runs/29937369904/job/88982330997

## Fix
The pre-flight gate (`tests/globalSetup.ts`, #884/#885) runs before every `playwright test` invocation and hard-fails in CI when a provider key is in the env but not yet a Langflow global variable. The `collect-models.spec.ts` run is exactly what *imports* those credentials — so the gate blocked its own bootstrap. `globalSetup` skips the check when `PREFLIGHT_SKIP_CREDENTIALS` is set; `daily-stable.yml` already sets it on Collect models, but `pr-validation.yml` was never updated. This adds the one env line, mirroring `daily-stable.yml`.

## Scope note
Single-line workflow change: `PREFLIGHT_SKIP_CREDENTIALS: "1"` on the `Collect models` step only. No spec, globalSetup, or other step touched. The impacted-specs step still runs the full credential check (its credentials are configured by the now-unblocked collect-models run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)