### PR TITLE
test(core-components): cover the legacy operations link to Data Operations (#1192)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -278,7 +278,7 @@
 
 #### 3.10 Data Operations (1.11.0)
 - [x] Data Operations component: unified JSON/Table/Text operations produce correct outputs per operation mode (Text→Message, Word Count→JSON override, JSON Select Keys, Table Filter) → `core-components/data-operations-component.spec.ts`
-- [ ] Legacy operations components link/redirect to Data Operations (legacy flows keep working) → `core-components/data-operations-legacy-link.spec.ts`
+- [x] Legacy operations components link/redirect to Data Operations (banner resolves the replacement, link filters the sidebar, old names still find the new component, legacy flows keep working) → `core-components/data-operations-legacy-link.spec.ts`
 
 ---
 

--- a/docs/core-components/data-operations-legacy-link.md
+++ b/docs/core-components/data-operations-legacy-link.md
@@ -1,0 +1,248 @@
+# Spec: legacy operations components link to Data Operations
+
+**Test file:** `tests/tests-automations/regression/core-components/data-operations-legacy-link.spec.ts`
+
+**Last validated:** Langflow 1.12.x
+
+---
+
+## What this test validates
+
+The other half of `QA-CHECKLIST.md` §3.10. When 1.11.0 merged JSON / Table / Text
+Operations into the unified **Data Operations** node (covered by
+`data-operations-component.spec.ts`, #1191), the three originals were not deleted — they
+were marked `legacy = True` with `replacement = ["processing.Operations"]`, and upstream
+`langflow-ai/langflow#14118` wired that pointer into the UI. This spec covers the promise
+that pairing makes to a user who already has one of the old components:
+
+> A legacy operations node **tells you what replaced it, by name**, gives you a one-click
+> route to it, is still reachable when you search for its old name — and **keeps building**
+> in the meantime.
+
+Four tests, one claim each:
+
+1. **All three legacy nodes resolve their replacement.** Each of JSON / Table / Text
+   Operations renders the Legacy banner reading `Use Data Operations.`
+2. **The banner link is a route, not decoration.** Clicking `Data Operations` in the banner
+   filters the component sidebar down to that component.
+3. **Searching the old name finds the new component**, with the Legacy toggle in its
+   default OFF state.
+4. **A legacy operations component still runs**, returning the value its operation defines.
+
+### Why the banner text is the assertion, and why `No direct replacement.` is the trap
+
+`NodeLegacyComponent/index.tsx` does not print the raw `replacement` string. It resolves it
+through `useGetReplacementComponents`, which splits `"processing.Operations"` into category
+and name and looks up `data["processing"]["Operations"].display_name` in the types store.
+Only when that lookup succeeds does it render `Use <display name>.`; otherwise it falls back
+to the literal string **`No direct replacement.`**
+
+That makes the observable unusually sharp for a UI string. Asserting `Use Data Operations.`
+proves the *whole chain*: the legacy component still declares a `replacement`, the pointer
+still names a category and component that exist in this build, and the frontend resolved it
+to the display name a user can act on. Rename or move the unified component and the banner
+silently degrades to `No direct replacement.` — the node still renders, nothing errors, and
+only this assertion notices. So every banner check asserts the positive string **and** the
+absence of the fallback.
+
+### Distinct from the sibling spec that looks similar
+
+`flow-functionality/general-bugs-frontend-crashing-on-invalid-replace.spec.ts` also mentions
+`No direct replacement` — but it is the **opposite** journey and a different subject: it
+builds a *custom* component with a deliberately bogus `replacement`
+(`THISISNOTEXISTING.COMPONENT`) and proves the frontend degrades to that fallback instead of
+crashing. It asserts the fallback path **works**; this spec asserts the three real legacy
+operations components are **not on it**. Neither covers the other.
+
+`core-components/legacy-components-toggle-regression.spec.ts` covers the sidebar Legacy
+toggle itself (visibility on/off) with an unrelated component pair, not the
+replacement-pointer contract. Test 3 below depends on that toggle's default only as a
+precondition.
+
+---
+
+## Tags
+
+`@stable` `@components` `@ui-ux`
+
+`@components` is the cross-cutting tag (canvas/sidebar component behaviour); `@ui-ux` the
+functional one — the banner, the sidebar filter and the sidebar search are interface
+surfaces. Same reasoning as `data-operations-component.md` and `human-input-node-config.md`.
+
+`@regression` is deliberately **absent**: first-time coverage of a 1.11.0 feature, not a
+previously fixed bug. `@destructive` does not apply — each test creates and deletes its own
+flow, and the one piece of shared-looking state it touches (`showLegacy`) is **localStorage**
+(`getBooleanFromStorage("showLegacy", false)`), so it is per browser context and cannot leak
+into a parallel worker.
+
+---
+
+## Preconditions
+
+- Langflow running at `PLAYWRIGHT_BASE_URL` (validated on the nightly, 1.12.x).
+- **No** model provider credentials, no `collect-models`, no `--workers=1`.
+- The sidebar **Legacy** toggle defaults to OFF. Tests 1, 2 and 4 turn it on via
+  `addLegacyComponents(page)` to reach the legacy components; test 3 depends on it being
+  **off** and therefore never touches it.
+
+---
+
+## Scenarios (one `test()` per row)
+
+| # | Scenario | Setup | Asserted observable |
+|---|---|---|---|
+| 1 | All three legacy operations nodes name their replacement | Legacy toggle on; add JSON Operations, Table Operations and Text Operations to one flow | Each node exposes `dismiss-warning-bar` (the Legacy banner) and contains the text `Use Data Operations.`; none contains `No direct replacement.` |
+| 2 | The banner link filters the sidebar to the replacement | Legacy toggle on; one JSON Operations node; click the `Data Operations` link inside its banner | `sidebar-filter-reset` becomes visible (a component filter is active) and the sidebar offers `add-component-button-data-operations` while `add-component-button-json-operations` drops to count 0 |
+| 3 | The old names find the new component with Legacy off | Default toggle state; type each legacy name into `sidebar-search-input` | For all three searches the sidebar offers `add-component-button-data-operations`, and the matching legacy button (`…-json-operations` / `…-table-operations` / `…-text-operations`) has count 0 |
+| 4 | A legacy operations component still builds | Legacy toggle on; Text Operations, `Case Conversion` = uppercase, text `legacy still works abc123` | `node_duration_text operations` renders (successful build) and `output-inspection-message-textoperations` shows `LEGACY STILL WORKS ABC123` |
+
+Test 3 is what makes the "redirect" claim true for a user who never enables the Legacy
+toggle: the unified component carries the old names in `metadata.keywords`
+(`"json operations"`, `"table operations"`, `"text operations"` — `operations.py`), so the
+search that used to land on the legacy node now lands on its replacement. The negative half
+(the legacy button absent) is what keeps the test honest — without it, the assertion would
+also pass on a build where the search matched both.
+
+Test 4's expected value comes from the legacy component's own source
+(`text_operations.py` → `_case_conversion` → `str.upper`), not from observation, and reuses
+the sentinel shape of the #1191 spec.
+
+---
+
+## Step by step
+
+### Shared setup
+
+`openFlowWithLegacy(page, request, bearer, { enableLegacy })` (local helper):
+
+1. `createFlow` via the REST API with a unique name (parallel-safe); push the id onto
+   `createdFlowIds` for id-scoped teardown.
+2. `page.goto("/flow/<id>")`, wait for `sidebar-search-input`.
+3. When `enableLegacy`, call `addLegacyComponents(page)` — the existing helper that opens
+   `sidebar-options-trigger`, flips `sidebar-legacy-switch`, asserts it is checked, and
+   closes the menu.
+
+### Per-test steps
+
+**Test 1 — the three banners**
+1. Setup with the Legacy toggle on.
+2. Add `JSON Operations`, `Table Operations` and `Text Operations` from the sidebar
+   (`add-component-button-{json,table,text}-operations`), asserting the node count after
+   each so a silently missing component fails here and not in the assertion.
+3. For each node — located by its own `title-<name>` testid, so the three stacked nodes are
+   never confused — assert `dismiss-warning-bar` is attached, the node text contains
+   `Use Data Operations.`, and it does **not** contain `No direct replacement.`
+
+The nodes are deliberately **not** separated: this test only reads text and testids inside
+each node, so the pointer-interception problem that forces `separateOverlappingNodes` in the
+chained #1191 tests does not arise.
+
+**Test 2 — the link filters the sidebar**
+1. Setup with the Legacy toggle on; add one `JSON Operations` node.
+2. Inside the node, click the banner's `Data Operations` button
+   (`getByRole("button", { name: "Data Operations" })` — the link carries no testid).
+3. Assert `sidebar-filter-reset` is visible, `add-component-button-data-operations` is
+   visible, and `add-component-button-json-operations` has count 0.
+
+**Test 3 — search by the old names, Legacy off**
+1. Setup **without** enabling the toggle.
+2. For each of `json operations`, `table operations`, `text operations`: fill
+   `sidebar-search-input`, then assert `add-component-button-data-operations` is visible and
+   the corresponding legacy add-button has count 0.
+
+**Test 4 — a legacy component still builds**
+1. Setup with the Legacy toggle on; add `Text Operations`.
+2. Fill `textarea_str_text_input` with `legacy still works abc123`.
+3. Open `button_open_list_selection_sortablelist_sortablelist_operation`, pick
+   `list_item_case_conversion`, set `value-dropdown-dropdown_str_case_type` to `uppercase`.
+4. Run via `button_run_text operations`; wait for `node_duration_text operations`.
+5. Open `output-inspection-message-textoperations` and assert the modal's textarea equals
+   `LEGACY STILL WORKS ABC123`; close it and wait for the modal to be gone.
+
+---
+
+## Validation criterion
+
+| # | Pass condition |
+|---|---|
+| 1 | All three legacy nodes render the Legacy banner and read `Use Data Operations.`, none reads `No direct replacement.` |
+| 2 | After the banner click the sidebar carries an active component filter and offers exactly the replacement, not the legacy origin. |
+| 3 | With Legacy off, each old name surfaces `Data Operations` and no legacy button. |
+| 4 | The legacy Text Operations node builds (`node_duration_*`) and its Message output equals `LEGACY STILL WORKS ABC123`. |
+
+Nothing here can be satisfied by an empty state: three of the four assert a **positive**
+string or element plus the **absence** of the alternative it would degrade to, and the fourth
+asserts a value the component had to compute.
+
+---
+
+## External dependencies
+
+- `lfx/components/processing/data_operations.py`, `dataframe_operations.py`,
+  `text_operations.py` — each declares `legacy = True` and
+  `replacement = ["processing.Operations"]`; `text_operations.py` also owns the
+  `_case_conversion` behaviour test 4 asserts.
+- `lfx/components/processing/operations.py` — the replacement target; its
+  `metadata.keywords` carry the three legacy names that test 3 searches for.
+- `src/frontend/src/CustomNodes/GenericNode/components/NodeLegacyComponent/index.tsx` —
+  renders the banner, the `dismiss-warning-bar` testid, the `Use <name>.` / `No direct
+  replacement.` branch, and the link whose click calls `setFilterComponent`.
+- `src/frontend/src/CustomNodes/GenericNode/hooks/use-get-replacement-components.ts` —
+  resolves `"processing.Operations"` to a display name via the types store.
+- `src/frontend/src/pages/FlowPage/components/flowSidebarComponent/index.tsx` — owns
+  `showLegacy` (localStorage, default false) and the `sidebar-filter-reset` control.
+- `tests/helpers/flows/add-legacy-components.ts`, `create-flow.ts`, `delete-flow.ts`,
+  `add-component-from-sidebar.ts`, `unmount-editor-for-cleanup.ts`,
+  `tests/helpers/ui/assistant-onboarding.ts`.
+
+No external network, no provider key.
+
+---
+
+## Flow cleanup
+
+Each test creates exactly one flow via `createFlow`, so the id is known without sniffing
+responses. `afterEach` leaves the editor through `unmountEditorForCleanup(page)` — a mounted
+editor keeps polling `GET /flows/{id}/events` and would log a burst of `🚨 Backend Error`
+404s against a flow being deleted underneath it (#1023/#1103/#1288) — then deletes each id
+with an explicit `Authorization` header. Never `cleanAllFlows` or a name/diff-scoped wipe
+(#553).
+
+---
+
+## What this test does not cover
+
+- **The `Dismiss` control.** `dismiss-warning-bar` sets `dismissAllLegacy` and persists per
+  flow in localStorage (`dismiss_legacy_<flowId>`, `flowStore.ts`). It is banner UX, not the
+  replacement contract; its presence is asserted, its behaviour is not.
+- **Migrating a legacy node into the unified one.** The banner link *filters the sidebar*; it
+  does not rewrite the node. There is no in-place upgrade action for these components on this
+  build, so there is nothing to assert.
+- **Importing a flow JSON saved by an older Langflow.** Any fixture committed here would be
+  serialized by the build under test, so it would prove deserialization of *this* build's
+  payload, not of an older one. Test 4 covers the claim that matters and is provable — a
+  legacy component still builds and returns the right value.
+- **The remaining operations of the legacy components.** Their per-operation semantics were
+  the point of the components the unified one replaces; #1191 covers that surface on the
+  replacement. Test 4 exercises one operation as proof of life, not as a matrix.
+- **The other legacy components in the sidebar** (Python Function, Alter Metadata, …). This
+  spec is scoped to §3.10's three operations components.
+
+---
+
+## Notes
+
+- The legacy nodes keep their **original** class names in every testid — the node type is
+  `DataOperations` / `DataFrameOperations` / `TextOperations`, not `Operations`. Hence
+  `output-inspection-message-textoperations` and `button_run_text operations`, and hence no
+  testid collision with the unified component if both ever sit on one canvas.
+- The banner link has no testid; it is matched by accessible name
+  (`getByRole("button", { name: "Data Operations" })`), scoped to the node so it can never
+  resolve to the sidebar entry of the same name.
+- `showLegacy` is localStorage-backed and defaults to `false`, so enabling it in one test
+  cannot affect a parallel worker, and test 3's precondition holds without any reset.
+- All four mechanics were confirmed live on nightly `1.12.0.dev10` during PLAN: the three
+  banners read `Use Data Operations.`; the link left the sidebar filtered to a single
+  `Data Operations` entry with `sidebar-filter-reset` present; each legacy name searched with
+  the toggle off returned only `add-component-button-data-operations`; and the legacy Text
+  Operations node built and returned `LEGACY STILL WORKS ABC123`.

--- a/tests/tests-automations/regression/core-components/data-operations-legacy-link.spec.ts
+++ b/tests/tests-automations/regression/core-components/data-operations-legacy-link.spec.ts
@@ -44,23 +44,35 @@ const UNRESOLVED_BANNER = "No direct replacement.";
 // The three legacy components of §3.10, with the sidebar handles scouted live.
 // Their testids keep the ORIGINAL class names (`TextOperations`, …), never
 // `Operations` — so they can never collide with the unified component's.
+// `label` is the human name (step titles, failure messages); every other field is
+// a selector. Keeping them apart matters here because the display name and its
+// testid differ only by a prefix, and interpolating the testid into a step title
+// is what makes a Playwright report read `title-JSON Operations carries …`.
 const LEGACY_COMPONENTS = [
   {
+    label: "JSON Operations",
     search: "json operations",
     addButton: "add-component-button-json-operations",
-    title: "title-JSON Operations",
+    titleTestId: "title-JSON Operations",
   },
   {
+    label: "Table Operations",
     search: "table operations",
     addButton: "add-component-button-table-operations",
-    title: "title-Table Operations",
+    titleTestId: "title-Table Operations",
   },
   {
+    label: "Text Operations",
     search: "text operations",
     addButton: "add-component-button-text-operations",
-    title: "title-Text Operations",
+    titleTestId: "title-Text Operations",
   },
 ] as const;
+
+// Named rather than indexed at the call sites: which legacy component a test
+// drives is part of what the test means, and `LEGACY_COMPONENTS[2]` hides it.
+const JSON_OPERATIONS = LEGACY_COMPONENTS[0];
+const TEXT_OPERATIONS = LEGACY_COMPONENTS[2];
 
 // Ids of the flows each test creates via the REST API — deleted id-scoped in
 // afterEach (#490/#681/#515), never a global/name/diff-scoped wipe (#553).
@@ -137,7 +149,7 @@ async function addNode(
 
 // Locate a node by its own title testid — the three nodes are added stacked and
 // are never told apart by position.
-function nodeByTitle(page: Page, titleTestId: string): Locator {
+function nodeByTitleTestId(page: Page, titleTestId: string): Locator {
   return page
     .locator(".react-flow__node")
     .filter({ has: page.getByTestId(titleTestId) });
@@ -164,9 +176,12 @@ test(
     });
 
     for (const component of LEGACY_COMPONENTS) {
-      await test.step(`${component.title} carries the Legacy banner pointing at Data Operations`, async () => {
-        const node = nodeByTitle(page, component.title);
-        await expect(node).toHaveCount(1, { timeout: 15000 });
+      await test.step(`${component.label} carries the Legacy banner pointing at Data Operations`, async () => {
+        const node = nodeByTitleTestId(page, component.titleTestId);
+        await expect(
+          node,
+          `${component.label} should be on the canvas exactly once`,
+        ).toHaveCount(1, { timeout: 15000 });
         // The banner itself — its Dismiss control is the only testid it exposes.
         await expect(node.getByTestId("dismiss-warning-bar")).toBeAttached({
           timeout: 15000,
@@ -193,15 +208,11 @@ test(
 
     await test.step("Open a flow with one legacy JSON Operations node", async () => {
       await openFlowWithLegacy(page, request, bearer, { enableLegacy: true });
-      await addNode(
-        page,
-        LEGACY_COMPONENTS[0].search,
-        LEGACY_COMPONENTS[0].addButton,
-      );
+      await addNode(page, JSON_OPERATIONS.search, JSON_OPERATIONS.addButton);
     });
 
     await test.step("Click the Data Operations link inside the banner", async () => {
-      const node = nodeByTitle(page, LEGACY_COMPONENTS[0].title);
+      const node = nodeByTitleTestId(page, JSON_OPERATIONS.titleTestId);
       // The link carries no testid; match it by accessible name, scoped to the
       // node so it can never resolve to the sidebar entry of the same name.
       await node
@@ -220,9 +231,7 @@ test(
       ).toBeVisible({ timeout: 15000 });
       // The negative half: the filter narrowed to the REPLACEMENT. Without it
       // the assertion would also pass on a sidebar that simply showed both.
-      await expect(
-        page.getByTestId(LEGACY_COMPONENTS[0].addButton),
-      ).toHaveCount(0);
+      await expect(page.getByTestId(JSON_OPERATIONS.addButton)).toHaveCount(0);
     });
   },
 );
@@ -262,11 +271,7 @@ test(
 
     await test.step("Open a flow with one legacy Text Operations node", async () => {
       await openFlowWithLegacy(page, request, bearer, { enableLegacy: true });
-      await addNode(
-        page,
-        LEGACY_COMPONENTS[2].search,
-        LEGACY_COMPONENTS[2].addButton,
-      );
+      await addNode(page, TEXT_OPERATIONS.search, TEXT_OPERATIONS.addButton);
     });
 
     const node = page.locator(".react-flow__node").first();

--- a/tests/tests-automations/regression/core-components/data-operations-legacy-link.spec.ts
+++ b/tests/tests-automations/regression/core-components/data-operations-legacy-link.spec.ts
@@ -1,0 +1,322 @@
+import type { APIRequestContext, Locator, Page } from "@playwright/test";
+import { expect, test } from "../../../fixtures/fixtures";
+import { getAuthToken } from "../../../helpers/auth/get-auth-token";
+import { createFlow } from "../../../helpers/flows/create-flow";
+import { deleteFlow } from "../../../helpers/flows/delete-flow";
+import { unmountEditorForCleanup } from "../../../helpers/flows/unmount-editor-for-cleanup";
+import { addComponentFromSidebar } from "../../../helpers/flows/add-component-from-sidebar";
+import { addLegacyComponents } from "../../../helpers/flows/add-legacy-components";
+import { seedAssistantDiscovered } from "../../../helpers/ui/assistant-onboarding";
+
+// §3.10 Data Operations (1.11.0) — the OTHER half of the section: what happens to
+// the three components the unified node replaced. JSON Operations
+// (`DataOperations`), Table Operations (`DataFrameOperations`) and Text
+// Operations (`TextOperations`) were kept as `legacy = True` with
+// `replacement = ["processing.Operations"]`, and upstream #14118 wired that
+// pointer into the UI. Per-operation coverage of the REPLACEMENT lives in
+// `data-operations-component.spec.ts` (#1191).
+//
+// The banner text is the assertion surface, and it is sharper than a UI string
+// usually is: `NodeLegacyComponent` does not print `replacement` raw — it
+// resolves it through `useGetReplacementComponents`, which splits
+// "processing.Operations" into category + name and looks up
+// `data.processing.Operations.display_name` in the types store. Only a
+// successful lookup renders `Use <display name>.`; anything else falls back to
+// the literal `No direct replacement.`. So asserting the positive string proves
+// the whole chain, and asserting the fallback's ABSENCE is what catches the
+// silent degradation a rename would cause (the node still renders, nothing
+// errors).
+//
+// Not to be confused with
+// `flow-functionality/general-bugs-frontend-crashing-on-invalid-replace.spec.ts`,
+// which proves the fallback path itself works for a custom component with a
+// bogus replacement. That one asserts the fallback happens; this one asserts
+// these three components are not on it.
+//
+// No provider key, no models.json. See
+// docs/core-components/data-operations-legacy-link.md.
+
+const REPLACEMENT_BANNER = "Use Data Operations.";
+// The literal `NodeLegacyComponent` renders when the replacement pointer cannot
+// be resolved to a component in the types store.
+const UNRESOLVED_BANNER = "No direct replacement.";
+
+// The three legacy components of §3.10, with the sidebar handles scouted live.
+// Their testids keep the ORIGINAL class names (`TextOperations`, …), never
+// `Operations` — so they can never collide with the unified component's.
+const LEGACY_COMPONENTS = [
+  {
+    search: "json operations",
+    addButton: "add-component-button-json-operations",
+    title: "title-JSON Operations",
+  },
+  {
+    search: "table operations",
+    addButton: "add-component-button-table-operations",
+    title: "title-Table Operations",
+  },
+  {
+    search: "text operations",
+    addButton: "add-component-button-text-operations",
+    title: "title-Text Operations",
+  },
+] as const;
+
+// Ids of the flows each test creates via the REST API — deleted id-scoped in
+// afterEach (#490/#681/#515), never a global/name/diff-scoped wipe (#553).
+const createdFlowIds: string[] = [];
+
+// Before the first document load — the only point at which the assistant
+// onboarding tooltip can be suppressed (#1220). It overlays canvas chrome, and
+// test 2 clicks inside a node's banner.
+test.beforeEach(async ({ page }) => {
+  await seedAssistantDiscovered(page);
+});
+
+test.afterEach(async ({ page, request }) => {
+  const ids = createdFlowIds.splice(0);
+  if (ids.length === 0) return;
+  // Leave the editor before deleting: a mounted editor keeps polling
+  // `GET /flows/{id}/events` and 404s once the flow is gone, which the fixture
+  // logs as `🚨 Backend Error` (#1023/#1103/#1288).
+  await unmountEditorForCleanup(page);
+  const bearer = await getAuthToken(request);
+  for (const id of ids) {
+    await deleteFlow(request, id, { headers: { Authorization: bearer } });
+  }
+});
+
+// Create a blank flow through the REST API (unique name → parallel-safe), open
+// it, and optionally reveal the legacy components in the sidebar.
+//
+// `showLegacy` is localStorage-backed (`getBooleanFromStorage("showLegacy",
+// false)`, flowSidebarComponent), so flipping it is scoped to this browser
+// context and cannot reach a parallel worker — which is also why test 3 can rely
+// on the OFF default without resetting anything.
+async function openFlowWithLegacy(
+  page: Page,
+  request: APIRequestContext,
+  bearer: string,
+  { enableLegacy = false }: { enableLegacy?: boolean } = {},
+): Promise<string> {
+  const flowId = await createFlow(
+    request,
+    {
+      name: `Legacy Ops ${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      description: "",
+      data: { nodes: [], edges: [] },
+      is_component: false,
+    },
+    { headers: { Authorization: bearer } },
+  );
+  createdFlowIds.push(flowId);
+
+  await page.goto(`/flow/${flowId}`);
+  await page
+    .getByTestId("sidebar-search-input")
+    .waitFor({ state: "visible", timeout: 60000 });
+  if (enableLegacy) await addLegacyComponents(page);
+  return flowId;
+}
+
+// Add one component and gate on the node count, so a component that never
+// arrives fails here — naming the component — instead of further down in an
+// assertion about a node that was never added.
+async function addNode(
+  page: Page,
+  search: string,
+  addButton: string,
+): Promise<void> {
+  const before = await page.locator(".react-flow__node").count();
+  await addComponentFromSidebar(page, search, addButton);
+  await expect(
+    page.locator(".react-flow__node"),
+    `adding "${search}" should put one more node on the canvas`,
+  ).toHaveCount(before + 1, { timeout: 15000 });
+}
+
+// Locate a node by its own title testid — the three nodes are added stacked and
+// are never told apart by position.
+function nodeByTitle(page: Page, titleTestId: string): Locator {
+  return page
+    .locator(".react-flow__node")
+    .filter({ has: page.getByTestId(titleTestId) });
+}
+
+test(
+  "All three legacy operations components name Data Operations as their replacement",
+  { tag: ["@stable", "@components", "@ui-ux"] },
+  async ({ page, request }) => {
+    const bearer = await getAuthToken(request);
+
+    await test.step("Open a flow with the legacy components revealed", async () => {
+      await openFlowWithLegacy(page, request, bearer, { enableLegacy: true });
+    });
+
+    await test.step("Add JSON, Table and Text Operations", async () => {
+      for (const component of LEGACY_COMPONENTS) {
+        await addNode(page, component.search, component.addButton);
+      }
+      // The nodes are deliberately left stacked: this test only reads text and
+      // testids inside each node, so the pointer-interception problem that
+      // forces `separateOverlappingNodes` elsewhere does not apply.
+      await expect(page.locator(".react-flow__node")).toHaveCount(3);
+    });
+
+    for (const component of LEGACY_COMPONENTS) {
+      await test.step(`${component.title} carries the Legacy banner pointing at Data Operations`, async () => {
+        const node = nodeByTitle(page, component.title);
+        await expect(node).toHaveCount(1, { timeout: 15000 });
+        // The banner itself — its Dismiss control is the only testid it exposes.
+        await expect(node.getByTestId("dismiss-warning-bar")).toBeAttached({
+          timeout: 15000,
+        });
+        // The pointer RESOLVED: `useGetReplacementComponents` found
+        // `processing.Operations` in the types store and rendered its display
+        // name.
+        await expect(node).toContainText(REPLACEMENT_BANNER, {
+          timeout: 15000,
+        });
+        // …and did not degrade to the fallback, which is what a renamed or moved
+        // replacement would silently produce.
+        await expect(node).not.toContainText(UNRESOLVED_BANNER);
+      });
+    }
+  },
+);
+
+test(
+  "The legacy banner link filters the sidebar to Data Operations",
+  { tag: ["@stable", "@components", "@ui-ux"] },
+  async ({ page, request }) => {
+    const bearer = await getAuthToken(request);
+
+    await test.step("Open a flow with one legacy JSON Operations node", async () => {
+      await openFlowWithLegacy(page, request, bearer, { enableLegacy: true });
+      await addNode(
+        page,
+        LEGACY_COMPONENTS[0].search,
+        LEGACY_COMPONENTS[0].addButton,
+      );
+    });
+
+    await test.step("Click the Data Operations link inside the banner", async () => {
+      const node = nodeByTitle(page, LEGACY_COMPONENTS[0].title);
+      // The link carries no testid; match it by accessible name, scoped to the
+      // node so it can never resolve to the sidebar entry of the same name.
+      await node
+        .getByRole("button", { name: "Data Operations", exact: true })
+        .click();
+    });
+
+    await test.step("The sidebar is filtered to the replacement, not to the legacy origin", async () => {
+      // `setFilterComponent` puts the sidebar in filtered mode — the reset
+      // control only exists while a filter is active.
+      await expect(page.getByTestId("sidebar-filter-reset")).toBeVisible({
+        timeout: 15000,
+      });
+      await expect(
+        page.getByTestId("add-component-button-data-operations"),
+      ).toBeVisible({ timeout: 15000 });
+      // The negative half: the filter narrowed to the REPLACEMENT. Without it
+      // the assertion would also pass on a sidebar that simply showed both.
+      await expect(
+        page.getByTestId(LEGACY_COMPONENTS[0].addButton),
+      ).toHaveCount(0);
+    });
+  },
+);
+
+test(
+  "Searching a legacy operations name surfaces Data Operations with legacy components hidden",
+  { tag: ["@stable", "@components", "@ui-ux"] },
+  async ({ page, request }) => {
+    const bearer = await getAuthToken(request);
+
+    await test.step("Open a flow with the Legacy toggle in its default OFF state", async () => {
+      // No `enableLegacy`: the point of this test is the default experience.
+      await openFlowWithLegacy(page, request, bearer);
+    });
+
+    for (const component of LEGACY_COMPONENTS) {
+      await test.step(`Searching "${component.search}" offers Data Operations only`, async () => {
+        await page.getByTestId("sidebar-search-input").fill(component.search);
+        // The unified component carries the three legacy names in
+        // `metadata.keywords` (operations.py), so the old name leads to the
+        // replacement even for a user who never enables the Legacy toggle.
+        await expect(
+          page.getByTestId("add-component-button-data-operations"),
+        ).toBeVisible({ timeout: 15000 });
+        await expect(page.getByTestId(component.addButton)).toHaveCount(0);
+      });
+    }
+  },
+);
+
+test(
+  "A legacy operations component still builds and returns its result",
+  { tag: ["@stable", "@components", "@ui-ux"] },
+  async ({ page, request }) => {
+    const bearer = await getAuthToken(request);
+    const TEXT = "legacy still works abc123";
+
+    await test.step("Open a flow with one legacy Text Operations node", async () => {
+      await openFlowWithLegacy(page, request, bearer, { enableLegacy: true });
+      await addNode(
+        page,
+        LEGACY_COMPONENTS[2].search,
+        LEGACY_COMPONENTS[2].addButton,
+      );
+    });
+
+    const node = page.locator(".react-flow__node").first();
+
+    await test.step("Configure Case Conversion → uppercase", async () => {
+      await node.getByTestId("textarea_str_text_input").fill(TEXT);
+      await node
+        .getByTestId(
+          "button_open_list_selection_sortablelist_sortablelist_operation",
+        )
+        .click();
+      await page.getByTestId("list_item_case_conversion").click();
+      await expect(page.getByTestId("list_item_case_conversion")).toHaveCount(
+        0,
+        { timeout: 15000 },
+      );
+      await node.getByTestId("value-dropdown-dropdown_str_case_type").click();
+      await page.getByRole("option", { name: "uppercase", exact: true }).click();
+      await expect(
+        node.getByTestId("value-dropdown-dropdown_str_case_type"),
+      ).toHaveText("uppercase", { timeout: 15000 });
+    });
+
+    await test.step("Run the legacy node and assert its Message output", async () => {
+      // Dispatched at the event level: the node's controls can sit under
+      // `main_canvas_controls` / the build toast, which intercept hit-tested
+      // clicks. The assertion right after is the guard against a no-op dispatch
+      // (same pattern as `data-operations-component.spec.ts`).
+      await node.getByTestId("button_run_text operations").dispatchEvent("click");
+      await expect(
+        node.getByTestId("node_duration_text operations"),
+      ).toBeVisible({ timeout: 60000 });
+
+      // The output testid keeps the LEGACY class name (`textoperations`), which
+      // is what makes it distinguishable from the unified component's.
+      await node
+        .getByTestId("output-inspection-message-textoperations")
+        .dispatchEvent("click");
+      const modal = page.locator('[role="dialog"]').last();
+      await expect(modal).toBeVisible({ timeout: 15000 });
+      // `text_operations.py` → `_case_conversion` → `str.upper`.
+      await expect(modal.locator("textarea").first()).toHaveValue(
+        TEXT.toUpperCase(),
+        { timeout: 15000 },
+      );
+
+      await page.getByTestId("btn-close-modal").click();
+      await expect(page.getByTestId("btn-close-modal")).toHaveCount(0, {
+        timeout: 15000,
+      });
+    });
+  },
+);


### PR DESCRIPTION
Closes #1192.

Closes the `[ ] Legacy operations components link/redirect to Data Operations (legacy flows keep working)` gap in `QA-CHECKLIST.md` §3.10 — the second and last bullet of that section, whose first bullet was closed by #1291 (`data-operations-component.spec.ts`, #1191). §3.10 is now fully covered.

When 1.11.0 merged JSON Operations (`DataOperations`), Table Operations (`DataFrameOperations`) and Text Operations (`TextOperations`) into the unified **Data Operations** node, the three originals were not deleted — they were marked `legacy = True` with `replacement = ["processing.Operations"]`, and upstream `langflow-ai/langflow#14118` wired that pointer into the UI. This PR covers the promise that pairing makes to a user who already has one of the old components: it tells you what replaced it **by name**, gives you a one-click route to it, is still reachable when you search its old name, and **keeps building** in the meantime.

**Distinct from the two specs that look adjacent.** `flow-functionality/general-bugs-frontend-crashing-on-invalid-replace.spec.ts` also mentions `No direct replacement` — but it is the opposite journey and a different subject: it builds a *custom* component with a bogus `replacement` and proves the frontend degrades to that fallback instead of crashing. It asserts the fallback path **works**; this PR asserts the three real legacy operations components are **not on it**. And `legacy-components-toggle-regression.spec.ts` covers the sidebar toggle's visibility behaviour with an unrelated component pair, not the replacement-pointer contract.

## 1. Covered tests

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `All three legacy operations components name Data Operations as their replacement` | Each of JSON / Table / Text Operations renders the Legacy banner (`dismiss-warning-bar`) reading **`Use Data Operations.`**, and **not** `No direct replacement.`. Catches a `replacement` pointer that stopped resolving — a rename or a move of the unified component. |
| 2 | `The legacy banner link filters the sidebar to Data Operations` | Clicking `Data Operations` inside the banner activates a component filter (`sidebar-filter-reset` appears), the sidebar offers `add-component-button-data-operations`, and `add-component-button-json-operations` drops to count 0. The link is a route to the replacement, not decoration. |
| 3 | `Searching a legacy operations name surfaces Data Operations with legacy components hidden` | With the Legacy toggle in its **default OFF** state, each of the three old names typed into the sidebar search offers `Data Operations` and no legacy button. The unified component carries the old names in `metadata.keywords`, so the search that used to land on the legacy node now lands on its replacement. |
| 4 | `A legacy operations component still builds and returns its result` | A legacy Text Operations node with `Case Conversion = uppercase` builds (`node_duration_text operations`) and its Message output equals `LEGACY STILL WORKS ABC123`. The "legacy flows keep working" half of the checklist bullet. |

## 2. How the test was built

- **The banner text is a far sharper observable than a UI string usually is,** and that is the core of the design. `NodeLegacyComponent` does not print `replacement` raw — it resolves it through `useGetReplacementComponents`, which splits `"processing.Operations"` into category + name and looks up `data.processing.Operations.display_name` in the types store. Only a successful lookup renders `Use <display name>.`; anything else falls back to the literal **`No direct replacement.`**. So asserting the positive string proves the whole chain (the component still declares a replacement, the pointer still names something that exists, the frontend resolved it to an actionable name), and asserting the fallback's **absence** is what catches the silent degradation a rename would cause — the node still renders and nothing errors.
- **Setup:** blank flow via the REST API (`createFlow`, unique name → parallel-safe), opened at `/flow/{id}`; the existing `addLegacyComponents` helper flips the sidebar Legacy toggle where the test needs it.
- **Live-confirmed selectors** (scouted in the running DOM, none invented): `add-component-button-{json,table,text}-operations`, `title-{JSON,Table,Text} Operations`, `dismiss-warning-bar`, `sidebar-filter-reset`, `sidebar-options-trigger` + `sidebar-legacy-switch`, `textarea_str_text_input`, `button_open_list_selection_sortablelist_sortablelist_operation`, `list_item_case_conversion`, `value-dropdown-dropdown_str_case_type`, `button_run_text operations`, `node_duration_text operations`, `output-inspection-message-textoperations`, `btn-close-modal`.
- **Legacy nodes keep their ORIGINAL class names in every testid** — the node type is `DataOperations` / `DataFrameOperations` / `TextOperations`, never `Operations`. Hence `output-inspection-message-textoperations`, and hence no testid collision with the unified component if both ever share a canvas.
- **The banner link has no testid**, so it is matched by accessible name (`getByRole("button", { name: "Data Operations", exact: true })`), scoped to the node — otherwise it could resolve to the sidebar entry of the same name.
- **Test 1 deliberately leaves the three nodes stacked.** It only reads text and testids *inside* each node (located by its own `title-…`), so the pointer-interception problem that forces `separateOverlappingNodes` in the chained #1191 tests simply does not arise. Adding the separation would be cost with no assertion behind it.
- **`showLegacy` was verified to be client-side before relying on its default.** It is localStorage-backed (`getBooleanFromStorage("showLegacy", false)`, `flowSidebarComponent`), not a server-side user setting — so enabling it in tests 1, 2 and 4 cannot leak into a parallel worker, and test 3's OFF precondition holds without any reset. Had it been server state, test 3 would have been a cross-worker hazard of exactly the class #553 documents.
- **Expected value in test 4 comes from the legacy source** (`text_operations.py` → `_case_conversion` → `str.upper`), not from observation.
- **Cleanup:** one flow per test, id known from creation; `afterEach` leaves the editor via `unmountEditorForCleanup` (so the events poll stops 404ing against a flow being deleted, #1288) and deletes only that id with an explicit bearer. Verified after the runs: **zero orphans**.

## 3. Dependencies

- **None — pure UI/Python.** No model provider, no API key, no `collect-models`, no `models.json`, no external network.
- **Parallel-safe:** unique flow names, id-scoped cleanup, and the one piece of shared-looking state (`showLegacy`) is per browser context. No `--workers=1` needed.

## Validation (nightly 1.12.0.dev10, `--retries=0`)

- typecheck ✅ · eslint ✅ · QA-CHECKLIST guards ✅
- **3/3 clean bursts** at `--retries=0 --workers=1` (`expected=4, unexpected=0, flaky=0` each), plus a green run after the force-fail reverts ✅
- zero `🚨 Backend Error` on every run ✅ · suite runs in ~16 s
- **force-fail executed for all 4 tests**, each isolated by `--grep`, each marked `// FF-MUTATION` and reverted (final marker count: 0):
  - #1 — expect the banner to read `Use JSON Operations.` (the legacy component's own name) → failed ✅
  - #2 — expect the legacy entry to survive the sidebar filter → failed ✅
  - #3 — search a term matching nothing, proving the assertion is driven by the **search term** and not by a sidebar that always lists Data Operations → failed ✅
  - #4 — expect the untouched lowercase text instead of the uppercased result → failed ✅
- flow cleanup verified via `GET /api/v1/flows/`: zero orphans ✅

> **Nightly note:** validated on `1.12.0.dev10` (the same local instance as #1291). It was deliberately not rebuilt — it runs without a volume, so recreating it would destroy its SQLite state. The `Run impacted E2E specs` job runs this spec against the newest nightly.
>
> `--trace=on` was not run: known local hang on this stack (see the langflow-e2e-issues skill). Step verification is covered by the clean `--retries=0` bursts, the executed force-fails, and the live DOM scouting the selectors came from.

Generated blocks in `QA-CHECKLIST.md` were **not** regenerated — only the §3.10 bullet was edited (they regenerate on merge, #741).
