### PR TITLE
fix(playground): heal attachment-preview delete locator after 1.12 DOM change (#908)

### DIFF
--- a/docs/core-functionality/playground/playground-attachments-management.md
+++ b/docs/core-functionality/playground/playground-attachments-management.md
@@ -1,6 +1,6 @@
 # Playground — Chat Input Attachments Management
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.12.x
 
 ---
 
@@ -37,7 +37,7 @@ All five tests share the same setup: create a ChatInput → ChatOutput echo flow
 **Test 2 — remove one of two attachments leaves the other**
 
 1. Attach both images (as in Test 1).
-2. Click the delete button scoped to `chain.png` via `div:has(> img[alt="chain.png"]) button[aria-label="Delete file"]` (filename-targeted, no DOM-order assumption).
+2. Click the delete button scoped to `chain.png`, anchored on the image and walking up to the nearest ancestor tile that contains a `Delete file` button (`img[alt="chain.png"]` → `xpath=ancestor::div[.//button[@aria-label="Delete file"]][1]` → `getByLabel("Delete file")`), filename-targeted with no DOM-order assumption. **Drift note (#908):** the previous locator `div:has(> img[alt="chain.png"]) button[aria-label="Delete file"]` assumed the Delete button was a descendant of the image's *direct* parent; on 1.12 the preview markup moved the button up to the tile (2 levels above the image), so that selector matched nothing and the click timed out (20s). The image-anchored ancestor locator is class-independent, so a further Tailwind restyle of the tile will not re-break it.
 3. Assert `img[alt="chain.png"]` count is 0; `img[alt="chain-2.png"]` is visible; delete button count is 1.
 
 **Test 3 — send with two attachments renders both in the user message**

--- a/tests/tests-automations/regression/core-functionality/playground/playground-attachments-management.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-attachments-management.spec.ts
@@ -24,6 +24,18 @@ const previewDeleteButton = (page: Page) =>
     '[data-testid="input-wrapper"] button[aria-label="Delete file"]',
   );
 
+// The Delete button for a SPECIFIC image's preview. On 1.12 the preview markup
+// changed: the "Delete file" button is no longer a descendant of the img's
+// direct parent (the old `div:has(> img[alt="…"]) button` matched nothing and
+// the click timed out — #908). Anchor on the img and walk up to the nearest
+// ancestor tile that actually contains a Delete button, then that button —
+// class-independent, so a Tailwind restyle of the tile cannot re-break it.
+const previewDeleteButtonFor = (page: Page, fileName: string) =>
+  page
+    .locator(`[data-testid="input-wrapper"] img[alt="${fileName}"]`)
+    .locator('xpath=ancestor::div[.//button[@aria-label="Delete file"]][1]')
+    .getByLabel("Delete file");
+
 test.describe("Playground — Chat Input Attachments Management", () => {
   test.describe.configure({ mode: "serial" });
 
@@ -91,11 +103,7 @@ test.describe("Playground — Chat Input Attachments Management", () => {
       await test.step(
         "Remove the chain.png preview via its X button",
         async () => {
-          await page
-            .locator(
-              '[data-testid="input-wrapper"] div:has(> img[alt="chain.png"]) button[aria-label="Delete file"]',
-            )
-            .click();
+          await previewDeleteButtonFor(page, "chain.png").click();
         },
       );
 


### PR DESCRIPTION
Closes #908

## Verdict: DOM drift (product), not saturation

`playground-attachments-management.spec.ts:78` ("keep the remaining preview when one of two attachments is removed") hard-failed with `locator.click: Timeout 20000ms exceeded`. Reproduced **3/3 at `--workers=1` isolated** (no parallel load) — so it is **not** the single-backend saturation cluster the triage flagged as a possibility; it is deterministic.

Root cause: on 1.12 the preview markup moved the `Delete file` button up to the **tile ancestor** (2 levels above the `<img>`). The test's locator `div:has(> img[alt="chain.png"]) button[aria-label="Delete file"]` assumed the button was a descendant of the image's **direct** parent, so it matched **nothing** and the click timed out. Only this test (remove one-of-two → needs the file-specific button) was affected; the other four use the single-button locator and pass.

## Fix

New helper `previewDeleteButtonFor(page, fileName)` — anchor on the image and walk up to the nearest ancestor tile that contains a Delete button:
```
img[alt="<file>"] → xpath=ancestor::div[.//button[@aria-label="Delete file"]][1] → getByLabel("Delete file")
```
Class-independent, so a further Tailwind restyle of the tile cannot re-break it. Only `:78` changed. Spec doc updated (`Last validated: 1.12.x` + drift note).

## Validation (1.12.0.dev3)

- Full file **5 passed (~37s)** at `--workers=1 --retries=0`
- typecheck ✓ · lint ✓ (0 warnings)
- Before fix: `:78` failed **3/3** at `--workers=1`; after: green
- **Force-fail (1/1, reverted):** pointing the delete at the wrong file (`"chain-2.png"`) leaves `chain.png` present → `previewImage("chain.png").toHaveCount(0)` **fails** — proving the locator targets the correct file
- 0 flow orphans (`afterEach` deletes the created flow); `@stable` kept

## Run

```bash
PLAYWRIGHT_BASE_URL="http://localhost:7860/" \
npx playwright test tests/tests-automations/regression/core-functionality/playground/playground-attachments-management.spec.ts --workers=1 --retries=0
```
Expected: **5 passed (~37s)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)