### PR TITLE
fix(agents): make the Agent credential guard non-vacuous and self-describing (#1072)

### DIFF
--- a/tests/helpers/flows/agent-credential-settle.test.ts
+++ b/tests/helpers/flows/agent-credential-settle.test.ts
@@ -1,0 +1,342 @@
+// Unit tests for the Agent credential-settle classifier (issue #1072).
+// Run with: npm run test:units
+//
+// What rides on this module: the guard at the end of every
+// `SimpleAgentTemplatePage.load()` fails with whatever this produces, and that
+// message is the entire product of the failure in a daily's report. Before #1072
+// the guard raised a bare `expect(...).toBe(...)` mismatch — "Expected
+// GOOGLE_API_KEY / Received ANTHROPIC_API_KEY" — which was triaged as a
+// provider-wiring bug on the 2026-07-22 and 2026-07-27 dailies before anyone
+// traced it to this guard.
+//
+// Two properties these tests exist to protect:
+//
+//  1. **The payload shape.** `template.model.value` is an ARRAY of model objects,
+//     not a string. The first cut of this module read it as a string, so every
+//     probe came back with no model and the verdicts that carry the whole
+//     distinction became unreachable — while the tests passed, because the fixture
+//     used a string too. Every fixture below therefore uses the real shape, and
+//     `MODEL_VALUE_SHAPE` documents where it is verified in the product.
+//  2. **The verdict distinctions.** Several states produce the same "wrong
+//     credential" observation and they send a reader to opposite places: a lagging
+//     autosave, a model click that never registered, a credential that matches only
+//     because it is the selector's default, and a read that never succeeded. A
+//     classifier that collapses any of those silently re-creates the mis-triage,
+//     and no Playwright spec would fail for it.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  classifyCredentialSettle,
+  formatCredentialSettleFailure,
+  readAgentCredentialProbe,
+  type AgentCredentialProbe,
+} from "./agent-credential-settle";
+
+/**
+ * Where the array shape is established in the product and in this repo:
+ * `provider-setup/setup-language-model-openai.ts` ("the backend executes
+ * `model.value[0].name` directly"), `agent-structured-output.spec.ts` (reads
+ * `value` and maps `m.name`), and `rag-pipeline.spec.ts` (`tmpl.model.value =
+ * [modelOption]`).
+ */
+const MODEL_VALUE_SHAPE = (name: string) => [
+  { id: `openai/${name}`, name, provider: "OpenAI", icon: "OpenAI" },
+];
+
+/**
+ * A `GET /api/v1/flows/{id}` payload shaped like the real one: the Simple Agent
+ * template's ChatInput + Agent + ChatOutput, with only the fields the probe reads
+ * spelled out.
+ */
+const flowWithAgent = (credential: string, modelValue: unknown) => ({
+  id: "flow-1",
+  data: {
+    nodes: [
+      { data: { type: "ChatInput", node: { template: { input_value: { value: "" } } } } },
+      {
+        data: {
+          type: "Agent",
+          node: {
+            template: {
+              api_key: { value: credential },
+              model: { value: modelValue },
+              system_prompt: { value: "You are a helpful assistant" },
+            },
+          },
+        },
+      },
+      { data: { type: "ChatOutput", node: { template: {} } } },
+    ],
+  },
+});
+
+// ─── readAgentCredentialProbe — against the real payload shape ───────────────
+
+test("reads the credential and the SELECTED model names off the real shape", () => {
+  const probe = readAgentCredentialProbe(
+    flowWithAgent("OPENAI_API_KEY", MODEL_VALUE_SHAPE("gpt-4o-mini")),
+  );
+  assert.deepEqual(probe, {
+    credential: "OPENAI_API_KEY",
+    selectedModels: ["gpt-4o-mini"],
+  });
+});
+
+test("an unselected model field reads as no models, not as one empty name", () => {
+  // The template ships `model.value: ""`, and the field stays empty until a
+  // selection is autosaved. `[""]` would make `includes(expectedModel)` false but
+  // `length === 0` false too, hiding `nothing-persisted`.
+  for (const empty of [[], "", null, undefined, [null], [{}], [{ name: 42 }]]) {
+    const probe = readAgentCredentialProbe(flowWithAgent("ANTHROPIC_API_KEY", empty));
+    assert.deepEqual(
+      probe?.selectedModels,
+      [],
+      `expected no model names for ${JSON.stringify(empty)}`,
+    );
+  }
+});
+
+test("a bare-string model value is still read, for a pre-unified-selector payload", () => {
+  const probe = readAgentCredentialProbe(
+    flowWithAgent("OPENAI_API_KEY", "gpt-4o-mini"),
+  );
+  assert.deepEqual(probe?.selectedModels, ["gpt-4o-mini"]);
+});
+
+test("returns null when the flow carries no Agent node", () => {
+  const noAgent = { data: { nodes: [{ data: { type: "ChatInput" } }] } };
+  assert.equal(readAgentCredentialProbe(noAgent), null);
+});
+
+test("survives every partial payload a poll can observe", () => {
+  // The probe runs inside a retry loop, so a transient/incomplete body must read
+  // as "not settled yet" — never as a crash that escapes the loop.
+  for (const payload of [
+    undefined,
+    null,
+    {},
+    { data: {} },
+    { data: { nodes: null } },
+    { data: { nodes: [{}] } },
+    { data: { nodes: [{ data: { type: "Agent" } }] } },
+  ]) {
+    const probe = readAgentCredentialProbe(payload);
+    assert.ok(
+      probe === null ||
+        (probe.credential === "" && probe.selectedModels.length === 0),
+      `unexpected probe for ${JSON.stringify(payload)}: ${JSON.stringify(probe)}`,
+    );
+  }
+});
+
+test("a non-string api_key reads as empty, not as the raw object", () => {
+  const weird = flowWithAgent(
+    { name: "OPENAI_API_KEY" } as unknown as string,
+    MODEL_VALUE_SHAPE("gpt-4o-mini"),
+  );
+  assert.equal(readAgentCredentialProbe(weird)?.credential, "");
+});
+
+// ─── classifyCredentialSettle — the distinctions that matter ─────────────────
+
+const probeOf = (credential: string, models: string[]): AgentCredentialProbe => ({
+  credential,
+  selectedModels: models,
+});
+
+test("credential and model both applied is settled", () => {
+  assert.equal(
+    classifyCredentialSettle(
+      probeOf("GOOGLE_API_KEY", ["gemini-2.5-flash"]),
+      "GOOGLE_API_KEY",
+      "gemini-2.5-flash",
+    ),
+    "settled",
+  );
+});
+
+test("the anthropic default binding alone is model-pending, NOT settled", () => {
+  // The vacuity #1072 found: for `provider: "anthropic"` the expected credential
+  // IS the selector's default auto-binding, so a credential-only check declared
+  // the load settled before the model selection had been applied at all.
+  assert.equal(
+    classifyCredentialSettle(
+      probeOf("ANTHROPIC_API_KEY", []),
+      "ANTHROPIC_API_KEY",
+      "claude-sonnet-5",
+    ),
+    "model-pending",
+  );
+});
+
+test("model applied but credential still on the default is credential-pending", () => {
+  // The 2026-07-27 daily flake, exactly: a google target observing the default
+  // ANTHROPIC binding while the requested Gemini model IS already selected.
+  assert.equal(
+    classifyCredentialSettle(
+      probeOf("ANTHROPIC_API_KEY", ["gemini-2.5-flash"]),
+      "GOOGLE_API_KEY",
+      "gemini-2.5-flash",
+    ),
+    "credential-pending",
+  );
+});
+
+test("a different persisted model is model-not-applied", () => {
+  assert.equal(
+    classifyCredentialSettle(
+      probeOf("ANTHROPIC_API_KEY", ["claude-sonnet-5"]),
+      "GOOGLE_API_KEY",
+      "gemini-2.5-flash",
+    ),
+    "model-not-applied",
+  );
+});
+
+test("no persisted model at all is nothing-persisted", () => {
+  assert.equal(
+    classifyCredentialSettle(
+      probeOf("ANTHROPIC_API_KEY", []),
+      "OPENAI_API_KEY",
+      "gpt-4o-mini",
+    ),
+    "nothing-persisted",
+  );
+});
+
+test("without an expected model only the credential axis is available", () => {
+  // A caller that lets the setup helper pick the first model has no name to
+  // compare, so the model axis must not manufacture a verdict.
+  assert.equal(
+    classifyCredentialSettle(probeOf("OPENAI_API_KEY", []), "OPENAI_API_KEY"),
+    "settled",
+  );
+  assert.equal(
+    classifyCredentialSettle(
+      probeOf("ANTHROPIC_API_KEY", ["claude-sonnet-5"]),
+      "OPENAI_API_KEY",
+    ),
+    "credential-pending",
+  );
+});
+
+test("a missing Agent node is its own verdict, not a pending credential", () => {
+  assert.equal(
+    classifyCredentialSettle(null, "OPENAI_API_KEY", "gpt-4o-mini"),
+    "no-agent-node",
+  );
+});
+
+// ─── formatCredentialSettleFailure ───────────────────────────────────────────
+
+const failure = (
+  over: Partial<Parameters<typeof formatCredentialSettleFailure>[0]> = {},
+) =>
+  formatCredentialSettleFailure({
+    flowId: "abc-123",
+    provider: "google",
+    expectedCredential: "GOOGLE_API_KEY",
+    expectedModel: "gemini-2.5-flash",
+    probe: probeOf("ANTHROPIC_API_KEY", ["gemini-2.5-flash"]),
+    verdict: "credential-pending",
+    elapsedMs: 20_400,
+    reads: 14,
+    ...over,
+  });
+
+/** The value on a labelled line, so an assertion cannot pass on a coincidence. */
+function field(message: string, label: string): string | undefined {
+  const line = message
+    .split("\n")
+    .find((candidate) => candidate.trim().startsWith(`${label} `));
+  return line?.trim().slice(label.length).trim();
+}
+
+test("the message carries every fact needed to triage without the artifacts", () => {
+  const message = failure();
+  // Read per labelled field rather than substring-matching the whole message:
+  // `gemini-2.5-flash` appears on two lines, so a plain `includes` could not fail
+  // if the "model wanted" line were dropped.
+  assert.equal(field(message, "flow"), "abc-123");
+  assert.equal(field(message, "provider"), 'google (expected credential "GOOGLE_API_KEY")');
+  assert.equal(field(message, "model wanted"), "gemini-2.5-flash");
+  assert.equal(
+    field(message, "observed"),
+    'api_key="ANTHROPIC_API_KEY" models=[gemini-2.5-flash]',
+  );
+  assert.equal(field(message, "waited"), "20.4s over 14 read(s)");
+  assert.equal(field(message, "verdict"), "credential-pending");
+  // The two issues a reader needs: why the guard exists, where the load relief is.
+  assert.ok(message.includes("#751"), message);
+  assert.ok(message.includes("#1077"), message);
+});
+
+test("a caller that chose no model says so on the model line", () => {
+  assert.equal(
+    field(failure({ expectedModel: undefined }), "model wanted"),
+    "(caller let the setup helper choose)",
+  );
+});
+
+test("credential-pending does not wave the failure off as load", () => {
+  // It prints only AFTER the budget expired, i.e. retrying did not help within it,
+  // and a credential belonging to a THIRD provider is a real misbinding.
+  const message = failure();
+  assert.ok(
+    message.includes("retrying did NOT help"),
+    "the guidance must not tell the reader to dismiss a failure that did not settle",
+  );
+  assert.ok(message.includes("THIRD provider"), message);
+});
+
+test("nothing-persisted points at the request that actually rebinds", () => {
+  // The flows PATCH only persists the result; the binding is computed by the
+  // custom_component update. Naming the wrong one sends the reader to a healthy
+  // request and a wrong conclusion.
+  const message = failure({
+    verdict: "nothing-persisted",
+    probe: probeOf("ANTHROPIC_API_KEY", []),
+  });
+  assert.ok(message.includes("custom_component/update"), message);
+});
+
+test("model-pending covers BOTH the default-binding and the real-rebind case", () => {
+  // The verdict is reachable two ways and they mean different things: anthropic,
+  // where the credential match is free because it is the selector's default; and
+  // any other provider, where the rebind DID land and only the selection has not.
+  // Guidance that asserts only the first is false half the time it prints.
+  const message = failure({
+    verdict: "model-pending",
+    provider: "anthropic",
+    expectedCredential: "ANTHROPIC_API_KEY",
+    expectedModel: "claude-sonnet-5",
+    probe: probeOf("ANTHROPIC_API_KEY", []),
+  });
+  assert.ok(message.includes("DEFAULT binding"), message);
+  assert.ok(
+    message.includes("any other provider"),
+    "must not assert the default-binding cause for a provider where it is wrong",
+  );
+  assert.ok(message.includes("provider setup"), message);
+});
+
+test("a guard that never read the flow reports UNKNOWN, not an absent Agent node", () => {
+  const message = failure({
+    probe: null,
+    verdict: "read-failed",
+    reads: 0,
+    lastReadError: "apiRequestContext.get: Timeout 20000ms exceeded.",
+  });
+  assert.equal(field(message, "observed"), "no successful read of the persisted flow");
+  assert.equal(field(message, "last read err"), "apiRequestContext.get: Timeout 20000ms exceeded.");
+  assert.ok(message.includes("UNKNOWN"), message);
+  assert.ok(
+    !message.includes("has no Agent node"),
+    "read-failed must not assert a fact the guard never observed",
+  );
+});
+
+test("no-agent-node is reported only for a flow that WAS read", () => {
+  const message = failure({ probe: null, verdict: "no-agent-node" });
+  assert.equal(field(message, "observed"), "the flow was read and carries no Agent node");
+});

