### PR TITLE
test(core-components): cover Human Input node configuration (#1190)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -273,7 +273,7 @@
 - [ ] `max_iterations` + `default_route` cycle break (not implementable as a standalone If-Else feedback loop on 1.12.x — Langflow forms graph cycles only via loop-aware target handles (`from_loop_target_handle`, `target_handle.type is None`) that `LoopComponent` ports provide; a feedback edge into the router's regular `match_text` field-input persists in the flow JSON but does not make the graph iterate (`is_cyclic` stays false, router runs once). `conditional_router.py`'s cycle-break only fires when the router already sits inside a Loop-created cycle. Confirmed live on 1.12.0.dev3; product finding filed upstream; #891, follow-up of #822)
 
 #### 3.9 Human Input (HITL, 1.11.0)
-- [ ] Human Input node config: default Approve/Reject branch handles, custom User Action creates a new handle, configured handles persist after save + reload → `core-components/human-input-node-config.spec.ts`
+- [x] Human Input node config: default Approve/Reject branch handles, custom User Action creates a new handle, configured handles persist after save + reload → `core-components/human-input-node-config.spec.ts`
 
 #### 3.10 Data Operations (1.11.0)
 - [ ] Data Operations component: unified JSON/Table/Text operations produce correct outputs per operation mode → `core-components/data-operations-component.spec.ts`

--- a/docs/core-components/human-input-node-config.md
+++ b/docs/core-components/human-input-node-config.md
@@ -13,15 +13,27 @@ Confirms the **configuration surface** of the `Human Input` node shipped with La
 derived from its `User Choices` field**, one handle per choice, and that derivation
 holds on three occasions.
 
-1. **On add** — a freshly dragged node already renders the two default branch handles
-   (`Approve`, `Reject`), before any field is touched. Upstream relies on a hardcoded
-   `outputs` list for exactly this case, because `update_outputs()` only fires on a
-   field change (`lfx/components/flow_controls/human_input.py`).
+1. **On add** — a freshly added node presents **exactly** the two default branch handles
+   (`Approve`, `Reject`), before any field is touched: both present, and no third branch
+   nobody asked for.
+   **Scope caveat, measured rather than assumed:** this does *not* isolate the hardcoded
+   `outputs` list in `lfx/components/flow_controls/human_input.py`. That list carries the
+   comment *"update_outputs only fires on a field change"*, but the frontend fires
+   `POST /api/v1/custom_component/update` **on mount** for any `real_time_refresh` field
+   whose `options` are empty (`hooks/use-fetch-data-on-mount.ts`), and `decisions` is such
+   a field — so the handles would be rebuilt on add even with that list removed. Isolating
+   the fallback needs a different oracle (delay that response with `page.route` and assert
+   the handles are already there); out of scope here.
 2. **On change (live)** — adding a custom choice creates its branch handle **without a
    reload**: the `real_time_refresh` field round-trips through
    `POST /api/v1/custom_component/update` and the node re-renders with the new handle.
-3. **After save + reload** — the configured choices and their handles survive a full
-   page load, rebuilt from the persisted `decisions` by `update_frontend_node()`.
+3. **After save + reload** — the configured choices and their handles survive a full page
+   load. **Two** mechanisms can rebuild them — `update_frontend_node()` on the backend and
+   the frontend's own on-mount round trip — so the spec asserts the **observable** (the
+   handles are there after the reload) without attributing it to either. What it does pin
+   is that the reload actually happened: a `window` sentinel set before it must be gone
+   after, because every DOM assertion in that step is *also* satisfied by the pre-reload
+   page, so a silently-cancelled navigation would otherwise pass it.
 
 The custom choice is deliberately a **two-word label** (`Request Changes`), because the
 label→handle mapping is where the two ends of this feature have to agree: the backend
@@ -95,10 +107,13 @@ is first-time coverage of a new feature, not a previously fixed bug.
    are exactly `["branch_approve", "branch_reject", "branch_request_changes"]` — this is
    also the assertion that the `Request Changes` → `branch_request_changes` slug survived
    the round trip.
-3. `page.reload()`. No `page.on("dialog")` handler is registered anywhere in the spec, on
-   purpose: `FlowPage` installs a `beforeunload` that `preventDefault()`s while the store
-   is dirty, and Playwright's default ACCEPTS a `beforeunload` dialog — registering a
-   handler would silently cancel the reload (documented in
+3. Set a `window.__reloadSentinel` marker, then `page.reload()`, then assert the marker is
+   **gone** — the proof that the navigation happened. Every DOM assertion in step 4 is also
+   satisfied by the pre-reload page, so without this a reload that never occurred would
+   pass the whole step. No `page.on("dialog")` handler is registered anywhere in the spec,
+   on purpose: `FlowPage` installs a `beforeunload` that `preventDefault()`s while the
+   store is dirty, and Playwright's default ACCEPTS a `beforeunload` dialog — registering a
+   handler would cancel the reload (documented in
    `helpers/flows/leave-flow-editor.ts`).
 4. Assert the rehydrated node renders all three chips (`action-edit-Approve`,
    `action-edit-Reject`, `action-edit-Request Changes`) and all three branch handles, with
@@ -117,7 +132,7 @@ is first-time coverage of a new feature, not a previously fixed bug.
 |---|---|
 | Human Input renders the default Approve and Reject branch handles when added to the canvas | `handle-humaninput-shownode-approve-right` **and** `handle-humaninput-shownode-reject-right` visible, with the node's output-handle count exactly `2` |
 | adding a custom User Action creates its branch handle without a reload | after committing `Request Changes` in `action-add-input`, `handle-humaninput-shownode-request changes-right` becomes visible on the same page and the output-handle count goes `2` → `3` |
-| the configured branch handles persist after save and reload | `GET /api/v1/flows/{id}` reports the node's `outputs` names as exactly `branch_approve, branch_reject, branch_request_changes`, and after `page.reload()` the three chips and three handles render again |
+| the configured branch handles persist after save and reload | `GET /api/v1/flows/{id}` reports the node's `outputs` names as exactly `branch_approve, branch_reject, branch_request_changes`; the `window.__reloadSentinel` marker is gone after `page.reload()` (the navigation really happened); and the three chips and three handles render again |
 
 ---
 

--- a/docs/core-components/human-input-node-config.md
+++ b/docs/core-components/human-input-node-config.md
@@ -1,0 +1,177 @@
+# Spec: Human Input node configuration (HITL branch handles)
+
+**Test file:** `tests/tests-automations/regression/core-components/human-input-node-config.spec.ts`
+
+**Last validated:** Langflow 1.12.x (scouted on `1.12.0.dev10`)
+
+---
+
+## What this test validates
+
+Confirms the **configuration surface** of the `Human Input` node shipped with Langflow
+1.11.0 (upstream `langflow-ai/langflow#13633`, LE-1449): the node's **branch outputs are
+derived from its `User Choices` field**, one handle per choice, and that derivation
+holds on three occasions.
+
+1. **On add** — a freshly dragged node already renders the two default branch handles
+   (`Approve`, `Reject`), before any field is touched. Upstream relies on a hardcoded
+   `outputs` list for exactly this case, because `update_outputs()` only fires on a
+   field change (`lfx/components/flow_controls/human_input.py`).
+2. **On change (live)** — adding a custom choice creates its branch handle **without a
+   reload**: the `real_time_refresh` field round-trips through
+   `POST /api/v1/custom_component/update` and the node re-renders with the new handle.
+3. **After save + reload** — the configured choices and their handles survive a full
+   page load, rebuilt from the persisted `decisions` by `update_frontend_node()`.
+
+The custom choice is deliberately a **two-word label** (`Request Changes`), because the
+label→handle mapping is where the two ends of this feature have to agree: the backend
+slugifies it (`_action_id()`: lowercase, spaces → underscores) into the output **name**
+`branch_request_changes`, while the frontend derives the handle **testid** from the
+display name (`handle-humaninput-shownode-request changes-right`) and its own
+`toActionId()` mirror decides whether an existing edge still belongs to the renamed
+choice. A one-word label would pass even if one side dropped its normalisation.
+
+**Execution is out of scope** — pausing a run, the decision card and branch routing are
+covered separately (issue #1189 → `core-functionality/playground/human-input-pause-resume.spec.ts`).
+This spec never runs the flow, so it needs **no LLM provider**.
+
+---
+
+## Tags
+
+`@stable` `@components` `@ui-ux` — plus `@database` on the persistence test, which
+asserts state read back from the flows API after a reload.
+
+No functional tag maps to HITL today; `@ui-ux` is used because every assertion here is
+made against the node's configuration UI. `@regression` is deliberately **absent**: this
+is first-time coverage of a new feature, not a previously fixed bug.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` (validated on the nightly, `1.12.0.dev10`).
+- No provider credentials, no `models.json`, no `--workers=1` — nothing here is
+  model-dependent.
+- The `Human Input` component must be present in the sidebar under **Flow Control**
+  (`add-component-button-human-input`). It is non-legacy and non-beta on 1.12.x, so no
+  sidebar toggle is required.
+
+---
+
+## Step by step
+
+**beforeEach (all tests)**
+1. `setupBlankFlow(page)` — create a blank flow through the REST API and open it via the
+   dashboard card (avoids the UI-creation race); keep the returned id for cleanup.
+2. Assert `sidebar-search-input` is visible (the editor is interactive).
+
+**Test 1 — default branch handles on add**
+1. `addComponentFromSidebar(page, "Human Input", "add-component-button-human-input")`.
+2. Assert `title-Human Input` is visible and `.react-flow__node` has count `1`.
+3. Assert the two default choice chips are rendered: `action-edit-Approve`,
+   `action-edit-Reject`.
+4. Assert both branch handles are visible: `handle-humaninput-shownode-approve-right`,
+   `handle-humaninput-shownode-reject-right`.
+5. Assert the node has **exactly two** output handles — every
+   `[data-testid^="handle-humaninput-shownode-"][data-testid$="-right"]` inside the node,
+   count `2` (so a third, unexpected branch fails the test too).
+
+**Test 2 — a custom User Action creates its handle live**
+1. Add the node (steps 1–2 above) and assert the output-handle count baseline is `2`.
+2. Click `actionpicker-add-decisions` (the `+` next to **User Choices**) and assert the
+   inline input `action-add-input` is visible.
+3. Fill it with `Request Changes` and press `Enter`.
+4. Assert, **on the same page — no reload, no navigation** — that
+   `handle-humaninput-shownode-request changes-right` becomes visible, and that the chip
+   `action-edit-Request Changes` is rendered.
+5. Assert the output-handle count is now `3`, and that the two defaults are still there
+   (adding a choice adds a branch; it does not replace the existing ones).
+
+**Test 3 — configured handles persist after save + reload**
+1. Add the node and the `Request Changes` choice (Test 2's steps 1–3).
+2. Gate on **server truth**, not on network silence: poll `GET /api/v1/flows/{id}`
+   (Bearer from `getAuthToken`) until the persisted `Human Input` node's `outputs` names
+   are exactly `["branch_approve", "branch_reject", "branch_request_changes"]` — this is
+   also the assertion that the `Request Changes` → `branch_request_changes` slug survived
+   the round trip.
+3. `page.reload()`. No `page.on("dialog")` handler is registered anywhere in the spec, on
+   purpose: `FlowPage` installs a `beforeunload` that `preventDefault()`s while the store
+   is dirty, and Playwright's default ACCEPTS a `beforeunload` dialog — registering a
+   handler would silently cancel the reload (documented in
+   `helpers/flows/leave-flow-editor.ts`).
+4. Assert the rehydrated node renders all three chips (`action-edit-Approve`,
+   `action-edit-Reject`, `action-edit-Request Changes`) and all three branch handles, with
+   the output-handle count back at `3`.
+
+**afterEach (all tests)**
+1. `page.goto("/")` to unmount the editor (an editor left mounted over a deleted flow
+   404s its `GET /flows/{id}/events` poll, which the fixture logs as a backend error),
+   then `deleteFlow(page.request, flowId)`.
+
+---
+
+## Validation criterion
+
+| Test | Criterion |
+|---|---|
+| Human Input renders the default Approve and Reject branch handles when added to the canvas | `handle-humaninput-shownode-approve-right` **and** `handle-humaninput-shownode-reject-right` visible, with the node's output-handle count exactly `2` |
+| adding a custom User Action creates its branch handle without a reload | after committing `Request Changes` in `action-add-input`, `handle-humaninput-shownode-request changes-right` becomes visible on the same page and the output-handle count goes `2` → `3` |
+| the configured branch handles persist after save and reload | `GET /api/v1/flows/{id}` reports the node's `outputs` names as exactly `branch_approve, branch_reject, branch_request_changes`, and after `page.reload()` the three chips and three handles render again |
+
+---
+
+## External dependencies
+
+- **Sidebar add affordance** — `sidebar-search-input` + `add-component-button-human-input`
+  (component `HumanInput`, category `flow_controls`, display name `Human Input`).
+- **Node markers** — `title-Human Input`, `.react-flow__node` for scoping and counting.
+- **`User Choices` field (`decisions`)** — an `ActionPickerInput` rendered by
+  `components/core/parameterRenderComponent/components/actionPickerComponent`: `+` button
+  `actionpicker-add-decisions`, inline input `action-add-input` (commits on `Enter` or
+  blur, rejects a duplicate with an error toast), chip buttons `action-edit-<label>` /
+  `action-remove-<label>` (the label verbatim, **not** slugified).
+- **Branch handles** — `handle-{component}-shownode-{output display name lowercased}-{side}`,
+  from `CustomNodes/GenericNode/components/handleRenderComponent`. `group_outputs: true`
+  on every Human Input output is what makes each branch render its **own** handle instead
+  of the single selectable output most components show (`NodeOutputParameter/NodeOutputs.tsx`).
+- **`POST /api/v1/custom_component/update`** — the round trip behind the live rebuild
+  (`real_time_refresh` on `decisions`). Not asserted directly: the DOM assertion is the
+  user-visible outcome, and pinning the endpoint would couple the spec to a refresh
+  mechanism upstream may change.
+- **`GET /api/v1/flows/{id}`** with a Bearer token (`helpers/auth/get-auth-token.ts`) —
+  the persistence oracle.
+- **Helpers** — `helpers/flows/setup-blank-flow.ts`,
+  `helpers/flows/add-component-from-sidebar.ts`, `helpers/flows/delete-flow.ts`.
+
+---
+
+## What this test does not cover
+
+- **Running the flow** — the pause/resume, the decision card and exclusive branch routing
+  belong to #1189 (`human-input-pause-resume.spec.ts`).
+- **Removing or renaming a choice** — `action-remove-<label>` / `action-edit-<label>`
+  dropping or renaming a branch handle (and the "connection removed" notice when the
+  renamed branch had an edge) is adjacent behaviour, deliberately left out of this
+  issue's scope.
+- **The duplicate-choice guard** — committing a label that already exists surfaces an
+  error toast and no new branch.
+- **`Enable Fallback`** — the advanced toggle that adds a `Fallback` branch and reveals
+  the `Timeout` field.
+- **Edge wiring** — connecting a branch handle to a downstream node, and what happens to
+  that edge when its choice is renamed or removed.
+
+---
+
+## Notes
+
+- Everything above was scouted against the running nightly (`1.12.0.dev10`) before the
+  spec was written: the node's testids were harvested from the live DOM, and the
+  persisted shape (`decisions: ["Approve","Reject","Request Changes"]` →
+  `outputs: branch_approve, branch_reject, branch_request_changes`) was read back from
+  `GET /api/v1/flows/{id}`.
+- The three tests each build their own flow rather than sharing one in a serial describe:
+  the setup is cheap (no LLM, no build), and independent tests keep a failure in the live
+  rebuild from masking the persistence check.
+- Sibling reference for shape: `core-components/singleton-components.spec.ts` (blank flow
+  + sidebar add + node assertions + id-scoped cleanup).

--- a/tests/tests-automations/regression/core-components/human-input-node-config.spec.ts
+++ b/tests/tests-automations/regression/core-components/human-input-node-config.spec.ts
@@ -38,7 +38,10 @@ const HUMAN_INPUT = {
 const CUSTOM_CHOICE = "Request Changes";
 const CUSTOM_CHOICE_OUTPUT = "branch_request_changes";
 
-// Branch handles, in the order the node renders them.
+// Branch handles, in the order the node renders them. `CUSTOM_HANDLE` is spelled
+// out rather than derived from `CUSTOM_CHOICE.toLowerCase()` on purpose: the
+// frontend lowercases the display name to build the testid, and deriving it the
+// same way would make the assertion agree with itself no matter what the app did.
 const APPROVE_HANDLE = "handle-humaninput-shownode-approve-right";
 const REJECT_HANDLE = "handle-humaninput-shownode-reject-right";
 const CUSTOM_HANDLE = "handle-humaninput-shownode-request changes-right";
@@ -104,13 +107,22 @@ async function expectPersistedOutputs(
   flowId: string,
   expected: string[],
 ) {
+  // `getAuthToken` resolves to "" on an environment without auth (it throws only
+  // when the backend never answers), and an empty `Authorization` header is not
+  // the same as no header — it would override the browser context's own auth and
+  // turn this poll into a 401 loop that reports as "the outputs never persisted".
+  // Same guard the repo's own helpers use (`setup-blank-flow.ts`).
   const authToken = await getAuthToken(page.request);
+  const authOptions = authToken
+    ? { headers: { Authorization: authToken } }
+    : undefined;
   await expect
     .poll(
       async () => {
-        const res = await page.request.get(`/api/v1/flows/${flowId}`, {
-          headers: { Authorization: authToken },
-        });
+        const res = await page.request.get(
+          `/api/v1/flows/${flowId}`,
+          authOptions,
+        );
         if (!res.ok()) return `GET /api/v1/flows/${flowId} → ${res.status()}`;
         const body = await res.json();
         const node = (body?.data?.nodes ?? []).find(
@@ -227,7 +239,27 @@ test.describe("Human Input node configuration (HITL branch handles)", () => {
         // store is dirty, and Playwright ACCEPTS a beforeunload dialog only while
         // no handler is registered — one here would cancel this reload
         // (see `helpers/flows/leave-flow-editor.ts`).
+        //
+        // The sentinel is what makes the reload load-bearing rather than
+        // decorative: every assertion below is ALSO satisfied by the pre-reload
+        // DOM, so a navigation that silently did not happen would pass all of
+        // them (reproduced in review by dismissing that dialog). A `window`
+        // property cannot survive a document load, so its absence is proof the
+        // page really reloaded — without it this step asserts nothing about
+        // rehydration.
+        await page.evaluate(() => {
+          (window as Window & { __reloadSentinel?: true }).__reloadSentinel =
+            true;
+        });
+
         await page.reload();
+
+        expect(
+          await page.evaluate(
+            () =>
+              (window as Window & { __reloadSentinel?: true }).__reloadSentinel,
+          ),
+        ).toBeUndefined();
 
         await expect(page.getByTestId(HUMAN_INPUT.title)).toBeVisible({
           timeout: 30000,

--- a/tests/tests-automations/regression/core-components/human-input-node-config.spec.ts
+++ b/tests/tests-automations/regression/core-components/human-input-node-config.spec.ts
@@ -1,0 +1,250 @@
+/**
+ * Human Input node configuration — branch handles derived from `User Choices`.
+ *
+ * Covers the configuration surface of the HITL node shipped in Langflow 1.11.0
+ * (upstream #13633 / LE-1449): its branch outputs come from the `decisions`
+ * field, one handle per choice, and that derivation must hold when the node is
+ * added, when a choice is added live, and after a save + reload.
+ *
+ * Sibling coverage — do not duplicate here:
+ * - Running the flow (pause, decision card, exclusive branch routing) belongs to
+ *   `core-functionality/playground/human-input-pause-resume.spec.ts` (issue #1189).
+ * - Removing/renaming a choice, the duplicate-choice guard and `Enable Fallback`
+ *   are listed as out of scope in the spec doc.
+ *
+ * Spec doc: `docs/core-components/human-input-node-config.md`. No provider
+ * credentials are needed — nothing here runs the flow.
+ */
+
+import type { Locator, Page } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
+import { addComponentFromSidebar } from "../../../helpers/flows/add-component-from-sidebar";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+
+// Sidebar search term + add button for the component under test, kept together
+// so a testid can't drift from the term that filters it into view.
+const HUMAN_INPUT = {
+  searchTerm: "Human Input",
+  addButton: "add-component-button-human-input",
+  title: "title-Human Input",
+};
+
+// A deliberately TWO-WORD custom choice: the backend slugifies it into the
+// output name (`_action_id`: lowercase, spaces → underscores) while the frontend
+// builds the handle testid from the display name. A one-word label would pass
+// even if one of the two sides dropped its normalisation.
+const CUSTOM_CHOICE = "Request Changes";
+const CUSTOM_CHOICE_OUTPUT = "branch_request_changes";
+
+// Branch handles, in the order the node renders them.
+const APPROVE_HANDLE = "handle-humaninput-shownode-approve-right";
+const REJECT_HANDLE = "handle-humaninput-shownode-reject-right";
+const CUSTOM_HANDLE = "handle-humaninput-shownode-request changes-right";
+
+// Output names the persisted flow must carry once the custom choice is added.
+const PERSISTED_OUTPUTS = ["branch_approve", "branch_reject", CUSTOM_CHOICE_OUTPUT];
+
+/** The Human Input node on the canvas. */
+const humanInputNode = (page: Page): Locator =>
+  page.locator('.react-flow__node:has([data-testid="title-Human Input"])');
+
+/**
+ * Every branch (output) handle of the Human Input node.
+ *
+ * `handle-` and not `div-handle-`: each handle renders both, and only the
+ * prefixed form is the interactive element. `-right` excludes the node's single
+ * input handle (`…-input-left`). Counting these is what makes an unexpected
+ * extra or missing branch fail, instead of only asserting the ones we expect.
+ */
+const branchHandles = (page: Page): Locator =>
+  humanInputNode(page).locator(
+    '[data-testid^="handle-humaninput-shownode-"][data-testid$="-right"]',
+  );
+
+/** Add the Human Input node via the sidebar and confirm it landed. */
+async function addHumanInputNode(page: Page) {
+  await addComponentFromSidebar(
+    page,
+    HUMAN_INPUT.searchTerm,
+    HUMAN_INPUT.addButton,
+  );
+  await expect(page.getByTestId(HUMAN_INPUT.title)).toBeVisible({
+    timeout: 15000,
+  });
+  await expect(page.locator(".react-flow__node")).toHaveCount(1);
+}
+
+/**
+ * Add a custom entry to `User Choices`.
+ *
+ * The `+` reveals an inline input that commits on `Enter` (or blur) — see
+ * `actionPickerComponent`. The input is asserted visible first: typing into the
+ * canvas without confirmed focus lands as a hotkey.
+ */
+async function addCustomChoice(page: Page, label: string) {
+  await page.getByTestId("actionpicker-add-decisions").click();
+  const input = page.getByTestId("action-add-input");
+  await expect(input).toBeVisible({ timeout: 10000 });
+  await input.fill(label);
+  await input.press("Enter");
+}
+
+/**
+ * Poll the flows API until the persisted Human Input node carries `expected` as
+ * its output names.
+ *
+ * Server truth rather than `waitForFlowSaveSettled`: that helper resolves on
+ * network silence, which also happens when the debounced PATCH has not fired yet
+ * (#518). Returns nothing — the assertion IS the poll.
+ */
+async function expectPersistedOutputs(
+  page: Page,
+  flowId: string,
+  expected: string[],
+) {
+  const authToken = await getAuthToken(page.request);
+  await expect
+    .poll(
+      async () => {
+        const res = await page.request.get(`/api/v1/flows/${flowId}`, {
+          headers: { Authorization: authToken },
+        });
+        if (!res.ok()) return `GET /api/v1/flows/${flowId} → ${res.status()}`;
+        const body = await res.json();
+        const node = (body?.data?.nodes ?? []).find(
+          (n: { data?: { type?: string } }) => n?.data?.type === "HumanInput",
+        );
+        if (!node) return "no HumanInput node in the persisted flow";
+        return (node.data?.node?.outputs ?? []).map(
+          (o: { name: string }) => o.name,
+        );
+      },
+      { timeout: 30000, intervals: [500, 1000, 2000] },
+    )
+    .toEqual(expected);
+}
+
+test.describe("Human Input node configuration (HITL branch handles)", () => {
+  let createdFlowId: string | null = null;
+
+  test.beforeEach(async ({ page }) => {
+    // Creates the flow via API (avoids the UI-creation 500 race) and returns its
+    // id so afterEach can delete exactly that one.
+    createdFlowId = await setupBlankFlow(page);
+    await expect(page.getByTestId("sidebar-search-input")).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (createdFlowId) {
+      // Leave the editor first: an editor left mounted over a deleted flow 404s
+      // its `GET /flows/{id}/events` poll, which the fixture logs as a backend
+      // error.
+      await page.goto("/").catch(() => {});
+      await deleteFlow(page.request, createdFlowId);
+      createdFlowId = null;
+    }
+  });
+
+  test("Human Input renders the default Approve and Reject branch handles when added to the canvas",
+    { tag: ["@stable", "@components", "@ui-ux"] },
+    async ({ page }) => {
+      await test.step("Add a Human Input node to the canvas", async () => {
+        await addHumanInputNode(page);
+      });
+
+      await test.step("The default User Choices are Approve and Reject", async () => {
+        await expect(page.getByTestId("action-edit-Approve")).toBeVisible();
+        await expect(page.getByTestId("action-edit-Reject")).toBeVisible();
+      });
+
+      await test.step("Each default choice renders its own branch handle, and there are no others", async () => {
+        await expect(page.getByTestId(APPROVE_HANDLE)).toBeVisible({
+          timeout: 15000,
+        });
+        await expect(page.getByTestId(REJECT_HANDLE)).toBeVisible();
+        // Exactly two: `group_outputs` gives every branch its own handle, so a
+        // third one here would mean the node derived a branch we never asked for.
+        await expect(branchHandles(page)).toHaveCount(2);
+      });
+    },
+  );
+
+  test("adding a custom User Action creates its branch handle without a reload",
+    { tag: ["@stable", "@components", "@ui-ux"] },
+    async ({ page }) => {
+      await test.step("Add a Human Input node with its two default branches", async () => {
+        await addHumanInputNode(page);
+        await expect(branchHandles(page)).toHaveCount(2);
+      });
+
+      await test.step(`Add "${CUSTOM_CHOICE}" to User Choices`, async () => {
+        await addCustomChoice(page, CUSTOM_CHOICE);
+        await expect(
+          page.getByTestId(`action-edit-${CUSTOM_CHOICE}`),
+        ).toBeVisible({ timeout: 15000 });
+      });
+
+      await test.step("Its branch handle appears on the same page, with the defaults intact", async () => {
+        // No reload and no navigation between the commit above and this
+        // assertion: the node rebuilds its outputs live, through the
+        // `real_time_refresh` round trip on `decisions`.
+        await expect(page.getByTestId(CUSTOM_HANDLE)).toBeVisible({
+          timeout: 15000,
+        });
+        await expect(page.getByTestId(APPROVE_HANDLE)).toBeVisible();
+        await expect(page.getByTestId(REJECT_HANDLE)).toBeVisible();
+        await expect(branchHandles(page)).toHaveCount(3);
+      });
+    },
+  );
+
+  test("the configured branch handles persist after save and reload",
+    { tag: ["@stable", "@components", "@database", "@ui-ux"] },
+    async ({ page }) => {
+      const flowId = createdFlowId as string;
+
+      await test.step(`Add a Human Input node and a "${CUSTOM_CHOICE}" choice`, async () => {
+        await addHumanInputNode(page);
+        await addCustomChoice(page, CUSTOM_CHOICE);
+        await expect(page.getByTestId(CUSTOM_HANDLE)).toBeVisible({
+          timeout: 15000,
+        });
+      });
+
+      await test.step("The persisted flow carries one branch output per choice", async () => {
+        // Also the assertion that the label survived the round trip as a slug:
+        // "Request Changes" → `branch_request_changes`.
+        await expectPersistedOutputs(page, flowId, PERSISTED_OUTPUTS);
+      });
+
+      await test.step("A full page reload rebuilds all three choices and handles", async () => {
+        // No `page.on("dialog")` handler anywhere in this spec, on purpose:
+        // `FlowPage` installs a `beforeunload` that `preventDefault()`s while the
+        // store is dirty, and Playwright ACCEPTS a beforeunload dialog only while
+        // no handler is registered — one here would cancel this reload
+        // (see `helpers/flows/leave-flow-editor.ts`).
+        await page.reload();
+
+        await expect(page.getByTestId(HUMAN_INPUT.title)).toBeVisible({
+          timeout: 30000,
+        });
+        await expect(page.getByTestId("action-edit-Approve")).toBeVisible({
+          timeout: 15000,
+        });
+        await expect(page.getByTestId("action-edit-Reject")).toBeVisible();
+        await expect(
+          page.getByTestId(`action-edit-${CUSTOM_CHOICE}`),
+        ).toBeVisible();
+
+        await expect(page.getByTestId(APPROVE_HANDLE)).toBeVisible();
+        await expect(page.getByTestId(REJECT_HANDLE)).toBeVisible();
+        await expect(page.getByTestId(CUSTOM_HANDLE)).toBeVisible();
+        await expect(branchHandles(page)).toHaveCount(3);
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #1190.

Closes the `[ ]` gap in `QA-CHECKLIST.md` §3.9 — first coverage of the **Human Input**
node (HITL, Langflow 1.11.0 — upstream langflow-ai/langflow#13633 / LE-1449). This is the
node's **configuration** surface only: its branch outputs are derived from the
`User Choices` field, and the spec pins that derivation on add, on live change, and after
a reload. Running the flow — pausing, the decision card, exclusive branch routing — is
#1189 (`core-functionality/playground/human-input-pause-resume.spec.ts`) and is
deliberately absent here, which is why this spec needs no provider credentials.

## 1. Covered tests

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `Human Input renders the default Approve and Reject branch handles when added to the canvas` | A freshly added node already exposes both branch handles (`handle-humaninput-shownode-approve-right`, `…-reject-right`) and the `Approve`/`Reject` chips, with the node's output-handle count **exactly 2**. Catches a regression in the hardcoded `outputs` list a dragged node depends on — `update_outputs()` only fires on a field change, so a node whose handles appeared only after touching a field would fail here. |
| 2 | `adding a custom User Action creates its branch handle without a reload` | Committing `Request Changes` in `action-add-input` makes `handle-humaninput-shownode-request changes-right` appear **on the same page, with no reload or navigation**, the two defaults intact, count 2 → 3. Catches a break in the `real_time_refresh` rebuild (the `POST /api/v1/custom_component/update` round trip) — the failure mode where the handle only shows up after a reload. |
| 3 | `the configured branch handles persist after save and reload` | `GET /api/v1/flows/{id}` reports the node's outputs as exactly `branch_approve, branch_reject, branch_request_changes` — which is also the assertion that the label survived as a slug — and after `page.reload()` all three chips and handles render again, count 3. Catches a break in `update_frontend_node()`, which rebuilds the outputs from the persisted `decisions` on load. |

## 2. How the test was built

- **Setup**: `setupBlankFlow(page)` (flow created via the REST API, opened through the
  dashboard card) and id-scoped cleanup in `afterEach` — `page.goto("/")` to unmount the
  editor first, then `deleteFlow`. Verified flow-neutral: the instance's user-flow count
  was identical before and after the runs (the ~16 flows the burst and the force-fail runs
  created were all deleted, including on the runs that failed on purpose).
- **Live-confirmed selectors** — every testid harvested from the running nightly's DOM
  (`1.12.0.dev10`), none inferred: `add-component-button-human-input`,
  `title-Human Input`, `actionpicker-add-decisions`, `action-add-input`,
  `action-edit-<label>`, `handle-humaninput-shownode-{approve,reject,request changes}-right`.
  Two names in the issue body did not survive the scout and are corrected here: the field
  is **`User Choices`** (`decisions`), not "User Action", and `action-add-input` is the
  inline input the `+` reveals, not the button itself.
- **A two-word custom label is the point.** The label→handle mapping is where the two ends
  of the feature must agree: the backend slugifies it (`_action_id()`: lowercase, spaces →
  underscores) into `branch_request_changes`, while the frontend derives the handle testid
  from the display name and its own `toActionId()` mirror decides whether an existing edge
  still belongs to a renamed choice. A one-word label would pass even if one side dropped
  its normalisation.
- **Counting the handles, not just asserting the expected ones.** `group_outputs: true`
  gives every branch its own handle, so `toHaveCount(2|3)` over
  `[data-testid^="handle-humaninput-shownode-"][data-testid$="-right"]` fails on an extra
  branch as well as a missing one. `-right` excludes the node's single input handle;
  `handle-` excludes the `div-handle-` twin each handle also renders.
- **Persistence is gated on server truth**, not on network silence: `expect.poll` over
  `GET /api/v1/flows/{id}` until the outputs match. `waitForFlowSaveSettled` resolves on
  700 ms of quiet, which also holds while the debounced PATCH has not fired yet (#518).
- **No `page.on("dialog")` handler**, on purpose and commented as such: `FlowPage`
  installs a `beforeunload` that `preventDefault()`s while the store is dirty, and
  Playwright accepts that dialog only while no handler is registered — one here would
  silently cancel the reload the third test depends on (documented in
  `helpers/flows/leave-flow-editor.ts`).
- **Tags**: `@stable @components @ui-ux`, plus `@database` on the persistence test.
  `@regression` is absent deliberately — this is first-time coverage of a new feature, not
  a previously fixed bug. No functional tag maps to HITL today; `@ui-ux` is used because
  every assertion is made against the node's configuration UI.

## 3. Dependencies

- **None — pure UI + REST.** No LLM, no provider key, no `models.json`, no
  `collect-models`. The flow is never run.
- **Parallel-safe**: each test builds its own flow, no named-flow collision, no shared
  state. No `--workers=1` requirement.

## Validation (nightly `1.12.0.dev10`, `--retries=0 --workers=1`)

- `npm run typecheck` ✅ · `npx eslint <spec>` ✅ (both re-run after rebasing onto
  `origin/main`)
- **3 clean burst runs**, `expected=3 unexpected=0 flaky=0` each, plus a green run after
  the force-fail reverts ✅
- Zero `🚨 Backend Error` on every run ✅
- **Force-fail, executed — one per test, all observed red:**
  - Test 1 — branch-handle count `2 → 3`: proves the count is measured from the live DOM.
  - Test 2 — commit the choice as one word (`RequestChanges`) while the asserts still
    expect `Request Changes`: proves the chip and handle testids derive from the label
    typed, i.e. the label→handle coupling is what is being tested.
  - Test 3 (a) — persistence oracle expecting only `[branch_approve, branch_reject]`:
    proves the poll compares against live API state and is not vacuous.
  - Test 3 (b) — post-reload count `3 → 4`: proves the assertions after `page.reload()`
    are re-read from the rehydrated node, so a reload that dropped a handle fails here.
  - Reverts proven: `grep -c FF-MUTATION` = 0, plus the final green run above.
- `--trace=on` **not** run locally — the known local tracing hang (documented for the
  template family and reproduced on a plain blank-flow spec, #518). Step verification
  rests on the `--retries=0` bursts, the four executed force-fails and the live scout
  instead; CI still captures a trace on first retry.
- **Validation-environment gap, stated rather than papered over**: the local instance is
  `1.12.0.dev10` and the newest nightly tag is `1.12.0.dev15`. `human_input.py` has no
  upstream commit since 2026-07-15 (local Langflow clone at 2026-07-30), and this PR's own
  impacted-specs lane runs the spec against a fresh nightly service container — that lane
  is the cross-check for the 5-build gap.
