### PR TITLE
docs(triage): require backticked spec paths, count comments as scope

### DIFF
--- a/.claude/skills/langflow-e2e-triage/references/issue-templates.md
+++ b/.claude/skills/langflow-e2e-triage/references/issue-templates.md
@@ -46,6 +46,17 @@ Include:
 - The locator/selector being waited on
 - The exact error message or timeout signature
 
+**Name every spec you are claiming, in backticked repo-relative form, on every
+`daily-failure` issue** — in this table at triage time, and in follow-up comments
+as the scope grows. The QA Platform parses those paths to decide whether a failure
+on a run page is already being worked on, and shows a `tracked · #NNN` chip on the
+matching failures. Comments count as much as the body: a broad investigation
+naturally accumulates specs over time (see #773, which took on the whole
+`llm-agents` cluster across four comments), and that is the expected shape — not
+something to fold back into the opening post. What does *not* work is naming a spec
+in prose only, without the path: `agent-max-tokens` alone is unmatchable, while
+`` `core-functionality/llm-agents/agent-max-tokens.spec.ts:249` `` is not.
+
 #### Preliminary read (descriptive — NOT a verdict)
 
 Observations that *describe* the failure without claiming root cause. Format:


### PR DESCRIPTION
## What changed

One section of `.claude/skills/langflow-e2e-triage/references/issue-templates.md` — the `Include:` list under **Symptom**. It now states that every spec being claimed is named in backticked repo-relative form (in the table at triage time, in comments as the scope grows), that comments count as scope equal to the body, and that a prose nickname without a path does not count.

No change to triage decisions or to any other section.

## Why

The QA Platform now derives a treatment state for each failure on an E2E run page — `tracked` / `resolved` / `regressed` / `untracked` — by matching the failure against the spec paths named in this repo's `daily-failure` issues. That makes our reference style load-bearing: a run page either reflects the work in flight or claims nobody looked at it.

Two habits break the match:

- **Nicknames.** `agent-max-tokens` is unmatchable; `` `core-functionality/llm-agents/agent-max-tokens.spec.ts:249` `` is not.
- **Body-only reading.** #773 names no spec in its body, but four of its comments name the whole `llm-agents` cluster with paths and lines. A broad investigation cannot know its scope at triage time, so accumulating it in comments is the correct shape — and the template should say so rather than push people to rewrite the opening post.

Line numbers stay out of the contract on purpose: #773 records `agent-context-id-continuity.spec.ts:468` and the same test fails at `:474` today. The platform keys on path plus optional test title, and stores the line for display only.

## Notes for reviewers

Skill-only change — no spec, helper, workflow or config touched, so nothing in the suite can regress from it. `tsc` and ESLint do not cover `.claude/`.

The matching side of this is a `quality-platform` concern and is tracked there; this PR only fixes what we write.

Closes #957