### PR TITLE
fix(regressions): harden the ledger generator, promote LE-2019, guard the indicator in CI

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -24,6 +24,12 @@ jobs:
       - name: TypeScript check
         run: npm run typecheck
 
+      # The REGRESSIONS.md indicator block is generated and committed by hand.
+      # Fail the PR when a row was added without regenerating it, so the
+      # headline number can never silently disagree with the table.
+      - name: Regression Ledger indicator in sync
+        run: npm run regressions:check
+
   lint:
     name: ESLint
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,14 @@ The JSONL files are **machine-written and human-read only** — never hand-edit.
 
 Triage rules driven by this history (when to remove `@stable`, when to open an issue for a recurring flake) live in `CONTRIBUTING.md` under "Tag @stable — validated tests".
 
+## REGRESSIONS.md — the Regression Ledger
+
+Curated, append-only registry of the real Langflow regressions **the suite caught**, and the source of the ROI indicator at the top of the file. A row is added only when all three hold: a confirmed `langflow-regression` verdict, adversarial (refute-first) validation, and a filed upstream ticket (Jira `LE-####` or a `langflow-ai/langflow` issue). Confirmed but unticketed goes under **Candidates**; a finding validation downgrades to a non-user-facing gap is listed nowhere. Regressions the team confirms by hand, outside the suite, stay on the Jira board — every row must trace to a spec failure or spec-validation run recorded in a repo issue.
+
+The block between `<!-- REGRESSIONS:START -->` and `<!-- REGRESSIONS:END -->` is **auto-generated** — never hand-edit it, and never hand-edit the counts. Edit the `## Ledger` table only, then run `npm run regressions:summary` to regenerate the block and commit both. Logic lives in `scripts/regressions-summary.ts`; it is idempotent and aborts rather than emitting a wrong count (bad marker order, missing/empty `## Ledger` section, wrong column count, invalid `Severity`/`Status`, an `Area / Test` cell without the `area · spec-file` separator, or two rows with the same `Upstream` ticket).
+
+Unlike `QA-CHECKLIST.md`, the generated block here **is** committed in the PR that adds the row — the file changes a handful of times per quarter, so the collision risk that forced the checklist guard (issue #741) does not apply. The `pr-validation.yml` typecheck job runs `npm run regressions:check`, which fails the PR when the committed block disagrees with the table.
+
 ## QA-CHECKLIST.md
 
 Two passages in `QA-CHECKLIST.md` are **auto-generated**:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -652,11 +652,16 @@ regressions the suite has caught, and the source of the ROI indicator at its
 top. It is the suite's headline evidence that it finds product breakage a green
 run never proves — so keeping it current is not optional.
 
-When a resolution confirms a **`langflow-regression`** verdict, has it
-**adversarially validated** (refute-first across source/API/UI where
-applicable), and a **filed upstream ticket** exists (DataStax Jira `LE-####` or
-a `langflow-ai/langflow` issue), **adding a row to `REGRESSIONS.md` is a
-mandatory step of the report/resolution** — not a follow-up.
+When a resolution confirms a **`langflow-regression`** verdict, has it **been
+adversarially validated** (refute-first across source/API/UI where applicable),
+and a **filed upstream ticket** exists (DataStax Jira `LE-####` or a
+`langflow-ai/langflow` issue), **adding a row to `REGRESSIONS.md` is a mandatory
+step of the report/resolution** — not a follow-up.
+
+Only regressions the **suite** caught earn a row: every row traces to a spec
+failure or a spec-validation run recorded in a repo issue. A regression the team
+confirms by hand — a manual Desktop session, an API investigation outside the
+suite — is filed upstream but stays off the ledger.
 
 - Confirmed but not yet ticketed → add it under **Candidates**, not the ledger.
 - A finding that adversarial validation downgrades to a non-user-facing
@@ -664,7 +669,9 @@ mandatory step of the report/resolution** — not a follow-up.
   `REGRESSIONS.md`).
 - After editing the table, run `npm run regressions:summary` to regenerate the
   indicator block, then commit. **Never hand-edit** the block between the
