### PR TITLE
fix(model-provider): wait instead of sampling in the invalid-auth spec, and lift the google quarantine (#933)

### DIFF
--- a/docs/core-functionality/llm-agents/provider-invalid-auth-error.md
+++ b/docs/core-functionality/llm-agents/provider-invalid-auth-error.md
@@ -1,6 +1,6 @@
 # Provider Invalid API Key Error
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x
 
 ---
 
@@ -15,6 +15,18 @@ Protects against regressions in the integration between the frontend (ProviderCo
 ## Tags *(required)*
 
 `@stable` `@regression` `@model-provider` `@agents`
+
+The tag is shared by all three provider variants (one parameterized `test()` call).
+Between 2026-07-24 and #933 the google variant was skipped by an in-body
+`test.fixme` — `@stable` could not be dropped for one provider alone without
+de-stabling the other two. That quarantine is lifted: the recurrence was caused by
+this spec's own action path, not by google.
+
+The invalid key is made **unique per run** (`${invalidKey}-${Date.now()}`).
+Langflow validates a provider key on save, and re-saving the value it already
+holds produces no validation and therefore no toast at all — so with a cleanup
+that could silently fail to restore, a retry re-submitting the identical string
+could never pass. Uniqueness makes every save a real state change.
 
 ---
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/provider-invalid-auth-error.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/provider-invalid-auth-error.spec.ts
@@ -40,34 +40,73 @@ function getProviderTargets(): ProviderTarget[] {
 
 // Fills the API key input on the current provider page and clicks Save/Replace.
 // Use when already on the provider configuration screen.
+//
+// #933 — every step here used to be a SNAPSHOT, not a wait:
+//
+//     if ((await apiKeyInput.count()) > 0) { … if ((await saveBtn.count()) > 0) … }
+//
+// `count()` resolves against the DOM as it is at that instant. When the provider
+// form had not finished mounting, the `if` simply did not run and the function
+// returned as if it had done its job — so the test went on to assert a toast for a
+// save that never happened, and waited the full 30 s for an effect nobody had
+// triggered. The daily's own step timings show this happening: on 2026-07-22 the
+// restore step took 75 / 253 / 195 ms across three attempts and on 2026-07-24 it
+// took 162 ms — far too little to fill an input and click a button, i.e. the
+// conditional never entered and the invalid key was left in place, silently.
+//
+// Now every step asserts. `expect(...).toBeVisible()` waits, and `click()` carries
+// Playwright's own actionability checks, so a form that never mounts fails here,
+// naming this function, instead of surfacing 30 s later as "toast not visible".
 async function fillProviderApiKey(
   page: any,
   apiKeyPlaceholder: string,
   apiKey: string,
 ): Promise<void> {
   const apiKeyInput = page.getByPlaceholder(apiKeyPlaceholder);
-  if ((await apiKeyInput.count()) > 0) {
-    await apiKeyInput.fill(apiKey);
+  await expect(
+    apiKeyInput,
+    `The API key input (placeholder "${apiKeyPlaceholder}") never appeared — ` +
+      "the provider form did not mount, so nothing was saved (#933)",
+  ).toBeVisible({ timeout: 15000 });
+  await apiKeyInput.fill(apiKey);
 
-    const saveBtn = page.getByRole("button", { name: /^(Save|Replace|Retry Save)$|Save Configuration|Replace Configuration/i });
-    if ((await saveBtn.count()) > 0) {
-      await saveBtn.first().click();
-    }
+  const saveBtn = page
+    .getByRole("button", {
+      name: /^(Save|Replace|Retry Save)$|Save Configuration|Replace Configuration/i,
+    })
+    .first();
+  await expect(
+    saveBtn,
+    "The Save/Replace button never appeared, so the key was never submitted (#933)",
+  ).toBeVisible({ timeout: 15000 });
+  await saveBtn.click();
 
-    // Confirm the disconnect warning dialog if it appears (shown when replacing an existing key).
-    // Uses evaluate because the Save button overlaps the Confirm button in the DOM layout.
-    try {
-      const confirmBtn = page.getByRole("button", { name: "Confirm" });
-      await confirmBtn.waitFor({ state: "visible", timeout: 5000 });
-      await page.evaluate(() => {
-        const btn = Array.from(document.querySelectorAll("button")).find(
-          (b) => b.textContent?.trim() === "Confirm",
-        );
-        btn?.click();
-      });
-    } catch {
-      // No confirmation dialog — key was saved directly
-    }
+  // Replacing an existing key opens a disconnect-warning dialog; a first-time save
+  // does not. Absence is legitimate, so this stays optional — but the click itself
+  // is a real click now. It used to be `page.evaluate(() => btn?.click())`, which
+  // fires on the raw DOM node and bypasses every actionability check, so a dialog
+  // whose React handler was not yet attached swallowed the confirmation and the
+  // save never completed. Scoping to the dialog handles the layout overlap that
+  // motivated the evaluate in the first place.
+  //
+  // The presence check must WAIT, not sample. `locator.isVisible()` resolves
+  // against the DOM as it is right now — using it here would reproduce the exact
+  // bug this function is being fixed for, one line further down: a dialog that
+  // takes 200 ms to mount would be declared absent, the confirmation skipped, and
+  // the save left uncommitted. `waitFor` gives the dialog its 5 s and reports
+  // absence as absence.
+  const dialog = page.getByRole("dialog");
+  const confirmBtn = dialog.getByRole("button", { name: "Confirm" });
+  const dialogAppeared = await confirmBtn
+    .waitFor({ state: "visible", timeout: 5000 })
+    .then(() => true)
+    .catch(() => false);
+  if (dialogAppeared) {
+    await confirmBtn.click();
+    await expect(
+      confirmBtn,
+      "The confirmation dialog stayed open — the save was not committed (#933)",
+    ).toBeHidden({ timeout: 10000 });
   }
 }
 
@@ -82,11 +121,11 @@ async function navigateAndFillProviderApiKey(
   const settingsPage = new SettingsPage(page);
   await settingsPage.navigate();
 
+  // Both clicks carry Playwright's actionability wait; the provider form's own
+  // readiness is asserted by fillProviderApiKey below, which is where a form that
+  // never mounts must be reported (#933).
   await page.getByTestId("icon-BrainCircuit").click();
   await page.getByTestId(providerTestId).click();
-
-  // Wait for the provider form to finish loading before filling
-  await page.getByPlaceholder(apiKeyPlaceholder).waitFor({ state: "visible", timeout: 15000 });
 
   await fillProviderApiKey(page, apiKeyPlaceholder, apiKey);
 }
@@ -103,18 +142,34 @@ for (const {
   invalidKey,
 } of targets) {
   test.describe.serial(`Invalid Auth Error — ${provider}`, () => {
-    // #933: the google variant is a recurrent flake (dailies 2026-07-22, 2026-07-24).
-    // The @stable tag is shared across all provider variants of this parameterized
-    // test (one test() call, one tag), so it cannot be dropped for google alone
-    // without also de-stabling openai/anthropic. Quarantine google via an in-body
-    // test.fixme instead: the daily still grep-selects @stable but skips google,
-    // while openai/anthropic keep running. Restoration = remove this fixme (#933).
-    const quarantined = provider === "google";
+    // The google variant was quarantined here for #933 (recurrent on the dailies of
+    // 2026-07-22 and 2026-07-24) via an in-body `test.fixme`, because the `@stable`
+    // tag is shared by every provider variant of this parameterized test and could
+    // not be dropped for google alone. The quarantine is lifted: the cause was this
+    // spec's own action path, fixed above and below, not anything google-specific.
     test(
       `should display error message when using invalid authentication for provider ${provider}`,
       { tag: ["@stable", "@regression", "@model-provider", "@agents"] },
       async ({ page }) => {
-        test.fixme(quarantined, "#933: recurrent invalid-auth flake (google)");
+        // Guaranteed non-empty: `getProviderTargets()` filters on
+        // `hasProviderEnvKeys`, which is `every(key => !!process.env[key])` — an
+        // absent OR empty key drops the provider from the matrix altogether, so the
+        // restore below can never blank out the provider's configuration. (An
+        // explicit guard here was tried and removed: force-failing it showed it can
+        // never fire, because with an empty key this variant does not exist.)
+        const validKey = process.env[primaryEnvVar] as string;
+
+        // Unique per run (#933). Langflow validates a provider key on save, and
+        // saving the SAME value it already holds produces no validation and no
+        // toast at all — measured: a second identical fill left the screen with no
+        // `.error-build-message` after 15 s. Combined with a cleanup that could
+        // silently fail to restore, that made retries structurally unable to pass:
+        // attempt 1 left the invalid key stored, attempt 2 re-submitted the very
+        // same string, nothing was validated, and the assertion waited out its full
+        // 30 s. That is exactly the shape of 2026-07-22, where all three attempts
+        // failed with identical timings. A unique suffix guarantees the save is a
+        // real state change, independent of what the instance already holds.
+        const uniqueInvalidKey = `${invalidKey}-${Date.now()}`;
 
         await page.goto("/");
         await page.waitForSelector('[data-testid="mainpage_title"]', { timeout: 30000 });
@@ -124,10 +179,16 @@ for (const {
             page,
             providerTestId,
             keyPlaceholder,
-            invalidKey,
+            uniqueInvalidKey,
           );
         });
 
+        // A restore that fails must be reported, but it must never replace the
+        // reason the test failed in the first place: an exception thrown from
+        // `finally` would overwrite the assertion error below. So it is captured
+        // here and asserted after — if the body already threw, its error wins and
+        // this assertion is never reached (#933).
+        let restoreError = "";
         try {
           await test.step("Validate that the invalid authentication error is displayed", async () => {
             const errorBox = errorToastLocator(page);
@@ -137,13 +198,23 @@ for (const {
           });
         } finally {
           await test.step(`Restore valid authentication for provider ${provider}`, async () => {
-            await fillProviderApiKey(
-              page,
-              keyPlaceholder,
-              process.env[primaryEnvVar] ?? "",
-            );
+            try {
+              await fillProviderApiKey(page, keyPlaceholder, validKey);
+            } catch (e) {
+              restoreError = (e as Error)?.message ?? String(e);
+              console.log(
+                `🚨 #933 restore FAILED for ${provider} — this instance may still ` +
+                  `hold an invalid ${primaryEnvVar}, which will break every later ` +
+                  `spec that uses this provider: ${restoreError}`,
+              );
+            }
           });
         }
+        expect(
+          restoreError,
+          `Cleanup did not restore ${primaryEnvVar}: the instance is left holding an ` +
+            "invalid provider key, which silently breaks later specs (#933)",
+        ).toBe("");
       },
     );
   });


### PR DESCRIPTION
Closes #933.

## None of the issue's hypotheses survived measurement

The issue asked to rule out three things. All three are fine on Nightly **1.12.0.dev10**:

| Hypothesis | Measured |
|---|---|
| (a) the error surface / testid changed | the message is correct and **identical** across providers — `"Validation Failed / Invalid API key for Google Generative AI"`; the `.error-build-message` anchor is alive |
| (b) intermittent google-genai availability | 14/14 green locally; no import or build failure anywhere |
| (c) fragile wait on the toast | the toast is on screen **7–23 ms** after the wait begins — the 30 s budget has four orders of magnitude of headroom |

So it is neither a product regression nor google-specific. Two defects in this spec explain the dailies.

## Defect 1 — the action path was built from snapshots, not waits

```ts
if ((await apiKeyInput.count()) > 0) { … if ((await saveBtn.count()) > 0) { … } }
```

`count()` resolves against the DOM as it is at that instant. A provider form that had not finished mounting made the `if` skip, and the function returned as though it had saved. The test then asserted a toast for a save that never happened and burned the full 30 s.

The daily's own step timings show it happening — from the JSON artifacts:

| Run | Set invalid auth | Validate error | **Restore** |
|---|---|---|---|
| 2026-07-22 attempt 1 | 2 516 ms | 30 003 ms | **75 ms** |
| 2026-07-22 attempt 2 | 2 834 ms | 30 027 ms | **253 ms** |
| 2026-07-22 attempt 3 | 1 351 ms | 30 011 ms | **195 ms** |
| 2026-07-24 attempt 1 | 1 667 ms | 30 010 ms | **162 ms** |
| 2026-07-24 attempt 2 (passed) | 2 123 ms | 428 ms | 388 ms |

A restore step of 75–253 ms cannot have filled an input and clicked a button. The conditional never entered: the cleanup was a **silent no-op** that left an invalid provider key stored and reported success.

## Defect 2 — the invalid key was a fixed literal, so retries could not recover

Langflow validates a provider key on save. Saving the value it already holds produces **no validation and no toast at all** — measured directly: a second identical fill left the screen with no `.error-build-message` after 15 s.

Compose that with defect 1 and the retry mechanism is structurally broken: attempt 1 leaves the invalid key stored, attempt 2 re-submits the identical string, nothing is validated, and the assertion waits out its full 30 s. That is exactly the 2026-07-22 shape — three attempts, identical timings, hard failure. A flake that cannot recover on retry is not a flake.

## The fix

- **Every step asserts, with its own message.** `expect(...).toBeVisible()` waits, and `click()` carries Playwright's actionability checks, so a form that never mounts fails *there*, naming the function, instead of surfacing 30 s later as "toast not visible".
- **The Confirm click is a real click, scoped to the dialog.** It was `page.evaluate(() => btn?.click())`, which fires on the raw DOM node and bypasses every actionability check — a dialog whose React handler was not yet attached swallowed the confirmation and the save never completed. Scoping to `getByRole("dialog")` handles the layout overlap that motivated the evaluate.
- **The invalid key is unique per run** (`${invalidKey}-${Date.now()}`), so every save is a real state change regardless of what the instance already holds.
- **A failed restore is loud**: captured, logged with 🚨, and asserted **after** the `finally`. Throwing from inside `finally` would overwrite the body's own failure, so the precedence is explicit — the body's error wins, and a cleanup failure fails the test only when the body passed.
- **The google quarantine is lifted** (the in-body `test.fixme`), which is #933's stated deliverable.

**This corrects all three providers, not just google.** openai and anthropic carry `@stable` and run in the daily every day through the same conditional path; they had not failed yet by timing luck alone. Fixing google alone would have closed the issue and left the charge in place under the two that run daily.

## Validation

**9/9 green** — 3 bursts × 3 providers, `--workers=1 --retries=0`, against a throwaway 1.12.0.dev10 container (never the developer's instance: this spec rewrites the provider key).

**Four force-fails, each failing with its intended message:**

```
FF: input assertion (placeholder never matches)  → 1 failed, "provider form did not mount"
FF: Save assertion (name never matches)          → 1 failed, "never appeared, so the key was never submitted"
FF: toast assertion (text never matches)         → 1 failed, Timeout
FF: restore broken while the body passes         → 1 failed, "Cleanup did not restore"
reverted                                         → 3 passed
```

The harness asserts the *message*, not just the failure: a guard that goes red without naming its cause would reproduce the original problem of #933, where a 30 s "toast not visible" sent the investigation looking at toast latency.

`tsc --noEmit` 0 errors · ESLint 0 errors (3 warnings, all pre-existing in this file) · spec doc `Last validated` → 1.12.x with the quarantine history and the unique-key rationale · no `QA-CHECKLIST.md` change (the `@stable` tag is unchanged and all three bullets already reference the spec).

## Deliberately not claimed

**The Confirm-dialog branch is not force-failed.** Measured `dialogAppeared=false` on 1.12.0.dev10 — the branch is dead code on this build, so an inverted assertion inside it cannot fail. It is kept rather than deleted because the daily's instance has flows connected to the providers, where the disconnect warning is plausible; removing a guard because it does not reproduce on one machine is the mirror image of the mistake this issue started with. Its cost is measured too: the 5 s absence wait runs twice per test, ~10 s of the 15 s runtime. If CI also reports the dialog absent, the branch and that cost can go in a follow-up.

**The trigger of the CI first attempt remains inferred.** What is proven: every action on that path fails silently by construction, and at least one of them did so in that very run (the 162 ms restore). Which UI transition removes the form under load is not established, and no claim is made about it.

**Two of my own defects were caught by the force-fail, not by the green runs** — worth stating because it is the argument for the rule: I first wrote `isVisible({ timeout })`, which is an *instant* sample, in the very diff whose thesis is that sampling is the bug; and I added an empty-env-key guard that can never fire, because `hasProviderEnvKeys` already drops a provider whose key is empty. Nine green bursts would have shipped both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
