### PR TITLE
fix(project-management): tear the page down before the data and stop leaking folders (#1023)

### DIFF
--- a/docs/core-functionality/project-management/folder-crud.md
+++ b/docs/core-functionality/project-management/folder-crud.md
@@ -1,6 +1,6 @@
 # Project Management – Folder (Project) CRUD
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev9`)
 
 ---
 
@@ -11,7 +11,11 @@ the `MainPage` folder helpers (`addProject` / `renameProject` / `deleteProject` 
 `clickProject`):
 
 1. **Create** — `add-project-button` creates a new folder that appears in the
-   project sidebar as `sidebar-nav-New Project`.
+   project sidebar. The entry is addressed by the name the **backend** assigned
+   (`createProjectThroughSidebar` reads it from the `201` body), not by the
+   literal `sidebar-nav-New Project`: Langflow de-duplicates the name into
+   `New Project (N)` whenever one already exists, so the literal was a bet on the
+   instance having no other folder by that name (#1023).
 2. **Rename** — double-clicking the folder and committing a new name updates the
    sidebar entry to `sidebar-nav-<new name>`. We assert only the new unique entry
    (not the absence of `New Project`), since other specs may create `New Project`
@@ -39,12 +43,17 @@ which is required for safety under `fullyParallel`.
 ### Test 1 — create, rename and delete an empty folder
 
 1. Bootstrap the session without the templates modal (`awaitBootstrapTest(page, { skipModal: true })`).
-2. Click `add-project-button`; assert `sidebar-nav-New Project` is visible.
+2. Create the folder with `createProjectThroughSidebar(page)`; it clicks
+   `add-project-button`, captures the `201` body and asserts
+   `sidebar-nav-<assigned name>` is visible. The id it returns is what teardown
+   deletes.
 3. Rename the folder to a unique name (`crud-folder-<timestamp>`); assert the new
    `sidebar-nav-<name>` is visible (the unique entry alone proves the rename
    committed — see note above on parallel `New Project` collisions).
 4. Delete the folder via its more-options menu and confirm; assert the
    "Project deleted successfully" notification and that the sidebar entry is gone.
+5. **Cleanup (finally):** delete the captured project id through `deleteProject`
+   — see *Why the UI delete is the assertion, not the cleanup* below.
 
 ### Test 2 — delete a folder containing a flow
 
@@ -59,6 +68,28 @@ which is required for safety under `fullyParallel`.
    deleted with the folder.
 6. **Cleanup (finally):** delete the captured flow ID (ignored if already gone)
    and, only if the UI deletion did not complete, the folder ID.
+
+---
+
+## Why the UI delete is the assertion, not the cleanup (#1023)
+
+Test 1 deletes its folder through the UI and asserts the toast plus the sidebar
+entry disappearing. **Neither proves the folder is gone.** The sidebar entry is
+removed optimistically, and `DELETE /api/v1/projects/{id}` answers **500** under
+concurrent writes while the toast still reads "Project deleted successfully"
+(#965 / LE-2020 — `database is locked` on `DELETE FROM folder`). The folder then
+survives with nothing left to remove it.
+
+Measured on `1.12.0.dev9`, this folder's four specs at `--workers=2`: a **7/7
+green** run still logged a `500` on a project delete, and six consecutive runs
+from a clean instance left **11 orphan folders** named `New Project`,
+`New Project (2)`… Those leftovers are not cosmetic — with 8 of them seeded,
+`folder-deletion-integrity.spec.ts` goes from *3 passed in 18.4 s* to *2 failed
+in 55.0 s*.
+
+So the `finally` block deletes the captured id unconditionally via
+`deleteProject`, which retries the 500 and treats `404` (the happy path, where
+the UI really did delete it) as done. The UI assertions are unchanged.
 
 ---
 

--- a/docs/core-functionality/project-management/folder-deletion-integrity.md
+++ b/docs/core-functionality/project-management/folder-deletion-integrity.md
@@ -1,6 +1,6 @@
 # Folder Deletion Integrity
 
-**Last validated:** Langflow 1.12.x (`1.12.0.dev8`)
+**Last validated:** Langflow 1.12.x (`1.12.0.dev9`)
 
 ---
 
@@ -56,21 +56,22 @@ see *The destructive lane* below.
 
 **Test 2 — `deleting one folder should not affect other folders`**
 1. Bootstrap, open a template and come back (exercises the real navigation path)
-2. Create `folder-alpha` and `folder-beta` through the UI (`add-project-button` →
-   double-click the `New Project` entry → type the name → Enter)
+2. Create `folder-alpha-<stamp>` and `folder-beta-<stamp>` through the UI with
+   `createProjectThroughSidebar` (`add-project-button`, then rename the entry the
+   backend reports → type the name → Enter)
 3. Assert both sidebar entries exist
-4. Delete `folder-alpha` via its `more-options-button_folder-alpha` → `btn-delete-project` → confirm
-5. Assert the toast, assert `folder-alpha` is gone and `folder-beta` is still visible
-6. Click `folder-beta` and assert `mainpage_title` renders — the survivor is still usable
-7. Delete `folder-beta` (cleanup through the same UI path)
+4. Delete the alpha folder via its `more-options-button_<name>` → `btn-delete-project` → confirm
+5. Assert the toast, assert the alpha entry is gone and the beta one is still visible
+6. Click the beta folder and assert `mainpage_title` renders — the survivor is still usable
+7. Delete it (cleanup through the same UI path; afterEach still removes both ids)
 
 **Test 3 — `creating a new folder after deletion should work correctly`**
-1. Bootstrap, template round-trip, create `folder-one` through the UI
-2. Delete `folder-one`, assert the toast and that its sidebar entry is gone
-3. **Immediately** create `folder-two` through the same UI path
-4. Assert `folder-two` appears and `sidebar-nav-folder-two` is visible — proves no
+1. Bootstrap, template round-trip, create `folder-one-<stamp>` through the UI
+2. Delete it, assert the toast and that its sidebar entry is gone
+3. **Immediately** create `folder-two-<stamp>` through the same UI path
+4. Assert it appears and `sidebar-nav-folder-two-<stamp>` is visible — proves no
    stale-cache collision between the deletion and the next creation
-5. Delete `folder-two` (cleanup)
+5. Delete it (cleanup)
 
 **Test 4 — `deleting every folder lands on the empty project screen`** *(`@destructive`)*
 1. Create one folder via API **holding a flow** (`POST /api/v1/projects/` then
@@ -161,6 +162,71 @@ two tags as mutually exclusive — noted in `CONTRIBUTING.md` next to the tag ta
 
 ---
 
+## Teardown order and id-scoped folder cleanup (#1023)
+
+Two teardown defects survived the destructive lane (#1010) and are fixed here.
+
+### 1. The page must leave the canvas before the flow is deleted
+
+`afterEach` deletes the starter-template flow tests 2 and 3 create. When the page
+is still showing that flow, the editor keeps asking for it. Measured on
+`1.12.0.dev9` with a probe that varies **only** the page's location at delete
+time:
+
+| Page at delete time | Backend errors |
+|---|---|
+| folder view | **0** |
+| editor open, idle | `404` on `/api/v1/flows/{id}/events?since=` |
+| editor still mounting | `404` on `GET /api/v1/flows/{id}` **and** on `/events?since=` |
+
+The last row is the signature #1023 reports, and it is the state a test that dies
+inside `openTemplateAndReturnToFolders` leaves behind. Those `404`s are an
+artifact of teardown **order** — the fixture logs each as `🚨 Backend Error` and
+the deterministic pipeline's VALIDATE gate hard-stops on them — not a product
+defect, so the hook navigates to `about:blank` (no backend traffic of its own)
+before deleting anything.
+
+### 2. A UI delete is not cleanup
+
+Tests 2 and 3 delete their folders through the UI, and that used to be the only
+thing removing them. It is not reliable: `DELETE /api/v1/projects/{id}` answers
+**500** under concurrent writes while the toast still reads "Project deleted
+successfully" (#965 / LE-2020), and the folder survives. Test 1 had the same hole
+in a different shape — its `finally` only deleted the folder *if the UI deletion
+had not completed*, and "completed" was inferred from the sidebar entry
+disappearing, which the UI does optimistically.
+
+Measured: six consecutive `--workers=2` runs of the four folder specs from a
+clean instance left **11 orphan folders** (`New Project`, `New Project (2)`…),
+and the leak is what breaks the next run — with 8 of them seeded, this spec goes
+from *3 passed in 18.4 s* to *2 failed in 55.0 s*, both on `input-project` never
+appearing after the double-click. That is also why the folder names now carry a
+per-run stamp and why the fresh entry is addressed by the name the backend
+returned (`createProjectThroughSidebar`) instead of
+`getByText("New Project").last()`.
+
+Every project created through the page is therefore deleted id-scoped in
+`afterEach` via `deleteProject`, which retries the 500 and treats `404` (the
+happy path, where the UI really did delete it) as done. The same hook also
+tracks **every** `POST /api/v1/flows/ → 201` the page makes, not just the
+template one, and **all four tests register the tracker** — including the two
+that open no template. Two flows still leaked with only tests 2 and 3 tracking:
+on an instance left with no flows (which test 4 does inside its own lane),
+`awaitBootstrapTest` seeds one through `addFlowToTestOnEmptyLangflow`, and
+`openNewFlowTemplatesModal`'s welcome-overlay branch can land on a freshly
+created "New Flow". Neither is a flow the test asked for, and neither had an
+owner.
+
+**A/B for the naming half**, both arms with 8 leftover `New Project` folders
+seeded on the same instance:
+
+| Arm | Result |
+|---|---|
+| before (`getByText("New Project").last()`) | **2 failed** in 55.0 s |
+| after (name read from the `201`) | **3 passed** in 21.8 s, project count unchanged |
+
+---
+
 ## Validation criterion *(required)*
 
 - **The race is gone where it was observable.** Running the four folder-touching
@@ -169,6 +235,10 @@ two tags as mutually exclusive — noted in `CONTRIBUTING.md` next to the tag ta
   `flow-navigation-between-folders`) produces **no `404` on a sibling-owned flow
   or project id** and no folder-disappeared timeout, 3× in a row. Before the fix
   the same command logs `404`s on ids another test is still using.
+- **The run is repeatable, not just green once (#1023).** The same command, six
+  times back to back from a clean instance: 6/6 green and the project count back
+  at its baseline after **every** run. Before the id-scoped folder cleanup the
+  same six runs left 11 orphan folders and failed from run 2 onwards.
 - **The default lane really excludes it:** `npx playwright test <spec> --list`
   reports 3 tests, not 4, and a normal run prints the notice naming
   `@destructive` and the lane command.

--- a/tests/helpers/flows/create-project-through-sidebar.ts
+++ b/tests/helpers/flows/create-project-through-sidebar.ts
@@ -1,0 +1,63 @@
+import { expect, type Page } from "@playwright/test";
+
+export type CreatedProject = { id: string; name: string };
+
+/**
+ * Creates a project (folder) through the home sidebar's `add-project-button`
+ * and returns what the backend actually created — **id and name**.
+ *
+ * Why the name has to come from the API (#1023): the button always asks for a
+ * folder called "New Project", and Langflow de-duplicates that server-side into
+ * `New Project (N)` whenever the name is taken. Callers used to reach for the
+ * fresh entry with `page.getByText("New Project").last()`, which stops being
+ * the folder they just created the moment a second entry with that prefix
+ * exists — a leftover from an earlier run, or a sibling worker creating its own
+ * folder under `fullyParallel`.
+ *
+ * Measured on `1.12.0.dev9`: `folder-deletion-integrity.spec.ts` is 3 passed in
+ * 18.4 s on a clean instance and **2 failed in 55.0 s** with 8 leftover
+ * "New Project" folders seeded — both failures on `input-project` never
+ * appearing after the double-click.
+ *
+ * The returned id is what teardown deletes (`deleteProject`), so a folder
+ * created here can never be orphaned by a UI delete that silently 500s (#965).
+ */
+export async function createProjectThroughSidebar(
+  page: Page,
+): Promise<CreatedProject> {
+  const created = page.waitForResponse(
+    (response) =>
+      new URL(response.url()).pathname.replace(/\/$/, "") ===
+        "/api/v1/projects" &&
+      response.request().method() === "POST" &&
+      response.status() === 201,
+    { timeout: 30000 },
+  );
+
+  await page.getByTestId("add-project-button").click();
+
+  const project = (await (await created).json()) as CreatedProject;
+  await expect(page.getByTestId(`sidebar-nav-${project.name}`)).toBeVisible({
+    timeout: 15000,
+  });
+  return { id: project.id, name: project.name };
+}
+
+/**
+ * Renames a project through the sidebar's inline input, addressing it by its
+ * `sidebar-nav-<name>` testid rather than by a substring text match — the same
+ * ambiguity described above, on the rename side. Double-clicking the testid
+ * opens `input-project` (confirmed live on `1.12.0.dev9`).
+ */
+export async function renameProjectThroughSidebar(
+  page: Page,
+  currentName: string,
+  newName: string,
+): Promise<void> {
+  await page.getByTestId(`sidebar-nav-${currentName}`).dblclick();
+  await page.getByTestId("input-project").fill(newName);
+  await page.keyboard.press("Enter");
+  await expect(page.getByTestId(`sidebar-nav-${newName}`)).toBeVisible({
+    timeout: 15000,
+  });
+}

--- a/tests/tests-automations/regression/core-functionality/project-management/folder-crud.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/folder-crud.spec.ts
@@ -1,6 +1,10 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import {
+  createProjectThroughSidebar,
+  renameProjectThroughSidebar,
+} from "../../../../helpers/flows/create-project-through-sidebar";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { deleteProject } from "../../../../helpers/flows/delete-project";
 import { MainPage } from "../../../../pages/MainPage";
@@ -22,40 +26,60 @@ import { MainPage } from "../../../../pages/MainPage";
 test(
   "creates, renames and deletes an empty project folder via the UI",
   { tag: ["@stable", "@release", "@workspace", "@mainpage"] },
-  async ({ page }) => {
+  async ({ page, request }) => {
     await awaitBootstrapTest(page, { skipModal: true });
 
     const mainPage = new MainPage(page);
     const renamedFolder = `crud-folder-${Date.now()}`;
+    let createdId: string | undefined;
+    let createdName = "";
 
-    await test.step("Create a new folder from the sidebar", async () => {
-      await mainPage.addProject();
-      await expect(page.getByTestId("sidebar-nav-New Project")).toBeVisible({
-        timeout: 15000,
+    try {
+      await test.step("Create a new folder from the sidebar", async () => {
+        // `createProjectThroughSidebar` returns the name the backend assigned —
+        // "New Project" only while that name is free, `New Project (N)`
+        // otherwise. Asserting on the literal `sidebar-nav-New Project` was a
+        // bet on the instance having no other folder by that name (#1023).
+        const created = await createProjectThroughSidebar(page);
+        createdId = created.id;
+        createdName = created.name;
       });
-    });
 
-    await test.step("Rename the folder to a unique name", async () => {
-      await mainPage.renameProject("New Project", renamedFolder);
-      // Asserting on the unique renamed entry is enough to prove the rename
-      // committed. We deliberately do NOT assert that "New Project" is gone:
-      // several specs create folders via the UI in parallel against the same
-      // backend, so a generic "New Project" entry from another worker may
-      // legitimately exist at the same time.
-      await expect(
-        page.getByTestId(`sidebar-nav-${renamedFolder}`),
-      ).toBeVisible({ timeout: 15000 });
-    });
-
-    await test.step("Delete the folder", async () => {
-      await mainPage.deleteProject(renamedFolder);
-      await expect(page.getByText("Project deleted successfully")).toBeVisible({
-        timeout: 15000,
+      await test.step("Rename the folder to a unique name", async () => {
+        await renameProjectThroughSidebar(page, createdName, renamedFolder);
+        // Asserting on the unique renamed entry is enough to prove the rename
+        // committed. We deliberately do NOT assert that "New Project" is gone:
+        // several specs create folders via the UI in parallel against the same
+        // backend, so a generic "New Project" entry from another worker may
+        // legitimately exist at the same time.
+        await expect(
+          page.getByTestId(`sidebar-nav-${renamedFolder}`),
+        ).toBeVisible({ timeout: 15000 });
       });
-      await expect(
-        page.getByTestId(`sidebar-nav-${renamedFolder}`),
-      ).not.toBeVisible({ timeout: 10000 });
-    });
+
+      await test.step("Delete the folder", async () => {
+        await mainPage.deleteProject(renamedFolder);
+        await expect(
+          page.getByText("Project deleted successfully"),
+        ).toBeVisible({ timeout: 15000 });
+        await expect(
+          page.getByTestId(`sidebar-nav-${renamedFolder}`),
+        ).not.toBeVisible({ timeout: 10000 });
+      });
+    } finally {
+      // The UI delete above is the assertion, NOT the cleanup (#1023): the
+      // sidebar entry disappears optimistically while `DELETE
+      // /api/v1/projects/{id}` can answer 500 under contention (#965/LE-2020),
+      // leaving the folder on the instance for every later run to trip over.
+      // `deleteProject` retries the 500 and treats 404 (the happy path) as done.
+      if (createdId) {
+        await deleteProject(request, createdId, {
+          headers: { Authorization: await getAuthToken(request) },
+        }).catch((error) => {
+          console.warn(`⚠️ Orphan project left behind (${createdId}): ${error}`);
+        });
+      }
+    }
   },
 );
 

