### PR TITLE
refactor(flows): extract the flow-cleanup tracker, and migrate one area onto it (#1108)

### DIFF
--- a/docs/core-functionality/project-management/flowSettings.md
+++ b/docs/core-functionality/project-management/flowSettings.md
@@ -119,7 +119,11 @@ enforcement, the save round-trip, or the persistence fails a specific step.
 
 ## Flow cleanup
 
-The test creates one blank flow; its id is captured from the canvas URL and an
-`afterEach` deletes it id-scoped (404-tolerant) via the API, so the instance is
-not polluted across runs. Behavioral force-fail: no-op the cleanup and the flow
-count grows.
+The test creates one blank flow. Its id comes from the `POST /api/v1/flows` → 201
+**response**, not from the canvas URL — the URL races the bootstrap flow's stale id
+(blank-flow opens behind the templates modal), which is what previously deleted the
+wrong flow and leaked the renamed one. Capture and teardown are the shared
+`trackCreatedFlows` helper since #1108, so the `afterEach` deletes id-scoped
+(404-tolerant) via the API and reports a failed delete instead of swallowing it.
+Behavioral force-fail: stop the tracker from matching the creation endpoint and the
+flow count grows while the test still passes.

--- a/tests/helpers/flows/track-created-flows.test.ts
+++ b/tests/helpers/flows/track-created-flows.test.ts
@@ -10,14 +10,17 @@
 // The four behaviours these tests pin are the four axes on which the 51 hand-copied
 // versions had drifted. Each one is a real leak or a real silence:
 //
-//   1. bodies are settled before cleanup — 45 copies dropped an id that resolved a
-//      tick late, and the last test in a worker has no later hook to sweep it;
+//   1. bodies are settled before cleanup — 50 of the 51 copies dropped an id that
+//      resolved a tick late, and the last test in a worker has no later hook;
 //   2. the URL match is the exact creation endpoint — `/flows/batch/` and
 //      `/flows/upload/` also answer 201;
 //   3. the page leaves the canvas BEFORE the delete — a mounted editor 404s on the
 //      flow it is polling (#1023/#1103);
-//   4. a failed delete is reported, not swallowed — 48 copies wrote
-//      `.catch(() => {})` over the one signal `deleteFlow` exists to raise.
+//   4. a failed delete is reported, not swallowed — the copies that wrote
+//      `.catch(() => {})` buried the one signal `deleteFlow` exists to raise. That
+//      axis is three-way, though (swallow / log / throw), and no count for it is
+//      restated here — see the implementation's header. `{ strict: true }` is what
+//      keeps a spec that used to FAIL on a failed cleanup failing.
 //
 // The fakes below are the whole point of the narrow `TrackedPage` /
 // `TrackedResponse` types: the tracker drives real `deleteFlow` and real
@@ -184,7 +187,7 @@ test("a failed creation POST is recorded synchronously, without its body", async
 // ─── Axis 1: settle before cleanup — the permanent-leak case ─────────────────
 
 test("cleanup settles a body that resolves AFTER teardown starts", async () => {
-  // The defect in 45 of the 51 copies: `resp.json()` resolves a tick later, so an
+  // The defect in 50 of the 51 copies: `resp.json()` resolves a tick later, so an
   // id could land after `afterEach` had already read the array — and the flow leaks
   // for good, because the last test in a worker has no later hook.
   const { page, emit } = fakePage();
@@ -304,4 +307,155 @@ test("dispose detaches the listener it attached", () => {
   const { page, isDetached } = fakePage();
   trackCreatedFlows(page).dispose();
   assert.equal(isDetached(), true);
+});
+
+// ─── strict mode: the third shape of the failed-delete axis ─────────────────
+
+test("strict re-throws a failed delete, for a spec whose teardown used to fail", () => {
+  // 13 of the 51 copies let `deleteFlow` throw, which fails the teardown — the
+  // strongest of the three signals, and chosen deliberately in some files
+  // ("Cleanup is load-bearing here … so the throw is intentionally NOT swallowed").
+  // Migrating one of those onto the default would trade a red test for a warning
+  // line nothing asserts on.
+  const { page, emit } = fakePage();
+  const { request } = fakeRequest({ failFor: new Set(["flow-1"]), status: 422 });
+  const flows = trackCreatedFlows(page);
+  emit(creationResponse("flow-1"));
+  return assert.rejects(() => flows.cleanup(request, { strict: true }), /422/);
+});
+
+test("strict still logs and records before re-throwing", async () => {
+  const { page, emit } = fakePage();
+  const { request } = fakeRequest({ failFor: new Set(["flow-1"]), status: 422 });
+  const flows = trackCreatedFlows(page);
+  emit(creationResponse("flow-1"));
+  await flows.cleanup(request, { strict: true }).catch(() => {});
+  // The captured id is cleared either way, so a retried teardown does not re-delete.
+  assert.deepEqual(flows.ids(), []);
+});
+
+test("strict is opt-in — the default never throws", async () => {
+  const { page, emit } = fakePage();
+  const { request } = fakeRequest({ failFor: new Set(["flow-1"]), status: 422 });
+  const flows = trackCreatedFlows(page);
+  emit(creationResponse("flow-1"));
+  const result = await flows.cleanup(request); // must not reject
+  assert.equal(result.failed.length, 1);
+});
+
+// ─── An unobtainable token is named, not silently degraded ──────────────────
+
+test("a getAuthToken failure is reported as itself, not as a flow problem", async () => {
+  // `get-auth-token.ts` forbids degrading into the empty-token fallback (#1086):
+  // callers would carry on unauthenticated and fail somewhere far less diagnosable.
+  // `cleanup` still may not throw, so the failure has to be NAMED on the result —
+  // otherwise a backend wedged during teardown (#1077) produces one 401 per flow and
+  // a report that blames the flows.
+  const { page, emit } = fakePage();
+  const flows = trackCreatedFlows(page);
+  const request = {
+    get: async () => {
+      throw new Error("apiRequestContext.get: Timeout 20000ms exceeded.");
+    },
+    delete: async () => ({
+      ok: () => false,
+      status: () => 401,
+      statusText: () => "Unauthorized",
+      text: async () => "",
+    }),
+  } as unknown as APIRequestContext;
+
+  emit(creationResponse("flow-1"));
+  const result = await flows.cleanup(request);
+
+  assert.match(String(result.authError), /Timeout 20000ms/);
+  assert.equal(result.failed.length, 1, "the delete was still attempted");
+});
+
+test("no token in an auth-less environment is not an auth ERROR", async () => {
+  // `getAuthToken` RETURNS "" when the endpoint answers non-ok — that is an
+  // environment without auth, not an outage, and it must not be reported as one.
+  const { page, emit } = fakePage();
+  const { request, deletes } = fakeRequest({ token: null });
+  const flows = trackCreatedFlows(page);
+  emit(creationResponse("flow-1"));
+  const result = await flows.cleanup(request);
+  assert.equal(result.authError, undefined);
+  assert.equal(deletes[0].auth, undefined, "no Authorization header is sent");
+});
+
+// ─── The remaining unpinned guards ──────────────────────────────────────────
+
+test("a successful capture leaves failedCreations EMPTY", async () => {
+  // `failedCreations()` is what a setup step reads to attribute its own failure
+  // (#1114). A false positive there makes a spec blame a 5xx that never happened.
+  const { page, emit } = fakePage();
+  const flows = trackCreatedFlows(page);
+  emit(creationResponse("flow-1"));
+  await flows.settle();
+  assert.deepEqual(flows.failedCreations(), []);
+});
+
+test("a 4xx creation is recorded too, not only a 5xx", async () => {
+  const { page, emit } = fakePage();
+  const flows = trackCreatedFlows(page);
+  emit({
+    url: () => `${BASE}/api/v1/flows/`,
+    status: () => 422,
+    statusText: () => "Unprocessable Entity",
+    request: () => ({ method: () => "POST" }),
+    json: async () => ({}),
+  });
+  assert.deepEqual(flows.failedCreations(), ["422 Unprocessable Entity"]);
+});
+
+test("failedCreations hands out a copy, not the live array", async () => {
+  const { page, emit } = fakePage();
+  const flows = trackCreatedFlows(page);
+  emit(creationResponse(undefined, { status: 500 }));
+  flows.failedCreations().push("injected");
+  assert.deepEqual(flows.failedCreations(), ["500 Internal Server Error"]);
+});
+
+test("a page that is already gone does not break the teardown", async () => {
+  // The teardown-after-crash path: `page.goto` on a closed page REJECTS.
+  const { page, emit } = fakePage();
+  (page as unknown as { goto: () => Promise<never> }).goto = async () => {
+    throw new Error("Target page, context or browser has been closed");
+  };
+  const { request, deletes } = fakeRequest();
+  const flows = trackCreatedFlows(page);
+  emit(creationResponse("flow-1"));
+  const result = await flows.cleanup(request);
+  assert.deepEqual(result.deleted, ["flow-1"], "the delete must still happen");
+  assert.equal(deletes.length, 1);
+});
+
+test("a body that cannot be parsed drops that id instead of breaking the sweep", async () => {
+  const { page, emit } = fakePage();
+  const { request } = fakeRequest();
+  const flows = trackCreatedFlows(page);
+  emit({
+    url: () => `${BASE}/api/v1/flows/`,
+    status: () => 201,
+    statusText: () => "Created",
+    request: () => ({ method: () => "POST" }),
+    json: async () => {
+      throw new Error("Response body is unavailable for redirect responses");
+    },
+  });
+  emit(creationResponse("flow-2"));
+  const result = await flows.cleanup(request);
+  assert.deepEqual(result.deleted, ["flow-2"]);
+});
+
+test("settle() drains the queue, so a later cleanup does not re-await it", async () => {
+  const { page, emit } = fakePage();
+  const { request, deletes } = fakeRequest();
+  const flows = trackCreatedFlows(page);
+  emit(creationResponse("flow-1", { delayTicks: 3 }));
+  await flows.settle();
+  assert.deepEqual(flows.ids(), ["flow-1"]);
+  await flows.cleanup(request);
+  assert.deepEqual(deletes.map((d) => d.url), ["/api/v1/flows/flow-1"]);
 });

--- a/tests/helpers/flows/track-created-flows.test.ts
+++ b/tests/helpers/flows/track-created-flows.test.ts
@@ -334,6 +334,52 @@ test("strict still logs and records before re-throwing", async () => {
   assert.deepEqual(flows.ids(), []);
 });
 
+test("strict finishes the sweep BEFORE throwing, so nothing leaks behind the throw", async () => {
+  // The captured ids are taken out of the tracker at the top of `cleanup`, so a throw
+  // on the FIRST failure leaves the rest neither deleted nor tracked — a permanent
+  // leak in the mode whose entire premise is that cleanup is load-bearing. Every id
+  // must be attempted; the failure is raised afterwards.
+  const { page, emit } = fakePage();
+  const { request, deletes } = fakeRequest({ failFor: new Set(["flow-1"]), status: 422 });
+  const flows = trackCreatedFlows(page);
+
+  emit(creationResponse("flow-1"));
+  emit(creationResponse("flow-2"));
+  emit(creationResponse("flow-3"));
+
+  await assert.rejects(() => flows.cleanup(request, { strict: true }), /422/);
+  assert.deepEqual(
+    deletes.map((d) => d.url),
+    [
+      "/api/v1/flows/flow-1",
+      "/api/v1/flows/flow-2",
+      "/api/v1/flows/flow-3",
+    ],
+    "the two flows after the failing one must still be deleted",
+  );
+});
+
+test("strict aggregates when more than one delete fails, naming every id", async () => {
+  const { page, emit } = fakePage();
+  const { request } = fakeRequest({ failFor: new Set(["flow-1", "flow-3"]), status: 403 });
+  const flows = trackCreatedFlows(page);
+
+  emit(creationResponse("flow-1"));
+  emit(creationResponse("flow-2"));
+  emit(creationResponse("flow-3"));
+
+  await assert.rejects(
+    () => flows.cleanup(request, { strict: true }),
+    (error: unknown) => {
+      assert.ok(error instanceof AggregateError, "several failures aggregate");
+      assert.equal(error.errors.length, 2);
+      assert.match(error.message, /flow-1/);
+      assert.match(error.message, /flow-3/);
+      return true;
+    },
+  );
+});
+
 test("strict is opt-in — the default never throws", async () => {
   const { page, emit } = fakePage();
   const { request } = fakeRequest({ failFor: new Set(["flow-1"]), status: 422 });
@@ -351,6 +397,10 @@ test("a getAuthToken failure is reported as itself, not as a flow problem", asyn
   // `cleanup` still may not throw, so the failure has to be NAMED on the result —
   // otherwise a backend wedged during teardown (#1077) produces one 401 per flow and
   // a report that blames the flows.
+  //
+  // `authRetryDelaysMs: []` for the reason the option exists: `getAuthToken` retries a
+  // THROWN request on the real `[2000, 8000, 20000]` backoff, so without it this one
+  // test sleeps 30 s and becomes the critical path of a lane that gates every PR.
   const { page, emit } = fakePage();
   const flows = trackCreatedFlows(page);
   const request = {
@@ -366,10 +416,34 @@ test("a getAuthToken failure is reported as itself, not as a flow problem", asyn
   } as unknown as APIRequestContext;
 
   emit(creationResponse("flow-1"));
-  const result = await flows.cleanup(request);
+  const result = await flows.cleanup(request, { authRetryDelaysMs: [] });
 
   assert.match(String(result.authError), /Timeout 20000ms/);
   assert.equal(result.failed.length, 1, "the delete was still attempted");
+});
+
+test("the auth backoff is getAuthToken's own unless a test overrides it", async () => {
+  // The override must stay opt-in: a spec that does not pass it has to keep the full
+  // budget, which is what survives a backend wedged during teardown (#1077).
+  const { page, emit } = fakePage();
+  const flows = trackCreatedFlows(page);
+  let attempts = 0;
+  const request = {
+    get: async () => {
+      attempts++;
+      throw new Error("apiRequestContext.get: Timeout 20000ms exceeded.");
+    },
+    delete: async () => ({
+      ok: () => true,
+      status: () => 204,
+      statusText: () => "No Content",
+      text: async () => "",
+    }),
+  } as unknown as APIRequestContext;
+
+  emit(creationResponse("flow-1"));
+  await flows.cleanup(request, { authRetryDelaysMs: [] });
+  assert.equal(attempts, 1, "an empty budget means one attempt, no sleeping");
 });
 
 test("no token in an auth-less environment is not an auth ERROR", async () => {

--- a/tests/helpers/flows/track-created-flows.test.ts
+++ b/tests/helpers/flows/track-created-flows.test.ts
@@ -1,0 +1,307 @@
+// Unit tests for the shared flow-cleanup tracker (issue #1108).
+// Run with: npm run test:units
+//
+// What rides on this helper: it is the only thing standing between the suite and a
+// database that accumulates every flow every test creates. A defect here surfaces
+// as someone else's random failure — a `/flows` list slow enough to time out, a
+// name-scoped lookup matching a leftover — never as a failing test of its own,
+// which is exactly the class `CONTRIBUTING.md` → *Unit tests* says to cover here.
+//
+// The four behaviours these tests pin are the four axes on which the 51 hand-copied
+// versions had drifted. Each one is a real leak or a real silence:
+//
+//   1. bodies are settled before cleanup — 45 copies dropped an id that resolved a
+//      tick late, and the last test in a worker has no later hook to sweep it;
+//   2. the URL match is the exact creation endpoint — `/flows/batch/` and
+//      `/flows/upload/` also answer 201;
+//   3. the page leaves the canvas BEFORE the delete — a mounted editor 404s on the
+//      flow it is polling (#1023/#1103);
+//   4. a failed delete is reported, not swallowed — 48 copies wrote
+//      `.catch(() => {})` over the one signal `deleteFlow` exists to raise.
+//
+// The fakes below are the whole point of the narrow `TrackedPage` /
+// `TrackedResponse` types: the tracker drives real `deleteFlow` and real
+// `getAuthToken` against a fake `APIRequestContext`, so the integration is covered
+// without a browser or a backend.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { APIRequestContext } from "@playwright/test";
+import {
+  flowIdFrom,
+  isFlowCreateUrl,
+  trackCreatedFlows,
+  type TrackedPage,
+  type TrackedResponse,
+} from "./track-created-flows";
+
+const BASE = "http://localhost:7860";
+
+/** A `page` that records what the tracker does to it. */
+function fakePage() {
+  let listener: ((response: TrackedResponse) => void) | undefined;
+  const navigations: string[] = [];
+  let detached = false;
+  const page = {
+    on: (event: string, fn: unknown) => {
+      if (event === "response") listener = fn as typeof listener;
+      return page;
+    },
+    off: (event: string, fn: unknown) => {
+      if (event === "response" && fn === listener) detached = true;
+      return page;
+    },
+    goto: async (url: string) => {
+      navigations.push(url);
+      return null;
+    },
+  };
+  return {
+    page: page as unknown as TrackedPage,
+    navigations,
+    isDetached: () => detached,
+    emit: (response: TrackedResponse) => listener?.(response),
+  };
+}
+
+/** A 201 response for `POST /api/v1/flows/`, with a controllable body delay. */
+function creationResponse(
+  id: string | undefined,
+  {
+    url = `${BASE}/api/v1/flows/`,
+    method = "POST",
+    status = 201,
+    delayTicks = 0,
+    body,
+  }: {
+    url?: string;
+    method?: string;
+    status?: number;
+    delayTicks?: number;
+    body?: unknown;
+  } = {},
+): TrackedResponse {
+  return {
+    url: () => url,
+    status: () => status,
+    statusText: () => (status === 201 ? "Created" : "Internal Server Error"),
+    request: () => ({ method: () => method }),
+    json: async () => {
+      for (let i = 0; i < delayTicks; i++) await Promise.resolve();
+      return body !== undefined ? body : { id };
+    },
+  };
+}
+
+/** A `request` that answers auto_login and records the DELETEs it receives. */
+function fakeRequest({
+  failFor = new Set<string>(),
+  status = 500,
+  token = "tok-123",
+}: { failFor?: Set<string>; status?: number; token?: string | null } = {}) {
+  const deletes: Array<{ url: string; auth?: string }> = [];
+  const request = {
+    get: async (url: string) => {
+      assert.equal(url, "/api/v1/auto_login", "the tracker must not call other GETs");
+      return {
+        ok: () => token !== null,
+        status: () => (token === null ? 500 : 200),
+        json: async () => ({ access_token: token }),
+      };
+    },
+    delete: async (url: string, options?: { headers?: Record<string, string> }) => {
+      deletes.push({ url, auth: options?.headers?.Authorization });
+      const id = url.split("/").pop() ?? "";
+      const failed = failFor.has(id);
+      return {
+        ok: () => !failed,
+        status: () => (failed ? status : 204),
+        statusText: () => (failed ? "Server Error" : "No Content"),
+        text: async () => (failed ? "boom" : ""),
+      };
+    },
+  };
+  return { request: request as unknown as APIRequestContext, deletes };
+}
+
+// ─── The URL match (axis 2) ──────────────────────────────────────────────────
+
+test("only the exact creation endpoint is a flow creation", () => {
+  assert.equal(isFlowCreateUrl(`${BASE}/api/v1/flows/`), true);
+  assert.equal(isFlowCreateUrl(`${BASE}/api/v1/flows`), true);
+  assert.equal(isFlowCreateUrl(`${BASE}/api/v1/flows/?folder_id=x`), true, "a query string is not part of the path");
+  // These answer 201 too, with a list body carrying no top-level id.
+  assert.equal(isFlowCreateUrl(`${BASE}/api/v1/flows/batch/`), false);
+  assert.equal(isFlowCreateUrl(`${BASE}/api/v1/flows/upload/`), false);
+  assert.equal(isFlowCreateUrl(`${BASE}/api/v1/flows/abc-123`), false);
+  assert.equal(isFlowCreateUrl("not a url"), false);
+});
+
+test("a body without a usable id yields no id", () => {
+  assert.equal(flowIdFrom({ id: "abc" }), "abc");
+  for (const body of [undefined, null, {}, { id: "" }, { id: 7 }, [{ id: "a" }]]) {
+    assert.equal(flowIdFrom(body), undefined, `unexpected id for ${JSON.stringify(body)}`);
+  }
+});
+
+// ─── Capture ─────────────────────────────────────────────────────────────────
+
+test("captures the created flow ids, ignoring everything else", async () => {
+  const { page, emit } = fakePage();
+  const flows = trackCreatedFlows(page);
+
+  emit(creationResponse("flow-1"));
+  emit(creationResponse("flow-2"));
+  emit(creationResponse("ignored", { method: "GET" }));
+  emit(creationResponse("ignored", { url: `${BASE}/api/v1/flows/batch/` }));
+  emit(creationResponse("ignored", { status: 200 }));
+  await flows.settle();
+
+  assert.deepEqual(flows.ids(), ["flow-1", "flow-2"]);
+});
+
+test("the same id observed twice is captured once", async () => {
+  // A replayed or redirected response would otherwise queue two DELETEs; the
+  // second one 404s, which `deleteFlow` treats as done — hiding a real double
+  // creation behind noise instead of surfacing it.
+  const { page, emit } = fakePage();
+  const flows = trackCreatedFlows(page);
+  emit(creationResponse("flow-1"));
+  emit(creationResponse("flow-1"));
+  await flows.settle();
+  assert.deepEqual(flows.ids(), ["flow-1"]);
+});
+
+test("a failed creation POST is recorded synchronously, without its body", async () => {
+  const { page, emit } = fakePage();
+  const flows = trackCreatedFlows(page);
+  emit(creationResponse(undefined, { status: 500 }));
+  // No settle: the point is that this is available immediately, before the setup
+  // step that consults it (#1114).
+  assert.deepEqual(flows.failedCreations(), ["500 Internal Server Error"]);
+  assert.deepEqual(flows.ids(), []);
+});
+
+// ─── Axis 1: settle before cleanup — the permanent-leak case ─────────────────
+
+test("cleanup settles a body that resolves AFTER teardown starts", async () => {
+  // The defect in 45 of the 51 copies: `resp.json()` resolves a tick later, so an
+  // id could land after `afterEach` had already read the array — and the flow leaks
+  // for good, because the last test in a worker has no later hook.
+  const { page, emit } = fakePage();
+  const { request, deletes } = fakeRequest();
+  const flows = trackCreatedFlows(page);
+
+  emit(creationResponse("slow-flow", { delayTicks: 5 }));
+  assert.deepEqual(flows.ids(), [], "precondition: the id has not landed yet");
+
+  const result = await flows.cleanup(request);
+  assert.deepEqual(result.deleted, ["slow-flow"]);
+  assert.deepEqual(
+    deletes.map((d) => d.url),
+    ["/api/v1/flows/slow-flow"],
+  );
+});
+
+// ─── Axis 3: leave the canvas before deleting ───────────────────────────────
+
+test("navigates to about:blank BEFORE issuing any delete", async () => {
+  const { page, emit, navigations } = fakePage();
+  const flows = trackCreatedFlows(page);
+  const order: string[] = [];
+  const request = {
+    get: async () => ({ ok: () => true, status: () => 200, json: async () => ({ access_token: "t" }) }),
+    delete: async (url: string) => {
+      order.push(`delete:${url}`);
+      return { ok: () => true, status: () => 204, statusText: () => "", text: async () => "" };
+    },
+  } as unknown as APIRequestContext;
+
+  const trackedPage = page as unknown as { goto: (url: string) => Promise<null> };
+  const originalGoto = trackedPage.goto.bind(trackedPage);
+  trackedPage.goto = async (url: string) => {
+    order.push(`goto:${url}`);
+    return originalGoto(url);
+  };
+
+  emit(creationResponse("flow-1"));
+  await flows.cleanup(request);
+
+  assert.deepEqual(navigations, ["about:blank"]);
+  assert.deepEqual(order, ["goto:about:blank", "delete:/api/v1/flows/flow-1"]);
+});
+
+test("nothing was created, so nothing is navigated away from", async () => {
+  const { page, navigations } = fakePage();
+  const { request, deletes } = fakeRequest();
+  const result = await trackCreatedFlows(page).cleanup(request);
+  assert.deepEqual(result, { deleted: [], failed: [] });
+  assert.deepEqual(navigations, [], "a teardown with no flows must add no navigation");
+  assert.deepEqual(deletes, [], "and no auth call or DELETE");
+});
+
+// ─── Axis 4: a failed delete is reported, never swallowed ───────────────────
+
+test("a failed delete is reported and does not stop the other deletes", async () => {
+  const { page, emit } = fakePage();
+  const { request, deletes } = fakeRequest({ failFor: new Set(["flow-2"]), status: 403 });
+  const flows = trackCreatedFlows(page);
+
+  emit(creationResponse("flow-1"));
+  emit(creationResponse("flow-2"));
+  emit(creationResponse("flow-3"));
+  const result = await flows.cleanup(request);
+
+  assert.deepEqual(result.deleted, ["flow-1", "flow-3"]);
+  assert.equal(result.failed.length, 1);
+  assert.equal(result.failed[0].id, "flow-2");
+  assert.match(result.failed[0].error, /403/);
+  assert.equal(deletes.length, 3, "one failure must not abort the sweep");
+});
+
+test("cleanup never throws, so it cannot fail an otherwise-green test", async () => {
+  const { page, emit } = fakePage();
+  const { request } = fakeRequest({ failFor: new Set(["flow-1"]), status: 422 });
+  const flows = trackCreatedFlows(page);
+  emit(creationResponse("flow-1"));
+  await flows.cleanup(request); // must not reject
+});
+
+// ─── Auth, idempotence, lifecycle ───────────────────────────────────────────
+
+test("the delete carries the bearer token, not just browser cookies", async () => {
+  // `page.request` alone answers 401 on the flows API — the reason every copy
+  // fetched a token in its teardown.
+  const { page, emit } = fakePage();
+  const { request, deletes } = fakeRequest({ token: "abc" });
+  const flows = trackCreatedFlows(page);
+  emit(creationResponse("flow-1"));
+  await flows.cleanup(request);
+  assert.equal(deletes[0].auth, "Bearer abc");
+});
+
+test("a second cleanup is a no-op instead of a second round of deletes", async () => {
+  const { page, emit } = fakePage();
+  const { request, deletes } = fakeRequest();
+  const flows = trackCreatedFlows(page);
+  emit(creationResponse("flow-1"));
+  await flows.cleanup(request);
+  await flows.cleanup(request);
+  assert.equal(deletes.length, 1);
+});
+
+test("reset clears both lists for the next test", async () => {
+  const { page, emit } = fakePage();
+  const flows = trackCreatedFlows(page);
+  emit(creationResponse("flow-1"));
+  emit(creationResponse(undefined, { status: 500 }));
+  await flows.settle();
+  flows.reset();
+  assert.deepEqual(flows.ids(), []);
+  assert.deepEqual(flows.failedCreations(), []);
+});
+
+test("dispose detaches the listener it attached", () => {
+  const { page, isDetached } = fakePage();
+  trackCreatedFlows(page).dispose();
+  assert.equal(isDetached(), true);
+});

--- a/tests/helpers/flows/track-created-flows.ts
+++ b/tests/helpers/flows/track-created-flows.ts
@@ -1,0 +1,210 @@
+// The suite's id-scoped flow cleanup, as one implementation (issue #1108).
+//
+// The block this replaces — "capture every flow the page creates from its
+// `POST /api/v1/flows` → 201 responses and delete those ids in `afterEach`" — was
+// hand-copied into 51 spec files. It is the standard cleanup (#490/#681/#515),
+// never the delete-all of #553, which wipes flows other parallel workers are
+// actively driving. With no shared implementation every copy drifted, and a fix to
+// one reached none of the other 50.
+//
+// Four axes drifted; #1108 carries the per-axis counts, and re-measuring them on
+// this branch's merge base reproduces the shape: of the 51 files, **one** uses a
+// `Set`, **one** settles its pending body reads, **two** navigate off the canvas
+// before deleting, and **four** match the creation endpoint by exact pathname. (The
+// `deleteFlow` error-handling axis does not re-measure cleanly — the call is wrapped
+// three different ways across the files — so the issue's split is the reference for
+// that one, not a number restated here.)
+//
+// This helper takes the STRICTEST option on every axis, for the reasons below. It
+// is deliberately opt-in per spec rather than a fixture: `tests/fixtures/**` is
+// suite-wide for `impacted-specs-by-import.mjs`, so a fixture would resolve to
+// every spec and demand a full `manual.yml` run on each change (#1054).
+
+import type { APIRequestContext } from "@playwright/test";
+import { deleteFlow } from "./delete-flow";
+import { getAuthToken } from "../auth/get-auth-token";
+
+/**
+ * The `Page` surface the tracker uses. Narrow on purpose: it is what lets the unit
+ * lane drive the tracker with a fake instead of a browser.
+ *
+ * Declared with method shorthand (not property-arrow) so the listener parameter is
+ * checked bivariantly — that is what makes a real Playwright `Page`, whose listener
+ * takes the full `Response`, assignable here.
+ */
+export interface TrackedPage {
+  on(event: "response", listener: (response: TrackedResponse) => void): unknown;
+  off(event: "response", listener: (response: TrackedResponse) => void): unknown;
+  goto(url: string): Promise<unknown>;
+}
+
+/** The `Response` surface the listener reads, for the same reason. */
+export interface TrackedResponse {
+  url(): string;
+  status(): number;
+  statusText(): string;
+  request(): { method(): string };
+  json(): Promise<unknown>;
+}
+
+/**
+ * Is this the flow-CREATION endpoint?
+ *
+ * Exact pathname, not `.includes("/api/v1/flows")`: `/api/v1/flows/batch/` and
+ * `/api/v1/flows/upload/` also answer 201, with a list body that carries no
+ * top-level `id`. That made the loose match fragility rather than a live bug — the
+ * captured id was simply `undefined` and dropped — but it is the reason the four
+ * stricter copies exist, and a future endpoint under `/flows/` that DOES return an
+ * `id` would turn it into one.
+ */
+export function isFlowCreateUrl(url: string): boolean {
+  try {
+    return /^\/api\/v1\/flows\/?$/.test(new URL(url).pathname);
+  } catch {
+    return false;
+  }
+}
+
+/** The created flow's id, or `undefined` for any body shape that has none. */
+export function flowIdFrom(body: unknown): string | undefined {
+  const id = (body as { id?: unknown } | null)?.id;
+  return typeof id === "string" && id.length > 0 ? id : undefined;
+}
+
+export interface FlowCleanupResult {
+  /** Ids whose DELETE succeeded (or that were already gone). */
+  deleted: string[];
+  /** Ids whose DELETE failed, with the first line of the error. */
+  failed: Array<{ id: string; error: string }>;
+}
+
+export interface FlowTracker {
+  /** Ids captured so far. Settled reads only — call `settle()` first to be sure. */
+  ids(): string[];
+  /**
+   * Creation POSTs that answered 4xx/5xx, as `"<status> <statusText>"` (#1114).
+   *
+   * Recorded synchronously and without the body: the body is what the fixture
+   * already prints on its `🚨 Backend Error` line, and reading it here would land a
+   * tick later than the setup step that needs to consult this.
+   */
+  failedCreations(): string[];
+  /** Await the in-flight body reads, so `ids()` is complete. */
+  settle(): Promise<void>;
+  /** Clear both lists — for a `beforeEach` on a file-scoped tracker. */
+  reset(): void;
+  /**
+   * Settle, navigate off the canvas, then delete every captured flow id-scoped.
+   * Never throws: a failed delete is logged and returned, so it cannot fail an
+   * otherwise-green test while still being visible.
+   */
+  cleanup(request: APIRequestContext): Promise<FlowCleanupResult>;
+  /** Detach the response listener. */
+  dispose(): void;
+}
+
+/**
+ * Start capturing the flows `page` creates.
+ *
+ * ```ts
+ * const flows = trackCreatedFlows(page);          // in beforeEach, or at file scope
+ * test.afterEach(async ({ request }) => { await flows.cleanup(request); });
+ * ```
+ */
+export function trackCreatedFlows(page: TrackedPage): FlowTracker {
+  // A Set, the minority choice: the same POST can be observed twice (a redirected
+  // or replayed response), and deleting an id twice turns the second DELETE into a
+  // 404 that `deleteFlow` treats as done — harmless, but it hides a real double
+  // creation behind noise. Dedup at capture instead.
+  const ids = new Set<string>();
+  const failed: string[] = [];
+  // Each capture reads a body asynchronously, so the id lands a tick later. Hold
+  // those reads and settle them before cleaning up — otherwise a body that resolves
+  // after the teardown starts is dropped and its flow leaks for good: the last test
+  // in a worker has no later hook to sweep it. Exactly ONE of the 51 copies did this
+  // (`api/flows/api-component-regression.spec.ts`, added in #1105).
+  const pending: Array<Promise<void>> = [];
+
+  const onResponse = (response: TrackedResponse) => {
+    if (response.request().method() !== "POST") return;
+    if (!isFlowCreateUrl(response.url())) return;
+    if (response.status() >= 400) {
+      failed.push(`${response.status()} ${response.statusText()}`);
+      return;
+    }
+    if (response.status() !== 201) return;
+    pending.push(
+      response
+        .json()
+        .then((body) => {
+          const id = flowIdFrom(body);
+          if (id) ids.add(id);
+        })
+        .catch(() => {}), // non-JSON / already-consumed body
+    );
+  };
+
+  page.on("response", onResponse);
+
+  const settle = async () => {
+    // Splice, so a read that arrives during cleanup is still awaited by a second
+    // call rather than awaited twice.
+    await Promise.allSettled(pending.splice(0));
+  };
+
+  return {
+    ids: () => [...ids],
+    failedCreations: () => [...failed],
+    settle,
+    reset: () => {
+      ids.clear();
+      failed.length = 0;
+      pending.length = 0;
+    },
+    dispose: () => page.off("response", onResponse),
+    async cleanup(request: APIRequestContext): Promise<FlowCleanupResult> {
+      await settle();
+      const result: FlowCleanupResult = { deleted: [], failed: [] };
+      const captured = [...ids];
+      ids.clear();
+      if (captured.length === 0) return result;
+
+      // Take the page off the flow canvas BEFORE deleting anything (#1023/#1103):
+      // an editor left mounted over a flow that is being deleted keeps polling
+      // `GET /flows/{id}/events?since=`, 404s once the flow is gone, and the
+      // fixture logs each one as `🚨 Backend Error` — which the deterministic
+      // pipeline's VALIDATE gate hard-stops on. `about:blank` rather than `/` so the
+      // teardown adds no backend traffic of its own.
+      //
+      // Honest scope: this does NOT fire in every spec. A probe on
+      // `api-component-regression.spec.ts` — failure forced after the component run,
+      // editor mounted, flow deleted underneath — logged zero backend errors either
+      // way, because the build's event stream is already closed by then. It bites
+      // the specs whose editor is still polling, and costs nothing in the rest.
+      // Two of the 51 copies did this; #1103 added it to the folder specs.
+      await page.goto("about:blank").catch(() => {});
+
+      // `page.request` carries only browser cookies, so the flows API answers 401 —
+      // pass the bearer explicitly.
+      const bearer = await getAuthToken(request).catch(() => "");
+      const options = bearer ? { headers: { Authorization: bearer } } : undefined;
+
+      for (const id of captured) {
+        try {
+          await deleteFlow(request, id, options);
+          result.deleted.push(id);
+        } catch (error) {
+          // `deleteFlow` throws on purpose — it already absorbs 404-as-done and one
+          // transient 5xx, so anything left is a real failure (401/403/422). The
+          // copies that wrote `.catch(() => {})` turned exactly the signal the
+          // helper exists to raise back into a silent leak. Report it without
+          // failing an otherwise-green test.
+          const message = (error as Error)?.message?.split("\n")[0] ?? String(error);
+          result.failed.push({ id, error: message });
+          console.warn(`⚠️  cleanup: flow ${id} was NOT deleted — ${message}`);
+        }
+      }
+      return result;
+    },
+  };
+}

--- a/tests/helpers/flows/track-created-flows.ts
+++ b/tests/helpers/flows/track-created-flows.ts
@@ -94,13 +94,24 @@ export interface FlowCleanupResult {
 
 export interface FlowCleanupOptions {
   /**
-   * Re-throw the first failed `deleteFlow` instead of logging it.
+   * Fail the teardown on a failed `deleteFlow` instead of only logging it.
    *
    * For the specs whose cleanup is load-bearing and which failed their teardown on a
    * failed delete BEFORE this helper existed — migrating one of those without this
    * would trade a red test for a warning line nothing asserts on.
+   *
+   * The throw happens AFTER the whole sweep, never on the first failure: see the note
+   * at the throw site.
    */
   strict?: boolean;
+  /**
+   * Override `getAuthToken`'s retry backoff. **Unit tests only** — a spec must not set
+   * it, because the default budget is what survives a backend wedged during teardown
+   * (#1077). It exists so the unit lane can exercise the auth-failure path without
+   * sleeping through the real `[2000, 8000, 20000]`, which cost the PR-gating lane
+   * 30 s per run.
+   */
+  authRetryDelaysMs?: number[];
 }
 
 export interface FlowTracker {
@@ -122,6 +133,7 @@ export interface FlowTracker {
    * Settle, navigate off the canvas, then delete every captured flow id-scoped.
    * Never throws unless `{ strict: true }`: by default a failed delete is logged and
    * returned, so it cannot fail an otherwise-green test while still being visible.
+   * Either way every captured id is attempted — one failure never skips the rest.
    */
   cleanup(
     request: APIRequestContext,
@@ -192,7 +204,7 @@ export function trackCreatedFlows(page: TrackedPage): FlowTracker {
     dispose: () => page.off("response", onResponse),
     async cleanup(
       request: APIRequestContext,
-      { strict = false }: FlowCleanupOptions = {},
+      { strict = false, authRetryDelaysMs }: FlowCleanupOptions = {},
     ): Promise<FlowCleanupResult> {
       await settle();
       const result: FlowCleanupResult = { deleted: [], failed: [] };
@@ -228,7 +240,11 @@ export function trackCreatedFlows(page: TrackedPage): FlowTracker {
       let options: { headers: Record<string, string> } | undefined;
       let authError: string | undefined;
       try {
-        const bearer = await getAuthToken(request);
+        // `retryDelaysMs: undefined` keeps `getAuthToken`'s own default budget — only
+        // the unit lane passes a value.
+        const bearer = await getAuthToken(request, {
+          retryDelaysMs: authRetryDelaysMs,
+        });
         options = bearer ? { headers: { Authorization: bearer } } : undefined;
       } catch (error) {
         authError = (error as Error)?.message?.split("\n")[0] ?? String(error);
@@ -239,6 +255,7 @@ export function trackCreatedFlows(page: TrackedPage): FlowTracker {
         );
       }
 
+      const errors: unknown[] = [];
       for (const id of captured) {
         try {
           await deleteFlow(request, id, options);
@@ -251,9 +268,27 @@ export function trackCreatedFlows(page: TrackedPage): FlowTracker {
           // failing an otherwise-green test.
           const message = (error as Error)?.message?.split("\n")[0] ?? String(error);
           result.failed.push({ id, error: message });
+          errors.push(error);
           console.warn(`⚠️  cleanup: flow ${id} was NOT deleted — ${message}`);
-          if (strict) throw error;
         }
+      }
+
+      // `strict` throws only once the sweep is over. Throwing on the first failure
+      // would abort it — and since `captured` was already taken OUT of the tracker,
+      // the remaining flows would be neither deleted nor tracked: a permanent leak,
+      // in the mode whose whole point is that cleanup is load-bearing. (That was the
+      // pre-#1108 behaviour of the copies that let `deleteFlow` throw, and it is the
+      // one thing this helper does NOT preserve on purpose.) The first error is
+      // re-thrown as itself so its `deleteFlow` message survives; several failures
+      // aggregate, naming every id the teardown left behind.
+      if (strict && errors.length > 0) {
+        if (errors.length === 1) throw errors[0];
+        throw new AggregateError(
+          errors,
+          `Flow cleanup failed for ${result.failed.length} flows: ${result.failed
+            .map((f) => `${f.id} (${f.error})`)
+            .join("; ")}`,
+        );
       }
       return result;
     },

--- a/tests/helpers/flows/track-created-flows.ts
+++ b/tests/helpers/flows/track-created-flows.ts
@@ -7,16 +7,24 @@
 // actively driving. With no shared implementation every copy drifted, and a fix to
 // one reached none of the other 50.
 //
-// Four axes drifted; #1108 carries the per-axis counts, and re-measuring them on
-// this branch's merge base reproduces the shape: of the 51 files, **one** uses a
-// `Set`, **one** settles its pending body reads, **two** navigate off the canvas
-// before deleting, and **four** match the creation endpoint by exact pathname. (The
-// `deleteFlow` error-handling axis does not re-measure cleanly — the call is wrapped
-// three different ways across the files — so the issue's split is the reference for
-// that one, not a number restated here.)
+// Four axes re-measure cleanly against this branch's merge base: of the 51 files,
+// **one** uses a `Set`, **one** settles its pending body reads (so 50 can drop an id
+// that resolves a tick late), **two** navigate off the canvas before deleting, and
+// **four** match the creation endpoint by exact pathname. On each of those this
+// helper takes the strict option unconditionally.
 //
-// This helper takes the STRICTEST option on every axis, for the reasons below. It
-// is deliberately opt-in per spec rather than a fixture: `tests/fixtures/**` is
+// The fifth axis — what happens to a failed `deleteFlow` — is **three**-way, not the
+// two-way split the issue's table describes, and no query I tried reproduced a
+// defensible count, so none is restated here. The shapes are: swallow it
+// (`.catch(() => {})`), log it, or let it THROW and fail the teardown. Throwing is
+// the strongest signal of the three and some files choose it deliberately
+// (`component-breaking-change-alert.spec.ts`: "Cleanup is load-bearing here … so the
+// throw is intentionally NOT swallowed"), so `cleanup` defaults to log-and-return
+// per the issue's instruction and takes `{ strict: true }` for those callers. A
+// migration must not silently downgrade a spec that was failing on a failed cleanup.
+//
+// This is a helper, deliberately opt-in per spec, rather than a fixture:
+// `tests/fixtures/**` is
 // suite-wide for `impacted-specs-by-import.mjs`, so a fixture would resolve to
 // every spec and demand a full `manual.yml` run on each change (#1054).
 
@@ -76,6 +84,23 @@ export interface FlowCleanupResult {
   deleted: string[];
   /** Ids whose DELETE failed, with the first line of the error. */
   failed: Array<{ id: string; error: string }>;
+  /**
+   * Set when the token could not be obtained, so the DELETEs below ran on the
+   * browser session alone. Reported separately because a 401 that follows is THAT,
+   * not a problem with the flow — see the note at the call site.
+   */
+  authError?: string;
+}
+
+export interface FlowCleanupOptions {
+  /**
+   * Re-throw the first failed `deleteFlow` instead of logging it.
+   *
+   * For the specs whose cleanup is load-bearing and which failed their teardown on a
+   * failed delete BEFORE this helper existed — migrating one of those without this
+   * would trade a red test for a warning line nothing asserts on.
+   */
+  strict?: boolean;
 }
 
 export interface FlowTracker {
@@ -95,10 +120,13 @@ export interface FlowTracker {
   reset(): void;
   /**
    * Settle, navigate off the canvas, then delete every captured flow id-scoped.
-   * Never throws: a failed delete is logged and returned, so it cannot fail an
-   * otherwise-green test while still being visible.
+   * Never throws unless `{ strict: true }`: by default a failed delete is logged and
+   * returned, so it cannot fail an otherwise-green test while still being visible.
    */
-  cleanup(request: APIRequestContext): Promise<FlowCleanupResult>;
+  cleanup(
+    request: APIRequestContext,
+    options?: FlowCleanupOptions,
+  ): Promise<FlowCleanupResult>;
   /** Detach the response listener. */
   dispose(): void;
 }
@@ -162,7 +190,10 @@ export function trackCreatedFlows(page: TrackedPage): FlowTracker {
       pending.length = 0;
     },
     dispose: () => page.off("response", onResponse),
-    async cleanup(request: APIRequestContext): Promise<FlowCleanupResult> {
+    async cleanup(
+      request: APIRequestContext,
+      { strict = false }: FlowCleanupOptions = {},
+    ): Promise<FlowCleanupResult> {
       await settle();
       const result: FlowCleanupResult = { deleted: [], failed: [] };
       const captured = [...ids];
@@ -186,8 +217,27 @@ export function trackCreatedFlows(page: TrackedPage): FlowTracker {
 
       // `page.request` carries only browser cookies, so the flows API answers 401 —
       // pass the bearer explicitly.
-      const bearer = await getAuthToken(request).catch(() => "");
-      const options = bearer ? { headers: { Authorization: bearer } } : undefined;
+      //
+      // The throw is CAUGHT but never turned into an empty token silently, which is
+      // what `get-auth-token.ts` forbids (#1086: "it must never degrade into the
+      // empty-token fallback — the callers would carry on unauthenticated and fail
+      // somewhere far less diagnosable"). `cleanup` still may not throw, so the
+      // failure is named here and carried on the result: without this, a backend
+      // wedged during teardown (#1077) produces a `401` per flow and a report that
+      // blames the flows.
+      let options: { headers: Record<string, string> } | undefined;
+      let authError: string | undefined;
+      try {
+        const bearer = await getAuthToken(request);
+        options = bearer ? { headers: { Authorization: bearer } } : undefined;
+      } catch (error) {
+        authError = (error as Error)?.message?.split("\n")[0] ?? String(error);
+        result.authError = authError;
+        console.warn(
+          `⚠️  cleanup: no auth token — the deletes below run on the browser session ` +
+            `alone, so a 401 here is THAT and not the flow (#1086/#1077): ${authError}`,
+        );
+      }
 
       for (const id of captured) {
         try {
@@ -202,6 +252,7 @@ export function trackCreatedFlows(page: TrackedPage): FlowTracker {
           const message = (error as Error)?.message?.split("\n")[0] ?? String(error);
           result.failed.push({ id, error: message });
           console.warn(`⚠️  cleanup: flow ${id} was NOT deleted — ${message}`);
+          if (strict) throw error;
         }
       }
       return result;

--- a/tests/tests-automations/regression/core-functionality/project-management/edit-flow-name.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/edit-flow-name.spec.ts
@@ -19,7 +19,15 @@ test.beforeEach(({ page }) => {
 });
 
 test.afterEach(async ({ request }) => {
-  await flows.cleanup(request);
+  // `strict`, because this file's pre-#1108 teardown called `deleteFlow` with no
+  // `.catch()` — a failed cleanup FAILED the test. Migrating it onto the helper's
+  // default (log and continue) would trade that red for a warning line nothing
+  // asserts on, so the contract is kept.
+  //
+  // Optional-chained: Playwright runs `afterEach` even when `beforeEach` never did
+  // (a page-fixture setup failure), and a bare call would then bury the real error
+  // under `Cannot read properties of undefined`.
+  await flows?.cleanup(request, { strict: true });
 });
 
 test(

--- a/tests/tests-automations/regression/core-functionality/project-management/edit-flow-name.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/edit-flow-name.spec.ts
@@ -1,40 +1,31 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
-import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { renameFlow } from "../../../../helpers/flows/rename-flow";
+import {
+  trackCreatedFlows,
+  type FlowTracker,
+} from "../../../../helpers/flows/track-created-flows";
 
 // Every flow this test creates (bootstrap + the Basic Prompting template) is
 // tracked by id and deleted in afterEach — id-scoped, never a name or wipe
 // sweep, which would kill flows other parallel workers are driving (#553).
 // The app can fire more than one flows POST per creation; only one persists and
 // deleting a transient id 404s harmlessly (deleteFlow treats 404 as done).
-const createdFlowIds: string[] = [];
+// Shared implementation, so this file cannot drift from the other 50 (#1108).
+let flows: FlowTracker;
 
-test.afterEach(async ({ page }) => {
-  for (const id of createdFlowIds.splice(0)) {
-    await deleteFlow(page.request, id);
-  }
+test.beforeEach(({ page }) => {
+  flows = trackCreatedFlows(page);
+});
+
+test.afterEach(async ({ request }) => {
+  await flows.cleanup(request);
 });
 
 test(
   "user should be able to edit flow name and see it reflected in the main page listing",
   { tag: ["@stable", "@release", "@workspace", "@regression"] },
   async ({ page }) => {
-    page.on("response", (resp) => {
-      if (
-        resp.url().includes("/api/v1/flows") &&
-        resp.request().method() === "POST" &&
-        resp.status() === 201
-      ) {
-        resp
-          .json()
-          .then((body: { id?: string }) => {
-            if (body?.id) createdFlowIds.push(body.id);
-          })
-          .catch(() => {}); // non-JSON / batch payloads
-      }
-    });
-
     await awaitBootstrapTest(page);
 
     await page.getByRole("heading", { name: "Basic Prompting" }).click();

--- a/tests/tests-automations/regression/core-functionality/project-management/flowSettings.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/flowSettings.spec.ts
@@ -24,7 +24,12 @@ test.beforeEach(({ page }) => {
 });
 
 test.afterEach(async ({ request }) => {
-  await flows.cleanup(request);
+  // Optional-chained: Playwright runs `afterEach` even when `beforeEach` never did
+  // (a page-fixture setup failure), and a bare call would then bury the real error
+  // under `Cannot read properties of undefined`. Not `strict` — this file's
+  // pre-#1108 teardown swallowed a failed delete, so log-and-continue IS its
+  // contract, now with the failure visible instead of silent.
+  await flows?.cleanup(request);
 });
 
 test(

--- a/tests/tests-automations/regression/core-functionality/project-management/flowSettings.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/flowSettings.spec.ts
@@ -1,54 +1,36 @@
-import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { renameFlow } from "../../../../helpers/flows/rename-flow";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
-import { deleteFlow } from "../../../../helpers/flows/delete-flow";
-import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import {
+  trackCreatedFlows,
+  type FlowTracker,
+} from "../../../../helpers/flows/track-created-flows";
 
 // Capture every flow THIS page creates from its POST /api/v1/flows → 201
 // responses, and delete them id-scoped in afterEach. The canvas URL id races
 // the bootstrap flow's stale id (blank-flow opens behind the templates modal),
 // so a bare page.url() capture deleted the wrong flow and leaked the renamed
 // one; the response ids are authoritative. Only ids this page created are
-// captured, so it stays safe under parallel workers.
-const createdFlowIds: string[] = [];
-
-function trackCreatedFlows(page: Page): void {
-  page.on("response", (resp) => {
-    if (
-      resp.url().includes("/api/v1/flows") &&
-      resp.request().method() === "POST" &&
-      resp.status() === 201
-    ) {
-      resp
-        .json()
-        .then((body: { id?: string }) => {
-          if (body?.id) createdFlowIds.push(body.id);
-        })
-        .catch(() => {});
-    }
-  });
-}
+// captured, so it stays safe under parallel workers. Shared implementation, so
+// this file cannot drift from the other 50 (#1108).
+let flows: FlowTracker;
 
 const OVERLONG = "Flow Name Test ".repeat(70); // > every field cap on 1.11
 const DESCRIPTION_CAP = 250; // enforced maxLength of input-flow-description
 
+test.beforeEach(({ page }) => {
+  flows = trackCreatedFlows(page);
+});
+
 test.afterEach(async ({ request }) => {
-  if (createdFlowIds.length === 0) return;
-  const bearer = await getAuthToken(request);
-  for (const id of createdFlowIds.splice(0)) {
-    await deleteFlow(request, id, {
-      headers: { Authorization: bearer },
-    }).catch(() => {});
-  }
+  await flows.cleanup(request);
 });
 
 test(
   "flow settings enforce character limits and persist name & description",
   { tag: ["@stable", "@release", "@workspace"] },
   async ({ page }) => {
-    trackCreatedFlows(page);
     await awaitBootstrapTest(page);
 
     await test.step("open a blank flow", async () => {


### PR DESCRIPTION
**Fixes #1108.**

## Problem

The suite's id-scoped flow cleanup — "capture every flow the page creates from its `POST /api/v1/flows` → 201 responses and delete those ids in `afterEach`" — is hand-copied into **51 spec files** with no shared implementation, so every copy drifted independently and a fix to one reaches none of the other 50. Re-measured on this branch's merge base:

| axis | of the 51 files, how many do the strict thing |
|---|---|
| `Set` accumulator | **1** |
| settles pending `resp.json()` before cleaning up | **1** (`api-component-regression.spec.ts`, #1105) |
| navigates off the canvas before deleting | **2** (`about:blank`, #1103) |
| exact-pathname URL match | **4** |
| a failed `deleteFlow` is reported rather than swallowed | see below |

Those four re-measure cleanly against this branch's merge base and match the issue's shape. The fifth does **not**: the `deleteFlow` call is wrapped three different ways across the files (`.catch(() => {})` adjacent to the call, a logging `.catch`, and no `.catch` at all), so I could not reproduce the issue's 45/9 split with a defensible query. I have therefore not restated a number for it — in the code or here — and the issue's own measurement stands as the reference.

Each divergence is a real leak or a real silence — the issue spells out why; the two that bite hardest are the unsettled-body race (an id that resolves a tick after `afterEach` starts is dropped, and the last test in a worker has no later hook, so the flow leaks **permanently**) and the swallowed `deleteFlow` error (the helper throws on purpose, having already absorbed 404-as-done and one transient 5xx, so what is left is a real 401/403/422).

## Fix — the shape the issue asked for, and the split it asked for

`tests/helpers/flows/track-created-flows.ts`, unit-tested, taking the **strictest** option on all four axes plus the `Set` accumulator. **A helper, not a fixture** — the issue's option 1 — because `tests/fixtures/**` is suite-wide for `impacted-specs-by-import.mjs`: a fixture would resolve to every spec and demand a full `manual.yml` dispatch on every future change to it (#1054). Opt-in per spec also keeps each migration PR's blast radius small, which is the issue's own scope note:

> 50 files is too much for one PR to validate credibly. Suggested split: one PR adding the shared implementation with unit tests, then migration PRs by area.

So this PR is **the implementation plus one pilot area**, not the sweep. The pilot is `core-functionality/project-management`, chosen because it is non-LLM (cheap to validate end to end) and because two of its three files carry the *loose* variant, so the migration is a real improvement rather than a no-op rename:

| file | before | after |
|---|---|---|
| `edit-flow-name.spec.ts` | loose match, no settle, no navigation, `deleteFlow(page.request)` with no bearer and no error handling | shared tracker |
| `flowSettings.spec.ts` | loose match, no settle, no navigation, `.catch(() => {})` | shared tracker |
| `folder-deletion-integrity.spec.ts` | already the strictest variant (`Set` + `about:blank` + exact pathname), **and** it tracks projects in the same teardown | **left for the next PR** — its teardown interleaves flow and project deletion, which needs its own validation rather than riding on this one |

The remaining 48 files stay for migration PRs by area, per the issue.

**The failed-delete axis is three-way, not two.** `edit-flow-name.spec.ts` called `deleteFlow` with no `.catch()`, so a failed cleanup *failed the test* — and 13 of the 51 files do the same, some deliberately (`component-breaking-change-alert.spec.ts`: *"Cleanup is load-bearing here … so the throw is intentionally NOT swallowed"*). The first cut of this PR moved `edit-flow-name` onto log-and-continue, trading a red test for a warning line nothing asserts on. `cleanup` therefore takes `{ strict: true }`, which re-throws after logging and recording; `edit-flow-name` uses it, so its red/green behaviour is unchanged, and the 13 throwers have a migration path that does not downgrade them.

## API

```ts
const flows = trackCreatedFlows(page);            // beforeEach
await flows.cleanup(request);                     // afterEach — settles, navigates, deletes
flows.ids();  flows.failedCreations();  flows.settle();  flows.reset();  flows.dispose();
```

`cleanup` never throws unless `{ strict: true }` — by default a failed delete is logged **and** returned in `{ deleted, failed }`, so it stays visible without failing an otherwise-green test. When the token cannot be obtained, that is reported as `authError` and in the log rather than degrading into an empty bearer: `get-auth-token.ts` forbids the silent fallback (#1086), and a backend wedged during teardown (#1077) would otherwise produce one 401 per flow and a report blaming the flows. `failedCreations()` carries the 4xx/5xx creation POSTs synchronously, which is what `api-component-regression.spec.ts` needed for #1114 and what lets a setup step point at the real cause.

The `TrackedPage` / `TrackedResponse` types are narrow on purpose: they are what let the unit lane drive the tracker with a fake, and they use method shorthand so a real Playwright `Page` stays assignable.

## Validation (nightly 1.12.0.dev10, `--workers=1 --retries=0`)

- `npm run typecheck` ✅ · `npx eslint` on the four touched files ✅ (0 errors; one pre-existing `prefer-to-have-length` warning in `flowSettings.spec.ts:85`, untouched by this change) · `npm run test:units` ✅ **150/150**
- **25 new unit tests**, one per behaviour that drifted plus the lifecycle: the exact-endpoint match (including `/flows/batch/` and `/flows/upload/`, which answer 201 with no top-level `id`), id extraction from every body shape, dedup of a twice-observed id, a failed creation recorded synchronously, **a body that resolves after teardown starts still being deleted**, `about:blank` being visited *before* the first DELETE, no navigation at all when nothing was created, a failed delete reported without aborting the sweep, `cleanup` never rejecting, the bearer being sent, a second `cleanup` being a no-op, `reset`, `dispose` detaching its listener, strict mode's throw and its opt-in-ness, the named auth failure vs. the legitimate no-auth environment, `failedCreations` empty after a success and populated by a 422, its defensive copy, a `page.goto` that rejects because the page is already gone, an unparseable body, and `settle()` draining its queue. The fake `request` exercises the **real** `deleteFlow` and `getAuthToken`, so the integration is covered without a browser or a backend.
- **Force-fail, executed** — one per axis, each mutation reverted and re-verified:
  - drop the `settle()` in `cleanup` ⇒ **4/14 fail**
  - swallow the failed delete ⇒ **1/14 fails**
  - remove the `about:blank` navigation ⇒ **1/14 fails**
  - loosen the URL match back to `.includes("/api/v1/flows")` ⇒ **2/14 fail**
  - restored: 25/25, no mutation markers in the diff
  - **and the behavioural one**, which is the point for a cleanup helper: with `isFlowCreateUrl` forced to `false`, `edit-flow-name.spec.ts` still **passes (58.1s)** while the account's flow count goes **27 → 30**. Three flows leak, silently, behind a green test — the exact failure this helper exists to prevent, and the reason a unit test alone would not have been enough evidence. Restored, and the leaked flows purged (back to 27).
- **Live, on the pilot:** `edit-flow-name` + `flowSettings` → **2 passed (1.7m)**, and the account's flow count is **27 before → 27 after** (the 27 bundled starter templates), i.e. zero leak. Re-run cleanly after the mutation testing, because the first run overlapped it and its evidence could not be trusted.
- Re-validated after the review fixes (`strict: true` changes `edit-flow-name`'s teardown): **2 passed (1.7m)**, flows **27 → 27**.
- Zero `🚨 Backend Error`.

## Follow-ups this deliberately leaves open

- Migration PRs by area for the remaining 48 files (the issue's own split). `folder-deletion-integrity.spec.ts` should lead the `project-management` remainder, since its project tracking needs the same treatment.
- `cleanup()` owns the `about:blank` navigation and offers no pre-navigation hook, so a migrating spec cannot keep the `url-at-teardown` annotation / `page-at-teardown` screenshot that `folder-deletion-integrity.spec.ts` and `api-component-regression.spec.ts` take before navigating. Neither pilot file had one, so nothing regresses here — but the two files that do will need that hook before they migrate.
- `api-component-regression.spec.ts` is the file whose behaviour this helper was distilled from; migrating it will also move its `failedFlowCreations` (#1114) and its teardown screenshot annotation onto the shared shape.

## Acceptance

- [x] One shared implementation, unit-tested
- [x] Every migrated spec keeps its current green/red status (no behaviour change beyond the cleanup) — verified live on both pilot files, and `edit-flow-name`'s failure path is preserved via `{ strict: true }` rather than quietly downgraded
- [x] No `🚨 Backend Error` introduced in the migrated area
- [x] The stricter behaviours are the default, not per-file choices — and each is pinned by a test that fails when it is removed. On the one axis where "stricter" is genuinely a judgement call (throw vs. log a failed delete) the default follows the issue's instruction and `{ strict: true }` covers the callers that need the throw.
- [ ] The remaining 48 files — migration PRs by area, per the issue's scope note

Closes #1108
