### PR TITLE
fix: gate provider-hardcoded specs on provider health, not env-var presence

### DIFF
--- a/.claude/skills/langflow-e2e-infra/references/failure-modes.md
+++ b/.claude/skills/langflow-e2e-infra/references/failure-modes.md
@@ -34,14 +34,18 @@ path). This skill never removes `@stable` itself.
 
 **Symptom:** whole provider's agent specs silently skip, or fail with 403; a
 single inaccessible lead model disables the provider; PR impacted-specs gate picks
-an inaccessible model; a raw API key probes OK but the model isn't Langflow-buildable.
+an inaccessible model; a raw API key probes OK but the model isn't Langflow-buildable;
+a spec runs a live call against a provider already recorded `inactive` and hangs
+the shard's worker.
 
 **Levers:** build-probe the provider's model class (not just the raw key) ·
 collect models **before** the impacted-specs gate · set `PREFLIGHT_SKIP_CREDENTIALS`
-on PR collect-models · resolve model via alias/settled, never a hardcoded dated id.
+on PR collect-models · resolve model via alias/settled, never a hardcoded dated id ·
+gate provider-hardcoded specs on recorded **health**, never on env-var presence
+(`providerSkipGate` in `tests/helpers/provider-setup/provider-health.ts`).
 
-**Docs:** `docs/collect-models.md`.
-**Issues/PRs:** #570 · #873 · #900 · #886 · #892 · PR #878 · PR #887 · PR #893 · PR #901.
+**Docs:** `docs/collect-models.md` (→ *Who consumes the recorded health*).
+**Issues/PRs:** #570 · #873 · #900 · #886 · #892 · #1029 · PR #878 · PR #887 · PR #893 · PR #901.
 
 ## 3. External-dependency hard-fail
 

--- a/docs/collect-models.md
+++ b/docs/collect-models.md
@@ -68,6 +68,28 @@ A provider with a key that genuinely fails its probe (e.g. a model the
 account cannot access) is a legitimate `inactive` — recorded, logged, not a
 test failure.
 
