### PR TITLE
test: assert node parameter DOM ids stay unique across sibling nodes (LE-2037)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -145,7 +145,7 @@
 - [x] Edit slider → `core-components/parameters-panel-field-types.spec.ts`
 - [x] Edit tab component → `core-components/parameters-panel-field-types.spec.ts`
 - [-] Visibility toggle of a connected input is disabled (tooltip "Cannot change visibility of connected handles") and re-enables once the edge is deleted → `flow-functionality/general-bugs-hidden-input-edges.spec.ts`
-- [x] Two nodes exposing the same field name do not render duplicate DOM ids, and `data-testid` stays unscoped so both nodes remain selectable (LE-2037 / langflow#14312) → `core-components/duplicate-dom-ids-regression.spec.ts`
+- [-] Two nodes on the canvas exposing the same field name render distinct DOM ids, while `data-testid` stays unscoped so both nodes remain selectable (LE-2037 / langflow#14312 — awaiting the fix on the 1.12 line before `@stable`) → `core-components/duplicate-dom-ids-regression.spec.ts`
 
 #### 2.2 Tool Mode
 - [x] Enable Tool Mode on a component → `core-components/tool-mode.spec.ts`

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -145,6 +145,7 @@
 - [x] Edit slider → `core-components/parameters-panel-field-types.spec.ts`
 - [x] Edit tab component → `core-components/parameters-panel-field-types.spec.ts`
 - [-] Visibility toggle of a connected input is disabled (tooltip "Cannot change visibility of connected handles") and re-enables once the edge is deleted → `flow-functionality/general-bugs-hidden-input-edges.spec.ts`
+- [x] Two nodes exposing the same field name do not render duplicate DOM ids, and `data-testid` stays unscoped so both nodes remain selectable (LE-2037 / langflow#14312) → `core-components/duplicate-dom-ids-regression.spec.ts`
 
 #### 2.2 Tool Mode
 - [x] Enable Tool Mode on a component → `core-components/tool-mode.spec.ts`

--- a/docs/core-components/duplicate-dom-ids-regression.md
+++ b/docs/core-components/duplicate-dom-ids-regression.md
@@ -1,0 +1,126 @@
+# Node Parameter DOM Ids — Uniqueness Across Sibling Nodes
+
+**Last validated:** Langflow 1.12.x (pre-fix negative control on nightly `1.12.0.dev9`; passing build `1.11.1`, which carries langflow#14312)
+
+---
+
+## What this test validates *(required)*
+
+Node parameter fields must not render duplicate DOM `id` attributes when two nodes on the same canvas expose a field with the same name.
+
+Origin: LE-2037 / langflow-ai/langflow#14096. A field's `id` was derived from the template type/name alone, without the `nodeId`, so two nodes sharing a field name produced multiple elements carrying one `id` — a WCAG 4.1.1 (ID uniqueness) violation that also prevents browser autofill from resolving the field. Chrome surfaces it as *"Duplicate form field id in the same form"* in the DevTools **Issues** panel. Fixed upstream by langflow-ai/langflow#14312, which scopes the rendered DOM id by node (`<id>-<nodeId>`).
+
+The test asserts **both halves** of that fix:
+
+1. **Uniqueness** — no `input` / `textarea` / `select` on a two-node canvas shares an `id`.
+2. **Test-id stability** — `data-testid` stays **unscoped** and still resolves to both nodes. This is the load-bearing half for this repository: 132 call sites across 45 specs select node fields by `data-testid`. If uniqueness were ever achieved by scoping the testid instead of the id, those specs would break en masse — and this assertion fails first, naming the cause.
+
+If this test fails, either two nodes are colliding on a DOM id again (a renderer that does not call `getNodeScopedDomId`), or the scoping was applied to `data-testid` and this suite's entire selector strategy is about to break.
+
+**Why this is worth covering here even though upstream ships its own test.** langflow#14312 adds `src/frontend/tests/core/regression/duplicateDomIds.spec.ts`, which runs in Langflow's CI against the PR's own code. This suite runs against **published images** — different net: theirs catches the author, ours catches what reached the user. Two properties make the regression likely enough to be worth the net: the fix is **opt-in** (`getNodeScopedDomId` is called manually at each `id={...}` site — 15 renderer files were edited one by one, and the sixteenth renderer someone adds will not call it), and `nodeId` is **optional with a silent fallback** to the unscoped id, so a renderer that merely fails to receive the prop regresses with no signal.
+
+---
+
+## Tags *(required)*
+
+Both tests: `@stable` `@release` `@regression` `@components`
+The Agent case additionally carries `@agents`.
+
+No provider credentials and no LLM call: the nodes are placed and inspected, never executed. That is what makes an Agent case cheap enough for `@stable`.
+
+---
+
+## Step by step *(required)*
+
+**Case A — two API Request nodes** (`StrRenderComponent` → `InputComponent` → `popover` id path)
+
+1. `setupBlankFlow(page)` — create a blank flow via the REST API and open it; returns the flow id used for cleanup.
+2. `addComponentFromSidebar(page, "API Request", "add-component-button-api-request")`, twice.
+3. Assert `.react-flow__node` count is `2`; `adjustScreenView` for trace legibility.
+4. Assert `popover-anchor-input-url_input` resolves to **2** elements — the test-id stability half, and the gate that prevents a vacuous pass on a half-mounted canvas.
+5. Sweep `input[id], textarea[id], select[id]` in the page and assert no id appears more than once.
+
+**Case B — two Agent nodes** (`TextAreaComponent` id path)
+
+1. `setupBlankFlow(page)`.
+2. Open the `disclosure-models & agents` sidebar section; drag `models_and_agentsAgent` onto `//*[@id="react-flow-id"]` at two distinct positions (the proven pattern from `agent-component-regression.spec.ts` — no `add-component-button-agent` testid exists).
+3. Assert `.react-flow__node` count is `2`; `adjustScreenView`.
+4. Assert `textarea_str_system_prompt` resolves to **2** elements.
+5. Same duplicate-id sweep.
+
+**afterEach (both cases)**
+
+1. Navigate to `/` so the unmounted editor stops polling a flow about to be deleted — gated on the test having passed, because Playwright captures the on-failure screenshot after user hooks and navigating would archive the home page instead of the failed canvas.
+2. `deleteFlow(request, id, { headers: { Authorization: bearer } })` for each flow created, id-scoped — never a global wipe (#553).
+
+---
+
+## Validation criterion *(required)*
+
+| Assertion | Criterion |
+|---|---|
+| Both nodes mounted | `.react-flow__node` count is `2` |
+| Both fields mounted (test-id stability) | the case's field testid resolves to `2` elements |
+| No duplicate ids | the collected duplicate list is exactly `[]`; on failure the message names each offending `<id> x<count>` |
+
+The sweep is **scoped to form controls** (`input` / `textarea` / `select`) on purpose. That is what the reported DevTools warning covers and what breaks autofill. Icon SVGs legitimately repeat their own internal ids (gradients, masks, filters) whenever the same icon renders twice — a distinct concern that must not fail this test for the wrong reason.
+
+Measured behaviour on both sides of the upstream fix, two nodes on canvas:
+
+| build | Case A duplicates | Case B duplicates |
+|---|---|---|
+| nightly `1.12.0.dev9` (pre-fix) | `popover-anchor-input-url_input x2` | `popover-anchor-input-input_value x2`, `textarea_str_system_prompt x2` |
+| `1.11.1` (carries langflow#14312) | none — ids read `…-APIRequest-<suffix>` | none — ids read `…-Agent-<suffix>` |
+
+In both builds the field **testid** resolved to 2 elements, which is the contract half staying green across the fix.
+
+---
+
+## External dependencies *(required)*
+
+- `src/frontend/src/components/core/parameterRenderComponent/helpers/get-node-scoped-dom-id.ts` — the helper that scopes the DOM id by `nodeId`, introduced by langflow#14312. If removed or bypassed, this test fails.
+- `src/frontend/src/components/core/parameterRenderComponent/index.tsx` — builds the base id from the template type/name and threads `nodeId` down to the renderers.
+- `src/frontend/src/components/core/parameterRenderComponent/components/textAreaComponent/index.tsx` — renders the `textarea_str_*` fields the Agent case asserts; `id` scoped, `data-testid` unscoped.
+- `src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/index.tsx` and `.../components/popover/index.tsx` — render the `popover-anchor-input-*` fields the API Request case asserts. Any renderer added here that does not call `getNodeScopedDomId` reintroduces the defect.
+- `src/frontend/src/types/components/index.ts` — declares the optional `nodeId` prop. The helper falls back to the unscoped id when it is absent, so a renderer that simply fails to receive the prop regresses silently.
+- Sidebar add affordances — `sidebar-search-input`, `add-component-button-api-request`, `disclosure-models & agents`, `models_and_agentsAgent`.
+- Node titles — `title-API Request`, `title-Agent` (rendered by `CustomNodes/GenericNode/components/NodeName`).
+- React Flow canvas — `.react-flow__node` for node counting, `//*[@id="react-flow-id"]` as the drag drop target.
+- Field testids — `popover-anchor-input-url_input`, `textarea_str_system_prompt`.
+- `tests/helpers/flows/setup-blank-flow.ts` — API-based flow creation plus the id used for cleanup.
+
+---
+
+## What this test does not cover *(optional)*
+
+- **`IntComponent` / `FloatComponent` / `ToggleShadComponent` id paths.** Upstream's own case uses `int_int_k` on WikipediaAPI. The only proven int field in this suite, `int_int_timeout` on API Request, is `advanced=True` and would have to be revealed per node (`parameters-button` mounts only for the currently-selected node), which is disproportionate for a first iteration.
+- **Two *different* components sharing a field name** (e.g. OpenAI + Anthropic both exposing `api_key`). Same defect class, but it needs provider components whose availability varies by distribution (`lfx-bundles` is absent from `langflow-nightly:latest` — #1039), so the case would skip silently.
+- **Three or more nodes.** Two proves the scoping; an N-node collision would require the scope itself to be non-unique, which `nodeId` guarantees it is not.
+- **The inspector / edit-node surface.** Fields rendered in the parameters side panel carry an edit-mode prefix and are a separate id path.
+- **Non-form-control ids.** A pre-fix sweep of *every* `[id]` also showed `other_tools x2` on the Agent canvas; it is not an `input`/`textarea`/`select`, so this test's form-control scope excludes it by design (see Validation criterion).
+- **The unrelated, still-open** *"A form field element should have an id or name attribute"* DevTools info-level issue, present before and after this fix.
+- **Actual browser autofill behaviour.** Not observable from Playwright; id uniqueness is the proxy.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` on a build that includes langflow#14312. On a pre-fix build both cases fail **by design** — that is the negative control, not a defect in the test.
+- No model provider credentials required.
+
+---
+
+## When to review this test *(optional)*
+
+- A new parameter renderer is added under `parameterRenderComponent/components/` — it must call `getNodeScopedDomId` or this test goes red.
+- The suite's selector strategy changes, or someone proposes scoping `data-testid`. This test is the tripwire for that.
+- The Agent or API Request node stops exposing the asserted field, in which case the `toHaveCount(2)` gate fails first and names it.
+
+---
+
+## Notes *(optional)*
+
+- Chrome reports this defect through the CDP `Audits` domain that feeds the DevTools **Issues** panel — **not** the console. Neither `page.on("console")` nor the repo fixture's response monitor can observe it, which is why the check is an explicit DOM sweep rather than a listener.
+- Node overlap is irrelevant: the sweep reads the DOM, not layout. The `adjustScreenView` calls exist only to keep failure traces legible.
+- **Chat Input and Webhook are unsuitable subjects** — they are singletons, so adding one removes the other's sidebar `+` and they cannot be duplicated or pasted (which is why upstream had to build its ChatInput case through the API). **Prompt Template is also unsuitable**: its visible field is a prompt-modal surface, not a form control, and a two-node Prompt Template canvas produces no duplicate-id warning at all.
+- Sibling specs place two identical nodes but assert only node counts, so none of them would catch this: `ui-ux/langflowShortcuts.spec.ts` (duplication via shortcuts — its header comment states Chat Output was chosen *because* it carries no text field) and `flow-functionality/canvas-copy-paste.spec.ts` (paste of a second Prompt Template). `core-components/chat-input-output-component-regression.spec.ts` actually hit this ambiguity — Chat Input and Chat Output both render `popover-anchor-input-sender_name` — diagnosed it as "DOM ordering", and worked around it with a node-scoped filter.

--- a/docs/core-components/duplicate-dom-ids-regression.md
+++ b/docs/core-components/duplicate-dom-ids-regression.md
@@ -1,6 +1,6 @@
 # Node Parameter DOM Ids — Uniqueness Across Sibling Nodes
 
-**Last validated:** Langflow 1.12.x (pre-fix negative control on nightly `1.12.0.dev9`; passing build `1.11.1`, which carries langflow#14312)
+**Last validated:** Langflow 1.11.x — validated against a build carrying langflow#14312 (see *Preconditions*; the fix has **not** reached the 1.12 line yet, where both cases fail by design)
 
 ---
 
@@ -10,23 +10,30 @@ Node parameter fields must not render duplicate DOM `id` attributes when two nod
 
 Origin: LE-2037 / langflow-ai/langflow#14096. A field's `id` was derived from the template type/name alone, without the `nodeId`, so two nodes sharing a field name produced multiple elements carrying one `id` — a WCAG 4.1.1 (ID uniqueness) violation that also prevents browser autofill from resolving the field. Chrome surfaces it as *"Duplicate form field id in the same form"* in the DevTools **Issues** panel. Fixed upstream by langflow-ai/langflow#14312, which scopes the rendered DOM id by node (`<id>-<nodeId>`).
 
-The test asserts **both halves** of that fix:
+The test asserts **both halves** of that fix, per field:
 
-1. **Uniqueness** — no `input` / `textarea` / `select` on a two-node canvas shares an `id`.
-2. **Test-id stability** — `data-testid` stays **unscoped** and still resolves to both nodes. This is the load-bearing half for this repository: 132 call sites across 45 specs select node fields by `data-testid`. If uniqueness were ever achieved by scoping the testid instead of the id, those specs would break en masse — and this assertion fails first, naming the cause.
+1. **Uniqueness** — the two elements sharing a field testid carry distinct, non-empty DOM ids, and no form control anywhere on the canvas shares an id.
+2. **Test-id stability** — `data-testid` stays **unscoped** and still resolves to both nodes. This is the load-bearing half for this repository: 132 call sites across 45 specs select node fields by `data-testid`. If uniqueness were ever achieved by scoping the testid instead of the id, those specs would break en masse — and this spec fails first, naming the cause.
 
 If this test fails, either two nodes are colliding on a DOM id again (a renderer that does not call `getNodeScopedDomId`), or the scoping was applied to `data-testid` and this suite's entire selector strategy is about to break.
 
-**Why this is worth covering here even though upstream ships its own test.** langflow#14312 adds `src/frontend/tests/core/regression/duplicateDomIds.spec.ts`, which runs in Langflow's CI against the PR's own code. This suite runs against **published images** — different net: theirs catches the author, ours catches what reached the user. Two properties make the regression likely enough to be worth the net: the fix is **opt-in** (`getNodeScopedDomId` is called manually at each `id={...}` site — 15 renderer files were edited one by one, and the sixteenth renderer someone adds will not call it), and `nodeId` is **optional with a silent fallback** to the unscoped id, so a renderer that merely fails to receive the prop regresses with no signal.
+**Why cover this here when upstream ships its own test.** langflow#14312 adds `src/frontend/tests/core/regression/duplicateDomIds.spec.ts`, which runs in Langflow's CI against the PR's own code. This suite runs against **published images** — different net: theirs catches the author, ours catches what reached the user. Two properties make the regression likely enough to be worth the net: the fix is **opt-in** (`getNodeScopedDomId` is called manually at each `id={...}` site — 15 renderer files were edited one by one), and `nodeId` is **optional with a silent fallback** to the unscoped id, so a renderer that merely fails to receive the prop regresses with no signal.
 
 ---
 
 ## Tags *(required)*
 
-Both tests: `@stable` `@release` `@regression` `@components`
-The Agent case additionally carries `@agents`.
+Case A: `@regression` `@components` · Case B: `@regression` `@components` `@agents`
 
-No provider credentials and no LLM call: the nodes are placed and inspected, never executed. That is what makes an Agent case cheap enough for `@stable`.
+**`@stable` is deliberately absent, and this is the reason.** The upstream fix landed on the **`release-1.11.2`** branch (PR merged 2026-07-29). `langflowai/langflow-nightly:latest` — the image `daily-stable.yml` runs against — is built from the highest `release-*` branch, currently `release-1.12.0`, where the helper `get-node-scoped-dom-id.ts` is **verifiably absent** (it 404s on both `main` and `release-1.12.0`). Both cases therefore hard-fail on today's nightly *by design*. Tagging them `@stable` would open a `daily-failure` issue every weekday and trigger the `auto-remove-stable` path, which would strip the tag and commit to `main` — burning triage cycles to rediscover something already known.
+
+`@stable` should be added once the fix reaches `main` / the 1.12 line and a run against the nightly confirms both cases green. Verify with:
+
+```bash
+gh api repos/langflow-ai/langflow/contents/src/frontend/src/components/core/parameterRenderComponent/helpers/get-node-scoped-dom-id.ts?ref=main --jq .sha
+```
+
+`@release` is also deliberately absent: this is a DOM-contract / accessibility regression guard, not a happy-path flow required before a deploy.
 
 ---
 
@@ -35,23 +42,26 @@ No provider credentials and no LLM call: the nodes are placed and inspected, nev
 **Case A — two API Request nodes** (`StrRenderComponent` → `InputComponent` → `popover` id path)
 
 1. `setupBlankFlow(page)` — create a blank flow via the REST API and open it; returns the flow id used for cleanup.
-2. `addComponentFromSidebar(page, "API Request", "add-component-button-api-request")`, twice.
-3. Assert `.react-flow__node` count is `2`; `adjustScreenView` for trace legibility.
-4. Assert `popover-anchor-input-url_input` resolves to **2** elements — the test-id stability half, and the gate that prevents a vacuous pass on a half-mounted canvas.
-5. Sweep `input[id], textarea[id], select[id]` in the page and assert no id appears more than once.
+2. `addComponentFromSidebar(page, "API Request", "add-component-button-api-request")`.
+3. Gate on `title-API Request` being visible before adding the second node — the sidebar click is fire-and-forget, and asserting the count immediately can observe 1 while the second node is still mounting.
+4. Add the second API Request the same way; assert `.react-flow__node` count is `2`.
+5. Read the `id` of every element matching `popover-anchor-input-url_input` and assert: exactly 2 elements, both with a non-empty id, and the two ids distinct.
+6. Sweep `input[id], textarea[id], select[id]` **inside the canvas** and assert no id appears more than once.
 
 **Case B — two Agent nodes** (`TextAreaComponent` id path)
 
 1. `setupBlankFlow(page)`.
 2. Open the `disclosure-models & agents` sidebar section; drag `models_and_agentsAgent` onto `//*[@id="react-flow-id"]` at two distinct positions (the proven pattern from `agent-component-regression.spec.ts` — no `add-component-button-agent` testid exists).
-3. Assert `.react-flow__node` count is `2`; `adjustScreenView`.
-4. Assert `textarea_str_system_prompt` resolves to **2** elements.
-5. Same duplicate-id sweep.
+3. Assert `.react-flow__node` count is `2`.
+4. Same id assertions as step 5 above, for `textarea_str_system_prompt`.
+5. Same canvas-scoped duplicate sweep.
+
+The two tests are **not** serial: they drive independent flows with unique generated names and share no state. Independence is deliberate — under `mode: "serial"` a failure in case A would *skip* case B, leaving no verdict for it at all.
 
 **afterEach (both cases)**
 
 1. Navigate to `/` so the unmounted editor stops polling a flow about to be deleted — gated on the test having passed, because Playwright captures the on-failure screenshot after user hooks and navigating would archive the home page instead of the failed canvas.
-2. `deleteFlow(request, id, { headers: { Authorization: bearer } })` for each flow created, id-scoped — never a global wipe (#553).
+2. `deleteFlow(request, id, { headers: { Authorization: bearer } })` for each flow created, id-scoped — never a global wipe (#553). A failed delete is logged, not swallowed.
 
 ---
 
@@ -60,19 +70,25 @@ No provider credentials and no LLM call: the nodes are placed and inspected, nev
 | Assertion | Criterion |
 |---|---|
 | Both nodes mounted | `.react-flow__node` count is `2` |
-| Both fields mounted (test-id stability) | the case's field testid resolves to `2` elements |
-| No duplicate ids | the collected duplicate list is exactly `[]`; on failure the message names each offending `<id> x<count>` |
-
-The sweep is **scoped to form controls** (`input` / `textarea` / `select`) on purpose. That is what the reported DevTools warning covers and what breaks autofill. Icon SVGs legitimately repeat their own internal ids (gradients, masks, filters) whenever the same icon renders twice — a distinct concern that must not fail this test for the wrong reason.
+| Test-id stability | the field testid resolves to exactly `2` elements |
+| Ids exist | both elements carry a non-empty `id` — guards the vacuity path where a dropped `id` attribute would empty the sweep and pass for the wrong reason |
+| Ids distinct | `new Set(ids).size === 2` |
+| No duplicates on the canvas | the collected duplicate list is exactly `[]`; on failure the message names each offending `<id> x<count>` |
 
 Measured behaviour on both sides of the upstream fix, two nodes on canvas:
 
 | build | Case A duplicates | Case B duplicates |
 |---|---|---|
 | nightly `1.12.0.dev9` (pre-fix) | `popover-anchor-input-url_input x2` | `popover-anchor-input-input_value x2`, `textarea_str_system_prompt x2` |
-| `1.11.1` (carries langflow#14312) | none — ids read `…-APIRequest-<suffix>` | none — ids read `…-Agent-<suffix>` |
+| build carrying langflow#14312 | none — ids read `…-APIRequest-<suffix>` | none — ids read `…-Agent-<suffix>` |
 
-In both builds the field **testid** resolved to 2 elements, which is the contract half staying green across the fix.
+In both builds the field **testid** resolved to 2 elements — the contract half staying green across the fix.
+
+### Scope of the sweep, and what that costs
+
+**Canvas-scoped, not document-scoped.** The parameters side panel renders the same field with the **same DOM id** as the node body: `popover/index.tsx` applies `getNodeScopedDomId(id, nodeId)` unconditionally, and only `data-testid` gets the `-edit` suffix in edit mode. A document-wide sweep would therefore report a duplicate whenever that panel is open for a selected node — a false failure with no LE-2037 regression behind it. Scoping to `#react-flow-id` also excludes app-chrome and portal noise. The sweep throws if the canvas root is missing, so a selector change surfaces as an error instead of an empty list that would pass vacuously.
+
+**Form controls only** (`input` / `textarea` / `select`) — what the DevTools warning covers, what breaks autofill, and what upstream's own regression test sweeps. Icon SVGs legitimately repeat their internal ids (gradients, masks, filters) whenever the same icon renders twice and must not fail this test for the wrong reason. **The cost is real:** of the 15 `id=` sites langflow#14312 edited, those whose id lands on a `span`, a `div`, a contenteditable `div` or a Radix `button[role="switch"]` — `promptComponent`, `mustachePromptComponent`, `accordionPromptComponent`, `emptyParameterComponent`, `toggleShadComponent` — are **not** reached by this sweep. The per-field assertions cover the two paths this spec claims regardless of element type; the broader sweep is a bonus net over form controls only. (`select[id]` is defensive: Langflow renders Radix Select, not a native `<select>`.)
 
 ---
 
@@ -81,11 +97,12 @@ In both builds the field **testid** resolved to 2 elements, which is the contrac
 - `src/frontend/src/components/core/parameterRenderComponent/helpers/get-node-scoped-dom-id.ts` — the helper that scopes the DOM id by `nodeId`, introduced by langflow#14312. If removed or bypassed, this test fails.
 - `src/frontend/src/components/core/parameterRenderComponent/index.tsx` — builds the base id from the template type/name and threads `nodeId` down to the renderers.
 - `src/frontend/src/components/core/parameterRenderComponent/components/textAreaComponent/index.tsx` — renders the `textarea_str_*` fields the Agent case asserts; `id` scoped, `data-testid` unscoped.
+- `src/frontend/src/components/core/parameterRenderComponent/components/strRenderComponent/index.tsx` — routes single-line string fields and forwards `nodeId`.
 - `src/frontend/src/components/core/parameterRenderComponent/components/inputComponent/index.tsx` and `.../components/popover/index.tsx` — render the `popover-anchor-input-*` fields the API Request case asserts. Any renderer added here that does not call `getNodeScopedDomId` reintroduces the defect.
 - `src/frontend/src/types/components/index.ts` — declares the optional `nodeId` prop. The helper falls back to the unscoped id when it is absent, so a renderer that simply fails to receive the prop regresses silently.
 - Sidebar add affordances — `sidebar-search-input`, `add-component-button-api-request`, `disclosure-models & agents`, `models_and_agentsAgent`.
-- Node titles — `title-API Request`, `title-Agent` (rendered by `CustomNodes/GenericNode/components/NodeName`).
-- React Flow canvas — `.react-flow__node` for node counting, `//*[@id="react-flow-id"]` as the drag drop target.
+- Node titles — `title-API Request` (rendered by `CustomNodes/GenericNode/components/NodeName`).
+- React Flow canvas — `.react-flow__node` for node counting, `#react-flow-id` as both the sweep root and the drag drop target.
 - Field testids — `popover-anchor-input-url_input`, `textarea_str_system_prompt`.
 - `tests/helpers/flows/setup-blank-flow.ts` — API-based flow creation plus the id used for cleanup.
 
@@ -93,11 +110,12 @@ In both builds the field **testid** resolved to 2 elements, which is the contrac
 
 ## What this test does not cover *(optional)*
 
-- **`IntComponent` / `FloatComponent` / `ToggleShadComponent` id paths.** Upstream's own case uses `int_int_k` on WikipediaAPI. The only proven int field in this suite, `int_int_timeout` on API Request, is `advanced=True` and would have to be revealed per node (`parameters-button` mounts only for the currently-selected node), which is disproportionate for a first iteration.
+- **Renderers whose id lands on a non-form-control element** — see *Scope of the sweep* above. The two asserted fields are covered directly; the other renderers are not.
+- **`IntComponent` / `FloatComponent` id paths.** Upstream's own case uses `int_int_k` on WikipediaAPI. The only proven int field in this suite, `int_int_timeout` on API Request, is `advanced=True` and would have to be revealed per node (`parameters-button` mounts only for the currently-selected node), which is disproportionate here.
 - **Two *different* components sharing a field name** (e.g. OpenAI + Anthropic both exposing `api_key`). Same defect class, but it needs provider components whose availability varies by distribution (`lfx-bundles` is absent from `langflow-nightly:latest` — #1039), so the case would skip silently.
 - **Three or more nodes.** Two proves the scoping; an N-node collision would require the scope itself to be non-unique, which `nodeId` guarantees it is not.
-- **The inspector / edit-node surface.** Fields rendered in the parameters side panel carry an edit-mode prefix and are a separate id path.
-- **Non-form-control ids.** A pre-fix sweep of *every* `[id]` also showed `other_tools x2` on the Agent canvas; it is not an `input`/`textarea`/`select`, so this test's form-control scope excludes it by design (see Validation criterion).
+- **The parameters side panel.** It shares the node body's DOM id by design (only the testid differs), so it is excluded from the sweep rather than asserted — covering it would require deciding whether that shared id is itself a defect, which is out of scope here.
+- **Non-form-control ids on the canvas.** A pre-fix sweep of every `[id]` on a two-Agent canvas also reported `other_tools x2`. That element is not an `input`/`textarea`/`select`, so this scope excludes it — note this is a *dropped true positive*, not noise like the SVG gradient ids.
 - **The unrelated, still-open** *"A form field element should have an id or name attribute"* DevTools info-level issue, present before and after this fix.
 - **Actual browser autofill behaviour.** Not observable from Playwright; id uniqueness is the proxy.
 
@@ -105,22 +123,24 @@ In both builds the field **testid** resolved to 2 elements, which is the contrac
 
 ## Preconditions *(optional)*
 
-- Langflow running at `PLAYWRIGHT_BASE_URL` on a build that includes langflow#14312. On a pre-fix build both cases fail **by design** — that is the negative control, not a defect in the test.
-- No model provider credentials required.
+- Langflow running at `PLAYWRIGHT_BASE_URL` on a build that includes langflow#14312 — currently the **`release-1.11.2`** line. On any build without it (including today's `langflowai/langflow-nightly:latest`, built from `release-1.12.0`) both cases fail **by design**; that is the negative control, not a defect in the test.
+- The positive validation for this spec ran against a local instance reporting version `1.11.1` / package `Langflow` that demonstrably carries the fix (its ids read `popover-anchor-input-url_input-APIRequest-<suffix>`), consistent with a build off the `release-1.11.2` line. Note that the **published** `langflowai/langflow:1.11.1` image does not contain the helper, so it is not a reproduction target.
+- No model provider credentials required — the nodes are placed and inspected, never executed, so the Agent case makes no LLM call.
 
 ---
 
 ## When to review this test *(optional)*
 
-- A new parameter renderer is added under `parameterRenderComponent/components/` — it must call `getNodeScopedDomId` or this test goes red.
-- The suite's selector strategy changes, or someone proposes scoping `data-testid`. This test is the tripwire for that.
-- The Agent or API Request node stops exposing the asserted field, in which case the `toHaveCount(2)` gate fails first and names it.
+- **The fix reaches `main` / the 1.12 line** — that is the trigger to add `@stable` (see *Tags*).
+- A new parameter renderer is added under `parameterRenderComponent/components/` **whose id lands on an `input`, `textarea` or `select`** — it must call `getNodeScopedDomId` or this test goes red. Renderers using a `span`, `div` or Radix switch are outside the sweep's reach.
+- The suite's selector strategy changes, or someone proposes scoping `data-testid`. This spec is the tripwire for that.
+- The Agent or API Request node stops exposing the asserted field, in which case the field assertion fails first and names it.
 
 ---
 
 ## Notes *(optional)*
 
 - Chrome reports this defect through the CDP `Audits` domain that feeds the DevTools **Issues** panel — **not** the console. Neither `page.on("console")` nor the repo fixture's response monitor can observe it, which is why the check is an explicit DOM sweep rather than a listener.
-- Node overlap is irrelevant: the sweep reads the DOM, not layout. The `adjustScreenView` calls exist only to keep failure traces legible.
+- Node overlap is irrelevant: the sweep reads the DOM, not layout. React Flow is not configured with `onlyRenderVisibleElements`, so off-screen nodes keep their fields mounted and no zoom/pan state can make this vacuous. There is deliberately **no** `adjustScreenView` call — it would add a dependency on the canvas-controls layout (#997) for a purely cosmetic gain.
 - **Chat Input and Webhook are unsuitable subjects** — they are singletons, so adding one removes the other's sidebar `+` and they cannot be duplicated or pasted (which is why upstream had to build its ChatInput case through the API). **Prompt Template is also unsuitable**: its visible field is a prompt-modal surface, not a form control, and a two-node Prompt Template canvas produces no duplicate-id warning at all.
 - Sibling specs place two identical nodes but assert only node counts, so none of them would catch this: `ui-ux/langflowShortcuts.spec.ts` (duplication via shortcuts — its header comment states Chat Output was chosen *because* it carries no text field) and `flow-functionality/canvas-copy-paste.spec.ts` (paste of a second Prompt Template). `core-components/chat-input-output-component-regression.spec.ts` actually hit this ambiguity — Chat Input and Chat Output both render `popover-anchor-input-sender_name` — diagnosed it as "DOM ordering", and worked around it with a node-scoped filter.

--- a/docs/core-components/duplicate-dom-ids-regression.md
+++ b/docs/core-components/duplicate-dom-ids-regression.md
@@ -60,7 +60,7 @@ The two tests are **not** serial: they drive independent flows with unique gener
 
 **afterEach (both cases)**
 
-1. Navigate to `/` so the unmounted editor stops polling a flow about to be deleted — gated on the test having passed, because Playwright captures the on-failure screenshot after user hooks and navigating would archive the home page instead of the failed canvas.
+1. Navigate to `/` so the mounted editor stops polling a flow about to be deleted (#1023/#1103) — **unconditionally**, including on failure. On `@playwright/test` 1.58.2 (the pinned version) the `only-on-failure` screenshot is captured *before* the `afterEach` hooks run, not during the page-fixture teardown — measured on #1105, where a `goto` in this hook still left `test-failed-1.png` showing the canvas. Gating the navigation on the test having passed would protect no artifact and only reintroduce the teardown 404.
 2. `deleteFlow(request, id, { headers: { Authorization: bearer } })` for each flow created, id-scoped — never a global wipe (#553). A failed delete is logged, not swallowed.
 
 ---

--- a/tests/tests-automations/regression/core-components/duplicate-dom-ids-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/duplicate-dom-ids-regression.spec.ts
@@ -40,18 +40,20 @@ const CANVAS_ROOT_ID = "react-flow-id";
 // parallel workers are actively driving (#553).
 const createdFlowIds: string[] = [];
 
-test.afterEach(async ({ page, request }, testInfo) => {
+test.afterEach(async ({ page, request }) => {
   if (createdFlowIds.length === 0) return;
-  // Leave the editor so the unmounted flow page stops polling a flow we are
-  // about to delete (a mid-poll delete 404s, which the fixture logs).
+  // Leave the editor BEFORE deleting, so the mounted flow page stops polling a
+  // flow that is about to disappear (a mid-poll delete 404s, which the fixture
+  // logs as a backend error — see the run on this spec's own PR).
   //
-  // On success only: Playwright captures the on-failure screenshot while tearing
-  // down the page fixture, which runs AFTER this hook, so navigating away on a
-  // failing test would archive a picture of the home page instead of the canvas
-  // whose ids collided.
-  if (testInfo.status === testInfo.expectedStatus) {
-    await page.goto("/").catch(() => {});
-  }
+  // Unconditional, including on failure: with `@playwright/test` 1.58.2 (the
+  // pinned version) the `only-on-failure` screenshot is captured BEFORE the
+  // afterEach hooks run, not during the page-fixture teardown — measured on
+  // #1105, where a `goto` here still left `test-failed-1.png` showing the
+  // canvas. Gating the navigation on the test having passed would therefore
+  // protect nothing and only reintroduce the teardown 404 that #1023/#1103
+  // exist to avoid.
+  await page.goto("/").catch(() => {});
   // `page.request` carries only browser cookies and the flows API answers 401 to
   // those, so pass the bearer token explicitly.
   const bearer = await getAuthToken(request);

--- a/tests/tests-automations/regression/core-components/duplicate-dom-ids-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/duplicate-dom-ids-regression.spec.ts
@@ -1,0 +1,199 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { addComponentFromSidebar } from "../../../helpers/flows/add-component-from-sidebar";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
+import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
+
+/**
+ * LE-2037 / langflow#14096, fixed by langflow#14312: node parameter fields
+ * derived their DOM id from the template type/name alone, so two nodes exposing
+ * a field with the same name rendered duplicate ids — a WCAG 4.1.1 violation
+ * that also breaks browser autofill. The fix scopes the DOM id by nodeId
+ * (`<id>-<nodeId>`) and deliberately leaves `data-testid` unscoped, which is
+ * what this suite selects on. Both halves are asserted here: uniqueness of the
+ * `id`, and stability of the `data-testid`.
+ *
+ * The second half is the load-bearing one for this repository. 132 call sites
+ * across 45 specs select node fields by `data-testid`; if uniqueness were ever
+ * "fixed" by scoping the testid instead, this spec fails first and names the
+ * cause, instead of 45 files failing at once for no obvious reason.
+ *
+ * Sibling specs place two identical nodes but assert only node counts, so none
+ * of them covers this: `ui-ux/langflowShortcuts.spec.ts` (duplication via
+ * shortcuts, deliberately using a node with no text field) and
+ * `flow-functionality/canvas-copy-paste.spec.ts` (paste of a second Prompt
+ * Template). `core-components/chat-input-output-component-regression.spec.ts`
+ * actually hit this ambiguity and worked around it with a node-scoped filter.
+ */
+
+// Each test creates a flow that autosaves to the backend. Serial mode prevents
+// parallel autosave races within this file.
+test.describe.configure({ mode: "serial" });
+
+// Ids of the flows each test created, deleted id-scoped in afterEach (repo
+// convention #490/#681) — never a global cleanAllFlows, which wipes flows other
+// parallel workers are actively driving (#553).
+const createdFlowIds: string[] = [];
+
+test.afterEach(async ({ page, request }, testInfo) => {
+  if (createdFlowIds.length === 0) return;
+  // Leave the editor so the unmounted flow page stops polling a flow we are
+  // about to delete (a mid-poll delete 404s, which the fixture logs).
+  //
+  // On success only: Playwright captures the on-failure screenshot while tearing
+  // down the page fixture, which runs AFTER this hook, so navigating away on a
+  // failing test would archive a picture of the home page instead of the canvas
+  // whose ids collided.
+  if (testInfo.status === testInfo.expectedStatus) {
+    await page.goto("/").catch(() => {});
+  }
+  // `page.request` carries only browser cookies and the flows API answers 401 to
+  // those, so pass the bearer token explicitly.
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    // `deleteFlow` throws on purpose so a failed cleanup stays visible; log it
+    // rather than swallowing it, but don't fail an otherwise-green test on a
+    // teardown blip.
+    await deleteFlow(
+      request,
+      id,
+      bearer ? { headers: { Authorization: bearer } } : undefined,
+    ).catch((error: unknown) => {
+      console.warn(
+        `⚠️  cleanup: flow ${id} was NOT deleted — ${
+          (error as Error)?.message?.split("\n")[0] ?? error
+        }`,
+      );
+    });
+  }
+});
+
+/**
+ * Collects duplicated DOM ids among form controls only.
+ *
+ * Scoped to `input` / `textarea` / `select` on purpose: that is what the reported
+ * DevTools warning ("Duplicate form field id in the same form") covers and what
+ * breaks autofill. Icon SVGs legitimately repeat their own internal ids
+ * (gradients, masks, filters) whenever the same icon renders twice — a separate
+ * concern that must not fail this test for the wrong reason.
+ *
+ * Returns entries like `popover-anchor-input-url_input x2` so a failure names the
+ * offending ids instead of reporting a bare count mismatch.
+ */
+async function collectDuplicateFormFieldIds(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const counts = new Map<string, number>();
+    for (const element of Array.from(
+      document.querySelectorAll("input[id], textarea[id], select[id]"),
+    )) {
+      counts.set(element.id, (counts.get(element.id) ?? 0) + 1);
+    }
+    return Array.from(counts.entries())
+      .filter(([, count]) => count > 1)
+      .map(([id, count]) => `${id} x${count}`)
+      .sort();
+  });
+}
+
+test.describe("Node parameter DOM ids — uniqueness across sibling nodes", () => {
+  test("two API Request nodes expose the same field without duplicating its DOM id",
+    { tag: ["@stable", "@release", "@regression", "@components"] },
+    async ({ page }) => {
+      await test.step("Open a blank flow and add two API Request nodes", async () => {
+        createdFlowIds.push(await setupBlankFlow(page));
+
+        await addComponentFromSidebar(
+          page,
+          "API Request",
+          "add-component-button-api-request",
+        );
+        // Gate on the first node rendering before adding the second: the sidebar
+        // click is fire-and-forget, and asserting the count straight away can
+        // observe 1 while the second is still mounting.
+        await expect(page.getByTestId("title-API Request")).toBeVisible({
+          timeout: 15000,
+        });
+
+        await addComponentFromSidebar(
+          page,
+          "API Request",
+          "add-component-button-api-request",
+        );
+        await expect(page.locator(".react-flow__node")).toHaveCount(2, {
+          timeout: 15000,
+        });
+        await adjustScreenView(page, { numberOfZoomOut: 2 });
+      });
+
+      await test.step("Both URL fields are mounted, proving data-testid stayed unscoped", async () => {
+        // Two purposes. It gates the sweep below — a half-mounted canvas would
+        // pass it vacuously — and it is itself the test-id stability assertion:
+        // count 2 is only possible while `data-testid` is NOT node-scoped, which
+        // is the contract 132 call sites in this suite depend on.
+        await expect(
+          page.getByTestId("popover-anchor-input-url_input"),
+        ).toHaveCount(2, { timeout: 15000 });
+      });
+
+      await test.step("No form control shares a DOM id", async () => {
+        const duplicates = await collectDuplicateFormFieldIds(page);
+        expect(
+          duplicates,
+          `duplicate form field ids on a two-node API Request canvas: ${duplicates.join(", ")}`,
+        ).toEqual([]);
+      });
+    },
+  );
+
+  test("two Agent nodes expose the same field without duplicating its DOM id",
+    { tag: ["@stable", "@release", "@regression", "@components", "@agents"] },
+    async ({ page }) => {
+      await test.step("Open a blank flow and drag two Agent nodes onto the canvas", async () => {
+        createdFlowIds.push(await setupBlankFlow(page));
+
+        // The Agent has no `add-component-button-agent` testid, so the drag from
+        // the sidebar disclosure is the proven path (mirrors
+        // `agent-component-regression.spec.ts`).
+        await page.getByTestId("disclosure-models & agents").click();
+        await page.getByTestId("models_and_agentsAgent").waitFor({
+          state: "visible",
+          timeout: 15000,
+        });
+
+        // Distinct drop positions so the two nodes do not stack. Irrelevant to
+        // the DOM assertion — the sweep reads the DOM, not layout — but it keeps
+        // a failure trace readable.
+        for (const targetPosition of [
+          { x: 250, y: 200 },
+          { x: 650, y: 200 },
+        ]) {
+          await page
+            .getByTestId("models_and_agentsAgent")
+            .dragTo(page.locator('//*[@id="react-flow-id"]'), {
+              targetPosition,
+            });
+        }
+        await expect(page.locator(".react-flow__node")).toHaveCount(2, {
+          timeout: 15000,
+        });
+        await adjustScreenView(page, { numberOfZoomOut: 2 });
+      });
+
+      await test.step("Both Agent Instructions fields are mounted, proving data-testid stayed unscoped", async () => {
+        await expect(
+          page.getByTestId("textarea_str_system_prompt"),
+        ).toHaveCount(2, { timeout: 15000 });
+      });
+
+      await test.step("No form control shares a DOM id", async () => {
+        const duplicates = await collectDuplicateFormFieldIds(page);
+        expect(
+          duplicates,
+          `duplicate form field ids on a two-Agent canvas: ${duplicates.join(", ")}`,
+        ).toEqual([]);
+      });
+    },
+  );
+});

--- a/tests/tests-automations/regression/core-components/duplicate-dom-ids-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/duplicate-dom-ids-regression.spec.ts
@@ -4,7 +4,6 @@ import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { addComponentFromSidebar } from "../../../helpers/flows/add-component-from-sidebar";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
 import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
-import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 
 /**
  * LE-2037 / langflow#14096, fixed by langflow#14312: node parameter fields
@@ -12,13 +11,12 @@ import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
  * a field with the same name rendered duplicate ids — a WCAG 4.1.1 violation
  * that also breaks browser autofill. The fix scopes the DOM id by nodeId
  * (`<id>-<nodeId>`) and deliberately leaves `data-testid` unscoped, which is
- * what this suite selects on. Both halves are asserted here: uniqueness of the
- * `id`, and stability of the `data-testid`.
+ * what this suite selects on. Both halves are asserted here.
  *
- * The second half is the load-bearing one for this repository. 132 call sites
- * across 45 specs select node fields by `data-testid`; if uniqueness were ever
- * "fixed" by scoping the testid instead, this spec fails first and names the
- * cause, instead of 45 files failing at once for no obvious reason.
+ * The `data-testid` half is the load-bearing one for this repository. 132 call
+ * sites across 45 specs select node fields by `data-testid`; if uniqueness were
+ * ever "fixed" by scoping the testid instead, this spec fails first and names
+ * the cause, instead of 45 files failing at once for no obvious reason.
  *
  * Sibling specs place two identical nodes but assert only node counts, so none
  * of them covers this: `ui-ux/langflowShortcuts.spec.ts` (duplication via
@@ -26,11 +24,16 @@ import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
  * `flow-functionality/canvas-copy-paste.spec.ts` (paste of a second Prompt
  * Template). `core-components/chat-input-output-component-regression.spec.ts`
  * actually hit this ambiguity and worked around it with a node-scoped filter.
+ *
+ * NOT serial: the two tests drive independent flows created with unique names
+ * and share no state, so parallelism races nothing. Keeping them independent is
+ * deliberate — under `mode: "serial"` a failure in the first test SKIPS the
+ * second, which would leave the daily with no verdict at all for that case.
  */
 
-// Each test creates a flow that autosaves to the backend. Serial mode prevents
-// parallel autosave races within this file.
-test.describe.configure({ mode: "serial" });
+// The React Flow canvas root. The duplicate sweep is scoped to it rather than to
+// `document` — see `collectDuplicateFormFieldIds`.
+const CANVAS_ROOT_ID = "react-flow-id";
 
 // Ids of the flows each test created, deleted id-scoped in afterEach (repo
 // convention #490/#681) — never a global cleanAllFlows, which wipes flows other
@@ -71,22 +74,45 @@ test.afterEach(async ({ page, request }, testInfo) => {
 });
 
 /**
- * Collects duplicated DOM ids among form controls only.
+ * Collects duplicated DOM ids among the form controls rendered **inside the
+ * canvas**.
  *
- * Scoped to `input` / `textarea` / `select` on purpose: that is what the reported
- * DevTools warning ("Duplicate form field id in the same form") covers and what
- * breaks autofill. Icon SVGs legitimately repeat their own internal ids
- * (gradients, masks, filters) whenever the same icon renders twice — a separate
- * concern that must not fail this test for the wrong reason.
+ * Two deliberate scope decisions, both of which bound what this can prove:
+ *
+ * 1. **Canvas-scoped, not document-scoped.** The parameters side panel renders
+ *    the same field with the SAME DOM id as the node body — `popover/index.tsx`
+ *    applies `getNodeScopedDomId(id, nodeId)` unconditionally, and only the
+ *    `data-testid` gets the `-edit` suffix in edit mode. A document-wide sweep
+ *    would therefore report a duplicate whenever the panel is open for a
+ *    selected node, which is not the LE-2037 defect. Scoping to the canvas also
+ *    drops app-chrome and portal noise for free.
+ * 2. **Form controls only** (`input` / `textarea` / `select`). That is what the
+ *    reported DevTools warning ("Duplicate form field id in the same form")
+ *    covers, what breaks autofill, and what upstream's own regression test
+ *    sweeps. Icon SVGs legitimately repeat their internal ids (gradients, masks,
+ *    filters) whenever the same icon renders twice, and must not fail this test
+ *    for the wrong reason. The cost is real and stated in the spec doc: the
+ *    renderers whose id lands on a `span`, `div` or Radix `button[role=switch]`
+ *    (prompt, mustache-prompt, accordion-prompt, empty-parameter, toggle) are
+ *    NOT covered by this sweep. The per-field assertions in each test cover the
+ *    two paths this spec claims, regardless of element type.
  *
  * Returns entries like `popover-anchor-input-url_input x2` so a failure names the
- * offending ids instead of reporting a bare count mismatch.
+ * offending ids instead of reporting a bare count mismatch. Throws if the canvas
+ * root is missing, so a selector change surfaces as an error rather than as an
+ * empty list that would pass for the wrong reason.
  */
 async function collectDuplicateFormFieldIds(page: Page): Promise<string[]> {
-  return page.evaluate(() => {
+  return page.evaluate((canvasRootId) => {
+    const root = document.getElementById(canvasRootId);
+    if (!root) {
+      throw new Error(
+        `canvas root #${canvasRootId} not found — the duplicate sweep would be vacuous`,
+      );
+    }
     const counts = new Map<string, number>();
     for (const element of Array.from(
-      document.querySelectorAll("input[id], textarea[id], select[id]"),
+      root.querySelectorAll("input[id], textarea[id], select[id]"),
     )) {
       counts.set(element.id, (counts.get(element.id) ?? 0) + 1);
     }
@@ -94,12 +120,46 @@ async function collectDuplicateFormFieldIds(page: Page): Promise<string[]> {
       .filter(([, count]) => count > 1)
       .map(([id, count]) => `${id} x${count}`)
       .sort();
-  });
+  }, CANVAS_ROOT_ID);
+}
+
+/**
+ * Asserts the field contract for one testid on a two-node canvas:
+ * the testid resolves to both nodes, each element carries a DOM id, and the two
+ * ids differ.
+ *
+ * The middle assertion is what keeps this test from passing vacuously.
+ * `getNodeScopedDomId` returns `undefined` for an empty base id and React then
+ * omits the attribute — so a refactor that stopped threading `id` into a
+ * renderer would drop both elements out of the `[id]` sweep and leave it
+ * reporting no duplicates, i.e. green for the wrong reason.
+ */
+async function expectFieldIdsUniquePerNode(
+  page: Page,
+  fieldTestId: string,
+): Promise<void> {
+  const ids = await page
+    .getByTestId(fieldTestId)
+    .evaluateAll((elements) => elements.map((element) => element.id));
+
+  // `data-testid` stayed unscoped — the contract 132 call sites in this suite
+  // depend on. Scoping it by node instead of the id would make this 1, not 2.
+  expect(ids, `expected ${fieldTestId} on both nodes, got ${ids.length}`).toHaveLength(2);
+  // Each field actually has an id to be unique about.
+  expect(
+    ids.filter(Boolean),
+    `both ${fieldTestId} elements must carry a DOM id, got ${JSON.stringify(ids)}`,
+  ).toHaveLength(2);
+  // The defect itself: two nodes, two distinct ids.
+  expect(
+    new Set(ids).size,
+    `the two ${fieldTestId} elements share a DOM id: ${JSON.stringify(ids)}`,
+  ).toBe(2);
 }
 
 test.describe("Node parameter DOM ids — uniqueness across sibling nodes", () => {
   test("two API Request nodes expose the same field without duplicating its DOM id",
-    { tag: ["@stable", "@release", "@regression", "@components"] },
+    { tag: ["@regression", "@components"] },
     async ({ page }) => {
       await test.step("Open a blank flow and add two API Request nodes", async () => {
         createdFlowIds.push(await setupBlankFlow(page));
@@ -124,20 +184,16 @@ test.describe("Node parameter DOM ids — uniqueness across sibling nodes", () =
         await expect(page.locator(".react-flow__node")).toHaveCount(2, {
           timeout: 15000,
         });
-        await adjustScreenView(page, { numberOfZoomOut: 2 });
       });
 
-      await test.step("Both URL fields are mounted, proving data-testid stayed unscoped", async () => {
-        // Two purposes. It gates the sweep below — a half-mounted canvas would
-        // pass it vacuously — and it is itself the test-id stability assertion:
-        // count 2 is only possible while `data-testid` is NOT node-scoped, which
-        // is the contract 132 call sites in this suite depend on.
-        await expect(
-          page.getByTestId("popover-anchor-input-url_input"),
-        ).toHaveCount(2, { timeout: 15000 });
+      await test.step("Both URL fields carry distinct DOM ids under one testid", async () => {
+        await expectFieldIdsUniquePerNode(
+          page,
+          "popover-anchor-input-url_input",
+        );
       });
 
-      await test.step("No form control shares a DOM id", async () => {
+      await test.step("No form control on the canvas shares a DOM id", async () => {
         const duplicates = await collectDuplicateFormFieldIds(page);
         expect(
           duplicates,
@@ -148,7 +204,7 @@ test.describe("Node parameter DOM ids — uniqueness across sibling nodes", () =
   );
 
   test("two Agent nodes expose the same field without duplicating its DOM id",
-    { tag: ["@stable", "@release", "@regression", "@components", "@agents"] },
+    { tag: ["@regression", "@components", "@agents"] },
     async ({ page }) => {
       await test.step("Open a blank flow and drag two Agent nodes onto the canvas", async () => {
         createdFlowIds.push(await setupBlankFlow(page));
@@ -163,31 +219,29 @@ test.describe("Node parameter DOM ids — uniqueness across sibling nodes", () =
         });
 
         // Distinct drop positions so the two nodes do not stack. Irrelevant to
-        // the DOM assertion — the sweep reads the DOM, not layout — but it keeps
-        // a failure trace readable.
+        // the DOM assertions — React Flow does not cull off-screen nodes
+        // (`onlyRenderVisibleElements` is not used), so the fields are in the DOM
+        // either way — but it keeps a failure trace readable.
         for (const targetPosition of [
           { x: 250, y: 200 },
           { x: 650, y: 200 },
         ]) {
           await page
             .getByTestId("models_and_agentsAgent")
-            .dragTo(page.locator('//*[@id="react-flow-id"]'), {
+            .dragTo(page.locator(`//*[@id="${CANVAS_ROOT_ID}"]`), {
               targetPosition,
             });
         }
         await expect(page.locator(".react-flow__node")).toHaveCount(2, {
           timeout: 15000,
         });
-        await adjustScreenView(page, { numberOfZoomOut: 2 });
       });
 
-      await test.step("Both Agent Instructions fields are mounted, proving data-testid stayed unscoped", async () => {
-        await expect(
-          page.getByTestId("textarea_str_system_prompt"),
-        ).toHaveCount(2, { timeout: 15000 });
+      await test.step("Both Agent Instructions fields carry distinct DOM ids under one testid", async () => {
+        await expectFieldIdsUniquePerNode(page, "textarea_str_system_prompt");
       });
 
-      await test.step("No form control shares a DOM id", async () => {
+      await test.step("No form control on the canvas shares a DOM id", async () => {
         const duplicates = await collectDuplicateFormFieldIds(page);
         expect(
           duplicates,


### PR DESCRIPTION
## What this does

Adds the suite's **first** DOM-id-uniqueness coverage, closing a class-level gap left by LE-2037 / langflow-ai/langflow#14096 (fixed upstream by [langflow#14312](https://github.com/langflow-ai/langflow/pull/14312)): a node parameter field derived its DOM `id` from the template type/name alone, so two nodes exposing a same-named field rendered multiple elements sharing one `id` — a WCAG 4.1.1 violation that also breaks browser autofill. The fix produces `<id>-<nodeId>` for the `id` while deliberately leaving `data-testid` **unscoped**, because that is what this suite selects on.

## The suite was structurally blind to this

- **No id-uniqueness assertion anywhere.** Raw `#id` selectors existed only for app-chrome singletons.
- **No accessibility tooling** — `axe-core|AxeBuilder|injectAxe|checkA11y|pa11y|lighthouse` → 0 hits.
- **The fixture cannot see it.** Chrome reports *"Duplicate form field id in the same form"* through the CDP `Audits` domain that feeds the DevTools Issues panel, not the console — so neither `page.on("console")` nor the fixture's response monitor would ever observe it. Hence an explicit DOM sweep.

Several specs came close and were designed *around* the ambiguity. The clearest is `chat-input-output-component-regression.spec.ts`, where Chat Input and Chat Output both render `popover-anchor-input-sender_name`: the authors hit the double match, diagnosed it as *"DOM ordering"*, and worked around it with a node-scoped filter. Others mask the class with `.nth(0)` on a regex node-field locator. None of it is wrong — it just means an id collision cannot fail anything today.

## Two cases, two distinct renderer paths

| case | nodes | field | id path |
|---|---|---|---|
| A | API Request ×2 (sidebar `+`) | `popover-anchor-input-url_input` | `StrRenderComponent` → `InputComponent` → `popover` |
| B | Agent ×2 (sidebar drag) | `textarea_str_system_prompt` | `TextAreaComponent` |

Each asserts **both halves** of the fix. The uniqueness half is obvious; the `data-testid` half is the load-bearing one for this repo — **132 call sites across 45 specs** select node fields by testid, so if uniqueness were ever "fixed" by scoping the testid instead, this spec fails first and names the cause rather than 45 files failing at once.

Subject choice is constrained, not arbitrary: Chat Input and Webhook are **singletons** (adding one removes the other's `+`; they cannot be duplicated or pasted — which is why upstream built its ChatInput case through the API), and Prompt Template does not reproduce the defect at all because its visible field is a prompt-modal surface, not a form control.

## ⚠️ Merged without `@stable`, deliberately — the fix is NOT in the nightly

This is the one thing to read before approving. The upstream PR landed on the **`release-1.11.2`** branch, not `main`. `langflowai/langflow-nightly:latest` — the image `daily-stable.yml` runs — is built from the highest `release-*` branch, currently `release-1.12.0`, where the helper is verifiably absent:

```
$ gh api .../helpers/get-node-scoped-dom-id.ts?ref=main            --jq .sha  → 404
$ gh api .../helpers/get-node-scoped-dom-id.ts?ref=release-1.12.0  --jq .sha  → 404
$ gh api .../helpers/get-node-scoped-dom-id.ts?ref=release-1.11.2  --jq .sha  → a8a903e
```

So this is **not** "the next nightly picks it up" — the fix has to reach the 1.12 line first. Tagged `@stable`, both cases would hard-fail the first weekday daily, trip `auto-remove-stable` into stripping the tag and committing to `main`, and open a `daily-failure` issue, to rediscover something already documented in the spec doc. The doc's **Tags** section states the reason and the one-command check that gates promotion, and the checklist bullet is `[-]` to match.

**Trade-off worth naming:** without `@stable` the spec runs nowhere except this PR's impacted-specs job (`nightly.yml` is disabled), so it is dormant until promoted. That is the cost of not seeding a knowingly-red daily. Promotion is a one-line change — say the word and I will flip it in this PR instead.

## Validation

Both sides of the upstream fix, `--retries=0`:

| build | result |
|---|---|
| build carrying langflow#14312 | **both PASS** · 3/3 burst runs green · ~6-7 s in parallel |
| nightly `1.12.0.dev9` (pre-fix) | **both FAIL**, `skipped: 0`, each naming its own ids |

The pre-fix run **is** the force-fail, and it names what it found:

```
the two popover-anchor-input-url_input elements share a DOM id:
  ["popover-anchor-input-url_input","popover-anchor-input-url_input"]
the two textarea_str_system_prompt elements share a DOM id:
  ["textarea_str_system_prompt","textarea_str_system_prompt"]
```

Post-fix the same ids read `…-APIRequest-<suffix>` / `…-Agent-<suffix>` while the testids still resolve to 2 elements — the fix's two halves, observed directly rather than inferred.

Cleanup is id-scoped (#490/#681), never a global wipe (#553), and verified **flow-neutral**: the instance held 16 flows before and after every run, including the runs where both tests failed. The navigate-away before deleting is gated on the test having passed, because Playwright captures the on-failure screenshot after user hooks — navigating unconditionally would archive the home page instead of the canvas whose ids collided.

Gates: `typecheck` clean · `lint` 0 errors · `validate:specs` exit 0 · coverage guard green · generated-block guard green (only the manual Part II bullet was touched).

## Notes for the reviewer

Three design decisions that an independent review changed, and are worth a look:

1. **The sweep is canvas-scoped (`#react-flow-id`), not document-scoped.** The parameters side panel renders the same field with the **same DOM id** as the node body — `popover/index.tsx` applies the scoping unconditionally and only `data-testid` gets the `-edit` suffix. A document-wide sweep would report a duplicate whenever that panel is open, with no regression behind it. The sweep now throws if the canvas root is missing, so a selector rename surfaces as an error rather than as an empty list that would pass vacuously.
2. **Each case asserts the ids directly**, not just `toHaveCount(2)`. The count proves the testid resolves to both nodes but not that either element *has* an id — and `getNodeScopedDomId` returns `undefined` for an empty base id, which React omits, silently emptying the sweep. So: exactly 2 elements, both ids non-empty, the two distinct.
3. **Not serial, and no `adjustScreenView`.** Serial mode bought nothing (independent flows, no shared state) while a case-A failure *skipped* case B — the pre-fix run proved it: previously 1 failed + 1 skipped, now both fail with their own diagnostics. `adjustScreenView` was cosmetic (React Flow does not cull off-screen nodes here) but adds a dependency on the canvas-controls layout, which hard-throws when it changes (#997).

**Stated limitation:** the sweep sees only `input`/`textarea`/`select` — what the DevTools warning covers and what upstream's own test sweeps — so 5 of the 15 renderers the fix touched (`prompt`, `mustachePrompt`, `accordionPrompt`, `emptyParameter`, `toggleShad`, whose ids land on a `span`, `div` or Radix `button[role=switch]`) are **not** reached. The per-field assertions cover the two paths this spec claims regardless of element type. This is documented in the spec doc rather than implied, along with `other_tools` being a *dropped true positive* rather than noise.

Closes #1102


---

## Review follow-ups applied

1. **Teardown navigates unconditionally** (`fb70baa`). The pass-gated navigation rested on the screenshot being captured *after* the `afterEach` hooks; on the pinned `@playwright/test` 1.58.2 it is captured *before* them (measured on #1105). The gate protected no artifact and reintroduced the teardown 404 — this PR's own run logged `🚨 Backend Error: 404 Not Found - /api/v1/flows/<id>` on a failing case. The comment and the spec doc now state the measured timing.
2. **Promotion is tracked in #1109.** Since this PR closes #1102 and `nightly.yml` is disabled, the spec would otherwise be dormant with nothing pointing at the `@stable` promotion. #1109 carries the trigger (the helper appearing on `main`), the four-step scope, and the note that until then the spec is red-by-design in the impacted-specs job of any PR touching a helper it imports (`setup-blank-flow`, `delete-flow`, `get-auth-token`, `add-component-from-sidebar` — #1054 selects transitively).
