### PR TITLE
fix(mcp): address the starter-project MCP server row by name (#1123)

### DIFF
--- a/docs/mcp/server/mcp-server-starter-projects.md
+++ b/docs/mcp/server/mcp-server-starter-projects.md
@@ -50,7 +50,8 @@ is out of sync with the project folder), or the duplicate-server guard is gone.
 
 **Test 1 — starter projects & folder CRUD**
 
-1. Bootstrap (skip modal); `cleanOldFolders` to start from a known project set.
+1. Bootstrap (skip modal); `cleanOldFolders` to start from a known project set,
+   then delete any leftover `renamed_project` via the API — see **Notes**.
 2. Settings → **MCP Servers**: assert exactly one server row is named
    `lf-starter_project`, addressed **by name** (`mcp_server_name_<index>` filtered
    on the exact name) rather than by position — see **Notes**.
@@ -84,15 +85,21 @@ is out of sync with the project folder), or the duplicate-server guard is gone.
 
 ## Guarding against false positives *(how)*
 
-- **Exact-name counts** (`.count()` === 1 / === 0 on `getByText(..., {exact:true})`)
-  instead of "visible", so a stale or partially-matching row cannot pass.
+- **Exact-name counts** (`toHaveCount(1)` / `toHaveCount(0)` on
+  `getByText(..., {exact:true})`) instead of "visible", so a stale or
+  partially-matching row cannot pass.
+- **Auto-retrying counts** — every count assertion is `await expect(...)
+  .toHaveCount(n)`, never `expect(await ....count())`. The MCP-server row is
+  written by the backend as a side effect of the project write and can lag the
+  navigation; a single DOM read turns that lag into a failure (#1135).
 - **Starter-project presence** re-checked after every mutation, so a project
   operation that silently drops the starter project's server cannot pass.
 - **Row-scoped locator** — the starter-project assert filters the
   `mcp_server_name_<index>` server rows on the exact name, so matching text
   elsewhere on the page (a heading, a tooltip, an error string) cannot satisfy it.
-- **`cleanOldFolders`** normalizes the starting project set so the add/rename/
-  delete counts are deterministic.
+- **`cleanOldFolders` + leftover-`renamed_project` sweep** normalize the starting
+  project set so the add/rename/delete counts are deterministic, and so a failed
+  attempt cannot change what the next one measures.
 - **Force-failure check** (CONTRIBUTING §2) run during VERIFY on the name/count
   assertions of each test.
 
@@ -153,7 +160,19 @@ is out of sync with the project folder), or the duplicate-server guard is gone.
   *projects*, and this is an internal server (`langflow_internal: True`), not a
   project-derived one.
 - Test 1 mutates project folders; `cleanOldFolders` in setup keeps the counts
