### PR TITLE
docs(qa-checklist): §6.2 Agent timeout — no product surface (reclassify #825)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -332,7 +332,7 @@
 - [x] Agent stops when configured stop condition is reached → `core-functionality/llm-agents/agent-max-iterations.spec.ts` (`max_iterations` is the Agent's only configurable stop mechanism — no dedicated stop-condition field exists; see #824)
 - [x] Agent stops when maximum number of iterations is reached → `core-functionality/llm-agents/agent-max-iterations.spec.ts`
 - [x] Agent with multiple configured tools executes correctly → `agent-multi-tool-selection.spec.ts`
-- [ ] Agent with configured timeout respects the limit
+- [ ] Agent with configured timeout respects the limit (no product surface on 1.12.x — the Agent component exposes no timeout field: its inputs are `max_iterations`, `max_tokens`, `n_messages`, `system_prompt`, `context_id`, `stream`, and tools; Langflow's only configurable per-component timeouts live on the A2A Agent (`timeout`) and MCP tools (`tool_execution_timeout`), not the Agent, and the Language Model / chat models expose none either. The client/transport execution timeout that bounds any run is covered by `ui-ux/execution-error-notification.spec.ts`. Not automatable as written; #825, same class as #824)
 - [x] Connecting an external model in Agent drops the prior model selection (connection-mode isolation, prevents stale provider config) → `llm-agents/agent-model-connection-isolation.spec.ts`
 - [x] Flow with Agent saved and reopened → settings preserved → `core-functionality/llm-agents/agent-config-persistence.spec.ts`
 - [x] max_tokens truncates response as configured → `llm-agents/agent-max-tokens.spec.ts` (validated at token level via the Playground token-usage tooltip)


### PR DESCRIPTION
## What

Reclassifies §6.2 "Agent with configured timeout respects the limit" — the premise does not hold and no spec is authorable.

**Finding (SPECIFY investigation, container source `lfx/components/models_and_agents/agent.py`):** the Langflow **Agent component exposes no timeout field**. Its inputs are `max_iterations`, `max_tokens`, `n_messages`, `system_prompt`, `context_id`, `stream`, and tools — 0 occurrences of `timeout` in the file. The Language Model and chat model components expose none either. Langflow's only user-configurable per-component timeouts live on the **A2A Agent** (`timeout`) and **MCP tools** (`tool_execution_timeout`), not the Agent.

Same class as #824 (which found the Agent has no dedicated stop-condition field).

## Change

- `QA-CHECKLIST.md` §6.2 — keep the bullet unchecked with a **no-product-surface** note (mirroring the #829 convention for MCP resources/prompts), pointing to the nearest real coverage: the client/transport execution timeout in `ui-ux/execution-error-notification.spec.ts`. Not marked `[x]` — that would inflate validated coverage for a behavior no dedicated `@stable` spec exercises.

No spec or spec doc authored — there is no field to exercise (writing one would be an engineered-green test, which the suite forbids).

## Validation

- Manual Part II bullet only; no generated block touched (checklist guard passes).
- No `.spec.ts` changed → no test run required.

Closes #825. Refs #824.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
