### PR TITLE
test(quarantine): quarantine mcp-server's tool-mode test (#1266)

### DIFF
--- a/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
@@ -128,9 +128,17 @@ test.afterEach(async ({ request }) => {
   }
 });
 
-test(
+// Quarantined for #1266 — recurrent flake on a TRANSPORT-level signature:
+// `apiRequestContext.get: Timeout 20000ms exceeded.` on GET
+// /api/v2/mcp/servers?action_count=true, same signature on the 2026-07-30,
+// 2026-08-03 and 2026-08-04 dailies. Filed as load/reachability about this
+// spec, not about changing tool mode (CONTRIBUTING.md -> Infra-signature
+// exemption: a spec that keeps appearing as collateral while others do not).
+// Lifting the quarantine (remove test.fixme + restore @stable) is a
+// deliverable of #1266.
+test.fixme(
   "user must be able to change mode of MCP tools without any issues",
-  { tag: ["@release", "@workspace", "@components", "@mcp", "@stable"] },
+  { tag: ["@release", "@workspace", "@components", "@mcp"] },
   async ({ page }) => {
     (page as any).allowFlowErrors();
     await page.waitForTimeout(5000);


### PR DESCRIPTION
Quarantines `mcp-server.spec.ts`'s "user must be able to change mode of MCP tools without any issues" test as **prevention**, from the 2026-08-04 daily triage (umbrella #1258).

Tracked by #1266 — **not closed by this PR**. Lifting the quarantine (remove `test.fixme` + restore `@stable`, after re-validating per `CONTRIBUTING.md`) is a deliverable of that issue.

## Why

Recurrent flake meeting the criterion in `CONTRIBUTING.md` → *Triage protocol* step 2 — the **same** `error_signature` on three dailies inside the 30-day window:

| Daily | Signature |
|---|---|
| 2026-07-30 | `TimeoutError: apiRequestContext.get: Timeout 20000ms exceeded.` |
| 2026-08-03 | `TimeoutError: apiRequestContext.get: Timeout 20000ms exceeded.` |
| 2026-08-04 ([run 30901311395](https://github.com/oriontech-me/langflow-e2e/actions/runs/30901311395)) | `TimeoutError: apiRequestContext.get: Timeout 20000ms exceeded.` |

The call log names the request: `GET http://localhost:7860/api/v2/mcp/servers?action_count=true`.

**This signature deserves the extra sentence, because the usual reading inverts here.** `apiRequestContext.*: Timeout` **is** on the infra-signature exemption list (`scripts/lib/infra-signatures.ts`) — it is transport-level and cannot be a product assertion under any reading. A single occurrence would be triaged once for the run as wedge collateral and get **no** per-spec issue.

What makes this one an issue anyway is the clause in that same rule: *"If the same spec keeps appearing as collateral across days while other specs do not, that is a signal about the spec (it hammers the backend hardest) and belongs on a dedicated issue about load, not about the assertion."* The discriminating day is **2026-08-03**, where this test was the **only** transport-level signature of the entire run (1 of 5 flakes) — so a whole-run outage does not explain it.

#1266 is therefore scoped to load/reachability for this spec, explicitly **not** to whether changing MCP tool mode works.

## What changed

Two edits, applied **together**, on the one `test()` call:

- `@stable` removed from the `tag` array
- `test()` → `test.fixme()`, with the reason, the dates and the issue number in a comment above it

`@stable` removal alone would only stop the daily — the test would keep going red on `pr-validation.yml`'s impacted-specs gate, which selects specs by **file diff**, not by tag (#871), so this very PR would go red. `test.fixme` skips it in every context.

The file's other tests keep `@stable`, so `QA-CHECKLIST.md` needs no change and no generated block is touched.

## Checks run locally

- `npm run typecheck` — clean
- `npx eslint <file>` — 0 errors (pre-existing warnings only, untouched by this diff)
- `npm run check:checklist-coverage` — passes
- `node scripts/check-checklist-guard.mjs` — passes
