### PR TITLE
test(triage): quarantine two recurrent flakes from daily #1121

### DIFF
--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/upload-via-component.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/upload-via-component.spec.ts
@@ -65,9 +65,13 @@ test.afterEach(async ({ request }) => {
   await deleteUploadedFiles(request, bearer);
 });
 
-test(
+// Quarantined for #1125 — recurrent flake (dailies 2026-07-23, 2026-07-30):
+// the uploaded file item `file-item-test-file` never renders within 15 s, even
+// though the upload POST is awaited. Lifting the quarantine and restoring
+// @stable is a deliverable of #1125.
+test.fixme(
   "upload a file through the Read File component and read its content",
-  { tag: ["@stable", "@release", "@files", "@components"] },
+  { tag: ["@release", "@files", "@components"] },
   async ({ page }) => {
     trackCreatedFlows(page);
     await awaitBootstrapTest(page);

--- a/tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts
@@ -235,9 +235,13 @@ test.describe("MCP Client – Configure and Execute Tool", () => {
     },
   );
 
-  test(
+  // Quarantined for #1126 — recurrent flake (dailies 2026-07-16, 2026-07-20,
+  // 2026-07-30): openBlankFlow's page.waitForURL times out after 30 s even
+  // though POST /api/v1/flows already returned 201. Lifting the quarantine and
+  // restoring @stable is a deliverable of #1126.
+  test.fixme(
     "unreachable HTTP server results in empty tool dropdown",
-    { tag: ["@mcp", "@regression", "@stable"] },
+    { tag: ["@mcp", "@regression"] },
     async ({ page }) => {
       const BAD_SERVER = BAD_SERVER_NAME;
 


### PR DESCRIPTION
## What this does

Quarantines the two **recurrent same-signature flakes** the triage of daily run
[30534416609](https://github.com/oriontech-me/langflow-e2e/actions/runs/30534416609)
(2026-07-30) identified. Quarantine = `@stable` removed **and** `test.fixme`
added, together — tag removal alone only stops the daily, so the test keeps
going red on the PR impacted-specs gate, which is file-diff selected rather
than tag-filtered.

| Test | Recurrence | Signature | Tracked in |
|---|---|---|---|
| `tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/upload-via-component.spec.ts:68` | 2× (2026-07-23, 2026-07-30) | `expect(locator).toBeVisible() failed` on `file-item-test-file` | #1125 |
| `tests/tests-automations/regression/mcp/client/mcp-client-regression.spec.ts:238` | 3× (2026-07-16, 2026-07-20, 2026-07-30) | `TimeoutError: page.waitForURL: Timeout 30000ms exceeded.` | #1126 |

## What this does NOT do

No test logic, wait strategy or spec doc is touched, and no root cause is
asserted. Lifting each quarantine — remove `test.fixme`, restore `@stable`,
re-validate per `CONTRIBUTING.md` — is an explicit deliverable of #1125 and
#1126 respectively.

The two **hard failures** from the same run needed nothing here: the daily
workflow already auto-removed their `@stable` (commit `dffeee9` on `main`).
They are tracked in #1123 and #1124.

## Why this closes the umbrella

The triage of #1121 is complete once every criterion-required removal is done:

- 4 dedicated issues created — #1123, #1124, #1125, #1126
- Hard-failure tags: auto-removed by the workflow, verified absent on `main`
- Recurrent-flake quarantines: this PR

Closes #1121

## Validation

- `npm run typecheck` — clean
- `npm run lint` on both files — no new findings (3 pre-existing warnings in `mcp-client-regression.spec.ts`)
- `npm run check:checklist-coverage` — passes (both specs keep their Part II bullet)
- `node scripts/check-checklist-guard.mjs` — no generated block touched
