### PR TITLE
fix(scripts): default start-langflow-docker.sh to the nightly image (#1076)

### DIFF
--- a/.claude/skills/langflow-e2e-infra/references/infra-map.md
+++ b/.claude/skills/langflow-e2e-infra/references/infra-map.md
@@ -25,7 +25,7 @@ before acting; this list drifts.
 
 | Script | Role |
 |---|---|
-| `start-langflow-docker.sh` / `stop-langflow-docker.sh` | Bring a Langflow instance up/down via Docker (nightly by default) |
+| `start-langflow-docker.sh` / `stop-langflow-docker.sh` | Bring a Langflow instance up/down via Docker. No arg → `langflowai/langflow-nightly:latest` (refreshed before start); a version arg → the released repo; `LANGFLOW_IMAGE` → an exact reference (`#1076`) |
 | `start-langflow-pip.sh` / `stop-langflow-pip.sh` | Same via pip (local dev). Caps to 1 worker to avoid OOM (`#888`) |
 | `coverage-summary.ts` | Regenerates the QA-CHECKLIST Coverage Summary table (bullet markers → table) |
 | `stable-tests.ts` | Regenerates the `Phase 0 — Validated` block from `@stable` `test()` calls |

--- a/.claude/skills/langflow-e2e/SKILL.md
+++ b/.claude/skills/langflow-e2e/SKILL.md
@@ -198,40 +198,36 @@ interleaving; the JSON stats caught it.
 
 ```bash
 cp .env.example .env        # set PLAYWRIGHT_BASE_URL, superuser creds, API keys
-./scripts/start-langflow-docker.sh           # Docker — see nightly-vs-stable trap below
-./scripts/start-langflow-docker.sh 1.5.1     # specific stable version
+./scripts/start-langflow-docker.sh           # Docker — nightly (the image CI runs)
+./scripts/start-langflow-docker.sh 1.5.1     # specific released version
 ./scripts/start-langflow-pip.sh              # via pip (local dev)
 ./scripts/stop-langflow-docker.sh            # stop Docker instance
 ```
 
 An instance must be up (default `http://localhost:7860`) before running.
 
-> **Trap — `start-langflow-docker.sh` does NOT run nightly.** Despite the "nightly
-> by default" claim in CLAUDE.md, the script hardcodes
-> `IMAGE="langflowai/langflow:${tag}"` with `tag` defaulting to `latest` — that is
-> the **stable** repo (`langflowai/langflow:latest` → e.g. 1.10.1), a *different
-> Docker repo* from nightly (`langflowai/langflow-nightly`). No tag arg makes the
-> script pull nightly (`langflowai/langflow:nightly-latest` doesn't exist). Running
-> it blindly silently downgrades the instance to stable and your tests validate the
-> wrong build. To (re)start on **nightly**, run the image directly with the script's
-> flags:
-> ```bash
-> docker rm -f langflow-e2e-runner
-> docker run -d --name langflow-e2e-runner -p 7860:7860 \
->   -e LANGFLOW_AUTO_LOGIN=true -e LANGFLOW_SUPERUSER=langflow \
->   -e LANGFLOW_SUPERUSER_PASSWORD=langflow123 -e LANGFLOW_DEACTIVATE_TRACING=true \
->   -e LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true -e LANGFLOW_WORKERS=1 \
->   langflowai/langflow-nightly:latest
-> ```
-> `-e LANGFLOW_WORKERS=1` caps the backend to one worker. Langflow defaults to
+> **Which image you get.** With no argument the script starts
+> `langflowai/langflow-nightly:latest` — the image CI runs — and refreshes that
+> moving tag before starting, so a stale local copy cannot silently take over. A
+> version argument (`1.5.1`) resolves against the **released** repo
+> `langflowai/langflow`, because the nightly repo keeps only recent dev tags; for
+> anything else pass an exact reference,
+> `LANGFLOW_IMAGE=langflowai/langflow:latest ./scripts/start-langflow-docker.sh`.
+> Until #1076 the repository was hardcoded to `langflowai/langflow`, so the script
+> could not reach the nightly at all and silently validated the wrong build — if
+> you find a hand-rolled `docker run` in an older doc or issue, that is the
+> workaround it needed.
+> The script prints the running version on success; confirm any time with
+> `curl -s localhost:7860/api/v1/version` — the nightly package reports
+> `"package":"Langflow Nightly"` and a `.devNN` version.
+>
+> `LANGFLOW_WORKERS` defaults to 1 in the script. Langflow itself defaults to
 > `(2*cpu)+1` workers, each inheriting the full in-memory state; on a small local
 > Docker VM (~4 GB, no per-container limit) several heavy workers exhaust memory
 > and the kernel SIGKILLs one mid-build — surfacing as `ERR_EMPTY_RESPONSE` / a
 > node run that never completes when running the knowledge/agent specs (#773).
-> One worker is plenty locally (heavy specs run `--workers=1`); drop the flag /
-> raise it on a beefier box.
-> Always confirm with `curl -s localhost:7860/api/v1/version` — the nightly package
-> reports `"package":"Langflow Nightly"` and a `.devNN` version.
+> One worker is plenty locally (heavy specs run `--workers=1`); raise it on a
+> beefier box with `LANGFLOW_WORKERS=4 ./scripts/start-langflow-docker.sh`.
 >
 > **Trap — the nightly image ships `LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false`.** With
 > the flag off (the image default, seen from ~1.11.0.dev42), custom-component
@@ -256,18 +252,14 @@ docker inspect --format '{{.Id}}' langflowai/langflow-nightly:latest  # ...vs fr
 ```
 
 If the ids differ (or `docker pull` reports a new digest), the running instance
-is **stale** — restart it on the fresh image before testing. **Do not use
-`start-langflow-docker.sh` for this** (it pulls stable — see the trap above); run
-the nightly image directly:
+is **stale** — restart it on the fresh image before testing:
 
 ```bash
-docker rm -f langflow-e2e-runner
-docker run -d --name langflow-e2e-runner -p 7860:7860 \
-  -e LANGFLOW_AUTO_LOGIN=true -e LANGFLOW_SUPERUSER=langflow \
-  -e LANGFLOW_SUPERUSER_PASSWORD=langflow123 -e LANGFLOW_DEACTIVATE_TRACING=true \
-  -e LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true -e LANGFLOW_WORKERS=1 \
-  langflowai/langflow-nightly:latest
+./scripts/start-langflow-docker.sh    # pulls nightly:latest, then restarts on it
 ```
+
+The script refreshes the moving tag itself, so step 2 above is only needed to
+*detect* staleness in an instance you want to keep running.
 
 `-e LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true` is required — the nightly image
 defaults it to `false`, which hides `sidebar-custom-component-button` and makes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,8 +34,9 @@ ANTHROPIC_API_KEY=
 Start a Langflow instance before running tests:
 
 ```bash
-./scripts/start-langflow-docker.sh           # Docker (nightly by default)
-./scripts/start-langflow-docker.sh 1.5.1     # Specific version
+./scripts/start-langflow-docker.sh           # Docker — nightly (langflowai/langflow-nightly:latest)
+./scripts/start-langflow-docker.sh 1.5.1     # Docker — a released version (langflowai/langflow)
+LANGFLOW_IMAGE=langflowai/langflow:latest ./scripts/start-langflow-docker.sh   # any exact image
 ./scripts/start-langflow-pip.sh              # Via pip (local dev)
 ./scripts/stop-langflow-docker.sh            # Stop Docker instance
 ```

--- a/README.md
+++ b/README.md
@@ -23,11 +23,14 @@ cp .env.example .env  # adjust PLAYWRIGHT_BASE_URL and API keys
 ## Starting Langflow
 
 ```bash
-# Docker — nightly (default)
+# Docker — nightly (default): langflowai/langflow-nightly:latest, the image CI runs
 ./scripts/start-langflow-docker.sh
 
-# Docker — specific version
+# Docker — a released version, from langflowai/langflow
 ./scripts/start-langflow-docker.sh 1.3.0
+
+# Docker — any exact image reference
+LANGFLOW_IMAGE=langflowai/langflow:latest ./scripts/start-langflow-docker.sh
 
 # External instance (staging, PR branch, already running locally)
 # Just set PLAYWRIGHT_BASE_URL in .env or on the command line

--- a/scripts/start-langflow-docker.sh
+++ b/scripts/start-langflow-docker.sh
@@ -1,16 +1,61 @@
 #!/usr/bin/env bash
-# Usage: ./scripts/start-langflow-docker.sh [image_tag]
-# Example: ./scripts/start-langflow-docker.sh latest
-#          ./scripts/start-langflow-docker.sh 1.3.0
+# Usage: ./scripts/start-langflow-docker.sh [version]
+#
+# Image selection:
+#   (no argument)   langflowai/langflow-nightly:latest — the reference image this
+#                   suite validates against (CONTRIBUTING.md, daily-stable.yml and
+#                   nightly.yml all run on it).
+#   <version>       langflowai/langflow:<version> — a published build.
+#                   Example: ./scripts/start-langflow-docker.sh 1.5.1
+#   LANGFLOW_IMAGE  An exact image reference, which wins over both. Example:
+#                   LANGFLOW_IMAGE=langflowai/langflow:latest ./scripts/start-langflow-docker.sh
+#
+# Nightly and released builds live in DIFFERENT Docker repositories
+# (langflowai/langflow-nightly vs langflowai/langflow), and the nightly repo keeps
+# only recent dev tags — which is why a version argument resolves against the
+# release repo. Until #1076 the repository was hardcoded to langflowai/langflow, so
+# no argument could reach the nightly and the documented "nightly by default" was
+# false; the workaround was a hand-rolled `docker run` that duplicated the env
+# block below, losing the LANGFLOW_WORKERS rationale with it.
 
 set -euo pipefail
 
-IMAGE_TAG="${1:-${LANGFLOW_IMAGE_TAG:-latest}}"
-IMAGE="langflowai/langflow:${IMAGE_TAG}"
+IMAGE_TAG="${1:-${LANGFLOW_IMAGE_TAG:-}}"
+
+if [ -n "${LANGFLOW_IMAGE:-}" ]; then
+  IMAGE="${LANGFLOW_IMAGE}"
+elif [ -n "${IMAGE_TAG}" ]; then
+  IMAGE="${LANGFLOW_IMAGE_REPO:-langflowai/langflow}:${IMAGE_TAG}"
+else
+  IMAGE="${LANGFLOW_IMAGE_REPO:-langflowai/langflow-nightly}:latest"
+fi
+
 CONTAINER_NAME="langflow-e2e-runner"
 PORT="${LANGFLOW_PORT:-7860}"
 
 echo "Starting Langflow: ${IMAGE} on port ${PORT}..."
+
+# `latest` is a moving tag, so a local copy pulled days ago is silently stale —
+# and testing today's build is the entire point of defaulting to the nightly.
+# Refresh it here. Pinned versions are immutable, so they are left alone.
+# A failed refresh must not cost you a working instance: with a local copy we warn
+# and start it, naming the risk, rather than aborting an offline or low-disk box
+# (the pull is a new step — the script never used to fail this way). With nothing
+# local there is nothing to fall back to, so that path exits.
+case "${IMAGE}" in
+*:latest)
+  echo "Refreshing ${IMAGE} (moving tag)..."
+  if ! docker pull "${IMAGE}"; then
+    if docker image inspect "${IMAGE}" > /dev/null 2>&1; then
+      echo "WARNING: could not refresh ${IMAGE} — starting the LOCAL copy, which may be stale."
+      echo "         Confirm the version reported below before trusting a run against it."
+    else
+      echo "ERROR: could not pull ${IMAGE}, and no local copy exists to fall back to."
+      exit 1
+    fi
+  fi
+  ;;
+esac
 
 # Remove any previous container
 docker rm -f "${CONTAINER_NAME}" 2>/dev/null || true
@@ -40,6 +85,11 @@ echo "Waiting for Langflow to be ready (up to 120s)..."
 for i in $(seq 1 24); do
   if curl -sf "http://localhost:${PORT}/health_check" > /dev/null 2>&1; then
     echo "Langflow ready after $((i * 5))s"
+    # Report the build that actually came up. The image tag alone does not say
+    # it — `latest` moves, and a spec doc's `Last validated` field records this
+    # version, not the tag.
+    VERSION="$(curl -sf "http://localhost:${PORT}/api/v1/version" 2>/dev/null || true)"
+    [ -n "${VERSION}" ] && echo "Running: ${VERSION}"
     exit 0
   fi
   echo "  Waiting... ($((i * 5))s)"

--- a/scripts/start-langflow-docker.test.mjs
+++ b/scripts/start-langflow-docker.test.mjs
@@ -1,0 +1,156 @@
+// Unit tests for scripts/start-langflow-docker.sh (issue #1076).
+// Run with: npm run test:scripts
+//
+// What these protect: the script resolves an IMAGE from three inputs whose
+// precedence is not obvious — a positional version, LANGFLOW_IMAGE_TAG, and
+// LANGFLOW_IMAGE — across two DIFFERENT Docker repositories (nightly vs
+// released). #1076 was exactly a silent divergence in that resolution: the
+// repository was hardcoded to langflowai/langflow, so the documented
+// "nightly by default" was false and every local validation ran the wrong build
+// without saying so. A regression here is invisible for the same reason, which
+// is why it is asserted rather than trusted.
+//
+// docker is stubbed via a PATH shim, so nothing is pulled and no container is
+// started; the assertions read the arguments the script would have passed.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, readFileSync, chmodSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = fileURLToPath(new URL("./start-langflow-docker.sh", import.meta.url));
+
+/**
+ * Runs the script with `docker` and `curl` stubbed out.
+ *
+ * The docker stub logs every invocation and can be told to fail `pull` and to
+ * deny that a local copy exists, which is how the two refresh-failure branches
+ * are reached. The curl stub answers the health check immediately so the run
+ * does not sit through the 120 s readiness loop.
+ */
+function runScript({ args = [], env = {}, pullFails = false, localCopy = true } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "start-langflow-test-"));
+  const log = join(dir, "docker.log");
+
+  writeFileSync(
+    join(dir, "docker"),
+    `#!/usr/bin/env bash
+echo "$*" >> "${log}"
+case "$1" in
+  pull) [ "\${FAKE_PULL_FAILS}" = "1" ] && exit 1 ;;
+  image) [ "$2" = "inspect" ] && [ "\${FAKE_LOCAL_COPY}" = "0" ] && exit 1 ;;
+esac
+exit 0
+`,
+  );
+  writeFileSync(
+    join(dir, "curl"),
+    `#!/usr/bin/env bash
+echo '{"version":"0.0.0-test"}'
+exit 0
+`,
+  );
+  chmodSync(join(dir, "docker"), 0o755);
+  chmodSync(join(dir, "curl"), 0o755);
+
+  let stdout = "";
+  let status = 0;
+  try {
+    stdout = execFileSync("bash", [SCRIPT, ...args], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ...env,
+        PATH: `${dir}:${process.env.PATH}`,
+        FAKE_PULL_FAILS: pullFails ? "1" : "0",
+        FAKE_LOCAL_COPY: localCopy ? "1" : "0",
+      },
+    });
+  } catch (err) {
+    status = err.status ?? 1;
+    stdout = `${err.stdout ?? ""}${err.stderr ?? ""}`;
+  }
+
+  let calls = [];
+  try {
+    calls = readFileSync(log, "utf8").trim().split("\n").filter(Boolean);
+  } catch {
+    // no docker call at all — a valid outcome for the hard-fail branch
+  }
+  rmSync(dir, { recursive: true, force: true });
+
+  const runCall = calls.find((c) => c.startsWith("run "));
+  return {
+    stdout,
+    status,
+    calls,
+    pulled: calls.some((c) => c.startsWith("pull ")),
+    // The image is the last argument of `docker run`.
+    image: runCall ? runCall.trim().split(/\s+/).pop() : null,
+  };
+}
+
+test("no argument starts the nightly, and refreshes the moving tag", () => {
+  const r = runScript();
+  assert.equal(r.image, "langflowai/langflow-nightly:latest");
+  assert.ok(r.pulled, "a moving tag must be refreshed before starting");
+  assert.equal(r.status, 0);
+});
+
+test("a version argument resolves against the RELEASED repo, not nightly", () => {
+  // The nightly repo keeps only recent dev tags, so `1.5.1` exists solely in
+  // langflowai/langflow. Resolving it against nightly would fail on pull.
+  const r = runScript({ args: ["1.5.1"] });
+  assert.equal(r.image, "langflowai/langflow:1.5.1");
+  assert.equal(r.pulled, false, "a pinned tag is immutable — no refresh needed");
+});
+
+test("LANGFLOW_IMAGE wins over the positional argument", () => {
+  const r = runScript({
+    args: ["1.5.1"],
+    env: { LANGFLOW_IMAGE: "langflowai/langflow:1.11.1" },
+  });
+  assert.equal(r.image, "langflowai/langflow:1.11.1");
+});
+
+test("LANGFLOW_IMAGE_TAG still selects a released version (back-compat)", () => {
+  const r = runScript({ env: { LANGFLOW_IMAGE_TAG: "1.9.0" } });
+  assert.equal(r.image, "langflowai/langflow:1.9.0");
+});
+
+test("LANGFLOW_IMAGE_REPO overrides the repository", () => {
+  const r = runScript({ env: { LANGFLOW_IMAGE_REPO: "langflowai/langflow" } });
+  assert.equal(r.image, "langflowai/langflow:latest");
+  assert.ok(r.pulled, "still a moving tag");
+});
+
+test("a failed refresh with a local copy warns and starts it anyway", () => {
+  // Regression guard for the pull step itself: aborting here would make the
+  // script unusable offline or on a full disk, which the pre-#1076 version
+  // (no pull at all) never was.
+  const r = runScript({ pullFails: true, localCopy: true });
+  assert.match(r.stdout, /WARNING: could not refresh/);
+  assert.match(r.stdout, /may be stale/);
+  assert.equal(r.image, "langflowai/langflow-nightly:latest");
+  assert.equal(r.status, 0);
+});
+
+test("a failed refresh with no local copy fails loudly and starts nothing", () => {
+  const r = runScript({ pullFails: true, localCopy: false });
+  assert.match(r.stdout, /ERROR: could not pull/);
+  assert.equal(r.status, 1);
+  assert.equal(r.image, null, "nothing may be started when there is no image");
+});
+
+test("the superuser and worker defaults are passed to the container", () => {
+  // LANGFLOW_WORKERS=1 is load-bearing (#773: OOM on a small Docker VM) and
+  // LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true is required by every custom-component
+  // spec (#668/#746). Both are easy to drop when editing the run block.
+  const r = runScript();
+  const runCall = r.calls.find((c) => c.startsWith("run "));
+  assert.match(runCall, /LANGFLOW_WORKERS=1/);
+  assert.match(runCall, /LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true/);
+  assert.match(runCall, /LANGFLOW_AUTO_LOGIN=true/);
+});


