### PR TITLE
ci(triage): give the contract guard's sweep an on-demand entry and guard its wiring (#1037)

### DIFF
--- a/.github/workflows/issue-contract-guard.yml
+++ b/.github/workflows/issue-contract-guard.yml
@@ -17,8 +17,9 @@ on:
     # `edited` closes the loop: fixing the body re-runs the check, and the guard
     # comment is updated in place rather than a new one being appended.
     types: [opened, edited]
-  # Manual entry: run the identical composite action against a chosen issue,
-  # printing the verdict without mutating it by default.
+  # Manual entry: run the identical composite action against a chosen issue, or
+  # over a `since` window, printing the verdict without mutating anything by
+  # default.
   #
   # NOTE on what this does and does not buy. GitHub requires a workflow_dispatch
   # workflow to exist on the DEFAULT branch before it can be dispatched at all
@@ -26,11 +27,23 @@ on:
   # it. What it does buy, from here on: every later change to this guard is
   # testable from its own branch (`gh workflow run ... --ref <branch>`), and the
   # guard can be re-run on demand against any issue.
+  #
+  # `since` exists because the SWEEP path had no on-demand entry at all (#1037).
+  # That path only ever runs as an inline post-step of triage-dispatch.yml's
+  # `execute` job, which fires on a human "pode abrir" after a red daily — and in
+  # the automation's whole lifetime that has happened ZERO times (every
+  # triage-dispatch run to date is a `propose`). So the one code path documented as
+  # failing silently by construction was also the only one that could not be
+  # exercised. Dispatching it here runs the identical composite action, on a real
+  # runner, against real issues, and prints `Contract guard: N checked, …`.
   workflow_dispatch:
     inputs:
       issue:
-        description: "Issue number to check"
-        required: true
+        description: "Issue number to check. Leave empty when using `since`."
+        required: false
+      since:
+        description: "ISO-8601 timestamp (e.g. 2026-07-30T11:34:00Z) — sweep every daily-failure issue created at or after it. Mutually exclusive with `issue`."
+        required: false
       dry_run:
         description: "Print the verdict without commenting or labelling"
         type: boolean
@@ -58,12 +71,26 @@ jobs:
     timeout-minutes: 5
     concurrency:
       # An edit burst must not race itself into duplicate comments.
-      group: issue-contract-guard-${{ github.event.issue.number || inputs.issue }}
+      # A sweep has no issue number, so it groups by run id instead of collapsing
+      # every dispatched sweep onto one cancel-in-progress group.
+      group: issue-contract-guard-${{ github.event.issue.number || inputs.issue || github.run_id }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
+
+      # The action prefers `issue` when both arrive, which would silently ignore a
+      # `since` the dispatcher typed. Say so instead — a guard that quietly checks
+      # something other than what was asked is the class of bug #1037 is about.
+      - name: Reject an ambiguous dispatch
+        if: github.event_name == 'workflow_dispatch' && inputs.issue != '' && inputs.since != ''
+        run: |
+          echo "::error::pass either issue or since, not both — the action would use issue and ignore since."
+          exit 1
+
       - uses: ./.github/actions/guard-dedicated-issue
         with:
           issue: ${{ github.event.issue.number || inputs.issue }}
+          # Empty on the `issues` path, so single-issue behaviour is unchanged.
+          since: ${{ inputs.since }}
           dry_run: ${{ inputs.dry_run || false }}
           github_token: ${{ github.token }}

--- a/scripts/select-dedicated-issues.test.mjs
+++ b/scripts/select-dedicated-issues.test.mjs
@@ -12,10 +12,15 @@
 // (`date -u -d '-1 minute' +%Y-%m-%dT%H:%M:%SZ`).
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
 import {
   isAtOrAfter,
   selectDedicatedIssues,
 } from "./select-dedicated-issues.mjs";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "..");
+const readWorkflow = (name) => fs.readFileSync(path.join(REPO_ROOT, ".github/workflows", name), "utf8");
 
 // The four dedicated issues the 2026-07-30 triage actually created, plus that
 // day's umbrella — the data this selection was verified against by hand.
