### PR TITLE
fix(repo): drop the node_modules symlink that #1253 merged into main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Both forms on purpose. `node_modules/` matches a DIRECTORY only, so it does not
+# cover a SYMLINK named node_modules — which is how one reached main in #1253: a
+# worktree symlinked the repo's own install to avoid a second `npm ci`, and
+# `git add -A` committed the link (mode 120000) pointing at an absolute path on
+# one machine. The bare form below covers both.
+node_modules
 node_modules/
 .DS_Store
 playwright-report/

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/rafael/Documents/langflow-e2e/node_modules

--- a/scripts/no-tracked-symlinks.test.mjs
+++ b/scripts/no-tracked-symlinks.test.mjs
@@ -1,0 +1,55 @@
+// A tracked symlink is a machine-specific absolute path committed into the repo.
+// Run with: npm run test:scripts
+//
+// WHY THIS EXISTS
+//
+// PR #1253 merged a `node_modules` symlink into main pointing at
+// `/Users/<someone>/Documents/langflow-e2e/node_modules`. It got there because a
+// git worktree symlinked the repo's own install to avoid a second `npm ci`, and
+// `git add -A` picked it up: `.gitignore`'s `node_modules/` matches a DIRECTORY,
+// and a symlink is a blob (mode 120000), so the ignore rule never applied.
+//
+// Nothing caught it. Every PR check passed — `npm ci` deletes and recreates the
+// path, so CI was green while the committed tree carried a link that resolves to
+// nothing on any other machine. The `.gitignore` fix beside this file closes the
+// one entry point that was used; this closes the class.
+//
+// Scoped to symlinks, not to "unexpected files": the repo legitimately gains
+// files all the time, and a guard that argues about which ones belong would be
+// noise. A tracked symlink has no legitimate use here today, so the rule can be
+// absolute — and if one is ever wanted, this test is the place to state why.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "..");
+
+test("no symlink is tracked in git", () => {
+  // `git ls-files -s` prints the mode as the first field; 120000 is a symlink.
+  // Reading the index rather than the working tree on purpose: an untracked
+  // symlink (a worktree's own convenience link) is fine and must not fail this.
+  let out;
+  try {
+    out = execFileSync("git", ["ls-files", "-s"], { cwd: REPO_ROOT, encoding: "utf8" });
+  } catch (error) {
+    // Not a git checkout (a tarball, a vendored copy): the guard cannot reach a
+    // verdict, and an unreachable verdict is not a pass (#1012). Skip loudly
+    // rather than assert on nothing.
+    assert.fail(`could not read the git index to check for tracked symlinks: ${error?.message || error}`);
+  }
+
+  const symlinks = out
+    .split("\n")
+    .filter((line) => line.startsWith("120000 "))
+    .map((line) => line.split("\t").slice(1).join("\t"));
+
+  assert.deepEqual(
+    symlinks,
+    [],
+    `tracked symlink(s) found: ${symlinks.join(", ")}. A symlink in the index is an ` +
+      "absolute path from one machine committed for everyone — it resolves to nothing " +
+      "on a fresh clone and on every CI runner. Remove it with `git rm --cached <path>` " +
+      "and add the path to .gitignore.",
+  );
+});


### PR DESCRIPTION
## Type

- [x] `fix` — a broken state on `main`

## Roadmap linkage

Follow-up to **#1253**, which merged the defect this removes. No new scope.

## What happened

`main` carries `node_modules` as a **tracked symlink** (mode `120000`) pointing at `/Users/<someone>/Documents/langflow-e2e/node_modules` — an absolute path from one machine, committed for everyone.

```
$ git ls-tree a1f7428 node_modules
120000 blob dda90ed6	node_modules
$ git show a1f7428:node_modules
/Users/rafael/Documents/langflow-e2e/node_modules
```

A fresh clone and every CI runner materialise a link that resolves to nothing.

## How it got in, and why nothing caught it

A git worktree symlinked the repo's own install to avoid a second `npm ci`, and `git add -A` committed the link.

`.gitignore`'s first line is `node_modules/`. **With the trailing slash it matches a directory only** — a symlink is a blob, so the ignore rule never applied to it.

All six checks on #1253 were green, and correctly so: `npm ci` deletes and recreates the path, so nothing any lane runs ever observes the broken link. The committed tree was wrong while every signal said it was fine.

## The fix

| Part | What it does |
|---|---|
| `git rm --cached node_modules` | The entry itself. |
| `.gitignore` | Gains the bare `node_modules` **alongside** `node_modules/`, so the symlink form is covered too. Both forms kept, with the reason written at the line — the next person to tidy it will otherwise delete the one that matters. |
| `scripts/no-tracked-symlinks.test.mjs` | Closes the **class**, not the one entry point. |

The guard reads the git **index**, not the working tree: an untracked convenience symlink inside someone's worktree is legitimate and must not fail the build. It fails naming any mode-`120000` path, and a checkout where it cannot reach a verdict fails rather than passing quietly (#1012's rule).

Scoped to symlinks and not to "unexpected files" deliberately — the repo gains files constantly and a guard that argues about which ones belong would be noise. A tracked symlink has no legitimate use here today, so the rule can be absolute; if one is ever wanted, that test is where the exception gets stated.

## Validation

- [x] `npm run test:scripts` → **558 pass, 0 fail** (557 at merge base)
- [x] `npm run test:units` → **389 pass, 0 fail**
- [x] `npx tsc --noEmit` → **0 errors**
- [x] `npm run lint` → 0 errors, baseline warnings unchanged
- [x] `git ls-files -s | awk '$1=="120000"'` → **empty**
- [x] Re-created the symlink on disk and confirmed `git status` now ignores it
- [x] **Reverted-and-reddened** — with the entry restored the guard fails naming `node_modules`. It also caught a real slip while this PR was being written, when a `git stash pop` silently undid the `git rm --cached`.

## Note for anyone with a clone

A clone or worktree made from `main` between #1253 and this merge already has the symlink on disk. `git pull` removes it; if you had symlinked your own `node_modules` there, re-create it after pulling — it is ignored now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)