### PR TITLE
test(quarantine): quarantine the credential-variable grid flake (#1303)

### DIFF
--- a/tests/tests-automations/regression/ui-ux/global-variables-crud.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/global-variables-crud.spec.ts
@@ -141,9 +141,13 @@ test(
   },
 );
 
-test(
+test.fixme(
   "Credential variable value is hidden from the variable list",
-  { tag: ["@stable", "@release", "@workspace", "@regression"] },
+  // Quarantined at triage (#1296): recurrent flake 3x (2026-07-15, 2026-07-17,
+  // 2026-08-05) — the variable the test just created never appears in the grid,
+  // so the sanity assertion fails before the secret-leak assertion is reached.
+  // Restore (`test` + `@stable`) in #1303.
+  { tag: ["@release", "@workspace", "@regression"] },
   async ({ page }) => {
     await openGlobalVariablesSettings(page);
 


### PR DESCRIPTION
Quarantines the recurrent flake tracked by #1303, from the triage of daily run [30997773754](https://github.com/oriontech-me/langflow-e2e/actions/runs/30997773754) (umbrella #1296).

| Spec (line) | Recurrence | Signature |
|---|---|---|
| `tests/tests-automations/regression/ui-ux/global-variables-crud.spec.ts:144` | 3× same-signature (2026-07-15, 2026-07-17, 2026-08-05) | `Error: expect(locator).toBeVisible() failed` |

**The test name misdirects, which is worth knowing before reviewing.** It does not fail on the secret-leak assertion it exists for. It fails on the sanity step *before* it — `getByRole('treegrid').getByText(varName, { exact: true })` — with `element(s) not found` after 15 s: the variable the test just created never appears in the grid, so the credential value was never checked at all.

## What changed

`@stable` removed **and** `test.fixme` added — always together. Removing `@stable` alone only stops the daily; the test keeps going red on the `pr-validation.yml` impacted-specs gate, which selects specs by **file diff** rather than by tag, so a `@stable`-only quarantine PR goes red on itself (#871). `test.fixme` skips the test in every context.

No test logic, spec doc or `QA-CHECKLIST.md` change.

## Relationship to #1235

#1235 tracks the same surface (the Global Variables ag-grid) but a different step: a **row interaction** not producing the state it should (clicking a row does not open the Update Variable modal; ticking a checkbox does not enable the delete button). Here no row interaction has happened yet — the row itself never renders after a create. The signatures cannot carry a match either: `expect(locator).toBeVisible() failed` is the most generic string Playwright emits, and #1235's own grouping argument rests on a shared run-pair (07-27, 08-03) that this test does not share. Deciding whether one grid-refresh mechanism explains both — and merging into #1235 if so — is an explicit deliverable of #1303.

## Not resolved by this PR

Deliberately no `Closes` keyword. Quarantine is **prevention**, not a fix — #1303 stays open, and *lifting* the quarantine (remove `test.fixme` + restore `@stable`, re-validated per `CONTRIBUTING.md`) is a deliverable of that issue. #1303 also requires that the test end up actually exercising its real assertion, not merely stopping its flake on the sanity step.

## Verification

Run locally on the branch:

- `npm run typecheck` — clean
- `npm run lint` — 0 errors (`test.fixme` warns under `playwright/no-skipped-test`, matching every existing quarantine in the repo)
- `npm run check:checklist-coverage` and the QA-CHECKLIST guard — pass
- `npm run test:scripts` (676) and `npm run test:units` (425) — all pass
- `npx playwright test --list --reporter=json` — the test reports `annotations: ['fixme']` and no `@stable`

The failure has no outage cover: it ran on shard 1, measured by the in-run liveness recorder at **0 outages / 0 s unreachable backend** for the whole run, so it is attributable rather than collateral of that day's backend wedge.