### PR TITLE
ci(pr-validation): pin the PR lane to one provider's settled model (#1169)

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -566,6 +566,34 @@ jobs:
           # here is a HARD gate (not `continue-on-error`), so a failed sweep has
           # already reddened the job and there is no surviving run to warn about.
 
+      # Pin this lane to ONE provider's settled model (#1169). getTestTargets()
+      # parametrizes over one model per active provider, so every impacted agent
+      # spec runs an openai AND an anthropic AND a google variant here. That is
+      # daily-stable.yml's job — it is the lane that owes multi-provider coverage.
+      # This lane answers "does this PR break the specs it touches", which one
+      # provider settles, and the difference is not cosmetic: measured 2026-07-31,
+      # this workflow ran 141 times in 3.5 days, each model-needing run paying an
+      # anthropic variant on claude-sonnet-5 ($3/$15 per MTok) for assertions
+      # gpt-4o-mini ($0.15/$0.60) satisfies identically — 20-25x per token, with no
+      # prompt caching on the anthropic side. Both the CI secret and the local key
+      # drained inside that window (Anthropic credit is account-scoped, so they
+      # share one balance).
+      #
+      # Why a script (see its header for the full argument): MODEL_TEST_PROVIDER
+      # alone does not narrow the run, it runs the provider's ENTIRE catalog (the
+      # dedup branch is skipped) — so the two variables must be emitted as a pair,
+      # which this does. And the model must be the one collect-models settled on:
+      # a hardcoded id skips silently the day the CI project loses access, leaving
+      # a green PR that tested nothing (#570/#1012).
+      #
+      # Declines to pin — with a ::warning:: — when the provider is not active, so
+      # a drained openai key costs a costlier multi-provider run rather than zero
+      # coverage. Gated on needs_models for the same reason as the two steps above:
+      # with no sweep there is no settled model to read.
+      - name: Pin the lane to a single provider's settled model
+        if: needs.detect-specs.outputs.needs_models == 'true'
+        run: node scripts/select-pr-model-target.mjs --provider openai
+
       - name: Run impacted specs
         env:
           CI: "true"

