### PR TITLE
test(canvas): cover node move, minimize, box-select and deselect (#940)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -712,13 +712,13 @@
 - [x] Delete component from canvas via node options (...) menu → `core-components/componentDelete.spec.ts`
 - [x] Copy and paste ChatOutput component (Ctrl+C / Ctrl+V) → `flow-functionality/canvas-copy-paste.spec.ts`
 - [x] Copy and paste Prompt Template (component with dynamic ports) (Ctrl+C / Ctrl+V) → `flow-functionality/canvas-copy-paste.spec.ts`
-- [-] Canvas keyboard shortcuts
-- [-] Minimize component on canvas
-- [-] Move component within canvas
-- [-] Select multiple components via box selection
-- [x] Delete multiple selected components (marquee box selection) → `core-components/componentDelete.spec.ts`
-- [-] Deselect node by clicking on empty canvas area
-- [-] Deselect node via Escape
+- [x] Canvas keyboard shortcuts — Duplicate/Delete/Copy/Paste/Cut/Undo/Redo each act on the selected node, with the selection re-gated before every keypress → `ui-ux/langflowShortcuts.spec.ts`
+- [x] Minimize component on canvas — the options menu collapses the node (every handle gains `no-show`, height shrinks) and persists `data.showNode = false`; the item swaps to Expand, which restores both → `ui-ux/minimize.spec.ts`
+- [x] Move component within canvas — dragging a node by its title moves it on canvas and the new coordinates reach the backend (`GET /api/v1/flows/{id}` `position` matches the rendered transform) → `flow-functionality/canvas-move-node.spec.ts`
+- [x] Select multiple components via box selection — a Shift+drag marquee enclosing two separated nodes takes `.react-flow__node.selected` from 0 to 2, while a marquee drawn away from them selects nothing (negative control) → `flow-functionality/canvas-multiselect.spec.ts`
+- [x] Delete multiple selected components (marquee box selection) → `core-components/componentDelete.spec.ts`, `flow-functionality/canvas-multiselect.spec.ts`
+- [x] Deselect node by clicking on empty canvas area — clicking `.react-flow__pane` clears a selection asserted present first → `flow-functionality/canvas-deselect-node.spec.ts`
+- [x] Deselect node via Escape → `flow-functionality/canvas-deselect-node.spec.ts`
 
 #### 15.5 Canvas Zoom and Navigation
 - [x] Zoom in / Zoom out → `ui-ux/canvas-zoom-navigation.spec.ts`

--- a/docs/flow-functionality/canvas-deselect-node.md
+++ b/docs/flow-functionality/canvas-deselect-node.md
@@ -1,0 +1,59 @@
+# Spec: Canvas — Deselecting a Node
+
+**Test file:** `tests/tests-automations/regression/flow-functionality/canvas-deselect-node.spec.ts`
+
+## What this test validates
+
+Covers two `§15.4` checklist items — `Deselect node by clicking on empty canvas
+area` and `Deselect node via Escape`. Both are the same contract from two
+affordances: a selected node must return to unselected, so the node toolbar and
+the canvas shortcuts stop acting on it.
+
+Two tests on a blank flow holding a single **Prompt Template** node:
+
+1. **Click on empty canvas deselects** — select the node (`.react-flow__node.selected`
+   count 1), click a point on `.react-flow__pane` away from the node, count
+   returns to 0.
+2. **`Escape` deselects** — same setup, `Escape` instead of the click.
+
+Both tests assert the selected state **before** acting, so a run where the node
+was never selected fails at the setup step instead of passing vacuously on a
+canvas that was already empty of selection.
+
+## Tags
+
+`@stable` `@release` `@workspace` `@ui-ux`
+
+## Validation criterion
+
+| Step | Criterion |
+|---|---|
+| Blank flow + Prompt Template added | `.react-flow__node` count is exactly 1 |
+| Click the node | `.react-flow__node.selected` count is 1 (precondition — makes the deselect causal) |
+| Click empty canvas / press `Escape` | `.react-flow__node.selected` count is 0 |
+
+Non-criteria (deliberate):
+
+- **The empty-canvas click targets `.react-flow__pane` by position**, not the
+  `#react-flow-id` wrapper: the wrapper's coordinate space includes the node
+  layer, and a "far away" position computed against it can still land on a node
+  after a zoom change.
+- **`Escape` also closes an open node context menu** (§15.9,
+  `ui-ux/right-click-dropdown.spec.ts`). Here no menu is open, so the test
+  isolates the deselect half of that behavior.
+- **Node toolbar visibility is not asserted** as a proxy for selection —
+  `.react-flow__node.selected` is the state ReactFlow owns; the toolbar is a
+  downstream render detail that has moved between releases.
+
+## External dependencies
+
+- ReactFlow's pane-click and `Escape` deselect handling; `.react-flow__node.selected`.
+- Sidebar `add-component-button-prompt-template`.
+
+No provider API key and no LLM call. The spec creates one flow per test via
+`setupBlankFlow` and deletes exactly that id in `afterEach` (`deleteFlow`); the
+inherited version leaked one flow per test.
+
+## Last validated
+
+1.12.x (nightly `1.12.0.dev8`)

--- a/docs/flow-functionality/canvas-move-node.md
+++ b/docs/flow-functionality/canvas-move-node.md
@@ -1,0 +1,74 @@
+# Spec: Canvas — Move a Component Within the Canvas
+
+**Test file:** `tests/tests-automations/regression/flow-functionality/canvas-move-node.spec.ts`
+
+## What this test validates
+
+Covers the `§15.4 — Move component within canvas` checklist item: dragging a
+node by its title must move it on the canvas **and** persist the new coordinates
+to the backend, so reopening the flow finds the node where the user left it.
+
+One test on a blank flow holding a single **Prompt Template** node:
+
+1. Read the node's starting position from both layers — `style.transform` on the
+   `.react-flow__node` element and `position` in `GET /api/v1/flows/{id}`.
+2. Drag the node by its title (`title-Prompt Template`) with a measured offset.
+3. Assert the DOM transform changed by approximately that offset, and then poll
+   the flows API until the persisted `position` matches the DOM — the autosave
+   round-trip is the real assertion.
+
+The cross-layer check is what makes this a regression test rather than a DOM
+tautology: a UI-only move that never reaches `PATCH /api/v1/flows/{id}` looks
+correct on screen and loses the layout on reload. Measured on `1.12.0.dev8`, the
+two agree exactly (DOM `translate(541px, 181px)` ↔ API `{x: 541, y: 181}`).
+
+Sibling coverage, deliberately not duplicated here:
+
+- `ui-ux/sidebar-add-component.spec.ts` — dragging a component **from the
+  sidebar** onto the canvas (the node lands at the drop position). That is
+  creation, not movement of an existing node.
+- `flow-functionality/dragAndDrop.spec.ts` — dropping a flow **file** onto the
+  dashboard to import it. Unrelated despite the name.
+
+## Tags
+
+`@stable` `@release` `@workspace` `@ui-ux`
+
+## Validation criterion
+
+| Step | Criterion |
+|---|---|
+| Blank flow + Prompt Template added | `.react-flow__node` count is exactly 1 |
+| Starting state | the node's `style.transform` parses to `(x0, y0)`; `GET /api/v1/flows/{id}` reports the same `position` |
+| Drag the title by `(dx, dy)` | the node's `style.transform` parses to approximately `(x0+dx, y0+dy)` — tolerance accounts for canvas zoom |
+| Persistence | polling `GET /api/v1/flows/{id}` converges on a `position` matching the post-drag DOM coordinates (within the same tolerance) |
+
+Non-criteria (deliberate):
+
+- **Exact pixel equality is not asserted** — the canvas may be at a zoom level
+  other than 1, so the drag delta in screen pixels is not the delta in flow
+  coordinates. The assert uses a tolerance and, crucially, requires DOM and API
+  to agree with **each other**.
+- **The drag is issued as `mouse.move` → `down` → `move(steps)` → `up`**, not
+  `locator.dragTo`. ReactFlow needs intermediate move events to start a node
+  drag; a single jump can be swallowed.
+- **The node is dragged by its title**, never by its body — a body-center press
+  can land on an interactive field inside the node and start editing instead of
+  dragging (same trap the delete helpers document).
+- **A single-node canvas** — with overlapping nodes the topmost one captures the
+  press, which silently moves the wrong node (observed during scouting: two
+  components added from the sidebar stack 10 px apart).
+
+## External dependencies
+
+- `src/frontend/src/CustomNodes/GenericNode/index.tsx` — the node title drag
+  handle (`title-{Component Name}`).
+- ReactFlow's node drag → `PATCH /api/v1/flows/{id}` autosave path.
+- Sidebar `add-component-button-prompt-template` — the fixture node.
+
+No provider API key and no LLM call. The spec creates one flow via
+`setupBlankFlow` and deletes exactly that id in `afterEach` (`deleteFlow`).
+
+## Last validated
+
+1.12.x (nightly `1.12.0.dev8`)

--- a/docs/flow-functionality/canvas-multiselect.md
+++ b/docs/flow-functionality/canvas-multiselect.md
@@ -1,0 +1,78 @@
+# Spec: Canvas — Box Selection of Multiple Components
+
+**Test file:** `tests/tests-automations/regression/flow-functionality/canvas-multiselect.spec.ts`
+
+## What this test validates
+
+Covers the `§15.4 — Select multiple components via box selection` checklist
+item: a Shift+drag marquee over the canvas must select every node it encloses.
+
+Two tests on a blank flow holding **two non-overlapping, non-singleton** nodes
+(Prompt Template + Chat Output, moved apart before the marquee):
+
+1. **The marquee selects both nodes** — starting from an unselected canvas,
+   Shift+dragging a rectangle around both takes `.react-flow__node.selected`
+   from 0 to 2. A marquee drawn away from the nodes leaves the count at 0, so
+   the assertion is causal rather than "something got selected".
+2. **The selection is actionable** — pressing `Delete` with both selected clears
+   the canvas (`.react-flow__node` count 0). This is the multi-select
+   counterpart of the single-node delete and proves the selection reached the
+   canvas action layer.
+
+### Why the inherited version was red
+
+Test 1 asserted box selection **indirectly**: it copied the selection with
+`Ctrl+C`, pasted with `Ctrl+V` and expected `2 originals + 2 pasted = 4` nodes.
+It got **3**, deterministically — one of its two fixture components was
+`Chat Input`, a **singleton** that cannot be copy/pasted (see
+`core-components/singleton-components.spec.ts`), so only one node ever pasted.
+The rewrite asserts the selection **directly** (`.react-flow__node.selected`),
+which is both the honest observable and immune to the singleton rule.
+
+## Tags
+
+`@stable` `@release` `@workspace` `@ui-ux`
+
+## Validation criterion
+
+| Step | Criterion |
+|---|---|
+| Blank flow + two components added and separated | `.react-flow__node` count is exactly 2, and their bounding boxes do not overlap |
+| Canvas unselected | `.react-flow__node.selected` count is 0 |
+| Shift+drag a marquee that encloses neither node | `.react-flow__node.selected` stays 0 (negative control — the marquee itself does not select) |
+| Shift+drag a marquee enclosing both | `.react-flow__node.selected` count becomes 2 |
+| Press `Delete` | `.react-flow__node` count becomes 0 |
+
+Non-criteria (deliberate):
+
+- **No copy/paste in the assertions.** Clipboard round-trips depend on the
+  singleton rule and on clipboard permissions; keyboard Copy/Paste is covered by
+  `ui-ux/langflowShortcuts.spec.ts` and
+  `flow-functionality/canvas-copy-paste.spec.ts`.
+- **The two nodes are separated by an explicit drag before the marquee.** Two
+  components added from the sidebar stack ~10 px apart on 1.12, and a marquee
+  over stacked nodes cannot distinguish "selected both" from "selected the top
+  one twice".
+- **No `if (box)` guard around the drag.** The inherited version wrapped the
+  whole marquee in `if (firstBox && secondBox)`, which silently skips the action
+  when a bounding box is unavailable; the rewrite asserts the boxes exist.
+- **Marquee-delete of a whole flow already has a sibling** —
+  `core-components/componentDelete.spec.ts` covers "delete multiple selected
+  components" (§15.4, already `[x]`). Test 2 here is scoped to proving *this*
+  selection is actionable, and the doc records the overlap.
+
+## External dependencies
+
+- ReactFlow's selection-on-drag behavior, keyed by `Shift`
+  (`selectionKeyCode="Shift"` in the canvas setup).
+- `.react-flow__node.selected` — the class ReactFlow puts on selected nodes.
+- Sidebar `add-component-button-prompt-template`,
+  `add-component-button-chat-output`.
+
+No provider API key and no LLM call. The spec creates one flow via
+`setupBlankFlow` and deletes exactly that id in `afterEach` (`deleteFlow`); the
+inherited version leaked one flow per test.
+
+## Last validated
+
+1.12.x (nightly `1.12.0.dev8`)

--- a/docs/ui-ux/minimize.md
+++ b/docs/ui-ux/minimize.md
@@ -1,0 +1,81 @@
+# Spec: Canvas — Minimize and Expand a Component
+
+**Test file:** `tests/tests-automations/regression/ui-ux/minimize.spec.ts`
+
+## What this test validates
+
+Covers the `§15.4 — Minimize component on canvas` checklist item: the node
+options menu must collapse a node to its compact form and restore it, in the DOM
+**and** in the persisted flow.
+
+One test on a blank flow holding a single **Prompt Template** node:
+
+1. **Baseline** — the node renders expanded: no `.react-flow__handle.no-show`,
+   and the options menu offers `minimize-button-modal`.
+2. **Minimize** — after picking it, every handle on that node carries `no-show`,
+   the node's rendered height collapses (measured 209 px → 52 px on
+   `1.12.0.dev8`), and `GET /api/v1/flows/{id}` reports `data.showNode === false`
+   for that node.
+3. **Expand** — the menu now offers `expand-button-modal`; picking it clears
+   `no-show`, restores the height, and flips `data.showNode` back to `true`.
+
+**The fixture component matters.** `Chat Output` — which the inherited version of
+this spec would otherwise be a natural fit for — **ships minimized by default**
+on 1.12 (`minimized: true` in `GET /api/v1/all`), so a "minimize it" test would
+start in the end state. Prompt Template has `minimized: false` and renders
+expanded, making the transition observable in both directions.
+
+### Why the inherited version was red
+
+It searched the sidebar for `Text Input` and waited on
+`[data-testid="input_outputText Input"]`, which times out on 1.12.0.dev8:
+**`Text Input` is now `legacy: true`** in the component catalog, so it is hidden
+from the sidebar unless the legacy toggle is on. This is an intentional product
+change, not a regression — the fix is a different fixture component, not enabling
+the legacy toggle (that surface is covered by
+`core-components/legacy-components-toggle-regression.spec.ts`).
+
+## Tags
+
+`@stable` `@release` `@workspace` `@ui-ux`
+
+## Validation criterion
+
+| Step | Criterion |
+|---|---|
+| Blank flow + Prompt Template added | `.react-flow__node` count is exactly 1, with `0` handles carrying `no-show` |
+| Options menu (expanded node) | `minimize-button-modal` is present |
+| After Minimize | every `.react-flow__handle` inside the node carries `no-show`; the node's bounding height is smaller than the expanded height; `GET /api/v1/flows/{id}` → the node's `data.showNode === false` |
+| Options menu (minimized node) | `expand-button-modal` is present (the item swaps, it is not a toggle with one testid) |
+| After Expand | no handle carries `no-show`; the height is back to the expanded value; `data.showNode === true` |
+
+Non-criteria (deliberate):
+
+- **Exact pixel heights are not asserted** — only "collapsed < expanded" and the
+  handle/persistence signals. Node heights shift with upstream styling.
+- **The minimize state is read from `data.showNode`, not `node.minimized`.**
+  `node.minimized` is the component catalog's **default** (true for Chat Output,
+  false for Prompt Template) and does not track the user's action;
+  `data.showNode` is what the canvas writes. Confirmed live: after minimizing the
+  Prompt Template, `data.showNode` was `false` while `node.minimized` stayed
+  `false`.
+- **The menu is opened from the node toolbar** (`icon-MoreHorizontal`), the same
+  affordance `core-components/componentDelete.spec.ts` uses. Reaching the same
+  items by right-click is §15.9's subject
+  (`ui-ux/right-click-dropdown.spec.ts`), not repeated here.
+
+## External dependencies
+
+- `src/frontend/src/CustomNodes/GenericNode/components/NodeToolbarComponent` —
+  `icon-MoreHorizontal`, `minimize-button-modal`, `expand-button-modal`.
+- `GET /api/v1/all` — `minimized` defaults per component (Chat Output `true`,
+  Prompt Template `false`).
+- `GET /api/v1/flows/{id}` — `data.showNode` per node.
+
+No provider API key and no LLM call. The spec creates one flow via
+`setupBlankFlow` and deletes exactly that id in `afterEach` (`deleteFlow`); the
+inherited version created a flow per run and never deleted it.
+
+## Last validated
+
+1.12.x (nightly `1.12.0.dev8`)

