### PR TITLE
test(model-provider): restore @stable on the Anthropic Agent-execution test (#967)

### DIFF
--- a/docs/core-functionality/model-provider/anthropic-provider.md
+++ b/docs/core-functionality/model-provider/anthropic-provider.md
@@ -1,6 +1,6 @@
 # Anthropic Provider — configure key, select Claude, switch models
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x
 
 ---
 

--- a/tests/tests-automations/regression/core-functionality/model-provider/anthropic-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/anthropic-provider.spec.ts
@@ -238,7 +238,7 @@ test.describe("Anthropic Provider", () => {
 
   test(
     "configured Anthropic selects a Claude model in the Agent and executes the flow",
-    { tag: ["@model-provider", "@agents", "@playground"] },
+    { tag: ["@stable", "@model-provider", "@agents", "@playground"] },
     async ({ page }) => {
       test.skip(
         !hasProviderEnvKeys(PROVIDER),


### PR DESCRIPTION
Closes #967.

## Why the tag was off

The daily workflow auto-removed `@stable` from `anthropic-provider.spec.ts` ("configured Anthropic selects a Claude model in the Agent and executes the flow") after the 2026-07-27 run, where `collect-models` probed the provider inactive:

```
last error: Your credit balance is too low to access the Anthropic API.
```

A credential outage, not a broken test — the designed degradation path from #955 (a transient billing/quota failure warns instead of failing the gate, and the provider's parametrized specs skip). Restoring the tag was the open deliverable on #967, per the audit in #974.

## Root-cause verdict

The credential is funded again. `collect-models` in CI resolves **`anthropic (claude-sonnet-5)`**, and the 2026-07-29 daily ([run 30444299314](https://github.com/oriontech-me/langflow-e2e/actions/runs/30444299314)) already executed anthropic-parameterized specs — no `provider inactive` skip. Cause classified as **transient billing/quota**, not key rot (`401`) and not model-list drift: the per-model error was the same model-independent billing message for every candidate, so the early-stop kicked in after 3 of 13.

Not a Langflow regression: `:239`'s `div-chat-message` timeout was the drained key, and the test passes on the current nightly (below).

## Validation

Three consecutive dispatches on nightly `1.12.0.dev9`, `test_grep: Anthropic Provider`:

| Run | Result |
|---|---|
| [30452510616](https://github.com/oriontech-me/langflow-e2e/actions/runs/30452510616) | 4 passed (51.0s), 0 flaky |
| [30453355830](https://github.com/oriontech-me/langflow-e2e/actions/runs/30453355830) | 4 passed (51.1s), 0 flaky |
| [30453363115](https://github.com/oriontech-me/langflow-e2e/actions/runs/30453363115) | 4 passed (53.5s), 0 flaky |

`0 flaky` in every run means each test passed on its **first** attempt. Covered: `:181` (key configured via Settings), `:239` (Claude selected and flow executed — the test whose tag this PR restores), `:269` (switches between Claude families — no longer serial-cascade skipped), plus `model-provider-api-key.spec.ts:43`, which the grep also matched.

Local validation was impossible: the `.env` Anthropic key is itself drained (`collect-models` → `❌ anthropic`), which is why the evidence above comes from CI with the repo secret.

## Spun off, not folded in

- **#1070 / PR #1071** — `manual.yml` handed only `OPENAI_API_KEY` to the test step, so the first validation dispatch reported success having skipped 32 of 33 matched tests. Fixed there; the runs above ran on that branch.
- **#1072** — `agent-tool-name-validation.spec.ts:321`'s `Expected: "GOOGLE_API_KEY" / Received: "ANTHROPIC_API_KEY"`, which #967 asked to classify. It is the #751 guard (`SimpleAgentTemplatePage.waitForAgentCredentialSettled`) timing out on the async `api_key` rebind — **independent** of this issue's root cause; `ANTHROPIC_API_KEY` appears only as the default binding.

## Change

- `@stable` back on the `:239` `test(...)` — tag only, no test logic touched.
- Spec doc `Last validated` → `1.12.x`.

No `QA-CHECKLIST.md` edit: the manual Part II bullets already reference this spec (lines 401-403) and `npm run check:checklist-coverage` passes. The generated `Phase 0` block regenerates on merge.

Gates run locally: `npm run typecheck` ✅ · `npm run check:checklist-coverage` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)