### PR TITLE
test(provider-setup): one tier-aware target resolver, replacing 17 in-spec copies (#1184)

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -297,7 +297,7 @@ jobs:
           # PR that never touches that provider (the recurring #915/#910/#911
           # class). A spec needs models if it lives in an always-LLM area
           # (llm-agents/ or model-provider/) OR its content references a
-          # collect-models consumer (getTestTargets / SimpleAgentTemplatePage /
+          # collect-models consumer (resolveTestTargets / SimpleAgentTemplatePage /
           # provider-setup / models.json / MODEL_TEST_ID / initialGPTsetup /
           # setupOpenAI / resolveGptModel / resolveGeminiModel) — this catches the
           # cross-area consumers (mcp/client agent specs, the loop-component
@@ -327,7 +327,7 @@ jobs:
               tests/tests-automations/regression/core-functionality/llm-agents/*|tests/tests-automations/regression/core-functionality/model-provider/*)
                 NEEDS_MODELS=true; break;;
             esac
-            if grep -qE 'getTestTargets|SimpleAgentTemplatePage|provider-setup|models\.json|MODEL_TEST_ID|initialGPTsetup|setupOpenAI|resolveGptModel|resolveGeminiModel' "$f" 2>/dev/null; then
+            if grep -qE 'resolveTestTargets|SimpleAgentTemplatePage|provider-setup|models\.json|MODEL_TEST_ID|initialGPTsetup|setupOpenAI|resolveGptModel|resolveGeminiModel' "$f" 2>/dev/null; then
               NEEDS_MODELS=true; break
             fi
           done
@@ -453,7 +453,7 @@ jobs:
 
       # Collect provider/model data BEFORE the impacted specs, mirroring
       # daily-stable.yml. Without this, `models.json` is absent (it is
-      # git-ignored) and an agent/LLM spec's `getTestTargets` falls back to
+      # git-ignored) and an agent/LLM spec's `resolveTestTargets` falls back to
       # picking a model straight from the live agent dropdown by name — without
       # validating that the key can access it. On some nightly builds that
       # resolves to a model the CI OPENAI_API_KEY's project cannot use (e.g.
@@ -566,7 +566,7 @@ jobs:
           # here is a HARD gate (not `continue-on-error`), so a failed sweep has
           # already reddened the job and there is no surviving run to warn about.
 
-      # Pin this lane to ONE provider's settled model (#1169). getTestTargets()
+      # Pin this lane to ONE provider's settled model (#1169). resolveTestTargets()
       # parametrizes over one model per active provider, so every impacted agent
       # spec runs an openai AND an anthropic AND a google variant here. That is
       # daily-stable.yml's job — it is the lane that owes multi-provider coverage.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,33 +152,29 @@ Basic structure:
 ```typescript
 import * as dotenv from "dotenv";
 import path from "path";
-import fs from "fs";
 import { test, expect } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
 import { hasProviderEnvKeys, type Provider } from "../../../../helpers/provider-setup";
-import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
+import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targets";
 
 if (!process.env.CI) {
   dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
 }
 
-// Read models and apply the .env strategy
-function getTestTargets() {
-  const jsonPath = path.resolve(__dirname, "../../../../helpers/provider-setup/data/models.json");
-  if (!fs.existsSync(jsonPath)) return [];
-  const allModels = JSON.parse(fs.readFileSync(jsonPath, "utf-8"));
-  // Inactive providers, so their targets report as skipped with the collected
-  // reason. Never inline this — one shared implementation (#1043).
-  const skipReasons = providerSkipReasons();
-  // apply strategy filter (see agent-component-regression.spec.ts for full implementation)
-  return allModels.map((m: any) => ({
-    label: `${m.provider} / ${m.model}`,
-    options: { provider: m.provider as Provider, model: m.model },
-    skipReason: skipReasons.get(m.provider),
-  }));
-}
-
-const targets = getTestTargets();
+// One shared resolver — NEVER inline a copy of this (#1184). It reads models.json,
+// applies the .env strategy (MODEL_TEST_ID → MODEL_TEST_PROVIDER → ALL_MODELS → one
+// per provider) and attaches each provider's inactive-skip reason. Seventeen specs
+// used to carry their own copy and they had drifted into five variants, two of which
+// silently ignored MODEL_TEST_ID — same drift #1043 removed for providerSkipReasons.
+//
+// `tier` declares what the spec needs from a lane, so a lane can pick the cheapest
+// target that satisfies it (#1185, #1187) instead of guessing per spec:
+//   "tool-calling"     — the assertion IS model capability (tools, structured output)
+//   "any-completion"   — any model that returns text; the assertion is plumbing
+//   "none"             — no inference at all (modals, invalid-key UI)
+// Add `requires: "vision" | "chat"` when the spec needs a specific capability
+// WITHIN the provider.
+const targets = resolveTestTargets({ tier: "tool-calling" });
 
 for (const { label, options, skipReason } of targets) {
   const provider = options.provider ?? "openai";
@@ -347,7 +343,7 @@ await page.getByText("Anthropic").click();
 await page.getByTestId("popover-anchor-input-api_key").fill(process.env.ANTHROPIC_API_KEY);
 
 // ✅ CORRECT — parameterized by the project's provider infrastructure
-for (const { label, options, skipReason } of getTestTargets()) {
+for (const { label, options, skipReason } of resolveTestTargets({ tier: "tool-calling" })) {
   test.describe.serial(`My Test [${label}]`, () => {
     test("should ...", async ({ page }) => {
       await new SimpleAgentTemplatePage(page).load(options);

--- a/docs/core-functionality/llm-agents/agent-component-regression.md
+++ b/docs/core-functionality/llm-agents/agent-component-regression.md
@@ -24,7 +24,7 @@ no code change was needed, only the verification.
 
 ## Step by step *(required)*
 
-The spec generates **2 tests per active model** via `getTestTargets()`. By default (nightly/CI) it runs 1 model per provider; `ALL_MODELS=true` runs all models from `models.json`.
+The spec generates **2 tests per active model** via `resolveTestTargets()`. By default (nightly/CI) it runs 1 model per provider; `ALL_MODELS=true` runs all models from `models.json`.
 
 ---
 
@@ -116,7 +116,7 @@ Kept separate from the suite because it interrupts the execution state.
 
 ## Notes *(optional)*
 - **Test structure**: 2 tests per model — `agent interaction suite` (5 validations in `test.step` with `expect.soft`) and `agent stop button` (kept separate because it is destructive). Using `expect.soft` ensures all validations run even if one fails, without losing visibility.
-- **Model selection**: by default (`ALL_MODELS` omitted), `getTestTargets()` returns 1 model per active provider (the first one in `models.json`). To run all models: `ALL_MODELS=true`. To filter by provider: `MODEL_TEST_PROVIDER=openai`. For a specific model: `MODEL_TEST_ID=gpt-4o-mini`.
+- **Model selection**: by default (`ALL_MODELS` omitted), `resolveTestTargets()` returns 1 model per active provider (the first one in `models.json`). To run all models: `ALL_MODELS=true`. To filter by provider: `MODEL_TEST_PROVIDER=openai`. For a specific model: `MODEL_TEST_ID=gpt-4o-mini`.
 - **Streaming assertion**: waits for Stop to appear (confirms the model is actively generating), then polls `div-chat-message` text length every 100ms for up to 5s. If text grows during the polling window → streaming confirmed, loop exits early. If Stop never appears → validates final text is non-empty and returns early (step passes, remaining steps continue). If growth is not observed (Stop gone before growth, or model renders faster than the poll interval, or `div-chat-message` testid is applied only after streaming completes) → no assertion; the final-text `expect.soft` is the safety net for truly broken streaming. This replaces the previous fixed 3s sleep + conditional guard that silently passed for fast models.
 - **"Finished in Xs" in the Playground**: conditional check — the text appears in `BotMessage` based on the `isBuilding` cycle of `useFlowStore`; not guaranteed in multi-message sessions or with models that respond very quickly. The canonical duration assertion is `node_duration_agent` on the canvas.
 - **The stop test asserts the Stop button, it no longer probes for it (#992).** It used to read `isVisible({ timeout: 30000 }).catch(() => false)` and `return` early when the button was absent, on the rationale that a fast model may answer before the button renders. That rationale rested on a false premise: `locator.isVisible()` **never waits** — Playwright marks its `timeout` option `@deprecated: this option is ignored` — so the check fired instantaneously, microseconds after the send click, and any render latency at all turned the whole test into a silent no-op that asserted nothing while reporting green. As a `@stable` test that would blind the daily on this surface. The gate is now `expect(stopButton).toBeVisible({ timeout: 30000 })`, which polls for real. The prompt asks for a long story, so the button is visible for the whole stream on every model target; if some future model does finish before it renders, the failure is the correct signal — investigate then, do not restore the bypass.

--- a/docs/core-functionality/llm-agents/agent-current-date-tool.md
+++ b/docs/core-functionality/llm-agents/agent-current-date-tool.md
@@ -72,7 +72,7 @@ guards the toggle→toolkit wiring; `@agents` — agent tool configuration;
 
 ## Step by step *(required)*
 
-The spec generates tests per active model via the `getTestTargets()`
+The spec generates tests per active model via the `resolveTestTargets()`
 machinery (family standard). Per model, a serial describe with two tests:
 
 **Test 1 — toggle ON (default): the date tool exists and returns today (§6.5)**

--- a/docs/core-functionality/llm-agents/agent-empty-refusal-response.md
+++ b/docs/core-functionality/llm-agents/agent-empty-refusal-response.md
@@ -57,7 +57,7 @@ the model through the Playground.
 
 ## Step by step *(required)*
 
-The spec generates **2 tests per active model** via `getTestTargets()` (default:
+The spec generates **2 tests per active model** via `resolveTestTargets()` (default:
 1 model per active provider; `ALL_MODELS=true` runs all models in `models.json`;
 `MODEL_TEST_ID` / `MODEL_TEST_PROVIDER` narrow it). A per-run marker
 `REFUSE-<Date.now()>-<rand>` makes each refusal unambiguous.

--- a/docs/core-functionality/llm-agents/agent-input-sources.md
+++ b/docs/core-functionality/llm-agents/agent-input-sources.md
@@ -49,7 +49,7 @@ drives input through the Playground.
 
 ## Step by step *(required)*
 
-The spec generates **2 tests per active model** via `getTestTargets()` (default:
+The spec generates **2 tests per active model** via `resolveTestTargets()` (default:
 1 model per active provider; `ALL_MODELS=true` runs all models in `models.json`).
 A per-run token `SENTINEL_<Date.now()>` is generated so a match is unambiguous.
 

--- a/docs/core-functionality/llm-agents/agent-markdown-output.md
+++ b/docs/core-functionality/llm-agents/agent-markdown-output.md
@@ -60,9 +60,17 @@ achieved. Absence of `@stable` is explained here per the PR checklist.
 
 ## Step by step *(required)*
 
-The spec generates **1 test per active model** via `getTestTargets()` (default:
-one chat model per active provider), reusing the Simple Agent parameterization
-pattern from `agent-multimodal-image-input.spec.ts`.
+The spec generates **1 test per active model** via
+`resolveTestTargets({ tier: "tool-calling", requires: "chat" })` (default: one chat
+model per active provider). `requires: "chat"` excludes the non-chat families
+(embedding / tts / audio / whisper / realtime / image / moderation / search).
+
+**Changed in #1184:** this spec carried its own copy of the resolver with **no
+`MODEL_TEST_ID` branch**, so pinning a model did not pin this spec — it kept running
+one target per provider. It now honours the documented env precedence like every
+other parametrized spec, which also means `MODEL_TEST_PROVIDER` alone sweeps that
+provider's chat catalog rather than narrowing to one model. Use the
+`MODEL_TEST_PROVIDER` + `MODEL_TEST_ID` pair to narrow.
 
 ---
 

--- a/docs/core-functionality/llm-agents/agent-max-iterations.md
+++ b/docs/core-functionality/llm-agents/agent-max-iterations.md
@@ -58,7 +58,7 @@ through the Playground.
 
 ## Step by step *(required)*
 
-The spec generates **2 tests per active model** via `getTestTargets()` (default:
+The spec generates **2 tests per active model** via `resolveTestTargets()` (default:
 1 model per active provider). The limit message and the arithmetic answer are
 provider-agnostic (Langflow-level), so any chat model works.
 

--- a/docs/core-functionality/llm-agents/agent-max-tokens.md
+++ b/docs/core-functionality/llm-agents/agent-max-tokens.md
@@ -65,7 +65,7 @@ the token-usage observable live in the Playground.
 
 ## Step by step *(required)*
 
-The spec generates **2 tests per active model** via `getTestTargets()`
+The spec generates **2 tests per active model** via `resolveTestTargets()`
 (default: 1 model per active provider).
 
 Shared setup per test:

--- a/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
+++ b/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
@@ -104,7 +104,7 @@ unaffected (never depended on httpbin).
 
 ## Step by step *(required)*
 
-The spec generates tests per active model via the `getTestTargets()`
+The spec generates tests per active model via the `resolveTestTargets()`
 machinery (same as `agent-tool-error-handling.spec.ts`). Per model, a serial
 describe with two tests:
 

--- a/docs/core-functionality/llm-agents/agent-multimodal-image-input.md
+++ b/docs/core-functionality/llm-agents/agent-multimodal-image-input.md
@@ -57,9 +57,19 @@ Playground.
 
 ## Step by step *(required)*
 
-The spec generates **2 tests per active model** via `getTestTargets()` (default:
-1 vision model per active provider). It resolves a vision-capable model for the
-target provider; if none is available the provider is skipped.
+The spec generates **2 tests per active model** via
+`resolveTestTargets({ tier: "tool-calling", requires: "vision" })` (default: 1 vision
+model per active provider). `requires: "vision"` resolves a vision-capable model for
+the target provider — preferring the one `collect-models` settled on, falling back to
+the per-provider preference list only when that model cannot serve vision (#964); if
+none is available the provider is skipped with that reason.
+
+**Changed in #1184:** this spec carried its own copy of the resolver with **no
+`MODEL_TEST_ID` branch**, so pinning a model did not pin this spec — it kept running
+one target per provider. It now honours the documented env precedence like every
+other parametrized spec, which also means `MODEL_TEST_PROVIDER` alone sweeps that
+provider's vision-capable catalog rather than narrowing to one model. Use the
+`MODEL_TEST_PROVIDER` + `MODEL_TEST_ID` pair to narrow.
 
 ---
 

--- a/docs/core-functionality/llm-agents/agent-system-prompt.md
+++ b/docs/core-functionality/llm-agents/agent-system-prompt.md
@@ -97,9 +97,10 @@ reliable signal (fail — invalidates the positive assertion).
 
 ## Model strategy
 
-- Parameterized per provider/model from `models.json` (inline `getTestTargets`,
-  mirroring `agent-component-regression.spec.ts` in this folder — there is no
-  shared export yet).
+- Parameterized per provider/model from `models.json` via the shared
+  `resolveTestTargets({ tier: "tool-calling" })` in
+  `helpers/provider-setup/test-targets.ts` (#1184 replaced the inline copy this
+  spec used to mirror from `agent-component-regression.spec.ts`).
 - Requires `collect-models.spec.ts` to have run and at least one provider API key
   in `.env`. Without keys/data, every target skips with a reason (no false pass).
 - Run with `--workers=1` (agent specs create named flows that collide in parallel).

--- a/docs/core-functionality/llm-agents/agent-tool-error-handling.md
+++ b/docs/core-functionality/llm-agents/agent-tool-error-handling.md
@@ -77,7 +77,7 @@ running as concurrent load.
 
 ## Step by step *(required)*
 
-The spec generates **1 test per active model** via `getTestTargets()` (same
+The spec generates **1 test per active model** via `resolveTestTargets()` (same
 machinery as `agent-max-iterations.spec.ts` / `agent-tool-name-validation.spec.ts`).
 
 **Test — agent handles a tool error and continues execution** (§6.4)

--- a/docs/core-functionality/llm-agents/agent-tool-inspection.md
+++ b/docs/core-functionality/llm-agents/agent-tool-inspection.md
@@ -59,7 +59,7 @@ promotion is gated on the clean non-guarded baseline (#818), per issue #827.
 - Langflow running at `PLAYWRIGHT_BASE_URL`.
 - `models.json` / `providers.json` generated via
   `npx playwright test tests/collect-models.spec.ts`.
-- One active provider (resolved via `getTestTargets` — `MODEL_TEST_ID` /
+- One active provider (resolved via `resolveTestTargets` — `MODEL_TEST_ID` /
   `MODEL_TEST_PROVIDER` when set, else one model per active provider; the
   inspection surface is provider-agnostic).
 - Run with `--workers=1` (agent-family convention — shared instance state).

--- a/docs/core-functionality/llm-agents/agent-tool-name-validation.md
+++ b/docs/core-functionality/llm-agents/agent-tool-name-validation.md
@@ -66,7 +66,7 @@ Playground.
 
 ## Step by step *(required)*
 
-The spec generates **2 tests per active model** via `getTestTargets()`
+The spec generates **2 tests per active model** via `resolveTestTargets()`
 (default: 1 model per active provider — same machinery as
 `agent-max-iterations.spec.ts`).
 

--- a/docs/mcp/client/mcp-client-agent.md
+++ b/docs/mcp/client/mcp-client-agent.md
@@ -73,4 +73,13 @@ Validates that an LLM agent can discover and call an MCP tool mid-conversation v
 
 - `SimpleAgentTemplatePage.load()` deletes all existing flows before loading the template. MCP server registration must happen after the template loads, as server data lives in a separate DB table and survives the cleanup.
 - The test is parameterized: one describe block is generated per active provider in `models.json`. Run with `--workers=1` to prevent parallel workers from deleting each other's flows.
+
+- **Test title changed in #1184 when `MODEL_TEST_ID` is set.** This spec used to carry its own copy of the target resolver, and that copy labelled the pinned target `model:<id>` rather than `<provider> / <id>`. Under the shared `resolveTestTargets()` it matches every other parametrized spec:
+
+  | | Describe title with `MODEL_TEST_ID=gpt-4o-mini` |
+  |---|---|
+  | Before | `MCP Client – Agent using MCPTools [model:gpt-4o-mini]` |
+  | After | `MCP Client – Agent using MCPTools [openai / gpt-4o-mini]` |
+
+  The new title is the better one — it names the provider, which the old one hid — but it is a **change of test identity**, and identity is the key for `results.json`, `spec-durations.json` and the Flakiness.io history. So this test's history on the pinned lanes starts fresh: `pr-validation.yml` pins today (#1169), and `daily-stable.yml` will once #1185 lands. Recorded here rather than discovered later from a duration outlier or a reset flake rate.
 - Handle testids for the connection step: `handle-mcp-shownode-toolset-right` (MCPTools output — normalized to `mcp`, not `mcp tools`) and `handle-agent-shownode-tools-left` (Agent tools input).

--- a/scripts/ci-change-coverage.test.mjs
+++ b/scripts/ci-change-coverage.test.mjs
@@ -136,7 +136,7 @@ test("every canary spec exists, is @stable, and needs no provider model", () => 
   // The three properties that make the canary usable: it exists (or the CLI
   // aborts), it is validated, and it never depends on provider key health — a
   // canary that skips on a drained key proves nothing (#915/#910/#911).
-  const LLM = /getTestTargets|SimpleAgentTemplatePage|provider-setup|models\.json|MODEL_TEST_ID|initialGPTsetup|setupOpenAI|resolveGptModel|resolveGeminiModel/;
+  const LLM = /resolveTestTargets|SimpleAgentTemplatePage|provider-setup|models\.json|MODEL_TEST_ID|initialGPTsetup|setupOpenAI|resolveGptModel|resolveGeminiModel/;
   for (const spec of CANARY_SPECS) {
     const file = path.join(REPO_ROOT, spec);
     assert.ok(fs.existsSync(file), `canary spec missing: ${spec}`);

--- a/scripts/select-pr-model-target.mjs
+++ b/scripts/select-pr-model-target.mjs
@@ -5,7 +5,7 @@
  *
  * ## Why the PR lane pins one provider at all
  *
- * `getTestTargets()` (~17 agent specs) parametrizes over **one model per active
+ * `resolveTestTargets()` (~17 agent specs) parametrizes over **one model per active
  * provider**, so every LLM spec selected by the impacted-specs job runs once per
  * provider whose key is in the repo secrets — openai *and* anthropic *and* google.
  * That is the right shape for `daily-stable.yml`, which is the lane that owes
@@ -28,7 +28,7 @@
  * Two reasons, both of which have already bitten this repo:
  *
  * 1. **`MODEL_TEST_PROVIDER` alone is a trap, not a filter.** In
- *    `getTestTargets()` the `MODEL_TEST_PROVIDER` branch filters the catalog by
+ *    `resolveTestTargets()` the `MODEL_TEST_PROVIDER` branch filters the catalog by
  *    provider and **skips the first-per-provider dedup**, so setting it without
  *    `MODEL_TEST_ID` runs *every* model that provider exposes — 41 openai entries
  *    in the catalog collected 2026-07-30. That turns a cost fix into a 41x cost
@@ -36,7 +36,7 @@
  *    without the other.
  * 2. **The model has to be the settled one.** Hardcoding `gpt-4o-mini` in YAML
  *    fails silently the day it retires or the CI project loses access:
- *    `getTestTargets()` warns `MODEL_TEST_ID="…" not found in models.json` and
+ *    `resolveTestTargets()` warns `MODEL_TEST_ID="…" not found in models.json` and
  *    returns a target with no provider, so the spec skips and the PR still reads
  *    green — the exact silent-skip failure #570 and #1012 exist to prevent.
  *    `providers.json` already records what `collect-models` probed successfully;
@@ -222,7 +222,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 
   if (result.ok) {
     // Both variables, always together — MODEL_TEST_PROVIDER on its own makes
-    // getTestTargets skip the per-provider dedup and run the whole catalog.
+    // resolveTestTargets skip the per-provider dedup and run the whole catalog.
     const lines = [
       `MODEL_TEST_ID=${result.model}`,
       `MODEL_TEST_PROVIDER=${result.provider}`,

--- a/scripts/select-pr-model-target.test.mjs
+++ b/scripts/select-pr-model-target.test.mjs
@@ -4,7 +4,7 @@
 // Why these exist: the two ways to get this wrong both read as success.
 //
 //  - Emitting `MODEL_TEST_PROVIDER` without `MODEL_TEST_ID` does not narrow the
-//    lane, it *widens* it: `getTestTargets()` skips the first-per-provider dedup
+//    lane, it *widens* it: `resolveTestTargets()` skips the first-per-provider dedup
 //    on that branch and runs every model the provider exposes (41 openai entries
 //    in the 2026-07-30 catalog). A cost fix that becomes a 41x cost regression
 //    would look exactly like a working one in the log, so the pair invariant is

--- a/tests/helpers/provider-setup/test-targets.test.ts
+++ b/tests/helpers/provider-setup/test-targets.test.ts
@@ -238,6 +238,55 @@ test("ALL_MODELS reports each emptied provider once, and keeps catalog order for
   ]);
 });
 
+test("a sweep on a provider absent from the catalog REPORTS instead of running nothing", () => {
+  // Round-2 review finding, and NOT introduced by #1184 — the pre-existing copies
+  // filtered identically and had the same hole. Consolidating them is what made it
+  // fixable in one place. Highly reachable: the catalog keys are lowercase while the
+  // UI/testids use display casing, so `MODEL_TEST_PROVIDER=OpenAI` silently ran zero
+  // tests and read green.
+  for (const name of ["anthropic", "OpenAI"]) {
+    const targets = resolveTestTargets({
+      tier: "tool-calling",
+      env: { MODEL_TEST_PROVIDER: name },
+      models: [{ provider: "openai", model: "gpt-4o-mini" }],
+      skipReasons: NO_SKIPS,
+    });
+    assert.equal(targets.length, 1, `${name} must report, not vanish`);
+    assert.deepEqual(labels(targets), [`provider:${name} (not in catalog)`]);
+    assert.match(targets[0].skipReason ?? "", /matches no model in models\.json/);
+    assert.match(targets[0].skipReason ?? "", /present: openai/);
+  }
+});
+
+test("the absent-provider report also fires with a capability filter set", () => {
+  const targets = resolveTestTargets({
+    tier: "tool-calling",
+    requires: "vision",
+    env: { MODEL_TEST_PROVIDER: "anthropic" },
+    models: [{ provider: "openai", model: "gpt-4o-mini" }],
+    skipReasons: NO_SKIPS,
+  });
+  assert.equal(targets.length, 1);
+  assert.match(targets[0].skipReason ?? "", /matches no model in models\.json/);
+});
+
+test("the unfit-pin reason points at the heuristic, since it matches on substrings", () => {
+  // `gemini-2.5-flash-image` and `gpt-4o-image-preview` are excluded by NON_VISION
+  // purely because their names contain "image", so an explicit pin of a genuinely
+  // vision-capable model can be refused. The refusal is a reported skip, not a false
+  // pass — but the message has to say the exclusion is a heuristic, or the reader is
+  // told to "pin a vision-capable model" when they just did.
+  const targets = resolveTestTargets({
+    tier: "tool-calling",
+    requires: "vision",
+    env: { MODEL_TEST_ID: "gemini-2.5-flash-image" },
+    models: [{ provider: "google", model: "gemini-2.5-flash-image" }],
+    skipReasons: NO_SKIPS,
+  });
+  assert.match(targets[0].skipReason ?? "", /name heuristic/);
+  assert.match(targets[0].skipReason ?? "", /matches on substrings/);
+});
+
 test("a pinned MODEL_TEST_ID that cannot serve the capability is REPORTED, not run", () => {
   // The second review finding. The two capability specs had no MODEL_TEST_ID branch
   // at all, so they could never be handed an unfit model; gaining one without this
@@ -251,7 +300,7 @@ test("a pinned MODEL_TEST_ID that cannot serve the capability is REPORTED, not r
     skipReasons: NO_SKIPS,
   });
   assert.equal(targets.length, 1);
-  assert.match(targets[0].skipReason ?? "", /cannot serve "vision"/);
+  assert.match(targets[0].skipReason ?? "", /excluded from "vision"/);
   assert.match(targets[0].skipReason ?? "", /pin a vision-capable model/);
 });
 

--- a/tests/helpers/provider-setup/test-targets.test.ts
+++ b/tests/helpers/provider-setup/test-targets.test.ts
@@ -1,0 +1,291 @@
+// Unit tests for the tier-aware target resolver (issue #1184).
+// Run with: npm run test:units
+//
+// What rides on this function: it decides which { provider, model } every
+// parametrized LLM spec runs against — ~30 `@stable` tests across 17 files that
+// used to each carry their own copy. Two failure directions, both expensive and
+// both silent:
+//
+//  - Resolving MORE targets than before multiplies real paid inference across the
+//    daily. The `MODEL_TEST_PROVIDER` sweep is exactly one such multiplier: 41
+//    openai entries in the 2026-07-30 catalog.
+//  - Resolving FEWER, or resolving a target with no provider, makes specs skip while
+//    the run stays green — the #570 / #1012 failure this repo keeps re-learning.
+//
+// So the parity block below is the point of the file: for each of the five variants
+// the copies had drifted into, assert the resolver reproduces what that variant
+// produced. Everything else is the sharp edges.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  resolveTestTargets,
+  type ModelRecord,
+  type TestTarget,
+} from "./test-targets";
+
+/** Shaped like a real models.json: settled model first per provider (collect-models
+ * promotes it), with the rejected/unsuitable ones still listed behind it. */
+const CATALOG: ModelRecord[] = [
+  { provider: "openai", model: "gpt-4o-mini" },
+  { provider: "openai", model: "gpt-image-1" },
+  { provider: "openai", model: "text-embedding-3-small" },
+  { provider: "anthropic", model: "claude-sonnet-5" },
+  { provider: "anthropic", model: "claude-haiku-4-5" },
+  { provider: "google", model: "gemini-2.5-flash" },
+];
+
+const NO_SKIPS = new Map<string, string>();
+
+/** Every call site passes these seams; `env` defaults to process.env otherwise. */
+function resolve(
+  env: NodeJS.ProcessEnv,
+  extra: Partial<Parameters<typeof resolveTestTargets>[0]> = {},
+): TestTarget[] {
+  return resolveTestTargets({
+    tier: "tool-calling",
+    env,
+    models: CATALOG,
+    skipReasons: NO_SKIPS,
+    ...extra,
+  });
+}
+
+const labels = (targets: TestTarget[]): string[] => targets.map((t) => t.label);
+
+// ─── Parity with the five pre-#1184 variants ─────────────────────────────────
+
+test("parity A/B: no env set resolves one model per provider, catalog order", () => {
+  const targets = resolve({});
+  assert.deepEqual(labels(targets), [
+    "openai / gpt-4o-mini",
+    "anthropic / claude-sonnet-5",
+    "google / gemini-2.5-flash",
+  ]);
+  assert.deepEqual(
+    targets.map((t) => t.options),
+    [
+      { provider: "openai", model: "gpt-4o-mini" },
+      { provider: "anthropic", model: "claude-sonnet-5" },
+      { provider: "google", model: "gemini-2.5-flash" },
+    ],
+  );
+});
+
+test("parity A/B: MODEL_TEST_ID resolves one target and infers its provider", () => {
+  const targets = resolve({ MODEL_TEST_ID: "claude-haiku-4-5" });
+  assert.deepEqual(labels(targets), ["anthropic / claude-haiku-4-5"]);
+  assert.deepEqual(targets[0].options, {
+    provider: "anthropic",
+    model: "claude-haiku-4-5",
+  });
+});
+
+test("parity D: requires vision skips the non-vision families", () => {
+  // The vision copy excluded image/embedding models and preferred the settled one.
+  const targets = resolve({}, { requires: "vision" });
+  assert.deepEqual(labels(targets), [
+    "openai / gpt-4o-mini",
+    "anthropic / claude-sonnet-5",
+    "google / gemini-2.5-flash",
+  ]);
+});
+
+test("parity D: a provider with no vision model reports it instead of skipping blind", () => {
+  const targets = resolveTestTargets({
+    tier: "tool-calling",
+    requires: "vision",
+    env: {},
+    models: [{ provider: "openai", model: "gpt-image-1" }],
+    skipReasons: NO_SKIPS,
+  });
+  assert.deepEqual(labels(targets), ["openai / (no vision model)"]);
+  assert.equal(
+    targets[0].skipReason,
+    'Provider "openai" has no vision-capable model in models.json',
+  );
+});
+
+test("parity E: the chat wording is preserved verbatim, not unified with vision", () => {
+  const targets = resolveTestTargets({
+    tier: "tool-calling",
+    requires: "chat",
+    env: {},
+    models: [{ provider: "openai", model: "text-embedding-3-small" }],
+    skipReasons: NO_SKIPS,
+  });
+  assert.deepEqual(labels(targets), ["openai / (no chat model)"]);
+  assert.equal(
+    targets[0].skipReason,
+    'Provider "openai" has no chat model in models.json',
+  );
+});
+
+test("vision prefers the SETTLED model over its own preference list (#964)", () => {
+  // The assertion the first force-fail pass showed was missing. Settled-first is
+  // only observable when the settled model IS capable and the preference list would
+  // pick a different one — which is the #964 failure verbatim: the spec preferred a
+  // hardcoded `gemini-*` alias over the model collect-models had actually validated,
+  // and Google had retired the alias. Without this, dropping settled-first is a
+  // silent behaviour change.
+  const targets = resolveTestTargets({
+    tier: "tool-calling",
+    requires: "vision",
+    env: {},
+    models: [
+      { provider: "google", model: "gemini-3.5-flash" }, // settled, promoted to front
+      { provider: "google", model: "gemini-flash-latest" }, // VISION_PREFS' first choice
+    ],
+    skipReasons: NO_SKIPS,
+  });
+  assert.deepEqual(labels(targets), ["google / gemini-3.5-flash"]);
+});
+
+test("vision falls back to VISION_PREFS only when the settled model cannot serve it", () => {
+  // Settled model first and NOT vision-capable → the preference scan picks gpt-4o.
+  const targets = resolveTestTargets({
+    tier: "tool-calling",
+    requires: "vision",
+    env: {},
+    models: [
+      { provider: "openai", model: "gpt-image-1" },
+      { provider: "openai", model: "gpt-4.1-mini" },
+      { provider: "openai", model: "gpt-4o" },
+    ],
+    skipReasons: NO_SKIPS,
+  });
+  assert.deepEqual(labels(targets), ["openai / gpt-4o"]);
+});
+
+// ─── The sharp edges ─────────────────────────────────────────────────────────
+
+test("MODEL_TEST_PROVIDER alone SWEEPS the provider's catalog — documented, and the cost multiplier", () => {
+  // This is the behaviour README / .env.example / CONTRIBUTING document, and the
+  // reason select-pr-model-target.mjs never emits this variable without
+  // MODEL_TEST_ID (#1169). If this assertion ever flips to a single target,
+  // the docs and that script must change in the same commit.
+  const targets = resolve({ MODEL_TEST_PROVIDER: "openai" });
+  assert.deepEqual(labels(targets), [
+    "openai / gpt-4o-mini",
+    "openai / gpt-image-1",
+    "openai / text-embedding-3-small",
+  ]);
+});
+
+test("the pair MODEL_TEST_PROVIDER + MODEL_TEST_ID narrows to one — this is what pins a lane", () => {
+  const targets = resolve({
+    MODEL_TEST_PROVIDER: "openai",
+    MODEL_TEST_ID: "gpt-4o-mini",
+  });
+  assert.deepEqual(labels(targets), ["openai / gpt-4o-mini"]);
+});
+
+test("a swept provider still honours the capability filter", () => {
+  const targets = resolve({ MODEL_TEST_PROVIDER: "openai" }, { requires: "chat" });
+  assert.deepEqual(labels(targets), ["openai / gpt-4o-mini"]);
+});
+
+test("ALL_MODELS=true sweeps every provider", () => {
+  const targets = resolve({ ALL_MODELS: "true" });
+  assert.equal(targets.length, CATALOG.length);
+});
+
+test("MODEL_TEST_ID outranks MODEL_TEST_PROVIDER across providers", () => {
+  // Behaviour change for the two copies that had no MODEL_TEST_ID branch, made
+  // explicit so it is a decision and not a regression discovered later.
+  const targets = resolve({
+    MODEL_TEST_PROVIDER: "openai",
+    MODEL_TEST_ID: "claude-sonnet-5",
+  });
+  assert.deepEqual(labels(targets), ["anthropic / claude-sonnet-5"]);
+});
+
+test("an id absent from the catalog returns a provider-less target AND warns", () => {
+  // The silent-skip path (#570 / #1012). mcp-client-agent's copy took it without
+  // printing anything, which is the one thing this must never do again.
+  const warnings: string[] = [];
+  const original = console.warn;
+  console.warn = (msg: unknown) => void warnings.push(String(msg));
+  try {
+    const targets = resolve({ MODEL_TEST_ID: "gpt-9-imaginary" });
+    assert.deepEqual(labels(targets), ["model:gpt-9-imaginary"]);
+    assert.equal(targets[0].options.provider, undefined);
+  } finally {
+    console.warn = original;
+  }
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /not found in models\.json/);
+});
+
+test("an empty catalog falls back to the first configured provider AND warns", () => {
+  const warnings: string[] = [];
+  const original = console.warn;
+  console.warn = (msg: unknown) => void warnings.push(String(msg));
+  let targets: TestTarget[];
+  try {
+    targets = resolveTestTargets({
+      tier: "tool-calling",
+      env: {},
+      models: [],
+      skipReasons: NO_SKIPS,
+    });
+  } finally {
+    console.warn = original;
+  }
+  assert.deepEqual(labels(targets), ["provider:openai (fallback)"]);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /run collect-models\.spec\.ts first/);
+});
+
+test("skipReason from provider health reaches every target and outranks the capability reason", () => {
+  const skips = new Map([["anthropic", "Anthropic key drained"]]);
+  const targets = resolve({}, { skipReasons: skips });
+  const anthropic = targets.find((t) => t.options.provider === "anthropic");
+  assert.equal(anthropic?.skipReason, "Anthropic key drained");
+  assert.equal(targets.find((t) => t.options.provider === "openai")?.skipReason, undefined);
+});
+
+test("an unreadable models.json degrades to the fallback instead of throwing at collection time", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "test-targets-"));
+  const bad = path.join(dir, "models.json");
+  fs.writeFileSync(bad, "{ not json");
+  const original = console.warn;
+  console.warn = () => {};
+  try {
+    const targets = resolveTestTargets({
+      tier: "tool-calling",
+      env: {},
+      skipReasons: NO_SKIPS,
+      catalogPath: bad,
+    });
+    assert.deepEqual(labels(targets), ["provider:openai (fallback)"]);
+  } finally {
+    console.warn = original;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ─── Structural guard: the provider-contract layer must stay unpinnable ──────
+
+test("provider-contract specs read neither pin variable — this is what #1185 relies on", () => {
+  // core-functionality/model-provider/*-provider.spec.ts is the layer that keeps
+  // multi-provider coverage once the daily pins the tool-calling tier. If one of
+  // them starts reading MODEL_TEST_ID / MODEL_TEST_PROVIDER, the pin silently
+  // narrows the contract layer too and the coverage argument in #1185 stops holding.
+  const dir = path.join(
+    __dirname,
+    "../../tests-automations/regression/core-functionality/model-provider",
+  );
+  const specs = fs.readdirSync(dir).filter((f) => f.endsWith(".spec.ts"));
+  assert.ok(specs.length >= 6, `expected the provider-contract specs, found ${specs.length}`);
+  for (const spec of specs) {
+    const source = fs.readFileSync(path.join(dir, spec), "utf-8");
+    assert.doesNotMatch(
+      source,
+      /MODEL_TEST_ID|MODEL_TEST_PROVIDER/,
+      `${spec} reads a pin variable — see #1185`,
+    );
+  }
+});

--- a/tests/helpers/provider-setup/test-targets.test.ts
+++ b/tests/helpers/provider-setup/test-targets.test.ts
@@ -187,6 +187,90 @@ test("a swept provider still honours the capability filter", () => {
   assert.deepEqual(labels(targets), ["openai / gpt-4o-mini"]);
 });
 
+test("a sweep whose capability filter empties a provider REPORTS it instead of vanishing", () => {
+  // The review's worst finding: the filter could empty the list and the branch
+  // returned [], so the spec declared zero tests, contributed nothing to the report,
+  // and read green under --pass-with-no-tests. The same catalog must not be
+  // "reported" on the default path and "invisible" on the sweep path (#570 / #1012).
+  const catalog = [
+    { provider: "openai", model: "text-embedding-3-small" },
+    { provider: "openai", model: "gpt-image-1" },
+  ];
+  const swept = resolveTestTargets({
+    tier: "tool-calling",
+    requires: "vision",
+    env: { MODEL_TEST_PROVIDER: "openai" },
+    models: catalog,
+    skipReasons: NO_SKIPS,
+  });
+  const byDefault = resolveTestTargets({
+    tier: "tool-calling",
+    requires: "vision",
+    env: {},
+    models: catalog,
+    skipReasons: NO_SKIPS,
+  });
+  assert.deepEqual(labels(swept), ["openai / (no vision model)"]);
+  assert.deepEqual(labels(swept), labels(byDefault), "the two paths must agree");
+  assert.equal(
+    swept[0].skipReason,
+    'Provider "openai" has no vision-capable model in models.json',
+  );
+});
+
+test("ALL_MODELS reports each emptied provider once, and keeps catalog order for the capable ones", () => {
+  const catalog = [
+    { provider: "openai", model: "gpt-4o-mini" },
+    { provider: "openai", model: "gpt-4o" },
+    { provider: "google", model: "gemini-embedding-001" },
+  ];
+  const targets = resolveTestTargets({
+    tier: "tool-calling",
+    requires: "vision",
+    env: { ALL_MODELS: "true" },
+    models: catalog,
+    skipReasons: NO_SKIPS,
+  });
+  assert.deepEqual(labels(targets), [
+    "openai / gpt-4o-mini",
+    "openai / gpt-4o",
+    "google / (no vision model)",
+  ]);
+});
+
+test("a pinned MODEL_TEST_ID that cannot serve the capability is REPORTED, not run", () => {
+  // The second review finding. The two capability specs had no MODEL_TEST_ID branch
+  // at all, so they could never be handed an unfit model; gaining one without this
+  // check would trade a silent skip for a misleading failure — a vision spec fed an
+  // embedding model fails in a way that reads as a product regression (#570).
+  const targets = resolveTestTargets({
+    tier: "tool-calling",
+    requires: "vision",
+    env: { MODEL_TEST_ID: "text-embedding-3-small" },
+    models: [{ provider: "openai", model: "text-embedding-3-small" }],
+    skipReasons: NO_SKIPS,
+  });
+  assert.equal(targets.length, 1);
+  assert.match(targets[0].skipReason ?? "", /cannot serve "vision"/);
+  assert.match(targets[0].skipReason ?? "", /pin a vision-capable model/);
+});
+
+test("a pinned id that DOES serve the capability carries no skip reason", () => {
+  const targets = resolve({ MODEL_TEST_ID: "gpt-4o-mini" }, { requires: "vision" });
+  assert.equal(targets[0].skipReason, undefined);
+});
+
+test("an inactive provider outranks an unfit pinned model — it is the deeper reason", () => {
+  const targets = resolveTestTargets({
+    tier: "tool-calling",
+    requires: "vision",
+    env: { MODEL_TEST_ID: "text-embedding-3-small" },
+    models: [{ provider: "openai", model: "text-embedding-3-small" }],
+    skipReasons: new Map([["openai", "OpenAI key drained"]]),
+  });
+  assert.equal(targets[0].skipReason, "OpenAI key drained");
+});
+
 test("ALL_MODELS=true sweeps every provider", () => {
   const targets = resolve({ ALL_MODELS: "true" });
   assert.equal(targets.length, CATALOG.length);
@@ -247,24 +331,59 @@ test("skipReason from provider health reaches every target and outranks the capa
   assert.equal(targets.find((t) => t.options.provider === "openai")?.skipReason, undefined);
 });
 
-test("an unreadable models.json degrades to the fallback instead of throwing at collection time", () => {
+test("an unreadable models.json THROWS — a missing file is a state, a corrupt one is undecidable", () => {
+  // The first version of this file asserted the opposite (degrade to the fallback),
+  // which was wrong in the direction this repo cares about: a corrupt catalog would
+  // silently run the first-provider fallback — a different suite than intended —
+  // while the report looked normal (#1035). The pre-#1184 copies threw here too
+  // (`JSON.parse` with no `try`), so this is a restoration, not a new rule.
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "test-targets-"));
-  const bad = path.join(dir, "models.json");
-  fs.writeFileSync(bad, "{ not json");
-  const original = console.warn;
-  console.warn = () => {};
   try {
-    const targets = resolveTestTargets({
+    const bad = path.join(dir, "models.json");
+    fs.writeFileSync(bad, "{ not json");
+    assert.throws(() =>
+      resolveTestTargets({
+        tier: "tool-calling",
+        env: {},
+        skipReasons: NO_SKIPS,
+        catalogPath: bad,
+      }),
+    );
+
+    // A parseable payload of the wrong shape is equally undecidable.
+    fs.writeFileSync(bad, JSON.stringify({ openai: "gpt-4o-mini" }));
+    assert.throws(
+      () =>
+        resolveTestTargets({
+          tier: "tool-calling",
+          env: {},
+          skipReasons: NO_SKIPS,
+          catalogPath: bad,
+        }),
+      /must be an array of \{ provider, model \} records/,
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a MISSING models.json still degrades softly — the file is gitignored and the sweep is skippable", () => {
+  const warnings: string[] = [];
+  const original = console.warn;
+  console.warn = (msg: unknown) => void warnings.push(String(msg));
+  let targets: TestTarget[];
+  try {
+    targets = resolveTestTargets({
       tier: "tool-calling",
       env: {},
       skipReasons: NO_SKIPS,
-      catalogPath: bad,
+      catalogPath: path.join(os.tmpdir(), "definitely-absent-models.json"),
     });
-    assert.deepEqual(labels(targets), ["provider:openai (fallback)"]);
   } finally {
     console.warn = original;
-    fs.rmSync(dir, { recursive: true, force: true });
   }
+  assert.deepEqual(labels(targets), ["provider:openai (fallback)"]);
+  assert.ok(warnings.some((w) => /models\.json not found/.test(w)));
 });
 
 // ─── Structural guard: the provider-contract layer must stay unpinnable ──────
@@ -277,6 +396,10 @@ test("provider-contract specs read neither pin variable — this is what #1185 r
   const dir = path.join(
     __dirname,
     "../../tests-automations/regression/core-functionality/model-provider",
+  );
+  assert.ok(
+    fs.existsSync(dir),
+    `the provider-contract spec directory moved — update this guard, do not delete it: ${dir}`,
   );
   const specs = fs.readdirSync(dir).filter((f) => f.endsWith(".spec.ts"));
   assert.ok(specs.length >= 6, `expected the provider-contract specs, found ${specs.length}`);

--- a/tests/helpers/provider-setup/test-targets.ts
+++ b/tests/helpers/provider-setup/test-targets.ts
@@ -282,10 +282,12 @@ export function resolveTestTargets(opts: ResolveTestTargetsOptions): TestTarget[
     // failure.
     const unfit =
       requires && CAPABILITY_EXCLUDES[requires].test(model)
-        ? `MODEL_TEST_ID="${model}" cannot serve "${requires}" for this spec ` +
-          `(excluded model family). Pinned explicitly, so it is reported rather than ` +
-          `silently replaced — pin a ${requires}-capable model, or drop MODEL_TEST_ID ` +
-          `to let the resolver pick one.`
+        ? `MODEL_TEST_ID="${model}" is excluded from "${requires}" by the name ` +
+          `heuristic in test-targets.ts. Pinned explicitly, so it is reported rather ` +
+          `than silently replaced. Either pin a ${requires}-capable model, drop ` +
+          `MODEL_TEST_ID to let the resolver pick one, or — if this model really does ` +
+          `serve ${requires} — fix the heuristic: it matches on substrings, so a name ` +
+          `containing "image" or "search" is excluded even when the model is capable.`
         : undefined;
     if (!record) {
       // Never silent: this path returns a target with NO provider, which makes the
@@ -333,6 +335,34 @@ export function resolveTestTargets(opts: ResolveTestTargetsOptions): TestTarget[
     const scoped = allModels.filter((m) =>
       sweepProvider ? m.provider === sweepProvider : true,
     );
+
+    // A sweep scoped to a provider the catalog does not contain resolved to ZERO
+    // targets, silently, on every path — the spec declared no tests and read green.
+    // This one is NOT new in #1184: the pre-existing copies filtered the same way and
+    // had the same hole. Consolidating them is what makes it fixable in one place.
+    //
+    // It is very reachable. `MODEL_TEST_PROVIDER` is a bare string nothing validates,
+    // and the catalog keys are lowercase (`openai`) while the UI and the testids use
+    // display casing (`provider-item-OpenAI`) — so `MODEL_TEST_PROVIDER=OpenAI` is a
+    // natural typo that silently ran nothing. A provider whose key is not configured
+    // is also legitimately absent from the catalog, so this reports rather than
+    // throws: a typo must not take all 17 specs down, but it must not read as a pass
+    // either (#570 / #1012).
+    if (sweepProvider && scoped.length === 0) {
+      const present = Array.from(new Set(allModels.map((m) => m.provider)));
+      const reason =
+        `MODEL_TEST_PROVIDER="${sweepProvider}" matches no model in models.json ` +
+        `(present: ${present.join(", ") || "none"}) — nothing would have run. Names are ` +
+        `lowercase catalog keys, not display names.`;
+      console.warn(reason);
+      return [
+        {
+          label: `provider:${sweepProvider} (not in catalog)`,
+          options: {},
+          skipReason: reason,
+        },
+      ];
+    }
     const exclude = requires ? CAPABILITY_EXCLUDES[requires] : undefined;
     const capable = scoped.filter((m) => (exclude ? !exclude.test(m.model) : true));
     const targets: TestTarget[] = capable.map((m) => ({

--- a/tests/helpers/provider-setup/test-targets.ts
+++ b/tests/helpers/provider-setup/test-targets.ts
@@ -1,0 +1,316 @@
+// The one resolver that decides which { provider, model } targets a parametrized
+// LLM spec runs against (issue #1184).
+//
+// ## Why this exists
+//
+// Until now `getTestTargets()` was **copy-pasted into 17 spec files**, and the copies
+// had drifted into five variants — three of them semantically different, not just
+// cosmetically:
+//
+//  - 14 specs carried the canonical shape (a `MODEL_TEST_ID` branch, a
+//    `MODEL_TEST_PROVIDER` sweep, `ALL_MODELS`, and a first-per-provider dedup);
+//    4 of those differed only in a warning string and blank lines.
+//  - `mcp/client/mcp-client-agent.spec.ts` returned a target with
+//    `provider: undefined` on the not-in-catalog path **with no warning at all**,
+//    and had lost the empty-catalog warning too — the silent-skip failure #570 and
+//    #1012 exist to prevent, on the one copy that announced nothing.
+//  - `agent-multimodal-image-input.spec.ts` and `agent-markdown-output.spec.ts`
+//    had **no `MODEL_TEST_ID` branch**, resolved a capability-filtered model
+//    (vision / chat) instead of the catalog's first entry, and made
+//    `MODEL_TEST_PROVIDER` *narrow* to one model rather than sweep.
+//
+// The last one was live: PR #1170 pins the PR lane by emitting `MODEL_TEST_PROVIDER`
+// and `MODEL_TEST_ID` as a pair, and the vision copy ignored the id outright. It
+// happened to run the intended model anyway, because `collect-models` promotes the
+// settled model to `models.json[0]` and the vision resolver prefers index 0 — an
+// accident of promotion, not a pin. That is the same latent coupling #1169 recorded.
+//
+// So the copies were not just duplication: they were 17 independent answers to
+// "which model does this spec run", and a model-selection policy could not be
+// changed without editing all of them and hoping none was missed.
+//
+// ## Two axes, not one
+//
+// `tier` says **what kind of target a lane should give this spec** — it is the
+// vocabulary #1185 (pin the daily) and #1187 (route to Ollama) branch on. `requires`
+// says **which model within a provider** satisfies the spec's assertion. They are
+// orthogonal: `agent-multimodal-image-input` needs a real agent *and* a
+// vision-capable model.
+//
+// Nothing in this module acts on `tier` yet, deliberately. It is declared here so a
+// lane can resolve it in one place instead of 17, and so a spec's requirement is
+// recorded next to the spec rather than inferred by whoever changes a workflow.
+//
+// ## Env precedence — unchanged, and load-bearing
+//
+// The order below is what `README.md`, `.env.example` and `CONTRIBUTING.md` already
+// document, and it is preserved exactly (#1184's parity requirement):
+//
+//   MODEL_TEST_ID       → one target, that model (provider inferred from the catalog)
+//   MODEL_TEST_PROVIDER → EVERY model that provider exposes  ← a sweep, not a filter
+//   ALL_MODELS=true     → every model of every provider
+//   (none set)          → one model per provider
+//
+// Two specs did not implement that order and now do, which is the point of the
+// consolidation rather than a side effect: the vision and markdown copies gain the
+// `MODEL_TEST_ID` branch they lacked. The one behaviour that genuinely changes for
+// them is the cross-provider case — `MODEL_TEST_ID` naming a model that belongs to a
+// provider other than `MODEL_TEST_PROVIDER`. They used to ignore the id and run the
+// provider's own model; now the id wins and its provider is inferred, because that is
+// what "highest priority" means everywhere else in the suite.
+//
+// `MODEL_TEST_PROVIDER` widening is **intentional documented behaviour**, not the bug
+// #1169 called a trap. It is how a developer sweeps one provider locally. It is a
+// footgun only when a lane emits it *without* `MODEL_TEST_ID` expecting a narrow run,
+// which is precisely why `scripts/select-pr-model-target.mjs` never emits one without
+// the other. Narrowing it here instead would contradict three documents and change 15
+// specs; that trade was weighed for #1184 and declined.
+import * as fs from "fs";
+import * as path from "path";
+import { providerConfigMap, type Provider } from "./provider-config";
+import { providerSkipReasons } from "./provider-health";
+
+/**
+ * What a lane owes this spec. Consumed by lane-level policy (#1185, #1187), not here.
+ *
+ * - `none` — the spec makes no inference at all (provider modals, invalid-key UI,
+ *   model toggles). A paid call added to such a spec later is a defect, not a cost.
+ * - `any-completion` — any model that returns text; the assertion is plumbing, not
+ *   model quality. The tier #1187 routes to a local model.
+ * - `tool-calling` — the assertion *is* model capability: tool selection, structured
+ *   output, iteration caps. Needs a capable hosted model.
+ * - `provider-contract` — this spec exists to exercise *that* provider specifically
+ *   (`core-functionality/model-provider/*-provider.spec.ts`). Never narrowed by a
+ *   lane pin: those specs read neither pin variable today, and a unit test in
+ *   `test-targets.test.ts` fails if one starts to. That independence is what lets
+ *   #1185 pin the daily without losing multi-provider coverage.
+ */
+export type ModelTier =
+  | "none"
+  | "any-completion"
+  | "tool-calling"
+  | "provider-contract";
+
+/** Which model *within* a provider satisfies the spec. Omit when any model will do. */
+export type ModelCapability = "vision" | "chat";
+
+export interface ModelRecord {
+  provider: string;
+  model: string;
+}
+
+/**
+ * Structurally compatible with `LoadSimpleAgentOptions` from `tests/pages`, declared
+ * locally so `helpers/` does not depend on `pages/`.
+ */
+export interface TestTargetOptions {
+  provider?: Provider;
+  model?: string;
+}
+
+export interface TestTarget {
+  label: string;
+  options: TestTargetOptions;
+  skipReason?: string;
+}
+
+export interface ResolveTestTargetsOptions {
+  /** What the spec needs from a lane. Every migrated agent spec is `tool-calling`. */
+  tier: ModelTier;
+  /** Capability filter within a provider. Omit for "any model this provider lists". */
+  requires?: ModelCapability;
+  /** Seam for unit tests, matching `providerSkipReasons`' convention. */
+  env?: NodeJS.ProcessEnv;
+  /** Seam for unit tests: `undefined` reads the catalog from disk. */
+  models?: ModelRecord[];
+  /** Seam for unit tests. */
+  skipReasons?: Map<string, string>;
+  /** Seam for unit tests. */
+  catalogPath?: string;
+}
+
+const MODELS_PATH = path.join(__dirname, "data", "models.json");
+
+// Model families that cannot serve a chat completion. Verbatim from
+// agent-markdown-output.spec.ts.
+const NON_CHAT = /embedding|tts|audio|whisper|realtime|image|moderation|search/i;
+
+// Same, plus the families that are chat-capable but not vision-capable. Verbatim
+// from agent-multimodal-image-input.spec.ts.
+const NON_VISION =
+  /gemma|embedding|tts|audio|whisper|realtime|image|customtools|moderation|search/i;
+
+// Fallback preference per provider, used only when the settled model is not
+// vision-usable. Alias/undated patterns only — a hardcoded dated id goes stale the
+// moment the provider retires it (#886, #964). Verbatim from the vision spec.
+const VISION_PREFS: Record<string, RegExp[]> = {
+  openai: [/^gpt-4o-mini$/, /^gpt-4o$/, /^gpt-4\.1(-mini)?$/, /gpt-4o/, /^gpt-5.*mini$/, /^gpt-5/],
+  google: [/^gemini-flash-latest$/, /gemini.*flash/, /gemini/],
+  anthropic: [/^claude-3-5-sonnet/, /^claude-3-5-haiku/, /^claude-3-7/, /claude-3\.?5/, /claude-3/, /claude/],
+};
+
+const CAPABILITY_EXCLUDES: Record<ModelCapability, RegExp> = {
+  chat: NON_CHAT,
+  vision: NON_VISION,
+};
+
+// The `(no … model)` label fragment, kept byte-identical to the pre-#1184 copies:
+// it reaches the test title, and a test title is the test's identity in
+// `results.json`, `spec-durations.json` and the `@stable` auto-removal path.
+// Renaming one silently orphans its history.
+const CAPABILITY_MISSING_LABEL: Record<ModelCapability, string> = {
+  chat: "(no chat model)",
+  vision: "(no vision model)",
+};
+
+// Verbatim from each copy — the two specs worded this differently ("no chat model"
+// vs "no vision-capable model") and parity is cheaper than picking a winner.
+const CAPABILITY_MISSING_REASON: Record<ModelCapability, (p: string) => string> = {
+  chat: (p) => `Provider "${p}" has no chat model in models.json`,
+  vision: (p) => `Provider "${p}" has no vision-capable model in models.json`,
+};
+
+function readCatalog(jsonPath: string = MODELS_PATH): ModelRecord[] {
+  if (!fs.existsSync(jsonPath)) {
+    console.warn("models.json not found — run collect-models.spec.ts first.");
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(fs.readFileSync(jsonPath, "utf-8"));
+    return Array.isArray(parsed) ? (parsed as ModelRecord[]) : [];
+  } catch {
+    console.warn("models.json is unreadable — run collect-models.spec.ts first.");
+    return [];
+  }
+}
+
+function modelsOf(provider: string, models: ModelRecord[]): string[] {
+  return models.filter((m) => m.provider === provider).map((m) => m.model);
+}
+
+/**
+ * The model of `provider` that satisfies `requires`, or `undefined` when it has none.
+ *
+ * **Settled-first (#964).** `collect-models` probes the catalog with real calls and
+ * promotes the model it actually validated to the front of that provider's entries,
+ * while still listing the ones it rejected. Preferring a hardcoded id over that
+ * settled model pins a model nobody validated — the vision spec asked for
+ * `^gemini-2.5-flash$` first, which Google had retired. So: take the settled model,
+ * and fall back to the preference scan only when it cannot serve the capability.
+ *
+ * With no `requires`, this is the catalog's first entry for that provider — which is
+ * exactly what the canonical copies' first-per-provider dedup produced.
+ */
+function resolveModel(
+  provider: string,
+  models: ModelRecord[],
+  requires?: ModelCapability,
+): string | undefined {
+  const providerModels = modelsOf(provider, models);
+  if (!requires) return providerModels[0];
+
+  const exclude = CAPABILITY_EXCLUDES[requires];
+  const settled = providerModels[0];
+  if (settled && !exclude.test(settled)) return settled;
+
+  const candidates = providerModels.filter((m) => !exclude.test(m));
+  if (requires === "vision") {
+    for (const pref of VISION_PREFS[provider] ?? [/.*/]) {
+      const hit = candidates.find((m) => pref.test(m));
+      if (hit) return hit;
+    }
+  }
+  return candidates[0];
+}
+
+function targetFor(
+  provider: string,
+  models: ModelRecord[],
+  skipReasons: Map<string, string>,
+  requires?: ModelCapability,
+): TestTarget {
+  const model = resolveModel(provider, models, requires);
+  const missing = requires ? CAPABILITY_MISSING_LABEL[requires] : "(no model)";
+  return {
+    label: `${provider} / ${model ?? missing}`,
+    options: { provider: provider as Provider, model },
+    skipReason:
+      skipReasons.get(provider) ??
+      (model || !requires ? undefined : CAPABILITY_MISSING_REASON[requires](provider)),
+  };
+}
+
+/**
+ * Resolve the targets a parametrized spec should run against.
+ *
+ * Replaces the 17 in-spec copies of `getTestTargets()`. With no env set the returned
+ * list is identical to what each copy produced — asserted in `test-targets.test.ts`,
+ * because a change here silently re-parametrizes ~30 `@stable` tests.
+ */
+export function resolveTestTargets(opts: ResolveTestTargetsOptions): TestTarget[] {
+  const env = opts.env ?? process.env;
+  const skipReasons = opts.skipReasons ?? providerSkipReasons();
+  const allModels = opts.models ?? readCatalog(opts.catalogPath);
+  const { requires } = opts;
+
+  // 1. MODEL_TEST_ID — highest documented priority. An explicit id is honoured as
+  //    given: the caller asked for that model, so `requires` is not second-guessed.
+  if (env.MODEL_TEST_ID) {
+    const model = env.MODEL_TEST_ID;
+    const record = allModels.find((m) => m.model === model);
+    if (!record) {
+      // Never silent: this path returns a target with NO provider, which makes the
+      // spec skip while the run stays green (#570 / #1012).
+      console.warn(
+        `MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred. ` +
+          `Run collect-models.spec.ts first, or set MODEL_TEST_PROVIDER.`,
+      );
+      return [{ label: `model:${model}`, options: { model } }];
+    }
+    const provider = record.provider as Provider;
+    return [
+      {
+        label: `${provider} / ${model}`,
+        options: { provider, model },
+        skipReason: skipReasons.get(provider),
+      },
+    ];
+  }
+
+  // 2. No catalog at all — fall back to the first configured provider and say why.
+  //    Without this a missing models.json parametrizes nothing and the spec vanishes
+  //    from the report rather than reporting a reason.
+  if (allModels.length === 0) {
+    const fallback = Object.keys(providerConfigMap)[0] as Provider;
+    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
+    return [
+      {
+        label: `provider:${fallback} (fallback)`,
+        options: { provider: fallback },
+        skipReason: skipReasons.get(fallback),
+      },
+    ];
+  }
+
+  // 3. MODEL_TEST_PROVIDER — sweep that provider's whole catalog. Documented
+  //    behaviour (README / .env.example / CONTRIBUTING): "run all models for a
+  //    provider". Capability-filtered when the spec declared one, so a vision spec
+  //    sweeping openai does not try to send an image to an embedding model.
+  // 4. ALL_MODELS=true — the same sweep across every provider.
+  const sweepProvider = env.MODEL_TEST_PROVIDER;
+  if (sweepProvider || env.ALL_MODELS === "true") {
+    const exclude = requires ? CAPABILITY_EXCLUDES[requires] : undefined;
+    return allModels
+      .filter((m) => (sweepProvider ? m.provider === sweepProvider : true))
+      .filter((m) => (exclude ? !exclude.test(m.model) : true))
+      .map((m) => ({
+        label: `${m.provider} / ${m.model}`,
+        options: { provider: m.provider as Provider, model: m.model },
+        skipReason: skipReasons.get(m.provider),
+      }));
+  }
+
+  // 5. Default — one model per provider present in the catalog.
+  const providers = Array.from(new Set(allModels.map((m) => m.provider)));
+  return providers.map((provider) => targetFor(provider, allModels, skipReasons, requires));
+}

--- a/tests/helpers/provider-setup/test-targets.ts
+++ b/tests/helpers/provider-setup/test-targets.ts
@@ -175,13 +175,20 @@ function readCatalog(jsonPath: string = MODELS_PATH): ModelRecord[] {
     console.warn("models.json not found — run collect-models.spec.ts first.");
     return [];
   }
-  try {
-    const parsed = JSON.parse(fs.readFileSync(jsonPath, "utf-8"));
-    return Array.isArray(parsed) ? (parsed as ModelRecord[]) : [];
-  } catch {
-    console.warn("models.json is unreadable — run collect-models.spec.ts first.");
-    return [];
+  // A MISSING file is a legitimate state — the sweep was skipped, or this is a fresh
+  // clone (the file is gitignored). A file that EXISTS but cannot be parsed is
+  // undecidable, and degrading it to the first-provider fallback would run a
+  // different suite than the one intended while reporting as normal (#1035). The
+  // pre-#1184 copies threw here too (`JSON.parse` with no `try`), so failing loud
+  // restores that rather than inventing it.
+  const parsed = JSON.parse(fs.readFileSync(jsonPath, "utf-8"));
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      `${jsonPath} must be an array of { provider, model } records, got ` +
+        `${parsed === null ? "null" : typeof parsed}`,
+    );
   }
+  return parsed as ModelRecord[];
 }
 
 function modelsOf(provider: string, models: ModelRecord[]): string[] {
@@ -230,13 +237,21 @@ function targetFor(
   requires?: ModelCapability,
 ): TestTarget {
   const model = resolveModel(provider, models, requires);
-  const missing = requires ? CAPABILITY_MISSING_LABEL[requires] : "(no model)";
+  if (model === undefined) {
+    // Only reachable with a capability filter: providers are derived from the
+    // catalog, so every one of them has at least one entry.
+    const capability = requires as ModelCapability;
+    return {
+      label: `${provider} / ${CAPABILITY_MISSING_LABEL[capability]}`,
+      options: { provider: provider as Provider, model },
+      skipReason:
+        skipReasons.get(provider) ?? CAPABILITY_MISSING_REASON[capability](provider),
+    };
+  }
   return {
-    label: `${provider} / ${model ?? missing}`,
+    label: `${provider} / ${model}`,
     options: { provider: provider as Provider, model },
-    skipReason:
-      skipReasons.get(provider) ??
-      (model || !requires ? undefined : CAPABILITY_MISSING_REASON[requires](provider)),
+    skipReason: skipReasons.get(provider),
   };
 }
 
@@ -258,6 +273,20 @@ export function resolveTestTargets(opts: ResolveTestTargetsOptions): TestTarget[
   if (env.MODEL_TEST_ID) {
     const model = env.MODEL_TEST_ID;
     const record = allModels.find((m) => m.model === model);
+    // An explicitly pinned id is honoured as given rather than silently swapped for
+    // a capable one — but a model that cannot serve the declared capability must be
+    // REPORTED, not run. A vision spec handed a non-vision model fails in a way that
+    // reads as a product regression, which is the #570 trap. The pre-#1184 vision and
+    // markdown copies could not hit this because they had no MODEL_TEST_ID branch at
+    // all; gaining one without this check would trade a silent skip for a misleading
+    // failure.
+    const unfit =
+      requires && CAPABILITY_EXCLUDES[requires].test(model)
+        ? `MODEL_TEST_ID="${model}" cannot serve "${requires}" for this spec ` +
+          `(excluded model family). Pinned explicitly, so it is reported rather than ` +
+          `silently replaced — pin a ${requires}-capable model, or drop MODEL_TEST_ID ` +
+          `to let the resolver pick one.`
+        : undefined;
     if (!record) {
       // Never silent: this path returns a target with NO provider, which makes the
       // spec skip while the run stays green (#570 / #1012).
@@ -265,14 +294,16 @@ export function resolveTestTargets(opts: ResolveTestTargetsOptions): TestTarget[
         `MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred. ` +
           `Run collect-models.spec.ts first, or set MODEL_TEST_PROVIDER.`,
       );
-      return [{ label: `model:${model}`, options: { model } }];
+      return [{ label: `model:${model}`, options: { model }, skipReason: unfit }];
     }
     const provider = record.provider as Provider;
     return [
       {
         label: `${provider} / ${model}`,
         options: { provider, model },
-        skipReason: skipReasons.get(provider),
+        // A dead provider outranks an unfit model: it is the more fundamental
+        // reason the target cannot run.
+        skipReason: skipReasons.get(provider) ?? unfit,
       },
     ];
   }
@@ -299,15 +330,31 @@ export function resolveTestTargets(opts: ResolveTestTargetsOptions): TestTarget[
   // 4. ALL_MODELS=true — the same sweep across every provider.
   const sweepProvider = env.MODEL_TEST_PROVIDER;
   if (sweepProvider || env.ALL_MODELS === "true") {
+    const scoped = allModels.filter((m) =>
+      sweepProvider ? m.provider === sweepProvider : true,
+    );
     const exclude = requires ? CAPABILITY_EXCLUDES[requires] : undefined;
-    return allModels
-      .filter((m) => (sweepProvider ? m.provider === sweepProvider : true))
-      .filter((m) => (exclude ? !exclude.test(m.model) : true))
-      .map((m) => ({
-        label: `${m.provider} / ${m.model}`,
-        options: { provider: m.provider as Provider, model: m.model },
-        skipReason: skipReasons.get(m.provider),
-      }));
+    const capable = scoped.filter((m) => (exclude ? !exclude.test(m.model) : true));
+    const targets: TestTarget[] = capable.map((m) => ({
+      label: `${m.provider} / ${m.model}`,
+      options: { provider: m.provider as Provider, model: m.model },
+      skipReason: skipReasons.get(m.provider),
+    }));
+
+    // A provider the capability filter emptied must still produce a REPORTED target,
+    // exactly as the default path below does. Without this it simply vanishes from the
+    // sweep: zero tests declared for that spec, nothing in the report, and green under
+    // `--pass-with-no-tests` — the silent-skip failure #570 and #1012 exist to prevent.
+    // The same catalog must not be "reported" on one code path and "invisible" on
+    // another. Appended rather than interleaved so the capable targets keep catalog
+    // order, which is what the pre-#1184 copies produced.
+    if (exclude) {
+      for (const provider of Array.from(new Set(scoped.map((m) => m.provider)))) {
+        if (capable.some((m) => m.provider === provider)) continue;
+        targets.push(targetFor(provider, scoped, skipReasons, requires));
+      }
+    }
+    return targets;
   }
 
   // 5. Default — one model per provider present in the catalog.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/CLAUDE.md
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/CLAUDE.md
@@ -34,19 +34,19 @@ await new SimpleAgentTemplatePage(page).load(options);
 ### 3. Parameterize the test by model (project standard)
 
 ```typescript
-import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
+import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targets";
 
-// The target list is built per spec from models.json — copy the `getTestTargets()`
-// in agent-component-regression.spec.ts. The inactive-provider skip map is NOT:
-// it is one shared implementation, and inlining a copy of it is the drift #1043
-// removed from 18 specs.
-function getTestTargets(): TestTarget[] {
-  const skipReasons = providerSkipReasons();
-  // ... filter models.json by MODEL_TEST_ID / MODEL_TEST_PROVIDER, then attach
-  // skipReasons.get(provider) as each target's skipReason
-}
-
-for (const { label, options, skipReason } of getTestTargets()) {
+// The target list comes from ONE shared resolver — never copy it into the spec
+// (#1184). It reads models.json, applies the .env strategy and attaches each
+// provider's inactive-skip reason. Seventeen specs used to carry their own copy and
+// they had drifted into five variants, two of which silently ignored MODEL_TEST_ID —
+// the same drift #1043 removed for providerSkipReasons.
+//
+// `tier` is what the spec needs from a lane, so a lane can resolve the cheapest
+// target that satisfies it in one place (#1185, #1187) instead of guessing per spec.
+// Add `requires: "vision" | "chat"` when the assertion needs a specific capability
+// within the provider — see agent-multimodal-image-input / agent-markdown-output.
+for (const { label, options, skipReason } of resolveTestTargets({ tier: "tool-calling" })) {
   test.describe.serial(`My Test [${label}]`, () => {
     test("should ...", async ({ page }) => {
       test.skip(!!skipReason, skipReason ?? "");

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-component-regression.spec.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import path from "path";
-import fs from "fs";
 import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
@@ -10,91 +9,12 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
+import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targets";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
-import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
 
 if (!process.env.CI) {
   dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
-}
-
-interface ModelRecord {
-  provider: string;
-  model: string;
-}
-
-interface TestTarget {
-  label: string;
-  options: LoadSimpleAgentOptions;
-  skipReason?: string;
-}
-
-function getModelsFromJson(): ModelRecord[] {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/models.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("models.json not found — run collect-models.spec.ts first.");
-    return [];
-  }
-  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
-}
-
-function getTestTargets(): TestTarget[] {
-  const skipReasons = providerSkipReasons();
-
-  if (process.env.MODEL_TEST_ID) {
-    const model = process.env.MODEL_TEST_ID;
-    const allModels = getModelsFromJson();
-    const record = allModels.find((m) => m.model === model);
-
-    if (!record) {
-      console.warn(
-        `MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred. ` +
-        `Run collect-models.spec.ts first, or set MODEL_TEST_PROVIDER.`,
-      );
-      return [{ label: `model:${model}`, options: { model } }];
-    }
-
-    const provider = record.provider as Provider;
-    return [{
-      label: `${provider} / ${model}`,
-      options: { provider, model },
-      skipReason: skipReasons.get(provider),
-    }];
-  }
-
-  const allModels = getModelsFromJson();
-
-  if (allModels.length === 0) {
-    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
-    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
-    return [{
-      label: `provider:${fallbackProvider} (fallback)`,
-      options: { provider: fallbackProvider },
-      skipReason: skipReasons.get(fallbackProvider),
-    }];
-  }
-
-  let models = allModels;
-
-  if (process.env.MODEL_TEST_PROVIDER) {
-    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
-  } else if (process.env.ALL_MODELS !== "true") {
-    const seen = new Set<string>();
-    models = models.filter((m) => {
-      if (seen.has(m.provider)) return false;
-      seen.add(m.provider);
-      return true;
-    });
-  }
-
-  return models.map((m) => ({
-    label: `${m.provider} / ${m.model}`,
-    options: { provider: m.provider as Provider, model: m.model },
-    skipReason: skipReasons.get(m.provider),
-  }));
 }
 
 // Ids of the flows created by loadAgent(), so afterEach can delete exactly
@@ -135,7 +55,7 @@ async function waitForAgentToFinish(page: Page): Promise<void> {
   }
 }
 
-const targets = getTestTargets();
+const targets = resolveTestTargets({ tier: "tool-calling" });
 
 // File-level serial mode: each provider block creates a named Simple Agent flow;
 // serial execution avoids "flow must be unique" collisions across blocks.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-continuity.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-continuity.spec.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import path from "path";
-import fs from "fs";
 import type { APIRequestContext, Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
@@ -20,7 +19,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
+import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targets";
 
 /**
  * Agent context_id continuity (QA-CHECKLIST §6.3 "Agent uses custom
@@ -50,78 +49,6 @@ import { providerSkipReasons } from "../../../../helpers/provider-setup/provider
 
 if (!process.env.CI) {
   dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
-}
-
-interface ModelRecord {
-  provider: string;
-  model: string;
-}
-
-interface TestTarget {
-  label: string;
-  options: LoadSimpleAgentOptions;
-  skipReason?: string;
-}
-
-function getModelsFromJson(): ModelRecord[] {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/models.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("models.json not found — run collect-models.spec.ts first.");
-    return [];
-  }
-  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
-}
-
-function getTestTargets(): TestTarget[] {
-  const skipReasons = providerSkipReasons();
-
-  if (process.env.MODEL_TEST_ID) {
-    const model = process.env.MODEL_TEST_ID;
-    const allModels = getModelsFromJson();
-    const record = allModels.find((m) => m.model === model);
-    if (!record) {
-      console.warn(`MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred.`);
-      return [{ label: `model:${model}`, options: { model } }];
-    }
-    const provider = record.provider as Provider;
-    return [{
-      label: `${provider} / ${model}`,
-      options: { provider, model },
-      skipReason: skipReasons.get(provider),
-    }];
-  }
-
-  const allModels = getModelsFromJson();
-  if (allModels.length === 0) {
-    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
-    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
-    return [{
-      label: `provider:${fallbackProvider} (fallback)`,
-      options: { provider: fallbackProvider },
-      skipReason: skipReasons.get(fallbackProvider),
-    }];
-  }
-
-  let models = allModels;
-  if (process.env.MODEL_TEST_PROVIDER) {
-    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
-  } else if (process.env.ALL_MODELS !== "true") {
-    const seen = new Set<string>();
-    models = models.filter((m) => {
-      if (seen.has(m.provider)) return false;
-      seen.add(m.provider);
-      return true;
-    });
-  }
-
-  return models.map((m) => ({
-    label: `${m.provider} / ${m.model}`,
-    options: { provider: m.provider as Provider, model: m.model },
-    skipReason: skipReasons.get(m.provider),
-  }));
 }
 
 // Flows created by test 1 are tracked here and deleted by id in afterEach —
@@ -408,7 +335,7 @@ async function retrieveViaMessageHistory(
   return textarea.inputValue();
 }
 
-const targets = getTestTargets();
+const targets = resolveTestTargets({ tier: "tool-calling" });
 
 // Test 1 loads the Simple Agent template — serial + --workers=1 per the
 // agent-area rule. Cleanup is id-scoped; nothing here wipes flows.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-isolation.spec.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import path from "path";
-import fs from "fs";
 import type { APIRequestContext, Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
@@ -20,7 +19,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
+import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targets";
 
 /**
  * Agent context_id isolation (QA-CHECKLIST §6.3 "Switching context_id
@@ -53,78 +52,6 @@ import { providerSkipReasons } from "../../../../helpers/provider-setup/provider
 
 if (!process.env.CI) {
   dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
-}
-
-interface ModelRecord {
-  provider: string;
-  model: string;
-}
-
-interface TestTarget {
-  label: string;
-  options: LoadSimpleAgentOptions;
-  skipReason?: string;
-}
-
-function getModelsFromJson(): ModelRecord[] {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/models.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("models.json not found — run collect-models.spec.ts first.");
-    return [];
-  }
-  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
-}
-
-function getTestTargets(): TestTarget[] {
-  const skipReasons = providerSkipReasons();
-
-  if (process.env.MODEL_TEST_ID) {
-    const model = process.env.MODEL_TEST_ID;
-    const allModels = getModelsFromJson();
-    const record = allModels.find((m) => m.model === model);
-    if (!record) {
-      console.warn(`MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred.`);
-      return [{ label: `model:${model}`, options: { model } }];
-    }
-    const provider = record.provider as Provider;
-    return [{
-      label: `${provider} / ${model}`,
-      options: { provider, model },
-      skipReason: skipReasons.get(provider),
-    }];
-  }
-
-  const allModels = getModelsFromJson();
-  if (allModels.length === 0) {
-    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
-    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
-    return [{
-      label: `provider:${fallbackProvider} (fallback)`,
-      options: { provider: fallbackProvider },
-      skipReason: skipReasons.get(fallbackProvider),
-    }];
-  }
-
-  let models = allModels;
-  if (process.env.MODEL_TEST_PROVIDER) {
-    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
-  } else if (process.env.ALL_MODELS !== "true") {
-    const seen = new Set<string>();
-    models = models.filter((m) => {
-      if (seen.has(m.provider)) return false;
-      seen.add(m.provider);
-      return true;
-    });
-  }
-
-  return models.map((m) => ({
-    label: `${m.provider} / ${m.model}`,
-    options: { provider: m.provider as Provider, model: m.model },
-    skipReason: skipReasons.get(m.provider),
-  }));
 }
 
 // Flows created by test 2 are tracked here and deleted by id in afterEach —
@@ -557,7 +484,7 @@ async function runRetrievalScopedTo(page: Page, contextId: string): Promise<stri
   return text;
 }
 
-const targets = getTestTargets();
+const targets = resolveTestTargets({ tier: "tool-calling" });
 
 // Test 2 loads the Simple Agent template — serial + --workers=1 per the
 // agent-area rule. Cleanup is id-scoped; nothing here wipes flows.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-current-date-tool.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-current-date-tool.spec.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import path from "path";
-import fs from "fs";
 import type { Page } from "@playwright/test";
 import type { APIRequestContext } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
@@ -18,7 +17,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
+import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targets";
 
 /**
  * Agent current-date tool toggle (QA-CHECKLIST §6.5 "Toggle
@@ -58,78 +57,6 @@ function acceptedUtcDates(): string[] {
   const today = now.toISOString().slice(0, 10);
   const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
   return [today, yesterday];
-}
-
-interface ModelRecord {
-  provider: string;
-  model: string;
-}
-
-interface TestTarget {
-  label: string;
-  options: LoadSimpleAgentOptions;
-  skipReason?: string;
-}
-
-function getModelsFromJson(): ModelRecord[] {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/models.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("models.json not found — run collect-models.spec.ts first.");
-    return [];
-  }
-  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
-}
-
-function getTestTargets(): TestTarget[] {
-  const skipReasons = providerSkipReasons();
-
-  if (process.env.MODEL_TEST_ID) {
-    const model = process.env.MODEL_TEST_ID;
-    const allModels = getModelsFromJson();
-    const record = allModels.find((m) => m.model === model);
-    if (!record) {
-      console.warn(`MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred.`);
-      return [{ label: `model:${model}`, options: { model } }];
-    }
-    const provider = record.provider as Provider;
-    return [{
-      label: `${provider} / ${model}`,
-      options: { provider, model },
-      skipReason: skipReasons.get(provider),
-    }];
-  }
-
-  const allModels = getModelsFromJson();
-  if (allModels.length === 0) {
-    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
-    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
-    return [{
-      label: `provider:${fallbackProvider} (fallback)`,
-      options: { provider: fallbackProvider },
-      skipReason: skipReasons.get(fallbackProvider),
-    }];
-  }
-
-  let models = allModels;
-  if (process.env.MODEL_TEST_PROVIDER) {
-    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
-  } else if (process.env.ALL_MODELS !== "true") {
-    const seen = new Set<string>();
-    models = models.filter((m) => {
-      if (seen.has(m.provider)) return false;
-      seen.add(m.provider);
-      return true;
-    });
-  }
-
-  return models.map((m) => ({
-    label: `${m.provider} / ${m.model}`,
-    options: { provider: m.provider as Provider, model: m.model },
-    skipReason: skipReasons.get(m.provider),
-  }));
 }
 
 // Flows created by each test are tracked here and deleted by id in
@@ -319,7 +246,7 @@ async function expectNoDateToolBlocks(
     .toBe("no-date-tool-blocks");
 }
 
-const targets = getTestTargets();
+const targets = resolveTestTargets({ tier: "tool-calling" });
 
 // Serial mode + --workers=1 keeps the shared instance state deterministic
 // (area rule for agent specs). Cleanup is id-scoped in afterEach — nothing

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-empty-refusal-response.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-empty-refusal-response.spec.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import path from "path";
-import fs from "fs";
 import type { APIRequestContext, Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
@@ -10,9 +9,9 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
+import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targets";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
-import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
 
 /**
  * Agent robustness on a degenerate model output (QA-CHECKLIST §6.5,
@@ -38,85 +37,6 @@ if (!process.env.CI) {
 // would normally answer, so a refusal / empty reply can only come from the
 // instruction we set.
 const USER_MESSAGE = "What is the capital of France?";
-
-interface ModelRecord {
-  provider: string;
-  model: string;
-}
-
-interface TestTarget {
-  label: string;
-  options: LoadSimpleAgentOptions;
-  skipReason?: string;
-}
-
-function getModelsFromJson(): ModelRecord[] {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/models.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("models.json not found — run collect-models.spec.ts first.");
-    return [];
-  }
-  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
-}
-
-function getTestTargets(): TestTarget[] {
-  const skipReasons = providerSkipReasons();
-
-  if (process.env.MODEL_TEST_ID) {
-    const model = process.env.MODEL_TEST_ID;
-    const allModels = getModelsFromJson();
-    const record = allModels.find((m) => m.model === model);
-
-    if (!record) {
-      console.warn(
-        `MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred. ` +
-        `Run collect-models.spec.ts first, or set MODEL_TEST_PROVIDER.`,
-      );
-      return [{ label: `model:${model}`, options: { model } }];
-    }
-
-    const provider = record.provider as Provider;
-    return [{
-      label: `${provider} / ${model}`,
-      options: { provider, model },
-      skipReason: skipReasons.get(provider),
-    }];
-  }
-
-  const allModels = getModelsFromJson();
-
-  if (allModels.length === 0) {
-    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
-    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
-    return [{
-      label: `provider:${fallbackProvider} (fallback)`,
-      options: { provider: fallbackProvider },
-      skipReason: skipReasons.get(fallbackProvider),
-    }];
-  }
-
-  let models = allModels;
-
-  if (process.env.MODEL_TEST_PROVIDER) {
-    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
-  } else if (process.env.ALL_MODELS !== "true") {
-    const seen = new Set<string>();
-    models = models.filter((m) => {
-      if (seen.has(m.provider)) return false;
-      seen.add(m.provider);
-      return true;
-    });
-  }
-
-  return models.map((m) => ({
-    label: `${m.provider} / ${m.model}`,
-    options: { provider: m.provider as Provider, model: m.model },
-    skipReason: skipReasons.get(m.provider),
-  }));
-}
 
 async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
   try {
@@ -212,7 +132,7 @@ async function expectMarkerInPersistedReply(
     .toBe("marker-persisted");
 }
 
-const targets = getTestTargets();
+const targets = resolveTestTargets({ tier: "tool-calling" });
 
 // SimpleAgentTemplatePage.load() deletes all flows before loading the template.
 // File-level serial mode prevents parallel provider blocks from wiping each

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-input-sources.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-input-sources.spec.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import path from "path";
-import fs from "fs";
 import type { APIRequestContext, Page, Response } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
@@ -12,7 +11,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
+import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targets";
 
 /**
  * Validates that the Agent component accepts its `input_value` from either of
@@ -31,85 +30,6 @@ import { providerSkipReasons } from "../../../../helpers/provider-setup/provider
 
 if (!process.env.CI) {
   dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
-}
-
-interface ModelRecord {
-  provider: string;
-  model: string;
-}
-
-interface TestTarget {
-  label: string;
-  options: LoadSimpleAgentOptions;
-  skipReason?: string;
-}
-
-function getModelsFromJson(): ModelRecord[] {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/models.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("models.json not found — run collect-models.spec.ts first.");
-    return [];
-  }
-  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
-}
-
-function getTestTargets(): TestTarget[] {
-  const skipReasons = providerSkipReasons();
-
-  if (process.env.MODEL_TEST_ID) {
-    const model = process.env.MODEL_TEST_ID;
-    const allModels = getModelsFromJson();
-    const record = allModels.find((m) => m.model === model);
-
-    if (!record) {
-      console.warn(
-        `MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred. ` +
-        `Run collect-models.spec.ts first, or set MODEL_TEST_PROVIDER.`,
-      );
-      return [{ label: `model:${model}`, options: { model } }];
-    }
-
-    const provider = record.provider as Provider;
-    return [{
-      label: `${provider} / ${model}`,
-      options: { provider, model },
-      skipReason: skipReasons.get(provider),
-    }];
-  }
-
-  const allModels = getModelsFromJson();
-
-  if (allModels.length === 0) {
-    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
-    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
-    return [{
-      label: `provider:${fallbackProvider} (fallback)`,
-      options: { provider: fallbackProvider },
-      skipReason: skipReasons.get(fallbackProvider),
-    }];
-  }
-
-  let models = allModels;
-
-  if (process.env.MODEL_TEST_PROVIDER) {
-    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
-  } else if (process.env.ALL_MODELS !== "true") {
-    const seen = new Set<string>();
-    models = models.filter((m) => {
-      if (seen.has(m.provider)) return false;
-      seen.add(m.provider);
-      return true;
-    });
-  }
-
-  return models.map((m) => ({
-    label: `${m.provider} / ${m.model}`,
-    options: { provider: m.provider as Provider, model: m.model },
-    skipReason: skipReasons.get(m.provider),
-  }));
 }
 
 // Track every flow the template load creates (POST /api/v1/flows → 201) so
@@ -202,7 +122,7 @@ async function waitForAgentToFinish(page: Page): Promise<void> {
   }
 }
 
-const targets = getTestTargets();
+const targets = resolveTestTargets({ tier: "tool-calling" });
 
 // SimpleAgentTemplatePage.load() deletes all flows before loading the template.
 // File-level serial mode prevents parallel provider blocks from wiping each other's flows.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-markdown-output.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-markdown-output.spec.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import path from "path";
-import fs from "fs";
 import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
@@ -13,7 +12,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
+import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targets";
 
 /**
  * Agent Markdown output (QA-CHECKLIST §6.5, "Agent returns output in correctly
@@ -49,83 +48,6 @@ const PROMPT =
   "items `- alpha`, `- beta`, `- gamma`; then a separate paragraph containing the " +
   "word **important** in bold; then a single fenced code block whose only content " +
   "is print('hello'). Output nothing else.";
-
-// Model families that are not chat-capable — excluded when resolving a model.
-const NON_CHAT = /embedding|tts|audio|whisper|realtime|image|moderation|search/i;
-
-interface ModelRecord {
-  provider: string;
-  model: string;
-}
-
-interface TestTarget {
-  label: string;
-  options: LoadSimpleAgentOptions;
-  skipReason?: string;
-}
-
-function getModelsFromJson(): ModelRecord[] {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/models.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("models.json not found — run collect-models.spec.ts first.");
-    return [];
-  }
-  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
-}
-
-// Resolve a chat model for a provider: MODEL_TEST_ID wins (if it belongs to the
-// provider), otherwise the first non-excluded model in models.json.
-function resolveChatModel(provider: string, models: ModelRecord[]): string | undefined {
-  const forProvider = models.filter((m) => m.provider === provider).map((m) => m.model);
-  const envId = process.env.MODEL_TEST_ID;
-  if (envId && forProvider.includes(envId)) return envId;
-  return forProvider.find((m) => !NON_CHAT.test(m)) ?? forProvider[0];
-}
-
-// One target per active provider, each with a resolved chat model. Honors the
-// MODEL_TEST_PROVIDER override (single provider); MODEL_TEST_ID (via
-// resolveChatModel) further pins the model when it belongs to that provider.
-function getTestTargets(): TestTarget[] {
-  const skipReasons = providerSkipReasons();
-  const allModels = getModelsFromJson();
-
-  if (allModels.length === 0) {
-    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
-    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
-    return [{
-      label: `provider:${fallbackProvider} (fallback)`,
-      options: { provider: fallbackProvider },
-      skipReason: skipReasons.get(fallbackProvider),
-    }];
-  }
-
-  if (process.env.MODEL_TEST_PROVIDER) {
-    const provider = process.env.MODEL_TEST_PROVIDER;
-    const model = resolveChatModel(provider, allModels);
-    return [{
-      label: `${provider} / ${model ?? "(no chat model)"}`,
-      options: { provider: provider as Provider, model },
-      skipReason:
-        skipReasons.get(provider) ??
-        (model ? undefined : `Provider "${provider}" has no chat model in models.json`),
-    }];
-  }
-
-  const providers = Array.from(new Set(allModels.map((m) => m.provider)));
-  return providers.map((provider) => {
-    const model = resolveChatModel(provider, allModels);
-    return {
-      label: `${provider} / ${model ?? "(no chat model)"}`,
-      options: { provider: provider as Provider, model },
-      skipReason:
-        skipReasons.get(provider) ??
-        (model ? undefined : `Provider "${provider}" has no chat model in models.json`),
-    };
-  });
-}
 
 // Flows created by the template load are tracked here and deleted by id in
 // afterEach — loadTemplateByName does NO cleanup (post-#553 contract), and the
@@ -197,7 +119,7 @@ async function openPlayground(page: Page): Promise<void> {
   await expect(chatInput).toHaveValue(PROMPT, { timeout: 15000 });
 }
 
-const targets = getTestTargets();
+const targets = resolveTestTargets({ tier: "tool-calling", requires: "chat" });
 
 // SimpleAgentTemplatePage.load() deletes all flows before loading the template.
 // File-level serial mode prevents parallel provider blocks from wiping each

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-max-iterations.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-max-iterations.spec.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import path from "path";
-import fs from "fs";
 import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
@@ -15,7 +14,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
+import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targets";
 
 /**
  * Agent Max Iterations (QA-CHECKLIST §6.2 "Agent stops when maximum number of
@@ -51,78 +50,6 @@ const SYSTEM_PROMPT =
 const TASK = `Fetch ${TARGET_URL} and tell me the exact "version" value it returns.`;
 const LIMIT_MESSAGE = /model call limits exceeded/i;
 const HIGH_LIMIT = "20";
-
-interface ModelRecord {
-  provider: string;
-  model: string;
-}
-
-interface TestTarget {
-  label: string;
-  options: LoadSimpleAgentOptions;
-  skipReason?: string;
-}
-
-function getModelsFromJson(): ModelRecord[] {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/models.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("models.json not found — run collect-models.spec.ts first.");
-    return [];
-  }
-  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
-}
-
-function getTestTargets(): TestTarget[] {
-  const skipReasons = providerSkipReasons();
-
-  if (process.env.MODEL_TEST_ID) {
-    const model = process.env.MODEL_TEST_ID;
-    const allModels = getModelsFromJson();
-    const record = allModels.find((m) => m.model === model);
-    if (!record) {
-      console.warn(`MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred.`);
-      return [{ label: `model:${model}`, options: { model } }];
-    }
-    const provider = record.provider as Provider;
-    return [{
-      label: `${provider} / ${model}`,
-      options: { provider, model },
-      skipReason: skipReasons.get(provider),
-    }];
-  }
-
-  const allModels = getModelsFromJson();
-  if (allModels.length === 0) {
-    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
-    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
-    return [{
-      label: `provider:${fallbackProvider} (fallback)`,
-      options: { provider: fallbackProvider },
-      skipReason: skipReasons.get(fallbackProvider),
-    }];
-  }
-
-  let models = allModels;
-  if (process.env.MODEL_TEST_PROVIDER) {
-    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
-  } else if (process.env.ALL_MODELS !== "true") {
-    const seen = new Set<string>();
-    models = models.filter((m) => {
-      if (seen.has(m.provider)) return false;
-      seen.add(m.provider);
-      return true;
-    });
-  }
-
-  return models.map((m) => ({
-    label: `${m.provider} / ${m.model}`,
-    options: { provider: m.provider as Provider, model: m.model },
-    skipReason: skipReasons.get(m.provider),
-  }));
-}
 
 async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
   try {
@@ -194,7 +121,7 @@ async function runAndGetBubble(page: Page) {
   return bubble;
 }
 
-const targets = getTestTargets();
+const targets = resolveTestTargets({ tier: "tool-calling" });
 
 // SimpleAgentTemplatePage.load() deletes all flows before loading the template;
 // serial mode + --workers=1 keeps the shared instance state deterministic.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-max-tokens.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-max-tokens.spec.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import path from "path";
-import fs from "fs";
 import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
@@ -16,7 +15,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
+import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targets";
 
 /**
  * Agent max_tokens (QA-CHECKLIST §6.2 "max_tokens truncates response as
@@ -43,78 +42,6 @@ if (!process.env.CI) {
 const TOKEN_LIMIT = 50;
 const ESSAY_PROMPT =
   "Write a detailed 500-word essay about the history of the ocean. Do not use any tools — answer directly.";
-
-interface ModelRecord {
-  provider: string;
-  model: string;
-}
-
-interface TestTarget {
-  label: string;
-  options: LoadSimpleAgentOptions;
-  skipReason?: string;
-}
-
-function getModelsFromJson(): ModelRecord[] {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/models.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("models.json not found — run collect-models.spec.ts first.");
-    return [];
-  }
-  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
-}
-
-function getTestTargets(): TestTarget[] {
-  const skipReasons = providerSkipReasons();
-
-  if (process.env.MODEL_TEST_ID) {
-    const model = process.env.MODEL_TEST_ID;
-    const allModels = getModelsFromJson();
-    const record = allModels.find((m) => m.model === model);
-    if (!record) {
-      console.warn(`MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred.`);
-      return [{ label: `model:${model}`, options: { model } }];
-    }
-    const provider = record.provider as Provider;
-    return [{
-      label: `${provider} / ${model}`,
-      options: { provider, model },
-      skipReason: skipReasons.get(provider),
-    }];
-  }
-
-  const allModels = getModelsFromJson();
-  if (allModels.length === 0) {
-    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
-    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
-    return [{
-      label: `provider:${fallbackProvider} (fallback)`,
-      options: { provider: fallbackProvider },
-      skipReason: skipReasons.get(fallbackProvider),
-    }];
-  }
-
-  let models = allModels;
-  if (process.env.MODEL_TEST_PROVIDER) {
-    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
-  } else if (process.env.ALL_MODELS !== "true") {
-    const seen = new Set<string>();
-    models = models.filter((m) => {
-      if (seen.has(m.provider)) return false;
-      seen.add(m.provider);
-      return true;
-    });
-  }
-
-  return models.map((m) => ({
-    label: `${m.provider} / ${m.model}`,
-    options: { provider: m.provider as Provider, model: m.model },
-    skipReason: skipReasons.get(m.provider),
-  }));
-}
 
 // Id-scoped flow cleanup via the shared tracker (#1108). It captures every
 // `POST /api/v1/flows` → 201 the page makes, which is what the previous
@@ -340,7 +267,7 @@ async function readOutputTokens(page: Page): Promise<number> {
   return parseTokenCount(match?.[1]);
 }
 
-const targets = getTestTargets();
+const targets = resolveTestTargets({ tier: "tool-calling" });
 
 // Each test loads the Simple Agent template (creating a flow) and runs it in the
 // shared Playground; serial mode + --workers=1 keeps that shared instance state

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-multi-tool-selection.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-multi-tool-selection.spec.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import path from "path";
-import fs from "fs";
 import type { Page } from "@playwright/test";
 import type { APIRequestContext } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
@@ -13,7 +12,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
+import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targets";
 
 /**
  * Agent multi-tool selection (QA-CHECKLIST §6.2 "Agent with multiple
@@ -72,78 +71,6 @@ const SYSTEM_PROMPT =
 const SYSTEM_PROMPT_SEQUENCE =
   "Use the connected tools to complete the task. You may call multiple tools in " +
   "sequence as the task requires; never answer from memory and never refuse.";
-
-interface ModelRecord {
-  provider: string;
-  model: string;
-}
-
-interface TestTarget {
-  label: string;
-  options: LoadSimpleAgentOptions;
-  skipReason?: string;
-}
-
-function getModelsFromJson(): ModelRecord[] {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/models.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("models.json not found — run collect-models.spec.ts first.");
-    return [];
-  }
-  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
-}
-
-function getTestTargets(): TestTarget[] {
-  const skipReasons = providerSkipReasons();
-
-  if (process.env.MODEL_TEST_ID) {
-    const model = process.env.MODEL_TEST_ID;
-    const allModels = getModelsFromJson();
-    const record = allModels.find((m) => m.model === model);
-    if (!record) {
-      console.warn(`MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred.`);
-      return [{ label: `model:${model}`, options: { model } }];
-    }
-    const provider = record.provider as Provider;
-    return [{
-      label: `${provider} / ${model}`,
-      options: { provider, model },
-      skipReason: skipReasons.get(provider),
-    }];
-  }
-
-  const allModels = getModelsFromJson();
-  if (allModels.length === 0) {
-    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
-    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
-    return [{
-      label: `provider:${fallbackProvider} (fallback)`,
-      options: { provider: fallbackProvider },
-      skipReason: skipReasons.get(fallbackProvider),
-    }];
-  }
-
-  let models = allModels;
-  if (process.env.MODEL_TEST_PROVIDER) {
-    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
-  } else if (process.env.ALL_MODELS !== "true") {
-    const seen = new Set<string>();
-    models = models.filter((m) => {
-      if (seen.has(m.provider)) return false;
-      seen.add(m.provider);
-      return true;
-    });
-  }
-
-  return models.map((m) => ({
-    label: `${m.provider} / ${m.model}`,
-    options: { provider: m.provider as Provider, model: m.model },
-    skipReason: skipReasons.get(m.provider),
-  }));
-}
 
 // Flows created by each test are tracked here and deleted by id in
 // afterEach — loadTemplateByName does NO cleanup (post-#553 contract), and
@@ -406,7 +333,7 @@ async function expectToolSequencePersisted(
     .toBe("tool-sequence-in-order");
 }
 
-const targets = getTestTargets();
+const targets = resolveTestTargets({ tier: "tool-calling" });
 
 // Serial mode + --workers=1 keeps the shared instance state deterministic
 // (area rule for agent specs). Cleanup is id-scoped in afterEach — nothing

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-multimodal-image-input.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-multimodal-image-input.spec.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import path from "path";
-import fs from "fs";
 import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
@@ -13,7 +12,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
+import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targets";
 
 /**
  * Agent multimodal image input (QA-CHECKLIST §6.5, "Image passed via input
@@ -56,112 +55,6 @@ const IMAGE_SPECIFIC = /chain/i;
 // instead of surfacing as "pattern not found".
 const NO_IMAGE_REACHED_MODEL =
   /(cannot|can not|can't|unable to|not able to)[\s\S]{0,40}(interpret|describe|process|analy[sz]e|see|view)|did not (provide|attach|include)|no image (was )?(provided|attached|included)|please (upload|provide|attach|share)/i;
-
-interface ModelRecord {
-  provider: string;
-  model: string;
-}
-
-interface TestTarget {
-  label: string;
-  options: LoadSimpleAgentOptions;
-  skipReason?: string;
-}
-
-// Non-vision / non-chat model families to exclude when resolving a vision model.
-const NON_VISION = /gemma|embedding|tts|audio|whisper|realtime|image|customtools|moderation|search/i;
-
-// Fallback preference per provider, used only when the settled model cannot be
-// used (see resolveVisionModel). Alias/undated patterns only — a hardcoded dated
-// id goes stale the moment the provider retires it (#886, #964).
-const VISION_PREFS: Record<string, RegExp[]> = {
-  openai: [/^gpt-4o-mini$/, /^gpt-4o$/, /^gpt-4\.1(-mini)?$/, /gpt-4o/, /^gpt-5.*mini$/, /^gpt-5/],
-  google: [/^gemini-flash-latest$/, /gemini.*flash/, /gemini/],
-  anthropic: [/^claude-3-5-sonnet/, /^claude-3-5-haiku/, /^claude-3-7/, /claude-3\.?5/, /claude-3/, /claude/],
-};
-
-// Resolve a vision-capable model for a provider from its models.json entries.
-//
-// **Settled-first (#964).** `collect-models` probes the provider's catalog with
-// real calls and promotes the model it actually validated to the front of that
-// provider's entries; models.json still lists the ones it rejected. Preferring a
-// hardcoded id over that settled model pins a model nobody validated: this spec
-// asked for `^gemini-2.5-flash$` first, which Google has retired ("no longer
-// available to new users") — collect-models skipped it as gated and settled on
-// `gemini-3.5-flash`, while the spec kept resolving the retired id. Locally that
-// 404s ("Flow build failed"); in CI, on a key that still reaches it, the agent
-// answered that it cannot interpret images at all (#964, dailies 2026-07-20 /
-// 07-22 / 07-27). So: take the settled model, and fall back to the preference
-// scan only when it is not usable for vision.
-function resolveVisionModel(provider: string, models: ModelRecord[]): string | undefined {
-  const providerModels = models.filter((m) => m.provider === provider).map((m) => m.model);
-  const candidates = providerModels.filter((m) => !NON_VISION.test(m));
-
-  const settled = providerModels[0];
-  if (settled && !NON_VISION.test(settled)) return settled;
-
-  const prefs = VISION_PREFS[provider] ?? [/.*/];
-  for (const pref of prefs) {
-    const hit = candidates.find((m) => pref.test(m));
-    if (hit) return hit;
-  }
-  return candidates[0];
-}
-
-function getModelsFromJson(): ModelRecord[] {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/models.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("models.json not found — run collect-models.spec.ts first.");
-    return [];
-  }
-  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
-}
-
-// One target per active provider, each with a resolved vision-capable model.
-// A provider with no vision model is skipped with a reason.
-function getTestTargets(): TestTarget[] {
-  const skipReasons = providerSkipReasons();
-  const allModels = getModelsFromJson();
-
-  if (allModels.length === 0) {
-    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
-    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
-    return [{
-      label: `provider:${fallbackProvider} (fallback)`,
-      options: { provider: fallbackProvider },
-      skipReason: skipReasons.get(fallbackProvider),
-    }];
-  }
-
-  // Explicit single-provider override.
-  if (process.env.MODEL_TEST_PROVIDER) {
-    const provider = process.env.MODEL_TEST_PROVIDER;
-    const model = resolveVisionModel(provider, allModels);
-    return [{
-      label: `${provider} / ${model ?? "(no vision model)"}`,
-      options: { provider: provider as Provider, model },
-      skipReason:
-        skipReasons.get(provider) ??
-        (model ? undefined : `Provider "${provider}" has no vision-capable model in models.json`),
-    }];
-  }
-
-  // One vision model per provider present in models.json.
-  const providers = Array.from(new Set(allModels.map((m) => m.provider)));
-  return providers.map((provider) => {
-    const model = resolveVisionModel(provider, allModels);
-    return {
-      label: `${provider} / ${model ?? "(no vision model)"}`,
-      options: { provider: provider as Provider, model },
-      skipReason:
-        skipReasons.get(provider) ??
-        (model ? undefined : `Provider "${provider}" has no vision-capable model in models.json`),
-    };
-  });
-}
 
 // Flows created by the template load are tracked here and deleted BY ID in
 // afterEach. `SimpleAgentTemplatePage.load()` does NO cleanup (post-#553
@@ -266,7 +159,7 @@ async function openPlayground(page: Page, attachImage: boolean): Promise<void> {
   }
 }
 
-const targets = getTestTargets();
+const targets = resolveTestTargets({ tier: "tool-calling", requires: "vision" });
 
 // Serial: each provider block loads the Simple Agent template and runs it, and
 // the Playground work is heavy enough that concurrent provider blocks starve the

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-structured-output.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-structured-output.spec.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import path from "path";
-import fs from "fs";
 import type { APIRequestContext, Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
@@ -13,7 +12,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
+import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targets";
 
 /**
  * Agent structured output (QA-CHECKLIST §6.5 "Agent returns output in
@@ -42,78 +41,6 @@ import { providerSkipReasons } from "../../../../helpers/provider-setup/provider
 
 if (!process.env.CI) {
   dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
-}
-
-interface ModelRecord {
-  provider: string;
-  model: string;
-}
-
-interface TestTarget {
-  label: string;
-  options: LoadSimpleAgentOptions;
-  skipReason?: string;
-}
-
-function getModelsFromJson(): ModelRecord[] {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/models.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("models.json not found — run collect-models.spec.ts first.");
-    return [];
-  }
-  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
-}
-
-function getTestTargets(): TestTarget[] {
-  const skipReasons = providerSkipReasons();
-
-  if (process.env.MODEL_TEST_ID) {
-    const model = process.env.MODEL_TEST_ID;
-    const allModels = getModelsFromJson();
-    const record = allModels.find((m) => m.model === model);
-    if (!record) {
-      console.warn(`MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred.`);
-      return [{ label: `model:${model}`, options: { model } }];
-    }
-    const provider = record.provider as Provider;
-    return [{
-      label: `${provider} / ${model}`,
-      options: { provider, model },
-      skipReason: skipReasons.get(provider),
-    }];
-  }
-
-  const allModels = getModelsFromJson();
-  if (allModels.length === 0) {
-    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
-    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
-    return [{
-      label: `provider:${fallbackProvider} (fallback)`,
-      options: { provider: fallbackProvider },
-      skipReason: skipReasons.get(fallbackProvider),
-    }];
-  }
-
-  let models = allModels;
-  if (process.env.MODEL_TEST_PROVIDER) {
-    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
-  } else if (process.env.ALL_MODELS !== "true") {
-    const seen = new Set<string>();
-    models = models.filter((m) => {
-      if (seen.has(m.provider)) return false;
-      seen.add(m.provider);
-      return true;
-    });
-  }
-
-  return models.map((m) => ({
-    label: `${m.provider} / ${m.model}`,
-    options: { provider: m.provider as Provider, model: m.model },
-    skipReason: skipReasons.get(m.provider),
-  }));
 }
 
 // Flows created by the template load are tracked here and deleted by id in
@@ -350,7 +277,7 @@ async function runAgentAndParseStructuredOutput(
   return parsed;
 }
 
-const targets = getTestTargets();
+const targets = resolveTestTargets({ tier: "tool-calling" });
 
 // Loads the Simple Agent template — serial + --workers=1 per the agent-area
 // rule. Cleanup is id-scoped; nothing here wipes flows.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-system-prompt.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-system-prompt.spec.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import path from "path";
-import fs from "fs";
 import type { APIRequestContext, Page, Response } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
@@ -12,7 +11,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
+import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targets";
 
 if (!process.env.CI) {
   dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
@@ -27,85 +26,6 @@ const SENTINEL_BASE = "PINEAPPLE";
 // The user message is unrelated to the sentinel — the model has no reason to
 // produce the code word unless the system prompt instructed it.
 const USER_MESSAGE = "What is the capital of France?";
-
-interface ModelRecord {
-  provider: string;
-  model: string;
-}
-
-interface TestTarget {
-  label: string;
-  options: LoadSimpleAgentOptions;
-  skipReason?: string;
-}
-
-function getModelsFromJson(): ModelRecord[] {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/models.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("models.json not found — run collect-models.spec.ts first.");
-    return [];
-  }
-  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
-}
-
-function getTestTargets(): TestTarget[] {
-  const skipReasons = providerSkipReasons();
-
-  if (process.env.MODEL_TEST_ID) {
-    const model = process.env.MODEL_TEST_ID;
-    const allModels = getModelsFromJson();
-    const record = allModels.find((m) => m.model === model);
-
-    if (!record) {
-      console.warn(
-        `MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred. ` +
-        `Run collect-models.spec.ts first, or set MODEL_TEST_PROVIDER.`,
-      );
-      return [{ label: `model:${model}`, options: { model } }];
-    }
-
-    const provider = record.provider as Provider;
-    return [{
-      label: `${provider} / ${model}`,
-      options: { provider, model },
-      skipReason: skipReasons.get(provider),
-    }];
-  }
-
-  const allModels = getModelsFromJson();
-
-  if (allModels.length === 0) {
-    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
-    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
-    return [{
-      label: `provider:${fallbackProvider} (fallback)`,
-      options: { provider: fallbackProvider },
-      skipReason: skipReasons.get(fallbackProvider),
-    }];
-  }
-
-  let models = allModels;
-
-  if (process.env.MODEL_TEST_PROVIDER) {
-    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
-  } else if (process.env.ALL_MODELS !== "true") {
-    const seen = new Set<string>();
-    models = models.filter((m) => {
-      if (seen.has(m.provider)) return false;
-      seen.add(m.provider);
-      return true;
-    });
-  }
-
-  return models.map((m) => ({
-    label: `${m.provider} / ${m.model}`,
-    options: { provider: m.provider as Provider, model: m.model },
-    skipReason: skipReasons.get(m.provider),
-  }));
-}
 
 // Track every flow the template load creates (POST /api/v1/flows → 201) so
 // afterEach can delete exactly those ids. SimpleAgentTemplatePage.load() does NO
@@ -234,7 +154,7 @@ async function askAndGetReply(page: Page, message: string): Promise<string> {
   return chatMessage.innerText();
 }
 
-const targets = getTestTargets();
+const targets = resolveTestTargets({ tier: "tool-calling" });
 
 // SimpleAgentTemplatePage.load() deletes all flows before loading the template.
 // File-level serial mode prevents parallel provider blocks from wiping each

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-error-handling.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-error-handling.spec.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import path from "path";
-import fs from "fs";
 import type { Page } from "@playwright/test";
 import type { APIRequestContext } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
@@ -14,7 +13,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
+import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targets";
 
 /**
  * Agent tool error handling (QA-CHECKLIST §6.4 "Tool returns error — agent
@@ -47,78 +46,6 @@ const SYSTEM_PROMPT =
   "If a tool call fails or returns an error, reply with a message that starts with TOOL_FAILED: followed by the reason.";
 const SSRF_MARKER = /SSRF Protection/i;
 const CONTINUATION_SENTINEL = /TOOL_FAILED/i;
-
-interface ModelRecord {
-  provider: string;
-  model: string;
-}
-
-interface TestTarget {
-  label: string;
-  options: LoadSimpleAgentOptions;
-  skipReason?: string;
-}
-
-function getModelsFromJson(): ModelRecord[] {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/models.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("models.json not found — run collect-models.spec.ts first.");
-    return [];
-  }
-  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
-}
-
-function getTestTargets(): TestTarget[] {
-  const skipReasons = providerSkipReasons();
-
-  if (process.env.MODEL_TEST_ID) {
-    const model = process.env.MODEL_TEST_ID;
-    const allModels = getModelsFromJson();
-    const record = allModels.find((m) => m.model === model);
-    if (!record) {
-      console.warn(`MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred.`);
-      return [{ label: `model:${model}`, options: { model } }];
-    }
-    const provider = record.provider as Provider;
-    return [{
-      label: `${provider} / ${model}`,
-      options: { provider, model },
-      skipReason: skipReasons.get(provider),
-    }];
-  }
-
-  const allModels = getModelsFromJson();
-  if (allModels.length === 0) {
-    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
-    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
-    return [{
-      label: `provider:${fallbackProvider} (fallback)`,
-      options: { provider: fallbackProvider },
-      skipReason: skipReasons.get(fallbackProvider),
-    }];
-  }
-
-  let models = allModels;
-  if (process.env.MODEL_TEST_PROVIDER) {
-    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
-  } else if (process.env.ALL_MODELS !== "true") {
-    const seen = new Set<string>();
-    models = models.filter((m) => {
-      if (seen.has(m.provider)) return false;
-      seen.add(m.provider);
-      return true;
-    });
-  }
-
-  return models.map((m) => ({
-    label: `${m.provider} / ${m.model}`,
-    options: { provider: m.provider as Provider, model: m.model },
-    skipReason: skipReasons.get(m.provider),
-  }));
-}
 
 // Ids of the flows created by loadAgent(), so afterEach can delete exactly
 // those via the API (id-scoped, #515) — never a global cleanAllFlows.
@@ -284,7 +211,7 @@ async function expectReplyContainsPersisted(
     .toBe("reply-contains-expected");
 }
 
-const targets = getTestTargets();
+const targets = resolveTestTargets({ tier: "tool-calling" });
 
 // Serial mode + --workers=1 keeps the shared instance state deterministic.
 // (This used to claim SimpleAgentTemplatePage.load() deletes all flows first —

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-inspection.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-inspection.spec.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import path from "path";
-import fs from "fs";
 import type { Page } from "@playwright/test";
 import type { APIRequestContext } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
@@ -13,7 +12,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
+import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targets";
 
 /**
  * Agent tool inspection (QA-CHECKLIST §6.5 "Inspect tools used by Agent in
@@ -58,78 +57,6 @@ const EXPECTED_TITLE = /Sample Slide Show/i;
 const SYSTEM_PROMPT =
   "For every user question you MUST call exactly one tool to obtain the answer - " +
   "never answer from memory and never refuse. Choose the tool that fits the question.";
-
-interface ModelRecord {
-  provider: string;
-  model: string;
-}
-
-interface TestTarget {
-  label: string;
-  options: LoadSimpleAgentOptions;
-  skipReason?: string;
-}
-
-function getModelsFromJson(): ModelRecord[] {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/models.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("models.json not found — run collect-models.spec.ts first.");
-    return [];
-  }
-  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
-}
-
-function getTestTargets(): TestTarget[] {
-  const skipReasons = providerSkipReasons();
-
-  if (process.env.MODEL_TEST_ID) {
-    const model = process.env.MODEL_TEST_ID;
-    const allModels = getModelsFromJson();
-    const record = allModels.find((m) => m.model === model);
-    if (!record) {
-      console.warn(`MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred.`);
-      return [{ label: `model:${model}`, options: { model } }];
-    }
-    const provider = record.provider as Provider;
-    return [{
-      label: `${provider} / ${model}`,
-      options: { provider, model },
-      skipReason: skipReasons.get(provider),
-    }];
-  }
-
-  const allModels = getModelsFromJson();
-  if (allModels.length === 0) {
-    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
-    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
-    return [{
-      label: `provider:${fallbackProvider} (fallback)`,
-      options: { provider: fallbackProvider },
-      skipReason: skipReasons.get(fallbackProvider),
-    }];
-  }
-
-  let models = allModels;
-  if (process.env.MODEL_TEST_PROVIDER) {
-    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
-  } else if (process.env.ALL_MODELS !== "true") {
-    const seen = new Set<string>();
-    models = models.filter((m) => {
-      if (seen.has(m.provider)) return false;
-      seen.add(m.provider);
-      return true;
-    });
-  }
-
-  return models.map((m) => ({
-    label: `${m.provider} / ${m.model}`,
-    options: { provider: m.provider as Provider, model: m.model },
-    skipReason: skipReasons.get(m.provider),
-  }));
-}
 
 // Flow ids created by each test, deleted by id in afterEach (id-scoped — never
 // name-based or delete-all). SimpleAgentTemplatePage.load() discards the id, so
@@ -286,7 +213,7 @@ async function expectToolInspectionPersisted(
     .toBe("tool-inspection-captured");
 }
 
-const targets = getTestTargets();
+const targets = resolveTestTargets({ tier: "tool-calling" });
 
 // Serial + --workers=1: shared instance state (agent-family rule). Cleanup is
 // id-scoped in afterEach — nothing here wipes flows.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-name-validation.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-tool-name-validation.spec.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import path from "path";
-import fs from "fs";
 import type { Page } from "@playwright/test";
 import type { APIRequestContext } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
@@ -14,7 +13,7 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
-import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
+import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targets";
 
 /**
  * Agent tool name validation (QA-CHECKLIST §6.4 "Tool with invalid name —
@@ -49,78 +48,6 @@ const TASK = "Reply with exactly: hello from the control test";
 // probed live on claude-sonnet-5 — #632).
 const INVALID_NAME_ERROR =
   /invalid function name|does not match pattern|should match pattern|INVALID_ARGUMENT/i;
-
-interface ModelRecord {
-  provider: string;
-  model: string;
-}
-
-interface TestTarget {
-  label: string;
-  options: LoadSimpleAgentOptions;
-  skipReason?: string;
-}
-
-function getModelsFromJson(): ModelRecord[] {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/models.json",
-  );
-  if (!fs.existsSync(jsonPath)) {
-    console.warn("models.json not found — run collect-models.spec.ts first.");
-    return [];
-  }
-  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
-}
-
-function getTestTargets(): TestTarget[] {
-  const skipReasons = providerSkipReasons();
-
-  if (process.env.MODEL_TEST_ID) {
-    const model = process.env.MODEL_TEST_ID;
-    const allModels = getModelsFromJson();
-    const record = allModels.find((m) => m.model === model);
-    if (!record) {
-      console.warn(`MODEL_TEST_ID="${model}" not found in models.json — provider cannot be inferred.`);
-      return [{ label: `model:${model}`, options: { model } }];
-    }
-    const provider = record.provider as Provider;
-    return [{
-      label: `${provider} / ${model}`,
-      options: { provider, model },
-      skipReason: skipReasons.get(provider),
-    }];
-  }
-
-  const allModels = getModelsFromJson();
-  if (allModels.length === 0) {
-    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
-    console.warn("models.json not found or empty — run collect-models.spec.ts first.");
-    return [{
-      label: `provider:${fallbackProvider} (fallback)`,
-      options: { provider: fallbackProvider },
-      skipReason: skipReasons.get(fallbackProvider),
-    }];
-  }
-
-  let models = allModels;
-  if (process.env.MODEL_TEST_PROVIDER) {
-    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
-  } else if (process.env.ALL_MODELS !== "true") {
-    const seen = new Set<string>();
-    models = models.filter((m) => {
-      if (seen.has(m.provider)) return false;
-      seen.add(m.provider);
-      return true;
-    });
-  }
-
-  return models.map((m) => ({
-    label: `${m.provider} / ${m.model}`,
-    options: { provider: m.provider as Provider, model: m.model },
-    skipReason: skipReasons.get(m.provider),
-  }));
-}
 
 // SimpleAgentTemplatePage.load() does NO cleanup (post-#553 contract) — track
 // every flow the load actually creates (POST /api/v1/flows → 201) and delete
@@ -258,7 +185,7 @@ async function openPlaygroundAndSend(page: Page): Promise<void> {
   await waitForAgentToFinish(page);
 }
 
-const targets = getTestTargets();
+const targets = resolveTestTargets({ tier: "tool-calling" });
 
 // Named template loads collide under parallelism — this file is serial and
 // the folder is run with --workers=1 (agent-family convention).

--- a/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
@@ -1,6 +1,5 @@
 import * as dotenv from "dotenv";
 import path from "path";
-import fs from "fs";
 import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
@@ -10,10 +9,10 @@ import {
   providerConfigMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
+import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targets";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
-import { providerSkipReasons } from "../../../../helpers/provider-setup/provider-health";
 
 if (!process.env.CI) {
   dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
@@ -31,70 +30,6 @@ const MCP_JSON_CONFIG = JSON.stringify({
     },
   },
 });
-
-interface ModelRecord {
-  provider: string;
-  model: string;
-}
-
-interface TestTarget {
-  label: string;
-  options: LoadSimpleAgentOptions;
-  skipReason?: string;
-}
-
-function getModelsFromJson(): ModelRecord[] {
-  const jsonPath = path.resolve(
-    __dirname,
-    "../../../../helpers/provider-setup/data/models.json",
-  );
-  if (!fs.existsSync(jsonPath)) return [];
-  return JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as ModelRecord[];
-}
-
-function getTestTargets(): TestTarget[] {
-  const skipReasons = providerSkipReasons();
-
-  if (process.env.MODEL_TEST_ID) {
-    const model = process.env.MODEL_TEST_ID;
-    const allModels = getModelsFromJson();
-    const record = allModels.find((m) => m.model === model);
-    const provider = record?.provider as Provider | undefined;
-    return [{
-      label: `model:${model}`,
-      options: { provider, model },
-      skipReason: provider ? skipReasons.get(provider) : undefined,
-    }];
-  }
-
-  const allModels = getModelsFromJson();
-  if (allModels.length === 0) {
-    const fallbackProvider = Object.keys(providerConfigMap)[0] as Provider;
-    return [{
-      label: `provider:${fallbackProvider} (fallback)`,
-      options: { provider: fallbackProvider },
-      skipReason: skipReasons.get(fallbackProvider),
-    }];
-  }
-
-  let models = allModels;
-  if (process.env.MODEL_TEST_PROVIDER) {
-    models = models.filter((m) => m.provider === process.env.MODEL_TEST_PROVIDER);
-  } else if (process.env.ALL_MODELS !== "true") {
-    const seen = new Set<string>();
-    models = models.filter((m) => {
-      if (seen.has(m.provider)) return false;
-      seen.add(m.provider);
-      return true;
-    });
-  }
-
-  return models.map((m) => ({
-    label: `${m.provider} / ${m.model}`,
-    options: { provider: m.provider as Provider, model: m.model },
-    skipReason: skipReasons.get(m.provider),
-  }));
-}
 
 // Id of the flow the running test created; teardown deletes only this one via
 // the API (scoped) — never a global cleanAllFlows, which wipes flows other
@@ -118,7 +53,7 @@ async function waitForAgentToFinish(page: Page): Promise<void> {
   }
 }
 
-const targets = getTestTargets();
+const targets = resolveTestTargets({ tier: "tool-calling" });
 
 // Serial mode prevents parallel provider blocks from racing autosaves of the
 // template flow. (load() no longer deletes all flows — that cross-worker wipe


### PR DESCRIPTION
Closes #1184.

Foundation for the model-selection thread that follows #1169 / PR #1170: one resolver, so a
lane can change what the suite runs against in one place instead of seventeen.

## The premise in #1184 was wrong, and the real state is worse

The issue said the function was copy-pasted into 17 specs. It was — but the copies had
drifted into **five variants, three of them semantically different**:

| Variant | Specs | What differed |
|---|---|---|
| A | 10 | canonical: `MODEL_TEST_ID` branch, `MODEL_TEST_PROVIDER` sweep, `ALL_MODELS`, first-per-provider dedup |
| B | 4 | identical to A — a longer warning string and blank lines |
| C | `mcp-client-agent` | not-in-catalog path returns `provider: undefined` **with no warning**, and the empty-catalog warning was gone too |
| D | `agent-multimodal-image-input` | **no `MODEL_TEST_ID` branch**; `resolveVisionModel`; `MODEL_TEST_PROVIDER` *narrowed* instead of sweeping; no `ALL_MODELS` |
| E | `agent-markdown-output` | same shape as D, with `resolveChatModel` |

**C is the #570 / #1012 failure with the alarm disconnected** — the one copy that could
return a provider-less target, silently, while the run stayed green.

**D and E were live.** PR #1170 pins the PR lane by emitting `MODEL_TEST_PROVIDER` and
`MODEL_TEST_ID` as a pair, and these two ignored the id. Measured on this branch:

| env | before (D + E) | after |
|---|---|---|
| `MODEL_TEST_ID=gpt-4o-mini` | **2 targets** — openai *and* anthropic | 1 target |
| `MODEL_TEST_PROVIDER=openai` | 1 target | 33 targets (the documented sweep) |
| the pair | 1 target | 1 target |

So the pin narrowed those two specs only by accident of the paired provider variable, and
`MODEL_TEST_ID` on its own did not pin them at all. That is the same latent coupling #1169
recorded as "`getTestTargets()` reads `models.json[0]` rather than the settled
`providers.json` pick".

## What this ships

**`tests/helpers/provider-setup/test-targets.ts`** — two orthogonal axes, because the
copies were already encoding both:

- **`tier`** — what a lane owes the spec: `none` / `any-completion` / `tool-calling` /
  `provider-contract`. This is the vocabulary #1185 (pin the daily) and #1187 (route to
  Ollama) branch on. **Nothing acts on it here, deliberately** — it exists so a lane
  resolves policy in one place instead of 17, and so a spec's requirement lives next to the
  spec rather than in whoever edits a workflow next.
- **`requires`** — which model *within* a provider satisfies the assertion (`vision` /
  `chat`). Orthogonal: `agent-multimodal-image-input` needs a real agent **and** a
  vision-capable model.

Env precedence is unchanged and stays exactly what `README.md`, `.env.example` and
`CONTRIBUTING.md` document, `MODEL_TEST_PROVIDER` widening included. That widening is an
**intentional sweep lever**, not the trap #1169 named: narrowing it here would contradict
three documents and change 15 specs. The footgun is neutralised where it matters —
`select-pr-model-target.mjs` never emits one variable without the other. Reconsidering it
belongs to #1185 / #1186, where the lanes are wired.

## Why the docs commit is the root cause, not a tidy-up

`CONTRIBUTING.md` shipped a full inline `getTestTargets` to paste into a new spec, and
`llm-agents/CLAUDE.md` said it in words: *"copy the `getTestTargets()` in
agent-component-regression.spec.ts"*. Both then warned **not** to inline the
inactive-provider skip map — *"one shared implementation, and inlining a copy of it is the
drift #1043 removed from 18 specs"*. Same argument, other function, opposite instruction.

Left alone, the next agent spec is copy 18. #1184 is #1043 finished.

## Validation

| Check | Result |
|---|---|
| **Collection parity** | **589 tests identical** before/after — same files, titles and per-provider/model parametrization (`playwright --list` over the whole suite, diff empty ignoring line numbers) |
| `npm run test:units` | 278 passed, 0 failed (26 new) |
| `npm run test:scripts` | 262 passed, 0 failed |
| `npm run typecheck` | clean |
| `npm run lint` | 0 errors (1307 warnings, all pre-existing) |
| PR guards | `check:checklist-coverage` ✓ · `check-checklist-guard` ✓ · `regressions:check` ✓ |
| Force-fail ×7 | sweep→narrow: 2 red · settled-first removed: 1 red · provider spec reading a pin variable: guard red · plus the four review fixes below, one force-fail each |
| Runtime, model-free | 1 passed (5.4 s) — the migrated module loads and executes |
| Runtime, paid | 1 passed (13.6 s) — `[openai / gpt-4o-mini]`, the pinned pair resolves and the agent runs end to end |
| Orphan flows | 1 before → 1 after |

Labels are byte-identical **except for one test, deliberately**. A title is the test's identity
in `results.json`, `spec-durations.json` and the `@stable` auto-removal path, so a rename
orphans history; `(no vision model)` and `(no chat model)` are preserved verbatim. The
exception is `mcp-client-agent`, whose copy labelled a pinned target `model:<id>` rather than
`<provider> / <id>`:

| | Describe title with `MODEL_TEST_ID=gpt-4o-mini` |
|---|---|
| Before | `MCP Client – Agent using MCPTools [model:gpt-4o-mini]` |
| After | `MCP Client – Agent using MCPTools [openai / gpt-4o-mini]` |

The new title is the better one — it names the provider, which the old one hid — but it
**resets that test's history on the pinned lanes**: `pr-validation.yml` pins today,
`daily-stable.yml` will once #1185 lands. Recorded in `docs/mcp/client/mcp-client-agent.md` so
it is a decision rather than a duration outlier someone chases later.

*(This paragraph originally claimed unqualified byte-identity. That was wrong, and the review
pass below is what caught it.)*

**The force-fail pass earned its keep.** Removing settled-first (#964) left every test
green — the branch was only observable when the settled model *is* capable and the
preference list would pick a different one, exactly the case where Google's retired
`gemini-*` alias broke the vision spec. A test was missing; it is now there and it goes red
when the branch is removed.

## Review pass — four defects found and fixed on this branch

An adversarial review of this PR's own diff found four defects, **three of them introduced by
code paths this PR added**, all in the same class: a silent skip, or a failure that would read
as a product regression. Each fix carries a test that goes red when the fix is reverted.

**1. Sweep + capability filter returned ZERO targets, silently.** The filter could empty the
list, the branch returned `[]`, the spec declared no tests, contributed nothing to the report,
and read green under `--pass-with-no-tests`. The same catalog was *reported* on the default
path (a `(no vision model)` target with a skip reason) and *invisible* on the sweep path. Both
paths now agree, with the placeholder appended so capable targets keep catalog order.

**2. `MODEL_TEST_ID` bypassed `requires` with no warning.** Pinning an embedding model to a
vision spec produced a runnable target with no skip reason. The pre-#1184 vision and markdown
copies could not hit this — no `MODEL_TEST_ID` branch at all — so gaining one without a
fitness check traded a silent skip for a **misleading failure** (#570). An explicit pin is
still honoured rather than swapped; an unfit one is reported. A dead provider outranks it.

**3. A corrupt `models.json` degraded to the first-provider fallback instead of failing.** That
runs a different suite than intended while the report looks normal (#1035) — and the first
version of the test file *pinned that wrong behaviour*. Restored to what the pre-#1184 copies
did (`JSON.parse` with no `try`), plus an explicit error for a parseable payload of the wrong
shape. A **missing** file still degrades softly and is covered separately: it is gitignored and
the sweep is legitimately skippable (#980).

**4. A sweep on a provider absent from the catalog returned ZERO targets, silently.** Found in
the second round, and **not introduced here** — the pre-existing copies filtered identically.
Consolidating them is what made it a one-place fix. Highly reachable: nothing validates the
variable, and the catalog keys are lowercase (`openai`) while the UI and testids use display
casing (`provider-item-OpenAI`), so `MODEL_TEST_PROVIDER=OpenAI` silently ran nothing. It
reports rather than throws — a key-less provider is legitimately absent, so a typo must not
take all 17 specs down at collection, but must not read as a pass either.

Also amended: the unfit-pin reason now points at the **name heuristic** as the thing to fix.
Verified that `gemini-2.5-flash-image` and `gpt-4o-image-preview` are excluded from `vision`
purely for containing `image`, so an explicit pin of a plausibly capable model can be refused.
The refusal stays a reported skip; telling the reader to "pin a vision-capable model" when they
just did was the part that was wrong.

**Cleared by measurement, not by reading:** all 17 specs resolve exactly one
`[openai / gpt-4o-mini]` target under the PR lane's pin, with no placeholder and no new skip;
no orphan imports survive the migration (worth checking, since `no-unused-vars` is a *warning*
here and lint would not have failed); collection parity is still the same 589 tests.

**Process note, worth more than the findings.** Parity was proven on the default path and the
env paths were *sampled* — on 2 of the 5 drifted variants. Defect 2's label change was in the
third. With five variants, the matrix had to be five.

## Deliberate behaviour change, scoped to two specs

D and E gain the `MODEL_TEST_ID` branch, so a pinned model pins them. The consequence is
that `MODEL_TEST_PROVIDER` alone sweeps their capability-filtered catalog (1 → 33 locally)
rather than narrowing. That is what the other 15 specs have always done and what the docs
describe, so this is uniformity rather than a new hazard class — but it is a real cost for
anyone using that documented lever on those two files locally, and it is written into both
spec docs.

## What this PR's own CI can and cannot prove

The resolver is reached by every parametrized agent spec, so `impacted-specs-by-import`
(#1054) will select a wide list and likely hit `IMPACTED_SPEC_CAP` (20). That is correct
behaviour and the dropped specs are listed in the job log and the run summary. The
collection-parity check above is the evidence that the 589-test shape is unchanged
regardless of which 20 the lane picks.

## Reproduce

```bash
# unit tests for the resolver (17 pass, 0 fail)
node --require ts-node/register --test tests/helpers/provider-setup/test-targets.test.ts

# collection parity — the check that matters (expect an empty diff)
npx playwright test --list --reporter=list 2>/dev/null | grep "^  \[chromium\]" \
  | sed -E 's/\.spec\.ts:[0-9]+:[0-9]+ ›/.spec.ts ›/' | sort > /tmp/after.n
git stash push -- tests/tests-automations
npx playwright test --list --reporter=list 2>/dev/null | grep "^  \[chromium\]" \
  | sed -E 's/\.spec\.ts:[0-9]+:[0-9]+ ›/.spec.ts ›/' | sort > /tmp/before.n
git stash pop
diff /tmp/before.n /tmp/after.n

# runtime, no cost
npx playwright test tests/tests-automations/regression/core-functionality/llm-agents/agent-context-id-continuity.spec.ts \
  --grep "model-free" --workers=1

# runtime, the cheapest paid agent test there is (max_iterations=1)
MODEL_TEST_ID=gpt-4o-mini MODEL_TEST_PROVIDER=openai PLAYWRIGHT_RETRIES=0 \
  npx playwright test tests/tests-automations/regression/core-functionality/llm-agents/agent-max-iterations.spec.ts \
  --grep "agent stops when max iterations is reached" --workers=1

npm run typecheck && npm run lint && npm run test:units && npm run test:scripts
```

## Next in the thread

#1185 pins the daily's `tool-calling` tier to one settled provider — the step where the
spend actually drops. #1186 gives `manual.yml` the multi-provider lane so nothing is lost.
#1187 routes `any-completion` to Ollama, priced in runner minutes and justified as Ollama
coverage rather than savings. #1183 (assigned separately) produces the spend baseline the
last one depends on.