### PR DESCRIPTION
**Closes #1076.**

## Problem

`scripts/start-langflow-docker.sh` could not start the nightly — the image every
other part of the project validates against. The repository was hardcoded and the
default tag was `latest`:

```bash
IMAGE_TAG="${1:-${LANGFLOW_IMAGE_TAG:-latest}}"
IMAGE="langflowai/langflow:${IMAGE_TAG}"
```

The nightly is a **different Docker repository** (`langflowai/langflow-nightly`),
and `langflowai/langflow` publishes no `nightly` tag, so no argument or env var
could reach it. Meanwhile four docs claimed nightly was the default —
`CLAUDE.md:37`, `README.md:26`, `langflow-e2e-infra/references/infra-map.md:28`,
and (by implication) `langflow-e2e/references/team-workflow.md:51` — while
`CONTRIBUTING.md:99`, `daily-stable.yml` and `nightly.yml` all validate against
the nightly. The documented local entry point therefore started the **wrong
image** for the workflow the repo prescribes: validate against stable, record a
nightly cycle in the spec doc, and miss the drift the suite exists to catch (the
`1.11.0rc4` class of gap; also #907/#1039, where a component is present on one
image and absent on the other).

The divergence was already known and worked around rather than fixed —
`langflow-e2e/SKILL.md` carried a **"Trap"** section and `ISSUE-818-HANDOFF.md` a
warning, both telling readers to hand-roll a `docker run`. That workaround
duplicates the script's env block, which is exactly where the
`LANGFLOW_WORKERS=1` rationale (#773, OOM on a small Docker VM) and
`LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true` (#668/#746) live — so every hand-rolled
copy is a chance to drop them.

Found while reviewing #1052: reproducing that PR's evidence needed the nightly,
and the script could not provide it.

## Fix

Image resolution is now explicit:

| Input | Image |
|---|---|
| *(no argument)* | `langflowai/langflow-nightly:latest` — what CI runs |
| `1.5.1` | `langflowai/langflow:1.5.1` — the **released** repo |
| `LANGFLOW_IMAGE=<ref>` | exactly `<ref>`, winning over both |

A version argument resolves against the released repo because the nightly repo
keeps only recent dev tags — `1.5.1` does not exist there, so resolving it against
nightly would fail on pull. `LANGFLOW_IMAGE_TAG` keeps working (back-compat) and
`LANGFLOW_IMAGE_REPO` overrides the repository.

Two supporting changes, both in service of the same failure mode — *you cannot
tell which build you are testing*:

- **`latest` is refreshed before starting.** A default of "nightly" that silently
  runs a days-old local copy is the same bug wearing a different hat. A failed
  refresh does **not** cost a working instance: with a local copy it warns, names
  the staleness risk and starts it; with nothing local it exits. Without that
  branch the new `docker pull` under `set -euo pipefail` would abort on an offline
  or full-disk box — something the pre-#1076 script never did. (Not theoretical:
  the pull failed for real during validation on a full VM disk.)
- **The running version is printed on success.** The tag does not identify the
  build a spec doc's `Last validated` field records.

Docs: the four nightly-by-default claims now describe what the script does, and
the obsolete `SKILL.md` **Trap** section plus the "do not use
`start-langflow-docker.sh` for this" note in its staleness section are retired in
favour of calling the script. `ISSUE-818-HANDOFF.md` is left alone — a frozen
postmortem should keep saying what was true when it was written.

## Tests

`scripts/start-langflow-docker.test.mjs` (new) — 8 tests picked up by the existing
`npm run test:scripts` PR gate. `docker` and `curl` are stubbed via a PATH shim, so
nothing is pulled and no container starts; the assertions read the arguments the
script would have passed. Coverage: the full resolution matrix, both
refresh-failure branches, and the two load-bearing env defaults.

Unit-tested rather than trusted because a regression here is **silent** — the
script keeps starting *something*, and that is precisely how #1076 survived long
enough to be documented as a trap.

## Validation

| Gate | Result |
|---|---|
| `shellcheck` + `bash -n` | 0 findings |
| `npm run test:scripts` | **97/97** (89 + 8 new) |
| ↳ with the #1076 bug reintroduced | **2 fail** — the guard bites |
| ↳ with `LANGFLOW_WORKERS=1` removed | **1 fail** — the guard bites |
| `npm run test:units` | 84/84 |
| `npm run typecheck` | clean |
| `npm run lint:ci` | exit 0 |
| QA-CHECKLIST guard + coverage guard + `regressions:check` | green |

**Real run, no stubs** — the instance was on `1.12.0.dev8`; the script pulled and
came up on **`1.12.0.dev9`**:

```
Starting Langflow: langflowai/langflow-nightly:latest on port 7860...
Refreshing langflowai/langflow-nightly:latest (moving tag)...
Status: Downloaded newer image for langflowai/langflow-nightly:latest
Langflow ready after 20s
Running: {"version":"1.12.0.dev9","main_version":"1.12.0","package":"Langflow Nightly"}
```

The non-default paths (pinned version, `LANGFLOW_IMAGE`) are proven by the stubbed
tests, not by a real pull — pulling the released image costs ~5 GB and the box was
disk-constrained. Stating that rather than implying full coverage.

No spec, tag, doc-under-`docs/` or checklist bullet changes — a script fix.

## Reproduce

```bash
# resolution + both failure branches, no docker involved
npm run test:scripts                                   # 97 pass
node --test scripts/start-langflow-docker.test.mjs     # 8 pass

# force the failure (proves the guard is not decorative)
sed -i '' 's|langflow-nightly}:latest|langflow}:latest|' scripts/start-langflow-docker.sh
node --test scripts/start-langflow-docker.test.mjs     # expect 2 fail
git checkout scripts/start-langflow-docker.sh

# real: start the nightly and confirm the build
./scripts/start-langflow-docker.sh                     # expect "Running: {...dev…, Langflow Nightly}"
./scripts/start-langflow-docker.sh 1.5.1               # released repo
LANGFLOW_IMAGE=langflowai/langflow:latest ./scripts/start-langflow-docker.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
