### PR TITLE
test(quarantine): quarantine the model-name trigger hard failure (#1304)

### DIFF
--- a/tests/tests-automations/regression/core-functionality/llm-agents/modelInputComponent.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/modelInputComponent.spec.ts
@@ -103,9 +103,17 @@ test.describe("ModelInputComponent", () => {
     },
   );
 
-  test(
+  test.fixme(
     "the trigger shows the selected model name",
-    { tag: ["@stable", "@release", "@components", "@workspace", "@model-provider"] },
+    // Quarantined at triage of #1296: hard failure on 2026-08-05 — the canvas
+    // renders no node at all (`[data-testid^="rf__node-"]` never resolves), on
+    // all 3 attempts, with zero overlap against any measured backend-outage
+    // window on its shard. The mass-failure guard tripped that day, so the
+    // workflow auto-removed nothing; on a normal daily this tag would have been
+    // removed automatically, which is what this restores.
+    // Restore (`test` + `@stable`) in #1304 — note that a first occurrence needs
+    // evidence about why it failed that day, not just a green run.
+    { tag: ["@release", "@components", "@workspace", "@model-provider"] },
     async ({ page }) => {
       await addLanguageModelNode(page);
 


### PR DESCRIPTION
Quarantines the hard failure tracked by #1304, from the triage of daily run [30997773754](https://github.com/oriontech-me/langflow-e2e/actions/runs/30997773754) (umbrella #1296).

| Spec (line) | Attempts | Signature |
|---|---|---|
| `tests/tests-automations/regression/core-functionality/llm-agents/modelInputComponent.spec.ts:106` | 3 (retries exhausted) | `Error: expect(locator).toBeVisible() failed` |

**The test name misdirects.** It fails upstream of anything about the model-name trigger: `expect(locator('[data-testid^="rf__node-"]').first()).toBeVisible()` fails with `element(s) not found` after 15 s, i.e. `addLanguageModelNode(page)` returned but no node is on the canvas at all.

## Why a hard failure is being quarantined by hand

Unlike the other three quarantines from this triage, this is not a recurrent flake — hard failures normally have `@stable` auto-removed by `daily-stable.yml`. On this run the **mass-failure guard tripped** (24 hard failures against a threshold of 5), which suppresses that automatic removal for every hard failure, so this tag survived *only because of the guard*.

The triage's day-level verdict is that 2026-08-05 was **not** environmental — its dominant cluster (14 failures) is our own `#751` credential guard against upstream #14311, tracked in #1274, not the environment. This PR therefore restores the outcome a normal daily would have produced. **It asserts nothing about the cause**, which #1304 investigates with the product as prime suspect.

## What changed

`@stable` removed **and** `test.fixme` added — always together. Removing `@stable` alone only stops the daily; the test keeps going red on the `pr-validation.yml` impacted-specs gate, which selects specs by **file diff** rather than by tag (#871). `test.fixme` skips the test in every context. This file already carries one `test.fixme` (at `:63`, for #1265), so this is the second, independent quarantine in it — the two are different tests with different observables and signatures, and #1304 carries deciding whether they share a mechanism.

No test logic, spec doc or `QA-CHECKLIST.md` change.

## Not resolved by this PR

Deliberately no `Closes` keyword. #1304 stays open, and *lifting* the quarantine (remove `test.fixme` + restore `@stable`) is a deliverable of that issue — with one condition recorded there and worth repeating: this is a **first occurrence**, so restoring `@stable` needs evidence about *why it failed on 2026-08-05*, not merely a green run.

## Verification

Run locally on the branch:

- `npm run typecheck` — clean
- `npm run lint` — 0 errors (`test.fixme` warns under `playwright/no-skipped-test`, matching every existing quarantine in the repo)
- `npm run check:checklist-coverage` and the QA-CHECKLIST guard — pass
- `npm run test:scripts` (676) and `npm run test:units` (425) — all pass
- `npx playwright test --list --reporter=json` — the test reports `annotations: ['fixme']` and no `@stable`

The failure has **no outage cover**, measured rather than assumed: it ran on shard 3, whose two measured outage windows were `10:36:37→10:38:25` and `10:42:39→10:44:11` UTC, while its three attempts ran `10:47:57→10:48:18`, `10:48:19→10:48:49` and `10:48:51→10:49:14` — no overlap with either.