### PR TITLE
chore: write the provider-setup ignore comment in English

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,8 @@ docs/superpowers/
 .playwright-mcp/
 .worktrees/
 
-# Artefatos gerados localmente — cada dev gera via collect-models.spec.ts
+# Locally generated artifacts — every dev produces their own by running
+# collect-models.spec.ts against their instance.
 tests/helpers/provider-setup/data/models.json
 tests/helpers/provider-setup/data/providers.json
 


### PR DESCRIPTION
## What this does

Rewrites the one Portuguese comment in `.gitignore` in English, per `CLAUDE.md` →
**Language** ("all content in this repository must be written in English —
without exception", inline comments included).

```diff
-# Artefatos gerados localmente — cada dev gera via collect-models.spec.ts
+# Locally generated artifacts — every dev produces their own by running
+# collect-models.spec.ts against their instance.
```

The rewrite keeps what the comment was for — naming who generates the two paths
below it — and adds the *how*, so a reader without those files knows the command.

## Scope

`.gitignore:27` was the **only** occurrence. A sweep over every tracked file
outside `docs/` and `.claude/` now returns nothing.

`tests/assets/flows/group_test_iadevs.json` is deliberately left untouched: its
Portuguese text is the *payload* of a prompt inside a flow fixture — test data,
not repo prose — and rewriting it would change what the fixture exercises. Stated
here so the next sweep does not re-flag it.

## Validation

- Sweep re-run after the change: no Portuguese prose in any tracked file outside
  `docs/` and `.claude/`.
- `git check-ignore -v` still attributes both `provider-setup/data/*.json` paths
  to the rule under this comment — the edit did not disturb the rules it documents.

Closes #1129
