### PR TITLE
test(flows): survive the upstream editor-exit deadlock, attributed (#1153)

### DIFF
--- a/docs/flow-functionality/duplicate-flow.md
+++ b/docs/flow-functionality/duplicate-flow.md
@@ -1,6 +1,6 @@
 # Flow Functionality — Duplicate Flow
 
-**Last validated:** Langflow 1.10.x
+**Last validated:** Langflow 1.12.x
 
 ---
 
@@ -28,8 +28,8 @@ API test: `@release` `@workspace` `@api` `@stable`
 
 1. Bootstrap the app
 2. Click `side_nav_options_all-templates`, then click the `Basic Prompting` heading to open the template (which creates a new flow)
-3. Wait for `sidebar-search-input` to confirm the editor loaded; navigate back via `icon-ChevronLeft`
-4. Wait for the first `home-dropdown-menu` to be visible
+3. Wait for `sidebar-search-input` to confirm the editor loaded; return to the listing with `leaveFlowEditor(page)` — the `icon-ChevronLeft` click plus its home assertion, wrapped so the exit survives the `SaveChangesModal` deadlock (#1153)
+4. `leaveFlowEditor` asserts the first `home-dropdown-menu` is visible before returning
 5. Acquire a Bearer token via `getAuthToken(request)`
 6. Click the first `home-dropdown-menu`, wait for `btn-duplicate-flow`
 7. Register a `page.waitForResponse` listener for `POST /api/v1/flows/` with status `201`, then click `btn-duplicate-flow`
@@ -68,6 +68,7 @@ The API test must assert **all** of:
 ## External dependencies *(required)*
 
 - `tests/helpers/auth/get-auth-token.ts` — issues the Bearer token
+- `tests/helpers/flows/leave-flow-editor.ts` — the editor exit: drains in-flight flow saves, clicks `icon-ChevronLeft`, and distinguishes the #1153 blocker deadlock from a swallowed click. It depends on upstream `src/frontend/src/pages/FlowPage/index.tsx` (`useBlocker` / `handleSave`), `src/frontend/src/modals/saveChangesModal/index.tsx`, and the `flow.unsavedChangesTitle` string in `src/frontend/src/locales/en.json` — if that title is reworded the dialog stops being recognised and every deadlock silently reclassifies as a swallowed click
 - `src/frontend/src/pages/MainPage/components/dropdown/index.tsx` — registers `btn-duplicate-flow` testid; the test would need updating if it is renamed or removed
 - `src/frontend/src/pages/MainPage/hooks/use-handle-duplicate.ts` — calls `createNewFlow` then `postAddFlow`; the API test mirrors this round-trip directly
 - `src/frontend/src/utils/reactflowUtils.ts` (`createNewFlow`) — keeps the original `name` (no client-side suffix); the suffix originates server-side

--- a/docs/flow-functionality/export-import-flow.md
+++ b/docs/flow-functionality/export-import-flow.md
@@ -1,6 +1,6 @@
 # Flow Functionality — Export and Import Flow
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x
 
 ---
 
@@ -32,8 +32,11 @@ If these break, users cannot share flows, back them up, or restore previously ex
    proof the node-add autosave persisted, replacing the quiet-window guard
    (`waitForFlowSaveSettled` resolves after 700 ms of silence even when the
    debounced PATCH hasn't fired yet — the #384 loophole)
-3. Return to main page and open the three-dot menu **of the created flow's own
-   card**: `list-card` filtered by `flow-name-{id}` → `home-dropdown-menu`
+3. Return to the main page with `leaveFlowEditor(page)` — the `icon-ChevronLeft`
+   click plus its home assertion, wrapped so the exit survives the
+   `SaveChangesModal` deadlock (#1153) — then open the three-dot menu **of the
+   created flow's own card**: `list-card` filtered by `flow-name-{id}` →
+   `home-dropdown-menu`
    inside it. Never `nth(0)`: the home sorts by `updated_at` DESC, so under
    parallel CI the first card is whatever flow a neighbor worker touched last
    — exporting it produced the `nodes: []` failures (#518; export serializes
@@ -73,6 +76,7 @@ If these break, users cannot share flows, back them up, or restore previously ex
 - `src/frontend/src/components/core/flowEditorComponents/` — flow editor header, export modal
 - `src/backend/base/langflow/api/v1/flows.py` — flow export/import endpoints
 - `tests/helpers/ui/simulate-drag-and-drop.ts` — `simulateDragAndDrop` helper
+- `tests/helpers/flows/leave-flow-editor.ts` — the editor exit: drains in-flight flow saves, clicks `icon-ChevronLeft`, and distinguishes the #1153 blocker deadlock from a swallowed click. It depends on upstream `src/frontend/src/pages/FlowPage/index.tsx` (`useBlocker` / `handleSave`), `src/frontend/src/modals/saveChangesModal/index.tsx`, and the `flow.unsavedChangesTitle` string in `src/frontend/src/locales/en.json` — if that title is reworded the dialog stops being recognised and every deadlock silently reclassifies as a swallowed click
 - `tests/assets/flows/collection.json` — multi-flow JSON used as import fixture
 - `data-testid="home-dropdown-menu"` — three-dot menu on flow cards
 - `data-testid="btn-download-json"` — download/export menu item

--- a/docs/flow-functionality/run-flow.md
+++ b/docs/flow-functionality/run-flow.md
@@ -87,7 +87,6 @@ does. Shared-helper blast radius (`awaitBootstrapTest`,
 milliseconds once the list is rendered and returns immediately on non-list pages,
 so no consumer's behavior changes.
 
-
 **Verdict: product defect, not a test defect.** An enabled button with a wired
 `onClick` whose click is a no-op while the list loads is broken behavior — invisible
 to a human (who takes more than a second to move the mouse), fatal to a test that
@@ -127,7 +126,12 @@ was not what happened.
 Step 5 now goes through `leaveFlowEditor(page)`, which drains in-flight flow
 saves before the click (prevention — `changesNotSaved` is exactly what
 `useBlocker` gates on) and throws with the mechanism named if the dialog is still
-up after 15 s. The recovery-by-page-load that helper also offers is deliberately
+up after 15 s. That 15 s is charged **only** to a dialog that is demonstrably on
+screen; an exit where nothing has rendered yet is an ordinary in-flight
+navigation and keeps the full 30 s the listing assertion has always had —
+otherwise a slow-but-healthy exit would be reported as the swallowed-click class
+above, which is the same mis-attribution with a more confident label.
+The recovery-by-page-load that helper also offers is deliberately
 **not** enabled here: everything the rest of this spec asserts lives in the flow
 built on the canvas, so discarding it would trade a clean failure at the exit for
 an inscrutable one at the Run Flow dropdown.

--- a/docs/flow-functionality/run-flow.md
+++ b/docs/flow-functionality/run-flow.md
@@ -26,7 +26,9 @@ If this breaks, users cannot compose flows via the Run Flow component — a core
 2. Add ChatOutput and ChatInput components to the canvas
 3. Connect: ChatInput → ChatOutput
 4. Rename the built flow to a unique name (for deterministic selection later)
-5. Return to main page and create a second blank flow
+5. Return to main page with `leaveFlowEditor(page)` — the `icon-ChevronLeft`
+   click, preceded by a save barrier and followed by an attributed throw if the
+   exit is blocked (#1153) — and create a second blank flow
 6. Add the Run Flow component to the second flow
 7. Open the flow name dropdown in Run Flow and refresh the list
 8. Select the built flow by its unique name from the dropdown
@@ -85,6 +87,7 @@ does. Shared-helper blast radius (`awaitBootstrapTest`,
 milliseconds once the list is rendered and returns immediately on non-list pages,
 so no consumer's behavior changes.
 
+
 **Verdict: product defect, not a test defect.** An enabled button with a wired
 `onClick` whose click is a no-op while the list loads is broken behavior — invisible
 to a human (who takes more than a second to move the mouse), fatal to a test that
@@ -104,6 +107,31 @@ re-validated there. The helper gate keeps the suite out of the broken window; it
 does not fix the product, and the suite must not claim a validated behavior that
 upstream still breaks. `#966` stays open tracking that.
 
+### A second product defect on the same back-navigation (issue #1153)
+
+Distinct from LE-2019 above and with a different mechanism: LE-2019 is a click
+that lands and does nothing while the list loads; this one is a click that lands,
+starts the navigation, and is then held by react-router's `useBlocker` behind
+`SaveChangesModal`. In autosave mode that dialog renders **no confirm and no
+cancel**, so only `FlowPage.handleSave` can complete the navigation — and it
+calls `saveFlow()` with **no `.catch()`**, so a save that fails or never settles
+leaves `proceed` false and the dialog up indefinitely. Reproduced
+deterministically on 1.12.0.dev10 by aborting every flow-save PATCH: the modal
+appears, does not clear in 30 s, and the URL stays on `/flow/{id}`.
+
+Why it matters here specifically: this call site had **nothing** waiting on the
+navigation, so a blocked exit surfaced downstream inside
+`openNewFlowTemplatesModal` — wearing LE-2019's signature on a run where LE-2019
+was not what happened.
+
+Step 5 now goes through `leaveFlowEditor(page)`, which drains in-flight flow
+saves before the click (prevention — `changesNotSaved` is exactly what
+`useBlocker` gates on) and throws with the mechanism named if the dialog is still
+up after 15 s. The recovery-by-page-load that helper also offers is deliberately
+**not** enabled here: everything the rest of this spec asserts lives in the flow
+built on the canvas, so discarding it would trade a clean failure at the exit for
+an inscrutable one at the Run Flow dropdown.
+
 ---
 
 ## External dependencies *(required)*
@@ -111,6 +139,7 @@ upstream still breaks. `#966` stays open tracking that.
 - `src/frontend/src/components/core/nodeToolbarComponents/` — Run Flow component UI and flow name dropdown
 - `src/backend/base/langflow/api/v1/flows.py` — flow listing API used by the dropdown refresh
 - `src/backend/base/langflow/processing/` — flow execution chain that runs the pipeline
+- `tests/helpers/flows/leave-flow-editor.ts` — the editor exit: drains in-flight flow saves, clicks `icon-ChevronLeft`, and distinguishes the #1153 blocker deadlock from a swallowed click. It depends on upstream `src/frontend/src/pages/FlowPage/index.tsx` (`useBlocker` / `handleSave`), `src/frontend/src/modals/saveChangesModal/index.tsx`, and the `flow.unsavedChangesTitle` string in `src/frontend/src/locales/en.json` — if that title is reworded the dialog stops being recognised and every deadlock silently reclassifies as a swallowed click
 
 ---
 

--- a/tests/helpers/flows/leave-flow-editor.test.ts
+++ b/tests/helpers/flows/leave-flow-editor.test.ts
@@ -7,7 +7,7 @@
 // timeout, which #1005's triage spent a full 24-run burst re-deriving into "the
 // blocker dialog never cleared".
 //
-// Three distinctions these tests exist to protect:
+// Four distinctions these tests exist to protect:
 //
 //  1. **`stuck` is not `blocked-deadlocked`.** A swallowed chevron click and a
 //     blocked navigation both end with the editor still on screen, and they send
@@ -20,91 +20,132 @@
 //  3. **Home wins over a painted dialog.** The dialog animates out, so it is
 //     routinely still in the DOM on the tick where home first renders. Reporting
 //     that as a deadlock would warn — and force a page load — on healthy exits.
+//  4. **The two deadlines are not one deadline.** An empty screen is an ordinary
+//     in-flight navigation and gets the full home budget; only a dialog already
+//     on screen is judged on the shorter blocker grace. Charging the grace window
+//     to a slow-but-healthy exit reports a dead click that never happened — the
+//     same mis-attribution as a bare timeout, only with a confident label.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   BLOCKER_GRACE_MS,
+  HOME_TIMEOUT_MS,
   classifyEditorExit,
   formatEditorExitStuckFailure,
   formatEditorExitWarning,
   type EditorExitVerdict,
 } from "./leave-flow-editor";
 
-const verdict = (
-  homeVisible: boolean,
-  blockerVisible: boolean,
-  graceExpired: boolean,
-): EditorExitVerdict =>
-  classifyEditorExit({ homeVisible, blockerVisible, graceExpired });
+/**
+ * Named rather than positional, and every deadline defaults to NOT expired: a
+ * test that forgets to expire one gets `pending` — which fails loudly — instead
+ * of silently agreeing with whichever flag happened to be passed.
+ */
+const verdict = (observed: {
+  home?: boolean;
+  blocker?: boolean;
+  /** `BLOCKER_GRACE_MS` elapsed. Only ever promotes a dialog already on screen. */
+  grace?: boolean;
+  /** `HOME_TIMEOUT_MS` elapsed. The only thing that may call an empty screen stuck. */
+  homeBudget?: boolean;
+}): EditorExitVerdict =>
+  classifyEditorExit({
+    homeVisible: observed.home ?? false,
+    blockerVisible: observed.blocker ?? false,
+    graceExpired: observed.grace ?? false,
+    homeBudgetExpired: observed.homeBudget ?? false,
+  });
 
 test("home rendered with no dialog is a clean exit", () => {
-  assert.equal(verdict(true, false, false), "left");
-  assert.equal(verdict(true, false, true), "left");
+  assert.equal(verdict({ home: true }), "left");
+  assert.equal(verdict({ home: true, grace: true, homeBudget: true }), "left");
 });
 
 test("home rendered while the dialog is still painted is NOT a deadlock", () => {
   // The dialog animates out; it is routinely still in the DOM on the tick where
   // home first renders. Calling that a deadlock would warn and force a page load
   // on every healthy exit that happened to pass through the blocker.
-  assert.equal(verdict(true, true, false), "blocked-settled");
-  assert.equal(verdict(true, true, true), "blocked-settled");
+  assert.equal(verdict({ home: true, blocker: true }), "blocked-settled");
+  assert.equal(
+    verdict({ home: true, blocker: true, grace: true, homeBudget: true }),
+    "blocked-settled",
+  );
 });
 
 test("the dialog inside the grace window is pending, not a verdict", () => {
   // `handleSave`'s own timeout is 1200ms, so a dialog that is up for a moment is
   // the normal save-then-proceed path. Returning a terminal verdict here would
   // make the caller give up before the exit had a chance to complete.
-  assert.equal(verdict(false, true, false), "pending");
+  assert.equal(verdict({ blocker: true }), "pending");
 });
 
 test("the dialog past the grace window is the #1153 deadlock", () => {
-  assert.equal(verdict(false, true, true), "blocked-deadlocked");
+  assert.equal(verdict({ blocker: true, grace: true }), "blocked-deadlocked");
 });
 
-test("neither home nor dialog past the window is a swallowed click, not a deadlock", () => {
+test("an empty screen past the grace window is NOT yet stuck", () => {
+  // The regression this pins: `stuck` used to share the blocker's deadline, so a
+  // navigation that was merely slow — a client-side route change plus the
+  // listing's own GET, the thing that runs long on a saturated daily — failed at
+  // 15s claiming the click never registered. The call sites this helper replaced
+  // allowed 30s for exactly this window.
+  assert.equal(verdict({ grace: true }), "pending");
+});
+
+test("an empty screen past the HOME budget is a swallowed click, not a deadlock", () => {
   // Distinct from `blocked-deadlocked` on purpose: this is the editor still on
   // screen with nothing blocking it, i.e. the chevron click never registered.
-  assert.equal(verdict(false, false, true), "stuck");
+  assert.equal(verdict({ grace: true, homeBudget: true }), "stuck");
 });
 
-test("neither home nor dialog inside the window is still pending", () => {
-  assert.equal(verdict(false, false, false), "pending");
+test("neither home nor dialog inside both windows is still pending", () => {
+  assert.equal(verdict({}), "pending");
 });
 
 test("`pending` is never terminal, so the poll loop cannot exit early", () => {
   // The loop's only exit condition is `verdict !== "pending"`. Every combination
   // that has not resolved yet must therefore classify as pending, or the caller
   // asserts against a page that has not navigated.
-  const unresolvedInsideWindow: Array<[boolean, boolean]> = [
-    [false, false],
-    [false, true],
+  //
+  // Includes the deadline states, because they expire at different times: with
+  // the blocker grace elapsed but the home budget still open, an empty screen is
+  // the one state where a shared deadline used to produce a wrong verdict.
+  const unresolved = [
+    { blocker: false, grace: false },
+    { blocker: true, grace: false },
+    { blocker: false, grace: true },
   ];
-  for (const [home, blocker] of unresolvedInsideWindow) {
+  for (const { blocker, grace } of unresolved) {
     assert.equal(
-      verdict(home, blocker, false),
+      verdict({ blocker, grace }),
       "pending",
-      `home=${home} blocker=${blocker} must stay pending inside the grace window`,
+      `blocker=${blocker} grace=${grace} must stay pending while the home budget is open`,
     );
   }
 });
 
 test("the deadlock message names the upstream defect, not just the symptom", () => {
-  // Fed the real constant, not a literal: asserting against a hand-written
-  // number would pass a regression that logged a budget the helper never used.
-  const message = formatEditorExitWarning(BLOCKER_GRACE_MS);
+  // Called with NO argument, so this pins the pairing the helper actually ships
+  // — not just the formatting. Feeding the constant in would have passed a
+  // regression that quoted a budget this verdict is not gated on.
+  const message = formatEditorExitWarning();
   // A triager reading only this line has to reach the issue and the mechanism
   // without opening the screenshot.
   assert.match(message, /#1153/);
   assert.match(message, /SaveChangesModal/);
   assert.match(message, /no \.catch\(\)/);
   assert.match(message, new RegExp(`${BLOCKER_GRACE_MS}ms`));
+  // Must not quote the home budget: this verdict is gated on the grace window,
+  // and swapping the two is precisely how the deadlines get collapsed again.
+  assert.doesNotMatch(message, new RegExp(`${HOME_TIMEOUT_MS}ms`));
 });
 
 test("the stuck message rules the deadlock OUT rather than staying vague", () => {
   // The two failures send a reader to opposite places, so the message for one
   // must not read as the other. A triager who sees this line must not go
   // looking at SaveChangesModal.
-  const message = formatEditorExitStuckFailure(BLOCKER_GRACE_MS);
+  // Also called with no argument — see the deadlock message test above.
+  const message = formatEditorExitStuckFailure();
   assert.match(message, /did not navigate/);
   assert.match(message, /NOT the #1153/);
   assert.match(message, /LE-2019/);
@@ -113,6 +154,12 @@ test("the stuck message rules the deadlock OUT rather than staying vague", () =>
     /deadlocked/,
     "the swallowed-click message must not describe itself as the deadlock",
   );
+  // It must quote the window it actually waited out. Quoting the blocker's
+  // shorter grace would understate the evidence behind "the click never
+  // registered" — and would be the visible symptom of the two deadlines having
+  // been collapsed back into one.
+  assert.match(message, new RegExp(`${HOME_TIMEOUT_MS}ms`));
+  assert.doesNotMatch(message, new RegExp(`${BLOCKER_GRACE_MS}ms`));
 });
 
 test("the grace budget is not below the repo's save budgets", () => {
@@ -123,5 +170,22 @@ test("the grace budget is not below the repo's save budgets", () => {
   assert.ok(
     BLOCKER_GRACE_MS >= 15000,
     `grace window ${BLOCKER_GRACE_MS}ms is below renameFlow's 15000ms per-step budget`,
+  );
+});
+
+test("the home budget stays above the blocker grace, and above what the call sites had", () => {
+  // Ordering is the whole point of splitting the deadlines: if the home budget
+  // ever fell to or below the grace window, `stuck` would start firing on slow
+  // navigations again and this helper would be back to mis-attributing them.
+  assert.ok(
+    HOME_TIMEOUT_MS > BLOCKER_GRACE_MS,
+    `home budget ${HOME_TIMEOUT_MS}ms must exceed the blocker grace ${BLOCKER_GRACE_MS}ms`,
+  );
+  // 30s is inherited, not invented: it is what `duplicate-flow` (`toBeVisible`)
+  // and `export-import-flow` (`waitForSelector`) allowed this assertion before
+  // the helper existed. The helper must not silently shorten it.
+  assert.ok(
+    HOME_TIMEOUT_MS >= 30000,
+    `home budget ${HOME_TIMEOUT_MS}ms is below the 30000ms the call sites already allowed`,
   );
 });

--- a/tests/helpers/flows/leave-flow-editor.test.ts
+++ b/tests/helpers/flows/leave-flow-editor.test.ts
@@ -1,0 +1,127 @@
+// Unit tests for the editor-exit classifier (issue #1153).
+// Run with: npm run test:units
+//
+// What rides on this module: when the upstream exit deadlock fires, the line
+// this produces is the entire product of the failure in a daily's report. Before
+// #1153 the same event surfaced as a bare `home-dropdown-menu` visibility
+// timeout, which #1005's triage spent a full 24-run burst re-deriving into "the
+// blocker dialog never cleared".
+//
+// Three distinctions these tests exist to protect:
+//
+//  1. **`stuck` is not `blocked-deadlocked`.** A swallowed chevron click and a
+//     blocked navigation both end with the editor still on screen, and they send
+//     a reader to opposite places (a click that never fired vs. the upstream
+//     defect). Collapsing them re-creates the unattributed timeout.
+//  2. **`pending` is a verdict, not an absence.** The polling loop terminates on
+//     "anything but pending", so a classifier that returned `left` for "nothing
+//     has happened yet" would make the loop exit on its first tick and assert
+//     against a page that has not navigated.
+//  3. **Home wins over a painted dialog.** The dialog animates out, so it is
+//     routinely still in the DOM on the tick where home first renders. Reporting
+//     that as a deadlock would warn — and force a page load — on healthy exits.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  BLOCKER_GRACE_MS,
+  classifyEditorExit,
+  formatEditorExitStuckFailure,
+  formatEditorExitWarning,
+  type EditorExitVerdict,
+} from "./leave-flow-editor";
+
+const verdict = (
+  homeVisible: boolean,
+  blockerVisible: boolean,
+  graceExpired: boolean,
+): EditorExitVerdict =>
+  classifyEditorExit({ homeVisible, blockerVisible, graceExpired });
+
+test("home rendered with no dialog is a clean exit", () => {
+  assert.equal(verdict(true, false, false), "left");
+  assert.equal(verdict(true, false, true), "left");
+});
+
+test("home rendered while the dialog is still painted is NOT a deadlock", () => {
+  // The dialog animates out; it is routinely still in the DOM on the tick where
+  // home first renders. Calling that a deadlock would warn and force a page load
+  // on every healthy exit that happened to pass through the blocker.
+  assert.equal(verdict(true, true, false), "blocked-settled");
+  assert.equal(verdict(true, true, true), "blocked-settled");
+});
+
+test("the dialog inside the grace window is pending, not a verdict", () => {
+  // `handleSave`'s own timeout is 1200ms, so a dialog that is up for a moment is
+  // the normal save-then-proceed path. Returning a terminal verdict here would
+  // make the caller give up before the exit had a chance to complete.
+  assert.equal(verdict(false, true, false), "pending");
+});
+
+test("the dialog past the grace window is the #1153 deadlock", () => {
+  assert.equal(verdict(false, true, true), "blocked-deadlocked");
+});
+
+test("neither home nor dialog past the window is a swallowed click, not a deadlock", () => {
+  // Distinct from `blocked-deadlocked` on purpose: this is the editor still on
+  // screen with nothing blocking it, i.e. the chevron click never registered.
+  assert.equal(verdict(false, false, true), "stuck");
+});
+
+test("neither home nor dialog inside the window is still pending", () => {
+  assert.equal(verdict(false, false, false), "pending");
+});
+
+test("`pending` is never terminal, so the poll loop cannot exit early", () => {
+  // The loop's only exit condition is `verdict !== "pending"`. Every combination
+  // that has not resolved yet must therefore classify as pending, or the caller
+  // asserts against a page that has not navigated.
+  const unresolvedInsideWindow: Array<[boolean, boolean]> = [
+    [false, false],
+    [false, true],
+  ];
+  for (const [home, blocker] of unresolvedInsideWindow) {
+    assert.equal(
+      verdict(home, blocker, false),
+      "pending",
+      `home=${home} blocker=${blocker} must stay pending inside the grace window`,
+    );
+  }
+});
+
+test("the deadlock message names the upstream defect, not just the symptom", () => {
+  // Fed the real constant, not a literal: asserting against a hand-written
+  // number would pass a regression that logged a budget the helper never used.
+  const message = formatEditorExitWarning(BLOCKER_GRACE_MS);
+  // A triager reading only this line has to reach the issue and the mechanism
+  // without opening the screenshot.
+  assert.match(message, /#1153/);
+  assert.match(message, /SaveChangesModal/);
+  assert.match(message, /no \.catch\(\)/);
+  assert.match(message, new RegExp(`${BLOCKER_GRACE_MS}ms`));
+});
+
+test("the stuck message rules the deadlock OUT rather than staying vague", () => {
+  // The two failures send a reader to opposite places, so the message for one
+  // must not read as the other. A triager who sees this line must not go
+  // looking at SaveChangesModal.
+  const message = formatEditorExitStuckFailure(BLOCKER_GRACE_MS);
+  assert.match(message, /did not navigate/);
+  assert.match(message, /NOT the #1153/);
+  assert.match(message, /LE-2019/);
+  assert.doesNotMatch(
+    message,
+    /deadlocked/,
+    "the swallowed-click message must not describe itself as the deadlock",
+  );
+});
+
+test("the grace budget is not below the repo's save budgets", () => {
+  // `renameFlow` allows 15s per modal step and a single save click has needed
+  // longer than that under CI saturation (#790). A budget below that would
+  // classify a slow-but-working save as a deadlock — and, where recovery is
+  // enabled, discard editor state over it.
+  assert.ok(
+    BLOCKER_GRACE_MS >= 15000,
+    `grace window ${BLOCKER_GRACE_MS}ms is below renameFlow's 15000ms per-step budget`,
+  );
+});

--- a/tests/helpers/flows/leave-flow-editor.ts
+++ b/tests/helpers/flows/leave-flow-editor.ts
@@ -1,0 +1,220 @@
+// Leaving the flow editor, around an upstream exit deadlock (issue #1153).
+//
+// Clicking the editor's back chevron with a diverged store trips react-router's
+// `useBlocker` and renders `SaveChangesModal`. In AUTOSAVE mode that dialog has
+// no confirm and no cancel — upstream passes `loading` hardcoded `true` and
+// leaves `confirmationText`/`cancelText`/`onConfirm` undefined, so
+// `ConfirmationModal` renders no footer at all — which leaves
+// `FlowPage.handleSave` as the only thing that can complete the navigation:
+//
+//   const handleSave = () => {
+//     let saving = true; let proceed = false;
+//     setTimeout(() => { saving = false; if (proceed) blocker.proceed?.() }, 1200);
+//     saveFlow().then(() => {
+//       if (!autoSaving || saving === false) blocker.proceed?.();
+//       proceed = true;
+//     });                                     // <- no .catch()
+//   };
+//
+// When that save does not resolve, the `.then` never runs, `proceed` stays
+// false, the 1200 ms timeout finds it false and does nothing, and the dialog
+// spins indefinitely. Reproduced deterministically on 1.12.0.dev10 by aborting
+// every flow-save PATCH: the modal appears, does not clear in 30 s, and the URL
+// stays on `/flow/{id}`.
+//
+// The dialog DOES render `BaseModal`'s default X (and Escape works), so a human
+// is not trapped on screen — but both route to `blocker.reset()`, which returns
+// them to the editor. Dismissing is possible; LEAVING is not. Under natural load
+// this fired twice in 24 runs at `--workers=4` (#1005's investigation), where it
+// read as an unattributed `home-dropdown-menu` timeout.
+//
+// Shape of the workaround, following `renameFlow`'s #995 contract — PREVENTION
+// first, recovery last, and loud either way:
+//
+//  - Prevention: drain in-flight flow saves before the click. `changesNotSaved`
+//    is exactly what `useBlocker` gates on, so a settled store keeps most exits
+//    out of the blocked state entirely.
+//  - Recovery: only where the caller opts in. A full document load leaves the
+//    SPA blocker behind — measured: `page.goto("/")` lands on `/flows` with the
+//    home markers rendered and the dialog gone, the same route the chevron's own
+//    handler navigates to (`appHeaderComponent` → `navigate("/")`). It also
+//    DISCARDS whatever the editor had unsaved, so it is wrong for a caller whose
+//    later assertions depend on that state — those get an attributed throw
+//    instead, which is strictly better than the same failure 90 s downstream.
+
+import { type Page, expect } from "@playwright/test";
+import { waitForFlowSaveSettled } from "./wait-for-flow-save-settled";
+
+/** The blocker dialog's title, `flow.unsavedChangesTitle` with `name: "Flow"`. */
+const BLOCKER_TITLE = "Flow has unsaved changes";
+
+/** Rendered on the flows list once it is interactive. */
+const HOME_MARKER = "home-dropdown-menu";
+
+/**
+ * How long the blocker may legitimately stay up.
+ *
+ * Matched to `renameFlow`'s per-modal-step budget rather than to
+ * `handleSave`'s own 1200 ms timeout: on a saturated single-backend daily a
+ * single save click has needed far longer than that (45 s in #790's case), and
+ * calling a slow-but-working save a deadlock would warn — and, where recovery is
+ * enabled, discard state — on a healthy exit.
+ */
+export const BLOCKER_GRACE_MS = 15000;
+
+/** Budget for the home list to render, on either path. */
+const HOME_TIMEOUT_MS = 30000;
+
+/** What the exit did, once the click has been made. */
+export type EditorExitVerdict =
+  /** Nothing has resolved yet and the grace window is still open — keep polling. */
+  | "pending"
+  /** Home rendered. */
+  | "left"
+  /** Home rendered with the dialog still painted — it came and went. */
+  | "blocked-settled"
+  /** The blocker is still up past the grace window: #1153. */
+  | "blocked-deadlocked"
+  /** Neither home nor the blocker — the click did not register at all. */
+  | "stuck";
+
+/**
+ * Classify an exit attempt from what is on screen. Pure, so the `node --test`
+ * lane covers the distinctions instead of a Playwright run having to produce
+ * each of them.
+ *
+ * The `stuck` verdict is kept separate from `blocked-deadlocked` on purpose: a
+ * swallowed chevron click and a blocked navigation both end with the editor
+ * still on screen, and they send a reader to opposite places (the #420 /
+ * LE-2019 dead-click class vs. this upstream defect). Collapsing them would
+ * re-create the unattributed timeout this helper exists to replace.
+ */
+export function classifyEditorExit(observed: {
+  homeVisible: boolean;
+  blockerVisible: boolean;
+  graceExpired: boolean;
+}): EditorExitVerdict {
+  // Home wins even with the dialog still painted: the route changed, which is
+  // the only thing the caller asked for. The dialog animates out, so it is
+  // routinely still in the DOM on the tick where home first renders — reporting
+  // that as a deadlock would fire on healthy exits.
+  if (observed.homeVisible) {
+    return observed.blockerVisible ? "blocked-settled" : "left";
+  }
+  if (observed.blockerVisible) {
+    return observed.graceExpired ? "blocked-deadlocked" : "pending";
+  }
+  return observed.graceExpired ? "stuck" : "pending";
+}
+
+/**
+ * The line a triager reads when the deadlock fires. It has to name the defect,
+ * not just the symptom — an unattributed `home-dropdown-menu` timeout is exactly
+ * what #1005 spent a 24-run burst re-deriving.
+ */
+export function formatEditorExitWarning(graceMs: number): string {
+  return (
+    `[leaveFlowEditor] the editor exit is deadlocked behind SaveChangesModal ` +
+    `("${BLOCKER_TITLE}") — it did not clear in ${graceMs}ms, and in autosave ` +
+    `mode that dialog renders no confirm and no cancel, so nothing but ` +
+    `FlowPage.handleSave can complete the navigation. Upstream defect: ` +
+    `handleSave calls saveFlow() with no .catch(), so a save that fails or ` +
+    `never settles leaves the blocker up indefinitely (issue #1153).`
+  );
+}
+
+/** Same, for the swallowed-click case — a different cause and a different fix. */
+export function formatEditorExitStuckFailure(graceMs: number): string {
+  return (
+    `[leaveFlowEditor] the chevron click did not navigate and nothing is ` +
+    `blocking it: no flows list and no SaveChangesModal after ${graceMs}ms. ` +
+    `This is the swallowed-click class (#420 / LE-2019), NOT the #1153 exit ` +
+    `deadlock — the editor is simply still on screen.`
+  );
+}
+
+export interface LeaveFlowEditorOptions {
+  /**
+   * Recover from a #1153 deadlock with a full page load instead of throwing.
+   *
+   * Off by default, because the reload discards whatever the editor had unsaved.
+   * Opt in only where nothing the test asserts later depends on that state —
+   * otherwise the recovery converts a clean, attributed failure at the exit into
+   * an inscrutable one much further downstream.
+   */
+  escapeDeadlock?: boolean;
+}
+
+/**
+ * Click the editor's back chevron and land on the flows list.
+ *
+ * Replaces the bare `getByTestId("icon-ChevronLeft").click()` plus a home
+ * assertion. On the happy path it costs the save barrier plus one visibility
+ * poll; it only pays the grace window when the blocker actually shows up.
+ *
+ * The closing assertion is unconditional, so a navigation that genuinely never
+ * happens still fails the caller.
+ *
+ * Only valid for editors whose exit target is the default flows list — the
+ * chevron's own handler is `navigate("/")`. A caller that exits into a specific
+ * folder view needs its own assertion, not this helper.
+ */
+export async function leaveFlowEditor(
+  page: Page,
+  { escapeDeadlock = false }: LeaveFlowEditorOptions = {},
+): Promise<EditorExitVerdict> {
+  // Prevention. `useBlocker(changesNotSaved || isBuilding)` only fires when the
+  // store has diverged from what is persisted, so draining the in-flight saves
+  // first keeps most exits out of the blocked state. Request-aware, not a
+  // silence probe (#995), so a PATCH already issued still holds the barrier.
+  await waitForFlowSaveSettled(page);
+
+  const home = page.getByTestId(HOME_MARKER).first();
+  // Scoped to the dialog and `.first()`: an unscoped `getByText` that matched
+  // two nodes would raise a strict-mode violation, which the `.catch()` below
+  // swallows into "not visible" — silently downgrading every deadlock to
+  // `stuck`, i.e. losing exactly the attribution this helper exists for.
+  const blocker = page
+    .locator('[role="dialog"]')
+    .getByText(BLOCKER_TITLE)
+    .first();
+
+  await page.getByTestId("icon-ChevronLeft").first().click();
+
+  // Poll both rather than awaiting either: a `waitFor` on the blocker would pay
+  // its full timeout on every healthy exit, and a `waitFor` on home would hide
+  // which of the two failure modes happened.
+  const deadline = Date.now() + BLOCKER_GRACE_MS;
+  let verdict: EditorExitVerdict;
+  for (;;) {
+    verdict = classifyEditorExit({
+      homeVisible: await home.isVisible().catch(() => false),
+      blockerVisible: await blocker.isVisible().catch(() => false),
+      graceExpired: Date.now() >= deadline,
+    });
+    if (verdict !== "pending") break;
+    await page.waitForTimeout(200);
+  }
+
+  if (verdict === "blocked-deadlocked") {
+    if (!escapeDeadlock) {
+      // Thrown, not warned: console output is not attached to the Playwright
+      // failure, and the whole point is that the reason reaches the report.
+      throw new Error(formatEditorExitWarning(BLOCKER_GRACE_MS));
+    }
+    // Loud on purpose — a silent recovery would hide how often #1153 fires,
+    // which is the only signal the suite has on it.
+    console.warn(
+      `${formatEditorExitWarning(BLOCKER_GRACE_MS)} Escaping with a full page ` +
+        `load; anything this flow had unsaved is discarded.`,
+    );
+    await page.goto("/");
+  }
+
+  if (verdict === "stuck") {
+    throw new Error(formatEditorExitStuckFailure(BLOCKER_GRACE_MS));
+  }
+
+  await expect(home).toBeVisible({ timeout: HOME_TIMEOUT_MS });
+  return verdict;
+}

--- a/tests/helpers/flows/leave-flow-editor.ts
+++ b/tests/helpers/flows/leave-flow-editor.ts
@@ -62,12 +62,30 @@ const HOME_MARKER = "home-dropdown-menu";
  */
 export const BLOCKER_GRACE_MS = 15000;
 
-/** Budget for the home list to render, on either path. */
-const HOME_TIMEOUT_MS = 30000;
+/**
+ * How long the flows list may take to render before the exit is called broken.
+ *
+ * Deliberately LONGER than `BLOCKER_GRACE_MS` and tracked as its own deadline:
+ * the two windows answer different questions and collapsing them costs a real
+ * budget. `BLOCKER_GRACE_MS` bounds "the dialog is up and not clearing" — the
+ * one thing the blocker being on screen already tells us. This bounds "nothing
+ * is on screen yet", which is the ordinary in-flight navigation: a client-side
+ * route change plus the listing's own `GET /api/v1/flows/`, and on a saturated
+ * single-backend daily that request is exactly what runs long (#790 measured
+ * 45 s for a single save). The 30 s is inherited, not invented — it is what
+ * `duplicate-flow` and `export-import-flow` already allowed this assertion
+ * before the helper existed.
+ *
+ * Charging the blocker's 15 s to a healthy-but-slow navigation would fail it as
+ * `stuck`, i.e. report the swallowed-click class (#420 / LE-2019) on a run where
+ * the click landed fine — the same mis-attribution this helper exists to end,
+ * only with a confident label instead of a silent timeout.
+ */
+export const HOME_TIMEOUT_MS = 30000;
 
 /** What the exit did, once the click has been made. */
 export type EditorExitVerdict =
-  /** Nothing has resolved yet and the grace window is still open — keep polling. */
+  /** Nothing has resolved yet and its own window is still open — keep polling. */
   | "pending"
   /** Home rendered. */
   | "left"
@@ -88,11 +106,19 @@ export type EditorExitVerdict =
  * still on screen, and they send a reader to opposite places (the #420 /
  * LE-2019 dead-click class vs. this upstream defect). Collapsing them would
  * re-create the unattributed timeout this helper exists to replace.
+ *
+ * The two terminal failures are gated on SEPARATE deadlines, and they must stay
+ * separate. `graceExpired` (`BLOCKER_GRACE_MS`) only ever promotes a dialog that
+ * is already up; `homeBudgetExpired` (`HOME_TIMEOUT_MS`) is the only thing that
+ * may call an empty screen `stuck`. Sharing one deadline would charge the
+ * blocker's short grace window to an ordinary slow navigation and report it as a
+ * dead click.
  */
 export function classifyEditorExit(observed: {
   homeVisible: boolean;
   blockerVisible: boolean;
   graceExpired: boolean;
+  homeBudgetExpired: boolean;
 }): EditorExitVerdict {
   // Home wins even with the dialog still painted: the route changed, which is
   // the only thing the caller asked for. The dialog animates out, so it is
@@ -104,15 +130,25 @@ export function classifyEditorExit(observed: {
   if (observed.blockerVisible) {
     return observed.graceExpired ? "blocked-deadlocked" : "pending";
   }
-  return observed.graceExpired ? "stuck" : "pending";
+  // Nothing on screen is the in-flight navigation, so it gets the full home
+  // budget — NOT the blocker's grace window.
+  return observed.homeBudgetExpired ? "stuck" : "pending";
 }
 
 /**
  * The line a triager reads when the deadlock fires. It has to name the defect,
  * not just the symptom — an unattributed `home-dropdown-menu` timeout is exactly
  * what #1005 spent a 24-run burst re-deriving.
+ *
+ * The window DEFAULTS to the constant this verdict is actually gated on, so the
+ * call sites pass nothing and the unit lane can pin the pairing. Passing it in
+ * left the "which budget does this message quote" wiring as an untested
+ * one-liner — the very drift the test asserting against the real constant was
+ * written to prevent.
  */
-export function formatEditorExitWarning(graceMs: number): string {
+export function formatEditorExitWarning(
+  graceMs: number = BLOCKER_GRACE_MS,
+): string {
   return (
     `[leaveFlowEditor] the editor exit is deadlocked behind SaveChangesModal ` +
     `("${BLOCKER_TITLE}") — it did not clear in ${graceMs}ms, and in autosave ` +
@@ -123,13 +159,22 @@ export function formatEditorExitWarning(graceMs: number): string {
   );
 }
 
-/** Same, for the swallowed-click case — a different cause and a different fix. */
-export function formatEditorExitStuckFailure(graceMs: number): string {
+/**
+ * Same, for the swallowed-click case — a different cause and a different fix.
+ *
+ * Defaults to the HOME budget, not the blocker's grace window: that is the
+ * window this verdict actually waited out, and quoting the shorter one would
+ * understate the evidence behind a claim as specific as "the click never
+ * registered".
+ */
+export function formatEditorExitStuckFailure(
+  homeBudgetMs: number = HOME_TIMEOUT_MS,
+): string {
   return (
     `[leaveFlowEditor] the chevron click did not navigate and nothing is ` +
-    `blocking it: no flows list and no SaveChangesModal after ${graceMs}ms. ` +
-    `This is the swallowed-click class (#420 / LE-2019), NOT the #1153 exit ` +
-    `deadlock — the editor is simply still on screen.`
+    `blocking it: no flows list and no SaveChangesModal after ` +
+    `${homeBudgetMs}ms. This is the swallowed-click class (#420 / LE-2019), ` +
+    `NOT the #1153 exit deadlock — the editor is simply still on screen.`
   );
 }
 
@@ -152,8 +197,12 @@ export interface LeaveFlowEditorOptions {
  * assertion. On the happy path it costs the save barrier plus one visibility
  * poll; it only pays the grace window when the blocker actually shows up.
  *
- * The closing assertion is unconditional, so a navigation that genuinely never
- * happens still fails the caller.
+ * It never shortens the budget the call sites had before it: an exit that is
+ * simply slow keeps the full `HOME_TIMEOUT_MS`, and only a dialog that is
+ * demonstrably on screen is judged on the shorter `BLOCKER_GRACE_MS`.
+ *
+ * Every path either throws with the cause named or ends on the closing
+ * assertion, so a navigation that never happened cannot be reported as an exit.
  *
  * Only valid for editors whose exit target is the default flows list — the
  * chevron's own handler is `navigate("/")`. A caller that exits into a specific
@@ -184,13 +233,20 @@ export async function leaveFlowEditor(
   // Poll both rather than awaiting either: a `waitFor` on the blocker would pay
   // its full timeout on every healthy exit, and a `waitFor` on home would hide
   // which of the two failure modes happened.
-  const deadline = Date.now() + BLOCKER_GRACE_MS;
+  //
+  // Two deadlines, not one. The blocker's grace window is short because a dialog
+  // that is already up is evidence in itself; an empty screen is just an
+  // in-flight navigation and gets the full home budget. Sharing one deadline
+  // would fail a slow-but-healthy exit as a dead click.
+  const blockerDeadline = Date.now() + BLOCKER_GRACE_MS;
+  const homeDeadline = Date.now() + HOME_TIMEOUT_MS;
   let verdict: EditorExitVerdict;
   for (;;) {
     verdict = classifyEditorExit({
       homeVisible: await home.isVisible().catch(() => false),
       blockerVisible: await blocker.isVisible().catch(() => false),
-      graceExpired: Date.now() >= deadline,
+      graceExpired: Date.now() >= blockerDeadline,
+      homeBudgetExpired: Date.now() >= homeDeadline,
     });
     if (verdict !== "pending") break;
     await page.waitForTimeout(200);
@@ -200,21 +256,32 @@ export async function leaveFlowEditor(
     if (!escapeDeadlock) {
       // Thrown, not warned: console output is not attached to the Playwright
       // failure, and the whole point is that the reason reaches the report.
-      throw new Error(formatEditorExitWarning(BLOCKER_GRACE_MS));
+      throw new Error(formatEditorExitWarning());
     }
     // Loud on purpose — a silent recovery would hide how often #1153 fires,
     // which is the only signal the suite has on it.
     console.warn(
-      `${formatEditorExitWarning(BLOCKER_GRACE_MS)} Escaping with a full page ` +
-        `load; anything this flow had unsaved is discarded.`,
+      `${formatEditorExitWarning()} Escaping with a full page load; anything ` +
+        `this flow had unsaved is discarded.`,
     );
+    // Load-bearing Playwright default: `FlowPage` registers a `beforeunload`
+    // that calls `preventDefault()` whenever `changesNotSaved || isBuilding` —
+    // i.e. always, on this path. The load only completes because Playwright
+    // ACCEPTS beforeunload dialogs when no `page.on("dialog")` handler is
+    // registered (`dialog.close()` → `accept()` for that type, `dismiss()` for
+    // every other). No spec in this repo registers one; the first that does
+    // would silently turn this escape into a cancelled navigation.
     await page.goto("/");
   }
 
   if (verdict === "stuck") {
-    throw new Error(formatEditorExitStuckFailure(BLOCKER_GRACE_MS));
+    throw new Error(formatEditorExitStuckFailure());
   }
 
+  // Reached only with home already visible (`left` / `blocked-settled`) or right
+  // after the escape's page load, so this never stacks a second full budget on
+  // top of the poll above. Kept unconditional so the helper cannot return a
+  // verdict it did not actually observe.
   await expect(home).toBeVisible({ timeout: HOME_TIMEOUT_MS });
   return verdict;
 }

--- a/tests/tests-automations/regression/flow-functionality/duplicate-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/duplicate-flow.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "../../../fixtures/fixtures";
+import { leaveFlowEditor } from "../../../helpers/flows/leave-flow-editor";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
@@ -22,11 +23,15 @@ test(
       timeout: 30000,
     });
 
-    await page.getByTestId("icon-ChevronLeft").first().click();
-
-    await expect(page.getByTestId("home-dropdown-menu").first()).toBeVisible({
-      timeout: 30000,
-    });
+    // Back to the listing through the helper: the bare chevron click can land
+    // behind `SaveChangesModal`, which in autosave mode offers no confirm or
+    // cancel and can spin indefinitely, turning this into an unattributed
+    // `home-dropdown-menu` timeout (#1153).
+    //
+    // `escapeDeadlock` is safe here: the template flow is already persisted
+    // server-side by the template click, and everything after this line reads
+    // the home listing, so a reload discards nothing this test asserts on.
+    await leaveFlowEditor(page, { escapeDeadlock: true });
 
     const authToken = await getAuthToken(request);
 

--- a/tests/tests-automations/regression/flow-functionality/export-import-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/export-import-flow.spec.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "fs";
+import { leaveFlowEditor } from "../../../helpers/flows/leave-flow-editor";
 import path from "path";
 import type { Page } from "@playwright/test";
 import { expect, test } from "../../../fixtures/fixtures";
@@ -111,11 +112,16 @@ test.describe("Export and Import Flow (IDs 173 + 120)", () => {
         )
         .toBeGreaterThan(0);
 
-      await page.getByTestId("icon-ChevronLeft").click();
-
-      await page.waitForSelector('[data-testid="home-dropdown-menu"]', {
-        timeout: 30000,
-      });
+      // Back to the listing through the helper: the bare chevron click can land
+      // behind `SaveChangesModal`, which in autosave mode offers no confirm or
+      // cancel and can spin indefinitely, turning this into an unattributed
+      // `home-dropdown-menu` timeout (#1153).
+      //
+      // `escapeDeadlock` is safe here — and mildly helpful. The poll above
+      // already proved the node reached the backend, and the export reads the
+      // card's CLIENT-side data, so a reload makes that data fresher rather than
+      // losing it (the axis #518 was about).
+      await leaveFlowEditor(page, { escapeDeadlock: true });
 
       // Arm the download capture BEFORE clicking the export button to avoid a
       // race between the download event and modal interaction.

--- a/tests/tests-automations/regression/flow-functionality/run-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/run-flow.spec.ts
@@ -1,4 +1,5 @@
 import * as dotenv from "dotenv";
+import { leaveFlowEditor } from "../../../helpers/flows/leave-flow-editor";
 import path from "path";
 import { expect, test } from "../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
@@ -127,7 +128,18 @@ test(
       // select it deterministically by name (issue #340).
       await renameFlow(page, { flowName: targetFlowName });
 
-      await page.getByTestId("icon-ChevronLeft").click();
+      // Back to the listing through the helper: the bare chevron click can land
+      // behind `SaveChangesModal` and spin indefinitely (#1153), and this call
+      // site had nothing waiting on the navigation at all — so a blocked exit
+      // surfaced downstream inside `openNewFlowTemplatesModal`, i.e. wearing
+      // LE-2019's signature on a run where LE-2019 was not what happened.
+      //
+      // NO `escapeDeadlock` here, deliberately. The recovery is a full page
+      // load, and everything the rest of this test asserts lives in the flow
+      // built on the canvas above; discarding it would trade a clean, attributed
+      // failure at the exit for an inscrutable one ~90 s later at the Run Flow
+      // dropdown. The helper throws with the reason instead.
+      await leaveFlowEditor(page);
 
       await openNewFlowTemplatesModal(page);
 


### PR DESCRIPTION
Closes #1153

## The defect

Clicking the editor's back chevron with a diverged store trips react-router's
`useBlocker` and renders `SaveChangesModal`. In **autosave mode** that dialog
offers no confirm and no cancel — upstream passes `loading` hardcoded `true` and
leaves `confirmationText`/`cancelText`/`onConfirm` undefined, so
`ConfirmationModal` renders no footer at all. That leaves `FlowPage.handleSave`
as the only thing that can complete the navigation:

```ts
const handleSave = () => {
  let saving = true; let proceed = false;
  setTimeout(() => { saving = false; if (proceed) blocker.proceed?.() }, 1200);
  saveFlow().then(() => {
    if (!autoSaving || saving === false) blocker.proceed?.();
    proceed = true;
  });                                     // <- no .catch()
};
```

A save that fails or never settles never runs the `.then`, so `proceed` stays
false, the 1200 ms timeout finds it false and does nothing, and the dialog spins
indefinitely.

**Reproduced deterministically** on `1.12.0.dev10` by aborting every flow-save
PATCH and clicking the chevron:

```
blocker modal appeared:            true
modal cleared within 30s:          false
url after:                         http://localhost:7860/flow/{id}   <- exit deadlocked
confirm/cancel buttons in dialog:  0
flow PATCHes observed:             8x "PATCH FAILED"
```

Under natural load it fired **2 in 24 runs at `--workers=4`** during #1005's
investigation, where it read as an unattributed `home-dropdown-menu` timeout —
which is the whole cost: the failure names nothing.

The dialog *does* render `BaseModal`'s default X (Escape works too), so a human
is not trapped on screen — but both route to `blocker.reset()`, which returns
them to the editor. Dismissing is possible; **leaving is not.** (The issue body
originally claimed zero buttons; corrected there.)

## The change

`tests/helpers/flows/leave-flow-editor.ts`, following `renameFlow`'s #995
contract — **prevention first, recovery last, loud either way**:

- **Prevention.** Drains in-flight flow saves before the click.
  `changesNotSaved` is exactly what `useBlocker` gates on, so a settled store
  keeps the exit out of the blocked state entirely. Measured: the healthy path
  went from *reaching the dialog and waiting it out* (`blocked-settled`) to
  **never rendering it** — verdict `left`, 2.1 s.
- **Attribution.** Distinguishes the deadlock from a swallowed click (the #420 /
  LE-2019 class). Both leave the editor on screen and they send a reader to
  opposite places; collapsing them re-creates the unattributed timeout. Each gets
  its own message, and the deadlock message rules the other one out by name.
- **Recovery is opt-in.** The escape is a full page load, which discards whatever
  the editor had unsaved. Callers whose later assertions depend on that state get
  an attributed **throw** instead — strictly better than the same failure ~90 s
  downstream. The text is thrown, not warned: console output is not attached to
  the Playwright failure.

| Adopter | `escapeDeadlock` | Why |
|---|---|---|
| `duplicate-flow.spec.ts` | **on** | the template flow is already persisted server-side; everything after reads the home listing |
| `export-import-flow.spec.ts` | **on** | persistence was already proven by an `expect.poll` on `GET /api/v1/flows/{id}`, and export reads the card's *client-side* data — a reload makes it fresher (the #518 axis) |
| `run-flow.spec.ts` | **off** | everything the rest asserts lives in the canvas flow; discarding it would trade a clean failure at the exit for an inscrutable one at the Run Flow dropdown |

## Validation

Local instance, **Langflow Nightly 1.12.0.dev10**.

| Path | Result |
|---|---|
| Deadlocked, `escapeDeadlock: true` | verdict `blocked-deadlocked`, warns with the full mechanism, recovers to `/flows` |
| Deadlocked, default | **throws**, message contains `#1153` and the `no .catch()` mechanism |
| Healthy | verdict **`left`, 2.1 s**, zero warnings — the dialog never appears |
| Three adopting specs | **6 passed** |

**Force-fail — executed, reverted** (`grep FF-MUTATION` → 0 hits):

- `FF:` classifier's deadlock branch → `"stuck"` → unit test *"the dialog past
  the grace window is the #1153 deadlock"* fails
- `FF:` remove the escape → the unconditional closing assertion fails at
  `leave-flow-editor.ts:156`, proving both the escape and the assertion are
  load-bearing

Gates: `tsc --noEmit` clean; eslint 0 errors; `npm run test:units` **225 pass**
(215 → 225); `npm run test:scripts` 169 pass; checklist coverage + guard pass.

The one `🚨 Backend Error: 500 POST /api/v1/flows/` in the spec run is Langflow's
non-transactional name suffixing under concurrent creation (#588), present on the
base branch too.

## Review

Reviewed independently before opening. Findings applied:

- The `stuck` verdict produced no warning and no throw — attribution was *worse*
  than before, by the length of the grace window. Now throws with its own message.
- `sawBlocker` promised to expose the near-miss rate and had **zero** observable
  effect (no call site reads the return). Dropped, along with the claim.
- The grace window was 8 s, below this repo's save budgets (`renameFlow` 15 s;
  #790 needed 45 s under saturation). Raised to 15 s, with a unit test pinning
  the floor.
- The blocker locator was an unscoped `getByText`; a strict-mode violation would
  be swallowed by the `.catch()` and silently downgrade every deadlock to
  `stuck`. Now scoped to `[role="dialog"]` + `.first()`.
- The `renameFlow` precedent was cited for recovery when it is really about
  prevention. The save barrier is the missing half, and it is the change with the
  largest measured effect.
- `run-flow`'s escape could discard state the test needs — hence opt-in.
- Docs: the new section split LE-2019's verdict paragraph from its evidence;
  `run-flow.md`'s mandatory step list was not updated; all three docs were
  missing the helper (and the upstream files it depends on) under **External
  dependencies**, which `file-watcher.yml` reads; two had a stale
  `Last validated`.

## Scope left open

~10 of the 25 `icon-ChevronLeft` references are true editor exits. This helper
hardcodes `.first()` and the flows-list target, so sites using `.last()` or
exiting into a folder view (`folder-deletion-integrity.spec.ts`) need a
parameterised version first. `auto-save-off.spec.ts` is excluded **on purpose** —
with autosave OFF the dialog *does* render buttons and that spec asserts on them.
The remaining at-risk sites are listed on #1153 for a follow-up; the two most
exposed (`edit-flow-name.spec.ts`, `general-bugs-save-changes-on-node.spec.ts`)
are touched by open PRs #1152 and #1155 and would conflict here.
