### PR TITLE
fix(llm-agents): fit the canvas before opening the inspector — restore @stable on 4 agent-memory tests (#989)

### DIFF
--- a/docs/core-functionality/llm-agents/agent-context-id-continuity.md
+++ b/docs/core-functionality/llm-agents/agent-context-id-continuity.md
@@ -1,6 +1,6 @@
 # Agent context_id — continuity between session messages
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev7`)
 
 ---
 

--- a/docs/core-functionality/llm-agents/agent-context-id-isolation.md
+++ b/docs/core-functionality/llm-agents/agent-context-id-isolation.md
@@ -1,6 +1,6 @@
 # Agent context_id — switching isolates history between contexts
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev7`)
 
 ---
 

--- a/docs/core-functionality/llm-agents/agent-n-messages-limit.md
+++ b/docs/core-functionality/llm-agents/agent-n-messages-limit.md
@@ -1,6 +1,6 @@
 # n_messages — limits the number of retained messages
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev7`)
 
 ---
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-continuity.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-continuity.spec.ts
@@ -12,6 +12,7 @@ import {
 } from "../../../../helpers/ui/open-advanced-options";
 import { createRunnableChatFlowViaApi } from "../../../../helpers/flows/create-runnable-chat-flow-via-api";
 import { addComponentFromSidebar } from "../../../../helpers/flows/add-component-from-sidebar";
+import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import {
   hasProviderEnvKeys,
@@ -393,6 +394,11 @@ async function retrieveViaMessageHistory(
   );
   const node = page.locator('[data-testid^="rf__node-Memory"]').first();
   await expect(node).toBeVisible({ timeout: 15000 });
+  // Fit the canvas BEFORE selecting the node: a sidebar-added node can land
+  // outside the viewport, taking `parameters-button` — which mounts in the
+  // node's own toolbar — off-screen with it (#989). Order matters: fitting
+  // AFTER selection drops the selection and unmounts the toolbar (#867).
+  await adjustScreenView(page, { numberOfZoomOut: 0 });
 
   await page.getByTestId("title-Message History").click();
   // dev46: expose the advanced n_messages / session_id / context_id fields on the
@@ -473,7 +479,7 @@ for (const { label, options, skipReason } of targets) {
 test.describe("Context ID continuity — retrieval layer (model-free)", () => {
   test(
     "context-scoped retrieval returns all turns of the context and not the untagged control",
-    { tag: ["@regression", "@agents", "@components"] },
+    { tag: ["@stable", "@regression", "@agents", "@components"] },
     async ({ page, request }) => {
       const seeded = await seedContextSession(request);
       try {

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts
@@ -12,6 +12,7 @@ import {
 } from "../../../../helpers/ui/open-advanced-options";
 import { createRunnableChatFlowViaApi } from "../../../../helpers/flows/create-runnable-chat-flow-via-api";
 import { addComponentFromSidebar } from "../../../../helpers/flows/add-component-from-sidebar";
+import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import {
   hasProviderEnvKeys,
@@ -466,6 +467,11 @@ async function setupMessageHistoryNode(
   );
   const node = page.locator('[data-testid^="rf__node-Memory"]').first();
   await expect(node).toBeVisible({ timeout: 15000 });
+  // Fit the canvas BEFORE selecting the node: a sidebar-added node can land
+  // outside the viewport, taking `parameters-button` — which mounts in the
+  // node's own toolbar — off-screen with it (#989). Order matters: fitting
+  // AFTER selection drops the selection and unmounts the toolbar (#867).
+  await adjustScreenView(page, { numberOfZoomOut: 0 });
 
   await page.getByTestId("title-Message History").click();
   // dev46: expose the advanced n_messages / session_id / context_id fields on the
@@ -518,7 +524,7 @@ test.describe.configure({ mode: "serial" });
 test.describe("Context ID isolation — retrieval layer (model-free)", () => {
   test(
     "mirrored context-scoped retrievals return only their own context's messages",
-    { tag: ["@regression", "@agents", "@components"] },
+    { tag: ["@stable", "@regression", "@agents", "@components"] },
     async ({ page, request }) => {
       const seeded = await seedTwoContextSession(request);
       try {

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-n-messages-limit.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-n-messages-limit.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { createRunnableChatFlowViaApi } from "../../../../helpers/flows/create-runnable-chat-flow-via-api";
 import { addComponentFromSidebar } from "../../../../helpers/flows/add-component-from-sidebar";
+import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
 import {
   closeAdvancedOptions,
@@ -131,6 +132,11 @@ async function retrieveViaMessageHistory(
   );
   const node = page.locator('[data-testid^="rf__node-Memory"]').first();
   await expect(node).toBeVisible({ timeout: 15000 });
+  // Fit the canvas BEFORE selecting the node: a sidebar-added node can land
+  // outside the viewport, taking `parameters-button` — which mounts in the
+  // node's own toolbar — off-screen with it (#989). Order matters: fitting
+  // AFTER selection drops the selection and unmounts the toolbar (#867).
+  await adjustScreenView(page, { numberOfZoomOut: 0 });
 
   // n_messages and session_id are hidden by default — expose them on the node
   // body via the inspector (dev46 replaced the edit-fields modal + show<field>).
@@ -166,7 +172,7 @@ function countOccurrences(text: string, needle: string): number {
 test.describe("Message History n_messages limit", () => {
   test(
     "a small n_messages truncates retrieval to the most recent messages",
-    { tag: ["@regression", "@agents", "@components"] },
+    { tag: ["@stable", "@regression", "@agents", "@components"] },
     async ({ page, request }) => {
       const seeded = await seedFlowSession(request);
       try {
@@ -190,7 +196,7 @@ test.describe("Message History n_messages limit", () => {
 
   test(
     "causal control — a large n_messages retrieves the full seeded history",
-    { tag: ["@regression", "@agents", "@components"] },
+    { tag: ["@stable", "@regression", "@agents", "@components"] },
     async ({ page, request }) => {
       const seeded = await seedFlowSession(request);
       try {


### PR DESCRIPTION
Fixes the cause that took the four agent-memory retrieval tests out of the daily on 2026-07-24, and restores `@stable` on all four in the same PR.

## Root cause

A node added from the sidebar can land **outside the viewport**, and `parameters-button` mounts in the node's *own toolbar* — so it is off-screen with it. Playwright reports the element visible, enabled and stable, then refuses the click:

```
tests/helpers/ui/open-advanced-options.ts:12   page.getByTestId("parameters-button").click()

  - element is visible, enabled and stable
  - scrolling into view if needed
  - done scrolling
  - element is outside of the viewport      ← 37+ retries
  → TimeoutError: locator.click: Timeout 20000ms exceeded
