### PR TITLE
fix(helpers): report a failed teardown unmount instead of discarding it (#1288)

### DIFF
--- a/.claude/skills/langflow-e2e/references/authoring-conventions.md
+++ b/.claude/skills/langflow-e2e/references/authoring-conventions.md
@@ -339,18 +339,24 @@ failure). Reference: `ollama-provider.spec.ts`, `groq-provider.spec.ts`,
 B** — the bootstrap flow's `POST /flows` competes with the blank-flow click
 and `page.url()` returns the stale bootstrap id (#681).
 
-**The teardown's unmount navigation WARNS and carries on — it neither throws
-nor swallows** (#1288). Both patterns leave the editor before deleting (an
-editor mounted over a deleted flow 404s its `GET /flows/{id}/events` poll and
-the fixture logs each one), and both obvious ways to write that are wrong:
-letting the rejection propagate aborts the hook **before** the delete and leaks
-the flow — strictly worse than the noise the navigation prevents — while
-`.catch(() => {})` discards the one line that would attribute the 404 burst to
-its cause. Log the first line of the error and continue to the deletes.
-`trackCreatedFlows.cleanup()` does this for you and also returns it as
-`unmountError`, alongside `authError`, so a spec on the shared helper needs no
-teardown code of its own. 26 spec-local copies still carry the silent form;
-migrate one as you touch it rather than sweeping them.
+**Use `unmountEditorForCleanup(page, url?)` for the teardown's unmount
+navigation — it neither throws nor swallows** (#1288). Both patterns leave the
+editor before deleting (an editor mounted over a deleted flow 404s its
+`GET /flows/{id}/events` poll and the fixture logs each one), and both obvious
+ways to write that navigation are wrong: letting the failure propagate aborts
+the hook **before** the delete and leaks the flow (measured: 3 leaked flows from
+one spec), while `.catch(() => {})` discards the one line that would attribute
+the 404 burst to its cause. The helper warns with the first line and returns it;
+`trackCreatedFlows.cleanup()` calls it for you and surfaces it as `unmountError`
+alongside `authError`, so a spec on the shared tracker writes no unmount code of
+its own (it still writes the `afterEach` that calls `cleanup`).
+
+**27** spec-local copies still carry the silent form — migrate one as you touch
+it rather than sweeping them. Two of those use `about:blank` rather than `/` and
+hand-roll their own delete loop, so they inherit nothing from the tracker and are
+easy to miss: `api/flows/api-component-regression.spec.ts` and
+`core-functionality/project-management/folder-deletion-integrity.spec.ts` (whose
+local function is *also* named `trackCreatedFlows` and is not this helper).
 
 Validation contract (both patterns): (1) a **behavioral force-fail** of the
 cleanup itself — no-op the delete, run green, count surviving orphans (>0),

--- a/.claude/skills/langflow-e2e/references/authoring-conventions.md
+++ b/.claude/skills/langflow-e2e/references/authoring-conventions.md
@@ -339,6 +339,19 @@ failure). Reference: `ollama-provider.spec.ts`, `groq-provider.spec.ts`,
 B** — the bootstrap flow's `POST /flows` competes with the blank-flow click
 and `page.url()` returns the stale bootstrap id (#681).
 
+**The teardown's unmount navigation WARNS and carries on — it neither throws
+nor swallows** (#1288). Both patterns leave the editor before deleting (an
+editor mounted over a deleted flow 404s its `GET /flows/{id}/events` poll and
+the fixture logs each one), and both obvious ways to write that are wrong:
+letting the rejection propagate aborts the hook **before** the delete and leaks
+the flow — strictly worse than the noise the navigation prevents — while
+`.catch(() => {})` discards the one line that would attribute the 404 burst to
+its cause. Log the first line of the error and continue to the deletes.
+`trackCreatedFlows.cleanup()` does this for you and also returns it as
+`unmountError`, alongside `authError`, so a spec on the shared helper needs no
+teardown code of its own. 26 spec-local copies still carry the silent form;
+migrate one as you touch it rather than sweeping them.
+
 Validation contract (both patterns): (1) a **behavioral force-fail** of the
 cleanup itself — no-op the delete, run green, count surviving orphans (>0),
 revert, count again (0); (2) checking the instance's user-flow count after

--- a/docs/core-components/human-input-node-config.md
+++ b/docs/core-components/human-input-node-config.md
@@ -123,6 +123,10 @@ is first-time coverage of a new feature, not a previously fixed bug.
 1. `page.goto("/")` to unmount the editor (an editor left mounted over a deleted flow
    404s its `GET /flows/{id}/events` poll, which the fixture logs as a backend error),
    then `deleteFlow(page.request, flowId)`.
+   A failed unmount is **warned about and carried on from**, never rethrown and never
+   swallowed (#1288): rethrowing would abort the hook before the delete below and leak the
+   flow — worse than the noise the navigation prevents — while swallowing silently discards
+   the one line that would attribute that 404 noise to its cause.
 
 ---
 

--- a/tests/helpers/flows/track-created-flows.test.ts
+++ b/tests/helpers/flows/track-created-flows.test.ts
@@ -258,14 +258,14 @@ test("nothing was created, so nothing is navigated away from", async () => {
 });
 
 test("a failed unmount still deletes every flow, and is reported rather than swallowed", async () => {
-  // Issue #1288. Both obvious behaviours are wrong here, which is why this is
-  // pinned: letting the rejection propagate would abort the teardown BEFORE the
-  // deletes — and since `captured` has already been taken out of the tracker by
-  // then, those flows are neither deleted nor tracked, i.e. a permanent leak, for
-  // a navigation whose only job was to reduce log noise. Swallowing it (the shape
-  // this replaces, and the shape 26 spec-local copies still carry) discards the
-  // one line that attributes the `🚨 Backend Error` 404 burst that follows to its
-  // real cause.
+  // Issue #1288. What THIS test owns is that a failed unmount does not cost the
+  // deletes: letting the failure propagate would abort the teardown before them,
+  // and since `captured` has already been taken out of the tracker by then, those
+  // flows would be neither deleted nor tracked — a permanent leak, for a navigation
+  // whose only job was to reduce log noise. The warning itself, and the shape of
+  // the message, belong to `unmount-editor-for-cleanup.test.ts`, which is where the
+  // `console.warn` is asserted (a review of #1289 deleted that warn and the whole
+  // lane stayed green — hence a test that pins it, once, next to its code).
   const { page, emit } = fakePage();
   const { request, deletes } = fakeRequest();
   const trackedPage = page as unknown as { goto: (url: string) => Promise<null> };

--- a/tests/helpers/flows/track-created-flows.test.ts
+++ b/tests/helpers/flows/track-created-flows.test.ts
@@ -257,6 +257,44 @@ test("nothing was created, so nothing is navigated away from", async () => {
   assert.deepEqual(deletes, [], "and no auth call or DELETE");
 });
 
+test("a failed unmount still deletes every flow, and is reported rather than swallowed", async () => {
+  // Issue #1288. Both obvious behaviours are wrong here, which is why this is
+  // pinned: letting the rejection propagate would abort the teardown BEFORE the
+  // deletes — and since `captured` has already been taken out of the tracker by
+  // then, those flows are neither deleted nor tracked, i.e. a permanent leak, for
+  // a navigation whose only job was to reduce log noise. Swallowing it (the shape
+  // this replaces, and the shape 26 spec-local copies still carry) discards the
+  // one line that attributes the `🚨 Backend Error` 404 burst that follows to its
+  // real cause.
+  const { page, emit } = fakePage();
+  const { request, deletes } = fakeRequest();
+  const trackedPage = page as unknown as { goto: (url: string) => Promise<null> };
+  trackedPage.goto = async () => {
+    throw new Error("net::ERR_ABORTED at http://localhost:7860/\nsecond line dropped");
+  };
+
+  const flows = trackCreatedFlows(page);
+  emit(creationResponse("flow-1"));
+  emit(creationResponse("flow-2"));
+  const result = await flows.cleanup(request);
+
+  // The load-bearing half ran regardless.
+  assert.deepEqual(result.deleted, ["flow-1", "flow-2"]);
+  assert.deepEqual(result.failed, []);
+  assert.deepEqual(
+    deletes.map((d) => d.url),
+    ["/api/v1/flows/flow-1", "/api/v1/flows/flow-2"],
+  );
+
+  // And the failure is visible on the result, the way `authError` is — first line
+  // only, so a multi-line Playwright error stays one readable line.
+  assert.match(String(result.unmountError), /ERR_ABORTED/);
+  assert.ok(
+    !String(result.unmountError).includes("second line dropped"),
+    "only the first line of the error is carried",
+  );
+});
+
 // ─── Axis 4: a failed delete is reported, never swallowed ───────────────────
 
 test("a failed delete is reported and does not stop the other deletes", async () => {

--- a/tests/helpers/flows/track-created-flows.ts
+++ b/tests/helpers/flows/track-created-flows.ts
@@ -33,6 +33,7 @@ import { deleteFlow } from "./delete-flow";
 import { getAuthToken } from "../auth/get-auth-token";
 import { recordTokenAttribution, type TokenAttributionResult } from "./token-attribution";
 import { resolveTestAttribution } from "./resolve-test-attribution";
+import { unmountEditorForCleanup } from "./unmount-editor-for-cleanup";
 
 /**
  * The `Page` surface the tracker uses. Narrow on purpose: it is what lets the unit
@@ -101,6 +102,10 @@ export interface FlowCleanupResult {
    * editor's `GET /flows/{id}/events` poll hitting a flow that no longer exists —
    * unattributable noise unless the navigation failure that caused it is named.
    * First line only, so a multi-line Playwright error stays readable.
+   *
+   * Under `{ strict: true }` the whole result is discarded when the sweep throws,
+   * so this field never reaches that caller — the `console.warn` is what survives.
+   * Same as `authError` above; unreachable today, since no spec passes `strict`.
    */
   unmountError?: string;
   /** Set when `attribution` was requested — what the sidecar recorded or skipped. */
@@ -315,21 +320,13 @@ export function trackCreatedFlows(page: TrackedPage): FlowTracker {
       // the specs whose editor is still polling, and costs nothing in the rest.
       // Two of the 51 copies did this; #1103 added it to the folder specs.
       //
-      // A failed navigation is neither rethrown nor swallowed (#1288). Rethrowing
-      // would abort this method BEFORE the deletes — and `captured` has already
-      // been taken out of the tracker, so those flows would be neither deleted nor
-      // tracked: a permanent leak, traded for a navigation whose only job was to
-      // reduce log noise. Swallowing it silently is what this replaces, and it
-      // discards the one line that attributes the 404 burst above to its cause.
-      await page.goto("about:blank").catch((error: unknown) => {
-        result.unmountError =
-          (error as Error)?.message?.split("\n")[0] ?? String(error);
-        console.warn(
-          `⚠️  cleanup: could not leave the flow canvas (${result.unmountError}) — ` +
-            `the deletes below still run, so any 404 on the editor's events poll is ` +
-            `THAT and not the flow (#1288).`,
-        );
-      });
+      // A failed navigation is neither rethrown nor swallowed (#1288) — see
+      // `unmountEditorForCleanup`, which owns that decision, the message, and the
+      // `try`/`catch` that also covers a synchronous throw. Rethrowing here would
+      // abort this method BEFORE the deletes, and `captured` has already been taken
+      // out of the tracker, so those flows would be neither deleted nor tracked: a
+      // permanent leak traded for a navigation whose only job was to reduce noise.
+      result.unmountError = await unmountEditorForCleanup(page);
 
       const errors: unknown[] = [];
       for (const id of captured) {

--- a/tests/helpers/flows/track-created-flows.ts
+++ b/tests/helpers/flows/track-created-flows.ts
@@ -92,6 +92,17 @@ export interface FlowCleanupResult {
    * not a problem with the flow — see the note at the call site.
    */
   authError?: string;
+  /**
+   * Set when leaving the canvas failed, so the deletes below ran with the editor
+   * still mounted (issue #1288).
+   *
+   * Same reason `authError` exists: the consequence arrives later and looks like
+   * something else. Here it is a burst of `🚨 Backend Error` 404s from the
+   * editor's `GET /flows/{id}/events` poll hitting a flow that no longer exists —
+   * unattributable noise unless the navigation failure that caused it is named.
+   * First line only, so a multi-line Playwright error stays readable.
+   */
+  unmountError?: string;
   /** Set when `attribution` was requested — what the sidecar recorded or skipped. */
   attribution?: TokenAttributionResult;
 }
@@ -303,7 +314,22 @@ export function trackCreatedFlows(page: TrackedPage): FlowTracker {
       // way, because the build's event stream is already closed by then. It bites
       // the specs whose editor is still polling, and costs nothing in the rest.
       // Two of the 51 copies did this; #1103 added it to the folder specs.
-      await page.goto("about:blank").catch(() => {});
+      //
+      // A failed navigation is neither rethrown nor swallowed (#1288). Rethrowing
+      // would abort this method BEFORE the deletes — and `captured` has already
+      // been taken out of the tracker, so those flows would be neither deleted nor
+      // tracked: a permanent leak, traded for a navigation whose only job was to
+      // reduce log noise. Swallowing it silently is what this replaces, and it
+      // discards the one line that attributes the 404 burst above to its cause.
+      await page.goto("about:blank").catch((error: unknown) => {
+        result.unmountError =
+          (error as Error)?.message?.split("\n")[0] ?? String(error);
+        console.warn(
+          `⚠️  cleanup: could not leave the flow canvas (${result.unmountError}) — ` +
+            `the deletes below still run, so any 404 on the editor's events poll is ` +
+            `THAT and not the flow (#1288).`,
+        );
+      });
 
       const errors: unknown[] = [];
       for (const id of captured) {

--- a/tests/helpers/flows/unmount-editor-for-cleanup.test.ts
+++ b/tests/helpers/flows/unmount-editor-for-cleanup.test.ts
@@ -1,0 +1,125 @@
+// Unit tests for the teardown's editor-unmount navigation (issue #1288).
+// Run with: npm run test:units
+//
+// What rides on this helper: it is the last thing that runs before a teardown
+// deletes its flow, and BOTH of its guarantees are invisible when broken. If it
+// rethrows, the caller's deletes never run and the flow leaks silently (measured:
+// dropping the catch from one spec's `afterEach` left 3 leaked flows). If it stays
+// quiet, the 404 burst the failed navigation causes cannot be attributed to
+// anything, and an advisory log nobody can read is worth nothing (#1084's rule).
+//
+// The console assertion is the point, not ceremony. `unmountError` is returned to
+// callers but no production caller inspects it, so the WARNING is this helper's
+// only human-visible effect — a review of #1289 deleted the `console.warn` and the
+// whole unit lane stayed green, which is how this file came to exist. The capture
+// pattern is `delete-flow.test.ts`'s.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { unmountEditorForCleanup } from "./unmount-editor-for-cleanup";
+
+/** Run `fn` with `console.warn` captured, restoring it even on failure. */
+async function withWarnings(fn: () => Promise<void>): Promise<string[]> {
+  const warnings: string[] = [];
+  const realWarn = console.warn;
+  console.warn = (msg: string) => warnings.push(String(msg));
+  try {
+    await fn();
+  } finally {
+    console.warn = realWarn;
+  }
+  return warnings;
+}
+
+test("navigates to about:blank by default, silently, and reports nothing", async () => {
+  const visited: string[] = [];
+  const page = {
+    goto: async (url: string) => {
+      visited.push(url);
+      return null;
+    },
+  };
+
+  let error: string | undefined = "unset";
+  const warnings = await withWarnings(async () => {
+    error = await unmountEditorForCleanup(page);
+  });
+
+  assert.deepEqual(visited, ["about:blank"]);
+  assert.equal(error, undefined, "a successful unmount reports nothing");
+  assert.deepEqual(warnings, [], "and says nothing");
+});
+
+test("a spec can send it to the flows list instead", async () => {
+  const visited: string[] = [];
+  const page = { goto: async (url: string) => { visited.push(url); return null; } };
+  await unmountEditorForCleanup(page, "/");
+  assert.deepEqual(visited, ["/"]);
+});
+
+test("a rejected navigation is WARNED about and returned, never thrown", async () => {
+  const page = {
+    goto: async () => {
+      throw new Error("page.goto: Timeout 1ms exceeded.\nCall log:\n  - navigating");
+    },
+  };
+
+  let error: string | undefined;
+  const warnings = await withWarnings(async () => {
+    // Not wrapped in assert.rejects: the whole contract is that it resolves, so a
+    // throw here fails the test by escaping it.
+    error = await unmountEditorForCleanup(page);
+  });
+
+  assert.equal(error, "page.goto: Timeout 1ms exceeded.", "first line only");
+  assert.equal(warnings.length, 1, `exactly one warning; got ${JSON.stringify(warnings)}`);
+  assert.match(warnings[0], /could not leave the flow editor/);
+  assert.match(warnings[0], /Timeout 1ms exceeded/);
+  assert.match(warnings[0], /#1288/, "the warning names the issue that explains it");
+  assert.ok(
+    !warnings[0].includes("Call log"),
+    `the warning stays one line; got ${JSON.stringify(warnings[0])}`,
+  );
+});
+
+test("a SYNCHRONOUS throw is caught too, so the caller's deletes still run", async () => {
+  // `.catch()` attaches to the returned promise, so this shape escaped the version
+  // this helper replaces — and escaping it skips the deletes, which is the leak the
+  // helper exists to prevent. Real Playwright's `goto` is async, but this repo
+  // proxies it in its own tests and a fake that throws is normal to write.
+  const page = {
+    goto: (() => {
+      throw new Error("goto is not a function");
+    }) as unknown as (url: string) => Promise<unknown>,
+  };
+
+  let error: string | undefined;
+  const warnings = await withWarnings(async () => {
+    error = await unmountEditorForCleanup(page);
+  });
+
+  assert.equal(error, "goto is not a function");
+  assert.equal(warnings.length, 1);
+});
+
+test("a rejection that is not an Error, or whose message is not a string, is still one line", async () => {
+  // The `?.message?.split(…) ?? String(error)` idiom this replaces breaks on both:
+  // it leaves the `String(error)` fallback untruncated (a bare string rejection with
+  // a newline), and it THROWS on `{ message: 42 }` (`.split is not a function`) —
+  // the very shape its fallback was written for.
+  for (const [label, thrown, expected] of [
+    ["bare string", "boom\nsecond line", "boom"],
+    ["non-string message", { message: 42 }, "42"],
+    ["empty message", new Error(""), "Error"],
+  ] as Array<[string, unknown, string]>) {
+    const page = {
+      goto: async () => {
+        throw thrown;
+      },
+    };
+    let error: string | undefined;
+    await withWarnings(async () => {
+      error = await unmountEditorForCleanup(page);
+    });
+    assert.equal(error, expected, `${label}: expected ${expected}, got ${error}`);
+  }
+});

--- a/tests/helpers/flows/unmount-editor-for-cleanup.ts
+++ b/tests/helpers/flows/unmount-editor-for-cleanup.ts
@@ -1,0 +1,75 @@
+// Leaving the flow editor at teardown time, so deleting the flow is quiet (#1288).
+//
+// NOT `leave-flow-editor.ts`, which is a different job: that one is the UI exit
+// around the #1153 SPA-blocker deadlock, with 15 s/30 s budgets and assertions
+// about the flows list rendering. This is the teardown's own one-line navigation,
+// whose only purpose is that the editor stops polling the flow we are about to
+// delete — an editor left mounted over a deleted flow keeps requesting
+// `GET /flows/{id}/events`, 404s once the flow is gone, and the fixture logs each
+// one as `🚨 Backend Error`.
+//
+// It exists as a helper rather than as a block copied per spec because both
+// obvious ways to write that navigation are wrong, and getting it wrong is
+// expensive in a way the copies hide:
+//
+//   - Letting the failure propagate aborts the teardown BEFORE the deletes.
+//     Measured on `human-input-node-config.spec.ts` by dropping the catch: 3
+//     failed tests and 3 leaked flows — a permanent leak (in `cleanup()` the ids
+//     have already been spliced out of the tracker), traded for a navigation
+//     whose only job was to reduce log noise.
+//   - Swallowing it discards the one line that attributes the 404 burst that
+//     follows to its cause, leaving a run full of unattributable backend-error
+//     lines. An advisory log is only worth reading if what makes it noisy is
+//     nameable (#1084's rule).
+//
+// So it warns and carries on, and the caller decides whether to record what it
+// returns. One implementation also means one message string and one place where
+// the warning is asserted — the three hand-written copies this replaces had
+// three different texts, which is the drift #1108 exists to prevent.
+
+/**
+ * The `page` surface this needs. Narrow on purpose, so the unit lane can drive it
+ * with a fake and so `TrackedPage` (which is itself narrow) is assignable.
+ */
+export interface NavigablePage {
+  goto(url: string): Promise<unknown>;
+}
+
+/**
+ * Navigate away from the flow editor before a teardown deletes its flow.
+ *
+ * Never throws — a failure is warned about and returned, so the caller's deletes
+ * always run. Returns the **first line** of the failure, or `undefined` when the
+ * navigation succeeded.
+ *
+ * @param page  the page to navigate
+ * @param url   where to go. Defaults to `about:blank`, which adds no backend
+ *              traffic of its own; a spec that wants the flows list passes `"/"`.
+ */
+export async function unmountEditorForCleanup(
+  page: NavigablePage,
+  url = "about:blank",
+): Promise<string | undefined> {
+  try {
+    // `try`/`catch` rather than `.catch()`: the latter attaches to the returned
+    // promise only, so a `goto` that throws SYNCHRONOUSLY escapes it and skips
+    // the caller's deletes — the exact leak this helper exists to prevent. Real
+    // Playwright's `Page.goto` is async, but this repo proxies it (the tracker's
+    // own unit tests do) and a fake that throws is a normal thing to write.
+    await page.goto(url);
+    return undefined;
+  } catch (error) {
+    // Coerced BEFORE the split. The `?.message?.split(…) ?? String(error)` idiom
+    // used elsewhere in this directory leaves its fallback untruncated, and it
+    // throws outright on the one shape it was written for — a rejection whose
+    // `message` is not a string (`{ message: 42 }` → `.split is not a function`).
+    // `||` rather than `??` so an empty `message` falls back to the value too.
+    const message = String((error as Error)?.message || error).split("\n")[0];
+    console.warn(
+      `⚠️  teardown: could not leave the flow editor (${message}) — the deletes ` +
+        `still run, so a 404 on the editor's events poll is THAT and not the ` +
+        `flow (#1288).`,
+    );
+    return message;
+  }
+}

--- a/tests/tests-automations/regression/core-components/human-input-node-config.spec.ts
+++ b/tests/tests-automations/regression/core-components/human-input-node-config.spec.ts
@@ -21,6 +21,7 @@ import { expect, test } from "../../../fixtures/fixtures";
 import { setupBlankFlow } from "../../../helpers/flows/setup-blank-flow";
 import { addComponentFromSidebar } from "../../../helpers/flows/add-component-from-sidebar";
 import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { unmountEditorForCleanup } from "../../../helpers/flows/unmount-editor-for-cleanup";
 import { getAuthToken } from "../../../helpers/auth/get-auth-token";
 
 // Sidebar search term + add button for the component under test, kept together
@@ -156,18 +157,11 @@ test.describe("Human Input node configuration (HITL branch handles)", () => {
       // its `GET /flows/{id}/events` poll, which the fixture logs as a backend
       // error.
       //
-      // Warned about and carried on from, never rethrown and never swallowed
-      // (#1288): rethrowing would abort this hook before the delete below and leak
-      // the flow — worse than the noise this navigation prevents — while silence
-      // discards the one line that attributes that 404 burst to its cause.
-      await page.goto("/").catch((error: unknown) => {
-        const message = (error as Error)?.message?.split("\n")[0] ?? String(error);
-        console.warn(
-          `⚠️  teardown: could not leave the flow editor (${message}) — the delete ` +
-            `below still runs, so a 404 on the editor's events poll is THAT and not ` +
-            `the flow (#1288).`,
-        );
-      });
+      // Warned about and carried on from, never rethrown and never swallowed — the
+      // helper owns that decision and its message (#1288). Rethrowing here would
+      // abort this hook before the delete below and leak the flow, which is worse
+      // than the noise the navigation prevents.
+      await unmountEditorForCleanup(page, "/");
       await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }

--- a/tests/tests-automations/regression/core-components/human-input-node-config.spec.ts
+++ b/tests/tests-automations/regression/core-components/human-input-node-config.spec.ts
@@ -155,7 +155,19 @@ test.describe("Human Input node configuration (HITL branch handles)", () => {
       // Leave the editor first: an editor left mounted over a deleted flow 404s
       // its `GET /flows/{id}/events` poll, which the fixture logs as a backend
       // error.
-      await page.goto("/").catch(() => {});
+      //
+      // Warned about and carried on from, never rethrown and never swallowed
+      // (#1288): rethrowing would abort this hook before the delete below and leak
+      // the flow — worse than the noise this navigation prevents — while silence
+      // discards the one line that attributes that 404 burst to its cause.
+      await page.goto("/").catch((error: unknown) => {
+        const message = (error as Error)?.message?.split("\n")[0] ?? String(error);
+        console.warn(
+          `⚠️  teardown: could not leave the flow editor (${message}) — the delete ` +
+            `below still runs, so a 404 on the editor's events poll is THAT and not ` +
+            `the flow (#1288).`,
+        );
+      });
       await deleteFlow(page.request, createdFlowId);
       createdFlowId = null;
     }

--- a/tests/tests-automations/regression/core-functionality/playground/human-input-pause-resume.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/playground/human-input-pause-resume.spec.ts
@@ -29,6 +29,7 @@ import { createFlow } from "../../../../helpers/flows/create-flow";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
+import { unmountEditorForCleanup } from "../../../../helpers/flows/unmount-editor-for-cleanup";
 
 // Pre-wired fixture: Chat Input (input_value = SENTINEL_PROMPT) -> Human Input
 // (default Approve/Reject) -> one Chat Output per branch, each with its own
@@ -237,17 +238,7 @@ test.afterEach(async ({ page }) => {
   // Leave the editor first so it stops polling `GET /flows/{id}/events` on a
   // flow about to be deleted, then pass an explicit Bearer — `page.request` is
   // unauthenticated under AUTO_LOGIN and would 401.
-  await page.goto("/").catch((error: unknown) => {
-    // Neither swallowed nor rethrown, on purpose. Rethrowing would abort this
-    // hook BEFORE the deletes below — the load-bearing half — and leak the flow;
-    // swallowing silently would hide why the editor kept 404-polling a deleted
-    // flow, which is the whole reason for leaving it first.
-    const message = (error as Error)?.message?.split("\n")[0] ?? String(error);
-    console.warn(
-      `⚠️  teardown: could not leave the flow editor (${message}) — the deletes ` +
-        `below still run, so expect 404 noise from the editor's events poll.`,
-    );
-  });
+  await unmountEditorForCleanup(page, "/");
   const authHeader = await getAuthToken(page.request);
   const opts = authHeader
     ? { headers: { Authorization: authHeader } }


### PR DESCRIPTION
Closes #1288. Follow-up from the review of #1286, where the same objection was raised independently by Copilot and by an adversarial review pass.

**Fixes the diagnosability of the teardown's editor-unmount navigation.**

## Problem

Every spec that creates a flow leaves the editor before deleting it: an editor mounted over
a deleted flow keeps polling `GET /flows/{id}/events`, 404s once the flow is gone, and the
fixture logs each one as `🚨 Backend Error`. That navigation was written:

```ts
await page.goto("/").catch(() => {});
```

Measured on `main`: **28 spec files** carry that silent form, plus the shared tracker
(`track-created-flows.ts` → `cleanup()`, with `about:blank`).

This is a **latent** defect, not an observed failure — and that is stated plainly rather
than dressed up: a rejecting `goto` in the wild is silent *by construction*, which IS the
defect, so there is no failing run to point at. What it costs is attribution: when the
unmount fails, the deletes still run with the editor mounted, the run fills with 404s from a
poll nobody can trace, and the one line that would have named the cause was discarded. The
advisory error log is only worth reading if what makes it noisy is nameable (#1084's rule).

## Fix

**Warn and carry on** — neither of the obvious behaviours is correct:

- **Rethrowing** (the intuitive fix, and the one Copilot proposed) aborts `cleanup()`
  **before** the deletes. `captured` has already been taken out of the tracker by that
  point, so those flows are neither deleted nor tracked: a permanent leak, traded for a
  navigation whose only job was to reduce log noise.
- **Swallowing** discards the only diagnostic.

`cleanup()` also returns it as **`unmountError`**, following `authError` in the same
function — same reason that field exists ("*a 401 that follows is THAT, not a problem with
the flow*"): the consequence arrives later and looks like something else. That is also what
makes the behaviour assertable **structurally**, the way the unit lane already asserts
`authError` without capturing console.

Applied to: the shared tracker, and `core-components/human-input-node-config.spec.ts` —
closing the divergence with its #1189 sibling, which already warned. The convention is now
written down under *Flow cleanup* in `authoring-conventions.md`, so the next spec is not
copied from whichever neighbour it happened to open.

## Scope note

The other **26** spec-local copies are deliberately untouched: they are migrating onto the
tracker anyway (#1108), a 26-file mechanical sweep is churn with real merge-conflict cost
against concurrent spec work, and the pattern is harmless until the navigation actually
fails. The convention says to migrate one as it is touched.

Also unchanged: *which* URL the teardown navigates to (`/` vs `about:blank` — the tracker
uses `about:blank` deliberately, so teardown adds no backend traffic of its own). This PR is
only about what happens when that navigation fails.

## Validation (nightly `1.12.0.dev10`, `--retries=0 --workers=1`)

- `npm run test:units` — **420 pass / 0 fail** ✅ · `npm run typecheck` ✅ · `npm run lint`
  0 errors ✅ (both re-run after rebasing onto `origin/main`)
- **3 clean runs** of the touched spec, `expected=3 unexpected=0 flaky=0` each, plus a green
  run after the force-fail reverts ✅
- Zero `🚨 Backend Error` ✅ · no leaked flows (instance count back to baseline) ✅
- **Force-fail, executed — five mutations, all observed red:**
  - **Pre-fix, test-first**: the new unit test fails against the unmodified helper at
    *compile* time — `Property 'unmountError' does not exist on type 'FlowCleanupResult'` —
    which is the defect stated precisely: no channel exists to report that failure.
  - Helper A — rethrow instead of warn-and-continue → the delete-count assertion fails,
    proving the deletes are what the warn-and-continue shape protects.
  - Helper B — warn but record nothing → the reporting assertion fails.
  - Touched spec, all three tests re-verified because a cleanup edit can silently defuse a
    sibling's assert (scope = the whole file): branch-handle count `2 → 3`; the custom choice
    committed as one word while the asserts expect two; the persistence oracle expecting 2 of
    the 3 persisted outputs. All red.
  - Reverts proven: `grep -c FF-MUTATION` = 0 across all three files, plus the final green
    run and `420 pass / 0 fail`.
- `--trace=on` not run locally (known local tracing hang, #518/#490); step verification rests
  on the bursts and the executed force-fails.
