### PR TITLE
test(playground): cover Human Input pause/resume in the Playground (#1189)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -544,7 +544,8 @@
 - [x] DataFrame output renders as Markdown table → `core-functionality/playground/playground-output-data.spec.ts`
 
 #### 9.6 Human-in-the-Loop (1.11.0)
-- [x] Human Input pauses the run durably, decision card renders in the Playground, Approve routes only the approved branch and the run completes; Reject routes only the reject branch → `core-functionality/playground/human-input-pause-resume.spec.ts`
+- [x] Human Input suspends the run server-side, decision card renders in the Playground, Approve routes only the approved branch and the run leaves the suspended state; Reject routes only the reject branch → `core-functionality/playground/human-input-pause-resume.spec.ts`
+- [ ] A suspended Human Input run is recoverable after a page reload (durable execution outliving the tab)
 
 ---
 

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -544,7 +544,7 @@
 - [x] DataFrame output renders as Markdown table → `core-functionality/playground/playground-output-data.spec.ts`
 
 #### 9.6 Human-in-the-Loop (1.11.0)
-- [ ] Human Input pauses the run durably, decision card renders in the Playground, Approve routes only the approved branch and the run completes; Reject routes only the reject branch → `core-functionality/playground/human-input-pause-resume.spec.ts`
+- [x] Human Input pauses the run durably, decision card renders in the Playground, Approve routes only the approved branch and the run completes; Reject routes only the reject branch → `core-functionality/playground/human-input-pause-resume.spec.ts`
 
 ---
 

--- a/docs/core-functionality/playground/human-input-pause-resume.md
+++ b/docs/core-functionality/playground/human-input-pause-resume.md
@@ -43,6 +43,15 @@ outgoing edge, and the component then **skips the pause entirely** — status
 routes nowhere would strand it. So the two Chat Outputs are a **precondition of the
 behaviour under test**, not scenery.
 
+Which is why the setup asserts the **edge count**, not just the node titles: React Flow
+renders nodes independently of edges, so a fixture that lost a branch edge still shows
+`title-Approved Output` and `title-Rejected Output` (measured — both visible with both
+branch edges stripped). Without the edge assertion that defect surfaces 30 s later as
+"the decision card never appeared", i.e. a wiring problem reported as a card-UI failure.
+One nuance worth carrying: on the skip branch the component calls **no** `stop()`, so a
+`successor_map` regression *with* the edges present fires **both** branches rather than
+merely skipping the pause — which is what the exclusivity assertion below catches.
+
 **The two branches carry identical text, so routing needs a distinguishable sink.**
 `route_branch()` returns `Message(text=self._rendered_prompt())` on *whichever* branch
 wins, so both Chat Outputs would emit the same string and "which branch ran" would be
@@ -61,7 +70,9 @@ must have count `0`.
 
 `@release` is claimed here and deliberately **not** on the sibling config spec (#1190):
 this is the execution happy path of 1.11's flagship feature — if it breaks, a HITL flow
-cannot be answered at all — and eight sibling playground specs carry the same set.
+cannot be answered at all. (Measured, since an earlier draft of this doc overstated it:
+exactly **one** other playground spec carries this exact set — `playground-shareable-url` —
+while 11 of 23 carry `@release` alongside further tags.)
 `@regression` is absent: first-time coverage of a new feature, not a previously fixed bug.
 
 ---
@@ -78,9 +89,13 @@ cannot be answered at all — and eight sibling playground specs carry the same 
   renders empty (nodes need `type: "genericNode"` plus their full template) and an edge
   only attaches when its `sourceHandle` string matches the handle's own `data-handleid`
   verbatim (`{œdataTypeœ:œHumanInputœ,œidœ:…,œnameœ:œbranch_approveœ,…}`).
-- The file runs **serial**: each test creates a named flow through the API and those
-  creations race on the backend's unique-name suffixing under parallelism (same reason as
-  the sibling fixture specs).
+- The file is **parallel-safe** and deliberately not serial. Each test owns its flow (unique
+  `${Date.now()}-${random}` name, so the backend's unique-name suffixing has nothing to
+  race) and its own page, and a suspended run is flow-scoped, so the two cannot observe each
+  other. The sibling fixture specs use `mode: "serial"` for that name race; inheriting it
+  here would cost signal, because a flake in the first test **skips** the second and one bad
+  day in the daily would lose the Reject verdict. Measured green at `--workers=2` (and
+  faster: ~7 s against ~10 s serial).
 
 ---
 
@@ -89,28 +104,38 @@ cannot be answered at all — and eight sibling playground specs carry the same 
 **Per test (shared helper)**
 1. Read the fixture, `POST /api/v1/flows/` with a unique name (`createFlow` + explicit
    Bearer), keep the id for teardown.
-2. `page.goto('/flow/{id}')`, wait for `title-Human Input`, then `adjustScreenView(page)`.
+2. `page.goto('/flow/{id}')`, wait for `title-Human Input`, both output titles, and
+   **`.react-flow__edge` count `3`** (the wiring precondition — see above), then
+   `adjustScreenView(page)`.
 3. Open the Playground (`playground-btn-flow-io`) and assert `input-chat-playground` is
    pre-filled with the fixture's sentinel prompt — the node's value, not typed text (typing
    into that field races the template default, `authoring-conventions.md`).
 
 **Test 1 — Approve**
 4. Click `button-send`.
-5. Assert the run **suspended**: `human-input-card` is visible, contains the sentinel
-   prompt, and both `human-input-decision-approve` and `human-input-decision-reject` are
-   **enabled**. Assert no branch output has emitted yet (both sender-scoped bubbles count
-   `0`) — this is what makes it a *pause* rather than a slow completion.
+5. Assert the run **suspended**, on both sides:
+   - UI — `human-input-card` visible, containing the sentinel prompt, with both
+     `human-input-decision-approve` and `human-input-decision-reject` **enabled**;
+   - server — `GET /api/v2/workflows/pending?flow_id={id}` holds exactly **one** suspended
+     request. This is what separates "the card is on screen" from "the run is parked";
+   - and no branch output has emitted yet (both sender-scoped bubbles count `0`) — a pause,
+     not a slow completion.
 6. Click `human-input-decision-approve`.
 7. Assert `chat-message-APPROVED-<prompt>` becomes visible.
 8. Assert `chat-message-REJECTED-<prompt>` has count `0` — exclusive routing.
-9. Assert the card recorded the decision: `human-input-decision-reject` is **gone** and
-   `human-input-decision-approve` is **disabled** (measured post-decision state — the card
-   keeps only the chosen action, disabled).
+9. Assert the run **left the suspended state**: `pending?flow_id={id}` polls to `0`. The
+   routed bubble arrives through the message-query invalidation, independent of the run's
+   own event stream, so without this a resume that never completed would pass step 7.
+10. Assert the card's affordance followed the answer: `human-input-decision-reject` is
+    **gone** and `-approve` is **disabled**. Deliberately a weak claim — the card sets this
+    from local state synchronously (measured 45 ms after the click, before the request is
+    sent) and keeps it locked on an error too, so it pins the UI, never that the backend
+    accepted anything. Step 9 is what does that.
 
 **Test 2 — Reject**
 Same, mirrored: click `human-input-decision-reject`, expect
 `chat-message-REJECTED-<prompt>`, `chat-message-APPROVED-<prompt>` count `0`, the
-`-approve` button gone and `-reject` disabled.
+`pending` list back to `0`, the `-approve` button gone and `-reject` disabled.
 
 **afterEach**
 `page.goto("/")` to unmount the editor (it polls `GET /flows/{id}/events`, which 404s once
@@ -122,8 +147,13 @@ the flow is gone), then `deleteFlow` for each created id with an explicit Bearer
 
 | Test | Criterion |
 |---|---|
-| approving a Human Input pause routes only the approved branch and completes the run | `human-input-card` visible with both decisions enabled and **neither** output bubble present (the pause); after clicking `human-input-decision-approve`, `chat-message-APPROVED-<prompt>` visible **and** `chat-message-REJECTED-<prompt>` count `0`; `-reject` removed and `-approve` disabled |
-| rejecting a Human Input pause routes only the reject branch and completes the run | the mirror: `chat-message-REJECTED-<prompt>` visible, `chat-message-APPROVED-<prompt>` count `0`, `-approve` removed and `-reject` disabled |
+| `approving a Human Input pause routes only the approved branch` | `human-input-card` visible with both decisions enabled, `pending?flow_id` holding exactly **1** request, and **neither** output bubble present (the pause); after clicking `human-input-decision-approve`, `chat-message-APPROVED-<prompt>` visible, `chat-message-REJECTED-<prompt>` count `0`, `pending?flow_id` back to **0**; `-reject` removed and `-approve` disabled |
+| `rejecting a Human Input pause routes only the reject branch` | the mirror: `chat-message-REJECTED-<prompt>` visible, `chat-message-APPROVED-<prompt>` count `0`, `pending?flow_id` back to **0**, `-approve` removed and `-reject` disabled |
+
+The titles above are the `test()` titles verbatim, and neither claims the run *completes*:
+what is asserted is that it **leaves the suspended state**. `pending` lists suspended jobs,
+so an empty list proves the answer was accepted and the job resumed — not that it reached a
+terminal state.
 
 ---
 
@@ -138,15 +168,22 @@ the flow is gone), then `deleteFlow` for each created id with an explicit Bearer
   `reject`.
 - **Chat bubbles** — `chat-message-${sender_name}-${text}`
   (`modals/IOModal/.../chat-message.tsx`). The suspend also renders an **empty**
-  `chat-message-AI-` bubble, which is the Human Input's own `Message(text="")` on the
-  pause path; the spec deliberately ignores it and scopes every assertion to the
-  sender-named bubbles.
-- **Run/resume transport** — the run is `POST /api/v2/workflows`, the answer is
-  `POST /api/v2/workflows/{job_id}/resume` (`api/v2/workflow_execution.py`; 409 on a stale
-  `request_id`, 422 on an action id outside `allowed_decisions`), and a suspended run is
-  discoverable via `GET /api/v2/workflows/pending?flow_id=`. **None is asserted directly**:
-  the user path is the card click, and pinning the transport would couple this spec to a
-  mechanism that moved once already (v1 build → v2 workflows).
+  `chat-message-AI-` bubble. It is **not** the component's return value: the frontend
+  synthesizes it in `injectHumanInputCard()`
+  (`controllers/API/agui/human-input-card.ts` — `text: ""`, `sender: "Machine"`,
+  `sender_name: "AI"`, `id: human-input-${request_id}`) purely to carry the card's content
+  block, which means it appears on every pause render, including a replayed one. The spec
+  ignores it and scopes every assertion to the sender-named bubbles.
+- **Run/resume transport** — the run is `POST /api/v2/workflows` and the answer is
+  `POST /api/v2/workflows/{job_id}/resume` (`api/v2/workflow.py` → `resume_workflow`, with
+  helpers in `api/v2/hitl.py`: 422 when the `action_id` is outside `allowed_decisions`, 409
+  on a stale `request_id`). Neither is asserted directly — the user path is the card click,
+  and pinning the transport would couple this spec to a mechanism that moved once already
+  (v1 build → v2 workflows).
+- **`GET /api/v2/workflows/pending?flow_id=`** (`api/v2/workflow.py` →
+  `list_pending_workflows`) — this one **is** asserted, as the server-side oracle for the
+  pause and for the resume. It is flow-scoped by construction (422 without `flow_id`), so it
+  can never observe another spec's run.
 - **Helpers** — `helpers/flows/create-flow.ts`, `helpers/flows/delete-flow.ts`,
   `helpers/auth/get-auth-token.ts`, `helpers/ui/adjust-screen-view.ts`.
 
@@ -158,8 +195,15 @@ the flow is gone), then `deleteFlow` for each created id with an explicit Bearer
   reroutes a late answer to it. Needs a clock-dependent setup; a candidate of its own.
 - **Custom choices at run time** — the card renders one button per configured choice, but
   editing choices is #1190's surface; this spec runs the defaults.
-- **Recovering a suspended run after a reload** — `GET /api/v2/workflows/pending` exists
-  for exactly that, and it is a distinct behaviour (durable execution outliving the tab).
+- **Recovering a suspended run after a reload** — durable execution outliving the tab is a
+  distinct behaviour, and this spec's use of `pending?flow_id=` does **not** cover it: it
+  reads the suspended state, it never reloads the page and reattaches to it. Tracked as its
+  own `[ ]` bullet under §9.6 so the checklist does not imply otherwise. **The word
+  "durably" was removed from that bullet for the same reason** — nothing here proves it.
+- **The run reaching a terminal state.** The spec proves the run *left* the suspended state
+  (`pending` → `0`), not that it finished: `pending` lists suspended jobs only. There is no
+  cheap UI signal for completion on this path — `button-stop` never renders at any point in
+  this flow (measured before send, at the pause, at the routed bubble and +4 s after).
 - **The stale/duplicate answer guards** — resume answering twice (409) or with a
   disallowed `action_id` (422) are API-level contracts, better covered under `api/`.
 - **Multiple sequential pauses** in one run, and an Agent's own tool-approval pause

