### PR TITLE
ci(migration): close the tracking issue only on the default branch (#1145)

### DIFF
--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -299,8 +299,16 @@ jobs:
             /tmp/latest-digest.txt
             /tmp/nightly-digest.txt
 
+      # Scoped to the default branch (#1145). This step used to fire on ANY green
+      # run, so a `workflow_dispatch` on a branch closed the issue that tracks a bug
+      # still present on `main`. It happened for real: run #117, dispatched on the
+      # #1143 fix branch, closed #1143 while the fix was still unmerged and `main`
+      # still carried the racy assertion. Dispatching on a branch is the recommended
+      # way to prove changes to this workflow — #1139, #1141 and #1143 could only be
+      # proven that way — so the practice that produces the best evidence must not
+      # silently write to the tracker.
       - name: Close issue on success
-        if: success()
+        if: success() && github.ref == 'refs/heads/main'
         uses: actions/github-script@v9
         with:
           script: |
@@ -332,6 +340,10 @@ jobs:
               });
             }
 
+      # Deliberately NOT scoped to the default branch (#1145): a red branch run is
+      # worth filing — that is exactly how #1143 was found, by dispatching on a
+      # branch. The body names the ref and the event instead, so a reader can tell a
+      # branch experiment from a `main` failure rather than assuming the latter.
       - name: Create or update issue on failure
         if: failure()
         uses: actions/github-script@v9
@@ -354,6 +366,8 @@ jobs:
 
             const body = [
               `## Run #${context.runNumber} — ${new Date().toISOString().split('T')[0]}`,
+              '',
+              `**Ref:** \`${context.ref}\` · **Event:** \`${context.eventName}\``,
               '',
               report,
               '',
@@ -743,8 +757,9 @@ jobs:
             /tmp/run-target.json
           retention-days: 30
 
+      # Same default-branch scope as the API job above (#1145).
       - name: Close issue on success
-        if: success()
+        if: success() && github.ref == 'refs/heads/main'
         uses: actions/github-script@v9
         with:
           script: |
@@ -789,6 +804,8 @@ jobs:
             });
             const body = [
               `## Run #${context.runNumber} — ${new Date().toISOString().split('T')[0]}`,
+              '',
+              `**Ref:** \`${context.ref}\` · **Event:** \`${context.eventName}\``,
               '',
               `docker-compose migration test failed. Source: \`langflowai/langflow:latest\` → Target: \`langflowai/langflow-nightly:latest\`.`,
               `Compose file: pinned to upstream main of \`langflow-ai/langflow/docker_example/docker-compose.yml\`.`,


### PR DESCRIPTION
Closes #1145.

## The hole

`Close issue on success` fired on any green run, from any ref:

```yaml
- name: Close issue on success
  if: success()
```

So a `workflow_dispatch` on a branch closed the issue that tracks a bug still present on `main`.

Observed, not hypothesised, while validating #1143:

1. Run [#116](https://github.com/oriontech-me/langflow-e2e/actions/runs/30565105144) failed and opened #1143 — correct.
2. Run [#117](https://github.com/oriontech-me/langflow-e2e/actions/runs/30565950660) was dispatched on `fix/issue-1143-playground-reply-stream-race`, passed, and **closed #1143** at 17:29:23 — while the fix was unmerged and `main` still carried the racy assertion. I reopened it by hand; nothing in the tracker recorded that the closure came from a branch.

What makes this worse than untidy: dispatching on a branch is the *recommended* way to prove changes to this workflow — #1139, #1141 and #1143 could only be proven that way. The practice that produces the best evidence was also the one that silently wrote to the tracker.

Same family as #1120, #1141 and #1143: one signal (a green run) read as proof of a different claim (fixed on the default branch).

## The change

Both jobs — `migration-test` and `migration-test-compose`, each with its own copy of the step — now guard the close:

```yaml
if: success() && github.ref == 'refs/heads/main'
```

**The failure path is deliberately NOT scoped.** A red branch run is worth filing — that is exactly how #1143 was found. Both failure bodies instead name where the run came from:

```js
`**Ref:** \`${context.ref}\` · **Event:** \`${context.eventName}\``,
```

Before, an issue filed by a branch experiment was indistinguishable from a `main` failure. This is the explicit decision the issue's last Done-when item asked for.

## Validation

**Before/after on the same kind of run** — both green `workflow_dispatch` runs on a branch:

| | [Run #117](https://github.com/oriontech-me/langflow-e2e/actions/runs/30565950660) — pre-fix | [Run #118](https://github.com/oriontech-me/langflow-e2e/actions/runs/30567248024) — this branch |
|---|---|---|
| `migration-test` → `Close issue on success` | **`success`** — closed #1143 | **`skipped`** |
| `migration-test-compose` → same step | **`success`** | **`skipped`** |
| Job conclusions | both `success` | both `success` |

The tracker confirms it: #1143's `updatedAt` is still `17:38:01`, the merge of PR #1144 — run #118 did not touch it. Both jobs were exercised, not only the one that produced the original symptom.

Run #117 *is* the executed force-fail here: the pre-fix condition is the mutation, and it wrote to the tracker for real.

**Scheduled runs are unaffected** — the assumption worth checking, because if a `schedule` ran on some other ref the issue would never close again, a silent failure in the opposite direction. Verified against run `30530547302`: `event=schedule`, `head_branch=main`, and the repo's `default_branch` is `main`.

**PR #793 does not conflict.** `git merge-tree --write-tree` returns clean between this branch and `fix/migration-test-issue-label-collision`, and — worth noting for that PR — also between #793 and current `main`, despite the API reporting `mergeable=UNKNOWN` (stale cache, not a conflict). #793 swaps the `labels:` string those steps filter on; this changes the `if:` and the bodies. Either order works.

**Not covered:** the `Ref:`/`Event:` line only renders on a red run. Proving it would mean breaking a run on purpose, which now files an issue — real tracker pollution to validate body cosmetics. It will be visible on the first legitimate failure.

No spec files are touched, so nothing here creates flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
