### PR TITLE
fix(project-management): confine the account-wide folder wiper to a destructive lane (#1010)

### DIFF
--- a/.github/actions/run-e2e/action.yml
+++ b/.github/actions/run-e2e/action.yml
@@ -52,6 +52,32 @@ runs:
         echo "Running: npx playwright test ${ARGS[*]}"
         npx playwright test "${ARGS[@]}"
 
+    # Destructive lane (#1010). `@destructive` tests mutate account-wide state, so
+    # playwright.config.ts excludes them from the run above and pins this lane to
+    # workers=1. It runs after that run, ANDed with whatever filters the dispatch
+    # asked for, and no-ops when nothing destructive matches.
+    - name: Run destructive lane
+      if: always()
+      shell: bash
+      env:
+        CI: "true"
+        PW_DESTRUCTIVE: "1"
+        PLAYWRIGHT_BASE_URL: ${{ inputs.base_url }}
+        TEST_TAG: ${{ inputs.test_tag }}
+        TEST_GREP: ${{ inputs.test_grep }}
+        OPENAI_API_KEY: ${{ inputs.openai_api_key }}
+      run: |
+        # Same one-grep constraint as above: AND the filters into a single
+        # lookahead regex, always including @destructive.
+        FILTER="(?=.*@destructive)"
+        if [ -n "$TEST_TAG" ]; then FILTER="${FILTER}(?=.*${TEST_TAG})"; fi
+        if [ -n "$TEST_GREP" ]; then FILTER="${FILTER}(?=.*${TEST_GREP})"; fi
+        # --reporter=github only: keeps this lane from overwriting the HTML report
+        # the step above produced and the artifact below uploads.
+        echo "Running destructive lane: --grep $FILTER"
+        npx playwright test --pass-with-no-tests --reporter=github \
+          --output=test-results-destructive --grep "$FILTER"
+
     - name: Upload Playwright report
       if: always()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/adaptive-impacted.yml
+++ b/.github/workflows/adaptive-impacted.yml
@@ -202,6 +202,27 @@ jobs:
             npx playwright test $SPECS --reporter=github
           fi
 
+      # Destructive lane (#1010). Excluded from the run above by
+      # playwright.config.ts and pinned to workers=1 here; runs after it, scoped to
+      # the same subset, and no-ops when nothing destructive is in scope.
+      - name: Run destructive lane
+        if: always()
+        env:
+          CI: "true"
+          PW_DESTRUCTIVE: "1"
+          PLAYWRIGHT_BASE_URL: "http://localhost:7860/"
+          RUN_FULL: ${{ needs.compute-impact.outputs.run_full }}
+          SPECS: ${{ needs.compute-impact.outputs.specs }}
+        run: |
+          if [ "$RUN_FULL" = "true" ]; then
+            npx playwright test --grep "@destructive" --pass-with-no-tests \
+              --reporter=github --output=test-results-destructive
+          else
+            # shellcheck disable=SC2086
+            npx playwright test $SPECS --grep "@destructive" --pass-with-no-tests \
+              --reporter=github --output=test-results-destructive
+          fi
+
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7
         if: always()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -96,6 +96,31 @@ jobs:
           CI: "true"
           PLAYWRIGHT_BASE_URL: "http://localhost:7860/"
 
+      # Destructive lane (#1010). `@destructive` tests mutate account-wide state
+      # (deleting every project of the shared superuser), so playwright.config.ts
+      # excludes them from the run above and pins this lane to workers=1. It runs
+      # AFTER that run, and `--pass-with-no-tests` makes it a no-op when the
+      # optional grep filter above selected nothing destructive.
+      #
+      # `--reporter=github` replaces the whole configured reporter list, so this
+      # step writes no HTML and cannot clobber the main run's `playwright-report/`
+      # — at the cost of the lane not reaching Flakiness.io. `--output` keeps its
+      # traces/screenshots out of the main run's `test-results/` too. The GitHub
+      # annotations are the lane's signal.
+      - name: Run destructive lane
+        if: always()
+        run: |
+          GREP="${{ github.event.inputs.test_grep }}"
+          if [ -n "$GREP" ]; then
+            npx playwright test --grep "(?=.*@destructive)(?=.*${GREP})" --pass-with-no-tests --reporter=github --output=test-results-destructive
+          else
+            npx playwright test --grep "@destructive" --pass-with-no-tests --reporter=github --output=test-results-destructive
+          fi
+        env:
+          CI: "true"
+          PW_DESTRUCTIVE: "1"
+          PLAYWRIGHT_BASE_URL: "http://localhost:7860/"
+
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7
         if: always()

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -276,6 +276,30 @@ jobs:
           # shellcheck disable=SC2086
           npx playwright test $SPECS --reporter=github
 
+      # Destructive lane (#1010). `@destructive` tests wipe account-wide state, so
+      # playwright.config.ts keeps them out of the run above and pins this lane to
+      # workers=1. Scoped to the same impacted $SPECS, so it is a no-op (via
+      # --pass-with-no-tests) unless a destructive spec is actually impacted.
+      # --reporter=github replaces the reporter list, so no HTML is written here and
+      # the main run's playwright-report/ stays intact.
+      - name: Run destructive lane
+        if: always()
+        env:
+          CI: "true"
+          PW_DESTRUCTIVE: "1"
+          PREFLIGHT_SKIP_CREDENTIALS: ${{ needs.detect-specs.outputs.needs_models == 'true' && '0' || '1' }}
+          PLAYWRIGHT_BASE_URL: "http://localhost:7860/"
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          SPECS: ${{ needs.detect-specs.outputs.specs }}
+        run: |
+          # shellcheck disable=SC2086
+          npx playwright test $SPECS --grep "@destructive" --pass-with-no-tests \
+            --reporter=github --output=test-results-destructive
+
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,7 @@ Tags are split into two groups: **cross-cutting** (severity/layer) and **functio
 | `@workspace` | Flow/folder/canvas management |
 | `@database` | Tests with persistent saved state |
 | `@mainpage` | Home/dashboard UI tests |
+| `@destructive` | Test mutates account-wide state (e.g. deletes every project of the shared superuser). **Lane selector, not a severity:** `playwright.config.ts` excludes it from every normal run via `grepInvert` and CI runs it alone afterwards with `PW_DESTRUCTIVE=1` (workers pinned to 1). Run it locally with `PW_DESTRUCTIVE=1 npx playwright test --grep @destructive`. Do **not** combine with `@stable` — `daily-stable.yml` has no destructive lane, so such a test would silently never run there (#1010) |
 
 **Functional** (product area — use alongside cross-cutting tags)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -546,6 +546,7 @@ Three cases where the tag is intentionally absent:
 1. **Inherited tests not yet reviewed** — they exist in the repository but have not yet gone through the validation and documentation process.
 2. **Tests temporarily removed while failing** — the tag was removed while the test awaits correction (see lifecycle below).
 3. **Utility specs** — scripts that collect data or configure infrastructure rather than asserting product behavior (e.g. `collect-models.spec.ts`). These are not regression tests and must never enter the stable workflow.
+4. **`@destructive` tests** — a test that mutates account-wide state (deleting every project of the shared superuser, for instance) runs only in the destructive lane: `playwright.config.ts` excludes `@destructive` from every normal run and CI runs it alone afterwards with `PW_DESTRUCTIVE=1`. `daily-stable.yml` filters on `--grep "@stable"` and has **no destructive lane**, so a test carrying both tags would be excluded from the daily and silently never run. Treat the two as mutually exclusive until the daily grows a lane of its own (#1010).
 
 **When `@stable` is permanently absent** (case 3): state the reason in the spec doc's **Tags** section so it is visible without reading PR history.
 

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -536,8 +536,9 @@
 - [x] Rename folder → `core-functionality/project-management/folder-crud.spec.ts`
 - [x] Delete empty folder → `core-functionality/project-management/folder-crud.spec.ts`
 - [x] Delete folder with flows inside → `core-functionality/project-management/folder-crud.spec.ts`
-- [-] Integrity after deletion
-- [-] Create folder after deleting all folders
+- [-] Integrity after deletion — the deleted folder leaves the sidebar immediately, the page stays functional, and a sibling folder is untouched and still clickable → `core-functionality/project-management/folder-deletion-integrity.spec.ts`
+- [-] Create folder after deleting all folders — creating a folder right after a deletion works (no stale-cache collision) → `core-functionality/project-management/folder-deletion-integrity.spec.ts`
+- [-] Deleting every folder lands on the empty-project screen (sidebar empty message + `new_project_btn_empty_page`) → `core-functionality/project-management/folder-deletion-integrity.spec.ts` (`@destructive` — account-wide wiper, runs only in the low-concurrency lane via `PW_DESTRUCTIVE=1`, see #1010)
 - [-] Upload flow by drag-and-drop to folder — dropping a collection file imports one flow per entry; dropping a single flow file imports exactly one → `flow-functionality/dragAndDrop.spec.ts`
 - [-] Move flow to another folder
 

--- a/docs/core-functionality/project-management/folder-deletion-integrity.md
+++ b/docs/core-functionality/project-management/folder-deletion-integrity.md
@@ -1,0 +1,229 @@
+# Folder Deletion Integrity
+
+**Last validated:** Langflow 1.12.x (`1.12.0.dev8`)
+
+---
+
+## What this test validates *(required)*
+
+Validates the **integrity properties around folder (project) deletion** — that the
+UI does not keep stale state after a folder disappears. The create/rename/
+delete-empty CRUD lifecycle itself belongs to the canonical `folder-crud.spec.ts`;
+this spec starts where that one stops and asserts what must remain true *after* a
+deletion:
+
+1. the deleted folder leaves the sidebar immediately and the page stays functional;
+2. deleting one folder does not disturb a sibling folder, which stays clickable;
+3. a folder created right after a deletion is created normally (no stale-cache collision);
+4. deleting **every** folder lands on the empty-project screen.
+
+A regression here is the class of bug where the backend deleted the row but the
+frontend keeps rendering the folder, keeps a dangling selected-project id, or
+refuses to create the next folder because a cache still holds the old one. Test 4
+is the only place in the suite that exercises the zero-project state at all.
+
+---
+
+## Tags *(required)*
+
+`@release` `@api` — and `@destructive` on test 4 only.
+
+**No `@stable` yet**, on purpose: the empty-project screen that test 4 reaches
+makes the frontend fire `GET /api/v1/projects/undefined` and the suite's fixture
+logs the resulting `422` (issue #1008, a product-side defect). Until that is
+resolved, this file always carries a `🚨 Backend Error` line, and `@stable` would
+put that noise in the daily. The tag is restored once #1008 lands.
+
+**`@destructive` (introduced by #1010)** marks a test that mutates account-wide
+state and therefore cannot run beside anything else. It is a lane selector, not a
+severity: the default run excludes it and the destructive lane runs it alone —
+see *The destructive lane* below.
+
+---
+
+## Step by step *(required)*
+
+**Test 1 — `deleting a folder should update the folder list immediately`**
+1. Create the target folder via `POST /api/v1/projects/` (API setup, so the
+   deletion target is deterministic and the UI create flow is not re-tested here)
+2. `awaitBootstrapTest(page, { skipModal: true })`; assert `sidebar-nav-{name}` is visible
+3. Delete it through the UI via `MainPage.deleteProject(name)`
+4. Assert the `"Project deleted successfully"` toast
+5. Assert `sidebar-nav-{name}` is **no longer visible** — the no-stale-data observable
+6. Assert `add-project-button` is still visible (the page did not break)
+7. `finally`: if the UI deletion did not complete, remove the folder through
+   `deleteProject()` so a failed assertion cannot leak a project (#965)
+
+**Test 2 — `deleting one folder should not affect other folders`**
+1. Bootstrap, open a template and come back (exercises the real navigation path)
+2. Create `folder-alpha` and `folder-beta` through the UI (`add-project-button` →
+   double-click the `New Project` entry → type the name → Enter)
+3. Assert both sidebar entries exist
+4. Delete `folder-alpha` via its `more-options-button_folder-alpha` → `btn-delete-project` → confirm
+5. Assert the toast, assert `folder-alpha` is gone and `folder-beta` is still visible
+6. Click `folder-beta` and assert `mainpage_title` renders — the survivor is still usable
+7. Delete `folder-beta` (cleanup through the same UI path)
+
+**Test 3 — `creating a new folder after deletion should work correctly`**
+1. Bootstrap, template round-trip, create `folder-one` through the UI
+2. Delete `folder-one`, assert the toast and that its sidebar entry is gone
+3. **Immediately** create `folder-two` through the same UI path
+4. Assert `folder-two` appears and `sidebar-nav-folder-two` is visible — proves no
+   stale-cache collision between the deletion and the next creation
+5. Delete `folder-two` (cleanup)
+
+**Test 4 — `deleting every folder lands on the empty project screen`** *(`@destructive`)*
+1. Create one folder via API **holding a flow** (`POST /api/v1/projects/` then
+   `POST /api/v1/flows/` with that `folder_id`), so the delete-everything path runs
+   against real content rather than only empty folders
+2. Bootstrap with `skipModal: true`
+3. Loop: count `sidebar-nav-*` entries in `project-sidebar`, delete the first one
+   through the UI (hover → `more-options-button_{kebab}` → `btn-delete-project` →
+   confirm → toast), re-count; repeat until zero
+4. Assert the count reached `0`
+5. Assert the sidebar shows `"Start creating a project or flow"`
+6. Assert `new_project_btn_empty_page` is visible
+
+---
+
+## The destructive lane (#1010)
+
+Test 4 deletes **every folder of the shared superuser**. Under `fullyParallel:
+true` with `workers: 2` that is a cross-test wiper: `fullyParallel` distributes
+tests *within a file* across workers, so test 4 could run beside tests 1–3 of this
+same file, and beside `folder-crud.spec.ts`, `bulk-actions.spec.ts` and
+`flow-navigation-between-folders.spec.ts` in the same job. Observed victim: on PR
+#1009 the `Run impacted E2E specs` job failed its first attempt on test 3 (~1.0 min)
+and passed on retry.
+
+Measured baseline on `1.12.0.dev8` — the four folder-touching specs run together at
+`--workers=2 --retries=0`, three times:
+
+| Run | Result | `404` on sibling-owned ids |
+|---|---|---|
+| 1 | **1 failed**, 7 passed | 3 (two on `/api/v1/projects/{id}`, one on `/api/v1/flows/{id}/events`) |
+| 2 | 8 passed | 0 |
+| 3 | 8 passed | 1 (on `/api/v1/projects/{id}`) |
+
+`404` on a **project** id is the wiper's fingerprint: a sibling's own cleanup asks
+for a folder the wiper already deleted (same class as #553). The failure in run 1
+is the exact victim named in the issue, and its mechanism is sharper than "a
+timeout":
+
+```
+folder-deletion-integrity.spec.ts:193 › creating a new folder after deletion …
+  Error: expect(received).toBe(expected)   Expected: true  Received: false
+  Timeout 30000ms exceeded while waiting on the predicate
+    at dismissWelcomeOverlayAndWaitForModal (helpers/flows/open-new-flow-templates-modal.ts:106)
+    at addFlowToTestOnEmptyLangflow (helpers/flows/add-flow-to-test-on-empty-langflow.ts:10)
+    at awaitBootstrapTest (helpers/other/await-bootstrap-test.ts:24)
+```
+
+The wiper empties the account mid-flight, so the victim's `awaitBootstrapTest`
+takes the **empty-instance branch** and waits 30 s for a welcome overlay that this
+state does not produce. Scheduling decides who loses: when the wiper happens to be
+scheduled last, the run is clean — which is exactly why the daily sees this as a
+rare flake and why `--workers=1` validation never reproduces it.
+
+**Fix: a lane, not a weaker assertion.** Test 4 keeps deleting for real and keeps
+asserting the real empty-project screen; what changes is *when* it is allowed to
+run:
+
+- `playwright.config.ts` sets `grepInvert: /@destructive/` for every normal run,
+  so the default lane never schedules it. `grepInvert` is used deliberately
+  instead of `grep`: a CLI `--grep` (the daily's `@stable`, nightly's optional
+  filter) **overrides** `config.grep` but leaves `config.grepInvert` in place, so
+  the exclusion cannot be bypassed by accident.
+- Setting `PW_DESTRUCTIVE=1` clears that exclusion and pins the run to
+  `workers: 1` with `fullyParallel: false` — enforced in config, so a caller
+  cannot forget it on the command line.
+- CI runs the lane as a **separate step after** the normal run (`nightly.yml`,
+  `pr-validation.yml`, `adaptive-impacted.yml`, and the shared `run-e2e` action
+  used by `manual.yml`), with `--pass-with-no-tests` so it is a no-op when no
+  destructive test is in scope.
+- To keep the exclusion from becoming a silent cap, a plain run prints a one-line
+  notice naming the tag and the exact command that runs the lane.
+
+**Rejected alternatives, with the reason:**
+
+| Direction | Why not |
+|---|---|
+| Per-test user isolation | Not viable in the UI. `LANGFLOW_AUTO_LOGIN=true` in every workflow and in `start-langflow-docker.sh`; injecting another user's token into the cookies is undone on mount — the app calls `GET /api/v1/auto_login`, overwrites the token, and `whoami` reports the superuser again, with that user's own project invisible in the sidebar (measured on `1.12.0.dev8`; matches the finding in #690). API-level isolation does work, but this test's subject is the UI. |
+| Re-scope with a `page.route` mock | Would keep CI untouched, but the deletion→empty-screen transition stops being end-to-end and becomes "the frontend renders an empty list", which is not what the test is for. |
+| Cross-process lockfile mutex | Preserves the assertion, but requires every sibling folder spec to take a shared lock and silently regresses the moment a future folder spec forgets to. |
+| `test.describe.configure({ mode: "serial" })` | Partial only: removes the intra-file race, not the cross-file one — the wiper deletes folders belonging to three other spec files. |
+
+**Known gap, stated rather than implied:** `daily-stable.yml` runs `--grep
+"@stable"` and has no destructive lane. It does not need one today (test 4 is not
+`@stable`), but that means **a test carrying both `@stable` and `@destructive`
+would silently never run in the daily**. Until the daily grows a lane, treat the
+two tags as mutually exclusive — noted in `CONTRIBUTING.md` next to the tag table.
+
+---
+
+## Validation criterion *(required)*
+
+- **The race is gone where it was observable.** Running the four folder-touching
+  specs together at `--workers=2 --retries=0`
+  (`folder-deletion-integrity`, `folder-crud`, `bulk-actions`,
+  `flow-navigation-between-folders`) produces **no `404` on a sibling-owned flow
+  or project id** and no folder-disappeared timeout, 3× in a row. Before the fix
+  the same command logs `404`s on ids another test is still using.
+- **The default lane really excludes it:** `npx playwright test <spec> --list`
+  reports 3 tests, not 4, and a normal run prints the notice naming
+  `@destructive` and the lane command.
+- **The lane really runs it:** `PW_DESTRUCTIVE=1 npx playwright test <spec>
+  --grep @destructive` reports exactly 1 test and it passes, reaching the real
+  empty-project screen (both the sidebar message and `new_project_btn_empty_page`).
+- **Each test still fails when it should:** every `test()` in the file mutated red
+  one at a time (force-fail), including test 4 inside the lane.
+- **No leaks:** the folders/flows each test creates are gone at the end, and the
+  project count returns to its baseline.
+- Expected residue while #1008 is open: exactly one `🚨 Backend Error: 422 …
+  /api/v1/projects/undefined` from test 4. It is product-side and must not be
+  silenced here.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Folder rename and the create/delete-empty lifecycle — `folder-crud.spec.ts`.
+- Moving flows between folders — `flow-navigation-between-folders.spec.ts` (UI)
+  and `api/flows/api-folders-crud.spec.ts` (API).
+- Bulk selection and multi-delete — `bulk-actions.spec.ts`.
+- Multi-user isolation of folders — not testable through the UI while
+  `LANGFLOW_AUTO_LOGIN=true` (see the lane section).
+- Whether flows inside a deleted folder are cascaded or re-parented — asserted in
+  `folder-crud.spec.ts`, not here.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow reachable at `PLAYWRIGHT_BASE_URL`, auto-login enabled so
+  `getAuthToken()` can mint a bearer for the API setup steps.
+- Test 4 assumes the acting user's folders are all deletable, including the
+  initial Starter Project — true since the initial folder became deletable.
+- Test 4 must run in the destructive lane. Running it beside other specs is the
+  defect this spec's own history documents.
+
+---
+
+## External dependencies *(required)*
+<!-- Files from the Langflow repository that, if changed, could break this test. -->
+
+- `src/backend/base/langflow/api/v1/projects.py` — `DELETE /api/v1/projects/{id}`
+  and the project list endpoint; the `500`-under-contention defect (LE-2020)
+  observed on delete also reaches this spec's cleanup path.
+- `src/frontend/src/pages/MainPage/components/myCollectionComponent/` — renders
+  the `project-sidebar` and its `sidebar-nav-*` entries; the loop in test 4 and
+  every visibility assertion depend on those testids.
+- `src/frontend/src/pages/MainPage/components/dropdown/` — the
+  `more-options-button_{name}` → `btn-delete-project` → confirm path used by
+  tests 2, 3 and 4.
+- `src/frontend/src/pages/MainPage/pages/emptyPage/` — the empty-project screen:
+  the `"Start creating a project or flow"` copy and `new_project_btn_empty_page`
+  testid asserted by test 4; it is also where the `projects/undefined` request of
+  #1008 originates.
+- `src/frontend/src/controllers/API/queries/folders/` — the folder query cache;
+  a stale-cache regression here is exactly what tests 1 and 3 are built to catch.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,12 +10,47 @@ dotenv.config();
  */
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:7860";
 
+/**
+ * Destructive lane (#1010).
+ *
+ * A `@destructive` test mutates account-wide state — today
+ * `folder-deletion-integrity.spec.ts` deleting EVERY project of the shared
+ * superuser to reach the empty-project screen. Under `fullyParallel` that is a
+ * cross-test wiper: it emptied the account under its own file-siblings and under
+ * folder-crud / bulk-actions / flow-navigation-between-folders, whose bootstrap
+ * then took the empty-instance branch and burned a 30s poll on a welcome overlay
+ * that state never produces.
+ *
+ * So the tag is a LANE SELECTOR, not a severity: every normal run excludes it,
+ * and `PW_DESTRUCTIVE=1` runs it alone. Two details are deliberate:
+ *  - the exclusion uses `grepInvert`, not `grep`. A CLI `--grep` (the daily's
+ *    `@stable`, nightly's optional filter) OVERRIDES `config.grep` but leaves
+ *    `config.grepInvert` in place — so no caller can bypass the exclusion by
+ *    passing a filter of its own.
+ *  - the lane pins `workers: 1` / `fullyParallel: false` HERE rather than relying
+ *    on the command line, so a caller cannot forget and let two destructive tests
+ *    wipe each other.
+ */
+const DESTRUCTIVE_LANE = !!process.env.PW_DESTRUCTIVE;
+
+if (!DESTRUCTIVE_LANE) {
+  // Never let the exclusion become a silent cap: say it on every run, with the
+  // exact command that runs what was left out.
+  console.log(
+    "[lane] @destructive tests are excluded from this run — run them with: PW_DESTRUCTIVE=1 npx playwright test --grep @destructive",
+  );
+}
+
 export default defineConfig({
   testDir: "./tests",
+  // The destructive lane runs account-wide wipers, so it must never schedule two
+  // tests at once (see DESTRUCTIVE_LANE above).
+  grepInvert: DESTRUCTIVE_LANE ? undefined : /@destructive/,
   // File-level sharding for the daily's sharded run keeps every test() of a spec
   // file in one shard (so @database state-sharing holds). The sharded job sets
   // PW_SHARD_FILE_LEVEL=1; local dev / nightly / manual keep test-level parallelism.
-  fullyParallel: process.env.PW_SHARD_FILE_LEVEL ? false : true,
+  fullyParallel:
+    DESTRUCTIVE_LANE || process.env.PW_SHARD_FILE_LEVEL ? false : true,
   forbidOnly: !!process.env.CI,
   // PLAYWRIGHT_RETRIES overrides the retry count when set (e.g. a manual
   // validation dispatch passing 0 for a fast, unamplified signal); empty/unset
@@ -32,7 +67,7 @@ export default defineConfig({
   // per shard (~90 tests each) the 2nd worker is a net win — benchmarked at ~28min
   // (workers=2) vs ~39min (workers=1) at N=4, correctness identical. See
   // ISSUE-833-SHARDING-DESIGN.md §"workers per shard".
-  workers: process.env.CI ? 2 : undefined,
+  workers: DESTRUCTIVE_LANE ? 1 : process.env.CI ? 2 : undefined,
   timeout: 5 * 60 * 1000, // 5 minutes per test
   // Reporters run side by side. The Flakiness.io reporter MUST live here, not on
   // the CLI `--reporter` flag, because its `flakinessProject` option (required for

--- a/tests/tests-automations/regression/core-functionality/project-management/folder-deletion-integrity.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/folder-deletion-integrity.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { deleteProject } from "../../../../helpers/flows/delete-project";
 import { MainPage } from "../../../../pages/MainPage";
 
@@ -18,6 +19,65 @@ import { MainPage } from "../../../../pages/MainPage";
  * the integrity properties around deletion and set their fixtures up via the
  * REST API so they don't repeat the UI create/rename steps.
  */
+
+// Ids of flows a test created, deleted id-scoped in afterEach (#515 — never a
+// global cleanAllFlows, which wipes flows other workers are building). Tests 2
+// and 3 open a starter template to reach the folder view through the real
+// navigation path, and opening it CREATES a flow; nothing used to delete it, so
+// every run left one behind (47 flows on the local instance, 20 of them stray
+// "Basic Prompting" copies, before this was added).
+const createdFlowIds: string[] = [];
+
+test.afterEach(async ({ page, request }) => {
+  const ids = [...createdFlowIds];
+  createdFlowIds.length = 0;
+  if (ids.length === 0) return;
+  const authToken = await getAuthToken(request);
+  for (const id of ids) {
+    // Not swallowed silently: a failed cleanup is reported, never hidden — but it
+    // must not fail the hook and mask the assertion that already ran.
+    await deleteFlow(request, id, {
+      headers: { Authorization: authToken },
+    }).catch((error) => {
+      console.warn(`⚠️ Orphan flow left behind (${id}): ${error}`);
+    });
+  }
+});
+
+/**
+ * Opens the starter-template gallery, creates a flow from "Basic Prompting" and
+ * comes back to the folder view — the navigation round-trip tests 2 and 3 use to
+ * reach the sidebar the way a user does. Captures the created flow id from the
+ * creation POST so afterEach can delete exactly that flow.
+ */
+async function openTemplateAndReturnToFolders(page: any) {
+  const flowCreation = page.waitForResponse(
+    (resp: any) =>
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201,
+    { timeout: 30000 },
+  );
+
+  await page.getByTestId("side_nav_options_all-templates").click();
+  await page.getByRole("heading", { name: "Basic Prompting" }).click();
+
+  const created = (await (await flowCreation).json()) as { id?: string };
+  if (created.id) {
+    createdFlowIds.push(created.id);
+  }
+
+  await page.waitForSelector('[data-testid="sidebar-search-input"]', {
+    timeout: 30000,
+  });
+
+  // Go back to folder view
+  await page.getByTestId("icon-ChevronLeft").first().click();
+
+  await page.waitForSelector('[data-testid="add-project-button"]', {
+    timeout: 30000,
+  });
+}
 
 test(
   "deleting a folder should update the folder list immediately",
@@ -80,20 +140,9 @@ test(
   async ({ page }) => {
     await awaitBootstrapTest(page);
 
-    // Navigate to templates
-    await page.getByTestId("side_nav_options_all-templates").click();
-    await page.getByRole("heading", { name: "Basic Prompting" }).click();
-
-    await page.waitForSelector('[data-testid="sidebar-search-input"]', {
-      timeout: 30000,
-    });
-
-    // Go back to folder view
-    await page.getByTestId("icon-ChevronLeft").first().click();
-
-    await page.waitForSelector('[data-testid="add-project-button"]', {
-      timeout: 30000,
-    });
+    // Template round-trip to reach the folder view the way a user does; the
+    // created flow is tracked and deleted in afterEach.
+    await openTemplateAndReturnToFolders(page);
 
     // Create first folder
     await page.getByTestId("add-project-button").click();
@@ -196,20 +245,9 @@ test(
   async ({ page }) => {
     await awaitBootstrapTest(page);
 
-    // Navigate to templates
-    await page.getByTestId("side_nav_options_all-templates").click();
-    await page.getByRole("heading", { name: "Basic Prompting" }).click();
-
-    await page.waitForSelector('[data-testid="sidebar-search-input"]', {
-      timeout: 30000,
-    });
-
-    // Go back to folder view
-    await page.getByTestId("icon-ChevronLeft").first().click();
-
-    await page.waitForSelector('[data-testid="add-project-button"]', {
-      timeout: 30000,
-    });
+    // Template round-trip to reach the folder view the way a user does; the
+    // created flow is tracked and deleted in afterEach.
+    await openTemplateAndReturnToFolders(page);
 
     // Create first folder
     await page.getByTestId("add-project-button").click();
@@ -289,13 +327,24 @@ test(
   },
 );
 
-// NOTE: destructive — this test deletes EVERY folder of the shared superuser.
-// Under fullyParallel it can race with sibling folder tests (delete their
-// folders / be prevented from reaching zero). Proper isolation (a per-test user)
-// is tracked separately; CI retries currently absorb the rare collision.
+// Destructive — this test deletes EVERY folder of the shared superuser, so the
+// `@destructive` tag keeps it out of every normal run and confines it to the
+// low-concurrency lane (`PW_DESTRUCTIVE=1`, workers pinned to 1 in
+// playwright.config.ts). It used to run under fullyParallel beside its own
+// file-siblings and beside folder-crud / bulk-actions /
+// flow-navigation-between-folders: it emptied the account mid-flight and their
+// awaitBootstrapTest then took the empty-instance branch and timed out waiting
+// for a welcome overlay (#1010 — 1 of 3 measured runs failed that way, with 404s
+// on project ids the siblings still owned).
+//
+// The assertions below are unchanged: the deletion is real and the empty-project
+// screen is the real one. Per-test user isolation was measured and is NOT
+// possible while LANGFLOW_AUTO_LOGIN=true — the app re-mints a superuser token on
+// mount. See docs/core-functionality/project-management/folder-deletion-integrity.md
+// (§"The destructive lane") for the rejected alternatives and the daily's known gap.
 test(
   "deleting every folder lands on the empty project screen",
-  { tag: ["@release", "@api"] },
+  { tag: ["@release", "@api", "@destructive"] },
   async ({ page, request }) => {
     // Guarantee there is at least one folder holding a flow, so the
     // "delete everything" path is exercised against real content.


### PR DESCRIPTION
**Closes #1010.**

## Problem

`folder-deletion-integrity.spec.ts` — *"deleting every folder lands on the empty project screen"* — deletes **every folder of the shared superuser**. `playwright.config.ts` runs `fullyParallel: true` with `workers: 2`, and `fullyParallel` distributes tests **within a file** across workers, so the wiper ran beside its own file-siblings and beside `folder-crud.spec.ts`, `bulk-actions.spec.ts` and `flow-navigation-between-folders.spec.ts` in the same job. The file already admitted the hazard in a comment and deferred it to "tracked separately" — this is that.

The mechanism is sharper than the `waitFor` timeout the CI failure on PR #1009 looked like:

```
folder-deletion-integrity.spec.ts:193 › creating a new folder after deletion should work correctly
  Error: expect(received).toBe(expected)   Expected: true  Received: false
  Timeout 30000ms exceeded while waiting on the predicate
    at dismissWelcomeOverlayAndWaitForModal (helpers/flows/open-new-flow-templates-modal.ts:106)
    at addFlowToTestOnEmptyLangflow (helpers/flows/add-flow-to-test-on-empty-langflow.ts:10)
    at awaitBootstrapTest (helpers/other/await-bootstrap-test.ts:24)
```

The wiper empties the account mid-flight, so the victim's `awaitBootstrapTest` takes the **empty-instance branch** and waits 30 s for a welcome overlay that state never produces. Scheduling decides who loses — when the wiper happens to run last the whole set is green, which is why the daily sees a rare flake and `--workers=1` validation never reproduces it.

Per `references/triage-verdicts.md` this is verdict 5, cross-worker destructive cleanup: **fix the wiper, never the victim**. No victim spec is edited, no timeout relaxed, no tag removed.

## Fix — a low-concurrency lane

The wiper keeps deleting for real and keeps asserting the real empty-project screen. What changes is *when* it may run.

```ts
// playwright.config.ts
const DESTRUCTIVE_LANE = !!process.env.PW_DESTRUCTIVE;
grepInvert: DESTRUCTIVE_LANE ? undefined : /@destructive/,
fullyParallel: DESTRUCTIVE_LANE || process.env.PW_SHARD_FILE_LEVEL ? false : true,
workers: DESTRUCTIVE_LANE ? 1 : process.env.CI ? 2 : undefined,
```

- **`grepInvert`, not `grep`** — deliberate: a CLI `--grep` (the daily's `@stable`, nightly's optional filter) *overrides* `config.grep` but leaves `config.grepInvert` in place, so no caller can bypass the exclusion with a filter of its own. Verified: `--grep @release` matches all 4 tests and `--list` still reports 3.
- **`workers: 1` lives in config**, not on the command line, so a caller cannot forget it and let two destructive tests wipe each other.
- **CI runs the lane as a separate step after the normal run** in `nightly.yml`, `pr-validation.yml`, `adaptive-impacted.yml` and the shared `run-e2e` action (used by `manual.yml`) — each with `--pass-with-no-tests` (no-op when nothing destructive is in scope), `--reporter=github` (writes no HTML, so it cannot clobber the main run's `playwright-report/`) and its own `--output` directory.
- **The exclusion announces itself.** Every plain run prints the tag it left out and the exact command that runs it, so this can never become a silent coverage cap.

### Rejected alternatives, with the reason

| Direction | Why not |
|---|---|
| **Per-test user isolation** | Measured, not assumed: with `LANGFLOW_AUTO_LOGIN=true` (every workflow + `start-langflow-docker.sh`) injecting another user's token into the browser cookies is undone on mount — the app fires `GET /api/v1/auto_login`, overwrites the token, `whoami` reports `langflow` again and the probe user's own project is invisible in the sidebar. Matches the #690 finding. API-level isolation *does* work, but this test's subject is the UI. |
| **Re-scope with a `page.route` mock** | Leaves CI untouched, but the deletion→empty-screen transition stops being end-to-end and becomes "the frontend renders an empty list". |
| **Cross-process lockfile mutex** | Keeps the assertion, but requires every sibling folder spec to take a shared lock and silently regresses the moment a future folder spec forgets. |
| **`mode: "serial"` on the file** | Partial only — removes the intra-file race, not the cross-file one. The wiper deletes folders belonging to three other spec files. |

## Also fixed — an orphan-flow leak in the same spec

Found while checking the orphan count (standing rule: every touched spec cleans up its own flows id-scoped). Tests 2 and 3 open the "Basic Prompting" starter template to reach the folder view through the real navigation path — and opening a template **creates a flow**, which nothing deleted. The local instance had **47 flows, 20 of them stray `Basic Prompting` copies**. They now capture the id from the creation `POST` and delete exactly that flow in an `afterEach` (#515 pattern, never a global wipe).

## Validation (nightly `1.12.0.dev8`, `--retries=0`)

**The criterion** — the four folder-touching specs run together at `--workers=2`:

| | Failures | `404` on a **project** id (the wiper's fingerprint) |
|---|---|---|
| **Before** (3 runs) | **1** | 3, across 2 of the 3 runs |
| **After** (6 runs) | **0** | **0** |

- **Residual, reported not silenced:** 1 of those 6 runs logged five `404`s on one *flow* id, with the `/events?since=` + `/note_translations` signature of an open editor polling a deleted flow. Not the wiper — it is excluded from those runs and the `422` it emits disappeared with it — and not reproducible in pairs (`folder-deletion-integrity` alone, `+bulk-actions`, `+folder-crud`: 0 `404`s each). A separate collider; it gets its own issue rather than being folded in here.
- **3× `--workers=1 --retries=0`** on the spec: `expected=3 unexpected=0 flaky=0 backendErrors=false`. The `3` (not 4) is the lane working. **`backendErrors=false` is a side effect worth naming:** the #1008 `422` came from the wiper, so this file no longer trips the pipeline gate that #1008 was blocking — #1008 itself stays open, the `422` now appears only in the lane.
- **The lane:** `PW_DESTRUCTIVE=1 npx playwright test <spec> --grep @destructive` → `Total: 1 test`, `1 passed (6.4s)`, reaching the real empty-project screen (sidebar message + `new_project_btn_empty_page`), with the expected #1008 `422` there.
- **Force-fail:** all **4** tests mutated red one at a time and restored byte-for-byte, 0 `FF-MUTATION` markers left. The 4th ran **inside** the lane — without `PW_DESTRUCTIVE` it would have been a vacuous pass-with-no-tests, which is itself a check that the gating is real.
- **Orphans:** local instance purged back to its 28-flow baseline before the runs; nothing left after them.
- typecheck ✅ · eslint ✅ · QA-CHECKLIST guard ✅ · spec↔doc↔checklist coverage guard ✅ · all four edited YAML files parse ✅

## Known gap, documented rather than implied

`daily-stable.yml` filters `--grep "@stable"` and has **no destructive lane**. It needs none today (the wiper is not `@stable`), but that means a test carrying **both** tags would be excluded from the daily and silently never run. `@stable` and `@destructive` are recorded as mutually exclusive in the `CLAUDE.md` tag table and in `CONTRIBUTING.md` until the daily grows a lane of its own.

## Docs

The spec had **no doc** under `docs/` — one is added (`docs/core-functionality/project-management/folder-deletion-integrity.md`) with the four tests, the lane, the measured baseline, the rejected directions and the daily gap. The two existing `[-]` checklist bullets (*Integrity after deletion*, *Create folder after deleting all folders*) get the spec reference the coverage guard requires, plus a new bullet for the wiper. They stay `[-]`, not `[x]` — the spec is not `@stable` while #1008 is open.

## Reproduce locally

```bash
D=tests/tests-automations/regression/core-functionality/project-management

# default lane — 3 tests, the destructive one excluded (the run says so)
npx playwright test $D/folder-deletion-integrity.spec.ts --workers=1 --retries=0

# the destructive lane — 1 test, alone (DELETES every project of the local superuser)
PW_DESTRUCTIVE=1 npx playwright test $D/folder-deletion-integrity.spec.ts --grep "@destructive" --retries=0

# the criterion — the scenario that used to break
npx playwright test $D/folder-deletion-integrity.spec.ts $D/folder-crud.spec.ts \
  $D/bulk-actions.spec.ts $D/flow-navigation-between-folders.spec.ts --workers=2 --retries=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
