### PR TITLE
test(flow-functionality): quarantine run-flow welcome-panel flake (#966)

### DIFF
--- a/tests/tests-automations/regression/flow-functionality/run-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/run-flow.spec.ts
@@ -9,9 +9,12 @@ import { deleteFlow } from "../../../helpers/flows/delete-flow";
 import { renameFlow } from "../../../helpers/flows/rename-flow";
 import { openNewFlowTemplatesModal } from "../../../helpers/flows/open-new-flow-templates-modal";
 
-test(
+// Quarantined for #966 — recurrent flake (2026-07-16 / 07-27): neither the
+// welcome overlay nor the templates modal surfaces after the "New Flow" entry
+// point, so the reconciliation poll in openNewFlowTemplatesModal times out.
+test.fixme(
   "user should be able to use Run Flow without any issues",
-  { tag: ["@stable", "@release", "@workspace", "@api", "@regression"] },
+  { tag: ["@release", "@workspace", "@api", "@regression"] },
   async ({ page, request }) => {
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../.env") });


### PR DESCRIPTION
Quarantine PR spun out of daily-failure triage #962 (run [30261409427](https://github.com/oriontech-me/langflow-e2e/actions/runs/30261409427), 2026-07-27).

`tests/tests-automations/regression/flow-functionality/run-flow.spec.ts:12` ("user should be able to use Run Flow without any issues") is a **recurrent flake** — it failed on the dailies of **2026-07-16 and 2026-07-27** with the same `error_signature` (`expect(received).toBe(expected) // Object.is equality`), inside the 30-day window. After the "New Flow" entry point, neither the `FlowBuilderWelcome` overlay nor the templates modal surfaces, so the reconciliation poll in `tests/helpers/flows/open-new-flow-templates-modal.ts:51` exhausts its 30s budget.

Quarantined as prevention per `CONTRIBUTING.md` → *Triage protocol*: **`@stable` removed and `test.fixme` added together**, so the test stops running in every context (daily, PR impacted-specs gate, full suite) until the issue is worked. Tag removal alone would leave it red on the impacted-specs gate (#871).

The shared helper `tests/helpers/flows/open-new-flow-templates-modal.ts` is **not** touched here — assessing its blast radius is part of #966.

No test logic, spec doc or `QA-CHECKLIST.md` change — per the triage protocol, the traceability record is this PR, the dedicated issue, and the future restoration PR.

**Lifting the quarantine** (remove `test.fixme` + restore `@stable`, after re-validation) is a deliverable of #966, not of this PR.

Refs #966