### PR TITLE
fix(ci): make the token sidecar's bounds reach the step that reads them (#1217)

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -258,6 +258,29 @@ jobs:
       OLLAMA_BASE_URL: http://ollama:11434
       OLLAMA_BASE_URL_FROM_LANGFLOW: http://ollama:11434
       OLLAMA_TEST_MODEL: llama3.2:1b
+      # The token sidecar's bounds, at JOB level because TWO steps read them: the
+      # poller below and the Playwright step, where the attribution sidecar runs inside
+      # `deleteFlow`'s teardown hook. They used to live in the poller step's own
+      # `env:`, which does not cross into another step -- so the sidecar never saw
+      # either one and silently used its hard-coded defaults. The numbers happened
+      # to match, so nothing was wrong in the run and nothing could be seen in a
+      # diff; the only symptom was a knob that did not turn, precisely when a
+      # wedged monitor endpoint made someone want to turn it.
+      #
+      # Defined ONCE, here, so the poller and the sidecar cannot end up bounded by
+      # different numbers. Pinned by scripts/token-sidecar-knobs.test.mjs.
+      TOKENS_TIMEOUT_MS: "8000"
+      TOKENS_DETAIL_CAP: "25"
+      # Per-CALL wall-clock ceiling for the attribution sidecar. Wired AHEAD of its
+      # reader on purpose: the budget itself lands with #1217's `deleteFlow` hook,
+      # and adding it from that PR would mean touching pr-validation.yml from a
+      # spec change, which flips that lane's coverage verdict to `canary` and drops
+      # its impacted-spec run. An unread variable costs nothing; a lane that cannot
+      # turn the knob when a monitor endpoint wedges costs a shard. With the two
+      # above it bounds a call at budget + timeout = 23s instead of
+      # cap x timeout = 208s. Read by the sidecar only; the poller has its own
+      # TOKENS_MAX_SECONDS.
+      TOKENS_BUDGET_MS: "15000"
 
     steps:
       - uses: actions/checkout@v7
@@ -539,11 +562,12 @@ jobs:
           TOKENS_BASE_URL: http://localhost:7860
           TOKENS_OUT: token-probes-${{ matrix.shard }}.jsonl
           TOKENS_INTERVAL_MS: "15000"
-          TOKENS_TIMEOUT_MS: "8000"
+          # TOKENS_TIMEOUT_MS and TOKENS_DETAIL_CAP are deliberately NOT here: they
+          # are defined once at job level, because the attribution sidecar in the
+          # Playwright step reads them too and a step-level env: does not reach it.
           # Same reasoning as WATCH_MAX_SECONDS: below the job's timeout-minutes so
           # it is a real backstop rather than dead configuration.
           TOKENS_MAX_SECONDS: "3600"
-          TOKENS_DETAIL_CAP: "25"
 
       - name: Run @stable tests (shard ${{ matrix.shard }})
         # Sharded run. The reporter list is NOT overridden on the CLI: setting

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -212,6 +212,29 @@ jobs:
       ANY_COMPLETION_PROVIDER: >-
         ${{ github.event.inputs.any_completion_provider == 'ollama' && 'ollama' || '' }}
       PLAYWRIGHT_RETRIES: ${{ github.event.inputs.retries }}
+      # The token sidecar's bounds, at JOB level because TWO steps read them: the
+      # poller below and the test step of the `run-e2e` composite, where the attribution sidecar runs inside
+      # `deleteFlow`'s teardown hook. They used to live in the poller step's own
+      # `env:`, which does not cross into another step -- so the sidecar never saw
+      # either one and silently used its hard-coded defaults. The numbers happened
+      # to match, so nothing was wrong in the run and nothing could be seen in a
+      # diff; the only symptom was a knob that did not turn, precisely when a
+      # wedged monitor endpoint made someone want to turn it.
+      #
+      # Defined ONCE, here, so the poller and the sidecar cannot end up bounded by
+      # different numbers. Pinned by scripts/token-sidecar-knobs.test.mjs.
+      TOKENS_TIMEOUT_MS: "8000"
+      TOKENS_DETAIL_CAP: "25"
+      # Per-CALL wall-clock ceiling for the attribution sidecar. Wired AHEAD of its
+      # reader on purpose: the budget itself lands with #1217's `deleteFlow` hook,
+      # and adding it from that PR would mean touching pr-validation.yml from a
+      # spec change, which flips that lane's coverage verdict to `canary` and drops
+      # its impacted-spec run. An unread variable costs nothing; a lane that cannot
+      # turn the knob when a monitor endpoint wedges costs a shard. With the two
+      # above it bounds a call at budget + timeout = 23s instead of
+      # cap x timeout = 208s. Read by the sidecar only; the poller has its own
+      # TOKENS_MAX_SECONDS.
+      TOKENS_BUDGET_MS: "15000"
 
     steps:
       - uses: actions/checkout@v7
