### PR TITLE
fix(project-management): complete the #932 quarantine and correct its root cause (#932)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -104,7 +104,7 @@
 #### 1.3.1 Folder (Project) CRUD via API
 - [x] POST `/api/v1/projects/` → creates folder, returns id and name → `api/flows/api-folders-crud.spec.ts`
 - [x] GET `/api/v1/projects/` → lists folders including the created one → `api/flows/api-folders-crud.spec.ts`
-- [!] DELETE `/api/v1/projects/{id}` → returns 204 and the folder leaves the listing — quarantined (#965): under concurrent writes the endpoint answers **500** (`sqlite3.OperationalError: database is locked`) and the folder survives; measured 44% of deletes on `1.12.0.dev7` vs 6% on stable `1.10.3` at the same 2-client contention. Product defect filed as [LE-2020](https://datastax.jira.com/browse/LE-2020); the `204` assertion is unchanged → `api/flows/api-folders-crud.spec.ts`
+- [!] DELETE `/api/v1/projects/{id}` → returns 204 and the folder leaves the listing — quarantined (#965): under concurrent writes the endpoint answers **500** (`sqlite3.OperationalError: database is locked`) and the folder survives; measured 44% of deletes on `1.12.0.dev7` vs 6% on stable `1.10.3` at the same 2-client contention. Product defect filed as [LE-2020](https://datastax.jira.com/browse/LE-2020); the `204` assertion is unchanged. The same ticket also covers `PATCH /api/v1/flows/{id}` (§12.5, #932) — one root cause, two endpoints → `api/flows/api-folders-crud.spec.ts`
 
 #### 1.4 Components via API
 - [x] GET `/api/v1/all` → lists all available components → `api/flows/api-custom-component-creation.spec.ts`
@@ -638,7 +638,7 @@
 #### 12.5 Flow Operations
 - [x] Lock flow — prevents editing → `flow-functionality/lock-flow.spec.ts`
 - [x] Unlock flow → `flow-functionality/flow-lock.spec.ts`
-- [!] Move flow between folders via API — quarantined (#932): `PATCH /api/v1/flows/{id}` returns `200` but the association read back is intermittently stale. Separate root cause from #965 — under contention the `PATCH` can 500, yet every `200` observed persisted the new `folder_id` (18/18) → `api/flows/api-folders-crud.spec.ts`
+- [!] Move flow between folders via API — quarantined (#932): under concurrent writes `PATCH /api/v1/flows/{id}` answers **500** (`sqlite3.OperationalError: database is locked` on `UPDATE flow SET folder_id`) and the flow does not move; 14/24 at 2 concurrent clients, 0/30 serial. **Same root cause as #965**, not a separate one — the daily artifact shows the failing assert is `expect(patchRes.status()).toBe(200)` receiving 500, not a stale `folder_id`. Product defect tracked under [LE-2020](https://datastax.jira.com/browse/LE-2020); the `200` assertion is unchanged → `api/flows/api-folders-crud.spec.ts`
 - [x] Publish flow → `flow-functionality/publish-flow.spec.ts`
 - [x] Save flow components as template → `core-components/saveComponents.spec.ts`
 

--- a/REGRESSIONS.md
+++ b/REGRESSIONS.md
@@ -65,6 +65,18 @@ toast, notification centre empty, only a console error. That silent no-op is wha
 makes the row user-facing; it is Medium, not High, because it needs sustained
 concurrent writes.
 
+**Second affected endpoint, same ticket (2026-07-29, #930 → #932).**
+`PATCH /api/v1/flows/{id}` fails the same way — `500 (sqlite3.OperationalError)
+database is locked` on `UPDATE flow SET folder_id`, with **two** concurrent writers
+(14/24; 0/30 serial) — so the row's claim that sibling write endpoints survive the
+identical contention does not hold for this one. It is deliberately **not** a second
+Ledger row: same root cause, same upstream ticket (LE-2020), and the ledger counts
+one row per ticket. The user-visible outcome differs and is milder: the flow stays
+in its source project and the UI *does* raise `Failed to save flow` (with the raw
+SQL and bound parameters), where the project-delete equivalent silently no-ops.
+Evidence, API and UI:
+[docs/upstream-bugs/UPSTREAM-BUG-flow-patch-500-under-contention.md](docs/upstream-bugs/UPSTREAM-BUG-flow-patch-500-under-contention.md).
+
 ## Candidates — pending upstream ticket
 
 Confirmed locally but not yet filed upstream; promoted to a Ledger row the

--- a/docs/api/flows/api-folders-crud.md
+++ b/docs/api/flows/api-folders-crud.md
@@ -140,13 +140,69 @@ explicitly.
 Filed upstream as **[LE-2020](https://datastax.jira.com/browse/LE-2020)** — full evidence
 in `docs/upstream-bugs/UPSTREAM-BUG-project-delete-500-under-contention.md`.
 
-## Relationship between #965 and #932 — separate causes, both stay
+## Relationship between #965 and #932 — CORRECTED: one root cause, two endpoints
 
-Settled with evidence, not assumption. Under the same contention that breaks the
-DELETE, `PATCH /api/v1/flows/{id}` also returns `500` (7/20 at P=2, 27/32 at
-P=4) — but **every** `PATCH` that returned `200` had persisted the new
-`folder_id` (13/13 and 5/5). #932's symptom is a `200` followed by a **stale**
-association, which contention does not reproduce. Two issues, two root causes.
+An earlier pass of this document concluded these were separate causes, on the
+premise that *"#932's symptom is a `200` followed by a stale association, which
+contention does not reproduce"*. **That premise was wrong**, and the correction
+matters because it was being used to rule contention out.
+
+The daily artifact settles it. From `playwright-json-daily-30085452003`
+(run 30085452003, 2026-07-24), the failing assertion is:
+
+```
+Error: expect(received).toBe(expected)   Expected: 200   Received: 500
+
+> 160 |       expect(patchRes.status()).toBe(200);
+```
+
+It is the **HTTP status**, not the `folder_id`. There never was a `200` followed by
+a stale association. The `expect(received).toBe(expected) // Object.is equality`
+wording in the triage issue reads like an association mismatch, and both this
+document and #932's own hypotheses were written from that misreading.
+
+So the earlier measurement was right and its conclusion inverted: `PATCH
+/api/v1/flows/{id}` returning `500` under contention (7/20 at P=2, 27/32 at P=4;
+independently reproduced 2026-07-29 as 14/24 at P=2, 20/24 at P=4, 0/30 serial)
+**is** #932. #965 and #932 are the same root cause — SQLite write contention — on
+two different endpoints.
+
+What still distinguishes them is the **user-visible outcome**, which is why they
+remain separate reports:
+
+| | `DELETE /projects/{id}` (#965 / LE-2020) | `PATCH /flows/{id}` (#932) |
+|---|---|---|
+| End state | project **survives** the "successful" delete | flow stays in its source project |
+| User signal | **silent no-op** past the retry budget — no toast, notification centre empty | `Failed to save flow` notification, with the raw SQL and bound parameters |
+| Severity | Medium (silent) | Medium (reported, consistent state) |
+
+Measured on the UI path 2026-07-29 under 4 background writers: the drag fails, two
+`500`s appear in the console, the flow does not move, and the notification centre
+is **not** empty. Full evidence:
+`docs/upstream-bugs/UPSTREAM-BUG-flow-patch-500-under-contention.md`.
+
+**Do not re-derive "two root causes" from the symptom wording.** Read the artifact.
+
+### The duplicate that was left unquarantined
+
+`core-functionality/project-management/folder-drag-drop-flow.spec.ts` carried
+`moving a flow to another folder via API PATCH updates folder_id` — the same
+sequence as test 4, differing only in using the `/api/v1/folders/` legacy alias
+instead of `/api/v1/projects/`, and asserting `expect(patchRes.status()).toBe(200)`
+identically. It was **not** quarantined, so silencing test 4 for #932 left the
+same failure reachable from a second file: two flake sites, one signal, and a
+quarantine that only looked complete.
+
+It was removed by #932 rather than quarantined too — the API-level folder-move
+contract belongs here, in the API spec, and a pure-API test in a UI-focused
+project-management file is drift. When #932's upstream fix lands, test 4 here is
+the single place to restore.
+
+Noted while doing it, **not** fixed by #932 (out of scope): that file is named for
+drag-drop but contains no drag-drop test — its three tests are two API checks and
+one UI listing check. The UI move affordance *is* automatable; dragging
+`list-card` onto `sidebar-nav-<folder>` moves the flow, verified live on
+1.12.0.dev8 while measuring this defect. Worth a checklist item of its own.
 
 ---
 

--- a/docs/upstream-bugs/UPSTREAM-BUG-flow-patch-500-under-contention.md
+++ b/docs/upstream-bugs/UPSTREAM-BUG-flow-patch-500-under-contention.md
@@ -1,0 +1,151 @@
+# `PATCH /api/v1/flows/{id}` answers `500 database is locked` under concurrent writes — moving a flow between folders fails in the UI
+
+| | |
+|---|---|
+| **Filed upstream** | **[LE-2020](https://datastax.jira.com/browse/LE-2020)** — the SAME ticket as the `DELETE /projects` case; the fix is expected to land there. This document records the second affected endpoint, it does not ask for a new ticket |
+| **Tracked in** | `oriontech-me/langflow-e2e#932` (daily-failure, spun out of triage #930) |
+| **Component** | Langflow — backend, flows API + database layer (SQLite) |
+| **Surfaces** | `PATCH /api/v1/flows/{id}` returns `500`; in the UI, dragging a flow onto another project fails with a `Failed to save flow` notification carrying the raw SQLAlchemy error |
+| **Observed on** | `langflowai/langflow-nightly:latest` — `1.12.0.dev8` |
+| **Determinism** | Deterministic **given** concurrent writes; invisible without them (0/30 serial) |
+| **Captured** | 2026-07-29, local Docker, `LANGFLOW_AUTO_LOGIN=true`, `LANGFLOW_WORKERS=1`, default SQLite |
+| **Related** | LE-2020's own report covers `DELETE /api/v1/projects/{id}` and states that sibling write endpoints survive the identical contention. `PATCH /flows` does **not** — that claim is the one fact in the ticket this document contradicts. Not tracked as a separate regression in `REGRESSIONS.md`: same root cause, same ticket, one Ledger row per ticket |
+| **Prior art in this repo** | The `500` under contention was already measured during #965's investigation (7/20 at P=2, 27/32 at P=4) and then **wrongly ruled out** as #932's cause, on the belief that #932 was a `200` followed by a stale association. The daily artifact disproves that belief — see §6 |
+
+---
+
+## 1. Summary
+
+With any other write in flight, `PATCH /api/v1/flows/{id}` fails instead of moving
+the flow:
+
+```
+500 (sqlite3.OperationalError) database is locked
+[SQL: UPDATE flow SET updated_at=?, folder_id=? WHERE flow.id = ?]
+```
+
+The failure is **not silent** — the UI raises a notification and the flow stays in
+its original project, so no data is lost or misplaced. What is wrong is that a
+routine single-record update fails at all under mild contention, and that the
+message shown to the end user is a raw database error.
+
+---
+
+## 2. Steps to reproduce (API)
+
+1. Create two projects and a flow in the first one.
+2. Issue `PATCH /api/v1/flows/{flow_id}` with `{"folder_id": "<second project>"}`
+   from **two or more** clients concurrently.
+3. Observe `500` with the message above.
+
+Measured rate, 24 iterations per level, each iteration creating its own projects
+and flow so no two clients touch the same row:
+
+| Concurrent clients | Failures |
+|---|---|
+| 1 | **0 / 30** |
+| 2 | 14 / 24 |
+| 3 | 18 / 24 |
+| 4 | 20 / 24 |
+
+Two clients are enough. The failing statement is always the `UPDATE flow`.
+
+## 2.1 Steps to reproduce (UI — the user-facing path)
+
+1. Create projects `SRC` and `DST`; put a flow in `SRC`.
+2. Generate background write load (4 clients renaming their own flows in a loop).
+3. In the UI, drag the flow card from `SRC` onto `DST` in the project sidebar.
+
+Observed:
+
+| Signal | Result |
+|---|---|
+| Browser console | `500 Internal Server Error` on `PATCH /api/v1/flows/{id}`, ×2 |
+| Flow's project after the drag | **unchanged** — still `SRC` |
+| Notification centre | **`Failed to save flow`**, body = the verbatim SQLAlchemy error including the SQL statement, the bound parameters and a timestamp |
+
+Without the background load the same drag succeeds every time, so the drag
+mechanism itself is fine.
+
+---
+
+## 3. Why this is not simply "SQLite is single-writer"
+
+The instance runs with Langflow's own defaults, which are already tuned for this:
+
+```python
+sqlite_pragmas = {"synchronous": "NORMAL", "journal_mode": "WAL", "busy_timeout": 30000}
+db_connect_timeout = 30
+```
+
+`journal_mode=wal` is confirmed active on the running database file. With a 30 s
+`busy_timeout`, a writer that merely has to *wait* should wait, not fail — and yet
+the `500` comes back in ~60 ms, three orders of magnitude before that budget.
+
+That is the signature of the one case `busy_timeout` deliberately does **not**
+cover: a transaction that reads first and then upgrades to a write while another
+transaction holds the write lock. SQLite returns `SQLITE_BUSY` immediately there,
+because retrying would deadlock. The usual remedies are to open write paths with
+`BEGIN IMMEDIATE`, or to retry the transaction at the application layer.
+
+**Suggestive asymmetry, not yet explained:** the four background writers, each
+repeatedly `PATCH`ing its *own* flow, completed **~5178 requests with zero
+non-200**, while the single newcomer `PATCH` failed. Whatever the mechanism, the
+request that arrives during an established write burst is the one that loses.
+
+**Not established:** the exact transaction boundary in the flows-update path, and
+whether Postgres deployments are affected (untested — the reproduction is
+SQLite-only).
+
+---
+
+## 4. Expected behaviour
+
+`PATCH /api/v1/flows/{id}` either applies the update or waits for the lock within
+the configured `busy_timeout`. A `500` for a single-row update under two
+concurrent clients is not an acceptable contract, and an end user should never be
+shown a SQL statement with bound parameters.
+
+---
+
+## 5. Impact
+
+- **A routine action fails.** Moving a flow between projects is a normal
+  organisational gesture; it breaks whenever anything else is writing.
+- **The error is unactionable for the user.** "database is locked" plus a SQL
+  statement tells the person dragging a card nothing they can act on.
+- **Internal detail leaks to the UI** — statement text, bound parameter values,
+  server timestamps.
+- **It costs CI time elsewhere.** This is what the `api-folders-crud` folder-move
+  test has been catching intermittently on the daily (2026-07-15, 2026-07-24),
+  where it reads as a flaky test rather than a product defect.
+
+Severity assessed **Medium**: user-visible and reproducible at low concurrency,
+but reported rather than silent, with no data loss and a consistent end state —
+milder than the `DELETE /projects` manifestation tracked under the same ticket,
+which **silently no-ops**. Fixing the shared root cause fixes both.
+
+---
+
+## 6. Notes for triage
+
+- **The failing assertion, verbatim from the daily artifact** (`playwright-json-daily-30085452003`,
+  run 30085452003, 2026-07-24):
+
+  ```
+  Error: expect(received).toBe(expected)   Expected: 200   Received: 500
+
+  > 160 |       expect(patchRes.status()).toBe(200);
+  ```
+
+  The mismatch is the **HTTP status**, not the `folder_id`. Playwright's
+  `Object.is equality` wording reads like an association mismatch, and that
+  misreading sent both #932's stated hypotheses and an earlier in-repo analysis
+  down the wrong path — the latter had already measured this exact `500` and
+  discarded it as unrelated. Read the artifact before re-deriving a cause from
+  the symptom wording.
+- Not reproducible serially. Any investigation that runs the sequence once, by
+  hand, will conclude the endpoint is fine.
+- No version A/B was run here, so **do not quote a first-affected version**.
+  LE-2020 established that its own endpoint regressed in rate (~7×) between
+  1.10.3 and 1.12; whether this endpoint follows the same curve is untested.

--- a/tests/tests-automations/regression/core-functionality/project-management/folder-drag-drop-flow.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/folder-drag-drop-flow.spec.ts
@@ -57,83 +57,21 @@ test(
   },
 );
 
-test(
-  "moving a flow to another folder via API PATCH updates folder_id",
-  { tag: ["@release", "@workspace", "@regression"] },
-  async ({ request }) => {
-    const authToken = await getAuthToken(request);
-
-    // Create two folders
-    const folder1Res = await request.post("/api/v1/folders/", {
-      headers: { Authorization: authToken },
-      data: {
-        name: `move-src-${Date.now()}`,
-        description: "Source folder",
-      },
-    });
-    expect(folder1Res.status()).toBe(201);
-    const { id: folder1Id } = await folder1Res.json();
-
-    const folder2Res = await request.post("/api/v1/folders/", {
-      headers: { Authorization: authToken },
-      data: {
-        name: `move-dst-${Date.now()}`,
-        description: "Destination folder",
-      },
-    });
-    expect(folder2Res.status()).toBe(201);
-    const { id: folder2Id } = await folder2Res.json();
-
-    let flowId: string | undefined;
-    try {
-      // Create a flow in folder 1
-      const flowRes = await request.post("/api/v1/flows/", {
-        headers: { Authorization: authToken },
-        data: {
-          name: `move-flow-${Date.now()}`,
-          folder_id: folder1Id,
-          data: {
-            nodes: [],
-            edges: [],
-            viewport: { x: 0, y: 0, zoom: 1 },
-          },
-          is_component: false,
-        },
-      });
-      expect(flowRes.status()).toBe(201);
-      const flow = await flowRes.json();
-      flowId = flow.id;
-      expect(flow.folder_id).toBe(folder1Id);
-
-      // Move the flow to folder 2 via PATCH
-      const patchRes = await request.patch(`/api/v1/flows/${flowId}`, {
-        headers: { Authorization: authToken },
-        data: { folder_id: folder2Id },
-      });
-      expect(patchRes.status()).toBe(200);
-      const updated = await patchRes.json();
-
-      // The flow must now belong to folder 2
-      expect(updated.folder_id).toBe(folder2Id);
-    } finally {
-      if (flowId) {
-        await deleteFlow(request, flowId, {
-          headers: { Authorization: authToken },
-        }).catch(() => {});
-      }
-      await request
-        .delete(`/api/v1/folders/${folder1Id}`, {
-          headers: { Authorization: authToken },
-        })
-        .catch(() => {});
-      await request
-        .delete(`/api/v1/folders/${folder2Id}`, {
-          headers: { Authorization: authToken },
-        })
-        .catch(() => {});
-    }
-  },
-);
+// The API-level folder-move assertion that used to live here
+// ("moving a flow to another folder via API PATCH updates folder_id") was removed
+// by #932. It duplicated `api/flows/api-folders-crud.spec.ts` test 4 line for line,
+// differing only in using the `/api/v1/folders/` legacy alias, and it was NOT
+// quarantined — so silencing the canonical test for #932 left the identical failure
+// reachable from this file: two flake sites for one signal, and a quarantine that
+// only looked complete.
+//
+// The failure is a product defect, not a test defect: `PATCH /api/v1/flows/{id}`
+// answers `500 (sqlite3.OperationalError) database is locked` with two concurrent
+// writers (14/24; 0/30 serial). Tracked upstream under LE-2020, evidence in
+// docs/upstream-bugs/UPSTREAM-BUG-flow-patch-500-under-contention.md.
+//
+// Restore point when the upstream fix lands: api-folders-crud.spec.ts test 4 — the
+// single place, in the API spec where the API contract belongs.
 
 test(
   "folder listing shows flows correctly via UI",


### PR DESCRIPTION
**Refs #932.** Does **not** close it — the quarantine stays until the upstream fix lands (same pattern as #966 / LE-2019). What this PR delivers is the confirmed root cause, the corrected record, and a quarantine that is actually complete.

## Problem

`api-folders-crud.spec.ts` test 4 failed on the dailies of 2026-07-15 and 2026-07-24 with `expect(received).toBe(expected) // Object.is equality`, and was quarantined at triage (`test.fixme` + `@stable` off, PR #934).

The issue body read that signature as a wrong `folder_id` and listed three hypotheses accordingly. The daily artifact says otherwise — `playwright-json-daily-30085452003`, run 30085452003:

```
Error: expect(received).toBe(expected)   Expected: 200   Received: 500

> 160 |       expect(patchRes.status()).toBe(200);
```

It is the **HTTP status**. Playwright renders a status mismatch as `Object.is equality`, which reads like an association mismatch — and that misreading also produced an earlier in-repo analysis which had *already measured this exact 500* and discarded it as unrelated.

## Root cause

`PATCH /api/v1/flows/{id}` answers `500 (sqlite3.OperationalError) database is locked` on `UPDATE flow SET folder_id` under concurrent writes. Measured on `1.12.0.dev8`, each iteration owning its own projects and flow:

| Concurrent clients | Failures |
|---|---|
| 1 (serial) | **0 / 30** |
| 2 | 14 / 24 |
| 3 | 18 / 24 |
| 4 | 20 / 24 |

Two writers are enough. **Not** merely "SQLite is single-writer": Langflow already defaults `journal_mode=WAL`, `busy_timeout=30000`, `db_connect_timeout=30`, and WAL is confirmed active on the running database — yet the `500` returns in ~60 ms, three orders of magnitude inside that budget. That is the read-then-upgrade case `busy_timeout` deliberately does not cover (SQLite returns `SQLITE_BUSY` immediately rather than deadlock).

### All four hypotheses refuted

| Hypothesis | Verdict |
|---|---|
| (a) product change to `PATCH folder_id` semantics | ❌ 0/30 serial |
| (b) read-after-write race in the test | ❌ the `500` is on the `PATCH`; the `GET` is never reached |
| (c) test data / isolation leak | ❌ every iteration owns its rows |
| (d) cross-worker destructive cleanup (#1010 wiper — my own) | ❌ on 07-15/07-24 that test was tagged `["@release","@api"]`, no `@stable`, and `daily-stable.yml` runs `@stable` only |

### User-facing, but reported — not silent

Measured through the UI under 4 background writers: the drag fails, two `500`s hit the console, the flow **stays in its source project**, and the notification centre shows `Failed to save flow` carrying the verbatim SQLAlchemy error with the SQL statement and bound parameters. Without the load the same drag succeeds every time.

That is the discriminator that decided the LE-2020 adjudication, and it lands differently here: reported, consistent end state, no data loss — hence Medium, milder than the project-delete case that silently no-ops. The defect of its own is that raw SQL and bound parameters are shown to an end user.

## Changes

None of them make the spec green — the product is what is broken.

- **`docs/api/flows/api-folders-crud.md`** — replaces the section claiming #965 and #932 were separate root causes. Its premise ("#932's symptom is a `200` followed by a stale association, which contention does not reproduce") is false and was being used to rule contention out. **One root cause, two endpoints**, with a table of the differing user-visible outcomes.
- **`docs/upstream-bugs/UPSTREAM-BUG-flow-patch-500-under-contention.md`** *(new)* — API rate table, UI measurement, the WAL/`busy_timeout` analysis, and the unexplained asymmetry (the 4 background writers completed ~5178 `PATCH`es with **zero** non-200; only the newcomer fails).
- **`REGRESSIONS.md`** — no new Ledger row (one row per ticket) and no Candidates row (it *is* ticketed). The second affected endpoint is recorded in the existing note under the LE-2020 row. Indicator stays **7**, `regressions:check` passes. **LE-2020 itself is untouched, by decision.**
- **`QA-CHECKLIST.md`** §12.5 and the §10 DELETE bullet — same correction, so the checklist stops asserting a stale-association cause that never existed. Manual bullets only.
- **`folder-drag-drop-flow.spec.ts`** — deletes `moving a flow to another folder via API PATCH updates folder_id`. It matched `api-folders-crud.spec.ts` test 4 line for line (only the `/api/v1/folders/` legacy alias differed), asserted the same `toBe(200)`, and was **not** quarantined — so silencing the canonical test left the identical failure reachable from a second file. Two flake sites, one signal, and a quarantine that only looked complete. A comment at the removal site records the restore point.

## Scope note

The quarantine (`test.fixme` + no `@stable`) on `api-folders-crud.spec.ts` test 4 is **unchanged**, and #932 stays open. Lifting it is that issue's remaining deliverable, gated on the upstream fix landing under LE-2020.

Flagged in the doc, deliberately **not** fixed here: `folder-drag-drop-flow.spec.ts` is named for drag-drop but contains no drag-drop test. The UI move affordance *is* automatable — dragging `list-card` onto `sidebar-nav-<folder>` moves the flow, verified live on 1.12.0.dev8 while measuring this defect. Worth its own checklist item.

## Validation (nightly `1.12.0.dev8`, `--retries=0 --workers=1`)

- 3 clean runs of the touched spec ✅ — `expected=2 unexpected=0 flaky=0 backendErrors=false` each
- `npm run typecheck` ✅ 0 errors · `npm run lint` ✅ 0 errors
- `npm run regressions:check` ✅ in sync (7) · QA-CHECKLIST guard ✅ · coverage guard ✅
- Zero `🚨 Backend Error` ✅
- Force-fail ✅ — both remaining tests, reverted, final green run after revert:
  - `creating a flow in a specific folder…` → asserts a non-existent `folder_id` → `unexpected=1`
  - `folder listing shows flows correctly via UI` → asserts a flow name never created → `unexpected=1`
- Instance left clean: **1 project, 29 flows**. Worth recording: the reproduction script leaked **169 projects**, because `DELETE /api/v1/projects/` *also* `500`s under contention — #965/LE-2020 biting the very script measuring its sibling. Purged serially with retries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
