### PR TITLE
test(webhook): lift the flow-persistence quarantine with an authenticated read (#990)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -224,7 +224,7 @@
 
 #### 3.4 Webhook
 - [x] POST aceita JSON e text/plain retornando 202 com `status: "in progress"` → `core-components/webhook-component-regression.spec.ts`
-- [!] Flow salvo no banco contém o nó Webhook com endpoint="BACKEND_URL" → `core-components/webhook-component-regression.spec.ts` (fixme — upstream Accept-Language TypeError, see #165 item 2)
+- [x] Flow salvo no banco contém o nó Webhook com endpoint="BACKEND_URL" → `core-components/webhook-component-regression.spec.ts` (quarentena de 2½ meses liberada em #990: o teste lia o flow via `page.evaluate(fetch)` e tropeçava no defeito do interceptor de `window.fetch` do frontend; agora lê via `request.get` autenticado)
 - [x] Campo cURL no inspector mostra URL válida com flow ID e flags corretas (`-X POST`, `Content-Type`, `-d`) → `core-components/webhook-component-regression.spec.ts`
 - [x] Data field vazia retorna objeto Data vazio `{}` ao executar → `core-components/webhook-component-regression.spec.ts`
 - [x] Campo endpoint (`str_endpoint`) renderiza a URL real do webhook → `core-components/webhook-component-regression.spec.ts`

--- a/docs/core-components/webhook-component-regression.md
+++ b/docs/core-components/webhook-component-regression.md
@@ -1,6 +1,6 @@
 # Webhook Component — Regression
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x (`1.12.0.dev8`)
 
 ---
 
@@ -11,7 +11,7 @@ Validates the full surface of the Webhook component: rendering on the canvas, HT
 The 10 tests cover:
 
 1. **HTTP POST — JSON and plain-text bodies** — the endpoint accepts both `application/json` and `text/plain` bodies, returning 202 with `{"status": "in progress"}` in both cases.
-2. **Flow persistence** — after autosave, the flow is retrievable via `GET /api/v1/flows/{id}` and contains a Webhook node whose `endpoint.value` stores the `"BACKEND_URL"` placeholder (substituted by the frontend at render time).
+2. **Flow persistence** — after autosave, the flow is retrievable via `GET /api/v1/flows/{id}` (read with an authenticated `request.get`, see the note below) and contains a Webhook node whose `endpoint.value` stores the `"BACKEND_URL"` placeholder (substituted by the frontend at render time).
 3. **cURL inspector field** — the inspector panel shows a pre-filled cURL command with `-X POST`, the correct `/api/v1/webhook/{flowId}` URL, `Content-Type: application/json`, and `-d`.
 4. **Empty data field** — running the component with no payload produces `{}` in the output inspection modal (`build_data()` short-circuit path).
 5. **Endpoint field renders real URL** — the `str_endpoint` field shows the actual webhook URL (protocol + host + `/api/v1/webhook/`), confirming the `BACKEND_URL` placeholder was resolved by the frontend.
@@ -29,9 +29,20 @@ If any of these tests fails, the Webhook component is broken in one of its core 
 
 `@stable` `@release` `@regression`
 
-**`@stable` exceptions:**
+All 10 tests carry `@stable`. There are no exceptions.
 
-- **Test 2** (`flow is saved to database and contains the Webhook node`) does **not** carry `@stable` — removed in the triage of weekly run [25663131100](https://github.com/oriontech-me/langflow-e2e/actions/runs/25663131100) (issue #206) after the same upstream regression first observed in [25441253323](https://github.com/oriontech-me/langflow-e2e/actions/runs/25441253323) recurred on three consecutive attempts. The Langflow frontend bundle wraps `window.fetch` and the wrapper throws `Cannot set properties of undefined (setting 'Accept-Language')` when `fetch()` is called from `page.evaluate` without a `headers` init. Tracked in #180; tag is restored once upstream is fixed and one weekly cycle passes clean.
+**Test 2 was quarantined and is no longer** (#990). Between 2026-05-11 and
+2026-07-28 test 2 ran as `test.fixme` without `@stable`: it read the persisted
+flow with `page.evaluate(fetch)`, and the Langflow frontend bundle's `fetch`
+wrapper throws `TypeError: Cannot set properties of undefined (setting
+'Accept-Language')` on that call. The quarantine was hung on an upstream fix that
+was **never requested** — #180 was closed with all four of its own criteria
+unchecked, the first being "upstream issue filed", so the test waited 2½ months
+for an event nobody triggered. The frontend defect is real and still present on
+`1.12.0.dev8` (see *The frontend `fetch` wrapper defect* below), but it is not
+this test's subject: test 2 asserts flow persistence and the `BACKEND_URL`
+placeholder, and reads the flow through an authenticated `request.get` instead —
+which never enters the buggy wrapper.
 
 ---
 
@@ -60,7 +71,11 @@ If any of these tests fails, the Webhook component is broken in one of its core 
 **Test 2 — flow is saved to database and contains the Webhook node**
 1. Run `addWebhookComponent`
 2. Wait 4 s for autosave
-3. Fetch `GET /api/v1/flows/{flowId}` via `page.evaluate(fetch)` (browser context carries session cookies)
+3. `GET /api/v1/flows/{flowId}` through the `request` fixture with an explicit
+   `Authorization` header from `getAuthToken(request)`; treat a non-ok response
+   as `null` so the assertion in step 4 reports "flow not persisted" rather than
+   a raw HTTP failure. The read runs **outside** the browser context on purpose —
+   see the note on the frontend `fetch` wrapper below
 4. Assert the response is not null and contains a node with `data.type === "Webhook"`
 5. Assert `webhookNode.data.node.template.endpoint.value === "BACKEND_URL"`
 
@@ -142,6 +157,110 @@ If any of these tests fails, the Webhook component is broken in one of its core 
 - An invalid JSON string in `data` is wrapped as `{"payload": "<raw string>"}` in the output inspection modal
 - `GET /api/v1/monitor/messages` returns 200 with an array body
 
+**Concrete gate for lifting test 2's quarantine (#990)** — the quarantine is not
+lifted by "it passed once". All four hold:
+
+1. The whole file passes 3× in a row at `--workers=1 --retries=0` — 10 tests,
+   0 skipped (a `test.fixme` still left in place would report `9 passed, 1 skipped`,
+   so the count itself proves the quarantine is gone).
+2. The file passes at `--workers=2 --repeat-each=2` — the concurrency re-check
+   applied in PR #986. The file is `test.describe.configure({ mode: "serial" })`
+   and every test creates a flow, so a cross-worker collision would show up as
+   `400 flow must be unique` or a 404 on a sibling's flow id.
+3. `GET /api/v1/flows/` reports the **same flow count before and after** the run
+   (scoped teardown, #515) — 0 orphans. Not "a DELETE was issued": the observable
+   is the count.
+4. Test 2 fails for the right reason when mutated — forcing the expected
+   placeholder to a wrong value, or pointing the read at a non-existent flow id,
+   must produce a failed assertion, never a silent pass.
+
+---
+
+## The frontend `fetch` wrapper defect (`Accept-Language` TypeError)
+
+Recorded here because it is a **real Langflow frontend defect that this suite
+deliberately stopped exercising** — and because leaving that implicit is what
+turned #180 into 2½ months of orphaned debt.
+
+Langflow's frontend patches `window.fetch` with `fetch-intercept` and registers a
+request interceptor that injects the i18n language header:
+
+```js
+// assets/index-DA5lq9QP.js (1.12.0.dev8), inside the auth-interceptor effect
+const h = { "Accept-Language": i18n.language || "en" };
+vHr.register({
+  request: (_, R) => {
+    if (!x(_)) for (const [k, D] of Object.entries(h)) R.headers[k] = D;
+    return [_, R];
+  },
+});
+// x = url => ["https://raw.githubusercontent.com","https://api.github.com",
+//             "https://api.segment.io","https://cdn.sprig.com"]
+//            .some(o => new URL(url).origin === o)   // throws on a relative URL -> false
+```
+
+`R` is `fetch`'s second argument and `R.headers` its header init. The interceptor
+assumes both exist and that `headers` is a plain mutable object. So a call to a
+**relative** URL (`x` returns `false` because `new URL()` throws on it) crashes
+whenever the init omits `headers`:
+
+Measured live on `1.12.0.dev8` against `/api/v1/version` from the page context.
+Reproduce it in ~10 seconds from the devtools console on any Langflow page:
+
+```js
+await fetch("/api/v1/version");                             // TypeError
+await fetch("/api/v1/version", { credentials: "include" }); // TypeError
+await fetch("/api/v1/version", { headers: {} });            // 200, header sent
+await fetch("/api/v1/version", { headers: new Headers() }); // 200, header LOST
+```
+
+
+| Call from the page context | Result |
+|---|---|
+| `fetch(url)` | `TypeError: Cannot read properties of undefined (reading 'headers')` |
+| `fetch(url, { credentials: "include" })` | `TypeError: Cannot set properties of undefined (setting 'Accept-Language')` |
+| `fetch(url, { headers: {} })` | `200`, and `accept-language: en` arrives on the wire |
+| `fetch(url, { headers: new Headers() })` | `200`, but `accept-language` is **absent** on the wire |
+
+Row 2 is exactly what test 2 used to do. Row 4 is a **second, independent
+defect** in the same three lines: `R.headers[k] = D` on a `Headers` instance sets
+a plain JS property instead of a header, so the injection silently no-ops for the
+standard Web-API idiom — the user's language is dropped without any error.
+
+**Why we stop being exposed to it.** The only reason the test ran a `fetch` inside
+the page was the claim in its own comment that "the `request` fixture is
+unauthenticated and would get a 403 from the flows endpoint even in auto-login
+mode". That is half-true and no longer a constraint: `GET /api/v1/flows/` does
+answer `403` unauthenticated, but `getAuthToken()` mints a bearer from
+`/api/v1/auto_login` and the same endpoint then answers `200`. The helper is
+already imported in this very spec file, and used by tests 1, 7, and 10.
+
+**What is lost.** The browser-context `fetch` incidentally exercised the
+frontend's own HTTP path, so it would trip on this bundle defect. That was never
+this test's purpose, and a webhook-persistence test is a poor place to catch a
+bundle regression — if we want that covered it belongs in a deliberate UI test.
+Note also that the app's own API traffic goes through its axios instance (XHR
+adapter), which does **not** route through the patched `window.fetch` — which is
+why normal use never surfaces this, and why the incidental coverage was weak.
+
+**Decision on filing it upstream: NO — decided 2026-07-28, and recorded here on
+purpose.** Not "we forgot", not "someone should look at it": we deliberately do
+not report it. The reason is the paragraph above — Langflow's own API traffic goes
+through axios's XHR adapter and never enters the patched `window.fetch`, so no
+user-facing behaviour is broken by either defect. The only consumers that reach
+those three lines are page-level scripts, which is what our test used to be and
+no longer is. That makes this a **non-user-facing gap**, and by the rule in
+`CLAUDE.md` → *REGRESSIONS.md* a finding that downgrades to a non-user-facing gap
+is listed nowhere: no ledger row, no candidate row, no upstream ticket.
+
+Recording it as a decision rather than a silence is the whole point. #180 was
+closed with "upstream issue filed" unchecked and no explanation, and a test sat
+quarantined for 2½ months waiting on a ticket nobody had opened. The failure mode
+was the implicitness, not the verdict — so if this ever needs revisiting (an
+`accept-language` bug report from a user, axios migrating to the fetch adapter,
+or a component adopting native `fetch`), the mechanism, the four measured cases,
+and the reason we walked away are all in this section.
+
 ---
 
 ## External dependencies *(required)*
@@ -189,5 +308,6 @@ If any of these tests fails, the Webhook component is broken in one of its core 
 - **Post-bootstrap network-idle wait.** When transient "New Flow" flows exist at home-page mount, the Langflow frontend sweeps them with a batch `DELETE /api/v1/flows/` of its own. If our blank-flow `POST` lands mid-sweep, SQLite raises `database is locked` and the sweep 500s (`Unable to cascade delete flow`, upstream weakness in `delete_multiple_flows` — log-only via the fixture, no test impact, no flow leak since afterEach still deletes the captured id; observed 2× in 5 file runs). Waiting for network idle after `awaitBootstrapTest` serializes the sweep before our flow creation, removing the contention window (#464). The old pre-test wipe masked this by emptying transients first — the wait replaces that side-effect without the destructive wipe.
 
 - Tests 8 and 9 use `page.route` to inject a value into the Webhook's `data` field (Payload, `advanced=True`), which has no editable UI in the inspector. The intercept patches the `GET /api/v1/flows/{id}` response before the page navigates to the flow, simulating what the real webhook POST would write to that field. The intercept is removed via `page.unroute` after navigation to avoid side-effects.
-- The `request` fixture used in tests 1 and 7 is unauthenticated by default; both tests now create a temporary `x-api-key` because Langflow's `WEBHOOK_AUTH_ENABLE` defaults to `True` since 1.9.2+ (PR langflow-ai/langflow#12845). The auth dependency `get_webhook_user` runs before `get_flow_by_id_or_endpoint_name` inside `get_webhook_auth`, so without an API key the endpoint returns 403 before any flow resolution — that is why test 7 also needs to authenticate to reach the 404 path. `GET /api/v1/flows/{id}` requires session cookies — that is why test 2 uses `page.evaluate(fetch)` instead of `request.get`.
+- The `request` fixture used in tests 1 and 7 is unauthenticated by default; both tests now create a temporary `x-api-key` because Langflow's `WEBHOOK_AUTH_ENABLE` defaults to `True` since 1.9.2+ (PR langflow-ai/langflow#12845). The auth dependency `get_webhook_user` runs before `get_flow_by_id_or_endpoint_name` inside `get_webhook_auth`, so without an API key the endpoint returns 403 before any flow resolution — that is why test 7 also needs to authenticate to reach the 404 path.
+- **`GET /api/v1/flows/{id}` does not require session cookies** — a bearer token from `getAuthToken()` is enough (verified on `1.12.0.dev8`: `403` with no auth, `200` with the `Authorization` header). The opposite claim used to justify test 2's `page.evaluate(fetch)`, which is what exposed it to the frontend `fetch`-wrapper defect and got it quarantined for 2½ months (#990). Test 2 now uses the authenticated `request.get`.
 - The `output-inspection-json-webhook` testid is generated dynamically by the frontend as `output-inspection-{display_name.toLowerCase()}-{component_type}`; if the output display name reverts to `"Data"`, the testid becomes `output-inspection-data-webhook`.

--- a/tests/tests-automations/regression/core-components/webhook-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/webhook-component-regression.spec.ts
@@ -145,17 +145,10 @@ test(
   },
 );
 
-// Marked fixme until the Langflow frontend bundle stops mutating an undefined
-// `Accept-Language` header inside the request wrapper (see #165 item 2 — surfaced
-// by weekly run 25441253323 as `TypeError: Cannot set properties of undefined`).
-// When the upstream bug is fixed, remove `.fixme` and re-validate.
-test.fixme(
+test(
   "Webhook component — flow is saved to database and contains the Webhook node",
-  // @stable removed: upstream Langflow regression breaks page.evaluate(fetch)
-  // with "Cannot set properties of undefined (setting 'Accept-Language')".
-  // Tracked in #180; restore @stable once upstream is fixed.
-  { tag: ["@release", "@regression"] },
-  async ({ page }) => {
+  { tag: ["@stable", "@release", "@regression"] },
+  async ({ page, request }) => {
     await addWebhookComponent(page);
 
     const flowId = page.url().split("/").slice(-1)[0];
@@ -166,16 +159,19 @@ test.fixme(
     await page.waitForTimeout(4000);
 
     // Verify the flow is persisted and contains the Webhook component.
-    // Use page.evaluate(fetch) so the request runs in the browser context and
-    // carries the session cookies. The request fixture is unauthenticated and
-    // would get a 403 from the flows endpoint even in auto-login mode.
-    const flowData = await page.evaluate(async (fId) => {
-      const res = await fetch(`/api/v1/flows/${fId}`, {
-        credentials: "include",
-      });
-      if (!res.ok) return null;
-      return res.json();
-    }, flowId);
+    // Read it through the `request` fixture with an explicit bearer, NOT through
+    // page.evaluate(fetch): the flows endpoint only needs a token (403 without
+    // one, 200 with the bearer getAuthToken mints from /api/v1/auto_login), and
+    // a fetch issued from the page context hits a defect in the Langflow bundle's
+    // window.fetch wrapper — it assumes the init carries a mutable `headers`
+    // object and throws "Cannot set properties of undefined (setting
+    // 'Accept-Language')". That defect is real and unrelated to what this test
+    // asserts; running the read out here keeps the product bug out of our signal
+    // (#990, and docs/core-components/webhook-component-regression.md).
+    const flowRes = await request.get(`/api/v1/flows/${flowId}`, {
+      headers: { Authorization: await getAuthToken(request) },
+    });
+    const flowData = flowRes.ok() ? await flowRes.json() : null;
 
     expect(flowData).not.toBeNull();
     const nodes: any[] = flowData?.data?.nodes ?? [];


### PR DESCRIPTION
**Closes #990.**

## Problem

`core-components/webhook-component-regression.spec.ts` — *"Webhook component — flow is saved to database and contains the Webhook node"* — had been `test.fixme` without `@stable` since **2026-05-11** (2½ months), waiting on an upstream fix that was **never requested**. [#180](https://github.com/oriontech-me/langflow-e2e/issues/180) was closed on 2026-06-15 with all four of its own closing criteria unchecked — the first being *"Upstream issue filed in `langflow-ai/langflow`"* — and no such issue exists upstream. The quarantine was waiting on an event nobody had triggered.

The underlying Langflow frontend defect is real and still present on `1.12.0.dev8`, reproduced at spec level by flipping `test.fixme` back to `test` with the read unchanged:

```
Error: page.evaluate: TypeError: Cannot set properties of undefined (setting 'Accept-Language')
    at request (http://localhost:7860/assets/index-DA5lq9QP.js:1028:30112)
```

Root cause of the *exposure*, however, is on our side. The test read the persisted flow through `page.evaluate(fetch)` purely because of a claim in its own comment:

> `// The request fixture is unauthenticated and would get a 403 from the flows endpoint even in auto-login mode.`

That is no longer a constraint. Verified on `1.12.0.dev8`: `GET /api/v1/flows/` answers `403` with no auth and `200` with the bearer `getAuthToken()` mints from `/api/v1/auto_login` — and that helper was already imported in this very file (line 9), used by tests 1, 7 and 10.

## Fix

The read moves out of the browser context:

```diff
-  async ({ page }) => {
+  async ({ page, request }) => {
...
-    const flowData = await page.evaluate(async (fId) => {
-      const res = await fetch(`/api/v1/flows/${fId}`, { credentials: "include" });
-      if (!res.ok) return null;
-      return res.json();
-    }, flowId);
+    const flowRes = await request.get(`/api/v1/flows/${flowId}`, {
+      headers: { Authorization: await getAuthToken(request) },
+    });
+    const flowData = flowRes.ok() ? await flowRes.json() : null;
```

`res.ok() ? … : null` is deliberate: it keeps the existing `expect(flowData).not.toBeNull()` reporting *"flow not persisted"* rather than a raw HTTP failure. `test.fixme` becomes `test`, `@stable` is restored in the same commit, and the dead `#180`/`#165` comment block is replaced by a pointer to the spec doc.

**Rejected alternatives:** keeping the page-context `fetch` and adding a `headers: {}` init (works, but keeps a product bug wired into our signal for no coverage gain); waiting for the upstream fix (that is exactly what produced 2½ months of debt); asserting around the TypeError (would weaken the test).

## Scope note

**No assertion changed.** The test still asserts the flow is persisted, contains a node with `data.type === "Webhook"`, and that `template.endpoint.value === "BACKEND_URL"` — the placeholder that protects the endpoint URL for all users. Only *how* it reads the persisted flow changed. The other 9 tests, the shared `addWebhookComponent` helper, and the scoped `afterEach` teardown (#515) are untouched.

**What is lost:** the browser-context `fetch` incidentally exercised the frontend's own HTTP path. That was never this test's purpose, and a webhook-persistence test is a poor place to catch a bundle regression — if we want that covered it belongs in a deliberate UI test.

## The frontend defect, and the decision not to report it

Documented in the spec doc with the mechanism read out of the bundle: the frontend patches `window.fetch` via `fetch-intercept` and the request interceptor does `init.headers[k] = v` without guarding `init` or `init.headers`, while its external-origin allowlist (`new URL(url).origin`) throws on a relative URL and so falls through to the *inject* branch for every same-origin API call. Four cases measured on `1.12.0.dev8` against `/api/v1/version`:

| Call from the page context | Result |
|---|---|
| `fetch(url)` | `TypeError: Cannot read properties of undefined (reading 'headers')` |
| `fetch(url, { credentials: "include" })` | `TypeError: Cannot set properties of undefined (setting 'Accept-Language')` |
| `fetch(url, { headers: {} })` | `200`, `accept-language: en` on the wire |
| `fetch(url, { headers: new Headers() })` | `200`, `accept-language` **absent** — a second, independent defect: the injection silently no-ops for the standard Web-API idiom |

**Decision: we do NOT report it upstream** — recorded explicitly in the spec doc, not left implied. Langflow's own API traffic goes through its axios instance (XHR adapter) and never enters the patched `window.fetch`, so no user-facing behaviour is broken by either defect; the only consumers that reach those three lines are page-level scripts, which is what our test used to be and no longer is. That makes it a **non-user-facing gap**, and per `CLAUDE.md` → *REGRESSIONS.md* such a finding is listed nowhere: no ledger row, no candidate row, no ticket. The mechanism, the four cases and a 4-line devtools repro stay in the spec doc so the call can be revisited (a user-reported `accept-language` bug, axios moving to the fetch adapter, or a component adopting native `fetch`).

Writing the decision down **is** the deliverable here: #180 proved that the failure mode is the silence, not the verdict.

## Validation (nightly `1.12.0.dev8`, `--retries=0`)

- typecheck ✅ (`tsc --noEmit`, clean) · eslint ✅ (0 errors; 26 pre-existing warnings, none in changed lines)
- QA-CHECKLIST guard ✅ (`no auto-generated blocks were edited by this PR`) · coverage guard ✅ (`every @stable and every documented spec is referenced by a Part II bullet`)
- **3× `--workers=1 --retries=0` on the file:** `expected=10 unexpected=0 flaky=0 backendErrors=false` on every run. **Ten, not nine-plus-one-skipped** — the count itself is what proves the quarantine is gone.
- **`--workers=2 --repeat-each=2`:** `20 passed (1.7m)` — the concurrency re-check from PR #986, since the file is `test.describe.configure({ mode: "serial" })` and every test creates a flow.
- **Orphans:** `GET /api/v1/flows/` = **28 before, 28 after** all five runs, with no flow updated past the baseline → scoped teardown (#515) intact, 0 leaks.
- **Force-fail:** all **10** `test()` in the file mutated red one at a time (each carrying an `// FF-MUTATION` marker, each recorded only after Playwright reported `unexpected=1`), file restored byte-for-byte after every case, **0 markers left in the diff**. Plus an 11th on the *new* code path: the authenticated `request.get` pointed at a non-existent flow id → `flowData` is null → the persistence assertion fires, proving the replacement read is load-bearing and not a silent pass.
- Zero `🚨 Backend Error` across all runs.

## Reproduce locally

```bash
npx playwright test tests/tests-automations/regression/core-components/webhook-component-regression.spec.ts \
  --workers=1 --retries=0
# expected: 10 passed, ~2.5 min

npx playwright test tests/tests-automations/regression/core-components/webhook-component-regression.spec.ts \
  --grep "flow is saved to database" --workers=1 --retries=0
# expected: 1 passed, ~15 s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
