### PR TITLE
test(core-components): cover the unified Data Operations component (#1191)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -277,7 +277,7 @@
 - [x] Human Input node config: default Approve/Reject branch handles, custom User Action creates a new handle, configured handles persist after save + reload → `core-components/human-input-node-config.spec.ts`
 
 #### 3.10 Data Operations (1.11.0)
-- [ ] Data Operations component: unified JSON/Table/Text operations produce correct outputs per operation mode → `core-components/data-operations-component.spec.ts`
+- [x] Data Operations component: unified JSON/Table/Text operations produce correct outputs per operation mode (Text→Message, Word Count→JSON override, JSON Select Keys, Table Filter) → `core-components/data-operations-component.spec.ts`
 - [ ] Legacy operations components link/redirect to Data Operations (legacy flows keep working) → `core-components/data-operations-legacy-link.spec.ts`
 
 ---

--- a/docs/core-components/data-operations-component.md
+++ b/docs/core-components/data-operations-component.md
@@ -53,7 +53,7 @@ pandas); the spec neither resolves a model nor consumes `models.json`.
 ### Why the assertion surface is the output inspector
 
 Each test reads the value the component actually returned, from the node's output inspector
-(`output-inspection-<output>-operations`), not from a downstream sink:
+(`output-inspection-<output display name>-operations`), not from a downstream sink:
 
 - `Message` output → the inspector renders a `textarea`; assert `toHaveValue(...)`.
 - `JSON` output → the inspector renders a JSON viewer; assert the dialog's text contains the
@@ -61,11 +61,17 @@ Each test reads the value the component actually returned, from the node's outpu
   is absent).
 - `Table` output → the inspector renders an ag-grid; assert the `role="gridcell"` contents.
 
-The inspector testid itself carries the output's display name
-(`output-inspection-${title.toLowerCase()}-${type.toLowerCase()}`, from
-`CustomNodes/GenericNode/components/NodeOutputfield/index.tsx`), so asserting on
-`output-inspection-json-operations` *is* an assertion that the node advertises a JSON output
-— the testid cannot exist unless `update_outputs` produced that output.
+The inspector testid itself carries the output's display name **first**, the component type
+second — `output-inspection-${title.toLowerCase()}-${classNameFromType(id).toLowerCase()}`,
+from `CustomNodes/GenericNode/components/NodeOutputfield/index.tsx`. So in
+`output-inspection-json-operations`, `json` is the **output's display name** (what
+`update_outputs` advertised) and `operations` is the **component type** (`name="Operations"`,
+identical on every node of this component). Reading it the other way round — component first
+— is the easy mistake here, precisely because both halves are lowercase nouns and the
+component is *called* Data Operations: it would suggest the testid is stable per node, when
+in fact its first half is exactly the thing under test. Asserting on
+`output-inspection-json-operations` *is* therefore an assertion that the node advertises a
+JSON output — the testid cannot exist unless `update_outputs` produced that output.
 
 ---
 
