### PR TITLE
chore(tokens): carry the run's token spend to the QA Platform, after the summarize computes it (#1217)

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -676,6 +676,13 @@ jobs:
           mkdir -p tokens
           cp token-probes-${{ matrix.shard }}.jsonl tokens/ 2>/dev/null || true
           cp token-attrib-${{ matrix.shard }}.jsonl tokens/ 2>/dev/null || true
+          # §6.4: the provider this shard actually resolved, carried to the merge
+          # job. $GITHUB_ENV reaches later steps of THIS job only, and the POST
+          # lives in the merge job -- so the value rides the artifact that already
+          # crosses that boundary. Written unconditionally: an EMPTY file means
+          # the rotation declined to pin (every provider dry), which is a real
+          # outcome and must not be confused with a shard that failed to report.
+          printf '%s' "${MODEL_TEST_PROVIDER:-}" > "tokens/token-provider-${{ matrix.shard }}.txt"
           echo "--- token recorder stdout (tail) ---"
           tail -n 5 /tmp/tokens.log 2>/dev/null || true
 
@@ -1022,6 +1029,46 @@ jobs:
           # dispatch → "1" (suppressed), scheduled run → "" (not suppressed, the
           # knob's own truthiness check treats an empty string as "not set").
           TOKENS_SUPPRESS_HISTORY: ${{ github.event_name != 'schedule' && '1' || '' }}
+          TOKENS_SUMMARY_OUT: tokens-block.json
+
+      # §5.2 — the run's token spend, POSTed after the summarize computed it.
+      #
+      # The run's own POST (above) happens ~40 steps before this number exists,
+      # and must NOT be moved behind a telemetry step. So this re-POSTs the same
+      # payload with a `tokens` block added; the platform's edge function calls
+      # its token ingest on the already-recorded path too, so the run row is
+      # untouched and only the token rows land.
+      #
+      # Gated on the FILE, not on an exit code: merge-token-payload.mjs writes
+      # nothing when the run captured nothing, because a zeroed token block would
+      # clamp the run's token columns and read as "this run spent nothing".
+      - name: POST token consumption to QA Platform
+        if: always()
+        continue-on-error: true            # telemetry must never fail the suite
+        env:
+          QA_PLATFORM_ENDPOINT: ${{ vars.QA_PLATFORM_ENDPOINT }}
+          QA_E2E_AUTOMATION_TOKEN: ${{ secrets.QA_E2E_AUTOMATION_TOKEN }}
+          TOKENS_SUMMARY_OUT: tokens-block.json
+          TOKENS_DIR: all-tokens
+          PAYLOAD_IN: payload.json
+          PAYLOAD_OUT: payload-with-tokens.json
+        run: |
+          node scripts/merge-token-payload.mjs
+          if [ ! -f payload-with-tokens.json ]; then
+            echo "::notice::No token block for this run — nothing to POST."; exit 0; fi
+          if [ -z "$QA_PLATFORM_ENDPOINT" ] || [ -z "$QA_E2E_AUTOMATION_TOKEN" ]; then
+            echo "::warning::QA platform endpoint/token not configured — skipping token POST."; exit 0; fi
+          code=$(curl -s -o /tmp/tokresp.json -w '%{http_code}' -X POST "$QA_PLATFORM_ENDPOINT" \
+            -H "Authorization: Bearer $QA_E2E_AUTOMATION_TOKEN" -H "Content-Type: application/json" \
+            --data @payload-with-tokens.json)
+          echo "HTTP $code"; cat /tmp/tokresp.json || true
+          # tokens_received/tokens_inserted/tokens_dropped come back in the body;
+          # a dropped-row count is the signal that the block and the ingest
+          # disagree, so surface a mismatch instead of trusting HTTP 200 alone.
+          case "$code" in
+            200|201) echo "Token rows delivered.";;
+            *) echo "::warning::QA platform token POST failed ($code)";;
+          esac
 
       # Long-lived run history: append one JSON line per scheduled run to
       # reports/daily-history.jsonl and commit it back to main. See

--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -769,8 +769,10 @@ jobs:
 
       # Token consumption artifacts from every shard (#1197). Flattened like the
       # blob download above: each shard names its files uniquely
-      # (token-probes-<shard>.jsonl / token-attrib-<shard>.jsonl), so
-      # merge-multiple cannot collide them.
+      # (token-probes-<shard>.jsonl / token-attrib-<shard>.jsonl /
+      # token-provider-<shard>.txt), so merge-multiple cannot collide them.
+      # NOTE: this `path:` is the value merge-token-payload.mjs is given as
+      # TOKENS_DIR — the provider files are read from here, so the two must agree.
       # continue-on-error: same reasoning as the liveness download — a shard that
       # never uploaded (an old job, a run that died in prep) must not fail the merge.
       - name: Download shard token consumption data
@@ -1053,22 +1055,63 @@ jobs:
           PAYLOAD_IN: payload.json
           PAYLOAD_OUT: payload-with-tokens.json
         run: |
-          node scripts/merge-token-payload.mjs
+          merge_log=$(node scripts/merge-token-payload.mjs 2>&1) || true
+          echo "$merge_log"
+          verdict=$(printf '%s\n' "$merge_log" | sed -n 's/^merge-token-payload: code=//p' | tail -n 1)
           if [ ! -f payload-with-tokens.json ]; then
-            echo "::notice::No token block for this run — nothing to POST."; exit 0; fi
+            # The three no-POST outcomes are NOT the same fact, and the script
+            # already tells them apart. Collapsing them here would report a block
+            # that was computed and then LOST as a run that captured nothing —
+            # the absent-vs-zero conflation this path exists to prevent (#1012).
+            case "$verdict" in
+              block_missing)
+                echo "::notice::No token block for this run — the run captured nothing to POST.";;
+              block_unparseable)
+                echo "::warning::The token block exists but is unparseable — this run's token spend was computed and then LOST, not zero. See the merge log above.";;
+              payload_missing|payload_unparseable)
+                echo "::warning::The run payload ($verdict) is unusable, so the token block could not be attached — the tokens were computed and are being discarded.";;
+              *)
+                echo "::warning::merge-token-payload reached no verdict (code='$verdict') — treat this run's token spend as UNKNOWN, not zero.";;
+            esac
+            exit 0; fi
           if [ -z "$QA_PLATFORM_ENDPOINT" ] || [ -z "$QA_E2E_AUTOMATION_TOKEN" ]; then
             echo "::warning::QA platform endpoint/token not configured — skipping token POST."; exit 0; fi
           code=$(curl -s -o /tmp/tokresp.json -w '%{http_code}' -X POST "$QA_PLATFORM_ENDPOINT" \
             -H "Authorization: Bearer $QA_E2E_AUTOMATION_TOKEN" -H "Content-Type: application/json" \
             --data @payload-with-tokens.json)
           echo "HTTP $code"; cat /tmp/tokresp.json || true
-          # tokens_received/tokens_inserted/tokens_dropped come back in the body;
-          # a dropped-row count is the signal that the block and the ingest
-          # disagree, so surface a mismatch instead of trusting HTTP 200 alone.
-          case "$code" in
-            200|201) echo "Token rows delivered.";;
-            *) echo "::warning::QA platform token POST failed ($code)";;
-          esac
+          # HTTP 200 is NOT the verdict (#1253 review, finding 2). The ingest is
+          # diagnostic on the platform's side too, so it never fails the request:
+          # a rejected or lost block comes back inside a 200. What the body says,
+          # verified against the edge function's own contract
+          # (quality-platform, e2e-automation-runs-create/index.ts — `tokenFields`):
+          #   tokens_status ∈ skipped | ingested | rejected | failed  (always present)
+          #   tokens_dropped  — the RPC's own count of payload rows that did NOT land
+          #   tokens_superseded — a newer attempt already holds this run's rows
+          # `ingested` requires the RPC to have updated the run; `rejected` is
+          # "no such run" or "this attempt is older than the one recorded". So the
+          # only success is `ingested` with nothing dropped, and every other shape
+          # gets named rather than printed as delivered.
+          if [ "$code" != "200" ] && [ "$code" != "201" ]; then
+            echo "::warning::QA platform token POST failed ($code)"; exit 0; fi
+          # Read through node, not grep: the four values are read from ONE parse of
+          # the body, so a field that is present-but-null cannot be confused with a
+          # field that is absent. `absent` is a literal the branches below check for
+          # — an unreadable body must not resolve to a plausible-looking "0".
+          fields=$(node -e 'let r={};try{r=JSON.parse(require("node:fs").readFileSync("/tmp/tokresp.json","utf8"))}catch{};process.stdout.write([r.tokens_status??"absent",r.tokens_dropped??"absent",r.tokens_received??"absent",r.tokens_superseded??"absent"].join(" "))')
+          # shellcheck disable=SC2086  # deliberate word splitting: four space-free fields
+          set -- $fields
+          t_status="${1:-absent}"; t_dropped="${2:-absent}"; t_received="${3:-absent}"; t_superseded="${4:-absent}"
+          echo "tokens_status=$t_status dropped=$t_dropped received=$t_received superseded=$t_superseded"
+          if [ "$t_status" = "absent" ]; then
+            echo "::warning::HTTP $code but the response carries no tokens_status — cannot confirm the rows landed. Treat this run's token spend as UNKNOWN."
+          elif [ "$t_status" != "ingested" ]; then
+            echo "::warning::QA platform did not ingest the token rows (tokens_status=$t_status, superseded=$t_superseded) — the run row is fine, the token rows are NOT recorded."
+          elif [ "$t_dropped" != "0" ]; then
+            echo "::warning::QA platform dropped $t_dropped of $t_received token rows — the block and the ingest disagree (missing model, or two payload rows on one identity)."
+          else
+            echo "Token rows delivered — $t_received row(s) ingested, none dropped."
+          fi
 
       # Long-lived run history: append one JSON line per scheduled run to
       # reports/daily-history.jsonl and commit it back to main. See

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/rafael/Documents/langflow-e2e/node_modules

