### PR TITLE
fix(migration): stop the report reading silence as success, and drive the Playground with real testids (#1120)

### DIFF
--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -127,7 +127,12 @@ jobs:
       - name: Wait for Langflow latest
         run: python tests/github-workflows/migration/wait_for_langflow.py
 
+      # `id`s on the three verification steps feed `steps.<id>.outcome` to the report
+      # below. That is what lets the report reconcile "what the runner observed"
+      # against "what the phase recorded", instead of inferring success from the
+      # absence of a failure record — see the Generate report step (#1120).
       - name: Create flow, configure and execute on latest
+        id: phase_latest
         run: python tests/github-workflows/migration/setup_latest.py
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -188,11 +193,17 @@ jobs:
 
       # ── Phase 3: Verify Migration ─────────────────────────────
       - name: Verify migration via API
+        id: phase_nightly_api
         run: python tests/github-workflows/migration/verify_migration_api.py
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
+      # Deliberately NOT `continue-on-error`: that would mark the step's conclusion
+      # as success and the job would stop failing, which is what the issue-opening
+      # condition below keys on. The report step reads `steps.*.outcome` under
+      # `if: always()`, which is available for a failed step anyway (#1120).
       - name: Verify migration via UI (Playwright)
+        id: phase_nightly_ui
         run: pytest tests/github-workflows/migration/test_ui_migration.py -v --tracing=retain-on-failure --output=test-results
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -202,8 +213,18 @@ jobs:
         if: always()
         run: kill "$(cat /tmp/langflow.pid)" 2>/dev/null || true
 
+      # The outcomes are what stop the report inferring success from silence
+      # (#1120): a phase the runner saw fail, that recorded no failing step, is
+      # reported as a crash rather than rendered as `Result: PASSED`. Run #115
+      # opened an issue titled "Failed" whose body said PASSED for exactly that
+      # reason — `test_05_execute_flow_ui` died on a Playwright timeout before it
+      # could write its own verdict.
       - name: Generate report
         if: always()
+        env:
+          PHASE_OUTCOME_latest: ${{ steps.phase_latest.outcome }}
+          PHASE_OUTCOME_nightly_api: ${{ steps.phase_nightly_api.outcome }}
+          PHASE_OUTCOME_nightly_ui: ${{ steps.phase_nightly_ui.outcome }}
         run: python tests/github-workflows/migration/generate_report.py
 
       - name: Print report

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -72,6 +72,45 @@ jobs:
       - name: Lint
         run: npm run lint:ci
 
+  # The repo's own Python code had no lane at all, which is how `generate_report.py`
+  # shipped a report that said `Result: PASSED` on a run whose UI phase had failed
+  # (#1120, run #115). The two `test:units` / `test:scripts` lanes only cover
+  # TypeScript and `.mjs`, so nothing here was verifiable before merge.
+  python-units:
+    name: Python unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install pytest
+        run: pip install --quiet pytest
+
+      - name: Migration helper unit tests
+        run: |
+          # `test_ui_migration.py` is excluded, not missing: it drives a real browser
+          # against a migrated Langflow and belongs to migration-test.yml. Everything
+          # else under this path is a plain unit test, so a new one is picked up
+          # without touching this workflow.
+          #
+          # Fail loudly on an empty selection, like the two Node lanes do — a unit
+          # lane that silently runs nothing is worse than no lane (#1012's rule).
+          COUNT=$(python -m pytest tests/github-workflows/migration \
+            --ignore=tests/github-workflows/migration/test_ui_migration.py \
+            --collect-only -q 2>/dev/null | grep -cE '::' || true)
+          if [ "${COUNT:-0}" -eq 0 ]; then
+            echo "::error::no Python unit tests were collected — this lane would have passed without verifying anything."
+            exit 1
+          fi
+          echo "collected $COUNT Python unit test(s)"
+          python -m pytest tests/github-workflows/migration \
+            --ignore=tests/github-workflows/migration/test_ui_migration.py -v
+
   checklist-guard:
     name: QA-CHECKLIST guard
     runs-on: ubuntu-latest

--- a/tests/github-workflows/migration/generate_report.py
+++ b/tests/github-workflows/migration/generate_report.py
@@ -1,8 +1,36 @@
-"""Generate a markdown migration test report from the collected state."""
+"""Generate a markdown migration test report from the collected state.
+
+## Why the verdict is not just "did anything record a failure" (#1120)
+
+Run #115 opened an issue titled *"Langflow Migration Test Failed"* whose body said
+**`Result: PASSED`**, with every listed step green. Both were accurate about what
+they measured, and that is the defect:
+
+- `Verify migration via UI (Playwright)` failed — `test_05_execute_flow_ui` died on
+  a 30 s `Locator.click` timeout.
+- A pytest test that **crashes** never reaches its own `_save_results()`, so it
+  writes **no** `fail` entry. The old verdict scanned the state file for a `fail`
+  status, found none, and printed `Result: PASSED`.
+
+So the report read the **absence of a failure record as evidence of success** — and
+the one situation where the report matters most is exactly the one that records
+nothing. A reader who trusts the first line of the body draws the opposite of the
+truth.
+
+The fix is to stop inferring. The workflow now tells this script the outcome of
+each verification step (`PHASE_OUTCOME_<phase>`), and the script **reconciles** that
+against what the phase actually recorded. A phase the runner says failed, that
+recorded no failure, is reported as a crash — never as a pass. A phase that was
+supposed to run and is missing from the state entirely is reported as incomplete.
+Nothing here can conclude "passed" from missing data.
+"""
 
 import json
 import os
 from datetime import datetime, timezone
+# `Optional`, not `dict | None`: CI runs 3.12 but the file is also imported by the
+# unit tests on whatever interpreter a developer has, and macOS still ships 3.9.
+from typing import Optional
 
 STATE_FILE = os.environ.get("STATE_FILE", "/tmp/migration-test-state.json")
 REPORT_FILE = os.environ.get("REPORT_FILE", "/tmp/migration-report.md")
@@ -13,6 +41,15 @@ STATUS_ICON = {
     "warn": "WARN",
     "skip": "SKIP",
 }
+
+# Per-phase step outcomes handed in by the workflow, as
+# `PHASE_OUTCOME_<phase>=success|failure|skipped|cancelled` — GitHub's
+# `steps.<id>.outcome` vocabulary, passed straight through.
+PHASE_OUTCOME_PREFIX = "PHASE_OUTCOME_"
+
+RESULT_FAILED = "FAILED"
+RESULT_PASSED = "PASSED"
+RESULT_PASSED_WARN = "PASSED (with warnings)"
 
 
 def load_state() -> dict:
@@ -31,6 +68,85 @@ def load_digest(path: str) -> str:
         return "unknown"
 
 
+def declared_outcomes(environ=None) -> dict:
+    """Phase name → runner outcome, from the `PHASE_OUTCOME_<phase>` variables."""
+    env = os.environ if environ is None else environ
+    out = {}
+    for key, value in env.items():
+        if not key.startswith(PHASE_OUTCOME_PREFIX):
+            continue
+        phase = key[len(PHASE_OUTCOME_PREFIX) :]
+        if phase and value and value.strip():
+            out[phase] = value.strip().lower()
+    return out
+
+
+def assess(state: dict, declared: dict) -> dict:
+    """Decide the overall result, and surface anything that makes the report untrustworthy.
+
+    Returns `{"result", "failures", "warnings", "integrity"}`. `integrity` holds
+    mismatches between what the runner observed and what the phase recorded — the
+    #1120 class. Those count as failures: a report that cannot account for a phase
+    must not claim that phase passed.
+    """
+    phases = state.get("phases", {}) or {}
+
+    failures = []
+    warnings = []
+    integrity = []
+
+    for phase_name, phase_data in phases.items():
+        for step_name, step_data in (phase_data.get("steps", {}) or {}).items():
+            status = (step_data or {}).get("status")
+            detail = str((step_data or {}).get("detail", "no detail"))[:200]
+            if status == "fail":
+                failures.append(f"- **{phase_name}/{step_name}**: {detail}")
+            elif status == "warn":
+                warnings.append(f"- **{phase_name}/{step_name}**: {detail}")
+
+    for phase_name, outcome in sorted(declared.items()):
+        recorded_steps = (phases.get(phase_name) or {}).get("steps", {}) or {}
+        recorded_fail = any(
+            (s or {}).get("status") == "fail" for s in recorded_steps.values()
+        )
+
+        if outcome == "failure" and not recorded_fail:
+            # The #1120 case: the step died before it could write its own verdict.
+            integrity.append(
+                f"- **{phase_name}**: the runner reports this phase FAILED, but it recorded no "
+                f"failing step — it crashed before writing its result "
+                f"({len(recorded_steps)} step(s) recorded). Read the job log for the real cause; "
+                f"this report cannot attribute it."
+            )
+        elif outcome in {"success", "failure"} and phase_name not in phases:
+            integrity.append(
+                f"- **{phase_name}**: the runner ran this phase (outcome `{outcome}`) but it is "
+                f"absent from the state file, so nothing about it was verified."
+            )
+
+    # A state file with no phases at all is the strongest form of the same problem:
+    # it used to render as a clean PASS.
+    if not phases:
+        integrity.append(
+            "- **(all phases)**: the state file records no phases at all, so this report "
+            "verified nothing. Treated as a failure rather than an empty pass."
+        )
+
+    if failures or integrity:
+        result = RESULT_FAILED
+    elif warnings:
+        result = RESULT_PASSED_WARN
+    else:
+        result = RESULT_PASSED
+
+    return {
+        "result": result,
+        "failures": failures,
+        "warnings": warnings,
+        "integrity": integrity,
+    }
+
+
 def format_step(name: str, step: dict) -> str:
     icon = STATUS_ICON.get(step.get("status", ""), "?")
     line = f"| {icon} | {name} |"
@@ -44,67 +160,57 @@ def format_step(name: str, step: dict) -> str:
     return line
 
 
-def generate_report(state: dict) -> str:
+def generate_report(state: dict, declared: Optional[dict] = None) -> str:
+    if declared is None:
+        declared = declared_outcomes()
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     latest_digest = load_digest("/tmp/latest-digest.txt")
     nightly_digest = load_digest("/tmp/nightly-digest.txt")
 
+    verdict = assess(state, declared)
+
     lines = [
-        f"# Langflow Migration Test Report",
+        "# Langflow Migration Test Report",
         f"**Date:** {now}",
         f"**Flow:** {state.get('flow_name', 'N/A')} (`{state.get('flow_id', 'N/A')}`)",
         f"**Latest digest:** `{latest_digest[-20:]}`",
         f"**Nightly digest:** `{nightly_digest[-20:]}`",
         "",
+        f"## Result: {verdict['result']}",
+        "",
     ]
 
-    # Overall result
-    all_statuses = []
-    for phase_data in state.get("phases", {}).values():
-        for step in phase_data.get("steps", {}).values():
-            all_statuses.append(step.get("status", ""))
+    # Right under the verdict, because it is the reason the verdict cannot be
+    # trusted at face value — burying it below the per-step tables is how run #115
+    # read as a pass.
+    if verdict["integrity"]:
+        lines.append("## Unaccounted phases")
+        lines.append("")
+        lines.extend(verdict["integrity"])
+        lines.append("")
 
-    has_fail = "fail" in all_statuses
-    has_warn = "warn" in all_statuses
-    if has_fail:
-        lines.append("## Result: FAILED")
-    elif has_warn:
-        lines.append("## Result: PASSED (with warnings)")
-    else:
-        lines.append("## Result: PASSED")
-    lines.append("")
-
-    # Phase details — only show failures and warnings in detail
     for phase_name, phase_data in state.get("phases", {}).items():
         duration = phase_data.get("duration_s", "?")
-        lines.append(f"### Phase: {phase_name} ({duration}s)")
+        outcome = declared.get(phase_name)
+        suffix = f" — runner outcome: `{outcome}`" if outcome else ""
+        lines.append(f"### Phase: {phase_name} ({duration}s){suffix}")
         lines.append("")
         lines.append("| Status | Step | Detail |")
         lines.append("|--------|------|--------|")
 
-        for step_name, step_data in phase_data.get("steps", {}).items():
+        for step_name, step_data in (phase_data.get("steps", {}) or {}).items():
             lines.append(format_step(step_name, step_data))
 
         lines.append("")
 
-    # Failures summary
-    failures = []
-    warnings = []
-    for phase_name, phase_data in state.get("phases", {}).items():
-        for step_name, step_data in phase_data.get("steps", {}).items():
-            if step_data.get("status") == "fail":
-                failures.append(f"- **{phase_name}/{step_name}**: {step_data.get('detail', 'no detail')[:200]}")
-            elif step_data.get("status") == "warn":
-                warnings.append(f"- **{phase_name}/{step_name}**: {step_data.get('detail', 'no detail')[:200]}")
-
-    if failures:
+    if verdict["failures"]:
         lines.append("## Failures")
-        lines.extend(failures)
+        lines.extend(verdict["failures"])
         lines.append("")
 
-    if warnings:
+    if verdict["warnings"]:
         lines.append("## Warnings")
-        lines.extend(warnings)
+        lines.extend(verdict["warnings"])
         lines.append("")
 
     return "\n".join(lines)

--- a/tests/github-workflows/migration/state_store.py
+++ b/tests/github-workflows/migration/state_store.py
@@ -1,0 +1,70 @@
+"""The shared migration state file's write contract.
+
+Stdlib only, deliberately: `helpers.py` pulls in `requests`, and this has to be
+importable by a unit test on any interpreter.
+
+## Why merging is the contract, not assigning (#1120)
+
+`test_ui_migration.py` used to write its phase with:
+
+```python
+state["phases"]["nightly_ui"] = results
+```
+
+`TestMigrationUI.setup` is an **autouse fixture**, so pytest builds a fresh
+instance per test method and `self.results` starts empty every time. Assigning
+therefore discarded every step recorded by the tests before it. Run #115 ran six UI
+tests and the report showed **one** row — whichever test happened to save last.
+
+Combined with the report's old habit of reading a missing failure as a pass, that
+meant a failing UI phase could neither fail the report nor appear in it.
+"""
+
+import json
+import os
+
+STATE_FILE = os.environ.get("STATE_FILE", "/tmp/migration-test-state.json")
+
+
+def merge_phase(state: dict, phase: str, results: dict) -> dict:
+    """Fold one test's `results` into `state`'s `phase`, keeping what is already there.
+
+    Steps accumulate. `duration_s` spans the phase — earliest start to latest end —
+    rather than the last test's own runtime, which is what made run #115's UI phase
+    report `1.7s` for a phase that took over a minute.
+    """
+    state = dict(state or {})
+    phases = dict(state.get("phases") or {})
+    existing = dict(phases.get(phase) or {})
+
+    steps = dict(existing.get("steps") or {})
+    steps.update(results.get("steps") or {})
+    existing["steps"] = steps
+
+    starts = [t for t in (existing.get("start_time"), results.get("start_time")) if t is not None]
+    ends = [t for t in (existing.get("end_time"), results.get("end_time")) if t is not None]
+    if starts:
+        existing["start_time"] = min(starts)
+    if ends:
+        existing["end_time"] = max(ends)
+    if starts and ends:
+        existing["duration_s"] = round(max(ends) - min(starts), 1)
+
+    phases[phase] = existing
+    state["phases"] = phases
+    return state
+
+
+def save_phase(phase: str, results: dict, state_file: str = None) -> dict:
+    """Read, merge and write back. Returns the state that was written."""
+    path = state_file or STATE_FILE
+    try:
+        with open(path) as f:
+            state = json.load(f)
+    except FileNotFoundError:
+        state = {"phases": {}}
+
+    merged = merge_phase(state, phase, results)
+    with open(path, "w") as f:
+        json.dump(merged, f, indent=2)
+    return merged

--- a/tests/github-workflows/migration/test_generate_report.py
+++ b/tests/github-workflows/migration/test_generate_report.py
@@ -1,0 +1,180 @@
+"""Unit tests for the migration report's verdict (#1120).
+
+Why these exist: `generate_report.py` produced an issue titled *"Langflow Migration
+Test Failed"* whose body said `Result: PASSED` — and nothing in the repo could have
+caught it, because this was our own code with no test around it. The reproduction of
+run #115 is the first test below.
+
+Run with: pytest tests/github-workflows/migration/test_generate_report.py
+"""
+
+from . import generate_report as gr
+import pytest
+
+# The shape run #115 actually left behind: `latest` and `nightly_api` fully
+# recorded, and `nightly_ui` holding ONE step — the last test that managed to save
+# — while the UI step itself had died on a Playwright timeout.
+RUN_115_STATE = {
+    "flow_id": "3a343fa6-7ba4-41d4-a913-936619fd5f6c",
+    "flow_name": "Migration Test Agent",
+    "phases": {
+        "latest": {
+            "duration_s": 4.5,
+            "steps": {
+                "auth": {"status": "pass"},
+                "execute_flow": {"status": "pass", "detail": "Ahoy there, matey!"},
+            },
+        },
+        "nightly_api": {
+            "duration_s": 3.7,
+            "steps": {
+                "flow_exists": {"status": "pass"},
+                "execute_flow_api": {"status": "pass"},
+            },
+        },
+        "nightly_ui": {
+            "duration_s": 1.7,
+            "steps": {"execute_flow_api_post_update": {"status": "pass"}},
+        },
+    },
+}
+
+
+def test_run_115_is_reported_as_failed_not_passed():
+    """The regression this file exists for."""
+    verdict = gr.assess(
+        RUN_115_STATE,
+        {"latest": "success", "nightly_api": "success", "nightly_ui": "failure"},
+    )
+
+    assert verdict["result"] == gr.RESULT_FAILED, (
+        "a phase the runner says failed must never render as PASSED, however little "
+        "it managed to record"
+    )
+    assert len(verdict["integrity"]) == 1
+    assert "nightly_ui" in verdict["integrity"][0]
+    assert "crashed before writing its result" in verdict["integrity"][0]
+
+
+def test_the_old_logic_is_what_this_replaces():
+    """Same state, no declared outcomes — the pre-fix behaviour, for contrast.
+
+    Kept deliberately: it documents that scanning for a recorded `fail` is NOT
+    sufficient, and that the declared outcomes are the load-bearing input. If the
+    workflow ever stops passing them, this is what the report degrades to.
+    """
+    verdict = gr.assess(RUN_115_STATE, {})
+
+    assert verdict["result"] == gr.RESULT_PASSED
+    assert verdict["integrity"] == []
+
+
+def test_a_recorded_failure_still_fails():
+    state = {
+        "phases": {
+            "nightly_api": {
+                "steps": {
+                    "variables_preserved": {
+                        "status": "fail",
+                        "detail": "openai_key_present=False",
+                    }
+                }
+            }
+        }
+    }
+    verdict = gr.assess(state, {"nightly_api": "failure"})
+
+    assert verdict["result"] == gr.RESULT_FAILED
+    assert any("variables_preserved" in f for f in verdict["failures"])
+    # Attributed, so it is NOT an integrity problem — the phase accounted for itself.
+    assert verdict["integrity"] == []
+
+
+def test_a_declared_failure_that_recorded_its_own_failure_is_not_double_reported():
+    state = {"phases": {"p": {"steps": {"s": {"status": "fail", "detail": "boom"}}}}}
+    verdict = gr.assess(state, {"p": "failure"})
+
+    assert verdict["result"] == gr.RESULT_FAILED
+    assert len(verdict["failures"]) == 1
+    assert verdict["integrity"] == []
+
+
+def test_a_phase_that_ran_but_is_absent_from_the_state_fails():
+    state = {"phases": {"latest": {"steps": {"auth": {"status": "pass"}}}}}
+    verdict = gr.assess(state, {"latest": "success", "nightly_ui": "success"})
+
+    assert verdict["result"] == gr.RESULT_FAILED
+    assert "absent from the state file" in verdict["integrity"][0]
+    assert "nightly_ui" in verdict["integrity"][0]
+
+
+def test_an_empty_state_is_a_failure_not_an_empty_pass():
+    """The strongest form of the same bug: nothing ran, everything looked green."""
+    for state in ({}, {"phases": {}}, {"phases": None}):
+        verdict = gr.assess(state, {})
+        assert verdict["result"] == gr.RESULT_FAILED, state
+        assert "verified nothing" in verdict["integrity"][0]
+
+
+def test_a_skipped_phase_is_not_treated_as_missing():
+    """`skipped` means the runner never ran it — no claim to reconcile."""
+    state = {"phases": {"latest": {"steps": {"auth": {"status": "pass"}}}}}
+    verdict = gr.assess(state, {"latest": "success", "nightly_ui": "skipped"})
+
+    assert verdict["result"] == gr.RESULT_PASSED
+    assert verdict["integrity"] == []
+
+
+def test_warnings_alone_pass_with_warnings():
+    state = {"phases": {"p": {"steps": {"s": {"status": "warn", "detail": "hmm"}}}}}
+    verdict = gr.assess(state, {"p": "success"})
+
+    assert verdict["result"] == gr.RESULT_PASSED_WARN
+    assert len(verdict["warnings"]) == 1
+
+
+def test_an_integrity_problem_outranks_warnings():
+    """A warn must never soften an unaccounted phase into "passed with warnings"."""
+    state = {"phases": {"p": {"steps": {"s": {"status": "warn"}}}}}
+    verdict = gr.assess(state, {"p": "success", "q": "failure"})
+
+    assert verdict["result"] == gr.RESULT_FAILED
+
+
+def test_declared_outcomes_are_parsed_from_the_env_vocabulary():
+    env = {
+        "PHASE_OUTCOME_nightly_ui": "failure",
+        "PHASE_OUTCOME_latest": "Success",  # GitHub casing varies by expression
+        "PHASE_OUTCOME_blank": "   ",
+        "PHASE_OUTCOME_": "failure",  # no phase name
+        "UNRELATED": "failure",
+    }
+    assert gr.declared_outcomes(env) == {
+        "nightly_ui": "failure",
+        "latest": "success",
+    }
+
+
+def test_the_rendered_report_leads_with_the_unaccounted_phase():
+    """Placement matters: below the per-step tables is where run #115 hid it."""
+    body = gr.generate_report(
+        RUN_115_STATE,
+        {"latest": "success", "nightly_api": "success", "nightly_ui": "failure"},
+    )
+
+    assert "## Result: FAILED" in body
+    assert "## Unaccounted phases" in body
+    assert body.index("## Unaccounted phases") < body.index("### Phase: latest")
+    # The runner's own verdict is shown next to the phase it belongs to.
+    assert "runner outcome: `failure`" in body
+
+
+def test_the_rendered_report_still_lists_every_step():
+    body = gr.generate_report(RUN_115_STATE, {})
+
+    for step in ("auth", "execute_flow", "flow_exists", "execute_flow_api_post_update"):
+        assert step in body
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/github-workflows/migration/test_state_store.py
+++ b/tests/github-workflows/migration/test_state_store.py
@@ -1,0 +1,122 @@
+"""Unit tests for the migration state file's write contract (#1120).
+
+The bug these lock down: `state["phases"]["nightly_ui"] = results` discarded every
+step recorded before it, because `TestMigrationUI.setup` is an autouse fixture and
+each test method gets a fresh `self.results`. Run #115 ran six UI tests; the report
+showed one row.
+
+Run with: pytest tests/github-workflows/migration/test_state_store.py
+"""
+
+import json
+
+import pytest
+from . import state_store as ss
+
+
+def test_steps_from_successive_tests_accumulate():
+    """The regression: six tests must leave six steps, not one."""
+    state = {"phases": {}}
+    for i in range(1, 7):
+        state = ss.merge_phase(
+            state,
+            "nightly_ui",
+            {"steps": {f"step_{i}": {"status": "pass"}}, "start_time": 100 + i},
+        )
+
+    steps = state["phases"]["nightly_ui"]["steps"]
+    assert len(steps) == 6, "each save must ADD, never replace the phase"
+    assert sorted(steps) == [f"step_{i}" for i in range(1, 7)]
+
+
+def test_a_later_test_does_not_erase_an_earlier_failure():
+    """The #1120 shape exactly: a failing test followed by a passing one."""
+    state = ss.merge_phase(
+        {"phases": {}},
+        "nightly_ui",
+        {"steps": {"execute_flow_ui": {"status": "fail", "detail": "click timeout"}}},
+    )
+    state = ss.merge_phase(
+        state,
+        "nightly_ui",
+        {"steps": {"execute_flow_api_post_update": {"status": "pass"}}},
+    )
+
+    steps = state["phases"]["nightly_ui"]["steps"]
+    assert steps["execute_flow_ui"]["status"] == "fail", (
+        "the failure must survive a later test's save — erasing it is how the report "
+        "lost the only thing that mattered"
+    )
+    assert steps["execute_flow_api_post_update"]["status"] == "pass"
+
+
+def test_re_recording_the_same_step_takes_the_newer_value():
+    state = ss.merge_phase({"phases": {}}, "p", {"steps": {"s": {"status": "warn"}}})
+    state = ss.merge_phase(state, "p", {"steps": {"s": {"status": "fail"}}})
+
+    assert state["phases"]["p"]["steps"]["s"]["status"] == "fail"
+
+
+def test_duration_spans_the_whole_phase_not_the_last_test():
+    state = ss.merge_phase(
+        {"phases": {}}, "p", {"steps": {"a": {}}, "start_time": 1000.0, "end_time": 1005.0}
+    )
+    state = ss.merge_phase(
+        state, "p", {"steps": {"b": {}}, "start_time": 1060.0, "end_time": 1070.0}
+    )
+
+    phase = state["phases"]["p"]
+    assert phase["start_time"] == 1000.0
+    assert phase["end_time"] == 1070.0
+    assert phase["duration_s"] == 70.0, (
+        "run #115 reported 1.7s for a phase that took over a minute, because it kept "
+        "only the last test's own runtime"
+    )
+
+
+def test_other_phases_are_untouched():
+    state = {
+        "flow_id": "abc",
+        "phases": {"latest": {"steps": {"auth": {"status": "pass"}}}},
+    }
+    merged = ss.merge_phase(state, "nightly_ui", {"steps": {"open_flow": {"status": "pass"}}})
+
+    assert merged["phases"]["latest"]["steps"]["auth"]["status"] == "pass"
+    assert merged["flow_id"] == "abc", "top-level keys survive"
+
+
+def test_merge_does_not_mutate_the_input():
+    state = {"phases": {"p": {"steps": {"a": {"status": "pass"}}}}}
+    ss.merge_phase(state, "p", {"steps": {"b": {"status": "pass"}}})
+
+    assert list(state["phases"]["p"]["steps"]) == ["a"], "callers keep their own copy"
+
+
+def test_missing_and_malformed_shapes_do_not_raise():
+    for state in ({}, {"phases": None}, {"phases": {"p": None}}):
+        merged = ss.merge_phase(state, "p", {"steps": {"s": {"status": "pass"}}})
+        assert merged["phases"]["p"]["steps"]["s"]["status"] == "pass"
+
+    merged = ss.merge_phase({"phases": {}}, "p", {})
+    assert merged["phases"]["p"]["steps"] == {}
+
+
+def test_save_phase_round_trips_through_the_file(tmp_path):
+    path = tmp_path / "state.json"
+
+    ss.save_phase("nightly_ui", {"steps": {"one": {"status": "pass"}}}, state_file=str(path))
+    ss.save_phase("nightly_ui", {"steps": {"two": {"status": "fail"}}}, state_file=str(path))
+
+    written = json.loads(path.read_text())
+    assert sorted(written["phases"]["nightly_ui"]["steps"]) == ["one", "two"]
+
+
+def test_save_phase_creates_the_file_when_absent(tmp_path):
+    path = tmp_path / "nested-missing.json"
+    ss.save_phase("p", {"steps": {"s": {"status": "pass"}}}, state_file=str(path))
+
+    assert json.loads(path.read_text())["phases"]["p"]["steps"]["s"]["status"] == "pass"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/github-workflows/migration/test_ui_migration.py
+++ b/tests/github-workflows/migration/test_ui_migration.py
@@ -8,7 +8,6 @@ Tests:
 5. Execute the flow from the Playground UI
 """
 
-import json
 import os
 import re
 import time
@@ -16,20 +15,23 @@ import time
 import pytest
 from playwright.sync_api import Page, expect
 
+from . import state_store
+
 STATE_FILE = os.environ.get("STATE_FILE", "/tmp/migration-test-state.json")
+
+PHASE = "nightly_ui"
 
 
 def save_ui_state(results: dict):
-    """Append UI test results to the shared state file."""
-    try:
-        with open(STATE_FILE) as f:
-            state = json.load(f)
-    except FileNotFoundError:
-        state = {"phases": {}}
+    """Merge this test's results into the shared state file's `nightly_ui` phase.
 
-    state["phases"]["nightly_ui"] = results
-    with open(STATE_FILE, "w") as f:
-        json.dump(state, f, indent=2)
+    Merges rather than assigns (#1120). `setup` below is an autouse fixture, so
+    pytest hands each test method a fresh `self.results`; the previous
+    `state["phases"]["nightly_ui"] = results` therefore erased every step recorded
+    before it. Run #115 ran six UI tests and the report showed one row. The contract
+    and its unit tests live in `state_store.py`.
+    """
+    state_store.save_phase(PHASE, results, state_file=STATE_FILE)
 
 
 class TestMigrationUI:
@@ -224,92 +226,72 @@ class TestMigrationUI:
         self.page.screenshot(path="test-results/after-update-components.png")
 
     def test_05_execute_flow_ui(self):
-        """Execute the flow from the Playground UI."""
+        """Execute the flow from the Playground UI.
+
+        ## Selectors (#1120)
+
+        Every locator below is one the TypeScript suite drives against live Langflow
+        — `playground-btn-flow-io` (81 call sites), `input-chat-playground` (125),
+        `button-send` (74), `button-stop` (18), `div-chat-message` (51). The previous
+        version invented its own and two of them matched nothing:
+
+        - `[data-testid='playground-btn']` — never existed.
+        - `button[data-testid='send-button']` — never existed either, so the
+          `button:has(svg):near(textarea)` fallback clicked some *other* svg button
+          near the textarea and `click()` timed out after 30 s. That is the failure
+          that opened this issue.
+
+        ## No conditional bypasses
+
+        The old body was a chain of `if count() > 0 and is_visible(): … else:
+        status="skip"; return`, and its final verdict could only be `pass` or
+        `warn` — so a Playground that never rendered, or a flow that answered
+        nothing, was recorded as a non-failure. This test now fails when the
+        Playground does not open, when the reply never arrives, or when the reply is
+        empty.
+        """
         self.page.goto(f"{self.base_url}/flow/{self.flow_id}", wait_until="networkidle")
-        self.page.wait_for_timeout(3000)
 
-        # Click the "Playground" button to open the playground panel
-        playground_btn = self.page.locator(
-            "button:has-text('Playground'), [data-testid='playground-btn']"
-        )
-        if playground_btn.count() > 0 and playground_btn.first.is_visible():
-            playground_btn.first.click()
-            self.page.wait_for_timeout(2000)
-
-        # Find the chat input
-        chat_input = self.page.locator(
-            "textarea[placeholder*='Send'], "
-            "textarea[placeholder*='message'], "
-            "textarea[placeholder*='Type'], "
-            "input[placeholder*='Send'], "
-            "input[placeholder*='message']"
+        # Open the Playground. A migrated flow that cannot open its Playground is a
+        # migration failure, so this is asserted, not probed.
+        self.page.get_by_test_id("playground-btn-flow-io").click(timeout=30_000)
+        expect(self.page.get_by_test_id("button-send").last).to_be_visible(
+            timeout=30_000
         )
 
-        if chat_input.count() == 0 or not chat_input.first.is_visible():
-            self.results["steps"]["execute_flow_ui"] = {
-                "status": "skip",
-                "detail": "Could not find chat input in Playground",
-            }
-            self._save_results()
-            self.page.screenshot(path="test-results/playground-no-input.png")
-            return
+        question = "Hello, what is 2+2?"
+        self.page.get_by_test_id("input-chat-playground").last.fill(question)
+        self.page.get_by_test_id("button-send").last.click()
 
-        # Type a message
-        chat_input.first.fill("Hello, what is 2+2?")
-        self.page.wait_for_timeout(500)
+        # The user's own bubble proves the send landed — the step the old version
+        # could not tell apart from a click that did nothing. Langflow renders it as
+        # `chat-message-User-<text>`, verified on 1.12.0.dev9.
+        # `.last`, not the bare locator: the session keeps its history, so asking the
+        # same question twice resolves to several bubbles and strict mode rejects it.
+        expect(
+            self.page.get_by_test_id(f"chat-message-User-{question}").last
+        ).to_be_visible(timeout=30_000)
 
-        # Send the message (press Enter or click send button)
-        send_btn = self.page.locator(
-            "button[data-testid='send-button'], "
-            "button[aria-label*='send' i], "
-            "button:has(svg):near(textarea)"
-        )
-
-        if send_btn.count() > 0 and send_btn.first.is_visible():
-            send_btn.first.click()
-        else:
-            chat_input.first.press("Enter")
-
-        # Wait for response (look for a new message bubble or loading indicator)
-        self.page.wait_for_timeout(3000)
-
-        # Wait for loading to finish (up to 60s for LLM response)
-        loading = self.page.locator(
-            "[class*='loading' i], [class*='spinner' i], "
-            "[class*='animate-spin']"
-        )
-        try:
-            if loading.count() > 0 and loading.first.is_visible():
-                loading.first.wait_for(state="hidden", timeout=60_000)
-        except Exception:
-            pass
-
-        self.page.wait_for_timeout(2000)
-
-        # Check for error messages in playground
-        error_in_playground = self.page.locator(
-            ".playground-error, [class*='error' i]:near(textarea)"
-        )
-        has_error = False
-        error_text = ""
-
-        # Check for the response message
-        messages = self.page.locator(
-            "[class*='message' i], [data-testid*='message'], "
-            "[class*='chat-message'], [class*='markdown']"
-        )
+        # Then the reply. Waited on directly rather than via `button-stop`
+        # disappearing: `to_be_hidden` is satisfied by an element that never
+        # existed, so a run that never started would have passed that check —
+        # the same read-absence-as-success mistake this issue is about.
+        reply = self.page.get_by_test_id("div-chat-message").last
+        expect(reply).to_be_visible(timeout=120_000)
+        reply_text = reply.inner_text().strip()
 
         self.page.screenshot(path="test-results/playground-result.png")
 
-        msg_count = messages.count()
-        got_response = msg_count > 1  # At least the user message + bot response
-
         self.results["steps"]["execute_flow_ui"] = {
-            "status": "pass" if got_response else "warn",
-            "message_count": msg_count,
-            "got_response": got_response,
+            "status": "pass" if reply_text else "fail",
+            "detail": reply_text[:200] if reply_text else "the reply bubble rendered empty",
         }
         self._save_results()
+
+        assert reply_text, (
+            "the Playground rendered a reply bubble with no text — the flow ran but "
+            "produced nothing after migration"
+        )
 
     def test_06_execute_flow_api_post_update(self):
         """Execute the flow via API after component updates."""


### PR DESCRIPTION
Closes #1120

## The problem

Run #115 opened an issue titled **"Langflow Migration Test Failed"** whose body said **`Result: PASSED`**, with every listed step green. Both statements were accurate about what they measured — and that is the defect. A reader who trusts the first line of the body draws the opposite of the truth.

The real failure: `test_05_execute_flow_ui` died on a 30 s `Locator.click` timeout. Three independent causes conspired to hide it.

## 1. The report inferred success from missing data

`generate_report.py` decided the verdict by scanning the state file for a `fail` status. A pytest test that **crashes** never reaches its own `_save_results()`, so it writes nothing — no `fail` entry, therefore `Result: PASSED`. **The one situation where the report matters most was the one it could not represent.**

It no longer infers. The workflow hands each verification step's `steps.<id>.outcome` to the script as `PHASE_OUTCOME_<phase>`, and the script **reconciles** that against what the phase actually recorded:

| Situation | Before | Now |
|---|---|---|
| runner says FAILED, phase recorded no failure | `PASSED` | `FAILED` + **Unaccounted phases** naming it |
| phase ran but is absent from the state | `PASSED` | `FAILED` |
| state file has no phases at all | `PASSED` | `FAILED` |
| a `warn` alongside an unaccounted phase | `PASSED (with warnings)` | `FAILED` |

Verified against run #115's **exact** state:

```
OLD: ## Result: PASSED
NEW: ## Result: FAILED
     ## Unaccounted phases
     - **nightly_ui**: the runner reports this phase FAILED, but it recorded no failing
       step — it crashed before writing its result (1 step(s) recorded).
```

The heading sits **above** the per-step tables on purpose: below them is where run #115 would have buried it.

## 2. The UI phase overwrote itself once per test

```python
state["phases"]["nightly_ui"] = results   # assignment, not merge
```

`TestMigrationUI.setup` is an **autouse** fixture, so pytest hands each test method a fresh `self.results` and every save discarded the steps before it. Run #115 ran **six** UI tests and the report showed **one** row — whichever test saved last. Combined with cause 1, a failing UI phase could neither fail the report nor appear in it.

The write contract now merges and lives in `state_store.py` with unit tests. Phase duration spans the whole phase rather than the last test's own runtime — run #115 reported `1.7s` for a phase that took over a minute.

## 3. The failing click was aimed at a testid that does not exist

`button[data-testid='send-button']` has never existed in Langflow, so the `button:has(svg):near(textarea)` fallback clicked some **other** svg button and `click()` timed out. `[data-testid='playground-btn']` did not exist either.

Every locator is now one the TypeScript suite already drives against live Langflow:

| Used now | Call sites in the TS suite | Replaced |
|---|---|---|
| `playground-btn-flow-io` | 81 | `[data-testid='playground-btn']` (nonexistent) |
| `input-chat-playground` | 125 | four `placeholder*=` guesses |
| `button-send` | 74 | `send-button` (nonexistent) + svg fallback |
| `div-chat-message` | 51 | `[class*='message' i]` and friends |
| `chat-message-User-<text>` | scouted on 1.12.0.dev9 | — |

**All five confirmed present by driving them locally**, not by reading code.

### The conditional bypasses are gone too

The old body was a chain of `if count() > 0 and is_visible(): … else: status="skip"; return`, and its verdict could only be `pass` or `warn`. A Playground that never opened, or a flow that answered nothing, was recorded as a non-failure. Each of those now fails.

The run finishing is asserted by **waiting for the reply bubble**, deliberately not by `button-stop` becoming hidden: `to_be_hidden` is satisfied by an element that never existed, so a run that never started would have passed that check — cause 1 reintroduced inside the test. I had written it that way first and caught it locally.

## The repo's Python code had no lane at all

`npm run test:units` covers TypeScript, `npm run test:scripts` covers `.mjs`. **Nothing in the repo could have caught any of this before merge.** So `pr-validation.yml` gains a `python-units` job over `tests/github-workflows/migration` — excluding the browser-driven `test_ui_migration.py`, which belongs to `migration-test.yml` — and it fails loudly on an empty collection rather than passing while verifying nothing (#1012's rule).

This is scope I added beyond the issue; say the word and I will split it out.

## Validation

Against Langflow Nightly **1.12.0.dev9**.

- **21 Python unit tests pass**, from both invocations (repo root and inside the directory)
- `npm run typecheck` — 0 errors · `npm run lint` — 0 errors · `test:units` 215/215 · `test:scripts` 169/169 · both workflow YAMLs parse
- The rewritten UI test drives the real Playground end to end: opens it, fills the input, sends, sees the user bubble, and reaches the reply. It ends **red locally by design** — the probe flow had no model configured (in CI `ensure_model_selected` does that), so the reply comes back empty and the new hard assertion catches it in **~4 s**. The old version, same flow, burned **39 s** on its bogus selector and **recorded nothing**. That contrast is the before/after.

**Force-fail (3, executed and reverted, 0 mutation markers left):**

| # | Mutation | Result |
|---|---|---|
| FF1 | point the lane at a directory with no tests | the empty-collection guard exits 1 |
| FF2 | `merge_phase` reverted to assignment | 4 state-store tests fail, including *"a later test does not erase an earlier failure"* |
| FF3 | verdict ignores the declared outcomes again | 5 report tests fail, including the run #115 reproduction |

### Three traps I introduced and fixed on the way

Worth recording, because two of them would have shipped a test that never ran:

- `dict | None` broke on Python 3.9 — CI has 3.12, but the file is imported by tests on whatever a developer has.
- `import generate_report` **fails when pytest runs from the repo root**: `__init__.py` makes the directory the `migration` package, so only its parent lands on `sys.path`. Switched to package-relative imports and verified both invocations.
- `to_be_hidden(button-stop)` as proof the run finished — see above.

## Honest limits

- **The workflow wiring is proven only by a real run.** The report reconciliation, the merge and the locators are all proven locally; what needs CI is that `steps.*.outcome` reaches the report step as expected. Recommend a `workflow_dispatch` of `migration-test.yml` after merge instead of waiting for the schedule.
- The **green** path of the UI test — a configured flow producing a real reply — was not reproduced locally; `ensure_model_selected` plus the auto-imported credential are what provide it in CI, and `execute_flow_api` already proves the flow answers there.
- Flow count on the local instance went 30 → 29. My two probe flows were deleted by id (`200` each) and are accounted for; the second copies of `Basic Prompting` and `Memory Chatbot` also disappeared, most likely template copies from earlier spec runs cleaned up by their own teardowns — but I did not keep the prior id list, so I am not claiming that as certain. Nothing I did not create was deleted deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
