### PR TITLE
chore(triage): quarantine the two Global Variables ag-grid flakes (#1235)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -306,7 +306,7 @@
 #### 4.3 Global Variables (API Keys)
 - [x] Create global variable
 - [-] Use global variable in component (API key) → `ui-ux/use-global-variable-in-component.spec.ts`
-- [x] Edit existing global variable → `ui-ux/global-variable-edit.spec.ts`
+- [!] Edit existing global variable — quarantined (#1235): clicking the variable's ag-grid row does not open the Update Variable modal, recurrent on the dailies of 2026-07-27 and 2026-08-03. Same surface and same shape as the provider-credential removal below (§7.5) — filed as one cause → `ui-ux/global-variable-edit.spec.ts`
 - [x] Delete global variable → `ui-ux/global-variables-crud.spec.ts`
 - [x] Create global variable of type "Generic" → `ui-ux/global-variables-crud.spec.ts`
 - [x] Credential variable value is hidden from the variable list → `ui-ux/global-variables-crud.spec.ts`
@@ -424,7 +424,7 @@
 - [x] Language Model component — configuration → `llm-agents/language-model-regression.spec.ts`
 - [x] Model Input component → `llm-agents/modelInputComponent.spec.ts`
 - [x] Add new provider via modal → `llm-agents/model-provider-api-key.spec.ts` (positive add validated via invalid-key rejection + Replace edit surface — a real re-add poisons a backend credential cache, see #505)
-- [x] Remove API key from existing provider → `llm-agents/remove-provider-api-key.spec.ts`
+- [~] Remove API key from existing provider — the API path (`DELETE /api/v1/variables/{id}`) stays validated; the **UI** path is quarantined (#1235): after ticking the row's checkbox the header trash action stays disabled, recurrent on the dailies of 2026-07-27 and 2026-08-03. Same Global Variables ag-grid surface as §4.3's edit entry — filed as one cause → `llm-agents/remove-provider-api-key.spec.ts`
 - [x] Per-model enable/disable toggle changes immediately and persists across reopen → `llm-agents/model-provider-model-toggle.spec.ts`
 - [x] Disabling a model in Settings removes it from a component model dropdown; re-enabling restores it → `llm-agents/model-provider-model-toggle.spec.ts`
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/remove-provider-api-key.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/remove-provider-api-key.spec.ts
@@ -14,9 +14,14 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 // `default_fields`, which the old payload lacked. Every step is a hard
 // assertion now.
 
-test(
+// Quarantined for #1235 — recurrent flake (dailies 2026-07-27, 2026-08-03): after
+// ticking the row's checkbox the header trash action stays disabled, so the click
+// retries for the full 20 s as `element is not enabled`. Same Global Variables
+// ag-grid surface as global-variable-edit.spec.ts:76. Lifting the quarantine and
+// restoring @stable is a deliverable of #1235.
+test.fixme(
   "a provider credential variable can be removed through the Global Variables UI",
-  { tag: ["@stable", "@release", "@workspace", "@regression", "@model-provider"] },
+  { tag: ["@release", "@workspace", "@regression", "@model-provider"] },
   async ({ page, request }) => {
     const bearer = await getAuthToken(request);
     const uniqueName = `provider-key-${Date.now()}`;

--- a/tests/tests-automations/regression/ui-ux/global-variable-edit.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/global-variable-edit.spec.ts
@@ -73,9 +73,13 @@ test.describe("Global Variable Edit (Settings page)", () => {
     },
   );
 
-  test(
+  // Quarantined for #1235 — recurrent flake (dailies 2026-07-27, 2026-08-03):
+  // clicking the variable's ag-grid row does not open the Update Variable modal,
+  // so `getByRole('heading', { name: 'Update Variable' })` never becomes visible.
+  // Lifting the quarantine and restoring @stable is a deliverable of #1235.
+  test.fixme(
     "edit existing global variable by clicking its row",
-    { tag: ["@stable", "@release", "@workspace", "@regression"] },
+    { tag: ["@release", "@workspace", "@regression"] },
     async ({ page }) => {
       createdVarName = `test_edit_var_${Date.now()}`;
 


### PR DESCRIPTION
Quarantines the two recurrent flakes the triage of #1231 dispatched to #1235, as prevention.

Both tests drive the **same surface** — the ag-grid row list on Settings → Global Variables — and fail in the same shape: the row interaction is performed and the state it should produce never arrives. Across the 30-day window each flaked on **exactly the same two dailies and no others**, `30261409427` (2026-07-27) and `30809091241` (2026-08-03), which is why they are filed as one cause rather than one issue per spec.

| Spec (line) | Waits for | Signature |
|---|---|---|
| `tests/tests-automations/regression/ui-ux/global-variable-edit.spec.ts:76` | `getByRole('heading', { name: 'Update Variable' })` | `Error: expect(locator).toBeVisible() failed` |
| `tests/tests-automations/regression/core-functionality/llm-agents/remove-provider-api-key.spec.ts:17` | `getByRole('button', { name: /delete\|confirm\|yes/i }).last()` → `[data-testid="delete-row-button"]` | `TimeoutError: locator.click: Timeout 20000ms exceeded.` |

For the delete case the call log shows the button *was* found and was retried for the full 20 s as `element is not enabled` — a delete button with nothing selected — rather than not found. In both, the row interaction is what did not register.

## What this PR does

Two edits per test, applied **together**, following the precedent in `mcp-client-regression.spec.ts:238` and `api-folders-crud.spec.ts:89`:

1. `@stable` removed from the tag array.
2. `test.fixme` with a comment block carrying the reason, the recurrence dates and the issue number.

Removing the tag alone would only stop the daily. The `pr-validation.yml` impacted-specs gate selects specs by **file diff, not by tag**, so the test would keep going red there — which is exactly what made a tag-only quarantine PR merge red in #871. `test.fixme` skips it in every context.

`QA-CHECKLIST.md` Part II moves the two manual bullets to `[!]` (§4.3 edit) and `[~]` (§7.5 provider removal — its **API** path, `DELETE /api/v1/variables/{id}`, is untouched and stays validated). Only the manual bullets are edited; the generated blocks are regenerated on merge by `update-coverage-summary.yml`.

## Why these are not wedge collateral

The same run had two failures that **were** attributed to a measured backend outage and deliberately kept their tags (`mcp-server.spec.ts:131` and `google-provider.spec.ts:155`, both enriched onto #1077). These two are different, checked against the in-run liveness recorder for their own shards:

- `global-variable-edit` failed `11:37:26→11:37:37` on **shard 1**, whose last failed probe of the run was `11:33:56`.
- `remove-provider-api-key` failed `11:30:54→11:31:18` on **shard 4**, which measured **0 outages / 0 min down** for the whole run.

Neither window overlaps unreachable-backend time, so both are attributable and belong in a quarantine rather than in the run's outage story.

## Validation

- `npm run typecheck` — clean
- `npm run lint` — 0 errors on both changed files (only pre-existing warnings)
- `node scripts/check-checklist-guard.mjs` — no generated block edited
- `npm run check:checklist-coverage` — every `@stable` and documented spec still referenced by a Part II bullet
- `npx playwright test <both specs> --grep @stable --list` — the two quarantined tests no longer match; only their untouched siblings do

No spec-doc change: `CLAUDE.md` treats a temporary `@stable` removal as tracked by the GitHub issue, not by the doc's Tags section.

Lifting the quarantine — remove `test.fixme` **and** restore `@stable`, re-validated per `CONTRIBUTING.md` — is a deliverable of #1235, not of this PR.

Refs #1231
