### PR TITLE
ci(pr-validation): skip collect-models when no impacted spec needs provider models (#952)

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -75,6 +75,7 @@ jobs:
     outputs:
       specs: ${{ steps.diff.outputs.specs }}
       has_specs: ${{ steps.diff.outputs.has_specs }}
+      needs_models: ${{ steps.diff.outputs.needs_models }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -94,6 +95,31 @@ jobs:
             echo "has_specs=false" >> "$GITHUB_OUTPUT"
           fi
           echo "specs=$SPECS" >> "$GITHUB_OUTPUT"
+
+          # Decide whether the impacted specs need provider model data. Only
+          # LLM-dependent specs consume collect-models output (models.json), so
+          # running "Collect models" for an LLM-free PR needlessly gates it on
+          # provider key health — a provider billing/quota outage then reddens a
+          # PR that never touches that provider (the recurring #915/#910/#911
+          # class). A spec needs models if it lives in an always-LLM area
+          # (llm-agents/ or model-provider/) OR its content references a
+          # collect-models consumer (getTestTargets / SimpleAgentTemplatePage /
+          # provider-setup / models.json / MODEL_TEST_ID) — this catches the
+          # cross-area consumers (mcp/client agent specs, the loop-component
+          # regression) without a blanket path rule, and leaves LLM-free specs
+          # (e.g. mcp/server/*) out.
+          NEEDS_MODELS=false
+          for f in $SPECS; do
+            case "$f" in
+              tests/tests-automations/regression/core-functionality/llm-agents/*|tests/tests-automations/regression/core-functionality/model-provider/*)
+                NEEDS_MODELS=true; break;;
+            esac
+            if grep -qE 'getTestTargets|SimpleAgentTemplatePage|provider-setup|models\.json|MODEL_TEST_ID' "$f" 2>/dev/null; then
+              NEEDS_MODELS=true; break
+            fi
+          done
+          echo "Needs provider models: $NEEDS_MODELS"
+          echo "needs_models=$NEEDS_MODELS" >> "$GITHUB_OUTPUT"
 
   e2e:
     name: Run impacted E2E specs
@@ -160,7 +186,11 @@ jobs:
       # ~1-token completion and writes only ACCESSIBLE models, so agent specs
       # resolve a usable model — matching what the daily validates (no
       # divergence). Same provider keys as daily-stable.yml.
+      # Skipped when no impacted spec needs provider model data (see detect-specs
+      # → needs_models). Keeps a provider billing/quota outage from reddening a
+      # PR whose specs never use that provider (#915/#910/#911 class).
       - name: Collect models
+        if: needs.detect-specs.outputs.needs_models == 'true'
         env:
           CI: "true"
           # This run is what IMPORTS the provider credentials into Langflow, so


### PR DESCRIPTION
Closes #952

## Problem

`pr-validation.yml` runs **Collect models** on every PR that touches a spec.
`collect-models.spec.ts` hard-fails when an env-keyed provider probes `inactive`
(the #570 coverage-erosion guarantee) — which also fires on a transient
**billing/quota outage** (Anthropic `credit balance is too low`, OpenAI
`insufficient_quota`). That reddens the impacted-specs job of **every** PR,
including PRs whose specs never touch a provider (MCP server, UI, API). Recurring
`ci-provider-key-gate` class: blocked #915 / #910 / #911, and #951 right now.

## Fix (Approach A)

Only LLM-dependent specs consume collect-models output (`models.json`), so gate
the step on that.

- `detect-specs` emits **`needs_models`** — `true` when a changed spec is under
  `core-functionality/llm-agents/` or `core-functionality/model-provider/`, **or**
  its content references a consumer (`getTestTargets` / `SimpleAgentTemplatePage` /
  `provider-setup` / `models.json` / `MODEL_TEST_ID`). Catches cross-area
  consumers (mcp/client agent specs, loop-component regression) without a blanket
  path rule; leaves LLM-free specs (`mcp/server/*`) out.
- **Collect models** guarded with `if: needs.detect-specs.outputs.needs_models == 'true'`.

LLM-free PRs stop being gated on provider key health; LLM PRs stay gated (an agent
spec genuinely can't validate without a model).

## Scope / safety

`pr-validation.yml` **only**. `daily-stable.yml` / `nightly.yml` and the #570
logic in `collect-models.spec.ts` are untouched — real coverage validation is
unchanged. No test/product code touched; this repo has no production runtime.

## Validation

- YAML parse ✓; `actionlint` ✓.
- Classifier simulated in **bash** (CI's shell) across sample spec sets:
  - `mcp/server/*` (LLM-free) → **false**
  - `llm-agents/`, `mcp/client` agent, `core-components/loop-component`, mixed → **true**
  - empty → **false**
- Final proof: the next PR-CI run (this PR itself is spec-free → the `e2e` job is skipped by the existing `has_specs` gate).

## Follow-up (not in scope)

Approach B: for LLM PRs, downgrade a *transient* billing/quota error to a warning
when ≥1 other provider is active, so one provider's lapse doesn't block an LLM PR
while genuine key rot (401/403) still fails loud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)