@@ -242,7 +248,9 @@ by an empty output, a passthrough, or a node that failed to build (the run gate 
   emits `button_open_list_selection_sortablelist_sortablelist_<field>` and the
   `list_item_<snake_case_name>` options.
 - `src/frontend/src/CustomNodes/GenericNode/components/NodeOutputfield/index.tsx` — emits
-  `output-inspection-<output>-<type>`, the spec's per-operation output-type assertion.
+  `output-inspection-<output display name>-<component type>` — output first, component
+  second (e.g. `output-inspection-json-operations`). This is the spec's per-operation
+  output-type assertion.
 - `tests/helpers/flows/create-flow.ts`, `delete-flow.ts`,
   `add-component-from-sidebar.ts`, `unmount-editor-for-cleanup.ts`.
 - `tests/helpers/ui/zoom-out.ts`, `adjust-screen-view.ts`, `separate-overlapping-nodes.ts`,

--- a/docs/core-components/data-operations-component.md
+++ b/docs/core-components/data-operations-component.md
@@ -1,0 +1,307 @@
+# Spec: Data Operations — unified component, per-operation outputs
+
+**Test file:** `tests/tests-automations/regression/core-components/data-operations-component.spec.ts`
+
+**Last validated:** Langflow 1.12.x
+
+---
+
+## What this test validates
+
+Langflow 1.11.0 merged the three separate operation components — **JSON Operations**
+(`DataOperations`), **Table Operations** (`DataFrameOperations`) and **Text Operations**
+(`TextOperations`) — into a single **Data Operations** component
+(`lfx/components/processing/operations.py`, class `OperationsComponent`, `name="Operations"`).
+Upstream: `langflow-ai/langflow#13743` (unify) and `#14025` (naming). The three originals
+remain in the sidebar as `legacy: true` with `replacement = ["processing.Operations"]`.
+
+The unification rests on one contract, and this spec proves exactly that contract:
+
+> An **Input Type** tab (Text / JSON / Table) selects which operations are offered, which
+> main input is shown, and which output the node advertises — and the **selected operation**
+> can then override the output type. Each operation must produce the value its own semantics
+> define, from the input the selected type accepts.
+
+Four tests cover it, one per axis:
+
+1. **Text → Message.** The default path: `Case Conversion` on a Text input returns a
+   `Message` whose text is the converted string.
+2. **Word Count overrides the output type.** Still on Input Type `Text`, choosing
+   `Word Count` re-advertises the node's output as **JSON** (`as_data`) — the output is
+   decided by the *operation*, not only by the input type. This is the single most
+   distinctive consequence of the merge: two operations under the same tab emit different
+   Langflow types.
+3. **JSON → Data, fed by the component itself.** A second Data Operations node in
+   Input Type `JSON` consumes the Word Count node's JSON output and runs `Select Keys`,
+   returning only the requested key. This proves both the JSON operation semantics and that
+   the unified component's own output plugs into its own typed input.
+4. **Table → DataFrame, fed by the component itself.** An upstream node converts a
+   pipe-separated text block into a Table (`Text to DataFrame`, which likewise overrides the
+   Text tab's default output); a downstream node in Input Type `Table` runs `Filter` and
+   returns only the matching rows.
+
+Tests 3 and 4 also assert the **operation picker is filtered by the Input Type**: after
+switching to JSON the picker offers `Select Keys` and no longer offers `Case Conversion`;
+after switching to Table it offers `Filter` and, again, not `Case Conversion`. That is
+`update_build_config`'s `build_config["operation"]["options"] = OPERATIONS_BY_TYPE[input_type]`
+observed from the UI — a regression that stopped filtering would leave a Text operation
+selectable against a Table input and fail here.
+
+**No model provider is required.** Every operation is pure Python (string ops, dict ops,
+pandas); the spec neither resolves a model nor consumes `models.json`.
+
+### Why the assertion surface is the output inspector
+
+Each test reads the value the component actually returned, from the node's output inspector
+(`output-inspection-<output>-operations`), not from a downstream sink:
+
+- `Message` output → the inspector renders a `textarea`; assert `toHaveValue(...)`.
+- `JSON` output → the inspector renders a JSON viewer; assert the dialog's text contains the
+  exact `"key": value` pairs (and, negatively, that a key the operation should have dropped
+  is absent).
+- `Table` output → the inspector renders an ag-grid; assert the `role="gridcell"` contents.
+
+The inspector testid itself carries the output's display name
+(`output-inspection-${title.toLowerCase()}-${type.toLowerCase()}`, from
+`CustomNodes/GenericNode/components/NodeOutputfield/index.tsx`), so asserting on
+`output-inspection-json-operations` *is* an assertion that the node advertises a JSON output
+— the testid cannot exist unless `update_outputs` produced that output.
+
+---
+
+## Tags
+
+`@stable` `@components` `@ui-ux`
+
+`@components` is the cross-cutting tag (canvas component configuration and execution).
+`@ui-ux` is the functional tag: no functional tag maps to data processing today, and every
+assertion here is made through the node UI and its output inspector — the same reasoning
+recorded in `docs/core-components/human-input-node-config.md`.
+
+`@regression` is deliberately **absent**: this is first-time coverage of a 1.11.0 feature,
+not a previously fixed bug. `@destructive` does not apply — each test creates and deletes
+exactly its own flow.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` (validated on the nightly, 1.12.x).
+- **No** model provider credentials, no `collect-models` pre-flight, no `--workers=1`.
+- No legacy-components toggle: **Data Operations is the non-legacy component** and is
+  present in the default sidebar (`add-component-button-data-operations`). The three
+  originals it replaces are the legacy ones and are not used here.
+
+---
+
+## Scenarios (one `test()` per row)
+
+| # | Scenario | Input Type | Operation | Input value | Advertised output | Asserted result |
+|---|---|---|---|---|---|---|
+| 1 | Text operation returns the converted Message | Text | Case Conversion (`case_type=uppercase`) | `data ops probe abc123` | Message | inspector textarea === `DATA OPS PROBE ABC123` |
+| 2 | Word Count overrides the Text output to JSON | Text | Word Count | `data ops probe abc123 data ops` | **JSON** (not Message) | `"word_count": 6`, `"unique_words": 4`, `"character_count": 30`; `output-inspection-message-operations` has count 0 |
+| 3 | JSON operation selects one key from an upstream JSON output | JSON (downstream node) | Select Keys (`["word_count"]`) | upstream Word Count JSON | JSON | output is `{ "word_count": 6 }` and does **not** contain `unique_words` |
+| 4 | Table operation filters the rows of an upstream Table output | Table (downstream node) | Filter (`column_name=score`, `greater than`, `15`) | upstream `Text to DataFrame` of a 4-line pipe table | Table | grid cells are exactly `beta, 30, gamma, 20` (2 of 3 rows) |
+
+### Expected values are derived from the component source, not observed
+
+- `_word_count` (operations.py): `word_count = len(text.split())`, `unique_words =
+  len(set(text.split()))`, `character_count = len(text)`. For
+  `data ops probe abc123 data ops` → 6 / 4 / 30. The sentinel repeats `data` and `ops`
+  **on purpose**, so `unique_words` (4) differs from `word_count` (6) — a regression that
+  returned the same list for both would pass a same-value sentinel and fails here.
+- `select_keys`: `{key: value for key, value in data_dict.items() if key in filter_criteria}`
+  → a single-key dict. The negative half of the assertion (`unique_words` absent) is what
+  separates "Select Keys ran" from "the upstream payload was passed through".
+- `filter_rows_by_value` with `greater than`: `pd.to_numeric(filter_value)` then
+  `column > numeric_value`. `_convert_numeric_columns` has already made `score` numeric, so
+  `10, 30, 20 > 15` → rows `beta` and `gamma`. Values are chosen so the survivors are **not**
+  the first N rows — a `head`-like regression, or a comparison done on strings
+  (`"10" > "15"` is `False`, `"30" > "15"` is `True`, `"20" > "15"` is `True` — same rows,
+  but `"9"` would flip), cannot be mistaken for a pass. The table's row order also proves
+  the filter preserves order.
+
+---
+
+## Step by step
+
+### Shared setup
+
+`openFlowWithDataOperations(page, request, bearer)` (local helper):
+
+1. `createFlow` via the REST API with a unique name (parallel-safe), pushing the id onto the
+   spec's `createdFlowIds` for id-scoped teardown.
+2. `page.goto("/flow/<id>")`, wait for `sidebar-search-input`.
+3. `addComponentFromSidebar(page, "data operations", "add-component-button-data-operations")`.
+4. Assert `title-Data Operations` is visible.
+
+Tests 3 and 4 call it once, then add a **second** Data Operations node from the sidebar and
+call `zoomOut` + `adjustScreenView` + `separateOverlappingNodes` — two sidebar `+` clicks land
+the nodes ~10 px apart, and a stacked node intercepts pointer events aimed at a handle
+underneath it (#939).
+
+### Node identity in the two-node tests
+
+The two nodes share every testid (both are type `Operations`), so they are **not** addressed
+by DOM order once configured. After the downstream node is switched to its Input Type, the
+two are distinguished by an identity-carrying child:
+
+- upstream = the node containing `textarea_str_text_input` (only a Text-mode node has it);
+- downstream = the node containing `handle-operations-shownode-json-left` (test 3) or
+  `handle-operations-shownode-table-left` (test 4) — only a JSON/Table-mode node has it.
+
+Each locator is asserted to resolve to exactly **one** node before use, so a mis-selection
+fails naming the cause instead of silently configuring the wrong node.
+
+### Per-test steps
+
+**Test 1 — Text → Message**
+1. Setup (one node). Input Type stays on the default `Text` tab.
+2. Fill `textarea_str_text_input` with `data ops probe abc123`.
+3. Open the operation picker (`button_open_list_selection_sortablelist_sortablelist_operation`)
+   and click `list_item_case_conversion`.
+4. Set `value-dropdown-dropdown_str_case_type` → option `uppercase`.
+5. Click `button_run_data operations`; wait for `node_duration_data operations`.
+6. Click `output-inspection-message-operations`; assert the dialog textarea has value
+   `DATA OPS PROBE ABC123`; close with `btn-close-modal`.
+
+**Test 2 — Word Count overrides the output type**
+1. Setup (one node), Input Type `Text`.
+2. Fill the text with `data ops probe abc123 data ops`.
+3. Pick `list_item_word_count`.
+4. **Before running**, assert the advertised output flipped: `output-inspection-json-operations`
+   is visible and `output-inspection-message-operations` has count 0.
+5. Run; wait for `node_duration_data operations`.
+6. Open the JSON inspector and assert its text contains `"word_count": 6`,
+   `"unique_words": 4` and `"character_count": 30`.
+
+**Test 3 — JSON mode over the component's own JSON output**
+1. Setup, then add a second node; separate them.
+2. Upstream node: text `data ops probe abc123 data ops`, operation `Word Count`.
+3. Downstream node: click `tab_1_json`. Assert the picker is now filtered — open it, expect
+   `list_item_select_keys` visible and `list_item_case_conversion` count 0 — and pick
+   `list_item_select_keys`.
+4. Fill `inputlist_str_select_keys_input_0` with `word_count`.
+5. Wire `handle-operations-shownode-json-right` (upstream) →
+   `handle-operations-shownode-json-left` (downstream); assert 1 edge exists.
+6. Run the **downstream** node; wait for its `node_duration_data operations`.
+7. Open its `output-inspection-json-operations`; assert the dialog contains `"word_count": 6`
+   and does **not** contain `unique_words`.
+
+**Test 4 — Table mode over the component's own Table output**
+1. Setup, add a second node, separate them.
+2. Upstream node: open the text-area modal
+   (`button_open_text_area_modal_textarea_str_text_input`), fill `text-area-modal` with
+   ```
+   name|score
+   alpha|10
+   beta|30
+   gamma|20
+   ```
+   and click `genericModalBtnSave`. (The node-level field is an `<input>` and strips
+   newlines — the modal is the only way to enter a multi-line value.) Then pick
+   `list_item_text_to_dataframe` and assert the advertised output became
+   `output-inspection-table-operations`.
+3. Downstream node: click `tab_2_table`; assert the picker offers `list_item_filter` and no
+   longer `list_item_case_conversion`; pick `list_item_filter`.
+4. Fill `popover-anchor-input-column_name` = `score`,
+   `popover-anchor-input-filter_value` = `15`, and set
+   `value-dropdown-dropdown_str_filter_operator` → `greater than`.
+5. Wire `handle-operations-shownode-table-right` → `handle-operations-shownode-table-left`;
+   assert 1 edge exists.
+6. Run the downstream node; open `output-inspection-table-operations`; assert the grid cells
+   are exactly `["beta", "30", "gamma", "20"]`.
+
+---
+
+## Validation criterion
+
+| # | Pass condition |
+|---|---|
+| 1 | The Message inspector's textarea equals `DATA OPS PROBE ABC123` exactly. |
+| 2 | `output-inspection-json-operations` exists **and** `output-inspection-message-operations` does not, before the run; after it, the JSON payload carries `word_count: 6`, `unique_words: 4`, `character_count: 30`. |
+| 3 | The JSON-mode picker offers `Select Keys` and not `Case Conversion`; the downstream node's JSON output contains `"word_count": 6` and no `unique_words` key. |
+| 4 | The Table-mode picker offers `Filter` and not `Case Conversion`; the downstream node's Table output has exactly the cells `beta, 30, gamma, 20`. |
+
+Every criterion is a value the component computed in that run. None of them can be satisfied
+by an empty output, a passthrough, or a node that failed to build (the run gate is
+`node_duration_data operations`, which renders only on a successful build).
+
+---
+
+## External dependencies
+
+- `lfx/components/processing/operations.py` — `OperationsComponent`: `OPERATIONS_BY_TYPE`
+  (the picker's source of truth), `update_build_config` (input-type filtering + field
+  reveal), `update_outputs` (per-operation output routing), `as_message` / `as_data` /
+  `as_dataframe`, `_word_count`, `select_keys`, `_text_to_dataframe`,
+  `filter_rows_by_value`.
+- `src/frontend/.../parameterRenderComponent/components/tabComponent/index.tsx` — emits
+  `tab_{index}_{testIdCase(tab)}` for the Input Type selector.
+- `src/frontend/.../parameterRenderComponent/components/sortableListComponent/index.tsx` —
+  emits `button_open_list_selection_sortablelist_sortablelist_<field>` and the
+  `list_item_<snake_case_name>` options.
+- `src/frontend/src/CustomNodes/GenericNode/components/NodeOutputfield/index.tsx` — emits
+  `output-inspection-<output>-<type>`, the spec's per-operation output-type assertion.
+- `tests/helpers/flows/create-flow.ts`, `delete-flow.ts`,
+  `add-component-from-sidebar.ts`, `unmount-editor-for-cleanup.ts`.
+- `tests/helpers/ui/zoom-out.ts`, `adjust-screen-view.ts`, `separate-overlapping-nodes.ts`,
+  `assistant-onboarding.ts` (`seedAssistantDiscovered`).
+
+No external network, no provider key, no `httpbin`/echo endpoint.
+
+---
+
+## Flow cleanup
+
+Each test creates exactly one flow through `createFlow` (REST), so its id is known without
+sniffing responses. `afterEach` navigates off the canvas via `unmountEditorForCleanup(page)`
+— the mounted editor polls `GET /flows/{id}/events` and would log a burst of
+`🚨 Backend Error` 404s against a flow being deleted underneath it (#1023/#1103/#1288) —
+then deletes each id with an explicit `Authorization` header (`page.request`/`request` is
+unauthenticated under AUTO_LOGIN and would 401). Never `cleanAllFlows`, never a name-scoped
+or diff-based wipe: those kill flows other parallel workers are driving (#553).
+
+---
+
+## What this test does not cover
+
+- **The other 25 operations.** Text has 10, JSON 8, Table 12; four are exercised here, one
+  per axis plus the output-override case. The remaining ones share the same dispatch
+  (`_json_handlers`, `table_handlers`, `text_handlers`) and the same `update_outputs`
+  routing that these four prove; individual operation semantics are separate coverage.
+- **`Merge` / `Concatenate`** (Table) and **`Combine`** (JSON), which consume *multiple*
+  connected inputs (`left_dataframe`/`right_dataframe`, `is_list=True`). Different wiring
+  shape; out of scope here.
+- **`Path Selection`**, whose `mapped_json_display` refresh repopulates a dynamic
+  `selected_key` dropdown via `update_build_config` — a distinct dynamic-field behaviour.
+- **`Text Join`**, the only operation advertising **two** outputs (Text + Message).
+- **The legacy link/redirect.** `QA-CHECKLIST.md` §3.10's second bullet — legacy JSON/Table/Text
+  Operations components pointing at Data Operations, and legacy flows still building — is
+  separate coverage (`core-components/data-operations-legacy-link.spec.ts`) and is not
+  touched here.
+- **Persistence across reload.** `update_frontend_node` re-derives the picker options and the
+  outputs from the saved `input_type` on load; asserting that would be a reload test, and the
+  four tests here assert the live-configuration path only.
+
+---
+
+## Notes
+
+- The operation picker is a `SortableListInput` with `limit=1`: once an operation is chosen
+  the "Select Operation" button is replaced by a chip. Every test picks its operation **once**,
+  so no chip removal is needed. Switching the **Input Type** clears the selection by itself
+  (`build_config["operation"]["value"] = []`), which is what lets tests 3 and 4 re-open the
+  picker after clicking the tab.
+- `count_words` / `count_characters` / `count_lines` are `advanced=True` and default to
+  `True`; test 2 relies on those defaults and never reveals them.
+- The Text main input renders as an `<input type="text">` on the node
+  (`textarea_str_text_input`) — multi-line values must go through
+  `button_open_text_area_modal_textarea_str_text_input` → `text-area-modal` →
+  `genericModalBtnSave` (test 4).
+- `seedAssistantDiscovered(page)` runs in `beforeEach`, before the first document load: the
+  two-node tests click the canvas-controls bar (`zoomOut`, `adjustScreenView`), which the
+  assistant onboarding tooltip covers (#1220).
+- All four mechanics were confirmed live on nightly `1.12.0.dev10` during PLAN, including the
+  two chained flows: the JSON chain returned `{"word_count": 6}` and the Table chain returned
+  the two-row grid `beta/30, gamma/20`.

--- a/tests/tests-automations/regression/core-components/data-operations-component.spec.ts
+++ b/tests/tests-automations/regression/core-components/data-operations-component.spec.ts
@@ -192,9 +192,11 @@ async function runNode(node: Locator): Promise<void> {
   });
 }
 
-// Open a node's output inspector and return the modal. The testid carries the
-// output's DISPLAY NAME (`output-inspection-<title>-<type>`), so requesting
-// `output-inspection-json-operations` is itself an assertion that the node
+// Open a node's output inspector and return the modal. The testid is
+// `output-inspection-<output display name>-<component type>` — output FIRST: in
+// `output-inspection-json-operations`, `json` is what `update_outputs`
+// advertised and `operations` is the component type, identical on every node of
+// this component. So requesting that testid is itself an assertion that the node
 // advertises a JSON output.
 async function openOutputInspector(
   page: Page,
@@ -209,8 +211,16 @@ async function openOutputInspector(
   return modal;
 }
 
+// Wait for the modal to be GONE, not just clicked away: `openOutputInspector`
+// resolves `[role="dialog"]` by `.last()`, so a dialog still animating out would
+// be a live candidate for the next open. `btn-close-modal` is the precise
+// signal — it belongs to this modal only, unlike `[role="dialog"]`, which the
+// assistant onboarding tooltip also carries.
 async function closeOutputInspector(page: Page): Promise<void> {
   await page.getByTestId("btn-close-modal").click();
+  await expect(page.getByTestId("btn-close-modal")).toHaveCount(0, {
+    timeout: 15000,
+  });
 }
 
 // The node-level Text field is an `<input type="text">` and strips newlines —

--- a/tests/tests-automations/regression/core-components/data-operations-component.spec.ts
+++ b/tests/tests-automations/regression/core-components/data-operations-component.spec.ts
@@ -1,0 +1,510 @@
+import type { APIRequestContext, Locator, Page } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { createFlow } from "../../../helpers/flows/create-flow";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { unmountEditorForCleanup } from "../../../helpers/flows/unmount-editor-for-cleanup";
+import { addComponentFromSidebar } from "../../../helpers/flows/add-component-from-sidebar";
+import { adjustScreenView } from "../../../helpers/ui/adjust-screen-view";
+import { seedAssistantDiscovered } from "../../../helpers/ui/assistant-onboarding";
+import { separateOverlappingNodes } from "../../../helpers/ui/separate-overlapping-nodes";
+import { zoomOut } from "../../../helpers/ui/zoom-out";
+
+// §3.10 Data Operations (1.11.0) — the component that unified JSON Operations,
+// Table Operations and Text Operations into one node (upstream #13743/#14025;
+// `lfx/components/processing/operations.py`, class OperationsComponent,
+// name="Operations"). The three originals stayed in the sidebar as `legacy`
+// with `replacement = ["processing.Operations"]`.
+//
+// The contract under test: the Input Type tab (Text/JSON/Table) filters the
+// operation picker, swaps the main input and the advertised output — and the
+// SELECTED OPERATION can override that output type (Word Count on a Text input
+// emits JSON; Text to DataFrame emits a Table). Each operation must then return
+// the value its own semantics define.
+//
+// No provider key, no models.json, no --workers=1: every operation is pure
+// Python (string ops, dict ops, pandas). See
+// docs/core-components/data-operations-component.md.
+
+// The sentinel repeats `data` and `ops` ON PURPOSE, so `unique_words` (4) and
+// `word_count` (6) differ — a regression returning the same list for both would
+// pass against a sentinel with all-distinct words.
+const WORD_COUNT_TEXT = "data ops probe abc123 data ops";
+const CASE_TEXT = "data ops probe abc123";
+
+// Pipe-separated table for `Text to DataFrame` (default separator `|`,
+// has_header default true). `score` is converted to numeric by
+// `_convert_numeric_columns`, so `> 15` keeps beta and gamma — deliberately NOT
+// the first N rows, so a head-like regression cannot look like a pass.
+const TABLE_TEXT = ["name|score", "alpha|10", "beta|30", "gamma|20"].join("\n");
+
+// Ids of the flows each test creates via the REST API — deleted id-scoped in
+// afterEach (#490/#681/#515). Never cleanAllFlows / name-scoped / diff-based:
+// those wipe flows other parallel workers are actively driving (#553).
+const createdFlowIds: string[] = [];
+
+// Before the first document load — the only point at which the assistant
+// onboarding tooltip can be suppressed (#1220). The two-node tests click the
+// canvas-controls bar (zoomOut, adjustScreenView), which the tooltip covers.
+test.beforeEach(async ({ page }) => {
+  await seedAssistantDiscovered(page);
+});
+
+test.afterEach(async ({ page, request }) => {
+  const ids = createdFlowIds.splice(0);
+  if (ids.length === 0) return;
+  // Leave the editor before deleting: a mounted editor keeps polling
+  // `GET /flows/{id}/events` and 404s once the flow is gone, which the fixture
+  // logs as `🚨 Backend Error` (#1023/#1103/#1288).
+  await unmountEditorForCleanup(page);
+  const bearer = await getAuthToken(request);
+  for (const id of ids) {
+    await deleteFlow(request, id, { headers: { Authorization: bearer } });
+  }
+});
+
+// Create a blank flow through the REST API (parallel-safe unique name), open it
+// and add one Data Operations node. Returns the flow id. Mirrors
+// `parameters-panel-field-types.spec.ts` — going through the API means the id is
+// known without sniffing the creation response, and the canvas URL id is
+// transient on this Langflow version.
+async function openFlowWithDataOperations(
+  page: Page,
+  request: APIRequestContext,
+  bearer: string,
+): Promise<string> {
+  const flowId = await createFlow(
+    request,
+    {
+      name: `Data Ops ${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      description: "",
+      data: { nodes: [], edges: [] },
+      is_component: false,
+    },
+    { headers: { Authorization: bearer } },
+  );
+  createdFlowIds.push(flowId);
+
+  await page.goto(`/flow/${flowId}`);
+  await page
+    .getByTestId("sidebar-search-input")
+    .waitFor({ state: "visible", timeout: 60000 });
+  await addDataOperationsNode(page);
+  return flowId;
+}
+
+async function addDataOperationsNode(page: Page): Promise<void> {
+  const before = await page.locator(".react-flow__node").count();
+  await addComponentFromSidebar(
+    page,
+    "data operations",
+    "add-component-button-data-operations",
+  );
+  await expect(page.locator(".react-flow__node")).toHaveCount(before + 1, {
+    timeout: 15000,
+  });
+}
+
+// Both nodes in the chained tests are of type `Operations`, so every testid on
+// them is identical. They are addressed by an identity-carrying child instead of
+// by DOM order: only a Text-mode node renders `textarea_str_text_input`, and only
+// a JSON/Table-mode node renders the matching typed input handle. Each locator is
+// asserted to resolve to exactly one node before use, so a mis-selection fails
+// naming the cause instead of silently configuring the wrong node.
+function nodeContaining(page: Page, childTestId: string): Locator {
+  return page
+    .locator(".react-flow__node")
+    .filter({ has: page.getByTestId(childTestId) });
+}
+
+async function expectSingleNode(node: Locator, what: string): Promise<Locator> {
+  await expect(node, `${what} should resolve to exactly one node`).toHaveCount(
+    1,
+    { timeout: 15000 },
+  );
+  return node;
+}
+
+// The operation picker is a SortableListInput with limit=1: the "Select
+// Operation" button is replaced by a chip once an operation is chosen. Every
+// test picks its operation once, so no chip removal is needed here. Switching the
+// Input Type clears the selection by itself (update_build_config sets
+// `operation.value = []`), which is what lets the chained tests re-open it.
+async function pickOperation(
+  page: Page,
+  node: Locator,
+  optionTestId: string,
+): Promise<void> {
+  await node
+    .getByTestId("button_open_list_selection_sortablelist_sortablelist_operation")
+    .click();
+  await page.getByTestId(optionTestId).click();
+  await expect(page.getByTestId(optionTestId)).toHaveCount(0, {
+    timeout: 15000,
+  });
+}
+
+// Assert the picker offers the operations of `input_type` and no longer offers
+// the others — `update_build_config` swapping
+// `build_config["operation"]["options"]` to OPERATIONS_BY_TYPE[input_type],
+// observed from the UI. Leaves the picker OPEN on the wanted option so the
+// caller can click it.
+async function expectPickerFilteredTo(
+  page: Page,
+  node: Locator,
+  presentTestId: string,
+): Promise<void> {
+  await node
+    .getByTestId("button_open_list_selection_sortablelist_sortablelist_operation")
+    .click();
+  await expect(page.getByTestId(presentTestId)).toBeVisible({ timeout: 15000 });
+  // `Case Conversion` belongs to the Text tab only: still being offered would
+  // mean the picker was never re-filtered for the selected type.
+  await expect(page.getByTestId("list_item_case_conversion")).toHaveCount(0);
+}
+
+async function selectDropdownOption(
+  page: Page,
+  node: Locator,
+  dropdownTestId: string,
+  optionName: string,
+): Promise<void> {
+  await node.getByTestId(dropdownTestId).click();
+  await page.getByRole("option", { name: optionName, exact: true }).click();
+  await expect(node.getByTestId(dropdownTestId)).toHaveText(optionName, {
+    timeout: 15000,
+  });
+}
+
+// Run one node and wait for its build badge — `node_duration_*` renders only on
+// a successful build and is the repo's canonical completion signal (#506/#507).
+//
+// The click is dispatched at the event level: on the two-node canvas the lower
+// node's controls sit under `main_canvas_controls` (and, right after a build,
+// under the "built successfully" toast), which intercepts hit-tested clicks.
+// Same fix, and same safeguard, as `selectOperator` in
+// `if-else-component-regression.spec.ts`: the assertion below fails loudly if
+// the dispatch was a no-op.
+async function runNode(node: Locator): Promise<void> {
+  await node.getByTestId("button_run_data operations").dispatchEvent("click");
+  await expect(node.getByTestId("node_duration_data operations")).toBeVisible({
+    timeout: 60000,
+  });
+}
+
+// Open a node's output inspector and return the modal. The testid carries the
+// output's DISPLAY NAME (`output-inspection-<title>-<type>`), so requesting
+// `output-inspection-json-operations` is itself an assertion that the node
+// advertises a JSON output.
+async function openOutputInspector(
+  page: Page,
+  node: Locator,
+  outputTestId: string,
+): Promise<Locator> {
+  // Dispatched for the same reason as in `runNode`, and guarded the same way:
+  // the modal becoming visible is what proves the dispatch landed.
+  await node.getByTestId(outputTestId).dispatchEvent("click");
+  const modal = page.locator('[role="dialog"]').last();
+  await expect(modal).toBeVisible({ timeout: 15000 });
+  return modal;
+}
+
+async function closeOutputInspector(page: Page): Promise<void> {
+  await page.getByTestId("btn-close-modal").click();
+}
+
+// The node-level Text field is an `<input type="text">` and strips newlines —
+// a multi-line value has to go through the text-area modal.
+async function fillMultilineText(
+  page: Page,
+  node: Locator,
+  value: string,
+): Promise<void> {
+  await node
+    .getByTestId("button_open_text_area_modal_textarea_str_text_input")
+    .click();
+  const modal = page.locator('[role="dialog"]').last();
+  await modal.getByTestId("text-area-modal").fill(value);
+  await modal.getByTestId("genericModalBtnSave").click();
+  await expect(modal).toBeHidden({ timeout: 15000 });
+}
+
+// Add the second Data Operations node and spread the two apart. Two sidebar `+`
+// clicks land the nodes ~10px apart, and a stacked node intercepts pointer
+// events aimed at a handle underneath it — which can silently produce a
+// different connection than intended (#939).
+//
+// Order matters, and the obvious one is wrong: `adjustScreenView` starts with
+// `fit_view`, which on two STACKED nodes zooms IN to fill the canvas with them,
+// undoing the zoom-out and leaving each node ~415 px tall — taller than
+// `separateOverlappingNodes`' default 220 px step, so the separation poll can
+// never converge (measured: both chained tests failed there on the first run).
+// So: zoom out first, separate with a step wider than the zoomed-out node, and
+// only then fit both nodes back into view.
+async function addSecondNodeAndSeparate(page: Page): Promise<void> {
+  await addDataOperationsNode(page);
+  await zoomOut(page, 3);
+  await separateOverlappingNodes(page, 300);
+  await adjustScreenView(page);
+}
+
+test(
+  "Data Operations Text mode returns the Case Conversion result as a Message",
+  { tag: ["@stable", "@components", "@ui-ux"] },
+  async ({ page, request }) => {
+    const bearer = await getAuthToken(request);
+
+    await test.step("Open a flow with one Data Operations node", async () => {
+      await openFlowWithDataOperations(page, request, bearer);
+      await expect(page.getByTestId("title-Data Operations")).toBeVisible({
+        timeout: 15000,
+      });
+    });
+
+    const node = page.locator(".react-flow__node").first();
+
+    await test.step("Configure Text / Case Conversion → uppercase", async () => {
+      // Input Type stays on its default `Text` tab.
+      await node.getByTestId("textarea_str_text_input").fill(CASE_TEXT);
+      await pickOperation(page, node, "list_item_case_conversion");
+      await selectDropdownOption(
+        page,
+        node,
+        "value-dropdown-dropdown_str_case_type",
+        "uppercase",
+      );
+    });
+
+    await test.step("Run and assert the Message output is the uppercased text", async () => {
+      await runNode(node);
+      const modal = await openOutputInspector(
+        page,
+        node,
+        "output-inspection-message-operations",
+      );
+      // `as_message` → Message(text=text.upper()); the inspector renders a
+      // Message output in a textarea.
+      await expect(modal.locator("textarea").first()).toHaveValue(
+        CASE_TEXT.toUpperCase(),
+        { timeout: 15000 },
+      );
+      await closeOutputInspector(page);
+    });
+  },
+);
+
+test(
+  "Data Operations Word Count switches the Text-mode output to JSON and counts the text",
+  { tag: ["@stable", "@components", "@ui-ux"] },
+  async ({ page, request }) => {
+    const bearer = await getAuthToken(request);
+
+    await test.step("Open a flow with one Data Operations node", async () => {
+      await openFlowWithDataOperations(page, request, bearer);
+      await expect(page.getByTestId("title-Data Operations")).toBeVisible({
+        timeout: 15000,
+      });
+    });
+
+    const node = page.locator(".react-flow__node").first();
+
+    await test.step("Configure Text / Word Count", async () => {
+      await node.getByTestId("textarea_str_text_input").fill(WORD_COUNT_TEXT);
+      await pickOperation(page, node, "list_item_word_count");
+    });
+
+    await test.step("The advertised output flips from Message to JSON", async () => {
+      // The distinctive consequence of the merge: the OPERATION, not only the
+      // Input Type, decides the output. Word Count is routed to `as_data` while
+      // the tab is still `Text`.
+      await expect(
+        node.getByTestId("output-inspection-json-operations"),
+      ).toBeVisible({ timeout: 15000 });
+      await expect(
+        node.getByTestId("output-inspection-message-operations"),
+      ).toHaveCount(0);
+    });
+
+    await test.step("Run and assert the counted values", async () => {
+      await runNode(node);
+      const modal = await openOutputInspector(
+        page,
+        node,
+        "output-inspection-json-operations",
+      );
+      // `_word_count`: len(split()) / len(set(split())) / len(text).
+      // "data ops probe abc123 data ops" → 6 words, 4 unique, 30 characters.
+      await expect(modal).toContainText('"word_count": 6', { timeout: 15000 });
+      await expect(modal).toContainText('"unique_words": 4');
+      await expect(modal).toContainText('"character_count": 30');
+      await closeOutputInspector(page);
+    });
+  },
+);
+
+test(
+  "Data Operations JSON mode selects a single key from an upstream JSON output",
+  { tag: ["@stable", "@components", "@ui-ux"] },
+  async ({ page, request }) => {
+    const bearer = await getAuthToken(request);
+
+    await test.step("Open a flow with two Data Operations nodes", async () => {
+      await openFlowWithDataOperations(page, request, bearer);
+      await addSecondNodeAndSeparate(page);
+    });
+
+    // Before the downstream node is switched to JSON, both nodes are in Text
+    // mode, so order is the only way to tell them apart — the second node added
+    // is the last one in the DOM.
+    const downstream = page.locator(".react-flow__node").last();
+    const upstream = page.locator(".react-flow__node").first();
+
+    await test.step("Upstream node produces a JSON payload via Word Count", async () => {
+      await upstream.getByTestId("textarea_str_text_input").fill(WORD_COUNT_TEXT);
+      await pickOperation(page, upstream, "list_item_word_count");
+      await expect(
+        upstream.getByTestId("output-inspection-json-operations"),
+      ).toBeVisible({ timeout: 15000 });
+    });
+
+    await test.step("Downstream node switches to JSON and the picker is re-filtered", async () => {
+      await downstream.getByTestId("tab_1_json").click();
+      // Only a JSON-mode node renders this handle — from here on both nodes are
+      // addressed by identity, never by position.
+      await expect(
+        downstream.getByTestId("handle-operations-shownode-json-left"),
+      ).toBeVisible({ timeout: 15000 });
+      await expectPickerFilteredTo(page, downstream, "list_item_select_keys");
+      await page.getByTestId("list_item_select_keys").click();
+      await downstream
+        .getByTestId("inputlist_str_select_keys_input_0")
+        .fill("word_count");
+    });
+
+    const jsonConsumer = await expectSingleNode(
+      nodeContaining(page, "handle-operations-shownode-json-left"),
+      "the JSON-mode node",
+    );
+    const jsonProducer = await expectSingleNode(
+      nodeContaining(page, "textarea_str_text_input"),
+      "the Text-mode node",
+    );
+
+    await test.step("Wire the JSON output into the JSON input", async () => {
+      await jsonProducer
+        .getByTestId("handle-operations-shownode-json-right")
+        .click();
+      await jsonConsumer
+        .getByTestId("handle-operations-shownode-json-left")
+        .click();
+      await expect(page.locator(".react-flow__edge")).toHaveCount(1, {
+        timeout: 15000,
+      });
+    });
+
+    await test.step("Run and assert only the requested key survives", async () => {
+      await runNode(jsonConsumer);
+      const modal = await openOutputInspector(
+        page,
+        jsonConsumer,
+        "output-inspection-json-operations",
+      );
+      // `select_keys` keeps only the requested key; the upstream payload also
+      // carried unique_words / character_count / line_count. The negative half
+      // is what separates "Select Keys ran" from "the payload passed through".
+      await expect(modal).toContainText('"word_count": 6', { timeout: 15000 });
+      await expect(modal).not.toContainText("unique_words");
+      await closeOutputInspector(page);
+    });
+  },
+);
+
+test(
+  "Data Operations Table mode filters the rows of an upstream Table output",
+  { tag: ["@stable", "@components", "@ui-ux"] },
+  async ({ page, request }) => {
+    const bearer = await getAuthToken(request);
+
+    await test.step("Open a flow with two Data Operations nodes", async () => {
+      await openFlowWithDataOperations(page, request, bearer);
+      await addSecondNodeAndSeparate(page);
+    });
+
+    const downstream = page.locator(".react-flow__node").last();
+    const upstream = page.locator(".react-flow__node").first();
+
+    await test.step("Upstream node produces a Table via Text to DataFrame", async () => {
+      await fillMultilineText(page, upstream, TABLE_TEXT);
+      await pickOperation(page, upstream, "list_item_text_to_dataframe");
+      // Text to DataFrame is the second operation that overrides the Text tab's
+      // default output — here to a Table.
+      await expect(
+        upstream.getByTestId("output-inspection-table-operations"),
+      ).toBeVisible({ timeout: 15000 });
+    });
+
+    await test.step("Downstream node switches to Table and the picker is re-filtered", async () => {
+      await downstream.getByTestId("tab_2_table").click();
+      await expect(
+        downstream.getByTestId("handle-operations-shownode-table-left"),
+      ).toBeVisible({ timeout: 15000 });
+      await expectPickerFilteredTo(page, downstream, "list_item_filter");
+      await page.getByTestId("list_item_filter").click();
+    });
+
+    const tableConsumer = await expectSingleNode(
+      nodeContaining(page, "handle-operations-shownode-table-left"),
+      "the Table-mode node",
+    );
+    const tableProducer = await expectSingleNode(
+      nodeContaining(page, "textarea_str_text_input"),
+      "the Text-mode node",
+    );
+
+    await test.step("Configure Filter: score greater than 15", async () => {
+      await tableConsumer
+        .getByTestId("popover-anchor-input-column_name")
+        .fill("score");
+      await tableConsumer
+        .getByTestId("popover-anchor-input-filter_value")
+        .fill("15");
+      await selectDropdownOption(
+        page,
+        tableConsumer,
+        "value-dropdown-dropdown_str_filter_operator",
+        "greater than",
+      );
+    });
+
+    await test.step("Wire the Table output into the Table input", async () => {
+      await tableProducer
+        .getByTestId("handle-operations-shownode-table-right")
+        .click();
+      await tableConsumer
+        .getByTestId("handle-operations-shownode-table-left")
+        .click();
+      await expect(page.locator(".react-flow__edge")).toHaveCount(1, {
+        timeout: 15000,
+      });
+    });
+
+    await test.step("Run and assert only the matching rows survive", async () => {
+      await runNode(tableConsumer);
+      const modal = await openOutputInspector(
+        page,
+        tableConsumer,
+        "output-inspection-table-operations",
+      );
+      // `filter_rows_by_value` with `greater than` compares numerically after
+      // `_convert_numeric_columns`: 10, 30, 20 > 15 keeps beta and gamma, in the
+      // original row order. alpha must be gone.
+      await expect
+        .poll(
+          async () => modal.getByRole("gridcell").allInnerTexts(),
+          { timeout: 20000 },
+        )
+        .toEqual(["beta", "30", "gamma", "20"]);
+      await closeOutputInspector(page);
+    });
+  },
+);


