### PR TITLE
feat(provider-setup): build-probe a provider's component, not just its API key (#900)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -46,6 +46,7 @@
 - [-] Google Generative AI Provider Setup → `helpers/provider-setup/setup-google.ts`
 - [-] Provider Map (`providerSetupMap`) — central registration point → `helpers/provider-setup/index.ts`
 - [-] Provider validation via API (credit, valid key) → `helpers/provider-setup/collect-models.ts`
+- [-] Provider build-axis probe (registry key present + component instantiates) → `helpers/provider-setup/probe-component-buildable.ts`
 - [-] Collection of available models via UI (Settings → Model Providers) → `helpers/provider-setup/collect-models.ts`
 - [-] `providers.json` — status of each provider (active/inactive + reason) → `data/providers.json`
 - [-] `models.json` — list of models per provider → `data/models.json`
@@ -384,6 +385,7 @@
 
 #### 7.1 Provider Collection and Validation
 - [x] Validate API keys of all providers via real call → `collect-models.spec.ts`
+- [x] Validate the running build can instantiate each provider's component (registry + build, not just the key) → `collect-models.spec.ts`
 - [x] Collect available models per provider via UI → `collect-models.spec.ts`
 - [x] Inactive providers appear as skipped in tests with reason → `agent-component-regression.spec.ts`
 - [x] Configure provider API key via Save Configuration (first setup) → `collect-models.spec.ts`

--- a/docs/collect-models.md
+++ b/docs/collect-models.md
@@ -9,9 +9,27 @@
 This is a utility spec — not a regression assertion test. It exists to populate two local data files used by LLM agent and model-provider specs as preconditions:
 
 - `tests/helpers/provider-setup/data/models.json` — list of models available per provider (collected from Settings → Model Providers UI)
-- `tests/helpers/provider-setup/data/providers.json` — provider status (`active` / `inactive`) validated via real API calls
+- `tests/helpers/provider-setup/data/providers.json` — provider status (`active` / `inactive`), validated on two independent axes: the raw API key works, **and** the running Langflow build can actually instantiate that provider's component
 
 If this spec is not run before the LLM agent specs, those specs fall back to a hardcoded model and may skip or fail due to missing provider configuration.
+
+### The two axes, and why the second one exists (#900)
+
+A provider is only usable when **both** hold, and they fail independently:
+
+| Axis | Question | Failure it catches |
+|---|---|---|
+| **Key** | does the provider's own cloud API accept this key? | drained credit, revoked key, spend cap |
+| **Build** | can *this Langflow image* instantiate the provider's component? | the component's distribution or its `langchain-*` runtime package is missing from the image |
+
+Before #900 only the first was checked. The key probe calls the provider's API
+**directly, upstream of Langflow**, so a perfectly valid key on an image that
+cannot build the model recorded a false `active` — and the real failure surfaced
+tens of layers downstream as a generic node-build timeout. It cost a full triage
+cycle each time it happened: #898 (`langchain-google-genai`, upstream LE-1974,
+~17 Google `@stable` specs) and #907 (`langchain-groq` / `langchain-mistralai`,
+upstream LE-1987). The build axis converts that into one attributed failure at
+collect time.
 
 ---
 
