### PR TITLE
test(mcp): promote §13.1 MCP Client remainder to @stable (#947)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -642,16 +642,16 @@
 ### mcp/client/ — Tool and Context Consumption
 
 #### 13.1 MCP Client
-- [-] Configure connection with external MCP server (stdio or HTTP) → `mcp/client/mcp-client-regression.spec.ts`
-- [-] List available tools via MCP protocol → `mcp/client/mcp-client-regression.spec.ts`
-- [-] Execute MCP server tool and receive result in flow → `mcp/client/mcp-client-regression.spec.ts`
-- [-] MCP server connection error — unreachable server produces empty tool dropdown → `mcp/client/mcp-client-regression.spec.ts`
-- [-] Configure connection via HTTP form tab → `mcp/client/mcp-client-regression.spec.ts`
-- [-] Execute numeric tool with inputs and verify result → `mcp/client/mcp-client-regression.spec.ts`
+- [x] Configure connection with external MCP server (stdio or HTTP) → `mcp/client/mcp-client-regression.spec.ts`
+- [x] List available tools via MCP protocol → `mcp/client/mcp-client-regression.spec.ts`
+- [x] Execute MCP server tool and receive result in flow → `mcp/client/mcp-client-regression.spec.ts`
+- [x] MCP server connection error — unreachable server produces empty tool dropdown → `mcp/client/mcp-client-regression.spec.ts`
+- [x] Configure connection via HTTP form tab → `mcp/client/mcp-client-regression.spec.ts`
+- [x] Execute numeric tool with inputs and verify result → `mcp/client/mcp-client-regression.spec.ts`
 - [x] Duplicate MCP server registration returns 409 Conflict → `mcp/client/mcp-server-registration-status-codes.spec.ts`
 - [x] Deleting a non-existent MCP server returns 404 Not Found → `mcp/client/mcp-server-registration-status-codes.spec.ts`
-- [-] Agent uses MCPTools as tool and calls echo via MCP → `mcp/client/mcp-client-agent.spec.ts`
-- [-] Gemini × MCP tool-calling regression — agent runs but invokes no echo MCP tool (guards upstream #440) → `mcp/client/mcp-client-agent-gemini-tool-regression.spec.ts`
+- [x] Agent uses MCPTools as tool and calls echo via MCP → `mcp/client/mcp-client-agent.spec.ts`
+- [x] Gemini × MCP tool-calling regression — agent invokes the echo MCP tool (regression for fixed upstream #440) → `mcp/client/mcp-client-agent-gemini-tool-regression.spec.ts`
 - [ ] List available resources via MCP protocol (client not-implementable on 1.11.x — MCPTools component and v2 client API expose tools only; server-side resources covered in §14.1 → `mcp/server/mcp-server-resources.spec.ts`)
 - [ ] Consume resource URI and inject content into flow (client not-implementable on 1.11.x — no client resource surface; server-side read covered in §14.1 → `mcp/server/mcp-server-resources.spec.ts`)
 

--- a/docs/mcp/client/mcp-client-agent-gemini-tool-regression.md
+++ b/docs/mcp/client/mcp-client-agent-gemini-tool-regression.md
@@ -1,6 +1,6 @@
 # MCP Client – Gemini Tool-Calling Regression (#440)
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x
 **Tracking issue:** oriontech-me/langflow-e2e #858 · **Upstream bug:** langflow-ai/langflow #440
 
 ---
@@ -35,12 +35,13 @@ Gemini pinned and named in the test title (self-attributing signal), and a
 unique assertion read from the monitor API (backend truth, immune to frontend
 selector drift and to the `toBeHidden` flake).
 
-**Direction of the assert.** While #440 is **open upstream**, the test asserts
-the **currently-broken** behavior — the agent runs and answers but invokes **no**
-`echo` MCP tool — and therefore **passes** today. It **flips red the moment
-Langflow fixes #440** (an `echo` tool_use block starts being persisted): a red
-here is the promote signal — remove this guard and fold Gemini back into
-`mcp-client-agent`'s coverage.
+**Direction of the assert.** #440 is **FIXED** as of Langflow **1.12.0.dev5**
+(validated under #947, `gemini-flash-latest`, 3/3 deterministic: `echoToolUseCount`
+= 1 with the reply carrying the echoed payload). The test now asserts the
+**fixed** behavior — the agent runs, answers, **and invokes** the `echo` MCP tool
+at least once. It is a **forward regression**: it flips red if Langflow ever
+regresses Gemini × MCP tool-calling (the `echo` tool_use count drops back to 0,
+the #440 state).
 
 `test.fail()` was deliberately **rejected**. It converts *any* failure (a broken
 bootstrap, a down instance, an unregistered MCP server) into a green "expected
@@ -54,14 +55,11 @@ check encodes the expected #440 state.
 
 ## Tags *(required)*
 
-`@mcp` `@agents` `@regression` `@model-provider`
+`@mcp` `@agents` `@regression` `@model-provider` `@stable`
 
-> **No `@stable` yet (intentional).** The test genuinely passes while #440 is
-> open (it asserts the broken state), so it is `@stable`-eligible in principle —
-> but it is held out of `@stable` until team-validated against a nightly with the
-> UI served, since authoring could only validate it statically (typecheck + lint)
-> against an API-only local instance. Promote after one green nightly run.
-> Absence tracked by upstream #440.
+> **`@stable` — promoted under #947** after #440 was confirmed fixed on
+> 1.12.0.dev5 and the positive assertion (Gemini invokes `echo`) ran clean
+> `--workers=1 --retries=0` with a per-test force-failure check.
 
 ---
 
@@ -84,22 +82,21 @@ check encodes the expected #440 state.
    agent turn for this session (keyed by the nonce) is persisted.
 8. Assert (pipeline ran): the final reply contains the echoed payload
    (`hello mcp`).
-9. Assert (**the #440 flip**): the count of persisted `tool_use` blocks named
-   `/echo/i` for the session is **0** — Gemini invoked no `echo` MCP tool.
+9. Assert (**the #440 fix**): the count of persisted `tool_use` blocks named
+   `/echo/i` for the session is **> 0** — Gemini invoked the `echo` MCP tool.
 
 ---
 
 ## Validation criterion *(required)*
 
-- **While #440 open:** step 8 passes (a reply with `hello mcp` is produced) **and**
-  step 9's `echoToolUseCount === 0` holds → the test **passes**, documenting the
-  bug. A false pass — the count reading 0 because the pipeline never ran — is
-  prevented by step 8 (the persisted reply proves the agent completed a turn, so
-  a tool call was genuinely possible) and by the loud setup asserts (a broken
-  bootstrap / MCP registration fails before reaching step 9).
-- **When #440 is fixed:** an `echo` `tool_use` block is persisted →
-  `echoToolUseCount > 0` → step 9 **fails loudly**, signalling that the guard
-  must be removed and Gemini folded back into `mcp-client-agent` coverage.
+- **#440 fixed (current):** step 8 passes (a reply with `hello mcp` is produced)
+  **and** step 9's `echoToolUseCount > 0` holds → the test **passes**, proving
+  Gemini invoked the `echo` MCP tool. A false pass is prevented by step 8 (the
+  persisted reply proves the agent completed a turn) and by the loud setup asserts
+  (a broken bootstrap / MCP registration fails before reaching step 9).
+- **If #440 regresses:** no `echo` `tool_use` block is persisted →
+  `echoToolUseCount === 0` → step 9 **fails loudly**, signalling Gemini × MCP
+  tool-calling has regressed to the #440 state.
 
 ---
 

--- a/docs/mcp/client/mcp-client-regression.md
+++ b/docs/mcp/client/mcp-client-regression.md
@@ -1,6 +1,6 @@
 # MCP Client – Configure and Execute Tool
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.12.x
 
 ---
 

--- a/tests/tests-automations/regression/mcp/client/mcp-client-agent-gemini-tool-regression.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-agent-gemini-tool-regression.spec.ts
@@ -14,28 +14,26 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 /**
  * MCP Client – Gemini tool-calling regression (upstream Langflow #440).
  *
- * Guards the Gemini × MCP tool-calling path IN ISOLATION. On 1.11.0
- * gemini-2.5-flash calls native Langflow tools (URL, Web Search, Calculator)
- * but silently does NOT invoke MCP tools (`echo`) — bug #440. The generic
- * mcp-client-agent.spec.ts could not surface this: its three provider variants
- * share a file-scope `mode: "serial"` group, the OpenAI variant runs first and
- * flakes daily on an unrelated `toBeHidden` timeout, and in serial mode a
- * failure SKIPS every later test — so the Gemini variant (the only one that
- * exercises #440) never ran. This file is deliberately standalone (no shared
- * serial group), pins Gemini and names it in the title (self-attributing
- * signal). See docs/mcp/client/mcp-client-agent-gemini-tool-regression.md.
+ * Covers the Gemini × MCP tool-calling path IN ISOLATION. Historically (1.11.0,
+ * gemini-2.5-flash) Gemini called native Langflow tools (URL, Web Search,
+ * Calculator) but silently did NOT invoke MCP tools (`echo`) — bug #440. The
+ * generic mcp-client-agent.spec.ts could not surface Gemini specifically: its
+ * provider variants share a file-scope `mode: "serial"` group where an earlier
+ * variant's failure SKIPS the later ones, so the Gemini variant could be masked.
+ * This file is deliberately standalone (no shared serial group), pins Gemini and
+ * names it in the title (self-attributing signal).
+ * See docs/mcp/client/mcp-client-agent-gemini-tool-regression.md.
  *
  * DIRECTION OF THE ASSERT (read before "fixing" this test):
- * While #440 is OPEN, this test asserts the CURRENTLY-BROKEN behavior — the
- * agent runs and answers but invokes NO `echo` MCP tool — via the monitor API
- * (backend truth, immune to frontend selector drift). It therefore PASSES today
- * and FLIPS RED the moment Langflow fixes #440 (an `echo` tool_use block starts
- * being persisted). A red here is the promote signal: remove this guard, fold
- * Gemini back into mcp-client-agent's coverage, promote to @stable.
- * `test.fail()` was deliberately rejected: it converts ANY failure (a broken
- * bootstrap, a down instance, an unregistered MCP server) into a green
- * "expected failure", masking real breakage — proven live during authoring.
- * Here the setup asserts stay LOUD: infra breakage goes genuinely red.
+ * #440 is FIXED as of Langflow 1.12.0.dev5 (validated under #947, gemini-flash-
+ * latest, 3/3 deterministic). This test now asserts the FIXED behavior — the
+ * agent runs, answers, AND invokes the `echo` MCP tool at least once — via the
+ * monitor API (backend truth, immune to frontend selector drift). It is a
+ * forward regression: it FLIPS RED if Langflow ever regresses Gemini × MCP
+ * tool-calling (echo tool_use count drops back to 0). `test.fail()` was
+ * deliberately rejected: it converts ANY failure (a broken bootstrap, a down
+ * instance, an unregistered MCP server) into a green "expected failure", masking
+ * real breakage. Here the setup asserts stay LOUD: infra breakage goes red.
  */
 
 if (!process.env.CI) {
@@ -44,7 +42,13 @@ if (!process.env.CI) {
 
 // Worker- and timestamp-suffixed name prevents cross-file races with the other
 // specs that also register an "everything" MCP server.
-const MCP_SERVER_NAME = `everything-gemini-${process.env.TEST_WORKER_INDEX ?? "0"}-${Date.now()}`;
+// Langflow silently truncates a registered MCP server name to 30 chars. A
+// base-10 `Date.now()` suffix pushed `everything-gemini-<worker>-<ts>` to 33
+// chars, so the stored name was truncated and the sidebar testid
+// (`add-component-button-<name>`) never matched the full name — the spec timed
+// out registering the server, and afterEach then failed to delete it (leaking an
+// orphan MCP server). A base-36 timestamp keeps the name ≤ 30 chars.
+const MCP_SERVER_NAME = `everything-gemini-${process.env.TEST_WORKER_INDEX ?? "0"}-${Date.now().toString(36)}`;
 const MCP_JSON_CONFIG = JSON.stringify({
   mcpServers: {
     [MCP_SERVER_NAME]: {
@@ -149,8 +153,8 @@ test.describe(`MCP Client – Gemini tool regression (#440) [${PROVIDER} / ${gem
   });
 
   test(
-    "Gemini runs but invokes no echo MCP tool (guards upstream #440)",
-    { tag: ["@mcp", "@agents", "@regression", "@model-provider"] },
+    "Gemini invokes the echo MCP tool (regression for fixed upstream #440)",
+    { tag: ["@mcp", "@agents", "@regression", "@model-provider", "@stable"] },
     async ({ page, request }) => {
       test.skip(!!skipReason, skipReason ?? "");
       test.skip(
@@ -271,7 +275,7 @@ test.describe(`MCP Client – Gemini tool regression (#440) [${PROVIDER} / ${gem
         ).toBeVisible({ timeout: 10000 });
       });
 
-      await test.step("#440: agent completes a turn but invokes no echo MCP tool", async () => {
+      await test.step("#440 (fixed): agent completes a turn and invokes the echo MCP tool", async () => {
         await waitForAgentToFinish(page);
 
         // Poll the monitor until the agent turn for this session is persisted —
@@ -295,16 +299,16 @@ test.describe(`MCP Client – Gemini tool regression (#440) [${PROVIDER} / ${gem
           "Agent must produce a final reply containing the echoed payload",
         ).toMatch(new RegExp(ECHO_PAYLOAD, "i"));
 
-        // The #440 flip (backend truth, no frontend selector drift): while the
-        // bug is OPEN, Gemini invokes NO `echo` MCP tool → count is 0 and this
-        // passes. When Langflow FIXES #440, an `echo` tool_use block starts
-        // being persisted → count > 0 → this FAILS. A red here means: #440 is
-        // fixed — remove this guard and promote Gemini into mcp-client-agent.
+        // The #440 fix (backend truth, no frontend selector drift): #440 is
+        // FIXED, so Gemini persists at least one `echo` MCP tool_use block for
+        // this turn → count > 0. This is a forward regression: if Langflow ever
+        // regresses Gemini × MCP tool-calling, the count drops back to 0 and
+        // this FAILS loudly (see spec doc / header for the #440 history).
         expect(
           turn!.echoToolUseCount,
-          "EXPECTED while Langflow #440 is open: Gemini invoked NO 'echo' MCP tool. " +
-            "If this fails, #440 is FIXED — promote this guard (see spec doc).",
-        ).toBe(0);
+          "Gemini must invoke the 'echo' MCP tool at least once (regression for fixed #440). " +
+            "A 0 count means Gemini × MCP tool-calling regressed to the #440 state.",
+        ).toBeGreaterThan(0);
       });
     },
   );

--- a/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
@@ -174,7 +174,7 @@ for (const { label, options, skipReason } of targets) {
 
     test(
       "agent calls echo MCP tool and returns echoed message",
-      { tag: ["@mcp", "@agents", "@regression"] },
+      { tag: ["@mcp", "@agents", "@regression", "@stable"] },
       async ({ page }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(

--- a/tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts
@@ -130,7 +130,7 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
 
   test(
     "configures MCP server via JSON, selects echo tool, runs it, and verifies output",
-    { tag: ["@mcp", "@regression"] },
+    { tag: ["@mcp", "@regression", "@stable"] },
     async ({ page }) => {
       // Allow backend errors — npx server may return transient errors while starting
       (page as any).allowFlowErrors();


### PR DESCRIPTION
Closes #947 · Roadmap: Wave 4 — Canvas UI/UX & MCP

## What this promotes

Validate & promote the QA-CHECKLIST **§13.1 MCP Client** remainder to `@stable`.
Six tests validated via clean `--workers=1 --retries=0` bursts on nightly
**1.12.0.dev5** + a per-test **executed force-failure** check.

| Test | Observable | FF (executed → reverted) |
|---|---|---|
| regression: configure via JSON, run echo | node output shows `oi` | `getByText("oi")`→`oi-FFMUT` → **failed** |
| regression: unreachable → empty dropdown | `dropdown_str_tool` options `toHaveCount(0)` | `0`→`999` → **failed** |
| regression: configure via HTTP form tab | server present in `GET /api/v2/mcp/servers` | `toBeTruthy()`→`toBeFalsy()` → **failed** |
| regression: get-sum numeric tool | output `The sum of 3 and 5 is 8.` | `is 8.`→`is 999.` → **failed** |
| agent: agent calls echo MCP tool | `tool_echo` chip + reply contains `hello mcp` | `/hello mcp/i`→`/hello mcp FFMUT/i` → **failed** |
| gemini: Gemini invokes echo MCP tool | `echoToolUseCount > 0` (monitor API) + reply payload | `toBeGreaterThan(0)`→`toBe(-1)` → **failed** |

All 6 force-fails executed, failed as expected, then reverted (0 `FF-MUTATION` markers; final green run ✓).

## Findings

- **Upstream Langflow #440 is FIXED** (1.12.0.dev5, `gemini-flash-latest`, 3/3 deterministic: `echoToolUseCount=1` with the reply carrying the echoed payload). The guard asserted `echoToolUseCount===0` (bug-open state) and flipped red. **Converted it to a positive forward-regression test** — Gemini MUST invoke `echo` (count > 0). Rewrote assertion, title, header comment, and the spec doc.
- **Test defect fixed:** `MCP_SERVER_NAME` exceeded Langflow's **30-char** server-name limit (silent truncation), so the sidebar testid never matched (registration timed out) and `afterEach` failed to delete the server (leaked an orphan). Shortened via a base-36 timestamp (≤ 30 chars).
- **#809 watch reconciled:** the tool-call steps completed clean across the bursts; the `toBeHidden` loading-timeout signature did not reproduce on dev5.

## Scope / safety

`§13.1` bullets edited (Part II only; generated blocks regenerate on merge). No
product code. Provider data: openai + google active, anthropic inactive (no
credit) → anthropic agent variant auto-skips.

## Validation

- Langflow Nightly **1.12.0.dev5**.
- Bursts: gemini 3/3, regression 4/4, agent 3/3 — 0 unexpected, 0 flaky, 0 backend errors.
- `tsc --noEmit` = 0; `eslint` = 0 errors.
- Flow cleanup verified: 0 orphan flows, 0 leftover `everything-*` MCP servers.

## Note

With #440 fixed, the related tracker(s) can be closed/updated — the Gemini spec
is now a forward regression rather than a bug guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)