### PR TITLE
ci: bound the outage a wedged Langflow worker can cost

### DIFF
--- a/.claude/skills/langflow-e2e-infra/references/failure-modes.md
+++ b/.claude/skills/langflow-e2e-infra/references/failure-modes.md
@@ -18,7 +18,8 @@ specs into a low-concurrency lane · cap workers per shard · reproduce locally 
 `--workers=N` before blaming the product · cap the **outage per wedge** with
 `LANGFLOW_WORKER_TIMEOUT` on the service container (async worker ⇒ the value
 watches the event-loop heartbeat, not request duration, so it bounds a blocked loop
-without killing a slow live-LLM build — #1048).
+without killing a slow live-LLM build — #1048; Langflow's own docs get this
+backwards and advise raising it, so check the code, not `deployment-multi-worker.mdx`).
 
 **Docs:** `ISSUE-817-CI-RUNNER-SIZING.md`, `ISSUE-833-SHARDING-DESIGN.md`,
 `ISSUE-833-SHARDING-PLAN.md`; `@stable`-removal rules → `CONTRIBUTING.md` →

--- a/.claude/skills/langflow-e2e-infra/references/failure-modes.md
+++ b/.claude/skills/langflow-e2e-infra/references/failure-modes.md
@@ -15,7 +15,10 @@ spikes; `expandFocusedNode` / modal clicks time out; not reproducible at
 
 **Levers:** shard the `@stable` suite across runners · isolate heavy live-LLM
 specs into a low-concurrency lane · cap workers per shard · reproduce locally with
