### PR TITLE
ci(daily-stable): detect a PARTIAL run, and degrade a provider instead of killing the shard (#1058)

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -848,8 +848,12 @@ jobs:
       # later daily. `needs.test.result == 'success'` does NOT cover that on its own —
       # the shard step runs with `--pass-with-no-tests`, so a run matching no @stable
       # test at all is GREEN with zero tests.
+      # ALSO gated on runguard.partial (#1058): durations extracted from a run where
+      # some shards aborted would record only the shards that ran, so the specs of a
+      # dead shard silently lose their timing and the partitioner mis-balances every
+      # later daily on stale data.
       - name: Refresh spec durations (green runs only)
-        if: needs.test.result == 'success' && github.event_name == 'schedule' && steps.runguard.outputs.empty == 'false'
+        if: needs.test.result == 'success' && github.event_name == 'schedule' && steps.runguard.outputs.empty == 'false' && steps.runguard.outputs.partial == 'false'
         run: node scripts/partition-shards.mjs extract results.json > reports/spec-durations.json
 
       # Long-lived run history: append one JSON line per scheduled run to
@@ -929,9 +933,14 @@ jobs:
       # 2026-07-28 this step ran on an empty report and only found nothing to do
       # by luck — the abort happened in globalSetup, before any test could be
       # recorded as failing, so the action's mass-failure guard was never reached.
+      # ALSO gated on runguard.partial (#1058). The same reasoning as `empty`, one
+      # granularity down: on run 30444299314 two of four shards aborted in the
+      # credentials preflight, so the report held 205 results against a ~380
+      # baseline. Mutating @stable on that report would judge tags by a report that
+      # never saw half the suite — and a spec cannot fail in a shard that never ran.
       - name: Auto-remove @stable from hard failures
         id: auto_remove
-        if: needs.test.result == 'failure' && github.event_name == 'schedule' && steps.shardguard.outputs.complete == 'true' && steps.runguard.outputs.empty == 'false'
+        if: needs.test.result == 'failure' && github.event_name == 'schedule' && steps.shardguard.outputs.complete == 'true' && steps.runguard.outputs.empty == 'false' && steps.runguard.outputs.partial == 'false'
         uses: ./.github/actions/auto-remove-stable
         with:
           playwright_json: results.json
@@ -964,6 +973,12 @@ jobs:
           RUN_UNREADABLE: ${{ steps.runguard.outputs.unreadable }}
           RUN_ERRORS: ${{ steps.runguard.outputs.report_errors }}
           RUN_FIRST_ERROR: ${{ steps.runguard.outputs.first_error }}
+          # PARTIAL (#1058): SOME shards aborted while others ran, so the totals in
+          # this body are UNDER-COUNTED. Without saying so, the umbrella reads as an
+          # ordinary failure day — which is exactly how run 30444299314 reported ~184
+          # unexecuted tests as a routine 10-failure triage.
+          RUN_PARTIAL: ${{ steps.runguard.outputs.partial }}
+          RUN_TESTS: ${{ steps.runguard.outputs.tests_total }}
           # In-run backend liveness (#1030). Rendered on EVERY umbrella issue,
           # not only on a wedged run: "the backend answered every probe" rules
           # the wedge out for the triager, and "not measured" says the state is
@@ -979,6 +994,8 @@ jobs:
             const unreadable = process.env.RUN_UNREADABLE === 'true';
             const runErrors = process.env.RUN_ERRORS || '0';
             const firstError = process.env.RUN_FIRST_ERROR || '';
+            const partial = process.env.RUN_PARTIAL === 'true';
+            const runTests = process.env.RUN_TESTS || '0';
             // Three shapes, most specific first.
             // 1. ZERO tests executed (#1012): there is no per-test evidence to
             //    triage, so say so instead of rendering the auto-removal line,
@@ -1004,7 +1021,25 @@ jobs:
                         'any test starts. Known cause of this shape: the post-`collect-models` backend wedge — #1011.',
                       ]),
                 ]
