### PR TITLE
test(quarantine): quarantine modelInputComponent's model-selector test (#1265)

### DIFF
--- a/tests/tests-automations/regression/core-functionality/llm-agents/modelInputComponent.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/modelInputComponent.spec.ts
@@ -60,9 +60,13 @@ test.describe("ModelInputComponent", () => {
     }
   });
 
-  test(
+  // Quarantined for #1265 — recurrent flake: the wait that times out is
+  // `sidebar-search-input`, not the model selector this test is named for
+  // (same signature on the 2026-07-15 and 2026-08-04 dailies). Lifting the
+  // quarantine (remove test.fixme + restore @stable) is a deliverable of #1265.
+  test.fixme(
     "the Language Model node renders its model selector",
-    { tag: ["@stable", "@release", "@components", "@workspace", "@model-provider"] },
+    { tag: ["@release", "@components", "@workspace", "@model-provider"] },
     async ({ page }) => {
       const node = await addLanguageModelNode(page);
       await expect(node.getByTestId("model_model")).toBeVisible({ timeout: 10000 });


### PR DESCRIPTION
Quarantines `modelInputComponent.spec.ts`'s "the Language Model node renders its model selector" test as **prevention**, from the 2026-08-04 daily triage (umbrella #1258).

Tracked by #1265 — **not closed by this PR**. Lifting the quarantine (remove `test.fixme` + restore `@stable`, after re-validating per `CONTRIBUTING.md`) is a deliverable of that issue.

## Why

Recurrent flake meeting the criterion in `CONTRIBUTING.md` → *Triage protocol* step 2: the **same** `error_signature` on two dailies inside the 30-day window —

| Daily | Signature |
|---|---|
| 2026-07-15 | `TimeoutError: locator.waitFor: Timeout 30000ms exceeded.` |
| 2026-08-04 ([run 30901311395](https://github.com/oriontech-me/langflow-e2e/actions/runs/30901311395)) | `TimeoutError: locator.waitFor: Timeout 30000ms exceeded.` |

The criterion is the cause, not the count, and the signature is identical on both.

Worth noting for whoever picks up #1265: despite the test's name, the wait that times out is `getByTestId('sidebar-search-input')` inside `addLanguageModelNode()` — the component sidebar never renders — not the model selector. The investigation directive on #1265 reflects that.

## What changed

Two edits, applied **together**, on the one `test()` call:

- `@stable` removed from the `tag` array
- `test()` → `test.fixme()`, with the reason and issue number in a comment above it

`@stable` removal alone would only stop the daily — the test would keep going red on `pr-validation.yml`'s impacted-specs gate, which selects specs by **file diff**, not by tag (#871), so this very PR would go red. `test.fixme` skips it in every context.

The file's other three tests keep `@stable`, so `QA-CHECKLIST.md` needs no change and no generated block is touched.

## Checks run locally

- `npm run typecheck` — clean
- `npx eslint <file>` — 0 errors (3 pre-existing `no-explicit-any` warnings, untouched by this diff)
- `npm run check:checklist-coverage` — passes
- `node scripts/check-checklist-guard.mjs` — passes
