### PR TITLE
docs(triage): quarantine via @stable removal + test.fixme, not tag removal alone (#871)

### DIFF
--- a/.claude/skills/langflow-e2e-triage/SKILL.md
+++ b/.claude/skills/langflow-e2e-triage/SKILL.md
@@ -23,11 +23,12 @@ This skill is the **producer** of the dedicated issues that the sibling
 fixes.** This skill never investigates a failure's root cause — it reads a
 run, groups symptoms, and opens issues that direct someone else to
 investigate. It is **non-mutating by default**: it never edits test code as a
-side effect of opening issues. The single exception is retiring `@stable` as
-prevention (recurrent flakes; hard failures are already auto-removed by the
+side effect of opening issues. The single exception is **quarantining** a
+recurrent flake as prevention (hard failures are already auto-removed by the
 workflow), and that happens **only behind its own explicit authorization**
 (see the hard gate) — never bundled into issue creation, and it never restores
-a tag.
+a tag. **Quarantine = remove `@stable` AND add `test.fixme(...)`** (not tag
+removal alone — see the hard gate for why).
 
 Repo: `oriontech-me/langflow-e2e`.
 
@@ -45,16 +46,20 @@ Talk to the user in **Portuguese (PT-BR)**; produce every GitHub artifact
   abrir"). Do all analysis and grouping first; the gate is the only thing
   standing between plan and execution — don't erode it by creating "just the
   obvious one" early.
-- **`@stable` removal: separate gate, never inadvertent.** Retiring `@stable`
-  is **prevention** — a broken test must stop running in the daily until it is
-  worked — so it is a **mandatory part of the triage**. But it is a
-  code-mutating action, so it is **never a side effect of opening issues**: it
-  requires its **own explicit authorization**, distinct from the issue-dispatch
-  approval, and the **exact diff (`spec:line`) is shown before** anything is
-  edited. Hard failures are already auto-removed by the workflow; only
-  **recurrent flakes** need a removal here (flake removal is never automatic).
-  The skill **never restores** a tag and never edits test *logic*, spec docs,
-  or `QA-CHECKLIST.md` — restoration is a deliverable of the dedicated issue.
+- **Quarantine: separate gate, never inadvertent.** Quarantining a broken test
+  is **prevention** — a **mandatory part of the triage**, but a code-mutating
+  action that is **never a side effect of opening issues**: it needs its **own
+  explicit authorization**, distinct from the issue-dispatch approval, with the
+  **exact diff (`spec:line`) shown first**. **Quarantine = remove `@stable` AND
+  add `test.fixme(<reason + issue #>)`, always together** — tag removal alone
+  only stops the daily, so the test keeps going red on the impacted-specs gate
+  (file-diff selected, not tag-filtered — #871); `test.fixme` skips it in every
+  context. Full mechanism + why: `references/issue-templates.md` →
+  *Quarantine mechanism*. Hard failures are already auto-removed by the workflow
+  (tag only); only **recurrent flakes** are quarantined here (never automatic).
+  The skill **never restores** either edit and never touches test *logic*, spec
+  docs, or `QA-CHECKLIST.md` — un-`fixme` + restore-`@stable` is the dedicated
+  issue's deliverable.
 - **The triage does not close until the tags are gone.** The umbrella is closed
   only after every criterion-required removal is **verified done** (tag absent
   on `main` / its removal PR open and linked). If a removal was not authorized
@@ -192,13 +197,15 @@ each time) is **only noted** in the panorama — the retry budget absorbs
 single-run noise, and opening an issue for it would be triage noise of its
 own.
 
-For each actionable flake, `@stable` must be retired **as prevention** (so the
-flake stops running in the daily until it is worked) — part of the triage, not
-a deferred follow-up. But the removal is a code change: **record the exact spec
-path + line here** and carry it into the plan (Phase 6) as its own row; it is
-executed only in Phase 7, behind its **own authorization** with the diff shown
-(never restore it here). The dedicated issue then carries **restoring
-`@stable`** as an explicit deliverable.
+For each actionable flake, the test must be **quarantined as prevention** (so it
+stops running everywhere until it is worked) — part of the triage, not a
+deferred follow-up. Quarantine = **remove `@stable` + add `test.fixme`**
+together (see the hard gate + `references/issue-templates.md` → *Quarantine
+mechanism*). But it is a code change: **record the exact spec path + line here**
+and carry it into the plan (Phase 6) as its own row; it is executed only in
+Phase 7, behind its **own authorization** with the diff shown (never restore it
+here). The dedicated issue then carries **un-`fixme` + restore `@stable`** as an
+explicit deliverable.
 
 ### Phase 5 — SKIPS
 
@@ -215,9 +222,10 @@ it to the user in PT-BR:
 |---|---|---|---|---|
 | 1 | ... | hard-failure / flake / skip | create / enrich / note | new issue title, or existing #NNN |
 
-Below the table, list the **`@stable` removals the triage requires** as a
-separate block — one line per recurrent flake (`spec/path.spec.ts:line`). Hard
-failures are already auto-removed by the workflow, so do **not** list them.
+Below the table, list the **quarantines the triage requires** (remove `@stable`
++ add `test.fixme`) as a separate block — one line per recurrent flake
+(`spec/path.spec.ts:line`). Hard failures are auto-removed by the workflow, so
+do **not** list them.
 
 Then **wait for explicit approval of the issue plan** ("pode abrir" or
 equivalent). This approval covers issue create/enrich/close **only** — it does
@@ -235,16 +243,16 @@ Only after the user approves the plan:
    `references/issue-templates.md`.
 2. For each **enrich** row: `gh issue comment` on the matched existing issue,
    per the same reference's *Enrich vs Create Rule*.
-3. **`@stable` removals — separate authorization, one at a time.** For each
-   recurrent flake in the removals block: show the **exact diff** (the
-   `@stable` tag to drop, at `spec:line`) and ask for a **distinct**
-   confirmation (e.g. "pode remover a tag do teste X?"). Only on an explicit
-   yes, open the removal PR (branch off `main`, drop the tag, reference the
-   dedicated issue in the body — restoration is that issue's deliverable, never
-   done here). If the user declines or defers, **do not edit** — record the
-   removal as still pending. (Hard failures were already auto-removed by the
-   workflow; on a guard-tripped mass-failure day the tag is **kept** — no
-   removal in either case.)
+3. **Quarantines — separate authorization, one at a time.** For each recurrent
+   flake in the removals block: show the **exact diff** (drop `@stable` **and**
+   wrap the test as `test.fixme(<reason + issue #>)`, at `spec:line`) and ask
+   for a **distinct** confirmation (e.g. "pode colocar o teste X em
+   quarentena?"). Only on an explicit yes, open the quarantine PR (branch off
+   `main`, apply both edits, reference the dedicated issue — un-`fixme` +
+   restore is that issue's deliverable, never done here). If the user declines
+   or defers, **do not edit** — record it as still pending. (Hard failures were
+   already auto-removed by the workflow; on a guard-tripped mass-failure day
+   nothing is quarantined here.)
 4. Comment on the umbrella issue linking every dedicated issue just
    created/enriched (so the umbrella's history stays a readable index).
 5. **Close the umbrella only when the triage is truly complete:** every needed
@@ -261,7 +269,7 @@ Only after the user approves the plan:
    run are still linked here.
 
 Report back to the user in PT-BR with the final list of issue numbers/URLs
-created or enriched, each `@stable`-removal PR opened (and any removal left
+created or enriched, each quarantine PR opened (and any quarantine left
 pending), and whether the umbrella was closed or intentionally left open.
 
 ## Headless / CI mode
@@ -275,8 +283,8 @@ Two rules override the interactive flow:
 - **Never call `AskUserQuestion`** and never block on human input. The CI job
   has no interactive channel; a prompt would hang the run.
 - **Never edit code.** The CI job runs with `--allowedTools "Read,Bash"` (no
-  `Edit`/`Write`) and `contents: read`. `@stable` removal is therefore **out of
-  the automated path** — it stays a manual/local PR (list it, never do it here).
+  `Edit`/`Write`) and `contents: read`. Quarantine is therefore **out of the
+  automated path** — it stays a manual/local PR (list it, never do it here).
 
 The invocation may carry the umbrella issue number as `--issue <n>` (manual
 `workflow_dispatch`). When `--issue` is absent (the `workflow_run` auto-trigger),
@@ -291,18 +299,16 @@ Run **Phase 0–6** exactly as documented, with one substitution at Phase 6:
 instead of presenting the plan and waiting for "pode abrir", **post the plan as
 a comment on the umbrella issue** and stop.
 
-- **Per-skip reasons:** the `workflow_run` job downloads the triggering daily's
-  `results.json` to the repo root (best-effort). In Phase 1, if `results.json`
-  is present, run the dataset builder with `--results results.json` so Phase 5
-  (SKIPS) sees real per-skip reasons; if it is absent (manual dispatch, or the
-  artifact expired), run history-only and **say so** in the proposal ("per-skip
-  detail unavailable — skips reported by total only").
-- Build the same Phase-6 table plus the `@stable`-removal block.
+- **Per-skip reasons:** the `workflow_run` job downloads the daily's
+  `results.json` (best-effort). In Phase 1, pass `--results results.json` when
+  present so Phase 5 sees real per-skip reasons; if absent, run history-only and
+  **say so** in the proposal ("per-skip detail unavailable — totals only").
+- Build the same Phase-6 table plus the quarantine block.
 - Post it with `gh issue comment <n>`, whose **first line is the exact marker**
   `<!-- triage-proposal -->` so Phase execute finds it deterministically.
 - End the comment with: *"A triage-team member: reply `pode abrir` on this
-  issue to create/enrich the dedicated issues. `@stable` removals listed above
-  are manual/local TODOs — they are NOT performed by the automation."*
+  issue to create/enrich the dedicated issues. Quarantines listed above are
+  manual/local TODOs — they are NOT performed by the automation."*
 - Then **STOP**. Create nothing, enrich nothing, close nothing, edit nothing.
 
 **Always leave an observable trace — never a silent no-op.** Propose must end
@@ -338,22 +344,21 @@ trigger itself as the authorization; do not re-ask.
 - Re-run the **Phase 2 dedup** pass before creating, so a re-approval enriches
   instead of duplicating.
 - Run **Phase 7 steps 1, 2, 4, 5** (create / enrich / link-on-umbrella /
-  close-if-complete). **Skip step 3** (`@stable` removal — manual/local).
+  close-if-complete). **Skip step 3** (quarantine — manual/local).
 - **Umbrella closure:** close only if the triage is complete **and** no
-  criterion-required `@stable` removal is pending. If a recurrent-flake removal
-  is required, leave the umbrella **open** and post a checklist comment listing
-  the pending manual/local removals (`spec/path.spec.ts:line` + a ready-to-run
-  command), so a human finishes them locally.
+  criterion-required quarantine is pending. If a recurrent-flake quarantine is
+  required, leave the umbrella **open** and post a checklist comment listing the
+  pending manual/local quarantines (`spec/path.spec.ts:line`), so a human
+  finishes them locally.
 - Post a final comment summarizing the issues created/enriched and the umbrella
   state (closed, or left open with N pending removals).
 
 ## Relationship to sibling skills
 
 - **`langflow-e2e-triage`** (this skill) — **producer**: turns one red daily
-  run into dedicated follow-up issues and, as prevention, retires `@stable`
-  from recurrent flakes (behind its own gate — see the hard gates). It never
-  investigates a root cause, fixes a test, or restores a tag — restoration is
-  the consumer's deliverable.
+  run into dedicated follow-up issues and, as prevention, quarantines recurrent
+  flakes (behind its own gate). It never investigates a root cause, fixes a
+  test, or restores a quarantine — restoration is the consumer's deliverable.
 - **`langflow-e2e-issues`** / **`langflow-e2e-issue-deterministic`** —
   **consumers**: pick up a dedicated issue this skill spawned and drive it to
   a fix PR (their `daily-failure triage` classify-row explicitly says

--- a/.claude/skills/langflow-e2e-triage/references/issue-templates.md
+++ b/.claude/skills/langflow-e2e-triage/references/issue-templates.md
@@ -87,7 +87,7 @@ A checkbox list of concrete acceptance criteria. Format:
 
 - [ ] Root cause confirmed per spec (product regression vs. test/wait-strategy vs. environment) with evidence on the current nightly.
 - [ ] Each spec passes reliably (multiple clean `--retries=0` runs), fixing waits/flow as needed.
-- [ ] **`@stable` restored** in the fix PR — the tag was removed at triage as prevention (hard failures and recurrent flakes); re-validate per `CONTRIBUTING.md` before restoring. *(On a guard-tripped mass-failure day the tag is instead **kept** — then there is nothing to restore unless the cluster later reproduces on a clean daily and the tag is removed.)*
+- [ ] **Quarantine lifted** in the fix PR — remove `test.fixme` **and** restore `@stable` (both were applied at triage as prevention for recurrent flakes; hard failures had only `@stable` auto-removed). Re-validate per `CONTRIBUTING.md` before lifting. *(On a guard-tripped mass-failure day nothing was quarantined — then there is nothing to lift unless the cluster later reproduces on a clean daily and is quarantined.)*
 - [ ] If the root cause is a **product (Langflow) regression**: recorded as such here, and this issue stays **open** until the upstream fix lands in `langflowai/langflow-nightly:latest` (or the `release-1.x.x` branch), is re-validated there, and `@stable` is restored — not on a test-side mute.
 ```
 
@@ -95,7 +95,7 @@ Rules:
 - Boxes are checkable (`- [ ]`)
 - Each item is a single, verifiable outcome
 - Include validation steps from `CONTRIBUTING.md` if the fix touches product code
-- **Restoring `@stable` is always a deliverable** whenever the tag was removed at triage (the normal case) — "done" includes putting it back after the fix. Only a guard-tripped day, where the tag was kept, has nothing to restore.
+- **Lifting the quarantine is always a deliverable** whenever a test was quarantined at triage (the normal case) — "done" includes removing `test.fixme` and putting `@stable` back after the fix. Only a guard-tripped day, where nothing was quarantined, has nothing to lift.
 - A **product regression** closes only when the product is fixed where the suite runs (nightly / release branch), not on a test-side workaround
 
 ---
@@ -176,6 +176,28 @@ Apply exactly two labels to every dedicated issue:
 
 ---
 
+## Quarantine mechanism
+
+Quarantining a broken test (recurrent flake at triage) is **two edits, always applied together**, on the test's `test()` call:
+
+1. **Remove `@stable`.** `QA-CHECKLIST.md` Phase 0 ("validated") is generated from `@stable` `test()` calls (`scripts/stable-tests.ts`); leaving the tag on keeps counting a quarantined test as validated.
+2. **Add `test.fixme`.** Wrap the test with the Playwright-native quarantine primitive, carrying the reason + issue number:
+
+```ts
+// before
+test("... title ...", { tag: ["@stable", "@components"] }, async ({ page }) => { ... });
+// after (quarantined for #NNN)
+test.fixme("... title ...", { tag: ["@components"] }, async ({ page }) => { ... });
+```
+
+**Why both — `@stable` removal alone is incomplete.** Removing `@stable` only stops the **daily** (`daily-stable.yml` runs `@stable` only). The test keeps running — and going red — in every other context: the `pr-validation.yml` **impacted-specs gate** (selects specs by *file diff*, not by tag, so any PR touching the file runs the broken test), `test:features`, `adaptive-impacted.yml`, and manual full runs. This is why a `@stable`-removal-only quarantine PR itself goes red on the impacted-specs gate (#871, seen on PR #870, merged red). `test.fixme` skips the test in **all** contexts, so the quarantine PR merges green and the noise stops everywhere.
+
+**Restoration** (the dedicated issue's deliverable) is the exact inverse, in one PR after the fix: remove `test.fixme`, restore `@stable`, re-validate per `CONTRIBUTING.md`.
+
+**Scope:** quarantine is for **recurrent flakes** removed manually at triage. Hard failures are auto-removed by the workflow (tag only, committed straight to `main` — no PR gate, so no red-PR problem); a hard-failure test that also needs `test.fixme` gets it when its dedicated `fix` issue is worked. On a **guard-tripped** day nothing is quarantined (tags kept).
+
+---
+
 ## Flake-Signal Block
 
 When an issue is opened to track a **recurrent flake** (a test failing on multiple separate daily runs, or a long-standing intermittent), include this block:
@@ -183,18 +205,18 @@ When an issue is opened to track a **recurrent flake** (a test failing on multip
 ```markdown
 ## Flake signal
 
-This test is confirmed recurrent (failed on dailies 2026-07-08, 2026-07-09, 2026-07-13). As prevention, `@stable` was removed at triage (PR #NNN) so it stops running in the daily until this issue is worked:
+This test is confirmed recurrent (failed on dailies 2026-07-08, 2026-07-09, 2026-07-13). As prevention, it was **quarantined** at triage (PR #NNN) — `@stable` removed **and** `test.fixme` added — so it stops running in **every** context (daily, PR impacted-specs gate, full suite) until this issue is worked:
 
 - `tests/tests-automations/regression/core-functionality/playground/playground-input-text-prefill.spec.ts` (test at line 97)
 
-Restoring `@stable` after the fix is a deliverable of this issue.
+Lifting the quarantine after the fix (remove `test.fixme` + restore `@stable`) is a deliverable of this issue.
 ```
 
 Rules:
 - Include only when the failure appears across multiple independent daily runs
 - List **exact spec file paths** and test line numbers
-- `@stable` removal is manual (the workflow never auto-removes flakes) and happens **at triage as prevention** — it is not deferred until after the fix; link the removal PR (`#NNN`)
-- Restoring `@stable` after the fix is an explicit **deliverable** of this issue
+- Quarantine is manual (the workflow never auto-removes flakes) and happens **at triage as prevention** — not deferred until after the fix; link the quarantine PR (`#NNN`)
+- Lifting the quarantine after the fix is an explicit **deliverable** of this issue
 
 ---
 
@@ -265,6 +287,6 @@ Every dedicated issue embodies this philosophy:
 - **Description before diagnosis:** symptom table + preliminary observations, no verdict
 - **Investigation as independent branches:** test the product first, then environment, then test design
 - **Deliverables as checkboxes:** done when all items are ticked
-- **`@stable` decisions are explicit:** removed at triage as prevention (or kept on a guard-tripped day), and **restored as a deliverable** after the fix — always documented
+- **Quarantine decisions are explicit:** quarantined at triage as prevention — `@stable` removed **+** `test.fixme` added (or nothing quarantined on a guard-tripped day) — and **lifted as a deliverable** after the fix — always documented
 
 This ensures investigators inherit not just a failure, but the context and constraints needed to fix it efficiently.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -556,7 +556,7 @@ On a red scheduled `daily-stable.yml` run, the workflow does two things **automa
 1. Removes `@stable` from **every hard failure** (a test that failed all retries), regenerates `QA-CHECKLIST.md`, and commits it to `main` with `[skip ci]` — no PR, no approval. If the mass-failure guard trips (too many at once → treated as infra), nothing is removed.
 2. Opens a single **triage issue** for the run, listing what was removed.
 
-The triage issue is the analyst's **inbox and dispatcher** — not the tracking issue for each problem. Its only deliverable is the **triage itself**: read the run, route each occurrence into a dedicated issue (or enrich an existing one), and then **close the triage issue**. It never carries an investigation or a fix. The triage issue is closed **only once the triage is complete** — every needed dedicated issue created or enriched (hard failure / flake / skip, per the criteria below) **and** `@stable` removed from every test the criteria require (hard failures: auto-removed by the workflow; recurrent flakes: removed via PR at this point, as prevention). When the mass-failure guard trips (see below), the triage gains one extra deliverable: **decide whether the day was environmental** and, if not, **manually remove `@stable`** from the real hard failures — and, because that day's today-only collateral is **noted rather than filed**, the triage issue **stays open** as the standing record until a clean, non-guarded daily rechecks it (only durable cross-day clusters get a dedicated issue on a guard day; see the Mass-failure guard note below). The human steps are the fan-out, the manual removal for recurrent flakes, and the restoration.
+The triage issue is the analyst's **inbox and dispatcher** — not the tracking issue for each problem. Its only deliverable is the **triage itself**: read the run, route each occurrence into a dedicated issue (or enrich an existing one), and then **close the triage issue**. It never carries an investigation or a fix. The triage issue is closed **only once the triage is complete** — every needed dedicated issue created or enriched (hard failure / flake / skip, per the criteria below) **and** every test the criteria require quarantined (hard failures: `@stable` auto-removed by the workflow; recurrent flakes: **quarantined via PR** at this point — remove `@stable` **and** add `test.fixme` — as prevention). When the mass-failure guard trips (see below), the triage gains one extra deliverable: **decide whether the day was environmental** and, if not, **manually quarantine** the real hard failures — and, because that day's today-only collateral is **noted rather than filed**, the triage issue **stays open** as the standing record until a clean, non-guarded daily rechecks it (only durable cross-day clusters get a dedicated issue on a guard day; see the Mass-failure guard note below). The human steps are the fan-out, the manual quarantine for recurrent flakes, and lifting it after the fix.
 
 The runbook — order, dedup, analysis depth, and how the follow-up issue must be written — is in **[Triage protocol — working the triage issue](#triage-protocol--working-the-triage-issue)** below.
 
@@ -576,7 +576,8 @@ Analyst works the triage issue (dispatcher) — order: HARD FAILURES → FLAKES 
       │
       ├─► per RECURRENT FLAKE  (same error_signature within a 30-day window,
       │        confirmed in reports/daily-history.jsonl)
-      │        → open a DEDICATED issue AND remove @stable via PR (manual)
+      │        → open a DEDICATED issue AND quarantine via PR (manual):
+      │          remove @stable AND add test.fixme (together)
       │
       └─► per UNEXPECTED SKIP  (reason not already tracked)
       │        → open a DEDICATED issue
@@ -584,10 +585,11 @@ Analyst works the triage issue (dispatcher) — order: HARD FAILURES → FLAKES 
 Before opening ANY issue: search for an OPEN issue on the same subject
       │        → if one exists, ENRICH it instead of duplicating
       ▼
-Problem resolved → @stable RESTORED via PR; the dedicated issue is closed
+Problem resolved → quarantine LIFTED via PR (remove test.fixme + restore
+      @stable); the dedicated issue is closed
 ```
 
-> **Mass-failure guard.** The threshold is the `max_auto_remove` input of the `auto-remove-stable` action (default `5`, so the guard trips at **6+** hard failures in a run). Above the threshold, the workflow assumes an environment-wide failure and removes nothing, so a bad infra day cannot strip `@stable` off the whole suite. When it trips, the triage issue says so and the tags are still in place — investigate the environment; if it turns out not to be environmental, remove `@stable` manually from the real hard failures. There is nothing to restore for tags never removed.
+> **Mass-failure guard.** The threshold is the `max_auto_remove` input of the `auto-remove-stable` action (default `5`, so the guard trips at **6+** hard failures in a run). Above the threshold, the workflow assumes an environment-wide failure and removes nothing, so a bad infra day cannot strip `@stable` off the whole suite. When it trips, the triage issue says so and the tags are still in place — investigate the environment; if it turns out not to be environmental, **manually quarantine** the real hard failures (remove `@stable` + add `test.fixme`). There is nothing to lift for tests never quarantined.
 >
 > On a guard-tripped day, split the clusters by durability: a cluster whose same test + error signature also failed on **other, non-adjacent** dailies is a **durable** signal (it reproduces off mass-failure days) and gets its own dedicated issue as usual; **today-only collateral** (no cross-day recurrence) is **noted, not filed** — a dedicated tracker for what most likely vanishes when the instance recovers is throwaway triage noise (same reason a first-occurrence flake is noted, not filed). Because the collateral has no dedicated issue, the **umbrella stays open** on a guard-tripped run as the standing record; the next clean, non-guarded daily's triage closes it once it confirms recovery, or promotes any cluster that persists into a durable issue.
 
@@ -604,7 +606,7 @@ The triage is **dispatch, not solution**. Its analysis is **preliminary and desc
 
 **2. Flakes (second).** Consult `reports/daily-history.jsonl`.
 - Open an issue **only for a recurrent flake**. A first occurrence is **only noted** in the triage — the retry budget absorbs single-run noise.
-- **Recurrence window: 30 days.** The criterion is the **cause, not the count**: it is not enough that the test flaked 2+ times in the window — the occurrences must share the **same `error_signature`** (the cheap, descriptive proxy for "same cause" at triage time). Same signature within the window → recurrent → open a **dedicated issue and remove `@stable` via PR as prevention** (flake removal is always manual; the workflow never auto-removes flakes) — so the flaky test stops running in the daily until it is worked. Restoring the tag is a **deliverable of that issue**, done after the fix. *(30 days is a revisable convention, not an absolute.)*
+- **Recurrence window: 30 days.** The criterion is the **cause, not the count**: it is not enough that the test flaked 2+ times in the window — the occurrences must share the **same `error_signature`** (the cheap, descriptive proxy for "same cause" at triage time). Same signature within the window → recurrent → open a **dedicated issue and quarantine the test via PR as prevention** (flake quarantine is always manual; the workflow never auto-removes flakes) — so the flaky test stops running until it is worked. **Quarantine = remove `@stable` AND wrap the test as `test.fixme(<reason + issue #>)`, together**: `@stable` removal alone only stops the daily, so the test keeps going red on the `pr-validation.yml` impacted-specs gate (which selects specs by file diff, not by tag — the quarantine PR itself would go red; #871). `test.fixme` skips it in every context so the quarantine PR merges green. Lifting the quarantine (remove `test.fixme` + restore `@stable`) is a **deliverable of that issue**, done after the fix. *(30 days is a revisable convention, not an absolute.)*
 
 **3. Skips (third).**
 - Analyse the **reason** for each skip.
@@ -659,7 +661,7 @@ Then compare the signatures — the action depends on **what** recurred (same ca
 |---|---|---|
 | Hard failure (all retries failed) | any | `@stable` was already auto-removed (or the mass-failure guard tripped and left it in place). No manual removal — classify on the dedicated issue and restore the tag when the test is fixed. |
 | Flake (passed on retry) | No matching signature in the last 30 days | Note in the triage; **do not** open an issue yet. The retry budget absorbs single-run noise. |
-| Flake (recurrent) | **Same `error_signature`** seen before within 30 days | Open a **dedicated issue** (`daily-failure` + `area:<...>`, cite the run ids) **and remove `@stable` via PR as prevention**. Flake removal is manual — the workflow never auto-removes flakes. Restoring the tag is a **deliverable of that dedicated issue**. |
+| Flake (recurrent) | **Same `error_signature`** seen before within 30 days | Open a **dedicated issue** (`daily-failure` + `area:<...>`, cite the run ids) **and quarantine via PR as prevention** — remove `@stable` **and** add `test.fixme` (tag removal alone leaves the test red on the impacted-specs gate; #871). Quarantine is manual — the workflow never auto-removes flakes. Lifting it (remove `test.fixme` + restore `@stable`) is a **deliverable of that dedicated issue**. |
 | Flake with a **different** signature | Prior flake on the same test, but a different signature | Treat as a first occurrence of a **new cause** — note it; the raw count alone does not trigger an issue. |
 | Mix (hard-failed one day, flaky later) | 2+ days | The hard-fail day already auto-removed `@stable`; once restored, apply the flake rows above if the flakiness persists. |
 


### PR DESCRIPTION
Closes #871

## Problem
Triage quarantine PRs cannot go green through `pr-validation.yml` → **Run impacted E2E specs**. The gate selects specs by **file diff** (not by tag), so a PR that only removes `@stable` from a broken test still runs that test → red (seen on PR #870, merged red). `@stable` removal alone only targets the **daily**; the test keeps producing red/noise on the impacted-specs gate, `test:features`, `adaptive-impacted.yml`, and manual runs.

## Fix (process, not test code)
Quarantine becomes **two edits applied together**:
1. **Remove `@stable`** — so `QA-CHECKLIST.md` Phase 0 stops counting the test as validated (`scripts/stable-tests.ts`).
2. **Add `test.fixme(<reason + issue #>)`** — the Playwright-native quarantine primitive that skips the test in **every** run context, so the quarantine PR merges green and the noise stops everywhere.

Restoration (the dedicated issue's deliverable) is the inverse in one PR after the fix: remove `test.fixme`, restore `@stable`, re-validate.

## Changes
- **`langflow-e2e-triage` SKILL.md** — hard gate, Phase 4/6/7, headless mode, relationship section now describe quarantine = `@stable` removal + `test.fixme`. Kept under the 20KB skill-hygiene target.
- **`references/issue-templates.md`** — new **Quarantine mechanism** section (two edits + why + `test.fixme` syntax + restoration); Deliverables / Flake-Signal / Summary now say *lift quarantine*.
- **`CONTRIBUTING.md`** — triage protocol (deliverables, ASCII flow, guard note, recurrence rule, flake table) updated to match.

Rejected alternative (documented in #871): teaching the gate to skip tests that lost `@stable` in the same PR — high complexity, and it only fixes the PR gate, leaving the test running everywhere else. `test.fixme` fixes all contexts with a one-line primitive.

## Proof
`test.fixme` on a test + `npx playwright test <spec>` (the gate's exact mechanism) → **`1 skipped`** (test not run) → a quarantine PR built this way goes green. Verified locally on `notifications.spec.ts`, then reverted.

## Deliverables (#871)
- [x] Quarantine documented as `@stable` removal + `test.fixme`, restoration undoing both.
- [x] `langflow-e2e-triage` skill updated (Phase 4/7 + template restoration deliverable).
- [x] `CONTRIBUTING.md` triage protocol updated.
- [x] Quarantine-PR-goes-green mechanism proven (`test.fixme` → `1 skipped` under the gate's run command).

Docs/skill only — no test-code or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)