### PR TITLE
ci(daily-stable): stop a narrow backend wedge from stripping @stable (#1031)

### DIFF
--- a/.claude/skills/langflow-e2e-triage/SKILL.md
+++ b/.claude/skills/langflow-e2e-triage/SKILL.md
@@ -177,6 +177,14 @@ occurrences under it.
 than splitting it across per-symptom buckets — this is the #899 fix for the
 misgrouping that hid #898's `langchain-google-genai` cause.
 
+**Set aside the wedge collateral (#1031).** The umbrella's `@stable` section
+renders, ahead of the removals, the hard failures the run could **not** attribute
+to their spec — those whose last error is transport-level. Their tag was kept on
+purpose. Do **not** cluster them and do **not** open a per-spec issue for them:
+they are one backend outage, triaged once for the run against the umbrella's
+backend liveness section. Rule and signature list: `CONTRIBUTING.md` →
+*Infra-signature exemption (wedge collateral)*.
+
 Then cluster the rest of `hard_failures[]` by root cause: **same normalized
 error signature + same area + same failure symptom → one issue.** Don't open one
 issue per failing spec by default — a shared root cause is one problem, not N.

--- a/.github/actions/auto-remove-stable/action.yml
+++ b/.github/actions/auto-remove-stable/action.yml
@@ -27,6 +27,10 @@ inputs:
       backend was not measured. WORDING ONLY — the infra-signature exemption
       never depends on it, so a caller with no liveness step (weekly-stable)
       can leave it unset and still get the exemption.
+      Callers must NOT forward `report-backend-outages.mjs`'s `wedged` output
+      bare: it is also "false" when no shard produced probes at all. Gate it on
+      that step's `measured` output so "unmeasured" arrives here as "", or the
+      summary claims the recorder measured no outage on a run it never measured.
     required: false
     default: ""
 
@@ -74,6 +78,10 @@ runs:
     - name: Commit @stable removals to main
       if: steps.remove.outputs.status == 'removed'
       shell: bash
+      env:
+        REMOVED_COUNT: ${{ steps.remove.outputs.removed_count }}
+        EXEMPT_COUNT: ${{ steps.remove.outputs.exempt_count }}
+        RUN_LABEL: ${{ inputs.run_label }}
       run: |
         set -euo pipefail
         # Same "dubious ownership" workaround as the history commit step: the job
@@ -89,5 +97,12 @@ runs:
         # results.json / payload.json / auto-remove-result.json at repo root are
         # not git-ignored and must not be committed.
         git add tests/tests-automations/regression QA-CHECKLIST.md
-        git commit -m "chore(triage): auto-remove @stable from ${{ steps.remove.outputs.removed_count }} hard-failing test(s) (${{ inputs.run_label }}) [skip ci]"
+        MSG="chore(triage): auto-remove @stable from ${REMOVED_COUNT} hard-failing test(s) (${RUN_LABEL}) [skip ci]"
+        if [ "${EXEMPT_COUNT:-0}" != "0" ]; then
+          # Record in the commit itself why fewer tags were removed than tests
+          # failed — otherwise auditing this commit means re-opening the run
+          # to discover the wedge collateral (#1031).
+          MSG="${MSG}"$'\n\n'"${EXEMPT_COUNT} further hard failure(s) kept @stable as non-attributable wedge collateral (#1031)."
+        fi
+        git commit -m "$MSG"
         git push

--- a/.github/actions/auto-remove-stable/action.yml
+++ b/.github/actions/auto-remove-stable/action.yml
@@ -4,8 +4,10 @@ description: >-
   (failed every retry), regenerate QA-CHECKLIST.md, and commit the change back
   to main — no human review (leadership decision; restoring the tag is the
   human-gated step). A mass-failure guard leaves everything untouched when too
-  many tests fail at once (treated as infra, not per-test rot). Shared by
-  daily-stable.yml and weekly-stable.yml. Assumes checkout + npm ci already ran.
+  many tests fail at once (treated as infra, not per-test rot), and a hard
+  failure whose last error is transport-level is exempted outright as wedge
+  collateral (#1031). Shared by daily-stable.yml and weekly-stable.yml. Assumes
+  checkout + npm ci already ran.
 
 inputs:
   playwright_json:
@@ -19,6 +21,14 @@ inputs:
   run_label:
     description: "Human label for the commit message, e.g. 'daily #123'."
     required: true
+  backend_wedged:
+    description: >-
+      The in-run liveness verdict (#1030): "true", "false", or empty when the
+      backend was not measured. WORDING ONLY — the infra-signature exemption
+      never depends on it, so a caller with no liveness step (weekly-stable)
+      can leave it unset and still get the exemption.
+    required: false
+    default: ""
 
 outputs:
   status:
@@ -27,6 +37,9 @@ outputs:
   removed_count:
     description: "Number of tests the @stable tag was removed from."
     value: ${{ steps.remove.outputs.removed_count }}
+  exempt_count:
+    description: "Hard failures exempted as non-attributable wedge collateral (#1031)."
+    value: ${{ steps.remove.outputs.exempt_count }}
   summary_md:
     description: "Markdown summary for the triage issue body."
     value: ${{ steps.remove.outputs.summary_md }}
@@ -40,6 +53,7 @@ runs:
       env:
         PLAYWRIGHT_JSON: ${{ inputs.playwright_json }}
         MAX_AUTO_REMOVE: ${{ inputs.max_auto_remove }}
+        BACKEND_WEDGED: ${{ inputs.backend_wedged }}
       run: |
         set -euo pipefail
         npx ts-node scripts/remove-stable-from-failures.ts > auto-remove-result.json
@@ -47,6 +61,7 @@ runs:
         {
           echo "status=$(node -p "require('./auto-remove-result.json').status")"
           echo "removed_count=$(node -p "require('./auto-remove-result.json').removed.length")"
+          echo "exempt_count=$(node -p "(require('./auto-remove-result.json').exempt || []).length")"
         } >> "$GITHUB_OUTPUT"
         # Multi-line markdown value via a heredoc delimiter (GitHub Actions format).
         SUMMARY="$(node scripts/format-auto-remove-summary.mjs auto-remove-result.json)"

--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -948,7 +948,14 @@ jobs:
           # inside the action stands on the failure's own error, so it still
           # applies when this is empty — which is the run where the backend
           # state is least known and the exemption matters most.
-          backend_wedged: ${{ steps.liveness.outputs.wedged }}
+          #
+          # Gated on `measured`: a run whose shards uploaded NO liveness artifact
+          # also emits `wedged=false`, and forwarding that bare would have the
+          # auto-removal block claim the recorder "measured no outage" over a run
+          # where it measured nothing. That is the exact misreading
+          # report-backend-outages.mjs warns about ("must never be read as no
+          # outage"), so unmeasured has to arrive as "" (unknown), not "false".
+          backend_wedged: ${{ steps.liveness.outputs.measured == 'true' && steps.liveness.outputs.wedged || '' }}
 
       # Open the umbrella triage issue on failure — scheduled runs ONLY, aligned
       # with the history / auto-remove steps above. A manual dispatch is itself a

--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -726,9 +726,11 @@ jobs:
       # announce the wedge, not a list of collateral specs that reads as
       # per-test rot.
       #
-      # Reports only — it sets no gate. The @stable auto-removal below keeps its
-      # own guards untouched; consuming this attribution to exempt collateral
-      # failures from the tag mutation is #1031, under its own rules.
+      # Reports only — it sets no gate. The @stable auto-removal below decides the
+      # tag on the failure's OWN error signature (#1031), not on this table: the
+      # honesty note in the section explains why overlap with an outage window is
+      # a lead and not a verdict. The only thing that crosses over is the `wedged`
+      # output, passed to the auto-remove action to word its exemption.
       #
       # continue-on-error: the two steps that follow and matter most on a red day
       # — `Auto-remove @stable from hard failures` and `Create issue on failure` —
@@ -922,6 +924,11 @@ jobs:
       # mass-failure guard inside the action leaves everything untouched when too
       # many tests fail at once (infra, not per-test rot). Scheduled runs only —
       # a manual dispatch must never mutate the test source.
+      # On top of the guard, #1031: a hard failure whose last error is
+      # transport-level (apiRequestContext timeout, ECONNREFUSED, the globalSetup
+      # `is not reachable`) is wedge collateral, not per-test rot, and is exempted
+      # INDEPENDENTLY of the threshold. The guard only ever covered the WIDE
+      # wedge; a wedge costing ≤5 tests used to strip their tags with no review.
       # Gated on shardguard.complete: an incomplete merge (a dead shard) yields an
       # under-counted results.json, so never mutate the @stable tag on partial data.
       # ALSO gated on runguard.empty (#1012): a report with zero tests carries no
@@ -937,6 +944,11 @@ jobs:
           playwright_json: results.json
           max_auto_remove: "5"
           run_label: "daily #${{ github.run_id }}"
+          # #1030's verdict, for WORDING only. The infra-signature exemption
+          # inside the action stands on the failure's own error, so it still
+          # applies when this is empty — which is the run where the backend
+          # state is least known and the exemption matters most.
+          backend_wedged: ${{ steps.liveness.outputs.wedged }}
 
       # Open the umbrella triage issue on failure — scheduled runs ONLY, aligned
       # with the history / auto-remove steps above. A manual dispatch is itself a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -657,7 +657,7 @@ Three cases where the tag is intentionally absent:
 
 On a red scheduled `daily-stable.yml` run, the workflow does two things **automatically**:
 
-1. Removes `@stable` from **every hard failure** (a test that failed all retries), regenerates `QA-CHECKLIST.md`, and commits it to `main` with `[skip ci]` — no PR, no approval. If the mass-failure guard trips (too many at once → treated as infra), nothing is removed.
+1. Removes `@stable` from **every attributable hard failure** (a test that failed all retries with an error that could be its own), regenerates `QA-CHECKLIST.md`, and commits it to `main` with `[skip ci]` — no PR, no approval. Two things hold it back: the mass-failure guard (too many at once → treated as infra, nothing is removed) and the **infra-signature exemption** (a failure whose error is transport-level is wedge collateral and keeps its tag, whatever the count).
 2. Opens a single **triage issue** for the run, listing what was removed.
 
 The triage issue is the analyst's **inbox and dispatcher** — not the tracking issue for each problem. Its only deliverable is the **triage itself**: read the run, route each occurrence into a dedicated issue (or enrich an existing one), and then **close the triage issue**. It never carries an investigation or a fix. The triage issue is closed **only once the triage is complete** — every needed dedicated issue created or enriched (hard failure / flake / skip, per the criteria below) **and** every test the criteria require quarantined (hard failures: `@stable` auto-removed by the workflow; recurrent flakes: **quarantined via PR** at this point — remove `@stable` **and** add `test.fixme` — as prevention). When the mass-failure guard trips (see below), the triage gains one extra deliverable: **decide whether the day was environmental** and, if not, **manually quarantine** the real hard failures (only durable cross-day clusters get a dedicated issue on a guard day; the rest is **noted rather than filed** — see the Mass-failure guard note below). The triage issue still **closes** at the end of that triage, like on any other day, with the noted collateral listed in its closing comment. The human steps are the fan-out, the manual quarantine for recurrent flakes, and lifting it after the fix.
@@ -668,13 +668,17 @@ The runbook — order, dedup, analysis depth, and how the follow-up issue must b
 daily-stable.yml run goes red
       │
       │  AUTOMATIC:
-      │   • @stable removed from each hard failure + committed to main [skip ci]
-      │     (unless the mass-failure guard trips → nothing removed)
-      │   • one TRIAGE ISSUE opened for the run, listing what was removed
+      │   • infra-signature failures set aside as WEDGE COLLATERAL (tag kept)
+      │   • @stable removed from each remaining hard failure + committed to
+      │     main [skip ci] (unless the mass-failure guard trips → nothing removed)
+      │   • one TRIAGE ISSUE opened for the run, listing both groups
       ▼
 Analyst works the triage issue (dispatcher) — order: HARD FAILURES → FLAKES → SKIPS:
       │
-      ├─► per HARD FAILURE  (tag already auto-removed)
+      ├─► per WEDGE COLLATERAL failure  (tag still in place)
+      │        → NO per-spec issue. Triage the backend outage once, for the run
+      │
+      ├─► per ATTRIBUTABLE HARD FAILURE  (tag already auto-removed)
       │        → one DEDICATED issue per failure
       │          (group failures that share a root cause into one issue)
       │
@@ -696,6 +700,14 @@ Problem resolved → quarantine LIFTED via PR (remove test.fixme + restore
 > **Mass-failure guard.** The threshold is the `max_auto_remove` input of the `auto-remove-stable` action (default `5`, so the guard trips at **6+** hard failures in a run). Above the threshold, the workflow assumes an environment-wide failure and removes nothing, so a bad infra day cannot strip `@stable` off the whole suite. When it trips, the triage issue says so and the tags are still in place — investigate the environment; if it turns out not to be environmental, **manually quarantine** the real hard failures (remove `@stable` + add `test.fixme`). There is nothing to lift for tests never quarantined.
 >
 > On a guard-tripped day, split the clusters by durability: a cluster whose same test + error signature also failed on **other, non-adjacent** dailies is a **durable** signal (it reproduces off mass-failure days) and gets its own dedicated issue as usual; **today-only collateral** (no cross-day recurrence) is **noted, not filed** — a dedicated tracker for what most likely vanishes when the instance recovers is throwaway triage noise (same reason a first-occurrence flake is noted, not filed). The collateral has no dedicated issue, but that is **not** a reason to leave the umbrella open: **close it at the end of triage, as on any other day**, listing the noted-not-filed collateral in the closing comment so the thread stays readable. The standing record is `reports/daily-history.jsonl`, not the issue — every triage recomputes recurrence from that file over a 30-day window, so a collateral cluster that persists is re-detected on the next run and filed then, whether or not an umbrella was left open. Keeping them open instead accumulates stale rows in the `daily-failure` list that every later triage has to dedup against, and contradicts the rule above that the triage issue is a dispatcher, never a tracker.
+
+> **Infra-signature exemption (wedge collateral).** A hard failure whose last error is **transport-level** — the harness could not reach or talk to the backend — is not attributable to the spec that reported it. It is collateral of a mid-run backend wedge (#1030/#1048), and `@stable` is left in place **regardless of the mass-failure guard**. The guard only ever covered the *wide* wedge (6+ failures); a wedge costing ≤5 tests used to strip their tags in an unreviewed commit — issue #1031.
+>
+> The exempting signatures live in `scripts/lib/infra-signatures.ts` and the list is **deliberately narrow**: only errors that cannot be a product assertion under any reading (`apiRequestContext.*: Timeout`, the globalSetup `[preflight] … is not reachable`, `ECONNREFUSED`/`ECONNRESET`/`socket hang up`, `net::ERR_CONNECTION_*`, DNS failures). Signatures a wedge also produces but a real regression produces too — `locator.click: Timeout`, `page.waitForSelector: Timeout`, `expect(...).toBeVisible()` — are **not** on it, because exempting them would switch auto-removal off for most genuine breakage. Widening the list is a deliberate change, not a convenience: add a pattern only when it is transport-level, and add a case to `scripts/remove-stable-from-failures.test.ts` with it.
+>
+> **What this changes for triage.** The umbrella issue renders collateral in its own block, ahead of the removals. **Do not open a per-spec issue for a collateral failure** — triage the outage once for the run (start from the backend liveness section of the same issue, then the Langflow service container log; `WORKER TIMEOUT` ⇒ #1048). The tag is still in place, so there is nothing to restore. If the same spec keeps appearing as collateral across days while other specs do not, that is a signal about the *spec* (it hammers the backend hardest) and belongs on a dedicated issue about load, not about the assertion.
+>
+> The in-run liveness verdict (#1030) is **corroboration, not the criterion**: the exemption is decided on the failure's own error, so it still applies on a run where the recorder measured nothing — which is exactly the run whose backend state is least known. The liveness section itself says overlap with an outage window is a *lead, not a verdict*, because at a 33-73% down-share a failure lands inside a window by chance.
 
 > **Trade-off.** Auto-removal does not distinguish a product regression from a test bug before removing — a hard failure quarantines the test either way, and the classification happens afterwards on the dedicated issue. Accepted trade-off: a genuine regression stops being tracked by the stable suite until a human restores the tag, but the daily stops going red immediately.
 
@@ -791,6 +803,7 @@ Then compare the signatures — the action depends on **what** recurred (same ca
 
 | Symptom in the latest daily run | History context | Action |
 |---|---|---|
+| Hard failure, **infra signature** (transport-level error — the umbrella lists it as wedge collateral) | any | Not attributable to the spec. `@stable` was **kept** (#1031). **No per-spec issue** — triage the backend outage once for the run. Nothing to restore. |
 | Hard failure (all retries failed) | any | `@stable` was already auto-removed (or the mass-failure guard tripped and left it in place). No manual removal — classify on the dedicated issue and restore the tag when the test is fixed. |
 | Flake (passed on retry) | No matching signature in the last 30 days | Note in the triage; **do not** open an issue yet. The retry budget absorbs single-run noise. |
 | Flake (recurrent) | **Same `error_signature`** seen before within 30 days | Open a **dedicated issue** (`daily-failure` + `area:<...>`, cite the run ids) **and quarantine via PR as prevention** — remove `@stable` **and** add `test.fixme` (tag removal alone leaves the test red on the impacted-specs gate; #871). Quarantine is manual — the workflow never auto-removes flakes. Lifting it (remove `test.fixme` + restore `@stable`) is a **deliverable of that dedicated issue**. |

--- a/scripts/format-auto-remove-summary.mjs
+++ b/scripts/format-auto-remove-summary.mjs
@@ -1,10 +1,52 @@
 #!/usr/bin/env node
 // Turn the JSON output of remove-stable-from-failures.ts into a Markdown block
 // for the triage issue body. Usage: node format-auto-remove-summary.mjs <json-file>
+//
+// Since #1031 the block has TWO halves, and the order is deliberate: what was
+// NOT attributable comes first. A wedged backend produces a list of unrelated
+// specs that reads as per-test rot, and triage that starts from that list pays a
+// full cycle to rediscover the cause (run 30374528125: 14 of 19 hard failures
+// described one wedged backend).
 import { readFileSync } from "node:fs";
 
 const r = JSON.parse(readFileSync(process.argv[2], "utf8"));
 const lines = [];
+
+const exempt = Array.isArray(r.exempt) ? r.exempt : [];
+// `attributableFailures` is absent on output produced before #1031; fall back to
+// the total so an older artifact still renders something truthful.
+const attributable = Number.isFinite(r.attributableFailures)
+  ? r.attributableFailures
+  : r.hardFailures;
+
+if (exempt.length) {
+  // The liveness verdict (#1030) only strengthens or weakens the wording — the
+  // exemption itself stands on the error signature, so it survives a run where
+  // the recorder measured nothing.
+  const corroboration =
+    r.backendWedged === "true"
+      ? " The in-run liveness recorder **measured a mid-run outage** on this run (#1030), which corroborates it."
+      : r.backendWedged === "false"
+        ? " The in-run liveness recorder measured **no** outage (#1030) — the exemption stands on the error alone, since a transport error is still not a product assertion."
+        : " Backend liveness was **not measured** on this run (#1030), so the exemption stands on the error alone.";
+
+  lines.push(
+    `🔌 **${exempt.length} hard failure(s) are NOT attributable to their spec** — wedge collateral. ` +
+      `Their last error is transport-level (the harness could not reach or talk to the backend), ` +
+      `so \`@stable\` was **left in place** regardless of the mass-failure guard (#1031).${corroboration}`,
+  );
+  lines.push("");
+  for (const e of exempt) {
+    lines.push(`- \`${e.file}\` — ${e.title} _(${e.signature}: ${e.why})_`);
+    lines.push(`  \`${String(e.error).split("\n")[0]}\``);
+  }
+  lines.push("");
+  lines.push(
+    "**Do not open a per-spec issue for these.** Triage the backend outage instead — start from the " +
+      "backend liveness section above and the Langflow service container log (`WORKER TIMEOUT` ⇒ #1048).",
+  );
+  lines.push("");
+}
 
 if (r.status === "guard_tripped") {
   lines.push(
@@ -13,6 +55,14 @@ if (r.status === "guard_tripped") {
       `this many stable tests fail at once is almost always infra (Langflow didn't boot, ` +
       `network/model outage), not per-test rot. Triage manually.`,
   );
+  if (exempt.length) {
+    lines.push("");
+    lines.push(
+      `The guard counts **every** hard failure, collateral included (${exempt.length} of ${r.hardFailures} ` +
+        `here), so it never removes more than it would have before #1031 — the ${attributable} attributable ` +
+        `failure(s) above are for manual triage.`,
+    );
+  }
 } else if (r.status === "removed") {
   lines.push(`🔻 **Auto-removed \`@stable\`** from ${r.removed.length} hard-failing test(s):`);
   lines.push("");
@@ -24,6 +74,13 @@ if (r.status === "guard_tripped") {
   }
   lines.push("");
   lines.push("These were committed to `main` automatically. **Restoring `@stable` is manual**: once the test or Langflow is fixed, re-add the tag via PR.");
+} else if (exempt.length && attributable === 0) {
+  // Every hard failure was collateral. Saying "nothing was auto-removed" alone
+  // would read as a clean triage over a run that was anything but.
+  lines.push(
+    `No \`@stable\` tag was touched: **all ${r.hardFailures} hard failure(s) were non-attributable** (above). ` +
+      "There is no per-spec evidence to triage on this run.",
+  );
 } else {
   lines.push("No per-test `@stable` hard failures were auto-removed.");
 }

--- a/scripts/format-auto-remove-summary.mjs
+++ b/scripts/format-auto-remove-summary.mjs
@@ -12,6 +12,13 @@ import { readFileSync } from "node:fs";
 const r = JSON.parse(readFileSync(process.argv[2], "utf8"));
 const lines = [];
 
+/**
+ * Make text safe inside a single-backtick code span. An error message is
+ * arbitrary product text — one backtick in it closes the span and the rest of
+ * the line renders as prose, mid-issue-body.
+ */
+const code = (text) => String(text).replaceAll("`", "'");
+
 const exempt = Array.isArray(r.exempt) ? r.exempt : [];
 // `attributableFailures` is absent on output produced before #1031; fall back to
 // the total so an older artifact still renders something truthful.
@@ -38,7 +45,7 @@ if (exempt.length) {
   lines.push("");
   for (const e of exempt) {
     lines.push(`- \`${e.file}\` — ${e.title} _(${e.signature}: ${e.why})_`);
-    lines.push(`  \`${String(e.error).split("\n")[0]}\``);
+    lines.push(`  \`${code(String(e.error).split("\n")[0])}\``);
   }
   lines.push("");
   lines.push(
@@ -58,9 +65,13 @@ if (r.status === "guard_tripped") {
   if (exempt.length) {
     lines.push("");
     lines.push(
-      `The guard counts **every** hard failure, collateral included (${exempt.length} of ${r.hardFailures} ` +
-        `here), so it never removes more than it would have before #1031 — the ${attributable} attributable ` +
-        `failure(s) above are for manual triage.`,
+      attributable === 0
+        ? `The guard counts **every** hard failure, so it never removes more than it would have before ` +
+            `#1031 — but here **all ${r.hardFailures} were collateral** (above). There is no per-spec ` +
+            `evidence to triage on this run.`
+        : `The guard counts **every** hard failure, collateral included (${exempt.length} of ${r.hardFailures} ` +
+            `here), so it never removes more than it would have before #1031 — the ${attributable} attributable ` +
+            `failure(s) above are for manual triage.`,
     );
   }
 } else if (r.status === "removed") {

--- a/scripts/format-auto-remove-summary.test.mjs
+++ b/scripts/format-auto-remove-summary.test.mjs
@@ -117,6 +117,45 @@ test("a guard-tripped run still names its collateral and explains the count", ()
   assert.match(md, /the 5 attributable/);
 });
 
+test("a guard-tripped run that is ALL collateral does not promise attributable triage", () => {
+  // The 0-attributable wording matters: "the 0 attributable failure(s) above are
+  // for manual triage" would send the analyst looking for evidence that is not
+  // there.
+  const md = render({
+    status: "guard_tripped",
+    threshold: 5,
+    hardFailures: 6,
+    attributableFailures: 0,
+    removed: [],
+    skipped: [],
+    exempt: Array.from({ length: 6 }, (_, i) => collateral(`c${i}`)),
+    backendWedged: "true",
+  });
+
+  assert.match(md, /Mass-failure guard tripped/);
+  assert.match(md, /all 6 were collateral/);
+  assert.match(md, /no per-spec evidence to triage/);
+  assert.doesNotMatch(md, /the 0 attributable/);
+});
+
+test("a backtick in the error cannot break out of the code span", () => {
+  const md = render({
+    status: "none",
+    threshold: 5,
+    hardFailures: 1,
+    attributableFailures: 0,
+    removed: [],
+    skipped: [],
+    exempt: [{ ...collateral("a"), error: "Error: connect ECONNREFUSED to `langflow`:7860" }],
+    backendWedged: "",
+  });
+
+  // One line, and the backticks in it are only the two that open and close it.
+  const line = md.split("\n").find((l) => l.includes("ECONNREFUSED"));
+  assert.equal((line.match(/`/g) || []).length, 2, line);
+  assert.match(line, /'langflow'/);
+});
+
 test("a run with no collateral renders exactly the pre-#1031 block", () => {
   const md = render({
     status: "removed",

--- a/scripts/format-auto-remove-summary.test.mjs
+++ b/scripts/format-auto-remove-summary.test.mjs
@@ -1,0 +1,152 @@
+// Unit tests for the auto-removal issue-body formatter (issue #1031).
+// Run with: npm run test:scripts
+//
+// This block IS the daily umbrella's `@stable` section. Its job since #1031 is
+// to keep two things apart that a wedged run mashes together: failures the run
+// can attribute to their spec, and failures that only describe a dead backend.
+// Getting that wrong is expensive in a specific way — on run 30374528125 triage
+// read 14 collateral specs as 14 broken specs and paid a full cycle for it.
+//
+// The script is a plain stdout filter, so drive it as one rather than importing:
+// the argv-in/stdout-out contract is what `.github/actions/auto-remove-stable`
+// actually uses.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = path.join(path.dirname(fileURLToPath(import.meta.url)), "format-auto-remove-summary.mjs");
+
+function render(result) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fmt-1031-"));
+  try {
+    const file = path.join(dir, "auto-remove-result.json");
+    fs.writeFileSync(file, JSON.stringify(result));
+    return execFileSync(process.execPath, [SCRIPT, file], { encoding: "utf-8" });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const collateral = (title) => ({
+  file: `tests/x/${title}.spec.ts`,
+  title,
+  line: 4,
+  signature: "api-request-timeout",
+  why: "a direct REST call to the backend never answered",
+  error: "TimeoutError: apiRequestContext.get: Timeout 20000ms exceeded.",
+});
+
+test("an all-collateral run says so instead of reading as a clean triage", () => {
+  const md = render({
+    status: "none",
+    threshold: 5,
+    hardFailures: 3,
+    attributableFailures: 0,
+    removed: [],
+    skipped: [],
+    exempt: [collateral("a"), collateral("b"), collateral("c")],
+    backendWedged: "true",
+  });
+
+  assert.match(md, /3 hard failure\(s\) are NOT attributable/);
+  assert.match(md, /all 3 hard failure\(s\) were non-attributable/);
+  // The pre-#1031 wording alone would have read as "nothing to see here".
+  assert.doesNotMatch(md, /^No per-test `@stable` hard failures were auto-removed\./m);
+  assert.match(md, /Do not open a per-spec issue for these/);
+  assert.match(md, /measured a mid-run outage/);
+});
+
+test("collateral is rendered BEFORE the removals, and the two never merge", () => {
+  const md = render({
+    status: "removed",
+    threshold: 5,
+    hardFailures: 2,
+    attributableFailures: 1,
+    removed: [{ file: "tests/x/broken.spec.ts", title: "broken", line: 9, soleTag: false }],
+    skipped: [],
+    exempt: [collateral("wedged")],
+    backendWedged: "true",
+  });
+
+  assert.ok(md.indexOf("NOT attributable") < md.indexOf("Auto-removed"), md);
+  assert.match(md, /Auto-removed `@stable`\*\* from 1 hard-failing test\(s\)/);
+  assert.match(md, /- `tests\/x\/wedged\.spec\.ts` — wedged _\(api-request-timeout/);
+  assert.match(md, /- `tests\/x\/broken\.spec\.ts` — broken/);
+});
+
+test("the liveness verdict only changes the wording, never the claim", () => {
+  const base = {
+    status: "none",
+    threshold: 5,
+    hardFailures: 1,
+    attributableFailures: 0,
+    removed: [],
+    skipped: [],
+    exempt: [collateral("a")],
+  };
+
+  assert.match(render({ ...base, backendWedged: "false" }), /measured \*\*no\*\* outage/);
+  assert.match(render({ ...base, backendWedged: "" }), /not measured/);
+  // Whatever the verdict, the exemption itself is stated the same way.
+  for (const backendWedged of ["true", "false", ""]) {
+    assert.match(render({ ...base, backendWedged }), /`@stable` was \*\*left in place\*\*/);
+  }
+});
+
+test("a guard-tripped run still names its collateral and explains the count", () => {
+  // The early return in the script must not cost the labelling: the wide wedge
+  // is precisely the run whose issue body has to lead with the cause.
+  const md = render({
+    status: "guard_tripped",
+    threshold: 5,
+    hardFailures: 19,
+    attributableFailures: 5,
+    removed: [],
+    skipped: [],
+    exempt: Array.from({ length: 14 }, (_, i) => collateral(`c${i}`)),
+    backendWedged: "true",
+  });
+
+  assert.match(md, /14 hard failure\(s\) are NOT attributable/);
+  assert.match(md, /Mass-failure guard tripped/);
+  assert.match(md, /counts \*\*every\*\* hard failure, collateral included \(14 of 19/);
+  assert.match(md, /the 5 attributable/);
+});
+
+test("a run with no collateral renders exactly the pre-#1031 block", () => {
+  const md = render({
+    status: "removed",
+    threshold: 5,
+    hardFailures: 1,
+    attributableFailures: 1,
+    removed: [{ file: "tests/x/broken.spec.ts", title: "broken", line: 9, soleTag: true }],
+    skipped: [],
+    exempt: [],
+    backendWedged: "false",
+  });
+
+  assert.doesNotMatch(md, /NOT attributable/);
+  assert.match(md, /^🔻 \*\*Auto-removed/);
+  assert.match(md, /the array was left empty, please review/);
+});
+
+test("output produced before #1031 still renders", () => {
+  // The action writes and reads the JSON within one job, so this is only a
+  // replay concern — but a formatter that throws on an older artifact would
+  // take the umbrella issue's whole `@stable` section with it.
+  const md = render({
+    status: "guard_tripped",
+    threshold: 5,
+    hardFailures: 6,
+    removed: [],
+    skipped: [{ file: "tests/x/ghost.spec.ts", title: "t1", line: 4, reason: "spec file not found" }],
+  });
+
+  assert.match(md, /Mass-failure guard tripped/);
+  assert.doesNotMatch(md, /NOT attributable/);
+  assert.match(md, /Skipped 1/);
+});

--- a/scripts/lib/infra-signatures.ts
+++ b/scripts/lib/infra-signatures.ts
@@ -1,0 +1,117 @@
+/**
+ * Which failure errors are NOT attributable to the spec that reported them.
+ *
+ * When the backend dies mid-run (#1030/#1048), every test that touches it fails
+ * with a transport-level error and the report blames the specs that happened to
+ * be running. On run 30374528125, 14 of 19 hard failures described one wedged
+ * backend, not 14 broken specs. Those failures must never reach the `@stable`
+ * auto-removal path (`scripts/remove-stable-from-failures.ts`), which edits spec
+ * files and commits them to `main` with no human review.
+ *
+ * WHY THE LIST IS DELIBERATELY NARROW
+ *
+ * The mass-failure guard already covers the WIDE wedge (>5 hard failures =>
+ * remove nothing). The hole #1031 closes is the NARROW one: a wedge that costs
+ * ≤5 tests silently strips their tags. Closing it means turning off auto-removal
+ * for whatever matches here — so a pattern that also fires on a real product
+ * regression would quietly disable the mechanism instead of protecting it.
+ *
+ * The bar for inclusion is therefore: **the error cannot be a product assertion
+ * under any reading**. It is the harness failing to reach or talk to the
+ * backend, full stop. Concretely:
+ *
+ *  - `apiRequestContext.*: Timeout` — a direct REST call to Langflow that never
+ *    answered. Backend down or backend stalled; both are infra. (14 occurrences
+ *    in `reports/daily-history.jsonl` at the time of writing.)
+ *  - `[preflight] … is not reachable` — the globalSetup health check (#1012).
+ *  - socket/DNS level errors — `ECONNREFUSED`, `ECONNRESET`, `socket hang up`,
+ *    `EAI_AGAIN`, `net::ERR_CONNECTION_*`, `net::ERR_EMPTY_RESPONSE`.
+ *
+ * Explicitly EXCLUDED, though they dominate a wedged run's report:
+ *
+ *  - `locator.click: Timeout`, `page.waitForSelector: Timeout`,
+ *    `expect(locator).toBeVisible() failed` — a wedge produces these, but so
+ *    does a genuine UI regression, and they are the three most common failure
+ *    signatures in the whole history file. Exempting them would mean the daily
+ *    stops quarantining almost anything.
+ *
+ * The consequence is accepted and asymmetric on purpose: a false negative (a
+ * genuinely broken spec keeps `@stable` for one more day) costs one extra red
+ * daily; a false positive costs a human-gated restoration PR for an innocent
+ * spec. The narrow list errs toward the cheaper mistake.
+ *
+ * This module is pure and dependency-free so both the auto-removal script and
+ * its unit tests can import it without touching disk.
+ */
+
+export interface InfraSignature {
+  /** Stable id, rendered in the issue body and asserted by the unit tests. */
+  id: string;
+  /** One-line reason this error cannot be the spec's own fault. */
+  why: string;
+  pattern: RegExp;
+}
+
+/**
+ * Ordered most-specific first — `classifyInfraError` returns the first match,
+ * and the id it returns is what triage reads.
+ */
+export const INFRA_SIGNATURES: InfraSignature[] = [
+  {
+    id: "preflight-unreachable",
+    why: "the globalSetup health check could not reach Langflow at all",
+    pattern: /\[preflight\][^\n]*is not reachable/i,
+  },
+  {
+    id: "api-request-timeout",
+    why: "a direct REST call to the backend never answered",
+    pattern: /\bapiRequestContext\.\w+:\s*Timeout\b/,
+  },
+  {
+    id: "connection-refused",
+    why: "the backend refused the TCP connection",
+    pattern: /\bECONNREFUSED\b|net::ERR_CONNECTION_REFUSED/,
+  },
+  {
+    id: "connection-dropped",
+    why: "the connection to the backend was dropped mid-request",
+    pattern:
+      /\bECONNRESET\b|socket hang up|net::ERR_CONNECTION_(RESET|CLOSED|ABORTED)|net::ERR_EMPTY_RESPONSE/i,
+  },
+  {
+    id: "host-unresolvable",
+    why: "the backend host could not be resolved",
+    pattern: /\bEAI_AGAIN\b|\bENOTFOUND\b|net::ERR_NAME_NOT_RESOLVED/,
+  },
+];
+
+/**
+ * Playwright colourises error messages; the patterns above match plain text.
+ *
+ * Two forms are stripped, not one: the proper \u001b[…m sequence, and a bare
+ * […m whose escape was already lost. The second is not hypothetical — the
+ * signatures stored in reports/daily-history.jsonl read `Error: [2mexpect([22m…`,
+ * so the escape does go missing somewhere between the reporter and the artifact.
+ * The bare form requires a digit so it cannot eat real text like `[preflight]`.
+ */
+export function stripAnsi(text: string): string {
+  return String(text || "")
+    // eslint-disable-next-line no-control-regex
+    .replace(/\u001b\[[0-9;]*m/g, "")
+    .replace(/\[[0-9;]+m/g, "");
+}
+
+/**
+ * The infra signature carried by `error`, or `null` when the error is (or could
+ * be) the spec's own. Matches anywhere in the message, not just the first line:
+ * a wedge often surfaces as an assertion whose *cause* line is the transport
+ * error, and the first line alone would miss it.
+ */
+export function classifyInfraError(error: string | null | undefined): InfraSignature | null {
+  const text = stripAnsi(error ?? "");
+  if (!text.trim()) return null;
+  for (const signature of INFRA_SIGNATURES) {
+    if (signature.pattern.test(text)) return signature;
+  }
+  return null;
+}

--- a/scripts/remove-stable-from-failures.test.ts
+++ b/scripts/remove-stable-from-failures.test.ts
@@ -75,7 +75,14 @@ function specSource(titles: string[]): string {
  */
 function runScript(opts: {
   specs: Record<string, string[]>;
-  failures?: Array<{ file: string; title: string; status?: string; error?: string }>;
+  failures?: Array<{
+    file: string;
+    title: string;
+    status?: string;
+    error?: string;
+    /** Raw `tests[].results` override, for shapes `error` alone cannot express. */
+    results?: unknown[];
+  }>;
   maxAutoRemove?: string;
   reportPath?: string;
   reportBody?: string;
@@ -106,7 +113,11 @@ function runScript(opts: {
                 status: f.status ?? "unexpected",
                 // The retry shape Playwright actually emits, so the exemption is
                 // exercised through `results[].error`, not a shortcut field.
-                ...(f.error ? { results: [{ status: "failed", error: { message: f.error } }] } : {}),
+                ...(f.results
+                  ? { results: f.results }
+                  : f.error
+                    ? { results: [{ status: "failed", error: { message: f.error } }] }
+                    : {}),
               },
             ],
           },
@@ -357,6 +368,91 @@ test("the signature is matched anywhere in the error, not only on line one", () 
   assert.equal(result.exempt[0].signature, "connection-refused");
 });
 
+test("a transport cause DEEP in the message still exempts — truncation is display-only", () => {
+  // The regression this pins: the error was cut to ERROR_MAX chars BEFORE being
+  // classified, so an assertion header plus a Playwright call log pushed the
+  // `Cause:` line out of range and the innocent spec lost its tag anyway — the
+  // exact harm #1031 exists to prevent.
+  const deepCause =
+    "Error: expect(received).toBeVisible() failed\n\n" +
+    "Locator: getByTestId('chat-message-ai-response')\nExpected: visible\n" +
+    "Received: <element(s) not found>\nTimeout: 30000ms\n\nCall log:\n" +
+    Array.from(
+      { length: 6 },
+      (_, i) => `  - waiting for getByTestId('chat-message-ai-response') attempt ${i}`,
+    ).join("\n") +
+    "\nCause: connect ECONNREFUSED 127.0.0.1:7860";
+  assert.ok(
+    deepCause.indexOf("ECONNREFUSED") > 240,
+    "fixture must push the cause past the display limit to be meaningful",
+  );
+
+  const titles = ["t1"];
+  const before = specSource(titles);
+  const { result, after } = runScript({
+    specs: { "fixture-1031-a.spec.ts": titles },
+    failures: [{ file: "fixture-1031-a.spec.ts", title: "t1", error: deepCause }],
+  });
+
+  assert.equal(result.exempt.length, 1);
+  assert.equal(result.exempt[0].signature, "connection-refused");
+  assert.equal(after["fixture-1031-a.spec.ts"], before);
+  // The issue body still carries a bounded excerpt, not the whole call log.
+  assert.ok(result.exempt[0].error.length <= 241, String(result.exempt[0].error.length));
+  assert.match(result.exempt[0].error, /…$/);
+});
+
+test("the transport error is found past errors[0] — the timedOut wrapper shape", () => {
+  // A test that times out while an API call hangs: Playwright puts the timeout
+  // wrapper in `error` and the pending call in a later `errors[]` entry. Reading
+  // only `error`/`errors[0]` would classify this as attributable.
+  const { result } = runScript({
+    specs: { "fixture-1031-a.spec.ts": ["t1"] },
+    failures: [
+      {
+        file: "fixture-1031-a.spec.ts",
+        title: "t1",
+        results: [
+          {
+            status: "timedOut",
+            error: { message: "Test timeout of 300000ms exceeded." },
+            errors: [
+              { message: "Test timeout of 300000ms exceeded." },
+              { message: INFRA_ERROR },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.equal(result.exempt.length, 1);
+  assert.equal(result.exempt[0].signature, "api-request-timeout");
+});
+
+test("a wide wedge with NO attributable failure still reports guard_tripped", () => {
+  // `status` has to keep meaning "would the guard have tripped". The triage
+  // skill's own detectGuard recomputes the guard from totals.failed, so an
+  // all-collateral mass-failure day reported as "none" would contradict it.
+  const titles = ["t1", "t2", "t3", "t4", "t5", "t6"];
+  const before = specSource(titles);
+  const { result, after } = runScript({
+    specs: { "fixture-1031-a.spec.ts": titles },
+    failures: titles.map((title) => ({
+      file: "fixture-1031-a.spec.ts",
+      title,
+      error: INFRA_ERROR,
+    })),
+    maxAutoRemove: "5",
+  });
+
+  assert.equal(result.status, "guard_tripped");
+  assert.equal(result.hardFailures, 6);
+  assert.equal(result.attributableFailures, 0);
+  assert.equal(result.exempt.length, 6);
+  assert.equal(after["fixture-1031-a.spec.ts"], before);
+});
+
 test("classifyInfraError covers the transport signatures and rejects product ones", () => {
   const infra: Array<[string, string]> = [
     ["TimeoutError: apiRequestContext.get: Timeout 20000ms exceeded.", "api-request-timeout"],
@@ -413,6 +509,28 @@ test("lastFailureError reads the LAST failed attempt, ANSI stripped", () => {
     INFRA_ERROR,
   );
   assert.equal(lastFailureError({}), "");
+
+  // Every error of the attempt is kept, and the `error === errors[0]` duplication
+  // Playwright normally emits is collapsed rather than repeated.
+  assert.equal(
+    lastFailureError({
+      results: [
+        {
+          status: "timedOut",
+          error: { message: PRODUCT_ERROR },
+          errors: [{ message: PRODUCT_ERROR }, { message: INFRA_ERROR }],
+        },
+      ],
+    }),
+    `${PRODUCT_ERROR}\n${INFRA_ERROR}`,
+  );
+
+  // No truncation here — the classifier needs the full text (#1031 review).
+  const long = `${"x".repeat(400)} ECONNREFUSED`;
+  assert.equal(
+    lastFailureError({ results: [{ status: "failed", error: { message: long } }] }),
+    long,
+  );
 });
 
 // ─── Nothing to do ───────────────────────────────────────────────────────────

--- a/scripts/remove-stable-from-failures.test.ts
+++ b/scripts/remove-stable-from-failures.test.ts
@@ -25,7 +25,8 @@ import { execFileSync } from "child_process";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { collectHardFailures } from "./remove-stable-from-failures";
+import { collectHardFailures, lastFailureError } from "./remove-stable-from-failures";
+import { classifyInfraError } from "./lib/infra-signatures";
 
 const SCRIPT = path.join(__dirname, "remove-stable-from-failures.ts");
 
@@ -33,9 +34,23 @@ interface Result {
   status: "removed" | "none" | "guard_tripped";
   threshold: number;
   hardFailures: number;
+  attributableFailures: number;
   removed: Array<{ file: string; title: string; line: number; soleTag: boolean }>;
   skipped: Array<{ file: string; title: string; line: number; reason: string }>;
+  exempt: Array<{
+    file: string;
+    title: string;
+    line: number;
+    signature: string;
+    why: string;
+    error: string;
+  }>;
+  backendWedged: string;
 }
+
+/** Real signatures, copied from `reports/daily-history.jsonl`. */
+const INFRA_ERROR = "TimeoutError: apiRequestContext.get: Timeout 20000ms exceeded.";
+const PRODUCT_ERROR = "TimeoutError: locator.click: Timeout 20000ms exceeded.";
 
 /** A minimal spec carrying one `@stable` test per title, plus decoy prose. */
 function specSource(titles: string[]): string {
@@ -60,10 +75,12 @@ function specSource(titles: string[]): string {
  */
 function runScript(opts: {
   specs: Record<string, string[]>;
-  failures?: Array<{ file: string; title: string; status?: string }>;
+  failures?: Array<{ file: string; title: string; status?: string; error?: string }>;
   maxAutoRemove?: string;
   reportPath?: string;
   reportBody?: string;
+  /** The #1030 liveness verdict the action forwards; "" when unmeasured. */
+  backendWedged?: string;
 }): { result: Result; after: Record<string, string> } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "autoremove-"));
   try {
@@ -84,7 +101,14 @@ function runScript(opts: {
             title: f.title,
             file: f.file,
             line: 4 + i,
-            tests: [{ status: f.status ?? "unexpected" }],
+            tests: [
+              {
+                status: f.status ?? "unexpected",
+                // The retry shape Playwright actually emits, so the exemption is
+                // exercised through `results[].error`, not a shortcut field.
+                ...(f.error ? { results: [{ status: "failed", error: { message: f.error } }] } : {}),
+              },
+            ],
           },
         ],
       })),
@@ -106,6 +130,7 @@ function runScript(opts: {
           ...process.env,
           PLAYWRIGHT_JSON: reportPath,
           MAX_AUTO_REMOVE: opts.maxAutoRemove ?? "5",
+          BACKEND_WEDGED: opts.backendWedged ?? "",
         },
         stdio: ["ignore", "pipe", "pipe"],
       },
@@ -192,6 +217,202 @@ test("guard counts failures ACROSS files, not per file", () => {
   for (const file of ["fixture-1017-a.spec.ts", "fixture-1017-b.spec.ts", "fixture-1017-c.spec.ts"]) {
     assert.equal(after[file], before);
   }
+});
+
+// ─── The infra-signature exemption (#1031) ───────────────────────────────────
+//
+// The mass-failure guard above only covers the WIDE wedge. The hole these cases
+// close is the NARROW one: on run 30374528125 the backend wedged and 14 of 19
+// hard failures described that one backend — we escaped by luck, because 19 > 5
+// tripped the guard. A wedge costing FIVE tests would have stripped five
+// innocent tags in an unreviewed commit to `main`.
+
+test("a narrow wedge (at the threshold) exempts every collateral spec and rewrites NOTHING", () => {
+  const titles = ["t1", "t2", "t3", "t4", "t5"];
+  const before = specSource(titles);
+  const { result, after } = runScript({
+    specs: { "fixture-1031-a.spec.ts": titles },
+    failures: titles.map((title) => ({ file: "fixture-1031-a.spec.ts", title, error: INFRA_ERROR })),
+    maxAutoRemove: "5",
+  });
+
+  // Pre-#1031 this exact report returned "removed" with five removals.
+  assert.equal(result.status, "none");
+  assert.equal(result.hardFailures, 5);
+  assert.equal(result.attributableFailures, 0);
+  assert.equal(result.removed.length, 0);
+  assert.equal(result.exempt.length, 5);
+  assert.deepEqual([...new Set(result.exempt.map((e) => e.signature))], ["api-request-timeout"]);
+  assert.equal(after["fixture-1031-a.spec.ts"], before);
+});
+
+test("collateral is exempted while the attributable failure in the same run is still removed", () => {
+  // The mixed shape of a real wedged day. The exemption must not become a blanket
+  // amnesty: a spec that failed on its own error still loses the tag.
+  const { result, after } = runScript({
+    specs: { "fixture-1031-a.spec.ts": ["wedged", "broken"] },
+    failures: [
+      { file: "fixture-1031-a.spec.ts", title: "wedged", error: INFRA_ERROR },
+      { file: "fixture-1031-a.spec.ts", title: "broken", error: PRODUCT_ERROR },
+    ],
+    maxAutoRemove: "5",
+  });
+
+  assert.equal(result.status, "removed");
+  assert.equal(result.hardFailures, 2);
+  assert.equal(result.attributableFailures, 1);
+  assert.deepEqual(result.removed.map((r) => r.title), ["broken"]);
+  assert.deepEqual(result.exempt.map((e) => e.title), ["wedged"]);
+  const after1 = after["fixture-1031-a.spec.ts"];
+  assert.match(after1, /test\("wedged", \{ tag: \["@stable", "@regression"\] \}/);
+  assert.match(after1, /test\("broken", \{ tag: \["@regression"\] \}/);
+});
+
+test("an ambiguous error does NOT exempt — the list must stay narrow", () => {
+  // `locator.click: Timeout` is the single most common signature in
+  // reports/daily-history.jsonl and a wedge produces plenty of it. Exempting it
+  // would switch auto-removal off for most genuine regressions too.
+  const { result, after } = runScript({
+    specs: { "fixture-1031-a.spec.ts": ["t1"] },
+    failures: [{ file: "fixture-1031-a.spec.ts", title: "t1", error: PRODUCT_ERROR }],
+  });
+
+  assert.equal(result.status, "removed");
+  assert.deepEqual(result.exempt, []);
+  // Quoted: `specSource` also plants the tag in prose, which must survive.
+  assert.equal(after["fixture-1031-a.spec.ts"].includes('"@stable"'), false);
+});
+
+test("a failure with NO error at all is treated as attributable, not exempt", () => {
+  // Fail-closed in the direction that keeps the mechanism working: an absent
+  // error is not evidence of a wedge. (`error_signature: "unknown"` appears 13
+  // times in the history file.)
+  const { result } = runScript({
+    specs: { "fixture-1031-a.spec.ts": ["t1"] },
+    failures: [{ file: "fixture-1031-a.spec.ts", title: "t1" }],
+  });
+
+  assert.equal(result.status, "removed");
+  assert.equal(result.attributableFailures, 1);
+  assert.deepEqual(result.exempt, []);
+});
+
+test("the guard still counts collateral — and still labels it", () => {
+  // Deliberate: netting the exempt failures out of the count would make the
+  // guard fire LESS often than before #1031 and remove tags a pre-#1031 run
+  // would have left alone. The removal set stays a subset. The labelling,
+  // though, has to survive the early return — the wide wedge is the run that
+  // most needs the issue body to name the cause.
+  const titles = ["t1", "t2", "t3", "t4", "t5", "t6"];
+  const before = specSource(titles);
+  const { result, after } = runScript({
+    specs: { "fixture-1031-a.spec.ts": titles },
+    failures: titles.map((title, i) => ({
+      file: "fixture-1031-a.spec.ts",
+      title,
+      error: i < 4 ? INFRA_ERROR : PRODUCT_ERROR,
+    })),
+    maxAutoRemove: "5",
+  });
+
+  assert.equal(result.status, "guard_tripped");
+  assert.equal(result.hardFailures, 6);
+  assert.equal(result.attributableFailures, 2);
+  assert.equal(result.exempt.length, 4);
+  assert.equal(after["fixture-1031-a.spec.ts"], before);
+});
+
+test("the exemption does not depend on the liveness verdict", () => {
+  // BACKEND_WEDGED is wording only. It has to be, or the exemption would fold
+  // on exactly the run where the recorder produced nothing — the run whose
+  // backend state is least known.
+  for (const backendWedged of ["", "false", "true"]) {
+    const { result } = runScript({
+      specs: { "fixture-1031-a.spec.ts": ["t1"] },
+      failures: [{ file: "fixture-1031-a.spec.ts", title: "t1", error: INFRA_ERROR }],
+      backendWedged,
+    });
+    assert.equal(result.exempt.length, 1, `wedged=${JSON.stringify(backendWedged)}`);
+    assert.equal(result.backendWedged, backendWedged);
+    assert.equal(result.removed.length, 0);
+  }
+});
+
+test("the signature is matched anywhere in the error, not only on line one", () => {
+  // A wedge frequently surfaces as an assertion header whose CAUSE line is the
+  // transport error. Matching the first line only (what build-run-payload.mjs
+  // stores as `error_signature`) would miss it.
+  const { result } = runScript({
+    specs: { "fixture-1031-a.spec.ts": ["t1"] },
+    failures: [
+      {
+        file: "fixture-1031-a.spec.ts",
+        title: "t1",
+        error: "Error: flow build failed\nCause: connect ECONNREFUSED 127.0.0.1:7860",
+      },
+    ],
+  });
+
+  assert.equal(result.exempt.length, 1);
+  assert.equal(result.exempt[0].signature, "connection-refused");
+});
+
+test("classifyInfraError covers the transport signatures and rejects product ones", () => {
+  const infra: Array<[string, string]> = [
+    ["TimeoutError: apiRequestContext.get: Timeout 20000ms exceeded.", "api-request-timeout"],
+    ["TimeoutError: apiRequestContext.post: Timeout 30000ms exceeded.", "api-request-timeout"],
+    [
+      "Error: [preflight] Langflow backend at http://localhost:7860/ is not reachable after 120000ms",
+      "preflight-unreachable",
+    ],
+    ["Error: connect ECONNREFUSED 127.0.0.1:7860", "connection-refused"],
+    ["Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:7860/", "connection-refused"],
+    ["Error: socket hang up", "connection-dropped"],
+    ["Error: read ECONNRESET", "connection-dropped"],
+    ["Error: getaddrinfo EAI_AGAIN localhost", "host-unresolvable"],
+  ];
+  for (const [error, id] of infra) {
+    assert.equal(classifyInfraError(error)?.id, id, error);
+  }
+
+  const product = [
+    "TimeoutError: locator.click: Timeout 20000ms exceeded.",
+    "TimeoutError: page.waitForSelector: Timeout 30000ms exceeded.",
+    "Error: expect(locator).toBeVisible() failed",
+    "Error: Playground must show a 'Called tool' indicator",
+    "",
+    null,
+    undefined,
+  ];
+  for (const error of product) {
+    assert.equal(classifyInfraError(error), null, String(error));
+  }
+});
+
+test("lastFailureError reads the LAST failed attempt, ANSI stripped", () => {
+  // Retries are what a wedge burns; the final attempt is the one that decided
+  // the verdict, so a first-attempt product error must not mask a wedge (or the
+  // other way round).
+  const test0 = {
+    results: [
+      { status: "failed", error: { message: PRODUCT_ERROR } },
+      { status: "failed", error: { message: INFRA_ERROR } },
+    ],
+  };
+  assert.equal(lastFailureError(test0), INFRA_ERROR);
+
+  // The escape-stripped form the history file actually carries.
+  assert.equal(
+    lastFailureError({ results: [{ status: "failed", error: { message: "Error: [2mexpect([22mx)" } }] }),
+    "Error: expect(x)",
+  );
+
+  // `errors[]` instead of `error`, and the no-result case.
+  assert.equal(
+    lastFailureError({ results: [{ status: "failed", errors: [{ message: INFRA_ERROR }] }] }),
+    INFRA_ERROR,
+  );
+  assert.equal(lastFailureError({}), "");
 });
 
 // ─── Nothing to do ───────────────────────────────────────────────────────────

--- a/scripts/remove-stable-from-failures.ts
+++ b/scripts/remove-stable-from-failures.ts
@@ -55,7 +55,10 @@ interface Failure {
   title: string;
   file: string; // absolute path
   line: number; // 1-based test() line, as Playwright reports it
-  /** Last failed attempt's error, ANSI-stripped and truncated; "" if none. */
+  /**
+   * Last failed attempt's error, ANSI-stripped and UNtruncated; "" if none.
+   * Full text on purpose — it is what the infra-signature classifier reads.
+   */
   error: string;
 }
 
@@ -113,6 +116,27 @@ function candidateBases(report: any): string[] {
 const ERROR_MAX = 240;
 
 /**
+ * Shorten an error for the result JSON / issue body.
+ *
+ * DISPLAY ONLY. Classification always runs on the untruncated text: a wedge
+ * frequently surfaces as an assertion header whose `Cause:` line — the transport
+ * error — sits hundreds of characters in, under a Playwright call log. Truncating
+ * before `classifyInfraError` would silently un-exempt exactly those, which is
+ * the harm #1031 exists to prevent.
+ */
+export function truncateError(error: string): string {
+  return error.length > ERROR_MAX ? `${error.slice(0, ERROR_MAX)}…` : error;
+}
+
+/** One error object flattened to text: message (or thrown value) plus its stack. */
+function errorText(e: any): string {
+  const message = stripAnsi(e?.message || e?.value || "");
+  const stack = stripAnsi(e?.stack || "");
+  if (stack && !message.includes(stack)) return message ? `${message}\n${stack}` : stack;
+  return message || stack;
+}
+
+/**
  * The error of the LAST failed attempt — the same result `build-run-payload.mjs`
  * picks for `error_signature`, so the exemption and the history file talk about
  * the same attempt. Last, not first: retries are what a wedge burns, and the
@@ -121,18 +145,33 @@ const ERROR_MAX = 240;
  * Unlike `firstErr` there, this keeps the whole message (plus the stack) rather
  * than its first line — a transport error is often the *cause* line under an
  * assertion header, and truncating to line one would hide it.
+ *
+ * It also keeps EVERY error of that attempt, not just the first. A `timedOut`
+ * result carries the `Test timeout of Xms exceeded` wrapper in `error` and the
+ * pending call — the transport error itself — in a later `errors[]` entry, which
+ * is precisely the shape "the test timed out while an API call hung".
  */
 export function lastFailureError(test: any): string {
   const results: any[] = Array.isArray(test?.results) ? test.results : [];
   const lastFailed =
     [...results].reverse().find((r) => r?.status !== "passed" && r?.status !== "skipped") ??
     results[results.length - 1];
-  const e = lastFailed?.error || lastFailed?.errors?.[0];
-  if (!e) return "";
-  const message = stripAnsi(e.message || e.value || "");
-  const stack = stripAnsi(e.stack || "");
-  const combined = stack && !message.includes(stack) ? `${message}\n${stack}` : message || stack;
-  return combined.slice(0, ERROR_MAX);
+  if (!lastFailed) return "";
+  const candidates = [
+    lastFailed.error,
+    ...(Array.isArray(lastFailed.errors) ? lastFailed.errors : []),
+  ];
+  // Playwright usually sets `error` to `errors[0]`, so dedup by text.
+  const seen = new Set<string>();
+  const parts: string[] = [];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const text = errorText(candidate);
+    if (!text || seen.has(text)) continue;
+    seen.add(text);
+    parts.push(text);
+  }
+  return parts.join("\n");
 }
 
 export function collectHardFailures(reportFile: string): Failure[] {
@@ -294,7 +333,7 @@ function main(): void {
       line: f.line,
       signature: signature.id,
       why: signature.why,
-      error: f.error,
+      error: truncateError(f.error),
     });
   }
 
@@ -321,11 +360,6 @@ function main(): void {
     backendWedged: BACKEND_WEDGED,
   };
 
-  if (failures.length === 0) {
-    process.stdout.write(JSON.stringify(result));
-    return;
-  }
-
   // Mass-failure guard: too many hard failures => treat as infra, remove nothing.
   //
   // Counts EVERY hard failure, not just the attributable ones. Netting the
@@ -335,8 +369,19 @@ function main(): void {
   // remove 5 tags with no review. #1031 asks to protect innocent specs, not to
   // widen auto-removal's reach — so the removal set here is always a subset of
   // what the pre-#1031 script would have produced.
+  //
+  // Evaluated BEFORE the "nothing attributable" exit so `status` keeps meaning
+  // "would the guard have tripped": a wide wedge whose every failure is
+  // collateral is still a mass-failure day, and the triage skill's own
+  // `detectGuard` (which recomputes from `totals.failed`) would otherwise
+  // disagree with this field.
   if (allFailures.length > MAX_AUTO_REMOVE) {
     result.status = "guard_tripped";
+    process.stdout.write(JSON.stringify(result));
+    return;
+  }
+
+  if (failures.length === 0) {
     process.stdout.write(JSON.stringify(result));
     return;
   }

--- a/scripts/remove-stable-from-failures.ts
+++ b/scripts/remove-stable-from-failures.ts
@@ -16,6 +16,12 @@
  *    removed. A red day where everything fails is almost always infra (Langflow
  *    container didn't boot, network/model outage), not per-test rot, and must
  *    not quarantine the whole stable suite.
+ *  - Infra-signature exemption (#1031): a hard failure whose last error is a
+ *    transport-level error (see `scripts/lib/infra-signatures.ts`) is NOT
+ *    attributable to the spec that reported it — it is collateral of a wedged
+ *    backend (#1030/#1048). It is excluded from removal INDEPENDENTLY of the
+ *    mass-failure guard, which only covers the wide wedge; the narrow one (a
+ *    wedge costing ≤ MAX_AUTO_REMOVE tests) used to strip innocent tags.
  *
  * Editing is AST-located + text-spliced: the TypeScript compiler API finds the
  * exact `"@stable"` element inside the `test(...)` `{ tag: [...] }` array, and
@@ -29,17 +35,28 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as ts from "typescript";
+import { classifyInfraError, stripAnsi } from "./lib/infra-signatures";
 
 const REPO_ROOT = path.resolve(__dirname, "..");
 const STABLE_TAG = "@stable";
 
 const reportPath = process.env.PLAYWRIGHT_JSON || "results.json";
 const MAX_AUTO_REMOVE = Number.parseInt(process.env.MAX_AUTO_REMOVE || "5", 10);
+/**
+ * Corroboration only, from `report-backend-outages.mjs`'s `wedged` output
+ * (#1030): "true" | "false" | "" (unmeasured / step skipped). It changes the
+ * WORDING of the exemption, never the decision — the exemption has to hold when
+ * the liveness recorder produced nothing, which is exactly the run where the
+ * backend state is least known.
+ */
+const BACKEND_WEDGED = process.env.BACKEND_WEDGED || "";
 
 interface Failure {
   title: string;
   file: string; // absolute path
   line: number; // 1-based test() line, as Playwright reports it
+  /** Last failed attempt's error, ANSI-stripped and truncated; "" if none. */
+  error: string;
 }
 
 interface Removed {
@@ -54,6 +71,19 @@ interface Skipped {
   title: string;
   line: number;
   reason: string;
+}
+
+/** A hard failure the run cannot attribute to its spec (#1031). */
+interface Exempt {
+  file: string; // repo-relative
+  title: string;
+  line: number;
+  /** `InfraSignature.id` that matched, e.g. `api-request-timeout`. */
+  signature: string;
+  /** Why that signature cannot be the spec's own fault. */
+  why: string;
+  /** The matched error text, truncated for the issue body. */
+  error: string;
 }
 
 // ─── Parse hard failures out of the Playwright JSON report ───────────────────
@@ -77,6 +107,32 @@ function candidateBases(report: any): string[] {
   bases.push(path.join(REPO_ROOT, "tests"));
   bases.push(REPO_ROOT);
   return bases;
+}
+
+/** Max error characters carried into the result JSON / issue body. */
+const ERROR_MAX = 240;
+
+/**
+ * The error of the LAST failed attempt — the same result `build-run-payload.mjs`
+ * picks for `error_signature`, so the exemption and the history file talk about
+ * the same attempt. Last, not first: retries are what a wedge burns, and the
+ * final attempt is the one that decided the verdict.
+ *
+ * Unlike `firstErr` there, this keeps the whole message (plus the stack) rather
+ * than its first line — a transport error is often the *cause* line under an
+ * assertion header, and truncating to line one would hide it.
+ */
+export function lastFailureError(test: any): string {
+  const results: any[] = Array.isArray(test?.results) ? test.results : [];
+  const lastFailed =
+    [...results].reverse().find((r) => r?.status !== "passed" && r?.status !== "skipped") ??
+    results[results.length - 1];
+  const e = lastFailed?.error || lastFailed?.errors?.[0];
+  if (!e) return "";
+  const message = stripAnsi(e.message || e.value || "");
+  const stack = stripAnsi(e.stack || "");
+  const combined = stack && !message.includes(stack) ? `${message}\n${stack}` : message || stack;
+  return combined.slice(0, ERROR_MAX);
 }
 
 export function collectHardFailures(reportFile: string): Failure[] {
@@ -107,7 +163,7 @@ export function collectHardFailures(reportFile: string): Failure[] {
       const line = spec?.line || spec?.location?.line || 0;
       for (const t of spec.tests || []) {
         if (t.status === "unexpected") {
-          failures.push({ title: spec.title, file, line });
+          failures.push({ title: spec.title, file, line, error: lastFailureError(t) });
         }
       }
     }
@@ -219,20 +275,50 @@ function spliceRange(
 // ─── Main ────────────────────────────────────────────────────────────────────
 
 function main(): void {
-  const failures = collectHardFailures(reportPath);
+  const allFailures = collectHardFailures(reportPath);
+
+  // Partition BEFORE the guard, and report both sides in every branch (#1031).
+  // Doing it after would lose the collateral labelling on precisely the run that
+  // motivated this — the wide wedge, where the guard returns early.
+  const failures: Failure[] = [];
+  const exempt: Exempt[] = [];
+  for (const f of allFailures) {
+    const signature = classifyInfraError(f.error);
+    if (!signature) {
+      failures.push(f);
+      continue;
+    }
+    exempt.push({
+      file: path.relative(REPO_ROOT, f.file),
+      title: f.title,
+      line: f.line,
+      signature: signature.id,
+      why: signature.why,
+      error: f.error,
+    });
+  }
 
   const result: {
     status: "removed" | "none" | "guard_tripped";
     threshold: number;
+    /** Every hard failure in the report, exempt ones included. */
     hardFailures: number;
+    /** Hard failures the run CAN attribute to their spec — the removal candidates. */
+    attributableFailures: number;
     removed: Removed[];
     skipped: Skipped[];
+    exempt: Exempt[];
+    /** "true" | "false" | "" — the #1030 liveness verdict, for wording only. */
+    backendWedged: string;
   } = {
     status: "none",
     threshold: MAX_AUTO_REMOVE,
-    hardFailures: failures.length,
+    hardFailures: allFailures.length,
+    attributableFailures: failures.length,
     removed: [],
     skipped: [],
+    exempt,
+    backendWedged: BACKEND_WEDGED,
   };
 
   if (failures.length === 0) {
@@ -241,7 +327,15 @@ function main(): void {
   }
 
   // Mass-failure guard: too many hard failures => treat as infra, remove nothing.
-  if (failures.length > MAX_AUTO_REMOVE) {
+  //
+  // Counts EVERY hard failure, not just the attributable ones. Netting the
+  // exempt ones out would make the mechanism strictly more aggressive than it
+  // is today: on run 30374528125 (19 failures, 14 with an infra signature) the
+  // guard trips and removes nothing, while an attributable-only count would
+  // remove 5 tags with no review. #1031 asks to protect innocent specs, not to
+  // widen auto-removal's reach — so the removal set here is always a subset of
+  // what the pre-#1031 script would have produced.
+  if (allFailures.length > MAX_AUTO_REMOVE) {
     result.status = "guard_tripped";
     process.stdout.write(JSON.stringify(result));
     return;

--- a/scripts/report-backend-outages.mjs
+++ b/scripts/report-backend-outages.mjs
@@ -17,8 +17,13 @@
 // on daily run 30444299314 the heavy shards were unreachable for 33-73% of
 // their span. At that coverage "the failure landed inside an outage" is close to
 // a coin flip, so the section states the share next to the count and calls the
-// overlap a lead, never a verdict. Turning overlap into a tag decision is #1031's
-// job, under its own rules.
+// overlap a lead, never a verdict.
+//
+// #1031 settled the tag decision elsewhere for exactly that reason: it exempts a
+// failure from @stable auto-removal on its OWN error signature (a transport-level
+// error is never a product assertion — scripts/lib/infra-signatures.ts), not on
+// overlap with these windows. The only value that crosses over is the `wedged`
+// output, which the auto-remove action uses to word its exemption.
 //
 // This step REPORTS. It never fails the run and never gates the @stable tag: a
 // missing artifact yields `measured=false`, which must never be read as "no

--- a/scripts/watch-backend.mjs
+++ b/scripts/watch-backend.mjs
@@ -25,7 +25,9 @@
 // polls the same URL the specs talk to, at a fixed interval, and appends one
 // JSONL line per probe. Two consecutive failed probes bound an outage to a few
 // seconds instead of two minutes, which is narrow enough for the merge job to
-// attribute collateral failures honestly (#1031 consumes that attribution).
+// attribute collateral failures honestly. (#1031 keeps the @stable decision on
+// the failure's own error signature and consumes only the `wedged` verdict, to
+// word its exemption — see scripts/lib/infra-signatures.ts.)
 //
 // It is DIAGNOSTIC ONLY. It never fails a step, never aborts a shard, and never
 // gates the @stable tag — at this wedge frequency an abort would discard the


### PR DESCRIPTION
## Problem

When the backend dies mid-run, every test that touches it fails with a transport-level error, and the report blames the specs that happened to be running. On run [30374528125](https://github.com/oriontech-me/langflow-e2e/actions/runs/30374528125), 14 of 19 hard failures described **one wedged backend**, not 14 broken specs.

We escaped by luck: 19 > `MAX_AUTO_REMOVE` (5), so the mass-failure guard tripped and nothing was removed. The guard only ever covered the **wide** wedge — a wedge costing **≤5** tests would have stripped five innocent tags in an unreviewed commit to `main`, since auto-removal runs without review by design and *restoration* is the human-gated path.

## What this does

Classifies a hard failure as **non-attributable** when its last error is transport-level, and exempts it from `@stable` auto-removal **independently of the threshold**.

| File | Change |
|---|---|
| `scripts/lib/infra-signatures.ts` *(new)* | The signature list + `classifyInfraError`. |
| `scripts/remove-stable-from-failures.ts` | Reads the last failed attempt's error; partitions **before** the guard; emits `attributableFailures`, `exempt[]`, `backendWedged`. |
| `scripts/format-auto-remove-summary.mjs` | Renders collateral in its own block, **ahead of** the removals. |
| `.github/actions/auto-remove-stable/action.yml` | Optional `backend_wedged` input, `exempt_count` output. |
| `.github/workflows/daily-stable.yml` | Forwards `steps.liveness.outputs.wedged` (#1030). |
| `CONTRIBUTING.md` | *Infra-signature exemption (wedge collateral)* note, decision-table row, lifecycle diagram. |
| `.claude/skills/langflow-e2e-triage/SKILL.md` | Phase 3 pointer — don't cluster collateral. |

### Three decisions worth reviewing

**1. The signature list is deliberately narrow.** Only errors that cannot be a product assertion under any reading: `apiRequestContext.*: Timeout`, the globalSetup `[preflight] … is not reachable`, `ECONNREFUSED`/`ECONNRESET`/`socket hang up`, `net::ERR_CONNECTION_*`, DNS failures. The three signatures that *dominate* `reports/daily-history.jsonl` — `locator.click: Timeout`, `page.waitForSelector: Timeout`, `expect(locator).toBeVisible()` — are **excluded on purpose**. A wedge produces them, but so does real breakage; exempting them would switch auto-removal off for most genuine regressions instead of protecting it.

**2. The mass-failure guard keeps counting *every* hard failure**, collateral included. Netting the exempt ones out would make the mechanism *more* aggressive than today: on run 30374528125 the guard trips and removes nothing, while an attributable-only count would remove 5 tags with no review. #1031 asks to protect innocent specs, not to widen auto-removal's reach — so **the removal set is always a subset of what the pre-#1031 script produced**. The partition still happens *before* the guard, so the wide wedge (the run that most needs its cause named) still gets its collateral labelled.

**3. #1030's `wedged` verdict words the exemption, it never decides it.** The exemption has to hold on a run where the liveness recorder produced nothing — that is exactly the run whose backend state is least known. This also keeps faith with `report-backend-outages.mjs`'s own honesty note: at a 33–73% down-share, overlap with an outage window is a *lead, not a verdict*.

## Done when

- [x] Infra-signature failures are excluded from auto-removal independently of `MAX_AUTO_REMOVE`
- [x] The daily issue distinguishes collateral from attributable failures
- [x] Unit-covered next to the script, including the ≤5-failure wedge that today would strip tags
- [x] Triage rules in `CONTRIBUTING.md` updated to match

## Validation

```
npm run typecheck                # clean
npm run test:units               # 93/93  (24 in remove-stable-from-failures, 8 new)
npm run test:scripts             # 119/119 (6 new in format-auto-remove-summary)
npm run lint                     # 0 errors
node scripts/check-checklist-guard.mjs && npm run check:checklist-coverage   # both pass
```

The case the issue names:

```
node --require ts-node/register --test scripts/remove-stable-from-failures.test.ts \
  --test-name-pattern "narrow wedge"
# 1 pass — status "none", 5 exempt, spec file byte-identical
```

New cases: narrow wedge at the threshold · mixed run (collateral exempt, attributable still removed) · ambiguous error must **not** exempt · failure with no error is attributable · guard-tripped run still labels its collateral · exemption independent of the liveness verdict · signature matched on a cause line, not only line one · `lastFailureError` reads the last attempt · pre-#1031 result JSON still renders.

**No local proof for:** the `steps.liveness.outputs.wedged` → `backend_wedged` wiring, which only runs in CI. The YAML parses and the `liveness` step is in the same `merge` job, ahead of `auto_remove`. Final proof is the next red daily — check that the corroboration sentence in the `@stable auto-removal` block agrees with the backend-liveness section directly above it. The change is latent (it only acts on a red day), so it does not warrant a daily re-dispatch.

Closes #1031