### PR TITLE
docs(regressions): close three ledger rows whose fix PR merged upstream

### DIFF
--- a/REGRESSIONS.md
+++ b/REGRESSIONS.md
@@ -36,7 +36,7 @@ issue that carries the evidence. Both shapes are allowed; what is not allowed is
 a reference that does not resolve.
 
 <!-- REGRESSIONS:START -->
-**Regressions caught:** 7 — **Open:** 4 · **Fixed:** 3
+**Regressions caught:** 7 — **Open:** 1 · **Fixed:** 6
 
 **By severity:** High 2 · Medium 5 · Low 0
 
@@ -47,10 +47,10 @@ a reference that does not resolve.
 
 | Found | Area / Test | Regression | Severity | Detected by | Upstream | Status | Fixed in | Report |
 |-------|-------------|------------|----------|-------------|----------|--------|----------|--------|
-| 2026-07-28 | core-components · nested-grouping-regression.spec.ts | Grouping two connected non-IO components raises a false `Error while updating the Component` notification although the grouping fully succeeds — the `PATCH /api/v1/flows/{id}` that persists the grouped shape returns `200`, the console logs no error and no request fails, yet the message persists in the Notifications panel until dismissed by hand. Deterministic; reproduced independently in a manual browser session | Medium | #942 spec validation | [LE-2045](https://datastax.jira.com/browse/LE-2045) | Open | — | docs/upstream-bugs/UPSTREAM-BUG-group-cosmetic-error-toast.md |
+| 2026-07-28 | core-components · nested-grouping-regression.spec.ts | Grouping two connected non-IO components raises a false `Error while updating the Component` notification although the grouping fully succeeds — the `PATCH /api/v1/flows/{id}` that persists the grouped shape returns `200`, the console logs no error and no request fails, yet the message persists in the Notifications panel until dismissed by hand. Deterministic; reproduced independently in a manual browser session | Medium | #942 spec validation | [LE-2045](https://datastax.jira.com/browse/LE-2045) | Fixed | [langflow#14314](https://github.com/langflow-ai/langflow/pull/14314) | docs/upstream-bugs/UPSTREAM-BUG-group-cosmetic-error-toast.md |
 | 2026-07-27 | api · api-folders-crud.spec.ts | `DELETE /api/v1/projects/{id}` answers `500` (`sqlite3.OperationalError: database is locked`) instead of `204` while any other write is in flight, and the project survives. Not new — stable 1.10.3 emits the same instant `500` — but 1.12 raises the rate ~7× (6 % → 44 % at 2 concurrent clients, A/B/A/B) and flips the mode: 1.10.3 blocks and mostly honours the contract, 1.12 gives up in 0.03 s. Sibling write endpoints (`POST /projects`, `POST /flows`, `DELETE /flows`) survive the identical contention | Medium | daily 07-22 + 07-27 · #962 → #965 | [LE-2020](https://datastax.jira.com/browse/LE-2020) | Open | — | docs/upstream-bugs/UPSTREAM-BUG-project-delete-500-under-contention.md |
-| 2026-07-27 | flows · run-flow.spec.ts | "New Flow" click is silently dropped when the flows list has not painted its cards yet — no navigation, no modal, no console error, and the button then stops being actionable until a reload. Introduced in 1.10.1 by langflow#12575; 1.10.0 opened the templates modal and created nothing | Medium | daily 07-27 · #962 → #966 | [LE-2019](https://datastax.jira.com/browse/LE-2019) | Open | — | docs/upstream-bugs/UPSTREAM-BUG-new-flow-dead-click.md |
-| 2026-07-24 | mcp · mcp-server-resources.spec.ts | MCP `resources/read` crashes with `AttributeError: 'str' object has no attribute 'hex'` — the project server advertises a flow file it cannot itself read (worked on 1.11.0) | Medium | #948 spec validation | [LE-2012](https://datastax.jira.com/browse/LE-2012) | Open | — | docs/upstream-bugs/UPSTREAM-BUG-mcp-resources-read-uuid-hex.log |
+| 2026-07-27 | flows · run-flow.spec.ts | "New Flow" click is silently dropped when the flows list has not painted its cards yet — no navigation, no modal, no console error, and the button then stops being actionable until a reload. Introduced in 1.10.1 by langflow#12575; 1.10.0 opened the templates modal and created nothing | Medium | daily 07-27 · #962 → #966 | [LE-2019](https://datastax.jira.com/browse/LE-2019) | Fixed | [langflow#14349](https://github.com/langflow-ai/langflow/pull/14349) | docs/upstream-bugs/UPSTREAM-BUG-new-flow-dead-click.md |
+| 2026-07-24 | mcp · mcp-server-resources.spec.ts | MCP `resources/read` crashes with `AttributeError: 'str' object has no attribute 'hex'` — the project server advertises a flow file it cannot itself read (worked on 1.11.0) | Medium | #948 spec validation | [LE-2012](https://datastax.jira.com/browse/LE-2012) | Fixed | [langflow#14253](https://github.com/langflow-ai/langflow/pull/14253) | docs/upstream-bugs/UPSTREAM-BUG-mcp-resources-read-uuid-hex.log |
 | 2026-07-23 | model-provider · groq-provider.spec.ts | Groq / Mistral / Ollama components silently hidden from the sidebar — the image ships the component source but not the provider's `langchain-*` package, and Langflow now hides the component with no message. Mechanism note (measured on 1.12.0.dev8, #1039): the `langchain-*` diagnosis still holds, but it is only one of two gates — 1.12 also moved components out of `lfx.components.*` into per-vendor distributions plus an aggregate `lfx-bundles` package, and the default image installs neither that package nor the two extras. Only Ollama returned to the default image; Groq and Mistral stay out by product decision, which is not a regression | Medium | daily 07-23 · #907 | [LE-1987](https://datastax.jira.com/browse/LE-1987) | Fixed | [langflow#14248](https://github.com/langflow-ai/langflow/pull/14248) | #907 |
 | 2026-07-22 | model-provider · google-provider.spec.ts | Nightly ships without `langchain-google-genai` — every Google chat/embedding model raises ImportError at build; surfaced as node-build timeouts across ~17 `@stable` specs | High | daily 07-22 · #898 | [LE-1974](https://datastax.jira.com/browse/LE-1974) | Fixed | [langflow#14220](https://github.com/langflow-ai/langflow/pull/14220) | #898 |
 | 2026-07-17 | auth · logout-flow.spec.ts | Logout does not terminate the session — no redirect to login, no `POST /api/v1/logout` fired, and `POST /api/v1/refresh` silently re-authenticates so the session survives a reload | High | daily 07-17 · #808 | [LE-1850](https://datastax.jira.com/browse/LE-1850) | Fixed | [langflow#14158](https://github.com/langflow-ai/langflow/pull/14158) | #808 |