### PR DESCRIPTION
Closes #1191.

Closes the `[ ] Data Operations component: unified JSON/Table/Text operations produce correct outputs per operation mode` gap in `QA-CHECKLIST.md` §3.10.

Langflow 1.11.0 merged the three separate operation components — **JSON Operations** (`DataOperations`), **Table Operations** (`DataFrameOperations`) and **Text Operations** (`TextOperations`) — into a single **Data Operations** node (`lfx/components/processing/operations.py`, class `OperationsComponent`, `name="Operations"`); upstream `langflow-ai/langflow#13743` unified and `#14025` named it. The three originals stayed in the sidebar as `legacy: true` with `replacement = ["processing.Operations"]`.

No sibling spec touches this surface: §3.10's *other* bullet (legacy components linking/redirecting to Data Operations, legacy flows still building) is separate coverage and is **not** touched here.

## 1. Covered tests

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `Data Operations Text mode returns the Case Conversion result as a Message` | Input Type `Text` + `Case Conversion (uppercase)` on `data ops probe abc123` → the node advertises a **Message** output (`output-inspection-message-operations`) and the inspector textarea equals `DATA OPS PROBE ABC123` exactly. Catches a regression in `as_message` / `_case_conversion` or in the Text tab's default output routing. |
| 2 | `Data Operations Word Count switches the Text-mode output to JSON and counts the text` | With the tab still on `Text`, choosing `Word Count` re-advertises the output as **JSON** — `output-inspection-json-operations` exists and `output-inspection-message-operations` has count 0 — and the payload is `word_count: 6`, `unique_words: 4`, `character_count: 30`. This is the most distinctive consequence of the merge: the **operation**, not only the input type, decides the output (`update_outputs`). |
| 3 | `Data Operations JSON mode selects a single key from an upstream JSON output` | Switching to `JSON` re-filters the operation picker (`Select Keys` offered, `Case Conversion` gone — `update_build_config` swapping `OPERATIONS_BY_TYPE`), and `Select Keys ["word_count"]` over an upstream Word Count payload returns `{"word_count": 6}` **without** `unique_words`. The negative half separates "Select Keys ran" from "the payload passed through". |
| 4 | `Data Operations Table mode filters the rows of an upstream Table output` | Switching to `Table` re-filters the picker (`Filter` offered, `Case Conversion` gone), and `Filter: score greater than 15` over an upstream `Text to DataFrame` table returns exactly the cells `beta, 30, gamma, 20`. Also covers the second output override (`Text to DataFrame` → Table). |

