### PR TITLE
test(ui-ux): cover the component context menu and the main menu (#945)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -745,9 +745,9 @@
 - [-] Delete sticky note
 
 #### 15.9 Right-Click and Menus
-- [-] Context menu via right-click on canvas
-- [-] Context menu via right-click on component
-- [-] Main menu actions
+- [~] Context menu via right-click on canvas — **no product surface on 1.12.0.dev8**: a right-click on `.react-flow__pane` dispatches a `contextmenu` event that reaches `document` with `defaultPrevented === false` (so the browser's native menu is what opens) and renders zero `[role="menu"]` / `[role="listbox"]` / Radix popper elements, with or without a node selected — Langflow does not wire ReactFlow's `onPaneContextMenu`. Edge menus (`edge-context-menu-trigger`) are a left-click affordance and belong to §15.3 (#945)
+- [x] Context menu via right-click on component — one right-click selects the node AND opens its options menu with the exact ordered item contract (Save/Duplicate/Copy/Docs/Minimize/Freeze/Download/Delete), Escape closes it, and choosing Duplicate from that menu adds the node → `ui-ux/right-click-dropdown.spec.ts`
+- [x] Main menu actions — the header account menu lists all nine `menu_*_button` items, its version row matches `GET /api/v1/version`, the four external items carry their documented `href`/`target=_blank`, Escape closes it, and the Settings item routes to `/settings` → `ui-ux/main-menu-actions.spec.ts`
 
 #### 15.10 Settings and UI Configuration
 - [x] Access Settings page — profile menu opens Settings, the sidebar lists General/Model Providers/Shortcuts/Messages, and each section renders its own content (General shows the Language + Profile Picture groups) → `ui-ux/settings-navigation.spec.ts`, `ui-ux/settings-general-section.spec.ts`

--- a/docs/ui-ux/main-menu-actions.md
+++ b/docs/ui-ux/main-menu-actions.md
@@ -1,0 +1,80 @@
+# Spec: App Header — Main Menu Contract and Actions
+
+**Test file:** `tests/tests-automations/regression/ui-ux/main-menu-actions.spec.ts`
+
+## What this test validates
+
+Covers the `§15.9 — Main menu actions` checklist item. On `1.12.x` the flow
+editor no longer has a dedicated "menu bar" dropdown — the breadcrumb's
+`menu_bar_display` button opens the **Flow settings** dialog, and the
+application's main menu is the header account menu (`user_menu_button`), whose
+items are named `menu_*_button` in the source. That menu is the surface tested
+here.
+
+Two independent tests, both from the flows list (no flow is created):
+
+1. **The main menu opens with its full item contract** — clicking
+   `user_menu_button` opens a `role="menu"` (`data-state="open"`) exposing
+   `menu_version_button`, `menu_settings_button`, the four external links
+   (`menu_docs_button`, `menu_github_button`, `menu_discord_button`,
+   `menu_twitter_button`) and the theme trio (`menu_light_button`,
+   `menu_dark_button`, `menu_system_button`). The **version row** shows the exact
+   version reported by `GET /api/v1/version` — a cross-layer assert: the menu
+   cannot pass on a stale or hardcoded string. Each external link carries its
+   expected `href` and `target="_blank"`. `Escape` closes the menu.
+2. **A main-menu action navigates** — `menu_settings_button` closes the menu and
+   routes to `/settings`, with the Settings header rendered.
+
+Sibling coverage, deliberately not duplicated here:
+
+- `ui-ux/settings-navigation.spec.ts` (§15.10) — the Settings **page** structure
+  and its sidebar sections. Test 2 above only proves the menu→route wiring.
+- `ui-ux/settings-theme-toggle.spec.ts` (§15.10) — actually switching theme.
+  This spec asserts the three theme buttons **exist** and never clicks them:
+  theme is persisted per user, so clicking would mutate state shared with every
+  other spec on the instance.
+
+## Tags
+
+`@stable` `@release` `@mainpage` `@ui-ux` `@settings`
+
+## Validation criterion
+
+| Step | Criterion |
+|---|---|
+| Click `user_menu_button` | a `[role="menu"]` with `data-state="open"` is visible |
+| Item contract | `menu_version_button`, `menu_settings_button`, `menu_docs_button`, `menu_github_button`, `menu_discord_button`, `menu_twitter_button`, `menu_light_button`, `menu_dark_button`, `menu_system_button` are all visible inside that menu |
+| Version row | the row containing `menu_version_button` contains the `version` string returned by `GET /api/v1/version` |
+| External links | `Docs` → `https://docs.langflow.org`, `GitHub` → `https://github.com/langflow-ai/langflow`, `Discord` → `https://discord.com/invite/EqksyE2EX9`, `X` → `https://x.com/langflow_ai`, each with `target="_blank"` |
+| `Escape` | the `role="menu"` element is detached |
+| Click `menu_settings_button` | URL matches `/settings` and `settings_menu_header` is visible; the menu is closed |
+
+Non-criteria (deliberate):
+
+- **The freshness suffix is not asserted.** The version row renders
+  `1.12.0.dev8 (latest)`; the `(latest)` / `(update available)` part depends on
+  Langflow reaching GitHub's release feed from the test host, so only the version
+  substring is asserted.
+- **No logout item is asserted.** The E2E instance runs with
+  `LANGFLOW_AUTO_LOGIN=true`, under which the menu renders no logout entry.
+  Session/logout behavior belongs to the `@auth` specs.
+- **External links are never clicked** — asserting `href` + `target` keeps the
+  test offline and deterministic; opening a real tab to `x.com` would make the
+  suite depend on third-party availability.
+- **`menu_version_button` is not clicked.** It is a label span, not an action.
+
+## External dependencies
+
+- `src/frontend/src/components/core/appHeaderComponent/components/AccountMenu/index.tsx`
+  — `user_menu_button` and every `menu_*_button` testid, plus the four external
+  URLs asserted above.
+- `GET /api/v1/version` — the authoritative version string compared against the
+  menu row.
+- `src/frontend/src/pages/SettingsPage/index.tsx` — `settings_menu_header`.
+
+No provider API key, no LLM call, no flow creation — the spec is read-only UI
+navigation and leaves no state behind (no cleanup needed).
+
+## Last validated
+
+1.12.x (nightly `1.12.0.dev8`)

--- a/docs/ui-ux/right-click-dropdown.md
+++ b/docs/ui-ux/right-click-dropdown.md
@@ -1,0 +1,107 @@
+# Spec: Canvas — Right-Click Context Menu on a Component
+
+**Test file:** `tests/tests-automations/regression/ui-ux/right-click-dropdown.spec.ts`
+
+## What this test validates
+
+Covers the `§15.9 — Context menu via right-click on component` checklist item:
+a single right-click on a canvas node must (a) select that node, exactly like a
+left-click would, and (b) open the node's options menu immediately — no prior
+left-click, no hover on the toolbar's `...` button.
+
+Two independent tests on a blank flow holding a single **Prompt Template** node:
+
+1. **Right-click opens the menu and selects the node** — starting from an
+   unselected canvas, one right-click on the node makes it `.selected` and opens
+   the options menu (`role="listbox"`, `data-state="open"`) with its full ordered
+   item contract: `Save`, `Duplicate`, `Copy`, `Docs`, `Minimize`, `Freeze`,
+   `Download`, `Delete`. A single `Escape` closes the menu **and** clears the
+   node selection — measured on `1.12.0.dev8`; `Escape` is also the canvas
+   deselect shortcut (§15.4), and one keypress performs both.
+2. **A menu item picked from the right-click menu acts on that node** —
+   reopening the menu and choosing `Duplicate` adds exactly one node to the
+   canvas (1 → 2) and closes the menu. This proves the right-click path is wired
+   to the real actions, not just rendering a decorative popover.
+
+The menu item set is **component-dependent** — `Freeze` renders for Prompt
+Template but not for Chat Input / Language Model on `1.12.0.dev8`. The exact
+ordered list is therefore asserted for **Prompt Template only**; that component
+is the spec's fixture and is added deterministically from the sidebar.
+
+Sibling coverage, deliberately not duplicated here:
+
+- `core-components/componentDelete.spec.ts` — deleting via the toolbar `...`
+  menu (`icon-MoreHorizontal` → `icon-Delete`), §15.4.
+- `ui-ux/minimize.spec.ts` — Minimize/Expand through the toolbar menu, §15.4.
+- `flow-functionality/canvas-copy-paste.spec.ts` — Copy/Paste by keyboard, §15.4.
+
+## Tags
+
+`@stable` `@release` `@components` `@ui-ux`
+
+## Validation criterion
+
+| Step | Criterion |
+|---|---|
+| Blank flow + Prompt Template added | `.react-flow__node` count is exactly 1 |
+| Canvas unselected | `.react-flow__node.selected` count is 0 (proves the next assert is caused by the right-click) |
+| Right-click the node | `.react-flow__node.selected` count becomes 1 |
+| Menu opened | `[data-radix-popper-content-wrapper] [role="listbox"]` is visible with `data-state="open"` |
+| Menu contract | its `role="option"` items are, in order: `Save`, `Duplicate`, `Copy`, `Docs`, `Minimize`, `Freeze`, `Download`, `Delete` (8 items) |
+| `Escape` | the `role="listbox"` menu is detached AND `.react-flow__node.selected` drops back to 0 (one keypress closes the menu and deselects) |
+| Right-click → `Duplicate` | node count goes 1 → 2 and the menu closes |
+
+Non-criteria (deliberate):
+
+- **`Save` is never clicked.** It writes the node into the user's saved-component
+  library (and can raise a replace-confirmation dialog), i.e. account-wide state
+  that would leak into every other spec. The previous version of this test
+  clicked it; the rewrite asserts its presence only.
+- **`more-options-modal` is not used as the "menu is open" signal.** On
+  `1.12.0.dev8` that testid is an always-present, empty `div` (the Radix `Select`
+  trigger) that reports `data-state="closed"` **while the right-click menu is
+  open** — waiting for it passes on a closed menu, which is a false green. The
+  previous version of this test gated on exactly that selector.
+- **`Duplicate` and `Copy` share the testid `copy-button-modal`** (upstream
+  wart). Items are therefore located by `role="option"` + text, never by testid.
+- **Singleton components cannot be duplicated.** `Duplicate` on Chat Input /
+  Webhook is a documented no-op (see `core-components/singleton-components.spec.ts`),
+  which is why the fixture node is a Prompt Template.
+
+### Canvas (pane) right-click — no product surface on 1.12.0.dev8
+
+The sibling checklist item `§15.9 — Context menu via right-click on canvas`
+has **no surface to test** on this build, so it stays `[~]` instead of getting a
+spec (same treatment as the §15.1 sidebar-tooltip item, issue #937). Measured
+live on `1.12.0.dev8`:
+
+- A right-click on `.react-flow__pane` (empty canvas) dispatches a `contextmenu`
+  event that reaches `document` with `defaultPrevented === false` — Langflow
+  installs no pane handler, so the **browser's native** menu is what opens.
+- Zero `[role="menu"]`, `[role="listbox"]` and `[data-radix-popper-content-wrapper]`
+  elements appear after that right-click.
+- Same result with a node selected (2 events, both unprevented), so it is not a
+  selection-scoped menu either. ReactFlow's `onPaneContextMenu` /
+  `onSelectionContextMenu` strings exist in the bundle only because the library
+  ships them; Langflow does not wire them.
+
+Edges are the exception and belong to §15.3: each edge renders an
+`edge-context-menu-trigger` (a left-click affordance, not a right-click menu).
+
+## External dependencies
+
+- `src/frontend/src/CustomNodes/GenericNode/index.tsx` — the node's
+  `onContextMenu` handler that selects the node and opens the options menu.
+- `src/frontend/src/CustomNodes/GenericNode/components/NodeStatus` /
+  `NodeToolbarComponent` — the options menu items and the
+  `save-button-modal` / `copy-button-modal` / `docs-button-modal` /
+  `minimize-button-modal` / `download-button-modal` testids.
+- Sidebar `add-component-button-prompt-template` — the fixture node.
+
+No provider API key and no LLM call. The spec creates one flow via
+`setupBlankFlow` and deletes exactly that id in `afterEach` (`deleteFlow`), so it
+leaves no flow behind.
+
+## Last validated
+
+1.12.x (nightly `1.12.0.dev8`)

--- a/tests/tests-automations/regression/ui-ux/main-menu-actions.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/main-menu-actions.spec.ts
@@ -1,0 +1,128 @@
+import { expect, test } from "../../../fixtures/fixtures";
+import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+
+/**
+ * §15.9 — Main menu actions.
+ *
+ * On 1.12.x the flow editor has no dedicated "menu bar" dropdown anymore — the
+ * breadcrumb's `menu_bar_display` opens the Flow settings dialog — so the
+ * application's main menu is the header account menu, whose items are named
+ * `menu_*_button` upstream. `user_menu_button` is the real `<button>`;
+ * `user-profile-settings` is the `div` wrapping it.
+ *
+ * The version row is the spec's distinctive observable: it must match
+ * `GET /api/v1/version` exactly, so the menu cannot pass on a hardcoded or
+ * stale string.
+ *
+ * Sibling coverage not duplicated here: `ui-ux/settings-navigation.spec.ts`
+ * (§15.10, the Settings page structure — this spec only proves the menu → route
+ * wiring) and `ui-ux/settings-theme-toggle.spec.ts` (§15.10, actually switching
+ * theme). The theme buttons are asserted present and never clicked: the theme is
+ * persisted per user, so toggling it here would mutate state shared with every
+ * other spec on the instance. The external links are likewise asserted by
+ * `href`/`target` and never opened, keeping the run offline and deterministic.
+ *
+ * No flow is created, so there is nothing to clean up.
+ */
+
+/** Every item the main menu must expose on 1.12.0.dev8. */
+const MENU_ITEM_TESTIDS = [
+  "menu_version_button",
+  "menu_settings_button",
+  "menu_docs_button",
+  "menu_github_button",
+  "menu_discord_button",
+  "menu_twitter_button",
+  "menu_light_button",
+  "menu_dark_button",
+  "menu_system_button",
+];
+
+/** External destinations, asserted by attribute instead of by navigation. */
+const EXTERNAL_LINKS: Array<[string, string]> = [
+  ["menu_docs_button", "https://docs.langflow.org"],
+  ["menu_github_button", "https://github.com/langflow-ai/langflow"],
+  ["menu_discord_button", "https://discord.com/invite/EqksyE2EX9"],
+  ["menu_twitter_button", "https://x.com/langflow_ai"],
+];
+
+test.describe("App header — main menu", () => {
+  test("the main menu lists every item, reports the running version and links out",
+    { tag: ["@stable", "@release", "@mainpage", "@ui-ux", "@settings"] },
+    async ({ page, request }) => {
+      // skipModal keeps awaitBootstrapTest from opening the templates modal,
+      // which would create a flow this spec has no reason to own.
+      await awaitBootstrapTest(page, { skipModal: true });
+
+      const menu = page.getByRole("menu");
+
+      await test.step("Open the main menu from the header", async () => {
+        await page.getByTestId("user_menu_button").click();
+        await expect(menu).toBeVisible({ timeout: 10000 });
+        await expect(menu).toHaveAttribute("data-state", "open");
+      });
+
+      await test.step("Every documented item is present", async () => {
+        for (const testId of MENU_ITEM_TESTIDS) {
+          await expect(menu.getByTestId(testId)).toBeVisible({
+            timeout: 10000,
+          });
+        }
+      });
+
+      await test.step("The version row matches GET /api/v1/version", async () => {
+        const response = await request.get("/api/v1/version");
+        expect(response.status()).toBe(200);
+        const { version } = await response.json();
+        expect(version, "the version endpoint must report a version").toBeTruthy();
+
+        // The label span carries only "Version"; the value lives in its sibling
+        // div, so the assertion targets the row that wraps both. The freshness
+        // suffix ("(latest)") is not asserted — it depends on Langflow reaching
+        // GitHub's release feed from the test host.
+        const versionRow = menu.getByTestId("menu_version_button").locator("..");
+        await expect(versionRow).toContainText(version, { timeout: 10000 });
+      });
+
+      await test.step("Each external item points at its documented URL", async () => {
+        for (const [testId, href] of EXTERNAL_LINKS) {
+          const anchor = menu
+            .getByTestId(testId)
+            .locator("xpath=ancestor::a[1]");
+          await expect(anchor).toHaveAttribute("href", href);
+          await expect(anchor).toHaveAttribute("target", "_blank");
+        }
+      });
+
+      await test.step("Escape closes the menu", async () => {
+        await page.keyboard.press("Escape");
+        await expect(menu).toHaveCount(0, { timeout: 10000 });
+      });
+    },
+  );
+
+  test("the main menu's Settings action navigates to the Settings page",
+    { tag: ["@stable", "@release", "@mainpage", "@ui-ux", "@settings"] },
+    async ({ page }) => {
+      await awaitBootstrapTest(page, { skipModal: true });
+
+      await test.step("Open the main menu and choose Settings", async () => {
+        await page.getByTestId("user_menu_button").click();
+        await expect(page.getByTestId("menu_settings_button")).toBeVisible({
+          timeout: 10000,
+        });
+        await page.getByTestId("menu_settings_button").click();
+      });
+
+      await test.step("The Settings route rendered and the menu closed", async () => {
+        // 1.12 lands on /settings/general; the regex keeps the assert alive if
+        // upstream changes the default section.
+        await expect(page).toHaveURL(/\/settings/, { timeout: 15000 });
+        await expect(page.getByTestId("settings_menu_header")).toBeVisible({
+          timeout: 15000,
+        });
+        await expect(page.getByRole("menu")).toHaveCount(0);
+      });
+    },
+  );
+});

--- a/tests/tests-automations/regression/ui-ux/right-click-dropdown.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/right-click-dropdown.spec.ts
@@ -1,91 +1,171 @@
 import { expect, test } from "../../../fixtures/fixtures";
-import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { addComponentFromSidebar } from "../../../helpers/flows/add-component-from-sidebar";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
+import { unselectNodes } from "../../../helpers/ui/unselect-nodes";
 
-test(
-  "user can open component dropdown menu by right-clicking on nodes",
-  { tag: ["@release", "@components", "@ui-ux"] },
-  async ({ page }) => {
-    await awaitBootstrapTest(page);
+/**
+ * §15.9 — Context menu via right-click on a canvas component.
+ *
+ * A single right-click on a node must select it (exactly like a left-click)
+ * AND open its options menu immediately — no prior left-click, no hover over
+ * the toolbar's `...` button.
+ *
+ * Two selector decisions, both measured live on nightly 1.12.0.dev8:
+ *
+ * 1. The open menu is `[data-radix-popper-content-wrapper] [role="listbox"]`.
+ *    `more-options-modal` is NOT used: on this build it is an always-present,
+ *    empty `div` (the Radix Select trigger) that reports `data-state="closed"`
+ *    *while* the right-click menu is open — gating on it passes with the menu
+ *    shut, which is exactly the false green the previous version of this spec
+ *    shipped.
+ * 2. Items are located by `role="option"` + text, never by testid: `Duplicate`
+ *    and `Copy` share the testid `copy-button-modal` upstream.
+ *
+ * The item set is component-dependent (`Freeze` renders for Prompt Template but
+ * not for Chat Input / Language Model), so the exact ordered contract is
+ * asserted for the Prompt Template fixture only.
+ *
+ * `Save` is deliberately never clicked — it writes the node into the account's
+ * saved-component library, i.e. state shared with every other spec on the
+ * instance.
+ *
+ * Sibling coverage not duplicated here: `core-components/componentDelete.spec.ts`
+ * (Delete through the toolbar menu), `ui-ux/minimize.spec.ts` (Minimize/Expand),
+ * `flow-functionality/canvas-copy-paste.spec.ts` (keyboard Copy/Paste).
+ *
+ * The sibling checklist item "context menu via right-click on canvas" has no
+ * product surface on 1.12.0.dev8 (the pane's `contextmenu` event is not
+ * prevented and no menu renders) — see `docs/ui-ux/right-click-dropdown.md`.
+ */
 
-    // Start with a basic template that has multiple components
-    if (await page.getByTestId("components-btn").isVisible()) {
-      await page.getByTestId("side_nav_options_all-templates").click();
-      await page.getByRole("heading", { name: "Basic Prompting" }).click();
+/**
+ * Ordered item contract of the Prompt Template context menu on 1.12.0.dev8.
+ *
+ * Substring regexes rather than exact labels: each row's text also carries its
+ * shortcut hint ("DuplicateCtrlD"), Freeze is prefixed by its inline
+ * `snowflake-svg` element ("snowflake-svgFreezeCtrlF") and Delete arrives padded
+ * (" Delete "). Matched as an array, so the count and the order are still exact.
+ */
+const MENU_ITEMS = [
+  /Save/,
+  /Duplicate/,
+  /Copy/,
+  /Docs/,
+  /Minimize/,
+  /Freeze/,
+  /Download/,
+  /Delete/,
+];
+
+test.describe("Canvas — right-click context menu on a component", () => {
+  let createdFlowId: string | null = null;
+
+  test.beforeEach(async ({ page }) => {
+    // setupBlankFlow creates the flow via API (avoids the UI-creation 500 race)
+    // and returns its id so afterEach can clean it up.
+    createdFlowId = await setupBlankFlow(page);
+
+    // The canvas starts empty, so the "exactly 1 node" assert below proves the
+    // fixture component was really added.
+    await expect(page.locator(".react-flow__node")).toHaveCount(0);
+
+    // Prompt Template is not a singleton, so it can be duplicated (Chat Input
+    // and Webhook cannot — see core-components/singleton-components.spec.ts).
+    await addComponentFromSidebar(
+      page,
+      "prompt",
+      "add-component-button-prompt-template",
+    );
+    await expect(page.locator(".react-flow__node")).toHaveCount(1, {
+      timeout: 30000,
+    });
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (createdFlowId) {
+      // Leave the editor first: staying on it while the flow is deleted makes
+      // background polling 404, which the fixture's error monitor would flag.
+      await page.goto("/").catch(() => {});
+      await deleteFlow(page.request, createdFlowId);
+      createdFlowId = null;
     }
+  });
 
-    await page.getByTestId("template-get-started-card-basic-prompting").click();
+  test("right-clicking a component selects it and opens its options menu",
+    { tag: ["@stable", "@release", "@components", "@ui-ux"] },
+    async ({ page }) => {
+      const node = page.locator(".react-flow__node").first();
+      const menu = page.locator(
+        '[data-radix-popper-content-wrapper] [role="listbox"]',
+      );
 
-    // Wait for the flow to load
-    await page.waitForSelector('[data-testid="sidebar-search-input"]', {
-      timeout: 3000,
-    });
+      await test.step("Clear the selection left by adding the component", async () => {
+        await unselectNodes(page);
+        // Precondition: without this, the selection assert below could pass on
+        // the selection the sidebar "+" already left behind.
+        await expect(page.locator(".react-flow__node.selected")).toHaveCount(0);
+      });
 
-    // Test 1: Right-click on Chat Input component should open dropdown immediately (single click)
-    const chatInputComponent = page.getByText("Chat Input").first();
+      await test.step("Right-click the node once", async () => {
+        await node.click({ button: "right" });
+      });
 
-    // First, click somewhere else to ensure no component is selected
-    await page.click("body", { position: { x: 100, y: 100 } });
-    await page.waitForTimeout(500);
+      await test.step("The right-click selected the node", async () => {
+        await expect(page.locator(".react-flow__node.selected")).toHaveCount(
+          1,
+          { timeout: 10000 },
+        );
+      });
 
-    // Single right-click on the Chat Input component should immediately open dropdown
-    await chatInputComponent.click({ button: "right" });
+      await test.step("The options menu opened with its full item contract", async () => {
+        await expect(menu).toBeVisible({ timeout: 10000 });
+        await expect(menu).toHaveAttribute("data-state", "open");
+        // toHaveText with an array asserts the exact count AND order of items.
+        await expect(menu.getByRole("option")).toHaveText(MENU_ITEMS, {
+          timeout: 10000,
+        });
+      });
 
-    // Wait for and verify the dropdown menu appears immediately after single right-click
-    await page.waitForSelector('[data-testid="more-options-modal"]', {
-      timeout: 2000,
-    });
+      await test.step("Escape closes the menu and clears the selection", async () => {
+        await page.keyboard.press("Escape");
+        await expect(menu).toHaveCount(0, { timeout: 10000 });
+        // One keypress does both: Escape is also the canvas deselect shortcut
+        // (§15.4), so the node the right-click had selected goes back to
+        // unselected. Measured on 1.12.0.dev8.
+        await expect(page.locator(".react-flow__node.selected")).toHaveCount(0, {
+          timeout: 10000,
+        });
+      });
+    },
+  );
 
-    // Verify the dropdown menu is visible and contains expected options
-    const dropdown = page.locator('[data-testid="more-options-modal"]').first();
-    await expect(dropdown).toBeVisible();
+  test("an item picked from the right-click menu acts on that component",
+    { tag: ["@stable", "@release", "@components", "@ui-ux"] },
+    async ({ page }) => {
+      const node = page.locator(".react-flow__node").first();
+      const menu = page.locator(
+        '[data-radix-popper-content-wrapper] [role="listbox"]',
+      );
 
-    // Verify the right-clicked component is now selected/focused (like a left-click would do)
-    // The component should be visually selected and have the toolbar visible
-    // Since we right-clicked, both the dropdown menu AND regular selection should be active
-    const chatInputNode = page
-      .locator('[data-testid="div-generic-node"]')
-      .first();
-    await expect(chatInputNode).toBeVisible();
+      await test.step("Open the context menu on the node", async () => {
+        await unselectNodes(page);
+        await node.click({ button: "right" });
+        await expect(menu).toBeVisible({ timeout: 10000 });
+      });
 
-    // Test 2: Verify dropdown contains expected menu items
-    // Check for Save option
-    const saveOption = page.getByTestId("save-button-modal");
-    await expect(saveOption).toBeVisible();
-
-    // Check for Copy option
-    const copyOption = page.getByTestId("copy-button-modal").first();
-    await expect(copyOption).toBeVisible();
-
-    // Check for Delete option (should be at the bottom with red styling)
-    const deleteOption = page.locator('text="Delete"').last();
-    await expect(deleteOption).toBeVisible();
-
-    // Test 3: Verify clicking on dropdown option works
-    await saveOption.click();
-
-    // Handle the save dialog if it appears
-    if (await page.getByTestId("replace-button").isVisible()) {
-      await page.getByTestId("replace-button").click();
-    }
-
-    // Verify the dropdown closes after selection
-    await page.waitForTimeout(1000);
-    await expect(saveOption).not.toBeVisible();
-
-    // Test 4: Test right-click on different component
-    const promptComponent = page.getByText("Prompt").first();
-
-    // Right-click on the Prompt component
-    await promptComponent.click({ button: "right" });
-
-    // Verify dropdown opens for the new component
-    await page.waitForSelector('[data-testid="more-options-modal"]', {
-      timeout: 2000,
-    });
-
-    const newDropdown = page
-      .locator('[data-testid="more-options-modal"]')
-      .first();
-    await expect(newDropdown).toBeVisible();
-  },
-);
+      await test.step("Choosing Duplicate adds one node and closes the menu", async () => {
+        await menu
+          .getByRole("option")
+          .filter({ hasText: /^Duplicate/ })
+          .click();
+        // The duplicate is the observable: the action really ran, rather than
+        // the menu merely rendering a clickable row.
+        await expect(page.locator(".react-flow__node")).toHaveCount(2, {
+          timeout: 15000,
+        });
+        await expect(menu).toHaveCount(0, { timeout: 10000 });
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #945.

Closes the three `[-]` items in `QA-CHECKLIST.md` § 15.9 — Right-Click and Menus.
Two get specs; the third has no product surface on this build and is documented
as such instead.

| § 15.9 item | Outcome |
|---|---|
| Context menu via right-click on component | `[x]` — inherited spec **rewritten** and promoted to `@stable` |
| Main menu actions | `[x]` — **new** spec |
| Context menu via right-click on canvas | `[~]` — no product surface on 1.12.0.dev8, evidence below |

## 1. Covered tests

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `right-clicking a component selects it and opens its options menu` | From an unselected canvas, one right-click takes `.react-flow__node.selected` from 0 → 1 **and** opens `[data-radix-popper-content-wrapper] [role="listbox"]` with `data-state="open"`. Its `role="option"` rows match the exact ordered contract Save / Duplicate / Copy / Docs / Minimize / Freeze / Download / Delete (count + order). A single `Escape` closes the menu **and** clears the selection (`Escape` is also the canvas deselect shortcut, § 15.4 — one keypress does both). Catches: right-click losing its select-on-open behavior, an item disappearing from or being reordered in the menu. |
| 2 | `an item picked from the right-click menu acts on that component` | Choosing `Duplicate` from the right-click menu takes the node count 1 → 2 and closes the menu — the right-click path is wired to the real actions, not just rendering a clickable popover. |
| 3 | `the main menu lists every item, reports the running version and links out` | `user_menu_button` opens a single `role="menu"` (`data-state="open"`) exposing all nine `menu_*_button` items. The version row contains the **exact** string returned by `GET /api/v1/version`, so the menu cannot pass on a hardcoded or stale value. The four external rows carry their documented `href` and `target="_blank"`. `Escape` closes the menu. |
| 4 | `the main menu's Settings action navigates to the Settings page` | `menu_settings_button` closes the menu and routes to `/settings` (1.12 lands on `/settings/general`) with `settings_menu_header` rendered — the menu → route wiring. |

## 2. How the tests were built

**Why the inherited spec is rewritten, not merely tagged** — three real defects
in `right-click-dropdown.spec.ts` as it stood:

1. It gated on `[data-testid="more-options-modal"]` as the "menu is open" signal.
   Measured live on 1.12.0.dev8: that testid is an **always-present, empty `div`**
   (the Radix `Select` trigger) reporting `data-state="closed"` *while* the
   right-click menu is open — the wait passes with the menu shut, i.e. a false
   green.
2. It **clicked `Save`**, which writes the node into the account's
   saved-component library — account-wide state leaking into every other spec on
   the instance. The rewrite asserts its presence and never clicks it.
3. It created a flow from a template and **never deleted it**. The rewrite uses
   `setupBlankFlow` (API-created, returns the id) + `deleteFlow` in `afterEach`,
   id-scoped.

**Canvas (pane) right-click — no surface on 1.12.0.dev8.** Measured, not assumed:
a right-click on `.react-flow__pane` dispatches a `contextmenu` event that
reaches `document` with `defaultPrevented === false` (so the browser's **native**
menu is what opens) and renders zero `[role="menu"]`, `[role="listbox"]` and
`[data-radix-popper-content-wrapper]` elements — identical with a node selected
(two events, both unprevented). Langflow does not wire ReactFlow's
`onPaneContextMenu` / `onSelectionContextMenu`; those strings exist in the bundle
only because the library ships them. Following the § 15.1 precedent (#937), that
bullet becomes `[~]` with the evidence recorded in the bullet and in the spec doc,
rather than getting a negative test.

**Live-confirmed selectors** (harvested with `playwright-cli` against nightly
1.12.0.dev8, none invented):

- Open node menu: `[data-radix-popper-content-wrapper] [role="listbox"]`
  (`data-state="open"`); items are `role="option"`.
- Items are located by **role + text, never by testid**: `Duplicate` and `Copy`
  share the testid `copy-button-modal` upstream.
- Item labels carry their shortcut hint appended (`"DuplicateCtrlD"`), `Freeze` is
  prefixed by its inline `snowflake-svg` element (`"snowflake-svgFreezeCtrlF"`) and
  `Delete` arrives padded (`" Delete "`) — hence substring regexes, still matched
  as an array so count and order stay exact.
- The item set is **component-dependent**: `Freeze` renders for Prompt Template but
  not for Chat Input / Language Model. The exact contract is therefore asserted for
  the Prompt Template fixture only, which is also a non-singleton (Chat Input /
  Webhook cannot be duplicated — see `core-components/singleton-components.spec.ts`).
- Main menu trigger is `user_menu_button` (the real `<button>`);
  `user-profile-settings` is the `div` wrapping it.
- The version value lives in a sibling `div` of the `menu_version_button` label
  span, so the assert targets the wrapping row. The freshness suffix
  (`"(latest)"`) is deliberately not asserted — it depends on Langflow reaching
  GitHub's release feed from the test host.

**Non-duplication.** Deleting via the toolbar menu (`core-components/componentDelete.spec.ts`),
Minimize/Expand (`ui-ux/minimize.spec.ts`), keyboard Copy/Paste
(`flow-functionality/canvas-copy-paste.spec.ts`), the Settings **page** structure
(`ui-ux/settings-navigation.spec.ts`) and switching theme
(`ui-ux/settings-theme-toggle.spec.ts`) all stay where they are. The three theme
buttons here are asserted **present and never clicked** — the theme is persisted
per user, so toggling it would mutate state shared with the whole suite. External
links are asserted by attribute and never opened, keeping the run offline.

## 3. Dependencies

- **None** — pure UI. No provider API key, no LLM call, no `models.json`.
- Parallel-safe: `main-menu-actions.spec.ts` creates no flow;
  `right-click-dropdown.spec.ts` owns exactly one API-created blank flow and
  deletes that id in `afterEach`, so nothing is shared across workers.
- New spec docs: `docs/ui-ux/right-click-dropdown.md`, `docs/ui-ux/main-menu-actions.md`.
- `QA-CHECKLIST.md`: only the manual § 15.9 Part II bullets were edited (guard ✅).

## Validation (nightly `1.12.0.dev8`, `--retries=0 --workers=1`)

```
run 1/3 right-click-dropdown.spec.ts: expected=2 unexpected=0 flaky=0 backendErrors=false
run 2/3 right-click-dropdown.spec.ts: expected=2 unexpected=0 flaky=0 backendErrors=false
run 3/3 right-click-dropdown.spec.ts: expected=2 unexpected=0 flaky=0 backendErrors=false
run 1/3 main-menu-actions.spec.ts:    expected=2 unexpected=0 flaky=0 backendErrors=false
run 2/3 main-menu-actions.spec.ts:    expected=2 unexpected=0 flaky=0 backendErrors=false
run 3/3 main-menu-actions.spec.ts:    expected=2 unexpected=0 flaky=0 backendErrors=false
```

- `npm run typecheck` ✅ · `npx eslint` on both specs ✅ (0 warnings) ·
  `check-checklist-guard` ✅ · `check:checklist-coverage` ✅
- 3 clean `--retries=0` runs per spec, no flake ✅ · zero `🚨 Backend Error` ✅
- **Force-fail, every `test()`, each verified red then reverted** (`grep -c FF-MUTATION` = 0):
  - `right-clicking a component…` → right-click replaced by a plain left click → `unexpected=1` ✅
  - `an item picked from the right-click menu…` → picked `Minimize` instead of `Duplicate` (node count stays 1) → `unexpected=1` ✅
  - `the main menu lists every item…` → version row expected with a `-ff` suffix → `unexpected=1` ✅
  - `the main menu's Settings action…` → clicked `menu_version_button` (an inert label) instead of `menu_settings_button` → `unexpected=1` ✅
  - **Behavioral cleanup force-fail:** `deleteFlow` no-op'd → run stayed **green** (2 passed) while 2 flows survived (`e2e-blank-…car0t`, `e2e-blank-…0of6e`) → reverted → 0 orphans ✅
- Instance left with **0 orphan flows** (only the shared bootstrap `Basic Prompting`).

Two red runs on the way there, both test defects fixed spec-doc-first: the
`Freeze`/`Delete` label anchoring above, and a wrong assumption that `Escape`
keeps the node selected — it does not, one keypress closes the menu and
deselects, which the spec doc now records as measured behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
