### PR TITLE
fix(docs): resolve every External-dependencies path upstream and guard it (#1298)

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -153,6 +153,66 @@ jobs:
       - name: Guard spec ↔ doc ↔ QA-CHECKLIST triad
         run: npm run check:checklist-coverage
 
+  doc-deps-guard:
+    name: Spec-doc dependency paths
+    runs-on: ubuntu-latest
+    timeout-minutes: 6
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "20"
+
+      # The docs this PR touched. Severity turns on this list: a path in a doc the
+      # PR changed FAILS, a pre-existing one is reported (#980's coverage-first
+      # trade — one upstream rename must not redden every PR that edits an
+      # unrelated doc). An empty list is normal and means nothing can fail here.
+      - name: Collect the docs this PR changed
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -eo pipefail
+          git fetch origin "$BASE_REF" --quiet
+          git diff --name-only --diff-filter=d "origin/$BASE_REF...HEAD" -- docs README.md > all-changed.txt
+          # `grep` exits 1 on no match, which under `pipefail` would abort a PR that
+          # simply touches no doc — the empty list is a valid, common outcome.
+          grep -E '\.md$' all-changed.txt > changed-docs.txt || :
+          echo "changed docs: $(wc -l < changed-docs.txt)"
+          cat changed-docs.txt
+
+      # Trees only, no blobs, no working tree: 520 KB and ~1.6 s measured, against
+      # ~117 MB to materialise the files. `--mode=check-docs` resolves through
+      # `git ls-tree`, which is what makes that possible (issue #1298).
+      - name: Clone the upstream tree
+        run: |
+          set -eo pipefail
+          for attempt in 1 2 3; do
+            if git clone --filter=blob:none --depth 1 --no-checkout \
+                 https://github.com/langflow-ai/langflow.git langflow-upstream; then
+              exit 0
+            fi
+            echo "::warning::upstream clone attempt $attempt failed; retrying"
+            rm -rf langflow-upstream
+            sleep 5
+          done
+          echo "::error::could not clone langflow-ai/langflow, so no dependency-path verdict exists for this PR. Not treating that as 'every path resolves'."
+          exit 1
+
+      # Fails only on the changed docs; the repo-wide sweep is emitted as
+      # ::warning:: so drift that lands upstream between PRs stays visible
+      # (#1012 — an unevaluated path is unknown, not clean).
+      - name: Resolve every External-dependencies path against upstream
+        run: |
+          set -eo pipefail
+          node scripts/watch-upstream-areas.mjs \
+            --mode=check-docs \
+            --root langflow-upstream \
+            --ref origin/main \
+            --changed changed-docs.txt | tee -a "$GITHUB_STEP_SUMMARY"
+
   detect-specs:
     name: Detect changed specs
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ CLI usage:
 
 ```bash
 # Map changed paths to spec files (default output: file paths)
-npm run impacted -- src/backend/base/langflow/components/inputs/webhook.py
+npm run impacted -- src/lfx/src/lfx/components/input_output/webhook.py
 
 # Read paths from stdin (e.g. piped from `git diff --name-only`)
 git diff --name-only main..HEAD | npm run impacted -- --stdin

--- a/docs/TEST-SPEC-TEMPLATE.md
+++ b/docs/TEST-SPEC-TEMPLATE.md
@@ -37,7 +37,14 @@ Think: "if this test fails, what broke in the product?"
 
 ## External dependencies *(required)*
 <!-- Files from the Langflow repository that, if changed, could break this test.
-     This list is read by the monitoring workflow — fill it in carefully. -->
+     This list is read by the monitoring workflow — fill it in carefully.
+
+     Every path must RESOLVE against upstream: `pr-validation.yml` checks the docs
+     a PR touches with `watch-upstream-areas.mjs --mode=check-docs` and fails on a
+     path that does not exist (issue #1298). A `*`/`**` glob is fine and is
+     resolved; an ellipsis (`.../`, `…`) is not — it can never be confirmed, so
+     write the real path. The placeholders below are exempt because this file is
+     the template. -->
 
 - `src/frontend/...` — description of what this file does and why it impacts the test
 - `src/backend/...` — same

--- a/docs/api/flows/api-flows-crud.md
+++ b/docs/api/flows/api-flows-crud.md
@@ -107,4 +107,4 @@ The spec runs **9 independent tests** against `/api/v1/flows/` via Playwright's 
 
 - `src/backend/base/langflow/api/v1/flows.py` — router that exposes `POST/GET/PATCH/DELETE /api/v1/flows/`; any signature, status code, or response shape change here directly affects the spec.
 - `src/backend/base/langflow/services/database/models/flow/model.py` — flow schema (name, description, data, is_component); renaming or removing a field breaks the POST payload and the PATCH/GET assertions.
-- `src/backend/base/langflow/api/utils.py` — shared API helpers used by the flows router (validation, current-user resolution); changes here can shift 422 vs 400 boundaries.
+- `src/backend/base/langflow/api/utils/` — shared API helpers used by the flows router (validation, current-user resolution); changes here can shift 422 vs 400 boundaries.

--- a/docs/collect-models.md
+++ b/docs/collect-models.md
@@ -264,8 +264,8 @@ exists to prevent. Two consequences, both load-bearing:
 ## External dependencies *(required)*
 
 - `src/frontend/src/pages/SettingsPage/pages/GlobalVariablesPage/index.tsx` — Settings navigation; if the `sidebar-nav-Model Providers` testid changes, the spec cannot reach the provider list
-- `src/frontend/src/components/core/modelProviderTag/` — provider list items (testids like `provider-item-OpenAI`) and model toggles (`llm-toggle-*`); any rename breaks model collection
-- `src/frontend/src/components/ui/button` — Save / Replace button labels; if these change the API key save step is silently skipped and `models.json` ends up empty
+- `src/frontend/src/modals/modelProviderModal/` — provider list items (testids like `provider-item-OpenAI`) and model toggles (`llm-toggle-*`); any rename breaks model collection
+- `src/frontend/src/components/ui/button.tsx` — Save / Replace button labels; if these change the API key save step is silently skipped and `models.json` ends up empty
 - `GET /api/v1/all` — the component registry the catalog layer reads. It returns
   `{ category: { ComponentType: template } }`; note the **`component_display_names`
   pseudo-category**, a lowercased echo of every type that the probe must skip so a

--- a/docs/core-components/agent-component-regression.md
+++ b/docs/core-components/agent-component-regression.md
@@ -80,8 +80,8 @@ If any of these tests fails, the Agent component is broken at the canvas level: 
 
 ## External dependencies *(required)*
 
-- `src/lfx/src/lfx/components/agents/agent.py` — `AgentComponent` definition; the `system_prompt` input and the per-provider model-list metadata are the schema this spec asserts against
-- `src/frontend/src/CustomNodes/GenericNode/components/parameterRenderComponent/` — renders `value-dropdown-model_model` and the `manage-model-providers` button inside it; testid renames break Tests 3 and 4
+- `src/lfx/src/lfx/components/models_and_agents/agent.py` — `AgentComponent` definition; the `system_prompt` input and the per-provider model-list metadata are the schema this spec asserts against
+- `src/frontend/src/components/core/parameterRenderComponent/` — renders `value-dropdown-model_model` and the `manage-model-providers` button inside it; testid renames break Tests 3 and 4
 - `src/frontend/src/CustomNodes/GenericNode/` — renders the handles; the `handle-agent-shownode-{port}-{side}` pattern must remain stable
 - Provider icon assets in `src/frontend/src/icons/` — the `icon-OpenAI` and `icon-Anthropic` testids on the Agent node carry the assertion in Test 4 and break if the icon mapping changes
 

--- a/docs/core-components/chat-input-files-field-regression.md
+++ b/docs/core-components/chat-input-files-field-regression.md
@@ -83,7 +83,7 @@ All 4 tests carry `@stable` per the project rule "spec is born 100% @stable; tag
 
 - `src/lfx/src/lfx/components/input_output/chat.py:70-78` — defines the FileInput `name="files"` with `advanced=True`, `is_list=True`, `temp_file=True`, `file_types=TEXT_FILE_TYPES + IMG_FILE_TYPES`. Renaming the field, dropping `advanced`, or flipping `temp_file=False` breaks Tests 1, 2, and 4.
 - `src/frontend/src/components/core/parameterRenderComponent/components/inputFileComponent/index.tsx` — renders the two branches based on `tempFile`. With `tempFile=True` (Chat Input case) it always renders the `input-file-component` text input + `button_upload_file` regardless of `ENABLE_FILE_MANAGEMENT`. The empty-value placeholder literal `"Upload a file..."` and the dismiss handler (which sets value/file_path to `""`) come from this file.
-- `src/frontend/src/pages/FlowPage/components/InspectionPanel/components/InspectionPanelEditField.tsx` — generates the `show${name}` toggle. Renaming the testid pattern breaks Test 1's toggle click and the helper used by Tests 2-4.
+- `src/frontend/src/components/core/parameterRenderComponent/components/tableComponent/components/tableAdvancedToggleCellRender/index.tsx` — generates the `show${name}` toggle. Renaming the testid pattern breaks Test 1's toggle click and the helper used by Tests 2-4.
 - `src/lfx/src/lfx/schema/message.py` — `Message` carries `files: list[str | Image]` and serializes them so the Playground can render the user-side image. Test 3 depends on this propagation chain.
 - `src/frontend/src/helpers/create-file-upload.ts` — backs `handleButtonClick` on the FileInput; the hidden `<input type="file">` it creates is what `page.waitForEvent("filechooser")` captures.
 

--- a/docs/core-components/configure-mcp-and-custom-component.md
+++ b/docs/core-components/configure-mcp-and-custom-component.md
@@ -131,7 +131,7 @@ current flaky cluster (#773).
 
 ## External dependencies *(required)*
 
-- `src/frontend/src/.../mcpServerTab` (or equivalent) — the MCP sidebar,
+- `src/frontend/src/pages/MainPage/pages/homePage/components/McpServerTab.tsx` (or equivalent) — the MCP sidebar,
   `sidebar-add-mcp-server-button`, `http-tab`, `http-name-input`,
   `http-url-input`, `add-mcp-server-button`.
 - `POST/GET/DELETE /api/v2/mcp/servers` — MCP server registration + persistence.

--- a/docs/core-components/custom-component-add.md
+++ b/docs/core-components/custom-component-add.md
@@ -48,8 +48,8 @@ The pulse-pink visual contract is the user-facing signal that Langflow uses to d
 
 ## External dependencies
 
-- `src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarHeaderComponent/index.tsx` — owns the `sidebar-custom-component-button` test ID. Renaming it breaks step 2.
-- `src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/CodeButton/index.tsx` (or equivalent) — emits the `code-button-modal` test ID and applies the `animate-pulse-pink` class while code is unsaved. A change to either the test ID or the class name breaks the entire spec.
+- `src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarFooterButtons.tsx` — owns the `sidebar-custom-component-button` test ID. Renaming it breaks step 2.
+- `src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx` (or equivalent) — emits the `code-button-modal` test ID and applies the `animate-pulse-pink` class while code is unsaved. A change to either the test ID or the class name breaks the entire spec.
 - `src/frontend/src/modals/codeAreaModal/index.tsx` — Ace editor lives here. The `.ace_content` selector and the underlying `<textarea>` mirror are stable since multiple specs depend on them.
 - `src/backend/base/langflow/custom/custom_component/component.py` — Check & Save calls validation here; if validation rejects the minimal Component class shipped in the spec body, step 6 fails.
 

--- a/docs/core-components/data-operations-component.md
+++ b/docs/core-components/data-operations-component.md
@@ -242,9 +242,9 @@ by an empty output, a passthrough, or a node that failed to build (the run gate 
   reveal), `update_outputs` (per-operation output routing), `as_message` / `as_data` /
   `as_dataframe`, `_word_count`, `select_keys`, `_text_to_dataframe`,
   `filter_rows_by_value`.
-- `src/frontend/.../parameterRenderComponent/components/tabComponent/index.tsx` — emits
+- `src/frontend/src/components/core/parameterRenderComponent/components/tabComponent/index.tsx` — emits
   `tab_{index}_{testIdCase(tab)}` for the Input Type selector.
-- `src/frontend/.../parameterRenderComponent/components/sortableListComponent/index.tsx` —
+- `src/frontend/src/components/core/parameterRenderComponent/components/sortableListComponent/index.tsx` —
   emits `button_open_list_selection_sortablelist_sortablelist_<field>` and the
   `list_item_<snake_case_name>` options.
 - `src/frontend/src/CustomNodes/GenericNode/components/NodeOutputfield/index.tsx` — emits

--- a/docs/core-components/general-bugs-component-webhook-api-key-display.md
+++ b/docs/core-components/general-bugs-component-webhook-api-key-display.md
@@ -70,7 +70,7 @@ component. Every flow the page creates is captured from its
 
 ## External dependencies
 
-- `src/backend/base/langflow/components/data/webhook.py` — Webhook component; the
+- `src/lfx/src/lfx/components/input_output/webhook.py` — Webhook component; the
   generated cURL and the `curl` advanced field.
 - `GET /api/v1/config` (`webhook_auth_enable`) and `GET /api/v1/auto_login` — both
   mocked via `page.route`, so no real auth config is required.

--- a/docs/core-components/general-bugs-delete-handle-advanced-input.md
+++ b/docs/core-components/general-bugs-delete-handle-advanced-input.md
@@ -60,10 +60,10 @@ The handle-presence assertion (`case true-left` 1 → 0) is the primary, most di
 
 ## External dependencies
 
-- `src/backend/base/langflow/components/logic/conditional_router.py` — If-Else component. The `true_case_message` advanced field must exist as an addable inspector field for step 3 to find `inspector-add-true_case_message`.
-- `src/frontend/src/CustomNodes/GenericNode/components/parameterRenderComponent/index.tsx` — emits the `Receiving input` placeholder for connected handles and the field widget on the node body.
+- `src/lfx/src/lfx/components/flow_controls/conditional_router.py` — If-Else component. The `true_case_message` advanced field must exist as an addable inspector field for step 3 to find `inspector-add-true_case_message`.
+- `src/frontend/src/components/core/parameterRenderComponent/index.tsx` — emits the `Receiving input` placeholder for connected handles and the field widget on the node body.
 - `src/frontend/src/modals/codeAreaModal/index.tsx` — Check & Save flow. The post-save handle cleanup happens here (or in the store reducer it triggers).
-- `src/frontend/src/components/genericIconComponent/index.tsx` — emits the `icon-lock` test ID consumed by the spec.
+- `src/frontend/src/components/common/genericIconComponent/index.tsx` — emits the `icon-lock` test ID consumed by the spec.
 - `tests/helpers/ui/open-advanced-options.ts` — `openAdvancedOptions` (opens the inspector via `parameters-button`), `closeAdvancedOptions` (`inspection-panel-close`). Renaming these helpers breaks the spec. The `enableInspectPanel` / `disableInspectPanel` helpers are **no longer used** by this spec (the inspect-panel toggle feature was removed in dev46).
 
 ---

--- a/docs/core-components/prompt-template-component-regression.md
+++ b/docs/core-components/prompt-template-component-regression.md
@@ -90,7 +90,7 @@ Tests 2–6 use the helper `setPromptTemplate(page, value)` which:
 ## External dependencies *(required)*
 
 - `src/frontend/src/modals/promptModal/` — `genericModalBtnSave` button, `edit-prompt-sanitized` preview, and the textarea that holds the editable template; changes here break tests 2–6
-- `src/frontend/src/CustomNodes/GenericNode/components/parameterRenderComponent/components/promptAreaComponent/` — `button_open_prompt_modal` trigger on the node inspector; breaks tests 2–6
+- `src/frontend/src/components/core/parameterRenderComponent/components/promptComponent/` — `button_open_prompt_modal` trigger on the node inspector; breaks tests 2–6
 - `src/lfx/src/lfx/interface/utils.py` — `extract_input_variables_from_prompt()`: derives the variable list from the template string using Python's `string.Formatter().parse()` (not a regex); breaks tests 2–5
 - `src/lfx/src/lfx/base/prompts/api_utils.py` — `validate_prompt()` and `_check_input_variables()`: validation layer around the extracted variables; breaks tests 2–5
 - `src/lfx/src/lfx/components/models_and_agents/prompt.py` — `PromptComponent` definition (`display_name="Prompt Template"`, template field) and `update_build_config()` that synchronizes template ↔ input fields; breaks tests 2–6 and the backend assertion in test 6

--- a/docs/core-components/tool-mode.md
+++ b/docs/core-components/tool-mode.md
@@ -63,12 +63,12 @@ For the Custom Component branch the test asserts that `tool_name` is present but
 
 ## External dependencies
 
-- `src/backend/base/langflow/components/data/url.py` — URL component must expose a tool-mode-compatible interface; renaming `URL` or its outputs breaks the `data_sourceURL` sidebar test ID and the `urlcomponent` handle prefix.
+- `src/lfx/src/lfx/components/data_source/url.py` — URL component must expose a tool-mode-compatible interface; renaming `URL` or its outputs breaks the `data_sourceURL` sidebar test ID and the `urlcomponent` handle prefix.
 - `src/backend/base/langflow/custom/custom_component/component.py` — Tool Mode plumbing; if `tool_mode` flag handling changes, the toggle stops emitting the `toolset` view.
-- `src/frontend/src/CustomNodes/GenericNode/components/NodeToolbarComponent/index.tsx` — `tool-mode-button` test ID lives here. Any rename breaks the UI-toggle assertions.
+- `src/frontend/src/pages/FlowPage/components/nodeToolbarComponent/index.tsx` — `tool-mode-button` test ID lives here. Any rename breaks the UI-toggle assertions.
 - `src/frontend/src/pages/FlowPage/components/PageComponent/index.tsx` — registers the `Ctrl/Meta+Shift+M` shortcut. If the binding changes, the keyboard branch fails.
-- `src/frontend/src/components/core/parameterRenderComponent/components/sidebarComponent/sideBarItem/index.tsx` — `data_source*` and `models_and_agents*` sidebar test IDs.
-- `src/backend/base/langflow/components/agents/agent.py` — Agent component's `tools` input; renaming the port breaks the `handle-agent-shownode-tools-left` selector.
+- `src/frontend/src/pages/FlowPage/components/flowSidebarComponent/components/sidebarDraggableComponent.tsx` — `data_source*` and `models_and_agents*` sidebar test IDs.
+- `src/lfx/src/lfx/components/models_and_agents/agent.py` — Agent component's `tools` input; renaming the port breaks the `handle-agent-shownode-tools-left` selector.
 
 ---
 

--- a/docs/core-components/webhook-component-regression.md
+++ b/docs/core-components/webhook-component-regression.md
@@ -265,7 +265,7 @@ and the reason we walked away are all in this section.
 
 ## External dependencies *(required)*
 
-- `src/backend/base/langflow/components/inputs/webhook.py` — `WebhookComponent.build_data()`: JSON parsing, fallback wrapping, and empty-data short-circuit; changes here break tests 4, 8, and 9
+- `src/lfx/src/lfx/components/input_output/webhook.py` — `WebhookComponent.build_data()`: JSON parsing, fallback wrapping, and empty-data short-circuit; changes here break tests 4, 8, and 9
 - `src/backend/base/langflow/api/v1/endpoints.py` — `POST /api/v1/webhook/{flow_id_or_name}` and `GET /api/v1/monitor/messages` endpoints; status codes and response shape affect tests 1, 7, and 10
 - `src/frontend/src/CustomNodes/GenericNode/components/NodeOutputParameter/` — renders `output-inspection-{name}-{component}` buttons; the `output-inspection-json-webhook` testid depends on the output `display_name` being `"JSON"` (updated in langflow-ai/langflow#11554); breaks tests 4, 8, and 9
 - `src/frontend/src/components/core/parameterRenderComponent/components/webhookFieldComponent/` — renders the cURL field (an advanced field on dev49, exposed via the inspector and read from its `text-area-modal`); changes to the rendering break test 3

--- a/docs/core-functionality/llm-agents/agent-component-regression.md
+++ b/docs/core-functionality/llm-agents/agent-component-regression.md
@@ -103,7 +103,7 @@ Kept separate from the suite because it interrupts the execution state.
 - `src/frontend/src/components/core/playgroundComponent/` — main Playground component; changes to `input-chat-playground`, `button-send`, `div-chat-message`, or `playground-close-button` break this spec
 - `src/frontend/src/components/core/flowToolbarComponent/` — `playground-btn-flow-io` button that opens the Playground from the editor
 - `src/frontend/src/CustomNodes/GenericNode/components/NodeStatus/index.tsx` — renders `node_duration_agent` on the canvas after execution
-- `src/backend/base/langflow/components/agents/` — Agent execution logic; changes to streaming or duration field generation affect multiple tests
+- `src/lfx/src/lfx/components/models_and_agents/` — Agent execution logic; changes to streaming or duration field generation affect multiple tests
 
 ---
 

--- a/docs/core-functionality/llm-agents/agent-empty-refusal-response.md
+++ b/docs/core-functionality/llm-agents/agent-empty-refusal-response.md
@@ -156,7 +156,7 @@ The spec generates **2 tests per active model** via `resolveTestTargets()` (defa
 
 ## External dependencies *(required)*
 
-- `src/backend/base/langflow/components/agents/` — Agent execution and its
+- `src/lfx/src/lfx/components/models_and_agents/` — Agent execution and its
   handling of empty / refusal model output; a regression here (e.g. a `NoneType`
   on empty content) breaks this spec.
 - `src/frontend/src/CustomNodes/GenericNode/` — renders the Agent's

--- a/docs/core-functionality/llm-agents/agent-input-sources.md
+++ b/docs/core-functionality/llm-agents/agent-input-sources.md
@@ -131,7 +131,7 @@ A per-run token `SENTINEL_<Date.now()>` is generated so a match is unambiguous.
 
 ## External dependencies *(required)*
 
-- `src/backend/base/langflow/components/agents/` — Agent execution and the
+- `src/lfx/src/lfx/components/models_and_agents/` — Agent execution and the
   `input_value` input; a change to how the field vs. the connected handle is
   resolved breaks this spec.
 - `src/frontend/src/CustomNodes/GenericNode/` — renders the Agent's

--- a/docs/core-functionality/llm-agents/agent-markdown-output.md
+++ b/docs/core-functionality/llm-agents/agent-markdown-output.md
@@ -141,7 +141,7 @@ tags proves the constructs rendered; absence of the raw tokens proves they were
 - `src/frontend/src/components/core/chatComponents/` — Playground Markdown /
   code-block rendering (react-markdown + remarkGfm inside `.markdown.prose`); a
   change to the plugins or the container class breaks the assertions.
-- `src/backend/base/langflow/components/agents/` — the Agent must keep emitting
+- `src/lfx/src/lfx/components/models_and_agents/` — the Agent must keep emitting
   its reply as a Message rendered through the chat renderer.
 - Simple Agent starter template — must keep shipping `ChatInput → Agent →
   ChatOutput`.

--- a/docs/core-functionality/llm-agents/agent-max-iterations.md
+++ b/docs/core-functionality/llm-agents/agent-max-iterations.md
@@ -141,7 +141,7 @@ flaky). The fetch is SSRF-blocked backend-side, but that is irrelevant — the
 
 ## External dependencies *(required)*
 
-- `src/backend/base/langflow/components/agents/` — the Agent executor and its
+- `src/lfx/src/lfx/components/models_and_agents/` — the Agent executor and its
   `max_iterations` enforcement; the fix this spec guards lives here.
 - `src/frontend/src/CustomNodes/GenericNode/` — the Agent node inspector
   (`int_int_max_iterations`).

--- a/docs/core-functionality/llm-agents/agent-max-tokens.md
+++ b/docs/core-functionality/llm-agents/agent-max-tokens.md
@@ -173,9 +173,9 @@ Shared setup per test:
 
 ## External dependencies *(required)*
 
-- `src/lfx/components/models_and_agents/agent.py` — `max_tokens` IntInput and
+- `src/lfx/src/lfx/components/models_and_agents/agent.py` — `max_tokens` IntInput and
   `_get_max_tokens_value()` (empty/`0` ⇒ `None` ⇒ unlimited).
-- `src/lfx/base/models/unified_models/instantiation.py` — provider-specific
+- `src/lfx/src/lfx/base/models/unified_models/instantiation.py` — provider-specific
   mapping via `max_tokens_field_name` (Google ⇒ `max_output_tokens`).
 - `src/frontend/src/CustomNodes/GenericNode/` — the Agent node inspector
   (`int_int_max_tokens`) and its int-field input handling.

--- a/docs/core-functionality/llm-agents/agent-multimodal-image-input.md
+++ b/docs/core-functionality/llm-agents/agent-multimodal-image-input.md
@@ -169,12 +169,12 @@ provider's vision-capable catalog rather than narrowing to one model. Use the
 
 ## External dependencies *(required)*
 
-- `src/backend/base/langflow/components/agents/` — Agent multimodal input
+- `src/lfx/src/lfx/components/models_and_agents/` — Agent multimodal input
   handling; a regression in how image messages are consumed breaks this spec.
 - `src/frontend/src/components/core/playgroundComponent/` — the
   `input-wrapper` file input, `input-chat-playground`, `button-send`, and the
   attachment `img` preview.
-- `src/backend/base/langflow/components/inputs/` (ChatInput) — must keep emitting
+- `src/lfx/src/lfx/components/input_output/` (ChatInput) — must keep emitting
   a Message carrying attached files on its `chat message` output.
 - Simple Agent starter template — must keep shipping `ChatInput → Agent →
   ChatOutput`; a rewire changes the input-handle path.

--- a/docs/core-functionality/llm-agents/agent-n-messages-limit.md
+++ b/docs/core-functionality/llm-agents/agent-n-messages-limit.md
@@ -159,7 +159,7 @@ Shared setup per test (all data is per-run unique):
 
 ## External dependencies *(required)*
 
-- `src/lfx/components/models_and_agents/memory.py` — the Message History
+- `src/lfx/src/lfx/components/models_and_agents/memory.py` — the Message History
   (`Memory`) component: `retrieve_messages` applies `limit=n_messages` and the
   flow-scoped retrieval this spec depends on; the Agent's memory resolves
   through the same helper.

--- a/docs/core-functionality/llm-agents/agent-tool-inspection.md
+++ b/docs/core-functionality/llm-agents/agent-tool-inspection.md
@@ -158,7 +158,7 @@ cleanup and the flow count grows.
   daily self-hosts go-httpbin and exports `ECHO_BASE_URL`; its `/json` serves
   the identical slideshow, keeping the output assert deterministic (same
   convention + SSRF-allowlist note as `agent-multi-tool-selection`).
-- `src/frontend/src/components/core/chatComponents/…` — renders the
+- `src/frontend/src/components/core/chatComponents/` — renders the
   `div-tools_tools_metadata` row and `tool_<name>` chips (the 1.12 tool-usage
   surface).
 - `GET /api/v1/monitor/messages` — persisted `content_blocks[].contents[]`

--- a/docs/core-functionality/llm-agents/provider-invalid-auth-error.md
+++ b/docs/core-functionality/llm-agents/provider-invalid-auth-error.md
@@ -56,7 +56,7 @@ The test is parameterized: runs for each provider that has an env var configured
 - `src/frontend/src/modals/modelProviderModal/hooks/useProviderConfiguration.ts` — validation logic, calls the endpoint and manages the `validationState`
 - `src/frontend/src/alerts/error/index.tsx` — visual component of the toast `.error-build-message`
 - `src/backend/base/langflow/api/v1/models.py` — endpoint `POST /api/v1/models/validate-provider`
-- `src/backend/base/langflow/services/credentials.py` — function `validate_model_provider_key`, which tests the key against the provider and returns `"Invalid API key for {provider}"`
+- `src/lfx/src/lfx/base/models/unified_models/credentials.py` — function `validate_model_provider_key`, which tests the key against the provider and returns `"Invalid API key for {provider}"`
 
 ---
 

--- a/docs/core-functionality/model-provider/anthropic-provider.md
+++ b/docs/core-functionality/model-provider/anthropic-provider.md
@@ -167,7 +167,7 @@ nightly. `@model-provider` (area) · `@settings` (Test 1 navigates Settings) ·
   `provider-item-Anthropic`, `provider-variable-input-ANTHROPIC_API_KEY`,
   the Save/Replace button; a rename breaks Test 1.
 - Provider-config storage — the global `ANTHROPIC_API_KEY` provider variable.
-- `src/backend/base/langflow/components/agents/` — Agent execution with the
+- `src/lfx/src/lfx/components/models_and_agents/` — Agent execution with the
   selected Claude model (Tests 2–3).
 - `src/frontend/src/components/core/playgroundComponent/` — Playground I/O.
 - Anthropic API — Test 1 validates the key live; Tests 2–3 make real calls.

--- a/docs/core-functionality/model-provider/azure-ai-foundry-provider-setup.md
+++ b/docs/core-functionality/model-provider/azure-ai-foundry-provider-setup.md
@@ -435,14 +435,14 @@ OpenRouter so the asserts cannot pass on a page-wide string.
   `provider-item-*`, `provider-variable-input-*`, `model-provider-selection`,
   `custom-deployment-hint`, `model-search-input`,
   `add-custom-*deployment-button`.
-- `src/lfx/base/models/model_metadata.py` — the `Azure AI Foundry` provider entry
+- `src/lfx/src/lfx/base/models/model_metadata.py` — the `Azure AI Foundry` provider entry
   (its two variables, the endpoint description carrying the deployment-name
   rule).
-- `src/lfx/base/models/azure_ai_foundry_constants.py` — seed catalog.
-- `src/lfx/base/models/model_utils.py` —
+- `src/lfx/src/lfx/base/models/azure_ai_foundry_constants.py` — seed catalog.
+- `src/lfx/src/lfx/base/models/model_utils.py` —
   `request_azure_ai_foundry_model_entries` (credential validation) and the
   free-text enable merge.
-- `src/lfx/base/models/unified_models/credentials.py` /
+- `src/lfx/src/lfx/base/models/unified_models/credentials.py` /
   `instantiation.py` — the Foundry validation branch and endpoint injection.
 - `src/backend/base/langflow/api/v1/models.py` —
   `validate-provider`, `enabled_models` (typed identities), and their variable

--- a/docs/core-functionality/model-provider/google-provider.md
+++ b/docs/core-functionality/model-provider/google-provider.md
@@ -143,7 +143,7 @@ nightly. `@model-provider` (area) · `@settings` (Test 1 navigates Settings) ·
   `provider-item-Google Generative AI`, `provider-variable-input-GOOGLE_API_KEY`,
   the Save/Replace button; a rename breaks Test 1.
 - Provider-config storage — the global `GOOGLE_API_KEY` provider variable.
-- `src/backend/base/langflow/components/agents/` — Agent execution with the
+- `src/lfx/src/lfx/components/models_and_agents/` — Agent execution with the
   selected Gemini model (Test 2).
 - `src/frontend/src/components/core/playgroundComponent/` — Playground I/O.
 - Google Generative AI API — Test 1 validates the key live; Test 2 makes a real

--- a/docs/core-functionality/model-provider/openai-provider.md
+++ b/docs/core-functionality/model-provider/openai-provider.md
@@ -152,9 +152,9 @@ the test ran clean at `--retries=0`.
 - `src/frontend/src/pages/SettingsPage/` (Model Providers page) — renders
   `provider-item-OpenAI`, `provider-variable-input-OPENAI_API_KEY`, and the
   Save/Replace button; a rename breaks Test 1.
-- `src/backend/base/langflow/api/.../variables` + provider-config storage — the
+- `src/backend/base/langflow/api/v1/variable.py` + provider-config storage — the
   global `OPENAI_API_KEY` provider variable the key is saved into.
-- `src/backend/base/langflow/components/agents/` — Agent execution with the
+- `src/lfx/src/lfx/components/models_and_agents/` — Agent execution with the
   selected GPT model (Test 2).
 - `src/frontend/src/components/core/playgroundComponent/` — Playground I/O used
   by Test 2.

--- a/docs/core-functionality/model-provider/provider-management.md
+++ b/docs/core-functionality/model-provider/provider-management.md
@@ -253,9 +253,9 @@ accepted / fake rejected), remove key — are each pinned by at least one test.
 - `src/frontend/src/pages/SettingsPage/` — Model Providers page
   (`provider-list`, `provider-item-*`, `provider-variable-input-*`,
   `model-provider-selection`).
-- `src/backend/base/langflow/api/v1/variables.py` — variables CRUD (the
+- `src/backend/base/langflow/api/v1/variable.py` — variables CRUD (the
   `default_fields` requirement; key storage behind providers).
-- `src/lfx/base/models/unified_models/credentials.py` — key validation on
+- `src/lfx/src/lfx/base/models/unified_models/credentials.py` — key validation on
   Save (real 1-token inference per provider).
 - `src/frontend/src/components/` model input — `model_model` dropdown and
   `<model>-option` entries.

--- a/docs/core-functionality/playground/playground-clear-history.md
+++ b/docs/core-functionality/playground/playground-clear-history.md
@@ -56,8 +56,8 @@ These are distinct operations: Default sessions expose "Clear chat"; user-create
 
 ## External dependencies *(required)*
 
-- `src/frontend/src/components/core/chatComponents/chatHeader/chat-header.tsx` — `isDefaultSession` logic controls which menu options are shown (`clear-chat-option` vs `delete-session-option`). Any change to this conditional or to the `data-testid` attributes will break these tests.
-- `src/frontend/src/components/core/chatComponents/chatHeader/` — `data-testid="chat-header-more-menu"` menu trigger; wrapped in `AnimatedConditional` (framer-motion), which is why `evaluate((el) => el.click())` is used instead of a coordinate-based click.
+- `src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/components/chat-header.tsx` — `isDefaultSession` logic controls which menu options are shown (`clear-chat-option` vs `delete-session-option`). Any change to this conditional or to the `data-testid` attributes will break these tests.
+- `src/frontend/src/components/core/playgroundComponent/chat-view/chat-header/` — `data-testid="chat-header-more-menu"` menu trigger; wrapped in `AnimatedConditional` (framer-motion), which is why `evaluate((el) => el.click())` is used instead of a coordinate-based click.
 
 ---
 

--- a/docs/core-functionality/playground/playground-history-persist.md
+++ b/docs/core-functionality/playground/playground-history-persist.md
@@ -38,7 +38,7 @@ This test complements `llm-agents/memory-history-regression.spec.ts`, which cove
 ## External dependencies *(required)*
 - `src/frontend/src/components/core/playgroundComponent/` — main Playground component; changes to `data-testid="playground-close-button"`, `data-testid="input-chat-playground"`, `data-testid="button-send"`, `data-testid="button-stop"`, or `data-testid="chat-message-User-{text}"` break this test
 - `src/frontend/src/components/core/flowToolbarComponent/` — `playground-btn-flow-io` button that opens the Playground
-- `src/backend/langflow/api/v1/chat.py` — message persistence endpoint; regressions here break the assertion after reopen
+- `src/backend/base/langflow/api/v1/chat.py` — message persistence endpoint; regressions here break the assertion after reopen
 
 ---
 

--- a/docs/core-functionality/playground/playground-output-data.md
+++ b/docs/core-functionality/playground/playground-output-data.md
@@ -48,7 +48,7 @@ Both tests run without user input and without an API key or LLM — the Mock Dat
 
 ## External dependencies *(required)*
 
-- `src/backend/base/langflow/components/data/` — Mock Data component; changes to serialization logic (`_serialize_data` or `df.to_markdown`) would alter the rendered output format
+- `src/lfx/src/lfx/components/data_source/` — Mock Data component; changes to serialization logic (`_serialize_data` or `df.to_markdown`) would alter the rendered output format
 - `src/frontend/src/components/core/chatComponents/` — Markdown and code block rendering in the Playground chat; changes to react-markdown plugins or code block CSS classes would break the assertions
 
 ---

--- a/docs/core-functionality/playground/playground-send-while-in-progress.md
+++ b/docs/core-functionality/playground/playground-send-while-in-progress.md
@@ -115,7 +115,7 @@ proves the block is tied to the in-progress state, not a permanent lock.
 
 ## External dependencies *(required)*
 
-- `src/frontend/src/.../playground` — the chat input disabled state and the
+- `src/frontend/src/components/core/playgroundComponent/` — the chat input disabled state and the
   `button-send`/`button-stop` swap during a run.
 - `POST /api/v2/workflows` — the run endpoint held to create the in-progress
   window (matched by path; an upstream move requires updating the route regex).

--- a/docs/core-functionality/playground/stop-button-playground.md
+++ b/docs/core-functionality/playground/stop-button-playground.md
@@ -39,8 +39,8 @@ The test uses a Custom Component with a 60-second `sleep()` to guarantee the flo
 
 ## External dependencies *(required)*
 
-- `src/frontend/src/components/core/playgroundComponent/chat-view/send-message/button-send-wrapper.tsx` — renders `button-stop` during active builds; calls `stopBuilding()` on click
-- `src/frontend/src/components/core/playgroundComponent/chat-view/send-message/no-input.tsx` — alternate render path for `button-stop` when the flow has no input component
+- `src/frontend/src/components/core/playgroundComponent/chat-view/chat-input/components/button-send-wrapper.tsx` — renders `button-stop` during active builds; calls `stopBuilding()` on click
+- `src/frontend/src/components/core/playgroundComponent/chat-view/chat-input/components/no-input.tsx` — alternate render path for `button-stop` when the flow has no input component
 
 ---
 

--- a/docs/core-functionality/project-management/folder-deletion-integrity.md
+++ b/docs/core-functionality/project-management/folder-deletion-integrity.md
@@ -285,7 +285,7 @@ seeded on the same instance:
 - `src/backend/base/langflow/api/v1/projects.py` — `DELETE /api/v1/projects/{id}`
   and the project list endpoint; the `500`-under-contention defect (LE-2020)
   observed on delete also reaches this spec's cleanup path.
-- `src/frontend/src/pages/MainPage/components/myCollectionComponent/` — renders
+- `src/frontend/src/components/core/folderSidebarComponent/` — renders
   the `project-sidebar` and its `sidebar-nav-*` entries; the loop in test 4 and
   every visibility assertion depend on those testids.
 - `src/frontend/src/pages/MainPage/components/dropdown/` — the

--- a/docs/flow-functionality/canvas-copy-paste.md
+++ b/docs/flow-functionality/canvas-copy-paste.md
@@ -52,7 +52,7 @@ The two tests differ only in step 2 (which component is added).
 ## External dependencies *(required)*
 
 - `src/frontend/src/hooks/flows/use-add-flow.ts` — the UI flow-creation path with the unique-name suffix race (`addVersionToDuplicates`). Bypassed via the API helper, but if the API contract for `POST /api/v1/flows/` changes (status, payload shape), the helper fails loudly.
-- `src/frontend/src/components/core/.../canvas/...` — ReactFlow node rendering. If the node container's `.react-flow__node` class is renamed upstream, the count assertions break.
+- `src/frontend/src/pages/FlowPage/components/PageComponent/` — ReactFlow node rendering. If the node container's `.react-flow__node` class is renamed upstream, the count assertions break.
 - ReactFlow's keyboard handler for copy/paste — if Langflow stops propagating Ctrl+C / Ctrl+V to the canvas, paste produces zero new nodes and the test fails on the post-paste count assertion.
 
 ---

--- a/docs/flow-functionality/export-import-flow.md
+++ b/docs/flow-functionality/export-import-flow.md
@@ -73,7 +73,8 @@ If these break, users cannot share flows, back them up, or restore previously ex
 
 ## External dependencies *(required)*
 
-- `src/frontend/src/components/core/flowEditorComponents/` — flow editor header, export modal
+- `src/frontend/src/components/core/flowToolbarComponent/` — flow editor header actions that open the export dialog
+- `src/frontend/src/modals/exportModal/` — the export modal itself
 - `src/backend/base/langflow/api/v1/flows.py` — flow export/import endpoints
 - `tests/helpers/ui/simulate-drag-and-drop.ts` — `simulateDragAndDrop` helper
 - `tests/helpers/flows/leave-flow-editor.ts` — the editor exit: drains in-flight flow saves, clicks `icon-ChevronLeft`, and distinguishes the #1153 blocker deadlock from a swallowed click. It depends on upstream `src/frontend/src/pages/FlowPage/index.tsx` (`useBlocker` / `handleSave`), `src/frontend/src/modals/saveChangesModal/index.tsx`, and the `flow.unsavedChangesTitle` string in `src/frontend/src/locales/en.json` — if that title is reworded the dialog stops being recognised and every deadlock silently reclassifies as a swallowed click

--- a/docs/flow-functionality/flow-lock.md
+++ b/docs/flow-functionality/flow-lock.md
@@ -109,9 +109,11 @@ management; `@ui-ux` — settings-modal interaction + locked-state indicators.
 
 ## External dependencies *(required)*
 
-- `src/frontend/src/…/flowSettings` (Flow Settings modal) — renders
-  `lock-flow-switch`, `input-flow-name`, `input-flow-description`,
-  `save-flow-settings`, and the dialog `icon-Lock` / `icon-Unlock`.
+- `src/frontend/src/components/core/editFlowSettingsComponent/` (Flow Settings
+  modal fields) — renders `lock-flow-switch`, `input-flow-name`,
+  `input-flow-description`, and the dialog `icon-Lock` / `icon-Unlock`.
+- `src/frontend/src/components/core/flowSettingsComponent/` — owns the
+  `save-flow-settings` action that commits the modal.
 - Canvas node chrome — renders the per-node `icon-lock` badge shown while the
   flow is locked (the 1.11 replacement for the old header lock icon).
 - "Basic Prompting" starter template — the disposable subject flow.

--- a/docs/flow-functionality/flow-rename-header.md
+++ b/docs/flow-functionality/flow-rename-header.md
@@ -71,7 +71,7 @@ The API test must assert **all** of:
 - `tests/helpers/flows/rename-flow.ts` — opens the rename modal, fills `input-flow-name`, clicks `save-flow-settings`, dismisses the "Changes saved successfully" toast, and waits for the `flow_name` DOM to commit via `waitForFunction`
 - `tests/helpers/auth/get-auth-token.ts` — issues a Bearer token from the configured superuser credentials
 - `tests/helpers/flows/track-created-flows.ts` — captures the UI test's created flow ids from the page's `POST /api/v1/flows` → 201 responses and deletes them id-scoped in `afterEach`. It does **not** see the API test's flow: that one is created through the `request` fixture, which emits no page-level response events (#1147), so the API test keeps its own `finally` `DELETE`
-- `src/frontend/src/components/headerComponent/` — renders the `flow_name` header that opens the rename modal
+- `src/frontend/src/components/core/appHeaderComponent/components/FlowMenu/` — renders the `flow_name` header that opens the rename modal
 - `src/backend/base/langflow/api/v1/flows.py` — owns `POST/PATCH/GET/DELETE /api/v1/flows`; the round-trip in the API test exercises this endpoint directly
 
 ---

--- a/docs/flow-functionality/general-bugs-shard-3836.md
+++ b/docs/flow-functionality/general-bugs-shard-3836.md
@@ -54,7 +54,7 @@ The dev46 nightly replaced the old "Controls" edit modal with a node inspector s
 ## External dependencies
 
 - **OpenAI** — `test.skip` when `OPENAI_API_KEY` is absent. Runs the Basic Prompting flow through an OpenAI model (`initialGPTsetup`).
-- `src/backend/base/langflow/components/input_output/chat.py` — Chat Input component; the advanced `files` field must exist as an addable inspector field for step 2 to find `inspector-add-files`.
+- `src/lfx/src/lfx/components/input_output/chat.py` — Chat Input component; the advanced `files` field must exist as an addable inspector field for step 2 to find `inspector-add-files`.
 - `tests/assets/media/chain.png` — the uploaded test image.
 - `tests/helpers/ui/open-advanced-options.ts` — `openAdvancedOptions` / `closeAdvancedOptions` (the inspector panel).
 - `tests/helpers/other/initialGPTsetup.ts` — provider/model setup on the template.

--- a/docs/flow-functionality/run-flow.md
+++ b/docs/flow-functionality/run-flow.md
@@ -140,7 +140,8 @@ an inscrutable one at the Run Flow dropdown.
 
 ## External dependencies *(required)*
 
-- `src/frontend/src/components/core/nodeToolbarComponents/` — Run Flow component UI and flow name dropdown
+- `src/lfx/src/lfx/components/flow_controls/run_flow.py` — the Run Flow component itself; its `flow_name` input is what the dropdown populates
+- `src/frontend/src/components/core/dropdownComponent/` — the flow name dropdown UI (`dropdown-option-*` options and the refresh button)
 - `src/backend/base/langflow/api/v1/flows.py` — flow listing API used by the dropdown refresh
 - `src/backend/base/langflow/processing/` — flow execution chain that runs the pipeline
 - `tests/helpers/flows/leave-flow-editor.ts` — the editor exit: drains in-flight flow saves, clicks `icon-ChevronLeft`, and distinguishes the #1153 blocker deadlock from a swallowed click. It depends on upstream `src/frontend/src/pages/FlowPage/index.tsx` (`useBlocker` / `handleSave`), `src/frontend/src/modals/saveChangesModal/index.tsx`, and the `flow.unsavedChangesTitle` string in `src/frontend/src/locales/en.json` — if that title is reworded the dialog stops being recognised and every deadlock silently reclassifies as a swallowed click

--- a/docs/mcp/server/mcp-server-protocol.md
+++ b/docs/mcp/server/mcp-server-protocol.md
@@ -148,10 +148,14 @@ server area; `@regression` — guards a server-exposure/execution regression.
 
 ## External dependencies *(required)*
 
-- `src/backend/base/langflow/api/v1/mcp*` (MCP server routes:
-  `/api/v1/mcp/project/{id}`, `/composer-url`, `/streamable`, `/sse`) — the
-  generated endpoint and the protocol handlers.
-- `src/backend/base/langflow/services/mcp*` (or equivalent) — the MCP server
+- `src/backend/base/langflow/api/v1/mcp.py` — the MCP server routes
+  (`/api/v1/mcp/project/{id}`, `/composer-url`, `/streamable`, `/sse`) and the
+  protocol handlers.
+- `src/backend/base/langflow/api/v1/mcp_projects.py` — the per-project generated
+  endpoint this spec calls.
+- `src/backend/base/langflow/api/v1/mcp_utils.py` — the shared request/response
+  plumbing both routers use.
+- `src/lfx/src/lfx/services/mcp_composer/` (or equivalent) — the MCP server
   implementation that maps enabled flows to tools and executes `tools/call`.
 - ChatInput / ChatOutput components — the passthrough must keep echoing its input.
 - `tests/assets/flows/chat-io-ok-trace-fixture.json` — the passthrough fixture.

--- a/docs/ui-ux/canvas-zoom-navigation.md
+++ b/docs/ui-ux/canvas-zoom-navigation.md
@@ -137,7 +137,7 @@ containment, so a viewport-size change does not redden the spec.
 
 ## External dependencies
 
-- `src/frontend/src/CustomNodes/../CanvasControls` — `main_canvas_controls`,
+- `src/frontend/src/components/core/canvasControlsComponent/` — `main_canvas_controls`,
   `canvas_controls_dropdown`, `zoom_in`, `zoom_out`, `reset_zoom`, `fit_view`
   testids and the collapsed-by-default dropdown.
 - React Flow (`@xyflow/react`) viewport: the `.react-flow__viewport` transform,

--- a/docs/ui-ux/edit-sticky-note-text.md
+++ b/docs/ui-ux/edit-sticky-note-text.md
@@ -60,7 +60,7 @@ appending to it.
 
 ## External dependencies
 
-- `src/frontend/src/components/core/genericNode/` — NoteNode / generic-node-desc rendering
+- `src/frontend/src/CustomNodes/NoteNode/` — NoteNode / generic-node-desc rendering
   and the double-click handler that toggles edit mode
 - `data-testid="canvas-add-note-button"` — toolbar button that places a sticky note
 - `data-testid="note_node"` — the sticky note node container on the React Flow canvas

--- a/docs/ui-ux/minimize.md
+++ b/docs/ui-ux/minimize.md
@@ -91,7 +91,7 @@ reuses the node, the menu helper and the persisted-state reader already set up.
 
 ## External dependencies
 
-- `src/frontend/src/CustomNodes/GenericNode/components/NodeToolbarComponent` —
+- `src/frontend/src/pages/FlowPage/components/nodeToolbarComponent` —
   `icon-MoreHorizontal`, `minimize-button-modal`, `expand-button-modal`.
 - `GET /api/v1/all` — `minimized` defaults per component (Chat Output `true`,
   Prompt Template `false`).

--- a/scripts/watch-upstream-areas.mjs
+++ b/scripts/watch-upstream-areas.mjs
@@ -69,17 +69,22 @@
  *   node scripts/watch-upstream-areas.mjs --mode=check  --root langflow-upstream
  *   node scripts/watch-upstream-areas.mjs --mode=detect --root langflow-upstream --since "24 hours ago"
  *   node scripts/watch-upstream-areas.mjs --mode=areas          # print the table, no checkout needed
+ *   node scripts/watch-upstream-areas.mjs --mode=check-docs --root langflow-upstream --ref origin/main \
+ *       [--changed changed-docs.txt]   # spec-doc dependency paths (#1298)
  *
  * Exit codes: 0 = verdict produced; 1 = the checkout contradicts the table (a
- * monitored path is gone, or an unclassified subtree exists); 2 = the script
- * could not decide (bad flag, unreadable checkout, `git log` failed).
+ * monitored path is gone, an unclassified subtree exists, or a changed doc names
+ * a dependency path that does not resolve); 2 = the script could not decide (bad
+ * flag, unreadable checkout, `git log`/`git ls-tree` failed, unreadable
+ * `--changed` list).
  *
  * Dependency-free ESM; covered by `npm run test:scripts`.
  */
 
+import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
 /** Commits listed per area in the issue body — same cap the bash version used. */
 export const MAX_COMMITS_PER_AREA = 5;
@@ -487,6 +492,180 @@ export function findLfxDrift({ classification = LFX_CLASSIFICATION, listChildren
   return { unclassified: unclassified.sort(), stale: stale.sort(), scanned };
 }
 
+/* ------------------------------------------------------------------------- *
+ * Spec-doc dependency paths (issue #1298)
+ * ------------------------------------------------------------------------- */
+
+/**
+ * The same defect as (2) above, one file over: `validate-spec-deps.ts` checks
+ * that a spec doc's mandatory `## External dependencies` section EXISTS and is
+ * populated, and never that the paths in it RESOLVE. Measured against four real
+ * refs (release-1.10.0, release-1.11.2, release-1.12.0, main), 42 distinct paths
+ * across 35 files resolved on NONE of them — 17 in the pre-`lfx` tree, gone since
+ * *feat: introduce lfx package* (#9133, 2025-09-02); ~20 under `src/frontend/`
+ * whose directory was reorganised; 7 missing the real `src/lfx/src/lfx/` prefix.
+ *
+ * The cost is not only a dead end for a reviewer. `scripts/impacted-tests.ts`
+ * maps a changed Langflow path to the specs whose docs name it, by PREFIX — so a
+ * path that resolves to nothing makes that spec unselectable by
+ * `adaptive-impacted.yml`. A wrong path there is silent in exactly the way a
+ * missing one is.
+ *
+ * WHY THIS LIVES HERE, AND WHY IT RESOLVES VIA `git ls-tree`
+ *
+ * The resolution machinery — an upstream checkout plus a fail-closed verdict over
+ * it — is what `--mode=check` already is (#1092), so the check extends this
+ * script rather than growing a second copy inside `validate-spec-deps.ts`.
+ *
+ * It reads the tree with `git ls-tree` instead of `fs.existsSync`, which is what
+ * lets it run on a lane that has no upstream working tree: a
+ * `--filter=blob:none --depth 1 --no-checkout` clone of langflow is 520 KB and
+ * 1.6 s (measured), while materialising the files is ~117 MB. `--mode=check`
+ * still needs the working tree for its `lfx` subtree scan, so the two modes read
+ * the checkout differently on purpose.
+ */
+export const DOC_DEPS_HEADER_RE = /^##\s+External dependencies(\s+\*\(required\)\*)?\s*$/;
+const DOC_DEPS_SECTION_END_RE = /^(##\s+|---\s*)$/;
+
+/**
+ * Docs whose dependency bullets are illustrative by design. The template's whole
+ * job is to show the SHAPE of the section, so `src/frontend/...` there is content,
+ * not a defect. Kept as an explicit allowlist rather than a heuristic, because
+ * "looks like a placeholder" is exactly the judgement that let 10 real ellipses
+ * pass unverified.
+ */
+export const DOC_DEPS_EXEMPT_FILES = ["docs/TEST-SPEC-TEMPLATE.md"];
+
+/**
+ * Every backticked `src/…` token inside the section — not just the leading one.
+ *
+ * A bullet routinely names a second file mid-sentence, and a multi-file
+ * dependency is written as continuation lines; checking only the first token per
+ * bullet (what `impacted-tests.ts` consumes) would leave those unverified, which
+ * is the silence this guard exists to remove.
+ *
+ * @param {string} markdown
+ * @returns {Array<{token: string, line: number}>}
+ */
+export function parseDocDeps(markdown) {
+  const out = [];
+  const lines = String(markdown).split("\n");
+  let inSection = false;
+
+  lines.forEach((line, index) => {
+    if (!inSection) {
+      if (DOC_DEPS_HEADER_RE.test(line)) inSection = true;
+      return;
+    }
+    if (DOC_DEPS_SECTION_END_RE.test(line)) {
+      inSection = false;
+      return;
+    }
+    for (const match of line.matchAll(/`([^`]+)`/g)) {
+      const token = match[1].trim();
+      if (token.startsWith("src/")) out.push({ token, line: index + 1 });
+    }
+  });
+
+  return out;
+}
+
+/**
+ * What kind of thing a dependency token is, and what should be resolved for it.
+ *
+ * - `literal` — a path. A trailing `:70-78` line range is informative and is
+ *   stripped before resolving; a trailing slash is cosmetic.
+ * - `glob` — contains `*`. Resolvable: it must match at least one tree entry.
+ * - `ellipsis` — contains `...` or `…`. NOT resolvable, by any means, so it is a
+ *   defect rather than a skip: an unevaluated path is unknown, not clean
+ *   (#1012's rule, the same one `runguard` and the lfx scan apply).
+ *
+ * @param {string} token
+ * @returns {{kind: "literal"|"glob"|"ellipsis", target: string}}
+ */
+export function classifyDepToken(token) {
+  const target = String(token).replace(/:\d+(?:-\d+)?$/, "").replace(/\/+$/, "");
+  if (/\.\.\.|…/.test(target)) return { kind: "ellipsis", target };
+  if (target.includes("*")) return { kind: "glob", target };
+  return { kind: "literal", target };
+}
+
+/**
+ * Anchored glob match over tree entries. `**` crosses directories, `*` does not,
+ * which is how the three surviving `pages/MainPage/**`-style entries are meant to
+ * read.
+ *
+ * @param {string} pattern
+ * @param {string[]} treeEntries
+ * @returns {string[]} matches (empty means the pattern resolves to nothing)
+ */
+export function matchGlob(pattern, treeEntries) {
+  const source = pattern
+    .split(/(\*\*|\*)/)
+    .map((part) => {
+      if (part === "**") return ".*";
+      if (part === "*") return "[^/]*";
+      return part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    })
+    .join("");
+  const re = new RegExp(`^${source}$`);
+  return treeEntries.filter((entry) => re.test(entry));
+}
+
+/**
+ * The verdict, over already-read docs so it is testable without a checkout.
+ *
+ * Severity follows the coverage-first trade (#980): a path the PR itself touched
+ * FAILS, everything else is reported. One upstream rename must not redden every
+ * PR that edits an unrelated doc — but it must not be invisible either, so the
+ * pre-existing half is announced, never dropped (#1012).
+ *
+ * @param {{
+ *   docs: Array<{file: string, markdown: string}>,
+ *   treeEntries: string[],
+ *   changedFiles?: string[],
+ *   exemptFiles?: string[],
+ * }} options
+ * @returns {{checked: number, failures: Array, warnings: Array, exempt: string[]}}
+ */
+export function checkDocDeps({ docs, treeEntries, changedFiles = [], exemptFiles = DOC_DEPS_EXEMPT_FILES }) {
+  const treeSet = new Set(treeEntries);
+  const changed = new Set(changedFiles);
+  const exemptSet = new Set(exemptFiles);
+  const failures = [];
+  const warnings = [];
+  const exempt = [];
+  let checked = 0;
+
+  for (const doc of docs) {
+    if (exemptSet.has(doc.file)) {
+      exempt.push(doc.file);
+      continue;
+    }
+    for (const { token, line } of parseDocDeps(doc.markdown)) {
+      const { kind, target } = classifyDepToken(token);
+      checked += 1;
+
+      let reason = null;
+      if (kind === "ellipsis") {
+        reason =
+          "contains an ellipsis, so it can never be resolved against upstream — write the real path, or a glob";
+      } else if (kind === "glob") {
+        if (matchGlob(target, treeEntries).length === 0) reason = "glob matches nothing upstream";
+      } else if (!treeSet.has(target)) {
+        reason = "does not exist upstream";
+      }
+      if (!reason) continue;
+
+      const finding = { file: doc.file, line, token, kind, reason };
+      if (changed.has(doc.file)) failures.push(finding);
+      else warnings.push(finding);
+    }
+  }
+
+  return { checked, failures, warnings, exempt };
+}
+
 /**
  * Accepted `--since` windows.
  *
@@ -663,6 +842,96 @@ function runCheck(root) {
   process.stdout.write("All monitored paths exist and every lfx subtree is classified.\n");
 }
 
+/** Every `.md` under `docs/`, plus the top-level README — the files that can carry the section. */
+function collectDocFiles(repoRoot) {
+  const out = [];
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile() && entry.name.endsWith(".md")) out.push(full);
+    }
+  };
+  walk(path.join(repoRoot, "docs"));
+  const readme = path.join(repoRoot, "README.md");
+  if (fs.existsSync(readme)) out.push(readme);
+  return out.map((file) => ({ file: path.relative(repoRoot, file), markdown: fs.readFileSync(file, "utf8") }));
+}
+
+function runCheckDocs(root, ref, changedListPath) {
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+  let treeEntries;
+  try {
+    treeEntries = git(root, ["ls-tree", "-r", "-t", "--name-only", ref]).split("\n").filter(Boolean);
+  } catch (error) {
+    process.stderr.write(
+      `::error::watch-upstream-areas: could not list the upstream tree at "${ref}" in --root "${root}" (${error.message}). Treating as undecidable, not as "every path resolves".\n`,
+    );
+    process.exit(2);
+  }
+  if (treeEntries.length === 0) {
+    process.stderr.write(
+      `::error::watch-upstream-areas: the upstream tree at "${ref}" is empty, so every path would "not exist". Undecidable.\n`,
+    );
+    process.exit(2);
+  }
+
+  // An unreadable changed-file list is undecidable too: defaulting to "nothing
+  // changed" would silently downgrade every finding to a warning, which is the
+  // same fail-open the guard exists to remove.
+  let changedFiles = [];
+  if (changedListPath) {
+    try {
+      changedFiles = fs
+        .readFileSync(changedListPath, "utf8")
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean);
+    } catch (error) {
+      process.stderr.write(
+        `::error::watch-upstream-areas: could not read --changed "${changedListPath}" (${error.message}). Refusing to report a diff-scoped verdict without the diff.\n`,
+      );
+      process.exit(2);
+    }
+  }
+
+  const docs = collectDocFiles(repoRoot);
+  const { checked, failures, warnings, exempt } = checkDocDeps({ docs, treeEntries, changedFiles });
+
+  process.stdout.write(
+    `Resolved ${checked} dependency path(s) from ${docs.length - exempt.length} doc(s) against ${ref} (${treeEntries.length} tree entries); ${exempt.length} doc(s) exempt.\n`,
+  );
+  if (!changedListPath) {
+    process.stdout.write(
+      "No --changed list given, so every finding is reported and none fails: the diff decides severity.\n",
+    );
+  }
+
+  for (const w of warnings) {
+    process.stderr.write(
+      `::warning::${w.file}:${w.line} — dependency path \`${w.token}\` ${w.reason}. Pre-existing (this PR did not touch the doc), so it is reported, not failed.\n`,
+    );
+  }
+  for (const f of failures) {
+    process.stderr.write(
+      `::error::${f.file}:${f.line} — dependency path \`${f.token}\` ${f.reason}. This PR changed the doc, so the path must resolve upstream (issue #1298).\n`,
+    );
+  }
+
+  if (failures.length > 0) {
+    process.stderr.write(
+      `::error::${failures.length} dependency path(s) in doc(s) this PR changed do not resolve upstream.\n`,
+    );
+    process.exit(1);
+  }
+  process.stdout.write(
+    warnings.length > 0
+      ? `No unresolved dependency path in the changed docs; ${warnings.length} pre-existing one(s) reported above.\n`
+      : "Every dependency path resolves upstream.\n",
+  );
+}
+
 function runDetect(root, since) {
   let changed;
   let window;
@@ -728,8 +997,8 @@ function renderAreaTable() {
 
 /** `--flag value` and `--flag=value` both work — the mixed forms bit a reviewer. */
 export function parseArgs(args) {
-  const opts = { mode: "check", root: ".", since: "24 hours ago" };
-  const KEYS = new Set(["mode", "root", "since"]);
+  const opts = { mode: "check", root: ".", since: "24 hours ago", ref: "HEAD", changed: "" };
+  const KEYS = new Set(["mode", "root", "since", "ref", "changed"]);
   for (let i = 0; i < args.length; i += 1) {
     const a = args[i];
     const match = /^--([a-z]+)(?:=(.*))?$/.exec(a);
@@ -749,13 +1018,13 @@ function main(argv) {
     process.stderr.write(`::error::watch-upstream-areas: ${error.message}\n`);
     process.exit(2);
   }
-  const { mode, root, since } = opts;
+  const { mode, root, since, ref, changed } = opts;
 
   if (mode === "areas") {
     process.stdout.write(`${renderAreaTable()}\n`);
     return;
   }
-  if (mode !== "check" && mode !== "detect") {
+  if (mode !== "check" && mode !== "detect" && mode !== "check-docs") {
     process.stderr.write(`::error::watch-upstream-areas: unknown mode "${mode}"\n`);
     process.exit(2);
   }
@@ -776,7 +1045,9 @@ function main(argv) {
   }
 
   try {
-    return mode === "check" ? runCheck(root) : runDetect(root, since);
+    if (mode === "check") return runCheck(root);
+    if (mode === "check-docs") return runCheckDocs(root, ref, changed);
+    return runDetect(root, since);
   } catch (error) {
     // Includes the fail-closed throw from findLfxDrift and a bad area name in
     // buildAreas — both mean the table no longer describes the checkout.

--- a/scripts/watch-upstream-areas.test.mjs
+++ b/scripts/watch-upstream-areas.test.mjs
@@ -17,6 +17,7 @@ import { spawnSync } from "node:child_process";
 import {
   AREAS,
   BODY_DELIMITER,
+  DOC_DEPS_EXEMPT_FILES,
   assertValidSince,
   parseArgs,
   LANGFLOW_AREAS,
@@ -25,9 +26,13 @@ import {
   MAX_COMMITS_PER_AREA,
   PARTIAL,
   buildAreas,
+  checkDocDeps,
+  classifyDepToken,
   detectChangedAreas,
   findLfxDrift,
   findMissingPaths,
+  matchGlob,
+  parseDocDeps,
   renderIssueBody,
 } from "./watch-upstream-areas.mjs";
 
@@ -316,6 +321,17 @@ test("parseArgs accepts both --flag value and --flag=value", () => {
     mode: "detect",
     root: "up",
     since: "2026-07-15",
+    ref: "HEAD",
+    changed: "",
+  });
+  // check-docs adds two flags; `--changed` defaults to empty, which is what makes
+  // the diff-scoped severity opt-in rather than silently absent (#1298).
+  assert.deepEqual(parseArgs(["--mode=check-docs", "--ref", "origin/main", "--changed=list.txt"]), {
+    mode: "check-docs",
+    root: ".",
+    since: "24 hours ago",
+    ref: "origin/main",
+    changed: "list.txt",
   });
   assert.throws(() => parseArgs(["--nope"]), /unknown argument --nope/);
   assert.throws(() => parseArgs(["--root"]), /--root needs a value/);
@@ -403,4 +419,177 @@ test("a symlinked lfx subtree is classified, not skipped", () => {
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
+});
+
+// ---------- spec-doc dependency paths (issue #1298) ----------
+//
+// The unit lane has no upstream clone, so these pin the DECISION rules over an
+// injected tree. What they cannot prove — that the repo's 423 real paths resolve
+// against upstream — is proven by running `--mode=check-docs` against a clone;
+// see the run recorded in the PR. The last two tests below are over the real
+// docs and need no clone.
+
+const DOC = (markdown, file = "docs/area/thing.md") => ({ file, markdown });
+const SECTION = (...bullets) => ["## External dependencies", "", ...bullets, "", "---"].join("\n");
+
+test("parseDocDeps takes every src/ token in the section, not just the leading one", () => {
+  const deps = parseDocDeps(
+    [
+      "# Title",
+      "",
+      "- `src/before/section.py` — outside the section, must be ignored",
+      "",
+      "## External dependencies *(required)*",
+      "",
+      "- `src/one.py` — leading token, plus `src/two.py` named mid-sentence",
+      "  `src/three.py` — a continuation line",
+      "- `tests/helpers/local.ts` — ours, not upstream",
+      "",
+      "---",
+      "",
+      "- `src/after/section.py` — after the section ends",
+    ].join("\n"),
+  );
+
+  assert.deepEqual(
+    deps.map((d) => d.token),
+    ["src/one.py", "src/two.py", "src/three.py"],
+  );
+  assert.equal(deps[0].line, 7);
+});
+
+test("classifyDepToken strips a line range and a trailing slash, and names the three kinds", () => {
+  assert.deepEqual(classifyDepToken("src/lfx/src/lfx/components/input_output/chat.py:70-78"), {
+    kind: "literal",
+    target: "src/lfx/src/lfx/components/input_output/chat.py",
+  });
+  assert.deepEqual(classifyDepToken("src/frontend/src/pages/MainPage/"), {
+    kind: "literal",
+    target: "src/frontend/src/pages/MainPage",
+  });
+  assert.equal(classifyDepToken("src/frontend/src/pages/MainPage/**").kind, "glob");
+  assert.equal(classifyDepToken("src/backend/base/langflow/api/.../variables").kind, "ellipsis");
+  // The unicode ellipsis is the same defect as three dots and was used in 3 docs.
+  assert.equal(classifyDepToken("src/frontend/src/…/flowSettings").kind, "ellipsis");
+});
+
+test("matchGlob lets ** cross directories and keeps * inside one segment", () => {
+  const tree = ["src/a/b", "src/a/b/c.tsx", "src/a/d.tsx", "src/other.tsx"];
+  assert.deepEqual(matchGlob("src/a/**", tree), ["src/a/b", "src/a/b/c.tsx", "src/a/d.tsx"]);
+  // If `*` crossed `/`, a dead path like `src/a/*` would match a nested file and
+  // pass — the silence this guard removes.
+  assert.deepEqual(matchGlob("src/a/*", tree), ["src/a/b", "src/a/d.tsx"]);
+  assert.deepEqual(matchGlob("src/gone/**", tree), []);
+});
+
+test("checkDocDeps fails a path in a doc the PR changed and warns on a pre-existing one", () => {
+  const docs = [
+    DOC(SECTION("- `src/gone.py` — moved upstream"), "docs/area/touched.md"),
+    DOC(SECTION("- `src/gone.py` — moved upstream"), "docs/area/untouched.md"),
+  ];
+  const verdict = checkDocDeps({
+    docs,
+    treeEntries: ["src/here.py"],
+    changedFiles: ["docs/area/touched.md"],
+  });
+
+  assert.equal(verdict.checked, 2);
+  assert.deepEqual(
+    verdict.failures.map((f) => f.file),
+    ["docs/area/touched.md"],
+  );
+  assert.deepEqual(
+    verdict.warnings.map((w) => w.file),
+    ["docs/area/untouched.md"],
+  );
+});
+
+test("checkDocDeps treats an ellipsis as a defect, not as a path it cannot judge", () => {
+  const verdict = checkDocDeps({
+    docs: [DOC(SECTION("- `src/frontend/src/.../playground` — the chat input"), "docs/area/touched.md")],
+    // Even with the real directory present, the token itself is unresolvable.
+    treeEntries: ["src/frontend/src/components/core/playgroundComponent"],
+    changedFiles: ["docs/area/touched.md"],
+  });
+
+  assert.equal(verdict.failures.length, 1);
+  assert.equal(verdict.failures[0].kind, "ellipsis");
+});
+
+test("checkDocDeps accepts a resolving glob and a path carrying a line range", () => {
+  const verdict = checkDocDeps({
+    docs: [
+      DOC(
+        SECTION(
+          "- `src/frontend/src/pages/LoginPage/**` — the login page",
+          "- `src/lfx/chat.py:70-78` — the FileInput block",
+        ),
+        "docs/area/touched.md",
+      ),
+    ],
+    treeEntries: ["src/frontend/src/pages/LoginPage", "src/frontend/src/pages/LoginPage/index.tsx", "src/lfx/chat.py"],
+    changedFiles: ["docs/area/touched.md"],
+  });
+
+  assert.deepEqual(verdict.failures, []);
+  assert.deepEqual(verdict.warnings, []);
+  assert.equal(verdict.checked, 2);
+});
+
+test("checkDocDeps skips an exempt doc entirely and reports that it did", () => {
+  const verdict = checkDocDeps({
+    docs: [DOC(SECTION("- `src/backend/...` — placeholder by design"), "docs/TEST-SPEC-TEMPLATE.md")],
+    treeEntries: ["src/backend"],
+    changedFiles: ["docs/TEST-SPEC-TEMPLATE.md"],
+  });
+
+  assert.equal(verdict.checked, 0);
+  assert.deepEqual(verdict.exempt, ["docs/TEST-SPEC-TEMPLATE.md"]);
+  assert.deepEqual(verdict.failures, []);
+});
+
+test("no real doc outside the allowlist carries an unresolvable ellipsis dependency", () => {
+  // Pins the #1298 sweep: 10 entries were written as `src/frontend/src/.../x`,
+  // which no ref can confirm or refute. This costs no clone, so it runs in the
+  // PR unit lane and catches the style coming back.
+  const offenders = [];
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile() && entry.name.endsWith(".md")) {
+        const rel = path.relative(REPO_ROOT, full);
+        if (DOC_DEPS_EXEMPT_FILES.includes(rel)) continue;
+        for (const dep of parseDocDeps(fs.readFileSync(full, "utf8"))) {
+          if (classifyDepToken(dep.token).kind === "ellipsis") offenders.push(`${rel}:${dep.line} ${dep.token}`);
+        }
+      }
+    }
+  };
+  walk(path.join(REPO_ROOT, "docs"));
+
+  assert.deepEqual(offenders, []);
+});
+
+test("every exempt doc exists, so the allowlist cannot rot into a blanket skip", () => {
+  for (const rel of DOC_DEPS_EXEMPT_FILES) {
+    assert.ok(fs.existsSync(path.join(REPO_ROOT, rel)), `${rel} is exempt but does not exist`);
+  }
+});
+
+test("pr-validation.yml runs the doc-deps guard with a diff list and a real upstream ref", () => {
+  // Presence wiring, not behaviour: the behaviour is pinned by checkDocDeps above.
+  // #1226's lesson is that a regex over YAML cannot prove a verdict is right —
+  // but the guard reaching the lane at all is exactly what a regex can prove, and
+  // a mode nobody invokes is how #1092's watcher ended up with no run history.
+  const yml = fs.readFileSync(path.join(REPO_ROOT, ".github/workflows/pr-validation.yml"), "utf8");
+  assert.match(yml, /watch-upstream-areas\.mjs \\\n\s+--mode=check-docs/);
+  // Without --changed the verdict cannot fail anything, so the flag IS the gate.
+  assert.match(yml, /--changed changed-docs\.txt/);
+  assert.match(yml, /--ref origin\/main/);
+  // A blobless, no-checkout clone is what makes the ls-tree resolver affordable
+  // here; a plain clone would pull ~117 MB per PR.
+  assert.match(yml, /git clone --filter=blob:none --depth 1 --no-checkout/);
+  // The clone must not fail open: no tree means no verdict, which is not a pass.
+  assert.match(yml, /::error::could not clone langflow-ai\/langflow/);
 });


### PR DESCRIPTION
Closes #1298. Follow-up split out of #1040.

## What the sweep measured

Every backticked `src/…` token inside `## External dependencies`, resolved against four real upstream refs (`release-1.10.0`, `release-1.11.2`, `release-1.12.0`, `main`):

| Class | Count |
|---|---|
| resolve on ≥1 ref | 342 |
| **resolve on NO ref** | **51 occurrences / 42 unique / 35 files** |
| ellipsis-shaped (`...`, `…`) — unresolvable by any means | 10 |
| glob-shaped (`**`, `mcp*`) | 5 |
| present only on an older ref | 1 |

The issue names 20 across two classes. Three more turned up: ~20 reorganised `src/frontend/` paths, 7 missing the real `src/lfx/src/lfx/` prefix, and the `components/agents/agent.py` that #1040 recorded as already fixed (still dead on all four refs — it moved to `models_and_agents/`).

**Why the count matters beyond a reviewer's dead end:** `scripts/impacted-tests.ts` maps a changed Langflow path to the specs whose docs name it, by prefix. A path that resolves to nothing makes that spec unselectable by `adaptive-impacted.yml`. A wrong path there is silent in exactly the way a missing one is.

## How each path was resolved

By its current **owner**, not by name similarity — the testid named in the bullet, grepped in a sparse checkout of upstream `main`:

| Bullet claims | Old path | Resolved to |
|---|---|---|
| `code-button-modal`, `animate-pulse-pink` | `CustomNodes/GenericNode/components/NodeStatus/CodeButton/index.tsx` | `pages/FlowPage/components/nodeToolbarComponent/index.tsx` |
| `sidebar-custom-component-button` | `flowSidebarComponent/components/sidebarHeaderComponent/index.tsx` | `flowSidebarComponent/components/sidebarFooterButtons.tsx` |
| `project-sidebar`, `sidebar-nav-*` | `pages/MainPage/components/myCollectionComponent/` | `components/core/folderSidebarComponent/` |
| `button_open_prompt_modal` | `…/parameterRenderComponent/components/promptAreaComponent/` | `components/core/parameterRenderComponent/components/promptComponent/` |
| `data_sourceURL` sidebar testid | `…/sidebarComponent/sideBarItem/index.tsx` | `flowSidebarComponent/components/sidebarDraggableComponent.tsx` (`data-testid={sectionName + display_name}`) |
| `show${name}` toggle | `InspectionPanel/components/InspectionPanelEditField.tsx` | `…/tableComponent/components/tableAdvancedToggleCellRender/index.tsx` (`id={"show" + parameterId}`) |
| `flow_name` header | `components/headerComponent/` | `components/core/appHeaderComponent/components/FlowMenu/` |
| `lock-flow-switch` / `save-flow-settings` | `src/frontend/src/…/flowSettings` | `editFlowSettingsComponent/` + `flowSettingsComponent/` (two bullets) |

All 58 replacement paths were verified present in `main`'s tree before the edit landed. The remaining pattern entries were expanded (`src/frontend/src/.../mcpServerTab` → the real `McpServerTab.tsx`) or kept as resolvable globs (`pages/MainPage/**`).

## The guard

Extends `watch-upstream-areas.mjs` as **`--mode=check-docs`**, per the issue, rather than duplicating the resolution machinery in `validate-spec-deps.ts`.

It resolves via **`git ls-tree`**, not `fs.existsSync`. That is what lets it run on a lane with no upstream working tree: a `--filter=blob:none --depth 1 --no-checkout` clone of langflow is **520 KB / 1.6 s** measured, against ~117 MB to materialise the files. `--mode=check` still needs the working tree for its `lfx` subtree scan, so the two modes read the checkout differently on purpose.

Rules, each one a decision the issue left open:

- **Severity follows the diff** (#980's coverage-first trade): a path in a doc **this PR changed** fails; a pre-existing one is a `::warning::`. One upstream rename cannot redden every PR that edits an unrelated doc — and cannot be invisible either (#1012).
- **An ellipsis is a defect, not a skip.** `src/frontend/src/.../playground` can never be confirmed or refuted, and "unevaluated" is not "clean" — the same rule `runguard` and the lfx scan apply. Globs *are* resolved: `**` crosses directories, `*` does not, so a dead `pages/*` cannot pass by matching a nested file.
- **Undecidable exits 2, never 0.** An unreadable tree, an empty tree, or an unreadable `--changed` list all refuse to report a verdict instead of degrading to "every path resolves".
- **`docs/TEST-SPEC-TEMPLATE.md` is exempt by allowlist** — its placeholders are the content. A unit test asserts every exempt file exists, so the allowlist cannot rot into a blanket skip.

### Where it runs, and why not `file-watcher`

The issue suggested extending `--mode=check`, which lives in `file-watcher.yml`. That workflow is `disabled_manually` **and** has no cron, so a guard placed only there would never run once. It goes into `pr-validation.yml` as the `doc-deps-guard` job instead.

## Evidence

| Check | Result |
|---|---|
| paths resolving on no ref | **42 → 0** (423 paths, 222 docs, 1 exempt) |
| mapping targets present on `main` | 58/58 |
| `npm run test:scripts` | 686 pass / 0 fail |
| `npm run test:units` | 429 pass / 0 fail |
| `npm run typecheck` / `npm run lint` | clean / 0 errors |
| QA-CHECKLIST guard + coverage guard | both green |
| force-fail: dead path in a changed doc | **exit 1**, `::error::` naming file:line |
| same path in an unchanged doc | exit 0 + `::warning::` |
| mutations caught | 3/3 — `*` crossing `/`; ellipsis downgraded to a skip; every finding downgraded to a warning |

The job YAML cannot run locally; all three of its steps were rehearsed with identical commands (clone, 45-file diff list, exit 0). Its final proof is this PR's own **Spec-doc dependency paths** job.

No `.spec.ts` was touched, so no flow cleanup applies.

## Reproduce

```bash
git clone --filter=blob:none --depth 1 --no-checkout \
  https://github.com/langflow-ai/langflow.git /tmp/langflow-upstream

# repo-wide verdict — expect "Every dependency path resolves upstream", exit 0
node scripts/watch-upstream-areas.mjs --mode=check-docs \
  --root /tmp/langflow-upstream --ref origin/main

# diff-scoped, as the lane runs it — expect exit 0
git diff --name-only --diff-filter=d origin/main...HEAD -- docs README.md \
  | grep -E '\.md$' > /tmp/changed-docs.txt
node scripts/watch-upstream-areas.mjs --mode=check-docs \
  --root /tmp/langflow-upstream --ref origin/main --changed /tmp/changed-docs.txt

# force-fail — expect exit 1
printf -- '- `src/frontend/src/gone.tsx` — probe\n' >> docs/ui-ux/minimize.md
node scripts/watch-upstream-areas.mjs --mode=check-docs \
  --root /tmp/langflow-upstream --ref origin/main --changed /tmp/changed-docs.txt
git checkout -- docs/ui-ux/minimize.md

npm run test:scripts   # 686 pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
