### PR TITLE
fix(ui-ux): walk to the sidebar add button, not the card wrapper (#1124)

### DIFF
--- a/docs/ui-ux/keyboardComponentSearch.md
+++ b/docs/ui-ux/keyboardComponentSearch.md
@@ -8,32 +8,88 @@ Driving the component sidebar entirely from the keyboard — the
 `§15.1 Component Sidebar` item *Keyboard search (keyboard shortcut)*: the `/`
 shortcut focuses the search field from the canvas, typing filters the tree,
 `Tab` walks into the results, and `Space` / `Enter` add the focused component to
-the canvas. `Escape` returns focus to the canvas.
+the canvas. `Escape` blurs the search field.
 
 One journey test (the shortcut chain only means something end to end):
 
 1. `/` pressed with the canvas focused moves focus to `sidebar-search-input`
    without typing the character into it (the field stays empty).
-2. Typing `chat` filters the tree — `input_outputChat Input` appears and
-   `models_and_agentsPrompt Template` does not.
-3. `Tab` is pressed until focus lands on `input_output_chat input_draggable`
-   (bounded loop, asserted by `data-testid`), then `Space` adds the component:
-   the canvas goes to exactly one node whose testid matches
-   `/^rf__node-ChatInput-/`.
-4. `Tab` walks to `input_output_chat output_draggable` and `Enter` adds it: two
-   nodes, the second matching `/^rf__node-ChatOutput-/`.
+2. Typing `chat` filters the tree — the `input_output_chat input_draggable` card
+   appears and `models_and_agentsPrompt Template` does not.
+3. `Tab` is pressed until focus lands on the Chat Input entry's
+   **"Add Chat Input to canvas"** button (`add-component-button-chat-input`,
+   bounded loop, asserted by `data-testid`), then `Space` adds the component: the
+   canvas goes to exactly one node whose testid matches `/^rf__node-ChatInput-/`.
+4. `Tab` walks to `add-component-button-chat-output` and `Enter` adds it: two
+   nodes, the new one matching `/^rf__node-ChatOutput-/`.
 5. `Escape` with the search focused blurs it (focus leaves
    `sidebar-search-input`).
+
+### The keyboard affordance moved (upstream, 1.12 line) — #1124
+
+Until nightly `1.12.0.dev6` the sidebar result **card wrapper**
+(`<category>_<name>_draggable`) carried `tabIndex={0}` plus an `onKeyDown`
+handler for `Enter`/`Space`, so the card itself was the tab stop and the `+`
+button was explicitly removed from the tab order (`tabIndex={-1}`).
+
+On the `release-1.12.0` line — the branch `langflowai/langflow-nightly:latest`
+is built from, and therefore what `daily-stable.yml` runs — that anti-pattern was
+replaced by a real control:
+
+| | ≤ `1.12.0.dev6` (and the 1.11 line) | ≥ `1.12.0.dev10` |
+|---|---|---|
+| Card wrapper `…_draggable` | `tabIndex={0}` + `onKeyDown` (Enter/Space) | no `tabIndex` — **not a tab stop** |
+| `add-component-button-<slug>` | `tabIndex={-1}` (skipped) | focusable `<button aria-label="Add <name> to canvas">` |
+| Plus-icon reveal class | `group-focus/draggable` | `group-focus-within/draggable` |
+
+The user-facing journey is unchanged (and more accessible: a native button with
+an accessible name instead of a `div` emulating one), so this is an intentional
+product change, not a regression. What broke was the test's focus target: the
+old target is no longer reachable by `Tab`, and the walk ran past it into the
+bundle sections — the recorded daily failure ended on
+`add-component-button-valkey-chat-memory`, the 10th tab stop.
+
+The spec therefore walks to the **add button**, which is also the handle the rest
+of this suite already uses for sidebar adds
+(`tests/helpers/flows/add-component-from-sidebar.ts`). Targeting the button (and
+not "either the button or the old wrapper") is deliberate: accepting both would
+stop guarding the a11y contract upstream just shipped. Consequence, stated
+explicitly: against a **1.11.x** image this spec fails at step 3 — expected, not
+a regression, until the change reaches a release line.
+
+### Chat Input is a singleton — the second walk is shorter
+
+`ChatInput` is constrained to one instance per flow
+(`evaluatePlacement` → `singleton`, tooltip *"Chat Input already added"*), so
+once step 3 adds it the Chat Input entry becomes `disabled` and stops rendering
+its add button. Its tab stop disappears, which is why step 4 reaches
+`add-component-button-chat-output` in the same number of presses that step 3
+needed for Chat Input. The walk is bounded by testid, not by a press count, so
+this costs the spec nothing — it is documented only so a reviewer is not
+surprised by the asymmetry.
+
+### The `/` press is retried, bounded — #1124 second symptom
+
+The same daily recorded one attempt where `/` did not move focus into the search
+field at all (attempts 2–3 of the same run focused it fine). It does not
+reproduce locally: 3/3 fresh flow loads on `1.12.0.dev10` focused the field, and
+the binding is intact (`useHotkeys(searchComponentsSidebar /* "/" */)` in
+`flowSidebarComponent`, whose only bail-out is `isWrappedWithClass(e, "noflow")`).
+Read as a race between the canvas click and the keypress under CI load, the step
+presses `/` and re-presses only while the field is **not** focused, bounded to
+20 s. A genuinely unbound shortcut still fails the test (0 of N presses land);
+the retry only absorbs a lost first keypress, and never presses while the field
+already has focus (which would type `/` into it and break the empty-value
+assertion).
 
 ### What changed from the inherited version
 
 - **Tabbing is targeted, not blind.** The previous version pressed `Tab` three
-  times and hoped: the real focus order on 1.12 is
-  `sidebar-options-trigger` → `disclosure-<category>` → the first result card, so
-  a single extra element upstream would have silently moved `Space` onto a
-  different control while the test still passed (the node-count assertion did not
-  say *which* component was added). The rewrite walks until the expected testid
-  holds focus and asserts the **type** of each added node.
+  times and hoped: a single extra focusable element upstream would have silently
+  moved `Space` onto a different control while the test still passed (the
+  node-count assertion did not say *which* component was added). The rewrite
+  walks until the expected testid holds focus and asserts the **type** of each
+  added node.
 - **Flow cleanup added.** The old version opened a blank flow through the UI after
   `awaitBootstrapTest` and deleted nothing, leaking one flow per run.
 - **Escape's real behavior is documented, not assumed:** on 1.12 `Escape` blurs
@@ -48,22 +104,27 @@ One journey test (the shortcut chain only means something end to end):
 | Step | Criterion |
 |---|---|
 | `/` from the canvas | `sidebar-search-input` is focused AND its value is still `""` |
-| Type `chat` | `input_outputChat Input` visible, `models_and_agentsPrompt Template` hidden |
-| `Tab` walk | focus reaches `input_output_chat input_draggable` within a bounded number of presses |
+| Type `chat` | `input_output_chat input_draggable` visible, `models_and_agentsPrompt Template` hidden |
+| `Tab` walk | focus reaches `add-component-button-chat-input` within a bounded number of presses (3 on `1.12.0.dev10`, budget 10) |
 | `Space` | exactly 1 `.react-flow__node`, testid matching `/^rf__node-ChatInput-/` |
-| `Tab` + `Enter` | exactly 2 nodes, the new one matching `/^rf__node-ChatOutput-/` |
+| `Tab` + `Enter` | focus reaches `add-component-button-chat-output`; exactly 2 nodes, the new one matching `/^rf__node-ChatOutput-/` |
 | `Escape` | `sidebar-search-input` is not focused |
 
 Non-criterion (deliberate): the search text after adding a component (the field
-keeps its query on 1.12) and `Escape` clearing the query (it does not).
+keeps its query on 1.12), `Escape` clearing the query (it does not), and the
+`aria-label` wording of the add button (an i18n string — the testid is the
+contract this spec asserts).
 
 ## External dependencies
 
