### PR TITLE
ci(daily-stable): measure the mid-run backend wedge and name it in the umbrella (#1030)

### DIFF
--- a/.claude/skills/langflow-e2e-infra/references/failure-modes.md
+++ b/.claude/skills/langflow-e2e-infra/references/failure-modes.md
@@ -19,12 +19,17 @@ specs into a low-concurrency lane · cap workers per shard · reproduce locally 
 `LANGFLOW_WORKER_TIMEOUT` on the service container (async worker ⇒ the value
 watches the event-loop heartbeat, not request duration, so it bounds a blocked loop
 without killing a slow live-LLM build — #1048; Langflow's own docs get this
-backwards and advise raising it, so check the code, not `deployment-multi-worker.mdx`).
+backwards and advise raising it, so check the code, not `deployment-multi-worker.mdx`) ·
+**measure** the mid-run outage instead of inferring it (`scripts/watch-backend.mjs`
+probes the backend during each shard; `scripts/report-backend-outages.mjs` names the
+wedge in the umbrella issue — #1030). Do **not** reach for `--max-failures` or a
+detect-and-abort probe: on run 30444299314 the heavy shards wedged 7-10 times and
+still passed ~100 specs each, so aborting costs more coverage than it saves.
 
 **Docs:** `ISSUE-817-CI-RUNNER-SIZING.md`, `ISSUE-833-SHARDING-DESIGN.md`,
 `ISSUE-833-SHARDING-PLAN.md`; `@stable`-removal rules → `CONTRIBUTING.md` →
 *Tag @stable* / *Triage protocol*.
-**Issues/PRs:** #817 · #830 · #833 · #867 · #882 · #816 · #773 · #818 · PR #888.
+**Issues/PRs:** #817 · #830 · #833 · #867 · #882 · #816 · #773 · #818 · #1030 · #1048 · PR #888.
 
 **`@stable` verdict routing** (when someone wants to drop `@stable` over this):
 confirmed saturation (green at `--workers=1`, flakes at higher N) → **keep

--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -458,6 +458,45 @@ jobs:
             sleep 5
           done
 
+      # Mid-run backend liveness (#1030). The gate above only proves the backend
+      # is alive when Playwright STARTS. On the heavy shards the single worker
+      # keeps wedging DURING the run: on run 30444299314 gunicorn killed it 7
+      # times on shard 3 and 10 times on shard 4, spread evenly across ~30
+      # minutes of specs. Those kills are visible only in the service container
+      # log, and only 60-120 s AFTER the event loop actually stalled
+      # (LANGFLOW_WORKER_TIMEOUT=120, #1048) — so an outage window inferred from
+      # them is 60-120 s wide, and at that wedge frequency such windows cover
+      # 33-73% of the shard. Any failure "correlates" with one by chance, which
+      # is why the wedge kept costing a full triage cycle to attribute.
+      #
+      # Measuring from inside fixes the resolution: probe the same URL the specs
+      # use every 2 s, and two consecutive failures bound an outage to ~4 s.
+      #
+      # DIAGNOSTIC ONLY — it never fails a step and never aborts the shard.
+      # Aborting was this issue's original proposal and the data rejected it:
+      # shard 4 wedged ten times and still passed 101 specs, so an abort would
+      # discard far more coverage than it saves.
+      - name: Start the backend liveness recorder (shard ${{ matrix.shard }})
+        # Force bash for `disown` — the container's default shell is sh (dash).
+        # Same reason as the port-forward step above.
+        shell: bash
+        run: |
+          nohup node scripts/watch-backend.mjs > /tmp/liveness.log 2>&1 &
+          echo "$!" > /tmp/liveness.pid
+          disown
+          echo "Backend liveness recorder started (pid $(cat /tmp/liveness.pid))."
+        env:
+          WATCH_URL: http://localhost:7860/api/v1/version
+          WATCH_OUT: backend-liveness.jsonl
+          WATCH_INTERVAL_MS: "2000"
+          # A wedged worker ACCEPTS the connection and never answers, so the
+          # probe needs its own deadline — without it the recorder would hang
+          # exactly when it has something to record.
+          WATCH_TIMEOUT_MS: "4000"
+          # Backstop so a recorder that outlives its kill cannot idle for the
+          # job's whole lifetime. Well above any observed shard duration (~40 min).
+          WATCH_MAX_SECONDS: "5400"
+
       - name: Run @stable tests (shard ${{ matrix.shard }})
         # Sharded run. The reporter list is NOT overridden on the CLI: setting
         # PW_SHARD_FILE_LEVEL selects the sharded reporter shape in
@@ -487,6 +526,52 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+
+      # always(): the liveness data is most valuable precisely when the shard
+      # went red, and a shard killed by its own timeout still leaves a probe log
+      # worth summarizing. WATCH_FILES carries this shard's spec list into the
+      # summary because the MERGED report has no shard column — without it the
+      # merge job could blame shard 3's outage for a shard-4 failure (#1030).
+      - name: Summarize backend liveness (shard ${{ matrix.shard }})
+        if: always()
+        shell: bash
+        run: |
+          # SIGTERM is the recorder's normal exit path: it stops after the
+          # current probe. `|| true` so a recorder that already died (or never
+          # started) cannot fail this step.
+          if [ -f /tmp/liveness.pid ]; then
+            kill "$(cat /tmp/liveness.pid)" 2>/dev/null || true
+          fi
+          # Let the in-flight probe land before reading the log — a probe can be
+          # mid-append when the signal arrives.
+          sleep 3
+          mkdir -p liveness
+          node scripts/watch-backend.mjs --summarize
+          # Ship the raw probe log too: the summary answers "when and how long",
+          # the log answers "what did the backend say", which is what a forensic
+          # pass on a new wedge shape needs.
+          cp backend-liveness.jsonl liveness/ 2>/dev/null || true
+          echo "--- recorder stdout (tail) ---"
+          tail -n 5 /tmp/liveness.log 2>/dev/null || true
+        env:
+          WATCH_OUT: backend-liveness.jsonl
+          WATCH_SUMMARY: liveness/backend-liveness.json
+          WATCH_LABEL: ${{ matrix.shard }}
+          WATCH_FILES: ${{ matrix.files }}
+
+      - name: Upload backend liveness (shard ${{ matrix.shard }})
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: liveness-${{ matrix.shard }}
+          path: liveness/
+          retention-days: 7
+          # NOT `error` (unlike the blob upload): a shard that died before the
+          # recorder ever wrote a line has no liveness data, and a missing
+          # diagnostic must not turn into a red step. The merge job reports the
+          # absence as `measured=false`, which it renders as UNKNOWN — never as
+          # a healthy backend.
+          if-no-files-found: warn
 
       # Resolve the ACTUAL Langflow version running in the service container.
       # The image tag is just `:latest` (or an RC/stable tag), so it never
@@ -544,6 +629,21 @@ jobs:
           # not recurse). The per-shard blob zips are uniquely named
           # (report-<hash>-<shard>.zip), so flattening cannot collide.
           merge-multiple: true
+
+      # Liveness summaries from every shard (#1030). Deliberately WITHOUT
+      # merge-multiple: each shard names its file `backend-liveness.json`, so
+      # flattening would have them overwrite each other. The reader recurses into
+      # the per-artifact subdirectories instead.
+      # continue-on-error: no shard ever uploading liveness data (an old shard
+      # job, a run that died in prep) must not fail the merge — the reporter
+      # renders that as UNKNOWN, which is the honest verdict.
+      - name: Download shard liveness data
+        uses: actions/download-artifact@v7
+        if: always()
+        continue-on-error: true
+        with:
+          pattern: liveness-*
+          path: all-liveness
 
       - name: Guard — every expected shard produced a blob
         id: shardguard
@@ -615,8 +715,25 @@ jobs:
         env:
           PLAYWRIGHT_JSON: results.json
 
+      # Name the wedge (#1030). Runs after the merge so it can attribute failing
+      # attempts to the outages measured on their OWN shard, and before the
+      # umbrella issue so the section can lead the body: a wedged run has to
+      # announce the wedge, not a list of collateral specs that reads as
+      # per-test rot.
+      #
+      # Reports only — it sets no gate. The @stable auto-removal below keeps its
+      # own guards untouched; consuming this attribution to exempt collateral
+      # failures from the tag mutation is #1031, under its own rules.
+      - name: Report mid-run backend outages
+        id: liveness
+        if: always()
+        run: node scripts/report-backend-outages.mjs
+        env:
+          LIVENESS_DIR: all-liveness
+          PLAYWRIGHT_JSON: results.json
+
       - name: Upload Playwright report (full, heavy)
-        id: upload_report                     # ← full report: index.html + data/ + trace/ attachments (~380 MB)
+        id: upload_report                   # ← full report: index.html + data/ + trace/ attachments (~380 MB)
         uses: actions/upload-artifact@v7
         if: always()
         with:
@@ -829,6 +946,11 @@ jobs:
           RUN_UNREADABLE: ${{ steps.runguard.outputs.unreadable }}
           RUN_ERRORS: ${{ steps.runguard.outputs.report_errors }}
           RUN_FIRST_ERROR: ${{ steps.runguard.outputs.first_error }}
+          # In-run backend liveness (#1030). Rendered on EVERY umbrella issue,
+          # not only on a wedged run: "the backend answered every probe" rules
+          # the wedge out for the triager, and "not measured" says the state is
+          # unknown. Only silence would be misleading.
+          LIVENESS_MD: ${{ steps.liveness.outputs.summary_md }}
         with:
           script: |
             const today = new Date().toISOString().split('T')[0];
@@ -873,6 +995,12 @@ jobs:
                     '3. If the test is incorrect or outdated: remove the `@stable` tag from the test and open a fix PR',
                     '4. If it is a Langflow regression: flag it to the team and monitor upstream',
                   ];
+            // The liveness section leads the body when the backend went down:
+            // the cause has to be the first thing read, ahead of the per-test
+            // material, or triage starts from the collateral specs again
+            // (#1030). Empty when the reporting step produced no output at all.
+            const liveness = (process.env.LIVENESS_MD || '').trim();
+            const livenessSection = liveness ? [liveness, ''] : [];
             // The title is what gets scanned in the issue list, so an empty run
             // must not claim that tests failed — none ran.
             const title = empty
