### PR TITLE
refactor(flows): one id-addressed flow entry, replacing three diverged copies (#1214)

### DIFF
--- a/docs/core-functionality/project-management/edit-flow-name.md
+++ b/docs/core-functionality/project-management/edit-flow-name.md
@@ -34,11 +34,12 @@ in editor-local state.
    copy the **Basic Prompting** starter graph into a uniquely-named flow of this
    worker's own, over the REST API. Not a click on the shared template card: see
    *The template-entry race* below.
-2. `openFlowById(page, flowId)` — `page.goto('/flow/{id}')`, wait for
-   `canvas_controls_dropdown`, then gate on `menu_bar_display` being **enabled**
-   (write permission resolved). The assistant onboarding tooltip is suppressed
-   before the first load by seeding `langflow-assistant-discovered` in
-   localStorage — see *The onboarding tooltip is armed on a 10 s timer* below.
+2. `openFlowById(page, flowId)` — the shared entry helper (#1214):
+   `page.goto('/flow/{id}')`, wait for `canvas_controls_dropdown`, then gate on
+   `menu_bar_display` being **enabled** (write permission resolved). It also
+   suppresses the assistant onboarding tooltip before the load by seeding
+   `langflow-assistant-discovered` in localStorage — see *The onboarding tooltip
+   is armed on a 10 s timer* below.
 3. For each of two random target names:
    1. `renameFlow(page, { flowName: targetName })` — rename via the flow header
       settings modal; then `renameFlow(page)` (read-only) asserts the committed
@@ -193,7 +194,8 @@ localStorage flag (`langflow-assistant-discovered`, written when the user opens
 the assistant or clicks the tooltip's X), which is **empty in every fresh
 Playwright context**, so every test is exposed on every entry.
 
-Dismissing it on entry does not work, and the reason is worth recording:
+This is owned by `openFlowById` (#1214) since three specs needed it, and
+dismissing it on entry does not work, for a reason worth recording:
 upstream arms the tooltip on an **idle timer of 10 s** after mount
 (`ONBOARDING_TOOLTIP_DELAY_MS` in `CanvasControls.tsx`). A probe right after the
 canvas renders looks ~8 s too early, sees nothing, and the tooltip then pops

--- a/docs/core-functionality/project-management/edit-flow-name.md
+++ b/docs/core-functionality/project-management/edit-flow-name.md
@@ -187,12 +187,19 @@ loudly, so the suite keeps its only signal on how often #1153 fires.
 
 ### The onboarding tooltip is armed on a 10 s timer
 
-`assistant-onboarding-tooltip` renders in a Portal over the editor and its
-overlay intercepts clicks on the canvas **and on the Flow Settings modal** — the
-one this spec drives on every iteration (#684). Upstream gates it on a
+`assistant-onboarding-tooltip` renders in a Portal over the editor, anchored
+beside `assistant-button` in the canvas controls bar. Upstream gates it on a
 localStorage flag (`langflow-assistant-discovered`, written when the user opens
 the assistant or clicks the tooltip's X), which is **empty in every fresh
 Playwright context**, so every test is exposed on every entry.
+
+The #684 write-up says the overlay also intercepts clicks on the Flow Settings
+modal — the one this spec drives on every iteration. That is no longer true on
+1.12.x and should not be repeated: upstream renders the popover as
+`modal={false}` at `z-40`, deliberately capped below the z-50 dialog layer so it
+cannot float in front of an open modal. What is left is a small opaque rectangle
+over the canvas-controls region — enough to eat a hit-tested click on whatever it
+covers, which is reason enough to remove it rather than race it.
 
 This is owned by `openFlowById` (#1214) since three specs needed it, and
 dismissing it on entry does not work, for a reason worth recording:

--- a/docs/flow-functionality/flow-lock.md
+++ b/docs/flow-functionality/flow-lock.md
@@ -1,6 +1,6 @@
 # Flow Lock — settings-modal round-trip & locked-state UI
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x
 
 ---
 
@@ -58,10 +58,13 @@ management; `@ui-ux` — settings-modal interaction + locked-state indicators.
 **Test 1 — lock and unlock a flow and verify UI changes**
 
 1. Create a uniquely-named Basic Prompting flow via the API
-   (`createFlowFromStarter`) and open it by id (`/flow/{id}`); its id is kept for
-   id-scoped teardown. This id-addressed open (rather than clicking the shared
-   "Basic Prompting" template card) is what keeps the spec parallel-safe — see
-   Notes.
+   (`createFlowFromStarter`) and open it with `openFlowById(page, flowId)`; its id
+   is kept for id-scoped teardown. This id-addressed open (rather than clicking
+   the shared "Basic Prompting" template card) is what keeps the spec
+   parallel-safe — see Notes. The shared helper (#1214) also suppresses the
+   assistant onboarding overlay before the load and gates on the flow being
+   **writable** (`menu_bar_display` enabled), which this spec needs: it locks and
+   unlocks through the settings menu.
 2. Assert the flow is initially unlocked — no `icon-lock` badge on the canvas.
 3. Open Flow Settings (`flow_name`); wait for `lock-flow-switch`.
 4. Assert the switch is `unchecked` and both `input-flow-name` /

--- a/docs/flow-functionality/lock-flow.md
+++ b/docs/flow-functionality/lock-flow.md
@@ -9,8 +9,8 @@
 A **locked** flow blocks all canvas graph edits, and unlocking restores them —
 the functional core of the "Lock flow (prevents editing)" behavior:
 
-1. **Lock persists across navigation** — locking a flow, leaving to the flows
-   list, and reopening it keeps the flow locked (the `icon-lock` badge is shown
+1. **Lock persists across a reload** — locking a flow and reopening it by id
+   keeps the flow locked (the Flow Settings `lock-flow-switch` reads `checked`
    on reopen).
 2. **Locked ⇒ edits blocked** — while locked, clicking edges and pressing
    `Backspace` does **not** delete them (edge count stays constant), and
@@ -61,8 +61,11 @@ on the fresh nightly. `@components` — node/edge canvas manipulation; `@workspa
    Reopens later in the test also go by id (not `list-card.first()`) so parallel
    workers never open each other's flow — see Notes.
 2. `lockFlow(page)` — open settings, toggle `lock-flow-switch`, save.
-3. Navigate to the flows list (`icon-ChevronLeft`) and reopen the flow via its
-   card; assert the `icon-lock` badge is present (lock persisted).
+3. Reopen the **same** flow by id (`openFlowById` again — a full reload, not a
+   trip through the flows list) and assert the lock persisted with
+   `expectLockState(page, "checked")`: open Flow Settings via `flow_name` and
+   require `lock-flow-switch` to read `data-state="checked"`. Deliberately
+   **not** the per-node `icon-lock` badge — see Notes.
 4. `unlockFlow(page)` — reopen settings, toggle the switch off, save.
 5. Reopen the flow. Run `tryDeleteEdge`: **re-lock**, then assert that clicking
    each edge + `Backspace` leaves the edge count at 3 across several attempts
@@ -80,7 +83,8 @@ on the fresh nightly. `@components` — node/edge canvas manipulation; `@workspa
 - While locked: edge count is invariant under delete attempts, and handle clicks
   create no edges.
 - While unlocked: edges delete to 0 and re-wire back to exactly 3.
-- The lock state survives leaving and reopening the flow (`icon-lock` on reopen).
+- The lock state survives a reopen of the flow — `lock-flow-switch` reads
+  `checked` after the reload.
 
 ---
 
@@ -95,19 +99,25 @@ on the fresh nightly. `@components` — node/edge canvas manipulation; `@workspa
 ## External dependencies *(required)*
 
 - `tests/helpers/flows/lock-flow.ts` — `lockFlow` / `unlockFlow` drive the
-  settings switch (`flow_name` → `lock-flow-switch` → `save-flow-settings`).
+  settings switch (`flow_name` → `lock-flow-switch` → `save-flow-settings`);
+  `expectLockState` reads that switch back without mutating it.
+- `tests/helpers/flows/open-flow-by-id.ts` — the shared id-addressed entry
+  (#1214). Its **writable** gate is load-bearing here and not merely defensive:
+  `expectLockState` opens Flow Settings by clicking `flow_name`, upstream renders
+  `menu_bar_display` as `disabled={isReadOnly}` and the popover as
+  `open={openSettings && !isReadOnly}`, so a click landing while
+  `POST /api/v1/authz/me/permissions` is still in flight opens nothing.
 - Canvas edit surface — `.react-flow__edge`, node handles
   (`handle-…-shownode-…`), and the lock enforcement that suppresses
   delete/connect while locked.
-- Canvas node chrome — renders the per-node `icon-lock` badge (1.11).
 - "Basic Prompting" starter template — the disposable subject flow.
 
 ---
 
 ## When to review this test *(optional)*
 
-- If the locked-state indicator testid changes (moved from header `icon-Lock` to
-  per-node `icon-lock` on 1.11 — see Notes).
+- If `lock-flow-switch` or `flow_name` moves, or if Flow Settings stops reflecting
+  the persisted lock state — that is what the persistence check now reads.
 - If the "Basic Prompting" template's node/handle testids change, or if the
   lock-enforcement on the canvas changes.
 
@@ -115,11 +125,16 @@ on the fresh nightly. `@components` — node/edge canvas manipulation; `@workspa
 
 ## Notes *(optional)*
 
-- **Locked-state indicator drift (#684):** the persistence check waits for the
-  per-node **`icon-lock`** badge (lowercase, 1.11) on reopen. The prior header
-  `icon-Lock` (capital) no longer renders — asserting it was the sole reason
-  this test hard-failed on the nightly while the lock feature itself works
-  (locked flows still refuse edge deletion, verified live).
+- **The persistence check is the settings switch, and it took two corrections to
+  get there.** It was originally the header `icon-Lock` badge (capital), which
+  stopped rendering and hard-failed this test on the nightly while the lock
+  feature itself worked (#684). It then became the per-node **`icon-lock`** badge
+  (lowercase, 1.11) — which force-fail showed renders on **every** flow regardless
+  of lock state, so it passed even when the flow was never locked (#909). Neither
+  badge is asserted today: `expectLockState(page, "checked")` reads
+  `lock-flow-switch` out of Flow Settings, the same control `lockFlow` wrote, so a
+  lock that did not persist cannot satisfy it. Do not reintroduce an `icon-lock`
+  assertion here without first proving it distinguishes locked from unlocked.
 - **Complementary to `flow-lock.spec.ts`:** same lock mechanism, different
   assertions — this spec proves the *functional* editing-block; the sibling
   proves the *settings-UI* state. Kept separate so the functional proof stands

--- a/docs/flow-functionality/lock-flow.md
+++ b/docs/flow-functionality/lock-flow.md
@@ -1,6 +1,6 @@
 # Lock Flow — functional editing-prevention on the canvas
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x
 
 ---
 
@@ -53,10 +53,13 @@ on the fresh nightly. `@components` — node/edge canvas manipulation; `@workspa
 **Test — user must be able to lock a flow and it must be saved**
 
 1. Create a uniquely-named Basic Prompting flow via the API
-   (`createFlowFromStarter`) and open it by id (`/flow/{id}`); id captured for
-   teardown. Wait for `canvas_controls_dropdown`. Reopens later in the test also
-   go by id (not `list-card.first()`) so parallel workers never open each
-   other's flow — see Notes.
+   (`createFlowFromStarter`) and open it with `openFlowById(page, flowId)`; id
+   captured for teardown. That shared helper (#1214) waits for
+   `canvas_controls_dropdown`, suppresses the assistant onboarding overlay before
+   the load, and gates on the flow being **writable** (`menu_bar_display`
+   enabled) — every step below mutates the flow through the settings menu.
+   Reopens later in the test also go by id (not `list-card.first()`) so parallel
+   workers never open each other's flow — see Notes.
 2. `lockFlow(page)` — open settings, toggle `lock-flow-switch`, save.
 3. Navigate to the flows list (`icon-ChevronLeft`) and reopen the flow via its
    card; assert the `icon-lock` badge is present (lock persisted).

--- a/tests/helpers/flows/open-flow-by-id.test.ts
+++ b/tests/helpers/flows/open-flow-by-id.test.ts
@@ -118,49 +118,65 @@ test("the seeded key is the flag upstream reads", () => {
   assert.equal(ASSISTANT_DISCOVERED_STORAGE_KEY, "langflow-assistant-discovered");
 });
 
-test("the init script writes the upstream key with the upstream value", () => {
+/**
+ * Run `body` with `globalThis.localStorage` replaced by `stub`, then restore.
+ *
+ * Via `defineProperty` against the saved descriptor, not `globals.localStorage =`.
+ * Node exposes `localStorage` as a getter-only global from v22.4 (unflagged in
+ * v24), and a plain assignment to an accessor with no setter THROWS under the
+ * `"use strict"` these modules compile to — so the direct form would fail both
+ * tests below on a newer runtime, for a reason having nothing to do with what
+ * they assert. Restoring the descriptor rather than the value keeps that global
+ * a getter afterwards instead of flattening it into a data property.
+ */
+function withLocalStorage(stub: unknown, body: () => void): void {
+  const original = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  Object.defineProperty(globalThis, "localStorage", {
+    value: stub,
+    configurable: true,
+    writable: true,
+  });
+  try {
+    body();
+  } finally {
+    if (original) Object.defineProperty(globalThis, "localStorage", original);
+    else delete (globalThis as { localStorage?: unknown }).localStorage;
+  }
+}
+
+test("the init script writes the upstream key with the upstream value", async () => {
   const page = fakePage();
-  return seedAssistantDiscovered(page).then(() => {
-    const { script, arg } = page.initScripts[0];
-    const written: Record<string, string> = {};
-    const globals = globalThis as { localStorage?: unknown };
-    const original = globals.localStorage;
-    globals.localStorage = {
+  await seedAssistantDiscovered(page);
+  const { script, arg } = page.initScripts[0];
+  const written: Record<string, string> = {};
+  withLocalStorage(
+    {
       setItem: (key: string, value: string) => {
         written[key] = value;
       },
-    };
-    try {
-      script(arg);
-    } finally {
-      if (original === undefined) delete globals.localStorage;
-      else globals.localStorage = original;
-    }
-    assert.deepEqual(written, { "langflow-assistant-discovered": "true" });
-  });
+    },
+    () => script(arg),
+  );
+  assert.deepEqual(written, { "langflow-assistant-discovered": "true" });
 });
 
-test("a localStorage that throws does not reject the seed", () => {
+test("a localStorage that throws does not reject the seed", async () => {
   const page = fakePage();
-  return seedAssistantDiscovered(page).then(() => {
-    const { script, arg } = page.initScripts[0];
-    const globals = globalThis as { localStorage?: unknown };
-    const original = globals.localStorage;
-    globals.localStorage = {
+  await seedAssistantDiscovered(page);
+  const { script, arg } = page.initScripts[0];
+  withLocalStorage(
+    {
       setItem: () => {
         throw new Error("private browsing");
       },
-    };
-    try {
+    },
+    () => {
       // Upstream treats its own write as best-effort for the same reason; the
       // consequence of swallowing it is a visible overlay and a loud spec
       // failure, never a silent pass.
       assert.doesNotThrow(() => script(arg));
-    } finally {
-      if (original === undefined) delete globals.localStorage;
-      else globals.localStorage = original;
-    }
-  });
+    },
+  );
 });
 
 test("the canvas budget is separate from, and longer than, the writable budget", () => {

--- a/tests/helpers/flows/open-flow-by-id.test.ts
+++ b/tests/helpers/flows/open-flow-by-id.test.ts
@@ -1,0 +1,216 @@
+// Unit tests for the id-addressed flow entry (issue #1214).
+// Run with: npm run test:units
+//
+// What rides on this module: the three specs that enter the editor by id all now
+// depend on it, and two of its behaviours are invisible when they break — which
+// is exactly how the divergence it replaces survived.
+//
+// Three invariants these tests exist to protect:
+//
+//  1. **The seed is registered BEFORE the navigation.** `addInitScript` applies
+//     to the loads that follow it, so registering it after the `goto` leaves the
+//     one load the caller cares about unseeded — and the failure is not an error,
+//     it is an onboarding overlay appearing 10 s later, over a dialog, in a
+//     different assertion. Nothing in a Playwright run would name this.
+//  2. **The seed is registered once per page.** A spec that enters three times
+//     would otherwise stack three identical init scripts on the same page, which
+//     is harmless today and exactly the kind of quiet growth nobody notices.
+//  3. **The storage key and the deadlines cannot drift unnoticed.** Stated
+//     honestly, because it is easy to oversell: nothing here reads the upstream
+//     source, so these are CHANGE-DETECTORS, not proof that the suite still
+//     matches Langflow. What they buy is that changing the key or inverting the
+//     two budgets requires editing an assertion that says why — instead of being
+//     a one-character edit whose consequence surfaces months later as a spec
+//     flaking behind an overlay.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  ASSISTANT_DISCOVERED_STORAGE_KEY,
+  CANVAS_TIMEOUT_MS,
+  WRITABLE_TIMEOUT_MS,
+  navigateToFlow,
+  seedAssistantDiscovered,
+  type NavigablePage,
+} from "./open-flow-by-id";
+
+/**
+ * A page that records what was called on it, in order.
+ *
+ * Deliberately not a mock framework: the assertions below are about ORDER and
+ * COUNT, and a plain array of call names is the most direct way to state them.
+ */
+function fakePage(): NavigablePage & {
+  calls: string[];
+  initScripts: Array<{ script: (key: string) => void; arg: string }>;
+  gotos: string[];
+} {
+  const calls: string[] = [];
+  const initScripts: Array<{ script: (key: string) => void; arg: string }> = [];
+  const gotos: string[] = [];
+  return {
+    calls,
+    initScripts,
+    gotos,
+    async addInitScript(script, arg) {
+      calls.push("addInitScript");
+      initScripts.push({ script, arg });
+    },
+    async goto(url) {
+      calls.push(`goto:${url}`);
+      gotos.push(url);
+    },
+  };
+}
+
+test("the seed is registered before the navigation it must apply to", async () => {
+  const page = fakePage();
+  await navigateToFlow(page, "flow-123");
+  assert.deepEqual(page.calls, ["addInitScript", "goto:/flow/flow-123"]);
+});
+
+test("the flow is addressed by id, on the editor route", async () => {
+  const page = fakePage();
+  await navigateToFlow(page, "abc-def");
+  assert.deepEqual(page.gotos, ["/flow/abc-def"]);
+});
+
+test("re-entering the same page does not stack a second init script", async () => {
+  const page = fakePage();
+  await navigateToFlow(page, "flow-1");
+  await navigateToFlow(page, "flow-1");
+  await navigateToFlow(page, "flow-1");
+  assert.equal(page.initScripts.length, 1, "one registration for three entries");
+  assert.deepEqual(page.gotos, ["/flow/flow-1", "/flow/flow-1", "/flow/flow-1"]);
+});
+
+test("a different page gets its own seed", async () => {
+  const first = fakePage();
+  const second = fakePage();
+  await navigateToFlow(first, "flow-1");
+  await navigateToFlow(second, "flow-2");
+  assert.equal(first.initScripts.length, 1);
+  assert.equal(second.initScripts.length, 1);
+});
+
+test("seedAssistantDiscovered reports whether it registered", async () => {
+  const page = fakePage();
+  assert.equal(await seedAssistantDiscovered(page), true, "first call registers");
+  assert.equal(
+    await seedAssistantDiscovered(page),
+    false,
+    "second call is a no-op",
+  );
+});
+
+test("the seeded key is the flag upstream reads", () => {
+  // `readAssistantDiscovered()` in
+  // `components/core/assistantPanel/hooks/assistant-discovery-storage.ts` reads
+  // exactly this key and compares against the string "true".
+  //
+  // This asserts a literal against a literal, and it cannot detect an upstream
+  // rename — nothing in this lane reads the Langflow source, and adding that
+  // dependency would make the unit lane require a checkout it does not have in
+  // CI. What it does buy: the key is the one thing here whose value is dictated
+  // by another codebase, so pinning it turns "someone tidied a constant" into a
+  // failing test that names where the real definition lives.
+  assert.equal(ASSISTANT_DISCOVERED_STORAGE_KEY, "langflow-assistant-discovered");
+});
+
+test("the init script writes the upstream key with the upstream value", () => {
+  const page = fakePage();
+  return seedAssistantDiscovered(page).then(() => {
+    const { script, arg } = page.initScripts[0];
+    const written: Record<string, string> = {};
+    const globals = globalThis as { localStorage?: unknown };
+    const original = globals.localStorage;
+    globals.localStorage = {
+      setItem: (key: string, value: string) => {
+        written[key] = value;
+      },
+    };
+    try {
+      script(arg);
+    } finally {
+      if (original === undefined) delete globals.localStorage;
+      else globals.localStorage = original;
+    }
+    assert.deepEqual(written, { "langflow-assistant-discovered": "true" });
+  });
+});
+
+test("a localStorage that throws does not reject the seed", () => {
+  const page = fakePage();
+  return seedAssistantDiscovered(page).then(() => {
+    const { script, arg } = page.initScripts[0];
+    const globals = globalThis as { localStorage?: unknown };
+    const original = globals.localStorage;
+    globals.localStorage = {
+      setItem: () => {
+        throw new Error("private browsing");
+      },
+    };
+    try {
+      // Upstream treats its own write as best-effort for the same reason; the
+      // consequence of swallowing it is a visible overlay and a loud spec
+      // failure, never a silent pass.
+      assert.doesNotThrow(() => script(arg));
+    } finally {
+      if (original === undefined) delete globals.localStorage;
+      else globals.localStorage = original;
+    }
+  });
+});
+
+test("the canvas budget is separate from, and longer than, the writable budget", () => {
+  // A RELATION between two independently-editable constants, not a restatement of
+  // either. They answer different questions: "nothing is on screen yet" (document
+  // load + flow fetch + first render) versus "the editor is up and the permission
+  // query has not answered". Inverting them would hide a permission map that
+  // genuinely denies `write` behind the longer wait, and the migration this helper
+  // performed is exactly the moment someone edits one budget and not the other.
+  assert.ok(
+    CANVAS_TIMEOUT_MS > WRITABLE_TIMEOUT_MS,
+    `canvas ${CANVAS_TIMEOUT_MS}ms must exceed writable ${WRITABLE_TIMEOUT_MS}ms`,
+  );
+  // The floor is the largest budget any of the three migrated copies carried: the
+  // helper unified them by taking the MAX, because none was ever measured and
+  // shrinking one on an argument buys a red on a saturated daily. Lowering this
+  // should require replacing the floor with a measurement.
+  assert.equal(
+    CANVAS_TIMEOUT_MS,
+    100000,
+    "canvas budget is the max of the three migrated copies (100 s), not a middle",
+  );
+});
+
+test("the entry cannot navigate without seeding first", () => {
+  // The ordering invariant is what makes the seed work at all, and the tests above
+  // can only pin it for `navigateToFlow`. A `page.goto` added straight into
+  // `openFlowById` — the obvious refactor — would satisfy every other test here
+  // while silently leaving the load it performs unseeded.
+  //
+  // Structural guard, in the spirit of the workflow-shape guard in
+  // `scripts/wait-for-backend.test.mjs`: the module must contain exactly one
+  // navigation, and it must be the one `seedAssistantDiscovered` precedes.
+  const source = readFileSync(
+    join(__dirname, "open-flow-by-id.ts"),
+    "utf8",
+  );
+  // Comments mention `page.goto('/flow/{id}')` when explaining the entry, so the
+  // count has to be over CODE. Strip block and line comments first, or the guard
+  // fails on its own documentation.
+  const code = source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "");
+  const navigations = code.match(/\.goto\(/g) ?? [];
+  assert.equal(
+    navigations.length,
+    1,
+    "exactly one .goto( in the module — add navigations to navigateToFlow, not around it",
+  );
+  const seedAt = code.indexOf("await seedAssistantDiscovered(page)");
+  const gotoAt = code.indexOf(".goto(");
+  assert.ok(seedAt > 0 && gotoAt > seedAt, "the seed must precede the navigation");
+});

--- a/tests/helpers/flows/open-flow-by-id.ts
+++ b/tests/helpers/flows/open-flow-by-id.ts
@@ -1,0 +1,187 @@
+// Entering the flow editor by id, as one implementation (issue #1214).
+//
+// The block this replaces — "`page.goto('/flow/{id}')`, then wait for the canvas"
+// — was hand-copied into three specs (`lock-flow`, `flow-lock`, `edit-flow-name`)
+// and had already diverged on every axis that matters: the canvas deadline
+// (100 s vs. 30 s), an arbitrary `waitForTimeout(500)` in one of them, the
+// onboarding handling, and the write-permission gate. Same failure mode #1108
+// documented for id-scoped cleanup: a fix to one copy reached none of the others,
+// and two of the three fixes existed in exactly one caller.
+//
+// Addressing the flow by id — never `list-card.first()` or a name-filtered
+// `list-card-open-button` click — is what makes the entry parallel-safe: `.first()`
+// opens whichever card is on top of the shared home grid, i.e. another worker's
+// flow, and the cards other workers leave behind overlap the target's
+// absolute-inset open button and intercept a hit-tested click (#684/#580/#588). A
+// full document load also leaves no SPA hop to race (#1005).
+//
+// A helper, deliberately opt-in per spec, rather than a fixture — including the
+// onboarding seed, which a fixture could arguably own since it must run before the
+// first document load. `tests/fixtures/**` is suite-wide for
+// `impacted-specs-by-import.mjs`, so anything living there resolves to EVERY spec
+// and demands a full `manual.yml` run on each change (#1054). The same trade
+// `trackCreatedFlows` made (#1108). The seed is registered by the entry itself and
+// is idempotent per page, so a caller cannot forget it and a caller that enters
+// three times still pays for one registration.
+
+import { type Page, expect } from "@playwright/test";
+
+/**
+ * How long the canvas may take to render after the document load.
+ *
+ * ONE deadline, replacing the 100 s / 30 s / 30 s the three copies carried, and
+ * it is the **MAX** of the three on purpose. None of the three was measured —
+ * they were inherited — and this wait is not a single request but a composite
+ * (document load + `GET /api/v1/flows/{id}` + the editor's first render), so no
+ * per-request figure bounds it. Picking the middle would have shrunk
+ * `lock-flow`'s budget by 40 % on nothing but an argument, and the failure that
+ * buys is a red on a saturated daily reported as "the canvas never rendered".
+ *
+ * Raising the other two costs only how long a doomed entry takes to say so, and
+ * that cost is bounded: this gate plus the writable gate below are SERIAL, so a
+ * dead entry spends at most `CANVAS_TIMEOUT_MS + WRITABLE_TIMEOUT_MS` (130 s)
+ * before failing — comfortably inside the suite's 5-minute per-test timeout, so
+ * the failure still lands on this assertion with its own message rather than as
+ * an unattributed test-level timeout.
+ *
+ * Lowering it is a measurement, not an opinion: it wants entry durations from a
+ * saturated daily, which the repo does not record today.
+ */
+export const CANVAS_TIMEOUT_MS = 100000;
+
+/**
+ * How long the flow header may stay disabled before the entry is called broken.
+ *
+ * Separate from the canvas budget on purpose: by the time this runs the editor is
+ * already on screen, so the only thing outstanding is
+ * `POST /api/v1/authz/me/permissions`. Charging it the canvas window would hide a
+ * permission map that genuinely denies `write` behind a minute of waiting.
+ */
+export const WRITABLE_TIMEOUT_MS = 30000;
+
+/**
+ * The localStorage flag upstream reads to decide whether the assistant
+ * onboarding affordances still need to surface
+ * (`assistant-discovery-storage.ts`). Pinned by the unit lane, because a rename
+ * upstream would silently restore the overlay this suppresses.
+ */
+export const ASSISTANT_DISCOVERED_STORAGE_KEY = "langflow-assistant-discovered";
+
+/**
+ * Pages already carrying the seed, so a spec that enters three times registers
+ * one init script instead of three. `WeakSet`, so a closed page is collectable.
+ */
+const seededPages = new WeakSet<object>();
+
+/** The `Page` surface this helper's navigation half needs. Narrow, so the unit lane can drive it with a fake. */
+export interface NavigablePage {
+  addInitScript(script: (key: string) => void, arg: string): Promise<unknown>;
+  goto(url: string): Promise<unknown>;
+}
+
+/**
+ * Suppress the assistant onboarding affordances for every subsequent load.
+ *
+ * `assistant-onboarding-tooltip` renders in a Portal over the editor and its
+ * overlay intercepts clicks on the canvas AND on the Flow Settings modal (#684).
+ * The flag gating it lives in localStorage, i.e. it is empty in every fresh
+ * Playwright context, so every test is exposed on every entry.
+ *
+ * Seeding rather than dismissing is not a preference, it is what works: upstream
+ * arms the tooltip on an **idle timer of 10 s** after mount
+ * (`ONBOARDING_TOOLTIP_DELAY_MS` in `CanvasControls.tsx`), so the
+ * `dismissOnboardingIfPresent` probe two of the three callers ran at entry looked
+ * ~8 s too early, saw nothing, and left the tooltip to pop mid-test with a dialog
+ * already open. Measured on 1.12.0.dev10, one run each: seed present → the
+ * tooltip never appears; key renamed → it appears within 20 s.
+ *
+ * Scope, stated rather than implied: this replaces the ENTRY-time probes only.
+ * `dismissOnboardingIfPresent` still has two callers this does not reach —
+ * `helpers/ui/expand-focused-node.ts` and `ui-ux/langflowShortcuts.spec.ts` — and
+ * the 10 s argument does **not** automatically condemn them: both probe further
+ * into the test, where the timer may well have fired, so whether they catch the
+ * tooltip is an open measurement, not a known no-op. Tracked separately; nothing
+ * here changes their behaviour.
+ *
+ * @returns whether this call registered the script (false when already seeded).
+ */
+export async function seedAssistantDiscovered(
+  page: NavigablePage,
+): Promise<boolean> {
+  if (seededPages.has(page)) return false;
+  // Marked AFTER the registration lands, never before: an `addInitScript` that
+  // rejects would otherwise leave the page permanently flagged as seeded, so no
+  // later entry would retry it and the overlay would be back with nothing saying
+  // so.
+  await page.addInitScript((key) => {
+    try {
+      localStorage.setItem(key, "true");
+    } catch {
+      // Best-effort, exactly as upstream treats it (private browsing, quota):
+      // the worst case is the affordance surfacing and the caller's own
+      // assertions failing loudly, never a silent pass.
+    }
+  }, ASSISTANT_DISCOVERED_STORAGE_KEY);
+  seededPages.add(page);
+  return true;
+}
+
+/**
+ * Seed, then navigate — in that order, which is the whole reason the seed works.
+ *
+ * `addInitScript` applies to the navigations that follow it, so registering it
+ * after the `goto` would leave the very load the caller cares about unseeded.
+ * Split out from `openFlowById` so the unit lane can pin that ordering with a
+ * fake page instead of a browser.
+ */
+export async function navigateToFlow(
+  page: NavigablePage,
+  flowId: string,
+): Promise<void> {
+  await seedAssistantDiscovered(page);
+  await page.goto(`/flow/${flowId}`);
+}
+
+export interface OpenFlowByIdOptions {
+  /**
+   * Wait for the flow header to report enabled before returning.
+   *
+   * On by default: upstream renders `menu_bar_display` as
+   * `disabled={isReadOnly}` with
+   * `useIsFlowReadOnly = Boolean(flowId) && (isLoading || !can(flowId, "write"))`,
+   * which fails CLOSED for the whole time `POST /api/v1/authz/me/permissions` is
+   * in flight — so a mutation issued in that window is swallowed with no error
+   * (#1005). Every current caller mutates the flow it opens.
+   *
+   * Turn it off only for a caller that must observe the editor in a state where
+   * the header is legitimately disabled, and say why at the call site — a flow
+   * the user cannot write is exactly what this would otherwise catch.
+   */
+  requireWritable?: boolean;
+}
+
+/**
+ * Open a flow addressed by id and wait until the editor is ready to be driven.
+ *
+ * Three guarantees on return: the canvas is rendered, the onboarding overlay
+ * cannot appear, and (unless opted out) the flow is writable. Everything else —
+ * dismissing modals, adjusting the viewport, selecting nodes — belongs to the
+ * caller.
+ */
+export async function openFlowById(
+  page: Page,
+  flowId: string,
+  { requireWritable = true }: OpenFlowByIdOptions = {},
+): Promise<void> {
+  await navigateToFlow(page, flowId);
+
+  await expect(page.getByTestId("canvas_controls_dropdown")).toBeVisible({
+    timeout: CANVAS_TIMEOUT_MS,
+  });
+
+  if (requireWritable) {
+    await expect(page.getByTestId("menu_bar_display")).toBeEnabled({
+      timeout: WRITABLE_TIMEOUT_MS,
+    });
+  }
+}

--- a/tests/helpers/flows/open-flow-by-id.ts
+++ b/tests/helpers/flows/open-flow-by-id.ts
@@ -23,6 +23,21 @@
 // `trackCreatedFlows` made (#1108). The seed is registered by the entry itself and
 // is idempotent per page, so a caller cannot forget it and a caller that enters
 // three times still pays for one registration.
+//
+// What this does NOT do, stated so the next reader does not conclude the
+// duplication is gone: three callers is the whole reach today, and roughly twenty
+// other `page.goto('/flow/{id}')` sites remain across the suite
+// (`core-components/edit-tools`, `parameters-panel-field-types`,
+// `flow-execution-canvas`, the three `llm-agents` agent-context specs, three
+// knowledge-ingestion specs, `traces-latency-tokens`,
+// `webhook-component-regression`, plus `helpers/flows/setup-playground.ts` and
+// `load-template-by-name.ts`). They are not copies of this — they gate readiness
+// on `sidebar-search-input` rather than `canvas_controls_dropdown`, a genuinely
+// different signal — but none seeds the onboarding flag and none gates on
+// writability, so both hazards above are still open there. Migrating them is a
+// separate change on purpose: every spec added here is selected by the impacted
+// lane on every edit to this file (#1054), so reach is a cost to spend
+// deliberately, with a measurement behind it, not in passing.
 
 import { type Page, expect } from "@playwright/test";
 
@@ -82,10 +97,20 @@ export interface NavigablePage {
 /**
  * Suppress the assistant onboarding affordances for every subsequent load.
  *
- * `assistant-onboarding-tooltip` renders in a Portal over the editor and its
- * overlay intercepts clicks on the canvas AND on the Flow Settings modal (#684).
- * The flag gating it lives in localStorage, i.e. it is empty in every fresh
- * Playwright context, so every test is exposed on every entry.
+ * `assistant-onboarding-tooltip` renders in a Portal over the editor, anchored
+ * beside `assistant-button` in the canvas controls bar, and the flag gating it
+ * lives in localStorage — empty in every fresh Playwright context, so every test
+ * is exposed on every entry.
+ *
+ * What it actually costs is worth stating precisely, because the #684 write-up
+ * this helper inherited overstates it on 1.12.x. Upstream renders the popover as
+ * `modal={false}` at `z-40`, with a comment saying the z-index is deliberately
+ * capped below the z-50 dialog layer "so the onboarding tooltip never floats in
+ * front of an open modal". So there is no body-wide blocking layer and no
+ * interception of the Flow Settings modal any more — what remains is a small
+ * opaque rectangle over the canvas-controls region, which is enough to eat a
+ * hit-tested click on whatever it covers, and enough to have flaked
+ * click-heavy specs before that cap landed.
  *
  * Seeding rather than dismissing is not a preference, it is what works: upstream
  * arms the tooltip on an **idle timer of 10 s** after mount

--- a/tests/tests-automations/regression/core-functionality/project-management/edit-flow-name.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/edit-flow-name.spec.ts
@@ -1,9 +1,9 @@
-import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { renameFlow } from "../../../../helpers/flows/rename-flow";
 import { createFlowFromStarter } from "../../../../helpers/flows/create-flow-from-starter";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { leaveFlowEditor } from "../../../../helpers/flows/leave-flow-editor";
+import { openFlowById } from "../../../../helpers/flows/open-flow-by-id";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 
 // Id of the flow this file creates, so afterEach deletes exactly it — id-scoped,
@@ -15,64 +15,9 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 // the flow (the #1147 lesson).
 const createdFlowIds: string[] = [];
 
-/**
- * The localStorage flag upstream reads to decide whether the assistant
- * onboarding affordances still need to surface (`assistant-discovery-storage.ts`).
- */
-const ASSISTANT_DISCOVERED_KEY = "langflow-assistant-discovered";
-
-/**
- * Seed "the user has already met the assistant" before the first document load.
- *
- * The `assistant-onboarding-tooltip` renders in a Portal over the editor and its
- * overlay intercepts clicks on the canvas AND on the Flow Settings modal — the
- * modal this spec drives on every iteration (#684). Suppressing it up front,
- * rather than dismissing it on entry, is what makes that deterministic:
- * upstream arms the tooltip on an **idle timer of 10 s** after mount
- * (`ONBOARDING_TOOLTIP_DELAY_MS`), so a probe at entry looks 8 s too early and
- * sees nothing, and the tooltip then pops mid-rename with the dialog already
- * open. The flag lives in localStorage, i.e. it is empty in every fresh
- * Playwright context, so every test is exposed on every entry.
- *
- * Registered once per test and applied to every subsequent load, including the
- * two re-entries and the teardown's `goto("/")`.
- */
-test.beforeEach(async ({ page }) => {
-  await page.addInitScript((key) => {
-    try {
-      localStorage.setItem(key, "true");
-    } catch {
-      // Best-effort, exactly as upstream treats it: worst case the tooltip
-      // surfaces and the assertions below fail loudly rather than silently.
-    }
-  }, ASSISTANT_DISCOVERED_KEY);
-});
-
-/**
- * Open a flow addressed by id and wait until the editor is ready to be driven.
- *
- * `page.goto`, not a click on the home grid's `list-card-open-button`: the cards
- * other parallel workers leave behind overlap the target's absolute-inset open
- * button and intercept a hit-tested click, which lands without navigating
- * (#580/#588). A full document load also has no SPA hop left to race.
- *
- * The `menu_bar_display` gate is the write-permission barrier: upstream disables
- * that button while the effective-permissions query is in flight, and everything
- * the test does next mutates the flow (#1005). `renameFlow` carries the same gate
- * internally, so on this file's happy path it resolves instantly — it is kept
- * because this function's contract is "the editor is ready to be DRIVEN", which
- * must not depend on which mutation a caller happens to reach for first.
- */
-async function openFlowById(page: Page, flowId: string): Promise<void> {
-  await page.goto(`/flow/${flowId}`);
-  await expect(page.getByTestId("canvas_controls_dropdown")).toBeVisible({
-    timeout: 30000,
-  });
-  await expect(page.getByTestId("menu_bar_display")).toBeEnabled({
-    timeout: 30000,
-  });
-}
-
+// Entry, onboarding suppression and the write-permission gate all live in the
+// shared helper (#1214) — this file's local copy was the third, and the three had
+// already diverged on the canvas deadline, the overlay handling and the gate.
 test.afterEach(async ({ page, request }) => {
   const ids = createdFlowIds.splice(0);
   if (ids.length === 0) return;

--- a/tests/tests-automations/regression/flow-functionality/flow-lock.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/flow-lock.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from "../../../fixtures/fixtures";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { createFlowFromStarter } from "../../../helpers/flows/create-flow-from-starter";
-import { dismissOnboardingIfPresent } from "../../../helpers/ui/dismiss-onboarding";
+import { openFlowById } from "../../../helpers/flows/open-flow-by-id";
 
 // Ids of the flows this file creates, so afterEach deletes exactly those via the
 // API (id-scoped, #515).
@@ -22,13 +22,10 @@ async function openIsolatedBasicPrompting(page: Page): Promise<string> {
     `flow-lock ${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
   );
   createdFlowIds.push(flowId);
-  await page.goto(`/flow/${flowId}`);
-  await expect(page.getByTestId("canvas_controls_dropdown")).toBeVisible({
-    timeout: 30000,
-  });
-  // The getting-started onboarding popup (also role="dialog") intercepts clicks
-  // and stalls the settings-modal detached-wait — dismiss it up front (#684).
-  await dismissOnboardingIfPresent(page);
+  // Shared entry (#1214): canvas wait, onboarding overlay suppressed before the
+  // load rather than probed for after it, and a gate on the flow being writable —
+  // this spec locks and unlocks through the settings menu, so every step mutates.
+  await openFlowById(page, flowId);
   return flowId;
 }
 

--- a/tests/tests-automations/regression/flow-functionality/lock-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/lock-flow.spec.ts
@@ -12,26 +12,19 @@ import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 import { createFlowFromStarter } from "../../../helpers/flows/create-flow-from-starter";
-import { dismissOnboardingIfPresent } from "../../../helpers/ui/dismiss-onboarding";
+import { openFlowById } from "../../../helpers/flows/open-flow-by-id";
 
 // Id of the flow this file creates, so afterEach deletes exactly it (#515).
 const createdFlowIds: string[] = [];
 
-// Open a flow (freshly created, or a reopen of the same one) addressed by id and
-// wait for the canvas. Reopening by id — not `list-card.first()` — is what makes
-// the persistence checks parallel-safe: `.first()` would open whichever card is
-// on top of the shared home grid, i.e. another worker's flow (#684).
-async function openFlowById(page: Page, flowId: string): Promise<void> {
-  await page.goto(`/flow/${flowId}`);
-  await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
-    timeout: 100000,
-    state: "visible",
-  });
-  await page.waitForTimeout(500);
-  // The onboarding popup overlays the canvas on entry and intercepts the
-  // settings clicks lockFlow/unlockFlow issue — dismiss it first (#684).
-  await dismissOnboardingIfPresent(page);
-}
+// Entry is the shared helper (#1214). The local copy this replaces addressed the
+// flow by id for the same reason — `list-card.first()` opens whichever card is on
+// top of the shared home grid, i.e. another worker's flow (#684) — but carried an
+// unexplained 100 s canvas deadline, an arbitrary `waitForTimeout(500)`, and an
+// onboarding dismiss that is measurably a no-op at entry (upstream arms the
+// tooltip on a 10 s idle timer, so the probe looked ~8 s too early). The helper
+// suppresses the overlay outright and gates on the flow being writable, which
+// this spec needs: every step below mutates the flow through the settings menu.
 
 test.afterEach(async ({ page }) => {
   const ids = createdFlowIds.splice(0);

--- a/tests/tests-automations/regression/flow-functionality/lock-flow.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/lock-flow.spec.ts
@@ -24,7 +24,19 @@ const createdFlowIds: string[] = [];
 // onboarding dismiss that is measurably a no-op at entry (upstream arms the
 // tooltip on a 10 s idle timer, so the probe looked ~8 s too early). The helper
 // suppresses the overlay outright and gates on the flow being writable, which
-// this spec needs: every step below mutates the flow through the settings menu.
+// this spec needs: `expectLockState` opens Flow Settings by clicking `flow_name`,
+// and upstream renders that popover as `open={openSettings && !isReadOnly}`, so a
+// click landing while the permissions query is in flight opens nothing.
+//
+// One consequence to know before triaging a flake here: the two things dropped
+// were doing nothing as OVERLAY handling but were ~2.5 s of settle time by
+// accident (`waitForTimeout(500)` plus the dismiss probe's own
+// `isVisible({ timeout: 2000 })` burning its full budget on an absent element).
+// The writable gate that replaces them normally resolves in milliseconds. The
+// migration ran 12/12 at `--workers=4 --retries=0` on 1.12.0.dev10 and every step
+// below asserts through polling `toHaveCount`, so this is not a known problem —
+// but if this spec starts flaking on the saturated daily, look here first rather
+// than at the canvas deadline.
 
 test.afterEach(async ({ page }) => {
   const ids = createdFlowIds.splice(0);


### PR DESCRIPTION
Closes #1214

## Why

`page.goto('/flow/{id}')` + a canvas wait existed as **three** hand-rolled copies,
and they had already diverged on every axis that matters:

| Spec | Canvas deadline | Onboarding | Writable gate | Extra |
|---|---|---|---|---|
| `lock-flow.spec.ts` | 100 s | `dismissOnboardingIfPresent` | — | `waitForTimeout(500)` |
| `flow-lock.spec.ts` | 30 s | `dismissOnboardingIfPresent` | — | — |
| `edit-flow-name.spec.ts` | 30 s | localStorage seed | ✅ | — |

Same failure mode #1108 documented for id-scoped cleanup: a fix to one copy
reached none of the others. Two of the three fixes lived in exactly one caller,
and one of them was **measurably not working** in the other two.

## What the helper guarantees on return

`tests/helpers/flows/open-flow-by-id.ts` — canvas rendered, onboarding overlay
cannot appear, flow writable (opt-out). Nothing else: dismissing modals,
adjusting the viewport and selecting nodes stay with the caller.

**Write-permission gate (#1005).** Upstream renders `menu_bar_display` as
`disabled={isReadOnly}` with
`useIsFlowReadOnly = Boolean(flowId) && (isLoading || !can(flowId, "write"))`,
which fails **closed** for the whole time `POST /api/v1/authz/me/permissions` is in
flight — so a mutation issued in that window is swallowed with no error. All three
callers mutate the flow they open. Verified non-vacuous: `DashboardWrapperPage`
mounts `PermissionsProvider` around `AppHeader` with `resourceIds: [currentFlow.id]`.

**Onboarding suppression, not dismissal.** The tooltip's overlay intercepts clicks
on the canvas *and* on the Flow Settings modal (#684), and its
`langflow-assistant-discovered` flag lives in localStorage — empty in every fresh
Playwright context. The entry-time `dismissOnboardingIfPresent` the two lock specs
ran is a **no-op**: upstream arms the tooltip on a **10 s idle timer** after mount
(`ONBOARDING_TOOLTIP_DELAY_MS`), so the 2 s probe looked ~8 s early. Measured on
1.12.0.dev10, one run each:

| Seed | tooltip within 20 s |
|---|---|
| present | never appears |
| key renamed | **appears** |

**The canvas deadline is the MAX (100 s), not a middle.** None of the three was
measured — they were inherited — and this wait is a composite (document load +
`GET /flows/{id}` + first render), so no per-request figure bounds it. Shrinking
`lock-flow`'s budget 40 % on an argument buys a red on a saturated daily reported
as "the canvas never rendered". Raising the other two costs only how long a doomed
entry takes to say so, and the two gates are **serial**, so a dead entry spends at
most 130 s — inside the 5-minute per-test timeout, so the failure still lands on
its own assertion instead of as a test-level timeout.

**Helper, not fixture** — including the seed, which must run before the first load.
`tests/fixtures/**` is suite-wide for `impacted-specs-by-import.mjs`, so anything
there resolves to every spec and demands a full `manual.yml` run on each change
(#1054). Same trade `trackCreatedFlows` made. The seed is registered by the entry
itself and is idempotent per page, so a caller cannot forget it and three entries
cost one registration.

## Scope, stated rather than implied

This replaces the **entry-time** probes only. `dismissOnboardingIfPresent` keeps
two callers — `helpers/ui/expand-focused-node.ts` and `ui-ux/langflowShortcuts.spec.ts`
— that probe further into the test, where the 10 s argument does **not**
automatically apply: the timer may well have fired by then. Whether they catch the
tooltip is an open measurement, not a known no-op, and nothing here changes their
behaviour. Recorded in the helper and filed as a follow-up.

**Blast radius:** the helper is imported by exactly 3 specs, all LLM-free, so the
impacted lane selects those 3 and needs no provider sweep.

## Unit lane

10 tests, deliberately honest about what each is worth:

- the **ordering invariant** (seed before goto) is pinned on `navigateToFlow`
  **and** by a structural guard that the module contains exactly one navigation —
  a `goto` added straight into `openFlowById` would satisfy every behavioural test
  while leaving its load unseeded (same spirit as the workflow-shape guard in
  `scripts/wait-for-backend.test.mjs`);
- idempotence per page, and per-page isolation;
- the init script's actual write, and that a throwing `localStorage` does not
  reject the seed;
- the key and deadline assertions are labelled **change-detectors**, not proof the
  suite matches upstream — nothing in this lane reads the Langflow source, and
  adding that dependency would require a checkout CI does not have.

## Validation

Live 1.12.0.dev10. The three specs: **12 passed** at `--workers=4 --retries=0`
after the review fixes (16 before them), zero leaked flows. Among them
`lock-flow.spec.ts` re-enters an **already-locked** flow, which is what verifies
the writable gate is not tripped by lock state — confirmed in the source too:
`disabled` reads `isReadOnly` only, and `locked` gates the assistant and add-note,
nothing in the header.

Gates: `tsc --noEmit` clean, eslint 0 errors on the touched files, `test:units`
**309 pass** (299 → 309), `test:scripts` pass, QA-CHECKLIST guard + coverage guard
pass. No generated block touched; no `@stable` added or removed.

## Review round

An independent review of the staged diff produced five findings; all five are
addressed in this branch:

1. `Last validated` was stale (`1.11.x`) in the two lock docs → bumped to `1.12.x`,
   which the local runs support.
2. The 100 s → 60 s cut was asserted, not evidenced → **reverted to the max**, with
   the composite-wait reasoning and the serial 130 s cost written down.
3. The two remaining `dismissOnboardingIfPresent` callers were unaddressed and
   undocumented → scope now stated in the helper, with the honest caveat that
   mid-test probes are not automatically no-ops. Follow-up filed.
4. The unit test oversold itself → claims corrected, and the one invariant that
   really could regress silently now has a structural guard.
5. `seededPages.add(page)` ran before the `await` → a rejecting `addInitScript`
   would have marked the page seeded forever. Moved after.