-  `<!-- REGRESSIONS:START -->` / `<!-- REGRESSIONS:END -->` markers.
+  `<!-- REGRESSIONS:START -->` / `<!-- REGRESSIONS:END -->` markers. The
+  `pr-validation.yml` typecheck job runs `npm run regressions:check` and fails
+  the PR if the committed block disagrees with the table.
 
 ### Monitoring rules driven by run history
 

--- a/README.md
+++ b/README.md
@@ -275,3 +275,5 @@ See [`QA_CHECKLIST.md`](./QA_CHECKLIST.md) for the full coverage map.
 ## Contributing
 
 See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the complete guide on how to create tests, validate coverage and respond to file-watcher issues.
+
+See [`REGRESSIONS.md`](./REGRESSIONS.md) for the ledger of real Langflow regressions this suite has caught — each one adversarially validated and tracked upstream.

--- a/REGRESSIONS.md
+++ b/REGRESSIONS.md
@@ -31,18 +31,23 @@ Never hand-edit the block between the markers.
 Langflow version once the suite re-runs green against a build carrying that fix
 — the PR is what we can verify today, the version is what we will have verified.
 
+`Report` is the committed evidence file when one exists, and otherwise the repo
+issue that carries the evidence. Both shapes are allowed; what is not allowed is
+a reference that does not resolve.
+
 <!-- REGRESSIONS:START -->
-**Regressions caught:** 4 — **Open:** 1 · **Fixed:** 3
+**Regressions caught:** 5 — **Open:** 2 · **Fixed:** 3
 
-**By severity:** High 2 · Medium 2 · Low 0
+**By severity:** High 2 · Medium 3 · Low 0
 
-**By area:** model-provider 2 · auth 1 · mcp 1
+**By area:** model-provider 2 · auth 1 · flows 1 · mcp 1
 <!-- REGRESSIONS:END -->
 
 ## Ledger
 
 | Found | Area / Test | Regression | Severity | Detected by | Upstream | Status | Fixed in | Report |
 |-------|-------------|------------|----------|-------------|----------|--------|----------|--------|
+| 2026-07-27 | flows · run-flow.spec.ts | "New Flow" click is silently dropped when the flows list has not painted its cards yet — no navigation, no modal, no console error, and the button then stops being actionable until a reload. Introduced in 1.10.1 by langflow#12575; 1.10.0 opened the templates modal and created nothing | Medium | daily 07-27 · #962 → #966 | [LE-2019](https://datastax.jira.com/browse/LE-2019) | Open | — | docs/upstream-bugs/UPSTREAM-BUG-new-flow-dead-click.md |
 | 2026-07-24 | mcp · mcp-server-resources.spec.ts | MCP `resources/read` crashes with `AttributeError: 'str' object has no attribute 'hex'` — the project server advertises a flow file it cannot itself read (worked on 1.11.0) | Medium | #948 spec validation | [LE-2012](https://datastax.jira.com/browse/LE-2012) | Open | — | docs/upstream-bugs/UPSTREAM-BUG-mcp-resources-read-uuid-hex.log |
 | 2026-07-23 | model-provider · groq-provider.spec.ts | Groq / Mistral / Ollama components silently hidden from the sidebar — the image ships the component source but not the provider's `langchain-*` package, and Langflow now hides the component with no message | Medium | daily 07-23 · #907 | [LE-1987](https://datastax.jira.com/browse/LE-1987) | Fixed | [langflow#14248](https://github.com/langflow-ai/langflow/pull/14248) | #907 |
 | 2026-07-22 | model-provider · google-provider.spec.ts | Nightly ships without `langchain-google-genai` — every Google chat/embedding model raises ImportError at build; surfaced as node-build timeouts across ~17 `@stable` specs | High | daily 07-22 · #898 | [LE-1974](https://datastax.jira.com/browse/LE-1974) | Fixed | [langflow#14220](https://github.com/langflow-ai/langflow/pull/14220) | #898 |
