### PR TITLE
fix(ui-ux): wait for the post-action canvas viewport transform (#1094)

### DIFF
--- a/docs/ui-ux/canvas-zoom-navigation.md
+++ b/docs/ui-ux/canvas-zoom-navigation.md
@@ -26,6 +26,23 @@ on a clamped viewport "zoom in raises the scale" is untestable. The tests assert
 the behavior of the controls, not this entry state; test 3 is the one that uses
 it, as a free "displaced viewport" to prove Fit View acts.
 
+**Wait strategy — why a plain "the transform stopped changing" poll is not enough
+(#1094).** React Flow commits a viewport change in one frame (measured: the
+transform still holds its pre-click value at `t+0` after the `fit_view` click and
+carries the fitted value by `t+100ms`), and Playwright's `expect.poll` runs its
+callback immediately. A settle poll seeded with a transform read *before* the
+action therefore compares the pre-action value against itself on its first tick,
+reports "settled" and hands back the **stale** viewport — which is how this spec
+read `scale(2)` out of a Fit View that had already fitted to `0.880331`. Whether
+the commit landed before that first read depends on CDP round-trip timing, so the
+same code passed in CI and failed locally. So `waitForViewportSettled` takes an
+optional predicate: every step whose action *must* move the viewport waits for a
+transform that both **differs from the pre-action one** and then holds, and
+`normalizeViewport` waits on its real postcondition (the nodes contained in the
+pane) rather than on "something changed". Only the two steps where no change is
+expected — editor hydration and the second, idempotent `fit_view` click — use the
+bare settle.
+
 Four independent tests:
 
 1. **Zoom in / Zoom out** — `zoom_in` multiplies the viewport scale by `1.2` per
@@ -81,6 +98,7 @@ part of test 3's enabled-controls assertion), and the minimap.
 | Zoom-out clamp | `zoom_out` becomes `disabled` with scale exactly `0.25`; `zoom_in` still enabled |
 | Zoom-in clamp | `zoom_in` becomes `disabled` with scale exactly `2`; `zoom_out` still enabled |
 | Fit View precondition | at scale `2` the nodes' union box is NOT contained in the pane rect |
+| Fit View scale | the fitted scale is strictly below `maxZoom` (`2`). Sound for this fixture, not an accident of the pane: the two nodes span `1090 × 315` flow px, so the unclamped fit is `min(1000/1090, 672/315) ≈ 0.92` — measured `0.880331` live, a factor of 2.3 away from the bound (#1094) |
 | Fit View centering | union box inside the pane rect (1 px tolerance) AND \|union center − pane center\| ≤ 4 px on both axes AND both node titles visible |
 | Fit View idempotence | second `fit_view` click leaves the `transform` string byte-identical |
 | Toolbar collapsed | `main_canvas_controls` visible; `fit_view`/`zoom_in`/`zoom_out`/`reset_zoom` `count() === 0` |
@@ -147,13 +165,15 @@ the editor's event poll.
      (scale `2`, at least one click landed).
   2. Measure the union box of `.react-flow__node` against the
      `.react-flow__pane` rect — assert it overflows (precondition).
-  3. Click `fit_view`.
+  3. Record the transform, click `fit_view`, and wait for a transform that
+     differs from the recorded one and then holds (see *Wait strategy*).
   4. Re-measure the union box and the pane rect; read `title-Chat Input` and
      `title-Chat Output` visibility; read the transform string.
   5. Click `fit_view` again; read the transform string.
-- **Validation:** after step 3 the union box is inside the pane (1 px tolerance),
-  its center is within 4 px of the pane center on both axes, both titles are
-  visible, and the step-5 transform is identical to the step-4 one.
+- **Validation:** after step 3 the fitted scale is strictly below `2`, the union
+  box is inside the pane (1 px tolerance), its center is within 4 px of the pane
+  center on both axes, both titles are visible, and the step-5 transform is
+  identical to the step-4 one.
 
 ### 15.5.3 Fit View is reachable from the canvas controls toolbar [-]
 
@@ -201,4 +221,4 @@ the editor's event poll.
 
 ## Last validated
 
-1.12.x (nightly `1.12.0.dev6`)
+1.12.x (nightly `1.12.0.dev9`; originally authored against `1.12.0.dev6`)

--- a/tests/tests-automations/regression/ui-ux/canvas-zoom-navigation.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/canvas-zoom-navigation.spec.ts
@@ -21,6 +21,12 @@ import { createRunnableChatFlowViaApi } from "../../../helpers/flows/create-runn
 // The flow is a repo-owned Chat Input -> Chat Output fixture created through the
 // API: no starter template, no provider key, no LLM call and no flow build, so
 // the spec is pure viewport geometry.
+//
+// Every viewport read goes through `waitForViewportSettled`, whose contract is
+// load-bearing rather than incidental: React Flow commits a viewport change in
+// one frame, so a settle poll can hand back the PRE-action transform and redden
+// an assertion about a control that worked. Read its comment before touching any
+// wait in this file (#1094).
 
 // React Flow bounds configured by Langflow. A silent change to either bound is a
 // product change this spec is meant to catch.
@@ -153,11 +159,20 @@ async function openCanvasControls(page: Page): Promise<void> {
  * already disabled — reproducible across reloads). Without normalizing, "zoom in
  * raises the scale" is untestable, so each test that measures relative zoom
  * starts from the deterministic Fit View state instead.
+ *
+ * The wait is on containment rather than on "the transform changed" (#1094): the
+ * baseline this returns is the divisor of every relative zoom assertion, so it
+ * must be the fitted viewport and not whatever the transform happened to hold on
+ * the first read. Containment is the postcondition regardless of the entry state,
+ * so this keeps working if the editor ever stops opening clamped.
  */
 async function normalizeViewport(page: Page): Promise<Viewport> {
   await openCanvasControls(page);
   await page.getByTestId("fit_view").click();
-  const fitted = await waitForViewportSettled(page);
+  const fitted = await waitForViewportSettled(
+    page,
+    async () => (await measureGeometry(page)).contained,
+  );
   await closeCanvasControls(page);
   return fitted;
 }
@@ -200,25 +215,61 @@ async function zoomUntilClamped(
   return clicks;
 }
 
+/** Sentinel no transform string can equal — see waitForViewportSettled. */
+const UNREAD_TRANSFORM = "<unread>";
+
 /**
- * Waits for the viewport transform to settle (React Flow animates zoom/fit
- * transitions), then returns the settled viewport. Polls the transform instead
- * of sleeping a fixed amount, so the wait tracks the real animation.
+ * Waits for the viewport transform to settle, then returns the settled viewport.
+ *
+ * `settledWhen` is the postcondition the caller actually depends on, and it is
+ * mandatory reading rather than a nicety (#1094). React Flow commits a viewport
+ * change in a single frame — measured: after the `fit_view` click the transform
+ * still holds its pre-click value at `t+0` and carries the fitted one by
+ * `t+100ms` — while `expect.poll` runs its callback immediately. Seeding
+ * `previous` with a transform read BEFORE the poll therefore let the first tick
+ * compare the pre-action value against itself, report "settled" and hand back the
+ * STALE viewport: that is how this spec read `scale(2)` out of a Fit View that had
+ * already fitted to `0.880331`. Whether the commit landed before that first read
+ * came down to CDP round-trip timing, so the identical code passed in CI and
+ * failed locally.
+ *
+ * Two guards, therefore:
+ *  - `previous` starts on a sentinel, so the first tick can never resolve and the
+ *    stability check always compares two reads at least one interval apart;
+ *  - `settledWhen` lets a caller demand the state it is about to assert on — a
+ *    transform different from the pre-action one, or the fitted geometry — so a
+ *    viewport that never moved times out here, naming the wait, instead of
+ *    reddening an unrelated assertion downstream.
+ *
+ * It defaults to "any stable transform", which is correct only where no change is
+ * expected: editor hydration and the idempotent second `fit_view` click.
  */
-async function waitForViewportSettled(page: Page): Promise<Viewport> {
-  let previous = await readTransform(page);
+async function waitForViewportSettled(
+  page: Page,
+  settledWhen: (transform: string) => boolean | Promise<boolean> = () => true,
+): Promise<Viewport> {
+  let previous = UNREAD_TRANSFORM;
   await expect
     .poll(
       async () => {
         const current = await readTransform(page);
-        const stable = current === previous;
+        const stable = current !== UNREAD_TRANSFORM && current === previous;
         previous = current;
-        return stable;
+        return stable && (await settledWhen(current));
       },
-      { timeout: 15000, intervals: [150, 150, 150, 200] },
+      {
+        timeout: 15000,
+        intervals: [150, 150, 150, 200],
+        message: "the canvas viewport never reached the expected settled state",
+      },
     )
     .toBe(true);
   return readViewport(page);
+}
+
+/** `settledWhen` predicate: the viewport moved off `from` and then held. */
+function movedFrom(from: string): (transform: string) => boolean {
+  return (transform) => transform !== from;
 }
 
 /** The flow-space point under a screen point, given the current viewport. */
@@ -281,25 +332,31 @@ test.describe("ui-ux — canvas zoom and navigation", () => {
       });
 
       await test.step("zoom in multiplies the scale by the zoom step", async () => {
+        const before = await readTransform(page);
         await page.getByTestId("zoom_in").click();
-        const zoomedIn = await waitForViewportSettled(page);
+        const zoomedIn = await waitForViewportSettled(page, movedFrom(before));
 
         expect(zoomedIn.scale).toBeGreaterThan(baseline.scale);
         expect(zoomedIn.scale / baseline.scale).toBeCloseTo(ZOOM_STEP, 2);
       });
 
       await test.step("zoom out returns the scale to its previous value", async () => {
+        const before = await readTransform(page);
         await page.getByTestId("zoom_out").click();
-        const zoomedOut = await waitForViewportSettled(page);
+        const zoomedOut = await waitForViewportSettled(page, movedFrom(before));
 
         expect(zoomedOut.scale).toBeCloseTo(baseline.scale, 3);
       });
 
       await test.step("zoom out clamps at the minimum zoom and disables the button", async () => {
+        // `movedFrom` and not "scale is at the bound": predicating the wait on the
+        // value under test would turn a wrong clamp into an opaque 15s timeout.
+        // The bound itself is asserted below, off the settled read.
+        const before = await readTransform(page);
         const clicks = await zoomUntilClamped(page, "zoom_out");
         expect(clicks).toBeLessThan(MAX_ZOOM_CLICKS);
 
-        const clamped = await waitForViewportSettled(page);
+        const clamped = await waitForViewportSettled(page, movedFrom(before));
         expect(clamped.scale).toBeCloseTo(MIN_ZOOM, 4);
         await expect(page.getByTestId("zoom_out")).toBeDisabled();
         // The opposite direction must stay available at the bound.
@@ -307,10 +364,11 @@ test.describe("ui-ux — canvas zoom and navigation", () => {
       });
 
       await test.step("zoom in clamps at the maximum zoom and disables the button", async () => {
+        const before = await readTransform(page);
         const clicks = await zoomUntilClamped(page, "zoom_in");
         expect(clicks).toBeLessThan(MAX_ZOOM_CLICKS);
 
-        const clamped = await waitForViewportSettled(page);
+        const clamped = await waitForViewportSettled(page, movedFrom(before));
         expect(clamped.scale).toBeCloseTo(MAX_ZOOM, 4);
         await expect(page.getByTestId("zoom_in")).toBeDisabled();
         await expect(page.getByTestId("zoom_out")).toBeEnabled();
@@ -325,10 +383,11 @@ test.describe("ui-ux — canvas zoom and navigation", () => {
         // doing rather than the editor's entry state.
         await normalizeViewport(page);
         await openCanvasControls(page);
+        const before = await readTransform(page);
         const clicks = await zoomUntilClamped(page, "zoom_in");
         expect(clicks).toBeGreaterThan(0);
         expect(clicks).toBeLessThan(MAX_ZOOM_CLICKS);
-        const clamped = await waitForViewportSettled(page);
+        const clamped = await waitForViewportSettled(page, movedFrom(before));
         expect(clamped.scale).toBeCloseTo(MAX_ZOOM, 4);
       });
 
@@ -344,10 +403,16 @@ test.describe("ui-ux — canvas zoom and navigation", () => {
 
       await test.step("Fit View brings every node inside the pane, centered", async () => {
         await openCanvasControls(page);
+        const displaced = await readTransform(page);
         await page.getByTestId("fit_view").click();
-        const fitted = await waitForViewportSettled(page);
+        const fitted = await waitForViewportSettled(page, movedFrom(displaced));
         fittedTransform = await readTransform(page);
 
+        // Sound for this fixture rather than a property of Fit View in general:
+        // the two nodes span 1090 x 315 flow px against a 1000 x 672 pane, so the
+        // unclamped fit is ~0.92 (measured 0.880331) — a factor of 2.3 off the
+        // bound. A fitted scale reading exactly `2` means the viewport never left
+        // the max-zoom clamp, which is the failure this asserts (#1094).
         expect(fitted.scale).toBeLessThan(MAX_ZOOM);
 
         const geometry = await measureGeometry(page);
@@ -366,6 +431,12 @@ test.describe("ui-ux — canvas zoom and navigation", () => {
       await test.step("a second Fit View click is a no-op", async () => {
         // Idempotence is the contract the suite's adjustScreenView helper relies
         // on: fitting twice must not drift the viewport.
+        //
+        // The one step that must NOT wait for a change — so it waits for two
+        // identical reads at least one poll interval apart instead (#1094). A
+        // no-op and a not-yet-committed fit are indistinguishable from the
+        // transform alone; the interval is what separates them in practice, and
+        // the previous step has already proven this same click does commit.
         await openCanvasControls(page);
         await page.getByTestId("fit_view").click();
         await waitForViewportSettled(page);
@@ -404,7 +475,10 @@ test.describe("ui-ux — canvas zoom and navigation", () => {
         expect((await measureGeometry(page)).contained).toBe(false);
 
         await page.getByTestId("fit_view").click();
-        await waitForViewportSettled(page);
+        // The wait demands the move; the assertion below still states it, so a
+        // regression reports as a diff on the transform and not only as a wait
+        // timeout.
+        await waitForViewportSettled(page, movedFrom(displacedTransform));
 
         expect(await readTransform(page)).not.toBe(displacedTransform);
         expect((await measureGeometry(page)).contained).toBe(true);
@@ -451,10 +525,11 @@ test.describe("ui-ux — canvas zoom and navigation", () => {
 
       await test.step("scrolling down zooms out around the pointer", async () => {
         const anchorBefore = toFlowCoords(baseline, pointP.x, pointP.y, pane);
+        const before = await readTransform(page);
 
         await page.mouse.move(pointP.x, pointP.y);
         await page.mouse.wheel(0, WHEEL_DELTA);
-        const scrolled = await waitForViewportSettled(page);
+        const scrolled = await waitForViewportSettled(page, movedFrom(before));
 
         expect(scrolled.scale).toBeLessThan(baseline.scale);
 
@@ -470,9 +545,13 @@ test.describe("ui-ux — canvas zoom and navigation", () => {
       await test.step("scrolling up restores the previous zoom level", async () => {
         const before = await readViewport(page);
         const anchorBefore = toFlowCoords(before, pointP.x, pointP.y, pane);
+        const beforeTransform = await readTransform(page);
 
         await page.mouse.wheel(0, -WHEEL_DELTA);
-        const scrolled = await waitForViewportSettled(page);
+        const scrolled = await waitForViewportSettled(
+          page,
+          movedFrom(beforeTransform),
+        );
 
         expect(scrolled.scale).toBeGreaterThan(before.scale);
         expect(scrolled.scale).toBeCloseTo(baseline.scale, 3);
@@ -491,10 +570,14 @@ test.describe("ui-ux — canvas zoom and navigation", () => {
         // steps above only by luck and fails here.
         const before = await readViewport(page);
         const anchorBefore = toFlowCoords(before, pointQ.x, pointQ.y, pane);
+        const beforeTransform = await readTransform(page);
 
         await page.mouse.move(pointQ.x, pointQ.y);
         await page.mouse.wheel(0, WHEEL_DELTA);
-        const scrolled = await waitForViewportSettled(page);
+        const scrolled = await waitForViewportSettled(
+          page,
+          movedFrom(beforeTransform),
+        );
 
         expect(scrolled.scale).toBeLessThan(before.scale);
 


### PR DESCRIPTION
**Fixes #1094.** Closes #1094.

## Problem

`canvas-zoom-navigation.spec.ts:351` (`@stable`) failed on
`expect(fitted.scale).toBeLessThan(MAX_ZOOM)` with `fitted.scale` landing exactly
on `2`. Reproduced on clean `main` against nightly `1.12.0.dev9`
(`--workers=1 --retries=0`), 2/2; absent from the 07-27..29 dailies.

**The issue's diagnosis does not hold, and neither do its three options.** It read
the failure as an unsound assertion — Fit View clamping *at* `maxZoom` on a pane
wide enough for two nodes. Measured live instead:

| Measurement | Value |
|---|---|
| pane | `1000 x 672` |
| node flow-space size / positions | `320 x 207` at `x=689.572` and `x=1460.07` |
| nodes' union bounds | `1090 x 315` flow px |
| unclamped fit zoom | `min(1000/1090, 672/315) ≈ 0.92` |
| **fitted scale actually produced** | **`0.880331`** — a factor of 2.3 off the bound |

So the fit is bounded by width at ~0.88 and never approaches the clamp. Giving the
nodes more spread (option 1) is unnecessary; pinning the viewport (option 2) is a
no-op, since `devices["Desktop Chrome"]` already fixes it at 1280x720 → the same
1000x672 pane in CI and locally (the spec doc records this at its *Non-criterion*
note); dropping the assertion (option 3) would discard a sound check.

**Root cause: the wait strategy.** Instrumenting the click shows Fit View working
and committing inside one frame:

```
before click:  translate(-1971.91px, -1508.88px) scale(2)
t+0ms:         translate(-1971.91px, -1508.88px) scale(2)      <- still pre-click
t+100ms:       translate(-588.052px, -476.054px) scale(0.880331)
```

`waitForViewportSettled` seeded `previous` with a transform read **before** the
poll, and `expect.poll` runs its callback immediately — so the first tick compared
the pre-click value against itself, reported "settled" and handed back the
**stale** viewport (`scale(2)`). Whether the commit landed before that first read
depended on CDP round-trip latency, which is exactly why identical code passed in
CI and failed locally. Every relative read in the file was exposed, not just the
Fit View one.

## Fix

Two independent guards in `waitForViewportSettled`:

- **Sentinel seed** — `previous` starts on `UNREAD_TRANSFORM`, so the first tick can
  never resolve and the stability check always compares two reads at least one poll
  interval apart.
- **`settledWhen` predicate** — each call site demands the state it is about to
  assert on: `movedFrom(<pre-action transform>)` for every action that must move the
  viewport (both `fit_view` sites, the single-click and clamp-loop zoom steps, the
  three wheel steps), and the fitted-geometry postcondition (`contained`) in
  `normalizeViewport`, whose return value is the divisor of every relative zoom
  assertion. A viewport that never moves now times out naming the wait
  (`the canvas viewport never reached the expected settled state`) instead of
  reddening an unrelated assertion downstream.

Deliberately **not** predicated on the value under test: the clamp steps wait on
`movedFrom`, not on "scale is at the bound", so a wrong clamp still fails as a
value diff rather than as an opaque 15 s timeout.

Rejected: relaxing `:351` to `toBeLessThanOrEqual` (would admit exactly the no-op
case the `contained === false` precondition exists to exclude, and the assertion is
sound anyway), and the issue's options 1–3 per the table above.

## Scope note

- No assertion was weakened or removed; `expect(fitted.scale).toBeLessThan(MAX_ZOOM)`
  stays, now with the arithmetic that proves it sound recorded in the code and the
  spec doc.
- The `contained === false` precondition at `:339` — the teeth that stop the test
  passing on a dead Fit View button — is untouched.
- The one wait where no change is expected (the idempotent second `fit_view` click)
  keeps the bare settle, by design.
- No tag change: all four tests stay `@stable`. No `QA-CHECKLIST.md` change: the
  eight bullets for this spec are already `[x]` and coverage is unaffected.
- `tests/helpers/ui/adjust-screen-view.ts` was checked for the same pattern — it
  already seeds `previous = null`, so it is not affected and needs no follow-up.

## Validation (nightly `1.12.0.dev9`, `--workers=1 --retries=0`)

- typecheck ✅ (`tsc --noEmit` clean) · eslint ✅ (0 errors)
- **4 clean runs**, no flake: 16.0s / 16.1s / 15.7s / 15.5s (+ a 5th at 16.3s for the log capture)
- `--trace=on` ✅ — 1 passed in 6.2s; the #518 trace hang does not affect this family
- zero `🚨 Backend Error` ✅ · zero `HTTP error(s) detected` ✅
- flow cleanup ✅ — `GET /api/v1/flows/` returns 27 flows, all Langflow starter
  templates; zero `Runnable Chat Flow *` orphans after ~14 runs
- **force-fail ✅ — every test in the file, executed, reverted (0 mutation markers left)**

| Mutation | Result |
|---|---|
| both guards defeated (**= pre-fix code**) | test 2 fails at `:351` — `Expected: < 2 / Received: 2`, reproducing the issue exactly |
| `movedFrom` defeated only | **passes** — the sentinel alone suffices at normal timing |
| sentinel reverted only | **passes** — `movedFrom` alone suffices ⇒ the two guards are independently sufficient |
| `fit_view` click removed (test 2) | fails with `the canvas viewport never reached the expected settled state` (15 s predicate timeout) instead of passing silently |
| `fit_view` click removed (test 3) | same — the wait has teeth on the toolbar path too |
| `ZOOM_STEP` 1.2 → 1.5 (test 1) | fails — `Expected: 1.5 / Received: 1.2000031806218343` |
| `WHEEL_DELTA` 300 → −300 (test 4) | fails — `Expected: < 0.880331 / Received: 1.33433` |
