### PR TITLE
ci(pr-validation): match specs directly under tests/ via :(glob) pathspec (#1016)

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -119,7 +119,19 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: |
           git fetch origin "$BASE_REF" --quiet
-          SPECS=$(git diff --name-only --diff-filter=d "origin/$BASE_REF"...HEAD -- 'tests/**/*.spec.ts' | tr '\n' ' ' | sed 's/ *$//')
+          # The `:(glob)` magic prefix is load-bearing — do NOT "simplify" it away
+          # (issue #1016). Without it, git matches the pathspec with fnmatch and
+          # no FNM_PATHNAME, so `**` degrades to a plain `*` that carries no
+          # "zero or more directories" meaning, and the literal `/` after it must
+          # still match something. Every spec under a subdirectory matched (245 of
+          # them), while the one spec sitting directly under `tests/` never did:
+          # `tests/collect-models.spec.ts` — the @stable pre-flight utility every
+          # provider spec depends on, and thus the only spec exempt from PR-time
+          # E2E validation (surfaced by PR #1015, blast radius shown by #1007).
+          # `:(glob)` switches git to wildmatch with pathname semantics, where
+          # `/**/` genuinely means "zero or more directories", so the pattern now
+          # means what it always looked like it meant. Verified: 246 specs matched.
+          SPECS=$(git diff --name-only --diff-filter=d "origin/$BASE_REF"...HEAD -- ':(glob)tests/**/*.spec.ts' | tr '\n' ' ' | sed 's/ *$//')
           echo "Changed specs: ${SPECS:-<none>}"
           if [ -n "$SPECS" ]; then
             echo "has_specs=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/update-coverage-summary.yml
+++ b/.github/workflows/update-coverage-summary.yml
@@ -17,6 +17,14 @@ on:
       - "scripts/stable-tests.ts"
       # The `@stable` parser the Phase 0 generator reads from (#985).
       - "scripts/lib/stable-tests.ts"
+      # Unlike a git pathspec, an Actions `paths:` filter DOES match a spec
+      # sitting directly under `tests/` — so this one needs no `tests/*.spec.ts`
+      # companion. Measured, not assumed (issue #1016): commit f0bee50 was a
+      # single-commit push to main whose only changed file was
+      # `tests/collect-models.spec.ts`, and this workflow ran on it
+      # (event=push, conclusion=success). The identical-looking git pathspec in
+      # `pr-validation.yml` silently missed that same file — different glob
+      # engine, different rules. Don't port a fix from there to here.
       - "tests/**/*.spec.ts"
       - ".github/workflows/update-coverage-summary.yml"
 


### PR DESCRIPTION
Closes #1016

Approved exception per `ROADMAP.md` → *Intake*: `follow-up` of merged work (PR #1015, for #1011), labelled `qa-infra`.

## The bug

The impacted-specs detector used the git pathspec `tests/**/*.spec.ts`, which **requires at least one subdirectory**. Without `:(glob)` magic, git matches pathspecs with fnmatch and no `FNM_PATHNAME`, so `**` carries no "zero or more directories" meaning — it is just `*`, and the literal `/` after it must still match something.

All 245 specs living under a subdirectory matched. The one spec sitting directly under `tests/` never did: **`tests/collect-models.spec.ts`** — the `@stable` pre-flight that populates `providers.json` / `models.json` for every LLM and model-provider spec, and the pre-flight step of `daily-stable.yml`.

The one spec whose breakage takes the whole suite down (#1007) was the only spec exempt from PR-time E2E validation. That is how PR #1015 modified it and still reported `Changed specs: <none>` / `Needs provider models: false`.

## The fix

`':(glob)tests/**/*.spec.ts'`. Chosen over the bare `tests/*.spec.ts`: that alternative works only by relying on `*` crossing `/` in the default matcher — the same non-obvious behaviour that caused this bug. `:(glob)` switches git to wildmatch with pathname semantics, where `/**/` genuinely means "zero or more directories", so the pattern now means what it always looked like it meant instead of working by accident.

A comment records why the prefix is load-bearing, with the measured counts, so a later edit does not "simplify" it back into the bug.

## Evidence

Verified against real history — `f0bee50` is a single-commit push to `main` whose only changed file was that spec, i.e. the exact scenario:

```console
$ git diff --name-only --diff-filter=d f0bee50^...f0bee50 -- 'tests/**/*.spec.ts'
                                                    # 0 files — reproduces the bug
$ git diff --name-only --diff-filter=d f0bee50^...f0bee50 -- ':(glob)tests/**/*.spec.ts'
tests/collect-models.spec.ts

$ git ls-files -- 'tests/**/*.spec.ts' | wc -l          # 245
$ git ls-files -- ':(glob)tests/**/*.spec.ts' | wc -l   # 246
```

The full step logic was simulated over three PR shapes:

| PR shape | `Changed specs` | `has_specs` | `needs_models` |
|---|---|---|---|
| spec at root (`f0bee50`) | `tests/collect-models.spec.ts` | true | **true** |
| nested specs (`33dfc6a`) | 2 ui-ux specs | true | false |
| workflow-only (`3ec5ad0`) | `<none>` | false | false |

`needs_models=true` for the root spec is self-validating: it imports from `provider-setup`, which the content grep already matches — so a PR touching it now runs `Collect models` plus the spec against nightly.

Both workflows parse-check clean (`js-yaml`) and the quoted pathspec survives YAML intact. `typecheck`, `lint` (0 errors), `check:checklist-coverage` and `regressions:check` all pass.

## `update-coverage-summary.yml` — measured, not assumed

The issue raised its `paths:` filter as *possibly* the same class. It is **not**, and this was settled by measurement rather than by reading the docs:

```console
$ gh run list --workflow update-coverage-summary.yml --limit 40 \
    --json headSha,event,conclusion -q '.[] | select(.headSha|startswith("f0bee50"))'
sha=f0bee506… event=push concl=success
```

`f0bee50` changed **only** `tests/collect-models.spec.ts`, and the workflow ran on it. An Actions `paths:` filter uses a different glob engine from git's and does match a file at the repo root, so it needs no companion pattern. Recorded as a comment in the file — including the warning **not** to port this fix there — so the hypothesis is not reopened later.

## Deliverables

- [x] Detector matches all 246 specs, with the pathspec semantics explicit rather than accidental
- [ ] Live CI proof on a PR touching **only** that spec — deliberately not forced here (see below)
- [x] `update-coverage-summary.yml` confirmed unaffected, with the verification recorded in-file
- [x] Note in the workflow explaining why the pathspec carries `:(glob)`

On the second box: this PR touches only `.github/`, so it cannot exercise the corrected path against itself. Adding a no-op edit to the spec purely to trigger CI was considered and rejected — it would also redden the `Collect models` step on the current drained OpenAI key (#980 class), producing a misleading signal for a fix that is already proven over real history. The live proof lands on the next PR that genuinely touches `tests/collect-models.spec.ts`.

## What this PR's own CI proves

No regression on the common path: `Detect changed specs` should print `Changed specs: <none>` and `Run impacted E2E specs` should skip, since this PR touches no spec.

## Related

- #1011 / PR #1015 — the work that surfaced this
- #1007 — the daily incident that made this spec's blast radius concrete
- #1012 — the other detection gap found in the same triage

🤖 Generated with [Claude Code](https://claude.com/claude-code)