### PR TITLE
test(mcp): restore @stable on the v2 status-code guards — upstream fixed the 500s (#991)

### DIFF
--- a/docs/mcp/client/mcp-server-registration-status-codes.md
+++ b/docs/mcp/client/mcp-server-registration-status-codes.md
@@ -1,6 +1,6 @@
 # MCP v2 Server Registration — HTTP Status Codes
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x
 
 ---
 
@@ -13,22 +13,22 @@ server-registration endpoints (`/api/v2/mcp/servers/{name}`). It asserts the
 - `POST` an already-registered server name → **409 Conflict**
 - `DELETE` a non-existent server → **404 Not Found**
 
-> **This test is a known-defect watchdog (issue #396) and is EXPECTED TO FAIL
-> against current Langflow builds.** `api/v2/mcp.py` currently returns **500**
-> for both conditions ("Server already exists." / "Server not found."). The
-> intentional failure is the formal record — captured in `reports/daily-history.jsonl`,
-> the QA Platform, and the `[Daily Failure]` issue — that the suite detected the
-> defect. On the first daily failure the workflow auto-removes `@stable` from
-> these tests (so they stop running); once upstream returns the correct codes,
-> restore `@stable` and they become forward regression guards. A reviewer should
-> **not** treat the red as a mistake — see the **Tags** section.
+> **These were known-defect watchdogs (#396, #633, #991) and are not any more.**
+> From 1.5.0 until 2026-07-27 `api/v2/mcp.py` returned **500** for both conditions
+> ("Server already exists." / "Server not found."), so both tests failed by design
+> and `@stable` was auto-removed on 2026-07-10. Upstream fixed it in
+> langflow-ai/langflow#14005 (merged 2026-07-27) — verified on Nightly
+> **1.12.0.dev10**, source-confirmed in the image. `@stable` is restored and the
+> tests are now **forward regression guards**: a failure here is a regression of
+> that upstream fix, not the historical red.
 
 Why 409/404 are the correct codes is not just REST theory — it is Langflow's own
 convention: 409 for uniqueness conflicts (`flows_helpers.py` "Name must be
 unique", `authz_*`, `deployments`, and the sibling project-scoped MCP endpoint
 `api/v1/projects_mcp_helpers.py` which already returns 409 for a duplicate server
-name), and 404 for missing resources (145+ call sites). The 500s in
-`api/v2/mcp.py` are the anomaly.
+name), and 404 for missing resources (145+ call sites). The 500s
+`api/v2/mcp.py` used to return were the anomaly; it now matches the convention its
+own sibling endpoint already followed.
 
 ---
 
@@ -36,12 +36,15 @@ name), and 404 for missing resources (145+ call sites). The 500s in
 
 Both tests: `@mcp` `@regression` `@api` `@stable`.
 
-`@stable` is intentional: these tests must run in the daily workflow so the
-defect is formally recorded and the eventual upstream fix is detected. Because
-the tests fail by design against the buggy nightly, the daily's
-`auto-remove-stable` step will strip `@stable` on the first run — that is the
-intended lifecycle, not a regression. Restore `@stable` once Langflow returns
-409/404 (tracked in #396).
+`@stable` is restored as of #991, after the upstream fix landed. Promotion
+evidence: 10/10 clean executions (5 bursts x 2 tests, `--workers=1 --retries=0`)
+against Nightly 1.12.0.dev10, plus a force-fail of all four assertions (both
+status codes and both `detail` matchers) — each mutation failed exactly one test.
+
+Historical note, so a reader does not mistake the record for a defect: between
+2026-07-10 and #991 these tests carried no `@stable` and ran in no lane. That is
+also why nobody noticed the upstream fix for three days — a watchdog outside the
+daily watches nothing.
 
 ---
 
@@ -52,14 +55,14 @@ intended lifecycle, not a regression. Restore `@stable` once Langflow returns
 1. Get an auth token (`GET /api/v1/auto_login`)
 2. Pre-clean: `DELETE /api/v2/mcp/servers/{name}` (remove any leftover)
 3. `POST /api/v2/mcp/servers/{name}` with `{ "url": "http://localhost:1/mcp" }` → expect **200**
-4. `POST` the same name again → expect **409 Conflict** *(currently 500 — fails by design)*
+4. `POST` the same name again → expect **409 Conflict**
 5. Cleanup: `DELETE` the server
 
 **Test 2 — delete missing → 404**
 
 1. Get an auth token
 2. Guard: `DELETE` the (unique, never-registered) name to ensure absence
-3. `DELETE /api/v2/mcp/servers/{name}` → expect **404 Not Found** *(currently 500 — fails by design)*
+3. `DELETE /api/v2/mcp/servers/{name}` → expect **404 Not Found**
 
 ---
 

--- a/tests/tests-automations/regression/mcp/client/mcp-server-registration-status-codes.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-server-registration-status-codes.spec.ts
@@ -11,15 +11,22 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 //   • POST an already-registered name  → 409 Conflict  (duplicate resource)
 //   • DELETE a non-existent server      → 404 Not Found
 //
-// KNOWN-DEFECT WATCHDOG (issue #396): on current Langflow builds these endpoints
-// return **500** for both conditions (`api/v2/mcp.py` — "Server already exists."
-// / "Server not found."), so these tests are EXPECTED TO FAIL against the
-// nightly until the defect is fixed upstream. That failure is intentional and is
-// the formal, dated record (reports/daily-history.jsonl + QA Platform + daily-failure
-// issue) that the suite detected the bug. On the first daily failure the daily
-// workflow auto-removes `@stable` from these tests; once upstream returns the
-// correct codes, restore `@stable` and the tests become forward regression
-// guards.
+// HISTORY — these were expected-red watchdogs, and they are not any more (#991).
+// From 1.5.0 (upstream PR langflow-ai/langflow#8388) until 2026-07-27,
+// `api/v2/mcp.py` answered **500** for both conditions ("Server already exists."
+// / "Server not found."), so both tests failed by design against the nightly and
+// `@stable` was auto-removed on 2026-07-10 (daily #29087610824). That red was the
+// formal, dated record that the suite detected the defect — see #396, #633, #991.
+//
+// Upstream fixed it in langflow-ai/langflow#14005 (merged 2026-07-27, a
+// concurrency fix that also corrected these two status codes). Verified on
+// Langflow Nightly **1.12.0.dev10**: 409 and 404 are returned, source-confirmed
+// in the image (`api/v2/mcp.py` raises 404 at the delete path and 409 at the
+// duplicate path), 10/10 clean test executions, every assertion force-failed.
+//
+// So the direction of these tests has INVERTED: they no longer document a bug we
+// are waiting on, they protect a contract that is now correct. A failure here is a
+// REGRESSION — read it as new, not as the known-defect red it used to be.
 //
 // Why 409/404 are the correct codes (not just REST theory): Langflow itself uses
 //   • 409 for uniqueness conflicts — `flows_helpers.py` ("Name must be unique"),
@@ -28,7 +35,8 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 //     duplicate server name;
 //   • 404 for missing resources — 145+ call sites across the API. (Langflow
 //     resolves a missing DELETE to 404, not an idempotent 204/200.)
-// The 500s in `api/v2/mcp.py` are the anomaly.
+// The 500s `api/v2/mcp.py` used to return were the anomaly; it now matches the
+// convention its own sibling endpoint already followed.
 //
 // Each assertion checks BOTH the status code AND the response `detail`: a status
 // alone can pass for the wrong reason — e.g. a renamed/removed route makes the
@@ -37,8 +45,12 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 // pass to the intended code path.
 //
 // Pure `page.request` (APIRequestContext) is used deliberately: it runs outside
-// the browser page, so the intentional 5xx does NOT trip the fixture's
-// `page.on("response")` backend-error monitor — no `allowFlowErrors()` needed.
+// the browser page, so the deliberate error statuses do NOT reach the fixture's
+// `page.on("response")` backend-error monitor — no `allowHttpErrors()` needed.
+// This matters more since #1084 widened that monitor from four exact codes to
+// every 4xx/5xx on an `/api/` route: the 409 and 404 these tests provoke on
+// purpose are now monitored statuses, and `page.request` traffic is what keeps
+// them out of the advisory log.
 
 // Unique, collision-proof names. Worker index + timestamp disambiguate parallel
 // workers; the random UUID also rules out two independent invocations sharing the
@@ -69,7 +81,7 @@ async function readDetail(resp: {
 test.describe("MCP v2 server registration — HTTP status codes", () => {
   test(
     "registering an already-existing MCP server returns 409 Conflict",
-    { tag: ["@mcp", "@regression", "@api"] },
+    { tag: ["@mcp", "@regression", "@api", "@stable"] },
     async ({ page }) => {
       const authHeader = await getAuthToken(page.request);
       expect(
@@ -112,8 +124,9 @@ test.describe("MCP v2 server registration — HTTP status codes", () => {
           });
           expect(
             second.status(),
-            "Duplicate MCP server registration must return 409 Conflict " +
-              "(Langflow currently returns 500 — issue #396)",
+            "Duplicate MCP server registration must return 409 Conflict. " +
+              "A 500 here is a REGRESSION of langflow-ai/langflow#14005 (see #991), " +
+              "not the known defect this test used to document",
           ).toBe(409);
           expect(
             await readDetail(second),
@@ -130,7 +143,7 @@ test.describe("MCP v2 server registration — HTTP status codes", () => {
 
   test(
     "deleting a non-existent MCP server returns 404 Not Found",
-    { tag: ["@mcp", "@regression", "@api"] },
+    { tag: ["@mcp", "@regression", "@api", "@stable"] },
     async ({ page }) => {
       const authHeader = await getAuthToken(page.request);
       expect(
@@ -147,8 +160,9 @@ test.describe("MCP v2 server registration — HTTP status codes", () => {
         const resp = await page.request.delete(path, { headers });
         expect(
           resp.status(),
-          "Deleting a non-existent MCP server must return 404 Not Found " +
-            "(Langflow currently returns 500 — issue #396)",
+          "Deleting a non-existent MCP server must return 404 Not Found. " +
+            "A 500 here is a REGRESSION of langflow-ai/langflow#14005 (see #991), " +
+            "not the known defect this test used to document",
         ).toBe(404);
         // Guard against a route-level 404 (bare "Not Found") masquerading as the
         // resource-level "Server not found." — a renamed/removed endpoint would


### PR DESCRIPTION
Closes #991.

## The premise expired before the issue was written

#991 asks for one thing above all: *"The upstream issue is filed … This is the only deliverable that can actually unblock the tests."* It was never needed.

| When | What |
|---|---|
| 2026-07-27 **16:34 UTC** | langflow-ai/langflow#14005 merged — a concurrency fix that also corrects both status codes in `api/v2/mcp.py` |
| 2026-07-27 **21:08 UTC** | #991 opened, verified against Nightly **1.12.0.dev7** — built *before* that merge — and concluded the defect was still present |
| today | Nightly **1.12.0.dev10**: both tests pass |

The upstream diff is exactly the two-line change #633 predicted:

```diff
-            raise HTTPException(status_code=500, detail="Server not found.")
+            raise HTTPException(status_code=404, detail="Server not found.")
-        raise HTTPException(status_code=500, detail="Server already exists.")
+            raise HTTPException(status_code=409, detail="Server already exists.")
```

So the deliverable that applies is #991's third one — *"When a nightly returns 409/404, the assertions become forward regression guards and `@stable` is restored — as a deliverable of this issue"*.

## Confirmed three ways

One green run is not enough to promote two tests that have been red for three weeks:

1. **Tests** — 2 passed on 1.12.0.dev10.
2. **The image's own source** — `api/v2/mcp.py` raises `status_code=404` at the delete path (lines 440, 502) and `status_code=409` at the duplicate path (line 451), where the 500s used to be.
3. **The upstream diff** — the change above, in the file #396/#633 identified.

## Promotion evidence

- **10/10 clean executions** — 5 bursts × 2 tests, `--workers=1 --retries=0`, against 1.12.0.dev10.
- **Force-fail of all four assertions**, each mutation failing exactly one test:

```
FF: duplicate — status 409 → 418                      → 1 failed
FF: duplicate — detail /already exists/ → /never …/   → 1 failed
FF: missing   — status 404 → 418                      → 1 failed
FF: missing   — detail /server not found/ → /never …/ → 1 failed
reverted                                              → 2 passed
```

The `detail` matchers are force-failed on purpose, not just the status codes: they are what separates a resource-level 404 ("Server not found.") from a route-level one (a renamed endpoint's bare "Not Found"), and an unexercised matcher is an unproven one.

## What changed

**`mcp-server-registration-status-codes.spec.ts`**

- `@stable` restored on both tests. The `QA-CHECKLIST.md` bullets already reference this spec (lines 671–672), so the #985 coverage guard is satisfied without touching the file — and `npm run coverage:summary` was **not** run (generated blocks regenerate on merge, per #741).
- The purpose block is rewritten. It claimed in three places that Langflow returns 500 and pointed at #396, closed. It now carries the dated history — defect present from 1.5.0 (PR #8388) to 2026-07-27, detected by this suite, `@stable` auto-removed 2026-07-10, fixed in #14005 — and states plainly that the direction has inverted.
- Both failure messages inverted: `"A 500 here is a REGRESSION of langflow-ai/langflow#14005 (see #991), not the known defect this test used to document"`. Without this, the next red reads as "known defect, ignore" — which is how three weeks of parked tests happen.
- The `page.request` rationale refreshed for #1084: that change widened the fixture's monitor from four exact codes to every 4xx/5xx on an `/api/` route, so the 409 and 404 these tests provoke deliberately are now *monitored* statuses. Running outside the browser page is what keeps them out of the advisory log — worth stating, since the old comment justified it by "the intentional 5xx" alone.

**`docs/mcp/client/mcp-server-registration-status-codes.md`** — `Last validated` → 1.12.x; the expected-red callout replaced by the closed history; the **Tags** section carries the promotion evidence; the two *"(currently 500 — fails by design)"* asides removed from the steps.

## Validation

`tsc --noEmit` 0 errors · ESLint 0 errors · `npm run check:checklist-coverage` ✓ · final run with the tags in place: `2 passed`.

The tests create and delete their own MCP servers (unique names, cleanup in `finally`) and create no flows, so there is nothing to leak.

## Two things this leaves open, deliberately

**#974's expected-red policy never landed.** #991 conditions the tests' treatment on *"the expected-red watchdog policy being written into `CONTRIBUTING.md` on #974"*. #974 closed on 2026-07-27 and `CONTRIBUTING.md` contains no `expected-red`, `watchdog` or `test.fail` guidance. It did not block this PR — the defect is gone, so the `test.fail()` dilemma evaporated — but the next watchdog meets the same vacuum.

**The blind spot this episode demonstrates.** The upstream fix went unnoticed for three days because the only thing that would have detected it was the test that had been removed from the daily. A watchdog outside every lane watches nothing. That is a concrete argument for the dedicated lane #974 discussed and did not deliver — worth a follow-up issue if the team wants it tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