+### Who consumes the recorded health
+
+Writing `inactive` is only half the mechanism — a spec has to obey it. Two kinds
+of spec do:
+
+- **Provider-parametrized** specs (the `agent-*` family, `mcp-client-agent`) build
+  their target list from `models.json` and drop a target whose provider is
+  `inactive`, quoting the recorded reason.
+- **Provider-hardcoded** specs gate through
+  `providerSkipGate(...)` in `tests/helpers/provider-setup/provider-health.ts`
+  (#1029). That helper is the single implementation of the rule: missing env key
+  first, then the recorded `inactive` reason. It **fails open** when
+  `providers.json` is absent or unparseable — a fresh clone has no file (it is
+  gitignored) and CI is allowed to run with a failed `Collect models` step (#980),
+  so "no signal" must never skip the suite. `IGNORE_PROVIDER_HEALTH=1` overrides a
+  stale local file.
+
+Before #1029 the hardcoded specs gated on env-var presence, so a key that existed
+but was drained still made the live call. On run 30374528125 that hung two Google
+tests past gunicorn's 300s timeout, killed shard 2's Langflow worker six times, and
+produced 14 collateral timeouts in specs that never touch Google.
+
 ### Env-keyed provider must be ACTIVE — with one exception
 
 A provider whose key IS configured but that ends `inactive` silently

--- a/docs/core-components/loop-component-regression.md
+++ b/docs/core-components/loop-component-regression.md
@@ -41,7 +41,9 @@ If any of these tests fails, the Loop component is broken in the product: either
 5. Verify that `button_run_loop` is still accessible and `title-Loop` is still visible with a single node on the canvas
 
 **Test 3 — Research Translation Loop template: full wiring and iterates over 2 ArXiv papers**
-1. Skip the test if `OPENAI_API_KEY` is not set in the environment
+1. Skip the test when OpenAI cannot serve a live call — `OPENAI_API_KEY` unset, or
+   the provider recorded `inactive` in `providers.json`
+   (`providerSkipGate("openai")`, #1029)
 2. Navigate to "All Templates" and wait for the `template-research-translation-loop` card
 3. Click the template and wait for `title-Loop` to appear
 4. Verify that there are edges on the canvas (confirms template wiring)
@@ -103,7 +105,7 @@ If any of these tests fails, the Loop component is broken in the product: either
 
 - Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
 - Tests 1 and 2 do not need an API key (no LLM execution)
-- Test 3 requires `OPENAI_API_KEY` in the environment; it is skipped gracefully when the key is absent. The test configures the Language Model component via the "Setup Provider" UI before executing the flow — the template ships unconfigured and fails with "A model selection is required" without this step
+- Test 3 requires `OPENAI_API_KEY` in the environment **and** OpenAI recorded `active` in `providers.json` by `collect-models`; it is skipped gracefully otherwise (`providerSkipGate("openai")` — #1029; the two sequential completions under an 8-minute budget are exactly the shape that hangs a shard's worker when the key is drained). The test configures the Language Model component via the "Setup Provider" UI before executing the flow — the template ships unconfigured and fails with "A model selection is required" without this step
 - Tests run in `serial` mode to avoid 400 errors from parallel autosave ("flow must be unique")
 
 ---
@@ -120,7 +122,7 @@ If any of these tests fails, the Loop component is broken in the product: either
 
 - Test 3 configures the Language Model component before running the Playground — the template ships without a provider selected, causing "A model selection is required" if the setup step is skipped
 - Test 3 reads the streamed response with `toContainText(/title/i, { timeout: 240000 })` rather than a one-shot `textContent()` read — `toContainText` re-evaluates as tokens stream in, so it never samples a partially-streamed message. The earlier one-shot read fired on the first streamed token and made the "title" assertion intermittently fail (flake tracked in #356). The test-level timeout is set to 8 minutes via `test.setTimeout` — the template makes 2 sequential model calls (one per ArXiv article) which can take 3-4 minutes on CI infrastructure; the global 5-minute cap is insufficient for this flow
-- The test is skipped automatically (not failed) when `OPENAI_API_KEY` is absent, so it does not block local runs without API keys
+- The test is skipped automatically (not failed) when OpenAI is unusable — key absent, or recorded `inactive` — so it does not block local runs without API keys. Set `IGNORE_PROVIDER_HEALTH=1` to override a stale local `providers.json`
 - The validation criterion counts occurrences of "title" (case-insensitive) in the aggregated LLM response; the threshold is ≥ 1 because the LLM produces a free-form output and may echo "title" in only one of the N responses — checking ≥ N would couple the assertion to non-deterministic LLM formatting
 - `allowFlowErrors()` is required in Test 2 to disable the automatic flow error monitor injected by the fixture
 - **Test 4 daily-#744 timeout was environmental, not a product/wait defect (#751):** the daily on 2026-07-14 hit a 60s `waitForSelector("text=built successfully")` timeout on the `loop-exit-condition.json` flow (`CreateList → Loop → TypeConverter → ChatOutput`, no LLM). Root-cause on the current nightly proved the product healthy: the flow builds in ~0.1s via `POST /api/v1/build/{id}/flow` with every vertex `valid:true`. That daily was a mass-failure run (296 passed / 27 hard-failed / 27 flaky across unrelated areas — traces, agents, custom-component, mcp), i.e. shared-instance saturation. No code change to Test 4; `@stable` kept per `CONTRIBUTING.md` (quarantine only if it reproduces on a clean, non-saturated daily)

--- a/docs/core-functionality/knowledge-ingestion-management/rag-pipeline.md
+++ b/docs/core-functionality/knowledge-ingestion-management/rag-pipeline.md
@@ -89,8 +89,12 @@ bundle-free and never yields a false failure on a packaging change.
 ### Key/bundle guard
 
 The components are all core, so **no bundle presence guard is needed**. The spec
-**skips** only when `GOOGLE_API_KEY` is not configured (embedding + answer both
-need a live Google key), matching the provider-key skips elsewhere in the suite.
+**skips** when Google cannot serve a live call (embedding + answer both need a live
+Google key) — either `GOOGLE_API_KEY` is unset, or `collect-models` recorded the
+provider `inactive` in `providers.json`. The gate is `providerSkipGate("google")`
+(`helpers/provider-setup/provider-health.ts`), matching the provider-health skips
+elsewhere in the suite: gating on the env var alone let a drained key through, and
+the resulting hung call killed the shard's Langflow worker (#1029).
 
 ## Validation criterion (concrete, distinctive)
 
@@ -138,7 +142,7 @@ The answer observed live on 1.11.0.dev38 is exactly `ZEPHYR-42`.
 canvas-component configuration. `@stable`/`@release` cross-cutting. Third and
 final §5.2 RAG spec, builds on #673/#674; created `@stable` after deterministic
 end-to-end validation on the fresh nightly. All-core components — no bundle guard;
-skips cleanly only when `GOOGLE_API_KEY` is absent.)
+skips cleanly when Google is unusable — key absent or recorded `inactive`.)
 
 ---
 
@@ -147,7 +151,9 @@ skips cleanly only when `GOOGLE_API_KEY` is absent.)
 One test, one shared fixture flow, imported via the API with a unique flow name
 per run.
 
-**Guard:** skip if `GOOGLE_API_KEY` is unset.
+**Guard:** skip if Google cannot serve a live call — `GOOGLE_API_KEY` unset, or the
+provider recorded `inactive` in `providers.json` (`providerSkipGate("google")`, #1029).
+`IGNORE_PROVIDER_HEALTH=1` overrides a stale local `providers.json`.
 
 **Setup:**
 1. Create a fresh KB via `POST /api/v1/knowledge_bases` — unique name per run,
@@ -187,7 +193,8 @@ per run.
   the spec replaces per run. Built + configured live on the canvas and validated
   end-to-end on 1.11.0.dev38.
 - `GOOGLE_API_KEY` — required (embeds each chunk with `models/gemini-embedding-001` and
-  answers with `gemini-flash-latest`).
+  answers with `gemini-flash-latest`), **and** Google recorded `active` in
+  `providers.json` by `collect-models` (#1029).
 - Knowledge Base API: `POST /api/v1/knowledge_bases` (create),
   `GET /api/v1/knowledge_bases/{name}` (chunk count),
   `DELETE /api/v1/knowledge_bases/{name}` (scoped cleanup).

--- a/docs/core-functionality/knowledge-ingestion-management/vector-store-index-query.md
+++ b/docs/core-functionality/knowledge-ingestion-management/vector-store-index-query.md
@@ -63,8 +63,12 @@ a packaging change.
 ### Bundle/key guard
 
 The Knowledge component is core, so **no bundle presence guard is needed**. The
-spec **skips** only when `GOOGLE_API_KEY` is not configured (the embedding model
-needs a live key), matching the provider-key skips elsewhere in the suite.
+spec **skips** when Google cannot serve a live call (the embedding model needs a
+live key) — either `GOOGLE_API_KEY` is unset, or `collect-models` recorded the
+provider `inactive` in `providers.json`. The gate is `providerSkipGate("google")`
+(`helpers/provider-setup/provider-health.ts`), matching the provider-health skips
+elsewhere in the suite: gating on the env var alone let a drained key through, and
+the resulting hung call killed the shard's Langflow worker (#1029).
 
 ## Validation criterion (concrete, distinctive)
 
@@ -107,8 +111,8 @@ is both sharp and deterministic.
 (`@files`: knowledge-ingestion surface — functional. `@components`:
 canvas-component configuration. `@stable`/`@release` cross-cutting. Second §5.2
 RAG spec, builds on #673; created `@stable` after deterministic validation on the
-fresh nightly. Core Knowledge component — no bundle guard; skips cleanly only when
-`GOOGLE_API_KEY` is absent.)
+fresh nightly. Core Knowledge component — no bundle guard; skips cleanly when
+Google is unusable — key absent or recorded `inactive`.)
 
 ---
 
@@ -117,7 +121,10 @@ fresh nightly. Core Knowledge component — no bundle guard; skips cleanly only 
 Two tests, one shared fixture flow (`Chat Input → Split Text → Knowledge[Ingest]`
 + `Knowledge[Retrieve]`), imported via the API with a unique flow name per run.
 
-**Guard (both tests):** skip if `GOOGLE_API_KEY` is unset.
+**Guard (both tests):** skip if Google cannot serve a live call — `GOOGLE_API_KEY`
+unset, or the provider recorded `inactive` in `providers.json`
+(`providerSkipGate("google")`, #1029). `IGNORE_PROVIDER_HEALTH=1` overrides a stale
+local `providers.json`.
 
 **Setup (each test):**
 1. Create a fresh KB via `POST /api/v1/knowledge_bases` — unique name per run,
@@ -162,7 +169,9 @@ Two tests, one shared fixture flow (`Chat Input → Split Text → Knowledge[Ing
   `top_k = 1`, `search_query` = the embedding-topic query). Both Knowledge nodes'
   `knowledge_base` is a placeholder (`__KB_NAME__`) the spec replaces per run.
   Built live on the canvas and exported on 1.11.0.dev38.
-- `GOOGLE_API_KEY` — required (the KB embeds each chunk with `models/gemini-embedding-001`).
+- `GOOGLE_API_KEY` — required (the KB embeds each chunk with
+  `models/gemini-embedding-001`), **and** Google recorded `active` in
+  `providers.json` by `collect-models` (#1029).
 - Knowledge Base API: `POST /api/v1/knowledge_bases` (create),
   `GET /api/v1/knowledge_bases/{name}` (chunk count),
   `DELETE /api/v1/knowledge_bases/{name}` (scoped cleanup).
@@ -190,7 +199,8 @@ Two tests, one shared fixture flow (`Chat Input → Split Text → Knowledge[Ing
 ## Preconditions
 
 - Langflow running at `PLAYWRIGHT_BASE_URL` (auto_login).
-- `GOOGLE_API_KEY` configured in `.env` (else both tests skip).
+- `GOOGLE_API_KEY` configured in `.env` **and** Google recorded `active` by
+  `collect-models` (else both tests skip — #1029).
 
 ---
 

--- a/docs/core-functionality/llm-agents/general-bugs-agent-images-playground.md
+++ b/docs/core-functionality/llm-agents/general-bugs-agent-images-playground.md
@@ -25,7 +25,7 @@ and the spec ran clean at `--retries=0`.
 
 The spec contains **1 test** — `"user must be able to send images in the playground with the agent component"`.
 
-Requires `OPENAI_API_KEY` (vision-capable `gpt-4o-mini`); skips when the key is absent. OpenAI is used (not Anthropic) so the test actually runs in the weekly workflow, which provides `OPENAI_API_KEY`.
+Requires `OPENAI_API_KEY` (vision-capable `gpt-4o-mini`) **and** OpenAI recorded `active` in `providers.json`; skips otherwise via `providerSkipGate("openai")` (#1029 — a key that exists but is drained used to run the multimodal completion anyway and hang the shard's Langflow worker). OpenAI is used (not Anthropic) so the test actually runs in the weekly workflow, which provides `OPENAI_API_KEY`.
 
 1. Load the **Simple Agent** template via the canonical `SimpleAgentTemplatePage.load({ provider: "openai" })` — it opens the templates modal through the correct entry point, waits for the canvas to actually load (`canvas_controls_dropdown`), then configures the OpenAI provider. With no explicit model it selects a resilient default (`gpt-4o-mini`, vision-capable on the Agent component). The returned flow id is captured for teardown; `load()` deliberately does **not** pre-clean other flows (removed in #553 — it was wiping flows other parallel workers were using)
 2. (Provider setup is part of step 1's `load()` — the centralized path: open `model_model` → `manage-model-providers` → select `provider-item-OpenAI` → fill the `sk-...` key → save → enable model toggles → select model)
@@ -67,7 +67,7 @@ Requires `OPENAI_API_KEY` (vision-capable `gpt-4o-mini`); skips when the key is 
 ## Preconditions *(optional)*
 
 - Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
-- `OPENAI_API_KEY` defined in `.env` — without it the test skips
+- `OPENAI_API_KEY` defined in `.env` **and** OpenAI recorded `active` by `collect-models` — otherwise the test skips (#1029; `IGNORE_PROVIDER_HEALTH=1` overrides a stale local `providers.json`)
 - Run with `--workers=1` to avoid flow conflicts
 
 ---

--- a/docs/core-functionality/llm-agents/language-model-regression.md
+++ b/docs/core-functionality/llm-agents/language-model-regression.md
@@ -41,8 +41,14 @@ the test ran clean at `--retries=0`.
 
 ## Preconditions *(optional)*
 
-- `OPENAI_API_KEY` / `GOOGLE_API_KEY` in the env (each test self-skips
-  without its key).
+- `OPENAI_API_KEY` / `GOOGLE_API_KEY` in the env, **and** the corresponding
+  provider recorded `active` in `providers.json`. Each test gates on provider
+  *health* via `providerSkipGate` (`helpers/provider-setup/provider-health.ts`),
+  not on the env var alone: a key that exists but is drained used to pass the old
+  gate and hang the live call past gunicorn's 300s timeout, killing the shard's
+  Langflow worker (#1029). The skip reason quotes the error `collect-models`
+  recorded. Set `IGNORE_PROVIDER_HEALTH=1` to override a stale local
+  `providers.json`.
 - `models.json` fresh (`collect-models.spec.ts`) for the setup helpers.
 - `--workers=1` (template loads create named flows; id-scoped afterEach
   cleanup is in place).

--- a/docs/core-functionality/llm-agents/memory-history-regression.md
+++ b/docs/core-functionality/llm-agents/memory-history-regression.md
@@ -45,7 +45,7 @@ Does not require an API key. Validates only the canvas structure.
 
 **Test 2 — message history context retention suite**
 
-Requires `OPENAI_API_KEY`. Groups behavior validations in `test.step` with `expect.soft`.
+Requires OpenAI usable — `OPENAI_API_KEY` set **and** the provider recorded `active` in `providers.json` (`providerSkipGate("openai")`, #1029). Groups behavior validations in `test.step` with `expect.soft`.
 
 1. Load the Memory Chatbot template and configure OpenAI via `setupLanguageModelOpenAI`:
    - If `model_model` is not visible (providers not configured): click the "Setup Provider" button (no data-testid) → select `provider-item-OpenAI` → fill the API key with `pressSequentially` → click "Save" → wait for the "Replace" button to appear → enable a **single** preferred model toggle (`llm-toggle-{model}`, with `scrollIntoViewIfNeeded`) → close with Escape → wait for `model_model` to appear. Enabling only one model (not every toggle) is deliberate: the OpenAI bundle now lists 45+ models and the trailing toggles render off the scroll viewport, so clicking each one timed out on a non-visible element (issue #569); one enabled model is all the dropdown needs
@@ -60,7 +60,7 @@ Requires `OPENAI_API_KEY`. Groups behavior validations in `test.step` with `expe
 
 **Test 3 — session isolation: new session has no context from previous session**
 
-Requires `OPENAI_API_KEY`. Kept separate because it is destructive (creates a new session).
+Requires OpenAI usable — same `providerSkipGate("openai")` gate as Test 2 (#1029). Kept separate because it is destructive (creates a new session).
 
 1. Load the template, configure the API key **and pin the Agent model via API** (same `openConfiguredPlayground` path as Test 2 — see Test 2 step 2)
 2. Open the Playground, send `"My name is Bob..."`
@@ -104,7 +104,7 @@ Requires `OPENAI_API_KEY`. Kept separate because it is destructive (creates a ne
 ## Preconditions *(optional)*
 
 - Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
-- `OPENAI_API_KEY` defined in `.env` for Tests 2 and 3
+- `OPENAI_API_KEY` defined in `.env` **and** OpenAI recorded `active` by `collect-models`, for Tests 2 and 3 (#1029)
 - Run with `--workers=1` to avoid flow conflicts
 
 ---

--- a/docs/core-functionality/observability-monitoring/traces-detail-llm-span-populated.md
+++ b/docs/core-functionality/observability-monitoring/traces-detail-llm-span-populated.md
@@ -38,7 +38,7 @@ Langflow emits **two** spans of `type === "llm"` for a single model call:
 
 **`describe("Single trace — populated LLM span (OpenAI)")` — `mode: "serial"`**
 
-The whole describe block is `test.skip`-ped when `OPENAI_API_KEY` is absent — without a real LLM call the populated values can never exist.
+The whole describe block is `test.skip`-ped when OpenAI cannot serve a live call — `OPENAI_API_KEY` absent, or the provider recorded `inactive` in `providers.json` (`providerSkipGate("openai")`, #1029). Without a real LLM call the populated values can never exist, and with a drained key the call hangs the shard's Langflow worker instead of failing.
 
 **`beforeAll` (shared setup)**
 1. Get a bearer token via `getAuthToken(request)`
@@ -98,7 +98,7 @@ External services: **OpenAI** (`OPENAI_API_KEY`) — one `gpt-4o-mini` call per 
 
 - Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
 - The configured superuser must be able to issue a token via `getAuthToken`
-- `OPENAI_API_KEY` set in the environment — the describe block skips entirely without it
+- `OPENAI_API_KEY` set in the environment **and** OpenAI recorded `active` in `providers.json` by `collect-models` — the describe block skips entirely otherwise (#1029)
 
 ---
 

--- a/docs/ui-ux/settings-message-history.md
+++ b/docs/ui-ux/settings-message-history.md
@@ -59,8 +59,10 @@ burst on nightly `1.12.0.dev6`.
 ## Preconditions *(optional)*
 
 - Langflow running at `PLAYWRIGHT_BASE_URL`.
-- `OPENAI_API_KEY` set — the flow is the Simple Agent template driven through
-  `initialGPTsetup` (the test skips without the key).
+- `OPENAI_API_KEY` set **and** OpenAI recorded `active` in `providers.json` by
+  `collect-models` — the flow is the Simple Agent template driven through
+  `initialGPTsetup`, and the test skips when either is missing
+  (`providerSkipGate("openai")`, #1029).
 - Run with `--workers=1` for local validation (agent-family convention —
   named template loads collide under parallelism).
 

--- a/tests/helpers/provider-setup/provider-health.test.ts
+++ b/tests/helpers/provider-setup/provider-health.test.ts
@@ -22,6 +22,7 @@ import * as os from "os";
 import * as path from "path";
 import {
   readProviderHealth,
+  toSkipGate,
   unavailableReason,
   type ProviderHealthRecord,
 } from "./provider-health";
@@ -65,6 +66,20 @@ test("the skip reason quotes the collected error, not a generic message", () => 
   // reader cannot tell a drained key from a revoked one.
   const reason = unavailableReason(["google"], RUN_30374528125, ALL_KEYS_SET);
   assert.match(reason!, /monthly spending cap/);
+});
+
+test("an inactive record with no collected error still reads as a sentence", () => {
+  // The field is nullable; a skip reason ending in "inactive — null" would tell
+  // the report reader nothing.
+  const reason = unavailableReason(
+    ["google"],
+    [record("google", "inactive", null)],
+    ALL_KEYS_SET,
+  );
+  assert.equal(
+    reason,
+    'Provider "google" inactive — no reason recorded by collect-models',
+  );
 });
 
 test("an inactive provider taints a multi-provider gate", () => {
@@ -174,6 +189,20 @@ test("only the exact value \"1\" arms the escape hatch", () => {
     }),
     "a truthy-looking value must not silently disable the gate",
   );
+});
+
+// ─── The test.skip pair the 22 call sites consume ────────────────────────────
+
+test("toSkipGate returns an empty-string reason when nothing is skipped", () => {
+  // Playwright's test.skip(condition, description) types `description` as string.
+  // Passing `undefined` through would be a type error at every call site, so the
+  // no-skip case MUST carry "".
+  assert.deepEqual(toSkipGate(undefined), { skip: false, reason: "" });
+});
+
+test("toSkipGate carries the reason verbatim when it skips", () => {
+  const reason = unavailableReason(["google"], RUN_30374528125, ALL_KEYS_SET)!;
+  assert.deepEqual(toSkipGate(reason), { skip: true, reason });
 });
 
 // ─── readProviderHealth I/O ──────────────────────────────────────────────────

--- a/tests/helpers/provider-setup/provider-health.test.ts
+++ b/tests/helpers/provider-setup/provider-health.test.ts
@@ -1,0 +1,217 @@
+// Unit tests for the provider health gate (issue #1029).
+// Run with: npm run test:units
+//
+// What rides on this function: it decides whether a provider-hardcoded spec makes
+// a live LLM call. Getting it wrong in either direction is expensive.
+//
+// - Too permissive (the pre-#1029 behavior): a spec calls a provider whose key is
+//   dead, the request blocks past gunicorn's 300s timeout and kills the shard's
+//   single Langflow worker. On run 30374528125 that cost six worker restarts and
+//   14 collateral timeouts across specs that never touch Google.
+// - Too strict: a missing or unparseable providers.json skips the whole suite.
+//   CI is explicitly allowed to run with a failed `Collect models` step (#980),
+//   and a fresh clone has no providers.json at all (it is gitignored), so "no
+//   signal" MUST fail open.
+//
+// The Google error string below is verbatim from the providers.json of the run
+// that motivated the issue.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  readProviderHealth,
+  unavailableReason,
+  type ProviderHealthRecord,
+} from "./provider-health";
+
+/** Verbatim from run 30374528125's providers.json — Google monthly spend cap. */
+const SPEND_CAP =
+  "3 of 36 candidate model(s) failed validation with the SAME model-independent " +
+  "error — stopped early (tried: gemini-2.5-flash, gemini-3.5-flash, " +
+  "gemini-flash-latest); last error: Your project has exceeded its monthly " +
+  "spending cap.";
+
+const ALL_KEYS_SET: NodeJS.ProcessEnv = {
+  OPENAI_API_KEY: "sk-test",
+  ANTHROPIC_API_KEY: "sk-ant-test",
+  GOOGLE_API_KEY: "AIza-test",
+};
+
+const record = (
+  provider: string,
+  status: "active" | "inactive",
+  error: string | null = null,
+): ProviderHealthRecord => ({ provider, model: "some-model", status, error });
+
+/** The exact provider state of run 30374528125: Google drained, the rest fine. */
+const RUN_30374528125: ProviderHealthRecord[] = [
+  record("openai", "active"),
+  record("anthropic", "active"),
+  record("google", "inactive", SPEND_CAP),
+];
+
+// ─── The regression this exists to prevent ───────────────────────────────────
+
+test("a key that EXISTS but is recorded inactive still skips", () => {
+  const reason = unavailableReason(["google"], RUN_30374528125, ALL_KEYS_SET);
+  assert.ok(reason, "google is inactive — the gate must skip, not call it live");
+  assert.match(reason, /inactive/);
+});
+
+test("the skip reason quotes the collected error, not a generic message", () => {
+  // The reason lands in the Playwright report; without the collected error the
+  // reader cannot tell a drained key from a revoked one.
+  const reason = unavailableReason(["google"], RUN_30374528125, ALL_KEYS_SET);
+  assert.match(reason!, /monthly spending cap/);
+});
+
+test("an inactive provider taints a multi-provider gate", () => {
+  // language-model-regression's switch test drives OpenAI AND Google; a dead key
+  // on either one wedges it.
+  const reason = unavailableReason(
+    ["openai", "google"],
+    RUN_30374528125,
+    ALL_KEYS_SET,
+  );
+  assert.match(reason!, /"google" inactive/);
+});
+
+// ─── Healthy path ────────────────────────────────────────────────────────────
+
+test("an active provider does not skip", () => {
+  assert.equal(
+    unavailableReason(["openai"], RUN_30374528125, ALL_KEYS_SET),
+    undefined,
+  );
+});
+
+test("several active providers do not skip", () => {
+  assert.equal(
+    unavailableReason(["openai", "anthropic"], RUN_30374528125, ALL_KEYS_SET),
+    undefined,
+  );
+});
+
+// ─── Fail open on absent signal ──────────────────────────────────────────────
+
+test("null records fail OPEN — no providers.json must not skip the world", () => {
+  assert.equal(unavailableReason(["google"], null, ALL_KEYS_SET), undefined);
+});
+
+test("a provider absent from the records fails open", () => {
+  // collect-models can write a partial file (a provider it never reached).
+  assert.equal(
+    unavailableReason(["google"], [record("openai", "active")], ALL_KEYS_SET),
+    undefined,
+  );
+});
+
+test("an empty records array fails open", () => {
+  assert.equal(unavailableReason(["google"], [], ALL_KEYS_SET), undefined);
+});
+
+// ─── Env-key precedence ──────────────────────────────────────────────────────
+
+test("a missing env key skips, naming the variable", () => {
+  const reason = unavailableReason(["google"], RUN_30374528125, {
+    ...ALL_KEYS_SET,
+    GOOGLE_API_KEY: undefined,
+  });
+  assert.equal(reason, "GOOGLE_API_KEY required to run this test");
+});
+
+test("the missing env key wins over the recorded inactive reason", () => {
+  // For an unset key collect-models records `"GOOGLE_API_KEY not set"` anyway —
+  // naming the variable is the actionable half, so it must come first.
+  const reason = unavailableReason(["google"], RUN_30374528125, {
+    GOOGLE_API_KEY: undefined,
+  });
+  assert.doesNotMatch(reason!, /inactive/);
+});
+
+test("an empty-string env key counts as missing", () => {
+  // `.env` files routinely carry `GOOGLE_API_KEY=` for an unused provider.
+  const reason = unavailableReason(["google"], RUN_30374528125, {
+    ...ALL_KEYS_SET,
+    GOOGLE_API_KEY: "",
+  });
+  assert.equal(reason, "GOOGLE_API_KEY required to run this test");
+});
+
+test("the first missing key in the argument order is the one reported", () => {
+  const reason = unavailableReason(["openai", "google"], RUN_30374528125, {});
+  assert.equal(reason, "OPENAI_API_KEY required to run this test");
+});
+
+// ─── Escape hatch ────────────────────────────────────────────────────────────
+
+test("IGNORE_PROVIDER_HEALTH=1 bypasses a stale inactive record", () => {
+  assert.equal(
+    unavailableReason(["google"], RUN_30374528125, {
+      ...ALL_KEYS_SET,
+      IGNORE_PROVIDER_HEALTH: "1",
+    }),
+    undefined,
+  );
+});
+
+test("IGNORE_PROVIDER_HEALTH does NOT bypass a missing env key", () => {
+  // The escape hatch overrides a possibly-stale health record; it cannot conjure
+  // a credential the test needs to authenticate at all.
+  const reason = unavailableReason(["google"], RUN_30374528125, {
+    IGNORE_PROVIDER_HEALTH: "1",
+  });
+  assert.equal(reason, "GOOGLE_API_KEY required to run this test");
+});
+
+test("only the exact value \"1\" arms the escape hatch", () => {
+  assert.ok(
+    unavailableReason(["google"], RUN_30374528125, {
+      ...ALL_KEYS_SET,
+      IGNORE_PROVIDER_HEALTH: "true",
+    }),
+    "a truthy-looking value must not silently disable the gate",
+  );
+});
+
+// ─── readProviderHealth I/O ──────────────────────────────────────────────────
+
+test("readProviderHealth returns null for a missing file", () => {
+  assert.equal(
+    readProviderHealth(path.join(os.tmpdir(), "no-such-providers-1029.json")),
+    null,
+  );
+});
+
+test("readProviderHealth returns null for malformed JSON instead of throwing", () => {
+  // A truncated write (killed collect-models) must degrade to "no signal", not
+  // crash every spec that consults the gate at collection time.
+  const file = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), "provider-health-")),
+    "providers.json",
+  );
+  fs.writeFileSync(file, '[{"provider":"google",');
+  assert.equal(readProviderHealth(file), null);
+});
+
+test("readProviderHealth returns null for valid JSON that is not an array", () => {
+  const file = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), "provider-health-")),
+    "providers.json",
+  );
+  fs.writeFileSync(file, '{"provider":"google","status":"inactive"}');
+  assert.equal(readProviderHealth(file), null);
+});
+
+test("readProviderHealth parses a real providers.json shape", () => {
+  const file = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), "provider-health-")),
+    "providers.json",
+  );
+  fs.writeFileSync(file, JSON.stringify(RUN_30374528125));
+  const records = readProviderHealth(file);
+  assert.equal(records?.length, 3);
+  assert.equal(records?.find((r) => r.provider === "google")?.status, "inactive");
+});

--- a/tests/helpers/provider-setup/provider-health.ts
+++ b/tests/helpers/provider-setup/provider-health.ts
@@ -24,7 +24,18 @@ import { providerConfigMap, type Provider } from "./provider-config";
 // `test.skip` quoting the collected reason instead of a live call against a dead
 // key.
 
-/** Shape of one providers.json entry written by `collect-models`. */
+/**
+ * Shape of one providers.json entry written by `collect-models`.
+ *
+ * Deliberately re-declared instead of importing `ProviderRecord` from
+ * `collect-models.ts`: that module imports `@playwright/test` and drives a
+ * `SettingsPage`, and this one is consumed by a `node --test` unit lane that must
+ * not pull a browser-facing dependency graph. Only the fields this gate reads are
+ * declared — the real records also carry `checkedAt`, the timestamp that would let
+ * a future version expire a stale record automatically instead of relying on
+ * `IGNORE_PROVIDER_HEALTH=1`. Keep in sync with `collect-models.ts` by hand; the
+ * producer's own spec asserts the record shape it writes.
+ */
 export interface ProviderHealthRecord {
   provider: string;
   model: string | null;
@@ -92,7 +103,13 @@ export function unavailableReason(
   for (const provider of providers) {
     const record = records.find((r) => r.provider === provider);
     if (record?.status === "inactive") {
-      return `Provider "${provider}" inactive — ${record.error}`;
+      // The reason lands in the Playwright report — it is the whole product of a
+      // skip, so it must never read `inactive — null`. `collect-models` always
+      // fills `error` for an inactive record today, but the field is nullable and
+      // a hand-edited or future-schema file must still produce a usable line.
+      return `Provider "${provider}" inactive — ${
+        record.error ?? "no reason recorded by collect-models"
+      }`;
     }
   }
 
@@ -114,6 +131,21 @@ export function providerUnavailableReason(
 }
 
 /**
+ * Shapes a reason into the `test.skip(condition, description)` pair.
+ *
+ * Split out for the same reason `unavailableReason` is: it makes the contract the
+ * 22 call sites actually depend on — `reason` is ALWAYS a string, so Playwright's
+ * signature is satisfied even when nothing is skipped — testable without a
+ * providers.json on disk.
+ */
+export function toSkipGate(reason: string | undefined): {
+  skip: boolean;
+  reason: string;
+} {
+  return { skip: !!reason, reason: reason ?? "" };
+}
+
+/**
  * `test.skip`-shaped gate for a provider-hardcoded spec:
  *
  *   const gate = providerSkipGate("openai", "google");
@@ -126,6 +158,5 @@ export function providerSkipGate(...providers: Provider[]): {
   skip: boolean;
   reason: string;
 } {
-  const reason = providerUnavailableReason(...providers);
-  return { skip: !!reason, reason: reason ?? "" };
+  return toSkipGate(providerUnavailableReason(...providers));
 }

--- a/tests/helpers/provider-setup/provider-health.ts
+++ b/tests/helpers/provider-setup/provider-health.ts
@@ -1,0 +1,131 @@
+import fs from "fs";
+import path from "path";
+import { providerConfigMap, type Provider } from "./provider-config";
+
+// Provider health gate for specs that HARDCODE a provider (issue #1029).
+//
+// `collect-models` already records a provider as `inactive` in providers.json
+// when its key is dead — drained balance, revoked key, spend cap. Specs that are
+// PARAMETRIZED by provider honor that. Specs that hardcode one used to gate on
+// the mere presence of the env var:
+//
+//   test.skip(!process.env.GOOGLE_API_KEY, "GOOGLE_API_KEY required")
+//
+// A key that exists but is dead therefore ran the test. On run 30374528125 the
+// Google key had exceeded its monthly spending cap; `models.json` still listed
+// all 36 Google models (it mirrors the Langflow catalog, not the validation),
+// so the two Google tests in `language-model-regression.spec.ts` resolved a
+// model and made the live call anyway. Each blocked a backend request past
+// gunicorn's 300s timeout, killing the shard's single Langflow worker — six
+// kill/restart cycles and 14 collateral timeouts across unrelated specs.
+//
+// This module is the single source of that gate. It reads the same providers.json
+// the parametrized specs read, so a provider recorded `inactive` produces a
+// `test.skip` quoting the collected reason instead of a live call against a dead
+// key.
+
+/** Shape of one providers.json entry written by `collect-models`. */
+export interface ProviderHealthRecord {
+  provider: string;
+  model: string | null;
+  status: "active" | "inactive";
+  error: string | null;
+}
+
+const PROVIDERS_PATH = path.join(__dirname, "data", "providers.json");
+
+/**
+ * Reads providers.json, or returns `null` when it is absent or unparseable.
+ *
+ * `null` means "no health signal" and callers must FAIL OPEN — never skip the
+ * world because the pre-flight did not run. providers.json is gitignored and
+ * only exists after `collect-models`, so a fresh clone or a targeted local run
+ * legitimately has no file, and CI's `Collect models` step is explicitly allowed
+ * to fail without aborting the shard (#980).
+ */
+export function readProviderHealth(
+  jsonPath: string = PROVIDERS_PATH,
+): ProviderHealthRecord[] | null {
+  if (!fs.existsSync(jsonPath)) return null;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(jsonPath, "utf-8"));
+    return Array.isArray(parsed) ? (parsed as ProviderHealthRecord[]) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pure decision function: the reason the given providers cannot serve a live
+ * call, or `undefined` when every one of them is usable.
+ *
+ * Precedence is deliberate — a missing env key is reported before a recorded
+ * `inactive`, because without the key the provider cannot even be configured and
+ * "GOOGLE_API_KEY is not set" is more actionable than the stale collected error
+ * (which, for an unset key, is just `"GOOGLE_API_KEY not set"` anyway).
+ *
+ * Split from the I/O above so the matrix can be unit-tested without a fixture
+ * file on disk (`provider-health.test.ts`).
+ */
+export function unavailableReason(
+  providers: Provider[],
+  records: ProviderHealthRecord[] | null,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  for (const provider of providers) {
+    const missing = (providerConfigMap[provider]?.envKeys ?? []).filter(
+      (key) => !env[key],
+    );
+    if (missing.length > 0) {
+      return `${missing.join(", ")} required to run this test`;
+    }
+  }
+
+  // Escape hatch for a STALE local providers.json: `collect-models` is not part
+  // of a targeted local run, so a record from days ago can hold back a spec that
+  // would pass today. CI never needs this — every shard collects its own health
+  // immediately before the @stable run.
+  if (env.IGNORE_PROVIDER_HEALTH === "1") return undefined;
+
+  if (!records) return undefined; // no signal — fail open, see readProviderHealth
+
+  for (const provider of providers) {
+    const record = records.find((r) => r.provider === provider);
+    if (record?.status === "inactive") {
+      return `Provider "${provider}" inactive — ${record.error}`;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * The reason the given provider(s) cannot serve a live call right now, reading
+ * the health recorded by `collect-models`; `undefined` when all are usable.
+ *
+ * Pass every provider the test actually calls — the switch test in
+ * `language-model-regression.spec.ts` needs both OpenAI and Google, and a dead
+ * key on either one wedges it just the same.
+ */
+export function providerUnavailableReason(
+  ...providers: Provider[]
+): string | undefined {
+  return unavailableReason(providers, readProviderHealth());
+}
+
+/**
+ * `test.skip`-shaped gate for a provider-hardcoded spec:
+ *
+ *   const gate = providerSkipGate("openai", "google");
+ *   test.skip(gate.skip, gate.reason);
+ *
+ * `reason` is always a string so it satisfies Playwright's signature; it is only
+ * surfaced when `skip` is true.
+ */
+export function providerSkipGate(...providers: Provider[]): {
+  skip: boolean;
+  reason: string;
+} {
+  const reason = providerUnavailableReason(...providers);
+  return { skip: !!reason, reason: reason ?? "" };
+}

--- a/tests/tests-automations/regression/core-components/loop-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/loop-component-regression.spec.ts
@@ -153,10 +153,10 @@ test(
   "Loop component — Research Translation Loop template: full wiring and iterates over 2 ArXiv papers",
   { tag: ["@stable", "@release", "@components", "@templates", "@playground"] },
   async ({ page }) => {
-    // Two sequential real completions run below (one per ArXiv paper, with an
-// 8-minute budget), so gate on provider HEALTH rather than on
-    // the mere presence of the env var: a key that exists but is drained blocks
-    // the backend past gunicorn's 300s timeout and kills the shard's Langflow
+    // Two sequential real completions run below (one per ArXiv paper, under an
+    // 8-minute budget), so gate on provider HEALTH rather than on the mere
+    // presence of the env var: a key that exists but is drained blocks the
+    // backend past gunicorn's 300s timeout and kills the shard's Langflow
     // worker (#1029).
     const gate = providerSkipGate("openai");
     test.skip(gate.skip, gate.reason);

--- a/tests/tests-automations/regression/core-components/loop-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/loop-component-regression.spec.ts
@@ -7,6 +7,7 @@ import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test"
 import { createFlow } from "../../../helpers/flows/create-flow";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
 import { setupLanguageModelOpenAI } from "../../../helpers/provider-setup/setup-language-model-openai";
+import { providerSkipGate } from "../../../helpers/provider-setup/provider-health";
 
 // Run tests serially to avoid "flow must be unique" 400 errors from parallel autosaves
 test.describe.configure({ mode: "serial" });
@@ -152,10 +153,13 @@ test(
   "Loop component — Research Translation Loop template: full wiring and iterates over 2 ArXiv papers",
   { tag: ["@stable", "@release", "@components", "@templates", "@playground"] },
   async ({ page }) => {
-    test.skip(
-      !process.env.OPENAI_API_KEY,
-      "OPENAI_API_KEY required to execute the Language Model component in the Research Translation Loop template",
-    );
+    // Two sequential real completions run below (one per ArXiv paper, with an
+// 8-minute budget), so gate on provider HEALTH rather than on
+    // the mere presence of the env var: a key that exists but is drained blocks
+    // the backend past gunicorn's 300s timeout and kills the shard's Langflow
+    // worker (#1029).
+    const gate = providerSkipGate("openai");
+    test.skip(gate.skip, gate.reason);
 
     // Override the global 5-minute cap: this flow makes 2 sequential LLM calls
     // (one per ArXiv paper) which can take 3-4 minutes on CI infrastructure.

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/rag-pipeline.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/rag-pipeline.spec.ts
@@ -10,6 +10,7 @@ import {
   deleteKnowledgeBase,
   getKnowledgeBase,
 } from "../../../../helpers/knowledge/knowledge-base";
+import { providerSkipGate } from "../../../../helpers/provider-setup/provider-health";
 
 // §5.2.4 — the *complete RAG pipeline* end-to-end. Builds on #673 (Split Text
 // chunking) and #674 (vector-store index + query) and adds the final "answer"
@@ -67,10 +68,14 @@ const createdKbNames: string[] = [];
 // knowledge-ingestion specs).
 test.describe.configure({ mode: "serial" });
 
-test.skip(
-  !process?.env?.GOOGLE_API_KEY,
-  "GOOGLE_API_KEY required to embed the document and answer with gemini-flash-latest",
-);
+// Google backs BOTH the embedding of every chunk and the answer model, so a key
+// that exists but is drained turns each node run into a live call against a dead
+// provider — which blocks the backend past gunicorn's 300s timeout and kills the
+// shard's Langflow worker. Gate on the health `collect-models` recorded, not on
+// the env var alone (#1029). Reason when it fires: either GOOGLE_API_KEY is
+// unset, or the collected `inactive` error (spend cap, revoked key, …).
+const googleGate = providerSkipGate("google");
+test.skip(googleGate.skip, googleGate.reason);
 
 async function authHeaders(page: Page): Promise<Record<string, string>> {
   const authHeader = await getAuthToken(page.request);

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/vector-store-index-query.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/vector-store-index-query.spec.ts
@@ -61,10 +61,10 @@ const createdKbNames: string[] = [];
 // knowledge-ingestion specs).
 test.describe.configure({ mode: "serial" });
 
-// Google embeds every chunk into the Knowledge Base, so gate on provider HEALTH rather than on
-// the mere presence of the env var: a key that exists but is drained blocks
-// the backend past gunicorn's 300s timeout and kills the shard's Langflow
-// worker (#1029).
+// Google embeds every chunk into the Knowledge Base, so gate on provider HEALTH
+// rather than on the mere presence of the env var: a key that exists but is
+// drained blocks the backend past gunicorn's 300s timeout and kills the shard's
+// Langflow worker (#1029).
 const gate = providerSkipGate("google");
 test.skip(gate.skip, gate.reason);
 

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/vector-store-index-query.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/vector-store-index-query.spec.ts
@@ -11,6 +11,7 @@ import {
   getKnowledgeBase,
 } from "../../../../helpers/knowledge/knowledge-base";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
+import { providerSkipGate } from "../../../../helpers/provider-setup/provider-health";
 
 // §5.2.2 + §5.2.3 — the *vectorization + retrieval* step of RAG ingestion. The
 // chunks produced by Split Text are embedded and indexed into a native (core,
@@ -60,10 +61,12 @@ const createdKbNames: string[] = [];
 // knowledge-ingestion specs).
 test.describe.configure({ mode: "serial" });
 
-test.skip(
-  !process?.env?.GOOGLE_API_KEY,
-  "GOOGLE_API_KEY required to embed the document into the Knowledge Base",
-);
+// Google embeds every chunk into the Knowledge Base, so gate on provider HEALTH rather than on
+// the mere presence of the env var: a key that exists but is drained blocks
+// the backend past gunicorn's 300s timeout and kills the shard's Langflow
+// worker (#1029).
+const gate = providerSkipGate("google");
+test.skip(gate.skip, gate.reason);
 
 async function authHeaders(page: Page): Promise<Record<string, string>> {
   const authHeader = await getAuthToken(page.request);

--- a/tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-0.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-0.spec.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../../helpers/ui/open-advanced-options";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { providerSkipGate } from "../../../../helpers/provider-setup/provider-health";
 
 // Capture every flow THIS page creates from its POST /api/v1/flows → 201
 // responses and delete them id-scoped in afterEach (repo convention, #490/#681).
@@ -47,14 +48,16 @@ test(
   "user must be able to send an image on chat",
   { tag: ["@release", "@workspace", "@components"] },
   async ({ page }) => {
-    test.skip(
-      !process?.env?.OPENAI_API_KEY,
-      "OPENAI_API_KEY required to run this test",
-    );
-
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
     }
+
+    // Real completions run below, so gate on provider HEALTH, not on the env var
+    // alone — a drained key would block the backend past gunicorn's 300s timeout
+    // and kill the shard's Langflow worker (#1029). Evaluated after dotenv so a
+    // local `.env`-only key is seen.
+    const gate = providerSkipGate("openai");
+    test.skip(gate.skip, gate.reason);
 
     trackCreatedFlows(page);
     await awaitBootstrapTest(page);

--- a/tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-0.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-0.spec.ts
@@ -54,8 +54,7 @@ test(
 
     // Real completions run below, so gate on provider HEALTH, not on the env var
     // alone — a drained key would block the backend past gunicorn's 300s timeout
-    // and kill the shard's Langflow worker (#1029). Evaluated after dotenv so a
-    // local `.env`-only key is seen.
+    // and kill the shard's Langflow worker (#1029).
     const gate = providerSkipGate("openai");
     test.skip(gate.skip, gate.reason);
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-1.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-1.spec.ts
@@ -5,19 +5,22 @@ import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { initialGPTsetup } from "../../../../helpers/other/initialGPTsetup";
 import { zoomOut } from "../../../../helpers/ui/zoom-out";
+import { providerSkipGate } from "../../../../helpers/provider-setup/provider-health";
 
 test(
   "user must be able to see output inspection",
   { tag: ["@release", "@components", "@agents"] },
   async ({ page }) => {
-    test.skip(
-      !process?.env?.OPENAI_API_KEY,
-      "OPENAI_API_KEY required to run this test",
-    );
-
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
     }
+
+    // Real completions run below, so gate on provider HEALTH, not on the env var
+    // alone — a drained key would block the backend past gunicorn's 300s timeout
+    // and kill the shard's Langflow worker (#1029). Evaluated after dotenv so a
+    // local `.env`-only key is seen.
+    const gate = providerSkipGate("openai");
+    test.skip(gate.skip, gate.reason);
 
     await awaitBootstrapTest(page);
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-1.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-1.spec.ts
@@ -17,8 +17,7 @@ test(
 
     // Real completions run below, so gate on provider HEALTH, not on the env var
     // alone — a drained key would block the backend past gunicorn's 300s timeout
-    // and kill the shard's Langflow worker (#1029). Evaluated after dotenv so a
-    // local `.env`-only key is seen.
+    // and kill the shard's Langflow worker (#1029).
     const gate = providerSkipGate("openai");
     test.skip(gate.skip, gate.reason);
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-2.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-2.spec.ts
@@ -53,8 +53,7 @@ test(
 
     // Real completions run below, so gate on provider HEALTH, not on the env var
     // alone — a drained key would block the backend past gunicorn's 300s timeout
-    // and kill the shard's Langflow worker (#1029). Evaluated after dotenv so a
-    // local `.env`-only key is seen.
+    // and kill the shard's Langflow worker (#1029).
     const gate = providerSkipGate("openai");
     test.skip(gate.skip, gate.reason);
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-2.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/chatInputOutputUser-shard-2.spec.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../../helpers/ui/open-advanced-options";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { providerSkipGate } from "../../../../helpers/provider-setup/provider-health";
 
 // Capture every flow THIS page creates from its POST /api/v1/flows → 201
 // responses and delete them id-scoped in afterEach (repo convention, #490/#681).
@@ -46,14 +47,16 @@ test(
   "user must interact with chat with Input/Output",
   { tag: ["@release", "@components", "@agents"] },
   async ({ page }) => {
-    test.skip(
-      !process?.env?.OPENAI_API_KEY,
-      "OPENAI_API_KEY required to run this test",
-    );
-
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
     }
+
+    // Real completions run below, so gate on provider HEALTH, not on the env var
+    // alone — a drained key would block the backend past gunicorn's 300s timeout
+    // and kill the shard's Langflow worker (#1029). Evaluated after dotenv so a
+    // local `.env`-only key is seen.
+    const gate = providerSkipGate("openai");
+    test.skip(gate.skip, gate.reason);
 
     trackCreatedFlows(page);
     await awaitBootstrapTest(page);

--- a/tests/tests-automations/regression/core-functionality/llm-agents/composio.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/composio.spec.ts
@@ -7,6 +7,11 @@ test(
   "user should be able to interact with composio component",
   { tag: ["@release", "@workspace", "@api", "@components"] },
   async ({ page, context }) => {
+    // Env-var presence is the CORRECT gate here (#1029 audit): Composio is a tool
+    // provider, not an LLM provider — `collect-models` never probes it, so
+    // providers.json holds no health record to consume. The test also drives no
+    // completion; it only configures the Gmail component's credential surface, so
+    // a dead key cannot produce the hung request that wedges a shard.
     test.skip(
       !process?.env?.COMPOSIO_API_KEY,
       "COMPOSIO_API_KEY required to run this test",

--- a/tests/tests-automations/regression/core-functionality/llm-agents/general-bugs-agent-images-playground.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/general-bugs-agent-images-playground.spec.ts
@@ -4,6 +4,7 @@ import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage } from "../../../../pages";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { providerSkipGate } from "../../../../helpers/provider-setup/provider-health";
 
 // Id of the flow created by the template load, so afterEach deletes exactly
 // that one via the API (id-scoped, #515) — never a global cleanAllFlows.
@@ -29,14 +30,16 @@ test(
   "user must be able to send images in the playground with the agent component",
   { tag: ["@stable", "@release", "@components", "@agents"] },
   async ({ page }) => {
-    test.skip(
-      !process?.env?.OPENAI_API_KEY,
-      "OPENAI_API_KEY required to run this test",
-    );
-
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
     }
+
+    // A real multimodal completion runs below, so gate on provider HEALTH, not on
+    // the env var alone — a drained key would block the backend past gunicorn's
+    // 300s timeout and kill the shard's Langflow worker (#1029). Evaluated after
+    // dotenv so a local `.env`-only key is seen.
+    const openaiGate = providerSkipGate("openai");
+    test.skip(openaiGate.skip, openaiGate.reason);
     // Load the Simple Agent template via the canonical helper, which clears
     // existing flows, opens the templates modal through the correct entry point,
     // and waits for the canvas to actually load. The previous manual

--- a/tests/tests-automations/regression/core-functionality/llm-agents/general-bugs-agent-images-playground.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/general-bugs-agent-images-playground.spec.ts
@@ -36,10 +36,10 @@ test(
 
     // A real multimodal completion runs below, so gate on provider HEALTH, not on
     // the env var alone — a drained key would block the backend past gunicorn's
-    // 300s timeout and kill the shard's Langflow worker (#1029). Evaluated after
-    // dotenv so a local `.env`-only key is seen.
+    // 300s timeout and kill the shard's Langflow worker (#1029).
     const openaiGate = providerSkipGate("openai");
     test.skip(openaiGate.skip, openaiGate.reason);
+
     // Load the Simple Agent template via the canonical helper, which clears
     // existing flows, opens the templates modal through the correct entry point,
     // and waits for the canvas to actually load. The previous manual

--- a/tests/tests-automations/regression/core-functionality/llm-agents/general-bugs-agent-sum-duplicate-message-playground.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/general-bugs-agent-sum-duplicate-message-playground.spec.ts
@@ -3,19 +3,22 @@ import path from "path";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { setupAnthropic } from "../../../../helpers/provider-setup/setup-anthropic";
+import { providerSkipGate } from "../../../../helpers/provider-setup/provider-health";
 
 test(
   "user must not experience message duplication in mathematical expressions with agent component",
   { tag: ["@release", "@components", "@workspace"] },
   async ({ page }) => {
-    test.skip(
-      !process?.env?.ANTHROPIC_API_KEY,
-      "ANTHROPIC_API_KEY required to run this test",
-    );
-
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
     }
+
+    // Real completions run below, so gate on provider HEALTH, not on the env var
+    // alone — a drained key would block the backend past gunicorn's 300s timeout
+    // and kill the shard's Langflow worker (#1029). Evaluated after dotenv so a
+    // local `.env`-only key is seen.
+    const gate = providerSkipGate("anthropic");
+    test.skip(gate.skip, gate.reason);
     await awaitBootstrapTest(page);
 
     await page.getByTestId("side_nav_options_all-templates").click();

--- a/tests/tests-automations/regression/core-functionality/llm-agents/general-bugs-agent-sum-duplicate-message-playground.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/general-bugs-agent-sum-duplicate-message-playground.spec.ts
@@ -15,8 +15,7 @@ test(
 
     // Real completions run below, so gate on provider HEALTH, not on the env var
     // alone — a drained key would block the backend past gunicorn's 300s timeout
-    // and kill the shard's Langflow worker (#1029). Evaluated after dotenv so a
-    // local `.env`-only key is seen.
+    // and kill the shard's Langflow worker (#1029).
     const gate = providerSkipGate("anthropic");
     test.skip(gate.skip, gate.reason);
     await awaitBootstrapTest(page);

--- a/tests/tests-automations/regression/core-functionality/llm-agents/language-model-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/language-model-regression.spec.ts
@@ -6,6 +6,7 @@ import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-te
 import { initialGPTsetup } from "../../../../helpers/other/initialGPTsetup";
 import { setupGoogle } from "../../../../helpers/provider-setup/setup-google";
 import { resolveGeminiModel } from "../../../../helpers/provider-setup/resolve-gemini-model";
+import { providerSkipGate } from "../../../../helpers/provider-setup/provider-health";
 import { hideInspectorPanel } from "../../../../helpers/ui/hide-inspector-panel";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
@@ -16,9 +17,15 @@ import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 // - the multi-provider tests use Google instead of Anthropic — same contract
 //   (a second provider answers; a switch persists), and the suite holds a
 //   funded GOOGLE_API_KEY (no Anthropic credits available; Save/validation
-//   requires a real funded key). They skip without the env key — the
+//   requires a real funded key). They skip when the provider is unusable — the
 //   daily-stable workflow needs the GOOGLE_API_KEY secret for them to run
 //   in CI (flagged on the PR).
+//
+// Every test here drives a REAL completion, so each gates on provider HEALTH
+// (`providerSkipGate`), not on the mere presence of the env key (#1029). A key
+// that exists but is drained used to pass the old gate and block the backend
+// past gunicorn's 300s timeout, killing the shard's Langflow worker — the
+// Google tests below did exactly that on run 30374528125.
 // - the "Manage Model Providers" test lost its if-wrapping: every step is a
 //   hard assertion against live-scouted testids.
 
@@ -69,10 +76,8 @@ test.describe("Language Model Component Regression", () => {
     "language model must respond with OpenAI provider",
     { tag: ["@stable", "@release", "@components", "@model-provider"] },
     async ({ page }) => {
-      test.skip(
-        !process?.env?.OPENAI_API_KEY,
-        "OPENAI_API_KEY required to run this test",
-      );
+      const gate = providerSkipGate("openai");
+      test.skip(gate.skip, gate.reason);
 
       await openBasicPrompting(page);
 
@@ -131,10 +136,8 @@ test.describe("Language Model Component Regression", () => {
     "language model must respond with Google provider",
     { tag: ["@stable", "@release", "@components", "@model-provider"] },
     async ({ page }) => {
-      test.skip(
-        !process?.env?.GOOGLE_API_KEY,
-        "GOOGLE_API_KEY required to run this test",
-      );
+      const gate = providerSkipGate("google");
+      test.skip(gate.skip, gate.reason);
 
       await openBasicPrompting(page);
 
@@ -214,10 +217,10 @@ test.describe("Language Model Component Regression", () => {
     "language model provider switch from OpenAI to Google must persist",
     { tag: ["@stable", "@release", "@components", "@model-provider"] },
     async ({ page }) => {
-      test.skip(
-        !process?.env?.OPENAI_API_KEY || !process?.env?.GOOGLE_API_KEY,
-        "OPENAI_API_KEY and GOOGLE_API_KEY required to run this test",
-      );
+      // Both providers are driven here, so a dead key on EITHER one wedges the
+      // test — gate on both.
+      const gate = providerSkipGate("openai", "google");
+      test.skip(gate.skip, gate.reason);
 
       await openBasicPrompting(page);
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/memory-history-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/memory-history-regression.spec.ts
@@ -10,6 +10,7 @@ import {
   setupLanguageModelOpenAI,
   setAgentModelViaApi,
 } from "../../../../helpers/provider-setup/setup-language-model-openai";
+import { providerSkipGate } from "../../../../helpers/provider-setup/provider-health";
 
 if (!process.env.CI) {
   dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
@@ -118,10 +119,11 @@ test.describe("Memory Chatbot Regression", () => {
     "message history context retention suite",
     { tag: ["@stable", "@release", "@agents", "@playground"] },
     async ({ page }) => {
-      test.skip(
-        !process.env.OPENAI_API_KEY,
-        "OPENAI_API_KEY required to run this test",
-      );
+      // Real OpenAI completions drive the whole suite, so gate on provider
+      // HEALTH, not on the env var alone — a drained key would block the backend
+      // past gunicorn's 300s timeout and kill the shard's worker (#1029).
+      const gate = providerSkipGate("openai");
+      test.skip(gate.skip, gate.reason);
 
       createdFlowId = await loadMemoryChatbot(page);
       const playground = await openConfiguredPlayground(page, createdFlowId);
@@ -164,10 +166,11 @@ test.describe("Memory Chatbot Regression", () => {
     "session isolation: new session has no context from previous session",
     { tag: ["@stable", "@release", "@agents", "@playground"] },
     async ({ page }) => {
-      test.skip(
-        !process.env.OPENAI_API_KEY,
-        "OPENAI_API_KEY required to run this test",
-      );
+      // Real OpenAI completions drive the whole suite, so gate on provider
+      // HEALTH, not on the env var alone — a drained key would block the backend
+      // past gunicorn's 300s timeout and kill the shard's worker (#1029).
+      const gate = providerSkipGate("openai");
+      test.skip(gate.skip, gate.reason);
 
       createdFlowId = await loadMemoryChatbot(page);
       const playground = await openConfiguredPlayground(page, createdFlowId);

--- a/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-api-key.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-api-key.spec.ts
@@ -58,6 +58,13 @@ test.describe("Model Provider API Key Management", () => {
       // OpenAI is the configured-provider reference (collect-models configures
       // it in both environments). Skip with a reason when the instance has no
       // stored key — never silently.
+      //
+      // Deliberately NOT gated on provider health (#1029 audit): this asserts the
+      // key-edit SURFACE, and a configured-but-drained key is exactly a state it
+      // must still cover. It drives no completion — the models badge comes from the
+      // catalog and the typed value is never submitted — so it cannot produce the
+      // hung request that wedges a shard. The instance-side variable check below is
+      // already stronger than env-var presence.
       const bearer = await getAuthToken(request);
       const vars = await request
         .get("/api/v1/variables/", { headers: { Authorization: bearer } })

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-llm-span-populated.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-llm-span-populated.spec.ts
@@ -66,12 +66,11 @@ function languageModelNodeId(): string {
 test.describe("Single trace — populated LLM span (OpenAI)", () => {
   test.describe.configure({ mode: "serial" });
 
-  // A real LLM call is the whole point of this spec — without a key the
-  // tokenUsage / modelName / latencyMs values can never populate.
-  // A real LLM call is the whole point of this spec, so gate on provider HEALTH rather than on
-  // the mere presence of the env var: a key that exists but is drained blocks
-  // the backend past gunicorn's 300s timeout and kills the shard's Langflow
-  // worker (#1029).
+  // A real LLM call is the whole point of this spec — without one the tokenUsage /
+  // modelName / latencyMs values can never populate. So gate on provider HEALTH,
+  // not on the mere presence of the env var: a key that exists but is drained
+  // blocks the backend past gunicorn's 300s timeout and kills the shard's
+  // Langflow worker (#1029).
   const gate = providerSkipGate("openai");
   test.skip(gate.skip, gate.reason);
 

--- a/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-llm-span-populated.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/observability-monitoring/traces-detail-llm-span-populated.spec.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { providerSkipGate } from "../../../../helpers/provider-setup/provider-health";
 
 const TRACE_FIXTURE = JSON.parse(
   readFileSync(
@@ -67,10 +68,12 @@ test.describe("Single trace — populated LLM span (OpenAI)", () => {
 
   // A real LLM call is the whole point of this spec — without a key the
   // tokenUsage / modelName / latencyMs values can never populate.
-  test.skip(
-    !process?.env?.OPENAI_API_KEY,
-    "OPENAI_API_KEY required to run this test",
-  );
+  // A real LLM call is the whole point of this spec, so gate on provider HEALTH rather than on
+  // the mere presence of the env var: a key that exists but is drained blocks
+  // the backend past gunicorn's 300s timeout and kills the shard's Langflow
+  // worker (#1029).
+  const gate = providerSkipGate("openai");
+  test.skip(gate.skip, gate.reason);
 
   let bearerToken: string;
   let apiKey: string;

--- a/tests/tests-automations/regression/flow-functionality/freeze-path.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/freeze-path.spec.ts
@@ -5,16 +5,19 @@ import { addFlowToTestOnEmptyLangflow } from "../../../helpers/flows/add-flow-to
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { initialGPTsetup } from "../../../helpers/other/initialGPTsetup";
+import { providerSkipGate } from "../../../helpers/provider-setup/provider-health";
 
 test(
   "user must be able to freeze a path",
   { tag: ["@release", "@workspace", "@components"] },
 
   async ({ page }) => {
-    test.skip(
-      !process?.env?.OPENAI_API_KEY,
-      "OPENAI_API_KEY required to run this test",
-    );
+    // Three real builds run below, so gate on provider HEALTH rather than on
+    // the mere presence of the env var: a key that exists but is drained blocks
+    // the backend past gunicorn's 300s timeout and kills the shard's Langflow
+    // worker (#1029).
+    const gate = providerSkipGate("openai");
+    test.skip(gate.skip, gate.reason);
 
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../.env") });

--- a/tests/tests-automations/regression/flow-functionality/freeze-path.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/freeze-path.spec.ts
@@ -12,16 +12,17 @@ test(
   { tag: ["@release", "@workspace", "@components"] },
 
   async ({ page }) => {
-    // Three real builds run below, so gate on provider HEALTH rather than on
-    // the mere presence of the env var: a key that exists but is drained blocks
-    // the backend past gunicorn's 300s timeout and kills the shard's Langflow
-    // worker (#1029).
-    const gate = providerSkipGate("openai");
-    test.skip(gate.skip, gate.reason);
-
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
     }
+
+    // Three real builds run below, so gate on provider HEALTH rather than on
+    // the mere presence of the env var: a key that exists but is drained blocks
+    // the backend past gunicorn's 300s timeout and kills the shard's Langflow
+    // worker (#1029). After the .env load, so a key that lives only in .env is
+    // visible to the gate on a local run.
+    const gate = providerSkipGate("openai");
+    test.skip(gate.skip, gate.reason);
 
     await awaitBootstrapTest(page);
 

--- a/tests/tests-automations/regression/flow-functionality/general-bugs-shard-3836.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/general-bugs-shard-3836.spec.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../helpers/ui/open-advanced-options";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { providerSkipGate } from "../../../helpers/provider-setup/provider-health";
 
 // Capture every flow THIS page creates from its POST /api/v1/flows → 201
 // responses and delete them id-scoped in afterEach (repo convention, #490/#681).
@@ -47,10 +48,12 @@ test(
   "user must be able to send an image on chat using advanced tool on ChatInputComponent",
   { tag: ["@release", "@components"] },
   async ({ page }) => {
-    test.skip(
-      !process?.env?.OPENAI_API_KEY,
-      "OPENAI_API_KEY required to run this test",
-    );
+    // A real build runs below, so gate on provider HEALTH rather than on
+    // the mere presence of the env var: a key that exists but is drained blocks
+    // the backend past gunicorn's 300s timeout and kills the shard's Langflow
+    // worker (#1029).
+    const gate = providerSkipGate("openai");
+    test.skip(gate.skip, gate.reason);
 
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../.env") });

--- a/tests/tests-automations/regression/flow-functionality/general-bugs-shard-3836.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/general-bugs-shard-3836.spec.ts
@@ -48,16 +48,17 @@ test(
   "user must be able to send an image on chat using advanced tool on ChatInputComponent",
   { tag: ["@release", "@components"] },
   async ({ page }) => {
-    // A real build runs below, so gate on provider HEALTH rather than on
-    // the mere presence of the env var: a key that exists but is drained blocks
-    // the backend past gunicorn's 300s timeout and kills the shard's Langflow
-    // worker (#1029).
-    const gate = providerSkipGate("openai");
-    test.skip(gate.skip, gate.reason);
-
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
     }
+
+    // A real build runs below, so gate on provider HEALTH rather than on the mere
+    // presence of the env var: a key that exists but is drained blocks the backend
+    // past gunicorn's 300s timeout and kills the shard's Langflow worker (#1029).
+    // After the .env load, so a key that lives only in .env is visible to the gate
+    // on a local run.
+    const gate = providerSkipGate("openai");
+    test.skip(gate.skip, gate.reason);
 
     trackCreatedFlows(page);
     await awaitBootstrapTest(page);

--- a/tests/tests-automations/regression/flow-functionality/general-bugs-shard-3909.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/general-bugs-shard-3909.spec.ts
@@ -7,6 +7,15 @@ test(
   "user must be able to create a new flow clicking on New Flow button",
   { tag: ["@release", "@mainpage"] },
   async ({ page }) => {
+    // Left on env-var presence (#1029 audit): this test only asserts that the
+    // per-node run buttons RENDER (`button_run_chat output`, `button_run_language
+    // model`, …) after creating a project and opening Basic Prompting. It never
+    // clicks one, so no completion is driven and a dead key cannot produce the
+    // hung request that wedges a shard.
+    //
+    // As in lock-flow.spec.ts, the gate reads as vestigial — nothing here consumes
+    // OPENAI_API_KEY. Dropping it would make the test run where it currently
+    // skips, a behaviour change left to whoever revisits this spec.
     test.skip(
       !process?.env?.OPENAI_API_KEY,
       "OPENAI_API_KEY required to run this test",

--- a/tests/tests-automations/regression/flow-functionality/generalBugs-shard-1.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/generalBugs-shard-1.spec.ts
@@ -3,15 +3,18 @@ import path from "path";
 import { test } from "../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { initialGPTsetup } from "../../../helpers/other/initialGPTsetup";
+import { providerSkipGate } from "../../../helpers/provider-setup/provider-health";
 
 test(
   "should delete rows from table message",
   { tag: ["@release"] },
   async ({ page }) => {
-    test.skip(
-      !process?.env?.OPENAI_API_KEY,
-      "OPENAI_API_KEY required to run this test",
-    );
+    // A real build runs below, so gate on provider HEALTH rather than on
+    // the mere presence of the env var: a key that exists but is drained blocks
+    // the backend past gunicorn's 300s timeout and kills the shard's Langflow
+    // worker (#1029).
+    const gate = providerSkipGate("openai");
+    test.skip(gate.skip, gate.reason);
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
     }

--- a/tests/tests-automations/regression/flow-functionality/generalBugs-shard-1.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/generalBugs-shard-1.spec.ts
@@ -9,15 +9,18 @@ test(
   "should delete rows from table message",
   { tag: ["@release"] },
   async ({ page }) => {
-    // A real build runs below, so gate on provider HEALTH rather than on
-    // the mere presence of the env var: a key that exists but is drained blocks
-    // the backend past gunicorn's 300s timeout and kills the shard's Langflow
-    // worker (#1029).
-    const gate = providerSkipGate("openai");
-    test.skip(gate.skip, gate.reason);
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
     }
+
+    // A real build runs below, so gate on provider HEALTH rather than on the mere
+    // presence of the env var: a key that exists but is drained blocks the backend
+    // past gunicorn's 300s timeout and kills the shard's Langflow worker (#1029).
+    // After the .env load, so a key that lives only in .env is visible to the gate
+    // on a local run.
+    const gate = providerSkipGate("openai");
+    test.skip(gate.skip, gate.reason);
+
     await awaitBootstrapTest(page);
 
     await page.getByTestId("side_nav_options_all-templates").click();

--- a/tests/tests-automations/regression/flow-functionality/generalBugs-shard-10.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/generalBugs-shard-10.spec.ts
@@ -10,16 +10,17 @@ test(
   "freeze must work correctly",
   { tag: ["@release", "@api", "@components"] },
   async ({ page }) => {
-    // Two real builds and a playground reply run below, so gate on provider HEALTH rather than on
-    // the mere presence of the env var: a key that exists but is drained blocks
-    // the backend past gunicorn's 300s timeout and kills the shard's Langflow
-    // worker (#1029).
-    const gate = providerSkipGate("openai");
-    test.skip(gate.skip, gate.reason);
-
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
     }
+
+    // Two real builds and a playground reply run below, so gate on provider
+    // HEALTH rather than on the mere presence of the env var: a key that exists
+    // but is drained blocks the backend past gunicorn's 300s timeout and kills
+    // the shard's Langflow worker (#1029). After the .env load, so a key that
+    // lives only in .env is visible to the gate on a local run.
+    const gate = providerSkipGate("openai");
+    test.skip(gate.skip, gate.reason);
 
     const promptText = "answer as you are a dog";
     const newPromptText = "answer as you are a bird";

--- a/tests/tests-automations/regression/flow-functionality/generalBugs-shard-10.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/generalBugs-shard-10.spec.ts
@@ -4,15 +4,18 @@ import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { initialGPTsetup } from "../../../helpers/other/initialGPTsetup";
+import { providerSkipGate } from "../../../helpers/provider-setup/provider-health";
 
 test(
   "freeze must work correctly",
   { tag: ["@release", "@api", "@components"] },
   async ({ page }) => {
-    test.skip(
-      !process?.env?.OPENAI_API_KEY,
-      "OPENAI_API_KEY required to run this test",
-    );
+    // Two real builds and a playground reply run below, so gate on provider HEALTH rather than on
+    // the mere presence of the env var: a key that exists but is drained blocks
+    // the backend past gunicorn's 300s timeout and kills the shard's Langflow
+    // worker (#1029).
+    const gate = providerSkipGate("openai");
+    test.skip(gate.skip, gate.reason);
 
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../.env") });

--- a/tests/tests-automations/regression/flow-functionality/generalBugs-shard-3.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/generalBugs-shard-3.spec.ts
@@ -8,6 +8,7 @@ import { clearApiKeyBadges } from "../../../helpers/ui/clear-api-key-badges";
 import { initialGPTsetup } from "../../../helpers/other/initialGPTsetup";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { providerSkipGate } from "../../../helpers/provider-setup/provider-health";
 
 // Capture every flow THIS page creates from its POST /api/v1/flows → 201
 // responses and delete them id-scoped in afterEach — the legacy spec built a
@@ -50,10 +51,12 @@ test(
   async ({ page }) => {
     trackCreatedFlows(page);
 
-    test.skip(
-      !process?.env?.OPENAI_API_KEY,
-      "OPENAI_API_KEY required to run this test",
-    );
+    // A real playground send runs below, so gate on provider HEALTH rather than on
+    // the mere presence of the env var: a key that exists but is drained blocks
+    // the backend past gunicorn's 300s timeout and kills the shard's Langflow
+    // worker (#1029).
+    const gate = providerSkipGate("openai");
+    test.skip(gate.skip, gate.reason);
 
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../.env") });

--- a/tests/tests-automations/regression/flow-functionality/generalBugs-shard-3.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/generalBugs-shard-3.spec.ts
@@ -51,16 +51,17 @@ test(
   async ({ page }) => {
     trackCreatedFlows(page);
 
-    // A real playground send runs below, so gate on provider HEALTH rather than on
-    // the mere presence of the env var: a key that exists but is drained blocks
-    // the backend past gunicorn's 300s timeout and kills the shard's Langflow
-    // worker (#1029).
-    const gate = providerSkipGate("openai");
-    test.skip(gate.skip, gate.reason);
-
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
     }
+
+    // A real playground send runs below, so gate on provider HEALTH rather than on
+    // the mere presence of the env var: a key that exists but is drained blocks
+    // the backend past gunicorn's 300s timeout and kills the shard's Langflow
+    // worker (#1029). After the .env load, so a key that lives only in .env is
+    // visible to the gate on a local run.
+    const gate = providerSkipGate("openai");
+    test.skip(gate.skip, gate.reason);
     await awaitBootstrapTest(page);
 
     await page.waitForSelector('[data-testid="blank-flow"]', {

--- a/tests/tests-automations/regression/flow-functionality/lock-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/lock-flow.spec.ts
@@ -48,6 +48,16 @@ test(
   "user must be able to lock a flow and it must be saved",
   { tag: ["@stable", "@release", "@components", "@workspace"] },
   async ({ page }) => {
+    // Left on env-var presence (#1029 audit): this test never drives a
+    // completion. It creates a Basic Prompting flow from the starter, locks it,
+    // reopens, asserts the lock persisted, unlocks and deletes edges — the model
+    // is never run, so a dead key cannot produce the hung request that wedges a
+    // shard, and consulting provider health would only add a false skip.
+    //
+    // The gate looks vestigial: nothing here reads OPENAI_API_KEY. Removing it
+    // would make the test run where it currently skips, which is a behaviour
+    // change this sweep deliberately does not make — it belongs to whoever
+    // revisits this spec.
     test.skip(
       !process?.env?.OPENAI_API_KEY,
       "OPENAI_API_KEY required to run this test",

--- a/tests/tests-automations/regression/ui-ux/refresh-dropdown-list.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/refresh-dropdown-list.spec.ts
@@ -15,9 +15,7 @@ test(
 
     // Gate on provider HEALTH, not on the env var alone — a drained key would
     // block the backend past gunicorn's 300s timeout and kill the shard's
-    // Langflow worker (#1029). Evaluated after dotenv so a local `.env`-only key
-    // is seen.
-    //
+    // Langflow worker (#1029).
     // NOTE (#1029 audit): the gate names Anthropic but the test configures the
     // node with `initialGPTsetup` (OpenAI). The mismatch predates this change and
     // is preserved deliberately — this is an unvalidated inherited spec with no

--- a/tests/tests-automations/regression/ui-ux/refresh-dropdown-list.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/refresh-dropdown-list.spec.ts
@@ -3,19 +3,29 @@ import path from "path";
 import { test } from "../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { initialGPTsetup } from "../../../helpers/other/initialGPTsetup";
+import { providerSkipGate } from "../../../helpers/provider-setup/provider-health";
 
 test(
   "refresh dropdown list",
   { tag: ["@release", "@components"] },
   async ({ page }) => {
-    test.skip(
-      !process?.env?.ANTHROPIC_API_KEY,
-      "ANTHROPIC_API_KEY required to run this test",
-    );
-
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
     }
+
+    // Gate on provider HEALTH, not on the env var alone — a drained key would
+    // block the backend past gunicorn's 300s timeout and kill the shard's
+    // Langflow worker (#1029). Evaluated after dotenv so a local `.env`-only key
+    // is seen.
+    //
+    // NOTE (#1029 audit): the gate names Anthropic but the test configures the
+    // node with `initialGPTsetup` (OpenAI). The mismatch predates this change and
+    // is preserved deliberately — this is an unvalidated inherited spec with no
+    // `@stable`, so it runs nowhere today and a silent provider swap would be an
+    // unreviewed behavior change. Fixing the gate to name the provider the test
+    // actually drives belongs to whoever validates this spec.
+    const gate = providerSkipGate("anthropic");
+    test.skip(gate.skip, gate.reason);
 
     await page.goto("/");
     await awaitBootstrapTest(page);

--- a/tests/tests-automations/regression/ui-ux/settings-message-history.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/settings-message-history.spec.ts
@@ -33,6 +33,7 @@ import { navigateSettingsPages } from "../../../helpers/ui/go-to-settings";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
 import { FlowEditorPage, PlaygroundPage } from "../../../pages";
+import { providerSkipGate } from "../../../helpers/provider-setup/provider-health";
 
 const FIRST_MESSAGE = "Hello, how are you?";
 const SECOND_MESSAGE = "What is 2+2?";
@@ -73,14 +74,16 @@ test(
   "Settings > Messages displays sent messages in correct order with working filters",
   { tag: ["@stable", "@release", "@workspace", "@api", "@settings"] },
   async ({ page }) => {
-    test.skip(
-      !process?.env?.OPENAI_API_KEY,
-      "OPENAI_API_KEY required to run this test",
-    );
-
     if (!process.env.CI) {
       dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
     }
+
+    // Two real OpenAI completions run below, so gate on provider HEALTH, not on
+    // the env var alone — a drained key would otherwise block the backend past
+    // gunicorn's 300s timeout and kill the shard's Langflow worker (#1029).
+    // Evaluated after dotenv so a local `.env`-only key is seen.
+    const openaiGate = providerSkipGate("openai");
+    test.skip(openaiGate.skip, openaiGate.reason);
 
     const flowEditor = new FlowEditorPage(page);
     const playground = new PlaygroundPage(page);

--- a/tests/tests-automations/regression/ui-ux/settings-message-history.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/settings-message-history.spec.ts
@@ -81,7 +81,6 @@ test(
     // Two real OpenAI completions run below, so gate on provider HEALTH, not on
     // the env var alone — a drained key would otherwise block the backend past
     // gunicorn's 300s timeout and kill the shard's Langflow worker (#1029).
-    // Evaluated after dotenv so a local `.env`-only key is seen.
     const openaiGate = providerSkipGate("openai");
     test.skip(openaiGate.skip, openaiGate.reason);
 

--- a/tests/tests-automations/regression/ui-ux/voice-assistant.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/voice-assistant.spec.ts
@@ -7,6 +7,11 @@ test.skip(
   { tag: ["@release", "@workspace", "@api"] },
 
   async ({ page }) => {
+    // Left on env-var presence (#1029 audit): the enclosing `test.skip(...)` above
+    // makes this body unreachable — the test is permanently skipped pending the
+    // voice-assistant vs text-to-voice review in the TODO. It can never reach a
+    // provider call, so it cannot wedge a shard. Whoever un-skips it must swap
+    // this for `providerSkipGate("openai")`.
     test.skip(
       !process?.env?.OPENAI_API_KEY,
       "OPENAI_API_KEY required to run this test",


### PR DESCRIPTION
Closes #1029

## Problem

`collect-models` already records a provider as `inactive` in `providers.json` when its key is dead. Provider-**parametrized** specs honor that. Provider-**hardcoded** specs gated on the mere presence of the env var, so a key that exists but is drained still made the live call.

On run [30374528125](https://github.com/oriontech-me/langflow-e2e/actions/runs/30374528125) the Google key had exceeded its monthly spending cap. `models.json` mirrors the Langflow **catalog**, not the validation, so all 36 Google models were still listed, `resolveGeminiModel()` returned one, and the two Google tests in `language-model-regression.spec.ts` called it anyway. Each blocked a backend request past gunicorn's 300s timeout: six worker kill/restart cycles ~313s apart left shard 2's backend dead and produced **14 collateral timeouts** in specs that never touch Google.

## Approach

`tests/helpers/provider-setup/provider-health.ts` is the single implementation of the rule, reading the same `providers.json` the parametrized specs read.

- **Precedence:** missing env key first (more actionable — and for an unset key `collect-models` records only `"<KEY> not set"` anyway), then the recorded `inactive` reason, quoted verbatim into the skip.
- **Fails open** when `providers.json` is absent or unparseable. A fresh clone has no file (it is gitignored) and CI is allowed to run with a failed `Collect models` step (#980), so "no signal" must never skip the suite.
- `IGNORE_PROVIDER_HEALTH=1` overrides a stale local file (`collect-models` is not part of a targeted local run).
- The decision matrix is split from the I/O so it is unit-testable without a fixture on disk.

## The sweep

Every `test.skip` whose condition reads a provider env var was audited — **22 sites across 21 specs**. Twelve gates in nine specs now consume health:

| Spec | `@stable` | Provider |
|---|---|---|
| `language-model-regression` x3 | yes | openai / google / both |
| `rag-pipeline` (file-level) | yes | google |
| `settings-message-history` | yes | openai |
| `memory-history-regression` x2 | yes | openai |
| `general-bugs-agent-images-playground` | yes | openai |
| `chatInputOutputUser-shard-{0,1,2}` | no | openai |
| `general-bugs-agent-sum-duplicate-message-playground` | no | anthropic |
| `refresh-dropdown-list` | no | anthropic |

…and ten more that a **first, incomplete pass missed** (see *Audit method* below):

| Spec | `@stable` | Provider | Live call |
|---|---|---|---|
| `core-components/loop-component-regression` | yes | openai | **two sequential completions, 8-min budget** |
| `knowledge-ingestion-management/vector-store-index-query` | yes | **google** | file-level; embeds every chunk |
| `observability-monitoring/traces-detail-llm-span-populated` | yes | openai | *"A real LLM call is the whole point of this spec"* |
| `flow-functionality/freeze-path` | no | openai | three builds |
| `flow-functionality/general-bugs-shard-3836` | no | openai | one build |
| `flow-functionality/generalBugs-shard-1` | no | openai | one build |
| `flow-functionality/generalBugs-shard-10` | no | openai | two builds + playground reply |
| `flow-functionality/generalBugs-shard-3` | no | openai | playground send |

`vector-store-index-query` is the sharpest miss: **Google**, the provider whose spend cap wedged shard 2, and a direct sibling of `rag-pipeline.spec.ts` which the first pass did convert. `loop-component-regression` is worse than the case that motivated the issue — two hung calls under an 8-minute test timeout.

The switch test in `language-model-regression` drives two providers, so a dead key on either one gates it.

### Five gates deliberately keep env-var presence

Each documented in place, after checking what the test actually executes:

- `composio` — a tool provider, not an LLM provider; `collect-models` never probes it, so there is no health record to consume, and no completion is driven.
- `voice-assistant` — the enclosing `test.skip(...)` makes the body unreachable.
- `model-provider-api-key` — asserts the key-edit **surface**; a configured-but-drained key is a state it must still cover. No completion; its instance-side variable check is already stronger than env-var presence.
- `lock-flow` (`@stable`) — locks/unlocks a flow and deletes edges; never runs the model.
- `general-bugs-shard-3909` — asserts the run buttons *render*; never clicks one.

The last two read as **vestigial**: nothing in either test consumes `OPENAI_API_KEY`. Removing the gate would make them run where they currently skip — a behaviour change this sweep deliberately does not make.

`refresh-dropdown-list` gates on `ANTHROPIC_API_KEY` but configures the node with `initialGPTsetup` (**OpenAI**). The mismatch predates this PR; preserved and flagged in a comment rather than swapped silently, since the spec is unvalidated, carries no `@stable`, and a provider change there deserves its own review.

### Audit method

The first pass covered **12 of 22** sites: its grep was truncated with `head -60`, and a follow-up pass still missed one, because `process?.env?.X` (optional chaining) does not match a `process\.env` pattern. The complete set was found by parsing every `test.skip` condition rather than grepping lines. Re-verifiable:

```
providerSkipGate call sites: 22 across 19 spec files
env-var gates remaining:      4  (composio, voice-assistant, lock-flow, general-bugs-shard-3909)
```

## Evidence

Validated against a live Langflow (Nightly **1.12.0.dev7**) whose `providers.json` had `google: inactive` with the spend-cap error — the exact state of the run that motivated the issue — with `GOOGLE_API_KEY` present and confirmed configured by the preflight:

| Scenario | Result |
|---|---|
| `language-model-regression --grep Google` | **2 skipped** (previously ran and wedged the worker) |
| `rag-pipeline` (file-level gate) | **1 skipped** |
| `language-model-regression --grep "OpenAI provider"` — negative control | **1 passed (18.4s)**, real completion |
| `providers.json` removed | `readProviderHealth() = null` → gate returns RUN (fail-open) |

Zero flows touched in the hour after those runs — id-scoped cleanup leaked nothing.

Local gates: `typecheck` clean · `lint` 0 errors · `test:units` 61/61 (18 new) · `test:scripts` 89/89 · checklist coverage + guard · `regressions:check`.

```bash
npm run typecheck && npm run lint && npm run test:units && npm run test:scripts

npx playwright test tests/tests-automations/regression/core-functionality/llm-agents/language-model-regression.spec.ts \
  --grep "Google" --workers=1 --retries=0 --reporter=line   # → 2 skipped

npx playwright test tests/tests-automations/regression/core-functionality/llm-agents/language-model-regression.spec.ts \
  --grep "OpenAI provider" --workers=1 --retries=0 --reporter=line   # → 1 passed
```

## What only CI can prove

The issue's third *Done when* — verified on a run where at least one provider is inactive, with no shard wedge attributable to those specs — closes on the next `daily-stable`. If the Google cap is still in force, watch for: the Google tests reported **skipped** with the collected reason, no worker kill/restart cycle in the shard log, and none of the `apiRequestContext.get: Timeout 20000ms exceeded` collateral.

## Out of scope

Nineteen specs still carry an inline copy of `getProviderSkipReasons()`, plus a fourth hardcoded variant in `mcp-client-agent-gemini-tool-regression`. They already honor health correctly, so folding them into this helper is cleanup, not a fix — tracked separately.

