### PR TITLE
test(ui-ux): validate & promote §15.10 Settings and editor shortcuts to @stable (#946)

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -104,17 +104,19 @@ jobs:
           # class). A spec needs models if it lives in an always-LLM area
           # (llm-agents/ or model-provider/) OR its content references a
           # collect-models consumer (getTestTargets / SimpleAgentTemplatePage /
-          # provider-setup / models.json / MODEL_TEST_ID) — this catches the
+          # provider-setup / models.json / MODEL_TEST_ID / initialGPTsetup /
+          # setupOpenAI / resolveGptModel / resolveGeminiModel) — this catches the
           # cross-area consumers (mcp/client agent specs, the loop-component
-          # regression) without a blanket path rule, and leaves LLM-free specs
-          # (e.g. mcp/server/*) out.
+          # regression, the ui-ux message-history spec, which reaches the
+          # resolvers indirectly through initialGPTsetup — #946), and leaves
+          # LLM-free specs (e.g. mcp/server/*) out.
           NEEDS_MODELS=false
           for f in $SPECS; do
             case "$f" in
               tests/tests-automations/regression/core-functionality/llm-agents/*|tests/tests-automations/regression/core-functionality/model-provider/*)
                 NEEDS_MODELS=true; break;;
             esac
-            if grep -qE 'getTestTargets|SimpleAgentTemplatePage|provider-setup|models\.json|MODEL_TEST_ID' "$f" 2>/dev/null; then
+            if grep -qE 'getTestTargets|SimpleAgentTemplatePage|provider-setup|models\.json|MODEL_TEST_ID|initialGPTsetup|setupOpenAI|resolveGptModel|resolveGeminiModel' "$f" 2>/dev/null; then
               NEEDS_MODELS=true; break
             fi
           done
@@ -209,6 +211,15 @@ jobs:
       - name: Run impacted specs
         env:
           CI: "true"
+          # When "Collect models" is skipped (needs_models == false) the provider
+          # keys below are still in the environment but were never imported into
+          # Langflow as global variables, so globalSetup's credential pre-flight
+          # (#884) hard-fails in CI and the job dies before running a single
+          # spec — every LLM-free spec PR was guaranteed red after #953 added the
+          # skip. Nothing in an LLM-free run consumes those credentials, so the
+          # check has nothing to protect there: skip it exactly when the import
+          # step was skipped, and keep it enforced for LLM runs.
+          PREFLIGHT_SKIP_CREDENTIALS: ${{ needs.detect-specs.outputs.needs_models == 'true' && '0' || '1' }}
           PLAYWRIGHT_BASE_URL: "http://localhost:7860/"
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -735,11 +735,11 @@
 - [-] Main menu actions
 
 #### 15.10 Settings and UI Configuration
-- [-] Access Settings page
-- [-] Message history settings → `ui-ux/settings-message-history.spec.ts`
+- [x] Access Settings page — profile menu opens Settings, the sidebar lists General/Model Providers/Shortcuts/Messages, and each section renders its own content (General shows the Language + Profile Picture groups) → `ui-ux/settings-navigation.spec.ts`, `ui-ux/settings-general-section.spec.ts`
+- [x] Message history settings — Settings → Messages grid keeps the 11-column contract, renders messages oldest-first (1.12 `get_messages` defaults to `order=ASC`) and the sender "Equals User" filter narrows/restores the row set → `ui-ux/settings-message-history.spec.ts`
 - [x] Change appearance/theme settings — dark/light toggle updates #body.dark class → `ui-ux/settings-theme-toggle.spec.ts`
-- [-] Keyboard shortcuts work in editor
-- [~] All documented shortcuts work
+- [x] Keyboard shortcuts work in editor — Duplicate/Delete/Copy/Paste/Cut/Undo/Redo each act on the selected node (node count asserted after every keypress) → `ui-ux/langflowShortcuts.spec.ts`
+- [~] All documented shortcuts work — all 27 `defaultShortcuts` rows are listed with a non-empty key binding in Settings → Shortcuts (`ui-ux/settings-navigation.spec.ts`), and 7 of them are exercised on canvas (`ui-ux/langflowShortcuts.spec.ts`) plus 1 rebound end-to-end (`ui-ux/settings-shortcuts-edit.spec.ts`); the remaining 20 (API, Docs, Download, Play, Group, Minimize, Freeze, Save, Code, Update, Controls, sidebar search, …) are not exercised yet
 - [x] Edit a keyboard shortcut (Duplicate → `Ctrl/Cmd+Alt+U`) persists to the table and the new combination triggers the action on canvas → `ui-ux/settings-shortcuts-edit.spec.ts`
 - [x] API Keys table renders `created_at`/`expires_at` in the viewer's local timezone (UTC→local), shows "Never" for unused keys and ∞ for no-expiry keys (PR #13471) → `ui-ux/api-keys-timezone-display.spec.ts`
 

--- a/docs/ui-ux/langflowShortcuts.md
+++ b/docs/ui-ux/langflowShortcuts.md
@@ -1,0 +1,88 @@
+# Spec: Canvas Keyboard Shortcuts
+
+**Test file:** `tests/tests-automations/regression/ui-ux/langflowShortcuts.spec.ts`
+
+## What this test validates
+
+The `§15.10 — Keyboard shortcuts work in editor` checklist item: the canvas
+keybind handler actually performs the bound action on the selected node. The node
+count on canvas is the concrete observable, so a broken keybind (or a keybind
+firing the wrong action) fails immediately, naming the shortcut in the message.
+
+One test walks a single **Chat Output** node through seven documented shortcuts:
+
+| Shortcut | Action | Node count after |
+|---|---|---|
+| — | node selected; `node-edit-name-description-button` appears | 1 |
+| `Ctrl/Cmd+D` | Duplicate | 2 |
+| `Backspace` | Delete (the duplicate) | 1 |
+| `Ctrl/Cmd+C` then `Ctrl/Cmd+V` | Copy + Paste | 2 |
+| `Backspace` | Delete (the pasted node) | 1 |
+| `Ctrl/Cmd+X` | Cut | 0 |
+| `Ctrl/Cmd+V` | Paste | 1 |
+| `Backspace` | Delete | 0 |
+| `Ctrl/Cmd+Z` | Undo | 1 |
+| `Ctrl/Cmd+Y` | Redo | 0 |
+
+## Changes this validation pass made to the inherited spec
+
+1. **1.12 testid drift (this is why it was failing).** After clicking the node
+   title the spec asserted `panel-description`, which **no longer exists** in the
+   1.12 nightly bundle (0 occurrences; grepped inside
+   `langflowai/langflow-nightly:latest`, `1.12.0.dev5`). The current testid for
+   the same affordance is `node-edit-name-description-button` (scouted live).
+   Retargeted, not dropped.
+2. **Component swapped from Ollama to Chat Output.** Ollama ships as a
+   **langchain extra** the nightly image has already dropped once (#907 /
+   LE-1987 — the component then disappears from the sidebar), so a shortcut test
+   built on it goes red for a provider-packaging reason. Chat Output is core.
+   **Chat Input is deliberately NOT used**: its node body carries a text field
+   that holds keyboard focus right after the node is added, and a focused field
+   swallows `mod+…` keydowns before the canvas hotkey handler sees them (hotkey
+   libraries ignore key events originating in inputs). A Chat-Input-based version
+   of this spec produced silent Duplicate/Copy no-ops that look exactly like a
+   product regression — they are not. Chat Input's body click also focuses the
+   field instead of selecting the node.
+3. **Selection is gated, not assumed.** Every canvas shortcut acts on the
+   selected node, so `selectNode()` clicks `generic-node-title-arrangement` and
+   asserts `.react-flow__node.selected` has exactly one match before any
+   keypress. Without the gate, an unselected canvas turns every shortcut into a
+   no-op and the failure message blames the keybind.
+4. **Assertions are nameable and wait properly.** `if (count != n) expect(false).toBeTruthy()`
+   became `expect(nodes, "<shortcut> should …").toHaveCount(n)` — auto-retrying
+   (the canvas re-renders asynchronously after a keypress) and it names the
+   shortcut that broke.
+5. **Flow cleanup.** Clicking `blank-flow` creates a real flow
+   (`POST /api/v1/flows` → 201); the spec now tracks the id from the response and
+   deletes it id-scoped in `afterEach`. The inherited version leaked one
+   `New Flow` per run — orphans found on the shared instance were purged while
+   validating this issue.
+6. **Onboarding tooltip dismissed** via the existing
+   `dismissOnboardingIfPresent(page)` helper (its overlay intercepts canvas
+   clicks; same reason the flow-lock specs call it).
+
+## Tags
+
+`@stable` `@release` `@workspace` `@ui-ux`
+
+## Validation criterion
+
+| Step | Criterion |
+|---|---|
+| Before every keypress | `.react-flow__node.selected` has exactly 1 match |
+| Node selected | `node-edit-name-description-button` is visible |
+| After each shortcut | `page.getByTestId("title-Chat Output")` has the exact expected count from the table above (`toHaveCount`, 10s) |
+| `afterEach` | the flow created by `blank-flow` is deleted by id; `GET /api/v1/flows/` shows no leftover `New Flow` |
+
+## External dependencies
+
+- `src/frontend/src/CustomNodes/GenericNode/index.tsx` — `generic-node-title-arrangement`, `title-<display_name>`, `node-edit-name-description-button` testids.
+- `src/frontend/src/constants/constants.ts` — `defaultShortcuts` entries `Duplicate` (`mod+d`), `Copy` (`mod+c`), `Paste` (`mod+v`), `Cut` (`mod+x`), `Delete` (`backspace`), `Undo` (`mod+z`), `Redo` (`mod+y`).
+- `src/frontend/src/stores/shortcuts.ts` — the store the canvas keybind handler reads.
+- Core `Chat Output` component (`add-component-button-chat-output`) — bundled in Langflow core, no provider extra required.
+
+No provider API key needed.
+
+## Last validated
+
+1.12.x (nightly `1.12.0.dev6`)

--- a/docs/ui-ux/settings-general-section.md
+++ b/docs/ui-ux/settings-general-section.md
@@ -1,0 +1,56 @@
+# Spec: Settings — General / Messages / Shortcuts Sections Load
+
+**Test file:** `tests/tests-automations/regression/ui-ux/settings-general-section.spec.ts`
+
+## What this test validates
+
+Second half of the `§15.10 — Access Settings page` checklist item: once the
+Settings page is open, each of its long-standing sections must actually render
+its own content when selected from the sidebar — not just switch the header.
+
+`beforeEach` enters Settings through the profile menu
+(`user-profile-settings` → `menu_settings_button`) and waits for
+`settings_menu_header`. Then:
+
+1. **General section renders its content** — clicking `General` shows the
+   header `General` **and** the two settings groups the page promises on the
+   1.12 nightly: the **Language** group (with its description
+   `"Choose the display language for the Langflow interface."`) and the
+   **Profile Picture** group. Asserting the groups — rather than "some `main`
+   element is visible", which passed even with an empty page — is what makes
+   this test able to fail.
+   Note: with `LANGFLOW_AUTO_LOGIN=true` the password form is intentionally not
+   rendered (`{!autoLogin && <PasswordFormComponent>}`), so it is not asserted.
+2. **Messages section is accessible** — clicking `Messages` switches the header
+   to `Messages`. The message-grid contents are covered by
+   `settings-message-history.spec.ts`; here only reachability is asserted.
+3. **Shortcuts section is accessible and lists shortcuts** — clicking
+   `Shortcuts` switches the header and the shortcut grid renders at least one
+   row. Deliberate overlap with `settings-navigation.spec.ts` test 3: that spec
+   reaches Shortcuts by URL-level navigation and asserts the *full catalog*;
+   this one asserts the *sidebar link* path works after landing on General.
+
+## Tags
+
+`@stable` `@release` `@regression` `@settings`
+
+## Validation criterion
+
+| Step | Criterion |
+|---|---|
+| Sidebar → General | header contains `General` AND texts `Language`, `"Choose the display language for the Langflow interface."` and `Profile Picture` are visible |
+| Sidebar → Messages | `settings_menu_header` contains `Messages` |
+| Sidebar → Shortcuts | `settings_menu_header` contains `Shortcuts` AND the shortcut grid renders ≥ 1 row |
+
+## External dependencies
+
+- `src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx` — `user-profile-settings`, `menu_settings_button` testids.
+- `src/frontend/src/pages/SettingsPage/index.tsx` — `settings_menu_header` testid; sidebar link labels `General` / `Messages` / `Shortcuts`.
+- `src/frontend/src/pages/SettingsPage/pages/GeneralPage/index.tsx` — the `Language` and `Profile Picture` group headings plus the language description string.
+- `LANGFLOW_AUTO_LOGIN=true` (the CI/local default) — hides the password form on the General page.
+
+Read-only UI navigation: no provider key, no flow created, nothing to clean up.
+
+## Last validated
+
+1.12.x (nightly `1.12.0.dev6`)

--- a/docs/ui-ux/settings-message-history.md
+++ b/docs/ui-ux/settings-message-history.md
@@ -1,6 +1,6 @@
 # Settings → Messages — history shows sent messages in order with working filters
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev6`)
 
 ---
 
@@ -17,10 +17,15 @@ conversation, the test validates that:
    new columns (1.11 added `context_id`, `edit`, `duration`,
    `session_metadata`) must not fail the test; a promised column *removed*
    must.
-2. **Messages appear newest first** — the backend orders by timestamp DESC
-   by design (`monitor.py` `get_messages` always applies `.desc()`; verified
-   in the 1.11 nightly source) and the grid renders the API order. The old
-   spec asserted ascending ("oldest first"), a premise that no longer holds.
+2. **Messages appear oldest first (chronological)** — the grid renders the
+   API order, and **1.12 flipped that order on purpose**: `monitor.py`
+   `get_messages` no longer hardcodes `.desc()`; it now exposes `order_by`
+   (default `timestamp`) and `order` (default **`ASC`**), validated against
+   `ALLOWED_MESSAGE_ORDER_FIELDS` / `{ASC,DESC}`, and applies
+   `order_col.desc()` only when `order == DESC` (verified in the shipped
+   `1.12.0.dev5` source). The newest-first premise this spec carried for 1.11
+   (#616) is dead **by design**, not by regression — see the ordering-history
+   note below.
 3. **Content integrity** — both sent prompts appear verbatim in the `text`
    column; `sender` distinguishes `User` from the machine/agent side.
 4. **Column filters work** — filtering `sender` by "Equals User" leaves only
@@ -43,11 +48,11 @@ per-column DOM visibility.
 
 ## Tags *(required)*
 
-`@release` `@workspace` `@api` `@settings`
+`@stable` `@release` `@workspace` `@api` `@settings`
 
-No `@stable`: the spec was broken on clean main when triaged (#616) and is
-restored under its original tag set; promotion is a separate
-validate-&-promote decision after the fix has soaked.
+Promoted to `@stable` in #946 after the ordering premise was re-derived from the
+1.12 backend (`order=ASC` default) and the spec ran clean in a 3x `--retries=0`
+burst on nightly `1.12.0.dev6`.
 
 ---
 
@@ -74,7 +79,11 @@ validate-&-promote decision after the fix has soaked.
    `.ag-header-cell` `col-id`; assert the collected set contains all 11
    promised columns (superset-tolerant).
 6. **Order:** read all `timestamp` cells (≥ 4 rows expected: 2 user + 2
-   agent); parse and assert descending (newest-first) order.
+   agent); assert they parse (≥ 4 parseable, so the check is never vacuous)
+   and are **monotonically ascending**. Monotonicity alone also holds for a
+   reversed grid, so it is paired with a direction-sensitive check: the row
+   index of `Hello, how are you?` must be **less than** the row index of
+   `What is 2+2?` in the `text` column.
 7. **Content:** `sender` column contains `User` and a machine/agent value;
    `text` column contains both prompts verbatim.
 8. **Filter:** click the `sender` header's dedicated filter button
@@ -88,8 +97,9 @@ validate-&-promote decision after the fix has soaked.
 ## Validation criterion *(required)*
 
 - The collected column-id set ⊇ the 11 promised columns.
-- Timestamps render in descending (newest-first) order; ≥ 4 rows after two
-  exchanges.
+- Timestamps render in ascending (oldest-first) order, with ≥ 4 parseable
+  timestamp cells after two exchanges; the first prompt sent renders above the
+  second one.
 - Both prompts present verbatim; `User` and machine senders both present.
 - "Equals User" filter yields only User rows; clearing restores the full set.
 

--- a/docs/ui-ux/settings-navigation.md
+++ b/docs/ui-ux/settings-navigation.md
@@ -1,0 +1,69 @@
+# Spec: Settings — Page Access and Sidebar Navigation
+
+**Test file:** `tests/tests-automations/regression/ui-ux/settings-navigation.spec.ts`
+
+## What this test validates
+
+Covers the entry point to the Settings page and the integrity of its sidebar
+navigation — the `§15.10 — Access Settings page` checklist item.
+
+Four independent tests:
+
+1. **Access Settings page** — the profile menu (`user-profile-settings` →
+   `menu_settings_button`) navigates to Settings and the page renders its
+   section header (`settings_menu_header`).
+2. **Sidebar sections listed** — the four long-standing sections (General,
+   Model Providers, Shortcuts, Messages) are present as navigation links. The
+   1.12 nightly renders nine links (General, MCP Servers, Langflow API Keys,
+   Langflow MCP Client, Global Variables, Model Providers, DB Providers,
+   Shortcuts, Messages); only the four stable ones are asserted, so an upstream
+   addition/rename of the newer MCP/DB entries does not redden the daily run,
+   while removing a core section does.
+3. **Shortcuts section lists every documented shortcut** — the Shortcuts page
+   renders an AG Grid (`role="row"`, columns `display_name` / `shortcut`).
+   The test asserts the grid lists **at least 27 shortcut rows** (the
+   `defaultShortcuts` catalog size on 1.12.0.dev5) and that **every** row shows
+   a non-empty key binding in its `shortcut` cell. This is the *listing* half
+   of `§15.10 — All documented shortcuts work`; actually exercising the
+   bindings on canvas is covered by `langflowShortcuts.spec.ts` (7 of them) and
+   `settings-shortcuts-edit.spec.ts` (rebinding one), which is why the
+   checklist bullet stays `[~]`.
+4. **Model Providers section loads** — navigating to Model Providers switches
+   the header and renders the page description
+   `"Configure AI model providers and manage their API keys."`.
+
+Tests 1–2 are the "can the user reach Settings at all" gate; a regression in the
+profile menu, the route, or the section list breaks them before any deeper
+Settings spec runs.
+
+## Tags
+
+`@stable` `@release` `@workspace` `@regression` `@settings`
+
+## Validation criterion
+
+| Step | Criterion |
+|---|---|
+| Profile menu → Settings | `settings_menu_header` is visible (Settings route rendered) |
+| Settings sidebar | Links `General`, `Model Providers`, `Shortcuts`, `Messages` all visible |
+| Shortcuts section | `settings_menu_header` contains `Shortcuts`; shortcut grid has ≥ 27 data rows; every row's `shortcut` cell has non-empty text |
+| Model Providers section | header contains `Model Providers` AND text `"Configure AI model providers and manage their API keys."` is visible |
+
+Non-criterion (deliberate): the test does not assert the *total* number of
+sidebar links, nor the presence of the 1.12-only sections (MCP Servers, DB
+Providers, Langflow MCP Client) — those are still moving upstream.
+
+## External dependencies
+
+- `src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx` — `user-profile-settings`, `menu_settings_button` testids.
+- `src/frontend/src/pages/SettingsPage/index.tsx` — `settings_menu_header` testid and the sidebar link labels.
+- `src/frontend/src/pages/SettingsPage/pages/ShortcutsPage/index.tsx` — AG Grid with `display_name` / `shortcut` columns.
+- `src/frontend/src/constants/constants.ts` — `defaultShortcuts` array (27 entries on 1.12.0.dev5). Shrinking it below 27 fails test 3 by design.
+- `src/frontend/src/pages/SettingsPage/pages/ModelProvidersPage/index.tsx` — the literal description string asserted in test 4.
+
+No provider API key and no flow creation — the spec is read-only UI navigation,
+so it leaves no state behind (no cleanup needed).
+
+## Last validated
+
+1.12.x (nightly `1.12.0.dev6`)

--- a/tests/tests-automations/regression/ui-ux/langflowShortcuts.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/langflowShortcuts.spec.ts
@@ -1,11 +1,74 @@
 import { expect, test } from "../../../fixtures/fixtures";
+import { addComponentFromSidebar } from "../../../helpers/flows/add-component-from-sidebar";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { dismissOnboardingIfPresent } from "../../../helpers/ui/dismiss-onboarding";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+
+// Clicking `blank-flow` creates a real flow (POST /api/v1/flows → 201). Track
+// the ids the run creates and delete them id-scoped in afterEach — the
+// inherited version of this spec leaked one "New Flow" per run on the shared
+// instance.
+const createdFlowIds: string[] = [];
+
+// The node the shortcuts operate on. Chat Output is a core component (no
+// langchain extra — the nightly has dropped those before, hiding the Ollama
+// component the inherited spec dragged in: #907 / LE-1987) AND, unlike Chat
+// Input, its body carries no text field. That matters: a focused field inside
+// the node swallows `mod+…` keydowns before the canvas hotkey handler sees them,
+// so a Chat-Input-based spec silently fails to trigger Duplicate/Copy.
+const NODE_TITLE_TESTID = "title-Chat Output";
+
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, {
+      headers: { Authorization: bearer },
+    }).catch(() => {});
+  }
+});
 
 test(
   "LangflowShortcuts",
-  { tag: ["@release", "@workspace"] },
+  { tag: ["@stable", "@release", "@workspace", "@ui-ux"] },
   async ({ page }) => {
+    const nodes = page.getByTestId(NODE_TITLE_TESTID);
+    const selectedNodes = page.locator(".react-flow__node.selected");
+
+    // The canvas applies a shortcut asynchronously (ReactFlow re-render), so the
+    // count is asserted with the auto-retrying `toHaveCount` — a raw `count()`
+    // read right after `keyboard.press` samples it mid-update.
+    const expectNodes = (n: number, because: string) =>
+      expect(nodes, because).toHaveCount(n, { timeout: 10000 });
+
+    // Every canvas shortcut acts on the SELECTED node, so selection is gated
+    // explicitly before each keypress instead of assumed: an unselected canvas
+    // makes the shortcuts no-ops and the test would blame the keybind.
+    const selectNode = async (which: "first" | "last" = "first") => {
+      await page.getByTestId("generic-node-title-arrangement")[which]().click();
+      await expect(
+        selectedNodes,
+        "the clicked node must be selected before pressing a shortcut",
+      ).toHaveCount(1, { timeout: 10000 });
+    };
+
+    page.on("response", (resp) => {
+      if (
+        resp.url().includes("/api/v1/flows") &&
+        resp.request().method() === "POST" &&
+        resp.status() === 201
+      ) {
+        resp
+          .json()
+          .then((body: { id?: string }) => {
+            if (body?.id) createdFlowIds.push(body.id);
+          })
+          .catch(() => {}); // non-JSON / batch payloads
+      }
+    });
+
     await awaitBootstrapTest(page);
 
     await page.waitForSelector('[data-testid="blank-flow"]', {
@@ -13,83 +76,69 @@ test(
     });
     await page.getByTestId("blank-flow").click();
 
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("ollama");
+    // The assistant onboarding tooltip opens over the editor on flow entry and
+    // its overlay intercepts canvas clicks — dismissed for the same reason the
+    // flow-lock specs do it (no-op when absent).
+    await dismissOnboardingIfPresent(page);
 
-    await page.waitForSelector('[data-testid="ollamaOllama"]', {
-      timeout: 3000,
-    });
-
-    await page
-      .getByTestId("ollamaOllama")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'));
-    await page.mouse.up();
-    await page.mouse.down();
+    await addComponentFromSidebar(
+      page,
+      "chat output",
+      "add-component-button-chat-output",
+    );
+    await expectNodes(1, "the Chat Output component should be on the canvas");
 
     await adjustScreenView(page);
     await adjustScreenView(page, { numberOfZoomOut: 2 });
 
-    await page.getByTestId("generic-node-title-arrangement").click();
-    await expect(page.getByTestId("panel-description")).toBeVisible();
+    // Selecting the node via its title arrangement also exposes the
+    // name/description edit affordance. On 1.11 that was `panel-description`,
+    // which has 0 occurrences in the 1.12 nightly frontend bundle; the current
+    // testid for the same affordance is `node-edit-name-description-button`
+    // (scouted live on 1.12.0.dev5).
+    await selectNode();
+    await expect(
+      page.getByTestId("node-edit-name-description-button"),
+    ).toBeVisible();
 
-    await page.getByTestId("generic-node-title-arrangement").click();
+    // Duplicate (mod+d)
     await page.keyboard.press(`ControlOrMeta+d`);
+    await expectNodes(2, "Duplicate (mod+d) should add one node");
 
-    let numberOfNodes = await page.getByTestId("title-Ollama")?.count();
-    if (numberOfNodes != 2) {
-      expect(false).toBeTruthy();
-    }
-
-    const ollamaTitleElement = await page.getByTestId("title-Ollama").last();
-
-    await ollamaTitleElement.click();
+    // Delete (backspace) removes the duplicate
+    await selectNode("last");
     await page.keyboard.press("Backspace");
+    await expectNodes(1, "Delete (backspace) should remove the duplicate");
 
-    numberOfNodes = await page.getByTestId("title-Ollama")?.count();
-    if (numberOfNodes != 1) {
-      expect(false).toBeTruthy();
-    }
-
-    await page.getByTestId("generic-node-title-arrangement").click();
+    // Copy (mod+c) + Paste (mod+v)
+    await selectNode();
     await page.keyboard.press(`ControlOrMeta+c`);
-
-    await page.getByTestId("title-Ollama").click();
     await page.keyboard.press(`ControlOrMeta+v`);
+    await expectNodes(2, "Copy + Paste (mod+c / mod+v) should add one node");
 
-    numberOfNodes = await page.getByTestId("title-Ollama")?.count();
-    if (numberOfNodes != 2) {
-      expect(false).toBeTruthy();
-    }
-
-    await ollamaTitleElement.click();
+    await selectNode("last");
     await page.keyboard.press("Backspace");
+    await expectNodes(1, "Delete (backspace) should remove the pasted node");
 
-    await page.getByTestId("title-Ollama").click();
+    // Cut (mod+x) removes the node…
+    await selectNode();
     await page.keyboard.press(`ControlOrMeta+x`);
+    await expectNodes(0, "Cut (mod+x) should remove the node");
 
-    numberOfNodes = await page.getByTestId("title-Ollama")?.count();
-    if (numberOfNodes != 0) {
-      expect(false).toBeTruthy();
-    }
+    // …and Paste (mod+v) restores what Cut took
     await page.keyboard.press(`ControlOrMeta+v`);
-    numberOfNodes = await page.getByTestId("title-Ollama")?.count();
-    if (numberOfNodes != 1) {
-      expect(false).toBeTruthy();
-    }
+    await expectNodes(1, "Paste (mod+v) after Cut should restore the node");
 
-    // Test undo (Command+Z or Control+Z)
-    await page.getByTestId("title-Ollama").click();
+    // Undo (mod+z) — delete first, then undo the deletion
+    await selectNode();
     await page.keyboard.press("Backspace");
-    numberOfNodes = await page.getByTestId("title-Ollama")?.count();
-    expect(numberOfNodes).toBe(0);
+    await expectNodes(0, "Delete (backspace) should remove the node");
 
     await page.keyboard.press(`ControlOrMeta+z`);
-    numberOfNodes = await page.getByTestId("title-Ollama")?.count();
-    expect(numberOfNodes).toBe(1);
+    await expectNodes(1, "Undo (mod+z) should bring the node back");
 
-    // Test redo (Command+Y or Control+Y)
+    // Redo (mod+y) re-applies the deletion
     await page.keyboard.press(`ControlOrMeta+y`);
-    numberOfNodes = await page.getByTestId("title-Ollama")?.count();
-    expect(numberOfNodes).toBe(0);
+    await expectNodes(0, "Redo (mod+y) should re-apply the deletion");
   },
 );

--- a/tests/tests-automations/regression/ui-ux/settings-general-section.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/settings-general-section.spec.ts
@@ -17,7 +17,7 @@ test.describe("Settings General Section", () => {
 
   test(
     "Settings General section loads and shows its header",
-    { tag: ["@release", "@regression", "@settings"] },
+    { tag: ["@stable", "@release", "@regression", "@settings"] },
     async ({ page }) => {
       await page.getByRole("link", { name: "General", exact: true }).click();
       await page.waitForTimeout(500);
@@ -28,16 +28,26 @@ test.describe("Settings General Section", () => {
         { timeout: 10000 },
       );
 
-      // The section content area must be present (at minimum the page header component)
-      await expect(page.locator("main, [role='main'], .flex.h-full.w-full").first()).toBeVisible({
-        timeout: 5000,
-      });
+      // The header alone does not prove the section rendered — assert the
+      // groups the General page actually ships on the 1.12 nightly. A generic
+      // "some main element is visible" check passed even on an empty page.
+      await expect(
+        page.getByText("Language", { exact: true }).first(),
+      ).toBeVisible({ timeout: 10000 });
+      await expect(
+        page.getByText(
+          "Choose the display language for the Langflow interface.",
+        ),
+      ).toBeVisible({ timeout: 5000 });
+      await expect(
+        page.getByText("Profile Picture", { exact: true }).first(),
+      ).toBeVisible({ timeout: 5000 });
     },
   );
 
   test(
     "Settings Messages section is accessible",
-    { tag: ["@release", "@regression", "@settings"] },
+    { tag: ["@stable", "@release", "@regression", "@settings"] },
     async ({ page }) => {
       await page.getByRole("link", { name: "Messages", exact: true }).click();
       await page.waitForTimeout(500);
@@ -51,7 +61,7 @@ test.describe("Settings General Section", () => {
 
   test(
     "Settings Shortcuts section is accessible and lists shortcuts",
-    { tag: ["@release", "@regression", "@settings"] },
+    { tag: ["@stable", "@release", "@regression", "@settings"] },
     async ({ page }) => {
       await page.getByRole("link", { name: "Shortcuts", exact: true }).click();
       await page.waitForTimeout(500);

--- a/tests/tests-automations/regression/ui-ux/settings-message-history.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/settings-message-history.spec.ts
@@ -9,9 +9,11 @@
  *
  * Expected Results:
  * - All sent and received messages appear in the message history
- * - Messages are displayed newest first (the backend orders by
- *   timestamp DESC by design — monitor.py get_messages always applies
- *   .desc(); verified in the 1.11 nightly source, #616)
+ * - Messages are displayed oldest first (chronological): 1.12 replaced the
+ *   hardcoded .desc() in monitor.py get_messages with order_by/order query
+ *   params defaulting to timestamp/ASC, so the grid — which renders the API
+ *   order — now starts with the oldest message (the 1.11 newest-first premise
+ *   from #616 is dead by design)
  * - All columns display correct information: timestamp, text, sender, sender_name,
  *   session_id, files, id, flow_id, properties, category, content_blocks
  * - Message content matches what was sent/received in Playground
@@ -69,7 +71,7 @@ test.afterEach(async ({ request }) => {
 
 test(
   "Settings > Messages displays sent messages in correct order with working filters",
-  { tag: ["@release", "@workspace", "@api", "@settings"] },
+  { tag: ["@stable", "@release", "@workspace", "@api", "@settings"] },
   async ({ page }) => {
     test.skip(
       !process?.env?.OPENAI_API_KEY,
@@ -178,17 +180,21 @@ test(
       expect(renderedColumnIds, `column "${column}" missing from the messages grid`).toContain(column);
     }
 
-    // Steps 11-13: Verify display order — newest first. The backend orders
-    // messages by timestamp DESC by design (monitor.py get_messages always
-    // applies .desc(); verified in the 1.11 nightly source — #616), and the
-    // grid renders the API order.
+    // Steps 11-13: Verify display order — OLDEST first (chronological). The
+    // grid renders the API order, and 1.12 flipped that order on purpose:
+    // `monitor.py` `get_messages` no longer hardcodes `.desc()` — it now takes
+    // `order_by` (default `timestamp`) and `order` (default **ASC**), validated
+    // against ALLOWED_MESSAGE_ORDER_FIELDS / {ASC,DESC}, and applies
+    // `order_col.desc()` only when `order == DESC` (verified in the shipped
+    // 1.12.0.dev5 source; the newest-first premise #616 encoded for 1.11 is
+    // dead by design, not by regression).
     const timestampCells = page.locator('.ag-cell[col-id="timestamp"]');
     await expect(timestampCells.first()).toBeVisible({ timeout: 10000 });
 
     const rowCount = await timestampCells.count();
     expect(rowCount).toBeGreaterThanOrEqual(4); // at least: 2 user msgs + 2 agent responses
 
-    // Collect timestamps and verify descending (newest-first) order
+    // Collect timestamps and verify ascending (oldest-first) order
     const timestamps: number[] = [];
     for (let i = 0; i < rowCount; i++) {
       const rawTimestamp = await timestampCells.nth(i).textContent();
@@ -199,8 +205,15 @@ test(
         }
       }
     }
+    expect(
+      timestamps.length,
+      "timestamp cells must be parseable, otherwise the order check is vacuous",
+    ).toBeGreaterThanOrEqual(4);
     for (let i = 1; i < timestamps.length; i++) {
-      expect(timestamps[i]).toBeLessThanOrEqual(timestamps[i - 1]);
+      expect(
+        timestamps[i],
+        `row ${i} is older than row ${i - 1} — the grid is not in chronological order`,
+      ).toBeGreaterThanOrEqual(timestamps[i - 1]);
     }
 
     // Step 14: Verify sender values — "User" rows and "Machine"/"AI" rows exist
@@ -230,6 +243,19 @@ test(
     const joinedTexts = allTexts.join(" ");
     expect(joinedTexts).toContain(FIRST_MESSAGE);
     expect(joinedTexts).toContain(SECOND_MESSAGE);
+
+    // Direction-sensitive companion to the timestamp check: monotonic
+    // timestamps alone also hold for a reversed grid, so pin the two prompts to
+    // their chronological positions — the first message sent must render above
+    // the second one.
+    const firstMessageRow = allTexts.findIndex((t) => t === FIRST_MESSAGE);
+    const secondMessageRow = allTexts.findIndex((t) => t === SECOND_MESSAGE);
+    expect(firstMessageRow, `"${FIRST_MESSAGE}" row not found`).toBeGreaterThanOrEqual(0);
+    expect(secondMessageRow, `"${SECOND_MESSAGE}" row not found`).toBeGreaterThanOrEqual(0);
+    expect(
+      firstMessageRow,
+      "the first message sent must render above the second one (oldest-first)",
+    ).toBeLessThan(secondMessageRow);
 
     // Steps 16-18: Filter by sender "Equals User"
     // The header renders a dedicated filter button (.ag-header-cell-filter-button)

--- a/tests/tests-automations/regression/ui-ux/settings-navigation.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/settings-navigation.spec.ts
@@ -3,7 +3,7 @@ import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test"
 
 test(
   "user can access Settings page from the profile menu",
-  { tag: ["@release", "@workspace", "@regression", "@settings"] },
+  { tag: ["@stable", "@release", "@workspace", "@regression", "@settings"] },
   async ({ page }) => {
     await awaitBootstrapTest(page, { skipModal: true });
 
@@ -21,7 +21,7 @@ test(
 
 test(
   "Settings page shows all main sections in sidebar navigation",
-  { tag: ["@release", "@workspace", "@regression", "@settings"] },
+  { tag: ["@stable", "@release", "@workspace", "@regression", "@settings"] },
   async ({ page }) => {
     await awaitBootstrapTest(page, { skipModal: true });
 
@@ -42,7 +42,7 @@ test(
 
 test(
   "Settings Shortcuts section lists keyboard shortcuts",
-  { tag: ["@release", "@workspace", "@regression", "@settings"] },
+  { tag: ["@stable", "@release", "@workspace", "@regression", "@settings"] },
   async ({ page }) => {
     await awaitBootstrapTest(page, { skipModal: true });
 
@@ -62,15 +62,33 @@ test(
       "Shortcuts",
     );
 
-    // Must list at least some keyboard shortcuts (key bindings shown in the table)
-    const shortcutRows = page.locator("table tbody tr, [role='row']");
-    await expect(shortcutRows.first()).toBeVisible({ timeout: 5000 });
+    // The Shortcuts page renders an AG Grid (columns `display_name` /
+    // `shortcut`), NOT an HTML table — `role="row"` includes the header row on
+    // top of the data rows. The catalog (`defaultShortcuts`) has 27 entries on
+    // the 1.12 nightly, so the grid must list at least that many bindings, and
+    // every one of them must actually show a key combination. This is the
+    // "documented shortcuts are all listed" half of §15.10; exercising the
+    // bindings on canvas lives in `langflowShortcuts.spec.ts`.
+    const shortcutCells = page.locator('[role="row"] [col-id="shortcut"]');
+    await expect(shortcutCells.first()).toBeVisible({ timeout: 5000 });
+
+    const shortcutTexts = await shortcutCells.allTextContents();
+    // Drop the header cell ("Keyboard Shortcut") — only data rows carry bindings.
+    const bindings = shortcutTexts.slice(1).map((t) => t.trim());
+    expect(
+      bindings.length,
+      "Settings > Shortcuts must list the whole documented shortcut catalog",
+    ).toBeGreaterThanOrEqual(27);
+    expect(
+      bindings.filter((b) => b.length === 0),
+      "every documented shortcut must show a key combination",
+    ).toEqual([]);
   },
 );
 
 test(
   "Settings Model Providers section loads with provider configuration",
-  { tag: ["@release", "@workspace", "@regression", "@settings"] },
+  { tag: ["@stable", "@release", "@workspace", "@regression", "@settings"] },
   async ({ page }) => {
     await awaitBootstrapTest(page, { skipModal: true });
 


### PR DESCRIPTION
Closes #946.

Closes the four remaining `[-]`/`[~]` items in `QA-CHECKLIST.md` § 15.10 — Settings and UI Configuration. All four specs already existed, so this is a validate-&-promote pass: fix the broken one, harden the assertions that could not fail, promote the set to `@stable`, and write the missing spec docs.

## 1. Covered tests

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `LangflowShortcuts` | Seven canvas keybinds act on the selected node, with the exact node count asserted after each: `mod+d`→2, `Backspace`→1, `mod+c`+`mod+v`→2, `Backspace`→1, `mod+x`→0, `mod+v`→1, `Backspace`→0, `mod+z`→1, `mod+y`→0. Every keypress is gated on `.react-flow__node.selected == 1`, so a broken keybind fails naming itself instead of silently no-op'ing. |
| 2 | `user can access Settings page from the profile menu` | `user-profile-settings` → `menu_settings_button` renders `settings_menu_header` — the Settings route loads at all. |
| 3 | `Settings page shows all main sections in sidebar navigation` | The four long-standing sidebar links (General, Model Providers, Shortcuts, Messages) are present. The 1.12-only entries (MCP Servers, DB Providers, Langflow MCP Client) are deliberately NOT asserted — they are still moving upstream. |
| 4 | `Settings Shortcuts section lists keyboard shortcuts` | The Shortcuts AG Grid lists the whole documented catalog: ≥ 27 `col-id="shortcut"` data cells (the `defaultShortcuts` size on 1.12) and **none** of them empty. |
| 5 | `Settings Model Providers section loads with provider configuration` | Header switches to `Model Providers` and the page renders `"Configure AI model providers and manage their API keys."`. |
| 6 | `Settings General section loads and shows its header` | The General page renders its actual groups — `Language` + `"Choose the display language for the Langflow interface."` + `Profile Picture` — replacing a `main`-is-visible check that passed even on an empty page. |
| 7 | `Settings Messages section is accessible` | Sidebar → Messages switches `settings_menu_header` to `Messages`. |
| 8 | `Settings Shortcuts section is accessible and lists shortcuts` | The sidebar-link path to Shortcuts works after landing on General, and the grid renders rows. |
| 9 | `Settings > Messages displays sent messages in correct order with working filters` | After a two-message Simple Agent conversation: the 11 promised columns are present (collected by sweeping the AG Grid horizontal scroll), timestamps are monotonically **ascending** with ≥ 4 parseable cells, the first prompt renders above the second, both senders (`User` / `Machine`) appear, and the `sender` "Equals User" filter narrows then restores the row set. |

## 2. How the work was done

**`langflowShortcuts.spec.ts` was RED on the nightly — root cause was 1.12 testid drift.** The spec asserted `panel-description`, which has **0 occurrences** in `langflowai/langflow-nightly:latest`'s frontend bundle. The current testid for the same node name/description affordance is `node-edit-name-description-button`, confirmed live (it appears only after the node title is clicked). Retargeted, not dropped.

**Component swapped from Ollama to the core Chat Output.** Ollama ships as a langchain extra the nightly image has already dropped once (#907 / LE-1987 — the component then disappears from the sidebar), so a keyboard-shortcut spec built on it goes red for a provider-packaging reason.

**Chat Input is explicitly NOT the subject, and the comment in the spec says why.** A Chat-Input-based draft produced silent `mod+d` / `mod+c` no-ops that looked exactly like a product regression. It is not: Chat Input renders a text field in its node body that holds keyboard focus, and a focused field swallows `mod+…` keydowns before the canvas hotkey handler sees them (a `document`-level capture proved the events reach the page — `d meta=true`, `prevented=false` — they are just ignored). Verified by contrast: with Chat Output or Ollama, `mod+d` duplicates and `mod+c`+`mod+v` pastes; and `settings-shortcuts-edit.spec.ts` (rebinding Duplicate onto an Ollama node) passes on the same nightly. Clicking Chat Input's body focuses the field instead of selecting the node, so the selection never moves either.

**Selection is gated, not assumed.** Every canvas shortcut acts on the selected node, so `selectNode()` clicks `generic-node-title-arrangement` and asserts exactly one `.react-flow__node.selected` before any keypress. Without that gate an unselected canvas turns every shortcut into a no-op and the failure blames the keybind — which is precisely the false trail described above.

**Message-history ordering premise re-derived from the shipped backend.** The spec asserted newest-first (the #616 premise for 1.11, where `monitor.py` `get_messages` always applied `.desc()`). On 1.12 that function takes `order_by` (default `timestamp`) and `order` (default **`ASC`**), validated against `ALLOWED_MESSAGE_ORDER_FIELDS` / `{ASC,DESC}`, and calls `order_col.desc()` only for `DESC`. The grid renders the API order, so it is oldest-first by design. The assertion now requires ascending timestamps **and** that `"Hello, how are you?"` renders above `"What is 2+2?"` — monotonicity alone would also hold for a reversed grid.

**Weak assertions hardened, not loosened.** `settings-general-section`'s `main, [role='main'], .flex.h-full.w-full` visibility check could not fail; it now asserts the General page's real groups. `settings-navigation`'s "at least one shortcut row" became the full-catalog check. `langflowShortcuts`' `if (count != n) expect(false).toBeTruthy()` became `expect(nodes, "<shortcut> should …").toHaveCount(n)` — auto-retrying (the canvas re-renders asynchronously) and self-describing on failure.

**Flow cleanup.** `langflowShortcuts` clicks `blank-flow`, which creates a real flow (`POST /api/v1/flows` → 201); it now tracks the id from the response and deletes it id-scoped in `afterEach`. It previously leaked one `New Flow` per run — the orphans it had accumulated on the shared instance were purged, and a post-fix run leaves the instance at 28 flows / 0 orphans.

**Spec docs.** New: `docs/ui-ux/settings-navigation.md`, `docs/ui-ux/settings-general-section.md`, `docs/ui-ux/langflowShortcuts.md`. Updated: `docs/ui-ux/settings-message-history.md` (ordering contract, `@stable`, Last validated).

**Checklist.** § 15.10 items 1–3 flip to `[x]`. "All documented shortcuts work" stays `[~]` with an explicit scope: all 27 documented shortcuts are asserted as *listed with a binding*, 7 are exercised on canvas, 1 is rebound end-to-end (`settings-shortcuts-edit.spec.ts`), and the remaining 20 (API, Docs, Download, Play, Group, Minimize, Freeze, Save, Code, Update, Controls, sidebar search, …) are not exercised yet. Only the manual Part II bullets were edited — no generated block touched.

## 3. Dependencies

- Tests 1–8: pure UI, no provider key, parallel-safe.
- Test 9: needs `OPENAI_API_KEY` (Simple Agent template via `initialGPTsetup`); on a freshly started container run `tests/collect-models.spec.ts` first so the provider credentials exist in Langflow, otherwise `model_model` never renders.
- Local validation ran `--workers=1`.

## 4. Validation (nightly `1.12.0.dev6`, `--retries=0`)

- typecheck ✅ (`tsc --noEmit`, exit 0) · eslint ✅ (exit 0)
- Deterministic burst: **3/3 clean runs per spec** at `--retries=0 --workers=1`, `unexpected=0 flaky=0` on all four (`langflowShortcuts` 1 test, `settings-general-section` 3, `settings-message-history` 1, `settings-navigation` 4)
- Confirmation run on `1.12.0.dev6` after the nightly bumped mid-flight: 8 passed in one pass + `settings-message-history` passed on its own (1.9 min). Its single failure on the fresh container was the missing provider credentials described above, resolved by `collect-models` — not a spec defect.
- Zero `🚨 Backend Error` in every run
- **Force-fail: 9 executed mutations, one per `test()` in the touched files, each verified RED and reverted** (0 `FF-MUTATION` markers left in the diff) + a final green run:
  - `mod+d` swapped for an unbound `mod+Shift+F9` → node count never reaches 2
  - waited on a non-existent `settings_menu_header_ff`
  - required a sidebar link `GeneralFF`
  - demanded ≥ 2700 shortcut rows
  - asserted `"…manage their FF keys."` on Model Providers
  - asserted a `LanguageFF` group on General
  - required the header to contain `MessagesFF`
  - pointed the row locator at `[role='rowFF']`
  - inverted the chronological order (first message required *below* the second)
- `--trace=on` skipped: known local hang on this stack (#518/#490); covered instead by the `--retries=0` bursts + the executed force-fails + live `playwright-cli` scouting.
- Instance left clean: `GET /api/v1/flows/` → 28 flows, 0 `New Flow`/`Untitled` orphans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 5. CI fix carried in this PR (`ci(pr-validation)`, commit 2)

The first CI run of this PR ([30222582798](https://github.com/oriontech-me/langflow-e2e/actions/runs/30222582798)) died at pre-flight before executing a single spec, exposing two defects in the `collect-models` skip path added by #953:

1. **The `needs_models` detector missed indirect consumers.** It matched only `getTestTargets|SimpleAgentTemplatePage|provider-setup|models.json|MODEL_TEST_ID`; `settings-message-history.spec.ts` reaches the model resolvers through `initialGPTsetup` (→ `setupOpenAI` + `resolveGptModel`), so it was classified LLM-free and ran with no model data. The pattern now also matches `initialGPTsetup`, `setupOpenAI`, `resolveGptModel`, `resolveGeminiModel`.
2. **Skipping `Collect models` made the job unconditionally red.** `Run impacted specs` still exports the five provider keys, and `globalSetup`'s credential pre-flight (#884) hard-fails in CI when a key is in the environment but not in Langflow's global variables — precisely the state a skipped import leaves behind. Any LLM-free spec PR would have hit this. `PREFLIGHT_SKIP_CREDENTIALS` is now derived from `needs_models`, so the check is skipped exactly when the import step is skipped and stays enforced for LLM runs.

Verified locally by replaying the detector loop over this PR's four spec paths under `bash`: `match in tests/tests-automations/regression/ui-ux/settings-message-history.spec.ts` → `needs_models=true`, and the workflow still parses (`yaml.safe_load`, jobs: typecheck, lint, checklist-guard, detect-specs, e2e).
