### PR TITLE
fix(ui-ux): return the verified transform from the canvas viewport wait (#1099)

### DIFF
--- a/docs/ui-ux/canvas-zoom-navigation.md
+++ b/docs/ui-ux/canvas-zoom-navigation.md
@@ -57,6 +57,13 @@ never fail. Reading the DOM again keeps that assertion independent of the wait, 
 it still catches a viewport that snaps back after settling — and it is what fails
 if the predicate is ever weakened.
 
+The same one-read rule applies on the way **in**. The wheel test needs the
+pre-gesture transform twice — as numbers, to place the pointer anchor in flow
+space, and as a string, to pin `movedFrom` — and takes both from a single read
+(`parseViewport(await readTransform(page))`). Two reads could describe two
+different viewports, and the drift between them is precisely what the anchor
+tolerance then measures. There is no `readViewport` helper for that reason.
+
 Four independent tests:
 
 1. **Zoom in / Zoom out** — `zoom_in` multiplies the viewport scale by `1.2` per
@@ -112,9 +119,9 @@ part of test 3's enabled-controls assertion), and the minimap.
 | Zoom-out clamp | `zoom_out` becomes `disabled` with scale exactly `0.25`; `zoom_in` still enabled |
 | Zoom-in clamp | `zoom_in` becomes `disabled` with scale exactly `2`; `zoom_out` still enabled |
 | Fit View precondition | at scale `2` the nodes' union box is NOT contained in the pane rect |
-| Fit View scale | the fitted scale is strictly below `maxZoom` (`2`). Sound for this fixture, not an accident of the pane: the two nodes span `1090 × 315` flow px, so the unclamped fit is `min(1000/1090, 672/315) ≈ 0.92` before `fitView()`'s padding, which brings it to the `0.880331` measured live — either way a factor of ~2.3 away from the bound (#1094) |
+| Fit View scale | the fitted scale is strictly below `maxZoom` (`2`). Sound for this fixture, not an accident of the pane, and the arithmetic closes exactly: the two nodes span `1090 × 315` flow px against a `1000 × 672` pane, and Langflow's toolbar handler calls `fitView({ padding: { left: "20px", right: "20px", top: "80px" } })` (`CanvasControlsDropdown.tsx`), so the fit is width-driven: `(1000 − 40)/1090 ≈ 0.881` against the `0.880331` measured live, agreeing to the rounding of the quoted span (`960 / 0.880331 = 1090.5` flow px). Either figure is a factor of ~2.3 away from the bound (#1094) |
 | Fit View centering | union box inside the pane rect (1 px tolerance) AND \|union center − pane center\| ≤ 4 px on both axes AND both node titles visible |
-| Fit View idempotence | second `fit_view` click leaves the `transform` string byte-identical |
+| Fit View idempotence | second `fit_view` click leaves the `transform` string byte-identical — conditional on no node being **selected** between the clicks, since the handler's right padding jumps to `340px` when the inspection panel is open with a selection; this spec never selects a node |
 | Toolbar collapsed | `main_canvas_controls` visible; `fit_view`/`zoom_in`/`zoom_out`/`reset_zoom` `count() === 0` |
 | Toolbar expanded | all four controls visible after clicking `canvas_controls_dropdown`; `fit_view` and `reset_zoom` enabled |
 | Toolbar Fit View wired | nodes NOT contained before the click; after it the transform differs, every node is inside the pane, and `zoom_in`/`zoom_out` are both enabled |

--- a/docs/ui-ux/canvas-zoom-navigation.md
+++ b/docs/ui-ux/canvas-zoom-navigation.md
@@ -43,6 +43,20 @@ pane) rather than on "something changed". Only the two steps where no change is
 expected — editor hydration and the second, idempotent `fit_view` click — use the
 bare settle.
 
