### PR TITLE
fix(helpers): make setupPlayground concurrency-safe (#988)

### DIFF
--- a/docs/core-functionality/playground/playground-input-text-prefill.md
+++ b/docs/core-functionality/playground/playground-input-text-prefill.md
@@ -1,6 +1,6 @@
 # Playground — Input Text Pre-fill Behavior
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.12.x
 
 ---
 

--- a/docs/core-functionality/playground/playground-session-clear.md
+++ b/docs/core-functionality/playground/playground-session-clear.md
@@ -1,6 +1,6 @@
 # Playground – Clear Chat (Default Session)
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.12.x
 
 ---
 

--- a/docs/core-functionality/playground/playground-session-nav.md
+++ b/docs/core-functionality/playground/playground-session-nav.md
@@ -1,6 +1,6 @@
 # Playground – Session Creation and Navigation
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.12.x
 
 ---
 

--- a/docs/core-functionality/playground/playground-session-rename.md
+++ b/docs/core-functionality/playground/playground-session-rename.md
@@ -1,6 +1,6 @@
 # Playground Session — Rename Availability
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x
 
 ---
 

--- a/docs/upstream-bugs/UPSTREAM-BUG-concurrent-flow-create-500.md
+++ b/docs/upstream-bugs/UPSTREAM-BUG-concurrent-flow-create-500.md
@@ -1,0 +1,113 @@
+# `POST /api/v1/flows/` returns 500 when two flows are created concurrently by the same user
+
+| | |
+|---|---|
+| **Filed upstream** | Not yet — evidence collected here first |
+| **Tracked in** | `oriontech-me/langflow-e2e#988` |
+| **Component** | Langflow — backend, `api/v1/flows` create endpoint |
+| **Surfaces** | `POST /api/v1/flows/` → `500 {"detail":"An internal error occurred while creating the flow."}` |
+| **Observed on** | `langflowai/langflow-nightly:latest` — `1.12.0.dev7`, SQLite, `LANGFLOW_WORKERS=1`, `LANGFLOW_AUTO_LOGIN=true` |
+| **Determinism** | Deterministic with a shared name — 3 of 4 simultaneous identical-name POSTs fail. Through the UI it is intermittent, because the collision window is the gap between two requests' name lookups |
+| **Captured** | 2026-07-27, local Podman instance |
+
+---
+
+## 1. Summary
+
+Creating two flows at the same time under one user returns **500** for all but one of
+them. The endpoint derives a unique name with a **check-then-insert**: it SELECTs the
+existing `<name> (N)` rows, computes `N+1`, and INSERTs in a separate statement. Two
+requests interleaved between those two steps resolve to the *same* name, so the second
+INSERT violates `UNIQUE (flow.user_id, flow.name)`. The resulting `IntegrityError` is
+caught by a blanket `except Exception` and re-raised as an opaque 500 — no retry, and
+no indication that the cause is a name conflict.
+
+The SPA always posts the same base name for a new flow, so *every* concurrent creation
+by one user is a candidate. When it happens the UI stays on the flows list with only a
+toast; nothing navigates.
+
+## 2. Steps to reproduce
+
+```bash
+TOK=$(curl -s http://localhost:7860/api/v1/auto_login | python3 -c "import sys,json;print(json.load(sys.stdin)['access_token'])")
+
+# Same name, four at once
+for i in 1 2 3 4; do
+  curl -s -o /dev/null -w "req$i → %{http_code}\n" -X POST "http://localhost:7860/api/v1/flows/" \
+    -H "Authorization: Bearer $TOK" -H "Content-Type: application/json" \
+    -d '{"name":"Concurrency Probe","description":"","data":{"nodes":[],"edges":[],"viewport":{"zoom":1,"x":0,"y":0}}}' &
+done; wait
+```
+
+**Observed**
+
+```
+req4 → 201
+req2 → 500
+req3 → 500
+req1 → 500
+```
+
+**Expected** — four 201s with de-duplicated names (`Concurrency Probe`,
+`Concurrency Probe (1)`, …), which is precisely what the endpoint promises for the
+sequential case.
+
+The same four requests with **distinct** names all succeed, isolating the name
+derivation as the failing step:
+
+```
+unique1 → 201   unique2 → 201   unique3 → 201   unique4 → 201
+```
+
+## 3. Server-side evidence
+
+```
+IntegrityError: (sqlite3.IntegrityError) UNIQUE constraint failed: flow.user_id, flow.name
+[SQL: INSERT INTO flow (name, description, …, user_id, …) VALUES (?, ?, …)]
+[parameters: ('New Flow (79)', 'Conversational Cartography Unlocked.', …)]
+```
+
+## 4. Code path
+
+`src/backend/base/langflow/api/v1/flows_helpers.py`
+
+```python
+async def _deduplicate_flow_name(session, name, user_id) -> str:
+    if not (await session.exec(select(Flow).where(Flow.name == name)
+                                           .where(Flow.user_id == user_id))).first():
+        return name
+    flows = (await session.exec(select(Flow).where(Flow.name.like(f"{name} (%"))
+                                            .where(Flow.user_id == user_id))).all()
+    numbers = [...]
+    return f"{name} ({max(numbers) + 1})" if numbers else f"{name} (1)"
+```
+
+```python
+flow.name = await _deduplicate_flow_name(session, flow.name, user_id)   # ← SELECT
+...
+session.add(db_flow)
+await session.flush()                                                    # ← INSERT
+...
+except Exception as e:
+    logger.exception("Error creating flow")
+    raise HTTPException(status_code=500,
+                        detail="An internal error occurred while creating the flow.") from e
+```
+
+Nothing serialises the two statements, and no branch handles `IntegrityError`.
+
+## 5. Suggested fix
+
+Retry the derive-and-insert on `IntegrityError` (bounded), or make the name unique in a
+single statement. Independently: a name conflict the server itself caused is not a 500 —
+surfacing it as a 409 with the conflicting name would make the failure diagnosable from
+the client.
+
+## 6. Impact on this suite
+
+`setupPlayground` used to create its flow through the UI and therefore inherited this
+race — a random member of the playground family died in setup, 30s later, as an
+unexplained `waitForURL` timeout. The helper now posts an explicit unique name, which
+takes the de-duplication branch out of play entirely. That is a workaround for our own
+writes only: any spec that creates a flow through the UI while another worker does the
+same remains exposed until this is fixed upstream.

--- a/tests/helpers/flows/setup-playground.ts
+++ b/tests/helpers/flows/setup-playground.ts
@@ -1,45 +1,162 @@
+import { randomUUID } from "node:crypto";
 import { expect, Page } from "@playwright/test";
 import { adjustScreenView } from "../ui/adjust-screen-view";
-import { awaitBootstrapTest } from "../other/await-bootstrap-test";
+import { getAuthToken } from "../auth/get-auth-token";
 import { zoomOut } from "../ui/zoom-out";
 import { deleteFlow } from "./delete-flow";
 
-export async function setupPlayground(page: Page): Promise<string> {
-  await awaitBootstrapTest(page);
-  await page.waitForSelector('[data-testid="blank-flow"]', { timeout: 30000 });
+/** Empty graph payload — what the SPA posts when the "Blank Flow" card is picked. */
+const BLANK_FLOW_DATA = {
+  nodes: [],
+  edges: [],
+  viewport: { zoom: 1, x: 0, y: 0 },
+};
 
-  const flowCreationPromise = page.waitForResponse(
-    (resp) =>
-      resp.url().includes("/api/v1/flows") &&
-      resp.request().method() === "POST" &&
-      resp.status() === 201,
-    { timeout: 15000 },
-  );
+/**
+ * Creates the empty flow through the REST API and returns its id.
+ *
+ * Why not the UI (#988): `POST /api/v1/flows/` derives the flow name
+ * server-side with a check-then-insert (`_deduplicate_flow_name` SELECTs the
+ * highest `New Flow (N)` and the INSERT follows in a separate statement). Two
+ * concurrent creations for the same user therefore resolve to the SAME name and
+ * the loser dies on `UNIQUE constraint failed: flow.user_id, flow.name`, which
+ * the endpoint maps to a bare **500** — measured directly in the container log
+ * while reproducing this helper's flake. The SPA stays on the flows list when
+ * that happens, so the old UI path then waited 30s for a navigation that could
+ * never occur.
+ *
+ * Posting an explicit, unique name takes the deduplication branch out of play
+ * entirely: the exact-name lookup misses, the name is used verbatim, and there
+ * is no shared value left for two workers to collide on.
+ */
+async function createBlankFlow(
+  page: Page,
+): Promise<{ id: string; name: string; authorization: string }> {
+  // Hyphens stripped on purpose: Langflow derives an MCP tool slug from the flow
+  // name and normalises `-` the same way it normalises spaces, which would make
+  // the slug unpredictable for `mcp-server-regression.spec.ts`.
+  const name = `E2E Playground ${randomUUID().replace(/-/g, "")}`;
+  // The browser context has not loaded the app yet, so it carries no session:
+  // mint one up front (auto-login mode) and let the resulting cookies serve the
+  // subsequent `page.goto` as well. Falls back to whatever credentials the
+  // context already holds when the instance is not in auto-login mode.
+  const authorization = await getAuthToken(page.request);
+  const res = await page.request.post("/api/v1/flows/", {
+    data: { name, description: "", data: BLANK_FLOW_DATA },
+    headers: authorization ? { Authorization: authorization } : undefined,
+  });
 
-  await page.getByTestId("blank-flow").click();
-
-  const creationResponse = await flowCreationPromise;
-  const flowData = await creationResponse.json();
-  const flowId = flowData.id as string | undefined;
-  if (!flowId || flowId.trim() === "") {
+  if (!res.ok()) {
+    // Surface the real reason instead of the downstream navigation timeout the
+    // old implementation reported (#988).
     throw new Error(
-      "Flow creation response did not include a valid non-empty id.",
+      `setupPlayground: flow creation failed — POST /api/v1/flows/ → ${res.status()} ${res.statusText()}: ${await res
+        .text()
+        .catch(() => "<unreadable body>")}`,
     );
   }
 
+  const created = await res.json();
+  const flowId = created?.id as string | undefined;
+  if (!flowId || flowId.trim() === "") {
+    throw new Error(
+      "setupPlayground: flow creation response did not include a valid non-empty id.",
+    );
+  }
+  return {
+    id: flowId,
+    name: (created?.name as string) ?? name,
+    authorization,
+  };
+}
+
+/**
+ * Blocks until the persisted graph satisfies `predicate`.
+ *
+ * Exists to serialise our canvas edits against the SPA's debounced autosave
+ * (#988). Each graph change schedules its own `PATCH /api/v1/flows/{id}` with
+ * the WHOLE graph, and those requests are not serialised client-side: under
+ * parallel load two of them overlap and the older one can be committed last,
+ * silently rolling the graph back. Measured on a failing run — the PATCH issued
+ * at 6.2s (nodes, no edge) answered at 7.56s, AFTER the 7.36s PATCH that carried
+ * the edge; the flow then stayed edge-less permanently, so no amount of waiting
+ * downstream recovered it. Letting each change reach the database before making
+ * the next one removes the overlap, and makes "the graph this helper built is
+ * durable" a postcondition callers can rely on after a reload.
+ */
+async function waitForGraphPersisted(
+  page: Page,
+  flowId: string,
+  authorization: string,
+  predicate: (data: { nodes?: unknown[]; edges?: unknown[] }) => boolean,
+  timeoutMs = 30000,
+): Promise<void> {
+  const options = authorization
+    ? { headers: { Authorization: authorization } }
+    : undefined;
+  await expect(async () => {
+    const res = await page.request.get(`/api/v1/flows/${flowId}`, options);
+    expect(res.ok()).toBe(true);
+    expect(predicate((await res.json())?.data ?? {})).toBe(true);
+  }).toPass({ timeout: timeoutMs, intervals: [250, 500, 1000] });
+}
+
+/**
+ * Creates a flow wired as ChatInput → ChatOutput and leaves the page on its
+ * canvas, ready for the playground. Returns the created flow's id so callers
+ * can clean it up with `deleteFlow`.
+ *
+ * The empty flow is created via the API (see `createBlankFlow`) and the canvas
+ * is reached by direct navigation; the two components are then added and
+ * connected through the real UI, which is the part the playground specs depend
+ * on. Compared with driving the home page → templates modal → "Blank Flow"
+ * path, this drops two of the three flow writes the setup used to perform (the
+ * throwaway flow the "New Flow" entry point eagerly creates, plus the bulk
+ * DELETE that disposes of it) and removes the navigation race altogether.
+ *
+ * Postcondition: the wired graph is durable — every canvas edit is confirmed
+ * server-side before the next one is made (`waitForGraphPersisted`), so callers
+ * may reload the page or read the flow back over the API immediately.
+ */
+export async function setupPlayground(page: Page): Promise<string> {
+  const {
+    id: flowId,
+    name: flowName,
+    authorization,
+  } = await createBlankFlow(page);
+
   try {
-    // POST /api/v1/flows → 201 only confirms the flow exists server-side — it
-    // does NOT confirm the SPA finished routing into the flow editor. Gate on
-    // the destination state (editor URL + canvas) before reaching for
-    // editor-only elements; otherwise an occasional navigation race leaves the
-    // app on the flows list and the sidebar wait times out (flaky).
-    await page.waitForURL(/\/flow\/[^/?#]+/, { timeout: 30000 });
+    await page.goto(`/flow/${flowId}`);
+
+    // Gate on the canvas being mounted before reaching for editor-only
+    // elements. Unlike the previous URL wait, this cannot hang on a navigation
+    // that never happened — the flow provably exists at this point.
     await expect(page.getByTestId("canvas_controls_dropdown")).toBeVisible({
       timeout: 30000,
     });
 
-    // The flow editor sidebar mounts after the POST /api/v1/flows response
-    // resolves; wait for sidebar-search-input before interacting (see #278).
+    // …and on the flow store having HYDRATED this flow, not merely on the
+    // canvas chrome being painted. The header name renders
+    // `useFlowStore.currentFlow.name`, so a match proves the fetched flow is in
+    // the store. Without it a component added into the pre-hydration window is
+    // wiped when the store swaps in the persisted (empty) graph.
+    await expect(page.getByTestId("flow_name")).toContainText(flowName, {
+      timeout: 30000,
+    });
+
+    // …and on write permission having RESOLVED. `useAddComponent` bails out
+    // silently while `useIsFlowReadOnly(currentFlow.id)` is true, and that hook
+    // reports read-only for the whole time the effective-permissions query is
+    // in flight — so a click landed in that window adds nothing at all, with no
+    // error anywhere. The header's flow-name button is disabled by the very
+    // same expression (`FlowMenu` → `useIsFlowReadOnly(currentFlow?.id)`), so
+    // its enabled state is an exact observable for "the add will register".
+    await expect(page.getByTestId("menu_bar_display")).toBeEnabled({
+      timeout: 30000,
+    });
+
+    // The flow editor sidebar mounts after the flow payload resolves; wait for
+    // sidebar-search-input before interacting (see #278).
     await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
       timeout: 30000,
     });
@@ -53,6 +170,24 @@ export async function setupPlayground(page: Page): Promise<string> {
       .then(async () => {
         await page.getByTestId("add-component-button-chat-output").click();
       });
+
+    // Assert each component landed before adding the next one: a bare
+    // "expected 2, got 1" at the end of the setup does not say WHICH add was
+    // lost, and that ambiguity cost a debug cycle on #988.
+    await expect(page.locator(".react-flow__node")).toHaveCount(1, {
+      timeout: 15000,
+    });
+
+    // …and let it reach the database before the next edit — see
+    // `waitForGraphPersisted`. The gate has to sit after EVERY mutation, not
+    // just at the end: it is the in-flight save of edit N that edit N+1's save
+    // can overtake, and the loser is committed last.
+    await waitForGraphPersisted(
+      page,
+      flowId,
+      authorization,
+      (data) => (data.nodes?.length ?? 0) === 1,
+    );
 
     await zoomOut(page, 2);
 
@@ -72,6 +207,14 @@ export async function setupPlayground(page: Page): Promise<string> {
       timeout: 10000,
     });
 
+    // Both nodes committed before the edge is drawn.
+    await waitForGraphPersisted(
+      page,
+      flowId,
+      authorization,
+      (data) => (data.nodes?.length ?? 0) === 2,
+    );
+
     await page
       .getByTestId("handle-chatinput-noshownode-chat message-source")
       .click();
@@ -82,10 +225,25 @@ export async function setupPlayground(page: Page): Promise<string> {
     await expect(page.locator(".react-flow__edge")).toHaveCount(1, {
       timeout: 8000,
     });
+
+    // Postcondition: the wired graph survives a reload. Several callers reload
+    // the page or read the flow back over the API right after this returns.
+    await waitForGraphPersisted(
+      page,
+      flowId,
+      authorization,
+      (data) => (data.edges?.length ?? 0) >= 1,
+    );
   } catch (err) {
     // Best-effort rollback of the created flow — swallow so the original
     // failure (err) is the one that surfaces, not a secondary cleanup error.
-    await deleteFlow(page.request, flowId).catch(() => {});
+    // The explicit header matters: `page.request` on its own is unauthenticated
+    // under AUTO_LOGIN, so a bare delete would 401 and leak the flow.
+    await deleteFlow(
+      page.request,
+      flowId,
+      authorization ? { headers: { Authorization: authorization } } : undefined,
+    ).catch(() => {});
     throw err;
   }
 

--- a/tests/helpers/flows/setup-playground.ts
+++ b/tests/helpers/flows/setup-playground.ts
@@ -32,10 +32,15 @@ const BLANK_FLOW_DATA = {
 async function createBlankFlow(
   page: Page,
 ): Promise<{ id: string; name: string; authorization: string }> {
-  // Hyphens stripped on purpose: Langflow derives an MCP tool slug from the flow
-  // name and normalises `-` the same way it normalises spaces, which would make
-  // the slug unpredictable for `mcp-server-regression.spec.ts`.
-  const name = `E2E Playground ${randomUUID().replace(/-/g, "")}`;
+  // Two constraints from the MCP tool name Langflow derives from this
+  // (`lfx.base.mcp.util.sanitize_mcp_name`), both of which
+  // `mcp-server-regression.spec.ts` asserts on:
+  //  - hyphens are normalised like spaces, so a raw UUID makes the slug
+  //    ambiguous — strip them;
+  //  - the sanitised name is truncated at 46 characters, so keep the whole
+  //    thing well under that. 16 hex digits is 64 bits of uniqueness, far more
+  //    than enough to keep two workers off the same name.
+  const name = `E2E Playground ${randomUUID().replace(/-/g, "").slice(0, 16)}`;
   // The browser context has not loaded the app yet, so it carries no session:
   // mint one up front (auto-login mode) and let the resulting cookies serve the
   // subsequent `page.goto` as well. Falls back to whatever credentials the

--- a/tests/helpers/flows/setup-playground.ts
+++ b/tests/helpers/flows/setup-playground.ts
@@ -79,13 +79,16 @@ async function createBlankFlow(
   }
   return {
     id: flowId,
-    name: (created?.name as string) ?? name,
+    // `||`, not `??`: an empty name would slip past a nullish check and turn the
+    // hydration gate below into `toContainText("")`, which passes against any
+    // page at all — a safety gate that fails open is worse than none.
+    name: (created?.name as string) || name,
     authorization,
   };
 }
 
 /**
- * Blocks until the persisted graph satisfies `predicate`.
+ * Blocks until the persisted graph satisfies `expectation.matches`.
  *
  * Exists to serialise our canvas edits against the SPA's debounced autosave
  * (#988). Each graph change schedules its own `PATCH /api/v1/flows/{id}` with
@@ -97,22 +100,48 @@ async function createBlankFlow(
  * downstream recovered it. Letting each change reach the database before making
  * the next one removes the overlap, and makes "the graph this helper built is
  * durable" a postcondition callers can rely on after a reload.
+ *
+ * A bare `toPass` timeout here would read "expected true, received false",
+ * which says neither what was awaited nor how far the graph got — the same mute
+ * failure this helper was rewritten to stop producing. So the last observed
+ * state is captured on every probe and reported when the budget runs out.
  */
 async function waitForGraphPersisted(
   page: Page,
   flowId: string,
   authorization: string,
-  predicate: (data: { nodes?: unknown[]; edges?: unknown[] }) => boolean,
-  timeoutMs = 30000,
+  expectation: {
+    expected: string;
+    matches: (data: { nodes?: unknown[]; edges?: unknown[] }) => boolean;
+  },
+  // Deliberately tighter than the UI gates above: this polls a local API, so a
+  // budget that stretches toward the 5-minute test timeout only delays the real
+  // error. If the write has not landed in 15s it is not slow, it is lost.
+  timeoutMs = 15000,
 ): Promise<void> {
   const options = authorization
     ? { headers: { Authorization: authorization } }
     : undefined;
-  await expect(async () => {
-    const res = await page.request.get(`/api/v1/flows/${flowId}`, options);
-    expect(res.ok()).toBe(true);
-    expect(predicate((await res.json())?.data ?? {})).toBe(true);
-  }).toPass({ timeout: timeoutMs, intervals: [250, 500, 1000] });
+  let lastSeen = "no successful read";
+
+  try {
+    await expect(async () => {
+      const res = await page.request.get(`/api/v1/flows/${flowId}`, options);
+      if (!res.ok()) {
+        lastSeen = `GET /api/v1/flows/{id} → ${res.status()} ${res.statusText()}`;
+      }
+      expect(res.ok()).toBe(true);
+      const data = (await res.json())?.data ?? {};
+      lastSeen = `${data.nodes?.length ?? 0} node(s), ${data.edges?.length ?? 0} edge(s)`;
+      expect(expectation.matches(data)).toBe(true);
+    }).toPass({ timeout: timeoutMs, intervals: [250, 500, 1000] });
+  } catch {
+    throw new Error(
+      `setupPlayground: a canvas edit never reached the database — expected ${expectation.expected}, ` +
+        `last saw ${lastSeen} after ${timeoutMs}ms. The usual cause is a stale autosave PATCH ` +
+        `committed after a newer one, which rolls the graph back for good (#988).`,
+    );
+  }
 }
 
 /**
@@ -200,7 +229,7 @@ export async function setupPlayground(page: Page): Promise<string> {
       page,
       flowId,
       authorization,
-      (data) => (data.nodes?.length ?? 0) === 1,
+      { expected: "1 node", matches: (data) => (data.nodes?.length ?? 0) === 1 },
     );
 
     await zoomOut(page, 2);
@@ -226,7 +255,7 @@ export async function setupPlayground(page: Page): Promise<string> {
       page,
       flowId,
       authorization,
-      (data) => (data.nodes?.length ?? 0) === 2,
+      { expected: "2 nodes", matches: (data) => (data.nodes?.length ?? 0) === 2 },
     );
 
     await page
@@ -246,7 +275,7 @@ export async function setupPlayground(page: Page): Promise<string> {
       page,
       flowId,
       authorization,
-      (data) => (data.edges?.length ?? 0) >= 1,
+      { expected: "1 edge", matches: (data) => (data.edges?.length ?? 0) >= 1 },
     );
   } catch (err) {
     // Best-effort rollback of the created flow — swallow so the original

--- a/tests/helpers/flows/setup-playground.ts
+++ b/tests/helpers/flows/setup-playground.ts
@@ -42,7 +42,16 @@ async function createBlankFlow(
   // context already holds when the instance is not in auto-login mode.
   const authorization = await getAuthToken(page.request);
   const res = await page.request.post("/api/v1/flows/", {
-    data: { name, description: "", data: BLANK_FLOW_DATA },
+    data: {
+      name,
+      description: "",
+      data: BLANK_FLOW_DATA,
+      // The SPA's `createNewFlow` hardcodes this to true while the column
+      // defaults to false, so omitting it produces a flow that — unlike every
+      // UI-created one — is NOT exposed as an MCP tool. Caught by
+      // `mcp-server-regression.spec.ts` on a clean instance.
+      mcp_enabled: true,
+    },
     headers: authorization ? { Authorization: authorization } : undefined,
   });
 

--- a/tests/tests-automations/regression/core-functionality/playground/playground-input-text-prefill.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-input-text-prefill.spec.ts
@@ -56,6 +56,9 @@ async function injectChatInputValue(
 // Poll the backend until the ChatInput → ChatOutput edge is persisted, so the
 // upcoming reload renders the saved graph. Replaces a fixed-duration sleep
 // that was tuned to the autosave debounce.
+// Kept as a local guard even though `setupPlayground` now returns only once the
+// edge is committed (#988) — it costs one API call when the graph is already
+// durable, and it keeps this spec's precondition explicit at the call site.
 async function waitForEdgePersisted(
   page: Page,
   flowId: string,
@@ -116,7 +119,7 @@ test.describe("Playground – Input Text Pre-fill Behavior", () => {
 
   test(
     "creating a new session re-applies the Input Text pre-fill",
-    { tag: ["@regression", "@playground"] },
+    { tag: ["@stable", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step("set up flow with Input Text and open playground", async () => {
         createdFlowId = await setupFlowWithPrefill(page);
@@ -150,7 +153,7 @@ test.describe("Playground – Input Text Pre-fill Behavior", () => {
 
   test(
     "pre-filled value is sent as the first message of the session",
-    { tag: ["@regression", "@playground"] },
+    { tag: ["@stable", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step("set up flow with Input Text and open playground", async () => {
         createdFlowId = await setupFlowWithPrefill(page);

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-clear.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-clear.spec.ts
@@ -1,10 +1,8 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
-import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
-import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
-import { zoomOut } from "../../../../helpers/ui/zoom-out";
+import { setupPlayground } from "../../../../helpers/flows/setup-playground";
 
 // Id of the flow the running test created; teardown deletes only this one via
 // the API (scoped) — never a global cleanAllFlows, which wipes flows other
@@ -17,62 +15,12 @@ let createdFlowId: string | undefined;
  */
 
 async function setupChatEchoFlow(page: Page): Promise<void> {
-  await awaitBootstrapTest(page);
-  await expect(page.getByTestId("blank-flow")).toBeVisible({ timeout: 30000 });
-
-  // Capture the id from the flow-creation POST so teardown can delete only this
-  // flow (scoped), NOT from the canvas URL: the URL id is a transient
-  // client-side handle on this Langflow version and does not match the
-  // persisted flow (deleting it 404s and silently leaks the real one).
-  const flowCreation = page.waitForResponse(
-    (resp) =>
-      resp.url().includes("/api/v1/flows") &&
-      resp.request().method() === "POST" &&
-      resp.status() === 201,
-    { timeout: 30000 },
-  );
-  await page.getByTestId("blank-flow").click();
-  const created = (await (await flowCreation).json()) as { id?: string };
-  if (!created.id) {
-    throw new Error("blank-flow creation returned no flow id");
-  }
-  createdFlowId = created.id;
-
-  await page.getByTestId("sidebar-search-input").fill("chat output");
-  await expect(page.getByTestId("input_outputChat Output")).toBeVisible({
-    timeout: 30000,
-  });
-  await page
-    .getByTestId("input_outputChat Output")
-    .hover()
-    .then(async () => {
-      await page.getByTestId("add-component-button-chat-output").click();
-    });
-
-  await zoomOut(page, 2);
-
-  await page.getByTestId("sidebar-search-input").fill("chat input");
-  await expect(page.getByTestId("input_outputChat Input")).toBeVisible({
-    timeout: 30000,
-  });
-  await page
-    .getByTestId("input_outputChat Input")
-    .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-      targetPosition: { x: 100, y: 100 },
-    });
-
-  await adjustScreenView(page);
-
-  await page
-    .getByTestId("handle-chatinput-noshownode-chat message-source")
-    .click();
-  await page
-    .getByTestId("handle-chatoutput-noshownode-inputs-target")
-    .click();
-
-  await expect(page.locator(".react-flow__edge")).toHaveCount(1, {
-    timeout: 8000,
-  });
+  // Was a line-by-line copy of `setupPlayground`, and therefore carried the same
+  // concurrency defect (#988): it created the flow through the home page →
+  // templates modal → "Blank Flow" path, whose `POST /api/v1/flows/` races
+  // another worker's on the server-derived name and 500s. Delegating to the
+  // shared helper fixes it in one place and keeps the two from drifting apart.
+  createdFlowId = await setupPlayground(page);
 }
 
 async function openPlayground(page: Page): Promise<void> {
@@ -112,7 +60,7 @@ test.describe("Playground – Clear Session History", () => {
 
   test(
     "clear-chat removes all messages from Default Session",
-    { tag: ["@regression", "@playground"] },
+    { tag: ["@stable", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step(
         "Set up ChatInput → ChatOutput echo flow and open playground",

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-nav.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-nav.spec.ts
@@ -20,7 +20,7 @@ test.describe("Playground – Session Creation and Navigation", () => {
 
   test(
     "new-chat button must add a new session entry to the sidebar",
-    { tag: ["@regression", "@playground"] },
+    { tag: ["@stable", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step("set up ChatInput → ChatOutput flow and open playground", async () => {
         createdFlowId = await setupPlayground(page);

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-rename.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-rename.spec.ts
@@ -30,7 +30,7 @@ test.describe("Playground – Session Rename (B2)", () => {
 
   test(
     "rename option must not be available for the Default Session",
-    { tag: ["@regression", "@playground"] },
+    { tag: ["@stable", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step(
         "Set up ChatInput → ChatOutput echo flow and open playground",

--- a/tests/tests-automations/regression/mcp/server/mcp-server-regression.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-regression.spec.ts
@@ -1,5 +1,4 @@
 import { expect, test } from "../../../../fixtures/fixtures";
-import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { setupPlayground } from "../../../../helpers/flows/setup-playground";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
@@ -20,7 +19,11 @@ test.describe("MCP Server – Flow Exposed as MCP Tool", () => {
       let flowName = "";
 
       await test.step("Create a blank ChatInput → ChatOutput flow and capture its name", async () => {
-        await awaitBootstrapTest(page);
+        // No `awaitBootstrapTest` here: `setupPlayground` creates the flow over
+        // the API and navigates straight to its canvas (#988). Going through
+        // the home page first would only add a throwaway flow — the "New Flow"
+        // entry point eagerly creates one — and leak it, since nothing in this
+        // path disposes of it any more.
         flowId = await setupPlayground(page);
         // Capture the auto-generated name so we can assert this specific flow surfaces
         // in the tool list, instead of relying on a generic "at least one tool" check


### PR DESCRIPTION
**Fixes #988.**

## Problem

`setupPlayground` (imported by 19 specs) died **in setup**, taking down a random
member of the playground family — always at `setup-playground.ts:36-37`, with
HTTP 500s on `POST /api/v1/flows/` alongside. Reproduced here at **3/12 and
6/12** setups under `--workers=4` on nightly `1.12.0.dev7`.

Three distinct defects, separated by reproduction:

**1. The 500 is the trigger, and it is an upstream backend bug.** `create_flow`
derives a unique name with a check-then-insert — `_deduplicate_flow_name`
SELECTs the highest `New Flow (N)`, the INSERT follows in a separate statement.
Two concurrent requests resolve to the same name; the loser violates
`UNIQUE (flow.user_id, flow.name)`, and the `IntegrityError` is swallowed by a
blanket `except Exception` and re-raised as an opaque 500. Deterministic,
browser-free:

```
4 simultaneous POSTs, same name:      201, 500, 500, 500
4 simultaneous POSTs, unique names:   201, 201, 201, 201
```

The SPA stays on the flows list when this happens, so the old helper waited 30s
for a navigation that could never occur. Filed in
`docs/upstream-bugs/UPSTREAM-BUG-concurrent-flow-create-500.md` (not yet
reported upstream).

**2. Two silent no-ops on the direct-navigation path.** `useAddComponent` does
`if (isReadOnly) return;`, and `useIsFlowReadOnly` reports read-only for the
entire effective-permissions fetch — a click landed in that window adds nothing,
with no error anywhere. Same for a component added before the flow store
hydrates: it is wiped when the persisted graph swaps in.

**3. Autosave has no client-side serialisation.** Each canvas edit PATCHes the
whole graph; under load an older PATCH can be committed last and roll the graph
back permanently. Measured on a failing run: the PATCH issued at 6.2s (nodes, no
edge) answered at **7.56s**, after the 7.36s PATCH that carried the edge. This —
not latency — is what broke `playground-input-text-prefill:117`.

## Fix

- Create the flow over the **API with an explicit unique name**, then navigate
  straight to its canvas. The de-duplication branch is never entered, so no
  shared value is left for two workers to collide on. A failed creation reports
  the real status and body instead of a downstream timeout.
- Gate on `flow_name` (store hydrated) and on `menu_bar_display` being enabled
  (write permission resolved — the header button is disabled by the very same
  expression `useAddComponent` bails on).
- Confirm the graph is persisted **after every canvas edit**, which serialises
  our edits against autosave and makes durability a postcondition callers can
  rely on after a reload.
- `playground-session-clear` carried a line-by-line copy of the helper; it now
  delegates. `mcp-server-regression` drops a now-harmful `awaitBootstrapTest`
  that would leak a throwaway flow.

Rejected: retrying the UI create. It leaves the collision in place and keeps
fighting a saturated backend — the create itself is what has to stop colliding.

Side effect: setup drops from ~24s to ~7s, and performs **one** flow write
instead of three (the "New Flow" entry point used to create a throwaway flow and
bulk-DELETE it).

## Scope note

No assertion in any spec was weakened. The graph is still built through the real
UI — only the empty-flow creation moved to the API. `@stable` is restored on the
five tests this unblocks (`playground-session-nav:21`,
`playground-session-rename:31`, `playground-session-clear:113`,
`playground-input-text-prefill:117` and `:151`); `playground-input-text-prefill:97`,
already `@stable` and also affected, is covered by the same validation.

## Validation (nightly `1.12.0.dev7`, `--retries=0`)

- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors) · QA-CHECKLIST guards ✅ (both)
- Reproduction harness, 12 setups, `--workers=4`: **3/12 and 6/12 failed** before,
  **12/12 green with zero HTTP 500s** after (2.7 min → 55 s)
- 4 target specs, `--workers=2 --repeat-each=2`: **18/18**
- 4 target specs, `--workers=4 --repeat-each=2`, twice: **18/18** and **18/18**
- 12 playground specs, `--workers=2 --repeat-each=2`: **52/52**
- Remaining callers (attachments, non-image attachment, output-image, streaming
  SSE, `llm-invalid-api-key-ui`): **12 passed**
- Force-fail executed on all 9 tests in the touched files — every mutation
  observed failing, reverted, and re-run green. Note: on
  `clear-chat removes all messages`, the obvious `toHaveCount(0)` → `(1)`
  mutation **passes** (the count matches transiently before removal); it needed
  `(7)` to be falsifiable
- Zero `🚨 Backend Error` · zero leaked flows (`GET /api/v1/flows/` checked)
- `--trace=on` skipped per the known local hang; covered by the `--retries=0`
  bursts and the force-fail pass instead
- CI `Run impacted E2E specs` green (10 specs, includes `mcp-server-regression`)
- After the review follow-ups (diagnostic gate message, 15s budget, strict name
  fallback): 18/18 and 18/18 at `--workers=4 --repeat-each=2`, 34/34 at
  `--workers=2 --repeat-each=2`, CI green again. The gate's new message was
  force-failed by making the expectation unreachable and reading the output.

## Two regressions this PR introduced and fixed (found by CI, not locally)

The first CI run went red on `mcp-server-regression`. Both causes were mine — moving
creation to the API dropped two things the SPA does:

1. **`mcp_enabled` was missing.** `createNewFlow` hardcodes it to `true` while the
   column defaults to `false`, so helper-built flows were never exposed as MCP tools.
   Verified directly against the API: the same POST without the field returns
   `mcp_enabled=false`, with it `true`.
2. **The flow name exceeded the MCP tool-name limit.** `lfx.base.mcp.util.sanitize_mcp_name`
   truncates at 46 characters and `E2E Playground <32 hex>` is 47, so the server
   rendered the tool one character short of the slug the spec builds. The suffix is now
   16 hex digits (31 characters total).

Neither reproduced locally, because this instance has 160+ accumulated flows and
`ToolsComponent` renders only the first N tools — the spec failed there for an unrelated
reason and masked both. The clean CI container is what exposed them.

## Pre-existing failure, NOT from this PR

`playground-session-id:21` — `popover-anchor-input-session_id` no longer exists in the
DOM. Confirmed identical on unmodified `main` by stashing this branch's changes, on
`--workers=1 --retries=0`. It carries `@release` but not `@stable`, and `nightly.yml`
has been disabled since 03-2026, so it runs in no scheduled workflow and had been
failing silently. Tracked in #1000.

Context: #327, #974, #986.
