### PR TITLE
perf(collect-models): rank claude-haiku-4-5 ahead of sonnet for anthropic (#1171)

### DIFF
--- a/tests/helpers/provider-setup/collect-models.test.ts
+++ b/tests/helpers/provider-setup/collect-models.test.ts
@@ -23,6 +23,7 @@ import assert from "node:assert/strict";
 import * as fs from "fs";
 import * as path from "path";
 import {
+  rankCandidates,
   validateProviderWithFallback,
   type ProviderRecord,
 } from "./collect-models";
@@ -387,4 +388,83 @@ test("first candidate works: exactly one probe, record returned untouched", asyn
   assert.equal(result.status, "active");
   assert.equal(result.model, "gpt-4o-mini");
   assert.equal(result.error, null);
+});
+
+// ─── CANDIDATE_PREFS ordering (#1171) ────────────────────────────────────────
+//
+// What a unit test can and cannot prove here. `rankCandidates` decides which
+// model `collect-models` probes FIRST, and the first one that validates is what
+// it settles on and promotes to models.json[0] — which every parametrized agent
+// spec then runs against. So the ordering is a real cost and coverage lever.
+//
+// But ordering is ALL a unit test can prove. CANDIDATE_PREFS encodes agent
+// COMPATIBILITY, and the probe is a ~1-token completion that cannot tell "the
+// key reaches this model" from "the Agent can drive it" — #570 found `gpt-5.6`
+// passing the probe while the Agent returned empty replies. These assertions
+// therefore guard against a silent reordering; they are NOT evidence that the
+// leading model drives the agent suite. That evidence is the real @stable run
+// recorded on #1171.
+
+test("anthropic ranks claude-haiku-4-5 first — 2x cheaper than sonnet today, 3x from 2026-09-01", () => {
+  const ranked = rankCandidates("anthropic", ANTHROPIC_CATALOG);
+  assert.equal(ranked[0], "claude-haiku-4-5");
+});
+
+test("anthropic keeps sonnet reachable — a haiku-less catalog must not fall through to opus", () => {
+  // The catalog here is in RAW api order, not the promoted order collect-models
+  // writes after a successful sweep. That distinction is the whole test: a
+  // failing sweep promotes nothing, so the raw order stands — and it leads with
+  // claude-opus-5, the most expensive model Anthropic exposes (#1169's latent
+  // risk note). Filtering the promoted ANTHROPIC_CATALOG instead would prove
+  // nothing, because that fixture already starts with sonnet: the assertion
+  // would pass with the sonnet tail deleted.
+  const rawUnpromoted = [
+    "claude-opus-5",
+    "claude-fable-5",
+    "claude-opus-4-8",
+    "claude-sonnet-5",
+    "claude-sonnet-4-6",
+  ];
+  assert.equal(rankCandidates("anthropic", rawUnpromoted)[0], "claude-sonnet-5");
+});
+
+test("a future claude-haiku-5 is preferred over the pinned 4-5 id", () => {
+  // The exact id ranks first, then the generic /haiku/ — so a newer haiku is
+  // picked up without editing this map, as long as it sorts ahead in the
+  // catalog. Both are haiku-tier, so either outcome is correct on price; this
+  // pins that neither falls behind sonnet.
+  const ranked = rankCandidates("anthropic", ["claude-sonnet-5", "claude-haiku-5", "claude-haiku-4-5"]);
+  assert.deepEqual(ranked.slice(0, 2), ["claude-haiku-4-5", "claude-haiku-5"]);
+  assert.ok(ranked.indexOf("claude-sonnet-5") > 1, "sonnet must rank behind every haiku");
+});
+
+test("openai still leads with gpt-4o-mini — the cheaper entries are reasoning models (#569)", () => {
+  // Regression guard for the tempting-but-wrong optimisation: gpt-5-nano and
+  // gpt-5.4-mini are cheaper per token and hang the playground for 120 s.
+  const ranked = rankCandidates("openai", [
+    "gpt-5-nano",
+    "gpt-5.4-mini",
+    "gpt-4o",
+    "gpt-4o-mini",
+    "gpt-4.1-nano",
+  ]);
+  assert.equal(ranked[0], "gpt-4o-mini");
+  assert.ok(
+    ranked.indexOf("gpt-5-nano") > ranked.indexOf("gpt-4.1-nano"),
+    "no gpt-5.x model may outrank a gpt-4 family model",
+  );
+});
+
+test("google is unchanged — its entries are already the flash tier", () => {
+  const ranked = rankCandidates("google", [
+    "gemini-3-pro",
+    "gemini-flash-latest",
+    "gemini-2.5-flash",
+  ]);
+  assert.equal(ranked[0], "gemini-2.5-flash");
+});
+
+test("an unknown provider falls back to raw catalog order rather than dropping models", () => {
+  const catalog = ["b", "a", "c"];
+  assert.deepEqual(rankCandidates("groq", catalog), catalog);
 });