-- `sidebar-search-input`, `<category>_<name>_draggable` cards, and the canvas
+- `sidebar-search-input`, the `<category>_<name>_draggable` result cards, the
+  per-result `add-component-button-<slug>` buttons, and the canvas
   `.react-flow__node` / `rf__node-<Type>-<hash>` testids.
-- The `/` shortcut binding and the sidebar's `Space`/`Enter` add handlers
-  (upstream `SidebarDraggableComponent`). A change to the focus order does not
-  break the test (it walks by testid), but removing the keyboard add handler does.
+- The `/` shortcut binding and the sidebar add button's native `Space`/`Enter`
+  activation (upstream `sidebarDraggableComponent.tsx`). A change to the focus
+  **order** does not break the test (it walks by testid); moving the keyboard
+  affordance to another element does, by design — that is the contract under
+  test.
 - `POST /api/v1/flows/` — the empty flow the editor opens on.
 
 No provider API key, no LLM, no flow build.
@@ -79,11 +140,12 @@ Flow cleanup: the flow is created via the API and deleted by id in `afterEach`.
   filter → focus → add.
 - **Precondition:** empty flow created via API; editor open; canvas focused.
 - **Step by step:**
-  1. Click the canvas pane, press `/`, read focus and the field value.
+  1. Click the canvas pane, press `/` (bounded retry), read focus and the field
+     value.
   2. Type `chat`; read the matching and non-matching cards.
