### PR TITLE
fix(tokens): stop a partial provider pin and a half identity from resolving as whole (#1255)

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -1054,6 +1054,12 @@ jobs:
           TOKENS_DIR: all-tokens
           PAYLOAD_IN: payload.json
           PAYLOAD_OUT: payload-with-tokens.json
+          # How many shards were MEANT to report their resolved provider (#1255
+          # item 1). Nothing in the token artifacts records this, so without it a
+          # shard whose artifact never uploaded is invisible — neither a vote nor an
+          # abstention — and three shards of four naming one provider would resolve
+          # as a full pin. Same source the matrix itself uses.
+          TOKENS_SHARD_TOTAL: ${{ needs.prep.outputs.shard_total }}
         run: |
           merge_log=$(node scripts/merge-token-payload.mjs 2>&1) || true
           echo "$merge_log"

--- a/scripts/lib/token-cost.mjs
+++ b/scripts/lib/token-cost.mjs
@@ -270,7 +270,21 @@ export function aggregate({ probes = [], attributions = [], costs = [], prices =
     // Write the separator as the ESCAPE `\u0000`, never as a literal control
     // character in the source. A raw NUL is invisible in an editor, in a diff and
     // in a review, and the first draft of this plan shipped four of them by accident.
-    const specModelKey = attribution ? `${specPath}\u0000${titlePath}\u0000` : "\u0000\u0000";
+    //
+    // Keyed on the two VALUES, not on whether `attribution` exists (#1255 item 2).
+    // An attribution record carrying a trace_id but no file/test used to key on
+    // `"null\u0000null\u0000"` while emitting a row whose spec_path and title_path are
+    // both null -- the same DB identity as the unattributed bucket
+    // (`COALESCE(test_key,'')`), reached from a different producer key. Two rows on
+    // one identity do not duplicate: the live ingest upserts, keeps the LAST, and
+    // counts the loser in `rows_dropped`, so one of the two numbers is silently
+    // discarded. Unreachable through the sidecar today -- resolveTestAttribution()
+    // returns null unless title, file and project.testDir are all present -- but that
+    // is an invariant enforced two modules away, in a TypeScript helper this pure ESM
+    // module cannot see. Enforcing it here makes the row identity depend only on what
+    // this function was handed.
+    const identified = Boolean(specPath && titlePath);
+    const specModelKey = identified ? `${specPath}\u0000${titlePath}\u0000` : "\u0000\u0000";
 
     let spanTotal = 0;
     let traceUsd = 0;
@@ -308,8 +322,13 @@ export function aggregate({ probes = [], attributions = [], costs = [], prices =
       const row =
         specModels.get(rowKey) ??
         {
-          spec_path: specPath,
-          title_path: titlePath,
+          // The row's identity fields must be exactly what `specModelKey` was built
+          // from, or a half-identified trace (a `file` with no `test`, say) would key
+          // into the unattributed bucket while stamping its own spec_path onto it --
+          // and whichever trace happened to create the row first would decide what
+          // the merged row claims to measure.
+          spec_path: identified ? specPath : null,
+          title_path: identified ? titlePath : null,
           model: m.model,
           price_key: resolvePriceKey(m.model, prices),
           calls: 0,

--- a/scripts/lib/token-cost.test.mjs
+++ b/scripts/lib/token-cost.test.mjs
@@ -760,3 +760,78 @@ test("bySpecModel is empty when there are no probes", () => {
   assert.deepEqual(agg.bySpecModel, []);
   assert.equal(agg.spanTokens, 0);
 });
+
+// #1255 item 2: the row identity must depend only on what aggregate() was handed.
+//
+// The DB keys a row on (run_id, COALESCE(test_key,''), model), so a row whose
+// spec_path/title_path are null IS the unattributed bucket. An attribution record
+// that carries a trace_id but no file/test used to key on the literal text
+// "null" + NUL + "null" + NUL — a DIFFERENT producer key for the SAME DB identity.
+// The live ingest upserts and keeps the last, counting the loser in `rows_dropped`,
+// so one of the two numbers would be silently discarded. resolveTestAttribution()
+// makes that record impossible today, but it is a TypeScript helper two modules
+// away that this pure ESM module cannot see.
+
+test("an attribution with no file/test does not open a SECOND unattributed row", () => {
+  const agg = aggregate({
+    probes: [twoModelProbe("t1"), twoModelProbe("t2")],
+    // t1 has no attribution at all; t2 has a record that names neither field.
+    attributions: [{ trace_id: "t2" }],
+    prices: P,
+  });
+  const mini = agg.bySpecModel.filter((r) => r.model === "gpt-4o-mini");
+  assert.equal(
+    mini.length,
+    1,
+    "two producer rows on one DB identity — the ingest would keep one and count the " +
+      `other in rows_dropped: ${JSON.stringify(mini)}`,
+  );
+  assert.equal(mini[0].spec_path, null);
+  assert.equal(mini[0].title_path, null);
+  // And no token is lost to the merge: both traces' spans land in the one row.
+  assert.equal(mini[0].total_tokens, 400);
+  assert.equal(mini[0].calls, 4);
+});
+
+test("an attribution with a file but no test is not credited to that file", () => {
+  // Half an identity is not an identity: the DB's test_key is
+  // md5(normalize(spec_path) || '::' || title_path), which a null title_path makes
+  // NULL — i.e. the unattributed bucket. Stamping the spec_path onto that row would
+  // make it read as a real measurement of a file, with no test to point at.
+  const agg = aggregate({
+    probes: [twoModelProbe("t1")],
+    attributions: [{ trace_id: "t1", file: "a.spec.ts" }],
+    prices: P,
+  });
+  for (const row of agg.bySpecModel) {
+    assert.equal(row.spec_path, null, "a file without a test must not name the row");
+    assert.equal(row.title_path, null);
+  }
+});
+
+test("an empty-string test is treated as no identity, not as a real one", () => {
+  // resolveTestAttribution already refuses an empty title upstream; this pins that
+  // aggregate() does not depend on it having done so.
+  const agg = aggregate({
+    probes: [twoModelProbe("t1")],
+    attributions: [{ trace_id: "t1", file: "a.spec.ts", test: "" }],
+    prices: P,
+  });
+  assert.deepEqual(
+    agg.bySpecModel.map((r) => [r.spec_path, r.title_path]),
+    agg.bySpecModel.map(() => [null, null]),
+  );
+});
+
+test("a fully identified attribution is still credited exactly as before", () => {
+  // The guard above must not cost a real attribution its name — the regression this
+  // change could plausibly introduce.
+  const agg = aggregate({
+    probes: [twoModelProbe("t1")],
+    attributions: [{ trace_id: "t1", file: "a.spec.ts", test: "does a thing" }],
+    prices: P,
+  });
+  const mini = agg.bySpecModel.find((r) => r.model === "gpt-4o-mini");
+  assert.equal(mini.spec_path, "a.spec.ts");
+  assert.equal(mini.title_path, "does a thing");
+});

--- a/scripts/merge-token-payload.mjs
+++ b/scripts/merge-token-payload.mjs
@@ -65,11 +65,63 @@ export const MERGE_CODES = [
 // When they do, no value is published: reporting one shard's provider as "the
 // run's" would name a provider the other shard never used, and design §6.4
 // requires the field to be the RESOLVED value or nothing.
-export function resolveTargetProvider(values = []) {
-  const distinct = [...new Set(values.map((v) => String(v ?? "").trim()).filter(Boolean))].sort();
-  if (distinct.length === 0) return { provider: null, conflict: [] };
-  if (distinct.length === 1) return { provider: distinct[0], conflict: [] };
-  return { provider: null, conflict: distinct };
+//
+// AN EMPTY FILE IS AN ABSTENTION, AND AN ABSTENTION IS NOT A VOTE (#1255 item 1)
+//
+// The shard writes its provider file UNCONDITIONALLY, and its comment in
+// daily-stable.yml is explicit that an empty file means "the rotation declined to
+// pin" and "must not be confused with a shard that failed to report". This function
+// used to `.filter(Boolean)` and stop there, which made empty, whitespace and
+// no-file-at-all the same thing -- discarding, one step later, exactly the
+// distinction the shard takes care to preserve.
+//
+// The case that made it wrong: shard 1 pinned `anthropic`, shard 2's `Rotate the
+// lane` step failed (it is continue-on-error) and wrote an empty file. One distinct
+// value survived the filter, so the run published `target_provider: anthropic` for a
+// run that partly swept every provider -- with no conflict to log, because there was
+// none to see. That is a label that looks resolved and is not.
+//
+// So a PARTIAL pin resolves to no provider, the same way a disagreement does: the
+// field is the resolved value or nothing. The counts ride along either way
+// (`shards`), so the information is recorded rather than thrown away, and a reader
+// can tell a full pin from a partial one from an absent one. Publishing the majority
+// value plus a `partial: true` flag was the alternative and is one line from here --
+// rejected because a consumer reading only `target_provider` (which is every
+// consumer today, §6.3 not being built yet) would read a partial sweep as a full
+// one, which is the failure this whole path exists to prevent.
+//
+// A SHARD THAT NEVER REPORTED IS THE THIRD CASE, AND `expected` IS HOW IT IS SEEN
+//
+// The same defect one layer up: a shard whose artifact never uploaded produces no
+// file at all, so it is neither a vote nor an abstention -- it is invisible. Three
+// shards of four naming `anthropic` would read as `{named: 3, abstained: 0}` and
+// resolve as a full pin. `expected` (the run's own shard_total, passed in from the
+// workflow) is the only thing that can see the gap, since nothing in the token
+// artifacts records how many shards there were meant to be.
+//
+// Unknown `expected` keeps the old behaviour rather than defaulting to "partial":
+// this function is also called from lanes that do not shard, and treating an absent
+// count as a missing shard would omit the provider on every one of them.
+export function resolveTargetProvider(values = [], expected) {
+  const trimmed = values.map((v) => String(v ?? "").trim());
+  const abstained = trimmed.filter((v) => !v).length;
+  const distinct = [...new Set(trimmed.filter(Boolean))].sort();
+  const total = Number(expected);
+  const knownExpected = Number.isFinite(total) && total > 0;
+  const missing = knownExpected ? Math.max(0, total - trimmed.length) : 0;
+  const shards = {
+    named: trimmed.length - abstained,
+    abstained,
+    ...(knownExpected ? { expected: total, missing } : {}),
+  };
+  if (distinct.length === 0) return { provider: null, conflict: [], shards, partial: false };
+  if (distinct.length > 1) return { provider: null, conflict: distinct, shards, partial: false };
+  // Exactly one named provider. It is the run's only if every shard that was meant
+  // to report did, and each one pinned it.
+  if (abstained > 0 || missing > 0) {
+    return { provider: null, conflict: [], shards, partial: true, majority: distinct[0] };
+  }
+  return { provider: distinct[0], conflict: [], shards, partial: false };
 }
 
 export async function mergeTokenPayload({
@@ -133,11 +185,23 @@ export async function mergeTokenPayload({
       // A shard that uploaded no provider file simply does not vote.
     }
   }
-  const { provider, conflict } = resolveTargetProvider(values);
+  const { provider, conflict, shards, partial, majority } = resolveTargetProvider(
+    values,
+    env.TOKENS_SHARD_TOTAL,
+  );
   if (conflict.length) {
     log(
       `merge-token-payload: shards disagree on the resolved provider (${conflict.join(", ")}) — ` +
         "omitting target_provider rather than publishing one shard's value as the run's.",
+    );
+  } else if (partial) {
+    // The one outcome that used to publish a wrong label instead of no label.
+    const of = shards.expected ?? shards.named + shards.abstained;
+    log(
+      `merge-token-payload: only ${shards.named} of ${of} shard(s) pinned a provider ` +
+        `(${majority}); ${shards.abstained} abstained and ${shards.missing ?? 0} never reported, ` +
+        "so part of this run swept every provider — omitting target_provider and carrying the " +
+        "counts instead.",
     );
   } else if (!provider) {
     log("merge-token-payload: no shard recorded a resolved provider — omitting target_provider.");
@@ -152,11 +216,24 @@ export async function mergeTokenPayload({
   // The two guards are redundant today by design, not by accident; a change to
   // either one alone, with the other left intact, is not expected to be
   // independently observable from outside this module.
-  const tokens = { ...block.value, ...(provider ? { target_provider: provider } : {}) };
+  //
+  // `target_provider_shards` rides ALWAYS, including when the provider itself is
+  // omitted — that is the point (#1255 item 1). Omitting the label without recording
+  // why leaves "no shard pinned anything", "the shards disagreed" and "some shards
+  // abstained" looking identical from the platform's side, which is the same
+  // three-outcomes-one-message failure the verdict `code` above exists to avoid. The
+  // ingest accepts unknown keys and ignores them (§6.3 is not built yet), so this
+  // costs nothing today and is already there when it is.
+  const tokens = {
+    ...block.value,
+    ...(provider ? { target_provider: provider } : {}),
+    target_provider_shards: shards,
+  };
   writeFile(payloadOut, JSON.stringify({ ...payload.value, tokens }));
   log(
     `merge-token-payload: wrote ${payloadOut} — ${tokens.rows?.length ?? 0} token row(s), ` +
-      `${tokens.total_tokens ?? "?"} tokens, provider ${provider ?? "unreported"}.`,
+      `${tokens.total_tokens ?? "?"} tokens, provider ${provider ?? "unreported"} ` +
+      `(${shards.named} pinned, ${shards.abstained} abstained).`,
   );
   return { written: true, reason: "merged", code: "merged" };
 }

--- a/scripts/merge-token-payload.test.mjs
+++ b/scripts/merge-token-payload.test.mjs
@@ -408,11 +408,198 @@ test("the POST step judges the ingest by its body, not by HTTP 200 alone", () =>
 });
 
 test("resolveTargetProvider is pure and reports its own verdict", () => {
-  assert.deepEqual(resolveTargetProvider(["anthropic", "anthropic"]), { provider: "anthropic", conflict: [] });
-  assert.deepEqual(resolveTargetProvider([]), { provider: null, conflict: [] });
-  assert.deepEqual(resolveTargetProvider(["", "  "]), { provider: null, conflict: [] });
+  // `shards` and `partial` joined the verdict in #1255 item 1 — an abstention is
+  // counted rather than filtered away, so a partial pin is distinguishable from a
+  // full one and from a disagreement.
+  assert.deepEqual(resolveTargetProvider(["anthropic", "anthropic"]), {
+    provider: "anthropic",
+    conflict: [],
+    shards: { named: 2, abstained: 0 },
+    partial: false,
+  });
+  assert.deepEqual(resolveTargetProvider([]), {
+    provider: null,
+    conflict: [],
+    shards: { named: 0, abstained: 0 },
+    partial: false,
+  });
+  assert.deepEqual(resolveTargetProvider(["", "  "]), {
+    provider: null,
+    conflict: [],
+    shards: { named: 0, abstained: 2 },
+    partial: false,
+  });
   assert.deepEqual(resolveTargetProvider(["google", "anthropic", "google"]), {
     provider: null,
     conflict: ["anthropic", "google"],
+    shards: { named: 3, abstained: 0 },
+    partial: false,
   });
+  // A single shard that pinned nothing is nobody pinning, not a partial pin.
+  assert.equal(resolveTargetProvider([""]).partial, false);
+  assert.equal(resolveTargetProvider(["openai"]).provider, "openai");
+  // Whitespace around a real value is not an abstention.
+  assert.deepEqual(resolveTargetProvider([" openai \n"]).shards, { named: 1, abstained: 0 });
+});
+
+// --- #1255 item 1: an abstention is not a vote ---
+//
+// The shard writes token-provider-<shard>.txt UNCONDITIONALLY, so "the rotation
+// declined to pin" arrives as an EMPTY file. `.filter(Boolean)` alone made that
+// identical to "this shard uploaded nothing", so one named provider among abstainers
+// resolved as if every shard had pinned it.
+
+const providerEnv = {
+  TOKENS_SUMMARY_OUT: "tokens-block.json",
+  PAYLOAD_IN: "payload.json",
+  PAYLOAD_OUT: "merged.json",
+  TOKENS_DIR: "all-tokens",
+};
+
+test("a partial pin publishes NO provider — one shard named it, another abstained", async () => {
+  const t = io({
+    files: {
+      "payload.json": JSON.stringify(PAYLOAD),
+      "tokens-block.json": JSON.stringify(BLOCK),
+      "all-tokens/token-provider-1.txt": "anthropic",
+      // Shard 2's `Rotate the lane` step failed (continue-on-error) → empty file.
+      "all-tokens/token-provider-2.txt": "",
+    },
+    dir: ["all-tokens/token-provider-1.txt", "all-tokens/token-provider-2.txt"],
+  });
+  const res = await mergeTokenPayload({ env: providerEnv, ...t, log: (m) => t.logged.push(m) });
+  assert.equal(res.written, true, "a partial pin must not cost the token rows");
+  const tokens = JSON.parse(t.written.get("merged.json")).tokens;
+  assert.equal(
+    "target_provider" in tokens,
+    false,
+    "shard 2 swept every provider — naming shard 1's pin as the run's would be a label that looks resolved",
+  );
+  // The information is recorded, not discarded.
+  assert.deepEqual(tokens.target_provider_shards, { named: 1, abstained: 1 });
+  assert.ok(
+    t.logged.some((m) => /abstained/.test(m) && /anthropic/.test(m)),
+    `the omission must name both the majority and the abstention: ${JSON.stringify(t.logged)}`,
+  );
+});
+
+test("a full pin still publishes the provider, and says nobody abstained", async () => {
+  const t = io({
+    files: {
+      "payload.json": JSON.stringify(PAYLOAD),
+      "tokens-block.json": JSON.stringify(BLOCK),
+      "all-tokens/token-provider-1.txt": "anthropic\n",
+      "all-tokens/token-provider-2.txt": "anthropic",
+    },
+    dir: ["all-tokens/token-provider-1.txt", "all-tokens/token-provider-2.txt"],
+  });
+  await mergeTokenPayload({ env: providerEnv, ...t, log: () => {} });
+  const tokens = JSON.parse(t.written.get("merged.json")).tokens;
+  assert.equal(tokens.target_provider, "anthropic");
+  assert.deepEqual(tokens.target_provider_shards, { named: 2, abstained: 0 });
+});
+
+test("the shard counts ride along even when no shard pinned anything", async () => {
+  // Otherwise "nobody pinned", "they disagreed" and "some abstained" are one
+  // indistinguishable silence on the platform's side.
+  const t = io({
+    files: {
+      "payload.json": JSON.stringify(PAYLOAD),
+      "tokens-block.json": JSON.stringify(BLOCK),
+      "all-tokens/token-provider-1.txt": "",
+      "all-tokens/token-provider-2.txt": "   ",
+    },
+    dir: ["all-tokens/token-provider-1.txt", "all-tokens/token-provider-2.txt"],
+  });
+  await mergeTokenPayload({ env: providerEnv, ...t, log: () => {} });
+  const tokens = JSON.parse(t.written.get("merged.json")).tokens;
+  assert.equal("target_provider" in tokens, false);
+  assert.deepEqual(tokens.target_provider_shards, { named: 0, abstained: 2 });
+});
+
+test("a shard that never reported is not a vote either — 3 of 4 is a partial pin", async () => {
+  // The third case, and the one no token artifact can see on its own: shard 4's
+  // upload never happened, so there is no file to read. Without the expected count
+  // this reads as {named: 3, abstained: 0} and resolves as a full pin.
+  const t = io({
+    files: {
+      "payload.json": JSON.stringify(PAYLOAD),
+      "tokens-block.json": JSON.stringify(BLOCK),
+      "all-tokens/token-provider-1.txt": "anthropic",
+      "all-tokens/token-provider-2.txt": "anthropic",
+      "all-tokens/token-provider-3.txt": "anthropic",
+    },
+    dir: [
+      "all-tokens/token-provider-1.txt",
+      "all-tokens/token-provider-2.txt",
+      "all-tokens/token-provider-3.txt",
+    ],
+  });
+  const res = await mergeTokenPayload({
+    env: { ...providerEnv, TOKENS_SHARD_TOTAL: "4" },
+    ...t,
+    log: (m) => t.logged.push(m),
+  });
+  assert.equal(res.written, true);
+  const tokens = JSON.parse(t.written.get("merged.json")).tokens;
+  assert.equal("target_provider" in tokens, false, "one shard's sweep is unaccounted for");
+  assert.deepEqual(tokens.target_provider_shards, { named: 3, abstained: 0, expected: 4, missing: 1 });
+  assert.ok(
+    t.logged.some((m) => /never reported/.test(m)),
+    `the missing shard must be named: ${JSON.stringify(t.logged)}`,
+  );
+});
+
+test("every shard reporting the same provider IS a full pin, expected or not", async () => {
+  // The regression this could introduce: making the ordinary case look partial.
+  for (const env of [providerEnv, { ...providerEnv, TOKENS_SHARD_TOTAL: "2" }]) {
+    const t = io({
+      files: {
+        "payload.json": JSON.stringify(PAYLOAD),
+        "tokens-block.json": JSON.stringify(BLOCK),
+        "all-tokens/token-provider-1.txt": "anthropic",
+        "all-tokens/token-provider-2.txt": "anthropic",
+      },
+      dir: ["all-tokens/token-provider-1.txt", "all-tokens/token-provider-2.txt"],
+    });
+    await mergeTokenPayload({ env, ...t, log: () => {} });
+    const tokens = JSON.parse(t.written.get("merged.json")).tokens;
+    assert.equal(tokens.target_provider, "anthropic", `full pin lost with env ${JSON.stringify(env)}`);
+  }
+});
+
+test("an unusable TOKENS_SHARD_TOTAL is ignored, not read as a missing shard", () => {
+  // A blank/garbage value must not omit the provider on every run — and the
+  // non-sharded lanes pass nothing at all.
+  for (const bad of [undefined, "", "  ", "0", "-3", "many"]) {
+    const v = resolveTargetProvider(["openai", "openai"], bad);
+    assert.equal(v.provider, "openai", `TOKENS_SHARD_TOTAL=${JSON.stringify(bad)} cost a real pin`);
+    assert.equal("expected" in v.shards, false, "an unusable count must not be published as one");
+  }
+  // A usable one is honoured.
+  assert.equal(resolveTargetProvider(["openai", "openai"], "3").partial, true);
+  assert.equal(resolveTargetProvider(["openai", "openai"], 2).provider, "openai");
+});
+
+test("the daily passes the shard total the matrix was built from", () => {
+  const body = postStep();
+  assert.match(
+    body,
+    /TOKENS_SHARD_TOTAL:\s*\$\{\{\s*needs\.prep\.outputs\.shard_total\s*\}\}/,
+    "without the run's own shard_total a shard that never uploaded is invisible, and the " +
+      "provider resolves as if it had agreed",
+  );
+});
+
+test("a disagreement is still a disagreement, not an abstention", () => {
+  // The two omissions have different causes and must stay distinguishable.
+  const disagree = resolveTargetProvider(["anthropic", "google"]);
+  const abstain = resolveTargetProvider(["anthropic", ""]);
+  assert.deepEqual(disagree.conflict, ["anthropic", "google"]);
+  assert.equal(disagree.partial, false);
+  assert.deepEqual(abstain.conflict, []);
+  assert.equal(abstain.partial, true);
+  assert.equal(abstain.majority, "anthropic");
+  assert.equal(disagree.provider, null);
+  assert.equal(abstain.provider, null);
 });


### PR DESCRIPTION
## Type

- [x] `fix` — fix for a broken behaviour

---

## Roadmap linkage (required — do not delete)

- [x] **Exception** — off-wave work backed by an issue: **#1255** (`follow-up` label, "Approved exception: follow-up of merged work"). Items **1 and 2** of that issue; the rest stays open there.

---

## What this PR does

Both items are the same shape: **a value that is only partly known resolving as if it were fully known.**

### Item 1 — an abstention is not a vote

The shard writes `token-provider-<shard>.txt` **unconditionally**, and its comment in `daily-stable.yml` is explicit that an empty file means "the rotation declined to pin" and "must not be confused with a shard that failed to report". `resolveTargetProvider` then did `.filter(Boolean)` and stopped — making empty, whitespace and no-file-at-all the same thing, discarding one step later exactly the distinction the shard takes care to preserve.

The case that made it wrong: shard 1 pins `anthropic`, shard 2's `Rotate the lane` step fails (it is `continue-on-error`) and writes an empty file. One distinct value survives the filter, so the run publishes `target_provider: anthropic` for a run that partly swept **every** provider — with no conflict to log, because there is none to see.

| Provider files | Before | After |
|---|---|---|
| `anthropic`, `anthropic` | `anthropic` | `anthropic` + `{named: 2, abstained: 0}` |
| `anthropic`, `` (empty) | **`anthropic`** ← the bug | omitted, `partial`, `majority: anthropic` |
| `anthropic`, `google` | omitted + conflict | unchanged |
| 3 files, `expected: 4` | `anthropic` | omitted, `{named: 3, missing: 1}` |

`target_provider_shards` rides **always**, including when the provider is omitted. Without it, "nobody pinned", "they disagreed" and "some abstained" are one indistinguishable silence on the platform's side — the same three-outcomes-one-message failure the verdict `code` exists to avoid. The ingest accepts unknown keys and ignores them (§6.3 is not built yet), so it costs nothing today and is there when it is.

**Why omit rather than publish the majority with a `partial: true` flag** — that alternative is one line from here and is argued down in the code. Every consumer today reads only `target_provider`, so a partial sweep would read as a full one: the exact failure this path exists to prevent.

**A third case #1255 did not list.** A shard whose artifact never uploaded produces no file, so it is neither a vote nor an abstention — it is invisible. Three shards of four naming one provider read as `{named: 3, abstained: 0}` and resolved as a full pin. Nothing in the token artifacts knows how many shards were meant to report, so the step passes `TOKENS_SHARD_TOTAL: ${{ needs.prep.outputs.shard_total }}` (the `merge` job already has `needs: [prep, test]`). An **unusable or absent** count keeps the old behaviour — the non-sharded lanes pass nothing, and treating that as a missing shard would omit the provider on every one of them.

### Item 2 — half an identity is not an identity

`bySpecModel`'s row key was `attribution ? … : …`, so a record carrying a `trace_id` but no `file`/`test` keyed on the literal text `"null"` + NUL + `"null"` + NUL while emitting a row whose `spec_path` and `title_path` are **both null** — the same DB identity as the unattributed bucket (`COALESCE(test_key,'')`), reached from a different producer key.

Two rows on one identity do **not** duplicate. The live ingest upserts, keeps the last, and counts the loser in `rows_dropped` — so one of the two numbers is silently discarded.

The key now depends on the two **values**, and the row's own identity fields use the same condition. Both halves are needed: keying alone would let a half-identified trace merge into the unattributed bucket while stamping its own `spec_path` onto it, and whichever trace created the row first would decide what the merged row claims to measure.

Unreachable through the sidecar today — `resolveTestAttribution()` returns `null` unless `title`, `file` and `project.testDir` are all present. But that is an invariant enforced two modules away, in a TypeScript helper this pure ESM module cannot see. Enforcing it here makes the row identity depend only on what `aggregate()` was handed.

---

## Tests

Unit tests only — the diff is `scripts/` plus five lines of workflow env. `test:scripts` **558 → 570**.

| Test | What it pins |
|---|---|
| `a partial pin publishes NO provider` | One named + one abstaining → no label, counts recorded, and the log names both the majority and the abstention |
| `a full pin still publishes the provider` | The ordinary case is untouched — the regression this could introduce |
| `the shard counts ride along even when no shard pinned anything` | The three silences stay distinguishable |
| `a shard that never reported is not a vote either` | 3 of 4 with `expected: 4` → partial, `missing: 1`, "never reported" in the log |
| `every shard reporting the same provider IS a full pin, expected or not` | With and without `TOKENS_SHARD_TOTAL` |
| `an unusable TOKENS_SHARD_TOTAL is ignored` | `undefined`, `""`, `"  "`, `"0"`, `"-3"`, `"many"` must not cost a real pin, and must not be published as a count |
| `a disagreement is still a disagreement, not an abstention` | The two omissions have different causes |
| `the daily passes the shard total the matrix was built from` | Structural: the value comes from `needs.prep.outputs.shard_total`, not a literal |
| `an attribution with no file/test does not open a SECOND unattributed row` | One row per DB identity; both traces' spans land in it (400 tokens, 4 calls) |
| `an attribution with a file but no test is not credited to that file` | Half an identity does not name a row |
| `an empty-string test is treated as no identity` | `aggregate()` does not lean on the upstream helper |
| `a fully identified attribution is still credited exactly as before` | Non-regression |

---

## How the tests were built

**Reverted-and-reddened, 9 mutations.** Each run carries a changed-file counter proving the mutation actually applied, and each drops a **different** subset of assertions (1 to 4) rather than the whole file:

```
baseline merge                              files_changed=0 pass=28  fail=0
abstention filtered away again              files_changed=2 pass=24  fail=4
missing shards no longer make it partial    files_changed=2 pass=26  fail=2
shard counts dropped from the block         files_changed=2 pass=24  fail=4
expected accepts 0 and negatives            files_changed=2 pass=27  fail=1
env no longer read for the shard total      files_changed=2 pass=27  fail=1
YAML hardcodes the shard total              files_changed=2 pass=27  fail=1
baseline token-cost                         files_changed=0 pass=63  fail=0
key back on attribution existing            files_changed=2 pass=60  fail=3
row fields back to raw specPath/titlePath   files_changed=2 pass=61  fail=2
```

**The first attempt at this harness was invalid and is worth recording.** It reverted the files after each mutation with `git checkout --` while the production edits were still **uncommitted**, so it destroyed them and then measured `main` against the new tests. Every line came back red and looked like a clean sweep. The tell was in the output all along: the token-cost baseline reported `fail=3` instead of `fail=0`. Hence the changed-file counter, and hence committing before mutating.

---

## Not in this PR

Still open on #1255: the producer-vs-DB `spec_path` normalisation (item 4), the unattributed trace-vs-span gap, `run_attempt`, the second USD source (item 3), and the platform-side rendering (item 5).

---

## Validation

- [x] `npm run test:scripts` → **570 pass, 0 fail** (558 at merge base)
- [x] `npm run test:units` → **389 pass, 0 fail** (unchanged — no `.ts` touched)
- [x] `npx tsc --noEmit` → **0 errors**
- [x] `npm run lint` → 0 errors, baseline warnings unchanged
- [x] `.github/workflows/daily-stable.yml` parses under `yaml.safe_load`
- [x] Confirmed the `merge` job has `needs: [prep, test]`, so `needs.prep.outputs.shard_total` resolves
- [x] **Forced a failure** — see above
- [ ] Playwright specs — N/A, none in this PR
- [ ] `QA-CHECKLIST.md` — N/A, no scenario coverage change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
