### PR TITLE
fix(auth): retry auto_login across a bounded budget instead of dying on one timeout (#1086)

### DIFF
--- a/tests/helpers/auth/get-auth-token.test.ts
+++ b/tests/helpers/auth/get-auth-token.test.ts
@@ -1,0 +1,118 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { APIRequestContext } from "@playwright/test";
+import { getAuthToken, DEFAULT_RETRY_DELAYS_MS } from "./get-auth-token";
+
+/**
+ * The helper is called by 135 specs, and the daily's shared backend goes
+ * unresponsive mid-run (#1074/#1077) on a ~1-minute scale — long enough that
+ * every one of Playwright's test-level attempts died on `auto_login` for one
+ * target of daily #1057. These tests pin the contract that keeps that from
+ * killing an unrelated spec: a thrown request is retried across a bounded
+ * budget, a non-ok answer is not retried at all, and a budget that runs out
+ * surfaces the ORIGINAL error — never an empty token that would send the
+ * caller on unauthenticated (#1086).
+ */
+
+interface FakeResponse {
+  ok: () => boolean;
+  json: () => Promise<unknown>;
+}
+
+// Each entry is one scripted outcome for the next call: a response or a throw.
+function fakeRequest(outcomes: Array<FakeResponse | Error>): {
+  request: APIRequestContext;
+  calls: () => number;
+} {
+  let calls = 0;
+  const request = {
+    get: async () => {
+      const outcome = outcomes[Math.min(calls, outcomes.length - 1)];
+      calls++;
+      if (outcome instanceof Error) throw outcome;
+      return outcome;
+    },
+  } as unknown as APIRequestContext;
+  return { request, calls: () => calls };
+}
+
+const okResponse = (token: string): FakeResponse => ({
+  ok: () => true,
+  json: async () => ({ access_token: token }),
+});
+
+const timeout = () =>
+  new Error("apiRequestContext.get: Timeout 20000ms exceeded.\n  - → GET /api/v1/auto_login");
+
+test("returns the Bearer header on the first successful call", async () => {
+  const { request, calls } = fakeRequest([okResponse("abc")]);
+  assert.equal(await getAuthToken(request), "Bearer abc");
+  assert.equal(calls(), 1);
+});
+
+test("a non-ok response still yields the empty-token fallback, with no retry", async () => {
+  // An environment without auth answers 401/403 immediately — that is not an
+  // outage, so retrying it would only slow every caller down. The budget is
+  // deliberately NON-empty here: with `[]` the assertion would hold even if
+  // the helper retried answered responses, and the check would prove nothing.
+  const { request, calls } = fakeRequest([{ ok: () => false, json: async () => ({}) }]);
+  assert.equal(await getAuthToken(request, { retryDelaysMs: [0, 0, 0] }), "");
+  assert.equal(calls(), 1, "an answered request must not consume the retry budget");
+});
+
+test("an ok response without a token yields the empty-token fallback, with no retry", async () => {
+  const { request, calls } = fakeRequest([{ ok: () => true, json: async () => ({}) }]);
+  assert.equal(await getAuthToken(request, { retryDelaysMs: [0, 0, 0] }), "");
+  assert.equal(calls(), 1);
+});
+
+test("survives a worker recycle: one throw, then the token", async () => {
+  const { request, calls } = fakeRequest([timeout(), okResponse("xyz")]);
+  assert.equal(await getAuthToken(request, { retryDelaysMs: [0] }), "Bearer xyz");
+  assert.equal(calls(), 2);
+});
+
+test("keeps retrying across the whole budget — the outage outlasts one attempt", async () => {
+  // Daily #1057's shape: the first attempts find nothing, a later one lands
+  // after the backend is back. A single retry would have failed here.
+  const { request, calls } = fakeRequest([timeout(), timeout(), okResponse("late")]);
+  assert.equal(await getAuthToken(request, { retryDelaysMs: [0, 0, 0] }), "Bearer late");
+  assert.equal(calls(), 3);
+});
+
+test("a backend that never comes back rethrows the ORIGINAL error, never an empty token", async () => {
+  const { request, calls } = fakeRequest([timeout(), timeout()]);
+  await assert.rejects(
+    () => getAuthToken(request, { retryDelaysMs: [0] }),
+    /Timeout 20000ms exceeded/,
+  );
+  // An empty token here would send 135 specs on unauthenticated and surface as
+  // a far worse failure than the timeout it replaced.
+  assert.equal(calls(), 2);
+});
+
+test("the budget is bounded — it gives up instead of looping forever", async () => {
+  const { request, calls } = fakeRequest([timeout()]);
+  await assert.rejects(() => getAuthToken(request, { retryDelaysMs: [0, 0, 0] }));
+  assert.equal(calls(), 4, "one initial attempt plus one per configured delay");
+});
+
+test("waits between attempts so a booting worker is not hammered", async () => {
+  const { request } = fakeRequest([timeout(), okResponse("slow")]);
+  const started = Date.now();
+  assert.equal(await getAuthToken(request, { retryDelaysMs: [50] }), "Bearer slow");
+  assert.ok(Date.now() - started >= 50, "expected the helper to wait before retrying");
+});
+
+test("the default budget spans the observed ~1-minute outage", async () => {
+  // Guards the sizing decision itself: shrinking the default back to a single
+  // short retry would silently reintroduce the #1086 failures. Asserted on the
+  // module's own default, with no injected override.
+  const { request, calls } = fakeRequest([timeout(), timeout(), timeout(), okResponse("late")]);
+  const budgetMs = DEFAULT_RETRY_DELAYS_MS.reduce((a, b) => a + b, 0);
+  assert.ok(budgetMs >= 25000, `default backoff sums to ${budgetMs}ms — too short for the observed outage`);
+  assert.equal(DEFAULT_RETRY_DELAYS_MS.length, 3);
+  // …and the helper really uses one attempt per configured delay.
+  assert.equal(await getAuthToken(request, { retryDelaysMs: [0, 0, 0] }), "Bearer late");
+  assert.equal(calls(), 4);
+});

--- a/tests/helpers/auth/get-auth-token.ts
+++ b/tests/helpers/auth/get-auth-token.ts
@@ -1,20 +1,72 @@
 import type { APIRequestContext } from "@playwright/test";
 
 /**
+ * Retry budget, sized from what the failures actually look like — not from
+ * what a worker recycle costs in isolation.
+ *
+ * A recycle alone is ~15-20 s (the container log times a full Langflow boot at
+ * ~18 s, 11 s of it the component registry). But on daily #1057 and on both CI
+ * runs of #1080 the outage outlasted that: `auto_login` died on every one of
+ * Playwright's three test-level attempts for one target, while a sibling spec
+ * recovered on its third — i.e. the backend came back on a ~1-minute scale,
+ * not a ~20-second one. A single short retry would not have changed any of
+ * those results, so the budget spans the observed window instead.
+ *
+ * Backoff, not a tight loop: a wedged backend must not be hammered, and each
+ * attempt already carries its own request timeout (~20 s under the suite's
+ * `actionTimeout`), so the wall-clock span is roughly the delays plus those.
+ * Cost when the backend is genuinely dead: this budget, once, then the error.
+ * Relieving the wedge itself remains #1077 — this only survives it.
+ */
+export const DEFAULT_RETRY_DELAYS_MS = [2000, 8000, 20000];
+
+export interface GetAuthTokenOptions {
+  /** Override the backoff. Tests pass `[]` or short delays; callers should not set it. */
+  retryDelaysMs?: number[];
+}
+
+/**
  * Retrieves a Langflow authentication token.
  * In auto_login mode (default), uses /api/v1/auto_login.
  * Returns the Authorization header ready for use.
+ *
+ * A request that THROWS (the shared backend recycling its worker mid-run, so
+ * the call never answers and Playwright kills it at its timeout) is retried
+ * within the budget above. A request that ANSWERS non-ok is not: that is an
+ * environment without auth, not an outage, and retrying it would slow every
+ * caller down.
+ *
+ * Every retry is logged. The wedge stays visible in the run output — the point
+ * is to survive it, never to hide it.
+ *
+ * If the budget runs out, the original error propagates. It must never degrade
+ * into the empty-token fallback: the callers would carry on unauthenticated
+ * and fail somewhere far less diagnosable (#1086).
  */
-export async function getAuthToken(request: APIRequestContext): Promise<string> {
-  const res = await request.get("/api/v1/auto_login");
+export async function getAuthToken(
+  request: APIRequestContext,
+  { retryDelaysMs = DEFAULT_RETRY_DELAYS_MS }: GetAuthTokenOptions = {},
+): Promise<string> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      const res = await request.get("/api/v1/auto_login");
 
-  if (res.ok()) {
-    const body = await res.json();
-    if (body?.access_token) {
-      return `Bearer ${body.access_token}`;
+      if (res.ok()) {
+        const body = await res.json();
+        if (body?.access_token) {
+          return `Bearer ${body.access_token}`;
+        }
+      }
+
+      // fallback: no token (environment without auth)
+      return "";
+    } catch (error) {
+      if (attempt >= retryDelaysMs.length) throw error;
+      const delay = retryDelaysMs[attempt];
+      console.warn(
+        `⚠️  auth: /api/v1/auto_login did not answer (${(error as Error)?.message?.split("\n")[0] ?? error}) — retry ${attempt + 1}/${retryDelaysMs.length} in ${delay}ms. The backend is wedged or recycling (see #1077).`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, delay));
     }
   }
-
-  // fallback: no token (environment without auth)
-  return "";
 }