--- a/tests/tests-automations/regression/flow-functionality/canvas-deselect-node.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/canvas-deselect-node.spec.ts
@@ -1,95 +1,85 @@
 import { expect, test } from "../../../fixtures/fixtures";
-import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
-import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
+import { addComponentFromSidebar } from "../../../helpers/flows/add-component-from-sidebar";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
 
-test(
-  "clicking empty canvas area deselects a selected node",
-  { tag: ["@release", "@workspace", "@regression"] },
-  async ({ page }) => {
-    await awaitBootstrapTest(page);
+/**
+ * §15.4 — Deselect node by clicking an empty canvas area / via Escape.
+ *
+ * Same contract from two affordances: a selected node must return to
+ * unselected, so the node toolbar and the canvas shortcuts stop acting on it.
+ *
+ * Both tests gate on the node being selected FIRST, so a run where the click
+ * never selected anything fails at the setup step instead of passing vacuously
+ * on a canvas that had no selection to begin with.
+ *
+ * `Escape` also closes an open node context menu — that half is
+ * `ui-ux/right-click-dropdown.spec.ts` (§15.9). No menu is open here, so this
+ * spec isolates the deselect behavior.
+ */
 
-    await page.waitForSelector('[data-testid="blank-flow"]', { timeout: 30000 });
-    await page.getByTestId("blank-flow").click();
+test.describe("Canvas — deselecting a node", () => {
+  let createdFlowId: string | null = null;
 
-    // Add a component to the canvas
-    await page.getByTestId("sidebar-search-input").fill("chat input");
-    await page.waitForSelector('[data-testid="input_outputChat Input"]', {
+  test.beforeEach(async ({ page }) => {
+    createdFlowId = await setupBlankFlow(page);
+    await expect(page.locator(".react-flow__node")).toHaveCount(0);
+
+    await addComponentFromSidebar(
+      page,
+      "prompt",
+      "add-component-button-prompt-template",
+    );
+    await expect(page.locator(".react-flow__node")).toHaveCount(1, {
       timeout: 30000,
     });
-    await page
-      .getByTestId("input_outputChat Input")
-      .hover()
-      .then(async () => {
-        await page.getByTestId("add-component-button-chat-input").click();
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (createdFlowId) {
+      await page.goto("/").catch(() => {});
+      await deleteFlow(page.request, createdFlowId);
+      createdFlowId = null;
+    }
+  });
+
+  test("clicking empty canvas area deselects a selected node",
+    { tag: ["@stable", "@release", "@workspace", "@ui-ux"] },
+    async ({ page }) => {
+      const selected = page.locator(".react-flow__node.selected");
+
+      await test.step("Select the node", async () => {
+        await page.locator(".react-flow__node").first().click();
+        await expect(selected).toHaveCount(1, { timeout: 10000 });
       });
 
-    await adjustScreenView(page);
-    await expect(page.locator(".react-flow__node")).toHaveCount(1, {
-      timeout: 10000,
-    });
+      await test.step("Clicking the empty pane clears the selection", async () => {
+        // Targets `.react-flow__pane` rather than the `#react-flow-id` wrapper:
+        // the wrapper's coordinate space includes the node layer, so a "far
+        // away" offset computed against it can still land on a node after a
+        // zoom change.
+        await page
+          .locator(".react-flow__pane")
+          .click({ position: { x: 5, y: 5 } });
+        await expect(selected).toHaveCount(0, { timeout: 10000 });
+      });
+    },
+  );
 
-    // Click the node to select it
-    await page.locator(".react-flow__node").first().click();
-    await page.waitForTimeout(300);
+  test("pressing Escape deselects a selected node",
+    { tag: ["@stable", "@release", "@workspace", "@ui-ux"] },
+    async ({ page }) => {
+      const selected = page.locator(".react-flow__node.selected");
 
-    // Node must be in selected state
-    await expect(page.locator(".react-flow__node.selected")).toHaveCount(1, {
-      timeout: 3000,
-    });
-
-    // Click an empty area of the canvas to deselect
-    await page.locator('//*[@id="react-flow-id"]').click({
-      position: { x: 50, y: 450 },
-    });
-    await page.waitForTimeout(300);
-
-    // Node must no longer be selected
-    await expect(page.locator(".react-flow__node.selected")).toHaveCount(0, {
-      timeout: 3000,
-    });
-  },
-);
-
-test(
-  "pressing Escape deselects a selected node",
-  { tag: ["@release", "@workspace", "@regression"] },
-  async ({ page }) => {
-    await awaitBootstrapTest(page);
-
-    await page.waitForSelector('[data-testid="blank-flow"]', { timeout: 30000 });
-    await page.getByTestId("blank-flow").click();
-
-    // Add a component
-    await page.getByTestId("sidebar-search-input").fill("chat output");
-    await page.waitForSelector('[data-testid="input_outputChat Output"]', {
-      timeout: 30000,
-    });
-    await page
-      .getByTestId("input_outputChat Output")
-      .hover()
-      .then(async () => {
-        await page.getByTestId("add-component-button-chat-output").click();
+      await test.step("Select the node", async () => {
+        await page.locator(".react-flow__node").first().click();
+        await expect(selected).toHaveCount(1, { timeout: 10000 });
       });
 
-    await adjustScreenView(page);
-    await expect(page.locator(".react-flow__node")).toHaveCount(1, {
-      timeout: 10000,
-    });
-
-    // Select the node
-    await page.locator(".react-flow__node").first().click();
-    await page.waitForTimeout(300);
-    await expect(page.locator(".react-flow__node.selected")).toHaveCount(1, {
-      timeout: 3000,
-    });
-
-    // Press Escape to deselect
-    await page.keyboard.press("Escape");
-    await page.waitForTimeout(300);
-
-    // Node must no longer be selected
-    await expect(page.locator(".react-flow__node.selected")).toHaveCount(0, {
-      timeout: 3000,
-    });
-  },
-);
+      await test.step("Escape clears the selection", async () => {
+        await page.keyboard.press("Escape");
+        await expect(selected).toHaveCount(0, { timeout: 10000 });
+      });
+    },
+  );
+});

--- a/tests/tests-automations/regression/flow-functionality/canvas-move-node.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/canvas-move-node.spec.ts
@@ -1,0 +1,198 @@
+import { expect, test } from "../../../fixtures/fixtures";
+import { addComponentFromSidebar } from "../../../helpers/flows/add-component-from-sidebar";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
+
+/**
+ * §15.4 — Move component within canvas.
+ *
+ * Dragging a node must move it on screen AND persist the new coordinates, so a
+ * reopened flow keeps the layout. Asserting only the DOM would pass on a
+ * UI-only move that never reaches the autosave PATCH — the regression this spec
+ * exists to catch — so the DOM transform and the API `position` are compared
+ * against each other.
+ *
+ * Not to be confused with `ui-ux/sidebar-add-component.spec.ts` (dragging a
+ * component OUT of the sidebar, i.e. creation) or
+ * `flow-functionality/dragAndDrop.spec.ts` (dropping a flow FILE to import it).
+ */
+
+/** Screen-pixel offset applied to the node during the drag. */
+const DRAG_DX = 240;
+const DRAG_DY = 120;
+
+/**
+ * Tolerance, in flow units, when comparing an expected position to a measured
+ * one. The canvas may sit at a zoom level other than 1, so a screen-pixel drag
+ * is not a 1:1 flow-coordinate delta.
+ */
+const POSITION_TOLERANCE = 60;
+
+/** Reads `translate(Xpx, Ypx)` off a `.react-flow__node` element. */
+function parseTransform(transform: string): { x: number; y: number } {
+  const match = transform.match(
+    /translate\(\s*(-?[\d.]+)px[,\s]+(-?[\d.]+)px\s*\)/,
+  );
+  if (!match) {
+    throw new Error(`unexpected node transform: ${transform}`);
+  }
+  return { x: Number(match[1]), y: Number(match[2]) };
+}
+
+test.describe("Canvas — moving a component", () => {
+  let createdFlowId: string | null = null;
+
+  /** Nodes as the backend currently has them (empty until autosave lands). */
+  async function fetchNodes(
+    request: import("@playwright/test").APIRequestContext,
+    flowId: string,
+  ) {
+    const bearer = await getAuthToken(request);
+    const response = await request.get(`/api/v1/flows/${flowId}`, {
+      headers: bearer ? { Authorization: bearer } : undefined,
+    });
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    return (body?.data?.nodes ?? []) as Array<{
+      position: { x: number; y: number };
+    }>;
+  }
+
+  test.beforeEach(async ({ page, request }) => {
+    createdFlowId = await setupBlankFlow(page);
+    await expect(page.locator(".react-flow__node")).toHaveCount(0);
+
+    // A single node: with two stacked components the topmost one captures the
+    // press and the drag silently moves the wrong node.
+    await addComponentFromSidebar(
+      page,
+      "prompt",
+      "add-component-button-prompt-template",
+    );
+    await expect(page.locator(".react-flow__node")).toHaveCount(1, {
+      timeout: 30000,
+    });
+
+    // The canvas autosave is debounced, so the flow is still node-less on the
+    // server right after the component renders. Gate on server truth before
+    // any position is read from it (network silence is not persistence).
+    await expect
+      .poll(async () => (await fetchNodes(request, createdFlowId!)).length, {
+        timeout: 30000,
+        message: "the added component should be persisted before the drag",
+      })
+      .toBe(1);
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (createdFlowId) {
+      await page.goto("/").catch(() => {});
+      await deleteFlow(page.request, createdFlowId);
+      createdFlowId = null;
+    }
+  });
+
+  test("dragging a component moves it on the canvas and persists the new position",
+    { tag: ["@stable", "@release", "@workspace", "@ui-ux"] },
+    async ({ page, request }) => {
+      const node = page.locator(".react-flow__node").first();
+      const flowId = createdFlowId!;
+
+      const readPersistedPosition = async () => {
+        const nodes = await fetchNodes(request, flowId);
+        expect(nodes.length, "the flow should hold exactly one node").toBe(1);
+        return nodes[0].position;
+      };
+
+      let before = { x: 0, y: 0 };
+
+      await test.step("Read the starting position from the DOM and the API", async () => {
+        before = parseTransform(
+          await node.evaluate((el: HTMLElement) => el.style.transform),
+        );
+
+        const persisted = await readPersistedPosition();
+        expect(
+          Math.abs(persisted.x - before.x),
+          "the stored position must match the rendered one before the drag",
+        ).toBeLessThanOrEqual(POSITION_TOLERANCE);
+        expect(Math.abs(persisted.y - before.y)).toBeLessThanOrEqual(
+          POSITION_TOLERANCE,
+        );
+      });
+
+      await test.step("Drag the node by its title", async () => {
+        // The title is the drag handle: pressing the node body can land on an
+        // interactive field and start editing instead of dragging.
+        const title = node.getByTestId("title-Prompt Template");
+        const box = await title.boundingBox();
+        expect(box, "the node title must be on screen to drag it").not.toBeNull();
+
+        const startX = box!.x + box!.width / 2;
+        const startY = box!.y + box!.height / 2;
+
+        // ReactFlow starts a node drag from intermediate move events — a single
+        // jump from press to release is swallowed and the node stays put.
+        await page.mouse.move(startX, startY);
+        await page.mouse.down();
+        await page.mouse.move(startX + DRAG_DX, startY + DRAG_DY, {
+          steps: 15,
+        });
+        await page.mouse.up();
+      });
+
+      await test.step("The node moved by approximately the dragged offset", async () => {
+        await expect
+          .poll(
+            async () => {
+              const now = parseTransform(
+                await node.evaluate((el: HTMLElement) => el.style.transform),
+              );
+              return (
+                Math.abs(now.x - (before.x + DRAG_DX)) <= POSITION_TOLERANCE &&
+                Math.abs(now.y - (before.y + DRAG_DY)) <= POSITION_TOLERANCE
+              );
+            },
+            {
+              timeout: 15000,
+              message: "the node transform should reflect the drag offset",
+            },
+          )
+          .toBe(true);
+      });
+
+      await test.step("The new position reached the backend", async () => {
+        const after = parseTransform(
+          await node.evaluate((el: HTMLElement) => el.style.transform),
+        );
+
+        // The autosave PATCH is debounced, so the API is polled rather than read
+        // once. This is the assertion that a UI-only move cannot satisfy.
+        await expect
+          .poll(
+            async () => {
+              const persisted = await readPersistedPosition();
+              return (
+                Math.abs(persisted.x - after.x) <= POSITION_TOLERANCE &&
+                Math.abs(persisted.y - after.y) <= POSITION_TOLERANCE
+              );
+            },
+            {
+              timeout: 20000,
+              message: "the moved position should be persisted to the flow",
+            },
+          )
+          .toBe(true);
+
+        // …and it must actually differ from where the node started, otherwise a
+        // no-op drag would satisfy the check above.
+        const persisted = await readPersistedPosition();
+        expect(
+          Math.abs(persisted.x - before.x) + Math.abs(persisted.y - before.y),
+          "the persisted position must differ from the pre-drag one",
+        ).toBeGreaterThan(POSITION_TOLERANCE);
+      });
+    },
+  );
+});

--- a/tests/tests-automations/regression/flow-functionality/canvas-multiselect.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/canvas-multiselect.spec.ts
@@ -1,169 +1,193 @@
 import { expect, test } from "../../../fixtures/fixtures";
-import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
-import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
-import { zoomOut } from "../../../helpers/ui/zoom-out";
+import { addComponentFromSidebar } from "../../../helpers/flows/add-component-from-sidebar";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
+import { unselectNodes } from "../../../helpers/ui/unselect-nodes";
 
-test(
-  "box selection (shift+drag) selects multiple components",
-  { tag: ["@release", "@workspace", "@regression"] },
-  async ({ page }) => {
-    await awaitBootstrapTest(page);
+/**
+ * §15.4 — Select multiple components via box selection.
+ *
+ * A Shift+drag marquee must select every node it encloses. The selection is
+ * asserted DIRECTLY through `.react-flow__node.selected`.
+ *
+ * The inherited version asserted it indirectly — copy the selection, paste it,
+ * expect `2 originals + 2 pasted = 4` — and was deterministically red at 3: one
+ * of its fixtures was Chat Input, a **singleton** that cannot be copy/pasted
+ * (`core-components/singleton-components.spec.ts`), so only one node ever
+ * pasted. Keyboard Copy/Paste is covered by `ui-ux/langflowShortcuts.spec.ts`
+ * and `flow-functionality/canvas-copy-paste.spec.ts`; this spec has no business
+ * routing a selection assertion through the clipboard.
+ *
+ * Marquee-delete of a whole canvas is also covered by
+ * `core-components/componentDelete.spec.ts` (§15.4, already `[x]`); test 2 here
+ * is scoped to proving *this* selection reaches the canvas action layer.
+ */
 
-    await page.waitForSelector('[data-testid="blank-flow"]', { timeout: 30000 });
-    await page.getByTestId("blank-flow").click();
+/** How far the second node is dragged so the two stop overlapping. */
+const SEPARATION_DX = 40;
+const SEPARATION_DY = 260;
 
-    // Add ChatOutput (first component via hover+click)
-    await page.getByTestId("sidebar-search-input").fill("chat output");
-    await page.waitForSelector('[data-testid="input_outputChat Output"]', {
+test.describe("Canvas — box selection", () => {
+  let createdFlowId: string | null = null;
+
+  test.beforeEach(async ({ page }) => {
+    createdFlowId = await setupBlankFlow(page);
+    await expect(page.locator(".react-flow__node")).toHaveCount(0);
+
+    await addComponentFromSidebar(
+      page,
+      "prompt",
+      "add-component-button-prompt-template",
+    );
+    await expect(page.locator(".react-flow__node")).toHaveCount(1, {
       timeout: 30000,
     });
-    await page
-      .getByTestId("input_outputChat Output")
-      .hover()
-      .then(async () => {
-        await page.getByTestId("add-component-button-chat-output").click();
-      });
 
-    await zoomOut(page, 2);
-
-    // Add ChatInput (second component via dragTo)
-    await page.getByTestId("sidebar-search-input").fill("chat input");
-    await page.waitForSelector('[data-testid="input_outputChat Input"]', {
-      timeout: 30000,
-    });
-    await page
-      .getByTestId("input_outputChat Input")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-        targetPosition: { x: 100, y: 100 },
-      });
-
-    await adjustScreenView(page);
+    await addComponentFromSidebar(
+      page,
+      "chat output",
+      "add-component-button-chat-output",
+    );
     await expect(page.locator(".react-flow__node")).toHaveCount(2, {
-      timeout: 10000,
-    });
-
-    // Get bounding boxes of both nodes
-    const nodes = page.locator(".react-flow__node");
-    const firstBox = await nodes.first().boundingBox();
-    const secondBox = await nodes.nth(1).boundingBox();
-
-    if (firstBox && secondBox) {
-      // Calculate selection rectangle that encompasses both nodes
-      const startX = Math.min(firstBox.x, secondBox.x) - 30;
-      const startY = Math.min(firstBox.y, secondBox.y) - 30;
-      const endX =
-        Math.max(
-          firstBox.x + firstBox.width,
-          secondBox.x + secondBox.width,
-        ) + 30;
-      const endY =
-        Math.max(
-          firstBox.y + firstBox.height,
-          secondBox.y + secondBox.height,
-        ) + 30;
-
-      // Box selection via Shift+drag on the canvas
-      await page.keyboard.down("Shift");
-      await page.mouse.move(startX, startY);
-      await page.mouse.down();
-      await page.mouse.move(endX, endY, { steps: 10 });
-      await page.mouse.up();
-      await page.keyboard.up("Shift");
-      await page.waitForTimeout(500);
-    }
-
-    // Both nodes should be selected (selection box visible or nodes have selected state)
-    // Verify by checking that Ctrl+C copies both nodes (lastCopiedSelection has 2 nodes)
-    await page.keyboard.press("Control+c");
-    await page.waitForTimeout(300);
-
-    // Click empty canvas area for paste
-    await page.locator('//*[@id="react-flow-id"]').click({
-      position: { x: 50, y: 400 },
-    });
-    await page.waitForTimeout(300);
-
-    await page.keyboard.press("Control+v");
-    await page.waitForTimeout(1500);
-
-    // After pasting the multi-selection, should have exactly 4 nodes (2 original + 2 pasted)
-    await expect(page.locator(".react-flow__node")).toHaveCount(4, {
-      timeout: 5000,
-    });
-  },
-);
-
-test(
-  "box-selecting all nodes and deleting clears the canvas",
-  { tag: ["@release", "@workspace", "@regression"] },
-  async ({ page }) => {
-    await awaitBootstrapTest(page);
-
-    await page.waitForSelector('[data-testid="blank-flow"]', { timeout: 30000 });
-    await page.getByTestId("blank-flow").click();
-
-    // Add two components
-    await page.getByTestId("sidebar-search-input").fill("chat output");
-    await page.waitForSelector('[data-testid="input_outputChat Output"]', {
       timeout: 30000,
     });
-    await page
-      .getByTestId("input_outputChat Output")
-      .hover()
-      .then(async () => {
-        await page.getByTestId("add-component-button-chat-output").click();
-      });
 
-    await zoomOut(page, 2);
-
-    await page.getByTestId("sidebar-search-input").fill("chat input");
-    await page.waitForSelector('[data-testid="input_outputChat Input"]', {
-      timeout: 30000,
+    // Components added from the sidebar stack ~10px apart. A marquee over
+    // stacked nodes cannot distinguish "selected both" from "selected the top
+    // one", so the second node is dragged clear first.
+    const topNode = page.locator(".react-flow__node").nth(1);
+    const box = await topNode.boundingBox();
+    expect(box, "the second node must be on screen to separate it").not.toBeNull();
+    const startX = box!.x + box!.width / 2;
+    const startY = box!.y + 12;
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(startX + SEPARATION_DX, startY + SEPARATION_DY, {
+      steps: 15,
     });
-    await page
-      .getByTestId("input_outputChat Input")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-        targetPosition: { x: 100, y: 100 },
-      });
+    await page.mouse.up();
 
-    await adjustScreenView(page);
-    await expect(page.locator(".react-flow__node")).toHaveCount(2, {
-      timeout: 10000,
-    });
+    await expect
+      .poll(
+        async () => {
+          const boxes = await page
+            .locator(".react-flow__node")
+            .evaluateAll((nodes) =>
+              nodes.map((n) => {
+                const r = n.getBoundingClientRect();
+                return { top: r.top, bottom: r.bottom };
+              }),
+            );
+          return boxes[0].bottom < boxes[1].top || boxes[1].bottom < boxes[0].top;
+        },
+        {
+          timeout: 15000,
+          message: "the two nodes must not overlap before the marquee",
+        },
+      )
+      .toBe(true);
+  });
 
-    // Box-select all nodes via Shift+drag from corner to corner
-    const nodes = page.locator(".react-flow__node");
-    const firstBox = await nodes.first().boundingBox();
-    const secondBox = await nodes.nth(1).boundingBox();
-
-    if (firstBox && secondBox) {
-      const startX = Math.min(firstBox.x, secondBox.x) - 30;
-      const startY = Math.min(firstBox.y, secondBox.y) - 30;
-      const endX =
-        Math.max(firstBox.x + firstBox.width, secondBox.x + secondBox.width) +
-        30;
-      const endY =
-        Math.max(
-          firstBox.y + firstBox.height,
-          secondBox.y + secondBox.height,
-        ) + 30;
-
-      await page.keyboard.down("Shift");
-      await page.mouse.move(startX, startY);
-      await page.mouse.down();
-      await page.mouse.move(endX, endY, { steps: 10 });
-      await page.mouse.up();
-      await page.keyboard.up("Shift");
-      await page.waitForTimeout(500);
+  test.afterEach(async ({ page }) => {
+    if (createdFlowId) {
+      await page.goto("/").catch(() => {});
+      await deleteFlow(page.request, createdFlowId);
+      createdFlowId = null;
     }
+  });
 
-    // Delete selected nodes
-    await page.keyboard.press("Delete");
-    await page.waitForTimeout(1000);
+  /**
+   * Shift+drags a marquee across the given screen rectangle. ReactFlow needs an
+   * intermediate move to start the selection gesture.
+   */
+  const marquee = async (
+    page: import("@playwright/test").Page,
+    from: { x: number; y: number },
+    to: { x: number; y: number },
+  ) => {
+    await page.keyboard.down("Shift");
+    await page.mouse.move(from.x, from.y);
+    await page.mouse.down();
+    await page.mouse.move(from.x + 20, from.y + 20, { steps: 5 });
+    await page.mouse.move(to.x, to.y, { steps: 15 });
+    await page.mouse.up();
+    await page.keyboard.up("Shift");
+  };
 
-    // Canvas must be completely empty after deleting all selected nodes
-    await expect(page.locator(".react-flow__node")).toHaveCount(0, {
-      timeout: 5000,
-    });
-  },
-);
+  /** Screen rectangle enclosing every node, padded by `pad` pixels. */
+  const nodesBounds = async (
+    page: import("@playwright/test").Page,
+    pad: number,
+  ) => {
+    const boxes = await page
+      .locator(".react-flow__node")
+      .evaluateAll((nodes) =>
+        nodes.map((n) => {
+          const r = n.getBoundingClientRect();
+          return { x: r.x, y: r.y, right: r.right, bottom: r.bottom };
+        }),
+      );
+    return {
+      from: {
+        x: Math.min(...boxes.map((b) => b.x)) - pad,
+        y: Math.min(...boxes.map((b) => b.y)) - pad,
+      },
+      to: {
+        x: Math.max(...boxes.map((b) => b.right)) + pad,
+        y: Math.max(...boxes.map((b) => b.bottom)) + pad,
+      },
+    };
+  };
+
+  test("a Shift+drag marquee selects every component it encloses",
+    { tag: ["@stable", "@release", "@workspace", "@ui-ux"] },
+    async ({ page }) => {
+      const selected = page.locator(".react-flow__node.selected");
+
+      await test.step("Start from an unselected canvas", async () => {
+        await unselectNodes(page);
+        await expect(selected).toHaveCount(0);
+      });
+
+      await test.step("A marquee drawn away from the nodes selects nothing", async () => {
+        // Negative control: proves the count below is caused by enclosing the
+        // nodes, not by the marquee gesture itself.
+        const bounds = await nodesBounds(page, 30);
+        const emptyY = bounds.from.y - 120;
+        await marquee(
+          page,
+          { x: bounds.from.x, y: emptyY },
+          { x: bounds.to.x, y: bounds.from.y - 40 },
+        );
+        await expect(selected).toHaveCount(0);
+      });
+
+      await test.step("A marquee enclosing both nodes selects both", async () => {
+        const bounds = await nodesBounds(page, 30);
+        await marquee(page, bounds.from, bounds.to);
+        await expect(selected).toHaveCount(2, { timeout: 10000 });
+      });
+    },
+  );
+
+  test("deleting a box selection clears the selected components",
+    { tag: ["@stable", "@release", "@workspace", "@ui-ux"] },
+    async ({ page }) => {
+      const selected = page.locator(".react-flow__node.selected");
+
+      await test.step("Box-select both nodes", async () => {
+        await unselectNodes(page);
+        const bounds = await nodesBounds(page, 30);
+        await marquee(page, bounds.from, bounds.to);
+        await expect(selected).toHaveCount(2, { timeout: 10000 });
+      });
+
+      await test.step("Delete removes every selected node", async () => {
+        await page.keyboard.press("Delete");
+        await expect(page.locator(".react-flow__node")).toHaveCount(0, {
+          timeout: 10000,
+        });
+      });
+    },
+  );
+});

--- a/tests/tests-automations/regression/ui-ux/minimize.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/minimize.spec.ts
@@ -1,73 +1,162 @@
 import { expect, test } from "../../../fixtures/fixtures";
-import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
-import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
-import { zoomOut } from "../../../helpers/ui/zoom-out";
+import { addComponentFromSidebar } from "../../../helpers/flows/add-component-from-sidebar";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
 
-test(
-  "user must be able to minimize and expand a component",
-  { tag: ["@release", "@workspace"] },
-  async ({ page }) => {
-    await awaitBootstrapTest(page);
+/**
+ * §15.4 — Minimize component on canvas.
+ *
+ * Collapsing and restoring a node through its options menu, asserted in the DOM
+ * and in the persisted flow.
+ *
+ * Two facts drive the fixture choice, both measured on nightly 1.12.0.dev8:
+ *
+ * 1. **Chat Output ships minimized** (`minimized: true` in `GET /api/v1/all`),
+ *    so a spec built on it would start in the end state. Prompt Template has
+ *    `minimized: false` and renders expanded, making both directions observable.
+ * 2. **The inherited version of this spec was red** because it searched for
+ *    `Text Input`, which is now `legacy: true` and therefore hidden from the
+ *    default sidebar — an intentional product change. The fix is a different
+ *    fixture component, not enabling the legacy toggle (that surface belongs to
+ *    `core-components/legacy-components-toggle-regression.spec.ts`).
+ *
+ * The minimize state is read from `data.showNode`, not `node.minimized`:
+ * `minimized` is the catalog default and does not track the user's action
+ * (verified — after minimizing the Prompt Template, `showNode` was `false`
+ * while `minimized` stayed `false`).
+ */
 
-    await page.waitForSelector('[data-testid="blank-flow"]', {
+test.describe("Canvas — minimize and expand a component", () => {
+  let createdFlowId: string | null = null;
+
+  /** Nodes as the backend currently has them (empty until autosave lands). */
+  async function fetchNodes(
+    request: import("@playwright/test").APIRequestContext,
+    flowId: string,
+  ) {
+    const bearer = await getAuthToken(request);
+    const response = await request.get(`/api/v1/flows/${flowId}`, {
+      headers: bearer ? { Authorization: bearer } : undefined,
+    });
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    return (body?.data?.nodes ?? []) as Array<{
+      data: { showNode?: boolean };
+    }>;
+  }
+
+  test.beforeEach(async ({ page, request }) => {
+    createdFlowId = await setupBlankFlow(page);
+    await expect(page.locator(".react-flow__node")).toHaveCount(0);
+
+    await addComponentFromSidebar(
+      page,
+      "prompt",
+      "add-component-button-prompt-template",
+    );
+    await expect(page.locator(".react-flow__node")).toHaveCount(1, {
       timeout: 30000,
     });
-    await page.getByTestId("blank-flow").click();
 
-    await page.getByTestId("sidebar-search-input").click();
-    await page.getByTestId("sidebar-search-input").fill("text input");
-    await page.waitForSelector('[data-testid="input_outputText Input"]', {
-      timeout: 30000,
-    });
+    // The canvas autosave is debounced, so the flow is still node-less on the
+    // server right after the component renders. Gate on server truth before
+    // reading `showNode` from it.
+    await expect
+      .poll(async () => (await fetchNodes(request, createdFlowId!)).length, {
+        timeout: 30000,
+        message: "the added component should be persisted before minimizing",
+      })
+      .toBe(1);
+  });
 
-    await page
-      .getByTestId("input_outputText Input")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'));
+  test.afterEach(async ({ page }) => {
+    if (createdFlowId) {
+      await page.goto("/").catch(() => {});
+      await deleteFlow(page.request, createdFlowId);
+      createdFlowId = null;
+    }
+  });
 
-    await page
-      .locator('//*[@id="react-flow-id"]')
-      .hover()
-      .then(async () => {
-        await page.mouse.down();
-        await page.mouse.move(-800, 300);
+  test("user must be able to minimize and expand a component",
+    { tag: ["@stable", "@release", "@workspace", "@ui-ux"] },
+    async ({ page, request }) => {
+      const node = page.locator(".react-flow__node").first();
+      const hiddenHandles = node.locator(".react-flow__handle.no-show");
+      const flowId = createdFlowId!;
+
+      const readShowNode = async () => {
+        const nodes = await fetchNodes(request, flowId);
+        expect(nodes.length, "the flow should hold exactly one node").toBe(1);
+        return nodes[0].data.showNode;
+      };
+
+      /** Selects the node and opens its toolbar options menu. */
+      const openNodeMenu = async () => {
+        await node.click();
+        await page.getByTestId("icon-MoreHorizontal").click();
+      };
+
+      let expandedHeight = 0;
+      let minimizedHeight = 0;
+
+      await test.step("The node starts expanded", async () => {
+        await expect(hiddenHandles).toHaveCount(0);
+        const box = await node.boundingBox();
+        expect(box, "the node must be on screen").not.toBeNull();
+        expandedHeight = box!.height;
       });
 
-    await page.mouse.up();
+      await test.step("Minimize collapses the node", async () => {
+        await openNodeMenu();
+        await page.getByTestId("minimize-button-modal").click();
 
-    await adjustScreenView(page);
+        // Every handle on a minimized node is rendered with `no-show`; a
+        // count > 0 is the durable DOM signal (heights shift with styling).
+        await expect(hiddenHandles.first()).toBeVisible({ timeout: 10000 });
+        await expect
+          .poll(async () => (await node.boundingBox())!.height, {
+            timeout: 10000,
+            message: "the minimized node should be shorter than the expanded one",
+          })
+          .toBeLessThan(expandedHeight);
+        minimizedHeight = (await node.boundingBox())!.height;
+      });
 
-    await zoomOut(page, 4);
+      await test.step("The minimized state reached the backend", async () => {
+        await expect
+          .poll(readShowNode, {
+            timeout: 20000,
+            message: "minimizing should persist data.showNode = false",
+          })
+          .toBe(false);
+      });
 
-    await page.getByTestId("more-options-modal").click();
+      await test.step("Expand restores the node", async () => {
+        await openNodeMenu();
+        // The item swaps identity rather than toggling under one testid.
+        await page.getByTestId("expand-button-modal").click();
 
-    await page.waitForSelector('[data-testid="minimize-button-modal"]', {
-      timeout: 10000,
-    });
+        await expect(hiddenHandles).toHaveCount(0, { timeout: 10000 });
+        // Compared against the minimized height, not the original expanded one:
+        // selecting the node adds affordances, so the restored height is close
+        // to — but not exactly — the first measurement.
+        await expect
+          .poll(async () => (await node.boundingBox())!.height, {
+            timeout: 10000,
+            message: "the expanded node should be taller than the minimized one",
+          })
+          .toBeGreaterThan(minimizedHeight);
+      });
 
-    await page.getByTestId("minimize-button-modal").first().click();
-
-    await expect(
-      page.locator(".react-flow__handle-left.no-show").first(),
-    ).toBeVisible({ timeout: 10000 });
-
-    await expect(
-      page.locator(".react-flow__handle-right.no-show").first(),
-    ).toBeVisible({ timeout: 10000 });
-
-    await page.getByTestId("more-options-modal").click();
-
-    await page.waitForSelector('[data-testid="expand-button-modal"]', {
-      timeout: 10000,
-    });
-
-    await page.getByTestId("expand-button-modal").first().click();
-
-    await expect(page.locator(".react-flow__handle-left").first()).toBeVisible({
-      timeout: 10000,
-    });
-
-    await expect(page.locator(".react-flow__handle-right").first()).toBeVisible(
-      { timeout: 10000 },
-    );
-  },
-);
+      await test.step("The expanded state reached the backend", async () => {
+        await expect
+          .poll(readShowNode, {
+            timeout: 20000,
+            message: "expanding should persist data.showNode = true",
+          })
+          .toBe(true);
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #940.

Closes the six remaining `[-]` items in `QA-CHECKLIST.md` § 15.4 — Node
Manipulation. Five get specs; the sixth is already covered by an existing
`@stable` spec and only needed its bullet pointed at it.

| § 15.4 item | Outcome |
|---|---|
| Canvas keyboard shortcuts | `[x]` → `ui-ux/langflowShortcuts.spec.ts` (already `@stable`) — **no code change** |
| Minimize component on canvas | `[x]` — `ui-ux/minimize.spec.ts` **rewritten** (was red) |
| Move component within canvas | `[x]` — **new** `flow-functionality/canvas-move-node.spec.ts` |
| Select multiple components via box selection | `[x]` — `flow-functionality/canvas-multiselect.spec.ts` **rewritten** (was red) |
| Deselect by clicking empty canvas area | `[x]` — `flow-functionality/canvas-deselect-node.spec.ts` hardened |
| Deselect via Escape | `[x]` — same file |

Baseline before touching anything, on nightly `1.12.0.dev8`: **3 passed, 2 failed**,
and **5 orphan flows from a single run** — none of the three inherited files
cleaned up after itself.

## 1. Covered tests

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `dragging a component moves it on the canvas and persists the new position` | Dragging a node by its title moves it **and** the new coordinates reach the backend: the DOM `transform` and the `position` in `GET /api/v1/flows/{id}` are compared against each other, and a final assert requires the persisted position to differ from the pre-drag one (a no-op drag cannot satisfy the poll alone). Catches a UI-only move that never reaches the autosave `PATCH` — looks right on screen, loses the layout on reload. |
| 2 | `user must be able to minimize and expand a component` | The options menu collapses the node (every handle gains `no-show`, height shrinks) and persists `data.showNode = false`; the menu item then swaps identity to `expand-button-modal`, whose click clears `no-show`, grows the node back and persists `data.showNode = true`. |
| 3 | `a Shift+drag marquee selects every component it encloses` | With two separated nodes, `.react-flow__node.selected` goes 0 → 2. A marquee drawn **away** from the nodes first leaves the count at 0 — a negative control proving the gesture alone does not select. |
| 4 | `deleting a box selection clears the selected components` | `Delete` with both nodes box-selected empties the canvas — the selection reaches the canvas action layer. |
| 5 | `clicking empty canvas area deselects a selected node` | `.react-flow__node.selected` 1 → 0 after clicking `.react-flow__pane`, with the selected state asserted **first** so the deselect is causal. |
| 6 | `pressing Escape deselects a selected node` | Same contract via the keyboard. |

## 2. How the tests were built

**Why two inherited specs were red — two different verdicts, neither a product
regression:**

1. `minimize.spec.ts` waited on `[data-testid="input_outputText Input"]`.
   `Text Input` is now **`legacy: true`** in `GET /api/v1/all`, so it is hidden
   from the default sidebar — an intentional product change. The fix is a
   different fixture component; enabling the legacy toggle would be testing a
   different surface (`core-components/legacy-components-toggle-regression.spec.ts`
   owns that).
2. `canvas-multiselect.spec.ts` asserted box selection **indirectly**: copy the
   selection, paste it, expect `2 originals + 2 pasted = 4`. It got **3**,
   deterministically — one fixture was `Chat Input`, a **singleton** that cannot
   be copy/pasted (`core-components/singleton-components.spec.ts`). Routing a
   selection assertion through the clipboard was the defect; the rewrite asserts
   `.react-flow__node.selected` directly.

**Fixture choices, measured live on 1.12.0.dev8:**

- **Prompt Template everywhere.** It is non-singleton and, crucially,
  **renders expanded** (`minimized: false` in the catalog). `Chat Output`
  **ships minimized** (`minimized: true`), so a minimize test built on it would
  start in the end state.
- **The minimize state is read from `data.showNode`, not `node.minimized`.**
  `minimized` is the catalog default and does not track the user's action —
  verified: after minimizing the Prompt Template, `showNode` was `false` while
  `minimized` stayed `false`.
- **Nodes are separated before any marquee.** Two components added from the
  sidebar stack ~10 px apart; a marquee over stacked nodes cannot distinguish
  "selected both" from "selected the top one".
- **Drags are `mouse.move` → `down` → `move(steps)` → `up`**, not
  `locator.dragTo`: ReactFlow needs intermediate move events to start a node
  drag or a selection gesture.
- **Nodes are dragged by their title**, never the body — a body press can land
  on an interactive field and start editing instead of dragging.
- **The empty-canvas click targets `.react-flow__pane`**, not the
  `#react-flow-id` wrapper whose coordinate space includes the node layer.

**Server-truth gate.** Both persistence specs poll `GET /api/v1/flows/{id}`
until the added node exists before reading `position` / `showNode`. Reading once
right after the component renders returns `data.nodes: []` — the canvas autosave
is debounced, and network silence is not persistence. Both specs were red on
exactly this before the gate was added.

**Cleanup.** All four specs now create their flow through `setupBlankFlow`
(API-created, returns the id) and delete that id in `afterEach`. The inherited
files used `awaitBootstrapTest` + a `blank-flow` click and deleted nothing.

**Removed anti-patterns:** every `page.waitForTimeout` replaced by an assertion,
and the `if (firstBox && secondBox)` guard that silently skipped the whole
marquee gesture when a bounding box was unavailable.

## 3. Dependencies

- **None** — pure UI. No provider API key, no LLM call.
- Parallel-safe: each test owns exactly one API-created flow and deletes it.
- New spec docs: `docs/flow-functionality/canvas-move-node.md`,
  `docs/flow-functionality/canvas-multiselect.md`,
  `docs/flow-functionality/canvas-deselect-node.md`, `docs/ui-ux/minimize.md`.
- `QA-CHECKLIST.md`: only the manual § 15.4 Part II bullets were edited (guard ✅).

## Validation (nightly `1.12.0.dev8`, `--retries=0 --workers=1`)

```
run 1..3/3 canvas-deselect-node.spec.ts: expected=2 unexpected=0 flaky=0 backendErrors=false
run 1..3/3 canvas-multiselect.spec.ts:   expected=2 unexpected=0 flaky=0 backendErrors=false
run 1..3/3 minimize.spec.ts:             expected=1 unexpected=0 flaky=0 backendErrors=false
run 1..3/3 canvas-move-node.spec.ts:     expected=1 unexpected=0 flaky=0 backendErrors=false
```

- `npm run typecheck` ✅ · `npx eslint` on all four specs ✅ (0 warnings) ·
  `check-checklist-guard` ✅ · `check:checklist-coverage` ✅
- 3 clean `--retries=0` runs per spec, no flake ✅ · zero `🚨 Backend Error` ✅
- **Force-fail, every `test()`, each verified red then reverted**
  (`grep -c FF-MUTATION` = 0):
  - `dragging a component moves it…` → `DRAG_DX`/`DRAG_DY` zeroed (no-op drag) → `unexpected=1` ✅
  - `minimize and expand…` → closed the menu with `Escape` instead of clicking `minimize-button-modal` → `unexpected=1` ✅
  - `Shift+drag marquee selects…` → final marquee drawn above the nodes → `unexpected=1` ✅
  - `deleting a box selection…` → `ArrowRight` instead of `Delete` → `unexpected=1` ✅
  - `clicking empty canvas area…` → clicked the node again instead of the pane → `unexpected=1` ✅
  - `pressing Escape deselects…` → `ArrowRight` instead of `Escape` → `unexpected=1` ✅
  - **Behavioral cleanup force-fail across all four files:** `deleteFlow` no-op'd
    → run stayed **green** (6 passed) while **6 flows survived** → reverted →
    0 orphans ✅
- Instance left with **0 orphan flows** (only the shared bootstrap `Basic Prompting`).

Related: #1027 (follow-up from #945) tracks `canvas-right-click-component.spec.ts`,
a § 15.9 spec with the same missing-cleanup problem. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
