### PR TITLE
test(project-management): navigate between folders scopes flow listing (§10.2)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -529,7 +529,7 @@
 - [-] Move flow to another folder
 
 #### 10.2 Folder Navigation
-- [~] Navigate between folders
+- [-] Navigate between folders → `core-functionality/project-management/flow-navigation-between-folders.spec.ts`
 - [-] Search flow by name filters results correctly
 - [-] Folders in navigation sidebar
 

--- a/docs/core-functionality/project-management/flow-navigation-between-folders.md
+++ b/docs/core-functionality/project-management/flow-navigation-between-folders.md
@@ -1,0 +1,85 @@
+# Project Management – Navigate Between Folders
+
+**Last validated:** Langflow 1.12.x
+
+---
+
+## What this test validates *(required)*
+
+Validates **folder-to-folder navigation** on the home page (QA-CHECKLIST §10.2
+"Navigate between folders"): clicking a folder in the project sidebar filters the
+flow listing to **that folder's own flows**, and switching to another folder
+swaps the listing to the second folder's flows. This is the navigation/scoping
+behavior — distinct from folder CRUD, flow search, and moving a flow.
+
+Setup is API-first for determinism: two folders (projects) are created via
+`POST /api/v1/projects/`, and one uniquely-named flow is created **inside each**
+via `POST /api/v1/flows/` with the folder's `folder_id`. The UI then navigates
+between the two folders and asserts each listing is correctly scoped.
+
+The key assertion is **mutual exclusion**: folder A's view shows flow A and
+**not** flow B, and folder B's view shows flow B and **not** flow A — proving the
+sidebar navigation actually re-scopes the listing rather than showing a global
+list.
+
+---
+
+## Tags *(required)*
+
+`@release` `@workspace` `@mainpage` `@regression`
+
+> Not `@stable` yet — new spec, pending team validation on a clean run (mirrors
+> the sibling `flow-navigation-folders.spec.ts` / `folder-crud.spec.ts` tag set;
+> `@workspace` is this area's functional tag).
+
+---
+
+## Step by step *(required)*
+
+### Test — navigating between two folders scopes the listing to each folder
+
+1. Create folder **A** via `POST /api/v1/projects/` (unique name `nav-folderA-<timestamp>`); capture `folderAId`.
+2. Create folder **B** via `POST /api/v1/projects/` (unique name `nav-folderB-<timestamp>`); capture `folderBId`.
+3. Create flow **A** via `POST /api/v1/flows/` with `folder_id = folderAId` (unique name `nav-flowA-<timestamp>`); assert the echoed `folder_id` matches; capture `flowAId`.
+4. Create flow **B** via `POST /api/v1/flows/` with `folder_id = folderBId` (unique name `nav-flowB-<timestamp>`); assert the echoed `folder_id` matches; capture `flowBId`.
+5. Bootstrap the session (`awaitBootstrapTest(page, { skipModal: true })`); assert both `sidebar-nav-<folderA>` and `sidebar-nav-<folderB>` are visible.
+6. `clickProject(folderA)` → assert flow **A** name is visible **and** flow **B** name is hidden (`toBeHidden` / `toHaveCount(0)`).
+7. `clickProject(folderB)` → assert flow **B** name is visible **and** flow **A** name is hidden.
+8. **Cleanup (finally):** delete `flowAId`, `flowBId` (id-scoped, ignored if already gone), then folders `folderAId`, `folderBId` via `DELETE /api/v1/projects/{id}`.
+
+---
+
+## Validation criterion *(required)*
+
+- With folder A selected: flow A is listed and flow B is **not** — `getByText(flowA)` visible, `getByText(flowB)` hidden.
+- With folder B selected: flow B is listed and flow A is **not** — `getByText(flowB)` visible, `getByText(flowA)` hidden.
+- Both folders remain visible in the sidebar throughout (navigation, not deletion).
+
+A regression that made the listing global (ignoring the selected folder) would
+show both flows in each view and fail the mutual-exclusion assertion. Unique
+timestamped names make each `getByText` unambiguous under `fullyParallel`.
+
+---
+
+## External dependencies *(required)*
+
+- Home sidebar testids: `project-sidebar`, `sidebar-nav-<name>` (via `MainPage.clickProject`), `mainpage_title`.
+- Flow listing surface: the flow name rendered on the home grid (asserted via `page.getByText(<flowName>)`, the same surface `folder-crud.spec.ts` uses after `clickProject`).
+- REST API: `POST`/`DELETE /api/v1/projects/` (folders), `POST`/`DELETE /api/v1/flows/` with `folder_id` (auth via `getAuthToken`).
+- No LLM or provider API key required (model-independent).
+
+---
+
+## What this test does not cover *(optional)*
+
+- Folder CRUD (create/rename/delete) — `folder-crud.spec.ts`.
+- Flow search-by-name filtering and API-created flows appearing on the listing — `flow-navigation-folders.spec.ts`.
+- Moving a flow between folders (drag-drop / API placement) — `folder-drag-drop-flow.spec.ts`.
+- Deletion integrity across folders — `folder-deletion-integrity.spec.ts`.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running and accessible at `PLAYWRIGHT_BASE_URL`.
+- No LLM or API key needed.

--- a/tests/tests-automations/regression/core-functionality/project-management/flow-navigation-between-folders.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/flow-navigation-between-folders.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "../../../../fixtures/fixtures";
+import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { MainPage } from "../../../../pages/MainPage";
+
+/**
+ * Folder-to-folder navigation on the home page (QA-CHECKLIST §10.2 "Navigate
+ * between folders"): selecting a folder in the project sidebar scopes the flow
+ * listing to THAT folder's flows, and switching folders swaps the listing.
+ *
+ * Distinct from the sibling specs, which are intentionally not repeated:
+ *   - folder CRUD → folder-crud.spec.ts
+ *   - flow search-by-name / API-created flows appearing → flow-navigation-folders.spec.ts
+ *   - moving a flow between folders → folder-drag-drop-flow.spec.ts
+ *
+ * Setup is API-first for determinism: two folders (projects) and one uniquely
+ * named flow inside each (via folder_id). The key assertion is MUTUAL EXCLUSION
+ * — folder A shows flow A and not flow B, folder B shows flow B and not flow A —
+ * which proves the sidebar navigation re-scopes the listing instead of showing a
+ * global list. Cleanup is id-scoped (never a global sweep), required under
+ * fullyParallel.
+ */
+
+test(
+  "navigating between two folders scopes the listing to each folder's flows",
+  { tag: ["@release", "@workspace", "@mainpage", "@regression"] },
+  async ({ page, request }) => {
+    const authToken = await getAuthToken(request);
+    const headers = { Authorization: authToken };
+    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const folderAName = `nav-folderA-${stamp}`;
+    const folderBName = `nav-folderB-${stamp}`;
+    const flowAName = `nav-flowA-${stamp}`;
+    const flowBName = `nav-flowB-${stamp}`;
+
+    let folderAId: string | undefined;
+    let folderBId: string | undefined;
+    let flowAId: string | undefined;
+    let flowBId: string | undefined;
+
+    const createFolder = async (name: string): Promise<string> => {
+      const res = await request.post("/api/v1/projects/", {
+        headers,
+        data: { name, description: "Folder navigation test" },
+      });
+      expect(res.status()).toBe(201);
+      return (await res.json()).id as string;
+    };
+
+    const createFlowInFolder = async (
+      name: string,
+      folderId: string,
+    ): Promise<string> => {
+      const res = await request.post("/api/v1/flows/", {
+        headers,
+        data: {
+          name,
+          folder_id: folderId,
+          data: { nodes: [], edges: [], viewport: { x: 0, y: 0, zoom: 1 } },
+          is_component: false,
+        },
+      });
+      expect(res.status()).toBe(201);
+      const flow = await res.json();
+      expect(flow.folder_id).toBe(folderId);
+      return flow.id as string;
+    };
+
+    try {
+      await test.step("Create two folders, each with one distinct flow (API)", async () => {
+        folderAId = await createFolder(folderAName);
+        folderBId = await createFolder(folderBName);
+        flowAId = await createFlowInFolder(flowAName, folderAId);
+        flowBId = await createFlowInFolder(flowBName, folderBId);
+      });
+
+      const mainPage = new MainPage(page);
+
+      await test.step("Both folders are listed in the project sidebar", async () => {
+        await awaitBootstrapTest(page, { skipModal: true });
+        await expect(
+          page.getByTestId(`sidebar-nav-${folderAName}`),
+        ).toBeVisible({ timeout: 15000 });
+        await expect(
+          page.getByTestId(`sidebar-nav-${folderBName}`),
+        ).toBeVisible({ timeout: 15000 });
+      });
+
+      await test.step("Folder A shows flow A and not flow B", async () => {
+        await mainPage.clickProject(folderAName);
+        await expect(page.getByText(flowAName)).toBeVisible({ timeout: 15000 });
+        await expect(page.getByText(flowBName)).toHaveCount(0);
+      });
+
+      await test.step("Folder B shows flow B and not flow A", async () => {
+        await mainPage.clickProject(folderBName);
+        await expect(page.getByText(flowBName)).toBeVisible({ timeout: 15000 });
+        await expect(page.getByText(flowAName)).toHaveCount(0);
+      });
+    } finally {
+      if (flowAId) await deleteFlow(request, flowAId, { headers });
+      if (flowBId) await deleteFlow(request, flowBId, { headers });
+      if (folderAId) {
+        await request.delete(`/api/v1/projects/${folderAId}`, { headers }).catch(() => {});
+      }
+      if (folderBId) {
+        await request.delete(`/api/v1/projects/${folderBId}`, { headers }).catch(() => {});
+      }
+    }
+  },
+);


### PR DESCRIPTION
## What

New spec for **QA-CHECKLIST §10.2 "Navigate between folders"** — Wave 3 test-coverage. Covers the folder-to-folder navigation gap: selecting a folder in the project sidebar scopes the flow listing to **that folder's flows**, and switching folders swaps the listing.

## Why (dedup)

A dedup scout confirmed the existing specs cover adjacent behavior but not this:
- flow listing / search-by-name → `flow-navigation-folders.spec.ts`
- folder CRUD → `folder-crud.spec.ts`
- move flow between folders → `folder-drag-drop-flow.spec.ts`

None navigate between multiple folders asserting per-folder scoping.

## Test

| # | Test | Asserts |
|---|---|---|
| 1 | navigating between two folders scopes the listing to each folder's flows | **Mutual exclusion** — with folder A selected `getByText(flowA)` visible + `getByText(flowB)` `toHaveCount(0)`; with folder B selected, the inverse. |

Setup is API-first (2 folders via `/api/v1/projects/` + 1 uniquely-named flow in each via `folder_id`); cleanup is id-scoped (2 flows + 2 folders in `finally`), safe under `fullyParallel`. Model-independent.

## Validation (nightly `1.12.0.dev3`, `--workers=1 --retries=0`)

- `npm run typecheck` ✓ · `npm run lint` 0 errors ✓ · QA-CHECKLIST guard ✓.
- **3 clean runs** (4.9 / 4.6 / 3.9 s).
- **Force-fail:** placing both flows in the same folder makes the mutual-exclusion assert fail (`toHaveCount` Received 1 at line 93); reverted (marker grep = 0).
- **0 leaked orphans** (id-scoped cleanup verified via `GET /api/v1/flows/` + `/projects/`).

## Notes

- Tagged `@release @workspace @mainpage @regression` — **not `@stable`** yet (new spec, pending team validation; mirrors the sibling folder specs' tag set).
- `QA-CHECKLIST.md` §10.2 bullet flipped `[~]` → `[-]` with the spec path (manual Part II bullet only; generated blocks untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
