### PR TITLE
fix(flow-editor): open node ⋮ menu via dispatchEvent to avoid ReactFlow pane deselect (#867)

### DIFF
--- a/tests/helpers/ui/expand-focused-node.ts
+++ b/tests/helpers/ui/expand-focused-node.ts
@@ -8,10 +8,15 @@ import { dismissOnboardingIfPresent } from "./dismiss-onboarding";
 // (no `hide-node-content` in the DOM) this is a no-op, which future-proofs callers
 // against an upstream change to the `minimized` default.
 //
-// The `more-options-modal` menu can fail to render on the first click when the
-// single Langflow backend is under load — many flow-builds in one session degrade
-// it (issue #816/#817), so the menu-open is retried before failing instead of
-// timing out on `expand-button-modal`.
+// The `more-options-modal` (⋮) menu that hosts the expand action lives in a
+// floating ReactFlow NodeToolbar and only mounts for the SELECTED node. On 1.12 a
+// REAL coordinate click on that ⋮ button is hit-tested by the ReactFlow pane and
+// DESELECTS the node — which unmounts the toolbar and destroys the Radix menu as
+// it opens, so the expand item never appears (issue #867: reproduced at
+// `--workers=1` with no backend load — a UI-interaction defect, not the earlier
+// backend-saturation theory of #816/#817; deselection confirmed via
+// instrumentation). The fix dispatches the pointer events directly on the ⋮
+// element (see the retry below) so the pane never sees a coordinate hit.
 export async function expandFocusedNode(page: Page): Promise<void> {
   // The dev46 assistant-onboarding dialog opens over the flow editor on entry and
   // its overlay steals node selection / intercepts canvas clicks, so the node
@@ -20,18 +25,35 @@ export async function expandFocusedNode(page: Page): Promise<void> {
 
   if ((await page.getByTestId("hide-node-content").count()) === 0) return;
 
-  // Drive open-menu → expand → settle as ONE retried unit. Under backend load the
-  // menu can fail to open OR the expand click can be dropped mid-transition; when
-  // that happens the node stays minimized (`hide-node-content` lingers), so we
-  // re-drive the whole sequence rather than retrying only the menu-open. `toPass`
+  const minimizedNode = page
+    .locator('.react-flow__node:has([data-testid="hide-node-content"])')
+    .first();
+  const moreOptions = page.getByTestId("more-options-modal");
+  const expandButton = page.getByTestId("expand-button-modal");
+
+  // Drive re-select → open-menu → expand → settle as ONE retried unit. `toPass`
   // re-runs the body until the node has actually left the minimized state,
   // replacing the manual attempt loop + fixed `waitForTimeout` (Playwright
   // anti-patterns) with a web-first assertion. The onboarding dialog can reappear
   // a beat after mount, so it is re-dismissed inside the retry.
   await expect(async () => {
     await dismissOnboardingIfPresent(page);
-    await page.getByTestId("more-options-modal").click({ timeout: 5000 });
-    await page.getByTestId("expand-button-modal").click({ timeout: 5000 });
+    // A prior retry may already have expanded the node — nothing minimized left.
+    if ((await minimizedNode.count()) === 0) return;
+    // The ⋮ toolbar mounts only for the selected node; re-select it (a real click
+    // on the node BODY, which lives in the pane, selects correctly) if the toolbar
+    // is gone. This is the recovery for a selection genuinely lost before entry.
+    if ((await moreOptions.count()) === 0) {
+      await minimizedNode.click();
+    }
+    // Open the ⋮ menu by DISPATCHING the pointer events on the trigger element
+    // rather than issuing a real coordinate click — a real click deselects the
+    // node via the ReactFlow pane and destroys the menu (see the header comment,
+    // issue #867). Dispatching directly opens the Radix menu with selection intact.
+    await moreOptions.dispatchEvent("pointerdown");
+    await moreOptions.dispatchEvent("pointerup");
+    await moreOptions.dispatchEvent("click");
+    await expandButton.click({ timeout: 5000 });
     await expect(page.getByTestId("hide-node-content")).toHaveCount(0, {
       timeout: 5000,
     });

--- a/tests/tests-automations/regression/core-functionality/playground/output-modal-copy-button.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/output-modal-copy-button.spec.ts
@@ -1,24 +1,7 @@
-import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
-
-// Expand the currently focused node from minimized to full view. Chat Input
-// defaults to `minimized = True` (see lfx/components/input_output/chat.py);
-// without expanding, the run button and inspector fields rendered on the node
-// body are not present in the DOM. Idempotent: if the node is already expanded
-// (no `hide-node-content` in the DOM) the helper is a no-op.
-async function expandFocusedNode(page: Page) {
-  if ((await page.getByTestId("hide-node-content").count()) === 0) return;
-  await page.getByTestId("more-options-modal").click();
-  await expect(page.getByTestId("expand-button-modal")).toBeVisible({
-    timeout: 10000,
-  });
-  await page.getByTestId("expand-button-modal").click();
-  await expect(page.getByTestId("hide-node-content")).toHaveCount(0, {
-    timeout: 5000,
-  });
-}
+import { expandFocusedNode } from "../../../../helpers/ui/expand-focused-node";
 
 test.describe("Output Modal — Copy Button", () => {
   test.describe.configure({ mode: "serial" });

--- a/tests/tests-automations/regression/ui-ux/notifications.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/notifications.spec.ts
@@ -1,68 +1,78 @@
-import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { expandFocusedNode } from "../../../helpers/ui/expand-focused-node";
 
-// Expand the currently focused node from minimized to full view. Chat Input
-// defaults to `minimized = True`; without expanding, the run button rendered on
-// the node body is not present in the DOM. Idempotent: if the node is already
-// expanded (no `hide-node-content` in the DOM) the helper is a no-op.
-async function expandFocusedNode(page: Page) {
-  if ((await page.getByTestId("hide-node-content").count()) === 0) return;
-  await page.getByTestId("more-options-modal").click();
-  await expect(page.getByTestId("expand-button-modal")).toBeVisible({
-    timeout: 10000,
+test.describe("Notifications tab", () => {
+  let createdFlowId: string | null = null;
+
+  test.afterEach(async ({ page }) => {
+    if (createdFlowId) {
+      // Navigate home first so pending polling GETs for the flow settle before
+      // the DELETE, avoiding spurious 404 fixture errors.
+      await page.goto("/");
+      await deleteFlow(page.request, createdFlowId);
+      createdFlowId = null;
+    }
   });
-  await page.getByTestId("expand-button-modal").click();
-  await expect(page.getByTestId("hide-node-content")).toHaveCount(0, {
-    timeout: 5000,
-  });
-}
 
-test(
-  "User should be able to interact notifications tab",
-  { tag: ["@stable", "@release", "@ui-ux"] },
-  async ({ page }) => {
-    await awaitBootstrapTest(page);
-    await page.getByTestId("blank-flow").click();
+  test(
+    "User should be able to interact notifications tab",
+    { tag: ["@stable", "@release", "@ui-ux"] },
+    async ({ page }) => {
+      await awaitBootstrapTest(page);
 
-    // Add a Chat Input and run it to produce a "Flow built successfully"
-    // notification. Text Input (the original trigger) is `legacy` on 1.10.0 and
-    // hidden from the sidebar — Chat Input is the durable equivalent.
-    await page.getByTestId("sidebar-search-input").fill("chat input");
-    await page
-      .getByTestId("input_outputChat Input")
-      .hover()
-      .then(async () => {
-        await page.getByTestId("add-component-button-chat-input").click();
+      // Capture the blank flow's id so afterEach can delete it id-scoped.
+      const flowCreationPromise = page.waitForResponse(
+        (resp) =>
+          resp.url().includes("/api/v1/flows") &&
+          resp.request().method() === "POST" &&
+          resp.status() === 201,
+        { timeout: 15000 },
+      );
+      await page.getByTestId("blank-flow").click();
+      const creationResponse = await flowCreationPromise;
+      createdFlowId = (await creationResponse.json()).id ?? null;
+
+      // Add a Chat Input and run it to produce a "Flow built successfully"
+      // notification. Text Input (the original trigger) is `legacy` on 1.10.0 and
+      // hidden from the sidebar — Chat Input is the durable equivalent.
+      await page.getByTestId("sidebar-search-input").fill("chat input");
+      await page
+        .getByTestId("input_outputChat Input")
+        .hover()
+        .then(async () => {
+          await page.getByTestId("add-component-button-chat-input").click();
+        });
+      await expect(page.locator(".react-flow__node")).toHaveCount(1, {
+        timeout: 10000,
       });
-    await expect(page.locator(".react-flow__node")).toHaveCount(1, {
-      timeout: 10000,
-    });
 
-    // Chat Input is added minimized — expand it so the run button is in the DOM.
-    await page.getByTestId("title-Chat Input").click();
-    await expandFocusedNode(page);
+      // Chat Input is added minimized — expand it so the run button is in the DOM.
+      await page.getByTestId("title-Chat Input").click();
+      await expandFocusedNode(page);
 
-    await page.getByTestId("button_run_chat input").click();
-    await expect(page.getByText("built successfully").last()).toBeVisible({
-      timeout: 30000,
-    });
+      await page.getByTestId("button_run_chat input").click();
+      await expect(page.getByText("built successfully").last()).toBeVisible({
+        timeout: 30000,
+      });
 
-    await page.getByTestId("notification_button").click();
+      await page.getByTestId("notification_button").click();
 
-    await test.step("notifications tab shows the build-success entry", async () => {
-      const notificationsText = page
-        .getByText("Notifications", { exact: true })
-        .last();
-      await expect(notificationsText).toBeVisible({ timeout: 10000 });
+      await test.step("notifications tab shows the build-success entry", async () => {
+        const notificationsText = page
+          .getByText("Notifications", { exact: true })
+          .last();
+        await expect(notificationsText).toBeVisible({ timeout: 10000 });
 
-      const trashIcon = page.getByTestId("icon-Trash2").last();
-      await expect(trashIcon).toBeVisible();
+        const trashIcon = page.getByTestId("icon-Trash2").last();
+        await expect(trashIcon).toBeVisible();
 
-      const builtSuccessfullyText = page
-        .getByText("Flow built successfully", { exact: true })
-        .last();
-      await expect(builtSuccessfullyText).toBeVisible();
-    });
-  },
-);
+        const builtSuccessfullyText = page
+          .getByText("Flow built successfully", { exact: true })
+          .last();
+        await expect(builtSuccessfullyText).toBeVisible();
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #867

## Problem
`expandFocusedNode` flaked ~50% (daily #864) opening a minimized node's `more-options-modal` (⋮) menu. Prior theories (backend saturation #816/#817, then "re-select node") were incomplete.

## Root cause (instrumented, 1.12.0.dev3, reproduced at `--workers=1`)
The ⋮ button lives in a floating **ReactFlow NodeToolbar**. A **real coordinate `.click()`** on it is hit-tested by the ReactFlow **pane** on 1.12 → **deselects the node** (`sel=0 more=0` confirmed via instrumentation) → unmounts the toolbar → destroys the Radix menu as it opens, so `expand-button-modal` never appears. The "waiting for more-options-modal" symptom was just the next retry after the deselect.

Ruled out by instrumentation: zoom (⋮ fixed 53×53), onboarding (`onb=0`), overlay (`elementFromPoint` = the ⋮ itself), selection-recency (500ms settle didn't help), keyboard (`focus+Enter` keeps selection but Radix won't open).

## Fix
Dispatch pointer events directly on the ⋮ element instead of a coordinate click:
```ts
await moreOptions.dispatchEvent("pointerdown");
await moreOptions.dispatchEvent("pointerup");
await moreOptions.dispatchEvent("click");
```
The pane never sees a coordinate hit, selection holds, and the Radix menu opens reliably. A guarded `minimizedNode.click()` re-select remains only as recovery when the ⋮ is genuinely absent (a real click on the node **body**, which lives in the pane, selects correctly — only the portaled toolbar button has the deselect problem).

## Scope
- **3 specs** import the shared helper (chat-input-output, chat-input-files, if-else) — fixed transitively.
- **2 specs** carried a local buggy copy of the helper (output-modal-copy-button, notifications) — folded into the shared import.
- Added id-scoped `afterEach` cleanup to notifications (was leaking a "New Flow" per run).
- `@stable` on the historically-flaky tests was already present (no restore needed; #910 was closed unmerged).

## Validation (langflow-nightly 1.12.0.dev3)
Bursts `--workers=1 --retries=0`, all green:
- chat-input-output: 6 passed ×3
- chat-input-files: 4 passed ×3
- if-else: 11 passed ×2
- output-modal-copy: 1 passed ×2
- notifications: 1 passed ×2 (leaves no orphan flow)

**Force-fail:** helper mutated to a no-op → all 5 specs failed their downstream asserts (run button / handles / build-success) → reverted, 0 markers left.

Gates: `tsc --noEmit` 0 errors, ESLint 0 errors, Prettier clean.

## Note (out of scope)
The other blank-flow specs (chat-input-output, chat-input-files, if-else) also leak "New Flow" orphans — a pre-existing systemic cleanup gap, candidate for a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)