--- a/tests/helpers/flows/agent-credential-settle.test.ts
+++ b/tests/helpers/flows/agent-credential-settle.test.ts
@@ -72,6 +72,16 @@ const flowWithAgent = (credential: string, modelValue: unknown) => ({
 
 // ─── readAgentCredentialProbe — against the real payload shape ───────────────
 
+test("the fixture itself uses the real array-of-objects shape", () => {
+  // Without this, the pair (fixture, implementation) can be reverted TOGETHER to
+  // the string shape and every other test still passes — which is exactly the
+  // inert state described in this file's header. The fixture is the property.
+  const value = MODEL_VALUE_SHAPE("gpt-4o-mini");
+  assert.ok(Array.isArray(value), "model.value must be an array");
+  assert.equal(typeof value[0], "object");
+  assert.equal(value[0]?.name, "gpt-4o-mini");
+});
+
 test("reads the credential and the SELECTED model names off the real shape", () => {
   const probe = readAgentCredentialProbe(
     flowWithAgent("OPENAI_API_KEY", MODEL_VALUE_SHAPE("gpt-4o-mini")),
@@ -339,4 +349,34 @@ test("a guard that never read the flow reports UNKNOWN, not an absent Agent node
 test("no-agent-node is reported only for a flow that WAS read", () => {
   const message = failure({ probe: null, verdict: "no-agent-node" });
   assert.equal(field(message, "observed"), "the flow was read and carries no Agent node");
+  assert.ok(
+    message.includes("did not instantiate as expected"),
+    "the verdict needs guidance of its own, not an empty line",
+  );
+});
+
+test("model-not-applied covers the wedged save path, not only a wrong click", () => {
+  // Verified on 1.12.0.dev10: the Agent's mount-time prefill persists
+  // ANTHROPIC_API_KEY plus the default Claude model, so on a google/openai load a
+  // save path that never lands leaves EXACTLY this state. Guidance that sends the
+  // reader to the setup helper only would misdirect every wedged load (#1077).
+  const message = failure({
+    verdict: "model-not-applied",
+    probe: probeOf("ANTHROPIC_API_KEY", ["claude-opus-5"]),
+  });
+  assert.ok(message.includes("setup helper"), message);
+  assert.ok(message.includes("prefill"), message);
+  assert.ok(message.includes("#1077"), message);
+});
+
+test("credential-pending with NO pinned model does not claim the selection registered", () => {
+  // Reachable from the three specs that call load({ provider }) with no model, and
+  // from any spec whose models.json came back empty. The usual guidance asserts
+  // "the requested model IS applied" — nothing checked that here.
+  const message = failure({ expectedModel: undefined });
+  assert.ok(
+    !message.includes("The requested model IS applied"),
+    "must not assert a check that could not run:\n" + message,
+  );
+  assert.ok(message.includes("pinned no model"), message);
 });

--- a/tests/helpers/flows/agent-credential-settle.ts
+++ b/tests/helpers/flows/agent-credential-settle.ts
@@ -1,0 +1,287 @@
+// Reading and classifying the Agent node's provider binding on a PERSISTED flow
+// payload (issue #1072).
+//
+// `SimpleAgentTemplatePage.load()` ends on a guard added by #751: it blocks until
+// the Agent node is bound to the provider the caller asked for. On the 1.11+
+// unified model selector (`ModelInput`), opening the model dropdown auto-binds
+// `api_key` to the DEFAULT credential (`ANTHROPIC_API_KEY`); picking the target
+// provider's model rebinds it, and both the rebind and the selection reach the
+// database through the editor's debounced autosave `PATCH /api/v1/flows/{id}`.
+//
+// The guard used to be a blind poll with a bare `expect(...).toBe(credential)`
+// inside, so when it ran out the whole report carried was:
+//
+//     Expected: "GOOGLE_API_KEY"
+//     Received: "ANTHROPIC_API_KEY"
+//
+// which reads like a wiring bug — a google-parameterized test observing an
+// Anthropic credential — and was triaged as one across the 2026-07-22 and
+// 2026-07-27 dailies before #1072 traced it to this guard. Several distinct states
+// produce that identical line and they send a reader to different places, so this
+// module names them instead of leaving them collapsed.
+//
+// It is pure over the flow payload, which is what lets the `node --test` lane cover
+// the classification instead of re-deriving it from a daily's artifacts.
+
+/** The provider binding of the Agent node, as persisted in a flow payload. */
+export interface AgentCredentialProbe {
+  /**
+   * `template.api_key.value` — the NAME of the Langflow global variable holding
+   * the key (e.g. `"OPENAI_API_KEY"`), never the secret itself. Empty string on a
+   * freshly instantiated template, before any provider is configured.
+   */
+  credential: string;
+  /**
+   * The `name` of every model selected on the unified `ModelInput` selector.
+   *
+   * `template.model.value` is an **array of model objects** (`{ name, provider,
+   * icon, metadata, … }`), not a string — the backend executes
+   * `model.value[0].name` directly (see `setAgentModelViaApi` in
+   * `provider-setup/setup-language-model-openai.ts`, and the same read in
+   * `agent-structured-output.spec.ts`). Reading it as a string is what made the
+   * first cut of this module inert: every probe came back empty and every verdict
+   * collapsed onto one.
+   */
+  selectedModels: string[];
+}
+
+export type CredentialSettleVerdict =
+  /** Credential AND (when known) model are both applied — nothing to wait for. */
+  | "settled"
+  /**
+   * The credential is right but the requested model is not applied yet. The
+   * dropdown's default binding IS the expected credential — i.e. the caller asked
+   * for anthropic — so the credential axis alone proves nothing here.
+   */
+  | "model-pending"
+  /**
+   * The requested model is applied but the credential still is not: the selection
+   * registered and only the rebind has yet to be persisted. Waiting helps.
+   */
+  | "credential-pending"
+  /**
+   * A DIFFERENT, non-empty model is persisted: the provider-setup step selected
+   * something other than what the caller asked for. Waiting cannot fix it.
+   */
+  | "model-not-applied"
+  /** No model is persisted at all — nothing has carried the selection. */
+  | "nothing-persisted"
+  /** The payload was read, and it carries no Agent node. */
+  | "no-agent-node"
+  /**
+   * No read of the persisted flow ever succeeded, so there is nothing to classify.
+   *
+   * Kept distinct from `no-agent-node` because conflating them makes the guard
+   * ASSERT a fact it never observed: on daily run 30444299314 every read in this
+   * family timed out, and a collapsed verdict would have reported "the flow has no
+   * Agent node" about a flow nobody managed to fetch.
+   */
+  | "read-failed";
+
+interface FlowNodeLike {
+  data?: {
+    type?: string;
+    node?: { template?: Record<string, { value?: unknown } | undefined> };
+  };
+}
+
+/** `template.api_key.value` as a string, or `""` when absent/non-scalar. */
+function credentialOf(node: FlowNodeLike): string {
+  const value = node.data?.node?.template?.api_key?.value;
+  return typeof value === "string" ? value : "";
+}
+
+/**
+ * The selected model names out of `template.model.value`.
+ *
+ * Accepts the array-of-objects shape the running build persists, and tolerates a
+ * bare string for the same reason `agent-structured-output.spec.ts` does: the
+ * field carried one before the unified selector, and a stale flow payload must
+ * degrade to "no model" rather than throw inside a poll.
+ */
+function selectedModelsOf(node: FlowNodeLike): string[] {
+  const value = node.data?.node?.template?.model?.value;
+  const entries = Array.isArray(value) ? value : [value];
+  return entries
+    .map((entry) => {
+      if (typeof entry === "string") return entry;
+      const name = (entry as { name?: unknown } | null)?.name;
+      return typeof name === "string" ? name : "";
+    })
+    .filter((name) => name.length > 0);
+}
+
+/**
+ * Reads the Agent node's binding out of a `GET /api/v1/flows/{id}` payload, or
+ * `null` when the flow carries no Agent node.
+ *
+ * Tolerant of every shape the endpoint can answer with (missing `data`, nodes
+ * without `data.node`, a non-string `value`) because it runs inside a poll: a
+ * transient partial payload must produce "not settled yet", never a crash that
+ * escapes the retry loop.
+ *
+ * A flow with more than one Agent node probes the FIRST in array order. The
+ * templates this guard runs against (Simple Agent) have exactly one, and
+ * `load()` never adds a second; a multi-agent flow would need the caller to say
+ * which node it means.
+ */
+export function readAgentCredentialProbe(
+  flow: unknown,
+): AgentCredentialProbe | null {
+  const nodes = (flow as { data?: { nodes?: FlowNodeLike[] } })?.data?.nodes;
+  const agent = (Array.isArray(nodes) ? nodes : []).find(
+    (node) => node?.data?.type === "Agent",
+  );
+  if (!agent) return null;
+  return {
+    credential: credentialOf(agent),
+    selectedModels: selectedModelsOf(agent),
+  };
+}
+
+/**
+ * Which state the probe is in.
+ *
+ * The credential is NOT sufficient on its own. `ANTHROPIC_API_KEY` is both the
+ * dropdown's default auto-binding and the expected credential of the `anthropic`
+ * provider, so a credential-only check returns "settled" for every anthropic
+ * caller the instant the default binding persists — before the requested model is
+ * applied at all. That is why `load()`'s contract ("every caller starts settled")
+ * did not hold for anthropic, and why the issue's anthropic row
+ * (`agent-max-iterations.spec.ts:255`) could never have been this guard's
+ * expected/received mismatch: for anthropic the mismatch is unreachable.
+ *
+ * `expectedModel` is optional — a caller may let the provider-setup helper pick
+ * the first available model, leaving no name to compare. Every parametrized agent
+ * spec does pass one, so the model axis is available in the common case.
+ *
+ * Gating on the model is only sound because a pinned model is never silently
+ * substituted on this path: `setup-openai`, `setup-anthropic` and `setup-google`
+ * each click the exact requested option or throw `MODEL_NOT_AVAILABLE` (which the
+ * specs turn into a `test.skip`). The one substituting path —
+ * `setupOpenAI(..., { fallbackToRanking: true })`, added for #606 — is opt-in and
+ * used only by `helpers/other/initialGPTsetup.ts`, which calls the helper directly
+ * and never through `SimpleAgentTemplatePage`. Wiring that option through
+ * `providerSetupMap` would make this comparison fail on a legitimately substituted
+ * model, so it must arrive with a way to tell the guard what was actually picked.
+ */
+export function classifyCredentialSettle(
+  probe: AgentCredentialProbe | null,
+  expectedCredential: string,
+  expectedModel?: string,
+): CredentialSettleVerdict {
+  if (!probe) return "no-agent-node";
+
+  const modelApplied =
+    !expectedModel || probe.selectedModels.includes(expectedModel);
+
+  if (probe.credential === expectedCredential) {
+    return modelApplied ? "settled" : "model-pending";
+  }
+  if (probe.selectedModels.length === 0) return "nothing-persisted";
+  if (!modelApplied) return "model-not-applied";
+  return "credential-pending";
+}
+
+export interface CredentialSettleFailure {
+  flowId: string;
+  provider: string;
+  expectedCredential: string;
+  expectedModel?: string;
+  /** The last probe read, or `null` when the flow had no Agent node / was never read. */
+  probe: AgentCredentialProbe | null;
+  verdict: CredentialSettleVerdict;
+  elapsedMs: number;
+  reads: number;
+  /** Last transport/HTTP error, when the reads themselves were failing. */
+  lastReadError?: string;
+}
+
+/**
+ * Per-verdict explanation: what to look at, and whether waiting could help.
+ *
+ * `settled` is absent on purpose — the formatter below only runs on failure, and a
+ * guidance string that can never be printed is one more thing to keep true.
+ */
+const VERDICT_GUIDANCE: Record<
+  Exclude<CredentialSettleVerdict, "settled">,
+  string
+> = {
+  "model-pending":
+    "The credential matches but the requested model is not applied, so nothing " +
+    "here says the model selection worked. Read the credential before concluding: " +
+    "when it is the selector's DEFAULT binding (ANTHROPIC_API_KEY) the match is " +
+    "free and proves nothing — this verdict exists because a credential-only check " +
+    "declared such a load settled. When it is any other provider's, the rebind did " +
+    "land and only the selection has not. Either way, look at the provider setup " +
+    "step for this provider, not at the credential.",
+  "credential-pending":
+    "The requested model IS applied, so the selection registered and only the " +
+    "credential rebind is missing from the persisted flow. The rebind is computed " +
+    "by `POST /api/v1/custom_component/update` and persisted by the editor's " +
+    "debounced autosave `PATCH /api/v1/flows/{id}`; a saturated backend delays " +
+    "both (#1077). Note this line prints only AFTER the budget expired, so " +
+    "retrying did NOT help within it — and a persisted credential belonging to a " +
+    "THIRD provider is a real misbinding, not slowness. Compare the observed " +
+    "credential against the provider before concluding load.",
+  "model-not-applied":
+    "A DIFFERENT model is persisted, so the provider-setup step selected something " +
+    "other than what was asked for — waiting longer cannot fix it. Look at the " +
+    "provider setup helper for this provider (dropdown intercepted, option " +
+    "missing from the list, panel still animating), not at the save path.",
+  "nothing-persisted":
+    "No model is persisted at all, so nothing carried the selection. Two causes " +
+    "fit and this guard cannot separate them: the model click never registered " +
+    "(provider setup), or the rebind never completed. Check the run for " +
+    "`POST /api/v1/custom_component/update` — that is the request that computes " +
+    "the binding; the flows PATCH only persists its result.",
+  "no-agent-node":
+    "The persisted flow was read and has no Agent node: the Simple Agent template " +
+    "did not instantiate as expected, or the id belongs to a different flow.",
+  "read-failed":
+    "No read of the persisted flow succeeded, so the binding is UNKNOWN — nothing " +
+    "here says anything about the credential. Treat the read error above as the " +
+    "finding (a wedged or recycling backend, #1077), not the binding.",
+};
+
+/**
+ * The failure message the guard raises. Spelled out rather than left to a bare
+ * `toBe` mismatch because this line is the entire product of the failure in a
+ * daily's report — #1072 exists because the mismatch alone was triaged as a
+ * provider-wiring bug across two separate runs.
+ */
+export function formatCredentialSettleFailure(
+  failure: CredentialSettleFailure,
+): string {
+  const {
+    flowId,
+    provider,
+    expectedCredential,
+    expectedModel,
+    probe,
+    verdict,
+    elapsedMs,
+    reads,
+    lastReadError,
+  } = failure;
+
+  const observed = probe
+    ? `api_key="${probe.credential}" models=[${probe.selectedModels.join(", ")}]`
+    : verdict === "read-failed"
+      ? "no successful read of the persisted flow"
+      : "the flow was read and carries no Agent node";
+
+  return [
+    `Agent credential never settled on the persisted flow (#751 guard, #1072).`,
+    ``,
+    `  flow           ${flowId}`,
+    `  provider       ${provider} (expected credential "${expectedCredential}")`,
+    `  model wanted   ${expectedModel ?? "(caller let the setup helper choose)"}`,
+    `  observed       ${observed}`,
+    `  waited         ${(elapsedMs / 1000).toFixed(1)}s over ${reads} read(s)`,
+    ...(lastReadError ? [`  last read err  ${lastReadError}`] : []),
+    ``,
+    `  verdict        ${verdict}`,
+    `                 ${VERDICT_GUIDANCE[verdict as Exclude<CredentialSettleVerdict, "settled">]}`,
+  ].join("\n");
+}

--- a/tests/helpers/flows/agent-credential-settle.ts
+++ b/tests/helpers/flows/agent-credential-settle.ts
@@ -3,10 +3,11 @@
 //
 // `SimpleAgentTemplatePage.load()` ends on a guard added by #751: it blocks until
 // the Agent node is bound to the provider the caller asked for. On the 1.11+
-// unified model selector (`ModelInput`), opening the model dropdown auto-binds
-// `api_key` to the DEFAULT credential (`ANTHROPIC_API_KEY`); picking the target
-// provider's model rebinds it, and both the rebind and the selection reach the
-// database through the editor's debounced autosave `PATCH /api/v1/flows/{id}`.
+// unified model selector (`ModelInput`), the node prefills `api_key` with the
+// DEFAULT credential (`ANTHROPIC_API_KEY`) when it MOUNTS — not when the dropdown
+// opens; picking the target provider's model rebinds it, and both the rebind and the
+// selection reach the database through the editor's debounced autosave
+// `PATCH /api/v1/flows/{id}`.
 //
 // The guard used to be a blind poll with a bare `expect(...).toBe(credential)`
 // inside, so when it ran out the whole report carried was:
@@ -151,9 +152,14 @@ export function readAgentCredentialProbe(
  * (`agent-max-iterations.spec.ts:255`) could never have been this guard's
  * expected/received mismatch: for anthropic the mismatch is unreachable.
  *
- * `expectedModel` is optional — a caller may let the provider-setup helper pick
- * the first available model, leaving no name to compare. Every parametrized agent
- * spec does pass one, so the model axis is available in the common case.
+ * `expectedModel` is optional — a caller may let the provider-setup helper pick the
+ * first available model, leaving no name to compare. Most agent specs are
+ * parametrized from `models.json` and do pass one, but three load without a model
+ * (`model-provider-model-toggle`, `general-bugs-agent-images-playground`,
+ * `agent-model-connection-isolation`), and so does any spec whose `models.json`
+ * came back empty. For those the model axis is simply unavailable — see
+ * `CREDENTIAL_PENDING_NO_MODEL_GUIDANCE`, which is what keeps the reported
+ * guidance from claiming a check that did not happen.
  *
  * Gating on the model is only sound because a pinned model is never silently
  * substituted on this path: `setup-openai`, `setup-anthropic` and `setup-google`
@@ -225,10 +231,15 @@ const VERDICT_GUIDANCE: Record<
     "THIRD provider is a real misbinding, not slowness. Compare the observed " +
     "credential against the provider before concluding load.",
   "model-not-applied":
-    "A DIFFERENT model is persisted, so the provider-setup step selected something " +
-    "other than what was asked for — waiting longer cannot fix it. Look at the " +
-    "provider setup helper for this provider (dropdown intercepted, option " +
-    "missing from the list, panel still animating), not at the save path.",
+    "A DIFFERENT model is persisted than the one requested. TWO states look like " +
+    "this and the observed model tells them apart: the provider-setup step selected " +
+    "the wrong option (waiting cannot fix it — look at the setup helper: dropdown " +
+    "intercepted, option missing, panel still animating), OR nothing was saved " +
+    "after the click at all, leaving the node's mount-time prefill in place — on a " +
+    "google/openai load that prefill IS `ANTHROPIC_API_KEY` plus the default " +
+    "Claude model, so this verdict is also what a wedged save path (#1077) looks " +
+    "like. If the observed pair is exactly that default, suspect the save, not the " +
+    "click.",
   "nothing-persisted":
     "No model is persisted at all, so nothing carried the selection. Two causes " +
     "fit and this guard cannot separate them: the model click never registered " +
@@ -243,6 +254,35 @@ const VERDICT_GUIDANCE: Record<
     "here says anything about the credential. Treat the read error above as the " +
     "finding (a wedged or recycling backend, #1077), not the binding.",
 };
+
+/**
+ * `credential-pending` with no pinned model.
+ *
+ * The verdict is the same — the credential is not there — but its usual guidance
+ * ("the requested model IS applied, so the selection registered") asserts something
+ * that was never checked: with no `expectedModel` the model axis is unavailable, so
+ * ANY wrong-credential read with a non-empty model list lands on that verdict.
+ * Three specs load without pinning a model (`model-provider-model-toggle`,
+ * `general-bugs-agent-images-playground`, `agent-model-connection-isolation`), plus
+ * any spec whose `models.json` came back empty.
+ */
+const CREDENTIAL_PENDING_NO_MODEL_GUIDANCE =
+  "The credential is missing from the persisted flow, and the caller pinned no " +
+  "model — so nothing here says whether the model selection registered. Read the " +
+  "`observed` models against what the provider-setup helper would have picked " +
+  "before concluding. The rebind is computed by " +
+  "`POST /api/v1/custom_component/update` and persisted by the editor's debounced " +
+  "autosave; a saturated backend delays both (#1077).";
+
+/** The guidance for this failure, including the cases the verdict alone cannot carry. */
+function guidanceFor(failure: CredentialSettleFailure): string {
+  if (failure.verdict === "credential-pending" && !failure.expectedModel) {
+    return CREDENTIAL_PENDING_NO_MODEL_GUIDANCE;
+  }
+  return VERDICT_GUIDANCE[
+    failure.verdict as Exclude<CredentialSettleVerdict, "settled">
+  ];
+}
 
 /**
  * The failure message the guard raises. Spelled out rather than left to a bare
@@ -282,6 +322,6 @@ export function formatCredentialSettleFailure(
     ...(lastReadError ? [`  last read err  ${lastReadError}`] : []),
     ``,
     `  verdict        ${verdict}`,
-    `                 ${VERDICT_GUIDANCE[verdict as Exclude<CredentialSettleVerdict, "settled">]}`,
+    `                 ${guidanceFor(failure)}`,
   ].join("\n");
 }

--- a/tests/pages/SimpleAgentTemplatePage.ts
+++ b/tests/pages/SimpleAgentTemplatePage.ts
@@ -25,25 +25,31 @@ export interface LoadSimpleAgentOptions {
 /**
  * How long the guard waits for the binding to appear in the persisted flow.
  *
- * Deliberately left at the pre-#1072 value. The recorded flakes are load-induced —
- * all four settled on a retry — and the relief for that belongs to the saturation
- * work (#1077), not here: a bigger number would only make a genuinely stuck
- * binding cost longer before it is reported. Two mechanisms were tried and
- * rejected instead of inflating it:
+ * Deliberately left at the pre-#1072 value. Of the four occurrences the caret line
+ * of each run's `results.json` pins on this guard, three recovered on a retry; the
+ * fourth hard-failed on 2026-07-22, a day the daily recorded 22 hard failures in
+ * total. Both readings point at the environment rather than at this number, and the
+ * relief for that belongs to the saturation work (#1077) — a bigger budget here
+ * would only make a genuinely stuck binding cost longer before it is reported. Two
+ * mechanisms were tried and rejected instead of inflating it:
  *
  *  - **An autosave barrier** (`waitForFlowSaveSettled` before the check). It
  *    cannot work from here: it is attached AFTER the model click, and the rebind
  *    chain is a 300 ms `mutateTemplate` debounce → `POST
- *    /api/v1/custom_component/update` → a second 300 ms autosave debounce, so the
- *    earliest `PATCH /api/v1/flows/{id}` is ~600 ms + one round trip away. With
- *    nothing in flight at attach time the helper's 700 ms quiet window simply
- *    expires first — measured locally, it resolved at ~0.7 s on a settle that
- *    completed at 1.5 s, having tracked no request at all. On a saturated backend
- *    (the flake's condition) it degenerates further, into a 700 ms sleep.
- *  - **Waiting on the rebind POST itself.** It has to be armed before the click,
- *    i.e. inside every provider-setup helper, and it answers before the autosave
- *    that this guard reads — so it would add a moving part to four files without
- *    removing the wait that actually matters.
+ *    /api/v1/custom_component/update` → the editor's autosave debounce, which is
+ *    `GET /api/v1/config.auto_saving_interval` and answers **1000** on the running
+ *    nightly (the 300 ms in `wait-for-flow-save-settled.ts` is only the store's
+ *    pre-fetch default). The earliest `PATCH /api/v1/flows/{id}` is therefore
+ *    ~1.3 s + a round trip away, while the helper's quiet window is 700 ms with
+ *    nothing in flight at attach time — so it expires first. Measured locally: it
+ *    resolved at ~0.7 s on a settle that completed at 1.5 s, having tracked no
+ *    request at all. Under load it degenerates into a 700 ms sleep.
+ *  - **Waiting on the rebind POST itself** (armable in `load()` before the setup
+ *    call, so no change to the setup helpers). The disqualifier is that the same
+ *    POST has ALREADY fired once when the Agent node mounted — the `api_key`
+ *    prefill — so a single `waitForResponse` resolves on the prefill, not on the
+ *    rebind, and telling them apart means inspecting bodies for a value this guard
+ *    can read directly from the flow.
  */
 const CREDENTIAL_SETTLE_TIMEOUT_MS = 20_000;
 
@@ -88,10 +94,10 @@ export class SimpleAgentTemplatePage extends BasePage {
     await adjustScreenView(this.page);
     await providerSetupMap[provider](this.page, model);
 
-    // #751: on the 1.11 unified model selector, opening the Agent model dropdown
-    // auto-binds the node's `api_key` to the DEFAULT credential (e.g.
-    // ANTHROPIC_API_KEY); picking the target provider's model rebinds it to that
-    // provider's credential ASYNCHRONOUSLY. A caller that opens the Playground
+    // #751: on the 1.11+ unified model selector the Agent node prefills its
+    // `api_key` with the DEFAULT credential (ANTHROPIC_API_KEY) when it MOUNTS —
+    // not when the dropdown opens; picking the target provider's model rebinds it
+    // to that provider's credential ASYNCHRONOUSLY. A caller that opens the Playground
     // and sends a message before the rebind settles builds the selected model
     // with the wrong provider's key — surfacing as
     // "Flow build failed: Incorrect API key provided" and a `div-chat-message`
@@ -130,8 +136,8 @@ export class SimpleAgentTemplatePage extends BasePage {
    * the in-memory store, and `modelInputComponent.spec.ts` already reads it — but
    * it only covers the axis that is not the risk. The risk #751 exists for is the
    * credential, and that has no non-modal surface: on the running nightly the
-   * Agent's `api_key` is `show: true, advanced: true` (check it with
-   * `GET /api/v1/all` → `Agent.template.api_key`), so reading it off the canvas
+   * Agent's `api_key` is `show: true, advanced: true` (check it with `GET
+   * /api/v1/all` → `.models_and_agents.Agent.template.api_key`), so reading it off the canvas
    * means opening the node's advanced-settings modal — an extra interaction on the
    * very canvas whose state is being measured. One persisted read covers both axes
    * and is the only observable that PROVES the rebind instead of proxying it.
@@ -164,7 +170,11 @@ export class SimpleAgentTemplatePage extends BasePage {
         });
         if ((res.status() === 401 || res.status() === 403) && !triedAuthFallback) {
           triedAuthFallback = true;
-          const auth = await getAuthToken(this.page.request);
+          // No inner retry budget: this loop IS the retry, and `getAuthToken`'s
+          // default `[2000, 8000, 20000]` backoff plus its per-attempt request
+          // timeout would add ~110 s inside a single iteration, past this guard's
+          // own deadline. One attempt, then the outer loop decides.
+          const auth = await getAuthToken(this.page.request, { retryDelaysMs: [] });
           if (auth) {
             // Said out loud on purpose: a green run is not evidence that the
             // cookie path worked — the fallback would carry it silently. This
@@ -179,9 +189,16 @@ export class SimpleAgentTemplatePage extends BasePage {
           }
         }
         if (res.ok()) {
+          // Parse BEFORE counting the read. A 2xx whose body does not parse (a
+          // truncated response from a recycling worker, a proxy's HTML) throws
+          // here; marking the read as successful first would leave `probe` null
+          // with `everRead` true and make the guard report "the flow was read and
+          // carries no Agent node" about a body it never parsed — the exact
+          // conflation `read-failed` exists to prevent.
+          const body = await res.json();
           reads++;
           everRead = true;
-          probe = readAgentCredentialProbe(await res.json());
+          probe = readAgentCredentialProbe(body);
           lastReadError = undefined;
           if (
             classifyCredentialSettle(probe, expectedCredential, expected.model) ===

--- a/tests/pages/SimpleAgentTemplatePage.ts
+++ b/tests/pages/SimpleAgentTemplatePage.ts
@@ -1,8 +1,14 @@
-import { expect, type Page } from "@playwright/test";
+import { type Page } from "@playwright/test";
 import { BasePage } from "./BasePage";
 import { adjustScreenView } from "../helpers/ui/adjust-screen-view";
 import { loadTemplateByName } from "../helpers/flows/load-template-by-name";
 import { getAuthToken } from "../helpers/auth/get-auth-token";
+import {
+  classifyCredentialSettle,
+  formatCredentialSettleFailure,
+  readAgentCredentialProbe,
+  type AgentCredentialProbe,
+} from "../helpers/flows/agent-credential-settle";
 import {
   providerConfigMap,
   providerSetupMap,
@@ -15,6 +21,42 @@ export interface LoadSimpleAgentOptions {
   provider?: Provider;
   model?: string;
 }
+
+/**
+ * How long the guard waits for the binding to appear in the persisted flow.
+ *
+ * Deliberately left at the pre-#1072 value. The recorded flakes are load-induced —
+ * all four settled on a retry — and the relief for that belongs to the saturation
+ * work (#1077), not here: a bigger number would only make a genuinely stuck
+ * binding cost longer before it is reported. Two mechanisms were tried and
+ * rejected instead of inflating it:
+ *
+ *  - **An autosave barrier** (`waitForFlowSaveSettled` before the check). It
+ *    cannot work from here: it is attached AFTER the model click, and the rebind
+ *    chain is a 300 ms `mutateTemplate` debounce → `POST
+ *    /api/v1/custom_component/update` → a second 300 ms autosave debounce, so the
+ *    earliest `PATCH /api/v1/flows/{id}` is ~600 ms + one round trip away. With
+ *    nothing in flight at attach time the helper's 700 ms quiet window simply
+ *    expires first — measured locally, it resolved at ~0.7 s on a settle that
+ *    completed at 1.5 s, having tracked no request at all. On a saturated backend
+ *    (the flake's condition) it degenerates further, into a 700 ms sleep.
+ *  - **Waiting on the rebind POST itself.** It has to be armed before the click,
+ *    i.e. inside every provider-setup helper, and it answers before the autosave
+ *    that this guard reads — so it would add a moving part to four files without
+ *    removing the wait that actually matters.
+ */
+const CREDENTIAL_SETTLE_TIMEOUT_MS = 20_000;
+
+/** Read spacing; the last entry repeats until the budget ends. */
+const CREDENTIAL_SETTLE_INTERVALS_MS = [250, 500, 1000, 2000];
+
+/**
+ * Above this, a SUCCESSFUL settle is still reported to the run output. A near-miss
+ * is the early warning for the wedge behind #1077, and it is worth exactly one
+ * line: the pre-#1072 guard was silent right up to the point where it failed, so a
+ * daily could not show that the margin had been shrinking.
+ */
+const CREDENTIAL_SETTLE_SLOW_MS = 5_000;
 
 export class SimpleAgentTemplatePage extends BasePage {
   constructor(page: Page) {
@@ -54,40 +96,146 @@ export class SimpleAgentTemplatePage extends BasePage {
     // with the wrong provider's key — surfacing as
     // "Flow build failed: Incorrect API key provided" and a `div-chat-message`
     // that never renders (the daily-#744 signature). Block until the PERSISTED
-    // api_key matches the provider's credential so every caller starts settled.
+    // flow shows BOTH that credential and the requested model, so every caller
+    // starts settled — the credential alone does not prove it (#1072, see the
+    // classifier's note on the anthropic default).
     await this.waitForAgentCredentialSettled(
       flowId,
       providerConfigMap[provider].envKeys[0],
+      { provider, model },
     );
 
     return flowId;
   }
 
   /**
-   * Poll the persisted flow until the Agent node's `api_key` references the
-   * given provider credential (e.g. `OPENAI_API_KEY`). The model-selection
-   * rebind persists via a debounced autosave PATCH, so the persisted value is a
-   * conservative "everything settled" signal — the in-memory canvas graph the
-   * Playground build sends is updated before that PATCH lands. #751.
+   * Block until the persisted flow shows the Agent bound to `expectedCredential`
+   * AND carrying the requested model. #751, reworked in #1072.
+   *
+   * What #1072 changed, and what it deliberately did not:
+   *
+   *  - **The check is no longer credential-only.** For `provider: "anthropic"` the
+   *    expected credential IS the selector's default auto-binding, so the old
+   *    check returned "settled" before the model selection had been applied at
+   *    all — `load()`'s contract did not hold for that provider. See
+   *    `classifyCredentialSettle`.
+   *  - **The failure is now self-describing** rather than a bare `toBe` mismatch
+   *    that reads as a provider-wiring bug (which is how it was triaged twice).
+   *  - **The budget is unchanged.** The recorded flakes are load-induced and the
+   *    relief for that is #1077; see `CREDENTIAL_SETTLE_TIMEOUT_MS` for the two
+   *    wait mechanisms measured and rejected here.
+   *
+   * Why the PERSISTED flow and not a UI signal, which directive (c) of #1072 asks
+   * about: the model widget (`model_model`) does settle earlier — it renders from
+   * the in-memory store, and `modelInputComponent.spec.ts` already reads it — but
+   * it only covers the axis that is not the risk. The risk #751 exists for is the
+   * credential, and that has no non-modal surface: on the running nightly the
+   * Agent's `api_key` is `show: true, advanced: true` (check it with
+   * `GET /api/v1/all` → `Agent.template.api_key`), so reading it off the canvas
+   * means opening the node's advanced-settings modal — an extra interaction on the
+   * very canvas whose state is being measured. One persisted read covers both axes
+   * and is the only observable that PROVES the rebind instead of proxying it.
    */
   private async waitForAgentCredentialSettled(
     flowId: string,
     expectedCredential: string,
+    expected: { provider: Provider; model?: string },
   ): Promise<void> {
-    const auth = await getAuthToken(this.page.request);
-    const headers = auth ? { Authorization: auth } : undefined;
-    await expect(async () => {
-      const res = await this.page.request.get(`/api/v1/flows/${flowId}`, {
-        headers,
-      });
-      expect(res.ok()).toBe(true);
-      const flow = await res.json();
-      const agent = (flow?.data?.nodes ?? []).find(
-        (n: { data?: { type?: string } }) => n?.data?.type === "Agent",
+    const startedAt = Date.now();
+    const deadline = startedAt + CREDENTIAL_SETTLE_TIMEOUT_MS;
+
+    let reads = 0; // successful reads only — what the diagnostic reports
+    let sleeps = 0; // drives the interval tier, so a retry cannot skip one
+    let probe: AgentCredentialProbe | null = null;
+    let everRead = false;
+    let lastReadError: string | undefined;
+    // Same-origin reads inherit the browser session's cookies, so the happy path
+    // costs no extra request. `getAuthToken` is the fallback for an environment
+    // that answers those unauthenticated — never the default, because it hits
+    // `/api/v1/auto_login`, and on daily run 30444299314 that one call was where
+    // 18 attempts across 8 agent specs died while the backend was wedged.
+    let headers: Record<string, string> | undefined;
+    let triedAuthFallback = false;
+
+    for (;;) {
+      try {
+        const res = await this.page.request.get(`/api/v1/flows/${flowId}`, {
+          headers,
+        });
+        if ((res.status() === 401 || res.status() === 403) && !triedAuthFallback) {
+          triedAuthFallback = true;
+          const auth = await getAuthToken(this.page.request);
+          if (auth) {
+            // Said out loud on purpose: a green run is not evidence that the
+            // cookie path worked — the fallback would carry it silently. This
+            // line is what makes "the happy path costs no auto_login" checkable.
+            console.warn(
+              `⚠️  agent credential guard: /api/v1/flows/${flowId} answered ` +
+                `${res.status()} on the browser session, falling back to an explicit ` +
+                `token (one extra /api/v1/auto_login on this load — #1072).`,
+            );
+            headers = { Authorization: auth };
+            continue; // retry immediately with the explicit token
+          }
+        }
+        if (res.ok()) {
+          reads++;
+          everRead = true;
+          probe = readAgentCredentialProbe(await res.json());
+          lastReadError = undefined;
+          if (
+            classifyCredentialSettle(probe, expectedCredential, expected.model) ===
+            "settled"
+          ) {
+            const elapsedMs = Date.now() - startedAt;
+            if (elapsedMs > CREDENTIAL_SETTLE_SLOW_MS) {
+              console.warn(
+                `⚠️  agent credential settled slowly: ${(elapsedMs / 1000).toFixed(1)}s ` +
+                  `over ${reads} read(s) for ${expected.provider} on flow ${flowId} ` +
+                  `(#751 guard; a saturated backend delays the rebind and its ` +
+                  `autosave — #1077).`,
+              );
+            }
+            return;
+          }
+        } else {
+          lastReadError = `HTTP ${res.status()} ${res.statusText()}`;
+        }
+      } catch (error) {
+        // A read that never answers (the shared backend recycling its worker) is
+        // retried within the budget like any other unsettled read — the guard's
+        // verdict must describe the binding, not the first transport hiccup.
+        lastReadError = (error as Error)?.message?.split("\n")[0] ?? String(error);
+      }
+
+      if (Date.now() >= deadline) break;
+      const interval =
+        CREDENTIAL_SETTLE_INTERVALS_MS[
+          Math.min(sleeps, CREDENTIAL_SETTLE_INTERVALS_MS.length - 1)
+        ];
+      sleeps++;
+      await new Promise((resolve) =>
+        setTimeout(resolve, Math.min(interval, Math.max(0, deadline - Date.now()))),
       );
-      expect(agent?.data?.node?.template?.api_key?.value).toBe(
+    }
+
+    throw new Error(
+      formatCredentialSettleFailure({
+        flowId,
+        provider: expected.provider,
         expectedCredential,
-      );
-    }).toPass({ timeout: 20000, intervals: [500, 1000, 2000] });
+        expectedModel: expected.model,
+        probe,
+        // A binding nobody managed to read is UNKNOWN, not absent: collapsing the
+        // two would make the guard assert "this flow has no Agent node" about a
+        // flow it never fetched — the shape of every read on daily 30444299314.
+        verdict: everRead
+          ? classifyCredentialSettle(probe, expectedCredential, expected.model)
+          : "read-failed",
+        elapsedMs: Date.now() - startedAt,
+        reads,
+        lastReadError,
+      }),
+    );
   }
 }


