### PR TITLE
test(quarantine): quarantine the two canvas node-click flakes (#1301)

### DIFF
--- a/tests/tests-automations/regression/core-components/edit-name-description-node.spec.ts
+++ b/tests/tests-automations/regression/core-components/edit-name-description-node.spec.ts
@@ -39,9 +39,12 @@ test.afterEach(async ({ request }) => {
   }
 });
 
-test(
+test.fixme(
   "user should be able to edit name and description of a node",
-  { tag: ["@stable", "@release", "@workspace", "@components"] },
+  // Quarantined at triage (#1296): recurrent flake 2x (2026-07-17, 2026-08-05) —
+  // the `div-generic-node` click times out at 20s, so the node never becomes
+  // clickable. Restore (`test` + `@stable`) in #1301.
+  { tag: ["@release", "@workspace", "@components"] },
 
   async ({ page }) => {
     trackCreatedFlows(page);

--- a/tests/tests-automations/regression/flow-functionality/stop-building.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/stop-building.spec.ts
@@ -21,8 +21,11 @@ test.afterEach(async ({ page }) => {
   createdFlowId = undefined;
 });
 
-test("user must be able to stop a building from the canvas",
-  { tag: ["@stable", "@release", "@workspace", "@components"] },
+test.fixme("user must be able to stop a building from the canvas",
+  // Quarantined at triage (#1296): recurrent flake 2x (2026-07-14, 2026-08-05) —
+  // the `div-generic-node` click times out at 20s, so the node never becomes
+  // clickable. Restore (`test` + `@stable`) in #1301.
+  { tag: ["@release", "@workspace", "@components"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 


### PR DESCRIPTION
Quarantines the two recurrent flakes grouped under #1301, from the triage of daily run [30997773754](https://github.com/oriontech-me/langflow-e2e/actions/runs/30997773754) (umbrella #1296).

| Spec (line) | Recurrence | Signature |
|---|---|---|
| `tests/tests-automations/regression/core-components/edit-name-description-node.spec.ts:42` | 2× (2026-07-17, 2026-08-05) | `TimeoutError: locator.click: Timeout 20000ms exceeded.` |
| `tests/tests-automations/regression/flow-functionality/stop-building.spec.ts:24` | 2× (2026-07-14, 2026-08-05) | `TimeoutError: locator.click: Timeout 20000ms exceeded.` |

## What changed

`@stable` removed **and** `test.fixme` added on both tests — always together. Removing `@stable` alone only stops the daily; the test keeps going red on the `pr-validation.yml` impacted-specs gate, which selects specs by **file diff** rather than by tag, so a `@stable`-only quarantine PR goes red on itself (#871). `test.fixme` skips the test in every context.

No test logic, spec doc or `QA-CHECKLIST.md` change — the generated checklist blocks are regenerated on merge by `update-coverage-summary.yml`.

## Why one PR for two specs

They are one cause, not two: each waits on the **same** locator, `getByTestId('div-generic-node')`, and both time out at 20 s — the canvas node never becomes clickable. `locator.click: Timeout` alone would be too generic to group on; the shared observable is what carries it. #1301 records the argument and the instruction to split if the investigation shows two mechanisms.

## Not resolved by this PR

Deliberately no `Closes` keyword. Quarantine is **prevention**, not a fix — #1301 stays open, and *lifting* the quarantine (remove `test.fixme` + restore `@stable`, re-validated per `CONTRIBUTING.md`) is a deliverable of that issue.

## Verification

Run locally on the branch:

- `npm run typecheck` — clean
- `npm run lint` — 0 errors (`test.fixme` warns under `playwright/no-skipped-test`, matching every existing quarantine in the repo)
- `npm run check:checklist-coverage` and the QA-CHECKLIST guard — pass
- `npm run test:scripts` (676) and `npm run test:units` (425) — all pass
- `npx playwright test --list --reporter=json` — both tests report `annotations: ['fixme']` and no `@stable`; the `@stable` lane drops from 480 to 475 tests across the full triage (5 tests)

Neither failure has outage cover: they ran on shards 1 and 4, each measured by the in-run liveness recorder at **0 outages / 0 s unreachable backend** for the whole run, so they are attributable rather than wedge collateral.