### PR TITLE
ci(triage): gate the agent on a usable report and pin it to Sonnet 5 (#1178)

### DIFF
--- a/.github/workflows/triage-dispatch.yml
+++ b/.github/workflows/triage-dispatch.yml
@@ -73,13 +73,43 @@ jobs:
             -n "playwright-json-daily-$DAILY_RUN_ID" -D . \
             || echo "::warning::results.json artifact unavailable for run $DAILY_RUN_ID — propose runs history-only."
           if [ -f results.json ]; then echo "results.json present ($(wc -c < results.json) bytes)."; else echo "no results.json — history-only."; fi
+
+      # Do not start the agent when the triggering run produced nothing to triage
+      # (#1178). Until this gate existed, the step above degraded to
+      # "history-only" and the agent ran anyway: on 2026-07-31 the daily's four
+      # shards all failed without a blob, the merge job died on `No report files
+      # found in .../all-blobs`, no results.json was uploaded, and the agent spent
+      # 28 of its 30 turns and $1.66 (its own log reports `num_turns` and
+      # `total_cost_usd`) reconstructing a run that had recorded ZERO test results.
+      #
+      # The decision reuses `analyze()` from scripts/check-run-integrity.mjs — the
+      # daily's own runguard logic (#1012) — so the two can never disagree, and so
+      # the case that makes a naive test-count check wrong is handled: a PARTIAL
+      # run, where some shards aborted in globalSetup while others executed
+      # (#1058), still RUNS the agent. Skipping is loud (::warning:: + a run-summary
+      # line), never silent; an unparseable-but-present report fails the step
+      # rather than reading as "nothing to triage" (#1035).
+      - name: Gate — does the triggering run give the agent anything to triage?
+        id: triage_input
+        run: node scripts/triage-input-gate.mjs --results results.json
+
       - uses: anthropics/claude-code-action@v1
+        if: steps.triage_input.outputs.should_run_agent == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: "/langflow-e2e-triage --phase propose ${{ inputs.issue && format('--issue {0}', inputs.issue) || '' }}"
-          claude_args: '--allowedTools "Read,Bash" --max-turns 30'
+          # --model pinned (#1178): the action's default is `claude-opus-5[1m]`, and
+          # nothing here needs Opus-tier reasoning at Opus-tier price. Sonnet 5
+          # keeps the 1M context window this job depends on (it reads CI logs) at
+          # 3/5 of the per-token price — on the three measured runs, $4.71 → ~$2.80.
+          # NOT haiku: its window is 200K, and the most expensive runs are the ones
+          # with the largest input, so it would overflow exactly where it matters.
+          # Worth an A/B once the input is bounded — via `workflow_dispatch --issue N`
+          # on the same umbrella — and #1171 is the standing reminder that a cheaper
+          # model has to be validated, not assumed.
+          claude_args: '--allowedTools "Read,Bash" --max-turns 30 --model claude-sonnet-5'
 
   execute:
     name: Execute approved triage
@@ -109,7 +139,10 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: "/langflow-e2e-triage --phase execute --issue ${{ github.event.issue.number }}"
-          claude_args: '--allowedTools "Read,Bash" --max-turns 40'
+          # Same pin as propose (#1178). NOT gated on a report: execute is triggered
+          # by a human "pode abrir" on a plan that already exists, so it has
+          # something to do regardless of what the daily uploaded.
+          claude_args: '--allowedTools "Read,Bash" --max-turns 40 --model claude-sonnet-5'
 
       # The contract gate for the AGENT path (#1035).
       #

--- a/.github/workflows/triage-dispatch.yml
+++ b/.github/workflows/triage-dispatch.yml
@@ -93,8 +93,15 @@ jobs:
         id: triage_input
         run: node scripts/triage-input-gate.mjs --results results.json
 
+      # The gate binds the AUTOMATIC path only. A `workflow_dispatch` is a human
+      # asking for this triage with an explicit `--issue`, and it downloads no
+      # artifact at all (there is no triggering run id), so gating it would refuse
+      # the one path that exists for re-proposing on demand — including the
+      # per-model A/B #1171 needs. Same reasoning as leaving `execute` ungated.
       - uses: anthropics/claude-code-action@v1
-        if: steps.triage_input.outputs.should_run_agent == 'true'
+        if: >-
+          github.event_name == 'workflow_dispatch' ||
+          steps.triage_input.outputs.should_run_agent == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         with:

--- a/scripts/triage-input-gate.mjs
+++ b/scripts/triage-input-gate.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+/**
+ * Decides whether `triage-dispatch.yml`'s propose job should start the triage
+ * agent at all, from the report the triggering daily produced (#1178).
+ *
+ * ## Why this gate exists
+ *
+ * The propose job downloads the daily's `results.json` "best-effort" and, when
+ * the artifact is missing, prints `no results.json — history-only` and runs the
+ * agent anyway. On 2026-07-31 that cost the maximum: the daily's four shards all
+ * failed without producing a blob, the merge job died on `No report files found
+ * in .../all-blobs`, and no `results.json` was ever uploaded. The agent then
+ * reconstructed the run from scratch through `Bash` — 28 of its 30 allowed turns,
+ * on `claude-opus-5[1m]`, **$1.66** (its own log reports `num_turns` and
+ * `total_cost_usd`) — to triage a run that had recorded **zero test results**.
+ *
+ * There is nothing to triage in that state: no failures to group, no clusters to
+ * dedup against open issues. The decision is cheap and deterministic, so it
+ * belongs before the agent, not inside it.
+ *
+ * ## Why it reuses `analyze()` rather than parsing the report itself
+ *
+ * `scripts/check-run-integrity.mjs` already owns "did this run actually produce
+ * tests" for the daily's own `runguard` step (#1012), including the case that
+ * makes a naive test-count check wrong: a **partial** run, where some shards
+ * aborted in `globalSetup` while others executed (#1058, measured on run
+ * 30444299314 — 205 tests recorded while ~184 never ran). A second
+ * implementation here would be a second thing to keep in sync, and the two
+ * disagreeing is exactly how a guard goes quietly wrong.
+ *
+ * ## The decision
+ *
+ * | Report state                          | Agent | Why |
+ * |---------------------------------------|-------|-----|
+ * | artifact absent                       | no    | the daily produced nothing |
+ * | present, `testsTotal === 0`           | no    | infra abort, not a per-test day (#1012) |
+ * | present, `partial`                    | YES   | real failures alongside an abort — the #1058 case worth triaging |
+ * | present, healthy                      | YES   | ordinary red daily |
+ * | present but unparseable               | ERROR | an undecidable verdict must not read as "nothing to triage" (#1035) |
+ *
+ * The skip path is **loud** — a `::warning::` plus a job-summary line naming the
+ * state observed — so an abort day is visible rather than silent (#1012's rule).
+ * It deliberately does not comment on the umbrella: on an abort there may be no
+ * umbrella at all (none was opened for 2026-07-31), and creating one is the
+ * agent's job behind the propose-confirm gate, not this script's.
+ *
+ * Run:
+ *   node scripts/triage-input-gate.mjs [--results results.json]
+ *
+ * Output (stdout, JSON): { runAgent, verdict, reason, testsTotal }
+ * Side effects: `should_run_agent` / `verdict` / `reason` on `$GITHUB_OUTPUT`,
+ * one line on `$GITHUB_STEP_SUMMARY`.
+ */
+
+import fs from "node:fs";
+import { analyze } from "./check-run-integrity.mjs";
+
+const HELP = `usage: triage-input-gate.mjs [options]
+
+  --results PATH   merged Playwright JSON report downloaded from the daily
+                   (default: results.json)
+`;
+
+const DEFAULT_RESULTS = "results.json";
+
+/**
+ * Pure decision. `readReport` returns the parsed report, `null` when the file is
+ * absent, and THROWS when the file exists but does not parse — the caller turns
+ * that into a hard error rather than a skip.
+ *
+ * @returns {{ runAgent: boolean, verdict: string, reason: string, testsTotal: number }}
+ */
+export function decideTriageInput(resultsPath, readReport) {
+  const report = readReport(resultsPath);
+
+  if (report === null) {
+    return {
+      runAgent: false,
+      verdict: "no-report",
+      reason:
+        `${resultsPath} was not produced by the triggering run — the daily ` +
+        `uploaded no merged report, so there are no failures to group and ` +
+        `nothing to dedup. Skipping the agent instead of letting it reconstruct ` +
+        `the run through Bash (that path cost 28 turns / $1.66 on 2026-07-31).`,
+      testsTotal: 0,
+    };
+  }
+
+  const state = analyze(report);
+
+  if (state.empty) {
+    return {
+      runAgent: false,
+      verdict: "zero-tests",
+      reason:
+        `the triggering run recorded ZERO test results` +
+        (state.aborted
+          ? ` and carries ${state.reportErrors} top-level error(s) — the shards ` +
+            `aborted before the first test`
+          : ``) +
+        `. That is an infra abort, not a per-test day (#1012), so there is ` +
+        `nothing for the agent to triage.`,
+      testsTotal: 0,
+    };
+  }
+
+  if (state.partial) {
+    return {
+      runAgent: true,
+      verdict: "partial",
+      reason:
+        `${state.testsTotal} test result(s) recorded alongside ` +
+        `${state.reportErrors} top-level error(s) — some shards aborted while ` +
+        `others ran (#1058). The recorded failures are worth triaging, and the ` +
+        `abort is part of what the plan must say.`,
+      testsTotal: state.testsTotal,
+    };
+  }
+
+  return {
+    runAgent: true,
+    verdict: "usable",
+    reason: `${state.testsTotal} test result(s) recorded — ordinary triage input.`,
+    testsTotal: state.testsTotal,
+  };
+}
+
+/**
+ * Absent → `null`. Present-but-unparseable → throw, so the CLI can fail loudly
+ * instead of reporting the healthy "nothing to triage" verdict for a state it
+ * could not read.
+ */
+export function readReportOrThrow(resultsPath, io = {}) {
+  const exists = io.exists ?? ((p) => fs.existsSync(p));
+  const read = io.readFile ?? ((p) => fs.readFileSync(p, "utf8"));
+
+  if (!exists(resultsPath)) return null;
+  const raw = read(resultsPath);
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `${resultsPath} exists but does not parse as JSON (${error.message}) — ` +
+        `refusing to report a verdict this gate could not derive`,
+    );
+  }
+}
+
+function parseArgs(argv) {
+  const args = { results: DEFAULT_RESULTS };
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    if (flag === "--help" || flag === "-h") {
+      args.help = true;
+      continue;
+    }
+    const value = argv[i + 1];
+    if (value === undefined) throw new Error(`missing value for ${flag}`);
+    i++;
+    if (flag === "--results") args.results = value;
+    else throw new Error(`unknown flag: ${flag}`);
+  }
+  return args;
+}
+
+function appendLine(envVar, line) {
+  const target = process.env[envVar];
+  if (target) fs.appendFileSync(target, `${line}\n`);
+}
+
+if (process.argv[1] && process.argv[1].endsWith("triage-input-gate.mjs")) {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`::error::triage-input-gate: ${error.message}\n`);
+    process.exit(2);
+  }
+  if (args.help) {
+    process.stdout.write(HELP);
+    process.exit(0);
+  }
+
+  let decision;
+  try {
+    decision = decideTriageInput(args.results, (p) => readReportOrThrow(p));
+  } catch (error) {
+    process.stderr.write(`::error::triage-input-gate: ${error.message}\n`);
+    process.exit(2);
+  }
+
+  appendLine("GITHUB_OUTPUT", `should_run_agent=${decision.runAgent}`);
+  appendLine("GITHUB_OUTPUT", `verdict=${decision.verdict}`);
+  appendLine("GITHUB_OUTPUT", `reason=${decision.reason.replace(/\n/g, " ")}`);
+
+  if (decision.runAgent) {
+    process.stderr.write(
+      `triage input OK (${decision.verdict}): ${decision.reason}\n`,
+    );
+    appendLine(
+      "GITHUB_STEP_SUMMARY",
+      `**Triage input:** \`${decision.verdict}\` — ${decision.reason}`,
+    );
+  } else {
+    // Loud, never silent: an abort day must be distinguishable from a quiet
+    // healthy one in the job log AND in the run summary.
+    process.stderr.write(`::warning::triage-input-gate: ${decision.reason}\n`);
+    appendLine(
+      "GITHUB_STEP_SUMMARY",
+      `**Triage agent SKIPPED** (\`${decision.verdict}\`) — ${decision.reason}`,
+    );
+  }
+
+  process.stdout.write(`${JSON.stringify(decision)}\n`);
+  process.exit(0);
+}

