### PR TITLE
fix(llm-agents): confirm the context_id write before each agent turn (#1060)

### DIFF
--- a/docs/core-functionality/llm-agents/agent-context-id-isolation.md
+++ b/docs/core-functionality/llm-agents/agent-context-id-isolation.md
@@ -1,6 +1,6 @@
 # Agent context_id — switching isolates history between contexts
 
-**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev7`)
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev8`)
 
 ---
 
@@ -97,15 +97,32 @@ surface; `@components` — Message History node drives the read-side assert;
 
 1. Load the Simple Agent template (provider/model from `models.json`/`.env`).
 2. Set `context_id = CTX-A` (unique per run) on the **Agent**, **Chat Input**
-   and **Chat Output** nodes (same advanced-field path as #487).
+   and **Chat Output** nodes (same advanced-field path as #487), and **confirm
+   the write survived** before running the turn (see the confirmed-write note
+   below).
 3. Seed the ChatInput with nonce N1; open the Playground, send, wait.
-4. Switch `context_id` to `CTX-B` on the same three nodes; seed nonce N2;
-   send a second turn in the same playground session.
+4. Switch `context_id` to `CTX-B` on the same three nodes — again **confirmed**
+   — seed nonce N2; send a second turn in the same playground session.
 5. **Assert (monitor API):** N1 → its session's turn-1 messages ALL carry
    `context_id === CTX-A` and none carry `CTX-B`; N2 → turn-2 messages ALL
    carry `CTX-B` and none carry `CTX-A`. Message sets are keyed by nonce, so
    the two turns are disjoint by construction.
 6. No `allowFlowErrors`.
+
+> **Confirmed-write setup (#1060).** The `context_id` write is an API PATCH on
+> the flow's nodes, and the editor keeps firing its own debounced
+> `PATCH /api/v1/flows/{id}` carrying the store's snapshot after a playground
+> turn. That autosave can be *issued* after our PATCH and land last — the
+> endpoint has no version check — silently reverting the switch, so the next
+> turn runs under the OLD context and the test reports a cross-tagging failure
+> that never happened. Reproduced locally at ~8% (1/12 `--retries=0` runs);
+> the daily's parallel shards widen the window, which is why every recorded
+> occurrence fell on a saturated day. Each turn's setup is therefore
+> **PATCH → reload → set the ChatInput → drain the autosave → read the flow
+> back**, retried while the server still disagrees, and the turn only runs
+> once the server confirms the intended context on all three nodes. If the
+> editor wins three times in a row the test fails as an explicit **setup**
+> error naming the reverted write — never as a fake isolation defect.
 
 ---
 
@@ -130,10 +147,16 @@ persisted/rendered data — no model judgment anywhere.
   seeding block separate "seed failed" from "isolation broken".
 - **Unique CTX-A/CTX-B/session per run** — monitor rows persist across flow
   deletion; per-run identifiers pin every lookup to THIS run.
+- **Setup failures are distinguishable from contract failures** — a reverted
+  `context_id` write fails in the setup step naming the reversion, so a
+  frontend/backend write race can never masquerade as broken isolation
+  (#1060).
 - **Force-failure checks** (CONTRIBUTING §2): M1 — test 1 asserts a `B-*`
   sentinel present in the `CTX-A` retrieval (inverted negative) ⇒ must fail;
   M2 — test 1 expects a never-seeded sentinel ⇒ must fail; M3 — test 2
-  expects turn-2 messages tagged `CTX-A` (stale context) ⇒ must fail.
+  expects turn-2 messages tagged `CTX-A` (stale context) ⇒ must fail; M4 —
+  test 2's confirmed-write gate targets a context the flow never receives
+  ⇒ must fail in setup, proving the gate is live.
 
 ---
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts
@@ -227,6 +227,28 @@ async function patchContextId(
   expect(patchRes.status()).toBe(200);
 }
 
+// Read the context_id currently stored on the given node types.
+async function readContextIds(
+  request: APIRequestContext,
+  bearer: string,
+  flowId: string,
+  nodeTypes: string[],
+): Promise<Record<string, unknown>> {
+  const res = await request.get(`/api/v1/flows/${flowId}`, {
+    headers: { Authorization: bearer },
+  });
+  expect(res.status()).toBe(200);
+  const flow = await res.json();
+  const values: Record<string, unknown> = {};
+  for (const node of flow.data?.nodes ?? []) {
+    const type = node.data?.type;
+    if (nodeTypes.includes(type)) {
+      values[type] = node.data?.node?.template?.context_id?.value;
+    }
+  }
+  return values;
+}
+
 // Set the task on the ChatInput node (the Playground prompt pre-fills from it;
 // typing into the Playground races an async default re-injection).
 async function setChatInputText(page: Page, text: string): Promise<void> {
@@ -237,6 +259,45 @@ async function setChatInputText(page: Page, text: string): Promise<void> {
   await field.click();
   await field.fill(text);
   await field.blur();
+}
+
+const CONTEXT_NODE_TYPES = ["Agent", "ChatInput", "ChatOutput"];
+const CONTEXT_WRITE_ATTEMPTS = 3;
+
+// Put the flow in the state a turn needs — context_id switched AND the task
+// seeded — and only return once the SERVER confirms the context on every node.
+//
+// The write is an API PATCH, but the editor keeps firing its own debounced
+// PATCH /api/v1/flows/{id} with the store's snapshot after a playground turn.
+// That autosave can be issued after ours and land last (the endpoint has no
+// version check), silently reverting the switch: the next turn then runs under
+// the OLD context and the isolation assert fails for a defect that does not
+// exist — the #1060 flake, reproduced locally with the frontend PATCH going out
+// 23 ms after ours and finishing 20 ms behind it. Re-patch while the server
+// still disagrees; if the editor wins every attempt, fail HERE naming the
+// reverted write instead of downstream as fake cross-tagging.
+async function prepareTurn(
+  page: Page,
+  request: APIRequestContext,
+  bearer: string,
+  flowId: string,
+  contextId: string,
+  task: string,
+): Promise<void> {
+  let stored: Record<string, unknown> = {};
+  for (let attempt = 1; attempt <= CONTEXT_WRITE_ATTEMPTS; attempt++) {
+    await patchContextId(request, bearer, flowId, CONTEXT_NODE_TYPES, contextId);
+    await page.reload();
+    await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', { timeout: 30000 });
+    await setChatInputText(page, task);
+    await waitForFlowSaveSettled(page);
+
+    stored = await readContextIds(request, bearer, flowId, CONTEXT_NODE_TYPES);
+    if (CONTEXT_NODE_TYPES.every((type) => stored[type] === contextId)) return;
+  }
+  throw new Error(
+    `context_id "${contextId}" was reverted by the editor autosave on ${CONTEXT_WRITE_ATTEMPTS} consecutive attempts — stored: ${JSON.stringify(stored)}`,
+  );
 }
 
 async function waitForAgentToFinish(page: Page): Promise<void> {
@@ -567,11 +628,9 @@ for (const { label, options, skipReason } of targets) {
   const provider = options.provider ?? (Object.keys(providerConfigMap)[0] as Provider);
 
   test.describe(`Agent Context ID Isolation [${label}]`, () => {
-    // Quarantined for #1060 — recurrent flake (2026-07-14 / 07-16 / 07-22): the
-    // context_id equality assertion fails intermittently.
-    test.fixme(
+    test(
       "switching the agent's context_id re-tags new turns without touching previous ones",
-      { tag: ["@regression", "@agents", "@playground"] },
+      { tag: ["@stable", "@regression", "@agents", "@playground"] },
       async ({ page, request }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(
@@ -592,11 +651,7 @@ for (const { label, options, skipReason } of targets) {
         const flowId = await resolveLiveFlowId(request, bearer, createdFlowIds);
 
         await test.step("set context_id = CTX-A on Agent + Chat Input + Chat Output, run turn 1", async () => {
-          await patchContextId(request, bearer, flowId, ["Agent", "ChatInput", "ChatOutput"], contextA);
-          await page.reload();
-          await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', { timeout: 30000 });
-          await setChatInputText(page, task1);
-          await waitForFlowSaveSettled(page);
+          await prepareTurn(page, request, bearer, flowId, contextA, task1);
           await openPlaygroundAndSend(page, task1);
         });
 
@@ -605,11 +660,7 @@ for (const { label, options, skipReason } of targets) {
 
         await test.step("switch context_id to CTX-B, run turn 2 in the same session", async () => {
           await page.keyboard.press("Escape"); // close the playground modal
-          await patchContextId(request, bearer, flowId, ["Agent", "ChatInput", "ChatOutput"], contextB);
-          await page.reload();
-          await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', { timeout: 30000 });
-          await setChatInputText(page, task2);
-          await waitForFlowSaveSettled(page);
+          await prepareTurn(page, request, bearer, flowId, contextB, task2);
           await openPlaygroundAndSend(page, task2);
         });
 


### PR DESCRIPTION
**Fixes #1060.**

## Problem

`switching the agent's context_id re-tags new turns without touching previous ones` failed the same way on three dailies — 2026-07-14, 2026-07-16 and 2026-07-22 (`openai / gpt-4o-mini`, `Object.is` equality) — and again as a flaky attempt on run [30444299314](https://github.com/oriontech-me/langflow-e2e/actions/runs/30444299314). It was quarantined at triage in #1064 (`test.fixme` + `@stable` removed).

Root cause is a **write race in the test**, not a product regression. The test PATCHes `context_id` on the flow's nodes and runs the turn right after, but the editor keeps firing its own debounced `PATCH /api/v1/flows/{id}` carrying the store's snapshot after a playground turn. That autosave can be *issued* after ours and land last — the endpoint has no version check (same last-writer-wins documented in `wait-for-flow-save-settled.ts`) — silently reverting the switch. Turn 2 then runs under the OLD context and the isolation assert reports cross-tagging that never happened.

Reproduced locally with a request-timeline probe (1 failure in 12 `--retries=0` runs on an idle backend, nightly `1.12.0.dev8`):

```
DIAGPATCH[api-out]  t=…702053 -> ctx-B      our PATCH goes out
DIAGPATCH[fe-out]   t=…702076 ctx=[ctx-A]   editor autosave goes out 23 ms later, stale snapshot
DIAGPATCH[api-done] t=…702123 status=200
DIAGPATCH[fe-done]  t=…702143               the editor's write lands LAST -> flow back on ctx-A
DIAG[turn2-before-send] {"ChatInput":"ctx-A…","ChatOutput":"ctx-A…","Agent":"ctx-A…"}
  1 failed   // exactly the daily's signature
```

The rate explains the recurrence pattern: every recorded occurrence fell on a saturated daily, because parallel shards widen the race window. That correlates with #773 without being #773.

**The `google / gemini-2.5-flash` hard failure on the same line is a different cause** — recovered from the run artifact it is `TimeoutError: apiRequestContext.get: Timeout 20000ms exceeded → GET /api/v1/auto_login` in `getAuthToken`, i.e. the #1030 cluster. It needs no dedicated issue, and it also reproduces locally (3× today, including on the first run after a container restart).

## Fix

Each turn's setup now goes through `prepareTurn`: PATCH → reload → seed the ChatInput → drain the autosave → **read the flow back from the server**, re-patching while the three nodes still disagree (3 attempts). The turn only runs once the server confirms the intended context. If the editor wins every attempt the test fails as an explicit **setup** error naming the reverted write, so a write race can never masquerade as broken isolation.

Both turns use it — turn 1 has the same exposure (the editor also autosaves right after the template load).

Rejected alternatives:
- **Autosave barrier only** (`waitForFlowSaveSettled` before the PATCH): the measured late save came 2.1 s after the previous one, outside the helper's 700 ms quiet window — it would not have caught this.
- **Run both turns through `POST /api/v1/run`**: deterministic, but it removes the Agent from the Playground path the spec exists to cover (`@playground`).

Quarantine lifted: `test.fixme` removed and `@stable` restored.

## Scope note

No assertion changed. The observables are the same: turn-1 messages all carry `CTX-A`, turn-2 messages (id-partitioned) all carry `CTX-B`, turn-1 messages are not re-tagged. Test 1 (model-free retrieval half) is untouched apart from being re-run and force-failed as part of the file. `QA-CHECKLIST.md` needs no edit — the bullets already reference the spec and the counts regenerate from the restored tag.

## Validation (nightly `1.12.0.dev8` / `1.12.0.dev9`, `--retries=0 --workers=1`)

- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors)
- **9 clean runs of the file, zero occurrences of the defect** ✅ (2 aborts on the #1030 `auto_login` timeout and 1 `built successfully` toast timeout on test 1 with the backend already degraded — none is this failure mode)
- Pre-fix baseline on the same machine: 1 occurrence in 12 runs
- Also green on `google / gemini-3.5-flash` (`gemini-2.5-flash` is gated locally; collect-models settled on 3.5)
- Force-fail — all four executed, each failed as designed, then reverted (`grep FFMUT` → 0 hits) with a green run after:
  - `M1` test 1 expects a `B-*` sentinel in the `CTX-A` retrieval → ✘ `Expected substring: "CTXISO-…-B-1"`
  - `M2` test 1 expects a never-seeded sentinel → ✘ `Expected substring: "NEVER-SEEDED-SENTINEL"`
  - `M3` test 2 expects turn 2 tagged `CTX-A` → ✘ `Received: turn-2 message(s) with wrong context_id: [… "ctx-B-probe-A-…"]` (also proves the switch now reaches the run)
  - `M4` the confirmed-write gate targets a context the flow never receives → ✘ `context_id "ctx-A-…" was reverted by the editor autosave on 3 consecutive attempts`
- Zero `🚨 Backend Error` ✅ · flow cleanup verified: one flow leaked by an aborted run was purged, final count 27 = starter templates only, no duplicates
- `--trace=on` **not run**: it hangs on the Simple Agent template family (known limitation, #490/#518). Step verification came from the `--retries=0` bursts, the force-fails and the request-timeline instrumentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
