### PR TITLE
fix: select node parameter fields by test id, never by DOM id (LE-2037)

### DIFF
--- a/docs/core-components/api-request-component-regression.md
+++ b/docs/core-components/api-request-component-regression.md
@@ -1,6 +1,6 @@
 # API Request Component — Rendering, Inspector, HTTP Methods, cURL Mode and Error Paths
 
-**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev7`)
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev9`; the cURL test re-validated on `1.11.1` as well, which already carries langflow#14312)
 
 ---
 
@@ -75,7 +75,7 @@ For each of GET, POST, PUT, PATCH, DELETE:
 
 ### 13. `cURL mode parses command, auto-fills URL, executes GET and returns 200`
 - Switches to the cURL tab **before** touching the URL field (pre-filling `url_input` would mask a regression in the cURL parser by letting the run fall back to the URL-tab path).
-- Fills the cURL command and waits for the parser to auto-populate `url_input` with `https://postman-echo.com/get`. The `waitForFunction` directly proves the parser ran.
+- Fills the cURL command and waits for the parser to auto-populate `url_input` with `https://postman-echo.com/get`. Asserting that value directly proves the parser ran. The field is reached with `getByTestId("popover-anchor-input-url_input")` and asserted with the web-first `toHaveValue` — **never** by DOM `id`: langflow#14312 (LE-2037) scopes node-parameter DOM ids by `nodeId` (`<id>-<nodeId>`) while deliberately leaving `data-testid` unscoped, so a `document.getElementById` read here resolves to nothing on any build carrying that fix, and reports a bare timeout instead of the value it saw.
 - Runs the component and asserts the output Data contains `200`, the echoed URL, and the structural keys.
 
 ### 14. `body table accepts key + value cell entries when method is POST`

--- a/tests/tests-automations/regression/api/flows/api-component-regression.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-component-regression.spec.ts
@@ -15,8 +15,7 @@ async function addApiRequestComponent(page: any) {
   await page.waitForSelector('[data-testid="popover-anchor-input-url_input"]', { timeout: 15000 });
 }
 
