### PR TITLE
ci(manual): import provider credentials so a dispatch can run a spec (#1055)

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -136,6 +136,81 @@ jobs:
           curl -sf --retry 10 --retry-delay 3 --retry-connrefused \
             "$OLLAMA_BASE_URL/api/tags" | grep -q "$OLLAMA_TEST_MODEL" \
             && echo "model $OLLAMA_TEST_MODEL ready"
+
+      # Import the provider credentials into THIS run's Langflow container, the
+      # same way daily-stable.yml and pr-validation.yml do (#1055).
+      #
+      # Without it every dispatch died before the first test: the run below
+      # passes OPENAI_API_KEY, and the #884 pre-flight hard-fails in CI on a key
+      # that is present in the environment but absent from Langflow's global
+      # variables — which is exactly the state a container that never ran
+      # collect-models is in. The gate landed 2026-07-22 (#885) and this
+      # workflow's last dispatch before the bug surfaced was 2026-07-08, so no
+      # one had run it since.
+      #
+      # Dropping the key instead would NOT have been equivalent: the provider
+      # health gate fails OPEN when providers.json is absent
+      # (`readProviderHealth` → null, #1029), so the provider-hardcoded specs
+      # would run against a credential-less Langflow and fail with the
+      # misleading node_duration errors #884 exists to remove.
+      #
+      # Same three guards the other two workflows carry:
+      #  - PREFLIGHT_SKIP_CREDENTIALS: this run is what IMPORTS the keys, so the
+      #    pre-flight must not assert them first (chicken-and-egg);
+      #  - PLAYWRIGHT_RETRIES=0: a failing sweep must not re-walk the Model
+      #    Providers UI three times against a single backend (#1011);
+      #  - continue-on-error: a drained key must not kill the specs that never
+      #    touch that provider (#980).
+      - name: Collect models
+        id: collect_models
+        continue-on-error: true
+        run: npx playwright test tests/collect-models.spec.ts --reporter=line
+        env:
+          CI: "true"
+          PLAYWRIGHT_BASE_URL: ${{ needs.detect-target.outputs.base_url }}
+          PLAYWRIGHT_RETRIES: "0"
+          PREFLIGHT_SKIP_CREDENTIALS: "1"
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+
+      # The sweep above can leave the shared backend WEDGED — container alive,
+      # event loop blocked, requests unanswered (#922/#927). globalSetup polls
+      # 120 s and then throws, reporting a preflight error that names nothing, so
+      # wait it out here and, when it does not clear, fail with the real cause.
+      # Short per-request timeout over a long deadline (#928): a hung request must
+      # fail fast so the loop keeps polling across the wedge.
+      #
+      # This is the FOURTH copy of this loop (daily-stable, pr-validation, here,
+      # and the one weekly-stable still lacks). #1045 extracts them into
+      # `.github/actions/wait-for-backend`; adopt it here when it lands rather
+      # than letting this drift on its own.
+      - name: Wait for the backend to recover from the collect-models load
+        shell: bash
+        env:
+          BASE_URL: ${{ needs.detect-target.outputs.base_url }}
+          COLLECT_MODELS_OUTCOME: ${{ steps.collect_models.outcome }}
+        run: |
+          if [ "$COLLECT_MODELS_OUTCOME" = "failure" ]; then
+            echo "::warning::Collect models FAILED. The run continues by design (#980), but providers.json/models.json may be stale or incomplete, so provider-parameterized specs can skip. Check that step's log for which provider is down."
+          fi
+          deadline=$(( $(date +%s) + 420 ))
+          attempt=0
+          while :; do
+            attempt=$((attempt + 1))
+            if curl -sf --connect-timeout 5 --max-time 8 "${BASE_URL%/}/api/v1/version" >/dev/null 2>&1; then
+              echo "Backend answered /api/v1/version on attempt $attempt — proceeding to the tests."
+              exit 0
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::Langflow did not answer /api/v1/version within 420s after the Collect models step (${attempt} attempts). The backend is wedged or dead, so the run would abort in globalSetup with zero tests. This is the post-collect-models wedge (#922/#927/#1011), NOT a failure of the tests you dispatched."
+              exit 1
+            fi
+            sleep 5
+          done
+
       - name: Run tests and upload report
         uses: ./.github/actions/run-e2e
         with:
@@ -160,10 +235,25 @@ jobs:
       - run: npm ci
       - name: Install Playwright browsers
         uses: ./.github/actions/setup-playwright
+
+      # No `openai_api_key`, and no `collect-models` — deliberately different
+      # from the Docker job (#1055).
+      #
+      # This job targets an instance that already exists and that we do not own:
+      # a staging deployment, someone's tunnel. `collect-models` would WRITE our
+      # CI provider keys into that instance as global variables, which is not a
+      # side effect a test dispatch may have on a shared environment. Passing the
+      # key WITHOUT importing it is what broke this workflow in the first place —
+      # the #884 pre-flight hard-fails on a key present in the environment but
+      # absent from Langflow.
+      #
+      # So the target's OWN credentials govern. With no provider key in the
+      # environment the pre-flight has nothing to assert and skips the check, and
+      # the provider specs exercise whatever that instance is actually configured
+      # with — the honest thing to test against a deployment we do not control.
       - name: Run tests and upload report
         uses: ./.github/actions/run-e2e
         with:
           base_url: ${{ needs.detect-target.outputs.base_url }}
           test_tag: ${{ github.event.inputs.test_tag }}
           test_grep: ${{ github.event.inputs.test_grep }}
-          openai_api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -192,20 +192,47 @@ jobs:
         env:
           BASE_URL: ${{ needs.detect-target.outputs.base_url }}
           COLLECT_MODELS_OUTCOME: ${{ steps.collect_models.outcome }}
+          # 420 s, matching pr-validation.yml rather than daily-stable.yml's 300 s
+          # — this run's own measurement (30422284968) took 260 s to clear, 87% of
+          # a 300 s budget. Parameterized like the other two copies so the value
+          # lives in one place instead of being repeated in the error message.
+          RECOVER_TIMEOUT_S: "420"
         run: |
           if [ "$COLLECT_MODELS_OUTCOME" = "failure" ]; then
             echo "::warning::Collect models FAILED. The run continues by design (#980), but providers.json/models.json may be stale or incomplete, so provider-parameterized specs can skip. Check that step's log for which provider is down."
           fi
-          deadline=$(( $(date +%s) + 420 ))
+          deadline=$(( $(date +%s) + RECOVER_TIMEOUT_S ))
           attempt=0
+          rc=0
           while :; do
             attempt=$((attempt + 1))
-            if curl -sf --connect-timeout 5 --max-time 8 "${BASE_URL%/}/api/v1/version" >/dev/null 2>&1; then
+            # `|| rc=$?` keeps the non-zero exit from tripping `bash -e` AND
+            # preserves curl's code, which is the one datum that distinguishes the
+            # two states this step exists to attribute (decoded at the deadline).
+            rc=0
+            curl -sf --connect-timeout 5 --max-time 8 "${BASE_URL%/}/api/v1/version" >/dev/null 2>&1 || rc=$?
+            if [ "$rc" -eq 0 ]; then
               echo "Backend answered /api/v1/version on attempt $attempt — proceeding to the tests."
               exit 0
             fi
+            # Heartbeat every ~6 attempts (~30 s when refused, ~78 s when each GET
+            # hangs for the full --max-time). This step legitimately sat silent for
+            # 4 min 20 s on the validation dispatch, and a manual run is the one a
+            # human watches live — without this it reads as hung.
+            if [ $((attempt % 6)) -eq 0 ]; then
+              echo "Still waiting: attempt $attempt, last curl exit=$rc, $(( deadline - $(date +%s) ))s left of ${RECOVER_TIMEOUT_S}s."
+            fi
             if [ "$(date +%s)" -ge "$deadline" ]; then
-              echo "::error::Langflow did not answer /api/v1/version within 420s after the Collect models step (${attempt} attempts). The backend is wedged or dead, so the run would abort in globalSetup with zero tests. This is the post-collect-models wedge (#922/#927/#1011), NOT a failure of the tests you dispatched."
+              # 7 = connection refused (nothing listening → the backend is DEAD or
+              # never came back); 28 = timeout (connection accepted, no answer →
+              # the WEDGE shape of #922/#927). Naming it here saves the next reader
+              # a dig through the container log.
+              case "$rc" in
+                7) diag="connection refused — the backend is DEAD or never came back";;
+                28) diag="connection accepted but unanswered within 8s — the WEDGE shape of #922/#927";;
+                *) diag="last curl exit code $rc";;
+              esac
+              echo "::error::Langflow did not answer /api/v1/version within ${RECOVER_TIMEOUT_S}s after the Collect models step (${attempt} attempts; ${diag}). The backend is wedged or dead, so the run would abort in globalSetup with zero tests. This is the post-collect-models wedge (#922/#927/#1011), NOT a failure of the tests you dispatched."
               exit 1
             fi
             sleep 5


