### PR TITLE
test(ui-ux): cover canvas zoom, fit view and wheel navigation §15.5 (#941)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -706,10 +706,10 @@
 - [-] Deselect node via Escape
 
 #### 15.5 Canvas Zoom and Navigation
-- [-] Zoom in / Zoom out
-- [-] Fit View centers nodes
-- [-] Fit View button in toolbar
-- [-] Scroll to navigate canvas
+- [x] Zoom in / Zoom out → `ui-ux/canvas-zoom-navigation.spec.ts`
+- [x] Fit View centers nodes → `ui-ux/canvas-zoom-navigation.spec.ts`
+- [x] Fit View button in toolbar → `ui-ux/canvas-zoom-navigation.spec.ts`
+- [x] Scroll to navigate canvas — on 1.12 the wheel zooms anchored at the pointer (no scroll-to-pan surface) → `ui-ux/canvas-zoom-navigation.spec.ts`
 - [~] Minimap — feature flag-gated
 
 #### 15.6 Grouping

--- a/docs/ui-ux/canvas-zoom-navigation.md
+++ b/docs/ui-ux/canvas-zoom-navigation.md
@@ -1,0 +1,204 @@
+# Spec: Canvas Zoom and Navigation
+
+**Test file:** `tests/tests-automations/regression/ui-ux/canvas-zoom-navigation.spec.ts`
+
+## What this test validates
+
+Covers the canvas viewport controls — the `§15.5 Canvas Zoom and Navigation`
+checklist items *Zoom in / Zoom out*, *Fit View centers nodes*, *Fit View button
+in toolbar* and *Scroll to navigate canvas*. Minimap (`[~]`, feature-flag-gated)
+is out of scope: on `1.12.0.dev6` no minimap element is rendered at all.
+
+Every assertion reads the **React Flow viewport transform**
+(`.react-flow__viewport` → `transform: translate(<x>px, <y>px) scale(<z>)`) and
+the on-screen geometry of `.react-flow__node` against `.react-flow__pane`. That
+is the only observable that proves the canvas actually moved: a control that
+renders, is enabled and is clickable but no longer wired to the viewport passes a
+"button is visible" check and fails these.
+
+**Entry-state note (measured live, 1.12.0.dev6).** The editor does **not** open on
+the flow's persisted viewport: it opens clamped at the maximum zoom
+(`scale(2)`, `zoom_in` already `disabled`, the graph overflowing the pane),
+reproducibly across reloads, while `GET /api/v1/flows/{id}` still reports
+`viewport.zoom = 0.896`. That is why every test that measures *relative* zoom
+first normalizes the viewport with one `fit_view` click (`normalizeViewport`) —
+on a clamped viewport "zoom in raises the scale" is untestable. The tests assert
+the behavior of the controls, not this entry state; test 3 is the one that uses
+it, as a free "displaced viewport" to prove Fit View acts.
+
+Four independent tests:
+
+1. **Zoom in / Zoom out** — `zoom_in` multiplies the viewport scale by `1.2` per
+   click and `zoom_out` divides it back to the original value; clicking
+   `zoom_out` to exhaustion clamps at exactly `0.25` and disables the button
+   (with `zoom_in` still enabled), clicking `zoom_in` to exhaustion clamps at
+   exactly `2` and disables it. The `0.25`/`2` bounds are React Flow's
+   `minZoom`/`maxZoom` as configured by Langflow — a silent change to either
+   bound, or a step factor change, reddens this test.
+2. **Fit View centers nodes** — from a deliberately displaced viewport (zoomed to
+   the `2` clamp, where the graph overflows the pane — asserted as a
+   precondition, so the test cannot pass on an already-fitted canvas), clicking
+   `fit_view` brings **every** node fully inside the pane and centers the nodes'
+   union bounding box on the pane center (≤ 4 px on each axis; measured 1 px /
+   0 px live). A second `fit_view` click is a no-op (identical transform string),
+   which is the idempotence contract other specs' `adjustScreenView` helper
+   relies on.
+3. **Fit View button in toolbar** — the toolbar surface contract:
+   `main_canvas_controls` is visible on flow entry while `fit_view`, `zoom_in`,
+   `zoom_out` and `reset_zoom` are **absent** from the DOM; clicking
+   `canvas_controls_dropdown` renders all four visible (`fit_view` and
+   `reset_zoom` enabled — `zoom_in` is legitimately disabled at the entry clamp);
+   clicking `fit_view` from the toolbar on that displaced entry viewport changes
+   the transform, brings every node inside the pane and re-enables both zoom
+   buttons — proving the toolbar entry is wired, not decorative. Collapsing the
+   dropdown removes all four from the DOM again and it can be re-expanded. The
+   collapse click is `force: true`: while open, the Radix popover overlay covers
+   the trigger and a normal click fails Playwright's hit-test (same forced click
+   as `loop-component.spec.ts` / `mcp-server.spec.ts`).
+4. **Scroll to navigate canvas** — a mouse wheel over the pane navigates the
+   canvas by zooming **anchored at the pointer**: `deltaY > 0` strictly decreases
+   the scale, `deltaY < 0` restores it, and in both directions the flow-space
+   point under the cursor is preserved (≤ 2 px), measured at two different pane
+   positions so a fixed-center zoom would fail. On `1.12.0.dev6` the wheel is
+   bound to zoom, not to panning (`deltaX` alone does not move the viewport) —
+   the test asserts the zoom-anchored semantics that ship today and would fail if
+   scroll stopped affecting the viewport.
+
+Non-goals (covered elsewhere or deliberately excluded): pane drag/pan and node
+movement (`§15.4`), `reset_zoom` (no `§15.5` bullet — its value is only used as
+part of test 3's enabled-controls assertion), and the minimap.
+
+## Tags
+
+`@stable` `@workspace` `@ui-ux`
+
+## Validation criterion
+
+| Step | Criterion |
+|---|---|
+| Zoom in | scale after click ÷ scale before = `1.2` (± 0.01) and strictly greater |
+| Zoom out | scale returns to the pre-zoom-in value (± 0.001) |
+| Zoom-out clamp | `zoom_out` becomes `disabled` with scale exactly `0.25`; `zoom_in` still enabled |
+| Zoom-in clamp | `zoom_in` becomes `disabled` with scale exactly `2`; `zoom_out` still enabled |
+| Fit View precondition | at scale `2` the nodes' union box is NOT contained in the pane rect |
+| Fit View centering | union box inside the pane rect (1 px tolerance) AND \|union center − pane center\| ≤ 4 px on both axes AND both node titles visible |
+| Fit View idempotence | second `fit_view` click leaves the `transform` string byte-identical |
+| Toolbar collapsed | `main_canvas_controls` visible; `fit_view`/`zoom_in`/`zoom_out`/`reset_zoom` `count() === 0` |
+| Toolbar expanded | all four controls visible after clicking `canvas_controls_dropdown`; `fit_view` and `reset_zoom` enabled |
+| Toolbar Fit View wired | nodes NOT contained before the click; after it the transform differs, every node is inside the pane, and `zoom_in`/`zoom_out` are both enabled |
+| Toolbar re-collapse | `count() === 0` for all four after a forced trigger click; all four visible again after re-expanding |
+| Scroll out | after `wheel(0, +300)` scale is strictly smaller AND the flow-space point under the cursor is unchanged (≤ 2 px) |
+| Scroll in | after `wheel(0, −300)` scale is strictly larger, back to the pre-scroll value (± 0.001), anchor preserved (≤ 2 px) |
+| Scroll anchoring | repeating the wheel-out at a second, different pane position also preserves its own pointer anchor (≤ 2 px) |
+
+Non-criterion (deliberate): no assertion on the absolute `translate` values
+produced by `fit_view` (they depend on the fixture's node coordinates and on the
+1000×672 pane of the default 1280×720 viewport) — only relative centering and
+containment, so a viewport-size change does not redden the spec.
+
+## External dependencies
+
+- `src/frontend/src/CustomNodes/../CanvasControls` — `main_canvas_controls`,
+  `canvas_controls_dropdown`, `zoom_in`, `zoom_out`, `reset_zoom`, `fit_view`
+  testids and the collapsed-by-default dropdown.
+- React Flow (`@xyflow/react`) viewport: the `.react-flow__viewport` transform,
+  `minZoom` `0.25` / `maxZoom` `2`, the `1.2` zoom step, and `zoomOnScroll` with
+  pointer anchoring.
+- `tests/assets/flows/chat-io-ok-trace-fixture.json` via
+  `createRunnableChatFlowViaApi` — a repo-owned Chat Input → Chat Output graph.
+  No starter template, no provider key, no LLM call, no flow build: the spec is
+  pure viewport geometry.
+
+Flow cleanup: the flow is created through the API, its id is held by the spec and
+deleted in `afterEach` (id-scoped, never a wipe), after `page.goto("/")` unmounts
+the editor's event poll.
+
+## Scenarios
+
+### 15.5.1 Zoom in / Zoom out step and clamp the viewport scale [-]
+
+- **File:** `tests/tests-automations/regression/ui-ux/canvas-zoom-navigation.spec.ts`
+- **Objective:** prove the toolbar zoom buttons change the canvas scale by the
+  documented step and stop at React Flow's configured bounds.
+- **Precondition:** running instance; flow created via API from the Chat I/O
+  fixture; editor open at `/flow/{id}`.
+- **Step by step:**
+  1. Wait for `canvas_controls_dropdown`, normalize the viewport (one `fit_view`
+     click) and expand the controls; both zoom buttons must be enabled.
+  2. Read the baseline scale from `.react-flow__viewport`.
+  3. Click `zoom_in`; read the scale.
+  4. Click `zoom_out`; read the scale.
+  5. Click `zoom_out` until it reports `disabled` (bounded loop); read the scale
+     and both buttons' enabled state.
+  6. Click `zoom_in` until it reports `disabled` (bounded loop); read the scale
+     and both buttons' enabled state.
+- **Validation:** step 3 scale = baseline × 1.2 (± 0.01); step 4 scale = baseline
+  (± 0.001); step 5 scale = `0.25` with `zoom_out` disabled and `zoom_in`
+  enabled; step 6 scale = `2` with `zoom_in` disabled and `zoom_out` enabled.
+
+### 15.5.2 Fit View centers every node inside the canvas [-]
+
+- **File:** same
+- **Objective:** prove `fit_view` reframes the graph — all nodes visible and the
+  graph centered — and that it is idempotent.
+- **Precondition:** as above.
+- **Step by step:**
+  1. Normalize the viewport, expand the controls, click `zoom_in` until disabled
+     (scale `2`, at least one click landed).
+  2. Measure the union box of `.react-flow__node` against the
+     `.react-flow__pane` rect — assert it overflows (precondition).
+  3. Click `fit_view`.
+  4. Re-measure the union box and the pane rect; read `title-Chat Input` and
+     `title-Chat Output` visibility; read the transform string.
+  5. Click `fit_view` again; read the transform string.
+- **Validation:** after step 3 the union box is inside the pane (1 px tolerance),
+  its center is within 4 px of the pane center on both axes, both titles are
+  visible, and the step-5 transform is identical to the step-4 one.
+
+### 15.5.3 Fit View is reachable from the canvas controls toolbar [-]
+
+- **File:** same
+- **Objective:** prove the canvas-controls toolbar exposes Fit View (and its
+  sibling zoom controls) behind the collapsible dropdown, and that the exposed
+  Fit View acts on the viewport.
+- **Precondition:** as above; controls NOT yet expanded and the viewport NOT
+  normalized (this test uses the displaced entry viewport on purpose).
+- **Step by step:**
+  1. Assert `main_canvas_controls` is visible and each of `fit_view`, `zoom_in`,
+     `zoom_out`, `reset_zoom` has `count() === 0`.
+  2. Click `canvas_controls_dropdown`; assert the four controls are visible and
+     that `fit_view` / `reset_zoom` are enabled.
+  3. Record the transform, assert the nodes are not contained, click `fit_view`.
+  4. Read the transform and the node/pane geometry; read both zoom buttons'
+     enabled state.
+  5. Click `canvas_controls_dropdown` (forced) and assert `count() === 0` for all
+     four; click it once more and assert all four are visible again.
+- **Validation:** the step-4 transform differs from the step-3 one, every node is
+  inside the pane rect, `zoom_in` and `zoom_out` are both enabled, and the
+  collapse/expand transitions hold exactly as asserted in steps 1, 2 and 5.
+
+### 15.5.4 Wheel scroll navigates the canvas anchored at the pointer [-]
+
+- **File:** same
+- **Objective:** prove wheel input over the canvas moves the viewport, anchored
+  at the cursor position (the navigation semantics shipped on 1.12).
+- **Precondition:** as above; viewport normalized (a clamped viewport cannot zoom
+  in) and the controls dropdown **closed** (its popover swallows wheel events).
+- **Step by step:**
+  1. Read the baseline transform and the pane rect.
+  2. Move the mouse to a point `P` at one third of the pane width; `wheel(0, +300)`.
+  3. Read the transform; compute the flow-space coordinate under `P` before and
+     after.
+  4. `wheel(0, −300)` at the same point; read the transform and recompute the
+     anchor.
+  5. Move to a point `Q` at two thirds of the pane width; `wheel(0, +300)`; read
+     the transform and compute the anchor under `Q` before/after.
+- **Validation:** step 3 scale strictly smaller than baseline with the `P` anchor
+  preserved (≤ 2 px on both axes); step 4 scale back to baseline (± 0.001) with
+  the anchor preserved; step 5 scale strictly smaller with the `Q` anchor
+  preserved (≤ 2 px) — a zoom pinned to the pane center instead of the pointer
+  fails steps 3 and 5.
+
+## Last validated
+
+1.12.x (nightly `1.12.0.dev6`)

--- a/tests/tests-automations/regression/ui-ux/canvas-zoom-navigation.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/canvas-zoom-navigation.spec.ts
@@ -1,0 +1,500 @@
+import type { APIRequestContext, Page } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { createRunnableChatFlowViaApi } from "../../../helpers/flows/create-runnable-chat-flow-via-api";
+
+// Canvas viewport controls — QA-CHECKLIST §15.5 "Canvas Zoom and Navigation":
+// zoom in / zoom out, Fit View centering, the Fit View toolbar entry, and wheel
+// navigation. Spec doc: docs/ui-ux/canvas-zoom-navigation.md
+//
+// Every assertion reads the React Flow viewport transform
+// (`.react-flow__viewport` -> `transform: translate(<x>px, <y>px) scale(<z>)`)
+// and the on-screen geometry of the nodes against the pane. A control that
+// renders, is enabled and is clickable but is no longer wired to the viewport
+// passes a "button is visible" check and fails these.
+//
+// Not covered here (deliberately): pane drag/pan and node movement (§15.4), and
+// the minimap (§15.5 `[~]`, feature-flag-gated — no minimap element is rendered
+// on 1.12.0.dev6). `reset_zoom` has no §15.5 bullet; it is only asserted as one
+// of the four controls the toolbar dropdown must expose.
+//
+// The flow is a repo-owned Chat Input -> Chat Output fixture created through the
+// API: no starter template, no provider key, no LLM call and no flow build, so
+// the spec is pure viewport geometry.
+
+// React Flow bounds configured by Langflow. A silent change to either bound is a
+// product change this spec is meant to catch.
+const MIN_ZOOM = 0.25;
+const MAX_ZOOM = 2;
+// Zoom step applied per zoom_in / zoom_out click.
+const ZOOM_STEP = 1.2;
+// Bounded loops for "click until the button disables" — the range 0.25..2 at a
+// 1.2 factor needs ~12 clicks, so these can only be reached if the button never
+// disables (which is itself the failure).
+const MAX_ZOOM_CLICKS = 30;
+// Pixel tolerances. Fit View centering measured 1px / 0px live; the pointer
+// anchor measured sub-pixel. Both are kept tight enough to fail a broken
+// implementation and loose enough to absorb React Flow's float rounding.
+const CENTERING_TOLERANCE_PX = 4;
+const CONTAINMENT_TOLERANCE_PX = 1;
+const ANCHOR_TOLERANCE_PX = 2;
+// Wheel delta per scroll gesture (one notch is 100; 300 is a comfortable
+// three-notch gesture that crosses at least one zoom step).
+const WHEEL_DELTA = 300;
+
+interface Viewport {
+  x: number;
+  y: number;
+  scale: number;
+}
+
+interface Geometry {
+  /** Distance between the nodes' union-box center and the pane center. */
+  centerDeltaX: number;
+  centerDeltaY: number;
+  /** True when every node's box sits inside the pane rect. */
+  contained: boolean;
+  nodeCount: number;
+}
+
+/**
+ * Reads the live React Flow viewport transform.
+ *
+ * The transform is the single source of truth for what the user sees: React Flow
+ * writes `translate(<x>px, <y>px) scale(<z>)` on `.react-flow__viewport` and
+ * everything on the canvas is positioned by it.
+ */
+async function readViewport(page: Page): Promise<Viewport> {
+  const transform = await page
+    .locator(".react-flow__viewport")
+    .evaluate((el) => (el as HTMLElement).style.transform);
+
+  const match = transform.match(
+    /translate\((-?[\d.]+)px,\s*(-?[\d.]+)px\)\s*scale\(([\d.]+)\)/,
+  );
+  expect(match, `unparsable viewport transform: "${transform}"`).not.toBeNull();
+
+  return {
+    x: Number(match![1]),
+    y: Number(match![2]),
+    scale: Number(match![3]),
+  };
+}
+
+/** Raw transform string — used for the byte-identical idempotence assertion. */
+async function readTransform(page: Page): Promise<string> {
+  return page
+    .locator(".react-flow__viewport")
+    .evaluate((el) => (el as HTMLElement).style.transform);
+}
+
+/**
+ * Measures the nodes' union bounding box against the canvas pane, in viewport
+ * (screen) pixels — the geometry a user judges "everything is visible and
+ * centered" by.
+ */
+async function measureGeometry(page: Page): Promise<Geometry> {
+  return page.evaluate((tolerance) => {
+    const nodes = Array.from(document.querySelectorAll(".react-flow__node"));
+    const pane = document
+      .querySelector(".react-flow__pane")!
+      .getBoundingClientRect();
+    const boxes = nodes.map((n) => n.getBoundingClientRect());
+
+    const union = {
+      left: Math.min(...boxes.map((b) => b.left)),
+      right: Math.max(...boxes.map((b) => b.right)),
+      top: Math.min(...boxes.map((b) => b.top)),
+      bottom: Math.max(...boxes.map((b) => b.bottom)),
+    };
+
+    return {
+      centerDeltaX: (union.left + union.right) / 2 - (pane.left + pane.right) / 2,
+      centerDeltaY: (union.top + union.bottom) / 2 - (pane.top + pane.bottom) / 2,
+      contained:
+        union.left >= pane.left - tolerance &&
+        union.right <= pane.right + tolerance &&
+        union.top >= pane.top - tolerance &&
+        union.bottom <= pane.bottom + tolerance,
+      nodeCount: nodes.length,
+    };
+  }, CONTAINMENT_TOLERANCE_PX);
+}
+
+/** The canvas pane rect, for placing the mouse at known pane-relative points. */
+async function paneBox(page: Page) {
+  const box = await page.locator(".react-flow__pane").boundingBox();
+  expect(box, "canvas pane has no bounding box").not.toBeNull();
+  return box!;
+}
+
+/**
+ * Expands the canvas-controls dropdown if it is collapsed.
+ *
+ * On 1.12 `zoom_in` / `zoom_out` / `reset_zoom` / `fit_view` are NOT in the DOM
+ * until `canvas_controls_dropdown` is clicked, so every control interaction has
+ * to go through here. Idempotent: a no-op when the controls are already out.
+ */
+async function openCanvasControls(page: Page): Promise<void> {
+  if ((await page.getByTestId("fit_view").count()) === 0) {
+    await page.getByTestId("canvas_controls_dropdown").click();
+    await expect(page.getByTestId("fit_view")).toBeVisible({ timeout: 15000 });
+  }
+}
+
+/**
+ * Brings the viewport to the canonical fitted state and collapses the controls.
+ *
+ * Needed because the editor does NOT open on the flow's persisted viewport: on
+ * 1.12.0.dev6 it opens clamped at the maximum zoom (`scale(2)`, `zoom_in`
+ * already disabled — reproducible across reloads). Without normalizing, "zoom in
+ * raises the scale" is untestable, so each test that measures relative zoom
+ * starts from the deterministic Fit View state instead.
+ */
+async function normalizeViewport(page: Page): Promise<Viewport> {
+  await openCanvasControls(page);
+  await page.getByTestId("fit_view").click();
+  const fitted = await waitForViewportSettled(page);
+  await closeCanvasControls(page);
+  return fitted;
+}
+
+/**
+ * Collapses the controls dropdown — its popover swallows wheel events.
+ *
+ * The click is forced: while the dropdown is open its Radix overlay covers the
+ * trigger, so a normal click never passes Playwright's hit-test (same reason
+ * `loop-component.spec.ts` and `mcp-server.spec.ts` force this exact click).
+ */
+async function closeCanvasControls(page: Page): Promise<void> {
+  if ((await page.getByTestId("fit_view").count()) > 0) {
+    await page.getByTestId("canvas_controls_dropdown").click({ force: true });
+    await expect(page.getByTestId("fit_view")).toHaveCount(0, { timeout: 15000 });
+  }
+}
+
+/**
+ * Clicks a zoom button until it disables, and returns how many clicks landed.
+ * Bounded so a never-disabling button fails on the assertion, not on a hang.
+ */
+async function zoomUntilClamped(
+  page: Page,
+  testId: "zoom_in" | "zoom_out",
+): Promise<number> {
+  const button = page.getByTestId(testId);
+  let clicks = 0;
+  while (clicks < MAX_ZOOM_CLICKS && !(await button.isDisabled())) {
+    await button.click();
+    clicks += 1;
+  }
+  return clicks;
+}
+
+/**
+ * Waits for the viewport transform to settle (React Flow animates zoom/fit
+ * transitions), then returns the settled viewport. Polls the transform instead
+ * of sleeping a fixed amount, so the wait tracks the real animation.
+ */
+async function waitForViewportSettled(page: Page): Promise<Viewport> {
+  let previous = await readTransform(page);
+  await expect
+    .poll(
+      async () => {
+        const current = await readTransform(page);
+        const stable = current === previous;
+        previous = current;
+        return stable;
+      },
+      { timeout: 15000, intervals: [150, 150, 150, 200] },
+    )
+    .toBe(true);
+  return readViewport(page);
+}
+
+/** The flow-space point under a screen point, given the current viewport. */
+function toFlowCoords(
+  viewport: Viewport,
+  screenX: number,
+  screenY: number,
+  pane: { x: number; y: number },
+): { x: number; y: number } {
+  // Screen -> pane-relative -> flow space (React Flow's own inverse transform).
+  return {
+    x: (screenX - pane.x - viewport.x) / viewport.scale,
+    y: (screenY - pane.y - viewport.y) / viewport.scale,
+  };
+}
+
+test.describe("ui-ux — canvas zoom and navigation", () => {
+  let flowId: string;
+  let removeFlow: (reqOverride?: APIRequestContext) => Promise<void>;
+
+  test.beforeEach(async ({ page, request }) => {
+    const token = await getAuthToken(request);
+    const flow = await createRunnableChatFlowViaApi(request, {
+      Authorization: token,
+    });
+    flowId = flow.flowId;
+    removeFlow = flow.deleteFlow;
+
+    await page.goto(`/flow/${flowId}`);
+    // Gate on the editor itself, not just the route: the controls trigger is
+    // the canvas-ready signal used across the suite.
+    await expect(page.getByTestId("canvas_controls_dropdown")).toBeVisible({
+      timeout: 30000,
+    });
+    await expect(page.getByTestId("title-Chat Input")).toBeVisible({
+      timeout: 30000,
+    });
+    // The stored viewport is applied on hydration; start from a settled one.
+    await waitForViewportSettled(page);
+  });
+
+  test.afterEach(async ({ page, request }) => {
+    // Unmount the editor before deleting: the open editor polls
+    // GET /flows/{id}/events and a mid-poll delete 404s into the fixture's
+    // backend-error monitor.
+    await page.goto("/").catch(() => {});
+    await removeFlow(request);
+  });
+
+  test("zoom in and zoom out step the canvas scale and clamp at the React Flow bounds",
+    { tag: ["@stable", "@workspace", "@ui-ux"] },
+    async ({ page }) => {
+      let baseline: Viewport;
+
+      await test.step("start from the fitted viewport with the controls expanded", async () => {
+        baseline = await normalizeViewport(page);
+        await openCanvasControls(page);
+        await expect(page.getByTestId("zoom_in")).toBeEnabled();
+        await expect(page.getByTestId("zoom_out")).toBeEnabled();
+      });
+
+      await test.step("zoom in multiplies the scale by the zoom step", async () => {
+        await page.getByTestId("zoom_in").click();
+        const zoomedIn = await waitForViewportSettled(page);
+
+        expect(zoomedIn.scale).toBeGreaterThan(baseline.scale);
+        expect(zoomedIn.scale / baseline.scale).toBeCloseTo(ZOOM_STEP, 2);
+      });
+
+      await test.step("zoom out returns the scale to its previous value", async () => {
+        await page.getByTestId("zoom_out").click();
+        const zoomedOut = await waitForViewportSettled(page);
+
+        expect(zoomedOut.scale).toBeCloseTo(baseline.scale, 3);
+      });
+
+      await test.step("zoom out clamps at the minimum zoom and disables the button", async () => {
+        const clicks = await zoomUntilClamped(page, "zoom_out");
+        expect(clicks).toBeLessThan(MAX_ZOOM_CLICKS);
+
+        const clamped = await waitForViewportSettled(page);
+        expect(clamped.scale).toBeCloseTo(MIN_ZOOM, 4);
+        await expect(page.getByTestId("zoom_out")).toBeDisabled();
+        // The opposite direction must stay available at the bound.
+        await expect(page.getByTestId("zoom_in")).toBeEnabled();
+      });
+
+      await test.step("zoom in clamps at the maximum zoom and disables the button", async () => {
+        const clicks = await zoomUntilClamped(page, "zoom_in");
+        expect(clicks).toBeLessThan(MAX_ZOOM_CLICKS);
+
+        const clamped = await waitForViewportSettled(page);
+        expect(clamped.scale).toBeCloseTo(MAX_ZOOM, 4);
+        await expect(page.getByTestId("zoom_in")).toBeDisabled();
+        await expect(page.getByTestId("zoom_out")).toBeEnabled();
+      });
+    });
+
+  test("Fit View centers every node inside the canvas viewport",
+    { tag: ["@stable", "@workspace", "@ui-ux"] },
+    async ({ page }) => {
+      await test.step("displace the viewport to the maximum zoom", async () => {
+        // Zoom in from the fitted state, so the displacement is the test's own
+        // doing rather than the editor's entry state.
+        await normalizeViewport(page);
+        await openCanvasControls(page);
+        const clicks = await zoomUntilClamped(page, "zoom_in");
+        expect(clicks).toBeGreaterThan(0);
+        expect(clicks).toBeLessThan(MAX_ZOOM_CLICKS);
+        const clamped = await waitForViewportSettled(page);
+        expect(clamped.scale).toBeCloseTo(MAX_ZOOM, 4);
+      });
+
+      await test.step("the graph overflows the pane before Fit View", async () => {
+        // Precondition with teeth: without it, a canvas that is already fitted
+        // would let the assertions below pass on a dead Fit View button.
+        const overflowing = await measureGeometry(page);
+        expect(overflowing.nodeCount).toBeGreaterThan(0);
+        expect(overflowing.contained).toBe(false);
+      });
+
+      let fittedTransform = "";
+
+      await test.step("Fit View brings every node inside the pane, centered", async () => {
+        await openCanvasControls(page);
+        await page.getByTestId("fit_view").click();
+        const fitted = await waitForViewportSettled(page);
+        fittedTransform = await readTransform(page);
+
+        expect(fitted.scale).toBeLessThan(MAX_ZOOM);
+
+        const geometry = await measureGeometry(page);
+        expect(geometry.contained).toBe(true);
+        expect(Math.abs(geometry.centerDeltaX)).toBeLessThanOrEqual(
+          CENTERING_TOLERANCE_PX,
+        );
+        expect(Math.abs(geometry.centerDeltaY)).toBeLessThanOrEqual(
+          CENTERING_TOLERANCE_PX,
+        );
+
+        await expect(page.getByTestId("title-Chat Input")).toBeVisible();
+        await expect(page.getByTestId("title-Chat Output")).toBeVisible();
+      });
+
+      await test.step("a second Fit View click is a no-op", async () => {
+        // Idempotence is the contract the suite's adjustScreenView helper relies
+        // on: fitting twice must not drift the viewport.
+        await openCanvasControls(page);
+        await page.getByTestId("fit_view").click();
+        await waitForViewportSettled(page);
+
+        expect(await readTransform(page)).toBe(fittedTransform);
+      });
+    });
+
+  test("Fit View is reachable from the canvas controls toolbar",
+    { tag: ["@stable", "@workspace", "@ui-ux"] },
+    async ({ page }) => {
+      const controlTestIds = ["fit_view", "zoom_in", "zoom_out", "reset_zoom"];
+
+      await test.step("the toolbar renders with the zoom controls collapsed", async () => {
+        await expect(page.getByTestId("main_canvas_controls")).toBeVisible();
+        await expect(page.getByTestId("canvas_controls_dropdown")).toBeVisible();
+        for (const testId of controlTestIds) {
+          await expect(page.getByTestId(testId)).toHaveCount(0);
+        }
+      });
+
+      await test.step("expanding the dropdown exposes all four controls", async () => {
+        await page.getByTestId("canvas_controls_dropdown").click();
+        for (const testId of controlTestIds) {
+          await expect(page.getByTestId(testId)).toBeVisible({ timeout: 15000 });
+        }
+        // Only these two are asserted enabled here: the editor opens clamped at
+        // the maximum zoom, so `zoom_in` is legitimately disabled until the
+        // viewport moves (asserted below, right after Fit View).
+        await expect(page.getByTestId("fit_view")).toBeEnabled();
+        await expect(page.getByTestId("reset_zoom")).toBeEnabled();
+      });
+
+      await test.step("the toolbar Fit View acts on the displaced entry viewport", async () => {
+        const displacedTransform = await readTransform(page);
+        expect((await measureGeometry(page)).contained).toBe(false);
+
+        await page.getByTestId("fit_view").click();
+        await waitForViewportSettled(page);
+
+        expect(await readTransform(page)).not.toBe(displacedTransform);
+        expect((await measureGeometry(page)).contained).toBe(true);
+        // Off the zoom bound, both zoom controls are live again.
+        await expect(page.getByTestId("zoom_in")).toBeEnabled();
+        await expect(page.getByTestId("zoom_out")).toBeEnabled();
+      });
+
+      await test.step("collapsing the dropdown removes the controls again", async () => {
+        // Forced click: the open popover's overlay covers the trigger (see
+        // closeCanvasControls).
+        await page.getByTestId("canvas_controls_dropdown").click({ force: true });
+        for (const testId of controlTestIds) {
+          await expect(page.getByTestId(testId)).toHaveCount(0, {
+            timeout: 15000,
+          });
+        }
+      });
+
+      await test.step("the dropdown can be expanded again", async () => {
+        await page.getByTestId("canvas_controls_dropdown").click();
+        for (const testId of controlTestIds) {
+          await expect(page.getByTestId(testId)).toBeVisible({ timeout: 15000 });
+        }
+      });
+    });
+
+  test("wheel scroll navigates the canvas anchored at the pointer",
+    { tag: ["@stable", "@workspace", "@ui-ux"] },
+    async ({ page }) => {
+      // Start off the maximum-zoom entry clamp (a clamped viewport cannot zoom
+      // in) and with the dropdown closed — its popover swallows wheel events.
+      const baseline = await normalizeViewport(page);
+
+      const pane = await paneBox(page);
+      const pointP = {
+        x: pane.x + pane.width / 3,
+        y: pane.y + pane.height / 2,
+      };
+      const pointQ = {
+        x: pane.x + (pane.width * 2) / 3,
+        y: pane.y + pane.height / 3,
+      };
+
+      await test.step("scrolling down zooms out around the pointer", async () => {
+        const anchorBefore = toFlowCoords(baseline, pointP.x, pointP.y, pane);
+
+        await page.mouse.move(pointP.x, pointP.y);
+        await page.mouse.wheel(0, WHEEL_DELTA);
+        const scrolled = await waitForViewportSettled(page);
+
+        expect(scrolled.scale).toBeLessThan(baseline.scale);
+
+        const anchorAfter = toFlowCoords(scrolled, pointP.x, pointP.y, pane);
+        expect(Math.abs(anchorAfter.x - anchorBefore.x)).toBeLessThanOrEqual(
+          ANCHOR_TOLERANCE_PX,
+        );
+        expect(Math.abs(anchorAfter.y - anchorBefore.y)).toBeLessThanOrEqual(
+          ANCHOR_TOLERANCE_PX,
+        );
+      });
+
+      await test.step("scrolling up restores the previous zoom level", async () => {
+        const before = await readViewport(page);
+        const anchorBefore = toFlowCoords(before, pointP.x, pointP.y, pane);
+
+        await page.mouse.wheel(0, -WHEEL_DELTA);
+        const scrolled = await waitForViewportSettled(page);
+
+        expect(scrolled.scale).toBeGreaterThan(before.scale);
+        expect(scrolled.scale).toBeCloseTo(baseline.scale, 3);
+
+        const anchorAfter = toFlowCoords(scrolled, pointP.x, pointP.y, pane);
+        expect(Math.abs(anchorAfter.x - anchorBefore.x)).toBeLessThanOrEqual(
+          ANCHOR_TOLERANCE_PX,
+        );
+        expect(Math.abs(anchorAfter.y - anchorBefore.y)).toBeLessThanOrEqual(
+          ANCHOR_TOLERANCE_PX,
+        );
+      });
+
+      await test.step("the anchor follows the pointer to a second position", async () => {
+        // A zoom pinned to the pane center (instead of the cursor) passes the
+        // steps above only by luck and fails here.
+        const before = await readViewport(page);
+        const anchorBefore = toFlowCoords(before, pointQ.x, pointQ.y, pane);
+
+        await page.mouse.move(pointQ.x, pointQ.y);
+        await page.mouse.wheel(0, WHEEL_DELTA);
+        const scrolled = await waitForViewportSettled(page);
+
+        expect(scrolled.scale).toBeLessThan(before.scale);
+
+        const anchorAfter = toFlowCoords(scrolled, pointQ.x, pointQ.y, pane);
+        expect(Math.abs(anchorAfter.x - anchorBefore.x)).toBeLessThanOrEqual(
+          ANCHOR_TOLERANCE_PX,
+        );
+        expect(Math.abs(anchorAfter.y - anchorBefore.y)).toBeLessThanOrEqual(
+          ANCHOR_TOLERANCE_PX,
+        );
+      });
+    });
+});


### PR DESCRIPTION
Closes #941.

Closes the four `[-]` gaps in `QA-CHECKLIST.md` § 15.5 *Canvas Zoom and Navigation* (Minimap stays `[~]` — feature-flag-gated, no minimap element is rendered on 1.12.0.dev6). No existing spec covered §15.5: the `[-]` marks came from the Page/Helper case in the checklist legend (`helpers/ui/zoom-out.ts`, `helpers/ui/adjust-screen-view.ts`, `FlowEditorPage.fitView/zoomOut`), which are convenience wrappers that swallow state and cannot assert anything. Sibling canvas specs exercise node manipulation (§15.4 — `componentDelete`, `canvas-copy-paste`) and never the viewport itself.

Spec doc: `docs/ui-ux/canvas-zoom-navigation.md`.

## 1. Covered tests

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `zoom in and zoom out step the canvas scale and clamp at the React Flow bounds` | `zoom_in` multiplies the viewport scale by `1.2` (±0.01) and `zoom_out` divides it back (±0.001); clicking to exhaustion clamps at exactly `0.25` (`zoom_out` disabled, `zoom_in` still enabled) and exactly `2` (the mirror). Catches a changed step factor, a changed `minZoom`/`maxZoom`, and a zoom button that stops driving the viewport. |
| 2 | `Fit View centers every node inside the canvas viewport` | From the `2` clamp — with the graph asserted to overflow the pane first, so the test cannot pass on an already-fitted canvas — `fit_view` brings the nodes' union box inside the `.react-flow__pane` rect (1px tolerance), centers it within 4px on both axes (measured 1px/0px live), keeps both node titles visible, and a second click is byte-identical (the idempotence contract `adjustScreenView` relies on). |
| 3 | `Fit View is reachable from the canvas controls toolbar` | The toolbar surface: `main_canvas_controls` visible while `fit_view`/`zoom_in`/`zoom_out`/`reset_zoom` have `count() === 0`; expanding `canvas_controls_dropdown` renders all four (with `fit_view`/`reset_zoom` enabled); the toolbar `fit_view` changes the transform of the displaced entry viewport, contains every node and re-enables both zoom buttons; collapsing removes all four from the DOM and it re-expands. Catches the controls disappearing from the toolbar or Fit View becoming decorative. |
| 4 | `wheel scroll navigates the canvas anchored at the pointer` | `wheel(0, +300)` over the pane strictly decreases the scale and `wheel(0, -300)` restores it (±0.001), and in both directions the flow-space point under the cursor is preserved (≤2px) — re-measured at a second pane position, so a zoom pinned to the pane center fails. On 1.12 the wheel is bound to zoom-at-pointer; there is no scroll-to-pan surface, which is stated on the checklist bullet. |

## 2. How the test was built

- **Setup:** flow created through the API from the repo-owned fixture `tests/assets/flows/chat-io-ok-trace-fixture.json` (Chat Input → Chat Output) via `createRunnableChatFlowViaApi`, then `page.goto("/flow/{id}")`. No starter template (no upstream coupling), no provider key, no LLM call, no flow build — the spec is pure viewport geometry, ~4s per test.
- **Cleanup:** id-scoped. The flow id is held by the spec and deleted in `afterEach` after `page.goto("/")` unmounts the editor's `GET /flows/{id}/events` poll. Never a wipe.
- **Live-confirmed selectors** (scouted on nightly `1.12.0.dev6`, throwaway scout deleted along with its flow): `main_canvas_controls`, `canvas_controls_dropdown`, and — only after the dropdown is expanded, they are absent from the DOM before that — `zoom_in`, `zoom_out`, `reset_zoom`, `fit_view`. Node titles `title-Chat Input` / `title-Chat Output`. No minimap testid exists.
- **Assertion mechanism:** every check reads `.react-flow__viewport`'s `transform: translate(<x>px, <y>px) scale(<z>)` (parsed into `{x, y, scale}`) and/or the union `getBoundingClientRect()` of `.react-flow__node` against `.react-flow__pane`. A "button is visible" check would pass on a control detached from the viewport; these fail.
- **Two live behaviors encoded instead of worked around:**
  1. *The editor ignores the flow's persisted viewport on entry* — it opens clamped at `scale(2)` with `zoom_in` already disabled, reproducibly across reloads, while `GET /api/v1/flows/{id}` reports `viewport.zoom = 0.896`. Tests that measure *relative* zoom therefore normalize with one `fit_view` click first (`normalizeViewport`), and test 3 reuses that displaced entry state as a free "Fit View has work to do" precondition.
  2. *The open controls popover swallows wheel events and covers its own trigger* — so wheel gestures run with the dropdown closed, and the collapse click is `force: true` (the same forced click `loop-component.spec.ts` and `mcp-server.spec.ts` already use on this trigger).
- **Waits are on real signals:** `waitForViewportSettled` polls the transform string until two consecutive reads match (React Flow animates zoom/fit), and the click-until-disabled loops are bounded so a never-disabling button fails on an assertion instead of hanging.

## 3. Dependencies

- **None** — pure UI. No provider API key, no `collect-models`, no LLM, no flow build.
- **Execution mode:** parallel-safe. Every flow is id-addressed and its name carries the helper's `Date.now()`+random suffix, so there is no named-flow collision; no `--workers=1` requirement.

## Validation (nightly `1.12.0.dev6`, `--retries=0 --workers=1`)

- `npm run typecheck` ✅ (0 errors) · `npm run lint` ✅ (0 errors)
- **3/3 clean runs**, no flake: `expected=4 unexpected=0 flaky=0` on each, zero `🚨 Backend Error` — ~16s per run
- **Force-fail, one per test** (each verified red, then reverted; final green run after the reverts ✅):
  - test 1 — `ZOOM_STEP 1.2 → 1.5` ⇒ red (the step-ratio assert has teeth)
  - test 2 — removed the `fit_view` click ⇒ red (containment + centering reject the un-fitted viewport)
  - test 3 — removed the toolbar `fit_view` click ⇒ red (transform-changed + containment + zoom re-enable)
  - test 4 — anchor probed at the pane center instead of the cursor ⇒ red (~38px drift under the same gesture)
- **Behavioral force-fail of the cleanup:** with the `afterEach` delete no-op'd the run stayed green but left **4 orphan flows**; reverted and purged ⇒ **0 orphans**. Instance flow count after the final green run: **0**.
- Note: nightly `1.12.0.dev7` was published mid-session but the Docker VM disk was full (`no space left on device` on `docker pull`), so validation is against `dev6`. `Last validated` in the spec doc says `1.12.x (nightly 1.12.0.dev6)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
