### PR TITLE
chore(triage): render and validate the dedicated-issue body from code

### DIFF
--- a/.claude/skills/langflow-e2e-triage/SKILL.md
+++ b/.claude/skills/langflow-e2e-triage/SKILL.md
@@ -239,11 +239,18 @@ plan and present it again — the gate re-applies to the revised plan too.
 
 Only after the user approves the plan:
 
-1. For each **create** row: `gh issue create` using the dedicated-issue
-   template and area-label mapping in
+1. For each **create** row: build the body with
+   `renderDedicatedIssueBody()` from `scripts/lib/triage-core.mjs` — do **not**
+   compose the Markdown by hand. The renderer owns section order, the
+   provenance line and the canonical deliverables; it refuses a cluster with a
+   missing `error_signature`, and `renderDedicatedIssueTitle()` refuses a title
+   built from the run id instead of the umbrella number. Then run
+   `assertDedicatedIssueBody(body, { throwOnError: true })` before
+   `gh issue create`, and apply the area-label mapping in
    `references/issue-templates.md`.
 2. For each **enrich** row: `gh issue comment` on the matched existing issue,
-   per the same reference's *Enrich vs Create Rule*.
+   per the same reference's *Enrich vs Create Rule*. Match on the **normalized
+   signature**, not on a description of the symptom.
 3. **Quarantines — separate authorization, one at a time.** For each recurrent
    flake in the removals block: show the **exact diff** (drop `@stable` **and**
    wrap the test as `test.fixme(<reason + issue #>)`, at `spec:line`) and ask

--- a/.claude/skills/langflow-e2e-triage/references/issue-templates.md
+++ b/.claude/skills/langflow-e2e-triage/references/issue-templates.md
@@ -44,6 +44,25 @@ Example: `[Daily #744] agent/flow execution does not complete — div-chat-messa
 Spun out of daily-failure triage #<umbrella> (run [<run_id>](<run_url>), <date>).
 ```
 
+**Upstream (second line)**
+
+```
+**Upstream:** LE-1234
+```
+
+The seam to the treatment layer. **This issue tracks the failure, not the fix** —
+what gets done about it is worked on the Jira board, so the card key has to be a
+field the body always carries. It is rendered as `_not filed_` when no card exists
+yet (the normal state at triage time, since the card follows the investigation),
+and the renderer never omits the line: an always-present slot is what makes the
+failure → issue → card walk possible, and what lets the link be swept for
+mechanically. Accepts a DataStax Jira key (`LE-####`) or a
+`langflow-ai/langflow#N` issue.
+
+Do **not** rely on the `REGRESSIONS.md` deliverable checkbox to carry this. That
+checkbox is an acceptance criterion — it records that a row is owed, not where the
+card is, and it vanishes from any sweep if nobody ticks it.
+
 **Sections**
 
 #### Symptom

--- a/.claude/skills/langflow-e2e-triage/references/issue-templates.md
+++ b/.claude/skills/langflow-e2e-triage/references/issue-templates.md
@@ -2,6 +2,27 @@
 
 This document defines the canonical template and rules for dedicated-issue triage in the `langflow-e2e-triage` skill.
 
+> **The body is rendered from code, not composed by hand.** `renderDedicatedIssueBody()`
+> and `assertDedicatedIssueBody()` in `scripts/lib/triage-core.mjs` own the structure;
+> Phase 7 calls them before `gh issue create`. This document explains *what each section
+> is for* and *what belongs in it* — the renderer enforces that the sections exist, that
+> every affected test carries a signature, and that at least one backticked spec path is
+> present. Editing the shape here without editing the renderer changes nothing.
+>
+> Why code and not prose: `gh issue create` bypasses `.github/ISSUE_TEMPLATE` entirely,
+> and the primary author of these issues is an LLM. A Markdown reference is advice; the
+> renderer is a guarantee. (The GitHub issue form at
+> `.github/ISSUE_TEMPLATE/failure-root-cause.yml` mirrors this same shape for humans
+> opening a cause issue by hand through the web UI.)
+
+## Scope — which issues this covers
+
+Two issues get opened around a red daily; only one is templated:
+
+- The **umbrella** is created by `daily-stable.yml` through the GitHub API
+  (`github.rest.issues.create`), which no template can govern. Not this.
+- The **dedicated per-cause issues** are created here, in Phase 7. These.
+
 ## Dedicated-Issue Template
 
 When opening a new issue to track a daily-failure cluster, use this structure:
@@ -44,7 +65,25 @@ Include:
 - Line number where the test fails
 - Human-readable test name (from `test()` or `test.describe()`)
 - The locator/selector being waited on
-- The exact error message or timeout signature
+- The `error_signature` **copied verbatim** from the run's row in
+  `reports/daily-history.jsonl`
+
+**The signature is copied, never written.** It is the key the same-signature
+recurrence rule matches on (`CONTRIBUTING.md` → *Monitoring rules driven by run
+history*), and `normalizeSignature()` only strips ANSI, collapses whitespace and
+lowercases — it does not understand paraphrase. So:
+
+- Copy the value out of the history row unedited. Do not shorten it, do not
+  reword it, do not merge two tests' signatures into one description.
+- If the run recorded `"unknown"` — which happens when the failure carried no
+  error message — write `unknown`. Substituting a description of what you think
+  happened makes the next run's occurrence unmatchable, and the flake rule then
+  reads a recurrence as a first occurrence.
+- ANSI codes are stripped by the renderer; a literal `|` is escaped so it cannot
+  break the table. Both are safe to leave in the value you copy.
+
+A paraphrased signature is the single most likely way per-cause issues quietly
+degrade back into one issue per day for the same cause.
 
 **Name every spec you are claiming, in backticked repo-relative form, on every
 `daily-failure` issue** — in this table at triage time, and in follow-up comments
