### PR TITLE
docs(triage-skill): state the guard-day rule as narrowly as CONTRIBUTING does (#1067)

### DIFF
--- a/.claude/skills/langflow-e2e-triage/SKILL.md
+++ b/.claude/skills/langflow-e2e-triage/SKILL.md
@@ -55,8 +55,11 @@ Talk to the user in **Portuguese (PT-BR)**; produce every GitHub artifact
   only stops the daily, so the test keeps going red on the impacted-specs gate
   (file-diff selected, not tag-filtered — #871); `test.fixme` skips it in every
   context. Full mechanism + why: `references/issue-templates.md` →
-  *Quarantine mechanism*. Hard failures are already auto-removed by the workflow
-  (tag only); only **recurrent flakes** are quarantined here (never automatic).
+  *Quarantine mechanism*. Hard failures are normally auto-removed by the
+  workflow (tag only), so **recurrent flakes** are what gets quarantined here —
+  except on a **guard-tripped** day, where the workflow removed nothing and a
+  hard failure the triage judged non-environmental is quarantined here too. A
+  guard day never suspends the quarantine of a recurrent flake.
   The skill **never restores** either edit and never touches test *logic*, spec
   docs, or `QA-CHECKLIST.md` — un-`fixme` + restore-`@stable` is the dedicated
   issue's deliverable.
@@ -186,8 +189,22 @@ When `guard_tripped` is true the day is a mass-failure day (mostly collateral).
 other non-adjacent dailies — durable) are created/enriched as usual;
 **today-only collateral** is **noted, not filed** (aggregated with counts) and
 recorded in the umbrella's closing comment — the umbrella still **closes** at
-the end of triage (Phase 7). `@stable` is **kept** on everything. Full rule + wording: `references/issue-templates.md` →
+the end of triage (Phase 7). Full rule + wording: `references/issue-templates.md` →
 *Guard-Tripped Rule*.
+
+**The guard adds a deliverable, it does not remove one** (`CONTRIBUTING.md`):
+
+- **Decide whether the day was environmental** and say so, with evidence, on
+  every issue this run produces. This verdict is mandatory on a guard day —
+  it is what the reader needs to weigh any cluster filed from it.
+- **Hard failures:** the workflow's automatic `@stable` removal is suppressed,
+  so the tags are still in place. If the verdict is **not** environmental,
+  **manually quarantine** the real hard failures (Phase 7 step 3). If it **is**,
+  keep `@stable` and say why — quarantine only if one reproduces on a clean,
+  non-guarded daily.
+- **Recurrent flakes: unaffected.** The guard governs hard failures only; it is
+  **not** an exemption from the flake criterion. A flake with `actionable: true`
+  is quarantined exactly as on any other day (Phase 4).
 
 ### Phase 4 — FLAKES
 
@@ -200,7 +217,9 @@ own.
 
 For each actionable flake, the test must be **quarantined as prevention** (so it
 stops running everywhere until it is worked) — part of the triage, not a
-deferred follow-up. Quarantine = **remove `@stable` + add `test.fixme`**
+deferred follow-up, **and not suspended by a guard-tripped day** (the guard
+suppresses the automatic removal that applies to hard failures; the flake
+criterion has no guard-day exemption). Quarantine = **remove `@stable` + add `test.fixme`**
 together (see the hard gate + `references/issue-templates.md` → *Quarantine
 mechanism*). But it is a code change: **record the exact spec path + line here**
 and carry it into the plan (Phase 6) as its own row; it is executed only in
@@ -258,9 +277,12 @@ Only after the user approves the plan:
    quarentena?"). Only on an explicit yes, open the quarantine PR (branch off
    `main`, apply both edits, reference the dedicated issue — un-`fixme` +
    restore is that issue's deliverable, never done here). If the user declines
-   or defers, **do not edit** — record it as still pending. (Hard failures were
-   already auto-removed by the workflow; on a guard-tripped mass-failure day
-   nothing is quarantined here.)
+   or defers, **do not edit** — record it as still pending. (Hard failures are
+   normally auto-removed by the workflow, so they do not pass through here. The
+   exception is a **guard-tripped** day: the workflow removed nothing, so a hard
+   failure the Phase-3 verdict judged **non-environmental** is quarantined here
+   too, behind the same per-test confirmation. A guard-tripped day never
+   suspends the quarantine of a **recurrent flake**.)
 4. Comment on the umbrella issue linking every dedicated issue just
    created/enriched (so the umbrella's history stays a readable index).
 5. **Close the umbrella only when the triage is truly complete:** every needed
@@ -333,10 +355,15 @@ run is indistinguishable from a broken post, so every terminal path posts:
   "Nothing to triage — no red run found / history stale." note and stop.
 - **Guard-tripped mass-failure day** → still post the plan (durable cross-day
   clusters as create/enrich rows; today-only collateral as **note** rows), and
-  state descriptively that the guard tripped (count + threshold) and that
-  `@stable` was left in place. The umbrella still closes at the end of triage,
-  carrying the collateral in its closing comment (Phase 3 + Phase 7; guard rule
-  in `references/issue-templates.md`).
+  state descriptively that the guard tripped (count + threshold), that the
+  workflow left `@stable` in place on the hard failures, and the **environmental
+  verdict** for the day (Phase 3 — mandatory on a guard day). Any hard failure
+  the verdict does not cover, and every recurrent flake, is listed in the
+  quarantine block as a manual/local TODO — CI never edits code, so a guard day
+  does not turn those rows off, it only means a human still owes them. The
+  umbrella still closes at the end of triage, carrying the collateral in its
+  closing comment (Phase 3 + Phase 7; guard rule in
+  `references/issue-templates.md`).
 
 ### `--phase execute` (triggered by an approved "pode abrir" comment)
 

--- a/.claude/skills/langflow-e2e-triage/SKILL.md
+++ b/.claude/skills/langflow-e2e-triage/SKILL.md
@@ -192,16 +192,23 @@ recorded in the umbrella's closing comment — the umbrella still **closes** at
 the end of triage (Phase 7). Full rule + wording: `references/issue-templates.md` →
 *Guard-Tripped Rule*.
 
-**The guard adds a deliverable, it does not remove one** (`CONTRIBUTING.md`):
+**The guard adds a deliverable, it does not remove one** (`CONTRIBUTING.md` →
+*@stable lifecycle*, and its *Mass-failure guard* note):
 
-- **Decide whether the day was environmental** and say so, with evidence, on
-  every issue this run produces. This verdict is mandatory on a guard day —
-  it is what the reader needs to weigh any cluster filed from it.
+- **Decide whether the day was environmental** and say so, with evidence, as the
+  run's verdict — it belongs to the triage (the umbrella records it) and is
+  carried into every issue this run produces, so a reader can weigh the cluster
+  without re-reading the umbrella. Mandatory on a guard day. It is a claim about
+  **the day**, never a cause asserted for a cluster: the descriptive rule still
+  holds (`references/issue-templates.md` → *Guard-Tripped Rule*, rules 2–3), and
+  a day judged environmental does not make every failure on it collateral.
 - **Hard failures:** the workflow's automatic `@stable` removal is suppressed,
   so the tags are still in place. If the verdict is **not** environmental,
-  **manually quarantine** the real hard failures (Phase 7 step 3). If it **is**,
-  keep `@stable` and say why — quarantine only if one reproduces on a clean,
-  non-guarded daily.
+  **manually quarantine** the real hard failures — **record the exact spec path +
+  line here**, exactly as Phase 4 does for a flake, and carry each one into the
+  plan (Phase 6) as its own row; it is executed only in Phase 7 step 3, behind
+  its own confirmation. If the verdict **is** environmental, keep `@stable` and
+  say why — quarantine only if one reproduces on a clean, non-guarded daily.
 - **Recurrent flakes: unaffected.** The guard governs hard failures only; it is
   **not** an exemption from the flake criterion. A flake with `actionable: true`
   is quarantined exactly as on any other day (Phase 4).
@@ -243,9 +250,14 @@ it to the user in PT-BR:
 | 1 | ... | hard-failure / flake / skip | create / enrich / note | new issue title, or existing #NNN |
 
 Below the table, list the **quarantines the triage requires** (remove `@stable`
-+ add `test.fixme`) as a separate block — one line per recurrent flake
-(`spec/path.spec.ts:line`). Hard failures are auto-removed by the workflow, so
-do **not** list them.
++ add `test.fixme`) as a separate block — one line per test
+(`spec/path.spec.ts:line`), each labelled with what put it there (`flake` /
+`hard-failure, guard day`). Every actionable recurrent flake (Phase 4) goes in
+the block. Hard failures normally do **not**: the workflow already auto-removed
+their tag. The exception is a **guard-tripped** day, where the workflow removed
+nothing — there, each hard failure the Phase-3 verdict judged
+**non-environmental** gets its own row too. If the block is empty, say so
+explicitly rather than omitting it.
 
 Then **wait for explicit approval of the issue plan** ("pode abrir" or
 equivalent). This approval covers issue create/enrich/close **only** — it does
@@ -270,8 +282,9 @@ Only after the user approves the plan:
 2. For each **enrich** row: `gh issue comment` on the matched existing issue,
    per the same reference's *Enrich vs Create Rule*. Match on the **normalized
    signature**, not on a description of the symptom.
-3. **Quarantines — separate authorization, one at a time.** For each recurrent
-   flake in the removals block: show the **exact diff** (drop `@stable` **and**
+3. **Quarantines — separate authorization, one at a time.** For **every row of
+   the removals block** (Phase 6) — a recurrent flake, or a guard-day hard
+   failure — show the **exact diff** (drop `@stable` **and**
    wrap the test as `test.fixme(<reason + issue #>)`, at `spec:line`) and ask
    for a **distinct** confirmation (e.g. "pode colocar o teste X em
    quarentena?"). Only on an explicit yes, open the quarantine PR (branch off
@@ -357,9 +370,10 @@ run is indistinguishable from a broken post, so every terminal path posts:
   clusters as create/enrich rows; today-only collateral as **note** rows), and
   state descriptively that the guard tripped (count + threshold), that the
   workflow left `@stable` in place on the hard failures, and the **environmental
-  verdict** for the day (Phase 3 — mandatory on a guard day). Any hard failure
-  the verdict does not cover, and every recurrent flake, is listed in the
-  quarantine block as a manual/local TODO — CI never edits code, so a guard day
+  verdict** for the day (Phase 3 — mandatory on a guard day). Every recurrent
+  flake, plus every hard failure that verdict judged **non-environmental**, is
+  listed in the quarantine block (Phase 6) as a manual/local TODO with its
+  `spec:line` — CI never edits code, so a guard day
   does not turn those rows off, it only means a human still owes them. The
   umbrella still closes at the end of triage, carrying the collateral in its
   closing comment (Phase 3 + Phase 7; guard rule in

--- a/.claude/skills/langflow-e2e-triage/references/issue-templates.md
+++ b/.claude/skills/langflow-e2e-triage/references/issue-templates.md
@@ -196,7 +196,7 @@ A checkbox list of concrete acceptance criteria. Format:
 
 - [ ] Root cause confirmed per spec (product regression vs. test/wait-strategy vs. environment) with evidence on the current nightly.
 - [ ] Each spec passes reliably (multiple clean `--retries=0` runs), fixing waits/flow as needed.
-- [ ] **Quarantine lifted** in the fix PR — remove `test.fixme` **and** restore `@stable` (both were applied at triage as prevention for recurrent flakes; hard failures had only `@stable` auto-removed). Re-validate per `CONTRIBUTING.md` before lifting. *(On a guard-tripped mass-failure day nothing was quarantined — then there is nothing to lift unless the cluster later reproduces on a clean daily and is quarantined.)*
+- [ ] **Quarantine lifted** in the fix PR — remove `test.fixme` **and** restore `@stable` (both were applied at triage as prevention for recurrent flakes; hard failures had only `@stable` auto-removed, or were quarantined manually on a guard-tripped day judged non-environmental). Re-validate per `CONTRIBUTING.md` before lifting. *(Nothing to lift only where nothing was quarantined — e.g. a hard failure on a guard-tripped day whose verdict was environmental, which keeps its tag until it reproduces on a clean daily.)*
 - [ ] If the root cause is a **product (Langflow) regression**: recorded as such here, and this issue stays **open** until the upstream fix lands in `langflowai/langflow-nightly:latest` (or the `release-1.x.x` branch), is re-validated there, and `@stable` is restored — not on a test-side mute.
 ```
 
@@ -204,7 +204,7 @@ Rules:
 - Boxes are checkable (`- [ ]`)
 - Each item is a single, verifiable outcome
 - Include validation steps from `CONTRIBUTING.md` if the fix touches product code
-- **Lifting the quarantine is always a deliverable** whenever a test was quarantined at triage (the normal case) — "done" includes removing `test.fixme` and putting `@stable` back after the fix. Only a guard-tripped day, where nothing was quarantined, has nothing to lift.
+- **Lifting the quarantine is always a deliverable** whenever a test was quarantined at triage (the normal case) — "done" includes removing `test.fixme` and putting `@stable` back after the fix. The one case with nothing to lift is a test that was never quarantined: a hard failure on a guard-tripped day whose verdict was **environmental** (a recurrent flake is quarantined on a guard day like any other — see *Quarantine mechanism* → *Scope*).
 - A **product regression** closes only when the product is fixed where the suite runs (nightly / release branch), not on a test-side workaround
 
 ---
@@ -252,7 +252,7 @@ Investigate all paths independently, **product as prime suspect first**: on the 
 - [ ] Each spec passes reliably (multiple clean `--retries=0` runs), fixing waits/flow as needed.
 - [ ] `@stable` was **left in place** (not confirmed a durable break; likely wave collateral) — if any is later fixed with a code change, re-validate per `CONTRIBUTING.md`.
 
-Note: `@stable` was **kept** on these three (the mass-failure guard tripped and the driver for this cluster is not confirmed non-environmental). Quarantine only if the failure reproduces on a clean (non-wave) daily.
+Note: `@stable` was **kept** on these three (the mass-failure guard tripped and the triage's verdict on the day is environmental — see above). Quarantine only if the failure reproduces on a clean (non-wave) daily.
 
 ---
 
@@ -383,7 +383,7 @@ When a daily run trips the mass-failure guard (`guard_tripped: true` in the dail
 
 **0. Decide which clusters get a dedicated issue at all — this is the guard-day split:**
 
-   - **Cross-day-recurrent clusters** (the same test + error signature also failed on other, *non-adjacent* dailies — `recurrence.same_signature` true with dates beyond today) reproduce on days that were **not** mass-failure days, so they are **durable** signals, not pure collateral. These **do** get a dedicated issue (create) or enrich their existing tracker — following rules 1–3 below.
+   - **Cross-day-recurrent clusters** (the same test + error signature also failed on other, *non-adjacent* dailies — `recurrence.same_signature` true with dates beyond today) reproduce on days that were **not** mass-failure days, so they are **durable** signals, not pure collateral. These **do** get a dedicated issue (create) or enrich their existing tracker — following rules 1–4 below.
    - **Today-only collateral** (failed only on this run, no cross-day recurrence) does **not** get a dedicated issue. Filing one is a throwaway tracker for what most likely vanishes when the instance recovers — the same reason a first-occurrence flake is noted, not filed. Instead, **note** it in the triage proposal (aggregated, with counts) and record it in the umbrella's closing comment.
    - **Close the umbrella anyway.** A guard-tripped run is **not** an exception to the normal close-at-end-of-triage rule: the collateral having no dedicated issue is not a reason to keep an issue open for it. List it in the closing comment and close. The standing record is `reports/daily-history.jsonl` — every triage recomputes recurrence from that file over a 30-day window, so a collateral cluster that persists is re-detected on a later run and filed then. Leaving umbrellas open instead accumulates stale rows in the `daily-failure` list that the Phase-2 dedup has to read on every subsequent triage.
 
@@ -399,19 +399,19 @@ Dedicated issues you **do** open on a guard day (the cross-day-recurrent ones) m
    - Name the plausible environmental cause (saturation, API outage, etc.)
    - Do not conclude it is the cause — only that it is consistent and must be ruled out
 
-3. **State what happened to `@stable`, and why.** When the guard trips the triage scripts auto-remove nothing, so the tags survive by default — but "the guard tripped" is not on its own a reason to leave them. What decides it is rule 4's verdict, and the issue records the outcome either way:
+3. **State the day's environmental verdict.** On a guard-tripped day, deciding whether the day was environmental is a **mandatory deliverable** of the triage (`CONTRIBUTING.md` → *@stable lifecycle*: "the triage gains one extra deliverable"), not an optional observation — it is what rule 4 turns on, and what a reader needs to weigh a cluster filed from a mass-failure run. Give the evidence, and keep it separable from rule 2: rule 2 forbids asserting an environmental cause **for this cluster**; rule 3 requires a verdict on **the day**. They are different claims, and a day judged environmental does not make every failure on it collateral.
+
+   ```markdown
+   The triage verdict on the day is that it **was environmental**: 6 of the 10 hard failures are a 20 s timeout on `GET /api/v1/auto_login` in shards where every provider was green and the health gate had already passed, and two further shards executed zero tests after a preflight abort.
+   ```
+
+4. **State what happened to `@stable`, and why.** When the guard trips the triage scripts auto-remove nothing, so the tags survive by default — but "the guard tripped" is not on its own a reason to leave them. What decides it is rule 3's verdict, and the issue records the outcome either way:
 
    ```markdown
    Note: `@stable` was **kept** on these three (the mass-failure guard tripped and the day's verdict is environmental — see above). Quarantine only if the failure reproduces on a clean (non-wave) daily.
    ```
 
    If the verdict is **not** environmental, the opposite is recorded — the tests were **manually quarantined** at triage (`@stable` removed **+** `test.fixme`), since the workflow did not do it.
-
-4. **State the day's environmental verdict.** On a guard-tripped day, deciding whether the day was environmental is a **mandatory deliverable** of the triage (`CONTRIBUTING.md`), not an optional observation — it is what rule 3 turns on, and what a reader needs to weigh a cluster filed from a mass-failure run. Give the evidence, and keep it separable from rule 2: rule 2 forbids asserting an environmental cause **for this cluster**; rule 4 requires a verdict on **the day**. They are different claims, and a day judged environmental does not make every failure on it collateral.
-
-   ```markdown
-   The triage verdict on the day is that it **was environmental**: 6 of the 10 hard failures are a 20 s timeout on `GET /api/v1/auto_login` in shards where every provider was green and the health gate had already passed, and two further shards executed zero tests after a preflight abort.
-   ```
 
 > **Recurrent flakes are outside all of this.** Rules 3–4 govern **hard failures**, which are the only thing the guard's suppression touches. A flake meeting the recurrence criterion is quarantined on a guard day exactly as on any other — see *Quarantine mechanism* → *Scope*.
 

--- a/.claude/skills/langflow-e2e-triage/references/issue-templates.md
+++ b/.claude/skills/langflow-e2e-triage/references/issue-templates.md
@@ -303,7 +303,12 @@ test.fixme("... title ...", { tag: ["@components"] }, async ({ page }) => { ... 
 
 **Restoration** (the dedicated issue's deliverable) is the exact inverse, in one PR after the fix: remove `test.fixme`, restore `@stable`, re-validate per `CONTRIBUTING.md`.
 
-**Scope:** quarantine is for **recurrent flakes** removed manually at triage. Hard failures are auto-removed by the workflow (tag only, committed straight to `main` — no PR gate, so no red-PR problem); a hard-failure test that also needs `test.fixme` gets it when its dedicated `fix` issue is worked. On a **guard-tripped** day nothing is quarantined (tags kept).
+**Scope:** quarantine is for **recurrent flakes** removed manually at triage. Hard failures are auto-removed by the workflow (tag only, committed straight to `main` — no PR gate, so no red-PR problem); a hard-failure test that also needs `test.fixme` gets it when its dedicated `fix` issue is worked.
+
+**On a guard-tripped day** the workflow's automatic removal is suppressed, so the hard failures keep their tags. That suppression is the *only* thing the guard changes, and it changes it in **one** direction — it does not cancel a quarantine the criteria require:
+
+- **Recurrent flakes are quarantined as on any other day.** The guard governs hard failures; the flake criterion has no guard-day exemption (`CONTRIBUTING.md` → the criteria table). Skipping them here is how a known-recurrent flake keeps running red for another week.
+- **Hard failures depend on the triage's environmental verdict**, which a guard day makes a mandatory deliverable. Judged environmental → keep `@stable`, document why, and revisit if it reproduces on a clean daily. Judged **not** environmental → **manually quarantine** them, since the workflow did not.
 
 ---
 
@@ -394,11 +399,21 @@ Dedicated issues you **do** open on a guard day (the cross-day-recurrent ones) m
    - Name the plausible environmental cause (saturation, API outage, etc.)
    - Do not conclude it is the cause — only that it is consistent and must be ruled out
 
-3. **State that `@stable` was left in place:**
+3. **State what happened to `@stable`, and why.** When the guard trips the triage scripts auto-remove nothing, so the tags survive by default — but "the guard tripped" is not on its own a reason to leave them. What decides it is rule 4's verdict, and the issue records the outcome either way:
+
    ```markdown
-   Note: `@stable` was **kept** on these three (the mass-failure guard tripped and the driver for this cluster is not confirmed non-environmental). Quarantine only if the failure reproduces on a clean (non-wave) daily.
+   Note: `@stable` was **kept** on these three (the mass-failure guard tripped and the day's verdict is environmental — see above). Quarantine only if the failure reproduces on a clean (non-wave) daily.
    ```
-   When the guard trips, the triage scripts do **not** auto-remove `@stable` tags. The issue itself documents why they were left. If the cluster fails again on a non-guarded daily, then `@stable` is a candidate for quarantine.
+
+   If the verdict is **not** environmental, the opposite is recorded — the tests were **manually quarantined** at triage (`@stable` removed **+** `test.fixme`), since the workflow did not do it.
+
+4. **State the day's environmental verdict.** On a guard-tripped day, deciding whether the day was environmental is a **mandatory deliverable** of the triage (`CONTRIBUTING.md`), not an optional observation — it is what rule 3 turns on, and what a reader needs to weigh a cluster filed from a mass-failure run. Give the evidence, and keep it separable from rule 2: rule 2 forbids asserting an environmental cause **for this cluster**; rule 4 requires a verdict on **the day**. They are different claims, and a day judged environmental does not make every failure on it collateral.
+
+   ```markdown
+   The triage verdict on the day is that it **was environmental**: 6 of the 10 hard failures are a 20 s timeout on `GET /api/v1/auto_login` in shards where every provider was green and the health gate had already passed, and two further shards executed zero tests after a preflight abort.
+   ```
+
+> **Recurrent flakes are outside all of this.** Rules 3–4 govern **hard failures**, which are the only thing the guard's suppression touches. A flake meeting the recurrence criterion is quarantined on a guard day exactly as on any other — see *Quarantine mechanism* → *Scope*.
 
 ---
 
@@ -412,6 +427,6 @@ Every dedicated issue embodies this philosophy:
 - **Grouping is argued, not assumed:** one issue per cause only means something if the issue says why these failures are one cause
 - **Investigation as independent branches:** test the product first, then environment, then test design
 - **Deliverables as checkboxes:** done when all items are ticked
-- **Quarantine decisions are explicit:** quarantined at triage as prevention — `@stable` removed **+** `test.fixme` added (or nothing quarantined on a guard-tripped day) — and **lifted as a deliverable** after the fix — always documented
+- **Quarantine decisions are explicit:** quarantined at triage as prevention — `@stable` removed **+** `test.fixme` added — and **lifted as a deliverable** after the fix — always documented; when a test was *not* quarantined (a hard failure on a guard-tripped day judged environmental), the issue says so and why
 
 This ensures investigators inherit not just a failure, but the context and constraints needed to fix it efficiently.


### PR DESCRIPTION
## Type

- [x] `docs` — documentation update

---

## Roadmap linkage (required — do not delete)

- [x] **Exception** — off-wave work backed by an issue: a follow-up, a `daily-failure` triage issue, or a `community`-labeled regression. Issue #1067

---

## What this PR does

The triage skill claimed, in two files, that

> On a **guard-tripped** day nothing is quarantined (tags kept).

`CONTRIBUTING.md` says something narrower, and in one direction only: the guard suppresses the **automatic** `@stable` removal, which applies to **hard failures** — and it *adds* a deliverable rather than removing one.

The blanket wording was wrong twice over on a guard day:

1. It **skipped the quarantine of recurrent flakes**, which the flake criterion requires regardless of the guard (`CONTRIBUTING.md` line 713 and the criteria table). The guard governs hard failures; the flake criterion carries no guard-day exemption.
2. It **dropped the environmental-verdict deliverable** — the triage is supposed to decide whether the day was environmental, and manually quarantine any hard failure that verdict does not cover, since the workflow removed nothing.

### It misfired in practice

On the triage of #1057 (run 30444299314, 2026-07-29), following the skill produced a plan with **no quarantine at all and no environmental verdict**. Both were corrected on review: the verdict now appears on #1058–#1063, and four recurrent flakes were quarantined in #1064 — work the skill's wording had explicitly ruled out.

### Where the change lands

The issue named two spots; the sweep it asked for found seven. All are places where the skill stated a guard-day rule more broadly than `CONTRIBUTING.md` does:

| File | Location | Was |
|---|---|---|
| `SKILL.md` | Hard gates | "only **recurrent flakes** are quarantined here" — on a guard day a non-environmental hard failure is quarantined here too |
| `SKILL.md` | Phase 3 | "`@stable` is **kept** on everything" — too broad; and the verdict deliverable was absent |
| `SKILL.md` | Phase 4 | did not say the flake criterion has no guard-day exemption |
| `SKILL.md` | Phase 7 step 3 | the original claim |
| `SKILL.md` | headless `--phase propose` | reported only that `@stable` was left in place, with no verdict |
| `references/issue-templates.md` | *Quarantine mechanism* → Scope | the original claim |
| `references/issue-templates.md` | *Guard-Tripped Rule* + summary bullet | rule 3 treated "kept" as unconditional |

### Two judgement calls worth reviewing

**The environmental verdict is now a numbered rule (4)** in the *Guard-Tripped Rule*, with a worked example. It existed in `CONTRIBUTING.md` but nowhere in the skill — which is why the #1057 triage never produced one.

**Rule 4 is explicitly separated from rule 2**, because they read as contradictory and are not: rule 2 forbids asserting an environmental cause **for a cluster**; rule 4 requires a verdict on **the day**. The text now states that a day judged environmental does not make every failure on it collateral — the exact trap that nearly led to not filing #1059.

## What this PR does not cover

- **No behaviour change.** Documentation only — no script, renderer, workflow or config is touched. `renderDedicatedIssueBody()` / `assertDedicatedIssueBody()` are unchanged, so the issue-body contract and the CI guard that enforces it are identical.
- **The guard's own mechanics are unchanged** — threshold, suppression of automatic removal, and the cluster split by durability all stay exactly as they were. Only the skill's *description* of what the triage still owes is corrected.
- **`CONTRIBUTING.md` is not edited.** It was already right; the skill was the one out of step. (The separate guard-day clause removed in #1065 / #1068 was a rule change and is already merged.)

## Known limitations

This is guidance read by an agent, so no test can enforce it — `npm run test:scripts` covers `triage-core.mjs`, not the prose. The real verification is the next red daily that trips the guard: the triage should produce an environmental verdict and quarantine any recurrent flake without a human catching the omission.

---

## Related issue

Closes #1067

---

## Validation

- [x] `npm run test:scripts` — 89 pass, 0 fail
- [x] `npm run typecheck` — clean
- [x] Grepped the whole skill directory **and** `CONTRIBUTING.md` for the superseded phrasings (`nothing is quarantined`, `kept on everything`, `nothing quarantined on a guard`) — **0 remaining**
- [x] Verified the corrected text against `CONTRIBUTING.md` lines 663, 696, 713 and the criteria table, which stay authoritative on conflict
- [x] Documentation-only change — nothing to run with `--trace=on`, force-fail, or step through in `--debug`

Provenance: raised during the triage of #1057 (daily run 30444299314, 2026-07-29), the run whose triage the defect misdirected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