-              : arStatus
+              : partial
+                ? [
+                    '### ⚠️ PARTIAL run — some shards never ran their tests',
+                    '',
+                    `The merged report carries **${runTests} test result(s)** but also **${runErrors} top-level report error(s)**.`,
+                    'A top-level error means a shard aborted before running the tests assigned to it, so',
+                    'the totals above are **UNDER-COUNTED** — the specs of the dead shard are neither',
+                    'passed nor failed, they simply never ran.',
+                    ...(firstError ? ['', '```', firstError, '```'] : []),
+                    '',
+                    '`@stable` auto-removal and the spec-duration refresh were **both skipped**: a tag must',
+                    'not be judged, nor a timing baseline rebuilt, on a report that never saw half the suite.',
+                    '',
+                    '**Triage the abort first.** Compare the recorded total against the last green run — a',
+                    'large drop is the abort, not a fix. The cause above is quoted from the shard that died;',
+                    'the shard logs hold the rest. Known cause of this shape: `Collect models` failing without',
+                    'importing a provider key as a Langflow global variable — #1058.',
+                  ]
+                : arStatus
                 ? ['### `@stable` auto-removal', '', arSummary]
                 : [
                     '### Next steps',
@@ -1023,7 +1058,9 @@ jobs:
             // must not claim that tests failed — none ran.
             const title = empty
               ? `[Daily Failure] @stable run executed ZERO tests on ${today} (${image})`
-              : `[Daily Failure] @stable tests failed on ${today} (${image})`;
+              : partial
+                ? `[Daily Failure] @stable run was PARTIAL — a shard never ran on ${today} (${image})`
+                : `[Daily Failure] @stable tests failed on ${today} (${image})`;
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -1060,14 +1097,16 @@ jobs:
       # this whole mechanism exists to remove. `complete` keeps `== 'false'`: its
       # own absence is already covered, since a skipped shardguard means no blobs
       # were downloaded and runguard then sees no report at all.
-      - name: Fail scheduled run on an incomplete or empty report
-        if: always() && github.event_name == 'schedule' && (steps.shardguard.outputs.complete == 'false' || steps.runguard.outputs.empty != 'false')
+      - name: Fail scheduled run on an incomplete, empty or partial report
+        if: always() && github.event_name == 'schedule' && (steps.shardguard.outputs.complete == 'false' || steps.runguard.outputs.empty != 'false' || steps.runguard.outputs.partial == 'true')
         env:
           COMPLETE: ${{ steps.shardguard.outputs.complete }}
           RUN_EMPTY: ${{ steps.runguard.outputs.empty }}
+          RUN_PARTIAL: ${{ steps.runguard.outputs.partial }}
           RUN_UNREADABLE: ${{ steps.runguard.outputs.unreadable }}
           RUN_ERRORS: ${{ steps.runguard.outputs.report_errors }}
           RUN_TESTS: ${{ steps.runguard.outputs.tests_total }}
+          RUN_FIRST_ERROR: ${{ steps.runguard.outputs.first_error }}
         run: |
           if [ "$COMPLETE" = "false" ]; then
             echo "::error::Merge was incomplete (a shard produced no blob); results are under-counted. Failing the scheduled run so it is not mistaken for a clean pass."
@@ -1076,6 +1115,8 @@ jobs:
             echo "::error::The merged report is missing or unparseable, so ZERO test results could be read. Check the 'Merge blob reports' step and the per-shard blob artifacts."
           elif [ "$RUN_EMPTY" = "true" ]; then
             echo "::error::ZERO tests executed — the shards aborted before the first test ($RUN_ERRORS top-level report error(s), tests_total=$RUN_TESTS). This is an INFRA abort, not a per-test failure: no spec failed and no @stable tag was touched. Triage the abort, not the tests (see #1011)."
+          elif [ "$RUN_PARTIAL" = "true" ]; then
+            echo "::error::PARTIAL run — $RUN_TESTS test result(s) recorded, but $RUN_ERRORS top-level report error(s) mean at least one shard aborted before running its tests. The totals are UNDER-COUNTED and the specs of that shard neither passed nor failed: they never ran. @stable auto-removal and the spec-duration refresh were skipped. Cause from the shard that died: $RUN_FIRST_ERROR (see #1058)."
           elif [ -z "$RUN_EMPTY" ]; then
             echo "::error::The report-integrity guard reported nothing (empty output is unset) — its verdict is UNKNOWN, so this run cannot be trusted as a clean pass. Check the 'Guard — merged report contains test results' step."
           fi

--- a/scripts/check-run-integrity.mjs
+++ b/scripts/check-run-integrity.mjs
@@ -101,16 +101,54 @@ export function testsTotal(report) {
   );
 }
 
