### PR TITLE
test(lock-flow): drop @stable from lock-persisted spec (#909)

### DIFF
--- a/tests/tests-automations/regression/flow-functionality/lock-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/lock-flow.spec.ts
@@ -42,7 +42,7 @@ test.afterEach(async ({ page }) => {
 
 test(
   "user must be able to lock a flow and it must be saved",
-  { tag: ["@stable", "@release", "@components", "@workspace"] },
+  { tag: ["@release", "@components", "@workspace"] },
   async ({ page }) => {
     test.skip(
       !process?.env?.OPENAI_API_KEY,


### PR DESCRIPTION
## What

Removes `@stable` from `lock-flow.spec.ts:43` ("user must be able to lock a flow and it must be saved") as **triage prevention** so it stops running in the daily until #909 is worked.

## Why

Recurrent flake, same signature `expect(received).toBe(expected) // Object.is equality` (saved lock state mismatch) on **2026-07-21 and 07-23**. 07-21 was the **only clean (non-guard-tripped) daily** in the window (failed=3), so this reproduces off the mass-failure days — a durable signal, not saturation collateral.

## Scope

Only the tag array changes; no test logic touched.

## Follow-up

Restoring `@stable` after the fix is a **deliverable of #909** (re-validate per `CONTRIBUTING.md` before restoring).

Refs #909

🤖 Generated with [Claude Code](https://claude.com/claude-code)
