### PR TITLE
chore(ci): keep majors out of the dev-dependencies group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -102,9 +102,9 @@ updates:
 
       # TEMPORARY — remove once the lanes run Node 22. @flakiness/playwright 2.x
       # requires `node >= 22.9.0` (1.18.0 accepted `^20.17.0 || >=22.9.0`), while
-      # every workflow that calls actions/setup-node pins "20": pr-validation.yml
-      # (3 jobs), nightly.yml, manual.yml, update-coverage-summary.yml and
-      # adaptive-impacted.yml. The reporter is configured in playwright.config.ts
+      # all 11 `node-version:` pins in this repo say "20": pr-validation.yml (x4),
+      # adaptive-impacted.yml (x3), manual.yml (x2), nightly.yml and
+      # update-coverage-summary.yml. The reporter is configured in playwright.config.ts
       # for every CI=true run, so accepting v2 first risks losing the Flakiness.io
       # upload on those lanes — silently, since a manifest change resolves to zero
       # impacted specs and the PR still looks green. daily-stable.yml is the one

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,8 +42,20 @@ updates:
       # seen would have been six separate PRs, each booting a Langflow container
       # in the PR lane. There is exactly one production dependency (dotenv), so a
       # production group would be a group of one — it is left ungrouped on purpose.
+      #
+      # Minor and patch ONLY. A major does not belong in a group: the group is a
+      # single diff that merges as a unit, so one unreviewable major takes every
+      # reviewable minor down with it. PR #1204 is the measurement — six bumps,
+      # two majors, and all three npm lanes died at `npm ci` before running a
+      # single check, carrying four fine minors (eslint, eslint-plugin-playwright,
+      # typescript-eslint, @types/node) with them. Excluded majors are not
+      # blocked, they are UNBUNDLED: Dependabot proposes each one as its own PR,
+      # where it can be reviewed — or rejected — on its own evidence.
       dev-dependencies:
         dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
         patterns:
           - "*"
 
@@ -65,6 +77,44 @@ updates:
       # and the image tags together.
       - dependency-name: "@playwright/test"
       - dependency-name: "playwright"
+
+      # PERMANENT. typescript 7 is the native (Go) port, and it is not a version
+      # bump for this repo — it is three migrations at once, measured on #1204:
+      #
+      #   1. It has no JS compiler API (`ts.transpileModule` and `ts.createProgram`
+      #      are `undefined`), so ts-node@10 throws on load. That is the
+      #      `test:units` PR gate, `regressions:check`, `check:checklist-coverage`,
+      #      `coverage:summary`, `regressions:summary`, `impacted`,
+      #      `validate:specs` — and `update-coverage-summary.yml` on `main`, which
+      #      is what keeps the QA-CHECKLIST generated blocks in sync.
+      #   2. `tsconfig.json` stops compiling: `TS5108: Option
+      #      'moduleResolution=node10' has been removed`.
+      #   3. typescript-eslint 8.x peers `typescript >=4.8.4 <6.1.0`, so `npm ci`
+      #      cannot even resolve the tree.
+      #
+      # Adopting TS 7 means replacing ts-node, rewriting moduleResolution against
+      # the repo's imports, and waiting for typescript-eslint support. A bot
+      # cannot do that — same reasoning as the @playwright/test pin above. Minor
+      # and patch updates within the current major still flow.
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"
+
+      # TEMPORARY — remove once the lanes run Node 22. @flakiness/playwright 2.x
+      # requires `node >= 22.9.0` (1.18.0 accepted `^20.17.0 || >=22.9.0`), while
+      # every workflow that calls actions/setup-node pins "20": pr-validation.yml
+      # (3 jobs), nightly.yml, manual.yml, update-coverage-summary.yml and
+      # adaptive-impacted.yml. The reporter is configured in playwright.config.ts
+      # for every CI=true run, so accepting v2 first risks losing the Flakiness.io
+      # upload on those lanes — silently, since a manifest change resolves to zero
+      # impacted specs and the PR still looks green. daily-stable.yml is the one
+      # lane unaffected: it runs inside the Playwright image and sets up no Node.
+      #
+      # scripts/dependabot-config.test.mjs fails when the lanes no longer justify
+      # this entry, so the removal condition is enforced rather than remembered.
+      - dependency-name: "@flakiness/playwright"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,7 +30,14 @@ updates:
     # Langflow service container, and the daily is the run that must not contend
     # for the runner.
 
-    open-pull-requests-limit: 3
+    # Raised from 3 with the group's minor/patch limit below: the limit counts the
+    # group PR PLUS every now-unbundled major, and majors are by construction the
+    # slowest to merge, so they hold slots. Today that is already 3 (the group,
+    # @types/node 26, dotenv 17) — at the old limit the next major would have been
+    # suppressed, reintroducing this change's own failure mode (minors held up by a
+    # major) through the limit instead of through the diff. Security-update PRs do
+    # not count against it.
+    open-pull-requests-limit: 6
     labels:
       - "infra"
     commit-message:
@@ -60,6 +67,14 @@ updates:
           - "*"
 
     ignore:
+      # NOTE on everything in this list: `ignore` is one of the options that also
+      # applies to Dependabot SECURITY updates, not just version updates (it carries
+      # the shield icon in the options reference; `allow`'s `update-types` has an
+      # explicit version-updates-only carve-out and `ignore` has no equivalent). So
+      # an advisory whose fixed version falls inside an ignored range produces no PR
+      # at all — the alert simply stays open. That is the cost of every entry here,
+      # and the reason each is scoped as narrowly as its own evidence allows.
+      #
       # @playwright/test and playwright are pinned to an EXACT version on purpose,
       # and the pin is load-bearing across files Dependabot cannot edit. Bumping
       # the runner means 8 coordinated edits across 3 files:
@@ -78,8 +93,10 @@ updates:
       - dependency-name: "@playwright/test"
       - dependency-name: "playwright"
 
