### PR TITLE
fix(model-provider): assert the provider count as a floor and restore @stable (#993)

### DIFF
--- a/docs/core-functionality/model-provider/provider-management.md
+++ b/docs/core-functionality/model-provider/provider-management.md
@@ -1,6 +1,6 @@
 # Provider Management — modal, provider count, components, add/remove API key
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x
 
 ---
 
@@ -70,9 +70,13 @@ nightly, per test file.
 
 ## Step by step *(required)*
 
-Live-scouted testids (dev33): `provider-list`, `provider-item-<Name>` (8
-providers: Google Generative AI, OpenAI, Anthropic, IBM WatsonX, Ollama,
-OpenAI Compatible, OpenRouter, vLLM), `provider-search-input`,
+Live-scouted testids (dev33; re-scouted on 1.12.0.dev9): `provider-list`,
+`provider-item-<Name>` — 8 providers on 1.11 (Google Generative AI, OpenAI,
+Anthropic, IBM WatsonX, Ollama, OpenAI Compatible, OpenRouter, vLLM), **9 on
+1.12** (`Azure AI Foundry` added). `GET /api/v1/models/providers` returns a
+wider set (11 on dev9 — it also lists Groq and Azure OpenAI, which the page
+does not render); the page, not the API, is the contract here.
+`provider-search-input`,
 `provider-variable-input-<VAR>` (e.g. `OPENAI_API_KEY`, `OPENROUTER_API_KEY`),
 `model-provider-selection`, `model-search-input`, `llm-toggle-<model>`,
 `embeddings-toggle-<model>`; Save/Cancel/Confirm buttons (by role+name);
@@ -82,7 +86,10 @@ configured providers show a **"N models"** suffix in their list item and a
 
 **`modelProviderModal.spec.ts`**
 1. *Provider list renders* — Settings → Model Providers; assert `provider-list`
-   visible and the 8 known `provider-item-*` present.
+   visible and the 8 known `provider-item-*` present. **This spec owns the
+   by-name contract**: a known provider silently dropping from the page fails
+   here. Providers added after 1.11 (`Azure AI Foundry`) are deliberately not
+   pinned — a new catalog entry is not a regression.
 2. *Provider detail opens* — click `provider-item-OpenRouter` (unconfigured):
    assert its `provider-variable-input-OPENROUTER_API_KEY` becomes visible.
 3. *Configured provider shows model selection* — click `provider-item-OpenAI`
@@ -91,7 +98,21 @@ configured providers show a **"N models"** suffix in their list item and a
 
 **`model-provider-modal-actions.spec.ts`**
 1. *Page opens with description and provider count* — assert the description
-   text and `provider-item-*` count ≥ 8 (§7.5 "Available provider count").
+   text and `provider-item-*` count **≥ `MIN_PROVIDER_COUNT` (8)** (§7.5
+   "Available provider count").
+
+   > **Count contract: floor, not exact** (decided on issue #993). The
+   > assertion is `toBeGreaterThanOrEqual`, never `toHaveCount` — the risk this
+   > test exists to catch is *the provider list failing to render*, not Langflow
+   > shipping a new provider. An exact count couples the suite to the live
+   > catalog and breaks on unrelated additions: it was authored as
+   > `toHaveCount(8)`, went red when 1.11 shipped a 9th provider (#704 → #721,
+   > which closed with `@stable` off and the assertion untouched), and was still
+   > red on 1.12.0.dev9 (9 items: the 1.11 eight plus `Azure AI Foundry`).
+   > `MIN_PROVIDER_COUNT` stays at the 1.11 baseline of **8** — a page rendering
+   > fewer providers than 1.11 did is a real shrink. By-name coverage is not
+   > lost: `modelProviderModal.spec.ts` pins each known provider individually,
+   > so a provider disappearing still fails there.
 2. *Invalid key is rejected* — OpenRouter detail → fill
    `provider-variable-input-OPENROUTER_API_KEY` with a fake key → Save →
    assert the item does **not** gain the "models" suffix AND the API confirms
@@ -151,8 +172,10 @@ sidebar entry to the canonical **Language Model** component:
 ## Validation criterion *(required)*
 
 Every test asserts a **specific, live-scouted observable** (testid visibility,
-exact count, API state) with no conditional bypass: each one fails when its
-behavior breaks (verified by force-failure during promotion). The §7.5
+count floor, API state) with no conditional bypass: each one fails when its
+behavior breaks (verified by force-failure during promotion). Counts are
+asserted as a **floor against the 1.11 baseline**, never as an exact match —
+see the #993 note under `model-provider-modal-actions.spec.ts` above. The §7.5
 behaviors — modal, provider count, component configuration, add key (real
 accepted / fake rejected), remove key — are each pinned by at least one test.
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-modal-actions.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/model-provider-modal-actions.spec.ts
@@ -11,6 +11,9 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 // backend actually rejected the key — scouted live: a fake key creates no
 // global variable and no "N models" badge.
 
+// The provider list floor: the unified catalog shipped 8 providers on 1.11
+// (1.12 renders 9 — `Azure AI Foundry` was added). Asserted as a MINIMUM, never
+// an exact count — see the count-contract note below.
 const MIN_PROVIDER_COUNT = 8;
 
 async function openModelProviders(page: any): Promise<void> {
@@ -23,12 +26,9 @@ async function openModelProviders(page: any): Promise<void> {
 }
 
 test.describe("Model Provider Modal Actions", () => {
-  // @stable removed by daily triage #704 — provider count assertion fails
-  // deterministically (hardcoded 8, live catalog now 9 on 1.11.0.dev41).
-  // Restore once reconciled — see #721.
   test(
     "page opens with its description and the available provider count",
-    { tag: ["@release", "@workspace", "@regression", "@model-provider"] },
+    { tag: ["@stable", "@release", "@workspace", "@regression", "@model-provider"] },
     async ({ page }) => {
       await openModelProviders(page);
 
@@ -36,11 +36,18 @@ test.describe("Model Provider Modal Actions", () => {
         page.getByText("Configure AI model providers and manage their API keys."),
       ).toBeVisible({ timeout: 10000 });
 
-      // §7.5 "Available provider count" — the unified catalog ships 8
-      // providers on 1.11; fewer means the list regressed.
-      await expect(
-        page.locator('[data-testid^="provider-item-"]'),
-      ).toHaveCount(MIN_PROVIDER_COUNT, { timeout: 10000 });
+      // §7.5 "Available provider count" — a FLOOR, decided on issue #993. The
+      // regression this guards is the provider list failing to render (or
+      // shrinking below what 1.11 shipped), not Langflow adding a provider. An
+      // exact `toHaveCount` couples the suite to the live catalog: it went red
+      // when the 9th provider landed (#704 → #721, closed with @stable off and
+      // the assertion untouched) and was still red on 1.12.0.dev9. Per-provider
+      // presence is pinned by `modelProviderModal.spec.ts`, so nothing is lost.
+      const providerItems = page.locator('[data-testid^="provider-item-"]');
+      await expect(providerItems.first()).toBeVisible({ timeout: 10000 });
+      await expect
+        .poll(() => providerItems.count(), { timeout: 10000 })
+        .toBeGreaterThanOrEqual(MIN_PROVIDER_COUNT);
     },
   );
 


### PR DESCRIPTION
Closes #993

## Problem

`model-provider-modal-actions.spec.ts:29` — *"page opens with its description and the available provider count"* — asserted a constant named `MIN_PROVIDER_COUNT` with `toHaveCount`, which is **exact equality**:

```
Locator:  locator('[data-testid^="provider-item-"]')
Expected: 8
Received: 9
```

It went red the day Langflow shipped a 9th provider (#704 → #721 — that tracker closed with `@stable` off and the assertion untouched) and still reproduces deterministically on **1.12.0.dev9**, where the page renders **9** items: the 1.11 eight plus **`Azure AI Foundry`**.

Bumping `8 → 9` would go green today and re-break on the 10th provider — which is exactly how it broke the first time.

## The decided contract: floor, not exact

The assertion now matches the intent the constant's name already stated:

```ts
const providerItems = page.locator('[data-testid^="provider-item-"]');
await expect(providerItems.first()).toBeVisible({ timeout: 10000 });
await expect
  .poll(() => providerItems.count(), { timeout: 10000 })
  .toBeGreaterThanOrEqual(MIN_PROVIDER_COUNT);
```

- **`MIN_PROVIDER_COUNT` stays at 8** — the 1.11 baseline. A page rendering fewer providers than 1.11 did is a real shrink and still fails.
- The regression this test exists to catch is **the provider list failing to render**, not Langflow adding a provider. An exact count couples the suite to the live catalog.
- **By-name coverage is not lost.** `modelProviderModal.spec.ts` (`@stable`) pins each known provider individually, so a provider silently disappearing still fails there. That spec owns the by-name contract; this one owns the count floor. No duplication.
- Providers added after 1.11 (`Azure AI Foundry`) are deliberately **not** pinned by name — a new catalog entry is not a regression.

`@stable` is restored on the test in this same PR.

## Spec doc

`docs/core-functionality/model-provider/provider-management.md`:

- The count contract is **recorded** (floor, with the #704 → #721 → #993 history and why exact was rejected).
- Catalog re-scouted on 1.12.0.dev9: 9 providers in the page; `GET /api/v1/models/providers` returns **11** (it also lists Groq and Azure OpenAI, which the page does not render) — noted that the **page**, not the API, is the contract here.
- `Validation criterion` reworded: counts are asserted as a floor against the 1.11 baseline, never exact.
- `Last validated:` 1.11.x → **1.12.x**.

No `QA-CHECKLIST.md` change: the Part II bullets (`"Manage Model Providers" modal`, `Available provider count`) already reference this spec; the generated `Phase 0` block regenerates on merge.

## Validation

Langflow Nightly **1.12.0.dev9** (`langflowai/langflow-nightly:latest`), local.

- `--workers=1 --retries=0`, 3 consecutive bursts of the whole file: **3 passed** (15.5s / 14.7s / 15.7s).
- `npm run typecheck` — clean.
- ESLint on the touched spec — 0 errors, 2 **pre-existing** warnings (`any` on the local helper signature, `waitForTimeout` in the invalid-key test); out of scope for #993.
- `npm run check:checklist-coverage` and the QA-CHECKLIST guard — both pass.
- Zero `🚨 Backend Error`.
- `--trace=on` not run — known local hang, see `CONTRIBUTING.md` / skill notes.
- The spec creates no flows (Settings-page navigation only), so there is nothing to clean up; verified post-run that the invalid-key test left no `OPENROUTER_API_KEY` global variable.

### Force-fail (executed — every test in the touched file)

Each mutation applied in isolation, run with `--grep --retries=0`, then reverted (verified: 0 mutation markers left in the file).

| Mutation | Result |
|---|---|
| T1 — `MIN_PROVIDER_COUNT` 8 → 99 | ❌ failed: `Expected: >= 99 / Received: 9` |
| T1b — pinned description copy → bogus string | ❌ failed: `toBeVisible failed / element(s) not found` |
| T2 — rejected-key API check `created` expected `false` → `true` | ❌ failed: `Expected: true / Received: false` |
| T3 — OpenRouter input `toBeHidden` → `toBeVisible` after switching provider | ❌ failed: `element(s) not found` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)