### PR TITLE
fix(knowledge-ingestion): upload under a per-run unique name, not a fixed one (#1125)

### DIFF
--- a/docs/core-functionality/knowledge-ingestion-management/upload-via-component.md
+++ b/docs/core-functionality/knowledge-ingestion-management/upload-via-component.md
@@ -71,7 +71,11 @@ together with the determinism fix below.)
    (`Promise.all([page.waitForEvent("filechooser"), click])` → `setFiles`).
    Gate on the upload landing server-side (`POST /api/v2/files` with a `< 300`
    status) and keep the response's `id` + `name` for the cleanup and the
-   name-derived testids.
+   name-derived testids. Both fields are asserted rather than read optionally:
+   the `id` is the only handle `afterEach` has (losing it leaks the upload into
+   the shared account — the residue this spec was broken by), and the `name`
+   must **equal** the stem, so a rename fails loudly instead of being followed
+   silently.
 5. Assert the file appears (`file-item-<stem>`) **and that the app registered it
    as selected** — `checkbox-<stem>` with `data-state="checked"`. This is the
    load-bearing gate (#1125): the rendered row and the modal's internal
@@ -170,7 +174,10 @@ seeding one `test-file` row before the run, on 1.12.0.dev10.
 Two independent guards keep the spec deterministic:
 
 1. the upload name is a fresh random stem per run, so the collision branch is
-   never entered, and the testids come from the **response's** `name`;
+   never entered, and the testids come from the **response's** `name`. That
+   guard is itself checked — the run asserts `response.name === stem`, so a
+   collision (residue, a stem clash, or a future server-side normalization) is
+   reported instead of absorbed by the response-derived testids;
 2. the confirm click waits for `checkbox-<stem>` to read `data-state="checked"`,
    which proves the app's selection and the rendered row agree on the file path
    (the earlier gate — a `waitForResponse` on the POST plus a visible row — is

--- a/docs/core-functionality/knowledge-ingestion-management/upload-via-component.md
+++ b/docs/core-functionality/knowledge-ingestion-management/upload-via-component.md
@@ -2,7 +2,7 @@
 
 **Test file:** `tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/upload-via-component.spec.ts`
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x
 
 ---
 
@@ -26,10 +26,15 @@ The file's content is a unique sentinel, so the output match cannot be
 coincidental: `test-file.txt` = `This is a test file for upload functionality
 testing.`.
 
+The **bytes** come from that asset, but the **upload name is a fresh random stem
+per run** (`generateRandomFilename()`), because `POST /api/v2/files` renames an
+upload whose name collides — see _Unique upload name_ below. Every name-derived
+testid in this spec is therefore built from that stem.
+
 ## Validation criterion (concrete, distinctive)
 
-After uploading `test-file.txt` through the Read File component and running the
-node:
+After uploading the asset's bytes under a per-run unique name through the Read
+File component and running the node:
 
 - the node shows a successful build badge (`node_duration_read file`), and
 - the component's **raw-content output** (`output-inspection-raw content-file`
@@ -46,7 +51,9 @@ read path fails a specific step — the output text is the end-to-end proof.
 `@stable` `@release` `@files` `@components`
 
 (`@files`: file upload/ingestion surface. `@components`: canvas-component
-configuration. Created `@stable` by #671 after deterministic validation.)
+configuration. Created `@stable` by #671 after deterministic validation;
+quarantined (`test.fixme`) at the triage of daily #1121 and restored by #1125
+together with the determinism fix below.)
 
 ---
 
@@ -58,13 +65,22 @@ configuration. Created `@stable` by #671 after deterministic validation.)
 2. Add the **Read File** component: search "Read File" in the sidebar, click
    `add-component-button-read-file`.
 3. Open the component's file management modal (`button_open_file_management`).
-4. Upload the local asset: click the dropzone (`drag-files-component`), which
-   opens a native file chooser, and set `test-file.txt` on it
+4. Upload the asset's bytes under a per-run unique name: click the dropzone
+   (`drag-files-component`), which opens a native file chooser, and set
+   `{ name: "<stem>.txt", mimeType: "text/plain", buffer }` on it
    (`Promise.all([page.waitForEvent("filechooser"), click])` → `setFiles`).
-5. Assert the file appears and is selected (`file-item-test-file`,
-   `checkbox-test-file`, "1 selected"); confirm with `select-files-modal-button`.
-6. Assert the file attached to the component (`file-item-test-file` +
-   `remove-file-button-test-file` render on the node).
+   Gate on the upload landing server-side (`POST /api/v2/files` with a `< 300`
+   status) and keep the response's `id` + `name` for the cleanup and the
+   name-derived testids.
+5. Assert the file appears (`file-item-<stem>`) **and that the app registered it
+   as selected** — `checkbox-<stem>` with `data-state="checked"`. This is the
+   load-bearing gate (#1125): the rendered row and the modal's internal
+   selection are keyed on the file **path**, so a checked box is the only proof
+   that the optimistic upload entry has been replaced by the server's record and
+   that confirming will attach _this_ file. Then confirm with
+   `select-files-modal-button`.
+6. Assert the file attached to the component (`file-item-<stem>` renders on the
+   node, after the modal-only `select-files-modal-button` disappears).
 7. Run the component (`button_run_read file`); assert `node_duration_read file`
    (successful build).
 8. Open the output inspector (`output-inspection-raw content-file`); assert the
@@ -76,14 +92,17 @@ configuration. Created `@stable` by #671 after deterministic validation.)
 
 - Sidebar/component testids: `add-component-button-read-file`,
   `button_open_file_management`, `drag-files-component`,
-  `file-item-test-file`, `checkbox-test-file`, `select-files-modal-button`,
-  `remove-file-button-test-file`, `button_run_read file`,
-  `node_duration_read file`, `output-inspection-raw content-file` (scouted
-  live on 1.11.0.dev41).
-- Files API: `POST /api/v2/files` (upload), `GET /api/v2/files`,
+  `file-item-<stem>`, `checkbox-<stem>`, `select-files-modal-button`,
+  `button_run_read file`, `node_duration_read file`,
+  `output-inspection-raw content-file` (scouted live on 1.11.0.dev41,
+  re-confirmed on 1.12.0.dev10). The two `<stem>` testids are derived from the
+  **name the server returns**, never from the local asset name (#1125).
+- Files API: `POST /api/v2/files` (upload — its response carries the `id` used
+  for cleanup and the `name` the testids are built from), `GET /api/v2/files`,
   `DELETE /api/v2/files/{id}` (cleanup — the upload persists in the user's
   global file store).
-- Asset `tests/assets/files/test-file.txt` (resolved via `resolveAssetPath`).
+- Asset `tests/assets/files/test-file.txt` (read via `resolveAssetPath` +
+  `fs.readFileSync`; uploaded under a random stem).
 - No model provider credentials required (pure file read, no LLM).
 
 ---
@@ -115,7 +134,48 @@ Two persistent artifacts, both cleaned id-scoped in `afterEach`:
   collecting every `POST /api/v1/flows` 201 id) and delete all with
   `deleteFlow` (404-tolerant). Never `page.url()` here (#681).
 - **Uploaded file:** the upload persists in the user's global file store, so
-  list `GET /api/v2/files` and `DELETE /api/v2/files/{id}` the uploaded file
-  by name in `afterEach` — otherwise repeated runs accumulate
-  `test-file.txt`, `test-file (1).txt`, … Behavioral force-fail: no-op the file
-  cleanup and the file count grows.
+  `DELETE /api/v2/files/{id}` it in `afterEach`, with the id taken from the
+  upload response — otherwise repeated runs accumulate files. Deleting **by id**,
+  never by name prefix: the account is shared by every spec of the shard, so a
+  `name.startsWith(...)` sweep is a cross-worker wipe (the #465 hazard). The
+  previous version of this spec deleted every file whose name started with
+  `test-file`. Behavioral force-fail: no-op the file cleanup and the file count
+  grows.
+
+---
+
+## Unique upload name — why (#1125)
+
+`POST /api/v2/files` enforces unique names with a **prefix** query, not an
+equality check:
+
+```python
+stmt = select(UserFile).where(col(UserFile.name).like(f"{root_filename}%"),
+                              UserFile.user_id == current_user.id)
+if files:
+    root_filename = f"{root_filename} ({count + 1})"
+```
+
+So an upload of `test-file.txt` becomes `test-file (1)` whenever **any** row of
+that user already starts with `test-file` — a residue of an earlier run whose
+cleanup did not land, or a second upload in the same account. The file then
+attaches under the renamed label, and a name-derived testid built from the local
+asset name (`file-item-test-file`) matches nothing on the node.
+
+That is what failed on the daily of 2026-07-30 (run 30534416609): the modal step
+passed in ~1 s — matching the _residue_ row — and the node-chip assertion timed
+out 15 s later with `element(s) not found`. Reproduced deterministically by
+seeding one `test-file` row before the run, on 1.12.0.dev10.
+
+Two independent guards keep the spec deterministic:
+
+1. the upload name is a fresh random stem per run, so the collision branch is
+   never entered, and the testids come from the **response's** `name`;
+2. the confirm click waits for `checkbox-<stem>` to read `data-state="checked"`,
+   which proves the app's selection and the rendered row agree on the file path
+   (the earlier gate — a `waitForResponse` on the POST plus a visible row — is
+   also satisfied by the optimistic entry, whose row is `pointer-events-none`).
+
+The daily's 2026-07-23 failure on this spec was a **different** signature
+(`sidebar-search-input` never visible, during setup) and belongs to #1063 — this
+spec is not a same-signature repeat offender.

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/upload-via-component.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/upload-via-component.spec.ts
@@ -137,10 +137,17 @@ test(
         "the upload response must carry the file id",
       ).toBeTruthy();
       createdFileIds.push(uploaded.id as string);
+      // Equality, not just presence: the stem is random, so the server's
+      // uniqueness branch must not have fired. Asserting it keeps the
+      // unique-name guard falsifiable — the testids below are still built from
+      // the response (the server is the authority on the stored name), and
+      // without this the spec would silently follow a rename instead of
+      // reporting that the account already holds a colliding row. Same
+      // assertion as file-types-upload.spec.ts.
       expect(
         uploaded.name,
-        "the upload response must carry the stored name",
-      ).toBeTruthy();
+        "the upload must keep its per-run unique stem — a rename means the shared account already holds a colliding row (#1125)",
+      ).toBe(stem);
       uploadedName = uploaded.name as string;
 
       // The uploaded file appears in My Files, pre-selected. The visible row is

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/upload-via-component.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/upload-via-component.spec.ts
@@ -1,7 +1,9 @@
-import type { APIRequestContext, Page } from "@playwright/test";
+import fs from "fs";
+import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { resolveAssetPath } from "../../../../helpers/filesystem/resolve-asset-path";
+import { generateRandomFilename } from "../../../../helpers/filesystem/generate-filename";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 
@@ -11,12 +13,22 @@ const SENTINEL = "This is a test file for upload functionality testing.";
 const ASSET = "test-file.txt";
 
 // Two persistent artifacts to clean up id-scoped: the flow AND the uploaded
-// file (it lands in the user's global /api/v2/files store). The flow id is
-// captured from POST /api/v1/flows 201 responses (Pattern A) — never
-// page.url(), which returns the stale bootstrap flow id because
-// awaitBootstrapTest creates a competing flow before the blank-flow click
-// (#681).
+// file (it lands in the user's global /api/v2/files store). Both ids come from
+// the create responses (Pattern A) — never page.url() for the flow, which
+// returns the stale bootstrap flow id because awaitBootstrapTest creates a
+// competing flow before the blank-flow click (#681).
+//
+// The file cleanup used to sweep every file whose name started with the asset
+// stem. That is a cross-worker wipe on the shard's shared account (#465), and it
+// papered over the real problem: uploading a FIXED name at all. POST
+// /api/v2/files enforces unique names with a prefix query
+// (`name LIKE '<stem>%'`), so a single residue row renames the upload to
+// "<stem> (1)" and every name-derived testid built from the local asset name
+// misses — which is exactly how the daily of 2026-07-30 failed (#1125). The
+// upload therefore carries a random per-run stem and the testids are derived
+// from the name the SERVER returns.
 const createdFlowIds: string[] = [];
+const createdFileIds: string[] = [];
 
 function trackCreatedFlows(page: Page): void {
   page.on("response", (resp) => {
@@ -35,26 +47,6 @@ function trackCreatedFlows(page: Page): void {
   });
 }
 
-async function deleteUploadedFiles(
-  request: APIRequestContext,
-  bearer: string,
-): Promise<void> {
-  const res = await request.get("/api/v2/files", {
-    headers: { Authorization: bearer },
-  });
-  if (!res.ok()) return;
-  const files: Array<{ id: string; name: string }> = await res.json();
-  for (const f of files) {
-    // Match on the asset stem — Langflow strips the extension in `name` and
-    // suffixes duplicates ("test-file", "test-file (1)").
-    if (f.name.startsWith("test-file")) {
-      await request
-        .delete(`/api/v2/files/${f.id}`, { headers: { Authorization: bearer } })
-        .catch(() => {});
-    }
-  }
-}
-
 test.afterEach(async ({ request }) => {
   const bearer = await getAuthToken(request);
   for (const id of createdFlowIds.splice(0)) {
@@ -62,18 +54,26 @@ test.afterEach(async ({ request }) => {
       headers: { Authorization: bearer },
     }).catch(() => {});
   }
-  await deleteUploadedFiles(request, bearer);
+  for (const id of createdFileIds.splice(0)) {
+    await request
+      .delete(`/api/v2/files/${id}`, { headers: { Authorization: bearer } })
+      .catch(() => {});
+  }
 });
 
-// Quarantined for #1125 — recurrent flake (dailies 2026-07-23, 2026-07-30):
-// the uploaded file item `file-item-test-file` never renders within 15 s, even
-// though the upload POST is awaited. Lifting the quarantine and restoring
-// @stable is a deliverable of #1125.
-test.fixme(
+test(
   "upload a file through the Read File component and read its content",
-  { tag: ["@release", "@files", "@components"] },
+  { tag: ["@stable", "@release", "@files", "@components"] },
   async ({ page }) => {
     trackCreatedFlows(page);
+    // The asset's bytes under a per-run unique name: the name is what the
+    // server's uniqueness check (and every testid below) keys on.
+    const stem = generateRandomFilename();
+    const buffer = fs.readFileSync(resolveAssetPath(ASSET));
+    // Filled from the upload response — the server is the authority on the
+    // stored name, so the testids are built from it and not from `stem`.
+    let uploadedName = "";
+
     await awaitBootstrapTest(page);
 
     await test.step("open a blank flow", async () => {
@@ -112,7 +112,7 @@ test.fixme(
       // Gate on the upload actually completing server-side: clicking
       // "select" before the POST /api/v2/files response lands leaves the file
       // not-yet-selectable and the confirm is a no-op, so the modal never
-      // closes (the dominant flake here).
+      // closes.
       const uploadDone = page.waitForResponse(
         (r) =>
           r.url().includes("/api/v2/files") &&
@@ -120,13 +120,31 @@ test.fixme(
           r.status() < 300,
         { timeout: 30000 },
       );
-      await chooser.setFiles(resolveAssetPath(ASSET));
-      await uploadDone;
+      await chooser.setFiles([
+        { name: `${stem}.txt`, mimeType: "text/plain", buffer },
+      ]);
+      const uploaded: { id?: string; name?: string } = await (
+        await uploadDone
+      ).json();
+      if (uploaded.id) createdFileIds.push(uploaded.id);
+      expect(
+        uploaded.name,
+        "the upload response must carry the stored name",
+      ).toBeTruthy();
+      uploadedName = uploaded.name as string;
 
-      // The uploaded file appears in My Files, pre-selected.
-      await expect(page.getByTestId("file-item-test-file")).toBeVisible({
+      // The uploaded file appears in My Files, pre-selected. The visible row is
+      // NOT enough: the optimistic cache entry renders the same testid while it
+      // is still `pointer-events-none`, and the row is keyed on the file name
+      // while the modal's selection is keyed on the file PATH. A checked box is
+      // the only proof that the two agree — i.e. that confirming attaches THIS
+      // file (#1125).
+      await expect(page.getByTestId(`file-item-${uploadedName}`)).toBeVisible({
         timeout: 15000,
       });
+      await expect(
+        page.getByTestId(`checkbox-${uploadedName}`),
+      ).toHaveAttribute("data-state", "checked", { timeout: 15000 });
       await page.getByTestId("select-files-modal-button").click();
     });
 
@@ -140,7 +158,7 @@ test.fixme(
       await expect(
         page.getByTestId("select-files-modal-button"),
       ).toBeHidden({ timeout: 15000 });
-      await expect(page.getByTestId("file-item-test-file")).toBeVisible({
+      await expect(page.getByTestId(`file-item-${uploadedName}`)).toBeVisible({
         timeout: 15000,
       });
     });

--- a/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/upload-via-component.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/knowledge-ingestion-management/upload-via-component.spec.ts
@@ -126,7 +126,17 @@ test(
       const uploaded: { id?: string; name?: string } = await (
         await uploadDone
       ).json();
-      if (uploaded.id) createdFileIds.push(uploaded.id);
+      // Both fields are load-bearing, so neither is treated as optional: `id`
+      // is the only handle the afterEach cleanup has — dropping it silently
+      // leaks the upload into the shard's shared account, which is the very
+      // residue that broke this spec (#1125) — and `name` is what every testid
+      // below is built from. Register the id before asserting anything else, so
+      // a later failure still cleans up.
+      expect(
+        uploaded.id,
+        "the upload response must carry the file id",
+      ).toBeTruthy();
+      createdFileIds.push(uploaded.id as string);
       expect(
         uploaded.name,
         "the upload response must carry the stored name",


### PR DESCRIPTION
Closes #1125

## What failed

`upload-via-component.spec.ts` flaked on the daily of 2026-07-30 (run [30534416609](https://github.com/oriontech-me/langflow-e2e/actions/runs/30534416609)) and was quarantined at triage (`test.fixme` + `@stable` removed, PR #1127).

**The issue's framing was wrong on two points, corrected from the run artifacts:**

1. **The modal is not where it fails.** In `results.json` the step `upload the local file through the file-management modal` **passed in 1065 ms**. The failure is the next step, `the file is attached to the component` — `upload-via-component.spec.ts:139`, the **node chip** — with `element(s) not found` after 15 s. The failure screenshot and ARIA snapshot show the modal closed and the Read File `Files` field empty ("Select files").
2. **It is not a same-signature recurrence.** The 2026-07-23 failure of this spec was `sidebar-search-input` never visible during setup (line 81) — that is the #1063 cluster, not this one. 07-30 was the **first** occurrence of this signature.

## Root cause (verdict: test defect)

`POST /api/v2/files` enforces unique names with a **prefix** query, not an equality check:

```python
stmt = select(UserFile).where(col(UserFile.name).like(f"{root_filename}%"),
                              UserFile.user_id == current_user.id)
if files:
    root_filename = f"{root_filename} ({count + 1})"
```

The spec uploaded the asset under its literal name (`test-file.txt`) and asserted testids derived from **that local name**. So one residue row named `test-file*` in the shard's shared superuser account renames the upload to `test-file (1)`; the file attaches under that label and `file-item-test-file` matches nothing on the node — while the **modal** assertion still passes, because it matches the residue row (or the optimistic React Query entry, whose `name` is the local stem).

Measured live on 1.12.0.dev10, at the exact instant the old spec clicked confirm:

```
POST body: {"name":"test-file (1)","path":".../test-file (1).txt", ...}
checkbox data-state=unchecked | item text="test-file.txt\n53 B"
node chip visible after confirm: false
```

I could not attribute *which* run left the residue on 07-30: the old cleanup swallowed errors (`.catch(() => {})`), so a DELETE that failed leaves no trace, and the account is shared by every spec of the shard (2 workers; `files-page.spec.ts` ran on the same shard). The defect does not depend on the answer — coupling a fixed name to a shared, mutable global store is the bug.

No product bug: the rename is documented behaviour and the user still sees their file. Nothing to file upstream.

## Changes

- **Per-run unique upload name** (`generateRandomFilename()` + buffer upload, the pattern of `files-page` / `file-types-upload`), and every name-derived testid built from the **name the server returns** — two independent guards, either of which alone prevents the 07-30 failure.
- **Selection gate before confirming**: wait for `checkbox-<name>` to read `data-state="checked"`. The row is keyed on the file *name*, the modal's selection on the file *path*; a checked box is the only proof the two agree. The old gate (`waitForResponse` on the POST + a visible row) is also satisfied by the optimistic entry, whose row is `pointer-events-none`. This is step 5 the spec doc already prescribed and the code never did.
- **File cleanup by id** from the upload response, replacing the `name.startsWith("test-file")` sweep — that sweep deleted *any* matching file of the shared account, the cross-worker wipe hazard of #465.
- Quarantine lifted (`test.fixme` removed) and `@stable` restored.
- Spec doc updated: unique-name rationale, the new gate, id-scoped cleanup, `Last validated: 1.12.x`.

`QA-CHECKLIST.md` needs no change — the Part II bullet for this spec is already `[x]` and the quarantine PR did not touch it.

## Validation

Langflow **Nightly 1.12.0.dev10** (`langflowai/langflow-nightly`), local, `--workers=1 --retries=0`.

| Check | Result |
|---|---|
| Pre-fix reproduction | seeded one `test-file` row → failed at `upload-via-component.spec.ts:139`, `element(s) not found` — the daily's signature exactly |
| Clean burst | 3 passed (14.6 s) |
| **Regression proof** — old trigger seeded (`test-file` + `test-file (1)` present) | 2 passed (9.8 s); the two foreign rows **survived** the run, proving the cleanup is id-scoped |
| `--trace=on` | 1 passed in 7 s (no hang for this spec); trace steps match the spec doc's sequence, 109 screencast frames |
| `🚨 Backend Error` | zero across all 9 runs |
| `npm run typecheck` | clean |
| `npm run lint` | 0 errors |
| `npm run check:checklist-coverage` | pass |
| Artifact leak | `GET /api/v1/flows/` → 0 orphan flows, `GET /api/v2/files` → 0 files after the campaign |

**Force-fails (executed, each observed failing, then reverted and re-run green):**

- `FF1` sentinel content mutated → fails at `toHaveValue` (line 174) — the end-to-end observable is load-bearing.
- `FF2` confirm click removed → fails at `toBeHidden` (line 158) — the attach path is load-bearing.
- `FF3` node-chip testid hardcoded back to `file-item-test-file` → fails with `element(s) not found` — reproduces the daily failure on demand, proving the response-derived testid is what fixes it.
- `FF4` file cleanup no-oped → store grew 2 → 3 files; with cleanup restored the run leaves its own upload deleted.

`grep` for mutation markers in the final diff: 0 hits.