-  deterministic across reruns. Runs `--workers=1` in CI (shared project state).
+  deterministic across reruns. It shares the superuser account with everything
+  else in the run — CI runs `workers: 2` (`playwright.config.ts`), and nothing
+  pins this file to serial, so the counts must tolerate concurrent flow/project
+  activity. They do, because every one of them is scoped to a name this spec
+  owns (`lf-new_project*`, `lf-renamed_project`, `lf-starter_project`).
+- **Leftover `renamed_project` is swept in setup (#1135).** `cleanOldFolders`
+  only deletes folders named "New Project*", so an attempt that dies between the
+  rename (step 4) and the delete (step 5) leaves `renamed_project` on the
+  account. The next attempt's rename then hits `UNIQUE constraint failed:
+  folder.user_id, folder.name` → **500**, and fails for a reason the first
+  attempt never had — retries stop being independent evidence. Setup now deletes
+  any leftover by id via `deleteProject` before the rename. The sweep is in
+  *setup*, not teardown, so it also heals a run that was killed outright.
 - No standalone flows are created that need id-scoped cleanup — the artifacts are
   **projects/folders**, created and then renamed/deleted within the test; the
   duplicate-server test adds a server registration, not a flow.

--- a/docs/mcp/server/mcp-server-starter-projects.md
+++ b/docs/mcp/server/mcp-server-starter-projects.md
@@ -29,7 +29,9 @@ is out of sync with the project folder), or the duplicate-server guard is gone.
 `@release` `@workspace` `@components` `@mcp` `@stable` (both tests)
 
 - `@stable` — promoted under #948 after repeated clean `--workers=1 --retries=0`
-  runs on nightly 1.12.0.dev4 and a per-test force-failure check.
+  runs on nightly 1.12.0.dev4 and a per-test force-failure check. Auto-removed
+  from test 1 by the daily workflow on 2026-07-30 and restored under #1123 after
+  the positional-addressing fix (see **Notes**).
 - `@workspace` — project/folder management; `@components`/`@mcp` — MCP servers
   settings; `@release` — happy-path MCP-server surfacing.
 
@@ -49,15 +51,16 @@ is out of sync with the project folder), or the duplicate-server guard is gone.
 **Test 1 — starter projects & folder CRUD**
 
 1. Bootstrap (skip modal); `cleanOldFolders` to start from a known project set.
-2. Settings → **MCP Servers**: assert `mcp_server_name_0` contains
-   `lf-starter_project`.
+2. Settings → **MCP Servers**: assert exactly one server row is named
+   `lf-starter_project`, addressed **by name** (`mcp_server_name_<index>` filtered
+   on the exact name) rather than by position — see **Notes**.
 3. Add two projects (`add-project-button` ×2); back on MCP Servers, assert
-   `lf-starter_project` still first, and `lf-new_project` / `lf-new_project_1`
+   `lf-starter_project` is still listed, and `lf-new_project` / `lf-new_project_1`
    each appear exactly once.
 4. **Rename** the first "New Project" folder to `renamed_project`; on MCP Servers
-   assert `lf-renamed_project` appears exactly once (and starter still first).
+   assert `lf-renamed_project` appears exactly once (and starter still listed).
 5. **Delete** the renamed project; on MCP Servers assert `lf-renamed_project`
-   count is 0 (and starter still first).
+   count is 0 (and starter still listed).
 
 **Test 2 — duplicate MCP server rejected**
 
@@ -72,9 +75,10 @@ is out of sync with the project folder), or the duplicate-server guard is gone.
 ## Validation criterion *(required)*
 
 - **Test 1:** the MCP Servers page mirrors project-folder state at each step —
-  `lf-starter_project` always first; added projects appear by name (count 1);
-  a renamed project's server appears as `lf-renamed_project`; a deleted project's
-  server disappears (count 0).
+  a server row named exactly `lf-starter_project` is present (count 1) at every
+  step; added projects appear by name (count 1); a renamed project's server
+  appears as `lf-renamed_project`; a deleted project's server disappears
+  (count 0). **Row order is not part of the contract** — see **Notes**.
 - **Test 2:** re-adding an already-registered server surfaces exactly one
   "Server already exists." error (no silent success, no duplicate rows).
 
@@ -82,7 +86,11 @@ is out of sync with the project folder), or the duplicate-server guard is gone.
 
 - **Exact-name counts** (`.count()` === 1 / === 0 on `getByText(..., {exact:true})`)
   instead of "visible", so a stale or partially-matching row cannot pass.
-- **Ordering assert** (`mcp_server_name_0` first) re-checked after every mutation.
+- **Starter-project presence** re-checked after every mutation, so a project
+  operation that silently drops the starter project's server cannot pass.
+- **Row-scoped locator** — the starter-project assert filters the
+  `mcp_server_name_<index>` server rows on the exact name, so matching text
+  elsewhere on the page (a heading, a tooltip, an error string) cannot satisfy it.
 - **`cleanOldFolders`** normalizes the starting project set so the add/rename/
   delete counts are deterministic.
 - **Force-failure check** (CONTRIBUTING §2) run during VERIFY on the name/count
@@ -92,6 +100,9 @@ is out of sync with the project folder), or the duplicate-server guard is gone.
 
 ## What this test does not cover *(optional)*
 
+- The **row order** of the MCP Servers list, and the internal `langflow-agentic`
+  server Langflow injects into every user's list (see **Notes**) — neither is part
+  of the §14.1 contract, so neither is asserted.
 - MCP tool **selection/config** in the flow tab — `mcp-server-tab.spec.ts`.
 - MCP-server tool **execution** / **resources** over the protocol —
   `mcp-server-protocol.spec.ts` / `mcp-server-resources.spec.ts`.
@@ -101,7 +112,7 @@ is out of sync with the project folder), or the duplicate-server guard is gone.
 
 ## External dependencies *(required)*
 
-- Settings → MCP Servers page (`mcp_server_name_0`, `add-mcp-server-button-page`,
+- Settings → MCP Servers page (`mcp_server_name_<index>`, `add-mcp-server-button-page`,
   `add-mcp-server-button`, `json-input`) via `helpers/ui/go-to-settings.ts`
   (`navigateSettingsPages`).
 - Project folder CRUD (`add-project-button`, `more-options-button_<name>`,
@@ -116,6 +127,9 @@ is out of sync with the project folder), or the duplicate-server guard is gone.
 
 - If projects stop mapping 1:1 to MCP servers, or the `lf-` server-name prefix
   changes.
+- If Langflow starts **sorting** the MCP Servers list, or stops injecting
+  `langflow-agentic` (i.e. `agentic_experience` defaults back to off) — either
+  would change what row order means, though this test no longer depends on it.
 - If the MCP Servers settings page testids or the add-server modal change.
 - If the duplicate-server error copy ("Server already exists.") changes.
 
@@ -123,6 +137,21 @@ is out of sync with the project folder), or the duplicate-server guard is gone.
 
 ## Notes *(optional)*
 
+- **Row position is deliberately NOT asserted (#1123).** Test 1 originally read
+  `mcp_server_name_0` and expected the starter project. Langflow upstream enabled
+  the agentic experience by default (`agentic_experience: bool = True`, langflow
+  commit `d4d5592c1c` / langflow#14244, 2026-07-24), and with that flag on,
+  `auto_configure_agentic_mcp_server()` injects an internal server named
+  `langflow-agentic` into **every** user's MCP configuration at startup. Measured
+  on the nightly line, that row is created ~10 s **before** the starter project's
+  server, and `GET /api/v2/mcp/servers` orders by `created_at` while the page
+  renders that order with no sort — so `langflow-agentic` is permanently row 0 and
+  the positional assert failed deterministically. The starter project itself was
+  **not** renamed or dropped (`lf-starter_project` is still listed, at index 1),
+  so the §14.1 premise is intact and the fix is to address the row by name.
+  `cleanOldFolders` cannot and should not remove `langflow-agentic` — it deletes
+  *projects*, and this is an internal server (`langflow_internal: True`), not a
+  project-derived one.
 - Test 1 mutates project folders; `cleanOldFolders` in setup keeps the counts
   deterministic across reruns. Runs `--workers=1` in CI (shared project state).
 - No standalone flows are created that need id-scoped cleanup — the artifacts are
@@ -136,3 +165,11 @@ is out of sync with the project folder), or the duplicate-server guard is gone.
   fail the test (only `flow_error` fails; `http_error` is log-only). The test's
   assertions do not depend on that call. Import switched to `fixtures/fixtures.ts`
   under #948 to gain this monitoring; the 500 is peripheral/pre-existing.
+- **Second ambient 500 on the same endpoint (test 2, logged, not failing):**
+  re-validating on the 1.12 nightly line under #1123, the logged
+  `500 … /api/v2/mcp/servers/lf-starter_project` carried
+  `{"detail":"Server already exists."}` — i.e. test 2's duplicate-add is
+  *correctly* rejected, but the rejection answers **500 instead of 409**. That is
+  the status-code defect tracked in #991, not a failure of this test: the UI still
+  surfaces the "Server already exists." message the test asserts. Kept log-only
+  here; #991 owns the status-code contract.

--- a/tests/tests-automations/regression/mcp/server/mcp-server-starter-projects.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-starter-projects.spec.ts
@@ -3,7 +3,11 @@ import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { cleanOldFolders } from "../../../../helpers/filesystem/clean-old-folders";
 import { convertTestName } from "../../../../helpers/filesystem/convert-test-name";
+import { deleteProject } from "../../../../helpers/flows/delete-project";
 import { navigateSettingsPages } from "../../../../helpers/ui/go-to-settings";
+
+/** The name test 1 renames its first project to. */
+const RENAMED_PROJECT = "renamed_project";
 
 /**
  * Address an MCP server row on the Settings → MCP Servers page **by name**.
@@ -22,6 +26,38 @@ const mcpServerRow = (page: Page, name: string) =>
     .getByTestId(/^mcp_server_name_\d+$/)
     .filter({ hasText: new RegExp(`^${name}$`) });
 
+/**
+ * Delete any leftover `renamed_project` before the test renames a project to it.
+ *
+ * `cleanOldFolders` only removes folders named "New Project*", so an attempt
+ * that dies between the rename (step 4) and the delete (step 5) leaves
+ * `renamed_project` on the shared superuser account. The next attempt then hits
+ * `UNIQUE constraint failed: folder.user_id, folder.name` on its own rename —
+ * a 500 that makes the retry fail for a reason the first attempt did not have,
+ * so the retries stop being independent evidence. Observed on PR #1135's CI run
+ * (3/3 attempts red, two of them on the leftover rather than the original
+ * defect).
+ *
+ * API rather than the sidebar: this is teardown of the *previous* run, so it
+ * must not depend on the UI state the test is about to assert on. `deleteProject`
+ * treats 404 as the desired end state and retries the #965 contention 500.
+ */
+const removeLeftoverRenamedProject = async (page: Page) => {
+  const response = await page.request.get("/api/v1/projects/");
+  if (!response.ok()) return;
+
+  // The /api/v1/projects/ response shape varies (sometimes a bare array,
+  // sometimes `{ folders: [...] }`); mcp-server.spec.ts normalizes the same way.
+  const raw = await response.json();
+  const projects: Array<{ id: string; name: string }> = Array.isArray(raw)
+    ? raw
+    : (raw.folders ?? []);
+
+  for (const project of projects.filter((p) => p.name === RENAMED_PROJECT)) {
+    await deleteProject(page.request, project.id);
+  }
+};
+
 test(
   "user must be able to see starter projects for mcp servers",
   { tag: ["@stable", "@release", "@workspace", "@components", "@mcp"] },
@@ -33,6 +69,7 @@ test(
     });
 
     await cleanOldFolders(page);
+    await removeLeftoverRenamedProject(page);
 
     await navigateSettingsPages(page, "Settings", "MCP Servers");
 
@@ -49,12 +86,16 @@ test(
 
     await expect(mcpServerRow(page, "lf-starter_project")).toHaveCount(1);
 
-    expect(
-      await page.getByText("lf-new_project", { exact: true }).count(),
-    ).toBe(1);
-    expect(
-      await page.getByText("lf-new_project_1", { exact: true }).count(),
-    ).toBe(1);
+    // toHaveCount, not `expect(await ....count())`: the MCP-server row is
+    // written by the backend as a side effect of the project write, so it can
+    // lag the navigation. A bare .count() reads the DOM once and fails on that
+    // lag; toHaveCount polls until the expectation timeout (#1135).
+    await expect(page.getByText("lf-new_project", { exact: true })).toHaveCount(
+      1,
+    );
+    await expect(
+      page.getByText("lf-new_project_1", { exact: true }),
+    ).toHaveCount(1);
 
     await page.getByTestId("icon-ChevronLeft").first().click();
 
@@ -74,7 +115,7 @@ test(
           .last()
           .click();
         await page.getByText("Rename", { exact: true }).last().click();
-        await page.getByTestId("input-project").last().fill("renamed_project");
+        await page.getByTestId("input-project").last().fill(RENAMED_PROJECT);
         await page.keyboard.press("Enter");
         await page.waitForTimeout(1000);
       });
@@ -83,9 +124,9 @@ test(
 
     await expect(mcpServerRow(page, "lf-starter_project")).toHaveCount(1);
 
-    expect(
-      await page.getByText("lf-renamed_project", { exact: true }).count(),
-    ).toBe(1);
+    await expect(
+      page.getByText("lf-renamed_project", { exact: true }),
+    ).toHaveCount(1);
 
     //delete a folder
 
@@ -106,9 +147,9 @@ test(
     await navigateSettingsPages(page, "Settings", "MCP Servers");
 
     await expect(mcpServerRow(page, "lf-starter_project")).toHaveCount(1);
-    expect(
-      await page.getByText("lf-renamed_project", { exact: true }).count(),
-    ).toBe(0);
+    await expect(
+      page.getByText("lf-renamed_project", { exact: true }),
+    ).toHaveCount(0);
   },
 );
 

--- a/tests/tests-automations/regression/mcp/server/mcp-server-starter-projects.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-starter-projects.spec.ts
@@ -1,12 +1,30 @@
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { cleanOldFolders } from "../../../../helpers/filesystem/clean-old-folders";
 import { convertTestName } from "../../../../helpers/filesystem/convert-test-name";
 import { navigateSettingsPages } from "../../../../helpers/ui/go-to-settings";
 
+/**
+ * Address an MCP server row on the Settings → MCP Servers page **by name**.
+ *
+ * Row order is not part of the §14.1 contract and must not be asserted (#1123):
+ * with `agentic_experience` enabled by default upstream, Langflow injects an
+ * internal `langflow-agentic` server that is created before the starter
+ * project's, and the page renders `GET /api/v2/mcp/servers` (ordered by
+ * `created_at`) with no sort — so index 0 is not the starter project.
+ *
+ * Filtering the `mcp_server_name_<index>` rows keeps the assertion scoped to the
+ * server list, so matching text elsewhere on the page cannot satisfy it.
+ */
+const mcpServerRow = (page: Page, name: string) =>
+  page
+    .getByTestId(/^mcp_server_name_\d+$/)
+    .filter({ hasText: new RegExp(`^${name}$`) });
+
 test(
   "user must be able to see starter projects for mcp servers",
-  { tag: ["@release", "@workspace", "@components", "@mcp"] },
+  { tag: ["@stable", "@release", "@workspace", "@components", "@mcp"] },
   async ({ page }) => {
     //starter mcp project
 
@@ -18,9 +36,7 @@ test(
 
     await navigateSettingsPages(page, "Settings", "MCP Servers");
 
-    expect(await page.getByTestId("mcp_server_name_0").textContent()).toContain(
-      "lf-starter_project",
-    );
+    await expect(mcpServerRow(page, "lf-starter_project")).toHaveCount(1);
 
     await page.getByTestId("icon-ChevronLeft").first().click();
 
@@ -31,9 +47,7 @@ test(
 
     await navigateSettingsPages(page, "Settings", "MCP Servers");
 
-    expect(await page.getByTestId("mcp_server_name_0").textContent()).toContain(
-      "lf-starter_project",
-    );
+    await expect(mcpServerRow(page, "lf-starter_project")).toHaveCount(1);
 
     expect(
       await page.getByText("lf-new_project", { exact: true }).count(),
@@ -67,9 +81,7 @@ test(
 
     await navigateSettingsPages(page, "Settings", "MCP Servers");
 
-    expect(await page.getByTestId("mcp_server_name_0").textContent()).toContain(
-      "lf-starter_project",
-    );
+    await expect(mcpServerRow(page, "lf-starter_project")).toHaveCount(1);
 
     expect(
       await page.getByText("lf-renamed_project", { exact: true }).count(),
@@ -93,9 +105,7 @@ test(
 
     await navigateSettingsPages(page, "Settings", "MCP Servers");
 
-    expect(await page.getByTestId("mcp_server_name_0").textContent()).toContain(
-      "lf-starter_project",
-    );
+    await expect(mcpServerRow(page, "lf-starter_project")).toHaveCount(1);
     expect(
       await page.getByText("lf-renamed_project", { exact: true }).count(),
     ).toBe(0);


### PR DESCRIPTION
**Fixes #1123.** Closes #1123.

## Problem

`mcp-server-starter-projects.spec.ts` test 1 read `mcp_server_name_0` and expected it to contain `lf-starter_project`. On daily-stable run [30534416609](https://github.com/oriontech-me/langflow-e2e/actions/runs/30534416609) (2026-07-30) the row rendered `langflow-agentic` instead — **deterministic, 3/3 attempts**, on the very first assertion, so project creation / rename / delete were never exercised. `@stable` was auto-removed from the test by the daily workflow. First and only appearance in `reports/daily-history.jsonl`; the run was clean and non-guarded (466 passed, 2 hard failures), so it is not mass-failure collateral.

**Root cause — an intentional upstream product change, not a regression.** Langflow commit `d4d5592c1c` (*"fix(settings): enable agentic experience by default"*, langflow#14244, 2026-07-24) flipped `agentic_experience` from `False` to `True`. With that flag on, `auto_configure_agentic_mcp_server()` (`api/utils/mcp/agentic_mcp.py:52`) injects an internal server named `langflow-agentic` (`auto_configured: True`, `langflow_internal: True`) into **every** user's MCP configuration at startup. Before #14244 it early-returned and the row did not exist.

Measured on the nightly line:

```
GET /api/v2/mcp/servers → 0 | langflow-agentic
                          1 | lf-starter_project

mcp_server table (fresh DB):
  langflow-agentic    | 2026-07-30 14:05:29.093226
  lf-starter_project  | 2026-07-30 14:05:39.180801   (+10.09s)
```

The same ~10 s gap reproduces on a long-lived DB, so this is **deterministic, not a startup race**. `get_server_list` (`api/v2/mcp.py:137`) orders by `created_at` and `MCPServersPage/index.tsx:121` renders that order with **no sort** — so `langflow-agentic` is permanently row 0.

The two readings in the issue resolve as:

- **Upstream rename — refuted.** `lf-starter_project` still exists and is still surfaced as an MCP server, at index 1. The QA-CHECKLIST §14.1 premise ("Starter project with MCP") is intact.
- **Index-0 addressing — confirmed**, with one correction to the triage hypothesis: `langflow-agentic` is *not* a project that survived `cleanOldFolders`. It is an internal server, so `cleanOldFolders` — which deletes *projects* — could never remove it, and should not.

Nothing to file upstream. Side note for the record: `get_server_list`'s own comment ("*the starter project server stays first*") is now stale — upstream violates its own invariant. Low severity, no user-facing impact.

## Fix

Row order was never part of the §14.1 contract, so the assertion stops depending on it. A `mcpServerRow(page, name)` helper filters the `mcp_server_name_<index>` rows on the exact name; the four positional asserts become `await expect(mcpServerRow(page, "lf-starter_project")).toHaveCount(1)`. `@stable` is restored on test 1.

Rejected alternatives:

- **Assert `mcp_server_name_1`** — still positional, breaks on the next server upstream injects.
- **Plain `getByText("lf-starter_project", { exact: true })`** — matches the file's existing idiom, but would be satisfied by that text anywhere on the page, not only by a server row. The row-scoped locator keeps the assertion anchored to the surface §14.1 is about.
- **Teach `cleanOldFolders` to remove `langflow-agentic`** — wrong layer, and it would delete a Langflow-internal server every spec run.

## Scope note

- **Test 2 is unchanged** — it never addressed rows by position and kept `@stable` throughout.
- The existing `lf-new_project` / `lf-new_project_1` / `lf-renamed_project` count assertions are unchanged (still `getByText(..., { exact: true })`), as is the rename/delete flow.
- `mcp-server.spec.ts` and `mcp-server-tab.spec.ts` also reference `lf-starter_project`, but address it by name via `add-component-button-lf-starter_project` — unaffected.
- **No `QA-CHECKLIST.md` change**: the Part II bullet (line 685) is already `[x]` and references this spec; `npm run check:checklist-coverage` confirms. No generated block touched.
- Spec doc updated to record **why row position is deliberately not asserted** (the issue's deliverable), and to drop "always first" from the Validation criterion and the false-positive guards.

## Validation (`--workers=1 --retries=0`)

- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors; no new warning on the touched file) · `npm run test:scripts` ✅ · `npm run test:units` ✅ · QA-CHECKLIST coverage guard ✅ · QA-CHECKLIST generated-block guard ✅
- **6 clean runs**, 2 passed each, no flake: 14.8 s · 16.2 s · 16.5 s · 16.0 s · 15.1 s · 17.5 s
- **`--trace=on` ✅ — no hang on this spec**: test 1 12.0 s, test 2 8.2 s, both green; artifact contains 122 screenshots.
- **Force-fail — 3 mutations executed, each observed failing, all reverted (0 `FFMUTANT` markers in the diff):**
  - `FF1` — `mcpServerRow` regex → `^FFMUTANT_${name}$`: test 1 failed, `toHaveCount` Expected 1 / Received 0.
  - `FF2` — restored the pre-fix positional assert: test 1 failed reproducing the daily's exact signature, `Expected substring: "lf-starter_project"` / `Received string: "langflow-agentic"`.
  - `FF3` — test 2's error copy → `"FFMUTANT Server already exists."`: test 2 failed, `toBeVisible` element(s) not found.
- **No artifact leak**, verified after 6 runs: 29 flows / 29 distinct (test 2 opens the existing starter example flow rather than creating one), no leftover projects, `mcp_server` table back to its two-row baseline.

### Two caveats, stated plainly

1. **Not validated against the docker image.** `docker` is not installed on this machine, so validation ran against a source build of the Langflow clone at HEAD `e1dd51af6b` (2026-07-29) — the nightly line, and it already contains #14244 — not `langflowai/langflow-nightly:latest`. Its `/api/v1/version` reports `1.11.1` because the editable install's metadata is stale; the tree is the 07-29 nightly-line code. `FF2` reproducing the daily's exact failure signature is the evidence the environment is representative for this defect, but it is not the artifact CI runs. A `manual.yml` dispatch would close that gap if reviewers want it.
2. **Not determined:** why the 2026-07-27 and 2026-07-29 dailies passed when the flag flipped on 07-24. The likely reading is `nightly:latest` build lag, but `daily-history.jsonl` records only failures, not passes, so it cannot be proven from the history. It does not affect the fix.

**Checklist item 4 (zero `🚨 Backend Error`) is NOT met** — one ambient 500 fires during test 2 on `/api/v2/mcp/servers/lf-starter_project` with body `{"detail":"Server already exists."}`: the duplicate-add is correctly rejected, but answers **500 instead of 409**. That is the status-code defect already tracked in #991, it is log-only (`http_error` does not fail a test), and the UI still surfaces the message test 2 asserts. Documented and cross-referenced in the spec doc rather than silenced.