### PR TITLE
feat(triage): group failures by provider variant, surface provider-wide clusters (#899)

### DIFF
--- a/.claude/skills/langflow-e2e-triage/SKILL.md
+++ b/.claude/skills/langflow-e2e-triage/SKILL.md
@@ -117,17 +117,16 @@ detects the mass-failure guard, matches the umbrella `[Daily Failure]` issue
 via `gh issue list --label daily-failure`, and prints a normalized `Dataset`
 JSON: `run{run_id,run_url,date,langflow_image,duration_ms}`,
 `umbrella_issue`, `guard_tripped`, `totals`, `hard_failures[]`, `flakes[]`
-(each carrying `recurrence` and an `actionable` flag), `skips[]`.
+(each carrying `provider`/`model`, `recurrence`, and an `actionable` flag),
+`provider_wide_clusters[]`, `skips[]`. Flags: `--run <id>` triages a specific
+past run; `--results <json>` backfills provider labels + per-skip reasons.
 
-**Citing recurrence faithfully:** `recurrence.count` / `recurrence.dates`
-report only the **same-signature** (same-cause) occurrences — this is the
-recurrence to cite in the proposal ("recurrent 3× on 07-13/15/16"). The same
-test can also appear under its title for a *different* cause; those are
-excluded from `count`/`dates` and surfaced separately as
-`recurrence.total_count` / `total_dates` for context only. Never quote the raw
-`total_count` as the recurrence figure — it overstates same-cause recurrence
-(the report-faithfully gate). `actionable` is driven by `same_signature`
-(≥ 2 same-signature hits), unchanged.
+**Citing recurrence faithfully:** cite `recurrence.count` / `recurrence.dates`
+— they count only **same-signature** (same-cause) occurrences ("recurrent 3× on
+07-13/15/16"). `recurrence.total_count` / `total_dates` also count the same
+test's *different*-cause hits — context only; never quote them as the recurrence
+figure (it overstates same-cause recurrence). `actionable` = `same_signature`
+(≥ 2 same-signature hits).
 
 If a local Playwright report exists for that run (downloaded or already on
 disk), pass it for richer per-skip detail — the history file only carries
@@ -142,9 +141,11 @@ Other flags: `--history <path>` (default `reports/daily-history.jsonl`),
 
 Read the full dataset before doing anything else. Then report the panorama
 to the user in PT-BR: run id/date/image, **X hard failures / Y actionable
-flakes (of Z total flakes) / W skips**, and whether the **guard tripped**
-(and if so, at what count). This is the shared frame of reference for every
-phase below — don't start grouping before this is on the table.
+flakes (of Z total flakes) / W skips**, whether the **guard tripped** (and at
+what count), and any **`provider_wide_clusters`** (same provider failing across
+≥2 spec files — a descriptive hint the cause is environment/package, e.g. a
+missing `langchain-<provider>`, not per-test rot; #899). This is the shared
+frame of reference for every phase below.
 
 ### Phase 2 — DEDUP
 
@@ -167,26 +168,26 @@ occurrences under it.
 
 ### Phase 3 — GROUP (hard failures)
 
-Cluster `hard_failures[]` by root cause: **same normalized error signature +
-same area + same failure symptom → one issue.** Don't open one issue per
-failing spec by default — the point of grouping is that a shared root cause
-is one problem, not N. Worked example: issue **#751** covers three specs
-(`agent-component-regression.spec.ts`, `agent-input-sources.spec.ts`,
-`loop-component-regression.spec.ts`) under a single "execution never
-completes" issue because all three shared the same
-timeout-waiting-for-completion shape, even though the literal locator
-differed (`div-chat-message` vs `text=built successfully`).
+**Check `provider_wide_clusters` first:** when a cluster is flagged
+`provider_wide`, treat that whole provider variant as **one** candidate cluster
+(the shared cause is likely a package/environment gap for that provider) rather
+than splitting it across per-symptom buckets — this is the #899 fix for the
+misgrouping that hid #898's `langchain-google-genai` cause.
 
-When `guard_tripped` is true the day is a mass-failure day, most likely
-environment-wide, so most failures are collateral. **Split the clusters:**
-**cross-day-recurrent** ones (same test+signature on other non-adjacent
-dailies — durable, not pure collateral) are **created/enriched** as usual,
-grouped aggressively, environmental context noted descriptively (never a
-verdict). **Today-only collateral** (no cross-day recurrence) is **not** filed
-as a dedicated issue — that is a throwaway tracker for what vanishes when the
-instance recovers; **note** it (aggregated, with counts) and leave it under the
-umbrella, which **stays open** (Phase 7). `@stable` is **kept** on everything.
-Full rule + issue-body wording: `references/issue-templates.md` → *Guard-Tripped Rule*.
+Then cluster the rest of `hard_failures[]` by root cause: **same normalized
+error signature + same area + same failure symptom → one issue.** Don't open one
+issue per failing spec by default — a shared root cause is one problem, not N.
+Worked example: **#751** covers three specs under one "execution never completes"
+issue because all shared the same timeout-waiting-for-completion shape, even
+though the literal locator differed.
+
+When `guard_tripped` is true the day is a mass-failure day (mostly collateral).
+**Split the clusters:** **cross-day-recurrent** ones (same test+signature on
+other non-adjacent dailies — durable) are created/enriched as usual;
+**today-only collateral** is **noted, not filed** (aggregated with counts) and
+left under the umbrella, which **stays open** (Phase 7). `@stable` is **kept**
+on everything. Full rule + wording: `references/issue-templates.md` →
+*Guard-Tripped Rule*.
 
 ### Phase 4 — FLAKES
 

--- a/.claude/skills/langflow-e2e-triage/scripts/build-triage-dataset.mjs
+++ b/.claude/skills/langflow-e2e-triage/scripts/build-triage-dataset.mjs
@@ -15,6 +15,7 @@ const historyPath = arg('--history', 'reports/daily-history.jsonl');
 const resultsPath = arg('--results', null);
 const windowRaw = Number(arg('--window', '30'));
 const windowDays = Number.isFinite(windowRaw) ? windowRaw : 30;
+const runId = arg('--run', null);
 
 // Daily-failure issues (open + closed) — the umbrella may already be closed.
 function fetchIssues() {
@@ -56,10 +57,59 @@ function readSkips(path) {
   }
 }
 
+// Build a `${test}\0${file}` → param map from a local Playwright results.json,
+// walking the suite path exactly as the history appender does. Used to backfill
+// the `param` (provider variant) on runs whose history predates #899's appender
+// change, so a re-run against an old artifact still surfaces provider clusters.
+function readParamMap(path) {
+  const map = new Map();
+  if (!path) return map;
+  try {
+    const report = JSON.parse(readFileSync(path, 'utf8'));
+    const paramOf = (suitePath) => {
+      for (let i = suitePath.length - 1; i >= 0; i--) {
+        const m = /\[([^\]]+)\]/.exec(suitePath[i] || '');
+        if (m) return m[1].trim();
+      }
+      return null;
+    };
+    const walk = (suite, sp) => {
+      const path2 = suite.title ? [...sp, suite.title] : sp;
+      const param = paramOf(path2);
+      for (const spec of suite.specs || []) {
+        if (param) map.set(`${spec.title}\0${suite.file || spec.file || ''}`, param);
+      }
+      for (const s of suite.suites || []) walk(s, path2);
+    };
+    for (const s of report.suites || []) walk(s, []);
+  } catch (e) {
+    process.stderr.write(`warning: could not read results.json for params (${e.message})\n`);
+  }
+  return map;
+}
+
 const rows = parseHistory(readFileSync(historyPath, 'utf8'));
-const dataset = buildDataset(rows, fetchIssues(), { windowDays });
+
+// Backfill `param` on history entries from a supplied results.json (best effort).
+const paramMap = readParamMap(resultsPath);
+if (paramMap.size > 0) {
+  for (const row of rows) {
+    for (const e of [...(row.failures || []), ...(row.flaky || [])]) {
+      if (!e.param) {
+        const p = paramMap.get(`${e.test}\0${e.file}`);
+        if (p) e.param = p;
+      }
+    }
+  }
+}
+
+const dataset = buildDataset(rows, fetchIssues(), { windowDays, runId });
 if (!dataset) {
-  process.stderr.write('No red run found in history — nothing to triage.\n');
+  process.stderr.write(
+    runId
+      ? `Run ${runId} not found in history — nothing to triage.\n`
+      : 'No red run found in history — nothing to triage.\n',
+  );
   process.exit(2);
 }
 dataset.skips = readSkips(resultsPath);

--- a/.claude/skills/langflow-e2e-triage/scripts/lib/triage-core.mjs
+++ b/.claude/skills/langflow-e2e-triage/scripts/lib/triage-core.mjs
@@ -84,6 +84,88 @@ export function detectGuard(row, maxAutoRemove = 5) {
   return (row.totals?.failed || 0) > maxAutoRemove;
 }
 
+/** Provider tokens we recognise in labels, filenames, and titles. */
+const KNOWN_PROVIDERS = ['openai', 'anthropic', 'google', 'groq', 'mistral', 'ollama'];
+
+/** Best-effort provider from a bare model id (last-resort when only a model is known). */
+function providerFromModel(model) {
+  const m = String(model || '').toLowerCase();
+  if (/^(gpt|o1|o3|o4|text-|davinci|chatgpt)/.test(m)) return 'openai';
+  if (/^claude/.test(m)) return 'anthropic';
+  if (/^gemini/.test(m)) return 'google';
+  if (/^(mistral|mixtral|magistral|ministral|codestral|pixtral)/.test(m)) return 'mistral';
+  if (/(llama|qwen|phi|gemma|deepseek)/.test(m)) return 'ollama';
+  return null;
+}
+
+/**
+ * Derive `{ provider, model }` for a failure/flake entry. Model-parameterized
+ * specs run one `describe` per provider whose title carries the label
+ * (`[<provider> / <model>]` or `[model:<id>]`) — the appender records that bracket
+ * content as `entry.param`. When `param` is absent (older history, or a
+ * non-parameterized spec) fall back to two cheap, descriptive signals: a
+ * `<provider>-provider.spec.ts` filename, then a known provider token in the test
+ * title (e.g. "... with Google provider"). Returns nulls when nothing matches —
+ * this is a descriptive hint for grouping, never a verdict.
+ */
+export function parseProviderModel(entry) {
+  const param = String(entry?.param || '').trim();
+  // 1. Parameterization label: "<provider> / <model>"
+  let m = /^([a-z0-9.\-_]+)\s*\/\s*(.+)$/i.exec(param);
+  if (m) {
+    const provider = m[1].toLowerCase();
+    return { provider, model: m[2].trim() };
+  }
+  // 1b. "model:<id>" form (provider implicit → infer from the model id)
+  m = /^model:\s*(.+)$/i.exec(param);
+  if (m) {
+    const model = m[1].trim();
+    return { provider: providerFromModel(model), model };
+  }
+  // 2. Filename: "<provider>-provider.spec.ts"
+  m = /([a-z0-9]+)-provider\.spec\.ts$/i.exec(String(entry?.file || ''));
+  if (m && KNOWN_PROVIDERS.includes(m[1].toLowerCase())) {
+    return { provider: m[1].toLowerCase(), model: null };
+  }
+  // 3. Provider token in the test title
+  const title = String(entry?.test || '').toLowerCase();
+  const hit = KNOWN_PROVIDERS.find((p) => new RegExp(`\\b${p}\\b`).test(title));
+  return { provider: hit || null, model: null };
+}
+
+/**
+ * Group failures/flakes by provider variant and flag **provider-wide** clusters:
+ * the same provider failing across **≥2 distinct spec files** on one run. That is
+ * a descriptive signal that the cause is likely environment/package (e.g. a
+ * missing `langchain-<provider>` in the nightly, #898) rather than per-test rot or
+ * parallel-load flakiness — it does NOT root-cause, it only makes the shared
+ * provider dimension (already implicit in the labels) visible to grouping.
+ * Entries with no derivable provider are ignored.
+ */
+export function computeProviderClusters(entries) {
+  const byProvider = new Map();
+  for (const e of entries || []) {
+    const provider = e.provider || parseProviderModel(e).provider;
+    if (!provider) continue;
+    if (!byProvider.has(provider)) byProvider.set(provider, []);
+    byProvider.get(provider).push(e);
+  }
+  const clusters = [];
+  for (const [provider, items] of byProvider) {
+    if (items.length < 2) continue; // a single failure is not a cluster
+    const files = [...new Set(items.map((i) => i.file))];
+    clusters.push({
+      provider,
+      count: items.length,
+      files,
+      tests: items.map((i) => ({ test: i.test, file: i.file, line: i.line })),
+      provider_wide: files.length >= 2,
+    });
+  }
+  clusters.sort((a, b) => b.count - a.count);
+  return clusters;
+}
+
 /** Find the umbrella [Daily Failure] issue for a run id (matched in the body). */
 export function matchUmbrella(issues, runId) {
   const hit = (issues || []).find(
@@ -119,25 +201,35 @@ export function findNewestUmbrella(issues) {
 
 /** Assemble the normalized triage dataset from the latest red run. */
 export function buildDataset(rows, issues, opts = {}) {
-  const { windowDays = 30, maxAutoRemove = 5 } = opts;
-  const run = findLatestRedRun(rows);
+  const { windowDays = 30, maxAutoRemove = 5, runId = null } = opts;
+  // Target a specific run when asked (e.g. re-triaging a past artifact); default
+  // to the latest red run.
+  const run = runId ? rows.find((r) => r.run_id === runId) || null : findLatestRedRun(rows);
   if (!run) return null;
   const window = rowsWithinDays(rows, run.date, windowDays);
 
-  const withRecurrence = (e) => ({
-    test: e.test,
-    file: e.file,
-    line: e.line,
-    tags: e.tags,
-    error_signature: stripAnsi(e.error_signature),
-    recurrence: computeRecurrence(e, window),
-  });
+  const withRecurrence = (e) => {
+    const { provider, model } = parseProviderModel(e);
+    return {
+      test: e.test,
+      file: e.file,
+      line: e.line,
+      tags: e.tags,
+      provider,
+      model,
+      error_signature: stripAnsi(e.error_signature),
+      recurrence: computeRecurrence(e, window),
+    };
+  };
 
   const hard_failures = dedupeEntries(run.failures).map(withRecurrence);
   const flakes = dedupeEntries(run.flaky).map(withRecurrence).map((f) => ({
     ...f,
     actionable: f.recurrence.same_signature,
   }));
+
+  // Descriptive provider-wide signal: same provider failing across ≥2 spec files.
+  const provider_wide_clusters = computeProviderClusters([...hard_failures, ...flakes]);
 
   const newest = findNewestUmbrella(issues);
   const stale_history =
@@ -159,6 +251,7 @@ export function buildDataset(rows, issues, opts = {}) {
     totals: run.totals,
     hard_failures,
     flakes,
+    provider_wide_clusters,
     skips: [],
   };
 }

--- a/.claude/skills/langflow-e2e-triage/scripts/lib/triage-core.test.mjs
+++ b/.claude/skills/langflow-e2e-triage/scripts/lib/triage-core.test.mjs
@@ -14,6 +14,8 @@ import {
   buildDataset,
   dedupeEntries,
   findNewestUmbrella,
+  parseProviderModel,
+  computeProviderClusters,
 } from './triage-core.mjs';
 
 const fixture = (name) =>
@@ -183,4 +185,81 @@ test('buildDataset de-duplicates hard failures by test+line', () => {
   };
   const ds = buildDataset([dupRow], []);
   assert.equal(ds.hard_failures.length, 1);
+});
+
+test('parseProviderModel: parameterization label "<provider> / <model>"', () => {
+  assert.deepEqual(parseProviderModel({ param: 'google / gemini-2.5-flash' }), {
+    provider: 'google',
+    model: 'gemini-2.5-flash',
+  });
+});
+
+test('parseProviderModel: "model:<id>" infers provider from the model id', () => {
+  assert.deepEqual(parseProviderModel({ param: 'model:gpt-4o-mini' }), {
+    provider: 'openai',
+    model: 'gpt-4o-mini',
+  });
+});
+
+test('parseProviderModel: falls back to <provider>-provider.spec.ts filename', () => {
+  const r = parseProviderModel({ file: 'tests/.../model-provider/google-provider.spec.ts' });
+  assert.equal(r.provider, 'google');
+  assert.equal(r.model, null);
+});
+
+test('parseProviderModel: falls back to a provider token in the test title', () => {
+  const r = parseProviderModel({ test: 'language model must respond with Google provider' });
+  assert.equal(r.provider, 'google');
+});
+
+test('parseProviderModel: returns nulls when nothing matches', () => {
+  assert.deepEqual(parseProviderModel({ test: 'renders on canvas', file: 'x.spec.ts' }), {
+    provider: null,
+    model: null,
+  });
+});
+
+test('computeProviderClusters flags provider_wide across ≥2 files', () => {
+  const entries = [
+    { test: 'a', file: 'agent-x.spec.ts', line: 1, param: 'google / gemini-2.5-flash' },
+    { test: 'b', file: 'agent-y.spec.ts', line: 2, param: 'google / gemini-2.5-flash' },
+    { test: 'c', file: 'google-provider.spec.ts', line: 3 },
+    { test: 'd', file: 'agent-x.spec.ts', line: 4, param: 'anthropic / claude-sonnet-5' },
+  ];
+  const clusters = computeProviderClusters(entries);
+  const google = clusters.find((c) => c.provider === 'google');
+  assert.equal(google.count, 3);
+  assert.equal(google.provider_wide, true);
+  assert.equal(google.files.length, 3);
+  // anthropic has a single failure → not a cluster
+  assert.equal(clusters.find((c) => c.provider === 'anthropic'), undefined);
+});
+
+test('computeProviderClusters: single-file provider is not provider_wide', () => {
+  const entries = [
+    { test: 'a', file: 'groq-provider.spec.ts', line: 1 },
+    { test: 'b', file: 'groq-provider.spec.ts', line: 2, param: 'groq / llama-3' },
+  ];
+  const [c] = computeProviderClusters(entries);
+  assert.equal(c.provider, 'groq');
+  assert.equal(c.count, 2);
+  assert.equal(c.provider_wide, false);
+});
+
+test('buildDataset attaches provider/model and provider_wide_clusters', () => {
+  const row = {
+    date: '2026-07-14', run_id: '600', run_url: 'x', langflow_image: 'i', duration_ms: 1,
+    totals: { passed: 1, failed: 2, flaky: 0, skipped: 0 },
+    failures: [
+      { test: 'agent a', file: 'agent-x.spec.ts', line: 1, tags: [], attempts: 3, error_signature: 'E', param: 'google / gemini-2.5-flash' },
+      { test: 'cfg', file: 'google-provider.spec.ts', line: 2, tags: [], attempts: 3, error_signature: 'E' },
+    ],
+    flaky: [],
+  };
+  const ds = buildDataset([row], []);
+  assert.equal(ds.hard_failures[0].provider, 'google');
+  assert.equal(ds.hard_failures[0].model, 'gemini-2.5-flash');
+  const gw = ds.provider_wide_clusters.find((c) => c.provider === 'google');
+  assert.equal(gw.provider_wide, true);
+  assert.equal(gw.count, 2);
 });

--- a/reports/README.md
+++ b/reports/README.md
@@ -49,7 +49,10 @@ The series is **not continuous**. Document any missing weeks here rather than ba
       "line": 369,                           // test() declaration line
       "tags": ["@stable", "@regression"],    // tags at the moment of the run
       "attempts": 3,                         // total result entries (initial + retries)
-      "error_signature": "..."               // first line of the last failed-result error
+      "error_signature": "...",              // first line of the last failed-result error
+      "param": "google / gemini-2.5-flash"   // OPTIONAL: parameterization label from
+                                             // the describe title, when the spec is
+                                             // model-parameterized (#899). Omitted otherwise.
     }
   ],
   "flaky": [
@@ -70,6 +73,7 @@ The series is **not continuous**. Document any missing weeks here rather than ba
 - `tags` reflects the **state at the moment of the run**, not the current state in the repo. A test that was `@stable` at run time and has since had `@stable` removed will still show `@stable` in its historical entries.
 - `error_signature` is the first non-empty line of a failed result's error message, truncated to 240 chars. Stack frames and locator details are stripped — enough to cluster recurring failures, not enough to debug from history alone. For `failures[]` it is taken from the **last** failed result (the one that made the test fail for good); for `flaky[]` it is taken from the **first** failed attempt (the one that triggered the retry that later passed). Falls back to `"unknown"` when no message is available.
 - `failures` are tests where Playwright's final `test.status === "unexpected"`. `flaky` are tests where final status is `"flaky"` (failed and then passed on retry). Both carry `error_signature`, so the 30-day same-signature flake-recurrence criterion in `CONTRIBUTING.md` applies mechanically to either array.
+- `param` (optional, additive to schema v1) is the parameterization label a model-parameterized spec carries on its `describe` title — e.g. `"google / gemini-2.5-flash"` or `"model:gpt-4o-mini"`. The triage dataset builder uses it to group failures by provider variant and surface **provider-wide** clusters (same provider failing across ≥2 spec files → likely an environment/package cause, not per-test rot; #899). Absent for non-parameterized specs and for history written before #899.
 
 ---
 

--- a/scripts/append-weekly-history.mjs
+++ b/scripts/append-weekly-history.mjs
@@ -21,8 +21,12 @@
 //   "langflow_image": "...",
 //   "duration_ms": 0,
 //   "totals": { "passed": 0, "failed": 0, "flaky": 0, "skipped": 0 },
-//   "failures": [ { test, file, line, tags, attempts, error_signature } ],
-//   "flaky":    [ { test, file, line, tags, attempts, error_signature } ]
+//   "failures": [ { test, file, line, tags, attempts, error_signature, param? } ],
+//   "flaky":    [ { test, file, line, tags, attempts, error_signature, param? } ]
+//   `param` (optional, additive to schema v1) is the parameterization label a
+//   model-parameterized spec carries on its describe title (e.g.
+//   "google / gemini-2.5-flash" or "model:gpt-4o-mini"), used by the triage
+//   dataset to group failures by provider variant (#899).
 // }
 
 import { readFileSync, appendFileSync, mkdirSync, existsSync } from "node:fs";
@@ -64,7 +68,23 @@ function specRelFile(spec) {
   }
 }
 
-function visit(node) {
+// Extract the parameterization label a model-parameterized spec carries on its
+// `describe` title — e.g. `Agent max_tokens [google / gemini-2.5-flash]` →
+// `google / gemini-2.5-flash`, or `[model:gpt-4o-mini]` → `model:gpt-4o-mini`.
+// Scan the suite path innermost-first and return the first bracketed content;
+// null when nothing is parameterized. Recorded as `param` so the triage dataset
+// can group failures by provider variant (#899).
+function paramFromSuitePath(suitePath) {
+  for (let i = suitePath.length - 1; i >= 0; i--) {
+    const m = /\[([^\]]+)\]/.exec(suitePath[i] || "");
+    if (m) return m[1].trim();
+  }
+  return null;
+}
+
+function visit(node, suitePath = []) {
+  const path = node.title ? [...suitePath, node.title] : suitePath;
+  const param = paramFromSuitePath(path);
   for (const spec of node.specs || []) {
     const file = specRelFile(spec);
     const line = spec?.line || spec?.location?.line || 0;
@@ -102,6 +122,7 @@ function visit(node) {
           tags,
           attempts,
           error_signature: firstFailedSignature || "unknown",
+          ...(param ? { param } : {}),
         });
         continue;
       }
@@ -117,10 +138,11 @@ function visit(node) {
         tags,
         attempts,
         error_signature: firstErrorMessage(lastFailed) || "unknown",
+        ...(param ? { param } : {}),
       });
     }
   }
