### PR TITLE
chore(ci): add dependabot.yml with grouped weekly npm + actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,91 @@
+# Dependabot VERSION updates. Two things this file is NOT:
+#
+#  1. It is not what closes a Dependabot *alert*. Alerts are closed by Dependabot
+#     **security updates**, a repository setting (Settings → Code security →
+#     "Dependabot security updates") that cannot be enabled from this file and
+#     needs admin on the repo. That distinction matters here because every alert
+#     this repo has received (#1–#6) was a *transitive* dev dependency of eslint
+#     (`picomatch`, `brace-expansion`) — nothing in package.json. Version updates
+#     below sweep the dependencies we declare; the security-updates toggle is what
+#     reacts to an advisory landing on something we only reach through the tree.
+#     See issue #1202.
+#
+#  2. It is not a substitute for review. Grouped PRs land as one diff per
+#     ecosystem, and the PR lane reports `skipping` on a manifest-only change
+#     (nothing under tests/ imports a manifest, so the import graph honestly
+#     returns zero specs). A green Dependabot PR therefore proves that the tree
+#     resolves and the static gates pass — not that the suite still runs.
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "12:00"
+      timezone: "Etc/UTC"
+    # 12:00 UTC = 09:00 BRT, deliberately after daily-stable.yml's 05:00 BRT
+    # window: a Dependabot PR triggers pr-validation.yml, which boots its own
+    # Langflow service container, and the daily is the run that must not contend
+    # for the runner.
+
+    open-pull-requests-limit: 3
+    labels:
+      - "infra"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+
+    groups:
+      # One PR for all dev dependencies. Ungrouped, the six alerts this repo has
+      # seen would have been six separate PRs, each booting a Langflow container
+      # in the PR lane. There is exactly one production dependency (dotenv), so a
+      # production group would be a group of one — it is left ungrouped on purpose.
+      dev-dependencies:
+        dependency-type: "development"
+        patterns:
+          - "*"
+
+    ignore:
+      # @playwright/test and playwright are pinned to an EXACT version on purpose,
+      # and the pin is load-bearing across files Dependabot cannot edit. Bumping
+      # the runner means 8 coordinated edits across 3 files:
+      #
+      #   package.json          @playwright/test + playwright            (2)
+      #   daily-stable.yml      3x `image: mcr.microsoft.com/playwright:vX-noble`
+      #                         + 1x PLAYWRIGHT_VERSION env             (4)
+      #   weekly-stable.yml     1x image tag + 1x PLAYWRIGHT_VERSION env (2)
+      #
+      # Dependabot only touches package.json and the lockfile, so its PR would
+      # leave every workflow behind. daily-stable.yml then fails at its
+      # "Verify Playwright version matches the container image" guard — while the
+      # PR itself looks green, because a manifest change resolves to zero impacted
+      # specs. A bot cannot make this change correctly; a human bumps the runner
+      # and the image tags together.
+      - dependency-name: "@playwright/test"
+      - dependency-name: "playwright"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "12:00"
+      timezone: "Etc/UTC"
+
+    open-pull-requests-limit: 3
+    labels:
+      - "infra"
+    commit-message:
+      prefix: "ci(deps)"
+
+    groups:
+      # Grouped for the same reason as npm, plus one specific to this repo: the
+      # action pins have already drifted apart because nothing sweeps them
+      # (checkout @v7 vs @v4, upload-artifact @v7 vs @v4, setup-python @v6 vs @v5
+      # — see #1202). A per-action PR stream is what let that happen unnoticed;
+      # one grouped PR makes the whole set visible in a single diff.
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Closes #1202

## What this adds

`.github/dependabot.yml` — weekly **version** updates for the two ecosystems that exist in
this repo (there is no Dockerfile, no `requirements.txt`, no `pyproject.toml`), grouped into
one PR per ecosystem.

## Read this before reviewing: it is not what closes a Dependabot alert

The premise of #1202 was partly wrong, and the file header records the correction so the next
reader does not repeat it:

