### PR TITLE
fix(llm-agents): resolve the settled vision model and make the image assert falsifiable (#964)

### DIFF
--- a/docs/core-functionality/llm-agents/agent-multimodal-image-input.md
+++ b/docs/core-functionality/llm-agents/agent-multimodal-image-input.md
@@ -1,6 +1,6 @@
 # Agent Multimodal Image Input — image via input handle processed
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x
 
 ---
 
@@ -46,7 +46,12 @@ Playground.
   such a model per provider and skips a provider that has none.
 - Test image `tests/assets/media/chain.png` (a chain/links graphic).
 - Run with `--workers=1` (agent specs create named flows that collide in
-  parallel). File is serial (`SimpleAgentTemplatePage.load()` wipes all flows).
+  parallel). The file is serial so concurrent provider blocks do not starve the
+  single backend during the Playground runs.
+- **Teardown:** each test's flow is deleted **by id** in `afterEach` (ids captured
+  from the `POST /api/v1/flows/` 201 responses). `SimpleAgentTemplatePage.load()`
+  deletes nothing (post-#553 contract — no global `cleanAllFlows`, which races
+  parallel workers), so before #964 every run left one `Simple Agent` behind.
 
 ---
 
@@ -79,10 +84,13 @@ target provider; if none is available the provider is skipped.
    Playground races an async re-injection of the template default).
 6. Send (`button-send`); wait for the agent to finish
    (`waitForAgentToFinish` — Stop button appears then hides).
-7. **Validation:** the last rendered AI response (`.markdown.prose` / chat
-   bubble) **matches** `/chain|link|logo|inkscape/i` **and** its length is
-   `> 50` — the vision model described the image content, proving the image was
-   received via the input handle and processed.
+7. **Validation:** the last rendered **AI chat bubble**
+   (`[data-testid^="chat-message-AI-"]` → its `.markdown.prose`) **matches**
+   `/\bchains?\b|\binkscape\b/i`, does **not** match the "no image reached the
+   model" family (`cannot interpret/describe/see…`, `did not provide/attach`,
+   `please upload/provide…`), **and** its length is `> 50` — the vision model
+   described the image content, proving the image was received via the input
+   handle and processed.
 
 ---
 
@@ -103,9 +111,9 @@ target provider; if none is available the provider is skipped.
 ## Validation criterion *(required)*
 
 - **Positive:** with `chain.png` attached, the agent's response mentions the
-  image content (`/chain|link|logo|inkscape/i`) and is non-trivial (`> 50`
-  chars) — the image reached the vision model through the `ChatInput → Agent`
-  input handle and was processed.
+  image content (`/\bchains?\b|\binkscape\b/i`), is **not** a "no image / cannot
+  process images" reply, and is non-trivial (`> 50` chars) — the image reached the
+  vision model through the `ChatInput → Agent` input handle and was processed.
 - **Negative control:** with no image and the same prompt, the response does not
   mention `chain` — proving the positive match is caused by the image, not the
   prompt.
@@ -113,7 +121,20 @@ target provider; if none is available the provider is skipped.
 ## Guarding against false positives *(how)*
 
 - **Content keyword + length:** Test 1 asserts the reply describes the *actual*
