### PR TITLE
test(core-components): hatch the one spec that provokes a run error on purpose (#1165)

### DIFF
--- a/tests/tests-automations/regression/core-components/validate-raise-errors-components.spec.ts
+++ b/tests/tests-automations/regression/core-components/validate-raise-errors-components.spec.ts
@@ -1,4 +1,8 @@
-import { expect, test } from "../../../fixtures/fixtures";
+import {
+  expect,
+  test,
+  type PageWithErrorHooks,
+} from "../../../fixtures/fixtures";
 import { addCustomComponent } from "../../../helpers/flows/add-custom-component";
 import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../helpers/other/await-bootstrap-test";
@@ -32,6 +36,20 @@ test.describe("Core Components — Component That Raises a Python Error", () => 
   test("user should be able to see errors on popups when raise an error",
     { tag: ["@stable", "@release", "@regression", "@workspace", "@components"] },
     async ({ page }) => {
+      // This test's whole subject is a run that FAILS: the component below does
+      // `raise ValueError`, and the assertion is that the message reaches the UI.
+      // The hatch has been unnecessary until now only because the fixture could
+      // not see a v2 run at all (#1162), and it is still not load bearing today —
+      // a v2 verdict is advisory. It is added ahead of the flip (#1165) because
+      // the alternative is discovering it as a red `@stable @release` spec.
+      //
+      // Measured on 1.12.0.dev10: the run does emit
+      // `event_type=error / "THIS IS A TEST ERROR MESSAGE"`, but the fixture sees
+      // it only when the stream closes before the test ends. As written it does
+      // not (`read failed (stream aborted?)`, 3/3) — so the flip would make this
+      // spec fail INTERMITTENTLY, which is the worst version of the outcome.
+      (page as PageWithErrorHooks).allowFlowErrors();
+
       const customComponentCodeWithRaiseErrorMessage = `
 # from langflow.field_typing import Data
 from langflow.custom import Component


### PR DESCRIPTION
## What this does

Adds `page.allowFlowErrors()` to `core-components/validate-raise-errors-components.spec.ts`. One line, plus the comment saying why.

That spec runs a custom component whose code does `raise ValueError` and asserts the message reaches the UI. **A failed run is its subject.** It has never called the hatch because until #1162 the fixture could not see a v2 run at all — so the hatch protected against nothing and nobody missed it.

## Why now, and not during the flip

Because of what the flip would otherwise do to it. Measured against a live 1.12.0.dev10:

| | outcome |
|---|---|
| as written (3 s teardown drain) | `read failed (stream aborted?)` — **3/3, no verdict at all** |
| +2 s wait after the assertion | `ADVISORY · event_type=error · "THIS IS A TEST ERROR MESSAGE"` |

The run *does* emit the error. The fixture reads it only when the stream closes before the test ends, and as written it does not.

So flipping v2 to failing without this hatch would not turn the spec red. It would turn it red **sometimes** — on an `@stable @release` spec, with a fixture race as the cause. That is the worst available outcome, and it costs one line to avoid.

## The audit behind "the one spec"

Static pass over all 80 unhatched run-driving specs. This is the only one that provably provokes a failed run and asserts on it.

The near-miss is worth recording, because the distinction will keep coming up: `api/flows/api-component-regression.spec.ts`'s *"timeout error returns status_code 500 with error field"* reads like a second case and is not. The API Request component **catches** the exception and returns `status_code: 500` with an `error` key as a normal build output — the node build succeeds. **A component returning an error payload is not a failed run**, and only the second is a `flow_error`.

Re-counted while there, since these numbers have been wrong at each retelling: **89** run-driving specs (not 88), **80** without a hatch (not 75), **11** files calling `allowFlowErrors()` (not 13 — two contain the string only inside a comment saying no hatch is needed). Full inventory in #1165.

## Not fixed here

The race itself. It is the prerequisite for the flip and it does not belong in a one-line spec change:

- raising the teardown drain does **not** fix it — 10 s changes nothing;
- because the body is not slow, it is gone: `Protocol error (Network.getResponseBody): No resource with given identifier found`. CDP evicted the resource once the in-flight request was cancelled.

Teeing the stream (`page.route` + `route.fetch()`) is the option that survives. Tracked in #1165 with the measurements.

## Risk

None today: a v2 verdict is advisory, so the hatch is inert until the flip. `tsc --noEmit` clean, and the spec passes against 1.12.0.dev10.

Refs #1165 — the flip and its prerequisite keep that issue open.