-test(
-  "API Request component performs GET to httpbin and returns built successfully",
+test("API Request component performs GET to httpbin and returns built successfully",
   { tag: ["@release", "@regression"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
@@ -40,8 +39,7 @@ test(
   },
 );
 
-test(
-  "API Request component — cURL mode POST with JSON body",
+test("API Request component — cURL mode POST with JSON body",
   { tag: ["@release", "@regression"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
@@ -132,8 +130,7 @@ test(
   },
 );
 
-test(
-  "API Request component — include_httpx_metadata=true adds request headers to output",
+test("API Request component — include_httpx_metadata=true adds request headers to output",
   { tag: ["@release", "@regression"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
@@ -165,8 +162,7 @@ test(
   },
 );
 
-test(
-  "API Request component — timeout error returns status_code 500 with error field",
+test("API Request component — timeout error returns status_code 500 with error field",
   { tag: ["@release", "@regression"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
@@ -197,8 +193,7 @@ test(
   },
 );
 
-test(
-  "API Request component — URL mode POST via method dropdown returns 200",
+test("API Request component — URL mode POST via method dropdown returns 200",
   { tag: ["@release", "@regression"] },
   async ({ page }) => {
     await addApiRequestComponent(page);

--- a/tests/tests-automations/regression/api/flows/api-component-regression.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-component-regression.spec.ts
@@ -46,17 +46,47 @@ test.beforeEach(({ page }) => {
 test.afterEach(async ({ page, request }, testInfo) => {
   await Promise.allSettled(pendingCaptures.splice(0));
   if (createdFlowIds.length === 0) return;
-  // Leave the editor first: the open canvas polls GET /flows/{id}/events, and
-  // deleting the flow mid-poll 404s (logged by the fixture's error monitor).
+
+  // Record the failing state before the navigation below.
   //
-  // On success only. Playwright captures the on-failure screenshot while tearing
-  // down the page fixture, which happens AFTER this hook — navigating away on a
-  // failing test would archive a picture of the home page instead of the canvas
-  // that actually failed. A noisy 404 log line is a far cheaper price than an
-  // undiagnosable failure artifact.
-  if (testInfo.status === testInfo.expectedStatus) {
-    await page.goto("/").catch(() => {});
+  // This is NOT rescuing Playwright's own screenshot from the navigation —
+  // measured on 1.58.2, `screenshot: only-on-failure` is captured before this
+  // hook runs, and `test-failed-1.png` still shows the canvas with `about:blank`
+  // navigated unconditionally. It is worth capturing anyway: the config sets
+  // `screenshot` to `off` outside CI (playwright.config.ts), so locally this
+  // attachment is the ONLY failure artifact, and the annotation puts the flow id
+  // in the report where a reader does not have to dig for it.
+  if (testInfo.status !== testInfo.expectedStatus) {
+    try {
+      testInfo.annotations.push({
+        type: "url-at-teardown",
+        description: page.url(),
+      });
+      await testInfo.attach("page-at-teardown", {
+        body: await page.screenshot({ fullPage: true }),
+        contentType: "image/png",
+      });
+    } catch {
+      // The page may already be gone — the cleanup below is what matters.
+    }
   }
+
+  // Take the page off the flow canvas BEFORE deleting anything, unconditionally
+  // — same shape as the folder specs (#1023/#1103), which is where the rationale
+  // is documented in full: an editor left mounted over a flow that is being
+  // deleted keeps asking for it and 404s, the fixture logs each one as
+  // `🚨 Backend Error`, and the deterministic pipeline's VALIDATE gate hard-stops
+  // on those.
+  //
+  // Honest scope for THIS file: that 404 does not currently reproduce here. A
+  // probe forcing a failure after the component run — editor mounted, flow
+  // deleted underneath it — logged zero backend errors either way, because the
+  // build's event stream is already closed by then. So this is defensive and
+  // consistent with the rest of the suite, not a fix for observed noise.
+  // `about:blank` rather than `/` so the teardown adds no backend traffic of its
+  // own.
+  await page.goto("about:blank").catch(() => {});
+
   // `page.request` carries only browser cookies, so the flows API answers 401 —
   // pass the bearer token explicitly.
   const bearer = await getAuthToken(request);

--- a/tests/tests-automations/regression/api/flows/api-component-regression.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-component-regression.spec.ts
@@ -61,24 +61,49 @@ test(
       state: "visible",
     });
 
-    // Fill cURL command with POST + JSON body
+    // Fill cURL command with POST + JSON body.
+    //
+    // Filling the cURL command triggers the parser, which re-renders the
+    // component template via `POST /api/v1/custom_component/update`. Wait for
+    // that round-trip so the parsed URL has been written into the field state
+    // before reading it — switching tabs beforehand unmounts the textarea and
+    // loses the pending parse, leaving the URL field empty. Same causal waiter
+    // as the sibling spec in
+    // `core-components/api-request-component-regression.spec.ts`.
+    const curlRefresh = page.waitForResponse(
+      (r) =>
+        r.url().includes("/api/v1/custom_component/update") &&
+        r.request().method() === "POST",
+      { timeout: 15000 },
+    );
     await page.getByTestId("textarea_str_curl_input").click();
     await page.getByTestId("textarea_str_curl_input").fill(
       `curl -X POST https://httpbin.org/post -H "Content-Type: application/json" -d '{"langflow": "regression-test", "status": "ok"}'`,
     );
+    await curlRefresh;
 
     // Wait for the cURL to be parsed: URL field must be auto-populated.
     // The parsing is async (debounced), so we must wait before running,
     // otherwise the backend receives an empty URL and fails validation.
-    await page.waitForFunction(
-      () => {
-        const urlInput = document.getElementById(
-          "popover-anchor-input-url_input",
-        ) as HTMLInputElement | null;
-        return urlInput !== null && urlInput.value === "https://httpbin.org/post";
-      },
+    //
+    // The URL input is only mounted while the URL tab is active — the cURL tab
+    // unmounts it — so switch tabs to observe the parsed value. This still
+    // proves the parser ran: the cURL fill above is what populated the field.
+    // Same handling as the sibling spec in
+    // `core-components/api-request-component-regression.spec.ts`.
+    await page.getByTestId("tab_0_url").click();
+    // Selected by `data-testid`, never by DOM `id` — see LE-2037 /
+    // langflow#14312: node-parameter DOM ids are scoped by nodeId
+    // (`<id>-<nodeId>`), `data-testid` is not, so a DOM-`id` lookup here would
+    // silently resolve to nothing on any build carrying that fix.
+    await expect(page.getByTestId("popover-anchor-input-url_input")).toHaveValue(
+      "https://httpbin.org/post",
       { timeout: 10000 },
     );
+
+    // Switch back to the cURL tab so the run exercises the cURL-mode path,
+    // which is what this test is about.
+    await page.getByTestId("tab_1_curl").click();
     // Brief pause to let React flush all derived state (method, body) after the URL update.
     await page.waitForTimeout(300);
 

--- a/tests/tests-automations/regression/api/flows/api-component-regression.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-component-regression.spec.ts
@@ -3,6 +3,15 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 
+// Target of the cURL-mode test. Named because it is asserted three times — in
+// the parse waiter's response body, in the mounted URL field, and in the echoed
+// output — and all three must agree for the assertion chain to mean anything.
+//
+// Still httpbin.org, like the rest of this file: the migration to the
+// `ECHO_BASE_URL` knob the rest of the suite uses (#383/#407) is pre-existing
+// debt tracked separately, not part of this change.
+const CURL_TARGET_URL = "https://httpbin.org/post";
+
 // Capture every flow each test's page creates from its POST /api/v1/flows → 201
 // responses and delete them id-scoped in afterEach (repo convention, #490/#681).
 // Both flow-creating steps here — `awaitBootstrapTest` and the `blank-flow`
@@ -11,38 +20,62 @@ import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-te
 // Never a name-scoped or delete-all cleanup: that wipes flows other parallel
 // workers are actively driving (#553).
 const createdFlowIds: string[] = [];
+// Each capture reads a response body asynchronously, so the id lands in the
+// array a tick later. Hold those reads and settle them before cleaning up —
+// otherwise a body that resolves after `afterEach` starts is dropped and its
+// flow leaks for good (the last test in a worker has no later hook to sweep it).
+const pendingCaptures: Promise<void>[] = [];
 
 test.beforeEach(({ page }) => {
   page.on("response", (resp) => {
-    if (
-      resp.url().includes("/api/v1/flows") &&
-      resp.request().method() === "POST" &&
-      resp.status() === 201
-    ) {
+    if (resp.request().method() !== "POST" || resp.status() !== 201) return;
+    // The creation endpoint itself only — `/flows/batch/` and `/flows/upload/`
+    // also answer 201, but with a list body that carries no top-level `id`.
+    if (!/^\/api\/v1\/flows\/?$/.test(new URL(resp.url()).pathname)) return;
+    pendingCaptures.push(
       resp
         .json()
         .then((body: { id?: string }) => {
           if (body?.id) createdFlowIds.push(body.id);
         })
-        .catch(() => {});
-    }
+        .catch(() => {}),
+    );
   });
 });
 
-test.afterEach(async ({ page, request }) => {
+test.afterEach(async ({ page, request }, testInfo) => {
+  await Promise.allSettled(pendingCaptures.splice(0));
   if (createdFlowIds.length === 0) return;
   // Leave the editor first: the open canvas polls GET /flows/{id}/events, and
   // deleting the flow mid-poll 404s (logged by the fixture's error monitor).
-  await page.goto("/").catch(() => {});
+  //
+  // On success only. Playwright captures the on-failure screenshot while tearing
+  // down the page fixture, which happens AFTER this hook — navigating away on a
+  // failing test would archive a picture of the home page instead of the canvas
+  // that actually failed. A noisy 404 log line is a far cheaper price than an
+  // undiagnosable failure artifact.
+  if (testInfo.status === testInfo.expectedStatus) {
+    await page.goto("/").catch(() => {});
+  }
   // `page.request` carries only browser cookies, so the flows API answers 401 —
   // pass the bearer token explicitly.
   const bearer = await getAuthToken(request);
   for (const id of createdFlowIds.splice(0)) {
+    // `deleteFlow` throws on purpose so a failed cleanup is visible (it already
+    // absorbs 404-as-done and one transient 5xx). Don't let that failure fail an
+    // otherwise-green test, but never silently swallow it either: a 401/403/422
+    // here means the leak this cleanup exists to prevent is back.
     await deleteFlow(
       request,
       id,
       bearer ? { headers: { Authorization: bearer } } : undefined,
-    ).catch(() => {});
+    ).catch((error: unknown) => {
+      console.warn(
+        `⚠️  cleanup: flow ${id} was NOT deleted — ${
+          (error as Error)?.message?.split("\n")[0] ?? error
+        }`,
+      );
+    });
   }
 });
 
@@ -107,48 +140,65 @@ test("API Request component — cURL mode POST with JSON body",
     // Fill cURL command with POST + JSON body.
     //
     // Filling the cURL command triggers the parser, which re-renders the
-    // component template via `POST /api/v1/custom_component/update`. Wait for
-    // that round-trip so the parsed URL has been written into the field state
-    // before reading it — switching tabs beforehand unmounts the textarea and
-    // loses the pending parse, leaving the URL field empty. Same causal waiter
-    // as the sibling spec in
-    // `core-components/api-request-component-regression.spec.ts`.
-    const curlRefresh = page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/v1/custom_component/update") &&
-        r.request().method() === "POST",
+    // component template via `POST /api/v1/custom_component/update`. Gate on
+    // that response actually carrying the PARSED url_input, not merely on "an
+    // update happened": the `tab_1_curl` click above fires its own update for
+    // the `mode` field (declared `real_time_refresh`), and that one answers with
+    // url_input still empty. A waiter matching any update can resolve on the
+    // mode response instead, and the `tab_0_url` click below — which shares the
+    // same per-node debounce key — would then cancel the still-pending parse,
+    // leaving the field permanently empty. Measured on 1.11.1: update #1 (mode)
+    // returns `url_input: ""`, update #2 (parse) returns the URL.
+    const curlParsed = page.waitForResponse(
+      async (r) => {
+        if (
+          !r.url().includes("/api/v1/custom_component/update") ||
+          r.request().method() !== "POST"
+        ) {
+          return false;
+        }
+        try {
+          const body = (await r.json()) as {
+            template?: { url_input?: { value?: string } };
+          };
+          return body?.template?.url_input?.value === CURL_TARGET_URL;
+        } catch {
+          return false;
+        }
+      },
       { timeout: 15000 },
     );
     await page.getByTestId("textarea_str_curl_input").click();
     await page.getByTestId("textarea_str_curl_input").fill(
-      `curl -X POST https://httpbin.org/post -H "Content-Type: application/json" -d '{"langflow": "regression-test", "status": "ok"}'`,
+      `curl -X POST ${CURL_TARGET_URL} -H "Content-Type: application/json" -d '{"langflow": "regression-test", "status": "ok"}'`,
     );
-    await curlRefresh;
+    await curlParsed;
 
-    // Wait for the cURL to be parsed: URL field must be auto-populated.
-    // The parsing is async (debounced), so we must wait before running,
-    // otherwise the backend receives an empty URL and fails validation.
+    // The parser must have auto-populated url_input from the command — an empty
+    // URL would fail backend validation on the run below.
     //
-    // The URL input is only mounted while the URL tab is active — the cURL tab
-    // unmounts it — so switch tabs to observe the parsed value. This still
+    // The URL input is only mounted while the URL tab is active (the cURL tab
+    // unmounts it), so switch tabs to observe the parsed value. This still
     // proves the parser ran: the cURL fill above is what populated the field.
-    // Same handling as the sibling spec in
-    // `core-components/api-request-component-regression.spec.ts`.
     await page.getByTestId("tab_0_url").click();
     // Selected by `data-testid`, never by DOM `id` — see LE-2037 /
     // langflow#14312: node-parameter DOM ids are scoped by nodeId
     // (`<id>-<nodeId>`), `data-testid` is not, so a DOM-`id` lookup here would
     // silently resolve to nothing on any build carrying that fix.
     await expect(page.getByTestId("popover-anchor-input-url_input")).toHaveValue(
-      "https://httpbin.org/post",
+      CURL_TARGET_URL,
       { timeout: 10000 },
     );
 
-    // Switch back to the cURL tab so the run exercises the cURL-mode path,
-    // which is what this test is about.
-    await page.getByTestId("tab_1_curl").click();
-    // Brief pause to let React flush all derived state (method, body) after the URL update.
-    await page.waitForTimeout(300);
+    // Deliberately NOT switching back to the cURL tab before running. The
+    // backend's `make_api_request` reads url_input / method / headers / body;
+    // `mode` and `curl_input` are consumed only by `update_build_config` at
+    // design time, so the run is identical in either tab and the switch would
+    // add no coverage. It would add a `real_time_refresh` round-trip for `mode`,
+    // debounced ~300 ms per node — i.e. one landing around the moment the run
+    // starts, re-parsing the template mid-build for nothing. What proves cURL
+    // mode here is that the parse populated these fields, which the assertion
+    // above and the echoed output below both confirm.
 
     // Run the component
     await page.getByTestId("button_run_api request").click();
@@ -162,7 +212,9 @@ test("API Request component — cURL mode POST with JSON body",
 
     const dialog = page.locator('[role="dialog"]');
     await expect(dialog.getByText('"status_code": 200')).toBeVisible();
-    await expect(dialog.getByText('"source": "https://httpbin.org/post"')).toBeVisible();
+    await expect(
+      dialog.getByText(`"source": "${CURL_TARGET_URL}"`),
+    ).toBeVisible();
 
     // The output is rendered in a virtualized code editor — only visible lines appear in the DOM,
     // and JSON string values display with escaped quotes (e.g. \"langflow\").

--- a/tests/tests-automations/regression/api/flows/api-component-regression.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-component-regression.spec.ts
@@ -1,5 +1,50 @@
 import { expect, test } from "../../../../fixtures/fixtures";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+
+// Capture every flow each test's page creates from its POST /api/v1/flows → 201
+// responses and delete them id-scoped in afterEach (repo convention, #490/#681).
+// Both flow-creating steps here — `awaitBootstrapTest` and the `blank-flow`
+// click — POST their own flow, so neither `page.url()` nor a single
+// `waitForResponse` identifies the right one; the accumulator captures both.
+// Never a name-scoped or delete-all cleanup: that wipes flows other parallel
+// workers are actively driving (#553).
+const createdFlowIds: string[] = [];
+
+test.beforeEach(({ page }) => {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {});
+    }
+  });
+});
+
+test.afterEach(async ({ page, request }) => {
+  if (createdFlowIds.length === 0) return;
+  // Leave the editor first: the open canvas polls GET /flows/{id}/events, and
+  // deleting the flow mid-poll 404s (logged by the fixture's error monitor).
+  await page.goto("/").catch(() => {});
+  // `page.request` carries only browser cookies, so the flows API answers 401 —
+  // pass the bearer token explicitly.
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(
+      request,
+      id,
+      bearer ? { headers: { Authorization: bearer } } : undefined,
+    ).catch(() => {});
+  }
+});
 
 // Reusable helper: create blank flow and add the API Request component.
 // After this call the inspector panel is open with all component fields visible.

--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -721,13 +721,13 @@ test(
     // parser ran (the cURL fill above is what populated it). Asserting it directly
     // is the precondition the run relies on (an empty URL would fail validation).
     await page.getByTestId("tab_0_url").click();
-    await page.waitForFunction(
-      (expectedUrl) => {
-        const el = document.getElementById(
-          "popover-anchor-input-url_input",
-        ) as HTMLInputElement | null;
-        return el !== null && el.value === expectedUrl;
-      },
+    // Selected by `data-testid`, never by DOM `id`: LE-2037 (langflow#14312)
+    // scopes node-parameter DOM ids by nodeId (`<id>-<nodeId>`) while leaving
+    // `data-testid` unscoped, so a DOM-`id` lookup here would silently resolve
+    // to nothing on any build carrying that fix. `toHaveValue` also reports the
+    // value it actually saw, where the `waitForFunction` this replaces could only
+    // report a bare timeout.
+    await expect(page.getByTestId("popover-anchor-input-url_input")).toHaveValue(
       `${ECHO_BASE}/get`,
       { timeout: 10000 },
     );

--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -311,8 +311,7 @@ function tableDialog(page: Page, title: "Headers" | "Body"): Locator {
 // UI / Canvas tests — verify component rendering and inspector fields
 // =============================================================================
 
-test(
-  "API Request component — renders on canvas with correct output and URL handles",
+test("API Request component — renders on canvas with correct output and URL handles",
   { tag: ["@stable", "@release", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
@@ -335,8 +334,7 @@ test(
   },
 );
 
-test(
-  "API Request component — inspector fields accept configured values",
+test("API Request component — inspector fields accept configured values",
   { tag: ["@stable", "@release", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
@@ -358,8 +356,7 @@ test(
   },
 );
 
-test(
-  "API Request component — invalid URL is accepted by field and run shows error notification",
+test("API Request component — invalid URL is accepted by field and run shows error notification",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
     // Invalid URLs are accepted by the input field but rejected by the Pydantic HttpUrl
@@ -401,12 +398,11 @@ test(
 // Execution / Output tests — verify HTTP behavior and output Data structure
 // =============================================================================
 
-test(
-  // @stable restored (#462): the daily workflow now self-hosts a go-httpbin
-  // service and points ECHO_BASE_URL at its container IP, so this no longer
-  // depends on the public postman-echo endpoint that hard-failed the suite on
-  // external outages (daily 2026-07-01, weekly 2026-06-22).
-  "API Request component — GET request returns 200 and output Data contains all required fields",
+// @stable restored (#462): the daily workflow now self-hosts a go-httpbin
+// service and points ECHO_BASE_URL at its container IP, so this no longer
+// depends on the public postman-echo endpoint that hard-failed the suite on
+// external outages (daily 2026-07-01, weekly 2026-06-22).
+test("API Request component — GET request returns 200 and output Data contains all required fields",
   { tag: ["@stable", "@release", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
@@ -435,8 +431,7 @@ test(
   },
 );
 
-test(
-  "API Request component — POST method executes POST verb and returns 200",
+test("API Request component — POST method executes POST verb and returns 200",
   { tag: ["@stable", "@release", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
@@ -464,8 +459,7 @@ test(
   },
 );
 
-test(
-  "API Request component — PUT method executes PUT verb and returns 200",
+test("API Request component — PUT method executes PUT verb and returns 200",
   { tag: ["@stable", "@release", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
@@ -495,8 +489,7 @@ test(
   },
 );
 
-test(
-  "API Request component — PATCH method executes PATCH verb and returns 200",
+test("API Request component — PATCH method executes PATCH verb and returns 200",
   { tag: ["@stable", "@release", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
@@ -526,8 +519,7 @@ test(
   },
 );
 
-test(
-  "API Request component — DELETE method executes DELETE verb and returns 200",
+test("API Request component — DELETE method executes DELETE verb and returns 200",
   { tag: ["@stable", "@release", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
@@ -557,8 +549,7 @@ test(
   },
 );
 
-test(
-  "API Request component — non-2xx HTTP response propagates status_code without crashing",
+test("API Request component — non-2xx HTTP response propagates status_code without crashing",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
@@ -581,8 +572,7 @@ test(
   },
 );
 
-test(
-  "API Request component — query parameters embedded in URL are sent and echoed",
+test("API Request component — query parameters embedded in URL are sent and echoed",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
@@ -607,8 +597,7 @@ test(
 // Headers / Body / cURL tests
 // =============================================================================
 
-test(
-  "API Request component — inspector headers table accepts key + value cell entries",
+test("API Request component — inspector headers table accepts key + value cell entries",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
@@ -650,8 +639,7 @@ test(
   },
 );
 
-test(
-  "API Request component — cURL tab switches mode and field accepts a cURL command",
+test("API Request component — cURL tab switches mode and field accepts a cURL command",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
@@ -685,8 +673,7 @@ test(
   },
 );
 
-test(
-  "API Request component — cURL mode parses command, auto-fills URL, executes GET and returns 200",
+test("API Request component — cURL mode parses command, auto-fills URL, executes GET and returns 200",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
@@ -746,8 +733,7 @@ test(
   },
 );
 
-test(
-  "API Request component — body table accepts key + value cell entries when method is POST",
+test("API Request component — body table accepts key + value cell entries when method is POST",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
     await addApiRequestComponent(page);
@@ -821,8 +807,7 @@ test(
   },
 );
 
-test(
-  "API Request component — flow state persists in database after autosave (URL, method, headers)",
+test("API Request component — flow state persists in database after autosave (URL, method, headers)",
   { tag: ["@stable", "@regression", "@components"] },
   async ({ page }) => {
     const expectedUrl = `${ECHO_BASE}/get?persist=true`;


### PR DESCRIPTION
## What this does

Upstream [langflow-ai/langflow#14312](https://github.com/langflow-ai/langflow/pull/14312) (LE-2037) makes node-parameter DOM ids unique by scoping them with the node id — `id={getNodeScopedDomId(id, nodeId)}` → `<id>-<nodeId>` — while deliberately leaving `data-testid` **unscoped**, because that is the attribute this suite selects on. So every `getByTestId` in the repo is unaffected; only code reading the DOM `id` breaks. Two specs did exactly that, inside a `page.waitForFunction`:

- `core-components/api-request-component-regression.spec.ts:726` — **`@stable`**, so `daily-stable.yml` would have opened a `daily-failure` issue the first weekday after the fix reached the tested image.
- `api/flows/api-component-regression.spec.ts:75`.

Both now use `expect(getByTestId("popover-anchor-input-url_input")).toHaveValue(...)`. This is **version-agnostic**: both files already select this same field by test id elsewhere (8+ call sites in one, 5 in the other), so the form is correct before the upstream fix and after it. There was nothing to wait for.

## The API spec needed more than a selector swap

It was **already failing** on today's nightly, on that very `waitForFunction` (`Timeout 20000ms exceeded`, unattributed). A live DOM scout found the cause, and it is not the DOM id: **the URL input is unmounted while the cURL tab is active** — probing every `url_input` element with the cURL tab open returns nothing at all. The `@stable` sibling already handles this and documents it; this spec never switched tabs, so its wait could never satisfy.

Fixing that exposed a second problem: the parse round-trips through `POST /api/v1/custom_component/update`, and switching tabs before it lands loses the pending parse. So the spec now waits for that response — and, after review, waits for the *right* one:

| update | fired by | `template.url_input.value` |
|---|---|---|
| #1 | the `tab_1_curl` click (`mode` is `real_time_refresh`) | `""` |
| #2 | the cURL parse | `https://httpbin.org/post` |

A waiter matching *any* update can resolve on #1; the following `tab_0_url` click then shares the same per-node debounce key and **cancels the still-pending parse**, leaving the field permanently empty. That window is closed today only because `curl_input` is `show=False` until the mode response applies — a field-config accident, not an invariant. The predicate therefore reads the response body and requires the parsed value.

It also **no longer switches back to the cURL tab** before running. That click's stated rationale was wrong: `make_api_request` reads url_input / method / headers / body, while `mode` and `curl_input` are consumed only by `update_build_config` at design time. The run is byte-identical in either tab, so the click bought no coverage while adding a ~300 ms-debounced round-trip landing around the moment the run starts.

## Flow cleanup (repo rule, applies to any spec touched)

`api/flows/api-component-regression.spec.ts` created flows in all 5 tests — `awaitBootstrapTest` plus a `blank-flow` click — and cleaned up **none**. The 1.11.1 instance had accumulated 15 orphans. Added pattern A (response accumulator, id-scoped `afterEach`), not a single `waitForResponse`, because both creation paths POST their own flow and `page.url()` returns the stale bootstrap id (#490/#681). Never name-scoped, never delete-all — the #553 wiper class is avoided.

The teardown follows the shape merged in #1103 (`3642880`): record the failing state, then leave the page **unconditionally** for `about:blank`.

An earlier revision of this PR gated that navigation on the test having passed, on the theory that navigating would cost the on-failure screenshot. **Review caught it and measuring settled it — both halves of that theory are wrong on this suite:**

- **The native screenshot was never at risk.** Playwright 1.58.2 captures `screenshot: only-on-failure` *before* `afterEach` runs, not during page-fixture teardown. With `about:blank` navigated unconditionally, `test-failed-1.png` still shows the failing canvas. (The comment shipped in #1103 asserts the opposite ordering; it is stale for this version.)
- **The 404 the navigation avoids does not reproduce in this file.** A probe forcing a failure *after* the component run — editor mounted, flow deleted underneath it — logged **zero** backend errors with the gated code too, because the build's event stream is already closed by then. So this is defensive and consistent with the rest of the suite, **not** a fix for observed noise, and the code comment says exactly that rather than inheriting #1103's rationale.

`about:blank` rather than `/` so the teardown adds no backend traffic of its own.

Two more details worth flagging in review:

- The `testInfo.attach("page-at-teardown")` + `url-at-teardown` annotation are kept on their own merit, not to rescue the native screenshot: `playwright.config.ts` sets `screenshot` to `off` outside CI, so **locally that attachment is the only failure artifact there is** — previously there was none.
- A failed `deleteFlow` is **logged, not swallowed** — that helper throws on purpose so leaks stay visible.

## Validation

Two instances, `--retries=0`. The 1.11.1 instance turned out to **already carry** langflow#14312 (its ids read `popover-anchor-input-url_input-APIRequest-bPAh4`), so both sides of the change are covered, not just the pre-fix build:

| test | nightly `1.12.0.dev9` (pre-fix) | `1.11.1` (post-fix) |
|---|---|---|
| cURL mode parses command (**`@stable`**) | pass | pass |
| cURL mode POST with JSON body | pass — **was failing** | pass — **was failing** |

Re-validated after the teardown change, whole file on `1.12.0.dev9`, `--retries=0 --workers=1`: **3 passed / 2 failed** (the two pre-existing advanced-field failures below, unchanged), **0 `🚨 Backend Error`**, flow count **31 → 31** across both the passing and the failing paths, and both teardown artifacts confirmed present via the `json` reporter.

**Force-fails**, each with the mutation verified as applied and `grep -c FF-MUTATION` = 0 after reverting:

- Mutated expected URL → both assertions go red **naming the real value** (`Received: "https://postman-echo.com/get"`). That attribution is the point: the replaced `waitForFunction` could only ever report a bare timeout.
- Parse waiter pointed at a URL that never appears → fails in `waitForResponse` at 15 s, proving the predicate reads the body rather than rubber-stamping any update.
- Cleanup no-oped → flow count 15 → **16** while the test still **passed**, proving the leak is invisible to the test and that the count is what has teeth. Reverted: 15 → 15, and 16 → 16 on a run where two tests fail.

Other gates: `npm run typecheck` clean · `npm run lint` 0 errors · `grep -rn "getElementById" tests/` empty · no `🚨 Backend Error:` logged.

## Two pre-existing failures in the API spec, out of scope

`include_httpx_metadata` and `timeout error returns status_code 500` fail on both instances because their advanced fields (`toggle_bool_include_httpx_metadata`, `int_int_timeout`) are no longer on the node body — the sibling spec handles this class with `openAdvancedOptions`. **Verified pre-existing**: they fail identically on clean `main`. Untouched here; the file goes from 2 to 3 passing. Neither test carries `@stable`, so no CI lane regresses. Expect the impacted-specs check to be red from exactly these two.

Also left alone: this file hardcodes `httpbin.org` rather than using the `ECHO_BASE_URL` knob the rest of the suite moved to after three 503 outages (#383/#407). Pre-existing debt, noted in a comment, not this PR's scope.

## Docs / checklist

Refreshed the passage in `docs/core-components/api-request-component-regression.md` that still described the deleted `waitForFunction` as the proof the parser ran, and bumped its `Last validated`. No `QA-CHECKLIST.md` change: no spec is added or retagged, and the guard (`npm run check:checklist-coverage`) passes.

## Note on the formatting commit

`style(components)` moves 20 test titles onto their `test(` line, which the authoring conventions require when a file is edited. Kept as its own commit so the functional diff stays reviewable — formatting only, no assertion, selector or timeout altered.

Closes #1101

