### PR TITLE
fix(ui-ux): adopt adjustScreenView at the remaining canvas-controls spec sites

### DIFF
--- a/docs/ui-ux/canvas-zoom-navigation.md
+++ b/docs/ui-ux/canvas-zoom-navigation.md
@@ -53,8 +53,8 @@ Four independent tests:
    buttons — proving the toolbar entry is wired, not decorative. Collapsing the
    dropdown removes all four from the DOM again and it can be re-expanded. The
    collapse click is `force: true`: while open, the Radix popover overlay covers
-   the trigger and a normal click fails Playwright's hit-test (same forced click
-   as `loop-component.spec.ts` / `mcp-server.spec.ts`).
+   the trigger and a normal click fails Playwright's hit-test (the same forced
+   click `closeCanvasControls` issues in `helpers/ui/canvas-controls.ts`).
 4. **Scroll to navigate canvas** — a mouse wheel over the pane navigates the
    canvas by zooming **anchored at the pointer**: `deltaY > 0` strictly decreases
    the scale, `deltaY < 0` restores it, and in both directions the flow-space

--- a/tests/tests-automations/regression/core-functionality/llm-agents/loop-component.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/loop-component.spec.ts
@@ -155,10 +155,6 @@ test(
       .first()
       .click();
 
-    await page.getByTestId("canvas_controls_dropdown").click();
-
-    await page.getByTestId("canvas_controls_dropdown").click({ force: true });
-
     await page.getByTestId("div-generic-node").nth(5).click();
 
     await page.waitForTimeout(1000);

--- a/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
@@ -640,18 +640,18 @@ test(
     );
     await page.getByTestId("add-component-button-lf-starter_project").click();
 
-    await page.getByTestId("canvas_controls_dropdown").click();
+    await adjustScreenView(page, { numberOfZoomOut: 3 });
 
-    await page.getByTestId("fit_view").click();
-
-    await zoomOut(page, 3);
-
-    // zoomOut() already toggles the canvas-controls menu closed. The previous
-    // extra click({ force: true }) here re-opened it, leaving the Radix zoom
-    // menu overlay on screen where it intercepted the mcp-server-dropdown click
-    // ("<html> intercepts pointer events"). Ensure the menu is fully closed
-    // before interacting with the MCP node.
-    await page.keyboard.press("Escape");
+    // Explicit postcondition gate, kept from the pre-#1087 sequence. It no longer
+    // CLOSES anything — adjustScreenView leaves the menu closed by reading the
+    // trigger's `data-state` (#1053) — it ASSERTS that it did, and fails here,
+    // naming the canvas controls, instead of ~60 lines down as "<html> intercepts
+    // pointer events" on the mcp-server-dropdown click. That is the failure this
+    // test actually hit (#576), so the gate is worth its one locator call.
+    //
+    // The `keyboard.press("Escape")` that preceded it is deliberately gone: it
+    // would close a menu the helper had failed to close and hide that regression
+    // — the quiet workaround #997 exists to remove.
     await expect(page.getByTestId("zoom_out")).toBeHidden();
 
     await openAddMcpServerModal(page);
@@ -698,15 +698,10 @@ test(
 
     await page.getByTestId("fetch-0-option").click();
 
-    // Wait for canvas controls to be visible before adjusting view
-    await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
-      state: "visible",
-      timeout: 10000,
-    });
-    await page.getByTestId("canvas_controls_dropdown").click();
-
-    await page.getByTestId("fit_view").click();
-    await page.getByTestId("canvas_controls_dropdown").click({ force: true });
+    // Fit view only — no zoom step here. The helper waits on
+    // `canvas_controls_dropdown` itself (30 s), which subsumes the explicit
+    // 10 s wait this sequence used to open with.
+    await adjustScreenView(page, { numberOfZoomOut: 0 });
 
     await page.waitForSelector('[data-testid="int_int_max_length"]', {
       state: "visible",

--- a/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
@@ -642,16 +642,12 @@ test(
 
     await adjustScreenView(page, { numberOfZoomOut: 3 });
 
-    // Explicit postcondition gate, kept from the pre-#1087 sequence. It no longer
-    // CLOSES anything — adjustScreenView leaves the menu closed by reading the
-    // trigger's `data-state` (#1053) — it ASSERTS that it did, and fails here,
-    // naming the canvas controls, instead of ~60 lines down as "<html> intercepts
-    // pointer events" on the mcp-server-dropdown click. That is the failure this
-    // test actually hit (#576), so the gate is worth its one locator call.
-    //
-    // The `keyboard.press("Escape")` that preceded it is deliberately gone: it
-    // would close a menu the helper had failed to close and hide that regression
-    // — the quiet workaround #997 exists to remove.
+    // Postcondition gate kept from the pre-#1087 sequence: adjustScreenView already
+    // leaves the menu closed by reading the trigger's `data-state` (#1053), so this
+    // only ASSERTS that it did — failing here, naming the canvas controls, instead
+    // of ~60 lines down as "<html> intercepts pointer events" on the
+    // mcp-server-dropdown click (#576). The `keyboard.press("Escape")` that used to
+    // precede it is gone on purpose: it would mask that regression (#997).
     await expect(page.getByTestId("zoom_out")).toBeHidden();
 
     await openAddMcpServerModal(page);

--- a/tests/tests-automations/regression/ui-ux/canvas-zoom-navigation.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/canvas-zoom-navigation.spec.ts
@@ -134,6 +134,9 @@ async function paneBox(page: Page) {
  * On 1.12 `zoom_in` / `zoom_out` / `reset_zoom` / `fit_view` are NOT in the DOM
  * until `canvas_controls_dropdown` is clicked, so every control interaction has
  * to go through here. Idempotent: a no-op when the controls are already out.
+ *
+ * Shares a NAME with `helpers/ui/canvas-controls.ts` but not a signature or a
+ * job — see `closeCanvasControls` below for why this spec keeps its own pair.
  */
 async function openCanvasControls(page: Page): Promise<void> {
   if ((await page.getByTestId("fit_view").count()) === 0) {
@@ -164,7 +167,14 @@ async function normalizeViewport(page: Page): Promise<Viewport> {
  *
  * The click is forced: while the dropdown is open its Radix overlay covers the
  * trigger, so a normal click never passes Playwright's hit-test (same reason
- * `loop-component.spec.ts` and `mcp-server.spec.ts` force this exact click).
+ * `closeCanvasControls` forces this exact click in
+ * `helpers/ui/canvas-controls.ts`).
+ *
+ * NOT that shared helper, despite the shared name. The shared one takes the
+ * postcondition "leave the menu closed, whoever opened it" and reads it off the
+ * trigger's `data-state`; this local probes `fit_view` in both directions and
+ * asserts the transition, because observing expand/collapse is what this spec
+ * exists to validate rather than something it reaches past (#1053).
  */
 async function closeCanvasControls(page: Page): Promise<void> {
   if ((await page.getByTestId("fit_view").count()) > 0) {


### PR DESCRIPTION
Follow-up of #1053 / #1089, which extracted `tests/helpers/ui/canvas-controls.ts` and adopted its postcondition at the four **helper/POM** sites. This closes the class in the places it still lived inside **specs**.

Closes #1087

## What the issue asked for vs what shipped

The issue scoped one site (`mcp-server.spec.ts:643`). A grep for the pattern found the sequence **twice in the same test**, plus a dormant third occurrence in another spec:

| Site | Before | After |
|---|---|---|
| `mcp-server.spec.ts:643` | open → `fit_view` → `zoomOut(page, 3)` → `Escape` + `toBeHidden()` | `adjustScreenView(page, { numberOfZoomOut: 3 })` + kept gate |
| `mcp-server.spec.ts:701` | 10 s wait → open → `fit_view` → `click({ force: true })` | `adjustScreenView(page, { numberOfZoomOut: 0 })` |
| `loop-component.spec.ts:158` | open → blind `click({ force: true })` | deleted |

Both opens in `mcp-server.spec.ts` were **unconditional** — the same shape `upload-file.ts` carried: a menu already open on entry gets **closed** by that first click, `fit_view` goes missing, and the test dies on a click timeout.

The explicit 10 s wait on `canvas_controls_dropdown` at the second site is dropped — the helper waits on that same testid itself, with a wider budget.

## The trailing pair at site 1 is split on purpose

- `keyboard.press("Escape")` is **removed**. It would close a menu the helper failed to close, hiding exactly the regression #997 exists to surface.
- `expect(zoom_out).toBeHidden()` is **kept**. It no longer closes anything — after #1053 `adjustScreenView` leaves the menu closed by reading the trigger's `data-state` — it *asserts* that it did, and fails naming the canvas controls instead of ~60 lines later as `<html> intercepts pointer events` on the `mcp-server-dropdown` click. That is the failure this test actually hit (#576).

This is the recorded decision the issue's checklist asked for.

## Why `loop-component.spec.ts` is a deletion, not a migration

The pair was open → blind toggle with **no control click between them**, so there is nothing for `adjustScreenView` to replace. It is dormant today only because `adjustScreenView` at `:114` already left the menu closed; entered open, the first click closes and the forced second one **re-opens**, planting the #576 interceptor right before the `div-generic-node` clicks that follow.

## `canvas-zoom-navigation` is not a site

It is the spec that **tests the widget**, and its local drivers legitimately observe the open/closed transition. Its comment and spec doc cited the two now-deleted `force: true` clicks as precedent, so both now point at `closeCanvasControls`, and the locals carry a note that they share a name with the shared module without sharing its signature or its job.

## Validation (Nightly 1.12.0.dev7, `--workers=1 --retries=0`)

- **Site 1 exercised live** — the run reaches and passes the migrated call, then dies further down on a pre-existing failure (below).
- **Force-fail** — leaving the menu open after the migrated call fails the kept gate with `zoom_out` visible, at that line. The gate is reached and load-bearing.
- **Site 2 could NOT be reached live.** `mcp-server.spec.ts` is red on `main` today for an unrelated product change: Langflow now rejects a `command` that is not a single executable (*"put options and arguments in the 'args' field"*), and all 6 stdio registrations in the file pass `<exe> <arg>`. A scout that split the command got past it and then hit `uvx` failing to start in the container (*"Error loading server: Connection closed"*). The `numberOfZoomOut: 0` path is covered by unit tests and by 4 live callers, so the mechanism is proven — the site is not.
- **`loop-component.spec.ts`** still fails at `:125` on a canvas handle, *before* the deleted lines, identically to `main`. The deletion is inert by construction.
- **`canvas-zoom-navigation.spec.ts`** — 3 passed. *"Fit View centers every node"* fails on `fitted.scale` landing exactly at `maxZoom`; reproduces on clean `main` and is absent from the 07-27..29 dailies. Unrelated to this change; filed as #1094.
- `npm run typecheck`, `npm run lint`, `npm run check:checklist-coverage` and the QA-CHECKLIST guard: clean.

## Validation gap — tracked

`mcp-server.spec.ts` carries no `@stable` and `nightly.yml` is disabled, so neither migrated site is exercised by a scheduled lane: the only CI that runs them is this PR's impacted-specs job, which is red for #1091 (Langflow now rejects a `command` that is not a single executable — all 6 stdio registrations in the file pass `<exe> <arg>`). Site 1 was therefore exercised by hand only; site 2 was not reached at all. Revalidating site 2 belongs with #1091, alongside the `@stable` promotion discussed below.

## Sites deliberately left out

Two raw `fit_view` clicks remain in the suite and are **not** of this class — neither is preceded by an unconditional `canvas_controls_dropdown` open, so there is no blind toggle to replace:

- `toolModeGroup.spec.ts:18` — inside `test.skip`, under a standing `// TODO: fix this test`.
- `canvas-zoom-fitview.spec.ts:143` — inherited spec, no `@stable`; it expects `fit_view` visible **without** opening the dropdown, which contradicts the 1.12 layout this PR documents, so it is likely red in silence. Its own issue, not this one.

## On `@stable`

The issue's checklist said *"keeps `@stable`"*. That premise is wrong about this file: **`mcp-server.spec.ts` carries no `@stable` on any of its 6 tests**, and no test is promoted here. Promoting the touched one would put a test that downloads a package at runtime under a 30 s / 10 s budget into the daily, when the repo already had to raise a sibling MCP stdio test to 120 s for exactly that (#463) — and there is no baseline for this file, which has never run in a daily. Promotion belongs to a separate issue, after the `command`/`args` breakage above is resolved.

No assertion changed and no spec was promoted.

