### PR TITLE
fix(config): keep playwright.config.ts off stdout so the daily's shard matrix survives

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -526,7 +526,7 @@ jobs:
           # in #1011: a guard asserting "complete" over a run that executed nothing.
           case "$EXPECTED" in
             ''|*[!0-9]*)
-              echo "::warning::prep produced no usable shard_total ('$EXPECTED') — the run never got a shard matrix, so no shard could report. Treating the merged report as INCOMPLETE."
+              echo "::warning::prep produced no usable shard_total ('$EXPECTED') — the run never got a shard matrix, so no shard could report ($FOUND blob(s) present). Treating the merged report as INCOMPLETE."
               echo "complete=false" >> "$GITHUB_OUTPUT"
               exit 0
               ;;

--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -515,6 +515,22 @@ jobs:
           mkdir -p all-blobs
           # After merge-multiple, blobs are flat *.zip files (one per shard), not subdirs.
           FOUND="$(find all-blobs -maxdepth 1 -name '*.zip' | wc -l | tr -d ' ')"
+          # An empty (or non-numeric) shard_total means `prep` ITSELF failed, so the
+          # run never got a matrix and no shard could have produced anything — the
+          # most incomplete a run can be. Decide that explicitly, because the
+          # comparison below silently calls it COMPLETE (#1024): `[ 0 -lt "" ]`
+          # errors with "integer expression expected", and a failing command inside
+          # an `if` condition is not fatal under `set -e`, so it falls through to
+          # the else. Defaulting EXPECTED to 0 does not help either — `0 -lt 0` is
+          # false and lands in the same else. Same shape as the hole always() closed
+          # in #1011: a guard asserting "complete" over a run that executed nothing.
+          case "$EXPECTED" in
+            ''|*[!0-9]*)
+              echo "::warning::prep produced no usable shard_total ('$EXPECTED') — the run never got a shard matrix, so no shard could report. Treating the merged report as INCOMPLETE."
+              echo "complete=false" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
           echo "Expected $EXPECTED shard blobs, found $FOUND."
           if [ "$FOUND" -lt "$EXPECTED" ]; then
             echo "::warning::Only $FOUND/$EXPECTED shard blobs present — the merged report is INCOMPLETE (a shard died before producing a blob). Failures may be under-counted."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -540,7 +540,12 @@ Next to the code it covers, named `*.test.ts` (or `*.test.mjs` for the dependenc
 scripts/lib/stable-tests.ts             →  scripts/lib/stable-tests.test.ts
 scripts/remove-stable-from-failures.ts  →  scripts/remove-stable-from-failures.test.ts
 tests/helpers/provider-setup/x.ts       →  tests/helpers/provider-setup/x.test.ts
+playwright.config.ts                    →  playwright.config.test.ts
 ```
+
+The discovery roots are `scripts/`, `tests/` and the repo root's top level (not recursive
+outside those two) — so a `*.test.ts` anywhere else is **not run**, which is the one way to
+add a unit test that silently never executes.
 
 Never validate a helper in a scratch file outside the repo. That is what left the
 `collect-models` fallback with its only regression net living in a PR description

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:integrations": "npx playwright test tests/core/integrations/",
     "test:unit": "npx playwright test tests/core/unit/",
     "test:scripts": "node --test scripts/",
-    "test:units": "files=$(find scripts tests -name '*.test.ts' -not -path '*/node_modules/*' | sort); [ -n \"$files\" ] || { echo 'no *.test.ts found — the TypeScript unit lane would silently pass' >&2; exit 1; }; node --require ts-node/register --test $files",
+    "test:units": "files=$( { find . -maxdepth 1 -name '*.test.ts'; find scripts tests -name '*.test.ts' -not -path '*/node_modules/*'; } | sort); [ -n \"$files\" ] || { echo 'no *.test.ts found — the TypeScript unit lane would silently pass' >&2; exit 1; }; node --require ts-node/register --test $files",
     "test:regression": "npx playwright test tests/core/regression/ tests/extended/regression/",
     "test:grep": "npx playwright test --grep",
     "report": "npx playwright show-report",

--- a/playwright.config.test.ts
+++ b/playwright.config.test.ts
@@ -1,0 +1,115 @@
+// Unit test for the Playwright config's STDOUT contract (issue #1024).
+// Run with: npm run test:units
+//
+// Nothing in this module may write to stdout. It is imported by every
+// `playwright` invocation, and one of them has a machine-readable stdout:
+// `daily-stable.yml`'s `prep` job runs
+//
+//   npx playwright test --grep "@stable" --list --reporter=json > /tmp/stable-list.json
+//
+// and feeds that file to `partition-shards.mjs matrix`. PR #1021 added a
+// `console.log` announcing the `@destructive` lane exclusion — a good idea on the
+// wrong channel: the line landed ahead of the JSON, the partitioner exited 1, and
+// the daily would have died at `prep` with zero tests executed. No PR check could
+// catch it, because `pr-validation.yml` uses `--reporter=github` and `line`.
+//
+// This is the cheap check that closes that gap. stderr is deliberately NOT
+// asserted on: keeping the exclusion visible in the log is the point of #1010, it
+// just has to happen off the data path.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+const REPO_ROOT = __dirname;
+
+/**
+ * Import the config in a FRESH process and hand back what each stream received.
+ * A fresh process matters twice: this file's own runner has already loaded
+ * modules that could mask a write, and the top-level `if (!DESTRUCTIVE_LANE)`
+ * only runs on first import — a cached module would make the test vacuous.
+ */
+function importConfig(env: Record<string, string> = {}): { stdout: string; stderr: string } {
+  // spawnSync, not execFileSync: the two streams must be read from ONE run and
+  // kept apart, so a noisy stderr can never be mistaken for a stdout write.
+  const run = spawnSync(
+    process.execPath,
+    ["--require", "ts-node/register", "-e", 'require("./playwright.config");'],
+    {
+      cwd: REPO_ROOT,
+      encoding: "utf-8",
+      env: { ...process.env, ...env },
+    },
+  );
+  assert.equal(run.status, 0, `importing the config failed: ${run.stderr}`);
+  return { stdout: run.stdout, stderr: run.stderr };
+}
+
+test("importing playwright.config.ts writes NOTHING to stdout", () => {
+  const { stdout } = importConfig();
+  assert.equal(
+    stdout,
+    "",
+    `playwright.config.ts wrote to stdout, which breaks the JSON contract the ` +
+      `daily's shard matrix depends on (#1024). Move it to console.error. Got: ${JSON.stringify(stdout)}`,
+  );
+});
+
+test("the destructive-lane notice still reaches stderr", () => {
+  // The exclusion must not become a silent cap (#1010) — it just has to announce
+  // itself off the data path.
+  const { stderr } = importConfig();
+  assert.match(stderr, /@destructive tests are excluded/);
+  assert.match(stderr, /PW_DESTRUCTIVE=1/);
+});
+
+test("stdout stays clean in the destructive lane too", () => {
+  const { stdout, stderr } = importConfig({ PW_DESTRUCTIVE: "1" });
+  assert.equal(stdout, "");
+  // Inside the lane there is nothing to announce — the tests are running.
+  assert.doesNotMatch(stderr, /@destructive tests are excluded/);
+});
+
+test("the daily's prep command produces parseable JSON", () => {
+  // The end-to-end assertion, run exactly as `daily-stable.yml`'s `prep` job does
+  // (line 81) rather than trusting the unit checks above to imply it. Kept to
+  // `--list`, so nothing executes and no backend is needed.
+  const listed = execFileSync(
+    "npx",
+    ["playwright", "test", "--grep", "@stable", "--list", "--reporter=json"],
+    { cwd: REPO_ROOT, encoding: "utf-8", maxBuffer: 64 * 1024 * 1024, stdio: ["ignore", "pipe", "ignore"] },
+  );
+
+  const report = JSON.parse(listed) as { suites?: unknown[] };
+  assert.ok(Array.isArray(report.suites), "the listed report has no suites array");
+  assert.ok(report.suites.length > 0, "no @stable specs were listed");
+
+  // And the consumer itself: `partition-shards.mjs matrix` is what actually dies
+  // on a polluted stdout, so run it over this output and require a usable matrix.
+  // Through a real file, exactly as the workflow does (`> /tmp/stable-list.json`),
+  // rather than `/dev/stdin` — the script reads its argument with readFileSync.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "prep-1024-"));
+  try {
+    const listPath = path.join(dir, "stable-list.json");
+    fs.writeFileSync(listPath, listed);
+    const matrix = execFileSync(
+      process.execPath,
+      [
+        path.join(REPO_ROOT, "scripts", "partition-shards.mjs"),
+        "matrix",
+        listPath,
+        path.join(REPO_ROOT, "reports", "spec-durations.json"),
+        "4",
+      ],
+      { cwd: REPO_ROOT, encoding: "utf-8", maxBuffer: 64 * 1024 * 1024 },
+    );
+
+    const parsed = JSON.parse(matrix) as { include?: Array<{ shard: number; files: string }> };
+    assert.ok(Array.isArray(parsed.include), "the matrix has no include array");
+    assert.equal(parsed.include!.length, 4);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/playwright.config.test.ts
+++ b/playwright.config.test.ts
@@ -24,27 +24,59 @@ import * as os from "os";
 import * as path from "path";
 
 const REPO_ROOT = __dirname;
+/** The local CLI entrypoint. NOT `npx`, which downloads from the registry when the
+ *  binary is missing instead of failing — a test must not be able to reach the network. */
+const PLAYWRIGHT_CLI = path.join(REPO_ROOT, "node_modules", "@playwright", "test", "cli.js");
 
 /**
  * Import the config in a FRESH process and hand back what each stream received.
  * A fresh process matters twice: this file's own runner has already loaded
  * modules that could mask a write, and the top-level `if (!DESTRUCTIVE_LANE)`
  * only runs on first import — a cached module would make the test vacuous.
+ *
+ * Hermetic against the developer's environment on purpose, in two ways:
+ *  - `PW_DESTRUCTIVE` is stripped from the inherited env. The very notice these
+ *    tests assert on tells the reader to run `PW_DESTRUCTIVE=1 npx playwright
+ *    test --grep @destructive`; exporting it and then running the lane in the
+ *    same shell would fail with a message blaming the config, not the shell.
+ *  - the child runs from an EMPTY cwd, because `playwright.config.ts` calls
+ *    `dotenv.config()`, which reads `.env` relative to cwd — and `.env` is
+ *    developer-local and git-ignored, so it could inject the same variable
+ *    invisibly. That means requiring the config by absolute path and pointing
+ *    ts-node at the repo tsconfig explicitly, since it resolves from cwd too.
  */
 function importConfig(env: Record<string, string> = {}): { stdout: string; stderr: string } {
-  // spawnSync, not execFileSync: the two streams must be read from ONE run and
-  // kept apart, so a noisy stderr can never be mistaken for a stdout write.
-  const run = spawnSync(
-    process.execPath,
-    ["--require", "ts-node/register", "-e", 'require("./playwright.config");'],
-    {
-      cwd: REPO_ROOT,
-      encoding: "utf-8",
-      env: { ...process.env, ...env },
-    },
-  );
-  assert.equal(run.status, 0, `importing the config failed: ${run.stderr}`);
-  return { stdout: run.stdout, stderr: run.stderr };
+  const base = { ...process.env };
+  delete base.PW_DESTRUCTIVE;
+
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "config-1024-"));
+  try {
+    // spawnSync, not execFileSync: the two streams must be read from ONE run and
+    // kept apart, so a noisy stderr can never be mistaken for a stdout write.
+    const run = spawnSync(
+      process.execPath,
+      [
+        "--require",
+        // Absolute: a bare specifier would be resolved against the empty cwd.
+        require.resolve("ts-node/register"),
+        "-e",
+        `require(${JSON.stringify(path.join(REPO_ROOT, "playwright.config.ts"))});`,
+      ],
+      {
+        cwd,
+        encoding: "utf-8",
+        env: {
+          ...base,
+          ...env,
+          TS_NODE_PROJECT: path.join(REPO_ROOT, "tsconfig.json"),
+        },
+      },
+    );
+    assert.equal(run.status, 0, `importing the config failed: ${run.stderr}`);
+    return { stdout: run.stdout, stderr: run.stderr };
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
 }
 
 test("importing playwright.config.ts writes NOTHING to stdout", () => {
@@ -77,8 +109,8 @@ test("the daily's prep command produces parseable JSON", () => {
   // (line 81) rather than trusting the unit checks above to imply it. Kept to
   // `--list`, so nothing executes and no backend is needed.
   const listed = execFileSync(
-    "npx",
-    ["playwright", "test", "--grep", "@stable", "--list", "--reporter=json"],
+    process.execPath,
+    [PLAYWRIGHT_CLI, "test", "--grep", "@stable", "--list", "--reporter=json"],
     { cwd: REPO_ROOT, encoding: "utf-8", maxBuffer: 64 * 1024 * 1024, stdio: ["ignore", "pipe", "ignore"] },
   );
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,7 +36,15 @@ const DESTRUCTIVE_LANE = !!process.env.PW_DESTRUCTIVE;
 if (!DESTRUCTIVE_LANE) {
   // Never let the exclusion become a silent cap: say it on every run, with the
   // exact command that runs what was left out.
-  console.log(
+  //
+  // stderr, NOT stdout (#1024). This module is imported by every `playwright`
+  // invocation, including `--list --reporter=json`, whose STDOUT is a machine
+  // contract: `daily-stable.yml`'s `prep` job redirects it into a file and feeds
+  // that to `partition-shards.mjs matrix`. One line ahead of the JSON made the
+  // file unparseable, the partitioner exited 1, and the daily died before a
+  // single test ran. stderr keeps the line just as visible in the Actions log —
+  // and `playwright-config.test.ts` now asserts stdout stays clean.
+  console.error(
     "[lane] @destructive tests are excluded from this run — run them with: PW_DESTRUCTIVE=1 npx playwright test --grep @destructive",
   );
 }


### PR DESCRIPTION
## Type

- [x] `fix` — fix for a broken or flaky test

---

## Roadmap linkage (required — do not delete)

- [ ] **Current wave** — a `roadmap`-labeled issue in the current wave's milestone: #___
- [x] **Exception** — off-wave work backed by an issue: a follow-up, a `daily-failure` triage issue, or a `community`-labeled regression. Issue #1024 (`qa-infra` + `follow-up`, a regression introduced by #1010 / PR #1021 earlier today)

---

## What this PR does

Stops tonight's daily from dying at `prep` with zero tests executed.

`playwright.config.ts` is imported by **every** `playwright` invocation, and one of them has a machine-readable stdout — `daily-stable.yml:81`:

```bash
npx playwright test --grep "@stable" --list --reporter=json > /tmp/stable-list.json
MATRIX="$(node scripts/partition-shards.mjs matrix /tmp/stable-list.json …)"
```

PR #1021's `console.log` announcing the `@destructive` lane exclusion landed one line ahead of the JSON. Reproduced on `main` at `ffac90b`, then again after the fix:

| | first 40 bytes of `/tmp/stable-list.json` | `partition-shards.mjs matrix` |
|---|---|---|
| before | `[lane] @destructive tests are exc` | **exit 1** — `Unexpected token 'l'` |
| after | `{\n  "config": {\n    "configFile"` | **exit 0** |

No shard matrix means no shards, which means a full day of `@stable` coverage lost. **No PR check could have caught it** — `pr-validation.yml` uses `--reporter=github` and `line`, so the JSON path is never exercised there. That is why the fix ships with a test rather than alone.

### 1. `console.log` → `console.error` (`e62480f`)

#1021's intent is untouched: an exclusion must never become a silent cap (#570's class), so the line still prints on every run — verified still visible, now on stderr, where no stdout pipeline can swallow it. A naive "delete the log line" fix would have traded this bug for that one.

### 2. A regression test in the #1017 lane (`17037a4`)

Four tests — the check that would have failed PR #1021 in CI instead of at 05:00 BRT:

- importing the config writes **nothing** to stdout — in a fresh process per import, since the top-level `if (!DESTRUCTIVE_LANE)` runs only on first import and a cached module would make the assertion vacuous;
- the notice **still reaches stderr** — #1010's requirement, asserted so the fix cannot regress into deletion;
- stdout stays clean inside the lane too (`PW_DESTRUCTIVE=1`);
- **end-to-end**: the `prep` command's output parses *and* `partition-shards.mjs matrix` yields a 4-shard include array from it. Kept to `--list`, so nothing executes and no backend is needed.

### 3. `shardguard` no longer calls a matrix-less run "complete" (`f2735a9`)

Found while tracing what the existing guards do when `prep` fails — see below. `needs.prep.outputs.shard_total` is empty in that case, and `[ 0 -lt "" ]` errors with `integer expression expected`, which is **not** fatal inside an `if` condition under `set -e`, so it falls through to the `else`. Verified over all three states:

```
EXPECTED=""  FOUND=0  → complete=false   (+ a warning naming the cause)
EXPECTED=4   FOUND=4  → complete=true
EXPECTED=4   FOUND=2  → complete=false
```

Defaulting `EXPECTED` to `0` does **not** fix it — `0 -lt 0` is false and lands in the same `else`. The case is decided explicitly, using the `''|*[!0-9]*` idiom the `prep` job already applies to its own input.

---

## What this PR does not cover

- **The existing zero-test guards needed no change** — and that is a finding, not an omission. Traced rather than assumed: `merge` runs on `if: always()`, the blob download fails, `Merge blob reports` is skipped so `results.json` never exists, `runguard` reports `empty=true` (fail-closed on a missing report), the **"executed ZERO tests" issue opens**, and both write paths — `@stable` auto-removal and the `spec-durations.json` refresh — stay blocked. What carries it is `|| steps.runguard.outputs.empty == 'true'` on line 752 from #1012: a failed `prep` leaves the `test` job **`skipped`**, not `failure`, so the other half of that condition is false. The guards buy attribution, not recovery — exactly as PR #1015 recorded under *Known limitations* — which is why fix 1 matters.
- **Other stdout writers.** Audited: `daily-stable.yml:81` is the only place that pipes Playwright's stdout into a JSON file. Every other consumer sets `PLAYWRIGHT_JSON_OUTPUT_NAME` / `PLAYWRIGHT_JSON`, where the reporter writes the file itself and a `console.log` cannot reach it. The new test guards the config against *any* future stdout write regardless.
- **The `@destructive` lane itself** (#1010 / PR #1021) is left exactly as designed — this changes the channel of one line, not the lane.

---

## Known limitations

- **The workflow YAML change has no local proof path.** The `shardguard` bash was extracted and exercised over all three input states (above), but the step's wiring — `needs.prep.outputs.shard_total` being empty on a failed `prep` — is a GitHub Actions behaviour that only the real workflow shows. It is also the branch that fires *only* when the daily is already broken, so a green daily will not exercise it. Watch the `Guard — every expected shard produced a blob` step the next time `prep` fails.
- **The end-to-end test costs ~0.9 s** (measured from the TAP `duration_ms`, corroborated by the `TypeScript Check` job going 46 s → 49 s for all four tests). An earlier revision of this description claimed ~15-20 s — an estimate that was never measured; the full `--list` over 246 spec files is simply much cheaper than assumed.

---

## Review round (independent review of this PR)

Four findings, all fixed in `862c3fb`, each verified by reproducing the failure first. The two audits that mattered most both came back clean and are recorded here so they are not re-litigated:

- **The fix is not a lateral move.** No workflow feeds Playwright's *stderr* into a parser — every `2>&1` in `.github/` belongs to `curl`, `docker` or `git`. Had one piped stderr into a JSON file, this PR would have traded one bug for another.
- **`daily-stable.yml:81` really is the only stdout→JSON pipe**, as claimed above.

One suspicion was investigated and **dismissed**: `assert.equal(parsed.include.length, 4)` looked brittle, since the `@stable` file set is mutated on `main` without review by the auto-removal. It is not — `buildShards` allocates exactly `n` bins via `Array.from({length: n})`, verified with a 2-file list producing 4 shards (two of them empty).

### The tests were not hermetic

```console
$ PW_DESTRUCTIVE=1 node --require ts-node/register --test playwright.config.test.ts
not ok 2 - the destructive-lane notice still reaches stderr
# pass 3 | fail 1
```

A self-inflicted trap: the notice these tests assert on is what tells the reader to run `PW_DESTRUCTIVE=1 npx playwright test --grep @destructive`. Doing that and then running the lane in the same shell went red — with a message blaming the config rather than the environment. Same vector through `.env`, which is developer-local and git-ignored, because the config calls `dotenv.config()` (which reads `.env` relative to cwd).

Both closed: the variable is stripped from the child env, and the child runs from an **empty temp cwd** so no `.env` is in reach. That required requiring the config by absolute path, pointing ts-node at the repo tsconfig, and resolving `ts-node/register` absolutely as well — a bare `--require` specifier resolves against cwd, and failed outright until that last part. Verified 4/4 under both vectors, and the tests still fail 3 of 4 when `console.log` is restored.

### `npx` could have reached the network

`execFileSync("npx", ["playwright", ...])` **downloads from the registry** when the binary is missing rather than failing. Replaced with the local `@playwright/test/cli.js` entrypoint. No behaviour change in CI, where it is installed.

### The new `shardguard` warning omitted the blob count

The step computes `FOUND` and the new branch reported only the bad `EXPECTED`. The count is half the diagnosis for whoever reads that annotation:

```
::warning::prep produced no usable shard_total ("") — the run never got a shard matrix,
so no shard could report (0 blob(s) present). Treating the merged report as INCOMPLETE.
```

### Noted, not changed

Test 1 asserts the **whole process** wrote nothing to stdout, not only the config — broader than the stated contract, and deliberately so: the JSON pipeline breaks regardless of who wrote the bytes. A concrete case it would catch: `dotenv` v17 prints a tips banner to stdout. The repo pins `^16.4.5`, so that needs a major bump — and this test is what would flag it.

---

## Related issue

Closes #1024

---

## Validation

### The bug, before and after

```console
# BEFORE (main @ ffac90b) — the daily's prep step, verbatim
$ npx playwright test --grep "@stable" --list --reporter=json > /tmp/stable-list.json
$ node scripts/partition-shards.mjs matrix /tmp/stable-list.json reports/spec-durations.json 4
Unexpected token 'l', "[lane] @des"... is not valid JSON   → exit 1

# AFTER (this branch)
$ node scripts/partition-shards.mjs matrix /tmp/stable-list.json reports/spec-durations.json 4
→ exit 0

# and the notice is still there, on stderr
$ npx playwright test --grep "@stable" --list --reporter=json 2>&1 >/dev/null | head -1
[lane] @destructive tests are excluded from this run — run them with: PW_DESTRUCTIVE=1 …
```

### The test fails when the bug returns

Restoring `console.log` fails **3 of the 4**, the end-to-end one included:

```
not ok 1 - importing playwright.config.ts writes NOTHING to stdout
not ok 2 - the destructive-lane notice still reaches stderr
not ok 4 - the daily's prep command produces parseable JSON
# pass 1 | fail 3
```

### Repo checks

- [x] `npm run test:units` — **42 passed** (38 + the 4 here)
- [x] `npm run test:scripts` — 22 passed
- [x] `npm run typecheck`, `npm run lint:ci` — clean
- [x] The `prep` command reproduced verbatim post-fix: parseable JSON, `partition-shards.mjs matrix` exit 0
- [x] `shardguard` bash exercised over all three `EXPECTED`/`FOUND` states
- [x] Root-level discovery added to `npm run test:units`, without which `playwright.config.test.ts` would have been collected by nothing and passed silently — the failure mode #1017's lane exists to end. Roots documented in `CONTRIBUTING.md`.

Not applicable: no Playwright spec added or modified, so no `--trace=on` walkthrough, no `QA-CHECKLIST.md` change and no `QA-SCENARIOS-GUIDE.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