+// Did at least one shard abort before running its assigned tests?
+//
+// A top-level report `error` is the signal, and it is exact — measured against
+// Playwright 1.58 blob reports for the three cases the daily can produce (#1058):
+//
+//   shard ran its tests          → no top-level error
+//   shard ABORTED in globalSetup → top-level error (the preflight throw)
+//   shard legitimately had no    → no top-level error
+//     file to run, tolerated by
+//     `--pass-with-no-tests`
+//
+// The third case is why this cannot be inferred from a zero test count: the
+// workflow deliberately shards N ways over fewer files, so an empty shard is
+// normal. And the errors survive `merge-reports`, so the merged report answers
+// the question without per-shard artifacts.
+export function aborted(report) {
+  return (report?.errors || []).length > 0;
+}
+
 export function analyze(report) {
   // `null` = the report could not be read/parsed at all. Treated as empty, with
-  // no error signatures to show, so the caller still fails loudly.
+  // no error signatures to show, so the caller still fails loudly. `aborted` is
+  // false here on purpose: nothing was observed, so claiming an abort would name
+  // the wrong cause — `unreadable` already carries that verdict.
   if (!report) {
-    return { empty: true, testsTotal: 0, reportErrors: 0, signatures: [], unreadable: true };
+    return {
+      empty: true,
+      aborted: false,
+      partial: false,
+      testsTotal: 0,
+      reportErrors: 0,
+      signatures: [],
+      unreadable: true,
+    };
   }
   const total = testsTotal(report);
   const signatures = errorSignatures(report);
+  const didAbort = aborted(report);
   return {
     empty: total === 0,
+    aborted: didAbort,
+    // The #1058 gap, and the reason `empty` alone was not enough: SOME shards
+    // aborted while others ran. On run 30444299314 shards 1 and 2 died in the
+    // credentials preflight with zero tests while 3 and 4 executed 205 between
+    // them — so `stats` was non-empty, `empty` was false, every guard went green,
+    // and ~184 tests silently never ran behind a report that looked like an
+    // ordinary 10-failure day.
+    partial: didAbort && total > 0,
     testsTotal: total,
     reportErrors: (report.errors || []).length,
     signatures,
@@ -141,6 +179,16 @@ function main() {
     for (const sig of result.signatures.slice(0, 4)) {
       console.log(`[integrity]   ${displaySignature(sig)}`);
     }
+  } else if (result.partial) {
+    console.log(
+      `[integrity] PARTIAL run: ${result.testsTotal} test result(s), but ` +
+        `${result.reportErrors} top-level report error(s) — at least one shard ` +
+        `aborted before running its tests, so the recorded totals are ` +
+        `UNDER-COUNTED (#1058).`,
+    );
+    for (const sig of result.signatures.slice(0, 4)) {
+      console.log(`[integrity]   ${displaySignature(sig)}`);
+    }
   } else {
     console.log(
       `[integrity] ${result.testsTotal} test result(s) in ${reportPath}` +
@@ -153,6 +201,8 @@ function main() {
       process.env.GITHUB_OUTPUT,
       [
         `empty=${result.empty}`,
+        `aborted=${result.aborted}`,
+        `partial=${result.partial}`,
         `unreadable=${result.unreadable}`,
         `tests_total=${result.testsTotal}`,
         `report_errors=${result.reportErrors}`,

--- a/scripts/check-run-integrity.test.mjs
+++ b/scripts/check-run-integrity.test.mjs
@@ -85,13 +85,85 @@ test("a run that only SKIPPED is not empty — that is coverage erosion, not an 
   assert.equal(r.testsTotal, 42);
 });
 
-test("a report with errors but tests that still ran is not empty", () => {
+test("a report with errors but tests that still ran is not empty, but IS partial", () => {
   // A worker-level error can coexist with a run that produced results; only the
-  // absence of results makes a run empty.
+  // absence of results makes a run empty. This test used to stop there — and that
+  // was precisely the #1058 blind spot: `empty: false` was the only verdict, so a
+  // run where half the shards aborted read as clean. `partial` is the missing one.
   const r = analyze({ stats: { expected: 10, unexpected: 1, flaky: 0, skipped: 0 }, errors: [{ message: "boom" }] });
   assert.equal(r.empty, false);
+  assert.equal(r.aborted, true);
+  assert.equal(r.partial, true);
   assert.equal(r.reportErrors, 1);
   assert.deepEqual(r.signatures, ["boom"]);
+});
+
+test("the 2026-07-29 PARTIAL run is detected — some shards aborted, others ran", () => {
+  // Run 30444299314 (#1058), the case no guard caught. Shards 1 and 2 died in the
+  // credentials preflight with ZERO tests because `Collect models` never imported
+  // GOOGLE_API_KEY as a Langflow global variable; shards 3 and 4 executed 205
+  // tests between them against a ~380 baseline. `stats` was therefore non-empty,
+  // `empty` was false, shardguard saw 4/4 blobs, and ~184 tests silently never
+  // ran behind a report that rendered as an ordinary 10-failure day.
+  const partialRun = {
+    suites: [{ file: "a.spec.ts", specs: [] }],
+    errors: [
+      {
+        message:
+          "Error: [preflight] provider key(s) set in the environment but NOT configured as a " +
+          "Langflow global variable: GOOGLE_API_KEY. Specs resolve credentials from Langflow, " +
+          "not the env var, so they would fail with a misleading error",
+      },
+      {
+        message:
+          "Error: [preflight] provider key(s) set in the environment but NOT configured as a " +
+          "Langflow global variable: GOOGLE_API_KEY.",
+      },
+    ],
+    stats: { expected: 183, skipped: 12, unexpected: 10, flaky: 12, duration: 2_486_000 },
+  };
+
+  const r = analyze(partialRun);
+  assert.equal(r.empty, false, "tests DID run — this is not the #1012 empty case");
+  assert.equal(r.aborted, true);
+  assert.equal(r.partial, true, "the verdict that must gate the mutating steps");
+  assert.equal(r.reportErrors, 2, "one per aborted shard");
+  assert.match(r.signatures[0], /NOT configured as a\s+Langflow global variable: GOOGLE_API_KEY/);
+});
+
+test("a shard left empty by --pass-with-no-tests is NOT an abort", () => {
+  // The discriminator, measured against Playwright 1.58 blob reports rather than
+  // assumed. The workflow shards N ways over fewer files on purpose and passes
+  // `--pass-with-no-tests`, so a shard with nothing to run is routine. Such a
+  // shard emits NO top-level error (4 jsonl lines: metadata, configure, begin,
+  // end), while a shard that aborts in globalSetup emits one. Were `partial`
+  // inferred from a zero test count instead, every normal run with more shards
+  // than files would fail here.
+  const r = analyze({
+    suites: [{ file: "a.spec.ts", specs: [] }],
+    errors: [],
+    stats: { expected: 205, skipped: 0, unexpected: 0, flaky: 0 },
+  });
+  assert.equal(r.aborted, false);
+  assert.equal(r.partial, false);
+});
+
+test("a fully empty run is aborted but NOT partial — it stays the #1012 case", () => {
+  // Keeps the two verdicts from colliding: `partial` must mean "some ran, some
+  // did not", so the workflow can keep naming the two conditions separately
+  // (an infra abort of the whole run vs. an under-counted report).
+  const r = analyze(emptyRun);
+  assert.equal(r.empty, true);
+  assert.equal(r.aborted, true);
+  assert.equal(r.partial, false);
+});
+
+test("an unreadable report is not reported as an abort — that would name the wrong cause", () => {
+  const r = analyze(null);
+  assert.equal(r.unreadable, true);
+  assert.equal(r.empty, true);
+  assert.equal(r.aborted, false);
+  assert.equal(r.partial, false);
 });
 
 test("testsTotal tolerates a missing or partial stats block", () => {
@@ -181,13 +253,42 @@ test("the CLI writes its outputs even when its own path needs URL escaping", () 
   assert.equal(outputs.report_errors, "4");
   assert.match(outputs.first_error, /^Error: \[preflight\] Langflow backend/);
   // Exactly the documented keys — nothing injected by the report's error text.
+  // Every key here is read by a `steps.runguard.outputs.*` expression in
+  // daily-stable.yml, so this list is the guard's published contract: adding one
+  // without wiring it is dead weight, and removing one silently un-gates a
+  // mutating step (the `empty != 'false'` fail-closed idiom depends on the key
+  // existing at all).
   assert.deepEqual(Object.keys(outputs).sort(), [
+    "aborted",
     "empty",
     "first_error",
+    "partial",
     "report_errors",
     "tests_total",
     "unreadable",
   ]);
+});
+
+test("the CLI reports partial=true for a run where only some shards aborted", () => {
+  // End-to-end through the real entrypoint, not just analyze(): the workflow
+  // reads these as step outputs, so a verdict that never reaches $GITHUB_OUTPUT
+  // is a verdict the run cannot gate on.
+  const dir = mkdtempSync(join(tmpdir(), "run integrity partial "));
+  const reportPath = join(dir, "results.json");
+  writeFileSync(
+    reportPath,
+    JSON.stringify({
+      suites: [{ file: "a.spec.ts", specs: [] }],
+      errors: [{ message: "Error: [preflight] provider key(s) ... GOOGLE_API_KEY" }],
+      stats: { expected: 205, skipped: 0, unexpected: 10, flaky: 0 },
+    }),
+  );
+
+  const { outputs } = runCli({ reportPath, dir });
+  assert.equal(outputs.empty, "false", "tests ran — must not read as the #1012 empty case");
+  assert.equal(outputs.aborted, "true");
+  assert.equal(outputs.partial, "true");
+  assert.equal(outputs.tests_total, "215");
 });
 
 test("a missing report is reported as unreadable, not merely empty", () => {

--- a/tests/globalSetup.ts
+++ b/tests/globalSetup.ts
@@ -4,6 +4,12 @@ import {
 } from "@playwright/test";
 import * as dotenv from "dotenv";
 import { getAuthToken } from "./helpers/auth/get-auth-token";
+import {
+  degradeProviders,
+  providersForEnvKeys,
+  readProviderHealth,
+  writeProviderHealth,
+} from "./helpers/provider-setup/provider-health";
 
 dotenv.config();
 
@@ -146,7 +152,43 @@ async function checkProviderCredentials(ctx: APIRequestContext): Promise<void> {
     `(the daily-stable CI does this automatically).`;
 
   if (process.env.CI) {
-    throw new Error(message);
+    // Degrade the affected providers instead of aborting the shard (#1058).
+    //
+    // This used to `throw`, and that defeated the guarantee #980 exists to give:
+    // a red `Collect models` is deliberately non-fatal (`continue-on-error`) so a
+    // drained provider key cannot kill a day of testing — but `Collect models` is
+    // ALSO what imports the keys as Langflow global variables, so its failure made
+    // this gate fire and killed the shard anyway. On run 30444299314 shards 1 and 2
+    // died here over google alone, and ~184 tests that never touch google went
+    // unexecuted behind a report that read as an ordinary failure day.
+    //
+    // Recording the providers unusable routes them through the gate the suite
+    // already has (`provider-health.ts` → `test.skip` with the reason), so their
+    // specs skip and every other spec runs. The run is still marked: the annotation
+    // below surfaces in the job log, `Collect models` is already red, and the
+    // report's top-level errors no longer hide a whole shard (see the `partial`
+    // verdict in `scripts/check-run-integrity.mjs`).
+    const affected = providersForEnvKeys(missing);
+    const persisted = writeProviderHealth(
+      degradeProviders(
+        readProviderHealth(),
+        affected,
+        `${missing.join(", ")} is set in the environment but was never imported as a ` +
+          `Langflow global variable — \`Collect models\` did not complete. Specs read ` +
+          `credentials from Langflow, so a live call would fail with a misleading ` +
+          `node_duration/build timeout (#1058).`,
+      ),
+    );
+
+    console.error(`::error::${message}`);
+    console.error(
+      persisted
+        ? `[preflight] recorded ${affected.join(", ")} as inactive — their specs will SKIP; ` +
+            `the rest of the shard runs.`
+        : `[preflight] WARNING: could not persist provider health, so ${affected.join(", ")} ` +
+            `specs may attempt a live call against a key Langflow does not have.`,
+    );
+    return;
   }
   console.warn(`${message}\n(local run — warning only, not blocking.)`);
 }

--- a/tests/helpers/provider-setup/provider-health.test.ts
+++ b/tests/helpers/provider-setup/provider-health.test.ts
@@ -21,9 +21,12 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import {
+  degradeProviders,
+  providersForEnvKeys,
   readProviderHealth,
   toSkipGate,
   unavailableReason,
+  writeProviderHealth,
   type ProviderHealthRecord,
 } from "./provider-health";
 
@@ -243,4 +246,100 @@ test("readProviderHealth parses a real providers.json shape", () => {
   const records = readProviderHealth(file);
   assert.equal(records?.length, 3);
   assert.equal(records?.find((r) => r.provider === "google")?.status, "inactive");
+});
+
+// --- Pre-flight degradation (issue #1058) -----------------------------------
+//
+// What rides on these: the credentials pre-flight in globalSetup used to `throw`
+// in CI when a provider key was present in the env but missing as a Langflow
+// global variable, killing the entire shard over one provider. It now records the
+// provider unusable and lets the rest of the shard run. If that recording is
+// wrong in either direction the fix backfires — too permissive and the spec makes
+// a live call against a key Langflow does not have (the #1029 worker-kill class),
+// too aggressive and it erases the more actionable reason collect-models measured.
+
+test("providersForEnvKeys maps an env key back to its provider", () => {
+  assert.deepEqual(providersForEnvKeys(["GOOGLE_API_KEY"]), ["google"]);
+  assert.deepEqual(providersForEnvKeys(["OPENAI_API_KEY", "ANTHROPIC_API_KEY"]).sort(), [
+    "anthropic",
+    "openai",
+  ]);
+  assert.deepEqual(providersForEnvKeys(["NOT_A_PROVIDER_KEY"]), []);
+});
+
+test("degradeProviders marks an ACTIVE provider inactive with the given reason", () => {
+  const records: ProviderHealthRecord[] = [
+    { provider: "openai", model: "gpt-4o-mini", status: "active", error: null },
+    { provider: "google", model: "gemini-2.5-flash", status: "active", error: null },
+  ];
+
+  const out = degradeProviders(records, ["google"], "never imported");
+
+  assert.equal(out.find((r) => r.provider === "google")?.status, "inactive");
+  assert.equal(out.find((r) => r.provider === "google")?.error, "never imported");
+  assert.equal(out.find((r) => r.provider === "google")?.model, null);
+  // Untouched providers keep running — that is the whole point of the change.
+  assert.deepEqual(out.find((r) => r.provider === "openai"), records[0]);
+});
+
+test("degradeProviders NEVER overwrites an existing inactive reason", () => {
+  // collect-models measured WHY the key is dead ("monthly spending cap"), which is
+  // strictly more actionable for triage than the pre-flight's structural note.
+  const records: ProviderHealthRecord[] = [
+    { provider: "google", model: null, status: "inactive", error: SPEND_CAP },
+  ];
+
+  const out = degradeProviders(records, ["google"], "never imported");
+
+  assert.equal(out[0].error, SPEND_CAP);
+});
+
+test("degradeProviders creates a record for a provider that has none", () => {
+  // Absence means "no signal" to readProviderHealth and callers fail OPEN, so
+  // leaving it absent would let the specs run against a key Langflow lacks.
+  const out = degradeProviders(null, ["google"], "never imported");
+
+  assert.equal(out.length, 1);
+  assert.equal(out[0].provider, "google");
+  assert.equal(out[0].status, "inactive");
+});
+
+test("degradeProviders does not mutate its input", () => {
+  const records: ProviderHealthRecord[] = [
+    { provider: "google", model: "gemini-2.5-flash", status: "active", error: null },
+  ];
+  degradeProviders(records, ["google"], "never imported");
+  assert.equal(records[0].status, "active", "the caller's array must be untouched");
+});
+
+test("the degraded record drives the existing skip gate", () => {
+  // End-to-end through the gate the specs actually consult: degrading is only
+  // useful if unavailableReason then reports it.
+  const out = degradeProviders(
+    [{ provider: "google", model: "gemini-2.5-flash", status: "active", error: null }],
+    ["google"],
+    "GOOGLE_API_KEY was never imported as a Langflow global variable",
+  );
+
+  const reason = unavailableReason(["google"], out, { GOOGLE_API_KEY: "set" } as NodeJS.ProcessEnv);
+  assert.match(String(reason), /never imported as a Langflow global variable/);
+});
+
+test("writeProviderHealth round-trips through readProviderHealth", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "provider-health-"));
+  const file = path.join(dir, "nested", "providers.json");
+  const records = degradeProviders(null, ["google"], "never imported");
+
+  assert.equal(writeProviderHealth(records, file), true, "must create missing parent dirs");
+  assert.deepEqual(readProviderHealth(file), records);
+});
+
+test("writeProviderHealth reports failure instead of throwing", () => {
+  // It runs from globalSetup: a write failure must never become the reason the
+  // suite cannot start. The caller says so out loud instead of assuming success.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "provider-health-"));
+  const asDir = path.join(dir, "providers.json");
+  fs.mkdirSync(asDir); // a directory where the file should go — write must fail
+
+  assert.equal(writeProviderHealth([], asDir), false);
 });

--- a/tests/helpers/provider-setup/provider-health.ts
+++ b/tests/helpers/provider-setup/provider-health.ts
@@ -67,6 +67,78 @@ export function readProviderHealth(
 }
 
 /**
+ * The providers that own the given env keys — `["GOOGLE_API_KEY"]` → `["google"]`.
+ *
+ * Inverts `providerConfigMap.envKeys` rather than hardcoding the mapping, so a
+ * provider that grows a second required key is covered without editing this.
+ */
+export function providersForEnvKeys(envKeys: string[]): Provider[] {
+  const wanted = new Set(envKeys);
+  return (Object.keys(providerConfigMap) as Provider[]).filter((provider) =>
+    (providerConfigMap[provider]?.envKeys ?? []).some((key) => wanted.has(key)),
+  );
+}
+
+/**
+ * Marks the given providers `inactive`, returning a NEW record list (issue #1058).
+ *
+ * The credentials pre-flight used to `throw` in CI when a provider key was present
+ * in the environment but absent as a Langflow global variable — killing the whole
+ * shard over ONE provider. On run 30444299314 that cost ~184 tests that never
+ * touch google. Recording the provider as unusable instead routes it through the
+ * gate this module already owns: dependent specs `test.skip` with the reason, and
+ * every unrelated spec runs.
+ *
+ * An existing `inactive` record is NEVER overwritten: `collect-models` measured
+ * why the provider is dead ("credit balance too low", "monthly spending cap"), and
+ * that is strictly more actionable than the pre-flight's structural observation.
+ * A provider with no record at all gets one, because absence means "no signal" to
+ * `readProviderHealth` and callers fail OPEN — leaving it absent would let the
+ * specs run against a key Langflow does not have.
+ */
+export function degradeProviders(
+  records: ProviderHealthRecord[] | null,
+  providers: Provider[],
+  reason: string,
+): ProviderHealthRecord[] {
+  const existing = records ?? [];
+  const seen = new Map(existing.map((r) => [r.provider, r]));
+
+  for (const provider of providers) {
+    const record = seen.get(provider);
+    if (record?.status === "inactive") continue;
+    seen.set(provider, { provider, model: null, status: "inactive", error: reason });
+  }
+
+  // Preserve input order, then append providers that had no record at all.
+  const ordered = existing.map((r) => seen.get(r.provider) ?? r);
+  for (const [provider, record] of seen) {
+    if (!existing.some((r) => r.provider === provider)) ordered.push(record);
+  }
+  return ordered;
+}
+
+/**
+ * Persists provider health. Best-effort by design: this runs from `globalSetup`,
+ * where a write failure must not become the reason the suite cannot start — a
+ * failed write leaves the previous (or absent) signal, and `readProviderHealth`
+ * already fails open on absence. Returns whether the write landed so the caller
+ * can say so out loud instead of assuming.
+ */
+export function writeProviderHealth(
+  records: ProviderHealthRecord[],
+  jsonPath: string = PROVIDERS_PATH,
+): boolean {
+  try {
+    fs.mkdirSync(path.dirname(jsonPath), { recursive: true });
+    fs.writeFileSync(jsonPath, JSON.stringify(records, null, 2), "utf-8");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Pure decision function: the reason the given providers cannot serve a live
  * call, or `undefined` when every one of them is usable.
  *


### PR DESCRIPTION
**Closes #1058.**

## Problem

Two independent gates turned one dead provider key into ~184 silently unexecuted
tests, behind a report that read as an ordinary failure day.

`Collect models` is deliberately non-fatal (`continue-on-error`, #980) so a drained
provider key cannot kill a day of testing. But it is **also** what imports the keys
as Langflow global variables — so when it failed on run
[30444299314](https://github.com/oriontech-me/langflow-e2e/actions/runs/30444299314),
the credentials pre-flight in `globalSetup` found `GOOGLE_API_KEY` in the
environment and absent from Langflow, and threw:

```
Models found (google): []
❌ google (no model) — no models collected from the providers panel
Error: env-keyed provider(s) inactive for a NON-billing reason: google
   ↓  Collect models is red, but by design (#980) it does NOT abort the shard
Error: [preflight] provider key(s) set in the environment but NOT configured as a
  Langflow global variable: GOOGLE_API_KEY
   ↓
Run @stable tests (shard 1) → exit 1, zero tests executed
```

The #980 guarantee was defeated by a second gate downstream of it.

**Neither report guard noticed.** `shardguard` counts blob *files* and saw 4/4 (the
two empty ones uploaded fine, ~1.3 KB each). `runguard` reads the **merged** report,
and shards 3 and 4 had produced 205 results, so `empty` was `false`. #1012 closed
the case where the *whole run* executes zero tests; the **per-shard** case was
uncovered. Recorded totals were 205 against a ~380 baseline, and the umbrella
rendered a routine 10-failure triage.

## Detection: a `partial` verdict, read from the merged report

I started building per-shard artifacts and a zip parser, then measured first — and
found neither is needed. The aborted shard's top-level `errors` **survive**
`merge-reports`, and a top-level error is an *exact* signal. Measured against real
Playwright 1.58 blob reports for all three shapes the daily can produce:

| Shard | `report.jsonl` | `onProject` | top-level error | tests |
|---|---|---|---|---|
| ran its tests | 23 lines | ✓ | — | 2 |
| **aborted** in `globalSetup` | 5 lines | absent | **✓** | 0 |
| empty via `--pass-with-no-tests` | 4 lines | absent | — | 0 |

The third row is why this cannot be inferred from a zero test count: the workflow
shards N ways over fewer files on purpose, so an empty shard is routine. Inferring
from the count would fail every normal run with more shards than files.

`scripts/check-run-integrity.mjs` therefore gains two verdicts — `aborted` (some
shard never ran) and `partial` (`aborted && tests > 0`, the #1058 gap). `empty` is
untouched, so the six existing gates keep their exact semantics.

## Contract: degrade the provider, do not kill the shard

Per the investigation directive, the contract had to be *decided*. This takes the
second option: the pre-flight no longer throws in CI. It records the affected
providers `inactive` and returns, routing them through the skip gate the suite
already owns (`provider-health.ts` → `test.skip` quoting the reason). Their specs
skip; every unrelated spec runs. On a day like 2026-07-29 that is ~184 tests
recovered.

Chosen over "abort loudly and early" because it is what #980 already decided one
step upstream — a dead provider key must not kill specs that never touch it — and
because this is the third provider key to die this way in three weeks (#772 OpenAI,
Anthropic on 2026-07-28, Google now, key axis tracked on #976). The abort would
keep paying ~184 tests every time.

An existing `inactive` record is **never overwritten**: `collect-models` measured
*why* the key is dead ("monthly spending cap"), which is strictly more actionable
for triage than the pre-flight's structural observation. A provider with no record
at all gets one, because absence means "no signal" and callers fail OPEN.

## The run still tells the truth

Degrading alone would trade a loud abort for a silent skip, so `partial` gates the
two steps that act on the strength of the report:

- **`@stable` auto-removal** — a tag must not be judged by a report that never saw
  half the suite, and a spec cannot fail in a shard that never ran.
- **`spec-durations.json` refresh** — durations from a partial run would drop the
  dead shard's specs, mis-balancing the partitioner on stale data for every later
  daily.

The umbrella issue gets its own title (`… run was PARTIAL — a shard never ran …`)
and a section naming the under-count and the skipped steps, and the final gate
fails the scheduled run quoting the cause from the shard that died.

## Validation

| Gate | Result |
|---|---|
| `npm run test:scripts` | **126/126** (121 + 5 new) |
| `npm run test:units` | **92/92** (84 + 8 new) |
| `npm run typecheck` | clean |
| `npm run lint:ci` | exit 0 |
| `actionlint` | **3 findings before, 3 after** — same signatures, pre-existing |

Force-failed rather than assumed green: breaking the `partial` verdict fails 3
tests, and the test that used to *document* the blind spot ("a report with errors
but tests that still ran is not empty") now asserts `partial === true`. The
`#1058` fixture is the real run — 2 shards aborted in the credentials pre-flight,
205 results against a ~380 baseline. The final gate's shell was simulated for all
three cases and renders the right message; the umbrella `github-script` passes
`node --check`.

**Declared, not implied:** the four workflow gates are `event_name == 'schedule'`,
so **no manual dispatch can exercise them** — their proof is the next scheduled
run. What to watch there: with the degradation in place the #1058 cause should no
longer produce a zero-test shard at all; if any other cause does, the run must go
**red** with the `PARTIAL` title and the umbrella must state that auto-removal and
the duration refresh were skipped.

## Not addressed — by measurement, not omission

Directive 4 (state *which* specs went unexecuted) is left out: `config.shard` is
`null` in the merged report, so shard identity is not recoverable from it. Doing
this needs a different mechanism — the expected `@stable` list minus the files
observed in the report — with its own plumbing. Worth a follow-up rather than a
guess wired into this guard.

## Reproduce

```bash
# the guard's verdict matrix, including the #1058 fixture
node --test scripts/check-run-integrity.test.mjs        # 19 pass

# force the failure (proves the guard is not decorative)
sed -i '' 's|partial: didAbort && total > 0,|partial: false,|' scripts/check-run-integrity.mjs
node --test scripts/check-run-integrity.test.mjs        # expect 3 fail
git checkout scripts/check-run-integrity.mjs

# the degradation contract
npm run test:units                                      # 92 pass
node --require ts-node/register --test \
  tests/helpers/provider-setup/provider-health.test.ts  # 30 pass

npm run test:scripts && npm run typecheck && npm run lint:ci
actionlint .github/workflows/daily-stable.yml           # 3 pre-existing warnings
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
