### PR TITLE
fix(flows): stop leaking projects when DELETE 500s under contention (#965)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -100,6 +100,11 @@
 - [x] POST with invalid API key → returns 401/403 → `api-invalid-key.spec.ts`
 - [x] POST to non-existent flow → returns 404 → `api/flows/api-run-flow.spec.ts`
 
+#### 1.3.1 Folder (Project) CRUD via API
+- [x] POST `/api/v1/projects/` → creates folder, returns id and name → `api/flows/api-folders-crud.spec.ts`
+- [x] GET `/api/v1/projects/` → lists folders including the created one → `api/flows/api-folders-crud.spec.ts`
+- [!] DELETE `/api/v1/projects/{id}` → returns 204 and the folder leaves the listing — quarantined (#965): under concurrent writes the endpoint answers **500** (`sqlite3.OperationalError: database is locked`) and the folder survives; measured 44% of deletes on `1.12.0.dev7` vs 6% on stable `1.10.3` at the same 2-client contention. Product defect, upstream card pending; the `204` assertion is unchanged → `api/flows/api-folders-crud.spec.ts`
+
 #### 1.4 Components via API
 - [x] GET `/api/v1/all` → lists all available components → `api/flows/api-custom-component-creation.spec.ts`
 - [x] POST `/api/v1/custom_component` → creates custom component → `api/flows/api-custom-component-creation.spec.ts`
@@ -630,7 +635,7 @@
 #### 12.5 Flow Operations
 - [x] Lock flow — prevents editing → `flow-functionality/lock-flow.spec.ts`
 - [x] Unlock flow → `flow-functionality/flow-lock.spec.ts`
-- [x] Move flow between folders via API → `api/flows/api-folders-crud.spec.ts`
+- [!] Move flow between folders via API — quarantined (#932): `PATCH /api/v1/flows/{id}` returns `200` but the association read back is intermittently stale. Separate root cause from #965 — under contention the `PATCH` can 500, yet every `200` observed persisted the new `folder_id` (18/18) → `api/flows/api-folders-crud.spec.ts`
 - [x] Publish flow → `flow-functionality/publish-flow.spec.ts`
 - [x] Save flow components as template → `core-components/saveComponents.spec.ts`
 

--- a/REGRESSIONS.md
+++ b/REGRESSIONS.md
@@ -60,9 +60,16 @@ moment a ticket is filed. Not counted in the indicator.
 
 | Found | Area / Test | Regression | Severity | Report |
 |-------|-------------|------------|----------|--------|
+| 2026-07-27 | api · api-folders-crud.spec.ts | `DELETE /api/v1/projects/{id}` answers `500` (`sqlite3.OperationalError: database is locked`) instead of `204` while any other write is in flight, and the project survives. Not new — stable 1.10.3 emits the same instant `500` — but 1.12 raises the rate ~7× (6 % → 44 % at 2 concurrent clients, A/B/A/B) and flips the mode: 1.10.3 blocks and mostly honours the contract, 1.12 gives up in 0.03 s. Sibling write endpoints (`POST /projects`, `POST /flows`, `DELETE /flows`) survive the identical contention | Medium | docs/upstream-bugs/UPSTREAM-BUG-project-delete-500-under-contention.md |
 
-*(none — the New Flow dead click was promoted to the Ledger on 2026-07-27 when
-LE-2019 was filed.)*
+Note on the row above, so the earlier adjudication is not re-litigated blindly:
+the *Bulk-flow-delete SQLite-lock 500* entry below was downgraded because a
+client-side retry masked the failure. That defence was re-tested here and holds
+**only at light contention** — 6/6 UI deletes succeeded at 2 background writers,
+2 of them via a masked retry. With 4 writers the retry budget is exhausted and
+the delete **silently no-ops**: project still in the sidebar, no toast, notification
+centre empty, only a console error. That silent no-op is what makes this row
+user-facing; it is Medium, not High, because it needs sustained concurrent writes.
 
 ## Not listed — validated non-regression
 

--- a/docs/api/flows/api-folders-crud.md
+++ b/docs/api/flows/api-folders-crud.md
@@ -1,6 +1,6 @@
 # API Folders (Projects) CRUD
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x (`1.12.0.dev6` / `1.12.0.dev7`)
 
 ---
 
@@ -15,6 +15,17 @@ If any of these tests fail against `langflowai/langflow-nightly:latest`, the fol
 
 ## Tags *(required)*
 `@stable` `@release` `@api` `@regression`
+
+Tests 1 and 2 carry `@stable`. Tests 3 and 4 do **not**, and both are currently
+`test.fixme` — each for a different, independently tracked reason:
+
+- **Test 3** (`DELETE`) — quarantined for **#965**. The endpoint returns `500`
+  instead of `204` under concurrent writes; a product defect, not a test defect
+  (measurements below). `@stable` stays off and the test stays `test.fixme`
+  until the upstream fix lands on `langflowai/langflow-nightly:latest`, at which
+  point the test is re-validated there and both are restored.
+- **Test 4** (`PATCH folder_id`) — quarantined for **#932**, a *different* root
+  cause (see *Relationship between #965 and #932* below).
 
 ---
 
@@ -37,11 +48,16 @@ The spec runs **4 independent tests** against `/api/v1/projects/` and `/api/v1/f
 4. Assert the freshly created `id` is present in the list with the correct name
 5. Cleanup
 
-**Test 3 — `DELETE removes folder and it no longer appears in listing`**
+**Test 3 — `DELETE removes folder and it no longer appears in listing`** *(quarantined, #965)*
 1. Create a folder via `POST`
 2. `DELETE /api/v1/projects/{id}`
 3. Assert HTTP status is `204` (No Content)
 4. `GET /api/v1/projects/` and assert the deleted `id` is absent from the list
+
+The assertion in step 3 is **deliberately unchanged**: `204` is the documented
+contract (`@router.delete("/{project_id}", status_code=204)`) and the endpoint
+breaks it under concurrent writes. Accepting a `500`, retrying the delete, or
+widening the assertion would hide a product defect — see the section below.
 
 **Test 4 — `moving flow between folders via PATCH folder_id updates association`** *(QA-CHECKLIST §12.5)*
 1. Create two folders (A and B) via `POST /api/v1/projects/`
@@ -54,11 +70,82 @@ The spec runs **4 independent tests** against `/api/v1/projects/` and `/api/v1/f
 ---
 
 ## Validation criterion *(required)*
-- All 4 tests pass 5× in a row against `langflowai/langflow-nightly:latest`.
+- The **active** tests (1 and 2) pass 3× in a row at `--retries=0 --workers=1`
+  against `langflowai/langflow-nightly:latest`.
 - Status codes match: folder `POST` returns `201`; folder `GET` returns `200`; folder `DELETE` returns `204`; flow `PATCH`/`GET` return `200`.
 - **Move is durable and observable**: after `PATCH /api/v1/flows/{id}` with a new `folder_id`, a fresh `GET /api/v1/flows/{id}` reports the new `folder_id` — proving the association moved and persisted, not just that the request was accepted.
 - Deleted folders disappear from `GET /api/v1/projects/`.
-- Each test cleans up after itself — no orphan folders or flows remain after the suite completes.
+- Each test cleans up after itself — no orphan folders or flows remain after the
+  suite completes. This is stronger than "issue a DELETE": the cleanup runs
+  through `deleteProject()`
+  (`tests/helpers/flows/delete-project.ts`, sibling of `delete-flow.ts`), which
+  **verifies** the folder is gone and retries the delete when it comes back
+  `500`, because a swallowed `500`
+  leaves a permanent orphan (see the defect below). The observable is
+  `GET /api/v1/projects/` no longer listing the id, not the status of one call.
+- **Quarantine gate for test 3 (#965)** — the concrete observable that lifts it:
+  the burst under *concurrent writes* returns `204` for every delete. Measured on
+  `1.12.0.dev7` with 2 concurrent clients issuing create+delete cycles, **44 %**
+  of the deletes come back `500` (40 of 90); the criterion is 0 of 90 with the
+  same script, at which point `test.fixme` and `@stable` are restored together.
+  A serial pass is NOT sufficient evidence — serially the endpoint is already
+  green (10/10), which is exactly why the daily saw this as a flake.
+
+---
+
+## Known product defect behind the quarantine of test 3 (#965)
+
+`DELETE /api/v1/projects/{id}` answers **`500`** — not `204` — whenever another
+write transaction is in flight, and **the folder is not deleted**. The response
+leaks the raw SQL:
+
+```json
+{"detail":"(sqlite3.OperationalError) database is locked\n[SQL: DELETE FROM folder WHERE folder.id = ?]\n[parameters: ('0913fdcdc2bd4f68bfa26d8ed3f0fc83',)]\n(Background on this error at: https://sqlalche.me/e/20/e3q8)"}
+```
+
+Why this is a product defect and not "SQLite being SQLite":
+
+| Endpoint, same P=2 contention, 12 rounds | Result |
+|---|---|
+| `POST /api/v1/projects/` | 24/24 → `201` |
+| `POST /api/v1/flows/` | 24/24 → `201` |
+| `DELETE /api/v1/flows/{id}` | 24/24 → `200` |
+| `DELETE /api/v1/projects/{id}` | 13/24 → `204`, **11/24 → `500`** |
+
+Sibling write paths survive the identical contention. `busy_timeout` **is**
+configured (30 000 ms, plus WAL — `lfx/services/settings/groups/database.py`),
+yet the failures return in ~0.03 s, so SQLite's busy handler never waits on this
+path. `delete_project` wraps every exception into
+`HTTPException(status_code=500, detail=str(e))` and only
+`retry_project_operation_on_deployment_guard` retries — `OperationalError` is not
+covered, so a transient lock becomes a permanent client-visible failure.
+
+Rate versus the previous release (A/B/A/B, one arm at a time, 3 alternations,
+P=2, 30 deletes per round, orphans purged between rounds):
+
+| Build | `204` | `500` | median latency of a failure |
+|---|---|---|---|
+| stable `1.10.3` | 66/90 | **5 (6 %)** | 1.80 s |
+| nightly `1.12.0.dev7` | 50/90 | **40 (44 %)** | 0.03 s |
+
+So the defect is **not new** — 1.10.3 produces the same instant `500` — but 1.12
+makes it ~7× more frequent and changes the failure mode: 1.10.3 mostly blocks and
+still honours the contract (rounds of 68–196 s, individual deletes waiting up to
+42 s, some connections dropped), 1.12 gives up in 0.03 s. The endpoint source and
+`services/database/service.py` are byte-identical between the two builds, as are
+SQLAlchemy 2.0.51 / aiosqlite 0.22.1 / SQLite 3.46.1 — the rate change is
+reproducible but **not explained at code level**, and the upstream report says so
+explicitly.
+
+Filed upstream: see `docs/upstream-bugs/UPSTREAM-BUG-project-delete-500-under-contention.md`.
+
+## Relationship between #965 and #932 — separate causes, both stay
+
+Settled with evidence, not assumption. Under the same contention that breaks the
+DELETE, `PATCH /api/v1/flows/{id}` also returns `500` (7/20 at P=2, 27/32 at
+P=4) — but **every** `PATCH` that returned `200` had persisted the new
+`folder_id` (13/13 and 5/5). #932's symptom is a `200` followed by a **stale**
+association, which contention does not reproduce. Two issues, two root causes.
 
 ---
 
@@ -67,6 +154,11 @@ The spec runs **4 independent tests** against `/api/v1/projects/` and `/api/v1/f
 - Cascade behavior when a folder holding flows is deleted (do the flows move to root, or are they deleted?) — out of scope here.
 - Multi-user isolation of folders — out of scope; would require seeding a second user.
 - The UI drag-drop affordance for moving a flow between folders — this spec covers the API contract only.
+- **Concurrency as a first-class scenario.** The spec asserts the single-client
+  contract; it does not itself drive concurrent writers. The #965 defect is
+  *observed* through this spec (the suite runs `fullyParallel`, so other workers
+  supply the contention) but is *measured* with the standalone scripts recorded in
+  the upstream report. A dedicated load spec is not in scope here.
 
 ---
 
@@ -81,5 +173,6 @@ The spec runs **4 independent tests** against `/api/v1/projects/` and `/api/v1/f
 
 - `src/backend/base/langflow/api/v1/projects.py` — router that exposes `POST/GET/DELETE /api/v1/projects/`; any signature, status code (notably the `204` on DELETE), or response shape change here directly affects the folder tests.
 - `src/backend/base/langflow/api/v1/folders.py` — legacy folders router / alias kept for compatibility; changes to how folders and projects share models can shift behavior.
+- `src/backend/base/langflow/api/v1/mappers/deployments/sync.py` — `retry_project_operation_on_deployment_guard` wraps the whole delete in a nested transaction and decides which failures are retried; widening it to cover `OperationalError` is the likely shape of the #965 fix, and would flip test 3 back to green.
 - `src/backend/base/langflow/api/v1/flows.py` — exposes `PATCH /api/v1/flows/{id}`; the move-flow test depends on `folder_id` being an accepted, persisted field on this endpoint.
 - `src/backend/base/langflow/services/database/models/flow/model.py` — flow schema including the `folder_id` foreign key; renaming/removing it breaks the move assertion.

--- a/docs/upstream-bugs/UPSTREAM-BUG-project-delete-500-under-contention.md
+++ b/docs/upstream-bugs/UPSTREAM-BUG-project-delete-500-under-contention.md
@@ -1,0 +1,336 @@
+# `DELETE /api/v1/projects/{id}` returns 500 (`database is locked`) and leaves the project undeleted when any other write is in flight
+
+| Field | Value |
+|---|---|
+| **Filed upstream** | *pending — Jira card to be opened* |
+| **Repo issue** | [oriontech-me/langflow-e2e#965](https://github.com/oriontech-me/langflow-e2e/issues/965) (spun out of daily triage #962) |
+| **Affected builds** | `langflowai/langflow-nightly:latest` → `1.12.0.dev6` and `1.12.0.dev7`; reproduced at a lower rate on stable `langflowai/langflow:latest` → `1.10.3` |
+| **Component** | `src/backend/base/langflow/api/v1/projects.py` → `delete_project` |
+| **Database** | SQLite (the default for the Docker image), WAL enabled, `busy_timeout = 30000` |
+| **Severity** | Medium. A documented `204` contract returns `500` and the delete does not happen. No data loss. In the UI a single retry usually hides it, but when the retry budget is exhausted the delete silently no-ops with no toast and no notification (§4.4). |
+| **Discovered by** | Langflow E2E regression suite — `tests/tests-automations/regression/api/flows/api-folders-crud.spec.ts` (test: *DELETE removes folder and it no longer appears in listing*), recurrent on the dailies of 2026-07-22 and 2026-07-27 |
+
+---
+
+## 1. Summary
+
+`DELETE /api/v1/projects/{project_id}` is declared as `status_code=204`. Whenever
+another write transaction is in flight against the same SQLite database, the
+endpoint instead answers **HTTP 500** with the raw SQLAlchemy error in `detail`,
+and **the project is not deleted** — a follow-up `GET /api/v1/projects/` still
+lists it.
+
+Two properties make this more than "SQLite under load":
+
+1. **Sibling write endpoints survive the identical contention.** With two
+   concurrent clients, `POST /api/v1/projects/`, `POST /api/v1/flows/` and
+   `DELETE /api/v1/flows/{id}` were 100 % successful while
+   `DELETE /api/v1/projects/{id}` failed 11 of 24 times (§4.2).
+2. **`busy_timeout` is configured but never engages.** The pragma is set to
+   30 000 ms (`lfx/services/settings/groups/database.py:48`) and WAL is active
+   (`langflow.db-wal` / `-shm` present), yet the failures return in **~0.03 s**
+   (§4.1, §4.3). SQLite's busy handler is not invoked on this path, so the
+   configured tolerance for lock contention has no effect.
+
+---
+
+## 2. Reproduction
+
+No UI needed; two concurrent API clients are enough. Scripts used for every
+number in this report are reproduced in Appendix E.
+
+```bash
+docker run -d --name lf-repro -p 7860:7860 \
+  -e LANGFLOW_AUTO_LOGIN=true -e LANGFLOW_SUPERUSER=langflow \
+  -e LANGFLOW_SUPERUSER_PASSWORD=langflow123 -e LANGFLOW_WORKERS=1 \
+  langflowai/langflow-nightly:latest
+
+TOK=$(curl -s localhost:7860/api/v1/auto_login | python3 -c 'import sys,json;print(json.load(sys.stdin)["access_token"])')
+
+# Two shells (or the script in Appendix E), each looping:
+ID=$(curl -s -X POST localhost:7860/api/v1/projects/ -H "Authorization: Bearer $TOK" \
+      -H 'Content-Type: application/json' -d '{"name":"repro-'$RANDOM'"}' \
+      | python3 -c 'import sys,json;print(json.load(sys.stdin)["id"])')
+curl -s -w '\n%{http_code} %{time_total}\n' -X DELETE "localhost:7860/api/v1/projects/$ID" \
+      -H "Authorization: Bearer $TOK"
+```
+
+**Serially the endpoint is healthy** — 10 create+delete cycles, 10 × `204`. The
+failure requires a concurrent writer, which is why a browser with two open tabs,
+any parallel API consumer, or a CI suite running tests in parallel hits it while
+a manual click-through never does.
+
+---
+
+## 3. Expected vs actual
+
+**Expected:** `204 No Content`, and the project gone from `GET /api/v1/projects/`.
+
+**Actual:** `500` with the SQL statement echoed to the client, project still
+present:
+
+```json
+{"detail":"(sqlite3.OperationalError) database is locked\n[SQL: DELETE FROM folder WHERE folder.id = ?]\n[parameters: ('0913fdcdc2bd4f68bfa26d8ed3f0fc83',)]\n(Background on this error at: https://sqlalche.me/e/20/e3q8)"}
+```
+
+Secondary problems visible in that payload:
+
+- The raw SQL, table name and bound parameters are returned to the caller.
+- A transient database condition is reported as `500` (non-retriable by
+  convention) rather than a retriable status such as `503`, so well-behaved
+  clients do not retry.
+
+---
+
+## 4. Measurements
+
+All runs on one machine (Colima VM, 2 vCPU / 4 GiB), `LANGFLOW_WORKERS=1`, one
+Langflow container under load at a time, orphaned projects purged between rounds
+so database size stays comparable.
+
+### 4.1 Rate versus concurrency — nightly `1.12.0.dev6`, seasoned database
+
+| Concurrent clients | cycles | `204` | `500` | latency of a failure (min/avg/max) |
+|---|---|---|---|---|
+| 1 (serial) | 10 | 10 | **0** | — |
+| 2 | 30 | 15 | **15** | 0.02 / 0.02 / 0.03 s |
+| 4 | 60 | 31 | **29** | 0.02 / 0.03 / 0.04 s |
+| 8 | 80 | 13 | **67** | 0.03 / 0.07 / 0.22 s |
+
+### 4.2 Endpoint scope — same contention, `1.12.0.dev7`, 2 clients × 12 rounds
+
+| Endpoint | Result |
+|---|---|
+| `POST /api/v1/projects/` | 24/24 → `201` |
+| `POST /api/v1/flows/` | 24/24 → `201` |
+| `DELETE /api/v1/flows/{id}` | 24/24 → `200` |
+| `DELETE /api/v1/projects/{id}` | 13/24 → `204`, **11/24 → `500`** |
+
+Only the project delete breaks. This is the strongest argument that the fix
+belongs in the endpoint's transaction handling, not in the caller or the database
+engine choice.
+
+### 4.3 Version comparison — A/B/A/B, one arm at a time
+
+3 alternations, 2 concurrent clients, 30 deletes per round, orphans purged
+between rounds. Arms never ran simultaneously, so neither competed for CPU.
+
+| Round | Build | `204` | `500` | other | median latency of a failure | wall clock |
+|---|---|---|---|---|---|---|
+| 1 | stable `1.10.3` | 23 | **1** | 6 | 6.37 s | 87.5 s |
+| 1 | nightly `1.12.0.dev7` | 18 | **12** | 0 | 0.03 s | 0.8 s |
+| 2 | stable `1.10.3` | 22 | **2** | 6 | 1.61 s | 150.4 s |
+| 2 | nightly `1.12.0.dev7` | 15 | **15** | 0 | 0.03 s | 0.8 s |
+| 3 | stable `1.10.3` | 21 | **2** | 7 | 1.80 s | 195.9 s |
+| 3 | nightly `1.12.0.dev7` | 17 | **13** | 0 | 0.02 s | 0.7 s |
+| **total** | stable `1.10.3` | 66/90 | **5 (6 %)** | 19 | 1.80 s | — |
+| **total** | nightly `1.12.0.dev7` | 50/90 | **40 (44 %)** | 0 | 0.03 s | — |
+
+An extra stable round with the full status breakdown, so the *other* column is
+not read as success (see Appendix C for the raw output): of 30 attempts, 22 →
+`204`, **4 → `500` in 0.02–0.04 s**, 3 deletes and 1 create had the connection
+dropped by the server after 1.3–42 s.
+
+**Interpretation.** The defect is **not new** — `1.10.3` emits the same instant
+`500`. What changed in `1.12` is the rate (≈ 7×: 6 % → 44 %) and the dominant
+failure mode: `1.10.3` mostly *blocks* and still honours the contract (rounds of
+68–196 s, individual deletes waiting up to 42 s, some connections dropped);
+`1.12` gives up in 0.03 s. Both are wrong; `1.12` breaks correctness where
+`1.10.3` mostly paid latency.
+
+### 4.4 What the UI does with the failure (the "is it user-facing?" test)
+
+Driven through the real sidebar (row menu → *Delete* → confirm) on
+`1.12.0.dev7`, with the same contention script running in the background. This
+section exists because a *previous* SQLite-lock finding in this suite was
+adversarially downgraded to non-user-facing on the grounds that a client-side
+retry masks the 500 — that defence had to be tested here, not assumed.
+
+**Light contention (2 background writers), 6 consecutive UI deletes:** 6/6
+projects were deleted. In 2 of the 6 the client got a `500` and **immediately
+re-issued the DELETE**, which returned `204`; the user saw only
+*"Project deleted successfully."* So at this level the retry does mask the defect
+— the earlier finding's defence holds.
+
+**Heavier contention (4 background writers):** the retry budget is finite and can
+be exhausted. Two hand-driven deletes:
+
+| Attempt | DELETE calls issued by the client | Project afterwards | Toast | Notification centre |
+|---|---|---|---|---|
+| A | 3 × `500` | **still present** | none | *"No new notifications"* |
+| B | 1 × `500` | **still present** | none | *"No new notifications"* |
+
+The only trace is in the browser console
+(`Failed to load resource: the server responded with a status of 500`). The user
+clicks *Delete*, confirms, and **nothing happens and nothing is said** — the
+project is still in the sidebar.
+
+Also at that level, the project list itself frequently never finishes rendering
+(5 of 8 scripted iterations had to be skipped because the row never appeared),
+and one full automated pass could not complete within 10 minutes.
+
+**Net:** at low concurrency the retry hides the defect; when the retry budget is
+exhausted the deletion silently does not happen and the UI reports success-shaped
+silence rather than an error. The user-facing part is the *silent* no-op, not the
+`500` itself.
+
+---
+
+## 5. Code pointers (paths as installed in the image)
+
+`langflow/api/v1/projects.py` → `delete_project`:
+
+```python
+async def _delete_project_operation() -> None:
+    flows = (await session.exec(select(Flow).where(Flow.folder_id == project_id, ...))).all()
+    ...
+    await check_project_has_deployments(session, project_id=project_id)
+    await session.delete(project)
+    # Flush eagerly so guard/constraint errors surface in-request rather than at teardown commit.
+    await session.flush()
+
+try:
+    await retry_project_operation_on_deployment_guard(
+        db=session, user_id=project_owner_id, project_id=project_id,
+        operation=_delete_project_operation,
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+except Exception as e:
+    await araise_if_deployment_guard_error_or_skip(...)
+    raise HTTPException(status_code=500, detail=str(e)) from e
+```
+
+- The `except Exception` funnel maps **every** failure, including a transient
+  `sqlite3.OperationalError`, to `500` with `str(e)` as the public detail.
+- `retry_project_operation_on_deployment_guard`
+  (`langflow/api/v1/mappers/deployments/sync.py`) retries **only**
+  `DeploymentGuardError` — it re-raises anything else — and it runs the operation
+  inside `async with db.begin_nested()`, i.e. a SAVEPOINT write issued while the
+  same session has already read (the authorization fetch, the MCP cleanup, the
+  flow enumeration and the deployment check all precede it).
+- Suggested directions, in the order we would try them: retry the operation on
+  `OperationalError`/`SQLITE_BUSY`; begin the write transaction as `IMMEDIATE` so
+  the lock is taken before the reads; failing both, map the condition to `503`
+  with a clean message instead of `500` with raw SQL.
+
+---
+
+## 6. What we did NOT verify (stated so the report is not over-read)
+
+- **Why the rate differs between `1.10.3` and `1.12`.** `delete_project` and
+  `services/database/service.py` are byte-identical between the two images, as
+  are SQLAlchemy 2.0.51, aiosqlite 0.22.1, SQLite 3.46.1 and the pragma defaults.
+  The only diffs on the path are `main.py` (+98 lines, mostly an audit-log
+  cleanup worker whose cadence is daily and whose first pass waits a full
+  interval — so it is *not* the competing writer) and
+  `mappers/deployments/sync.py` (+73 lines, rowcount confirmation on stale
+  deployment deletes). Neither explains the change. The rate difference is
+  reproducible; its mechanism is unexplained.
+- **PostgreSQL.** Not tested. The defect is expected to be SQLite-specific, but
+  that is an inference, not a measurement. Note that SQLite is the image default,
+  so the affected configuration is the out-of-the-box one.
+- **A single-statement causal trace** (SQL echo / `EXPLAIN`-level proof of which
+  concurrent statement holds the write lock at the moment of failure). The
+  evidence here is black-box: status codes, latencies and the error payload.
+- **A clean failure rate for the UI path.** §4.4 has hand-driven observations and
+  one automated run at light contention; the heavier-contention loop could not be
+  completed (the app degrades so much that a single pass exceeded 10 minutes).
+
+---
+
+## 7. Impact
+
+- **Users on the default Docker/SQLite deployment**: with light concurrency the
+  frontend's retry hides the failure and the delete goes through (§4.4). When the
+  retry budget is exhausted the delete **silently does not happen**: no toast, no
+  entry in the notification centre, the project still in the sidebar, and only a
+  console error. A user who is not watching DevTools has no way to tell the
+  operation failed.
+- **API consumers**: a `500` on a valid `DELETE` is not retried by conventional
+  clients, so the caller reports a hard failure for a transient condition.
+- **CI / test suites**: any suite running in parallel against one instance sees
+  this as flakiness. In ours it recurred on two dailies with an identical
+  signature; teardown paths that ignored the status silently accumulated orphan
+  projects on the instance.
+
+---
+
+## 8. Suggested acceptance for the fix
+
+With two concurrent clients issuing create+delete cycles (Appendix E script,
+`P=2`, 45 cycles): **0 responses other than `204`**, and `GET /api/v1/projects/`
+listing none of the created ids afterwards. Our quarantined regression test is
+restored to `@stable` on exactly that evidence.
+
+---
+
+## Appendix A — failing daily signature (repo issue #965)
+
+```
+tests/tests-automations/regression/api/flows/api-folders-crud.spec.ts:82
+  "DELETE removes folder and it no longer appears in listing"
+  Error: expect(received).toBe(expected) // Object.is equality
+  Expected: 204
+  Received: 500
+```
+
+Recurrent with the same `error_signature` on the dailies of 2026-07-22 and
+2026-07-27 (`langflowai/langflow-nightly:latest`), recovered on retry both times.
+
+## Appendix B — burst output, nightly `1.12.0.dev6`, 8 clients (excerpt)
+
+```
+w5 i12 DELETE=500 id=0913fdcd-c2bd-4f68-bfa2-6d8ed3f0fc83 body={"detail":"(sqlite3.OperationalError) database is locked\n[SQL: DELETE FROM folder WHERE folder.id = ?]\n[parameters: ('0913fdcdc2bd4f68bfa26d8ed3f0fc83',)]\n(Background on this error at: https://sqlalche.me/e/20/e3q8)"}
+w6 i12 DELETE=500 id=cd0a83b8-91fb-4693-84b3-9851e13742d1 body={"detail":"(sqlite3.OperationalError) database is locked ...
+w4 i12 DELETE=500 id=166b3f90-6aed-4984-a648-12ac23600bc1 body={"detail":"(sqlite3.OperationalError) database is locked ...
+...
+total=80 ok204=13 failed=67
+ok   time_total  min/avg/max: 0.01 / 0.03 / 0.09 s
+fail time_total  min/avg/max: 0.03 / 0.07 / 0.22 s
+failure codes: {'500': 67}
+```
+
+After that burst, 101 of the created projects were still listed by
+`GET /api/v1/projects/` and had to be deleted serially (all 101 then returned
+`204`) — direct evidence that the failed deletes did not happen.
+
+## Appendix C — stable `1.10.3`, full status breakdown for one P=2 round
+
+```
+stable-1.10.3 P=2 N=15 wall=68s
+  create-0    n=  1  min= 1.95s  max= 1.95s     <- connection dropped by the server
+  delete-0    n=  3  min= 1.29s  max=42.23s     <- connection dropped by the server
+  delete-204  n= 22  min= 0.02s  max= 2.00s
+  delete-500  n=  4  min= 0.02s  max= 0.04s     <- same instant 500
+  purged=7
+```
+
+## Appendix D — related but distinct: `PATCH /api/v1/flows/{id}` under the same contention
+
+| Concurrency | `PATCH` 200 | `PATCH` 500 | of the 200s, association persisted |
+|---|---|---|---|
+| 2 clients × 10 rounds | 13 | **7** | 13/13 |
+| 4 clients × 8 rounds | 5 | **27** | 5/5 |
+
+So the flow-move endpoint suffers the same contention-as-500 family, but it never
+returned a `200` with a stale association. (Recorded here because our repo issue
+#932 tracks that stale-association symptom separately; the data says the two are
+different root causes.)
+
+## Appendix E — scripts
+
+Committed next to this report under `docs/upstream-bugs/scripts/`. Each is
+self-contained (bash + curl, or Python stdlib only), takes the concurrency and
+cycle count as arguments, and purges what it creates:
+
+| Script | Produces | Invocation used here |
+|---|---|---|
+| `scout-965-timed.sh` | §4.1 — status + `time_total` per delete, min/avg/max split by outcome | `./scout-965-timed.sh 2 15 out.csv` (and `4 15`, `8 10`) |
+| `scout-965-scope.py` | §4.2 — the endpoint-scope matrix | `python3 scout-965-scope.py 2 12` |
+| `ab-965.py` | §4.3 — the A/B/A/B harness, purging orphans between rounds | `python3 ab-965.py 3 2 15` |
+| `scout-932-probe.py` | Appendix D — the `PATCH folder_id` persistence probe | `BASE=http://localhost:7862 python3 scout-932-probe.py 2 10` |
+| `saboteur.sh` + `ui-delete-loop.sh` | §4.4 — background write pressure, then real UI deletes classified by what the user perceives | `./saboteur.sh 2 &` then `./ui-delete-loop.sh 6` |
+
+`scout-965-timed.sh` honours `BASE` (default `http://localhost:7860`);
+`ab-965.py` has the two arms hardcoded to `:7861` (stable) and `:7862` (nightly),
+matching the two containers described in §4.

--- a/docs/upstream-bugs/scripts/ab-965.py
+++ b/docs/upstream-bugs/scripts/ab-965.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""A/B/A/B contention test for #965.
+
+Question: is the instant `500 database is locked` on DELETE /api/v1/projects/{id}
+a THRESHOLD REGRESSION in 1.12 (nightly) versus 1.10.3 (stable), or the same
+long-standing defect measured under different machine load?
+
+Design (each arm gets identical treatment, never simultaneously, so the 2-core
+Docker VM is not shared between arms):
+  - arms alternate A(stable 1.10.3, :7861) / B(nightly 1.12.0.dev7, :7862)
+  - ROUNDS alternations; each round = P concurrent clients x N create+delete cycles
+  - between rounds every leftover probe project is deleted serially, so DB size
+    stays comparable across rounds
+  - per round we record: 204 count, 500 count, other, and the latency profile of
+    the failures (an instant failure means SQLite's busy handler never waited;
+    a slow one means it waited and gave up)
+
+Prints a per-round table plus a per-arm total. No test-suite code involved.
+"""
+import json
+import statistics
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from collections import Counter
+
+ARMS = [("stable-1.10.3", "http://localhost:7861"), ("nightly-1.12.0.dev7", "http://localhost:7862")]
+ROUNDS = int(sys.argv[1]) if len(sys.argv) > 1 else 3
+P = int(sys.argv[2]) if len(sys.argv) > 2 else 2
+N = int(sys.argv[3]) if len(sys.argv) > 3 else 15
+PREFIX = "AB965"
+
+
+def call(base, method, path, token, body=None, timeout=200):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(base + path, data=data, method=method)
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    if data:
+        req.add_header("Content-Type", "application/json")
+    t0 = time.monotonic()
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            raw = r.read()
+            return r.status, (json.loads(raw) if raw else None), time.monotonic() - t0
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        try:
+            return e.code, json.loads(raw), time.monotonic() - t0
+        except Exception:
+            return e.code, raw[:200].decode(errors="replace"), time.monotonic() - t0
+    except Exception as e:  # timeout / connection reset
+        return 0, str(e)[:120], time.monotonic() - t0
+
+
+def token_for(base):
+    with urllib.request.urlopen(base + "/api/v1/auto_login") as r:
+        return json.load(r)["access_token"]
+
+
+def purge(base, token):
+    """Delete every leftover probe project, serially and with one retry."""
+    st, body, _ = call(base, "GET", "/api/v1/projects/", token)
+    lst = body if isinstance(body, list) else (body or {}).get("folders", [])
+    ids = [f["id"] for f in lst if str(f.get("name", "")).startswith(PREFIX)]
+    for pid in ids:
+        st, _, _ = call(base, "DELETE", f"/api/v1/projects/{pid}", token)
+        if st >= 400:
+            call(base, "DELETE", f"/api/v1/projects/{pid}", token)
+    return len(ids)
+
+
+def round_once(name, base, rnd):
+    token = token_for(base)
+    codes = Counter()
+    fail_lat, ok_lat = [], []
+    lock = threading.Lock()
+
+    def worker(w):
+        for i in range(N):
+            st, body, _ = call(base, "POST", "/api/v1/projects/", token,
+                               {"name": f"{PREFIX} r{rnd}-w{w}-{i}"})
+            if not isinstance(body, dict) or "id" not in body:
+                with lock:
+                    codes[f"create-{st}"] += 1
+                continue
+            st, body, dt = call(base, "DELETE", f"/api/v1/projects/{body['id']}", token)
+            with lock:
+                codes[st] += 1
+                (ok_lat if st == 204 else fail_lat).append(dt)
+
+    threads = [threading.Thread(target=worker, args=(w,)) for w in range(P)]
+    t0 = time.monotonic()
+    [t.start() for t in threads]
+    [t.join() for t in threads]
+    wall = time.monotonic() - t0
+    leftovers = purge(base, token)
+
+    total = sum(codes.values())
+    n500 = codes.get(500, 0)
+    other = total - codes.get(204, 0) - n500
+    med = statistics.median(fail_lat) if fail_lat else 0.0
+    print(f"round {rnd} | {name:20s} | 204={codes.get(204,0):3d} 500={n500:3d} other={other:2d} "
+          f"| fail median={med:6.2f}s | wall={wall:6.1f}s | purged={leftovers}", flush=True)
+    return {"arm": name, "round": rnd, "n204": codes.get(204, 0), "n500": n500,
+            "other": other, "fail_median": med, "wall": wall}
+
+
+print(f"--- A/B contention test: ROUNDS={ROUNDS} P={P} N={N} (deletes per round = {P * N})", flush=True)
+for name, base in ARMS:
+    tok = token_for(base)
+    print(f"pre-purge {name}: {purge(base, tok)} leftover probe projects removed", flush=True)
+
+results = []
+for rnd in range(1, ROUNDS + 1):
+    for name, base in ARMS:
+        results.append(round_once(name, base, rnd))
+
+print("\n--- per-arm totals")
+for name, _ in ARMS:
+    rs = [r for r in results if r["arm"] == name]
+    t204 = sum(r["n204"] for r in rs)
+    t500 = sum(r["n500"] for r in rs)
+    tot = t204 + t500 + sum(r["other"] for r in rs)
+    meds = [r["fail_median"] for r in rs if r["n500"]]
+    print(f"{name:20s} 204={t204:3d}/{tot:3d}  500={t500:3d}  ({100*t500/tot:.0f}% of requests)  "
+          f"fail-median across rounds={statistics.median(meds) if meds else 0:.2f}s")
+json.dump(results, open("/tmp/ab965-results.json", "w"), indent=1)

--- a/docs/upstream-bugs/scripts/saboteur.sh
+++ b/docs/upstream-bugs/scripts/saboteur.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Background write pressure against one Langflow instance, so a UI action can be
+# performed inside the #965 contention window. Creates and deletes throwaway
+# projects until killed; leftovers are purged by the caller.
+BASE=${BASE:-http://localhost:7862}
+P=${1:-6}
+TOK=$(curl -s "$BASE/api/v1/auto_login" | python3 -c 'import sys,json;print(json.load(sys.stdin)["access_token"])')
+export TOK BASE
+worker() {
+  while :; do
+    id=$(curl -s -X POST "$BASE/api/v1/projects/" -H "Authorization: Bearer $TOK" \
+      -H 'Content-Type: application/json' -d "{\"name\":\"SAB965 $1-$RANDOM\"}" \
+      | python3 -c 'import sys,json;print(json.load(sys.stdin).get("id",""))' 2>/dev/null)
+    [ -n "$id" ] && curl -s -o /dev/null -X DELETE "$BASE/api/v1/projects/$id" -H "Authorization: Bearer $TOK"
+  done
+}
+export -f worker
+seq 1 "$P" | xargs -P "$P" -I{} bash -c 'worker {}'

--- a/docs/upstream-bugs/scripts/scout-932-probe.py
+++ b/docs/upstream-bugs/scripts/scout-932-probe.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Probe for the #965 <-> #932 relationship.
+
+#932's symptom is NOT a 5xx: `PATCH /api/v1/flows/{id}` with a new `folder_id`
+returns 200, but a follow-up `GET /api/v1/flows/{id}` reports the OLD folder_id.
+Question: does write contention (the #965 trigger) also produce that silent
+non-persistence, i.e. one shared backend cause?
+
+Each client loops: create folders A and B, create a flow in A, PATCH it into B,
+GET it back. Tallies (a) PATCH status, (b) whether the GET shows B.
+"""
+import json
+import os
+import sys
+import threading
+import urllib.error
+import urllib.request
+from collections import Counter
+
+BASE = os.environ.get("BASE", "http://localhost:7862")
+P = int(sys.argv[1]) if len(sys.argv) > 1 else 4
+N = int(sys.argv[2]) if len(sys.argv) > 2 else 8
+
+
+def call(method, path, token, body=None):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(BASE + path, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    if data:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req) as r:
+            raw = r.read()
+            return r.status, (json.loads(raw) if raw else None)
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        try:
+            return e.code, json.loads(raw)
+        except Exception:
+            return e.code, raw[:200].decode(errors="replace")
+
+
+with urllib.request.urlopen(BASE + "/api/v1/auto_login") as r:
+    TOKEN = json.load(r)["access_token"]
+
+tally = Counter()
+lock = threading.Lock()
+leaked = []
+
+
+def worker(w):
+    for i in range(N):
+        st, a = call("POST", "/api/v1/projects/", TOKEN, {"name": f"Probe932 A{w}-{i}"})
+        st2, b = call("POST", "/api/v1/projects/", TOKEN, {"name": f"Probe932 B{w}-{i}"})
+        if not (isinstance(a, dict) and isinstance(b, dict)):
+            with lock:
+                tally["folder_create_failed"] += 1
+            continue
+        st3, flow = call("POST", "/api/v1/flows/", TOKEN, {
+            "name": f"Probe932 f{w}-{i}",
+            "description": "",
+            "folder_id": a["id"],
+            "data": {"nodes": [], "edges": [], "viewport": {"x": 0, "y": 0, "zoom": 1}},
+        })
+        if not isinstance(flow, dict) or "id" not in flow:
+            with lock:
+                tally[f"flow_create_{st3}"] += 1
+            continue
+        st4, patched = call("PATCH", f"/api/v1/flows/{flow['id']}", TOKEN, {"folder_id": b["id"]})
+        st5, got = call("GET", f"/api/v1/flows/{flow['id']}", TOKEN)
+        persisted = isinstance(got, dict) and got.get("folder_id") == b["id"]
+        with lock:
+            tally[f"PATCH {st4}"] += 1
+            if st4 == 200:
+                tally["patch200_persisted" if persisted else "patch200_NOT_persisted"] += 1
+            leaked.append((flow["id"], a["id"], b["id"]))
+
+
+threads = [threading.Thread(target=worker, args=(w,)) for w in range(P)]
+[t.start() for t in threads]
+[t.join() for t in threads]
+
+print(f"--- BASE={BASE} P={P} rounds={N}")
+for k, v in sorted(tally.items()):
+    print(f"{k:28s} x{v}")
+
+# Serial cleanup, retrying once — contention is gone once the threads are done.
+for fid, aid, bid in leaked:
+    call("DELETE", f"/api/v1/flows/{fid}", TOKEN)
+    for pid in (aid, bid):
+        st, _ = call("DELETE", f"/api/v1/projects/{pid}", TOKEN)
+        if st >= 400:
+            call("DELETE", f"/api/v1/projects/{pid}", TOKEN)
+print(f"--- cleanup attempted for {len(leaked)} flows and {2 * len(leaked)} projects")

--- a/docs/upstream-bugs/scripts/scout-965-scope.py
+++ b/docs/upstream-bugs/scripts/scout-965-scope.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Scope #965: is the SQLITE_BUSY-as-500 specific to project DELETE, or does it
+hit every write path? Runs P concurrent clients, each doing N rounds of
+{project POST, project DELETE, flow POST, flow DELETE}, and tallies status codes
+plus the error detail per operation. Cleans up whatever survives."""
+import json
+import sys
+import threading
+import urllib.request
+from collections import Counter
+
+BASE = "http://localhost:7860"
+P = int(sys.argv[1]) if len(sys.argv) > 1 else 2
+N = int(sys.argv[2]) if len(sys.argv) > 2 else 10
+
+def call(method, path, token, body=None):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(BASE + path, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    if data:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req) as r:
+            raw = r.read()
+            return r.status, (json.loads(raw) if raw else None)
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        try:
+            return e.code, json.loads(raw)
+        except Exception:
+            return e.code, raw[:200].decode(errors="replace")
+
+with urllib.request.urlopen(BASE + "/api/v1/auto_login") as r:
+    TOKEN = json.load(r)["access_token"]
+
+tally = Counter()
+details = Counter()
+leaked = {"projects": [], "flows": []}
+lock = threading.Lock()
+
+def record(op, status, body):
+    with lock:
+        tally[(op, status)] += 1
+        if status >= 400:
+            d = body.get("detail") if isinstance(body, dict) else str(body)
+            details[(op, str(d)[:120])] += 1
+
+def worker(w):
+    for i in range(N):
+        st, body = call("POST", "/api/v1/projects/", TOKEN, {"name": f"Scope965 p{w}-{i}"})
+        record("POST /projects", st, body)
+        pid = body.get("id") if isinstance(body, dict) else None
+
+        st, body = call("POST", "/api/v1/flows/", TOKEN, {
+            "name": f"Scope965 f{w}-{i}",
+            "description": "",
+            "data": {"nodes": [], "edges": [], "viewport": {"x": 0, "y": 0, "zoom": 1}},
+        })
+        record("POST /flows", st, body)
+        fid = body.get("id") if isinstance(body, dict) else None
+
+        if fid:
+            st, body = call("DELETE", f"/api/v1/flows/{fid}", TOKEN)
+            record("DELETE /flows", st, body)
+            if st >= 400:
+                with lock:
+                    leaked["flows"].append(fid)
+        if pid:
+            st, body = call("DELETE", f"/api/v1/projects/{pid}", TOKEN)
+            record("DELETE /projects", st, body)
+            if st >= 400:
+                with lock:
+                    leaked["projects"].append(pid)
+
+threads = [threading.Thread(target=worker, args=(w,)) for w in range(P)]
+[t.start() for t in threads]
+[t.join() for t in threads]
+
+print(f"--- P={P} rounds={N}")
+for (op, status), c in sorted(tally.items()):
+    print(f"{op:20s} {status}  x{c}")
+print("--- error details")
+for (op, d), c in details.most_common():
+    print(f"{op:20s} x{c}  {d}")
+
+# Serial cleanup — contention is gone by now, so these succeed.
+for fid in leaked["flows"]:
+    call("DELETE", f"/api/v1/flows/{fid}", TOKEN)
+for pid in leaked["projects"]:
+    call("DELETE", f"/api/v1/projects/{pid}", TOKEN)
+print(f"--- cleaned leaked: {len(leaked['flows'])} flows, {len(leaked['projects'])} projects")

--- a/docs/upstream-bugs/scripts/scout-965-timed.sh
+++ b/docs/upstream-bugs/scripts/scout-965-timed.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Timed variant: records HTTP status AND time_total for every DELETE, so a
+# SQLITE_BUSY that ignores busy_timeout (instant failure) is distinguishable
+# from one that waited out the 30 s timeout.
+BASE=${BASE:-http://localhost:7860}
+P=${1:-8}
+N=${2:-10}
+OUT=${3:-/tmp/scout965-timed.csv}
+TOK=$(curl -s "$BASE/api/v1/auto_login" | python3 -c 'import sys,json;print(json.load(sys.stdin)["access_token"])')
+export TOK BASE N OUT
+: > "$OUT"
+
+worker() {
+  w=$1
+  for i in $(seq 1 "$N"); do
+    id=$(curl -s -X POST "$BASE/api/v1/projects/" -H "Authorization: Bearer $TOK" \
+      -H 'Content-Type: application/json' -d "{\"name\":\"Scout965T w$w-$i-$RANDOM\"}" \
+      | python3 -c 'import sys,json;print(json.load(sys.stdin).get("id",""))' 2>/dev/null)
+    [ -z "$id" ] && { echo "$w,$i,CREATE_FAIL,0,," >> "$OUT"; continue; }
+    out=$(curl -s -w '\n%{http_code},%{time_total}' -X DELETE "$BASE/api/v1/projects/$id" -H "Authorization: Bearer $TOK")
+    meta=$(printf '%s' "$out" | tail -1)
+    body=$(printf '%s' "$out" | sed '$d' | tr -d '\n' | head -c 200)
+    echo "$w,$i,$meta,$id,\"$body\"" >> "$OUT"
+  done
+}
+export -f worker
+seq 1 "$P" | xargs -P "$P" -I{} bash -c 'worker {}'
+python3 - "$OUT" <<'PY'
+import sys, csv
+rows = list(csv.reader(open(sys.argv[1])))
+ok = [r for r in rows if len(r) > 2 and r[2] == '204']
+bad = [r for r in rows if len(r) > 2 and r[2] not in ('204',)]
+def stat(rs):
+    ts = [float(r[3]) for r in rs if len(r) > 3 and r[3] not in ('', '0')]
+    return (min(ts), sum(ts)/len(ts), max(ts)) if ts else (0, 0, 0)
+print(f"total={len(rows)} ok204={len(ok)} failed={len(bad)}")
+print("ok   time_total  min/avg/max: %.2f / %.2f / %.2f s" % stat(ok))
+print("fail time_total  min/avg/max: %.2f / %.2f / %.2f s" % stat(bad))
+codes = {}
+for r in bad:
+    codes[r[2]] = codes.get(r[2], 0) + 1
+print("failure codes:", codes)
+PY

--- a/docs/upstream-bugs/scripts/ui-delete-loop.sh
+++ b/docs/upstream-bugs/scripts/ui-delete-loop.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Does a user ever SEE the #965 failure, or does a client-side retry hide it?
+#
+# The prior SQLite-lock finding in REGRESSIONS.md was downgraded to
+# "non-user-facing robustness gap" because a client retry masked the 500. This
+# loop tests that claim for the project-delete path: create a project via the
+# API, delete it through the real UI while write contention runs, and classify
+# the outcome by what the USER perceives — the toast, the notification centre,
+# and whether the project is still there afterwards.
+#
+# Outcomes:
+#   SUCCESS        — project gone, success toast (with or without a masked 500)
+#   SILENT-FAILURE — project still there, no toast and no notification
+#   VISIBLE-ERROR  — project still there, but the UI said so
+BASE=${BASE:-http://localhost:7862}
+N=${1:-8}
+PW="npx --no-install playwright-cli"
+TOK=$(curl -s "$BASE/api/v1/auto_login" | python3 -c 'import sys,json;print(json.load(sys.stdin)["access_token"])')
+
+for i in $(seq 1 "$N"); do
+  name="ZZDEL$i"
+  slug=$(printf '%s' "$name" | tr 'A-Z' 'a-z')
+  id=$(curl -s -X POST "$BASE/api/v1/projects/" -H "Authorization: Bearer $TOK" \
+    -H 'Content-Type: application/json' -d "{\"name\":\"$name\"}" \
+    | python3 -c 'import sys,json;print(json.load(sys.stdin)["id"])')
+
+  $PW press Escape >/dev/null 2>&1
+  $PW reload >/dev/null 2>&1
+  sleep 2
+  present=$($PW --raw eval "() => !!document.querySelector('[data-testid=\"more-options-button_$slug\"]')" 2>/dev/null | tr -d '\n ')
+  if [ "$present" != "true" ]; then
+    echo "iter $i | SKIPPED — row never rendered (list still loading under contention)"
+    curl -s -o /dev/null -X DELETE "$BASE/api/v1/projects/$id" -H "Authorization: Bearer $TOK"
+    continue
+  fi
+
+  # Each click needs the previous surface to be mounted: the row menu is a
+  # Radix popover and the confirmation is a modal, so firing them back-to-back
+  # silently no-ops (observed: 0 DELETE calls for 8 iterations).
+  $PW click "getByTestId('more-options-button_$slug')" >/dev/null 2>&1
+  sleep 1
+  $PW click "getByTestId('btn-delete-project')" >/dev/null 2>&1
+  sleep 1
+  $PW click "getByTestId('btn_delete_delete_confirmation_modal')" >/dev/null 2>&1
+  sleep 5
+
+  calls=$($PW --raw requests 2>/dev/null | grep -c "DELETE.*projects/$id")
+  fails=$($PW --raw requests 2>/dev/null | grep "DELETE.*projects/$id" | grep -c "500")
+  feedback=$($PW --raw eval "() => document.body.innerText.split('\n').map(s=>s.trim()).filter(l => /deleted|error|wrong|fail/i.test(l)).slice(0,2).join(' / ')" 2>/dev/null | tr -d '\n' | sed 's/^\"//; s/\"$//')
+  gone=$(curl -s -o /dev/null -w '%{http_code}' "$BASE/api/v1/projects/$id" -H "Authorization: Bearer $TOK")
+
+  if [ "$gone" = "404" ]; then
+    verdict="SUCCESS$([ "$fails" -gt 0 ] && echo ' (500 masked by retry)')"
+  elif [ -n "$feedback" ]; then
+    verdict="VISIBLE-ERROR"
+  else
+    verdict="SILENT-FAILURE"
+  fi
+  echo "iter $i | $verdict | DELETE calls=$calls (500s=$fails) | GET after=$gone | ui text: ${feedback:-<none>}"
+  [ "$gone" != "404" ] && curl -s -o /dev/null -X DELETE "$BASE/api/v1/projects/$id" -H "Authorization: Bearer $TOK"
+done

--- a/tests/helpers/flows/delete-project.ts
+++ b/tests/helpers/flows/delete-project.ts
@@ -1,0 +1,76 @@
+import type { APIRequestContext } from "@playwright/test";
+
+/**
+ * Deletes a project (folder) via the Langflow REST API and surfaces a failed
+ * deletion — the project-level sibling of `deleteFlow`.
+ *
+ * Why a helper instead of `request.delete(...).catch(() => {})`: on Langflow
+ * 1.12 `DELETE /api/v1/projects/{id}` answers **500** — not the documented
+ * `204` — whenever another write transaction is in flight, and the project
+ * survives (#965; `(sqlite3.OperationalError) database is locked` on
+ * `DELETE FROM folder`). Measured on `1.12.0.dev7` with only 2 concurrent
+ * clients, 44% of deletes came back 500. Under `fullyParallel` that contention
+ * is normal, so every cleanup site that ignored the status was silently
+ * accumulating orphan projects on the instance — one per failed teardown,
+ * forever.
+ *
+ * The retry here is cleanup robustness, NOT a workaround for the defect: the
+ * assertion in `api/flows/api-folders-crud.spec.ts` still demands a bare `204`
+ * from the endpoint under test, and that test stays quarantined until the
+ * upstream fix lands. See `docs/api/flows/api-folders-crud.md` and
+ * `docs/upstream-bugs/UPSTREAM-BUG-project-delete-500-under-contention.md`.
+ *
+ * Contract, mirroring `deleteFlow` so the two can't drift:
+ *  - `2xx` or `404` (already gone) is the desired idempotent end state;
+ *  - a non-5xx error is deterministic (401/403/422/…) — it won't change on
+ *    retry, so it throws immediately with the original body;
+ *  - a 5xx is retried on a short backoff (the lock clears in milliseconds once
+ *    the competing writer commits) before throwing.
+ *
+ * Pass `page.request` (browser-context auth is reused automatically) or a
+ * standalone `request` with an explicit Authorization header via
+ * `options.headers`.
+ *
+ * @param request  A Playwright `APIRequestContext` (`page.request` or the `request` fixture).
+ * @param id       The project (folder) ID to delete.
+ * @param options  Optional Playwright request options (same shape as `request.delete`'s), e.g. `{ headers: { Authorization } }`.
+ */
+export async function deleteProject(
+  request: APIRequestContext,
+  id: string,
+  options?: Parameters<APIRequestContext["delete"]>[1],
+): Promise<void> {
+  const url = `/api/v1/projects/${id}`;
+  const isDone = (r: { ok(): boolean; status(): number }) =>
+    r.ok() || r.status() === 404;
+
+  // 3 attempts total: enough for the #965 lock window (a competing write
+  // commits in milliseconds) without turning a genuinely broken teardown into a
+  // multi-second stall.
+  const MAX_ATTEMPTS = 3;
+  const BACKOFF_MS = 250;
+
+  let last: { status(): number; text(): Promise<string> } | undefined;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const res = await request.delete(url, options);
+    if (isDone(res)) return;
+    last = res;
+    if (res.status() < 500) {
+      throw new Error(
+        `Project cleanup failed: ${res.status()} — ${await res.text()}`,
+      );
+    }
+    if (attempt < MAX_ATTEMPTS) {
+      // Surfaced in stdout so a run's artifacts show how often the #965 defect
+      // fired during teardown, instead of the retry hiding it entirely.
+      console.warn(
+        `⚠️ Project cleanup got ${res.status()} for ${id} (attempt ${attempt}/${MAX_ATTEMPTS}) — retrying`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, BACKOFF_MS));
+    }
+  }
+
+  throw new Error(
+    `Project cleanup failed after ${MAX_ATTEMPTS} attempts: ${last?.status()} — ${await last?.text()}`,
+  );
+}

--- a/tests/tests-automations/regression/api/flows/api-folders-crud.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-folders-crud.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { deleteProject } from "../../../../helpers/flows/delete-project";
 
 // Folders use the /api/v1/projects/ endpoint (legacy alias kept for compatibility)
 test.describe("Folder (Projects) CRUD via API", () => {
@@ -19,10 +20,16 @@ test.describe("Folder (Projects) CRUD via API", () => {
       await deleteFlow(request, id, { headers: { Authorization: authToken } });
     }
     for (const id of createdFolderIds) {
-      // request.delete resolves on any status and 404 (already gone) is the
-      // desired idempotent end state, so no throw/catch is needed here.
-      await request.delete(`/api/v1/projects/${id}`, {
+      // deleteProject, not a bare request.delete: the endpoint answers 500
+      // instead of 204 under concurrent writes (#965, a product defect), and a
+      // bare call resolves on any status — so every such teardown used to leave
+      // a permanent orphan project behind. The helper verifies the deletion and
+      // retries the transient 5xx; a still-failing cleanup is logged rather than
+      // failing this hook, so it can never mask the assertion that already ran.
+      await deleteProject(request, id, {
         headers: { Authorization: authToken },
+      }).catch((error) => {
+        console.warn(`⚠️ Orphan project left behind (${id}): ${error}`);
       });
     }
     createdFlowIds.length = 0;

--- a/tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts
@@ -3,6 +3,7 @@ import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-te
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { createFlow } from "../../../../helpers/flows/create-flow";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { deleteProject } from "../../../../helpers/flows/delete-project";
 
 test(
   "user should be able to select flows with different methods and perform bulk actions",
@@ -190,10 +191,14 @@ test(
           }
         }
         // Delete the dedicated folder last (its flows are already gone above).
+        // deleteProject retries the 500 the endpoint returns under concurrent
+        // writes (#965), which a bare request.delete silently accepted.
         if (folderId) {
-          await request
-            .delete(`/api/v1/projects/${folderId}`, { headers })
-            .catch(() => {});
+          await deleteProject(request, folderId, { headers }).catch((error) => {
+            console.warn(
+              `⚠️ Orphan project left behind (${folderId}): ${error}`,
+            );
+          });
         }
       } catch {
         // Cleanup is best-effort — do not mask the original test failure.

--- a/tests/tests-automations/regression/core-functionality/project-management/flow-navigation-between-folders.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/flow-navigation-between-folders.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { deleteProject } from "../../../../helpers/flows/delete-project";
 import { MainPage } from "../../../../pages/MainPage";
 
 /**
@@ -101,11 +102,14 @@ test(
     } finally {
       if (flowAId) await deleteFlow(request, flowAId, { headers });
       if (flowBId) await deleteFlow(request, flowBId, { headers });
-      if (folderAId) {
-        await request.delete(`/api/v1/projects/${folderAId}`, { headers }).catch(() => {});
-      }
-      if (folderBId) {
-        await request.delete(`/api/v1/projects/${folderBId}`, { headers }).catch(() => {});
+      // deleteProject retries the 500 the endpoint returns under concurrent
+      // writes (#965) — the bare request.delete here resolved on that status and
+      // left both folders on the instance permanently.
+      for (const folderId of [folderAId, folderBId]) {
+        if (!folderId) continue;
+        await deleteProject(request, folderId, { headers }).catch((error) => {
+          console.warn(`⚠️ Orphan project left behind (${folderId}): ${error}`);
+        });
       }
     }
   },

--- a/tests/tests-automations/regression/core-functionality/project-management/folder-crud.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/folder-crud.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { deleteProject } from "../../../../helpers/flows/delete-project";
 import { MainPage } from "../../../../pages/MainPage";
 
 /**
@@ -127,11 +128,14 @@ test(
         }).catch(() => {});
       }
       if (!folderDeleted) {
-        await request
-          .delete(`/api/v1/projects/${folderId}`, {
-            headers: { Authorization: authToken },
-          })
-          .catch(() => {});
+        // deleteProject retries the 500 the endpoint returns under concurrent
+        // writes (#965) — a bare request.delete resolved on that status and left
+        // the folder behind for good.
+        await deleteProject(request, folderId, {
+          headers: { Authorization: authToken },
+        }).catch((error) => {
+          console.warn(`⚠️ Orphan project left behind (${folderId}): ${error}`);
+        });
       }
     }
   },

--- a/tests/tests-automations/regression/core-functionality/project-management/folder-deletion-integrity.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/folder-deletion-integrity.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteProject } from "../../../../helpers/flows/delete-project";
 import { MainPage } from "../../../../pages/MainPage";
 
 /**
@@ -61,11 +62,13 @@ test(
       });
     } finally {
       if (!folderDeleted) {
-        await request
-          .delete(`/api/v1/projects/${folderId}`, {
-            headers: { Authorization: authToken },
-          })
-          .catch(() => {});
+        // deleteProject retries the 500 the endpoint returns under concurrent
+        // writes (#965), which the bare request.delete accepted as done.
+        await deleteProject(request, folderId, {
+          headers: { Authorization: authToken },
+        }).catch((error) => {
+          console.warn(`⚠️ Orphan project left behind (${folderId}): ${error}`);
+        });
       }
     }
   },


### PR DESCRIPTION
Works [#965](https://github.com/oriontech-me/langflow-e2e/issues/965) (`daily-failure`, off-wave exception). **`Refs`, not `Closes`** — the root cause is a product defect and the issue's own criteria keep it open until the upstream fix lands on the nightly.

## Verdict — `langflow-regression` (product defect confirmed live), not a test defect

`DELETE /api/v1/projects/{id}` is declared `status_code=204` but answers **`500`** whenever another write transaction is in flight, and **the project is not deleted**:

```json
{"detail":"(sqlite3.OperationalError) database is locked\n[SQL: DELETE FROM folder WHERE folder.id = ?]\n[parameters: ('0913fdcdc2bd4f68bfa26d8ed3f0fc83',)]..."}
```

Why it is the endpoint and not "SQLite being SQLite" — same P=2 contention, 12 rounds:

| Endpoint | Result |
|---|---|
| `POST /api/v1/projects/` | 24/24 → `201` |
| `POST /api/v1/flows/` | 24/24 → `201` |
| `DELETE /api/v1/flows/{id}` | 24/24 → `200` |
| `DELETE /api/v1/projects/{id}` | 13/24 → `204`, **11/24 → `500`** |

`busy_timeout` **is** set (30 000 ms) with WAL active, yet failures return in ~0.03 s — the busy handler never engages on this path. `delete_project` funnels every exception into `HTTPException(500, str(e))` and only `DeploymentGuardError` is retried.

**Not a new defect, but ~7× worse on 1.12** (A/B/A/B, one arm at a time, 3 alternations, P=2, 30 deletes/round, orphans purged between rounds):

| Build | `204` | `500` | median latency of a failure |
|---|---|---|---|
| stable `1.10.3` | 66/90 | **5 (6 %)** | 1.80 s |
| nightly `1.12.0.dev7` | 50/90 | **40 (44 %)** | 0.03 s |

`delete_project` and `services/database/service.py` are byte-identical between the two builds, as are SQLAlchemy 2.0.51 / aiosqlite 0.22.1 / SQLite 3.46.1 — the rate change is reproducible but **not explained at code level**, and the report says so instead of guessing.

**Is it user-facing?** Tested, because a sibling SQLite-lock finding was previously downgraded in `REGRESSIONS.md` on the grounds that a client retry masks it. At 2 background writers that defence holds — 6/6 UI deletes succeeded, 2 via a masked retry. At 4 writers the retry budget is exhausted: the project stays in the sidebar with **no toast and an empty notification centre**, only a console error. The silent no-op is the user-facing part.

**#932 settled — separate causes, both stay open.** Under contention `PATCH /api/v1/flows/{id}` also 500s (7/20 at P=2, 27/32 at P=4), but **every** `PATCH` that returned `200` had persisted the new `folder_id` (13/13 and 5/5). #932's symptom (`200` + stale association) is not produced by contention.

## What this PR changes

The broken assertion is **untouched** — `expect(deleteRes.status()).toBe(204)` stays bare and the test stays `test.fixme` without `@stable`. What is fixed is our own fallout: five cleanup sites issued `request.delete(...)` and ignored the status, so every failed teardown left a permanent orphan project.

- **`tests/helpers/flows/delete-project.ts`** (new) — mirrors `delete-flow.ts`: `2xx`/`404` is the idempotent end state, a deterministic `4xx` throws immediately, a transient `5xx` is retried on a 250 ms backoff (3 attempts), and each retry is logged so run artifacts show how often the defect fired.
- **Adopted at the 5 sites**: `api-folders-crud`, `folder-crud`, `bulk-actions`, `flow-navigation-between-folders`, `folder-deletion-integrity`. Cleanup failures are logged, never thrown, so they cannot mask an assertion that already ran.
- **Docs**: the spec doc gains the defect, the A/B table, the #932 verdict and a concrete quarantine-lift criterion (0 of 90 deletes non-`204` under the same script). `QA-CHECKLIST.md` marks the two quarantined bullets `[!]` with their issue pointers.
- **Evidence**: `docs/upstream-bugs/UPSTREAM-BUG-project-delete-500-under-contention.md` + the 6 reproduction scripts under `docs/upstream-bugs/scripts/`, and a `REGRESSIONS.md` **Candidates** row (no ticket filed yet, so not counted in the indicator).

## Validation

Langflow `1.12.0.dev7` (burst) and `1.12.0.dev8` (re-checks) — `langflowai/langflow-nightly:latest`, fresh container, `LANGFLOW_WORKERS=1`.

- **VALIDATE burst** (`--retries=0 --workers=1`, 3×): `api-folders-crud` 3/3, `bulk-actions` 3/3, `flow-navigation-between-folders` 3/3, `folder-crud` 3/3 — all `unexpected=0 flaky=0 backendErrors=false`. `typecheck=0 lint=0`, QA-CHECKLIST guard ok.
- **FORCE_FAIL — 10/10.** Every active `test()` in all five specs was mutated one assertion at a time (marked `// FF-MUTATION`), proven red at `--retries=0 --workers=1`, then restored byte-for-byte and re-run green.
- **Behavioral cleanup force-fail.** With `deleteProject()` no-op'd, `api-folders-crud` still passed but left **2 orphan projects** (`Test Folder …`, `List Folder …`); with the helper restored, **0**. The cleanup is load-bearing.
- **Instance clean afterwards**: `GET /api/v1/projects/` → 0, `GET /api/v1/flows/` → 0.

### Known blocker, pre-existing and now tracked

`folder-deletion-integrity.spec.ts` logs `🚨 Backend Error: 422` for `GET /api/v1/projects/undefined` (the frontend fires the flows query with an `undefined` project id once the last project is deleted). All 4 tests pass, but the deterministic pipeline treats `backendErrors=true` as a hard stop, so **#965's pipeline is parked at VALIDATE by design** and this PR was opened outside the gate, with the user's authorization.

Attribution is measured, not assumed: reverting this PR's diff for that file (`git stash push -- <spec>`) reproduces the identical 422 with `4 passed`; the failing request is a frontend `GET`, not a helper call; and it reproduces on both `dev7` and `dev8`. Isolated per test, only *"deleting every folder lands on the empty project screen"* emits it (1/1; the other three 0/1). Filed as [#1008](https://github.com/oriontech-me/langflow-e2e/issues/1008).

## Follow-ups

- **#965 stays open** until the upstream fix lands on `langflowai/langflow-nightly:latest`; then re-validate, lift `test.fixme`, restore `@stable`, and flip the checklist bullet from `[!]` to `[x]`.
- Jira card for the product defect still to be filed; the `REGRESSIONS.md` row moves from **Candidates** to the **Ledger** once it has a `LE-####`.
- #1008 owns the 422 that blocks the gate for any PR touching `folder-deletion-integrity.spec.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)