--- a/tests/helpers/provider-setup/collect-models.test.ts
+++ b/tests/helpers/provider-setup/collect-models.test.ts
@@ -18,6 +18,15 @@
 // so is the candidate ORDER of the Google/Anthropic catalogs — read out of that
 // run's `Shard 1/4` log. Two strings are synthesized because that run never
 // produced them; each says so where it is defined.
+//
+// That recorded order is a HISTORICAL snapshot, not the current ranking:
+// #1171 moved `CANDIDATE_PREFS.anthropic` to haiku-first, so
+// `rankCandidates("anthropic", ANTHROPIC_CATALOG)` now leads with
+// `claude-haiku-4-5` rather than `claude-sonnet-5`. That is deliberate — these
+// fixtures are INPUT to the fallback tests (which care about probe count and
+// error classification, not order), and freezing the run's real order is what
+// makes those tests reproduce the incident. The ordering assertions at the
+// bottom of this file call `rankCandidates` directly and are the live contract.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import * as fs from "fs";

--- a/tests/helpers/provider-setup/collect-models.ts
+++ b/tests/helpers/provider-setup/collect-models.ts
@@ -145,10 +145,33 @@ const CANDIDATE_PREFS: Record<string, RegExp[]> = {
     /^gemini-3\.5-flash$/,
     /^gemini-flash-latest$/,
   ],
-  anthropic: [/^claude-sonnet-5$/, /sonnet/, /haiku/],
+  // Haiku-first (#1171). The Anthropic entry is the one place in this map where
+  // the leading model is chosen for PRICE rather than only for agent
+  // compatibility, so the reasoning is worth stating: `claude-haiku-4-5` is
+  // $1/$5 per MTok against `claude-sonnet-5` at $2/$10 (introductory, through
+  // 2026-08-31) and $3/$15 after — 2x today, 3x from September. After #1185's
+  // weekday rotation, Anthropic runs twice a week but carries ~87% of the
+  // daily's remaining agentic spend, because it is ~13x the openai target's
+  // price. That makes this the dominant cost lever left on the lane.
+  //
+  // Sonnet stays at the tail, and that matters: without it a catalog with no
+  // haiku falls through to raw catalog order, which currently leads with
+  // `claude-opus-5` — the most expensive model Anthropic exposes here. The
+  // generic /haiku/ after the exact id is future-proofing for a later
+  // `claude-haiku-5`.
+  //
+  // NOT extended to the other two providers, deliberately. openai's cheaper
+  // catalog entries (`gpt-5-nano`, `gpt-5.4-mini`, …) are reasoning models,
+  // which hang the playground for 120 s (#569) — the gpt-4-family list below is
+  // that constraint, not an oversight. google's entries are already the flash
+  // tier.
+  anthropic: [/^claude-haiku-4-5$/, /haiku/, /^claude-sonnet-5$/, /sonnet/],
 };
 