-  3. Press `Tab` until `input_output_chat input_draggable` has focus; press
+  3. Press `Tab` until `add-component-button-chat-input` has focus; press
      `Space`; read the node count and the node testid.
-  4. Press `Tab` until `input_output_chat output_draggable` has focus; press
+  4. Press `Tab` until `add-component-button-chat-output` has focus; press
      `Enter`; read the node count and the new node's testid.
   5. Focus the search field, press `Escape`, read focus.
 - **Validation:** as tabulated above — the criterion is the *identity* of the
@@ -91,4 +153,4 @@ Flow cleanup: the flow is created via the API and deleted by id in `afterEach`.
 
 ## Last validated
 
-1.12.x (nightly `1.12.0.dev6`)
+1.12.x (nightly `1.12.0.dev10`)

--- a/docs/ui-ux/keyboardComponentSearch.md
+++ b/docs/ui-ux/keyboardComponentSearch.md
@@ -57,6 +57,15 @@ stop guarding the a11y contract upstream just shipped. Consequence, stated
 explicitly: against a **1.11.x** image this spec fails at step 3 — expected, not
 a regression, until the change reaches a release line.
 
+**That failure names itself.** Upstream's nightly image is built from a pinned
+release branch (`release-1.12.0`) while upstream `main` still carries the old
+shape, so the pin moving to a branch cut from `main` would reproduce #1124's exact
+signature. When the walk runs out of presses it therefore checks whether a
+`…_draggable` wrapper is still a tab stop (`tabindex="0"`) and, if so, appends
+*"this build predates the 1.12 a11y change (#1124), not a regression"* to the
+error. On a build that has the change the hint is empty, so a genuine keyboard
+regression still reads as one.
+
 ### Chat Input is a singleton — the second walk is shorter
 
 `ChatInput` is constrained to one instance per flow

--- a/tests/tests-automations/regression/ui-ux/keyboardComponentSearch.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/keyboardComponentSearch.spec.ts
@@ -12,20 +12,24 @@ import { deleteFlow } from "../../../helpers/flows/delete-flow";
 // tree, Tab walks into the results, and Space / Enter add the focused component.
 //
 // Rewritten from the inherited version, which pressed Tab three times blindly and
-// then asserted only a node COUNT: the live focus order is
-// sidebar-options-trigger -> disclosure-<category> -> first result card, so one
-// extra focusable element upstream would have moved Space onto another control
-// with the test still green. Here the Tab walk stops on the expected testid and
-// each added node is asserted by TYPE. The inherited version also opened a blank
-// flow through the UI and never deleted it.
+// then asserted only a node COUNT: one extra focusable element upstream would
+// have moved Space onto another control with the test still green. Here the Tab
+// walk stops on the expected testid and each added node is asserted by TYPE. The
+// inherited version also opened a blank flow through the UI and never deleted it.
 
