### PR TITLE
ci(pr-validation): cap impacted-specs Langflow service container to LANGFLOW_WORKERS=1 (#922)

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -111,6 +111,14 @@ jobs:
           LANGFLOW_AUTO_LOGIN: "true"
           LANGFLOW_SUPERUSER: langflow
           LANGFLOW_SUPERUSER_PASSWORD: langflow123
+          # Cap the backend to one worker. Langflow's image default is (2*cpu)+1
+          # workers, each holding full in-memory state; under the collect-models
+          # load on the runner they contend until requests hang, and the
+          # impacted-specs preflight then times out on /api/v1/version after
+          # collect-models succeeds (#922, blocked #867). The launch scripts
+          # already default LANGFLOW_WORKERS=1 for this reason (#773) — the
+          # service container was the one place missing it.
+          LANGFLOW_WORKERS: "1"
           # Nightly image defaults LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false
           # (custom-component creation disabled → sidebar button hidden, API
           # 403). Enable it so the custom-component specs exercise the feature.


### PR DESCRIPTION
Closes #922

## Problem
`pr-validation.yml` → **Run impacted E2E specs** fails at globalSetup preflight (`GET /api/v1/version` hangs 30s) even though the prior **Collect models** step succeeds. Container logs show Langflow serving `/api/v1/models` right up to the preflight window, then stops responding — the backend is **saturated, not crashed**. Reproduced 3× on PR #921 (#867 fix).

## Root cause
The service container ran with the image default `(2*cpu)+1` workers, each holding full in-memory state; under collect-models load on the runner they contend until requests hang (#773). The launch scripts (`start-langflow-docker.sh`, `start-langflow-pip.sh`) already default `LANGFLOW_WORKERS=1` — the `services:` block was the one place missing it.

## Evidence
- Local backend with `LANGFLOW_WORKERS=1`: collect-models exercised all 3 providers, `/api/v1/version` polled throughout — never blocked.
- CI multi-worker: `/api/v1/version` hangs 30s after collect-models.
- Classified single-backend saturation (failure-modes.md §1, already lists #867).

## Fix
Add `LANGFLOW_WORKERS: "1"` to the impacted-specs service container env.

**Scope: pr-validation.yml only.** daily-stable / sharding (#833, active) untouched; the same gap in the other service-container workflows (nightly, manual, migration-*, adaptive-impacted, weekly) is deferred for coordinated follow-up.

## Proof
YAML can't run locally — final proof is the next `pr-validation` run: once this is on `main`, re-run the impacted-specs job on #921 and confirm the preflight passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)