--- a/tests/tests-automations/regression/core-functionality/project-management/folder-deletion-integrity.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/folder-deletion-integrity.spec.ts
@@ -1,6 +1,11 @@
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import {
+  createProjectThroughSidebar,
+  renameProjectThroughSidebar,
+} from "../../../../helpers/flows/create-project-through-sidebar";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { deleteProject } from "../../../../helpers/flows/delete-project";
 import { MainPage } from "../../../../pages/MainPage";
@@ -20,26 +25,104 @@ import { MainPage } from "../../../../pages/MainPage";
  * REST API so they don't repeat the UI create/rename steps.
  */
 
-// Ids of flows a test created, deleted id-scoped in afterEach (#515 — never a
-// global cleanAllFlows, which wipes flows other workers are building). Tests 2
-// and 3 open a starter template to reach the folder view through the real
-// navigation path, and opening it CREATES a flow; nothing used to delete it, so
-// every run left one behind (47 flows on the local instance, 20 of them stray
-// "Basic Prompting" copies, before this was added).
-const createdFlowIds: string[] = [];
+// Ids of flows and projects a test created, deleted id-scoped in afterEach
+// (#515 — never a global cleanAllFlows, which wipes what other workers are
+// building). Tests 2 and 3 open a starter template to reach the folder view
+// through the real navigation path, and opening it CREATES a flow; nothing used
+// to delete it, so every run left one behind (47 flows on the local instance, 20
+// of them stray "Basic Prompting" copies, before this was added).
+const createdFlowIds = new Set<string>();
+const createdProjectIds = new Set<string>();
 