-      # PERMANENT. typescript 7 is the native (Go) port, and it is not a version
-      # bump for this repo — it is three migrations at once, measured on #1204:
+      # typescript >= 7 ONLY, and scoped by version range rather than by
+      # `update-types: semver-major` on purpose. TS 7 is the native (Go) port, and it
+      # is not a version bump for this repo — it is three migrations at once, each
+      # measured against 7.0.2 on #1204:
       #
       #   1. It has no JS compiler API (`ts.transpileModule` and `ts.createProgram`
       #      are `undefined`), so ts-node@10 throws on load. That is the
@@ -93,28 +110,31 @@ updates:
       #      cannot even resolve the tree.
       #
       # Adopting TS 7 means replacing ts-node, rewriting moduleResolution against
-      # the repo's imports, and waiting for typescript-eslint support. A bot
-      # cannot do that — same reasoning as the @playwright/test pin above. Minor
-      # and patch updates within the current major still flow.
-      - dependency-name: "typescript"
-        update-types:
-          - "version-update:semver-major"
-
-      # TEMPORARY — remove once the lanes run Node 22. @flakiness/playwright 2.x
-      # requires `node >= 22.9.0` (1.18.0 accepted `^20.17.0 || >=22.9.0`), while
-      # all 11 `node-version:` pins in this repo say "20": pr-validation.yml (x4),
-      # adaptive-impacted.yml (x3), manual.yml (x2), nightly.yml and
-      # update-coverage-summary.yml. The reporter is configured in playwright.config.ts
-      # for every CI=true run, so accepting v2 first risks losing the Flakiness.io
-      # upload on those lanes — silently, since a manifest change resolves to zero
-      # impacted specs and the PR still looks green. daily-stable.yml is the one
-      # lane unaffected: it runs inside the Playwright image and sets up no Node.
+      # the repo's imports, and waiting for typescript-eslint support. A bot cannot
+      # do that — same reasoning as the @playwright/test pin above.
       #
-      # scripts/dependabot-config.test.mjs fails when the lanes no longer justify
-      # this entry, so the removal condition is enforced rather than remembered.
-      - dependency-name: "@flakiness/playwright"
-        update-types:
-          - "version-update:semver-major"
+      # None of it is true of TS 6, and a `semver-major` scope would have blocked TS 6
+      # while citing those three reasons. Measured against 6.0.3, the version
+      # Dependabot is proposing today (#1228): the JS compiler API is intact and
+      # ts-node runs; the same tsconfig yields `TS5107 ... is deprecated and will stop
+      # functioning in TypeScript 7.0`, silenced by one `ignoreDeprecations: "6.0"`
+      # line; and typescript-eslint 8.65.0's peer range (`<6.1.0`) admits it. So TS 6
+      # is deliberately let through — as its own PR, since the group takes no majors —
+      # for a reviewer to decide on. Blocking a major nobody has evidence against is
+      # how a rationale rots into a rule.
+      - dependency-name: "typescript"
+        versions:
+          - ">=7"
+
+      # There is deliberately NO entry for @flakiness/playwright. 2.0.0 dropped Node
+      # 20 (`engines` went to `>=22.9.0`) while every lane here pins "20" — but 2.0.1,
+      # `latest` since 2026-07-30, restored `^20.17.0 || >=22.9.0`. An ignore written
+      # against 2.0.0 would have blocked a release that was already compatible, and a
+      # guard tying its removal to the Node pins would have failed the PR that removed
+      # it. v2 arrives as its own PR, which is where its two real breaking changes
+      # (the dropped `flakiness-playwright-shard` bin, unused here — sharding is
+      # scripts/partition-shards.mjs; and `shardBalancing` needing Playwright 1.62+,
+      # also unused) can be checked against what this repo does.
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/scripts/dependabot-config.test.mjs
+++ b/scripts/dependabot-config.test.mjs
@@ -4,31 +4,32 @@
 // artifact IS the declarative config, so these are structural guards over its text,
 // in the style of scripts/manual-dispatch-inputs.test.mjs. Text is the available
 // instrument: no YAML parser is declared in package.json, and adding a dependency
-// to lint one 90-line config is a worse trade than the parsing below.
+// to lint one 100-line config is a worse trade than the parsing below.
 //
 // CLAUDE.md is right that a guard pinning a SPELLING does not pin a BEHAVIOUR
 // (#1226), and the first version of this file proved the point: `- major` without
-// quotes, and a commented-out `# node-version: "20"`, both walked straight past it
-// while it reported 5/5. So nothing here matches a literal any more. Values are
-// extracted (quotes stripped, block and flow sequences alike) and compared as sets,
-// and every scan is anchored to a real YAML key so a comment cannot impersonate one.
+// quotes walked straight past it while it reported 5/5. So nothing here matches a
+// literal. Values are extracted (quotes stripped, block and flow sequences alike)
+// and compared as sets or as numbers.
 //
-// Two things this file exists to catch, both of which fail SILENTLY:
+// What is worth guarding, and what is not, moved once already. The first version
+// tied the @flakiness/playwright ignore to the repo's `node-version:` pins, on the
+// premise that 2.x required Node >= 22.9.0 — which review showed was false by the
+// time it was written (2.0.1, `latest` since 2026-07-30, restored
+// `^20.17.0 || >=22.9.0`). A guard enforcing a condition that is not the real one is
+// worse than no guard: it would have failed every PR that removed the entry, which
+// was the correct change. The entry and its guard are both gone; the lesson kept is
+// that a guard must encode the reason, not a proxy for it.
+//
+// So the two things pinned here are the two whose failure is SILENT:
 //
 //   1. Majors back inside the `dev-dependencies` group. The symptom is not a red
 //      guard, it is a grouped PR that dies at `npm ci` and takes its reviewable
 //      minors with it (PR #1204: six bumps, two majors, four fine minors that could
 //      not be verified because the install never completed).
