### PR TITLE
fix(components): assert the headers field where it actually lives, and stop this file leaking flows (#1136)

### DIFF
--- a/tests/tests-automations/regression/api/flows/api-request-component-ui.spec.ts
+++ b/tests/tests-automations/regression/api/flows/api-request-component-ui.spec.ts
@@ -1,5 +1,26 @@
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import {
+  closeAdvancedOptions,
+  openAdvancedOptions,
+} from "../../../../helpers/ui/open-advanced-options";
+import { trackCreatedFlows } from "../../../../helpers/flows/track-created-flows";
+
+// Id-scoped flow cleanup, via the shared tracker (#1108). This file had NONE: all
+// four tests reach the canvas through `awaitBootstrapTest` + the `blank-flow`
+// click, so every run leaked. Measured with the tracker disabled: one orphan per
+// test, i.e. four per full run of this file, kept for good. Never a name-scoped or
+// delete-all sweep — that deletes flows other parallel workers are driving (#553).
+let flows: ReturnType<typeof trackCreatedFlows>;
+
+test.beforeEach(({ page }) => {
+  flows = trackCreatedFlows(page);
+});
+
+test.afterEach(async ({ request }) => {
+  await flows.cleanup(request);
+  flows.dispose();
+});
 
 // Reusable helper: navigate to a blank flow and add the API Request component.
 // Waits until the URL input in the inspector is ready.
@@ -88,36 +109,33 @@ test(
   async ({ page }) => {
     await addApiRequestComponent(page);
 
-    // The headers field is rendered as a key-value table in the inspector.
-    // Look for the label "Headers" which appears above the key-value input widget.
-    const headersLabel = page.getByText(/^headers$/i).first();
+    // `headers` is an ADVANCED field, so it is not on the node body — measured on
+    // 1.12.0.dev9 via `GET /api/v1/all`: `template.headers.advanced === true`
+    // while `url_input` and `method` are false. Scouted on the same build, the
+    // node carries no header-related `data-testid` at all; the field lives in the
+    // node inspector panel, which `parameters-button` opens (#1136).
+    //
+    // The previous version searched the node for a `/^headers$/i` label and, on
+    // missing it, clicked a `/advanced/i` button — a control the nightly replaced
+    // with this panel around dev46 — so it had been failing on every run of a
+    // spec no lane happens to execute (`@release`, never `@stable`).
+    await openAdvancedOptions(page);
 
-    // If not immediately visible, try opening an "Advanced" section first
-    const isHeadersVisible = await headersLabel
-      .isVisible({ timeout: 3000 })
-      .catch(() => false);
+    // Asserted by exact testid, never by a `/.*headers.*/` regex: the page also
+    // renders `app-header` and `chat-header-more-menu`, so a substring match
+    // would report success with the headers field absent — the false-positive
+    // shape `CONTRIBUTING.md` warns about, and the reason this test could not
+    // have failed honestly either way (#1136).
+    await expect(page.getByTestId("inspector-param-headers")).toBeVisible({
+      timeout: 15000,
+    });
 
-    if (!isHeadersVisible) {
-      const advancedBtn = page
-        .getByRole("button", { name: /advanced/i })
-        .first();
-      const advancedExists = await advancedBtn
-        .isVisible({ timeout: 3000 })
-        .catch(() => false);
-      if (advancedExists) {
-        await advancedBtn.click();
-        await page.waitForTimeout(300);
-      }
-    }
+    // The field is a key-value table, and the panel exposes its editor plus the
+    // add-to-node toggle every advanced input gets. Both prove the field is
+    // genuinely wired, not just a label rendered by the panel.
+    await expect(page.getByTestId("inspector-api-headers")).toBeVisible();
+    await expect(page.getByTestId("inspector-add-headers")).toBeVisible();
 
-    // The headers label (or an "Add" button for the headers table) must now be present
-    const headersPresent =
-      (await page.getByText(/^headers$/i).first().isVisible({ timeout: 5000 }).catch(() => false)) ||
-      (await page.getByTestId(/.*headers.*/).first().isVisible({ timeout: 2000 }).catch(() => false));
-
-    expect(
-      headersPresent,
-      "Headers field or section should be visible in the API Request component inspector",
-    ).toBe(true);
+    await closeAdvancedOptions(page);
   },
 );


### PR DESCRIPTION
Closes #1136

## What was broken

`api-request-component-ui.spec.ts`'s headers test had been failing on **every** run, unnoticed:

```
Error: Headers field or section should be visible in the API Request component inspector
Expected: true
Received: false
```

It surfaced on PR #1134, whose diff touched this file with a **comment only** — six added lines, zero code — which was enough to select the spec for the impacted-specs run. Reproduced locally, and reproduced against `origin/main`'s exact file, so it is not #1134's doing.

## Not a product regression

`GET /api/v1/all` on Langflow Nightly **1.12.0.dev9**, `APIRequest` template:

| field | `advanced` | `show` |
|---|---|---|
| `url_input` | false | true |
| `method` | false | true |
| **`headers`** | **true** | true |

The field exists; it is advanced, so it does not render on the node body. Scouted live on the same build — the node carries **no** header-related `data-testid` at all, while the inspector panel (`parameters-button`) carries `inspector-param-headers`, `inspector-api-headers`, `inspector-api-wrapper-headers` and `inspector-add-headers`.

The test searched the node for a `/^headers$/i` label and, failing that, clicked a `/advanced/i` button — a control the nightly replaced with that panel around dev46. It now opens the panel via the shared `openAdvancedOptions` helper, which is what the rest of the suite already uses for advanced fields.

## It could not have failed honestly either way

The old assertion was computed from `.catch(() => false)` chains, with `getByTestId(/.*headers.*/)` as the fallback locator — a substring match that also hits `app-header` and `chat-header-more-menu`, both present on the page. So on a build where the field *did* render on the node, this test would have reported success **with the headers field absent entirely** — the false-positive shape `CONTRIBUTING.md` warns about. Fixing only the drift would have left that in place, so the bypasses are gone and the assertions are exact testids.

## Flow cleanup, which this file had none of

All four tests reach the canvas through `awaitBootstrapTest` + the `blank-flow` click, and nothing deleted what that created. **Measured with the tracker disabled: one orphan per test, four per full run**, kept for good. Now id-scoped via the shared tracker from #1108 — never a name-scoped or delete-all sweep (#553).

## Validation

Langflow Nightly **1.12.0.dev9**.

- **4/4 green**, `--workers=1 --retries=0`, ~19s, zero `🚨 Backend Error`
- `npm run typecheck` — 0 errors · ESLint — 0 errors
- Flow count **30 before, 30 after** (and the four orphans my own pre-fix runs had leaked were purged)

**Force-fail (executed and reverted, 0 mutation markers left):**

| # | Mutation | Result |
|---|---|---|
| FF1 | assertion pointed at `inspector-param-FF-MUTATION` | fails |
| FF2 | `openAdvancedOptions(page)` removed | fails — the panel step is load-bearing, not decoration |
| FF3 | `flows.cleanup(request)` disabled | test still passes but **one flow leaks** (33 → 34), proving the cleanup does the work |

Audited the three sibling tests in this file for the same shape: all assert with hard `expect`s on exact testids and carry no conditional bypass, so none needed changing (a Done-when item on #1136).

## Note

This spec is `@release` and **not** `@stable`, so `daily-stable.yml` never runs it — which is why a permanently-red test stayed invisible. Whether it should be promoted needs its own validation burst and is deliberately out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
