### PR TITLE
ci(daily-stable): rotate the agent specs through one provider per weekday (#1185)

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -475,6 +475,43 @@ jobs:
           # configuration rather than a backstop.
           WATCH_MAX_SECONDS: "3600"
 
+      # Rotate the agent specs through ONE provider per run, by weekday (#1185).
+      # The parametrized specs resolve one model per ACTIVE provider, so ~30 @stable
+      # agent tests run an openai AND an anthropic AND a google variant every weekday —
+      # multi-turn agent runs with the tool schemas re-sent every turn (Langflow sets no
+      # `cache_control`, so nothing is cached on the anthropic side). `claude-sonnet-5`
+      # is $3/$15 per MTok against `gpt-4o-mini` at ~$0.15/$0.60: 20-25x per token for
+      # assertions that are about Langflow, not about the provider. The PR lane stopped
+      # paying that on 2026-07-31 (#1169 / PR #1170); this is the same argument applied
+      # to the lane #1170 deliberately left multi-provider.
+      #
+      # Coverage is not what is being cut. The provider-contract specs
+      # (core-functionality/model-provider/*-provider.spec.ts) read NEITHER pin
+      # variable, so every provider is still exercised end-to-end EVERY day — #1184
+      # added a unit test that fails if one of them starts reading one. What rotates is
+      # agent behaviour, which is a Langflow contract rather than a provider one.
+      #
+      # Rotation rather than a fixed pin, at identical cost: a fixed pin would make the
+      # detection window for a provider-specific regression a standing human decision
+      # (#643 anthropic streaming/`thinking`, #963 gemini "Message empty." — both real,
+      # both caught here). Rotating bounds it to <=3 days automatically. The weekday
+      # mapping is FIXED, not evenly distributed, so two Mondays are comparable:
+      #   Mon openai · Tue anthropic · Wed google · Thu openai · Fri anthropic
+      #
+      # A drained key costs a DEVIATION, not the day: the script advances to the next
+      # active provider in the rotation and says so with a ::warning::. It declines to
+      # pin only when every provider is down — where the fallback is moot anyway — and
+      # exits 2 on a providers.json it cannot read (#1035). Losing coverage is the more
+      # expensive failure (#980), and it is not hypothetical: this lane recorded ZERO
+      # tests on 07-28 and 07-31.
+      #
+      # continue-on-error: the pin is an optimisation. If it fails outright, the right
+      # outcome is the costlier multi-provider run, not a lost day — the same trade
+      # `Collect models` above already makes.
+      - name: Rotate the lane to this weekday's provider
+        continue-on-error: true
+        run: node scripts/select-daily-model-target.mjs
+
       - name: Run @stable tests (shard ${{ matrix.shard }})
         # Sharded run. The reporter list is NOT overridden on the CLI: setting
         # PW_SHARD_FILE_LEVEL selects the sharded reporter shape in

--- a/scripts/select-daily-model-target.mjs
+++ b/scripts/select-daily-model-target.mjs
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+/**
+ * Picks the single model target `daily-stable.yml` should run its LLM specs against
+ * on a given day, rotating through the providers by weekday (#1185).
+ *
+ * ## Why the daily narrows at all
+ *
+ * The parametrized agent specs resolve **one model per active provider**, so every
+ * `@stable` agent test runs an openai variant *and* an anthropic variant *and* a
+ * google variant. That is ~30 multi-turn agent tests × 3 providers, every weekday,
+ * with the Simple Agent tool schemas re-sent on every turn (Langflow sets no
+ * `cache_control`, so nothing is cached on the anthropic side). `claude-sonnet-5` is
+ * $3/$15 per MTok against `gpt-4o-mini` at ~$0.15/$0.60 — 20-25x per token for
+ * assertions that are about **Langflow**, not about the provider.
+ *
+ * The PR lane stopped paying that on 2026-07-31 (#1169 / PR #1170). This is the same
+ * argument applied to the lane #1170 deliberately left alone.
+ *
+ * ## Why a rotation and not a fixed pin
+ *
+ * A fixed pin is cheaper to reason about, but it makes the detection window for a
+ * provider-specific regression a standing human decision — anthropic and google
+ * agent behaviour would run only when someone dispatched `manual.yml`. This suite
+ * catches real provider-specific regressions (#643, anthropic streaming dropping the
+ * `thinking` block; #963, gemini returning "Message empty." while the tool fires), so
+ * that window matters.
+ *
+ * Rotating costs exactly the same — one provider per run — and bounds the window to
+ * **≤3 days, automatically**.
+ *
+ * The weekday mapping is FIXED rather than an even round-robin:
+ *
+ *   Mon → openai   Tue → anthropic   Wed → google   Thu → openai   Fri → anthropic
+ *
+ * so every Monday resolves the same provider and two Mondays are comparable. The
+ * price is an uneven 2/2/1 split across three providers over a Mon-Fri week, which is
+ * the right trade: comparability is what triage needs, evenness buys nothing. `openai`
+ * leads because it is the cheapest and is already the PR lane's target, so a Monday
+ * red is directly comparable to a PR red.
+ *
+ * ## Why the fallback is the whole point
+ *
+ * A rotation that loses the day when its provider is dry is WORSE than the
+ * multi-provider run it replaces. Lost coverage costs more than spend — #980's trade —
+ * and it is not hypothetical: the daily recorded **zero tests on 2026-07-28 and
+ * 2026-07-31**, and the shared anthropic key drained mid-window (#1169).
+ *
+ * So this walks the rotation order from the day's slot and takes the first provider
+ * `collect-models` probed `active`:
+ *
+ *  - day's provider active            → use it.
+ *  - inactive / absent from the file  → advance to the next, with a `::warning::`
+ *                                       naming what was skipped and why. NOT a
+ *                                       decline to multi-provider: that pays 3x on
+ *                                       exactly the day a key is already broken.
+ *  - every provider inactive          → decline to pin, keep the lane's existing
+ *                                       behaviour, warn. There is no live key to
+ *                                       spend, so the fallback is moot and declining
+ *                                       keeps the failure attributable.
+ *  - providers.json missing           → decline and warn. The sweep is
+ *                                       `continue-on-error` on this lane by design.
+ *  - providers.json unreadable        → exit 2. An undecidable verdict must not read
+ *                                       as "nothing to pin" (#1035).
+ *
+ * Every deviation is loud, and recoverable after the fact: the resolved provider and
+ * model land in the `param` field of `reports/daily-history.jsonl`, so "which provider
+ * did Tuesday actually run?" is answerable without opening the job log.
+ *
+ * ## Why it reuses the PR lane's decision function
+ *
+ * `selectPrModelTarget` already validates the payload shape and answers
+ * "is this provider usable, and what did it settle on" with a reason string. Calling
+ * it per candidate means the two lanes cannot drift on what `active` means, and a
+ * fallback attempt produces the same `reason` text a decline would. Only the
+ * *iteration* is new here.
+ *
+ * Run:
+ *   node scripts/select-daily-model-target.mjs \
+ *     --providers-file tests/helpers/provider-setup/data/providers.json \
+ *     --order openai,anthropic,google
+ *
+ * Side effect: appends `MODEL_TEST_ID` / `MODEL_TEST_PROVIDER` to `$GITHUB_ENV` when
+ * it pins. Always prints the decision as JSON on stdout.
+ */
+import * as fs from "fs";
+import {
+  readProvidersFile,
+  // Named for the lane that first needed it (#1169); it is really
+  // "is this provider usable, and what model did collect-models settle on".
+  selectPrModelTarget as selectSettledTarget,
+} from "./select-pr-model-target.mjs";
+
+const DEFAULT_ORDER = ["openai", "anthropic", "google"];
+
+const HELP = `Usage: node scripts/select-daily-model-target.mjs [options]
+
+  --providers-file PATH  providers.json written by collect-models
+  --order LIST           comma-separated rotation order
+                         (default: ${DEFAULT_ORDER.join(",")})
+  --date ISO             UTC instant deciding the weekday (default: now)
+  -h, --help             this text
+`;
+
+/**
+ * The rotation slot for a UTC date. Monday is slot 0 — the daily's cron is 05:00 BRT
+ * = 08:00 UTC, so the UTC weekday and the Brazilian one always agree for this lane.
+ * Saturday and Sunday map onto the same slots as Mon/Tue rather than being rejected:
+ * the lane is Mon-Fri on schedule, but a `workflow_dispatch` on a weekend must still
+ * resolve a provider instead of erroring.
+ * @param {Date} date
+ * @param {number} orderLength
+ * @returns {number}
+ */
+export function rotationSlot(date, orderLength) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    throw new Error(`--date is not a valid instant: ${date}`);
+  }
+  if (!Number.isInteger(orderLength) || orderLength < 1) {
+    throw new Error(`rotation order must have at least one provider`);
+  }
+  // getUTCDay(): Sunday 0 … Saturday 6. Shift so Monday is 0.
+  const mondayFirst = (date.getUTCDay() + 6) % 7;
+  return mondayFirst % orderLength;
+}
+
+/**
+ * Why the *decision* is shared but the *message* is not.
+ *
+ * `selectSettledTarget` ends its reason with the PR lane's remedy — "the lane keeps
+ * its default per-provider parametrization". On the rotation that sentence is FALSE:
+ * the lane does not keep multi-provider, it advances to the next active provider. A
+ * log line that contradicts what the run did is worse than no line, so the advance
+ * path composes its own diagnosis from the record while the verdict (`ok`) and the
+ * payload validation stay shared — the two lanes still cannot drift on what "active"
+ * means, which is the part that matters.
+ * @param {Array<{provider: string, status: string, error?: string}>} providers
+ * @param {string} provider
+ * @returns {string}
+ */
+function advanceReason(providers, provider) {
+  const record = providers.find((r) => r.provider === provider);
+  if (!record) {
+    return (
+      `provider "${provider}" is absent from providers.json (present: ` +
+      `${providers.map((r) => r.provider).join(", ") || "none"})`
+    );
+  }
+  return (
+    `provider "${provider}" probed "${record.status}" — collect-models reported: ` +
+    `${record.error ?? "no error message"}`
+  );
+}
+
+/**
+ * Resolve the day's target, advancing through the rotation past unusable providers.
+ *
+ * @param {unknown} providers  parsed providers.json
+ * @param {{ order?: string[], date?: Date }} [options]
+ * @returns {{ ok: boolean, provider: string|null, model: string|null, reason: string|null, warnings: string[], skipped: Array<{provider: string, reason: string}> }}
+ * @throws {Error} when the payload is not a readable provider record list, or the
+ *   rotation order is empty — both are undecidable, not "nothing to pin" (#1035).
+ */
+export function selectDailyModelTarget(providers, options = {}) {
+  const order = options.order ?? DEFAULT_ORDER;
+  if (!Array.isArray(order) || order.length === 0) {
+    throw new Error("rotation order must be a non-empty list of provider names");
+  }
+  const start = rotationSlot(options.date ?? new Date(), order.length);
+
+  // Rotate the order so the day's provider is first, then the fallbacks in order.
+  const candidates = order.map((_, i) => order[(start + i) % order.length]);
+
+  const skipped = [];
+  for (const provider of candidates) {
+    // Throws on a malformed payload — deliberately NOT caught: the first candidate
+    // already proves the file is undecidable, and trying the rest would turn a hard
+    // error into a quiet fallback.
+    const attempt = selectSettledTarget(providers, { provider });
+    if (attempt.ok) {
+      return {
+        ok: true,
+        provider: attempt.provider,
+        model: attempt.model,
+        reason: null,
+        warnings: skipped.map(
+          (s) =>
+            `rotation advanced past "${s.provider}" (this weekday's slot): ${s.reason}`,
+        ),
+        skipped,
+      };
+    }
+    skipped.push({ provider, reason: advanceReason(providers, provider) });
+  }
+
+  return {
+    ok: false,
+    provider: null,
+    model: null,
+    reason:
+      `no provider in the rotation (${order.join(", ")}) is usable, so there is no ` +
+      `settled model to pin to — the lane keeps its default per-provider ` +
+      `parametrization. With every key down that costs nothing extra and keeps the ` +
+      `failure attributable. Per provider: ` +
+      skipped.map((s) => `${s.provider} — ${s.reason}`).join(" | "),
+    warnings: [],
+    skipped,
+  };
+}
+
+function parseArgs(argv) {
+  const args = {
+    providersFile: "tests/helpers/provider-setup/data/providers.json",
+    order: DEFAULT_ORDER,
+    date: undefined,
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    if (flag === "-h" || flag === "--help") {
+      args.help = true;
+      continue;
+    }
+    const value = argv[i + 1];
+    if (value === undefined) throw new Error(`${flag} needs a value`);
+    if (flag === "--providers-file") args.providersFile = value;
+    else if (flag === "--order") {
+      args.order = value
+        .split(",")
+        .map((p) => p.trim())
+        .filter(Boolean);
+      if (args.order.length === 0) throw new Error("--order is empty");
+    } else if (flag === "--date") args.date = new Date(value);
+    else throw new Error(`unknown flag: ${flag}`);
+    i++;
+  }
+  return args;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`::error::select-daily-model-target: ${error.message}\n`);
+    process.exit(2);
+  }
+  if (args.help) {
+    process.stdout.write(HELP);
+    process.exit(0);
+  }
+
+  let result;
+  try {
+    const { providers, missing } = readProvidersFile(args.providersFile);
+    result = missing
+      ? {
+          ok: false,
+          provider: null,
+          model: null,
+          reason:
+            `${args.providersFile} does not exist — collect-models did not write ` +
+            `it, so there is no settled model to pin to`,
+          warnings: [],
+          skipped: [],
+        }
+      : selectDailyModelTarget(providers, { order: args.order, date: args.date });
+  } catch (error) {
+    // Fail loud (#1035): a payload this cannot read must not read as "nothing to
+    // pin". The lane is expected to fail here rather than quietly pay for a
+    // multi-provider run nobody chose.
+    process.stderr.write(`::error::select-daily-model-target: ${error.message}\n`);
+    process.exit(2);
+  }
+
+  // Deviations first, so they are visible even when the pin succeeded.
+  for (const warning of result.warnings) {
+    process.stderr.write(`::warning::select-daily-model-target: ${warning}\n`);
+  }
+
+  if (result.ok) {
+    // Both variables, always together — MODEL_TEST_PROVIDER on its own makes the
+    // resolver skip the per-provider dedup and run that provider's whole catalog.
+    const lines = [
+      `MODEL_TEST_ID=${result.model}`,
+      `MODEL_TEST_PROVIDER=${result.provider}`,
+    ];
+    if (process.env.GITHUB_ENV) {
+      fs.appendFileSync(process.env.GITHUB_ENV, `${lines.join("\n")}\n`);
+    }
+    process.stderr.write(
+      `daily lane pinned to ${result.provider} / ${result.model} ` +
+        `(settled by collect-models). The other providers' agent variants run on ` +
+        `their own weekday; the provider-contract specs still cover every provider ` +
+        `today.\n`,
+    );
+  } else {
+    process.stderr.write(`::warning::select-daily-model-target: ${result.reason}\n`);
+  }
+
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+  process.exit(0);
+}