```

`scrollIntoViewIfNeeded` cannot help here: the react-flow canvas pans via **CSS transform**, not scroll. The 20s is `actionTimeout` (`playwright.config.ts:74`), which matches the signature the daily recorded on 07-17, 07-20, 07-22, 07-23 and 07-24 — `"TimeoutError: locator.click: Timeout 20000ms exceeded"`, `provider: null`.

## The fix

One `adjustScreenView(page, { numberOfZoomOut: 0 })` after the node add, in each of the three specs' Message History setup helper — `retrieveViaMessageHistory` in `agent-n-messages-limit` and `agent-context-id-continuity`, **`setupMessageHistoryNode`** in `agent-context-id-isolation`.

Two details the fix depends on, both recorded at the call sites rather than left implicit:

- **Order: fit BEFORE selecting the node.** #867 diagnosed selection loss and toolbar unmount when `adjustScreenView` runs *after* selection. Here the node title is clicked afterwards, so selection is established post-re-render. Reversing these two lines silently reintroduces #867's failure mode, which is exactly why the constraint is written down.
- **`numberOfZoomOut: 0`.** The helper zooms out once by default, changing canvas scale for no benefit here. Verified the fix holds without it (2/2 in 11.3s), so the extra side effect is dropped.

**No shared-helper change, and no effect on any other test.** Each of the three setup helpers has exactly **one caller** — the test being restored — so nothing already carrying `@stable` in these files is touched. And these are the only three specs that combine `addComponentFromSidebar` with `openAdvancedOptions`:

```
$ for f in $(grep -rl "openAdvancedOptions" tests/tests-automations); do
    grep -q "addComponentFromSidebar" "$f" && echo "$f"; done
