### PR TITLE
fix(quarantine): quarantine four recurrent flakes from the 2026-07-29 daily (#1057)

### DIFF
--- a/tests/tests-automations/regression/core-components/component-breaking-change-alert.spec.ts
+++ b/tests/tests-automations/regression/core-components/component-breaking-change-alert.spec.ts
@@ -87,9 +87,11 @@ async function importOutdatedFlowAndOpen(page: Page): Promise<void> {
   ).toBeVisible({ timeout: 30000 });
 }
 
-test(
+// Quarantined for #1061 — recurrent flake (2026-07-27 / 07-29): the
+// breaking-change alert never becomes visible.
+test.fixme(
   "breaking-change outdated components alert with a Review action, not a silent Update",
-  { tag: ["@stable", "@components", "@regression", "@ui-ux"] },
+  { tag: ["@components", "@regression", "@ui-ux"] },
   async ({ page }) => {
     trackCreatedFlows(page);
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts
@@ -567,9 +567,11 @@ for (const { label, options, skipReason } of targets) {
   const provider = options.provider ?? (Object.keys(providerConfigMap)[0] as Provider);
 
   test.describe(`Agent Context ID Isolation [${label}]`, () => {
-    test(
+    // Quarantined for #1060 — recurrent flake (2026-07-14 / 07-16 / 07-22): the
+    // context_id equality assertion fails intermittently.
+    test.fixme(
       "switching the agent's context_id re-tags new turns without touching previous ones",
-      { tag: ["@stable", "@regression", "@agents", "@playground"] },
+      { tag: ["@regression", "@agents", "@playground"] },
       async ({ page, request }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(

--- a/tests/tests-automations/regression/core-functionality/playground/playground-message-edit.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-message-edit.spec.ts
@@ -96,9 +96,11 @@ test.describe("Playground Message Edit", () => {
     }
   });
 
-  test(
+  // Quarantined for #1062 — recurrent flake (2026-07-20 / 07-29): hover does
+  // not reveal the edit button.
+  test.fixme(
     "edit user message — hover reveals edit button and saved changes replace original text",
-    { tag: ["@release", "@playground", "@stable"] },
+    { tag: ["@release", "@playground"] },
     async ({ page }) => {
       await test.step("set up flow", async () => {
         createdFlowId = await setupPlayground(page);

--- a/tests/tests-automations/regression/ui-ux/execution-error-notification.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/execution-error-notification.spec.ts
@@ -134,9 +134,11 @@ test.describe("Execution Error Notifications", () => {
     },
   );
 
-  test(
+  // Quarantined for #1063 — recurrent flake (2026-07-21 / 07-29): the
+  // error-feedback waitForSelector times out at 30 s.
+  test.fixme(
     "executing flow with server error shows error feedback",
-    { tag: ["@stable", "@release", "@workspace", "@observability"] },
+    { tag: ["@release", "@workspace", "@observability"] },
     async ({ page }) => {
       (page as any).allowFlowErrors();
       trackCreatedFlows(page);


### PR DESCRIPTION
## Type

- [x] `fix` — fix for a broken or flaky test

---

## Roadmap linkage (required — do not delete)

- [x] **Exception** — off-wave work backed by an issue: a follow-up, a `daily-failure` triage issue, or a `community`-labeled regression. Issue #1057

---

## What this PR does

Quarantines four recurrent flakes surfaced by the triage of #1057 (daily run [30444299314](https://github.com/oriontech-me/langflow-e2e/actions/runs/30444299314), 2026-07-29). Each one recurred with the **same `error_signature`** inside the 30-day window, which is the criterion in `CONTRIBUTING.md` for quarantining a flake at triage as prevention.

| Spec (line) | Issue | Dailies (same signature) | Signature |
|---|---|---|---|
| `core-components/component-breaking-change-alert.spec.ts:90` | #1061 | 07-27, 07-29 | `Error: expect(locator).toBeVisible() failed` |
| `ui-ux/execution-error-notification.spec.ts:137` | #1063 | 07-21, 07-29 | `TimeoutError: page.waitForSelector: Timeout 30000ms exceeded.` |
| `core-functionality/playground/playground-message-edit.spec.ts:99` | #1062 | 07-20, 07-29 | `Error: expect(locator).toBeVisible() failed` |
| `core-functionality/llm-agents/agent-context-id-isolation.spec.ts:570` | #1060 | 07-14, 07-16, 07-22 | `Error: expect(received).toBe(expected) // Object.is equality` |

Each test gets the two edits that make up a quarantine, applied together: **`@stable` removed** *and* **`test()` → `test.fixme()`**, with a comment carrying the issue number and the recurrence dates. Tag removal alone would only stop the daily — the test would keep going red on the `pr-validation.yml` impacted-specs gate, which selects specs by file diff rather than by tag (#871), so this PR itself would merge red.

## Why a quarantine on a guard-tripped day

The run tripped the mass-failure guard (10 hard failures vs. a threshold of 5), so the workflow auto-removed no `@stable` tag. That suppression covers **hard failures**; it does not exempt a recurrent flake from the quarantine criterion (`CONTRIBUTING.md`, *Triage protocol* + the criteria table).

The guard day also obliges the triage to decide whether the day was environmental. The verdict recorded on the issues is that **it was**: 6 of the 10 hard failures are a 20 s timeout on `GET /api/v1/auto_login` in shards where every provider was green and the post-`collect-models` health gate had already passed (#1030), and two further shards executed zero tests after a credentials-preflight abort (#1058). **No hard failure is quarantined here** — `@stable` stays in place on all of them.

## What this PR does not cover

- **No hard failure is touched** — see above. #1059 (`agent-max-tokens`) keeps `@stable` and remains a watchdog.
- **No fix, no root cause.** Quarantine is prevention. Diagnosing each flake and **lifting** its quarantine (remove `test.fixme`, restore `@stable`, re-validate) is a deliverable of #1060, #1061, #1062 and #1063 respectively.
- **`component-breaking-change-alert.spec.ts:164` is not quarantined.** It flaked on the same signature in this run but it is a first occurrence, so it does not meet the recurrence criterion. It keeps `@stable` and stays live.
- **No spec-doc or `QA-CHECKLIST.md` change.** A temporary `@stable` absence needs no spec-doc update — the absence is tracked by the issue and by this commit (`CONTRIBUTING.md`). The generated checklist blocks are regenerated on merge to `main` by `update-coverage-summary.yml`.

## Known limitations

`agent-context-id-isolation.spec.ts:570` sits inside the `for (const { label, options, skipReason } of targets)` loop, so `test.fixme` suppresses it for **every** provider target, not only `openai / gpt-4o-mini` where it flakes. `test.fixme` on a declaration is not parameterizable per target. That is an argument for lifting #1060 promptly, and it is recorded on the issue.

Two of the four have a weaker signal worth stating plainly: every prior occurrence of #1060 (07-14, 07-16, 07-22) and #1062 (07-20) is itself a guard-tripped daily. They meet the criterion as written, but the pattern is not yet distinguishable from the load-induced agent/playground flakiness under investigation on #773. #1061 and #1063 are the strong ones — each has an occurrence on a clean, non-guarded daily (07-27 and 07-21).

---

## Related issue

Traces to the triage of #1057. This PR closes none of the four dedicated issues — they stay open until each flake is diagnosed and its quarantine lifted.

---

## Validation

- [x] `npm run typecheck` — clean
- [x] `npx eslint` on the four specs — 0 errors (21 warnings, all pre-existing, on other tests in the same files)
- [x] `npm run check:checklist-coverage` — passes; every `@stable` and every documented spec is still referenced by a Part II bullet
- [x] `node scripts/check-checklist-guard.mjs` — passes; no generated block edited (`QA-CHECKLIST.md` untouched)
- [x] `npm run regressions:check` — in sync
- [x] `npx playwright test --grep @stable --list` — the four tests no longer appear in the `@stable` lane
- [x] Verified the remaining `@stable` occurrences in the four files belong to **other** tests, left untouched

Not applicable: no test was added or modified in behavior, so there is nothing to run with `--trace=on`, force-fail, or step through in `--debug`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