--- a/scripts/triage-input-gate.test.mjs
+++ b/scripts/triage-input-gate.test.mjs
@@ -1,0 +1,201 @@
+// Unit tests for the triage input gate (#1178). Run with: npm run test:scripts
+//
+// Why these exist: the failure this gate prevents already happened and was
+// invisible in the job log — the propose job printed `no results.json —
+// history-only` as a warning and ran the agent anyway, which spent 28 of 30 turns
+// and $1.66 reconstructing a daily that had recorded ZERO test results. Every
+// branch below is one of the states that run could have been in, and the two that
+// matter most are the ones that look alike:
+//
+//  - a run with zero tests (skip) vs a PARTIAL run where some shards aborted and
+//    others executed (#1058 — must still be triaged, 205 tests recorded while
+//    ~184 never ran);
+//  - an absent report (skip, the daily produced nothing) vs a present-but-
+//    unparseable one (hard error — a verdict this gate cannot derive must not be
+//    reported as the healthy "nothing to triage", #1035).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { decideTriageInput, readReportOrThrow } from "./triage-input-gate.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.join(HERE, "triage-input-gate.mjs");
+const REPO_ROOT = path.resolve(HERE, "..");
+
+const healthy = { stats: { expected: 460, unexpected: 2, flaky: 10, skipped: 2 } };
+const zeroTests = { stats: { expected: 0, unexpected: 0, flaky: 0, skipped: 0 } };
+const zeroWithAbort = {
+  stats: { expected: 0, unexpected: 0, flaky: 0, skipped: 0 },
+  errors: [{ message: "Error: No report files found in .../all-blobs" }],
+};
+const partial = {
+  stats: { expected: 200, unexpected: 5, flaky: 0, skipped: 0 },
+  errors: [{ message: "Error: credentials preflight failed" }],
+};
+
+const from = (report) => () => report;
+
+test("an absent report skips the agent", () => {
+  const d = decideTriageInput("results.json", from(null));
+
+  assert.equal(d.runAgent, false);
+  assert.equal(d.verdict, "no-report");
+  assert.match(d.reason, /was not produced by the triggering run/);
+});
+
+test("a zero-test run skips the agent and names the abort", () => {
+  const d = decideTriageInput("results.json", from(zeroWithAbort));
+
+  assert.equal(d.runAgent, false);
+  assert.equal(d.verdict, "zero-tests");
+  assert.match(d.reason, /ZERO test results/);
+  assert.match(d.reason, /1 top-level error/);
+  assert.match(d.reason, /infra abort/);
+});
+
+test("a zero-test run with no top-level error still skips", () => {
+  const d = decideTriageInput("results.json", from(zeroTests));
+
+  assert.equal(d.runAgent, false);
+  assert.equal(d.verdict, "zero-tests");
+  // No abort claim when nothing was observed — naming the wrong cause is worse
+  // than naming none.
+  assert.doesNotMatch(d.reason, /top-level error/);
+});
+
+test("a PARTIAL run RUNS the agent — the #1058 case is exactly what triage is for", () => {
+  // The trap this asserts against: gating on "did anything abort" would skip the
+  // most misleading run shape there is.
+  const d = decideTriageInput("results.json", from(partial));
+
+  assert.equal(d.runAgent, true);
+  assert.equal(d.verdict, "partial");
+  assert.equal(d.testsTotal, 205);
+  assert.match(d.reason, /some shards aborted while others ran/);
+});
+
+test("an ordinary red daily runs the agent", () => {
+  const d = decideTriageInput("results.json", from(healthy));
+
+  assert.equal(d.runAgent, true);
+  assert.equal(d.verdict, "usable");
+  assert.equal(d.testsTotal, 474);
+});
+
+test("present-but-unparseable throws instead of returning a verdict", () => {
+  assert.equal(
+    readReportOrThrow("absent.json", { exists: () => false }),
+    null,
+    "an absent file is a state, not an error",
+  );
+
+  assert.throws(
+    () =>
+      readReportOrThrow("results.json", {
+        exists: () => true,
+        readFile: () => "{not json",
+      }),
+    /exists but does not parse as JSON/,
+  );
+});
+
+test("CLI: skip path writes should_run_agent=false, warns, and summarises", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "triage-gate-"));
+  const results = path.join(dir, "results.json");
+  const out = path.join(dir, "github_output");
+  const summary = path.join(dir, "github_step_summary");
+  fs.writeFileSync(results, JSON.stringify(zeroWithAbort));
+  fs.writeFileSync(out, "");
+  fs.writeFileSync(summary, "");
+
+  const stdout = execFileSync(process.execPath, [SCRIPT, "--results", results], {
+    env: { ...process.env, GITHUB_OUTPUT: out, GITHUB_STEP_SUMMARY: summary },
+    encoding: "utf-8",
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  assert.equal(JSON.parse(stdout).runAgent, false);
+  assert.match(fs.readFileSync(out, "utf-8"), /^should_run_agent=false$/m);
+  assert.match(fs.readFileSync(out, "utf-8"), /^verdict=zero-tests$/m);
+  // The reason must survive onto GITHUB_OUTPUT as ONE line — a multi-line value
+  // would corrupt the output file and every later key with it.
+  const reasonLines = fs
+    .readFileSync(out, "utf-8")
+    .split("\n")
+    .filter((l) => l.startsWith("reason="));
+  assert.equal(reasonLines.length, 1);
+  assert.match(fs.readFileSync(summary, "utf-8"), /Triage agent SKIPPED/);
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("CLI: usable path writes should_run_agent=true; unparseable exits 2", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "triage-gate-"));
+  const results = path.join(dir, "results.json");
+  const out = path.join(dir, "github_output");
+  fs.writeFileSync(results, JSON.stringify(healthy));
+  fs.writeFileSync(out, "");
+
+  execFileSync(process.execPath, [SCRIPT, "--results", results], {
+    env: { ...process.env, GITHUB_OUTPUT: out },
+    encoding: "utf-8",
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  assert.match(fs.readFileSync(out, "utf-8"), /^should_run_agent=true$/m);
+
+  fs.writeFileSync(results, "{not json");
+  assert.throws(
+    () =>
+      execFileSync(process.execPath, [SCRIPT, "--results", results], {
+        encoding: "utf-8",
+        stdio: "pipe",
+      }),
+    (error) => error.status === 2,
+  );
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("triage-dispatch.yml gates the propose agent and pins the model on both jobs", () => {
+  // Structural guard. Without it the gate can be reduced to a step that runs and
+  // is ignored — the agent would still start, and the log would still look right.
+  const yaml = fs.readFileSync(
+    path.join(REPO_ROOT, ".github/workflows/triage-dispatch.yml"),
+    "utf-8",
+  );
+  const lines = yaml.split("\n");
+
+  const gate = lines.findIndex((l) => l.includes("scripts/triage-input-gate.mjs"));
+  assert.ok(gate > 0, "the propose job must run the input gate");
+
+  // Match the STEP, not any mention: a comment in this file also names the
+  // action, and counting it made this guard fail against a correct workflow.
+  const agents = lines
+    .map((l, i) => [l, i])
+    .filter(([l]) => /^\s*-\s+uses:\s*anthropics\/claude-code-action/.test(l))
+    .map(([, i]) => i);
+  assert.equal(agents.length, 2, "expected exactly two agent steps (propose + execute)");
+
+  // The propose agent is the one after the gate, and it must be conditional on it.
+  const proposeAgent = agents.find((i) => i > gate);
+  assert.ok(proposeAgent, "the gate must precede the propose agent step");
+  const proposeBlock = lines.slice(proposeAgent, proposeAgent + 8).join("\n");
+  assert.match(
+    proposeBlock,
+    /should_run_agent == 'true'/,
+    "the propose agent step must be gated on the input verdict",
+  );
+
+  // Model pinned on BOTH jobs — the action's default is claude-opus-5[1m].
+  const pinned = lines.filter((l) => l.includes("--model claude-sonnet-5"));
+  assert.equal(pinned.length, 2, "both claude_args must pin --model claude-sonnet-5");
+  assert.equal(
+    lines.filter((l) => l.includes("claude_args")).length,
+    2,
+    "expected exactly two claude_args lines",
+  );
+});

--- a/scripts/triage-input-gate.test.mjs
+++ b/scripts/triage-input-gate.test.mjs
@@ -189,6 +189,15 @@ test("triage-dispatch.yml gates the propose agent and pins the model on both job
     /should_run_agent == 'true'/,
     "the propose agent step must be gated on the input verdict",
   );
+  // …and the manual path must stay open. A workflow_dispatch downloads no
+  // artifact (there is no triggering run id), so a gate without this escape
+  // hatch would refuse the only way to re-propose on demand — the path #1171's
+  // per-model A/B depends on.
+  assert.match(
+    proposeBlock,
+    /github\.event_name == 'workflow_dispatch'/,
+    "workflow_dispatch must bypass the report gate",
+  );
 
   // Model pinned on BOTH jobs — the action's default is claude-opus-5[1m].
   const pinned = lines.filter((l) => l.includes("--model claude-sonnet-5"));


### PR DESCRIPTION
Closes #1178.

Two changes to `triage-dispatch.yml`: stop the agent when there is nothing to triage, and stop paying Opus prices when nothing here needs Opus.

## Why

From the action's own log on run [30624377765](https://github.com/oriontech-me/langflow-e2e/actions/runs/30624377765):

```
"model": "claude-opus-5[1m]"
"num_turns": 28,
"total_cost_usd": 1.6609247499999995
```

28 of the 30 allowed turns, on the 1M-context Opus, **$1.66** — reasoning over an input that did not exist:

```
::warning::results.json artifact unavailable for run 30624101377
no results.json — history-only.
```

The triggering daily had all four shards fail without producing a blob, so the merge job died on `No report files found in .../all-blobs` and never uploaded `results.json`. The propose job logged that as a warning and started the agent anyway, which reconstructed the run from scratch through `Bash`. That is what filled the transcript and consumed the turn budget.

Triage agent cost over the window in which the shared key drained: **$4.71** (07-29 $2.06 / 25 turns · 07-30 $0.99 / 16 turns · 07-31 $1.66 / 28 turns). For scale, the whole E2E suite's Anthropic spend on 07-31 was ~$0.25 — the 1.8M opus-5 tokens on the console are dominated by cache reads, which is why they cost $1.66 rather than $9. **Token count was not the bill, and a smaller model alone was not the fix.**

## 1. Gate the agent on a usable input

| Report state | Decision |
|---|---|
| artifact absent | skip — the daily produced nothing |
| present, `testsTotal === 0` | skip — infra abort, not a per-test day (#1012) |
| present, `partial` | **run** — some shards aborted while others executed (#1058); the recorded failures are exactly what triage is for |
| present, healthy | run |
| present but unparseable | **exit 2** — an undecidable verdict must not read as "nothing to triage" (#1035) |

It reuses `analyze()` from `scripts/check-run-integrity.mjs` — the daily's own `runguard` logic — rather than re-implementing report parsing, so the two cannot drift apart and the `partial` lookalike is handled by construction. On 30444299314 that shape recorded 205 tests while ~184 never ran; a naive "did anything abort" gate would have skipped the most misleading run the daily can produce.

The skip path is loud: a `::warning::` plus a run-summary line naming the state observed. It deliberately does **not** comment on the umbrella — on an abort there may be none (07-31 opened none), and creating one is the agent's job behind the propose-confirm gate.

**Two paths stay ungated, for the same reason:** `execute` (a human "pode abrir" means a plan already exists) and `workflow_dispatch` (a human asking with an explicit `--issue`, which downloads no artifact — gating it would refuse the only way to re-propose on demand, including the per-model A/B in #1171). The second one was caught by the change-coverage classifier while preparing this PR and is fixed in the second commit, with its own assertion.

## 2. Pin the model

Both `claude_args` omitted `--model`, so the action ran its default, `claude-opus-5[1m]`. Pinning `claude-sonnet-5` keeps the 1M context window this job depends on — it reads CI logs — at 3/5 of the per-token price: **$4.71 → ~$2.80** across the measured runs.

Not haiku. `claude-haiku-4-5` is 1/5 of Opus, but its window is **200K**, and the most expensive runs are the ones with the largest input — it would overflow exactly where it matters. It is worth an A/B once this PR bounds the input, and #1171 is the standing precedent for validating rather than assuming: haiku was measured against the agent specs and **rejected**, failing a `max_iterations` contract 3/3 that sonnet passes.

## Validation

| Check | Result |
|---|---|
| `npm run test:scripts` | 228 passed, 0 failed (9 new) |
| `npm run typecheck` | clean |
| `npm run lint` | 0 errors (pre-existing warnings only) |
| YAML parse | gate precedes the agent; `if` on propose only; `execute` untouched |
| Force-fail ×3 | `if` removed → *must be gated*; execute unpinned → *both claude_args must pin*; escape hatch removed → *workflow_dispatch must bypass* |

Unit coverage is every report state (including the `partial`/`zero` lookalikes), the unparseable hard error, the single-line `GITHUB_OUTPUT` contract (a multi-line `reason` would corrupt every later key), and a structural guard that the agent step is still gated and both jobs still pin the model.

**This PR's own CI cannot exercise the change, and says so rather than implying coverage.** `scripts/ci-change-coverage.mjs` classifies the diff as **`dispatch`** — the surface belongs to another lane. Proof comes from the next red daily's triage run, or from a manual `workflow_dispatch` on an umbrella. What to watch: `should_run_agent`, the `Triage input` / `Triage agent SKIPPED` summary line, and `"model": "claude-sonnet-5"` with a lower `total_cost_usd` in the action's log.

## Not fixed here, and more urgent than cost

The daily itself is aborting: 07-31 recorded zero tests, 07-28 recorded `{passed:0, failed:0, flaky:0, skipped:0}`, today's `daily-history.jsonl` push failed so there is no 07-31 row, and no `[Daily Failure]` umbrella was opened. That is lost coverage, not lost money. It needs its own issue — this PR only stops the agent from paying full price to triage the void.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
