### PR TITLE
ci(echo-endpoint): read the decision with node, not jq

### DIFF
--- a/.github/actions/resolve-echo-endpoint/action.yml
+++ b/.github/actions/resolve-echo-endpoint/action.yml
@@ -96,24 +96,50 @@ runs:
         CODE=$?
         set -e
 
-        # Exit 2 is the resolver itself being broken (bad flag, crash). That must
-        # never read as "the service is absent" — the two call for opposite
-        # responses, and conflating them is how a gate silently stops gating.
-        if [ "$CODE" -eq 2 ] || ! echo "$DECISION" | jq -e . >/dev/null 2>&1; then
-          echo "::error::resolve-echo-endpoint could not produce a decision (exit $CODE). Treating as a wiring failure, not an absent service."
+        # Read the decision with `node`, NOT `jq`. This is the only composite action
+        # the containerized lane uses (`daily-stable.yml`, `in_container: true`), and
+        # `mcr.microsoft.com/playwright:v1.58.2-noble` ships no `jq` — its Dockerfile
+        # installs curl/wget/gpg/ca-certificates, nodejs and git/openssh-client, and
+        # nothing else. The four `jq` calls this replaces aborted all four shards of
+        # the 2026-07-31 daily before its first test, and the failure was invisible:
+        # `jq -e . >/dev/null 2>&1` sent `jq: command not found` to /dev/null, so a
+        # missing binary was indistinguishable from malformed JSON. `node` needs no
+        # such trust — the line above just used it to PRODUCE this decision.
+        #
+        # One invocation, three tab-separated fields, stderr left ALONE so the next
+        # environment gap names itself in the log instead of surfacing as the "exit 0"
+        # contradiction that made this cost a whole day of @stable coverage.
+        set +e
+        FIELDS="$(node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{let v;try{v=JSON.parse(d)}catch(e){process.stderr.write("decision is not JSON: "+e.message+"\n");process.exit(1)}if(!v||typeof v!=="object"||Array.isArray(v)){process.stderr.write("decision is not a JSON object\n");process.exit(1)}process.stdout.write([v.ok===true?"true":"false",v.langflowUrl||"",v.probeUrl||""].join("\t")+"\n")})' <<<"$DECISION")"
+        PARSE=$?
+        set -e
+
+        # Exit 2 is the resolver itself being broken (bad flag, crash); a non-zero
+        # PARSE is the same class of fault one step later. Neither must read as "the
+        # service is absent" — the two call for opposite responses, and conflating
+        # them is how a gate silently stops gating.
+        if [ "$CODE" -eq 2 ] || [ "$PARSE" -ne 0 ]; then
+          echo "::error::resolve-echo-endpoint could not produce a decision (resolver exit $CODE, parse exit $PARSE). Treating as a wiring failure, not an absent service."
           exit 1
         fi
 
-        OK="$(echo "$DECISION" | jq -r .ok)"
+        # One tab-split `read`, not `mapfile` and not three `read`s. Both alternatives
+        # reintroduce the class of bug being fixed here:
+        #   - `mapfile` is a bash-4 builtin, absent from the bash 3.2 on macOS, so the
+        #     fix for a missing-binary bug could not itself be run outside CI.
+        #   - three sequential `read`s hit EOF on a not-ok decision (the URL fields are
+        #     empty and command substitution strips trailing newlines) and return 1,
+        #     which under `set -e` kills the step silently on the exact path
+        #     `mode: warn` exists to keep alive.
+        # `|| true` covers a wholly empty FIELDS; a short line leaves the tail empty.
+        IFS=$'\t' read -r OK LANGFLOW_URL PROBE_URL <<<"$FIELDS" || true
+
         if [ "$OK" != "true" ]; then
           # The script already emitted ::error:: or ::warning:: with the reason.
           echo "echo_base_url=" >> "$GITHUB_OUTPUT"
           [ "$MODE" = "warn" ] && exit 0
           exit 1
         fi
-
-        LANGFLOW_URL="$(echo "$DECISION" | jq -r .langflowUrl)"
-        PROBE_URL="$(echo "$DECISION" | jq -r .probeUrl)"
 
         # The image is `scratch`-based — no shell, no curl — so it cannot carry a
         # container healthcheck. This poll IS the healthcheck (#639).