--- a/scripts/select-pr-model-target.mjs
+++ b/scripts/select-pr-model-target.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+/**
+ * Picks the single model target the **PR lane** should run its LLM specs against,
+ * out of what `collect-models` actually settled on (#1169).
+ *
+ * ## Why the PR lane pins one provider at all
+ *
+ * `getTestTargets()` (~17 agent specs) parametrizes over **one model per active
+ * provider**, so every LLM spec selected by the impacted-specs job runs once per
+ * provider whose key is in the repo secrets — openai *and* anthropic *and* google.
+ * That is the right shape for `daily-stable.yml`, which is the lane that owes
+ * multi-provider coverage. It is the wrong shape here, and the cost is not
+ * theoretical: measured 2026-07-31, `pr-validation.yml` ran **141 times in
+ * 3.5 days** (37/49/49/6 per day), each model-needing run paying an anthropic
+ * variant of every impacted agent spec — on `claude-sonnet-5` at $3/$15 per MTok
+ * against `gpt-4o-mini` at ~$0.15/$0.60, i.e. **20-25x the price per token** for
+ * the same assertions, with no prompt caching on the anthropic side (Langflow
+ * sets no `cache_control`, so every turn re-sends the agent prompt and tool
+ * schemas at full price). Both the CI secret and the local `.env` key drained
+ * inside that window — Anthropic credit is **account-scoped**, so the two share
+ * one balance and the PR lane was the volume driver.
+ *
+ * So: the PR lane answers "does this PR break the specs it touches", which one
+ * provider settles. The daily keeps answering "does it break on every provider".
+ *
+ * ## Why this is a script and not two `env:` lines
+ *
+ * Two reasons, both of which have already bitten this repo:
+ *
+ * 1. **`MODEL_TEST_PROVIDER` alone is a trap, not a filter.** In
+ *    `getTestTargets()` the `MODEL_TEST_PROVIDER` branch filters the catalog by
+ *    provider and **skips the first-per-provider dedup**, so setting it without
+ *    `MODEL_TEST_ID` runs *every* model that provider exposes — 41 openai entries
+ *    in the catalog collected 2026-07-30. That turns a cost fix into a 41x cost
+ *    regression. The two variables are a **pair**; this script never emits one
+ *    without the other.
+ * 2. **The model has to be the settled one.** Hardcoding `gpt-4o-mini` in YAML
+ *    fails silently the day it retires or the CI project loses access:
+ *    `getTestTargets()` warns `MODEL_TEST_ID="…" not found in models.json` and
+ *    returns a target with no provider, so the spec skips and the PR still reads
+ *    green — the exact silent-skip failure #570 and #1012 exist to prevent.
+ *    `providers.json` already records what `collect-models` probed successfully;
+ *    read that.
+ *
+ * ## When it declines to pin
+ *
+ * If the chosen provider is not `active` (drained key, dead credential), pinning
+ * to it would make every parametrized spec skip — trading spend for **zero**
+ * coverage. The decision then is `ok: false`, the lane keeps its existing
+ * multi-provider behaviour, and the reason is printed as a `::warning::`. That is
+ * a deliberate fallback to the *more expensive* path, because a PR check that
+ * runs nothing is worth less than one that costs more (#980's trade: a provider
+ * outage must not silently erode coverage). A payload it cannot read at all is a
+ * hard error (exit 2) rather than a quiet fallback — #1035's rule.
+ *
+ * Run:
+ *   node scripts/select-pr-model-target.mjs \
+ *     --providers-file tests/helpers/provider-setup/data/providers.json \
+ *     --provider openai
+ *
+ * Output (stdout, JSON): { ok, provider, model, reason, warnings }
+ * Side effect: appends `MODEL_TEST_ID` / `MODEL_TEST_PROVIDER` to `$GITHUB_ENV`
+ * when it pins and that variable is set.
+ */
+
+import fs from "node:fs";
+
+const HELP = `usage: select-pr-model-target.mjs [options]
+
+  --providers-file PATH  providers.json written by collect-models
+                         (default: tests/helpers/provider-setup/data/providers.json)
+  --provider NAME        provider to pin the lane to (default: openai)
+`;
+
+const DEFAULT_PROVIDERS_FILE =
+  "tests/helpers/provider-setup/data/providers.json";
+
+/**
+ * @param {unknown} providers parsed `providers.json` payload
+ * @param {{ provider?: string }} [options]
+ * @returns {{ ok: boolean, provider: string, model: string|null, reason: string|null, warnings: string[] }}
+ * @throws {Error} when the payload is not a readable provider record list
+ */
+export function selectPrModelTarget(providers, options = {}) {
+  const provider = options.provider ?? "openai";
+
+  if (!Array.isArray(providers)) {
+    throw new Error(
+      `providers.json must be an array of provider records, got ${
+        providers === null ? "null" : typeof providers
+      }`,
+    );
+  }
+
+  for (const [i, record] of providers.entries()) {
+    if (record === null || typeof record !== "object") {
+      throw new Error(
+        `providers.json[${i}] must be an object, got ${
+          record === null ? "null" : typeof record
+        }`,
+      );
+    }
+    if (typeof record.provider !== "string" || record.provider === "") {
+      throw new Error(`providers.json[${i}] has no "provider" name`);
+    }
+    if (typeof record.status !== "string" || record.status === "") {
+      throw new Error(
+        `providers.json[${i}] ("${record.provider}") has no "status"`,
+      );
+    }
+  }
+
+  const record = providers.find((r) => r.provider === provider);
+  if (!record) {
+    return {
+      ok: false,
+      provider,
+      model: null,
+      reason:
+        `provider "${provider}" is absent from providers.json (present: ` +
+        `${providers.map((r) => r.provider).join(", ") || "none"}) — ` +
+        `leaving the lane on its default per-provider parametrization`,
+      warnings: [],
+    };
+  }
+
+  if (record.status !== "active") {
+    return {
+      ok: false,
+      provider,
+      model: null,
+      reason:
+        `provider "${provider}" probed "${record.status}" — pinning the lane to ` +
+        `it would skip every parametrized spec, so the lane keeps its default ` +
+        `per-provider parametrization (costlier, but it covers something). ` +
+        `collect-models reported: ${record.error ?? "no error message"}`,
+      warnings: [],
+    };
+  }
+
+  if (typeof record.model !== "string" || record.model === "") {
+    throw new Error(
+      `provider "${provider}" is active but carries no settled "model" — ` +
+        `providers.json is inconsistent`,
+    );
+  }
+
+  return {
+    ok: true,
+    provider,
+    model: record.model,
+    reason: null,
+    warnings: [],
+  };
+}
+
+/**
+ * Reads the providers file. A missing file is a legitimate state (the sweep was
+ * skipped, or ran `continue-on-error` on a canary), not a crash.
+ * @returns {{ providers: unknown, missing: boolean }}
+ */
+export function readProvidersFile(providersFile, { readFile, exists } = {}) {
+  const fileExists = exists ?? ((p) => fs.existsSync(p));
+  const read = readFile ?? ((p) => fs.readFileSync(p, "utf-8"));
+
+  if (!fileExists(providersFile)) return { providers: null, missing: true };
+  return { providers: JSON.parse(read(providersFile)), missing: false };
+}
+
+function parseArgs(argv) {
+  const args = { providersFile: DEFAULT_PROVIDERS_FILE, provider: "openai" };
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    if (flag === "--help" || flag === "-h") {
+      args.help = true;
+      continue;
+    }
+    const value = argv[i + 1];
+    if (value === undefined) throw new Error(`missing value for ${flag}`);
+    i++;
+    if (flag === "--providers-file") args.providersFile = value;
+    else if (flag === "--provider") args.provider = value;
+    else throw new Error(`unknown flag: ${flag}`);
+  }
+  return args;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`::error::select-pr-model-target: ${error.message}\n`);
+    process.exit(2);
+  }
+  if (args.help) {
+    process.stdout.write(HELP);
+    process.exit(0);
+  }
+
+  let result;
+  try {
+    const { providers, missing } = readProvidersFile(args.providersFile);
+    result = missing
+      ? {
+          ok: false,
+          provider: args.provider,
+          model: null,
+          reason:
+            `${args.providersFile} does not exist — collect-models did not write ` +
+            `it, so there is no settled model to pin to`,
+          warnings: [],
+        }
+      : selectPrModelTarget(providers, { provider: args.provider });
+  } catch (error) {
+    // Fail loud: a payload this cannot read must not read as "nothing to pin"
+    // (#1035). The lane is expected to fail here rather than quietly pay for a
+    // multi-provider run it did not choose.
+    process.stderr.write(`::error::select-pr-model-target: ${error.message}\n`);
+    process.exit(2);
+  }
+
+  if (result.ok) {
+    // Both variables, always together — MODEL_TEST_PROVIDER on its own makes
+    // getTestTargets skip the per-provider dedup and run the whole catalog.
+    const lines = [
+      `MODEL_TEST_ID=${result.model}`,
+      `MODEL_TEST_PROVIDER=${result.provider}`,
+    ];
+    if (process.env.GITHUB_ENV) {
+      fs.appendFileSync(process.env.GITHUB_ENV, `${lines.join("\n")}\n`);
+    }
+    process.stderr.write(
+      `PR lane pinned to ${result.provider} / ${result.model} ` +
+        `(settled by collect-models); other providers' variants will not run here — ` +
+        `daily-stable.yml keeps the multi-provider coverage.\n`,
+    );
+  } else {
+    process.stderr.write(`::warning::select-pr-model-target: ${result.reason}\n`);
+  }
+
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+  process.exit(0);
+}

