### PR TITLE
fix(mcp): register stdio MCP servers as command + args (#1091)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -682,6 +682,11 @@
 - [x] Starter project with MCP → `mcp/server/mcp-server-starter-projects.spec.ts`
 - [x] Flow exposed as MCP server — verify generated endpoint → `mcp/server/mcp-server-protocol.spec.ts`
 - [x] Execute MCP server tool via MCP protocol → `mcp/server/mcp-server-protocol.spec.ts`
+- [x] Register an external MCP server through the stdio form — `command` + `args` resolves the server's real tools into the MCPTools node → `mcp/server/mcp-server.spec.ts`
+- [x] Add-server modal fields persist across save → reopen-for-edit — stdio (name, command, 4 args, 2 env pairs) and HTTP/SSE (name, URL, 2 headers, 2 env pairs) → `mcp/server/mcp-server.spec.ts`
+- [x] Tool list refreshes when a registered server is edited to run a different package → `mcp/server/mcp-server.spec.ts`
+- [x] stdio `command` must be a single executable — a command with an embedded argument is refused and the same registration split into `command` + `args` is accepted (upstream hardening `#14073`; #1091) → `mcp/server/mcp-server.spec.ts`
+- [x] The project's own Streamable HTTP endpoint registers as an MCP server and exposes its flows as tools → `mcp/server/mcp-server.spec.ts`
 - [-] Resource exposed by server is accessible via URI — flow files are exposed as MCP resources: `resources/list` is `@stable`; `resources/read` blocked by a live Langflow regression on 1.12.x (`AttributeError: 'str' object has no attribute 'hex'`, filed upstream **LE-2012**) — kept as a guard, not promoted → `mcp/server/mcp-server-resources.spec.ts`
 - [ ] Prompt exposed by server returns correct template (no product surface on 1.11.x — MCP server `prompts/list` returns `[]`; #829)
 

--- a/docs/mcp/server/mcp-server.md
+++ b/docs/mcp/server/mcp-server.md
@@ -1,0 +1,287 @@
+# MCP Server — add-server modal: stdio / HTTP registration, field persistence & tool refresh
+
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev9`)
+
+---
+
+## What this test validates *(required)*
+
+Covers the **Add MCP Server modal** as the registration surface for external MCP
+servers, across both transports, plus the security contract the stdio form now
+enforces (QA-CHECKLIST §14.1):
+
+1. **stdio registration round-trip** — a server registered with
+   `command` + `args` resolves its tools into the MCPTools node's
+   `dropdown_str_tool`, renders the selected tool's inputs on the node, appears
+   in Settings → MCP Servers, and can be edited and deleted from there.
+2. **Field persistence** — every stdio field (name, command, N args, N env
+   pairs) and every HTTP/SSE field (name, URL, N headers, N env pairs) survives
+   save → reopen-for-edit.
+3. **Tool-list refresh on edit** — changing which package a registered server
+   runs makes the node's tool list reflect the *new* server, not the cached one.
+4. **The stdio command/args contract** — `command` must be a single executable;
+   an option or package glued onto it is refused, and the same registration
+   split into `command` + `args` is accepted.
+5. **Streamable HTTP against Langflow itself** — a project's own
+   `/api/v1/mcp/project/{id}/streamable` endpoint registers as an MCP server and
+   exposes the project's flows as tools.
+
+If this fails, external MCP servers can no longer be registered from the UI, the
+modal loses field state, the tool list serves stale data after an edit, or the
+stdio input-shape validation that keeps every policy layer seeing the same argv
+has been dropped.
+
+---
+
+## Tags *(required)*
+
+`@release` `@workspace` `@components` `@mcp` `@stable`
+(plus `@regression` on the command/args contract test)
+
+- `@stable` — promoted under #1091 after the file was brought back to green on
+  nightly `1.12.0.dev9` with repeated `--workers=1 --retries=0` runs and a
+  per-test force-failure check. Before #1091 the file carried no `@stable` and
+  therefore ran in **no automated lane**, which is why every stdio registration
+  in it had been broken since 2026-07-15 without a single red run.
+- `@regression` — on the contract test only: it guards an intentional upstream
+  security change (see *External dependencies*), so a silent removal of that
+  validation must fail the suite.
+- `@workspace`/`@components` — drives the flow canvas, sidebar and MCPTools
+  node; `@mcp` — MCP server area; `@release` — happy-path MCP registration.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`; auto-login superuser.
+- The default MCP starter project exists (`lf-starter_project`).
+- **Network egress to the npm registry** — the stdio tests run real MCP servers
+  via `npx`. A cold container downloads the package on first use; see the
+  timeout budgets below.
+- `npx` on `PATH` inside the Langflow container (it ships there; verified on the
+  nightly image).
+- No LLM / provider key required — no agent executes.
+
+---
+
+## Step by step *(required)*
+
+### 1 — `user must be able to change mode of MCP tools without any issues`
+
+1. Bootstrap; blank flow; add the first MCP component from the sidebar.
+2. Assert the node's `icon-Mcp` paths use the theme-correct fill.
+3. Open the Add MCP Server modal → **stdio** tab; register
+   `command: npx`, `args[0]: @modelcontextprotocol/server-everything` under a
+   per-run random name.
+4. Poll `GET /api/v2/mcp/servers?action_count=true` until the server's
+   `toolsCount` is non-null; open `dropdown_str_tool` and pick `echo-0-option`.
+5. Assert the `echo` tool's `message` input renders on the node.
+6. Settings → MCP Servers → Edit the server: assert the JSON and HTTP tabs are
+   disabled, stdio is enabled, and **both** `stdio-command-input` (`npx`) and
+   `stdio-args_0` (the package) round-tripped.
+7. Delete the server; assert it disappears from the list.
+
+### 2 — `user must be able to add and delete MCP server from sidebar`
+
+1. Bootstrap; blank flow; open the MCP sidebar and its add-server trigger.
+2. Register the same `npx` + `server-everything` split under a random name.
+3. Add the server's component to the canvas; assert `dropdown_str_tool` renders.
+4. Settings → MCP Servers: assert the server is listed, delete it, assert it is
+   gone.
+
+### 3 — `STDIO MCP server fields should persist after saving and editing`
+
+1. Bootstrap; add the `lf-starter_project` MCP component.
+2. Open the modal → stdio tab; fill name, `command: uvx`, and **four** args —
+   `mcp-server-test`, `--verbose`, `--port=8080`, `--config=test.json` — plus two
+   env pairs. (`mcp-server-test` is a deliberately non-existent package: this
+   test asserts form persistence, not connectivity, and registration is accepted
+   independently of whether the subprocess starts.)
+3. Save; Settings → MCP Servers → Edit.
+4. Assert every field round-tripped: name, command, `stdio-args_0..3`, and both
+   env key/value pairs.
+5. Escape the modal and delete the server.
+
+### 4 — `HTTP/SSE MCP server fields should persist after saving and editing`
+
+Unchanged by #1091 (no stdio surface). Registers an HTTP server with two headers
+and two env pairs, reopens it for edit, and asserts all ten field values
+round-tripped; then deletes it.
+
+### 5 — `mcp server tools should be refreshed when editing a server`
+
+1. Bootstrap; add the `lf-starter_project` MCP component; `adjustScreenView`
+   and assert the canvas-controls menu is closed (`zoom_out` hidden) — the
+   postcondition gate kept from #1053/#997.
+2. Register server **A**: `command: npx`,
+   `args[0]: @modelcontextprotocol/server-sequential-thinking`.
+3. Assert `dropdown_str_tool` enables and exposes `sequentialthinking-0-option`;
+   select it and assert the tool's own inputs render on the node
+   (`anchor-popover-anchor-input-thought` and `int_int_thoughtnumber`).
+4. Settings → MCP Servers → Edit: assert `command` is `npx` and `args[0]` is the
+   sequential-thinking package, then **edit `args[0]`** to
+   `@modelcontextprotocol/server-everything` (server **B**) and save.
+5. Return to the flow, re-select the server on the node, and assert the tool
+   list now exposes `echo-0-option` — the refresh, not the cached A list.
+6. Delete the server; assert it is gone; re-register it as **A** again and assert
+   the node's tool list is back to `sequentialthinking-0-option`.
+
+### 6 — `Streamable HTTP MCP server with server-everything should load tools correctly`
+
+Unchanged by #1091 (no stdio surface). Derives the project's own
+`/api/v1/mcp/project/{id}/streamable` URL, registers it via the HTTP tab, polls
+`toolsCount`, and asserts ≥1 tool option; cleans up via the API.
+
+### 7 — `stdio command with an embedded argument is refused, and command plus args is accepted` *(new)*
+
+1. Bootstrap; blank flow; open the Add MCP Server modal → stdio tab.
+2. Fill a random name and `command: npx @modelcontextprotocol/server-everything`
+   (executable and package glued together); save.
+3. Assert the **rejection**: the modal stays open (`add-mcp-server-button` still
+   visible), an in-dialog `role="alert"` carries
+   `/single executable name or path/`, and `GET /api/v2/mcp/servers` does **not**
+   list the name.
+4. Without closing the modal, correct the input — `command: npx`,
+   `args[0]: @modelcontextprotocol/server-everything` — and save again.
+5. Assert the **acceptance**: the modal closes, no alert remains, and the API now
+   lists the server with `command === "npx"` and
+   `args === ["@modelcontextprotocol/server-everything"]`.
+6. Delete the server via the API.
+
+---
+
+## Validation criterion *(required)*
+
+- **stdio registration works only in the split shape.** A `command` carrying an
+  embedded argument is refused with an in-dialog alert matching
+  `/single executable name or path/` and creates no server; the same
+  registration as `command` + `args[0]` is accepted, closes the modal, and is
+  readable back from `GET /api/v2/mcp/servers` with exactly that command/args
+  pair.
+- **Tools resolve from a really-running server.** `dropdown_str_tool` exposes
+  the tool testid the registered package actually serves
+  (`echo-0-option` for `server-everything`, `sequentialthinking-0-option` for
+  `server-sequential-thinking`) — not merely "some option".
+- **The selected tool's own inputs render**: `popover-anchor-input-message`
+  (echo), `anchor-popover-anchor-input-thought` + `int_int_thoughtnumber`
+  (sequentialthinking).
+- **Every modal field round-trips** save → edit: stdio name/command/`args_0..3`
+  + 2 env pairs; HTTP name/URL + 2 headers + 2 env pairs.
+- **The tool list refreshes on edit**: after changing `args[0]` from
+  sequential-thinking to server-everything, the node exposes `echo-0-option`;
+  after reverting, `sequentialthinking-0-option`.
+
+## Guarding against false positives *(how)*
+
+- **Per-run random server names** (`test_server_<5-digit>`) — no test can pass
+  on a server a previous run left behind.
+- **Tool-name-specific option testids**, never `[data-testid*="-option"]` on the
+  stdio path: a server that starts but serves the *wrong* tool set fails. This
+  is exactly what the tool-refresh test turns into its assertion.
+- **The contract test asserts both directions in one test.** A refusal assert
+  alone would still pass if the modal rejected *everything*; the accepted-shape
+  half proves the validation is discriminating, not blanket.
+- **The contract test checks the API, not only the UI** — a modal that stays
+  open while the server is created anyway would pass a UI-only assert.
+- **Canvas-controls postcondition gate** (`zoom_out` hidden) in test 5 fails at
+  the canvas controls instead of ~60 lines later as `<html> intercepts pointer
+  events` (#576/#997/#1053).
+- **Force-failure check** (CONTRIBUTING §2) executed per test during VERIFY.
+
+---
+
+## What this test does not cover *(optional)*
+
+- MCP **tool execution** through a registered client server — covered by
+  `mcp/client/mcp-client-regression.spec.ts` and `mcp/client/mcp-client-agent.spec.ts`.
+- The MCP Server **tab** on a flow (exposing a project) — `mcp-server-tab.spec.ts`.
+- Protocol-level tool listing/execution — `mcp-server-protocol.spec.ts`.
+- Flow-file **resources** — `mcp-server-resources.spec.ts`.
+- Registration **status codes** (409/404) — `mcp/client/mcp-server-registration-status-codes.spec.ts`.
+- The rest of the stdio security policy — the arg blocklist
+  (`DANGEROUS_KEYWORDS`), shell-metacharacter rejection, the docker-arg policy
+  and the env blocklist are **not** covered here; test 7 covers only the
+  command-shape rule.
+- `uvx`-launched MCP servers that actually start. See *Notes*.
+
+---
+
+## External dependencies *(required)*
+
+- **Langflow's stdio security policy** —
+  `src/lfx/src/lfx/base/mcp/security.py` → `validate_mcp_stdio_config()`.
+  Since upstream `f4d6ac4` (PR `#14073`, 2026-07-15, forward-porting the
+  release-1.10.3 multi-tenant hardening from `#13530`/`#14044`), `command` must
+  be a single executable name or path; options and arguments belong in `args`.
+  `npx` and `uvx` remain in `ALLOWED_MCP_COMMANDS`. This is the contract test 7
+  pins.
+- **Public npm registry** — `@modelcontextprotocol/server-everything` and
+  `@modelcontextprotocol/server-sequential-thinking` are fetched by `npx` inside
+  the Langflow container.
+- Add-MCP-server modal testids (`stdio-tab`, `stdio-name-input`,
+  `stdio-command-input`, `stdio-args_N`, `input-list-plus-btn_-0`,
+  `stdio-env-key-N`/`stdio-env-value-N`, `stdio-env-plus-btn-0`, `http-tab`,
+  `http-name-input`, `http-url-input`, `http-headers-*`, `http-env-*`,
+  `add-mcp-server-button`) and `helpers/mcp/open-add-mcp-server-modal.ts`.
+- Settings → MCP Servers page (`sidebar-nav-MCP Servers`,
+  `add-mcp-server-button-page`, `mcp-server-menu-button-<name>`,
+  `btn_delete_delete_confirmation_modal`).
+- MCPTools node (`dropdown_str_tool`, `mcp-server-dropdown`, `list_item_<name>`).
+- `GET`/`DELETE /api/v2/mcp/servers[/{name}]`, `helpers/auth/get-auth-token.ts`,
+  `helpers/other/await-bootstrap-test.ts`, `helpers/ui/adjust-screen-view.ts`,
+  `helpers/ui/zoom-out.ts`, `helpers/flows/delete-flow.ts`.
+
+---
+
+## When to review this test *(optional)*
+
+- If `validate_mcp_stdio_config()` changes which command shapes are accepted, or
+  the rejection message stops matching `/single executable name or path/`.
+- If the add-server modal testids or the args/env list controls change.
+- If either `@modelcontextprotocol` package renames its tools (`echo`,
+  `sequentialthinking`) or stops publishing.
+- If the MCPTools node's tool-input testid derivation changes (integers are
+  lowercased into `int_int_<name>`; strings keep their case in
+  `popover-anchor-input-<name>`).
+
+---
+
+## Notes *(optional)*
+
+- **Why `npx` and not `uvx` for the servers that must really start.** Before
+  #1091 tests 1/2/5 registered `uvx mcp-server-fetch` / `mcp-server-time`.
+  Splitting those into `command` + `args` gets past the new validation but the
+  subprocess still dies: the published `mcp-server-fetch` and `mcp-server-time`
+  packages fail at import against the current `mcp` Python SDK —
+  `ImportError: cannot import name 'McpError' from 'mcp.shared.exceptions'`
+  (renamed to `MCPError`), reproduced inside the nightly container and **not**
+  fixed by pinning the server version, because the `mcp` dependency floats.
+  That is a third-party breakage in `modelcontextprotocol/servers`, outside both
+  Langflow and this suite. The `npx` servers start cleanly on the same image and
+  are already the shape the `@stable` `mcp/client/` specs use, so tests 1/2/5
+  register through `npx`. `uvx` stays covered as a *command* by test 3, which
+  only asserts form persistence.
+- **Timeout budgets.** `npx` cold-starts a package download on a fresh
+  container. The sibling stdio test in `mcp-client-regression.spec.ts` was
+  raised to **120 s** for exactly this (#463), so the tool-list waits here use
+  the same 120 s budget rather than the 30 s the file carried while it was
+  never running in CI. The subsequent option/testid waits stay short (10 s) —
+  once `toolsCount` is non-null the dropdown is local state.
+- **A second defect the fix exposed.** With registration working again, test 1
+  reached an assertion it had never executed: it sampled the selected tool's
+  `message` input with a bare `count()` immediately after clicking the option.
+  The node's inputs arrive with a rebuild a beat later, so the count was 0. It
+  is now an auto-retrying `toBeVisible`, matching how the `@stable` sibling that
+  selects the same `echo` tool waits (`mcp-client-regression.spec.ts`) — which
+  is why that spec never hit the race and this one could not have, while its
+  registration was failing 60 lines earlier.
+- **Flow cleanup.** Every test bootstraps and creates a flow. Ids are collected
+  from `POST /api/v1/flows` 201 responses (pattern A — `awaitBootstrapTest` runs
+  first, so the canvas URL id is not trustworthy, #681) and deleted id-scoped in
+  `afterEach`. Registered MCP servers are also deleted by name in `afterEach`, so
+  a mid-test failure cannot leak one into the next run.
+- Trace-on may hang on this ReactFlow-canvas family (see the skill's known
+  `--trace=on` limitation); step verification relies on `--retries=0` bursts +
+  force-fail.
+- A commented-out seventh block (SSE against a public Cloudflare MCP endpoint)
+  remains at the bottom of the file, untouched by #1091.

--- a/docs/mcp/server/mcp-server.md
+++ b/docs/mcp/server/mcp-server.md
@@ -266,7 +266,11 @@ Unchanged by #1091 (no stdio surface). Derives the project's own
   raised to **120 s** for exactly this (#463), so the tool-list waits here use
   the same 120 s budget rather than the 30 s the file carried while it was
   never running in CI. The subsequent option/testid waits stay short (10 s) —
-  once `toolsCount` is non-null the dropdown is local state.
+  once `toolsCount` is non-null the dropdown is local state. Test 5 carries
+  **three** of those 120 s waits (register A → edit to B → re-register A), which
+  does not fit the suite's 5-minute per-test cap, so it raises its own budget to
+  8 min via `test.setTimeout` — otherwise a slow registry surfaces as a test
+  timeout instead of as the wait that actually ran out.
 - **A second defect the fix exposed.** With registration working again, test 1
   reached an assertion it had never executed: it sampled the selected tool's
   `message` input with a bare `count()` immediately after clicking the option.

--- a/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
@@ -54,6 +54,14 @@ async function listMcpServerNames(page: Page): Promise<string[]> {
   const resp = await page.request.get("/api/v2/mcp/servers", {
     headers: authHeader ? { Authorization: authHeader } : undefined,
   });
+  // Checked, not assumed: an error body is not an array, so an unchecked read
+  // fails as `servers.map is not a function` inside whichever assertion called
+  // this — hiding the status that actually explains the run.
+  if (!resp.ok()) {
+    throw new Error(
+      `GET /api/v2/mcp/servers: ${resp.status()} — ${await resp.text()}`,
+    );
+  }
   const servers: Array<{ name: string }> = await resp.json();
   return servers.map((s) => s.name);
 }
@@ -95,11 +103,26 @@ test.afterEach(async ({ request }) => {
       : names;
     for (const name of names) {
       if (existing.includes(name)) {
-        await request.delete(`/api/v2/mcp/servers/${name}`, options);
+        const del = await request.delete(
+          `/api/v2/mcp/servers/${name}`,
+          options,
+        );
+        // Warn rather than throw: the flow cleanup below still has to run, and
+        // a silent failure here is what lets registered servers accumulate on
+        // the shared instance (the buildup #545 set out to stop).
+        if (!del.ok()) {
+          console.warn(
+            `⚠️  MCP server cleanup failed: ${name} — ${del.status()} ${await del.text()}`,
+          );
+        }
       }
     }
   }
 
+  // Deliberately NOT swallowed, unlike the precedent in
+  // `agent-tool-name-validation.spec.ts` — `deleteFlow` throws so a cleanup
+  // regression is visible instead of silent (see its docstring). A transient id
+  // 404s, which it treats as done, so this only fires on a real failure.
   for (const id of ids) {
     await deleteFlow(request, id, options);
   }
@@ -745,6 +768,13 @@ test(
   "mcp server tools should be refreshed when editing a server",
   { tag: ["@release", "@workspace", "@components", "@mcp", "@stable"] },
   async ({ page }) => {
+    // Three `TOOL_LIST_TIMEOUT` waits (register A, edit to B, re-register A)
+    // plus the settings round-trips do not fit the suite's 5-minute per-test
+    // cap. Without this the test would die at the TEST timeout on a slow npm
+    // registry instead of at the wait that actually ran out — the unattributed
+    // timeout that costs a triage cycle to explain (#1011/#1019).
+    test.setTimeout(8 * 60 * 1000);
+
     await page.waitForTimeout(5000);
 
     await awaitBootstrapTest(page);

--- a/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
@@ -1,13 +1,113 @@
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { openAddMcpServerModal } from "../../../../helpers/mcp/open-add-mcp-server-modal";
 import { zoomOut } from "../../../../helpers/ui/zoom-out";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+
+/**
+ * Add-MCP-Server modal: stdio / HTTP registration, field persistence and tool
+ * refresh. Spec doc: `docs/mcp/server/mcp-server.md`.
+ *
+ * STDIO CONTRACT (#1091). Langflow requires `command` to be a SINGLE executable
+ * — options and the package go in `args`. Registering
+ * "npx @modelcontextprotocol/server-everything" as the command is refused with
+ * a 422 ("MCP stdio command must be a single executable name or path"). The
+ * rule arrived with the multi-tenant hardening forward-port (upstream #14073,
+ * 2026-07-15) so every policy layer sees the same argv; `npx`/`uvx` themselves
+ * are still allowlisted. Every stdio registration below therefore fills
+ * `stdio-command-input` with the bare executable and `stdio-args_N` with the
+ * rest. The last test in this file pins that contract directly.
+ */
+
+// Package runners are `npx`, not `uvx`, wherever the subprocess must actually
+// come up: the published `mcp-server-fetch`/`mcp-server-time` packages this file
+// used to register now fail at import against the current `mcp` Python SDK
+// (`McpError` renamed to `MCPError`), and pinning the server version does not
+// help because its `mcp` dependency floats. That is a third-party breakage, not
+// Langflow's — see the spec doc. `uvx` stays covered as a command by the
+// field-persistence test, which never starts the subprocess.
+const NPX = "npx";
+const PKG_EVERYTHING = "@modelcontextprotocol/server-everything";
+const PKG_SEQUENTIAL = "@modelcontextprotocol/server-sequential-thinking";
+
+// `npx` downloads the package on a cold container, so the FIRST tool list of a
+// run can take far longer than every dropdown interaction that follows it. The
+// sibling stdio test in `mcp-client-regression.spec.ts` needed exactly this
+// budget for the same reason (#463); the 30 s this file carried was never
+// exercised in CI, because none of these tests were `@stable` until #1091.
+const TOOL_LIST_TIMEOUT = 120_000;
+
+// Flow ids observed on `POST /api/v1/flows` 201, plus the MCP servers each test
+// registered. Pattern A from authoring-conventions: `awaitBootstrapTest` runs
+// before the blank-flow / starter click, so the canvas URL id is the stale
+// bootstrap one (#681) and only the response ids are trustworthy. Deleting a
+// transient id 404s harmlessly — `deleteFlow` treats 404 as done.
+const createdFlowIds: string[] = [];
+const registeredServers: string[] = [];
+
+/** Server names currently registered on the instance. */
+async function listMcpServerNames(page: Page): Promise<string[]> {
+  const authHeader = await getAuthToken(page.request);
+  const resp = await page.request.get("/api/v2/mcp/servers", {
+    headers: authHeader ? { Authorization: authHeader } : undefined,
+  });
+  const servers: Array<{ name: string }> = await resp.json();
+  return servers.map((s) => s.name);
+}
+
+test.beforeEach(async ({ page }) => {
+  createdFlowIds.length = 0;
+  registeredServers.length = 0;
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {}); // non-JSON / batch payloads
+    }
+  });
+});
+
+// Id-scoped cleanup — never a wipe (#553). The servers are listed first so a
+// test that already deleted its own through the UI (the happy path for most of
+// them) does not issue a 404 delete on every run.
+test.afterEach(async ({ request }) => {
+  const names = registeredServers.splice(0);
+  const ids = createdFlowIds.splice(0);
+  if (names.length === 0 && ids.length === 0) return;
+
+  const bearer = await getAuthToken(request);
+  const options = bearer ? { headers: { Authorization: bearer } } : undefined;
+
+  if (names.length > 0) {
+    const resp = await request.get("/api/v2/mcp/servers", options);
+    const existing: string[] = resp.ok()
+      ? ((await resp.json()) as Array<{ name: string }>).map((s) => s.name)
+      : names;
+    for (const name of names) {
+      if (existing.includes(name)) {
+        await request.delete(`/api/v2/mcp/servers/${name}`, options);
+      }
+    }
+  }
+
+  for (const id of ids) {
+    await deleteFlow(request, id, options);
+  }
+});
 
 test(
   "user must be able to change mode of MCP tools without any issues",
-  { tag: ["@release", "@workspace", "@components", "@mcp"] },
+  { tag: ["@release", "@workspace", "@components", "@mcp", "@stable"] },
   async ({ page }) => {
     (page as any).allowFlowErrors();
     await page.waitForTimeout(5000);
@@ -54,11 +154,11 @@ test(
 
     const randomSuffix = Math.floor(Math.random() * 90000) + 10000; // 5-digit random number
     const testName = `test_server_${randomSuffix}`;
+    registeredServers.push(testName);
     await page.getByTestId("stdio-name-input").fill(testName);
 
-    await page
-      .getByTestId("stdio-command-input")
-      .fill("npx @modelcontextprotocol/server-everything");
+    await page.getByTestId("stdio-command-input").fill(NPX);
+    await page.getByTestId("stdio-args_0").fill(PKG_EVERYTHING);
 
     await page.getByTestId("add-mcp-server-button").click();
 
@@ -73,7 +173,7 @@ test(
             await resp.json();
           return servers.find((s) => s.name === testName)?.toolsCount ?? null;
         },
-        { timeout: 90000, intervals: [3000] },
+        { timeout: TOOL_LIST_TIMEOUT, intervals: [3000] },
       )
       .not.toBeNull();
 
@@ -100,11 +200,16 @@ test(
 
     await adjustScreenView(page);
 
-    const messageInputCount = await page
-      .getByTestId("popover-anchor-input-message")
-      .count();
-
-    expect(messageInputCount).toBeGreaterThan(0);
+    // The selected tool's own inputs arrive with a node rebuild that lands a
+    // beat after the option click, so this needs an auto-retrying assertion —
+    // a bare count() samples the node before `message` is on it. The `@stable`
+    // sibling that selects the same echo tool waits the same way
+    // (`mcp-client-regression.spec.ts`), which is why it never hit this race;
+    // here it stayed invisible because the registration above had been failing
+    // since 2026-07-15 and the test never got this far (#1091).
+    await expect(page.getByTestId("popover-anchor-input-message")).toBeVisible({
+      timeout: 30000,
+    });
 
     await page.getByTestId("user_menu_button").click({ timeout: 3000 });
 
@@ -154,8 +259,11 @@ test(
       timeout: 3000,
     });
 
-    expect(await page.getByTestId("stdio-command-input").inputValue()).toBe(
-      "npx @modelcontextprotocol/server-everything",
+    // Both halves of the split must round-trip: a backend that dropped `args`
+    // on save would still show the right command.
+    expect(await page.getByTestId("stdio-command-input").inputValue()).toBe(NPX);
+    expect(await page.getByTestId("stdio-args_0").inputValue()).toBe(
+      PKG_EVERYTHING,
     );
 
     await page.waitForTimeout(500);
@@ -196,7 +304,7 @@ test(
 
 test(
   "user must be able to add and delete MCP server from sidebar",
-  { tag: ["@release", "@workspace", "@components", "@mcp"] },
+  { tag: ["@release", "@workspace", "@components", "@mcp", "@stable"] },
   async ({ page }) => {
     (page as any).allowFlowErrors();
     await awaitBootstrapTest(page);
@@ -231,13 +339,13 @@ test(
 
     const randomSuffix = Math.floor(Math.random() * 90000) + 10000; // 5-digit random number
     const testName = `test_server_${randomSuffix}`;
+    registeredServers.push(testName);
     await page.getByTestId("stdio-name-input").fill(testName);
 
     await page.waitForTimeout(500);
 
-    await page
-      .getByTestId("stdio-command-input")
-      .fill("npx @modelcontextprotocol/server-everything");
+    await page.getByTestId("stdio-command-input").fill(NPX);
+    await page.getByTestId("stdio-args_0").fill(PKG_EVERYTHING);
 
     await page.getByTestId("add-mcp-server-button").click();
 
@@ -282,7 +390,7 @@ test(
 
 test(
   "STDIO MCP server fields should persist after saving and editing",
-  { tag: ["@release", "@workspace", "@components", "@mcp"] },
+  { tag: ["@release", "@workspace", "@components", "@mcp", "@stable"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 
@@ -313,7 +421,13 @@ test(
     // Test data with random suffix
     const randomSuffix = Math.floor(Math.random() * 90000) + 10000; // 5-digit random number
     const testName = `test_stdio_server_${randomSuffix}`;
-    const testCommand = "uvx mcp-server-test";
+    registeredServers.push(testName);
+    // `uvx` keeps the second allowlisted package runner covered as a COMMAND.
+    // `mcp-server-test` is deliberately a package that does not exist: this test
+    // asserts form persistence, and registration is accepted independently of
+    // whether the subprocess ever starts.
+    const testCommand = "uvx";
+    const testPackageArg = "mcp-server-test";
     const testArg1 = "--verbose";
     const testArg2 = "--port=8080";
     const testArg3 = "--config=test.json";
@@ -326,16 +440,20 @@ test(
     await page.getByTestId("stdio-name-input").fill(testName);
     await page.getByTestId("stdio-command-input").fill(testCommand);
 
-    // Add first argument
-    await page.getByTestId("stdio-args_0").fill(testArg1);
+    // The package that used to be glued onto the command is now args[0]
+    await page.getByTestId("stdio-args_0").fill(testPackageArg);
 
-    // Add second argument by clicking plus button
+    // Add first option by clicking plus button
     await page.getByTestId("input-list-plus-btn_-0").click();
-    await page.getByTestId("stdio-args_1").fill(testArg2);
+    await page.getByTestId("stdio-args_1").fill(testArg1);
 
-    // Add third argument
+    // Add second option
     await page.getByTestId("input-list-plus-btn_-0").click();
-    await page.getByTestId("stdio-args_2").fill(testArg3);
+    await page.getByTestId("stdio-args_2").fill(testArg2);
+
+    // Add third option
+    await page.getByTestId("input-list-plus-btn_-0").click();
+    await page.getByTestId("stdio-args_3").fill(testArg3);
 
     // Add first environment variable
     await page.getByTestId("stdio-env-key-0").fill(testEnvKey1);
@@ -388,9 +506,12 @@ test(
     expect(await page.getByTestId("stdio-command-input").inputValue()).toBe(
       testCommand,
     );
-    expect(await page.getByTestId("stdio-args_0").inputValue()).toBe(testArg1);
-    expect(await page.getByTestId("stdio-args_1").inputValue()).toBe(testArg2);
-    expect(await page.getByTestId("stdio-args_2").inputValue()).toBe(testArg3);
+    expect(await page.getByTestId("stdio-args_0").inputValue()).toBe(
+      testPackageArg,
+    );
+    expect(await page.getByTestId("stdio-args_1").inputValue()).toBe(testArg1);
+    expect(await page.getByTestId("stdio-args_2").inputValue()).toBe(testArg2);
+    expect(await page.getByTestId("stdio-args_3").inputValue()).toBe(testArg3);
     expect(await page.getByTestId("stdio-env-key-0").last().inputValue()).toBe(
       testEnvKey1,
     );
@@ -432,7 +553,7 @@ test(
 
 test(
   "HTTP/SSE MCP server fields should persist after saving and editing",
-  { tag: ["@release", "@workspace", "@components", "@mcp"] },
+  { tag: ["@release", "@workspace", "@components", "@mcp", "@stable"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 
@@ -463,6 +584,7 @@ test(
     // Test data with random suffix
     const randomSuffix = Math.floor(Math.random() * 90000) + 10000; // 5-digit random number
     const testName = `test_http_server_${randomSuffix}`;
+    registeredServers.push(testName);
     const testUrl = "https://api.example.com/mcp";
     const testHeaderKey1 = "Authorization";
     const testHeaderValue1 = "Bearer token123";
@@ -621,7 +743,7 @@ test(
 
 test(
   "mcp server tools should be refreshed when editing a server",
-  { tag: ["@release", "@workspace", "@components", "@mcp"] },
+  { tag: ["@release", "@workspace", "@components", "@mcp", "@stable"] },
   async ({ page }) => {
     await page.waitForTimeout(5000);
 
@@ -661,9 +783,13 @@ test(
 
     const randomSuffix = Math.floor(Math.random() * 90000) + 10000; // 5-digit random number
     const testName = `test_server_${randomSuffix}`;
+    registeredServers.push(testName);
     await page.getByTestId("stdio-name-input").fill(testName);
 
-    await page.getByTestId("stdio-command-input").fill("uvx mcp-server-fetch");
+    // Server A — sequential-thinking serves exactly one tool, so the tool list
+    // it produces is unambiguous when compared against server B's below.
+    await page.getByTestId("stdio-command-input").fill(NPX);
+    await page.getByTestId("stdio-args_0").fill(PKG_SEQUENTIAL);
 
     await page.getByTestId("add-mcp-server-button").click();
 
@@ -676,45 +802,50 @@ test(
     await page.waitForSelector(
       '[data-testid="dropdown_str_tool"]:not([disabled])',
       {
-        timeout: 30000,
+        timeout: TOOL_LIST_TIMEOUT,
         state: "visible",
       },
     );
 
     await page.getByTestId("dropdown_str_tool").click();
 
-    await page.waitForSelector('[data-testid="fetch-0-option"]', {
+    await page.waitForSelector('[data-testid="sequentialthinking-0-option"]', {
       state: "visible",
       timeout: 10000,
     });
 
-    const fetchOptionCount = await page.getByTestId("fetch-0-option").count();
+    const sequentialOptionCount = await page
+      .getByTestId("sequentialthinking-0-option")
+      .count();
 
-    expect(fetchOptionCount).toBeGreaterThan(0);
+    expect(sequentialOptionCount).toBeGreaterThan(0);
 
-    await page.getByTestId("fetch-0-option").click();
+    await page.getByTestId("sequentialthinking-0-option").click();
 
     // Fit view only — no zoom step here. The helper waits on
     // `canvas_controls_dropdown` itself (30 s), which subsumes the explicit
     // 10 s wait this sequence used to open with.
     await adjustScreenView(page, { numberOfZoomOut: 0 });
 
-    await page.waitForSelector('[data-testid="int_int_max_length"]', {
+    // The selected tool's OWN inputs must render on the node. `sequentialthinking`
+    // exposes `thoughtNumber` (integer) and `thought` (string); the node lowercases
+    // integer names into `int_int_<name>` but keeps the case of string inputs.
+    await page.waitForSelector('[data-testid="int_int_thoughtnumber"]', {
       state: "visible",
       timeout: 30000,
     });
 
-    const maxLengthOptionCount = await page
-      .getByTestId("int_int_max_length")
+    const thoughtNumberOptionCount = await page
+      .getByTestId("int_int_thoughtnumber")
       .count();
 
-    expect(maxLengthOptionCount).toBeGreaterThan(0);
+    expect(thoughtNumberOptionCount).toBeGreaterThan(0);
 
-    const urlOptionCount = await page
-      .getByTestId("anchor-popover-anchor-input-url")
+    const thoughtOptionCount = await page
+      .getByTestId("anchor-popover-anchor-input-thought")
       .count();
 
-    expect(urlOptionCount).toBeGreaterThan(0);
+    expect(thoughtOptionCount).toBeGreaterThan(0);
 
     await page.getByTestId("user_menu_button").click({ timeout: 10000 });
 
@@ -766,11 +897,15 @@ test(
       timeout: 10000,
     });
 
-    expect(await page.getByTestId("stdio-command-input").inputValue()).toBe(
-      "uvx mcp-server-fetch",
+    expect(await page.getByTestId("stdio-command-input").inputValue()).toBe(NPX);
+    expect(await page.getByTestId("stdio-args_0").inputValue()).toBe(
+      PKG_SEQUENTIAL,
     );
 
-    await page.getByTestId("stdio-command-input").fill("uvx mcp-server-time");
+    // Switch to server B. Both runners are `npx` now that the command field
+    // holds a bare executable, so the package in args[0] is what changes — which
+    // also proves `args` round-trips through an edit, not only through a create.
+    await page.getByTestId("stdio-args_0").fill(PKG_EVERYTHING);
 
     await page.getByTestId("add-mcp-server-button").click();
 
@@ -812,23 +947,27 @@ test(
     await page.waitForSelector(
       '[data-testid="dropdown_str_tool"]:not([disabled])',
       {
-        timeout: 30000,
+        timeout: TOOL_LIST_TIMEOUT,
         state: "visible",
       },
     );
 
     await page.getByTestId("dropdown_str_tool").click();
 
-    await page.waitForSelector('[data-testid="get_current_time-0-option"]', {
+    // The refresh under test: the node must serve server B's tools, not the
+    // sequential-thinking list it cached before the edit.
+    await page.waitForSelector('[data-testid="echo-0-option"]', {
       state: "visible",
       timeout: 10000,
     });
 
-    const timeOptionCount = await page
-      .getByTestId("get_current_time-0-option")
-      .count();
+    const echoOptionCount = await page.getByTestId("echo-0-option").count();
 
-    expect(timeOptionCount).toBeGreaterThan(0);
+    expect(echoOptionCount).toBeGreaterThan(0);
+
+    await expect(
+      page.getByTestId("sequentialthinking-0-option"),
+    ).toHaveCount(0);
 
     await page.getByTestId("user_menu_button").click({ timeout: 10000 });
 
@@ -887,7 +1026,9 @@ test(
 
     await page.getByTestId("stdio-name-input").fill(testName);
 
-    await page.getByTestId("stdio-command-input").fill("uvx mcp-server-fetch");
+    // Re-register as server A — the node's tool list must go back to A's tools.
+    await page.getByTestId("stdio-command-input").fill(NPX);
+    await page.getByTestId("stdio-args_0").fill(PKG_SEQUENTIAL);
 
     await page.getByTestId("add-mcp-server-button").click();
 
@@ -926,27 +1067,29 @@ test(
     await page.waitForSelector(
       '[data-testid="dropdown_str_tool"]:not([disabled])',
       {
-        timeout: 30000,
+        timeout: TOOL_LIST_TIMEOUT,
         state: "visible",
       },
     );
 
     await page.getByTestId("dropdown_str_tool").click();
 
-    await page.waitForSelector('[data-testid="fetch-0-option"]', {
+    await page.waitForSelector('[data-testid="sequentialthinking-0-option"]', {
       state: "visible",
       timeout: 10000,
     });
 
-    const fetchOptionCount2 = await page.getByTestId("fetch-0-option").count();
+    const sequentialOptionCount2 = await page
+      .getByTestId("sequentialthinking-0-option")
+      .count();
 
-    expect(fetchOptionCount2).toBeGreaterThan(0);
+    expect(sequentialOptionCount2).toBeGreaterThan(0);
   },
 );
 
 test(
   "Streamable HTTP MCP server with server-everything should load tools correctly",
-  { tag: ["@release", "@workspace", "@components", "@mcp"] },
+  { tag: ["@release", "@workspace", "@components", "@mcp", "@stable"] },
   async ({ page }) => {
     (page as any).allowFlowErrors();
     await awaitBootstrapTest(page);
@@ -1000,6 +1143,7 @@ test(
 
     const randomSuffix = Math.floor(Math.random() * 90000) + 10000;
     const testName = `test_streamable_http_${randomSuffix}`;
+    registeredServers.push(testName);
 
     await page.getByTestId("http-name-input").fill(testName);
     await page.getByTestId("http-url-input").fill(server);
@@ -1043,6 +1187,96 @@ test(
     const authHeader = await getAuthToken(page.request);
     await page.request.delete(`/api/v2/mcp/servers/${testName}`, {
       headers: { Authorization: authHeader },
+    });
+  },
+);
+
+test(
+  "stdio command with an embedded argument is refused, and command plus args is accepted",
+  { tag: ["@regression", "@workspace", "@components", "@mcp", "@stable"] },
+  async ({ page }) => {
+    // The refused registration is a deliberate 422. The fixture only FAILS a
+    // test on flow errors, but this keeps the intent explicit — and the run log
+    // will carry one expected `🚨 Backend Error: 422 /api/v2/mcp/servers/...`.
+    (page as any).allowFlowErrors();
+
+    await awaitBootstrapTest(page);
+
+    await page.waitForSelector('[data-testid="blank-flow"]', {
+      timeout: 30000,
+    });
+    await page.getByTestId("blank-flow").click();
+    await page.getByTestId("sidebar-nav-mcp").click();
+
+    // Sidebar trigger, not `openAddMcpServerModal` — this test adds no MCP node
+    // to the canvas, and that helper reaches the modal through the node's
+    // server dropdown. Two testid variants exist depending on whether servers
+    // already exist; same fallback the sidebar tests above use.
+    const sidebarButton = page.getByTestId("sidebar-add-mcp-server-button");
+    const fallbackButton = page.getByTestId("add-mcp-server-button-sidebar");
+    if (await sidebarButton.isVisible({ timeout: 30000 }).catch(() => false)) {
+      await sidebarButton.click();
+    } else {
+      await fallbackButton.click();
+    }
+    await page.waitForSelector('[data-testid="add-mcp-server-button"]', {
+      state: "visible",
+      timeout: 30000,
+    });
+
+    await page.getByTestId("stdio-tab").click();
+
+    await page.waitForSelector('[data-testid="stdio-name-input"]', {
+      state: "visible",
+      timeout: 30000,
+    });
+
+    const randomSuffix = Math.floor(Math.random() * 90000) + 10000; // 5-digit random number
+    const testName = `test_contract_${randomSuffix}`;
+    registeredServers.push(testName);
+    await page.getByTestId("stdio-name-input").fill(testName);
+
+    await test.step("an executable with the package glued on is refused", async () => {
+      await page
+        .getByTestId("stdio-command-input")
+        .fill(`${NPX} ${PKG_EVERYTHING}`);
+
+      await page.getByTestId("add-mcp-server-button").click();
+
+      // The dialog surfaces the policy message and stays open.
+      await expect(page.getByRole("dialog").getByRole("alert")).toContainText(
+        /single executable name or path/i,
+        { timeout: 15000 },
+      );
+      await expect(page.getByTestId("add-mcp-server-button")).toBeVisible();
+
+      // Asserted against the API too: a modal that stayed open while the server
+      // was created anyway would satisfy a UI-only check.
+      expect(await listMcpServerNames(page)).not.toContain(testName);
+    });
+
+    await test.step("the same registration split into command + args is accepted", async () => {
+      await page.getByTestId("stdio-command-input").fill(NPX);
+      await page.getByTestId("stdio-args_0").fill(PKG_EVERYTHING);
+
+      await page.getByTestId("add-mcp-server-button").click();
+
+      await expect(page.getByTestId("add-mcp-server-button")).toBeHidden({
+        timeout: 30000,
+      });
+
+      // The accepted half is what proves the validation discriminates rather
+      // than refusing everything.
+      expect(await listMcpServerNames(page)).toContain(testName);
+
+      const authHeader = await getAuthToken(page.request);
+      const stored = await (
+        await page.request.get(`/api/v2/mcp/servers/${testName}`, {
+          headers: authHeader ? { Authorization: authHeader } : undefined,
+        })
+      ).json();
+      expect(stored.command).toBe(NPX);
+      expect(stored.args).toEqual([PKG_EVERYTHING]);
     });
   },
 );


### PR DESCRIPTION
**Closes #1091.**

## Problem

All six stdio registrations in `mcp/server/mcp-server.spec.ts` filled
`stdio-command-input` with `<executable> <package>` (e.g. `uvx mcp-server-fetch`,
`npx @modelcontextprotocol/server-everything`). Every one of them was refused:

```
HTTP 422 — Value error, MCP stdio command must be a single executable name or
path; put options and arguments in the 'args' field
```

Root cause is upstream and intentional: `src/lfx/src/lfx/base/mcp/security.py` →
`validate_mcp_stdio_config()` requires `command` to be exactly one executable so
every policy layer (allowlist, arg blocklist, interpreter hardening) sees the
same argv. It arrived with the multi-tenant hardening trail — `#13530` →
`#14044` → `f4d6ac4` (`#14073`, 2026-07-15). `npx` and `uvx` remain in
`ALLOWED_MCP_COMMANDS`; only the input shape moved.

**Verdict: test defect**, not a Langflow regression and not a dead surface.

The break went unnoticed for two weeks because none of these tests carried
`@stable` — the file ran in no automated lane.

## Fix

- **Split the six registrations** into a bare executable plus `stdio-args_N`,
  and assert **both halves** round-trip through save → reopen-for-edit (a
  backend that dropped `args` would still show the right command).
- **Repoint the tool-refresh test at `npx` servers that actually start.**
  Splitting command/args was necessary but not sufficient: the published
  `mcp-server-fetch` / `mcp-server-time` packages now fail at import against the
  current `mcp` Python SDK — `ImportError: cannot import name 'McpError' from
  'mcp.shared.exceptions'` (renamed to `MCPError`) — reproduced inside the
  nightly container and **not** fixed by pinning the server version, because its
  `mcp` dependency floats. That is a third-party breakage in
  `modelcontextprotocol/servers`, outside both Langflow and this suite. The pair
  is now `server-sequential-thinking` → `server-everything`, the same shape the
  `@stable` `mcp/client/` specs already use. *Rejected alternative:* `uvx --with
  mcp==<version>` — it pins a floating SDK to a version that rots, and the
  package-runner coverage is preserved anyway (see below).
- **`uvx` stays covered as a command** by the field-persistence test, which never
  starts the subprocess (its package is deliberately non-existent).
- **Tool-list budget 30 s → 120 s**, matching the cold-`npx` precedent from #463.
  The 30 s was never exercised in CI.
- **A second defect the repair exposed.** With registration working again, test 1
  reached an assertion it had never executed: it sampled the selected tool's
  `message` input with a bare `count()` immediately after the option click,
  before the node rebuild landed. Now an auto-retrying `toBeVisible`, matching
  how the `@stable` sibling that selects the same `echo` tool waits.
- **Id-scoped `afterEach` cleanup** for flows and registered MCP servers — the
  file had none.
- **New `@regression` test** pinning the contract, so a silent removal of that
  validation fails the suite.
- **Promoted all seven tests to `@stable`**, closing the lane gap that hid this.

## Scope note

Tests 4 and 6 (HTTP/SSE persistence, Streamable HTTP) have no stdio surface and
are unchanged apart from cleanup registration. The commented-out SSE block at the
bottom of the file is untouched. Test 5's differentiator moves from `command` to
`args[0]` — both runners are `npx` now — so "change the command" coverage is
traded for "`args` round-trips on edit"; recorded in the spec doc.

## Covered tests

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `user must be able to change mode of MCP tools without any issues` | `toolsCount` leaves `null`; `echo-0-option` present; the tool's `message` input renders; on edit both `command === "npx"` and `args_0 === package` round-trip; the server disappears after delete |
| 2 | `user must be able to add and delete MCP server from sidebar` | Registration from the sidebar renders `dropdown_str_tool`; the server is listed in Settings and is gone after a confirmed delete |
| 3 | `STDIO MCP server fields should persist after saving and editing` | Nine values round-trip: name, `uvx`, `args_0..3`, two env pairs |
| 4 | `HTTP/SSE MCP server fields should persist after saving and editing` | Ten values round-trip: name, URL, two headers, two env pairs |
| 5 | `mcp server tools should be refreshed when editing a server` | A serves `sequentialthinking-0-option` + renders `int_int_thoughtnumber` / `anchor-popover-anchor-input-thought`; after editing `args[0]` the list serves `echo-0-option` **and** `sequentialthinking-0-option` has count 0; after re-registering A it is back |
| 6 | `Streamable HTTP MCP server with server-everything should load tools correctly` | The project's own `/streamable` endpoint registers and exposes ≥1 tool |
| 7 | `stdio command with an embedded argument is refused, and command plus args is accepted` *(new)* | Refusal: modal stays open, in-dialog `role="alert"` matches `/single executable name or path/`, and the API does **not** list the name. Acceptance: modal closes and the API stores `command === "npx"`, `args === [package]` |

Test 7 asserts **both** directions on purpose: a refusal assert alone would pass
against a modal that rejected everything, and it checks the API as well as the
UI, so a modal that stayed open while the server was created anyway cannot pass.

## Validation (nightly `1.12.0.dev9`, `--workers=1 --retries=0`)

- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors) · QA-CHECKLIST guard ✅ · coverage guard ✅
- **Two consecutive clean runs:** `7 passed (6.1m)` and `7 passed (6.2m)` ✅
- **Force-fail — executed, one mutation per test, all observed failing:**

  | Mutation | Observed failure |
  |---|---|
  | T1 `message` input testid → nonexistent | `element(s) not found` |
  | T2 delete confirmation cancelled | `Expected: not visible / Received: visible` |
  | T3 `args_3` expected `"FFMUT"` | `Received: "--config=test.json"` |
  | T4 second header expected `"FFMUT"` | `Received: "application/json"` |
  | T5 server B points at server A's package | `waiting for echo-0-option` |
  | T6 `toBeGreaterThan(10000)` | `Received: 1` |
  | T7 rejection step fed the already-valid command | `waiting for dialog > alert` |
  | `afterEach` cleanup returns early | leaked 3 flows + 1 MCP server (27 → 30) |

  A first attempt at T2 (flipping `not.toBeVisible` → `toBeVisible`) **passed** —
  the row still exists during the removal animation — so it was replaced with the
  behavioral mutation above. Mutations reverted; 0 `FFMUT` markers remain.
- **Orphan check:** 27 flows after both clean runs (baseline 27), no test MCP
  servers left ✅
- `--trace=on` **not run** — it hangs on this ReactFlow-canvas family (known
  repo limitation); step verification came from the `--retries=0` bursts,
  force-fail and live `playwright` scouting.
- **One expected `🚨 Backend Error: 422`** per run, emitted by test 7's
  deliberate refusal. Commented in the test.

## Dependencies

- No LLM / provider key — pure UI + MCP API.
- Network egress to the npm registry: the stdio tests run real MCP servers via
  `npx` inside the Langflow container (hence the 120 s cold-start budget).
- Parallel-safe: per-run random server names, id-scoped cleanup, no shared
  fixture state.