--- a/scripts/resolve-echo-endpoint.test.mjs
+++ b/scripts/resolve-echo-endpoint.test.mjs
@@ -12,12 +12,17 @@
 // `github_network_*` bridges hand out.
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   resolveEchoEndpoint,
   isPrivateIpv4,
   isLoopback,
   isIpv4,
 } from "./resolve-echo-endpoint.mjs";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 test("host-based job: Langflow gets the container IP, the job probes the published port", () => {
   // pr-validation / nightly / manual: no `container:`, so `getent` cannot resolve
@@ -165,4 +170,88 @@ test("isLoopback covers every shape the SSRF error message named", () => {
     assert.equal(isLoopback(h), true, h);
   }
   assert.equal(isLoopback("172.18.0.2"), false);
+});
+
+// ── Portability guard: nothing the containerized lane runs may need `jq` ─────
+//
+// The 2026-07-31 daily executed ZERO tests. All four shards aborted in this very
+// action, because it parsed the decision with `jq` and
+// `mcr.microsoft.com/playwright:v1.58.2-noble` ships none — its Dockerfile installs
+// curl/wget/gpg/ca-certificates, nodejs and git/openssh-client, nothing more.
+//
+// The bug survived review because `pr-validation.yml` is `runs-on: ubuntu-latest`
+// with no `container:`, where `jq` is preinstalled: the PR lane CANNOT reach the
+// topology it broke. `daily-stable.yml` is the only lane whose jobs are all
+// containerized, and it is unattended. So the invariant has to be asserted here or
+// it is only ever discovered by a lost day of @stable coverage.
+//
+// The convention already held everywhere else — every `jq` call site in the repo
+// (pr-validation, adaptive-impacted, migration-test, guard-dedicated-issue) sits in
+// a host-based job, and daily-stable's own three container jobs use `node -e`
+// instead — it was simply never written down.
+
+// Comment lines are stripped first: this file and the action both DISCUSS `jq` at
+// length, and a guard that tripped on the word rather than the call would force the
+// explanation out of the code that needs it.
+function shellLines(yaml) {
+  return yaml
+    .split("\n")
+    .filter((l) => !/^\s*#/.test(l))
+    .filter((l) => !/^\s*(#|description:)/.test(l));
+}
+
+function jqInvocations(yaml) {
+  // `--jq` is `gh`'s own built-in JSON filter, not the binary — `gh` implements it
+  // internally, so it stays available in a jq-less image and must not be flagged.
+  return shellLines(yaml).filter((l) => /(^|[\s|(`$])jq\b/.test(l) && !/--jq\b/.test(l));
+}
+
+const CONTAINERIZED_LANE = "daily-stable.yml";
+
+test(`${CONTAINERIZED_LANE} itself invokes no jq (all three of its jobs run in a container)`, () => {
+  const text = fs.readFileSync(path.join(REPO_ROOT, ".github/workflows", CONTAINERIZED_LANE), "utf8");
+  const lines = text.split("\n");
+
+  // Guard the premise too: if a job ever loses its `container:`, the reasoning above
+  // stops applying and this test should be revisited rather than quietly relaxed.
+  // Counted from the `jobs:` line down — 2-space keys also occur under `on:`
+  // (`schedule:`, `workflow_dispatch:`), which are not jobs.
+  const jobsAt = lines.findIndex((l) => /^jobs:\s*$/.test(l));
+  assert.ok(jobsAt > -1, `no top-level jobs: block found in ${CONTAINERIZED_LANE}`);
+  const body = lines.slice(jobsAt + 1);
+  const jobs = body.filter((l) => /^ {2}[a-z][a-z0-9-]*:\s*$/.test(l)).length;
+  const containers = body.filter((l) => /^ {4}container:\s*$/.test(l)).length;
+
+  assert.ok(jobs > 0, "no jobs parsed — the guard would pass vacuously");
+  assert.equal(
+    containers,
+    jobs,
+    `every job in ${CONTAINERIZED_LANE} must be containerized for this guard's premise to hold (${containers} container: for ${jobs} jobs)`,
+  );
+  assert.deepEqual(jqInvocations(text), []);
+});
+
+test(`every composite action ${CONTAINERIZED_LANE} uses invokes no jq`, () => {
+  const lane = fs.readFileSync(path.join(REPO_ROOT, ".github/workflows", CONTAINERIZED_LANE), "utf8");
+  const used = [...new Set([...lane.matchAll(/uses:\s*\.\/(\.github\/actions\/[a-z-]+)/g)].map((m) => m[1]))];
+
+  // A guard that silently checks nothing is the failure mode #1035/#1037 called out.
+  assert.ok(used.length > 0, `no local composite actions found in ${CONTAINERIZED_LANE} — the guard would pass vacuously`);
+  assert.ok(
+    used.includes(".github/actions/resolve-echo-endpoint"),
+    "the action this guard exists for is no longer used by the containerized lane",
+  );
+
+  for (const action of used) {
+    const text = fs.readFileSync(path.join(REPO_ROOT, action, "action.yml"), "utf8");
+    assert.deepEqual(jqInvocations(text), [], `${action}/action.yml invokes jq, which the Playwright container lacks`);
+  }
+});
+
+test("the guard flags a real jq call and ignores a comment or gh --jq", () => {
+  // Proving the guard can fail: a guard never seen red is a guard nobody can trust.
+  assert.deepEqual(jqInvocations('        OK="$(echo "$D" | jq -r .ok)"').length, 1);
+  assert.deepEqual(jqInvocations("        jq -e . <<<\"$D\"").length, 1);
+  assert.deepEqual(jqInvocations("        # we deliberately avoid jq here"), []);
+  assert.deepEqual(jqInvocations("          gh issue view 1 --json title --jq .title"), []);
 });


### PR DESCRIPTION
Closes #1175

The 2026-07-31 daily ([run 30624101377](https://github.com/oriontech-me/langflow-e2e/actions/runs/30624101377)) executed **zero tests**. All four shards aborted in `resolve-echo-endpoint` before the first test — a full day of `@stable` coverage lost to an infra abort.

## What broke

The action parsed the resolver's decision with `jq`, and `mcr.microsoft.com/playwright:v1.58.2-noble` ships none: its Dockerfile is `FROM ubuntu:noble` and installs `curl wget gpg ca-certificates`, `nodejs`, `git openssh-client`, nothing else. `daily-stable.yml` is the only lane that calls the action with `in_container: "true"`.

The failure was also unreadable. `jq -e . >/dev/null 2>&1` sent jq's own `command not found` to `/dev/null`, so a missing binary was indistinguishable from malformed JSON, and the lane reported:

```
::error::resolve-echo-endpoint could not produce a decision (exit 0). …
```

An `exit 0` next to "could not produce a decision" is the tell. Running the old block locally with `jq` off `PATH` emits that line byte for byte — the diagnosis is reproduced, not inferred.

`mode: warn` did not protect the daily: the wiring-failure fork exits 1 **before** `mode` is read. Correct for a genuinely broken resolver, but here the resolver was fine and the action was the broken wiring, so a lane that deliberately opted out of strictness was still killed by it.

## The change

**`.github/actions/resolve-echo-endpoint/action.yml`** — four `jq` calls become one `node` invocation that validates the JSON and emits three tab-separated fields. The parser's stderr is no longer redirected to `/dev/null`, so the next environment gap names itself instead of surfacing as a contradictory `exit 0`. `node` needs no trust here: the line above just used it to *produce* the decision, and daily-stable's container jobs already use `node -e` for JSON for exactly this reason.

Two alternatives were rejected because both reintroduce this class of bug, and the rationale is in the code so it is not re-litigated:

- `mapfile` is a bash-4 builtin, absent from the bash 3.2 on macOS — a fix for a missing-binary bug that cannot be run outside CI.
- Three sequential `read`s hit EOF on a not-ok decision (the URL fields are empty and command substitution strips trailing newlines) and return 1, which under `set -e` kills the step silently on the exact path `mode: warn` exists to keep alive. **I hit this one while writing the fix** — the local harness caught it before it reached CI.

**`scripts/resolve-echo-endpoint.test.mjs`** — a structural guard for the invariant that already held everywhere else but was never written down: every `jq` call site in the repo sits in a host-based job, and daily-stable's three container jobs use `node -e`. The guard asserts neither `daily-stable.yml` nor any composite action it uses invokes `jq`. It strips comment lines (both files discuss `jq` at length, and a guard that tripped on the word would push the explanation out of the code that needs it) and ignores `gh --jq`, which `gh` implements internally. It also guards its own premise — that every job in the lane is containerized — and refuses to pass vacuously.

## Why CI did not catch this

`pr-validation.yml` is `runs-on: ubuntu-latest` with no `container:`, so it calls the action with `in_container: "false"` **by construction** and cannot exercise the container topology. #1134 shipped validated on half the topologies the action supports; the other half failed 22 h later, unattended. The guard closes that specific gap; the general one (no lane rehearses the container topology on a PR) is worth a separate look.

## Validation

- The parse block **extracted verbatim from `action.yml`** by a generator, so the harness cannot drift from the code it tests, exercised over 8 paths — the daily's and pr-validation's real decisions, not-ok under `warn` (must stay 0) and under `fail` (must be 1), empty decision, non-JSON, JSON array, resolver exit 2 — with the expected exit code in every case.
- The old block reproduced red and the new block green **in the same `jq`-less environment**.
- The guard forced red by reintroducing the exact `jq` call, and green again on restore.
- `npm run test:scripts` 231/231 · `npm run typecheck` clean · `npm run lint` 0 errors.

Noted for honesty: one `npm run test:units` run showed 3 failures. It did not reproduce in 6 subsequent runs, including 3 on a clean `main`, so it is not from this change — but it is unexplained.

## Scope

Fix only. The other two consequences of that run — no umbrella issue was opened (`Create issue on failure` skipped by the implicit `success()`) and no `daily-history.jsonl` entry was written — are #1176, and touch `daily-stable.yml` plus `append-weekly-history.mjs`, so they belong in their own PR.

Not tagged `@stable`: no spec changes here, this is CI infrastructure only.

After merge the daily is worth a re-dispatch rather than waiting for tomorrow's schedule — there is currently no coverage at all, so the usual "don't spend 35 min on a latent change" reasoning does not apply.