--- a/docs/core-functionality/playground/human-input-pause-resume.md
+++ b/docs/core-functionality/playground/human-input-pause-resume.md
@@ -1,0 +1,181 @@
+# Spec: Human Input pause/resume in the Playground (HITL decision card)
+
+**Test file:** `tests/tests-automations/regression/core-functionality/playground/human-input-pause-resume.spec.ts`
+
+**Last validated:** Langflow 1.12.x (built and measured on `1.12.0.dev10`)
+
+---
+
+## What this test validates
+
+The **execution** half of the Human Input feature (HITL, Langflow 1.11.0 — upstream
+`langflow-ai/langflow#13633` durable background execution + suspend/resume, `#14090`
+polish; manual recipes HITL-01/02/03). Three claims, both scenarios:
+
+1. **The run suspends.** Sending a message in the Playground does not complete the flow —
+   the run parks and the decision card (`human-input-card`) renders in the transcript with
+   one enabled button per configured choice.
+2. **Answering resumes the run.** Clicking a decision completes the flow: the chosen
+   branch's downstream Chat Output produces its message.
+3. **Routing is exclusive.** The other branch produces **nothing** — the component calls
+   `stop("branch_<action_id>")` on every non-chosen branch, so the counterpart Chat Output
+   never emits.
+
+Test 1 answers **Approve**, test 2 answers **Reject**. They are mirror images on purpose:
+a spec that only ever approves cannot tell exclusive routing from "the approve branch is
+the only one wired".
+
+**Configuration is out of scope** — the default handles, adding a choice live and
+persistence across reload are covered by `core-components/human-input-node-config.spec.ts`
+(issue #1190, merged). This spec never edits the node.
+
+No LLM provider is involved: the flow is Chat Input → Human Input → two Chat Outputs, and
+`route_branch()` returns the prompt text itself.
+
+---
+
+## Two design decisions the live scout forced
+
+**Both branches must be wired, or the run never pauses.** `_has_downstream_consumer()`
+(`lfx/components/flow_controls/human_input.py`) returns `False` when the node has no
+outgoing edge, and the component then **skips the pause entirely** — status
+`"Skipped: no connected outputs"` — because suspending a whole run for a decision that
+routes nowhere would strand it. So the two Chat Outputs are a **precondition of the
+behaviour under test**, not scenery.
+
+**The two branches carry identical text, so routing needs a distinguishable sink.**
+`route_branch()` returns `Message(text=self._rendered_prompt())` on *whichever* branch
+wins, so both Chat Outputs would emit the same string and "which branch ran" would be
+invisible in the chat. The fixture therefore gives each Chat Output a distinct
+`sender_name` (`APPROVED` / `REJECTED`) and a distinct display name (`Approved Output` /
+`Rejected Output`). The Playground bubble testid is
+`chat-message-${sender_name}-${text}`, which turns the routing claim into an exact
+locator: `chat-message-APPROVED-<prompt>` must exist and `chat-message-REJECTED-<prompt>`
+must have count `0`.
+
+---
+
+## Tags
+
+`@stable` `@release` `@playground`
+
+`@release` is claimed here and deliberately **not** on the sibling config spec (#1190):
+this is the execution happy path of 1.11's flagship feature — if it breaks, a HITL flow
+cannot be answered at all — and eight sibling playground specs carry the same set.
+`@regression` is absent: first-time coverage of a new feature, not a previously fixed bug.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` (built and measured on the nightly,
+  `1.12.0.dev10`).
+- **No provider credentials**, no `models.json`, no `collect-models`.
+- Fixture flow `tests/assets/flows/human-input-branching-fixture.json` — Chat Input
+  (`input_value` = the sentinel prompt) → Human Input (default `Approve`/`Reject`) →
+  `Approved Output` / `Rejected Output`. Built by wiring it in the UI on a live nightly and
+  exporting the result through `GET /api/v1/flows/{id}`, because a hand-written flow JSON
+  renders empty (nodes need `type: "genericNode"` plus their full template) and an edge
+  only attaches when its `sourceHandle` string matches the handle's own `data-handleid`
+  verbatim (`{œdataTypeœ:œHumanInputœ,œidœ:…,œnameœ:œbranch_approveœ,…}`).
+- The file runs **serial**: each test creates a named flow through the API and those
+  creations race on the backend's unique-name suffixing under parallelism (same reason as
+  the sibling fixture specs).
+
+---
+
+## Step by step
+
+**Per test (shared helper)**
+1. Read the fixture, `POST /api/v1/flows/` with a unique name (`createFlow` + explicit
+   Bearer), keep the id for teardown.
+2. `page.goto('/flow/{id}')`, wait for `title-Human Input`, then `adjustScreenView(page)`.
+3. Open the Playground (`playground-btn-flow-io`) and assert `input-chat-playground` is
+   pre-filled with the fixture's sentinel prompt — the node's value, not typed text (typing
+   into that field races the template default, `authoring-conventions.md`).
+
+**Test 1 — Approve**
+4. Click `button-send`.
+5. Assert the run **suspended**: `human-input-card` is visible, contains the sentinel
+   prompt, and both `human-input-decision-approve` and `human-input-decision-reject` are
+   **enabled**. Assert no branch output has emitted yet (both sender-scoped bubbles count
+   `0`) — this is what makes it a *pause* rather than a slow completion.
+6. Click `human-input-decision-approve`.
+7. Assert `chat-message-APPROVED-<prompt>` becomes visible.
+8. Assert `chat-message-REJECTED-<prompt>` has count `0` — exclusive routing.
+9. Assert the card recorded the decision: `human-input-decision-reject` is **gone** and
+   `human-input-decision-approve` is **disabled** (measured post-decision state — the card
+   keeps only the chosen action, disabled).
+
+**Test 2 — Reject**
+Same, mirrored: click `human-input-decision-reject`, expect
+`chat-message-REJECTED-<prompt>`, `chat-message-APPROVED-<prompt>` count `0`, the
+`-approve` button gone and `-reject` disabled.
+
+**afterEach**
+`page.goto("/")` to unmount the editor (it polls `GET /flows/{id}/events`, which 404s once
+the flow is gone), then `deleteFlow` for each created id with an explicit Bearer.
+
+---
+
+## Validation criterion
+
+| Test | Criterion |
+|---|---|
+| approving a Human Input pause routes only the approved branch and completes the run | `human-input-card` visible with both decisions enabled and **neither** output bubble present (the pause); after clicking `human-input-decision-approve`, `chat-message-APPROVED-<prompt>` visible **and** `chat-message-REJECTED-<prompt>` count `0`; `-reject` removed and `-approve` disabled |
+| rejecting a Human Input pause routes only the reject branch and completes the run | the mirror: `chat-message-REJECTED-<prompt>` visible, `chat-message-APPROVED-<prompt>` count `0`, `-approve` removed and `-reject` disabled |
+
+---
+
+## External dependencies
+
+- **Playground** — `playground-btn-flow-io`, `input-chat-playground`, `button-send`,
+  `new-chat`, `playground-close-button`.
+- **Decision card** — `human-input-card`, `human-input-decision-<action_id>` (and
+  `human-input-field-<name>` for extra fields, unused here), from
+  `components/core/chatComponents/HumanInputCard.tsx`. `action_id` is the slugified label
+  (`_action_id()`: lowercase, spaces → underscores), so the defaults are `approve` and
+  `reject`.
+- **Chat bubbles** — `chat-message-${sender_name}-${text}`
+  (`modals/IOModal/.../chat-message.tsx`). The suspend also renders an **empty**
+  `chat-message-AI-` bubble, which is the Human Input's own `Message(text="")` on the
+  pause path; the spec deliberately ignores it and scopes every assertion to the
+  sender-named bubbles.
+- **Run/resume transport** — the run is `POST /api/v2/workflows`, the answer is
+  `POST /api/v2/workflows/{job_id}/resume` (`api/v2/workflow_execution.py`; 409 on a stale
+  `request_id`, 422 on an action id outside `allowed_decisions`), and a suspended run is
+  discoverable via `GET /api/v2/workflows/pending?flow_id=`. **None is asserted directly**:
+  the user path is the card click, and pinning the transport would couple this spec to a
+  mechanism that moved once already (v1 build → v2 workflows).
+- **Helpers** — `helpers/flows/create-flow.ts`, `helpers/flows/delete-flow.ts`,
+  `helpers/auth/get-auth-token.ts`, `helpers/ui/adjust-screen-view.ts`.
+
+---
+
+## What this test does not cover
+
+- **`Enable Fallback` + `Timeout`** — the advanced pair that adds a `fallback` branch and
+  reroutes a late answer to it. Needs a clock-dependent setup; a candidate of its own.
+- **Custom choices at run time** — the card renders one button per configured choice, but
+  editing choices is #1190's surface; this spec runs the defaults.
+- **Recovering a suspended run after a reload** — `GET /api/v2/workflows/pending` exists
+  for exactly that, and it is a distinct behaviour (durable execution outliving the tab).
+- **The stale/duplicate answer guards** — resume answering twice (409) or with a
+  disallowed `action_id` (422) are API-level contracts, better covered under `api/`.
+- **Multiple sequential pauses** in one run, and an Agent's own tool-approval pause
+  interacting with a Human Input pause.
+
+---
+
+## Notes
+
+- Measured on `1.12.0.dev10`: the pause appears **~1 s** after send and the routed bubble
+  **~1 s** after the decision, so the per-assertion budgets are generous rather than tight
+  (30 s for the card, 30 s for the routed bubble — a saturated CI backend is the case they
+  exist for).
+- The absent-branch assertion is a `toHaveCount(0)` on a **sender-scoped** testid, so it
+  cannot pass vacuously on a page where nothing rendered at all: the positive assertion for
+  the chosen branch runs first and would fail in that case.
+- Sibling references: `core-components/human-input-node-config.spec.ts` (the config half,
+  #1190) and the fixture-driven pattern in
+  `core-functionality/knowledge-ingestion-management/split-text-chunking.spec.ts`.

--- a/tests/assets/flows/human-input-branching-fixture.json
+++ b/tests/assets/flows/human-input-branching-fixture.json
@@ -1,0 +1,1256 @@
+{
+  "data": {
+    "nodes": [
+      {
+        "id": "ChatInput-FXoDx",
+        "type": "genericNode",
+        "position": {
+          "x": 0,
+          "y": 0
+        },
+        "data": {
+          "node": {
+            "base_classes": [
+              "Message"
+            ],
+            "beta": false,
+            "conditional_paths": [],
+            "custom_fields": {},
+            "description": "Get chat inputs from the Playground.",
+            "display_name": "Chat Input",
+            "documentation": "https://docs.langflow.org/chat-input-and-output",
+            "edited": false,
+            "field_order": [
+              "input_value",
+              "should_store_message",
+              "sender",
+              "sender_name",
+              "session_id",
+              "context_id",
+              "files"
+            ],
+            "frozen": false,
+            "icon": "MessagesSquare",
+            "legacy": false,
+            "metadata": {
+              "code_hash": "7a26c54d89ed",
+              "dependencies": {
+                "dependencies": [
+                  {
+                    "name": "lfx",
+                    "version": null
+                  }
+                ],
+                "total_dependencies": 1
+              },
+              "module": "lfx.components.input_output.chat.ChatInput"
+            },
+            "minimized": true,
+            "output_types": [],
+            "outputs": [
+              {
+                "allows_loop": false,
+                "cache": true,
+                "display_name": "Chat Message",
+                "group_outputs": false,
+                "method": "message_response",
+                "name": "message",
+                "selected": "Message",
+                "tool_mode": true,
+                "types": [
+                  "Message"
+                ],
+                "value": "__UNDEFINED__"
+              }
+            ],
+            "pinned": false,
+            "template": {
+              "_type": "Component",
+              "code": {
+                "advanced": true,
+                "api_editable": false,
+                "dynamic": true,
+                "fileTypes": [],
+                "file_path": "",
+                "info": "",
+                "list": false,
+                "load_from_db": false,
+                "multiline": true,
+                "name": "code",
+                "password": false,
+                "placeholder": "",
+                "required": true,
+                "show": true,
+                "title_case": false,
+                "type": "code",
+                "value": "from lfx.base.data.utils import IMG_FILE_TYPES, TEXT_FILE_TYPES\nfrom lfx.base.io.chat import ChatComponent\nfrom lfx.inputs.inputs import BoolInput\nfrom lfx.io import (\n    DropdownInput,\n    FileInput,\n    MessageTextInput,\n    MultilineInput,\n    Output,\n)\nfrom lfx.schema.message import Message\nfrom lfx.utils.constants import (\n    MESSAGE_SENDER_AI,\n    MESSAGE_SENDER_NAME_USER,\n    MESSAGE_SENDER_USER,\n)\n\n\nclass ChatInput(ChatComponent):\n    display_name = \"Chat Input\"\n    description = \"Get chat inputs from the Playground.\"\n    documentation: str = \"https://docs.langflow.org/chat-input-and-output\"\n    icon = \"MessagesSquare\"\n    name = \"ChatInput\"\n    minimized = True\n\n    inputs = [\n        MultilineInput(\n            name=\"input_value\",\n            display_name=\"Input Text\",\n            value=\"\",\n            info=\"Message to be passed as input.\",\n            input_types=[],\n        ),\n        BoolInput(\n            name=\"should_store_message\",\n            display_name=\"Store Messages\",\n            info=\"Store the message in the history.\",\n            value=True,\n            advanced=True,\n        ),\n        DropdownInput(\n            name=\"sender\",\n            display_name=\"Sender Type\",\n            options=[MESSAGE_SENDER_AI, MESSAGE_SENDER_USER],\n            value=MESSAGE_SENDER_USER,\n            info=\"Type of sender.\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"sender_name\",\n            display_name=\"Sender Name\",\n            info=\"Name of the sender.\",\n            value=MESSAGE_SENDER_NAME_USER,\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"session_id\",\n            display_name=\"Session ID\",\n            info=\"The session ID of the chat. If empty, the current session ID parameter will be used.\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"context_id\",\n            display_name=\"Context ID\",\n            info=\"The context ID of the chat. Adds an extra layer to the local memory.\",\n            value=\"\",\n            advanced=True,\n        ),\n        FileInput(\n            name=\"files\",\n            display_name=\"Files\",\n            file_types=TEXT_FILE_TYPES + IMG_FILE_TYPES,\n            info=\"Files to be sent with the message.\",\n            advanced=True,\n            is_list=True,\n            temp_file=True,\n        ),\n    ]\n    outputs = [\n        Output(display_name=\"Chat Message\", name=\"message\", method=\"message_response\"),\n    ]\n\n    async def message_response(self) -> Message:\n        # Ensure files is a list and filter out empty/None values\n        files = self.files if self.files else []\n        if files and not isinstance(files, list):\n            files = [files]\n        # Filter out None/empty values\n        files = [f for f in files if f is not None and f != \"\"]\n\n        session_id = self.session_id or self.graph.session_id or \"\"\n        message = await Message.create(\n            text=self.input_value,\n            sender=self.sender,\n            sender_name=self.sender_name,\n            session_id=session_id,\n            context_id=self.context_id,\n            files=files,\n        )\n        if session_id and isinstance(message, Message) and self.should_store_message:\n            stored_message = await self.send_message(\n                message,\n            )\n            self.message.value = stored_message\n            message = stored_message\n\n        self.status = message\n        return message\n"
+              },
+              "context_id": {
+                "_input_type": "MessageTextInput",
+                "advanced": true,
+                "api_editable": false,
+                "display_name": "Context ID",
+                "dynamic": false,
+                "info": "The context ID of the chat. Adds an extra layer to the local memory.",
+                "input_types": [
+                  "Message"
+                ],
+                "list": false,
+                "list_add_label": "Add More",
+                "load_from_db": false,
+                "name": "context_id",
+                "override_skip": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "track_in_telemetry": false,
+                "type": "str",
+                "value": ""
+              },
+              "files": {
+                "_input_type": "FileInput",
+                "advanced": true,
+                "api_editable": false,
+                "display_name": "Files",
+                "dynamic": false,
+                "fileTypes": [
+                  "csv",
+                  "json",
+                  "pdf",
+                  "txt",
+                  "md",
+                  "mdx",
+                  "yaml",
+                  "yml",
+                  "xml",
+                  "html",
+                  "htm",
+                  "docx",
+                  "py",
+                  "sh",
+                  "sql",
+                  "js",
+                  "ts",
+                  "tsx",
+                  "jpg",
+                  "jpeg",
+                  "png",
+                  "bmp",
+                  "image"
+                ],
+                "file_path": "",
+                "info": "Files to be sent with the message.",
+                "list": true,
+                "list_add_label": "Add More",
+                "name": "files",
+                "override_skip": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "temp_file": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "track_in_telemetry": false,
+                "type": "file",
+                "value": ""
+              },
+              "input_value": {
+                "_input_type": "MultilineInput",
+                "advanced": false,
+                "ai_enabled": false,
+                "api_editable": false,
+                "copy_field": false,
+                "display_name": "Input Text",
+                "dynamic": false,
+                "info": "Message to be passed as input.",
+                "input_types": [],
+                "list": false,
+                "list_add_label": "Add More",
+                "load_from_db": false,
+                "multiline": true,
+                "name": "input_value",
+                "override_skip": false,
+                "password": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "track_in_telemetry": false,
+                "type": "str",
+                "value": "HITL-1189 please review this request"
+              },
+              "sender": {
+                "_input_type": "DropdownInput",
+                "advanced": true,
+                "api_editable": false,
+                "combobox": false,
+                "dialog_inputs": {},
+                "display_name": "Sender Type",
+                "dynamic": false,
+                "external_options": {},
+                "info": "Type of sender.",
+                "name": "sender",
+                "options": [
+                  "Machine",
+                  "User"
+                ],
+                "options_metadata": [],
+                "override_skip": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "toggle": false,
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "track_in_telemetry": true,
+                "type": "str",
+                "value": "User"
+              },
+              "sender_name": {
+                "_input_type": "MessageTextInput",
+                "advanced": true,
+                "api_editable": false,
+                "display_name": "Sender Name",
+                "dynamic": false,
+                "info": "Name of the sender.",
+                "input_types": [
+                  "Message"
+                ],
+                "list": false,
+                "list_add_label": "Add More",
+                "load_from_db": false,
+                "name": "sender_name",
+                "override_skip": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "track_in_telemetry": false,
+                "type": "str",
+                "value": "User"
+              },
+              "session_id": {
+                "_input_type": "MessageTextInput",
+                "advanced": true,
+                "api_editable": false,
+                "display_name": "Session ID",
+                "dynamic": false,
+                "info": "The session ID of the chat. If empty, the current session ID parameter will be used.",
+                "input_types": [
+                  "Message"
+                ],
+                "list": false,
+                "list_add_label": "Add More",
+                "load_from_db": false,
+                "name": "session_id",
+                "override_skip": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "track_in_telemetry": false,
+                "type": "str",
+                "value": ""
+              },
+              "should_store_message": {
+                "_input_type": "BoolInput",
+                "advanced": true,
+                "api_editable": false,
+                "display_name": "Store Messages",
+                "dynamic": false,
+                "info": "Store the message in the history.",
+                "list": false,
+                "list_add_label": "Add More",
+                "name": "should_store_message",
+                "override_skip": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "track_in_telemetry": true,
+                "type": "bool",
+                "value": true
+              }
+            },
+            "tool_mode": false,
+            "lf_version": "1.12.0.dev10"
+          },
+          "showNode": false,
+          "type": "ChatInput",
+          "id": "ChatInput-FXoDx"
+        },
+        "positionAbsolute": {
+          "x": 0,
+          "y": 0
+        }
+      },
+      {
+        "id": "HumanInput-TgsrH",
+        "type": "genericNode",
+        "position": {
+          "x": 520,
+          "y": 0
+        },
+        "data": {
+          "node": {
+            "base_classes": [
+              "Message"
+            ],
+            "beta": false,
+            "conditional_paths": [],
+            "custom_fields": {},
+            "description": "Pause the flow for a human-in-the-loop (HITL) decision and route on the chosen action.",
+            "display_name": "Human Input",
+            "documentation": "",
+            "edited": false,
+            "field_order": [
+              "prompt",
+              "decisions",
+              "timeout",
+              "enable_fallback"
+            ],
+            "frozen": false,
+            "icon": "HumanInput",
+            "legacy": false,
+            "metadata": {
+              "code_hash": "63cbbf99823f",
+              "dependencies": {
+                "dependencies": [
+                  {
+                    "name": "lfx",
+                    "version": null
+                  }
+                ],
+                "total_dependencies": 1
+              },
+              "keywords": [
+                "hitl",
+                "human-in-the-loop",
+                "decision"
+              ],
+              "module": "lfx.components.flow_controls.human_input.HumanInput"
+            },
+            "minimized": false,
+            "output_types": [],
+            "outputs": [
+              {
+                "types": [
+                  "Message"
+                ],
+                "selected": "Message",
+                "name": "branch_approve",
+                "display_name": "Approve",
+                "method": "route_branch",
+                "value": "__UNDEFINED__",
+                "cache": true,
+                "required_inputs": null,
+                "allows_loop": false,
+                "loop_types": null,
+                "group_outputs": true,
+                "options": null,
+                "tool_mode": true
+              },
+              {
+                "types": [
+                  "Message"
+                ],
+                "selected": "Message",
+                "name": "branch_reject",
+                "display_name": "Reject",
+                "method": "route_branch",
+                "value": "__UNDEFINED__",
+                "cache": true,
+                "required_inputs": null,
+                "allows_loop": false,
+                "loop_types": null,
+                "group_outputs": true,
+                "options": null,
+                "tool_mode": true
+              }
+            ],
+            "pinned": false,
+            "template": {
+              "_type": "Component",
+              "code": {
+                "advanced": true,
+                "api_editable": false,
+                "dynamic": true,
+                "fileTypes": [],
+                "file_path": "",
+                "info": "",
+                "list": false,
+                "load_from_db": false,
+                "multiline": true,
+                "name": "code",
+                "password": false,
+                "placeholder": "",
+                "required": true,
+                "show": true,
+                "title_case": false,
+                "type": "code",
+                "value": "\"\"\"Human Input node: pause a flow for a human decision, then route on the pick (LE-1449).\n\nThe User Choices picker chooses which actions the human can take (presets like\nApprove/Reject/Escalate, or custom); each becomes a branch output. On first execution\nthe node requests a pause carrying a ``node_input`` request; on resume the injected\ndecision selects exactly one branch (the others are stopped). With Enable Fallback on,\na ``fallback`` branch is added for when no user action is answered (e.g. after timeout).\n\"\"\"\n\nfrom __future__ import annotations\n\nfrom datetime import datetime, timezone\nfrom typing import Any\n\nfrom lfx.custom import Component\nfrom lfx.inputs.inputs import ActionPickerInput, BoolInput, DurationInput\nfrom lfx.io import MultilineInput, Output\nfrom lfx.schema.message import Message\n\nHUMAN_INPUT_REQUIRED = \"human_input_required\"\n_KIND_NODE_INPUT = \"node_input\"\n_FALLBACK_ACTION = \"fallback\"\n_UNIT_SECONDS = {\"Minutes\": 60, \"Hours\": 3600, \"Days\": 86400}\n\n\ndef _action_id(label: str) -> str:\n    \"\"\"Stable branch id for a human-facing action label (e.g. 'Request Changes' -> 'request_changes').\"\"\"\n    return str(label).strip().lower().replace(\" \", \"_\")\n\n\nclass HumanInput(Component):\n    display_name = \"Human Input\"\n    description = \"Pause the flow for a human-in-the-loop (HITL) decision and route on the chosen action.\"\n    icon = \"HumanInput\"\n    name = \"HumanInput\"\n    metadata = {\"keywords\": [\"hitl\", \"human-in-the-loop\", \"decision\"]}\n\n    inputs = [\n        MultilineInput(\n            name=\"prompt\",\n            display_name=\"Input\",\n            info=\"Content shown to the human for review.\",\n            value=\"\",\n        ),\n        ActionPickerInput(\n            name=\"decisions\",\n            display_name=\"User Choices\",\n            info=\"Choices the human can pick; each becomes a branch output. Pick from the list or type a custom one.\",\n            value=[\"Approve\", \"Reject\"],\n            real_time_refresh=True,\n            required=True,\n        ),\n        DurationInput(\n            name=\"timeout\",\n            display_name=\"Timeout\",\n            info=\"A response received after this window is rerouted to the fallback path (when enabled) \"\n            \"instead of the chosen action. The run stays paused until a response arrives or the \"\n            \"server's suspended-run deadline expires it. Set to 0 to wait indefinitely.\",\n            options=[\"Minutes\", \"Hours\", \"Days\"],\n            value={\"value\": 3, \"unit\": \"Days\"},\n            advanced=True,\n            show=False,\n        ),\n        BoolInput(\n            name=\"enable_fallback\",\n            display_name=\"Enable Fallback\",\n            info=\"Add a 'fallback' output taken when the answer arrives after the timeout window.\",\n            value=False,\n            advanced=True,\n            real_time_refresh=True,\n        ),\n    ]\n\n    # Default branch outputs mirror the default ``decisions`` so a freshly dragged\n    # node shows handles immediately (update_outputs only fires on a field change).\n    outputs: list[Output] = [\n        Output(display_name=\"Approve\", name=\"branch_approve\", method=\"route_branch\", group_outputs=True),\n        Output(display_name=\"Reject\", name=\"branch_reject\", method=\"route_branch\", group_outputs=True),\n    ]\n\n    async def update_frontend_node(self, new_frontend_node: dict, current_frontend_node: dict) -> dict:\n        \"\"\"Rebuild branch outputs from the saved User Choices so loaded/refreshed flows keep their handles.\"\"\"\n        new_frontend_node = await super().update_frontend_node(new_frontend_node, current_frontend_node)\n        template = new_frontend_node.get(\"template\", {})\n        decisions = (template.get(\"decisions\") or {}).get(\"value\")\n        self.update_outputs(new_frontend_node, \"decisions\", decisions if decisions is not None else [])\n        self._sync_timeout_visibility(template)\n        return new_frontend_node\n\n    @staticmethod\n    def _sync_timeout_visibility(template: dict) -> None:\n        \"\"\"Timeout only matters when the fallback branch exists to reroute to.\"\"\"\n        if \"timeout\" in template:\n            template[\"timeout\"][\"show\"] = bool((template.get(\"enable_fallback\") or {}).get(\"value\"))\n\n    def update_build_config(self, build_config: dict, field_value: Any, field_name: str | None = None) -> dict:\n        if field_name == \"enable_fallback\" and \"timeout\" in build_config:\n            build_config[\"timeout\"][\"show\"] = bool(field_value)\n        return build_config\n\n    def update_outputs(self, frontend_node: dict, field_name: str, field_value: Any) -> dict:\n        \"\"\"One branch output per selected action (+ optional fallback) + a stable action output.\"\"\"\n        if field_name not in (\"decisions\", \"enable_fallback\"):\n            return frontend_node\n        template = frontend_node.get(\"template\", {})\n\n        def _other(field: str, attr_default):\n            if field in template:\n                return (template.get(field) or {}).get(\"value\")\n            return getattr(self, attr_default[0], attr_default[1])\n\n        actions = field_value if field_name == \"decisions\" else _other(\"decisions\", (\"decisions\", []))\n        fallback_on = (\n            field_value if field_name == \"enable_fallback\" else _other(\"enable_fallback\", (\"enable_fallback\", False))\n        )\n        outputs: list[Output] = []\n        seen: set[str] = set()\n        for label in actions or []:\n            action_id = _action_id(label)\n            if not action_id or action_id in seen:\n                continue\n            seen.add(action_id)\n            outputs.append(\n                Output(\n                    display_name=str(label).strip(),\n                    name=f\"branch_{action_id}\",\n                    method=\"route_branch\",\n                    group_outputs=True,\n                )\n            )\n        if fallback_on:\n            outputs.append(\n                Output(\n                    display_name=\"Fallback\",\n                    name=f\"branch_{_FALLBACK_ACTION}\",\n                    method=\"route_branch\",\n                    group_outputs=True,\n                )\n            )\n        frontend_node[\"outputs\"] = outputs\n        return frontend_node\n\n    def _actions(self) -> list[tuple[str, str]]:\n        \"\"\"Selected actions as (action_id, label) pairs, de-duplicated by id.\"\"\"\n        seen: set[str] = set()\n        actions: list[tuple[str, str]] = []\n        for label in getattr(self, \"decisions\", []) or []:\n            action_id = _action_id(label)\n            if not action_id or action_id in seen:\n                continue\n            seen.add(action_id)\n            actions.append((action_id, str(label).strip()))\n        return actions\n\n    def _rendered_prompt(self) -> str:\n        return str(getattr(self, \"prompt\", \"\") or \"\")\n\n    def _timeout_seconds(self) -> int:\n        timeout = getattr(self, \"timeout\", None) or {}\n        if not isinstance(timeout, dict):\n            return 0\n        unit = timeout.get(\"unit\", \"Days\") or \"Days\"\n        return int(timeout.get(\"value\", 0) or 0) * _UNIT_SECONDS.get(unit, _UNIT_SECONDS[\"Days\"])\n\n    def _request_id(self) -> str:\n        run_id = str(getattr(self.graph, \"run_id\", \"\") or \"\")\n        return f\"{self._id}:{run_id}\"\n\n    def _injected_decision(self) -> dict | None:\n        decisions = getattr(self.graph, \"human_input_decisions\", None) if self.graph is not None else None\n        if not isinstance(decisions, dict):\n            return None\n        return decisions.get(self._request_id())\n\n    def _allowed_decisions(self) -> list[str]:\n        ids = [action_id for action_id, _ in self._actions()]\n        if getattr(self, \"enable_fallback\", False):\n            ids.append(_FALLBACK_ACTION)\n        return ids\n\n    def _pause_request(self) -> dict[str, Any]:\n        return {\n            \"request_id\": self._request_id(),\n            \"kind\": _KIND_NODE_INPUT,\n            \"prompt\": self._rendered_prompt(),\n            \"options\": [{\"action_id\": action_id, \"label\": label} for action_id, label in self._actions()],\n            \"allowed_decisions\": self._allowed_decisions(),\n            \"timeout_seconds\": self._timeout_seconds(),\n            \"fallback_action\": _FALLBACK_ACTION if getattr(self, \"enable_fallback\", False) else None,\n            \"paused_at\": datetime.now(timezone.utc).isoformat(),\n        }\n\n    def _has_downstream_consumer(self) -> bool:\n        \"\"\"True if any branch output feeds a downstream node.\n\n        A node with no outgoing edges runs as an isolated start vertex; pausing it would\n        suspend the whole run for a decision that routes nowhere (and, alongside an Agent's\n        own tool-approval pause, leave that pause unresolved on resume). The successor_map is\n        absent only outside a prepared graph (standalone/tests), where the old behavior holds.\n        \"\"\"\n        graph = getattr(self, \"graph\", None)\n        successor_map = getattr(graph, \"successor_map\", None)\n        if not isinstance(successor_map, dict):\n            return True\n        return bool(successor_map.get(self._id))\n\n    def _suspend(self) -> None:\n        self.graph.request_pause(reason=HUMAN_INPUT_REQUIRED, data=self._pause_request())\n        self.status = \"Awaiting human input\"\n\n    def route_branch(self) -> Message:\n        decision = self._injected_decision()\n        if decision is None:\n            if not self._has_downstream_consumer():\n                self.status = \"Skipped: no connected outputs\"\n                return Message(text=self._rendered_prompt())\n            self._suspend()\n            return Message(text=\"\")\n        chosen = decision.get(\"action_id\")\n        non_chosen = [action_id for action_id in self._allowed_decisions() if action_id != chosen]\n        for action_id in non_chosen:\n            self.stop(f\"branch_{action_id}\")\n        return Message(text=self._rendered_prompt())\n"
+              },
+              "decisions": {
+                "_input_type": "ActionPickerInput",
+                "advanced": false,
+                "api_editable": false,
+                "combobox": true,
+                "display_name": "User Choices",
+                "dynamic": false,
+                "info": "Choices the human can pick; each becomes a branch output. Pick from the list or type a custom one.",
+                "list": true,
+                "list_add_label": "Add More",
+                "name": "decisions",
+                "options": [],
+                "override_skip": false,
+                "placeholder": "",
+                "real_time_refresh": true,
+                "required": true,
+                "show": true,
+                "title_case": false,
+                "toggle": false,
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "track_in_telemetry": false,
+                "type": "actionPicker",
+                "value": [
+                  "Approve",
+                  "Reject"
+                ]
+              },
+              "enable_fallback": {
+                "_input_type": "BoolInput",
+                "advanced": true,
+                "api_editable": false,
+                "display_name": "Enable Fallback",
+                "dynamic": false,
+                "info": "Add a 'fallback' output taken when the answer arrives after the timeout window.",
+                "list": false,
+                "list_add_label": "Add More",
+                "name": "enable_fallback",
+                "override_skip": false,
+                "placeholder": "",
+                "real_time_refresh": true,
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "track_in_telemetry": true,
+                "type": "bool",
+                "value": false
+              },
+              "prompt": {
+                "_input_type": "MultilineInput",
+                "advanced": false,
+                "ai_enabled": false,
+                "api_editable": false,
+                "copy_field": false,
+                "display_name": "Input",
+                "dynamic": false,
+                "info": "Content shown to the human for review.",
+                "input_types": [
+                  "Message"
+                ],
+                "list": false,
+                "list_add_label": "Add More",
+                "load_from_db": false,
+                "multiline": true,
+                "name": "prompt",
+                "override_skip": false,
+                "password": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "track_in_telemetry": false,
+                "type": "str",
+                "value": ""
+              },
+              "timeout": {
+                "_input_type": "DurationInput",
+                "advanced": true,
+                "api_editable": false,
+                "display_name": "Timeout",
+                "dynamic": false,
+                "info": "A response received after this window is rerouted to the fallback path (when enabled) instead of the chosen action. The run stays paused until a response arrives or the server's suspended-run deadline expires it. Set to 0 to wait indefinitely.",
+                "name": "timeout",
+                "options": [
+                  "Minutes",
+                  "Hours",
+                  "Days"
+                ],
+                "override_skip": false,
+                "placeholder": "",
+                "required": false,
+                "show": false,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "track_in_telemetry": false,
+                "type": "duration",
+                "value": {
+                  "unit": "Days",
+                  "value": 3
+                }
+              },
+              "_frontend_node_flow_id": {
+                "value": "6e428105-7720-4474-8933-1bcabc035d7b"
+              },
+              "_frontend_node_folder_id": {
+                "value": "70af1547-0bd1-4799-be28-41f738b6e6dc"
+              },
+              "is_refresh": false
+            },
+            "tool_mode": false,
+            "last_updated": "2026-08-05T00:11:33.357Z",
+            "lf_version": "1.12.0.dev10"
+          },
+          "showNode": true,
+          "type": "HumanInput",
+          "id": "HumanInput-TgsrH"
+        },
+        "positionAbsolute": {
+          "x": 520,
+          "y": 0
+        }
+      },
+      {
+        "id": "ChatOutput-uTw2N",
+        "type": "genericNode",
+        "position": {
+          "x": 1060,
+          "y": -200
+        },
+        "data": {
+          "node": {
+            "base_classes": [
+              "Message"
+            ],
+            "beta": false,
+            "conditional_paths": [],
+            "custom_fields": {},
+            "description": "Display a chat message in the Playground.",
+            "display_name": "Approved Output",
+            "documentation": "https://docs.langflow.org/chat-input-and-output",
+            "edited": false,
+            "field_order": [
+              "input_value",
+              "should_store_message",
+              "sender",
+              "sender_name",
+              "session_id",
+              "context_id",
+              "data_template",
+              "clean_data"
+            ],
+            "frozen": false,
+            "icon": "MessagesSquare",
+            "legacy": false,
+            "metadata": {
+              "code_hash": "84009527d08c",
+              "dependencies": {
+                "dependencies": [
+                  {
+                    "name": "orjson",
+                    "version": "3.11.9"
+                  },
+                  {
+                    "name": "fastapi",
+                    "version": "0.139.2"
+                  },
+                  {
+                    "name": "lfx",
+                    "version": null
+                  }
+                ],
+                "total_dependencies": 3
+              },
+              "module": "lfx.components.input_output.chat_output.ChatOutput"
+            },
+            "minimized": true,
+            "output_types": [],
+            "outputs": [
+              {
+                "allows_loop": false,
+                "cache": true,
+                "display_name": "Output Message",
+                "group_outputs": false,
+                "method": "message_response",
+                "name": "message",
+                "selected": "Message",
+                "tool_mode": true,
+                "types": [
+                  "Message"
+                ],
+                "value": "__UNDEFINED__"
+              }
+            ],
+            "pinned": false,
+            "template": {
+              "_type": "Component",
+              "clean_data": {
+                "_input_type": "BoolInput",
+                "advanced": true,
+                "api_editable": false,
+                "display_name": "Basic Clean Data",
+                "dynamic": false,
+                "info": "Whether to clean data before converting to string.",
+                "list": false,
+                "list_add_label": "Add More",
+                "name": "clean_data",
+                "override_skip": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "track_in_telemetry": true,
+                "type": "bool",
+                "value": true
+              },
+              "code": {
+                "advanced": true,
+                "api_editable": false,
+                "dynamic": true,
+                "fileTypes": [],
+                "file_path": "",
+                "info": "",
+                "list": false,
+                "load_from_db": false,
+                "multiline": true,
+                "name": "code",
+                "password": false,
+                "placeholder": "",
+                "required": true,
+                "show": true,
+                "title_case": false,
+                "type": "code",
+                "value": "from collections.abc import Generator\nfrom typing import Any\n\nimport orjson\nfrom fastapi.encoders import jsonable_encoder\n\nfrom lfx.base.io.chat import ChatComponent\nfrom lfx.helpers.data import safe_convert\nfrom lfx.inputs.inputs import BoolInput, DropdownInput, HandleInput, MessageTextInput\nfrom lfx.schema.data import Data\nfrom lfx.schema.dataframe import DataFrame\nfrom lfx.schema.message import Message\nfrom lfx.schema.properties import Source\nfrom lfx.template.field.base import Output\nfrom lfx.utils.constants import (\n    MESSAGE_SENDER_AI,\n    MESSAGE_SENDER_NAME_AI,\n    MESSAGE_SENDER_USER,\n)\n\n\nclass ChatOutput(ChatComponent):\n    display_name = \"Chat Output\"\n    description = \"Display a chat message in the Playground.\"\n    documentation: str = \"https://docs.langflow.org/chat-input-and-output\"\n    icon = \"MessagesSquare\"\n    name = \"ChatOutput\"\n    minimized = True\n\n    inputs = [\n        HandleInput(\n            name=\"input_value\",\n            display_name=\"Inputs\",\n            info=\"Message to be passed as output.\",\n            input_types=[\"Data\", \"JSON\", \"DataFrame\", \"Table\", \"Message\"],\n            required=True,\n        ),\n        BoolInput(\n            name=\"should_store_message\",\n            display_name=\"Store Messages\",\n            info=\"Store the message in the history.\",\n            value=True,\n            advanced=True,\n        ),\n        DropdownInput(\n            name=\"sender\",\n            display_name=\"Sender Type\",\n            options=[MESSAGE_SENDER_AI, MESSAGE_SENDER_USER],\n            value=MESSAGE_SENDER_AI,\n            advanced=True,\n            info=\"Type of sender.\",\n        ),\n        MessageTextInput(\n            name=\"sender_name\",\n            display_name=\"Sender Name\",\n            info=\"Name of the sender.\",\n            value=MESSAGE_SENDER_NAME_AI,\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"session_id\",\n            display_name=\"Session ID\",\n            info=\"The session ID of the chat. If empty, the current session ID parameter will be used.\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"context_id\",\n            display_name=\"Context ID\",\n            info=\"The context ID of the chat. Adds an extra layer to the local memory.\",\n            value=\"\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"data_template\",\n            display_name=\"Data Template\",\n            value=\"{text}\",\n            advanced=True,\n            info=\"Template to convert Data to Text. If left empty, it will be dynamically set to the Data's text key.\",\n        ),\n        BoolInput(\n            name=\"clean_data\",\n            display_name=\"Basic Clean Data\",\n            value=True,\n            advanced=True,\n            info=\"Whether to clean data before converting to string.\",\n        ),\n    ]\n    outputs = [\n        Output(\n            display_name=\"Output Message\",\n            name=\"message\",\n            method=\"message_response\",\n        ),\n    ]\n\n    def _build_source(self, id_: str | None, display_name: str | None, source: str | None) -> Source:\n        source_dict = {}\n        if id_:\n            source_dict[\"id\"] = id_\n        if display_name:\n            source_dict[\"display_name\"] = display_name\n        if source:\n            # Handle case where source is a ChatOpenAI object\n            if hasattr(source, \"model_name\"):\n                source_dict[\"source\"] = source.model_name\n            elif hasattr(source, \"model\"):\n                source_dict[\"source\"] = str(source.model)\n            else:\n                source_dict[\"source\"] = str(source)\n        return Source(**source_dict)\n\n    async def message_response(self) -> Message:\n        # First convert the input to string if needed\n        text = self.convert_to_string()\n\n        # Get source properties\n        source, _, display_name, source_id = self.get_properties_from_source_component()\n\n        # Create or use existing Message object\n        if isinstance(self.input_value, Message) and not self.is_connected_to_chat_input():\n            message = self.input_value\n            # Update message properties\n            message.text = text\n            # Preserve existing session_id from the incoming message if it exists\n            existing_session_id = message.session_id\n        else:\n            message = Message(text=text)\n            existing_session_id = None\n\n        # Set message properties\n        message.sender = self.sender\n        message.sender_name = self.sender_name\n        # Preserve session_id from incoming message, or use component/graph session_id\n        message.session_id = (\n            self.session_id or existing_session_id or (self.graph.session_id if hasattr(self, \"graph\") else None) or \"\"\n        )\n        message.context_id = self.context_id\n        message.flow_id = self.graph.flow_id if hasattr(self, \"graph\") else None\n        message.properties.source = self._build_source(source_id, display_name, source)\n\n        # Store message if needed\n        if message.session_id and self.should_store_message:\n            stored_message = await self.send_message(message)\n            self.message.value = stored_message\n            message = stored_message\n\n        # Set accumulated token usage from all upstream LLM vertices.\n        # This must happen AFTER send_message() because streaming captures\n        # usage from chunks and would overwrite accumulated totals.\n        if hasattr(self, \"_vertex\") and self._vertex is not None:\n            accumulated_usage = self._vertex._accumulate_upstream_token_usage()  # noqa: SLF001\n            if accumulated_usage:\n                message.properties.usage = accumulated_usage\n                if self.should_store_message and message.get_id():\n                    message = await self._update_stored_message(message)\n                    await self._send_message_event(message, id_=message.get_id())\n\n        self.status = message\n        return message\n\n    def _serialize_data(self, data: Data) -> str:\n        \"\"\"Serialize Data object to JSON string.\"\"\"\n        # Convert data.data to JSON-serializable format\n        serializable_data = jsonable_encoder(data.data)\n        # Serialize with orjson, enabling pretty printing with indentation\n        json_bytes = orjson.dumps(serializable_data, option=orjson.OPT_INDENT_2)\n        # Convert bytes to string and wrap in Markdown code blocks\n        return \"```json\\n\" + json_bytes.decode(\"utf-8\") + \"\\n```\"\n\n    def _validate_input(self) -> None:\n        \"\"\"Validate the input data and raise ValueError if invalid.\"\"\"\n        if self.input_value is None:\n            msg = \"Input data cannot be None\"\n            raise ValueError(msg)\n        if isinstance(self.input_value, list) and not all(\n            isinstance(item, Message | Data | DataFrame | str) for item in self.input_value\n        ):\n            invalid_types = [\n                type(item).__name__\n                for item in self.input_value\n                if not isinstance(item, Message | Data | DataFrame | str)\n            ]\n            msg = f\"Expected Data or DataFrame or Message or str, got {invalid_types}\"\n            raise TypeError(msg)\n        if not isinstance(\n            self.input_value,\n            Message | Data | DataFrame | str | list | Generator | type(None),\n        ):\n            type_name = type(self.input_value).__name__\n            msg = f\"Expected Data or DataFrame or Message or str, Generator or None, got {type_name}\"\n            raise TypeError(msg)\n\n    def convert_to_string(self) -> str | Generator[Any, None, None]:\n        \"\"\"Convert input data to string with proper error handling.\"\"\"\n        self._validate_input()\n        if isinstance(self.input_value, list):\n            clean_data: bool = getattr(self, \"clean_data\", False)\n            return \"\\n\".join([safe_convert(item, clean_data=clean_data) for item in self.input_value])\n        if isinstance(self.input_value, Generator):\n            return self.input_value\n        return safe_convert(self.input_value)\n"
+              },
+              "context_id": {
+                "_input_type": "MessageTextInput",
+                "advanced": true,
+                "api_editable": false,
+                "display_name": "Context ID",
+                "dynamic": false,
+                "info": "The context ID of the chat. Adds an extra layer to the local memory.",
+                "input_types": [
+                  "Message"
+                ],
+                "list": false,
+                "list_add_label": "Add More",
+                "load_from_db": false,
+                "name": "context_id",
+                "override_skip": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "track_in_telemetry": false,
+                "type": "str",
+                "value": ""
+              },
+              "data_template": {
+                "_input_type": "MessageTextInput",
+                "advanced": true,
+                "api_editable": false,
+                "display_name": "Data Template",
+                "dynamic": false,
+                "info": "Template to convert Data to Text. If left empty, it will be dynamically set to the Data's text key.",
+                "input_types": [
+                  "Message"
+                ],
+                "list": false,
+                "list_add_label": "Add More",
+                "load_from_db": false,
+                "name": "data_template",
+                "override_skip": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "track_in_telemetry": false,
+                "type": "str",
+                "value": "{text}"
+              },
+              "input_value": {
+                "_input_type": "HandleInput",
+                "advanced": false,
+                "api_editable": false,
+                "display_name": "Inputs",
+                "dynamic": false,
+                "info": "Message to be passed as output.",
+                "input_types": [
+                  "Data",
+                  "JSON",
+                  "DataFrame",
+                  "Table",
+                  "Message"
+                ],
+                "list": false,
+                "list_add_label": "Add More",
+                "name": "input_value",
+                "override_skip": false,
+                "placeholder": "",
+                "required": true,
+                "show": true,
+                "title_case": false,
+                "trace_as_metadata": true,
+                "track_in_telemetry": false,
+                "type": "other",
+                "value": ""
+              },
+              "sender": {
+                "_input_type": "DropdownInput",
+                "advanced": true,
+                "api_editable": false,
+                "combobox": false,
+                "dialog_inputs": {},
+                "display_name": "Sender Type",
+                "dynamic": false,
+                "external_options": {},
+                "info": "Type of sender.",
+                "name": "sender",
+                "options": [
+                  "Machine",
+                  "User"
+                ],
+                "options_metadata": [],
+                "override_skip": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "toggle": false,
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "track_in_telemetry": true,
+                "type": "str",
+                "value": "Machine"
+              },
+              "sender_name": {
+                "_input_type": "MessageTextInput",
+                "advanced": true,
+                "api_editable": false,
+                "display_name": "Sender Name",
+                "dynamic": false,
+                "info": "Name of the sender.",
+                "input_types": [
+                  "Message"
+                ],
+                "list": false,
+                "list_add_label": "Add More",
+                "load_from_db": false,
+                "name": "sender_name",
+                "override_skip": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "track_in_telemetry": false,
+                "type": "str",
+                "value": "APPROVED"
+              },
+              "session_id": {
+                "_input_type": "MessageTextInput",
+                "advanced": true,
+                "api_editable": false,
+                "display_name": "Session ID",
+                "dynamic": false,
+                "info": "The session ID of the chat. If empty, the current session ID parameter will be used.",
+                "input_types": [
+                  "Message"
+                ],
+                "list": false,
+                "list_add_label": "Add More",
+                "load_from_db": false,
+                "name": "session_id",
+                "override_skip": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "track_in_telemetry": false,
+                "type": "str",
+                "value": ""
+              },
+              "should_store_message": {
+                "_input_type": "BoolInput",
+                "advanced": true,
+                "api_editable": false,
+                "display_name": "Store Messages",
+                "dynamic": false,
+                "info": "Store the message in the history.",
+                "list": false,
+                "list_add_label": "Add More",
+                "name": "should_store_message",
+                "override_skip": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "track_in_telemetry": true,
+                "type": "bool",
+                "value": true
+              }
+            },
+            "tool_mode": false,
+            "lf_version": "1.12.0.dev10"
+          },
+          "showNode": false,
+          "type": "ChatOutput",
+          "id": "ChatOutput-uTw2N"
+        },
+        "positionAbsolute": {
+          "x": 1060,
+          "y": -200
+        }
+      },
+      {
+        "id": "ChatOutput-D4NcR",
+        "type": "genericNode",
+        "position": {
+          "x": 1060,
+          "y": 220
+        },
+        "data": {
+          "node": {
+            "base_classes": [
+              "Message"
+            ],
+            "beta": false,
+            "conditional_paths": [],
+            "custom_fields": {},
+            "description": "Display a chat message in the Playground.",
+            "display_name": "Rejected Output",
+            "documentation": "https://docs.langflow.org/chat-input-and-output",
+            "edited": false,
+            "field_order": [
+              "input_value",
+              "should_store_message",
+              "sender",
+              "sender_name",
+              "session_id",
+              "context_id",
+              "data_template",
+              "clean_data"
+            ],
+            "frozen": false,
+            "icon": "MessagesSquare",
+            "legacy": false,
+            "metadata": {
+              "code_hash": "84009527d08c",
+              "dependencies": {
+                "dependencies": [
+                  {
+                    "name": "orjson",
+                    "version": "3.11.9"
+                  },
+                  {
+                    "name": "fastapi",
+                    "version": "0.139.2"
+                  },
+                  {
+                    "name": "lfx",
+                    "version": null
+                  }
+                ],
+                "total_dependencies": 3
+              },
+              "module": "lfx.components.input_output.chat_output.ChatOutput"
+            },
+            "minimized": true,
+            "output_types": [],
+            "outputs": [
+              {
+                "allows_loop": false,
+                "cache": true,
+                "display_name": "Output Message",
+                "group_outputs": false,
+                "method": "message_response",
+                "name": "message",
+                "selected": "Message",
+                "tool_mode": true,
+                "types": [
+                  "Message"
+                ],
+                "value": "__UNDEFINED__"
+              }
+            ],
+            "pinned": false,
+            "template": {
+              "_type": "Component",
+              "clean_data": {
+                "_input_type": "BoolInput",
+                "advanced": true,
+                "api_editable": false,
+                "display_name": "Basic Clean Data",
+                "dynamic": false,
+                "info": "Whether to clean data before converting to string.",
+                "list": false,
+                "list_add_label": "Add More",
+                "name": "clean_data",
+                "override_skip": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "track_in_telemetry": true,
+                "type": "bool",
+                "value": true
+              },
+              "code": {
+                "advanced": true,
+                "api_editable": false,
+                "dynamic": true,
+                "fileTypes": [],
+                "file_path": "",
+                "info": "",
+                "list": false,
+                "load_from_db": false,
+                "multiline": true,
+                "name": "code",
+                "password": false,
+                "placeholder": "",
+                "required": true,
+                "show": true,
+                "title_case": false,
+                "type": "code",
+                "value": "from collections.abc import Generator\nfrom typing import Any\n\nimport orjson\nfrom fastapi.encoders import jsonable_encoder\n\nfrom lfx.base.io.chat import ChatComponent\nfrom lfx.helpers.data import safe_convert\nfrom lfx.inputs.inputs import BoolInput, DropdownInput, HandleInput, MessageTextInput\nfrom lfx.schema.data import Data\nfrom lfx.schema.dataframe import DataFrame\nfrom lfx.schema.message import Message\nfrom lfx.schema.properties import Source\nfrom lfx.template.field.base import Output\nfrom lfx.utils.constants import (\n    MESSAGE_SENDER_AI,\n    MESSAGE_SENDER_NAME_AI,\n    MESSAGE_SENDER_USER,\n)\n\n\nclass ChatOutput(ChatComponent):\n    display_name = \"Chat Output\"\n    description = \"Display a chat message in the Playground.\"\n    documentation: str = \"https://docs.langflow.org/chat-input-and-output\"\n    icon = \"MessagesSquare\"\n    name = \"ChatOutput\"\n    minimized = True\n\n    inputs = [\n        HandleInput(\n            name=\"input_value\",\n            display_name=\"Inputs\",\n            info=\"Message to be passed as output.\",\n            input_types=[\"Data\", \"JSON\", \"DataFrame\", \"Table\", \"Message\"],\n            required=True,\n        ),\n        BoolInput(\n            name=\"should_store_message\",\n            display_name=\"Store Messages\",\n            info=\"Store the message in the history.\",\n            value=True,\n            advanced=True,\n        ),\n        DropdownInput(\n            name=\"sender\",\n            display_name=\"Sender Type\",\n            options=[MESSAGE_SENDER_AI, MESSAGE_SENDER_USER],\n            value=MESSAGE_SENDER_AI,\n            advanced=True,\n            info=\"Type of sender.\",\n        ),\n        MessageTextInput(\n            name=\"sender_name\",\n            display_name=\"Sender Name\",\n            info=\"Name of the sender.\",\n            value=MESSAGE_SENDER_NAME_AI,\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"session_id\",\n            display_name=\"Session ID\",\n            info=\"The session ID of the chat. If empty, the current session ID parameter will be used.\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"context_id\",\n            display_name=\"Context ID\",\n            info=\"The context ID of the chat. Adds an extra layer to the local memory.\",\n            value=\"\",\n            advanced=True,\n        ),\n        MessageTextInput(\n            name=\"data_template\",\n            display_name=\"Data Template\",\n            value=\"{text}\",\n            advanced=True,\n            info=\"Template to convert Data to Text. If left empty, it will be dynamically set to the Data's text key.\",\n        ),\n        BoolInput(\n            name=\"clean_data\",\n            display_name=\"Basic Clean Data\",\n            value=True,\n            advanced=True,\n            info=\"Whether to clean data before converting to string.\",\n        ),\n    ]\n    outputs = [\n        Output(\n            display_name=\"Output Message\",\n            name=\"message\",\n            method=\"message_response\",\n        ),\n    ]\n\n    def _build_source(self, id_: str | None, display_name: str | None, source: str | None) -> Source:\n        source_dict = {}\n        if id_:\n            source_dict[\"id\"] = id_\n        if display_name:\n            source_dict[\"display_name\"] = display_name\n        if source:\n            # Handle case where source is a ChatOpenAI object\n            if hasattr(source, \"model_name\"):\n                source_dict[\"source\"] = source.model_name\n            elif hasattr(source, \"model\"):\n                source_dict[\"source\"] = str(source.model)\n            else:\n                source_dict[\"source\"] = str(source)\n        return Source(**source_dict)\n\n    async def message_response(self) -> Message:\n        # First convert the input to string if needed\n        text = self.convert_to_string()\n\n        # Get source properties\n        source, _, display_name, source_id = self.get_properties_from_source_component()\n\n        # Create or use existing Message object\n        if isinstance(self.input_value, Message) and not self.is_connected_to_chat_input():\n            message = self.input_value\n            # Update message properties\n            message.text = text\n            # Preserve existing session_id from the incoming message if it exists\n            existing_session_id = message.session_id\n        else:\n            message = Message(text=text)\n            existing_session_id = None\n\n        # Set message properties\n        message.sender = self.sender\n        message.sender_name = self.sender_name\n        # Preserve session_id from incoming message, or use component/graph session_id\n        message.session_id = (\n            self.session_id or existing_session_id or (self.graph.session_id if hasattr(self, \"graph\") else None) or \"\"\n        )\n        message.context_id = self.context_id\n        message.flow_id = self.graph.flow_id if hasattr(self, \"graph\") else None\n        message.properties.source = self._build_source(source_id, display_name, source)\n\n        # Store message if needed\n        if message.session_id and self.should_store_message:\n            stored_message = await self.send_message(message)\n            self.message.value = stored_message\n            message = stored_message\n\n        # Set accumulated token usage from all upstream LLM vertices.\n        # This must happen AFTER send_message() because streaming captures\n        # usage from chunks and would overwrite accumulated totals.\n        if hasattr(self, \"_vertex\") and self._vertex is not None:\n            accumulated_usage = self._vertex._accumulate_upstream_token_usage()  # noqa: SLF001\n            if accumulated_usage:\n                message.properties.usage = accumulated_usage\n                if self.should_store_message and message.get_id():\n                    message = await self._update_stored_message(message)\n                    await self._send_message_event(message, id_=message.get_id())\n\n        self.status = message\n        return message\n\n    def _serialize_data(self, data: Data) -> str:\n        \"\"\"Serialize Data object to JSON string.\"\"\"\n        # Convert data.data to JSON-serializable format\n        serializable_data = jsonable_encoder(data.data)\n        # Serialize with orjson, enabling pretty printing with indentation\n        json_bytes = orjson.dumps(serializable_data, option=orjson.OPT_INDENT_2)\n        # Convert bytes to string and wrap in Markdown code blocks\n        return \"```json\\n\" + json_bytes.decode(\"utf-8\") + \"\\n```\"\n\n    def _validate_input(self) -> None:\n        \"\"\"Validate the input data and raise ValueError if invalid.\"\"\"\n        if self.input_value is None:\n            msg = \"Input data cannot be None\"\n            raise ValueError(msg)\n        if isinstance(self.input_value, list) and not all(\n            isinstance(item, Message | Data | DataFrame | str) for item in self.input_value\n        ):\n            invalid_types = [\n                type(item).__name__\n                for item in self.input_value\n                if not isinstance(item, Message | Data | DataFrame | str)\n            ]\n            msg = f\"Expected Data or DataFrame or Message or str, got {invalid_types}\"\n            raise TypeError(msg)\n        if not isinstance(\n            self.input_value,\n            Message | Data | DataFrame | str | list | Generator | type(None),\n        ):\n            type_name = type(self.input_value).__name__\n            msg = f\"Expected Data or DataFrame or Message or str, Generator or None, got {type_name}\"\n            raise TypeError(msg)\n\n    def convert_to_string(self) -> str | Generator[Any, None, None]:\n        \"\"\"Convert input data to string with proper error handling.\"\"\"\n        self._validate_input()\n        if isinstance(self.input_value, list):\n            clean_data: bool = getattr(self, \"clean_data\", False)\n            return \"\\n\".join([safe_convert(item, clean_data=clean_data) for item in self.input_value])\n        if isinstance(self.input_value, Generator):\n            return self.input_value\n        return safe_convert(self.input_value)\n"
+              },
+              "context_id": {
+                "_input_type": "MessageTextInput",
+                "advanced": true,
+                "api_editable": false,
+                "display_name": "Context ID",
+                "dynamic": false,
+                "info": "The context ID of the chat. Adds an extra layer to the local memory.",
+                "input_types": [
+                  "Message"
+                ],
+                "list": false,
+                "list_add_label": "Add More",
+                "load_from_db": false,
+                "name": "context_id",
+                "override_skip": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "track_in_telemetry": false,
+                "type": "str",
+                "value": ""
+              },
+              "data_template": {
+                "_input_type": "MessageTextInput",
+                "advanced": true,
+                "api_editable": false,
+                "display_name": "Data Template",
+                "dynamic": false,
+                "info": "Template to convert Data to Text. If left empty, it will be dynamically set to the Data's text key.",
+                "input_types": [
+                  "Message"
+                ],
+                "list": false,
+                "list_add_label": "Add More",
+                "load_from_db": false,
+                "name": "data_template",
+                "override_skip": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "track_in_telemetry": false,
+                "type": "str",
+                "value": "{text}"
+              },
+              "input_value": {
+                "_input_type": "HandleInput",
+                "advanced": false,
+                "api_editable": false,
+                "display_name": "Inputs",
+                "dynamic": false,
+                "info": "Message to be passed as output.",
+                "input_types": [
+                  "Data",
+                  "JSON",
+                  "DataFrame",
+                  "Table",
+                  "Message"
+                ],
+                "list": false,
+                "list_add_label": "Add More",
+                "name": "input_value",
+                "override_skip": false,
+                "placeholder": "",
+                "required": true,
+                "show": true,
+                "title_case": false,
+                "trace_as_metadata": true,
+                "track_in_telemetry": false,
+                "type": "other",
+                "value": ""
+              },
+              "sender": {
+                "_input_type": "DropdownInput",
+                "advanced": true,
+                "api_editable": false,
+                "combobox": false,
+                "dialog_inputs": {},
+                "display_name": "Sender Type",
+                "dynamic": false,
+                "external_options": {},
+                "info": "Type of sender.",
+                "name": "sender",
+                "options": [
+                  "Machine",
+                  "User"
+                ],
+                "options_metadata": [],
+                "override_skip": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "toggle": false,
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "track_in_telemetry": true,
+                "type": "str",
+                "value": "Machine"
+              },
+              "sender_name": {
+                "_input_type": "MessageTextInput",
+                "advanced": true,
+                "api_editable": false,
+                "display_name": "Sender Name",
+                "dynamic": false,
+                "info": "Name of the sender.",
+                "input_types": [
+                  "Message"
+                ],
+                "list": false,
+                "list_add_label": "Add More",
+                "load_from_db": false,
+                "name": "sender_name",
+                "override_skip": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "track_in_telemetry": false,
+                "type": "str",
+                "value": "REJECTED"
+              },
+              "session_id": {
+                "_input_type": "MessageTextInput",
+                "advanced": true,
+                "api_editable": false,
+                "display_name": "Session ID",
+                "dynamic": false,
+                "info": "The session ID of the chat. If empty, the current session ID parameter will be used.",
+                "input_types": [
+                  "Message"
+                ],
+                "list": false,
+                "list_add_label": "Add More",
+                "load_from_db": false,
+                "name": "session_id",
+                "override_skip": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_input": true,
+                "trace_as_metadata": true,
+                "track_in_telemetry": false,
+                "type": "str",
+                "value": ""
+              },
+              "should_store_message": {
+                "_input_type": "BoolInput",
+                "advanced": true,
+                "api_editable": false,
+                "display_name": "Store Messages",
+                "dynamic": false,
+                "info": "Store the message in the history.",
+                "list": false,
+                "list_add_label": "Add More",
+                "name": "should_store_message",
+                "override_skip": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "track_in_telemetry": true,
+                "type": "bool",
+                "value": true
+              }
+            },
+            "tool_mode": false,
+            "lf_version": "1.12.0.dev10"
+          },
+          "showNode": false,
+          "type": "ChatOutput",
+          "id": "ChatOutput-D4NcR"
+        },
+        "positionAbsolute": {
+          "x": 1060,
+          "y": 220
+        }
+      }
+    ],
+    "edges": [
+      {
+        "animated": false,
+        "className": "",
+        "data": {
+          "sourceHandle": {
+            "dataType": "ChatInput",
+            "id": "ChatInput-FXoDx",
+            "name": "message",
+            "output_types": [
+              "Message"
+            ]
+          },
+          "targetHandle": {
+            "fieldName": "prompt",
+            "id": "HumanInput-TgsrH",
+            "inputTypes": [
+              "Message"
+            ],
+            "type": "str"
+          }
+        },
+        "id": "reactflow__edge-ChatInput-FXoDx{œdataTypeœ:œChatInputœ,œidœ:œChatInput-FXoDxœ,œnameœ:œmessageœ,œoutput_typesœ:[œMessageœ]}-HumanInput-TgsrH{œfieldNameœ:œpromptœ,œidœ:œHumanInput-TgsrHœ,œinputTypesœ:[œMessageœ],œtypeœ:œstrœ}",
+        "selected": false,
+        "source": "ChatInput-FXoDx",
+        "sourceHandle": "{œdataTypeœ:œChatInputœ,œidœ:œChatInput-FXoDxœ,œnameœ:œmessageœ,œoutput_typesœ:[œMessageœ]}",
+        "target": "HumanInput-TgsrH",
+        "targetHandle": "{œfieldNameœ:œpromptœ,œidœ:œHumanInput-TgsrHœ,œinputTypesœ:[œMessageœ],œtypeœ:œstrœ}"
+      },
+      {
+        "animated": false,
+        "className": "",
+        "data": {
+          "sourceHandle": {
+            "dataType": "HumanInput",
+            "id": "HumanInput-TgsrH",
+            "name": "branch_approve",
+            "output_types": [
+              "Message"
+            ]
+          },
+          "targetHandle": {
+            "fieldName": "input_value",
+            "id": "ChatOutput-uTw2N",
+            "inputTypes": [
+              "Data",
+              "JSON",
+              "DataFrame",
+              "Table",
+              "Message"
+            ],
+            "type": "other"
+          }
+        },
+        "id": "reactflow__edge-HumanInput-TgsrH{œdataTypeœ:œHumanInputœ,œidœ:œHumanInput-TgsrHœ,œnameœ:œbranch_approveœ,œoutput_typesœ:[œMessageœ]}-ChatOutput-uTw2N{œfieldNameœ:œinput_valueœ,œidœ:œChatOutput-uTw2Nœ,œinputTypesœ:[œDataœ,œJSONœ,œDataFrameœ,œTableœ,œMessageœ],œtypeœ:œotherœ}",
+        "selected": false,
+        "source": "HumanInput-TgsrH",
+        "sourceHandle": "{œdataTypeœ:œHumanInputœ,œidœ:œHumanInput-TgsrHœ,œnameœ:œbranch_approveœ,œoutput_typesœ:[œMessageœ]}",
+        "target": "ChatOutput-uTw2N",
+        "targetHandle": "{œfieldNameœ:œinput_valueœ,œidœ:œChatOutput-uTw2Nœ,œinputTypesœ:[œDataœ,œJSONœ,œDataFrameœ,œTableœ,œMessageœ],œtypeœ:œotherœ}"
+      },
+      {
+        "animated": false,
+        "className": "",
+        "data": {
+          "sourceHandle": {
+            "dataType": "HumanInput",
+            "id": "HumanInput-TgsrH",
+            "name": "branch_reject",
+            "output_types": [
+              "Message"
+            ]
+          },
+          "targetHandle": {
+            "fieldName": "input_value",
+            "id": "ChatOutput-D4NcR",
+            "inputTypes": [
+              "Data",
+              "JSON",
+              "DataFrame",
+              "Table",
+              "Message"
+            ],
+            "type": "other"
+          }
+        },
+        "id": "reactflow__edge-HumanInput-TgsrH{œdataTypeœ:œHumanInputœ,œidœ:œHumanInput-TgsrHœ,œnameœ:œbranch_rejectœ,œoutput_typesœ:[œMessageœ]}-ChatOutput-D4NcR{œfieldNameœ:œinput_valueœ,œidœ:œChatOutput-D4NcRœ,œinputTypesœ:[œDataœ,œJSONœ,œDataFrameœ,œTableœ,œMessageœ],œtypeœ:œotherœ}",
+        "selected": false,
+        "source": "HumanInput-TgsrH",
+        "sourceHandle": "{œdataTypeœ:œHumanInputœ,œidœ:œHumanInput-TgsrHœ,œnameœ:œbranch_rejectœ,œoutput_typesœ:[œMessageœ]}",
+        "target": "ChatOutput-D4NcR",
+        "targetHandle": "{œfieldNameœ:œinput_valueœ,œidœ:œChatOutput-D4NcRœ,œinputTypesœ:[œDataœ,œJSONœ,œDataFrameœ,œTableœ,œMessageœ],œtypeœ:œotherœ}"
+      }
+    ],
+    "viewport": {
+      "x": 0,
+      "y": 0,
+      "zoom": 0.5
+    }
+  },
+  "name": "HITL Approve/Reject Branching",
+  "description": "Chat Input -> Human Input (Approve/Reject) -> one Chat Output per branch",
+  "is_component": false
+}

