### PR TITLE
test(llm-agents): quarantine multimodal image-input flake (#964)

### DIFF
--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-multimodal-image-input.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-multimodal-image-input.spec.ts
@@ -218,9 +218,12 @@ for (const { label, options, skipReason } of targets) {
   const provider = options.provider ?? (Object.keys(providerConfigMap)[0] as Provider);
 
   test.describe(`Agent Multimodal Image Input [${label}]`, () => {
-    test(
+    // Quarantined for #964 — recurrent flake (2026-07-20 / 07-22 / 07-27): the
+    // agent answers that it cannot interpret images instead of describing the
+    // one delivered through the input handle.
+    test.fixme(
       "image via input handle is described by the agent",
-      { tag: ["@stable", "@regression", "@agents", "@playground"] },
+      { tag: ["@regression", "@agents", "@playground"] },
       async ({ page }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(


### PR DESCRIPTION
Quarantine PR spun out of daily-failure triage #962 (run [30261409427](https://github.com/oriontech-me/langflow-e2e/actions/runs/30261409427), 2026-07-27).

`tests/tests-automations/regression/core-functionality/llm-agents/agent-multimodal-image-input.spec.ts:221` ("image via input handle is described by the agent") is a **recurrent flake** — it failed on the dailies of **2026-07-20, 2026-07-22 and 2026-07-27** with the same `error_signature` (`expect(locator).toContainText(expected) failed`), inside the 30-day window. The agent answers that it cannot interpret images instead of describing the one delivered through the input handle.

Quarantined as prevention per `CONTRIBUTING.md` → *Triage protocol*: **`@stable` removed and `test.fixme` added together**, so the test stops running in every context (daily, PR impacted-specs gate, full suite) until the issue is worked. Tag removal alone would leave it red on the impacted-specs gate (#871).

No test logic, spec doc or `QA-CHECKLIST.md` change — per the triage protocol, the traceability record is this PR, the dedicated issue, and the future restoration PR.

**Lifting the quarantine** (remove `test.fixme` + restore `@stable`, after re-validation) is a deliverable of #964, not of this PR.

Refs #964