### PR TITLE
fix(fixtures): make the HTTP error monitor cover 4xx/5xx and say what it does (#1084)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ Do not restate the current wave here — it changes every cycle; follow the poin
 
 ### Test Infrastructure
 
-- **`tests/fixtures/fixtures.ts`** — Always import `test` from here, never directly from Playwright. It extends the base `test` with automatic backend HTTP error monitoring (4xx/5xx) and flow execution error detection. Provides `page.allowFlowErrors()` for tests that intentionally trigger failures.
+- **`tests/fixtures/fixtures.ts`** — Always import `test` from here, never directly from Playwright. It extends the base `test` with backend HTTP error monitoring and flow execution error detection. **The two are not equally strong, and the difference decides how much a green run is worth (#1084):** a `flow_error` **fails** the test; an `http_error` is **logged and never fails it**, on any path, for any endpoint — so the only thing between a real backend 500 and a green test is a human reading the log (checklist step 4 below, `CONTRIBUTING.md` step 5). Which responses reach that log is decided by `tests/fixtures/http-error-policy.ts` — every 4xx/5xx on an `/api/` route except the documented exemptions (auth endpoints; the external Langflow Store, unreachable in CI). It genuinely covers 4xx/5xx now; before #1084 it matched four exact codes and silently missed 401/403/405/409/502/503, which is why `execution-error-notification` could mock a 503 specifically to slip past it. Escape hatches: `page.allowFlowErrors()` for tests that provoke execution failures, `page.allowHttpErrors()` for tests that drive an endpoint into a 4xx/5xx on purpose (keeps the advisory log trustworthy). `PW_HTTP_ERROR_DEBUG=1` prints what the policy ignored, with reasons.
 
 - **`tests/pages/`** — Page Object Model (POM). `BasePage.ts` provides common navigation; `FlowEditorPage.ts`, `PlaygroundPage.ts`, `MainPage.ts`, `LoginPage.ts`, `SidebarComponent.ts` provide feature-specific selectors and actions.
 
@@ -137,7 +137,7 @@ importable, `testMatch`/discovery gotchas — in `CONTRIBUTING.md` → **Unit te
 1. Run with full trace (`--trace=on`) and verify steps match screenshots
 2. Force a failure to confirm no false positives
 3. Walk through in debug mode (`--debug`)
-4. Confirm no backend errors logged (`🚨 Backend Error:`)
+4. Confirm no backend errors logged (`🚨 Backend Error:`) — **this step is a real gate, not a formality: an HTTP error never fails the test on its own** (#1084)
 5. Update `QA-CHECKLIST.md` coverage symbols
 
 **PR review checklist** — request changes if any of these are missing:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,9 @@ test.describe("Area or feature name", () => {
 });
 ```
 
-> Always import from `fixtures` — never directly from Playwright. The base fixture adds automatic backend error monitoring.
+> Always import from `fixtures` — never directly from Playwright. The base fixture adds
+> backend error monitoring: flow execution errors **fail** the test, HTTP errors are
+> **logged only** (step 5 below explains why that distinction matters).
 
 **4. Use existing helpers and pages**
 
@@ -257,8 +259,22 @@ npx playwright test path/to/test.spec.ts --debug
 
 The base fixture prints backend errors automatically. Look for:
 
-- `🚨 Backend Error:` — unexpected HTTP error
-- `🚨 Flow Error Detected` — silent failure in flow execution
+- `🚨 Backend Error:` — unexpected HTTP error. **Logged, never fails the test** (#1084)
+- `🚨 Flow Error Detected` — silent failure in flow execution. **Fails the test** unless
+  the spec called `page.allowFlowErrors()`
+
+Because an HTTP error cannot fail a test, **this step is the only thing standing between a
+real backend 500 and a green run** — the fixture prints
+`⚠️  N HTTP error(s) detected — ADVISORY` to say so out loud. Treat any line under it as a
+finding to explain, not noise to scroll past.
+
+Which responses reach that log is decided by `tests/fixtures/http-error-policy.ts` (every
+4xx/5xx on an `/api/` route, minus documented exemptions: auth endpoints, and the external
+Langflow Store which is unreachable from CI). If your spec drives an endpoint into a 4xx/5xx
+**on purpose** — including mocking one with `page.route` — call `page.allowHttpErrors()` so
+the deliberate error stays out of the log instead of teaching readers to ignore it. Adding an
+endpoint to the exemption list makes it invisible to all 235 specs, so it needs a reason that
+survives review; run with `PW_HTTP_ERROR_DEBUG=1` to see what is currently being ignored.
 
 **6. Update the checklist**
 

--- a/tests/fixtures/fixtures.ts
+++ b/tests/fixtures/fixtures.ts
@@ -1,5 +1,29 @@
 // tests/fixtures.ts
-import { test as base, expect } from "@playwright/test";
+import { test as base, expect, type Page } from "@playwright/test";
+import { classifyHttpError } from "./http-error-policy";
+
+/**
+ * The escape hatches this fixture bolts onto `page`.
+ *
+ * Specs reach them through `(page as any)` today; this type exists so the two
+ * names are discoverable and spelled consistently.
+ */
+export type PageWithErrorHooks = Page & {
+  /** Flow-execution errors are expected in this test — do not fail on them. */
+  allowFlowErrors: () => void;
+  /**
+   * Backend HTTP errors are expected in this test — do not report them.
+   *
+   * For specs that drive an endpoint into a 4xx/5xx **on purpose**, including
+   * the ones that mock one with `page.route` (`execution-error-notification`
+   * fulfils a 503, `llm-invalid-api-key-ui` a 500). Since HTTP errors are
+   * advisory (below), this suppresses log noise rather than a failure — which is
+   * the point: the fixture's only real gate is a human reading that log, so a
+   * deliberately-provoked error sitting in it makes the log less trustworthy,
+   * not more (#1084).
+   */
+  allowHttpErrors: () => void;
+};
 
 // Extend test to log backend errors
 export const test = base.extend({
@@ -14,10 +38,24 @@ export const test = base.extend({
 
     // Flag to allow flow errors (for tests that expect errors)
     let allowFlowErrors = false;
+    // Same, for backend HTTP errors the test provokes deliberately.
+    let allowHttpErrors = false;
+    /**
+     * Responses the policy chose not to report, by reason. Not printed unless
+     * asked for: the Store 500s alone would put a line in every test's log, and
+     * re-noising the log is exactly what #1084 was about. Set
+     * `PW_HTTP_ERROR_DEBUG=1` to see them — useful when deciding whether the
+     * ignore list is still right, or whether HTTP errors could start failing
+     * tests (the open half of #1084).
+     */
+    const ignoredByPolicy = new Map<string, number>();
 
     // Add helper method to page context
     (page as any).allowFlowErrors = () => {
       allowFlowErrors = true;
+    };
+    (page as any).allowHttpErrors = () => {
+      allowHttpErrors = true;
     };
 
     // Monitor API responses for errors
@@ -25,34 +63,50 @@ export const test = base.extend({
       const url = response.url();
       const status = response.status();
 
-      // Log 400/404/422/500 API errors (ignore auth endpoints)
-      if (
-        url.includes("/api/") &&
-        (status === 400 || status === 404 || status === 422 || status === 500)
-      ) {
-        const isAuth =
-          url.includes("/login") ||
-          url.includes("/refresh") ||
-          url.includes("/auto_login") ||
-          url.includes("/logout");
-        if (!isAuth) {
-          console.log(
-            `🚨 Backend Error: ${status} ${response.statusText()} - ${url}`,
+      // Report any backend 4xx/5xx the policy considers meaningful. The rules —
+      // and the reason for each exemption — live in `http-error-policy.ts`,
+      // where they are unit-tested; this used to be an inline list of four
+      // status codes that silently missed 401/403/405/409/502/503 (#1084).
+      const verdict = classifyHttpError({ url, status });
+      if (!verdict.monitored) {
+        // Only 4xx/5xx are worth accounting for. Counting every 2xx would put
+        // "32× not an error status" in the debug breakdown and bury the entries
+        // that answer the question it exists to answer.
+        if (status >= 400) {
+          ignoredByPolicy.set(
+            verdict.ignoreReason,
+            (ignoredByPolicy.get(verdict.ignoreReason) ?? 0) + 1,
           );
-          let responseBody: string | undefined;
-          try {
-            responseBody = await response.text();
-            console.log(`   Response: ${responseBody}`);
-          } catch (e) {
-            responseBody = "Could not read response";
-          }
-          errors.push({
-            url,
-            status,
-            statusText: response.statusText(),
-            responseBody,
-            type: "http_error",
-          });
+        }
+      } else if (!allowHttpErrors) {
+        console.log(
+          `🚨 Backend Error: ${status} ${response.statusText()} - ${url}`,
+        );
+        // Recorded BEFORE the body is read, because reading it is an `await`
+        // inside an async event handler and the fixture's teardown does not wait
+        // for it. An error observed late in a test therefore raced the summary
+        // below and could be dropped from the count — measured: a 405 fired at
+        // the end of a test printed `🚨` with no `📋 Found N backend error(s)`
+        // line at all. Since that summary is the whole gate for HTTP errors, an
+        // undercount is the one failure this mechanism cannot afford (#1084).
+        const entry: {
+          url: string;
+          status: number;
+          statusText: string;
+          responseBody?: string;
+          type: string;
+        } = {
+          url,
+          status,
+          statusText: response.statusText(),
+          type: "http_error",
+        };
+        errors.push(entry);
+        try {
+          entry.responseBody = await response.text();
+          console.log(`   Response: ${entry.responseBody}`);
+        } catch (e) {
+          entry.responseBody = "Could not read response";
         }
       }
 
@@ -227,6 +281,15 @@ export const test = base.extend({
 
     await use(page);
 
+    if (process.env.PW_HTTP_ERROR_DEBUG === "1" && ignoredByPolicy.size > 0) {
+      const breakdown = [...ignoredByPolicy.entries()]
+        .map(([reason, count]) => `      ${count}× ${reason}`)
+        .join("\n");
+      console.log(
+        `\n🔎 HTTP responses ignored by policy (tests/fixtures/http-error-policy.ts):\n${breakdown}`,
+      );
+    }
+
     // Check for errors and fail test if not allowed
     if (errors.length > 0) {
       const flowErrors = errors.filter((e) => e.type === "flow_error");
@@ -240,7 +303,14 @@ export const test = base.extend({
         );
       }
       if (httpErrors.length > 0) {
-        console.log(`   ⚠️  ${httpErrors.length} HTTP error(s) detected`);
+        // Say what happens next, because nothing does. An HTTP error is logged
+        // and never fails the test — on any path, for any endpoint — so the only
+        // thing between a real backend 500 and a green run is someone reading
+        // this line. Leaving that implicit is how the suite ended up with docs
+        // claiming a gate it does not have (#1084).
+        console.log(
+          `   ⚠️  ${httpErrors.length} HTTP error(s) detected — ADVISORY: these do NOT fail the test. Review them before trusting this run.`,
+        );
       }
 
       // Fail the test if flow errors occurred and weren't allowed

--- a/tests/fixtures/http-error-policy.test.ts
+++ b/tests/fixtures/http-error-policy.test.ts
@@ -1,0 +1,149 @@
+// Unit tests for the base fixture's HTTP-error classification (#1084).
+// Run with: npm run test:units
+//
+// Why these exist: the classification used to live inside `fixtures.ts`, where it
+// only ran in a live browser session — so "does the monitor see a 403?" could be
+// answered only by running the suite and reading a terminal. It did not, for two
+// years, while `CLAUDE.md` advertised 4xx/5xx coverage. Every URL/status pair
+// below was observed against Langflow Nightly 1.12.0.dev9 while resolving #1084.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { classifyHttpError } from "./http-error-policy";
+
+const BASE = "http://localhost:7860";
+
+test("the four codes the old filter matched are still monitored", () => {
+  for (const status of [400, 404, 422, 500]) {
+    assert.equal(
+      classifyHttpError({ url: `${BASE}/api/v1/flows/`, status }).monitored,
+      true,
+      `${status} must stay monitored — widening the filter must not drop coverage`,
+    );
+  }
+});
+
+test("the codes the old filter missed are now monitored", () => {
+  // Each of these was measured invisible before the fix:
+  //   405 — an in-page `DELETE /api/v1/version` (probe C)
+  //   403 — `GET /api/v1/flows/` with no credentials, the shape seen under
+  //         contention in #773 and the #1052 review
+  //   502/503 — a wedged or restarting backend (#1030/#1048), and the 503 the
+  //         `execution-error-notification` spec mocks on purpose
+  const cases: Array<[number, string]> = [
+    [401, "/api/v1/flows/"],
+    [403, "/api/v1/flows/"],
+    [405, "/api/v1/version"],
+    [409, "/api/v1/mcp/servers"],
+    [502, "/api/v1/flows/"],
+    [503, "/api/v2/workflows"],
+    [504, "/api/v1/build/abc"],
+  ];
+  for (const [status, path] of cases) {
+    assert.equal(
+      classifyHttpError({ url: `${BASE}${path}`, status }).monitored,
+      true,
+      `${status} ${path} must be monitored — "4xx/5xx" is what the docs promise`,
+    );
+  }
+});
+
+test("a successful or redirect response is never an error", () => {
+  for (const status of [200, 201, 204, 302, 304, 399]) {
+    const verdict = classifyHttpError({ url: `${BASE}/api/v1/flows/`, status });
+    assert.equal(verdict.monitored, false);
+  }
+});
+
+test("auth endpoints stay ignored, including the ones specs mock into 500", () => {
+  // Real routes from the suite: `login-invalid-credentials`, `session-expired`,
+  // `logout-flow`, `admin-password-change` and
+  // `general-bugs-component-webhook-api-key-display` all fulfil these with 500
+  // deliberately. Reporting those would be reporting the test's own fixture.
+  for (const path of [
+    "/api/v1/login",
+    "/api/v1/auto_login",
+    "/api/v1/refresh",
+    "/api/v1/logout",
+  ]) {
+    const verdict = classifyHttpError({ url: `${BASE}${path}`, status: 500 });
+    assert.equal(verdict.monitored, false, `${path} must stay ignored`);
+    assert.match(
+      verdict.monitored === false ? verdict.ignoreReason : "",
+      /auth endpoint/,
+    );
+  }
+});
+
+test("the external Langflow Store is ignored, with the reason recorded", () => {
+  // The concrete trigger for #1084: a container with no outbound DNS answers
+  // `500 [Errno -2] Name or service not known`, three times per test.
+  const verdict = classifyHttpError({
+    url: `${BASE}/api/v1/store/tags`,
+    status: 500,
+  });
+  assert.equal(verdict.monitored, false);
+  assert.match(
+    verdict.monitored === false ? verdict.ignoreReason : "",
+    /external/,
+  );
+  assert.equal(
+    classifyHttpError({ url: `${BASE}/api/v1/store/components`, status: 500 })
+      .monitored,
+    false,
+    "the whole Store prefix, not just /tags",
+  );
+});
+
+test("the ambient DELETE /api/v1/flows/ 500 stays VISIBLE", () => {
+  // Measured twice in one 48-test run, in two unrelated specs, both green. It is
+  // a real Langflow 500 on bulk delete, not an environmental artefact, so the
+  // one thing it must not become is an allowlist entry — this test is here to
+  // fail if someone silences it to quieten the log.
+  assert.equal(
+    classifyHttpError({ url: `${BASE}/api/v1/flows/`, status: 500 }).monitored,
+    true,
+  );
+});
+
+test("non-API traffic is ignored", () => {
+  for (const url of [
+    `${BASE}/assets/index-CSJ7TV2F.js`,
+    `${BASE}/favicon.ico`,
+    "https://cdn.example.com/font.woff2",
+  ]) {
+    const verdict = classifyHttpError({ url, status: 404 });
+    assert.equal(verdict.monitored, false, `${url} must be ignored`);
+  }
+});
+
+test("an unparseable URL is ignored instead of throwing", () => {
+  // This runs inside a `page.on("response")` handler: a throw there would break
+  // the very test the monitor is supposed to be observing.
+  assert.doesNotThrow(() =>
+    classifyHttpError({ url: "not-a-url", status: 500 }),
+  );
+  const verdict = classifyHttpError({ url: "not-a-url", status: 500 });
+  assert.equal(verdict.monitored, false);
+  assert.match(
+    verdict.monitored === false ? verdict.ignoreReason : "",
+    /unparseable URL/,
+  );
+});
+
+test("every ignore verdict carries a reason", () => {
+  const ignored = [
+    { url: `${BASE}/api/v1/flows/`, status: 200 },
+    { url: `${BASE}/api/v1/login`, status: 401 },
+    { url: `${BASE}/api/v1/store/tags`, status: 500 },
+    { url: `${BASE}/favicon.ico`, status: 404 },
+    { url: "://broken", status: 500 },
+  ];
+  for (const facts of ignored) {
+    const verdict = classifyHttpError(facts);
+    assert.equal(verdict.monitored, false, `${facts.url} ${facts.status}`);
+    assert.ok(
+      verdict.monitored === false && verdict.ignoreReason.length > 0,
+      `an ignore without a reason cannot be reviewed: ${facts.url}`,
+    );
+  }
+});

--- a/tests/fixtures/http-error-policy.ts
+++ b/tests/fixtures/http-error-policy.ts
@@ -1,0 +1,109 @@
+/**
+ * Decides which backend HTTP responses the base fixture reports as errors.
+ *
+ * Extracted from `fixtures.ts` (#1084) for two reasons:
+ *
+ * 1. **It was wrong and nobody could tell.** The filter matched four exact
+ *    status codes — `400 || 404 || 422 || 500` — while `CLAUDE.md` advertised
+ *    "4xx/5xx monitoring". Measured on 1.12.0.dev9: an in-page `405` and the
+ *    `403 — No authentication credentials provided` that an unauthenticated
+ *    `/api/v1/flows/` returns were both **invisible**, as were the `502`/`503`
+ *    a wedged or restarting backend produces (#1030/#1048).
+ * 2. **The fixture cannot be unit-tested.** It only runs inside a real browser
+ *    session, so the classification was provable only by running the suite and
+ *    reading a terminal. As a pure function it is covered by
+ *    `npm run test:units` on every PR.
+ *
+ * ## This decides visibility, not pass/fail
+ *
+ * An `http_error` is **logged and never fails a test** — that is the fixture's
+ * real, measured behaviour (see `fixtures.ts`, and `CLAUDE.md`'s validation
+ * step). The load-bearing part of the mechanism is therefore a human reading
+ * the log, which makes noise the actual defect: a log that always carries the
+ * same three 500s is a log nobody reads carefully. That is what #1084 was
+ * raised for — every entry in `IGNORED` below exists to keep a logged error
+ * meaningful, and nothing is ignored merely because it is inconvenient.
+ */
+
+export interface HttpResponseFacts {
+  url: string;
+  status: number;
+}
+
+export type HttpErrorVerdict =
+  /** Report it: `🚨 Backend Error` in the log and one entry in the test's error list. */
+  | { monitored: true }
+  /** Stay quiet, and say why — an ignore without a reason is indistinguishable from a bug. */
+  | { monitored: false; ignoreReason: string };
+
+/**
+ * Endpoints whose error responses carry no signal about the product under test.
+ *
+ * Deliberately short. Anything added here becomes invisible to every spec in the
+ * suite, so an entry needs a reason that survives review — not "it is noisy".
+ */
+const IGNORED: Array<{ matches: (pathname: string) => boolean; reason: string }> =
+  [
+    {
+      // Pre-existing behaviour, kept: the auth specs drive these endpoints into
+      // 4xx/5xx on purpose (invalid credentials, expired session, mocked 500s),
+      // and the SPA probes `/refresh` speculatively, so a 401 here is routine
+      // rather than a finding.
+      matches: (p) =>
+        p.endsWith("/login") ||
+        p.endsWith("/auto_login") ||
+        p.endsWith("/refresh") ||
+        p.endsWith("/logout"),
+      reason: "auth endpoint — answers 4xx by design and is driven there deliberately",
+    },
+    {
+      // The Langflow Store is an EXTERNAL service. A container without outbound
+      // DNS answers `500 … [Errno -2] Name or service not known`, which is what
+      // exposed this whole gap: in the #1052 review every test in a 20-test
+      // slice logged three of these, and a log like that trains readers to skip
+      // it. Environmental, not a Langflow defect (#1084 → "Not in scope").
+      matches: (p) => p.startsWith("/api/v1/store/"),
+      reason: "Langflow Store is external — unreachable in CI, environmental not a product defect",
+    },
+  ];
+
+/**
+ * Classifies one response.
+ *
+ * `status >= 400` rather than a code list: this is the "4xx/5xx" the docs always
+ * claimed. Widening it cost **zero** extra noise when measured over 48 `@stable`
+ * tests in `ui-ux` + `project-management` (the only two errors in that run were
+ * `DELETE /api/v1/flows/` → 500, already matched by the old list).
+ *
+ * A URL this cannot parse is treated as unmonitored rather than throwing — the
+ * caller runs inside a `page.on("response")` handler, where a throw would break
+ * the test it is supposed to be observing.
+ */
+export function classifyHttpError({
+  url,
+  status,
+}: HttpResponseFacts): HttpErrorVerdict {
+  if (status < 400) {
+    return { monitored: false, ignoreReason: "not an error status" };
+  }
+
+  let pathname: string;
+  try {
+    pathname = new URL(url).pathname;
+  } catch {
+    return { monitored: false, ignoreReason: `unparseable URL: ${url}` };
+  }
+
+  if (!pathname.includes("/api/")) {
+    return {
+      monitored: false,
+      ignoreReason: "not a backend API call (static asset, page navigation, third party)",
+    };
+  }
+
+  for (const { matches, reason } of IGNORED) {
+    if (matches(pathname)) return { monitored: false, ignoreReason: reason };
+  }
+
+  return { monitored: true };
+}

--- a/tests/tests-automations/regression/core-functionality/llm-agents/llm-invalid-api-key-ui.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/llm-invalid-api-key-ui.spec.ts
@@ -1,4 +1,8 @@
-import { expect, test } from "../../../../fixtures/fixtures";
+import {
+  expect,
+  test,
+  type PageWithErrorHooks,
+} from "../../../../fixtures/fixtures";
 import { setupPlayground } from "../../../../helpers/flows/setup-playground";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
@@ -19,7 +23,13 @@ test.describe("LLM Invalid API Key UI Error Display", () => {
     async ({ page }) => {
       // This test intentionally injects an HTTP 500 on the run endpoint, so the
       // fixture's backend-error monitor will see it — allow it explicitly.
-      (page as any).allowFlowErrors();
+      // `allowFlowErrors()` alone never covered the HTTP side: it gates flow
+      // execution errors only, so the mocked 500 was logged as a backend error
+      // on every run of this spec regardless. `allowHttpErrors()` is what the
+      // comment above always meant (#1084).
+      const hooks = page as PageWithErrorHooks;
+      hooks.allowFlowErrors();
+      hooks.allowHttpErrors();
       createdFlowId = await setupPlayground(page);
 
       // Open Playground first so initialization build calls are not intercepted
@@ -81,7 +91,13 @@ test.describe("LLM Invalid API Key UI Error Display", () => {
     async ({ page }) => {
       // This test intentionally injects an HTTP 500 on the run endpoint, so the
       // fixture's backend-error monitor will see it — allow it explicitly.
-      (page as any).allowFlowErrors();
+      // `allowFlowErrors()` alone never covered the HTTP side: it gates flow
+      // execution errors only, so the mocked 500 was logged as a backend error
+      // on every run of this spec regardless. `allowHttpErrors()` is what the
+      // comment above always meant (#1084).
+      const hooks = page as PageWithErrorHooks;
+      hooks.allowFlowErrors();
+      hooks.allowHttpErrors();
       createdFlowId = await setupPlayground(page);
 
       // Open Playground first so initialization build calls are not intercepted

--- a/tests/tests-automations/regression/ui-ux/execution-error-notification.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/execution-error-notification.spec.ts
@@ -1,5 +1,9 @@
 import type { Page } from "@playwright/test";
-import { expect, test } from "../../../fixtures/fixtures";
+import {
+  expect,
+  test,
+  type PageWithErrorHooks,
+} from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { zoomOut } from "../../../helpers/ui/zoom-out";
@@ -140,17 +144,21 @@ test.describe("Execution Error Notifications", () => {
     "executing flow with server error shows error feedback",
     { tag: ["@release", "@workspace", "@observability"] },
     async ({ page }) => {
-      (page as any).allowFlowErrors();
+      const hooks = page as PageWithErrorHooks;
+      hooks.allowFlowErrors();
+      // The mocked 5xx below is this test's own fixture, not a finding — declare
+      // it so it stays out of the advisory error log (#1084).
+      hooks.allowHttpErrors();
       trackCreatedFlows(page);
       await setupChatFlow(page);
       await openPlayground(page);
 
-      // Return a 5xx from the execution endpoint (server-side failure). Uses
-      // 503, not 500: the fixture's global response monitor flags real backend
-      // errors on 400/404/422/500 (see fixtures.ts) and would treat this mocked
-      // 500 as an instance error. 503 is an equally valid server failure that
-      // drives the same "Workflow run failed" path without tripping the monitor
-      // on the shared instance. Live-confirmed on 1.11.0.dev41.
+      // Return a 5xx from the execution endpoint (server-side failure). 503 was
+      // originally chosen to slip past the fixture's monitor, which only matched
+      // 400/404/422/500 — that filter now covers every 4xx/5xx, so the evasion
+      // no longer works and `allowHttpErrors()` above is what keeps the mocked
+      // response out of the log (#1084). The status stays 503 because it drives
+      // the same "Workflow run failed" path, live-confirmed on 1.11.0.dev41.
       await page.route(WORKFLOWS_ENDPOINT, async (route) => {
         await route.fulfill({
           status: 503,


### PR DESCRIPTION
Closes #1084

## The problem

`CLAUDE.md` advertised "automatic backend HTTP error monitoring (4xx/5xx)". Neither half of that sentence was true.

**It matched four exact codes**, not a range: `status === 400 || status === 404 || status === 422 || status === 500`. Measured live on Langflow Nightly 1.12.0.dev9 while resolving this — an in-page `405`, and the `403 — No authentication credentials provided` an unauthenticated `GET /api/v1/flows/` returns, were both **invisible**, as were the `502`/`503` a wedged or restarting backend produces (#1030/#1048). `execution-error-notification` had already worked this out and mocked a **503 specifically to slip past the filter**, saying so in a comment.

**And an `http_error` never fails a test** — it is logged, counted, and then nothing happens to it, on any path, for any endpoint. Only `flow_error` throws. So the load-bearing part of the mechanism is a human reading the terminal, which makes noise the real defect: in the #1052 review every test in a 20-test slice logged three `500 /api/v1/store/tags` (no outbound DNS in the container), and a log that always carries the same three 500s is a log nobody reads carefully.

## The decision, and the measurement behind it

**HTTP errors stay advisory.** Making them fail was measured before being rejected, not assumed away:

| Question | Measured |
|---|---|
| Would the 15 API specs that assert 4xx on purpose break? | **No.** `page.request` traffic does not emit `page.on("response")` — verified by probe. Immune either way. |
| Deliberate page-traffic error mocks outside the auth exemption | **2 specs** (503 and 500) |
| Ambient noise over 48 `@stable` tests (ui-ux + project-management) | **2 events**, both `DELETE /api/v1/flows/` → 500 — an ambient upstream bug in *cleanup*, not in any test's subject |
| Extra noise from widening 4 codes → all 4xx/5xx | **0** |

So the blast radius is small — but 48 of **429** `@stable` tests is not a basis for flipping a suite-wide gate. This PR ships the mechanism and honest documentation and leaves enforcement to be decided on a full daily's data, which `PW_HTTP_ERROR_DEBUG=1` now produces.

## What changed

- **`tests/fixtures/http-error-policy.ts` (new)** — `classifyHttpError()` as a pure function: every 4xx/5xx on an `/api/` route, minus exemptions that each must carry a **reason** (auth endpoints; the external Langflow Store, unreachable from CI). Extracted because inside the fixture it only ran in a live browser, so "does the monitor see a 403?" was answerable only by running the suite and reading a terminal. Now covered by `npm run test:units` on every PR.
- **`page.allowHttpErrors()` + a `PageWithErrorHooks` type** — for specs that drive an endpoint into an error on purpose. `llm-invalid-api-key-ui` already carried a comment claiming it allowed exactly this and called `allowFlowErrors()`, which never covered the HTTP side: that spec logged its own mocked 500 as a backend error on every run.
- **The summary line now says what happens next**, because nothing does: `⚠️ N HTTP error(s) detected — ADVISORY: these do NOT fail the test.`
- **Docs corrected** — `CLAUDE.md` (the fixture description and validation step 4) and `CONTRIBUTING.md` (the import note and step 5) now state that `flow_error` fails and `http_error` only logs, and that reading the log is therefore the only gate.

### One extra defect, found while verifying this

The error was pushed into the array **after** `await response.text()`, inside an async handler the fixture teardown does not wait for. An error late in a test raced the summary and disappeared from it — measured: a 405 printed `🚨 Backend Error` with **no** `📋 Found N backend error(s)` line at all. Intermittent, not constant (both errors in the 48-test slice were counted). Since that summary is the entire gate for HTTP errors, an undercount is the one failure the mechanism cannot afford. Fixed by recording before reading the body.

## Validation

Against Langflow Nightly **1.12.0.dev9**, re-run on this branch after #1119 landed.

- `npm run test:units` — **181/181** (9 new) · `npm run test:scripts` — **157/157**
- `npm run typecheck` — 0 errors · `npm run lint` — 0 errors (the new files produce **zero** warnings) · `npm run check:checklist-coverage` — pass
- **50 `@stable` tests** (ui-ux + project-management + `llm-invalid-api-key-ui`) with the widened filter live: **50/50 in 3.3 min**, one single `🚨` — the same ambient `DELETE /api/v1/flows/` 500. Widening added **zero** noise.
- Touched specs: **4 passed, 1 skipped** (the `test.fixme` quarantined under #1063), no `🚨`.
- Wiring verified live: a 405 **is** now reported; `allowHttpErrors()` suppresses it; Store and auth responses are ignored **with the reason printed** under `PW_HTTP_ERROR_DEBUG=1`.
- Flow orphans: 30 before, 30 after — nothing leaked.

**Force-fail (5, executed and reverted):**

| # | Mutation | Result |
|---|---|---|
| FF1 | filter narrowed back to the four codes | *"the codes the old filter missed are now monitored"* fails |
| FF2 | `DELETE /api/v1/flows/` added to the exemption list | 3 tests fail, including the *"stays VISIBLE"* guard — which exists precisely to catch someone silencing that 500 to quieten the log |
| FF3 | an exemption with an empty reason | *"every ignore verdict carries a reason"* fails |
| FF4 | hatch removed from `llm-invalid-api-key-ui` | the spec goes back to logging its **own mock** as a Backend Error on both tests, every run |
| FF5 | revert proven | 0 mutation markers, all green |

## Honest limits

- Measured 50 of 429 `@stable` tests. Sufficient for this change — nothing newly fails, and the worst case is one extra log line — and deliberately insufficient for the enforcement flip, which is why the debug switch ships with it.
- The `DELETE /api/v1/flows/` 500 is **left visible on purpose**. It is a real Langflow 500, and FF2 exists to stop it being allowlisted later just to quieten the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## ⚠️ Reviewer: this is a suite-wide change — the PR E2E job does not cover it

`tests/fixtures/fixtures.ts` is one of the paths `pr-validation.yml` treats as suite-wide. The
import-graph selector resolves this diff to **all 236 specs**, and `IMPACTED_SPEC_CAP` selects
20 — so **216 specs are dropped** from the PR run (listed in the job log and run summary, per
#1012's rule). Verified locally with the same script:

```
$ git diff --name-only --diff-filter=d origin/main...HEAD | \
    node scripts/impacted-specs-by-import.mjs --stdin --format=json --cap 20
fullSuite: true   specs resolved: 236   selected: 20   dropped: 216
```

Every spec in the suite imports this fixture, so **dispatch `manual.yml` for a full run before
merging.** The local evidence above covers 50 `@stable` tests; the PR job adds 20 more; neither
is the whole suite.