### PR DESCRIPTION
**Fixes #1072.**

## Problem

`SimpleAgentTemplatePage.load()` ends on the #751 guard, which compared only the persisted `api_key` against the provider's credential inside a blind poll. Two defects.

**It was vacuous for anthropic.** `ANTHROPIC_API_KEY` is both the unified selector's default auto-binding *and* anthropic's expected credential, so the check passed the moment the default binding persisted — before the requested model had been applied at all. `load()`'s stated contract ("every caller starts settled") did not hold for that provider, and the expected/received mismatch is unreachable there.

**Its failure was unreadable.** All a daily carried was:

```
Expected: "GOOGLE_API_KEY"
Received: "ANTHROPIC_API_KEY"
```

which reads as a provider-wiring bug, and was triaged as one twice before #1072 traced it to this guard.

### Directive (a) — the cluster, from the caret line of each run's `results.json`

| Run (date) | Frame | Signature | Is it this guard? |
|---|---|---|---|
| 29911701167 (07-22) | `SimpleAgentTemplatePage.ts:91` (the `toPass`) | `toBe` — GOOGLE/OPENAI expected, ANTHROPIC received | **yes** — `agent-context-id-continuity:434`, `agent-context-id-isolation:564`, `agent-current-date-tool:383` |
| 30261409427 (07-27) | `:91` | same | **yes** — `agent-tool-name-validation:321` |
| 30444299314 (07-29) | `:77` (`getAuthToken`) | `apiRequestContext.get: Timeout 20000ms — GET /api/v1/auto_login` | **no** — 18 attempts across 8 specs; this is the wedge cluster of #1030/#1077 |

