### PR TITLE
test(model-provider): restore @stable to the OpenAI key-configuration test (#1263)

### DIFF
--- a/tests/tests-automations/regression/core-functionality/model-provider/openai-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/openai-provider.spec.ts
@@ -136,7 +136,7 @@ test.describe.configure({ mode: "serial" });
 test.describe("OpenAI Provider", () => {
   test(
     "OpenAI API key is configured via Settings → Model Providers",
-    { tag: ["@model-provider", "@settings"] },
+    { tag: ["@stable", "@model-provider", "@settings"] },
     async ({ page }) => {
       test.skip(
         !hasProviderEnvKeys(PROVIDER),


### PR DESCRIPTION
## What this PR does

Restores the `@stable` tag that `d401743` auto-removed from `openai-provider.spec.ts:137` ("OpenAI API key is configured via Settings → Model Providers") after daily #30901311395. One-line diff; the spec itself is untouched, per the #1263 directive ("restore `@stable` rather than changing the specs").

Closes #1263.

## Why restoration and not a fix

The investigation confirmed the failure was **environmental** — the known mid-run backend wedge (#1030/#1048) — with evidence on all three directive fronts (full detail in the [verdict comment](https://github.com/oriontech-me/langflow-e2e/issues/1263#issuecomment-5183029448)):

1. **Product ruled out** on the current nightly: 5/5 cold opens of Settings → Model Providers with the OpenAI row clickable in 0.6–1.4 s (Google row: 709 ms) and the key panel opening right after.
2. **Environment proven** from the run's service container logs: gunicorn `WORKER TIMEOUT → SIGKILL` on shard 4 at `10:46:42–43` UTC, with the worker re-boot spanning exactly the liveness outage window the test failed inside (`10:47:01→10:48:33`), plus a second `WORKER TIMEOUT` at `10:55:51` covering the retries; same pattern on shard 2 for the google flake. One retry attempt died at `awaitBootstrapTest` waiting for `mainpage_title` — the app home itself never rendered, which no provider-screen regression can produce.
3. **Reliability re-checked**: the spec ran clean multiple times locally against the current nightly with retries disabled.

## Scope

- Only `openai-provider.spec.ts:137` — the sole #1263 test whose tag was auto-removed. `google-provider.spec.ts:90` recovered on retry and kept its tag; the google removal in `d401743` was the *Agent model selection* test, which belongs to a different cluster.
- `openai-provider.spec.ts:201`'s skip was cascading from this hard failure and resolves with it.
- `QA-CHECKLIST.md` deliberately untouched — the generated blocks regenerate on merge to `main`.
- Nothing to unquarantine: no `test.fixme` was applied on this cluster.

## Linkage

- Exception issue (off-wave justification): #1263 (`daily-failure`, from triage #1258, run [30901311395](https://github.com/oriontech-me/langflow-e2e/actions/runs/30901311395))