@@ -142,4 +147,61 @@ test("an empty list is handled without throwing, and still warns", () => {
   assert.equal(result.scanned, 0);
   assert.equal(result.oldestScanned, null);
   assert.match(result.warnings.join(" "), /NOTHING selected/);
+});
+
+// ── Agent-path wiring ───────────────────────────────────────────────────────
+//
+// The selection above is only reached if the step that calls it is still wired
+// into `triage-dispatch.yml`'s `execute` job, in the right place, with the right
+// window. That wiring has NEVER executed: every triage-dispatch run to date is a
+// `propose` (the `execute` job needs a red daily plus a human "pode abrir"), so
+// nothing but these assertions stands between a broken wiring and a green log.
+
+test("the execute job stamps the window BEFORE the agent runs", () => {
+  // Order is the whole contract: a timestamp taken after the agent would exclude
+  // every issue the agent had already created, and the sweep would check zero
+  // while reporting success.
+  const text = readWorkflow("triage-dispatch.yml").split("\n");
+  const execute = text.findIndex((l) => l.startsWith("  execute:"));
+  assert.ok(execute > -1, "no `execute` job");
+
+  const stamp = text.findIndex((l, i) => i > execute && l.includes("id: started"));
+  const agent = text.findIndex((l, i) => i > execute && l.includes("anthropics/claude-code-action"));
+  const guard = text.findIndex((l, i) => i > execute && l.includes("uses: ./.github/actions/guard-dedicated-issue"));
+
+  assert.ok(stamp > -1 && agent > -1 && guard > -1, "stamp, agent or guard step missing from the execute job");
+  assert.ok(stamp < agent, "the window must be stamped BEFORE the agent creates the issues");
+  assert.ok(agent < guard, "the guard must run AFTER the agent, or there is nothing to check yet");
+});
+
+test("the guard's since input is bound to the stamped window, not to a literal", () => {
+  const text = readWorkflow("triage-dispatch.yml");
+  assert.match(text, /since: \$\{\{ steps\.started\.outputs\.at \}\}/);
+  // The stamp's own shape is load-bearing: `select-dedicated-issues` parses it as
+  // an instant, and the minute of slack absorbs runner/API clock skew.
+  assert.match(text, /date -u -d '-1 minute' \+%Y-%m-%dT%H:%M:%SZ/);
+});
+
+test("the guard reports without blocking, and runs even when the agent died", () => {
+  // `if: always()` — a triage that failed mid-way can still have created issues,
+  // and those are precisely the ones worth checking. `continue-on-error` — a
+  // malformed issue still carries evidence, so it gets a comment, not a red job.
+  const lines = readWorkflow("triage-dispatch.yml").split("\n");
+  const guard = lines.findIndex((l) => l.includes("uses: ./.github/actions/guard-dedicated-issue"));
+  const block = lines.slice(Math.max(0, guard - 4), guard + 4).join("\n");
+  assert.match(block, /if: always\(\)/);
+  assert.match(block, /continue-on-error: true/);
+});
+
+test("the sweep path has an on-demand entry, so it is not only provable by coincidence", () => {
+  // #1037's actual blocker: the sweep could only ever run inside a live `execute`,
+  // an event that has not occurred once. `issue-contract-guard.yml` accepts a
+  // `since` dispatch so the identical composite action can be exercised on real
+  // issues from a branch, dry-run by default.
+  const text = readWorkflow("issue-contract-guard.yml");
+  assert.match(text, /^ {6}since:$/m, "no `since` dispatch input");
+  assert.match(text, /since: \$\{\{ inputs\.since \}\}/, "the since input is not passed to the action");
+  // Both inputs at once would silently check the issue and ignore the window.
+  assert.match(text, /Reject an ambiguous dispatch/);
+  assert.match(text, /dry_run:[\s\S]*default: true/, "a dispatch must not mutate issues unless asked");
 });


### PR DESCRIPTION
Closes #1037.

## What #1037 asked, and why it had not happened

Verify the dedicated-issue contract guard on the **agent path** — the inline
post-step of `triage-dispatch.yml`'s `execute` job that sweeps every
`daily-failure` issue created since a stamped window.

