### PR TITLE
chore(skills): add /langflow-e2e-infra infra-layer skill

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -12,6 +12,7 @@ git-ignored — only the skills below are tracked.
 | **langflow-e2e-issues** | Prose orchestrator — wraps `langflow-e2e` to drive one GitHub issue → PR (intake, classify, 6 issue types, PR authorization). Best for family-clone specs and daily-failure triage. |
 | **langflow-e2e-issue-deterministic** | Deterministic orchestrator — a TypeScript state machine (`pipeline/cli.ts`) owns phase order, gates, and evidence. **Default for wave issues.** Same lifecycle as the prose variant, enforced in code. |
 | **langflow-e2e-triage** | Daily-run triage dispatcher — reads the latest red `daily-stable.yml` run, groups failures by root cause, dedups against open issues, and opens dedicated follow-up issues behind a propose-confirm gate. **Producer** of the issues the two orchestrators above **consume**. |
+| **langflow-e2e-infra** | Infrastructure layer. Owns CI workflows, `scripts/`, `playwright.config.ts`, and run-history/reporting; two modes — **audit** (continuous-improvement scan → propose `qa-infra` issues) and **resolve** (`qa-infra` issue → PR). Both behind a propose-confirm gate. Delegates any `tests/` edit to `langflow-e2e`; consumes the `qa-infra` issues `langflow-e2e-triage` produces. |
 
 The two orchestrators intentionally coexist (benchmark). Each SKILL.md opens with a
 "which orchestrator to use" note. Both delegate test authoring to `langflow-e2e`.

