### PR TITLE
fix(flow-functionality): fix false lock-persist assertion + harden edge-count waits (#909)

### DIFF
--- a/tests/helpers/flows/lock-flow.ts
+++ b/tests/helpers/flows/lock-flow.ts
@@ -48,3 +48,24 @@ export async function lockFlow(page: Page): Promise<void> {
 export async function unlockFlow(page: Page): Promise<void> {
   await setLockState(page, "unchecked");
 }
+
+// Assert the flow's persisted lock state by reading the Flow Settings lock
+// switch — the authoritative, has-teeth indicator. The per-node `icon-lock`
+// affordance is rendered regardless of lock state, so it cannot prove that a
+// lock persisted across a reopen (#909). Opens the settings modal, asserts the
+// switch `data-state`, then closes without saving (read-only check).
+export async function expectLockState(
+  page: Page,
+  state: "checked" | "unchecked",
+): Promise<void> {
+  await page.getByTestId("flow_name").click();
+  const lockSwitch = page.getByTestId("lock-flow-switch");
+  await expect(lockSwitch).toBeVisible({ timeout: 30000 });
+  await expect(lockSwitch).toHaveAttribute("data-state", state, {
+    timeout: 15000,
+  });
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("save-flow-settings")).toBeHidden({
+    timeout: 10000,
+  });
+}

--- a/tests/tests-automations/regression/flow-functionality/lock-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/lock-flow.spec.ts
@@ -2,7 +2,11 @@ import type { Page } from "@playwright/test";
 import * as dotenv from "dotenv";
 import path from "path";
 import { expect, test } from "../../../fixtures/fixtures";
-import { lockFlow, unlockFlow } from "../../../helpers/flows/lock-flow";
+import {
+  lockFlow,
+  unlockFlow,
+  expectLockState,
+} from "../../../helpers/flows/lock-flow";
 import { unselectNodes } from "../../../helpers/ui/unselect-nodes";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
@@ -67,12 +71,12 @@ test(
     // Reopen the SAME flow by id to prove the lock persisted across a reload.
     await openFlowById(page, flowId);
 
-    //ensure the UI is updated — lock persisted across the reopen. On 1.11 the
-    // locked-state indicator is the per-node `icon-lock` (lowercase) badge; the
-    // old header `icon-Lock` (capital) no longer renders (#684).
-    await page.waitForSelector('[data-testid="icon-lock"]', {
-      timeout: 3000,
-    });
+    // Prove the lock actually PERSISTED across the reopen: the Flow Settings
+    // lock switch must read `checked`. The previous check waited for the
+    // per-node `icon-lock` badge, but that affordance renders on every flow
+    // regardless of lock state, so it passed even when the flow was never
+    // locked — a false assertion caught by force-fail (#909).
+    await expectLockState(page, "checked");
 
     await unlockFlow(page);
 
@@ -82,27 +86,31 @@ test(
     await tryDeleteEdge(page);
     await page.waitForTimeout(500);
 
-    // Delete edges one by one (when unlocked, should work)
+    // Delete edges one by one (when unlocked, should work). Assert via the
+    // polling `toHaveCount` (retries until the canvas settles) instead of a
+    // fixed `waitForTimeout` + `count()` + `toBe` — the latter races the
+    // ReactFlow re-render under the daily's parallel load and produced the
+    // `toBe` Object.is flake (#909).
     await page.locator(".react-flow__edge").nth(0).click();
     await page.waitForTimeout(200);
     await page.keyboard.press("Backspace");
-    await page.waitForTimeout(300);
-    let numberOfEdges = await page.locator(".react-flow__edge").count();
-    expect(numberOfEdges).toBe(2);
+    await expect(page.locator(".react-flow__edge")).toHaveCount(2, {
+      timeout: 10000,
+    });
 
     await page.locator(".react-flow__edge").nth(0).click();
     await page.waitForTimeout(200);
     await page.keyboard.press("Backspace");
-    await page.waitForTimeout(300);
-    numberOfEdges = await page.locator(".react-flow__edge").count();
-    expect(numberOfEdges).toBe(1);
+    await expect(page.locator(".react-flow__edge")).toHaveCount(1, {
+      timeout: 10000,
+    });
 
     await page.locator(".react-flow__edge").nth(0).click();
     await page.waitForTimeout(200);
     await page.keyboard.press("Backspace");
-    await page.waitForTimeout(300);
-    numberOfEdges = await page.locator(".react-flow__edge").count();
-    expect(numberOfEdges).toBe(0);
+    await expect(page.locator(".react-flow__edge")).toHaveCount(0, {
+      timeout: 10000,
+    });
 
     await tryConnectNodes(page);
 
@@ -130,10 +138,9 @@ test(
       )
       .click();
     await page.getByTestId("handle-chatoutput-shownode-inputs-left").click();
-    await page.waitForTimeout(300);
-    numberOfEdges = await page.locator(".react-flow__edge").count();
-
-    expect(numberOfEdges).toBe(3);
+    await expect(page.locator(".react-flow__edge")).toHaveCount(3, {
+      timeout: 10000,
+    });
   },
 );
 
@@ -141,50 +148,44 @@ async function tryConnectNodes(page: Page) {
   await lockFlow(page);
 
   const numberOfTries = 5;
-  let numberOfEdges = await page.locator(".react-flow__edge").count();
+  const edges = page.locator(".react-flow__edge");
 
+  // While locked, clicking source/target handles must NOT wire an edge. The
+  // clicks are expected to be inert (the locked canvas ignores them); wrap them
+  // so an inert/timed-out click doesn't abort the test. The assertion below is
+  // UNCONDITIONAL (not catch-only) so the "locked blocks connect" check runs
+  // deterministically whether or not the click throws (#909).
   for (let i = 0; i < numberOfTries; i++) {
-    try {
-      await page.getByTestId("handle-prompt-shownode-prompt-right").click({
-        timeout: 500,
-      });
-    } catch (_e) {
-      numberOfEdges = await page.locator(".react-flow__edge").count();
-      expect(numberOfEdges).toBe(0);
-    }
-
-    try {
-      await page
-        .getByTestId(
-          "handle-languagemodelcomponent-shownode-system message-left",
-        )
-        .click({
-          timeout: 500,
-        });
-    } catch (_e) {
-      numberOfEdges = await page.locator(".react-flow__edge").count();
-      expect(numberOfEdges).toBe(0);
-    }
+    await page
+      .getByTestId("handle-prompt-shownode-prompt-right")
+      .click({ timeout: 500 })
+      .catch(() => {});
+    await page
+      .getByTestId("handle-languagemodelcomponent-shownode-system message-left")
+      .click({ timeout: 500 })
+      .catch(() => {});
   }
+
+  // No edge may have been created while locked.
+  await expect(edges).toHaveCount(0, { timeout: 10000 });
   await unlockFlow(page);
 }
 
 async function tryDeleteEdge(page: Page) {
   await lockFlow(page);
 
-  let numberOfEdges = await page.locator(".react-flow__edge").count();
-  expect(numberOfEdges).toBe(3);
+  const edges = page.locator(".react-flow__edge");
+  await expect(edges).toHaveCount(3, { timeout: 10000 });
   const numberOfTries = 5;
 
-  // When locked, clicking edges and pressing delete should not remove them
+  // When locked, clicking edges and pressing delete should not remove them.
   for (let i = 0; i < numberOfTries; i++) {
     await page.locator(".react-flow__edge").nth(0).click();
     await page.waitForTimeout(200);
     await page.keyboard.press("Backspace");
     await page.waitForTimeout(200);
 
-    numberOfEdges = await page.locator(".react-flow__edge").count();
-    expect(numberOfEdges).toBe(3);
+    await expect(edges).toHaveCount(3, { timeout: 10000 });
   }
   await unlockFlow(page);
 }


### PR DESCRIPTION
## What

Fixes #909 — two defects in `lock-flow.spec.ts` (the second surfaced by force-fail).

### 1. Flake — racy edge-count asserts (the reported `expect toBe Object.is`)
The edge-count checks used `waitForTimeout(200-300)` + `.count()` + `toBe(N)`, which races the ReactFlow re-render under the daily's parallel load. Replaced with the polling `expect(locator).toHaveCount(N)` (retries until the canvas settles) in the delete-edges, reconnect, `tryDeleteEdge` and `tryConnectNodes` paths.

### 2. False lock-persist assertion (dead-assertion, #505 class)
The "lock persisted across reopen" check waited for `[data-testid="icon-lock"]`, but that per-node affordance renders on **every** flow regardless of lock state (confirmed live: present on an unlocked flow). So the test *"...must be saved"* passed even when the flow was **never locked**. Replaced with `expectLockState(page, "checked")` — a new helper in `helpers/flows/lock-flow.ts` that reads the Flow Settings lock switch `data-state`, the authoritative indicator. Also made `tryConnectNodes` assert `toHaveCount(0)` **unconditionally** (was catch-only → the locked-blocks-connect check could be silently skipped).

## Validation (nightly `1.12.0.dev3`, `--workers=1 --retries=0`)

- `npm run typecheck` ✓ · `npm run lint` 0 errors ✓.
- Multiple clean runs (~24s).
- **Force-fail — every assertion path proven falsifiable:** persist (no lock → switch `unchecked`), locked-can't-delete, locked-can't-connect, edge-delete count, reconnect count — all fail as expected under mutation; reverted; final green.
- 0 leaked orphans (id-scoped cleanup).

## Notes

- `@stable` kept (it was never auto-removed — the run was guard-tripped). The `@stable`-removal PR **#911** should be **closed** once this merges: the tag stays, so there is nothing to restore.

Closes #909
Refs #911

🤖 Generated with [Claude Code](https://claude.com/claude-code)
