### PR TITLE
fix(llm-agents): gate agent-max-tokens on a model-agnostic completion signal (#1059)

### DIFF
--- a/docs/core-functionality/llm-agents/agent-max-tokens.md
+++ b/docs/core-functionality/llm-agents/agent-max-tokens.md
@@ -1,6 +1,6 @@
 # Agent max_tokens — caps generated output as configured
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x
 
 ---
 
@@ -55,8 +55,11 @@ the token-usage observable live in the Playground.
 - `models.json` / `providers.json` generated via
   `npx playwright test tests/collect-models.spec.ts`.
 - At least one active provider API key in `.env`.
-- Run with `--workers=1` — the spec is serial
-  (`SimpleAgentTemplatePage.load()` wipes all flows).
+- Run with `--workers=1` — the spec is serial: every test loads the Simple Agent
+  template into the shared instance and runs it in the shared Playground.
+  `SimpleAgentTemplatePage.load()` does **not** wipe existing flows (the
+  cross-worker wipe left in #553); cleanup is id-scoped via the shared tracker
+  (see *Notes* → flow cleanup).
 
 ---
 
@@ -81,11 +84,14 @@ Shared setup per test:
    race — see `agent-multimodal-image-input.md`): *"Write a detailed 500-word
    essay about the history of the ocean. Do not use any tools — answer
    directly."*
-5. Open the Playground, send, and wait for completion on the
-   `chat-message-token-usage` badge count.
-6. Hover the badge and read the **Output** token count from its tooltip
-   (`Input: 1.0K / Output: 46` format; values may be plain integers, `N.NK`,
-   or empty ⇒ 0).
+5. Open the Playground, send, and wait for completion on a **model-agnostic**
+   signal: the turn mounts (`div-chat-message` count rises) and the generating
+   indicator clears (`button-stop` hidden, `button-send` back). The
+   `chat-message-token-usage` badge is **not** the completion gate — see the
+   note on #1059/#569 below.
+6. Assert the badge exists (the `max_tokens` observable), then hover it and read
+   the **Output** token count from its tooltip (`Input: 1.0K / Output: 46`
+   format; values may be plain integers, `N.NK`, or empty ⇒ 0).
 
 ---
 
@@ -138,6 +144,13 @@ Shared setup per test:
   was intentionally **removed** (see the model-agnostic note below): it
   measured model verbosity, not the `max_tokens` contract, and produced a
   false negative on thinking models.
+- **Completion is proven before the observable is read** (#1059): the badge is
+  asserted only after the turn has demonstrably finished, so "still generating",
+  "finished without a badge" and "finished with an error" are three distinct
+  failures with three distinct messages instead of one blind
+  `toHaveCount … Received: 0`. A false positive is impossible in the other
+  direction too — the badge assertion is a hard `toHaveCount(1)`, never skipped
+  when absent.
 - **Force-failure check** (CONTRIBUTING §2) run during VERIFY on each hard
   assertion before `@stable`.
 
@@ -172,6 +185,9 @@ Shared setup per test:
 - If the node field testid changes from `int_int_max_tokens`.
 - If the token-usage tooltip format changes (`Output:` label, `N.NK`
   abbreviation).
+- If the Playground's generating indicator changes (`button-stop` /
+  `button-send` / `div-chat-message`) — that is the completion gate now, shared
+  in shape with `memory-history-regression.spec.ts`.
 - If the Agent regains a temperature/reasoning parameter (re-scope the §7.7
   bullets and extend this spec).
 
@@ -208,6 +224,43 @@ Shared setup per test:
   load. The floor was removed so the causal proof is token-level and holds for
   any collected model. `openai`/`anthropic` remain a real essay; that is a
   model trait, not a contract the suite pins.
+- **The token-usage badge is the observable, never the completion gate
+  (#1059 → #569).** The spec used to wait for
+  `chat-message-token-usage` to reach count 1 as its "response finished" signal.
+  That conflates three different states into one message — still generating,
+  finished without a badge, finished with an error — and reports all three as
+  `expect(locator).toHaveCount(expected) failed / Received: 0` after 120 s, with
+  the preceding Stop-button wait swallowed by a `.catch(() => {})`. **#569 had
+  already root-caused this exact pattern** on `memory-history-regression.spec.ts`:
+  not every model/response emits the badge, so its count can sit below the
+  expected value for the full budget even though the response has already
+  rendered. The completion gate is now the same model-agnostic pair that spec
+  uses (turn mounts → `button-stop` hidden → `button-send` back), and the badge
+  is asserted afterwards with a message that names it as a missing observable and
+  prints the reply that did render. Timeouts were **not** loosened (the total
+  budget went from ~248 s to ~205 s) and no assertion was weakened — only the
+  attribution changed.
+- **Where the #1059 signature came from.** The filed hard failure (daily
+  2026-07-29, `anthropic / claude-sonnet-5`) was **environmental collateral**, not
+  a product regression: attempt 0 of that very test died on the day's dominant
+  `GET /api/v1/auto_login` 20 s timeout (#1030), attempts 1–2 burned 231 s / 215 s
+  inside the run step, and ~15 unrelated specs failed on the same timeout in a
+  continuous 10:46→11:14 window. The next clean daily (2026-07-30, 466 passed /
+  2 hard, guard untripped) ran the same variant green twice (31 s, 35 s). The
+  issue's "recurrent same-signature on 07-13" reading does not hold: 07-13 was
+  **google / gemini-2.5-flash** failing the since-removed word-count floor
+  (`> 200` got 16 — the #866 family); `daily-history.jsonl` records only the
+  **last** attempt's signature, which is why that day was filed under
+  `toHaveCount`. 07-22 shows the same opaque `Received: 0` on google — also a
+  guard day. So the signature marks a weak wait, and load is what exposes it.
+- **Flow cleanup is captured from the creation POST, not from `load()`'s return
+  value** (#1108's shared tracker). The previous `afterEach` only knew the id
+  `SimpleAgentTemplatePage.load()` *returned*, so a `load()` that throws **after**
+  creating the flow leaked it — and the #751/#1072 credential-settle guard throws
+  exactly there. Measured while working #1059: one orphan `Simple Agent` per
+  failed load, on both local bursts (purged by hand). `trackCreatedFlows` records
+  every `POST /api/v1/flows` → 201 the page makes, so the flow is deleted
+  id-scoped regardless of where the setup died. Never a delete-all sweep (#553).
 - **Runtime honors the parameter** (verified two ways on dev33: an API run
   with a `max_tokens: 50` tweak returned an empty reply, and the UI-saved
   value produced Output = 46 ≤ 50), so unlike #481/#482 there is no

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-max-tokens.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-max-tokens.spec.ts
@@ -5,8 +5,7 @@ import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
-import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
-import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { trackCreatedFlows } from "../../../../helpers/flows/track-created-flows";
 import {
   closeAdvancedOptions,
   openAdvancedOptions,
@@ -117,23 +116,28 @@ function getTestTargets(): TestTarget[] {
   }));
 }
 
-// Ids of flows created by loadAgent — deleted id-scoped in afterEach.
-// SimpleAgentTemplatePage.load() no longer wipes existing flows (the cross-worker
-// wipe was removed in #553), so each loaded template persists until cleaned up.
-const createdFlowIds: string[] = [];
+// Id-scoped flow cleanup via the shared tracker (#1108). It captures every
+// `POST /api/v1/flows` → 201 the page makes, which is what the previous
+// `afterEach` could not: that one only knew the id `load()` RETURNED, so a
+// `load()` throwing AFTER creating the flow leaked it — and the #751/#1072
+// credential-settle guard throws exactly there. Measured while working #1059: one
+// orphan `Simple Agent` per failed load, on both local bursts.
+// SimpleAgentTemplatePage.load() does not wipe existing flows (the cross-worker
+// wipe left in #553), and this is never a delete-all sweep either.
+let flows: ReturnType<typeof trackCreatedFlows>;
+
+test.beforeEach(({ page }) => {
+  flows = trackCreatedFlows(page);
+});
 
 test.afterEach(async ({ request }) => {
-  if (createdFlowIds.length === 0) return;
-  const bearer = await getAuthToken(request);
-  for (const id of createdFlowIds.splice(0)) {
-    await deleteFlow(request, id, { headers: { Authorization: bearer } });
-  }
+  await flows.cleanup(request);
+  flows.dispose();
 });
 
 async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
   try {
-    const flowId = await new SimpleAgentTemplatePage(page).load(options);
-    createdFlowIds.push(flowId);
+    await new SimpleAgentTemplatePage(page).load(options);
   } catch (e: any) {
     if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);
     throw e;
@@ -195,7 +199,17 @@ async function getSavedMaxTokens(page: Page): Promise<unknown> {
 // Seed the prompt on the ChatInput node (the Playground prefill re-injects the
 // template default asynchronously and would corrupt typed text — see
 // agent-multimodal-image-input.md), then send it and wait for the response to
-// complete (token-usage badge renders only on completion).
+// complete on a MODEL-AGNOSTIC signal before touching the token-usage badge.
+//
+// The badge count used to BE the completion gate, which is what made #1059
+// unattributable: "still generating", "finished without a badge" and "finished
+// with an error" all surfaced as `toHaveCount … Received: 0` after 120 s, with the
+// Stop-button wait before it swallowed by a `.catch(() => {})`. #569 had already
+// root-caused that exact pattern on memory-history-regression.spec.ts — not every
+// model/response emits the badge, so its count cannot mean "done". Gate on the
+// same pair that spec uses (the turn mounts, then the generating indicator
+// clears), then assert the badge separately so each failure names its own cause.
+// No timeout was loosened: the worst case went from ~248 s to ~205 s.
 async function runPrompt(page: Page): Promise<string> {
   const node = page.locator(
     '[data-testid^="rf__node-ChatInput"] [data-testid="textarea_str_input_value"]',
@@ -208,15 +222,35 @@ async function runPrompt(page: Page): Promise<string> {
 
   await page.getByTestId("playground-btn-flow-io").click();
   await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({ timeout: 30000 });
+
+  const messages = page.getByTestId("div-chat-message");
+  const before = await messages.count();
   await page.getByTestId("button-send").last().click();
 
-  const stop = page.getByRole("button", { name: "Stop" });
-  if (await stop.isVisible({ timeout: 8000 }).catch(() => false)) {
-    await stop.waitFor({ state: "hidden", timeout: 120000 }).catch(() => {});
-  }
-  await expect(page.getByTestId("chat-message-token-usage")).toHaveCount(1, { timeout: 120000 });
+  // 1. The turn actually started — guards the "checked completion before
+  //    generation started" race that an indicator-only wait returns early on
+  //    (#354). `toBeGreaterThan` rather than an exact count, so it holds whether
+  //    or not the user bubble carries this testid.
+  await expect
+    .poll(() => messages.count(), { timeout: 60000 })
+    .toBeGreaterThan(before);
+  // 2. Generation finished. This is the completion signal because it is emitted
+  //    for every model and every response (#569).
+  await expect(page.getByTestId("button-stop")).toBeHidden({ timeout: 120000 });
+  await expect(page.getByTestId("button-send").last()).toBeVisible({ timeout: 10000 });
 
-  return (await page.getByTestId("div-chat-message").last().innerText()).trim();
+  const reply = (await messages.last().innerText()).trim();
+
+  // 3. Only now the observable itself. A finished turn that renders no badge is a
+  //    MISSING OBSERVABLE, not a slow model — and the message says so, quoting the
+  //    reply that did render (an error bubble included) instead of timing out blind.
+  await expect(
+    page.getByTestId("chat-message-token-usage"),
+    `the finished response must expose a token-usage badge — it is the max_tokens ` +
+      `observable this spec reads. Rendered reply: ${reply.slice(0, 300)}`,
+  ).toHaveCount(1, { timeout: 15000 });
+
+  return reply;
 }
 
 // "1.9K" -> 1900, "46" -> 46, missing/empty -> 0 (a tight cap can be fully
@@ -248,7 +282,7 @@ const targets = getTestTargets();
 // Each test loads the Simple Agent template (creating a flow) and runs it in the
 // shared Playground; serial mode + --workers=1 keeps that shared instance state
 // deterministic and avoids named-flow collisions. Flows are deleted id-scoped in
-// afterEach (load() no longer wipes them — see #553).
+// afterEach from the tracker above (load() does not wipe them — see #553).
 test.describe.configure({ mode: "serial" });
 
 for (const { label, options, skipReason } of targets) {


### PR DESCRIPTION
**Fixes #1059.**

## Problem

The filed hard failure — `causal control — unset max_tokens generates freely` on
`anthropic / claude-sonnet-5`, daily 2026-07-29 ([run 30444299314](https://github.com/oriontech-me/langflow-e2e/actions/runs/30444299314)),
`toHaveCount … Received: 0` after all 3 attempts — is **environmental collateral,
not a product regression**:

- Attempt 0 of that very test died on the day's dominant `GET /api/v1/auto_login`
  20 s timeout (#1030). Attempts 1–2 burned **231 s / 215 s inside the run step**.
- Correlated collapse: from 10:46:12 to 11:13:59, ~15 unrelated specs failed on
  the same `auto_login` timeout. The test's failure window (11:00:43 → 11:11:38)
  sits inside it.
- The next **clean** daily (2026-07-30, 466 passed / 2 hard, guard untripped) ran
  the same variant **green twice** (31 s, 35 s).

**The issue's "recurrent same-signature on 2026-07-13" premise does not hold.**
07-13 was `google / gemini-2.5-flash` failing the since-removed word-count floor
(`> 200` got 16 — the #866 family); only its *third* attempt was a `toHaveCount`.
`reports/daily-history.jsonl` records **only the last attempt's**
`error_signature`, which is what made two unrelated causes read as one. 07-22
shows the same opaque `Received: 0` on google (test 1, 3/3, ~140 s) — another
guard day.

**What the load exposed is a real wait-strategy defect.** `runPrompt` used the
`chat-message-token-usage` badge **count** as its completion gate, so "still
generating", "finished without a badge" and "finished with an error" all surfaced
as one blind `toHaveCount … Received: 0` after 120 s — with the preceding
Stop-button wait swallowed by a `.catch(() => {})`. **#569 had already
root-caused this exact pattern** on `memory-history-regression.spec.ts`: *not
every model/response emits the badge*, so its count cannot mean "done". Answering
the issue's investigation item 4 directly: the count is **not** a stable
postcondition, and both tests in the file shared the weakness through `runPrompt`.

## Fix

1. **Completion gate is now model-agnostic** — the turn mounts
   (`div-chat-message` count rises, guarding #354's "checked completion before
   generation started" race), then `button-stop` hides and `button-send` returns.
   The same pair `memory-history-regression.spec.ts` settled on after #569.
2. **The badge is asserted afterwards, as the observable it is**, with a message
   naming it as a *missing observable* and quoting the reply that did render (an
   error bubble included) instead of timing out blind.
3. **Flow cleanup moves to the shared tracker** (`trackCreatedFlows`, #1108). The
   old `afterEach` only knew the id `load()` **returned**, so a `load()` that
   throws *after* creating the flow leaked it — which the #751/#1072
   credential-settle guard does. Measured while working this issue: **one orphan
   `Simple Agent` per failed load**, on both local bursts (purged by hand).

**Rejected alternatives:** raising the 120 s budget (masks real regressions —
`triage-verdicts.md`), and keeping the badge as the gate with a longer timeout
(the #569 lineage says the badge may never arrive at all).

## Scope note

No assertion was weakened and **no timeout was loosened** — the worst case went
from ~248 s to ~205 s. `max_tokens = 50 ⇒ Output ≤ 50` and `unset ⇒ Output > 50`
are unchanged, as is the saved-value API check and the deliberate absence of a
reply-text assertion (#866). `@stable` stays: nothing was quarantined, per the
issue's own note that the guard had suppressed automatic removal.

## Validation (nightly 1.12.0.dev10, `--retries=0`, `--workers=1`)

- `npm run typecheck` ✅ · `npx eslint <spec>` ✅ (9 pre-existing warnings, 0 errors)
- `npm run check:checklist-coverage` ✅ · `scripts/check-checklist-guard.mjs` ✅
- **20/20 clean** before the force-fail cycle: openai `gpt-4o-mini` 3+2 repeats,
  google `gemini-3.5-flash` (a thinking model) 3+2 repeats
- **2/2 clean again after rebasing onto the #1162 fixtures** (restored `flow_error`
  detection on the v2 run stream) — no flow error surfaces on these runs
- **Isolated CI run on this branch** — `manual.yml`
  [30601070677](https://github.com/oriontech-me/langflow-e2e/actions/runs/30601070677):
  openai 2/2 green, google causal control green (24 s). google test 1 was flaky on
  `verdict read-failed` (#751/#1072 guard hitting a 20 s `GET /api/v1/flows/{id}`
  — the #1077/#1030 family, green on retry, untouched by this PR)
- **Flow orphans: 0** (`GET /api/v1/flows/` back to its 29-flow baseline)
- Zero `🚨 Backend Error` on the clean runs
- `--trace=on` **not** run: it hangs indefinitely on Simple Agent–template specs
  (#490/#518). Step verification came from the `--retries=0` bursts plus the
  force-fails below.

### Force-fails (executed, then reverted — `grep FFMARK` on the diff: 0 hits)

| Mutation | Observed failure |
|---|---|
| Test 1: `max_tokens` 50 → 1000 | `toBeLessThanOrEqual / Expected: <= 50 / Received: 702` |
| Test 2: cap 50 applied to the control | `toBeGreaterThan / Expected: > 50 / Received: 50` |
| Badge testid made bogus | the **new** message — `the finished response must expose a token-usage badge … Rendered reply: The history of the ocean is a chronicle…` — in **36 s**, not a blind 120 s timeout |
| Turn-started poll → `before + 5` | `toBeGreaterThan / Expected: > 5 / Received: 1` (confirms `div-chat-message` counts bot bubbles only) |
| `throw` right after `loadAgent` (post-create failure) | test died, flow total **29 → 29**: nothing leaked. The pre-fix code is the inverse mutation — it leaked one flow per failed load |

## Known limitation — the anthropic variant could not be re-run anywhere

The **exact** failing variant was not re-exercised: the local Anthropic key has
been out of credit since 2026-07-30, and the **CI secret drained during this
work** — the isolated run above logged `anthropic: candidate "claude-sonnet-5"
failed — Your credit balance is too low`, skipped its 2 tests, and stayed green
(the transient billing carve-out, #952). The verdict therefore rests on
cross-provider evidence (openai + a thinking google model, 22 clean runs) plus
the 2026-07-30 clean daily where that variant passed twice — **not** on a
re-run of it. Worth tracking separately: while the key is dry, every anthropic
variant skips silently and the daily still reports green.

## Follow-up worth filing (not in this PR)

`reports/daily-history.jsonl` storing only the **last** attempt's
`error_signature` is what let 07-13 (a #866 word-count-floor failure) be filed
under a `toHaveCount` signature, and that is the premise #1059 was opened on. One
signature per attempt — or the first attempt's — would prevent the next
misattribution.
