### PR TITLE
fix(playground): redesign playground-session-id against the current session surface (#994)

### DIFF
--- a/docs/core-functionality/playground/playground-session-id.md
+++ b/docs/core-functionality/playground/playground-session-id.md
@@ -1,12 +1,14 @@
-# Playground — Session ID Input
+# Playground — Session ID
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.12.x
 
 ---
 
 ## What this test validates *(required)*
 
-Validates that the Playground session ID input field is editable and correctly reflects a custom value typed by the user. If this breaks, users cannot control which session context their messages are sent to — affecting multi-session workflows.
+Validates that the session ID a user sets from the Playground is the session the backend actually stores the conversation under — both for the messages already in the session and for every message sent afterwards. If this breaks, users cannot control which session context their messages are sent to, which affects every multi-session workflow.
+
+The Playground has no free-text `session_id` input. The modal playground that rendered the Chat Input node's parameters was replaced by the sliding-sidebar playground (upstream `126c037aa0`, pre-1.8), whose session surface is the session list — **New chat** plus **Rename**. The `session_id` field itself survives only as an `advanced=True` parameter on the Chat Input node (exposed through `inspector-add-session_id`) and as a REST parameter. This spec therefore covers the surface that exists today (verdict recorded on #994).
 
 ---
 
@@ -19,9 +21,13 @@ Validates that the Playground session ID input field is editable and correctly r
 ## Step by step *(required)*
 
 1. Use `setupPlayground(page)` to create a blank flow with ChatInput → ChatOutput connected and capture the created `flowId`
-2. Click `playground-btn-flow-io` and wait for `input-chat-playground` to be visible (confirms playground is open)
-3. Clear `popover-anchor-input-session_id` and fill it with `session-${Date.now()}`
-4. Assert the field's value equals the filled string via `toHaveValue`
+2. Open the Playground (`playground-btn-flow-io`) and wait for `input-chat-playground` to be visible
+3. Click `new-chat` and send `first message`; wait for the send to settle
+4. Poll `GET /api/v1/monitor/messages?flow_id={flowId}` until a message carrying a `session_id` other than `flowId` is queryable, and record that auto-generated session ID. The rename endpoint reads the database and 404s while the message is only in the client cache (same persistence gate as `playground-session-rename`, #637)
+5. Rename the session to `e2e-session-<uuid>` through the session more-menu → `rename-session-option` → `session-rename-input` → `Enter`
+6. Assert over the API that every message of the flow now carries the custom session ID and none carries the pre-rename one
+7. Send `second message` in the same (renamed) session
+8. Assert the new message is persisted under the custom session ID as well, and that `GET /api/v1/monitor/messages/sessions?flow_id={flowId}` returns exactly `["<custom>"]`
 
 `afterEach` navigates to `/` and deletes the flow created by the helper via `DELETE /api/v1/flows/{id}`.
 
@@ -29,35 +35,45 @@ Validates that the Playground session ID input field is editable and correctly r
 
 ## Validation criterion *(required)*
 
-- After `.fill()`, `popover-anchor-input-session_id` holds the exact string typed (web-first `toHaveValue` assertion)
+- After the rename, `GET /api/v1/monitor/messages?flow_id={flowId}` returns **0** messages under the pre-rename session ID and **all** of the flow's messages under `<custom>`
+- The message sent after the rename is persisted with `session_id === <custom>`
+- `GET /api/v1/monitor/messages/sessions?flow_id={flowId}` equals `["<custom>"]` — the flow has exactly one session and it is the one the user named
 
 ---
 
 ## External dependencies *(required)*
 
-- `src/frontend/src/components/core/chatComponents/` — session ID input rendered inside the Playground header
-- `data-testid="popover-anchor-input-session_id"` — session ID input field
+- `src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/session-selector.tsx` — session row and its rename affordance
 - `data-testid="playground-btn-flow-io"` — opens the Playground from the editor
-- `data-testid="input-chat-playground"` — chat input field used as a readiness signal for the Playground
+- `data-testid="input-chat-playground"` — chat input, also the Playground readiness signal
+- `data-testid="new-chat"` — creates a session
+- `data-testid="button-send"` — sends the message
+- `data-testid="session-selector"` / `session-<id>-more-menu` / `rename-session-option` / `session-rename-input` — the rename path
+- `PATCH /api/v1/monitor/messages/session/{old_session_id}` — the rename write performed by the UI
+- `GET /api/v1/monitor/messages` and `GET /api/v1/monitor/messages/sessions` — the assertions
+- No LLM provider: the flow is a ChatInput → ChatOutput echo
 
 ---
 
 ## What this test does not cover *(optional)*
 
-- Actual backend isolation between sessions (messages from session A not appearing in session B) — covered by `llm-agents/memory-history-regression.spec.ts`
-- The sidebar-based session management (create / switch / rename) introduced in Langflow 1.9+ — covered by `playground-session-nav.spec.ts` and `playground-session-rename.spec.ts`
-- Sending a message after switching the session ID — out of scope for this spec
+- The rename UI affordance itself (when it is available, Escape cancelling it) — covered by `playground-session-rename.spec.ts`
+- Creating and switching sessions — covered by `playground-session-nav.spec.ts`
+- Clearing a session's history — covered by `playground-session-clear.spec.ts`
+- The Chat Input node's advanced `session_id` parameter overriding the graph session (`chat.py`: `self.session_id or self.graph.session_id`) — not covered anywhere today; candidate for a `core-components` spec
+- Agent memory isolation between sessions — covered by `llm-agents/memory-history-regression.spec.ts`
 
 ---
 
 ## Preconditions *(optional)*
 
 - Langflow running at `PLAYWRIGHT_BASE_URL`
-- No LLM required — the test only types into the session ID field, no flow execution happens
+- No API key required — the flow echoes the input, no model is invoked
 
 ---
 
 ## Notes *(optional)*
 
-- Test runs in `serial` mode for consistency with sibling playground specs and to keep the cleanup contract simple
+- Test runs in `serial` mode for consistency with the sibling playground specs and to keep the cleanup contract simple
 - Cleanup deletes only the flow created by this test (id captured from `setupPlayground`'s return value)
+- The assertions read the database through the monitor API rather than the rendered chat, so they cannot pass on a client-side cache that never reached the server

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-id.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-id.spec.ts
@@ -34,21 +34,43 @@ test.describe("Playground — Session ID", () => {
       const customSessionId = `e2e-session-${randomUUID().slice(0, 8)}`;
       let autoSessionId = "";
 
-      /** Every message the flow has produced, straight from the database. */
-      const readMessages = async (): Promise<
-        Array<{ session_id: string; text: string }>
-      > => {
+      type StoredMessage = { session_id: string; text: string };
+
+      /**
+       * Every message the flow has produced, straight from the database, or
+       * `null` when the read itself did not answer 200.
+       *
+       * The null is what makes this callable from inside `expect.poll`:
+       * Playwright runs the poll generator OUTSIDE its retry try/catch
+       * (`matchers/expect.js` → `pollMatcher`), so a generator that throws
+       * aborts the poll instead of retrying it. A single transient 500 from a
+       * container running the whole suite in parallel would then fail this test
+       * outright — the saturation signature behind #549/#553. Same shape as
+       * `playground-session-rename`'s persistence gate.
+       */
+      const readMessages = async (): Promise<StoredMessage[] | null> => {
         const response = await page.request.get(
           `/api/v1/monitor/messages?flow_id=${createdFlowId}`,
         );
-        expect(response.ok()).toBe(true);
-        return (await response.json()) as Array<{
-          session_id: string;
-          text: string;
-        }>;
+        if (!response.ok()) return null;
+        return (await response.json()) as StoredMessage[];
+      };
+
+      /** Same read, for the assertions that must not tolerate a failed GET. */
+      const readMessagesOrFail = async (): Promise<StoredMessage[]> => {
+        const messages = await readMessages();
+        if (messages === null) {
+          throw new Error(
+            `GET /api/v1/monitor/messages?flow_id=${createdFlowId} did not answer 200.`,
+          );
+        }
+        return messages;
       };
 
       const sendMessage = async (text: string) => {
+        const botBubblesBefore = await page
+          .getByTestId("div-chat-message")
+          .count();
         await page.getByTestId("input-chat-playground").fill(text);
         await page.getByTestId("button-send").click();
         await expect(page.getByTestId("input-chat-playground")).toHaveValue("", {
@@ -57,6 +79,17 @@ test.describe("Playground — Session ID", () => {
         await expect(page.getByTestId("button-stop")).toBeHidden({
           timeout: 30000,
         });
+        // The two gates above do not prove the run produced anything: the input
+        // is cleared optimistically on send, and `toBeHidden` passes trivially
+        // when the stop button never rendered. Without this the session
+        // assertions downstream report "0 messages persisted" for a flow that
+        // simply never executed, which names the wrong culprit.
+        // `div-chat-message` is rendered by `bot-message.tsx` only (the user
+        // bubble does not carry it), so one more of them IS the flow's answer.
+        await expect(page.getByTestId("div-chat-message")).toHaveCount(
+          botBubblesBefore + 1,
+          { timeout: 30000 },
+        );
       };
 
       await test.step("set up ChatInput → ChatOutput flow and open playground", async () => {
@@ -89,17 +122,18 @@ test.describe("Playground — Session ID", () => {
           await expect
             .poll(
               async () =>
-                (await readMessages()).filter(
+                (await readMessages())?.filter(
                   (message) => message.session_id !== createdFlowId,
-                ).length,
+                ).length ?? 0,
               { timeout: 20000, intervals: [250, 500, 1000] },
             )
             .toBeGreaterThan(0);
 
-          const persisted = (await readMessages()).find(
+          const persisted = (await readMessagesOrFail()).find(
             (message) => message.session_id !== createdFlowId,
           );
-          autoSessionId = persisted!.session_id;
+          autoSessionId = persisted?.session_id ?? "";
+          expect(autoSessionId).not.toBe("");
           expect(autoSessionId).not.toBe(customSessionId);
         },
       );
@@ -126,14 +160,14 @@ test.describe("Playground — Session ID", () => {
           await expect
             .poll(
               async () =>
-                (await readMessages()).filter(
+                (await readMessages())?.filter(
                   (message) => message.session_id === customSessionId,
-                ).length,
+                ).length ?? 0,
               { timeout: 15000, intervals: [250, 500, 1000] },
             )
             .toBeGreaterThan(0);
 
-          const messages = await readMessages();
+          const messages = await readMessagesOrFail();
           expect(
             messages.filter((message) => message.session_id === autoSessionId),
           ).toHaveLength(0);
@@ -153,7 +187,7 @@ test.describe("Playground — Session ID", () => {
           await expect
             .poll(
               async () =>
-                (await readMessages()).find(
+                (await readMessages())?.find(
                   (message) => message.text === "second message",
                 )?.session_id ?? "not persisted yet",
               { timeout: 20000, intervals: [250, 500, 1000] },

--- a/tests/tests-automations/regression/core-functionality/playground/playground-session-id.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-session-id.spec.ts
@@ -1,8 +1,17 @@
+import { randomUUID } from "node:crypto";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { setupPlayground } from "../../../../helpers/flows/setup-playground";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
-test.describe("Playground — Session ID input", () => {
+// The Playground has no free-text session_id input, and has not had one since the
+// modal playground was replaced by the sliding sidebar (upstream 126c037aa0,
+// pre-1.8): the `popover-anchor-input-session_id` this spec used to fill is the
+// generic node-parameter renderer for ChatInput's `session_id`, an advanced field
+// reachable only through `inspector-add-session_id`. The surface a user has for
+// naming a session today is the session list — New chat plus Rename — so that is
+// what this spec covers, asserting what the rename does to the stored data rather
+// than what it does to a label (#994).
+test.describe("Playground — Session ID", () => {
   test.describe.configure({ mode: "serial" });
 
   let createdFlowId: string | null = null;
@@ -19,30 +28,150 @@ test.describe("Playground — Session ID input", () => {
   });
 
   test(
-    "session ID input accepts a custom value",
-    { tag: ["@release", "@regression", "@playground"] },
+    "a session renamed in the playground is the session its messages are stored under",
+    { tag: ["@stable", "@release", "@regression", "@playground"] },
     async ({ page }) => {
-      await test.step("set up ChatInput → ChatOutput flow", async () => {
-        createdFlowId = await setupPlayground(page);
-      });
+      const customSessionId = `e2e-session-${randomUUID().slice(0, 8)}`;
+      let autoSessionId = "";
 
-      await test.step("open playground and wait for chat input", async () => {
-        await page.getByTestId("playground-btn-flow-io").click();
-        await expect(
-          page.getByTestId("input-chat-playground").last(),
-        ).toBeVisible({ timeout: 15000 });
-      });
-
-      await test.step("fill session ID and confirm value persists", async () => {
-        const customSession = `session-${Date.now()}`;
-        const sessionInput = page.getByTestId(
-          "popover-anchor-input-session_id",
+      /** Every message the flow has produced, straight from the database. */
+      const readMessages = async (): Promise<
+        Array<{ session_id: string; text: string }>
+      > => {
+        const response = await page.request.get(
+          `/api/v1/monitor/messages?flow_id=${createdFlowId}`,
         );
+        expect(response.ok()).toBe(true);
+        return (await response.json()) as Array<{
+          session_id: string;
+          text: string;
+        }>;
+      };
 
-        await sessionInput.clear();
-        await sessionInput.fill(customSession);
-        await expect(sessionInput).toHaveValue(customSession);
+      const sendMessage = async (text: string) => {
+        await page.getByTestId("input-chat-playground").fill(text);
+        await page.getByTestId("button-send").click();
+        await expect(page.getByTestId("input-chat-playground")).toHaveValue("", {
+          timeout: 15000,
+        });
+        await expect(page.getByTestId("button-stop")).toBeHidden({
+          timeout: 30000,
+        });
+      };
+
+      await test.step("set up ChatInput → ChatOutput flow and open playground", async () => {
+        createdFlowId = await setupPlayground(page);
+        await page.getByTestId("playground-btn-flow-io").click();
+        await expect(page.getByTestId("input-chat-playground")).toBeVisible({
+          timeout: 15000,
+        });
       });
+
+      await test.step("create a session and send the first message", async () => {
+        await page.getByTestId("new-chat").click();
+        await expect(page.getByTestId("input-chat-playground")).toBeVisible({
+          timeout: 10000,
+        });
+        await sendMessage("first message");
+      });
+
+      await test.step(
+        "wait until that message is durably persisted, and record its session ID",
+        async () => {
+          // The rename endpoint (PATCH /api/v1/monitor/messages/session/{old})
+          // reads the DB and 404s when no row exists for {old} yet, while the
+          // rename affordance is enabled from the client-side message cache the
+          // build stream fills first. On 404 the frontend keeps the old name and
+          // only toasts, so the rename silently does nothing. Sequence against
+          // real persistence instead of a timeout — this is the #637 flake.
+          // The new session's rows carry a session_id other than the flow id
+          // (which is the Default Session).
+          await expect
+            .poll(
+              async () =>
+                (await readMessages()).filter(
+                  (message) => message.session_id !== createdFlowId,
+                ).length,
+              { timeout: 20000, intervals: [250, 500, 1000] },
+            )
+            .toBeGreaterThan(0);
+
+          const persisted = (await readMessages()).find(
+            (message) => message.session_id !== createdFlowId,
+          );
+          autoSessionId = persisted!.session_id;
+          expect(autoSessionId).not.toBe(customSessionId);
+        },
+      );
+
+      await test.step("rename the session to a custom ID", async () => {
+        await page
+          .locator('[data-testid^="session-"][data-testid$="-more-menu"]')
+          .last()
+          .click();
+        await page.getByTestId("rename-session-option").click();
+        await page.getByTestId("session-rename-input").fill(customSessionId);
+        await page.keyboard.press("Enter");
+        await expect(
+          page.getByTestId("session-selector").getByText(customSessionId),
+        ).toBeVisible({ timeout: 10000 });
+      });
+
+      await test.step(
+        "the already-sent message is re-keyed under the custom session ID",
+        async () => {
+          // The rename is a backend write, so assert on the database rather than
+          // on the label the previous step already waited for: a rename that only
+          // repainted the sidebar would pass there and fail here.
+          await expect
+            .poll(
+              async () =>
+                (await readMessages()).filter(
+                  (message) => message.session_id === customSessionId,
+                ).length,
+              { timeout: 15000, intervals: [250, 500, 1000] },
+            )
+            .toBeGreaterThan(0);
+
+          const messages = await readMessages();
+          expect(
+            messages.filter((message) => message.session_id === autoSessionId),
+          ).toHaveLength(0);
+          expect(
+            messages.filter(
+              (message) => message.session_id !== customSessionId,
+            ),
+          ).toHaveLength(0);
+        },
+      );
+
+      await test.step(
+        "a message sent afterwards is stored under the custom session ID too",
+        async () => {
+          await sendMessage("second message");
+
+          await expect
+            .poll(
+              async () =>
+                (await readMessages()).find(
+                  (message) => message.text === "second message",
+                )?.session_id ?? "not persisted yet",
+              { timeout: 20000, intervals: [250, 500, 1000] },
+            )
+            .toBe(customSessionId);
+        },
+      );
+
+      await test.step(
+        "the flow reports exactly one session, the one the user named",
+        async () => {
+          const response = await page.request.get(
+            `/api/v1/monitor/messages/sessions?flow_id=${createdFlowId}`,
+          );
+          expect(response.ok()).toBe(true);
+          expect(await response.json()).toEqual([customSessionId]);
+        },
+      );
     },
   );
 });


### PR DESCRIPTION
**Closes #994.**

## Problem

`playground-session-id.spec.ts` timed out on `locator.clear` waiting for
`getByTestId('popover-anchor-input-session_id')` — the element never appears. The test
lost `@stable` on 2026-06-01 (`290038d`, the 13-spec block attributed to #327, whose cause
was the `cleanAllFlows` race) and, with `nightly.yml` disabled since 03-2026, nothing has
run it since. The issue required a **verdict before any fix**: intended product change, or
Langflow regression?

**Verdict: intended product change — not a regression, nothing to report upstream.**
Evidence recorded on [#994](https://github.com/oriontech-me/langflow-e2e/issues/994#issuecomment-5099222713):

1. `popover-anchor-input-session_id` is not a Playground element. It comes from the generic
   parameter renderer (`parameterRenderComponent/components/inputComponent`,
   ``id={`popover-anchor-${id}`}``), so it renders wherever a component's `session_id` field
   renders. On `ChatInput` (`lfx/components/input_output/chat.py`) that field is
   `advanced=True` and always has been — which is exactly why `agent-context-id-*.spec.ts`
   must call `inspector-add-session_id` first.
2. The current Playground has no session-ID input at all. A live dump of every `data-testid`
   with the playground open on 1.12.0.dev7 returns `new-chat`, `session-selector`,
   `session-<id>-more-menu`, `chat-header-more-menu`, `playground-close-button`,
   `input-chat-playground`, `button-send` — no `popover-anchor-*`. Grepping the whole
   `components/core/playgroundComponent/` subtree confirms it: the only session-related input
   that exists is `session-rename-input`.
3. It is not a recent break. The Playground became a sliding sidebar in upstream
   `126c037aa0` (2026-02-05, pre-1.8 main fork), and its session model is identical in
   `1.10.0`, `release-1.11.0` and `main` — `pages/FlowPage/index.tsx` renders the same
   `FlowPageSlidingContainerContent` in all three. The free-text input lived in the old modal
   playground (`modals/IOModal/*`, still in the tree but no longer mounted), so the spec was
   already asserting against a dead surface when it was last rewritten (`bc72c33`).

## Fix

Redesigned against the surface that exists today — **New chat + Rename** — and moved the
validation criterion from `toHaveValue` on an input to the stored data:

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `a session renamed in the playground is the session its messages are stored under` | After renaming the session to `e2e-session-<uuid>`: `GET /api/v1/monitor/messages?flow_id=` returns **0** messages under the pre-rename session ID and **all** under the custom one; the message sent afterwards is persisted with `session_id === <custom>`; `GET /api/v1/monitor/messages/sessions?flow_id=` equals exactly `["<custom>"]` |

Rejected alternatives, per the issue's explicit instruction:

- **Widening the timeout / adding `inspector-add-session_id`** — the field is a node
  parameter, not a Playground control; either would have made a dead premise "pass" and
  deleted the coverage.
- **Asserting the renamed label in the sidebar** — that is
  `playground-session-rename.spec.ts`'s job (affordance + label). Reading the database
  instead keeps the two specs distinct: a rename that only repainted the sidebar passes there
  and fails here.
- **Covering the ChatInput node's `session_id` override** (`chat.py`:
  `self.session_id or self.graph.session_id`) — a genuine uncovered gap, but a
  `core-components` concern; noted in the spec doc's *does not cover* section rather than
  smuggled into a Playground spec.

The persistence gate before the rename is kept from `playground-session-rename` (#637): the
rename endpoint reads the DB and 404s while the message is only in the client cache, and on
404 the frontend silently keeps the old name.

## Scope note

`@stable` restored in this PR, so the test is back under `daily-stable.yml` — the silence
mechanism described in the issue is closed, not just the assertion. Spec doc rewritten with
`Last validated: 1.12.x`. The `QA-CHECKLIST.md` bullet already referenced this spec as `[x]`
and is untouched; the generated blocks regenerate on merge. No helper, POM or fixture changed —
only this spec and its doc.

## Validation (nightly 1.12.0.dev7, `--workers=1 --retries=0`)

- typecheck ✅ · eslint ✅ (0 errors) · `check:checklist-coverage` ✅ · `validate:specs` ✅
- 4/4 clean runs, no flake ✅ — 10.4s / 11.9s / 11.3s / 11.6s
- `--trace=on` ✅ — 11.2s, no hang, 172 frames, all six `test.step`s present
- zero `🚨 Backend Error` ✅ · zero orphan flows after the runs (`E2E Playground` = 0) ✅
- force-fail ✅ — three executed mutations, all reverted (`grep` for markers = 0 hits, final run green):
  - rename writes `<custom>-FFMUTATION` (the substring `getByText` still matches, so the label
    step still passes) → fails the re-key poll: `expected > 0, received 0`
  - `sendMessage("second message")` commented out → fails the follow-up poll:
    `expected "e2e-session-49abbce1", received "not persisted yet"`
  - an extra `new-chat` + message leaked before the last step → fails `toEqual`:
    `Received + 1` in the sessions array

🤖 Generated with [Claude Code](https://claude.com/claude-code)