-// Focus targets in the filtered result list.
+// The result card is the observable of the FILTER, not a focus target: on the
+// 1.12 line it carries no tabIndex. The keyboard affordance is the per-result
+// "Add <name> to canvas" button, the same handle the rest of the suite uses to
+// add from the sidebar (helpers/flows/add-component-from-sidebar.ts). See the
+// spec doc -> "The keyboard affordance moved (upstream, 1.12 line) — #1124".
 const CHAT_INPUT_CARD = "input_output_chat input_draggable";
-const CHAT_OUTPUT_CARD = "input_output_chat output_draggable";
+const CHAT_INPUT_ADD = "add-component-button-chat-input";
+const CHAT_OUTPUT_ADD = "add-component-button-chat-output";
 // A component that must not survive the "chat" query.
 const NON_MATCHING_CARD = "models_and_agentsPrompt Template";
-// Bounded Tab walk: the live order needs 3 presses, so this only runs out when
-// the card is unreachable by keyboard — which is the failure being tested.
+// Bounded Tab walk: the live order needs 3 presses (sidebar-options-trigger ->
+// disclosure-<category> -> the add button), so this only runs out when the
+// component is unreachable by keyboard — which is the failure being tested.
 const MAX_TAB_PRESSES = 10;
 
 /** The `data-testid` of the currently focused element, if it has one. */
@@ -45,6 +49,29 @@ async function tabUntilFocused(page: Page, testId: string): Promise<number> {
     `"${testId}" never received focus within ${MAX_TAB_PRESSES} Tab presses ` +
       `(last focused: ${await focusedTestId(page)})`,
   );
