### PR TITLE
fix(provider-setup): self-configure OpenAI when the ModelInput dropdown offers none (#961)

### DIFF
--- a/tests/helpers/provider-setup/setup-language-model-openai.ts
+++ b/tests/helpers/provider-setup/setup-language-model-openai.ts
@@ -1,4 +1,4 @@
-import { type Page, expect } from "@playwright/test";
+import { type Locator, type Page, expect } from "@playwright/test";
 
 // Cheap, fast chat models in priority order. `gpt-4o-mini` is kept first so older
 // Langflow builds still match; the `gpt-5.x` entries cover newer builds (1.11.0+)
@@ -55,9 +55,17 @@ async function selectPreferredChatModel(page: Page): Promise<void> {
     // that fallback used to hand back a non-OpenAI model from a helper named
     // `...OpenAI` whenever PREFERRED_CHAT_MODELS drifted behind the build's
     // curated list (issue #961).
+    // A multi-line label carries a badge rendered inside the option (e.g.
+    // "Deprecated"): skip it. Unlike the exact-match PREFERRED lookup above,
+    // this pattern-based branch would otherwise put the badge text into
+    // `chosen` and break the trigger assertion below — and a deprecated model
+    // is not what a regression run wants either.
     labels.find(
       (label) =>
-        /^gpt-/i.test(label) && !NON_CHAT_MODEL.test(label) && !AVOID_MODEL.test(label),
+        !label.includes("\n") &&
+        /^gpt-/i.test(label) &&
+        !NON_CHAT_MODEL.test(label) &&
+        !AVOID_MODEL.test(label),
     ) ||
     labels.find((label) => !NON_CHAT_MODEL.test(label) && !AVOID_MODEL.test(label));
 
@@ -189,9 +197,23 @@ export async function setupLanguageModelOpenAI(page: Page): Promise<void> {
   // persisted the credential).
   if (!(await isOpenAIOffered(page))) {
     await configureOpenAIProviderFromDropdown(page);
-    await modelDropdown.dispatchEvent("click");
 
-    if (!(await isOpenAIOffered(page))) {
+    // Gate on an OpenAI OPTION appearing — never on a single sample of the list.
+    // Closing the panel refreshes every ModelInput *asynchronously*
+    // (`refreshAllModelInputs`, fired after the pending model toggles flush), so
+    // the reopened dropdown can still be rendering the pre-refresh list; sampling
+    // it once reports "no OpenAI model" for a provider that was just configured
+    // fine. The second dispatch covers the opposite state: if the panel left the
+    // popover open, the first dispatch toggled it shut instead of opening it.
+    const openAIOption = page.getByTestId(/^openai-.+-option$/i).first();
+    await modelDropdown.dispatchEvent("click");
+    let offered = await optionAppeared(openAIOption);
+    if (!offered) {
+      await modelDropdown.dispatchEvent("click");
+      offered = await optionAppeared(openAIOption);
+    }
+
+    if (!offered) {
       await page.keyboard.press("Escape");
       throw new Error(
         "setupLanguageModelOpenAI: the model dropdown still offers no OpenAI model after " +
@@ -204,17 +226,28 @@ export async function setupLanguageModelOpenAI(page: Page): Promise<void> {
   await selectPreferredChatModel(page);
 }
 
+// Resolves true when the option becomes visible within the wait, false on timeout.
+async function optionAppeared(option: Locator): Promise<boolean> {
+  return option
+    .waitFor({ state: "visible", timeout: 15000 })
+    .then(() => true)
+    .catch(() => false);
+}
+
 // True when the open ModelInput dropdown offers at least one OpenAI model.
 // Each option carries `data-testid="${provider}-${model}-option"` (frontend
 // `ModelList.getModelOptionTestId`), so the provider is authoritative straight
 // from the DOM; the `gpt-*` label check is a fallback for builds whose option
 // testid is not provider-prefixed. Returns false on the empty dropdown ("No
 // Models Enabled"), which is what an unconfigured instance renders.
+// The initial wait matches selectPreferredChatModel's own 15s budget for the same
+// list: a saturated runner that takes >5s to populate it must be waited out, not
+// mistaken for "OpenAI is missing" (which would trigger a pointless panel detour).
 async function isOpenAIOffered(page: Page): Promise<boolean> {
   const options = page.locator('[data-testid$="-option"]');
   await options
     .first()
-    .waitFor({ state: "visible", timeout: 5000 })
+    .waitFor({ state: "visible", timeout: 15000 })
     .catch(() => {});
 
   const testIds = await options.evaluateAll((els) =>
@@ -252,38 +285,42 @@ async function configureOpenAIProviderFromDropdown(page: Page): Promise<void> {
   const apiKeyInput = page.getByPlaceholder("sk-...");
   await apiKeyInput.waitFor({ state: "visible", timeout: 10000 });
 
-  // "Replace" means the credential is already stored — enabling a model is all
-  // that is left. "Retry Save" is the label after a failed key validation.
-  const alreadyConfigured = await page
-    .getByRole("button", { name: "Replace", exact: true })
-    .isVisible({ timeout: 2000 })
-    .catch(() => false);
+  // The form's single submit button carries the state: "Save" (unconfigured),
+  // "Replace" (credential already stored) or "Retry Save" (key rejected on a
+  // previous save). Wait for it and branch on the label it actually renders —
+  // `isVisible({ timeout })` would NOT wait (the option is documented as ignored),
+  // and a premature "not configured" reading re-saves a stored credential, which
+  // 400s on PATCH /variables and trips the backend-error monitor (issue #751).
+  // Scoped to the dialog so a same-named button elsewhere on the canvas cannot match.
+  const submitBtn = page
+    .getByRole("dialog")
+    .getByRole("button", { name: /^(Save|Replace|Retry Save)$/ })
+    .first();
+  await submitBtn.waitFor({ state: "visible", timeout: 10000 });
+  const alreadyConfigured = /^Replace$/i.test((await submitBtn.innerText()).trim());
 
   if (!alreadyConfigured) {
     await apiKeyInput.click();
     await apiKeyInput.pressSequentially(apiKey, { delay: 0 });
-    await page.getByRole("button", { name: /^(Save|Retry Save)$/ }).click();
+    await submitBtn.click();
 
     // Saving validates the key against the provider and loads its model list.
     // Failing hard here (instead of swallowing the timeout) is the point: with no
     // toggle there is no model to enable, and closing the panel anyway would let
     // the dropdown hand back another provider's model — the silent mis-run this
-    // whole branch exists to prevent. A rejected key leaves the button on
-    // "Retry Save", which is reported so the failure is diagnosable.
+    // whole branch exists to prevent. The submit button's label is reported as-is
+    // (it carries the save outcome) so the failure is diagnosable.
     try {
       await page
         .locator('[data-testid^="llm-toggle-"]')
         .first()
         .waitFor({ state: "visible", timeout: 30000 });
     } catch {
-      const rejected = await page
-        .getByRole("button", { name: "Retry Save", exact: true })
-        .isVisible()
-        .catch(() => false);
+      const label = (await submitBtn.innerText().catch(() => "<unreadable>")).trim();
       throw new Error(
-        "setupLanguageModelOpenAI: saving OPENAI_API_KEY in the Model Providers panel " +
-          `did not load any OpenAI model${rejected ? " — Langflow rejected the key on validation" : ""}. ` +
-          "Check that OPENAI_API_KEY is valid and the account can list models.",
+        "setupLanguageModelOpenAI: saving OPENAI_API_KEY in the Model Providers panel did " +
+          `not load any OpenAI model (submit button reads "${label}"). Check that ` +
+          "OPENAI_API_KEY is valid and the account can list models.",
       );
     }
   }

--- a/tests/helpers/provider-setup/setup-language-model-openai.ts
+++ b/tests/helpers/provider-setup/setup-language-model-openai.ts
@@ -49,6 +49,16 @@ async function selectPreferredChatModel(page: Page): Promise<void> {
   const chosen =
     (envModel && labels.find((label) => label === envModel)) ||
     PREFERRED_CHAT_MODELS.find((model) => labels.includes(model)) ||
+    // Prefer any OpenAI (`gpt-*`) chat option before the provider-agnostic
+    // last-resort fallback below: the 1.11+ unified ModelInput dropdown mixes
+    // providers and lists the Anthropic default (`claude-sonnet-5`) first, so
+    // that fallback used to hand back a non-OpenAI model from a helper named
+    // `...OpenAI` whenever PREFERRED_CHAT_MODELS drifted behind the build's
+    // curated list (issue #961).
+    labels.find(
+      (label) =>
+        /^gpt-/i.test(label) && !NON_CHAT_MODEL.test(label) && !AVOID_MODEL.test(label),
+    ) ||
     labels.find((label) => !NON_CHAT_MODEL.test(label) && !AVOID_MODEL.test(label));
 
   if (!chosen) {
@@ -164,7 +174,125 @@ export async function setupLanguageModelOpenAI(page: Page): Promise<void> {
   // pointer events, timing the click out (issue #580). dispatchEvent bypasses
   // hit-testing and still opens the dropdown.
   await modelDropdown.dispatchEvent("click");
+
+  // The unified ModelInput dropdown lists models only from ENABLED providers, and
+  // the node renders this dropdown (instead of the "Setup Provider" button above)
+  // as soon as ANY provider is enabled. So on an instance where another provider
+  // is enabled but OpenAI is not — collect-models recording OpenAI `inactive`
+  // after a key/quota outage, or a run that configured only Anthropic/Google —
+  // no OpenAI option is offered and selectPreferredChatModel would fall through
+  // to another provider's model, silently running a non-OpenAI model from a
+  // helper named `...OpenAI` (issue #961). Configure OpenAI from `OPENAI_API_KEY`
+  // through the dropdown's "Manage Model Providers" panel so the helper is
+  // self-sufficient, then reopen the dropdown. Skipped when OpenAI is already
+  // offered (daily-stable configures it via collect-models; a prior local run
+  // persisted the credential).
+  if (!(await isOpenAIOffered(page))) {
+    await configureOpenAIProviderFromDropdown(page);
+    await modelDropdown.dispatchEvent("click");
+
+    if (!(await isOpenAIOffered(page))) {
+      await page.keyboard.press("Escape");
+      throw new Error(
+        "setupLanguageModelOpenAI: the model dropdown still offers no OpenAI model after " +
+          "configuring the provider from OPENAI_API_KEY. Check that the key is valid " +
+          "(Langflow validates it on save) and that the OpenAI provider is enabled.",
+      );
+    }
+  }
+
   await selectPreferredChatModel(page);
+}
+
+// True when the open ModelInput dropdown offers at least one OpenAI model.
+// Each option carries `data-testid="${provider}-${model}-option"` (frontend
+// `ModelList.getModelOptionTestId`), so the provider is authoritative straight
+// from the DOM; the `gpt-*` label check is a fallback for builds whose option
+// testid is not provider-prefixed. Returns false on the empty dropdown ("No
+// Models Enabled"), which is what an unconfigured instance renders.
+async function isOpenAIOffered(page: Page): Promise<boolean> {
+  const options = page.locator('[data-testid$="-option"]');
+  await options
+    .first()
+    .waitFor({ state: "visible", timeout: 5000 })
+    .catch(() => {});
+
+  const testIds = await options.evaluateAll((els) =>
+    els.map((el) => el.getAttribute("data-testid") ?? ""),
+  );
+  if (testIds.some((id) => /^openai-/i.test(id))) return true;
+
+  const labels = await options.allInnerTexts();
+  return labels.some((label) => /^gpt-/i.test(label.trim()));
+}
+
+// Opens the model dropdown's "Manage Model Providers" panel, configures the
+// OpenAI credential from `OPENAI_API_KEY`, enables one preferred chat model and
+// closes the panel — so the dropdown then offers OpenAI options. Assumes the
+// dropdown is already open. Idempotent: when the credential is already stored
+// the button reads "Replace" and the re-save is skipped (re-saving 400s on
+// PATCH /variables and would trip the backend-error monitor, issue #751).
+// Restores the self-sufficiency the pre-ModelInput node had via its own
+// "Setup Provider" form.
+async function configureOpenAIProviderFromDropdown(page: Page): Promise<void> {
+  const apiKey = process.env.OPENAI_API_KEY?.trim();
+  if (!apiKey) {
+    await page.keyboard.press("Escape");
+    throw new Error(
+      "setupLanguageModelOpenAI: the model dropdown offers no OpenAI model and " +
+        "OPENAI_API_KEY is not set, so the provider cannot be configured.",
+    );
+  }
+
+  await page.getByTestId("manage-model-providers").click();
+  // The provider list is fetched when the modal mounts (`provider-list-loading`).
+  await page.waitForSelector('[data-testid="provider-item-OpenAI"]', { timeout: 15000 });
+  await page.getByTestId("provider-item-OpenAI").click();
+
+  const apiKeyInput = page.getByPlaceholder("sk-...");
+  await apiKeyInput.waitFor({ state: "visible", timeout: 10000 });
+
+  // "Replace" means the credential is already stored — enabling a model is all
+  // that is left. "Retry Save" is the label after a failed key validation.
+  const alreadyConfigured = await page
+    .getByRole("button", { name: "Replace", exact: true })
+    .isVisible({ timeout: 2000 })
+    .catch(() => false);
+
+  if (!alreadyConfigured) {
+    await apiKeyInput.click();
+    await apiKeyInput.pressSequentially(apiKey, { delay: 0 });
+    await page.getByRole("button", { name: /^(Save|Retry Save)$/ }).click();
+
+    // Saving validates the key against the provider and loads its model list.
+    // Failing hard here (instead of swallowing the timeout) is the point: with no
+    // toggle there is no model to enable, and closing the panel anyway would let
+    // the dropdown hand back another provider's model — the silent mis-run this
+    // whole branch exists to prevent. A rejected key leaves the button on
+    // "Retry Save", which is reported so the failure is diagnosable.
+    try {
+      await page
+        .locator('[data-testid^="llm-toggle-"]')
+        .first()
+        .waitFor({ state: "visible", timeout: 30000 });
+    } catch {
+      const rejected = await page
+        .getByRole("button", { name: "Retry Save", exact: true })
+        .isVisible()
+        .catch(() => false);
+      throw new Error(
+        "setupLanguageModelOpenAI: saving OPENAI_API_KEY in the Model Providers panel " +
+          `did not load any OpenAI model${rejected ? " — Langflow rejected the key on validation" : ""}. ` +
+          "Check that OPENAI_API_KEY is valid and the account can list models.",
+      );
+    }
+  }
+
+  // One enabled model is all the dropdown needs (issue #569).
+  await enablePreferredModelToggle(page);
+
+  // Closing flushes the pending model toggles and refreshes every ModelInput.
+  await page.getByRole("button", { name: "Close", exact: true }).click();
 }
 
 // Cheap, non-reasoning OpenAI chat models, in priority order. Unlike the gpt-5.x


### PR DESCRIPTION
**Closes #961.**

## Problem

`setupLanguageModelOpenAI` is shared by `loop-component-regression.spec.ts` (test 3) and `memory-history-regression.spec.ts` (all 3 tests). On 1.11+ the Language Model node uses the unified `ModelInput` widget, whose dropdown lists models **only from enabled providers** — and the node renders that dropdown (instead of the legacy `Setup Provider` button) as soon as **any** provider is enabled.

So on an instance where another provider is enabled but OpenAI is not, the helper found no `gpt-*` option and `selectPreferredChatModel`'s provider-agnostic last-resort fallback ("first option that is neither non-chat nor avoided") silently picked the first entry in a mixed dropdown. Reproduced live on `langflow-nightly:latest` (1.12.0.dev7) with Anthropic + Google enabled and OpenAI not: 49 options, none from OpenAI, and the helper **completed successfully** leaving the node on `claude-opus-5`. A helper named `...OpenAI` configured Anthropic, and the downstream failure ("Message empty.", build timeouts) pointed nowhere near the cause.

Two additional findings while scoping this, both corrections to the issue's premise:

- With **zero** providers configured the node still renders the legacy `Setup Provider` button (`model_model visible=false | Setup Provider buttons=1`), which the pre-existing path already handles. The gap is specifically the *other-provider-enabled* state.
- The `Run impacted E2E specs` job does run `collect-models` whenever a changed spec references `provider-setup` (`pr-validation.yml`, from #946), so the real trigger is OpenAI ending up inactive (key/quota outage, or a run that configured only Anthropic/Google) — not a missing collect-models step.

## Fix

Ported the two hardenings from the superseded PR #769 that are independent of #722:

- **Gap 1** — when the open dropdown offers no OpenAI model, configure the credential from `OPENAI_API_KEY` through the dropdown's "Manage Model Providers" panel (`manage-model-providers` → `provider-item-OpenAI` → `sk-...` → Save → enable one model toggle → Close), then reopen the dropdown and select as usual. Skipped when OpenAI is already offered, so the configured path (daily-stable, which imports credentials via `collect-models`) is untouched. Re-saving an already-stored credential is skipped as well — it 400s on `PATCH /variables` and would trip the backend-error monitor (#751).
- **Gap 2** — prefer any `gpt-*` chat option before the provider-agnostic last-resort fallback, so a drifted `PREFERRED_CHAT_MODELS` degrades to another OpenAI model instead of to a different provider.

Three deviations from #769, each driven by the live 1.12 surface rather than by the branch diff:

| #769 | This PR | Why |
|---|---|---|
| detected OpenAI by model name only (`gpt-*`) | detects by **provider in the option testid** (`/^openai-/i`), name as fallback | the frontend emits `data-testid="${provider}-${model}-option"` (`ModelList.getModelOptionTestId`); confirmed live: `Anthropic-claude-opus-5-option`, `Google Generative AI-gemini-2.5-flash-option` |
| `getByRole("button", { name: /^(Save\|Retry)$/i })` | `/^(Save\|Retry Save)$/` | the real label is **"Retry Save"** (`modelProviders.retrySaveButton`) — the original regex could never match it |
| `.catch(() => {})` on the model-toggle wait | hard wait + explicit error | swallowing it re-created the exact silent fallback to another provider this branch exists to prevent |

Signature stays `Promise<void>`: #769 changed it to return the selected model name for `waitForLanguageModelPersisted`, which is explicitly out of scope here.

## Scope note

No `.spec.ts` was touched, no test added or retagged, and no coverage change — so no spec doc and no `QA-CHECKLIST.md` edit. Both out-of-scope items from #769 were deliberately **not** ported: the `PREFERRED_CHAT_MODELS` rewrite (needs re-verification against the current nightly; reasoning-model exclusion is already handled by `isReasoningOption`, from #569 / #610) and `waitForLanguageModelPersisted` + `page.reload()` in the loop spec (#813 fixed that differently and it has been green in the dailies since 2026-07-16).

## Validation (nightly 1.12.0.dev7, `--retries=0`, `--workers=1`)

- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors)
- Burst 2× of both importing specs → **7 passed (1.1m)** each run ✅
- End-to-end run of `loop-component-regression` test 3 **in the Gap 1 state** (OpenAI credential deleted from Langflow; the preflight confirms it is absent) → **1 passed (23.7s)**, and the helper recreated the `OPENAI_API_KEY` global variable itself ✅
- Zero `🚨 Backend Error` ✅
- Flow cleanup: every flow the specs created was removed by their id-scoped `afterEach`; the only flows left in the default project are the `awaitBootstrapTest` bootstrap artifacts ✅
- `--trace=on` not run — known local hang on heavy-template specs (#490 / #518). Covered instead by the `--retries=0` bursts and the force-fail battery below.

### Force-fail (executed, one mutation per mechanism)

| Mutation | Observed |
|---|---|
| `isOpenAIOffered` forced to `true` (Gap 1 detection off) | helper completes silently on `claude-opus-5` — the reported bug |
| `manage-model-providers` testid corrupted | `locator.click: Timeout 20000ms exceeded` |
| control: unmutated helper, same state | `gpt-4o-mini` |
| whole `PREFERRED_CHAT_MODELS` invalidated, Gap 2 clause present | `gpt-5.6-sol` (still OpenAI) |
| same, Gap 2 clause removed | `claude-opus-5` |
| invalid `OPENAI_API_KEY` in the Gap 1 state | explicit `saving OPENAI_API_KEY in the Model Providers panel did not load any OpenAI model. Check that OPENAI_API_KEY is valid…` |

Revert verified: 0 mutation markers left, final diff `1 file changed, 128 insertions(+)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