@@ -76,6 +76,19 @@ in its source project and the UI *does* raise `Failed to save flow` (with the ra
 SQL and bound parameters), where the project-delete equivalent silently no-ops.
 Evidence, API and UI:
 [docs/upstream-bugs/UPSTREAM-BUG-flow-patch-500-under-contention.md](docs/upstream-bugs/UPSTREAM-BUG-flow-patch-500-under-contention.md).
+
+**Why LE-2020 stays `Open` while Jira marks it Done (2026-08-04).** The ticket was
+resolved on 2026-07-29 by
+[langflow#14308](https://github.com/langflow-ai/langflow/pull/14308) (*fix(api):
+retry project delete on sqlite lock*), which touches `api/v1/projects.py` and adds
+`services/database/lock_retry.py` — and **nothing under `api/v1/flows.py`**. So it
+fixes only the endpoint the row's first paragraph describes; the second affected
+endpoint above, filed under the same ticket, is untouched, and its quarantine in
+`folder-drag-drop-flow.spec.ts` is still in force. The row therefore stays `Open`
+until the `PATCH /flows/{id}` half is fixed too and the restore point in
+`api-folders-crud.spec.ts` test 4 can be taken. This is one of the divergences the
+platform's Regressions tab is built to surface, not a stale `Status` cell — a Jira
+`Done` closes a ticket, it does not prove the ledger row is closed.
 
 ## Candidates — pending upstream ticket
 


### PR DESCRIPTION
## What changed

Three Ledger rows move from `Open` to `Fixed`, each carrying the merged upstream PR in `Fixed in`:

| Row | Upstream | Fix PR | Merged |
|---|---|---|---|
| core-components · nested-grouping-regression | LE-2045 | [langflow#14314](https://github.com/langflow-ai/langflow/pull/14314) — *skip template update for group nodes* | 2026-07-29 |
| flows · run-flow | LE-2019 | [langflow#14349](https://github.com/langflow-ai/langflow/pull/14349) — *stop flow route request storm* | 2026-07-30 |
| mcp · mcp-server-resources | LE-2012 | [langflow#14253](https://github.com/langflow-ai/langflow/pull/14253) — *normalize MCP resource flow IDs* | 2026-07-24 |

The indicator block was regenerated with `npm run regressions:summary`: **7 caught, Open 1, Fixed 6** (was Open 4, Fixed 3).

A new note under the LE-2020 row records why that row **stays `Open`** despite Jira having closed the ticket.

## Why

The `Status` column is hand-typed and ages the moment a ticket moves. It had aged: all four rows marked `Open` are `Done` on the Jira board, three of them for over a week. The quality platform's Regressions tab joins these rows against the hourly Jira mirror, so every one of the four was rendering with a stale-ledger warning — which is the mechanism working, but the file is the source of truth and the one under `regressions:check`, so the file is where the fix belongs.

## Notes for reviewers

**Jira `Done` was not treated as proof.** Each fix PR was opened and its diff read before the row was closed. That check is what kept LE-2020 open:

- LE-2020 was resolved on 2026-07-29 by [langflow#14308](https://github.com/langflow-ai/langflow/pull/14308) (*fix(api): retry project delete on sqlite lock*).
- Its diff touches `api/v1/projects.py`, `services/database/lock_retry.py` and their tests — **nothing under `api/v1/flows.py`**.
- The row has a second affected endpoint filed under the same ticket: `PATCH /api/v1/flows/{id}`, same `database is locked` 500 at two concurrent writers. 14308 does not reach it.
- Its quarantine in `folder-drag-drop-flow.spec.ts` is still in force, and the restore point in `api-folders-crud.spec.ts` test 4 cannot be taken yet.

So LE-2020 keeps `Status: Open` and the platform will keep showing *ledger: Open / tracker: Done* for it. That divergence is now correct and documented, not stale.

**Not verified:** no suite run was executed against a build carrying any of the three fixes. Per this file's own rule, `Fixed in` therefore stays at the PR link and does not become a Langflow version — that substitution is for whoever sees the specs re-run green.

**Scope:** only `REGRESSIONS.md` is touched. No spec, quarantine or helper changed.