It had not happened, and the reason is structural rather than forgetfulness:
**that job has never run.** Every `triage-dispatch.yml` run in the automation's
lifetime is a `propose` (3 runs via `workflow_run`; every other run is
`skipped`). `execute` fires only on a human `pode abrir` comment on an umbrella,
which itself needs a red daily. So the one code path the issue documents as
*failing silently by construction* was also the only one with no way to exercise
it — waiting longer was not going to fix that.

## Change

1. **`issue-contract-guard.yml` accepts a `since` dispatch input.** The sweep now
   has an on-demand entry: the identical composite action, on a real runner,
   against real issues, from any branch, `dry_run: true` by default. Before this,
   the dispatch supported single-issue mode only — the *sweep* had no entry at
   all. Passing both `issue` and `since` is rejected instead of silently checking
   the issue and ignoring the window (the action prefers `issue`).

2. **Four wiring assertions** in `scripts/select-dedicated-issues.test.mjs`, over
   `triage-dispatch.yml` — covering what a tested selection function cannot:
   - the window is stamped **before** the agent runs. A stamp taken after it
     would exclude every issue the agent had already created, and the sweep would
     check zero while reporting success;
   - the guard step runs **after** the agent;
   - `since` is bound to `steps.started.outputs.at`, not to a literal, and the
     stamp keeps its `date -u -d '-1 minute' +%Y-%m-%dT%H:%M:%SZ` shape (the
     selection parses it as an instant; the minute absorbs clock skew);
   - the step keeps `if: always()` + `continue-on-error` — a triage that died
     mid-way can still have created issues, and a malformed issue must not kill
     the run.

## Verification

Both dispatched against **real production data** on this branch, `dry_run: true`
(nothing commented, nothing labelled):

[Run 30588063719](https://github.com/oriontech-me/langflow-e2e/actions/runs/30588063719) — the agent path's own window shape, one minute before the
2026-07-30 triage created its issues:

```
since=2026-07-30T11:34:00Z: scanned 100 daily-failure issue(s) (oldest 2026-07-07T12:18:24Z), 4 in window.
#1126 — ok
#1125 — ok
#1124 — ok
#1123 — ok
Contract guard: 4 checked, 0 invalid, 0 unevaluable.
```

[Run 30588106180](https://github.com/oriontech-me/langflow-e2e/actions/runs/30588106180) — widened to span that day's umbrella, to exercise the
title-based exclusion:

```
since=2026-07-30T10:00:00Z: scanned 100 daily-failure issue(s) (oldest 2026-07-07T12:18:24Z), 5 in window.
#1126 — ok  #1125 — ok  #1124 — ok  #1123 — ok
#1121 — skipped (umbrella)
Contract guard: 4 checked, 0 invalid, 0 unevaluable.
```

Against #1037's `Done when`: **N > 0** with the four issues the triage actually
created ✅ · umbrella `skipped (umbrella)`, not counted invalid ✅ · **0
unevaluable** ✅ · no false positives — the four real bodies pass the contract ✅

Unit lane: `npm run test:scripts` → **201 pass, 0 fail** (14 in this file). Both
new guards were **force-failed**: rebinding `since` to a literal, moving the
guard above the agent, and dropping the dispatch input each turn a specific test
red. Both workflows parse.

## One correction to #1037's checklist

> the day's umbrella listed as `skipped (umbrella)`, not counted as invalid

Not observable on the live agent path. The umbrella is always created *before*
the `pode abrir` that starts the execute run, so it falls outside `since` by
**time** and never reaches the title-based exclusion — visible in the first run
above, where the window selected 4 issues and no umbrella. It is observable in a
wider dispatched sweep (second run) and in single-issue mode. Worth keeping in
mind so a future reader does not treat its absence as a broken exclusion.

## What remains unproven

That the step fires **in position, inside a live `execute` job**, after
`claude-code-action`. That needs a red daily plus a human `pode abrir`, and no
such run has ever existed. The wiring is now asserted by the tests above instead
of merely intended, and the sweep itself is proven on real data — what is left is
a live smoke, not a correctness question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
