### PR TITLE
fix(model-provider): remove the phantom confirmation step from the credential-removal spec (#1235)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -424,7 +424,7 @@
 - [x] Language Model component — configuration → `llm-agents/language-model-regression.spec.ts`
 - [x] Model Input component → `llm-agents/modelInputComponent.spec.ts`
 - [x] Add new provider via modal → `llm-agents/model-provider-api-key.spec.ts` (positive add validated via invalid-key rejection + Replace edit surface — a real re-add poisons a backend credential cache, see #505)
-- [~] Remove API key from existing provider — the API path (`DELETE /api/v1/variables/{id}`) stays validated; the **UI** path is quarantined (#1235): after ticking the row's checkbox the header trash action stays disabled, recurrent on the dailies of 2026-07-27 and 2026-08-03. Same Global Variables ag-grid surface as §4.3's edit entry — filed as one cause → `llm-agents/remove-provider-api-key.spec.ts`
+- [x] Remove API key from existing provider — both paths validated. The UI path was quarantined (#1235) as a Global Variables permission-gate flake and is not one: the deletion already succeeded, and the spec then re-clicked the now-disabled header button through a phantom confirmation step. Fixed by asserting the header action is enabled and scoping the confirmation to a real dialog → `llm-agents/remove-provider-api-key.spec.ts`
 - [x] Per-model enable/disable toggle changes immediately and persists across reopen → `llm-agents/model-provider-model-toggle.spec.ts`
 - [x] Disabling a model in Settings removes it from a component model dropdown; re-enabling restores it → `llm-agents/model-provider-model-toggle.spec.ts`
 

--- a/docs/core-functionality/model-provider/provider-management.md
+++ b/docs/core-functionality/model-provider/provider-management.md
@@ -139,6 +139,14 @@ configured providers show a **"N models"** suffix in their list item and a
    `default_fields: []` — the old spec 422'd and "passed"), then delete it
    through the Settings → Global Variables UI and assert the row is gone. No
    silent early-returns: every intermediate element is a hard assertion.
+   **There is no confirmation dialog for this action** — ticking the row and
+   hitting the header trash deletes immediately (`GET` by id → `404`, row out of
+   the DOM). Confirming that is why the spec asserts `delete-row-button` is
+   *enabled* before clicking it (the only client-side observable that the
+   release-1.12 RBAC gate has opened) and scopes its optional-confirmation branch
+   to a real `[role="dialog"]`: matched page-wide, `/delete|confirm|yes/i`
+   resolves to the header button itself, disabled once the row is gone, and
+   clicking it burned the full 20 s timeout in ~75 % of runs (#1235).
 2. *API removal* — POST (with `default_fields`), DELETE → 200/204, GET-by-id
    → 404/422, list no longer contains it (hard-fail on non-2xx create).
 

--- a/tests/tests-automations/regression/core-functionality/llm-agents/remove-provider-api-key.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/remove-provider-api-key.spec.ts
@@ -14,14 +14,15 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 // `default_fields`, which the old payload lacked. Every step is a hard
 // assertion now.
 
-// Quarantined for #1235 — recurrent flake (dailies 2026-07-27, 2026-08-03): after
-// ticking the row's checkbox the header trash action stays disabled, so the click
-// retries for the full 20 s as `element is not enabled`. Same Global Variables
-// ag-grid surface as global-variable-edit.spec.ts:76. Lifting the quarantine and
-// restoring @stable is a deliverable of #1235.
-test.fixme(
+// Quarantine lifted (#1235). The recurrent flake (dailies 2026-07-27, 2026-08-03)
+// was not the Global Variables permission gate it was filed under: the deletion
+// already succeeded, and the spec then clicked the header button again through a
+// phantom confirmation step. See the fix at the deletion step below.
+test(
   "a provider credential variable can be removed through the Global Variables UI",
-  { tag: ["@release", "@workspace", "@regression", "@model-provider"] },
+  {
+    tag: ["@stable", "@release", "@workspace", "@regression", "@model-provider"],
+  },
   async ({ page, request }) => {
     const bearer = await getAuthToken(request);
     const uniqueName = `provider-key-${Date.now()}`;
@@ -59,14 +60,23 @@ test.fixme(
           .locator('[role="row"]', { hasText: uniqueName })
           .first();
         await rowContainer.locator('input[type="checkbox"], [role="checkbox"]').first().click();
-        await page.getByTestId("icon-Trash2").first().click();
 
-        const confirmButton = page
-          .getByRole("button", { name: /delete|confirm|yes/i })
-          .last();
-        if (await confirmButton.isVisible({ timeout: 3000 }).catch(() => false)) {
-          await confirmButton.click();
-        }
+        // Selection enabling the header action is the only client-side observable
+        // that the row is actually interactive (#1235): the RBAC permission gate on
+        // release-1.12 keeps rows unselectable while it loads, and asserting it here
+        // fails with the real cause instead of a downstream 20 s click timeout.
+        const deleteButton = page.getByTestId("delete-row-button").first();
+        await expect(deleteButton).toBeEnabled({ timeout: 20000 });
+        await deleteButton.click();
+
+        // No confirmation step: the action deletes straight away (measured 8/8 —
+        // `[role="dialog"]` count 0, GET by id already 404). The spec used to run
+        // an optional confirm whose page-wide /delete|confirm|yes/i locator matched
+        // the header button itself, disabled once the row was gone, burning the
+        // full 20 s timeout in ~75 % of runs — the flake filed as #1235.
+        await expect(
+          page.locator('[role="dialog"], [role="alertdialog"]'),
+        ).toHaveCount(0);
 
         await expect(page.getByText(uniqueName, { exact: true })).toBeHidden({
           timeout: 10000,


### PR DESCRIPTION
## What this PR fixes

Lifts the #1235 quarantine on `remove-provider-api-key.spec.ts` test 1 (`test.fixme` removed, `@stable` restored) by fixing the actual defect — which is **not** the Global Variables permission gate the issue filed it under.

## Root cause (measured on a healthy 1.12.0, permission gate open)

`POST /api/v1/authz/me/permissions` answered `200` before the row ever painted, in every run. With the gate open:

- **the checkbox path works** — `checked=true`, `aria-selected=true`, `delete-row-button` enabled within ~2–11 ms of the click, 10/10 runs. This is the step the issue supposed was broken;
- **the trash action deletes immediately** — `GET /api/v1/variables/{id}` → `404`, row gone from the DOM, and `[role="dialog"]` count `0` in 8/8 runs. This product has no confirmation dialog for the action;
- **the spec then re-clicked the button it had just used.** Its optional-confirm locator, `getByRole("button", { name: /delete|confirm|yes/i }).last()`, had exactly one match page-wide: the header `delete-row-button` itself (`aria-label="Delete selected items"`), disabled by then because the row was gone. The guard was `isVisible()` — always true for that button — so the branch was entered and clicked a disabled button for the full 20 s.

That reproduces the recorded signature (`locator.click: Timeout 20000ms exceeded … element is not enabled`) with no gate involvement, at **12 failures in 16 runs**. It presented as a flake because it races the grid's re-render: a click landing before React disables the button is a harmless no-op and the test passes (~25 %).

## The fix

- **Drop the confirmation step** rather than repair it. The product has no confirmation for this action, so the branch was speculative, and keeping it meant a conditional plus a `.catch(() => false)` in test logic — both anti-patterns here. Replaced by an assertion that no dialog appears.
- **Click `delete-row-button` directly** instead of `icon-Trash2` inside it: clicking the icon of a disabled button is a silent no-op, which is how the real cause stayed hidden.
- **Assert the button is enabled first.** This is the readiness observable the LE-2123 evidence doc recommends, and it turns a genuinely closed RBAC gate into a failure that names itself instead of a downstream click timeout.

## Validation

- `--retries=0 --workers=1 --repeat-each=8`: **16/16** on Langflow **1.12.0 release** and **16/16** on **nightly 1.12.0.dev15** (the daily's target). Before the fix: 12 failures in 16 runs on 1.12.0.
- Force-fail confirmed — suppressing the deletion click fails at `toBeHidden` with a readable message, not somewhere earlier by side effect.
- `npm run typecheck` clean; ESLint 0 errors (warnings down 3 → 2, both pre-existing); QA-CHECKLIST guard and coverage guard both pass; `--trace=on` steps coherent; zero `🚨 Backend Error`.

## Linkage

- Exception issue (off-wave justification): #1235 (`daily-failure`, from triage #1231)
- Companion PR #1276 scopes LE-2123 to `global-variable-edit.spec.ts` and records this finding in the evidence doc under *Not this bug*. #1235 stays **open** for the edit half, which is a real product regression pending langflow#14404.