-//   2. The TEMPORARY @flakiness/playwright ignore outliving its condition. It exists
-//      only because the lanes pin Node 20 while v2.x requires >= 22.9.0. A comment
-//      cannot enforce its own removal, so the last test reads the actual pins and
-//      fails when they stop justifying the entry.
-//
-// Where a pin cannot be read (an expression, a `node-version-file:`), the guard
-// FAILS naming the file and line rather than dropping it from the minimum — the
-// undecidable-is-not-clean rule this repo applies in provider-dependent-specs.mjs
-// and #1012. Silently ignoring an unreadable pin is how the temporary ignore would
-// get deleted while a lane is still on Node 20.
+//   2. An `ignore` widening past its own rationale. `ignore` suppresses SECURITY
+//      updates too, so an over-broad entry does not merely delay a bump — it can
+//      leave an advisory with no PR at all, and nothing about that is visible.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -39,6 +40,7 @@ const REPO_ROOT = path.resolve(import.meta.dirname, "..");
 const CONFIG_PATH = ".github/dependabot.yml";
 const CONFIG = fs.readFileSync(path.join(REPO_ROOT, CONFIG_PATH), "utf8");
 const LINES = CONFIG.split("\n");
+const PKG = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, "package.json"), "utf8"));
 
 const indentOf = (line) => line.search(/\S/);
 const unquote = (s) => s.trim().replace(/^["']|["']$/g, "");
@@ -136,24 +138,59 @@ test("the dev-dependencies group takes minor and patch only", () => {
   assert.deepEqual(types, new Set(["minor", "patch"]));
 });
 
-// ── the two ignores, and what distinguishes them ────────────────────────────
+// ── the typescript ignore stays as narrow as its evidence ───────────────────
 
-for (const name of ["typescript", "@flakiness/playwright"]) {
-  test(`the ${name} ignore is scoped to majors, and to nothing else`, () => {
-    const entry = entryFor(name);
+test("the typescript ignore blocks 7.x and up, not every major", () => {
+  const entry = entryFor("typescript");
+  const versions = listValues(entry.body, "versions");
 
-    assert.deepEqual(listValues(entry.body, "update-types"), new Set(["version-update:semver-major"]));
-    // `versions:` is the other key that can freeze a dependency, and it would do so
-    // without touching update-types — leaving the entry looking correctly scoped
-    // while security patches inside the current major stop arriving.
-    assert.equal(listValues(entry.body, "versions"), null, `${name} carries a versions: range — patches inside the current major would stop`);
+  assert.ok(versions, "the typescript ignore lost its versions: range");
+  // `update-types: semver-major` is the tempting shorthand and it is wrong here: it
+  // would also block TS 6, against which this repo has no evidence — the JS compiler
+  // API is intact there, ts-node runs, and typescript-eslint's peer range admits it.
+  assert.equal(
+    listValues(entry.body, "update-types"),
+    null,
+    "scoped by update-types instead of a version range — that blocks TS 6 too, which the file's own rationale does not justify",
+  );
+
+  const bounds = [...versions].map((v) => {
+    const m = v.match(/^>=?\s*(\d+)/);
+    assert.ok(m, `\`${v}\` is not a lower-bound range this guard can read`);
+    return Number(m[1]);
   });
-}
+  assert.deepEqual(bounds, [7], "the ignore no longer starts at the major the rationale is about");
+});
+
+test("no ignore range can block the major this repo is actually on", () => {
+  // The failure this catches: package.json moves to a new major while an ignore
+  // still starts at or below it, so the line the repo depends on stops receiving
+  // updates — including security ones — with the config looking untouched.
+  for (const entry of ENTRIES) {
+    const versions = listValues(entry.body, "versions");
+    if (!versions) continue;
+
+    const declared = PKG.devDependencies?.[entry.name] ?? PKG.dependencies?.[entry.name];
+    assert.ok(declared, `${CONFIG_PATH} ignores "${entry.name}", which package.json does not declare`);
+    const onMajor = Number(declared.match(/(\d+)/)[1]);
+
+    for (const v of versions) {
+      const lower = Number(v.match(/^>=?\s*(\d+)/)[1]);
+      assert.ok(
+        lower > onMajor,
+        `the ignore for "${entry.name}" starts at ${lower}, but package.json is on ${onMajor} — it would block the current line`,
+      );
+    }
+  }
+});
+
+// ── every entry says why ────────────────────────────────────────────────────
 
 test("each ignore entry carries a rationale in the file", () => {
   // A Dependabot ignore is invisible at the point it acts: the PR that would have
-  // existed simply never appears. Whoever finds that surprising has only this file
-  // to read, so an entry with no comment above it is a defect.
+  // existed simply never appears, and for a security advisory that means an alert
+  // with nothing attached to it. Whoever finds that surprising has only this file to
+  // read, so an entry with no comment above it is a defect.
   //
   // One comment may cover a run of consecutive entries — @playwright/test and
   // playwright share theirs. The walk-up therefore skips anything indented deeper
@@ -172,84 +209,5 @@ test("each ignore entry carries a rationale in the file", () => {
       break;
     }
     assert.ok(j >= 0 && LINES[j].trim().startsWith("#"), `no rationale comment above the ignore entry for "${entry.name}"`);
-  }
-});
-
-// ── the temporary ignore vs. the condition that removes it ──────────────────
-
-/** Every .yml/.yaml under .github, at any depth. */
-function ciFiles(dir = path.join(REPO_ROOT, ".github")) {
-  const out = [];
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) out.push(...ciFiles(full));
-    else if (/\.ya?ml$/.test(entry.name)) out.push(full);
-  }
-  return out;
-}
-
-/**
- * Node pins across CI, as { satisfied, undecidable }. A pin satisfies the
- * requirement when it is >= 22.9.0 — the floor @flakiness/playwright 2.x declares.
- * A bare major ("22") is treated as satisfying: setup-node resolves it to the
- * latest 22.x, which is past 22.9.0.
- */
-function readNodePins() {
-  const satisfied = [];
-  const undecidable = [];
-
-  for (const file of ciFiles()) {
-    const rel = path.relative(REPO_ROOT, file);
-    fs.readFileSync(file, "utf8")
-      .split("\n")
-      .forEach((line, i) => {
-        // Anchored at the start of the line: a `#` before the key kills the match,
-        // so a commented-out pin and prose mentioning one are both excluded.
-        const m = line.match(/^\s*(node-version|node-version-file):\s*(.+)$/);
-        if (!m) return;
-        const where = `${rel}:${i + 1}`;
-        if (m[1] === "node-version-file") {
-          undecidable.push(`${where} — pinned via node-version-file, which this guard cannot resolve`);
-          return;
-        }
-        const value = unquote(m[2].replace(/\s+#.*$/, ""));
-        const parsed = value.match(/^(\d+)(?:\.(\d+))?/);
-        if (!parsed) {
-          undecidable.push(`${where} — \`${value}\` is not a literal version`);
-          return;
-        }
-        const [major, minor] = [Number(parsed[1]), parsed[2] === undefined ? null : Number(parsed[2])];
-        const ok = major > 22 || (major === 22 && (minor === null || minor >= 9));
-        satisfied.push({ where, value, ok });
-      });
-  }
-
-  return { satisfied, undecidable };
-}
-
-test("the @flakiness/playwright ignore is removed once the lanes leave Node 20", () => {
-  const { satisfied, undecidable } = readNodePins();
-
-  assert.ok(satisfied.length > 0 || undecidable.length > 0, "no `node-version:` pin found anywhere under .github — this guard would pass vacuously");
-  // Fail loud rather than quietly shrinking the sample: an unreadable pin dropped
-  // from the minimum is how this guard would tell you to delete an ignore that a
-  // Node 20 lane still needs.
-  assert.deepEqual(undecidable, [], `unreadable Node pin(s); teach this guard to read them before trusting its verdict:\n  ${undecidable.join("\n  ")}`);
-
-  const behind = satisfied.filter((p) => !p.ok);
-  // Read from the parsed entries, not a substring: a commented-out entry is not an
-  // ignore, and must not read as one.
-  const ignored = ENTRIES.some((e) => e.name === "@flakiness/playwright");
-
-  if (behind.length > 0) {
-    assert.ok(
-      ignored,
-      `${behind.length} lane(s) pin Node below 22.9.0 (e.g. ${behind[0].where} → ${behind[0].value}), so @flakiness/playwright 2.x (engines: >=22.9.0) must stay ignored`,
-    );
-  } else {
-    assert.ok(
-      !ignored,
-      `every Node pin is now >= 22.9.0 — drop the TEMPORARY @flakiness/playwright ignore from ${CONFIG_PATH}`,
-    );
   }
 });

--- a/scripts/dependabot-config.test.mjs
+++ b/scripts/dependabot-config.test.mjs
@@ -1,0 +1,158 @@
+// Guards over .github/dependabot.yml (#1229).
+//
+// Unlike every other test in this directory, there is no script here whose output
+// can be asserted — the artifact IS the declarative config, so these are structural
+// guards over its text, in the style of the wait-for-backend adoption guard. That
+// makes them spelling guards, and CLAUDE.md is right that a spelling guard does not
+// pin a behaviour (#1226). They are still worth their line count, because both
+// things they pin fail SILENTLY:
+//
+//   1. Majors back inside the `dev-dependencies` group. The symptom is not a red
+//      guard, it is a grouped PR that dies at `npm ci` and takes its reviewable
+//      minors down with it (PR #1204: six bumps, two majors, four fine minors
+//      unverifiable because the install never completed).
+//   2. The TEMPORARY @flakiness/playwright ignore outliving its own condition. It
+//      exists only because every lane pins Node 20 while v2.x requires >= 22.9.0.
+//      A comment cannot enforce its own removal — so the third test reads the
+//      actual `node-version:` pins and fails when they no longer justify the entry.
+//      That is the test that turns "remove this later" into something CI can say.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "..");
+const CONFIG = fs.readFileSync(path.join(REPO_ROOT, ".github/dependabot.yml"), "utf8");
+
+/**
+ * Return the YAML block introduced by the line matching `header`, i.e. every
+ * following line indented deeper than the header itself. Comment and blank lines
+ * are kept — an entry's rationale lives in them.
+ */
+function blockUnder(text, header) {
+  const lines = text.split("\n");
+  const start = lines.findIndex((l) => l.includes(header));
+  assert.ok(start > -1, `no line matching \`${header}\` in .github/dependabot.yml`);
+  const indent = lines[start].search(/\S/);
+  const out = [];
+  for (const line of lines.slice(start + 1)) {
+    if (line.trim() === "") {
+      out.push(line);
+      continue;
+    }
+    if (line.search(/\S/) <= indent) break;
+    out.push(line);
+  }
+  return out.join("\n");
+}
+
+/** The block of a single `ignore:` entry, from its `- dependency-name:` line. */
+function ignoreEntry(name) {
+  const lines = CONFIG.split("\n");
+  const start = lines.findIndex((l) => l.trim() === `- dependency-name: "${name}"`);
+  assert.ok(start > -1, `no ignore entry for "${name}"`);
+  const indent = lines[start].search(/\S/);
+  const out = [lines[start]];
+  for (const line of lines.slice(start + 1)) {
+    if (line.trim() === "") break;
+    // A sibling entry starts at the same indent with its own `- `.
+    if (line.search(/\S/) <= indent) break;
+    out.push(line);
+  }
+  return out.join("\n");
+}
+
+// ── the group excludes majors ───────────────────────────────────────────────
+
+test("the dev-dependencies group takes minor and patch only", () => {
+  const group = blockUnder(CONFIG, "dev-dependencies:");
+
+  assert.match(group, /update-types:/, "the group has no update-types limit — majors ride in with the minors (#1204)");
+  assert.match(group, /^\s+- "minor"$/m);
+  assert.match(group, /^\s+- "patch"$/m);
+  // "major" must not appear as a listed update-type. Checked as a list item rather
+  // than a substring so the word may still be used in the block's rationale.
+  assert.doesNotMatch(group, /^\s+- "major"$/m, "majors are back in the group");
+});
+
+// ── the two ignores, and what distinguishes them ────────────────────────────
+
+test("typescript majors are ignored, minors and patches still flow", () => {
+  const entry = ignoreEntry("typescript");
+  assert.match(entry, /version-update:semver-major/);
+  // Scoping to majors is the whole point: an unscoped entry would freeze the 5.x
+  // line too, and a security patch inside the current major would stop arriving.
+  assert.doesNotMatch(entry, /version-update:semver-(minor|patch)/);
+});
+
+test("the @flakiness/playwright ignore is scoped to majors", () => {
+  const entry = ignoreEntry("@flakiness/playwright");
+  assert.match(entry, /version-update:semver-major/);
+  assert.doesNotMatch(entry, /version-update:semver-(minor|patch)/);
+});
+
+test("each ignore entry carries a rationale in the file", () => {
+  // Dependabot ignores are invisible at the point they act: the PR that would have
+  // existed simply never appears. Whoever finds that surprising has only this file
+  // to read, so an entry with no comment above it is a defect.
+  const lines = CONFIG.split("\n");
+  // One comment may cover a run of consecutive entries — @playwright/test and
+  // playwright share theirs, and splitting it would duplicate the same 15 lines.
+  // So walk up past sibling entry lines and require a comment before the run.
+  const partOfEntry = (l) =>
+    l.trim().startsWith("- dependency-name:") ||
+    l.trim().startsWith("update-types:") ||
+    l.trim().startsWith('- "version-update:');
+
+  for (const [i, line] of lines.entries()) {
+    if (!line.trim().startsWith("- dependency-name:")) continue;
+    let j = i - 1;
+    while (j >= 0 && (lines[j].trim() === "" || partOfEntry(lines[j]))) j--;
+    assert.ok(j >= 0 && lines[j].trim().startsWith("#"), `no rationale comment above ${line.trim()}`);
+  }
+});
+
+// ── the temporary ignore vs. the condition that removes it ──────────────────
+
+test("the @flakiness/playwright ignore is removed once the lanes leave Node 20", () => {
+  // @flakiness/playwright 2.x declares `engines.node: ">=22.9.0"`; 1.18.0 accepted
+  // `^20.17.0 || >=22.9.0`. The ignore is justified by, and only by, the lanes still
+  // pinning Node 20 — so read the pins rather than trusting the comment.
+  const dirs = [".github/workflows", ".github/actions"];
+  const files = [];
+  for (const dir of dirs) {
+    const root = path.join(REPO_ROOT, dir);
+    for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+      const full = path.join(root, entry.name);
+      if (entry.isDirectory()) {
+        files.push(...fs.readdirSync(full).filter((f) => f.endsWith(".yml")).map((f) => path.join(full, f)));
+      } else if (entry.name.endsWith(".yml")) {
+        files.push(full);
+      }
+    }
+  }
+
+  const pins = files
+    .flatMap((f) => fs.readFileSync(f, "utf8").split("\n"))
+    .map((l) => l.match(/node-version:\s*"?(\d+)/))
+    .filter(Boolean)
+    .map((m) => Number(m[1]));
+
+  assert.ok(pins.length > 0, "no `node-version:` pin found — this guard would pass vacuously");
+
+  const ignored = CONFIG.includes('- dependency-name: "@flakiness/playwright"');
+  const stillOnNode20 = Math.min(...pins) < 22;
+
+  if (stillOnNode20) {
+    assert.ok(
+      ignored,
+      `a lane still pins Node ${Math.min(...pins)}, so @flakiness/playwright 2.x (engines: >=22.9.0) must stay ignored`,
+    );
+  } else {
+    assert.ok(
+      !ignored,
+      "every lane now runs Node >= 22 — drop the TEMPORARY @flakiness/playwright ignore from .github/dependabot.yml",
+    );
+  }
+});

--- a/scripts/dependabot-config.test.mjs
+++ b/scripts/dependabot-config.test.mjs
@@ -1,21 +1,34 @@
 // Guards over .github/dependabot.yml (#1229).
 //
-// Unlike every other test in this directory, there is no script here whose output
-// can be asserted — the artifact IS the declarative config, so these are structural
-// guards over its text, in the style of the wait-for-backend adoption guard. That
-// makes them spelling guards, and CLAUDE.md is right that a spelling guard does not
-// pin a behaviour (#1226). They are still worth their line count, because both
-// things they pin fail SILENTLY:
+// Unlike most tests here there is no script whose output can be asserted — the
+// artifact IS the declarative config, so these are structural guards over its text,
+// in the style of scripts/manual-dispatch-inputs.test.mjs. Text is the available
+// instrument: no YAML parser is declared in package.json, and adding a dependency
+// to lint one 90-line config is a worse trade than the parsing below.
+//
+// CLAUDE.md is right that a guard pinning a SPELLING does not pin a BEHAVIOUR
+// (#1226), and the first version of this file proved the point: `- major` without
+// quotes, and a commented-out `# node-version: "20"`, both walked straight past it
+// while it reported 5/5. So nothing here matches a literal any more. Values are
+// extracted (quotes stripped, block and flow sequences alike) and compared as sets,
+// and every scan is anchored to a real YAML key so a comment cannot impersonate one.
+//
+// Two things this file exists to catch, both of which fail SILENTLY:
 //
 //   1. Majors back inside the `dev-dependencies` group. The symptom is not a red
 //      guard, it is a grouped PR that dies at `npm ci` and takes its reviewable
-//      minors down with it (PR #1204: six bumps, two majors, four fine minors
-//      unverifiable because the install never completed).
-//   2. The TEMPORARY @flakiness/playwright ignore outliving its own condition. It
-//      exists only because every lane pins Node 20 while v2.x requires >= 22.9.0.
-//      A comment cannot enforce its own removal — so the third test reads the
-//      actual `node-version:` pins and fails when they no longer justify the entry.
-//      That is the test that turns "remove this later" into something CI can say.
+//      minors with it (PR #1204: six bumps, two majors, four fine minors that could
+//      not be verified because the install never completed).
+//   2. The TEMPORARY @flakiness/playwright ignore outliving its condition. It exists
+//      only because the lanes pin Node 20 while v2.x requires >= 22.9.0. A comment
+//      cannot enforce its own removal, so the last test reads the actual pins and
+//      fails when they stop justifying the entry.
+//
+// Where a pin cannot be read (an expression, a `node-version-file:`), the guard
+// FAILS naming the file and line rather than dropping it from the minimum — the
+// undecidable-is-not-clean rule this repo applies in provider-dependent-specs.mjs
+// and #1012. Silently ignoring an unreadable pin is how the temporary ignore would
+// get deleted while a lane is still on Node 20.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -23,136 +36,220 @@ import fs from "node:fs";
 import path from "node:path";
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "..");
-const CONFIG = fs.readFileSync(path.join(REPO_ROOT, ".github/dependabot.yml"), "utf8");
+const CONFIG_PATH = ".github/dependabot.yml";
+const CONFIG = fs.readFileSync(path.join(REPO_ROOT, CONFIG_PATH), "utf8");
+const LINES = CONFIG.split("\n");
+
+const indentOf = (line) => line.search(/\S/);
+const unquote = (s) => s.trim().replace(/^["']|["']$/g, "");
 
 /**
- * Return the YAML block introduced by the line matching `header`, i.e. every
- * following line indented deeper than the header itself. Comment and blank lines
- * are kept — an entry's rationale lives in them.
+ * Every line indented deeper than the line at `start` (blank lines included — a
+ * blank line inside a block is legal YAML and must not truncate it).
  */
-function blockUnder(text, header) {
-  const lines = text.split("\n");
-  const start = lines.findIndex((l) => l.includes(header));
-  assert.ok(start > -1, `no line matching \`${header}\` in .github/dependabot.yml`);
-  const indent = lines[start].search(/\S/);
+function blockAt(lines, start) {
+  const indent = indentOf(lines[start]);
   const out = [];
   for (const line of lines.slice(start + 1)) {
     if (line.trim() === "") {
       out.push(line);
       continue;
     }
-    if (line.search(/\S/) <= indent) break;
+    if (indentOf(line) <= indent) break;
     out.push(line);
   }
-  return out.join("\n");
+  return out;
 }
 
-/** The block of a single `ignore:` entry, from its `- dependency-name:` line. */
-function ignoreEntry(name) {
-  const lines = CONFIG.split("\n");
-  const start = lines.findIndex((l) => l.trim() === `- dependency-name: "${name}"`);
-  assert.ok(start > -1, `no ignore entry for "${name}"`);
-  const indent = lines[start].search(/\S/);
-  const out = [lines[start]];
-  for (const line of lines.slice(start + 1)) {
-    if (line.trim() === "") break;
-    // A sibling entry starts at the same indent with its own `- `.
-    if (line.search(/\S/) <= indent) break;
-    out.push(line);
+function blockUnder(header) {
+  const start = LINES.findIndex((l) => l.includes(header));
+  assert.ok(start > -1, `no line matching \`${header}\` in ${CONFIG_PATH}`);
+  return blockAt(LINES, start);
+}
+
+/**
+ * The values of a YAML list `key:` inside `lines`, as a Set of unquoted strings.
+ * Handles both a block sequence and the flow form `key: ["a", "b"]`; returns null
+ * when the key is absent, so "missing" and "empty" stay distinguishable.
+ */
+function listValues(lines, key) {
+  const at = lines.findIndex((l) => new RegExp(`^\\s*${key}:`).test(l));
+  if (at === -1) return null;
+
+  const inline = lines[at].slice(lines[at].indexOf(":") + 1).trim();
+  if (inline.startsWith("[")) {
+    return new Set(
+      inline
+        .replace(/^\[|\]$/g, "")
+        .split(",")
+        .map(unquote)
+        .filter(Boolean),
+    );
   }
-  return out.join("\n");
+
+  return new Set(
+    blockAt(lines, at)
+      .filter((l) => l.trim().startsWith("- "))
+      .map((l) => unquote(l.trim().slice(2))),
+  );
+}
+
+/**
+ * The `ignore:` entries, parsed rather than string-matched: an entry is a
+ * `- dependency-name:` line plus everything indented under it. Quoting of the name
+ * is normalised, so an unquoted entry is found and a duplicate is detectable.
+ */
+function ignoreEntries() {
+  const entries = [];
+  for (const [i, line] of LINES.entries()) {
+    const m = line.match(/^(\s*)- dependency-name:\s*(.+)$/);
+    if (!m) continue;
+    entries.push({
+      name: unquote(m[2].replace(/\s+#.*$/, "")),
+      line: i,
+      indent: m[1].length,
+      body: blockAt(LINES, i),
+    });
+  }
+  return entries;
+}
+
+const ENTRIES = ignoreEntries();
+
+function entryFor(name) {
+  const found = ENTRIES.filter((e) => e.name === name);
+  // Exactly one: a second, wider entry for the same package later in the list would
+  // silently take effect while a positional lookup kept reading the first.
+  assert.equal(found.length, 1, `expected exactly 1 ignore entry for "${name}", found ${found.length}`);
+  return found[0];
 }
 
 // ── the group excludes majors ───────────────────────────────────────────────
 
 test("the dev-dependencies group takes minor and patch only", () => {
-  const group = blockUnder(CONFIG, "dev-dependencies:");
+  const group = blockUnder("dev-dependencies:");
+  const types = listValues(group, "update-types");
 
-  assert.match(group, /update-types:/, "the group has no update-types limit — majors ride in with the minors (#1204)");
-  assert.match(group, /^\s+- "minor"$/m);
-  assert.match(group, /^\s+- "patch"$/m);
-  // "major" must not appear as a listed update-type. Checked as a list item rather
-  // than a substring so the word may still be used in the block's rationale.
-  assert.doesNotMatch(group, /^\s+- "major"$/m, "majors are back in the group");
+  assert.ok(types, "the group has no update-types limit — majors ride in with the minors (#1204)");
+  // Compared as a set, so `- major` in any quoting fails and a pure reformat
+  // (flow style, unquoted items) does not.
+  assert.deepEqual(types, new Set(["minor", "patch"]));
 });
 
 // ── the two ignores, and what distinguishes them ────────────────────────────
 
-test("typescript majors are ignored, minors and patches still flow", () => {
-  const entry = ignoreEntry("typescript");
-  assert.match(entry, /version-update:semver-major/);
-  // Scoping to majors is the whole point: an unscoped entry would freeze the 5.x
-  // line too, and a security patch inside the current major would stop arriving.
-  assert.doesNotMatch(entry, /version-update:semver-(minor|patch)/);
-});
+for (const name of ["typescript", "@flakiness/playwright"]) {
+  test(`the ${name} ignore is scoped to majors, and to nothing else`, () => {
+    const entry = entryFor(name);
 
-test("the @flakiness/playwright ignore is scoped to majors", () => {
-  const entry = ignoreEntry("@flakiness/playwright");
-  assert.match(entry, /version-update:semver-major/);
-  assert.doesNotMatch(entry, /version-update:semver-(minor|patch)/);
-});
+    assert.deepEqual(listValues(entry.body, "update-types"), new Set(["version-update:semver-major"]));
+    // `versions:` is the other key that can freeze a dependency, and it would do so
+    // without touching update-types — leaving the entry looking correctly scoped
+    // while security patches inside the current major stop arriving.
+    assert.equal(listValues(entry.body, "versions"), null, `${name} carries a versions: range — patches inside the current major would stop`);
+  });
+}
 
 test("each ignore entry carries a rationale in the file", () => {
-  // Dependabot ignores are invisible at the point they act: the PR that would have
+  // A Dependabot ignore is invisible at the point it acts: the PR that would have
   // existed simply never appears. Whoever finds that surprising has only this file
   // to read, so an entry with no comment above it is a defect.
-  const lines = CONFIG.split("\n");
+  //
   // One comment may cover a run of consecutive entries — @playwright/test and
-  // playwright share theirs, and splitting it would duplicate the same 15 lines.
-  // So walk up past sibling entry lines and require a comment before the run.
-  const partOfEntry = (l) =>
-    l.trim().startsWith("- dependency-name:") ||
-    l.trim().startsWith("update-types:") ||
-    l.trim().startsWith('- "version-update:');
-
-  for (const [i, line] of lines.entries()) {
-    if (!line.trim().startsWith("- dependency-name:")) continue;
-    let j = i - 1;
-    while (j >= 0 && (lines[j].trim() === "" || partOfEntry(lines[j]))) j--;
-    assert.ok(j >= 0 && lines[j].trim().startsWith("#"), `no rationale comment above ${line.trim()}`);
+  // playwright share theirs. The walk-up therefore skips anything indented deeper
+  // than the entry (whatever keys a future entry gains) plus sibling entry lines,
+  // rather than enumerating the keys known today.
+  for (const entry of ENTRIES) {
+    let j = entry.line - 1;
+    while (j >= 0) {
+      const line = LINES[j];
+      const isDeeper = line.trim() !== "" && indentOf(line) > entry.indent;
+      const isSibling = /^\s*- dependency-name:/.test(line) && indentOf(line) === entry.indent;
+      if (line.trim() === "" || isDeeper || isSibling) {
+        j--;
+        continue;
+      }
+      break;
+    }
+    assert.ok(j >= 0 && LINES[j].trim().startsWith("#"), `no rationale comment above the ignore entry for "${entry.name}"`);
   }
 });
 
 // ── the temporary ignore vs. the condition that removes it ──────────────────
 
-test("the @flakiness/playwright ignore is removed once the lanes leave Node 20", () => {
-  // @flakiness/playwright 2.x declares `engines.node: ">=22.9.0"`; 1.18.0 accepted
-  // `^20.17.0 || >=22.9.0`. The ignore is justified by, and only by, the lanes still
-  // pinning Node 20 — so read the pins rather than trusting the comment.
-  const dirs = [".github/workflows", ".github/actions"];
-  const files = [];
-  for (const dir of dirs) {
-    const root = path.join(REPO_ROOT, dir);
-    for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
-      const full = path.join(root, entry.name);
-      if (entry.isDirectory()) {
-        files.push(...fs.readdirSync(full).filter((f) => f.endsWith(".yml")).map((f) => path.join(full, f)));
-      } else if (entry.name.endsWith(".yml")) {
-        files.push(full);
-      }
-    }
+/** Every .yml/.yaml under .github, at any depth. */
+function ciFiles(dir = path.join(REPO_ROOT, ".github")) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...ciFiles(full));
+    else if (/\.ya?ml$/.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Node pins across CI, as { satisfied, undecidable }. A pin satisfies the
+ * requirement when it is >= 22.9.0 — the floor @flakiness/playwright 2.x declares.
+ * A bare major ("22") is treated as satisfying: setup-node resolves it to the
+ * latest 22.x, which is past 22.9.0.
+ */
+function readNodePins() {
+  const satisfied = [];
+  const undecidable = [];
+
+  for (const file of ciFiles()) {
+    const rel = path.relative(REPO_ROOT, file);
+    fs.readFileSync(file, "utf8")
+      .split("\n")
+      .forEach((line, i) => {
+        // Anchored at the start of the line: a `#` before the key kills the match,
+        // so a commented-out pin and prose mentioning one are both excluded.
+        const m = line.match(/^\s*(node-version|node-version-file):\s*(.+)$/);
+        if (!m) return;
+        const where = `${rel}:${i + 1}`;
+        if (m[1] === "node-version-file") {
+          undecidable.push(`${where} — pinned via node-version-file, which this guard cannot resolve`);
+          return;
+        }
+        const value = unquote(m[2].replace(/\s+#.*$/, ""));
+        const parsed = value.match(/^(\d+)(?:\.(\d+))?/);
+        if (!parsed) {
+          undecidable.push(`${where} — \`${value}\` is not a literal version`);
+          return;
+        }
+        const [major, minor] = [Number(parsed[1]), parsed[2] === undefined ? null : Number(parsed[2])];
+        const ok = major > 22 || (major === 22 && (minor === null || minor >= 9));
+        satisfied.push({ where, value, ok });
+      });
   }
 
-  const pins = files
-    .flatMap((f) => fs.readFileSync(f, "utf8").split("\n"))
-    .map((l) => l.match(/node-version:\s*"?(\d+)/))
-    .filter(Boolean)
-    .map((m) => Number(m[1]));
+  return { satisfied, undecidable };
+}
 
-  assert.ok(pins.length > 0, "no `node-version:` pin found — this guard would pass vacuously");
+test("the @flakiness/playwright ignore is removed once the lanes leave Node 20", () => {
+  const { satisfied, undecidable } = readNodePins();
 
-  const ignored = CONFIG.includes('- dependency-name: "@flakiness/playwright"');
-  const stillOnNode20 = Math.min(...pins) < 22;
+  assert.ok(satisfied.length > 0 || undecidable.length > 0, "no `node-version:` pin found anywhere under .github — this guard would pass vacuously");
+  // Fail loud rather than quietly shrinking the sample: an unreadable pin dropped
+  // from the minimum is how this guard would tell you to delete an ignore that a
+  // Node 20 lane still needs.
+  assert.deepEqual(undecidable, [], `unreadable Node pin(s); teach this guard to read them before trusting its verdict:\n  ${undecidable.join("\n  ")}`);
 
-  if (stillOnNode20) {
+  const behind = satisfied.filter((p) => !p.ok);
+  // Read from the parsed entries, not a substring: a commented-out entry is not an
+  // ignore, and must not read as one.
+  const ignored = ENTRIES.some((e) => e.name === "@flakiness/playwright");
+
+  if (behind.length > 0) {
     assert.ok(
       ignored,
-      `a lane still pins Node ${Math.min(...pins)}, so @flakiness/playwright 2.x (engines: >=22.9.0) must stay ignored`,
+      `${behind.length} lane(s) pin Node below 22.9.0 (e.g. ${behind[0].where} → ${behind[0].value}), so @flakiness/playwright 2.x (engines: >=22.9.0) must stay ignored`,
     );
   } else {
     assert.ok(
       !ignored,
-      "every lane now runs Node >= 22 — drop the TEMPORARY @flakiness/playwright ignore from .github/dependabot.yml",
+      `every Node pin is now >= 22.9.0 — drop the TEMPORARY @flakiness/playwright ignore from ${CONFIG_PATH}`,
     );
   }
 });


### PR DESCRIPTION
Closes #1229

## What this changes

The `dev-dependencies` group matched `*` with no `update-types` limit, so majors rode in with
the minors. A group is a single diff that merges as a unit, which makes that a coverage
problem rather than only a review problem: **one unreviewable major takes every reviewable
minor down with it.**

PR #1204 is the measurement — six bumps, two majors, and all three npm lanes died at `npm ci`
before running a single check, carrying four fine minors (`eslint`, `eslint-plugin-playwright`,
`typescript-eslint`, `@types/node`) with them.

- **`update-types: ["minor", "patch"]`** on the `dev-dependencies` group. Majors are not
  banned, they are **unbundled** — per the options reference, *"any outdated dependencies that
  do not match a rule are updated in individual pull requests"* — so each one lands where it
  can be reviewed, or rejected, on its own evidence.
- **`ignore` for `typescript` `>=7`.** TS 7 is the native port and is three migrations at once:
  no JS compiler API (`ts.transpileModule` / `ts.createProgram` are `undefined`, so `ts-node@10`
  throws on load), `tsconfig.json` stops compiling (`TS5108: moduleResolution=node10 has been
  removed`), and `typescript-eslint` 8.x peers `<6.1.0`. Scoped by **version range, not
  `semver-major`** — see below.
- **`open-pull-requests-limit` 3 → 6**, because the limit now counts the group PR *plus* every
  unbundled major.

## What the two independent reviews changed

**The guard was pinning spellings, not behaviour.** `- major` *without quotes* inside the group,
and a commented-out `# node-version: "20"`, both walked past the first version of
`scripts/dependabot-config.test.mjs` while it reported 5/5 — the two things it existed to
catch. Meanwhile `["minor", "patch"]` in flow style, same meaning, went red. Nothing matches a
literal now: values are extracted (quotes stripped, block and flow alike) and compared as sets
or numbers. Also fixed there: `versions:` was invisible, a duplicate `- dependency-name:` won
by position, a commented-out entry read as present, and the rationale walk-up false-failed when
an entry gained a key.

**Both ignores were justified by claims that had already expired**, which the second review
caught against the npm registry rather than the config's prose:

- **`@flakiness/playwright` — entry and guard deleted.** 2.0.0 did drop Node 20
  (`engines: ">=22.9.0"`), but **2.0.1, `latest` since 2026-07-30**, restored
  `^20.17.0 || >=22.9.0`. The ignore blocked a release that already ran on the lanes' Node, and
  the guard tied its removal to *"every lane runs Node >= 22"* — not the real condition. It
  would have failed the PR that removed the entry, i.e. the correct change. A guard enforcing a
  proxy for the reason instead of the reason is worse than no guard.
- **`typescript` — `semver-major` → `versions: [">=7"]`.** The entry's three reasons are facts
  about TS 7, and Dependabot is proposing **6.0.3** (#1228, opened today). Measured against
  6.0.3: the JS compiler API is intact and `ts-node` runs; the same tsconfig yields **TS5107**,
  a *deprecation* silenced by one `ignoreDeprecations: "6.0"` line, not TS5108 *"has been
  removed"*; and `typescript-eslint@8.65.0`'s peer `<6.1.0` admits it. A `semver-major` scope
  would have blocked TS 6 while citing evidence that does not apply to it.

**`ignore` also suppresses security updates** — it carries the shield icon in the options
reference and, unlike `allow`, has no version-updates-only carve-out. An over-broad entry can
leave an advisory with no PR at all. That is recorded at the top of the `ignore:` list and is
why the guards check *scope*, not mere presence.

## Validation

18 mutations run across both rounds, each restored. The semantic breaks fail — `- major` in any
quoting, a `versions:` range freezing the current line, a duplicate or commented-out entry, a
`semver-major` scope on typescript, an ignore bound at or below the major `package.json`
declares. The meaning-preserving reformats stay green — flow style, unquoted list items,
unquoted `dependency-name`, an entry gaining a key under a shared comment.

Local gates: `npm run test:scripts` 439/439, `npm run test:units` 334/334, `npm run typecheck`
clean.

## Follow-up, not in this PR

- The server-side ignores set with `@dependabot ignore` on #1204 live in Dependabot's own
  state, not this repo, and survive the config change — `@dependabot unignore
  @flakiness/playwright` is posted on #1228 to clear the one this PR drops.
- `node-version: "20"` → `"22"` across the 5 lanes that call `setup-node`. No longer a blocker
  for `@flakiness/playwright` v2, still worth doing on its own.
- Treating `package.json` / `package-lock.json` as a `canary` surface in
  `scripts/ci-change-coverage.mjs` — the third open question left by #1202, which #1204
  illustrated: a bump that swapped the reporter under every run and the whole TS toolchain
  resolved to zero impacted specs and reported `skipping`.