So the confirmed cluster is **4 occurrences over two runs**, not the six the issue listed as candidates. The 07-29 rows are re-attributed. The anthropic row cannot be this guard at all, for the vacuity reason above.

### Directive (b) — verdict: load-induced

Three of the four recovered on a retry. The fourth — a parameterization of `agent-context-id-isolation:564` — hard-failed on 2026-07-22, a day whose daily recorded **22 hard failures in total**; the same title also appears twice under `flaky` that day, i.e. other parameterizations of it did recover. Both readings point at the environment rather than at the budget, so the relief belongs to **#1077** and the budget is unchanged: a larger one would only make a genuinely stuck binding cost longer before it is reported. Two waits were measured and rejected rather than inflating it — recorded on `CREDENTIAL_SETTLE_TIMEOUT_MS`:

- **An autosave barrier** (`waitForFlowSaveSettled` before the check) cannot work from this call site: it attaches *after* the model click, while the rebind chain is a 300 ms `mutateTemplate` debounce → `POST /api/v1/custom_component/update` → the editor's autosave debounce, which comes from `GET /api/v1/config.auto_saving_interval` and answers **1000** on the running nightly (the `300` in `wait-for-flow-save-settled.ts` is only the store's pre-fetch default). Earliest PATCH is therefore ~1.3 s + a round trip, against the helper's 700 ms quiet window. Measured locally it resolved at ~0.7 s on a settle that completed at 1.5 s, having tracked no request at all; under load it degenerates into a 700 ms sleep. (This shipped in an earlier draft of this PR and was removed after review.)
- **Waiting on the rebind POST** *can* be armed in `load()` without touching the setup helpers — the real disqualifier is that the same POST already fires when the Agent node mounts (the `api_key` prefill), so a single `waitForResponse` resolves on the prefill rather than on the rebind.