--- a/scripts/select-daily-model-target.test.mjs
+++ b/scripts/select-daily-model-target.test.mjs
@@ -1,0 +1,336 @@
+// Unit tests for the daily lane's provider rotation (issue #1185).
+// Run with: npm run test:scripts
+//
+// What rides on this: it decides which provider the daily's ~30 @stable agent tests
+// bill against, every weekday. Three failure directions, and two of them are silent:
+//
+//  - Rotating to a DEAD provider loses the whole day of agent coverage. The daily
+//    already recorded zero tests on 2026-07-28 and 2026-07-31; a rotation that adds
+//    a third way to lose a day is worse than the multi-provider run it replaces.
+//  - Declining to pin when a fallback WAS available pays 3x on exactly the day a key
+//    is already broken.
+//  - Emitting MODEL_TEST_PROVIDER without MODEL_TEST_ID does not narrow the run, it
+//    runs that provider's whole catalog (41 openai entries on 2026-07-30) — the trap
+//    #1169 wrote a script to avoid. The pair is asserted at the CLI boundary.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  rotationSlot,
+  selectDailyModelTarget,
+} from "./select-daily-model-target.mjs";
+
+const SCRIPT = path.join(import.meta.dirname, "select-daily-model-target.mjs");
+
+/** Shaped like a real providers.json written by collect-models. */
+const healthy = () => [
+  { provider: "openai", status: "active", model: "gpt-4o-mini" },
+  { provider: "anthropic", status: "active", model: "claude-sonnet-5" },
+  { provider: "google", status: "active", model: "gemini-2.5-flash" },
+];
+
+// 2026-07-27 is a Monday; the days below walk that week.
+const MON = new Date("2026-07-27T08:00:00Z");
+const TUE = new Date("2026-07-28T08:00:00Z");
+const WED = new Date("2026-07-29T08:00:00Z");
+const THU = new Date("2026-07-30T08:00:00Z");
+const FRI = new Date("2026-07-31T08:00:00Z");
+const SAT = new Date("2026-08-01T08:00:00Z");
+const SUN = new Date("2026-08-02T08:00:00Z");
+
+// ─── The rotation itself ─────────────────────────────────────────────────────
+
+test("the weekday mapping is Mon→openai, Tue→anthropic, Wed→google, Thu→openai, Fri→anthropic", () => {
+  // Fixed rather than evenly distributed, on purpose: two Mondays must be
+  // comparable. If this table changes, day-over-day triage comparisons break.
+  const on = (d) => selectDailyModelTarget(healthy(), { date: d }).provider;
+  assert.equal(on(MON), "openai");
+  assert.equal(on(TUE), "anthropic");
+  assert.equal(on(WED), "google");
+  assert.equal(on(THU), "openai");
+  assert.equal(on(FRI), "anthropic");
+});
+
+test("the pinned model is the one collect-models settled on, never a hardcoded id", () => {
+  const result = selectDailyModelTarget(healthy(), { date: TUE });
+  assert.equal(result.ok, true);
+  assert.equal(result.provider, "anthropic");
+  assert.equal(result.model, "claude-sonnet-5");
+});
+
+test("a weekend dispatch still resolves a provider instead of erroring", () => {
+  // The lane is Mon-Fri on schedule, but workflow_dispatch has no such limit.
+  assert.equal(selectDailyModelTarget(healthy(), { date: SAT }).ok, true);
+  assert.equal(selectDailyModelTarget(healthy(), { date: SUN }).ok, true);
+});
+
+test("rotationSlot is Monday-zero and wraps on the order length", () => {
+  assert.equal(rotationSlot(MON, 3), 0);
+  assert.equal(rotationSlot(WED, 3), 2);
+  assert.equal(rotationSlot(THU, 3), 0);
+  assert.equal(rotationSlot(MON, 1), 0);
+  assert.equal(rotationSlot(FRI, 1), 0);
+});
+
+test("a custom --order changes the rotation", () => {
+  const order = ["google", "openai"];
+  assert.equal(selectDailyModelTarget(healthy(), { date: MON, order }).provider, "google");
+  assert.equal(selectDailyModelTarget(healthy(), { date: TUE, order }).provider, "openai");
+});
+
+// ─── The fallback — the reason this is not a fixed pin ───────────────────────
+
+test("the day's provider being inactive advances to the next, it does NOT lose the day", () => {
+  // Tuesday is anthropic's slot. A drained anthropic key must cost a deviation,
+  // not a day of agent coverage (#980).
+  const providers = healthy();
+  providers[1] = {
+    provider: "anthropic",
+    status: "inactive",
+    model: null,
+    error: "credit balance too low",
+  };
+  const result = selectDailyModelTarget(providers, { date: TUE });
+  assert.equal(result.ok, true);
+  assert.equal(result.provider, "google");
+  assert.deepEqual(
+    result.skipped.map((s) => s.provider),
+    ["anthropic"],
+  );
+});
+
+test("the deviation is LOUD and names the provider and the collected reason", () => {
+  const providers = healthy();
+  providers[1] = {
+    provider: "anthropic",
+    status: "inactive",
+    model: null,
+    error: "credit balance too low",
+  };
+  const result = selectDailyModelTarget(providers, { date: TUE });
+  assert.equal(result.warnings.length, 1);
+  assert.match(result.warnings[0], /advanced past "anthropic"/);
+  assert.match(result.warnings[0], /credit balance too low/);
+});
+
+test("the advance warning does NOT claim the lane kept multi-provider — it did not", () => {
+  // Caught by reading a real run's log: the reason string inherited from the PR
+  // lane's decision function ends with "the lane keeps its default per-provider
+  // parametrization", which is true when that lane declines and FALSE here, where the
+  // rotation advanced to the next provider. A log line that contradicts what the run
+  // did is worse than no line.
+  const providers = healthy();
+  providers[1] = {
+    provider: "anthropic",
+    status: "inactive",
+    model: null,
+    error: "credit balance too low",
+  };
+  const result = selectDailyModelTarget(providers, { date: TUE });
+  assert.equal(result.provider, "google", "sanity: it advanced");
+  assert.doesNotMatch(result.warnings[0], /keeps its default per-provider/);
+  assert.doesNotMatch(result.skipped[0].reason, /keeps its default per-provider/);
+});
+
+test("the all-down decline DOES say the lane keeps multi-provider — there it is true", () => {
+  const providers = healthy().map((p) => ({
+    provider: p.provider,
+    status: "inactive",
+    model: null,
+    error: "dry",
+  }));
+  const result = selectDailyModelTarget(providers, { date: MON });
+  assert.equal(result.ok, false);
+  assert.match(result.reason, /keeps its default per-provider/);
+});
+
+test("it advances more than once when it has to", () => {
+  const providers = [
+    { provider: "openai", status: "active", model: "gpt-4o-mini" },
+    { provider: "anthropic", status: "inactive", model: null, error: "dry" },
+    { provider: "google", status: "inactive", model: null, error: "spend cap" },
+  ];
+  const result = selectDailyModelTarget(providers, { date: TUE });
+  assert.equal(result.provider, "openai");
+  assert.deepEqual(
+    result.skipped.map((s) => s.provider),
+    ["anthropic", "google"],
+  );
+  assert.equal(result.warnings.length, 2);
+});
+
+test("a provider absent from providers.json is skipped like an inactive one", () => {
+  const result = selectDailyModelTarget(
+    [{ provider: "openai", status: "active", model: "gpt-4o-mini" }],
+    { date: WED }, // google's slot, and google is not in the file
+  );
+  assert.equal(result.provider, "openai");
+  assert.match(result.skipped[0].reason, /absent from providers\.json/);
+});
+
+test("every provider down declines to pin instead of pretending, and explains per provider", () => {
+  // With no live key the fallback is moot: pinning would skip every parametrized
+  // spec while the run read green. Declining keeps the failure attributable.
+  const providers = healthy().map((p) => ({
+    provider: p.provider,
+    status: "inactive",
+    model: null,
+    error: `${p.provider} is dry`,
+  }));
+  const result = selectDailyModelTarget(providers, { date: MON });
+  assert.equal(result.ok, false);
+  assert.equal(result.provider, null);
+  assert.equal(result.model, null);
+  assert.match(result.reason, /no provider in the rotation/);
+  for (const name of ["openai", "anthropic", "google"]) {
+    assert.match(result.reason, new RegExp(`${name} is dry`));
+  }
+});
+
+// ─── Undecidable input must fail loud, never fall back ───────────────────────
+
+test("a malformed payload throws rather than falling back to the next provider", () => {
+  // The first candidate already proves the file is undecidable. Catching this and
+  // trying the rest would turn a hard error into a quiet fallback (#1035).
+  assert.throws(
+    () => selectDailyModelTarget({ not: "an array" }, { date: MON }),
+    /must be an array of provider records/,
+  );
+  assert.throws(
+    () => selectDailyModelTarget([{ status: "active" }], { date: MON }),
+    /has no "provider" name/,
+  );
+});
+
+test("an empty rotation order throws instead of silently doing nothing", () => {
+  assert.throws(
+    () => selectDailyModelTarget(healthy(), { date: MON, order: [] }),
+    /non-empty list/,
+  );
+});
+
+test("an unparseable --date throws", () => {
+  assert.throws(
+    () => selectDailyModelTarget(healthy(), { date: new Date("not a date") }),
+    /not a valid instant/,
+  );
+});
+
+// ─── The CLI boundary: the pair invariant and the exit codes ─────────────────
+
+function runCli(args, { providers, env = {} } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "daily-target-"));
+  const file = path.join(dir, "providers.json");
+  if (providers !== undefined) {
+    fs.writeFileSync(
+      file,
+      typeof providers === "string" ? providers : JSON.stringify(providers),
+    );
+  }
+  const ghEnv = path.join(dir, "github_env");
+  fs.writeFileSync(ghEnv, "");
+  try {
+    const stdout = execFileSync(
+      process.execPath,
+      [SCRIPT, "--providers-file", file, ...args],
+      { encoding: "utf-8", env: { ...process.env, GITHUB_ENV: ghEnv, ...env }, stdio: ["ignore", "pipe", "pipe"] },
+    );
+    return {
+      code: 0,
+      json: JSON.parse(stdout),
+      githubEnv: fs.readFileSync(ghEnv, "utf-8"),
+    };
+  } catch (error) {
+    return { code: error.status, stderr: String(error.stderr ?? "") };
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("pinning writes BOTH variables to GITHUB_ENV — never the provider alone", () => {
+  const r = runCli(["--date", TUE.toISOString()], { providers: healthy() });
+  assert.equal(r.code, 0);
+  assert.equal(r.json.ok, true);
+  const lines = r.githubEnv.trim().split("\n").sort();
+  assert.deepEqual(lines, [
+    "MODEL_TEST_ID=claude-sonnet-5",
+    "MODEL_TEST_PROVIDER=anthropic",
+  ]);
+});
+
+test("declining to pin writes NOTHING to GITHUB_ENV", () => {
+  // A half-written pair is worse than no pin: MODEL_TEST_PROVIDER alone sweeps the
+  // provider's whole catalog.
+  const providers = healthy().map((p) => ({
+    provider: p.provider,
+    status: "inactive",
+    model: null,
+    error: "dry",
+  }));
+  const r = runCli(["--date", MON.toISOString()], { providers });
+  assert.equal(r.code, 0);
+  assert.equal(r.json.ok, false);
+  assert.equal(r.githubEnv.trim(), "");
+});
+
+test("a missing providers.json declines with a reason and exits 0", () => {
+  // The sweep is continue-on-error on this lane by design (#980), so a missing file
+  // is a legitimate state, not a crash.
+  const r = runCli(["--date", MON.toISOString()]);
+  assert.equal(r.code, 0);
+  assert.equal(r.json.ok, false);
+  assert.match(r.json.reason, /does not exist/);
+  assert.equal(r.githubEnv.trim(), "");
+});
+
+test("an unreadable providers.json exits 2 — an undecidable verdict is not 'nothing to pin'", () => {
+  const r = runCli(["--date", MON.toISOString()], { providers: "{ not json" });
+  assert.equal(r.code, 2);
+  assert.match(r.stderr, /::error::select-daily-model-target/);
+});
+
+test("an unknown flag exits 2 rather than running with a silently ignored argument", () => {
+  const r = runCli(["--nope", "x"], { providers: healthy() });
+  assert.equal(r.code, 2);
+  assert.match(r.stderr, /unknown flag/);
+});
+
+// ─── Structural guard on the workflow wiring ─────────────────────────────────
+
+test("daily-stable.yml runs the rotation between the health gate and the @stable run", () => {
+  // The step is worthless before collect-models has written providers.json, and it
+  // must not sit after the run it is supposed to configure. Mirrors the guard the PR
+  // lane carries for its own pin step.
+  const yml = fs.readFileSync(
+    path.join(import.meta.dirname, "..", ".github", "workflows", "daily-stable.yml"),
+    "utf-8",
+  );
+  const gate = yml.indexOf("wait-for-backend");
+  const pin = yml.indexOf("select-daily-model-target.mjs");
+  const run = yml.indexOf("Run @stable tests");
+  assert.ok(gate > -1, "the post-collect-models health gate is gone");
+  assert.ok(pin > -1, "daily-stable.yml no longer runs the rotation");
+  assert.ok(run > -1, "the @stable run step is gone");
+  assert.ok(gate < pin, "the rotation must run AFTER the health gate");
+  assert.ok(pin < run, "the rotation must run BEFORE the @stable run");
+});
+
+test("the daily emits the provider/model pair from the script, not from inline env", () => {
+  // Two inline `env:` lines would reintroduce both failure modes the script exists
+  // to prevent: a hardcoded id that skips silently when access is lost (#570/#1012),
+  // and a provider set without an id (the catalog sweep, #1169).
+  const yml = fs.readFileSync(
+    path.join(import.meta.dirname, "..", ".github", "workflows", "daily-stable.yml"),
+    "utf-8",
+  );
+  const runStep = yml.slice(yml.indexOf("Run @stable tests"));
+  const envBlock = runStep.slice(0, runStep.indexOf("- name:", 10));
+  assert.doesNotMatch(
+    envBlock,
+    /MODEL_TEST_(ID|PROVIDER):/,
+    "the @stable run sets a pin variable inline — it must come from GITHUB_ENV",
+  );
+});


### PR DESCRIPTION
Closes #1185.

The step where the spend actually drops. #1169 / PR #1170 pinned `pr-validation.yml`; this
applies the same argument to the lane #1170 deliberately left multi-provider.

## Why

The parametrized specs resolve **one model per active provider**, so ~30 `@stable` agent
tests run an openai **and** an anthropic **and** a google variant every weekday. Each is a
multi-turn agent run with the Simple Agent tool schemas re-sent on every turn — Langflow
sets no `cache_control`, so nothing is cached on the anthropic side.

| Target the spec resolves | $ / MTok in-out | vs `gpt-4o-mini` |
|---|---|---|
| `gpt-4o-mini` | 0.15 / 0.60 | 1x |
| `claude-sonnet-5` (what anthropic settles to today) | 3 / 15 | **20x / 25x** |

That is 20-25x per token for assertions that are about **Langflow**, not about the provider.

## Coverage is not what is being cut

The provider-contract specs —
`core-functionality/model-provider/{openai,anthropic,google,ollama,groq,mistral}-provider.spec.ts`,
each with a Settings test and a real execution test — read **neither pin variable**, so
every provider is still exercised end to end **every day**. What rotates is *agent
behaviour*, which is a Langflow contract rather than a provider one.

## Rotation, not a fixed pin — same cost

| Weekday | Provider |
|---|---|
| Mon | openai |
| Tue | anthropic |
| Wed | google |
| Thu | openai |
| Fri | anthropic |

A fixed pin costs the same but makes the detection window for a provider-specific
regression a **standing human decision** — anthropic and google agent behaviour would run
only when someone dispatched `manual.yml`. Those regressions are real and this suite caught
them: #643 (anthropic streaming drops the `thinking` block → 400) and #963
(`mcp-client-agent` on `google/gemini-2.5-flash` returns "Message empty." while the tool
fires). Rotating bounds the window to **≤3 days, automatically**.

The weekday mapping is **fixed rather than evenly distributed**, so every Monday resolves the
same provider and two Mondays are comparable. The price is a 2/2/1 split over Mon-Fri —
comparability is what triage needs, evenness buys nothing. `openai` leads because it is the
cheapest and is already the PR lane's target, so a Monday red is directly comparable to a
PR red.

## The fallback is the point

**A rotation that loses the day when its provider is dry is worse than the multi-provider
run it replaces.** Lost coverage costs more than spend (#980), and it is not hypothetical:
this lane recorded **zero tests on 2026-07-28 and 2026-07-31** while the shared anthropic
key drained (#1169).

| Situation | Decision |
|---|---|
| day's provider `active` | pin to it |
| day's provider `inactive` / absent | **advance to the next active one**, with a `::warning::` naming what was skipped and why |
| every provider `inactive` | decline to pin, keep existing behaviour (the fallback is moot with no live key, and declining keeps the failure attributable) |
| `providers.json` missing | decline + warn — the sweep is `continue-on-error` on this lane by design |
| `providers.json` unreadable | **exit 2** — an undecidable verdict must not read as "nothing to pin" (#1035) |

Advancing rather than declining matters: declining to multi-provider would pay 3x on exactly
the day a key is already broken.

Deviations are recoverable after the fact, not just in the log — the resolved provider and
model land in the `param` field of `reports/daily-history.jsonl`, so "which provider did
Tuesday actually run?" is answerable without opening a job log.

## Implementation

`scripts/select-daily-model-target.mjs` reuses `selectPrModelTarget` and
`readProvidersFile` **per candidate**, so payload validation and the per-provider verdict
are shared and the two lanes cannot drift on what `active` means. Only the iteration is new.

The step sits between the post-`Collect models` health gate and `Run @stable tests`, inside
the shard job, mirroring the PR lane's placement — pinned by a structural guard.
`continue-on-error: true`, because the pin is an optimisation: if it fails outright the right
outcome is the costlier multi-provider run, not a lost day. That is the same trade
`Collect models` already makes, and an `::error::` annotation still surfaces on the run.

### A defect the smoke run caught

The first version reused the PR lane's reason string, which ends with *"the lane keeps its
default per-provider parametrization"*. That is true when **that** lane declines and **false
here**, where the rotation advanced to the next provider — a log line contradicting what the
run did is worse than no line. The advance message is now composed locally while the verdict
and validation stay shared, and a test goes red if it is reverted.

It surfaced because the local `providers.json` has **google inactive**, so the Wednesday slot
exercised the fallback on real data rather than only in fixtures.

## Validation

| Check | Result |
|---|---|
| `npm run test:scripts` | 284 passed, 0 failed (22 new) |
| `npm run test:units` | 252 passed, 0 failed |
| `npm run typecheck` | clean |
| `npm run lint` | 0 errors (1307 warnings, all pre-existing) |
| Force-fail ×5 | no fallback: 5 red · `MODEL_TEST_PROVIDER` alone: 1 red · Monday ≠ slot 0: 6 red · step moved after the run: guard red · inherited message restored: 1 red |
| CLI smoke | Mon→Fri against the real `providers.json`, fallback included |
| Step placement | liveness recorder (454) → rotation (511) → `@stable` run (515) |

Real rotation against the local file, google inactive:
`openai → anthropic → openai (↩ google inactive) → openai → anthropic`

```
::warning::select-daily-model-target: rotation advanced past "google" (this weekday's slot):
provider "google" probed "inactive" — collect-models reported: no models collected from the
providers panel
daily lane pinned to openai / gpt-4o-mini (settled by collect-models).
```

Unit coverage: the weekday table, single and multi-step advance, absent provider, all-down
decline, malformed payload (throws rather than falling back to the next candidate — the
first one already proves the file undecidable), the `GITHUB_ENV` pair invariant at the CLI
boundary, every exit code, and two structural guards (the step sits between the gate and the
run; the run step sets no pin variable inline).

## What this PR's own CI cannot prove

`pr-validation.yml` does not run `daily-stable.yml`, so nothing here exercises the wiring —
only the script and the structural guards. **The proof is the next daily.** What to watch:
the `Rotate the lane to this weekday's provider` step, the `daily lane pinned to
<provider> / <model>` line, any `::warning::` about an advance, and the `param` field in the
appended `reports/daily-history.jsonl` row.

## Relation to the rest of the thread

**Independent of #1199 (#1184).** Verified: the two branches share **no modified file**, so
neither order conflicts, and the pin travels by environment variables the pre-#1184 spec
copies already read — all 17 narrow to one target either way. #1184 improves things (the two
capability specs gain the `MODEL_TEST_ID` branch they lacked) and adds the guard that keeps
the provider-contract specs unpinnable, which turns this PR's coverage premise from *true
today* into *protected against drift*. That is a reason to prefer merging #1199 first, not a
dependency.

#1186 becomes a convenience for on-demand multi-provider runs rather than the only path to
one. #1171 (haiku vs sonnet) **stays relevant** — anthropic still runs twice a week, so its
unit price still lands on this lane. #1183 measures what this saves.
