### PR TITLE
fix(flows): stop the concurrent-autosave clobber from flaking renameFlow (#995)

### DIFF
--- a/docs/core-functionality/project-management/edit-flow-name.md
+++ b/docs/core-functionality/project-management/edit-flow-name.md
@@ -1,6 +1,6 @@
 # Project Management – Edit Flow Name
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.12.x
 
 ---
 
@@ -26,6 +26,8 @@ in editor-local state.
 
 ## Step by step *(required)*
 
+0. Install a `POST /api/v1/flows` → 201 listener so every flow the test creates
+   is tracked by id and deleted in `afterEach` (id-scoped cleanup, #553).
 1. Bootstrap the session (`awaitBootstrapTest(page)`).
 2. Open the **Basic Prompting** starter flow.
 3. For each of two random target names:
@@ -72,3 +74,26 @@ multiple nightly runs because the return-to-home flow-list API refetch + render
 exceeds 3 s under parallel load (issue #410). The web-first assertions auto-retry
 until the renamed flow appears, so a genuine failure (flow never listed) still
 fails the test.
+
+### The upstream rename-clobber race (issue #995)
+
+This test lost `@stable` on 2026-07-13 as a recurrent flake whose cause #727
+never classified. Root-caused on 1.12.0.dev7: `PATCH /api/v1/flows/{id}` has no
+version check and `use-save-flow.ts` applies whichever response lands last
+(`setCurrentFlow(updatedFlow)` in the mutation's `onSuccess`). The editor's
+debounced mount autosave carries the **pre-rename** name, so when it overlaps
+the flow-settings save and lands after it, the rename is reverted in the store
+**and in the database** — `GET /api/v1/flows/` returns the old name. The header
+then never reaches the new name.
+
+This is product behaviour, not test timing; the test is only fast enough to hit
+the window. Reproduced naturally in 2 of 6 runs at `--workers=4` under load, and
+deterministically by holding the mount autosave so it lands last.
+
+`renameFlow` mitigates it in three layers: `waitForFlowSaveSettled` now waits on
+in-flight PATCH **requests** (not just response silence); the barrier is closed a
+second time immediately before the save click; and the one variant no barrier can
+prevent — an autosave *issued after* our PATCH, from a store that has not yet
+received our response — is absorbed by re-applying the rename once, with a
+`console.warn`. The closing assertion is unconditional, so a rename that never
+persists still fails.

--- a/tests/helpers/flows/rename-flow.ts
+++ b/tests/helpers/flows/rename-flow.ts
@@ -8,30 +8,24 @@ import { waitForFlowSaveSettled } from "./wait-for-flow-save-settled";
 // stabilise or for `save-flow-settings` to become enabled.
 const MODAL_TIMEOUT = 15000;
 
+// One re-apply is enough in practice: the clobbering autosave belongs to the
+// editor's mount burst, which is long over by the time a second attempt runs.
+// A third attempt costs ~15s and has never been observed to be needed.
+const MAX_RENAME_ATTEMPTS = 2;
+
+type RenameOptions = { flowName?: string; flowDescription?: string };
+type RenameResult = { flowName: string; flowDescription: string };
+
 /**
- * Opens the flow-settings modal from the flow header, optionally edits the
- * name and/or description, and saves (or cancels when nothing changed).
- *
- * Hardening (issue #357): every gate is now a real auto-waiting assertion
- * (`expect(...).toBeVisible/toBeEnabled/toBeDisabled`) instead of the
- * non-waiting `locator.isVisible()/isEnabled()/isDisabled()` queries, whose
- * boolean results were discarded — they never actually waited. Before opening
- * the modal we also wait for the editor's autosave to settle
- * (`waitForFlowSaveSettled`): entering the editor fits the viewport and
- * schedules a debounced `PATCH /api/v1/flows/{id}`, and if that response lands
- * while the modal is open it re-renders the dialog, detaching `input-flow-name`
- * mid-click and briefly disabling `save-flow-settings` — exactly the race that
- * destabilised this helper.
+ * One pass through the flow-settings modal: open it from the header, optionally
+ * edit name/description, save (or cancel when nothing changed).
  *
  * @returns the name/description present in the inputs *before* any edit.
  */
-export const renameFlow = async (
+const applyFlowSettings = async (
   page: Page,
-  {
-    flowName,
-    flowDescription,
-  }: { flowName?: string; flowDescription?: string } = {},
-) => {
+  { flowName, flowDescription }: RenameOptions,
+): Promise<RenameResult> => {
   // Let any in-flight editor autosave settle so opening/saving the modal does
   // not race a PATCH that would re-render the dialog and detach its inputs.
   await waitForFlowSaveSettled(page);
@@ -66,6 +60,17 @@ export const renameFlow = async (
   if (flowName || flowDescription) {
     const saveButton = page.getByTestId("save-flow-settings");
     await expect(saveButton).toBeEnabled({ timeout: MODAL_TIMEOUT });
+
+    // Second barrier, immediately before the PATCH we are about to fire
+    // (issue #995). The barrier at the top of the helper is not enough: the
+    // editor's mount autosave is debounced, so under load it is routinely
+    // *issued* after that barrier returned (observed 183 ms after it, natural
+    // repro on 1.12.0.dev7). Waiting here — with the modal already filled, so
+    // nothing else can mutate the flow — leaves only the click→request hop
+    // between the last observed save and ours. Re-assert the button afterwards:
+    // a landing autosave re-renders the dialog.
+    await waitForFlowSaveSettled(page);
+    await expect(saveButton).toBeEnabled({ timeout: MODAL_TIMEOUT });
     await saveButton.click();
 
     // Confirm the save succeeded by asserting the modal closed. Upstream
@@ -81,17 +86,6 @@ export const renameFlow = async (
     await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
       timeout: 30000,
     });
-
-    if (flowName) {
-      await page.waitForFunction(
-        (expected) => {
-          const header = document.querySelector('[data-testid="flow_name"]');
-          return header && header.textContent?.trim() === expected;
-        },
-        flowName,
-        { timeout: 30000 },
-      );
-    }
   } else {
     await expect(page.getByTestId("save-flow-settings")).toBeDisabled({
       timeout: MODAL_TIMEOUT,
@@ -105,4 +99,77 @@ export const renameFlow = async (
     flowName: flowNameInput,
     flowDescription: flowDescriptionInput,
   };
+};
+
+/**
+ * Opens the flow-settings modal from the flow header, optionally edits the
+ * name and/or description, and saves (or cancels when nothing changed).
+ *
+ * Hardening (issue #357): every gate is a real auto-waiting assertion
+ * (`expect(...).toBeVisible/toBeEnabled/toBeDisabled`) instead of the
+ * non-waiting `locator.isVisible()/isEnabled()/isDisabled()` queries, whose
+ * boolean results were discarded — they never actually waited. Before opening
+ * the modal we also wait for the editor's autosave to settle
+ * (`waitForFlowSaveSettled`): entering the editor fits the viewport and
+ * schedules a debounced `PATCH /api/v1/flows/{id}`, and if that response lands
+ * while the modal is open it re-renders the dialog, detaching `input-flow-name`
+ * mid-click and briefly disabling `save-flow-settings` — exactly the race that
+ * destabilised this helper.
+ *
+ * Hardening (issue #995): the same PATCH race has a second, worse outcome — an
+ * UPSTREAM defect this helper can only work around. `PATCH /api/v1/flows/{id}`
+ * has no version check and `use-save-flow.ts` applies whichever response lands
+ * last (`setCurrentFlow(updatedFlow)` in the mutation's `onSuccess`), so an
+ * autosave that overlaps the rename rewrites the flow with the PRE-rename name
+ * in the store AND in the database. Confirmed live on 1.12.0.dev7: the header
+ * reverts and `GET /api/v1/flows/` returns the old name.
+ *
+ * Two of the three variants are now prevented by closing the save barrier twice
+ * (before opening the modal, and again once it is interactive). The third is not
+ * preventable from the test side: the clobbering autosave can be *issued after*
+ * our own PATCH — observed 176 ms after it — built from a store that has not yet
+ * received our response. For that one the rename is re-applied once, after the
+ * trailing autosave burst has drained. The final assertion is unconditional, so
+ * a rename that genuinely never persists still fails the caller.
+ *
+ * @returns the name/description present in the inputs *before* any edit.
+ */
+export const renameFlow = async (
+  page: Page,
+  { flowName, flowDescription }: RenameOptions = {},
+): Promise<RenameResult> => {
+  const previous = await applyFlowSettings(page, { flowName, flowDescription });
+
+  if (!flowName) return previous;
+
+  const header = page.getByTestId("flow_name");
+
+  for (let attempt = 1; attempt < MAX_RENAME_ATTEMPTS; attempt++) {
+    // Drain the trailing autosave burst before judging the header: the
+    // clobbering PATCH lands up to ~350 ms after ours, so reading the header
+    // straight after the modal closes would see the correct name and miss it.
+    await waitForFlowSaveSettled(page);
+    if ((await header.textContent())?.trim() === flowName) break;
+
+    // Loud on purpose — a silent retry would hide how often the upstream race
+    // fires, which is the only signal we have on it.
+    console.warn(
+      `[renameFlow] rename to "${flowName}" was reverted by a concurrent flow autosave ` +
+        `(upstream PATCH race, issue #995) — re-applying (attempt ${attempt + 1}/${MAX_RENAME_ATTEMPTS})`,
+    );
+    try {
+      await applyFlowSettings(page, { flowName, flowDescription });
+    } catch (error) {
+      // A re-apply can legitimately find nothing to change — if the flow
+      // already holds the requested name, `save-flow-settings` stays disabled
+      // and the pass throws. Swallow it: the unconditional assertion below is
+      // the arbiter, so a rename that really never landed still fails loudly.
+      console.warn(`[renameFlow] re-apply pass did not complete: ${error}`);
+    }
+  }
+
+  await waitForFlowSaveSettled(page);
+  await expect(header).toHaveText(flowName, { timeout: 30000 });
+
+  return previous;
 };

--- a/tests/helpers/flows/wait-for-flow-save-settled.ts
+++ b/tests/helpers/flows/wait-for-flow-save-settled.ts
@@ -1,4 +1,4 @@
-import type { Page, Response } from "@playwright/test";
+import type { Page, Request } from "@playwright/test";
 
 /**
  * Block until the flow's debounced autosave has settled.
@@ -9,48 +9,72 @@ import type { Page, Response } from "@playwright/test";
  * or simply opening a flow (the editor fits the view on mount). If such an
  * autosave is still in flight when the next flow-mutating action fires its own
  * PATCH — e.g. saving the prompt modal, or saving the flow-settings modal — the
- * two requests race. With no retry or version check on that endpoint the
- * backend can return a transient failure that the frontend renders as a
- * "Failed to save flow" toast, and the in-flight response can re-render the
- * open modal, detaching inputs mid-interaction.
+ * two requests race. The endpoint has no version check and the frontend applies
+ * whichever response lands LAST (`use-save-flow.ts` → `setCurrentFlow(updatedFlow)`
+ * in the mutation's `onSuccess`), so the loser silently overwrites the winner in
+ * both the store and the database.
  *
- * This surfaces as cross-test flake: a spurious error toast (issue #358) or a
- * detached `input-flow-name` / never-enabled `save-flow-settings` in the rename
- * helper (issue #357).
+ * This surfaces as cross-test flake: a spurious error toast (issue #358), a
+ * detached `input-flow-name` / never-enabled `save-flow-settings` (issue #357),
+ * or a rename that is reverted to the pre-rename name (issue #995).
  *
- * Resolves once no flow-save PATCH has been observed for `quietMs` (chosen
- * comfortably above the 300 ms autosave debounce), or after `timeout` as a
- * safety cap so a quiet flow never hangs the caller.
+ * Resolves once **no flow-save PATCH is in flight** and none has completed for
+ * `quietMs` (chosen comfortably above the 300 ms autosave debounce), or after
+ * `timeout` as a safety cap so a quiet flow never hangs the caller.
+ *
+ * Tracking requests — not just responses — is what makes this a barrier rather
+ * than a silence probe (issue #995). The response-only version armed its quiet
+ * timer immediately, so a PATCH that had already been *issued* but whose
+ * response was slow under load (>`quietMs`) left the helper returning while the
+ * autosave was still in flight — exactly the window in which the caller's own
+ * PATCH races it.
  */
 export async function waitForFlowSaveSettled(
   page: Page,
   { quietMs = 700, timeout = 10000 }: { quietMs?: number; timeout?: number } = {},
 ): Promise<void> {
-  const isFlowSave = (resp: Response) =>
-    resp.url().includes("/api/v1/flows/") &&
-    resp.request().method() === "PATCH";
+  const isFlowSave = (req: Request) =>
+    req.url().includes("/api/v1/flows/") && req.method() === "PATCH";
 
   await new Promise<void>((resolve) => {
-    let quietTimer: ReturnType<typeof setTimeout>;
+    let quietTimer: ReturnType<typeof setTimeout> | undefined;
+    let inFlight = 0;
 
     const finish = () => {
       clearTimeout(quietTimer);
       clearTimeout(cap);
-      page.off("response", onResponse);
+      page.off("request", onRequest);
+      page.off("requestfinished", onSettled);
+      page.off("requestfailed", onSettled);
       resolve();
     };
 
+    // Only start counting silence when nothing is in flight; a pending PATCH
+    // keeps the barrier closed no matter how long its response takes.
     const arm = () => {
       clearTimeout(quietTimer);
-      quietTimer = setTimeout(finish, quietMs);
+      if (inFlight === 0) quietTimer = setTimeout(finish, quietMs);
     };
 
-    const onResponse = (resp: Response) => {
-      if (isFlowSave(resp)) arm();
+    const onRequest = (req: Request) => {
+      if (!isFlowSave(req)) return;
+      inFlight++;
+      clearTimeout(quietTimer);
+    };
+
+    // A PATCH that was already in flight before this helper attached decrements
+    // below zero; clamping keeps the counter honest and still re-arms the quiet
+    // window, preserving the original response-driven behaviour for that case.
+    const onSettled = (req: Request) => {
+      if (!isFlowSave(req)) return;
+      inFlight = Math.max(0, inFlight - 1);
+      arm();
     };
 
     const cap = setTimeout(finish, timeout);
-    page.on("response", onResponse);
+    page.on("request", onRequest);
+    page.on("requestfinished", onSettled);
+    page.on("requestfailed", onSettled);
     arm();
   });
 }

--- a/tests/tests-automations/regression/core-functionality/project-management/edit-flow-name.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/edit-flow-name.spec.ts
@@ -1,13 +1,40 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { renameFlow } from "../../../../helpers/flows/rename-flow";
 
-// @stable removed by daily triage #704 — recurrent flake on healthy days
-// (07-03, 07-10; see reports/daily-history.jsonl). Restore once fixed — #727.
+// Every flow this test creates (bootstrap + the Basic Prompting template) is
+// tracked by id and deleted in afterEach — id-scoped, never a name or wipe
+// sweep, which would kill flows other parallel workers are driving (#553).
+// The app can fire more than one flows POST per creation; only one persists and
+// deleting a transient id 404s harmlessly (deleteFlow treats 404 as done).
+const createdFlowIds: string[] = [];
+
+test.afterEach(async ({ page }) => {
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(page.request, id);
+  }
+});
+
 test(
   "user should be able to edit flow name and see it reflected in the main page listing",
-  { tag: ["@release", "@workspace", "@regression"] },
+  { tag: ["@stable", "@release", "@workspace", "@regression"] },
   async ({ page }) => {
+    page.on("response", (resp) => {
+      if (
+        resp.url().includes("/api/v1/flows") &&
+        resp.request().method() === "POST" &&
+        resp.status() === 201
+      ) {
+        resp
+          .json()
+          .then((body: { id?: string }) => {
+            if (body?.id) createdFlowIds.push(body.id);
+          })
+          .catch(() => {}); // non-JSON / batch payloads
+      }
+    });
+
     await awaitBootstrapTest(page);
 
     await page.getByRole("heading", { name: "Basic Prompting" }).click();


### PR DESCRIPTION
**Closes #995.**

## Problem

`edit-flow-name.spec.ts:7` lost `@stable` on 2026-07-13 (`5b78a1b`) as a recurrent flake — it flaked on 07-03 and 07-10, both healthy days, plus a hard failure on 07-08. Its tracker #727 closed **without classifying the cause**, because `reports/daily-history.jsonl` stores no `error_signature` for flaky entries. The #974 audit re-caught it with a signature: `page.waitForFunction: Timeout 30000ms exceeded at tests/helpers/flows/rename-flow.ts:86`.

**Root cause — product behaviour, not test timing.** `PATCH /api/v1/flows/{id}` has no version check, and `use-save-flow.ts` applies whichever response lands **last** (`setCurrentFlow(updatedFlow)` in the mutation's `onSuccess`). The editor's debounced mount autosave carries the **pre-rename** name; when it overlaps the flow-settings save and lands after it, the rename is reverted in the store **and in the database**. The header never reaches the new name.

Natural capture on nightly 1.12.0.dev7 (unmodified spec, `--workers=4` under load, 2 of 6 runs):

```
4439ms  --- renaming to d18qtg49op
5140ms  waitForFlowSaveSettled returned        ← 700 ms silence; the autosave had not fired yet
5323ms  REQ  PATCH name=Basic Prompting (7)    ← mount autosave, 183 ms AFTER the barrier returned
5375ms  clicking save
5635ms  REQ  PATCH name=d18qtg49op             ← ours
6546ms  RESP PATCH -> name=Basic Prompting (7)
6705ms  RESP PATCH -> name=d18qtg49op
6785ms  RESP PATCH -> name=Basic Prompting (7) ← lands LAST → clobber
7504ms  header="Basic Prompting (7)"           ← and stays there for the full 30 s
```

Holding the mount autosave with `page.route` so it lands last reproduces it 1/1, and `GET /api/v1/flows/` then returns the **pre-rename** name — the rename is lost server-side, not just in the UI. Full evidence: https://github.com/oriontech-me/langflow-e2e/issues/995#issuecomment-5102615315

## Fix

Three variants of the same race, three answers:

| Variant | Answer |
|---|---|
| Autosave **in flight** when we save | `waitForFlowSaveSettled` tracks in-flight PATCH **requests** (`request` / `requestfinished` / `requestfailed`). The old version armed its quiet timer on **responses** only, and armed it immediately — so it returned both while a PATCH was pending whose response was slower than `quietMs`, and before a debounced autosave had even been issued |
| Autosave **issued between** the first barrier and our save | barrier closed a **second time**, immediately before the save click (with the modal already filled, so nothing else can mutate the flow) |
| Autosave **issued after** our PATCH, from a pre-response store | not preventable from the test side — observed 176 ms after our own request. The rename is **re-applied once** after the trailing burst drains, with a `console.warn`. The closing assertion is unconditional, so a rename that never persists still fails |

`page.waitForFunction` → `expect(...).toHaveText()`: it reports the name the header actually holds, which is what identified the clobber. The raw `waitForFunction` only ever said "Timeout 30000ms exceeded".

**Rejected explicitly:** widening `quietMs` or the 30 s timeout. The autosave was observed issued 183 ms, 176 ms and **2.9 s** relative to the barrier — no quiet window bounds a debounce that can be starved arbitrarily, and a bigger timeout cannot un-revert a name the backend already overwrote.

Also in scope: the spec created a flow per run and never deleted it. It now tracks every `POST /api/v1/flows` 201 id and deletes exactly those in `afterEach` — id-scoped, never a name or wipe sweep (#553).

## Scope note

No assertion was weakened. The spec's observables are unchanged (read-back name, `toHaveCount(1)` in the listing) and the helper's public contract still returns the pre-edit name/description. `rename-flow.ts` is shared by 7 call sites; the modal interaction was extracted into `applyFlowSettings` with identical behaviour and the re-apply only runs when a rename was demonstrably reverted.

## Validation (nightly 1.12.0.dev7, `--retries=0`)

- typecheck ✅ · eslint ✅ · QA-CHECKLIST guard ✅ · checklist-coverage guard ✅
- **Paired arms on the flake itself:**

| Arm | Runs | #995 signature |
|---|---|---|
| Original helper (light + under load) | 20 | **3 failures**, incl. a bare `waitForFunction rename-flow.ts:86` 30 s timeout in a *light* `--workers=2` run |
| This branch (light + under load) | 25 | **0** |

- Issue's prescribed command (`edit-flow-name` + `api-request-component-regression`, `--workers=2 --repeat-each=3`): **3/3 passed** ✅ — and 6/6 at `--repeat-each=6`
- Light burst `--workers=2 --repeat-each=8`: 7/8 (the one failure is a non-#995 mode, see below)
- Other `renameFlow` callers: `flow-rename-header` ✅ · `flowSettings` ✅ · `run-flow` ✅ · `general-bugs-save-changes-on-node` fails **after** the rename on the Text Output legacy removal (pre-existing, not `@stable`)
- force-fail ✅ (all executed, mutations reverted — `grep -c FF-MUTATION` = 0):
  - rename suppressed → fails at `spec.ts:50`, `Expected "sz91jld1twa" / Received "Basic Prompting (10)"`
  - extra rename before returning home → fails at `spec.ts:63`, `toHaveCount Expected 1 / Received 0`
  - cleanup tracker disabled → flow count 176 → **177**; enabled → 176 → 176
  - clobber check forced to always trigger → warning fires, re-apply runs, final assertion arbitrates, green
- zero `🚨 Backend Error` ✅
- `--trace=on` **not run** — the known local hang (#518); step verification came from the request traces above plus the `--retries=0` bursts and force-fails
- Flow cleanup verified: flow count unchanged across a run; orphans from the diagnostics purged

## Residual — not this issue's signature

Two low-rate modes (~7% locally, the same rate the original helper shows for non-#995 causes) survive, both *before* any rename logic runs: `save-flow-settings` disabled with a transient `title="(Read-Only)"` (the 1.12 RBAC gate fails **closed** while `POST /authz/me/permissions` resolves), and `flow_name` absent for 15 s. Tracked separately in #1005.