### Directive (c) — is the polled signal the right one?

Yes, with the model axis added. The model widget (`model_model`) does settle earlier — it renders from the in-memory store — but it only covers the axis that is not the risk. The risk #751 exists for is the credential, and that has no non-modal surface: on the running nightly the Agent's `api_key` is `show: true, advanced: true` (`GET /api/v1/all` → `.models_and_agents.Agent.template.api_key`), so reading it off the canvas means opening the node's advanced-settings modal — an extra interaction on the very canvas being measured. One persisted read covers both axes and is the only observable that *proves* the rebind.

### Directive (d) — product-regression check

**Not a regression.** On 1.12.0.dev10 the rebind lands: measured at **1.5 s over 3 reads** for openai (i.e. away from the Anthropic default). Not the `model-selection-drop` class of #491/#596/#894.

## Fix

- The guard now requires the persisted flow to carry **both** the expected credential **and** (when the caller pinned one) the requested model. Sound because no setup helper silently substitutes a pinned model on this path — each clicks the exact option or throws `MODEL_NOT_AVAILABLE`; the one substituting path (`setupOpenAI(..., { fallbackToRanking: true })`, #606) is opt-in and only used by `initialGPTsetup`, which never goes through this Page Object. The comment says so, because wiring that option through `providerSetupMap` would break the comparison.
- The failure is a diagnostic naming the flow, provider, requested model, observed binding, elapsed time and a **verdict**, extracted into a pure module (`helpers/flows/agent-credential-settle.ts`) with 23 unit tests. The verdicts separate what the single mismatch line collapsed: a lagging rebind, a model click that never registered, a credential matching only because it is the default, and a read that never succeeded — the last kept distinct so the guard cannot assert "this flow has no Agent node" about a flow it never fetched.
- One `/api/v1/auto_login` round trip is dropped from this shared path: the reads inherit the browser session's cookies, with `getAuthToken` kept as a **logged** fallback. On run 30444299314 that call, not the credential check, is where 18 attempts across 8 specs died.
- A successful settle over 5 s now prints one line, so a shrinking margin is visible in a daily before it becomes a failure.

## Scope note

No spec file changes; no tags, spec docs or `QA-CHECKLIST` bullets are affected. `tests/pages/**` is not suite-wide for `impacted-specs-by-import.mjs`, but **25 specs import this Page Object**, so the impacted-specs job will select the capped 20 — the dropped ones are listed in its summary.

## Validation (nightly 1.12.0.dev10, `--workers=1 --retries=0`)

- `npm run typecheck` ✅ · `npx eslint` on the three files ✅ (0 problems) · `npm run test:units` ✅ (23/23 in the new file)
- `agent-tool-name-validation` + `agent-current-date-tool` (openai/gpt-4o-mini): **4 passed (1.2m)** ✅
- `agent-tool-name-validation --grep "causal control"` (anthropic/claude-sonnet-5, the provider the new model gate changes): **1 passed (15.3s)** ✅
- `agent-system-prompt` + `agent-max-tokens` + `agent-multi-tool-selection`: 4 passed, **1 pre-existing failure** — `agent selects the URL tool for a fetch prompt` failed on an **external 503** from the fetched page (`503 Service Temporarily Unavailable` inside the tool output), an assertion downstream of this guard. That test has hard-failed in dailies 29087610808 and 29911701167 and flaked in 29489622983.
- Zero `🚨 Backend Error`; zero leaked flows (`GET /api/v1/flows/` back to the 27 bundled starter templates).
- Post-review re-verification: `1 passed (14.6s)` after the second commit; eslint/typecheck/units re-run clean (23 unit tests).
- **Force-fail, executed:**
  - `FF` budget → 1 ms ⇒ guard fails with the full diagnostic (`verdict nothing-persisted`, `waited 0.7s over 1 read`). This FF is what exposed a defect in the first draft, since fixed: an empty persisted model was being reported as `model-not-applied` ("waiting cannot help") on a state that resolves 800 ms later.
  - `FF` expected model → `ff-nonexistent-model` ⇒ guard fails at `20.0s over 12 read(s)`, `verdict model-pending`, `observed api_key="OPENAI_API_KEY" models=[gpt-4o-mini]` — proving the new model gate is load-bearing *and* that the array-shaped `model.value` is read correctly on live data.
  - `FF` unit — reading `model.value` as a string (the defect the first review caught) ⇒ 1 fails. Dropping the `model wanted` line ⇒ 2 fail (0 before the assertions were made per-field). Blanking the `model-not-applied` or `no-agent-node` guidance ⇒ 1 each. Reverting fixture **and** implementation together to the string shape — the pair that made the first cut inert while its tests stayed green ⇒ 1 fails.
  - Revert proven: 0 mutation markers in the diff, final run **1 passed (14.1s)**.
- `--trace=on` skipped: known to hang on Simple Agent–template specs (#490/#518).

## Still open after merge

The issue's last box — *"the affected tests run clean over several consecutive dailies"* — can only be checked post-merge. No `@stable` was removed on this account, so nothing needs restoring.

## Out of scope, found on the way

`collect-models` records **google as inactive on 1.12.0.dev10 with a live key**: "no models collected from the providers panel" (0 Google models listed in the UI, while the key answers 200 to the provider's own list endpoint). Not filed here — flagging it so it is not mistaken for this change.

Closes #1072
