### PR TITLE
fix(llm-agents): attribute the component-sidebar wait and restore modelInputComponent's @stable (#1265)

### DIFF
--- a/docs/core-functionality/model-provider/provider-management.md
+++ b/docs/core-functionality/model-provider/provider-management.md
@@ -147,12 +147,46 @@ sidebar entry to the canonical **Language Model** component:
 1. *Model selector renders* — blank flow → add
    `add-component-button-language-model` → assert node + `model_model`
    visible.
-2. *Dropdown opens with model options* — click `model_model` → assert ≥ 1
-   `*-option` entries render.
-3. *Dropdown lists models from multiple providers* — assert options from more
-   than one provider are present (the unified catalog behavior).
+2. *Dropdown opens with model options* — click `model_model` → assert the first
+   `*-option` is visible **and** that more than one renders (the unified
+   catalog behavior; a floor, never an exact count).
+3. *Dropdown exposes "Manage Model Providers"* — click `model_model` → assert
+   `manage-model-providers` is visible, i.e. the catalog dropdown still offers
+   the route into provider configuration.
 4. *Trigger shows the selected model* — assert `model_model` text is a
-   non-empty model name (catalog default, e.g. `gemini-3.5-flash`).
+   non-empty model name and is NOT a "Select a model" placeholder (the catalog
+   pre-selects a default, key-independent).
+
+> **Flake verdict & attributed sidebar barrier (issue #1265).** Test 1 flaked on
+> the 2026-07-15 and 2026-08-04 dailies with the same signature
+> (`TimeoutError: locator.waitFor: Timeout 30000ms exceeded.`) and was
+> quarantined at triage. Root cause on both days is the **run environment, not
+> this spec and not the model selector** — the wait that timed out is the
+> component sidebar's `sidebar-search-input`, reached by all four tests through
+> the shared `addLanguageModelNode` entry point, before any model selector is
+> touched. Evidence: on 2026-08-04 (run 30901311395, shard 2) the failing
+> attempt ran 10:45:07→10:49:55 across two measured backend outages (76 s and
+> 92 s of a 26.8 % down-share), gunicorn logged `WORKER TIMEOUT (pid:37)` +
+> SIGKILL at 10:46:30, and the attempt took **287 s** against **5.8–10.4 s** for
+> its own file-siblings once the backend recovered; the whole shard reported the
+> same shape (`apiRequestContext.post/get: Timeout` on localhost). On 2026-07-15
+> the attempt took 45 s and the retry 7 s on an unsharded run with 15 hard
+> failures / 29 flakes across every area. So `@stable` was restored **with no
+> timeout raised and no assertion weakened** — the 30 s budget is unchanged, and
+> the local burst on 1.12.0.dev17 measures the cold sidebar open well inside it.
+> What did change is **attribution**: the wait now goes through
+> `waitForAttributedSelector(…, { surface: "component-sidebar" })`
+> (`tests/helpers/other/page-entry-barrier.ts`, the #1262 mechanism), so a
+> timeout probes `/api/v1/version` and says whether Langflow was reachable —
+> carrying `[backend-unreachable]` when it was not. `locator.waitFor: Timeout`
+> can never be added to `scripts/lib/infra-signatures.ts` (a real UI regression
+> emits it too), which is why the bare message is unclassifiable by
+> construction; the attributed one embeds the probe's own transport error, so a
+> wedge already matches the existing `api-request-timeout` signature while a
+> healthy probe stays unclassified — both pinned in
+> `tests/helpers/other/page-entry-barrier.test.ts` against the real classifier.
+> The residual limitation is stated in that helper's header: the probe runs
+> after the budget is spent, so a wedge shorter than the wait reads healthy.
 
 **`language-model-regression.spec.ts`**
 1. *OpenAI answers* (skip without `OPENAI_API_KEY`) — Basic Prompting +

--- a/tests/helpers/other/page-entry-barrier.test.ts
+++ b/tests/helpers/other/page-entry-barrier.test.ts
@@ -23,9 +23,11 @@
 // (#1012's rule — an unevaluated probe is unknown, not healthy).
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { classifyInfraError } from "../../../scripts/lib/infra-signatures";
 import {
   entryBarrierMessage,
   INFRA_PREFIX,
+  PAGE_ENTRY_SURFACE,
   resolveProbeUrl,
 } from "./page-entry-barrier";
 
@@ -145,6 +147,145 @@ test("the message names the barrier's own budget so a raised timeout is visible"
   assert.match(msg, /15000ms/);
   assert.match(msg, /new-project-btn/);
   assert.match(msg, /http:\/\/langflow:7860/);
+});
+
+// --- the `surface` label (#1265) --------------------------------------------
+//
+// The barrier stopped being home-page-only when the SAME ambiguity cost the same
+// mis-triage one navigation later: `modelInputComponent.spec.ts` waited 30s for
+// the component sidebar's `sidebar-search-input` with a bare `locator.waitFor`,
+// timed out inside two measured shard-2 outages on the 2026-08-04 daily, and was
+// filed as a test-local flake about the model selector — the surface the message
+// named was neither the sidebar nor the backend.
+
+test("the surface defaults to page-entry, so #1262's callers read identically", () => {
+  const msg = entryBarrierMessage({
+    selector: SELECTOR,
+    timeoutMs: 30000,
+    probe: {
+      state: "healthy",
+      ms: 9,
+      status: 200,
+      url: "http://localhost:7860/api/v1/version",
+    },
+    cause: CAUSE,
+  });
+
+  assert.match(msg, new RegExp(`^${PAGE_ENTRY_SURFACE} barrier `));
+  // A blank label must not degrade into `" barrier"` — that is worse than the
+  // default, because it names nothing while looking deliberate.
+  const blank = entryBarrierMessage({
+    selector: SELECTOR,
+    timeoutMs: 30000,
+    surface: "   ",
+    probe: {
+      state: "healthy",
+      ms: 9,
+      status: 200,
+      url: "http://localhost:7860/api/v1/version",
+    },
+    cause: CAUSE,
+  });
+  assert.match(blank, new RegExp(`^${PAGE_ENTRY_SURFACE} barrier `));
+});
+
+test("a named surface appears in the barrier line AND in the product verdict", () => {
+  const msg = entryBarrierMessage({
+    selector: '[data-testid="sidebar-search-input"]',
+    timeoutMs: 30000,
+    surface: "component-sidebar",
+    probe: {
+      state: "healthy",
+      ms: 12,
+      status: 200,
+      url: "http://localhost:7860/api/v1/version",
+    },
+    cause:
+      "TimeoutError: locator.waitFor: Timeout 30000ms exceeded.\nCall log:\n" +
+      "  - waiting for getByTestId('sidebar-search-input') to be visible",
+  });
+
+  assert.match(msg, /^component-sidebar barrier "\[data-testid="sidebar-search-input"\]"/);
+  // The verdict sentence is the one a reader acts on, so it must name the same
+  // surface — "a product/UI failure at the page entry point" is what sent #1265
+  // to the wrong cluster.
+  assert.match(msg, /failure at the component-sidebar entry point/);
+  assert.doesNotMatch(msg, new RegExp(`${PAGE_ENTRY_SURFACE} entry point`));
+});
+
+test("attribution is surface-independent: a wedge behind any barrier is infra", () => {
+  const msg = entryBarrierMessage({
+    selector: '[data-testid="sidebar-search-input"]',
+    timeoutMs: 30000,
+    surface: "component-sidebar",
+    probe: {
+      state: "unreachable",
+      ms: 5001,
+      url: "http://localhost:7860/api/v1/version",
+      detail: "apiRequestContext.get: Timeout 5000ms exceeded.",
+    },
+    cause: "TimeoutError: locator.waitFor: Timeout 30000ms exceeded.",
+  });
+
+  // This is the whole point of #1265: `locator.waitFor: Timeout` can never join
+  // `scripts/lib/infra-signatures.ts` (a real UI regression emits it too), so the
+  // prefix is the only route by which a sidebar wait killed by a wedge becomes
+  // classifiable — and it must not depend on which barrier reported it.
+  assert.ok(
+    msg.startsWith(INFRA_PREFIX),
+    `a wedge behind a non-page-entry barrier must still be infra, got: ${msg}`,
+  );
+  assert.match(msg, /component-sidebar barrier/);
+});
+
+test("under a wedge the attributed message is classified by the EXISTING infra list", () => {
+  // The payoff, asserted against the real classifier rather than described in a
+  // comment. `locator.waitFor: Timeout` is not (and must not be) an infra
+  // signature, so today's bare message is unclassifiable — the barrier embeds the
+  // probe's own transport error, and THAT is what `infra-signatures.ts` already
+  // matches. No entry has to be added there for a wedge-killed sidebar wait to
+  // stop reading like a broken spec.
+  const bare =
+    "TimeoutError: locator.waitFor: Timeout 30000ms exceeded.\n" +
+    "Call log:\n  - waiting for getByTestId('sidebar-search-input') to be visible";
+
+  assert.equal(
+    classifyInfraError(bare),
+    null,
+    "the bare Playwright message must stay unclassifiable — that is the problem",
+  );
+
+  const wedged = entryBarrierMessage({
+    selector: '[data-testid="sidebar-search-input"]',
+    timeoutMs: 30000,
+    surface: "component-sidebar",
+    probe: {
+      state: "unreachable",
+      ms: 5001,
+      url: "http://localhost:7860/api/v1/version",
+      // What a wedged backend actually produces: it accepts the connection and
+      // never answers, so the probe times out (#922/#927).
+      detail: "apiRequestContext.get: Timeout 5000ms exceeded.",
+    },
+    cause: bare,
+  });
+  assert.equal(classifyInfraError(wedged)?.id, "api-request-timeout");
+
+  // And the healthy case must NOT become classifiable, or a real entry-point
+  // regression would be exempted as an outage.
+  const healthy = entryBarrierMessage({
+    selector: '[data-testid="sidebar-search-input"]',
+    timeoutMs: 30000,
+    surface: "component-sidebar",
+    probe: {
+      state: "healthy",
+      ms: 21,
+      status: 200,
+      url: "http://localhost:7860/api/v1/version",
+    },
+    cause: bare,
+  });
+  assert.equal(classifyInfraError(healthy), null);
 });
 
 test("the probed URL comes from the page's own origin, not from the environment", () => {

--- a/tests/helpers/other/page-entry-barrier.ts
+++ b/tests/helpers/other/page-entry-barrier.ts
@@ -2,7 +2,9 @@ import type { Page } from "@playwright/test";
 
 /**
  * The page-entry barrier every helper that lands on the home page waits on
- * (`mainpage_title`, then `new-project-btn`), with the failure ATTRIBUTED.
+ * (`mainpage_title`, then `new-project-btn`), with the failure ATTRIBUTED — and,
+ * since #1265, the same attribution for any other entry observable a spec has to
+ * wait on before it can start asserting (see `waitForAttributedSelector`).
  *
  * Why this exists (#1262). A bare `waitForSelector` on those two testids cannot
  * distinguish the only two things that make it time out:
@@ -43,6 +45,40 @@ import type { Page } from "@playwright/test";
  *
  * The original Playwright error is always appended, so the trace, screenshot and
  * call log stay readable against it.
+ *
+ * WHY IT IS NOT ONLY THE HOME PAGE (#1265)
+ *
+ * The same ambiguity exists one navigation later, and it cost the same mis-triage.
+ * `modelInputComponent.spec.ts` waited 30s for `sidebar-search-input` — the
+ * component sidebar's search field on a freshly-opened flow — with a bare
+ * `locator.waitFor`. On the 2026-08-04 daily (run 30901311395) that wait timed
+ * out inside two measured shard-2 outages (76s and 92s, with gunicorn logging
+ * `WORKER TIMEOUT (pid:37)` + SIGKILL at 10:46:30) and the failing attempt took
+ * 287s against ~6s for its own file-siblings once the backend recovered. The
+ * report showed only
+ *
+ *   TimeoutError: locator.waitFor: Timeout 30000ms exceeded.
+ *     - waiting for getByTestId('sidebar-search-input') to be visible
+ *
+ * so the flake was filed as test-local and an otherwise healthy `@stable` test
+ * was quarantined for a cycle. `locator.waitFor: Timeout` cannot be added to
+ * `scripts/lib/infra-signatures.ts` — a genuine UI regression produces it too —
+ * so that message is unclassifiable by construction. The attributed one is not,
+ * and NOT only because of `INFRA_PREFIX`: it embeds the probe's own transport
+ * error, so a wedge (accepted-and-never-answered ⇒ `apiRequestContext.get:
+ * Timeout`) already matches the existing `api-request-timeout` signature with no
+ * new entry added anywhere, while the healthy-probe message stays unclassified.
+ * Both halves of that are pinned in `page-entry-barrier.test.ts` against the real
+ * classifier. So the barrier is generic in the observable and carries a `surface`
+ * label naming which entry point failed.
+ *
+ * KNOWN LIMITATION, stated rather than papered over: the probe runs AFTER the
+ * wait's budget is spent, so it reports the backend's state then — not during.
+ * #1265's outages were 76s and 92s, comfortably longer than the 30s wait, but a
+ * shorter wedge that clears inside the budget reads `healthy` and the message
+ * then blames the UI. That asymmetry is deliberate and inherited from #1262:
+ * over-claiming an outage would let a real entry-point regression through
+ * unquarantined, which costs more than a wedge that has to be recognised by hand.
  */
 
 /**
@@ -74,12 +110,27 @@ export interface BackendProbe {
   detail?: string;
 }
 
+/**
+ * Default `surface` label — the home page this barrier was built for (#1262).
+ * Kept as the default so every existing caller, and every history entry already
+ * written against that wording, keeps reading the same.
+ */
+export const PAGE_ENTRY_SURFACE = "page-entry";
+
 export interface EntryBarrierContext {
   selector: string;
   timeoutMs: number;
   probe: BackendProbe;
   /** The original Playwright error text. */
   cause: string;
+  /**
+   * Which entry point this barrier guards, e.g. `page-entry` or
+   * `component-sidebar`. Named in the message so a reader knows WHICH surface
+   * failed without decoding the selector — #1265's flake was triaged as a model
+   * selector problem because the message named neither (default:
+   * `PAGE_ENTRY_SURFACE`).
+   */
+  surface?: string;
 }
 
 /**
@@ -88,7 +139,8 @@ export interface EntryBarrierContext {
  */
 export function entryBarrierMessage(ctx: EntryBarrierContext): string {
   const { selector, timeoutMs, probe, cause } = ctx;
-  const barrier = `page-entry barrier "${selector}" did not render within ${timeoutMs}ms`;
+  const surface = ctx.surface?.trim() || PAGE_ENTRY_SURFACE;
+  const barrier = `${surface} barrier "${selector}" did not render within ${timeoutMs}ms`;
   const url = probe.url;
 
   let head: string;
@@ -110,7 +162,7 @@ export function entryBarrierMessage(ctx: EntryBarrierContext): string {
       head =
         `${barrier} — the backend answered GET ${PROBE_PATH} with HTTP ` +
         `${probe.status} in ${probe.ms}ms (${url}), so the backend was reachable ` +
-        `and this IS a product/UI failure at the page entry point.`;
+        `and this IS a product/UI failure at the ${surface} entry point.`;
       break;
     default:
       head =
@@ -168,17 +220,21 @@ export async function probeBackend(
 }
 
 /**
- * `waitForSelector` for a page-entry observable, with the timeout attributed.
+ * `waitForSelector` for ANY entry observable, with the timeout attributed.
  *
- * Drop-in for `await page.waitForSelector(selector, { timeout })` on the home
- * page. Behaviour on success is identical (same selector, same budget); only the
- * failure path changes.
+ * Drop-in for `await page.waitForSelector(selector, { timeout })`. Behaviour on
+ * success is identical (same selector, same budget) — only the failure path
+ * changes, and it never loosens the budget: a barrier that masked a slow surface
+ * would defeat the point of measuring it (#1265).
+ *
+ * `surface` names the entry point in the message. Pass it whenever the barrier is
+ * not the home page, so the failure says which one broke.
  */
-export async function waitForPageEntry(
+export async function waitForAttributedSelector(
   page: Page,
   selector: string,
   timeoutMs: number,
-  options?: { baseURL?: string },
+  options?: { baseURL?: string; surface?: string },
 ): Promise<void> {
   try {
     await page.waitForSelector(selector, { timeout: timeoutMs });
@@ -189,8 +245,27 @@ export async function waitForPageEntry(
         selector,
         timeoutMs,
         probe,
+        surface: options?.surface,
         cause: String(error?.message ?? error),
       }),
     );
   }
+}
+
+/**
+ * The home-page specialisation (#1262) — `waitForAttributedSelector` with the
+ * `page-entry` surface. Kept as its own name because that is what every helper
+ * landing on the home page calls, and what the messages in
+ * `reports/daily-history.jsonl` were written against.
+ */
+export async function waitForPageEntry(
+  page: Page,
+  selector: string,
+  timeoutMs: number,
+  options?: { baseURL?: string },
+): Promise<void> {
+  await waitForAttributedSelector(page, selector, timeoutMs, {
+    baseURL: options?.baseURL,
+    surface: PAGE_ENTRY_SURFACE,
+  });
 }

--- a/tests/tests-automations/regression/core-functionality/llm-agents/modelInputComponent.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/modelInputComponent.spec.ts
@@ -1,8 +1,11 @@
 import { expect, test } from "../../../../fixtures/fixtures";
-import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { addComponentFromSidebar } from "../../../../helpers/flows/add-component-from-sidebar";
-import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import {
+  trackCreatedFlows,
+  type FlowTracker,
+} from "../../../../helpers/flows/track-created-flows";
+import { waitForAttributedSelector } from "../../../../helpers/other/page-entry-barrier";
 
 // The Model Input selector on the canonical Language Model component
 // (QA-CHECKLIST §7.5 "Model Input component"). Hardened for @stable (issue
@@ -11,32 +14,54 @@ import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 // component never rendered. Now the canonical models_and_agents Language Model
 // component is added unconditionally and every behavior is a hard assertion.
 
+// PROVIDER PREREQUISITE — the whole file needs at least one provider CREDENTIAL
+// configured in Langflow (measured on 1.12.0.dev17, #1265). With none, the node
+// still mounts but its Language Model field renders a **"Setup Provider"** CTA
+// behind `parameter-permission-gate` instead of `model_model`, and all four
+// tests fail on an observable that has nothing to do with what they assert. It
+// is the credential that matters, not a funded key: today's local run has a
+// drained `openai` (no credits) alongside an active anthropic/google and all
+// four pass. Nothing to wire up — `@model-provider` already makes
+// `scripts/provider-dependent-specs.mjs` force the `Collect models` sweep for
+// this file, and the daily always runs it — but locally, run
+// `npx playwright test tests/collect-models.spec.ts` first or the failures look
+// like a model-selector regression.
+
 // UI-created flows need explicit cleanup or they accumulate on the instance.
 // The canvas URL carries a TRANSIENT id on 1.11 (the persisted flow gets a
-// different one — deleting the URL id 404s), so capture the real id from the
-// page's own POST /api/v1/flows/ response instead. Targeted delete, never
-// cleanAllFlows: parallel workers own their own flows.
-const createdFlowIds: string[] = [];
+// different one — deleting the URL id 404s), so ids come from the page's own
+// `POST /api/v1/flows` 201 bodies. Targeted delete, never cleanAllFlows:
+// parallel workers own their own flows.
+//
+// Via the shared tracker (#1108) rather than a local `waitForResponse`, because
+// this entry point creates TWO flows and the local capture only ever saw one
+// (#1265). `awaitBootstrapTest` → `openNewFlowTemplatesModal` clicks "New Flow",
+// which on this build creates a flow of its own before the templates modal opens
+// (#1002) — and it runs BEFORE the old capture was armed, so that flow leaked on
+// every call: 2 orphaned "New Flow"/"New Flow (2)" were sitting on the local
+// instance when this issue was worked. The tracker listens from `beforeEach`, so
+// it catches both, and it settles its in-flight body reads before deleting (the
+// axis 50 of the 51 hand-rolled copies got wrong).
+let flows: FlowTracker;
 
 async function addLanguageModelNode(page: any) {
   await awaitBootstrapTest(page);
-  const flowCreated = page
-    .waitForResponse(
-      (r: any) =>
-        r.url().includes("/api/v1/flows/") &&
-        r.request().method() === "POST" &&
-        r.status() < 300,
-      { timeout: 30000 },
-    )
-    .then(async (r: any) => (await r.json()).id as string)
-    .catch(() => undefined);
   await page.getByTestId("blank-flow").click();
   await page.waitForURL(/\/flow\/[^/?#]+/, { timeout: 30000 });
-  const flowId = await flowCreated;
-  if (flowId) createdFlowIds.push(flowId);
-  await page
-    .getByTestId("sidebar-search-input")
-    .waitFor({ state: "visible", timeout: 30000 });
+  // Attributed, not a bare `locator.waitFor` (#1265). Every test in this file
+  // reaches the Language Model node THROUGH the component sidebar, so this wait
+  // — not the model selector the tests are named for — is what times out when
+  // Langflow stalls. Both recorded flakes were exactly that: on the 2026-08-04
+  // daily the failing attempt spanned two measured shard-2 outages (76s + 92s,
+  // gunicorn `WORKER TIMEOUT` + SIGKILL at 10:46:30) and took 287s where its own
+  // siblings took ~6s once the backend recovered. The budget is unchanged at 30s
+  // — the barrier attributes the failure, it does not paper over a slow surface.
+  await waitForAttributedSelector(
+    page,
+    '[data-testid="sidebar-search-input"]',
+    30000,
+    { surface: "component-sidebar" },
+  );
   await addComponentFromSidebar(
     page,
     "language model",
@@ -48,25 +73,31 @@ async function addLanguageModelNode(page: any) {
 }
 
 test.describe("ModelInputComponent", () => {
-  test.afterEach(async ({ request }) => {
-    // page.request carries only browser cookies — the flows API wants the
-    // Bearer token, so authenticate explicitly (a silent 401 here leaks flows).
-    if (createdFlowIds.length === 0) return;
-    const bearer = await getAuthToken(request);
-    while (createdFlowIds.length > 0) {
-      const id = createdFlowIds.pop();
-      if (!id) continue;
-      await deleteFlow(request, id, { headers: { Authorization: bearer } }).catch(() => {});
-    }
+  // Armed before the test body, so the flow "New Flow" creates during bootstrap is
+  // captured too — that is the leak the local capture could not see.
+  test.beforeEach(({ page }) => {
+    flows = trackCreatedFlows(page);
   });
 
-  // Quarantined for #1265 — recurrent flake: the wait that times out is
-  // `sidebar-search-input`, not the model selector this test is named for
-  // (same signature on the 2026-07-15 and 2026-08-04 dailies). Lifting the
-  // quarantine (remove test.fixme + restore @stable) is a deliverable of #1265.
-  test.fixme(
+  test.afterEach(async ({ request }) => {
+    // The tracker authenticates with the Bearer token itself: `page.request`
+    // carries only browser cookies and the flows API wants the header, so a
+    // silent 401 here would leak every flow.
+    await flows.cleanup(request);
+    flows.dispose();
+  });
+
+  test(
     "the Language Model node renders its model selector",
-    { tag: ["@release", "@components", "@workspace", "@model-provider"] },
+    {
+      tag: [
+        "@stable",
+        "@release",
+        "@components",
+        "@workspace",
+        "@model-provider",
+      ],
+    },
     async ({ page }) => {
       const node = await addLanguageModelNode(page);
       await expect(node.getByTestId("model_model")).toBeVisible({ timeout: 10000 });
@@ -105,20 +136,34 @@ test.describe("ModelInputComponent", () => {
 
   test.fixme(
     "the trigger shows the selected model name",
-    // Quarantined at triage of #1296: hard failure on 2026-08-05 — the canvas
-    // renders no node at all (`[data-testid^="rf__node-"]` never resolves), on
-    // all 3 attempts, with zero overlap against any measured backend-outage
-    // window on its shard. The mass-failure guard tripped that day, so the
-    // workflow auto-removed nothing; on a normal daily this tag would have been
-    // removed automatically, which is what this restores.
-    // Restore (`test` + `@stable`) in #1304 — note that a first occurrence needs
-    // evidence about why it failed that day, not just a green run.
+    // Quarantined at triage of #1296 (PR #1308) — NOT lifted here: #1265 owns the
+    // sidebar flake above, #1304 owns this one. Hard failure on 2026-08-05: the
+    // canvas renders no node at all (`[data-testid^="rf__node-"]` never resolves),
+    // on all 3 attempts, with zero overlap against any measured backend-outage
+    // window on its shard.
+    //
+    // #1265's investigation found a MECHANISM for it, which is why the two stay
+    // separate rather than merging as #1304 offered: this test is green 44/44 solo
+    // on 1.12.0.dev17, and fails only when a spec that mutates ACCOUNT-WIDE
+    // provider credentials runs beside it. Reproduced in the daily's own shape
+    // (`PW_SHARD_FILE_LEVEL=1 --workers=2 --retries=0`) against
+    // `model-provider/openai-compatible-provider-setup.spec.ts`, whose `afterEach`
+    // purges the OpenAI-Compatible credential pair unconditionally: 3 of 12 of
+    // this file's test executions failed with exactly this signature (rounds 1 and
+    // 3; in round 2 it passed but took 19.3 s against 3.5–8.1 s solo), and the
+    // neighbour failed 3/3 with its own credential dropped to `""` (LE-2124). The
+    // control — same shape, same worker count, `core-components/tool-mode.spec.ts`
+    // as the neighbour instead — is the discriminator, and its result belongs in
+    // #1304 with the rest of the evidence.
     { tag: ["@release", "@components", "@workspace", "@model-provider"] },
     async ({ page }) => {
       await addLanguageModelNode(page);
 
-      // The catalog pre-selects a default model (key-independent), so the
-      // trigger must show a concrete model name, not a "Select…" placeholder.
+      // The catalog pre-selects a default model, so the trigger must show a
+      // concrete model name, not a "Select…" placeholder. NOT key-independent,
+      // as this comment used to claim: with no provider credential at all the
+      // trigger is a "Setup Provider" CTA and `model_model` is absent — see the
+      // provider prerequisite at the top of the file (#1265).
       const text = (await page.getByTestId("model_model").textContent())?.trim() ?? "";
       expect(text.length).toBeGreaterThan(0);
       expect(text).not.toMatch(/select a model/i);


### PR DESCRIPTION
Closes #1265

## Verdict: the run ENVIRONMENT, on both recorded days

Not a sidebar regression, not a wait-strategy defect, and not cross-worker
destructive cleanup. The report could not say so because the wait that timed out
carried no attribution.

**2026-08-04** (run [30901311395](https://github.com/oriontech-me/langflow-e2e/actions/runs/30901311395), shard 2) — pinned from the run's own artifacts:

| fact | value |
|---|---|
| failing attempt | `10:45:07.480` for **287.4 s** |
| measured outages inside it | **76 s** (10:45:26→10:46:42) + **92 s** (10:46:48→10:48:20) = 168 s of 287 s |
| container log | `WORKER TIMEOUT (pid:37)` → `SIGKILL` at 10:46:30/31 |
| shard-wide | 7 outages, 294 s down of 1095 s observed (**26.8 %**) |
| the shard's other problems | all 5 flakes + 1 hard failure are `apiRequestContext.post/get: Timeout 20000ms` against localhost |
| this file's own siblings | ran 10:53:54+, after the last outage ended, in **10.4 / 5.8 / 6.9 s** |

The retry **passed while crossing a further 112 s of outage**, so the spec is not
fragile — attempt 0 simply had its 30 s window inside a contiguous blackout.

**2026-07-15** (run 29406577514, unsharded) is accounted for but deliberately not
claimed as strongly: attempt 0 took 45 s, the retry 7 s, the siblings 5 s, on a run
with 15 hard failures and 29 flakes across every area and a drained openai key.
Neither the liveness recorder nor the container-log dump existed then, so the wedge
cannot be named directly.

**Cross-worker destructive cleanup refuted twice** (the look-alike verdict, and the
co-runner on both days was `memory-history-regression`, the #553 wiper family): no
`cleanAllFlows` caller remains in the suite, and both failing attempts' stdout is
**empty** — a wipe produces a logged 404 on the victim's own flow, a wedge produces
timeouts, and only the latter fits an empty error log.

## What changes

`@stable` is restored with the **30 s budget unchanged and no assertion touched**.
What changes is ATTRIBUTION: `waitForPageEntry`'s mechanism (#1262) is generalised
into `waitForAttributedSelector` with a `surface` label, and the sidebar wait goes
through it as `component-sidebar`.

The payoff is stronger than the prefix alone, and it is **asserted against the real
classifier rather than described**: the bare `locator.waitFor: Timeout` is
unclassifiable by construction — it can never join `infra-signatures.ts`, since a
genuine UI regression emits it too — while the attributed message embeds the probe's
own transport error, so a wedge already matches the existing `api-request-timeout`
signature **with no new entry anywhere**, and a healthy probe stays unclassified.
The residual limitation is stated in the helper, not papered over: the probe runs
after the budget is spent, so a wedge shorter than the wait reads healthy.

Two further fixes the investigation surfaced in this file:

- **Cleanup moves to the shared tracker (#1108).** This entry point creates TWO
  flows and the local `waitForResponse` only ever saw one: `awaitBootstrapTest`
  clicks "New Flow", which creates a flow of its own (#1002) **before** the old
  capture was armed, so that flow leaked on every call — 2 orphaned `New Flow`
  flows were on the instance when this was worked, and disabling the new cleanup
  leaks 3, one per live test.
- **The provider prerequisite is documented**, because the old comment claimed the
  opposite ("key-independent"). With no provider credential the node still mounts
  but its field renders a **"Setup Provider"** CTA behind
  `parameter-permission-gate`, `model_model` is absent, and all four tests fail on
  an observable unrelated to what they assert. It is the credential that matters,
  not a funded key — a drained openai beside an active anthropic/google passes.

## #1304's quarantine is PRESERVED, not lifted

PR #1308 quarantined *"the trigger shows the selected model name"* while this was in
flight. This PR keeps it. #1304 offered to merge if one mechanism turned up, and one
did — but it is a **different** mechanism from these two wedge-driven flakes, so the
issues stay separate and the evidence goes to #1304:

| shape | failures of this file's tests |
|---|---|
| solo, `--workers=1 --retries=0`, 11 runs | **0 / 44** |
| `PW_SHARD_FILE_LEVEL=1 --workers=2` + non-provider neighbour (`tool-mode.spec.ts`) | 1 / 24 |
| same + provider-mutating neighbour (`openai-compatible-provider-setup.spec.ts`) | 3 / 12 |

The node-add is contention-sensitive (the swallowed-click class, #420/#966), and
**provider mutation is not the trigger** — the control failed too, which is what
refuted the first hypothesis. Two caveats stated rather than buried: the rate is
**not transferable to CI** (the host was at load average 14.4 on 8 cores, and the
control spec `tool-mode.spec.ts` — `@stable` and green in the daily — failed 3 of 6
rounds there), and whether provider churn aggravates it is suggestive, not
established, at these sample sizes.

## Validation

Langflow **1.12.0.dev17** (`langflowai/langflow-nightly:latest`, pulled fresh for
this work).

- [x] **44/44 test executions green** over 11 `--retries=0` runs, per-test 3.5–8.1 s
- [x] **Six executed force-fails**, each reverted and verified (0 markers in the diff):
  - `model_model` → bogus testid ⇒ `element(s) not found`
  - option-count floor `1` → `99999` ⇒ `Received: 90`
  - `manage-model-providers` → bogus testid ⇒ `element(s) not found`
  - `not.toMatch(/select a model/i)` → `toMatch` ⇒ `Received string: "claude-opus-5"`
  - barrier selector bogus, backend healthy ⇒ `component-sidebar barrier … HTTP 200 … IS a product/UI failure at the component-sidebar entry point`, no infra prefix
  - same with the probe pointed at a dead port ⇒ `[backend-unreachable] … ECONNREFUSED … NOT an entry-point regression`
  - cleanup disabled ⇒ **3 flows leaked** (`New Flow (1..3)`), one per live test
- [x] `npm run typecheck`, `npm run lint` (0 errors), `npm run test:units` **429/429**, `npm run test:scripts` **660/660**
- [x] QA-CHECKLIST guard + coverage guard green; **no** generated block edited (§7.5 bullet already references this spec)
- [x] Zero `🚨 Backend Error` on the validation runs; **zero orphaned flows** on the instance afterwards (27, starters only)
- [ ] Isolated-CI leg of the transient verdict (`manual.yml` dispatch) — not run; say the word and I'll dispatch it against this branch
- [ ] `--trace=on` step-walk — skipped per the repo's known local trace hang; covered by the `--retries=0` bursts, the force-fails and live `playwright-cli` scouting instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)
