### PR TITLE
fix(ui-ux): enter the blank flow over the API, not through the welcome overlay (#1063)

### DIFF
--- a/docs/core-functionality/playground/output-modal-copy-button.md
+++ b/docs/core-functionality/playground/output-modal-copy-button.md
@@ -1,6 +1,6 @@
 # Output Modal — Copy Button
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.12.x
 
 ---
 
@@ -24,8 +24,13 @@ If this breaks, users have no reliable way to grab the output of a component int
 
 ## Step by step *(required)*
 
-1. Open Langflow and create a blank flow; capture the flow id from the `POST /api/v1/flows` 201 response
-2. Add a **Chat Input** component, expand it (it is added minimized), and fill its `textarea_str_input_value` with `"Test content to copy"`
+1. Create the blank flow with the shared `setupBlankFlow` helper: it creates the flow
+   over the API, navigates to it, and returns the flow id (no `POST /api/v1/flows`
+   response interception needed)
+2. Gate on write permission having resolved (`menu_bar_display` enabled) and on
+   `sidebar-search-input` being visible, then add a **Chat Input** component, expand
+   it (it is added minimized), and fill its `textarea_str_input_value` with
+   `"Test content to copy"`
 3. Run the component (`button_run_chat input`) and wait for the "built successfully" toast
 4. Click the first `output-inspection-*` button to open the Component Output modal
 5. Click `copy-output-button`
@@ -33,7 +38,20 @@ If this breaks, users have no reliable way to grab the output of a component int
 7. Assert the Check icon (`icon-Check`) is visible inside the button
 8. Assert the Copy icon (`icon-Copy`) returns within 5s (web-first assertion — no `waitForTimeout`)
 
-`afterEach` navigates to `/` and deletes the captured flow via `DELETE /api/v1/flows/{id}`.
+`afterEach` navigates to `/` (so the editor's background polling cannot complete
+after the delete and log spurious 404s) and deletes the returned flow id via
+`DELETE /api/v1/flows/{id}`, passing an explicit bearer from `getAuthToken` — under
+AUTO_LOGIN a bare request context is unauthenticated, so an unheadered delete 401s
+and silently leaks the flow.
+
+**Sidebar entry race (#1063).** This step used to drive the home page → "New Flow" →
+templates modal → `blank-flow` path, which is what made the spec flake: while the
+welcome overlay is open, `FlowPage` mounts the whole `FlowSidebarComponent` inside a
+`display: none` wrapper, so `sidebar-search-input` was in the DOM with an empty
+bounding box — what Playwright reports as `hidden`. "New Flow" opens that overlay
+before navigating and "Browse more templates" does not close it. Creating the flow
+over the API never opens it. Full chain in
+`docs/ui-ux/execution-error-notification.md`.
 
 ---
 

--- a/docs/core-functionality/playground/playground-clear-history.md
+++ b/docs/core-functionality/playground/playground-clear-history.md
@@ -1,6 +1,6 @@
 # Playground — Clear History & Session Delete
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.12.x
 
 ---
 
@@ -25,7 +25,9 @@ These are distinct operations: Default sessions expose "Clear chat"; user-create
 
 **Test 1 — clear chat on Default session must remove messages but keep the session**
 
-1. Create a blank flow with ChatInput connected to ChatOutput (echo setup, no LLM required)
+1. Build the flow with the shared `setupPlayground` helper: it creates the flow over
+   the API, navigates straight to `/flow/{id}`, and wires ChatInput → ChatOutput
+   (echo setup, no LLM required). It returns the flow id for id-scoped cleanup
 2. Open the Playground via `playground-btn-flow-io`
 3. Send a message ("Hello from test") and confirm it appears as `div-chat-message`
 4. Open the Default session menu via `chat-header-more-menu` (using `evaluate` to bypass framer-motion overlay)
@@ -35,7 +37,7 @@ These are distinct operations: Default sessions expose "Clear chat"; user-create
 
 **Test 2 — deleting a user-created session must remove it and return to Default session**
 
-1. Create the same ChatInput → ChatOutput flow and open the Playground
+1. Build the same ChatInput → ChatOutput flow (`setupPlayground`) and open the Playground
 2. Click `new-chat` to create a new session
 3. Send a message ("Message in new session") in the new session
 4. Open the session menu via `chat-header-more-menu` and click `delete-session-option`
@@ -86,5 +88,22 @@ These are distinct operations: Default sessions expose "Clear chat"; user-create
 
 ## Notes *(optional)*
 
-- Tests run in `serial` mode to prevent race conditions from `cleanAllFlows` deleting flows mid-execution
+- Tests run in `serial` mode because Test 2 asserts a session **count** in the
+  playground sidebar, which a concurrent sibling on the same flow would perturb.
+  Cleanup is id-scoped — this file never calls `cleanAllFlows`, so it cannot
+  delete a parallel worker's flow (#465/#515). The earlier note claiming
+  `cleanAllFlows` was the reason for serial mode was stale.
+- **Sidebar entry race (#1063).** Both tests previously built the flow through the
+  home page → "New Flow" → templates modal → `blank-flow` path, and flaked because
+  `FlowPage` mounts the whole `FlowSidebarComponent` inside a `display: none`
+  wrapper while the welcome overlay is open — so `sidebar-search-input` sat in the
+  DOM with an empty bounding box, which Playwright reports as `hidden`. "New Flow"
+  opens that overlay **before** navigating and "Browse more templates" does not
+  close it, so the setup raced a multi-hop settle it did not drive. `setupPlayground`
+  creates the flow over the API and never opens the overlay, so the condition is
+  gone rather than re-budgeted. Full chain in `docs/ui-ux/execution-error-notification.md`.
+- Cleanup passes an explicit bearer from `getAuthToken`: under AUTO_LOGIN a bare
+  request context is unauthenticated, so an unheadered `DELETE` 401s and silently
+  leaks the flow.
+- `evaluate((el) => el.click())` is intentional: the menu trigger sits inside an `AnimatedConditional` that may have an overlapping sibling div during the animation, making coordinate-based clicks unreliable
 - `evaluate((el) => el.click())` is intentional: the menu trigger sits inside an `AnimatedConditional` that may have an overlapping sibling div during the animation, making coordinate-based clicks unreliable

--- a/docs/ui-ux/execution-error-notification.md
+++ b/docs/ui-ux/execution-error-notification.md
@@ -1,6 +1,6 @@
 # Execution Error Notifications — Network / Server Errors During Flow Execution
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x
 
 ---
 
@@ -57,14 +57,18 @@ promotion bullet in scope.
 
 ## Step by step *(required)*
 
-Shared setup (`setupChatFlow`): bootstrap the app (`awaitBootstrapTest`), open a
-blank flow, add **Chat Output** and **Chat Input**, connect ChatInput source →
-ChatOutput target. Every created flow id is captured from its
-`POST /api/v1/flows → 201` response and deleted id-scoped in `afterEach`.
-`page.allowFlowErrors()` is set because each test intentionally fails a run.
+Shared setup (`setupPlayground`, the repo-wide helper): create the blank flow over
+the API, navigate straight to `/flow/{id}`, add **Chat Output** and **Chat Input**,
+connect ChatInput source → ChatOutput target. It returns the flow id, which is
+deleted id-scoped in `afterEach`. `page.allowFlowErrors()` is set because each
+test intentionally fails a run.
+
+The helper deliberately does **not** enter through the home page → "New Flow" →
+templates modal → `blank-flow` path; that entry point is what made this file flake
+(see Notes → *Sidebar entry race*).
 
 **Network-error test (`@stable`):**
-1. Run `setupChatFlow`
+1. Run `setupPlayground`
 2. Open the playground (`playground-btn-flow-io`); wait for
    `input-chat-playground`
 3. Route `**/api/v2/workflows` to `route.abort("timedout")` (transport failure)
@@ -147,13 +151,39 @@ assertion (e.g. asserting the wrong error text) fails deterministically.
 - **Assert the persistent dropdown, not the toast.** The slide-in build-error
   toast auto-dismisses; the notification-dropdown entry persists. Asserting the
   dropdown avoids the toast-fade race (same lesson as #695).
-- **Server-error status = 503, not 500.** The fixture's global response monitor
-  (`fixtures.ts`) flags any real backend `400/404/422/500` on the shared
-  instance. The server-error test mocks a 5xx, so it uses **503** — outside that
-  monitored set — to exercise the same "Workflow run failed" path without
-  registering a false instance error. The network-error and loading-state tests
-  are inherently clean (a transport abort yields no HTTP response; a held-open
-  request stays pending), so only the server-error test needed this.
-- **Flow cleanup.** `setupChatFlow` creates a flow per test; ids are captured
-  from `POST /api/v1/flows → 201` (a bare `page.url()` races the bootstrap
-  flow's stale id — #490/#681) and deleted in `afterEach`.
+- **Server-error status = 503.** The status was originally chosen to sit outside
+  the fixture monitor's then-exact set of `400/404/422/500`. Since #1084 that
+  evasion no longer works — the policy covers every 4xx/5xx on an `/api/` route —
+  so the test declares its own mocked response via `page.allowHttpErrors()`
+  instead, which is what keeps it out of the advisory log. It stays **503**
+  because that status drives the same "Workflow run failed" path (live-confirmed
+  on 1.11.0.dev41). The network-error and loading-state tests are inherently clean
+  (a transport abort yields no HTTP response; a held-open request stays pending),
+  so only the server-error test needs the declaration.
+- **Flow cleanup.** `setupPlayground` creates exactly one flow per test and
+  returns its id, which `afterEach` deletes id-scoped. The previous local
+  `setupChatFlow` had to capture the id from a `POST /api/v1/flows → 201`
+  response because the UI path created *two* flows and a bare `page.url()` raced
+  the bootstrap flow's stale id (#490/#681); creating over the API removes both
+  the second write and the capture.
+- **Sidebar entry race (#1063) — why the UI entry path was dropped.** This file
+  was quarantined for a recurrent flake in which
+  `[data-testid="sidebar-search-input"]` was present in the DOM but never became
+  visible, timing out the setup at 30 s before the test's own subject ran. Root
+  cause, confirmed in the served 1.12.0.dev10 bundle: `FlowPage` mounts the whole
+  `FlowSidebarComponent` inside a `display: none` wrapper while the welcome
+  overlay is open (`isWelcomeOpen ? "none" : "contents"`), which is exactly the
+  empty-bounding-box condition Playwright reports as `hidden`. The old entry path
+  walked into that window: "New Flow" calls `openWelcome(flowA)` **before**
+  navigating (deliberate, so the overlay paints on the first frame), and
+  `openNewFlowTemplatesModal`'s "Browse more templates" dismissal does **not**
+  close the welcome — `handleBrowseMore` only opens the templates modal. So the
+  welcome stayed open behind the modal, and clicking `blank-flow` (which creates
+  a *second* flow, flowB) left it open until `FlowBuilderWelcomeMount` observed
+  `currentFlowId !== openedForFlowId` and closed it. That close depends on a
+  multi-hop async settle — navigate → flow load → store update → placeholder
+  delete → re-render — which nothing in the test drives, so under parallel CI
+  load it could exceed the 30 s budget and always recovered on retry. Creating
+  the flow over the API and navigating directly never calls `openWelcome`, so the
+  sidebar is never hidden and the race is gone rather than re-budgeted. The
+  condition is latent in every spec that still enters via `blank-flow`.

--- a/tests/tests-automations/regression/core-functionality/playground/output-modal-copy-button.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/output-modal-copy-button.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "../../../../fixtures/fixtures";
-import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { setupBlankFlow } from "../../../../helpers/flows/setup-blank-flow";
 import { expandFocusedNode } from "../../../../helpers/ui/expand-focused-node";
 
 test.describe("Output Modal — Copy Button", () => {
@@ -8,15 +9,20 @@ test.describe("Output Modal — Copy Button", () => {
 
   let createdFlowId: string | null = null;
 
-  test.afterEach(async ({ page }) => {
-    if (createdFlowId) {
-      // Navigate to home before deleting to stop background browser requests
-      // for the current flow; without this, pending polling GETs complete
-      // after the DELETE and trigger spurious 404 fixture errors.
-      await page.goto("/");
-      await deleteFlow(page.request, createdFlowId);
-      createdFlowId = null;
-    }
+  test.afterEach(async ({ page, request }) => {
+    if (!createdFlowId) return;
+    const id = createdFlowId;
+    createdFlowId = null;
+    // Navigate to home before deleting to stop background browser requests
+    // for the current flow; without this, pending polling GETs complete
+    // after the DELETE and trigger spurious 404 fixture errors.
+    await page.goto("/");
+    // Explicit bearer: under AUTO_LOGIN a bare request context is
+    // unauthenticated, so an unheadered DELETE 401s and silently leaks the flow.
+    const bearer = await getAuthToken(request);
+    await deleteFlow(request, id, {
+      headers: { Authorization: bearer },
+    }).catch(() => {});
   });
 
   test(
@@ -24,29 +30,34 @@ test.describe("Output Modal — Copy Button", () => {
     { tag: ["@stable", "@release", "@workspace", "@playground"] },
     async ({ page }) => {
       await test.step("create blank flow and capture flow id", async () => {
-        await awaitBootstrapTest(page);
-
-        const flowCreationPromise = page.waitForResponse(
-          (resp) =>
-            resp.url().includes("/api/v1/flows") &&
-            resp.request().method() === "POST" &&
-            resp.status() === 201,
-          { timeout: 15000 },
-        );
-
-        await page.getByTestId("blank-flow").click();
-
-        const creationResponse = await flowCreationPromise;
-        const flowData = await creationResponse.json();
-        // Capture id before asserting format so afterEach can still clean up
-        // if the regex assertion fails on an unexpected id shape.
-        createdFlowId = flowData.id ?? null;
-        expect(flowData.id, "flow creation response missing id").toMatch(
+        // setupBlankFlow creates the flow over the API and navigates to it,
+        // instead of the home page → "New Flow" → templates modal →
+        // `blank-flow` path this step used to drive. That path is what made this
+        // spec flake (#1063): "New Flow" opens the welcome overlay before
+        // navigating, and while it is open FlowPage mounts the whole
+        // FlowSidebarComponent inside a `display: none` wrapper — so the
+        // `sidebar-search-input` fill below raced an element that was in the DOM
+        // with an empty box. Creating over the API never opens the overlay.
+        createdFlowId = await setupBlankFlow(page);
+        expect(createdFlowId, "created flow id has an unexpected shape").toMatch(
           /^[0-9a-f-]{36}$/,
         );
       });
 
       await test.step("add Chat Input and fill its value", async () => {
+        // Gate on write permission having RESOLVED before adding: useAddComponent
+        // bails out SILENTLY while `useIsFlowReadOnly` is true, which it is for
+        // the whole time the effective-permissions query is in flight. The
+        // header's flow-name button is disabled by the same expression, so its
+        // enabled state is an exact observable for "the add will register".
+        // Without this the add is dropped with no error and the count assertion
+        // below fails without naming the cause.
+        await expect(page.getByTestId("menu_bar_display")).toBeEnabled({
+          timeout: 30000,
+        });
+        await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
+          timeout: 30000,
+        });
         await page.getByTestId("sidebar-search-input").fill("chat input");
         await page
           .getByTestId("input_outputChat Input")

--- a/tests/tests-automations/regression/core-functionality/playground/playground-clear-history.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/playground-clear-history.spec.ts
@@ -1,9 +1,8 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
-import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
-import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
-import { zoomOut } from "../../../../helpers/ui/zoom-out";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { setupPlayground } from "../../../../helpers/flows/setup-playground";
 
 /**
  * Session behavior confirmed from source (chat-header.tsx):
@@ -21,71 +20,20 @@ import { deleteFlow } from "../../../../helpers/flows/delete-flow";
  *   - Shows "Rename" (rename-session-option) only when session has at least 1 message
  *   - Never shows clear-chat-option
  *
- * Serial mode is required: both tests share the Langflow backend.
- * cleanAllFlows in afterEach deletes ALL flows — parallel execution causes race conditions.
+ * Serial mode is required: both tests share the Langflow backend, and the second
+ * test asserts a session COUNT in the playground sidebar, which a concurrent
+ * sibling on the same flow would perturb. Cleanup is id-scoped (never
+ * `cleanAllFlows`), so it does not delete a parallel worker's flow (#465/#515).
+ *
+ * The graph (ChatInput → ChatOutput) is built by the shared `setupPlayground`
+ * helper, which creates the flow over the API and navigates straight to
+ * `/flow/{id}`. The local `setupChatFlow` it replaces entered via the home page →
+ * "New Flow" → templates modal → `blank-flow` path, which is what made this file
+ * flake (#1063): while the welcome overlay is open, FlowPage mounts the whole
+ * FlowSidebarComponent inside a `display: none` wrapper, so
+ * `sidebar-search-input` is in the DOM with an empty box — what Playwright
+ * reports as `hidden`. Going through the API never opens that overlay.
  */
-
-async function setupChatFlow(page: Page): Promise<string> {
-  await awaitBootstrapTest(page);
-  await expect(page.getByTestId("blank-flow")).toBeVisible({ timeout: 30000 });
-
-  const flowCreationPromise = page.waitForResponse(
-    (resp) =>
-      resp.url().includes("/api/v1/flows") &&
-      resp.request().method() === "POST" &&
-      resp.status() === 201,
-    { timeout: 15000 },
-  );
-
-  await page.getByTestId("blank-flow").click();
-
-  // Add Chat Output via button
-  await page.getByTestId("sidebar-search-input").fill("chat output");
-  await expect(page.getByTestId("input_outputChat Output")).toBeVisible({
-    timeout: 30000,
-  });
-  await page
-    .getByTestId("input_outputChat Output")
-    .hover()
-    .then(async () => {
-      await page.getByTestId("add-component-button-chat-output").click();
-    });
-
-  await zoomOut(page, 2);
-
-  // Add Chat Input via drag to avoid node overlap
-  await page.getByTestId("sidebar-search-input").fill("chat input");
-  await expect(page.getByTestId("input_outputChat Input")).toBeVisible({
-    timeout: 30000,
-  });
-  await page
-    .getByTestId("input_outputChat Input")
-    .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-      targetPosition: { x: 100, y: 100 },
-    });
-
-  await adjustScreenView(page);
-
-  await expect(page.locator(".react-flow__node")).toHaveCount(2, {
-    timeout: 10000,
-  });
-
-  // Connect Chat Input → Chat Output
-  await page
-    .getByTestId("handle-chatinput-noshownode-chat message-source")
-    .click();
-  await page
-    .getByTestId("handle-chatoutput-noshownode-inputs-target")
-    .click();
-
-  await expect(page.locator(".react-flow__edge")).toHaveCount(1, {
-    timeout: 8000,
-  });
-
-  const creationResponse = await flowCreationPromise;
-  const flowData = await creationResponse.json();
-  return (flowData.id as string) ?? "";
-}
 
 async function sendMessage(page: Page, text: string): Promise<void> {
   await page.getByTestId("input-chat-playground").last().fill(text);
@@ -99,12 +47,19 @@ test.describe.configure({ mode: "serial" });
 test.describe("Playground – Clear History & Session Delete", () => {
   let createdFlowId: string | null = null;
 
-  test.afterEach(async ({ page }) => {
-    if (createdFlowId) {
-      await page.goto("/");
-      await deleteFlow(page.request, createdFlowId);
-      createdFlowId = null;
-    }
+  test.afterEach(async ({ page, request }) => {
+    if (!createdFlowId) return;
+    const id = createdFlowId;
+    createdFlowId = null;
+    // Leave the editor first: its background polling for the current flow would
+    // otherwise complete after the DELETE and log spurious 404s.
+    await page.goto("/");
+    // Explicit bearer: under AUTO_LOGIN a bare request context is
+    // unauthenticated, so an unheadered DELETE 401s and silently leaks the flow.
+    const bearer = await getAuthToken(request);
+    await deleteFlow(request, id, {
+      headers: { Authorization: bearer },
+    }).catch(() => {});
   });
 
   test(
@@ -112,7 +67,7 @@ test.describe("Playground – Clear History & Session Delete", () => {
     { tag: ["@stable", "@release", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step("Set up ChatInput → ChatOutput flow and open playground", async () => {
-        createdFlowId = await setupChatFlow(page);
+        createdFlowId = await setupPlayground(page);
         await page.getByTestId("playground-btn-flow-io").click();
         await expect(page.getByTestId("button-send")).toBeVisible({
           timeout: 15000,
@@ -156,7 +111,7 @@ test.describe("Playground – Clear History & Session Delete", () => {
     { tag: ["@stable", "@release", "@regression", "@playground"] },
     async ({ page }) => {
       await test.step("Set up ChatInput → ChatOutput flow and open playground", async () => {
-        createdFlowId = await setupChatFlow(page);
+        createdFlowId = await setupPlayground(page);
         await page.getByTestId("playground-btn-flow-io").click();
         await expect(page.getByTestId("button-send")).toBeVisible({
           timeout: 15000,

--- a/tests/tests-automations/regression/ui-ux/execution-error-notification.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/execution-error-notification.spec.ts
@@ -4,11 +4,9 @@ import {
   test,
   type PageWithErrorHooks,
 } from "../../../fixtures/fixtures";
-import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
-import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
-import { zoomOut } from "../../../helpers/ui/zoom-out";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { setupPlayground } from "../../../helpers/flows/setup-playground";
 
 // Playground execution on 1.11 runs through POST /api/v2/workflows (SSE), NOT
 // the retired /api/v1/build/{id}/flow path — the mocks below intercept that
@@ -16,82 +14,31 @@ import { deleteFlow } from "../../../helpers/flows/delete-flow";
 // "Workflow run failed" / "Failed to fetch" entry in the notifications dropdown.
 const WORKFLOWS_ENDPOINT = "**/api/v2/workflows";
 
-// Capture every flow THIS page creates from its POST /api/v1/flows → 201
-// responses and delete them id-scoped in afterEach. awaitBootstrapTest runs
-// first, so a bare page.url() capture races the bootstrap flow's stale id
-// (#490/#681); the response ids are authoritative and worker-safe.
-const createdFlowIds: string[] = [];
-
-function trackCreatedFlows(page: Page): void {
-  page.on("response", (resp) => {
-    if (
-      resp.url().includes("/api/v1/flows") &&
-      resp.request().method() === "POST" &&
-      resp.status() === 201
-    ) {
-      resp
-        .json()
-        .then((body: { id?: string }) => {
-          if (body?.id) createdFlowIds.push(body.id);
-        })
-        .catch(() => {});
-    }
-  });
-}
+// setupPlayground creates exactly ONE flow per test, over the API, and returns
+// its id — so cleanup is id-scoped without intercepting POST /api/v1/flows.
+//
+// The local setupChatFlow this replaces entered through the home page → "New
+// Flow" → templates modal → `blank-flow` path, which is what made this file
+// flake (#1063): while the welcome overlay is open, FlowPage mounts the whole
+// FlowSidebarComponent inside a `display: none` wrapper, so
+// `sidebar-search-input` sits in the DOM with an empty box — exactly what
+// Playwright reports as `hidden`. "New Flow" opens that overlay BEFORE
+// navigating and "Browse more templates" does not close it, so the setup raced a
+// multi-hop settle it did not drive. Creating the flow over the API never calls
+// `openWelcome`, so the sidebar is never hidden. Full chain in the spec doc.
+let createdFlowId: string | null = null;
 
 test.afterEach(async ({ request }) => {
-  if (createdFlowIds.length === 0) return;
+  if (!createdFlowId) return;
+  const id = createdFlowId;
+  createdFlowId = null;
+  // Explicit bearer: under AUTO_LOGIN a bare request context is unauthenticated,
+  // so an unheadered DELETE 401s and silently leaks the flow.
   const bearer = await getAuthToken(request);
-  for (const id of createdFlowIds.splice(0)) {
-    await deleteFlow(request, id, {
-      headers: { Authorization: bearer },
-    }).catch(() => {});
-  }
+  await deleteFlow(request, id, {
+    headers: { Authorization: bearer },
+  }).catch(() => {});
 });
-
-async function setupChatFlow(page: Page): Promise<void> {
-  await awaitBootstrapTest(page);
-  await page.waitForSelector('[data-testid="blank-flow"]', { timeout: 30000 });
-  await page.getByTestId("blank-flow").click();
-
-  // Add ChatOutput first (hover → click add button)
-  await page.waitForSelector('[data-testid="sidebar-search-input"]', {
-    timeout: 30000,
-  });
-  await page.getByTestId("sidebar-search-input").fill("chat output");
-  await page.waitForSelector('[data-testid="input_outputChat Output"]', {
-    timeout: 30000,
-  });
-  await page
-    .getByTestId("input_outputChat Output")
-    .hover()
-    .then(async () => {
-      await page.getByTestId("add-component-button-chat-output").click();
-    });
-
-  await zoomOut(page, 2);
-
-  // Add ChatInput via drag to a different position to avoid overlap
-  await page.getByTestId("sidebar-search-input").fill("chat input");
-  await page.waitForSelector('[data-testid="input_outputChat Input"]', {
-    timeout: 30000,
-  });
-  await page
-    .getByTestId("input_outputChat Input")
-    .dragTo(page.locator('//*[@id="react-flow-id"]'), {
-      targetPosition: { x: 100, y: 100 },
-    });
-
-  await adjustScreenView(page);
-
-  // Connect ChatInput source → ChatOutput target
-  await page
-    .getByTestId("handle-chatinput-noshownode-chat message-source")
-    .click();
-  await page
-    .getByTestId("handle-chatoutput-noshownode-inputs-target")
-    .click();
-}
 
 async function openPlayground(page: Page): Promise<void> {
   await page.getByTestId("playground-btn-flow-io").click();
@@ -112,8 +59,7 @@ test.describe("Execution Error Notifications", () => {
     async ({ page }) => {
       // The run is intercepted and aborted on purpose — allow the flow error.
       (page as any).allowFlowErrors();
-      trackCreatedFlows(page);
-      await setupChatFlow(page);
+      createdFlowId = await setupPlayground(page);
       await openPlayground(page);
 
       // Abort the execution request at the transport layer (dropped connection
@@ -138,19 +84,19 @@ test.describe("Execution Error Notifications", () => {
     },
   );
 
-  // Quarantined for #1063 — recurrent flake (2026-07-21 / 07-29): the
-  // error-feedback waitForSelector times out at 30 s.
-  test.fixme(
+  // Quarantine lifted in #1063: the 30 s timeout was in the shared setup's
+  // sidebar-entry wait, not in this test's error-feedback assertion. The setup
+  // no longer walks through the welcome overlay, so the condition is gone.
+  test(
     "executing flow with server error shows error feedback",
-    { tag: ["@release", "@workspace", "@observability"] },
+    { tag: ["@stable", "@release", "@workspace", "@observability"] },
     async ({ page }) => {
       const hooks = page as PageWithErrorHooks;
       hooks.allowFlowErrors();
       // The mocked 5xx below is this test's own fixture, not a finding — declare
       // it so it stays out of the advisory error log (#1084).
       hooks.allowHttpErrors();
-      trackCreatedFlows(page);
-      await setupChatFlow(page);
+      createdFlowId = await setupPlayground(page);
       await openPlayground(page);
 
       // Return a 5xx from the execution endpoint (server-side failure). 503 was
@@ -184,8 +130,7 @@ test.describe("Execution Error Notifications", () => {
     "flow run button shows loading state during execution",
     { tag: ["@release", "@workspace", "@observability"] },
     async ({ page }) => {
-      trackCreatedFlows(page);
-      await setupChatFlow(page);
+      createdFlowId = await setupPlayground(page);
       await openPlayground(page);
 
       // Hold the execution request open so the in-progress state is observable.


### PR DESCRIPTION
**Closes #1063.**

## Problem

Four `@stable` specs flaked with one signature: `[data-testid="sidebar-search-input"]`
present in the DOM but **never visible**, timing out the shared setup at 30 s —
before any test's own subject ran. Recurrent across the dailies of **2026-07-21**,
**2026-07-23** and **2026-07-29**; it recovered on retry every time, and appeared
only in runs of 236–410 tests in parallel. One test was quarantined at the
2026-07-29 triage (`test.fixme` + `@stable` removed, PR #1064).

**Root cause** — confirmed in the **served `1.12.0.dev10` bundle**, not just the
source clone. `FlowPage` mounts the whole `FlowSidebarComponent` inside a
`display: none` wrapper while the welcome overlay is open:

```jsx
{!view && (
  <div style={{ display: isWelcomeOpen ? "none" : "contents" }}>
    <FlowSidebarComponent isLoading={isLoading} />
  </div>
)}
```

`display: none` on an ancestor gives the input an **empty bounding box**, which is
exactly what Playwright reports as `hidden`. The old entry path walked into that
window:

1. "New Flow" (`useStartNewFlow`) creates **flow A** and calls `openWelcome(A)`
   **before** navigating — deliberate, so the overlay paints on the first frame.
2. `openNewFlowTemplatesModal` dismisses the overlay via "Browse more templates",
   but `handleBrowseMore` only calls `setIsTemplatesOpen(true)` — it never calls
   `close()`. The welcome stays open **behind** the modal.
3. Clicking `blank-flow` creates a **second** flow B and navigates to it.
4. The welcome closes only once `FlowBuilderWelcomeMount` observes
   `currentFlowId !== openedForFlowId` — a multi-hop async settle (navigate → flow
   load → store update → placeholder delete → re-render) that **nothing in the
   test drives**.

That is why it was load-dependent and always recovered on retry.

**Verdict: test defect (wait-strategy), not a Langflow regression.** The product
behaviour is intentional and documented in its own code comments. The specs waited
on a *downstream side effect* (the input becoming visible) of a precondition (the
welcome being closed) that the test never drove.

The quarantine note blaming the error-feedback selector was wrong — the timeout was
in the setup, as the corrected issue body records.

## Fix

Enter the blank flow through the **existing, already-validated** API-based helpers,
so `openWelcome` is never called and the sidebar is never hidden:

- `setupPlayground` — `execution-error-notification`, `playground-clear-history`
  (both need the ChatInput → ChatOutput graph).
- `setupBlankFlow` — `output-modal-copy-button` (needs a single Chat Input node).

Neither is new: adoption before this PR was 20 specs each, 19 of them `@stable`.
`setupPlayground`'s own docstring already recorded that going through the API
"removes the navigation race altogether".

This removes the cause rather than re-budgeting the symptom, drops the throwaway
second flow write, and brings stronger gates (flow hydration, write-permission
resolved, graph persisted after every mutation).

**Quarantine lifted:** `test.fixme` → `test` and `@stable` restored on
*executing flow with server error shows error feedback*.

**Rejected alternatives:**

- *Raise the timeout / wait on the welcome panel being hidden instead.* Same
  multi-hop settle, just a bigger budget — the 30 s expiry means the settle
  genuinely did not complete, so this only makes the flake rarer.
- *Actively dismiss the welcome (Esc / backdrop).* `handleDismiss` calls
  `setSidebarOpen(false)`, so it lands on a **collapsed** sidebar — trading a
  hidden input for an off-canvas one.
- *Fix `openNewFlowTemplatesModal` to close the welcome.* It is shared by many
  specs; changing it inside a `daily-failure` PR would be a refactor in disguise.

## Scope note

**No assertion changed.** Every test keeps its original subject and observables —
only how the flow is created and reached. Test titles and tags are unchanged except
the restored `@stable`. The *loading-state* test stays `@release`-only; the spec doc
already justifies that.

Two defects found while in these files and fixed:

- `deleteFlow(page.request, id)` was called **without an `Authorization` header** in
  two specs. Under AUTO_LOGIN a bare request context is unauthenticated, so that
  DELETE 401'd and silently leaked a flow per test. Now passes an explicit bearer
  from `getAuthToken`.
- `playground-clear-history`'s header comment justified `serial` mode with
  `cleanAllFlows` deleting all flows — the file has not done that for some time
  (cleanup is id-scoped). It was teaching exactly the hazard #465/#515 warns about.
  Corrected to the real reason (the second test asserts a session count).

`output-modal-copy-button` also gains a write-permission gate
(`menu_bar_display` enabled) before adding its component: `useAddComponent` bails
out **silently** while `useIsFlowReadOnly` is true, so an add landed in that window
registers nothing and the count assertion fails without naming the cause.

**Descoped, not silent:** `api-request-component-regression.spec.ts` — the fourth
spec in #1063's list — is tracked in **#1147**. It has 15 tests (15 force-fails) and
depends on the echo endpoint, so it needs the self-hosted `go-httpbin` lane to be
validated honestly. #1147 also records the wider latent exposure: 51 specs still
enter via `blank-flow` and touch `sidebar-search-input`, 31 of them `@stable`.

## Validation (nightly 1.12.0.dev10, `--retries=0`)

- typecheck ✅ · eslint 0 errors ✅ · `check:checklist-coverage` ✅ ·
  QA-CHECKLIST guard ✅ · `regressions:check` ✅
- `test:units` 215 pass / 0 fail ✅ · `test:scripts` 169 pass / 0 fail ✅
- **4 clean runs, no flake** ✅ — 3 × `--workers=1` (6 passed, 57–60 s each) plus a
  final run after reverting every force-fail mutation
- **Under parallel load** ✅ — the isolated run does not clear a load-dependent
  condition, so a 47-test slice (`core-functionality/playground/` +
  `ui-ux/execution-error-notification`) ran at `--workers=4`: **47 passed (2.3 m)**,
  0 failed, 0 flaky, all 6 of these tests among them
- **force-fail: 6/6 executed and confirmed** ✅ — one mutation per `test()` in every
  touched file, each run isolated with `--grep` so a serial file's first failure
  could not mask its siblings. Reverted and proven: 0 mutation markers in the diff
  plus the final green run.
  - The first attempt at the *clear chat* mutation (`toHaveCount(0)` → `(1)`)
    **passed** — the count transits 2 → 1 → 0, so the mutant matched a transient
    state. Replaced with a behavioural mutation (skip the `clear-chat-option`
    click), which fails on `toHaveCount(0)` as required.
- zero `🚨 Backend Error` ✅ across every run
- **no leaked flows** ✅ — `GET /api/v1/flows/` shows 0 residue under both helper
  naming schemes (`e2e-blank-*`, `E2E Playground *`); the 33 flows present are
  Langflow's own examples
- `--trace=on` ❌ **not run** — the known local hang (>3× normal duration, #490/#518).
  Step verification rests on the `--retries=0` bursts, the executed force-fails and
  the parallel-load run instead; CI's trace-on-first-retry still covers these specs.