--- a/scripts/lib/token-cost.mjs
+++ b/scripts/lib/token-cost.mjs
@@ -225,6 +225,13 @@ export function aggregate({ probes = [], attributions = [], costs = [], prices =
 
   const models = new Map();
   const specs = new Map();
+  // §5.3: the cross-tab the platform's fact table needs. Keyed to match the DB's
+  // own row identity -- (run_id, COALESCE(test_key,''), model), see
+  // 20260803130200_e2e_test_token_usage.sql:83 -- so an unattributed trace keys on
+  // the MODEL ALONE. Keying it on anything per-trace would emit rows the unique
+  // index treats as one and a re-POST would then duplicate.
+  const specModels = new Map();
+  let spanTokens = 0;
   const unpriced = new Set();
   const mismatches = [];
 
@@ -246,6 +253,17 @@ export function aggregate({ probes = [], attributions = [], costs = [], prices =
     if (!probe?.trace_id) continue;
     totals.traces += 1;
 
+    // Resolved BEFORE the span loop because the per-model cross-tab below needs
+    // the spec identity while it is walking the spans. The `unattributed`
+    // bookkeeping further down still uses the same value.
+    const attribution = byTrace.get(probe.trace_id);
+    const specPath = attribution?.file ?? null;
+    const titlePath = attribution?.test ?? null;
+    // Write the separator as the ESCAPE `\u0000`, never as a literal control
+    // character in the source. A raw NUL is invisible in an editor, in a diff and
+    // in a review, and the first draft of this plan shipped four of them by accident.
+    const specModelKey = attribution ? `${specPath}\u0000${titlePath}\u0000` : "\u0000\u0000";
+
     let spanTotal = 0;
     let traceUsd = 0;
     for (const m of probe.models ?? []) {
@@ -253,6 +271,7 @@ export function aggregate({ probes = [], attributions = [], costs = [], prices =
       const completion = Number(m.completion_tokens) || 0;
       const total = Number(m.total_tokens) || prompt + completion;
       spanTotal += total;
+      spanTokens += total;
       totals.prompt_tokens += prompt;
       totals.completion_tokens += completion;
 
@@ -276,6 +295,25 @@ export function aggregate({ probes = [], attributions = [], costs = [], prices =
       acc.total_tokens += total;
       if (acc.usd_estimated !== null && usd !== null) acc.usd_estimated += usd;
       models.set(m.model, acc);
+
+      const rowKey = `${specModelKey}${m.model}`;
+      const row =
+        specModels.get(rowKey) ??
+        {
+          spec_path: specPath,
+          title_path: titlePath,
+          model: m.model,
+          price_key: resolvePriceKey(m.model, prices),
+          calls: 0,
+          prompt_tokens: 0,
+          completion_tokens: 0,
+          total_tokens: 0,
+        };
+      row.calls += Number(m.calls) || 1;
+      row.prompt_tokens += prompt;
+      row.completion_tokens += completion;
+      row.total_tokens += total;
+      specModels.set(rowKey, row);
     }
 
     // The trace's own total is authoritative for the run (§2.1). When the two
@@ -298,7 +336,6 @@ export function aggregate({ probes = [], attributions = [], costs = [], prices =
     totals.total_tokens += runTotal;
     totals.usd_estimated += traceUsd;
 
-    const attribution = byTrace.get(probe.trace_id);
     if (!attribution) {
       unattributed.traces += 1;
       unattributed.total_tokens += runTotal;
@@ -319,6 +356,8 @@ export function aggregate({ probes = [], attributions = [], costs = [], prices =
     totals,
     byModel: [...models.values()].sort((a, b) => b.total_tokens - a.total_tokens),
     bySpec: [...specs.values()].sort((a, b) => b.total_tokens - a.total_tokens),
+    bySpecModel: [...specModels.values()].sort((a, b) => b.total_tokens - a.total_tokens),
+    spanTokens,
     attrib_ms: attribMs,
     attrib_calls: attribCalls,
     unattributed,

--- a/scripts/lib/token-cost.mjs
+++ b/scripts/lib/token-cost.mjs
@@ -228,8 +228,16 @@ export function aggregate({ probes = [], attributions = [], costs = [], prices =
   // §5.3: the cross-tab the platform's fact table needs. Keyed to match the DB's
   // own row identity -- (run_id, COALESCE(test_key,''), model), see
   // 20260803130200_e2e_test_token_usage.sql:83 -- so an unattributed trace keys on
-  // the MODEL ALONE. Keying it on anything per-trace would emit rows the unique
-  // index treats as one and a re-POST would then duplicate.
+  // the MODEL ALONE.
+  //
+  // WHY ONE ROW PER IDENTITY (the reason, corrected -- #1253 review, finding 7):
+  // NOT "a re-POST would duplicate". The live ingest
+  // (20260803130600_e2e_token_ingest_preserve_upsert_clamp.sql) upserts with
+  // ON CONFLICT ... DO UPDATE, so it cannot duplicate. What it does instead is
+  // keep the LAST occurrence of an identity and count the losers in
+  // `rows_dropped`. So emitting two rows the unique index treats as one does not
+  // create a duplicate -- it silently DISCARDS one of the two numbers. That is
+  // the failure this key avoids.
   const specModels = new Map();
   let spanTokens = 0;
   const unpriced = new Set();

--- a/scripts/lib/token-cost.mjs
+++ b/scripts/lib/token-cost.mjs
@@ -153,9 +153,13 @@ function isAllowedSuffix(leftover) {
 // survives the gate. A tie in key length falls back to a plain lexical sort
 // so the result never depends on which key the price table happened to
 // declare first.
-function resolveBands(model, prices) {
+//
+// Split into resolvePriceKey() + resolveBands() for #1217: the platform's
+// e2e_test_token_usage.price_key column records which key priced a row, so the
+// key itself became a return value rather than an intermediate.
+export function resolvePriceKey(model, prices) {
   if (!model || !prices) return null;
-  if (prices[model]) return toBands(prices[model]);
+  if (prices[model]) return model;
   const candidates = Object.keys(prices)
     .filter((key) => {
       if (model === key) return false;
@@ -164,7 +168,12 @@ function resolveBands(model, prices) {
       return isAllowedSuffix(longer.slice(shorter.length));
     })
     .sort((a, b) => b.length - a.length || a.localeCompare(b));
-  return candidates.length ? toBands(prices[candidates[0]]) : null;
+  return candidates.length ? candidates[0] : null;
+}
+
+function resolveBands(model, prices) {
+  const key = resolvePriceKey(model, prices);
+  return key ? toBands(prices[key]) : null;
 }
 
 export function usdFor(model, promptTokens, completionTokens, prices, date) {

--- a/scripts/lib/token-cost.test.mjs
+++ b/scripts/lib/token-cost.test.mjs
@@ -3,7 +3,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { usdFor, aggregate, parsePrices, loadPrices } from "./token-cost.mjs";
+import { usdFor, aggregate, parsePrices, loadPrices, resolvePriceKey } from "./token-cost.mjs";
 
 const PRICES = {
   "gpt-4o-mini": { inputPerMillion: 0.15, outputPerMillion: 0.6 },
@@ -566,4 +566,52 @@ test("a cost record perturbs no token figure — totals, by_model, by_spec, unat
     false,
     "a cost record must never appear as a spending spec",
   );
+});
+
+// #1217 §5.3: the platform's e2e_test_token_usage.price_key records WHICH table
+// key priced a row. resolveBands() already computes it and discards it; these
+// tests pin the extracted function to the resolver's real behaviour, including
+// the two refusals that exist to stop a wrong number (#1211).
+const KEYS = {
+  "gpt-4o": { inputPerMillion: 2.5, outputPerMillion: 10 },
+  "gpt-4o-mini": { inputPerMillion: 0.15, outputPerMillion: 0.6 },
+  "gemini-2.5-flash": { inputPerMillion: 0.3, outputPerMillion: 2.5 },
+  "claude-opus-4": { inputPerMillion: 15, outputPerMillion: 75 },
+};
+
+test("resolvePriceKey returns the exact key when the model is priced by name", () => {
+  assert.equal(resolvePriceKey("gpt-4o-mini", KEYS), "gpt-4o-mini");
+});
+
+test("resolvePriceKey resolves a dated id to its family key", () => {
+  assert.equal(resolvePriceKey("claude-opus-4-20250514", KEYS), "claude-opus-4");
+});
+
+test("resolvePriceKey prefers the longest matching key", () => {
+  // Matches both gpt-4o (leftover "-mini-search-preview", refused) and
+  // gpt-4o-mini (leftover "-search-preview", allowed).
+  assert.equal(resolvePriceKey("gpt-4o-mini-search-preview", KEYS), "gpt-4o-mini");
+});
+
+test("resolvePriceKey refuses a separately-priced tier suffix", () => {
+  // "-lite" is a real cheaper tier, not alias noise (#1211). Pricing it at the
+  // non-Lite rate is worse than admitting we cannot price it.
+  assert.equal(resolvePriceKey("gemini-2.5-flash-lite", KEYS), null);
+});
+
+test("resolvePriceKey returns null for an unknown family", () => {
+  assert.equal(resolvePriceKey("mistral-large", KEYS), null);
+});
+
+test("resolvePriceKey returns null on missing arguments", () => {
+  assert.equal(resolvePriceKey("", KEYS), null);
+  assert.equal(resolvePriceKey("gpt-4o", null), null);
+});
+
+test("usdFor is unchanged by the resolvePriceKey extraction", () => {
+  // The refactor's whole risk is a behaviour change in pricing. Pin the three
+  // paths that matter: exact key, substring family, refused suffix.
+  assert.equal(usdFor("gpt-4o-mini", 1_000_000, 0, KEYS), 0.15);
+  assert.equal(usdFor("claude-opus-4-20250514", 1_000_000, 0, KEYS), 15);
+  assert.equal(usdFor("gemini-2.5-flash-lite", 1_000_000, 0, KEYS), null);
 });

--- a/scripts/lib/token-cost.test.mjs
+++ b/scripts/lib/token-cost.test.mjs
@@ -615,3 +615,146 @@ test("usdFor is unchanged by the resolvePriceKey extraction", () => {
   assert.equal(usdFor("claude-opus-4-20250514", 1_000_000, 0, KEYS), 15);
   assert.equal(usdFor("gemini-2.5-flash-lite", 1_000_000, 0, KEYS), null);
 });
+
+// #1217 §5.3: bySpecModel is the row shape e2e_ingest_run_tokens destructures.
+// Its identity must match the DB's unique index — (run_id, COALESCE(test_key,''),
+// model) — so one row per (spec_path, title_path, model) and exactly ONE
+// unattributed row per model. See 20260803130200_e2e_test_token_usage.sql:83.
+const P = { "gpt-4o-mini": { inputPerMillion: 0.15, outputPerMillion: 0.6 } };
+
+const twoModelProbe = (traceId, over = {}) => ({
+  trace_id: traceId,
+  flow_id: "f1",
+  start_time: "2026-08-03T13:00:00.000Z",
+  status: "ok",
+  total_tokens: 300,
+  models: [
+    { model: "gpt-4o-mini", prompt_tokens: 100, completion_tokens: 100, total_tokens: 200, calls: 2 },
+    { model: "gemini-3.5-flash", prompt_tokens: 60, completion_tokens: 40, total_tokens: 100, calls: 1 },
+  ],
+  ...over,
+});
+
+test("bySpecModel crosses spec and model, and carries the price key", () => {
+  const agg = aggregate({
+    probes: [twoModelProbe("t1")],
+    attributions: [{ trace_id: "t1", file: "a.spec.ts", test: "does a thing" }],
+    prices: P,
+  });
+  const rows = [...agg.bySpecModel].sort((x, y) => x.model.localeCompare(y.model));
+  assert.equal(rows.length, 2);
+  assert.deepEqual(rows[0], {
+    spec_path: "a.spec.ts",
+    title_path: "does a thing",
+    model: "gemini-3.5-flash",
+    price_key: null,
+    calls: 1,
+    prompt_tokens: 60,
+    completion_tokens: 40,
+    total_tokens: 100,
+  });
+  assert.deepEqual(rows[1], {
+    spec_path: "a.spec.ts",
+    title_path: "does a thing",
+    model: "gpt-4o-mini",
+    price_key: "gpt-4o-mini",
+    calls: 2,
+    prompt_tokens: 100,
+    completion_tokens: 100,
+    total_tokens: 200,
+  });
+});
+
+test("bySpecModel accumulates repeat traces of the same spec and model", () => {
+  const agg = aggregate({
+    probes: [twoModelProbe("t1"), twoModelProbe("t2")],
+    attributions: [
+      { trace_id: "t1", file: "a.spec.ts", test: "does a thing" },
+      { trace_id: "t2", file: "a.spec.ts", test: "does a thing" },
+    ],
+    prices: P,
+  });
+  const row = agg.bySpecModel.find((r) => r.model === "gpt-4o-mini");
+  assert.equal(agg.bySpecModel.length, 2, "two traces of one spec must not make four rows");
+  assert.equal(row.calls, 4);
+  assert.equal(row.total_tokens, 400);
+});
+
+test("bySpecModel keeps two different tests in the same file apart", () => {
+  const agg = aggregate({
+    probes: [twoModelProbe("t1"), twoModelProbe("t2")],
+    attributions: [
+      { trace_id: "t1", file: "a.spec.ts", test: "first" },
+      { trace_id: "t2", file: "a.spec.ts", test: "second" },
+    ],
+    prices: P,
+  });
+  const titles = agg.bySpecModel.filter((r) => r.model === "gpt-4o-mini").map((r) => r.title_path).sort();
+  assert.deepEqual(titles, ["first", "second"]);
+});
+
+test("unattributed traces collapse to ONE row per model with null identity", () => {
+  // The DB's unique index treats two NULL test_keys as the SAME row
+  // (COALESCE(test_key,'')), so emitting two would collide on re-POST.
+  const agg = aggregate({
+    probes: [twoModelProbe("t1"), twoModelProbe("t2")],
+    attributions: [],
+    prices: P,
+  });
+  assert.equal(agg.bySpecModel.length, 2);
+  for (const row of agg.bySpecModel) {
+    assert.equal(row.spec_path, null);
+    assert.equal(row.title_path, null);
+  }
+  const row = agg.bySpecModel.find((r) => r.model === "gpt-4o-mini");
+  assert.equal(row.calls, 4);
+  assert.equal(row.total_tokens, 400);
+});
+
+test("an attributed and an unattributed trace of the same model stay separate rows", () => {
+  const agg = aggregate({
+    probes: [twoModelProbe("t1"), twoModelProbe("t2")],
+    attributions: [{ trace_id: "t1", file: "a.spec.ts", test: "named" }],
+    prices: P,
+  });
+  const mini = agg.bySpecModel.filter((r) => r.model === "gpt-4o-mini");
+  assert.equal(mini.length, 2);
+  assert.deepEqual(
+    mini.map((r) => r.spec_path).sort((a, b) => String(a).localeCompare(String(b))),
+    [null, "a.spec.ts"].sort((a, b) => String(a).localeCompare(String(b))),
+  );
+});
+
+test("spanTokens is the span-derived total, independent of the trace totals", () => {
+  // G3: trace-authoritative vs span-derived are two numbers and neither wins.
+  // This probe's own total (300) disagrees with its spans (200+100=300 here, so
+  // make one disagree deliberately).
+  const agg = aggregate({
+    probes: [twoModelProbe("t1", { total_tokens: 999 })],
+    attributions: [],
+    prices: P,
+  });
+  assert.equal(agg.spanTokens, 300, "spans sum to 300 regardless of the trace's claim");
+  assert.equal(agg.totals.total_tokens, 999, "the trace's own total stays authoritative");
+  assert.equal(agg.mismatches.length, 1, "and the disagreement is named");
+});
+
+test("spanTokens falls back to prompt+completion when a span omits its total", () => {
+  const agg = aggregate({
+    probes: [
+      {
+        trace_id: "t1",
+        models: [{ model: "gpt-4o-mini", prompt_tokens: 7, completion_tokens: 3, calls: 1 }],
+      },
+    ],
+    attributions: [],
+    prices: P,
+  });
+  assert.equal(agg.spanTokens, 10);
+});
+
+test("bySpecModel is empty when there are no probes", () => {
+  const agg = aggregate({ probes: [], attributions: [], prices: P });
+  assert.deepEqual(agg.bySpecModel, []);
+  assert.equal(agg.spanTokens, 0);
+});

--- a/scripts/lib/token-cost.test.mjs
+++ b/scripts/lib/token-cost.test.mjs
@@ -695,7 +695,9 @@ test("bySpecModel keeps two different tests in the same file apart", () => {
 
 test("unattributed traces collapse to ONE row per model with null identity", () => {
   // The DB's unique index treats two NULL test_keys as the SAME row
-  // (COALESCE(test_key,'')), so emitting two would collide on re-POST.
+  // (COALESCE(test_key,'')), so emitting two would not duplicate — the live
+  // ingest upserts and keeps the LAST, counting the loser in `rows_dropped`.
+  // One of the two numbers would be silently discarded (#1253 review, finding 7).
   const agg = aggregate({
     probes: [twoModelProbe("t1"), twoModelProbe("t2")],
     attributions: [],

--- a/scripts/merge-token-payload.mjs
+++ b/scripts/merge-token-payload.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * Fold the run's token spend into the payload the QA Platform already receives
+ * (issue #1217 §5.2).
+ *
+ * WHY A SECOND POST AND NOT A REORDER
+ *
+ * daily-stable.yml builds payload.json (~:931) and POSTs the run (~:950) well
+ * before `watch-tokens.mjs --summarize` (~:989) computes what the run cost. The
+ * run's own POST must not wait behind a telemetry step, so this script runs
+ * after the summarize and re-POSTs the same payload with a `tokens` block added.
+ * The platform's edge function calls the ingest at both of its exit points --
+ * including the short-circuit for a run it already recorded -- so the second
+ * POST lands the token rows and leaves the run row untouched. Verified against
+ * production on 2026-08-03: `status: exists`, `received: 4, inserted: 4`.
+ *
+ * THE BLOCK'S CONTRACT IS NOT DEFINED HERE
+ *
+ * `tokens` is opaque jsonb to the edge function, which passes it straight to
+ * `public.e2e_ingest_run_tokens`. That function is the authority on which keys
+ * mean anything -- see quality-platform's
+ * supabase/migrations/20260803130300_e2e_ingest_run_tokens.sql:103-131. Unknown
+ * keys are accepted and ignored, which is what lets this script carry
+ * `target_provider` and the coverage fields before the platform reads them
+ * (design §6.3).
+ *
+ * WHY A MISSING BLOCK MEANS "DO NOT POST" AND NOT "POST ZEROS"
+ *
+ * `summarize()` deliberately writes no block for a run that captured nothing.
+ * Sending `{traces: 0, total_tokens: 0, rows: []}` would clamp the run's token
+ * columns to zero, which is indistinguishable from a run that genuinely spent
+ * nothing -- the one distinction e2e_automation_runs' token columns exist to
+ * keep (20260803130100_e2e_run_token_columns.sql:14-16). So `written: false` is
+ * a real outcome and the caller must honour it by skipping the POST.
+ */
+import { readFileSync, writeFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const realIo = {
+  readFile: (p) => readFileSync(p, "utf8"),
+  writeFile: (p, body) => writeFileSync(p, body),
+  listDir: (dir) => readdirSync(dir).map((f) => path.join(dir, f)),
+};
+
+// Every shard resolves the day's provider independently -- the rotation walks on
+// to the next provider when the day's own is dry, and that verdict depends on the
+// providers.json that shard's own collect-models produced. So they CAN disagree.
+// When they do, no value is published: reporting one shard's provider as "the
+// run's" would name a provider the other shard never used, and design §6.4
+// requires the field to be the RESOLVED value or nothing.
+export function resolveTargetProvider(values = []) {
+  const distinct = [...new Set(values.map((v) => String(v ?? "").trim()).filter(Boolean))].sort();
+  if (distinct.length === 0) return { provider: null, conflict: [] };
+  if (distinct.length === 1) return { provider: distinct[0], conflict: [] };
+  return { provider: null, conflict: distinct };
+}
+
+export async function mergeTokenPayload({
+  env = process.env,
+  readFile = realIo.readFile,
+  writeFile = realIo.writeFile,
+  listDir = realIo.listDir,
+  log = console.log,
+} = {}) {
+  const blockPath = env.TOKENS_SUMMARY_OUT || "tokens-block.json";
+  const payloadIn = env.PAYLOAD_IN || "payload.json";
+  const payloadOut = env.PAYLOAD_OUT || "payload-with-tokens.json";
+  const tokensDir = env.TOKENS_DIR || "all-tokens";
+
+  const readJson = (p) => {
+    let raw;
+    try {
+      raw = readFile(p);
+    } catch (error) {
+      return { error: `could not read ${p}: ${error?.message || error}` };
+    }
+    try {
+      return { value: JSON.parse(raw) };
+    } catch (error) {
+      return { error: `could not parse ${p}: ${error?.message || error}` };
+    }
+  };
+
+  const block = readJson(blockPath);
+  if (block.error) {
+    const reason = `no tokens block to merge (${block.error})`;
+    log(`merge-token-payload: ${reason} — skipping the token POST.`);
+    return { written: false, reason };
+  }
+
+  const payload = readJson(payloadIn);
+  if (payload.error) {
+    const reason = `no run payload to merge into (${payload.error})`;
+    log(`merge-token-payload: ${reason} — skipping the token POST.`);
+    return { written: false, reason };
+  }
+
+  let providerFiles = [];
+  try {
+    providerFiles = listDir(tokensDir).filter((f) => path.basename(f).startsWith("token-provider-"));
+  } catch {
+    providerFiles = [];
+  }
+  const values = [];
+  for (const file of providerFiles) {
+    try {
+      values.push(readFile(file));
+    } catch {
+      // A shard that uploaded no provider file simply does not vote.
+    }
+  }
+  const { provider, conflict } = resolveTargetProvider(values);
+  if (conflict.length) {
+    log(
+      `merge-token-payload: shards disagree on the resolved provider (${conflict.join(", ")}) — ` +
+        "omitting target_provider rather than publishing one shard's value as the run's.",
+    );
+  } else if (!provider) {
+    log("merge-token-payload: no shard recorded a resolved provider — omitting target_provider.");
+  }
+
+  const tokens = { ...block.value, ...(provider ? { target_provider: provider } : {}) };
+  writeFile(payloadOut, JSON.stringify({ ...payload.value, tokens }));
+  log(
+    `merge-token-payload: wrote ${payloadOut} — ${tokens.rows?.length ?? 0} token row(s), ` +
+      `${tokens.total_tokens ?? "?"} tokens, provider ${provider ?? "unreported"}.`,
+  );
+  return { written: true, reason: "merged" };
+}
+
+// `import.meta.url` guard: the test imports this module, and importing it must
+// not run the CLI.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  // Deliberately no exit code branch: "nothing to merge" is a normal outcome and
+  // the workflow gates on whether PAYLOAD_OUT exists, not on this process's
+  // status. A non-zero exit here would only make the step's continue-on-error
+  // swallow a message the log already carries.
+  await mergeTokenPayload();
+}

--- a/scripts/merge-token-payload.mjs
+++ b/scripts/merge-token-payload.mjs
@@ -18,8 +18,12 @@
  *
  * `tokens` is opaque jsonb to the edge function, which passes it straight to
  * `public.e2e_ingest_run_tokens`. That function is the authority on which keys
- * mean anything -- see quality-platform's
- * supabase/migrations/20260803130300_e2e_ingest_run_tokens.sql:103-131. Unknown
+ * mean anything -- and the LIVE definition is quality-platform's
+ * supabase/migrations/20260803130600_e2e_token_ingest_preserve_upsert_clamp.sql,
+ * which DROPped and replaced the original 20260803130300_e2e_ingest_run_tokens.sql
+ * (#1253 review, finding 7: three files cited the dead one). Field names are
+ * identical across the two, so nothing behaved wrongly -- but the semantics did
+ * change: it upserts with DO UPDATE now, not ON CONFLICT DO NOTHING. Unknown
  * keys are accepted and ignored, which is what lets this script carry
  * `target_provider` and the coverage fields before the platform reads them
  * (design §6.3).
@@ -42,6 +46,18 @@ const realIo = {
   writeFile: (p, body) => writeFileSync(p, body),
   listDir: (dir) => readdirSync(dir).map((f) => path.join(dir, f)),
 };
+
+// The verdicts this script can reach, as the CLI prints them (`code=<…>`). Named
+// here rather than inline so the workflow's own structural guard can assert that
+// every one of them is handled by the step that reads them — a new code that the
+// YAML silently falls through on would report a real outcome as the default one.
+export const MERGE_CODES = [
+  "merged",
+  "block_missing",
+  "block_unparseable",
+  "payload_missing",
+  "payload_unparseable",
+];
 
 // Every shard resolves the day's provider independently -- the rotation walks on
 // to the next provider when the day's own is dry, and that verdict depends on the
@@ -68,17 +84,24 @@ export async function mergeTokenPayload({
   const payloadOut = env.PAYLOAD_OUT || "payload-with-tokens.json";
   const tokensDir = env.TOKENS_DIR || "all-tokens";
 
+  // `kind` separates ABSENT from UNPARSEABLE. Both end the same way here — no
+  // POST — but they are different facts about the run, and the caller (the
+  // workflow step) is the place where collapsing them does damage: an absent
+  // block is a run that captured nothing, while an unparseable one is a run
+  // whose numbers were computed and then lost. Reporting the second as the
+  // first is the absent-vs-zero conflation this whole path exists to prevent,
+  // reproduced one layer up (#1253 review, finding 3).
   const readJson = (p) => {
     let raw;
     try {
       raw = readFile(p);
     } catch (error) {
-      return { error: `could not read ${p}: ${error?.message || error}` };
+      return { kind: "missing", error: `could not read ${p}: ${error?.message || error}` };
     }
     try {
       return { value: JSON.parse(raw) };
     } catch (error) {
-      return { error: `could not parse ${p}: ${error?.message || error}` };
+      return { kind: "unparseable", error: `could not parse ${p}: ${error?.message || error}` };
     }
   };
 
@@ -86,14 +109,14 @@ export async function mergeTokenPayload({
   if (block.error) {
     const reason = `no tokens block to merge (${block.error})`;
     log(`merge-token-payload: ${reason} — skipping the token POST.`);
-    return { written: false, reason };
+    return { written: false, reason, code: `block_${block.kind}` };
   }
 
   const payload = readJson(payloadIn);
   if (payload.error) {
     const reason = `no run payload to merge into (${payload.error})`;
     log(`merge-token-payload: ${reason} — skipping the token POST.`);
-    return { written: false, reason };
+    return { written: false, reason, code: `payload_${payload.kind}` };
   }
 
   let providerFiles = [];
@@ -135,7 +158,7 @@ export async function mergeTokenPayload({
     `merge-token-payload: wrote ${payloadOut} — ${tokens.rows?.length ?? 0} token row(s), ` +
       `${tokens.total_tokens ?? "?"} tokens, provider ${provider ?? "unreported"}.`,
   );
-  return { written: true, reason: "merged" };
+  return { written: true, reason: "merged", code: "merged" };
 }
 
 // `import.meta.url` guard: the test imports this module, and importing it must
@@ -145,5 +168,10 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   // the workflow gates on whether PAYLOAD_OUT exists, not on this process's
   // status. A non-zero exit here would only make the step's continue-on-error
   // swallow a message the log already carries.
-  await mergeTokenPayload();
+  const result = await mergeTokenPayload();
+  // The LAST line, and machine-readable on purpose: daily-stable.yml greps this
+  // to tell "captured nothing" from "computed and then lost". The prose above is
+  // for a human reading the log; `code=` is the contract, and MERGE_CODES below
+  // is the list the workflow's own guard is pinned against.
+  console.log(`merge-token-payload: code=${result.code}`);
 }

--- a/scripts/merge-token-payload.mjs
+++ b/scripts/merge-token-payload.mjs
@@ -120,6 +120,15 @@ export async function mergeTokenPayload({
     log("merge-token-payload: no shard recorded a resolved provider — omitting target_provider.");
   }
 
+  // Second, deliberate guard: `resolveTargetProvider` is the first line of
+  // defense (it already filters blank/whitespace values out before a `provider`
+  // ever reaches here, so today `provider` is always exactly `null` or a
+  // non-empty string). This ternary re-checks truthiness anyway, on purpose --
+  // if that upstream filter is ever loosened, an empty string must still fail
+  // to produce a `target_provider` key rather than silently publishing one.
+  // The two guards are redundant today by design, not by accident; a change to
+  // either one alone, with the other left intact, is not expected to be
+  // independently observable from outside this module.
   const tokens = { ...block.value, ...(provider ? { target_provider: provider } : {}) };
   writeFile(payloadOut, JSON.stringify({ ...payload.value, tokens }));
   log(

--- a/scripts/merge-token-payload.test.mjs
+++ b/scripts/merge-token-payload.test.mjs
@@ -157,9 +157,22 @@ test("omits the provider when no shard recorded one", async () => {
   assert.equal("target_provider" in JSON.parse(t.written.get("merged.json")).tokens, false);
 });
 
-test("an empty provider file is not a provider", async () => {
+test("omits target_provider end-to-end when the only recorded file is empty", async () => {
   // The shard writes the file unconditionally, so "the rotation declined to pin"
   // arrives as an empty file, not a missing one.
+  //
+  // NAMING NOTE (fix round 1): this used to be named "an empty provider file is
+  // not a provider", which implied it was pinning down resolveTargetProvider's
+  // own filtering. It is not -- resolveTargetProvider already has a dedicated
+  // unit test below ("resolveTargetProvider is pure and reports its own
+  // verdict") that covers `["", "  "]` directly. This test instead proves the
+  // END-TO-END outcome through the full mergeTokenPayload pipeline: today that
+  // outcome is guaranteed twice over (resolveTargetProvider's filter AND the
+  // merge-site ternary in merge-token-payload.mjs), so this test cannot, by
+  // itself, tell you which guard is doing the work -- only that the observable
+  // result is still correct. See the comment on the merge-site ternary for why
+  // the two guards are intentionally redundant and why a break in exactly one
+  // of them, with the other intact, is not expected to turn this test red.
   const t = io({
     files: {
       "payload.json": JSON.stringify(PAYLOAD),

--- a/scripts/merge-token-payload.test.mjs
+++ b/scripts/merge-token-payload.test.mjs
@@ -1,0 +1,192 @@
+// Unit tests for the token payload merge (issue #1217 §5.2).
+// Run with: npm run test:scripts
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mergeTokenPayload, resolveTargetProvider } from "./merge-token-payload.mjs";
+
+const BLOCK = { traces: 1, total_tokens: 88, span_tokens: 88, mismatch_traces: 0, rows: [] };
+const PAYLOAD = {
+  version: 1,
+  date: "2026-08-03",
+  run_id: "42",
+  totals: { passed: 1 },
+  tokens: { stale: true },
+};
+
+const io = ({ files = {}, dir = [] } = {}) => {
+  const written = new Map();
+  return {
+    written,
+    logged: [],
+    readFile: (p) => {
+      if (!(p in files)) throw new Error(`ENOENT: ${p}`);
+      return files[p];
+    },
+    listDir: () => dir,
+    writeFile: (p, body) => written.set(p, body),
+  };
+};
+
+test("merges the tokens block into the payload and reports written", async () => {
+  const t = io({ files: { "payload.json": JSON.stringify(PAYLOAD), "tokens-block.json": JSON.stringify(BLOCK) } });
+  const res = await mergeTokenPayload({
+    env: { TOKENS_SUMMARY_OUT: "tokens-block.json", PAYLOAD_IN: "payload.json", PAYLOAD_OUT: "merged.json" },
+    ...t,
+    log: (m) => t.logged.push(m),
+  });
+  assert.equal(res.written, true);
+  const merged = JSON.parse(t.written.get("merged.json"));
+  assert.equal(merged.version, 1);
+  assert.equal(merged.run_id, "42");
+  assert.deepEqual(merged.totals, { passed: 1 });
+  // PAYLOAD carries a stale `tokens.stale` key; it must lose to the fresh block
+  // — this is what catches a spread-order regression (Step 5 mutation 4).
+  assert.equal(merged.tokens.total_tokens, 88);
+  assert.deepEqual(merged.tokens.rows, []);
+});
+
+test("writes nothing when the tokens block is absent", async () => {
+  // G4: no block means the run captured nothing. A payload with an empty tokens
+  // block would clamp the run's token columns to zero.
+  const t = io({ files: { "payload.json": JSON.stringify(PAYLOAD) } });
+  const res = await mergeTokenPayload({
+    env: { TOKENS_SUMMARY_OUT: "tokens-block.json", PAYLOAD_IN: "payload.json", PAYLOAD_OUT: "merged.json" },
+    ...t,
+    log: (m) => t.logged.push(m),
+  });
+  assert.equal(res.written, false);
+  assert.equal(t.written.size, 0);
+  assert.match(res.reason, /tokens block/i);
+  assert.ok(t.logged.length > 0, "the skip must be logged, never silent");
+});
+
+test("writes nothing when the payload itself is absent", async () => {
+  const t = io({ files: { "tokens-block.json": JSON.stringify(BLOCK) } });
+  const res = await mergeTokenPayload({
+    env: { TOKENS_SUMMARY_OUT: "tokens-block.json", PAYLOAD_IN: "payload.json", PAYLOAD_OUT: "merged.json" },
+    ...t,
+    log: (m) => t.logged.push(m),
+  });
+  assert.equal(res.written, false);
+  assert.equal(t.written.size, 0);
+  assert.match(res.reason, /payload/i);
+});
+
+test("writes nothing when the tokens block is unparseable", async () => {
+  const t = io({ files: { "payload.json": JSON.stringify(PAYLOAD), "tokens-block.json": "{not json" } });
+  const res = await mergeTokenPayload({
+    env: { TOKENS_SUMMARY_OUT: "tokens-block.json", PAYLOAD_IN: "payload.json", PAYLOAD_OUT: "merged.json" },
+    ...t,
+    log: (m) => t.logged.push(m),
+  });
+  assert.equal(res.written, false);
+  assert.equal(t.written.size, 0);
+});
+
+test("carries the resolved provider when every shard agrees", async () => {
+  const t = io({
+    files: {
+      "payload.json": JSON.stringify(PAYLOAD),
+      "tokens-block.json": JSON.stringify(BLOCK),
+      "all-tokens/token-provider-1.txt": "anthropic\n",
+      "all-tokens/token-provider-2.txt": "anthropic",
+    },
+    dir: ["all-tokens/token-provider-1.txt", "all-tokens/token-provider-2.txt", "all-tokens/token-probes-1.jsonl"],
+  });
+  const res = await mergeTokenPayload({
+    env: {
+      TOKENS_SUMMARY_OUT: "tokens-block.json",
+      PAYLOAD_IN: "payload.json",
+      PAYLOAD_OUT: "merged.json",
+      TOKENS_DIR: "all-tokens",
+    },
+    ...t,
+    log: (m) => t.logged.push(m),
+  });
+  assert.equal(res.written, true);
+  assert.equal(JSON.parse(t.written.get("merged.json")).tokens.target_provider, "anthropic");
+});
+
+test("omits the provider and says so when shards disagree", async () => {
+  // G5: the provider must be reported AS RESOLVED. Picking one of two
+  // disagreeing shards would publish a value no shard actually ran.
+  const t = io({
+    files: {
+      "payload.json": JSON.stringify(PAYLOAD),
+      "tokens-block.json": JSON.stringify(BLOCK),
+      "all-tokens/token-provider-1.txt": "anthropic",
+      "all-tokens/token-provider-2.txt": "google",
+    },
+    dir: ["all-tokens/token-provider-1.txt", "all-tokens/token-provider-2.txt"],
+  });
+  const res = await mergeTokenPayload({
+    env: {
+      TOKENS_SUMMARY_OUT: "tokens-block.json",
+      PAYLOAD_IN: "payload.json",
+      PAYLOAD_OUT: "merged.json",
+      TOKENS_DIR: "all-tokens",
+    },
+    ...t,
+    log: (m) => t.logged.push(m),
+  });
+  assert.equal(res.written, true, "a provider disagreement must not cost the token rows");
+  const merged = JSON.parse(t.written.get("merged.json"));
+  assert.equal("target_provider" in merged.tokens, false, "omitted, never null and never a guess");
+  assert.ok(
+    t.logged.some((m) => /anthropic/.test(m) && /google/.test(m)),
+    `both values must be named in the warning, got: ${JSON.stringify(t.logged)}`,
+  );
+});
+
+test("omits the provider when no shard recorded one", async () => {
+  const t = io({
+    files: { "payload.json": JSON.stringify(PAYLOAD), "tokens-block.json": JSON.stringify(BLOCK) },
+    dir: ["all-tokens/token-probes-1.jsonl"],
+  });
+  const res = await mergeTokenPayload({
+    env: {
+      TOKENS_SUMMARY_OUT: "tokens-block.json",
+      PAYLOAD_IN: "payload.json",
+      PAYLOAD_OUT: "merged.json",
+      TOKENS_DIR: "all-tokens",
+    },
+    ...t,
+    log: (m) => t.logged.push(m),
+  });
+  assert.equal(res.written, true);
+  assert.equal("target_provider" in JSON.parse(t.written.get("merged.json")).tokens, false);
+});
+
+test("an empty provider file is not a provider", async () => {
+  // The shard writes the file unconditionally, so "the rotation declined to pin"
+  // arrives as an empty file, not a missing one.
+  const t = io({
+    files: {
+      "payload.json": JSON.stringify(PAYLOAD),
+      "tokens-block.json": JSON.stringify(BLOCK),
+      "all-tokens/token-provider-1.txt": "\n",
+    },
+    dir: ["all-tokens/token-provider-1.txt"],
+  });
+  const res = await mergeTokenPayload({
+    env: {
+      TOKENS_SUMMARY_OUT: "tokens-block.json",
+      PAYLOAD_IN: "payload.json",
+      PAYLOAD_OUT: "merged.json",
+      TOKENS_DIR: "all-tokens",
+    },
+    ...t,
+    log: (m) => t.logged.push(m),
+  });
+  assert.equal("target_provider" in JSON.parse(t.written.get("merged.json")).tokens, false);
+});
+
+test("resolveTargetProvider is pure and reports its own verdict", () => {
+  assert.deepEqual(resolveTargetProvider(["anthropic", "anthropic"]), { provider: "anthropic", conflict: [] });
+  assert.deepEqual(resolveTargetProvider([]), { provider: null, conflict: [] });
+  assert.deepEqual(resolveTargetProvider(["", "  "]), { provider: null, conflict: [] });
+  assert.deepEqual(resolveTargetProvider(["google", "anthropic", "google"]), {
+    provider: null,
+    conflict: ["anthropic", "google"],
+  });
+});

--- a/scripts/merge-token-payload.test.mjs
+++ b/scripts/merge-token-payload.test.mjs
@@ -2,7 +2,26 @@
 // Run with: npm run test:scripts
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mergeTokenPayload, resolveTargetProvider } from "./merge-token-payload.mjs";
+import realFs, { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { MERGE_CODES, mergeTokenPayload, resolveTargetProvider } from "./merge-token-payload.mjs";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "..");
+const daily = () =>
+  realFs.readFileSync(path.join(REPO_ROOT, ".github/workflows/daily-stable.yml"), "utf8");
+
+// The POST step's own body, sliced from its `- name:` to the next one. Every
+// structural guard below reads THIS and not the whole file: a match anywhere in a
+// 1400-line workflow proves nothing about the step that has to carry it.
+const postStep = () => {
+  const text = daily();
+  const at = text.indexOf("- name: POST token consumption to QA Platform");
+  assert.ok(at > 0, "the daily no longer has a token POST step");
+  const next = text.indexOf("      - name:", at + 10);
+  return text.slice(at, next > 0 ? next : text.length);
+};
 
 const BLOCK = { traces: 1, total_tokens: 88, span_tokens: 88, mismatch_traces: 0, rows: [] };
 const PAYLOAD = {
@@ -192,6 +211,200 @@ test("omits target_provider end-to-end when the only recorded file is empty", as
     log: (m) => t.logged.push(m),
   });
   assert.equal("target_provider" in JSON.parse(t.written.get("merged.json")).tokens, false);
+});
+
+// --- The verdict code, which the workflow branches on ---
+//
+// `written: false` is three different facts (block absent / block computed then
+// lost / payload unusable) and the step's notice used to name only the first, so a
+// CORRUPTED block read as "this run captured nothing" — the absent-vs-zero
+// conflation this path exists to prevent, one layer up (#1253 review, finding 3).
+
+test("the code separates an ABSENT block from an UNPARSEABLE one", async () => {
+  const absent = io({ files: { "payload.json": JSON.stringify(PAYLOAD) } });
+  const corrupt = io({ files: { "payload.json": JSON.stringify(PAYLOAD), "tokens-block.json": "{not json" } });
+  const env = { TOKENS_SUMMARY_OUT: "tokens-block.json", PAYLOAD_IN: "payload.json", PAYLOAD_OUT: "merged.json" };
+
+  const a = await mergeTokenPayload({ env, ...absent, log: () => {} });
+  const c = await mergeTokenPayload({ env, ...corrupt, log: () => {} });
+
+  assert.equal(a.code, "block_missing");
+  assert.equal(c.code, "block_unparseable");
+  assert.notEqual(a.code, c.code, "the two must be distinguishable — the whole point of the field");
+});
+
+test("the code separates an absent payload from an unparseable one", async () => {
+  const absent = io({ files: { "tokens-block.json": JSON.stringify(BLOCK) } });
+  const corrupt = io({ files: { "tokens-block.json": JSON.stringify(BLOCK), "payload.json": "{nope" } });
+  const env = { TOKENS_SUMMARY_OUT: "tokens-block.json", PAYLOAD_IN: "payload.json", PAYLOAD_OUT: "merged.json" };
+
+  assert.equal((await mergeTokenPayload({ env, ...absent, log: () => {} })).code, "payload_missing");
+  assert.equal((await mergeTokenPayload({ env, ...corrupt, log: () => {} })).code, "payload_unparseable");
+});
+
+test("a successful merge reports code=merged", async () => {
+  const t = io({ files: { "payload.json": JSON.stringify(PAYLOAD), "tokens-block.json": JSON.stringify(BLOCK) } });
+  const res = await mergeTokenPayload({
+    env: { TOKENS_SUMMARY_OUT: "tokens-block.json", PAYLOAD_IN: "payload.json", PAYLOAD_OUT: "merged.json" },
+    ...t,
+    log: () => {},
+  });
+  assert.equal(res.code, "merged");
+});
+
+test("MERGE_CODES lists every code the module can actually return", async () => {
+  // The workflow's guard below is pinned against MERGE_CODES, so a code the
+  // module emits but the list omits would be a silent fallthrough in the YAML.
+  const env = { TOKENS_SUMMARY_OUT: "tokens-block.json", PAYLOAD_IN: "payload.json", PAYLOAD_OUT: "merged.json" };
+  const cases = [
+    { files: { "payload.json": JSON.stringify(PAYLOAD), "tokens-block.json": JSON.stringify(BLOCK) } },
+    { files: { "payload.json": JSON.stringify(PAYLOAD) } },
+    { files: { "payload.json": JSON.stringify(PAYLOAD), "tokens-block.json": "{x" } },
+    { files: { "tokens-block.json": JSON.stringify(BLOCK) } },
+    { files: { "tokens-block.json": JSON.stringify(BLOCK), "payload.json": "{x" } },
+  ];
+  const seen = [];
+  for (const c of cases) {
+    const res = await mergeTokenPayload({ env, ...io(c), log: () => {} });
+    seen.push(res.code);
+  }
+  assert.deepEqual([...seen].sort(), [...MERGE_CODES].sort());
+});
+
+// --- Structural guards: is the daily workflow actually wired to this script? ---
+//
+// Same rationale as watch-tokens.test.mjs's own guards (#1045): a real token POST
+// cannot be reproduced in a unit test, but the WIRING can be asserted cheaply.
+// These exist because #1217's own PR body named the TOKENS_SUMMARY_OUT seam as the
+// place where "a wrong number looks correct" and then verified it BY HAND
+// (#1253 review, finding 1) — hand-verification does not survive the next editor.
+
+test("the daily hands the same TOKENS_SUMMARY_OUT to the summarize step and the POST step", () => {
+  const text = daily();
+  const matches = [...text.matchAll(/TOKENS_SUMMARY_OUT:\s*(\S+)/g)].map((m) => m[1]);
+  assert.equal(
+    matches.length,
+    2,
+    `expected exactly two TOKENS_SUMMARY_OUT declarations (summarize + POST), got ${matches.length}: ${matches.join(", ")}`,
+  );
+  assert.equal(
+    matches[0],
+    matches[1],
+    "the summarizer would write one path while the merge looks for another — and the merge's own " +
+      '"no tokens block" branch would then report a run that DID capture as one that captured nothing',
+  );
+});
+
+test("the token POST runs AFTER the summarize that computes the number", () => {
+  const text = daily();
+  const summarize = text.indexOf("node scripts/watch-tokens.mjs --summarize");
+  const post = text.indexOf("node scripts/merge-token-payload.mjs");
+  assert.ok(summarize > 0, "the merge job no longer summarizes token consumption");
+  assert.ok(post > 0, "the merge job no longer runs the token payload merge");
+  assert.ok(post > summarize, "the block does not exist until --summarize has run");
+});
+
+test("the token POST step reads the same directory the shard artifacts are downloaded into", () => {
+  const text = daily();
+  const download = text.indexOf("- name: Download shard token consumption data");
+  assert.ok(download > 0, "the merge job no longer downloads the shard token artifacts");
+  const downloadPath = /path:\s*(\S+)/.exec(text.slice(download, download + 500))?.[1];
+  const stepTokensDir = /TOKENS_DIR:\s*(\S+)/.exec(postStep())?.[1];
+  assert.ok(downloadPath, "the download step declares no path:");
+  assert.equal(
+    stepTokensDir,
+    downloadPath,
+    "TOKENS_DIR must be the download's own path: — otherwise the provider files are silently never read " +
+      "and every run reports target_provider as unreported",
+  );
+});
+
+test("the shard writes its resolved provider into the directory it uploads", () => {
+  const text = daily();
+  const stop = text.indexOf("- name: Stop and collect token consumption");
+  const upload = text.indexOf("- name: Upload token consumption");
+  assert.ok(stop > 0 && upload > 0, "the shard's stop/upload token steps must both exist");
+  const stopBody = text.slice(stop, upload);
+  assert.match(
+    stopBody,
+    /token-provider-\$\{\{ matrix\.shard \}\}\.txt/,
+    "the provider must be written per-shard — one name for all shards would collide under merge-multiple",
+  );
+  assert.match(
+    stopBody,
+    /> "tokens\/token-provider-/,
+    "it must land inside tokens/, the directory the upload step actually ships",
+  );
+  assert.match(
+    text.slice(upload, upload + 400),
+    /path:\s*tokens\//,
+    "the upload step must still ship the tokens/ directory",
+  );
+});
+
+test("the POST step handles every MERGE_CODES verdict, and has a fallback for none of them", () => {
+  const body = postStep();
+  for (const code of MERGE_CODES) {
+    if (code === "merged") continue; // the merged path is the one that POSTs, not a notice
+    assert.ok(
+      body.includes(code),
+      `the POST step does not branch on "${code}" — that outcome would fall through to the default message`,
+    );
+  }
+  // The unknown-verdict arm: a code this list does not yet contain must be
+  // reported as UNKNOWN, never as a run that captured nothing (#1012, #1035).
+  assert.match(
+    body,
+    /UNKNOWN, not zero/,
+    "the step must name an unrecognised verdict as unknown rather than defaulting to a plausible zero",
+  );
+});
+
+// The `code` is only useful if the CLI PRINTS it in the shape the workflow reads.
+// Everything above tests the returned value; this runs the real process and then
+// applies the workflow's OWN extractor to its real stdout, so the contract is
+// pinned from both ends at once. Without it, renaming the printed prefix leaves
+// every other test in this file green while the step's verdict goes permanently
+// empty — measured: that mutation passed 19/19 before this test existed.
+test("the daily's own extractor reads the real CLI's real stdout", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "merge-token-payload-"));
+  writeFileSync(path.join(dir, "payload.json"), JSON.stringify(PAYLOAD));
+  // No tokens block on disk → the CLI must reach `block_missing`, a verdict the
+  // step has a distinct branch for.
+  const run = spawnSync(process.execPath, [path.join(REPO_ROOT, "scripts/merge-token-payload.mjs")], {
+    cwd: dir,
+    encoding: "utf8",
+    env: { ...process.env, TOKENS_SUMMARY_OUT: "tokens-block.json", PAYLOAD_IN: "payload.json" },
+  });
+  assert.equal(run.status, 0, `the CLI must exit 0 on a normal no-block run: ${run.stderr}`);
+
+  // Lifted verbatim from the workflow rather than re-typed here — a re-typed copy
+  // would keep agreeing with itself after the YAML changed.
+  const extractor = /verdict=\$\(printf '%s\\n' "\$merge_log" \| (sed -n 's[^']*'[^)]*)\)/.exec(postStep());
+  assert.ok(extractor, "the POST step no longer extracts a verdict from the merge log");
+  const extracted = spawnSync("bash", ["-c", `printf '%s\\n' "$1" | ${extractor[1]}`, "bash", run.stdout], {
+    encoding: "utf8",
+  });
+  assert.equal(
+    extracted.stdout.trim(),
+    "block_missing",
+    `the workflow's extractor read "${extracted.stdout.trim()}" out of the CLI's actual output:\n${run.stdout}`,
+  );
+});
+
+test("the POST step judges the ingest by its body, not by HTTP 200 alone", () => {
+  // #1253 review, finding 2: the platform's token ingest is diagnostic on its own
+  // side and never fails the request, so a rejected or partially-lost block comes
+  // back inside a 200. The contract is quality-platform's `tokenFields`.
+  const body = postStep();
+  for (const field of ["tokens_status", "tokens_dropped"]) {
+    assert.ok(body.includes(field), `the step must read ${field} from the response body`);
+  }
+  assert.match(body, /ingested/, "the only success is tokens_status=ingested");
+  assert.ok(
+    /absent/.test(body),
+    "a body with no tokens_status must be reported as unverifiable, not silently accepted",
+  );
 });
 
 test("resolveTargetProvider is pure and reports its own verdict", () => {

--- a/scripts/watch-tokens.mjs
+++ b/scripts/watch-tokens.mjs
@@ -504,7 +504,9 @@ export async function summarize({
 
   // §5.2: the block the merge step folds into payload.json and re-POSTs. Field
   // names are the INGEST RPC's, not this module's -- the authority is
-  // quality-platform's 20260803130300_e2e_ingest_run_tokens.sql, which
+  // quality-platform's live 20260803130600_e2e_token_ingest_preserve_upsert_clamp.sql
+  // (it DROPped and replaced 20260803130300_e2e_ingest_run_tokens.sql, which three
+  // files here used to cite -- #1253 review, finding 7), which
   // destructures exactly `traces`, `total_tokens`, `span_tokens`,
   // `mismatch_traces` and `rows[]`. Everything else here (unattributed,
   // attrib_*) is accepted and ignored until the platform reads it (§6.3).

--- a/scripts/watch-tokens.mjs
+++ b/scripts/watch-tokens.mjs
@@ -325,6 +325,7 @@ export async function summarize({
   const attribDir = env.TOKENS_ATTRIB_DIR || dir;
   const historyPath = env.TOKENS_HISTORY || "reports/token-history.jsonl";
   const summaryPath = env.TOKENS_SUMMARY_MD || env.GITHUB_STEP_SUMMARY;
+  const summaryOutPath = env.TOKENS_SUMMARY_OUT;
   // Measurement-only lanes (#1183 — pr-validation.yml, manual.yml). Those lanes
   // want the step-summary table (so the run's own spend is visible) but must
   // NEVER add a line to reports/token-history.jsonl: that file is the daily's
@@ -490,6 +491,35 @@ export async function summarize({
       appendFile(historyPath, `${JSON.stringify(runLine)}\n`);
     } catch (error) {
       log(`token summary: could not append the history line: ${error?.message || error}`);
+    }
+  }
+
+  // §5.2: the block the merge step folds into payload.json and re-POSTs. Field
+  // names are the INGEST RPC's, not this module's -- the authority is
+  // quality-platform's 20260803130300_e2e_ingest_run_tokens.sql, which
+  // destructures exactly `traces`, `total_tokens`, `span_tokens`,
+  // `mismatch_traces` and `rows[]`. Everything else here (unattributed,
+  // attrib_*) is accepted and ignored until the platform reads it (§6.3).
+  //
+  // Written ONLY on a run that captured something: this code sits below the
+  // zero-capture early return on purpose. A block of zeros would clamp the run's
+  // token columns to 0, which is indistinguishable from a run that genuinely
+  // spent nothing -- the distinction that table exists to keep.
+  if (summaryOutPath) {
+    const block = {
+      traces: agg.totals.traces,
+      total_tokens: agg.totals.total_tokens,
+      span_tokens: agg.spanTokens,
+      mismatch_traces: agg.mismatches.length,
+      unattributed: agg.unattributed,
+      attrib_ms: agg.attrib_ms,
+      attrib_calls: agg.attrib_calls,
+      rows: agg.bySpecModel,
+    };
+    try {
+      writeFile(summaryOutPath, JSON.stringify(block));
+    } catch (error) {
+      log(`token summary: could not write the tokens block: ${error?.message || error}`);
     }
   }
 

--- a/scripts/watch-tokens.mjs
+++ b/scripts/watch-tokens.mjs
@@ -311,6 +311,13 @@ const realIo = {
   // section on exactly the red days it matters (#1197 review, finding C1).
   writeFile: (p, text) => fs.appendFileSync(p, text),
   appendFile: (p, text) => fs.appendFileSync(p, text),
+  // A genuine overwrite seam, distinct from writeFile/appendFile above: the
+  // tokens block (below) is a single JSON document, not a log line, and
+  // TOKENS_SUMMARY_OUT is a dedicated file this script owns outright — nothing
+  // else appends to it the way other steps append to GITHUB_STEP_SUMMARY. A
+  // second `--summarize` against the same path must replace the block, not
+  // concatenate onto it (`{…}{…}` is not JSON).
+  writeOut: (p, text) => fs.writeFileSync(p, text),
 };
 
 export async function summarize({
@@ -319,6 +326,7 @@ export async function summarize({
   listDir = realIo.listDir,
   writeFile = realIo.writeFile,
   appendFile = realIo.appendFile,
+  writeOut = realIo.writeOut,
   log = console.log,
 } = {}) {
   const dir = env.TOKENS_DIR || "all-tokens";
@@ -505,6 +513,13 @@ export async function summarize({
   // zero-capture early return on purpose. A block of zeros would clamp the run's
   // token columns to 0, which is indistinguishable from a run that genuinely
   // spent nothing -- the distinction that table exists to keep.
+  //
+  // Through `writeOut`, NOT `writeFile`: `writeFile`'s real implementation is
+  // `fs.appendFileSync` (required for GITHUB_STEP_SUMMARY's append-only
+  // contract, see realIo above). This block is a single JSON document, and a
+  // second `--summarize` against the same TOKENS_SUMMARY_OUT must replace it,
+  // not append `{…}{…}` — the merge step would then read invalid JSON and
+  // silently skip the token POST.
   if (summaryOutPath) {
     const block = {
       traces: agg.totals.traces,
@@ -517,7 +532,7 @@ export async function summarize({
       rows: agg.bySpecModel,
     };
     try {
-      writeFile(summaryOutPath, JSON.stringify(block));
+      writeOut(summaryOutPath, JSON.stringify(block));
     } catch (error) {
       log(`token summary: could not write the tokens block: ${error?.message || error}`);
     }

--- a/scripts/watch-tokens.test.mjs
+++ b/scripts/watch-tokens.test.mjs
@@ -1067,7 +1067,7 @@ test("a summary-write failure is logged and summarize still resolves 0", async (
 // --- §5.2: the tokens block the merge step POSTs ---
 //
 // Field names are the INGEST RPC's, not this module's -- quality-platform's
-// 20260803130300_e2e_ingest_run_tokens.sql:103-131 destructures exactly
+// live 20260803130600_e2e_token_ingest_preserve_upsert_clamp.sql destructures exactly
 // `traces`, `total_tokens`, `span_tokens`, `mismatch_traces` and `rows[]`.
 
 // A second trace whose OWN total disagrees with its spans, so span_tokens and

--- a/scripts/watch-tokens.test.mjs
+++ b/scripts/watch-tokens.test.mjs
@@ -267,6 +267,14 @@ function fakeFs(files, { throwAppend = false, throwWrite = false } = {}) {
       if (throwAppend) throw new Error("ENOSPC: no space left on device");
       appended[p] = (appended[p] || "") + text;
     },
+    // Overwrite, NOT append — models fs.writeFileSync (realIo.writeOut), unlike
+    // writeFile above. Backs the tokens-block seam: a second `--summarize`
+    // against the same path must replace the prior document, never concatenate
+    // onto it, or a re-POST reads `{…}{…}` and silently fails to parse.
+    writeOut: (p, text) => {
+      if (throwWrite) throw new Error("ENOSPC: no space left on device");
+      written[p] = text;
+    },
   };
 }
 
@@ -1142,14 +1150,15 @@ test("a failed tokens-block write degrades the telemetry, not the run", async ()
     "prices.json": PRICES,
   });
   const logged = [];
-  // Throw for the tokens block ONLY, so the failure is isolated from the
-  // step-summary write that fakeFs's own `throwWrite` would also break.
+  // Throw for the tokens block ONLY (via its own `writeOut` seam), so the
+  // failure is isolated from the step-summary write that fakeFs's own
+  // `throwWrite` would also break.
   const result = await summarize({
     env: { ...baseEnv, TOKENS_SUMMARY_OUT: "tokens-block.json" },
     ...fs2,
-    writeFile: (p, text) => {
+    writeOut: (p, text) => {
       if (p === "tokens-block.json") throw new Error("ENOSPC: no space left on device");
-      return fs2.writeFile(p, text);
+      return fs2.writeOut(p, text);
     },
     log: (m) => logged.push(m),
   });
@@ -1158,6 +1167,28 @@ test("a failed tokens-block write degrades the telemetry, not the run", async ()
     logged.some((m) => /tokens block/i.test(m) && /ENOSPC/.test(m)),
     `expected a named failure in the log, got: ${JSON.stringify(logged)}`,
   );
+});
+
+// Regression guard: the tokens block used to go through `writeFile`, whose real
+// implementation is `fs.appendFileSync` (needed for GITHUB_STEP_SUMMARY's
+// append-only contract). That seam is correct for the step summary but wrong
+// for this block -- a single JSON document, not a log line -- so a second
+// `--summarize` against the same TOKENS_SUMMARY_OUT used to concatenate
+// `{…}{…}`, which merge-token-payload.mjs then reads as unparseable and
+// silently skips. `writeOut` exists precisely so this cannot happen again.
+test("a second --summarize against the same TOKENS_SUMMARY_OUT still parses", async () => {
+  const fs2 = fakeFs({
+    "all-tokens/token-probes-1.jsonl": `${PROBE_LINE}\n`,
+    "prices.json": PRICES,
+  });
+  const env = { ...baseEnv, TOKENS_SUMMARY_OUT: "tokens-block.json" };
+
+  await summarize({ env, ...fs2, log: () => {} });
+  await summarize({ env, ...fs2, log: () => {} });
+
+  const block = JSON.parse(fs2.written["tokens-block.json"]);
+  assert.equal(block.traces, 1);
+  assert.equal(block.total_tokens, 88);
 });
 
 // --- Structural guard: is the daily workflow actually wired to this script? ---

--- a/scripts/watch-tokens.test.mjs
+++ b/scripts/watch-tokens.test.mjs
@@ -1056,6 +1056,110 @@ test("a summary-write failure is logged and summarize still resolves 0", async (
   );
 });
 
+// --- §5.2: the tokens block the merge step POSTs ---
+//
+// Field names are the INGEST RPC's, not this module's -- quality-platform's
+// 20260803130300_e2e_ingest_run_tokens.sql:103-131 destructures exactly
+// `traces`, `total_tokens`, `span_tokens`, `mismatch_traces` and `rows[]`.
+
+// A second trace whose OWN total disagrees with its spans, so span_tokens and
+// total_tokens are different numbers in the fixture. Without this the two fields
+// are equal and a test asserting span_tokens cannot tell them apart (G3).
+const MISMATCH_PROBE_LINE = JSON.stringify({
+  trace_id: "t2",
+  flow_id: "f2",
+  start_time: "2026-07-31T13:40:00Z",
+  status: "ok",
+  total_tokens: 500,
+  models: [
+    { model: "gpt-4o-mini", prompt_tokens: 10, completion_tokens: 10, total_tokens: 20, calls: 1 },
+  ],
+});
+
+test("summarize writes the tokens block to TOKENS_SUMMARY_OUT", async () => {
+  const fs2 = fakeFs({
+    "all-tokens/token-probes-1.jsonl": `${PROBE_LINE}\n${MISMATCH_PROBE_LINE}\n`,
+    "all-tokens/token-attrib-1.jsonl": `${ATTRIB_LINE}\n`,
+    "prices.json": PRICES,
+  });
+  await summarize({
+    env: { ...baseEnv, TOKENS_SUMMARY_OUT: "tokens-block.json" },
+    ...fs2,
+    log: () => {},
+  });
+
+  const block = JSON.parse(fs2.written["tokens-block.json"]);
+  assert.equal(block.traces, 2);
+  assert.equal(block.total_tokens, 588, "trace-authoritative: 88 + 500");
+  assert.equal(block.span_tokens, 108, "span-derived: 88 + 20 -- a DIFFERENT number (G3)");
+  assert.equal(block.mismatch_traces, 1, "and the disagreement is counted, not reconciled");
+
+  // t1 is attributed, t2 is not -- same model, so this also pins that the two
+  // stay separate rows (the DB's unique index keys on test_key AND model).
+  assert.equal(block.rows.length, 2);
+  const named = block.rows.find((r) => r.spec_path !== null);
+  assert.equal(named.spec_path, "tests-automations/regression/core-functionality/llm-agents/x.spec.ts");
+  assert.equal(named.title_path, "agent suite");
+  assert.equal(named.model, "gpt-4o-mini");
+  assert.equal(named.price_key, "gpt-4o-mini");
+  const anon = block.rows.find((r) => r.spec_path === null);
+  assert.equal(anon.title_path, null);
+  assert.equal(anon.total_tokens, 20);
+
+  // A1: the coverage signal is the residue that already exists, not a spec ratio.
+  assert.equal(block.unattributed.traces, 1);
+  assert.equal(block.unattributed.total_tokens, 500);
+  assert.ok("attrib_calls" in block && "attrib_ms" in block);
+});
+
+test("summarize writes NO tokens block when the run captured nothing", async () => {
+  // G4: a block of zeros would clamp the run's token columns to 0, which is
+  // indistinguishable from a run that genuinely spent nothing -- the one
+  // distinction that table exists to keep
+  // (20260803130100_e2e_run_token_columns.sql:14-16).
+  const fs2 = fakeFs({ "prices.json": PRICES });
+  await summarize({
+    env: { ...baseEnv, TOKENS_SUMMARY_OUT: "tokens-block.json" },
+    ...fs2,
+    log: () => {},
+  });
+  assert.equal("tokens-block.json" in fs2.written, false);
+});
+
+test("summarize writes no tokens block when TOKENS_SUMMARY_OUT is unset", async () => {
+  const fs2 = fakeFs({
+    "all-tokens/token-probes-1.jsonl": `${PROBE_LINE}\n`,
+    "prices.json": PRICES,
+  });
+  await summarize({ env: baseEnv, ...fs2, log: () => {} });
+  assert.equal("tokens-block.json" in fs2.written, false);
+  assert.ok(fs2.written["summary.md"], "the step summary still got written — summarize DID run");
+});
+
+test("a failed tokens-block write degrades the telemetry, not the run", async () => {
+  const fs2 = fakeFs({
+    "all-tokens/token-probes-1.jsonl": `${PROBE_LINE}\n`,
+    "prices.json": PRICES,
+  });
+  const logged = [];
+  // Throw for the tokens block ONLY, so the failure is isolated from the
+  // step-summary write that fakeFs's own `throwWrite` would also break.
+  const result = await summarize({
+    env: { ...baseEnv, TOKENS_SUMMARY_OUT: "tokens-block.json" },
+    ...fs2,
+    writeFile: (p, text) => {
+      if (p === "tokens-block.json") throw new Error("ENOSPC: no space left on device");
+      return fs2.writeFile(p, text);
+    },
+    log: (m) => logged.push(m),
+  });
+  assert.equal(result, 0, "a telemetry write failure must not change summarize's exit code");
+  assert.ok(
+    logged.some((m) => /tokens block/i.test(m) && /ENOSPC/.test(m)),
+    `expected a named failure in the log, got: ${JSON.stringify(logged)}`,
+  );
+});
+
 // --- Structural guard: is the daily workflow actually wired to this script? ---
 
 // The wedge cannot be reproduced on demand and neither can a real token spend, so


### PR DESCRIPTION
## Type

- [ ] `feat` — new test or new helper/page object
- [ ] `fix` — fix for a broken or flaky test
- [x] `chore` — CI, checklist, dependencies, internal refactoring
- [ ] `docs` — documentation update

---

## Roadmap linkage (required — do not delete)

- [ ] **Current wave** — a `roadmap`-labeled issue in the current wave's milestone: #___
- [x] **Exception** — off-wave work backed by an issue: a follow-up, a `daily-failure` triage issue, or a `community`-labeled regression (worked in severity order — `high` → `medium` → `low priority` — when indicated). Issue **#1217**

#1217 carries the `follow-up` label ("Approved exception: follow-up of merged work"). It covers §5–§6 of the design; #1248 delivered §1–§4 (capture). This is the other half.

---

## What this PR does

**The token numbers never reached the QA Platform.** `build-run-payload.mjs` did not mention tokens, and the run's POST fires ~40 steps before `watch-tokens.mjs --summarize` computes the cost. #1248 raised attribution from 2 to 141 of 172 `@stable` specs; all of it stopped inside a CI artifact.

This PR carries it across:

| Change | What it does |
|---|---|
| `token-cost.mjs` — export `resolvePriceKey` | The platform's `price_key` column records **which** table key priced a row. `resolveBands` already computed it and threw it away. Pure extraction; pricing behaviour unchanged. |
| `token-cost.mjs` — `aggregate()` gains `bySpecModel` + `spanTokens` | The cross-tab the platform's fact table needs. `byModel` and `bySpec` already existed and were never crossed; the data was in the same loop iteration. |
| `watch-tokens.mjs` — `summarize()` writes `TOKENS_SUMMARY_OUT` | Serializes the block. Writes **nothing** on a run that captured nothing. |
| `merge-token-payload.mjs` (new) | Folds the block into `payload.json`, resolves the lane's provider across shards, refuses to emit when there is nothing to say. |
| `daily-stable.yml` | The shard records its resolved provider into the token artifact; one new step merges and re-POSTs. |

**The run's own POST is untouched** — `Build run payload` and `POST run to QA Platform` are byte-identical (zero removed lines in `.github/`). A second POST rather than a reorder, because the platform's edge function calls the token ingest on its already-recorded path too, so the run row stays put and only the token rows land.

### Two deliberate departures from the design (§5–§6)

**`attribution_coverage: {specs_armed, specs_ran}` was not built.** Measured on run 30867978556: 23 spec files recorded attribution and 31 called the hook, while `specs_ran` counts every spec that ran — and most specs consume no tokens at all. The pair would read ~46% against a true cost coverage of **98.4%**. That is the failure §6.2's own warning box describes: the field built to explain the discontinuity becomes the misleading number. It also has no clean source — `payload.json`'s `coverage.stable_count` counts `@stable` **tests in the repo**, not specs that ran. The block carries `unattributed` and `attrib_calls` instead, both already computed and already on the history line, and per-trace rather than per-spec.

**`provider` was not added to every `model-prices.json` entry.** Nothing in the POST path reads it — the ingest destructures eight row fields and `provider` is not among them. The lane's single **resolved** provider *is* carried, because it is unrecoverable after the run and without it the deliberate weekly sawtooth (Tue/Fri Anthropic at ~13× the openai target's price) is indistinguishable from a spike.

---

## Tests covered

Unit tests, not Playwright specs — the whole diff is under `scripts/`. `test:scripts` goes 517 → 546.

| # | Test | What it validates |
|---|---|---|
| 1 | `resolvePriceKey` × 6 | Exact key, dated-id family resolution, longest-key-first, and the two refusals that exist to stop a wrong number — `-lite` is a separately-priced tier, not alias noise (#1211). |
| 2 | `usdFor is unchanged by the extraction` | The refactor's only real risk: that a pure move changed pricing. |
| 3 | `bySpecModel` × 5 | Row identity matches the DB's unique index — one row per `(spec_path, title_path, model)` and **exactly one unattributed row per model**. Two would collide on `COALESCE(test_key,'') = ''` and a re-POST would corrupt the bucket. |
| 4 | `spanTokens` × 3 | The span-derived total stays independent of the trace-authoritative total, and the disagreement is counted rather than reconciled. |
| 5 | `summarize` writes the block | The five field names the ingest destructures, with a fixture whose trace total (588) disagrees with its spans (108) so the two are discriminable at all. |
| 6 | `summarize` writes **no** block when the run captured nothing | A zeroed block would clamp the run's token columns and read as "this run spent nothing" — the one distinction the platform's table exists to keep. |
| 7 | `merge-token-payload` × 9 | Merge, the three refuse-to-emit paths, and provider agreement / disagreement / absence / blankness. On disagreement the field is **omitted**, never guessed. |
| 8 | `a second --summarize still parses` | The block is written through an overwrite seam, not the append-only one the step summary needs. |

---

## How the tests were built

I/O is injected at the `readFile`/`listDir`/`writeFile`/`appendFile`/`writeOut` boundary, so every test runs with no disk access. The `summarize()` tests reuse the existing `fakeFs` helper rather than adding a second fake.

**Every fix in this branch shipped with proof the test knows how to fail** — break the property in a throwaway copy, watch it go red, restore. That is what caught the defects below; without it they would have shipped green.

Two worth naming, because both were *plan* errors rather than implementation slips:

- A test asserting "no `target_provider` key" for an empty provider file **could not go red** for the property its name claimed: a second guard at the merge site shadows `resolveTargetProvider`'s filtering. Renamed to what it actually proves, and the redundant guard is now documented rather than left reading as an accident. Isolating it was proven impossible through the public surface, so no seam was invented to fake coverage.
- The block was originally written through the `writeFile` seam, whose real implementation is `fs.appendFileSync` — append-only **on purpose**, because `GITHUB_STEP_SUMMARY` requires it. A second `--summarize` therefore produced `{…}{…}`. Reproduced: 471 → 942 bytes, `JSON.parse` failing at position 471. The existing tests could not catch it because `fakeFs.writeFile` faithfully concatenates too. Fixed with a separate `writeOut` seam, and `fakeFs` gained a `writeOut` that **assigns** rather than concatenates — without that, the new regression test would have passed for the wrong reason.

---

## Dependencies

Platform side is **already deployed and verified** — no coordinated release needed:

- `public.e2e_ingest_run_tokens` and `e2e_test_token_usage` exist in production.
- The edge function calls the token ingest at both exit points, including the short-circuit for a run it already recorded. Verified against production on 2026-08-03: `status: exists`, `received: 4, inserted: 4`, run row untouched.
- All five models in the reference run are priced. A model outside that set arrives as `price_key: null` and a `usd_estimated` floor — the honest degradation, never a silent zero.

`TOKENS_SUMMARY_OUT` is the same literal in two workflow steps. A mismatch there would make the summarizer write one path while the merge looks for another, and the merge's own "no tokens block" branch would report it as a run that captured nothing — a wrong number that looks correct. Verified character for character.

---

## What this PR does not cover

- **Anything in `oriontech-me/quality-platform`.** Storing and rendering `target_provider`, `unattributed` and `attrib_calls` is §6.3's named follow-up. Until then the weekly Anthropic sawtooth is explained in the data but not on screen, and anyone reading the daily cost trend across consecutive days needs telling once, out of band, that same-weekday is the only meaningful comparison.
- **`weekly-stable.yml`, `pr-validation.yml`, `manual.yml`.** Those lanes already suppress the history line because their scope is not comparable to the daily's fixed sweep (#1183). Giving them a token POST would mix incomparable scopes into the platform's series.
- **The 1.6% residue.** Measured on run 30867978556: 11 flows deleted through the UI rather than an API helper, which the attribution hook is structurally unable to see. Closing it needs a hook on the UI delete path — a separate design, and ~$0.004 per run.
- **The nine other unpriced Claude/Gemini models** named in §7.2.1.

---

## Known limitations

**The POST itself has never executed.** First real run is the next scheduled `daily-stable`. What to check there: the step's own log line naming the row count, and `tokens_received` / `tokens_inserted` / **`tokens_dropped`** in the response body. `tokens_dropped > 0` means the block and the ingest disagree.

**Three Important review findings are knowingly deferred** rather than fixed here. All three are about *reporting* failure, not about whether the pipeline works, and all three originate in the plan I wrote:

1. `daily-stable.yml` — the POST step branches on the HTTP code alone and prints `Token rows delivered.` for any 200/201. The platform returns `tokens_status` (`skipped|ingested|rejected|failed`) and `tokens_dropped` precisely so a caller can tell "sent nothing" from "lost everything". **A rejected block returns 200 and this step declares success**, and the comment there promises otherwise.
2. `daily-stable.yml` — the file-existence gate collapses "block absent" (a real outcome), "block unparseable" and "payload absent" into one notice, though `merge-token-payload.mjs` distinguishes all three in its `reason`. So a **corrupted block reads as "this run captured nothing"** — the absent-vs-zero conflation this work exists to prevent, reproduced one layer up. Its test should assert on `reason` when this lands.
3. Three files cite `20260803130300_e2e_ingest_run_tokens.sql` as the contract's authority. That function was `DROP`ped and replaced by `20260803130600_e2e_token_ingest_preserve_upsert_clamp.sql` in the same platform commit, one day before this plan was written. Field names are identical so nothing behaves wrongly, but `token-cost.mjs` justifies the row key with `ON CONFLICT DO NOTHING` semantics that no longer exist — the live function upserts, keeping the **last** occurrence and counting losers in `rows_dropped`. **The key choice is still correct; the stated reason is false.** The real reason to emit one row per identity is not to avoid a duplicate but to avoid silently discarding a number.

**Smaller, also recorded:** the producer keys rows on raw `(spec_path, title_path, model)` while the DB keys on `md5(e2e_normalize_spec_path(spec_path) || '::' || title_path)`, so two producer rows could map to one DB identity and the smaller number would win — unreachable in-repo today, since `resolveTestAttribution` rejects a `file` without a `test`. `block.unattributed.total_tokens` is trace-authoritative while the unattributed `rows[]` are span sums; internally consistent, but a future consumer diffing the two would find a gap the block does not explain. And `build-run-payload.mjs` emits no `run_attempt`, so a workflow re-run's token rows overwrite the prior attempt's instead of superseding them — pre-existing, but this is its first dependent.

---

## Validation

- [x] `npm run test:scripts` → **546 pass, 0 fail** (517 at merge base)
- [x] `npm run test:units` → **389 pass, 0 fail** (unchanged — no `.ts` touched)
- [x] `npx tsc --noEmit` → **0 errors**
- [x] `npm run lint` → **1311 problems (0 errors, 1311 warnings)** — baseline unchanged. `eslint.config.js` targets `tests/**/*.ts` only, so nothing here is linted.
- [x] `.github/workflows/daily-stable.yml` parses under `yaml.safe_load`
- [x] **Forced a failure to confirm it is not a false positive** — every test added or changed in this branch was reverted-and-reddened, and the transcripts are in the SDD ledger.
- [x] **End-to-end proof against real data, offline.** Ran `watch-tokens --summarize` then `merge-token-payload` against the genuine artifact of CI run 30867978556 (596k tokens). Output: total **596039**, unattributed **5409**, `target_provider` **anthropic**, `null_price_keys` **0** — matching numbers measured independently *before* this plan was written, which makes it an oracle rather than a rehearsal.
- [ ] Ran the test in isolation with `--trace=on` — N/A, no Playwright specs in this PR
- [ ] Updated `QA-CHECKLIST.md` — N/A, no scenario coverage change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