+The wait also **returns the transform it accepted**, parsed, rather than reading
+the DOM again once the poll clears (#1099). A fresh read would hand the caller a
+value none of the guards above had checked — the same shape of hazard, one step
+later: the wait would prove one transform sound and the assertion would run on
+another. Fit View idempotence, which compares the raw string across two clicks,
+therefore asserts on that verified string.
+
+The exception is the toolbar Fit View's "it moved" check, which keeps a **fresh**
+read on purpose. Its wait already demands `movedFrom(<displaced>)`, so asserting
+on the returned transform would restate the predicate's own precondition and could
+never fail. Reading the DOM again keeps that assertion independent of the wait, so
+it still catches a viewport that snaps back after settling — and it is what fails
+if the predicate is ever weakened.
+
 Four independent tests:
 
 1. **Zoom in / Zoom out** — `zoom_in` multiplies the viewport scale by `1.2` per
@@ -98,7 +112,7 @@ part of test 3's enabled-controls assertion), and the minimap.
 | Zoom-out clamp | `zoom_out` becomes `disabled` with scale exactly `0.25`; `zoom_in` still enabled |
 | Zoom-in clamp | `zoom_in` becomes `disabled` with scale exactly `2`; `zoom_out` still enabled |
 | Fit View precondition | at scale `2` the nodes' union box is NOT contained in the pane rect |
-| Fit View scale | the fitted scale is strictly below `maxZoom` (`2`). Sound for this fixture, not an accident of the pane: the two nodes span `1090 × 315` flow px, so the unclamped fit is `min(1000/1090, 672/315) ≈ 0.92` — measured `0.880331` live, a factor of 2.3 away from the bound (#1094) |
+| Fit View scale | the fitted scale is strictly below `maxZoom` (`2`). Sound for this fixture, not an accident of the pane: the two nodes span `1090 × 315` flow px, so the unclamped fit is `min(1000/1090, 672/315) ≈ 0.92` before `fitView()`'s padding, which brings it to the `0.880331` measured live — either way a factor of ~2.3 away from the bound (#1094) |
 | Fit View centering | union box inside the pane rect (1 px tolerance) AND \|union center − pane center\| ≤ 4 px on both axes AND both node titles visible |
 | Fit View idempotence | second `fit_view` click leaves the `transform` string byte-identical |
 | Toolbar collapsed | `main_canvas_controls` visible; `fit_view`/`zoom_in`/`zoom_out`/`reset_zoom` `count() === 0` |

--- a/tests/tests-automations/regression/ui-ux/canvas-zoom-navigation.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/canvas-zoom-navigation.spec.ts
@@ -54,6 +54,17 @@ interface Viewport {
   scale: number;
 }
 
+/**
+ * A viewport plus the exact transform string it was parsed from.
+ *
+ * `waitForViewportSettled` returns this so a caller needing the raw string (the
+ * byte-identical idempotence assertion) uses the one the wait verified instead of
+ * reading the DOM again (#1099).
+ */
+interface SettledViewport extends Viewport {
+  transform: string;
+}
+
 interface Geometry {
   /** Distance between the nodes' union-box center and the pane center. */
   centerDeltaX: number;
@@ -64,17 +75,18 @@ interface Geometry {
 }
 
 /**
- * Reads the live React Flow viewport transform.
+ * Parses a React Flow viewport transform string.
  *
  * The transform is the single source of truth for what the user sees: React Flow
  * writes `translate(<x>px, <y>px) scale(<z>)` on `.react-flow__viewport` and
  * everything on the canvas is positioned by it.
+ *
+ * Pure, and deliberately so (#1099): it lets a caller that has ALREADY read and
+ * verified a transform turn that exact string into numbers, instead of going back
+ * to the DOM for a fresh read whose value nothing has checked. See
+ * `waitForViewportSettled`.
  */
-async function readViewport(page: Page): Promise<Viewport> {
-  const transform = await page
-    .locator(".react-flow__viewport")
-    .evaluate((el) => (el as HTMLElement).style.transform);
-
+function parseViewport(transform: string): Viewport {
   const match = transform.match(
     /translate\((-?[\d.]+)px,\s*(-?[\d.]+)px\)\s*scale\(([\d.]+)\)/,
   );
@@ -85,6 +97,11 @@ async function readViewport(page: Page): Promise<Viewport> {
     y: Number(match![2]),
     scale: Number(match![3]),
   };
+}
+
+/** Reads the live viewport transform and parses it. */
+async function readViewport(page: Page): Promise<Viewport> {
+  return parseViewport(await readTransform(page));
 }
 
 /** Raw transform string — used for the byte-identical idempotence assertion. */
@@ -243,19 +260,32 @@ const UNREAD_TRANSFORM = "<unread>";
  *
  * It defaults to "any stable transform", which is correct only where no change is
  * expected: editor hydration and the idempotent second `fit_view` click.
+ *
+ * What it returns is the transform the poll ACCEPTED, parsed — not a fresh read
+ * (#1099). Re-reading the DOM after the poll would hand back a value nothing had
+ * checked, which is the same shape of hazard as the stale read above: the guards
+ * would prove one transform sound and the caller would assert on another.
+ *
+ * One exception, and it is the mirror image: a caller whose assertion would merely
+ * RESTATE its own `settledWhen` should keep reading the DOM itself, or the
+ * assertion becomes true by construction and cannot fail. See the toolbar Fit View
+ * step — don't "tidy" it into `.transform`.
  */
 async function waitForViewportSettled(
   page: Page,
   settledWhen: (transform: string) => boolean | Promise<boolean> = () => true,
-): Promise<Viewport> {
+): Promise<SettledViewport> {
   let previous = UNREAD_TRANSFORM;
+  let settled = UNREAD_TRANSFORM;
   await expect
     .poll(
       async () => {
         const current = await readTransform(page);
         const stable = current !== UNREAD_TRANSFORM && current === previous;
         previous = current;
-        return stable && (await settledWhen(current));
+        if (!stable || !(await settledWhen(current))) return false;
+        settled = current;
+        return true;
       },
       {
         timeout: 15000,
@@ -264,7 +294,7 @@ async function waitForViewportSettled(
       },
     )
     .toBe(true);
-  return readViewport(page);
+  return { ...parseViewport(settled), transform: settled };
 }
 
 /** `settledWhen` predicate: the viewport moved off `from` and then held. */
@@ -354,6 +384,10 @@ test.describe("ui-ux — canvas zoom and navigation", () => {
         // The bound itself is asserted below, off the settled read.
         const before = await readTransform(page);
         const clicks = await zoomUntilClamped(page, "zoom_out");
+        // Zero clicks would mean the button was ALREADY disabled here, which the
+        // `movedFrom` wait below can only report as an opaque timeout. State it as
+        // a click count instead, so that failure names itself (#1099).
+        expect(clicks).toBeGreaterThan(0);
         expect(clicks).toBeLessThan(MAX_ZOOM_CLICKS);
 
         const clamped = await waitForViewportSettled(page, movedFrom(before));
@@ -366,6 +400,8 @@ test.describe("ui-ux — canvas zoom and navigation", () => {
       await test.step("zoom in clamps at the maximum zoom and disables the button", async () => {
         const before = await readTransform(page);
         const clicks = await zoomUntilClamped(page, "zoom_in");
+        // Same reason as the step above (#1099).
+        expect(clicks).toBeGreaterThan(0);
         expect(clicks).toBeLessThan(MAX_ZOOM_CLICKS);
 
         const clamped = await waitForViewportSettled(page, movedFrom(before));
@@ -406,13 +442,16 @@ test.describe("ui-ux — canvas zoom and navigation", () => {
         const displaced = await readTransform(page);
         await page.getByTestId("fit_view").click();
         const fitted = await waitForViewportSettled(page, movedFrom(displaced));
-        fittedTransform = await readTransform(page);
+        // The transform the wait verified, not a fresh read: the step-5 assertion
+        // below treats this string as canonical (#1099).
+        fittedTransform = fitted.transform;
 
         // Sound for this fixture rather than a property of Fit View in general:
         // the two nodes span 1090 x 315 flow px against a 1000 x 672 pane, so the
-        // unclamped fit is ~0.92 (measured 0.880331) — a factor of 2.3 off the
-        // bound. A fitted scale reading exactly `2` means the viewport never left
-        // the max-zoom clamp, which is the failure this asserts (#1094).
+        // unclamped fit is ~0.92 before fitView()'s padding, which brings it to
+        // the measured 0.880331 — either way a factor of ~2.3 off the bound. A
+        // fitted scale reading exactly `2` means the viewport never left the
+        // max-zoom clamp, which is the failure this asserts (#1094).
         expect(fitted.scale).toBeLessThan(MAX_ZOOM);
 
         const geometry = await measureGeometry(page);
@@ -439,9 +478,9 @@ test.describe("ui-ux — canvas zoom and navigation", () => {
         // the previous step has already proven this same click does commit.
         await openCanvasControls(page);
         await page.getByTestId("fit_view").click();
-        await waitForViewportSettled(page);
+        const refitted = await waitForViewportSettled(page);
 
-        expect(await readTransform(page)).toBe(fittedTransform);
+        expect(refitted.transform).toBe(fittedTransform);
       });
     });
 
@@ -475,11 +514,13 @@ test.describe("ui-ux — canvas zoom and navigation", () => {
         expect((await measureGeometry(page)).contained).toBe(false);
 
         await page.getByTestId("fit_view").click();
-        // The wait demands the move; the assertion below still states it, so a
-        // regression reports as a diff on the transform and not only as a wait
-        // timeout.
         await waitForViewportSettled(page, movedFrom(displacedTransform));
 
+        // Deliberately a FRESH read, and the one place in this file where that is
+        // the right call (#1099): asserting on the transform the wait returned
+        // would restate `movedFrom`'s own precondition, so it could not fail —
+        // a dead assertion. Reading again keeps it independent of the predicate,
+        // so a viewport that snaps back after settling still reddens here.
         expect(await readTransform(page)).not.toBe(displacedTransform);
         expect((await measureGeometry(page)).contained).toBe(true);
         // Off the zoom bound, both zoom controls are live again.

--- a/tests/tests-automations/regression/ui-ux/canvas-zoom-navigation.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/canvas-zoom-navigation.spec.ts
@@ -99,12 +99,14 @@ function parseViewport(transform: string): Viewport {
   };
 }
 
-/** Reads the live viewport transform and parses it. */
-async function readViewport(page: Page): Promise<Viewport> {
-  return parseViewport(await readTransform(page));
-}
-
-/** Raw transform string — used for the byte-identical idempotence assertion. */
+/**
+ * Raw transform string — the only DOM read in this file.
+ *
+ * There is deliberately no `readViewport` convenience wrapper (#1099): a caller
+ * that needs both the string and the numbers must get them from ONE read, so
+ * `parseViewport(await readTransform(page))` is written out at the call site
+ * rather than hidden behind a second helper that invites a second read.
+ */
 async function readTransform(page: Page): Promise<string> {
   return page
     .locator(".react-flow__viewport")
@@ -446,12 +448,16 @@ test.describe("ui-ux — canvas zoom and navigation", () => {
         // below treats this string as canonical (#1099).
         fittedTransform = fitted.transform;
 
-        // Sound for this fixture rather than a property of Fit View in general:
-        // the two nodes span 1090 x 315 flow px against a 1000 x 672 pane, so the
-        // unclamped fit is ~0.92 before fitView()'s padding, which brings it to
-        // the measured 0.880331 — either way a factor of ~2.3 off the bound. A
-        // fitted scale reading exactly `2` means the viewport never left the
-        // max-zoom clamp, which is the failure this asserts (#1094).
+        // Sound for this fixture rather than a property of Fit View in general,
+        // and the arithmetic closes exactly: the two nodes span 1090 x 315 flow
+        // px against a 1000 x 672 pane, and Langflow's toolbar handler calls
+        // `fitView({ padding: { left: "20px", right: "20px", top: "80px" } })`
+        // (CanvasControlsDropdown.tsx), so the fit is width-driven:
+        // (1000 - 20 - 20) / 1090 ~= 0.881 against the 0.880331 measured live —
+        // they agree to the rounding of the quoted span (960 / 0.880331 = 1090.5
+        // flow px). Either figure is a factor of ~2.3 off the bound. A fitted
+        // scale reading exactly `2` means the viewport never left the max-zoom
+        // clamp, which is the failure this asserts (#1094).
         expect(fitted.scale).toBeLessThan(MAX_ZOOM);
 
         const geometry = await measureGeometry(page);
@@ -476,6 +482,12 @@ test.describe("ui-ux — canvas zoom and navigation", () => {
         // no-op and a not-yet-committed fit are indistinguishable from the
         // transform alone; the interval is what separates them in practice, and
         // the previous step has already proven this same click does commit.
+        //
+        // Idempotence here is also conditional on nothing being SELECTED between
+        // the two clicks: the handler's right padding jumps from 20px to 340px
+        // when the inspection panel is open with a node selected, so a selection
+        // would legitimately refit to a different transform. This spec never
+        // selects a node — stated because the assertion is byte-identical.
         await openCanvasControls(page);
         await page.getByTestId("fit_view").click();
         const refitted = await waitForViewportSettled(page);
@@ -565,12 +577,20 @@ test.describe("ui-ux — canvas zoom and navigation", () => {
       };
 
       await test.step("scrolling down zooms out around the pointer", async () => {
-        const anchorBefore = toFlowCoords(baseline, pointP.x, pointP.y, pane);
-        const before = await readTransform(page);
+        // ONE read, feeding both the anchor arithmetic and the wait predicate
+        // (#1099): computing the anchor off a different read than the one
+        // `movedFrom` is pinned to would let the two describe different
+        // viewports, which is exactly what the anchor comparison then measures.
+        const beforeTransform = await readTransform(page);
+        const before = parseViewport(beforeTransform);
+        const anchorBefore = toFlowCoords(before, pointP.x, pointP.y, pane);
 
         await page.mouse.move(pointP.x, pointP.y);
         await page.mouse.wheel(0, WHEEL_DELTA);
-        const scrolled = await waitForViewportSettled(page, movedFrom(before));
+        const scrolled = await waitForViewportSettled(
+          page,
+          movedFrom(beforeTransform),
+        );
 
         expect(scrolled.scale).toBeLessThan(baseline.scale);
 
@@ -584,9 +604,10 @@ test.describe("ui-ux — canvas zoom and navigation", () => {
       });
 
       await test.step("scrolling up restores the previous zoom level", async () => {
-        const before = await readViewport(page);
-        const anchorBefore = toFlowCoords(before, pointP.x, pointP.y, pane);
+        // Same single read as the step above (#1099).
         const beforeTransform = await readTransform(page);
+        const before = parseViewport(beforeTransform);
+        const anchorBefore = toFlowCoords(before, pointP.x, pointP.y, pane);
 
         await page.mouse.wheel(0, -WHEEL_DELTA);
         const scrolled = await waitForViewportSettled(
@@ -609,9 +630,9 @@ test.describe("ui-ux — canvas zoom and navigation", () => {
       await test.step("the anchor follows the pointer to a second position", async () => {
         // A zoom pinned to the pane center (instead of the cursor) passes the
         // steps above only by luck and fails here.
-        const before = await readViewport(page);
-        const anchorBefore = toFlowCoords(before, pointQ.x, pointQ.y, pane);
         const beforeTransform = await readTransform(page);
+        const before = parseViewport(beforeTransform);
+        const anchorBefore = toFlowCoords(before, pointQ.x, pointQ.y, pane);
 
         await page.mouse.move(pointQ.x, pointQ.y);
         await page.mouse.wheel(0, WHEEL_DELTA);


### PR DESCRIPTION
**Fixes #1099.** Closes #1099.

Follow-up of #1094 / #1098. Three review items left out of that PR deliberately —
none was a defect, and the fix there is correct without them.

## 1. The wait now returns the transform it verified

`waitForViewportSettled` proved a transform sound (two identical reads plus the
`settledWhen` postcondition) and then went back to the DOM for a fresh read whose
value nothing had checked — the same shape of hazard #1094 removed, one step later:
the guards would prove one transform sound and the caller would assert on another.

- `parseViewport(transform)` extracted as a pure function; `readViewport` becomes
  `parseViewport(await readTransform(page))`.
- The poll keeps the transform it accepted and returns it alongside the parsed
  viewport as `SettledViewport extends Viewport`. The field is **additive**, so all
  14 call sites compile unchanged.
- Fit View idempotence, which compares the raw string across two clicks, now
  asserts on that verified string instead of a third read.

## 2. `expect(clicks).toBeGreaterThan(0)` on test 1's two clamp steps

Test 3 already had it. Without it, a button already disabled on entry gives
`clicks === 0`, which the `movedFrom` wait can only report as an opaque 15 s
timeout instead of the diagnostic value diff — the outcome #1098 explicitly set out
to avoid for the clamp steps.

## 3. The `fitView()` padding clause

`1000/1090 = 0.917` against a measured `0.880331`; the ~4 % gap is `fitView()`'s
padding. Stated in the doc row and the comment so the arithmetic reconciles instead
of reading as a discrepancy to chase. The argument is unchanged — both values are
more than 2x away from the `2` bound.

## A dead assertion this PR introduced and then removed

Worth recording, because the first cut of item 1 made the spec weaker while looking
stricter. Applying `.transform` to the toolbar Fit View step turned

```ts
expect(refitted.transform).not.toBe(displacedTransform);
```

into an assertion that **cannot fail**: that step's wait is
`movedFrom(displacedTransform)`, so "the transform differs from the displaced one"
is the poll's own resolve condition. Asserting it on the returned value restates the
precondition — true by construction.

It also invalidated one of the force-fails: inverting that assert to `.toBe(...)`
fails by definition, so it proved the field carries the post-fit value and nothing
about the assertion having teeth.

That step therefore keeps a **fresh** read, now with the reason stated in the code,
in `waitForViewportSettled`'s docblock (the mirror-image rule: an assertion that
would merely restate its own `settledWhen` must read the DOM itself) and in the spec
doc. The general rule and its one exception are both written down so the next reader
does not "tidy" it back.

## Scope

- No assertion weakened or removed; the `contained === false` precondition and
  `expect(fitted.scale).toBeLessThan(MAX_ZOOM)` are untouched.
- Behaviour-neutral by design: the change removes CDP reads, it does not alter what
  any test asserts.
- No tag change — all four tests stay `@stable`. No `QA-CHECKLIST.md` change: the
  eight bullets are already `[x]` and coverage is unaffected.

## Validation (nightly `1.12.0.dev9`, `--workers=1 --retries=0`)

Full pass on the pre-review-fix diff:

- typecheck ✅ · eslint ✅ 0 errors · `test:scripts` 147/147 ✅ · `test:units` 136/136 ✅
- QA-CHECKLIST guard ✅ · coverage guard ✅
- **5 clean runs, no flake:** 16.1s / 17.6s / 19.7s / 23.4s / 15.5s — same band as
  #1098, so the refactor costs no time
- `--trace=on` ✅ 1 passed in 6.3s (the #518 hang does not affect this family)
- zero `🚨 Backend Error` / `HTTP error(s) detected` ✅
- flow cleanup ✅ — `GET /api/v1/flows/` returns 27 flows, all starter templates,
  zero `Runnable Chat Flow` orphans
- force-fail ✅ — executed per test, reverted, 0 mutation markers left:

| Mutation | Result |
|---|---|
| `zoomUntilClamped` never clicks (test 1) | fails at the new guard — `Expected: > 0 / Received: 0` |
| `ZOOM_STEP` 1.2 → 1.5 (test 1) | fails — `Expected: 1.5 / Received: 1.2000031806218343` |
| `fittedTransform := "MUTANT"` (test 2) | fails — `Received: "translate(-588.052px, -476.054px) scale(0.880331)"` |
| `WHEEL_DELTA` 300 → −300 (test 4) | fails — `Expected: < 0.880331 / Received: 1.33433` |

Re-validation of the review fix (typecheck, lint, clean runs, and a test-3
force-fail that weakens the predicate to a bare settle **and** drops the click — so
the wait resolves on the displaced viewport and the fresh read is what reddens)
is pending and will be posted here before merge.
