### PR TITLE
fix(ui-ux): adopt the canvas-controls postcondition at every site (#1053)

### DIFF
--- a/tests/helpers/filesystem/upload-file.ts
+++ b/tests/helpers/filesystem/upload-file.ts
@@ -4,6 +4,7 @@ import { expect } from "../../fixtures/fixtures";
 import { generateRandomFilename } from "./generate-filename";
 import { resolveAssetPath } from "./resolve-asset-path";
 import { unselectNodes } from "../ui/unselect-nodes";
+import { adjustScreenView } from "../ui/adjust-screen-view";
 
 // Function to get the correct mimeType based on file extension
 function getMimeType(extension: string): string {
@@ -33,13 +34,19 @@ function getMimeType(extension: string): string {
 }
 
 export async function uploadFile(page: Page, fileName: string) {
+  // Kept ahead of `adjustScreenView` (whose own canvas gate is 30 s) so the
+  // generous budget this helper has always had for the canvas to mount is not
+  // silently cut for the file-upload specs.
   await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
     timeout: 100000,
   });
 
-  await page.getByTestId("canvas_controls_dropdown").click();
-  await page.getByTestId("fit_view").click();
-  await page.getByTestId("canvas_controls_dropdown").click({ force: true });
+  // Was three hand-rolled lines doing open → fit_view → toggle-closed, which is
+  // exactly this call. The toggle was UNCONDITIONAL, so a menu left open by a
+  // sibling helper made the first click CLOSE it, `fit_view` vanish, and this
+  // helper die on a click timeout (#1053). No zoom-out: the previous code never
+  // zoomed either.
+  await adjustScreenView(page, { numberOfZoomOut: 0 });
 
   try {
     await page

--- a/tests/helpers/ui/adjust-screen-view.test.ts
+++ b/tests/helpers/ui/adjust-screen-view.test.ts
@@ -1,175 +1,21 @@
-// Unit tests for adjustScreenView (issue #997).
+// Unit tests for adjustScreenView (issues #997, #1053).
 // Run with: npm run test:units
 //
 // Why this helper is unit-tested at all: 61 spec files call it directly and
 // another 47 reach it through `setupPlayground`, `initialGPTsetup`,
 // `prompt-template` and `SimpleAgentTemplatePage` — 108 in total, most of the
 // indirect half in `llm-agents/` and `playground/`, where a canvas interceptor
-// reads as an agent or provider failure. And the branch that used to be wrong is
-// one the CURRENT UI cannot produce. On Nightly
-// 1.12.0.dev7 every canvas control (`fit_view`, `zoom_out`, ...) is rendered
-// inside the dropdown's menu content, so `fit_view` is present if and only if
-// the menu is open — which is exactly why the pre-#997 bug was dormant. No E2E
-// spec can reach the failing path until Langflow surfaces the fit-view control
-// directly on the canvas, at which point every dependent spec would start
-// leaving an open canvas-controls menu behind: a documented click interceptor
-// for the next canvas action (#576), arriving as a suite-wide break with a
-// confusing signature.
+// reads as an agent or provider failure.
 //
-// So the widget is simulated here instead: a toggling trigger plus a switchable
-// layout, which lets both today's DOM and the hypothetical one be asserted.
-// The simulated contract was verified live against Nightly 1.12.0.dev7:
-//   - `canvas_controls_dropdown` carries Radix's data-state="open"|"closed";
-//   - `fit_view` count is 0 with the menu closed, 1 with it open;
-//   - clicking `fit_view` leaves the menu open (the zoom-out loop needs that);
-//   - `fitView()` is not animated — the viewport transform settles in a frame.
+// The simulated widget, and why the failing branch is unreachable from any E2E
+// spec, are documented in `./canvas-controls.fake`. The menu-open/close mechanism
+// itself is covered in `./canvas-controls.test.ts`; what is asserted here is this
+// helper's own behaviour on top of it — the fit-view step, the settle poll, the
+// zoom-out loop, and the partial-migration refusal.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import type { Page } from "@playwright/test";
 import { adjustScreenView } from "./adjust-screen-view";
-
-type Layout =
-  /** Today's build: every canvas control lives inside the dropdown menu. */
-  | "in-dropdown"
-  /** Hypothetical build: every canvas control sits directly on the canvas. */
-  | "on-canvas"
-  /** Hypothetical build, partial migration: only fit-view moved out. */
-  | "fit-view-on-canvas";
-
-interface FakeOptions {
-  layout?: Layout;
-  menuOpen?: boolean;
-  /** Set false to simulate a build whose trigger has no `data-state`. */
-  exposesDataState?: boolean;
-  zoomOutDisabled?: boolean;
-  /**
-   * Successive `.react-flow__viewport` style reads. The last entry repeats
-   * forever, so a single-element array models an already-settled viewport.
-   */
-  viewportStyles?: string[];
-}
-
-interface FakeCanvas {
-  page: Page;
-  readonly menuOpen: boolean;
-  readonly triggerClicks: number;
-  readonly fitViewClicks: number;
-  readonly zoomOutClicks: number;
-  readonly viewportReads: number;
-}
-
-function fakeCanvas({
-  layout = "in-dropdown",
-  menuOpen = false,
-  exposesDataState = true,
-  zoomOutDisabled = false,
-  viewportStyles = ["transform: scale(1);"],
-}: FakeOptions = {}): FakeCanvas {
-  const state = {
-    menuOpen,
-    triggerClicks: 0,
-    fitViewClicks: 0,
-    zoomOutClicks: 0,
-    viewportReads: 0,
-  };
-
-  // A control is reachable while the menu is open, or once its own build has
-  // moved it onto the canvas.
-  const onCanvas = (testId: string) =>
-    layout === "on-canvas" ||
-    (layout === "fit-view-on-canvas" && testId === "fit_view");
-
-  const controlCount = (testId: string) =>
-    testId === "canvas_controls_dropdown" ||
-    onCanvas(testId) ||
-    state.menuOpen
-      ? 1
-      : 0;
-
-  // Playwright's locator methods do not resolve against a missing element: they
-  // reject once the timeout expires. Modelling that is what keeps the fake from
-  // flattering the helper — an `isDisabled` that quietly answers for an element
-  // that is not there would hide the partial-migration case entirely.
-  const requireRendered = (testId: string, method: string) => {
-    if (controlCount(testId) === 0) {
-      throw new Error(
-        `locator.${method}: Timeout 1000ms exceeded — ${testId} is not rendered`,
-      );
-    }
-  };
-
-  const locator = (testId: string) => ({
-    count: async () => controlCount(testId),
-    click: async () => {
-      if (testId === "canvas_controls_dropdown") {
-        state.triggerClicks += 1;
-        state.menuOpen = !state.menuOpen;
-        return;
-      }
-      // Clicking a control must not dismiss the menu — these are plain buttons,
-      // not Radix menu items (verified against the running nightly).
-      requireRendered(testId, "click");
-      if (testId === "fit_view") state.fitViewClicks += 1;
-      if (testId === "zoom_out") state.zoomOutClicks += 1;
-    },
-    getAttribute: async (name: string) => {
-      if (testId !== "canvas_controls_dropdown" || name !== "data-state") {
-        return null;
-      }
-      if (!exposesDataState) return null;
-      return state.menuOpen ? "open" : "closed";
-    },
-    isDisabled: async () => {
-      requireRendered(testId, "isDisabled");
-      return zoomOutDisabled;
-    },
-  });
-
-  const page = {
-    waitForSelector: async () => undefined,
-    waitForTimeout: async () => undefined,
-    getByTestId: (testId: string) => locator(testId),
-    // The selector is CHECKED, not ignored. A fake that answers for any argument
-    // would pass every test here with a typo in `.react-flow__viewport`, while in
-    // production every read rejects and the settle loop silently burns its whole
-    // budget — i.e. the 500 ms sleep this helper replaced, at full price. Same
-    // class as `requireRendered` above: the fake must not flatter the helper.
-    locator: (selector: string) => ({
-      getAttribute: async () => {
-        if (selector !== ".react-flow__viewport") {
-          throw new Error(
-            `locator.getAttribute: Timeout 200ms exceeded — no element matches ${selector}`,
-          );
-        }
-        const style =
-          viewportStyles[
-            Math.min(state.viewportReads, viewportStyles.length - 1)
-          ];
-        state.viewportReads += 1;
-        return style;
-      },
-    }),
-  } as unknown as Page;
-
-  return {
-    page,
-    get menuOpen() {
-      return state.menuOpen;
-    },
-    get triggerClicks() {
-      return state.triggerClicks;
-    },
-    get fitViewClicks() {
-      return state.fitViewClicks;
-    },
-    get zoomOutClicks() {
-      return state.zoomOutClicks;
-    },
-    get viewportReads() {
-      return state.viewportReads;
-    },
-  };
-}
+import { captureWarnings, fakeCanvas } from "./canvas-controls.fake";
 
 test("opens the menu when the controls are hidden, and closes it again", async () => {
   const canvas = fakeCanvas({ layout: "in-dropdown", menuOpen: false });
@@ -209,28 +55,6 @@ test("never opens the menu when fit-view is reachable on the canvas", async () =
   assert.equal(canvas.menuOpen, false);
 });
 
-/**
- * Runs `fn` with `console.warn` captured, returning what it emitted.
- *
- * The fallback below is the one branch whose CORRECTNESS cannot be asserted —
- * it is the behaviour #997 rejected, kept only because it can never open a menu.
- * So what gets pinned instead is that it announces itself: the warning is the
- * only signal that the helper stopped reading the real open/closed state.
- */
-async function captureWarnings(fn: () => Promise<void>): Promise<string[]> {
-  const original = console.warn;
-  const warnings: string[] = [];
-  console.warn = (...args: unknown[]) => {
-    warnings.push(args.map(String).join(" "));
-  };
-  try {
-    await fn();
-  } finally {
-    console.warn = original;
-  }
-  return warnings;
-}
-
 test("falls back to intent when the trigger exposes no data-state, and says so", async () => {
   const opened = fakeCanvas({
     layout: "in-dropdown",
@@ -244,7 +68,11 @@ test("falls back to intent when the trigger exposes no data-state, and says so",
   // Degrading into #997's boolean must never be silent: no other test can catch
   // it, because this very test asserts the fallback as acceptable behaviour.
   assert.equal(warnings.length, 1, JSON.stringify(warnings));
-  assert.match(warnings[0], /adjustScreenView/);
+  assert.match(
+    warnings[0],
+    /adjustScreenView/,
+    "the warning must name the caller — four helpers share this code (#1053)",
+  );
   assert.match(warnings[0], /data-state/);
   assert.match(warnings[0], /#997/);
 
@@ -291,6 +119,8 @@ test("throws, naming the cause, on a partial layout migration", async () => {
 });
 
 test("skips the zoom-out reachability check when no zoom-out was asked for", async () => {
+  // Also the shape `uploadFile` now calls (#1053): fit the view, zoom nothing,
+  // leave the menu closed.
   const canvas = fakeCanvas({
     layout: "fit-view-on-canvas",
     menuOpen: false,

--- a/tests/helpers/ui/adjust-screen-view.ts
+++ b/tests/helpers/ui/adjust-screen-view.ts
@@ -1,6 +1,10 @@
 import type { Page } from "@playwright/test";
+import {
+  CANVAS_CONTROLS,
+  closeCanvasControls,
+  openCanvasControls,
+} from "./canvas-controls";
 
-const CONTROLS = "canvas_controls_dropdown";
 const FIT_VIEW = "fit_view";
 const ZOOM_OUT = "zoom_out";
 const VIEWPORT = ".react-flow__viewport";
@@ -52,54 +56,6 @@ async function waitForViewportSettled(page: Page): Promise<void> {
 }
 
 /**
- * Leaves the canvas-controls menu CLOSED — whoever opened it.
- *
- * The postcondition is what the callers need, and it is deliberately not
- * expressed as a toggle. An open canvas-controls menu is a documented click
- * interceptor for the next canvas action (#576), so "close it if it is open"
- * is correct on every path; "click the trigger again" is only correct while
- * the menu happens to be open, and silently *opens* one otherwise.
- *
- * Radix renders the trigger with `data-state="open" | "closed"` (verified on
- * Nightly 1.12.0.dev7), which answers the question directly. If that attribute
- * ever disappears we fall back to intent — close only what this call opened —
- * which is still safe: it can leave a pre-existing menu open, but it can never
- * open one.
- *
- * That fallback is ANNOUNCED rather than silent, and the warning is the point.
- * "Close only what this call opened" is precisely the fix #997 proposed and this
- * helper rejects, so degrading into it un-fixes the already-open case (#576's
- * leftover interceptor) — and no test can catch that, because the unit test for
- * this branch asserts the fallback as correct behaviour. If the attribute moves
- * off the element carrying the testid, the only signal will be this line.
- */
-async function closeCanvasControls(
-  page: Page,
-  openedByThisCall: boolean,
-): Promise<void> {
-  const controls = page.getByTestId(CONTROLS);
-  const state = await controls
-    .getAttribute("data-state", { timeout: 1000 })
-    .catch(() => null);
-
-  if (state === null) {
-    console.warn(
-      `⚠️  [adjustScreenView] "${CONTROLS}" exposed no \`data-state\` — falling ` +
-        `back to closing only what this call opened. A menu that was ALREADY ` +
-        `open stays open and will intercept the next canvas click (#576). This ` +
-        `is the behaviour #997 rejected: find where Radix now carries the ` +
-        `open/closed state and read it there.`,
-    );
-  }
-
-  const isOpen = state === null ? openedByThisCall : state === "open";
-
-  if (isOpen) {
-    await controls.click({ force: true, timeout: 1000 });
-  }
-}
-
-/**
  * Fits the canvas to the flow, optionally zooms out, and returns with the
  * canvas-controls menu closed.
  *
@@ -112,7 +68,7 @@ async function closeCanvasControls(
  * That layout is a property of the current UI, not a contract: the day Langflow
  * surfaces the fit-view control directly on the canvas, `fit_view` is present
  * with the menu closed. This helper must not open a menu in that case — see
- * `closeCanvasControls` and issue #997.
+ * `./canvas-controls` and issue #997.
  *
  * What it deliberately does NOT do is survive a *partial* migration — fit-view
  * moved out, zoom-out left behind. Zooming out would then need a menu this call
@@ -129,20 +85,11 @@ export async function adjustScreenView(
     numberOfZoomOut?: number;
   } = {},
 ) {
-  await page.waitForSelector(`[data-testid="${CONTROLS}"]`, {
+  await page.waitForSelector(`[data-testid="${CANVAS_CONTROLS}"]`, {
     timeout: 30000,
   });
 
-  // Tracked separately from the `fit_view` probe below: they coincide today,
-  // but only because opening immediately follows the probe. `closeCanvasControls`
-  // asks "did THIS call open the menu", and that question must keep its own
-  // answer if anything is ever inserted between the two.
-  let openedByThisCall = false;
-
-  if ((await page.getByTestId(FIT_VIEW).count()) === 0) {
-    await page.getByTestId(CONTROLS).click();
-    openedByThisCall = true;
-  }
+  const openedByThisCall = await openCanvasControls(page, FIT_VIEW);
 
   await page.getByTestId(FIT_VIEW).click();
   await waitForViewportSettled(page);
@@ -156,9 +103,9 @@ export async function adjustScreenView(
     throw new Error(
       `[adjustScreenView] "${ZOOM_OUT}" is not rendered. On the build this ` +
         `helper was written against, the canvas controls live inside the ` +
-        `"${CONTROLS}" menu, so this means "${FIT_VIEW}" was reachable with ` +
-        `that menu closed — a Langflow layout change (#997). Zooming out needs ` +
-        `the menu open; teach this helper how the new layout exposes the ` +
+        `"${CANVAS_CONTROLS}" menu, so this means "${FIT_VIEW}" was reachable ` +
+        `with that menu closed — a Langflow layout change (#997). Zooming out ` +
+        `needs the menu open; teach this helper how the new layout exposes the ` +
         `controls rather than reintroducing a blind toggle.`,
     );
   }
@@ -173,5 +120,5 @@ export async function adjustScreenView(
     }
   }
 
-  await closeCanvasControls(page, openedByThisCall);
+  await closeCanvasControls(page, openedByThisCall, "adjustScreenView");
 }

--- a/tests/helpers/ui/canvas-controls.fake.ts
+++ b/tests/helpers/ui/canvas-controls.fake.ts
@@ -1,0 +1,208 @@
+// A simulated canvas-controls widget, shared by the unit tests of every helper
+// that drives it: `canvas-controls`, `adjust-screen-view` and `zoom-out`.
+//
+// NOT a test file — it defines no `test()`. `npm run test:units` collects
+// `*.test.ts` only and Playwright's `testMatch` is `*.spec.ts`, so this file is
+// imported by tests and never executed as one.
+//
+// Why the widget is simulated at all: the branch that was wrong in all four call
+// sites (#997, #1053) is one the CURRENT UI cannot produce. On Nightly
+// 1.12.0.dev7 every canvas control (`fit_view`, `zoom_out`, ...) is rendered
+// inside the dropdown's menu content, so a control is present if and only if the
+// menu is open — which is exactly why the bug was dormant. No E2E spec can reach
+// the failing path until Langflow surfaces those controls directly on the canvas,
+// at which point every dependent spec would start leaving an open
+// canvas-controls menu behind: a documented click interceptor for the next canvas
+// action (#576), arriving as a suite-wide break with a confusing signature.
+//
+// So a toggling trigger plus a switchable layout is modelled here, which lets
+// both today's DOM and the hypothetical one be asserted. The simulated contract
+// was verified live against Nightly 1.12.0.dev7:
+//   - `canvas_controls_dropdown` carries Radix's data-state="open"|"closed";
+//   - `fit_view` count is 0 with the menu closed, 1 with it open;
+//   - clicking `fit_view` leaves the menu open (the zoom-out loop needs that);
+//   - `fitView()` is not animated — the viewport transform settles in a frame.
+import type { Page } from "@playwright/test";
+
+export type Layout =
+  /** Today's build: every canvas control lives inside the dropdown menu. */
+  | "in-dropdown"
+  /** Hypothetical build: every canvas control sits directly on the canvas. */
+  | "on-canvas"
+  /** Hypothetical build, partial migration: only fit-view moved out. */
+  | "fit-view-on-canvas";
+
+export interface FakeOptions {
+  layout?: Layout;
+  menuOpen?: boolean;
+  /** Set false to simulate a build whose trigger has no `data-state`. */
+  exposesDataState?: boolean;
+  zoomOutDisabled?: boolean;
+  /**
+   * Controls that are never rendered, whatever the layout or menu state —
+   * a renamed or removed testid. Models the one case where opening the menu
+   * does not make the requested control reachable.
+   */
+  missingControls?: string[];
+  /**
+   * Successive `.react-flow__viewport` style reads. The last entry repeats
+   * forever, so a single-element array models an already-settled viewport.
+   */
+  viewportStyles?: string[];
+}
+
+export interface FakeCanvas {
+  page: Page;
+  readonly menuOpen: boolean;
+  readonly triggerClicks: number;
+  readonly fitViewClicks: number;
+  readonly zoomOutClicks: number;
+  readonly viewportReads: number;
+}
+
+export function fakeCanvas({
+  layout = "in-dropdown",
+  menuOpen = false,
+  exposesDataState = true,
+  zoomOutDisabled = false,
+  missingControls = [],
+  viewportStyles = ["transform: scale(1);"],
+}: FakeOptions = {}): FakeCanvas {
+  const state = {
+    menuOpen,
+    triggerClicks: 0,
+    fitViewClicks: 0,
+    zoomOutClicks: 0,
+    viewportReads: 0,
+  };
+
+  // A control is reachable while the menu is open, or once its own build has
+  // moved it onto the canvas.
+  const onCanvas = (testId: string) =>
+    layout === "on-canvas" ||
+    (layout === "fit-view-on-canvas" && testId === "fit_view");
+
+  const controlCount = (testId: string) => {
+    if (missingControls.includes(testId)) return 0;
+    return testId === "canvas_controls_dropdown" ||
+      onCanvas(testId) ||
+      state.menuOpen
+      ? 1
+      : 0;
+  };
+
+  // Playwright's locator methods do not resolve against a missing element: they
+  // reject once the timeout expires. Modelling that is what keeps the fake from
+  // flattering the helpers — an `isDisabled` that quietly answers for an element
+  // that is not there would hide the partial-migration case entirely.
+  const requireRendered = (testId: string, method: string) => {
+    if (controlCount(testId) === 0) {
+      throw new Error(
+        `locator.${method}: Timeout 1000ms exceeded — ${testId} is not rendered`,
+      );
+    }
+  };
+
+  const locator = (testId: string) => ({
+    count: async () => controlCount(testId),
+    click: async () => {
+      if (testId === "canvas_controls_dropdown") {
+        state.triggerClicks += 1;
+        state.menuOpen = !state.menuOpen;
+        return;
+      }
+      // Clicking a control must not dismiss the menu — these are plain buttons,
+      // not Radix menu items (verified against the running nightly).
+      requireRendered(testId, "click");
+      if (testId === "fit_view") state.fitViewClicks += 1;
+      if (testId === "zoom_out") state.zoomOutClicks += 1;
+    },
+    // Resolves for a rendered element, rejects otherwise — same shape as the real
+    // `waitFor`, whose rejection is what `openCanvasControls` converts into an
+    // attributed error.
+    waitFor: async () => {
+      requireRendered(testId, "waitFor");
+    },
+    getAttribute: async (name: string) => {
+      if (testId !== "canvas_controls_dropdown" || name !== "data-state") {
+        return null;
+      }
+      if (!exposesDataState) return null;
+      return state.menuOpen ? "open" : "closed";
+    },
+    isDisabled: async () => {
+      requireRendered(testId, "isDisabled");
+      return zoomOutDisabled;
+    },
+  });
+
+  const page = {
+    waitForSelector: async () => undefined,
+    waitForTimeout: async () => undefined,
+    getByTestId: (testId: string) => locator(testId),
+    // The selector is CHECKED, not ignored. A fake that answers for any argument
+    // would pass every test here with a typo in `.react-flow__viewport`, while in
+    // production every read rejects and the settle loop silently burns its whole
+    // budget — i.e. the 500 ms sleep the helper replaced, at full price. Same
+    // class as `requireRendered` above: the fake must not flatter the helper.
+    locator: (selector: string) => ({
+      getAttribute: async () => {
+        if (selector !== ".react-flow__viewport") {
+          throw new Error(
+            `locator.getAttribute: Timeout 200ms exceeded — no element matches ${selector}`,
+          );
+        }
+        const style =
+          viewportStyles[
+            Math.min(state.viewportReads, viewportStyles.length - 1)
+          ];
+        state.viewportReads += 1;
+        return style;
+      },
+    }),
+  } as unknown as Page;
+
+  return {
+    page,
+    get menuOpen() {
+      return state.menuOpen;
+    },
+    get triggerClicks() {
+      return state.triggerClicks;
+    },
+    get fitViewClicks() {
+      return state.fitViewClicks;
+    },
+    get zoomOutClicks() {
+      return state.zoomOutClicks;
+    },
+    get viewportReads() {
+      return state.viewportReads;
+    },
+  };
+}
+
+/**
+ * Runs `fn` with `console.warn` captured, returning what it emitted.
+ *
+ * The `data-state` fallback is the one branch whose CORRECTNESS cannot be
+ * asserted — it is the behaviour #997 rejected, kept only because it can never
+ * open a menu. So what gets pinned instead is that it announces itself: the
+ * warning is the only signal that a helper stopped reading the real open/closed
+ * state.
+ */
+export async function captureWarnings(
+  fn: () => Promise<void>,
+): Promise<string[]> {
+  const original = console.warn;
+  const warnings: string[] = [];
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(" "));
+  };
+  try {
+    await fn();
+  } finally {
+    console.warn = original;
+  }
+  return warnings;
+}

--- a/tests/helpers/ui/canvas-controls.test.ts
+++ b/tests/helpers/ui/canvas-controls.test.ts
@@ -73,6 +73,15 @@ test("openCanvasControls throws, attributed, when opening does not reveal the co
       assert.match(err.message, /canvas-controls/);
       assert.match(err.message, /zoom_out/);
       assert.match(err.message, /#997/);
+      // A rename is not the only way to get here: the wait is bounded, so a menu
+      // that merely mounted slowly lands on this same message. Naming only the
+      // layout change would send the reader after a Langflow diff that does not
+      // exist.
+      assert.match(
+        err.message,
+        /mounting/,
+        "the message must offer a slow mount as a cause, not only a rename",
+      );
       return true;
     },
   );

--- a/tests/helpers/ui/canvas-controls.test.ts
+++ b/tests/helpers/ui/canvas-controls.test.ts
@@ -1,0 +1,144 @@
+// Unit tests for the shared canvas-controls mechanism (issue #1053).
+// Run with: npm run test:units
+//
+// This module is the single implementation of "reach a canvas control, then leave
+// the menu closed" for `adjustScreenView`, `zoomOut` and `uploadFile`. Four call
+// sites hand-rolled it before #1053 and all four got the same branch wrong — the
+// branch the CURRENT UI cannot produce, so no E2E spec can reach it. That is what
+// these tests exist for; the simulated widget and its live-verified contract are
+// documented in `./canvas-controls.fake`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { captureWarnings, fakeCanvas } from "./canvas-controls.fake";
+import { closeCanvasControls, openCanvasControls } from "./canvas-controls";
+
+test("openCanvasControls opens the menu when the control is hidden", async () => {
+  const canvas = fakeCanvas({ layout: "in-dropdown", menuOpen: false });
+
+  const opened = await openCanvasControls(canvas.page, "fit_view");
+
+  assert.equal(opened, true, "it had to open the menu, and must report that");
+  assert.equal(canvas.triggerClicks, 1);
+  assert.equal(canvas.menuOpen, true);
+});
+
+test("openCanvasControls does nothing when the control is already reachable", async () => {
+  // Two ways to already be reachable, and both must be no-ops: the menu is open
+  // (today's build, a sibling helper left it open), or the control has moved onto
+  // the canvas (the hypothetical build that breaks a blind toggle).
+  for (const options of [
+    { layout: "in-dropdown" as const, menuOpen: true },
+    { layout: "on-canvas" as const, menuOpen: false },
+  ]) {
+    const canvas = fakeCanvas(options);
+
+    const opened = await openCanvasControls(canvas.page, "fit_view");
+
+    assert.equal(opened, false, JSON.stringify(options));
+    assert.equal(canvas.triggerClicks, 0, JSON.stringify(options));
+    assert.equal(canvas.menuOpen, options.menuOpen, JSON.stringify(options));
+  }
+});
+
+test("openCanvasControls probes the CONTROL, never the trigger", async () => {
+  // The `FlowEditorPage.adjustView()` defect (#1053): the trigger is present
+  // whenever the canvas is up, so guarding on ITS count is a condition that is
+  // always true. Asking for the trigger itself must therefore be a no-op — if
+  // this function ever probed the trigger, it would answer "already reachable"
+  // for every control, and no menu would ever be opened again.
+  const canvas = fakeCanvas({ layout: "in-dropdown", menuOpen: false });
+
+  const opened = await openCanvasControls(
+    canvas.page,
+    "canvas_controls_dropdown",
+  );
+
+  assert.equal(opened, false);
+  assert.equal(canvas.triggerClicks, 0);
+});
+
+test("openCanvasControls throws, attributed, when opening does not reveal the control", async () => {
+  // A renamed or removed testid. Before this guard the caller died on a bare
+  // click timeout naming only the locator, with nothing to say the menu had just
+  // been opened for it — the failure mode `zoomOut` shipped with.
+  const canvas = fakeCanvas({
+    layout: "in-dropdown",
+    menuOpen: false,
+    missingControls: ["zoom_out"],
+  });
+
+  await assert.rejects(
+    () => openCanvasControls(canvas.page, "zoom_out"),
+    (err: Error) => {
+      assert.match(err.message, /canvas-controls/);
+      assert.match(err.message, /zoom_out/);
+      assert.match(err.message, /#997/);
+      return true;
+    },
+  );
+});
+
+test("closeCanvasControls closes a menu it did not open", async () => {
+  // The defect class, stated positively. All four call sites expressed the close
+  // as a toggle, which is correct only while the menu happens to be open.
+  const canvas = fakeCanvas({ layout: "in-dropdown", menuOpen: true });
+
+  await closeCanvasControls(canvas.page, false, "test");
+
+  assert.equal(canvas.menuOpen, false);
+  assert.equal(canvas.triggerClicks, 1);
+});
+
+test("closeCanvasControls leaves a closed menu alone, whatever the intent says", async () => {
+  // The #997 failure. A caller that believes it opened the menu (because a
+  // reassigned count told it so) must still not click a trigger whose state
+  // reads `closed` — that click OPENS a menu, handing an interceptor (#576) to
+  // the next canvas action.
+  for (const openedByThisCall of [true, false]) {
+    const canvas = fakeCanvas({ layout: "in-dropdown", menuOpen: false });
+
+    await closeCanvasControls(canvas.page, openedByThisCall, "test");
+
+    assert.equal(
+      canvas.triggerClicks,
+      0,
+      `openedByThisCall=${openedByThisCall} must not produce a click`,
+    );
+    assert.equal(canvas.menuOpen, false);
+  }
+});
+
+test("closeCanvasControls falls back to intent without data-state, and names the caller", async () => {
+  const open = fakeCanvas({ menuOpen: true, exposesDataState: false });
+  const warnings = await captureWarnings(() =>
+    closeCanvasControls(open.page, true, "zoomOut"),
+  );
+  assert.equal(open.menuOpen, false, "intent said it opened it — close it");
+  assert.equal(open.triggerClicks, 1);
+
+  // The fallback IS #997's rejected behaviour, kept only because it can never
+  // open a menu. It is acceptable only while it announces itself, and the
+  // caller's name is what makes it actionable across four sharing helpers.
+  assert.equal(warnings.length, 1, JSON.stringify(warnings));
+  assert.match(warnings[0], /\[zoomOut\]/);
+  assert.match(warnings[0], /data-state/);
+  assert.match(warnings[0], /#997/);
+
+  // Same missing attribute, opposite intent: it must never open a menu.
+  const closed = fakeCanvas({ menuOpen: false, exposesDataState: false });
+  await captureWarnings(() =>
+    closeCanvasControls(closed.page, false, "uploadFile"),
+  );
+  assert.equal(closed.triggerClicks, 0);
+  assert.equal(closed.menuOpen, false);
+});
+
+test("closeCanvasControls warns about nothing on the normal path", async () => {
+  // The warning is read by whoever debugs a suite-wide canvas break. It is worth
+  // nothing if it fires on every one of the ~140 dependent specs.
+  const canvas = fakeCanvas({ menuOpen: true });
+  const warnings = await captureWarnings(() =>
+    closeCanvasControls(canvas.page, true, "adjustScreenView"),
+  );
+  assert.deepEqual(warnings, []);
+});

--- a/tests/helpers/ui/canvas-controls.ts
+++ b/tests/helpers/ui/canvas-controls.ts
@@ -1,0 +1,113 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Radix trigger for the canvas-controls menu.
+ *
+ * Doubles as the repo's canvas-is-mounted gate — `setup-blank-flow`,
+ * `setup-playground` and `load-template-by-name` all wait on this testid without
+ * ever clicking it, which is why they are not sites of the defect below.
+ */
+export const CANVAS_CONTROLS = "canvas_controls_dropdown";
+
+/**
+ * Makes `controlTestId` reachable, returning whether THIS call opened the menu.
+ *
+ * On the build this was written against (Nightly 1.12.0.dev7) every canvas
+ * control — `fit_view`, `zoom_in`, `zoom_out`, `reset_zoom` — is rendered inside
+ * the dropdown's `DropdownMenuContent`, so a control is present **iff** the menu
+ * is open. That is a property of the current UI, not a contract: the day Langflow
+ * surfaces these controls directly on the canvas, the probe below finds the
+ * control already there and this function correctly does nothing.
+ *
+ * Probing the CONTROL rather than the trigger is the whole point. The trigger is
+ * present whenever the canvas is up, so `if (trigger.count() > 0)` is a condition
+ * that is always true — the shape `FlowEditorPage.adjustView()` carried (#1053).
+ *
+ * The return value answers exactly one question — "did this call open it?" — and
+ * is only a *fallback* input to `closeCanvasControls`. It is deliberately not the
+ * primary one; see that function.
+ */
+export async function openCanvasControls(
+  page: Page,
+  controlTestId: string,
+): Promise<boolean> {
+  if ((await page.getByTestId(controlTestId).count()) > 0) {
+    return false;
+  }
+
+  await page.getByTestId(CANVAS_CONTROLS).click();
+
+  // `waitFor`, not `count()`. Radix mounts the menu content asynchronously, so a
+  // bare count immediately after the click can read 0 on a menu that is opening
+  // normally — which would turn this guard into a flake on every dependent spec.
+  // Callers used to absorb that latency by accident, because the next thing they
+  // did was `click()` the control and Playwright's auto-wait covered it.
+  try {
+    await page
+      .getByTestId(controlTestId)
+      .waitFor({ state: "attached", timeout: 5000 });
+  } catch {
+    throw new Error(
+      `[canvas-controls] "${controlTestId}" is still not rendered after opening ` +
+        `"${CANVAS_CONTROLS}". On the build these helpers were written against it ` +
+        `lives inside that menu, so either the control was renamed or the layout ` +
+        `changed (#997). Teach the caller how the new layout exposes it rather ` +
+        `than reintroducing a blind toggle.`,
+    );
+  }
+
+  return true;
+}
+
+/**
+ * Leaves the canvas-controls menu CLOSED — whoever opened it.
+ *
+ * The postcondition is what the callers need, and it is deliberately not
+ * expressed as a toggle. An open canvas-controls menu is a documented click
+ * interceptor for the next canvas action (#576), so "close it if it is open"
+ * is correct on every path; "click the trigger again" is only correct while
+ * the menu happens to be open, and silently *opens* one otherwise. That was the
+ * same defect in all four call sites — #997 for `adjustScreenView`, #1053 for
+ * `zoomOut`, `uploadFile` and the (now deleted) `FlowEditorPage` copies.
+ *
+ * Radix renders the trigger with `data-state="open" | "closed"` (verified on
+ * Nightly 1.12.0.dev7), which answers the question directly. If that attribute
+ * ever disappears we fall back to intent — close only what this call opened —
+ * which is still safe: it can leave a pre-existing menu open, but it can never
+ * open one.
+ *
+ * That fallback is ANNOUNCED rather than silent, and the warning is the point.
+ * "Close only what this call opened" is precisely the fix #997 proposed and this
+ * helper rejects, so degrading into it un-fixes the already-open case (#576's
+ * leftover interceptor) — and no test can catch that, because the unit test for
+ * this branch asserts the fallback as correct behaviour. If the attribute moves
+ * off the element carrying the testid, the only signal will be this line, which
+ * is why it names the `caller`: four helpers share this code, and a warning that
+ * cannot say which one degraded costs a debugging session to attribute.
+ */
+export async function closeCanvasControls(
+  page: Page,
+  openedByThisCall: boolean,
+  caller: string,
+): Promise<void> {
+  const controls = page.getByTestId(CANVAS_CONTROLS);
+  const state = await controls
+    .getAttribute("data-state", { timeout: 1000 })
+    .catch(() => null);
+
+  if (state === null) {
+    console.warn(
+      `⚠️  [${caller}] "${CANVAS_CONTROLS}" exposed no \`data-state\` — falling ` +
+        `back to closing only what this call opened. A menu that was ALREADY ` +
+        `open stays open and will intercept the next canvas click (#576). This ` +
+        `is the behaviour #997 rejected: find where Radix now carries the ` +
+        `open/closed state and read it there.`,
+    );
+  }
+
+  const isOpen = state === null ? openedByThisCall : state === "open";
+
+  if (isOpen) {
+    await controls.click({ force: true, timeout: 1000 });
+  }
+}

--- a/tests/helpers/ui/canvas-controls.ts
+++ b/tests/helpers/ui/canvas-controls.ts
@@ -10,6 +10,17 @@ import type { Page } from "@playwright/test";
 export const CANVAS_CONTROLS = "canvas_controls_dropdown";
 
 /**
+ * Mirror of `use.actionTimeout` in `playwright.config.ts` (20 s).
+ *
+ * Not imported from there on purpose: the config reads the environment and runs
+ * `dotenv`, and these helpers are exercised by `npm run test:units` outside the
+ * Playwright runner. Kept as a named constant so the coupling is visible — the
+ * reachability check below must not be stricter than the implicit budget the
+ * callers used to get from `click()`'s own auto-wait.
+ */
+const ACTION_TIMEOUT_MS = 20_000;
+
+/**
  * Makes `controlTestId` reachable, returning whether THIS call opened the menu.
  *
  * On the build this was written against (Nightly 1.12.0.dev7) every canvas
@@ -42,17 +53,25 @@ export async function openCanvasControls(
   // normally — which would turn this guard into a flake on every dependent spec.
   // Callers used to absorb that latency by accident, because the next thing they
   // did was `click()` the control and Playwright's auto-wait covered it.
+  //
+  // The budget matches that accidental one — `actionTimeout` in
+  // `playwright.config.ts`. A shorter one would be a NARROWER window than the
+  // code this replaced, on ~140 dependent specs: a menu whose mount is merely
+  // slow (a loaded worker, a template canvas re-rendering) would stop being
+  // absorbed and start hard-failing with the message below, which names a
+  // Langflow layout change. Keep the two in step.
   try {
     await page
       .getByTestId(controlTestId)
-      .waitFor({ state: "attached", timeout: 5000 });
+      .waitFor({ state: "attached", timeout: ACTION_TIMEOUT_MS });
   } catch {
     throw new Error(
-      `[canvas-controls] "${controlTestId}" is still not rendered after opening ` +
-        `"${CANVAS_CONTROLS}". On the build these helpers were written against it ` +
-        `lives inside that menu, so either the control was renamed or the layout ` +
-        `changed (#997). Teach the caller how the new layout exposes it rather ` +
-        `than reintroducing a blind toggle.`,
+      `[canvas-controls] "${controlTestId}" is still not rendered ` +
+        `${ACTION_TIMEOUT_MS} ms after opening "${CANVAS_CONTROLS}". On the ` +
+        `build these helpers were written against it lives inside that menu, so ` +
+        `either the control was renamed, the layout changed (#997), or the menu ` +
+        `never finished mounting. Check which before teaching the caller a new ` +
+        `layout — and do not reintroduce a blind toggle.`,
     );
   }
 

--- a/tests/helpers/ui/zoom-out.test.ts
+++ b/tests/helpers/ui/zoom-out.test.ts
@@ -1,0 +1,92 @@
+// Unit tests for zoomOut (issue #1053).
+// Run with: npm run test:units
+//
+// 18 spec files import this directly and `setup-playground` calls it too, which
+// another 24 specs go through — ~38 in total. The branch that was wrong here is
+// the one the current UI cannot produce, so the coverage has to be a unit test;
+// see `./canvas-controls.fake` for the simulated widget and why.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { fakeCanvas } from "./canvas-controls.fake";
+import { zoomOut } from "./zoom-out";
+
+test("opens the menu when zoom-out is hidden, and closes it again", async () => {
+  const canvas = fakeCanvas({ layout: "in-dropdown", menuOpen: false });
+
+  await zoomOut(canvas.page, 2);
+
+  assert.equal(canvas.zoomOutClicks, 2);
+  assert.equal(canvas.triggerClicks, 2, "one click to open, one to close");
+  assert.equal(canvas.menuOpen, false, "the menu must not be left open");
+});
+
+test("leaves a menu that was ALREADY open closed, without reopening it", async () => {
+  // Today's reachable hazard. `mcp-server.spec.ts` opens the menu itself and then
+  // calls this helper, and any sibling helper can leave one open — so the
+  // already-open path is not hypothetical, it is exercised in the suite today.
+  const canvas = fakeCanvas({ layout: "in-dropdown", menuOpen: true });
+
+  await zoomOut(canvas.page, 3);
+
+  assert.equal(canvas.zoomOutClicks, 3);
+  assert.equal(canvas.triggerClicks, 1, "no reopen — only the closing click");
+  assert.equal(canvas.menuOpen, false);
+});
+
+test("never opens the menu when zoom-out is reachable on the canvas", async () => {
+  // The #997 defect as it was reproduced in this helper: `zoomOutButton` was
+  // recounted INSIDE the `if` after opening the menu, so the trailing guard
+  // (`zoomOutButton > 0`) was true on both paths and the trigger was toggled
+  // unconditionally. On a build with the controls on the canvas that toggle
+  // OPENS a menu, leaving an interceptor (#576) for the next canvas click on all
+  // ~38 dependent specs.
+  const canvas = fakeCanvas({ layout: "on-canvas", menuOpen: false });
+
+  await zoomOut(canvas.page, 2);
+
+  assert.equal(canvas.zoomOutClicks, 2);
+  assert.equal(canvas.triggerClicks, 0, "the menu was never needed");
+  assert.equal(canvas.menuOpen, false);
+});
+
+test("clicks zoom-out exactly as many times as asked, and defaults to 2", async () => {
+  const explicit = fakeCanvas();
+  await zoomOut(explicit.page, 5);
+  assert.equal(explicit.zoomOutClicks, 5);
+  assert.equal(explicit.menuOpen, false);
+
+  // The default is depended on by callers that pass no count.
+  const defaulted = fakeCanvas();
+  await zoomOut(defaulted.page);
+  assert.equal(defaulted.zoomOutClicks, 2);
+  assert.equal(defaulted.menuOpen, false);
+
+  // Zero steps still has to honour the postcondition: it opened nothing, so
+  // there is nothing to close.
+  const none = fakeCanvas();
+  await zoomOut(none.page, 0);
+  assert.equal(none.zoomOutClicks, 0);
+  assert.equal(none.menuOpen, false);
+});
+
+test("fails attributed when zoom-out is not rendered at all", async () => {
+  // A renamed testid used to surface as a click timeout inside the loop, naming
+  // only the locator. Now the reachability check in `openCanvasControls` speaks
+  // first and says the menu was opened for it.
+  const canvas = fakeCanvas({
+    layout: "in-dropdown",
+    menuOpen: false,
+    missingControls: ["zoom_out"],
+  });
+
+  await assert.rejects(
+    () => zoomOut(canvas.page, 2),
+    (err: Error) => {
+      assert.match(err.message, /canvas-controls/);
+      assert.match(err.message, /zoom_out/);
+      return true;
+    },
+  );
+
+  assert.equal(canvas.zoomOutClicks, 0);
+});

--- a/tests/helpers/ui/zoom-out.ts
+++ b/tests/helpers/ui/zoom-out.ts
@@ -1,19 +1,37 @@
 import type { Page } from "@playwright/test";
+import {
+  CANVAS_CONTROLS,
+  closeCanvasControls,
+  openCanvasControls,
+} from "./canvas-controls";
 
+const ZOOM_OUT = "zoom_out";
+
+/**
+ * Zooms the canvas out `times` steps, returning with the canvas-controls menu
+ * closed.
+ *
+ * Reach is wider than the 18 spec files that import this directly:
+ * `setup-playground` calls it too, and 24 specs go through that. So the
+ * postcondition below is load-bearing on roughly 38 specs — a leftover open menu
+ * intercepts the next canvas click (#576) and surfaces as a playground or agent
+ * failure, nowhere near this helper.
+ *
+ * Before #1053 the trailing close was a toggle guarded on a count that had been
+ * REASSIGNED after opening the menu, so the guard was true on both paths — the
+ * #997 defect verbatim. Dormant only because every canvas control currently
+ * lives inside the menu; see `./canvas-controls`.
+ */
 export async function zoomOut(page: Page, times: number = 2) {
-  await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
+  await page.waitForSelector(`[data-testid="${CANVAS_CONTROLS}"]`, {
     timeout: 3000,
   });
 
-  let zoomOutButton = await page.getByTestId("zoom_out").count();
-  if (zoomOutButton === 0) {
-    await page.getByTestId("canvas_controls_dropdown").click();
-    zoomOutButton = await page.getByTestId("zoom_out").count();
-  }
+  const openedByThisCall = await openCanvasControls(page, ZOOM_OUT);
+
   for (let i = 0; i < times; i++) {
-    await page.getByTestId("zoom_out").click();
+    await page.getByTestId(ZOOM_OUT).click();
   }
-  if (zoomOutButton > 0) {
-    await page.getByTestId("canvas_controls_dropdown").click({ force: true });
-  }
+
+  await closeCanvasControls(page, openedByThisCall, "zoomOut");
 }

--- a/tests/pages/FlowEditorPage.ts
+++ b/tests/pages/FlowEditorPage.ts
@@ -17,35 +17,18 @@ export class FlowEditorPage extends BasePage {
     );
   }
 
-  // Canvas controls
-  async fitView() {
-    await this.waitForCanvas();
-
-    const fitViewBtn = this.page.getByTestId("fit_view");
-    if ((await fitViewBtn.count()) === 0) {
-      await this.page.getByTestId("canvas_controls_dropdown").click();
-    }
-    await fitViewBtn.click();
-    await this.page.waitForTimeout(500);
-  }
-
-  async zoomOut(times = 1) {
-    for (let i = 0; i < times; i++) {
-      const zoomOutBtn = this.page.getByTestId("zoom_out");
-      if (await zoomOutBtn.isDisabled({ timeout: 1000 })) break;
-      await zoomOutBtn.click({ timeout: 1000 });
-    }
-  }
-
-  async adjustView(numberOfZoomOut = 1) {
-    await this.fitView();
-    await this.zoomOut(numberOfZoomOut);
-    // Close controls dropdown if it was opened
-    const dropdown = this.page.getByTestId("canvas_controls_dropdown");
-    if ((await dropdown.count()) > 0) {
-      await dropdown.click({ force: true, timeout: 1000 });
-    }
-  }
+  // Canvas view: use `helpers/ui/adjust-screen-view.ts` (fit view + zoom out +
+  // the menu-closed postcondition) and `helpers/ui/zoom-out.ts`. Both are
+  // unit-tested against a simulated widget and read the trigger's real
+  // `data-state`.
+  //
+  // This class used to carry its own `fitView()` / `zoomOut()` / `adjustView()`.
+  // They had no callers anywhere and had drifted into strictly worse copies: a
+  // `waitForTimeout(500)` where the helper polls the viewport transform, and an
+  // `adjustView()` that closed the menu by toggling a trigger whose count is 1
+  // whenever the canvas is up — an always-true guard, i.e. the #997 defect with
+  // no condition left at all. Deleted rather than repaired (#1053); a POM copy of
+  // a mechanism this delicate is a defect waiting for its first caller.
 
   // Flow execution
   async runFlow() {


### PR DESCRIPTION
**Closes #1053.**

## Problem

#997 (fixed in #1052) repaired **one** of four places that open the
canvas-controls menu and then try to close it again. The other three express the
close as a **toggle** rather than as a postcondition, so each is correct only
while the menu happens to be open at that moment. An open canvas-controls menu is
a documented click interceptor for the next canvas action (#576).

| Site | Shape of the defect | Reach |
|---|---|---|
| `tests/helpers/ui/zoom-out.ts` | the #997 reassignment verbatim — the count is recomputed *inside* the `if`, so the trailing guard is true on both paths | **18** spec files direct, plus `setup-playground` (another 24 specs go through it) |
| `tests/helpers/filesystem/upload-file.ts` | opens and toggles closed **unconditionally** | 2 spec files |
| `tests/pages/FlowEditorPage.adjustView()` | guards on the **trigger's** count, which is 1 whenever the canvas is up — an always-true condition | 0 callers |

All three are dormant on today's build for the same reason #997 was: every canvas
control lives inside `DropdownMenuContent`, so a control is present **iff** the
menu is open. They break together the day Langflow surfaces those controls on the
canvas — which is precisely why the coverage here is unit tests against a
simulated widget, not specs.

`upload-file.ts` is the exception: its failure is reachable **today**. If the menu
is already open on entry, its first click *closes* it, `fit_view` is then gone,
and the call dies on a click timeout — loud rather than silent, but a real
breakage from state a sibling helper can leave behind.

## Fix

`tests/helpers/ui/canvas-controls.ts` becomes the single implementation, and all
four sites adopt it — `adjust-screen-view.ts` dropping the private copy it has
carried since #1052. Two things change beyond the move:

- **The fallback warning names the caller.** It was hardcoded `[adjustScreenView]`.
  Four helpers now share this code, and that warning is the only signal that a
  helper stopped reading the trigger's real `data-state`; one that cannot say
  *which* helper degraded costs a debugging session to attribute.
- **`openCanvasControls` fails attributed** when opening the menu does not reveal
  the requested control — `zoomOut` previously died on a bare click timeout naming
  only the locator. The check uses `waitFor`, **not** `count()`: Radix mounts the
  menu content asynchronously, so a bare count right after the click can read 0 on
  a menu that is opening normally, which would turn this guard into a flake on
  ~140 specs. Callers used to absorb that latency by accident, because the next
  thing they did was `click()` the control and Playwright's auto-wait covered it.

  **Its budget is that same accidental one.** Raised from an arbitrary 5 s to a
  named `ACTION_TIMEOUT_MS` mirroring `use.actionTimeout` in
  `playwright.config.ts` (20 s) — review of this PR caught that a shorter cap
  makes the new guard *stricter* than the code it takes over from, on ~140 specs:
  a menu that merely mounts slowly (loaded worker, template canvas re-rendering)
  would stop being absorbed and start hard-failing. Not imported from the config,
  which reads the environment and runs `dotenv` while these helpers are exercised
  outside the Playwright runner; the coupling is documented at both ends instead.
  For the same reason the message stops asserting a single cause — a bounded wait
  is also reachable by a slow mount, and sending the reader after a Langflow diff
  that does not exist is exactly the attribution cost the `caller` argument was
  added to avoid.

`upload-file.ts` now delegates to `adjustScreenView(page, { numberOfZoomOut: 0 })`
— literally what its three lines did — keeping its 100 s canvas gate ahead of the
call so the file-upload specs' budget is not silently cut to the helper's 30 s.

### The POM trio was deleted, not repaired

`FlowEditorPage.fitView()`, `zoomOut()` and `adjustView()` all had **zero callers**
anywhere, and had drifted into strictly worse copies of the helpers: a
`waitForTimeout(500)` where `adjustScreenView` polls the viewport transform, and
an `adjustView()` whose menu-closing guard had no condition left at all. #1053
asks for a decision rather than a repair here, and repairing dead code to keep it
dead is the weaker option. `waitForCanvas()` stays — `settings-message-history`
calls it.

## Validation

Langflow Nightly **1.12.0.dev7** — the build #1052 established the DOM facts
against.

| Gate | Result |
|---|---|
| `npm run test:units` | **127 pass / 0 fail** (13 new: 8 for the module, 5 for `zoomOut`) |
| `npm run test:scripts` | 134 pass / 0 fail |
| `npm run typecheck` | clean |
| `npm run lint` | **0 errors**; 9 warnings across the 9 touched files, every one a pre-existing rule the repo already carries (`no-wait-for-selector` ×4, `no-force-option`, `no-wait-for-timeout`, and 3 untouched ones in `upload-file.ts`) |
| QA-CHECKLIST guard | green — no bullet changes, no spec changed status |
| Each of the 5 commits, independently | typecheck clean + units green |

### Force-fail — 10 mutations applied and executed, 10 killed, baseline restored green

| Mutation | Killed by |
|---|---|
| M1 `closeCanvasControls` → "close only what I opened" (#997's rejected fix) | 4 tests |
| M2 `closeCanvasControls` → unconditional toggle | 6 tests |
| M3 `openCanvasControls` probes the TRIGGER (the `adjustView` defect) | 11 tests |
| M4 warning loses the caller attribution | 2 tests |
| M5 post-open reachability failure swallowed | 2 tests |
| M6 settle poll returns on its first read | 1 test |
| M7 partial-migration refusal disabled | 1 test |
| M8 `adjustScreenView` drops the closing postcondition | 5 tests |
| M9 `zoomOut` drops the closing postcondition | 3 tests |
| M10 reachability message names a rename as the only cause | 1 test |

### E2E sample of the dependents, `--workers=1 --retries=0`

- **23 passed (3.9 min)** — `if-else-component-regression` (11), `files-page` (6),
  `file-types-upload` (5), `run-flow` (1). Zero `🚨 Backend Error`.
- **`general-bugs-shard-3836` passed (22.8 s)** — the spec that actually exercises
  `uploadFile`, twice.
- **`loop-component` failed**, at line 125 on a canvas handle — *before* the
  `uploadFile` call on line 188, so the changed helper never ran. A control run on
  `origin/main` reproduces the **identical failure at the same line**: pre-existing
  breakage in an inherited (non-`@stable`) spec, unrelated to this PR.
- The 2 flows those two `loop-component` runs leaked were purged; that spec has no
  id-scoped cleanup, which is pre-existing.

## Notes for the reviewer

- **The `ACTION_TIMEOUT_MS` mirror is documentation, not a pinned invariant.** A
  test cannot assert it without importing the Playwright config into the unit
  lane (env + `dotenv`) or adding a source-reading guard — disproportionate for a
  constant whose coupling is written at both ends. Accepted knowingly.
- **`Run impacted E2E specs` will report `skipping`.** This PR changes only shared
  helpers and a Page Object, and `detect-specs` selects from changed **spec** files
  only — the gap tracked in #1054. The E2E coverage above was run by hand.
- `canvas-controls.fake.ts` is deliberately **not** a `*.test.ts`: `test:units`
  collects `*.test.ts` only and Playwright's `testMatch` is `*.spec.ts`, so it is
  importable by the three test files without running as one or firing the E2E job.
- **Remaining sites of this class, all in specs and all left out on purpose**
  (one issue, one PR — filed as #1087, and the inventory corrected there during
  review of this PR):
  - `mcp/server/mcp-server.spec.ts` carries the sequence **twice** in one test
    (`643-648` and `702-709`) — `@stable` MCP coverage that needs its own E2E
    validation.
  - `core-functionality/llm-agents/loop-component.spec.ts:158-160` — an open plus
    a blind toggle with no control click between them; deletion, not migration.
  - `ui-ux/canvas-zoom-navigation.spec.ts` is **not** a site: it tests the widget
    itself and its local drivers already probe `fit_view` in both directions.