@@ -56,6 +95,37 @@ naturally accumulates specs over time (see #773, which took on the whole
 something to fold back into the opening post. What does *not* work is naming a spec
 in prose only, without the path: `agent-max-tokens` alone is unmatchable, while
 `` `core-functionality/llm-agents/agent-max-tokens.spec.ts:249` `` is not.
+
+#### Why these failures are one cause
+
+The linking argument for this cluster. Format:
+
+```markdown
+## Why these failures are one cause
+
+All five failed inside the same 40s window on shard 3, every one on the first request issued after `Collect models`. The signatures differ (timeout, `toBeVisible failed`, 502) and no test-level change is common to them — the shared dimension is the backend they all hit, not anything in the specs.
+```
+
+The team files issues **per root cause, not per failing test**. That only works if
+the grouping is stated and checkable; otherwise a cause issue and a pile of
+unrelated failures filed together are indistinguishable — at triage time and, worse,
+six weeks later when someone tries to reopen the reasoning.
+
+Rules:
+- Name the **shared dimension**: same window, same shard, same provider, same
+  dependency, same step, same normalized signature.
+- Say it explicitly when the signatures **differ** and you are grouping anyway.
+  One cause routinely produces several signatures (a wedged backend surfaces as
+  timeouts, `toBeVisible failed`, 5xx and `unknown` at once) — that is a legitimate
+  grouping, but it has to be argued, not assumed.
+- Equally, the same signature across unrelated specs is **not** by itself a cause.
+  `expect(locator).toBeVisible() failed` is the most generic string Playwright
+  emits and it collides constantly.
+- Stay **descriptive**. Name what is shared, not what is broken — the mechanism is
+  the investigation's job, and the section below exists precisely to keep that
+  line intact.
+- One cluster whose argument splits into two arguments is two issues. Split it
+  and cross-link.
 
 #### Preliminary read (descriptive — NOT a verdict)
 
@@ -253,10 +323,24 @@ Then:
 
 2. **If the subject (symptom, specs, or root path) is genuinely new**, create the issue using the template above.
 
-**Symptom matching logic:**
-- Same failure symptom (e.g., "div-chat-message timeout") across different specs → **same issue, comment**
+**Match on the normalized signature, not on a description of the symptom.**
+Run each candidate's `error_signature` and the open issues' recorded signatures
+through `normalizeSignature()` and compare the results. Matching on prose is what
+lets the same cause read as new every morning — and one new issue per day for one
+cause is per-test issues wearing a hat, which is the exact outcome the per-cause
+policy exists to avoid.
+
+**Matching logic:**
+- Same normalized signature across different specs → **same issue, comment**
 - Same spec failing at different lines (different tests) → likely same issue, **comment** (unless it clearly branches into separate root paths, then split)
-- Same directory/feature but different symptoms (e.g., one auth failure, one upload failure) → **separate issues**
+- Same directory/feature but different signatures → **separate issues**, unless the *Why these failures are one cause* argument holds across them (a shared backend, provider or step can produce several signatures — see that section)
+- Generic signatures (`expect(locator).toBeVisible() failed`, `unknown`) are **too weak to match on alone**. They collide across unrelated specs, and `unknown` is a null key that would cluster every message-less failure together. Require a second shared dimension — same spec, same provider, same run window — before treating them as one cause.
+
+**Merge, not just split.** The rule runs both ways: two *open* dedicated issues
+later found to share a cause get merged (keep the older number, close the newer
+as a duplicate, cross-link both and carry over any spec paths the closed one
+claimed — the QA Platform matches on those paths, so a path dropped in the merge
+stops being tracked).
 
 ---
 
@@ -296,6 +380,8 @@ Every dedicated issue embodies this philosophy:
 
 - **Provenance first:** readers know where the issue came from and when
 - **Description before diagnosis:** symptom table + preliminary observations, no verdict
+- **Signatures verbatim:** copied from the history row, `unknown` included — recurrence is matched mechanically, and a paraphrase breaks it
+- **Grouping is argued, not assumed:** one issue per cause only means something if the issue says why these failures are one cause
 - **Investigation as independent branches:** test the product first, then environment, then test design
 - **Deliverables as checkboxes:** done when all items are ticked
 - **Quarantine decisions are explicit:** quarantined at triage as prevention — `@stable` removed **+** `test.fixme` added (or nothing quarantined on a guard-tripped day) — and **lifted as a deliverable** after the fix — always documented

--- a/.claude/skills/langflow-e2e-triage/scripts/lib/triage-core.mjs
+++ b/.claude/skills/langflow-e2e-triage/scripts/lib/triage-core.mjs
@@ -277,6 +277,7 @@ export function renderDedicatedIssueBody(input) {
     umbrella,
     run,
     provenanceNote = '',
+    upstream = null,
     summary,
     tests,
     whyOneCause,
@@ -310,6 +311,14 @@ export function renderDedicatedIssueBody(input) {
     `Spun out of daily-failure triage #${umbrella} (run ${runRef}, ${run.date}).` +
     (provenanceNote.trim() ? ` ${provenanceNote.trim()}` : '');
 
+  // The seam to the treatment layer. This issue tracks the *failure*; what is
+  // done about it is worked on the Jira board, so the key has to be a field the
+  // body always carries — not a mention inside a deliverable checkbox, which
+  // cannot be swept and disappears if nobody ticks it. Rendered unfilled at
+  // triage time (the card rarely exists yet) precisely so the slot is visible
+  // and someone fills it later.
+  const upstreamLine = `**Upstream:** ${String(upstream || '').trim() || '_not filed_'}`;
+
   const rows = tests.map((t) => {
     const spec = `\`${t.file}:${t.line}\`` + (t.test ? ` ("${tableCell(t.test)}")` : '');
     const waits = t.waits_for ? `\`${tableCell(t.waits_for)}\`` : '—';
@@ -320,6 +329,8 @@ export function renderDedicatedIssueBody(input) {
 
   const out = [
     provenance,
+    '',
+    upstreamLine,
     '',
     '## Symptom',
     '',
@@ -392,6 +403,10 @@ export function assertDedicatedIssueBody(body, opts = {}) {
 
   if (!/`[^`\s]+\.spec\.ts:\d+`/.test(text)) {
     problems.push('no backticked repo-relative spec path with a line number — the QA Platform cannot match this issue to a failure');
+  }
+
+  if (!/^\*\*Upstream:\*\* .+/m.test(text)) {
+    problems.push('missing the **Upstream:** line — the seam to the Jira/upstream card; render it as _not filed_ when no card exists yet, never omit it');
   }
 
   if (!/- \[ \] /.test(text)) {

--- a/.claude/skills/langflow-e2e-triage/scripts/lib/triage-core.mjs
+++ b/.claude/skills/langflow-e2e-triage/scripts/lib/triage-core.mjs
@@ -19,8 +19,13 @@ export function findLatestRedRun(rows) {
   return null;
 }
 
+// The ESC is required. Without it the pattern strips the `[2m` and leaves the
+// bare ESC byte behind, so a signature recorded with ANSI never compares equal to
+// the same signature recorded without it — silently breaking the same-signature
+// recurrence rule that drives every flake decision.
+// `scripts/build-run-payload.mjs` already uses this form; this one had drifted.
 // eslint-disable-next-line no-control-regex
-const ANSI_RE = /\[[0-9;]*m/g;
+const ANSI_RE = /\u001b\[[0-9;]*m/g;
 
 /** Strip ANSI SGR escape sequences. */
 export function stripAnsi(s) {

--- a/.claude/skills/langflow-e2e-triage/scripts/lib/triage-core.mjs
+++ b/.claude/skills/langflow-e2e-triage/scripts/lib/triage-core.mjs
@@ -23,7 +23,6 @@ export function findLatestRedRun(rows) {
 // bare ESC byte behind, so a signature recorded with ANSI never compares equal to
 // the same signature recorded without it — silently breaking the same-signature
 // recurrence rule. `scripts/build-run-payload.mjs` already uses this form.
-// eslint-disable-next-line no-control-regex
 const ANSI_RE = /\u001b\[[0-9;]*m/g;
 
 /** Strip ANSI SGR escape sequences. */
@@ -245,6 +244,24 @@ function tableCell(value) {
   return stripAnsi(value).replace(/\|/g, '\\|').replace(/\r?\n/g, '<br>').trim();
 }
 
+/** Table rows of the Symptom table: not the header, not the `|---|` separator. */
+function symptomRows(text) {
+  return text
+    .split('\n')
+    .filter((l) => /^\s*\|.*\|\s*$/.test(l))
+    .filter((l) => !/^\s*\|[\s\-:|]+\|\s*$/.test(l))
+    .filter((l) => !/\|\s*Signature\s*\|/.test(l));
+}
+
+/** Cells of a Markdown table row, splitting only on unescaped pipes. */
+function rowCells(line) {
+  return line
+    .trim()
+    .replace(/^\||\|$/g, '')
+    .split(/(?<!\\)\|/)
+    .map((c) => c.trim());
+}
+
 /**
  * Title for a dedicated issue: `[Daily #<umbrella>] <symptom>`.
  *
@@ -287,7 +304,21 @@ export function renderDedicatedIssueBody(input) {
     flakeSignal = null,
   } = input || {};
 
+  // Guard the umbrella the same way renderDedicatedIssueTitle does. buildDataset
+  // legitimately returns `umbrella_issue: null` when matchUmbrella() finds no
+  // umbrella carrying this run id, and interpolating that produces "#null" — a
+  // body the validator then rejects as a malformed provenance line, naming the
+  // wrong cause in a job with nobody watching. Fail here, where the reason is known.
+  if (!Number.isInteger(Number(umbrella)) || Number(umbrella) <= 0) {
+    throw new Error(`renderDedicatedIssueBody: umbrella must be a positive issue number, got ${JSON.stringify(umbrella)} — matchUmbrella() returns null when no umbrella carries this run id`);
+  }
   if (!run?.run_id) throw new Error('renderDedicatedIssueBody: run.run_id is required');
+  // Without this the provenance line renders "(run 123, undefined)" and the
+  // validator's `\(run .+\)` used to accept it — the line that joins the issue
+  // back to its history row, shipped broken.
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(String(run?.date || ''))) {
+    throw new Error(`renderDedicatedIssueBody: run.date must be YYYY-MM-DD, got ${JSON.stringify(run?.date)}`);
+  }
   if (!Array.isArray(tests) || tests.length === 0) {
     throw new Error('renderDedicatedIssueBody: at least one affected test is required');
   }
@@ -320,7 +351,9 @@ export function renderDedicatedIssueBody(input) {
   const upstreamLine = `**Upstream:** ${String(upstream || '').trim() || '_not filed_'}`;
 
   const rows = tests.map((t) => {
-    const spec = `\`${t.file}:${t.line}\`` + (t.test ? ` ("${tableCell(t.test)}")` : '');
+    // The title is quoted, not fenced, so a `"` inside it would close the quote early.
+    const title = tableCell(t.test).replace(/"/g, "'");
+    const spec = `\`${t.file}:${t.line}\`` + (t.test ? ` ("${title}")` : '');
     const waits = t.waits_for ? `\`${tableCell(t.waits_for)}\`` : '—';
     return `| ${spec} | ${waits} | \`${tableCell(t.error_signature)}\` |`;
   });
@@ -397,12 +430,37 @@ export function assertDedicatedIssueBody(body, opts = {}) {
     if (!text.includes(heading)) problems.push(`missing section: ${heading}`);
   }
 
-  if (!/^Spun out of daily-failure triage #\d+ \(run .+\)/m.test(text)) {
-    problems.push('missing or malformed provenance line (expected: "Spun out of daily-failure triage #N (run <id>, <date>).")');
+  // The date is matched explicitly: `\(run .+\)` accepted "(run 123, undefined)",
+  // which shipped a provenance line that joins to nothing.
+  if (!/^Spun out of daily-failure triage #\d+ \(run .+, \d{4}-\d{2}-\d{2}\)\./m.test(text)) {
+    problems.push('missing or malformed provenance line (expected: "Spun out of daily-failure triage #N (run <id>, YYYY-MM-DD).")');
   }
 
   if (!/`[^`\s]+\.spec\.ts:\d+`/.test(text)) {
     problems.push('no backticked repo-relative spec path with a line number — the QA Platform cannot match this issue to a failure');
+  }
+
+  // Shape is not content. A body can carry every heading and say nothing under
+  // them — which the renderer cannot produce, but a hand-written or enriched one
+  // can, and those are exactly what this function exists to cover.
+  const lines = text.split('\n');
+  for (const heading of DEDICATED_ISSUE_SECTIONS) {
+    const at = lines.findIndex((l) => l.trim() === heading);
+    if (at < 0) continue; // already reported as missing above
+    const body_ = [];
+    for (let i = at + 1; i < lines.length && !/^##\s/.test(lines[i]); i++) body_.push(lines[i]);
+    if (!body_.join('').trim()) problems.push(`empty section: ${heading}`);
+  }
+
+  // The whole point of the format: every affected test carries a signature.
+  const rows = symptomRows(text);
+  if (rows.length === 0) {
+    problems.push('the Symptom table has no test rows');
+  } else {
+    const blank = rows.filter((r) => !rowCells(r).at(-1));
+    if (blank.length) {
+      problems.push(`${blank.length} Symptom row(s) with an empty Signature cell — copy it verbatim from reports/daily-history.jsonl, or "unknown" if that is what the run recorded`);
+    }
   }
 
   if (!/^\*\*Upstream:\*\* .+/m.test(text)) {
@@ -413,10 +471,12 @@ export function assertDedicatedIssueBody(body, opts = {}) {
     problems.push('no checkbox deliverables — "Deliverables (Done when)" must be actionable');
   }
 
-  // Unfilled template scaffolding. Matches the `<placeholder>` form used in the
-  // reference doc and the issue form; real content rarely contains it, and when
-  // it does (an HTML tag in a signature) the signature is inside backticks.
-  const placeholder = /<(?:one sentence|symptom|umbrella|verbatim|placeholder|TODO)[^>]*>|\bTODO\b/i.exec(
+  // Unfilled template scaffolding. Deliberately case-SENSITIVE: an earlier
+  // case-insensitive `\bTODO\b` matched ordinary prose, and a test legitimately
+  // titled "todo list renders" reaches this text outside backticks (the table
+  // quotes the title, it does not fence it) — which aborted issue creation for a
+  // real cluster in the unattended Phase 7 path.
+  const placeholder = /<(?:one sentence|symptom|umbrella|verbatim|placeholder)[^>]*>|\bTODO\b/.exec(
     text.replace(/`[^`]*`/g, ''),
   );
   if (placeholder) problems.push(`unfilled placeholder left in the body: ${placeholder[0]}`);

--- a/.claude/skills/langflow-e2e-triage/scripts/lib/triage-core.mjs
+++ b/.claude/skills/langflow-e2e-triage/scripts/lib/triage-core.mjs
@@ -19,11 +19,10 @@ export function findLatestRedRun(rows) {
   return null;
 }
 
-// The ESC is required. Without it the pattern strips the `[2m` and leaves the
+// The ESC is required: without it the pattern strips the `[2m` and leaves the
 // bare ESC byte behind, so a signature recorded with ANSI never compares equal to
 // the same signature recorded without it — silently breaking the same-signature
-// recurrence rule that drives every flake decision.
-// `scripts/build-run-payload.mjs` already uses this form; this one had drifted.
+// recurrence rule. `scripts/build-run-payload.mjs` already uses this form.
 // eslint-disable-next-line no-control-regex
 const ANSI_RE = /\u001b\[[0-9;]*m/g;
 
@@ -202,6 +201,215 @@ export function findNewestUmbrella(issues) {
     if (!best || m[1] > best.date) best = { date: m[1], number: i.number };
   }
   return best;
+}
+
+// ---------------------------------------------------------------------------
+// Dedicated-issue rendering
+//
+// The canonical body format lives in ../../references/issue-templates.md, but a
+// Markdown reference is only ever advice to whoever (or whatever) is composing
+// the issue. Since Claude Code is the primary author of these issues — Phase 7
+// runs `gh issue create`, which bypasses .github/ISSUE_TEMPLATE entirely — the
+// structure has to be code to actually hold. These two functions are that:
+// render from data, then assert before creating.
+// ---------------------------------------------------------------------------
+
+/** Section headings a dedicated issue must carry, in order. */
+export const DEDICATED_ISSUE_SECTIONS = [
+  '## Symptom',
+  '## Why these failures are one cause',
+  '## Preliminary read (descriptive — NOT a verdict)',
+  '## Investigation directive',
+  '## Deliverables (Done when)',
+];
+
+/** Canonical acceptance criteria. Callers may extend, but not drop, these. */
+const DEFAULT_DELIVERABLES = [
+  'Root cause confirmed per spec (product regression vs. test/wait-strategy vs. environment), with evidence on the current nightly.',
+  'Each spec passes reliably (multiple clean `--retries=0` runs), fixing waits/flow as needed.',
+  '**Quarantine lifted** in the fix PR — remove `test.fixme` **and** restore `@stable`, re-validated per `CONTRIBUTING.md`. *(Nothing to lift if nothing was quarantined.)*',
+  'If the root cause is a **product (Langflow) regression**: recorded as such here, and this issue stays **open** until the upstream fix lands in `langflowai/langflow-nightly:latest` (or the `release-1.x.x` branch), is re-validated there, and `@stable` is restored — not on a test-side mute.',
+];
+
+/**
+ * Make a value safe as a single Markdown table cell.
+ *
+ * Signatures are copied verbatim out of `reports/daily-history.jsonl` so that
+ * recurrence stays matchable via `normalizeSignature()`. Two things still have
+ * to be neutralised or the table silently breaks: a literal `|` ends the cell
+ * early, and an embedded newline ends the row. Both are escaped rather than
+ * stripped — `normalizeSignature()` collapses whitespace and the reader can
+ * still see the original characters, so matching survives the escaping.
+ */
+function tableCell(value) {
+  return stripAnsi(value).replace(/\|/g, '\\|').replace(/\r?\n/g, '<br>').trim();
+}
+
+/**
+ * Title for a dedicated issue: `[Daily #<umbrella>] <symptom>`.
+ *
+ * The number is the **umbrella issue** number, never the run id — they are both
+ * bare integers in the dataset and swapping them produces a plausible-looking
+ * title that links nowhere, so it is enforced here instead of being a note in
+ * the reference doc.
+ */
+export function renderDedicatedIssueTitle({ umbrella, symptom }) {
+  const n = Number(umbrella);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`renderDedicatedIssueTitle: umbrella must be a positive issue number, got ${JSON.stringify(umbrella)}`);
+  }
+  const s = String(symptom || '').trim();
+  if (!s) throw new Error('renderDedicatedIssueTitle: symptom is required');
+  return `[Daily #${n}] ${s}`;
+}
+
+/**
+ * Render the canonical dedicated-issue body from triage data.
+ *
+ * `tests[]` entries carry `error_signature` exactly as recorded in the history
+ * row — including the literal string `"unknown"`, which is preserved rather
+ * than replaced by a description. A paraphrased signature cannot be matched
+ * against the next run's history, which is what would silently turn per-cause
+ * issues back into one-issue-per-day.
+ */
+export function renderDedicatedIssueBody(input) {
+  const {
+    umbrella,
+    run,
+    provenanceNote = '',
+    summary,
+    tests,
+    whyOneCause,
+    preliminaryRead,
+    investigation,
+    deliverables = [],
+    flakeSignal = null,
+  } = input || {};
+
+  if (!run?.run_id) throw new Error('renderDedicatedIssueBody: run.run_id is required');
+  if (!Array.isArray(tests) || tests.length === 0) {
+    throw new Error('renderDedicatedIssueBody: at least one affected test is required');
+  }
+  for (const [i, t] of tests.entries()) {
+    if (!t?.file || !t?.line) throw new Error(`renderDedicatedIssueBody: tests[${i}] needs file and line`);
+    if (!t?.error_signature) {
+      throw new Error(`renderDedicatedIssueBody: tests[${i}] (${t.file}:${t.line}) has no error_signature — copy it verbatim from reports/daily-history.jsonl, or "unknown" if that is what the run recorded`);
+    }
+  }
+  for (const [field, value] of [
+    ['summary', summary],
+    ['whyOneCause', whyOneCause],
+    ['preliminaryRead', preliminaryRead],
+    ['investigation', investigation],
+  ]) {
+    if (!String(value || '').trim()) throw new Error(`renderDedicatedIssueBody: ${field} is required`);
+  }
+
+  const runRef = run.run_url ? `[${run.run_id}](${run.run_url})` : `\`${run.run_id}\``;
+  const provenance =
+    `Spun out of daily-failure triage #${umbrella} (run ${runRef}, ${run.date}).` +
+    (provenanceNote.trim() ? ` ${provenanceNote.trim()}` : '');
+
+  const rows = tests.map((t) => {
+    const spec = `\`${t.file}:${t.line}\`` + (t.test ? ` ("${tableCell(t.test)}")` : '');
+    const waits = t.waits_for ? `\`${tableCell(t.waits_for)}\`` : '—';
+    return `| ${spec} | ${waits} | \`${tableCell(t.error_signature)}\` |`;
+  });
+
+  const items = [...DEFAULT_DELIVERABLES, ...deliverables].map((d) => `- [ ] ${d}`);
+
+  const out = [
+    provenance,
+    '',
+    '## Symptom',
+    '',
+    String(summary).trim(),
+    '',
+    '| Spec (line) | Waits for | Signature |',
+    '|---|---|---|',
+    ...rows,
+    '',
+    '## Why these failures are one cause',
+    '',
+    String(whyOneCause).trim(),
+    '',
+    '## Preliminary read (descriptive — NOT a verdict)',
+    '',
+    String(preliminaryRead).trim(),
+    '',
+    '## Investigation directive',
+    '',
+    String(investigation).trim(),
+    '',
+    '## Deliverables (Done when)',
+    '',
+    ...items,
+  ];
+
+  if (flakeSignal) {
+    const { dates = [], quarantine_pr = null, specs = [] } = flakeSignal;
+    const when = dates.length ? ` (dailies ${dates.join(', ')})` : '';
+    const pr = quarantine_pr ? ` in PR #${quarantine_pr}` : '';
+    out.push(
+      '',
+      '## Flake signal',
+      '',
+      `This test is confirmed recurrent${when}. As prevention it was **quarantined** at triage${pr} — \`@stable\` removed **and** \`test.fixme\` added — so it stops running in **every** context (daily, PR impacted-specs gate, full suite) until this issue is worked:`,
+      '',
+      ...specs.map((s) => `- \`${s.file}\` (test at line ${s.line})`),
+      '',
+      'Lifting the quarantine after the fix (remove `test.fixme` + restore `@stable`) is a deliverable of this issue.',
+    );
+  }
+
+  return out.join('\n') + '\n';
+}
+
+/**
+ * Validate a dedicated-issue body before `gh issue create`.
+ *
+ * Covers hand-written and enriched bodies too, so it is deliberately broader
+ * than the renderer's own input checks. Returns the list of problems; callers
+ * that want it fatal pass `{ throwOnError: true }`.
+ *
+ * The backticked `path.spec.ts:line` check is not cosmetic: the QA Platform
+ * parses those paths out of the body to decide whether a failure on a run page
+ * is already tracked, and renders the `tracked · #NNN` chip from the match. A
+ * spec named in prose alone is invisible to it.
+ */
+export function assertDedicatedIssueBody(body, opts = {}) {
+  const { throwOnError = false } = opts;
+  const text = String(body || '');
+  const problems = [];
+
+  for (const heading of DEDICATED_ISSUE_SECTIONS) {
+    if (!text.includes(heading)) problems.push(`missing section: ${heading}`);
+  }
+
+  if (!/^Spun out of daily-failure triage #\d+ \(run .+\)/m.test(text)) {
+    problems.push('missing or malformed provenance line (expected: "Spun out of daily-failure triage #N (run <id>, <date>).")');
+  }
+
+  if (!/`[^`\s]+\.spec\.ts:\d+`/.test(text)) {
+    problems.push('no backticked repo-relative spec path with a line number — the QA Platform cannot match this issue to a failure');
+  }
+
+  if (!/- \[ \] /.test(text)) {
+    problems.push('no checkbox deliverables — "Deliverables (Done when)" must be actionable');
+  }
+
+  // Unfilled template scaffolding. Matches the `<placeholder>` form used in the
+  // reference doc and the issue form; real content rarely contains it, and when
+  // it does (an HTML tag in a signature) the signature is inside backticks.
+  const placeholder = /<(?:one sentence|symptom|umbrella|verbatim|placeholder|TODO)[^>]*>|\bTODO\b/i.exec(
+    text.replace(/`[^`]*`/g, ''),
+  );
+  if (placeholder) problems.push(`unfilled placeholder left in the body: ${placeholder[0]}`);
+
+  if (throwOnError && problems.length) {
+    throw new Error(`Dedicated issue body is invalid:\n  - ${problems.join('\n  - ')}`);
+  }
+  return problems;
 }
 
 /** Assemble the normalized triage dataset from the latest red run. */

--- a/.claude/skills/langflow-e2e-triage/scripts/lib/triage-core.test.mjs
+++ b/.claude/skills/langflow-e2e-triage/scripts/lib/triage-core.test.mjs
@@ -16,6 +16,10 @@ import {
   findNewestUmbrella,
   parseProviderModel,
   computeProviderClusters,
+  renderDedicatedIssueTitle,
+  renderDedicatedIssueBody,
+  assertDedicatedIssueBody,
+  DEDICATED_ISSUE_SECTIONS,
 } from './triage-core.mjs';
 
 const fixture = (name) =>
@@ -281,4 +285,158 @@ test('buildDataset attaches provider/model and provider_wide_clusters', () => {
   const gw = ds.provider_wide_clusters.find((c) => c.provider === 'google');
   assert.equal(gw.provider_wide, true);
   assert.equal(gw.count, 2);
+});
+
+// --- dedicated-issue rendering ---------------------------------------------
+
+const CLUSTER = {
+  umbrella: 744,
+  run: { run_id: '30261409427', run_url: 'https://gh/runs/30261409427', date: '2026-07-27' },
+  summary: 'Three @stable tests hard-failed with the same shape.',
+  tests: [
+    {
+      file: 'core-functionality/llm-agents/agent-component-regression.spec.ts',
+      line: 145,
+      test: 'agent interaction suite',
+      waits_for: "getByTestId('div-chat-message')",
+      error_signature: 'Error: expect(locator).toBeVisible() failed',
+    },
+  ],
+  whyOneCause: 'All three failed in the same 40s window on shard 3.',
+  preliminaryRead: 'Mass-failure day (guard tripped); consistent with saturation, not concluded.',
+  investigation: 'Product first: confirm on the current nightly whether these flows complete.',
+};
+
+test('renderDedicatedIssueTitle uses the umbrella number', () => {
+  assert.equal(
+    renderDedicatedIssueTitle({ umbrella: 744, symptom: 'agent execution never completes' }),
+    '[Daily #744] agent execution never completes',
+  );
+});
+
+test('renderDedicatedIssueTitle rejects a non-issue-number umbrella', () => {
+  // Guards the run-id-for-umbrella swap the reference doc warns about.
+  assert.throws(() => renderDedicatedIssueTitle({ umbrella: 'abc', symptom: 'x' }), /positive issue number/);
+  assert.throws(() => renderDedicatedIssueTitle({ umbrella: 744, symptom: '  ' }), /symptom is required/);
+});
+
+test('renderDedicatedIssueBody emits every canonical section in order', () => {
+  const body = renderDedicatedIssueBody(CLUSTER);
+  let cursor = -1;
+  for (const heading of DEDICATED_ISSUE_SECTIONS) {
+    const at = body.indexOf(heading);
+    assert.ok(at > cursor, `${heading} missing or out of order`);
+    cursor = at;
+  }
+  assert.match(body, /^Spun out of daily-failure triage #744 \(run \[30261409427\]/);
+});
+
+test('renderDedicatedIssueBody keeps the signature verbatim', () => {
+  const body = renderDedicatedIssueBody(CLUSTER);
+  assert.ok(body.includes('`Error: expect(locator).toBeVisible() failed`'));
+});
+
+test('renderDedicatedIssueBody preserves the literal "unknown" signature', () => {
+  // The run recorded no error message; substituting a description here would
+  // make the next run's history unmatchable.
+  const body = renderDedicatedIssueBody({
+    ...CLUSTER,
+    tests: [{ ...CLUSTER.tests[0], error_signature: 'unknown' }],
+  });
+  assert.ok(body.includes('| `unknown` |'));
+});
+
+test('renderDedicatedIssueBody escapes a pipe so the table survives', () => {
+  const body = renderDedicatedIssueBody({
+    ...CLUSTER,
+    tests: [{ ...CLUSTER.tests[0], error_signature: 'Error: got a|b, want c' }],
+  });
+  const row = body.split('\n').find((l) => l.includes('agent-component-regression'));
+  assert.equal(row.split(/(?<!\\)\|/).length - 1, 4); // 4 unescaped delimiters = 3 cells
+  assert.ok(row.includes('a\\|b'));
+});
+
+test('renderDedicatedIssueBody strips ANSI from a raw history signature', () => {
+  // daily-history.jsonl stores signatures with the SGR codes Playwright emits.
+  const esc = String.fromCharCode(27);
+  const raw = `Error: ${esc}[2mexpect(${esc}[22mlocator).toBeVisible failed`;
+  const body = renderDedicatedIssueBody({
+    ...CLUSTER,
+    tests: [{ ...CLUSTER.tests[0], error_signature: raw }],
+  });
+  assert.ok(!body.includes(esc));
+  assert.ok(body.includes('Error: expect(locator).toBeVisible failed'));
+});
+
+test('renderDedicatedIssueBody refuses a test with no signature', () => {
+  assert.throws(
+    () => renderDedicatedIssueBody({ ...CLUSTER, tests: [{ file: 'a.spec.ts', line: 1 }] }),
+    /no error_signature/,
+  );
+});
+
+test('renderDedicatedIssueBody requires at least one test and the narrative fields', () => {
+  assert.throws(() => renderDedicatedIssueBody({ ...CLUSTER, tests: [] }), /at least one affected test/);
+  assert.throws(() => renderDedicatedIssueBody({ ...CLUSTER, whyOneCause: '' }), /whyOneCause is required/);
+  assert.throws(() => renderDedicatedIssueBody({ ...CLUSTER, run: {} }), /run\.run_id is required/);
+});
+
+test('renderDedicatedIssueBody always carries the canonical deliverables', () => {
+  const body = renderDedicatedIssueBody({ ...CLUSTER, deliverables: ['Extra thing.'] });
+  assert.ok(body.includes('- [ ] **Quarantine lifted**'));
+  assert.ok(body.includes('- [ ] Extra thing.'));
+});
+
+test('renderDedicatedIssueBody adds the flake block only when asked', () => {
+  assert.ok(!renderDedicatedIssueBody(CLUSTER).includes('## Flake signal'));
+  const body = renderDedicatedIssueBody({
+    ...CLUSTER,
+    flakeSignal: {
+      dates: ['2026-07-08', '2026-07-09'],
+      quarantine_pr: 870,
+      specs: [{ file: 'core-functionality/playground/prefill.spec.ts', line: 97 }],
+    },
+  });
+  assert.ok(body.includes('## Flake signal'));
+  assert.ok(body.includes('(dailies 2026-07-08, 2026-07-09)'));
+  assert.ok(body.includes('in PR #870'));
+  assert.ok(body.includes('(test at line 97)'));
+});
+
+test('assertDedicatedIssueBody accepts a rendered body', () => {
+  assert.deepEqual(assertDedicatedIssueBody(renderDedicatedIssueBody(CLUSTER)), []);
+});
+
+test('assertDedicatedIssueBody reports a missing section', () => {
+  const body = renderDedicatedIssueBody(CLUSTER).replace('## Why these failures are one cause', '## Notes');
+  assert.deepEqual(assertDedicatedIssueBody(body), [
+    'missing section: ## Why these failures are one cause',
+  ]);
+});
+
+test('assertDedicatedIssueBody rejects a spec named in prose only', () => {
+  // `agent-max-tokens` alone is unmatchable by the QA Platform.
+  const body = renderDedicatedIssueBody(CLUSTER).replace(
+    /`core-functionality\/llm-agents\/agent-component-regression\.spec\.ts:145`/,
+    'agent-component-regression',
+  );
+  assert.ok(assertDedicatedIssueBody(body).some((p) => /backticked repo-relative spec path/.test(p)));
+});
+
+test('assertDedicatedIssueBody catches an unfilled placeholder', () => {
+  const body = renderDedicatedIssueBody({ ...CLUSTER, whyOneCause: '<one sentence: why>' });
+  assert.ok(assertDedicatedIssueBody(body).some((p) => /unfilled placeholder/.test(p)));
+});
+
+test('assertDedicatedIssueBody ignores angle brackets inside code spans', () => {
+  // A signature legitimately containing markup must not read as scaffolding.
+  const body = renderDedicatedIssueBody({
+    ...CLUSTER,
+    tests: [{ ...CLUSTER.tests[0], error_signature: 'Error: <symptom> element not found' }],
+  });
+  assert.deepEqual(assertDedicatedIssueBody(body), []);
+});
+
+test('assertDedicatedIssueBody throws when asked', () => {
+  assert.throws(() => assertDedicatedIssueBody('nothing here', { throwOnError: true }), /is invalid/);
 });

--- a/.claude/skills/langflow-e2e-triage/scripts/lib/triage-core.test.mjs
+++ b/.claude/skills/langflow-e2e-triage/scripts/lib/triage-core.test.mjs
@@ -41,13 +41,32 @@ test('findLatestRedRun returns null when every run is green', () => {
   assert.equal(findLatestRedRun(green), null);
 });
 
+// Real signatures in reports/daily-history.jsonl carry the ESC byte (stored as
+// an escape by the appender). Building it here rather than pasting a literal
+// control character keeps the source clean — and an earlier version of these
+// tests used ESC-less input, which is what let a broken ANSI_RE go unnoticed.
+const ESC = String.fromCharCode(27);
+
 test('stripAnsi removes escape codes', () => {
-  assert.equal(stripAnsi('[2mError: x[22m'), 'Error: x');
+  assert.equal(stripAnsi(`${ESC}[2mError: x${ESC}[22m`), 'Error: x');
+});
+
+test('stripAnsi leaves no orphan ESC byte behind', () => {
+  // Guards the drift where the pattern matched `[2m` without the ESC: the codes
+  // vanished but the control bytes stayed, so two recordings of one cause
+  // stopped comparing equal.
+  const out = stripAnsi(`Error: ${ESC}[2mexpect(${ESC}[22mlocator).toBeVisible failed`);
+  assert.ok(!out.includes(ESC));
+  assert.equal(out, 'Error: expect(locator).toBeVisible failed');
+});
+
+test('stripAnsi does not eat bracketed text that is not an escape sequence', () => {
+  assert.equal(stripAnsi('Error: index [2m] out of range'), 'Error: index [2m] out of range');
 });
 
 test('normalizeSignature makes ANSI and plain signatures compare equal', () => {
   assert.equal(
-    normalizeSignature('[2mError: toBe equality[22m'),
+    normalizeSignature(`${ESC}[2mError: toBe equality${ESC}[22m`),
     normalizeSignature('Error:   toBe equality'),
   );
 });

--- a/.claude/skills/langflow-e2e-triage/scripts/lib/triage-core.test.mjs
+++ b/.claude/skills/langflow-e2e-triage/scripts/lib/triage-core.test.mjs
@@ -454,3 +454,82 @@ test('assertDedicatedIssueBody reports a dropped Upstream line', () => {
   const body = renderDedicatedIssueBody(CLUSTER).replace(/^\*\*Upstream:\*\* .+$/m, '');
   assert.ok(assertDedicatedIssueBody(body).some((p) => /Upstream/.test(p)));
 });
+
+// --- review findings on PR #1034 -------------------------------------------
+
+test('renderDedicatedIssueBody rejects a missing or malformed run.date', () => {
+  // Used to render "(run 123, undefined)" and pass validation — the provenance
+  // line joins the issue to its history row, so it shipped broken.
+  assert.throws(
+    () => renderDedicatedIssueBody({ ...CLUSTER, run: { run_id: '1', run_url: 'u' } }),
+    /run\.date must be YYYY-MM-DD/,
+  );
+  assert.throws(
+    () => renderDedicatedIssueBody({ ...CLUSTER, run: { run_id: '1', date: '27/07/2026' } }),
+    /run\.date must be YYYY-MM-DD/,
+  );
+});
+
+test('renderDedicatedIssueBody rejects a null umbrella naming the real cause', () => {
+  // buildDataset returns umbrella_issue: null when no umbrella carries the run id.
+  assert.throws(
+    () => renderDedicatedIssueBody({ ...CLUSTER, umbrella: null }),
+    /positive issue number.*matchUmbrella/s,
+  );
+});
+
+test('assertDedicatedIssueBody rejects a provenance line with no date', () => {
+  const body = renderDedicatedIssueBody(CLUSTER).replace(', 2026-07-27).', ', undefined).');
+  assert.ok(assertDedicatedIssueBody(body).some((p) => /provenance line/.test(p)));
+});
+
+test('a spec title containing "todo" is not a placeholder', () => {
+  // Case-insensitive \bTODO\b matched ordinary prose. The table quotes the title
+  // rather than fencing it, so the code-span strip does not protect it — this
+  // aborted issue creation for a real cluster in the unattended path.
+  const body = renderDedicatedIssueBody({
+    ...CLUSTER,
+    tests: [{ ...CLUSTER.tests[0], test: 'todo list renders after reload' }],
+  });
+  assert.deepEqual(assertDedicatedIssueBody(body), []);
+});
+
+test('an uppercase TODO is still caught', () => {
+  const body = renderDedicatedIssueBody({ ...CLUSTER, investigation: 'TODO: decide the path' });
+  assert.ok(assertDedicatedIssueBody(body).some((p) => /unfilled placeholder/.test(p)));
+});
+
+test('assertDedicatedIssueBody reports sections that carry no content', () => {
+  const body = renderDedicatedIssueBody(CLUSTER).replace(
+    'All three failed in the same 40s window on shard 3.',
+    '',
+  );
+  assert.ok(
+    assertDedicatedIssueBody(body).includes('empty section: ## Why these failures are one cause'),
+  );
+});
+
+test('assertDedicatedIssueBody reports an empty Signature cell', () => {
+  // The format's whole point; a hand-written or enriched table could drop it.
+  const body = renderDedicatedIssueBody(CLUSTER).replace(
+    '| `Error: expect(locator).toBeVisible() failed` |',
+    '|  |',
+  );
+  assert.ok(assertDedicatedIssueBody(body).some((p) => /empty Signature cell/.test(p)));
+});
+
+test('assertDedicatedIssueBody reports a Symptom table with no rows', () => {
+  const body = renderDedicatedIssueBody(CLUSTER).split('\n')
+    .filter((l) => !l.includes('agent-component-regression'))
+    .join('\n');
+  assert.ok(assertDedicatedIssueBody(body).some((p) => /no test rows/.test(p)));
+});
+
+test('a quote inside a test title cannot break out of the quoted cell', () => {
+  const body = renderDedicatedIssueBody({
+    ...CLUSTER,
+    tests: [{ ...CLUSTER.tests[0], test: 'the "new" flow opens' }],
+  });
+  assert.ok(body.includes(`("the 'new' flow opens")`));
+  assert.deepEqual(assertDedicatedIssueBody(body), []);
+});

--- a/.claude/skills/langflow-e2e-triage/scripts/lib/triage-core.test.mjs
+++ b/.claude/skills/langflow-e2e-triage/scripts/lib/triage-core.test.mjs
@@ -440,3 +440,17 @@ test('assertDedicatedIssueBody ignores angle brackets inside code spans', () => 
 test('assertDedicatedIssueBody throws when asked', () => {
   assert.throws(() => assertDedicatedIssueBody('nothing here', { throwOnError: true }), /is invalid/);
 });
+
+test('renderDedicatedIssueBody always carries the Upstream slot', () => {
+  // The seam to the treatment layer (Jira). Unfilled at triage time is normal —
+  // omitted is not, or the failure layer stops linking to the card layer.
+  assert.ok(renderDedicatedIssueBody(CLUSTER).includes('**Upstream:** _not filed_'));
+  assert.ok(
+    renderDedicatedIssueBody({ ...CLUSTER, upstream: 'LE-1234' }).includes('**Upstream:** LE-1234'),
+  );
+});
+
+test('assertDedicatedIssueBody reports a dropped Upstream line', () => {
+  const body = renderDedicatedIssueBody(CLUSTER).replace(/^\*\*Upstream:\*\* .+$/m, '');
+  assert.ok(assertDedicatedIssueBody(body).some((p) => /Upstream/.test(p)));
+});

--- a/.github/ISSUE_TEMPLATE/failure-root-cause.yml
+++ b/.github/ISSUE_TEMPLATE/failure-root-cause.yml
@@ -32,6 +32,20 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: upstream
+    attributes:
+      label: Upstream
+      description: >
+        The seam to the treatment layer. This issue tracks the **failure**; what is done
+        about it is worked on the Jira board. Leave `_not filed_` when no card exists yet —
+        normal at triage time, since the card follows the investigation — but never delete
+        the field, or the failure stops linking to the card. `LE-####` or
+        `langflow-ai/langflow#N`.
+      value: "_not filed_"
+    validations:
+      required: true
+
   - type: textarea
     id: symptom
     attributes:

--- a/.github/ISSUE_TEMPLATE/failure-root-cause.yml
+++ b/.github/ISSUE_TEMPLATE/failure-root-cause.yml
@@ -1,0 +1,143 @@
+name: Failure — Dedicated (root cause)
+description: One cause and every test it breaks. Mirrors the canonical template the triage skill renders — for opening a cause issue by hand.
+title: "[Daily #<umbrella>] <symptom>"
+labels: ["daily-failure"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **One issue = one cause.** Different causes ⇒ different issues. Two open issues that
+        turn out to share a cause get merged and cross-linked.
+
+        **Check first — enrich beats create.** `gh issue list --state open --label daily-failure`
+        and match on the *error signature*, not on a description of the symptom. A cause that
+        already has an open issue gets a comment with the new run id and occurrence count.
+
+        **Descriptive, not conclusive.** Do not state a root cause here. The verdict, and the
+        evidence behind it, is a *deliverable* of this issue — not an input to opening it.
+
+        This form mirrors `.claude/skills/langflow-e2e-triage/references/issue-templates.md`,
+        which is the canonical source. Opened by the triage skill, the same body is rendered
+        from code; this form exists so a hand-opened issue comes out in the same shape.
+
+  - type: input
+    id: provenance
+    attributes:
+      label: Provenance
+      description: >
+        Umbrella issue, run id and date. The run id is the value recorded in
+        `reports/daily-history.jsonl`, so the issue joins back to the history row.
+        Multiple runs in the cluster: newest first.
+      placeholder: "Spun out of daily-failure triage #744 (run 30261409427, 2026-07-27)."
+    validations:
+      required: true
+
+  - type: textarea
+    id: symptom
+    attributes:
+      label: Symptom
+      description: >
+        What failed, then one row per test. Full repo-relative path with line number
+        (the QA Platform parses these to show the `tracked · #NNN` chip — a spec named in
+        prose without its path is unmatchable). **The signature is copied unedited from
+        `reports/daily-history.jsonl`** — not paraphrased, not shortened; write `unknown`
+        where the run recorded `unknown`. Recurrence is matched on this string.
+      value: |
+        <one sentence: the shared shape of the failure>
+
+        | Spec (line) | Waits for | Signature |
+        |---|---|---|
+        | `core-functionality/.../x.spec.ts:123` ("test name") | `getByTestId('...')` | `<verbatim from daily-history.jsonl>` |
+    validations:
+      required: true
+
+  - type: textarea
+    id: why-one-cause
+    attributes:
+      label: Why these failures are one cause
+      description: >
+        The linking argument — what ties these observations together: shared timing, same
+        shard, same dependency, a common step, a signature cluster. Keep it descriptive;
+        naming the mechanism is the investigation's job. Without this field a root-cause
+        issue is indistinguishable from unrelated failures filed together.
+      placeholder: |
+        All five failed inside the same 40s window on shard 3, every one on the first request
+        after `Collect models`. The signatures differ (timeout, `toBeVisible failed`, 502) and
+        no test-level change is common to them.
+    validations:
+      required: true
+
+  - type: textarea
+    id: preliminary-read
+    attributes:
+      label: Preliminary read (descriptive — NOT a verdict)
+      description: >
+        Environmental context and pattern. State what the day looked like (mass-failure day?
+        guard tripped? counts) and what the shape is *consistent with* — never that it is the
+        cause. Cite related issues. Use "consistent with" / "must be ruled out", never
+        "likely caused by".
+      placeholder: |
+        Surfaced on a mass-failure day (27 hard + 27 flaky, guard tripped); the shape is
+        consistent with instance saturation under load. But these are final hard failures
+        (no recovery on retry), so the day-level signal must not be assumed as the cause.
+    validations:
+      required: true
+
+  - type: textarea
+    id: investigation
+    attributes:
+      label: Investigation directive
+      description: >
+        Independent paths, **product as prime suspect first**. List plausible roots as
+        parallel branches, not nested conclusions, each with a concrete verification step.
+      placeholder: |
+        Product first: on the current nightly, confirm whether these flows execute to
+        completion before concluding provider/latency. Only after ruling out a regression:
+        (a) transient saturation → prove on 3 environments and restore; (b) wait-strategy
+        fragility → harden the wait to a deterministic observable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: deliverables
+    attributes:
+      label: Deliverables (Done when)
+      description: >
+        A product regression closes only when the product is fixed where the suite runs —
+        never on a test-side mute. Lifting a quarantine is always a deliverable when one
+        was applied at triage.
+      value: |
+        - [ ] Root cause confirmed per spec (product regression vs. test/wait-strategy vs. environment), with evidence on the current nightly.
+        - [ ] Each spec passes reliably (multiple clean `--retries=0` runs).
+        - [ ] **Quarantine lifted** in the fix PR — remove `test.fixme` **and** restore `@stable`, re-validated per `CONTRIBUTING.md`. *(Nothing to lift if nothing was quarantined.)*
+        - [ ] If the verdict is a **product (Langflow) regression**: recorded here, and this issue stays **open** until the upstream fix lands in `langflowai/langflow-nightly:latest` (or the `release-1.x.x` branch) and is re-validated there.
+        - [ ] `REGRESSIONS.md` row added — required once the verdict is `langflow-regression`, adversarially validated, and an upstream ticket (`LE-####` / `langflow-ai/langflow#N`) exists.
+    validations:
+      required: true
+
+  - type: textarea
+    id: flake-signal
+    attributes:
+      label: Flake signal
+      description: >
+        Recurrent flakes only — a test failing across multiple independent dailies. List the
+        daily dates, the exact spec paths with test line numbers, and the quarantine PR.
+        Quarantine is manual and applied **at triage as prevention**: `@stable` removed
+        **and** `test.fixme` added (tag removal alone leaves the test red on the
+        impacted-specs gate — #871). Leave blank for hard failures.
+      placeholder: |
+        Confirmed recurrent (dailies 2026-07-08, 2026-07-09, 2026-07-13). Quarantined at
+        triage in PR #NNN — `@stable` removed and `test.fixme` added:
+
+        - `core-functionality/playground/playground-input-text-prefill.spec.ts` (test at line 97)
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        **Labels:** `daily-failure` is applied automatically. Add exactly one `area:<x>`
+        derived from the failing spec's directory (mapping table in `issue-templates.md`);
+        if no area label fits, `daily-failure` alone is correct.
+
+        **Assignee:** leave blank — the issue belongs to the triage queue, not a person.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:features": "npx playwright test tests/core/features/ tests/extended/features/",
     "test:integrations": "npx playwright test tests/core/integrations/",
     "test:unit": "npx playwright test tests/core/unit/",
-    "test:scripts": "node --test scripts/",
+    "test:scripts": "files=$(find scripts .claude/skills -name '*.test.mjs' -not -path '*/node_modules/*' | sort); [ -n \"$files\" ] || { echo 'no *.test.mjs found — the scripts unit lane would silently pass' >&2; exit 1; }; node --test $files",
     "test:units": "files=$( { find . -maxdepth 1 -name '*.test.ts'; find scripts tests -name '*.test.ts' -not -path '*/node_modules/*'; } | sort); [ -n \"$files\" ] || { echo 'no *.test.ts found — the TypeScript unit lane would silently pass' >&2; exit 1; }; node --require ts-node/register --test $files",
     "test:regression": "npx playwright test tests/core/regression/ tests/extended/regression/",
     "test:grep": "npx playwright test --grep",


### PR DESCRIPTION
## Type

- [x] `chore` — CI, checklist, dependencies, internal refactoring

---

## Roadmap linkage (required — do not delete)

- [x] **Exception** — off-wave work backed by an issue: a follow-up, a `daily-failure` triage issue, or a `community`-labeled regression. Issue #1032

---

## What this PR does

The team decided failure issues are opened **per root cause**, not per failing test. The canonical format for those issues lived only in `.claude/skills/langflow-e2e-triage/references/issue-templates.md` — Markdown read by an LLM. Since `gh issue create` bypasses `.github/ISSUE_TEMPLATE` entirely and Claude Code is the primary author of these issues, prose was the only thing holding the structure together.

**Scope:** this covers the **dedicated per-cause issues** created by the triage skill in Phase 7. The umbrella issue is created by `daily-stable.yml` through the GitHub API, which no template can govern — out of scope by construction.

### 1. The body is now rendered and validated by code

Three functions in `scripts/lib/triage-core.mjs`:

- `renderDedicatedIssueBody()` — builds the body from triage data. Fixed section order, provenance line, `**Upstream:**` slot, canonical deliverables, optional flake block. Refuses a cluster whose test carries no `error_signature`; escapes a literal `|` so a signature cannot break the table. Signatures otherwise pass through untouched, **including the literal `unknown`** — substituting a description makes the next run's occurrence unmatchable.
- `renderDedicatedIssueTitle()` — refuses a title built from the run id instead of the umbrella number. Both are bare integers in the dataset and swapping them yields a plausible title that links nowhere.
- `assertDedicatedIssueBody()` — validates before creation, covering hand-written and enriched bodies: required sections, provenance, the Upstream slot, at least one backticked repo-relative spec path, checkbox deliverables, leftover placeholders.

Phase 7 of `SKILL.md` now calls them instead of describing the format.

### 2. Two bugs found while building it

**`ANSI_RE` dropped the ESC byte.** It was `/\[[0-9;]*m/g` — no ESC — so it stripped the `[2m` and left the bare control byte:

```
stripAnsi('Error: <ESC>[2mexpect(')  ->  'Error: <ESC>expect('
```

`normalizeSignature()` inherits that, so the same cause recorded once with ANSI and once without does **not** compare equal — and the same-signature 30-day rule is what decides whether a flake earns an issue. **150 of the 437 entries** in `reports/daily-history.jsonl` carry a raw ESC, so roughly a third of every recurrence comparison was affected. `scripts/build-run-payload.mjs` already had the correct pattern; this copy had drifted.

**`npm run test:scripts` never reached `.claude/skills/**`.** It was `node --test scripts/`. The 28 tests in `triage-core.test.mjs` existed, passed locally, and ran in no PR — the lane reported 22. The lane now enumerates files the way `test:units` already does, with the same empty-result guard. **22 → 71 tests.**

### 3. Three content gaps in the reference doc

- **Signatures are copied, not written.** The Signature column was specified as "the exact error message or timeout signature" and the worked example carried paraphrases, which do not match `daily-history.jsonl`. Now: copied unedited, `unknown` written as `unknown`.
- **New section "Why these failures are one cause"** — the linking argument. The doc had aggressive grouping *rules* for guard days but no field stating why a given cluster is one cause, which leaves a root-cause issue indistinguishable from a batch of unrelated failures. Kept descriptive, so it does not cross the existing no-verdict line.
- **Enrich-vs-Create keyed on `normalizeSignature()`**, not on symptom prose, plus the inverse merge rule, plus a warning that generic signatures (`toBeVisible failed`, `unknown`) are too weak to match on alone.

### 4. The `**Upstream:**` slot

This issue layer tracks the **failure**; the treatment is worked on the Jira board. That split only holds if the layers are joinable, and the card key previously appeared only inside a `REGRESSIONS.md` deliverable checkbox — an acceptance criterion, not a link. Always rendered now, `_not filed_` when no card exists yet, and the validator fails when the line is missing.

---

## Tests covered

| # | Test | What it validates |
|---|---|---|
| 1 | `stripAnsi leaves no orphan ESC byte behind` | The regression that broke signature comparison: codes stripped, control bytes left behind |
| 2 | `stripAnsi does not eat bracketed text that is not an escape sequence` | The fix does not over-strip legitimate `[2m]` in prose |
| 3 | `renderDedicatedIssueBody preserves the literal "unknown" signature` | A message-less failure keeps a matchable key instead of a guess |
| 4 | `renderDedicatedIssueBody escapes a pipe so the table survives` | A signature containing `\|` cannot silently corrupt the Symptom table |
| 5 | `renderDedicatedIssueBody refuses a test with no signature` | A cluster cannot be filed without the key recurrence matches on |
| 6 | `renderDedicatedIssueTitle rejects a non-issue-number umbrella` | The run-id-for-umbrella swap cannot produce a title that links nowhere |
| 7 | `assertDedicatedIssueBody rejects a spec named in prose only` | The QA Platform's `tracked · #NNN` join cannot be silently dropped |
| 8 | `renderDedicatedIssueBody always carries the Upstream slot` | The seam to the Jira layer survives even when no card exists yet |

Plus emission order, the flake block, canonical deliverables, placeholder detection, and code-span tolerance — 21 new tests, 71 in the lane.

---

## What this PR does not cover

- **The umbrella issue.** Created via `github.rest.issues.create` in `daily-stable.yml`; templates do not apply to the API path.
- **A `Verdict` or `Root cause` field at dispatch time.** Deliberately rejected: it contradicts the established doctrine that a triage issue is descriptive, not conclusive (`issue-templates.md` → *"Do not conclude cause — that is the investigation's job"*). The verdict is a deliverable of the issue, not an input to opening it.
- **The treatment layer.** What gets done about a failure is worked on the Jira board; this layer tracks the failure and links out to it.
- **A masked `signature_key`.** `normalizeSignature()` still only strips ANSI, collapses whitespace and lowercases, so `Timeout 30000ms` and `Timeout 60000ms` remain distinct keys and a signature embedding a generated flow name is unique per run. Now an enhancement on a working comparison rather than a fix for a broken one; worth its own issue.
- **The producer asymmetry.** `scripts/append-weekly-history.mjs` writes `error_signature` on `flaky[]` rows; `scripts/build-run-payload.mjs` writes it only on `failures[]`, so the QA Platform cannot reproduce the triage verdict for flakes. Untouched here.

---

## Known limitations

**Enforcement is one step short of airtight.** The renderer and validator are deterministic and fail loud — but *calling* them is still an instruction in `SKILL.md`, so an agent that ignores Phase 7 and hand-writes a body can still create a malformed issue. The airtight version is a workflow on `issues.opened` (label `daily-failure`) that runs `assertDedicatedIssueBody` against the created body and labels/comments when it fails. Not in this PR; the honest description of what changed is "prose describing a format" → "prose invoking a deterministic enforcer", which is a real improvement in kind but not a hard gate.

**The renderer can now fail an unattended path.** Phase 7 runs headless from `triage-dispatch.yml`. A cluster shape the renderer rejects (missing signature, empty test list) will now throw where the previous prose path would have produced a degraded issue. Failing loud is the intended trade, but it is a behavior change in a path with no human watching.

**The issue form YAML is unvalidated locally.** No YAML parser is installed in the repo (`yaml`, `js-yaml`, `pyyaml` all absent). GitHub validates issue forms on push and surfaces errors on the "New issue" page — worth a look after merge.

---

## Related issue

Closes #1032

---

## Validation

- [x] `npm run test:scripts` — 71 passing (was 22 before the lane fix)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] Rendered and validated a body from the real `2026-07-27` history row: both hard failures emitted, `unknown` signature preserved verbatim, validator returned no problems
- [x] Confirmed the ANSI fix against real data — 150 of 437 history entries carry a raw ESC