@@ -55,21 +60,21 @@ moment a ticket is filed. Not counted in the indicator.
 
 | Found | Area / Test | Regression | Severity | Report |
 |-------|-------------|------------|----------|--------|
-| 2026-07-27 | flows · run-flow.spec.ts | "New Flow" fires `POST /api/v1/flows` (201) but never navigates — neither the welcome panel nor the templates modal opens, and the created flow only appears after a reload. Intermittent and session-dependent: 7/8 dead on repeat clicks in one browser context, 7/8 alive with a fresh context per click | — | docs/upstream-bugs/UPSTREAM-BUG-new-flow-creates-without-navigating.log |
 
-The New Flow candidate is short of **two** requirements, not one: no ticket is
-filed, and `Last known good` is unverified — it was only ever run on
-1.12.0.dev6, so it is a defect observed on that build until section 5 of the
-evidence log is re-run against 1.11.x. Tracked in #966.
+*(none — the New Flow dead click was promoted to the Ledger on 2026-07-27 when
+LE-2019 was filed.)*
 
 ## Not listed — validated non-regression
 
 Findings deliberately kept out of both tables, so nobody re-litigates them:
 
-- **Bulk-flow-delete SQLite-lock 500** (`LANGFLOW-BUG-bulk-flow-delete-sqlite-lock.md`)
-  — adversarially validated (`bulk-flow-delete-500-validation.md`, 2026-07-14)
-  and downgraded to Low / non-user-facing observability noise, with two report
-  claims refuted. A real robustness gap, not a countable regression.
+- **Bulk-flow-delete SQLite-lock 500** — adversarially validated by Victor on
+  2026-07-14 and downgraded to Low / non-user-facing observability noise, with
+  two report claims refuted: the trigger is narrower than "any blank-flow
+  navigation", and the 500 is masked by a client-side retry, so the user sees
+  success. A real robustness gap, not a countable regression. The report and
+  validation write-ups were never committed to this repo — the record is this
+  entry plus the Jira board.
 - **#643 — Anthropic HTTP 400 on a thinking block + tool call** — confirmed and
   then fixed upstream on 1.12.0.dev0 by the `langchain-anthropic` 1.3.5 → 1.4.8
   bump. No ticket was ever filed, so it never qualified; it is fixed, not

--- a/docs/product-regression-core/regression-ledger.md
+++ b/docs/product-regression-core/regression-ledger.md
@@ -1,8 +1,9 @@
 # Decision — Regression Ledger (`REGRESSIONS.md`)
 
 **Date:** 2026-07-17 · **Shared with the team:** 2026-07-27
-**Status:** Implemented and seeded with 4 regressions on branch
-`docs/regression-ledger-decision` — not merged, no PR yet
+**Status:** Active — `REGRESSIONS.md` is live at the repo root and carries the
+regressions listed below. Curation is mandatory (`CONTRIBUTING.md`) and CI
+guards the indicator against drift.
 **Owner:** Rafael
 
 ---
@@ -119,14 +120,27 @@ mirroring the existing `scripts/coverage-summary.ts` marker-block pattern:
 - The row table is the single source of truth; the script rewrites only the
   marked block.
 - **Idempotent** — a second run with no data change produces no diff.
-- **Fails loudly** — a malformed row (wrong column count, `Severity` outside
-  High/Medium/Low, `Status` outside Open/Fixed), a missing `## Ledger` section,
-  or a missing/duplicated marker aborts the run rather than emitting wrong
-  counts.
+- **Fails loudly** — a wrong headline number is the one outcome the ledger
+  cannot afford, so the script aborts on: a missing, duplicated or
+  **out-of-order** marker pair; a missing **or empty** `## Ledger` section; a
+  row without exactly 9 columns; a `Severity` / `Status` outside its set; an
+  `Area / Test` cell missing the `area · spec-file` separator (which would
+  otherwise report a spec path as an area); and **two rows carrying the same
+  `Upstream` ticket** (a pasted row would otherwise inflate the count).
 
