### PR TITLE
test(quarantine): quarantine the Ollama live-model execution flake (#1302)

### DIFF
--- a/tests/tests-automations/regression/core-functionality/model-provider/ollama-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/ollama-provider.spec.ts
@@ -221,14 +221,19 @@ test.describe("Ollama Provider", () => {
     },
   );
 
-  test(
+  test.fixme(
     "the Ollama component lists the local model live and executes the flow",
     {
-      // @stable restored for #931 after 4 consecutive green `manual.yml` runs on
-      // the branch (2 passed, 23.8-29.2s each) — the CI environment, not a dev
-      // box: the 07-23/24 bundle gap is fixed upstream and the rebuilt
-      // run-completion wait holds under runner-speed inference.
-      tag: ["@stable", "@regression", "@model-provider", "@components", "@playground"],
+      // Quarantined at triage (#1296): recurrent flake 2x same-signature
+      // (2026-07-30, 2026-08-05), 6 occurrences in the 30-day window — no
+      // `div-chat-message` arrives within the 180s budget (the locator resolved
+      // to 0 elements 183 times). Restore (`test` + `@stable`) in #1302.
+      //
+      // This supersedes the #931 restoration rationale that stood here: @stable
+      // had been restored after 4 consecutive green `manual.yml` runs on the
+      // branch, on the grounds that the rebuilt run-completion wait held under
+      // runner-speed inference. It does not hold on the daily.
+      tag: ["@regression", "@model-provider", "@components", "@playground"],
     },
     async ({ page, request }) => {
       // Local CPU inference on a shared CI runner is far slower than on a dev


### PR DESCRIPTION
Quarantines the recurrent flake tracked by #1302, from the triage of daily run [30997773754](https://github.com/oriontech-me/langflow-e2e/actions/runs/30997773754) (umbrella #1296).

| Spec (line) | Recurrence | Signature |
|---|---|---|
| `tests/tests-automations/regression/core-functionality/model-provider/ollama-provider.spec.ts:224` | 2× same-signature (2026-07-30, 2026-08-05); 6 occurrences in the 30-day window under varying signatures | `Error: expect(locator).toHaveCount(expected) failed` |

The failing wait is `expect(getByTestId('div-chat-message')).toHaveCount(1)` on a **180 s** budget: the locator resolved to **0 elements 183 times** and the message never arrived. The model list had already been read live, so what did not happen is the run producing output.

## What changed

`@stable` removed **and** `test.fixme` added — always together. Removing `@stable` alone only stops the daily; the test keeps going red on the `pr-validation.yml` impacted-specs gate, which selects specs by **file diff** rather than by tag, so a `@stable`-only quarantine PR goes red on itself (#871). `test.fixme` skips the test in every context.

**The `#931` restoration comment on that tag was replaced rather than left in place.** It read that `@stable` had been restored after 4 consecutive green `manual.yml` runs on a branch, because "the rebuilt run-completion wait holds under runner-speed inference". It does not hold on the daily, and leaving that rationale sitting beside a removed tag would misstate the record. The superseded reasoning is quoted in the new comment so the history is not lost.

No test logic, spec doc or `QA-CHECKLIST.md` change.

## Not resolved by this PR

Deliberately no `Closes` keyword. Quarantine is **prevention**, not a fix — #1302 stays open, and *lifting* the quarantine (remove `test.fixme` + restore `@stable`, re-validated per `CONTRIBUTING.md`) is a deliverable of that issue. #1302 also carries two things this PR does not touch: accounting for the four earlier different-signature occurrences, and justifying any replacement timeout by a recorded measurement rather than raising it empirically.

## Verification

Run locally on the branch:

- `npm run typecheck` — clean
- `npm run lint` — 0 errors (`test.fixme` warns under `playwright/no-skipped-test`, matching every existing quarantine in the repo)
- `npm run check:checklist-coverage` and the QA-CHECKLIST guard — pass
- `npm run test:scripts` (676) and `npm run test:units` (425) — all pass
- `npx playwright test --list --reporter=json` — the test reports `annotations: ['fixme']` and no `@stable`

The failure has no outage cover: it ran on shard 1, measured by the in-run liveness recorder at **0 outages / 0 s unreachable backend** for the whole run, so it is attributable rather than collateral of that day's backend wedge. Ollama is served by a keyless local service container, so no hosted-provider key or quota is involved.