### PR TITLE
fix(core-components): enter the blank flow over the API, not the welcome overlay (#1147)

### DIFF
--- a/docs/core-components/api-request-component-regression.md
+++ b/docs/core-components/api-request-component-regression.md
@@ -1,6 +1,6 @@
 # API Request Component — Rendering, Inspector, HTTP Methods, cURL Mode and Error Paths
 
-**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev9`; the cURL test re-validated on `1.11.1` as well, which already carries langflow#14312)
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev10`; the cURL test re-validated on `1.11.1` as well, which already carries langflow#14312)
 
 ---
 
@@ -29,12 +29,13 @@ The **GET request returns 200** test (#4 below) had `@stable` removed in the #46
 
 ## Step by step *(required)*
 
-Every test starts with `addApiRequestComponent(page)` which:
-1. Bootstraps the app (`awaitBootstrapTest`)
-2. Clicks `blank-flow` and waits for the API Request sidebar item to be attached
-3. Hovers the sidebar card (the add button reveals on hover) and clicks `add-component-button-api-request`
-4. Calls `adjustScreenView(page)` to fit the canvas
-5. Asserts `title-API Request` is visible
+Every test starts with `addApiRequestComponent(page)`, which returns the created flow's id and:
+1. Creates the blank flow **over the REST API** and navigates to it (`setupBlankFlow`) — it never enters through home page → "New Flow" → templates modal → `blank-flow`, so the welcome overlay is never opened (issue #1147; see "Notes")
+2. Waits for write permission to have resolved (`menu_bar_display` enabled) — `useAddComponent` bails out silently while the flow is still read-only
+3. Waits for `sidebar-search-input` to be **visible** and fills it with `API Request`, then waits for the sidebar item to be attached
+4. Hovers the sidebar card (the add button reveals on hover) and clicks `add-component-button-api-request`
+5. Calls `adjustScreenView(page)` to fit the canvas
+6. Asserts `title-API Request` is visible
 
 ### 1. `renders on canvas with correct output and URL handles`
 - Asserts `title-API Request`, the right-side `handle-apirequest-shownode-api response-right`, and the left-side `handle-apirequest-shownode-url-left` are all visible.
@@ -85,7 +86,7 @@ For each of GET, POST, PUT, PATCH, DELETE:
 - Closes the dialog with `btn-cancel-modal` — this test asserts in-session edit behavior only. End-to-end body persistence through reload is intentionally NOT covered (see "What this test does not cover").
 
 ### 15. `flow state persists in database after autosave (URL, method, headers)`
-- Configures URL (`https://postman-echo.com/get?persist=true`), method (`POST`) and a headers row (`X-Persist-Header` / `persisted-value`) on a freshly created flow; captures the `flowId` from the URL.
+- Configures URL (`https://postman-echo.com/get?persist=true`), method (`POST`) and a headers row (`X-Persist-Header` / `persisted-value`) on a freshly created flow; the `flowId` is the one `setupBlankFlow` returned (it created the flow), and the test asserts the editor URL carries that same id before polling it.
 - Like test 14, waits for the `POST /api/v1/custom_component/update` response after the method switch so the headers `[value]` useEffect settles before adding a new row.
 - Clicks the dialog-level **Save** button (not Cancel, which discards `tempValue` via `handleCancel` in `TableNodeComponent`) so the row commits before autosave fires.
 - Polls `GET /api/v1/flows/{id}` (using `page.request` which inherits the session cookie) until the autosave has written the URL, method and matching header row into the saved flow JSON. Polling the API directly proves the autosave reached the database — not just in-memory React state. The match key is `node.data.type === "APIRequest"` (Python class name, not the `"API Request"` display name).
@@ -101,6 +102,9 @@ The suite must:
 - Read execution output via the dialog's copy button + clipboard, not the Monaco editor's `textContent`: the editor is virtualized, so `textContent` only returns lines in the viewport and silently truncates fields below the fold for a verbose response. The helper clears the clipboard first (it persists across the serial tests) and polls until the fresh output lands rather than waiting on the transient "Copied to clipboard" toast.
 - Retry past transient upstream outages: `runAndOpenOutput` re-runs the component (up to 3 attempts) when its own top-level `status_code` is `5xx` or when a run produces no readable output (build error / timeout). Each attempt anchors build completion on the node's own success indicator — the `node_duration_api request` badge going hidden (a fresh build started, so `conditionSuccess` is momentarily false) then visible again (build finished successfully) — not on the inspect button (which stays enabled across re-runs and would re-read stale output) and not on any build endpoint URL. This is deliberately decoupled from the internal build endpoint, which moved from `/api/v1/build/{id}/events` to `/api/v1/flows/{id}/events` in 1.11.x and silently broke the previous `waitForResponse` anchor even though the build itself still succeeded (issue #478). No test here expects a 5xx, so retrying on one never masks a real assertion; once retries are exhausted on a still-5xx output it **throws loudly** rather than returning the 5xx, so a sustained outage or a regression surfacing as a 5xx fails clearly instead of slipping past a weak substring assertion (issue #383).
 - Run **serially** (`test.describe.configure({ mode: "serial" })`) — parallel autosaves on flow create cause `400 "flow must be unique"` errors that flag as backend errors in the fixture.
+- Enter the blank flow through **`setupBlankFlow`** (API create + navigate), never through home page → "New Flow" → templates modal → `blank-flow`. That UI path leaves the welcome overlay open behind the modal, and `FlowPage` mounts the whole `FlowSidebarComponent` inside a `display: none` wrapper while it is open — so `sidebar-search-input` is in the DOM with an empty bounding box and the fill races a `hidden` element (issue #1147, root-caused on #1063).
+- Gate the component add on write permission having **resolved** (`menu_bar_display` enabled) before touching the sidebar: `useAddComponent` returns early and **silently** while `useIsFlowReadOnly` is true, which it is for as long as the effective-permissions query is in flight. Without the gate an add that lands in that window registers nothing and the `react-flow__node` count assertion fails without naming the cause.
+- Delete the flow in `afterEach` with an **explicit `Authorization` bearer** (`getAuthToken`): under `AUTO_LOGIN` a bare `request` context is unauthenticated, so an unheadered `DELETE` returns `401` and silently leaks the flow.
 - For each verb test, hit an endpoint that returns a non-2xx for any other verb (postman-echo returns `404`; httpbin returned `405`) — this guarantees the test fails if the wrong verb is sent (e.g. POST sent as GET), because the assertion requires `200`.
 - For the cURL execution test, switch to the cURL tab *before* configuring the URL — and assert the parser auto-populates `url_input`. Asserting only the run output would let the test pass even if cURL parsing was broken.
 - For the headers and body table tests, fill both KEY and VALUE cells (not key only) — filling only the key cell would still pass even if the value column was non-functional or rejected entries.
@@ -115,7 +119,8 @@ The suite must:
 
 ## External dependencies *(required)*
 
-- `tests/helpers/other/await-bootstrap-test.ts` — bootstraps the app
+- `tests/helpers/flows/setup-blank-flow.ts` — creates the blank flow over the REST API and navigates to it, returning its id (replaces the `awaitBootstrapTest` + `blank-flow` entry, issue #1147)
+- `tests/helpers/auth/get-auth-token.ts` + `tests/helpers/flows/delete-flow.ts` — id-scoped `afterEach` cleanup with an explicit bearer
 - `tests/helpers/ui/adjust-screen-view.ts` — fits the canvas after adding the component
 - `tests/fixtures/fixtures.ts` — provides `(page as any).allowFlowErrors()` (the cast is required because the helper is injected via the fixture without a typed augmentation; see "Notes")
 - `src/lfx/src/lfx/components/data_source/api_request.py` — owns the field schema (URL, method, headers/body table inputs, cURL textarea); the test would need updating if a field is renamed, removed, or its `advanced` flag changes
@@ -162,6 +167,40 @@ The suite must:
 
 ## Notes *(optional)*
 
+- **Sidebar entry moved off the welcome overlay (issue #1147, root-caused on #1063).**
+  The setup used to enter the canvas through home page → "New Flow" → templates
+  modal → `blank-flow`, then fill `sidebar-search-input` with **no wait at all**
+  (relying on `fill`'s auto-wait). That window is not safe:
+  - "New Flow" (`useStartNewFlow`) creates a flow **and calls `openWelcome()` before
+    navigating**, deliberately, so the overlay paints on the first frame.
+  - `openNewFlowTemplatesModal` dismisses the overlay visually via "Browse more
+    templates", but `handleBrowseMore` only calls `setIsTemplatesOpen(true)` — it
+    never calls `close()`. The welcome stays **open behind the modal**.
+  - Clicking `blank-flow` then creates a **second** flow and navigates to it; the
+    welcome only closes once `FlowBuilderWelcomeMount` observes
+    `currentFlowId !== openedForFlowId` — a multi-hop settle (navigate → flow load →
+    store update → placeholder delete → re-render) that **nothing in the test drives**.
+  - While it is open, `FlowPage` mounts the whole `FlowSidebarComponent` inside a
+    `<div style={{ display: isWelcomeOpen ? "none" : "contents" }}>`, so
+    `sidebar-search-input` is in the DOM with an **empty bounding box** — exactly what
+    Playwright reports as `hidden`. Confirmed in the served `1.12.0.dev10` bundle, so
+    it is not a clone/skew artifact.
+
+  Under parallel CI load that settle can exceed the wait budget and the fill fails;
+  it always recovers on retry, which is why it reads as a flake. It is a **test
+  wait-strategy defect, not a Langflow regression** — the product behaviour is
+  intentional and documented in its own code comments. `setupBlankFlow` sidesteps it
+  entirely: the flow is created over the API and opened from the dashboard, so the
+  welcome overlay is never opened and the sidebar is never hidden. The helper also
+  returns the flow id, which replaced this spec's `POST /api/v1/flows` response
+  interception (the id is now known before the page is even touched) and the URL-regex
+  capture in test 15.
+
+  The same migration carried over two corrections from #1063: the add is gated on
+  `menu_bar_display` being enabled (silent `useAddComponent` bail-out while the flow
+  is read-only), and the `afterEach` `DELETE` now passes an explicit bearer (it
+  `401`ed unheadered under `AUTO_LOGIN` and leaked the flow — this file's cleanup had
+  the same defect).
 - **dev46 inspector migration (issue #818).** The nightly removed the always-on
   inspect-panel toggle (`canvas_controls_dropdown_toggle_inspector`) and made the
   `headers` / `body` table fields **advanced** — their `div-table_<field>` widget

--- a/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/api-request-component-regression.spec.ts
@@ -1,40 +1,29 @@
 import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
-import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import {
   closeAdvancedOptions,
   openAdvancedOptions,
 } from "../../../helpers/ui/open-advanced-options";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
 
 // Run tests serially to avoid "flow must be unique" 400 errors from parallel autosaves
 test.describe.configure({ mode: "serial" });
 
-// Capture every flow each test's page creates from its POST /api/v1/flows → 201
-// responses and delete them id-scoped in afterEach (repo convention, #490/#681).
+// Every flow this file creates comes from `setupBlankFlow` inside
+// `addApiRequestComponent`, which pushes the id here; afterEach deletes them
+// id-scoped (repo convention, #490/#681). This replaced a `page.on("response")`
+// interception of POST /api/v1/flows → 201: the flow is now created through
+// `page.request`, which does not emit page-level response events, so the
+// interception would have collected nothing and leaked every flow (#1147).
 const createdFlowIds: string[] = [];
-
-test.beforeEach(({ page }) => {
-  page.on("response", (resp) => {
-    if (
-      resp.url().includes("/api/v1/flows") &&
-      resp.request().method() === "POST" &&
-      resp.status() === 201
-    ) {
-      resp
-        .json()
-        .then((body: { id?: string }) => {
-          if (body?.id) createdFlowIds.push(body.id);
-        })
-        .catch(() => {});
-    }
-  });
-});
 
 test.afterEach(async ({ request }) => {
   if (createdFlowIds.length === 0) return;
+  // Explicit bearer: under AUTO_LOGIN a bare request context is
+  // unauthenticated, so an unheadered DELETE 401s and silently leaks the flow.
   const bearer = await getAuthToken(request);
   for (const id of createdFlowIds.splice(0)) {
     await deleteFlow(request, id, {
@@ -93,10 +82,34 @@ async function addTableFieldToBody(page: Page, field: "headers" | "body") {
 }
 
 // Helper: create a blank flow and add the API Request component to the canvas.
-// After this call the component node is visible on the canvas.
-async function addApiRequestComponent(page: Page) {
-  await awaitBootstrapTest(page);
-  await page.getByTestId("blank-flow").click();
+// After this call the component node is visible on the canvas. Returns the
+// created flow's id (the caller needs it in the persistence test).
+//
+// The flow is created over the REST API and opened from the dashboard
+// (`setupBlankFlow`) instead of through home page → "New Flow" → templates modal
+// → `blank-flow`. That UI path leaves the welcome overlay OPEN behind the modal
+// ("Browse more templates" only sets `isTemplatesOpen`, it never calls
+// `close()`), and while it is open FlowPage mounts the whole
+// FlowSidebarComponent inside a `display: none` wrapper — so the
+// `sidebar-search-input` fill below raced an element that was in the DOM with an
+// empty bounding box, which Playwright reports as `hidden` (#1147, root-caused
+// on #1063). Creating over the API never opens the overlay.
+async function addApiRequestComponent(page: Page): Promise<string> {
+  const flowId = await setupBlankFlow(page);
+  createdFlowIds.push(flowId);
+  // Gate on write permission having RESOLVED before adding: useAddComponent
+  // bails out SILENTLY while `useIsFlowReadOnly` is true, which it is for the
+  // whole time the effective-permissions query is in flight. The header's
+  // flow-name button is disabled by the same expression, so its enabled state is
+  // an exact observable for "the add will register". Without this the add is
+  // dropped with no error and the node-count assertions fail without naming the
+  // cause.
+  await expect(page.getByTestId("menu_bar_display")).toBeEnabled({
+    timeout: 30000,
+  });
+  await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
+    timeout: 30000,
+  });
   await page.getByTestId("sidebar-search-input").fill("API Request");
   await expect(
     page.getByTestId("add-component-button-api-request"),
@@ -113,6 +126,7 @@ async function addApiRequestComponent(page: Page) {
   await expect(page.getByTestId("title-API Request")).toBeVisible({
     timeout: 15000,
   });
+  return flowId;
 }
 
 // The output Data object the component returns is JSON. A transient upstream
@@ -816,16 +830,17 @@ test("API Request component — flow state persists in database after autosave (
     let flowId = "";
 
     await test.step("Configure URL, method and a header on a new flow", async () => {
-      await addApiRequestComponent(page);
-      // Match against the pathname rather than `split("/").slice(-1)` so a
-      // trailing slash / query string / hash on the route doesn't silently
-      // turn `flowId` into a non-UUID and make the persistence test fail for
-      // a routing change unrelated to the behavior under test.
-      const flowIdMatch = new URL(page.url()).pathname.match(
-        /\/flow\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/,
+      // `setupBlankFlow` created the flow, so its id is known up front — no need
+      // to parse it back out of the route (which is what this step used to do
+      // when the flow came from the `blank-flow` UI path, #1147). Assert the
+      // editor really is on that flow: everything below is configured through
+      // this page and then polled by id, so a mismatch would silently poll a
+      // flow nobody edited.
+      flowId = await addApiRequestComponent(page);
+      expect(flowId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
       );
-      expect(flowIdMatch).not.toBeNull();
-      flowId = flowIdMatch![1];
+      expect(new URL(page.url()).pathname).toContain(`/flow/${flowId}`);
 
       const urlInput = page.getByTestId("popover-anchor-input-url_input");
       await expect(urlInput).toBeVisible({ timeout: 10000 });


### PR DESCRIPTION
**Closes #1147.**

## Problem

The 15-test API Request spec entered the canvas through home page → "New Flow" →
templates modal → `blank-flow`, then filled `sidebar-search-input` with **no wait at
all** (relying on `fill`'s auto-wait). That window is not safe, and the condition was
root-caused on #1063:

1. "New Flow" (`useStartNewFlow`) creates a flow and calls `openWelcome()` **before**
   navigating — deliberate, so the overlay paints on the first frame.
2. `openNewFlowTemplatesModal` dismisses the overlay visually via "Browse more
   templates", but `handleBrowseMore` only calls `setIsTemplatesOpen(true)` — it never
   calls `close()`. The welcome stays **open behind the modal**.
3. Clicking `blank-flow` creates a **second** flow and navigates to it; the welcome
   closes only once `FlowBuilderWelcomeMount` observes
   `currentFlowId !== openedForFlowId` — a multi-hop settle (navigate → flow load →
   store update → placeholder delete → re-render) that **nothing in the test drives**.
4. While it is open, `FlowPage` mounts the whole `FlowSidebarComponent` inside a
   `<div style={{ display: isWelcomeOpen ? "none" : "contents" }}>`, so
   `sidebar-search-input` is in the DOM with an **empty bounding box** — exactly what
   Playwright reports as `hidden`. Confirmed in the served `1.12.0.dev10` bundle, so
   it is not a clone/skew artifact.

Under parallel CI load that settle can exceed the wait budget; it always recovers on
retry, which is why it reads as a flake. This is a **test wait-strategy defect, not a
Langflow regression** — the product behaviour is intentional and documented in its own
code comments. #1063 fixed the three specs it could validate; this spec was the fourth
observed with the signature and was split out because of its 15-test force-fail scope
and its echo-endpoint dependency.

## Fix

- `addApiRequestComponent` now enters through **`setupBlankFlow`** (API create +
  navigate from the dashboard), so the welcome overlay is never opened and the sidebar
  is never hidden. `sidebar-search-input` additionally gets an explicit
  `toBeVisible()` before the fill.
- The helper returns the flow id, which replaces the URL-regex capture in the
  persistence test — that test now **asserts** the editor is on the flow it polls
  instead of parsing the id back out of the route.
- **Write-permission gate before the add** (`menu_bar_display` enabled), carried over
  from #1063: `useAddComponent` bails out **silently** while `useIsFlowReadOnly` is
  true, which it is for as long as the effective-permissions query is in flight. An
  add that lands in that window registers nothing and the node-count assertion fails
  without naming the cause.
- **Cleanup fixed, not just moved.** The old `afterEach` collected ids from a
  `page.on("response")` interception of `POST /api/v1/flows` → 201. The flow is now
  created through `page.request`, which emits no page-level response events — that
  tracker would have collected nothing and leaked all 15 flows. The id from
  `setupBlankFlow` is pushed directly. (The explicit `Authorization` bearer this file
  already had is kept and now documented.)

Rejected alternative: `setupPlayground`. It builds a ChatInput → ChatOutput graph this
spec does not need — the tests assert `react-flow__node` count === 1.

## Scope note

**No assertion in any of the 15 tests changed**, and no test was added or removed. The
diff touches the entry path, the add gate, the flow-id capture and the cleanup
mechanism only. The echo-endpoint contract, the `runAndOpenOutput` retry, the serial
mode and the tags are all untouched.

The wider latent exposure recorded on #1147 (51 specs still enter via `blank-flow` and
then touch `sidebar-search-input`, 31 of them `@stable`) is deliberately **out of
scope** — per the issue, a pre-emptive migration is a worse bet than fixing each in
minutes when the daily flags it.

## Validation (nightly `1.12.0.dev10`, `--workers=1 --retries=0`)

Run against a **self-hosted `ghcr.io/mccutchen/go-httpbin:2.23.1`** on the container
network (`ECHO_BASE_URL=http://<container-ip>:8080`, RFC-1918 CIDRs in
`LANGFLOW_SSRF_ALLOWED_HOSTS`) — never `httpbin.org`, per the issue's requirement and
the #1128/#1133 lesson.

- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors) · `npm run test:scripts` ✅ ·
  `npm run test:units` ✅ (215 pass)
- QA-CHECKLIST guard ✅ · `npm run check:checklist-coverage` ✅ (bullets already
  present — a fix, so no checklist edit)
- **3 clean runs: 15 passed** (1.1m / 1.1m / 1.2m), no flake ✅
- `--trace=on`: **15 passed** (1.2m), 15 `trace.zip` captured ✅ — this spec family
  does **not** hit the documented local trace hang. The traces confirm the new entry:
  `list-card-open-button` + `menu_bar_display`, no `blank-flow` click anywhere.
- **Force-fail: 15/15 executed**, one mutation per `test()`, each run isolated with
  `--grep` (the file is serial, so a shared run would mask siblings). Every mutation
  failed at its intended assertion; revert proven with `grep FFMUT` = 0 plus a final
  clean run:

  | # | Mutation | Failed at |
  |---|---|---|
  | 1 | node count `1` → `2` | `toHaveCount` |
  | 2 | dropdown picks `PUT` | `toHaveText("POST")` |
  | 3 | valid URL instead of `not-a-url` | error notification *element(s) not found* |
  | 4 | GET against `/post` | `toContain("200")` |
  | 5 | POST against `/put` | `toContain("200")` |
  | 6 | PUT against `/post` | `toContain("200")` |
  | 7 | PATCH against `/post` | `toContain("200")` |
  | 8 | DELETE against `/post` | `toContain("200")` |
  | 9 | `/status/418` | `toContain("404")` |
  | 10 | `zzz_param` | `toContain("e2e_param")` |
  | 11 | value cell at `col-id="valuex"` | *Cell not found or not rendered* |
  | 12 | fills a different cURL command | `toHaveValue` |
  | 13 | cURL parses `/post` | `toHaveValue(${ECHO_BASE}/get)` |
  | 14 | value cell at `col-id="valuex"` | *Cell not found or not rendered* |
  | 15 | writes `expectedUrl&mutated=1` | poll `.toBe("persisted")` |

- Zero `🚨 Backend Error` ✅
- No leaked flows: `GET /api/v1/flows/` returned **0 flows** after every run ✅