## 2. How the test was built

- **Setup:** blank flow created via the REST API (`createFlow`, unique name → parallel-safe), then opened at `/flow/{id}` and populated from the sidebar. Going through the API means the id is known without sniffing the creation response — the canvas URL id is transient on this version.
- **Expected values are derived from the component source, not observed.** `_word_count` (`len(split())` / `len(set(split()))` / `len(text)`) → 6 / 4 / 30; `select_keys` → single-key dict; `filter_rows_by_value` with `greater than` compares numerically after `_convert_numeric_columns` → 10, 30, 20 > 15 keeps beta and gamma. The Word Count sentinel **repeats** `data` and `ops` on purpose so `unique_words` (4) ≠ `word_count` (6), and the table's surviving rows are deliberately **not** the first N, so a `head`-like regression cannot look like a pass.
- **Live-confirmed selectors** (scouted in the running DOM, none invented): `add-component-button-data-operations`, `tab_0_text` / `tab_1_json` / `tab_2_table`, `textarea_str_text_input`, `button_open_text_area_modal_textarea_str_text_input` → `text-area-modal` → `genericModalBtnSave`, `button_open_list_selection_sortablelist_sortablelist_operation`, `list_item_{case_conversion,word_count,text_to_dataframe,select_keys,filter}`, `value-dropdown-dropdown_str_case_type`, `inputlist_str_select_keys_input_0`, `popover-anchor-input-{column_name,filter_value}`, `value-dropdown-dropdown_str_filter_operator`, `handle-operations-shownode-{text,json,table,message}-{left,right}`, `button_run_data operations`, `node_duration_data operations`, `output-inspection-{message,json,table}-operations`, `btn-close-modal`.
- **Chained flows for JSON and Table.** Both inputs are connection-only, so tests 3 and 4 wire a second Data Operations node — which also proves the unified component's own output plugs into its own typed input. The two nodes share every testid (same component type), so once the downstream node is switched they are addressed by an **identity-carrying child** (`textarea_str_text_input` for the Text-mode producer; `handle-operations-shownode-json-left` / `table-left` for the consumer), each asserted to resolve to exactly **one** node — never by DOM order.
- **Two mechanics that took a debug cycle, both fixed rather than worked around:**
  - `adjustScreenView` starts with `fit_view`, which on two **stacked** nodes zooms *in* to fill the canvas and leaves each node ~415 px tall — wider than `separateOverlappingNodes`' 220 px default step, so the separation poll could never converge. Order is now zoom-out → separate (step 300) → fit.
  - The lower node's run control and output-inspector button sit under `main_canvas_controls` (and, right after a build, under the "built successfully" toast), which intercepts hit-tested clicks. Both are dispatched at the event level, each guarded by the assertion that follows (`node_duration_*` / the modal becoming visible), so a no-op dispatch fails loudly — the same fix and safeguard already documented in `if-else-component-regression.spec.ts`.
