### PR TITLE
fix(ui-ux): leave the canvas-controls menu closed, whoever opened it (#997)

### DIFF
--- a/tests/helpers/ui/adjust-screen-view.test.ts
+++ b/tests/helpers/ui/adjust-screen-view.test.ts
@@ -1,8 +1,12 @@
 // Unit tests for adjustScreenView (issue #997).
 // Run with: npm run test:units
 //
-// Why this helper is unit-tested at all: it is called by ~65 spec files, and the
-// branch that used to be wrong is one the CURRENT UI cannot produce. On Nightly
+// Why this helper is unit-tested at all: 61 spec files call it directly and
+// another 47 reach it through `setupPlayground`, `initialGPTsetup`,
+// `prompt-template` and `SimpleAgentTemplatePage` — 108 in total, most of the
+// indirect half in `llm-agents/` and `playground/`, where a canvas interceptor
+// reads as an agent or provider failure. And the branch that used to be wrong is
+// one the CURRENT UI cannot produce. On Nightly
 // 1.12.0.dev7 every canvas control (`fit_view`, `zoom_out`, ...) is rendered
 // inside the dropdown's menu content, so `fit_view` is present if and only if
 // the menu is open — which is exactly why the pre-#997 bug was dormant. No E2E
@@ -25,10 +29,12 @@ import type { Page } from "@playwright/test";
 import { adjustScreenView } from "./adjust-screen-view";
 
 type Layout =
-  /** Today's build: the canvas controls live inside the dropdown menu. */
+  /** Today's build: every canvas control lives inside the dropdown menu. */
   | "in-dropdown"
-  /** Hypothetical build: the canvas controls sit directly on the canvas. */
-  | "on-canvas";
+  /** Hypothetical build: every canvas control sits directly on the canvas. */
+  | "on-canvas"
+  /** Hypothetical build, partial migration: only fit-view moved out. */
+  | "fit-view-on-canvas";
 
 interface FakeOptions {
   layout?: Layout;
@@ -36,6 +42,11 @@ interface FakeOptions {
   /** Set false to simulate a build whose trigger has no `data-state`. */
   exposesDataState?: boolean;
   zoomOutDisabled?: boolean;
+  /**
+   * Successive `.react-flow__viewport` style reads. The last entry repeats
+   * forever, so a single-element array models an already-settled viewport.
+   */
+  viewportStyles?: string[];
 }
 
 interface FakeCanvas {
@@ -44,6 +55,7 @@ interface FakeCanvas {
   readonly triggerClicks: number;
   readonly fitViewClicks: number;
   readonly zoomOutClicks: number;
+  readonly viewportReads: number;
 }
 
 function fakeCanvas({
@@ -51,22 +63,40 @@ function fakeCanvas({
   menuOpen = false,
   exposesDataState = true,
   zoomOutDisabled = false,
+  viewportStyles = ["transform: scale(1);"],
 }: FakeOptions = {}): FakeCanvas {
   const state = {
     menuOpen,
     triggerClicks: 0,
     fitViewClicks: 0,
     zoomOutClicks: 0,
+    viewportReads: 0,
   };
 
-  // A control is reachable while the menu is open — or always, once the
-  // controls are rendered on the canvas itself.
+  // A control is reachable while the menu is open, or once its own build has
+  // moved it onto the canvas.
+  const onCanvas = (testId: string) =>
+    layout === "on-canvas" ||
+    (layout === "fit-view-on-canvas" && testId === "fit_view");
+
   const controlCount = (testId: string) =>
     testId === "canvas_controls_dropdown" ||
-    layout === "on-canvas" ||
+    onCanvas(testId) ||
     state.menuOpen
       ? 1
       : 0;
+
+  // Playwright's locator methods do not resolve against a missing element: they
+  // reject once the timeout expires. Modelling that is what keeps the fake from
+  // flattering the helper — an `isDisabled` that quietly answers for an element
+  // that is not there would hide the partial-migration case entirely.
+  const requireRendered = (testId: string, method: string) => {
+    if (controlCount(testId) === 0) {
+      throw new Error(
+        `locator.${method}: Timeout 1000ms exceeded — ${testId} is not rendered`,
+      );
+    }
+  };
 
   const locator = (testId: string) => ({
     count: async () => controlCount(testId),
@@ -78,9 +108,7 @@ function fakeCanvas({
       }
       // Clicking a control must not dismiss the menu — these are plain buttons,
       // not Radix menu items (verified against the running nightly).
-      if (controlCount(testId) === 0) {
-        throw new Error(`clicked ${testId} while it was not rendered`);
-      }
+      requireRendered(testId, "click");
       if (testId === "fit_view") state.fitViewClicks += 1;
       if (testId === "zoom_out") state.zoomOutClicks += 1;
     },
@@ -91,16 +119,26 @@ function fakeCanvas({
       if (!exposesDataState) return null;
       return state.menuOpen ? "open" : "closed";
     },
-    isDisabled: async () => zoomOutDisabled,
+    isDisabled: async () => {
+      requireRendered(testId, "isDisabled");
+      return zoomOutDisabled;
+    },
   });
 
   const page = {
     waitForSelector: async () => undefined,
     waitForTimeout: async () => undefined,
     getByTestId: (testId: string) => locator(testId),
-    // The viewport-settle poll reads a stable value, so it returns on its
-    // second read — the shape the live measurement showed.
-    locator: () => ({ getAttribute: async () => "transform: scale(1);" }),
+    locator: () => ({
+      getAttribute: async () => {
+        const style =
+          viewportStyles[
+            Math.min(state.viewportReads, viewportStyles.length - 1)
+          ];
+        state.viewportReads += 1;
+        return style;
+      },
+    }),
   } as unknown as Page;
 
   return {
@@ -116,6 +154,9 @@ function fakeCanvas({
     },
     get zoomOutClicks() {
       return state.zoomOutClicks;
+    },
+    get viewportReads() {
+      return state.viewportReads;
     },
   };
 }
@@ -148,7 +189,7 @@ test("leaves a menu that was ALREADY open closed, without reopening it", async (
 test("never opens the menu when fit-view is reachable on the canvas", async () => {
   // The #997 bug. Pre-fix, `fitViewButton` was reassigned inside the `if`, so
   // the trailing guard was true on both paths and this call ended with an open
-  // canvas-controls menu — for all ~65 dependent specs at once.
+  // canvas-controls menu — for all 108 dependent specs at once.
   const canvas = fakeCanvas({ layout: "on-canvas", menuOpen: false });
 
   await adjustScreenView(canvas.page);
@@ -180,6 +221,62 @@ test("falls back to intent when the trigger exposes no data-state", async () => 
     "without a state signal it must still never OPEN a menu",
   );
   assert.equal(untouched.menuOpen, false);
+});
+
+test("throws, naming the cause, on a partial layout migration", async () => {
+  // fit-view moved onto the canvas, zoom-out left inside the menu. The helper
+  // has no reason to open a menu, so zoom-out is unreachable. It must NOT guess
+  // at the new layout, and it must not fall back to a blind toggle — it fails
+  // with a message that names the control and points at #997.
+  const canvas = fakeCanvas({ layout: "fit-view-on-canvas", menuOpen: false });
+
+  await assert.rejects(
+    () => adjustScreenView(canvas.page),
+    (err: Error) => {
+      assert.match(err.message, /adjustScreenView/);
+      assert.match(err.message, /zoom_out/);
+      assert.match(err.message, /#997/);
+      return true;
+    },
+  );
+
+  assert.equal(canvas.triggerClicks, 0, "it must not open a menu to recover");
+  assert.equal(canvas.menuOpen, false);
+});
+
+test("skips the zoom-out reachability check when no zoom-out was asked for", async () => {
+  const canvas = fakeCanvas({
+    layout: "fit-view-on-canvas",
+    menuOpen: false,
+  });
+
+  await adjustScreenView(canvas.page, { numberOfZoomOut: 0 });
+
+  assert.equal(canvas.fitViewClicks, 1);
+  assert.equal(canvas.zoomOutClicks, 0);
+  assert.equal(canvas.triggerClicks, 0);
+});
+
+test("keeps polling the viewport until the transform stops changing", async () => {
+  // Guards the settle loop itself: a poll that returned on its first read would
+  // pass every other test here, because they all model an already-stable
+  // viewport. Two moving reads, then a repeat — the earliest it may return is
+  // the read that matches its predecessor.
+  const canvas = fakeCanvas({
+    viewportStyles: [
+      "transform: translate(0px, 0px) scale(1);",
+      "transform: translate(-97px, -120px) scale(1.17);",
+      "transform: translate(-97px, -120px) scale(1.17);",
+    ],
+  });
+
+  await adjustScreenView(canvas.page, { numberOfZoomOut: 0 });
+
+  assert.equal(
+    canvas.viewportReads,
+    3,
+    "must not settle before two consecutive reads agree",
+  );
 });
 
 test("zooms out the requested number of times", async () => {

--- a/tests/helpers/ui/adjust-screen-view.test.ts
+++ b/tests/helpers/ui/adjust-screen-view.test.ts
@@ -1,0 +1,201 @@
+// Unit tests for adjustScreenView (issue #997).
+// Run with: npm run test:units
+//
+// Why this helper is unit-tested at all: it is called by ~65 spec files, and the
+// branch that used to be wrong is one the CURRENT UI cannot produce. On Nightly
+// 1.12.0.dev7 every canvas control (`fit_view`, `zoom_out`, ...) is rendered
+// inside the dropdown's menu content, so `fit_view` is present if and only if
+// the menu is open — which is exactly why the pre-#997 bug was dormant. No E2E
+// spec can reach the failing path until Langflow surfaces the fit-view control
+// directly on the canvas, at which point every dependent spec would start
+// leaving an open canvas-controls menu behind: a documented click interceptor
+// for the next canvas action (#576), arriving as a suite-wide break with a
+// confusing signature.
+//
+// So the widget is simulated here instead: a toggling trigger plus a switchable
+// layout, which lets both today's DOM and the hypothetical one be asserted.
+// The simulated contract was verified live against Nightly 1.12.0.dev7:
+//   - `canvas_controls_dropdown` carries Radix's data-state="open"|"closed";
+//   - `fit_view` count is 0 with the menu closed, 1 with it open;
+//   - clicking `fit_view` leaves the menu open (the zoom-out loop needs that);
+//   - `fitView()` is not animated — the viewport transform settles in a frame.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { Page } from "@playwright/test";
+import { adjustScreenView } from "./adjust-screen-view";
+
+type Layout =
+  /** Today's build: the canvas controls live inside the dropdown menu. */
+  | "in-dropdown"
+  /** Hypothetical build: the canvas controls sit directly on the canvas. */
+  | "on-canvas";
+
+interface FakeOptions {
+  layout?: Layout;
+  menuOpen?: boolean;
+  /** Set false to simulate a build whose trigger has no `data-state`. */
+  exposesDataState?: boolean;
+  zoomOutDisabled?: boolean;
+}
+
+interface FakeCanvas {
+  page: Page;
+  readonly menuOpen: boolean;
+  readonly triggerClicks: number;
+  readonly fitViewClicks: number;
+  readonly zoomOutClicks: number;
+}
+
+function fakeCanvas({
+  layout = "in-dropdown",
+  menuOpen = false,
+  exposesDataState = true,
+  zoomOutDisabled = false,
+}: FakeOptions = {}): FakeCanvas {
+  const state = {
+    menuOpen,
+    triggerClicks: 0,
+    fitViewClicks: 0,
+    zoomOutClicks: 0,
+  };
+
+  // A control is reachable while the menu is open — or always, once the
+  // controls are rendered on the canvas itself.
+  const controlCount = (testId: string) =>
+    testId === "canvas_controls_dropdown" ||
+    layout === "on-canvas" ||
+    state.menuOpen
+      ? 1
+      : 0;
+
+  const locator = (testId: string) => ({
+    count: async () => controlCount(testId),
+    click: async () => {
+      if (testId === "canvas_controls_dropdown") {
+        state.triggerClicks += 1;
+        state.menuOpen = !state.menuOpen;
+        return;
+      }
+      // Clicking a control must not dismiss the menu — these are plain buttons,
+      // not Radix menu items (verified against the running nightly).
+      if (controlCount(testId) === 0) {
+        throw new Error(`clicked ${testId} while it was not rendered`);
+      }
+      if (testId === "fit_view") state.fitViewClicks += 1;
+      if (testId === "zoom_out") state.zoomOutClicks += 1;
+    },
+    getAttribute: async (name: string) => {
+      if (testId !== "canvas_controls_dropdown" || name !== "data-state") {
+        return null;
+      }
+      if (!exposesDataState) return null;
+      return state.menuOpen ? "open" : "closed";
+    },
+    isDisabled: async () => zoomOutDisabled,
+  });
+
+  const page = {
+    waitForSelector: async () => undefined,
+    waitForTimeout: async () => undefined,
+    getByTestId: (testId: string) => locator(testId),
+    // The viewport-settle poll reads a stable value, so it returns on its
+    // second read — the shape the live measurement showed.
+    locator: () => ({ getAttribute: async () => "transform: scale(1);" }),
+  } as unknown as Page;
+
+  return {
+    page,
+    get menuOpen() {
+      return state.menuOpen;
+    },
+    get triggerClicks() {
+      return state.triggerClicks;
+    },
+    get fitViewClicks() {
+      return state.fitViewClicks;
+    },
+    get zoomOutClicks() {
+      return state.zoomOutClicks;
+    },
+  };
+}
+
+test("opens the menu when the controls are hidden, and closes it again", async () => {
+  const canvas = fakeCanvas({ layout: "in-dropdown", menuOpen: false });
+
+  await adjustScreenView(canvas.page);
+
+  assert.equal(canvas.fitViewClicks, 1);
+  assert.equal(canvas.triggerClicks, 2, "one click to open, one to close");
+  assert.equal(canvas.menuOpen, false, "the menu must not be left open");
+});
+
+test("leaves a menu that was ALREADY open closed, without reopening it", async () => {
+  // The regression guard for the obvious fix. Capturing "did I open it?" and
+  // closing only in that case reads as correct, but on today's build a caller
+  // can reach this helper with the menu already open (#576's leftover
+  // interceptor). Closing only what we opened would hand that interceptor
+  // straight to the next canvas click.
+  const canvas = fakeCanvas({ layout: "in-dropdown", menuOpen: true });
+
+  await adjustScreenView(canvas.page);
+
+  assert.equal(canvas.fitViewClicks, 1);
+  assert.equal(canvas.triggerClicks, 1, "no reopen — only the closing click");
+  assert.equal(canvas.menuOpen, false);
+});
+
+test("never opens the menu when fit-view is reachable on the canvas", async () => {
+  // The #997 bug. Pre-fix, `fitViewButton` was reassigned inside the `if`, so
+  // the trailing guard was true on both paths and this call ended with an open
+  // canvas-controls menu — for all ~65 dependent specs at once.
+  const canvas = fakeCanvas({ layout: "on-canvas", menuOpen: false });
+
+  await adjustScreenView(canvas.page);
+
+  assert.equal(canvas.fitViewClicks, 1);
+  assert.equal(canvas.triggerClicks, 0, "the menu was never needed");
+  assert.equal(canvas.menuOpen, false);
+});
+
+test("falls back to intent when the trigger exposes no data-state", async () => {
+  const opened = fakeCanvas({
+    layout: "in-dropdown",
+    menuOpen: false,
+    exposesDataState: false,
+  });
+  await adjustScreenView(opened.page);
+  assert.equal(opened.triggerClicks, 2, "closes what it opened");
+  assert.equal(opened.menuOpen, false);
+
+  const untouched = fakeCanvas({
+    layout: "on-canvas",
+    menuOpen: false,
+    exposesDataState: false,
+  });
+  await adjustScreenView(untouched.page);
+  assert.equal(
+    untouched.triggerClicks,
+    0,
+    "without a state signal it must still never OPEN a menu",
+  );
+  assert.equal(untouched.menuOpen, false);
+});
+
+test("zooms out the requested number of times", async () => {
+  const canvas = fakeCanvas();
+
+  await adjustScreenView(canvas.page, { numberOfZoomOut: 3 });
+
+  assert.equal(canvas.zoomOutClicks, 3);
+  assert.equal(canvas.menuOpen, false);
+});
+
+test("stops zooming out when the control reports disabled", async () => {
+  const canvas = fakeCanvas({ zoomOutDisabled: true });
+
+  await adjustScreenView(canvas.page, { numberOfZoomOut: 3 });
+
+  assert.equal(canvas.zoomOutClicks, 0);
+  assert.equal(canvas.menuOpen, false);
+});

--- a/tests/helpers/ui/adjust-screen-view.test.ts
+++ b/tests/helpers/ui/adjust-screen-view.test.ts
@@ -129,8 +129,18 @@ function fakeCanvas({
     waitForSelector: async () => undefined,
     waitForTimeout: async () => undefined,
     getByTestId: (testId: string) => locator(testId),
-    locator: () => ({
+    // The selector is CHECKED, not ignored. A fake that answers for any argument
+    // would pass every test here with a typo in `.react-flow__viewport`, while in
+    // production every read rejects and the settle loop silently burns its whole
+    // budget — i.e. the 500 ms sleep this helper replaced, at full price. Same
+    // class as `requireRendered` above: the fake must not flatter the helper.
+    locator: (selector: string) => ({
       getAttribute: async () => {
+        if (selector !== ".react-flow__viewport") {
+          throw new Error(
+            `locator.getAttribute: Timeout 200ms exceeded — no element matches ${selector}`,
+          );
+        }
         const style =
           viewportStyles[
             Math.min(state.viewportReads, viewportStyles.length - 1)
@@ -199,28 +209,64 @@ test("never opens the menu when fit-view is reachable on the canvas", async () =
   assert.equal(canvas.menuOpen, false);
 });
 
-test("falls back to intent when the trigger exposes no data-state", async () => {
+/**
+ * Runs `fn` with `console.warn` captured, returning what it emitted.
+ *
+ * The fallback below is the one branch whose CORRECTNESS cannot be asserted —
+ * it is the behaviour #997 rejected, kept only because it can never open a menu.
+ * So what gets pinned instead is that it announces itself: the warning is the
+ * only signal that the helper stopped reading the real open/closed state.
+ */
+async function captureWarnings(fn: () => Promise<void>): Promise<string[]> {
+  const original = console.warn;
+  const warnings: string[] = [];
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(" "));
+  };
+  try {
+    await fn();
+  } finally {
+    console.warn = original;
+  }
+  return warnings;
+}
+
+test("falls back to intent when the trigger exposes no data-state, and says so", async () => {
   const opened = fakeCanvas({
     layout: "in-dropdown",
     menuOpen: false,
     exposesDataState: false,
   });
-  await adjustScreenView(opened.page);
+  const warnings = await captureWarnings(() => adjustScreenView(opened.page));
   assert.equal(opened.triggerClicks, 2, "closes what it opened");
   assert.equal(opened.menuOpen, false);
+
+  // Degrading into #997's boolean must never be silent: no other test can catch
+  // it, because this very test asserts the fallback as acceptable behaviour.
+  assert.equal(warnings.length, 1, JSON.stringify(warnings));
+  assert.match(warnings[0], /adjustScreenView/);
+  assert.match(warnings[0], /data-state/);
+  assert.match(warnings[0], /#997/);
 
   const untouched = fakeCanvas({
     layout: "on-canvas",
     menuOpen: false,
     exposesDataState: false,
   });
-  await adjustScreenView(untouched.page);
+  await captureWarnings(() => adjustScreenView(untouched.page));
   assert.equal(
     untouched.triggerClicks,
     0,
     "without a state signal it must still never OPEN a menu",
   );
   assert.equal(untouched.menuOpen, false);
+});
+
+test("the normal path warns about nothing", async () => {
+  // The warning is only worth anything if it does not cry wolf on 108 specs.
+  const canvas = fakeCanvas({ layout: "in-dropdown", menuOpen: false });
+  const warnings = await captureWarnings(() => adjustScreenView(canvas.page));
+  assert.deepEqual(warnings, []);
 });
 
 test("throws, naming the cause, on a partial layout migration", async () => {

--- a/tests/helpers/ui/adjust-screen-view.ts
+++ b/tests/helpers/ui/adjust-screen-view.ts
@@ -1,6 +1,8 @@
 import type { Page } from "@playwright/test";
 
 const CONTROLS = "canvas_controls_dropdown";
+const FIT_VIEW = "fit_view";
+const ZOOM_OUT = "zoom_out";
 const VIEWPORT = ".react-flow__viewport";
 
 /**
@@ -25,6 +27,10 @@ async function waitForViewportSettled(page: Page): Promise<void> {
   while (Date.now() < deadline) {
     // Short per-read timeout: the default actionTimeout (20 s) would turn a
     // missing viewport into a 20 s stall instead of a poll that just retries.
+    // The catch covers an absent viewport AND a strict-mode violation (should a
+    // build ever render two of them); either way the loop simply runs out its
+    // budget and the helper degrades to the 500 ms sleep this replaced — never
+    // worse than the previous behaviour, but silently so.
     const current = await viewport
       .getAttribute("style", { timeout: 200 })
       .catch(() => null);
@@ -78,6 +84,13 @@ async function closeCanvasControls(
  * surfaces the fit-view control directly on the canvas, `fit_view` is present
  * with the menu closed. This helper must not open a menu in that case — see
  * `closeCanvasControls` and issue #997.
+ *
+ * What it deliberately does NOT do is survive a *partial* migration — fit-view
+ * moved out, zoom-out left behind. Zooming out would then need a menu this call
+ * had no reason to open, and guessing at a layout no build has shipped is how a
+ * helper on 108 specs grows an untestable branch. It throws instead, naming the
+ * cause: a loud, attributed failure is the whole point of #997, whose bug was
+ * dormant precisely because it failed quietly.
  */
 export async function adjustScreenView(
   page: Page,
@@ -91,17 +104,38 @@ export async function adjustScreenView(
     timeout: 30000,
   });
 
-  const fitViewHidden = (await page.getByTestId("fit_view").count()) === 0;
+  // Tracked separately from the `fit_view` probe below: they coincide today,
+  // but only because opening immediately follows the probe. `closeCanvasControls`
+  // asks "did THIS call open the menu", and that question must keep its own
+  // answer if anything is ever inserted between the two.
+  let openedByThisCall = false;
 
-  if (fitViewHidden) {
+  if ((await page.getByTestId(FIT_VIEW).count()) === 0) {
     await page.getByTestId(CONTROLS).click();
+    openedByThisCall = true;
   }
 
-  await page.getByTestId("fit_view").click();
+  await page.getByTestId(FIT_VIEW).click();
   await waitForViewportSettled(page);
 
+  if (
+    numberOfZoomOut > 0 &&
+    (await page.getByTestId(ZOOM_OUT).count()) === 0
+  ) {
+    // Fail here rather than on a 1 s `isDisabled` timeout inside the loop, whose
+    // message says nothing about why the control is missing.
+    throw new Error(
+      `[adjustScreenView] "${ZOOM_OUT}" is not rendered. On the build this ` +
+        `helper was written against, the canvas controls live inside the ` +
+        `"${CONTROLS}" menu, so this means "${FIT_VIEW}" was reachable with ` +
+        `that menu closed — a Langflow layout change (#997). Zooming out needs ` +
+        `the menu open; teach this helper how the new layout exposes the ` +
+        `controls rather than reintroducing a blind toggle.`,
+    );
+  }
+
   for (let i = 0; i < numberOfZoomOut; i++) {
-    const zoomOutButton = page.getByTestId("zoom_out");
+    const zoomOutButton = page.getByTestId(ZOOM_OUT);
 
     if (await zoomOutButton.isDisabled({ timeout: 1000 })) {
       break;
@@ -110,5 +144,5 @@ export async function adjustScreenView(
     }
   }
 
-  await closeCanvasControls(page, fitViewHidden);
+  await closeCanvasControls(page, openedByThisCall);
 }

--- a/tests/helpers/ui/adjust-screen-view.ts
+++ b/tests/helpers/ui/adjust-screen-view.ts
@@ -1,5 +1,84 @@
 import type { Page } from "@playwright/test";
 
+const CONTROLS = "canvas_controls_dropdown";
+const VIEWPORT = ".react-flow__viewport";
+
+/**
+ * Waits for React Flow's viewport transform to stop changing.
+ *
+ * Replaces a fixed `waitForTimeout(500)`. Measured on Nightly 1.12.0.dev7:
+ * `CanvasControlsDropdown` calls React Flow's `fitView()` with no `duration`,
+ * so the new transform is applied in a single frame — the viewport's `style`
+ * reached its final value between the 20 ms and 47 ms samples after the click
+ * and never moved again. The sleep was therefore paying ~450 ms on every call,
+ * on every one of this helper's dependent specs.
+ *
+ * Two consecutive identical reads count as settled, so the common case costs
+ * one extra poll (~50 ms). The 500 ms cap keeps the worst case no slower than
+ * the sleep it replaces, should a future build ever animate the transition.
+ */
+async function waitForViewportSettled(page: Page): Promise<void> {
+  const viewport = page.locator(VIEWPORT);
+  const deadline = Date.now() + 500;
+  let previous: string | null = null;
+
+  while (Date.now() < deadline) {
+    // Short per-read timeout: the default actionTimeout (20 s) would turn a
+    // missing viewport into a 20 s stall instead of a poll that just retries.
+    const current = await viewport
+      .getAttribute("style", { timeout: 200 })
+      .catch(() => null);
+    if (current !== null && current === previous) return;
+    previous = current;
+    await page.waitForTimeout(50);
+  }
+}
+
+/**
+ * Leaves the canvas-controls menu CLOSED — whoever opened it.
+ *
+ * The postcondition is what the callers need, and it is deliberately not
+ * expressed as a toggle. An open canvas-controls menu is a documented click
+ * interceptor for the next canvas action (#576), so "close it if it is open"
+ * is correct on every path; "click the trigger again" is only correct while
+ * the menu happens to be open, and silently *opens* one otherwise.
+ *
+ * Radix renders the trigger with `data-state="open" | "closed"` (verified on
+ * Nightly 1.12.0.dev7), which answers the question directly. If that attribute
+ * ever disappears we fall back to intent — close only what this call opened —
+ * which is still safe: it can leave a pre-existing menu open, but it can never
+ * open one.
+ */
+async function closeCanvasControls(
+  page: Page,
+  openedByThisCall: boolean,
+): Promise<void> {
+  const controls = page.getByTestId(CONTROLS);
+  const state = await controls
+    .getAttribute("data-state", { timeout: 1000 })
+    .catch(() => null);
+  const isOpen = state === null ? openedByThisCall : state === "open";
+
+  if (isOpen) {
+    await controls.click({ force: true, timeout: 1000 });
+  }
+}
+
+/**
+ * Fits the canvas to the flow, optionally zooms out, and returns with the
+ * canvas-controls menu closed.
+ *
+ * `fit_view` and `zoom_out` are rendered inside the dropdown's menu content
+ * (`CanvasControlsDropdown.tsx`), so on today's build they exist only while the
+ * menu is open — which is why this helper opens it first. They are plain
+ * buttons rather than menu items, so clicking them does not dismiss the menu
+ * and the zoom-out loop below still finds its target.
+ *
+ * That layout is a property of the current UI, not a contract: the day Langflow
+ * surfaces the fit-view control directly on the canvas, `fit_view` is present
+ * with the menu closed. This helper must not open a menu in that case — see
+ * `closeCanvasControls` and issue #997.
+ */
 export async function adjustScreenView(
   page: Page,
   {
@@ -8,19 +87,18 @@ export async function adjustScreenView(
     numberOfZoomOut?: number;
   } = {},
 ) {
-  await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
+  await page.waitForSelector(`[data-testid="${CONTROLS}"]`, {
     timeout: 30000,
   });
 
-  let fitViewButton = await page.getByTestId("fit_view").count();
+  const fitViewHidden = (await page.getByTestId("fit_view").count()) === 0;
 
-  if (fitViewButton === 0) {
-    await page.getByTestId("canvas_controls_dropdown").click();
-    fitViewButton = await page.getByTestId("fit_view").count();
+  if (fitViewHidden) {
+    await page.getByTestId(CONTROLS).click();
   }
 
   await page.getByTestId("fit_view").click();
-  await page.waitForTimeout(500);
+  await waitForViewportSettled(page);
 
   for (let i = 0; i < numberOfZoomOut; i++) {
     const zoomOutButton = page.getByTestId("zoom_out");
@@ -31,9 +109,6 @@ export async function adjustScreenView(
       await zoomOutButton.click({ timeout: 1000 });
     }
   }
-  if (fitViewButton > 0) {
-    await page
-      .getByTestId("canvas_controls_dropdown")
-      .click({ force: true, timeout: 1000 });
-  }
+
+  await closeCanvasControls(page, fitViewHidden);
 }

--- a/tests/helpers/ui/adjust-screen-view.ts
+++ b/tests/helpers/ui/adjust-screen-view.ts
@@ -16,8 +16,19 @@ const VIEWPORT = ".react-flow__viewport";
  * on every one of this helper's dependent specs.
  *
  * Two consecutive identical reads count as settled, so the common case costs
- * one extra poll (~50 ms). The 500 ms cap keeps the worst case no slower than
- * the sleep it replaces, should a future build ever animate the transition.
+ * one extra poll (~50 ms). The cap bounds the worst case at roughly the 500 ms
+ * sleep this replaced — not exactly: a read that burns its 200 ms timeout just
+ * before the deadline, plus the trailing 50 ms wait, overshoots to ~750 ms.
+ *
+ * THE TWO-EQUAL-READS RULE IS LOAD-BEARING ON `fitView()` BEING UNANIMATED.
+ * With an instantaneous transform, two equal reads can only mean "already
+ * final". Animate the transition and that stops being true — two 50 ms samples
+ * can coincide mid-movement (a paused frame, an eased segment, a duration under
+ * the sample interval) and the poll would return on a transform that is still
+ * travelling. The 500 ms cap does NOT cover that: it bounds how long this waits,
+ * not whether what it settled on is final. If a future build animates the
+ * canvas controls, this function needs a different stop condition — poll for a
+ * stable read over a minimum span, or wait on React Flow's own transition end.
  */
 async function waitForViewportSettled(page: Page): Promise<void> {
   const viewport = page.locator(VIEWPORT);
@@ -54,6 +65,13 @@ async function waitForViewportSettled(page: Page): Promise<void> {
  * ever disappears we fall back to intent — close only what this call opened —
  * which is still safe: it can leave a pre-existing menu open, but it can never
  * open one.
+ *
+ * That fallback is ANNOUNCED rather than silent, and the warning is the point.
+ * "Close only what this call opened" is precisely the fix #997 proposed and this
+ * helper rejects, so degrading into it un-fixes the already-open case (#576's
+ * leftover interceptor) — and no test can catch that, because the unit test for
+ * this branch asserts the fallback as correct behaviour. If the attribute moves
+ * off the element carrying the testid, the only signal will be this line.
  */
 async function closeCanvasControls(
   page: Page,
@@ -63,6 +81,17 @@ async function closeCanvasControls(
   const state = await controls
     .getAttribute("data-state", { timeout: 1000 })
     .catch(() => null);
+
+  if (state === null) {
+    console.warn(
+      `⚠️  [adjustScreenView] "${CONTROLS}" exposed no \`data-state\` — falling ` +
+        `back to closing only what this call opened. A menu that was ALREADY ` +
+        `open stays open and will intercept the next canvas click (#576). This ` +
+        `is the behaviour #997 rejected: find where Radix now carries the ` +
+        `open/closed state and read it there.`,
+    );
+  }
+
   const isOpen = state === null ? openedByThisCall : state === "open";
 
   if (isOpen) {


### PR DESCRIPTION
**Closes #997.**

## Problem

`adjustScreenView` closed the canvas-controls dropdown behind a guard that was
true on **both** paths, because `fitViewButton` is reassigned inside the `if`:

```ts
let fitViewButton = await page.getByTestId("fit_view").count();
if (fitViewButton === 0) {
  await page.getByTestId("canvas_controls_dropdown").click();
  fitViewButton = await page.getByTestId("fit_view").count();   // ← now > 0
}
...
if (fitViewButton > 0) { /* toggle the trigger */ }
```

An open canvas-controls menu is a documented click interceptor for the next
canvas action (#576), and this helper reaches **108 spec files** — see below.

### Blast radius

The issue's `grep` reported 86 dependents; that is now 65 after the spec
consolidations in #1046 / #1047 / #1049, of which **61 actually call the
helper**. But a direct `grep` under-counts, because four shared pieces call it
too — so specs that never import it still go through it:

- `tests/helpers/flows/setup-playground.ts`
- `tests/helpers/other/initialGPTsetup.ts`
- `tests/helpers/ui/prompt-template.ts`
- `tests/pages/SimpleAgentTemplatePage.ts`

That adds **47 spec files** invisible to any `adjustScreenView` search:

| Area | direct | indirect only |
|---|---|---|
| `core-functionality/llm-agents/` | 9 | **21** |
| `core-functionality/playground/` | 3 | **17** |
| `core-components/` | 15 | — |
| `flow-functionality/` | 14 | 3 |
| `ui-ux/` | 7 | 2 |
| `core-functionality/model-provider/` | 3 | 3 |
| `mcp/` (client + server) | 4 | 1 |
| `knowledge-ingestion-management/` | 2 | — |
| `templates/`, `project-management/`, `auth/`, `api/flows/` | 1 each | — |
| **Total** | **61** | **47** |

The indirect half is what makes this worth fixing carefully: a break here does
not arrive as 61 obvious canvas failures. It lands mostly in `llm-agents/` and
`playground/`, where a `<html> intercepts pointer events` failure reads as an
agent or provider problem — the misattribution class of #576.

## Fix

**Not the fix the issue proposes**, and that is the substance of this PR.

#997 proposes capturing the boolean before the reassignment and closing only
what the call opened. That is correct for the UI the issue anticipates — the day
fit-view is surfaced directly on the canvas — but it **regresses the build we run
today**. Read against Langflow's `CanvasControlsDropdown.tsx` and verified live
on Nightly 1.12.0.dev7:

| Fact | How it was verified |
|---|---|
| `fit_view`, `zoom_in`, `zoom_out`, `reset_zoom` are all inside `DropdownMenuContent` | source + live count |
| ⇒ `fit_view` is present **iff** the menu is open | count 0 closed / 1 open |
| The trigger carries Radix's `data-state="open"｜"closed"` | attribute dump off the live DOM |
| Clicking `fit_view` does **not** dismiss the menu | `data-state` stays `open` (plain `Button`, not `DropdownMenuItem`) |

So on today's build, "fit_view was already visible" means **the menu was already
open** — #576's leftover interceptor — and the current toggle happens to close
it. Closing only what we opened would hand that menu straight to the next canvas
click.

This PR encodes the **postcondition** instead of a toggle: *the canvas-controls
menu is closed on return, whoever opened it*, guarded on the trigger's real
`data-state`. That holds on both the current layout and the one the issue
anticipates. If `data-state` ever disappears, the helper falls back to intent —
it can then leave a pre-existing menu open, but it can never open one.

**Rejected alternatives:** the issue's boolean (fails the already-open case,
demonstrated below); pressing `Escape` (deselects nodes — too broad a side effect
for 108 dependents).

### Secondary: the 500 ms sleep

Replaced by a viewport-stability poll. Measured, not assumed: `fitView()` is
called with no `duration`, so the `.react-flow__viewport` transform reaches its
final value between the 20 ms and 47 ms samples after the click and never moves
again. Typical cost is now one extra poll (~50 ms); the 500 ms cap keeps the
worst case no slower than the sleep it replaces.

## Scope note

The zoom-out loop, its disabled-button break, the `numberOfZoomOut` option and
the 30 s canvas wait are unchanged. No spec, tag, doc or checklist bullet
changes — this is a helper fix, so there is no `QA-CHECKLIST.md` edit to make.

Three sibling helpers carry the same defect class and are **deliberately left
alone** (shared-file risk, one issue / one PR) — proposed as a follow-up:
`tests/helpers/ui/zoom-out.ts` (identical reassignment, 18 dependents),
`tests/helpers/filesystem/upload-file.ts` (opens and toggles unconditionally, 3
dependents), and `FlowEditorPage.adjustView()` (guards on the trigger's count,
which is always 1 — currently dead code).

## Validation (nightly 1.12.0.dev7, `--workers=2`, `--retries=0`)

### Conclusion

**No failure is attributable to this change**, and the one candidate that looked
like a regression was isolated and refuted with six runs. On the build we run
today the helper's observable behaviour is in fact **unchanged** — both paths
already ended with the menu closed — so what the diff buys is correctness on a
layout that has not shipped yet, ~450 ms per call, and a guard that fails 5/9
against the pre-fix helper so the bug cannot come back silently.

It does **not** claim a green suite: this machine is noisy, for reasons
identified below.

### Static gates

| Check | Result |
|---|---|
| `npm run typecheck` | clean |
| `npm run lint` | 0 errors |
| `npm run test:units` | 73/73 |
| `npm run test:scripts` | 89/89 |
| `node --require ts-node/register --test tests/helpers/ui/adjust-screen-view.test.ts` | 9/9 pass |
| the same tests vs. the **pre-fix** helper | **5/9 fail** — the guards catch the regression |
| the same tests vs. the fix **as proposed in #997** | **3/9 fail** — including the already-open case |

Unit tests live next to the helper because **the branch that was wrong is one the
current UI cannot produce** — no E2E spec can reach it until Langflow moves the
control onto the canvas, at which point all 108 dependents break at once with a
`<html> intercepts pointer events` signature. The tests simulate both layouts.

### E2E

CI could not provide any: `pr-validation.yml` selects no specs for a helper
change (#1054) and `manual.yml` cannot execute a spec at all (#1055, discovered
by dispatching it for this PR). Run locally instead — the same 135-test scope the
dispatch was meant to cover (`@stable` AND `(?:@ui-ux|@workspace)`, 69 files),
twice: once on this branch, once with the helper reverted to `main`.

| 135 tests | passed | failed | skipped |
|---|---|---|---|
| pre-fix helper | 111 | **21** | 3 |
| this PR | 117 | **15** | 3 |

14 failures occur on both sides, 7 only without the fix, and **1 only with it**.

**The regression candidate, resolved.** `execution-error-notification.spec.ts`
failed only in the post-fix run. Isolated and re-run three times each way:
`3 passed / 0 failed` in all six. Deterministically green both ways, so it is a
flake under parallel load — consistent with where it failed, a hidden
`sidebar-search-input` at `setupChatFlow` line 54, which runs *before* both
`zoomOut` (line 68) and `adjustScreenView` (line 81).

The 21→15 delta is directionally positive but sits inside this box's noise; I
would not bank on it.

**Why the noise exists.** 8 of the 15 shared failures carry one signature —
`strict mode violation: getByTestId('add-component-button-chat-input') resolved
to 2 elements`, the second being `saved_componentsChat Input`. A saved component
named "Chat Input" had been left on the local instance by a failing
`saveComponents.spec.ts`; confirmed via the API and deleted. Worth a look beyond
this box: daily shards are file-level against one shared backend, so a leak there
breaks every later spec in the shard that uses the bare testid — the
cross-contamination class of #515.

Separately observed and **not** addressed here: `canvas-zoom-navigation.spec.ts`
fails 2–4 tests per run on this box against unmodified code, including Fit View
leaving the viewport at `scale(2)` (the max-zoom clamp). It is `@stable`, recent,
and does not call this helper — worth watching on the next daily.

### Reproduce

```bash
# regression guards
node --require ts-node/register --test tests/helpers/ui/adjust-screen-view.test.ts   # 9 pass
git stash push tests/helpers/ui/adjust-screen-view.ts
node --require ts-node/register --test tests/helpers/ui/adjust-screen-view.test.ts   # 5 fail
git stash pop

# the E2E scope (needs the nightly on localhost:7860)
PLAYWRIGHT_RETRIES=0 npx playwright test --workers=2 \
  --grep "(?=.*@stable)(?=.*(?:@ui-ux|@workspace))"
```