-  image (chain/link/logo) and is substantive, not a generic acknowledgement.
+  image (word-bounded `chain(s)` / `inkscape`) and is substantive, not a generic
+  acknowledgement.
+- **The predicate may not match a refusal (#964).** `link` used to be in the
+  positive set, and a reply with **no image attached** — *"please upload an image
+  or provide a **link** to one"* — matched it: the test passed while proving
+  nothing. Measured by force-failure (image detached ⇒ `1 passed` before the fix,
+  `1 failed` after). Any word a no-image reply can produce is banned from the
+  positive set; `NO_IMAGE_REACHED_MODEL` asserts the refusal family separately so
+  the failure names itself.
+- **The reply must be a reply.** The assertion is anchored to the AI chat bubble
+  (`chat-message-AI-*`), not to `.markdown.prose` alone — the canvas renders 6 of
+  those (the Simple Agent sticky note among them), so `.last()` matched the sticky
+  note whenever no reply rendered and reported a hard build failure as a content
+  mismatch against the template's help text (#964).
 - **Negative control (Test 2):** the same prompt without the image must NOT
   produce the keyword — this is the primary guard, mirroring the positive /
   negative pattern in `agent-system-prompt.spec.ts`. Together they prove the
@@ -177,6 +198,20 @@ target provider; if none is available the provider is skipped.
   model selects the *first available* model, which may not be vision-capable
   (e.g. a `gemma-*`). The spec therefore resolves a vision-capable model per
   provider and skips a provider with none.
+- **Model resolution is settled-first (#964).** `resolveVisionModel()` takes the
+  model `collect-models` actually validated — it probes the catalog with real
+  calls and promotes the model that passed to the front of that provider's
+  `models.json` entries, while still listing the ones it rejected. A hardcoded
+  dated id must never win over it: the spec used to ask for
+  `^gemini-2.5-flash$` first, which Google has retired (*"This model
+  models/gemini-2.5-flash is no longer available to new users"*). collect-models
+  skipped it as gated and settled on `gemini-3.5-flash`; the spec kept resolving
+  the retired id, so the daily ran a model nobody validated — locally it 404s
+  (`Flow build failed`), and in CI, on a key that still reaches it, the agent
+  answered *"I cannot directly interpret or describe images"* (dailies 2026-07-20 /
+  07-22 / 07-27). Measured on 1.12.0.dev9: `gemini-2.5-flash` 0/3 runs, settled
+  `gemini-3.5-flash` 5/5. `VISION_PREFS` remains only as a fallback for partial
+  `models.json` data, and holds alias/undated patterns only (same lesson as #886).
 - **Prompt via the ChatInput node, not the Playground textarea:** the Playground
   chat input pre-fills from the ChatInput node's `input_value`, and it
   **re-injects the template default (`Hello, how are you?`) asynchronously** —

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-multimodal-image-input.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-multimodal-image-input.spec.ts
@@ -5,6 +5,8 @@ import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import {
   hasProviderEnvKeys,
   missingProviderEnvKeys,
@@ -37,11 +39,23 @@ if (!process.env.CI) {
 const IMAGE_PATH = "tests/assets/media/chain.png";
 const IMAGE_ALT = "chain.png";
 const PROMPT = "what is this image? describe it";
-// chain.png is a chain/links graphic; a vision model describes it with one of
-// these tokens. `chain` is the most image-specific — the negative control keys
-// on it.
-const DESCRIBES_IMAGE = /chain|link|logo|inkscape/i;
+// chain.png is a chain/links graphic. The predicate must only match words that
+// require having SEEN it — measured replies: "two vertical metal chains", "a
+// stylized vector illustration of two chains".
+//
+// `link` was in this set and made the test unfalsifiable (#964): with NO image
+// attached the model answers "please upload an image or provide a link to one",
+// which matched — so the test passed while proving nothing about the image ever
+// reaching the model (verified by force-failure: 1 passed with the image
+// detached). Word-bounded `chain(s)` only.
+const DESCRIBES_IMAGE = /\bchains?\b|\binkscape\b/i;
 const IMAGE_SPECIFIC = /chain/i;
+// The two ways this test's real failure looks — the model says it got no image,
+// or that it cannot do images at all (the recurrent #964 signature on the
+// retired `gemini-2.5-flash`). Asserted separately so the failure names itself
+// instead of surfacing as "pattern not found".
+const NO_IMAGE_REACHED_MODEL =
+  /(cannot|can not|can't|unable to|not able to)[\s\S]{0,40}(interpret|describe|process|analy[sz]e|see|view)|did not (provide|attach|include)|no image (was )?(provided|attached|included)|please (upload|provide|attach|share)/i;
 
 interface ModelRecord {
   provider: string;
@@ -57,19 +71,35 @@ interface TestTarget {
 // Non-vision / non-chat model families to exclude when resolving a vision model.
 const NON_VISION = /gemma|embedding|tts|audio|whisper|realtime|image|customtools|moderation|search/i;
 
-// Per-provider preference for a fast, vision-capable chat model.
+// Fallback preference per provider, used only when the settled model cannot be
+// used (see resolveVisionModel). Alias/undated patterns only — a hardcoded dated
+// id goes stale the moment the provider retires it (#886, #964).
 const VISION_PREFS: Record<string, RegExp[]> = {
   openai: [/^gpt-4o-mini$/, /^gpt-4o$/, /^gpt-4\.1(-mini)?$/, /gpt-4o/, /^gpt-5.*mini$/, /^gpt-5/],
-  google: [/^gemini-2\.5-flash$/, /^gemini-3\.5-flash$/, /^gemini-flash-latest$/, /gemini.*flash/, /gemini/],
+  google: [/^gemini-flash-latest$/, /gemini.*flash/, /gemini/],
   anthropic: [/^claude-3-5-sonnet/, /^claude-3-5-haiku/, /^claude-3-7/, /claude-3\.?5/, /claude-3/, /claude/],
 };
 
 // Resolve a vision-capable model for a provider from its models.json entries.
+//
+// **Settled-first (#964).** `collect-models` probes the provider's catalog with
+// real calls and promotes the model it actually validated to the front of that
+// provider's entries; models.json still lists the ones it rejected. Preferring a
+// hardcoded id over that settled model pins a model nobody validated: this spec
+// asked for `^gemini-2.5-flash$` first, which Google has retired ("no longer
+// available to new users") — collect-models skipped it as gated and settled on
+// `gemini-3.5-flash`, while the spec kept resolving the retired id. Locally that
+// 404s ("Flow build failed"); in CI, on a key that still reaches it, the agent
+// answered that it cannot interpret images at all (#964, dailies 2026-07-20 /
+// 07-22 / 07-27). So: take the settled model, and fall back to the preference
+// scan only when it is not usable for vision.
 function resolveVisionModel(provider: string, models: ModelRecord[]): string | undefined {
-  const candidates = models
-    .filter((m) => m.provider === provider)
-    .map((m) => m.model)
-    .filter((m) => !NON_VISION.test(m));
+  const providerModels = models.filter((m) => m.provider === provider).map((m) => m.model);
+  const candidates = providerModels.filter((m) => !NON_VISION.test(m));
+
+  const settled = providerModels[0];
+  if (settled && !NON_VISION.test(settled)) return settled;
+
   const prefs = VISION_PREFS[provider] ?? [/.*/];
   for (const pref of prefs) {
     const hit = candidates.find((m) => pref.test(m));
@@ -152,7 +182,29 @@ function getTestTargets(): TestTarget[] {
   });
 }
 
+// Flows created by the template load are tracked here and deleted BY ID in
+// afterEach. `SimpleAgentTemplatePage.load()` does NO cleanup (post-#553
+// contract: never a global cleanAllFlows, which races parallel workers), so
+// without this every run left one "Simple Agent" behind (#964). The app can fire
+// more than one flows POST per load — only one persists, and deleting a transient
+// id 404s harmlessly (deleteFlow treats 404 as done).
+const createdFlowIds: string[] = [];
+
 async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {}); // non-JSON / batch payloads
+    }
+  });
   try {
     await new SimpleAgentTemplatePage(page).load(options);
   } catch (e: any) {
@@ -161,12 +213,38 @@ async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<v
   }
 }
 
+test.afterEach(async ({ request }) => {
+  if (createdFlowIds.length === 0) return;
+  const bearer = await getAuthToken(request);
+  for (const id of createdFlowIds.splice(0)) {
+    await deleteFlow(request, id, { headers: { Authorization: bearer } });
+  }
+});
+
 async function waitForAgentToFinish(page: Page): Promise<void> {
   const stopButton = page.getByRole("button", { name: "Stop" });
   const stopVisible = await stopButton.isVisible({ timeout: 10000 }).catch(() => false);
   if (stopVisible) {
     await expect(stopButton).toBeHidden({ timeout: 120000 });
   }
+}
+
+// The agent's rendered reply, anchored to the AI chat bubble.
+//
+// `.markdown.prose` alone is NOT the reply (#964): the canvas renders 6 of them
+// on this template — the Simple Agent sticky note is one — so `.last()` silently
+// matched the sticky note whenever no reply rendered, and a hard build failure
+// ("Error calling model 'gemini-2.5-flash' (Not Found): 404") was reported as a
+// content mismatch against the template's help text. Anchoring on the AI bubble
+// (`chat-message-AI-<text>`, the 1.12 container) makes a missing reply fail as a
+// missing reply.
+async function agentReply(page: Page) {
+  const bubble = page.locator('[data-testid^="chat-message-AI-"]').last();
+  await expect(
+    bubble,
+    "no AI chat message rendered — the agent produced no reply (check the flow build error)",
+  ).toBeVisible({ timeout: 60000 });
+  return bubble.locator(".markdown.prose").last();
 }
 
 // Set the ChatInput node's "Input Text" on the canvas. The Playground chat input
@@ -209,21 +287,19 @@ async function openPlayground(page: Page, attachImage: boolean): Promise<void> {
 
 const targets = getTestTargets();
 
-// SimpleAgentTemplatePage.load() deletes all flows before loading the template.
-// File-level serial mode prevents parallel provider blocks from wiping each
-// other's flows.
+// Serial: each provider block loads the Simple Agent template and runs it, and
+// the Playground work is heavy enough that concurrent provider blocks starve the
+// single backend. (It does NOT protect against flow wiping — load() deletes
+// nothing; teardown is the id-scoped afterEach above.)
 test.describe.configure({ mode: "serial" });
 
 for (const { label, options, skipReason } of targets) {
   const provider = options.provider ?? (Object.keys(providerConfigMap)[0] as Provider);
 
   test.describe(`Agent Multimodal Image Input [${label}]`, () => {
-    // Quarantined for #964 — recurrent flake (2026-07-20 / 07-22 / 07-27): the
-    // agent answers that it cannot interpret images instead of describing the
-    // one delivered through the input handle.
-    test.fixme(
+    test(
       "image via input handle is described by the agent",
-      { tag: ["@regression", "@agents", "@playground"] },
+      { tag: ["@stable", "@regression", "@agents", "@playground"] },
       async ({ page }) => {
         test.skip(!!skipReason, skipReason ?? "");
         test.skip(
@@ -243,11 +319,16 @@ for (const { label, options, skipReason } of targets) {
         await test.step("assert the vision model described the image content", async () => {
           // The image reached the model via ChatInput → Agent.input: the reply
           // describes the actual image (chain/links), not a generic answer.
-          const response = page.locator(".markdown.prose").last();
+          const response = await agentReply(page);
           await expect(response).toContainText(DESCRIBES_IMAGE, { timeout: 60000 });
-          const text = await response.textContent();
+          const text = (await response.textContent()) ?? "";
+          // The image reached the model at all — this is the #964 signature.
+          expect(
+            text,
+            "the agent replied that it received no image / cannot process images — the attached image did not reach the model",
+          ).not.toMatch(NO_IMAGE_REACHED_MODEL);
           // Secondary guard against a one-word answer.
-          expect((text ?? "").length).toBeGreaterThan(50);
+          expect(text.length).toBeGreaterThan(50);
         });
       },
     );
@@ -274,7 +355,7 @@ for (const { label, options, skipReason } of targets) {
         await test.step("assert the response does not describe a chain", async () => {
           // With no image the model cannot describe the chain — so the keyword
           // only appears in Test 1 because the image was actually processed.
-          const response = page.locator(".markdown.prose").last();
+          const response = await agentReply(page);
           await expect(response).toBeVisible({ timeout: 60000 });
           const text = (await response.textContent()) ?? "";
           expect(text.length).toBeGreaterThan(0);


### PR DESCRIPTION
Closes #964

## Verdict: test defect, not a Langflow regression

The `[google]` variant failed on three dailies (2026-07-20 / 07-22 / 07-27) with the agent answering *"I am sorry, but I cannot directly interpret or describe images"*. The multimodal path itself is healthy — on the model `collect-models` actually validated, the image is described consistently (5/5). So per the issue's last deliverable, this does **not** stay open waiting on an upstream fix.

**Root cause: the spec resolved a model nobody validated.** `collect-models` probes the catalog with real calls and promotes the model that passed to the front of that provider's `models.json` entries. Today it rejects `gemini-2.5-flash` outright:

```
google: candidate "gemini-2.5-flash" failed — This model models/gemini-2.5-flash is no longer
available to new users. Please update your code to use a newer model...
google: settled on "gemini-3.5-flash" after skipping 1 gated/unavailable candidate(s)
```

`resolveVisionModel()` had `^gemini-2\.5-flash$` as its **first hardcoded preference**, so it overrode that settled model and pinned the retired id — which is exactly the `param` the daily records. Locally the id 404s (`Flow build failed`); in CI, on a key that still reaches it, the model replies that it has no image capability. Same class as #886.

**Measured on Langflow Nightly 1.12.0.dev9** (`--workers=1 --retries=0`):

| Resolved model | Result |
|---|---|
| `gemini-2.5-flash` (pre-fix resolution) | **0/3** — `Flow build failed: Error calling model 'gemini-2.5-flash' (Not Found): 404` |
| `gemini-3.5-flash` (collect-models settled) | **5/5** passed |

Resolution is now **settled-first**: take the model collect-models promoted, and fall back to `VISION_PREFS` only when it is not usable for vision. Those fallback patterns now hold alias/undated ids only, so the next retired dated id cannot silently repoint the spec.

## Two defects the investigation exposed

**1. The positive assert was not falsifiable.** `DESCRIBES_IMAGE` included `link`, and a reply with **no image attached** matched it:

```
MUTREPLY>>> "You did not provide or attach an image. Please upload an image or provide a
link to one, and I will be happy to describe it if possible."   →  1 passed
```

The test could pass while proving nothing about the image reaching the model. The predicate is now word-bounded `\bchains?\b|\binkscape\b`, and `NO_IMAGE_REACHED_MODEL` asserts the refusal family separately — so the #964 signature fails with its own message instead of surfacing as "pattern not found".

**2. The reply locator was not the reply.** This template renders **6** `.markdown.prose` nodes (its sticky note among them), so `.last()` matched the sticky note whenever no message rendered — that is how a hard build failure got reported as a content mismatch against the template's help text. The assertion is now anchored to the AI chat bubble (`[data-testid^="chat-message-AI-"]`, the 1.12 container; both it and the legacy `div-chat-message` were confirmed present live on dev9).

**3. Missing teardown.** Flow ids are captured from the `POST /api/v1/flows/` 201 responses and deleted by id in `afterEach`, mirroring `agent-context-id-isolation.spec.ts`. `SimpleAgentTemplatePage.load()` deletes nothing (post-#553 contract — no global `cleanAllFlows`, which races parallel workers), so every run used to leave one `Simple Agent` behind.

## Quarantine lifted

`test.fixme` removed and `@stable` restored on `image via input handle is described by the agent` (quarantine applied in #971).

## Validation

Langflow Nightly **1.12.0.dev9**, local, `--workers=1 --retries=0`.

- 3 consecutive bursts of the whole file across all providers: **4 passed, 2 skipped** (56.8s / 53.9s / 53.5s).
- `npm run typecheck` — clean. ESLint on the spec — 0 errors, 6 pre-existing warnings (`test.skip` annotations).
- `npm run check:checklist-coverage` + QA-CHECKLIST guard — both pass. No `QA-CHECKLIST.md` edit needed (the Part II bullet already references this spec).
- Zero `🚨 Backend Error`.
- Flow residue: instance ended at the same 29 flows it started with; verified 70 → 70 across a full run with the new teardown.
- `--trace=on` not run — known hang on Simple Agent-template specs (#490/#518).

**The 2 skipped are the `[anthropic / claude-opus-5]` pair**, skipped with a reason because `providers.json` reports `anthropic | inactive` — *"Your credit balance is too low to access the Anthropic API"* (the same condition that skipped it in daily #962). Two notes for the reviewer: this PR's green covers **openai + google only**, and settled-first moves the anthropic target from `claude-3-5-*` to the settled `claude-opus-5` — vision-capable, but not exercised until the key is topped up.

### Force-fail (executed — every test in the file, plus both mechanisms)

Each mutation applied in isolation, run with `--grep --retries=0`, then reverted (verified: 0 mutation markers left).

| Mutation | Result |
|---|---|
| T1 — image **not** attached | ❌ failed: `Expected pattern /\bchains?\b\|\binkscape\b/i` vs *"…I currently cannot see any image in your request."* — the same mutation returned **`1 passed`** before the predicate fix |
| T1b — `agentReply()` anchored to a non-existent container | ❌ failed: `no AI chat message rendered — the agent produced no reply` |
| T1c — resolver reverted to the hardcoded retired `gemini-2.5-flash` | ❌ failed: `no AI chat message rendered` (the 404 build failure) |
| T2 — image attached to the **negative control** | ❌ failed: `Expected pattern: not /chain/i` vs *"…two vertical metal chain segments side by side."* |
| Cleanup — id tracker defused | ❌ leaked: flows 70 → **71**; with the tracker, 70 → 70 |

## Not addressed here

- The negative control failed on the 2026-07-29 daily with `TimeoutError: apiRequestContext.get: Timeout 20000ms exceeded` — a different, infra-side signature.
- The 2026-07-24 occurrence carried `expect(received).toBeGreaterThan(expected)` (a too-short reply). Same model-pinning cause, but not reproduced in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)