### PR TITLE
fix(core-components): harden table-field add-row against dropped click (#868)

### DIFF
--- a/docs/core-components/parameters-panel-field-types.md
+++ b/docs/core-components/parameters-panel-field-types.md
@@ -2,7 +2,7 @@
 
 **Test file:** `tests/tests-automations/regression/core-components/parameters-panel-field-types.spec.ts`
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x
 
 ---
 
@@ -65,7 +65,7 @@ matches what a reload would load.
 | 6 | Edit toggle field | `BoolInput` | Save File | `append_mode` | click `toggle_bool_append_mode` | phase 1 ✓ |
 | 7 | Edit slider | `SliderInput` | Language Model | `temperature` | click `slider_thumb` + `ArrowRight` | **phase 2 (this PR)** |
 | 8 | Edit code field | `CodeInput` | Python Function *(legacy)* | `function_code` | open `codearea_code_function_code` → set ACE value → `checkAndSaveBtn` | **phase 3 (this PR)** |
-| 9 | Edit table input | `TableInput` | API Request | `headers` *(advanced)* | show-or-reveal `div-table_headers` → settle (method→POST refresh) → Open table → `add-row-button` → fill key/value cells | **phase 3 (this PR)** |
+| 9 | Edit table input | `TableInput` | API Request | `headers` *(advanced)* | show-or-reveal `div-table_headers` → settle (method→POST refresh) → Open table → `add-row-button` (retried until the row lands) → fill key/value cells | **phase 3**; flake-hardened #868 |
 | 10 | Edit key-pair list | `NestedDictInput` | Alter Metadata *(legacy)* | `metadata` | `dict_nesteddict_metadata` → Edit Dictionary (text mode) → fill JSON → Save | **phase 3 (this PR)** |
 | 11 | Edit input list | `SortableListInput` | Read File | `storage_location` *(advanced)* | show-or-reveal the field → remove Local → `button_open_list_selection_…` → `list_item_aws` | deferred (build-divergent) |
 | 12 | Edit float field | `FloatInput` | Semantic Text Splitter | `breakpoint_threshold_amount` | fill `float_float_breakpoint_threshold_amount` | **phase 2 (this PR)** |

--- a/tests/tests-automations/regression/core-components/parameters-panel-field-types.spec.ts
+++ b/tests/tests-automations/regression/core-components/parameters-panel-field-types.spec.ts
@@ -409,7 +409,7 @@ test.describe("Parameters Panel — field-type edit matrix", () => {
 
   test(
     "table field edit persists",
-    { tag: ["@components", "@regression"] },
+    { tag: ["@stable", "@components", "@regression"] },
     async ({ page, request }) => {
       const bearer = await getAuthToken(request);
       const flowId = await openFlowWithComponent(
@@ -446,8 +446,16 @@ test.describe("Parameters Panel — field-type edit matrix", () => {
       await expect(dialog).toBeVisible({ timeout: 10000 });
       const dataRows = dialog.locator('[role="treegrid"] [role="row"][row-id]');
       await expect(dataRows).toHaveCount(1, { timeout: 10000 });
-      await dialog.getByTestId("add-row-button").click();
-      await expect(dataRows).toHaveCount(2, { timeout: 5000 });
+      // The grid can drop the add-row click while its TableNodeComponent effects
+      // are still settling (#868), so the row count stays 1. Retry the click only
+      // while the row has not appeared (the count<2 guard prevents a late-
+      // registering click from adding a second, overshooting row).
+      await expect(async () => {
+        if ((await dataRows.count()) < 2) {
+          await dialog.getByTestId("add-row-button").click();
+        }
+        await expect(dataRows).toHaveCount(2, { timeout: 3000 });
+      }).toPass({ timeout: 15000 });
 
       const newRow = dataRows.last();
       await fillTableTextCell(


### PR DESCRIPTION
Closes #868

## Verdict: ag-grid interaction race, not saturation

`parameters-panel-field-types.spec.ts` "table field edit persists" flaked **~33% (4/6) at `--workers=1` isolated** (no parallel load), and it also failed on the near-clean **07-21** daily (3 hard failures, guard not tripped) — so it is **not** the single-backend saturation cluster the triage flagged as a possibility.

Root cause: the ag-grid `add-row-button` click is **dropped** while the API Request `TableNodeComponent`'s `[value]` effects are still settling. Two manifestations, one root:
- (a) the row count stays 1 → `expect(dataRows).toHaveCount(2)` fails;
- (b) the row is only half-registered and its cell edits never persist → the API poll `toBe(true)` fails.

## Fix (directive option c — harden the interaction)

Retry the add-row click inside a `toPass` until the grid reflects the second row, **guarded by `count < 2`** so a late-registering click cannot add an overshooting third row (same pattern as lock-flow's `setLockState`):

```ts
await expect(async () => {
  if ((await dataRows.count()) < 2) {
    await dialog.getByTestId("add-row-button").click();
  }
  await expect(dataRows).toHaveCount(2, { timeout: 3000 });
}).toPass({ timeout: 15000 });
```

`@stable` **restored** (removed at triage as prevention). Spec doc updated (`Last validated: 1.12.x` + flake-hardening note).

## Validation (1.12.0.dev3)

- **12/12 consecutive clean** at `--workers=1 --retries=0` (was **4/6** before the fix)
- typecheck ✓ · lint ✓ (0 errors)
- 0 flow orphans (spec teardown cleans the created flow)
- **Force-fail (1/1, reverted):** changing the persisted-key assertion to a never-filled value (`"NEVER-FILLED-FF"`) fails the poll — proving the persistence check still catches a real regression

## Run

```bash
PLAYWRIGHT_BASE_URL="http://localhost:7860/" \
npx playwright test tests/tests-automations/regression/core-components/parameters-panel-field-types.spec.ts --grep "table field edit persists" --workers=1 --retries=0
```
Expected: **1 passed (~12s)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)