| | configured by | does what |
|---|---|---|
| Dependabot **alerts** | repo setting (on) | reports that an advisory applies |
| Dependabot **security updates** | repo setting — **not** this file | opens a PR to close an *alert* |
| Dependabot **version updates** | this file | weekly sweep of *declared* dependencies |

All six alerts this repo has received were **transitive** dev dependencies of `eslint`
(`picomatch`, `brace-expansion`) — absent from `package.json`. Version updates sweep what we
declare; what reacts to an advisory deeper in the tree is the **security-updates** toggle,
which cannot be set from here and needs repo admin (`automated-security-fixes` returns 404
for a non-admin token). **That toggle is the primary fix and is not in this PR.** What is
here is the other half of #1202: the Actions pin drift, and the nine dev dependencies we do
declare.

## The one substantive decision: the runner is ignored

`@playwright/test` and `playwright` are in `ignore`. Their exact pin is load-bearing across
files Dependabot cannot edit — bumping the runner is **8 coordinated edits over 3 files**:

| file | sites |
|---|---|
| `package.json` | `@playwright/test`, `playwright` (2) |
| `daily-stable.yml` | 3× `image: mcr.microsoft.com/playwright:v…-noble` + 1× `PLAYWRIGHT_VERSION` (4) |
| `weekly-stable.yml` | 1× image tag + 1× `PLAYWRIGHT_VERSION` (2) |

A bot PR moves the manifest only. `daily-stable.yml` then fails at its *"Verify Playwright
version matches the container image"* guard — **after** merge, because the PR itself looks
green: a manifest-only change resolves to zero impacted specs.

## That also settles the canary question from #1202

Whether `ci-change-coverage.mjs` should force a canary for a runner manifest — measured on
all three scenarios rather than reasoned about:

```
package.json + lock + daily-stable.yml + weekly-stable.yml → verdict "dispatch"
    "…daily-stable.yml governs another lane; a PR canary cannot exercise it"
    "…weekly-stable.yml governs another lane; a PR canary cannot exercise it"
package.json + lock only                                   → verdict "none"
.github/dependabot.yml (this PR)                           → verdict "none"
```

The dangerous case is now *prevented* by the `ignore`, and a legitimate human bump **must**
touch the workflows, where the classifier already returns `dispatch` and names both lanes.
**No classifier change is warranted** — the suspicion I raised in #1202 does not survive
measurement.

Deliberately not included: a PR-time guard asserting `package.json` and the workflow image
tags agree. The bot path is closed by the `ignore`, the human path is already caught by the
daily guard (just later), and it would mean a new script plus unit tests riding along with a
config file.

## Scheduling

Monday 12:00 UTC (09:00 BRT), after `daily-stable.yml`'s 05:00 BRT window. A Dependabot PR
triggers `pr-validation.yml`, which boots its own Langflow service container; the daily is
the run that must not contend for the runner. `open-pull-requests-limit: 3` per ecosystem.

## Validation

- **YAML parsed with a real parser** and every key checked against the documented schema.
  The repo ships no YAML parser by design (see `scripts/wait-for-backend.test.mjs:393`), so
  this was done with a throwaway install outside the repo.
- `npm run lint` 0 errors, `tsc --noEmit` clean, QA-CHECKLIST guard passes.
- Every count in the file's comments was verified by grep, not estimated — the 3 vs 1 image
  tags exclude the `::error::` message lines that also mention the image.

**Honest limitation: GitHub only reads `dependabot.yml` from the default branch**, so
GitHub's own validation of this file happens after merge, not on this PR. If the config is
malformed it will surface at Insights → Dependency graph → Dependabot, not here.

## Still open, and yours to decide (not blocking this PR)

1. **The security-updates toggle** — needs admin; the primary fix for #1202.
2. **A standing exception for bot PRs** under `ROADMAP.md` → *Intake*. I did not touch
   `ROADMAP.md`: that section is marked *"Status: proposed — flow still being designed (owner:
   Alice). Do not treat it as active process until the flow lands."* Without this decision the
   config is effectively inert, since each bot PR would need its own exception issue.

No spec, spec doc, or `QA-CHECKLIST.md` change — this PR touches no test.
