### PR TITLE
ci(manual): forward the Anthropic and Google keys to the test step (#1070)

### DIFF
--- a/.github/actions/run-e2e/action.yml
+++ b/.github/actions/run-e2e/action.yml
@@ -22,6 +22,14 @@ inputs:
     description: "OpenAI key for model-dependent specs (agents, playground). Optional."
     required: false
     default: ""
+  anthropic_api_key:
+    description: "Anthropic key for the anthropic-parameterized specs. Optional."
+    required: false
+    default: ""
+  google_api_key:
+    description: "Google key for the google-parameterized specs. Optional."
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -36,7 +44,14 @@ runs:
         # only ever sees them as variable contents.
         TEST_TAG: ${{ inputs.test_tag }}
         TEST_GREP: ${{ inputs.test_grep }}
+        # Every provider key the caller supplied, not just OpenAI: a
+        # provider-parameterized spec calls `hasProviderEnvKeys(<provider>)` and
+        # skips itself when its own key is absent from the environment, so a
+        # dispatch aimed at the anthropic or google specs silently ran zero of
+        # them while collect-models reported the provider active (#967).
         OPENAI_API_KEY: ${{ inputs.openai_api_key }}
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
+        GOOGLE_API_KEY: ${{ inputs.google_api_key }}
       run: |
         # Build the arg list as an array (no eval) so quoting is safe. Playwright
         # only honors one --grep, so to run "tag AND name" we combine them into a
@@ -66,6 +81,8 @@ runs:
         TEST_TAG: ${{ inputs.test_tag }}
         TEST_GREP: ${{ inputs.test_grep }}
         OPENAI_API_KEY: ${{ inputs.openai_api_key }}
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
+        GOOGLE_API_KEY: ${{ inputs.google_api_key }}
       run: |
         # Same one-grep constraint as above: AND the filters into a single
         # lookahead regex, always including @destructive.

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -244,7 +244,13 @@ jobs:
           base_url: ${{ needs.detect-target.outputs.base_url }}
           test_tag: ${{ github.event.inputs.test_tag }}
           test_grep: ${{ github.event.inputs.test_grep }}
+          # The same three keys the `Collect models` step above imported into this
+          # container. Passing only OpenAI made every anthropic/google-parameterized
+          # spec skip on `hasProviderEnvKeys`, so a dispatch could report success
+          # having run none of the specs it was aimed at (#967).
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          google_api_key: ${{ secrets.GOOGLE_API_KEY }}
 
   e2e-url:
     name: E2E via URL (${{ github.event.inputs.langflow_target }})
@@ -263,8 +269,8 @@ jobs:
       - name: Install Playwright browsers
         uses: ./.github/actions/setup-playwright
 
-      # No `openai_api_key`, and no `collect-models` — deliberately different
-      # from the Docker job (#1055).
+      # No provider key inputs at all, and no `collect-models` — deliberately
+      # different from the Docker job (#1055).
       #
       # This job targets an instance that already exists and that we do not own:
       # a staging deployment, someone's tunnel. `collect-models` would WRITE our


### PR DESCRIPTION
Closes #1070. Unblocks the validation of #967.

## Problem

`manual.yml`'s `Collect models` step imports all three provider keys into the Langflow container, but the run step received only `openai_api_key` — `./.github/actions/run-e2e` declared no other provider input. Provider-parameterized specs decide whether to run from the **environment** (`hasProviderEnvKeys(<provider>)`), so every anthropic/google case self-skipped and the job still went green.

Run [30451311649](https://github.com/oriontech-me/langflow-e2e/actions/runs/30451311649), a dispatch aimed at the Anthropic specs:

```
Collect models:  ✅ anthropic (claude-sonnet-5)
Run tests:       [preflight] provider credentials configured in Langflow: OPENAI_API_KEY
                 Running 33 tests using 2 workers
                   32 skipped
                   1 passed (13.8s)
```

## Change

- `run-e2e`: new `anthropic_api_key` and `google_api_key` inputs, exported in the main run **and** the destructive lane.
- `manual.yml`, Docker job: wires the two repo secrets — the same set `Collect models` already imports.
- `manual.yml`, external-URL job: unchanged, still key-free by design (#1055). Its comment now says "no provider key inputs" instead of naming only OpenAI.

`daily-stable.yml` needed no change — it already injects all keys into its test step.

## Validation

Three consecutive dispatches from this branch, `test_grep: Anthropic Provider`, nightly `1.12.0.dev9`:

| Run | Preflight | Result |
|---|---|---|
| [30452510616](https://github.com/oriontech-me/langflow-e2e/actions/runs/30452510616) | `OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_API_KEY` | 4 passed (51.0s), 0 flaky |
| [30453355830](https://github.com/oriontech-me/langflow-e2e/actions/runs/30453355830) | idem | 4 passed (51.1s), 0 flaky |
| [30453363115](https://github.com/oriontech-me/langflow-e2e/actions/runs/30453363115) | idem | 4 passed (53.5s), 0 flaky |

Before: 33 matched / 32 skipped. After: the 4 matched tests execute. `0 flaky` in all three runs means every test passed on its first attempt.

Resolved Langflow version: `Langflow Nightly 1.12.0.dev9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)