-test.afterEach(async ({ page, request }) => {
-  const ids = [...createdFlowIds];
-  createdFlowIds.length = 0;
-  if (ids.length === 0) return;
+/**
+ * Records every flow the PAGE creates, so teardown deletes exactly those.
+ *
+ * A listener rather than a push at the one call site (#1023): besides the
+ * starter template, `awaitBootstrapTest`'s modal path can itself land on a
+ * freshly-created "New Flow" (see `openNewFlowTemplatesModal` — the 1.10.0
+ * welcome-overlay branch), and nothing tracked that one. Six `--workers=2` runs
+ * of this folder left two stray `New Flow` copies behind on the local instance.
+ */
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (response) => {
+    if (response.request().method() !== "POST" || response.status() !== 201) {
+      return;
+    }
+    if (new URL(response.url()).pathname.replace(/\/$/, "") !== "/api/v1/flows") {
+      return;
+    }
+    response
+      .json()
+      .then((body: { id?: string }) => {
+        if (body?.id) createdFlowIds.add(body.id);
+      })
+      .catch(() => {});
+  });
+}
+
+test.afterEach(async ({ page, request }, testInfo) => {
+  const flowIds = [...createdFlowIds];
+  const projectIds = [...createdProjectIds];
+  createdFlowIds.clear();
+  createdProjectIds.clear();
+  if (flowIds.length === 0 && projectIds.length === 0) return;
+
+  // Playwright's own `screenshot: only-on-failure` fires while the page fixture
+  // tears down, which is AFTER this hook — so the navigation below would hand
+  // the report a blank canvas. Capture the failure state first: #1061 was
+  // diagnosed entirely from that artifact showing the wrong flow open.
+  if (testInfo.status !== testInfo.expectedStatus) {
+    try {
+      testInfo.annotations.push({
+        type: "url-at-teardown",
+        description: page.url(),
+      });
+      await testInfo.attach("page-at-teardown", {
+        body: await page.screenshot({ fullPage: true }),
+        contentType: "image/png",
+      });
+    } catch {
+      // The page may already be gone — the cleanup below is what matters.
+    }
+  }
+
+  // Take the page off the flow canvas BEFORE deleting anything (#1023).
+  //
+  // Deleting a flow underneath a mounted editor makes the editor keep asking
+  // for a flow that no longer exists. Measured on `1.12.0.dev9` with a probe
+  // that varies only the page's location at delete time:
+  //   - page on the folder view  → 0 backend errors;
+  //   - editor open and idle     → 404 on `/api/v1/flows/{id}/events?since=`;
+  //   - editor still mounting    → 404 on `GET /api/v1/flows/{id}` **and** on
+  //     `/events?since=` — the signature #1023 reports, and the state a test
+  //     that dies inside `openTemplateAndReturnToFolders` leaves behind.
+  //
+  // Those 404s are an artifact of teardown ORDER, not a product defect, but the
+  // fixture logs each one as `🚨 Backend Error` and the deterministic pipeline's
+  // VALIDATE gate hard-stops on them. `about:blank` (rather than `/`) is used so
+  // the teardown adds no backend traffic of its own.
+  await page.goto("about:blank").catch(() => {});
+
   const authToken = await getAuthToken(request);
-  for (const id of ids) {
+  const headers = { Authorization: authToken };
+  for (const id of flowIds) {
     // Not swallowed silently: a failed cleanup is reported, never hidden — but it
     // must not fail the hook and mask the assertion that already ran.
-    await deleteFlow(request, id, {
-      headers: { Authorization: authToken },
-    }).catch((error) => {
+    await deleteFlow(request, id, { headers }).catch((error) => {
       console.warn(`⚠️ Orphan flow left behind (${id}): ${error}`);
+    });
+  }
+  // Folders created through the UI are deleted through the UI by the tests
+  // themselves — but that delete is NOT reliable cleanup: `DELETE
+  // /api/v1/projects/{id}` answers 500 under contention while the toast still
+  // reads "Project deleted successfully", so the folder survives (#965/LE-2020).
+  // Measured: six `--workers=2` runs from a clean instance left 11 orphan
+  // folders, and tests 2 and 3 then failed every run from the second onwards.
+  // `deleteProject` retries the 500 and treats 404 (already deleted by the UI,
+  // the happy path) as done.
+  for (const id of projectIds) {
+    await deleteProject(request, id, { headers }).catch((error) => {
+      console.warn(`⚠️ Orphan project left behind (${id}): ${error}`);
     });
   }
 });
@@ -47,12 +130,12 @@ test.afterEach(async ({ page, request }) => {
 /**
  * Opens the starter-template gallery, creates a flow from "Basic Prompting" and
  * comes back to the folder view — the navigation round-trip tests 2 and 3 use to
- * reach the sidebar the way a user does. Captures the created flow id from the
- * creation POST so afterEach can delete exactly that flow.
+ * reach the sidebar the way a user does. The created flow is picked up by
+ * `trackCreatedFlows` and deleted id-scoped in afterEach.
  */
-async function openTemplateAndReturnToFolders(page: any) {
+async function openTemplateAndReturnToFolders(page: Page) {
   const flowCreation = page.waitForResponse(
-    (resp: any) =>
+    (resp) =>
       resp.url().includes("/api/v1/flows") &&
       resp.request().method() === "POST" &&
       resp.status() === 201,
@@ -62,10 +145,7 @@ async function openTemplateAndReturnToFolders(page: any) {
   await page.getByTestId("side_nav_options_all-templates").click();
   await page.getByRole("heading", { name: "Basic Prompting" }).click();
 
-  const created = (await (await flowCreation).json()) as { id?: string };
-  if (created.id) {
-    createdFlowIds.push(created.id);
-  }
+  await flowCreation;
 
   await page.waitForSelector('[data-testid="sidebar-search-input"]', {
     timeout: 30000,
@@ -83,6 +163,11 @@ test(
   "deleting a folder should update the folder list immediately",
   { tag: ["@release", "@api"] },
   async ({ page, request }) => {
+    // Registered even though this test opens no template: on an instance with no
+    // flows left (the `@destructive` sibling empties it in its own lane)
+    // `awaitBootstrapTest` seeds one through `addFlowToTestOnEmptyLangflow`, and
+    // that flow was the last untracked leak in this file (#1023).
+    trackCreatedFlows(page);
     const authToken = await getAuthToken(request);
     const folderName = `del-integrity-${Date.now()}`;
 
@@ -95,7 +180,6 @@ test(
     expect(folderRes.status()).toBe(201);
     const { id: folderId } = await folderRes.json();
 
-    let folderDeleted = false;
     try {
       await awaitBootstrapTest(page, { skipModal: true });
       const mainPage = new MainPage(page);
@@ -114,22 +198,24 @@ test(
       await expect(
         page.getByTestId(`sidebar-nav-${folderName}`),
       ).not.toBeVisible({ timeout: 10000 });
-      folderDeleted = true;
 
       // Verify the page is still functional by checking for the add project button
       await expect(page.getByTestId("add-project-button")).toBeVisible({
         timeout: 5000,
       });
     } finally {
-      if (!folderDeleted) {
-        // deleteProject retries the 500 the endpoint returns under concurrent
-        // writes (#965), which the bare request.delete accepted as done.
-        await deleteProject(request, folderId, {
-          headers: { Authorization: authToken },
-        }).catch((error) => {
-          console.warn(`⚠️ Orphan project left behind (${folderId}): ${error}`);
-        });
-      }
+      // Unconditional, not "only if the UI delete did not complete" (#1023):
+      // the sidebar entry disappearing does NOT prove the folder is gone. The
+      // UI removes it optimistically and `DELETE /api/v1/projects/{id}` answers
+      // 500 under contention while the toast still reads "deleted successfully"
+      // (#965/LE-2020) — one of those landed in a 7/7-green run here and left
+      // the folder on the instance. `deleteProject` retries the 500 and treats
+      // 404 (the happy path, where the UI really did delete it) as done.
+      await deleteProject(request, folderId, {
+        headers: { Authorization: authToken },
+      }).catch((error) => {
+        console.warn(`⚠️ Orphan project left behind (${folderId}): ${error}`);
+      });
     }
   },
 );
@@ -138,70 +224,43 @@ test(
   "deleting one folder should not affect other folders",
   { tag: ["@release", "@api"] },
   async ({ page }) => {
+    trackCreatedFlows(page);
     await awaitBootstrapTest(page);
 
     // Template round-trip to reach the folder view the way a user does; the
     // created flow is tracked and deleted in afterEach.
     await openTemplateAndReturnToFolders(page);
 
-    // Create first folder
-    await page.getByTestId("add-project-button").click();
+    // Per-run names (#1023): the fixed `folder-alpha` / `folder-beta` could be
+    // satisfied by a leftover from an earlier failed run, or collide with a
+    // sibling worker's folder under `fullyParallel`.
+    const stamp = Date.now();
+    const alpha = `folder-alpha-${stamp}`;
+    const beta = `folder-beta-${stamp}`;
 
-    await page
-      .locator("[data-testid='project-sidebar']")
-      .getByText("New Project")
-      .last()
-      .waitFor({ state: "visible", timeout: 10000 });
+    // Create both folders. `createProjectThroughSidebar` returns the name the
+    // backend actually assigned, so the rename addresses THIS folder instead of
+    // guessing with `getByText("New Project").last()` — see the helper's note.
+    const alphaProject = await createProjectThroughSidebar(page);
+    createdProjectIds.add(alphaProject.id);
+    await renameProjectThroughSidebar(page, alphaProject.name, alpha);
 
-    await page
-      .locator("[data-testid='project-sidebar']")
-      .getByText("New Project")
-      .last()
-      .dblclick();
-
-    await page.getByTestId("input-project").fill("folder-alpha");
-    await page.keyboard.press("Enter");
-
-    await page.getByText("folder-alpha").last().waitFor({
-      state: "visible",
-      timeout: 10000,
-    });
-
-    // Create second folder
-    await page.getByTestId("add-project-button").click();
-
-    await page
-      .locator("[data-testid='project-sidebar']")
-      .getByText("New Project")
-      .last()
-      .waitFor({ state: "visible", timeout: 10000 });
-
-    await page
-      .locator("[data-testid='project-sidebar']")
-      .getByText("New Project")
-      .last()
-      .dblclick();
-
-    await page.getByTestId("input-project").fill("folder-beta");
-    await page.keyboard.press("Enter");
-
-    await page.getByText("folder-beta").last().waitFor({
-      state: "visible",
-      timeout: 10000,
-    });
+    const betaProject = await createProjectThroughSidebar(page);
+    createdProjectIds.add(betaProject.id);
+    await renameProjectThroughSidebar(page, betaProject.name, beta);
 
     // Verify both folders exist
-    await expect(page.getByTestId("sidebar-nav-folder-alpha")).toBeVisible({
+    await expect(page.getByTestId(`sidebar-nav-${alpha}`)).toBeVisible({
       timeout: 5000,
     });
-    await expect(page.getByTestId("sidebar-nav-folder-beta")).toBeVisible({
+    await expect(page.getByTestId(`sidebar-nav-${beta}`)).toBeVisible({
       timeout: 5000,
     });
 
     // Delete the first folder
-    const folderAlpha = page.getByTestId("sidebar-nav-folder-alpha");
+    const folderAlpha = page.getByTestId(`sidebar-nav-${alpha}`);
     await folderAlpha.hover();
-    await page.getByTestId("more-options-button_folder-alpha").click();
+    await page.getByTestId(`more-options-button_${alpha}`).click();
     await page.getByTestId("btn-delete-project").click();
     await page.getByText("Delete").last().click();
 
@@ -210,16 +269,16 @@ test(
       timeout: 15000,
     });
 
-    // Verify folder-alpha is removed
-    await expect(page.getByTestId("sidebar-nav-folder-alpha")).not.toBeVisible({
+    // Verify the deleted folder is removed
+    await expect(page.getByTestId(`sidebar-nav-${alpha}`)).not.toBeVisible({
       timeout: 5000,
     });
 
-    // Verify folder-beta still exists and is accessible
-    const folderBeta = page.getByTestId("sidebar-nav-folder-beta");
+    // Verify the sibling folder still exists and is accessible
+    const folderBeta = page.getByTestId(`sidebar-nav-${beta}`);
     await expect(folderBeta).toBeVisible({ timeout: 5000 });
 
-    // Click on folder-beta to ensure the app is functional
+    // Click it to ensure the app is functional
     await folderBeta.click();
 
     // The page should still be functional
@@ -227,9 +286,11 @@ test(
       timeout: 10000,
     });
 
-    // Clean up - delete the remaining folder
+    // Clean up - delete the remaining folder through the same UI path. afterEach
+    // still deletes both ids via the API: this UI delete can 500 silently
+    // (#965), and the toast alone does not prove the folder is gone.
     await folderBeta.hover();
-    await page.getByTestId("more-options-button_folder-beta").click();
+    await page.getByTestId(`more-options-button_${beta}`).click();
     await page.getByTestId("btn-delete-project").click();
     await page.getByText("Delete").last().click();
 
@@ -243,39 +304,28 @@ test(
   "creating a new folder after deletion should work correctly",
   { tag: ["@release", "@api"] },
   async ({ page }) => {
+    trackCreatedFlows(page);
     await awaitBootstrapTest(page);
 
     // Template round-trip to reach the folder view the way a user does; the
     // created flow is tracked and deleted in afterEach.
     await openTemplateAndReturnToFolders(page);
 
-    // Create first folder
-    await page.getByTestId("add-project-button").click();
+    // Per-run names (#1023) — see the sibling test for why the fixed
+    // `folder-one` / `folder-two` were replaced.
+    const stamp = Date.now();
+    const one = `folder-one-${stamp}`;
+    const two = `folder-two-${stamp}`;
 
-    await page
-      .locator("[data-testid='project-sidebar']")
-      .getByText("New Project")
-      .last()
-      .waitFor({ state: "visible", timeout: 10000 });
+    // Create the first folder
+    const oneProject = await createProjectThroughSidebar(page);
+    createdProjectIds.add(oneProject.id);
+    await renameProjectThroughSidebar(page, oneProject.name, one);
 
-    await page
-      .locator("[data-testid='project-sidebar']")
-      .getByText("New Project")
-      .last()
-      .dblclick();
-
-    await page.getByTestId("input-project").fill("folder-one");
-    await page.keyboard.press("Enter");
-
-    await page.getByText("folder-one").last().waitFor({
-      state: "visible",
-      timeout: 10000,
-    });
-
-    // Delete the folder
-    const folderOne = page.getByTestId("sidebar-nav-folder-one");
+    // Delete it
+    const folderOne = page.getByTestId(`sidebar-nav-${one}`);
     await folderOne.hover();
-    await page.getByTestId("more-options-button_folder-one").click();
+    await page.getByTestId(`more-options-button_${one}`).click();
     await page.getByTestId("btn-delete-project").click();
     await page.getByText("Delete").last().click();
 
@@ -284,40 +334,23 @@ test(
     });
 
     // Verify folder is deleted
-    await expect(page.getByTestId("sidebar-nav-folder-one")).not.toBeVisible({
+    await expect(page.getByTestId(`sidebar-nav-${one}`)).not.toBeVisible({
       timeout: 5000,
     });
 
-    // Create a new folder immediately after deletion
-    await page.getByTestId("add-project-button").click();
+    // Create a new folder immediately after the deletion — the assertion under
+    // test: no stale-cache collision between a deletion and the next creation.
+    const twoProject = await createProjectThroughSidebar(page);
+    createdProjectIds.add(twoProject.id);
+    await renameProjectThroughSidebar(page, twoProject.name, two);
 
-    await page
-      .locator("[data-testid='project-sidebar']")
-      .getByText("New Project")
-      .last()
-      .waitFor({ state: "visible", timeout: 10000 });
-
-    await page
-      .locator("[data-testid='project-sidebar']")
-      .getByText("New Project")
-      .last()
-      .dblclick();
-
-    await page.getByTestId("input-project").fill("folder-two");
-    await page.keyboard.press("Enter");
-
-    // The new folder should be created successfully without any stale data issues
-    await page.getByText("folder-two").last().waitFor({
-      state: "visible",
-      timeout: 10000,
-    });
-
-    const folderTwo = page.getByTestId("sidebar-nav-folder-two");
+    const folderTwo = page.getByTestId(`sidebar-nav-${two}`);
     await expect(folderTwo).toBeVisible({ timeout: 5000 });
 
-    // Clean up
+    // Clean up through the UI; afterEach still deletes both ids via the API
+    // because this delete can 500 silently (#965).
     await folderTwo.hover();
-    await page.getByTestId("more-options-button_folder-two").click();
+    await page.getByTestId(`more-options-button_${two}`).click();
     await page.getByTestId("btn-delete-project").click();
     await page.getByText("Delete").last().click();
 
@@ -346,6 +379,7 @@ test(
   "deleting every folder lands on the empty project screen",
   { tag: ["@release", "@api", "@destructive"] },
   async ({ page, request }) => {
+    trackCreatedFlows(page);
     // Guarantee there is at least one folder holding a flow, so the
     // "delete everything" path is exercised against real content.
     const authToken = await getAuthToken(request);


### PR DESCRIPTION
Refs #1023.

Deliberately `Refs`, not `Closes`: three of the issue's four deliverables are met, the third is not and is blocked by two other issues (details in *Deliverables* below). Say the word and I'll switch it to `Closes` before merge.

## Residual A — teardown order, not contention

A probe that varies **only** the page's location at delete time, on `1.12.0.dev9`:

| Page at delete time | Backend errors |
|---|---|
| folder view | **0** |
| editor open, idle | `404` on `/api/v1/flows/{id}/events?since=` |
| editor still mounting | `404` on `GET /api/v1/flows/{id}` **and** on `/events?since=` |

The last row is the signature #1023 reports, and it is the state a test that dies inside `openTemplateAndReturnToFolders` leaves behind. This answers the issue's own question — *"does the #1021 teardown cleanup remove it or just move it?"* — with **it moved who deletes first**.

`afterEach` now takes the page to `about:blank` before deleting anything. It first attaches a screenshot and the URL when the test failed, because Playwright's `screenshot: only-on-failure` fires *later*, during the page fixture's teardown, and would otherwise capture a blank page — #1061 was diagnosed entirely from that artifact.

## Residual B — product, tracked by #1008

Deleting the *selected* folder through the UI refetches the **default** project (`200`), not the dead id. Zero `404` in the probe. Verdict: the product-side stale refetch of #1008 (which fires the same query with the literal `undefined`), not something the spec provokes. Nothing to fix here.

## What actually broke the runs — a leak the issue did not name

`DELETE /api/v1/projects/{id}` answers **500** under contention while the toast still reads *"Project deleted successfully"* (#965 / LE-2020), so the folder survives. And nothing removed it: tests 2 and 3 deleted only through the UI, and test 1's `finally` deleted the folder only *if the UI deletion had not completed* — inferred from a sidebar entry the UI removes optimistically.

| Measurement | Result |
|---|---|
| 6 × `--workers=2` from a clean instance | failures in **5 of 6** runs; **11 orphan folders** left behind |
| the same spec on a clean instance | 3 passed, 18.4 s |
| the same spec with **8** leftover `New Project` folders seeded | **2 failed, 55.0 s** — both on `input-project` never appearing |

So the leftovers are not cosmetic: they are what breaks the next run.

## Changes

| File | |
|---|---|
| `tests/helpers/flows/create-project-through-sidebar.ts` | **new.** Creates the folder through `add-project-button` and returns the id **and the name the backend assigned** — Langflow de-duplicates into `New Project (N)`, so `getByText("New Project").last()` stops pointing at the new folder as soon as a second entry with that prefix exists (a leftover, or a sibling worker's folder). Also renames by `sidebar-nav-<name>` testid. |
| `folder-deletion-integrity.spec.ts` | `about:blank` before the deletes; id-scoped project cleanup via `deleteProject`; **all four** tests register the flow tracker; per-run folder names; test 1's `finally` deletes unconditionally. |
| `folder-crud.spec.ts` | Deterministic create/rename; `finally` deletes the captured project id unconditionally. |
| both spec docs | New sections with the measured numbers; `Last validated` → `1.12.0.dev9`. |

All cleanup is id-scoped — never a global sweep (#515).

## Deliverables

- [x] **Residual A attributed and settled** — mechanism measured, and the #1021 cleanup only moved who deletes first.
- [x] **Residual B verdict recorded** — product-side stale refetch, owned by **#1008**.
- [ ] **Four specs at `--workers=2` with zero `🚨`, 5× in a row** — **not met, and not by anything in this PR's reach.** Zero failures and zero `404` across 9 runs, but every run logs a `500`: `DELETE /api/v1/projects/{id}` (**#965 / LE-2020**, 4 of 6 runs) and `POST /api/v1/flows/` (**#588**, 2 of 6). Both are product defects already filed. The `500` appears *more* often now (6/6 vs 3/6) for a benign reason: pre-fix, tests 2 and 3 died before reaching the UI delete, so they never issued the request that 500s.
- [x] **Not fixed by widening the fixture's 4xx filter or by an allowlist** — the fixture is untouched.

## Validation

Langflow nightly **`1.12.0.dev9`** (`docker inspect` matches `langflowai/langflow-nightly:latest`).

| | Before | After |
|---|---|---|
| 6 × 4 specs at `--workers=2 --retries=0` | failures in 5 of 6 | **6/6 green**, 18–22 s (was 26–37 s) |
| orphan folders after 6 runs | **11** | **0** |
| 3 final runs + the spec alone on a flowless home | — | **3/3 + 3/3**; `projects=1`, `flows=27` (baseline) |
| residual `404` (A and B) | the issue's signature | **0 in 9 runs** |

**Force-fail — 6 mutations, 6 red, all reverted** (`git diff | grep -c FF-MUTATION` = `0`):

| # | Test | Mutation | Result |
|---|---|---|---|
| 1 | `deleting a folder should update the folder list immediately` | deleted folder must still be visible | 1 failed |
| 2 | `deleting one folder should not affect other folders` | surviving sibling must be absent | 1 failed |
| 3 | `creating a new folder after deletion should work correctly` | folder created after the delete must be absent | 1 failed |
| 4 | `deleting every folder lands on the empty project screen` (`PW_DESTRUCTIVE=1`) | `folderCount` must end at `1` | 1 failed |
| 5 | `creates, renames and deletes an empty project folder via the UI` | renamed folder must be absent | 1 failed |
| 6 | `deleting a folder that contains a flow removes the flow with it` | contained flow must survive (`200`) | 1 failed |

**Behavioural A/B for the helper**, same seeded state in both arms (8 leftover `New Project` folders): before → **2 failed / 55.0 s**; after → **3 passed / 21.8 s**, project count unchanged.

`npm run typecheck` clean · `npm run lint` 0 errors.

## Honest limits

- **9 green runs do not prove the `404` is gone.** The residual was 1-in-6; three green runs at that rate is the expected outcome of doing nothing (the #1060 trap). What supports the fix is the **measured mechanism**, not the pass rate.
- **One leak is left, in two specs this PR does not touch.** `bulk-actions` and `flow-navigation-between-folders` bootstrap on a flowless home, and `addFlowToTestOnEmptyLangflow` seeds two flows per invocation that nobody tracks — 4 flows on the first run, then flat (the home is no longer empty). Proven not to be this PR's specs: `folder-deletion-integrity` run alone on a flowless home ends at `flows=27`, the exact baseline. The clean fix belongs in `addFlowToTestOnEmptyLangflow`, a helper `awaitBootstrapTest` imports — which the #1054 import-graph gate would resolve as **suite-wide**. Filed separately rather than turning a 5-file PR into a full-suite run.
- **Residual B's verdict comes from a probe, not from a reproduction of the reported event.** It never fired in 9 runs here.

## Run it

```bash
D=tests/tests-automations/regression/core-functionality/project-management
npx playwright test $D/folder-deletion-integrity.spec.ts $D/folder-crud.spec.ts \
  $D/bulk-actions.spec.ts $D/flow-navigation-between-folders.spec.ts \
  --workers=2 --retries=0
# expected: 7 passed, ~18-22s

PW_DESTRUCTIVE=1 npx playwright test $D/folder-deletion-integrity.spec.ts \
  --grep @destructive --workers=1 --retries=0
# expected: 1 passed

npx playwright test $D/folder-deletion-integrity.spec.ts --workers=1 --debug
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