@@ -889,6 +1017,7 @@ jobs:
                 `- **Langflow version:** \`${image}\``,
                 `- **Run:** [${context.runId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
                 '',
+                ...livenessSection,
                 ...section,
                 '',
                 '/cc @Victor-w-Madeira @daniellicnerski1 @rafaelgiln',

--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -724,9 +724,17 @@ jobs:
       # Reports only — it sets no gate. The @stable auto-removal below keeps its
       # own guards untouched; consuming this attribution to exempt collateral
       # failures from the tag mutation is #1031, under its own rules.
+      #
+      # continue-on-error: the two steps that follow and matter most on a red day
+      # — `Auto-remove @stable from hard failures` and `Create issue on failure` —
+      # carry NO always(), so they run under the implicit success() of every step
+      # before them. A throw in this diagnostic would therefore SKIP the umbrella
+      # issue it exists to improve. The script swallows its own errors too; this is
+      # the second layer, for the case the failure is the `node` invocation itself.
       - name: Report mid-run backend outages
         id: liveness
         if: always()
+        continue-on-error: true
         run: node scripts/report-backend-outages.mjs
         env:
           LIVENESS_DIR: all-liveness

--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -470,7 +470,9 @@ jobs:
       # is why the wedge kept costing a full triage cycle to attribute.
       #
       # Measuring from inside fixes the resolution: probe the same URL the specs
-      # use every 2 s, and two consecutive failures bound an outage to ~4 s.
+      # use every 2 s while it answers — a failed probe burns its whole 4 s
+      # deadline, so the cadence relaxes to ~4 s exactly while down — and two
+      # consecutive failures bound an outage to ~4 s instead of 120.
       #
       # DIAGNOSTIC ONLY — it never fails a step and never aborts the shard.
       # Aborting was this issue's original proposal and the data rejected it:
@@ -494,8 +496,11 @@ jobs:
           # exactly when it has something to record.
           WATCH_TIMEOUT_MS: "4000"
           # Backstop so a recorder that outlives its kill cannot idle for the
-          # job's whole lifetime. Well above any observed shard duration (~40 min).
-          WATCH_MAX_SECONDS: "5400"
+          # job's whole lifetime. Well above any observed shard duration (~40 min)
+          # and BELOW the job's timeout-minutes: 90 — at 90 min it would only ever
+          # be reached after the runner had already killed the job, making it dead
+          # configuration rather than a backstop.
+          WATCH_MAX_SECONDS: "3600"
 
       - name: Run @stable tests (shard ${{ matrix.shard }})
         # Sharded run. The reporter list is NOT overridden on the CLI: setting
@@ -739,9 +744,14 @@ jobs:
         env:
           LIVENESS_DIR: all-liveness
           PLAYWRIGHT_JSON: results.json
+          # Without the expected count the reporter can only speak about shards
+          # that uploaded data: "2 measured shard(s)" reads the same whether the
+          # run had 2 shards or 4, so a shard whose job died before writing a
+          # summary would disappear instead of reading as UNKNOWN.
+          SHARD_TOTAL: ${{ needs.prep.outputs.shard_total }}
 
       - name: Upload Playwright report (full, heavy)
-        id: upload_report                   # ← full report: index.html + data/ + trace/ attachments (~380 MB)
+        id: upload_report                     # ← full report: index.html + data/ + trace/ attachments (~380 MB)
         uses: actions/upload-artifact@v7
         if: always()
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ tests/helpers/provider-setup/data/providers.json
 
 # Transient spec fixtures written at runtime by remove-stable-from-failures.spec.ts
 tests/scripts/.auto-remove-fixture-*.ts
+
+# In-run backend liveness probes and summaries (scripts/watch-backend.mjs, #1030).
+# CI artifacts and local debugging output — never committed.
+backend-liveness.jsonl
+liveness/
+all-liveness/

--- a/scripts/report-backend-outages.mjs
+++ b/scripts/report-backend-outages.mjs
@@ -1,0 +1,316 @@
+#!/usr/bin/env node
+// Merge-side reporter for the in-run backend liveness data (issue #1030).
+//
+// Consumes the per-shard summaries written by scripts/watch-backend.mjs
+// --summarize and answers the question the umbrella issue could not answer
+// before: was the backend GONE during this run, and which failures overlap the
+// outages? Without it the daily reports a wedge as a list of unrelated specs and
+// triage pays a full cycle to rediscover the cause (run 30374528125: 14 phantom
+// failures on one shard, 5 real ones across the other three).
+//
+// Attribution across shards is only possible because each summary carries the
+// spec-file list its shard ran (matrix.files). The MERGED Playwright report has
+// no shard column, so without that list a shard-3 outage could be blamed for a
+// shard-4 failure.
+//
+// HONESTY REQUIREMENT (why the rendered output always prints the down-share):
+// on daily run 30444299314 the heavy shards were unreachable for 33-73% of
+// their span. At that coverage "the failure landed inside an outage" is close to
+// a coin flip, so the section states the share next to the count and calls the
+// overlap a lead, never a verdict. Turning overlap into a tag decision is #1031's
+// job, under its own rules.
+//
+// This step REPORTS. It never fails the run and never gates the @stable tag: a
+// missing artifact yields `measured=false`, which must never be read as "no
+// wedge happened" — the distinction a silent diagnostic would erase.
+//
+// Inputs (env):
+//   LIVENESS_DIR      directory of per-shard summary JSONs (default all-liveness)
+//   PLAYWRIGHT_JSON   merged Playwright JSON report (default results.json)
+//   MAX_WINDOWS       windows rendered per shard before truncating (default 12)
+//   GITHUB_OUTPUT     when set, step outputs are appended
+//   GITHUB_STEP_SUMMARY  when set, the section is appended to the run summary
+//
+// Outputs:
+//   measured             "true" when at least one shard recorded probes
+//   wedged               "true" when at least one outage was measured
+//   shards_measured      how many shard summaries carried probes
+//   outages_total        outage windows across all shards
+//   down_seconds_total   measured unreachable seconds across all shards
+//   collateral_attempts  failing attempts overlapping a measured outage
+//   summary_md           the rendered section (heredoc-delimited)
+//
+// Pure, dependency-free ESM so the merge job runs it with plain `node`.
+
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_MAX_WINDOWS = 12;
+// A fixed heredoc delimiter for the multiline step output. Any rendered line
+// equal to it is dropped (see outputLines) so the value cannot be closed early
+// — the $GITHUB_OUTPUT equivalent of the injection guard in
+// scripts/check-run-integrity.mjs.
+export const MD_DELIMITER = "LIVENESS_MD_EOF";
+
+// The merged report's spec paths are relative to Playwright's rootDir (`tests/`),
+// while matrix.files may carry either form depending on how the list was built.
+// Normalise both sides to the rootDir-relative shape.
+export function normalizeSpecPath(file) {
+  return String(file || "")
+    .replace(/^\.\//, "")
+    .replace(/^tests\//, "");
+}
+
+export function readSummaries(dir) {
+  let entries = [];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const summaries = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      // download-artifact without merge-multiple nests each artifact in its own
+      // directory; tolerate both layouts rather than depending on the caller.
+      summaries.push(...readSummaries(full));
+      continue;
+    }
+    if (!entry.name.endsWith(".json")) continue;
+    try {
+      const parsed = JSON.parse(fs.readFileSync(full, "utf8"));
+      if (parsed && typeof parsed === "object") summaries.push(parsed);
+    } catch {
+      // A truncated summary is data we do not have, not a reason to fail.
+    }
+  }
+  return summaries.sort((a, b) => String(a.shard).localeCompare(String(b.shard), "en", { numeric: true }));
+}
+
+// Flatten the merged report into attempt records. Every retry counts: the cost
+// of a wedge is precisely that each collateral test burns its whole retry budget.
+export function collectAttempts(report) {
+  const attempts = [];
+  const walk = (node, inheritedFile) => {
+    const file = node.file || inheritedFile;
+    for (const sub of node.suites || []) walk(sub, file);
+    for (const spec of node.specs || []) {
+      const specFile = spec.file || file;
+      for (const test of spec.tests || []) {
+        for (const result of test.results || []) {
+          const startAt = Date.parse(result.startTime);
+          if (!Number.isFinite(startAt)) continue;
+          attempts.push({
+            file: normalizeSpecPath(specFile),
+            title: spec.title || "",
+            status: result.status,
+            retry: Number(result.retry) || 0,
+            startAt,
+            endAt: startAt + (Number(result.duration) || 0),
+          });
+        }
+      }
+    }
+  };
+  for (const suite of report?.suites || []) walk(suite, suite.file);
+  return attempts;
+}
+
+const FAILED = new Set(["failed", "timedOut", "interrupted"]);
+
+function overlapsAny(attempt, windows) {
+  return windows.some((w) => {
+    const start = Date.parse(w.startAt);
+    const end = Date.parse(w.endAt);
+    if (!Number.isFinite(start) || !Number.isFinite(end)) return false;
+    return attempt.startAt <= end && attempt.endAt >= start;
+  });
+}
+
+export function attribute(summaries, attempts) {
+  const shards = summaries.map((summary) => {
+    const own = new Set((summary.files || []).map(normalizeSpecPath));
+    const mine = attempts.filter((a) => own.has(a.file));
+    const failing = mine.filter((a) => FAILED.has(a.status));
+    const windows = summary.windows || [];
+    const collateral = failing.filter((a) => overlapsAny(a, windows));
+    return {
+      shard: String(summary.shard || "?"),
+      measured: summary.measured === true,
+      outageCount: Number(summary.outageCount) || 0,
+      downSeconds: Number(summary.downSeconds) || 0,
+      spanSeconds: Number(summary.spanSeconds) || 0,
+      downPct: Number(summary.downPct) || 0,
+      probeCount: Number(summary.probeCount) || 0,
+      windows,
+      attempts: mine.length,
+      failing: failing.length,
+      collateral: collateral.length,
+      collateralFiles: [...new Set(collateral.map((a) => a.file.split("/").pop()))].sort(),
+    };
+  });
+
+  return {
+    shards,
+    measured: shards.some((s) => s.measured),
+    shardsMeasured: shards.filter((s) => s.measured).length,
+    wedged: shards.some((s) => s.outageCount > 0),
+    outagesTotal: shards.reduce((acc, s) => acc + s.outageCount, 0),
+    downSecondsTotal: Math.round(shards.reduce((acc, s) => acc + s.downSeconds, 0) * 10) / 10,
+    collateralAttempts: shards.reduce((acc, s) => acc + s.collateral, 0),
+  };
+}
+
+const min = (seconds) => `${Math.round((seconds / 60) * 10) / 10} min`;
+const clock = (iso) => (Date.parse(iso) ? new Date(iso).toISOString().slice(11, 19) : "?");
+
+export function renderSection(agg, { maxWindows = DEFAULT_MAX_WINDOWS } = {}) {
+  const head = "### 🔌 Backend liveness (in-run measurement)";
+
+  if (!agg.measured) {
+    return [
+      head,
+      "",
+      "**Not measured** — no shard produced liveness probes, so this run says *nothing*",
+      "about whether the backend was up. Do not read this as a clean backend: check the",
+      "`Start the backend liveness recorder` / `Summarize backend liveness` steps and the",
+      "`liveness-*` artifacts. Mechanism: #1030.",
+    ].join("\n");
+  }
+
+  if (!agg.wedged) {
+    return [
+      head,
+      "",
+      `The backend answered every probe on ${agg.shardsMeasured} measured shard(s) — no mid-run outage.`,
+      "Failures on this run are **not** wedge collateral (#1030).",
+    ].join("\n");
+  }
+
+  const rows = agg.shards
+    .filter((s) => s.measured)
+    .map(
+      (s) =>
+        `| ${s.shard} | ${s.outageCount} | ${min(s.downSeconds)} (${s.downPct}%) | ${min(s.spanSeconds)} | ${s.failing} | ${s.collateral} |`,
+    );
+
+  const worst = Math.max(...agg.shards.map((s) => s.downPct), 0);
+  const lines = [
+    head,
+    "",
+    `**The Langflow worker went down mid-run on ${agg.shards.filter((s) => s.outageCount > 0).length} shard(s)** —`,
+    `${agg.outagesTotal} outage(s), ${min(agg.downSecondsTotal)} of measured unreachable backend.`,
+    "This is the mid-run wedge (#1030), measured by the in-run recorder rather than inferred",
+    "from the report. It is **not** a per-test regression.",
+    "",
+    "| Shard | Outages | Backend down | Observed span | Failing attempts | …overlapping an outage |",
+    "|---|---|---|---|---|---|",
+    ...rows,
+    "",
+    `⚠️ **Read the last column against the down-share.** The backend was unreachable for up to ${worst}%`,
+    "of the observed span, so an attempt can overlap an outage by chance. Overlap is a **lead, not a",
+    "verdict** — the tag decision belongs to #1031's rules, not to this table.",
+  ];
+
+  for (const shard of agg.shards.filter((s) => s.outageCount > 0)) {
+    const shown = shard.windows.slice(0, maxWindows);
+    lines.push(
+      "",
+      `**Shard ${shard.shard} outage windows** (UTC):`,
+      shown
+        .map((w) => `\`${clock(w.startAt)}→${clock(w.endAt)}\` ${w.seconds}s${w.openEnded ? " (open-ended)" : ""}`)
+        .join(" · "),
+    );
+    if (shard.windows.length > shown.length) {
+      lines.push(`…and ${shard.windows.length - shown.length} more window(s) — full data in the \`liveness-${shard.shard}\` artifact.`);
+    }
+    if (shard.collateralFiles.length) {
+      const files = shard.collateralFiles.slice(0, 8);
+      lines.push(
+        `Specs failing inside an outage: ${files.map((f) => `\`${f}\``).join(", ")}` +
+          (shard.collateralFiles.length > files.length ? ` and ${shard.collateralFiles.length - files.length} more` : ""),
+      );
+    }
+  }
+
+  const unmeasured = agg.shards.filter((s) => !s.measured).map((s) => s.shard);
+  if (unmeasured.length) {
+    lines.push(
+      "",
+      `Shard(s) ${unmeasured.join(", ")} recorded no probes — their backend state is **unknown**, not clean.`,
+    );
+  }
+  return lines.join("\n");
+}
+
+// Kept pure (and exported) so the heredoc framing is unit-testable: a rendered
+// line equal to the delimiter would close the multiline value early and let the
+// rest of the markdown be parsed as further key=value outputs.
+export function outputLines(agg, markdown) {
+  const safe = String(markdown)
+    .split("\n")
+    .filter((line) => line.trim() !== MD_DELIMITER)
+    .join("\n");
+  return [
+    `measured=${agg.measured}`,
+    `wedged=${agg.wedged}`,
+    `shards_measured=${agg.shardsMeasured}`,
+    `outages_total=${agg.outagesTotal}`,
+    `down_seconds_total=${agg.downSecondsTotal}`,
+    `collateral_attempts=${agg.collateralAttempts}`,
+    `summary_md<<${MD_DELIMITER}`,
+    safe,
+    MD_DELIMITER,
+  ];
+}
+
+function writeOutputs(agg, markdown) {
+  if (!process.env.GITHUB_OUTPUT) return;
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, outputLines(agg, markdown).join("\n") + "\n");
+}
+
+function readReport(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    // No merged report (or unparseable): the outage data still stands on its
+    // own, only the failure attribution is lost.
+    return null;
+  }
+}
+
+function main() {
+  const dir = process.env.LIVENESS_DIR || "all-liveness";
+  const reportPath = process.env.PLAYWRIGHT_JSON || "results.json";
+  const maxWindows = Number(process.env.MAX_WINDOWS) || DEFAULT_MAX_WINDOWS;
+
+  const summaries = readSummaries(dir);
+  const report = readReport(reportPath);
+  if (!report) {
+    console.log(`[liveness] ${reportPath} unreadable — reporting outages without failure attribution.`);
+  }
+  const agg = attribute(summaries, collectAttempts(report));
+  const markdown = renderSection(agg, { maxWindows });
+
+  console.log(markdown);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, markdown + "\n");
+  }
+  writeOutputs(agg, markdown);
+}
+
+// See scripts/check-run-integrity.mjs for why both normalisations are required.
+function isMainModule() {
+  if (!process.argv[1]) return false;
+  try {
+    return import.meta.url === pathToFileURL(fs.realpathSync(process.argv[1])).href;
+  } catch {
+    return false;
+  }
+}
+
+if (isMainModule()) {
+  main();
+}

--- a/scripts/report-backend-outages.mjs
+++ b/scripts/report-backend-outages.mjs
@@ -24,6 +24,12 @@
 // missing artifact yields `measured=false`, which must never be read as "no
 // wedge happened" — the distinction a silent diagnostic would erase.
 //
+// "Never fails the run" is ENFORCED, not merely intended: the entry point below
+// swallows every throw, and the workflow step carries continue-on-error. Both
+// halves matter, because the merge job's `Auto-remove @stable from hard failures`
+// and `Create issue on failure` steps have no always() — a red step here would
+// skip the umbrella issue this reporter is meant to improve.
+//
 // Inputs (env):
 //   LIVENESS_DIR      directory of per-shard summary JSONs (default all-liveness)
 //   PLAYWRIGHT_JSON   merged Playwright JSON report (default results.json)
@@ -312,5 +318,17 @@ function isMainModule() {
 }
 
 if (isMainModule()) {
-  main();
+  try {
+    main();
+  } catch (err) {
+    // A diagnostic must never be the reason a step goes red — same contract as
+    // scripts/watch-backend.mjs. Here the stakes are higher than losing the
+    // section: the merge job's `Auto-remove @stable from hard failures` and
+    // `Create issue on failure` steps carry no always(), so they run under the
+    // implicit success() of every step before them. A throw here would SKIP the
+    // umbrella issue on a red daily — this reporter exists to make that issue
+    // more useful, not to delete it. The step also carries continue-on-error as
+    // a second layer.
+    console.log(`[liveness] reporter error (ignored): ${err?.stack || err}`);
+  }
 }

--- a/scripts/report-backend-outages.mjs
+++ b/scripts/report-backend-outages.mjs
@@ -33,6 +33,8 @@
 // Inputs (env):
 //   LIVENESS_DIR      directory of per-shard summary JSONs (default all-liveness)
 //   PLAYWRIGHT_JSON   merged Playwright JSON report (default results.json)
+//   SHARD_TOTAL       shards the run expected (prep.outputs.shard_total) — without
+//                     it a shard that uploaded NO artifact is invisible here
 //   MAX_WINDOWS       windows rendered per shard before truncating (default 12)
 //   GITHUB_OUTPUT     when set, step outputs are appended
 //   GITHUB_STEP_SUMMARY  when set, the section is appended to the run summary
@@ -44,6 +46,7 @@
 //   outages_total        outage windows across all shards
 //   down_seconds_total   measured unreachable seconds across all shards
 //   collateral_attempts  failing attempts overlapping a measured outage
+//   blips_total          single-probe failures below the outage threshold
 //   summary_md           the rendered section (heredoc-delimited)
 //
 // Pure, dependency-free ESM so the merge job runs it with plain `node`.
@@ -150,6 +153,13 @@ export function attribute(summaries, attempts) {
       spanSeconds: Number(summary.spanSeconds) || 0,
       downPct: Number(summary.downPct) || 0,
       probeCount: Number(summary.probeCount) || 0,
+      // Carried through so the clean verdict can stay honest: summarizeProbes
+      // discards runs shorter than minProbes into `ignoredBlips`, so a shard can
+      // have failed probes and still report outageCount 0. Dropping these two
+      // here is what let the section claim "answered every probe" over a shard
+      // that answered none of thirty.
+      failedProbes: Number(summary.failedProbes) || 0,
+      ignoredBlips: Number(summary.ignoredBlips) || 0,
       windows,
       attempts: mine.length,
       failing: failing.length,
@@ -166,33 +176,63 @@ export function attribute(summaries, attempts) {
     outagesTotal: shards.reduce((acc, s) => acc + s.outageCount, 0),
     downSecondsTotal: Math.round(shards.reduce((acc, s) => acc + s.downSeconds, 0) * 10) / 10,
     collateralAttempts: shards.reduce((acc, s) => acc + s.collateral, 0),
+    blipsTotal: shards.reduce((acc, s) => acc + s.ignoredBlips, 0),
   };
 }
 
 const min = (seconds) => `${Math.round((seconds / 60) * 10) / 10} min`;
 const clock = (iso) => (Date.parse(iso) ? new Date(iso).toISOString().slice(11, 19) : "?");
 
-export function renderSection(agg, { maxWindows = DEFAULT_MAX_WINDOWS } = {}) {
+// `shardTotal` is the run's expected shard count (prep.outputs.shard_total). It
+// exists so a shard that uploaded NO artifact at all cannot vanish: without it
+// the section can only speak about shards it received data for, and "2 measured
+// shards" reads identically whether the run had 2 shards or 4. A shard whose
+// summary says `measured: false` is already named below; this covers the shard
+// whose job died before writing one.
+export function renderSection(agg, { maxWindows = DEFAULT_MAX_WINDOWS, shardTotal = 0 } = {}) {
   const head = "### 🔌 Backend liveness (in-run measurement)";
+  const expected = Number(shardTotal) || 0;
+  const silent = expected > agg.shards.length ? expected - agg.shards.length : 0;
+  const ofTotal = expected ? ` of ${expected}` : "";
+  const silentNote = silent
+    ? [
+        "",
+        `${silent} shard(s) uploaded no liveness artifact at all — their backend state is **unknown**,`,
+        "not clean. Check their `Summarize backend liveness` step.",
+      ]
+    : [];
 
   if (!agg.measured) {
     return [
       head,
       "",
-      "**Not measured** — no shard produced liveness probes, so this run says *nothing*",
-      "about whether the backend was up. Do not read this as a clean backend: check the",
+      `**Not measured** — no shard${ofTotal ? ` (0${ofTotal})` : ""} produced liveness probes, so this run says`,
+      "*nothing* about whether the backend was up. Do not read this as a clean backend: check the",
       "`Start the backend liveness recorder` / `Summarize backend liveness` steps and the",
       "`liveness-*` artifacts. Mechanism: #1030.",
     ].join("\n");
   }
 
   if (!agg.wedged) {
-    return [
+    // No outage does NOT mean no failed probe: a run shorter than minProbes is
+    // counted as a blip and excluded from `outageCount`. Under a saturated single
+    // worker isolated 4 s timeouts are exactly what this recorder sees, so the
+    // clean verdict has to say how many it discarded — and must not clear the
+    // failures when it discarded any.
+    const clean = [
       head,
       "",
-      `The backend answered every probe on ${agg.shardsMeasured} measured shard(s) — no mid-run outage.`,
-      "Failures on this run are **not** wedge collateral (#1030).",
-    ].join("\n");
+      `No mid-run outage measured (no run of ≥2 consecutive failed probes) on ${agg.shardsMeasured}${ofTotal} measured shard(s).`,
+    ];
+    if (agg.blipsTotal > 0) {
+      clean.push(
+        `⚠️ But ${agg.blipsTotal} single-probe failure(s) were discarded as blips — the backend did **not** answer`,
+        "everything. Treat the wedge as unruled-out and read the `liveness-*` artifacts (#1030).",
+      );
+    } else {
+      clean.push("The backend answered **every** probe: failures on this run are not wedge collateral (#1030).");
+    }
+    return [...clean, ...silentNote].join("\n");
   }
 
   const rows = agg.shards
@@ -206,10 +246,14 @@ export function renderSection(agg, { maxWindows = DEFAULT_MAX_WINDOWS } = {}) {
   const lines = [
     head,
     "",
-    `**The Langflow worker went down mid-run on ${agg.shards.filter((s) => s.outageCount > 0).length} shard(s)** —`,
+    `**The backend stopped answering mid-run on ${agg.shards.filter((s) => s.outageCount > 0).length}${ofTotal} shard(s)** —`,
     `${agg.outagesTotal} outage(s), ${min(agg.downSecondsTotal)} of measured unreachable backend.`,
     "This is the mid-run wedge (#1030), measured by the in-run recorder rather than inferred",
     "from the report. It is **not** a per-test regression.",
+    "",
+    "Measured through the same `localhost:7860` forward the specs use, so it is what the specs",
+    "saw — a dead socat would read the same way. The service container log tells the two apart",
+    "(`WORKER TIMEOUT` from gunicorn ⇒ the Langflow worker, #1048).",
     "",
     "| Shard | Outages | Backend down | Observed span | Failing attempts | …overlapping an outage |",
     "|---|---|---|---|---|---|",
@@ -248,6 +292,14 @@ export function renderSection(agg, { maxWindows = DEFAULT_MAX_WINDOWS } = {}) {
       `Shard(s) ${unmeasured.join(", ")} recorded no probes — their backend state is **unknown**, not clean.`,
     );
   }
+  if (agg.blipsTotal > 0) {
+    lines.push(
+      "",
+      `A further ${agg.blipsTotal} single-probe failure(s) are excluded from the table (below the 2-probe`,
+      "threshold), so the down-share above is a floor, not a ceiling.",
+    );
+  }
+  lines.push(...silentNote);
   return lines.join("\n");
 }
 
@@ -266,6 +318,7 @@ export function outputLines(agg, markdown) {
     `outages_total=${agg.outagesTotal}`,
     `down_seconds_total=${agg.downSecondsTotal}`,
     `collateral_attempts=${agg.collateralAttempts}`,
+    `blips_total=${agg.blipsTotal}`,
     `summary_md<<${MD_DELIMITER}`,
     safe,
     MD_DELIMITER,
@@ -291,6 +344,7 @@ function main() {
   const dir = process.env.LIVENESS_DIR || "all-liveness";
   const reportPath = process.env.PLAYWRIGHT_JSON || "results.json";
   const maxWindows = Number(process.env.MAX_WINDOWS) || DEFAULT_MAX_WINDOWS;
+  const shardTotal = Number(process.env.SHARD_TOTAL) || 0;
 
   const summaries = readSummaries(dir);
   const report = readReport(reportPath);
@@ -298,7 +352,7 @@ function main() {
     console.log(`[liveness] ${reportPath} unreadable — reporting outages without failure attribution.`);
   }
   const agg = attribute(summaries, collectAttempts(report));
-  const markdown = renderSection(agg, { maxWindows });
+  const markdown = renderSection(agg, { maxWindows, shardTotal });
 
   console.log(markdown);
   if (process.env.GITHUB_STEP_SUMMARY) {

--- a/scripts/report-backend-outages.test.mjs
+++ b/scripts/report-backend-outages.test.mjs
@@ -278,3 +278,21 @@ test("the CLI reports NOT MEASURED when no liveness artifact was downloaded", ()
   assert.match(outputs, /^measured=false$/m);
   assert.match(outputs, /^wedged=false$/m);
 });
+
+// The load-bearing contract: the merge job's `Auto-remove @stable from hard
+// failures` and `Create issue on failure` steps have no always(), so ANY red step
+// before them skips the umbrella issue. A malformed summary must therefore
+// degrade, never exit non-zero.
+test("the CLI exits 0 on a malformed summary instead of failing the merge job", () => {
+  const dir = mkdtempSync(join(tmpdir(), "liveness-report-"));
+  const liveness = join(dir, "all-liveness");
+  mkdirSync(liveness, { recursive: true });
+  // `files` as a string, not an array — enough to throw inside attribute().
+  writeFileSync(join(liveness, "backend-liveness.json"), JSON.stringify({ ...shard3, files: FILE_A }));
+
+  const stdout = execFileSync(process.execPath, [SCRIPT], {
+    encoding: "utf8",
+    env: { ...process.env, LIVENESS_DIR: liveness, PLAYWRIGHT_JSON: join(dir, "absent.json") },
+  });
+  assert.match(stdout, /reporter error \(ignored\)/);
+});

--- a/scripts/report-backend-outages.test.mjs
+++ b/scripts/report-backend-outages.test.mjs
@@ -1,0 +1,280 @@
+// Unit tests for the merge-side liveness reporter (issue #1030).
+// Run with: node --test scripts/report-backend-outages.test.mjs
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  MD_DELIMITER,
+  attribute,
+  collectAttempts,
+  normalizeSpecPath,
+  outputLines,
+  renderSection,
+} from "./report-backend-outages.mjs";
+
+const SCRIPT = fileURLToPath(new URL("./report-backend-outages.mjs", import.meta.url));
+
+const FILE_A = "tests-automations/regression/core-functionality/llm-agents/agent-a.spec.ts";
+const FILE_B = "tests-automations/regression/core-functionality/playground/playground-b.spec.ts";
+
+// One outage on shard 3, none on shard 4 — the shape that proves attribution is
+// per-shard and not global.
+const shard3 = {
+  shard: "3",
+  files: [FILE_A],
+  measured: true,
+  probeCount: 300,
+  spanSeconds: 600,
+  downSeconds: 120,
+  downPct: 20,
+  outageCount: 1,
+  windows: [
+    {
+      startAt: "2026-07-29T10:50:00.000Z",
+      endAt: "2026-07-29T10:52:00.000Z",
+      seconds: 120,
+      probes: 60,
+      openEnded: false,
+      reason: "timeout>4000ms",
+    },
+  ],
+};
+const shard4 = {
+  shard: "4",
+  files: [FILE_B],
+  measured: true,
+  probeCount: 300,
+  spanSeconds: 600,
+  downSeconds: 0,
+  downPct: 0,
+  outageCount: 0,
+  windows: [],
+};
+
+// Shard 3's spec fails twice inside the outage; shard 4's fails outside any
+// window (and on a shard that never went down).
+const report = {
+  suites: [
+    {
+      file: FILE_A,
+      specs: [
+        {
+          title: "agent answers",
+          file: FILE_A,
+          tests: [
+            {
+              results: [
+                { status: "failed", retry: 0, startTime: "2026-07-29T10:50:30.000Z", duration: 40000 },
+                { status: "failed", retry: 1, startTime: "2026-07-29T10:51:30.000Z", duration: 40000 },
+              ],
+            },
+          ],
+        },
+      ],
+      suites: [
+        {
+          file: FILE_A,
+          specs: [
+            {
+              title: "nested passes",
+              file: FILE_A,
+              tests: [{ results: [{ status: "passed", retry: 0, startTime: "2026-07-29T10:45:00.000Z", duration: 5000 }] }],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      file: FILE_B,
+      specs: [
+        {
+          title: "playground fails clean",
+          file: FILE_B,
+          tests: [{ results: [{ status: "failed", retry: 0, startTime: "2026-07-29T11:05:00.000Z", duration: 20000 }] }],
+        },
+      ],
+    },
+  ],
+};
+
+test("normalizeSpecPath reconciles the report's rootDir-relative paths with matrix.files", () => {
+  assert.equal(normalizeSpecPath("tests/tests-automations/x.spec.ts"), "tests-automations/x.spec.ts");
+  assert.equal(normalizeSpecPath("./tests/tests-automations/x.spec.ts"), "tests-automations/x.spec.ts");
+  assert.equal(normalizeSpecPath("tests-automations/x.spec.ts"), "tests-automations/x.spec.ts");
+  assert.equal(normalizeSpecPath(undefined), "");
+});
+
+test("collectAttempts flattens nested suites and keeps every retry", () => {
+  const attempts = collectAttempts(report);
+  assert.equal(attempts.length, 4);
+  // Each retry counts: burning the retry budget IS the cost of a wedge.
+  assert.equal(attempts.filter((a) => a.file === FILE_A && a.status === "failed").length, 2);
+  assert.equal(attempts.filter((a) => a.status === "passed").length, 1);
+  assert.equal(collectAttempts(null).length, 0);
+});
+
+test("collectAttempts drops attempts with no parseable startTime", () => {
+  const attempts = collectAttempts({
+    suites: [
+      {
+        file: FILE_A,
+        specs: [{ title: "t", file: FILE_A, tests: [{ results: [{ status: "failed", retry: 0 }] }] }],
+      },
+    ],
+  });
+  assert.equal(attempts.length, 0);
+});
+
+test("attribute blames only the shard whose own backend went down", () => {
+  const agg = attribute([shard3, shard4], collectAttempts(report));
+  assert.equal(agg.measured, true);
+  assert.equal(agg.wedged, true);
+  assert.equal(agg.outagesTotal, 1);
+  assert.equal(agg.downSecondsTotal, 120);
+
+  const s3 = agg.shards.find((s) => s.shard === "3");
+  assert.equal(s3.failing, 2);
+  assert.equal(s3.collateral, 2);
+  assert.deepEqual(s3.collateralFiles, ["agent-a.spec.ts"]);
+
+  const s4 = agg.shards.find((s) => s.shard === "4");
+  assert.equal(s4.failing, 1);
+  // Shard 4's failure must never be attributed to shard 3's outage window.
+  assert.equal(s4.collateral, 0);
+  assert.equal(agg.collateralAttempts, 2);
+});
+
+test("attribute counts an attempt that merely overlaps the window edge", () => {
+  const agg = attribute(
+    [{ ...shard3, files: [FILE_A] }],
+    collectAttempts({
+      suites: [
+        {
+          file: FILE_A,
+          specs: [
+            {
+              title: "started before the outage, still running when it hit",
+              file: FILE_A,
+              tests: [{ results: [{ status: "timedOut", retry: 0, startTime: "2026-07-29T10:49:30.000Z", duration: 60000 }] }],
+            },
+          ],
+        },
+      ],
+    }),
+  );
+  assert.equal(agg.shards[0].collateral, 1);
+});
+
+test("renderSection distinguishes NOT MEASURED from a clean backend", () => {
+  const unmeasured = renderSection(attribute([], []));
+  assert.match(unmeasured, /Not measured/);
+  assert.doesNotMatch(unmeasured, /no mid-run outage/);
+
+  const clean = renderSection(attribute([shard4], collectAttempts(report)));
+  assert.match(clean, /no mid-run outage/);
+  assert.match(clean, /not\*\* wedge collateral/);
+});
+
+test("renderSection names the wedge, tabulates each shard, and prints the down-share caveat", () => {
+  const md = renderSection(attribute([shard3, shard4], collectAttempts(report)));
+  assert.match(md, /Langflow worker went down mid-run/);
+  assert.match(md, /\| 3 \| 1 \| 2 min \(20%\)/);
+  // The caveat is mandatory: at high down-share, overlap is chance, not proof.
+  assert.match(md, /lead, not a/);
+  assert.match(md, /10:50:00→10:52:00/);
+  assert.match(md, /agent-a\.spec\.ts/);
+});
+
+test("renderSection truncates the window list out loud, never silently", () => {
+  const many = {
+    ...shard3,
+    outageCount: 5,
+    windows: Array.from({ length: 5 }, (_, i) => ({
+      startAt: `2026-07-29T10:5${i}:00.000Z`,
+      endAt: `2026-07-29T10:5${i}:30.000Z`,
+      seconds: 30,
+      probes: 15,
+      openEnded: false,
+      reason: "",
+    })),
+  };
+  const md = renderSection(attribute([many], collectAttempts(report)), { maxWindows: 2 });
+  assert.match(md, /and 3 more window\(s\)/);
+});
+
+test("renderSection flags a shard that recorded nothing as unknown, not clean", () => {
+  const md = renderSection(attribute([shard3, { ...shard4, measured: false, probeCount: 0 }], collectAttempts(report)));
+  assert.match(md, /Shard\(s\) 4 recorded no probes/);
+  assert.match(md, /unknown\*\*, not clean/);
+});
+
+test("outputLines cannot be closed early by rendered markdown", () => {
+  const agg = attribute([shard3], collectAttempts(report));
+  const lines = outputLines(agg, `hello\n${MD_DELIMITER}\nmeasured=false\nworld`);
+  // Exactly one terminator, and it is the last line.
+  assert.equal(lines.filter((l) => l === MD_DELIMITER).length, 1);
+  assert.equal(lines[lines.length - 1], MD_DELIMITER);
+  const body = lines[lines.length - 2];
+  assert.equal(body, "hello\nmeasured=false\nworld");
+});
+
+test("the CLI aggregates a directory of shard summaries and writes step outputs", () => {
+  const dir = mkdtempSync(join(tmpdir(), "liveness-report-"));
+  const liveness = join(dir, "all-liveness");
+  // Nested one level, the way download-artifact lays artifacts out without
+  // merge-multiple — the reader has to cope with both.
+  mkdirSync(join(liveness, "liveness-3"), { recursive: true });
+  mkdirSync(join(liveness, "liveness-4"), { recursive: true });
+  writeFileSync(join(liveness, "liveness-3", "backend-liveness.json"), JSON.stringify(shard3));
+  writeFileSync(join(liveness, "liveness-4", "backend-liveness.json"), JSON.stringify(shard4));
+  const reportPath = join(dir, "results.json");
+  writeFileSync(reportPath, JSON.stringify(report));
+  const outputPath = join(dir, "gh-output");
+  writeFileSync(outputPath, "");
+  const summaryPath = join(dir, "step-summary.md");
+  writeFileSync(summaryPath, "");
+
+  execFileSync(process.execPath, [SCRIPT], {
+    env: {
+      ...process.env,
+      LIVENESS_DIR: liveness,
+      PLAYWRIGHT_JSON: reportPath,
+      GITHUB_OUTPUT: outputPath,
+      GITHUB_STEP_SUMMARY: summaryPath,
+    },
+    stdio: "ignore",
+  });
+
+  const outputs = readFileSync(outputPath, "utf8");
+  assert.match(outputs, /^measured=true$/m);
+  assert.match(outputs, /^wedged=true$/m);
+  assert.match(outputs, /^shards_measured=2$/m);
+  assert.match(outputs, /^outages_total=1$/m);
+  assert.match(outputs, /^collateral_attempts=2$/m);
+  assert.match(outputs, new RegExp(`^summary_md<<${MD_DELIMITER}$`, "m"));
+  assert.match(readFileSync(summaryPath, "utf8"), /Backend liveness/);
+});
+
+test("the CLI reports NOT MEASURED when no liveness artifact was downloaded", () => {
+  const dir = mkdtempSync(join(tmpdir(), "liveness-report-"));
+  const outputPath = join(dir, "gh-output");
+  writeFileSync(outputPath, "");
+  const stdout = execFileSync(process.execPath, [SCRIPT], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      LIVENESS_DIR: join(dir, "absent"),
+      PLAYWRIGHT_JSON: join(dir, "absent.json"),
+      GITHUB_OUTPUT: outputPath,
+      GITHUB_STEP_SUMMARY: "",
+    },
+  });
+  assert.match(stdout, /Not measured/);
+  const outputs = readFileSync(outputPath, "utf8");
+  assert.match(outputs, /^measured=false$/m);
+  assert.match(outputs, /^wedged=false$/m);
+});

--- a/scripts/report-backend-outages.test.mjs
+++ b/scripts/report-backend-outages.test.mjs
@@ -172,16 +172,45 @@ test("attribute counts an attempt that merely overlaps the window edge", () => {
 test("renderSection distinguishes NOT MEASURED from a clean backend", () => {
   const unmeasured = renderSection(attribute([], []));
   assert.match(unmeasured, /Not measured/);
-  assert.doesNotMatch(unmeasured, /no mid-run outage/);
+  assert.doesNotMatch(unmeasured, /No mid-run outage/);
 
   const clean = renderSection(attribute([shard4], collectAttempts(report)));
-  assert.match(clean, /no mid-run outage/);
-  assert.match(clean, /not\*\* wedge collateral/);
+  assert.match(clean, /No mid-run outage measured/);
+  assert.match(clean, /answered \*\*every\*\* probe/);
+});
+
+// The clean verdict's failure mode: `outageCount` excludes runs below minProbes,
+// so a shard that timed out on thirty isolated probes used to render as "answered
+// every probe". Under a saturated single worker that is the expected shape, not a
+// corner case.
+test("renderSection refuses to clear a shard that had discarded blips", () => {
+  const blippy = { ...shard4, failedProbes: 30, ignoredBlips: 30 };
+  const md = renderSection(attribute([blippy], collectAttempts(report)));
+  assert.match(md, /No mid-run outage measured/);
+  assert.match(md, /30 single-probe failure\(s\) were discarded/);
+  assert.match(md, /did \*\*not\*\* answer/);
+  // It must NOT clear the run's failures on the strength of outageCount alone.
+  assert.doesNotMatch(md, /answered \*\*every\*\* probe/);
+  assert.doesNotMatch(md, /are not wedge collateral/);
+});
+
+test("renderSection counts a shard that uploaded nothing at all", () => {
+  // Two of four shards reported; the other two never wrote a summary. "2 measured
+  // shard(s)" alone would read as a complete picture.
+  const md = renderSection(attribute([shard3, shard4], collectAttempts(report)), { shardTotal: 4 });
+  assert.match(md, /2 shard\(s\) uploaded no liveness artifact at all/);
+  assert.match(md, /\*\*unknown\*\*/);
+  const clean = renderSection(attribute([shard4], collectAttempts(report)), { shardTotal: 4 });
+  assert.match(clean, /1 of 4 measured shard\(s\)/);
+  assert.match(clean, /3 shard\(s\) uploaded no liveness artifact/);
 });
 
 test("renderSection names the wedge, tabulates each shard, and prints the down-share caveat", () => {
   const md = renderSection(attribute([shard3, shard4], collectAttempts(report)));
-  assert.match(md, /Langflow worker went down mid-run/);
+  assert.match(md, /backend stopped answering mid-run/);
+  // The measurement is taken through the specs' own forward, so the section must
+  // not overclaim which component died.
+  assert.match(md, /a dead socat would read the same way/);
   assert.match(md, /\| 3 \| 1 \| 2 min \(20%\)/);
   // The caveat is mandatory: at high down-share, overlap is chance, not proof.
   assert.match(md, /lead, not a/);
@@ -255,6 +284,7 @@ test("the CLI aggregates a directory of shard summaries and writes step outputs"
   assert.match(outputs, /^shards_measured=2$/m);
   assert.match(outputs, /^outages_total=1$/m);
   assert.match(outputs, /^collateral_attempts=2$/m);
+  assert.match(outputs, /^blips_total=0$/m);
   assert.match(outputs, new RegExp(`^summary_md<<${MD_DELIMITER}$`, "m"));
   assert.match(readFileSync(summaryPath, "utf8"), /Backend liveness/);
 });

--- a/scripts/watch-backend.mjs
+++ b/scripts/watch-backend.mjs
@@ -42,7 +42,11 @@
 //   WATCH_URL          probe target (default http://localhost:7860/api/v1/version)
 //   WATCH_OUT          JSONL probe log (default backend-liveness.jsonl)
 //   WATCH_SUMMARY      summary path, --summarize only (default backend-liveness.json)
-//   WATCH_INTERVAL_MS  probe period (default 2000)
+//   WATCH_INTERVAL_MS  probe period (default 2000) — the sleep is interval minus
+//                      the probe's own duration, so a probe that burns the full
+//                      timeout relaxes the cadence to ~WATCH_TIMEOUT_MS. The
+//                      resolution DURING an outage is therefore the timeout, not
+//                      the interval
 //   WATCH_TIMEOUT_MS   per-probe deadline (default 4000) — a wedged backend
 //                      accepts the TCP connection and never answers, so without
 //                      this the probe would hang instead of recording a failure

--- a/scripts/watch-backend.mjs
+++ b/scripts/watch-backend.mjs
@@ -1,0 +1,293 @@
+#!/usr/bin/env node
+// In-run backend liveness recorder for the sharded stable workflows (issue #1030).
+//
+// WHY THIS EXISTS
+//
+// The #1011 health gate protects the START of a shard: it waits out the
+// post-collect-models wedge before Playwright launches. Nothing watches the
+// backend DURING the run, and #1048 established that a wedge mid-run is not an
+// anomaly on the heavy shards — on daily run 30444299314 gunicorn killed the
+// single Langflow worker 7 times on shard 3 and 10 times on shard 4, spread
+// evenly across each shard's ~30 minutes of specs.
+//
+// That run also showed why the wedge cannot be quantified after the fact from
+// the artifacts we keep:
+//   - the Langflow image logs no per-request access line, so the container dump
+//     gives the KILL timestamps but not when the event loop actually stalled;
+//   - gunicorn's async worker only reveals a stall via `WORKER TIMEOUT`, which
+//     fires 60-120 s late (`LANGFLOW_WORKER_TIMEOUT=120`, #1048), so a
+//     post-hoc "outage window" is 60-120 s wide by construction;
+//   - at ~1 wedge per 3 minutes those windows cover 33-73% of the shard, and
+//     almost every failing attempt lands inside one BY CHANCE. Correlating
+//     failures against them proves nothing.
+//
+// So the measurement has to happen while the run is happening. This recorder
+// polls the same URL the specs talk to, at a fixed interval, and appends one
+// JSONL line per probe. Two consecutive failed probes bound an outage to a few
+// seconds instead of two minutes, which is narrow enough for the merge job to
+// attribute collateral failures honestly (#1031 consumes that attribution).
+//
+// It is DIAGNOSTIC ONLY. It never fails a step, never aborts a shard, and never
+// gates the @stable tag — at this wedge frequency an abort would discard the
+// ~100 specs per shard that pass across the outages (see #1030's rejected
+// levers). It records; the merge job reports.
+//
+// MODES
+//   (default)    poll until SIGTERM/SIGINT (or WATCH_MAX_SECONDS), appending
+//                one probe per tick to WATCH_OUT
+//   --summarize  read WATCH_OUT and write a compact JSON summary to
+//                WATCH_SUMMARY (outage windows + totals), for the merge job
+//
+// Inputs (env):
+//   WATCH_URL          probe target (default http://localhost:7860/api/v1/version)
+//   WATCH_OUT          JSONL probe log (default backend-liveness.jsonl)
+//   WATCH_SUMMARY      summary path, --summarize only (default backend-liveness.json)
+//   WATCH_INTERVAL_MS  probe period (default 2000)
+//   WATCH_TIMEOUT_MS   per-probe deadline (default 4000) — a wedged backend
+//                      accepts the TCP connection and never answers, so without
+//                      this the probe would hang instead of recording a failure
+//   WATCH_MAX_SECONDS  hard stop so a leaked recorder cannot outlive the job
+//                      (default 7200)
+//   WATCH_MIN_PROBES   consecutive failed probes required to call it an outage
+//                      (default 2 — one failed probe can be a local blip)
+//   WATCH_LABEL        shard label carried into the summary (e.g. "3")
+//   WATCH_FILES        the spec files this shard ran, whitespace-separated
+//                      (matrix.files) — the merge job needs it to map a test in
+//                      the MERGED report back to the shard whose backend wedged
+//
+// Always exits 0: a diagnostic must never be the reason a shard goes red.
+//
+// Pure, dependency-free ESM so CI runs it with plain `node` (no ts-node).
+
+import fs from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const DEFAULTS = {
+  url: "http://localhost:7860/api/v1/version",
+  out: "backend-liveness.jsonl",
+  summary: "backend-liveness.json",
+  intervalMs: 2000,
+  timeoutMs: 4000,
+  maxSeconds: 7200,
+  minProbes: 2,
+};
+
+// Reason strings are the only free-form text in a probe line. Cap them so a
+// pathological error message cannot bloat the log we upload as an artifact.
+const REASON_MAX = 80;
+
+function num(value, fallback) {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+export function parseProbes(text) {
+  const probes = [];
+  for (const line of String(text || "").split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let rec;
+    try {
+      rec = JSON.parse(trimmed);
+    } catch {
+      // A torn last line is expected: the recorder is killed mid-append when
+      // the job moves on. Skip it rather than failing the summary.
+      continue;
+    }
+    const t = Date.parse(rec?.t);
+    if (!Number.isFinite(t)) continue;
+    probes.push({ t, ok: rec.ok === true, ms: Number(rec.ms) || 0, reason: rec.reason || "" });
+  }
+  return probes.sort((a, b) => a.t - b.t);
+}
+
+// A window spans [first failed probe, first probe that answered again]. Both
+// edges are CONSERVATIVE in the direction that under-reports the outage: the
+// backend stopped answering at most one interval BEFORE the first failed probe,
+// and was back at most one interval before `endAt`. So `seconds` is a lower
+// bound on the real outage, never an inflated one — the opposite of the
+// post-hoc `WORKER TIMEOUT` window this replaces.
+export function summarizeProbes(probes, { minProbes = DEFAULTS.minProbes } = {}) {
+  const sorted = [...probes].sort((a, b) => a.t - b.t);
+  const windows = [];
+  let blips = 0;
+  let run = [];
+
+  const close = (endAt, openEnded) => {
+    if (!run.length) return;
+    if (run.length >= minProbes) {
+      const startAt = run[0].t;
+      windows.push({
+        startAt: new Date(startAt).toISOString(),
+        endAt: new Date(endAt).toISOString(),
+        seconds: Math.round(((endAt - startAt) / 1000) * 10) / 10,
+        probes: run.length,
+        openEnded,
+        reason: run[0].reason || "",
+      });
+    } else {
+      blips += run.length;
+    }
+    run = [];
+  };
+
+  for (const p of sorted) {
+    if (p.ok) {
+      close(p.t, false);
+    } else {
+      run.push(p);
+    }
+  }
+  // The log ended while the backend was still down (the run finished, or the
+  // recorder was killed). Close at the last failed probe: anything past it is
+  // unmeasured, and guessing would inflate the outage.
+  close(run.length ? run[run.length - 1].t : 0, true);
+
+  const downSeconds = windows.reduce((acc, w) => acc + w.seconds, 0);
+  const firstProbeAt = sorted.length ? new Date(sorted[0].t).toISOString() : null;
+  const lastProbeAt = sorted.length ? new Date(sorted[sorted.length - 1].t).toISOString() : null;
+  const spanSeconds = sorted.length
+    ? Math.round(((sorted[sorted.length - 1].t - sorted[0].t) / 1000) * 10) / 10
+    : 0;
+
+  return {
+    measured: sorted.length > 0,
+    probeCount: sorted.length,
+    failedProbes: sorted.filter((p) => !p.ok).length,
+    ignoredBlips: blips,
+    firstProbeAt,
+    lastProbeAt,
+    spanSeconds,
+    windows,
+    outageCount: windows.length,
+    downSeconds: Math.round(downSeconds * 10) / 10,
+    // Share of the OBSERVED span the backend was unreachable. The merge job
+    // prints this next to any failure correlation: at 50% coverage, "the
+    // failure fell inside an outage" is a coin flip, not evidence.
+    downPct: spanSeconds > 0 ? Math.round((downSeconds / spanSeconds) * 1000) / 10 : 0,
+  };
+}
+
+async function probeOnce(url, timeoutMs) {
+  const started = Date.now();
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+    return { ok: res.ok, ms: Date.now() - started, reason: res.ok ? "" : `HTTP ${res.status}` };
+  } catch (err) {
+    const reason = String(err?.name === "TimeoutError" ? `timeout>${timeoutMs}ms` : err?.message || err);
+    return { ok: false, ms: Date.now() - started, reason: reason.slice(0, REASON_MAX) };
+  }
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function watch() {
+  const url = process.env.WATCH_URL || DEFAULTS.url;
+  const out = process.env.WATCH_OUT || DEFAULTS.out;
+  const intervalMs = num(process.env.WATCH_INTERVAL_MS, DEFAULTS.intervalMs);
+  const timeoutMs = num(process.env.WATCH_TIMEOUT_MS, DEFAULTS.timeoutMs);
+  const maxSeconds = num(process.env.WATCH_MAX_SECONDS, DEFAULTS.maxSeconds);
+  const deadline = Date.now() + maxSeconds * 1000;
+
+  let running = true;
+  // The recorder is stopped by the workflow's `kill` in a later step, so a
+  // signal is the NORMAL exit path, not an error.
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      running = false;
+    });
+  }
+
+  console.log(`[liveness] probing ${url} every ${intervalMs}ms (timeout ${timeoutMs}ms) → ${out}`);
+  let lastOk = null;
+  while (running && Date.now() < deadline) {
+    const tick = Date.now();
+    const probe = await probeOnce(url, timeoutMs);
+    try {
+      fs.appendFileSync(
+        out,
+        JSON.stringify({ t: new Date(tick).toISOString(), ok: probe.ok, ms: probe.ms, ...(probe.reason ? { reason: probe.reason } : {}) }) + "\n",
+      );
+    } catch (err) {
+      // Losing a probe line is preferable to killing the recorder: the summary
+      // degrades, the shard is unaffected.
+      console.log(`[liveness] could not append a probe: ${err?.message || err}`);
+    }
+    // Log only transitions — a line per probe would bury the shard's own output.
+    if (lastOk !== probe.ok) {
+      console.log(
+        `[liveness] ${new Date(tick).toISOString()} backend ${probe.ok ? "UP" : `DOWN (${probe.reason})`}`,
+      );
+      lastOk = probe.ok;
+    }
+    await sleep(Math.max(0, intervalMs - (Date.now() - tick)));
+  }
+  console.log("[liveness] recorder stopped.");
+}
+
+function summarize() {
+  const out = process.env.WATCH_OUT || DEFAULTS.out;
+  const summaryPath = process.env.WATCH_SUMMARY || DEFAULTS.summary;
+  const minProbes = num(process.env.WATCH_MIN_PROBES, DEFAULTS.minProbes);
+  const shard = process.env.WATCH_LABEL || "";
+  const files = String(process.env.WATCH_FILES || "")
+    .split(/\s+/)
+    .filter(Boolean);
+
+  let text = "";
+  try {
+    text = fs.readFileSync(out, "utf8");
+  } catch {
+    // No probe log at all: the recorder never started (or died instantly). Say
+    // so explicitly — `measured: false` must never be read as "no outage".
+    console.log(`[liveness] ${out} is missing — writing an UNMEASURED summary for shard ${shard || "?"}.`);
+  }
+
+  const summary = { shard, files, ...summarizeProbes(parseProbes(text), { minProbes }) };
+  fs.writeFileSync(summaryPath, JSON.stringify(summary, null, 2) + "\n");
+
+  if (!summary.measured) {
+    console.log(`[liveness] shard ${shard || "?"}: NOT MEASURED (no usable probe recorded).`);
+    return;
+  }
+  console.log(
+    `[liveness] shard ${shard || "?"}: ${summary.outageCount} outage(s), ` +
+      `${summary.downSeconds}s down of ${summary.spanSeconds}s observed (${summary.downPct}%), ` +
+      `${summary.probeCount} probes, ${summary.ignoredBlips} single-probe blip(s) ignored.`,
+  );
+  for (const w of summary.windows) {
+    console.log(
+      `[liveness]   ${w.startAt} → ${w.endAt}  ${w.seconds}s` +
+        `${w.openEnded ? " (still down when the log ended)" : ""}${w.reason ? `  ${w.reason}` : ""}`,
+    );
+  }
+}
+
+async function main() {
+  try {
+    if (process.argv.includes("--summarize")) {
+      summarize();
+    } else {
+      await watch();
+    }
+  } catch (err) {
+    // Diagnostics never break the build.
+    console.log(`[liveness] recorder error (ignored): ${err?.stack || err}`);
+  }
+}
+
+// Run only when invoked directly (not when imported by the test file). Same
+// realpath/pathToFileURL normalisation as scripts/check-run-integrity.mjs —
+// see the comment there for why both halves are load-bearing.
+function isMainModule() {
+  if (!process.argv[1]) return false;
+  try {
+    return import.meta.url === pathToFileURL(fs.realpathSync(process.argv[1])).href;
+  } catch {
+    return false;
+  }
+}
+
+if (isMainModule()) {
+  await main();
+}

--- a/scripts/watch-backend.test.mjs
+++ b/scripts/watch-backend.test.mjs
@@ -1,0 +1,205 @@
+// Unit tests for the in-run backend liveness recorder (issue #1030).
+// Run with: node --test scripts/watch-backend.test.mjs
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawn } from "node:child_process";
+import http from "node:http";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseProbes, summarizeProbes } from "./watch-backend.mjs";
+
+const SCRIPT = fileURLToPath(new URL("./watch-backend.mjs", import.meta.url));
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Probe log shaped like the real one: 2 s cadence, backend answers, drops for
+// three probes, answers again.
+const probeLog = [
+  '{"t":"2026-07-29T10:42:00.000Z","ok":true,"ms":11}',
+  '{"t":"2026-07-29T10:42:02.000Z","ok":true,"ms":9}',
+  '{"t":"2026-07-29T10:42:04.000Z","ok":false,"ms":4001,"reason":"timeout>4000ms"}',
+  '{"t":"2026-07-29T10:42:08.000Z","ok":false,"ms":4002,"reason":"timeout>4000ms"}',
+  '{"t":"2026-07-29T10:42:12.000Z","ok":false,"ms":4000,"reason":"timeout>4000ms"}',
+  '{"t":"2026-07-29T10:42:16.000Z","ok":true,"ms":15}',
+  '{"t":"2026-07-29T10:42:18.000Z","ok":true,"ms":12}',
+].join("\n");
+
+test("parseProbes reads probe lines and tolerates a torn tail", () => {
+  // The recorder is killed mid-append when the job moves on, so the last line
+  // can be partial — that must degrade the summary, not break it.
+  const probes = parseProbes(probeLog + '\n{"t":"2026-07-29T10:42:2');
+  assert.equal(probes.length, 7);
+  assert.equal(probes[0].ok, true);
+  assert.equal(probes[2].reason, "timeout>4000ms");
+});
+
+test("parseProbes sorts by timestamp and drops records without a usable one", () => {
+  const probes = parseProbes(
+    [
+      '{"t":"2026-07-29T10:42:04.000Z","ok":true}',
+      '{"t":"2026-07-29T10:42:00.000Z","ok":true}',
+      '{"ok":false}',
+      '{"t":"not-a-date","ok":false}',
+    ].join("\n"),
+  );
+  assert.deepEqual(
+    probes.map((p) => p.t),
+    [Date.parse("2026-07-29T10:42:00.000Z"), Date.parse("2026-07-29T10:42:04.000Z")],
+  );
+});
+
+test("summarizeProbes bounds the outage between the first failure and the recovery", () => {
+  const s = summarizeProbes(parseProbes(probeLog));
+  assert.equal(s.measured, true);
+  assert.equal(s.outageCount, 1);
+  assert.equal(s.probeCount, 7);
+  assert.equal(s.failedProbes, 3);
+  const [w] = s.windows;
+  assert.equal(w.startAt, "2026-07-29T10:42:04.000Z");
+  assert.equal(w.endAt, "2026-07-29T10:42:16.000Z"); // first probe that answered again
+  assert.equal(w.seconds, 12);
+  assert.equal(w.openEnded, false);
+  assert.equal(s.downSeconds, 12);
+  assert.equal(s.spanSeconds, 18);
+  assert.equal(s.downPct, 66.7);
+});
+
+test("summarizeProbes ignores a single-probe blip but honours minProbes", () => {
+  const log = [
+    '{"t":"2026-07-29T10:00:00.000Z","ok":true}',
+    '{"t":"2026-07-29T10:00:02.000Z","ok":false}',
+    '{"t":"2026-07-29T10:00:04.000Z","ok":true}',
+  ].join("\n");
+  const ignored = summarizeProbes(parseProbes(log));
+  assert.equal(ignored.outageCount, 0);
+  assert.equal(ignored.ignoredBlips, 1);
+  assert.equal(ignored.downSeconds, 0);
+
+  // A caller that wants every failed probe counted can say so.
+  const counted = summarizeProbes(parseProbes(log), { minProbes: 1 });
+  assert.equal(counted.outageCount, 1);
+  assert.equal(counted.ignoredBlips, 0);
+});
+
+test("summarizeProbes marks a log that ends while down as open-ended", () => {
+  const s = summarizeProbes(
+    parseProbes(
+      [
+        '{"t":"2026-07-29T10:00:00.000Z","ok":true}',
+        '{"t":"2026-07-29T10:00:02.000Z","ok":false}',
+        '{"t":"2026-07-29T10:00:04.000Z","ok":false}',
+        '{"t":"2026-07-29T10:00:06.000Z","ok":false}',
+      ].join("\n"),
+    ),
+  );
+  assert.equal(s.outageCount, 1);
+  assert.equal(s.windows[0].openEnded, true);
+  // Closed at the LAST FAILED probe, never extrapolated past what was observed.
+  assert.equal(s.windows[0].endAt, "2026-07-29T10:00:06.000Z");
+  assert.equal(s.windows[0].seconds, 4);
+});
+
+test("summarizeProbes reports an empty log as NOT measured", () => {
+  const s = summarizeProbes(parseProbes(""));
+  // measured=false is the load-bearing distinction: it must never be rendered
+  // as "the backend stayed up".
+  assert.equal(s.measured, false);
+  assert.equal(s.outageCount, 0);
+  assert.equal(s.downPct, 0);
+});
+
+test("--summarize writes a shard-labelled summary carrying the shard's spec list", () => {
+  const dir = mkdtempSync(join(tmpdir(), "liveness-"));
+  const jsonl = join(dir, "probes.jsonl");
+  const out = join(dir, "summary.json");
+  writeFileSync(jsonl, probeLog + "\n");
+
+  const stdout = execFileSync(process.execPath, [SCRIPT, "--summarize"], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      WATCH_OUT: jsonl,
+      WATCH_SUMMARY: out,
+      WATCH_LABEL: "3",
+      WATCH_FILES: "tests-automations/regression/a.spec.ts tests-automations/regression/b.spec.ts",
+    },
+  });
+
+  const summary = JSON.parse(readFileSync(out, "utf8"));
+  assert.equal(summary.shard, "3");
+  assert.equal(summary.outageCount, 1);
+  assert.deepEqual(summary.files, [
+    "tests-automations/regression/a.spec.ts",
+    "tests-automations/regression/b.spec.ts",
+  ]);
+  assert.match(stdout, /shard 3: 1 outage\(s\)/);
+});
+
+test("--summarize on a missing probe log writes an UNMEASURED summary and exits 0", () => {
+  const dir = mkdtempSync(join(tmpdir(), "liveness-"));
+  const out = join(dir, "summary.json");
+  const stdout = execFileSync(process.execPath, [SCRIPT, "--summarize"], {
+    encoding: "utf8",
+    env: { ...process.env, WATCH_OUT: join(dir, "absent.jsonl"), WATCH_SUMMARY: out, WATCH_LABEL: "2" },
+  });
+  const summary = JSON.parse(readFileSync(out, "utf8"));
+  assert.equal(summary.measured, false);
+  assert.equal(summary.outageCount, 0);
+  assert.match(stdout, /NOT MEASURED/);
+});
+
+// End-to-end proof that the recorder detects a REAL outage: probe a local
+// server, take it away, bring it back. This is the behaviour the whole
+// mechanism rests on — a wedged backend accepts nothing and the probe must
+// record a failure rather than hang.
+test("the recorder records an outage while the target is gone", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "liveness-"));
+  const jsonl = join(dir, "probes.jsonl");
+  const summaryPath = join(dir, "summary.json");
+
+  const server = http.createServer((_req, res) => res.end('{"version":"test"}'));
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+
+  const child = spawn(process.execPath, [SCRIPT], {
+    env: {
+      ...process.env,
+      WATCH_URL: `http://127.0.0.1:${port}/api/v1/version`,
+      WATCH_OUT: jsonl,
+      WATCH_INTERVAL_MS: "100",
+      WATCH_TIMEOUT_MS: "300",
+      WATCH_MAX_SECONDS: "30",
+    },
+    stdio: "ignore",
+  });
+
+  try {
+    await sleep(600); // a few healthy probes
+    // closeAllConnections(): undici keeps the socket alive, so without this the
+    // probe could linger on an established connection instead of failing.
+    server.closeAllConnections?.();
+    await new Promise((resolve) => server.close(resolve));
+    await sleep(900); // several failing probes → one window
+    const revived = http.createServer((_req, res) => res.end('{"version":"test"}'));
+    await new Promise((resolve) => revived.listen(port, "127.0.0.1", resolve));
+    await sleep(600); // recovery probes close the window
+    child.kill("SIGTERM");
+    await new Promise((resolve) => child.on("exit", resolve));
+    await new Promise((resolve) => revived.close(resolve));
+
+    execFileSync(process.execPath, [SCRIPT, "--summarize"], {
+      env: { ...process.env, WATCH_OUT: jsonl, WATCH_SUMMARY: summaryPath, WATCH_LABEL: "e2e" },
+      stdio: "ignore",
+    });
+    const summary = JSON.parse(readFileSync(summaryPath, "utf8"));
+    assert.equal(summary.measured, true);
+    assert.ok(summary.probeCount >= 8, `expected several probes, got ${summary.probeCount}`);
+    assert.equal(summary.outageCount, 1, `expected exactly one outage, got ${summary.outageCount}`);
+    assert.equal(summary.windows[0].openEnded, false, "the window must close once the target answers again");
+    assert.ok(summary.downSeconds > 0.3, `outage looked too short: ${summary.downSeconds}s`);
+  } finally {
+    child.kill("SIGKILL");
+    server.close();
+  }
+});


