### PR TITLE
docs(checklist): map §6.2 stop-condition bullet to agent-max-iterations (#824)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -329,7 +329,7 @@
 - [-] Composio (tool integration for Agent) → `composio.spec.ts`
 - [x] Playground shows error when LLM run endpoint returns 500 (mocked invalid API key) → `llm-agents/llm-invalid-api-key-ui.spec.ts`
 - [x] Playground input remains usable after API error (mocked) → `llm-agents/llm-invalid-api-key-ui.spec.ts`
-- [ ] Agent stops when configured stop condition is reached
+- [x] Agent stops when configured stop condition is reached → `core-functionality/llm-agents/agent-max-iterations.spec.ts` (`max_iterations` is the Agent's only configurable stop mechanism — no dedicated stop-condition field exists; see #824)
 - [x] Agent stops when maximum number of iterations is reached → `core-functionality/llm-agents/agent-max-iterations.spec.ts`
 - [x] Agent with multiple configured tools executes correctly → `agent-multi-tool-selection.spec.ts`
 - [ ] Agent with configured timeout respects the limit


### PR DESCRIPTION
## What

Maps the QA-CHECKLIST §6.2 bullet **"Agent stops when a configured stop condition is reached"** to the existing `@stable` spec `agent-max-iterations.spec.ts`, and documents why.

## Why (Refs #824)

#824 asked for a new spec covering §6.2 "configured stop condition". A source-dive of the current nightly shows the Agent component (`lfx/components/models_and_agents/agent.py`) exposes **no** `stop_condition` / `stop_sequence` / `early_stopping` / agent-level `timeout` field. Its only configurable halt mechanism is `max_iterations`, whose backend docstring reads *"The maximum number of attempts the agent can make to complete its task before it stops."* — i.e. `max_iterations` **is** Langflow's "configured stop condition".

That behavior is already covered by `agent-max-iterations.spec.ts` (asserts the run-limit message `model call limits exceeded ... (1/1)` at the cap, with a high-cap causal control). #824 was therefore closed as a duplicate; this PR only updates the checklist bullet to reflect the existing coverage.

## Scope

- Doc-only: single Part II bullet in `QA-CHECKLIST.md`. No test code, no auto-generated block touched.

## Validation

- `npm run typecheck` — 0 errors
- `npm run lint` — 0 errors
- `node scripts/check-checklist-guard.mjs` — no auto-generated blocks edited
