### PR TITLE
refactor(provider-setup): dedupe the inline provider skip maps into provider-health (#1043)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,20 +154,10 @@ import fs from "fs";
 import { test, expect } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
 import { hasProviderEnvKeys, type Provider } from "../../../../helpers/provider-setup";
-import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
 
 if (!process.env.CI) {
   dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
-}
-
-// Read inactive providers to display as skipped in output
-function getProviderSkipReasons(): Map<string, string> {
-  const jsonPath = path.resolve(__dirname, "../../../../helpers/provider-setup/data/providers.json");
-  if (!fs.existsSync(jsonPath)) return new Map();
-  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
-  return new Map(
-    records.filter((r) => r.status === "inactive").map((r) => [r.provider, `Provider "${r.provider}" inactive — ${r.error}`])
-  );
 }
 
 // Read models and apply the .env strategy
@@ -175,7 +165,9 @@ function getTestTargets() {
   const jsonPath = path.resolve(__dirname, "../../../../helpers/provider-setup/data/models.json");
   if (!fs.existsSync(jsonPath)) return [];
   const allModels = JSON.parse(fs.readFileSync(jsonPath, "utf-8"));
-  const skipReasons = getProviderSkipReasons();
+  // Inactive providers, so their targets report as skipped with the collected
+  // reason. Never inline this — one shared implementation (#1043).
+  const skipReasons = providerSkipReasons();
   // apply strategy filter (see agent-component-regression.spec.ts for full implementation)
   return allModels.map((m: any) => ({
     label: `${m.provider} / ${m.model}`,

--- a/docs/collect-models.md
+++ b/docs/collect-models.md
@@ -152,19 +152,31 @@ place: all five components fail on missing credentials, none reaches the network
 ### Who consumes the recorded health
 
 Writing `inactive` is only half the mechanism — a spec has to obey it. Two kinds
-of spec do:
+of spec do, and since #1043 **both go through
+`tests/helpers/provider-setup/provider-health.ts`**, which is the single
+implementation of the rule:
 
 - **Provider-parametrized** specs (the `agent-*` family, `mcp-client-agent`) build
-  their target list from `models.json` and drop a target whose provider is
-  `inactive`, quoting the recorded reason.
-- **Provider-hardcoded** specs gate through
-  `providerSkipGate(...)` in `tests/helpers/provider-setup/provider-health.ts`
-  (#1029). That helper is the single implementation of the rule: missing env key
-  first, then the recorded `inactive` reason. It **fails open** when
-  `providers.json` is absent or unparseable — a fresh clone has no file (it is
-  gitignored) and CI is allowed to run with a failed `Collect models` step (#980),
-  so "no signal" must never skip the suite. `IGNORE_PROVIDER_HEALTH=1` overrides a
-  stale local file.
+  their target list from `models.json` and call `providerSkipReasons()` for the
+  `provider → reason` map, dropping a target whose provider is `inactive` and
+  quoting the recorded reason. Each of them used to carry its own inlined copy of
+  that map (18 of them, already drifted); #1043 deleted the copies.
+- **Provider-hardcoded** specs gate through `providerSkipGate(...)` (#1029), which
+  adds one precedence rule the map does not need: a missing env key is reported
+  before a recorded `inactive`, because without the key the provider cannot be
+  configured at all.
+
+Both **fail open** when `providers.json` is absent or unparseable — a fresh clone
+has no file (it is gitignored) and CI is allowed to run with a failed
+`Collect models` step (#980), so "no signal" must never skip the suite. And both
+honour `IGNORE_PROVIDER_HEALTH=1`, which overrides a stale local file.
+
+> **The escape hatch is local-only, and it is now blunter than it was.** The
+> variable is set in no workflow, script or config — only ever exported by hand.
+> Before #1043 it affected the hardcoded specs alone; it now also un-skips every
+> provider-parametrized target. Since these specs load `.env` whenever `CI` is
+> unset, leaving `IGNORE_PROVIDER_HEALTH=1` in a `.env` file will send the whole
+> agent family at a dead key on your next local run.
 
 Before #1029 the hardcoded specs gated on env-var presence, so a key that existed
 but was drained still made the live call. On run 30374528125 that hung two Google

--- a/tests/helpers/provider-setup/provider-health.test.ts
+++ b/tests/helpers/provider-setup/provider-health.test.ts
@@ -22,6 +22,7 @@ import * as os from "os";
 import * as path from "path";
 import {
   degradeProviders,
+  providerSkipReasons,
   providersForEnvKeys,
   readProviderHealth,
   toSkipGate,
@@ -342,4 +343,84 @@ test("writeProviderHealth reports failure instead of throwing", () => {
   fs.mkdirSync(asDir); // a directory where the file should go — write must fail
 
   assert.equal(writeProviderHealth([], asDir), false);
+});
+
+// ─── providerSkipReasons — the parametrized specs' gate (issue #1043) ─────────
+//
+// What rides on this function: 18 provider-parametrized spec files build one test
+// target per `models.json` entry and consult this map for the target's provider. Too
+// permissive and a target runs a live call against a dead key — the failure mode
+// #1029 exists to prevent (on run 30374528125 that killed the shard's only Langflow
+// worker six times and cost 14 collateral timeouts). Too strict and the whole agent
+// family skips, which reads as green.
+//
+// It replaced a byte-similar copy inlined in each of those files. The copies did NOT
+// honour `IGNORE_PROVIDER_HEALTH` and printed `inactive — null` for a nullable
+// error; both are corrected here, so these tests are also the record of the
+// behaviour change.
+
+const QUIET = { ...ALL_KEYS_SET } as NodeJS.ProcessEnv;
+
+test("maps every inactive provider to its collected reason", () => {
+  const reasons = providerSkipReasons(RUN_30374528125, QUIET);
+  assert.deepEqual([...reasons.keys()], ["google"]);
+  assert.equal(reasons.get("google"), `Provider "google" inactive — ${SPEND_CAP}`);
+});
+
+test("an active provider is absent from the map, not present with an empty reason", () => {
+  // The call sites do `skipReasons.get(provider)` and pass the result straight to
+  // `test.skip(!!reason, reason)`. An empty-string entry would skip nothing but
+  // would report a blank reason if the shape ever changed; absence is the contract.
+  const reasons = providerSkipReasons(RUN_30374528125, QUIET);
+  assert.equal(reasons.has("openai"), false);
+  assert.equal(reasons.get("anthropic"), undefined);
+});
+
+test("no health signal fails OPEN — an empty map, never a blanket skip", () => {
+  // providers.json is gitignored, so a fresh clone and any targeted local run
+  // legitimately have none, and CI may run with a failed `Collect models` (#980).
+  for (const records of [null, []]) {
+    assert.equal(providerSkipReasons(records, QUIET).size, 0);
+  }
+});
+
+test("IGNORE_PROVIDER_HEALTH=1 empties the map", () => {
+  // The escape hatch for a STALE local providers.json. `providerSkipGate` has
+  // honoured it since #1029; the inlined copies this replaced did not, so a local
+  // run of the agent family was unrunnable off a days-old file.
+  const reasons = providerSkipReasons(RUN_30374528125, {
+    ...QUIET,
+    IGNORE_PROVIDER_HEALTH: "1",
+  } as NodeJS.ProcessEnv);
+  assert.equal(reasons.size, 0);
+});
+
+test("a nullable error still produces a usable line, never `inactive — null`", () => {
+  const reasons = providerSkipReasons(
+    [{ provider: "google", model: null, status: "inactive", error: null }],
+    QUIET,
+  );
+  assert.equal(
+    reasons.get("google"),
+    'Provider "google" inactive — no reason recorded by collect-models',
+  );
+  assert.ok(!String(reasons.get("google")).includes("null"));
+});
+
+test("the map and the hardcoded gate report the SAME reason for the same record", () => {
+  // The two entry points must not drift: a spec parametrized over google and a spec
+  // hardcoding google should quote the same line in the report.
+  const reasons = providerSkipReasons(RUN_30374528125, QUIET);
+  assert.equal(
+    reasons.get("google"),
+    unavailableReason(["google"], RUN_30374528125, QUIET),
+  );
+});
+
+test("providerSkipReasons does not depend on env keys being set", () => {
+  // Deliberate parity with the copies it replaced: this gate reports COLLECTED
+  // health only. A missing env key is `unavailableReason`'s precedence rule, and
+  // folding it in here would change which targets skip vs. fail.
+  const reasons = providerSkipReasons(RUN_30374528125, {} as NodeJS.ProcessEnv);
+  assert.deepEqual([...reasons.keys()], ["google"]);
 });

--- a/tests/helpers/provider-setup/provider-health.test.ts
+++ b/tests/helpers/provider-setup/provider-health.test.ts
@@ -361,6 +361,20 @@ test("writeProviderHealth reports failure instead of throwing", () => {
 
 const QUIET = { ...ALL_KEYS_SET } as NodeJS.ProcessEnv;
 
+/** Collects `console.warn` output emitted while `run` executes. */
+function captureWarnings(run: () => void): string[] {
+  const warnings: string[] = [];
+  const original = console.warn;
+  console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
+  try {
+    run();
+  } finally {
+    console.warn = original;
+  }
+  return warnings;
+}
+
+
 test("maps every inactive provider to its collected reason", () => {
   const reasons = providerSkipReasons(RUN_30374528125, QUIET);
   assert.deepEqual([...reasons.keys()], ["google"]);
@@ -423,4 +437,46 @@ test("providerSkipReasons does not depend on env keys being set", () => {
   // folding it in here would change which targets skip vs. fail.
   const reasons = providerSkipReasons(RUN_30374528125, {} as NodeJS.ProcessEnv);
   assert.deepEqual([...reasons.keys()], ["google"]);
+});
+
+test("with no records argument it READS providers.json", () => {
+  // The zero-argument form is the only one the 18 call sites use, and nothing bound
+  // it to the file: changing the parameter's default to `null` left every one of
+  // these tests green while silently disabling the gate for the whole agent family —
+  // #1029's failure mode, restored by a one-word edit. `jsonPath` is the same
+  // test-only seam `readProviderHealth` / `writeProviderHealth` already take.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "provider-skip-reasons-"));
+  const file = path.join(dir, "providers.json");
+  writeProviderHealth(RUN_30374528125, file);
+
+  const reasons = providerSkipReasons(undefined, QUIET, file);
+  assert.equal(reasons.get("google"), `Provider "google" inactive — ${SPEND_CAP}`);
+});
+
+test("an armed escape hatch does not even read the file", () => {
+  // Ordering, not micro-optimisation: it documents that the hatch short-circuits
+  // before any I/O, so a missing file cannot make the hatch warn.
+  const warnings = captureWarnings(() =>
+    providerSkipReasons(undefined, { ...QUIET, IGNORE_PROVIDER_HEALTH: "1" } as NodeJS.ProcessEnv, path.join(os.tmpdir(), "does-not-exist-1043", "providers.json")),
+  );
+  assert.deepEqual(warnings, []);
+});
+
+test("only the exact value \"1\" arms the escape hatch here too", () => {
+  // `unavailableReason` has this test; without a parallel one the two entry points
+  // can drift on the value contract — the very drift this dedupe removed.
+  const reasons = providerSkipReasons(RUN_30374528125, {
+    ...QUIET,
+    IGNORE_PROVIDER_HEALTH: "true",
+  } as NodeJS.ProcessEnv);
+  assert.equal(reasons.size, 1, "a truthy-looking value must not disable the gate");
+});
+
+test("a missing providers.json says so, instead of looking healthy in silence", () => {
+  // Kept from the majority of the copies it replaced: this runs at collection time,
+  // and a local run with no providers.json should say why every provider looks fine.
+  // Two of the copies were silent; the warn is now uniform.
+  const warnings = captureWarnings(() => providerSkipReasons(null, QUIET));
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /collect-models\.spec\.ts/);
 });

--- a/tests/helpers/provider-setup/provider-health.ts
+++ b/tests/helpers/provider-setup/provider-health.ts
@@ -174,18 +174,74 @@ export function unavailableReason(
 
   for (const provider of providers) {
     const record = records.find((r) => r.provider === provider);
-    if (record?.status === "inactive") {
-      // The reason lands in the Playwright report — it is the whole product of a
-      // skip, so it must never read `inactive — null`. `collect-models` always
-      // fills `error` for an inactive record today, but the field is nullable and
-      // a hand-edited or future-schema file must still produce a usable line.
-      return `Provider "${provider}" inactive — ${
-        record.error ?? "no reason recorded by collect-models"
-      }`;
-    }
+    if (record?.status === "inactive") return inactiveReason(record);
   }
 
   return undefined;
+}
+
+/**
+ * The skip line for one `inactive` record.
+ *
+ * The reason lands in the Playwright report — it is the whole product of a skip, so
+ * it must never read `inactive — null`. `collect-models` always fills `error` for an
+ * inactive record today, but the field is nullable and a hand-edited or
+ * future-schema file must still produce a usable line.
+ */
+function inactiveReason(record: ProviderHealthRecord): string {
+  return `Provider "${record.provider}" inactive — ${
+    record.error ?? "no reason recorded by collect-models"
+  }`;
+}
+
+/**
+ * Every `inactive` provider and why, as `provider → reason` (issue #1043).
+ *
+ * The shape the provider-**parametrized** specs consume: they build one test target
+ * per `models.json` entry and need the reason for the target's provider, whichever
+ * that turns out to be — unlike the hardcoded specs, which know their providers up
+ * front and use `providerSkipGate`. Seventeen `agent-*.spec.ts` files plus
+ * `mcp-client-agent.spec.ts` carried a byte-similar copy of this, and
+ * `mcp-client-agent-gemini-tool-regression.spec.ts` a single-provider variant; #1029's
+ * audit found them already diverged (one silent where the others warn, one naming a
+ * `collect-providers.spec.ts` that does not exist), and every change to the skip
+ * contract had to be made in twenty places.
+ *
+ * Three deliberate differences from those copies, all of them the contract this
+ * module already owns elsewhere:
+ *
+ *  - `IGNORE_PROVIDER_HEALTH=1` empties the map, so the escape hatch for a stale
+ *    local `providers.json` now works for the parametrized specs too. It did not
+ *    before, which made a local run of the agent family unrunnable off a days-old
+ *    file even though `providerSkipGate` honoured the same variable.
+ *  - a nullable `error` produces "no reason recorded by collect-models" instead of
+ *    the literal `inactive — null`.
+ *  - the file is read once through `readProviderHealth`, which fails OPEN on an
+ *    absent or unparseable file (a fresh clone has none — it is gitignored).
+ *
+ * The `console.warn` on a missing file is kept from the majority of the copies: this
+ * runs at collection time, and a local run with no `providers.json` should say why
+ * every provider looks healthy.
+ */
+export function providerSkipReasons(
+  records: ProviderHealthRecord[] | null = readProviderHealth(),
+  env: NodeJS.ProcessEnv = process.env,
+): Map<string, string> {
+  const reasons = new Map<string, string>();
+  if (env.IGNORE_PROVIDER_HEALTH === "1") return reasons;
+  if (!records) {
+    console.warn(
+      "providers.json not found or unreadable — run collect-models.spec.ts first. " +
+        "Skipping provider pre-validation.",
+    );
+    return reasons;
+  }
+  for (const record of records) {
+    if (record.status === "inactive") {
+      reasons.set(record.provider, inactiveReason(record));
+    }
+  }
+  return reasons;
 }
 
 /**

--- a/tests/helpers/provider-setup/provider-health.ts
+++ b/tests/helpers/provider-setup/provider-health.ts
@@ -200,43 +200,59 @@ function inactiveReason(record: ProviderHealthRecord): string {
  * The shape the provider-**parametrized** specs consume: they build one test target
  * per `models.json` entry and need the reason for the target's provider, whichever
  * that turns out to be — unlike the hardcoded specs, which know their providers up
- * front and use `providerSkipGate`. Seventeen `agent-*.spec.ts` files plus
- * `mcp-client-agent.spec.ts` carried a byte-similar copy of this, and
- * `mcp-client-agent-gemini-tool-regression.spec.ts` a single-provider variant; #1029's
- * audit found them already diverged (one silent where the others warn, one naming a
- * `collect-providers.spec.ts` that does not exist), and every change to the skip
- * contract had to be made in twenty places.
+ * front and use `providerSkipGate`.
+ *
+ * It replaced 18 inlined copies: 16 `agent-*.spec.ts` files and
+ * `mcp-client-agent.spec.ts` carried this `Map`-returning shape, and
+ * `mcp-client-agent-gemini-tool-regression.spec.ts` a single-provider variant. They
+ * had already drifted — 15 warn on a missing `providers.json`, two are silent, and
+ * `agent-component-regression` names a `collect-providers.spec.ts` that does not
+ * exist — so every change to the skip contract had to be made in 18 places.
  *
  * Three deliberate differences from those copies, all of them the contract this
  * module already owns elsewhere:
  *
  *  - `IGNORE_PROVIDER_HEALTH=1` empties the map, so the escape hatch for a stale
  *    local `providers.json` now works for the parametrized specs too. It did not
- *    before, which made a local run of the agent family unrunnable off a days-old
- *    file even though `providerSkipGate` honoured the same variable.
+ *    before, even though `providerSkipGate` honoured the same variable, so a local
+ *    run had to delete the gitignored file to get a stale-`inactive` provider's
+ *    targets back. Local only: the variable is set in no workflow, script or config.
  *  - a nullable `error` produces "no reason recorded by collect-models" instead of
  *    the literal `inactive — null`.
- *  - the file is read once through `readProviderHealth`, which fails OPEN on an
- *    absent or unparseable file (a fresh clone has none — it is gitignored).
+ *  - the file is read via `readProviderHealth`, which fails OPEN on an absent or
+ *    unparseable file (a fresh clone has none — it is gitignored). Worth naming what
+ *    that widens: the copies THREW on malformed JSON, which surfaced as a loud
+ *    spec-load failure; these 18 specs now warn and run. That is the module's #980
+ *    contract — CI may legitimately run with a failed `Collect models` — but it does
+ *    apply to more specs than before.
  *
  * The `console.warn` on a missing file is kept from the majority of the copies: this
  * runs at collection time, and a local run with no `providers.json` should say why
  * every provider looks healthy.
+ *
+ * `records` and `jsonPath` exist for the unit tests, matching `readProviderHealth` /
+ * `writeProviderHealth`; every call site passes nothing. Explicit `null` means "no
+ * signal" and fails open, which is why the file read is keyed on `undefined` rather
+ * than on falsiness — and why the escape hatch is checked FIRST, so an armed hatch
+ * does not pay for a read it discards.
  */
 export function providerSkipReasons(
-  records: ProviderHealthRecord[] | null = readProviderHealth(),
+  records?: ProviderHealthRecord[] | null,
   env: NodeJS.ProcessEnv = process.env,
+  jsonPath?: string,
 ): Map<string, string> {
   const reasons = new Map<string, string>();
   if (env.IGNORE_PROVIDER_HEALTH === "1") return reasons;
-  if (!records) {
+  const resolved =
+    records === undefined ? readProviderHealth(jsonPath) : records;
+  if (!resolved) {
     console.warn(
       "providers.json not found or unreadable — run collect-models.spec.ts first. " +
         "Skipping provider pre-validation.",
     );
     return reasons;
   }
-  for (const record of records) {
+  for (const record of resolved) {
     if (record.status === "inactive") {
       reasons.set(record.provider, inactiveReason(record));
     }

--- a/tests/tests-automations/regression/core-functionality/llm-agents/CLAUDE.md
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/CLAUDE.md
@@ -34,9 +34,19 @@ await new SimpleAgentTemplatePage(page).load(options);
 ### 3. Parameterize the test by model (project standard)
 
 ```typescript
-import { getTestTargets } from "../../../../helpers/provider-setup"; // or inline as in agent-component-regression.spec.ts
+import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
 
-for (const { label, options, skipReason } of targets) {
+// The target list is built per spec from models.json — copy the `getTestTargets()`
+// in agent-component-regression.spec.ts. The inactive-provider skip map is NOT:
+// it is one shared implementation, and inlining a copy of it is the drift #1043
+// removed from 18 specs.
+function getTestTargets(): TestTarget[] {
+  const skipReasons = providerSkipReasons();
+  // ... filter models.json by MODEL_TEST_ID / MODEL_TEST_PROVIDER, then attach
+  // skipReasons.get(provider) as each target's skipReason
+}
+
+for (const { label, options, skipReason } of getTestTargets()) {
   test.describe.serial(`My Test [${label}]`, () => {
     test("should ...", async ({ page }) => {
       test.skip(!!skipReason, skipReason ?? "");
@@ -46,7 +56,7 @@ for (const { label, options, skipReason } of targets) {
 }
 ```
 
-This automatically creates one describe per model — the test runs for each model in `models.json`, respecting the `MODEL_TEST_ID` and `MODEL_TEST_PROVIDER` variables from `.env` (by priority).
+This automatically creates one describe per model — the test runs for each model in `models.json`, respecting the `MODEL_TEST_ID` and `MODEL_TEST_PROVIDER` variables from `.env` (by priority). The full pattern, including the strategy filter, is in `CONTRIBUTING.md` → **Model parameterization pattern**.
 
 ### 4. Handle MODEL_NOT_AVAILABLE
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
@@ -10,9 +10,9 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
 
 if (!process.env.CI) {
   dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
@@ -29,25 +29,6 @@ interface TestTarget {
   skipReason?: string;
 }
 
-function getProviderSkipReasons(): Map<string, string> {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/providers.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("providers.json not found — run collect-providers.spec.ts first. Skipping provider pre-validation.");
-    return new Map();
-  }
-  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
-  const reasons = new Map<string, string>();
-  for (const r of records) {
-    if (r.status === "inactive") {
-      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
-    }
-  }
-  return reasons;
-}
-
 function getModelsFromJson(): ModelRecord[] {
   const jsonPath = path.resolve(
     __dirname,
@@ -61,7 +42,7 @@ function getModelsFromJson(): ModelRecord[] {
 }
 
 function getTestTargets(): TestTarget[] {
-  const skipReasons = getProviderSkipReasons();
+  const skipReasons = providerSkipReasons();
 
   if (process.env.MODEL_TEST_ID) {
     const model = process.env.MODEL_TEST_ID;

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-continuity.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-continuity.spec.ts
@@ -20,7 +20,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
 
 /**
  * Agent context_id continuity (QA-CHECKLIST §6.3 "Agent uses custom
@@ -63,25 +63,6 @@ interface TestTarget {
   skipReason?: string;
 }
 
-function getProviderSkipReasons(): Map<string, string> {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/providers.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
-    return new Map();
-  }
-  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
-  const reasons = new Map<string, string>();
-  for (const r of records) {
-    if (r.status === "inactive") {
-      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
-    }
-  }
-  return reasons;
-}
-
 function getModelsFromJson(): ModelRecord[] {
   const jsonPath = path.resolve(
     __dirname,
@@ -95,7 +76,7 @@ function getModelsFromJson(): ModelRecord[] {
 }
 
 function getTestTargets(): TestTarget[] {
-  const skipReasons = getProviderSkipReasons();
+  const skipReasons = providerSkipReasons();
 
   if (process.env.MODEL_TEST_ID) {
     const model = process.env.MODEL_TEST_ID;

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts
@@ -20,7 +20,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
 
 /**
  * Agent context_id isolation (QA-CHECKLIST §6.3 "Switching context_id
@@ -66,25 +66,6 @@ interface TestTarget {
   skipReason?: string;
 }
 
-function getProviderSkipReasons(): Map<string, string> {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/providers.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
-    return new Map();
-  }
-  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
-  const reasons = new Map<string, string>();
-  for (const r of records) {
-    if (r.status === "inactive") {
-      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
-    }
-  }
-  return reasons;
-}
-
 function getModelsFromJson(): ModelRecord[] {
   const jsonPath = path.resolve(
     __dirname,
@@ -98,7 +79,7 @@ function getModelsFromJson(): ModelRecord[] {
 }
 
 function getTestTargets(): TestTarget[] {
-  const skipReasons = getProviderSkipReasons();
+  const skipReasons = providerSkipReasons();
 
   if (process.env.MODEL_TEST_ID) {
     const model = process.env.MODEL_TEST_ID;

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-current-date-tool.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-current-date-tool.spec.ts
@@ -18,7 +18,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
 
 /**
  * Agent current-date tool toggle (QA-CHECKLIST §6.5 "Toggle
@@ -71,25 +71,6 @@ interface TestTarget {
   skipReason?: string;
 }
 
-function getProviderSkipReasons(): Map<string, string> {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/providers.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
-    return new Map();
-  }
-  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
-  const reasons = new Map<string, string>();
-  for (const r of records) {
-    if (r.status === "inactive") {
-      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
-    }
-  }
-  return reasons;
-}
-
 function getModelsFromJson(): ModelRecord[] {
   const jsonPath = path.resolve(
     __dirname,
@@ -103,7 +84,7 @@ function getModelsFromJson(): ModelRecord[] {
 }
 
 function getTestTargets(): TestTarget[] {
-  const skipReasons = getProviderSkipReasons();
+  const skipReasons = providerSkipReasons();
 
   if (process.env.MODEL_TEST_ID) {
     const model = process.env.MODEL_TEST_ID;

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-empty-refusal-response.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-empty-refusal-response.spec.ts
@@ -10,9 +10,9 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
 
 /**
  * Agent robustness on a degenerate model output (QA-CHECKLIST §6.5,
@@ -50,25 +50,6 @@ interface TestTarget {
   skipReason?: string;
 }
 
-function getProviderSkipReasons(): Map<string, string> {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/providers.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
-    return new Map();
-  }
-  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
-  const reasons = new Map<string, string>();
-  for (const r of records) {
-    if (r.status === "inactive") {
-      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
-    }
-  }
-  return reasons;
-}
-
 function getModelsFromJson(): ModelRecord[] {
   const jsonPath = path.resolve(
     __dirname,
@@ -82,7 +63,7 @@ function getModelsFromJson(): ModelRecord[] {
 }
 
 function getTestTargets(): TestTarget[] {
-  const skipReasons = getProviderSkipReasons();
+  const skipReasons = providerSkipReasons();
 
   if (process.env.MODEL_TEST_ID) {
     const model = process.env.MODEL_TEST_ID;

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-input-sources.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-input-sources.spec.ts
@@ -12,7 +12,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
 
 /**
  * Validates that the Agent component accepts its `input_value` from either of
@@ -44,25 +44,6 @@ interface TestTarget {
   skipReason?: string;
 }
 
-function getProviderSkipReasons(): Map<string, string> {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/providers.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
-    return new Map();
-  }
-  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
-  const reasons = new Map<string, string>();
-  for (const r of records) {
-    if (r.status === "inactive") {
-      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
-    }
-  }
-  return reasons;
-}
-
 function getModelsFromJson(): ModelRecord[] {
   const jsonPath = path.resolve(
     __dirname,
@@ -76,7 +57,7 @@ function getModelsFromJson(): ModelRecord[] {
 }
 
 function getTestTargets(): TestTarget[] {
-  const skipReasons = getProviderSkipReasons();
+  const skipReasons = providerSkipReasons();
 
   if (process.env.MODEL_TEST_ID) {
     const model = process.env.MODEL_TEST_ID;

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-markdown-output.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-markdown-output.spec.ts
@@ -13,7 +13,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
 
 /**
  * Agent Markdown output (QA-CHECKLIST §6.5, "Agent returns output in correctly
@@ -64,25 +64,6 @@ interface TestTarget {
   skipReason?: string;
 }
 
-function getProviderSkipReasons(): Map<string, string> {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/providers.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
-    return new Map();
-  }
-  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
-  const reasons = new Map<string, string>();
-  for (const r of records) {
-    if (r.status === "inactive") {
-      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
-    }
-  }
-  return reasons;
-}
-
 function getModelsFromJson(): ModelRecord[] {
   const jsonPath = path.resolve(
     __dirname,
@@ -108,7 +89,7 @@ function resolveChatModel(provider: string, models: ModelRecord[]): string | und
 // MODEL_TEST_PROVIDER override (single provider); MODEL_TEST_ID (via
 // resolveChatModel) further pins the model when it belongs to that provider.
 function getTestTargets(): TestTarget[] {
-  const skipReasons = getProviderSkipReasons();
+  const skipReasons = providerSkipReasons();
   const allModels = getModelsFromJson();
 
   if (allModels.length === 0) {

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-max-iterations.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-max-iterations.spec.ts
@@ -15,7 +15,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
 
 /**
  * Agent Max Iterations (QA-CHECKLIST §6.2 "Agent stops when maximum number of
@@ -63,25 +63,6 @@ interface TestTarget {
   skipReason?: string;
 }
 
-function getProviderSkipReasons(): Map<string, string> {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/providers.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
-    return new Map();
-  }
-  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
-  const reasons = new Map<string, string>();
-  for (const r of records) {
-    if (r.status === "inactive") {
-      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
-    }
-  }
-  return reasons;
-}
-
 function getModelsFromJson(): ModelRecord[] {
   const jsonPath = path.resolve(
     __dirname,
@@ -95,7 +76,7 @@ function getModelsFromJson(): ModelRecord[] {
 }
 
 function getTestTargets(): TestTarget[] {
-  const skipReasons = getProviderSkipReasons();
+  const skipReasons = providerSkipReasons();
 
   if (process.env.MODEL_TEST_ID) {
     const model = process.env.MODEL_TEST_ID;

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-max-tokens.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-max-tokens.spec.ts
@@ -17,7 +17,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
 
 /**
  * Agent max_tokens (QA-CHECKLIST §6.2 "max_tokens truncates response as
@@ -56,25 +56,6 @@ interface TestTarget {
   skipReason?: string;
 }
 
-function getProviderSkipReasons(): Map<string, string> {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/providers.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
-    return new Map();
-  }
-  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
-  const reasons = new Map<string, string>();
-  for (const r of records) {
-    if (r.status === "inactive") {
-      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
-    }
-  }
-  return reasons;
-}
-
 function getModelsFromJson(): ModelRecord[] {
   const jsonPath = path.resolve(
     __dirname,
@@ -88,7 +69,7 @@ function getModelsFromJson(): ModelRecord[] {
 }
 
 function getTestTargets(): TestTarget[] {
-  const skipReasons = getProviderSkipReasons();
+  const skipReasons = providerSkipReasons();
 
   if (process.env.MODEL_TEST_ID) {
     const model = process.env.MODEL_TEST_ID;

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-multi-tool-selection.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-multi-tool-selection.spec.ts
@@ -13,7 +13,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
 
 /**
  * Agent multi-tool selection (QA-CHECKLIST §6.2 "Agent with multiple
@@ -84,25 +84,6 @@ interface TestTarget {
   skipReason?: string;
 }
 
-function getProviderSkipReasons(): Map<string, string> {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/providers.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
-    return new Map();
-  }
-  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
-  const reasons = new Map<string, string>();
-  for (const r of records) {
-    if (r.status === "inactive") {
-      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
-    }
-  }
-  return reasons;
-}
-
 function getModelsFromJson(): ModelRecord[] {
   const jsonPath = path.resolve(
     __dirname,
@@ -116,7 +97,7 @@ function getModelsFromJson(): ModelRecord[] {
 }
 
 function getTestTargets(): TestTarget[] {
-  const skipReasons = getProviderSkipReasons();
+  const skipReasons = providerSkipReasons();
 
   if (process.env.MODEL_TEST_ID) {
     const model = process.env.MODEL_TEST_ID;

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-multimodal-image-input.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-multimodal-image-input.spec.ts
@@ -13,7 +13,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
 
 /**
  * Agent multimodal image input (QA-CHECKLIST §6.5, "Image passed via input
@@ -108,25 +108,6 @@ function resolveVisionModel(provider: string, models: ModelRecord[]): string | u
   return candidates[0];
 }
 
-function getProviderSkipReasons(): Map<string, string> {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/providers.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
-    return new Map();
-  }
-  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
-  const reasons = new Map<string, string>();
-  for (const r of records) {
-    if (r.status === "inactive") {
-      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
-    }
-  }
-  return reasons;
-}
-
 function getModelsFromJson(): ModelRecord[] {
   const jsonPath = path.resolve(
     __dirname,
@@ -142,7 +123,7 @@ function getModelsFromJson(): ModelRecord[] {
 // One target per active provider, each with a resolved vision-capable model.
 // A provider with no vision model is skipped with a reason.
 function getTestTargets(): TestTarget[] {
-  const skipReasons = getProviderSkipReasons();
+  const skipReasons = providerSkipReasons();
   const allModels = getModelsFromJson();
 
   if (allModels.length === 0) {

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-structured-output.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-structured-output.spec.ts
@@ -13,7 +13,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
 
 /**
  * Agent structured output (QA-CHECKLIST §6.5 "Agent returns output in
@@ -55,25 +55,6 @@ interface TestTarget {
   skipReason?: string;
 }
 
-function getProviderSkipReasons(): Map<string, string> {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/providers.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
-    return new Map();
-  }
-  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
-  const reasons = new Map<string, string>();
-  for (const r of records) {
-    if (r.status === "inactive") {
-      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
-    }
-  }
-  return reasons;
-}
-
 function getModelsFromJson(): ModelRecord[] {
   const jsonPath = path.resolve(
     __dirname,
@@ -87,7 +68,7 @@ function getModelsFromJson(): ModelRecord[] {
 }
 
 function getTestTargets(): TestTarget[] {
-  const skipReasons = getProviderSkipReasons();
+  const skipReasons = providerSkipReasons();
 
   if (process.env.MODEL_TEST_ID) {
     const model = process.env.MODEL_TEST_ID;

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-system-prompt.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-system-prompt.spec.ts
@@ -12,7 +12,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
 
 if (!process.env.CI) {
   dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
@@ -39,25 +39,6 @@ interface TestTarget {
   skipReason?: string;
 }
 
-function getProviderSkipReasons(): Map<string, string> {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/providers.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
-    return new Map();
-  }
-  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
-  const reasons = new Map<string, string>();
-  for (const r of records) {
-    if (r.status === "inactive") {
-      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
-    }
-  }
-  return reasons;
-}
-
 function getModelsFromJson(): ModelRecord[] {
   const jsonPath = path.resolve(
     __dirname,
@@ -71,7 +52,7 @@ function getModelsFromJson(): ModelRecord[] {
 }
 
 function getTestTargets(): TestTarget[] {
-  const skipReasons = getProviderSkipReasons();
+  const skipReasons = providerSkipReasons();
 
   if (process.env.MODEL_TEST_ID) {
     const model = process.env.MODEL_TEST_ID;

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-error-handling.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-error-handling.spec.ts
@@ -14,7 +14,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
 
 /**
  * Agent tool error handling (QA-CHECKLIST §6.4 "Tool returns error — agent
@@ -59,25 +59,6 @@ interface TestTarget {
   skipReason?: string;
 }
 
-function getProviderSkipReasons(): Map<string, string> {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/providers.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
-    return new Map();
-  }
-  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
-  const reasons = new Map<string, string>();
-  for (const r of records) {
-    if (r.status === "inactive") {
-      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
-    }
-  }
-  return reasons;
-}
-
 function getModelsFromJson(): ModelRecord[] {
   const jsonPath = path.resolve(
     __dirname,
@@ -91,7 +72,7 @@ function getModelsFromJson(): ModelRecord[] {
 }
 
 function getTestTargets(): TestTarget[] {
-  const skipReasons = getProviderSkipReasons();
+  const skipReasons = providerSkipReasons();
 
   if (process.env.MODEL_TEST_ID) {
     const model = process.env.MODEL_TEST_ID;

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-inspection.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-inspection.spec.ts
@@ -13,7 +13,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
 
 /**
  * Agent tool inspection (QA-CHECKLIST §6.5 "Inspect tools used by Agent in
@@ -70,25 +70,6 @@ interface TestTarget {
   skipReason?: string;
 }
 
-function getProviderSkipReasons(): Map<string, string> {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/providers.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
-    return new Map();
-  }
-  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
-  const reasons = new Map<string, string>();
-  for (const r of records) {
-    if (r.status === "inactive") {
-      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
-    }
-  }
-  return reasons;
-}
-
 function getModelsFromJson(): ModelRecord[] {
   const jsonPath = path.resolve(
     __dirname,
@@ -102,7 +83,7 @@ function getModelsFromJson(): ModelRecord[] {
 }
 
 function getTestTargets(): TestTarget[] {
-  const skipReasons = getProviderSkipReasons();
+  const skipReasons = providerSkipReasons();
 
   if (process.env.MODEL_TEST_ID) {
     const model = process.env.MODEL_TEST_ID;

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-name-validation.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-name-validation.spec.ts
@@ -14,7 +14,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
 
 /**
  * Agent tool name validation (QA-CHECKLIST §6.4 "Tool with invalid name —
@@ -61,25 +61,6 @@ interface TestTarget {
   skipReason?: string;
 }
 
-function getProviderSkipReasons(): Map<string, string> {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/providers.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("providers.json not found — run collect-models.spec.ts first. Skipping provider pre-validation.");
-    return new Map();
-  }
-  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
-  const reasons = new Map<string, string>();
-  for (const r of records) {
-    if (r.status === "inactive") {
-      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
-    }
-  }
-  return reasons;
-}
-
 function getModelsFromJson(): ModelRecord[] {
   const jsonPath = path.resolve(
     __dirname,
@@ -93,7 +74,7 @@ function getModelsFromJson(): ModelRecord[] {
 }
 
 function getTestTargets(): TestTarget[] {
-  const skipReasons = getProviderSkipReasons();
+  const skipReasons = providerSkipReasons();
 
   if (process.env.MODEL_TEST_ID) {
     const model = process.env.MODEL_TEST_ID;

--- a/tests/tests-automations/regression/mcp/client/mcp-client-agent-gemini-tool-regression.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-agent-gemini-tool-regression.spec.ts
@@ -1,11 +1,10 @@
 import * as dotenv from "dotenv";
 import path from "path";
-import fs from "fs";
 import type { Page, APIRequestContext } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
 import { hasProviderEnvKeys, missingProviderEnvKeys } from "../../../../helpers/provider-setup";
-import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
+import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
 import { resolveGeminiModel } from "../../../../helpers/provider-setup/resolve-gemini-model";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
@@ -61,21 +60,6 @@ const MCP_JSON_CONFIG = JSON.stringify({
 const PROVIDER = "google" as const;
 const ECHO_PAYLOAD = "hello mcp";
 
-// Google provider inactive-status reason from providers.json (collect-models),
-// mirroring the sibling specs' skip contract.
-function getGoogleSkipReason(): string | undefined {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/providers.json",
-  );
-  if (!fs.existsSync(jsonPath)) return undefined;
-  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
-  const record = records.find((r) => r.provider === PROVIDER);
-  return record?.status === "inactive"
-    ? `Provider "${PROVIDER}" inactive — ${record.error}`
-    : undefined;
-}
-
 let createdFlowId: string | undefined;
 
 async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
@@ -130,7 +114,7 @@ async function fetchPersistedAgentTurn(
   return { replyText, echoToolUseCount };
 }
 
-const skipReason = getGoogleSkipReason();
+const skipReason = providerSkipReasons().get(PROVIDER);
 const geminiModel = resolveGeminiModel();
 
 test.describe(`MCP Client – Gemini tool regression (#440) [${PROVIDER} / ${geminiModel ?? "default"}]`, () => {

--- a/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
@@ -10,10 +10,10 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import type { ProviderRecord } from "../../../../helpers/provider-setup/collect-models";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
 
 if (!process.env.CI) {
   dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
@@ -43,22 +43,6 @@ interface TestTarget {
   skipReason?: string;
 }
 
-function getProviderSkipReasons(): Map<string, string> {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/providers.json",
-  );
-  if (!fs.existsSync(jsonPath)) return new Map();
-  const records = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ProviderRecord[];
-  const reasons = new Map<string, string>();
-  for (const r of records) {
-    if (r.status === "inactive") {
-      reasons.set(r.provider, `Provider "${r.provider}" inactive — ${r.error}`);
-    }
-  }
-  return reasons;
-}
-
 function getModelsFromJson(): ModelRecord[] {
   const jsonPath = path.resolve(
     __dirname,
@@ -69,7 +53,7 @@ function getModelsFromJson(): ModelRecord[] {
 }
 
 function getTestTargets(): TestTarget[] {
-  const skipReasons = getProviderSkipReasons();
+  const skipReasons = providerSkipReasons();
 
   if (process.env.MODEL_TEST_ID) {
     const model = process.env.MODEL_TEST_ID;


### PR DESCRIPTION
**Fixes #1043.**

## Problem

#1029 made `provider-health.ts` the single implementation of the provider-health skip rule and pointed the provider-**hardcoded** specs at it (PR #1042). The provider-**parametrized** specs got there first, and each carried its own inline copy:

- 16 `agent-*.spec.ts` files + `mcp/client/mcp-client-agent.spec.ts` → `getProviderSkipReasons(): Map<string, string>`
- `mcp/client/mcp-client-agent-gemini-tool-regression.spec.ts` → a single-provider `getGoogleSkipReason()` variant

**18 call sites**, not the 19+1 the issue's title counts — the issue body enumerates only 16 `agent-*` names, and this PR corrects the arithmetic rather than propagating it.

Nothing was broken: the copies honour provider health correctly. The cost is that the skip contract lived in 18 places — and they had **already drifted**, measurably on `main`:

| copies | behaviour on a missing `providers.json` |
|---|---|
| 15 | `console.warn("… run collect-models.spec.ts first …")` |
| 1 (`agent-component-regression`) | warns about **`collect-providers.spec.ts`**, a spec that does not exist |
| 1 (`mcp-client-agent`) | silent |
| 1 (the gemini variant) | silent, single-provider shape |

None honoured `IGNORE_PROVIDER_HEALTH`, and all rendered a nullable `error` as the literal `inactive — null`.

## Fix

One exported `providerSkipReasons()` in `provider-health.ts` replaces all 18, unit-tested alongside the existing matrix. **Net −199 lines** across the specs.

Three deliberate differences from the copies, each of them the contract this module already owned elsewhere:

1. **`IGNORE_PROVIDER_HEALTH=1` empties the map.** The escape hatch for a stale local `providers.json` now works for the parametrized specs too; before, getting a stale-`inactive` provider's targets back meant deleting the gitignored file, even though `providerSkipGate` honoured the same variable. **Verified safe:** the variable is set in no workflow, no script, `playwright.config.ts`, `globalSetup` or `.env.example` — it appears only in `docs/`, as a local override. CI cannot un-skip a dead-key provider through it.
2. **A nullable `error`** reads `no reason recorded by collect-models` instead of `inactive — null`.
3. **The read goes through `readProviderHealth`**, which fails OPEN on an absent or unparseable file. Named explicitly in the doc comment because it *widens* something: the copies **threw** on malformed JSON (a loud spec-load failure), while these 18 specs now warn and run. That is the module's #980 contract, but it applies to more specs than before.

The reason string is built once (`inactiveReason`) and shared with `unavailableReason`, so the parametrized and hardcoded gates cannot drift apart in what they quote to the report — a unit test pins that they agree for the same record.

Two docs that would have re-created the problem are fixed in the same PR:

- **`CONTRIBUTING.md` → "Model parameterization pattern"** handed the next author the inline copy verbatim, including the `ProviderRecord` import this PR prunes. After the dedupe it was the only remaining occurrence of `getProviderSkipReasons` in the repo. It now shows the shared call.
- **`docs/collect-models.md` → "Who consumes the recorded health"** described the two families as separate mechanisms and scoped the escape hatch to the hardcoded one. Both are false as of this commit; it now says both families share `provider-health.ts`, and carries a warning that a stray `IGNORE_PROVIDER_HEALTH=1` in a developer's `.env` will send the whole agent family at a dead key locally.

## Scope note

No test logic, tags, spec docs or `QA-CHECKLIST` bullets change — every touched spec keeps its behaviour and its tags. Both checklist guards are green.

**Selector reach, and a gap I closed by hand:** `tests/helpers/**` is in the import graph, so this selects **35 specs**; at `IMPACTED_SPEC_CAP=20` the job runs 20 and lists 15 dropped — and **both `mcp/client` files are in the dropped set**. Those are precisely the two non-mechanical rewrites (the silent copy and the single-provider variant), so I ran both locally; results below. Note also that `mcp-client-agent.spec.ts` carries no `@stable`, so the issue's rationale ("every touched spec is `@stable`, so the change is visible in the next daily") does not hold for it — another reason it is covered here by hand.

## Validation (nightly 1.12.0.dev10, `--workers=1 --retries=0`)

- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors; warnings 1307 → 1306) · `npm run test:units` ✅ **147/147** · `npm run test:scripts` ✅ 147/147 · `npm run check:checklist-coverage` ✅ · checklist guard ✅
- **11 new unit tests** on `providerSkipReasons` (41 in the file): the inactive→reason mapping, active providers absent from the map, fail-open on `null`/`[]`, the escape hatch and its exact-`"1"` contract, the nullable-`error` line, parity with `unavailableReason` for the same record, independence from env keys, that the zero-argument form really reads the file, that an armed hatch skips the read entirely, and that a missing file warns.
- **Mutation-tested**, after the review found three survivors — all three now fail: pointing the default at `null` so the file is never read (#1029's failure mode, restorable by a one-word edit), deleting the `console.warn`, and loosening the hatch to any truthy value. The `records` / `jsonPath` test seam this needed matches the one `readProviderHealth` and `writeProviderHealth` already take.
- **Behavioural parity, proven end to end** by marking `openai` inactive in the local (gitignored) `providers.json` with a sentinel error:
  - the target skips and the report carries `Provider "openai" inactive — SENTINEL-1043: pretend drained key` — identical in shape to what the inline copies produced (`2 skipped`);
  - re-running the same target with `IGNORE_PROVIDER_HEALTH=1` **runs and passes (24.1s)** — the behaviour change, demonstrated rather than asserted.
- Live runs on the restored `providers.json`:
  - `agent-max-tokens` + `mcp-client-agent-gemini-tool-regression` → **2 passed, 1 skipped (41.4s)** (re-run after the review restructure). The skip is the gemini spec, because this machine's `collect-models` records google `inactive` ("no models collected from the providers panel") — the shared gate firing for real, on the file's default path.
  - `mcp-client-agent.spec.ts` → **1 passed (26.4s)** (the file the CI cap drops and the daily never runs).
- Zero `🚨 Backend Error`.

## Done when

- [x] `provider-health.ts` exports the parametrized reason map; `provider-health.test.ts` covers it
- [x] All inline `getProviderSkipReasons()` copies and the `getGoogleSkipReason()` variant are gone (`git grep` → 0, including the one that lived in `CONTRIBUTING.md`)
- [x] The `fs` / `path` / `ProviderRecord` imports they pulled in are dropped where now unused (`ProviderRecord` in all 18; `fs` only in the gemini file, where it became unused; `path`/`fs` retained wherever `getModelsFromJson` still needs them)
- [x] `typecheck`, `lint`, `test:units` clean; the touched specs behave identically on a run with one provider inactive — proven above for both the parametrized family and the hardcoded gemini variant

Closes #1043