### PR DESCRIPTION
**Closes #1086.** Sibling of #1077 from the client side: that issue **relieves** the mid-run wedge, this one **survives** it.

## Problem

`getAuthToken` made exactly one attempt, and its `return ""` fallback only covers a **non-ok response**. A request that never answers **throws** — which is precisely what the shared backend produces while gunicorn recycles its wedged single worker (7–10× per shard, measured by #1074). Playwright kills it at the suite's `actionTimeout` (20 s, `playwright.config.ts`):

```
TimeoutError: apiRequestContext.get: Timeout 20000ms exceeded.
  - → GET http://localhost:7860/api/v1/auto_login
```

**144 files / 135 specs** call this helper, so any of them can be killed by an event that has nothing to do with what it tests:

| Where | What happened |
|---|---|
| Daily #1057 | `agent-context-id-isolation` on `google / gemini-2.5-flash` — 3 attempts, all dead in `getAuthToken` inside `SimpleAgentTemplatePage.load`; the test body never ran, and triage recorded it as signature `unknown` |
| PR #1080, both CI runs | Same target, same death, twice. Zero failures of the behaviour under test — the PR merged with a written justification because the gate could not go green |
| Local, 2026-07-29 | 3 aborts across ~24 runs on nightly `1.12.0.dev8`/`dev9` |

## Fix

A thrown request is retried on a **2 s / 8 s / 20 s** backoff (`DEFAULT_RETRY_DELAYS_MS`, exported so a test can assert the sizing). An answered non-ok response is **not** retried — that is an environment without auth, not an outage, and retrying it would slow every caller down.

**Why this budget and not the one the issue proposed.** The issue asked for a single bounded retry, sized against a worker recycle (~15–20 s: the container log times a full boot at ~18 s, 11 s of it the component registry). Working it showed that shape would not have flipped a single observed failure — in the runs above, *every* test-level attempt died on `auto_login` while a sibling spec recovered on its third, i.e. the backend was returning on a ~1-minute scale. The budget spans what was measured, not what is convenient. Recorded here rather than quietly shipped.

**It does not hide the wedge.** Every retry logs:

```
⚠️  auth: /api/v1/auto_login did not answer (apiRequestContext.get: socket hang up) — retry 1/3 in 2000ms. The backend is wedged or recycling (see #1077).
```

**Budget exhausted rethrows the ORIGINAL error.** It must never degrade into the empty-token fallback — the callers would carry on unauthenticated and fail somewhere far less diagnosable.

## Validation

**Live, against a real outage** — the helper called while the container restarted:

```
⚠️  auth: … socket hang up — retry 1/3 in 2000ms
⚠️  auth: … socket hang up — retry 2/3 in 8000ms
RESULT: token=Bearer eyJhbGciOiJ… after 15s
```

The old code threw on the first hang.

**Unit tests** — `tests/helpers/auth/get-auth-token.test.ts`, 9 cases, `npm run test:units`:

| # | Test | Pins |
|---|---|---|
| 1 | first call succeeds | happy path unchanged, 1 call |
| 2 | non-ok → `""`, no retry | asserted with a NON-empty budget, so it actually proves the answered path never consumes it |
| 3 | ok without token → `""`, no retry | same |
| 4 | one throw, then the token | recycle survived |
| 5 | throws until the third attempt | daily #1057's shape |
| 6 | budget exhausted | `assert.rejects(/Timeout 20000ms/)` — never `""` |
| 7 | bounded | one initial attempt + one per delay = 4, no infinite loop |
| 8 | waits between attempts | backoff really sleeps |
| 9 | default budget ≥ 25 s over 3 attempts | guards the sizing decision itself |

**Force-fail — 4 mutations, all executed, all reverted (`grep FF-MUTATION` → 0), green after:**

- `M1` no retry at all → **6 failed**
- `M2` exhaustion returns `""` instead of rethrowing → **2 failed**
- `M3` default shrunk to `[2000]` → **1 failed** (case 9 earns its place)
- `M4` retry answered non-ok responses too → **passed 9/9 at first.** The hole was in my own case 2, which disabled the budget and so proved nothing; hardened, it now **fails 2**. Worth stating plainly: the force-fail found this, review did not.

**Gates:** `npm run test:units` → 123 passed / 0 failed · `npm run typecheck` ✅ · `npm run lint` exit 0 (0 errors) · 19 API specs that exercise the helper green · `agent-context-id-isolation` (the #1060 spec) 2/2 green in 31 s.

## Still exposed (not in this issue's scope)

Three specs call `/api/v1/auto_login` directly instead of going through the helper, and keep the old single-attempt behaviour: `api-key-expiry-enforcement.spec.ts:26`, `api-custom-component-creation.spec.ts:23`, `api-keys-timezone-display.spec.ts:40`. Worth a follow-up; deliberately untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