--- a/.claude/skills/langflow-e2e-infra/SKILL.md
+++ b/.claude/skills/langflow-e2e-infra/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: langflow-e2e-infra
+description: >-
+  Use when the task concerns the E2E suite's INFRASTRUCTURE layer rather than
+  test authoring (oriontech-me/langflow-e2e) — CI workflows
+  (.github/workflows/*), scripts/*, playwright.config.ts, reports/ run-history +
+  Flakiness.io, or a qa-infra-labelled GitHub issue. Triggers: "otimiza/melhora a
+  infra dos testes", "resolve a issue qa-infra #NNN", daily slowdown, single-
+  backend saturation, sharding, low-concurrency lane, collect-models skips/403,
+  flaky-under-load, CI runner sizing, pre-flight gate, LLM mocking, external-
+  dependency hard-fail, isolation/cleanup race.
+---
+
+# Langflow E2E — Infrastructure
+
+Owns the **infrastructure layer** of this suite: continuous improvement of CI,
+tooling, and harness reliability, plus end-to-end resolution of `qa-infra`
+GitHub issues. It is the fifth team skill and the only one that owns the infra
+layer — the four test-oriented siblings revolve around test authoring and
+product-bug triage.
+
+Repo: `oriontech-me/langflow-e2e`. Infra work is gated by `ROADMAP.md` waves like
+any other work — resolve the current wave live, never hardcode it.
+
+## Scope — owns vs. defers
+
+**Owns:**
+- `.github/workflows/*` — nightly, daily-stable, pr-validation, manual,
+  file-watcher, update-coverage-summary, migration, triage-dispatch.
+- `scripts/*` — start/stop Langflow, collect-models, history appender,
+  coverage-summary, stable-tests, checklist guards.
+- `playwright.config.ts` — parallelism, workers, retries, timeouts, reporters,
+  lanes.
+- `reports/` (run-history JSONL + schema) and the Flakiness.io reporter.
+- The `qa-infra` issue class end-to-end.
+
+**Defers (invoke the owner, don't improvise):**
+- `.spec.ts` authoring + spec docs under `docs/` → **`langflow-e2e`** (invoke it
+  when an infra fix needs a test-side change, e.g. migrating a spec to API
+  creation + id-scoped cleanup).
+- Classifying a raw daily red into product-vs-infra issues → **`langflow-e2e-triage`**
+  produces the issues; this skill consumes the `qa-infra` ones.
+- QA-CHECKLIST generated blocks — never hand-edited (repo rule).
+
+## When to use this vs. the test skills
+
+| Task | Skill |
+|---|---|
+| Author/fix a `.spec.ts`, spec doc, POM, helper | `langflow-e2e` (+ `-issues` / `-issue-deterministic` to wrap an issue) |
+| Triage a daily red into dedicated issues | `langflow-e2e-triage` |
+| Change a workflow / script / `playwright.config` / reporting; resolve a `qa-infra` issue; make the suite faster/less flaky at the infra level | **this skill** |
+
+Rule of thumb: if the diff lands in `.github/`, `scripts/`, `playwright.config.ts`,
+or `reports/` — it's here. If it lands in `tests/` product logic — it's `langflow-e2e`.
+A fix that spans both: drive it here, delegate the `tests/` edit to `langflow-e2e`.
+
+## Language rule (always)
+
+Talk to the user in **Portuguese (PT-BR)**; produce every technical artifact
+(YAML, scripts, config, commit/PR/issue text, branch names, this skill) in
+**English**. Repo rule — see `CLAUDE.md`.
+
+## Hard gates (non-negotiable)
+
+- **Propose → confirm, for issues AND PRs.** Present findings / the fix, then
+  **wait**. Only run `gh issue create` or `gh pr create` / push when the user
+  explicitly authorizes it ("abre a issue", "manda o PR"). Consistent with
+  `langflow-e2e-triage` and the repo's external-action rule.
+- **Evidence before assertions.** Never claim a workflow is fixed or the suite is
+  faster without proof. Scripts/config are proven locally; workflow YAML that
+  can't run locally is declared as such — its final proof is the next CI run.
+  Confirm any test-run result from the run's final `N passed`/`N failed` summary,
+  never a premature signal.
+- **One issue at a time**, its own branch (`type/issue-NNN-desc`, never `main`).
+- **Every final report ends with (user rule):** (1) what changed and why, per
+  file; (2) the **copy-paste command** to reproduce/verify locally — including
+  env overrides, the `--debug` variant where relevant, and the expected outcome.
+  For infra with no local proof path, state exactly which CI run proves it and
+  what to watch.
+- **Touch a spec → clean its flows.** Any infra fix that edits a flow-creating
+  spec ships id-scoped `afterEach` cleanup, checks the orphan count via
+  `GET /api/v1/flows/` before reporting, and purges leaked orphans.
+
+## Two modes
+
+Track every phase with TodoWrite.
+
+### Mode A — AUDIT (continuous improvement)
+
+Trigger: `/langflow-e2e-infra`, "audita a infra", "onde melhorar a infra".
+
+1. **Inventory** the live infra state:
+   - workflows (`.github/workflows/*`), scripts, `playwright.config.ts` knobs;
+   - recent daily durations + failure counts — `reports/daily-history.jsonl`
+     (schema in `reports/README.md`; example `jq` queries there);
+   - open `qa-infra` issues — `gh issue list --label qa-infra --state open`;
+   - Flakiness.io signal — `flakiness-report/report.json`.
+2. **Rank** improvement opportunities by leverage against the failure-mode index
+   (`references/failure-modes.md`). Prefer levers that cut recurring pain
+   (saturation, silent skips, external-dep hard-fails) over cosmetic wins.
+3. **Dedup** against open `qa-infra` issues and in-flight roadmap items — never
+   propose what's already tracked; link the existing issue instead.
+4. **Propose → confirm.** Present ranked findings (leverage, effort, evidence).
+   Open `qa-infra` issues only after explicit authorization, and only if they
+   fit the current wave or trace to an approved exception (`ROADMAP.md` → Intake).
+
+### Mode B — RESOLVE (issue → PR)
+
+Trigger: `/langflow-e2e-infra #NNN`, "resolve a issue qa-infra #NNN".
+
+1. **INTAKE** — load and assign:
+   ```bash
+   gh issue view <NNN> --repo oriontech-me/langflow-e2e --comments
+   gh issue edit <NNN> --repo oriontech-me/langflow-e2e --add-assignee @me
+   ```
+   Confirm roadmap linkage (wave item or approved exception). Restate in PT-BR
+   what the issue asks and which subtype you classified.
+2. **CLASSIFY** the infra subtype (`references/failure-modes.md` maps each to its
+   canonical lever + authoritative doc):
+
+   | Subtype | Signal | Lever / owner doc |
+   |---|---|---|
+   | CI-workflow | `.github/workflows/*`, ci(...) | edit YAML; prove via `manual.yml` / next CI |
+   | script | `scripts/*`, collect-models, history | run locally + `typecheck`/`lint` |
+   | config | `playwright.config.ts`, workers/lanes/retries | parse-check + targeted run |
+   | history-reporting | `reports/`, Flakiness.io, coverage-summary | `reports/README.md` |
+   | external-dependency | httpbin/postman/npx-server hard-fail | decouple / mock (#462/#463/#639/#883) |
+   | isolation-cleanup | cross-worker flow deletion, POST 500 race | id-scoped cleanup + API creation (#515/#588/#605) |
+   | provider/collect-models | 403, silent skip, missing pip pkg | buildable probe + skip-credentials (#570/#873/#900) |
+
+3. **DIAGNOSE** via `superpowers:systematic-debugging` + the failure-mode index.
+   For a load/saturation symptom, reproduce with `--workers=N` locally before
+   assuming a product regression (`ISSUE-817-CI-RUNNER-SIZING.md`).
+4. **FIX** in the correct layer. If the root fix is a test-side change, delegate
+   the `tests/` edit to `langflow-e2e`.
+5. **VALIDATE** (below) → **propose → confirm** the PR.
+
+## Validate before the PR
+
+- **Scripts / config:** run locally — `npm run typecheck`, `npm run lint`,
+  execute the script, parse-check `playwright.config.ts`, and a targeted
+  `npx playwright test … --workers=1` when the change affects execution.
+- **Workflow YAML:** validate structure; it can't fully run locally — **say so**.
+  Dry-run via `manual.yml` (or `act` if available); otherwise state plainly that
+  the final proof is the next daily / PR-CI run and name what to watch.
+- **Never claim green without evidence.** End with the reproduce/verify command
+  and expected outcome, or the exact CI run that will prove it.
+
+## Companion skills — invoke when needed
+
+- **`langflow-e2e`** — owns all test-authoring conventions; invoke when an infra
+  fix needs a `tests/` edit (spec migration, helper, POM, cleanup).
+- **`langflow-e2e-triage`** — upstream producer of `qa-infra` daily-failure
+  issues; this skill consumes them.
+- **`superpowers:systematic-debugging`** — root-cause before fixing any infra
+  failure mode.
+- **`playwright-cli`** — drive a live browser to reproduce a load/flake symptom
+  under controlled concurrency.
+
+## Knowledge base — thin indexes, not a new catalog
+
+The repo already records resolved-infra context. These references **point** to
+that source of truth and capture only the connective tissue not yet written down.
+Same discipline as the skills `README.md` ("don't restate — point").
+
+- **`references/infra-map.md`** — CI / scripts / config topology: one line per
+  workflow, script, and key config knob, each linking to its file or owner doc.
+- **`references/failure-modes.md`** — a **symptom → lever** index: each recurring
+  infra failure class maps to the canonical fix pattern, the authoritative
+  in-repo doc, and the issue/PR IDs. Restates nothing a linked doc already says.
+
+Authoritative sources these link into: root `ISSUE-*.md` postmortems/designs,
+`docs/collect-models.md`, `CONTRIBUTING.md` (@stable lifecycle, triage protocol,
+run-history monitoring, false-positive anti-patterns, impacted-tests subset),
+`reports/README.md`, `ROADMAP.md` (Wave 3), and the closed `qa-infra` issues/PRs.
+
+## Red flags — STOP
+
+- About to `gh issue create` / `gh pr create` / push without explicit authorization → stop, report & wait.
+- Claiming a workflow is fixed with no local proof and no named CI run to watch → not validated.
+- Diagnosing a load symptom as a product regression before reproducing under controlled `--workers=N` → reproduce first (`ISSUE-817`).
+- Editing `tests/` product logic directly instead of delegating to `langflow-e2e` → wrong layer.
+- Hand-editing QA-CHECKLIST generated blocks, or committing `npm run coverage:summary` output in a PR (issue #741 guard) → edit bullets/tags only.
+- Restating a postmortem/doc inside a reference instead of linking it → indexes point, they don't copy.
+- Touching a flow-creating spec without id-scoped cleanup + orphan check → clean flows, always.
+- Picking up off-wave infra work with no approved exception issue → confirm roadmap linkage first.
+
+## Boundaries
+
+`CONTRIBUTING.md` and `ROADMAP.md` are repository conventions and outrank this
+skill; on any conflict, follow them and fix the skill. This skill is versioned in
+`.claude/skills/` and shared with the team — keep it accurate and English-only.
+It owns the infra layer; the authoritative infra knowledge lives in the linked
+repo docs and the two references — read them, don't restate them.

--- a/.claude/skills/langflow-e2e-infra/references/failure-modes.md
+++ b/.claude/skills/langflow-e2e-infra/references/failure-modes.md
@@ -1,0 +1,114 @@
+# Failure-mode index — symptom → lever
+
+Each recurring infra failure class maps to its **canonical fix pattern**, the
+**authoritative in-repo doc**, and the **issue/PR IDs**. This index restates
+nothing a linked doc already says — read the doc for the full reasoning; use this
+to route a symptom to the right lever fast. Confirm the linked docs/issues are
+still current before acting.
+
+## 1. Single-backend saturation (load flakiness)
+
+**Symptom:** specs time out / flake only under CI parallelism; daily duration
+spikes; `expandFocusedNode` / modal clicks time out; not reproducible at
+`--workers=1`. Root cause is one Langflow backend serializing concurrent work,
+**not** CPU sizing and **not** a product regression.
+
+**Levers:** shard the `@stable` suite across runners · isolate heavy live-LLM
+specs into a low-concurrency lane · cap workers per shard · reproduce locally with
+`--workers=N` before blaming the product.
+
+**Docs:** `ISSUE-817-CI-RUNNER-SIZING.md`, `ISSUE-833-SHARDING-DESIGN.md`,
+`ISSUE-833-SHARDING-PLAN.md`; `@stable`-removal rules → `CONTRIBUTING.md` →
+*Tag @stable* / *Triage protocol*.
+**Issues/PRs:** #817 · #830 · #833 · #867 · #882 · #816 · #773 · #818 · PR #888.
+
+**`@stable` verdict routing** (when someone wants to drop `@stable` over this):
+confirmed saturation (green at `--workers=1`, flakes at higher N) → **keep
+`@stable`**, fix at the infra layer (shard / lane / cap workers); do NOT remove the
+tag. Only a **confirmed product regression** justifies a tag change, and that
+verdict belongs to `langflow-e2e-triage`, with the `.spec.ts`/tag edit delegated to
+`langflow-e2e` (`scripts/remove-stable-from-failures.ts` automates the removal
+path). This skill never removes `@stable` itself.
+
+## 2. collect-models silent skip / 403
+
+**Symptom:** whole provider's agent specs silently skip, or fail with 403; a
+single inaccessible lead model disables the provider; PR impacted-specs gate picks
+an inaccessible model; a raw API key probes OK but the model isn't Langflow-buildable.
+
+**Levers:** build-probe the provider's model class (not just the raw key) ·
+collect models **before** the impacted-specs gate · set `PREFLIGHT_SKIP_CREDENTIALS`
+on PR collect-models · resolve model via alias/settled, never a hardcoded dated id.
+
+**Docs:** `docs/collect-models.md`.
+**Issues/PRs:** #570 · #873 · #900 · #886 · #892 · PR #878 · PR #887 · PR #893 · PR #901.
+
+## 3. External-dependency hard-fail
+
+**Symptom:** the suite hard-fails on an outage of an external service (httpbin.org,
+postman-echo, `npx server-everything`, a pinned httpbin service tag, missing pip
+package like `langchain-google-genai`).
+
+**Levers:** decouple from the external echo endpoint · mock the dependency ·
+assert the dependency is provisioned in a pre-flight gate rather than failing mid-run.
+
+**Docs:** pre-flight gate `#884`; OpenAI-compatible echo mock PoC PR #889.
+**Issues/PRs:** #462 · #463 · #639 · #600 · #898 · #883 (mocking) · #884 (pre-flight) · PR #881 · PR #885.
+
+## 4. Isolation / cleanup race
+
+**Symptom:** a spec's flows get deleted by a concurrent test; global `cleanAllFlows`
+wipes siblings; flow creation/open hits an ambient `POST /api/v1/flows/` 500;
+leaked "New Flow" orphans; SQLite lock on bulk delete.
+
+**Levers:** id-scoped `afterEach` cleanup (never global wipe) · create flows via API ·
+per-worker isolation · a shared `deleteFlow()` that surfaces failures · harden
+create/open against the parallel 500 race.
+
+**Docs:** `LANGFLOW-BUG-bulk-flow-delete-sqlite-lock.md`; `langflow-e2e`
+`references/authoring-conventions.md` → Flow cleanup (test-side owner).
+**Issues/PRs:** #515 · #547 · #588 · #589 · #605 · #877 · Memory: flow-cleanup-always.
+
+## 5. Pre-flight / fail-fast gate coverage
+
+**Symptom:** the suite runs to completion (or half-fails) on a broken environment —
+backend down, wrong nightly version, missing credentials/flags, custom-components
+flag off.
+
+**Levers:** pre-flight fail-fast gate (backend health + nightly version + required
+credentials & flags) before the suite; assert embedding credential before KB ingest.
+
+**Docs:** custom-components flag — Memory: custom-components-flag-nightly (#668).
+**Issues/PRs:** #884 · #880 · PR #885 · PR #881.
+
+## 6. Run-history / reporting integrity
+
+**Symptom:** history JSONL frozen / missing lines; push races on `main`;
+`error_signature` not recorded; Flakiness.io not tagged with the Langflow version;
+coverage-summary push collides between concurrent PRs.
+
+**Levers:** rebase/regenerate-retry the history push · backfill lost lines · record
+`error_signature` · tag Flakiness.io uploads with the resolved version · never
+commit `coverage:summary` output in a PR (guard `#741`).
+
+**Docs:** `reports/README.md`.
+**Issues/PRs:** #728 · #385 · #741 · PR #849 · PR #850 · PR #896 · PR #875 · PR #874.
+
+## 7. Triage-dispatch automation
+
+**Symptom:** triage propose runs blind to skip reasons; recurrence counts are
+signature-agnostic; approval phrase not anchored; skill guidance conflicts with
+`CONTRIBUTING.md`.
+
+**Levers:** wire `results.json` into propose · make recurrence signature-aware ·
+anchor the approval phrase + actor check on propose · reconcile skill ↔ `CONTRIBUTING.md`.
+
+**Docs:** `CONTRIBUTING.md` → Triage protocol; `langflow-e2e-triage` skill (owner).
+**Issues/PRs:** #791 · #803 · #819 · #777 · #719 · Memory: triage-skill-branch.
+
+---
+
+**Not sure which class?** Reproduce under controlled `--workers=N` first (rules out
+class 1), check whether the failing surface is a real product change vs a test-side
+drift (that's a `langflow-e2e-triage` verdict, not this skill's), and grep open
+`qa-infra` issues before proposing anything new.

--- a/.claude/skills/langflow-e2e-infra/references/infra-map.md
+++ b/.claude/skills/langflow-e2e-infra/references/infra-map.md
@@ -1,0 +1,58 @@
+# Infra map — CI / scripts / config topology
+
+One line per moving part, linking to its file or owner doc. This is an index, not
+an explanation — the authoritative behaviour lives in each file's header comments,
+`CLAUDE.md` (CI/CD section), and the linked docs. Verify against the live files
+before acting; this list drifts.
+
+## GitHub workflows (`.github/workflows/`)
+
+| Workflow | Role | Notes / owner doc |
+|---|---|---|
+| `nightly.yml` | Daily 03:00 BRT full run vs `langflow-nightly:latest`; opens issue on failure | `CLAUDE.md` → CI/CD |
+| `daily-stable.yml` | **Active stable workflow.** Weekdays 05:00 BRT, `@stable` only; opens `daily-failure` issue; appends `reports/daily-history.jsonl` | consumed by `langflow-e2e-triage` |
+| `weekly-stable.yml` | **Disabled** fallback (superseded by daily-stable); writes `reports/weekly-history.jsonl` | frozen history |
+| `pr-validation.yml` | Every PR: `tsc --noEmit` + ESLint + QA-CHECKLIST guard + impacted-specs gate | `#741`, `#873`, `#892` |
+| `adaptive-impacted.yml` | Runs the impacted-tests subset for a PR | `scripts/impacted-tests.ts`; `CONTRIBUTING.md` → Adaptive impacted-tests |
+| `manual.yml` | Parameterized manual run (Docker tag / URL, suite, grep) | use to dry-run a workflow-adjacent change |
+| `file-watcher.yml` | Detects upstream Langflow changes in critical paths; opens revalidation issue | `CONTRIBUTING.md` → Monitored areas |
+| `triage-dispatch.yml` | Automates daily-failure triage dispatch behind an approval gate | `#785/#786/#787`, `#819` |
+| `update-coverage-summary.yml` | Regenerates QA-CHECKLIST generated blocks on merge to `main` | `scripts/coverage-summary.ts`, `stable-tests.ts` |
+| `migration-test.yml` / `migration-fresh-install.yml` / `migration-upgrade-with-flows.yml` | Langflow version-migration checks (latest → nightly) | `migration-test` label |
+| `build-ollama-image.yml` | Builds the Ollama image used by provider specs | — |
+
+## Scripts (`scripts/`)
+
+| Script | Role |
+|---|---|
+| `start-langflow-docker.sh` / `stop-langflow-docker.sh` | Bring a Langflow instance up/down via Docker (nightly by default) |
+| `start-langflow-pip.sh` / `stop-langflow-pip.sh` | Same via pip (local dev). Caps to 1 worker to avoid OOM (`#888`) |
+| `coverage-summary.ts` | Regenerates the QA-CHECKLIST Coverage Summary table (bullet markers → table) |
+| `stable-tests.ts` | Regenerates the `Phase 0 — Validated` block from `@stable` `test()` calls |
+| `check-checklist-guard.mjs` | PR guard: fails a PR that edits a generated QA-CHECKLIST block (`#741`) |
+| `impacted-tests.ts` | Computes the impacted-specs subset for a PR |
+| `append-weekly-history.mjs` | Shared run-history appender (daily via `HISTORY_FILE` override) |
+| `backfill-runs.mjs` | Backfills missing run-history lines (`#849`) |
+| `build-run-payload.mjs` | Builds the run-history JSONL payload for a CI run |
+| `check-nightly-delta.ts` | Compares nightly versions to isolate product-vs-infra regressions (`#816`) |
+| `remove-stable-from-failures.ts` | Auto-removes `@stable` from hard failures (`#476`) |
+| `format-auto-remove-summary.mjs` | Formats the auto-remove summary comment |
+| `validate-spec-deps.ts` | Validates a spec's declared external dependencies |
+
+## `playwright.config.ts` knobs
+
+| Knob | Current value | Notes |
+|---|---|---|
+| `fullyParallel` | `true` (unless `PW_SHARD_FILE_LEVEL`) | file-level serialization for sharding (`ISSUE-833-SHARDING-DESIGN.md`) |
+| `workers` | 2 in CI, unset locally | 2-worker contention was the `#817` locus; `ISSUE-833` §workers-per-shard |
+| `retries` | 2 in CI, 3 locally | trace captured on first retry |
+| `timeout` | 5 min/test | |
+| `reporter` | HTML + Flakiness.io in CI, HTML locally | Flakiness.io reporter lives here, NOT the `--reporter` CLI flag (`#874/#875`) |
+| `projects` | see file | Chromium only, clipboard perms |
+
+## Run history & reporting (`reports/`)
+
+- `reports/README.md` — schema (version 1), expansion criteria, `jq` query examples. **Read before extending.**
+- `reports/daily-history.jsonl` — active, one line per `daily-stable.yml` run (machine-written, human-read only; never hand-edit).
+- `reports/weekly-history.jsonl` — frozen history from the disabled weekly workflow.
+- `flakiness-report/report.json` — latest Flakiness.io reporter output.

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ dist/
 !.claude/skills/langflow-e2e-issues/
 !.claude/skills/langflow-e2e-issue-deterministic/
 !.claude/skills/langflow-e2e-triage/
+!.claude/skills/langflow-e2e-infra/
 docs/superpowers/
 .playwright-mcp/
 .worktrees/


### PR DESCRIPTION
## What

Adds a fifth team skill, **\`langflow-e2e-infra\`**, under \`.claude/skills/\`. It owns the **infrastructure layer** of the suite — the gap none of the four existing skills covered.

**Owns:** \`.github/workflows/*\`, \`scripts/*\`, \`playwright.config.ts\`, \`reports/\` run-history + Flakiness.io, and the \`qa-infra\` issue class.

**Two modes**, both behind a propose→confirm gate (consistent with \`langflow-e2e-triage\` and the repo's external-action rule):
- **Audit** — scan live infra state (workflows, scripts, config, \`daily-history.jsonl\`, open \`qa-infra\`, Flakiness.io), rank improvements against the failure-mode index, dedup, propose issues.
- **Resolve** — take one \`qa-infra\` issue → PR: intake, classify subtype, diagnose (systematic-debugging), fix in the right layer, validate, propose PR.

**Boundaries:** delegates any \`tests/\` edit to \`langflow-e2e\`; consumes the \`qa-infra\` issues \`langflow-e2e-triage\` produces; never hand-edits QA-CHECKLIST generated blocks.

## Files

- \`SKILL.md\` — scope (owns vs defers), when-to-use-vs-siblings table, hard gates, two-mode workflow, validation discipline, red flags.
- \`references/infra-map.md\` — CI/scripts/config topology index (one line each, linking to owner file/doc).
- \`references/failure-modes.md\` — symptom→lever index: 7 recurring infra failure classes, each mapped to canonical fix + authoritative in-repo doc + issue/PR IDs.
- \`README.md\` — +1 row for the new skill.
- \`.gitignore\` — un-ignores the new skill dir so it is versioned/shared like its siblings.

References are **thin indexes** that point to the authoritative in-repo docs (\`ISSUE-*.md\`, \`docs/collect-models.md\`, \`CONTRIBUTING.md\`, \`reports/README.md\`) — they restate nothing.

## Validation

- Skill files live outside \`tests/\`, so \`tsc\`/ESLint PR-CI scope is unaffected.
- Retrieval/application test (fresh subagent, CI-only \`expandFocusedNode\` flake scenario): correctly routed to failure-mode class 1 (single-backend saturation), named the \`--workers=N\` reproduce-first step, cited the right docs, and honored the propose-confirm + "don't remove @stable yet" gates — 5/5. Two minor gaps it flagged were closed (@stable verdict routing + \`CONTRIBUTING.md\` cross-link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)