### PR TITLE
test(chat-input): drop @stable from files-field showfiles toggle (#867)

### DIFF
--- a/tests/tests-automations/regression/core-components/chat-input-files-field-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/chat-input-files-field-regression.spec.ts
@@ -120,7 +120,7 @@ function chatInputNodeScope(page: Page) {
 
 test(
   "Chat Input — toggling `showfiles` exposes the Files inspector field",
-  { tag: ["@stable", "@regression", "@components"] },
+  { tag: ["@regression", "@components"] },
   async ({ page }) => {
     // Scope to the Chat Input node body. The `input-file-component` testid is also
     // mounted by the advanced-options side panel even before the toggle, so an


### PR DESCRIPTION
## What

Removes `@stable` from `chat-input-files-field-regression.spec.ts:121` ("Chat Input — toggling `showfiles` exposes the Files inspector field") as **triage prevention** so it stops running in the daily until #867 is worked.

## Why

Recurrent flake, same signature `locator.click: Timeout 5000ms exceeded` on **2026-07-21, 07-22, 07-23**. 07-21 was the **only clean (non-guard-tripped) daily** in the window (failed=3), so this reproduces off the mass-failure days — a durable signal, not saturation collateral. It was previously carried as context on #867; the 2026-07-23 triage graduated it to actionable.

## Scope / caveat

- This spec is `test.describe.configure({ mode: "serial" })` and keeps `@stable` on two later tests (`:229`, `:285`). Confirmed the removed test is **not** a setup dependency for those — they don't consume its state — but the daily's remaining `@stable` serial subset should be watched on the next run.
- Only the tag array changes; no test logic touched.

## Follow-up

Restoring `@stable` after the fix is a **deliverable of #867** (re-validate per `CONTRIBUTING.md` before restoring).

Refs #867

🤖 Generated with [Claude Code](https://claude.com/claude-code)
