### PR TITLE
test(api): quarantine api-folders DELETE 500 flake (#965)

### DIFF
--- a/tests/tests-automations/regression/api/flows/api-folders-crud.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-folders-crud.spec.ts
@@ -79,9 +79,11 @@ test.describe("Folder (Projects) CRUD via API", () => {
     },
   );
 
-  test(
+  // Quarantined for #965 — recurrent flake (2026-07-22 / 07-27): the DELETE
+  // answers HTTP 500 where the contract expects 204 No Content.
+  test.fixme(
     "DELETE removes folder and it no longer appears in listing",
-    { tag: ["@stable", "@release", "@api", "@regression"] },
+    { tag: ["@release", "@api", "@regression"] },
     async ({ request }) => {
       const authToken = await getAuthToken(request);
       const folderName = `Delete Folder ${Date.now()}`;


### PR DESCRIPTION
Quarantine PR spun out of daily-failure triage #962 (run [30261409427](https://github.com/oriontech-me/langflow-e2e/actions/runs/30261409427), 2026-07-27).

`tests/tests-automations/regression/api/flows/api-folders-crud.spec.ts:82` ("DELETE removes folder and it no longer appears in listing") is a **recurrent flake** — it failed on the dailies of **2026-07-22 and 2026-07-27** with the same `error_signature` (`expect(received).toBe(expected) // Object.is equality`), inside the 30-day window. `DELETE /api/v1/projects/{id}` answered **HTTP 500** where the contract expects **204 No Content**.

Quarantined as prevention per `CONTRIBUTING.md` → *Triage protocol*: **`@stable` removed and `test.fixme` added together**, so the test stops running in every context (daily, PR impacted-specs gate, full suite) until the issue is worked. Tag removal alone would leave it red on the impacted-specs gate (#871).

Note: this is a **different test** from the one quarantined for #932 in the same file (line 115, PATCH `folder_id`) — distinct symptom, tracked separately.

No test logic, spec doc or `QA-CHECKLIST.md` change — per the triage protocol, the traceability record is this PR, the dedicated issue, and the future restoration PR.

**Lifting the quarantine** (remove `test.fixme` + restore `@stable`, after re-validation) is a deliverable of #965, not of this PR.

Refs #965