@@ -382,12 +405,13 @@ jobs:
           TOKENS_BASE_URL: http://localhost:7860
           TOKENS_OUT: token-probes.jsonl
           TOKENS_INTERVAL_MS: "15000"
-          TOKENS_TIMEOUT_MS: "8000"
+          # TOKENS_TIMEOUT_MS and TOKENS_DETAIL_CAP are deliberately NOT here: they
+          # are defined once at job level, because the attribution sidecar in the
+          # test step reads them too and a step-level env: does not reach it.
           # Below the job's timeout-minutes: 90 so this is a real backstop, not
           # dead configuration reached only after the runner already killed the
           # job. Same reasoning as the daily's TOKENS_MAX_SECONDS.
           TOKENS_MAX_SECONDS: "5100"
-          TOKENS_DETAIL_CAP: "25"
 
       # Export TOKENS_ATTRIB for the specs' cleanup sidecar (#1183), same as
       # daily-stable.yml / pr-validation.yml — with it unset, the helper makes

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -468,6 +468,30 @@ jobs:
         ports:
           - 8080:8080
 
+    # The token sidecar's bounds, at JOB level because TWO steps read them: the
+    # poller below and the Playwright step, where the attribution sidecar runs
+    # inside `deleteFlow`'s teardown hook. They used to live in the poller step's
+    # own `env:`, which does not cross into another step -- so the sidecar never
+    # saw either one and silently used its hard-coded defaults. The numbers
+    # happened to match, so nothing was wrong in the run and nothing could be seen
+    # in a diff; the only symptom was a knob that did not turn, precisely when a
+    # wedged monitor endpoint made someone want to turn it.
+    #
+    # Defined ONCE, here, so the poller and the sidecar cannot end up bounded by
+    # different numbers. Pinned by scripts/token-sidecar-knobs.test.mjs.
+    env:
+      TOKENS_TIMEOUT_MS: "8000"
+      TOKENS_DETAIL_CAP: "25"
+      # Per-CALL wall-clock ceiling for the attribution sidecar. Wired AHEAD of its
+      # reader on purpose: the budget itself lands with #1217's `deleteFlow` hook,
+      # and adding it from that PR would mean touching THIS file from a spec change,
+      # which flips this lane's coverage verdict to `canary` and drops its
+      # impacted-spec run. An unread variable costs nothing; a lane that cannot turn
+      # the knob when a monitor endpoint wedges costs a run. With the two above it
+      # bounds a call at budget + timeout = 23s instead of cap x timeout = 208s.
+      # Read by the sidecar only; the poller has its own TOKENS_MAX_SECONDS.
+      TOKENS_BUDGET_MS: "15000"
+
     steps:
       - uses: actions/checkout@v7
 
@@ -673,12 +697,13 @@ jobs:
           TOKENS_BASE_URL: http://localhost:7860
           TOKENS_OUT: token-probes.jsonl
           TOKENS_INTERVAL_MS: "15000"
-          TOKENS_TIMEOUT_MS: "8000"
+          # TOKENS_TIMEOUT_MS and TOKENS_DETAIL_CAP are deliberately NOT here: they
+          # are defined once at job level, because the attribution sidecar in the
+          # Playwright step reads them too and a step-level env: does not reach it.
           # Below the job's timeout-minutes: 60 so this is a real backstop, not
           # dead configuration reached only after the runner already killed the
           # job. Same reasoning as the daily's TOKENS_MAX_SECONDS.
           TOKENS_MAX_SECONDS: "3300"
