### PR TITLE
ci: make the provider-key resolver warn-only in the daily (#976)

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -226,20 +226,8 @@ jobs:
           PROVIDER_KEYS_STRICT: "1"
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_API_KEY_2: ${{ secrets.OPENAI_API_KEY_2 }}
-          # PARKED — Anthropic is unconfigured for the daily until its account
-          # has credit (#967). Both keys draw on the same drained balance, so
-          # the strict gate above correctly reddens every run
-          # ("all 2 candidate key(s) failed — credit balance is too low").
-          # Leaving the provider unset is the honest state: the resolver skips
-          # it, collect-models records "not set", and its specs skip via
-          # hasProviderEnvKeys() — the pre-#976 behaviour, scoped to Anthropic
-          # alone, with OpenAI and Google still strictly gated.
-          # REVERT: uncomment both lines once the balance is topped up (or a
-          # separately-billed backup account is registered as _2), then confirm
-          # with a manual daily — the resolver must print
-          # "anthropic: resolved to ANTHROPIC_API_KEY (candidate 1/1)".
-          # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          # ANTHROPIC_API_KEY_2: ${{ secrets.ANTHROPIC_API_KEY_2 }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY_2: ${{ secrets.ANTHROPIC_API_KEY_2 }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GOOGLE_API_KEY_2: ${{ secrets.GOOGLE_API_KEY_2 }}
 
@@ -357,8 +345,7 @@ jobs:
           PREFLIGHT_SKIP_CREDENTIALS: "1"
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          # PARKED with the Resolve provider keys step above — see #967.
-          # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
 
@@ -388,8 +375,7 @@ jobs:
           PLAYWRIGHT_BASE_URL: "http://localhost:7860/"
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          # PARKED with the Resolve provider keys step above — see #967.
-          # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
 

--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -218,12 +218,17 @@ jobs:
       # backup into Langflow while this job's test step still held the dead
       # primary, and the first spec calling setupAnthropic would overwrite the
       # working credential with it.
-      # STRICT here: a configured provider with no usable key is a broken
-      # environment, and eroded coverage must be loud. No continue-on-error.
+      # WARN-ONLY, deliberately. An earlier revision failed the step when a
+      # configured provider had no live key; on 2026-07-27 that killed all four
+      # shards at the first step over a drained Anthropic account, blocking the
+      # dozens of specs that never touch Anthropic. Picking a live key is worth
+      # doing on its own — gating the run on it is not. A provider with no
+      # usable candidate falls through to exactly the pre-existing behaviour:
+      # collect-models records it inactive and its specs skip.
       - name: Resolve provider keys
         run: npx ts-node scripts/resolve-provider-keys.ts
         env:
-          PROVIDER_KEYS_STRICT: "1"
+          PROVIDER_KEYS_STRICT: "0"
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_API_KEY_2: ${{ secrets.OPENAI_API_KEY_2 }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -226,8 +226,20 @@ jobs:
           PROVIDER_KEYS_STRICT: "1"
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_API_KEY_2: ${{ secrets.OPENAI_API_KEY_2 }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          ANTHROPIC_API_KEY_2: ${{ secrets.ANTHROPIC_API_KEY_2 }}
+          # PARKED — Anthropic is unconfigured for the daily until its account
+          # has credit (#967). Both keys draw on the same drained balance, so
+          # the strict gate above correctly reddens every run
+          # ("all 2 candidate key(s) failed — credit balance is too low").
+          # Leaving the provider unset is the honest state: the resolver skips
+          # it, collect-models records "not set", and its specs skip via
+          # hasProviderEnvKeys() — the pre-#976 behaviour, scoped to Anthropic
+          # alone, with OpenAI and Google still strictly gated.
+          # REVERT: uncomment both lines once the balance is topped up (or a
+          # separately-billed backup account is registered as _2), then confirm
+          # with a manual daily — the resolver must print
+          # "anthropic: resolved to ANTHROPIC_API_KEY (candidate 1/1)".
+          # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # ANTHROPIC_API_KEY_2: ${{ secrets.ANTHROPIC_API_KEY_2 }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GOOGLE_API_KEY_2: ${{ secrets.GOOGLE_API_KEY_2 }}
 
@@ -345,7 +357,8 @@ jobs:
           PREFLIGHT_SKIP_CREDENTIALS: "1"
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # PARKED with the Resolve provider keys step above — see #967.
+          # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
 
@@ -375,7 +388,8 @@ jobs:
           PLAYWRIGHT_BASE_URL: "http://localhost:7860/"
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # PARKED with the Resolve provider keys step above — see #967.
+          # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
 


### PR DESCRIPTION
Makes the provider-key resolver added in #976 **warn-only** in the daily.

## Why

The strict gate went too far. On [run 30275268359](https://github.com/oriontech-me/langflow-e2e/actions/runs/30275268359) a drained Anthropic account killed all four shards at the first step:

```
   anthropic: ANTHROPIC_API_KEY   rejected — Your credit balance is too low...
   anthropic: ANTHROPIC_API_KEY_2 rejected — Your credit balance is too low...
❌ anthropic: all 2 candidate key(s) failed
```

The attribution was correct and fast (~4s of probing instead of 14 minutes of suite), but it also blocked the dozens of specs that never touch Anthropic. Picking a live key among candidates is worth doing on its own; gating the whole run on it is not.

## What changes

One line — `PROVIDER_KEYS_STRICT: "1"` → `"0"` on the *Resolve provider keys* step of `daily-stable.yml`, with a comment recording why.

That restores the pre-#976 flow exactly: a provider with no usable candidate is recorded `inactive` by `collect-models` and its specs skip, as they always did. What is new, and all that is new, is that **a provider with a working backup key now runs on it instead of losing its specs** — which is the whole point of #976.

`pr-validation.yml` was already warn-only and is untouched.

## History of this branch

It first parked the Anthropic secrets out of the daily as a stopgap. Making the resolver warn-only makes that unnecessary, so the parking commit is reverted here — both keys stay wired and the resolver simply tries them in order.

## Validation

- Against the live (drained) Anthropic account: `PROVIDER_KEYS_STRICT=0 npx ts-node scripts/resolve-provider-keys.ts` → openai and google resolve at candidate 1, anthropic emits `::warning::`, **exit 0**.
- YAML parse-checked; the step's effective `env` still carries both Anthropic candidates.

## Trade-off, stated plainly

Coverage erosion from a dead provider goes back to being silent — a skip still does not trip the daily-failure gate. That is a deliberate call: the cost of a hard gate (blocking every unrelated spec) outweighed the benefit. The `::warning::` and the job-summary line remain as the visible signal.

Roadmap linkage: follow-up on #976, prompted by #967.
