### PR TITLE
docs(regressions): record LE-2123 — Global Variables RBAC gate regression caught by the quarantined specs (#1235)

### DIFF
--- a/REGRESSIONS.md
+++ b/REGRESSIONS.md
@@ -36,17 +36,18 @@ issue that carries the evidence. Both shapes are allowed; what is not allowed is
 a reference that does not resolve.
 
 <!-- REGRESSIONS:START -->
-**Regressions caught:** 7 — **Open:** 4 · **Fixed:** 3
+**Regressions caught:** 8 — **Open:** 5 · **Fixed:** 3
 
-**By severity:** High 2 · Medium 5 · Low 0
+**By severity:** High 2 · Medium 6 · Low 0
 
-**By area:** model-provider 2 · api 1 · auth 1 · core-components 1 · flows 1 · mcp 1
+**By area:** model-provider 2 · api 1 · auth 1 · core-components 1 · flows 1 · mcp 1 · ui-ux 1
 <!-- REGRESSIONS:END -->
 
 ## Ledger
 
 | Found | Area / Test | Regression | Severity | Detected by | Upstream | Status | Fixed in | Report |
 |-------|-------------|------------|----------|-------------|----------|--------|----------|--------|
+| 2026-08-04 | ui-ux · global-variable-edit.spec.ts | Global Variables grid silently drops row interactions while the RBAC permission query (`POST /api/v1/authz/me/permissions`) is loading — a row click never opens the Update Variable modal and checkbox ticking selects nothing, so the delete button stays disabled, with no spinner or feedback of any kind. Normally a 1–2 s window, but one transient network/5xx failure on the first call holds the gate through the query wrapper's 5× exponential-backoff retry ladder: ~31 s of dropped input, measured to the decimal (retries at 0.8/1.8/3.8/7.8/15.8/31.8 s under an injected 503). Introduced by the release-1.12 RBAC gate (langflow#14215, `2e677bf843`); also hits `remove-provider-api-key.spec.ts:17` — one mechanism, two affordances, one ledger row | Medium | daily 07-27 + 08-03 · #1231 → #1235 | [LE-2123](https://datastax.jira.com/browse/LE-2123) | Open | — | docs/upstream-bugs/UPSTREAM-BUG-global-variables-permission-gate-dead-window.md |
 | 2026-07-28 | core-components · nested-grouping-regression.spec.ts | Grouping two connected non-IO components raises a false `Error while updating the Component` notification although the grouping fully succeeds — the `PATCH /api/v1/flows/{id}` that persists the grouped shape returns `200`, the console logs no error and no request fails, yet the message persists in the Notifications panel until dismissed by hand. Deterministic; reproduced independently in a manual browser session | Medium | #942 spec validation | [LE-2045](https://datastax.jira.com/browse/LE-2045) | Open | — | docs/upstream-bugs/UPSTREAM-BUG-group-cosmetic-error-toast.md |
 | 2026-07-27 | api · api-folders-crud.spec.ts | `DELETE /api/v1/projects/{id}` answers `500` (`sqlite3.OperationalError: database is locked`) instead of `204` while any other write is in flight, and the project survives. Not new — stable 1.10.3 emits the same instant `500` — but 1.12 raises the rate ~7× (6 % → 44 % at 2 concurrent clients, A/B/A/B) and flips the mode: 1.10.3 blocks and mostly honours the contract, 1.12 gives up in 0.03 s. Sibling write endpoints (`POST /projects`, `POST /flows`, `DELETE /flows`) survive the identical contention | Medium | daily 07-22 + 07-27 · #962 → #965 | [LE-2020](https://datastax.jira.com/browse/LE-2020) | Open | — | docs/upstream-bugs/UPSTREAM-BUG-project-delete-500-under-contention.md |
 | 2026-07-27 | flows · run-flow.spec.ts | "New Flow" click is silently dropped when the flows list has not painted its cards yet — no navigation, no modal, no console error, and the button then stops being actionable until a reload. Introduced in 1.10.1 by langflow#12575; 1.10.0 opened the templates modal and created nothing | Medium | daily 07-27 · #962 → #966 | [LE-2019](https://datastax.jira.com/browse/LE-2019) | Open | — | docs/upstream-bugs/UPSTREAM-BUG-new-flow-dead-click.md |

--- a/docs/upstream-bugs/UPSTREAM-BUG-global-variables-permission-gate-dead-window.md
+++ b/docs/upstream-bugs/UPSTREAM-BUG-global-variables-permission-gate-dead-window.md
@@ -1,0 +1,75 @@
+# UPSTREAM BUG — Global Variables grid silently drops interactions while the RBAC permission query loads (dead window up to ~31 s)
+
+- **Upstream ticket:** [LE-2123](https://datastax.jira.com/browse/LE-2123)
+- **Introduced by:** [langflow#14215](https://github.com/langflow-ai/langflow/pull/14215) — "Complete release 1.12 RBAC authorization foundations", commit `2e677bf843` (2026-07-22, on `release-1.12.0`; **not** on langflow `main`)
+- **Detected by:** daily-stable 2026-07-27 (`30261409427`) and 2026-08-03 (`30809091241`) → triage #1231 → issue #1235
+- **Affected specs:** `ui-ux/global-variable-edit.spec.ts:76`, `core-functionality/llm-agents/remove-provider-api-key.spec.ts:17` (both quarantined by PR #1236)
+- **Validated on:** Langflow 1.12.0 (nightly Docker image), 2026-08-04
+
+## Behaviour
+
+`GlobalVariablesPage` is wrapped in a `PermissionsProvider` that resolves per-variable
+grants via `POST /api/v1/authz/me/permissions`. Every row interaction goes through
+`canMutateVariable()` (`GlobalVariablesPage/variableAccess.ts`), which returns `false`
+while that query is `isLoading`:
+
+- a row click calls `onRowClicked`, which returns early — the click is **silently
+  dropped**, the Update Variable modal never opens;
+- `isRowSelectable` is `false`, so ticking the row checkbox selects nothing and the
+  header `delete-row-button` never enables.
+
+There is no UI affordance during the window — no spinner, no disabled styling, no
+console output. The grid looks interactive and discards input.
+
+The window is normally the request's natural latency (~1–2 s). But the shared query
+wrapper (`request-processor.ts`) retries a failed request 5× with exponential backoff
+(`min(1000·2^n, 30000)`), so one network error or 5xx on the *first* call holds
+`isLoading` — and the dead window — for 1+2+4+8+16 ≈ **31 s**. After the ladder
+exhausts, `canMutateVariable` fails open for the user's own variables, which is why
+everything works ~32 s in. 4xx does not retry (`isClientError` aborts the ladder).
+
+## Why it surfaced as a recurrent flake, not a hard failure
+
+Both specs interact with the grid a few seconds after navigation. On a healthy backend
+the gate is already open by then — most dailies pass. On a day the first permissions
+call hits a transient failure (busy shard under collect-models load qualifies), the
+window (~31 s) outlasts both specs' waits (10 s for the modal, 20 s for the click
+retry loop), producing exactly the two recorded signatures:
+
+- `expect(getByRole('heading', { name: 'Update Variable' })).toBeVisible()` fails —
+  the click was dropped;
+- `locator.click: Timeout 20000ms exceeded … element is not enabled` on
+  `delete-row-button` — nothing ever got selected.
+
+One mechanism, two affordances. Same-run shard split (1 and 4) is consistent: the
+shared dimension is the surface, not the container.
+
+## Evidence
+
+1. **Deterministic repro (503 injection).** Intercepting
+   `POST /api/v1/authz/me/permissions` and answering 503 produced retry attempts at
+   `0.8 / 1.8 / 3.8 / 7.8 / 15.8 / 31.8 s` after page load — the backoff math to the
+   decimal. During the whole window the row checkbox would not select and
+   `delete-row-button` stayed `disabled`; after 31.8 s the grid behaved normally.
+2. **A single transient failure suffices.** Failing only the first call (the retry
+   succeeded at 2.3 s), a row click at 3.4 s was still swallowed; the modal opened
+   only on the next attempt at 5.3 s.
+3. **Gate isolation.** Inside the dead window a real DOM click does nothing, while
+   invoking the page's own `onRowClicked` handler — read fresh from the live React
+   tree, with the row's real `data` — opens the modal immediately. AG Grid fires
+   `rowClicked` with correct data (verified via `api.addEventListener`), React commits
+   normally elsewhere on the page (the "Add New" modal opens instantly), and the
+   permissions endpoint answers 200 in ~1.1 s with full `read/write/delete` grants
+   when not interfered with. The drop happens inside the handler's permission check
+   and nowhere else.
+4. **Version scoping.** langflow `main` does not carry the gate (the
+   `PermissionsProvider` wrap of this page exists only on `release-1.12.0`); the
+   behaviour is absent on builds without #14215.
+
+## Re-validation note (for lifting the #1235 quarantine)
+
+The only deterministic client-side observable that the gate is open is the row
+becoming selectable (AG Grid `node.selectable` / a non-disabled
+`.ag-checkbox-input`). The row-click path exposes no observable of its own but reads
+the same context, so checkbox-enabled works as a readiness proxy for both specs if
+they are hardened rather than only re-enabled.


### PR DESCRIPTION
## What this PR adds

Records in `REGRESSIONS.md` the Langflow regression the two quarantined Global Variables specs caught, now that the investigation of #1235 confirmed a `langflow-regression` verdict and the upstream ticket is filed:

- **Ledger row** — [LE-2123](https://datastax.jira.com/browse/LE-2123), area `ui-ux · global-variable-edit.spec.ts`, severity Medium, status Open (also hits `remove-provider-api-key.spec.ts:17`; one mechanism, two affordances, one row per ticket).
- **Evidence doc** — `docs/upstream-bugs/UPSTREAM-BUG-global-variables-permission-gate-dead-window.md`: mechanism, why it flaked instead of hard-failing, the deterministic 503-injection repro (retry ladder measured at 0.8/1.8/3.8/7.8/15.8/31.8 s), the gate-isolation experiment, and the re-validation note for lifting the quarantine.
- Indicator block regenerated via `npm run regressions:summary` (8 regressions, 5 open) — unlike `QA-CHECKLIST.md`, the ledger's generated block IS committed in the PR; `npm run regressions:check` passes.

## The regression, in one paragraph

The release-1.12 RBAC gate (langflow#14215, on `release-1.12.0`, not on langflow `main`) makes every row interaction on Settings → Global Variables pass through `canMutateVariable()`, which returns `false` while the `POST /api/v1/authz/me/permissions` query is loading — row clicks are silently dropped (edit modal never opens) and rows are unselectable (delete button never enables), with no UI feedback. Normally a 1–2 s window; one transient network/5xx on the first call holds it through the query wrapper's 5× exponential-backoff ladder: ~31 s, longer than both specs' waits — hence the recurrent flake (dailies 2026-07-27 and 2026-08-03).

## What this PR does NOT do

- Does not lift the #1235 quarantine — per the issue's deliverables, `test.fixme` stays and `@stable` is not restored until the upstream fix lands in `langflow-nightly:latest` and is re-validated there.
- Does not change any spec, helper or CI surface — docs-only diff.

## Linkage

- Exception issue (off-wave justification): #1235 (`daily-failure`, from triage #1231)
- Upstream: [LE-2123](https://datastax.jira.com/browse/LE-2123) · introduced by [langflow#14215](https://github.com/langflow-ai/langflow/pull/14215)
- Root-cause evidence recorded on the issue: https://github.com/oriontech-me/langflow-e2e/issues/1235#issuecomment-5182389540
