### PR TITLE
test(quarantine): quarantine the Research Translation Loop template test (#1234)

### DIFF
--- a/tests/tests-automations/regression/core-components/loop-component-regression.spec.ts
+++ b/tests/tests-automations/regression/core-components/loop-component-regression.spec.ts
@@ -149,7 +149,25 @@ test(
 // Wiring + Iteration — Research Translation Loop template: wiring and real execution
 // =============================================================================
 
-test(
+// Quarantined for #1234 — the template this test loads does not exist in the
+// image. The nightly refuses to register it on startup:
+//
+//   [warning] Skipping starter project 'Research Translation Loop';
+//   unavailable components: ArXivComponent
+//
+// so `template-research-translation-loop` never renders in the all-templates
+// sidebar and the 10s wait at the top of the body cannot pass. Deterministic:
+// 3/3 attempts on the 2026-08-03 daily (run 30809091241) and again on the
+// 2026-08-04 PR lane, plus a control run at `origin/main` on 1.12.0.dev15.
+// `@stable` was already auto-removed by the workflow (`32ac9a1`); `test.fixme`
+// is added here because the impacted-specs gate selects by import graph, not by
+// tag (#871/#1054), so tag removal alone left this reddening every PR that
+// touches a helper it imports — it did exactly that to #1279.
+//
+// Lifting the quarantine (remove test.fixme + restore @stable) is a deliverable
+// of #1234, and gated on the component returning to the image — not on a
+// test-side change here.
+test.fixme(
   "Loop component — Research Translation Loop template: full wiring and iterates over 2 ArXiv papers",
   { tag: ["@release", "@components", "@templates", "@playground"] },
   async ({ page }) => {


### PR DESCRIPTION
**Related to #1234** — this quarantines, it does **not** fix. #1234 stays open.

## Problem

`core-components/loop-component-regression.spec.ts:152` ("Research Translation Loop template: full wiring and iterates over 2 ArXiv papers") cannot pass on the current nightly: the template it loads is not in the image. The backend refuses to register it at startup —

```
[warning] Skipping starter project 'Research Translation Loop'; unavailable components: ArXivComponent
```

— so `[data-testid="template-research-translation-loop"]` never renders in the all-templates sidebar and the 10 s wait at the top of the body times out.

Deterministic, not a flake:

| Where | Result |
|---|---|
| 2026-08-03 daily (run 30809091241) | 3/3 attempts, same locator (#1234) |
| 2026-08-04 PR lane of #1279 | 3/3 attempts, same locator |
| Control run on `origin/main` @ `b2b3221`, nightly 1.12.0.dev15 | reproduces in 14.3 s, same locator |

## Fix

`test.fixme` on that one test, with the cause and the lift condition recorded in the body comment. `@stable` was already auto-removed by the workflow (`32ac9a1`).

Why the tag removal was not enough: the impacted-specs gate selects by **import graph**, not by tag (#871/#1054). Tag removal keeps the spec out of `daily-stable.yml` but leaves it running — and failing — on every PR that touches a helper it imports. It did exactly that to #1279, a page-entry-barrier change with nothing to do with templates, where it was the lane's only failure (1 failed / 68 passed).

Lifting the quarantine (remove `test.fixme`, restore `@stable`) is a deliverable of #1234 and is gated on `ArXivComponent` returning to the image — not on a test-side change here.

## Scope note

One `test(` → `test.fixme(` plus its comment. No assertion, helper, tag or doc change; the other three tests in the file are untouched and still `@stable`. Per `CONTRIBUTING.md`, a temporary removal is tracked by the GitHub issue, so no spec-doc edit is required.

## Validation (nightly 1.12.0.dev15, `--retries=0`, `--workers=1`)

- `loop-component-regression.spec.ts` full file: **3 passed, 1 skipped** (30.5 s) — the quarantined test is skipped, the other three still pass
- `npm run typecheck` ✅ (0 errors) · `npm run lint` ✅ (0 errors)
- `npm run check:checklist-coverage` ✅ · `scripts/check-checklist-guard.mjs` ✅ (no generated block edited)
- No force-fail applies: nothing asserted changed, and the quarantined body is unreachable by design. The failure it replaces is itself the evidence — reproduced 3× in CI and once on a clean `origin/main` control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
