### PR TITLE
fix(migration): select the model on the unified selector, not the legacy overrides (#1004)

### DIFF
--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -516,6 +516,33 @@ jobs:
 
           [[ -z "$TEMPLATE" || "$TEMPLATE" == "null" ]] && {
             echo "::error::No witness template found — /api/v1/flows/ and /api/v1/starter-projects/ both returned nothing usable"; exit 1; }
+
+          # Select a model on the witness (#1004). Starters ship the model
+          # component with NO selection, so the source smoke below used to die on
+          # "A model selection is required" — every run since 2026-07-23.
+          # Since 1.11.1 the selection lives in the required `model` field
+          # (`type: model`); `provider`/`model_name` are only advanced OVERRIDES of
+          # it, and writing them while `model` is empty is rejected with "Model
+          # name/provider overrides require a built-in model selection". So set
+          # `model` as a plain string when the field exists, and fall back to the
+          # legacy pair for older builds. Verified against langflow:1.11.1 and
+          # langflow-nightly 1.12.0.dev9: unpatched 500, patched 200 on both.
+          # `api_key` takes the NAME of the Credential Langflow auto-imports from
+          # the OPENAI_API_KEY env var (asserted a few lines above).
+          TEMPLATE=$(echo "$TEMPLATE" | jq --arg m "${WITNESS_MODEL:-gpt-4o-mini}" --arg key "OPENAI_API_KEY" '
+            (.data.nodes[]?
+              | select((.data.type // "") | test("^(LanguageModelComponent|OpenAIModel)$"))
+              | .data.node.template) |= (
+                (if has("model") then
+                   (if ((.model.value // "") == "") then .model.value = $m else . end)
+                 else
+                   (if ((.model_name.value // "") == "") then .model_name.value = $m else . end)
+                   | (if ((.provider.value // "") == "") then .provider.value = "OpenAI" else . end)
+                 end)
+                | (if (has("api_key") and ((.api_key.value // "") == "")) then .api_key.value = $key else . end)
+              )')
+          echo "Witness model selection: $(echo "$TEMPLATE" | jq -c '[.data.nodes[]? | select((.data.type // "") | test("LanguageModelComponent|OpenAIModel")) | .data.node.template | {model: .model.value, model_name: .model_name.value}]')"
+
           FLOW_PAYLOAD=$(echo "$TEMPLATE" | jq '{
             name: ((.name // "Simple Agent") + " — migration witness"),
             description: "compose migration witness",

--- a/tests/github-workflows/migration/helpers.py
+++ b/tests/github-workflows/migration/helpers.py
@@ -126,12 +126,27 @@ def ensure_model_selected(
 ) -> list:
     """Patch model components so the witness flow can build.
 
-    A starter's model component may ship with an empty `model_name` / `provider`
-    (the unified `LanguageModelComponent` on latest requires an explicit
-    selection — otherwise the build fails with "A model selection is required",
-    #905). Fill any empty model field in place so the flow is executable. Returns
-    the list of node types that were patched (for reporting). Non-empty fields
-    (e.g. `OpenAIModel` shipping `gpt-4o-mini`) are left untouched.
+    A starter's model component ships with no model selected, and the build fails
+    with "A model selection is required" (#905). Fill the selection in place so
+    the flow is executable. Returns the list of node types that were patched (for
+    reporting). Non-empty fields are left untouched.
+
+    **Fill the unified selector, not the legacy overrides (#1004).** Since 1.11.1
+    `LanguageModelComponent` carries a required `model` field (`type: model`,
+    `input_types: ['LanguageModel']`) and demotes `provider` / `model_name` to
+    advanced *overrides* of it. Writing the overrides while `model` stays empty is
+    rejected at build time:
+
+        Error running method "text_response": Model name/provider overrides
+        require a built-in model selection, not a connected model object.
+
+    which is what broke the baseline every day from 2026-07-23 (#1004). Measured
+    against `langflow:1.11.1` and `langflow-nightly:1.12.0.dev9`, both of which
+    ship the same node shape: `model` as a plain string builds and runs; a
+    `{provider, model_name}` dict fails with "A model selection is required"; the
+    legacy-overrides-only patch reproduces the #1004 error. So when the selector
+    exists, set it and leave the overrides alone; the legacy branch stays for
+    builds that predate it (e.g. `OpenAIModel`).
     """
     patched = []
     for node in (template.get("data") or {}).get("nodes", []):
@@ -140,12 +155,20 @@ def ensure_model_selected(
             continue
         tmpl = data.get("node", {}).get("template", {})
         changed = False
-        if "provider" in tmpl and not tmpl["provider"].get("value"):
-            tmpl["provider"]["value"] = provider
-            changed = True
-        if "model_name" in tmpl and not tmpl["model_name"].get("value"):
-            tmpl["model_name"]["value"] = model
-            changed = True
+        if "model" in tmpl:
+            if not tmpl["model"].get("value"):
+                tmpl["model"]["value"] = model
+                changed = True
+        else:
+            if "provider" in tmpl and not tmpl["provider"].get("value"):
+                tmpl["provider"]["value"] = provider
+                changed = True
+            if "model_name" in tmpl and not tmpl["model_name"].get("value"):
+                tmpl["model_name"]["value"] = model
+                changed = True
+        # The api_key field takes the NAME of the global Credential (Langflow
+        # auto-imports OPENAI_API_KEY on startup). Harmless alongside the unified
+        # selector — verified building both with and without it.
         if "api_key" in tmpl and not tmpl["api_key"].get("value"):
             tmpl["api_key"]["value"] = api_key_var
             changed = True

--- a/tests/github-workflows/migration/setup_latest.py
+++ b/tests/github-workflows/migration/setup_latest.py
@@ -54,9 +54,11 @@ def main():
         "node_types": node_types,
     }
 
-    # 2b. Ensure the model component has a model selected. A starter may ship an
-    # empty model_name/provider (the unified Language Model requires an explicit
-    # selection — otherwise the build fails "A model selection is required", #905).
+    # 2b. Ensure the model component has a model selected. A starter may ship
+    # with no selection (the unified Language Model requires an explicit
+    # selection — otherwise the build fails "A model selection is required", #905;
+    # since 1.11.1 the selection is the `model` field, not the legacy
+    # provider/model_name overrides — #1004).
     patched = ensure_model_selected(template)
     phase["steps"]["ensure_model"] = {"status": "pass", "patched_nodes": patched}
     if patched:


### PR DESCRIPTION
Closes #1004

## Problem

Both jobs of *Langflow Migration Test: Latest → Nightly* have failed **every run since 2026-07-23** (last green 07-22), on opposite sides of the same empty field:

| Job | Error |
|---|---|
| `migration-test-compose` — creates the witness from the starter untouched | `Error building Component Language Model: A model selection is required` |
| `migration-test` — patches only the legacy overrides | `Error running method "text_response": Model name/provider overrides require a built-in model selection, not a connected model object.` |

Since **1.11.1** the starter `LanguageModelComponent` carries a required `model` field (`type: model`, `input_types: ['LanguageModel']`) and demotes `provider` / `model_name` to advanced **overrides** of it. `ensure_model_selected()` filled the overrides and left `model` empty, which the build refuses; the compose job filled nothing at all. Matches the issue's own timeline — the 07-28 report PASSED on `langflow==1.11.0`, the 07-29 one FAILED on `langflow==1.11.1`.

## Fix

Fill the selector, not the overrides:

```python
if "model" in tmpl:                      # 1.11.1+ unified selector
    if not tmpl["model"].get("value"):
        tmpl["model"]["value"] = model   # a plain model id
else:                                    # pre-selector builds (OpenAIModel)
    ... provider / model_name ...
```

The compose job gets the same transform in `jq` before creating the witness, plus a log line echoing the resolved selection. `api_key` keeps taking the **name** of the Credential Langflow auto-imports from the `OPENAI_API_KEY` env var (already asserted a few lines above in that job).

`migration-fresh-install.yml` and `migration-upgrade-with-flows.yml` neither fetch starters nor execute a flow — they do not carry this gap. `verify_migration_api.py:81` re-runs the migrated witness on the target, which the nightly row below covers.

## Validation

Run against both images the workflow actually uses — `langflowai/langflow:1.11.1` (the `latest` source) and `langflowai/langflow-nightly` 1.12.0.dev9 (the target). Both ship the identical node shape (`model` required and empty).

| Phase | Path | Unpatched | With the fix |
|---|---|---|---|
| latest 1.11.1 | jq (compose job) | 500 `A model selection is required` | **200** — *"Arrr, matey! The answer be 4!"* |
| nightly dev9 | jq (compose job) | 500 `A model selection is required` | **200** |
| latest 1.11.1 | `ensure_model_selected` (API job) | 500 `Model name/provider overrides require…` | **200** |
| nightly dev9 | `ensure_model_selected` (API job) | — | **200** |

Alternatives measured and rejected, which is why the value is a plain string:

- `model.value = {"provider": "OpenAI", "model_name": "gpt-4o-mini"}` → 500 `A model selection is required`
- legacy overrides only (the current behaviour) → reproduces the #1004 error

Static checks: `py_compile` clean on both scripts; the workflow YAML parses (`jobs: migration-test, migration-test-compose`); `bash -n` clean on the edited step; the `jq` expression run against the real 46 KB starter payload yields `{model: "gpt-4o-mini", model_name: "", provider: "", api_key: "OPENAI_API_KEY"}`. Everything the verification created on the two containers (flows, the Credential, API keys) was deleted — zero residue.

**No local proof for the workflow as a whole** — it needs `AUTO_LOGIN`, the Postgres service container and a volume migration. Both code paths are proven against the real images, but the final proof is the next run: dispatch `migration-test.yml` manually instead of waiting for the 07:00 UTC cron. What to watch — compose job: the new `Witness model selection: [{"model":"gpt-4o-mini",…}]` line and the source smoke returning 200; API job: `ensure_model` reporting `patched_nodes` and `execute_flow` passing.

**Convention note:** there is no unit test for `helpers.py` — the repo's two unit lanes cover `.ts` and `.mjs` only, so a Python test would not be gated by CI. The evidence is the matrix above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)