### PR DESCRIPTION
## Why

The #1011 health gate proves the backend is alive when Playwright **starts**. Nothing watched it **during** the run, so a worker that wedged mid-shard reported itself as a list of unrelated spec failures — run 30374528125 spent ~26 of one shard's 38 minutes retrying against a dead backend and put 14 phantom failures into triage.

Two findings from run [30444299314](https://github.com/oriontech-me/langflow-e2e/actions/runs/30444299314) — the only daily after #1048's `LANGFLOW_WORKER_TIMEOUT=120` cap — set the shape of this PR:

1. **The wedge is steady state, not an incident.** gunicorn killed the single worker **7 times on shard 3 and 10 times on shard 4**, evenly spread across ~30 minutes of specs, and shard 4 still passed **101 tests**. So the levers #1030 originally proposed are out: aborting the shard on detection would discard ~100 passing specs per shard every day, and `--max-failures` would trip on the 5 legitimate failures shard 4 also produced.

2. **It cannot be quantified after the fact.** The image logs no per-request line, and gunicorn's async worker only reveals a stall via `WORKER TIMEOUT`, which fires 60-120 s late. An inferred outage window is therefore 60-120 s wide, and at this wedge frequency those windows cover **33-73% of the shard** — every failure "correlates" with one by chance:

   | Shard | Outages | Backend down | Observed span | Failing attempts | …overlapping a window |
   |---|---|---|---|---|---|
   | 3 | 7 | 15.8 min (47%) | 33.5 min | 22 | 19 |
   | 4 | 10 | 22.5 min (55%) | 41.1 min | 20 | 20 |

   At ~50% coverage, "19 of 22 fell inside a window" is what chance produces. The measurement has to happen while the run happens.

## What this changes

- **`scripts/watch-backend.mjs`** (new) — probes the URL the specs use every 2 s and appends one JSONL line per probe; two consecutive failures bound an outage to ~4 s instead of 120. `--summarize` turns the log into outage windows plus the shard's spec-file list (`matrix.files`), which the **merged** report has no column for — without it a shard-3 outage could be blamed for a shard-4 failure. Carries its own per-probe deadline, because a wedged worker accepts the connection and never answers.
- **`scripts/report-backend-outages.mjs`** (new) — aggregates the per-shard summaries, attributes failing attempts only to the shard whose **own** backend went down, and renders the section that leads the umbrella issue. It always prints the down-share next to the overlap count and calls overlap a **lead, not a verdict**.
- **`.github/workflows/daily-stable.yml`** — starts the recorder after the health gate, summarizes + uploads with `always()`, downloads `liveness-*` in the merge job (deliberately **without** `merge-multiple`: every shard names its file `backend-liveness.json`, so flattening would overwrite), runs the reporter before the issue step, and injects the section at the top of the umbrella body.
- **`.gitignore`**, **`.claude/skills/langflow-e2e-infra/references/failure-modes.md`** — ignore the local artifacts; record the *measure it* lever and the two rejected ones so the next reader does not re-propose them.

**Diagnostic only, by design.** It never fails a step, never aborts a shard, and never gates `@stable`. A missing artifact renders as **UNKNOWN**, never as a healthy backend — consuming this attribution to exempt collateral failures from the tag mutation stays **#1031**'s job, under its own rules.

## Validation

- `npm run test:scripts` → **110 pass / 0 fail** (21 of them new), `npm run test:units` → **84 pass / 0 fail**, `npm run typecheck` clean, `npm run lint` 0 errors.
- The recorder's outage path is proven end-to-end against a real socket: server up → killed → revived, asserting exactly one window that closes on recovery.
- The recorder run against a live Langflow (`1.12.0.dev7`): 9 probes at a 2 s cadence, clean SIGTERM shutdown, correct summary.
- The reporter run against the **real** merged `results.json` of run 30444299314 with that run's real kill windows — it produced the table above.
- **The workflow wiring cannot run locally.** Its proof is the next scheduled daily: watch each shard's `Summarize backend liveness` step for `[liveness] shard N: X outage(s), Ys down of Zs (P%)`, the `liveness-N` artifact, and the `🔌 Backend liveness` section at the top of the umbrella issue (or the one-line "answered every probe" verdict on a clean day).

## Scope

Covers #1030's **Done when 1 and 2** (quantify the cost; make the merge job name the wedge). **Done when 3** — choosing and benchmarking the lever — stays blocked on **#1058**: on the run above, 2 of 4 shards executed zero tests, so there is no baseline to measure a wall-clock / coverage trade-off against. Refs #1030, not a close.

No spec, spec doc, or `QA-CHECKLIST.md` change: this PR touches only `scripts/`, `.github/workflows/`, `.gitignore`, and the infra skill's reference index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
