### PR TITLE
chore(deps): bump brace-expansion to 5.0.9 — Dependabot alerts #5 and #6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -612,16 +612,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/create-require": {


### PR DESCRIPTION
Closes #1200

## What this changes

`package-lock.json` only — `brace-expansion` 5.0.6 → 5.0.9, four lines.

## Why

Dependabot alert [#5](https://github.com/oriontech-me/langflow-e2e/security/dependabot/5) —
[GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) / CVE-2026-13149,
high, `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L` (CWE-400 / CWE-407).

`expand_()` computes `post` unconditionally at the top of the function, before the
early-return branches that never use it. For input shaped like `a{},{},{},…` every level
recurses twice over the same remaining tail and throws one result away, giving
`T(n) = 2·T(n−1)` — O(2ⁿ). The `max` option does **not** mitigate it: `max` bounds only the
output-building loops, and neither recursion consults it. Upstream measured 30 `{}` groups
(~90 bytes) blocking the calling thread for ~2 minutes.

5.0.9 also carries the fix for alert **#6**
([GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg), unbounded
expansion → OOM crash, `A:H`, patched in 5.0.8). GitHub auto-dismissed that alert on
2026-07-26, but the defect was present in the 5.0.6 we resolved — the dismissal was
GitHub's triage call, not evidence it did not apply to us. Both alerts close with this one
bump.

## Exposure here is negligible, and that is the whole justification for the shape of this PR

```
langflow-e2e@1.0.0
└─┬ eslint@10.1.0
  └─┬ minimatch@10.2.4
    └── brace-expansion@5.0.6
```

Transitive **devDependency**. The attack needs an attacker-influenced string to reach
`expand()` or a glob pattern; the only consumer here is ESLint expanding globs we author
ourselves in `eslint.config.js` and the `testMatch` config. There is no untrusted-input
path. This is worth merging because the fix costs four lockfile lines — not because the
exposure is real. Reviewers should weigh it on that basis rather than on the `high` label.

## Why lockfile-only

`minimatch@10.2.4` declares `brace-expansion: ^5.0.2`, so 5.0.9 is inside the existing
range: no `package.json` change, no major, no `overrides` entry. Produced with
`npm update brace-expansion --package-lock-only`.

The `engines` narrowing (`18 || 20 || >=22` → `20 || >=22`) is inert — every workflow pins
`node-version: "20"`, and it is a transitive dev dep either way.

## Validation

Precedent worth knowing first: `da2861d` (*"chore: bump brace-expansion to 5.0.6"*,
2026-05-23) is the same change one version earlier — deliberate, lockfile-only, three lines,
closed alerts #3 and #4 the same day. 5.0.6 was clean when it landed; GHSA-3jxr-9vmj-r5cp
(`< 5.0.7`) was published later, which is how the unchanged line became alert #5 on
2026-07-21.

**The fix is empirically confirmed, not just version-matched.** The advisory PoC (30 `{}`
groups, 90 bytes), run against the actual installed package:

| version | n=20 | n=30 (PoC) | n=1000 |
|---|---|---|---|
| 5.0.4 (vulnerable) | 141 ms | did not finish in 120 s | — |
| **5.0.9 (this PR)** | **0.46 ms** | **0.07 ms** | **17 ms** |

The 5.0.4 row reproduces the advisory's own table (it reports 130 ms at n=20), and the
n=1000 figure is consistent with the ~O(n²) the advisory describes post-fix.

**Behavioural equivalence**, 5.0.6 vs 5.0.9 over 23 patterns — this repo's six real globs
plus the edge cases the advisory calls out (`a{},b}`, `{},a}b`, `x{{a,b}}y`, `${x}`,
sequences, zero-padding, nesting): **0 divergences**. Worth noting the reason the risk is
structurally low: **zero of this repo's globs contain a brace set**, so `expand()` is a
pass-through on every pattern we actually feed it.

Gates, re-run against the version genuinely on disk:

| gate | result |
|---|---|
| `npm run lint` | 1307 problems, **0 errors** — byte-identical to the pre-bump count |
| `npm run typecheck` | clean |
| `npm run test:units` | 252/252 |
| `npm run test:scripts` | 262/262 |
| `npm audit` | **1 high before → 0 after** |

The audit line is stated as a delta on purpose: "0 vulnerabilities" alone proves nothing
about whether the bump did anything. Pre-bump, audit reports one `brace-expansion` finding
carrying **both** advisories (`GHSA-3jxr-9vmj-r5cp` and `GHSA-mh99-v99m-4gvg`) — note the
human-readable output prints only the second title, so `--json` is needed to see that #5 is
in there at all.

Tree hygiene: one `brace-expansion` entry and one `minimatch` entry in the lockfile (no
nested older copy), and `balanced-match@4.0.4` was already present and satisfies the
unchanged `^4.0.2` — so no package is added to the tree.

<details>
<summary>A verification trap this PR walked into, in case a reviewer checks locally</summary>

`npm ls` and `npm audit` read the lockfile and `node_modules/.package-lock.json`, **not the
package on disk.** On my working copy `npm ls` said `brace-expansion@5.0.9` and `npm audit`
said 0 vulnerabilities while the directory held **5.0.4** — the version `da2861d` replaced
in May — and `require("brace-expansion")` loaded that vulnerable code. An earlier revision
of this PR body cited `npm ls` as proof of the installed version and called lint "the
meaningful smoke test"; both were metadata-deep, and the gates had in fact run against
5.0.4. Every number above was re-measured after `npm ci`.

**CI was never affected** — every lane runs `npm ci`, which installs exactly the lockfile,
so the green checks on this PR did exercise 5.0.9. The trap is local-only.
</details>

## Reading the CI result on this PR

Expect the **impacted-specs E2E lane to report `skipping`, and that is correct** — nothing
under `tests/` imports `package-lock.json`, so the import graph honestly returns zero specs
(`scripts/impacted-specs-by-import.mjs`). The `ci-change-coverage` classifier should return
**`none`**: a lockfile is not a workflow, an action, or a script any lane reaches, so no
canary is warranted. Neither is a coverage gap being waved through.

## Checklist notes

No spec, spec doc, or `QA-CHECKLIST.md` change — this PR touches no test. The `@stable` and
spec-doc items of the review checklist do not apply.
