### PR TITLE
fix(specs): attribute the page-entry barrier and stop the provider-panel re-fill (#1262)

### DIFF
--- a/docs/core-functionality/llm-agents/language-model-regression.md
+++ b/docs/core-functionality/llm-agents/language-model-regression.md
@@ -37,6 +37,13 @@ PR #775 — the key had no quota, not the test — and **restored in #992** once
 the quota was confirmed back (live HTTP 200 completion on `gpt-4o-mini`) and
 the test ran clean at `--retries=0`.
 
+`@stable` was removed from the **Google** test again by the 2026-08-04 daily's
+auto-removal (run 30901311395) and is **restored by the #1262 fix**. The
+removal was collateral: the attempt that set the recorded signature ran while
+the shard's backend was restarting after a gunicorn `WORKER TIMEOUT`, so the
+recorded error is a page-entry timeout, not this test's own observable — see
+Notes (#1262).
+
 ---
 
 ## Preconditions *(optional)*
@@ -58,7 +65,11 @@ the test ran clean at `--retries=0`.
 ## Step by step *(required)*
 
 Common: open the Basic Prompting template (flow id captured from the page's
-own `POST /api/v1/flows/` response; deleted in `afterEach`).
+own `POST /api/v1/flows/` response; deleted in `afterEach`). The page-entry
+barrier inside `awaitBootstrapTest` now fails **attributed** (#1262): on
+timeout it probes `GET /api/v1/version` and says whether the backend answered,
+so an unreachable backend can no longer be reported as "`mainpage_title` never
+rendered".
 
 **OpenAI test:** `initialGPTsetup` — which pins a deterministic GPT model
 from `models.json` via `resolveGptModel()` (#606; UI preference-ranking is
@@ -97,6 +108,11 @@ visible → Escape.
   `node_duration_` badge within 60s (OpenAI test still uses the `built
   successfully` toast — #750 hardened only the flaking Google test); the
   Playground reply is the end-to-end proof the selected provider executed.
+- **Fix #1262 exit criterion:** the recorded page-entry signature is
+  attributed (backend-reachability probed at the barrier), the Google test's
+  own recurrent observable is addressed at its cause (the provider-panel
+  re-fill race below), and the test proves clean `--retries=0` runs on the
+  current nightly before `@stable` is restored.
 - **Fix #596 exit criterion:** the Google test's root cause is identified
   with evidence (test defect vs product vs environment — triage verdicts),
   the fix does NOT weaken asserts (no timeout inflation to mask latency),
@@ -170,3 +186,44 @@ visible → Escape.
   `setupOpenAI` was already preference-ranked, not blind "first
   available" — the nondeterminism was the last-resort fallback and the
   missing race gate, both addressed.
+- **#1262 root cause (2026-08-04):** the issue was filed as an entry-point
+  failure — `mainpage_title` never rendering inside `openBasicPrompting()` —
+  and that framing does not survive the evidence. Three separate findings:
+  - **The recorded signature was the LAST attempt's.** Attempt 1 failed on
+    `node_duration_chat output` (60s, this file's own build observable), retry
+    #1 on `new-project-btn`, retry #2 on `mainpage_title`. The shard's Langflow
+    logged `WORKER TIMEOUT (pid:37)` at 10:46:42 UTC and SIGKILLed the worker;
+    the restart completed ~10:47:00, inside the triage's recorded outage window
+    (10:47:01→10:48:33). Both retries ran against a restarting backend —
+    **environment**, verdict 4, no test change earns anything there.
+  - **"Recurrent 3×, same signature" was an artifact** of the shared Playwright
+    prefix `TimeoutError: page.waitForSelector: Timeout 30000ms exceeded.`. On
+    2026-07-09, 07-14 and (the OpenAI sibling) 07-15 the locator was
+    `text=built successfully` — the #750 observable, a different failure. The
+    entry point was never the recurring cause.
+  - **The file's real recurrent cause is the provider panel's re-fill race.**
+    `setupGoogle` decided "already configured" from a 1s `isVisible` probe on
+    the Disconnect button, which is painted only after the panel's own backend
+    fetch resolves; a slow fetch read as "not configured" and the helper filled
+    the key field over a provider that already held a credential. Langflow then
+    called Google with an unusable key —
+    `Error calling model 'gemini-flash-latest' (INVALID_ARGUMENT): 400 … 'API
+    key not valid. Please pass a valid API key.' … API_KEY_INVALID` — so the
+    build never completed and the test timed out on its build observable, which
+    is exactly the 07-09/07-14/07-15 and attempt-1 shape. Reproduced on
+    1.12.0.dev15: **1 failure in 7 runs**, the 6 clean runs all observing the
+    provider already configured with the key masked (`AIza•••…`).
+    **Verdict: test defect.** Fix: `providerAlreadyConfigured()`
+    (`helpers/provider-setup/provider-config-state.ts`, unit-tested) polls both
+    signals to a 5s deadline and treats a **non-empty (masked) key field** as
+    configured on its own — a masked value can never be one this helper typed,
+    so it cannot skip a setup that was genuinely needed.
+- **Page-entry attribution (#1262, suite-wide):** the shared barrier now lives
+  in `helpers/other/page-entry-barrier.ts` and is used by `awaitBootstrapTest`,
+  `MainPage.waitForLoad`, `loadTemplateByName` and
+  `addFlowToTestOnEmptyLangflow`. On timeout it probes `/api/v1/version` and
+  prefixes the failure with `[backend-unreachable]` when the backend did not
+  answer (or answered non-2xx), keeps the failure attributed to the UI when it
+  did answer, and reports UNKNOWN when the probe itself could not run (#1012 —
+  an unevaluated probe is not a clean one). Success-path behaviour is unchanged;
+  only the failure message differs.

--- a/tests/helpers/flows/add-flow-to-test-on-empty-langflow.ts
+++ b/tests/helpers/flows/add-flow-to-test-on-empty-langflow.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { dismissWelcomeOverlayAndWaitForModal } from "./open-new-flow-templates-modal";
+import { waitForPageEntry } from "../other/page-entry-barrier";
 
 export const addFlowToTestOnEmptyLangflow = async (page: Page) => {
   await page.getByTestId("new_project_btn_empty_page").click();
@@ -15,7 +16,5 @@ export const addFlowToTestOnEmptyLangflow = async (page: Page) => {
   // Wait for home page to finish loading before awaitBootstrapTest continues.
   // Without this, the subsequent new-project-btn click can fire before navigation
   // completes, leaving tests in an inconsistent state.
-  await page.waitForSelector('[data-testid="mainpage_title"]', {
-    timeout: 15000,
-  });
+  await waitForPageEntry(page, '[data-testid="mainpage_title"]', 15000);
 };

--- a/tests/helpers/flows/load-template-by-name.ts
+++ b/tests/helpers/flows/load-template-by-name.ts
@@ -2,6 +2,7 @@ import type { Page, Response } from "@playwright/test";
 import { openNewFlowTemplatesModal } from "./open-new-flow-templates-modal";
 import { getAuthToken } from "../auth/get-auth-token";
 import { deleteFlow } from "./delete-flow";
+import { waitForPageEntry } from "../other/page-entry-barrier";
 
 /** How many times the template pick is retried when its creation POST fails. */
 const MAX_PICK_ATTEMPTS = 3;
@@ -204,9 +205,7 @@ export const loadTemplateByName = async (
 
   try {
     await page.goto("/");
-    await page.waitForSelector('[data-testid="mainpage_title"]', {
-      timeout: 30000,
-    });
+    await waitForPageEntry(page, '[data-testid="mainpage_title"]', 30000);
 
     let flowId: string | undefined;
     let lastCreation: FlowPost | undefined;
@@ -246,9 +245,7 @@ export const loadTemplateByName = async (
         // The failed pick leaves the app on the flows list with a toast; start
         // the next attempt from a known state.
         await page.goto("/");
-        await page.waitForSelector('[data-testid="mainpage_title"]', {
-          timeout: 30000,
-        });
+        await waitForPageEntry(page, '[data-testid="mainpage_title"]', 30000);
       }
     }
 

--- a/tests/helpers/other/await-bootstrap-test.ts
+++ b/tests/helpers/other/await-bootstrap-test.ts
@@ -1,6 +1,7 @@
 import type { Page } from "@playwright/test";
 import { addFlowToTestOnEmptyLangflow } from "../flows/add-flow-to-test-on-empty-langflow";
 import { openNewFlowTemplatesModal } from "../flows/open-new-flow-templates-modal";
+import { waitForPageEntry } from "./page-entry-barrier";
 
 export const awaitBootstrapTest = async (
   page: Page,
@@ -13,9 +14,10 @@ export const awaitBootstrapTest = async (
     await page.goto("/");
   }
 
-  await page.waitForSelector('[data-testid="mainpage_title"]', {
-    timeout: 30000,
-  });
+  // Attributed barrier, not a bare waitForSelector: a backend that is down or
+  // restarting produces the identical timeout as a UI regression here, and that
+  // ambiguity mis-triaged #1262. See helpers/other/page-entry-barrier.ts.
+  await waitForPageEntry(page, '[data-testid="mainpage_title"]', 30000);
 
   const countEmptyButton = await page
     .getByTestId("new_project_btn_empty_page")
@@ -24,9 +26,7 @@ export const awaitBootstrapTest = async (
     await addFlowToTestOnEmptyLangflow(page);
   }
 
-  await page.waitForSelector('[id="new-project-btn"]', {
-    timeout: 30000,
-  });
+  await waitForPageEntry(page, '[id="new-project-btn"]', 30000);
 
   if (!options?.skipModal) {
     let modalCount = 0;
@@ -58,9 +58,7 @@ export const awaitBootstrapTest = async (
         // new-project-btn is present again — otherwise the retry clicks into
         // the canvas and times out.
         await page.goto("/");
-        await page.waitForSelector('[id="new-project-btn"]', {
-          timeout: 30000,
-        });
+        await waitForPageEntry(page, '[id="new-project-btn"]', 30000);
         await page.waitForTimeout(1000);
       }
     }

--- a/tests/helpers/other/page-entry-barrier.test.ts
+++ b/tests/helpers/other/page-entry-barrier.test.ts
@@ -1,0 +1,173 @@
+// Unit tests for the page-entry barrier's attribution message (issue #1262).
+// Run with: npm run test:units
+//
+// What rides on this function: the triage verdict a human reads off a red daily.
+//
+// On the 2026-08-04 daily (run 30901311395, shard 4), gunicorn logged
+// `WORKER TIMEOUT (pid:37)` at 10:46:42 and SIGKILLed the worker; the backend
+// was restarting from 10:47:01 to 10:48:33. Two retries of
+// `language-model-regression.spec.ts` ran inside that window and both reported
+//
+//   TimeoutError: page.waitForSelector: Timeout 30000ms exceeded.
+//     - waiting for locator('[data-testid="mainpage_title"]') to be visible
+//
+// which reads as "the app's main page never renders". Triage grouped the test
+// into an entry-point cluster (#1262) on the strength of that string, away from
+// the provider cluster it actually belonged to — and the same string on
+// 2026-07-09/07-14 turned out to be a DIFFERENT observable (`text=built
+// successfully`), so the "recurrent, same signature" premise was an artifact of
+// the shared Playwright prefix.
+//
+// The barrier can therefore not just time out: it must say WHICH of the two
+// states it observed, and it must never claim a clean backend it did not probe
+// (#1012's rule — an unevaluated probe is unknown, not healthy).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  entryBarrierMessage,
+  INFRA_PREFIX,
+  resolveProbeUrl,
+} from "./page-entry-barrier";
+
+const CAUSE =
+  "TimeoutError: page.waitForSelector: Timeout 30000ms exceeded.\n" +
+  "Call log:\n" +
+  '  - waiting for locator(\'[data-testid="mainpage_title"]\') to be visible';
+
+const SELECTOR = '[data-testid="mainpage_title"]';
+
+test("an unreachable backend is named as the cause, with the infra prefix", () => {
+  const msg = entryBarrierMessage({
+    selector: SELECTOR,
+    timeoutMs: 30000,
+    probe: {
+      state: "unreachable",
+      ms: 5001,
+      url: "http://localhost:7860/api/v1/version",
+      detail: "apiRequestContext.get: Timeout 5000ms exceeded.",
+    },
+    cause: CAUSE,
+  });
+
+  assert.ok(
+    msg.startsWith(INFRA_PREFIX),
+    `expected the infra prefix so triage can classify it, got: ${msg}`,
+  );
+  assert.match(msg, /did not answer GET \/api\/v1\/version/);
+  assert.match(msg, /apiRequestContext\.get: Timeout 5000ms exceeded\./);
+  // The barrier that failed must still be identifiable, and the original
+  // Playwright error must survive — the trace/screenshot is read against it.
+  assert.match(msg, /mainpage_title/);
+  assert.match(msg, /page\.waitForSelector: Timeout 30000ms exceeded/);
+});
+
+test("a non-2xx answer is reported as an application failure, not as the wedge", () => {
+  const msg = entryBarrierMessage({
+    selector: SELECTOR,
+    timeoutMs: 30000,
+    probe: {
+      state: "http_error",
+      ms: 42,
+      status: 502,
+      url: "http://localhost:7860/api/v1/version",
+    },
+    cause: CAUSE,
+  });
+
+  assert.ok(msg.startsWith(INFRA_PREFIX));
+  assert.match(msg, /answered GET \/api\/v1\/version with HTTP 502/);
+  // 502 is the backend failing to serve, which is still not this spec's fault —
+  // but it must not be described as unreachable, because it answered.
+  assert.doesNotMatch(msg, /did not answer/);
+});
+
+test("a healthy backend keeps the failure attributed to the UI", () => {
+  const msg = entryBarrierMessage({
+    selector: SELECTOR,
+    timeoutMs: 30000,
+    probe: {
+      state: "healthy",
+      ms: 21,
+      status: 200,
+      url: "http://localhost:7860/api/v1/version",
+    },
+    cause: CAUSE,
+  });
+
+  // This is the case where the spec IS the right place to look, so the message
+  // must NOT carry the infra prefix — otherwise a genuine entry-point
+  // regression would be filed as an outage (and, once the prefix reaches
+  // `scripts/lib/infra-signatures.ts`, would stop being quarantined at all).
+  assert.ok(
+    !msg.startsWith(INFRA_PREFIX),
+    `a healthy probe must not be labelled infra, got: ${msg}`,
+  );
+  assert.match(msg, /answered GET \/api\/v1\/version with HTTP 200/);
+  assert.match(msg, /product|UI/i);
+});
+
+test("a probe that could not run is reported as unknown, never as healthy", () => {
+  const msg = entryBarrierMessage({
+    selector: SELECTOR,
+    timeoutMs: 30000,
+    probe: {
+      state: "unknown",
+      ms: 0,
+      url: "http://localhost:7860/api/v1/version",
+      detail: "probe threw: browser closed",
+    },
+    cause: CAUSE,
+  });
+
+  assert.match(msg, /could not be probed/);
+  assert.match(msg, /probe threw: browser closed/);
+  // Unknown must not be dressed up as either verdict.
+  assert.doesNotMatch(msg, /answered GET/);
+  assert.ok(
+    !msg.startsWith(INFRA_PREFIX),
+    "an unproven outage must not claim the infra prefix",
+  );
+});
+
+test("the message names the barrier's own budget so a raised timeout is visible", () => {
+  const msg = entryBarrierMessage({
+    selector: '[id="new-project-btn"]',
+    timeoutMs: 15000,
+    probe: {
+      state: "healthy",
+      ms: 8,
+      status: 200,
+      url: "http://langflow:7860/api/v1/version",
+    },
+    cause: CAUSE,
+  });
+
+  assert.match(msg, /15000ms/);
+  assert.match(msg, /new-project-btn/);
+  assert.match(msg, /http:\/\/langflow:7860/);
+});
+
+test("the probed URL comes from the page's own origin, not from the environment", () => {
+  const onLangflow = { url: () => "http://127.0.0.1:7861/flow/abc" } as any;
+  const blank = { url: () => "about:blank" } as any;
+  const previous = process.env.PLAYWRIGHT_BASE_URL;
+  process.env.PLAYWRIGHT_BASE_URL = "http://localhost:7860";
+  try {
+    // The page IS the authority: a spec driving a Langflow on another port must
+    // not be told the one named in the environment answered for it.
+    assert.equal(
+      resolveProbeUrl(onLangflow),
+      "http://127.0.0.1:7861/api/v1/version",
+    );
+    // No page origin to read (about:blank) ⇒ fall back to the environment.
+    assert.equal(resolveProbeUrl(blank), "http://localhost:7860/api/v1/version");
+    // An explicit override wins over both (used by the force-fail harness).
+    assert.equal(
+      resolveProbeUrl(onLangflow, "http://127.0.0.1:9"),
+      "http://127.0.0.1:9/api/v1/version",
+    );
+  } finally {
+    if (previous === undefined) delete process.env.PLAYWRIGHT_BASE_URL;
+    else process.env.PLAYWRIGHT_BASE_URL = previous;
+  }
+});

--- a/tests/helpers/other/page-entry-barrier.ts
+++ b/tests/helpers/other/page-entry-barrier.ts
@@ -1,0 +1,196 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * The page-entry barrier every helper that lands on the home page waits on
+ * (`mainpage_title`, then `new-project-btn`), with the failure ATTRIBUTED.
+ *
+ * Why this exists (#1262). A bare `waitForSelector` on those two testids cannot
+ * distinguish the only two things that make it time out:
+ *
+ *   1. the backend is unreachable or restarting — the page loads, the app shell
+ *      renders nothing, and the barrier burns its whole budget;
+ *   2. the entry point genuinely regressed — the backend answers and the UI
+ *      still does not render the observable.
+ *
+ * Both produce the same line, which is the most common failure string in
+ * `reports/daily-history.jsonl`:
+ *
+ *   TimeoutError: page.waitForSelector: Timeout 30000ms exceeded.
+ *     - waiting for locator('[data-testid="mainpage_title"]') to be visible
+ *
+ * That ambiguity has already cost a wrong triage. On the 2026-08-04 daily
+ * (run 30901311395, shard 4) gunicorn logged `WORKER TIMEOUT (pid:37)` at
+ * 10:46:42, SIGKILLed the worker, and the backend was restarting through
+ * 10:47:01→10:48:33; two retries of `language-model-regression.spec.ts` ran
+ * inside that window, reported the line above, and the test was filed as an
+ * entry-point failure (#1262) instead of as collateral of the wedge — while its
+ * own first attempt had failed on the provider's build. The same string on
+ * 2026-07-09/07-14/07-15 was a third observable entirely (`text=built
+ * successfully`), which is how "recurrent 3×, same signature" survived review.
+ *
+ * So the barrier probes `/api/v1/version` on timeout and says which state it
+ * observed. Three rules the unit tests pin:
+ *
+ *  - an unreachable or non-2xx backend gets `INFRA_PREFIX`, the marker meaning
+ *    "the harness could not talk to Langflow" — the same claim
+ *    `scripts/lib/infra-signatures.ts` requires before it will exempt a failure
+ *    from `@stable` auto-removal;
+ *  - a HEALTHY probe deliberately does NOT get that prefix: that failure is the
+ *    UI's, and mislabelling it would turn a real entry-point regression into an
+ *    unquarantined "outage";
+ *  - a probe that could not run is reported as UNKNOWN, never as healthy
+ *    (#1012 — an unevaluated check is not a clean one).
+ *
+ * The original Playwright error is always appended, so the trace, screenshot and
+ * call log stay readable against it.
+ */
+
+/**
+ * Marker for a failure the harness proved it could not attribute to the page.
+ * Kept in one place so a future `infra-signatures.ts` entry and this message
+ * cannot drift apart.
+ */
+export const INFRA_PREFIX = "[backend-unreachable]";
+
+/** Endpoint used as the liveness probe — unauthenticated and cheap. */
+export const PROBE_PATH = "/api/v1/version";
+
+export type ProbeState = "healthy" | "http_error" | "unreachable" | "unknown";
+
+export interface BackendProbe {
+  state: ProbeState;
+  /** Wall-clock the probe took, in ms. */
+  ms: number;
+  /**
+   * The absolute URL the probe actually called. Reported rather than rebuilt
+   * from the environment: `PLAYWRIGHT_BASE_URL` and the browser context's own
+   * baseURL can disagree, and a message that names an origin nobody called is
+   * how a reader concludes the wrong backend was healthy.
+   */
+  url: string;
+  /** Set when the backend answered. */
+  status?: number;
+  /** Transport error, or why the probe itself could not run. */
+  detail?: string;
+}
+
+export interface EntryBarrierContext {
+  selector: string;
+  timeoutMs: number;
+  probe: BackendProbe;
+  /** The original Playwright error text. */
+  cause: string;
+}
+
+/**
+ * Build the attributed failure message. Pure — the unit tests drive it directly
+ * with each probe state.
+ */
+export function entryBarrierMessage(ctx: EntryBarrierContext): string {
+  const { selector, timeoutMs, probe, cause } = ctx;
+  const barrier = `page-entry barrier "${selector}" did not render within ${timeoutMs}ms`;
+  const url = probe.url;
+
+  let head: string;
+  switch (probe.state) {
+    case "unreachable":
+      head =
+        `${INFRA_PREFIX} ${barrier} — and the backend did not answer GET ` +
+        `${PROBE_PATH} within ${probe.ms}ms (${url}): ${probe.detail}. ` +
+        `Langflow was unreachable or restarting, so this is NOT an entry-point ` +
+        `regression in the app.`;
+      break;
+    case "http_error":
+      head =
+        `${INFRA_PREFIX} ${barrier} — the backend answered GET ${PROBE_PATH} ` +
+        `with HTTP ${probe.status} in ${probe.ms}ms (${url}). Langflow is up but ` +
+        `failing to serve, so this is NOT an entry-point regression in the app.`;
+      break;
+    case "healthy":
+      head =
+        `${barrier} — the backend answered GET ${PROBE_PATH} with HTTP ` +
+        `${probe.status} in ${probe.ms}ms (${url}), so the backend was reachable ` +
+        `and this IS a product/UI failure at the page entry point.`;
+      break;
+    default:
+      head =
+        `${barrier} — backend liveness could not be probed ` +
+        `(${probe.detail}), so whether Langflow was reachable is UNKNOWN. ` +
+        `Do not read this as a healthy backend.`;
+  }
+
+  return `${head}\n\nOriginal error:\n${cause}`;
+}
+
+/**
+ * Origin to probe: the page's own, when it is on one — that is by definition the
+ * Langflow the spec is driving. `baseURL` exists for the force-fail harness and
+ * for a page parked on `about:blank`.
+ */
+export function resolveProbeUrl(page: Page, baseURL?: string): string {
+  const explicit = baseURL ?? undefined;
+  const pageUrl = page.url();
+  const origin =
+    explicit ??
+    (/^https?:/i.test(pageUrl) ? new URL(pageUrl).origin : undefined) ??
+    process.env.PLAYWRIGHT_BASE_URL ??
+    "http://localhost:7860";
+  return new URL(PROBE_PATH, origin).toString();
+}
+
+/** Probe Langflow's liveness through the page's own request context. */
+export async function probeBackend(
+  page: Page,
+  options?: { baseURL?: string; timeoutMs?: number },
+): Promise<BackendProbe> {
+  const timeoutMs = options?.timeoutMs ?? 5000;
+  const url = resolveProbeUrl(page, options?.baseURL);
+  const started = Date.now();
+  try {
+    const res = await page.request.get(url, { timeout: timeoutMs });
+    const ms = Date.now() - started;
+    return res.ok()
+      ? { state: "healthy", ms, status: res.status(), url }
+      : { state: "http_error", ms, status: res.status(), url };
+  } catch (error: any) {
+    const ms = Date.now() - started;
+    const detail = String(error?.message ?? error).split("\n")[0];
+    // A transport error IS the answer here (refused / timed out / DNS), which is
+    // different from the probe being unable to run at all — the latter only
+    // happens when the page or its context is already gone.
+    const unusable = /Target page|context or browser has been closed|browser has been closed/i.test(
+      detail,
+    );
+    return unusable
+      ? { state: "unknown", ms, url, detail: `probe could not run: ${detail}` }
+      : { state: "unreachable", ms, url, detail };
+  }
+}
+
+/**
+ * `waitForSelector` for a page-entry observable, with the timeout attributed.
+ *
+ * Drop-in for `await page.waitForSelector(selector, { timeout })` on the home
+ * page. Behaviour on success is identical (same selector, same budget); only the
+ * failure path changes.
+ */
+export async function waitForPageEntry(
+  page: Page,
+  selector: string,
+  timeoutMs: number,
+  options?: { baseURL?: string },
+): Promise<void> {
+  try {
+    await page.waitForSelector(selector, { timeout: timeoutMs });
+  } catch (error: any) {
+    const probe = await probeBackend(page, { baseURL: options?.baseURL });
+    throw new Error(
+      entryBarrierMessage({
+        selector,
+        timeoutMs,
+        probe,
+        cause: String(error?.message ?? error),
+      }),
+    );
+  }
+}

--- a/tests/helpers/provider-setup/provider-config-state.test.ts
+++ b/tests/helpers/provider-setup/provider-config-state.test.ts
@@ -1,0 +1,52 @@
+// Unit tests for the "is this provider already configured?" predicate (#1262).
+// Run with: npm run test:units
+//
+// What rides on it: whether `setup-google.ts` writes the API key field. Writing
+// it over a provider that already holds a credential stores an unusable key, and
+// the failure surfaces two steps later as a build that never completes — which
+// is how it stayed unattributed across four dailies.
+//
+// Measured on 1.12.0.dev15: 1 failure in 7 runs of
+// `language-model-regression.spec.ts:135`, the failing one calling Google with a
+// key it rejected (`API_KEY_INVALID`), the 6 clean ones observing the field
+// masked as `AIza•••••••••••••••••••••••••••••••••••`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { providerAlreadyConfigured } from "./provider-config-state";
+
+/** Verbatim from the panel on a configured Google provider. */
+const MASKED = "AIza•••••••••••••••••••••••••••••••••••";
+
+test("Disconnect visible ⇒ configured", () => {
+  assert.equal(
+    providerAlreadyConfigured({ disconnectVisible: true, keyFieldValue: "" }),
+    true,
+  );
+});
+
+test("a masked key counts as configured even before Disconnect paints", () => {
+  // This is the case the old 1s isVisible probe got wrong: the panel's fetch was
+  // still in flight, Disconnect had not rendered, and the helper re-filled.
+  assert.equal(
+    providerAlreadyConfigured({
+      disconnectVisible: false,
+      keyFieldValue: MASKED,
+    }),
+    true,
+  );
+});
+
+test("an empty field with no Disconnect ⇒ NOT configured (setup must still run)", () => {
+  // The inverse must keep working, or a fresh CI container never gets a key.
+  assert.equal(
+    providerAlreadyConfigured({ disconnectVisible: false, keyFieldValue: "" }),
+    false,
+  );
+  assert.equal(
+    providerAlreadyConfigured({
+      disconnectVisible: false,
+      keyFieldValue: "   ",
+    }),
+    false,
+  );
+});

--- a/tests/helpers/provider-setup/provider-config-state.ts
+++ b/tests/helpers/provider-setup/provider-config-state.ts
@@ -1,0 +1,42 @@
+/**
+ * Is a provider ALREADY configured in the model-provider panel?
+ *
+ * Split out of `setup-google.ts` (#1262) because this one boolean decides
+ * whether the helper writes the API key field, and writing it over a provider
+ * that already holds a credential stores a key Langflow cannot use — the next
+ * build then fails with
+ *
+ *   Error calling model 'gemini-flash-latest' (INVALID_ARGUMENT): 400 …
+ *   'API key not valid. Please pass a valid API key.' … API_KEY_INVALID
+ *
+ * and the spec times out on its build observable with no hint of why. That is
+ * the recurrent shape of `language-model-regression.spec.ts` on the 2026-07-09 /
+ * 07-14 / 07-15 dailies (`text=built successfully`) and of the first attempt on
+ * 2026-08-04 (`node_duration_chat output`).
+ *
+ * Two signals, because neither alone is reliable at the moment the panel opens:
+ *
+ *  - the **Disconnect** button is the panel's explicit "configured" affordance,
+ *    but it paints only after the panel's backend fetch resolves — the previous
+ *    1s `isVisible` probe decided "not configured" while that fetch was still in
+ *    flight;
+ *  - a **non-empty key field** is decisive on its own: Langflow renders a stored
+ *    credential masked (`AIza••••…`), and an unconfigured provider renders the
+ *    field empty with a placeholder. A masked value can never be a value this
+ *    helper typed, so treating it as "configured" cannot skip a setup that was
+ *    genuinely needed.
+ */
+export interface ProviderPanelState {
+  /** Whether the panel's Disconnect button is visible right now. */
+  disconnectVisible: boolean;
+  /**
+   * Current value of the API key input — `""` when absent or empty. The masked
+   * form Langflow renders (bullets) counts as a value.
+   */
+  keyFieldValue: string;
+}
+
+export function providerAlreadyConfigured(state: ProviderPanelState): boolean {
+  if (state.disconnectVisible) return true;
+  return state.keyFieldValue.trim().length > 0;
+}

--- a/tests/helpers/provider-setup/setup-google.ts
+++ b/tests/helpers/provider-setup/setup-google.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { hideInspectorPanel } from "../ui/hide-inspector-panel";
+import { providerAlreadyConfigured } from "./provider-config-state";
 
 export async function setupGoogle(
   page: Page,
@@ -43,18 +44,50 @@ export async function setupGoogle(
   const apiKeyInput = page.getByPlaceholder("AIza...");
   await apiKeyInput.waitFor({ state: "visible", timeout: 10000 }).catch(() => {});
 
-  const alreadyConfigured = await page
-    .getByRole("button", { name: "Disconnect", exact: true })
-    .isVisible({ timeout: 1000 })
-    .catch(() => false);
+  // Whether the provider is ALREADY configured decides whether the key field is
+  // written, and getting it wrong is expensive: filling over a configured
+  // provider stores a key Langflow cannot use, and the next build fails with
+  //
+  //   Error calling model 'gemini-flash-latest' (INVALID_ARGUMENT): 400 …
+  //   'API key not valid. Please pass a valid API key.' … API_KEY_INVALID
+  //
+  // which surfaces as the build observable never appearing — the recurrent
+  // signature of this file on the 2026-07-09/07-14/07-15 dailies and of the
+  // first attempt on 2026-08-04 (#1262). Reproduced locally: 1 failure in 7
+  // runs, and the 6 clean ones all observed the provider already configured
+  // with the key rendered masked.
+  //
+  // The old check was a 1s `isVisible` on the Disconnect button — decided while
+  // the panel's own backend fetch was still in flight, so a slow fetch read as
+  // "not configured". Both signals are now polled to a deadline, and a masked
+  // (non-empty) key field counts as configured on its own: Langflow renders a
+  // stored credential as `AIza••••…`, so a non-empty value means a credential
+  // exists whether or not Disconnect has painted yet.
+  const disconnectBtn = page.getByRole("button", {
+    name: "Disconnect",
+    exact: true,
+  });
+  const configuredSignal = async () =>
+    providerAlreadyConfigured({
+      disconnectVisible: await disconnectBtn.isVisible().catch(() => false),
+      keyFieldValue: await apiKeyInput.inputValue().catch(() => ""),
+    });
+  // 5s, not longer: the panel's fetch resolves in well under a second, and an
+  // unconfigured provider (a fresh CI container before its first setup) pays
+  // this whole window on every call.
+  const configuredDeadline = Date.now() + 5000;
+  let alreadyConfigured = await configuredSignal();
+  while (!alreadyConfigured && Date.now() < configuredDeadline) {
+    await page.waitForTimeout(500);
+    alreadyConfigured = await configuredSignal();
+  }
 
   if (!alreadyConfigured && (await apiKeyInput.count()) > 0) {
     await apiKeyInput.fill(process.env.GOOGLE_API_KEY ?? "");
     await page.getByRole("button", { name: /Save|Replace|Retry/i }).click();
     // Google provider validation can take ~35s — wait for the configured state
     // (Disconnect button) so the model toggles have rendered before Step 5.
-    await page
-      .getByRole("button", { name: "Disconnect", exact: true })
+    await disconnectBtn
       .waitFor({ state: "visible", timeout: 60000 })
       .catch(() => {});
   }

--- a/tests/pages/MainPage.ts
+++ b/tests/pages/MainPage.ts
@@ -2,6 +2,7 @@ import type { Page } from "@playwright/test";
 import { BasePage } from "./BasePage";
 import { SidebarComponent } from "./SidebarComponent";
 import { addFlowToTestOnEmptyLangflow } from "../helpers/flows/add-flow-to-test-on-empty-langflow";
+import { waitForPageEntry } from "../helpers/other/page-entry-barrier";
 
 export class MainPage extends BasePage {
   readonly sidebar: SidebarComponent;
@@ -13,18 +14,15 @@ export class MainPage extends BasePage {
 
   async waitForLoad({ skipModal = false }: { skipModal?: boolean } = {}) {
     await this.page.goto("/");
-    await this.page.waitForSelector('[data-testid="mainpage_title"]', {
-      timeout: 30000,
-    });
+    // Attributed barrier (#1262) — see helpers/other/page-entry-barrier.ts.
+    await waitForPageEntry(this.page, '[data-testid="mainpage_title"]', 30000);
 
     const emptyPageBtn = this.page.getByTestId("new_project_btn_empty_page");
     if ((await emptyPageBtn.count()) > 0) {
       await addFlowToTestOnEmptyLangflow(this.page);
     }
 
-    await this.page.waitForSelector('[id="new-project-btn"]', {
-      timeout: 30000,
-    });
+    await waitForPageEntry(this.page, '[id="new-project-btn"]', 30000);
 
     if (!skipModal) {
       await this.openNewProjectModal();

--- a/tests/tests-automations/regression/core-functionality/llm-agents/language-model-regression.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/language-model-regression.spec.ts
@@ -134,7 +134,7 @@ test.describe("Language Model Component Regression", () => {
 
   test(
     "language model must respond with Google provider",
-    { tag: ["@release", "@components", "@model-provider"] },
+    { tag: ["@stable", "@release", "@components", "@model-provider"] },
     async ({ page }) => {
       const gate = providerSkipGate("google");
       test.skip(gate.skip, gate.reason);


### PR DESCRIPTION
**Fixes #1262.**

## Problem

The issue was filed as an entry-point failure — `mainpage_title` never rendering inside `openBasicPrompting()`, "recurrent 3×, same signature". Neither half of that framing survives the evidence.

**The recorded signature was the LAST attempt's.** In shard 4 of run [30901311395](https://github.com/oriontech-me/langflow-e2e/actions/runs/30901311395) the three attempts failed on three different observables:

| Attempt | Observable | Where |
|---|---|---|
| 1 (initial) | `node_duration_chat output` (60s) + `apiRequestContext.get` timeout on `/api/v1/auto_login` | this file's own build wait (line 187) |
| retry #1 | `[id="new-project-btn"]` | `await-bootstrap-test.ts:61` |
| retry #2 | `[data-testid="mainpage_title"]` | `await-bootstrap-test.ts:16` |

**Environment confirmed for today's occurrence.** The Langflow service logged `WORKER TIMEOUT (pid:37)` at **10:46:42** UTC → `Worker (pid:37) was sent SIGKILL!` → restart finished ~10:47:00 (starter projects at 10:46:57), i.e. inside the triage's recorded outage window `10:47:01→10:48:33`. Both retries ran against a restarting backend, and `openai-provider.spec.ts:137` on the same shard failed on the same `mainpage_title` — collateral, not two broken specs (that sibling was restored separately in #1263 / #1278).

**"Recurrent 3×, same signature" was an artifact of the shared Playwright prefix** `TimeoutError: page.waitForSelector: Timeout 30000ms exceeded.`. On **2026-07-09**, **07-14** and (the OpenAI sibling) **07-15** the locator was `text=built successfully` — the #750 observable, a different failure. The entry point was never the recurring cause.

**Product ruled out first (mandatory step 1):** on 1.12.0.dev15 a cold entry renders `mainpage_title` in **1.4–4.3 s, 5/5**.

**The file's real recurrent cause, reproduced.** Running the whole file, the Google test failed with the build never completing, and the failure snapshot names the reason:

```
Error calling model 'gemini-flash-latest' (INVALID_ARGUMENT): 400 INVALID_ARGUMENT.
{'error': {'code': 400, 'message': 'API key not valid. Please pass a valid API key.',
 'status': 'INVALID_ARGUMENT', … 'reason': 'API_KEY_INVALID' …}}
```

`setupGoogle` decided "already configured" from a **1 s `isVisible`** probe on the Disconnect button, which paints only after the panel's own backend fetch resolves. A slow fetch read as "not configured", so the helper filled the API key field **over a provider that already held a credential**; Langflow then called Google with a key it rejects, the build never completed, and the spec timed out on its build observable — exactly the 07-09/07-14/07-15 and attempt-1 shape. Measured on 1.12.0.dev15: **1 failure in 7 runs**, with the 6 clean runs all observing the field masked as `AIza•••••••••••••••••••••••••••••••••••`.

**Verdict:** attempt 1 + the recurrence = **test defect** (fixed here); the recorded entry-point signature = **environment** (verdict 4, no test change earns anything there — only attribution).

## Fix

**1. The page-entry barrier is attributed** — new `tests/helpers/other/page-entry-barrier.ts`. On timeout it probes `GET /api/v1/version` and says which state it observed:

- backend did not answer, or answered non-2xx → prefixed `[backend-unreachable]`, stating this is not an entry-point regression;
- backend answered 200 → the failure stays attributed to the UI (a genuine entry-point regression must not be dressed up as an outage);
- the probe itself could not run → **UNKNOWN**, never "healthy" (#1012's rule).

The original Playwright error is always appended, so the trace/screenshot stays readable against it. Wired into all six barrier sites: `awaitBootstrapTest` (3), `MainPage.waitForLoad` (2), `loadTemplateByName` (2 — one shared with the retry path), `addFlowToTestOnEmptyLangflow` (1). The probed URL is taken from the page's own origin, not from `PLAYWRIGHT_BASE_URL` — the two can disagree, and naming an origin nobody called is how a reader concludes the wrong backend was healthy.

**2. The re-fill race is fixed at its source** — new `tests/helpers/provider-setup/provider-config-state.ts`. `providerAlreadyConfigured()` polls **both** signals to a 5 s deadline and treats a **non-empty (masked) key field as configured on its own**: Langflow renders a stored credential as `AIza••••…`, and a masked value can never be one this helper typed, so it cannot skip a setup that was genuinely needed. 5 s rather than longer because an unconfigured provider (a fresh CI container before its first setup) pays that whole window on every call.

**3. `@stable` restored** on `language model must respond with Google provider` — its removal was collateral of the wedge, not a verdict on the test.

**Rejected alternatives:** raising the 30 s entry barrier (a 90 s outage is not something 119 specs should wait out silently — retries already cover it, and attribution is what was missing); adding `[backend-unreachable]` to `scripts/lib/infra-signatures.ts` in this PR (the message now meets #1031's bar, but that changes the `@stable` auto-removal contract on `main` — proposed as a separate decision).

## Scope note

Success-path behaviour is unchanged everywhere: same selectors, same budgets, only the failure message differs. `setupGoogle`'s fill/save/toggle flow is untouched apart from the configured-detection. The only spec-file change is the restored tag. `QA-CHECKLIST.md` needs no edit — the manual Part II bullet already references this spec (`npm run check:checklist-coverage` ✅); the generated blocks regenerate on merge.

## Validation (nightly 1.12.0.dev15, `--retries=0`, `--workers=1`)

- `npm run typecheck` ✅ (0 errors) · `npm run lint` ✅ (0 errors) · `npm run test:units` ✅ 413/413 · `npm run test:scripts` ✅ 623/623 · `npm run check:checklist-coverage` ✅
- `language-model-regression.spec.ts` full file, 3 consecutive runs: **4 passed** (56.7 s / 52.2 s / 60 s)
- Google test in isolation before the fix: 3/3 green, 22–24 s — the failure only appears at ~1/7, which is why the whole file was run repeatedly
- Barrier consumers (`project-management/folder-crud.spec.ts`, `flow-functionality/duplicate-flow.spec.ts`): **4 passed**
- Zero `🚨 Backend Error` in the validating runs
- Force-fails **executed**, one per test in the touched file, isolated with `--grep` (serial files mask siblings after a failure), reverted from a pristine copy — post-FF the spec is byte-identical and carries 0 mutation markers:
  - `FF:` OpenAI test — `/4/` → `/FF_MUTANT_999777/` ⇒ failed (`toContainText`, 15000ms)
  - `FF:` Google test — `length > 1` → `> 100000` ⇒ failed (60000ms)
  - `FF:` switch test — `/gemini/i` → `/FF_MUTANT_no_such_model/i` ⇒ failed (15000ms)
  - `FF:` dialog test — `provider-item-OpenAI` → `provider-item-FF_MUTANT_absent` ⇒ failed (10000ms)
  - `FF:` barrier, product branch — healthy backend + a testid that never renders ⇒ message says `IS a product/UI failure`, **no** infra prefix
  - `FF:` barrier, infra branch — dead origin (`127.0.0.1:9`) ⇒ `[backend-unreachable] … did not answer GET /api/v1/version … ECONNREFUSED`
  - `FF:` predicate — `providerAlreadyConfigured` mutated to ignore the masked-key signal ⇒ its unit test fails (pass 2 / fail 1), reverted ⇒ 3/3
- `--trace=on` **not run**: known local hang on this repo beyond the template family (#518/#490) — step verification came from the `--retries=0` runs, the force-fails and the failure snapshots instead.
- Flow cleanup verified: the 4 flows leaked by the validation runs were deleted id-scoped; `GET /api/v1/flows/` is back to the 2 pre-session flows.

## Cross-checks

- **#1261** is this run's real Google cluster — cross-linked, not merged: it fails on the Agent's settled credential/model on the persisted flow, a different state from this file's build.
- **#1126** (`page.waitForURL` on the blank-flow entry point) and **#966** (welcome-panel predicate) stay **separate**: different observables, and the new barrier does not cover `waitForURL`. Both become easier to triage now that a backend outage is named as one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
