### PR TITLE
ci(collect-models): downgrade transient billing/quota outage to a warning (#955)

### DIFF
--- a/tests/collect-models.spec.ts
+++ b/tests/collect-models.spec.ts
@@ -79,25 +79,59 @@ test(
       }
     });
 
-    await test.step("every env-keyed provider is ACTIVE — inactive silently skips its whole parametrization", async () => {
+    await test.step("every env-keyed provider is ACTIVE (transient billing/quota outages warn, don't fail)", async () => {
       // The #570 guarantee: a provider whose key is configured but that ends
       // "inactive" silently test.skip()s every spec parametrized on it (16
       // OpenAI-variant agent tests on 2026-07-08) — and a skip never trips
       // the daily-failure gate. With the candidate fallback in collectAll,
-      // inactive-with-key now means ALL probed candidates failed: a real
+      // inactive-with-key means ALL probed candidates failed: a real
       // key/account/provider problem that must fail this spec (and the CI
       // "Collect models" step) loudly instead of eroding coverage quietly.
+      //
+      // EXCEPTION (#952 follow-up / Approach B): a *transient billing/quota*
+      // outage (Anthropic "credit balance is too low", OpenAI
+      // "insufficient_quota", Google RESOURCE_EXHAUSTED, 402/429) is an ops
+      // state, not a code/config defect. Failing on it reddens every LLM PR —
+      // even ones that don't depend on the drained provider — until someone
+      // tops up the account (the recurring #915/#910/#911 class). So a
+      // billing/quota inactive is downgraded to a loud WARNING while at least
+      // one provider is still active; genuine key rot (401 invalid key, 403 no
+      // model access, etc.) still fails LOUD, and a total wipeout (zero active
+      // providers) still fails.
+      const BILLING_OR_QUOTA =
+        /credit balance is too low|insufficient[_ ]?quota|exceeded your current quota|\bquota\b|resource[_ ]?exhausted|billing|payment required|\b402\b|\b429\b/i;
+
       const providers = JSON.parse(fs.readFileSync(PROVIDERS_PATH, "utf-8")) as ProviderRecord[];
+      const activeCount = providers.filter((p) => p.status === "active").length;
+
+      const hardFailures: ProviderRecord[] = [];
       for (const p of providers) {
         const envKeys = providerConfigMap[p.provider as Provider]?.envKeys ?? [];
         const hasEnvKey = envKeys.some((k: string) => !!process.env[k]);
-        if (hasEnvKey) {
-          expect(
-            p.status,
-            `env-keyed provider "${p.provider}" must probe active (error: ${p.error})`,
-          ).toBe("active");
+        if (!hasEnvKey || p.status === "active") continue;
+        if (BILLING_OR_QUOTA.test(p.error ?? "")) {
+          console.warn(
+            `⚠️  provider "${p.provider}" inactive for a TRANSIENT billing/quota reason — ` +
+              `its parametrized specs will skip this run (gate not failed): ${p.error}`,
+          );
+        } else {
+          hardFailures.push(p);
         }
       }
+
+      // Genuine key/config failures still erode coverage silently → fail loud.
+      expect(
+        hardFailures.map((p) => p.provider),
+        `env-keyed provider(s) inactive for a NON-billing reason (real key/account/config problem): ` +
+          hardFailures.map((p) => `${p.provider} — ${p.error}`).join(" | "),
+      ).toEqual([]);
+
+      // A total wipeout (every configured key failed, even if all "just" billing)
+      // means the collection produced nothing usable — still a hard failure.
+      expect(
+        activeCount,
+        "no provider probed active — every configured key failed; collection is unusable",
+      ).toBeGreaterThan(0);
     });
   },
 );


### PR DESCRIPTION
Closes #955 · Follow-up to #952/#953 (Approach B)

## Problem

Approach A (#953) skips collect-models for **LLM-free** PRs. An **LLM PR** still
runs it, and the #570 guard in `collect-models.spec.ts` hard-fails on ANY
env-keyed inactive provider — including a **transient billing/quota outage**
(Anthropic `credit balance is too low`, OpenAI `insufficient_quota`, Google
`RESOURCE_EXHAUSTED`). One drained provider reddens every LLM PR even when it
doesn't depend on it (#954 uses openai+google, blocked by anthropic having no
credit; recurring #915/#910/#911 class).

## Fix

Classify an env-keyed inactive provider's error in the guard:

| Case | Behavior |
|---|---|
| Transient billing/quota (credit too low / insufficient_quota / quota / resource_exhausted / billing / 402 / 429) | **loud `console.warn`, gate NOT failed** — its specs skip this run |
| Genuine key rot / config (401 invalid key, 403 no model access, …) | **fails loud** (real coverage erosion) |
| Zero providers active (total wipeout) | **fails** (collection unusable) |

Preserves the #570 coverage-erosion guarantee for real defects; a transient
billing lapse no longer blocks unrelated LLM PRs.

## Scope / safety

`collect-models.spec.ts` only. `daily-stable.yml` still runs it and surfaces the
warning. No other logic touched.

## Validation (local, nightly 1.12.0.dev5, anthropic drained)

- Guard now **passes** with `⚠️ provider "anthropic" inactive for a TRANSIENT billing/quota reason — gate not failed` (was a hard failure). `1 passed (8.5s)`.
- **Force-fail:** neutralizing the regex reclassifies anthropic as non-billing → guard **fails** loudly at the NON-billing assertion → hard-fail path intact. Reverted; final green.
- `tsc --noEmit` = 0; `eslint` = 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)