-`--workers=N` before blaming the product.
+`--workers=N` before blaming the product · cap the **outage per wedge** with
+`LANGFLOW_WORKER_TIMEOUT` on the service container (async worker ⇒ the value
+watches the event-loop heartbeat, not request duration, so it bounds a blocked loop
+without killing a slow live-LLM build — #1048).
 
 **Docs:** `ISSUE-817-CI-RUNNER-SIZING.md`, `ISSUE-833-SHARDING-DESIGN.md`,
 `ISSUE-833-SHARDING-PLAN.md`; `@stable`-removal rules → `CONTRIBUTING.md` →

--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -134,18 +134,31 @@ jobs:
           # (`worker_timeout` in lfx runtime settings), handed straight to
           # gunicorn's `timeout`. The worker class is LangflowUvicornWorker — an
           # ASYNC worker — so that timeout is a heartbeat watchdog on the event
-          # loop, NOT a per-request deadline: it fires when the loop stops
-          # ticking (the #922/#927 wedge), and a merely slow request that awaits
-          # network I/O keeps the heartbeat alive. A 4-minute live-LLM build is
-          # therefore unaffected.
+          # loop, NOT a per-request deadline: it fires when the loop stops ticking
+          # (the #922/#927 wedge). Build DURATION cannot trip it — a component's
+          # sync method runs off the loop in a thread (`asyncio.to_thread` in
+          # `custom_component/component.py`, `_get_output_result`), so even a
+          # blocking provider call keeps the heartbeat ticking and an 8-minute
+          # live-LLM build is unaffected.
+          #
+          # Langflow's own docs contradict this: `deployment-multi-worker.mdx`
+          # calls the value "how long a worker may handle a single request" and
+          # says to RAISE it for long agent runs (its heavy-agent profile uses
+          # 600). The code above does not support that reading. Do NOT restore a
+          # higher value on the strength of those docs.
           #
           # Why lower it: a wedged worker does not recover on its own — in run
           # 30410211167 gunicorn's kill is what restored service, twice, each
           # time a full 300 s after the loop stopped (one block began within
           # seconds of a failing Google call at 00:17:28 and was killed at
           # 00:22:28). Waiting the default out buys nothing and every second of
-          # it is served to unrelated specs as a dead backend. 120 s recycles the
-          # worker ~3 min earlier.
+          # it is served to unrelated specs as a dead backend.
+          #
+          # What 120 buys, precisely: the kill lands 60-120 s after the loop
+          # stops, not at a fixed 120 — gunicorn hands the worker `timeout / 2`
+          # and uvicorn refreshes the heartbeat only that often, so detection
+          # costs up to one notify interval. The default's equivalent band is
+          # 150-300 s.
           #
           # Measured, not assumed: a probe container of this image started with
           # LANGFLOW_WORKER_TIMEOUT=5 boots and serves /api/v1/version normally.

--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -130,6 +130,31 @@ jobs:
           # process-wide, not worker contention. The retry cap and the health gate
           # below are the other two halves.
           LANGFLOW_WORKERS: "1"
+          # Cap how long ONE wedge can cost (#1048). Langflow's default is 300 s
+          # (`worker_timeout` in lfx runtime settings), handed straight to
+          # gunicorn's `timeout`. The worker class is LangflowUvicornWorker — an
+          # ASYNC worker — so that timeout is a heartbeat watchdog on the event
+          # loop, NOT a per-request deadline: it fires when the loop stops
+          # ticking (the #922/#927 wedge), and a merely slow request that awaits
+          # network I/O keeps the heartbeat alive. A 4-minute live-LLM build is
+          # therefore unaffected.
+          #
+          # Why lower it: a wedged worker does not recover on its own — in run
+          # 30410211167 gunicorn's kill is what restored service, twice, each
+          # time a full 300 s after the loop stopped (one block began within
+          # seconds of a failing Google call at 00:17:28 and was killed at
+          # 00:22:28). Waiting the default out buys nothing and every second of
+          # it is served to unrelated specs as a dead backend. 120 s recycles the
+          # worker ~3 min earlier.
+          #
+          # Measured, not assumed: a probe container of this image started with
+          # LANGFLOW_WORKER_TIMEOUT=5 boots and serves /api/v1/version normally.
+          # Langflow's heavy init (components, starter projects, DB) runs in the
+          # PARENT process and gunicorn is launched afterwards with the app already
+          # built (`__main__.py`, progress step 6), so this ceiling does not bound
+          # startup — only a worker whose loop stops ticking once it is serving.
+          # Rollback is this one value.
+          LANGFLOW_WORKER_TIMEOUT: "120"
           # The nightly image ships LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false (a
           # security default): custom-component creation is disabled, which
           # hides the sidebar "New Custom Component" button and makes

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -205,6 +205,33 @@ jobs:
           # already default LANGFLOW_WORKERS=1 for this reason (#773) — the
           # service container was the one place missing it.
           LANGFLOW_WORKERS: "1"
+          # Cap how long ONE wedge can cost (#1048). Default is 300 s
+          # (`worker_timeout` in lfx runtime settings → gunicorn's `timeout`).
+          # LangflowUvicornWorker is ASYNC, so this is a heartbeat watchdog on the
+          # event loop, not a request deadline: it fires when the loop stops
+          # ticking (#922/#927), while a slow request that awaits I/O keeps the
+          # heartbeat alive — a long live-LLM build is unaffected.
+          #
+          # This job is where the cost was measured. Run 30410211167 (PR #1042)
+          # burned two full 300 s outages: the post-collect-models wedge the health
+          # gate below had to wait out (227 s, cleared only by gunicorn's kill),
+          # and a second block starting within seconds of a failing Google call.
+          # Four worker kill/restart cycles in 26 min, and the collateral landed on
+          # specs that make no LLM call at all (general-bugs-shard-3909 timing out
+          # on `add-project-button`). A wedged worker never self-heals, so waiting
+          # 300 s buys nothing; 120 s cuts each outage by ~3 min.
+          #
+          # This BOUNDS the damage, it does not prevent it: a spec whose API call
+          # has a 20 s timeout still dies inside a 120 s window. Eliminating
+          # collateral needs the provider-heavy specs not to share the backend with
+          # unrelated ones (serialization / low-concurrency lane) — see #1048.
+          #
+          # It does NOT bound startup, which was the obvious worry: a probe
+          # container of this image started with LANGFLOW_WORKER_TIMEOUT=5 boots and
+          # serves /api/v1/version fine, because Langflow's heavy init runs in the
+          # parent process and gunicorn is launched afterwards with the app already
+          # built (`__main__.py`, progress step 6). Rollback is this one value.
+          LANGFLOW_WORKER_TIMEOUT: "120"
           # Nightly image defaults LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false
           # (custom-component creation disabled → sidebar button hidden, API
           # 403). Enable it so the custom-component specs exercise the feature.

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -208,9 +208,9 @@ jobs:
           # Cap how long ONE wedge can cost (#1048). Default is 300 s
           # (`worker_timeout` in lfx runtime settings → gunicorn's `timeout`).
           # LangflowUvicornWorker is ASYNC, so this is a heartbeat watchdog on the
-          # event loop, not a request deadline: it fires when the loop stops
-          # ticking (#922/#927), while a slow request that awaits I/O keeps the
-          # heartbeat alive — a long live-LLM build is unaffected.
+          # event loop, not a request deadline — build duration cannot trip it, and
+          # Langflow's published docs describe it wrongly. Mechanism, the docs
+          # caveat, and the startup measurement: see daily-stable.yml.
           #
           # This job is where the cost was measured. Run 30410211167 (PR #1042)
           # burned two full 300 s outages: the post-collect-models wedge the health
@@ -219,18 +219,14 @@ jobs:
           # Four worker kill/restart cycles in 26 min, and the collateral landed on
           # specs that make no LLM call at all (general-bugs-shard-3909 timing out
           # on `add-project-button`). A wedged worker never self-heals, so waiting
-          # 300 s buys nothing; 120 s cuts each outage by ~3 min.
+          # 300 s buys nothing; at 120 the kill lands 60-120 s after the stall
+          # instead of 150-300 s.
           #
           # This BOUNDS the damage, it does not prevent it: a spec whose API call
-          # has a 20 s timeout still dies inside a 120 s window. Eliminating
+          # has a 20 s timeout still dies inside that window. Eliminating
           # collateral needs the provider-heavy specs not to share the backend with
           # unrelated ones (serialization / low-concurrency lane) — see #1048.
-          #
-          # It does NOT bound startup, which was the obvious worry: a probe
-          # container of this image started with LANGFLOW_WORKER_TIMEOUT=5 boots and
-          # serves /api/v1/version fine, because Langflow's heavy init runs in the
-          # parent process and gunicorn is launched afterwards with the app already
-          # built (`__main__.py`, progress step 6). Rollback is this one value.
+          # Rollback is this one value.
           LANGFLOW_WORKER_TIMEOUT: "120"
           # Nightly image defaults LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false
           # (custom-component creation disabled → sidebar button hidden, API

--- a/.github/workflows/weekly-stable.yml
+++ b/.github/workflows/weekly-stable.yml
@@ -42,6 +42,12 @@ jobs:
           LANGFLOW_AUTO_LOGIN: "true"
           LANGFLOW_SUPERUSER: langflow
           LANGFLOW_SUPERUSER_PASSWORD: langflow123
+          # Cap how long ONE wedge can cost (#1048) — see daily-stable.yml for the
+          # full reasoning and the measurement. Applied here too, while this
+          # workflow is disabled, so re-enabling the documented fallback does not
+          # bring back a 300 s outage per wedge. Note this workflow still lacks the
+          # #1011 health gate (tracked in #1045).
+          LANGFLOW_WORKER_TIMEOUT: "120"
           # Nightly image defaults LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false
           # (custom-component creation disabled → sidebar button hidden, API
           # 403). Enable it so the custom-component specs exercise the feature.

--- a/docs/collect-models.md
+++ b/docs/collect-models.md
@@ -90,6 +90,32 @@ but was drained still made the live call. On run 30374528125 that hung two Googl
 tests past gunicorn's 300s timeout, killed shard 2's Langflow worker six times, and
 produced 14 collateral timeouts in specs that never touch Google.
 
+### What the health gate does NOT cover
+
+`collect-models` records a **point-in-time probe**. The gate therefore covers a
+provider that is *durably* unusable — spend cap, revoked key, drained balance —
+and cannot cover a provider that is healthy when probed and limited minutes later.
+Run 30410211167 is the reference case: Google was recorded `✅ active` at 00:11:11
+and returned `429 RESOURCE_EXHAUSTED` (`retryDelay ~13.5s`, a per-minute limit) at
+00:15:46, inside the specs run. The record was 4 minutes old and correct when
+written, so no amount of gate logic — including expiring stale records via the
+`checkedAt` field `ProviderHealthRecord` omits — would have skipped those tests.
+
+The second half of the defence is therefore not prevention but a **bound on the
+damage**, and it lives in CI config, not here: `LANGFLOW_WORKER_TIMEOUT: "120"` on
+the service containers (#1048). Langflow's default is 300 s, handed to gunicorn as
+its `timeout`; because the worker class is async (`LangflowUvicornWorker`), that
+timeout watches the **event loop's heartbeat** rather than request duration — it
+fires on the wedge that a blocking provider call produces, and never on a merely
+slow live-LLM build that awaits I/O. A wedged worker does not recover on its own
+(gunicorn's kill is what restores service), so the lower ceiling turns each wedge
+from a ~300 s outage into a ~120 s one.
+
+That bounds collateral without eliminating it: a spec whose own API call has a 20 s
+timeout still fails inside a 120 s window. Removing the collateral entirely means
+not letting provider-heavy specs share a backend with unrelated ones — a
+serialization / low-concurrency lane, tracked in #1048.
+
 ### Env-keyed provider must be ACTIVE — with one exception
 
 A provider whose key IS configured but that ends `inactive` silently

--- a/docs/collect-models.md
+++ b/docs/collect-models.md
@@ -105,14 +105,24 @@ The second half of the defence is therefore not prevention but a **bound on the
 damage**, and it lives in CI config, not here: `LANGFLOW_WORKER_TIMEOUT: "120"` on
 the service containers (#1048). Langflow's default is 300 s, handed to gunicorn as
 its `timeout`; because the worker class is async (`LangflowUvicornWorker`), that
-timeout watches the **event loop's heartbeat** rather than request duration — it
-fires on the wedge that a blocking provider call produces, and never on a merely
-slow live-LLM build that awaits I/O. A wedged worker does not recover on its own
-(gunicorn's kill is what restores service), so the lower ceiling turns each wedge
-from a ~300 s outage into a ~120 s one.
+timeout watches the **event loop's heartbeat** rather than request duration. Build
+duration cannot trip it: a component's sync method runs off the loop in a thread
+(`asyncio.to_thread` in `custom_component/component.py`, `_get_output_result`), so
+even a blocking provider call keeps the heartbeat ticking. It fires on a stalled
+loop and nothing else. A wedged worker does not recover on its own (gunicorn's kill
+is what restores service), so the lower ceiling turns each wedge from a 150–300 s
+outage into a 60–120 s one — the spread, in both cases, is because gunicorn hands
+the worker `timeout / 2` and uvicorn refreshes the heartbeat only that often, so
+detection costs up to one notify interval.
+
+⚠️ Langflow's published docs describe this setting incorrectly:
+`deployment-multi-worker.mdx` calls it "how long a worker may handle a single
+request" and advises **raising** it for long agent runs (its heavy-agent profile
+uses `600`). That reading does not survive the code above — do not restore a higher
+value on the strength of those docs.
 
 That bounds collateral without eliminating it: a spec whose own API call has a 20 s
-timeout still fails inside a 120 s window. Removing the collateral entirely means
+timeout still fails inside that window. Removing the collateral entirely means
 not letting provider-heavy specs share a backend with unrelated ones — a
 serialization / low-concurrency lane, tracked in #1048.
 


### PR DESCRIPTION
Closes #1048

## Problem

#1029 / PR #1042 removed the predictable half of this failure class: a spec no longer calls a provider already recorded dead. Run [30410211167](https://github.com/oriontech-me/langflow-e2e/actions/runs/30410211167) showed the half that remains.

```
00:11:11  collect-models →  ✅ google (gemini-2.5-flash)          ← recorded ACTIVE
00:14:58  impacted specs start (after the #1044 gate waited out a wedge, 227 s)
00:15:46  error  Error calling model 'gemini-flash-latest' (RESOURCE_EXHAUSTED):
                 429 … 'retryDelay': '13.472270727s'              ← per-minute limit
00:17:28  error  Error calling model … (second occurrence)
00:22:28  critical  WORKER TIMEOUT  →  SIGKILL                    ← exactly 300 s later
```

`collect-models` records a **point-in-time probe**. The Google record was 4 minutes old and *correct* when written, so no gate logic reaches this case — not even expiring stale records via the `checkedAt` field `ProviderHealthRecord` omits. Four worker kill/restart cycles in a 26-minute run, and the collateral landed on specs that make no LLM call at all (`general-bugs-shard-3909` timing out on `add-project-button`).

## Approach — bound the damage, since the cause is unreachable

Langflow's `worker_timeout` (default **300**, `lfx/services/settings/groups/runtime.py:102`, `env_prefix="LANGFLOW_"`) is handed straight to gunicorn's `timeout` (`__main__.py:461,578`). The worker class is `LangflowUvicornWorker` — **async** (`server.py:86`) — so that value watches the **event loop's heartbeat**, not request duration:

- it fires when the loop stops ticking — the #922/#927 wedge;
- **build duration cannot trip it at all.** A component's sync method is dispatched off the loop in a thread — `await asyncio.to_thread(method)` in `custom_component/component.py` (`_get_output_result`) — so even a fully blocking provider call keeps the heartbeat ticking. The guarantee does not depend on the provider client being async: an 8-minute live-LLM build (`loop-component-regression`) is unaffected either way.

⚠️ **Langflow's own docs contradict this, in the direction that would undo the change.** `deployment-multi-worker.mdx` describes the value as "how long a worker may handle a single request before Gunicorn kills it" and advises **raising** it for long agent runs — its heavy-agent profile ships `600`; `environment-variables.mdx` and `configuration-cli.mdx` are merely vague. The code above does not support that reading, so anyone debugging a future timeout with those docs in hand has a documented reason to revert this value. The workflow comments now say so explicitly. Worth reporting upstream separately: on a multi-worker deployment that advice keeps a wedged worker serving dead traffic for 10 minutes, for a reason that does not hold.

Incidentally, `600` in that heavy profile against `120` here is not a contradiction we invented — the doc's own small/dev profile (4–8 GB RAM, which is our runner class) uses exactly `120`.

A wedged worker never self-heals: in run 30410211167 gunicorn's kill is what restored service, twice, each a full 300 s after the loop stopped. Waiting the default out buys nothing and every second of it is served to whatever else is in flight as a dead backend.

**`LANGFLOW_WORKER_TIMEOUT: "120"`** therefore has the kill land **60–120 s** after the loop stalls, not at a fixed 120: gunicorn hands the worker `timeout / 2` (`arbiter.py`) and uvicorn refreshes the heartbeat only that often (`timeout_notify`, `uvicorn/workers.py` → `server.py` `on_tick`), so detection costs up to one notify interval. The default's equivalent band is 150–300 s.

Set on the three workflows that run the `@stable` and PR lanes — `weekly-stable.yml` included, since it is the documented fallback and re-enabling it should not resurrect a 300 s outage. (It still lacks both #1011 guards; tracked in #1045.) `nightly.yml` and `manual.yml` also start a Langflow service container and are **not** covered here; they carry none of the #1011 guard family today (not even `LANGFLOW_WORKERS: "1"`).

## Is it safe? — the historical check

**The watchdog does not fire in normal operation.** All four shards of the 2026-07-27 daily ([30261409427](https://github.com/oriontech-me/langflow-e2e/actions/runs/30261409427)) contain **zero** `WORKER TIMEOUT` — including the two that went red, whose failures were genuine assertions (MCP echo, Anthropic provider). So on a healthy run the event loop never stalls anywhere near even the *old* 300 s ceiling, and lowering it changes nothing about that run.

**The wedge signature never appears as a recorded test failure.** Across the 20 days in `reports/daily-history.jsonl` — 201 failures — **0** carry a backend-unreachable `error_signature`. That is not because the wedge is harmless: on the daily it kills the shard *before* the specs, so it shows up as a **lost day**, which is exactly what the 2026-07-28 entry is (`failures: []`, run 30351107916 → #1011). The cost is invisible in the per-test channel by construction.

**Residual risk, stated plainly — and it is narrower than it looks.** The newly-exposed band is a loop stall of **~60–300 s** (wider than a naive "120–300", per the notify-interval arithmetic above: blocks under 150 s were previously always safe). But the thing that would have to fall in that band is a stall *on the event loop* — and the `to_thread` dispatch above means legitimate component work, however slow or however blocking, does not run there. Nothing in the history shows such a stall either (zero `WORKER TIMEOUT` in normal shards rules out >300 s; the shorter bands are not observable with current telemetry). The asymmetry is what makes it acceptable:

| | Cost |
|---|---|
| **False kill** (hypothetical) | one request fails, backend serving again in ~12 s, absorbed by Playwright's 2 CI retries |
| **What it prevents** (observed) | 300 s of dead backend per wedge → mass collateral, or an entire shard/day lost |

Secondary effect: more frequent kills mean more mid-build kills, so slightly more partially-written flow state. Every spec touched here uses id-scoped cleanup, so orphans stay handled.

## Expected gain

- Each wedge costs at most ~132 s (120 s detection + ~12 s restart) and as little as ~72 s, instead of ~162–312 s.
- On run 30410211167 that is ~10 min of dead backend reduced to ~4 min or less, and the `pr-validation` health gate would have closed in roughly half the attempts (it needed 18 / 227 s).
- The daily's 300 s gate keeps ≥2.3× the margin it needs to ride out a wedge, which also makes #1045's "settle one deadline" question easier.

It **bounds** collateral, it does not eliminate it: a spec whose own API call times out at 20 s still dies inside that window. Eliminating it means provider-heavy specs not sharing a backend with unrelated ones — a serialization / low-concurrency lane, left open on #1048 with its wall-clock cost.

## Validation

Structural: all three workflows parse (`js-yaml`) and carry the value on the right service env.

```
daily-stable.yml     test               WORKER_TIMEOUT= 120
pr-validation.yml    e2e                WORKER_TIMEOUT= 120
weekly-stable.yml    e2e-weekly-stable  WORKER_TIMEOUT= 120
```

Empirical — and it **corrected the change**. The obvious worry was that the ceiling also bounds worker startup. A probe container of this image on port 7861 with `LANGFLOW_WORKER_TIMEOUT=5` boots and answers `/api/v1/version` normally, because Langflow's heavy init (components, starter projects, DB) runs in the **parent** process and gunicorn is launched afterwards with the app already built (`__main__.py`, progress step 6). The first version of these comments claimed a "~4× boot headroom"; that claim was wrong and was replaced with the measurement.

```bash
podman run -d --name lf-wt-probe -p 7861:7860 -e LANGFLOW_AUTO_LOGIN=true \
  -e LANGFLOW_WORKERS=1 -e LANGFLOW_WORKER_TIMEOUT=5 langflowai/langflow-nightly:latest
sleep 75 && curl -s http://localhost:7861/api/v1/version   # → answers: startup is not bounded
podman rm -f lf-wt-probe
```

Local gates: `typecheck` 0 errors · `lint` 0 errors · `test:units` 64/64.

## What only CI can prove

The kill path cannot be exercised locally — there is no way to block the event loop on demand, and #927 already recorded that the wedge does not reproduce outside CI. Watch the next wedge: `WORKER TIMEOUT` should appear ~120 s after the loop stops instead of 300 s, and `pr-validation`'s health gate should close in roughly half the attempts.

