### PR TITLE
fix(migration): select an executable witness flow + tolerate auto-imported key (#905)

### DIFF
--- a/tests/github-workflows/migration/helpers.py
+++ b/tests/github-workflows/migration/helpers.py
@@ -49,36 +49,109 @@ def get_starter_projects(token: str) -> list:
     return r.json()
 
 
-def find_agent_template(starter_projects: list) -> dict | None:
-    """Find 'Simple Agent' or similar agent template.
+# Node types that need an external input (a file, a vector store, a URL, …) to
+# build — a witness flow containing any of these cannot execute headlessly from a
+# plain chat message, so it is unusable as a migration baseline (it fails with
+# "No files to process" / a missing connection rather than proving the migration).
+_DATA_SOURCE_TYPES = {
+    "File",
+    "AstraDB",
+    "SplitText",
+    "URLComponent",
+    "OpenAIEmbeddings",
+    "AstraDBToolComponent",
+}
 
-    Tries top-level name first; falls back to inspecting node display_names
-    (Langflow latest returns starter projects with name=null at top level).
+# Model components whose model must be selected for the flow to build.
+_MODEL_TYPES = {"OpenAIModel", "LanguageModelComponent"}
+
+
+def _node_types(project: dict) -> list:
+    return [
+        n.get("data", {}).get("type", "")
+        for n in (project.get("data") or {}).get("nodes", [])
+    ]
+
+
+def find_agent_template(starter_projects: list) -> dict | None:
+    """Pick an executable witness flow for the migration baseline.
+
+    Historically this looked for a 'Simple Agent' starter, but Langflow latest
+    (1.10.x) ships no agent starter and returns projects with name=null, so the
+    old fallback ("first project with data") non-deterministically landed on a
+    flow that cannot execute headlessly — a RAG flow whose `Read File` has no
+    file, or a `Language Model` flow with no model selected — failing the
+    baseline (#905). The witness only needs to be a simple, executable chat flow
+    that survives migration, so prefer that shape explicitly.
     """
-    # Pass 1: top-level name match
+    def is_simple_chat_flow(project: dict) -> bool:
+        types = _node_types(project)
+        if not types:
+            return False
+        # Must have a model component and NO external-input data source.
+        has_model = any(t in _MODEL_TYPES for t in types)
+        has_data_source = any(t in _DATA_SOURCE_TYPES for t in types)
+        return has_model and not has_data_source
+
+    # Pass 0: an agent starter by name (kept for builds that ship one).
     for project in starter_projects:
         name = (project.get("name") or "").lower()
         if "simple agent" in name or "basic agent" in name:
             return project
+
+    # Pass 1: a simple, executable chat flow (model + no external data source).
+    for project in starter_projects:
+        if is_simple_chat_flow(project):
+            return project
+
+    # Pass 2: any agent-named starter.
     for project in starter_projects:
         name = (project.get("name") or "").lower()
         if "agent" in name:
             return project
 
-    # Pass 2: inspect node display_names inside data
-    for project in starter_projects:
-        nodes = (project.get("data") or {}).get("nodes", [])
-        for node in nodes:
-            display = (node.get("data", {}).get("node", {}).get("display_name") or "").lower()
-            if "agent" in display:
-                return project
-
-    # Pass 3: any project that has flow data
+    # Pass 3: any project that has flow data (last resort).
     for project in starter_projects:
         if project.get("data"):
             return project
 
     return None
+
+
+def ensure_model_selected(
+    template: dict,
+    model: str = "gpt-4o-mini",
+    provider: str = "OpenAI",
+    api_key_var: str = "OPENAI_API_KEY",
+) -> list:
+    """Patch model components so the witness flow can build.
+
+    A starter's model component may ship with an empty `model_name` / `provider`
+    (the unified `LanguageModelComponent` on latest requires an explicit
+    selection — otherwise the build fails with "A model selection is required",
+    #905). Fill any empty model field in place so the flow is executable. Returns
+    the list of node types that were patched (for reporting). Non-empty fields
+    (e.g. `OpenAIModel` shipping `gpt-4o-mini`) are left untouched.
+    """
+    patched = []
+    for node in (template.get("data") or {}).get("nodes", []):
+        data = node.get("data", {})
+        if data.get("type") not in _MODEL_TYPES:
+            continue
+        tmpl = data.get("node", {}).get("template", {})
+        changed = False
+        if "provider" in tmpl and not tmpl["provider"].get("value"):
+            tmpl["provider"]["value"] = provider
+            changed = True
+        if "model_name" in tmpl and not tmpl["model_name"].get("value"):
+            tmpl["model_name"]["value"] = model
+            changed = True
+        if "api_key" in tmpl and not tmpl["api_key"].get("value"):
+            tmpl["api_key"]["value"] = api_key_var
+            changed = True
+        if changed:
+            patched.append(data.get("type"))
+    return patched
 
 
 def create_flow(token: str, template: dict) -> dict:

--- a/tests/github-workflows/migration/setup_latest.py
+++ b/tests/github-workflows/migration/setup_latest.py
@@ -7,9 +7,11 @@ import time
 from helpers import (
     create_flow,
     create_variable,
+    ensure_model_selected,
     find_agent_template,
     get_auth_token,
     get_starter_projects,
+    list_variables,
     run_flow_safe,
     save_state,
     load_state,
@@ -40,8 +42,25 @@ def main():
         save_state(state)
         sys.exit(1)
 
-    print(f"   Using template: {template['name']}")
-    phase["steps"]["find_template"] = {"status": "pass", "template_name": template["name"]}
+    template_name = template.get("name") or "Migration Test Agent"
+    node_types = [
+        n.get("data", {}).get("type", "")
+        for n in (template.get("data") or {}).get("nodes", [])
+    ]
+    print(f"   Using template: {template_name} (nodes: {node_types})")
+    phase["steps"]["find_template"] = {
+        "status": "pass",
+        "template_name": template_name,
+        "node_types": node_types,
+    }
+
+    # 2b. Ensure the model component has a model selected. A starter may ship an
+    # empty model_name/provider (the unified Language Model requires an explicit
+    # selection — otherwise the build fails "A model selection is required", #905).
+    patched = ensure_model_selected(template)
+    phase["steps"]["ensure_model"] = {"status": "pass", "patched_nodes": patched}
+    if patched:
+        print(f"   Patched empty model selection on: {patched}")
 
     # 3. Create flow from template
     print("── Creating flow...")
@@ -51,17 +70,33 @@ def main():
     print(f"   Created flow: {flow_name} (id={flow_id})")
     phase["steps"]["create_flow"] = {"status": "pass", "flow_id": flow_id, "flow_name": flow_name}
 
-    # 4. Create OPENAI_API_KEY variable
+    # 4. Ensure the OPENAI_API_KEY variable exists. Since v1.5 Langflow
+    # auto-imports the OPENAI_API_KEY env var as a global Credential on startup,
+    # so creating it again returns 400 "already exists" (#905). Treat an existing
+    # variable as success instead of a warning.
     openai_key = os.environ.get("OPENAI_API_KEY", "")
     if openai_key:
-        print("── Creating OPENAI_API_KEY variable...")
-        try:
-            var = create_variable(token, "OPENAI_API_KEY", openai_key)
-            phase["steps"]["create_variable"] = {"status": "pass", "variable_id": var.get("id")}
-            print("   OK")
-        except Exception as e:
-            print(f"   WARNING: Could not create variable: {e}")
-            phase["steps"]["create_variable"] = {"status": "warn", "detail": str(e)[:200]}
+        print("── Ensuring OPENAI_API_KEY variable...")
+        if any(v.get("name") == "OPENAI_API_KEY" for v in list_variables(token)):
+            print("   Already present (auto-imported as a Credential on startup)")
+            phase["steps"]["create_variable"] = {
+                "status": "pass",
+                "detail": "auto-imported",
+            }
+        else:
+            try:
+                var = create_variable(token, "OPENAI_API_KEY", openai_key)
+                phase["steps"]["create_variable"] = {
+                    "status": "pass",
+                    "variable_id": var.get("id"),
+                }
+                print("   Created")
+            except Exception as e:
+                print(f"   WARNING: Could not create variable: {e}")
+                phase["steps"]["create_variable"] = {
+                    "status": "warn",
+                    "detail": str(e)[:200],
+                }
     else:
         print("── OPENAI_API_KEY not set, skipping variable creation")
         phase["steps"]["create_variable"] = {"status": "skip", "detail": "No OPENAI_API_KEY env var"}


### PR DESCRIPTION
Closes #905

## Verdict: harness defect, NOT a product regression

The migration test's phase-1 baseline failed on `langflowai/langflow:latest` (1.10.3) with `HTTP 500: "Error building Component Language Model: A model selection is required"`. Every Langflow behavior it tripped over is **intended**, not a bug — the failure is a fragile test harness.

| latest behavior | nature |
|---|---|
| Language Model component requires an explicit model selection | correct (can't build a model without picking one) |
| `OPENAI_API_KEY` auto-imported as a Credential (v1.5+) → recreating 400s | intended feature |
| No "Agent" starter on 1.10.3 (only Basic Prompting / RAG) | product state |

## Root cause (3)

1. `find_agent_template` fell through to Pass 3 ("first project with data"); starter order is not guaranteed, so it **non-deterministically** picked a non-executable witness — a Language Model flow with empty `model_name`, or a RAG/File flow whose `Read File` has no file.
2. The picked template carried no model selection.
3. `create_variable("OPENAI_API_KEY")` conflicted with the auto-imported credential.

## Fix (harness only — masks no product behavior)

- `find_agent_template` now prefers a **simple, executable chat flow** (has a model component, **no** external-input data source: File / AstraDB / URL / SplitText / Embeddings) — deterministic regardless of starter order. Agent-name passes kept for builds that ship one.
- New `ensure_model_selected()` fills any empty `model_name` / `provider` / `api_key` on the model component (what a user would pick in the UI) as a safety net.
- `setup_latest` treats an already-present (auto-imported) `OPENAI_API_KEY` variable as success, not a warning.

## Validation (against `langflowai/langflow:latest` = 1.10.3, run locally)

- `find_agent_template` selects `[ChatInput, ChatOutput, OpenAIModel, Prompt Template]` (Basic Prompting) — no longer the RAG/File flow
- the selected witness **executes HTTP 200** (was 500)
- `ensure_model_selected` is a no-op here (OpenAIModel already ships `gpt-4o-mini`) — safety net confirmed
- `py_compile` clean on both files

**Infra caveat:** the full docker-compose Postgres migration cannot run locally — I validated the phase-1 core (witness selection + patch + execution) against the real `latest` image. **Final proof = a re-run of `migration-test.yml`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)