### PR TITLE
chore(quarantine): fixme api-folders PATCH folder_id flake (#932)

### DIFF
--- a/tests/tests-automations/regression/api/flows/api-folders-crud.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-folders-crud.spec.ts
@@ -112,9 +112,10 @@ test.describe("Folder (Projects) CRUD via API", () => {
     },
   );
 
-  test(
+  // quarantined for #932 — recurrent flaky association assertion (dailies 2026-07-15, 2026-07-24)
+  test.fixme(
     "moving flow between folders via PATCH folder_id updates association",
-    { tag: ["@stable", "@release", "@api", "@regression"] },
+    { tag: ["@release", "@api", "@regression"] },
     async ({ request }) => {
       const authToken = await getAuthToken(request);
 


### PR DESCRIPTION
Quarantines the recurrent flaky test tracked in #932 as prevention.

**What:** `api-folders-crud.spec.ts:115` ("moving flow between folders via PATCH folder_id updates association") — `toBe` equality mismatch, recurrent on dailies 2026-07-15 and 2026-07-24.

**How:** remove `@stable` **and** add `test.fixme` (both, per the quarantine mechanism — tag removal alone leaves it red on the PR impacted-specs gate, #871). `test.fixme` skips it in every context until #932 is worked.

Restoration (remove `test.fixme` + restore `@stable`, re-validate) is a deliverable of #932.

Refs #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)