### PR TITLE
fix(core-components): open the imported flow by id instead of clicking its card (#1061)

### DIFF
--- a/docs/core-components/component-breaking-change-alert.md
+++ b/docs/core-components/component-breaking-change-alert.md
@@ -2,7 +2,7 @@
 
 **Test file:** `tests/tests-automations/regression/core-components/component-breaking-change-alert.spec.ts`
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev9`)
 
 ---
 
@@ -92,6 +92,29 @@ Each assertion fails if the breaking-change alert regresses: e.g. every breaking
 component routed to a silent `update-button` (no `review-button` left, toolbar
 falls back to "Update All"), the warning copy removed, the backup default flipped
 off, or a breaking component pre-selected (submit enabled).
+
+### The banner is gated on the component registry, not on elapsed time (#1061)
+
+The outdated/breaking diff is computed against the frontend's component
+registry, fetched at app bootstrap by `GET /api/v1/all?force_refresh=true`.
+Measured on the running nightly, the banner appears **≈ the duration of that
+request + ~1 s**: stalling the response by 8 s renders the banner at 8.9 s, and
+stalling it by 20 s renders it at 21.0 s. Nothing is computed one-shot against
+an empty store — the diff re-runs when the registry lands.
+
+That makes a fixed wait on the banner a wait on someone else's clock. The
+request rebuilds the whole registry (`force_refresh=true`) on a backend the
+daily pins to a single worker while two Playwright workers share it, so it can
+outlast any window chosen in advance; the original 30 s bound is exactly what
+expired on 2026-07-27 and 2026-07-29 (`element(s) not found`, test duration
+38 s, retry green in 6 s once the registry was warm).
+
+The import helper therefore **waits for the registry response itself** before
+opening the flow, and only then asserts the banner within a short window. The
+generous bound belongs to the environment-dependent request; the assertion on
+the product's own behaviour stays tight, so a genuinely missing banner still
+fails fast instead of hiding behind a long timeout. The two failures are also
+distinguishable in the log: a registry that never lands names the registry.
 
 ### Frozen-fixture caveat
 

--- a/tests/tests-automations/regression/core-components/component-breaking-change-alert.spec.ts
+++ b/tests/tests-automations/regression/core-components/component-breaking-change-alert.spec.ts
@@ -56,7 +56,23 @@ test.afterEach(async ({ request }) => {
 // mechanism the @stable import-invalid-json spec uses. The flow is renamed with a
 // unique per-run suffix so we wait for THIS dropped card, not a bootstrap-seeded
 // or sibling-test card.
+// The outdated/breaking diff is computed against the frontend's component
+// registry, fetched once at app bootstrap. Arm the wait BEFORE the app boots —
+// the response can land while the flows page is still rendering, and a waiter
+// attached afterwards would miss it and then block for its whole timeout.
+const REGISTRY_RE = /\/api\/v1\/all\b/;
+// The registry rebuild is the environment's cost, not the product's: the daily
+// pins the backend to one worker while two Playwright workers share it, so this
+// bound is deliberately generous. The assertion on the banner stays tight.
+const REGISTRY_TIMEOUT = 120000;
+
 async function importOutdatedFlowAndOpen(page: Page): Promise<void> {
+  const registryLoaded = page
+    .waitForResponse((r) => REGISTRY_RE.test(r.url()) && r.ok(), {
+      timeout: REGISTRY_TIMEOUT,
+    })
+    .catch(() => null);
+
   await awaitBootstrapTest(page, { skipModal: true });
   await expect(page.getByTestId("mainpage_title")).toBeVisible({
     timeout: 30000,
@@ -71,27 +87,59 @@ async function importOutdatedFlowAndOpen(page: Page): Promise<void> {
     dt.items.add(new File([d], "outdated_flow.json", { type: "application/json" }));
     return dt;
   }, content);
-  await page.getByTestId("cards-wrapper").dispatchEvent("drop", { dataTransfer });
 
-  const card = page.getByTestId("list-card").filter({ hasText: flowName });
-  await card.waitFor({ state: "visible", timeout: 30000 });
-  await card.click();
+  // Armed AFTER bootstrap on purpose: on an empty instance the bootstrap helper
+  // creates a "Basic Prompting" flow of its own, and that POST would otherwise
+  // be the one this waiter matched.
+  const imported = page.waitForResponse(
+    (r) =>
+      new URL(r.url()).pathname.replace(/\/$/, "") === "/api/v1/flows" &&
+      r.request().method() === "POST" &&
+      r.status() === 201,
+    { timeout: 60000 },
+  );
+  await page.getByTestId("cards-wrapper").dispatchEvent("drop", { dataTransfer });
+  const flowId = (await imported.then((r) => r.json())).id as string;
+
+  // Navigate by id instead of clicking the imported card. Clicking made the
+  // test depend on the flows LIST — its length, its order, and whatever the
+  // bootstrap helper is doing to it — and that dependency is what broke on
+  // 2026-07-27 and 07-29: on an empty instance the bootstrap creates a "Basic
+  // Prompting" flow from a template and bounces through it, and the click then
+  // opened THAT flow instead of the import. A flow with no outdated components
+  // shows no banner, so the wait expired with "element(s) not found" and the
+  // retry passed because the instance was no longer empty (#1061; the three
+  // failing error-contexts all show the Basic Prompting editor).
+  await page.goto(`/flow/${flowId}`);
+
+  // Opening the flow is what triggers the registry fetch — the editor mounting,
+  // not the app booting, asks for /api/v1/all. Wait on that DEPENDENCY rather
+  // than on the derived banner: the banner appears ≈ registry duration + 1 s
+  // (measured: an 8 s stall renders it at 8.9 s, a 20 s stall at 21.0 s), so a
+  // fixed window on the banner alone is a bet on how loaded the backend is.
+  if ((await registryLoaded) === null) {
+    throw new Error(
+      `the component registry (GET /api/v1/all) did not respond within ${REGISTRY_TIMEOUT}ms — the backend is the blocker, not the breaking-change alert`,
+    );
+  }
 
   // The outdated banner is the frontend's signal that the diff finished
   // computing. Gate on the count-agnostic regex (not a pinned literal) so the
   // shared helper does not silently re-pin the component count the tests
   // deliberately relaxed — matches both the _one ("component needs updates")
   // and _other ("components need updates") i18n plurals.
+  //
+  // 15 s, tighter than the 30 s it replaces: with the registry already in the
+  // store the banner is ~1 s away, so a missing banner is a real defect and
+  // should fail fast instead of hiding behind a long wait.
   await expect(
     page.getByText(/\d+ components? needs? updates?/i),
-  ).toBeVisible({ timeout: 30000 });
+  ).toBeVisible({ timeout: 15000 });
 }
 
-// Quarantined for #1061 — recurrent flake (2026-07-27 / 07-29): the
-// breaking-change alert never becomes visible.
-test.fixme(
+test(
   "breaking-change outdated components alert with a Review action, not a silent Update",
-  { tag: ["@components", "@regression", "@ui-ux"] },
+  { tag: ["@stable", "@components", "@regression", "@ui-ux"] },
   async ({ page }) => {
     trackCreatedFlows(page);
 


### PR DESCRIPTION
**Closes #1061.**

## Problem

Both quarantined-or-flaking tests died on the same wait — the breaking-change banner never becoming visible — and the failing attempts' error-contexts name the cause: **all of them had the "Basic Prompting" editor open, not the flow the test had just imported.**

```
Locator: getByText(/\d+ components? needs? updates?/i)
Expected: visible
Error: element(s) not found
```

A flow with no outdated components shows no banner, so the wait ran its full window and the retry passed because the second attempt opened the right flow. "Basic Prompting" is not arbitrary: `addFlowToTestOnEmptyLangflow` creates exactly that template when the project is empty, which is the state a fresh shard starts in.

## Fix

**The helper no longer clicks the imported card.** It captures the flow id from the import's `POST /api/v1/flows/ 201` and navigates to `/flow/<id>`. That removes the flows list from the path entirely — its length, its order, its re-renders, and whatever the bootstrap helper is doing to it. The waiter is armed after bootstrap so it cannot match the template flow the bootstrap itself creates.

**The banner wait is gated on its real dependency.** The outdated/breaking diff is computed against the component registry the editor fetches on mount, and the banner appears about as late as that request — measured by stalling it:

| `GET /api/v1/all` stalled by | banner visible after |
|---|---|
| 8 s | 8.9 s |
| 20 s | 21.0 s |

So a fixed 30 s wait on the banner was a bet on backend load. The generous bound (120 s) now belongs to the registry request and fails naming the backend; the assertion on the product's own behaviour **drops to 15 s**, so a genuinely missing banner fails fast instead of hiding behind a long timeout.

Quarantine lifted: `test.fixme` removed and `@stable` restored on the line-90 test. The line-164 test shares the cause — all three tests go through the same helper — so no split and no additional quarantine was needed (directive item 5).

## Honest limits of this validation

**The effect is directly evidenced; the trigger is not reproducible on demand.** Six attempts to reproduce it locally all stayed green: a 40 s registry stall, a 52-flow list, an emptied project (the path that creates Basic Prompting), two concurrent runs against one instance, CPU saturation, and plain bursts. Twelve-plus runs have passed since the failing one.

So this is **not** the fails-before / passes-after A/B that a fix ideally carries. What it is: a directly observed failure mode, and a change that structurally cannot produce it, since the step that chose the wrong flow no longer exists. If the daily proves the trigger was something else, that will surface as a new dedicated issue — now against a spec that no longer depends on the flows list.

A first diagnosis in this investigation — that the registry timing alone explained the failures — was wrong, and the error-contexts corrected it. The registry finding survives as a real, measured dependency worth gating on; it was not the cause here.

## Validation

- Final burst: **5 runs × 3 tests, 0 failures** (14–20 s per run), `--retries=0 --workers=1`
- `npm run typecheck` ✅ · `npm run lint` exit 0
- Flow cleanup verified: no `Breaking Change Alert` leftovers; the flows the experiments seeded were purged; the instance is back to 27 starter flows
- **Force-fail — 5 mutations, all executed, all reverted (`grep FF-MUTATION` → 0), green after:**
  - `FF1` expect `"Update All"` instead of `"Review All"` → failed
  - `FF2` expect the backup checkbox unchecked → failed
  - `FF3` expect one extra `Breaking` tag → failed
  - `FF4` registry gate pointed at a URL that never fires → failed in the gate
  - `FF5` **navigate to the wrong flow** — the exact CI failure mode — → failed, i.e. the spec detects it rather than passing blind

## Side finding, not fixed here

The editor asks for `/api/v1/all?**force_refresh=true**` every time it mounts, so every spec that opens a flow pays a full component-registry rebuild on the shared backend. That is a plausible contributor to the contention #1077 is benchmarking; worth a look there rather than in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
