### PR TITLE
test(model-provider): cover Azure AI Foundry provider setup (#1194)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,22 @@ GROQ_TEST_MODEL=
 MISTRAL_API_KEY=
 MISTRAL_TEST_MODEL=
 
+# Azure AI Foundry provider (azure-ai-foundry-provider-setup.spec.ts, §7.8).
+# Only the two credential-gated tests need these — the surface, the rejection
+# control and the deployment-name mechanism run without any Azure account. The
+# probe hits GET <endpoint>/models with an `api-key` header from the TEST HOST
+# and skips with a reason when any of the three is unset or the resource does
+# not answer 200 with a `data` list. AZURE_AI_FOUNDRY_ENDPOINT is the
+# OpenAI-compatible endpoint from the Foundry portal ("Get endpoint"), e.g.
+# https://<resource>.services.ai.azure.com/openai/v1 — and
+# AZURE_AI_FOUNDRY_TEST_DEPLOYMENT is the PORTAL DEPLOYMENT NAME, not a catalog
+# model id (that distinction is what §7.8 exists to cover). The deployment's
+# existence cannot be pre-verified: /models is the resource catalog, not its
+# deployment list — the inference test is what proves it.
+AZURE_AI_FOUNDRY_API_KEY=
+AZURE_AI_FOUNDRY_ENDPOINT=
+AZURE_AI_FOUNDRY_TEST_DEPLOYMENT=
+
 # Model/provider test strategy (auto-detected by priority):
 # 1. MODEL_TEST_ID set    → runs only the specified model (e.g. gpt-4o-mini)
 # 2. MODEL_TEST_PROVIDER set → runs all models for the specified provider (e.g. openai | anthropic | google)

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -441,7 +441,7 @@
 
 #### 7.8 Unified Provider Setup — 1.11.0 additions
 - [ ] OpenAI Compatible as a first-class unified model provider: setup with base URL + key, models discovered, usable by a flow → `core-functionality/model-provider/openai-compatible-provider-setup.spec.ts`
-- [ ] Azure AI Foundry in the unified provider setup: configuration accepts deployment names, provider appears configured (requires Azure credentials in CI) → `core-functionality/model-provider/azure-ai-foundry-provider-setup.spec.ts`
+- [x] Azure AI Foundry in the unified provider setup: configuration accepts deployment names, provider appears configured → `core-functionality/model-provider/azure-ai-foundry-provider-setup.spec.ts` (6 tests, all validated against a live Azure resource on 1.12.0.dev15 — 3/3 clean `--retries=0 --workers=1` runs, every test force-failed. 4 of them need **no** Azure account and carry the surface on every lane: the two-variable form, the Foundry-only deployment hint asserted differentially against OpenRouter, the read-only unconfigured panel, an unresolvable endpoint rejected with `valid:false` and nothing persisted, and a deployment name absent from every catalog accepted and stored as `Azure AI Foundry::llm::<name>`. The other two — real credentials configuring the provider through Settings, and a real inference addressed by the deployment name — **skip with an explicit reason in CI** until `AZURE_AI_FOUNDRY_API_KEY` / `AZURE_AI_FOUNDRY_ENDPOINT` / `AZURE_AI_FOUNDRY_TEST_DEPLOYMENT` land as secrets, a maintainer action flagged on #1194)
 
 ---
 

--- a/docs/core-functionality/model-provider/azure-ai-foundry-provider-setup.md
+++ b/docs/core-functionality/model-provider/azure-ai-foundry-provider-setup.md
@@ -1,0 +1,458 @@
+# Azure AI Foundry — unified provider setup (deployment names, not catalog IDs)
+
+**Last validated:** Langflow 1.12.x
+
+---
+
+## What this test validates *(required)*
+
+QA-CHECKLIST §7.8 "Azure AI Foundry in the unified provider setup: configuration
+accepts deployment names, provider appears configured" — the 1.11.0 addition to
+the unified **Settings → Model Providers** surface (upstream
+`langflow-ai/langflow#13912`, `#14023`).
+
+Azure AI Foundry is the first provider in that surface whose model identities are
+**operator-defined**: the seed catalog (`gpt-4o`, `gpt-4o-mini`, `gpt-4.1`,
+`o3-mini`, `Mistral-Large-3` — `lfx/base/models/azure_ai_foundry_constants.py`) is
+a suggestion list, and inference actually addresses the **portal deployment name**
+the operator typed. Two consequences shape this spec and separate it from every
+keyed sibling (`openai-provider.spec.ts`, `google-provider.spec.ts`):
+
+1. **Two required variables, not one** — `AZURE_AI_FOUNDRY_API_KEY` *and*
+   `AZURE_AI_FOUNDRY_ENDPOINT` (the OpenAI-compatible endpoint from the Foundry
+   portal). Validation is a live `GET <endpoint>/models` with an `api-key` header
+   (`request_azure_ai_foundry_model_entries`, `lfx/base/models/model_utils.py`);
+   both variables must be present or the backend validator returns without
+   checking anything.
+2. **Free-text model enablement** — the provider panel renders a Foundry-only
+   hint (`custom-deployment-hint`: *"Use your Azure AI Foundry deployment names
+   from the portal (not catalog model IDs). Search or type a name to add one."*),
+   its search box says *"Search or add a deployment name…"* instead of *"Search
+   models…"*, and a name absent from every catalog can be enabled and is stored
+   under the typed identity `Azure AI Foundry::llm::<deployment>`.
+
+The six tests split by dependency, deliberately:
+
+| # | Test | Needs Azure credentials |
+|---|---|---|
+| 1 | Provider surface: listed, searchable, panel opens, Foundry-only deployment hint + placeholder, seed catalog, differential vs OpenRouter | no |
+| 2 | Unconfigured provider: two-variable form (both inputs + Save disabled), read-only catalog — no enable toggle, no add-deployment control | no |
+| 3 | Bogus endpoint + key are rejected and nothing is persisted (causal negative control) | no |
+| 4 | A non-catalog deployment name is accepted, stored under the typed identity, and rendered in the panel | no |
+| 5 | Real credentials configure the provider; the add-deployment control appears and enables a portal deployment through the UI | **yes** |
+| 6 | The configured deployment executes a real inference through the Language Model component | **yes** |
+
+Tests 1–4 hold the surface without any Azure account — they are what keeps this
+coverage alive on every lane, and their bite comes from being **differential and
+causal**, not from mere element presence (see *Guarding against false
+positives*). Tests 5–6 exercise the operator's real path and probe-gate
+themselves out with an explicit reason when the endpoint or key is absent.
+
+If this fails, the 1.11.0 unified-provider addition is broken: Azure AI Foundry
+stopped being configurable from Settings, the deployment-name mechanism
+regressed to catalog-only identities, or credential validation stopped
+validating.
+
+---
+
+## Tags *(required)*
+
+| Test | Tags |
+|---|---|
+| 1 | `@stable` `@model-provider` `@settings` |
+| 2 | `@stable` `@model-provider` `@settings` |
+| 3 | `@stable` `@api` `@model-provider` `@settings` |
+| 4 | `@stable` `@api` `@model-provider` `@settings` |
+| 5 | `@stable` `@model-provider` `@settings` |
+| 6 | `@stable` `@model-provider` `@components` `@playground` |
+
+`@stable` is added only after the validation burst in this issue's VALIDATE
+phase (3 clean `--retries=0 --workers=1` runs) plus the force-fail proof per
+test, per `CONTRIBUTING.md`.
+
+**Why `@stable` on the credential-gated tests too, and what it means there.**
+Issue #1194 assumed the whole spec needed Azure credentials and therefore
+shipped untagged. The surface triage disproved the premise for tests 1–4, and
+the credentials turned out to exist for the author's environment, so tests 5–6
+are validated for real rather than shipped blind. In CI, tests 5–6 **skip with
+an explicit reason** until `AZURE_AI_FOUNDRY_API_KEY` /
+`AZURE_AI_FOUNDRY_ENDPOINT` / `AZURE_AI_FOUNDRY_TEST_DEPLOYMENT` land as
+secrets — the same missing-dependency skip contract `google-provider.spec.ts`
+carries for `GOOGLE_API_KEY`, and a skip is never a green (it is reported as a
+skip). Leaving the whole file untagged was the worse option: `nightly.yml` is
+dormant and `daily-stable.yml` runs `--grep @stable`, so an untagged spec runs
+in **no** recurring workflow at all — the invisible-red pattern from #945/#940.
+
+**Adding the CI secrets is a maintainer action, flagged on the PR.** Until then
+the daily's real coverage of §7.8 is tests 1–4.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` (fresh nightly; the surface was
+  scouted on **1.12.0.dev14** and the whole spec validated on **1.12.0.dev15**).
+- `LANGFLOW_A2A_ENABLED`-style feature flag: **none** — Azure AI Foundry needs no
+  flag; it is in the stock provider catalog (`GET /api/v1/models/providers`
+  returns it on dev14) and the `langchain-azure-ai` package (1.2.3) ships in the
+  nightly image. Its absence would surface as a validation error naming the
+  package, which test 3 would report verbatim.
+- Tests 1–4: no credentials, no external network.
+- Tests 5–6 (`.env`, all three or the tests skip):
+
+  ```
+  # Azure AI Foundry provider (azure-ai-foundry-provider-setup.spec.ts). Tests 5-6
+  # probe GET <endpoint>/models directly and skip with a reason when the key,
+  # endpoint or deployment is missing / not served by the resource.
+  AZURE_AI_FOUNDRY_API_KEY=
+  AZURE_AI_FOUNDRY_ENDPOINT=          # https://<resource>.services.ai.azure.com/openai/v1
+  AZURE_AI_FOUNDRY_TEST_DEPLOYMENT=   # portal deployment name, e.g. gpt-4o-mini
+  ```
+
+- Serial (`test.describe.configure({ mode: "serial" })`) and run with
+  `--workers=1`: every test drives the same account-wide Settings state.
+- No `collect-models` run needed — Azure AI Foundry is deliberately **not** added
+  to `providerConfigMap` (`tests/helpers/provider-setup/provider-config.ts`).
+  That map feeds the `collect-models` sweep and the keyed-provider surfaces; a
+  two-variable provider does not fit its `api-key` / `base-url` union, and adding
+  it would couple every lane's pre-flight to an Azure resource. The spec keeps
+  its env gating local, exactly as `groq-provider.spec.ts` and
+  `mistral-provider.spec.ts` do.
+
+---
+
+## Step by step *(required)*
+
+Live-scouted testids (1.12.0.dev14, re-checked on dev15 where the run is green, via `playwright-cli`): `provider-list`,
+`provider-search-input`, `provider-item-Azure AI Foundry`,
+`provider-variable-input-AZURE_AI_FOUNDRY_API_KEY`,
+`provider-variable-input-AZURE_AI_FOUNDRY_ENDPOINT`, `model-provider-selection`,
+`custom-deployment-hint`, `model-search-input`, `model-search-empty`,
+`llm-models-section`, `llm-tag-tool-<model>`, `llm-toggle-<model>`,
+`add-custom-llm-deployment-button` / `add-custom-embeddings-deployment-button`
+(both when the panel shows all model types) or `add-custom-deployment-button`
+(type-filtered panel), Save by role+name; the Language Model node's model options are `<provider>-<model>-option` (e.g. `Azure AI Foundry-gpt-5-mini-option`). Endpoints:
+`POST /api/v1/models/validate-provider`, `GET|POST /api/v1/models/enabled_models`,
+`GET|POST|PATCH|DELETE /api/v1/variables/`.
+
+**Test 1 — Azure AI Foundry is offered with a Foundry-only deployment surface**
+
+1. Bootstrap, Settings → Model Providers; assert the header and `provider-list`.
+2. Type `azure` in `provider-search-input`; assert the filtered list is exactly
+   `provider-item-Azure AI Foundry` (the search path is how the page is used —
+   the list renders a subset).
+3. Clear the search, click `provider-item-Azure AI Foundry`; assert its
+   `model-provider-selection` panel opens.
+
+   > The **two-variable form** (both raw inputs + Save disabled while empty) is
+   > asserted in **test 2**, not here: a *configured* provider replaces the raw
+   > inputs with a masked value plus **Replace**, so those asserts only hold
+   > behind the unconfigured-state gate. This test must run on every lane
+   > regardless of what the instance has stored — it went red exactly once for
+   > this reason while authoring, on an instance that still held the credentials.
+
+4. **Assert (deployment-name contract):** `custom-deployment-hint` is visible and
+   its text contains both `deployment names` and `not catalog model IDs`;
+   `model-search-input`'s placeholder is `Search or add a deployment name…`.
+5. **Assert (seed catalog):** `llm-models-section` is visible and lists the seed
+   entries — `gpt-4o` present, ≥ 3 of the 5 seed names (floor, not exact: a
+   catalog addition is not a regression, per the #993 count rule).
+6. **Assert (differential):** open `provider-item-OpenRouter`; its
+   `provider-variable-input-OPENROUTER_API_KEY` renders,
+   `custom-deployment-hint` is **absent** and the search placeholder is
+   `Search models…`. This is what proves step 4 measured a Foundry-specific
+   surface rather than a page-wide string.
+
+**Test 2 — an unconfigured Azure AI Foundry panel asks for two variables and stays read-only**
+
+1. Open the Foundry panel (no credentials stored — asserted via
+   `GET /api/v1/variables/`: no `AZURE_AI_FOUNDRY_*` entry; a configured instance
+   skips with that reason).
+2. **Assert (two variables):** both
+   `provider-variable-input-AZURE_AI_FOUNDRY_API_KEY` and
+   `provider-variable-input-AZURE_AI_FOUNDRY_ENDPOINT` are visible, and Save is
+   **disabled** while the required pair is empty — Foundry is the first provider
+   on this page that needs two.
+3. **Assert:** no `llm-toggle-*` / `embeddings-toggle-*` control exists in
+   `model-provider-selection` — the seed rows render with their capability tags
+   (`llm-tag-tool-gpt-4o`) and nothing to switch.
+4. Type an arbitrary name (`e2e-unconfigured-probe`) into `model-search-input`.
+5. **Assert:** `model-search-empty` ("No models match your search.") renders and
+   **no** `add-custom-*deployment-button` appears — the add-deployment control is
+   gated on the provider being configured
+   (`isEnabledModel = is_enabled || is_configured`, scouted in the shipped
+   bundle). This is the precondition test 5 flips.
+
+**Test 3 — bogus endpoint + key are rejected and nothing is persisted**
+
+1. Assert the pre-state via API: no `AZURE_AI_FOUNDRY_API_KEY` /
+   `AZURE_AI_FOUNDRY_ENDPOINT` variable exists.
+2. Fill the key with a garbage token and the endpoint with a
+   deliberately-unresolvable Foundry-shaped host
+   (`https://e2e-invalid-<runId>.services.ai.azure.com/openai/v1`).
+3. Arm a waiter on `POST /api/v1/models/validate-provider` **before** clicking
+   Save, then Save.
+4. **Assert:** the response is HTTP **200** with body `valid === false` and an
+   `error` containing `Azure AI Foundry` — the backend took the Foundry branch
+   and reported a validation failure (measured: ~4.7 s, `NameResolutionError`).
+   The status alone is worthless here: this endpoint answers 200 for a failed
+   validation (same trap as `ollama-provider.spec.ts`' corrected M1).
+5. **Assert (nothing persisted):** `GET /api/v1/variables/` still has no
+   `AZURE_AI_FOUNDRY_*` entry, and the panel still shows no `llm-toggle-*` —
+   a rejected credential leaves no state behind.
+
+**Test 4 — a non-catalog deployment name is accepted and rendered (API + UI)**
+
+1. Pre-clean: `POST /api/v1/models/enabled_models` with
+   `enabled: false` for the fixed test name, ignoring the result, so a leftover
+   from an earlier run cannot pre-satisfy the assert.
+2. `POST /api/v1/models/enabled_models` →
+   `[{ provider: "Azure AI Foundry", model_id: "<E2E_DEPLOYMENT>", enabled: true,
+   model_type: "llm" }]`, where `<E2E_DEPLOYMENT>` is a fixed name that exists in
+   **no** catalog (`e2e-azure-foundry-deployment`).
+3. **Assert (API):** 200, and the response's `enabled_models` contains
+   `Azure AI Foundry::llm::e2e-azure-foundry-deployment` — the deployment name
+   survives verbatim under the typed identity, with no catalog membership and
+   **no credentials configured** (the backend validator returns early when the
+   provider's variables are absent, so enablement is credential-independent by
+   design — read in `api/v1/models.py::update_enabled_models`). The read side is
+   then asserted to know the identity too, **by key**:
+   `GET /api/v1/models/enabled_models` gains the deployment as a key in both
+   `enabled_models["Azure AI Foundry"]` and
+   `enabled_models_by_type["Azure AI Foundry"].llm`, and loses it on disable —
+   causal in both directions. Its **boolean stays `false`** here, and that is
+   correct rather than a defect: the value answers *"enabled AND usable"*, so
+   every seed entry reads `false` on an unconfigured provider too (measured on
+   1.12.0.dev14; the first authored version of this test asserted the boolean and
+   failed for exactly this reason). The `true` state belongs to the configured
+   path — test 5 reads the row's own toggle.
+4. Open Settings → Model Providers → Azure AI Foundry.
+5. **Assert (UI):** `llm-models-section` contains the deployment name **in
+   addition to** the seed entries — the panel merges free-text enables for this
+   provider only (scouted live: the row renders after a reload, with a `tool`
+   tag).
+6. Cleanup: `POST enabled_models` with `enabled: false`; assert the response's
+   `enabled_models` no longer contains the identity.
+
+**Test 5 — real credentials configure the provider and enable a portal deployment through the UI** *(skips without credentials, and on an instance that already has them)*
+
+0. **Ownership gate.** Skip when `GET /api/v1/variables/` already holds an
+   `AZURE_AI_FOUNDRY_*` credential. This test stores the pair and **deletes it**
+   in teardown, so on a pre-configured instance it would both race that state and
+   destroy a credential it does not own. Measured: with a credential left behind
+   by hand, the run produced three different intermittent failures across steps
+   (a missing `llm-toggle-*`, and a `400 Validation failed for Azure AI Foundry`
+   on the enable) — none of them a defect in what the test is about. Test 6
+   carries the same gate; test 4 does not need it (it only enables and disables a
+   synthetic deployment name).
+1. Probe `GET <AZURE_AI_FOUNDRY_ENDPOINT>/models` with the `api-key` header
+   straight from the test host; skip with the concrete reason when the key or
+   endpoint is missing, the probe is non-200, or the payload has no `data` list.
+2. Open the Foundry panel, fill both variables, arm waiters on
+   `POST /api/v1/models/validate-provider` **and** on the variables write
+   (`POST /api/v1/variables/` or `PATCH /api/v1/variables/{id}` — the frontend
+   branches on existence, #636), click Save.
+3. **Assert (configure):** validate-provider body `valid === true` and the
+   variables write is 2xx — armed before the click, so a pre-existing configured
+   state cannot pass the test.
+4. **Assert (provider state):** poll `GET /api/v1/variables/` until **both**
+   `AZURE_AI_FOUNDRY_API_KEY` and `AZURE_AI_FOUNDRY_ENDPOINT` are stored, then
+   assert the panel renders `llm-toggle-*` controls.
+
+   > **Why a poll and not a read.** A two-variable provider means Save issues
+   > **two separate** variables writes, and the waiter armed in step 2 resolves on
+   > the FIRST one. Reading the stored state right after it lost the race ~1 run
+   > in 3 while authoring: once with only `AZURE_AI_FOUNDRY_ENDPOINT` present, and
+   > once as "no `llm-toggle-*` within 30 s" — the same cause wearing a different
+   > symptom, since a half-configured provider legitimately renders no toggle.
+   > The pair is the backend fact this step is about; how many requests the
+   > frontend chose to make is not.
+5. Type `AZURE_AI_FOUNDRY_TEST_DEPLOYMENT` into `model-search-input`.
+6. **Assert (add-deployment control):** the `add-custom-*deployment-button` for
+   language models is now visible — the exact control test 2 proved absent while
+   unconfigured. Arm a waiter on `POST /api/v1/models/enabled_models` **before**
+   clicking it, and assert that write is 2xx with the identity in its body: the
+   row and its toggle render **optimistically**, so the UI alone cannot tell an
+   accepted deployment from a write that never landed. Measured while authoring —
+   reloading right after the click cancelled the in-flight POST and the
+   deployment was gone afterwards while the panel still showed it.
+7. **Assert (enabled + persisted):** the deployment row renders a real toggle
+   (`llm-toggle-<deployment>`) and the add left it `data-state="checked"` — the
+   half test 4 cannot reach, since an unconfigured provider renders no toggle at
+   all — and after a page reload `GET /api/v1/models/enabled_models` still carries
+   the deployment as a registered Foundry identity.
+8. Cleanup (restores the pre-test account state): disable the deployment, then
+   `DELETE /api/v1/variables/{id}` for both Foundry variables, asserting each
+   delete is 2xx and that `GET /api/v1/variables/` no longer lists them.
+
+**Test 6 — the configured deployment answers a real inference** *(skips without credentials)*
+
+1. Same probe/skip as test 5. Note what the probe cannot check: `<endpoint>/models`
+   is the resource's **catalog**, not its deployment list (*"Foundry /models is a
+   catalog, not deployments"* — `model_utils.py`), so the deployment's existence
+   cannot be pre-verified; the inference in step 6 is what proves it.
+2. Configure the provider and enable `AZURE_AI_FOUNDRY_TEST_DEPLOYMENT` via API
+   (setup, not the assert — test 5 owns the UI path).
+3. Copy the **Basic Prompting** starter over the API (`createFlowFromStarter` +
+   `openFlowById`) — it ships Chat Input → Language Model → Chat Output **wired**.
+   Two paths were rejected on measurement, both while authoring:
+   - adding the three components to a blank canvas leaves them **unconnected**,
+     and the run then persists the user turn with **no reply at all** — a symptom
+     indistinguishable from a provider failure;
+   - clicking the card in the templates modal (`loadTemplateByName`) creates a
+     blank `New Flow` placeholder first (#1005), whose id that helper can only
+     clean when it manages to read a response body the SPA discards on navigation
+     — here a stray `New Flow` **plus** `Basic Prompting` survived one run in two.
+     The API copy is id-addressed, leaks nothing and is isolated per worker (#684).
+   Open the node's `model_model` dropdown and pick
+   `<provider>-<model>-option` — `Azure AI Foundry-<deployment>-option`, scouted
+   live on 1.12.0.dev15. The **provider prefix matters**: a Foundry deployment
+   can carry the same name as an OpenAI catalog id.
+4. **Assert (selection):** `value-dropdown-model_model` shows the deployment name
+   exactly — a catalog ID silently substituted for it fails here.
+5. Playground: send a per-run sentinel; wait for completion on the deterministic
+   `button-stop` hidden **and** `button-send` visible pair.
+6. **Assert (execute):** the persisted reply for the session is non-empty and
+   echoes the sentinel (monitor API, not the live bubble — the #634 stream race).
+   Only a real Foundry inference addressed by deployment name can produce it.
+7. Cleanup: delete the created flow id-scoped, disable the deployment, delete
+   both variables.
+
+---
+
+## Validation criterion *(required)*
+
+§7.8's two claims are each pinned by an observable that cannot pass by accident:
+
+- *"configuration accepts deployment names (not catalog IDs)"* — test 4 stores a
+  name present in no catalog and reads it back verbatim under
+  `Azure AI Foundry::llm::<name>`, then finds it rendered in the provider panel
+  alongside the seed catalog; test 5 does the same through the UI's
+  add-deployment control; test 6 gets a real inference out of it.
+- *"provider appears configured"* — test 5 asserts `valid === true` + a 2xx
+  variables write from waiters armed before Save, and the resulting state change
+  (toggles + `N models`), while test 3 proves the negative: a credential that
+  does not validate leaves the provider unconfigured and the store untouched.
+
+Tests 1–2 pin the surface itself (two-variable form, Foundry-only deployment
+hint and placeholder, read-only-while-unconfigured), differentially against
+OpenRouter so the asserts cannot pass on a page-wide string.
+
+## Guarding against false positives *(how)*
+
+- **Differential, not presence** — the deployment hint and the
+  `Search or add a deployment name…` placeholder are asserted for Foundry **and**
+  asserted absent for OpenRouter in the same run. A page-wide regression that
+  showed the hint everywhere would fail.
+- **Absence test before the presence test** — test 2 proves
+  `add-custom-*deployment-button` is missing while unconfigured, so test 5's
+  "the control appeared" is a real state change, not a control that is always
+  there.
+- **Body-level validation assert** — `validate-provider` answers HTTP 200 for a
+  failed validation, so tests 3 and 5 assert `valid` in the body. An
+  `ok()`-only assert would pass on rejection.
+- **Waiters armed before Save** — the configure pass is caused by THIS save
+  (family pattern from `openai-provider.spec.ts`).
+- **No-state proof on rejection** — test 3 asserts the variables API is still
+  empty afterwards, so "Save was clicked and nothing broke" cannot read as
+  success.
+- **A name no catalog contains** — test 4's `e2e-azure-foundry-deployment` cannot
+  come from the seed catalog or any live fetch, so the assert can only pass
+  through the free-text mechanism.
+- **Skip ≠ pass** — tests 5–6 skip with the concrete reason (missing key /
+  endpoint / deployment, non-200 probe, or a credential the test would not own),
+  never silently green.
+- **No unattributed 400** — every non-200 from `POST /api/v1/models/enabled_models`
+  is logged with the backend's own `detail` (`Validation failed for
+  Azure AI Foundry: …`, which is how a transient failure of the live `/models`
+  probe surfaces). A bare "expected 200, received 400" cannot be triaged.
+- **Force-fail plan** (CONTRIBUTING §2, executed in the issue's FORCE_FAIL
+  phase): T1 — assert the hint on OpenRouter instead of Foundry ⇒ red;
+  T2 — assert the add-deployment button IS visible while unconfigured ⇒ red;
+  T3 — assert `valid === true` for the bogus endpoint ⇒ red; T4 — read back a
+  different deployment name than the one enabled ⇒ red; T5 — fill a garbage key
+  with the real endpoint ⇒ `valid === false` ⇒ red; T6 — expect a catalog ID
+  (`gpt-4o`) in `value-dropdown-model_model` instead of the deployment ⇒ red.
+  Every mutation carries `// FF-MUTATION` and is reverted with `grep -c` = 0.
+
+---
+
+## Cleanup *(required by the repo's flow-cleanup rule)*
+
+- Tests 1–5 create **no flows** — they are Settings-UI and API only. Test 6
+  creates one flow (an API copy of the starter, see step 3) and deletes it
+  id-scoped in `afterEach` (`deleteFlow` + `getAuthToken`), per the mandatory
+  contract. That `afterEach` deliberately carries **no `.catch()`**: `deleteFlow`
+  throws on a failed deletion, and swallowing it is exactly how a leak goes
+  silent. Verified by diffing the instance's flow-id set around a run — zero new
+  ids.
+- **Account-wide state:** every test restores what it wrote — credential
+  variables are deleted by id, enabled deployments are disabled.
+- **Cleanup tolerates the second write.** The credential purge lists-and-deletes
+  in up to 3 bounded passes rather than once: a single pass that ran between
+  Save's two writes left the second variable behind, and that leftover made the
+  NEXT run's unconfigured-state tests (2 and 3) **skip** instead of run — the
+  worse half of the failure, because a skip reads as "fine" in the summary.
+- **One documented residue:** disabling a model does not erase the identity, it
+  moves it into the internal `__disabled_models__` variable, and that variable is
+  filtered out of `GET /api/v1/variables/` (`variable.py` skips names wrapped in
+  `__`), so there is no id to DELETE. The test therefore uses a **fixed**
+  deployment name rather than a per-run one: the residue is bounded to a single
+  inert entry naming a deployment that does not exist, instead of growing by one
+  per run. It affects nothing else — a disabled entry only hides a model from
+  pickers, and no other spec uses Azure AI Foundry.
+
+---
+
+## What this test does not cover *(optional)*
+
+- Azure **OpenAI** (`Azure OpenAI`) — a separate provider, listed by
+  `GET /api/v1/models/providers` but not rendered on the Settings page on
+  1.12.0.dev14 (a divergence noted as a product observation, not a defect).
+- Embeddings deployments (`add-custom-embeddings-deployment-button`) — the same
+  mechanism, one type away; language deployments carry the contract.
+- The `AZURE_AI_FOUNDRY_*` **environment-variable fallback**
+  (`_env_if_allowed` in `instantiation.py`) — configuration via Settings is §7.8's
+  subject.
+- Deprecated/unsupported-model rejection (`400 Cannot enable … model`) — catalog
+  policy, not the Foundry path.
+- Tool calling / structured output through a Foundry deployment (covered
+  generically by the agent specs, provider-independent).
+
+---
+
+## External dependencies *(required)*
+
+- `src/frontend/src/pages/SettingsPage/` — Model Providers page:
+  `provider-item-*`, `provider-variable-input-*`, `model-provider-selection`,
+  `custom-deployment-hint`, `model-search-input`,
+  `add-custom-*deployment-button`.
+- `src/lfx/base/models/model_metadata.py` — the `Azure AI Foundry` provider entry
+  (its two variables, the endpoint description carrying the deployment-name
+  rule).
+- `src/lfx/base/models/azure_ai_foundry_constants.py` — seed catalog.
+- `src/lfx/base/models/model_utils.py` —
+  `request_azure_ai_foundry_model_entries` (credential validation) and the
+  free-text enable merge.
+- `src/lfx/base/models/unified_models/credentials.py` /
+  `instantiation.py` — the Foundry validation branch and endpoint injection.
+- `src/backend/base/langflow/api/v1/models.py` —
+  `validate-provider`, `enabled_models` (typed identities), and their variable
+  storage.
+- `langchain-azure-ai` present in the image (1.2.3 on 1.12.0.dev14) — absent, the
+  validator raises a message naming the package, which test 3 surfaces.
+- **Tests 5–6 only:** a live Azure AI Foundry resource — endpoint, key and one
+  language-model deployment (real network calls, real inference).
+
+---
+
+## When to review this test *(optional)*
+
+- When the Azure credentials land as CI secrets (tests 5–6 stop skipping there).
+- If the Foundry hint / placeholder strings change (`modelProviders.*` i18n keys)
+  — the assert is on the substrings `deployment names` and
+  `not catalog model IDs`.
+- If `enabled_models` changes its identity format
+  (`<provider>::<type>::<name>`) — test 4 asserts it directly.
+- If the add-deployment control stops being gated on `is_configured` — test 2's
+  absence assert is the tripwire.

--- a/tests/tests-automations/regression/core-functionality/model-provider/azure-ai-foundry-provider-setup.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/azure-ai-foundry-provider-setup.spec.ts
@@ -1,0 +1,757 @@
+import * as dotenv from "dotenv";
+import path from "path";
+import type { APIRequestContext, Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { SettingsPage } from "../../../../pages";
+import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { createFlowFromStarter } from "../../../../helpers/flows/create-flow-from-starter";
+import { openFlowById } from "../../../../helpers/flows/open-flow-by-id";
+import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
+
+/**
+ * Azure AI Foundry in the unified provider setup (QA-CHECKLIST §7.8, Langflow
+ * 1.11.0 — upstream #13912 / #14023). Spec doc:
+ * docs/core-functionality/model-provider/azure-ai-foundry-provider-setup.md
+ *
+ * Foundry is the first provider on the Settings → Model Providers surface whose
+ * model identities are OPERATOR-DEFINED: the seed catalog (gpt-4o, gpt-4o-mini,
+ * gpt-4.1, o3-mini, Mistral-Large-3) is a suggestion list, and inference
+ * addresses the PORTAL DEPLOYMENT NAME the operator typed. It is also the first
+ * one configured by TWO variables (api key + endpoint).
+ *
+ * Tests 1-4 hold that surface with no Azure account at all — the deployment-name
+ * mechanism is credential-independent by design (the backend validator returns
+ * early when the provider's variables are absent, api/v1/models.py ::
+ * update_enabled_models), which is what keeps §7.8 covered on every lane.
+ * Tests 5-6 exercise the operator's real path and probe-gate themselves out
+ * with an explicit reason when the endpoint/key/deployment are not configured.
+ *
+ * False-positive guards that shape the asserts (all measured on 1.12.0.dev14):
+ * - the Foundry hint and its "Search or add a deployment name…" placeholder are
+ *   asserted for Foundry AND asserted ABSENT for OpenRouter, so a page-wide
+ *   regression cannot pass;
+ * - `POST /api/v1/models/validate-provider` answers HTTP **200** with
+ *   `{"valid": false, "error": …}` for a credential it rejected, so every
+ *   validation assert reads the BODY (same trap as ollama-provider.spec.ts' M1);
+ * - test 2 proves `add-custom-*-deployment-button` is ABSENT while unconfigured,
+ *   so test 5's "the control appeared" is a real state change;
+ * - test 4 enables a name present in NO catalog, so only the free-text
+ *   mechanism can satisfy it.
+ */
+
+if (!process.env.CI) {
+  dotenv.config({ path: path.resolve(__dirname, "../../../../.env") });
+}
+
+const PROVIDER_NAME = "Azure AI Foundry";
+const PROVIDER_ITEM = `provider-item-${PROVIDER_NAME}`;
+const KEY_VAR = "AZURE_AI_FOUNDRY_API_KEY";
+const ENDPOINT_VAR = "AZURE_AI_FOUNDRY_ENDPOINT";
+const KEY_INPUT = `provider-variable-input-${KEY_VAR}`;
+const ENDPOINT_INPUT = `provider-variable-input-${ENDPOINT_VAR}`;
+
+// Seed catalog shipped by lfx/base/models/azure_ai_foundry_constants.py.
+// Asserted as a FLOOR (>= 3 present), never exactly: a catalog addition is not
+// a regression (#993's count rule).
+const SEED_MODELS = ["gpt-4o", "gpt-4o-mini", "gpt-4.1", "o3-mini", "Mistral-Large-3"];
+const SEED_FLOOR = 3;
+
+// FIXED, not per-run: disabling a model does not erase its identity, it moves it
+// into the internal `__disabled_models__` variable, which GET /api/v1/variables/
+// filters out (names wrapped in `__`), so there is no id to DELETE. A fixed name
+// bounds that residue to ONE inert entry naming a deployment that does not
+// exist, instead of one per run.
+const E2E_DEPLOYMENT = "e2e-azure-foundry-deployment";
+
+const FOUNDRY_KEY = process.env.AZURE_AI_FOUNDRY_API_KEY ?? "";
+const FOUNDRY_ENDPOINT = (process.env.AZURE_AI_FOUNDRY_ENDPOINT ?? "").replace(/\/+$/, "");
+const FOUNDRY_DEPLOYMENT = process.env.AZURE_AI_FOUNDRY_TEST_DEPLOYMENT ?? "";
+
+interface FoundryProbe {
+  usable: boolean;
+  reason: string;
+}
+
+/**
+ * Probes the real Foundry resource from the TEST host, before opening a browser,
+ * so an unusable account is an explicit skip and never a mid-test mystery.
+ *
+ * Note what it can NOT check: `<endpoint>/models` is the resource's CATALOG, not
+ * its deployment list (`request_azure_ai_foundry_model_entries` /
+ * "Foundry /models is a catalog, not deployments" in lfx/base/models/model_utils.py),
+ * so the configured deployment's existence cannot be pre-verified — the
+ * inference in test 6 is what proves it.
+ */
+async function probeFoundry(request: APIRequestContext): Promise<FoundryProbe> {
+  const missing = [
+    FOUNDRY_KEY ? "" : "AZURE_AI_FOUNDRY_API_KEY",
+    FOUNDRY_ENDPOINT ? "" : "AZURE_AI_FOUNDRY_ENDPOINT",
+    FOUNDRY_DEPLOYMENT ? "" : "AZURE_AI_FOUNDRY_TEST_DEPLOYMENT",
+  ].filter(Boolean);
+  if (missing.length > 0) {
+    return { usable: false, reason: `not set in the environment: ${missing.join(", ")}` };
+  }
+  try {
+    const res = await request.get(`${FOUNDRY_ENDPOINT}/models`, {
+      headers: { "api-key": FOUNDRY_KEY },
+      timeout: 15000,
+    });
+    if (res.status() !== 200) {
+      return {
+        usable: false,
+        reason: `GET ${FOUNDRY_ENDPOINT}/models answered ${res.status()}`,
+      };
+    }
+    const payload = await res.json().catch(() => null);
+    if (!payload || !Array.isArray((payload as { data?: unknown }).data)) {
+      return {
+        usable: false,
+        reason: `unexpected /models payload (no "data" list) from ${FOUNDRY_ENDPOINT}`,
+      };
+    }
+    return { usable: true, reason: "" };
+  } catch (e) {
+    return { usable: false, reason: `Foundry endpoint unreachable: ${(e as Error).message}` };
+  }
+}
+
+async function listVariables(
+  request: APIRequestContext,
+): Promise<Array<{ id: string; name: string }>> {
+  const bearer = await getAuthToken(request);
+  const res = await request.get("/api/v1/variables/", {
+    headers: { Authorization: bearer },
+  });
+  expect(res.status()).toBe(200);
+  const body = (await res.json()) as Array<{ id: string; name: string }>;
+  return body;
+}
+
+async function foundryVariables(
+  request: APIRequestContext,
+): Promise<Array<{ id: string; name: string }>> {
+  return (await listVariables(request)).filter((v) => v.name === KEY_VAR || v.name === ENDPOINT_VAR);
+}
+
+/**
+ * Deletes the Foundry credential pair, tolerating a write that is still in
+ * flight.
+ *
+ * A single list-then-delete pass is not enough: the UI's Save issues two
+ * separate variables writes, so a cleanup that ran between them left the second
+ * one behind — measured while authoring, and the leftover then made the NEXT
+ * run's unconfigured-state tests skip instead of run (a silent coverage loss,
+ * which is the worse half of the failure). Bounded, and the caller still asserts
+ * the end state.
+ */
+async function purgeFoundryCredentials(request: APIRequestContext): Promise<void> {
+  const bearer = await getAuthToken(request);
+  for (let pass = 0; pass < 3; pass++) {
+    const stored = await foundryVariables(request);
+    if (stored.length === 0 && pass > 0) return;
+    for (const variable of stored) {
+      await request
+        .delete(`/api/v1/variables/${variable.id}`, { headers: { Authorization: bearer } })
+        .catch(() => {});
+    }
+  }
+}
+
+interface EnabledModelsWrite {
+  enabled_models: string[];
+  disabled_models: string[];
+  /** Present only on a rejection — `Validation failed for <provider>: …`. */
+  detail?: string;
+}
+
+/**
+ * Model-level enablement (POST /api/v1/models/enabled_models). Returns the
+ * write's own response body, whose `enabled_models` carries the TYPED identity
+ * `<provider>::<type>::<name>` — the assert surface for the deployment-name
+ * contract.
+ */
+async function setDeploymentEnabled(
+  request: APIRequestContext,
+  deployment: string,
+  enabled: boolean,
+): Promise<{ status: number; body: EnabledModelsWrite }> {
+  const bearer = await getAuthToken(request);
+  const res = await request.post("/api/v1/models/enabled_models", {
+    headers: { Authorization: bearer, "Content-Type": "application/json" },
+    data: [{ provider: PROVIDER_NAME, model_id: deployment, enabled, model_type: "llm" }],
+  });
+  const body = (await res.json().catch(() => ({
+    enabled_models: [],
+    disabled_models: [],
+  }))) as EnabledModelsWrite;
+  // A bare "expected 200, received 400" is an unattributed red: the backend puts
+  // the reason in `detail` (`Validation failed for Azure AI Foundry: …`, which is
+  // how a transient Azure hiccup on the live /models probe surfaces here).
+  if (res.status() !== 200) {
+    console.log(
+      `POST /api/v1/models/enabled_models -> ${res.status()} ${JSON.stringify(body.detail ?? body)}`,
+    );
+  }
+  return { status: res.status(), body };
+}
+
+/**
+ * The Foundry model identities `GET /api/v1/models/enabled_models` KNOWS about,
+ * as names — the seed catalog plus every free-text deployment the user enabled.
+ *
+ * Reading the map's KEYS, not its booleans, is deliberate and was measured on
+ * 1.12.0.dev14: the value answers "enabled AND usable", so a deployment enabled
+ * while the provider carries no credentials is reported `false` (every seed entry
+ * is `false` there too). The KEY is what registration writes and erases —
+ * enabling adds it to both `enabled_models["Azure AI Foundry"]` and
+ * `enabled_models_by_type["Azure AI Foundry"].llm`, disabling removes it from
+ * both — so key presence is causal in both directions, which is exactly the
+ * "Langflow accepted this deployment name" contract §7.8 is about. The `true`
+ * value belongs to the configured-provider path (test 5, which reads the UI
+ * toggle's own state).
+ */
+async function registeredFoundryDeployments(request: APIRequestContext): Promise<string[]> {
+  const bearer = await getAuthToken(request);
+  const res = await request.get("/api/v1/models/enabled_models", {
+    headers: { Authorization: bearer },
+  });
+  expect(res.status()).toBe(200);
+  const body = (await res.json()) as {
+    enabled_models?: Record<string, Record<string, boolean>>;
+    enabled_models_by_type?: Record<string, Record<string, Record<string, boolean>>>;
+  };
+  const names = new Set<string>([
+    ...Object.keys(body.enabled_models?.[PROVIDER_NAME] ?? {}),
+    ...Object.keys(body.enabled_models_by_type?.[PROVIDER_NAME]?.llm ?? {}),
+  ]);
+  return [...names];
+}
+
+/** Settings → Model Providers → <provider>, with the detail panel open. */
+async function openProviderPanel(page: Page, providerItemTestId: string): Promise<void> {
+  await new SettingsPage(page).navigate();
+  await page.getByTestId("sidebar-nav-Model Providers").click();
+  await expect(page.getByTestId("settings_menu_header").last()).toContainText(
+    "Model Providers",
+    { timeout: 15000 },
+  );
+  await expect(page.getByTestId("provider-list")).toBeVisible({ timeout: 15000 });
+  await page.getByTestId(providerItemTestId).click();
+  await expect(page.getByTestId("model-provider-selection")).toBeVisible({ timeout: 15000 });
+}
+
+// Serial + --workers=1: every test drives the same account-wide Settings state
+// (provider credentials, enabled models), so parallel execution would have them
+// read each other's writes.
+test.describe.configure({ mode: "serial" });
+
+test.describe("Azure AI Foundry — unified provider setup", () => {
+  const createdFlowIds: string[] = [];
+
+  test.afterEach(async ({ request }) => {
+    if (createdFlowIds.length === 0) return;
+    // page.request carries only browser cookies — the flows API wants the Bearer
+    // token, so authenticate explicitly (a silent 401 here leaks flows).
+    const bearer = await getAuthToken(request);
+    // No `.catch()` here on purpose: deleteFlow throws on a failed deletion, and
+    // swallowing that is how a leak goes silent (the very buildup the helper was
+    // written for). A cleanup that cannot delete must fail the test.
+    for (const id of createdFlowIds.splice(0)) {
+      await deleteFlow(request, id, { headers: { Authorization: bearer } });
+    }
+  });
+
+  test(
+    "Azure AI Foundry is offered with a two-variable form and a Foundry-only deployment surface",
+    { tag: ["@stable", "@model-provider", "@settings"] },
+    async ({ page }) => {
+      await awaitBootstrapTest(page, { skipModal: true });
+
+      await test.step("the provider is searchable in Settings → Model Providers", async () => {
+        await new SettingsPage(page).navigate();
+        await page.getByTestId("sidebar-nav-Model Providers").click();
+        await expect(page.getByTestId("provider-list")).toBeVisible({ timeout: 15000 });
+
+        // Search, not scroll: the list renders a subset, and searching is how the
+        // page is used (provider-playbook step 0).
+        await page.getByTestId("provider-search-input").fill("azure");
+        const items = page.locator('[data-testid^="provider-item-"]');
+        await expect(items).toHaveCount(1, { timeout: 15000 });
+        await expect(page.getByTestId(PROVIDER_ITEM)).toBeVisible();
+
+        await page.getByTestId("provider-search-input").fill("");
+        await expect(items.first()).toBeVisible({ timeout: 15000 });
+      });
+
+      await test.step("its detail panel opens", async () => {
+        await page.getByTestId(PROVIDER_ITEM).click();
+        await expect(page.getByTestId("model-provider-selection")).toBeVisible({
+          timeout: 15000,
+        });
+        // The two-variable form itself is asserted in the next test: a CONFIGURED
+        // provider replaces the raw inputs with a masked value plus Replace, so
+        // that assert belongs behind the unconfigured-state gate — this test runs
+        // on every lane regardless of what the instance has stored.
+      });
+
+      await test.step("the panel states the deployment-name rule and offers to add one", async () => {
+        const hint = page.getByTestId("custom-deployment-hint");
+        await expect(hint).toBeVisible({ timeout: 15000 });
+        await expect(hint).toContainText("deployment names");
+        await expect(hint).toContainText("not catalog model IDs");
+        await expect(page.getByTestId("model-search-input")).toHaveAttribute(
+          "placeholder",
+          /Search or add a deployment name/,
+        );
+      });
+
+      await test.step("the seed catalog renders as suggestions", async () => {
+        const section = page.getByTestId("llm-models-section");
+        await expect(section).toBeVisible({ timeout: 15000 });
+        await expect(section).toContainText("gpt-4o");
+        const sectionText = (await section.innerText()) ?? "";
+        const present = SEED_MODELS.filter((m) => sectionText.includes(m));
+        expect(
+          present.length,
+          `seed catalog entries rendered: ${JSON.stringify(present)}`,
+        ).toBeGreaterThanOrEqual(SEED_FLOOR);
+      });
+
+      await test.step("the deployment surface is Foundry-specific, not page-wide", async () => {
+        // Differential control: OpenRouter is a plain keyed provider on the same
+        // page. Without this, a regression that showed the hint for EVERY
+        // provider would still pass the asserts above.
+        await page.getByTestId("provider-item-OpenRouter").click();
+        await expect(page.getByTestId("provider-variable-input-OPENROUTER_API_KEY")).toBeVisible({
+          timeout: 15000,
+        });
+        await expect(page.getByTestId("custom-deployment-hint")).toHaveCount(0);
+        await expect(page.getByTestId("model-search-input")).toHaveAttribute(
+          "placeholder",
+          /Search models/,
+        );
+      });
+    },
+  );
+
+  test(
+    "an unconfigured Azure AI Foundry panel is read-only: no enable toggle, no add-deployment control",
+    { tag: ["@stable", "@model-provider", "@settings"] },
+    async ({ page, request }) => {
+      const stored = await foundryVariables(request);
+      test.skip(
+        stored.length > 0,
+        `this instance already has ${PROVIDER_NAME} configured (${stored
+          .map((v) => v.name)
+          .join(", ")}) — the unconfigured-state assertions do not apply`,
+      );
+
+      await awaitBootstrapTest(page, { skipModal: true });
+      await openProviderPanel(page, PROVIDER_ITEM);
+
+      await test.step("the form requires BOTH an API key and an endpoint", async () => {
+        // Foundry is the first provider on this page needing two variables. Both
+        // raw inputs exist only while unconfigured (a configured provider shows a
+        // masked value + Replace), which is why this lives here and not in the
+        // always-on surface test.
+        await expect(page.getByTestId(KEY_INPUT)).toBeVisible({ timeout: 15000 });
+        await expect(page.getByTestId(ENDPOINT_INPUT)).toBeVisible();
+        // Save stays disabled while the required pair is empty — the two-variable
+        // contract asserted through the control the operator actually uses.
+        await expect(page.getByRole("button", { name: /^Save$/ }).first()).toBeDisabled();
+      });
+
+      await test.step("the seed models render with tags but nothing to switch", async () => {
+        await expect(page.getByTestId("llm-tag-tool-gpt-4o")).toBeVisible({ timeout: 15000 });
+        await expect(page.locator('[data-testid^="llm-toggle-"]')).toHaveCount(0);
+        await expect(page.locator('[data-testid^="embeddings-toggle-"]')).toHaveCount(0);
+      });
+
+      await test.step("typing a deployment name offers no add control while unconfigured", async () => {
+        await page.getByTestId("model-search-input").fill("e2e-unconfigured-probe");
+        // The empty state proves the search ran; the absent buttons are the
+        // contract (the control is gated on is_enabled || is_configured).
+        await expect(page.getByTestId("model-search-empty")).toBeVisible({ timeout: 15000 });
+        await expect(page.locator('[data-testid*="add-custom"]')).toHaveCount(0);
+      });
+    },
+  );
+
+  test(
+    "credentials that do not validate are rejected and nothing is persisted",
+    { tag: ["@stable", "@api", "@model-provider", "@settings"] },
+    async ({ page, request }) => {
+      const stored = await foundryVariables(request);
+      test.skip(
+        stored.length > 0,
+        `this instance already has ${PROVIDER_NAME} configured (${stored
+          .map((v) => v.name)
+          .join(", ")}) — saving bogus credentials would overwrite a real one`,
+      );
+
+      await awaitBootstrapTest(page, { skipModal: true });
+      await openProviderPanel(page, PROVIDER_ITEM);
+
+      // A Foundry-shaped host that cannot resolve: the backend takes the Foundry
+      // branch and fails at the live GET <endpoint>/models (measured ~4.7 s,
+      // NameResolutionError). Unique per run so no DNS cache can answer it.
+      const bogusEndpoint = `https://e2e-invalid-${Date.now()}.services.ai.azure.com/openai/v1`;
+
+      await test.step("save a garbage key and an unreachable endpoint", async () => {
+        await page.getByTestId(KEY_INPUT).fill("e2e-bogus-azure-foundry-key");
+        await page.getByTestId(ENDPOINT_INPUT).fill(bogusEndpoint);
+
+        const validatePromise = page.waitForResponse(
+          (r) =>
+            r.url().includes("/api/v1/models/validate-provider") &&
+            r.request().method() === "POST",
+          { timeout: 60000 },
+        );
+        await page.getByRole("button", { name: /^Save$/ }).first().click();
+        const validateResp = await validatePromise;
+
+        // HTTP 200 is NOT the verdict here — the endpoint answers 200 with
+        // valid:false for a rejected credential, so the body is the assert.
+        expect(validateResp.status()).toBe(200);
+        const body = (await validateResp.json()) as { valid?: boolean; error?: string };
+        expect(body.valid).toBe(false);
+        // The error names the provider: proof the backend ran the Foundry
+        // validation branch rather than a generic reject.
+        expect(body.error ?? "").toContain(PROVIDER_NAME);
+      });
+
+      await test.step("no credential is stored and the provider stays unconfigured", async () => {
+        expect(await foundryVariables(request)).toEqual([]);
+        await expect(page.locator('[data-testid^="llm-toggle-"]')).toHaveCount(0);
+      });
+    },
+  );
+
+  test(
+    "a portal deployment name absent from every catalog is accepted and rendered",
+    { tag: ["@stable", "@api", "@model-provider", "@settings"] },
+    async ({ page, request }) => {
+      const identity = `${PROVIDER_NAME}::llm::${E2E_DEPLOYMENT}`;
+
+      // Pre-clean: a leftover enable from an earlier run must not pre-satisfy the
+      // asserts below. Registration is causal in both directions, so the absence
+      // here is a real starting point, not an assumption.
+      await setDeploymentEnabled(request, E2E_DEPLOYMENT, false);
+      expect(await registeredFoundryDeployments(request)).not.toContain(E2E_DEPLOYMENT);
+
+      try {
+        await test.step("enabling the deployment stores it under the typed identity", async () => {
+          const { status, body } = await setDeploymentEnabled(request, E2E_DEPLOYMENT, true);
+          expect(status).toBe(200);
+          // The deployment name survives verbatim under the typed identity, with
+          // no catalog membership and no credentials configured.
+          expect(body.enabled_models).toContain(identity);
+          // …and the read side now knows the identity (see the helper's note on
+          // why this reads keys, not the enabled flag).
+          expect(await registeredFoundryDeployments(request)).toContain(E2E_DEPLOYMENT);
+        });
+
+        await test.step("the provider panel renders it alongside the seed catalog", async () => {
+          await awaitBootstrapTest(page, { skipModal: true });
+          await openProviderPanel(page, PROVIDER_ITEM);
+          const section = page.getByTestId("llm-models-section");
+          await expect(section).toBeVisible({ timeout: 15000 });
+          await expect(section).toContainText(E2E_DEPLOYMENT);
+          // Alongside, not instead of: the free-text enable is MERGED into the
+          // catalog list for this provider.
+          await expect(section).toContainText("gpt-4o");
+        });
+      } finally {
+        const { body } = await setDeploymentEnabled(request, E2E_DEPLOYMENT, false);
+        expect(body.enabled_models).not.toContain(identity);
+        expect(await registeredFoundryDeployments(request)).not.toContain(E2E_DEPLOYMENT);
+      }
+    },
+  );
+
+  test(
+    "real credentials configure the provider and enable a portal deployment through the UI",
+    { tag: ["@stable", "@model-provider", "@settings"] },
+    async ({ page, request }) => {
+      const probe = await probeFoundry(request);
+      test.skip(!probe.usable, `Azure AI Foundry not usable: ${probe.reason}`);
+      // This test CONFIGURES the provider and deletes the credential afterwards,
+      // so it must own what it deletes: on an instance where an operator already
+      // stored one, it would both race that state and destroy it. Same gate as the
+      // unconfigured-state tests, for a stronger reason.
+      const stored5 = await foundryVariables(request);
+      test.skip(
+        stored5.length > 0,
+        `this instance already has ${PROVIDER_NAME} configured (${stored5
+          .map((v) => v.name)
+          .join(", ")}) — this test would overwrite and then delete a credential it does not own`,
+      );
+
+      try {
+        await awaitBootstrapTest(page, { skipModal: true });
+        await openProviderPanel(page, PROVIDER_ITEM);
+
+        await test.step("save the endpoint and key — assert the save requests succeed", async () => {
+          await page.getByTestId(KEY_INPUT).fill(FOUNDRY_KEY);
+          await page.getByTestId(ENDPOINT_INPUT).fill(FOUNDRY_ENDPOINT);
+
+          // Armed BEFORE the click so the pass is caused by THIS save, never by a
+          // pre-existing configured state.
+          const validatePromise = page.waitForResponse(
+            (r) =>
+              r.url().includes("/api/v1/models/validate-provider") &&
+              r.request().method() === "POST",
+            { timeout: 60000 },
+          );
+          // Create (POST /variables/) on a fresh instance, update (PATCH
+          // /variables/{id}) when a value already exists — the frontend branches
+          // on existence (#636), so match both.
+          const persistPromise = page.waitForResponse(
+            (r) =>
+              r.url().includes("/api/v1/variables/") &&
+              (r.request().method() === "POST" || r.request().method() === "PATCH"),
+            { timeout: 60000 },
+          );
+
+          await page.getByRole("button", { name: /^Save$|^Replace$/ }).first().click();
+
+          const [validateResp, persistResp] = await Promise.all([
+            validatePromise,
+            persistPromise,
+          ]);
+          expect(validateResp.status()).toBe(200);
+          const validateBody = (await validateResp.json()) as { valid?: boolean; error?: string };
+          expect(
+            validateBody.valid,
+            `validate-provider rejected the credentials: ${validateBody.error ?? "(no error)"}`,
+          ).toBe(true);
+          expect(persistResp.ok()).toBe(true);
+        });
+
+        await test.step("the provider is now configured: both variables stored, toggles render", async () => {
+          // A two-variable provider means Save issues TWO separate variables
+          // writes, and the waiter above resolves on the FIRST one. Asserting the
+          // stored state right after it is a race the test loses ~1 run in 3
+          // (measured while authoring: only AZURE_AI_FOUNDRY_ENDPOINT present, and
+          // in an earlier run no toggle rendered within 30 s — same cause, the
+          // provider was still half-configured). So poll for the PAIR: that is the
+          // backend fact "this provider is configured", independent of how many
+          // requests the frontend chose to make.
+          await expect
+            .poll(async () => (await foundryVariables(request)).map((v) => v.name).sort(), {
+              timeout: 30000,
+            })
+            .toEqual([KEY_VAR, ENDPOINT_VAR].sort());
+
+          // Only then is the panel expected to reflect `is_configured` — the enable
+          // toggles the unconfigured panel (test 2) does not render at all.
+          await expect(page.locator('[data-testid^="llm-toggle-"]').first()).toBeVisible({
+            timeout: 30000,
+          });
+        });
+
+        await test.step("the add-deployment control appears and enables the portal deployment", async () => {
+          await page.getByTestId("model-search-input").fill(FOUNDRY_DEPLOYMENT);
+          // The exact control test 2 proved absent while unconfigured. Both
+          // testids exist upstream: the all-types panel renders
+          // `add-custom-llm-deployment-button`, a type-filtered one
+          // `add-custom-deployment-button`.
+          const addButton = page.locator(
+            '[data-testid="add-custom-llm-deployment-button"], [data-testid="add-custom-deployment-button"]',
+          );
+          await expect(addButton.first()).toBeVisible({ timeout: 15000 });
+
+          // Armed BEFORE the click, and asserted on the BODY: the row and its
+          // toggle render optimistically, so the UI alone cannot tell an accepted
+          // deployment from a write that never landed. Measured while authoring:
+          // reloading right after the click cancelled the in-flight POST and the
+          // deployment was absent afterwards, with the panel still showing it.
+          const enablePromise = page.waitForResponse(
+            (r) =>
+              r.url().includes("/api/v1/models/enabled_models") &&
+              r.request().method() === "POST",
+            { timeout: 30000 },
+          );
+          await addButton.first().click();
+          const enableResp = await enablePromise;
+          expect(enableResp.ok()).toBe(true);
+          const enableBody = (await enableResp.json()) as EnabledModelsWrite;
+          expect(enableBody.enabled_models).toContain(
+            `${PROVIDER_NAME}::llm::${FOUNDRY_DEPLOYMENT}`,
+          );
+
+          await expect(page.getByTestId("llm-models-section")).toContainText(
+            FOUNDRY_DEPLOYMENT,
+            { timeout: 15000 },
+          );
+          // With the provider configured, the row carries a real toggle and the
+          // add put it in the ON state — the half test 4 cannot reach, since an
+          // unconfigured provider renders no toggle at all.
+          await expect(page.getByTestId(`llm-toggle-${FOUNDRY_DEPLOYMENT}`)).toHaveAttribute(
+            "data-state",
+            "checked",
+            { timeout: 15000 },
+          );
+        });
+
+        await test.step("the enabled deployment persists across a reload", async () => {
+          await page.reload();
+          await expect(page.getByTestId("provider-list")).toBeVisible({ timeout: 30000 });
+          expect(await registeredFoundryDeployments(request)).toContain(FOUNDRY_DEPLOYMENT);
+        });
+      } finally {
+        // Restore the pre-test account state: deployment disabled, credentials
+        // removed by id (these two ARE listed by GET /api/v1/variables/).
+        await setDeploymentEnabled(request, FOUNDRY_DEPLOYMENT, false);
+        await purgeFoundryCredentials(request);
+        expect(await foundryVariables(request)).toEqual([]);
+      }
+    },
+  );
+
+  test(
+    "the configured deployment answers a real inference through the Language Model component",
+    { tag: ["@stable", "@model-provider", "@components", "@playground"] },
+    async ({ page, request }) => {
+      const probe = await probeFoundry(request);
+      test.skip(!probe.usable, `Azure AI Foundry not usable: ${probe.reason}`);
+
+      // Same ownership gate as test 5: this test stores the credential pair and
+      // deletes it in its own teardown.
+      const stored6 = await foundryVariables(request);
+      test.skip(
+        stored6.length > 0,
+        `this instance already has ${PROVIDER_NAME} configured (${stored6
+          .map((v) => v.name)
+          .join(", ")}) — this test would overwrite and then delete a credential it does not own`,
+      );
+
+      // Per-run sentinel: a match proves THIS execution produced the output.
+      const token = `AZFOUNDRY-${Date.now()}`;
+
+      try {
+        await test.step("configure the provider and enable the deployment (setup, via API)", async () => {
+          const bearer = await getAuthToken(request);
+          // Idempotent: a variable left behind by an interrupted run would make
+          // the create below a 4xx, so clear the pair first.
+          await purgeFoundryCredentials(request);
+          // Order matters: the backend validates on write and returns early while
+          // only one of the two variables exists, so the endpoint (written last)
+          // is the write that gets validated against the live resource.
+          for (const [name, value] of [
+            [KEY_VAR, FOUNDRY_KEY],
+            [ENDPOINT_VAR, FOUNDRY_ENDPOINT],
+          ] as const) {
+            const res = await request.post("/api/v1/variables/", {
+              headers: { Authorization: bearer, "Content-Type": "application/json" },
+              data: { name, value, type: "Credential", default_fields: [] },
+            });
+            expect(res.ok(), `storing ${name} answered ${res.status()}`).toBe(true);
+          }
+          const { status } = await setDeploymentEnabled(request, FOUNDRY_DEPLOYMENT, true);
+          expect(status).toBe(200);
+        });
+
+        await awaitBootstrapTest(page, { skipModal: true });
+
+        await test.step("open Basic Prompting and point its Language Model at the deployment", async () => {
+          // Basic Prompting ships Chat Input → Language Model → Chat Output
+          // WIRED. Adding the three components to a blank canvas instead leaves
+          // them unconnected, and the run then persists the user turn with NO
+          // reply — measured while authoring, and indistinguishable from a
+          // provider failure.
+          //
+          // Copied over the API rather than clicked in the templates modal: that
+          // path creates a blank `New Flow` placeholder first (#1005) whose id the
+          // helper can only clean when it manages to read the discarded response
+          // body — a leak observed here as a stray `New Flow` + `Basic Prompting`
+          // surviving one run in two. An id-addressed copy leaks nothing and is
+          // isolated per worker (#684).
+          const flowId = await createFlowFromStarter(
+            page.request,
+            "Basic Prompting",
+            `azure-ai-foundry ${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+          );
+          createdFlowIds.push(flowId);
+          await openFlowById(page, flowId);
+
+          await expect(page.getByTestId("title-Language Model")).toBeVisible({ timeout: 30000 });
+          await page.getByTestId("model_model").first().click();
+          // Options are keyed `<provider>-<model>-option` (scouted live on
+          // 1.12.0.dev15) — the provider prefix matters here: a Foundry
+          // deployment can share its name with an OpenAI catalog id.
+          await page
+            .getByTestId(`${PROVIDER_NAME}-${FOUNDRY_DEPLOYMENT}-option`)
+            .first()
+            .click();
+          // The selection autosaves with a debounce; the Playground builds the
+          // PERSISTED flow.
+          await waitForFlowSaveSettled(page);
+        });
+
+        await test.step("the node shows the DEPLOYMENT name, not a catalog id", async () => {
+          await expect(page.getByTestId("value-dropdown-model_model")).toContainText(
+            FOUNDRY_DEPLOYMENT,
+            { timeout: 15000 },
+          );
+        });
+
+        await test.step("the playground gets a real answer from the deployment", async () => {
+          await page.getByTestId("playground-btn-flow-io").click();
+          await expect(page.getByTestId("input-chat-playground").last()).toBeVisible({
+            timeout: 30000,
+          });
+          await page
+            .getByTestId("input-chat-playground")
+            .last()
+            .fill(`Repeat this token exactly and nothing else: ${token}`);
+          await page.getByTestId("button-send").last().click();
+
+          // Deterministic completion signal (never a "did Stop appear?" probe).
+          await expect(page.getByTestId("button-stop")).toBeHidden({ timeout: 180000 });
+          await expect(page.getByTestId("button-send").last()).toBeVisible({ timeout: 30000 });
+
+          // Assert on the PERSISTED reply: the live bubble renders the empty
+          // placeholder mid-stream (#634 race).
+          const bearer = await getAuthToken(request);
+          await expect
+            .poll(
+              async () => {
+                const res = await request.get("/api/v1/monitor/messages", {
+                  headers: { Authorization: bearer },
+                });
+                if (res.status() !== 200) return `GET monitor -> ${res.status()}`;
+                const messages = (await res.json()) as Array<{
+                  sender?: string;
+                  session_id?: string;
+                  text?: string;
+                }>;
+                if (!Array.isArray(messages)) return "monitor payload not a list";
+                const userMsg = messages.find(
+                  (m) => m.sender !== "Machine" && (m.text ?? "").includes(token),
+                );
+                if (!userMsg) return "user message with token not persisted yet";
+                const replies = messages
+                  .filter((m) => m.sender === "Machine" && m.session_id === userMsg.session_id)
+                  .map((m) => (m.text ?? "").trim());
+                if (replies.length === 0) return "AI reply for the session not persisted yet";
+                if (replies.every((t) => t === "")) return "AI reply persisted but still empty";
+                return replies.some((t) => t.includes(token))
+                  ? "reply-contains-token"
+                  : `reply did not echo the token: ${JSON.stringify(
+                      replies.map((t) => t.slice(0, 80)),
+                    )}`;
+              },
+              { timeout: 90000 },
+            )
+            .toBe("reply-contains-token");
+        });
+      } finally {
+        await setDeploymentEnabled(request, FOUNDRY_DEPLOYMENT, false);
+        await purgeFoundryCredentials(request);
+      }
+    },
+  );
+});


### PR DESCRIPTION
Closes the `[ ] Azure AI Foundry in the unified provider setup` gap in `QA-CHECKLIST.md` § 7.8 — the 1.11.0 addition to Settings → Model Providers (upstream langflow-ai/langflow#13912, #14023).

Distinct from every sibling provider spec because Foundry is the first provider on that page whose **model identities are operator-defined**: the seed catalog (`gpt-4o`, `gpt-4o-mini`, `gpt-4.1`, `o3-mini`, `Mistral-Large-3`) is a suggestion list, and inference addresses the **portal deployment name** the operator typed. It is also the first configured by **two** variables (`AZURE_AI_FOUNDRY_API_KEY` + `AZURE_AI_FOUNDRY_ENDPOINT`). `provider-management.md` only ever counted it as a catalog entry; nothing exercised the deployment-name path.

Closes #1194

## 1. Covered tests

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `Azure AI Foundry is offered with a Foundry-only deployment surface` | Searching `azure` filters the list to **exactly** `provider-item-Azure AI Foundry`; the panel shows `custom-deployment-hint` containing "deployment names" + "not catalog model IDs", the search placeholder is `Search or add a deployment name…`, and `llm-models-section` renders the seed catalog (`gpt-4o` + ≥3 of 5, a floor per #993). **Differential:** the same assertions are inverted on OpenRouter (hint absent, placeholder `Search models…`), so a regression that showed the deployment surface for every provider fails here |
| 2 | `an unconfigured Azure AI Foundry panel asks for two variables and stays read-only` | Both `provider-variable-input-AZURE_AI_FOUNDRY_{API_KEY,ENDPOINT}` render and **Save is disabled** while the required pair is empty (the two-variable contract); **zero** `llm-toggle-*` / `embeddings-toggle-*`; typing a name yields `model-search-empty` and **no** `add-custom-*-deployment-button` — the control is gated on `is_enabled \|\| is_configured` |
| 3 | `credentials that do not validate are rejected and nothing is persisted` | `POST /api/v1/models/validate-provider` answers **HTTP 200** with `valid: false` and an `error` naming `Azure AI Foundry` (proof the backend took the Foundry branch, not a generic reject); afterwards `GET /api/v1/variables/` still holds no `AZURE_AI_FOUNDRY_*` and the panel still renders no toggle — a rejected credential leaves no state |
| 4 | `a portal deployment name absent from every catalog is accepted and rendered` | Enabling a name present in **no** catalog returns 200 with `Azure AI Foundry::llm::e2e-azure-foundry-deployment`; the read side gains it as a key in `enabled_models` and `enabled_models_by_type[…].llm` and loses it on disable; the provider panel renders it **alongside** the seed catalog. Runs with **no credentials at all** |
| 5 | `real credentials configure the provider and enable a portal deployment through the UI` | Save fires `validate-provider` with `valid: true` and a 2xx variables write (both waiters armed **before** the click); the **pair** of variables is polled until stored; `llm-toggle-*` then renders; `add-custom-llm-deployment-button` — absent in test 2 — appears; its click's `POST /api/v1/models/enabled_models` is 2xx **with the identity in the body**; the row's toggle reads `data-state="checked"`; the enablement survives a reload |
| 6 | `the configured deployment answers a real inference through the Language Model component` | The dropdown offers `Azure AI Foundry-<deployment>-option`, `value-dropdown-model_model` shows the **deployment name** (a substituted catalog id fails), and the persisted reply for the session echoes a per-run sentinel — only a real Foundry inference addressed by deployment name produces that |

## 2. How the test was built

**Surface triage first** (`provider-playbook.md` step 0), on the running nightly — every decision below came from a measurement, not an assumption:

- **`validate-provider` answers HTTP 200 with `{"valid": false, "error": …}`** for a credential it rejected (4.7 s, `NameResolutionError` on an unresolvable Foundry-shaped host). Every validation assert therefore reads the **body**; a status-only check would pass on rejection — the same trap `ollama-provider.spec.ts` corrected in its M1 mutation.
- **Enablement is credential-independent by design.** `api/v1/models.py::update_enabled_models` → `validate_model_provider_key` returns early while the provider's variables are absent, so a non-catalog deployment name can be accepted with no Azure account. That is what lets tests 1–4 hold §7.8 on every lane, and it is read from the source, not inferred.
- **`enabled_models` is read by KEY, not by its boolean.** The value means *enabled AND usable*, so it reads `false` on an unconfigured provider — the whole seed catalog included. The first version of test 4 asserted the boolean and failed for exactly this reason. Key presence is what registration writes and erases (added on enable to both maps, removed on disable), so it is causal in both directions; the `true` state belongs to the configured path and test 5 reads the row's own toggle instead.
- **A two-variable Save issues TWO writes.** The waiter resolves on the first, so reading the stored state right after it lost the race ~1 run in 3 (once with only `AZURE_AI_FOUNDRY_ENDPOINT` present; once as "no `llm-toggle-*` within 30 s" — the same cause wearing a different symptom, since a half-configured provider legitimately renders no toggle). The configured state is now a **poll for the pair**. For the same reason the credential purge runs in up to 3 bounded passes: a single pass that ran between the two writes left one behind, and that leftover made the next run's unconfigured-state tests **skip** instead of run — the worse half of the failure, because a skip reads as "fine".
- **Ownership gate on the two credential tests.** They store the pair and delete it in teardown, so on an instance where an operator already configured Foundry they would race that state *and destroy a credential they do not own*. Both now skip with that reason (verified: with a credential planted by hand the run becomes `2 passed, 4 skipped` and the planted credential survives).
- **Live-confirmed selectors** (scouted with `playwright-cli`, none invented): `provider-search-input`, `provider-item-Azure AI Foundry`, `provider-variable-input-AZURE_AI_FOUNDRY_{API_KEY,ENDPOINT}`, `model-provider-selection`, `custom-deployment-hint`, `model-search-input`, `model-search-empty`, `llm-models-section`, `llm-tag-tool-<model>`, `llm-toggle-<model>`, `add-custom-llm-deployment-button` / `add-custom-deployment-button`, and the model option `Azure AI Foundry-<deployment>-option` (the **provider prefix matters** — a deployment can share a name with an OpenAI catalog id).
- **Test 6's flow is an API copy of the Basic Prompting starter** (`createFlowFromStarter` + `openFlowById`, #684). Two alternatives were rejected on measurement: adding Chat Input / Language Model / Chat Output to a blank canvas leaves them **unconnected**, and the run then persists the user turn with *no reply at all* — indistinguishable from a provider failure; and the templates-modal path (`loadTemplateByName`) creates a blank `New Flow` placeholder (#1005) whose id it can only clean when it manages to read a body the SPA discards — here a stray `New Flow` **plus** `Basic Prompting` survived one run in two.
- **No unattributed 400:** every non-200 from `POST /api/v1/models/enabled_models` is logged with the backend's own `detail`. "expected 200, received 400" cannot be triaged.

**Azure is deliberately NOT added to `providerConfigMap`** (`tests/helpers/provider-setup/provider-config.ts`): that map feeds the `collect-models` sweep on every lane and its `api-key | base-url` union has no room for a two-variable provider — adding it would couple unrelated PRs to an Azure resource's health. Env gating stays spec-local, exactly as `groq-provider.spec.ts` / `mistral-provider.spec.ts` do.

**Cleanup.** Tests 1–5 create no flows; test 6 deletes its flow id-scoped in `afterEach` with **no `.catch()`** (`deleteFlow` throws on a failed deletion, and swallowing it is how a leak goes silent). Verified by diffing the instance's flow-id set around three consecutive runs: **zero new ids**, no `AZURE_*` variable, no deployment residue. One documented residue remains: disabling a model moves its identity into the internal `__disabled_models__` variable, which `GET /api/v1/variables/` filters out (names wrapped in `__`), leaving no id to DELETE — so the synthetic deployment name is **fixed**, bounding that to one inert entry instead of one per run.

## 3. Dependencies

- **Tests 1–4: none** — no credentials, no external network. These are the lane-independent coverage of §7.8.
- **Tests 5–6: a live Azure AI Foundry resource** — `AZURE_AI_FOUNDRY_API_KEY`, `AZURE_AI_FOUNDRY_ENDPOINT` (the portal's OpenAI-compatible endpoint) and `AZURE_AI_FOUNDRY_TEST_DEPLOYMENT` (a **deployment name**, not a catalog id). A probe hits `GET <endpoint>/models` from the test host and skips with the concrete reason otherwise. The probe cannot pre-verify the deployment — `/models` is the resource catalog, not its deployment list (`model_utils.py`) — so the inference in test 6 is what proves it. `.env.example` carries the block.
- **⚠️ Maintainer action:** those three are **not** CI secrets yet, so tests 5–6 **skip with an explicit reason** in the daily until they land — the same missing-dependency contract `google-provider.spec.ts` carries for `GOOGLE_API_KEY`. Until then the daily's real §7.8 coverage is tests 1–4. `@stable` is on all six deliberately: `nightly.yml` is dormant and `daily-stable.yml` runs `--grep @stable`, so an untagged spec would run in **no** recurring workflow at all (#945/#940's invisible-red pattern).
- Execution mode: `--workers=1`, `test.describe.configure({ mode: "serial" })` — every test drives account-wide Settings state.

## Validation (nightly 1.12.0.dev15, `--retries=0 --workers=1`)

- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors; 4 `no-skipped-test` warnings, the probe-gated skips, same as the provider siblings)
- **3 consecutive clean runs from a clean instance**: `expected=6 unexpected=0 flaky=0 skipped=0` (33.3 s / 36.2 s / 38.0 s), all six executing against the live Azure resource
- **force-fail on every test** (each red, then reverted — `grep -c FF-MUTATION` = 0):
  - T1 — assert the Foundry hint on the **OpenRouter** panel ⇒ red
  - T2 — assert an `add-custom` control **is** rendered while unconfigured ⇒ red
  - T3 — assert `valid: true` for the unresolvable endpoint ⇒ red
  - T4 — read back a **different** deployment name than the one enabled ⇒ red
  - T5 — garbage key with the real endpoint ⇒ `valid: false` ⇒ red
  - T6 — expect a seed catalog id (`gpt-4o`) instead of the deployment name ⇒ red
  - (T5/T6 were re-verified by hand after two later fixes, so the evidence matches the shipped code)
- Zero `🚨 Backend Error` in the clean runs
- QA-CHECKLIST guards ✅ (`check:checklist-coverage` + generated-block guard); only the manual §7.8 bullet was edited

🤖 Generated with [Claude Code](https://claude.com/claude-code)
