### PR TITLE
docs(collect-models): note raw-key probe ≠ Langflow-buildable (#898)

### DIFF
--- a/docs/collect-models.md
+++ b/docs/collect-models.md
@@ -78,6 +78,7 @@ test failure.
 - Does not assert that specific models are returned — only that the collection and file-write succeed
 - Does not validate provider responses in detail — only checks HTTP status 2xx vs non-2xx
 - Does not configure providers that lack an API key in the environment
+- **Does not verify Langflow can BUILD a provider's model — only that the raw API key works.** The status probe calls the provider's own API directly, upstream of Langflow, so it cannot detect a missing server-side integration package. A nightly that ships without `langchain-google-genai` still records google `active` here, yet every Google chat/embedding build inside Langflow raises an `ImportError` and the affected `@stable` specs fail downstream as a misleading node-build timeout (root cause + impact: [#898]; upstream: LE-1974). A faithful check would have to build a Language Model flow per provider and inspect the error — no standalone endpoint triggers the class import (`/api/v1/models/*` return static metadata only) — so that build-probe hardening was deferred to [#900].
 
 ---
 

--- a/tests/helpers/provider-setup/collect-models.ts
+++ b/tests/helpers/provider-setup/collect-models.ts
@@ -133,6 +133,20 @@ function modelsFor(models: ModelRecord[], provider: string): string[] {
 // resolveGptModel / resolveGeminiModel, the models the agent suite already
 // runs green on; the catalog order stays as the tail so a provider with
 // none of the preferred models still validates on whatever it exposes.
+//
+// KNOWN GAP — "active" means the key works, NOT that Langflow can BUILD the
+// model. The probe calls the provider's own API directly, upstream of
+// Langflow, so it cannot see a missing server-side integration package. On a
+// nightly that shipped without `langchain-google-genai`, google probed
+// `active` here while every Google chat/embedding build inside Langflow raised
+// `ImportError: Could not import '...google_generative_ai_model' ... Install
+// the missing package`, surfacing downstream only as a misleading node-build
+// timeout across ~17 @stable specs (agents + Google-embedding KB). Root cause
+// + impact map: #898; upstream ticket: LE-1974. A faithful check would have to
+// BUILD a Language Model flow per provider and inspect the error — there is no
+// standalone endpoint that triggers the class import (`/api/v1/models/*`
+// return static metadata only). That build-probe hardening was deferred to
+// #900; this note is the trap marker for the next triager.
 const CANDIDATE_PREFS: Record<string, RegExp[]> = {
   openai: [/^gpt-4o-mini$/, /^gpt-4o$/, /^gpt-4\.1(-mini|-nano)?$/, /^gpt-4/],
   google: [


### PR DESCRIPTION
## What

Documents a known gap in `collect-models`: it validates a provider's **raw API key** (via the provider's own API, upstream of Langflow), not that Langflow can **build** the model class. A valid key + a missing server-side integration package = a false `active`.

This is a **light-touch note only** — no behavior change. It is the trap marker for the next triager until the build-probe hardening (#900) lands.

## Why

On the #879 daily, ~17 `@stable` specs failed only in their **Google** variant because the nightly image shipped without `langchain-google-genai`, so every Google chat/embedding model raised an `ImportError` at build. It surfaced downstream as a misleading node-build timeout, costing a full triage cycle to attribute. `collect-models` recorded google `active` throughout, because its probe never exercises the Langflow build.

- Root cause + impact map + live confirmation: #898
- Upstream ticket: LE-1974
- Deferred faithful hardening (build-probe): #900

## Changes

- `tests/helpers/provider-setup/collect-models.ts` — extend the existing #570 probe comment with the package-gap dimension (comment only)
- `docs/collect-models.md` — add a "What this test does not cover" bullet

## Validation

- `npm run typecheck` — 0 errors
- `npm run lint` — 0 errors (pre-existing warnings only)
- No spec logic touched; no test run required.

Refs #898, #900

🤖 Generated with [Claude Code](https://claude.com/claude-code)
