### PR TITLE
fix(playground): gate the message edit on run completion (#1062)

### DIFF
--- a/docs/core-functionality/playground/playground-message-edit.md
+++ b/docs/core-functionality/playground/playground-message-edit.md
@@ -1,6 +1,6 @@
 # Playground Message Edit
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.12.x
 
 ---
 
@@ -26,14 +26,17 @@ Three behaviors are covered:
 
 **Test 1 — Edit and save**
 
-1. Create a flow with ChatInput → ChatOutput via `setupPlayground`, mock `**/api/v1/run/**`
-2. Open Playground (`playground-btn-flow-io`), send "Original message", wait for bot reply
-3. Hover the message group container to reveal the edit button (`icon-Pen`)
-4. Click `icon-Pen`; wait for `save-button` to confirm EditMessageField is mounted
-5. Set textarea value via `setEditTextareaValue("Edited message")`; click `save-button`
-6. Wait for `save-button` to have count 0 (edit field closed on `onSuccess`)
-7. Assert `data-testid="chat-message-User-Edited message"` is visible
-8. Assert `data-testid="chat-message-User-Original message"` has count 0
+1. Create a flow with ChatInput → ChatOutput via `setupPlayground`
+2. Open Playground (`playground-btn-flow-io`), send "Original message", wait for the
+   user bubble (`div-chat-message`)
+3. **Wait for the flow run to finish** — `button-stop` hidden **and** `button-send`
+   visible. Editing before this point makes the message update fail (see #1062)
+4. Hover the message group container to reveal the edit button (`icon-Pen`)
+5. Click `icon-Pen`; wait for `save-button` to confirm EditMessageField is mounted
+6. Set textarea value via `setEditTextareaValue("Edited message")`; click `save-button`
+7. Wait for `save-button` to have count 0 (edit field closed)
+8. Assert `data-testid="chat-message-User-Edited message"` is visible
+9. Assert `data-testid="chat-message-User-Original message"` has count 0
 
 **Test 2 — Cancel edit**
 
@@ -80,14 +83,26 @@ Three behaviors are covered:
 ## Preconditions *(optional)*
 
 - Langflow running and accessible at `PLAYWRIGHT_BASE_URL`
-- `**/api/v1/run/**` is mocked to return a deterministic bot reply — no API key or LLM required
-- Message storage endpoints (`/api/v1/messages/`) are NOT mocked; the test relies on the real Langflow backend persisting the edit (required for Session Logs consistency check)
+- No API key or LLM required — the flow is ChatInput → ChatOutput, so the run echoes
+  the input. The run is **executed for real**: on 1.11+ the Playground runs through
+  `POST /api/v2/workflows` (SSE), so the legacy `**/api/v1/run/**` route mock this
+  spec used to install never fired and was removed (#1062)
+- Message storage endpoints (`/api/v1/monitor/messages/`) are NOT mocked; the test relies on the real Langflow backend persisting the edit (required for Session Logs consistency check)
 
 ---
 
 ## Notes *(optional)*
 
 - The edit button (`icon-Pen`) is inside an `invisible group-hover:visible` container. The test hovers the `.group` container (not just the message text) and scopes the icon lookup to within it, ensuring the CSS hover state is never lost when the mouse moves to the button.
-- `save-button` visibility is used as the readiness signal for `EditMessageField` being mounted. After clicking save, the test waits for `save-button` count to reach 0 — this confirms `onSuccess` fired and `setEditMessage(false)` was called before asserting the result.
+- `save-button` visibility is used as the readiness signal for `EditMessageField` being mounted. After clicking save, the test waits for `save-button` count to reach 0 — this only proves the edit field closed, **not** that the update succeeded: the field also closes when the update is rejected. The rejection raises an "Error updating messages." toast, but that toast is **not** a dependable assertion target — under load the flow page re-suspends right after, and the toast was gone from the failure snapshot in both the daily and the local reproduction. The run-completion gate below removes the cause instead.
+- **The run-completion gate is the fix for #1062.** The spec edited the message as soon
+  as the user bubble appeared, while the flow run was still executing. A message
+  update issued mid-run is rejected — the UI raises "Error updating messages." and the
+  bubble keeps its original text, so `chat-message-User-Edited message` never appears.
+  Measured on 1.12.0.dev9: with the backend unloaded the run finishes inside the ~900 ms
+  the spec spends hovering, so it passed 8/8; with the same backend under parallel load
+  the run was still in flight at save time and it failed 8/8 with exactly the daily's
+  signature. This is why the flake only ever appeared on heavily loaded daily runs
+  (2026-07-10, 07-20, 07-29). All three tests share the helper, so all three were exposed.
 - The edit textarea value is set via `setEditTextareaValue`, which calls the native `HTMLTextAreaElement.prototype.value` setter and then invokes React's `onChange` handler directly through `__reactProps$`. This is required because React 19's controlled textarea ignores synthetic DOM events dispatched by Playwright.
 - Assertions on text after edit use `data-testid="chat-message-User-{text}"` (set by `user-message.tsx`) rather than `getByText`. The playground renders bot messages via `SanitizedMarkdown` which can incidentally match user-input text; scoping to the user bubble's testid avoids false failures.

--- a/tests/tests-automations/regression/core-functionality/playground/playground-message-edit.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-message-edit.spec.ts
@@ -1,4 +1,3 @@
-import type { Route } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { setupPlayground } from "../../../../helpers/flows/setup-playground";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
@@ -7,19 +6,6 @@ async function openPlaygroundWithMessage(
   page: any,
   messageText: string,
 ): Promise<void> {
-  await page.route("**/api/v1/run/**", async (route: Route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        outputs: [
-          { outputs: [{ results: { message: { text: "Bot reply" } } }] },
-        ],
-        session_id: "msg-edit-session",
-      }),
-    });
-  });
-
   await page.getByTestId("playground-btn-flow-io").click();
   await page.waitForSelector('[data-testid="input-chat-playground"]', {
     timeout: 15000,
@@ -31,6 +17,12 @@ async function openPlaygroundWithMessage(
   await page.waitForSelector('[data-testid="div-chat-message"]', {
     timeout: 15000,
   });
+
+  // The user bubble appears while the flow run is still executing, and a message
+  // update issued mid-run is rejected ("Error updating messages.") — the flake
+  // behind #1062. Gate on the run being finished: stop hidden AND send visible.
+  await expect(page.getByTestId("button-stop")).toBeHidden({ timeout: 60000 });
+  await expect(page.getByTestId("button-send")).toBeVisible({ timeout: 60000 });
 }
 
 async function hoverMessageAndClickEdit(
@@ -96,11 +88,9 @@ test.describe("Playground Message Edit", () => {
     }
   });
 
-  // Quarantined for #1062 — recurrent flake (2026-07-20 / 07-29): hover does
-  // not reveal the edit button.
-  test.fixme(
+  test(
     "edit user message — hover reveals edit button and saved changes replace original text",
-    { tag: ["@release", "@playground"] },
+    { tag: ["@release", "@playground", "@stable"] },
     async ({ page }) => {
       await test.step("set up flow", async () => {
         createdFlowId = await setupPlayground(page);


### PR DESCRIPTION
Closes #1062

**Roadmap linkage:** off-wave work under an approved exception — `daily-failure` issue #1062, spun out of the 2026-07-29 triage #1057.

## The issue's premise was wrong

#1062 is titled *"hover does not reveal the edit button"*. The failing attempt's own artifacts (run [30444299314](https://github.com/oriontech-me/langflow-e2e/actions/runs/30444299314)) say otherwise:

- The step `hover user message to reveal edit button and enter edit mode` took **308 ms and passed**.
- The failure is in `verify edited text is shown`: `chat-message-User-Edited message` — *element(s) not found*.
- The `error-context` screenshot shows the toast **"Error updating messages."** with the bubble still holding `Original message` — the `PUT /api/v1/monitor/messages/{id}` was **rejected**.

Nothing reached the harness log because `tests/fixtures/fixtures.ts` only monitors 400/404/422/500, and this failure was not one of those.

## Root cause

The spec edited the message as soon as the user bubble appeared — **while the flow run was still executing**. An update issued mid-run is rejected.

Isolated on 1.12.0.dev9, same backend, same interaction:

| Condition | `button-stop` at save time | Result |
|---|---|---|
| Backend unloaded | hidden (run **finished**) | **8/8 passed** |
| Same backend, 6 parallel workers | visible (run **in flight**) | **8/8 failed**, error toast |

Unloaded, the run finishes inside the ~900 ms the spec spends hovering — which is why the flake only ever appeared on heavily loaded dailies (2026-07-10, 07-20, 07-29). It is a test defect, not environment: load only changes how long the run takes.

## The fix

The gate lives in `openPlaygroundWithMessage`, the helper **all three tests share** — `reports/daily-history.jsonl` shows all three flaking (07-08, 07-15, 07-22 too), not just the quarantined one:

```ts
await expect(page.getByTestId("button-stop")).toBeHidden({ timeout: 60000 });
await expect(page.getByTestId("button-send")).toBeVisible({ timeout: 60000 });
```

Also removes the `**/api/v1/run/**` route mock. Since 1.11 the Playground runs through `POST /api/v2/workflows` (SSE), so the mock **never fired** — the run was always real. Believing it was mocked (and therefore instantaneous) is exactly what justified not waiting for it.

**Quarantine lifted:** `test.fixme` removed and `@stable` restored.

## Covered tests

| # | Test | What it validates |
|---|---|---|
| 1 | `edit user message — hover reveals edit button and saved changes replace original text` | A saved edit replaces the user message in the chat: `chat-message-User-Edited message` present, `chat-message-User-Original message` gone. Regresses if the update is dropped or the bubble is not re-rendered. |
| 2 | `cancel message edit — original text is preserved` | Cancelling discards the draft: original text still visible, `Discarded edit` count 0. Regresses if cancel commits the draft. |
| 3 | `message edited in playground is reflected in Session Logs` | The edit is persisted backend-side, not only in local state: the new text appears in the Session Logs table. Regresses if the edit stays client-side. |

## How it was validated

Langflow Nightly **1.12.0.dev9** (`langflowai/langflow-nightly:latest`).

- `npm run typecheck` — 0 errors
- `npm run lint:ci` — 0 errors (the 5 warnings are byte-identical to `origin/main`)
- `npm run test:scripts` — 134 pass / 0 fail
- `npm run test:units` — 114 pass / 0 fail
- `check-checklist-guard.mjs` — no generated block edited
- `npm run check:checklist-coverage` — spec↔doc↔bullet triad OK
- `npm run regressions:check` — in sync
- `--workers=1 --retries=0` — **4 clean bursts, 12 tests, 0 flaky** (~33 s each)
- Under the load that reproduced the bug — **3/3 runs, 9 tests** green
- `--trace=on` — 3 passed in 43.4 s, traces produced, no hang
- `🚨 Backend Error` — **zero**
- Orphan flows via `GET /api/v1/flows/` — **0**

**Force-fails executed** (not inspected — run and observed failing):

- Gate removed + load → **1 failed**, reproducing the daily's exact signature. Revert proven: 0 mutation markers, green again.
- Test 1: expected testid → `...Edited messageFFMUT` → **failed**
- Test 2: `toHaveCount(0)` → `(1)` on `Discarded edit` → **failed**
- Test 3: `After edit` → `After editFFMUT` in Session Logs → **failed**
- All three mutations in one run: **0 passed / 3 failed**

## Dependencies

No LLM and no API key — the flow is ChatInput → ChatOutput, so the run echoes the input. Runs in parallel; `afterEach` deletes the created flow id-scoped via `deleteFlow`.

## What this does not cover

Editing bot messages, inline editing inside the Session Logs table (ag-grid, no stable testids), edit persistence across a page reload, and special/long characters — all pre-existing negative scope, unchanged by this PR.

## Known limitations

The gate waits up to **60 s** for the run to finish. On a saturated shard a run exceeding that fails the test — but that would be an attributable backend failure, not the silent flake this fixes. The per-test timeout (5 min) leaves headroom.

## Follow-ups (not in this PR — one issue per branch)

1. `playground-session-rename.spec.ts` mutates a message/session right after send with no run-completion gate, and flaked on the same 2026-07-10 daily.
2. `tests/fixtures/fixtures.ts` is blind to silent request failures (monitors only 400/404/422/500). That blindness emptied this failure's log and is why #1062 was filed with the wrong title — candidate for `qa-infra`.
