### PR TITLE
ci(secrets): pass the AZURE_AI_FOUNDRY_* trio to the daily and manual lanes (#1270)

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -598,6 +598,21 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          # Azure AI Foundry (§7.8, #1194 → #1270). Three variables because it is
+          # the first provider on the Model Providers page configured by a PAIR
+          # (key + the portal's OpenAI-compatible endpoint), plus the DEPLOYMENT
+          # NAME its inference is addressed by — a portal name, not a catalog id,
+          # which is the whole point of that coverage.
+          #
+          # Read ONLY here, never by the `Collect models` step above: Azure is
+          # deliberately absent from `providerConfigMap` (a two-variable provider
+          # does not fit its `api-key | base-url` union — see
+          # tests/helpers/provider-setup/provider-config.ts), so the sweep neither
+          # imports nor validates these. Absent, the spec's own probe skips its two
+          # credential tests with the concrete reason; the other four run regardless.
+          AZURE_AI_FOUNDRY_API_KEY: ${{ secrets.AZURE_AI_FOUNDRY_API_KEY }}
+          AZURE_AI_FOUNDRY_ENDPOINT: ${{ secrets.AZURE_AI_FOUNDRY_ENDPOINT }}
+          AZURE_AI_FOUNDRY_TEST_DEPLOYMENT: ${{ secrets.AZURE_AI_FOUNDRY_TEST_DEPLOYMENT }}
           # Turns the cleanup sidecar on: with TOKENS_ATTRIB unset the helper makes
           # no request and writes no file, which is every LOCAL run and nothing
           # else. NOT "the PR lane" — pr-validation.yml:711 sets it too, on purpose,

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -218,6 +218,24 @@ jobs:
       ANY_COMPLETION_PROVIDER: >-
         ${{ github.event.inputs.any_completion_provider == 'ollama' && 'ollama' || '' }}
       PLAYWRIGHT_RETRIES: ${{ github.event.inputs.retries }}
+      # Azure AI Foundry (§7.8, #1194 → #1270). At JOB level for the reason spelled
+      # out above the OLLAMA_* block: `.github/actions/run-e2e` declares per-step
+      # `env`, which ADDS to the job environment rather than replacing it, so the
+      # shared action needs no new inputs and no other lane moves.
+      #
+      # This lane is where a dispatch can PROVE the wiring: with the three secrets
+      # present the spec's two credential tests execute; without them they skip
+      # naming which variable is missing, and a wrong value skips naming the
+      # resource's answer instead — the probe distinguishes the two.
+      #
+      # Scoped to the Docker job on purpose. The external-URL job below runs no
+      # `collect-models` because writing our provider credentials as global
+      # variables into an instance we do not own is not ours to do (#1055), and
+      # these two tests STORE the credential pair in the target Langflow — the same
+      # rule, so it is not wired there.
+      AZURE_AI_FOUNDRY_API_KEY: ${{ secrets.AZURE_AI_FOUNDRY_API_KEY }}
+      AZURE_AI_FOUNDRY_ENDPOINT: ${{ secrets.AZURE_AI_FOUNDRY_ENDPOINT }}
+      AZURE_AI_FOUNDRY_TEST_DEPLOYMENT: ${{ secrets.AZURE_AI_FOUNDRY_TEST_DEPLOYMENT }}
       # The token sidecar's bounds, at JOB level because TWO steps read them: the
       # poller below and the test step of the `run-e2e` composite, where the attribution sidecar runs inside
       # `deleteFlow`'s teardown hook. They used to live in the poller step's own


### PR DESCRIPTION
**Closes #1270.** Follow-up of #1194 / PR #1269.

## Problem

The three `AZURE_AI_FOUNDRY_*` repository secrets exist (added 2026-08-04), but **no workflow handed them to the Playwright process** — so §7.8's two credential-dependent tests skipped in every lane while the coverage read as configured:

```
Azure AI Foundry not usable: not set in the environment: AZURE_AI_FOUNDRY_API_KEY, AZURE_AI_FOUNDRY_ENDPOINT, AZURE_AI_FOUNDRY_TEST_DEPLOYMENT
```

Confirmed on PR #1269's own E2E lane: `4 passed, 2 skipped`. A secret nobody reads buys nothing.

## Fix

| Lane | Where | Why there |
|---|---|---|
| `daily-stable.yml` | the shard's `Run @stable tests` step `env:`, beside the five provider keys already present | that is the step that runs Playwright; verified by parsing the YAML and checking which step carries the vars, not by eyeballing line numbers |
| `manual.yml` | **job level** on `e2e-docker` | `.github/actions/run-e2e` declares per-step `env` that **ADDS** to the job environment rather than replacing it — the same path the three `OLLAMA_*` vars already take, so the shared action gains no inputs and no other lane's behaviour moves |

Three variables, not one, because Foundry is the first provider on that page configured by a **pair** (key + the portal's OpenAI-compatible endpoint) plus the **deployment name** its inference is addressed by — a portal name, not a catalog id, which is what §7.8 exists to cover.

## Scope note — what was deliberately NOT wired

- **`Collect models` (both lanes).** Azure is intentionally absent from `providerConfigMap`: a two-variable provider does not fit its `api-key | base-url` union (`tests/helpers/provider-setup/provider-config.ts`), so the sweep neither imports nor validates these. Adding them there would be noise that implies a validation which does not happen.
- **`pr-validation.yml`.** Wiring it would make an unrelated PR's lane spend a real Azure inference and couple it to that account's health — the coupling #1216 exists to prevent. A PR that touches this spec is covered by a `manual.yml` dispatch.
- **`manual.yml`'s external-URL job.** It runs no `collect-models` because writing our provider credentials as global variables into an instance we do not own is not ours to do (#1055) — and these two tests **store** the credential pair in the target Langflow. Same rule, so it stays unwired; the comment in the YAML says so at the point where someone would otherwise "fix" the asymmetry.

Nothing else changes: no test file, no shared action, no other lane. `+33` lines, all `env:` entries and the comments explaining the placement.

## Validation

- `npm run typecheck` ✅ · `npm run test:scripts` ✅ (**588 pass / 0 fail** — includes the structural guards over these two workflows)
- Both workflows **parse** (`yaml.safe_load`) and the vars were verified **semantically**, not by line number:
  - `daily-stable` → they sit on the step whose `run` is `npx playwright test --grep "@stable" …`
  - `manual` → `e2e-docker` carries all three at job level; **`e2e-url` carries none**, as intended
- **Workflow YAML cannot be proven locally** — stated plainly per the infra rule. The real proof is a `manual.yml` dispatch on this branch, where the two tests must **execute** instead of skipping. That dispatch also validates the secret **values**: the spec's probe distinguishes "not set in the environment" from a non-200 answer from the resource, so a wrong endpoint or key names itself in the skip reason rather than reading as absent.

```bash
gh workflow run manual.yml --repo oriontech-me/langflow-e2e \
  --ref ci/issue-1270-azure-foundry-secrets \
  -f langflow_target=latest -f langflow_image=nightly \
  -f test_grep="Azure AI Foundry"
```

Expected: `6 passed` (against 1.12.0.dev15 locally the same six run in ~35 s). Anything skipping still means the wiring did not reach the process — and the reason line says which half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