-          TOKENS_DETAIL_CAP: "25"
 
       - name: Run impacted specs
         env:

--- a/scripts/token-sidecar-knobs.test.mjs
+++ b/scripts/token-sidecar-knobs.test.mjs
@@ -1,0 +1,191 @@
+// Adoption guard for the token attribution sidecar's bounds (issue #1217, §4.4).
+// Run with: npm run test:scripts
+//
+// What this protects, and why review cannot:
+//
+// `TOKENS_TIMEOUT_MS` and `TOKENS_DETAIL_CAP` shipped as DEAD CONFIGURATION. They
+// sat in the token POLLER step's own `env:` block, and a step-level `env:` does
+// not cross into another step -- the sidecar runs inside the Playwright step, so
+// it never saw either value and always used its hard-coded defaults. Nothing was
+// wrong in the run: the lanes happened to set exactly the numbers that were
+// already the defaults, so behaviour and intent agreed by coincidence. Change a
+// lane's number and nothing would happen; the only symptom is a knob that does
+// not turn.
+//
+// That is the failure mode this file exists for. It is invisible to a green run,
+// invisible to a diff (the value IS in the workflow, spelled correctly, in a
+// plausible place), and it defeats the mitigation exactly when it is needed --
+// these are the bounds that stop a wedged monitor endpoint from eating a spec's
+// 5-minute budget from inside `afterEach`, and the response to a wedge is to turn
+// them DOWN in the lane, which would have done nothing.
+//
+// So the fix is job-level `env:`, and it is asserted structurally rather than
+// reviewed. Job level is what makes ONE definition reach both readers: the poller
+// step and the Playwright step the sidecar runs in. It is also the mechanism
+// `manual.yml` already needs for its Ollama routing, because
+// `.github/actions/run-e2e` declares per-step `env:` that ADDS to the job
+// environment rather than replacing it.
+//
+// The lane list is DERIVED, not hard-coded: a lane is in scope because it sets
+// `TOKENS_ATTRIB`, i.e. because it turns the sidecar on. A fourth lane that
+// enables it inherits this guard the day it is written.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const WORKFLOW_DIR = path.join(REPO_ROOT, ".github/workflows");
+
+/**
+ * The bounds the sidecar reads. `TOKENS_ATTRIB` is the switch, not a bound.
+ *
+ * `TOKENS_BUDGET_MS` is listed ahead of its reader, deliberately. The per-call
+ * wall-clock budget lands with #1217's `deleteFlow` hook, so on `main` today
+ * nothing consumes it -- but the wiring is what this PR is about, and the
+ * alternative is worse: adding it later means touching `pr-validation.yml` from a
+ * spec PR, which flips that lane's coverage verdict to `canary` and drops its
+ * impacted-spec run. Configuring it here costs nothing (an unread variable) and
+ * means the sidecar lands into lanes that already turn its knob.
+ */
+const KNOBS = ["TOKENS_TIMEOUT_MS", "TOKENS_DETAIL_CAP", "TOKENS_BUDGET_MS"];
+
+/**
+ * Split a workflow into its jobs by indentation.
+ *
+ * No YAML parser is available in this repo (`npm run test:scripts` runs
+ * dependency-free `.mjs`), and every other structural guard here reads the text.
+ * Indentation is enough for the one question asked: GitHub Actions fixes the
+ * depth of `jobs:` (0), a job id (2) and a job-level key (4), while anything
+ * inside `steps:` sits at 6 or deeper.
+ */
+function jobsOf(text) {
+  const lines = text.split("\n");
+  const jobs = [];
+  let current = null;
+  let inJobs = false;
+  for (const line of lines) {
+    if (/^jobs:\s*$/.test(line)) {
+      inJobs = true;
+      continue;
+    }
+    if (!inJobs) continue;
+    // A top-level key at column 0 ends the jobs block.
+    if (/^\S/.test(line)) break;
+    const jobStart = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(line);
+    if (jobStart) {
+      current = { id: jobStart[1], lines: [] };
+      jobs.push(current);
+      continue;
+    }
+    if (current) current.lines.push(line);
+  }
+  return jobs;
+}
+
+/**
+ * The names defined in a job's JOB-LEVEL `env:` block — `    env:` at exactly
+ * four spaces, its entries at six. A step's `env:` is indented deeper and is
+ * deliberately not collected: that is the whole distinction this guard is about.
+ */
+function jobLevelEnv(job) {
+  const names = new Set();
+  let inside = false;
+  for (const line of job.lines) {
+    if (/^ {4}env:\s*$/.test(line)) {
+      inside = true;
+      continue;
+    }
+    if (!inside) continue;
+    if (/^\s*(#.*)?$/.test(line)) continue;
+    const entry = /^ {6}([A-Za-z0-9_]+):/.exec(line);
+    if (entry) {
+      names.add(entry[1]);
+      continue;
+    }
+    // The block ends only at an OUTDENT, never at a deeper line. Treating any
+    // non-entry line as the end was wrong and this guard caught it on itself: a
+    // block-scalar value (`ANY_COMPLETION_PROVIDER: >-`) continues on an
+    // eight-space line, so the scan stopped there and reported every later entry
+    // as missing — a false red on a lane that was correctly wired.
+    if (/^ {0,4}\S/.test(line)) inside = false;
+  }
+  return names;
+}
+
+/** Every `NAME:` defined inside a step-level `env:` (eight spaces or deeper). */
+function stepLevelEnv(job) {
+  const names = [];
+  let indent = null;
+  for (const line of job.lines) {
+    const open = /^( {8,})env:\s*$/.exec(line);
+    if (open) {
+      indent = open[1].length + 2;
+      continue;
+    }
+    if (indent === null) continue;
+    if (/^\s*(#.*)?$/.test(line)) continue;
+    const entry = new RegExp(`^ {${indent}}([A-Za-z0-9_]+):`).exec(line);
+    if (entry) {
+      names.push(entry[1]);
+      continue;
+    }
+    // Same outdent rule as jobLevelEnv: a deeper line is a value continuation.
+    if (new RegExp(`^ {0,${indent - 1}}\\S`).test(line)) indent = null;
+  }
+  return names;
+}
+
+/** Jobs that turn the sidecar on, across every workflow — the derived scope. */
+function sidecarJobs() {
+  const found = [];
+  for (const file of fs.readdirSync(WORKFLOW_DIR).filter((f) => f.endsWith(".yml"))) {
+    const text = fs.readFileSync(path.join(WORKFLOW_DIR, file), "utf8");
+    if (!text.includes("TOKENS_ATTRIB")) continue;
+    for (const job of jobsOf(text)) {
+      if (job.lines.some((l) => l.includes("TOKENS_ATTRIB"))) found.push({ file, job });
+    }
+  }
+  return found;
+}
+
+test("every lane that enables the attribution sidecar defines its bounds at JOB level (§4.4)", () => {
+  const jobs = sidecarJobs();
+  // Fail-closed: a scope that silently came back empty would log the same line as
+  // a healthy run, which is how this whole class of gap survives (#1012's rule).
+  assert.ok(
+    jobs.length >= 3,
+    `expected at least the three lanes known to set TOKENS_ATTRIB (daily-stable, pr-validation, manual); ` +
+      `found ${jobs.length} — either the scan broke or a lane lost the sidecar`,
+  );
+
+  for (const { file, job } of jobs) {
+    const env = jobLevelEnv(job);
+    for (const knob of KNOBS) {
+      assert.ok(
+        env.has(knob),
+        `${file} → job "${job.id}" enables the sidecar but does not define ${knob} at JOB level. ` +
+          `A step-level env: does not cross into the Playwright step the sidecar runs in, so the ` +
+          `value would be dead configuration and the hard-coded default would apply instead.`,
+      );
+    }
+  }
+});
+
+test("a bound is defined exactly once per lane, so the poller and the sidecar cannot drift (§4.4)", () => {
+  for (const { file, job } of sidecarJobs()) {
+    const perStep = stepLevelEnv(job);
+    for (const knob of KNOBS) {
+      const shadowed = perStep.filter((name) => name === knob).length;
+      assert.equal(
+        shadowed,
+        0,
+        `${file} → job "${job.id}" re-defines ${knob} in a step-level env:. Two definitions is how the ` +
+          `poller and the sidecar end up bounded by different numbers while the workflow reads as if ` +
+          `they share one — keep the job-level definition and delete this copy.`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
## Type

- [x] `fix` — CI wiring + a guard for it

---

## Roadmap linkage (required — do not delete)

- [x] **Exception** — off-wave work backed by an issue: a follow-up. Issue #1217 (labelled `follow-up`)

Split out of #1248's review. It is its own PR **because** it touches
`pr-validation.yml`: `scripts/ci-change-coverage.mjs` returns `canary` for that
diff, which replaces the impacted-spec run with a fixed 3-spec set. Landing it
inside #1248 would have made that PR — which changes `deleteFlow`, a helper 157
specs reach — stop running the specs that exercise the change.

---

## What this PR does

`TOKENS_TIMEOUT_MS` and `TOKENS_DETAIL_CAP` are **dead configuration**. They sit
in the token POLLER step's own `env:` block, and a step-level `env:` does not
cross into another step — the attribution sidecar (#1197) runs in the Playwright
step, so it has never seen either value and always uses its hard-coded defaults.

Nothing is wrong in any run today: the lanes happen to set exactly the numbers
that are already the defaults, so behaviour and intent agree **by coincidence**.
The only symptom is a knob that does not turn — and it would be found by someone
turning it DOWN in response to a wedged monitor endpoint (#1077), which is the
one moment these bounds matter.

Fixed by defining them **once, at JOB level**, in the three lanes that enable the
sidecar. Job level is what makes one definition reach both readers; it is also
the mechanism `manual.yml` already needs for Ollama routing, because
`.github/actions/run-e2e` declares per-step `env:` that ADDS to the job
environment rather than replacing it. The poller-step copies are deleted rather
than left as a second definition.

**Values are unchanged** (`8000` / `25`), so this is behaviour-neutral by
construction. It makes the knobs real; it does not turn them.

### `TOKENS_BUDGET_MS` is wired ahead of its reader

The per-call wall-clock budget lands with #1217's `deleteFlow` hook (#1248), so
nothing consumes it yet. It is here anyway because the alternative is worse:
adding it later means touching `pr-validation.yml` from a spec PR, with the
`canary` consequence described above. An unread variable costs nothing; a lane
that cannot turn the knob when a monitor endpoint wedges costs a run.

---

## Tests covered

`scripts/token-sidecar-knobs.test.mjs` (`npm run test:scripts`):

| # | Test | What it validates |
|---|---|---|
| 1 | every lane that enables the sidecar defines its bounds at JOB level | The actual defect. Fail-closed: a scope that came back empty would log the same line as a healthy run. |
| 2 | a bound is defined exactly once per lane | Two definitions is how the poller and the sidecar end up bounded by different numbers while the workflow reads as if they share one. |

The lane list is **derived** from which workflows set `TOKENS_ATTRIB`, not
hard-coded — a fourth lane inherits the guard the day it is written.

Both proven by mutation, not inspection:

| mutation | kills |
|---|---|
| delete `TOKENS_BUDGET_MS` from the daily's job env | test 1 |
| re-add a step-level `TOKENS_DETAIL_CAP` to manual's poller | test 2 |

**The guard caught a bug in itself**, which is why its parser ends a block only
at an OUTDENT: reading any non-entry line as the end of an `env:` block meant a
block-scalar value (`ANY_COMPLETION_PROVIDER: >-`) truncated the scan and
reported every entry after it as missing — a false red on a correctly wired lane.

---

## Verification

```
npm run typecheck    → clean
npm run lint         → 0 errors
npm run test:units   → 347 pass / 0 fail
npm run test:scripts → 503 pass / 0 fail
```

The three workflows were additionally parsed with a real YAML loader to confirm
each sidecar job resolves all three knobs at job level.

---

## Dependencies

None. No `package.json` change. No spec touched.

---

## Related issue

Follow-up to #1217. Reviewed out of #1248, which carries the sidecar itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)