--- a/tests/assets/flows/human-input-branching-fixture.json
+++ b/tests/assets/flows/human-input-branching-fixture.json
@@ -514,12 +514,6 @@
                   "value": 3
                 }
               },
-              "_frontend_node_flow_id": {
-                "value": "6e428105-7720-4474-8933-1bcabc035d7b"
-              },
-              "_frontend_node_folder_id": {
-                "value": "70af1547-0bd1-4799-be28-41f738b6e6dc"
-              },
               "is_refresh": false
             },
             "tool_mode": false,

--- a/tests/tests-automations/regression/core-functionality/playground/human-input-pause-resume.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/human-input-pause-resume.spec.ts
@@ -65,10 +65,14 @@ const bubble = (page: Page, sender: string) =>
 // (scoped) — never a global wipe, which kills flows other workers are driving.
 const createdFlowIds: string[] = [];
 
-// Each test creates a named flow through the API and those creations race on the
-// backend's unique-name suffixing under parallelism (same reason as the sibling
-// fixture specs).
-test.describe.configure({ mode: "serial" });
+// PARALLEL-SAFE, deliberately not serial. Each test owns its flow (a unique
+// `${Date.now()}-${random}` name, so the backend's unique-name suffixing has
+// nothing to race) and its own page, and a suspended run is flow-scoped, so the
+// two cannot observe each other. The sibling fixture specs run serial for the
+// name race; inheriting that here would cost real signal — under `mode: "serial"`
+// a flake in the first test SKIPS the second, so one bad day in the daily would
+// lose the Reject verdict entirely. Measured green at `--workers=2`.
+
 
 /**
  * Create the fixture flow via the API, open it on the canvas and open the
@@ -79,7 +83,7 @@ test.describe.configure({ mode: "serial" });
  * asynchronously and races any text typed directly into it
  * (`authoring-conventions.md`).
  */
