### PR TITLE
docs(regressions): promote the project-delete 500 to the Ledger as LE-2020 (#965)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -103,7 +103,7 @@
 #### 1.3.1 Folder (Project) CRUD via API
 - [x] POST `/api/v1/projects/` → creates folder, returns id and name → `api/flows/api-folders-crud.spec.ts`
 - [x] GET `/api/v1/projects/` → lists folders including the created one → `api/flows/api-folders-crud.spec.ts`
-- [!] DELETE `/api/v1/projects/{id}` → returns 204 and the folder leaves the listing — quarantined (#965): under concurrent writes the endpoint answers **500** (`sqlite3.OperationalError: database is locked`) and the folder survives; measured 44% of deletes on `1.12.0.dev7` vs 6% on stable `1.10.3` at the same 2-client contention. Product defect, upstream card pending; the `204` assertion is unchanged → `api/flows/api-folders-crud.spec.ts`
+- [!] DELETE `/api/v1/projects/{id}` → returns 204 and the folder leaves the listing — quarantined (#965): under concurrent writes the endpoint answers **500** (`sqlite3.OperationalError: database is locked`) and the folder survives; measured 44% of deletes on `1.12.0.dev7` vs 6% on stable `1.10.3` at the same 2-client contention. Product defect filed as [LE-2020](https://datastax.jira.com/browse/LE-2020); the `204` assertion is unchanged → `api/flows/api-folders-crud.spec.ts`
 
 #### 1.4 Components via API
 - [x] GET `/api/v1/all` → lists all available components → `api/flows/api-custom-component-creation.spec.ts`

--- a/REGRESSIONS.md
+++ b/REGRESSIONS.md
@@ -36,22 +36,33 @@ issue that carries the evidence. Both shapes are allowed; what is not allowed is
 a reference that does not resolve.
 
 <!-- REGRESSIONS:START -->
-**Regressions caught:** 5 — **Open:** 2 · **Fixed:** 3
+**Regressions caught:** 6 — **Open:** 3 · **Fixed:** 3
 
-**By severity:** High 2 · Medium 3 · Low 0
+**By severity:** High 2 · Medium 4 · Low 0
 
-**By area:** model-provider 2 · auth 1 · flows 1 · mcp 1
+**By area:** model-provider 2 · api 1 · auth 1 · flows 1 · mcp 1
 <!-- REGRESSIONS:END -->
 
 ## Ledger
 
 | Found | Area / Test | Regression | Severity | Detected by | Upstream | Status | Fixed in | Report |
 |-------|-------------|------------|----------|-------------|----------|--------|----------|--------|
+| 2026-07-27 | api · api-folders-crud.spec.ts | `DELETE /api/v1/projects/{id}` answers `500` (`sqlite3.OperationalError: database is locked`) instead of `204` while any other write is in flight, and the project survives. Not new — stable 1.10.3 emits the same instant `500` — but 1.12 raises the rate ~7× (6 % → 44 % at 2 concurrent clients, A/B/A/B) and flips the mode: 1.10.3 blocks and mostly honours the contract, 1.12 gives up in 0.03 s. Sibling write endpoints (`POST /projects`, `POST /flows`, `DELETE /flows`) survive the identical contention | Medium | daily 07-22 + 07-27 · #962 → #965 | [LE-2020](https://datastax.jira.com/browse/LE-2020) | Open | — | docs/upstream-bugs/UPSTREAM-BUG-project-delete-500-under-contention.md |
 | 2026-07-27 | flows · run-flow.spec.ts | "New Flow" click is silently dropped when the flows list has not painted its cards yet — no navigation, no modal, no console error, and the button then stops being actionable until a reload. Introduced in 1.10.1 by langflow#12575; 1.10.0 opened the templates modal and created nothing | Medium | daily 07-27 · #962 → #966 | [LE-2019](https://datastax.jira.com/browse/LE-2019) | Open | — | docs/upstream-bugs/UPSTREAM-BUG-new-flow-dead-click.md |
 | 2026-07-24 | mcp · mcp-server-resources.spec.ts | MCP `resources/read` crashes with `AttributeError: 'str' object has no attribute 'hex'` — the project server advertises a flow file it cannot itself read (worked on 1.11.0) | Medium | #948 spec validation | [LE-2012](https://datastax.jira.com/browse/LE-2012) | Open | — | docs/upstream-bugs/UPSTREAM-BUG-mcp-resources-read-uuid-hex.log |
 | 2026-07-23 | model-provider · groq-provider.spec.ts | Groq / Mistral / Ollama components silently hidden from the sidebar — the image ships the component source but not the provider's `langchain-*` package, and Langflow now hides the component with no message | Medium | daily 07-23 · #907 | [LE-1987](https://datastax.jira.com/browse/LE-1987) | Fixed | [langflow#14248](https://github.com/langflow-ai/langflow/pull/14248) | #907 |
 | 2026-07-22 | model-provider · google-provider.spec.ts | Nightly ships without `langchain-google-genai` — every Google chat/embedding model raises ImportError at build; surfaced as node-build timeouts across ~17 `@stable` specs | High | daily 07-22 · #898 | [LE-1974](https://datastax.jira.com/browse/LE-1974) | Fixed | [langflow#14220](https://github.com/langflow-ai/langflow/pull/14220) | #898 |
 | 2026-07-17 | auth · logout-flow.spec.ts | Logout does not terminate the session — no redirect to login, no `POST /api/v1/logout` fired, and `POST /api/v1/refresh` silently re-authenticates so the session survives a reload | High | daily 07-17 · #808 | [LE-1850](https://datastax.jira.com/browse/LE-1850) | Fixed | [langflow#14158](https://github.com/langflow-ai/langflow/pull/14158) | #808 |
+
+Note on the LE-2020 row, so the earlier adjudication is not re-litigated blindly:
+the *Bulk-flow-delete SQLite-lock 500* entry under *Not listed* was downgraded
+because a client-side retry masked the failure. That defence was re-tested for
+this row and holds **only at light contention** — 6/6 UI deletes succeeded at 2
+background writers, 2 of them via a masked retry. With 4 writers the retry budget
+is exhausted and the delete **silently no-ops**: project still in the sidebar, no
+toast, notification centre empty, only a console error. That silent no-op is what
+makes the row user-facing; it is Medium, not High, because it needs sustained
+concurrent writes.
 
 ## Candidates — pending upstream ticket
 
@@ -60,16 +71,9 @@ moment a ticket is filed. Not counted in the indicator.
 
 | Found | Area / Test | Regression | Severity | Report |
 |-------|-------------|------------|----------|--------|
-| 2026-07-27 | api · api-folders-crud.spec.ts | `DELETE /api/v1/projects/{id}` answers `500` (`sqlite3.OperationalError: database is locked`) instead of `204` while any other write is in flight, and the project survives. Not new — stable 1.10.3 emits the same instant `500` — but 1.12 raises the rate ~7× (6 % → 44 % at 2 concurrent clients, A/B/A/B) and flips the mode: 1.10.3 blocks and mostly honours the contract, 1.12 gives up in 0.03 s. Sibling write endpoints (`POST /projects`, `POST /flows`, `DELETE /flows`) survive the identical contention | Medium | docs/upstream-bugs/UPSTREAM-BUG-project-delete-500-under-contention.md |
 
-Note on the row above, so the earlier adjudication is not re-litigated blindly:
-the *Bulk-flow-delete SQLite-lock 500* entry below was downgraded because a
-client-side retry masked the failure. That defence was re-tested here and holds
-**only at light contention** — 6/6 UI deletes succeeded at 2 background writers,
-2 of them via a masked retry. With 4 writers the retry budget is exhausted and
-the delete **silently no-ops**: project still in the sidebar, no toast, notification
-centre empty, only a console error. That silent no-op is what makes this row
-user-facing; it is Medium, not High, because it needs sustained concurrent writes.
+*(none — the project-delete 500 was promoted to the Ledger on 2026-07-28 when
+LE-2020 was filed.)*
 
 ## Not listed — validated non-regression
 

--- a/docs/api/flows/api-folders-crud.md
+++ b/docs/api/flows/api-folders-crud.md
@@ -137,7 +137,8 @@ SQLAlchemy 2.0.51 / aiosqlite 0.22.1 / SQLite 3.46.1 — the rate change is
 reproducible but **not explained at code level**, and the upstream report says so
 explicitly.
 
-Filed upstream: see `docs/upstream-bugs/UPSTREAM-BUG-project-delete-500-under-contention.md`.
+Filed upstream as **[LE-2020](https://datastax.jira.com/browse/LE-2020)** — full evidence
+in `docs/upstream-bugs/UPSTREAM-BUG-project-delete-500-under-contention.md`.
 
 ## Relationship between #965 and #932 — separate causes, both stay
 

--- a/docs/upstream-bugs/UPSTREAM-BUG-project-delete-500-under-contention.md
+++ b/docs/upstream-bugs/UPSTREAM-BUG-project-delete-500-under-contention.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Filed upstream** | *pending — Jira card to be opened* |
+| **Filed upstream** | [LE-2020](https://datastax.jira.com/browse/LE-2020) (filed 2026-07-28) |
 | **Repo issue** | [oriontech-me/langflow-e2e#965](https://github.com/oriontech-me/langflow-e2e/issues/965) (spun out of daily triage #962) |
 | **Affected builds** | `langflowai/langflow-nightly:latest` → `1.12.0.dev6` and `1.12.0.dev7`; reproduced at a lower rate on stable `langflowai/langflow:latest` → `1.10.3` |
 | **Component** | `src/backend/base/langflow/api/v1/projects.py` → `delete_project` |

--- a/tests/helpers/flows/delete-project.ts
+++ b/tests/helpers/flows/delete-project.ts
@@ -17,7 +17,7 @@ import type { APIRequestContext } from "@playwright/test";
  * The retry here is cleanup robustness, NOT a workaround for the defect: the
  * assertion in `api/flows/api-folders-crud.spec.ts` still demands a bare `204`
  * from the endpoint under test, and that test stays quarantined until the
- * upstream fix lands. See `docs/api/flows/api-folders-crud.md` and
+ * upstream fix for LE-2020 lands. See `docs/api/flows/api-folders-crud.md` and
  * `docs/upstream-bugs/UPSTREAM-BUG-project-delete-500-under-contention.md`.
  *
  * Contract, mirroring `deleteFlow` so the two can't drift:

--- a/tests/tests-automations/regression/api/flows/api-folders-crud.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-folders-crud.spec.ts
@@ -87,7 +87,13 @@ test.describe("Folder (Projects) CRUD via API", () => {
   );
 
   // Quarantined for #965 — recurrent flake (2026-07-22 / 07-27): the DELETE
-  // answers HTTP 500 where the contract expects 204 No Content.
+  // answers HTTP 500 (`sqlite3.OperationalError: database is locked`) where the
+  // contract expects 204 No Content, and the folder survives. Product defect,
+  // filed upstream as LE-2020 (https://datastax.jira.com/browse/LE-2020); the
+  // 204 assertion below stays bare and this stays `test.fixme` without @stable
+  // until the fix reaches `langflowai/langflow-nightly:latest`. Evidence and the
+  // reproduction scripts: docs/api/flows/api-folders-crud.md §"Known product
+  // defect" and docs/upstream-bugs/.
   test.fixme(
     "DELETE removes folder and it no longer appears in listing",
     { tag: ["@release", "@api", "@regression"] },


### PR DESCRIPTION
Follow-up to #1009. The product defect behind [#965](https://github.com/oriontech-me/langflow-e2e/issues/965) is now filed as **[LE-2020](https://datastax.jira.com/browse/LE-2020)**, which is the missing condition for a Ledger row, so the finding moves out of **Candidates**.

`DELETE /api/v1/projects/{id}` answers `500` (`sqlite3.OperationalError: database is locked`) instead of `204` whenever another write is in flight, and the project survives. Not new — stable `1.10.3` emits the same instant `500` — but `1.12` raises the rate ~7× (6 % → 44 % at 2 concurrent clients, measured A/B/A/B) and flips the failure mode from block-and-honour-the-contract to fail-fast-and-lose-the-delete.

## Changes

- **`REGRESSIONS.md`** — Ledger row with `daily 07-22 + 07-27 · #962 → #965` as *Detected by* and LE-2020 as *Upstream*; Candidates back to empty with the usual promotion note. The generated block was regenerated with `npm run regressions:summary` and is committed as the convention requires: **6 regressions — Open 3 · Fixed 3**, severity High 2 · Medium 4, area gains `api 1`.
- **The adjudication note travels with the row.** It records why the masked-retry defence that downgraded the sibling *Bulk-flow-delete SQLite-lock 500* entry does **not** exonerate this one: at 2 background writers the retry does mask it (6/6 UI deletes succeeded), but at 4 writers the retry budget is exhausted and the delete **silently no-ops** — project still in the sidebar, no toast, notification centre empty, only a console error. Leaving that note under an empty Candidates table would have orphaned it.
- **Ticket pointers** where a reader lands first: the spec doc's *Known product defect* section, the `QA-CHECKLIST.md` bullet, the `test.fixme` comment in `api-folders-crud.spec.ts`, and the `deleteProject()` JSDoc.
- Report metadata: `Filed upstream: pending` → LE-2020.

## Validation

- `npm run regressions:check` → *indicator is in sync with the table (6 regression(s))*
- `node scripts/check-checklist-guard.mjs` → *no auto-generated blocks were edited by this PR*
- `npm run typecheck` → 0 errors · `npm run lint` → 0 errors
- No test behavior changed: the `204` assertion stays bare and the test stays `test.fixme` without `@stable`. **#965 stays open** until the LE-2020 fix reaches `langflowai/langflow-nightly:latest`; then re-validate, lift the quarantine, restore `@stable`, and flip the checklist bullet `[!]` → `[x]`.

Refs #965

🤖 Generated with [Claude Code](https://claude.com/claude-code)