### PR TITLE
test(flow-functionality): import outdated flow via UI upload surfaces outdated notification

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -616,7 +616,7 @@
 - [x] Export flow as JSON → `flow-functionality/export-import-flow.spec.ts`
 - [x] Exported JSON contains valid data.nodes structure → `flow-functionality/export-import-flow.spec.ts`
 - [x] Import flow via JSON file upload (drag-drop + upload button) → `flow-functionality/export-import-flow.spec.ts`
-- [~] Import flow with outdated components
+- [-] Import flow with outdated components → `flow-functionality/import-outdated-flow.spec.ts`
 - [x] Import invalid JSON — should display error message → `flow-functionality/import-invalid-json.spec.ts`
 
 #### 12.5 Flow Operations

--- a/docs/flow-functionality/import-outdated-flow.md
+++ b/docs/flow-functionality/import-outdated-flow.md
@@ -1,0 +1,146 @@
+# Import Flow with Outdated Components — UI Upload Path (§12.4 Export / Import Flow)
+
+**Last validated:** Langflow 1.12.x
+
+---
+
+## What this test validates *(required)*
+
+Validates that when a user imports a flow **through the real UI upload button**
+(`upload-project-button` → file chooser) and that flow contains components
+pinned to an old snapshot, Langflow (a) accepts the import cleanly — an outdated
+payload is still a valid, importable flow — and (b) surfaces the **outdated
+notification** once the imported flow is opened on the canvas.
+
+Concretely, uploading `tests/assets/flows/outdated_flow.json` (5 components
+pinned to a 1.4.0-era snapshot) yields:
+
+1. The **"uploaded successfully"** confirmation and a new flow card on the flows
+   page — the outdated content does not break the import ingestion itself.
+2. On opening the imported flow, the flow-level banner **"N components need
+   updates"** and the toolbar bulk CTA (`update-all-button`, labeled **"Review
+   All"** or **"Update All"**), exactly as the outdated diff is computed on open.
+
+If this breaks, a user importing a real (older) exported flow via the upload
+button would either see the import fail, or open a flow that silently drops its
+outdated state — no update prompt, so the user never learns the components are
+behind and cannot bring them current.
+
+**Why this is distinct from existing coverage (dedup).** The outdated
+notification itself, its per-node/banner count integrity, and the
+breaking-change Review flow are already covered by
+`core-components/outdated-component-notification.spec.ts` and
+`core-components/component-breaking-change-alert.spec.ts` — but those import the
+fixture **via the REST API** (deterministic setup, by design). The UI import
+path is covered by `flow-functionality/export-import-flow.spec.ts`, but only
+with a **current (non-outdated)** flow. No test drives **outdated content through
+the actual UI upload path**; that intersection is this spec's coverage point and
+the remaining §12.4 gap (`[~] Import flow with outdated components`).
+
+---
+
+## Tags *(required)*
+
+`@release` `@workspace` `@regression`
+
+Cross-cutting: `@release` (import is a happy-path flow), `@workspace` (flow
+management), `@regression` (guards the outdated-on-import behavior). Functional:
+covered by `@workspace` (Export/Import Flow, §12.4). Not `@stable` on
+introduction — promotion follows team validation per `CONTRIBUTING.md`.
+
+---
+
+## Step by step *(required)*
+
+Shared setup: bootstrap the app (`awaitBootstrapTest(page, { skipModal: true })`)
+and wait for `mainpage_title`. The flow this test creates is captured from its
+`POST /api/v1/flows` response and deleted id-scoped in `afterEach`
+(repo convention #490/#681 — never a global `cleanAllFlows`).
+
+1. Wait for `upload-project-button` to be visible on the flows page.
+2. Arm a `filechooser` capture, click `upload-project-button`, and feed
+   `tests/assets/flows/outdated_flow.json` (single-flow shape — has `data.nodes`,
+   no `flows[]` bundle — so it goes through the single-flow `uploadFlow` path).
+3. Capture the created flow's id from the `POST /api/v1/flows` response
+   (the UI upload mints a **fresh** id — verified live it does not reuse the
+   fixture's frozen `03bae731…`, so parallel uploads never collide on id).
+4. Assert the **"uploaded successfully"** message is visible — the outdated
+   payload was ingested without error.
+5. Open the imported flow deterministically by navigating to `/flow/<capturedId>`
+   (opening by captured id, not by the "Memory Chatbot" card, keeps the assertion
+   parallel-safe — the fixture's name is frozen, so multiple runs produce
+   same-named cards).
+6. Assert the flow-level outdated banner **"N components need updates"**
+   (count-agnostic regex) is visible.
+7. Assert the bulk CTA `update-all-button` is visible and reads **"Review All"**
+   or **"Update All"** (either — the breaking-vs-not distinction is the sibling
+   breaking-change spec's concern).
+
+---
+
+## Validation criterion *(required)*
+
+After importing `outdated_flow.json` via the `upload-project-button` file chooser
+and opening the imported flow by its captured id:
+
+- The **"uploaded successfully"** message appears (import accepted), AND
+- The flow-level banner matching `/\d+ components? needs? updates?/i` is visible,
+  AND
+- `update-all-button` is visible and matches `/Review All|Update All/`.
+
+Each assertion targets a single distinctive observable — no fuzzy OR-chain, no
+`.catch(() => false)` swallow, no "app didn't crash" tautology. Mutating the
+import (e.g. skipping the upload, or uploading a current flow with no outdated
+components) makes the banner assertion fail deterministically; removing the
+success assertion would let a rejected import pass silently.
+
+The count is asserted **count-agnostic** on purpose: the fixture's outdated total
+(5 on 1.12.0.dev3) is emergent from diffing its 1.4.0 snapshot against the
+running nightly and shifts as components evolve — pinning a literal would re-break
+on a benign version bump. The exact count and its per-node integrity are the
+sibling `outdated-component-notification.spec.ts`'s concern, not this spec's.
+
+---
+
+## External dependencies *(required)*
+
+- `data-testid="upload-project-button"` — the flows-page "Upload a flow" button
+  that opens the file chooser (single-flow upload path).
+- `data-testid="update-all-button"` — the toolbar bulk update/review CTA that
+  accompanies the outdated notification.
+- `data-testid="mainpage_title"` — flows page loaded marker.
+- `tests/assets/flows/outdated_flow.json` — shared frozen fixture (5 components on
+  a 1.4.0-era snapshot). Same fixture used by
+  `outdated-component-notification.spec.ts`.
+- No API key or provider required — the flow is never executed; only imported and
+  opened, and the outdated diff is a client-side computation on open.
+
+---
+
+## What this test does not cover *(optional)*
+
+- The outdated-notification count integrity (banner total == per-node indicators)
+  — covered by `core-components/outdated-component-notification.spec.ts`.
+- The breaking-change Review flow (Review action, disconnection warning, backup)
+  — covered by `core-components/component-breaking-change-alert.spec.ts`.
+- Actually applying the update (Update / Review All click and its result) —
+  covered by `core-components/update-component-action.spec.ts`.
+- The drag-and-drop import mechanism (`cards-wrapper` drop zone) — covered by
+  `flow-functionality/export-import-flow.spec.ts` and `import-invalid-json.spec.ts`.
+- Importing via the REST API (the deterministic setup the sibling specs use).
+
+---
+
+## Notes *(optional)*
+
+- **Observables verified live on 1.12.0.dev3** via `playwright-cli`: uploading
+  `outdated_flow.json` through `upload-project-button` left the app on `/flows`
+  with a new "Memory Chatbot" card (fresh id `c37ad69d…`, not the fixture's
+  frozen id); opening it showed "5 components need updates" + a "Review All"
+  button, with per-node `review-button` indicators present.
+- **Upload does not auto-open the flow** — the button adds the card and stays on
+  the flows page. The imported flow must be opened explicitly (here by captured
+  id) for the outdated diff to compute and the banner to render.
+- **Flow cleanup.** The imported flow is a real persisted flow — its id is
+  captured from the `POST /api/v1/flows` response and deleted id-scoped in
+  `afterEach` (#490/#681), so no "Memory Chatbot" orphan leaks across runs.

--- a/tests/tests-automations/regression/flow-functionality/import-outdated-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/import-outdated-flow.spec.ts
@@ -1,0 +1,109 @@
+import path from "path";
+import { expect, test } from "../../../fixtures/fixtures";
+import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+
+// Frozen fixture: a flow whose 5 components (Prompt, Chat Input, OpenAI, Chat
+// Output, Chat Memory) are pinned to a 1.4.0-era snapshot, old enough to resolve
+// to outdated updates on the current nightly. Shared with
+// core-components/outdated-component-notification.spec.ts — the outdated total is
+// emergent from diffing this snapshot against the nightly, so this spec asserts
+// the notification count-agnostically (the count integrity is that spec's job).
+const OUTDATED_FLOW = path.join(
+  __dirname,
+  "../../../assets/flows/outdated_flow.json",
+);
+
+// Ids of flows created by THIS page's own UI upload, captured from the
+// POST /api/v1/flows response and deleted id-scoped in afterEach (#490/#681) —
+// never a global cleanAllFlows that would wipe a concurrent worker's flow.
+const createdFlowIds: string[] = [];
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const headers = { Authorization: await getAuthToken(request) };
+  for (const id of createdFlowIds.splice(0)) {
+    // Best-effort per-flow so one failure does not abort the sweep.
+    await deleteFlow(request, id, { headers }).catch(() => {});
+  }
+});
+
+test(
+  "importing an outdated flow via the UI upload button surfaces the outdated notification on open",
+  { tag: ["@release", "@workspace", "@regression"] },
+  async ({ page }) => {
+    let importedFlowId: string | undefined;
+
+    await test.step("Bootstrap the flows page", async () => {
+      await awaitBootstrapTest(page, { skipModal: true });
+      await expect(page.getByTestId("mainpage_title")).toBeVisible({
+        timeout: 30000,
+      });
+    });
+
+    await test.step("Import the outdated fixture through the upload button", async () => {
+      await expect(page.getByTestId("upload-project-button").last()).toBeVisible(
+        { timeout: 10000 },
+      );
+
+      // Capture the created flow's id from the upload's POST response. The UI
+      // upload mints a FRESH id (verified live it does not reuse the fixture's
+      // frozen id), so this is parallel-safe and lets us open THIS run's flow by
+      // id rather than by the fixture's frozen "Memory Chatbot" card name.
+      const flowCreationPromise = page.waitForResponse(
+        (resp) =>
+          resp.url().includes("/api/v1/flows") &&
+          resp.request().method() === "POST" &&
+          resp.ok(),
+        { timeout: 30000 },
+      );
+
+      const fileChooserPromise = page.waitForEvent("filechooser", {
+        timeout: 10000,
+      });
+      await page.getByTestId("upload-project-button").last().click();
+      const fileChooser = await fileChooserPromise;
+      await fileChooser.setFiles(OUTDATED_FLOW);
+
+      const created = (await flowCreationPromise.then((r) => r.json())) as {
+        id?: string;
+      };
+      importedFlowId = created.id;
+      expect(
+        importedFlowId,
+        "upload POST /api/v1/flows must return the created flow id",
+      ).toBeTruthy();
+      createdFlowIds.push(importedFlowId as string);
+    });
+
+    await test.step("The outdated payload is ingested without error", async () => {
+      // The import mechanism accepts the outdated content — an old flow is still
+      // a valid, importable flow.
+      await expect(page.getByText("uploaded successfully")).toBeVisible({
+        timeout: 60000,
+      });
+    });
+
+    await test.step("Opening the imported flow raises the outdated notification", async () => {
+      // Open by captured id (deterministic; the card name is frozen and would be
+      // ambiguous under parallelism). The outdated diff computes on open.
+      await page.goto(`/flow/${importedFlowId}`);
+
+      // Flow-level banner. Count-agnostic (the fixture's outdated total is
+      // emergent from diffing its 1.4.0 snapshot against the nightly) — matches
+      // both the _one and _other i18n plurals.
+      await expect(
+        page.getByText(/\d+ components? needs? updates?/i),
+      ).toBeVisible({ timeout: 30000 });
+
+      // The toolbar bulk CTA that accompanies the notification. Its label is
+      // "Review All" when a breaking update is present and "Update All"
+      // otherwise; assert either so a benign breaking↔non-breaking flip does not
+      // false-fail (the breaking-vs-not distinction is a sibling spec's concern).
+      const updateAll = page.getByTestId("update-all-button");
+      await expect(updateAll).toBeVisible();
+      await expect(updateAll).toHaveText(/Review All|Update All/);
+    });
+  },
+);


### PR DESCRIPTION
## What this covers

Fills the §12.4 checklist gap **"Import flow with outdated components"** (was `[~]`). No existing test drives **outdated content through the real UI upload path**:

| Coverage | Import path | Flow |
|---|---|---|
| `outdated-component-notification.spec.ts` | REST API | outdated |
| `component-breaking-change-alert.spec.ts` | REST API | outdated |
| `update-component-action.spec.ts` | REST API | outdated |
| `export-import-flow.spec.ts` | **UI upload / drag-drop** | current |
| **this spec** | **UI upload** | **outdated** ← the gap |

## Test

`importing an outdated flow via the UI upload button surfaces the outdated notification on open` — uploads `outdated_flow.json` via `upload-project-button` (file chooser), captures the created flow id from `POST /api/v1/flows` (the UI mints a fresh id — parallel-safe), opens by id, and asserts:

- **"uploaded successfully"** (outdated payload ingested without error)
- flow-level banner `/\d+ components? needs? updates?/i` (count-agnostic)
- `update-all-button` visible, `/Review All|Update All/`

Count integrity (banner == per-node) and the update-apply flow are deliberately **not** duplicated here — owned by the sibling core-components specs.

## Validation

- Langflow **1.12.0.dev3** (Nightly), `--workers=1 --retries=0` → **1 passed (~6-8s)**
- `npm run typecheck` ✓ · `npm run lint` ✓ (0 warnings) · QA-CHECKLIST guard ✓
- **Force-fail (3/3 executed, all failed as expected, reverted):**
  - M1 (behavioral): upload a **current** flow → no outdated banner → assert fails (proves it tests outdated-ness, not always-true)
  - M2: break "uploaded successfully" → fails
  - M3: break `/Review All|Update All/` → fails
- Flow cleanup: id-scoped `afterEach`; **0 "Memory Chatbot" orphans** after runs
- Live scout: upload does not auto-open → flow opened by captured id; verified "5 components need updates" + "Review All"

Spec doc: `docs/flow-functionality/import-outdated-flow.md`. Not `@stable` on introduction (promotion follows team validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)