-function rankCandidates(provider: string, candidates: string[]): string[] {
+/** Exported for `collect-models.test.ts`: the ordering is the whole of what a
+ *  unit test can prove here (agent compatibility needs a real run — #570), so
+ *  it is pinned rather than left to inspection. */
+export function rankCandidates(provider: string, candidates: string[]): string[] {
   const prefs = CANDIDATE_PREFS[provider] ?? [];
   const preferred: string[] = [];
   for (const pref of prefs) {


### PR DESCRIPTION
Closes #1171.

> ### ⛔ Draft on purpose — do not convert until the validation run is recorded
> This ships a **cheaper model**, and `CANDIDATE_PREFS` encodes **agent compatibility**, not price. The evidence that `claude-haiku-4-5` drives the agent suite is a real `@stable` run that **has not happened**: the shared Anthropic balance is dry (`credit balance is too low`, probed 2026-07-31 — both sonnet and haiku fail identically, so it is account-level, not model access). Draft status is the gate; a note in a description is not.
>
> To unblock: top up, then run candidate-first — the command is in #1171 and repeated at the bottom.

## The change

One line, one provider, one model.

```diff
-anthropic: [/^claude-sonnet-5$/, /sonnet/, /haiku/],
+anthropic: [/^claude-haiku-4-5$/, /haiku/, /^claude-sonnet-5$/, /sonnet/],
```

Probe order against the real 13-model catalog:

| | First four probed |
|---|---|
| Before | `claude-sonnet-5` → `claude-sonnet-4-6` → `claude-sonnet-4-5` → `claude-sonnet-4-20250514` |
| After | **`claude-haiku-4-5`** → `claude-sonnet-5` → `claude-sonnet-4-6` → `claude-sonnet-4-5` |

`collect-models` promotes whatever settles to `models.json[0]`, and the shared resolver (`resolveTestTargets`, #1184) reads that — so this decides what every parametrized Anthropic agent variant runs against.

## Why it is worth a PR

| Model | $ / MTok in-out |
|---|---|
| `claude-sonnet-5` | **2 / 10** introductory, through **2026-08-31**; **3 / 15** after |
| `claude-haiku-4-5` | 1 / 5 |

**2x today, 3x from September 1.** #1171 said 3x — right from September, a month early today. Anyone measuring across that boundary will see the saving grow on its own; that is the vendor's price change, not this PR.

**The rotation made this more valuable, not less.** #1185 (PR #1207) moved the daily to one provider per weekday, so Anthropic went from 5 days to 2 — but at ~13x the openai target's price it now carries **~87% of the daily's remaining agentic spend**:

```
weekly, post-#1185:  30 × (A/13 + A + A/7 + A/13 + A)  ≈ 69A
        Anthropic (Tue + Fri):                  60A    ≈ 87%
```

| | Reduction in the daily's agentic spend |
|---|---|
| Today (2x) | **~43%** |
| From 2026-09-01 (3x) | **~61%** |

Ratio-derived, not measured. The absolute figure is #1183's job.

## Two things that look like detail and are not

**The sonnet tail is load-bearing.** Without it, a catalog containing no haiku falls through to **raw api order**, which leads with `claude-opus-5` — the most expensive model Anthropic exposes here. That only bites on a *failing* sweep, where nothing gets promoted, which is exactly #1169's latent-risk note.

**openai and google are deliberately untouched.** openai's cheaper catalog entries — `gpt-5-nano`, `gpt-5.4-nano`, `gpt-5-mini`, `gpt-5.4-mini` — are **reasoning models**, and this repo already paid for that: it detects them via `metadata.reasoning_models` because they hang the playground for 120 s (#569 / PR #610). The `gpt-4o-mini → gpt-4o → gpt-4.1(-mini|-nano) → gpt-4*` list is that constraint, not an oversight. google's three entries are already the flash tier.

## Tests, and what they do not prove

`rankCandidates` is now exported so the ordering can be pinned. Six tests: haiku first; sonnet still reachable; a future `claude-haiku-5` outranks sonnet; openai still leads with `gpt-4o-mini` and no gpt-5.x outranks a gpt-4-family model; google unchanged; an unknown provider falls back to raw order rather than dropping models.

**Ordering is all a unit test can prove here, and the test file says so in its own header.** The probe is a ~1-token completion that cannot tell "the key reaches this model" from "the Agent can drive it" — #570 found `gpt-5.6` passing the probe while the Agent returned empty replies. These guard against a *silent reordering*; they are not evidence that haiku drives the agent suite.

**A force-fail found one of them was vacuous.** Deleting the sonnet tail left the suite green: the fixture it filtered was already in *promoted* order, so removing the tail changed nothing. It now builds a raw unpromoted catalog led by opus — the state the tail actually protects against — and goes red when the tail is removed.

| Check | Result |
|---|---|
| `npm run test:units` | 284 passed, 0 failed (6 new) |
| `npm run test:scripts` | 284 passed, 0 failed |
| `npm run typecheck` / `lint` | clean / 0 errors |
| Force-fail ×2 | sonnet-first restored → 2 red · sonnet tail removed → 1 red (after the fix above) |

## What must happen before this merges

```bash
# 1. confirm credit — this currently returns invalid_request_error
curl -s https://api.anthropic.com/v1/messages \
  -H "x-api-key: $ANTHROPIC_API_KEY" -H "anthropic-version: 2023-06-01" \
  -H "content-type: application/json" \
  -d '{"model":"claude-haiku-4-5","max_tokens":4,"messages":[{"role":"user","content":"Say OK."}]}'

# 2. candidate-first — a clean run makes the sonnet baseline unnecessary and halves the spend
MODEL_TEST_ID=claude-haiku-4-5 MODEL_TEST_PROVIDER=anthropic PLAYWRIGHT_RETRIES=0 \
  npx playwright test tests/tests-automations/regression/core-functionality/llm-agents \
  --grep @stable --workers=2
```

Adopt **only if** haiku matches sonnet across the set. A partial result closes #1171 as *not adopted* with the failing specs named — shipping a cheaper model that erodes coverage is the failure this gate exists to prevent. Record the per-spec summary on #1171 either way.

## Related state worth knowing while this sits

With Anthropic dry **and** google already `inactive` (zero entries in `models.json`), #1185's rotation resolves to openai on every weekday — verified against `scripts/select-daily-model-target.mjs` with the real provider state. The fallback works and no day is lost, but the practical daily is **openai-only**: Anthropic and Google agent coverage are both at zero until the balance is topped up and the Google key is looked at.
