### PR TITLE
fix(preflight): resilient /api/v1/version poll to survive post-collect-models backend wedge (#927)

### DIFF
--- a/tests/globalSetup.ts
+++ b/tests/globalSetup.ts
@@ -39,9 +39,20 @@ const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:7860";
 // is the misconfiguration this gate catches (see #880).
 const PROVIDER_KEYS = ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"];
 
-// The backend can still be starting when the suite launches; poll briefly.
-const HEALTH_TIMEOUT_MS = 30_000;
+// The backend can still be starting when the suite launches — and, in the
+// pr-validation impacted-specs job, the `collect-models` preflight step drives a
+// full model-toggle sweep that leaves the single backend process transiently
+// wedged (event loop blocked >30s; container alive, just silent) right when this
+// step's globalSetup begins. So poll with a SHORT per-request timeout (a wedged
+// request fails fast and retries instead of consuming the whole budget on one
+// hung GET) over a LONGER overall deadline that rides out the wedge. Capping
+// LANGFLOW_WORKERS alone did not fix this (#922 was insufficient — the wedge is
+// process-wide, not a worker-count issue). Overridable via env for slow boxes.
+const HEALTH_TIMEOUT_MS = Number(process.env.PREFLIGHT_TIMEOUT_MS) || 120_000;
 const HEALTH_INTERVAL_MS = 2_000;
+// Per-request cap so one hung GET can't swallow the whole deadline — the loop
+// must be free to retry across the wedge window.
+const HEALTH_REQUEST_MS = Number(process.env.PREFLIGHT_REQUEST_MS) || 8_000;
 
 const truthy = (v: string | undefined): boolean =>
   !!v && v !== "0" && v.toLowerCase() !== "false";
@@ -55,7 +66,9 @@ async function assertBackendHealthy(ctx: APIRequestContext): Promise<void> {
   let lastError = "";
   for (;;) {
     try {
-      const res = await ctx.get("/api/v1/version");
+      const res = await ctx.get("/api/v1/version", {
+        timeout: HEALTH_REQUEST_MS,
+      });
       if (res.ok()) {
         const body = (await res.json()) as {
           version?: string;


### PR DESCRIPTION
Closes #927

## Problem
`pr-validation.yml` → **Run impacted E2E specs** fails at `globalSetup` preflight (a single `GET /api/v1/version` hangs the full 30s) even though the prior **Collect models** step succeeds and the service container does not crash (#921 ×3, #926). On the CI runner, collect-models' full model-toggle sweep leaves the single backend **process wedged** (event loop blocked >30s; container alive, silent) exactly when this step's globalSetup runs.

`LANGFLOW_WORKERS=1` (#922) did **not** fix it — verified on #926 (WORKERS=1 applied, same failure). The wedge is process-wide, and the preflight fired **one** GET with the default 30s request timeout, so a single hung request consumed the whole deadline and the retry loop never polled across the wedge.

## Fix (`tests/globalSetup.ts`)
- **Per-request timeout** `PREFLIGHT_REQUEST_MS` (default 8s) on the health GET → a hung request fails fast and the loop retries.
- **Longer deadline** `PREFLIGHT_TIMEOUT_MS` (default 120s, was 30s) → rides out the wedge if the backend recovers.
- Both env-overridable. A genuinely dead backend still fails (after 120s), so this never masks a real outage.

## Validation
- Backend up (local nightly 1.12.0.dev3): preflight passes fast (~ms), a spec runs green. typecheck + ESLint clean (0 errors).
- **Wedge-recovery path: proof is the next impacted-specs CI run** — not reproducible locally (local collect-models aborts early on limited provider keys, before the wedge phase). Stated plainly.

## Risk
If the backend never recovers, the preflight still fails (after 120s) — correct, just slower. Unlikely for an event-loop block.

Follow-up to #922 (LANGFLOW_WORKERS=1), which was necessary hardening but insufficient for this symptom. Unblocks all spec PRs through the impacted-specs gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)