### PR TITLE
chore(stable): restore @stable on 3 tests verified under load (#974)

### DIFF
--- a/docs/core-components/api-request-component-regression.md
+++ b/docs/core-components/api-request-component-regression.md
@@ -1,6 +1,6 @@
 # API Request Component — Rendering, Inspector, HTTP Methods, cURL Mode and Error Paths
 
-**Last validated:** Langflow 1.11.x (nightly `1.11.0.dev46`)
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev7`)
 
 ---
 

--- a/docs/core-components/chat-input-files-field-regression.md
+++ b/docs/core-components/chat-input-files-field-regression.md
@@ -1,6 +1,6 @@
 # Chat Input — `Files` Inspector Field Regression
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev7`)
 
 ---
 

--- a/docs/core-components/chat-input-output-component-regression.md
+++ b/docs/core-components/chat-input-output-component-regression.md
@@ -1,6 +1,6 @@
 # Chat Input / Chat Output Components — Regression
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev7`)
 
 ---
 

--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -437,7 +437,7 @@ test(
 
 test(
   "API Request component — POST method executes POST verb and returns 200",
-  { tag: ["@release", "@regression", "@components"] },
+  { tag: ["@stable", "@release", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
 

--- a/tests/tests-automations/regression/core-components/chat-input-files-field-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/chat-input-files-field-regression.spec.ts
@@ -172,7 +172,7 @@ test(
 
 test(
   "Chat Input — uploading via the inspector populates the Files field",
-  { tag: ["@regression", "@components"] },
+  { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
     const chatInputNode = chatInputNodeScope(page);
     const fileInput = chatInputNode.getByTestId("input-file-component");

--- a/tests/tests-automations/regression/core-components/chat-input-output-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/chat-input-output-component-regression.spec.ts
@@ -100,7 +100,7 @@ async function runFlowAndOpenChatOutputInspection(page: Page): Promise<string> {
 
 test(
   "Chat Input component — renders on canvas with Message output handle and Input Text field",
-  { tag: ["@regression", "@components"] },
+  { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
     await addChatInputComponent(page);
 


### PR DESCRIPTION
Restores `@stable` on **3 tests** from the orphaned-restoration debt audited on #974 — the ones that survive the daily's actual concurrency, not merely a serial pass.

> **This PR was rewritten.** The first version restored 6 tests on serial evidence. A load run then failed three of them, so the playground group and `edit-flow-name` were removed and two load-verified tests were added. The reasoning error is documented below, because it is the useful part.

## The three

| Test | Result across 3 runs |
|---|---|
| `chat-input-files-field-regression.spec.ts:173` | **6/6** green |
| `chat-input-output-component-regression.spec.ts:101` | **6/6** green |
| `api-request-component-regression.spec.ts:438` | **5/5** green |

## Evidence

Langflow Nightly **1.12.0.dev7**, `--retries=0`, three runs over the same spec set:

1. `--workers=4 --repeat-each=2` — deliberately **harsher than CI** (4 Playwright workers against a local backend capped at 1 worker, PR #888). It produced **36 backend 500s** on `/api/v1/flows/` and broke two other tests.
2. `--workers=2 --repeat-each=2` — the daily's actual `workers` setting.
3. `--workers=2 --repeat-each=2 --grep "@stable"` — after applying the tags, so it also proves lane selection.

None of the three ever failed, and their historical signatures (`locator.click: Timeout 5000ms` on the canvas / `more-options-modal`) never reappeared. Note this **supersedes #865's `--workers=4` reproduction** for `chat-input-files`: that was measured on 1.11.0.dev50 and does not hold on this build.

`npm run typecheck` clean, `npm run lint` **0 errors**, `scripts/check-checklist-guard.mjs` passes. Orphan-flow count via `GET /api/v1/flows/` is **0** after every run, despite the 500s on delete — the scoped teardown held.

## The reasoning error worth recording

The first version of this PR used: *a HARD failure that now passes in series means the cause is gone.* **That inference is invalid when the original cause was itself a concurrency mechanism.**

"Hard" means every retry failed — and when the cause is a race (the `cleanAllFlows` race of #327), every retry ran under that same concurrency. Hard ≠ deterministic in isolation. Conflating the two is what put five load-sensitive tests into the first version.

## Deliberately not restored

**The playground family** — `playground-session-nav:21`, `playground-session-rename:31`, `playground-session-clear:113`, `playground-input-text-prefill:117` & `:151`.

Across the two load runs, **four different members failed**, always at the same place:

```
tests/helpers/flows/setup-playground.ts:36  page.waitForURL(/\/flow\/[^/?#]+/)          → Timeout 30000ms
tests/helpers/flows/setup-playground.ts:37  expect(canvas_controls_dropdown).toBeVisible → element(s) not found
```

| Run | Failed members |
|---|---|
| `--workers=4` | `playground-input-text-prefill:97`, `playground-session-rename:31` |
| `--workers=2` | `playground-input-text-prefill:151`, `playground-session-nav:21` |

That is **one unstable shared helper hitting a random member**, not five flaky tests — rate ~2 in 15 playground instances per run. `setupPlayground` is used by **19 specs**. Restoring any member before the helper is fixed puts it back into a daily where the family fails ~1 in 8. Tracked separately; it is the real blocker for that group.

Worth noting `playground-input-text-prefill:97` already carries `@stable` and failed too — so the instability is not confined to the de-stabled members.

**`edit-flow-name.spec.ts:7`** — failed **1 of 6** at `helpers/flows/rename-flow.ts:86` (`page.waitForFunction` 30s). Consistent with #727's record of a sustained flake on healthy days, so two independent signals agree.

## Limits of this evidence

The load harness is local: a pip-run Langflow capped at 1 worker. It produces a low background failure rate across unrelated specs (`api-request:338` and `:498` each failed once, both pre-existing `@stable` tests), so it **cannot cleanly separate "this test is flaky" from "my backend saturated"** on a single occurrence. What it can do is rank: a test that passes 6/6 through a run that manufactures 36 backend 500s is meaningfully stronger than one that passes once in series. That ranking is all this PR claims.

The pre-existing `api-request` flakes are not introduced here and are the `#818`/`#833` saturation territory.

## Housekeeping

- `Last validated` bumped to `1.12.x (nightly 1.12.0.dev7)` on the three spec docs.
- For `api-request-component-regression.md` this also removes a documentation lie: it claimed "All 15 tests: `@stable`" and that the POST test's tag had been restored in #462, while the tag was in fact absent.
- **No `QA-CHECKLIST.md` change** — bullets are already `[x]`; generated blocks are left to `update-coverage-summary.yml` on merge, per #741.
- The branch name still says `6-verified-green`; it is now 3. Left as-is so the PR keeps its URL.

Refs #974