- **Assertion surface:** the node's own output inspector, whose testid carries the output's display name (`output-inspection-<title>-<type>`). Asking for `output-inspection-json-operations` *is* an assertion that `update_outputs` produced a JSON output — the testid cannot exist otherwise. Message → `textarea` value; JSON → the dialog's text; Table → `role="gridcell"` contents.
- **Cleanup:** each test creates exactly one flow whose id is known; `afterEach` leaves the editor via `unmountEditorForCleanup` (so the events poll stops 404ing against a flow being deleted, #1288) and deletes only that id with an explicit bearer. Verified after the runs: **zero orphans** — the instance holds exactly the flows it held before.

## 3. Dependencies

- **None — pure UI/Python.** No model provider, no API key, no `collect-models`, no `models.json`, no external network. Every operation is string/dict/pandas code.
- **Parallel-safe:** flow names are unique per test and cleanup is id-scoped; no `--workers=1` needed.
- Data Operations is the **non-legacy** component and is in the default sidebar — the Legacy toggle is not used.

## Validation (nightly 1.12.0.dev10, `--retries=0`)

- typecheck ✅ · eslint ✅
- **3/3 clean bursts** at `--retries=0 --workers=1` (`expected=4, unexpected=0, flaky=0` each), plus a 4th green run after the force-fail reverts ✅
- zero `🚨 Backend Error` on every run ✅
- **force-fail executed for all 4 tests**, each isolated by `--grep`, each marked `// FF-MUTATION` and reverted (final marker count in the diff: 0):
  - #1 — expect the untouched text instead of the uppercased result → failed ✅
  - #2 — expect `"unique_words": 6` (equal to `word_count`) → failed ✅
  - #3 — flip the negative half and require `unique_words` to be present → failed ✅
  - #4 — expect the full unfiltered grid with `alpha/10` → failed ✅
- flow cleanup verified via `GET /api/v1/flows/`: zero orphans ✅

> **Nightly note:** validated on `1.12.0.dev10`; the current nightly tag is `1.12.0.dev17`. The local instance was deliberately **not** rebuilt — it runs without a volume, so recreating it would destroy its SQLite state (flows and imported provider global variables). Nothing in the diff depends on behaviour that moved between those builds, and `daily-stable.yml` runs against the newest nightly.
>
> `--trace=on` was not run: it is a known local hang on this stack (see the langflow-e2e-issues skill). Step verification is covered by the clean `--retries=0` bursts, the executed force-fails, and the live DOM scouting the selectors came from.

Generated blocks in `QA-CHECKLIST.md` were **not** regenerated — only the §3.10 bullet was edited (they regenerate on merge, #741).
