### PR TITLE
feat(ci): provider API-key fallback — resolve a live key before the suite (#976)

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -206,6 +206,31 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Pick a LIVE key per provider before anything consumes one (#976). When a
+      # provider's key dies, collect-models records it "inactive" and the 17
+      # specs reading providers.json skip every target bound to it — silently,
+      # because a skip never trips the daily-failure gate (24 specs lost that way
+      # on 2026-07-27, #967). This probes <PROVIDER>_API_KEY, _2, _3... and
+      # re-exports the first that answers under the canonical name, so the
+      # Collect models step AND the sharded run below both inherit a validated
+      # key. It runs here rather than inside collect-models because those are
+      # separate steps: a fallback confined to collect-models would import the
+      # backup into Langflow while this job's test step still held the dead
+      # primary, and the first spec calling setupAnthropic would overwrite the
+      # working credential with it.
+      # STRICT here: a configured provider with no usable key is a broken
+      # environment, and eroded coverage must be loud. No continue-on-error.
+      - name: Resolve provider keys
+        run: npx ts-node scripts/resolve-provider-keys.ts
+        env:
+          PROVIDER_KEYS_STRICT: "1"
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_KEY_2: ${{ secrets.OPENAI_API_KEY_2 }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY_2: ${{ secrets.ANTHROPIC_API_KEY_2 }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GOOGLE_API_KEY_2: ${{ secrets.GOOGLE_API_KEY_2 }}
+
       # Guard: the @playwright/test version (from npm) MUST equal the container
       # image tag, or the runner looks for a browser revision the image doesn't
       # ship and every test fails at launch with a cryptic error. Fail fast with

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -191,6 +191,22 @@ jobs:
       # Skipped when no impacted spec needs provider model data (see detect-specs
       # → needs_models). Keeps a provider billing/quota outage from reddening a
       # PR whose specs never use that provider (#915/#910/#911 class).
+      # Same key resolution the daily runs (#976) — pick a live candidate before
+      # Collect models consumes one. WARN-ONLY here: this job must not go red
+      # because an account was drained, which is the whole point of #952/#955.
+      # Gated on needs_models for the same reason Collect models is.
+      - name: Resolve provider keys
+        if: needs.detect-specs.outputs.needs_models == 'true'
+        run: npx ts-node scripts/resolve-provider-keys.ts
+        env:
+          PROVIDER_KEYS_STRICT: "0"
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_KEY_2: ${{ secrets.OPENAI_API_KEY_2 }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY_2: ${{ secrets.ANTHROPIC_API_KEY_2 }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GOOGLE_API_KEY_2: ${{ secrets.GOOGLE_API_KEY_2 }}
+
       - name: Collect models
         if: needs.detect-specs.outputs.needs_models == 'true'
         env:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "coverage:summary": "ts-node scripts/coverage-summary.ts && ts-node scripts/stable-tests.ts",
     "impacted": "ts-node scripts/impacted-tests.ts",
     "validate:specs": "ts-node scripts/validate-spec-deps.ts",
-    "check:nightly-delta": "ts-node scripts/check-nightly-delta.ts"
+    "check:nightly-delta": "ts-node scripts/check-nightly-delta.ts",
+    "resolve:provider-keys": "ts-node scripts/resolve-provider-keys.ts"
   },
   "dependencies": {
     "dotenv": "^16.4.5"

--- a/scripts/resolve-provider-keys.test.ts
+++ b/scripts/resolve-provider-keys.test.ts
@@ -1,0 +1,50 @@
+// Unit tests for the provider API-key resolver (issue #976).
+// Run with: node --require ts-node/register --test scripts/resolve-provider-keys.test.ts
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { classifyProbeFailure } from "../tests/helpers/provider-setup/probe-provider-key";
+
+test("a thrown fetch (no HTTP response) is transport — never burns a key", () => {
+  assert.equal(classifyProbeFailure(null, "fetch failed"), "transport");
+  assert.equal(classifyProbeFailure(null, "ETIMEDOUT"), "transport");
+});
+
+test("a 5xx is transport — the provider is broken, not the key", () => {
+  assert.equal(classifyProbeFailure(500, "internal server error"), "transport");
+  assert.equal(classifyProbeFailure(503, "overloaded_error"), "transport");
+});
+
+test("a model-scoped rejection is model — the key is not to blame", () => {
+  assert.equal(classifyProbeFailure(404, "model not found"), "model");
+  assert.equal(
+    classifyProbeFailure(403, "The model `claude-4-opus` does not exist or you do not have access"),
+    "model",
+  );
+  assert.equal(classifyProbeFailure(400, "model is not supported for this endpoint"), "model");
+});
+
+test("auth, billing and quota rejections are key — advance to the next candidate", () => {
+  assert.equal(classifyProbeFailure(401, "invalid x-api-key"), "key");
+  assert.equal(classifyProbeFailure(402, "payment required"), "key");
+  assert.equal(classifyProbeFailure(429, "rate limit exceeded"), "key");
+  // The exact string that took Anthropic down on the 2026-07-27 daily (#967).
+  assert.equal(
+    classifyProbeFailure(400, "Your credit balance is too low to access the Anthropic API."),
+    "key",
+  );
+  assert.equal(classifyProbeFailure(429, "insufficient_quota"), "key");
+  assert.equal(classifyProbeFailure(400, "RESOURCE_EXHAUSTED"), "key");
+});
+
+test("billing wording wins over a status that would otherwise read as model", () => {
+  // A drained account answering 404 must still burn the key, not the model.
+  assert.equal(
+    classifyProbeFailure(404, "Your credit balance is too low to access the Anthropic API."),
+    "key",
+  );
+});
+
+test("an unrecognised failure is transport — inconclusive, never burns a key", () => {
+  assert.equal(classifyProbeFailure(418, "i am a teapot"), "transport");
+  assert.equal(classifyProbeFailure(400, "malformed request"), "transport");
+});

--- a/scripts/resolve-provider-keys.test.ts
+++ b/scripts/resolve-provider-keys.test.ts
@@ -3,6 +3,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { classifyProbeFailure } from "../tests/helpers/provider-setup/probe-provider-key";
+import { candidateEnvNames } from "./resolve-provider-keys";
 
 test("a thrown fetch (no HTTP response) is transport — never burns a key", () => {
   assert.equal(classifyProbeFailure(null, "fetch failed"), "transport");
@@ -47,4 +48,37 @@ test("billing wording wins over a status that would otherwise read as model", ()
 test("an unrecognised failure is transport — inconclusive, never burns a key", () => {
   assert.equal(classifyProbeFailure(418, "i am a teapot"), "transport");
   assert.equal(classifyProbeFailure(400, "malformed request"), "transport");
+});
+
+test("no key configured yields no candidates — absence of a key is valid config", () => {
+  assert.deepEqual(candidateEnvNames("ANTHROPIC_API_KEY", {}), []);
+  assert.deepEqual(candidateEnvNames("ANTHROPIC_API_KEY", { ANTHROPIC_API_KEY: "" }), []);
+});
+
+test("only the primary set yields one candidate", () => {
+  assert.deepEqual(candidateEnvNames("ANTHROPIC_API_KEY", { ANTHROPIC_API_KEY: "a" }), [
+    "ANTHROPIC_API_KEY",
+  ]);
+});
+
+test("primary plus backups are returned in order", () => {
+  assert.deepEqual(
+    candidateEnvNames("ANTHROPIC_API_KEY", {
+      ANTHROPIC_API_KEY: "a",
+      ANTHROPIC_API_KEY_2: "b",
+      ANTHROPIC_API_KEY_3: "c",
+    }),
+    ["ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY_2", "ANTHROPIC_API_KEY_3"],
+  );
+});
+
+test("a gap stops the scan — _3 without _2 is not reachable", () => {
+  assert.deepEqual(
+    candidateEnvNames("ANTHROPIC_API_KEY", { ANTHROPIC_API_KEY: "a", ANTHROPIC_API_KEY_3: "c" }),
+    ["ANTHROPIC_API_KEY"],
+  );
+});
+
+test("backups without a primary are not reachable — the canonical name anchors the scan", () => {
+  assert.deepEqual(candidateEnvNames("ANTHROPIC_API_KEY", { ANTHROPIC_API_KEY_2: "b" }), []);
 });

--- a/scripts/resolve-provider-keys.ts
+++ b/scripts/resolve-provider-keys.ts
@@ -1,0 +1,184 @@
+/**
+ * Resolves a LIVE API key per provider before the suite runs (issue #976).
+ *
+ * Run:
+ *   npx ts-node scripts/resolve-provider-keys.ts
+ *   PROVIDER_KEYS_STRICT=1 npx ts-node scripts/resolve-provider-keys.ts
+ *
+ * Why this exists. When a provider's key dies, collect-models records the
+ * provider "inactive" and the 17 specs that read providers.json skip every
+ * target bound to it — silently, because a skip never trips the daily-failure
+ * gate. On the 2026-07-27 daily a drained Anthropic account took out 24 specs
+ * that way (#967). The fallback that already existed in collect-models
+ * iterates candidate MODELS, not KEYS, so a dead account had no recovery path.
+ *
+ * What it does. For each provider in providerConfigMap it probes
+ * <PROVIDER>_API_KEY, then _2, _3, ... in order, and re-exports the first one
+ * that answers to $GITHUB_ENV under the CANONICAL name. Everything downstream
+ * — collect-models, the shards, the consumer specs — keeps reading the
+ * canonical name and transparently receives a validated key.
+ *
+ * Why a separate step, not a loop inside collect-models. "Collect models" and
+ * "Run @stable tests" are distinct steps. A fallback confined to collect-models
+ * would import the backup key into Langflow while the test step still received
+ * the dead primary from the workflow env block — and the first spec calling
+ * setupAnthropic would overwrite the working credential with the dead one. The
+ * winning key has to cross the step boundary, so it is resolved before anything
+ * consumes it.
+ *
+ * Strictness. PROVIDER_KEYS_STRICT=1 (daily-stable) exits non-zero when a
+ * configured provider has no live key. Anywhere else it warns: on PRs a billing
+ * outage must not redden a job whose specs never touch an LLM (#952/#955).
+ *
+ * No key material is ever printed — output carries provider names, env var
+ * names and candidate indexes only.
+ */
+import * as fs from "fs";
+import * as path from "path";
+import * as dotenv from "dotenv";
+import { providerConfigMap, type Provider } from "../tests/helpers/provider-setup/provider-config";
+import { probeProviderKey } from "../tests/helpers/provider-setup/probe-provider-key";
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../.env") });
+}
+
+type Env = Record<string, string | undefined>;
+
+/**
+ * Candidate env var names for a provider, in probe order: the canonical name
+ * first, then _2, _3, ... The scan stops at the first gap, so a stray _3 with
+ * no _2 is never silently reached, and backups without a primary are not
+ * reachable at all — the canonical name anchors the sequence.
+ */
+export function candidateEnvNames(base: string, env: Env = process.env): string[] {
+  if (!env[base]) return [];
+
+  const names = [base];
+  for (let i = 2; ; i++) {
+    const name = `${base}_${i}`;
+    if (!env[name]) break;
+    names.push(name);
+  }
+  return names;
+}
+
+interface Resolution {
+  provider: Provider;
+  envName: string | null;
+  index: number; // 1-based; 0 when nothing was resolved
+  candidates: number;
+  error?: string;
+}
+
+async function resolveProvider(provider: Provider): Promise<Resolution | null> {
+  const base = providerConfigMap[provider].envKeys[0];
+  const model = providerConfigMap[provider].probeModel;
+  const names = candidateEnvNames(base);
+
+  // No key configured at all is a valid setup, not a failure — it is what
+  // hasProviderEnvKeys() already handles downstream.
+  if (names.length === 0) {
+    console.log(`•  ${provider}: no key configured (${base} unset) — skipped`);
+    return null;
+  }
+
+  let lastError = "";
+  for (const [i, name] of names.entries()) {
+    const apiKey = process.env[name] as string;
+    const probe = await probeProviderKey(provider, apiKey, model);
+
+    if (probe.ok) {
+      return { provider, envName: name, index: i + 1, candidates: names.length };
+    }
+
+    lastError = probe.error ?? "Unknown error";
+
+    // Only a key/account verdict burns a candidate. A model-scoped or
+    // transport failure says nothing about the key: keep it and let the
+    // model-candidate loop in collect-models make that call.
+    if (probe.kind !== "key") {
+      console.log(
+        `⚠️  ${provider}: probe inconclusive on ${name} (${probe.kind}) — keeping it: ${lastError}`,
+      );
+      return { provider, envName: name, index: i + 1, candidates: names.length };
+    }
+
+    console.log(`   ${provider}: ${name} rejected — ${lastError}`);
+  }
+
+  return { provider, envName: null, index: 0, candidates: names.length, error: lastError };
+}
+
+function exportWinner(base: string, value: string): void {
+  const githubEnv = process.env.GITHUB_ENV;
+  if (!githubEnv) return;
+
+  // ::add-mask:: is only safe INSIDE Actions, where the runner consumes the
+  // workflow command and redacts the value from the log. Anywhere else it is
+  // a plain console.log of the key — which is how this very script leaked one
+  // during development. Guard on the runner, never on GITHUB_ENV alone.
+  if (process.env.GITHUB_ACTIONS === "true") {
+    console.log(`::add-mask::${value}`);
+  }
+  fs.appendFileSync(githubEnv, `${base}=${value}\n`);
+}
+
+function appendSummary(line: string): void {
+  const summary = process.env.GITHUB_STEP_SUMMARY;
+  if (!summary) return;
+  fs.appendFileSync(summary, `${line}\n`);
+}
+
+async function main(): Promise<void> {
+  const strict = process.env.PROVIDER_KEYS_STRICT === "1";
+  console.log(`Resolving provider API keys (strict=${strict ? "on" : "off"})...`);
+
+  const failures: Resolution[] = [];
+
+  for (const provider of Object.keys(providerConfigMap) as Provider[]) {
+    const result = await resolveProvider(provider);
+    if (!result) continue;
+
+    if (!result.envName) {
+      failures.push(result);
+      console.log(
+        `❌ ${provider}: all ${result.candidates} candidate key(s) failed — last error: ${result.error}`,
+      );
+      continue;
+    }
+
+    console.log(`✅ ${provider}: resolved to ${result.envName} (candidate ${result.index}/${result.candidates})`);
+
+    if (result.index > 1) {
+      const base = providerConfigMap[provider].envKeys[0];
+      exportWinner(base, process.env[result.envName] as string);
+      const note =
+        `provider "${provider}" fell back to ${result.envName} — the primary ${base} is not usable and needs attention`;
+      console.log(`::warning::${note}`);
+      appendSummary(`⚠️ ${note}`);
+    }
+  }
+
+  if (failures.length === 0) return;
+
+  const detail = failures
+    .map((f) => `${f.provider} (${f.candidates} candidate key(s)) — ${f.error}`)
+    .join(" | ");
+
+  if (strict) {
+    console.error(`::error::No usable API key for: ${detail}`);
+    process.exit(1);
+  }
+
+  console.log(`::warning::No usable API key for: ${detail}`);
+  appendSummary(`⚠️ No usable API key for: ${detail}`);
+}
+
+// Only run when invoked directly, so the unit tests can import the pure helpers.
+if (require.main === module) {
+  main().catch((e: unknown) => {
+    console.error(`::error::resolve-provider-keys crashed: ${e instanceof Error ? e.message : e}`);
+    process.exit(1);
+  });
+}

--- a/tests/helpers/provider-setup/collect-models.ts
+++ b/tests/helpers/provider-setup/collect-models.ts
@@ -4,6 +4,7 @@ import path from "path";
 import fs from "fs";
 import { SettingsPage } from "../../pages/SettingsPage";
 import { providerConfigMap, type Provider } from "./provider-config";
+import { probeProviderKey } from "./probe-provider-key";
 
 const DATA_DIR = path.join(__dirname, "data");
 const PROVIDERS_PATH = path.join(DATA_DIR, "providers.json");
@@ -26,99 +27,29 @@ interface ModelRecord {
 
 // ─── Provider validation (API calls) ──────────────────────────────────────────
 
-async function validateOpenAI(model: string): Promise<ProviderRecord> {
-  const apiKey = process.env.OPENAI_API_KEY ?? "";
-  const provider = "openai";
+// One probe implementation, shared with scripts/resolve-provider-keys.ts (#976).
+// Before that extraction these were three near-identical fetch blocks, each
+// reading its own env var — which is why a key-level fallback had nowhere to
+// live. The factory keeps the (model) => ProviderRecord shape that
+// validateProviderWithFallback drives, and preserves the "<ENV> not set"
+// suffix its early-exit keys off.
+function makeValidator(provider: Provider): (model: string) => Promise<ProviderRecord> {
+  const envKey = providerConfigMap[provider].envKeys[0];
 
-  if (!apiKey) {
-    return { provider, model, status: "inactive", error: "OPENAI_API_KEY not set", checkedAt: new Date().toISOString() };
-  }
+  return async (model: string): Promise<ProviderRecord> => {
+    const checkedAt = new Date().toISOString();
+    const apiKey = process.env[envKey] ?? "";
 
-  try {
-    const res = await fetch("https://api.openai.com/v1/chat/completions", {
-      method: "POST",
-      headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
-      body: JSON.stringify({
-        model,
-        messages: [{ role: "user", content: "hi" }],
-      }),
-    });
-
-    if (!res.ok) {
-      const body = await res.json().catch(() => ({}));
-      return { provider, model, status: "inactive", error: (body as any)?.error?.message ?? `HTTP ${res.status}`, checkedAt: new Date().toISOString() };
+    if (!apiKey) {
+      return { provider, model, status: "inactive", error: `${envKey} not set`, checkedAt };
     }
 
-    return { provider, model, status: "active", error: null, checkedAt: new Date().toISOString() };
-  } catch (e: any) {
-    return { provider, model, status: "inactive", error: e?.message ?? "Unknown error", checkedAt: new Date().toISOString() };
-  }
-}
+    const probe = await probeProviderKey(provider, apiKey, model);
 
-async function validateAnthropic(model: string): Promise<ProviderRecord> {
-  const apiKey = process.env.ANTHROPIC_API_KEY ?? "";
-  const provider = "anthropic";
-
-  if (!apiKey) {
-    return { provider, model, status: "inactive", error: "ANTHROPIC_API_KEY not set", checkedAt: new Date().toISOString() };
-  }
-
-  try {
-    const res = await fetch("https://api.anthropic.com/v1/messages", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-api-key": apiKey,
-        "anthropic-version": "2023-06-01",
-      },
-      body: JSON.stringify({
-        model,
-        max_tokens: 1,
-        messages: [{ role: "user", content: "hi" }],
-      }),
-    });
-
-    if (!res.ok) {
-      const body = await res.json().catch(() => ({}));
-      return { provider, model, status: "inactive", error: (body as any)?.error?.message ?? `HTTP ${res.status}`, checkedAt: new Date().toISOString() };
-    }
-
-    return { provider, model, status: "active", error: null, checkedAt: new Date().toISOString() };
-  } catch (e: any) {
-    return { provider, model, status: "inactive", error: e?.message ?? "Unknown error", checkedAt: new Date().toISOString() };
-  }
-}
-
-async function validateGoogle(model: string): Promise<ProviderRecord> {
-  const apiKey = process.env.GOOGLE_API_KEY ?? "";
-  const provider = "google";
-
-  if (!apiKey) {
-    return { provider, model, status: "inactive", error: "GOOGLE_API_KEY not set", checkedAt: new Date().toISOString() };
-  }
-
-  try {
-    const res = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          contents: [{ parts: [{ text: "hi" }] }],
-          generationConfig: { maxOutputTokens: 1 },
-        }),
-      },
-    );
-
-    if (!res.ok) {
-      const body = await res.json().catch(() => ({}));
-      return { provider, model, status: "inactive", error: (body as any)?.error?.message ?? `HTTP ${res.status}`, checkedAt: new Date().toISOString() };
-    }
-
-    return { provider, model, status: "active", error: null, checkedAt: new Date().toISOString() };
-  } catch (e: any) {
-    return { provider, model, status: "inactive", error: e?.message ?? "Unknown error", checkedAt: new Date().toISOString() };
-  }
+    return probe.ok
+      ? { provider, model, status: "active", error: null, checkedAt }
+      : { provider, model, status: "inactive", error: probe.error ?? "Unknown error", checkedAt };
+  };
 }
 
 function modelsFor(models: ModelRecord[], provider: string): string[] {
@@ -220,9 +151,9 @@ async function collectProviders(models: ModelRecord[]): Promise<ProviderRecord[]
   console.log("Validating providers via API...");
 
   const results = await Promise.all([
-    validateProviderWithFallback("openai", rankCandidates("openai", modelsFor(models, "openai")), validateOpenAI),
-    validateProviderWithFallback("anthropic", rankCandidates("anthropic", modelsFor(models, "anthropic")), validateAnthropic),
-    validateProviderWithFallback("google", rankCandidates("google", modelsFor(models, "google")), validateGoogle),
+    validateProviderWithFallback("openai", rankCandidates("openai", modelsFor(models, "openai")), makeValidator("openai")),
+    validateProviderWithFallback("anthropic", rankCandidates("anthropic", modelsFor(models, "anthropic")), makeValidator("anthropic")),
+    validateProviderWithFallback("google", rankCandidates("google", modelsFor(models, "google")), makeValidator("google")),
   ]);
 
   for (const r of results) {

--- a/tests/helpers/provider-setup/probe-provider-key.ts
+++ b/tests/helpers/provider-setup/probe-provider-key.ts
@@ -1,0 +1,104 @@
+// Key-parameterized provider probe, shared by collect-models.ts and
+// scripts/resolve-provider-keys.ts (issue #976).
+//
+// The probe must be a REAL 1-token inference call. An auth-only endpoint
+// (GET /v1/models) answers 200 on a zero-balance account and would not have
+// caught the failure that drained the 2026-07-27 daily (#967): "Your credit
+// balance is too low to access the Anthropic API".
+import { type Provider } from "./provider-config";
+
+export type ProbeFailureKind = "key" | "model" | "transport";
+
+export interface ProbeResult {
+  ok: boolean;
+  status: number | null;
+  kind?: ProbeFailureKind;
+  error?: string;
+}
+
+// Same wording set the collect-models.spec.ts gate keys off (#952/#955).
+const BILLING_OR_QUOTA =
+  /credit balance is too low|insufficient[_ ]?quota|exceeded your current quota|\bquota\b|resource[_ ]?exhausted|billing|payment required/i;
+
+const MODEL_SCOPED = /model|does not exist|not found|not supported/i;
+
+/**
+ * Decide whether a failed probe indicts the KEY (advance to the next
+ * candidate), the MODEL (the key is fine — the model-candidate loop in
+ * collect-models owns that call), or is inconclusive TRANSPORT noise.
+ *
+ * Deliberately conservative: anything unrecognised is transport, so an
+ * unexpected provider response can never burn through the key candidates.
+ */
+export function classifyProbeFailure(status: number | null, message: string): ProbeFailureKind {
+  if (status === null) return "transport";
+  if (status >= 500) return "transport";
+  // Billing wording wins over the status code: a drained account answering 404
+  // is still a key/account problem, not a missing model.
+  if (BILLING_OR_QUOTA.test(message)) return "key";
+  if (status === 404 || MODEL_SCOPED.test(message)) return "model";
+  if (status === 401 || status === 402 || status === 403 || status === 429) return "key";
+  return "transport";
+}
+
+interface ProviderRequest {
+  url: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+function buildRequest(provider: Provider, apiKey: string, model: string): ProviderRequest {
+  switch (provider) {
+    case "openai":
+      return {
+        url: "https://api.openai.com/v1/chat/completions",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+        body: { model, messages: [{ role: "user", content: "hi" }] },
+      };
+    case "anthropic":
+      return {
+        url: "https://api.anthropic.com/v1/messages",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": apiKey,
+          "anthropic-version": "2023-06-01",
+        },
+        body: { model, max_tokens: 1, messages: [{ role: "user", content: "hi" }] },
+      };
+    case "google":
+      return {
+        url: `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
+        headers: { "Content-Type": "application/json" },
+        body: { contents: [{ parts: [{ text: "hi" }] }], generationConfig: { maxOutputTokens: 1 } },
+      };
+  }
+}
+
+/**
+ * Probe one (provider, key, model) triple. Never throws — a transport failure
+ * comes back as an inconclusive ProbeResult.
+ *
+ * The error string is the provider's own `error.message`, verbatim, so callers
+ * that pattern-match on it (the collect-models gate) keep working unchanged.
+ */
+export async function probeProviderKey(
+  provider: Provider,
+  apiKey: string,
+  model: string,
+): Promise<ProbeResult> {
+  const { url, headers, body } = buildRequest(provider, apiKey, model);
+
+  let res: Response;
+  try {
+    res = await fetch(url, { method: "POST", headers, body: JSON.stringify(body) });
+  } catch (e: unknown) {
+    const error = e instanceof Error ? e.message : "Unknown error";
+    return { ok: false, status: null, kind: "transport", error };
+  }
+
+  if (res.ok) return { ok: true, status: res.status };
+
+  const payload = (await res.json().catch(() => ({}))) as { error?: { message?: string } };
+  const error = payload?.error?.message ?? `HTTP ${res.status}`;
+  return { ok: false, status: res.status, kind: classifyProbeFailure(res.status, error), error };
+}

--- a/tests/helpers/provider-setup/provider-config.ts
+++ b/tests/helpers/provider-setup/provider-config.ts
@@ -5,6 +5,10 @@ export interface ProviderConfig {
   keyPlaceholder: string;
   invalidKey: string;
   envKeys: string[]; // todas as env vars necessárias; a primeira é a chave primária
+  // Model used to probe a raw API key before the suite runs (#976). Must be a
+  // cheap, broadly available model: key resolution happens before models.json
+  // exists, so it cannot be picked from the collected catalog.
+  probeModel: string;
 }
 
 // ─── Fonte única de configuração por provider ─────────────────────────────────
@@ -18,17 +22,20 @@ export const providerConfigMap: Record<Provider, ProviderConfig> = {
     keyPlaceholder: "sk-...",
     invalidKey: "sk-invalid-openai-key-for-testing-12345",
     envKeys: ["OPENAI_API_KEY"],
+    probeModel: "gpt-4o-mini",
   },
   anthropic: {
     providerTestId: "provider-item-Anthropic",
     keyPlaceholder: "sk-ant-...",
     invalidKey: "sk-ant-invalid-for-testing-12345",
     envKeys: ["ANTHROPIC_API_KEY"],
+    probeModel: "claude-3-5-haiku-latest",
   },
   google: {
     providerTestId: "provider-item-Google Generative AI",
     keyPlaceholder: "AIza...",
     invalidKey: "AIza-invalid-google-key-for-testing-12345",
     envKeys: ["GOOGLE_API_KEY"],
+    probeModel: "gemini-2.5-flash",
   },
 };


### PR DESCRIPTION
Closes #976.

## What this adds

A pre-flight step that picks a **live** API key per provider before anything consumes one, so a dead primary key falls back to a backup instead of silently deleting a provider's test surface from the run.

**The problem it fixes.** When a provider's key dies, `collect-models` records the provider `inactive` in `providers.json`, and the 17 specs that read that file turn it into a `test.skip()` for every target bound to the provider. A skip never trips the daily-failure gate, so coverage erodes invisibly. On the 2026-07-27 daily ([run 30261409427](https://github.com/oriontech-me/langflow-e2e/actions/runs/30261409427)) a drained Anthropic account cost **24 specs** that way (#967). The fallback that already existed in `validateProviderWithFallback` iterates candidate **models**, not **keys** — all 13 Claude candidates failed for the same account-level reason.

**Why a separate step and not a loop inside `collect-models`.** `Collect models` and `Run @stable tests` are distinct steps. A fallback confined to `collect-models` would import the backup key into Langflow while the test step still received the dead primary from the workflow `env:` block — and the first spec calling `setupAnthropic` (`setup-anthropic.ts:52`) would overwrite the working credential with the dead one. The winning key has to cross the step boundary, so it is resolved before anything consumes it and re-exported to `$GITHUB_ENV` under the canonical name.

## Changes

| File | Change |
|---|---|
| `tests/helpers/provider-setup/probe-provider-key.ts` | **New.** Key-parameterized probe + `classifyProbeFailure` |
| `tests/helpers/provider-setup/provider-config.ts` | `probeModel` per provider |
| `tests/helpers/provider-setup/collect-models.ts` | Refactored onto the shared probe — **net 93 lines removed** |
| `scripts/resolve-provider-keys.ts` | **New.** The resolver |
| `scripts/resolve-provider-keys.test.ts` | **New.** 11 unit tests |
| `.github/workflows/daily-stable.yml` | Step wired, strict, no `continue-on-error` |
| `.github/workflows/pr-validation.yml` | Step wired, warn-only, gated on `needs_models` |

### Secret convention

`ANTHROPIC_API_KEY` → `ANTHROPIC_API_KEY_2` → `_3`… The scan is anchored on the canonical name and stops at the first gap. The winner is re-exported under the canonical name, so `hasProviderEnvKeys()`, `setup-anthropic.ts`, `collect-models` and all 17 consumer specs are untouched — they keep reading `ANTHROPIC_API_KEY` and transparently receive a validated key.

Covers the three providers in `providerConfigMap` (openai, anthropic, google). `GROQ_API_KEY` / `MISTRAL_API_KEY` have no entry in the map and no probe, so the resolver ignores them rather than guessing an endpoint.

### Classification — when a candidate is burned

Deliberately conservative, so an unexpected provider response can never burn through the candidates:

1. no HTTP response, or 5xx → `transport` (inconclusive, keep the key)
2. billing/quota wording → `key` (**wins over the status code** — a drained account answering 404 is still an account problem)
3. 404 or model-scoped wording → `model` (keep the key; the model-candidate loop owns that call)
4. 401/402/403/429 → `key`
5. anything else → `transport`

### Strict vs. warn

`daily-stable` runs strict: a configured provider with no usable key exits non-zero. `pr-validation` runs warn-only and gated on `needs_models`, so a drained account cannot redden a PR whose specs never touch an LLM — preserving #952/#955. `nightly.yml` is untouched: it injects no provider keys, so there is nothing to resolve.

## Validation

- `npm run typecheck` clean; `npm run lint:ci` exits 0.
- 11/11 unit tests: `node --require ts-node/register --test scripts/resolve-provider-keys.test.ts`
- **Refactor is behaviour-preserving, verified live** against `langflowai/langflow-nightly:latest`: `npx playwright test tests/collect-models.spec.ts --reporter=line --retries=0` passes, with openai/google active and anthropic returning the byte-identical `credit balance is too low` string as before — the billing regex still matches and the gate degrades it to a warning exactly as pre-refactor.
- Four scenarios exercised manually: baseline resolves at candidate 1 and exits 0; a poisoned primary falls back to `_2` with a warning and writes `$GITHUB_ENV`; strict mode with a dead key exits 1; a regex audit over the full output finds zero secrets printed.
- Both workflows YAML parse-checked, step order asserted (`Resolve provider keys` before `Collect models`), `continue-on-error` confirmed absent on the new step.

**Not proven here:** workflow execution itself. The final proof is the next `daily-stable` run — watch the **Resolve provider keys** step.

## Roadmap linkage

Off-wave: Wave 3 (infra stabilization) closed 2026-07-24 and Wave 4 is validation-heavy. Enters as an approved `follow-up` exception per `ROADMAP.md` → Intake, parent #967 — the same path #952 → #955 took.

## Before/after merge

- The mechanism is **inert until a `_2` secret exists**. Registering `ANTHROPIC_API_KEY_2` (on an account with **separate billing** — a same-org key draws on the same balance and fails identically) is what makes it useful for the #967 failure mode.
- With Anthropic currently drained and no backup registered, strict mode will turn the daily **red** instead of silently skipping 24 specs. That is the intended behaviour, but it means the balance should be topped up (or a backup registered) around merge time.