→ agent-context-id-isolation, agent-context-id-continuity, agent-n-messages-limit
```

`openAdvancedOptions` is shared by 20 files, but the others open the inspector on a node a template already placed inside a fitted viewport. Blast radius is exactly these three files, which is what keeps this low-risk.

## Evidence

Langflow Nightly **1.12.0.dev7**, `--retries=0`:

| Condition | Before | After |
|---|---|---|
| `--workers=1` | **4/4 FAIL**, all at `open-advanced-options.ts:12` | **4/4 pass** (23.2s) |
| `--workers=2 --repeat-each=2`, `api-request` as background load | — | **8/8 pass** (38/38 overall, no failures) |

The load check is deliberate. PR #986 established that a serial pass is not evidence when the original cause was a concurrency mechanism; here the cause is proven deterministic, so the load run is a confirmation rather than the primary evidence — but it is run anyway so this restoration does not repeat that mistake.

`npm run typecheck` clean, `npm run lint` **0 errors**, `scripts/check-checklist-guard.mjs` passes. All four tests are model-free (passthrough flow created via API + the Message History component), so no provider key is involved.

## Why these four had no tracker

The #930 triage recorded: *"No dedicated issue by decision — a fix is already in flight on branch `fix/agent-memory-messagehistory-fitview`; that PR restores `@stable`."*

That branch **never existed**, locally or on the remote, and no PR was ever opened. The fix that justified not filing never landed, which is how these four became the largest single block of orphaned `@stable` debt found by the #974 audit — and the least visible, precisely because the decision not to file was deliberate. The dead branch name is, ironically, an accurate description of the root cause.

## Deliberately out of scope

`retrieveViaMessageHistory` is **duplicated across the specs**. Extracting it into a shared helper is a real cleanup, but mixing a behavioural fix with a multi-file refactor makes both harder to review and to revert. Worth filing separately.

**A latent bug in `adjustScreenView` that this PR does not fix but does add exposure to.** Its trailing "close the dropdown" step is guarded by `if (fitViewButton > 0)`, intended to mean *"I opened the dropdown, so close it"* — but that condition is true in **both** branches, because `fitViewButton` is reassigned after the dropdown is opened:

```ts
let fitViewButton = await page.getByTestId("fit_view").count();
if (fitViewButton === 0) { /* open */ ; fitViewButton = await ...count(); }  // now > 0
...
if (fitViewButton > 0) { /* click dropdown — toggles */ }
```

If `fit_view` is ever directly visible (`count > 0`), that trailing click **opens** a menu that was closed — and an open canvas-controls menu is a documented click interceptor (#576). It is harmless on 1.12.0.dev7 because `fit_view` currently sits behind the dropdown, but that is a property of today's UI, not a guarantee. The correct guard is a boolean captured before the reassignment. This PR takes the helper's dependents from 83 to 86, so it is worth a follow-up.

## Housekeeping

- `Last validated` bumped to `1.12.x (nightly 1.12.0.dev7)` on the three spec docs.
- **No `QA-CHECKLIST.md` change** — the bullets are already `[x]`; generated blocks are left to `update-coverage-summary.yml` on merge, per #741.

## Reproduce the bug (revert the fix to see it)

```bash
npx playwright test \
  tests/tests-automations/regression/core-functionality/llm-agents/agent-n-messages-limit.spec.ts \
  tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-continuity.spec.ts \
  tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts \
  --grep "n_messages|context-scoped retrieval returns all turns|mirrored context-scoped retrievals" \
  --workers=1 --retries=0
```

Closes #989
EOF