-Regeneration is local for now. A CI auto-regen job mirroring
-`update-coverage-summary.yml` is a possible later addition, deliberately out of
-scope.
+Regeneration stays a local, hand-run step, but drift is now caught in CI:
+`npm run regressions:check` recomputes the block and exits non-zero when the
+committed one disagrees, wired as a step of the existing typecheck job in
+`pr-validation.yml`.
+
+**On committing a generated block in a PR.** This is precisely the pattern
+`scripts/check-checklist-guard.mjs` forbids for `QA-CHECKLIST.md`, where
+concurrent `@stable` PRs collided on the same count lines (issue #741). The
+ledger is deliberately the exception: it changes a handful of times per quarter,
+never on the same lines as another PR's work, so the collision risk that
+justified the guard does not apply — and hand-committing keeps the row and its
+count in one reviewable diff. If the rate ever rises, the resolution is a CI
+auto-regen job mirroring `update-coverage-summary.yml`, not a second guard.
 
 ## What this changes for the team
 
@@ -162,7 +176,7 @@ regression*.
 - **Not a replacement** for the detailed per-bug reports — those stay as
   standalone documents; the ledger consolidates and links to them.
 
-## Seed — the four regressions the suite has caught
+## Seed — the five regressions the suite has caught
 
 Re-derived on 2026-07-27 from the Jira board and the repo's issue trail. The
 original 2026-07-17 seed listed a single row and was already wrong on three
@@ -171,20 +185,23 @@ and both candidates were dead.
 
 | Found | Area | Regression | Sev | Detected by | Upstream | Status | Fixed in |
 |---|---|---|---|---|---|---|---|
+| 07-27 | flows | "New Flow" click silently dropped when the flows list has not painted its cards yet — no navigation, no modal, no console error, and the button then stops being actionable until a reload | Medium | daily 07-27 · #962 → #966 | [LE-2019](https://datastax.jira.com/browse/LE-2019) | **Open** | — |
 | 07-24 | mcp | `resources/read` crashes with `AttributeError: 'str' object has no attribute 'hex'` — the project server advertises a flow file it cannot read (worked on 1.11.0) | Medium | #948 spec validation | [LE-2012](https://datastax.jira.com/browse/LE-2012) | **Open** (Ready for QA) | — |
 | 07-23 | model-provider | Groq / Mistral / Ollama components silently hidden from the sidebar — image ships the component source but not the `langchain-*` package, and Langflow hides the component with no message | Medium | daily 07-23 · #907 | [LE-1987](https://datastax.jira.com/browse/LE-1987) | Fixed | [langflow#14248](https://github.com/langflow-ai/langflow/pull/14248) |
 | 07-22 | model-provider | Nightly ships without `langchain-google-genai` — every Google chat/embedding model raises ImportError at build; surfaced as node-build timeouts across ~17 `@stable` specs | High | daily 07-22 · #898 | [LE-1974](https://datastax.jira.com/browse/LE-1974) | Fixed | [langflow#14220](https://github.com/langflow-ai/langflow/pull/14220) |
 | 07-17 | auth | Logout does not terminate the session — no `POST /api/v1/logout` fired, and `POST /api/v1/refresh` silently re-authenticates so the session survives a reload | High | daily 07-17 · #808 | [LE-1850](https://datastax.jira.com/browse/LE-1850) | Fixed | [langflow#14158](https://github.com/langflow-ai/langflow/pull/14158) |
 
-Indicator: `Regressions caught: 4 — Open: 1 · Fixed: 3`,
-`High 2 · Medium 2 · Low 0`, `model-provider 2 · auth 1 · mcp 1`.
+Indicator: `Regressions caught: 5 — Open: 2 · Fixed: 3`,
+`High 2 · Medium 3 · Low 0`, `model-provider 2 · auth 1 · flows 1 · mcp 1`.
 
-**Candidate (1, uncounted):** the "New Flow" button fires
-`POST /api/v1/flows` (201) but never navigates — neither the welcome panel nor
-the templates modal opens (#966, evidence log under `docs/upstream-bugs/`). It
-is short of **two** requirements: no ticket filed, and `Last known good` is
-unverified — it was only run on 1.12.0.dev6, so it is a defect on that build
-until the evidence log's comparison section is re-run against 1.11.x.
+**Candidates: none.** The New Flow dead click was the sole candidate for a few
+hours on 2026-07-27 — short of two requirements, since it had no ticket and its
+last-known-good was unverified. Filing LE-2019 closed both gaps in one move: the
+ticket exists, and the investigation behind it established 1.10.0 as the last
+good build with 1.10.1 (langflow#12575) as the first affected, refuting the
+initial "1.12 regression" reading by comparing the nightly and 1.11.x frontend
+trees. It was promoted the same day. That is the intended lifecycle, not an
+exception.
 
 **Not listed, recorded so nobody re-litigates them:** the bulk-delete
 SQLite-lock 500 (validated non-regression, downgraded to Low observability
@@ -195,26 +212,29 @@ triage without a confirmed verdict. The last two were the original candidates.
 
 ## Implementation status
 
-Branch `docs/regression-ledger-decision`, cut from current `main` — this
-document plus the four original implementation commits (2026-07-17), rebased
-forward and re-seeded. **Local only: not pushed, no PR, not merged.** The
-original `feat/regression-ledger` branch is superseded.
+Live on `main`. The ledger, the generator, the `CONTRIBUTING.md` rule and this
+record shipped together; the CI drift check, the `CLAUDE.md` rule for agents and
+the LE-2019 row followed in the review round.
 
-| File | Change |
+| File | Role |
 |---|---|
-| `REGRESSIONS.md` | New — scope + curation note, marker block, 4-row ledger, candidate, non-regression list |
-| `scripts/regressions-summary.ts` | New — indicator generator (149 lines) |
-| `package.json` | `regressions:summary` script |
-| `CONTRIBUTING.md` | New section documenting the mandatory curation step |
+| `REGRESSIONS.md` | The ledger — scope + curation notes, generated marker block, row table, candidates, non-regression list |
+| `scripts/regressions-summary.ts` | Indicator generator; `--check` mode for CI |
+| `package.json` | `regressions:summary` and `regressions:check` scripts |
+| `.github/workflows/pr-validation.yml` | Runs `regressions:check` in the typecheck job |
+| `CONTRIBUTING.md` | The mandatory curation step, for humans |
+| `CLAUDE.md` | The never-hand-edit rule for the generated block, for agents |
 | `docs/product-regression-core/regression-ledger.md` | This decision record |
 
-Verified on 2026-07-27 against the re-seeded ledger: the generator emits
-`4 regression(s)` matching the table by hand-count, a second run reports
-*already up to date* with no diff, a `Critical` severity row throws
-`Invalid Severity`, an 8-column row throws `Malformed ledger row`, and
-`typecheck` / `lint` report 0 errors.
+Verified 2026-07-27 against the live ledger: the generator emits
+`5 regression(s)` matching the table by hand-count; a second run reports
+*already up to date* with no diff; `regressions:check` passes in sync and exits
+1 with the expected block when the committed one is stale; and each guard was
+reproduced against a deliberately broken copy — reversed markers, an emptied
+`## Ledger` table, a 8-column row, a `Critical` severity, an `Area / Test` cell
+without the separator, and a duplicated row all abort instead of publishing a
+number. `typecheck` and `lint` report 0 errors.
 
-**Open decision for the team:** push and open the PR. The one thing that will
-age is `Fixed in` — three rows carry the fixing PR rather than a verified
-Langflow version, and each becomes a version the next time the corresponding
-spec runs green on a build that contains the fix.
+The one thing that still ages: `Fixed in` carries the fixing upstream PR on
+three rows, not a verified Langflow version. Each becomes a version the next
+time the corresponding spec runs green on a build that contains the fix.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint:ci": "eslint tests/ --quiet",
     "coverage:summary": "ts-node scripts/coverage-summary.ts && ts-node scripts/stable-tests.ts",
     "regressions:summary": "ts-node scripts/regressions-summary.ts",
+    "regressions:check": "ts-node scripts/regressions-summary.ts --check",
     "impacted": "ts-node scripts/impacted-tests.ts",
     "validate:specs": "ts-node scripts/validate-spec-deps.ts",
     "check:nightly-delta": "ts-node scripts/check-nightly-delta.ts"

--- a/scripts/regressions-summary.ts
+++ b/scripts/regressions-summary.ts
@@ -4,11 +4,18 @@
  * from the hand-curated table in the `## Ledger` section.
  *
  * Run: `npx ts-node scripts/regressions-summary.ts` (or `npm run regressions:summary`).
+ * Pass `--check` (or `npm run regressions:check`) to verify without writing:
+ * exits 1 when the committed block disagrees with the table, which is how CI
+ * catches a row added without regenerating.
  *
  * Lean metrics only: total caught, open/fixed, by severity, by area.
  * Idempotent: a second run with no table change produces no diff.
- * Fails loudly on a malformed row or a missing/duplicate marker/section —
- * never emits wrong counts.
+ * Fails loudly rather than emitting a wrong count — a wrong headline number is
+ * the one outcome the ledger cannot afford. Aborts on: a missing, duplicated or
+ * out-of-order marker; a missing or empty `## Ledger` section; a row without
+ * exactly 9 columns; a `Severity` / `Status` outside its allowed set; an
+ * `Area / Test` cell missing the `area · spec-file` separator; and two rows
+ * carrying the same `Upstream` ticket.
  */
 
 import * as fs from "fs";
@@ -18,6 +25,7 @@ const FILE = path.join(__dirname, "..", "REGRESSIONS.md");
 const START = "<!-- REGRESSIONS:START -->";
 const END = "<!-- REGRESSIONS:END -->";
 const LEDGER_HEADER = "## Ledger";
+const AREA_SEPARATOR = "·";
 const SEVERITIES = ["High", "Medium", "Low"] as const;
 const STATUSES = ["Open", "Fixed"] as const;
 
@@ -28,6 +36,17 @@ interface Row {
   areaTest: string;
   severity: Severity;
   status: Status;
+  upstream: string;
+}
+
+/** Escape a literal for use inside a RegExp. */
+function escapeRe(literal: string): string {
+  return literal.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
+}
+
+/** Count non-overlapping occurrences of a literal. */
+function countOccurrences(haystack: string, literal: string): number {
+  return (haystack.match(new RegExp(escapeRe(literal), "g")) ?? []).length;
 }
 
 /** Split a markdown table row `| a | b |` into trimmed cell values. */
@@ -73,22 +92,49 @@ function parseLedger(md: string): Row[] {
     if (c.length !== 9) {
       throw new Error(`Malformed ledger row (expected exactly 9 columns, got ${c.length}): ${line}`);
     }
-    const [, areaTest, , severity, , , status] = c;
-    if (!SEVERITIES.includes(severity as Severity)) {
+    const [, areaTest, , severity, , upstream, status] = c;
+    if (!(SEVERITIES as readonly string[]).includes(severity)) {
       throw new Error(`Invalid Severity "${severity}" (must be High/Medium/Low): ${line}`);
     }
-    if (!STATUSES.includes(status as Status)) {
+    if (!(STATUSES as readonly string[]).includes(status)) {
       throw new Error(`Invalid Status "${status}" (must be Open/Fixed): ${line}`);
     }
-    rows.push({ areaTest, severity: severity as Severity, status: status as Status });
+    // The schema is `area · spec-file`; without the separator the whole cell
+    // becomes the area and the by-area breakdown silently reports a spec path.
+    if (!areaTest.includes(AREA_SEPARATOR)) {
+      throw new Error(
+        `Malformed "Area / Test" cell "${areaTest}" (expected "area ${AREA_SEPARATOR} spec-file"): ${line}`
+      );
+    }
+    rows.push({ areaTest, severity: severity as Severity, status: status as Status, upstream });
   }
+
+  if (rows.length === 0) {
+    throw new Error(
+      `"${LEDGER_HEADER}" section has no rows — refusing to publish a zero count. ` +
+        `The ledger is append-only; an empty table means the file was damaged.`
+    );
+  }
+
+  // A pasted row inflates the headline number, which is exactly the failure the
+  // indicator must never have. One ticket, one row.
+  const seen = new Map<string, string>();
+  for (const row of rows) {
+    const previous = seen.get(row.upstream);
+    if (previous) {
+      throw new Error(
+        `Duplicate Upstream "${row.upstream}" in the ledger (rows "${previous}" and "${row.areaTest}") — one ticket, one row.`
+      );
+    }
+    seen.set(row.upstream, row.areaTest);
+  }
+
   return rows;
 }
 
-/** Area = the token before " · " in the "Area / Test" cell. */
+/** Area = the token before the `·` in the "Area / Test" cell. */
 function areaOf(areaTest: string): string {
-  const idx = areaTest.indexOf("·");
-  return (idx === -1 ? areaTest : areaTest.slice(0, idx)).trim();
+  return areaTest.slice(0, areaTest.indexOf(AREA_SEPARATOR)).trim();
 }
 
 function buildBlock(rows: Row[]): string {
@@ -123,12 +169,18 @@ function buildBlock(rows: Row[]): string {
 }
 
 function main(): void {
+  const check = process.argv.includes("--check");
   const md = fs.readFileSync(FILE, "utf8");
 
-  const startCount = (md.match(new RegExp(START.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&"), "g")) ?? []).length;
-  const endCount = (md.match(new RegExp(END.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&"), "g")) ?? []).length;
+  const startCount = countOccurrences(md, START);
+  const endCount = countOccurrences(md, END);
   if (startCount !== 1 || endCount !== 1) {
     throw new Error(`Expected exactly one ${START} and one ${END} (found ${startCount}/${endCount})`);
+  }
+  // Reversed markers would otherwise slice the file inside out: the block gets
+  // duplicated and the prose between the markers is dropped, silently.
+  if (md.indexOf(END) < md.indexOf(START)) {
+    throw new Error(`${END} appears before ${START} in REGRESSIONS.md — markers are out of order.`);
   }
 
   const rows = parseLedger(md);
@@ -139,9 +191,24 @@ function main(): void {
   const next = before + block + after;
 
   if (next === md) {
-    console.log("REGRESSIONS.md indicator already up to date.");
+    console.log(
+      check
+        ? `REGRESSIONS.md indicator is in sync with the table (${rows.length} regression(s)).`
+        : "REGRESSIONS.md indicator already up to date."
+    );
     return;
   }
+
+  if (check) {
+    console.error(
+      "REGRESSIONS.md indicator is stale — the committed block disagrees with the Ledger table.\n" +
+        "Run `npm run regressions:summary` and commit the result.\n\n" +
+        `Expected block:\n${block}`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
   fs.writeFileSync(FILE, next);
   console.log(`REGRESSIONS.md indicator regenerated: ${rows.length} regression(s).`);
 }


### PR DESCRIPTION
Closes #983. Review round on Victor's feedback — **re-scoped**.

## Why the diff changed shape

The ledger itself (`REGRESSIONS.md`, the generator, the `CONTRIBUTING.md` rule, the decision record) reached `main` through #987 while this PR was open — byte-identical to what this branch carried. Keeping the original commits would have replayed content already on `main`, so the branch was reset onto `origin/main` and now carries only the delta: the review fixes plus one new regression row.

## Blocking items

**1. Dangling evidence references — fixed, and the root cause was staleness.** This branch was cut from `0c1deaa`; `main` had moved four commits ahead. The New Flow evidence *is* committed — as `docs/upstream-bugs/UPSTREAM-BUG-new-flow-dead-click.md`, added by #987 after the branch point. The ledger pointed at the pre-commit draft name. Repointed.

The two bulk-delete filenames are gone: neither exists in the tree, on disk, or anywhere in history (they were "do not commit" peer-review drafts). The counter-example keeps its full reasoning and now says plainly that the write-ups were never committed, so the record is the entry plus the Jira board. Also documented that `Report` holds an evidence file when one exists and the carrying issue otherwise — both shapes allowed, an unresolvable reference is not.

**2. Stale-on-arrival decision record — rewritten.** Status is now "Active", the branch housekeeping is gone, and the "push and open the PR" close is replaced by the one thing that genuinely still ages: `Fixed in` carries a PR on three rows until a spec re-runs green on a build with the fix.

## New: LE-2019 promoted from Candidate to a row

Filed 2026-07-27, reporter Rafael, and the ticket itself records *"Found by the E2E regression suite: #966"*. It clears all three requirements — the investigation established **1.10.0 as last-known-good** and **1.10.1 (langflow#12575) as first-affected**, refuting the initial "1.12 regression" reading by comparing the nightly and 1.11.x frontend trees byte-for-byte, and isolating the trigger to a click landing before the flows list paints its cards.

Indicator: **5 caught — 2 open · 3 fixed** · `High 2 · Medium 3` · `model-provider 2 · auth 1 · flows 1 · mcp 1`. Candidates is now empty, which is the intended lifecycle rather than an exception.

## Item 4 — four ways the generator could publish a wrong number

Each reproduced against a broken copy before fixing:

| Input | Old behaviour |
|---|---|
| Markers reversed (`END` before `START`) | passed the count check, **exit 0**, block duplicated and the prose between the markers deleted |
| `Area / Test` without the ` · ` separator | `**By area:** … auth/logout-flow.spec.ts 1` |
| Pasted duplicate row | `5 regression(s)` from 4 rows, silently |
| Emptied `## Ledger` table | silent `0 regression(s)`, while the design doc claimed a damaged section aborts |

All four now abort with a specific message. The empty-table case throws rather than the doc being softened — the file is append-only, so an empty table means damage.

## Item 3 — CI drift guard

`--check` recomputes the block and exits 1 with the expected content when the committed one disagrees, exposed as `npm run regressions:check` and wired as a step of the existing **typecheck** job (no extra `npm ci`).

The tension you named is now written down in both `CLAUDE.md` and the decision record rather than left implicit: committing a generated block in-PR is what `check-checklist-guard.mjs` forbids for `QA-CHECKLIST.md`, and the ledger is a deliberate exception because it changes a handful of times per quarter and never on another PR's lines — with the auto-regen job named as the resolution if that rate ever rises.

## Item 5 + minors

- `CLAUDE.md` gains a `REGRESSIONS.md` section: the bar, the suite-scope rule, never hand-edit the block, every abort condition, and the in-PR-commit rationale.
- `CONTRIBUTING.md`: "has it **been** adversarially validated"; suite-scope rule added; the CI check documented.
- `README.md` links the ledger next to the `CONTRIBUTING.md` pointer.
- `escapeRe()` helper replaces the duplicated regex-escape expression; `(SEVERITIES as readonly string[]).includes(...)` replaces the unsound cast.

**Not taking one minor:** `docs/product-regression-core/` stays. That path was Rafael's explicit choice when the record was filed, not an oversight — moving it is a call for him, not this review round.

## Verification

- `npm run regressions:summary` → `5 regression(s)`, matches the table by hand-count; second run → *already up to date*, no diff.
- `npm run regressions:check` → in sync, exit 0. Against a hand-edited count → exit 1 and prints the expected block.
- Reversed markers / emptied table / 8-column row / `Critical` severity / separator-less area / duplicated row → all abort with their specific error.
- `npm run typecheck` and `npm run lint` → 0 errors.

No spec files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)