--- a/scripts/select-pr-model-target.test.mjs
+++ b/scripts/select-pr-model-target.test.mjs
@@ -1,0 +1,208 @@
+// Unit tests for the PR lane's single-provider model target. Run with:
+//   npm run test:scripts
+//
+// Why these exist: the two ways to get this wrong both read as success.
+//
+//  - Emitting `MODEL_TEST_PROVIDER` without `MODEL_TEST_ID` does not narrow the
+//    lane, it *widens* it: `getTestTargets()` skips the first-per-provider dedup
+//    on that branch and runs every model the provider exposes (41 openai entries
+//    in the 2026-07-30 catalog). A cost fix that becomes a 41x cost regression
+//    would look exactly like a working one in the log, so the pair invariant is
+//    asserted against the real CLI, not just the pure function.
+//  - Pinning to a provider whose key is dead makes every parametrized spec skip
+//    and the PR still goes green — #570/#1012's silent-skip failure. So an
+//    inactive provider must decline to pin and say so, and that decline is
+//    asserted here rather than discovered by a quiet lane.
+//
+// The payloads are the real shapes, including the drained-Anthropic error string
+// captured on 2026-07-30.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { selectPrModelTarget, readProvidersFile } from "./select-pr-model-target.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.join(HERE, "select-pr-model-target.mjs");
+const REPO_ROOT = path.resolve(HERE, "..");
+
+/** providers.json as collect-models wrote it on 2026-07-30 (anthropic drained). */
+const PROVIDERS = [
+  {
+    provider: "openai",
+    model: "gpt-4o-mini",
+    status: "active",
+    error: null,
+    checkedAt: "2026-07-30T03:10:08.427Z",
+  },
+  {
+    provider: "anthropic",
+    model: "claude-sonnet-4-5",
+    status: "inactive",
+    error:
+      "3 of 13 candidate model(s) failed validation with the SAME " +
+      "model-independent error — stopped early; last error: Your credit balance " +
+      "is too low to access the Anthropic API.",
+    checkedAt: "2026-07-30T03:10:08.282Z",
+  },
+  {
+    provider: "google",
+    model: "gemini-3.5-flash",
+    status: "active",
+    error: null,
+    checkedAt: "2026-07-30T03:10:09.268Z",
+  },
+];
+
+test("pins the settled model of an active provider", () => {
+  const r = selectPrModelTarget(PROVIDERS);
+
+  assert.equal(r.ok, true);
+  assert.equal(r.provider, "openai");
+  // The SETTLED model, not the catalog head — a hardcoded id skips silently the
+  // day the CI project loses access to it.
+  assert.equal(r.model, "gpt-4o-mini");
+  assert.equal(r.reason, null);
+});
+
+test("honours an explicit provider override", () => {
+  const r = selectPrModelTarget(PROVIDERS, { provider: "google" });
+
+  assert.equal(r.ok, true);
+  assert.equal(r.model, "gemini-3.5-flash");
+});
+
+test("declines to pin an inactive provider, and names the reason", () => {
+  // Pinning here would skip every parametrized spec while the PR stayed green.
+  // The lane must fall back to the costlier multi-provider run instead (#980).
+  const r = selectPrModelTarget(PROVIDERS, { provider: "anthropic" });
+
+  assert.equal(r.ok, false);
+  assert.equal(r.model, null);
+  assert.match(r.reason, /probed "inactive"/);
+  assert.match(r.reason, /credit balance is too low/);
+});
+
+test("declines to pin a provider absent from providers.json", () => {
+  const r = selectPrModelTarget(PROVIDERS, { provider: "mistral" });
+
+  assert.equal(r.ok, false);
+  assert.equal(r.model, null);
+  assert.match(r.reason, /absent from providers\.json/);
+  // Lists what WAS there, so the log says which sweep produced this.
+  assert.match(r.reason, /openai, anthropic, google/);
+});
+
+test("a payload it cannot read is an error, never a quiet no-pin", () => {
+  // #1035: a verdict the script cannot produce must fail loudly rather than
+  // reading like the healthy "nothing to pin" path.
+  assert.throws(() => selectPrModelTarget(null), /must be an array/);
+  assert.throws(() => selectPrModelTarget({ openai: "gpt-4o-mini" }), /must be an array/);
+  assert.throws(() => selectPrModelTarget([null]), /must be an object/);
+  assert.throws(() => selectPrModelTarget([{ model: "x", status: "active" }]), /no "provider" name/);
+  assert.throws(() => selectPrModelTarget([{ provider: "openai", model: "x" }]), /no "status"/);
+  assert.throws(
+    () => selectPrModelTarget([{ provider: "openai", status: "active" }]),
+    /active but carries no settled "model"/,
+  );
+});
+
+test("a missing providers.json is a state, not a crash", () => {
+  // collect-models is skipped on LLM-free PRs and continue-on-error on a canary.
+  const r = readProvidersFile("/nonexistent/providers.json", {
+    exists: () => false,
+    readFile: () => {
+      throw new Error("must not read a file it decided is absent");
+    },
+  });
+
+  assert.equal(r.missing, true);
+  assert.equal(r.providers, null);
+});
+
+test("CLI writes BOTH env vars or neither — never MODEL_TEST_PROVIDER alone", () => {
+  // The pair invariant, asserted end-to-end: MODEL_TEST_PROVIDER on its own is
+  // not a narrower run, it is the whole 41-model catalog.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pr-model-target-"));
+  const providersFile = path.join(dir, "providers.json");
+  const githubEnv = path.join(dir, "github_env");
+  fs.writeFileSync(providersFile, JSON.stringify(PROVIDERS));
+  fs.writeFileSync(githubEnv, "");
+
+  const stdout = execFileSync(
+    process.execPath,
+    [SCRIPT, "--providers-file", providersFile, "--provider", "openai"],
+    { env: { ...process.env, GITHUB_ENV: githubEnv }, encoding: "utf-8" },
+  );
+
+  assert.equal(JSON.parse(stdout).model, "gpt-4o-mini");
+  const written = fs.readFileSync(githubEnv, "utf-8");
+  assert.match(written, /^MODEL_TEST_ID=gpt-4o-mini$/m);
+  assert.match(written, /^MODEL_TEST_PROVIDER=openai$/m);
+
+  // And the declining path writes NOTHING — a stale MODEL_TEST_PROVIDER with no
+  // MODEL_TEST_ID would be the 41-model regression.
+  fs.writeFileSync(githubEnv, "");
+  execFileSync(
+    process.execPath,
+    [SCRIPT, "--providers-file", providersFile, "--provider", "anthropic"],
+    { env: { ...process.env, GITHUB_ENV: githubEnv }, encoding: "utf-8" },
+  );
+  assert.equal(fs.readFileSync(githubEnv, "utf-8"), "");
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("CLI exits 2 on an unreadable payload, 0 on a legitimate no-pin", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pr-model-target-"));
+  const bad = path.join(dir, "providers.json");
+  fs.writeFileSync(bad, '{"openai": "gpt-4o-mini"}');
+
+  assert.throws(
+    () =>
+      execFileSync(process.execPath, [SCRIPT, "--providers-file", bad], {
+        encoding: "utf-8",
+        stdio: "pipe",
+      }),
+    (error) => error.status === 2,
+  );
+
+  // Absent file: the lane continues (exit 0) with a warning, because an LLM-free
+  // or canary run legitimately has no sweep output.
+  const stdout = execFileSync(
+    process.execPath,
+    [SCRIPT, "--providers-file", path.join(dir, "absent.json")],
+    { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
+  );
+  const result = JSON.parse(stdout);
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /does not exist/);
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("pr-validation.yml still runs the pin between the health gate and the specs", () => {
+  // Structural guard, same shape as the wait-for-backend one (#1045): the pin is
+  // only worth anything if it runs AFTER collect-models settled a model and
+  // BEFORE the specs read the env. A refactor that reorders the steps silently
+  // restores the multi-provider spend.
+  const yaml = fs.readFileSync(
+    path.join(REPO_ROOT, ".github/workflows/pr-validation.yml"),
+    "utf-8",
+  );
+  const lines = yaml.split("\n");
+  const indexOf = (needle) => lines.findIndex((l) => l.includes(needle));
+
+  const collect = indexOf("- name: Collect models");
+  const gate = indexOf("uses: ./.github/actions/wait-for-backend");
+  const pin = indexOf("scripts/select-pr-model-target.mjs");
+  const run = indexOf("- name: Run impacted specs");
+
+  assert.ok(collect > 0, "Collect models step is missing");
+  assert.ok(gate > collect, "health gate must follow Collect models");
+  assert.ok(pin > gate, "the model pin must follow the health gate");
+  assert.ok(run > pin, "the model pin must precede the impacted-specs run");
+});


### PR DESCRIPTION
Closes #1169.

Pins `pr-validation.yml` to **one provider's settled model** for its impacted LLM specs.
`daily-stable.yml` is untouched and keeps the multi-provider coverage — it is the lane
that owes it.

## Why

`getTestTargets()` parametrizes ~17 agent specs over one model per **active** provider, so
every provider key in the repo secrets multiplies the impacted-specs run: an openai *and*
an anthropic *and* a google variant of every selected LLM spec. Measured 2026-07-31,
`pr-validation.yml` ran **141 times in 3.5 days** (37 / 49 / 49 / 6 per day), each
model-needing run paying an anthropic variant on `claude-sonnet-5` ($3/$15 per MTok) for
assertions `gpt-4o-mini` ($0.15/$0.60) satisfies identically — 20-25x per token, and wider
in practice because Langflow sets no `cache_control`, so every agent turn re-sends the
system prompt and tool schemas at full input price while OpenAI discounts a repeated
prefix automatically. Anthropic credit is account-scoped, so the CI secret and the local
`.env` key share one balance; both went dry inside that window and this lane was the
volume driver. Full data and the price table are in #1169.

## Why a script and not two `env:` lines

Both ways to get this wrong read as success in the log:

- **`MODEL_TEST_PROVIDER` alone does not narrow the run, it widens it.** The provider
  branch of `getTestTargets()` skips the first-per-provider dedup and runs every model
  that provider exposes — 41 openai entries in the catalog collected 2026-07-30. A cost
  fix that becomes a 41x cost regression. The two variables are a **pair**, and the pair
  invariant is asserted end-to-end against the CLI, not by convention.
- **The model has to be the settled one.** A hardcoded `gpt-4o-mini` fails silently the
  day the CI project loses access: `getTestTargets()` warns `not found in models.json`,
  returns a target with no provider, the spec skips, and the PR still reads green — the
  silent-skip failure #570 and #1012 exist to prevent. `providers.json` already records
  what `collect-models` probed successfully.

## When it declines to pin

A provider that is not `active` would make every parametrized spec skip while the PR
stayed green. The script then emits a `::warning::` naming what `collect-models` reported
and leaves the lane on its existing per-provider parametrization — a deliberate fallback
to the *costlier* path, on #980's trade: a check that runs nothing is worth less than one
that costs more. A payload it cannot read at all is exit 2, not a quiet no-pin (#1035).

## Changes

| File | What |
|---|---|
| `scripts/select-pr-model-target.mjs` (new) | Reads `providers.json`, emits the `MODEL_TEST_ID` + `MODEL_TEST_PROVIDER` pair to `$GITHUB_ENV`, or declines with a reason. |
| `scripts/select-pr-model-target.test.mjs` (new) | 9 tests: the pin, both decline paths, the unreadable-payload error, the CLI pair invariant (writes a real temp `$GITHUB_ENV` and asserts both lines, or neither), and a structural guard on step order. |
| `.github/workflows/pr-validation.yml` | New step between the post-collect-models health gate and `Run impacted specs`, gated on `needs_models` like the two steps above it. |

## Validation

| Check | Result |
|---|---|
| `npm run test:scripts` | 228 passed, 0 failed (9 new) |
| `npm run typecheck` | clean |
| `npm run lint` | 0 errors (pre-existing warnings only) |
| `npm run check:checklist-coverage` | passes — no spec or `@stable` change |
| YAML parse | step lands in the `e2e` job with the intended `if:` |
| CLI against the real local `providers.json` | pins `openai / gpt-4o-mini`; `--provider anthropic` declines and prints the drained-balance reason |
| Force-fail (both directions) | step deleted → 1 fail; step moved after the specs run → `the model pin must precede the impacted-specs run` |

**No local proof exists for the workflow behaviour itself, and this states so plainly.**
The proof is this PR's own CI: `scripts/ci-change-coverage.mjs` classifies the diff as
**`canary`** (`pr-validation.yml` is the lane's own workflow, and the new script is
reachable from it), so the lane boots Langflow and walks pre-flight → health gate → the
new pin → Playwright for real. What to watch in the job log: either
`PR lane pinned to openai / <model>` or the `::warning::` decline.

## Follow-up, deliberately not here

`CANDIDATE_PREFS.anthropic` is sonnet-first, so the daily's anthropic coverage runs at 3x
`claude-haiku-4-5`. Moving haiku first is one line and cannot be validated by unit tests —
`CANDIDATE_PREFS` exists because the probe validates *access*, not *agent compatibility*
(#570: `gpt-5.6` passed the probe while the Agent returned empty replies), so it needs a
real `@stable` run against a funded key to prove it does not redden the ~30 anthropic
agent tests. Tracked in the follow-up section of #1169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