+}
+
+/**
+ * Presses `/` until the sidebar search holds focus.
+ *
+ * Bounded on purpose: a shortcut that is really unbound never focuses the field,
+ * so the step still fails — the retry only absorbs a keypress lost to the race
+ * between the canvas click and the hotkey under CI load (#1124, second symptom).
+ * It never presses while the field already has focus: the hotkey does not fire
+ * from form tags, so a second press would type "/" into it and defeat the
+ * empty-value assertion that follows.
+ */
+async function focusSearchWithSlash(page: Page): Promise<void> {
+  const search = page.getByTestId("sidebar-search-input");
+
+  await expect(async () => {
+    const alreadyFocused = await search.evaluate(
+      (el) => el === document.activeElement,
+    );
+    if (!alreadyFocused) await page.keyboard.press("/");
+
+    await expect(search).toBeFocused({ timeout: 2000 });
+  }).toPass({ timeout: 20000, intervals: [250, 500, 1000, 2000] });
 }
 
 test.describe("ui-ux — keyboard component search", () => {
@@ -77,7 +104,7 @@ test.describe("ui-ux — keyboard component search", () => {
   });
 
   test("user can search and add components using keyboard shortcuts",
-    { tag: ["@workspace", "@ui-ux"] },
+    { tag: ["@stable", "@workspace", "@ui-ux"] },
     async ({ page }) => {
       const search = page.getByTestId("sidebar-search-input");
       const nodes = page.locator(".react-flow__node");
@@ -87,9 +114,8 @@ test.describe("ui-ux — keyboard component search", () => {
           .locator(".react-flow__pane")
           .click({ position: { x: 500, y: 350 } });
 
-        await page.keyboard.press("/");
+        await focusSearchWithSlash(page);
 
-        await expect(search).toBeFocused({ timeout: 10000 });
         // The shortcut must not land in the field as text.
         await expect(search).toHaveValue("");
       });
@@ -104,7 +130,7 @@ test.describe("ui-ux — keyboard component search", () => {
       });
 
       await test.step("Tab reaches the first result and Space adds it", async () => {
-        await tabUntilFocused(page, CHAT_INPUT_CARD);
+        await tabUntilFocused(page, CHAT_INPUT_ADD);
         await page.keyboard.press("Space");
 
         await expect(nodes).toHaveCount(1, { timeout: 15000 });
@@ -118,7 +144,10 @@ test.describe("ui-ux — keyboard component search", () => {
 
       await test.step("Tab reaches the next result and Enter adds it", async () => {
         await search.click();
-        await tabUntilFocused(page, CHAT_OUTPUT_CARD);
+        // ChatInput is a singleton: now that one is on the canvas its entry is
+        // disabled and stops rendering an add button, so this walk costs the
+        // same number of presses the Chat Input one did.
+        await tabUntilFocused(page, CHAT_OUTPUT_ADD);
         await page.keyboard.press("Enter");
 
         await expect(nodes).toHaveCount(2, { timeout: 15000 });

--- a/tests/tests-automations/regression/ui-ux/keyboardComponentSearch.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/keyboardComponentSearch.spec.ts
@@ -39,6 +39,29 @@ async function focusedTestId(page: Page): Promise<string | null> {
   );
 }
 
+/**
+ * Diagnostic for the way this walk is most likely to break again: an image that
+ * predates the 1.12 a11y change, where the result CARD wrapper is the tab stop
+ * and the add button is out of the tab order (#1124). The nightly image is built
+ * from a release branch (`release-1.12.0` at the time of writing) while upstream
+ * `main` still carries the old shape, so the pin moving to a branch cut from
+ * `main` is enough to bring the old DOM back — with the exact failure signature
+ * of #1124. Naming it in the error saves triage from re-deriving it.
+ *
+ * Returns "" on a build that has the change, so a genuine keyboard regression
+ * reads as one.
+ */
+async function legacyTabStopHint(page: Page): Promise<string> {
+  const legacyTabStops = await page
+    .locator('[data-testid$="_draggable"][tabindex="0"]')
+    .count();
+
+  return legacyTabStops > 0
+    ? ` — the result card wrapper is the tab stop and the add button is not: ` +
+        `this build predates the 1.12 a11y change (#1124), not a regression.`
+    : "";
+}
+
 /** Presses Tab until `testId` holds focus; fails if it never does. */
 async function tabUntilFocused(page: Page, testId: string): Promise<number> {
   for (let presses = 1; presses <= MAX_TAB_PRESSES; presses++) {
@@ -47,7 +70,8 @@ async function tabUntilFocused(page: Page, testId: string): Promise<number> {
   }
   throw new Error(
     `"${testId}" never received focus within ${MAX_TAB_PRESSES} Tab presses ` +
-      `(last focused: ${await focusedTestId(page)})`,
+      `(last focused: ${await focusedTestId(page)})` +
+      (await legacyTabStopHint(page)),
   );
 }
 


### PR DESCRIPTION
**Closes #1124.**

## Problem

`keyboardComponentSearch` hard-failed on the daily of **2026-07-30** (run
[30534416609](https://github.com/oriontech-me/langflow-e2e/actions/runs/30534416609)
— a clean, non-guarded run: 466 passed, 2 hard failures, 10 flakes) and the
workflow auto-removed `@stable`, so the coverage has been running nowhere since.
Two symptoms across the three attempts:

1. **Attempts 2–3** — `"input_output_chat input_draggable" never received focus
   within 10 Tab presses (last focused: add-component-button-valkey-chat-memory)`.
2. **Attempt 1** — `/` did not move focus into `sidebar-search-input` at all.

**Root cause of (1): an intentional upstream a11y change, not a regression.** On
`release-1.12.0` — the branch `langflowai/langflow-nightly:latest` is built from,
and therefore what `daily-stable.yml` runs — `sidebarDraggableComponent.tsx`
replaced the card wrapper's keyboard emulation with a real control:

| | ≤ `1.12.0.dev6` (and the 1.11 line) | ≥ `1.12.0.dev10` |
|---|---|---|
| Card `…_draggable` | `tabIndex={0}` + `onKeyDown` (Enter/Space) | no `tabIndex` — **not a tab stop** |
| `add-component-button-<slug>` | `tabIndex={-1}` (skipped) | focusable `<button aria-label="Add <name> to canvas">` |
| Plus-icon reveal | `group-focus/draggable` | `group-focus-within/draggable` |

Note `main` still carries the old shape — scouting there (or on a local clone)
gives a stale DOM; the comparison above was made with
`?ref=release-1.12.0` **and** against the live nightly.

The old target is unreachable by `Tab`, so the bounded walk ran past it into the
bundle sections. The live tab order for the query `chat` accounts for the
recorded failure exactly: `sidebar-options-trigger`(1) →
`disclosure-input & output`(2) → `chat-input`(3) → `chat-output`(4) →
openai(5,6) → cassandra(7,8) → valkey(9,**10**) — the 10th stop is
`add-component-button-valkey-chat-memory`.

**Symptom (2)** does not reproduce: 3/3 fresh flow loads on `1.12.0.dev10`
focused the field, and the binding is intact (`useHotkeys(searchComponentsSidebar
/* "/" */)` in `flowSidebarComponent`, whose only bail-out is
`isWrappedWithClass(e, "noflow")`). Read as a race between the canvas click and
the keypress under CI load.

## Fix

- The Tab walk targets `add-component-button-chat-input` / `-chat-output` — also
  the handle the rest of this suite already uses for sidebar adds
  (`tests/helpers/flows/add-component-from-sidebar.ts`). The result card stays as
  the observable of the **filter** step, so no assertion was lost.
- The `/` press is retried only while the field is **not** focused, bounded to
  20 s. An unbound shortcut still fails the step (0 of N presses land); pressing
  while the field already has focus would type `/` into it and defeat the
  empty-value assertion, hence the guard.
- `@stable` restored (auto-removed by the daily).

**Rejected alternatives**, explicitly:

- *Accept either tab stop (new button or old wrapper).* It would keep the spec
  green on a version where the a11y affordance regressed, i.e. stop guarding the
  contract upstream just shipped. Consequence accepted and documented in the spec
  doc: against a **1.11.x** image this spec fails at step 3 — expected, not a
  regression, until the change reaches a release line.
- *Raise the Tab budget.* Does not help — the old target is not in the tab order
  at any budget.
- *Focus the target card directly instead of walking.* The walk **is** the
  behavior under test (§15.1 "Keyboard search"); it costs 3 presses on the
  current nightly against a budget of 10.

## Scope note

Unchanged: the journey, the filter observables (`input_output_chat input_draggable`
visible / `models_and_agentsPrompt Template` hidden), the node **identity**
assertions (`/^rf__node-ChatInput-/`, `/^rf__node-ChatOutput-/`), the `Escape`
blur assertion, and the API-created flow with id-scoped `afterEach` cleanup. No
`QA-CHECKLIST.md` change — the §15.1 bullet already references this spec and the
coverage is identical.

Also documented in the spec doc (not a behavior change): `ChatInput` is a
singleton (`evaluatePlacement` → `singleton`, tooltip *"Chat Input already
added"*), so after step 3 its entry is disabled and stops rendering an add
button — which is why the second walk costs the same number of presses as the
first.

## Validation (nightly `1.12.0.dev10`, `--retries=0`)

- `npm run typecheck` ✅ · `eslint` on the touched spec ✅ (0 warnings) ·
  `check:checklist-coverage` ✅ · `check-checklist-guard` ✅
- **5/5 clean runs** at `--workers=1 --retries=0` (~2.6 s each), plus a 6th green
  after reverting every mutation ✅
- **Force-fail, executed** (all observed failing, all reverted — `grep FFMUT` = 0):
  - `CHAT_INPUT_ADD` → `…-chat-input-FFMUT` ⇒ *never received focus within 10 Tab
    presses (last focused: add-component-button-valkey-chat-memory)* — reproduces
    the daily's own signature
  - `CHAT_OUTPUT_ADD` → `…-chat-output-FFMUT` ⇒ fails on `disclosure-bundles-datastax`
  - `/` → `F9` (a valid non-shortcut key) ⇒ `toBeFocused` times out and the
    `toPass` budget exhausts at 20 s — the retry cannot pass without the field
    focusing
  - identity regex `ChatInput` → `ChatOutput` ⇒ *Expected /^rf__node-ChatOutput-/,
    Received "rf__node-ChatInput-dxT6A"*
- `--trace=on` ✅ — 5 s, **no hang** for this spec; all 5 `test.step` recorded
  with 62 frames
- zero `🚨 Backend Error` ✅ · zero orphan flows (36 flows before and after) ✅

Not covered: the interactive `--debug` walkthrough (checklist item 3) — it needs a
human at the inspector. Step verification is covered by the `--trace=on` run above
plus the live-browser scout of the tab order.