### PR DESCRIPTION
**Closes #1055.**

## Problem

Every `manual.yml` dispatch died in `globalSetup` before the first test, on both
the main run and the destructive lane:

```
[preflight] backend healthy at http://localhost:7860/ — Langflow Nightly 1.12.0.dev9
Error: [preflight] provider key(s) set in the environment but NOT configured as a
Langflow global variable: OPENAI_API_KEY.
```

The workflow passes `secrets.OPENAI_API_KEY` into `run-e2e` on **every** dispatch,
has **no `collect-models` step** to import it into Langflow, and never sets
`PREFLIGHT_SKIP_CREDENTIALS` — precisely the state the #884 pre-flight hard-fails
on in CI. No dispatch input could work around it.

The gate landed 2026-07-22 (#885). This workflow's last dispatch before the bug
surfaced was **2026-07-08**, and the file itself had not changed since 07-14 — so
nobody had run it since the gate existed. Found by dispatching it to give PR
#1052 the E2E coverage `pr-validation.yml` does not provide for a shared-helper
change (#1054).

## Fix

The two jobs get **deliberately different treatment**, because they target
different things.

### `e2e-docker` — import the credentials

The Langflow container belongs to this run, so it does what `daily-stable.yml`
and `pr-validation.yml` do: run `collect-models` first, then gate on the
backend's recovery. Same three guards as the other two:

| Guard | Why |
|---|---|
| `PREFLIGHT_SKIP_CREDENTIALS: "1"` | this run is what *imports* the keys — the pre-flight must not assert them first |
| `PLAYWRIGHT_RETRIES: "0"` | a failing sweep must not re-walk the Model Providers UI three times against one backend (#1011) |
| `continue-on-error: true` | a drained key must not kill the specs that never touch that provider (#980) |

Provider specs now actually work from a manual dispatch, instead of the dispatch
aborting before anything runs.

### `e2e-url` — do not pass the key

This job targets an instance **we do not own**: a staging deployment, someone's
tunnel. Running `collect-models` there would *write* our CI provider keys into
that instance as global variables — not a side effect a test dispatch may have on
a shared environment. And passing the key *without* importing it is exactly what
broke the workflow.

So the key is simply not passed, and the target's own credentials govern: with no
provider key in the environment the pre-flight has nothing to assert and skips
the check.

### Rejected: just drop the key everywhere

This was the cheap option in the issue, and it is **wrong**. The provider health
gate fails **open** when `providers.json` is absent (`readProviderHealth` → null,
#1029 — deliberate: "never skip the world because the pre-flight did not run").
So provider-hardcoded specs would have run against a credential-less Langflow and
failed with exactly the misleading `node_duration` errors #884 exists to remove —
trading one loud abort for quiet misattribution across several specs.

## Validation — proven by dispatch, not by inspection

Run [30422284968](https://github.com/oriontech-me/langflow-e2e/actions/runs/30422284968)
on this branch, `@api` AND `version` (5 tests, deliberately tiny — the point is
that anything runs at all):

| Step | Result |
|---|---|
| `Collect models` | `1 passed (1.3m)` — keys imported |
| `Wait for the backend to recover…` | **answered on attempt 21** (04:31:43 → 04:36:04) |
| Pre-flight of the run | `[preflight] provider credentials configured in Langflow: OPENAI_API_KEY` |
| Tests | **`5 passed (5.7s)`** |
| Destructive lane | matched nothing, green |

**Attempt 21 is the interesting number.** The backend was wedged for ~4 min 20 s
after the collect-models sweep, so:

- `globalSetup`'s 120 s would have failed again, just with a different message —
  adding `collect-models` **without** the gate would not have fixed this workflow;
- `daily-stable.yml`'s 300 s would have cleared it by ~60 s;
- the 420 s adopted here (from `pr-validation.yml`) left ~2.5 min of margin.

That is a second independent measurement of the #922/#927 wedge — the first came
out of #1019's pr-validation job — and it argues that 300 s is tight for this
point in the run.

## Scope note

- The health gate here is the **fourth** copy of that polling loop. #1045
  extracts it into `.github/actions/wait-for-backend`; the code says so, so this
  copy is adopted rather than left to drift.
- `LANGFLOW_WORKERS` is deliberately **not** added to this workflow's service
  container. #1030 established that 1 is the image default, so the explicit pin
  the other workflows carry changes nothing in effect, and adding it here would
  be unmeasured scope.
- No spec, tag, doc or checklist change — CI only.
