### PR TITLE
fix(pipeline): let checkQaDiff accept a brand-new QA-CHECKLIST area (#1238)

### DIFF
--- a/.claude/skills/langflow-e2e-issue-deterministic/pipeline/gates.test.ts
+++ b/.claude/skills/langflow-e2e-issue-deterministic/pipeline/gates.test.ts
@@ -60,6 +60,25 @@ test('checkQaDiff rejects top-level non-bullet prose changes', () => {
   assert.ok(checkQaDiff('+Some new paragraph').length > 0)
 })
 
+test('checkQaDiff allows the structural lines a new Part II area needs', () => {
+  const diff = [
+    '--- a/QA-CHECKLIST.md', '+++ b/QA-CHECKLIST.md',
+    '+---',
+    '+### core-functionality/a2a/ — Agent-to-Agent Protocol (1.11.0)',
+    '+> ⚠️ Needs LANGFLOW_A2A_ENABLED=true; surface map in docs/.',
+    '+#### 16.1 A2A Server',
+    '+- [ ] Agent card served for a published flow — protocolVersion="0.3.0"',
+  ].join('\n')
+  assert.deepEqual(checkQaDiff(diff), [])
+})
+
+test('checkQaDiff still rejects a generated line that looks structural', () => {
+  // The generated-block branches run first, so heading/blockquote tolerance
+  // cannot be used to smuggle a table row or a Phase 0 edit past the gate.
+  assert.ok(checkQaDiff('+#### Phase 0 — Validated (12)').length > 0)
+  assert.ok(checkQaDiff('+| `core-functionality/a2a/` | 18 | 0 | 0 | 0 | 18 |').length > 0)
+})
+
 test('FF coverage requires one red entry per enumerated test', () => {
   const required = [{ file: 'a.spec.ts', titles: ['t1', 't2'] }]
   const ff = [{ file: 'a.spec.ts', test: 't1', mutation: 'inverted assert', unexpected: 1, at: 'x' }]

--- a/.claude/skills/langflow-e2e-issue-deterministic/pipeline/gates.ts
+++ b/.claude/skills/langflow-e2e-issue-deterministic/pipeline/gates.ts
@@ -30,6 +30,19 @@ export function checkQaDiff(diff: string): string[] {
       problems.push('generated "Phase 0 — Validated" block touched')
     } else if (content.trim() === '' || /^\s*- \[/.test(content) || /^\s{2,}\S/.test(content)) {
       // ok: blank, checklist bullet, or indented continuation of a bullet
+    } else if (/^#{2,4} \S/.test(content) || /^> \S/.test(content) || content.trim() === '---') {
+      // ok: the structural lines a BRAND-NEW Part II area needs — its `###`
+      // section heading, its `#### N.M` subsections, an area-level `>` note, and
+      // the `---` separator between areas. The repo's authoritative guard
+      // (scripts/check-checklist-guard.mjs) only rejects GENERATED line shapes
+      // (table row / count note / Phase bullet) at or after the `## Coverage
+      // Summary` anchor, so these were never a violation there; forbidding them
+      // here made adding a checklist area impossible, because dropping the
+      // heading makes coverage-summary.ts fail with "Section start not found"
+      // for the module's `sectionStart` (found while scoping A2A, #1195). The
+      // generated blocks stay protected by the two branches above, which run
+      // first: a table row and any "Phase 0 — Validated" line are still
+      // rejected even when they look like a heading.
     } else {
       problems.push(`non-bullet top-level line changed: "${line.trim()}"`)
     }


### PR DESCRIPTION
Closes #1238.

## Problem

The deterministic pipeline's `checkQaDiff` accepted only blank lines, `- [ ]` bullets and indented bullet continuations. Every other top-level line was a violation — so the five lines a **brand-new `QA-CHECKLIST.md` area** needs all failed the gate:

```
QA-CHECKLIST problems: non-bullet top-level line changed: "+### core-functionality/a2a/ — Agent-to-Agent Protocol (1.11.0)";
non-bullet top-level line changed: "+> ⚠️ Every bullet below needs LANGFLOW_A2A_ENABLED=true …";
non-bullet top-level line changed: "+#### 16.1 A2A Server";
non-bullet top-level line changed: "+#### 16.2 A2A Client";
non-bullet top-level line changed: "+---"
```

Any issue whose deliverable is a new checklist section was therefore blocked, with no workaround: dropping the `###` heading makes `scripts/coverage-summary.ts` fail with `Section start not found for module "…"`, because that heading **is** the module's `sectionStart`.

## Fix

Tolerate `##`–`####` headings, `> ` notes and a bare `---`, matching what the repo's authoritative guard already allows: [`scripts/check-checklist-guard.mjs`](../blob/main/scripts/check-checklist-guard.mjs) rejects only **generated** line shapes (table row, `@stable` count note, Phase list bullet) and only **at or after** the `## Coverage Summary` anchor. Headings and prose before it were always editable — PR #1237 adds exactly these five lines and its `QA-CHECKLIST guard` job passes.

Rejected alternative: relaxing the gate to "anything before the anchor". That would let a hand-edited Phase 1/2 table row through, which is the collision the guard exists to prevent (#741).

## Scope note

The two generated-block branches keep running **first**, so the new tolerance cannot smuggle a table row or a `Phase 0 — Validated` edit past the gate. Nothing else in the gate changed; no other pipeline phase, gate or runner is touched.

## Validation

- `npx tsx --test .claude/skills/langflow-e2e-issue-deterministic/pipeline/gates.test.ts` → **32 passed, 0 failed**
- Two new unit cases pin both halves: a new-area diff comes back clean, and `+#### Phase 0 — Validated (12)` / a `|` table row still return a problem each.
- **Force-fail**, run against the pre-fix `checkQaDiff` extracted with `git show HEAD:…/gates.ts` (editing the source to weaken a gate was refused by tooling, so the mutation was applied to a copy instead):

```
pre-fix gate on the new-area diff  → problems: 4   (the new test FAILS without this change)
post-fix gate on the new-area diff → problems: 0
post-fix gate still rejects "+#### Phase 0 — Validated (12)"            → problems: 1
post-fix gate still rejects "+| `core-functionality/a2a/` | 18 | 0 | …" → problems: 1
```

- `npm run typecheck` → 0 errors · `npm run lint` → 0 errors (1306 warnings, repo baseline)
- No `.spec.ts` touched, so no Playwright run applies.

Split out of #1237 on request: the fix is not #1195's scope, and #1237 merges without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