@@ -44,7 +62,18 @@ surface (the #505 lesson).
    (#570). It stops early on the first model that validates — or, when the SAME
    error repeats 3× in a row, on the conclusion that the error does not depend on
    the model at all (#1011; see Validation criterion).
-5. Write the provider status records to `data/providers.json`
+5. **Probe the build axis** (#900), in two layers, before the records are written:
+   a. **Catalog.** One `GET /api/v1/all` for every provider at once. Each provider
+      declares the exact component keys it needs (chat + embeddings); a key absent
+      from the registry means its distribution is not installed.
+   b. **Buildability.** Every component that passed (a) is placed in **one**
+      throwaway flow and built via `POST /api/v1/build/{flow_id}/flow`. The flow is
+      deleted in a `finally`. A registry hit does **not** prove the component can
+      build — see the contract table below.
+6. Write the provider status records to `data/providers.json`, merging both axes:
+   a build-axis failure records `inactive` with a reason that names the missing
+   **layer** (distribution vs. runtime package) and, when Langflow reports it, the
+   exact module
 
 ---
 
@@ -67,6 +96,48 @@ contract; the SPEC now verifies the outcome):
 A provider with a key that genuinely fails its probe (e.g. a model the
 account cannot access) is a legitimate `inactive` — recorded, logged, not a
 test failure.
+
+### The build axis — what makes it force-failable
+
+- **A provider whose component is missing from the registry is `inactive`**, with a
+  reason naming the *distribution* layer. Distinctive observable: the provider's
+  declared component key is absent from `GET /api/v1/all`.
+- **A provider whose component IS in the registry but cannot build is `inactive`**,
+  with a reason naming the *runtime package* layer. Distinctive observable: the
+  vertex's `errorMessage` carries a packaging signature
+  (`No module named '<pkg>'` / `not installed in this environment` /
+  `Could not import`), as opposed to any other build error.
+- **A credentials error is a PASS on this axis, not a failure.** It proves the
+  client class was imported and constructed — the probe got as far as rejecting a
+  blank key, which is exactly what "the package is present" looks like. Treating it
+  as a failure would make the gate permanently red.
+- **A build-axis `inactive` fails the spec loudly, on its own assert.** Every reason
+  this axis writes is stamped with a `build axis: ` prefix, and a dedicated step —
+  *"this Langflow build can instantiate every provider's component"* — asserts that
+  no provider carries one. It is deliberately **not** folded into the existing
+  "every env-keyed provider is ACTIVE" check: that check skips any provider whose
+  env key is unset, but an unbuildable component is a broken **image**, a verdict
+  that does not depend on whether anyone configured a key. Without the separate
+  step, a run without `ANTHROPIC_API_KEY` would let a genuinely unbuildable
+  Anthropic component pass in silence — the very silent-skip class this issue
+  removes. (A packaging reason also fails the env-keyed check, since it does not
+  match `BILLING_OR_QUOTA`; the two overlap for keyed providers and only the new
+  step covers unkeyed ones.)
+- **The probe fails OPEN on its own infrastructure.** An unreachable registry, a
+  build endpoint error, or a probe timeout leaves the key-axis verdict untouched and
+  logs a warning. The gate must never convert a runner-side hiccup into an
+  `inactive` provider — the same rule `readProviderHealth` and
+  `TRANSIENT_TRANSPORT` (#1011) already encode.
+
+### No paid call, ever
+
+Every `SecretStrInput` on the probed components is neutralised before the build
+(`value: ""`, `load_from_db: false`). This is load-bearing, not hygiene: the
+registry template ships `api_key` as `{ value: "OPENAI_API_KEY", load_from_db:
+true }`, so an un-neutralised probe would load the **global variable
+`collect-models` itself just saved** and the default `text_output` output would
+invoke the model for real. Measured on 1.12.0.dev8 with the neutralisation in
+place: all five components fail on missing credentials, none reaches the network.
 
 ### Who consumes the recorded health
 
@@ -137,6 +208,22 @@ exists to prevent. Two consequences, both load-bearing:
 - `src/frontend/src/pages/SettingsPage/pages/GlobalVariablesPage/index.tsx` — Settings navigation; if the `sidebar-nav-Model Providers` testid changes, the spec cannot reach the provider list
 - `src/frontend/src/components/core/modelProviderTag/` — provider list items (testids like `provider-item-OpenAI`) and model toggles (`llm-toggle-*`); any rename breaks model collection
 - `src/frontend/src/components/ui/button` — Save / Replace button labels; if these change the API key save step is silently skipped and `models.json` ends up empty
+- `GET /api/v1/all` — the component registry the catalog layer reads. It returns
+  `{ category: { ComponentType: template } }`; note the **`component_display_names`
+  pseudo-category**, a lowercased echo of every type that the probe must skip so a
+  component is not counted twice
+- `POST /api/v1/build/{flow_id}/flow` + `GET /api/v1/build/{job_id}/events` — the
+  build layer. It requires a **persisted** flow (passing `data` inline against a
+  random UUID returns `404 Flow with id … not found`), which is why the probe
+  creates and deletes one
+- The component keys themselves — `ext:openai:OpenAIModelComponent@official`,
+  `ext:openai:OpenAIEmbeddingsComponent@official`,
+  `ext:anthropic:AnthropicModelComponent@official`,
+  `ext:google:GoogleGenerativeAIComponent@official`,
+  `ext:google:GoogleGenerativeAIEmbeddingsComponent@official`. These are the
+  1.12 `lfx-bundles` per-vendor names (#1040); a rename upstream makes the catalog
+  layer report the provider absent, which is a loud failure by design rather than a
+  silent pass
 
 ---
 
@@ -145,7 +232,19 @@ exists to prevent. Two consequences, both load-bearing:
 - Does not assert that specific models are returned — only that the collection and file-write succeed
 - Does not validate provider responses in detail — only checks HTTP status 2xx vs non-2xx
 - Does not configure providers that lack an API key in the environment
-- **Does not verify Langflow can BUILD a provider's model — only that the raw API key works.** The status probe calls the provider's own API directly, upstream of Langflow, so it cannot detect a missing server-side integration package. A nightly that ships without `langchain-google-genai` still records google `active` here, yet every Google chat/embedding build inside Langflow raises an `ImportError` and the affected `@stable` specs fail downstream as a misleading node-build timeout (root cause + impact: [#898]; upstream: LE-1974). A faithful check would have to build a Language Model flow per provider and inspect the error — no standalone endpoint triggers the class import (`/api/v1/models/*` return static metadata only) — so that build-probe hardening was deferred to [#900].
+- **Does not prove the model produces a good answer.** The build axis stops at "the
+  component instantiates"; whether Langflow's Agent can actually drive the settled
+  model is the `agent-*` family's job (the #570 lesson — `gpt-5.6` passed the key
+  probe and returned empty replies through the Agent).
+- **Does not cover providers outside `providerConfigMap`.** Groq and Mistral are
+  deliberately not bundled in the image (product decision, #1039); they are gated
+  per-spec by `isProviderComponentAvailable` instead. Keeping them out of this gate
+  is what makes a *declared per-provider expectation map* unnecessary — every
+  provider this spec knows about is one the image is expected to ship, so "component
+  missing" is unambiguously a failure here.
+- **Does not detect a package that is present but broken at call time.** An
+  incompatible `langchain-*` version that imports cleanly and fails on `invoke`
+  (the #643 class) builds fine and passes this axis.
 
 ---
 
@@ -164,6 +263,48 @@ exists to prevent. Two consequences, both load-bearing:
 ---
 
 ## Notes *(optional)*
+
+### Why the catalog check alone is NOT enough (measured, 1.12.0.dev8)
+
+The obvious cheap design — "scan `GET /api/v1/all`, done" — is wrong, and the
+reason is an upstream implementation detail that varies **per component**: where
+the `langchain-*` import sits. Read from the installed sources in the running
+container:
+
+| Component | `langchain-*` import site | Package missing ⇒ |
+|---|---|---|
+| `OpenAIModelComponent` | module level (`from langchain_openai import ChatOpenAI`) | module fails to import → **absent from the registry** |
+| `OpenAIEmbeddingsComponent` | module level | absent |
+| `GoogleGenerativeAIComponent` | module level, transitively via `lfx.base.models.google_generative_ai_model` | absent |
+| `GoogleGenerativeAIEmbeddingsComponent` | module level | absent |
+| `AnthropicModelComponent` | **lazy, inside `build_model()`** | **registers normally, fails at BUILD** |
+
+So the failure mode #1039 first hit on Groq is **not** a Groq quirk — among the
+three providers this spec covers, Anthropic has exactly that shape today.
+
+Proven end to end rather than reasoned about: hiding
+`site-packages/langchain_anthropic` and restarting the backend leaves
+`ext:anthropic:AnthropicModelComponent@official` **present** in `/api/v1/all` (the
+catalog layer returns *available* — a false positive) while the build layer
+reports
+
+```
+No module named 'langchain_anthropic'. This flow needs a Python package that is
+not installed in this environment.
+```
+
+A restart is required to observe it: the import is cached in `sys.modules`, so
+hiding the package under a warm worker changes nothing.
+
+**Do not "simplify" this back to one layer.** Each layer catches a shape the other
+cannot, and which shape a given provider produces is decided upstream, without
+notice, by where a maintainer happens to put an `import`.
+
+### Cost
+
+All five components build in **one** flow, as disconnected vertices — one create,
+one build, one delete. Measured: **~9 s wall**, zero paid calls. Building them
+per-provider instead would multiply the flow round-trips for no added signal.
 
 - In CI (`daily-stable.yml`) this spec runs as a dedicated **Collect models** step before the `@stable` suite, ensuring `models.json` is on disk before Playwright's collection phase. The step uses `continue-on-error: true` so a missing API key does not block the rest of the run.
 - **Double-run in the daily (analyzed, benign):** with `@stable` the spec ALSO runs inside the suite. The in-suite run re-saves the same keys (the exact flow `openai-provider`/`google-provider` test 1 already exercise in-suite) and rewrites the JSONs with equivalent content; workers read the files at module load, so a mid-suite rewrite does not change already-collected test targets.

--- a/docs/collect-models.md
+++ b/docs/collect-models.md
@@ -49,20 +49,11 @@ surface (the #505 lesson).
 
 ## Step by step *(required)*
 
-1. Navigate to Settings → Model Providers
-2. For each configured provider (OpenAI, Anthropic, Google):
-   a. Click the provider entry to open its configuration panel
-   b. If an API key is present in the environment and the panel is visible, enter the key and click Save / Replace
-   c. Wait for model toggles to load; enable any that are unchecked
-   d. Record each model name paired with the provider
-3. Write the collected model list to `data/models.json`
-4. For each provider, call its API directly to confirm the key is active. The
-   probe walks the collected catalog in preference order rather than trusting a
-   single lead model, so one gated/preview model cannot disable a whole provider
-   (#570). It stops early on the first model that validates — or, when the SAME
-   error repeats 3× in a row, on the conclusion that the error does not depend on
-   the model at all (#1011; see Validation criterion).
-5. **Probe the build axis** (#900), in two layers, before the records are written:
+1. **Probe the BUILD axis first** (#900), on a still-idle backend. The order is
+   load-bearing — see *The build axis must run BEFORE the UI load* in the Notes. This
+   step needs only the component registry: not `models.json`, not the keys. Two
+   layers:
+
    a. **Catalog.** One `GET /api/v1/all` for every provider at once. Each provider
       declares the exact component keys it needs (chat + embeddings); a key absent
       from the registry means its distribution is not installed.
@@ -72,6 +63,19 @@ surface (the #505 lesson).
       20 s budget. On timeout the job is **cancelled** and that component is
       recorded `unknown`. The flow is deleted in a `finally`. A registry hit does
       **not** prove the component can build — see the contract table below.
+2. Navigate to Settings → Model Providers
+3. For each configured provider (OpenAI, Anthropic, Google):
+   a. Click the provider entry to open its configuration panel
+   b. If an API key is present in the environment and the panel is visible, enter the key and click Save / Replace
+   c. Wait for model toggles to load; enable any that are unchecked
+   d. Record each model name paired with the provider
+4. Write the collected model list to `data/models.json`
+5. **Probe the KEY axis:** for each provider, call its API directly to confirm the
+   key is active. The probe walks the collected catalog in preference order rather
+   than trusting a single lead model, so one gated/preview model cannot disable a
+   whole provider (#570). It stops early on the first model that validates — or, when
+   the SAME error repeats 3× in a row, on the conclusion that the error does not
+   depend on the model at all (#1011; see Validation criterion).
 6. Write the provider status records to `data/providers.json`, merging both axes:
    a build-axis failure records `inactive` with a reason that names the missing
    **layer** (distribution vs. runtime package) and, when Langflow reports it, the
@@ -314,6 +318,27 @@ hiding the package under a warm worker changes nothing.
 **Do not "simplify" this back to one layer.** Each layer catches a shape the other
 cannot, and which shape a given provider produces is decided upstream, without
 notice, by where a maintainer happens to put an `import`.
+
+### The build axis must run BEFORE the UI load
+
+`collect-models` saves three provider keys through the Settings UI, and each save
+makes Langflow validate the provider and fetch its model list. On the single-worker
+CI backend that is enough load to wedge it — `pr-validation.yml` and
+`daily-stable.yml` both carry a dedicated *"Wait for the backend to recover from the
+collect-models load"* step immediately after this spec for exactly that reason
+(#922/#927/#1044).
+
+The build probe was first placed *after* that load, concurrently with the key probe.
+Measured on PR #1051's CI run, twice: **every** component timed out at 20 s — several
+on the `POST` that merely *starts* the build — so the axis reported `unknown` for all
+three providers and delivered no signal at all, while gunicorn logged two
+`WORKER TIMEOUT`s. Locally, against an idle backend, the same probe takes ~9 s.
+
+The probe depends on nothing the UI collection produces — not `models.json`, not the
+saved keys, only the component registry. So it runs first, on an idle backend. **Do
+not move it back after the collection**; the failure is not subtle but it is silent
+in the sense that matters: the axis degrades to `unknown` and the run still goes
+green.
 
 ### The `unknown` state is not decoration — it is a CI regression made permanent
 

--- a/docs/collect-models.md
+++ b/docs/collect-models.md
@@ -66,10 +66,12 @@ surface (the #505 lesson).
    a. **Catalog.** One `GET /api/v1/all` for every provider at once. Each provider
       declares the exact component keys it needs (chat + embeddings); a key absent
       from the registry means its distribution is not installed.
-   b. **Buildability.** Every component that passed (a) is placed in **one**
-      throwaway flow and built via `POST /api/v1/build/{flow_id}/flow`. The flow is
-      deleted in a `finally`. A registry hit does **not** prove the component can
-      build — see the contract table below.
+   b. **Buildability.** Every component that passed (a) goes into **one** throwaway
+      flow as a disconnected vertex, and each is then built **individually** via
+      `POST /api/v1/build/{flow_id}/flow?stop_component_id=<node>`, with its own
+      20 s budget. On timeout the job is **cancelled** and that component is
+      recorded `unknown`. The flow is deleted in a `finally`. A registry hit does
+      **not** prove the component can build — see the contract table below.
 6. Write the provider status records to `data/providers.json`, merging both axes:
    a build-axis failure records `inactive` with a reason that names the missing
    **layer** (distribution vs. runtime package) and, when Langflow reports it, the
@@ -123,11 +125,15 @@ test failure.
   removes. (A packaging reason also fails the env-keyed check, since it does not
   match `BILLING_OR_QUOTA`; the two overlap for keyed providers and only the new
   step covers unkeyed ones.)
-- **The probe fails OPEN on its own infrastructure.** An unreachable registry, a
-  build endpoint error, or a probe timeout leaves the key-axis verdict untouched and
-  logs a warning. The gate must never convert a runner-side hiccup into an
-  `inactive` provider — the same rule `readProviderHealth` and
-  `TRANSIENT_TRANSPORT` (#1011) already encode.
+- **The probe fails OPEN on its own infrastructure — but never SILENTLY.** An
+  unreachable registry, a build-endpoint error, or a component that does not build
+  within its budget yields a third state, **`unknown`**, distinct from both `ok` and
+  `failed`. It leaves the key-axis verdict untouched, is never written to
+  `providers.json`, and is logged as `⚠️ … [NOT PROVEN — this run gives no build
+  signal for it]`. The gate must never convert a runner-side hiccup into an
+  `inactive` provider (the rule `readProviderHealth` and `TRANSIENT_TRANSPORT`
+  (#1011) already encode) **and must never report an unproven component as
+  proven** — see *The `unknown` state is not decoration* below.
 
 ### No paid call, ever
 
@@ -212,10 +218,19 @@ exists to prevent. Two consequences, both load-bearing:
   `{ category: { ComponentType: template } }`; note the **`component_display_names`
   pseudo-category**, a lowercased echo of every type that the probe must skip so a
   component is not counted twice
-- `POST /api/v1/build/{flow_id}/flow` + `GET /api/v1/build/{job_id}/events` — the
-  build layer. It requires a **persisted** flow (passing `data` inline against a
-  random UUID returns `404 Flow with id … not found`), which is why the probe
-  creates and deletes one
+- `POST /api/v1/build/{flow_id}/flow` + `GET /api/v1/build/{job_id}/events` +
+  `POST /api/v1/build/{job_id}/cancel` — the build layer. Three properties it
+  depends on, all measured rather than assumed:
+  - it requires a **persisted** flow (passing `data` inline against a random UUID
+    returns `404 Flow with id … not found`), which is why the probe creates and
+    deletes one;
+  - `stop_component_id=<node>` restricts the build to that single vertex — verified
+    on 1.12.0.dev8, where each call emitted exactly one `end_vertex`, for the
+    requested node;
+  - `event_delivery` defaults to **`polling`**, and the events `GET` is a
+    **long-poll**: it blocks until the build finishes and then returns the whole
+    event list at once. There is no incremental read to lean on, which is why the
+    budget is enforced per component and paired with `cancel`
 - The component keys themselves — `ext:openai:OpenAIModelComponent@official`,
   `ext:openai:OpenAIEmbeddingsComponent@official`,
   `ext:anthropic:AnthropicModelComponent@official`,
@@ -300,11 +315,36 @@ hiding the package under a warm worker changes nothing.
 cannot, and which shape a given provider produces is decided upstream, without
 notice, by where a maintainer happens to put an `import`.
 
+### The `unknown` state is not decoration — it is a CI regression made permanent
+
+The first CI run of this mechanism (PR #1051) built all five components in **one**
+request. It exceeded the budget, the axis fell back to fail-open — and still logged
+`build axis: ✅ openai / ✅ anthropic / ✅ google`, because fail-open and real
+success produced identical output. The probe had proven nothing and said everything
+was fine. Two things went wrong, both now fixed and both worth stating plainly
+because they are easy to reintroduce:
+
+1. **Fail-open must never look like a pass.** A verdict the probe could not reach
+   is `unknown`, printed as `⚠️ … [NOT PROVEN]`, never `✅`. A gate whose failure
+   mode is indistinguishable from its success is ceremony.
+2. **Stopping waiting and stopping working must be the same act.** The client gave
+   up at its timeout while the server kept building; gunicorn hit `WORKER TIMEOUT`
+   and the next CI step found the backend unreachable for 120 s. The probe now
+   `POST`s to `/api/v1/build/{job_id}/cancel` on timeout.
+
+The batching was the third mistake: one over-budget component discarded the signal
+for *all* of them, and the log could not even name which one was slow.
+
 ### Cost
 
-All five components build in **one** flow, as disconnected vertices — one create,
-one build, one delete. Measured: **~9 s wall**, zero paid calls. Building them
-per-provider instead would multiply the flow round-trips for no added signal.
+One flow holds every component as a disconnected vertex; `stop_component_id` then
+builds them **one at a time**, each with its own 20 s budget. Measured on
+1.12.0.dev8, isolated: 1.5 s / 1.5 s / 3.3 s / 1.3 s / 0.9 s — **~9 s total**, zero
+paid calls, same as the batched version but with per-component attribution and a
+bounded blast radius. A 90 s ceiling covers the whole axis.
+
+Do not re-batch it to "save a round trip". The round trips are not the cost; losing
+the ability to say *which* component failed to build is.
 
 - In CI (`daily-stable.yml`) this spec runs as a dedicated **Collect models** step before the `@stable` suite, ensuring `models.json` is on disk before Playwright's collection phase. The step uses `continue-on-error: true` so a missing API key does not block the rest of the run.
 - **Double-run in the daily (analyzed, benign):** with `@stable` the spec ALSO runs inside the suite. The in-suite run re-saves the same keys (the exact flow `openai-provider`/`google-provider` test 1 already exercise in-suite) and rewrites the JSONs with equivalent content; workers read the files at module load, so a mid-suite rewrite does not change already-collected test targets.

--- a/tests/collect-models.spec.ts
+++ b/tests/collect-models.spec.ts
@@ -5,6 +5,7 @@ import { expect, test } from "./fixtures/fixtures";
 import { collectAll } from "./helpers/provider-setup/collect-models";
 import type { ProviderRecord } from "./helpers/provider-setup/collect-models";
 import { providerConfigMap, type Provider } from "./helpers/provider-setup";
+import { isBuildAxisReason } from "./helpers/provider-setup/probe-component-buildable";
 
 /**
  * Utility spec that populates the provider data files every LLM spec depends
@@ -77,6 +78,29 @@ test(
           expect(p.error, `probe error recorded for env-keyed inactive provider "${p.provider}"`).toBeTruthy();
         }
       }
+    });
+
+    await test.step("this Langflow build can instantiate every provider's component", async () => {
+      // The BUILD axis (#900), asserted independently of the key axis below.
+      //
+      // Why this is not redundant with the env-keyed check that follows: that one
+      // skips every provider whose env key is unset. A component that cannot be
+      // built is a broken IMAGE, and that verdict does not depend on whether
+      // anyone configured a key — so without this step, running without (say)
+      // ANTHROPIC_API_KEY would let an unbuildable Anthropic component pass in
+      // silence. That is the same silent-skip class the whole issue removes.
+      //
+      // It is also never downgraded: a packaging gap is a broken environment, not
+      // a transient billing/quota outage, so it must fail loud every time.
+      const providers = JSON.parse(fs.readFileSync(PROVIDERS_PATH, "utf-8")) as ProviderRecord[];
+      const unbuildable = providers.filter((p) => isBuildAxisReason(p.error));
+      expect(
+        unbuildable.map((p) => p.provider),
+        `provider component(s) this Langflow build cannot instantiate — the image is ` +
+          `missing a distribution or a langchain-* package, and every spec parametrized ` +
+          `on them would fail downstream as a generic node-build timeout: ` +
+          unbuildable.map((p) => `${p.provider} — ${p.error}`).join(" | "),
+      ).toEqual([]);
     });
 
     await test.step("every env-keyed provider is ACTIVE (transient billing/quota outages warn, don't fail)", async () => {

--- a/tests/helpers/provider-setup/collect-models.ts
+++ b/tests/helpers/provider-setup/collect-models.ts
@@ -1,9 +1,10 @@
 // Test spec that runs this helper: tests/collect-models.spec.ts
-import type { Page } from "@playwright/test";
+import type { APIRequestContext, Page } from "@playwright/test";
 import path from "path";
 import fs from "fs";
 import { SettingsPage } from "../../pages/SettingsPage";
 import { providerConfigMap, type Provider } from "./provider-config";
+import { probeBuildAxis } from "./probe-component-buildable";
 
 const DATA_DIR = path.join(__dirname, "data");
 const PROVIDERS_PATH = path.join(DATA_DIR, "providers.json");
@@ -134,19 +135,9 @@ function modelsFor(models: ModelRecord[], provider: string): string[] {
 // runs green on; the catalog order stays as the tail so a provider with
 // none of the preferred models still validates on whatever it exposes.
 //
-// KNOWN GAP — "active" means the key works, NOT that Langflow can BUILD the
-// model. The probe calls the provider's own API directly, upstream of
-// Langflow, so it cannot see a missing server-side integration package. On a
-// nightly that shipped without `langchain-google-genai`, google probed
-// `active` here while every Google chat/embedding build inside Langflow raised
-// `ImportError: Could not import '...google_generative_ai_model' ... Install
-// the missing package`, surfacing downstream only as a misleading node-build
-// timeout across ~17 @stable specs (agents + Google-embedding KB). Root cause
-// + impact map: #898; upstream ticket: LE-1974. A faithful check would have to
-// BUILD a Language Model flow per provider and inspect the error — there is no
-// standalone endpoint that triggers the class import (`/api/v1/models/*`
-// return static metadata only). That build-probe hardening was deferred to
-// #900; this note is the trap marker for the next triager.
+// SCOPE — this probe answers "does the KEY work", nothing more. Whether Langflow
+// can actually BUILD the provider's component is the separate build axis in
+// `probe-component-buildable.ts`, merged in by `collectProviders` below (#900).
 const CANDIDATE_PREFS: Record<string, RegExp[]> = {
   openai: [/^gpt-4o-mini$/, /^gpt-4o$/, /^gpt-4\.1(-mini|-nano)?$/, /^gpt-4/],
   google: [
@@ -298,22 +289,47 @@ export async function validateProviderWithFallback(
   };
 }
 
-async function collectProviders(models: ModelRecord[]): Promise<ProviderRecord[]> {
-  console.log("Validating providers via API...");
+// A provider is usable only when BOTH axes pass, and they fail independently:
+// the key axis asks whether the provider's cloud API accepts the key, the build
+// axis whether THIS Langflow image can instantiate the component. A build-axis
+// failure overrides an `active` key verdict — a working key on an image that
+// cannot build the model is precisely the false `active` that made #898 and #907
+// cost a triage cycle each. The two run concurrently: the build probe is ~9s of
+// mostly-idle HTTP, and the key probe is network-bound too.
+async function collectProviders(
+  models: ModelRecord[],
+  request: APIRequestContext,
+): Promise<ProviderRecord[]> {
+  console.log("Validating providers via API (key axis) and build probe (build axis)...");
 
-  const results = await Promise.all([
-    validateProviderWithFallback("openai", rankCandidates("openai", modelsFor(models, "openai")), validateOpenAI),
-    validateProviderWithFallback("anthropic", rankCandidates("anthropic", modelsFor(models, "anthropic")), validateAnthropic),
-    validateProviderWithFallback("google", rankCandidates("google", modelsFor(models, "google")), validateGoogle),
+  const knownProviders = Object.keys(providerConfigMap) as Provider[];
+  const [results, buildAxis] = await Promise.all([
+    Promise.all([
+      validateProviderWithFallback("openai", rankCandidates("openai", modelsFor(models, "openai")), validateOpenAI),
+      validateProviderWithFallback("anthropic", rankCandidates("anthropic", modelsFor(models, "anthropic")), validateAnthropic),
+      validateProviderWithFallback("google", rankCandidates("google", modelsFor(models, "google")), validateGoogle),
+    ]),
+    probeBuildAxis(request, knownProviders),
   ]);
 
-  for (const r of results) {
+  const merged = results.map((r) => {
+    const axis = buildAxis[r.provider];
+    if (axis && !axis.ok) {
+      // Recorded even when the key is fine: the specs parametrized on this
+      // provider cannot run either way, and the reason must name the layer that
+      // is missing rather than blaming the key.
+      return { ...r, status: "inactive" as const, error: axis.reason ?? "build axis failed" };
+    }
+    return r;
+  });
+
+  for (const r of merged) {
     const icon = r.status === "active" ? "✅" : "❌";
     const detail = r.error ? ` — ${r.error}` : "";
     console.log(`${icon} ${r.provider} (${r.model ?? "no model"})${detail}`);
   }
 
-  return results;
+  return merged;
 }
 
 // ─── Model collection (UI navigation) ─────────────────────────────────────────
@@ -444,8 +460,9 @@ export async function collectAll(page: Page): Promise<void> {
   // Step 1: Collect models from UI via Settings
   const models = await collectModels(page);
 
-  // Step 2: Validate providers via API, falling back across candidate models
-  const providers = await collectProviders(models);
+  // Step 2: Validate providers on both axes — key (provider API, falling back
+  // across candidate models) and build (this image can instantiate the component)
+  const providers = await collectProviders(models, page.request);
   fs.writeFileSync(PROVIDERS_PATH, JSON.stringify(providers, null, 2), "utf-8");
   console.log(`providers.json saved with ${providers.length} providers.`);
 

--- a/tests/helpers/provider-setup/collect-models.ts
+++ b/tests/helpers/provider-setup/collect-models.ts
@@ -1,10 +1,10 @@
 // Test spec that runs this helper: tests/collect-models.spec.ts
-import type { APIRequestContext, Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import path from "path";
 import fs from "fs";
 import { SettingsPage } from "../../pages/SettingsPage";
 import { providerConfigMap, type Provider } from "./provider-config";
-import { probeBuildAxis } from "./probe-component-buildable";
+import { probeBuildAxis, type ProviderVerdict } from "./probe-component-buildable";
 
 const DATA_DIR = path.join(__dirname, "data");
 const PROVIDERS_PATH = path.join(DATA_DIR, "providers.json");
@@ -298,18 +298,14 @@ export async function validateProviderWithFallback(
 // mostly-idle HTTP, and the key probe is network-bound too.
 async function collectProviders(
   models: ModelRecord[],
-  request: APIRequestContext,
+  buildAxis: Record<string, ProviderVerdict>,
 ): Promise<ProviderRecord[]> {
-  console.log("Validating providers via API (key axis) and build probe (build axis)...");
+  console.log("Validating providers via API (key axis)...");
 
-  const knownProviders = Object.keys(providerConfigMap) as Provider[];
-  const [results, buildAxis] = await Promise.all([
-    Promise.all([
-      validateProviderWithFallback("openai", rankCandidates("openai", modelsFor(models, "openai")), validateOpenAI),
-      validateProviderWithFallback("anthropic", rankCandidates("anthropic", modelsFor(models, "anthropic")), validateAnthropic),
-      validateProviderWithFallback("google", rankCandidates("google", modelsFor(models, "google")), validateGoogle),
-    ]),
-    probeBuildAxis(request, knownProviders),
+  const results = await Promise.all([
+    validateProviderWithFallback("openai", rankCandidates("openai", modelsFor(models, "openai")), validateOpenAI),
+    validateProviderWithFallback("anthropic", rankCandidates("anthropic", modelsFor(models, "anthropic")), validateAnthropic),
+    validateProviderWithFallback("google", rankCandidates("google", modelsFor(models, "google")), validateGoogle),
   ]);
 
   const merged = results.map((r) => {
@@ -461,12 +457,26 @@ export async function collectAll(page: Page): Promise<void> {
     fs.mkdirSync(DATA_DIR, { recursive: true });
   }
 
-  // Step 1: Collect models from UI via Settings
+  // Step 1: BUILD axis first, on a still-idle backend.
+  //
+  // Order is load-bearing, not cosmetic (#900). Step 2 saves three provider keys
+  // through the Settings UI, and each save makes Langflow validate the provider and
+  // fetch its model list — enough load on the single-worker CI backend that
+  // `pr-validation.yml` carries a dedicated "Wait for the backend to recover from
+  // the collect-models load" step after this spec (#922/#927/#1044). Running the
+  // build probe after that load put it at the worst possible moment: on PR #1051's
+  // CI run every component timed out, several on the POST that merely STARTS the
+  // build, so the axis reported `unknown` for all three providers and produced no
+  // signal at all. The probe needs only the component registry — not models.json,
+  // not the keys — so it can and must run before that load.
+  const knownProviders = Object.keys(providerConfigMap) as Provider[];
+  const buildAxis = await probeBuildAxis(page.request, knownProviders);
+
+  // Step 2: Collect models from UI via Settings
   const models = await collectModels(page);
 
-  // Step 2: Validate providers on both axes — key (provider API, falling back
-  // across candidate models) and build (this image can instantiate the component)
-  const providers = await collectProviders(models, page.request);
+  // Step 3: Validate the key axis and merge both verdicts
+  const providers = await collectProviders(models, buildAxis);
   fs.writeFileSync(PROVIDERS_PATH, JSON.stringify(providers, null, 2), "utf-8");
   console.log(`providers.json saved with ${providers.length} providers.`);
 

--- a/tests/helpers/provider-setup/collect-models.ts
+++ b/tests/helpers/provider-setup/collect-models.ts
@@ -314,7 +314,11 @@ async function collectProviders(
 
   const merged = results.map((r) => {
     const axis = buildAxis[r.provider];
-    if (axis && !axis.ok) {
+    // Only a PROVEN build failure overrides the key verdict. `unknown` (the probe
+    // could not reach a verdict) must not: it says nothing about the provider, and
+    // writing it as `inactive` would turn a runner-side hiccup into a hard gate
+    // failure plus the silent downstream skips this mechanism exists to prevent.
+    if (axis && axis.state === "failed") {
       // Recorded even when the key is fine: the specs parametrized on this
       // provider cannot run either way, and the reason must name the layer that
       // is missing rather than blaming the key.

--- a/tests/helpers/provider-setup/probe-component-available.ts
+++ b/tests/helpers/provider-setup/probe-component-available.ts
@@ -41,8 +41,13 @@ import { getAuthToken } from "../auth/get-auth-token";
 // KNOWN LIMITATION: the match is a substring, so a short token can hit a
 // neighbouring component type (`openai` also matches `OpenAI Compatible`). Fine
 // for the current callers, whose tokens (`groq`, `mistral`) are unambiguous.
-// Lifting this probe into the `collect-models` gate needs an explicit
-// provider -> component-key map instead (#900).
+//
+// SCOPE — this probe stays the per-spec gate for providers that are NOT bundled
+// in the image (groq, mistral — #1039). The providers `collect-models` validates
+// go through `probe-component-buildable.ts` instead (#900), which uses exact
+// registry keys rather than this substring match AND adds the build layer this
+// one cannot supply: a registry hit does not prove the component builds, as the
+// trap above describes.
 export async function isProviderComponentAvailable(
   request: APIRequestContext,
   providerToken: string,

--- a/tests/helpers/provider-setup/probe-component-buildable.test.ts
+++ b/tests/helpers/provider-setup/probe-component-buildable.test.ts
@@ -1,0 +1,237 @@
+// Unit tests for the collect-models BUILD axis (issue #900).
+// Run with: npm run test:units
+//
+// What rides on these functions: whether `collect-models` records a provider
+// `active` on an image that cannot actually instantiate its component. Getting it
+// wrong in either direction is expensive.
+//
+// - Too permissive (the pre-#900 behavior): a valid key on an image missing the
+//   provider's package records `active`, and the real failure surfaces tens of
+//   layers downstream as a generic node-build timeout. That cost a full triage
+//   cycle twice — #898 (`langchain-google-genai`, LE-1974, ~17 Google @stable
+//   specs) and #907 (`langchain-groq` / `langchain-mistralai`, LE-1987).
+// - Too strict: a credentials error misread as a packaging failure would record
+//   every provider `inactive` and fail the gate on every run, forever. The probe
+//   builds with NO key on purpose, so a credentials error is the EXPECTED shape.
+//
+// Every error string below is verbatim from a build against a live
+// 1.12.0.dev8 (`langflowai/langflow-nightly:latest`, image built 2026-07-28).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  PROVIDER_COMPONENTS,
+  buildAxisReason,
+  isBuildAxisReason,
+  isPackagingError,
+  missingComponentKeys,
+} from "./probe-component-buildable";
+
+// ─── Verbatim build errors, 1.12.0.dev8 ───────────────────────────────────────
+
+/**
+ * The packaging failure, captured by hiding `site-packages/langchain_anthropic`
+ * and restarting the backend. Note it is Langflow's own standardised wording, not
+ * the component's ad-hoc `"langchain_anthropic is not installed"` message — the
+ * matcher has to accept both, because which one surfaces depends on whether the
+ * component guards its import.
+ */
+const MISSING_MODULE =
+  "No module named 'langchain_anthropic'. This flow needs a Python package that " +
+  "is not installed in this environment.\n\nInstall it and re-run:";
+
+/** The component's own guarded-import message (`lfx_anthropic/.../anthropic.py`). */
+const NOT_INSTALLED =
+  "Error building Component Anthropic: \n\nlangchain_anthropic is not installed. " +
+  "Please install it with `pip install langchain_anthropic`.";
+
+/** The #898 / LE-1974 shape, as quoted in that issue. */
+const COULD_NOT_IMPORT =
+  "ImportError: Could not import 'langchain_google_genai.chat_models'. " +
+  "Install the missing package.";
+
+/**
+ * The four credentials errors the probe actually produces on a healthy image.
+ * Each one PROVES the client class was imported and constructed, so each must
+ * classify as "not a packaging error".
+ */
+const CREDENTIALS_ERRORS = [
+  "Error building Component OpenAI: \n\nMissing credentials. Please pass an " +
+    "`api_key`, `workload_identity`, `admin_api_key`, or set the `OPENAI_API_KEY` " +
+    "or `OPENAI_ADMIN_KEY` environment variable.",
+  "Error building Component Anthropic: \n\nError running method \"text_response\": " +
+    '"Could not resolve authentication method. Expected one of api_key, auth_token, ' +
+    'or credentials to be set."',
+  "Error building Component Google Generative AI: \n\n1 validation error for " +
+    "ChatGoogleGenerativeAI\n  Value error, API key required for Gemini Developer API.",
+  "Error building Component Google Generative AI Embeddings: \n\nAPI Key is required",
+];
+
+// ─── missingComponentKeys ─────────────────────────────────────────────────────
+
+test("missingComponentKeys: reports nothing when every declared key is present", () => {
+  const registry = {
+    openai: { "ext:openai:OpenAIModelComponent@official": {} },
+    anthropic: { "ext:anthropic:AnthropicModelComponent@official": {} },
+  };
+  assert.deepEqual(
+    missingComponentKeys(registry, [
+      "ext:openai:OpenAIModelComponent@official",
+      "ext:anthropic:AnthropicModelComponent@official",
+    ]),
+    [],
+  );
+});
+
+test("missingComponentKeys: reports a key whose distribution is not installed", () => {
+  const registry = { openai: { "ext:openai:OpenAIModelComponent@official": {} } };
+  assert.deepEqual(
+    missingComponentKeys(registry, [
+      "ext:openai:OpenAIModelComponent@official",
+      "ext:groq:GroqModel@official",
+    ]),
+    ["ext:groq:GroqModel@official"],
+  );
+});
+
+test("missingComponentKeys: ignores the component_display_names pseudo-category", () => {
+  // /api/v1/all carries a lowercased echo of every type under this key. Counting
+  // it would report a component as present after its real category is gone.
+  const registry = {
+    component_display_names: { "ext:anthropic:anthropicmodelcomponent@official": {} },
+  };
+  assert.deepEqual(
+    missingComponentKeys(registry, ["ext:anthropic:AnthropicModelComponent@official"]),
+    ["ext:anthropic:AnthropicModelComponent@official"],
+  );
+});
+
+test("missingComponentKeys: matches exactly, so a neighbouring component cannot satisfy a key", () => {
+  // The pre-#900 probe used `componentType.includes(token)`, so the token
+  // `openai` was satisfied by `OpenAI Compatible`. Exact keys close that hole.
+  const registry = {
+    openai_compatible: { "ext:openai_compatible:OpenAICompatibleModel@official": {} },
+  };
+  assert.deepEqual(
+    missingComponentKeys(registry, ["ext:openai:OpenAIModelComponent@official"]),
+    ["ext:openai:OpenAIModelComponent@official"],
+  );
+});
+
+test("missingComponentKeys: an empty registry reports every key missing", () => {
+  assert.deepEqual(missingComponentKeys({}, ["a", "b"]), ["a", "b"]);
+});
+
+// ─── isPackagingError ─────────────────────────────────────────────────────────
+
+test("isPackagingError: recognises Langflow's standardised missing-module message", () => {
+  assert.equal(isPackagingError(MISSING_MODULE), true);
+});
+
+test("isPackagingError: recognises a component's own guarded-import message", () => {
+  assert.equal(isPackagingError(NOT_INSTALLED), true);
+});
+
+test("isPackagingError: recognises the #898 Could not import shape", () => {
+  assert.equal(isPackagingError(COULD_NOT_IMPORT), true);
+});
+
+test("isPackagingError: a credentials error is NOT a packaging error", () => {
+  // This is the load-bearing negative: the probe builds with no key ON PURPOSE,
+  // so these are the expected errors on a perfectly healthy image. Matching them
+  // would fail the gate on every run.
+  for (const message of CREDENTIALS_ERRORS) {
+    assert.equal(isPackagingError(message), false, `should not match: ${message}`);
+  }
+});
+
+test("isPackagingError: an empty or absent message is NOT a packaging error", () => {
+  assert.equal(isPackagingError(""), false);
+  assert.equal(isPackagingError(undefined), false);
+});
+
+// ─── buildAxisReason ──────────────────────────────────────────────────────────
+
+test("buildAxisReason: a distribution failure names the layer and the missing keys", () => {
+  const reason = buildAxisReason({
+    layer: "distribution",
+    missing: ["ext:google:GoogleGenerativeAIComponent@official"],
+  });
+  // The operator fix differs per layer, so the layer must be named explicitly.
+  assert.match(reason, /distribution/i);
+  assert.match(reason, /ext:google:GoogleGenerativeAIComponent@official/);
+});
+
+test("buildAxisReason: a runtime-package failure names the layer and quotes Langflow's error", () => {
+  const reason = buildAxisReason({
+    layer: "runtime-package",
+    component: "ext:anthropic:AnthropicModelComponent@official",
+    message: MISSING_MODULE,
+  });
+  assert.match(reason, /runtime package/i);
+  assert.match(reason, /ext:anthropic:AnthropicModelComponent@official/);
+  assert.match(reason, /No module named 'langchain_anthropic'/);
+});
+
+test("buildAxisReason: the reason never matches the billing/quota downgrade", () => {
+  // collect-models.spec.ts downgrades a BILLING_OR_QUOTA inactive to a warning.
+  // A packaging failure must NOT be downgraded — it has to fail the gate loud,
+  // which is the whole point of #900. Kept in sync with that spec by hand.
+  const BILLING_OR_QUOTA =
+    /credit balance is too low|insufficient[_ ]?quota|exceeded your current quota|\bquota\b|resource[_ ]?exhausted|billing|spend(?:ing)?[ _-]?cap|payment required|\b402\b|\b429\b/i;
+  const reasons = [
+    buildAxisReason({ layer: "distribution", missing: ["ext:groq:GroqModel@official"] }),
+    buildAxisReason({
+      layer: "runtime-package",
+      component: "ext:anthropic:AnthropicModelComponent@official",
+      message: MISSING_MODULE,
+    }),
+  ];
+  for (const reason of reasons) {
+    assert.equal(BILLING_OR_QUOTA.test(reason), false, `must fail loud, not warn: ${reason}`);
+  }
+});
+
+// ─── isBuildAxisReason ────────────────────────────────────────────────────────
+
+test("isBuildAxisReason: recognises both layers' reasons", () => {
+  // The spec asserts on this predicate to cover providers the `hardFailures`
+  // check cannot see (see the next test), so it has to recognise every reason
+  // buildAxisReason can emit.
+  assert.equal(
+    isBuildAxisReason(buildAxisReason({ layer: "distribution", missing: ["x"] })),
+    true,
+  );
+  assert.equal(
+    isBuildAxisReason(
+      buildAxisReason({ layer: "runtime-package", component: "x", message: MISSING_MODULE }),
+    ),
+    true,
+  );
+});
+
+test("isBuildAxisReason: a key-axis error is not a build-axis reason", () => {
+  // Verbatim from a real providers.json — a drained Anthropic balance. Claiming
+  // this as a build failure would blame the image for an ops state.
+  assert.equal(
+    isBuildAxisReason(
+      "3 of 13 candidate model(s) failed validation with the SAME model-independent " +
+        "error; last error: Your credit balance is too low to access the Anthropic API.",
+    ),
+    false,
+  );
+  assert.equal(isBuildAxisReason("OPENAI_API_KEY not set"), false);
+  assert.equal(isBuildAxisReason(null), false);
+});
+
+// ─── PROVIDER_COMPONENTS ──────────────────────────────────────────────────────
+
+test("PROVIDER_COMPONENTS: every provider collect-models validates declares at least one component", () => {
+  // A provider with an empty list would pass the build axis vacuously — the exact
+  // false `active` #900 exists to remove.
+  for (const provider of ["openai", "anthropic", "google"] as const) {
+    assert.ok(
+      PROVIDER_COMPONENTS[provider]?.length > 0,
+      `provider "${provider}" declares no component key`,
+    );
+  }
+});

--- a/tests/helpers/provider-setup/probe-component-buildable.test.ts
+++ b/tests/helpers/provider-setup/probe-component-buildable.test.ts
@@ -20,6 +20,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   PROVIDER_COMPONENTS,
+  aggregateVerdict,
   buildAxisReason,
   isBuildAxisReason,
   isPackagingError,
@@ -221,6 +222,48 @@ test("isBuildAxisReason: a key-axis error is not a build-axis reason", () => {
   );
   assert.equal(isBuildAxisReason("OPENAI_API_KEY not set"), false);
   assert.equal(isBuildAxisReason(null), false);
+});
+
+// ─── aggregateVerdict ─────────────────────────────────────────────────────────
+
+test("aggregateVerdict: every component built ⇒ ok", () => {
+  assert.deepEqual(
+    aggregateVerdict([
+      { key: "a", state: "ok" },
+      { key: "b", state: "ok" },
+    ]),
+    { state: "ok" },
+  );
+});
+
+test("aggregateVerdict: a packaging failure wins over everything else", () => {
+  const v = aggregateVerdict([
+    { key: "a", state: "unknown", message: "timed out" },
+    { key: "b", state: "packaging", message: MISSING_MODULE },
+  ]);
+  assert.equal(v.state, "failed");
+  assert.match(v.reason ?? "", /runtime package/i);
+  assert.match(v.reason ?? "", /^build axis: /);
+});
+
+test("aggregateVerdict: a component that could not be probed is UNKNOWN, never ok", () => {
+  // The CI regression this exists for: on PR #1051's first run the probe timed
+  // out and still logged "✅" for all three providers, because fail-open and real
+  // success produced identical output. An unproven component must read as
+  // unproven — that is the whole difference between a gate and ceremony.
+  const v = aggregateVerdict([
+    { key: "a", state: "ok" },
+    { key: "b", state: "unknown", message: "build did not finish within the probe budget" },
+  ]);
+  assert.equal(v.state, "unknown");
+  assert.match(v.reason ?? "", /b/);
+});
+
+test("aggregateVerdict: an UNKNOWN reason is not stamped as a build-axis failure", () => {
+  // `unknown` must not reach providers.json as an inactive reason — the probe
+  // could not run, which says nothing about the provider. Only `failed` does.
+  const v = aggregateVerdict([{ key: "a", state: "unknown", message: "timed out" }]);
+  assert.equal(isBuildAxisReason(v.reason), false);
 });
 
 // ─── PROVIDER_COMPONENTS ──────────────────────────────────────────────────────

--- a/tests/helpers/provider-setup/probe-component-buildable.ts
+++ b/tests/helpers/provider-setup/probe-component-buildable.ts
@@ -168,18 +168,75 @@ export function isBuildAxisReason(error: string | null | undefined): boolean {
   return !!error && error.startsWith(BUILD_AXIS_PREFIX);
 }
 
-// ─── I/O ──────────────────────────────────────────────────────────────────────
+/** One component's outcome. `unknown` means the probe could not reach a verdict. */
+export interface ComponentVerdict {
+  key: string;
+  state: "ok" | "packaging" | "unknown";
+  message?: string;
+}
 
-export interface BuildAxisResult {
-  /** false only on a PROVEN packaging gap; a probe that could not run is `true`. */
-  ok: boolean;
+export interface ProviderVerdict {
+  state: "ok" | "failed" | "unknown";
+  /** Only set for `failed` — this is what lands in providers.json. */
   reason?: string;
 }
 
-interface BuildVertexOutcome {
-  componentKey: string;
-  errorMessage: string;
+/**
+ * Folds a provider's per-component outcomes into one verdict.
+ *
+ * `unknown` is a first-class state, NOT a synonym for ok. On PR #1051's first CI
+ * run the probe timed out and still logged `✅` for all three providers, because
+ * fail-open and real success produced identical output — the exact blind spot this
+ * issue exists to remove, reintroduced one layer up. An unproven component now
+ * reads as unproven everywhere: in the log, and by being excluded from the
+ * `build axis: ` stamp so it can never reach providers.json as an inactive reason.
+ *
+ * A proven packaging failure outranks an unknown: one component we could not probe
+ * does not make another component's hard evidence go away.
+ */
+export function aggregateVerdict(verdicts: ComponentVerdict[]): ProviderVerdict {
+  const broken = verdicts.find((v) => v.state === "packaging");
+  if (broken) {
+    return {
+      state: "failed",
+      reason: buildAxisReason({
+        layer: "runtime-package",
+        component: broken.key,
+        message: broken.message ?? "no error message recorded",
+      }),
+    };
+  }
+  const unproven = verdicts.filter((v) => v.state === "unknown");
+  if (unproven.length > 0) {
+    return {
+      state: "unknown",
+      reason:
+        `not proven — ${unproven.length} component(s) could not be built within the ` +
+        `probe budget: ${unproven.map((v) => `${v.key} (${v.message ?? "no detail"})`).join(", ")}`,
+    };
+  }
+  return { state: "ok" };
 }
+
+// ─── I/O ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Per-component build budget. Measured on 1.12.0.dev8: an isolated component
+ * builds in 0.9–3.3 s, so 20 s is ~6× the slowest.
+ *
+ * Deliberately PER COMPONENT rather than one budget for the batch. On PR #1051's
+ * first CI run all five were built in a single request; it exceeded the budget and
+ * the whole axis fell back to fail-open, yielding no signal about any provider.
+ * Isolated builds bound the damage to the component that is actually slow and
+ * still return real verdicts for the rest — and the log then NAMES the slow one,
+ * which a batched probe cannot do.
+ */
+const BUILD_TIMEOUT_MS = 20000;
+
+/** Ceiling for the whole axis, so a systematically slow backend cannot hold the run. */
+const TOTAL_BUDGET_MS = 90000;
+
+const HTTP_TIMEOUT_MS = 20000;
 
 /**
  * Strips every secret field so the build cannot make a billable call.
@@ -203,97 +260,6 @@ function neutraliseSecrets(template: Record<string, unknown>): void {
   }
 }
 
-/**
- * Builds every given component as a disconnected vertex of ONE throwaway flow and
- * returns the ones that failed with a packaging error.
- *
- * One flow rather than one per provider: the vertices are independent, so a single
- * create/build/delete covers all of them (~9 s measured, against ~5 round-trips
- * otherwise). The build endpoint requires a PERSISTED flow — passing `data` inline
- * against a random UUID returns `404 Flow with id ... not found` — hence the
- * create, and hence the `finally` that deletes it.
- */
-async function buildComponents(
-  request: APIRequestContext,
-  auth: string,
-  registry: Record<string, Record<string, unknown>>,
-  componentKeys: string[],
-): Promise<BuildVertexOutcome[]> {
-  const headers = auth ? { Authorization: auth } : undefined;
-  const nodeIdToKey = new Map<string, string>();
-  const nodes = componentKeys.map((key, i) => {
-    const template = JSON.parse(
-      JSON.stringify(findTemplate(registry, key)),
-    ) as Record<string, unknown>;
-    neutraliseSecrets(template);
-    const id = `build-probe-${i}`;
-    nodeIdToKey.set(id, key);
-    return {
-      id,
-      type: "genericNode",
-      position: { x: i * 400, y: 0 },
-      data: { id, type: (template.name as string) ?? key, node: template },
-    };
-  });
-
-  const graph = { nodes, edges: [] };
-  const created = await request.post("/api/v1/flows/", {
-    headers,
-    data: { name: `build-probe-${Date.now()}`, description: "collect-models build axis (#900)", data: graph },
-    timeout: 30000,
-  });
-  if (!created.ok()) throw new Error(`flow create failed: HTTP ${created.status()}`);
-  const flowId = (await created.json()).id as string;
-
-  try {
-    const started = await request.post(`/api/v1/build/${flowId}/flow?log_builds=false`, {
-      headers,
-      data: { data: graph },
-      timeout: 30000,
-    });
-    if (!started.ok()) throw new Error(`build start failed: HTTP ${started.status()}`);
-    const jobId = (await started.json()).job_id as string;
-
-    // 60s against ~9s measured for all five components. Deliberately tight: this
-    // runs in the daily's `Collect models` PRE-FLIGHT, which shares its Langflow
-    // container with the @stable shard and has a history of wedging it (#922/#927,
-    // and #1011 where an over-eager pre-flight cost the entire run). Because the
-    // whole probe fails OPEN, an expired timeout degrades to "no build signal" and
-    // a warning — never to a blocked pre-flight or an inactive provider — so
-    // erring on the short side is the safe direction.
-    const events = await request.get(`/api/v1/build/${jobId}/events`, {
-      headers,
-      timeout: 60000,
-    });
-    if (!events.ok()) throw new Error(`build events failed: HTTP ${events.status()}`);
-
-    const outcomes: BuildVertexOutcome[] = [];
-    for (const line of (await events.text()).split("\n")) {
-      if (!line.trim()) continue;
-      let event: any;
-      try {
-        event = JSON.parse(line);
-      } catch {
-        continue; // a partial frame is not a verdict — ignore it
-      }
-      if (event?.event !== "end_vertex") continue;
-      const buildData = event.data?.build_data;
-      const key = nodeIdToKey.get(buildData?.id);
-      if (!key) continue;
-      for (const output of Object.values(buildData?.data?.outputs ?? {})) {
-        const errorMessage = (output as any)?.message?.errorMessage;
-        if (typeof errorMessage === "string" && errorMessage) {
-          outcomes.push({ componentKey: key, errorMessage });
-        }
-      }
-    }
-    return outcomes;
-  } finally {
-    // Always — a probe must never leak a flow onto the instance under test.
-    await request.delete(`/api/v1/flows/${flowId}`, { headers, timeout: 30000 }).catch(() => {});
-  }
-}
-
 function findTemplate(
   registry: Record<string, Record<string, unknown>>,
   key: string,
@@ -308,78 +274,172 @@ function findTemplate(
 }
 
 /**
+ * Builds ONE component and classifies the outcome.
+ *
+ * `stop_component_id` restricts the build to that single vertex — verified on
+ * 1.12.0.dev8, where each call emitted exactly one `end_vertex` for the requested
+ * node. On timeout the job is CANCELLED: without that, the client stops waiting
+ * while the server keeps building, which is what wedged the backend on PR #1051's
+ * first CI run (gunicorn `WORKER TIMEOUT`, then a 120 s unreachable backend for
+ * the next step). Stopping waiting and stopping working must be the same act.
+ */
+async function buildOne(
+  request: APIRequestContext,
+  headers: Record<string, string> | undefined,
+  flowId: string,
+  graph: unknown,
+  nodeId: string,
+  key: string,
+): Promise<ComponentVerdict> {
+  let jobId: string | undefined;
+  try {
+    const started = await request.post(
+      `/api/v1/build/${flowId}/flow?log_builds=false&stop_component_id=${nodeId}`,
+      { headers, data: { data: graph }, timeout: HTTP_TIMEOUT_MS },
+    );
+    if (!started.ok()) return { key, state: "unknown", message: `build start HTTP ${started.status()}` };
+    jobId = (await started.json()).job_id as string;
+
+    const events = await request.get(`/api/v1/build/${jobId}/events`, {
+      headers,
+      timeout: BUILD_TIMEOUT_MS,
+    });
+    if (!events.ok()) return { key, state: "unknown", message: `events HTTP ${events.status()}` };
+
+    for (const line of (await events.text()).split("\n")) {
+      if (!line.trim()) continue;
+      let event: any;
+      try {
+        event = JSON.parse(line);
+      } catch {
+        continue; // a partial frame is not a verdict
+      }
+      if (event?.event !== "end_vertex") continue;
+      for (const output of Object.values(event.data?.build_data?.data?.outputs ?? {})) {
+        const errorMessage = (output as any)?.message?.errorMessage;
+        if (typeof errorMessage === "string" && isPackagingError(errorMessage)) {
+          return { key, state: "packaging", message: errorMessage };
+        }
+      }
+    }
+    // Built, or failed for a reason that is NOT packaging (a credentials error is
+    // the expected shape here and PROVES the client class was constructed).
+    return { key, state: "ok" };
+  } catch (e: any) {
+    if (jobId) {
+      // Best-effort: stop the server-side work we just abandoned.
+      await request
+        .post(`/api/v1/build/${jobId}/cancel`, { headers, timeout: 10000 })
+        .catch(() => {});
+    }
+    return { key, state: "unknown", message: e?.message?.split("\n")[0] ?? String(e) };
+  }
+}
+
+/**
  * Runs both layers and returns a verdict per provider.
  *
- * FAILS OPEN on its own infrastructure. An unreachable registry, a build endpoint
- * error or a timeout returns `ok: true` for everyone and logs a warning: the gate
- * must never convert a runner-side hiccup into an `inactive` provider, which
- * would be a hard failure of collect-models plus the silent downstream skips the
- * whole mechanism exists to prevent. Same rule `readProviderHealth` (#1029) and
- * `TRANSIENT_TRANSPORT` (#1011) already encode.
+ * FAILS OPEN on its own infrastructure — but never SILENTLY. An unreachable
+ * registry or an unbuildable-within-budget component yields `unknown`, which is
+ * logged as `⚠️` and never written to providers.json: the gate must not convert a
+ * runner-side hiccup into an `inactive` provider, and it must not report an
+ * unproven component as proven either. Reporting `✅` on fail-open is exactly what
+ * PR #1051's first CI run did, and it made a timed-out probe indistinguishable
+ * from a passing one.
  */
 export async function probeBuildAxis(
   request: APIRequestContext,
   providers: readonly Provider[],
-): Promise<Record<string, BuildAxisResult>> {
-  const results: Record<string, BuildAxisResult> = {};
-  for (const provider of providers) results[provider] = { ok: true };
+): Promise<Record<string, ProviderVerdict>> {
+  const results: Record<string, ProviderVerdict> = {};
+  const started = Date.now();
+  let flowId: string | undefined;
+  const headers: Record<string, string> | undefined = undefined;
 
   try {
     const auth = await getAuthToken(request);
+    const authHeaders = auth ? { Authorization: auth } : undefined;
     const res = await request.get("/api/v1/all", {
-      headers: auth ? { Authorization: auth } : undefined,
-      timeout: 30000,
+      headers: authHeaders,
+      timeout: HTTP_TIMEOUT_MS,
     });
     if (!res.ok()) throw new Error(`registry unreachable: HTTP ${res.status()}`);
     const registry = (await res.json()) as Record<string, Record<string, unknown>>;
 
-    // Layer 1 — catalog.
-    const stillPresent: string[] = [];
+    // Layer 1 — catalog. One request, every provider.
+    const toBuild: { provider: Provider; key: string; nodeId: string }[] = [];
     for (const provider of providers) {
       const keys = PROVIDER_COMPONENTS[provider] ?? [];
       const missing = missingComponentKeys(registry, keys);
       if (missing.length > 0) {
-        results[provider] = { ok: false, reason: buildAxisReason({ layer: "distribution", missing }) };
+        results[provider] = {
+          state: "failed",
+          reason: buildAxisReason({ layer: "distribution", missing }),
+        };
         continue;
       }
-      stillPresent.push(...keys);
-    }
-    if (stillPresent.length === 0) return results;
-
-    // Layer 2 — buildability, for whatever survived layer 1.
-    // Logged BEFORE the build so the step is observable even if the build hangs:
-    // a probe whose success is indistinguishable from a probe that never ran is
-    // the #505 class of blind spot this whole mechanism exists to remove.
-    console.log(`   build axis: building ${stillPresent.length} component(s) with no API key — ${stillPresent.join(", ")}`);
-    const outcomes = await buildComponents(request, auth, registry, stillPresent);
-    for (const provider of providers) {
-      if (!results[provider].ok) continue;
-      const keys = PROVIDER_COMPONENTS[provider] ?? [];
-      const broken = outcomes.find(
-        (o) => keys.includes(o.componentKey) && isPackagingError(o.errorMessage),
-      );
-      if (broken) {
-        results[provider] = {
-          ok: false,
-          reason: buildAxisReason({
-            layer: "runtime-package",
-            component: broken.componentKey,
-            message: broken.errorMessage,
-          }),
-        };
+      for (const key of keys) {
+        toBuild.push({ provider, key, nodeId: `build-probe-${toBuild.length}` });
       }
     }
+    if (toBuild.length === 0) return results;
+
+    // Layer 2 — buildability. ONE flow holds every surviving component as a
+    // disconnected vertex; `stop_component_id` then builds them one at a time.
+    const nodes = toBuild.map(({ key, nodeId }) => {
+      const template = JSON.parse(JSON.stringify(findTemplate(registry, key))) as Record<string, unknown>;
+      neutraliseSecrets(template);
+      return {
+        id: nodeId,
+        type: "genericNode",
+        position: { x: 0, y: 0 },
+        data: { id: nodeId, type: (template.name as string) ?? key, node: template },
+      };
+    });
+    const graph = { nodes, edges: [] };
+
+    const created = await request.post("/api/v1/flows/", {
+      headers: authHeaders,
+      data: {
+        name: `build-probe-${Date.now()}`,
+        description: "collect-models build axis (#900)",
+        data: graph,
+      },
+      timeout: HTTP_TIMEOUT_MS,
+    });
+    if (!created.ok()) throw new Error(`flow create failed: HTTP ${created.status()}`);
+    flowId = (await created.json()).id as string;
+
+    const verdicts = new Map<Provider, ComponentVerdict[]>();
+    for (const { provider, key, nodeId } of toBuild) {
+      const verdict =
+        Date.now() - started > TOTAL_BUDGET_MS
+          ? ({ key, state: "unknown", message: "total probe budget exhausted" } as ComponentVerdict)
+          : await buildOne(request, authHeaders, flowId, graph, nodeId, key);
+      const list = verdicts.get(provider) ?? [];
+      list.push(verdict);
+      verdicts.set(provider, list);
+    }
+    for (const [provider, list] of verdicts) results[provider] = aggregateVerdict(list);
   } catch (e: any) {
-    console.warn(
-      `⚠️  build-axis probe could not run (${e?.message ?? e}) — keeping the key-axis ` +
-        `verdict for every provider. This is a fail-open by design (#900).`,
-    );
-    for (const provider of providers) results[provider] = { ok: true };
+    const message = e?.message?.split("\n")[0] ?? String(e);
+    for (const provider of providers) {
+      results[provider] ??= { state: "unknown", reason: `probe could not run — ${message}` };
+    }
+  } finally {
+    if (flowId) {
+      // Always — a probe must never leak a flow onto the instance under test.
+      await request.delete(`/api/v1/flows/${flowId}`, { headers, timeout: HTTP_TIMEOUT_MS }).catch(() => {});
+    }
   }
 
   for (const provider of providers) {
-    const r = results[provider];
-    console.log(`   build axis: ${r.ok ? "✅" : "❌"} ${provider}${r.ok ? "" : ` — ${r.reason}`}`);
+    const r = (results[provider] ??= { state: "unknown", reason: "probe produced no verdict" });
+    const icon = r.state === "ok" ? "✅" : r.state === "failed" ? "❌" : "⚠️";
+    console.log(
+      `   build axis: ${icon} ${provider}${r.state === "ok" ? "" : ` — ${r.reason}`}` +
+        (r.state === "unknown" ? " [NOT PROVEN — this run gives no build signal for it]" : ""),
+    );
   }
   return results;
 }

--- a/tests/helpers/provider-setup/probe-component-buildable.ts
+++ b/tests/helpers/provider-setup/probe-component-buildable.ts
@@ -1,0 +1,385 @@
+import type { APIRequestContext } from "@playwright/test";
+import { getAuthToken } from "../auth/get-auth-token";
+import type { Provider } from "./provider-config";
+
+// The BUILD axis of collect-models (#900): can THIS Langflow image actually
+// instantiate a provider's component? Independent of the key axis, which calls
+// the provider's own API upstream of Langflow and therefore cannot see a
+// packaging gap. A valid key on an image that cannot build the model used to
+// record a false `active`; the real failure then surfaced tens of layers
+// downstream as a generic node-build timeout, costing a full triage cycle each
+// time (#898 / LE-1974, #907 / LE-1987).
+//
+// TWO LAYERS, because neither catches the other's shape. Which shape a provider
+// produces is decided upstream by where a maintainer puts an `import`, and it is
+// inconsistent across components — measured on 1.12.0.dev8:
+//
+//   | Component                            | langchain-* import | missing =>          |
+//   |--------------------------------------|--------------------|---------------------|
+//   | OpenAIModelComponent / Embeddings    | module level       | absent from registry|
+//   | GoogleGenerativeAI* (chat via lfx.base) | module level    | absent from registry|
+//   | AnthropicModelComponent              | LAZY, in build_model | PRESENT, fails at build |
+//
+//   1. CATALOG — a component whose distribution is not installed has no key in
+//      GET /api/v1/all. One request covers every provider.
+//   2. BUILD — a component whose distribution IS installed but whose runtime
+//      package is missing registers normally and only fails when built. Proven by
+//      hiding site-packages/langchain_anthropic and restarting: the registry still
+//      exposed the Anthropic component while the build reported
+//      "No module named 'langchain_anthropic'".
+//
+// Do NOT collapse this back to the catalog check alone — that was the design this
+// issue started with, and Anthropic already falsifies it.
+//
+// This module is consumed by the node --test units lane, so its only
+// @playwright/test import is type-only (same constraint provider-health.ts and
+// get-auth-token.ts honour).
+
+/**
+ * `/api/v1/all` carries a lowercased echo of every component type under this
+ * pseudo-category. It is not a component namespace: counting it would report a
+ * component present after its real category is gone.
+ */
+const DISPLAY_NAMES_CATEGORY = "component_display_names";
+
+/**
+ * The exact registry keys each provider needs, replacing the substring token
+ * match in `probe-component-available.ts` (where `openai` also matched
+ * `OpenAI Compatible`). These are the 1.12 `lfx-bundles` per-vendor names
+ * (#1040); an upstream rename makes the catalog layer report the provider
+ * absent, which is a loud failure by design rather than a silent pass.
+ *
+ * Only the providers `collect-models` validates appear here. Groq and Mistral are
+ * deliberately absent: they are not bundled in the image by product decision
+ * (#1039) and are gated per-spec by `isProviderComponentAvailable`. Keeping them
+ * out is what makes a declared "expected in this image?" flag unnecessary —
+ * every provider listed here is one the image is expected to ship.
+ */
+export const PROVIDER_COMPONENTS: Record<Provider, readonly string[]> = {
+  openai: [
+    "ext:openai:OpenAIModelComponent@official",
+    "ext:openai:OpenAIEmbeddingsComponent@official",
+  ],
+  anthropic: ["ext:anthropic:AnthropicModelComponent@official"],
+  google: [
+    "ext:google:GoogleGenerativeAIComponent@official",
+    "ext:google:GoogleGenerativeAIEmbeddingsComponent@official",
+  ],
+};
+
+export type BuildAxisFailure =
+  | { layer: "distribution"; missing: string[] }
+  | { layer: "runtime-package"; component: string; message: string };
+
+/**
+ * The declared component keys that the registry does not expose.
+ *
+ * Exact match on the second-level COMPONENT-TYPE keys only — never on nested
+ * template field names, so a field like `ollama_base_url` on the unified Language
+ * Model cannot false-positive the Ollama component.
+ */
+export function missingComponentKeys(
+  registry: Record<string, unknown>,
+  keys: readonly string[],
+): string[] {
+  const present = new Set<string>();
+  for (const [category, components] of Object.entries(registry)) {
+    if (category === DISPLAY_NAMES_CATEGORY) continue;
+    if (components && typeof components === "object") {
+      for (const componentType of Object.keys(components as Record<string, unknown>)) {
+        present.add(componentType);
+      }
+    }
+  }
+  return keys.filter((key) => !present.has(key));
+}
+
+/**
+ * Langflow's standardised wording, plus the ad-hoc messages components raise from
+ * their own guarded imports. Both shapes occur — which one surfaces depends on
+ * whether the component wraps its import in a try/except, so the matcher accepts
+ * either.
+ */
+const PACKAGING_ERROR =
+  /no module named|not installed in this environment|is not installed|could not import|modulenotfounderror|importerror/i;
+
+/**
+ * Whether a build error means the component's runtime package is missing.
+ *
+ * This is a NEGATIVE-match classifier on purpose. The probe builds with no API
+ * key, so the expected error on a healthy image is a credentials error — and a
+ * credentials error is a PASS on this axis: it proves the client class was
+ * imported and constructed. Only the packaging signature reprove. Matching
+ * positively on "looks like a credentials error" instead would have to keep four
+ * different provider-specific strings in sync and would fail closed on any new
+ * wording, i.e. record every provider inactive.
+ */
+export function isPackagingError(message: string | undefined | null): boolean {
+  if (!message) return false;
+  return PACKAGING_ERROR.test(message);
+}
+
+/**
+ * The `inactive` reason recorded in providers.json.
+ *
+ * It must name the LAYER, because the operator fix differs: a missing
+ * distribution is fixed by installing the vendor package (or `lfx-bundles`), a
+ * missing runtime package by installing the `langchain-*` extra.
+ *
+ * It must also never match `BILLING_OR_QUOTA` in `tests/collect-models.spec.ts`,
+ * which downgrades an inactive provider to a warning. A packaging gap is a broken
+ * environment, not a transient ops state, so it has to fail the gate loud — that
+ * is the whole point of #900. `probe-component-buildable.test.ts` asserts it.
+ */
+export function buildAxisReason(failure: BuildAxisFailure): string {
+  if (failure.layer === "distribution") {
+    return (
+      `${BUILD_AXIS_PREFIX}component distribution not installed in this Langflow image — ` +
+      `${failure.missing.join(", ")} absent from GET /api/v1/all. ` +
+      `Install the provider's lfx distribution (see #1040)`
+    );
+  }
+  return (
+    `${BUILD_AXIS_PREFIX}component runtime package missing — ${failure.component} is ` +
+    `exposed by the registry but fails to build: ${failure.message.split("\n")[0]}. ` +
+    `Install the provider's langchain-* package`
+  );
+}
+
+/**
+ * Stamped on every build-axis reason so a consumer can tell WHICH axis recorded an
+ * `inactive` without re-deriving it from the wording.
+ */
+const BUILD_AXIS_PREFIX = "build axis: ";
+
+/**
+ * Whether a providers.json `error` was written by this axis rather than the key
+ * probe.
+ *
+ * `collect-models.spec.ts` asserts on it to cover a case the existing
+ * `hardFailures` check structurally cannot: that check skips every provider whose
+ * env key is unset, but a component that cannot build is a broken IMAGE — the
+ * verdict does not depend on whether anyone configured a key for it. Without this
+ * predicate, running with (say) no `ANTHROPIC_API_KEY` would let a genuinely
+ * unbuildable Anthropic component pass the gate in silence, which is the same
+ * silent-skip class #900 exists to remove.
+ */
+export function isBuildAxisReason(error: string | null | undefined): boolean {
+  return !!error && error.startsWith(BUILD_AXIS_PREFIX);
+}
+
+// ─── I/O ──────────────────────────────────────────────────────────────────────
+
+export interface BuildAxisResult {
+  /** false only on a PROVEN packaging gap; a probe that could not run is `true`. */
+  ok: boolean;
+  reason?: string;
+}
+
+interface BuildVertexOutcome {
+  componentKey: string;
+  errorMessage: string;
+}
+
+/**
+ * Strips every secret field so the build cannot make a billable call.
+ *
+ * Load-bearing, not hygiene: the registry template ships `api_key` as
+ * `{ value: "OPENAI_API_KEY", load_from_db: true }`, so an un-neutralised probe
+ * loads the global variable `collect-models` itself just saved and the default
+ * `text_output` output invokes the model for real. With the key blanked, every
+ * provider fails on missing credentials before any network call — measured on all
+ * five components.
+ */
+function neutraliseSecrets(template: Record<string, unknown>): void {
+  const fields = template.template as Record<string, Record<string, unknown>> | undefined;
+  if (!fields) return;
+  for (const field of Object.values(fields)) {
+    if (field && typeof field === "object" && field._input_type === "SecretStrInput") {
+      field.value = "";
+      field.load_from_db = false;
+      field.required = false;
+    }
+  }
+}
+
+/**
+ * Builds every given component as a disconnected vertex of ONE throwaway flow and
+ * returns the ones that failed with a packaging error.
+ *
+ * One flow rather than one per provider: the vertices are independent, so a single
+ * create/build/delete covers all of them (~9 s measured, against ~5 round-trips
+ * otherwise). The build endpoint requires a PERSISTED flow — passing `data` inline
+ * against a random UUID returns `404 Flow with id ... not found` — hence the
+ * create, and hence the `finally` that deletes it.
+ */
+async function buildComponents(
+  request: APIRequestContext,
+  auth: string,
+  registry: Record<string, Record<string, unknown>>,
+  componentKeys: string[],
+): Promise<BuildVertexOutcome[]> {
+  const headers = auth ? { Authorization: auth } : undefined;
+  const nodeIdToKey = new Map<string, string>();
+  const nodes = componentKeys.map((key, i) => {
+    const template = JSON.parse(
+      JSON.stringify(findTemplate(registry, key)),
+    ) as Record<string, unknown>;
+    neutraliseSecrets(template);
+    const id = `build-probe-${i}`;
+    nodeIdToKey.set(id, key);
+    return {
+      id,
+      type: "genericNode",
+      position: { x: i * 400, y: 0 },
+      data: { id, type: (template.name as string) ?? key, node: template },
+    };
+  });
+
+  const graph = { nodes, edges: [] };
+  const created = await request.post("/api/v1/flows/", {
+    headers,
+    data: { name: `build-probe-${Date.now()}`, description: "collect-models build axis (#900)", data: graph },
+    timeout: 30000,
+  });
+  if (!created.ok()) throw new Error(`flow create failed: HTTP ${created.status()}`);
+  const flowId = (await created.json()).id as string;
+
+  try {
+    const started = await request.post(`/api/v1/build/${flowId}/flow?log_builds=false`, {
+      headers,
+      data: { data: graph },
+      timeout: 30000,
+    });
+    if (!started.ok()) throw new Error(`build start failed: HTTP ${started.status()}`);
+    const jobId = (await started.json()).job_id as string;
+
+    // 60s against ~9s measured for all five components. Deliberately tight: this
+    // runs in the daily's `Collect models` PRE-FLIGHT, which shares its Langflow
+    // container with the @stable shard and has a history of wedging it (#922/#927,
+    // and #1011 where an over-eager pre-flight cost the entire run). Because the
+    // whole probe fails OPEN, an expired timeout degrades to "no build signal" and
+    // a warning — never to a blocked pre-flight or an inactive provider — so
+    // erring on the short side is the safe direction.
+    const events = await request.get(`/api/v1/build/${jobId}/events`, {
+      headers,
+      timeout: 60000,
+    });
+    if (!events.ok()) throw new Error(`build events failed: HTTP ${events.status()}`);
+
+    const outcomes: BuildVertexOutcome[] = [];
+    for (const line of (await events.text()).split("\n")) {
+      if (!line.trim()) continue;
+      let event: any;
+      try {
+        event = JSON.parse(line);
+      } catch {
+        continue; // a partial frame is not a verdict — ignore it
+      }
+      if (event?.event !== "end_vertex") continue;
+      const buildData = event.data?.build_data;
+      const key = nodeIdToKey.get(buildData?.id);
+      if (!key) continue;
+      for (const output of Object.values(buildData?.data?.outputs ?? {})) {
+        const errorMessage = (output as any)?.message?.errorMessage;
+        if (typeof errorMessage === "string" && errorMessage) {
+          outcomes.push({ componentKey: key, errorMessage });
+        }
+      }
+    }
+    return outcomes;
+  } finally {
+    // Always — a probe must never leak a flow onto the instance under test.
+    await request.delete(`/api/v1/flows/${flowId}`, { headers, timeout: 30000 }).catch(() => {});
+  }
+}
+
+function findTemplate(
+  registry: Record<string, Record<string, unknown>>,
+  key: string,
+): Record<string, unknown> {
+  for (const [category, components] of Object.entries(registry)) {
+    if (category === DISPLAY_NAMES_CATEGORY) continue;
+    if (components && typeof components === "object" && key in components) {
+      return (components as Record<string, Record<string, unknown>>)[key];
+    }
+  }
+  throw new Error(`template not found for ${key}`);
+}
+
+/**
+ * Runs both layers and returns a verdict per provider.
+ *
+ * FAILS OPEN on its own infrastructure. An unreachable registry, a build endpoint
+ * error or a timeout returns `ok: true` for everyone and logs a warning: the gate
+ * must never convert a runner-side hiccup into an `inactive` provider, which
+ * would be a hard failure of collect-models plus the silent downstream skips the
+ * whole mechanism exists to prevent. Same rule `readProviderHealth` (#1029) and
+ * `TRANSIENT_TRANSPORT` (#1011) already encode.
+ */
+export async function probeBuildAxis(
+  request: APIRequestContext,
+  providers: readonly Provider[],
+): Promise<Record<string, BuildAxisResult>> {
+  const results: Record<string, BuildAxisResult> = {};
+  for (const provider of providers) results[provider] = { ok: true };
+
+  try {
+    const auth = await getAuthToken(request);
+    const res = await request.get("/api/v1/all", {
+      headers: auth ? { Authorization: auth } : undefined,
+      timeout: 30000,
+    });
+    if (!res.ok()) throw new Error(`registry unreachable: HTTP ${res.status()}`);
+    const registry = (await res.json()) as Record<string, Record<string, unknown>>;
+
+    // Layer 1 — catalog.
+    const stillPresent: string[] = [];
+    for (const provider of providers) {
+      const keys = PROVIDER_COMPONENTS[provider] ?? [];
+      const missing = missingComponentKeys(registry, keys);
+      if (missing.length > 0) {
+        results[provider] = { ok: false, reason: buildAxisReason({ layer: "distribution", missing }) };
+        continue;
+      }
+      stillPresent.push(...keys);
+    }
+    if (stillPresent.length === 0) return results;
+
+    // Layer 2 — buildability, for whatever survived layer 1.
+    // Logged BEFORE the build so the step is observable even if the build hangs:
+    // a probe whose success is indistinguishable from a probe that never ran is
+    // the #505 class of blind spot this whole mechanism exists to remove.
+    console.log(`   build axis: building ${stillPresent.length} component(s) with no API key — ${stillPresent.join(", ")}`);
+    const outcomes = await buildComponents(request, auth, registry, stillPresent);
+    for (const provider of providers) {
+      if (!results[provider].ok) continue;
+      const keys = PROVIDER_COMPONENTS[provider] ?? [];
+      const broken = outcomes.find(
+        (o) => keys.includes(o.componentKey) && isPackagingError(o.errorMessage),
+      );
+      if (broken) {
+        results[provider] = {
+          ok: false,
+          reason: buildAxisReason({
+            layer: "runtime-package",
+            component: broken.componentKey,
+            message: broken.errorMessage,
+          }),
+        };
+      }
+    }
+  } catch (e: any) {
+    console.warn(
+      `⚠️  build-axis probe could not run (${e?.message ?? e}) — keeping the key-axis ` +
+        `verdict for every provider. This is a fail-open by design (#900).`,
+    );
+    for (const provider of providers) results[provider] = { ok: true };
+  }
+
+  for (const provider of providers) {
+    const r = results[provider];
+    console.log(`   build axis: ${r.ok ? "✅" : "❌"} ${provider}${r.ok ? "" : ` — ${r.reason}`}`);
+  }
+  return results;
+}


### PR DESCRIPTION
**Closes #900.**

`collect-models` recorded a provider `active` from the raw-key probe alone. That probe calls the provider's own API **upstream of Langflow**, so a valid key on an image that cannot instantiate the component produced a false `active` — and the real failure surfaced tens of layers downstream as a generic node-build timeout. It cost a full triage cycle twice: #898 / LE-1974 (`langchain-google-genai`, ~17 Google `@stable` specs) and #907 / LE-1987 (`langchain-groq` / `langchain-mistralai`).

This adds a second, independent **build axis**.

## Problem

A provider is only usable when two independent things hold, and only one was checked:

| Axis | Question | Failure it catches |
|---|---|---|
| Key | does the provider's cloud API accept this key? | drained credit, revoked key, spend cap |
| **Build** | can *this Langflow image* instantiate the component? | the component's distribution or its `langchain-*` package is missing |

## The measurement that decided the design

The issue originally proposed a cheap catalog scan of `GET /api/v1/all`. **That is not sufficient**, and the reason is an upstream implementation detail that varies *per component*: where the `langchain-*` import sits. Read from the installed sources in the running container, 1.12.0.dev8:

| Component | `langchain-*` import site | Package missing ⇒ |
|---|---|---|
| `OpenAIModelComponent` / `OpenAIEmbeddingsComponent` | module level | absent from the registry |
| `GoogleGenerativeAIComponent` (via `lfx.base`) / `…Embeddings` | module level | absent from the registry |
| **`AnthropicModelComponent`** | **lazy, inside `build_model()`** | **registers normally, fails at BUILD** |

So the failure mode #1039 first hit on Groq is **not a Groq quirk** — among the three providers this spec covers, Anthropic has exactly that shape today.

Proven end to end rather than reasoned about. Hiding `site-packages/langchain_anthropic` and restarting the backend leaves `ext:anthropic:AnthropicModelComponent@official` **present** in `/api/v1/all` (the catalog layer returns *available* — a false positive) while the build layer reports:

```
No module named 'langchain_anthropic'. This flow needs a Python package that is
not installed in this environment.
```

A restart is required to observe it — the import is cached in `sys.modules`, so hiding the package under a warm worker changes nothing.

Also ruled out by measurement: `POST /api/v1/validate/code` does **not** attempt imports (`from langchain_nonexistent_pkg import Foo` returns `{"imports":{"errors":[]}}`), so it cannot serve as a cheap import probe.

## Fix

Two layers in `tests/helpers/provider-setup/probe-component-buildable.ts`:

1. **Catalog** — one `GET /api/v1/all` with an **exact** provider → component-key map. Replaces the substring token match (where `openai` also matched `OpenAI Compatible`) and skips the `component_display_names` pseudo-category.
2. **Build** — every component that survived layer 1, as disconnected vertices of **one** throwaway flow, deleted in a `finally`. A **credentials error is a PASS**: it proves the client class was imported and constructed. Only a packaging signature reproves.

**No paid call is possible.** Every `SecretStrInput` is neutralised (`value: ""`, `load_from_db: false`) before the build. Load-bearing, not hygiene: the registry template ships `api_key` as `{ value: "OPENAI_API_KEY", load_from_db: true }`, so an un-neutralised probe would load the global variable `collect-models` itself just saved, and the default `text_output` output would invoke the model for real. Measured with the neutralisation in place: all five components fail on missing credentials, none reaches the network.

**Its own assert, not a rider on the existing one.** Every build-axis reason is stamped `build axis: `, and a dedicated step asserts no provider carries one. The existing "every env-keyed provider is ACTIVE" check skips providers whose env key is unset — but an unbuildable component is a broken *image* regardless of whether anyone configured a key, so folding it in would let an unbuildable Anthropic pass in silence on a run without `ANTHROPIC_API_KEY`.

**Fails OPEN on its own infrastructure**, with a 60s build timeout against ~9s measured. The daily's `Collect models` pre-flight shares its container with the `@stable` shard and has a history of wedging it (#922/#927, #1011), so a probe timeout degrades to a warning — never to a blocked pre-flight or a false `inactive`.

## Scope note

Only the providers in `providerConfigMap` (openai, anthropic, google) are covered. Groq and Mistral are deliberately not bundled in the image (#1039) and keep their per-spec `isProviderComponentAvailable` gate. Keeping them out is what makes a *declared per-provider expectation map* unnecessary: every provider listed here is one the image is expected to ship, so "component missing" is unambiguously a failure.

## Validation (nightly `1.12.0.dev8`, `--retries=0 --workers=1`)

- 3 clean runs, no flake ✅ — `expected=1 unexpected=0 flaky=0 backendErrors=false` each
- `npm run typecheck` ✅ 0 errors · `npm run lint` ✅ 0 errors
- `npm run test:units` ✅ 16 pass / 0 fail (new `probe-component-buildable.test.ts`)
- QA-CHECKLIST guard ✅ (manual bullets only; generated blocks untouched)
- Zero `🚨 Backend Error` ✅ · 29 flows on the instance, **zero `build-probe` orphans** ✅
- Force-fail ✅ — two mutations, both reverted, final green run after revert:
  - build-axis step also flags `google` → `unexpected=1` (the new assert is not vacuous)
  - `PROVIDER_COMPONENTS.openai` declares a key the registry does not expose → `unexpected=1`, failing with the designed message and **not** downgraded to the billing warning:
    ```
    env-keyed provider(s) inactive for a NON-billing reason: openai — build axis:
    component distribution not installed in this Langflow image —
    ext:openai:ThisComponentDoesNotExist@official absent from GET /api/v1/all.
    Install the provider's lfx distribution (see #1040)
    ```

> Note: `1.12.0.dev9` was published during this work. Validation stayed on `dev8` — the local container has no volume, so upgrading destroys the instance DB (flows + provider global variables). Everything measured and asserted here is internally consistent on `dev8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