-async function openHitlPlayground(page: Page): Promise<void> {
+async function openHitlPlayground(page: Page): Promise<string> {
   const fixture = JSON.parse(readFileSync(FIXTURE_PATH, "utf-8"));
   const authHeader = await getAuthToken(page.request);
   const headers: Record<string, string> = authHeader
@@ -103,12 +107,30 @@ async function openHitlPlayground(page: Page): Promise<void> {
   await expect(page.getByTestId("title-Human Input")).toBeVisible({
     timeout: 30000,
   });
-  // Both branch sinks must be on the canvas: a Human Input with no downstream
-  // consumer SKIPS the pause entirely (`_has_downstream_consumer()` →
-  // "Skipped: no connected outputs"), so a fixture that lost an edge would make
-  // the whole spec assert nothing.
-  await expect(page.getByTestId("title-Approved Output")).toBeVisible();
-  await expect(page.getByTestId("title-Rejected Output")).toBeVisible();
+  // Both branch sinks are on the canvas.
+  //
+  // Explicit budgets, like every other readiness check here: the config sets no
+  // `expect.timeout`, so a bare assertion gets Playwright's 5 s default, and a
+  // canvas that hydrates node-by-node under a saturated CI backend would fail
+  // these while the flow is merely slow.
+  await expect(page.getByTestId("title-Approved Output")).toBeVisible({
+    timeout: 30000,
+  });
+  await expect(page.getByTestId("title-Rejected Output")).toBeVisible({
+    timeout: 30000,
+  });
+
+  // The EDGES are the precondition, and they need their own assertion: React
+  // Flow renders nodes independently of edges, so a fixture that lost a branch
+  // edge still shows both titles above (measured — both visible with both branch
+  // edges stripped). Without this, that defect surfaces 30 s later as "the
+  // decision card never appeared", blaming the card UI for a wiring problem —
+  // because a Human Input with no downstream consumer SKIPS the pause entirely
+  // (`_has_downstream_consumer()` → "Skipped: no connected outputs").
+  await expect(page.locator(".react-flow__edge")).toHaveCount(3, {
+    timeout: 30000,
+  });
+
   await adjustScreenView(page);
 
   await page.getByTestId("playground-btn-flow-io").click();
@@ -116,10 +138,32 @@ async function openHitlPlayground(page: Page): Promise<void> {
     SENTINEL_PROMPT,
     { timeout: 30000 },
   );
+
+  return flowId;
+}
+
+/**
+ * How many HITL requests the backend currently holds suspended for this flow.
+ *
+ * The server-side counterpart to the card: `GET /api/v2/workflows/pending` lists
+ * the suspended jobs of ONE flow (it 422s without `flow_id`, so it can never see
+ * another spec's run). It is what separates "the card is on screen" from "the run
+ * is parked", and, after the answer, "a bubble rendered" from "the run is no
+ * longer suspended".
+ */
+async function pendingHitlCount(page: Page, flowId: string): Promise<number> {
+  const authHeader = await getAuthToken(page.request);
+  const res = await page.request.get(
+    `/api/v2/workflows/pending?flow_id=${flowId}`,
+    authHeader ? { headers: { Authorization: authHeader } } : undefined,
+  );
+  if (!res.ok()) throw new Error(`GET /workflows/pending → ${res.status()}`);
+  const body = await res.json();
+  return Array.isArray(body) ? body.length : -1;
 }
 
 /** Send the pre-filled prompt and wait for the run to park on the decision card. */
-async function sendAndExpectPause(page: Page): Promise<void> {
+async function sendAndExpectPause(page: Page, flowId: string): Promise<void> {
   await page.getByTestId("button-send").click();
 
   const card = page.getByTestId("human-input-card");
@@ -127,12 +171,24 @@ async function sendAndExpectPause(page: Page): Promise<void> {
   await expect(card).toContainText(SENTINEL_PROMPT);
 
   // One enabled button per configured choice.
-  await expect(page.getByTestId(BRANCHES.approve.decision)).toBeEnabled();
-  await expect(page.getByTestId(BRANCHES.reject.decision)).toBeEnabled();
+  await expect(page.getByTestId(BRANCHES.approve.decision)).toBeEnabled({
+    timeout: 15000,
+  });
+  await expect(page.getByTestId(BRANCHES.reject.decision)).toBeEnabled({
+    timeout: 15000,
+  });
 
-  // This is what makes it a PAUSE and not a slow completion: neither branch has
-  // emitted. (The empty `chat-message-AI-` bubble present here is the Human
-  // Input's own `Message(text="")` on the suspend path — deliberately ignored.)
+  // The run is parked SERVER-SIDE, not just visually: the backend holds exactly
+  // one suspended request for this flow.
+  await expect
+    .poll(() => pendingHitlCount(page, flowId), { timeout: 30000 })
+    .toBe(1);
+
+  // And it is a pause rather than a slow completion: neither branch has emitted.
+  // (The empty `chat-message-AI-` bubble present here is NOT the component's
+  // return value — it is a host message the frontend synthesizes in
+  // `injectHumanInputCard()` purely to carry the card's content block. Ignored on
+  // purpose; every assertion here is scoped to the sender-named bubbles.)
   await expect(bubble(page, BRANCHES.approve.sender)).toHaveCount(0);
   await expect(bubble(page, BRANCHES.reject.sender)).toHaveCount(0);
 }
@@ -145,6 +201,7 @@ async function sendAndExpectPause(page: Page): Promise<void> {
  */
 async function answerAndExpectExclusiveRouting(
   page: Page,
+  flowId: string,
   chosen: keyof typeof BRANCHES,
 ): Promise<void> {
   const other = chosen === "approve" ? "reject" : "approve";
@@ -156,7 +213,20 @@ async function answerAndExpectExclusiveRouting(
   });
   await expect(bubble(page, BRANCHES[other].sender)).toHaveCount(0);
 
-  // The card records the answer: it keeps only the chosen action, disabled.
+  // The run left the suspended state — the answer reached the backend and the
+  // job resumed. Without this, a resume that silently never completed would pass
+  // every assertion above: the routed bubble arrives through the message-query
+  // invalidation, independent of the run's own event stream.
+  await expect
+    .poll(() => pendingHitlCount(page, flowId), { timeout: 30000 })
+    .toBe(0);
+
+  // The card's own affordance follows the answer: only the chosen action remains,
+  // disabled. Deliberately weak claims — `HumanInputCard` sets this from local
+  // state synchronously (measured 45 ms after the click, before the request is
+  // even sent) and keeps it locked on an error too, so this pins the UI, never
+  // that the backend accepted anything. The `pending` poll above is what does
+  // that.
   await expect(page.getByTestId(BRANCHES[other].decision)).toHaveCount(0);
   await expect(page.getByTestId(BRANCHES[chosen].decision)).toBeDisabled();
 }
@@ -167,7 +237,17 @@ test.afterEach(async ({ page }) => {
   // Leave the editor first so it stops polling `GET /flows/{id}/events` on a
   // flow about to be deleted, then pass an explicit Bearer — `page.request` is
   // unauthenticated under AUTO_LOGIN and would 401.
-  await page.goto("/").catch(() => {});
+  await page.goto("/").catch((error: unknown) => {
+    // Neither swallowed nor rethrown, on purpose. Rethrowing would abort this
+    // hook BEFORE the deletes below — the load-bearing half — and leak the flow;
+    // swallowing silently would hide why the editor kept 404-polling a deleted
+    // flow, which is the whole reason for leaving it first.
+    const message = (error as Error)?.message?.split("\n")[0] ?? String(error);
+    console.warn(
+      `⚠️  teardown: could not leave the flow editor (${message}) — the deletes ` +
+        `below still run, so expect 404 noise from the editor's events poll.`,
+    );
+  });
   const authHeader = await getAuthToken(page.request);
   const opts = authHeader
     ? { headers: { Authorization: authHeader } }
@@ -181,16 +261,18 @@ test.describe("Human Input pause/resume in the Playground", () => {
   test("approving a Human Input pause routes only the approved branch",
     { tag: ["@stable", "@release", "@playground"] },
     async ({ page }) => {
+      let flowId = "";
+
       await test.step("Open the pre-wired HITL flow in the Playground", async () => {
-        await openHitlPlayground(page);
+        flowId = await openHitlPlayground(page);
       });
 
       await test.step("Sending the prompt suspends the run on the decision card", async () => {
-        await sendAndExpectPause(page);
+        await sendAndExpectPause(page, flowId);
       });
 
       await test.step("Approving resumes the run through the approved branch only", async () => {
-        await answerAndExpectExclusiveRouting(page, "approve");
+        await answerAndExpectExclusiveRouting(page, flowId, "approve");
       });
     },
   );
@@ -198,16 +280,18 @@ test.describe("Human Input pause/resume in the Playground", () => {
   test("rejecting a Human Input pause routes only the reject branch",
     { tag: ["@stable", "@release", "@playground"] },
     async ({ page }) => {
+      let flowId = "";
+
       await test.step("Open the pre-wired HITL flow in the Playground", async () => {
-        await openHitlPlayground(page);
+        flowId = await openHitlPlayground(page);
       });
 
       await test.step("Sending the prompt suspends the run on the decision card", async () => {
-        await sendAndExpectPause(page);
+        await sendAndExpectPause(page, flowId);
       });
 
       await test.step("Rejecting resumes the run through the reject branch only", async () => {
-        await answerAndExpectExclusiveRouting(page, "reject");
+        await answerAndExpectExclusiveRouting(page, flowId, "reject");
       });
     },
   );

--- a/tests/tests-automations/regression/core-functionality/playground/human-input-pause-resume.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/human-input-pause-resume.spec.ts
@@ -1,0 +1,214 @@
+/**
+ * Human Input pause/resume in the Playground — the HITL decision card.
+ *
+ * The execution half of the Human Input feature (Langflow 1.11.0 — upstream
+ * #13633 durable background execution + suspend/resume, #14090 polish): sending
+ * a message parks the run and renders the decision card, answering it resumes
+ * the run, and the answer routes EXACTLY one branch.
+ *
+ * Two mirrored tests, Approve and Reject. Mirroring is the point: a spec that
+ * only ever approves cannot distinguish exclusive routing from "the approve
+ * branch is the only one wired".
+ *
+ * Sibling coverage — do not duplicate here:
+ * - The node's configuration surface (default handles, adding a choice live,
+ *   persistence across reload) is `core-components/human-input-node-config.spec.ts`
+ *   (issue #1190). This spec never edits the node.
+ * - `Enable Fallback` / `Timeout`, recovering a suspended run after a reload
+ *   (`GET /api/v2/workflows/pending`) and the resume API's 409/422 guards are
+ *   listed as out of scope in the spec doc.
+ *
+ * Spec doc: `docs/core-functionality/playground/human-input-pause-resume.md`.
+ * No provider credentials — `route_branch()` returns the prompt text itself.
+ */
+
+import { readFileSync } from "fs";
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { createFlow } from "../../../../helpers/flows/create-flow";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
+
+// Pre-wired fixture: Chat Input (input_value = SENTINEL_PROMPT) -> Human Input
+// (default Approve/Reject) -> one Chat Output per branch, each with its own
+// `sender_name`. Built by wiring it in the UI on a live nightly and exporting
+// through `GET /api/v1/flows/{id}` — a hand-written flow JSON renders empty
+// (nodes need `type: "genericNode"` plus their full template) and an edge only
+// attaches when its `sourceHandle` matches the handle's own `data-handleid`
+// verbatim.
+const FIXTURE_PATH = "tests/assets/flows/human-input-branching-fixture.json";
+
+// The Chat Input's stored value. The Playground pre-fills from the node, so this
+// is also the text of the user bubble, of the card's prompt, and of whichever
+// branch output emits.
+const SENTINEL_PROMPT = "HITL-1189 please review this request";
+
+/**
+ * The two branch sinks, keyed by the decision that should reach them.
+ *
+ * `sender_name` is what makes routing observable at all: `route_branch()`
+ * returns the same `Message(text=prompt)` on whichever branch wins, so both
+ * Chat Outputs would emit identical text. The bubble testid is
+ * `chat-message-${sender_name}-${text}`, so a distinct sender per branch turns
+ * "only the approved branch ran" into an exact locator plus a `toHaveCount(0)`.
+ */
+const BRANCHES = {
+  approve: { decision: "human-input-decision-approve", sender: "APPROVED" },
+  reject: { decision: "human-input-decision-reject", sender: "REJECTED" },
+} as const;
+
+const bubble = (page: Page, sender: string) =>
+  page.getByTestId(`chat-message-${sender}-${SENTINEL_PROMPT}`);
+
+// Ids of the flows each test creates; teardown deletes only these via the API
+// (scoped) — never a global wipe, which kills flows other workers are driving.
+const createdFlowIds: string[] = [];
+
+// Each test creates a named flow through the API and those creations race on the
+// backend's unique-name suffixing under parallelism (same reason as the sibling
+// fixture specs).
+test.describe.configure({ mode: "serial" });
+
+/**
+ * Create the fixture flow via the API, open it on the canvas and open the
+ * Playground, ready for a run.
+ *
+ * The Playground input is asserted to be **pre-filled** from the Chat Input node
+ * rather than typed into: that field re-injects the template default
+ * asynchronously and races any text typed directly into it
+ * (`authoring-conventions.md`).
+ */
+async function openHitlPlayground(page: Page): Promise<void> {
+  const fixture = JSON.parse(readFileSync(FIXTURE_PATH, "utf-8"));
+  const authHeader = await getAuthToken(page.request);
+  const headers: Record<string, string> = authHeader
+    ? { Authorization: authHeader }
+    : {};
+
+  const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+  const flowId = await createFlow(
+    page.request,
+    {
+      name: `HITL Approve Reject ${uniqueSuffix}`,
+      description: fixture.description,
+      data: fixture.data,
+      is_component: false,
+    },
+    { headers },
+  );
+  createdFlowIds.push(flowId);
+
+  await page.goto(`/flow/${flowId}`);
+  await expect(page.getByTestId("title-Human Input")).toBeVisible({
+    timeout: 30000,
+  });
+  // Both branch sinks must be on the canvas: a Human Input with no downstream
+  // consumer SKIPS the pause entirely (`_has_downstream_consumer()` →
+  // "Skipped: no connected outputs"), so a fixture that lost an edge would make
+  // the whole spec assert nothing.
+  await expect(page.getByTestId("title-Approved Output")).toBeVisible();
+  await expect(page.getByTestId("title-Rejected Output")).toBeVisible();
+  await adjustScreenView(page);
+
+  await page.getByTestId("playground-btn-flow-io").click();
+  await expect(page.getByTestId("input-chat-playground")).toHaveValue(
+    SENTINEL_PROMPT,
+    { timeout: 30000 },
+  );
+}
+
+/** Send the pre-filled prompt and wait for the run to park on the decision card. */
+async function sendAndExpectPause(page: Page): Promise<void> {
+  await page.getByTestId("button-send").click();
+
+  const card = page.getByTestId("human-input-card");
+  await expect(card).toBeVisible({ timeout: 30000 });
+  await expect(card).toContainText(SENTINEL_PROMPT);
+
+  // One enabled button per configured choice.
+  await expect(page.getByTestId(BRANCHES.approve.decision)).toBeEnabled();
+  await expect(page.getByTestId(BRANCHES.reject.decision)).toBeEnabled();
+
+  // This is what makes it a PAUSE and not a slow completion: neither branch has
+  // emitted. (The empty `chat-message-AI-` bubble present here is the Human
+  // Input's own `Message(text="")` on the suspend path — deliberately ignored.)
+  await expect(bubble(page, BRANCHES.approve.sender)).toHaveCount(0);
+  await expect(bubble(page, BRANCHES.reject.sender)).toHaveCount(0);
+}
+
+/**
+ * Answer the card and assert the run resumed through exactly one branch.
+ *
+ * The positive assertion runs FIRST, so the `toHaveCount(0)` that follows cannot
+ * pass vacuously on a page where nothing rendered at all.
+ */
+async function answerAndExpectExclusiveRouting(
+  page: Page,
+  chosen: keyof typeof BRANCHES,
+): Promise<void> {
+  const other = chosen === "approve" ? "reject" : "approve";
+
+  await page.getByTestId(BRANCHES[chosen].decision).click();
+
+  await expect(bubble(page, BRANCHES[chosen].sender)).toBeVisible({
+    timeout: 30000,
+  });
+  await expect(bubble(page, BRANCHES[other].sender)).toHaveCount(0);
+
+  // The card records the answer: it keeps only the chosen action, disabled.
+  await expect(page.getByTestId(BRANCHES[other].decision)).toHaveCount(0);
+  await expect(page.getByTestId(BRANCHES[chosen].decision)).toBeDisabled();
+}
+
+test.afterEach(async ({ page }) => {
+  const ids = createdFlowIds.splice(0);
+  if (ids.length === 0) return;
+  // Leave the editor first so it stops polling `GET /flows/{id}/events` on a
+  // flow about to be deleted, then pass an explicit Bearer — `page.request` is
+  // unauthenticated under AUTO_LOGIN and would 401.
+  await page.goto("/").catch(() => {});
+  const authHeader = await getAuthToken(page.request);
+  const opts = authHeader
+    ? { headers: { Authorization: authHeader } }
+    : undefined;
+  for (const id of ids) {
+    await deleteFlow(page.request, id, opts);
+  }
+});
+
+test.describe("Human Input pause/resume in the Playground", () => {
+  test("approving a Human Input pause routes only the approved branch",
+    { tag: ["@stable", "@release", "@playground"] },
+    async ({ page }) => {
+      await test.step("Open the pre-wired HITL flow in the Playground", async () => {
+        await openHitlPlayground(page);
+      });
+
+      await test.step("Sending the prompt suspends the run on the decision card", async () => {
+        await sendAndExpectPause(page);
+      });
+
+      await test.step("Approving resumes the run through the approved branch only", async () => {
+        await answerAndExpectExclusiveRouting(page, "approve");
+      });
+    },
+  );
+
+  test("rejecting a Human Input pause routes only the reject branch",
+    { tag: ["@stable", "@release", "@playground"] },
+    async ({ page }) => {
+      await test.step("Open the pre-wired HITL flow in the Playground", async () => {
+        await openHitlPlayground(page);
+      });
+
+      await test.step("Sending the prompt suspends the run on the decision card", async () => {
+        await sendAndExpectPause(page);
+      });
+
+      await test.step("Rejecting resumes the run through the reject branch only", async () => {
+        await answerAndExpectExclusiveRouting(page, "reject");
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #1189.

Closes the `[ ]` gap in `QA-CHECKLIST.md` §9.6 — the **execution** half of Human Input
(HITL, Langflow 1.11.0 — upstream langflow-ai/langflow#13633 durable background execution
+ suspend/resume, #14090 polish; manual recipes HITL-01/02/03). Its sibling #1190
(PR #1284, merged) covers the node's **configuration** surface and explicitly scopes
execution out; this PR never edits the node. No provider credentials are involved:
`route_branch()` returns the prompt text itself.

## 1. Covered tests

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `approving a Human Input pause routes only the approved branch` | The run **parks**: `human-input-card` renders carrying the prompt, both decisions enabled, and **neither** branch output has emitted — that last part is what separates a pause from a slow completion. Answering **Approve** then produces `chat-message-APPROVED-<prompt>` while `chat-message-REJECTED-<prompt>` stays at count `0` (exclusive routing — the component calls `stop("branch_<action_id>")` on every non-chosen branch), and the card records the answer: the `-reject` button is removed and `-approve` is disabled. |
| 2 | `rejecting a Human Input pause routes only the reject branch` | The mirror. Mirroring is not redundancy: a spec that only ever approves cannot distinguish exclusive routing from *"the approve branch is the only one wired"*. |

## 2. How the test was built

- **Setup**: new fixture `tests/assets/flows/human-input-branching-fixture.json` — Chat Input
  → Human Input (default `Approve`/`Reject`) → one Chat Output per branch — created per test
  via `POST /api/v1/flows/` under a unique name, opened on the canvas, then driven through
  the Playground. Serial describe (named API flows race on the backend's unique-name
  suffixing). Teardown is id-scoped: navigate off the editor, then `deleteFlow` with an
  explicit Bearer. Verified flow-neutral — the instance's user-flow count was identical
  before and after ~14 flows' worth of runs.
- **Wiring both branches is a precondition of the behaviour, not scenery.** With no
  downstream consumer, `_has_downstream_consumer()`
  (`lfx/components/flow_controls/human_input.py`) makes the component **skip the pause
  entirely** — status `"Skipped: no connected outputs"` — because suspending a whole run for
  a decision that routes nowhere would strand it. A "simpler" one-output fixture would never
  pause, so the spec asserts both sinks are on the canvas before running.
- **The two branches carry identical text**, so routing needed a distinguishable sink.
  `route_branch()` returns `Message(text=prompt)` on whichever branch wins; both Chat Outputs
  would emit the same string and "which branch ran" would be invisible in the chat. Each
  Chat Output therefore carries its own `sender_name` (`APPROVED` / `REJECTED`) and display
  name, and the bubble testid is `chat-message-${sender_name}-${text}` — which turns the
  exclusivity claim into an exact locator plus a `toHaveCount(0)` on its counterpart. The
  positive assertion runs **first**, so that zero cannot pass vacuously on a page where
  nothing rendered at all.
- **The fixture is a UI round-trip, not hand-written JSON**, and that was not a preference:
  nodes need `type: "genericNode"` plus their full template to render at all, and an edge
  only attaches when its `sourceHandle` string matches the handle's own `data-handleid`
  **verbatim** (`{œdataTypeœ:œHumanInputœ,œidœ:…,œnameœ:œbranch_approveœ,…}`) — read off the
  live DOM rather than guessed. Upstream's own `src/backend/tests/data/human_input_flow.json`
  is backend-only and renders empty.
- **Live-confirmed selectors**, all harvested on the running nightly (`1.12.0.dev10`):
  `human-input-card`, `human-input-decision-approve` / `-reject` (the `action_id` is the
  slugified label), `playground-btn-flow-io`, `input-chat-playground`, `button-send`,
  `chat-message-${sender_name}-${text}`, `title-Human Input` / `title-Approved Output` /
  `title-Rejected Output`.
- **The prompt is never typed into the Playground input** — it is asserted as *pre-filled*
  from the Chat Input node, because that field re-injects the template default
  asynchronously and races typed text (`authoring-conventions.md`).
- **The transport is deliberately not asserted.** The run is `POST /api/v2/workflows` and
  the answer is `POST /api/v2/workflows/{job_id}/resume`; the user path is the card click,
  and pinning the transport would couple this spec to a mechanism that already moved once
  (v1 build → v2 workflows).
- **Tags**: `@stable @release @playground`. `@release` is claimed here and deliberately not
  on #1190's config spec — if this breaks, a HITL flow cannot be answered at all. No
  `@regression`: first-time coverage of a new feature.

## 3. Dependencies

- **None — pure UI + REST.** No LLM, no provider key, no `models.json`, no `collect-models`.
- **Serial** (`mode: "serial"`) for the unique-name race, not for provider reasons.

## Validation (nightly `1.12.0.dev10`, `--retries=0 --workers=1`)

- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors; the 2 `playwright/expect-expect`
  warnings are the standard false positive for helper-held assertions — 35 already exist in
  the repo and the CI gate is errors-only)
- **3 clean burst runs**, `expected=2 unexpected=0 flaky=0` each, plus a green run after the
  force-fail reverts ✅
- Zero `🚨 Backend Error` on every run ✅ · no leaked flows (count back to baseline) ✅
- **Force-fail, executed — one per test, both observed red:**
  - Test 1 — answer by clicking the **counterpart** decision (Reject) while every assertion
    still expects the approved branch: proves the routing assertions track which button was
    pressed, not merely that some output appeared.
  - Test 2 — flip the counterpart-absence assert from `toHaveCount(0)` to `toHaveCount(1)`:
    proves the exclusivity claim is measured against the real DOM (the `APPROVED` bubble
    genuinely never renders) rather than being a vacuous zero.
  - Reverts proven: `grep -c FF-MUTATION` = 0, plus the final green run above.
- `--trace=on` **not** run locally — known local tracing hang (#518/#490). Step verification
  rests on the bursts, the two executed force-fails and the live scout; CI still traces on
  first retry.
- **Validation-environment gap, stated rather than papered over**: the local instance is
  `1.12.0.dev10` and the newest nightly tag is `1.12.0.dev15`. This PR's impacted-specs lane
  runs the spec against a fresh nightly service container — that is the cross-check.

## Timing, measured

Pause appears ~1 s after send; the routed bubble ~1 s after the decision. Per-assertion
budgets are 30 s — generous on purpose, sized for a saturated CI backend rather than for
the local best case.
