### PR TITLE
test(mcp): promote §14.1 MCP Server server-side items to @stable (#948)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -660,12 +660,12 @@
 ### mcp/server/ — Resource and Tool Provider
 
 #### 14.1 MCP Server
-- [-] MCP Server tab in flow
-- [-] Add MCP server via modal
-- [-] Starter project with MCP
-- [-] Flow exposed as MCP server — verify generated endpoint → `mcp/server/mcp-server-protocol.spec.ts`
-- [-] Execute MCP server tool via MCP protocol → `mcp/server/mcp-server-protocol.spec.ts`
-- [-] Resource exposed by server is accessible via URI — flow files are exposed as MCP resources (`resources/list` is `[]` only for a file-less flow; an uploaded flow file appears and is readable via `resources/read`) → `mcp/server/mcp-server-resources.spec.ts`
+- [x] MCP Server tab in flow → `mcp/server/mcp-server-tab.spec.ts`
+- [x] Add MCP server via modal → `mcp/server/mcp-server-tab.spec.ts`
+- [x] Starter project with MCP → `mcp/server/mcp-server-starter-projects.spec.ts`
+- [x] Flow exposed as MCP server — verify generated endpoint → `mcp/server/mcp-server-protocol.spec.ts`
+- [x] Execute MCP server tool via MCP protocol → `mcp/server/mcp-server-protocol.spec.ts`
+- [-] Resource exposed by server is accessible via URI — flow files are exposed as MCP resources: `resources/list` is `@stable`; `resources/read` blocked by a live Langflow regression on 1.12.x (`AttributeError: 'str' object has no attribute 'hex'`, filed upstream **LE-2012**) — kept as a guard, not promoted → `mcp/server/mcp-server-resources.spec.ts`
 - [ ] Prompt exposed by server returns correct template (no product surface on 1.11.x — MCP server `prompts/list` returns `[]`; #829)
 
 ---

--- a/docs/mcp/server/mcp-server-protocol.md
+++ b/docs/mcp/server/mcp-server-protocol.md
@@ -1,6 +1,6 @@
 # MCP Server — flow-as-server endpoint & tool execution over the MCP protocol
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x
 
 ---
 
@@ -30,34 +30,28 @@ counterpart: Langflow *is* the MCP server and a client speaks the protocol to it
 If this fails, Langflow no longer exposes project flows as MCP-server tools, or no
 longer executes them over the protocol — a core MCP-server regression.
 
-### Scope decision — §14.1 items 667/668 are NOT covered (no product surface)
+### Scope decision — resource-by-URI split out; prompt-template not covered
 
-Scouted live on **1.11.0.dev49**: the project MCP server **advertises**
-`resources` and `prompts` capabilities on `initialize`, but `resources/list` and
-`prompts/list` both return **`[]`** — Langflow's MCP server exposes flows only as
-**tools**; there is no UI or API to expose a resource-by-URI or a prompt template.
-Therefore:
-
-- §14.1 "Resource exposed by server is accessible via URI" — **no product surface**;
-  left `[ ]` with a note (not a hollow test).
-- §14.1 "Prompt exposed by server returns correct template" — **no product surface**;
-  left `[ ]` with a note.
-
-A comment recording this is posted on issue #829. Writing an assertion that these
-lists are empty was rejected: it would be a false regression the moment Langflow
-implements either primitive.
+- §14.1 **"Resource exposed by server is accessible via URI"** IS covered — a
+  later scout found that a flow's **uploaded files** are exposed as MCP
+  resources. That dimension lives in the sibling `mcp-server-resources.spec.ts`
+  (`resources/list` + `resources/read`). On 1.12.x `resources/read` hits a live
+  Langflow regression (LE-2012) and is kept as a guard, not promoted; see that
+  spec's doc.
+- §14.1 **"Prompt exposed by server returns correct template"** — **no product
+  surface**: the MCP server's `prompts/list` returns `[]`; left `[ ]` with a
+  note (asserting emptiness was rejected — it would be a false regression the
+  moment Langflow implements the primitive).
 
 ---
 
 ## Tags *(required)*
 
-`@regression` `@api` `@mcp`
+`@stable` `@regression` `@api` `@mcp`
 
-**`@stable` intentionally withheld (promotion gated — issue #829).** MCP is in the
-current flaky cluster (#773) and the issue also flags MCP surface-health
-dependencies (#809 / #643); promote only after the Wave 3 clean baseline.
-`@api` — the MCP protocol is exercised over HTTP JSON-RPC; `@mcp` — MCP server
-area; `@regression` — guards a server-exposure/execution regression.
+**`@stable` — promoted under #948** after repeated clean `--workers=1
+--retries=0` runs on nightly 1.12.0.dev4 and a per-assertion force-failure check. `@api` — the MCP protocol is exercised over HTTP JSON-RPC; `@mcp` — MCP
+server area; `@regression` — guards a server-exposure/execution regression.
 
 ---
 

--- a/docs/mcp/server/mcp-server-resources.md
+++ b/docs/mcp/server/mcp-server-resources.md
@@ -1,6 +1,6 @@
 # MCP Server – List and Read Flow-File Resources
 
-**Last validated:** Langflow 1.11.0
+**Last validated:** Langflow 1.12.x
 
 ---
 
@@ -46,14 +46,21 @@ so this spec validates the surface that actually implements the behavior. The
 
 ## Tags *(required)*
 
-All tests: `@api` `@mcp` `@regression` — pure MCP-protocol (JSON-RPC over HTTP);
+Both tests: `@api` `@mcp` `@regression` — pure MCP-protocol (JSON-RPC over HTTP);
 no UI page, no LLM/agent. Mirrors the tag set of the direct sibling
 `mcp-server-protocol.spec.ts`.
 
-**`@stable` is intentionally withheld.** Per issue #828 the promotion is gated:
-this MCP area is in the current flaky cluster (#773) and the clean non-guarded
-daily baseline (#818) has not yet been achieved. Add `@stable` only after that
-gate is met and the spec has demonstrated repeated clean `--retries=0` runs.
+**Promotion (#948, nightly 1.12.0.dev4):**
+- **T1 `resources/list`** — `@stable`, after repeated clean `--workers=1
+  --retries=0` runs and a force-failure check.
+- **T2 `resources/read`** — **NOT `@stable`.** It hits a live Langflow
+  regression on 1.12.x: the server raises `AttributeError: 'str' object has no
+  attribute 'hex'` because `handle_read_resource` compares the UUID `Flow.id`
+  column to the raw string URI segment without a `UUID(...)` conversion
+  (`mcp_utils.py`). Reproduced 3/3 and proven product-side by a one-line
+  in-container patch. Filed upstream as **LE-2012**
+  (`docs/upstream-bugs/UPSTREAM-BUG-mcp-resources-read-uuid-hex.log`). T2 is kept
+  as a live regression guard and will be promoted once LE-2012 lands.
 
 ---
 

--- a/docs/mcp/server/mcp-server-starter-projects.md
+++ b/docs/mcp/server/mcp-server-starter-projects.md
@@ -1,0 +1,138 @@
+# MCP Server — starter projects & project folder CRUD (UI)
+
+**Last validated:** Langflow 1.12.x
+
+---
+
+## What this test validates *(required)*
+
+Covers the QA-CHECKLIST §14.1 item **"Starter project with MCP"** — every
+Langflow project is exposed as an MCP server on the Settings → MCP Servers page,
+and the default project ships as `lf-starter_project`. Two `test()` cases:
+
+1. **Starter projects appear as MCP servers, and reflect project folder CRUD.**
+   The default project `lf-starter_project` is listed on the MCP Servers settings
+   page. Adding two projects lists them as `lf-new_project` / `lf-new_project_1`;
+   renaming a project renames its MCP server (`lf-renamed_project`); deleting the
+   project removes its MCP server — each verified back on the MCP Servers page.
+2. **Duplicate MCP servers are rejected.** Copying a project's own MCP client
+   config and re-adding it via the Add-MCP-Server modal on the settings page
+   returns exactly one "Server already exists." error.
+
+If this fails, projects are no longer surfaced as MCP servers (or their lifecycle
+is out of sync with the project folder), or the duplicate-server guard is gone.
+
+---
+
+## Tags *(required)*
+
+`@release` `@workspace` `@components` `@mcp` `@stable` (both tests)
+
+- `@stable` — promoted under #948 after repeated clean `--workers=1 --retries=0`
+  runs on nightly 1.12.0.dev4 and a per-test force-failure check.
+- `@workspace` — project/folder management; `@components`/`@mcp` — MCP servers
+  settings; `@release` — happy-path MCP-server surfacing.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`; auto-login superuser.
+- Default MCP starter project `lf-starter_project` present.
+- No LLM / provider key required.
+- Test 2 uses the clipboard (copy the config, paste into the modal).
+
+---
+
+## Step by step *(required)*
+
+**Test 1 — starter projects & folder CRUD**
+
+1. Bootstrap (skip modal); `cleanOldFolders` to start from a known project set.
+2. Settings → **MCP Servers**: assert `mcp_server_name_0` contains
+   `lf-starter_project`.
+3. Add two projects (`add-project-button` ×2); back on MCP Servers, assert
+   `lf-starter_project` still first, and `lf-new_project` / `lf-new_project_1`
+   each appear exactly once.
+4. **Rename** the first "New Project" folder to `renamed_project`; on MCP Servers
+   assert `lf-renamed_project` appears exactly once (and starter still first).
+5. **Delete** the renamed project; on MCP Servers assert `lf-renamed_project`
+   count is 0 (and starter still first).
+
+**Test 2 — duplicate MCP server rejected**
+
+1. Bootstrap; open the **Basic Prompting** template; exit to the flow list.
+2. Open the flow's MCP tab, switch to JSON, copy the config.
+3. Settings → MCP Servers → **Add MCP Server** (`add-mcp-server-button-page`),
+   paste the config, submit (`add-mcp-server-button`).
+4. Assert "Server already exists." is visible and its count is exactly 1.
+
+---
+
+## Validation criterion *(required)*
+
+- **Test 1:** the MCP Servers page mirrors project-folder state at each step —
+  `lf-starter_project` always first; added projects appear by name (count 1);
+  a renamed project's server appears as `lf-renamed_project`; a deleted project's
+  server disappears (count 0).
+- **Test 2:** re-adding an already-registered server surfaces exactly one
+  "Server already exists." error (no silent success, no duplicate rows).
+
+## Guarding against false positives *(how)*
+
+- **Exact-name counts** (`.count()` === 1 / === 0 on `getByText(..., {exact:true})`)
+  instead of "visible", so a stale or partially-matching row cannot pass.
+- **Ordering assert** (`mcp_server_name_0` first) re-checked after every mutation.
+- **`cleanOldFolders`** normalizes the starting project set so the add/rename/
+  delete counts are deterministic.
+- **Force-failure check** (CONTRIBUTING §2) run during VERIFY on the name/count
+  assertions of each test.
+
+---
+
+## What this test does not cover *(optional)*
+
+- MCP tool **selection/config** in the flow tab — `mcp-server-tab.spec.ts`.
+- MCP-server tool **execution** / **resources** over the protocol —
+  `mcp-server-protocol.spec.ts` / `mcp-server-resources.spec.ts`.
+- The client-side add-server field persistence — `mcp-server.spec.ts`.
+
+---
+
+## External dependencies *(required)*
+
+- Settings → MCP Servers page (`mcp_server_name_0`, `add-mcp-server-button-page`,
+  `add-mcp-server-button`, `json-input`) via `helpers/ui/go-to-settings.ts`
+  (`navigateSettingsPages`).
+- Project folder CRUD (`add-project-button`, `more-options-button_<name>`,
+  Rename/Delete, `input-project`, `sidebar-nav-<name>`).
+- `helpers/filesystem/clean-old-folders.ts`, `helpers/filesystem/convert-test-name.ts`,
+  `helpers/other/await-bootstrap-test.ts`.
+- Basic Prompting template + the flow MCP tab (Test 2).
+
+---
+
+## When to review this test *(optional)*
+
+- If projects stop mapping 1:1 to MCP servers, or the `lf-` server-name prefix
+  changes.
+- If the MCP Servers settings page testids or the add-server modal change.
+- If the duplicate-server error copy ("Server already exists.") changes.
+
+---
+
+## Notes *(optional)*
+
+- Test 1 mutates project folders; `cleanOldFolders` in setup keeps the counts
+  deterministic across reruns. Runs `--workers=1` in CI (shared project state).
+- No standalone flows are created that need id-scoped cleanup — the artifacts are
+  **projects/folders**, created and then renamed/deleted within the test; the
+  duplicate-server test adds a server registration, not a flow.
+- **Ambient backend 500 (logged, not failing):** on the MCP Servers settings
+  page the browser session fires `GET /api/v2/mcp/servers/lf-starter_project`,
+  which returns 500 (`InvalidSignatureError: Signature verification failed`) in
+  the auto-login session context — a fresh-token `curl` to the same endpoint
+  returns 200. The fixture logs this as a `🚨 Backend Error` but does **not**
+  fail the test (only `flow_error` fails; `http_error` is log-only). The test's
+  assertions do not depend on that call. Import switched to `fixtures/fixtures.ts`
+  under #948 to gain this monitoring; the 500 is peripheral/pre-existing.

--- a/docs/mcp/server/mcp-server-tab.md
+++ b/docs/mcp/server/mcp-server-tab.md
@@ -1,0 +1,144 @@
+# MCP Server — flow MCP tab, tool selection & add-server modal (UI)
+
+**Last validated:** Langflow 1.12.x
+
+---
+
+## What this test validates *(required)*
+
+Covers two UI items of QA-CHECKLIST §14.1 that concern managing a Langflow
+**project as an MCP server from the UI**:
+
+1. **MCP Server tab in flow** (§14.1). The flow's MCP Server tab renders, lists
+   the project's flows/tools, lets a tool be selected and renamed through the
+   "Edit Tools" (Actions) modal, and the change persists across a reload. The
+   JSON configuration exposes a real, copyable client config (`mcpServers`,
+   `mcp-proxy`, `uvx`, an SSE endpoint URL) and can mint an API key.
+2. **Add MCP server via modal** (§14.1). The generated client config is fed back
+   into the **Add MCP Server** modal (from an MCP-starter-project flow) and, once
+   added, its tools resolve in the `dropdown_str_tool` selector — proving the
+   round-trip (project exposed → registered as an MCP server → tools discovered).
+
+If this fails, the MCP Server tab no longer manages tools, no longer emits a
+valid client configuration, or a server built from that configuration can no
+longer be added and have its tools discovered — a core MCP-server UI regression.
+
+---
+
+## Tags *(required)*
+
+`@release` `@workspace` `@components` `@mcp` `@stable`
+
+- `@stable` — promoted under #948 after repeated clean `--workers=1 --retries=0`
+  runs on nightly 1.12.0.dev4 and a per-assertion force-failure check.
+- `@workspace`/`@components` — drives the flow canvas + MCP tab UI; `@mcp` — MCP
+  server area; `@release` — happy-path MCP-server management.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`; auto-login superuser.
+- The default MCP starter project exists (`lf-starter_project`), so the
+  `add-component-button-lf-starter_project` starter is available in the sidebar.
+- No LLM / provider key required (no agent executes).
+- Clipboard permission (granted by the Playwright config) — the test reads the
+  generated client config via `navigator.clipboard`.
+
+---
+
+## Step by step *(required)*
+
+1. Bootstrap; create a blank flow and drag an **API Request** component onto the
+   canvas (gives the flow a tool to expose), then exit the flow.
+2. Open the **MCP Server tab** (`mcp-btn`); assert `mcp-server-title` and the
+   "Flows/Tools" header are visible.
+3. Open **Edit Tools** (`button_open_actions`) → the "MCP Server Tools" modal.
+   Assert the tools grid has rows/cells; select the first tool (checkbox becomes
+   checked); close the modal.
+4. **Reload**; reopen the MCP tab and the Actions modal; re-select the first data
+   row and rename its action via `input_update_name` → "mcp test name"; close.
+   Assert `div-mcp-server-tools` is visible (the selection persisted).
+5. Switch the config to **JSON** mode; assert a `pre` block renders. If a
+   "Generate API key" button is present, generate the key and assert the JSON
+   flips from `YOUR_API_KEY` to a real non-empty key and the button disappears;
+   otherwise assert the state is already "API key generated".
+6. Copy the config (Windows form): assert it contains `mcpServers`, `mcp-proxy`,
+   `uvx`, and a matchable SSE URL. Switch to **macOS/Linux** form and copy again:
+   assert its `args` SSE URL matches.
+7. Assert the **setup guide** link points at the documented MCP-server anchor.
+8. Bootstrap again; add an **MCP-starter-project** component to a new flow
+   (`add-component-button-lf-starter_project`); open the **Add MCP Server** modal
+   (`openAddMcpServerModal`); paste the Linux config with a unique server name
+   substituted; click `add-mcp-server-button`.
+9. Assert the `dropdown_str_tool` selector becomes enabled and, when opened,
+   exposes at least one tool option (`[data-testid*="-option"]`).
+
+---
+
+## Validation criterion *(required)*
+
+- The MCP Server tab renders (`mcp-server-title` + "Flows/Tools"); a tool can be
+  selected and renamed via the Actions modal, and the selection survives a reload
+  (`div-mcp-server-tools` visible).
+- The generated JSON client config contains `mcpServers` / `mcp-proxy` / `uvx`
+  and a matchable SSE endpoint URL for both the Windows and macOS/Linux forms;
+  the API-key generation flips `YOUR_API_KEY` to a real key when offered.
+- A server added from that config via the modal resolves ≥1 tool option in
+  `dropdown_str_tool` — the exposed-project → added-server round-trip works.
+
+## Guarding against false positives *(how)*
+
+- **Unique server name per run** (`test_server_<random>`) — the modal-add step
+  cannot pass on a stale server from a previous run.
+- **Concrete config asserts** (`mcpServers`/`mcp-proxy`/`uvx` + a regex-matched
+  SSE URL) — a blank or malformed config cannot satisfy them.
+- **Reload gate** — the rename/selection is re-read after `page.reload()`, so a
+  purely client-side (unpersisted) change fails.
+- **Force-failure check** (CONTRIBUTING §2) run during VERIFY on the tab-visible,
+  config-content and tool-count assertions.
+
+---
+
+## What this test does not cover *(optional)*
+
+- MCP-server tool **execution** over the protocol — covered by
+  `mcp-server-protocol.spec.ts`.
+- Flow-file **resources** — covered by `mcp-server-resources.spec.ts`.
+- MCP server **auth_settings** / OAuth composer path.
+- Starter-project folder CRUD — covered by `mcp-server-starter-projects.spec.ts`.
+
+---
+
+## External dependencies *(required)*
+
+- MCP Server tab UI (`mcp-btn`, `mcp-server-title`, `button_open_actions`,
+  `div-mcp-server-tools`, `input_update_name`) and the JSON-config panel
+  (`icon-copy`, API-key generation).
+- Add-MCP-server modal (`add-mcp-server-simple-button` / `mcp-server-dropdown` →
+  `add-mcp-server-button`, `json-input`) via `helpers/mcp/open-add-mcp-server-modal.ts`.
+- The `lf-starter_project` MCP starter (`add-component-button-lf-starter_project`).
+- API Request component (`data_sourceAPI Request`) — the tool exposed on the flow.
+- `helpers/other/await-bootstrap-test.ts`, `helpers/ui/adjust-screen-view.ts`.
+
+---
+
+## When to review this test *(optional)*
+
+- If the MCP Server tab testids, the Actions/Edit-Tools modal, or the JSON client
+  config shape (`mcpServers`/`mcp-proxy`/`uvx`) change.
+- If the add-MCP-server modal flow or `dropdown_str_tool` changes.
+- If the setup-guide docs anchor changes.
+
+---
+
+## Notes *(optional)*
+
+- Single `test()`, heavy UI (loads a flow + MCP starter project). Trace-on may
+  hang on the ReactFlow-canvas family (see the skill's known `--trace=on`
+  limitation); step verification relies on `--retries=0` bursts + force-fail.
+- The API-key generation is branch-guarded because the button only appears when
+  no key exists yet; both branches assert a valid end state.
+- No flows are left behind by design — the flows created live in the default
+  project and the test does not persist named artifacts requiring id-scoped
+  cleanup; folder CRUD is exercised by the sibling starter-projects spec.

--- a/docs/upstream-bugs/UPSTREAM-BUG-mcp-resources-read-uuid-hex.log
+++ b/docs/upstream-bugs/UPSTREAM-BUG-mcp-resources-read-uuid-hex.log
@@ -1,0 +1,136 @@
+================================================================================
+UPSTREAM BUG EVIDENCE LOG
+MCP server `resources/read` — AttributeError: 'str' object has no attribute 'hex'
+================================================================================
+
+Filed upstream : LE-2012 (https://datastax.jira.com/browse/LE-2012)
+Tracked in     : oriontech-me/langflow-e2e#948
+Component      : Langflow — backend, MCP project server
+Handler        : handle_read_resource
+Source         : langflow/api/v1/mcp_utils.py:224 (query build), :202 (namespace_id)
+Endpoint       : POST /api/v1/mcp/project/{project_id}/streamable  (JSON-RPC resources/read)
+Found on       : langflowai/langflow-nightly:latest
+                 version 1.12.0.dev4 (main_version 1.12.0, "Langflow Nightly")
+                 image sha256:c68f66adcaa1a686d57e14c4fefcd4ebc33b94adfeb795ce0c22a0e851c23f4f
+Last known good: 1.11.0 (spec doc "Last validated: 1.11.0")
+Determinism    : reproduced 3/3 runs; not flaky
+Captured       : 2026-07-24, single-worker local run against a fresh nightly
+
+--------------------------------------------------------------------------------
+1. WHAT HAPPENS
+--------------------------------------------------------------------------------
+A text file uploaded into a project flow is correctly advertised by
+`resources/list` (with URI .../api/v1/files/download/{flow_id}/{filename}), but
+calling `resources/read` on that exact URI returns a JSON-RPC error. The server
+advertises a resource it cannot itself read.
+
+resources/list  -> PASS (file surfaces with a URI)
+resources/read  -> FAIL (backend StatementError, see below)
+
+--------------------------------------------------------------------------------
+2. TEST RUNNER OUTPUT (Playwright, --workers=1 --retries=0)
+   tests/tests-automations/regression/mcp/server/mcp-server-resources.spec.ts
+--------------------------------------------------------------------------------
+Running 1 test using 1 worker
+
+  x  1 [chromium] > mcp-server-resources.spec.ts:160:7 > MCP Server — flow-file
+        resources protocol > resources/read returns the uploaded file content by
+        URI @regression @api @mcp (1.9s)
+
+  1) resources/read returns the uploaded file content by URI
+
+    Error (JSON-RPC error returned by the server):
+    {"code":0,"message":"(builtins.AttributeError) 'str' object has no attribute 'hex'
+    [SQL: SELECT flow.name, flow.description, flow.icon_bg_color, flow.gradient,
+     flow.is_component, flow.updated_at, flow.webhook, flow.endpoint_name,
+     flow.data, flow.mcp_enabled, flow.action_name, flow.action_description,
+     flow.access_type, flow.flow_type, flow.a2a_enabled, flow.a2a_card_overrides,
+     flow.id, flow.user_id, flow.icon, flow.tags, flow.locked, flow.folder_id,
+     flow.workspace_id, flow.fs_path
+     FROM flow
+     WHERE flow.id = ? AND flow.user_id = ? AND flow.folder_id = ?]
+    [parameters: [{}]]"}
+
+    expect(received).toBeUndefined()   // asserting resp.error is undefined
+      173 |       );
+      174 |
+    > 175 |       expect(resp.error, JSON.stringify(resp.error)).toBeUndefined();
+          |                                                      ^
+        at mcp-server-resources.spec.ts:175:54
+
+  1 failed
+
+--------------------------------------------------------------------------------
+3. BACKEND TRACEBACK (langflow-e2e-runner container logs; ANSI stripped)
+   Bottom frame — SQLAlchemy UUID type processor
+--------------------------------------------------------------------------------
+/app/.venv/lib64/python3.14/site-packages/sqlalchemy/engine/base.py:2365 in
+_handle_dbapi_exception
+    raise sqlalchemy_exception.with_traceback(exc_info[2] ...
+
+/app/.venv/lib64/python3.14/site-packages/sqlalchemy/engine/default.py:1496
+/app/.venv/lib64/python3.14/site-packages/sqlalchemy/sql/sqltypes.py:3734 in
+process
+
+   3731 │
+   3732 │   def process(value):
+   3733 │       if value is not None:
+ > 3734 │           value = value.hex          <-- str has no .hex; expects UUID
+   3735 │       return value
+
+   locals:
+     value = 'c52702b5-65ad-4510-82c8-583262d10d96'   <-- a valid UUID *string*
+
+StatementError: (builtins.AttributeError) 'str' object has no attribute 'hex'
+[SQL: SELECT ... FROM flow WHERE flow.id = ? AND flow.user_id = ? AND
+ flow.folder_id = ?]
+[parameters: [{}]]
+
+Note: `value` is a well-formed UUID string. The defect is the *type* (str vs
+uuid.UUID), not a malformed id. The SQLAlchemy UUID bind processor calls
+`value.hex`, which only exists on uuid.UUID objects.
+
+--------------------------------------------------------------------------------
+4. ROOT CAUSE  (langflow/api/v1/mcp_utils.py, handle_read_resource)
+--------------------------------------------------------------------------------
+    namespace_id = path_parts[-2]          # line 202: URI path segment -> a raw str
+    ...
+    flow_query = select(Flow).where(
+        Flow.id == namespace_id,           # line 224: Flow.id is a UUID column
+        Flow.user_id == current_user.id,
+    )
+    if project_id is not None:
+        flow_query = flow_query.where(Flow.folder_id == project_id)
+
+`namespace_id` is sliced out of the URI path as a string and never converted to
+UUID. On 1.12 the Flow.id UUID column no longer coerces a bare string, so the
+bind processor raises. `handle_list_resources` is unaffected: it filters on
+`Flow.folder_id == project_id` where `project_id` is already a real UUID passed
+from the route — hence list works while read crashes.
+
+--------------------------------------------------------------------------------
+5. PROPOSED FIX (one line; module already imports UUID)
+--------------------------------------------------------------------------------
+    flow_query = select(Flow).where(
+        Flow.id == UUID(str(namespace_id)),
+        Flow.user_id == current_user.id,
+    )
+
+Guard the coercion for the user-bucket branch (namespace may be the user's own
+id rather than a flow id): wrap in try/except ValueError and fall through to the
+existing user-level handling on a non-UUID segment.
+
+--------------------------------------------------------------------------------
+6. FIX VERIFIED IN-CONTAINER
+--------------------------------------------------------------------------------
+Applied the one-line change to mcp_utils.py inside the running 1.12.0.dev4
+container, restarted, re-ran the identical spec (no test/client change):
+
+  ✓  1 resources/list surfaces the uploaded flow file as a resource (133ms)
+  ✓  2 resources/read returns the uploaded file content by URI (40ms)
+  2 passed (2.0s)
+
+Changing only this product line flips read from FAIL to PASS, isolating the
+defect to line 224, server-side. The container was then recreated from the
+pristine image for the remainder of validation.
+================================================================================

--- a/tests/tests-automations/regression/mcp/server/mcp-server-protocol.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-protocol.spec.ts
@@ -20,12 +20,12 @@ import { mcpCall, mcpHandshake } from "../../../../helpers/mcp/mcp-streamable-cl
  *   T2 — tools/call runs the flow and echoes a unique sentinel back through the
  *        protocol (deterministic, no LLM).
  *
- * §14.1 resource-by-URI and prompt-template are NOT covered: Langflow's MCP
- * server exposes flows only as tools — resources/list and prompts/list return []
- * on 1.11.0.dev49 (no product surface). See docs/mcp/server/mcp-server-protocol.md.
+ * Resource-by-URI is covered separately in mcp-server-resources.spec.ts;
+ * prompt-template is NOT covered — the MCP server's prompts/list returns [] (no
+ * product surface). See docs/mcp/server/mcp-server-protocol.md.
  *
- * `@stable` withheld — promotion gated (#829; MCP flaky cluster #773, surface
- * deps #809/#643).
+ * `@stable` — promoted under #948 (validated on nightly 1.12.0.dev4: repeated
+ * clean --workers=1 --retries=0 runs + per-assertion force-failure check).
  */
 
 // Shared project MCP settings are instance-wide; run serially so a second
@@ -85,7 +85,7 @@ test.describe("MCP Server — flow-as-server protocol", () => {
 
   test(
     "generated endpoint advertises the project and lists the enabled flow",
-    { tag: ["@regression", "@api", "@mcp"] },
+    { tag: ["@stable", "@regression", "@api", "@mcp"] },
     async ({ request }) => {
       await test.step("composer-url returns the generated endpoint URLs", async () => {
         const res = await request.get(
@@ -126,7 +126,7 @@ test.describe("MCP Server — flow-as-server protocol", () => {
 
   test(
     "execute the exposed tool over the MCP protocol echoes the input",
-    { tag: ["@regression", "@api", "@mcp"] },
+    { tag: ["@stable", "@regression", "@api", "@mcp"] },
     async ({ request }) => {
       // Unique sentinel: a canned/empty/cached response cannot echo this exact
       // string, so a pass proves the call round-tripped through the flow.

--- a/tests/tests-automations/regression/mcp/server/mcp-server-resources.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-resources.spec.ts
@@ -22,8 +22,14 @@ import { mcpCall, mcpHandshake } from "../../../../helpers/mcp/mcp-streamable-cl
  * The client side (§13.1) is NOT covered — the MCPTools component / v2 client
  * API expose tools only, no resource surface exists to test.
  *
- * `@stable` withheld — promotion gated (issue #828; MCP flaky cluster #773,
- * clean-baseline gate #818, surface deps #809/#643).
+ * Promotion (#948, nightly 1.12.0.dev4): T1 (resources/list) is `@stable` after
+ * repeated clean --retries=0 runs + a force-failure check. T2 (resources/read)
+ * is NOT promoted — it hits a live Langflow regression on 1.12.x: the server
+ * throws `AttributeError: 'str' object has no attribute 'hex'` because
+ * handle_read_resource compares the UUID `Flow.id` column to the raw string URI
+ * segment without converting it to UUID (mcp_utils.py). Filed upstream as
+ * LE-2012; see docs/upstream-bugs/UPSTREAM-BUG-mcp-resources-read-uuid-hex.log.
+ * T2 is kept as a live regression guard and will be promoted once LE-2012 lands.
  */
 
 // A resource read can arrive base64-encoded (blob), and on 1.11.0 the blob is
@@ -119,7 +125,7 @@ test.describe("MCP Server — flow-file resources protocol", () => {
 
   test(
     "resources/list surfaces the uploaded flow file as a resource",
-    { tag: ["@regression", "@api", "@mcp"] },
+    { tag: ["@stable", "@regression", "@api", "@mcp"] },
     async ({ request }) => {
       await mcpHandshake(request, streamableUrl, authorization);
 
@@ -157,6 +163,10 @@ test.describe("MCP Server — flow-file resources protocol", () => {
     },
   );
 
+  // NOT @stable — resources/read is broken on Langflow 1.12.x (LE-2012): the
+  // server raises AttributeError 'str' has no attribute 'hex' (UUID column vs
+  // raw string URI segment in handle_read_resource). Kept as a live regression
+  // guard; promote to @stable once the upstream fix lands.
   test(
     "resources/read returns the uploaded file content by URI",
     { tag: ["@regression", "@api", "@mcp"] },

--- a/tests/tests-automations/regression/mcp/server/mcp-server-starter-projects.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-starter-projects.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { cleanOldFolders } from "../../../../helpers/filesystem/clean-old-folders";
 import { convertTestName } from "../../../../helpers/filesystem/convert-test-name";
@@ -6,7 +6,7 @@ import { navigateSettingsPages } from "../../../../helpers/ui/go-to-settings";
 
 test(
   "user must be able to see starter projects for mcp servers",
-  { tag: ["@release", "@workspace", "@components", "@mcp"] },
+  { tag: ["@stable", "@release", "@workspace", "@components", "@mcp"] },
   async ({ page }) => {
     //starter mcp project
 
@@ -104,7 +104,7 @@ test(
 
 test(
   "user must not be able to add duplicate mcp servers from starter projects",
-  { tag: ["@release", "@workspace", "@components", "@mcp"] },
+  { tag: ["@stable", "@release", "@workspace", "@components", "@mcp"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 

--- a/tests/tests-automations/regression/mcp/server/mcp-server-tab.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-tab.spec.ts
@@ -5,7 +5,7 @@ import { openAddMcpServerModal } from "../../../../helpers/mcp/open-add-mcp-serv
 
 test(
   "user should be able to manage MCP server tools and configuration",
-  { tag: ["@release", "@workspace", "@components", "@mcp"] },
+  { tag: ["@stable", "@release", "@workspace", "@components", "@mcp"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 


### PR DESCRIPTION
Closes #948 · Roadmap: Wave 4 — Canvas UI/UX & MCP

## What this promotes

Validate & promote the QA-CHECKLIST **§14.1 MCP Server** items to `@stable`.
Six tests promoted after repeated clean `--workers=1 --retries=0` runs on
nightly **1.12.0.dev4** and a per-test **executed force-failure** check.

| Test | §14.1 item | Force-fail (executed → reverted) |
|---|---|---|
| `mcp-server-tab.spec.ts` | tab in flow + add via modal | `toContain("mcpServers")` → mutated → **failed** |
| `mcp-server-starter-projects.spec.ts` — starter projects | starter project with MCP | `"lf-starter_project"` → mutated → **failed** |
| `mcp-server-starter-projects.spec.ts` — duplicate | (guard) | `toBe(1)` → `toBe(999)` → **failed** |
| `mcp-server-protocol.spec.ts` — endpoint | flow exposed as MCP server | `toContain(actionName)` → mutated → **failed** |
| `mcp-server-protocol.spec.ts` — execute | execute tool via protocol | `toBe(sentinel)` → mutated → **failed** |
| `mcp-server-resources.spec.ts` — list | resource accessible via URI (list half) | `toBe(uploadedName)` → mutated → **failed** |

All 6 force-fails executed and failed, then reverted (`grep FF948` = 0 hits).

## Also included

- Author the two missing spec docs (`mcp-server-tab.md`, `mcp-server-starter-projects.md`); refresh `mcp-server-protocol.md` / `mcp-server-resources.md` to `Last validated 1.12.x` with promotion notes.
- `mcp-server-starter-projects.spec.ts` import switched to `fixtures/fixtures.ts` (backend-error monitoring). It logs a peripheral, **non-failing** session-context 500 on `GET /api/v2/mcp/servers/lf-starter_project` (`InvalidSignatureError`; a fresh-token curl returns 200) — documented in the spec doc.

## Not promoted — live Langflow regression (LE-2012)

`mcp-server-resources.spec.ts` **T2 `resources/read`** fails 3/3 on 1.12.x:
`AttributeError: 'str' object has no attribute 'hex'`. Root cause:
`handle_read_resource` compares the UUID `Flow.id` column to the raw string URI
segment without a `UUID(...)` conversion (`mcp_utils.py`). Proven product-side by
a one-line in-container patch (read flips to green with no test change). Filed
upstream **[LE-2012](https://datastax.jira.com/browse/LE-2012)**; evidence in
`docs/upstream-bugs/UPSTREAM-BUG-mcp-resources-read-uuid-hex.log`. Kept as a live
regression guard (`@regression`, **not** `@stable`). §14.1 bullet left `[-]` with
a note. Prompt-template stays `[ ]` (no product surface; `prompts/list` → `[]`).

## Validation

- Langflow Nightly **1.12.0.dev4** (`main_version` 1.12.0), fresh image.
- Survivors: 2 clean burst rounds + final run — 5 passed + `resources/list` passed.
- `resources/read` guard: fails as expected (LE-2012).
- `tsc --noEmit` clean; `eslint` 0 errors on touched files.
- QA-CHECKLIST edits are Part II §14.1 bullets only; the guard confirms no
  auto-generated block was touched.
- Flow cleanup: API specs delete their passthrough flows id-scoped in `afterAll`
  (0 orphans remaining); UI specs create bounded, non-accumulating template flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)