### PR TITLE
feat(observability): measure token spend on the PR and manual lanes too (#1183)

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -966,6 +966,26 @@ jobs:
           # count (expected+unexpected+flaky+skipped, #1012) rather than adding a
           # second computation of the same thing.
           TESTS_TOTAL: ${{ steps.runguard.outputs.tests_total }}
+          # Suppress the history write on a MANUAL dispatch of this workflow
+          # (#1183, found live on run 30657439522: 4 shards, one red, dispatched
+          # by hand). This step still runs and still publishes its step summary
+          # either way — only reports/token-history.jsonl's line is affected.
+          #
+          # "Append daily history" / "Commit daily history" below are already
+          # gated `if: always() && github.event_name == 'schedule'`, so a manual
+          # dispatch never commits that file — but this step ran unconditionally
+          # and, before this line, wrote the line into the runner's ephemeral
+          # workspace regardless, silently diverging from what the (uncommitted)
+          # file on disk implied. A manual dispatch has an arbitrary shape (a
+          # different shard count, a subset of specs, one shard failing outright)
+          # that is not comparable to the daily's own fixed @stable sweep — the
+          # same reasoning that keeps pr-validation.yml and manual.yml's own
+          # summarize steps out of this series entirely.
+          #
+          # `github.event_name != 'schedule' && '1' || ''` reads as: manual
+          # dispatch → "1" (suppressed), scheduled run → "" (not suppressed, the
+          # knob's own truthiness check treats an empty string as "not set").
+          TOKENS_SUPPRESS_HISTORY: ${{ github.event_name != 'schedule' && '1' || '' }}
 
       # Long-lived run history: append one JSON line per scheduled run to
       # reports/daily-history.jsonl and commit it back to main. See

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -220,6 +220,61 @@ jobs:
           attribution: "NOT a failure of the tests you dispatched"
           collect_models_outcome: ${{ steps.collect_models.outcome }}
 
+      # In-run token consumption recorder, extended to this job (#1183 — measure
+      # the suite's real LLM spend per lane/provider). Same mechanism as
+      # daily-stable.yml / pr-validation.yml (#1197): poll
+      # /api/v1/monitor/traces and price what each trace spent, because
+      # deleting a flow 404s its trace and this suite deletes every flow it
+      # creates, so the only place to read the data is DURING the run.
+      #
+      # Only wired into THIS job. It polls TOKENS_BASE_URL, which defaults to
+      # localhost — exactly this job's Langflow service container. The
+      # `e2e-url` job below targets an EXTERNAL Langflow instance the runner
+      # does not host; a recorder started there would poll a localhost with
+      # nothing behind it and spend the whole run logging connection-refused
+      # errors, never producing a real number — worse than not measuring, so
+      # it is deliberately skipped there instead of started to fail.
+      #
+      # MEASUREMENT-ONLY: --summarize (below, after the run) still renders a
+      # step-summary table, but TOKENS_SUPPRESS_HISTORY keeps it from writing
+      # reports/token-history.jsonl — that file is the daily's series, one line
+      # per FULL @stable sweep, and a manual dispatch's scope (whatever
+      # tag/grep was chosen — @stable, a single spec, the whole suite) is
+      # arbitrary and not comparable to it. Mixing the two would corrupt the
+      # trend and the anomaly baseline the daily itself relies on (see the
+      # summarizer's own comment on the knob).
+      #
+      # DIAGNOSTIC ONLY: continue-on-error, and it never gates the run.
+      - name: Start the token consumption recorder
+        shell: bash
+        continue-on-error: true
+        run: |
+          nohup node scripts/watch-tokens.mjs > /tmp/tokens.log 2>&1 &
+          echo "$!" > /tmp/tokens.pid
+          disown
+          echo "Token recorder started (pid $(cat /tmp/tokens.pid))."
+        env:
+          TOKENS_BASE_URL: http://localhost:7860
+          TOKENS_OUT: token-probes.jsonl
+          TOKENS_INTERVAL_MS: "15000"
+          TOKENS_TIMEOUT_MS: "8000"
+          # Below the job's timeout-minutes: 90 so this is a real backstop, not
+          # dead configuration reached only after the runner already killed the
+          # job. Same reasoning as the daily's TOKENS_MAX_SECONDS.
+          TOKENS_MAX_SECONDS: "5100"
+          TOKENS_DETAIL_CAP: "25"
+
+      # Export TOKENS_ATTRIB for the specs' cleanup sidecar (#1183), same as
+      # daily-stable.yml / pr-validation.yml — with it unset, the helper makes
+      # no request and writes no file. The actual test run below is the
+      # `run-e2e` COMPOSITE action, not a plain `run:` step, so its own steps
+      # do not automatically see an `env:` set on this workflow's `uses:` line
+      # the way a plain step would; $GITHUB_ENV is the one mechanism guaranteed
+      # to reach every later step in this job regardless of how it runs,
+      # including a composite action's internal steps.
+      - name: Export TOKENS_ATTRIB for the specs' cleanup sidecar
+        run: echo "TOKENS_ATTRIB=token-attrib.jsonl" >> "$GITHUB_ENV"
+
       - name: Run tests and upload report
         uses: ./.github/actions/run-e2e
         with:
@@ -234,6 +289,58 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           google_api_key: ${{ secrets.GOOGLE_API_KEY }}
 
+      # Stop the recorder, price what it saw, and upload the raw JSONL — mirrors
+      # daily-stable.yml's shard-level "Stop and collect" + merge-job
+      # "Summarize" steps, collapsed into one job since this workflow has no
+      # shards to merge. always(): the recorder's data is most useful precisely
+      # when the run went red, and continue-on-error on every step here means a
+      # defect in the reporting itself can never touch the specs' own pass/fail.
+      - name: Stop and collect token consumption
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          # SIGTERM is the recorder's normal exit path: it stops after the
+          # current probe.
+          if [ -f /tmp/tokens.pid ]; then
+            kill "$(cat /tmp/tokens.pid)" 2>/dev/null || true
+          fi
+          # Let an in-flight append land before the file is copied — same
+          # reasoning and margin as the daily's own copy of this step.
+          sleep 10
+          mkdir -p tokens
+          cp token-probes.jsonl tokens/ 2>/dev/null || true
+          cp token-attrib.jsonl tokens/ 2>/dev/null || true
+          echo "--- token recorder stdout (tail) ---"
+          tail -n 5 /tmp/tokens.log 2>/dev/null || true
+
+      - name: Summarize token consumption
+        if: always()
+        continue-on-error: true
+        run: node scripts/watch-tokens.mjs --summarize
+        env:
+          TOKENS_DIR: tokens
+          TOKENS_PRICES: scripts/lib/model-prices.json
+          WORKFLOW: manual
+          LANGFLOW_IMAGE: ${{ needs.detect-target.outputs.docker_image }}
+          # Measurement-only lane (#1183): never add a line to
+          # reports/token-history.jsonl. See "Start the token consumption
+          # recorder" above and the summarizer's own comment on this knob for
+          # why an arbitrary manual-dispatch scope is not comparable to the
+          # daily's series. Suppressed openly, not silently: the summarizer
+          # states this in both its log line and the step summary itself
+          # (#1012's rule).
+          TOKENS_SUPPRESS_HISTORY: "1"
+
+      - name: Upload token consumption
+        uses: actions/upload-artifact@v4
+        if: always()
+        continue-on-error: true
+        with:
+          name: tokens-manual-${{ github.run_id }}
+          path: tokens/
+          if-no-files-found: ignore
+
   # Scoped OUT of the go-httpbin decoupling (#1128), deliberately: this job points
   # at a Langflow we do not host — a staging deployment, someone's tunnel — which
   # is not on this runner's Docker network and therefore cannot reach a service
@@ -241,6 +348,14 @@ jobs:
   # host in this job and remain exposed to its outages. Self-hosting for it would
   # need a publicly reachable echo, which is a different (and larger) decision
   # than the one #1128 asked for.
+  #
+  # Also scoped OUT of the token consumption recorder (#1183), for the same
+  # class of reason: TOKENS_BASE_URL defaults to localhost, which is
+  # `e2e-docker`'s own Langflow service container, not the external instance
+  # this job targets. Starting the recorder here would poll a localhost with
+  # nothing listening behind it and spend the whole run logging
+  # connection-refused errors instead of measuring anything real — so it is
+  # skipped rather than started to fail.
   e2e-url:
     name: E2E via URL (${{ github.event.inputs.langflow_target }})
     needs: detect-target

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -267,12 +267,22 @@ jobs:
       # Export TOKENS_ATTRIB for the specs' cleanup sidecar (#1183), same as
       # daily-stable.yml / pr-validation.yml — with it unset, the helper makes
       # no request and writes no file. The actual test run below is the
-      # `run-e2e` COMPOSITE action, not a plain `run:` step, so its own steps
-      # do not automatically see an `env:` set on this workflow's `uses:` line
-      # the way a plain step would; $GITHUB_ENV is the one mechanism guaranteed
-      # to reach every later step in this job regardless of how it runs,
-      # including a composite action's internal steps.
+      # `run-e2e` COMPOSITE action, not a plain `run:` step: composite actions
+      # do NOT inherit a caller step's `env:` block into their own internal
+      # steps, so an `env:` added to the `uses:` line below would silently not
+      # reach it. $GITHUB_ENV is not a fallback for that gap, it is the one
+      # mechanism that actually works here — anything appended to it becomes a
+      # real process environment variable for every later step in the job,
+      # composite-internal steps included.
+      #
+      # continue-on-error: true, like every other step this change adds. The
+      # step below it (`Run tests and upload report`) carries no `if:` of its
+      # own, so a failure here — however unlikely for a bare `echo` — would
+      # otherwise skip the run it exists only to measure: a diagnostic add-on
+      # aborting the work it measures, which this whole change is built to
+      # never do.
       - name: Export TOKENS_ATTRIB for the specs' cleanup sidecar
+        continue-on-error: true
         run: echo "TOKENS_ATTRIB=token-attrib.jsonl" >> "$GITHUB_ENV"
 
       - name: Run tests and upload report

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -594,6 +594,48 @@ jobs:
         if: needs.detect-specs.outputs.needs_models == 'true'
         run: node scripts/select-pr-model-target.mjs --provider openai
 
+      # In-run token consumption recorder, extended to this lane (#1183 — measure
+      # the suite's real LLM spend per lane/provider). Same mechanism as
+      # daily-stable.yml (#1197): poll /api/v1/monitor/traces and price what each
+      # trace spent, because deleting a flow 404s its trace and this suite deletes
+      # every flow it creates, so the only place to read the data is DURING the run.
+      #
+      # Placed here — after Collect models / the health gate / the model pin,
+      # right before the actual Playwright step — so it only ever runs where
+      # specs actually run: the job itself is already gated on
+      # `needs.detect-specs.outputs.has_specs == 'true'`, and this step carries
+      # no separate condition of its own, same as "Run impacted specs" below (an
+      # earlier hard failure in this job skips both identically).
+      #
+      # MEASUREMENT-ONLY on this lane: --summarize (below, after the run) still
+      # renders a step-summary table, but TOKENS_SUPPRESS_HISTORY keeps it from
+      # writing reports/token-history.jsonl — that file is the daily's series,
+      # one line per FULL @stable sweep, and this lane's scope is whatever
+      # subset of specs the import graph selected for THIS PR (capped at
+      # IMPACTED_SPEC_CAP, frequently zero LLM specs at all). Mixing the two
+      # would corrupt the trend and the anomaly baseline the daily itself relies
+      # on (see the summarizer's own comment on the knob).
+      #
+      # DIAGNOSTIC ONLY: continue-on-error, and it never gates the run.
+      - name: Start the token consumption recorder
+        shell: bash
+        continue-on-error: true
+        run: |
+          nohup node scripts/watch-tokens.mjs > /tmp/tokens.log 2>&1 &
+          echo "$!" > /tmp/tokens.pid
+          disown
+          echo "Token recorder started (pid $(cat /tmp/tokens.pid))."
+        env:
+          TOKENS_BASE_URL: http://localhost:7860
+          TOKENS_OUT: token-probes.jsonl
+          TOKENS_INTERVAL_MS: "15000"
+          TOKENS_TIMEOUT_MS: "8000"
+          # Below the job's timeout-minutes: 60 so this is a real backstop, not
+          # dead configuration reached only after the runner already killed the
+          # job. Same reasoning as the daily's TOKENS_MAX_SECONDS.
+          TOKENS_MAX_SECONDS: "3300"
+          TOKENS_DETAIL_CAP: "25"
+
       - name: Run impacted specs
         env:
           CI: "true"
@@ -619,6 +661,10 @@ jobs:
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
           SPECS: ${{ needs.detect-specs.outputs.specs }}
+          # Turns the cleanup sidecar on for this lane (#1183), same as
+          # daily-stable.yml: with this unset (local runs) the helper makes no
+          # request and writes no file.
+          TOKENS_ATTRIB: token-attrib.jsonl
         run: |
           echo "Running specs: $SPECS"
           # shellcheck disable=SC2086
@@ -647,6 +693,57 @@ jobs:
           # shellcheck disable=SC2086
           npx playwright test $SPECS --grep "@destructive" --pass-with-no-tests \
             --reporter=github --output=test-results-destructive
+
+      # Stop the recorder, price what it saw, and upload the raw JSONL — mirrors
+      # daily-stable.yml's shard-level "Stop and collect" + merge-job "Summarize"
+      # steps, collapsed into one job since this lane has no shards to merge.
+      # always(): the recorder's data is most useful precisely when the run went
+      # red, and continue-on-error on every step here means a defect in the
+      # reporting itself can never touch the specs' own pass/fail.
+      - name: Stop and collect token consumption
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: |
+          # SIGTERM is the recorder's normal exit path: it stops after the
+          # current probe.
+          if [ -f /tmp/tokens.pid ]; then
+            kill "$(cat /tmp/tokens.pid)" 2>/dev/null || true
+          fi
+          # Let an in-flight append land before the file is copied — same
+          # reasoning and margin as the daily's own copy of this step.
+          sleep 10
+          mkdir -p tokens
+          cp token-probes.jsonl tokens/ 2>/dev/null || true
+          cp token-attrib.jsonl tokens/ 2>/dev/null || true
+          echo "--- token recorder stdout (tail) ---"
+          tail -n 5 /tmp/tokens.log 2>/dev/null || true
+
+      - name: Summarize token consumption
+        if: always()
+        continue-on-error: true
+        run: node scripts/watch-tokens.mjs --summarize
+        env:
+          TOKENS_DIR: tokens
+          TOKENS_PRICES: scripts/lib/model-prices.json
+          WORKFLOW: pr-validation
+          LANGFLOW_IMAGE: "langflowai/langflow-nightly:latest"
+          # Measurement-only lane (#1183): never add a line to
+          # reports/token-history.jsonl. See "Start the token consumption
+          # recorder" above and the summarizer's own comment on this knob for
+          # why a capped, per-PR subset is not comparable to the daily's series.
+          # Suppressed openly, not silently: the summarizer states this in both
+          # its log line and the step summary itself (#1012's rule).
+          TOKENS_SUPPRESS_HISTORY: "1"
+
+      - name: Upload token consumption
+        uses: actions/upload-artifact@v7
+        if: always()
+        continue-on-error: true
+        with:
+          name: tokens-pr-${{ github.run_id }}
+          path: tokens/
+          if-no-files-found: ignore
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7

--- a/scripts/watch-tokens.mjs
+++ b/scripts/watch-tokens.mjs
@@ -15,6 +15,14 @@
 //   --summarize  join TOKENS_OUT with TOKENS_ATTRIB, price it, write the history
 //                line and the step summary (see the summarize section)
 //
+// TOKENS_SUPPRESS_HISTORY=1 (#1183): --summarize still renders the step-summary
+// table, but skips reading AND writing reports/token-history.jsonl entirely.
+// For pr-validation.yml / manual.yml — lanes whose per-run scope (a capped PR
+// subset, an arbitrary manual dispatch) is not comparable to the daily's fixed
+// @stable sweep, so mixing it into that one series would corrupt the trend and
+// the anomaly baseline. Never silent about it: both the log and the step
+// summary say the append was suppressed and why.
+//
 // One request per tick: /api/v1/monitor/traces answers WITHOUT flow_id (S2), so the
 // tick does not scale with the number of live flows. Detail fetches are capped per
 // tick, because a burst of traces must not turn one tick into a hundred requests
@@ -276,6 +284,19 @@ export async function summarize({
   const attribDir = env.TOKENS_ATTRIB_DIR || dir;
   const historyPath = env.TOKENS_HISTORY || "reports/token-history.jsonl";
   const summaryPath = env.TOKENS_SUMMARY_MD || env.GITHUB_STEP_SUMMARY;
+  // Measurement-only lanes (#1183 — pr-validation.yml, manual.yml). Those lanes
+  // want the step-summary table (so the run's own spend is visible) but must
+  // NEVER add a line to reports/token-history.jsonl: that file is the daily's
+  // series, one line per FULL @stable sweep, and its anomaly baseline
+  // (detectAnomalies() above) is a plain median over recent entries. A PR's
+  // scope is whatever subset of specs the import graph selected for THAT PR
+  // (capped, often zero LLM specs at all) and a manual dispatch's scope is
+  // whatever tag/grep was chosen — neither is comparable to the daily's fixed
+  // sweep, so writing either into the same series would corrupt the trend and
+  // silently poison every anomaly check that follows. Skips the read too (not
+  // just the write): comparing a bounded PR/manual run's totals against the
+  // daily's own baseline would produce a false anomaly on nearly every run.
+  const suppressHistory = /^(1|true)$/i.test(env.TOKENS_SUPPRESS_HISTORY || "");
 
   const read = (p) => {
     try {
@@ -359,7 +380,7 @@ export async function summarize({
   }
 
   const agg = aggregate({ probes: [...probesById.values()], attributions, prices });
-  const history = parseHistory(read(historyPath));
+  const history = suppressHistory ? [] : parseHistory(read(historyPath));
   const runLine = {
     version: 1,
     date: env.RUN_DATE || new Date().toISOString().slice(0, 10),
@@ -388,10 +409,23 @@ export async function summarize({
   // Writing the history line is the summarizer's one durable side effect. Losing it
   // to a bad path/full disk must degrade the run's cost visibility, not the run
   // itself — same reasoning as poll()'s own appendFileSync guard above.
-  try {
-    appendFile(historyPath, `${JSON.stringify(runLine)}\n`);
-  } catch (error) {
-    log(`token summary: could not append the history line: ${error?.message || error}`);
+  //
+  // Suppressed deliberately on measurement-only lanes (#1183, see the
+  // `suppressHistory` comment above) — logged here rather than silently
+  // skipped, so a reader of the run log is never left wondering why the file
+  // did not change (#1012's "never silently" rule applied to this knob).
+  if (suppressHistory) {
+    log(
+      "token summary: TOKENS_SUPPRESS_HISTORY set — history line NOT written " +
+        "(this lane's scope is not comparable to reports/token-history.jsonl's " +
+        "daily series, #1183)",
+    );
+  } else {
+    try {
+      appendFile(historyPath, `${JSON.stringify(runLine)}\n`);
+    } catch (error) {
+      log(`token summary: could not append the history line: ${error?.message || error}`);
+    }
   }
 
   const floor = agg.unpricedModels.length
@@ -402,6 +436,19 @@ export async function summarize({
     "",
     `**${agg.totals.total_tokens.toLocaleString("en-US")} tokens** across ${agg.totals.traces} trace(s) — ${usd(agg.totals.usd_estimated)}${floor}`,
     "",
+  );
+  if (suppressHistory) {
+    // Same "never silently" rule as the log line above (#1012), stated where a
+    // human reading the run's own step summary — not just its raw log — would
+    // otherwise wonder why reports/token-history.jsonl did not change.
+    lines.push(
+      "_History append suppressed for this lane (`TOKENS_SUPPRESS_HISTORY`) — " +
+        "this run's numbers are a per-run measurement only, not part of " +
+        "`reports/token-history.jsonl`'s daily trend/anomaly series (#1183)._",
+      "",
+    );
+  }
+  lines.push(
     "| Model | Calls | Prompt | Completion | Estimated |",
     "|---|---:|---:|---:|---:|",
     ...agg.byModel.map(

--- a/scripts/watch-tokens.test.mjs
+++ b/scripts/watch-tokens.test.mjs
@@ -929,7 +929,12 @@ test("manual's e2e-docker job starts the token recorder before the test run and 
   const dockerJobText = text.slice(0, urlJobAt > 0 ? urlJobAt : text.length);
   const start = dockerJobText.indexOf("node scripts/watch-tokens.mjs");
   const exportAttrib = dockerJobText.indexOf("TOKENS_ATTRIB=token-attrib.jsonl");
-  const run = dockerJobText.indexOf("Run tests and upload report");
+  // Anchor on the STEP HEADER, not the bare phrase — the export step's own
+  // comment mentions "Run tests and upload report" in prose (to explain why
+  // it needs continue-on-error), which sits BEFORE the actual step and would
+  // otherwise false-positive this guard (same class of bug as pr-validation's
+  // guard above, fixed the same way).
+  const run = dockerJobText.indexOf("- name: Run tests and upload report");
   const stop = dockerJobText.indexOf("Stop and collect token consumption");
   const summarizeStep = dockerJobText.indexOf("Summarize token consumption");
   assert.ok(start > 0, "manual.yml's e2e-docker job no longer starts the token recorder");
@@ -941,8 +946,25 @@ test("manual's e2e-docker job starts the token recorder before the test run and 
   assert.ok(exportAttrib < run, "TOKENS_ATTRIB must be exported BEFORE the test run consumes it");
   assert.ok(stop > run, "the stop/collect step must come after the test run");
   assert.ok(summarizeStep > stop, "the summary must run after the stop/collect step");
-  for (const label of ["Start the token consumption recorder", "Stop and collect token consumption", "Summarize token consumption", "Upload token consumption"]) {
-    const at = dockerJobText.indexOf(label);
+  // Includes the TOKENS_ATTRIB export step: it sits between the recorder start
+  // and the actual test run with no `if:` of its own, so a failure there would
+  // otherwise skip the run it exists only to measure — the same hazard the
+  // other four steps guard against (review finding on manual.yml:275).
+  //
+  // Anchored on the STEP HEADER ("- name: <label>"), not the bare label text:
+  // the export step's own comment repeats its name in prose ("Export
+  // TOKENS_ATTRIB for the specs' cleanup sidecar (#1183), same as ...") ahead
+  // of the actual `- name:` line, and a bare indexOf would match that comment
+  // instead of the step — the same false-positive class the `run` anchor
+  // above was fixed for.
+  for (const label of [
+    "Start the token consumption recorder",
+    "Export TOKENS_ATTRIB for the specs' cleanup sidecar",
+    "Stop and collect token consumption",
+    "Summarize token consumption",
+    "Upload token consumption",
+  ]) {
+    const at = dockerJobText.indexOf(`- name: ${label}`);
     assert.ok(at > 0, `manual.yml's e2e-docker job is missing the "${label}" step`);
     assert.match(
       dockerJobText.slice(at, at + 400),

--- a/scripts/watch-tokens.test.mjs
+++ b/scripts/watch-tokens.test.mjs
@@ -19,6 +19,10 @@ const SCRIPT = fileURLToPath(new URL("./watch-tokens.mjs", import.meta.url));
 const REPO_ROOT = path.resolve(import.meta.dirname, "..");
 const daily = () =>
   realFs.readFileSync(path.join(REPO_ROOT, ".github/workflows/daily-stable.yml"), "utf8");
+const prValidation = () =>
+  realFs.readFileSync(path.join(REPO_ROOT, ".github/workflows/pr-validation.yml"), "utf8");
+const manual = () =>
+  realFs.readFileSync(path.join(REPO_ROOT, ".github/workflows/manual.yml"), "utf8");
 
 // The exact span shape the spike measured: a component-level llm span with a null
 // modelName carrying the SAME usage as the inner provider span.
@@ -683,6 +687,110 @@ test("summarize never throws on a missing probe directory", async () => {
   assert.equal(await summarize({ env: { ...baseEnv, TOKENS_DIR: "nope" }, ...fs2, log: () => {} }), 0);
 });
 
+// --- TOKENS_SUPPRESS_HISTORY (#1183) ---
+//
+// pr-validation.yml and manual.yml run --summarize for the step-summary table
+// but must never add a line to reports/token-history.jsonl: their per-run
+// scope (a capped PR subset, an arbitrary manual dispatch) is not comparable
+// to the daily's fixed @stable sweep, and mixing it in would corrupt the
+// trend and the anomaly baseline. These tests pin: the write is suppressed,
+// the read is suppressed too (so an existing history file cannot seed a false
+// anomaly against a mismatched baseline), the suppression is logged, and it
+// is stated in the step summary itself — never silently (#1012's rule).
+
+test("TOKENS_SUPPRESS_HISTORY=1 writes no history line even though real trace data exists", async () => {
+  const fs2 = fakeFs({
+    "all-tokens/token-probes-1.jsonl": `${PROBE_LINE}\n`,
+    "prices.json": PRICES,
+  });
+  const env = { ...baseEnv, TOKENS_SUPPRESS_HISTORY: "1" };
+  const code = await summarize({ env, ...fs2, log: () => {} });
+  assert.equal(code, 0);
+  assert.equal(
+    fs2.appended["reports/token-history.jsonl"],
+    undefined,
+    "the history file must not be written when suppression is set",
+  );
+  // The run's own numbers must still be priced and rendered — suppression only
+  // affects the history file, not the step summary.
+  assert.match(fs2.written["summary.md"], /\*\*88 tokens\*\*/);
+});
+
+test("TOKENS_SUPPRESS_HISTORY=1 logs why, so a suppressed write does not read as a silent bug", async () => {
+  const fs2 = fakeFs({
+    "all-tokens/token-probes-1.jsonl": `${PROBE_LINE}\n`,
+    "prices.json": PRICES,
+  });
+  const env = { ...baseEnv, TOKENS_SUPPRESS_HISTORY: "1" };
+  const logs = [];
+  await summarize({ env, ...fs2, log: (msg) => logs.push(msg) });
+  assert.ok(
+    logs.some((l) => /TOKENS_SUPPRESS_HISTORY set/.test(l)),
+    `expected a log line naming the suppression, got: ${JSON.stringify(logs)}`,
+  );
+});
+
+test("TOKENS_SUPPRESS_HISTORY=1 states the suppression in the step summary itself", async () => {
+  const fs2 = fakeFs({
+    "all-tokens/token-probes-1.jsonl": `${PROBE_LINE}\n`,
+    "prices.json": PRICES,
+  });
+  const env = { ...baseEnv, TOKENS_SUPPRESS_HISTORY: "1" };
+  await summarize({ env, ...fs2, log: () => {} });
+  assert.match(
+    fs2.written["summary.md"],
+    /History append suppressed/i,
+    "a reader of the run's own step summary must not be left wondering why the history file did not change",
+  );
+});
+
+// #1197 review, finding I7's windowing fix (the anomaly baseline must be a
+// recent slice of history, not the whole all-time file) only matters when
+// history is actually read. A PR/manual run's totals are not comparable to the
+// daily's baseline AT ALL — a small subset's totals would read as a huge
+// negative "anomaly" against the daily's full-sweep numbers on every single
+// run — so suppression must skip the READ too, not only the write.
+test("TOKENS_SUPPRESS_HISTORY=1 does not read the existing history file for the anomaly baseline either", async () => {
+  const history = Array.from({ length: 5 }, () =>
+    JSON.stringify({ totals: { usd_estimated: 0.000001 }, by_spec: [] }),
+  ).join("\n");
+  const fs2 = fakeFs({
+    "all-tokens/token-probes-1.jsonl": `${PROBE_LINE}\n`,
+    "prices.json": PRICES,
+    "reports/token-history.jsonl": `${history}\n`,
+  });
+  const env = { ...baseEnv, TOKENS_SUPPRESS_HISTORY: "1" };
+  const logs = [];
+  await summarize({ env, ...fs2, log: (msg) => logs.push(msg) });
+  // No history line is appended (nothing to assert anomalies on), and no
+  // anomaly line is rendered — proving the pre-existing (daily-scoped) history
+  // was never consulted for this run's baseline.
+  assert.equal(fs2.appended["reports/token-history.jsonl"], undefined);
+  assert.doesNotMatch(fs2.written["summary.md"], /🔺/);
+});
+
+test("TOKENS_SUPPRESS_HISTORY is case-insensitive and accepts 'true' as well as '1'", async () => {
+  const fs2 = fakeFs({
+    "all-tokens/token-probes-1.jsonl": `${PROBE_LINE}\n`,
+    "prices.json": PRICES,
+  });
+  const env = { ...baseEnv, TOKENS_SUPPRESS_HISTORY: "true" };
+  await summarize({ env, ...fs2, log: () => {} });
+  assert.equal(fs2.appended["reports/token-history.jsonl"], undefined);
+});
+
+test("TOKENS_SUPPRESS_HISTORY unset (or falsy) preserves the existing daily behaviour", async () => {
+  const fs2 = fakeFs({
+    "all-tokens/token-probes-1.jsonl": `${PROBE_LINE}\n`,
+    "prices.json": PRICES,
+  });
+  assert.ok(await summarize({ env: { ...baseEnv, TOKENS_SUPPRESS_HISTORY: "0" }, ...fs2, log: () => {} }) === 0);
+  assert.ok(
+    fs2.appended["reports/token-history.jsonl"],
+    "an explicit '0' must behave exactly like the knob being absent — the daily never sets it",
+  );
+});
+
 test("a history-append failure is logged and summarize still resolves 0", async () => {
   const fs2 = fakeFs(
     { "all-tokens/token-probes-1.jsonl": `${PROBE_LINE}\n`, "prices.json": PRICES },
@@ -755,4 +863,121 @@ test("neither token step gates the run — the shard stop step AND the merge sum
   for (const start of [shardStep, mergeStep]) {
     assert.match(text.slice(start, start + 400), /continue-on-error: true/);
   }
+});
+
+// --- Structural guard: pr-validation.yml and manual.yml wiring (#1183) ---
+//
+// Same rationale as the daily's own guard above: neither the wedge nor a real
+// token spend can be reproduced on demand in a unit test, but the WIRING can
+// be asserted cheaply, and a silent regression here (a step quietly dropped
+// from a workflow edit) is exactly the failure mode these guards exist to
+// catch.
+
+test("pr-validation's E2E job starts the token recorder before the impacted-specs run and summarizes after, all steps continue-on-error", () => {
+  const text = prValidation();
+  const start = text.indexOf("node scripts/watch-tokens.mjs");
+  // Anchor on the STEP HEADER, not the bare phrase — the recorder-start step's
+  // own comment mentions "Run impacted specs" in prose (to explain why it
+  // needs no separate `if`), which sits BEFORE the recorder actually starts
+  // and would otherwise false-positive this guard.
+  const run = text.indexOf("- name: Run impacted specs");
+  const stop = text.indexOf("Stop and collect token consumption");
+  const summarizeStep = text.indexOf("Summarize token consumption");
+  assert.ok(start > 0, "pr-validation.yml no longer starts the token recorder");
+  assert.ok(run > 0, "pr-validation.yml no longer runs the impacted specs step");
+  assert.ok(stop > 0, "pr-validation.yml no longer stops/collects the token recorder");
+  assert.ok(summarizeStep > 0, "pr-validation.yml no longer summarizes token consumption");
+  assert.ok(start < run, "the token recorder must start BEFORE the impacted-specs run");
+  assert.ok(stop > run, "the stop/collect step must come after the impacted-specs run");
+  assert.ok(summarizeStep > stop, "the summary must run after the stop/collect step");
+  for (const label of ["Start the token consumption recorder", "Stop and collect token consumption", "Summarize token consumption", "Upload token consumption"]) {
+    const at = text.indexOf(label);
+    assert.ok(at > 0, `pr-validation.yml is missing the "${label}" step`);
+    assert.match(
+      text.slice(at, at + 400),
+      /continue-on-error: true/,
+      `the "${label}" step must carry continue-on-error: true — it is diagnostic-only and must never gate the PR`,
+    );
+  }
+});
+
+test("pr-validation's impacted-specs step sets TOKENS_ATTRIB for the cleanup sidecar", () => {
+  const text = prValidation();
+  const run = text.indexOf("- name: Run impacted specs");
+  const nextStep = text.indexOf("- name:", run + 1);
+  assert.match(
+    text.slice(run, nextStep > 0 ? nextStep : run + 2000),
+    /TOKENS_ATTRIB:/,
+    "TOKENS_ATTRIB must be set on the impacted-specs step, same as the daily's @stable run step",
+  );
+});
+
+test("pr-validation's summarize step suppresses the history append (#1183)", () => {
+  const text = prValidation();
+  const summarizeStep = text.indexOf("- name: Summarize token consumption");
+  const nextStep = text.indexOf("- name:", summarizeStep + 1);
+  assert.match(
+    text.slice(summarizeStep, nextStep > 0 ? nextStep : summarizeStep + 2000),
+    /TOKENS_SUPPRESS_HISTORY:\s*"1"/,
+    "pr-validation.yml must set TOKENS_SUPPRESS_HISTORY — a capped PR subset must never enter reports/token-history.jsonl's daily series",
+  );
+});
+
+test("manual's e2e-docker job starts the token recorder before the test run and summarizes after, all steps continue-on-error", () => {
+  const text = manual();
+  const urlJobAt = text.indexOf("e2e-url:");
+  const dockerJobText = text.slice(0, urlJobAt > 0 ? urlJobAt : text.length);
+  const start = dockerJobText.indexOf("node scripts/watch-tokens.mjs");
+  const exportAttrib = dockerJobText.indexOf("TOKENS_ATTRIB=token-attrib.jsonl");
+  const run = dockerJobText.indexOf("Run tests and upload report");
+  const stop = dockerJobText.indexOf("Stop and collect token consumption");
+  const summarizeStep = dockerJobText.indexOf("Summarize token consumption");
+  assert.ok(start > 0, "manual.yml's e2e-docker job no longer starts the token recorder");
+  assert.ok(exportAttrib > 0, "manual.yml's e2e-docker job no longer exports TOKENS_ATTRIB");
+  assert.ok(run > 0, "manual.yml's e2e-docker job no longer runs the test step");
+  assert.ok(stop > 0, "manual.yml's e2e-docker job no longer stops/collects the token recorder");
+  assert.ok(summarizeStep > 0, "manual.yml's e2e-docker job no longer summarizes token consumption");
+  assert.ok(start < run, "the token recorder must start BEFORE the test run");
+  assert.ok(exportAttrib < run, "TOKENS_ATTRIB must be exported BEFORE the test run consumes it");
+  assert.ok(stop > run, "the stop/collect step must come after the test run");
+  assert.ok(summarizeStep > stop, "the summary must run after the stop/collect step");
+  for (const label of ["Start the token consumption recorder", "Stop and collect token consumption", "Summarize token consumption", "Upload token consumption"]) {
+    const at = dockerJobText.indexOf(label);
+    assert.ok(at > 0, `manual.yml's e2e-docker job is missing the "${label}" step`);
+    assert.match(
+      dockerJobText.slice(at, at + 400),
+      /continue-on-error: true/,
+      `the "${label}" step must carry continue-on-error: true — it is diagnostic-only and must never gate a dispatch`,
+    );
+  }
+});
+
+test("manual's summarize step (e2e-docker) suppresses the history append (#1183)", () => {
+  const text = manual();
+  const urlJobAt = text.indexOf("e2e-url:");
+  const dockerJobText = text.slice(0, urlJobAt > 0 ? urlJobAt : text.length);
+  const summarizeStep = dockerJobText.indexOf("- name: Summarize token consumption");
+  const nextStep = dockerJobText.indexOf("- name:", summarizeStep + 1);
+  assert.match(
+    dockerJobText.slice(summarizeStep, nextStep > 0 ? nextStep : summarizeStep + 2000),
+    /TOKENS_SUPPRESS_HISTORY:\s*"1"/,
+    "manual.yml must set TOKENS_SUPPRESS_HISTORY — an arbitrary dispatch scope must never enter reports/token-history.jsonl's daily series",
+  );
+});
+
+// The recorder polls TOKENS_BASE_URL, which defaults to localhost — e2e-docker's
+// own service container, not the external instance e2e-url targets (#1183). A
+// recorder started there would only ever log connection-refused errors, so this
+// guard pins the omission itself: the recorder must exist ONLY inside the
+// e2e-docker job's own text, never inside e2e-url's.
+test("the token recorder is NOT wired into manual's e2e-url job (it targets an external Langflow, not localhost)", () => {
+  const text = manual();
+  const urlJobAt = text.indexOf("e2e-url:");
+  assert.ok(urlJobAt > 0, "manual.yml no longer has an e2e-url job — this guard's premise is gone");
+  const urlJobText = text.slice(urlJobAt);
+  assert.doesNotMatch(
+    urlJobText,
+    /node scripts\/watch-tokens\.mjs/,
+    "the token recorder must not be started in the e2e-url job — it targets an external Langflow, not the localhost the recorder polls",
+  );
 });

--- a/scripts/watch-tokens.test.mjs
+++ b/scripts/watch-tokens.test.mjs
@@ -791,6 +791,27 @@ test("TOKENS_SUPPRESS_HISTORY unset (or falsy) preserves the existing daily beha
   );
 });
 
+// #1183, found live on a manual dispatch of daily-stable.yml (run 30657439522):
+// the daily's merge job now sets TOKENS_SUPPRESS_HISTORY via
+// `github.event_name != 'schedule' && '1' || ''` — an empty string on the
+// scheduled branch, not an unset variable. GitHub Actions env values are
+// always strings, so this is the exact runtime value the daily's own
+// scheduled runs pass, and it must resolve to "not suppressed" just like the
+// knob being absent entirely — this pins that specific value, not just the
+// general "falsy" case #782 already covers.
+test("TOKENS_SUPPRESS_HISTORY as an empty string (the daily's own scheduled-run value) preserves history writes", async () => {
+  const fs2 = fakeFs({
+    "all-tokens/token-probes-1.jsonl": `${PROBE_LINE}\n`,
+    "prices.json": PRICES,
+  });
+  const env = { ...baseEnv, TOKENS_SUPPRESS_HISTORY: "" };
+  assert.equal(await summarize({ env, ...fs2, log: () => {} }), 0);
+  assert.ok(
+    fs2.appended["reports/token-history.jsonl"],
+    "an empty string must behave exactly like the knob being absent",
+  );
+});
+
 test("a history-append failure is logged and summarize still resolves 0", async () => {
   const fs2 = fakeFs(
     { "all-tokens/token-probes-1.jsonl": `${PROBE_LINE}\n`, "prices.json": PRICES },
@@ -862,6 +883,52 @@ test("neither token step gates the run — the shard stop step AND the merge sum
   assert.notEqual(shardStep, mergeStep, "the two must be distinct steps, not the same match twice");
   for (const start of [shardStep, mergeStep]) {
     assert.match(text.slice(start, start + 400), /continue-on-error: true/);
+  }
+});
+
+// #1183, found live on a manual dispatch of daily-stable.yml (run 30657439522):
+// "Append daily history" / "Commit daily history" are already gated
+// `if: always() && github.event_name == 'schedule'`, so a manual dispatch of
+// this workflow never COMMITS reports/token-history.jsonl — but the merge
+// job's "Summarize token consumption" step ran unconditionally and, before
+// this fix, WROTE the history line into the runner's (uncommitted) workspace
+// regardless, silently diverging from what the file on disk implied. This
+// guard pins that the merge step suppresses the write on any non-scheduled
+// run, using the exact same event_name check the two history steps already
+// use — expressed as an env value instead of a step `if:`, since the step
+// itself must keep running and keep publishing its step summary either way.
+test("the daily's merge-job summarize step suppresses history on a manual dispatch (#1183)", () => {
+  const text = daily();
+  const mergeStep = text.indexOf("- name: Summarize token consumption");
+  assert.ok(mergeStep > 0, "the merge job's summarize step must exist");
+  const nextStep = text.indexOf("- name:", mergeStep + 1);
+  const stepText = text.slice(mergeStep, nextStep > 0 ? nextStep : mergeStep + 3000);
+  assert.match(
+    stepText,
+    /TOKENS_SUPPRESS_HISTORY:/,
+    "the merge job's summarize step must set TOKENS_SUPPRESS_HISTORY — a manual dispatch's arbitrary shape must not silently write into the scheduled series",
+  );
+  assert.match(
+    stepText,
+    /github\.event_name\s*!=\s*'schedule'/,
+    "the suppression must key off the SAME event_name check the history append/commit steps already use, not a new one",
+  );
+});
+
+// The history steps' own `if:` conditions are explicitly out of scope for this
+// change (they were already correct) — pin that they are untouched, so a
+// future edit to the merge-job env does not accidentally start gating these
+// steps on something else instead.
+test("the history append/commit steps are still gated on if: always() && github.event_name == 'schedule' (unchanged)", () => {
+  const text = daily();
+  for (const label of ["Append daily history", "Commit daily history"]) {
+    const at = text.indexOf(`- name: ${label}`);
+    assert.ok(at > 0, `the "${label}" step must still exist`);
+    assert.match(
+      text.slice(at, at + 200),
+      /if:\s*always\(\)\s*&&\s*github\.event_name\s*==\s*'schedule'/,
+      `the "${label}" step's own if: condition must be untouched by the #1183 fix`,
+    );
   }
 });
 


### PR DESCRIPTION
Extends the token consumption recorder (#1197 / PR #1208) to `pr-validation.yml` and `manual.yml` in **measurement-only** mode, so #1183 can attribute LLM spend per lane instead of per repo.

## Why measurement-only

The recorder already runs on `daily-stable.yml` and its numbers land in `reports/token-history.jsonl`. That file is the **daily's series** — the anomaly baseline reads it. A PR lane's scope varies with the import-graph subset and a manual run's scope is arbitrary, so letting either write to it would poison the trend, for the same reason #1180 and #1183 exclude those lanes from analytics.

So these two lanes get the artifact and the step-summary table, and a new `TOKENS_SUPPRESS_HISTORY` knob skips the history **read and write** — the read matters too: an anomaly baseline read from a file this lane must not influence is still wrong. The suppression is stated in the log and in the step summary, never silent.

## What is wired

| Lane | Wiring |
|---|---|
| `pr-validation.yml` | Recorder around the impacted-specs Playwright step in the E2E job, which is already gated on `has_specs` — so a PR with nothing to run starts no recorder and cannot publish a misleading "0 tokens" |
| `manual.yml` | The `e2e-docker` job only. `TOKENS_ATTRIB` reaches the specs through `$GITHUB_ENV`, because the run happens inside the `run-e2e` composite action and composite actions do **not** inherit a caller step's `env:` block — that is the only mechanism that works, not a fallback |
| `manual.yml`'s external-URL job | Deliberately excluded, with the reason in a comment and pinned by a guard: the recorder polls `localhost`, which is the wrong container for a Langflow that is not on the runner |

Every added step carries `continue-on-error: true`, and the stop/collect/upload steps carry `if: always()`. Nothing here can fail a job or gate a merge.

## A collateral fix, found by dispatching the real thing

Dispatching `daily-stable.yml` manually on `main` ([run 30657439522](https://github.com/oriontech-me/langflow-e2e/actions/runs/30657439522), 4 shards) showed `Summarize token consumption` writing a history line that nothing kept: `Append daily history` and `Commit daily history` are `schedule`-gated and were skipped. The same knob now suppresses the write when the daily runs off-schedule, so the step's behaviour matches what the repo actually persists. The history steps' own conditions are untouched.

That run is also where this branch's purpose came from: it measured a full 4-shard daily at **27,155 tokens / $0.10**, against **$16.83 across 16 triage-agent runs** in the two weeks before — the comparison recorded in #1183.

## Guards

Six structural guards over the two lanes, plus two more for the daily's suppression: recorder before the run step, summary after it, `continue-on-error` on every added step including `manual.yml`'s export, the `e2e-url` exclusion, the suppression env present, and the history steps' `if:` unchanged. Each was verified by stripping the thing it pins and confirming the guard fails.

While extending them I also hardened two pre-existing anchors that could match a comment instead of a step header — a guard that matches prose cannot fail.

## Verification

`npm run test:scripts` 358/358, `npm run test:units` 293/293, `npm run typecheck` and `npm run lint` clean, all three workflow YAMLs parse. Local proof that the suppression works: a summarize run with the knob set renders the full step summary and creates no history file.

**This PR self-tests.** Its own `pr-validation` run exercises the new wiring — the recorder should start, the summary should publish, and no `reports/token-history.jsonl` should appear in the diff.

Refs #1183