-  for (const child of node.suites || []) visit(child);
+  for (const child of node.suites || []) visit(child, path);
 }
 
 for (const suite of report.suites || []) visit(suite);


### PR DESCRIPTION
Closes #899

## Problem
The triage dataset grouped failures by `error_signature` but was **blind to the provider**: model-parameterized specs run one `describe` per provider that share the same test title, and the history appender recorded only the bare title. So a deterministic per-provider cause — e.g. the nightly shipping without `langchain-google-genai` (#898), ~17 of 22 hard failures on the 2026-07-22 daily — was invisible to grouping and split across generic flakiness/RAG buckets.

## Fix (capture + group)
- **`append-weekly-history.mjs`** — thread the suite-title path through `visit()` and record the parameterization label (`[<provider> / <model>]` on the describe title) as a new optional **`param`** field (additive to schema v1).
- **`triage-core.mjs`** — `parseProviderModel` (param → provider/model, with `<provider>-provider.spec.ts` filename + test-title fallbacks) and `computeProviderClusters` (same provider across **≥2 spec files** → `provider_wide: true` — a descriptive environment/package hint, never a verdict). Attach `provider`/`model` to every entry; add `provider_wide_clusters[]`. New `runId` option.
- **`build-triage-dataset.mjs`** — `--run <id>` (triage a specific past run) and `--results` now also **backfills `param`** from an artifact, so a re-run against history written before this change still surfaces provider clusters.
- **`SKILL.md` / `reports/README.md`** — document the field, flags, and the "check `provider_wide_clusters` first" grouping step.

## Proof (deliverables)
- [x] provider/model attached — 07-22 `hard[0]` = `google` / `gemini-2.5-flash`.
- [x] provider_wide cluster emitted — 07-22 → `google count=20 files=16 provider_wide=true`.
- [x] Re-run against run 29911701167 (`--run` + `--results` on its artifact) groups the Google variant into **one** provider-wide cluster (would have pointed at #898).
- [x] Appender captures `param` — 13/22 failures carry `"google / gemini-2.5-flash"`.
- No regression / no false positives: default path (history without `param`) emits `provider_wide_clusters: []`. Unit tests **28/28** pass.

## Verify
```bash
node --test .claude/skills/langflow-e2e-triage/scripts/lib/triage-core.test.mjs   # 28 passed
gh run download 29911701167 -n playwright-json-daily-29911701167 -D /tmp/a
node .claude/skills/langflow-e2e-triage/scripts/build-triage-dataset.mjs --run 29911701167 --results /tmp/a/results.json | jq '.provider_wide_clusters'
```

Scripts/skill/docs only — no test-code or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)