### PR TITLE
fix(agents): settle the #751 guard on the provider, not on api_key (#1274)

### DIFF
--- a/tests/helpers/flows/agent-credential-settle.test.ts
+++ b/tests/helpers/flows/agent-credential-settle.test.ts
@@ -526,26 +526,33 @@ test("#1274 no verdict claims a check that did not run, for any caller", () => {
   }
 });
 
-test("#1274 the message says the empty api_key is not the finding", () => {
-  // Every reader of this message arrives knowing the pre-#14311 behaviour, and the
-  // observed line still prints `api_key=""`. Without this note the empty field
-  // reads as the defect — which is how the 2026-08-05 daily's 14 failures were
-  // first triaged as a product regression.
+test("#1274 the note says api_key is not asserted — without claiming it is empty", () => {
+  // Every reader arrives knowing the pre-#14311 behaviour, and the observed line
+  // still prints an api_key. Without a note the field reads as the defect, which is
+  // how the 2026-08-05 daily's failures were first triaged as a product regression.
+  //
+  // Asserted on the INTENT, not on a phrase about the value: `manual.yml` can
+  // dispatch a pre-#14311 build where api_key IS written, and a note claiming it is
+  // empty on "every build" would contradict the observed line above it. Pinning the
+  // phrase is what let that false claim ship (caught in review of this PR).
   const message = failure();
-  assert.ok(message.includes("api_key is EMPTY"), message);
-  assert.ok(message.includes("#14311"), message);
+  assert.ok(message.includes("NOT asserted in either direction"), message);
   assert.ok(message.includes("#1274"), message);
+  assert.ok(
+    !/api_key is EMPTY on every build/.test(message),
+    "the note must not claim the field is empty on builds where it is written:\n" + message,
+  );
 });
 
 test("#1274 the api_key note is printed only when an api_key was observed", () => {
   // Review caught it printing unconditionally, including for read-failed, where no
   // api_key was seen — the same unobserved-claim defect this module exists to avoid.
   const observed = failure();
-  assert.ok(observed.includes("api_key is EMPTY"), observed);
+  assert.ok(observed.includes("api_key is NOT asserted"), observed);
   for (const verdict of ["read-failed", "no-agent-node"] as const) {
     const message = failure({ probe: null, verdict, reads: 0 });
     assert.ok(
-      !message.includes("api_key is EMPTY"),
+      !message.includes("api_key is NOT asserted"),
       `${verdict} observed no api_key, so it must not comment on one:\n${message}`,
     );
   }

--- a/tests/helpers/flows/agent-credential-settle.test.ts
+++ b/tests/helpers/flows/agent-credential-settle.test.ts
@@ -17,12 +17,18 @@
 //     distinction became unreachable — while the tests passed, because the fixture
 //     used a string too. Every fixture below therefore uses the real shape, and
 //     `MODEL_VALUE_SHAPE` documents where it is verified in the product.
-//  2. **The verdict distinctions.** Several states produce the same "wrong
-//     credential" observation and they send a reader to opposite places: a lagging
-//     autosave, a model click that never registered, a credential that matches only
-//     because it is the selector's default, and a read that never succeeded. A
+//  2. **The verdict distinctions.** Several states produce the same "not the
+//     provider I asked for" observation and they send a reader to opposite places: a
+//     lagging autosave, a model click that never registered, a provider that matches
+//     only because it is the selector's default, and a read that never succeeded. A
 //     classifier that collapses any of those silently re-creates the mis-triage,
 //     and no Playwright spec would fail for it.
+//  3. **The axis itself (#1274).** The guard settles on the PROVIDER of the
+//     persisted model, not on `api_key` — upstream #14311 stopped writing that
+//     field, so a classifier that consults it can only ever refuse to settle, which
+//     is how 14 `@stable` specs failed on the 2026-08-05 daily. Tests below pin both
+//     directions: an empty api_key must not block settling, and a stale one must not
+//     either.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
@@ -82,12 +88,15 @@ test("the fixture itself uses the real array-of-objects shape", () => {
   assert.equal(value[0]?.name, "gpt-4o-mini");
 });
 
-test("reads the credential and the SELECTED model names off the real shape", () => {
+test("reads the provider, the SELECTED model names and the credential off the real shape", () => {
   const probe = readAgentCredentialProbe(
     flowWithAgent("OPENAI_API_KEY", MODEL_VALUE_SHAPE("gpt-4o-mini")),
   );
   assert.deepEqual(probe, {
     credential: "OPENAI_API_KEY",
+    // The axis #1274 moved the guard onto — it comes off the SAME entry as the
+    // model name, so a payload that carries one carries the other.
+    selectedProviders: ["OpenAI"],
     selectedModels: ["gpt-4o-mini"],
   });
 });
@@ -149,92 +158,145 @@ test("a non-string api_key reads as empty, not as the raw object", () => {
 
 // ─── classifyCredentialSettle — the distinctions that matter ─────────────────
 
-const probeOf = (credential: string, models: string[]): AgentCredentialProbe => ({
+const probeOf = (
+  providers: string[],
+  models: string[],
+  credential = "",
+): AgentCredentialProbe => ({
   credential,
+  selectedProviders: providers,
   selectedModels: models,
 });
 
-test("credential and model both applied is settled", () => {
+// Langflow's own spelling, measured on 1.12.0.dev16 — NOT this repo's Provider key.
+const GOOGLE = "Google Generative AI";
+const ANTHROPIC = "Anthropic";
+const OPENAI = "OpenAI";
+
+test("provider and model both applied is settled", () => {
+  assert.equal(
+    classifyCredentialSettle(probeOf([GOOGLE], ["gemini-2.5-flash"]), GOOGLE, "gemini-2.5-flash"),
+    "settled",
+  );
+});
+
+test("#1274 an empty api_key does NOT prevent settling — it is not an axis", () => {
+  // The regression this issue is: since #14311 `api_key` reads "" on every build,
+  // so any classification that consulted it could only ever refuse to settle.
+  // 14 @stable specs failed the guard on the 2026-08-05 daily for exactly this.
   assert.equal(
     classifyCredentialSettle(
-      probeOf("GOOGLE_API_KEY", ["gemini-2.5-flash"]),
-      "GOOGLE_API_KEY",
+      probeOf([GOOGLE], ["gemini-2.5-flash"], ""),
+      GOOGLE,
       "gemini-2.5-flash",
     ),
     "settled",
   );
 });
 
-test("the anthropic default binding alone is model-pending, NOT settled", () => {
-  // The vacuity #1072 found: for `provider: "anthropic"` the expected credential
-  // IS the selector's default auto-binding, so a credential-only check declared
-  // the load settled before the model selection had been applied at all.
+test("#1274 a stale api_key does not prevent settling either", () => {
+  // The mirror case: on a pre-#14311 build the field can still carry a value, and
+  // for a google load that value may be the mount-time ANTHROPIC default. The
+  // guard must not read that as unsettled once the provider is right, or it would
+  // swap one dated premise for another.
   assert.equal(
     classifyCredentialSettle(
-      probeOf("ANTHROPIC_API_KEY", []),
-      "ANTHROPIC_API_KEY",
-      "claude-sonnet-5",
+      probeOf([GOOGLE], ["gemini-2.5-flash"], "ANTHROPIC_API_KEY"),
+      GOOGLE,
+      "gemini-2.5-flash",
     ),
-    "model-pending",
+    "settled",
   );
 });
 
-test("model applied but credential still on the default is credential-pending", () => {
-  // The 2026-07-27 daily flake, exactly: a google target observing the default
-  // ANTHROPIC binding while the requested Gemini model IS already selected.
+test("the mount-time default provider is provider-pending, NOT settled", () => {
+  // Measured read 0 on 1.12.0.dev16: a freshly mounted node carries
+  // { name: "claude-opus-5", provider: "Anthropic" }. A google caller that settled
+  // here would run Anthropic's model with Anthropic's key — the #744 signature.
   assert.equal(
-    classifyCredentialSettle(
-      probeOf("ANTHROPIC_API_KEY", ["gemini-2.5-flash"]),
-      "GOOGLE_API_KEY",
-      "gemini-2.5-flash",
-    ),
-    "credential-pending",
+    classifyCredentialSettle(probeOf([ANTHROPIC], ["claude-opus-5"]), GOOGLE, "gemini-2.5-flash"),
+    "provider-pending",
   );
 });
 
-test("a different persisted model is model-not-applied", () => {
+test("#1274 an ANTHROPIC caller is not settled by the default binding either", () => {
+  // The vacuity #1072 found, carried onto the new axis: for anthropic the default
+  // provider IS the expected one, so the provider axis alone would settle before
+  // the pick lands. The model axis is what still separates them — which is why
+  // gating on the model when one is pinned is retained rather than dropped.
   assert.equal(
-    classifyCredentialSettle(
-      probeOf("ANTHROPIC_API_KEY", ["claude-sonnet-5"]),
-      "GOOGLE_API_KEY",
-      "gemini-2.5-flash",
-    ),
+    classifyCredentialSettle(probeOf([ANTHROPIC], ["claude-opus-5"]), ANTHROPIC, "claude-sonnet-5"),
+    "model-not-applied",
+  );
+  assert.equal(
+    classifyCredentialSettle(probeOf([ANTHROPIC], ["claude-sonnet-5"]), ANTHROPIC, "claude-sonnet-5"),
+    "settled",
+  );
+});
+
+test("a different model under the RIGHT provider is model-not-applied", () => {
+  assert.equal(
+    classifyCredentialSettle(probeOf([GOOGLE], ["gemini-3.5-pro"]), GOOGLE, "gemini-2.5-flash"),
     "model-not-applied",
   );
 });
 
-test("no persisted model at all is nothing-persisted", () => {
+test("no persisted model or provider at all is nothing-persisted", () => {
   assert.equal(
-    classifyCredentialSettle(
-      probeOf("ANTHROPIC_API_KEY", []),
-      "OPENAI_API_KEY",
-      "gpt-4o-mini",
-    ),
+    classifyCredentialSettle(probeOf([], []), OPENAI, "gpt-4o-mini"),
     "nothing-persisted",
   );
 });
 
-test("without an expected model only the credential axis is available", () => {
-  // A caller that lets the setup helper pick the first model has no name to
-  // compare, so the model axis must not manufacture a verdict.
+test("nothing-persisted is decided BEFORE the provider axis", () => {
+  // Order matters: an empty model list also has an empty provider list, so testing
+  // the provider first would report "a different provider is persisted" about a
+  // node carrying none — a claim about something nobody observed.
+  assert.equal(classifyCredentialSettle(probeOf([], []), GOOGLE), "nothing-persisted");
+});
+
+test("#1274 a caller that pins NO model still blocks on a real transition", () => {
+  // This is what the credential axis could no longer do. `api_key` is "" both
+  // before and after the pick, so these three specs
+  // (model-provider-model-toggle, general-bugs-agent-images-playground,
+  // agent-model-connection-isolation) would have settled on the first read and
+  // proved nothing. The provider is always known, so they still gate.
   assert.equal(
-    classifyCredentialSettle(probeOf("OPENAI_API_KEY", []), "OPENAI_API_KEY"),
-    "settled",
+    classifyCredentialSettle(probeOf([ANTHROPIC], ["claude-opus-5"]), OPENAI),
+    "provider-pending",
+    "the mount-time default must not settle an openai caller",
   );
   assert.equal(
-    classifyCredentialSettle(
-      probeOf("ANTHROPIC_API_KEY", ["claude-sonnet-5"]),
-      "OPENAI_API_KEY",
-    ),
-    "credential-pending",
+    classifyCredentialSettle(probeOf([OPENAI], ["gpt-4o-mini"]), OPENAI),
+    "settled",
   );
 });
 
-test("a missing Agent node is its own verdict, not a pending credential", () => {
+test("#1274 a keyless provider is a positive assertion, not an empty-string match", () => {
+  // #1187 had to lean on the caller passing a model, because for Ollama the settled
+  // credential ("") equalled the pre-selection state. `provider: "Ollama"` is
+  // observable in its own right.
   assert.equal(
-    classifyCredentialSettle(null, "OPENAI_API_KEY", "gpt-4o-mini"),
-    "no-agent-node",
+    classifyCredentialSettle(probeOf([ANTHROPIC], ["claude-opus-5"]), "Ollama"),
+    "provider-pending",
   );
+  assert.equal(
+    classifyCredentialSettle(probeOf(["Ollama"], ["llama3.1:latest"]), "Ollama"),
+    "settled",
+  );
+});
+
+test("a provider with no observable model name is model-pending, not model-not-applied", () => {
+  // Degenerate payload: an entry carrying `provider` and no `name`. There is no
+  // other model to name, so the sharper verdict would assert something unobserved.
+  assert.equal(
+    classifyCredentialSettle(probeOf([GOOGLE], []), GOOGLE, "gemini-2.5-flash"),
+    "model-pending",
+  );
+});
+
+test("a missing Agent node is its own verdict, not a pending provider", () => {
+  assert.equal(classifyCredentialSettle(null, OPENAI, "gpt-4o-mini"), "no-agent-node");
 });
 
 // ─── formatCredentialSettleFailure ───────────────────────────────────────────
@@ -245,10 +307,10 @@ const failure = (
   formatCredentialSettleFailure({
     flowId: "abc-123",
     provider: "google",
-    expectedCredential: "GOOGLE_API_KEY",
+    expectedProvider: "Google Generative AI",
     expectedModel: "gemini-2.5-flash",
-    probe: probeOf("ANTHROPIC_API_KEY", ["gemini-2.5-flash"]),
-    verdict: "credential-pending",
+    probe: probeOf(["Anthropic"], ["claude-opus-5"]),
+    verdict: "provider-pending",
     elapsedMs: 20_400,
     reads: 14,
     ...over,
@@ -268,14 +330,17 @@ test("the message carries every fact needed to triage without the artifacts", ()
   // `gemini-2.5-flash` appears on two lines, so a plain `includes` could not fail
   // if the "model wanted" line were dropped.
   assert.equal(field(message, "flow"), "abc-123");
-  assert.equal(field(message, "provider"), 'google (expected credential "GOOGLE_API_KEY")');
+  assert.equal(
+    field(message, "provider"),
+    'google (expected "Google Generative AI" on the persisted model)',
+  );
   assert.equal(field(message, "model wanted"), "gemini-2.5-flash");
   assert.equal(
     field(message, "observed"),
-    'api_key="ANTHROPIC_API_KEY" models=[gemini-2.5-flash]',
+    'providers=[Anthropic] models=[claude-opus-5] api_key=""',
   );
   assert.equal(field(message, "waited"), "20.4s over 14 read(s)");
-  assert.equal(field(message, "verdict"), "credential-pending");
+  assert.equal(field(message, "verdict"), "provider-pending");
   // The two issues a reader needs: why the guard exists, where the load relief is.
   assert.ok(message.includes("#751"), message);
   assert.ok(message.includes("#1077"), message);
@@ -288,9 +353,9 @@ test("a caller that chose no model says so on the model line", () => {
   );
 });
 
-test("credential-pending does not wave the failure off as load", () => {
+test("provider-pending does not wave the failure off as load", () => {
   // It prints only AFTER the budget expired, i.e. retrying did not help within it,
-  // and a credential belonging to a THIRD provider is a real misbinding.
+  // and a persisted THIRD provider is a real misbinding rather than slowness.
   const message = failure();
   assert.ok(
     message.includes("retrying did NOT help"),
@@ -305,29 +370,32 @@ test("nothing-persisted points at the request that actually rebinds", () => {
   // request and a wrong conclusion.
   const message = failure({
     verdict: "nothing-persisted",
-    probe: probeOf("ANTHROPIC_API_KEY", []),
+    probe: probeOf([], []),
   });
   assert.ok(message.includes("custom_component/update"), message);
 });
 
-test("model-pending covers BOTH the default-binding and the real-rebind case", () => {
-  // The verdict is reachable two ways and they mean different things: anthropic,
-  // where the credential match is free because it is the selector's default; and
-  // any other provider, where the rebind DID land and only the selection has not.
-  // Guidance that asserts only the first is false half the time it prints.
+test("#1274 provider-pending names BOTH of its causes and how to tell them apart", () => {
+  // Reachable two ways that mean different things: the mount-time DEFAULT provider,
+  // where the pick simply has not been autosaved and waiting is right; and some
+  // THIRD provider, where the setup step clicked wrong and waiting cannot help.
+  // Guidance asserting only one is misleading half the time it prints.
+  const message = failure();
+  assert.ok(message.includes("DEFAULT"), message);
+  assert.ok(message.includes("THIRD"), message);
+  assert.ok(message.includes("#1077"), "the waiting-is-right cause needs the load pointer");
+});
+
+test("#1274 model-pending describes the degenerate payload, not a normal pending state", () => {
   const message = failure({
     verdict: "model-pending",
-    provider: "anthropic",
-    expectedCredential: "ANTHROPIC_API_KEY",
-    expectedModel: "claude-sonnet-5",
-    probe: probeOf("ANTHROPIC_API_KEY", []),
+    probe: probeOf(["Google Generative AI"], []),
   });
-  assert.ok(message.includes("DEFAULT binding"), message);
+  assert.ok(message.includes("degenerate"), message);
   assert.ok(
-    message.includes("any other provider"),
-    "must not assert the default-binding cause for a provider where it is wrong",
+    !message.includes("DIFFERENT model is persisted"),
+    "there is no other model to name here:\n" + message,
   );
-  assert.ok(message.includes("provider setup"), message);
 });
 
 test("a guard that never read the flow reports UNKNOWN, not an absent Agent node", () => {
@@ -362,21 +430,39 @@ test("model-not-applied covers the wedged save path, not only a wrong click", ()
   // reader to the setup helper only would misdirect every wedged load (#1077).
   const message = failure({
     verdict: "model-not-applied",
-    probe: probeOf("ANTHROPIC_API_KEY", ["claude-opus-5"]),
+    expectedProvider: "Google Generative AI",
+    probe: probeOf(["Google Generative AI"], ["gemini-3.5-pro"]),
   });
   assert.ok(message.includes("setup helper"), message);
-  assert.ok(message.includes("prefill"), message);
-  assert.ok(message.includes("#1077"), message);
+  // The wedged-save case MOVED to provider-pending in #1274: a node that kept its
+  // mount-time default carries a different PROVIDER, not merely a different model.
+  // Guidance that still sent this verdict's reader hunting a wedged save would
+  // point at the wrong mechanism.
+  assert.ok(message.includes("provider-pending"), message);
 });
 
-test("credential-pending with NO pinned model does not claim the selection registered", () => {
-  // Reachable from the three specs that call load({ provider }) with no model, and
-  // from any spec whose models.json came back empty. The usual guidance asserts
-  // "the requested model IS applied" — nothing checked that here.
-  const message = failure({ expectedModel: undefined });
-  assert.ok(
-    !message.includes("The requested model IS applied"),
-    "must not assert a check that could not run:\n" + message,
-  );
-  assert.ok(message.includes("pinned no model"), message);
+test("#1274 no verdict claims a check that did not run, for any caller", () => {
+  // The old code needed a per-caller special case: `credential-pending`'s guidance
+  // asserted "the requested model IS applied", which was false for the three
+  // callers that pin no model. The primary axis is now the provider, which every
+  // caller supplies, so one string per verdict is true for all of them — and no
+  // guidance may assert the model axis was consulted.
+  for (const expectedModel of [undefined, "gemini-2.5-flash"]) {
+    const message = failure({ expectedModel });
+    assert.ok(
+      !message.includes("The requested model IS applied"),
+      `must not assert a check that could not run (expectedModel=${expectedModel}):\n${message}`,
+    );
+  }
+});
+
+test("#1274 the message says the empty api_key is not the finding", () => {
+  // Every reader of this message arrives knowing the pre-#14311 behaviour, and the
+  // observed line still prints `api_key=""`. Without this note the empty field
+  // reads as the defect — which is how the 2026-08-05 daily's 14 failures were
+  // first triaged as a product regression.
+  const message = failure();
+  assert.ok(message.includes("api_key is EMPTY"), message);
+  assert.ok(message.includes("#14311"), message);
+  assert.ok(message.includes("#1274"), message);
 });

--- a/tests/helpers/flows/agent-credential-settle.test.ts
+++ b/tests/helpers/flows/agent-credential-settle.test.ts
@@ -26,7 +26,7 @@
 //  3. **The axis itself (#1274).** The guard settles on the PROVIDER of the
 //     persisted model, not on `api_key` — upstream #14311 stopped writing that
 //     field, so a classifier that consults it can only ever refuse to settle, which
-//     is how 14 `@stable` specs failed on the 2026-08-05 daily. Tests below pin both
+//     is how 13 `@stable` specs failed on the 2026-08-05 daily. Tests below pin both
 //     directions: an empty api_key must not block settling, and a stale one must not
 //     either.
 import { test } from "node:test";
@@ -94,11 +94,56 @@ test("reads the provider, the SELECTED model names and the credential off the re
   );
   assert.deepEqual(probe, {
     credential: "OPENAI_API_KEY",
-    // The axis #1274 moved the guard onto — it comes off the SAME entry as the
-    // model name, so a payload that carries one carries the other.
+    // `selected` is what the classifier decides on: the provider and the model name
+    // PAIRED, off the same entry. The two flat arrays below are projections kept for
+    // the diagnostic — comparing them independently is what let a cross-entry
+    // combination classify as settled.
+    selected: [{ name: "gpt-4o-mini", provider: "OpenAI" }],
     selectedProviders: ["OpenAI"],
     selectedModels: ["gpt-4o-mini"],
   });
+});
+
+test("#1274 provider and model must match on the SAME entry", () => {
+  // Proved by review: with two entries each carrying half of the wanted pair, two
+  // independent `includes()` checks classified this as `settled` for
+  // (google, gemini-2.5-flash) — a combination neither entry contains.
+  const crossed = probeOfPairs([
+    ["OpenAI", "gemini-2.5-flash"],
+    ["Google Generative AI", "gpt-4o"],
+  ]);
+  assert.equal(
+    classifyCredentialSettle(crossed, "Google Generative AI", "gemini-2.5-flash"),
+    "model-not-applied",
+    "the google entry carries gpt-4o, not the wanted model",
+  );
+  assert.equal(
+    classifyCredentialSettle(
+      probeOfPairs([["Google Generative AI", "gemini-2.5-flash"]]),
+      "Google Generative AI",
+      "gemini-2.5-flash",
+    ),
+    "settled",
+  );
+});
+
+test("#1274 a model with no provider is unobservable, NOT a wrong provider", () => {
+  // Proved by review: this landed on `provider-pending`, whose guidance tells the
+  // reader to compare "the observed provider" while the diagnostic prints
+  // `providers=[]` — a claim about something never observed.
+  const noProvider = probeOfPairs([["", "gpt-4o-mini"]]);
+  assert.deepEqual(noProvider.selectedProviders, []);
+  assert.equal(classifyCredentialSettle(noProvider, "OpenAI"), "provider-unobservable");
+  const message = formatCredentialSettleFailure({
+    flowId: "f", provider: "openai", expectedProvider: "OpenAI",
+    probe: noProvider, verdict: "provider-unobservable", elapsedMs: 20_000, reads: 9,
+  });
+  assert.ok(message.includes("providers=[]"), message);
+  assert.ok(message.includes("unobservable"), message);
+  assert.ok(
+    !message.includes("A DIFFERENT provider"),
+    "must not claim a wrong provider when none was observed:\n" + message,
+  );
 });
 
 test("an unselected model field reads as no models, not as one empty name", () => {
@@ -158,15 +203,40 @@ test("a non-string api_key reads as empty, not as the raw object", () => {
 
 // ─── classifyCredentialSettle — the distinctions that matter ─────────────────
 
+/**
+ * A probe from PAIRED entries — the shape the classifier decides on.
+ *
+ * Takes `[provider, model]` tuples rather than two parallel arrays on purpose: the
+ * parallel-array helper this replaced could build a probe whose provider and model
+ * came from different entries, which is exactly the combination the classifier used
+ * to accept (and the review proved). A fixture that cannot express the bug is how
+ * the bug survives its own test.
+ */
+const probeOfPairs = (
+  pairs: Array<[provider: string, model: string]>,
+  credential = "",
+): AgentCredentialProbe => {
+  const selected = pairs.map(([provider, name]) => ({ name, provider }));
+  return {
+    credential,
+    selected,
+    selectedProviders: selected.map((e) => e.provider).filter((p) => p.length > 0),
+    selectedModels: selected.map((e) => e.name).filter((n) => n.length > 0),
+  };
+};
+
+/** One provider/model pair — the overwhelmingly common single-select case. */
 const probeOf = (
   providers: string[],
   models: string[],
   credential = "",
-): AgentCredentialProbe => ({
-  credential,
-  selectedProviders: providers,
-  selectedModels: models,
-});
+): AgentCredentialProbe => {
+  const width = Math.max(providers.length, models.length);
+  return probeOfPairs(
+    Array.from({ length: width }, (_, i) => [providers[i] ?? "", models[i] ?? ""]),
+    credential,
+  );
+};
 
 // Langflow's own spelling, measured on 1.12.0.dev16 — NOT this repo's Provider key.
 const GOOGLE = "Google Generative AI";
@@ -183,7 +253,7 @@ test("provider and model both applied is settled", () => {
 test("#1274 an empty api_key does NOT prevent settling — it is not an axis", () => {
   // The regression this issue is: since #14311 `api_key` reads "" on every build,
   // so any classification that consulted it could only ever refuse to settle.
-  // 14 @stable specs failed the guard on the 2026-08-05 daily for exactly this.
+  // 13 @stable specs failed the guard on the 2026-08-05 daily for exactly this.
   assert.equal(
     classifyCredentialSettle(
       probeOf([GOOGLE], ["gemini-2.5-flash"], ""),
@@ -465,4 +535,18 @@ test("#1274 the message says the empty api_key is not the finding", () => {
   assert.ok(message.includes("api_key is EMPTY"), message);
   assert.ok(message.includes("#14311"), message);
   assert.ok(message.includes("#1274"), message);
+});
+
+test("#1274 the api_key note is printed only when an api_key was observed", () => {
+  // Review caught it printing unconditionally, including for read-failed, where no
+  // api_key was seen — the same unobserved-claim defect this module exists to avoid.
+  const observed = failure();
+  assert.ok(observed.includes("api_key is EMPTY"), observed);
+  for (const verdict of ["read-failed", "no-agent-node"] as const) {
+    const message = failure({ probe: null, verdict, reads: 0 });
+    assert.ok(
+      !message.includes("api_key is EMPTY"),
+      `${verdict} observed no api_key, so it must not comment on one:\n${message}`,
+    );
+  }
 });

--- a/tests/helpers/flows/agent-credential-settle.ts
+++ b/tests/helpers/flows/agent-credential-settle.ts
@@ -31,7 +31,7 @@
 // line since 2026-08-04) deleted the block that wrote the variable name into
 // `api_key`. Measured on `1.12.0.dev16`: after selecting a Google model the persisted
 // node reads `api_key: ""`, `load_from_db: false`, on every read from mount onward —
-// so the transition this module used to wait for cannot happen, and 14 `@stable`
+// so the transition this module used to wait for cannot happen, and 13 `@stable`
 // specs failed the guard on the 2026-08-05 daily waiting 20s for it.
 //
 // The credential is no longer stored, but it is still DETERMINED — by the provider of
@@ -80,6 +80,19 @@ export interface AgentCredentialProbe {
    */
   selectedProviders: string[];
   /**
+   * The selected entries as PAIRS, which is what the classifier decides on.
+   *
+   * `selectedProviders` and `selectedModels` are flat projections for the
+   * diagnostic, and comparing them independently accepts a combination no entry
+   * contains: with `[{name:"gemini-2.5-flash",provider:"OpenAI"},
+   * {name:"gpt-4o",provider:"Google Generative AI"}]`, "google + gemini" matched
+   * across two different entries and classified as `settled`. Contrived on a
+   * single-select widget, but the pairing is strictly stronger at no cost, and the
+   * test comment asserting the two "come off the SAME entry" was describing a
+   * property the code did not have.
+   */
+  selected: Array<{ name: string; provider: string }>;
+  /**
    * The `name` of every model selected on the unified `ModelInput` selector.
    *
    * `template.model.value` is an **array of model objects** (`{ name, provider,
@@ -112,6 +125,14 @@ export type CredentialSettleVerdict =
    * autosave carries the pick.
    */
   | "provider-pending"
+  /**
+   * A model IS persisted but no entry carries a `provider`, so the axis is
+   * unobservable — NOT a wrong provider. Separate verdict because
+   * `provider-pending`'s guidance says "the observed provider separates them", and
+   * on this state the diagnostic prints `providers=[]`: telling a reader to compare
+   * something the run never observed is the mis-triage this module exists to stop.
+   */
+  | "provider-unobservable"
   /**
    * A DIFFERENT, non-empty model is persisted under the RIGHT provider: the
    * provider-setup step selected something other than what the caller asked for.
@@ -153,34 +174,25 @@ function credentialOf(node: FlowNodeLike): string {
  * field carried one before the unified selector, and a stale flow payload must
  * degrade to "no model" rather than throw inside a poll.
  */
-function selectedModelsOf(node: FlowNodeLike): string[] {
-  return modelFieldStrings(node, "name");
-}
-
-/**
- * The `provider` of each selected model, out of the same `template.model.value`.
- *
- * A bare-string entry (the pre-unified-selector shape) yields no provider — the
- * field carried only a model name then — so such a payload degrades to "no provider
- * observed" rather than to a wrong one.
- */
-function selectedProvidersOf(node: FlowNodeLike): string[] {
-  return modelFieldStrings(node, "provider");
-}
-
-/** One string field out of every entry in `template.model.value`. */
-function modelFieldStrings(node: FlowNodeLike, key: "name" | "provider"): string[] {
+function selectedEntriesOf(
+  node: FlowNodeLike,
+): Array<{ name: string; provider: string }> {
   const value = node.data?.node?.template?.model?.value;
   const entries = Array.isArray(value) ? value : [value];
   return entries
     .map((entry) => {
-      // A bare string is a model NAME; it says nothing about the provider.
-      if (typeof entry === "string") return key === "name" ? entry : "";
-      const field = (entry as Record<string, unknown> | null)?.[key];
-      return typeof field === "string" ? field : "";
+      // A bare string is a model NAME and says nothing about the provider — the
+      // pre-unified-selector shape, kept tolerated so a stale payload degrades to
+      // "no provider observed" rather than to a wrong one.
+      if (typeof entry === "string") return { name: entry, provider: "" };
+      const record = entry as Record<string, unknown> | null;
+      const str = (key: string) =>
+        typeof record?.[key] === "string" ? (record[key] as string) : "";
+      return { name: str("name"), provider: str("provider") };
     })
-    .filter((field) => field.length > 0);
+    .filter((entry) => entry.name.length > 0 || entry.provider.length > 0);
 }
+
 
 /**
  * Reads the Agent node's binding out of a `GET /api/v1/flows/{id}` payload, or
@@ -204,26 +216,40 @@ export function readAgentCredentialProbe(
     (node) => node?.data?.type === "Agent",
   );
   if (!agent) return null;
+  const selected = selectedEntriesOf(agent);
   return {
     credential: credentialOf(agent),
-    selectedProviders: selectedProvidersOf(agent),
-    selectedModels: selectedModelsOf(agent),
+    selected,
+    selectedProviders: selected.map((e) => e.provider).filter((p) => p.length > 0),
+    selectedModels: selected.map((e) => e.name).filter((n) => n.length > 0),
   };
 }
 
 /**
  * Which state the probe is in.
  *
- * **The provider is the primary axis (#1274), and it is always available.** Every
- * caller of `load()` names a provider, so — unlike the credential this used to read,
- * and unlike `expectedModel` — there is no caller for which this check degrades to
- * nothing. That matters for the three specs that load WITHOUT pinning a model
+ * **The provider is the primary axis (#1274), and every caller supplies one.** That
+ * matters for the three specs that load WITHOUT pinning a model
  * (`model-provider-model-toggle`, `general-bugs-agent-images-playground`,
  * `agent-model-connection-isolation`), plus any spec whose `models.json` came back
  * empty: on the credential axis those would now settle on the first read and prove
  * nothing, because `api_key` is `""` from mount onward. On the provider axis they
  * still block on a real transition, since a freshly mounted node carries the
  * selector's DEFAULT provider (`"Anthropic"`, measured on `1.12.0.dev16`).
+ *
+ * **ONE COMBINATION IS STILL UNGUARDED, and it is not new.** When the expected
+ * provider IS the mount-time default (`anthropic`) and the caller pins no model,
+ * the mount state already satisfies both available checks, so the first read
+ * settles and nothing was proved. The pre-#1274 code had the identical hole by the
+ * identical route (`probe.credential === expectedCredential` with no
+ * `expectedModel`, where the default binding WAS `ANTHROPIC_API_KEY`), so this is
+ * inherited, not introduced — an earlier draft of this comment claimed the axis
+ * closed it, which review disproved. Closing it needs an observable this module
+ * cannot see: whether the persisted value is the default or a deliberate pick.
+ * `SimpleAgentTemplatePage` therefore WARNS when it settles on the first read with
+ * no pinned model, so the vacuum is visible in the run log instead of silent
+ * (#1012). It matters on `daily-stable.yml`'s anthropic rotation day (#1185), for
+ * `model-provider-model-toggle` and `agent-model-connection-isolation`.
  *
  * `expectedModel` stays optional and stays a real check when supplied: same provider
  * with the wrong model still means the setup step clicked the wrong option.
@@ -249,22 +275,30 @@ export function classifyCredentialSettle(
 ): CredentialSettleVerdict {
   if (!probe) return "no-agent-node";
 
-  // Nothing persisted at all is its own verdict, and it is checked FIRST: an empty
-  // model list also has an empty provider list, so testing the provider before this
-  // would report "a different provider is persisted" about a node carrying none.
-  if (probe.selectedModels.length === 0 && probe.selectedProviders.length === 0) {
-    return "nothing-persisted";
-  }
+  // Nothing carried the selection at all. Checked FIRST: an empty selection has an
+  // empty provider list too, so testing the provider before this would report "a
+  // different provider is persisted" about a node carrying none.
+  if (probe.selected.length === 0) return "nothing-persisted";
 
-  if (!probe.selectedProviders.includes(expectedProvider)) return "provider-pending";
+  // The provider is present on some entry but on none we can compare — a payload
+  // shape this module tolerates (a bare-string model name) rather than a wrong
+  // provider. Distinct verdict because `provider-pending`'s guidance tells the
+  // reader to compare the OBSERVED provider, and there is none to compare.
+  if (probe.selectedProviders.length === 0) return "provider-unobservable";
 
-  const modelApplied =
-    !expectedModel || probe.selectedModels.includes(expectedModel);
-  if (modelApplied) return "settled";
+  // Paired, not two independent `includes()`: "the right provider" and "the right
+  // model" must hold on the SAME entry, or a multi-entry payload can satisfy the
+  // pair across two entries that each carry only half of it.
+  const match = probe.selected.filter((entry) => entry.provider === expectedProvider);
+  if (match.length === 0) return "provider-pending";
+  if (!expectedModel) return "settled";
+  if (match.some((entry) => entry.name === expectedModel)) return "settled";
   // The provider is right, so the credential the run resolves is right; only the
-  // pick within that provider is wrong. `model-not-applied` is the sharper of the
-  // two when we can see a concrete other model.
-  return probe.selectedModels.length > 0 ? "model-not-applied" : "model-pending";
+  // pick within it is wrong. `model-not-applied` is the sharper verdict when a
+  // concrete other model is visible under that provider.
+  return match.some((entry) => entry.name.length > 0)
+    ? "model-not-applied"
+    : "model-pending";
 }
 
 export interface CredentialSettleFailure {
@@ -319,6 +353,13 @@ const VERDICT_GUIDANCE: Record<
     "option missing, panel still animating). Before #1274 this verdict also covered " +
     "the wedged-save case, where the node kept its mount-time default; that state is " +
     "now `provider-pending`, because the default belongs to a different provider.",
+  "provider-unobservable":
+    "A model is persisted but NO entry carries a `provider`, so the axis this guard " +
+    "decides on is unobservable — this is NOT a wrong provider, and the `observed` " +
+    "line will show `providers=[]`. Either the payload is the pre-unified-selector " +
+    "shape (a bare model-name string, which no current build writes) or a partial " +
+    "write landed. Look at the shape of `template.model.value` in the persisted " +
+    "flow before anything else; the provider comparison never ran.",
   "nothing-persisted":
     "No model and no provider are persisted at all, so nothing carried the " +
     "selection. Two causes fit and this guard cannot separate them: the model click " +
@@ -386,9 +427,16 @@ export function formatCredentialSettleFailure(
     `  observed       ${observed}`,
     `  waited         ${(elapsedMs / 1000).toFixed(1)}s over ${reads} read(s)`,
     // Said once, here, because every reader of this message arrives knowing the old
-    // behaviour and would otherwise read the empty api_key as the finding.
-    `  note           api_key is EMPTY on every build since upstream #14311 and is`,
-    `                 not asserted either way — the provider above is the axis (#1274).`,
+    // behaviour and would otherwise read the empty api_key as the finding. Printed
+    // only when an api_key was actually OBSERVED: on `read-failed` / `no-agent-node`
+    // nothing was, and a note about a field nobody saw is the same unobserved claim
+    // this module exists to avoid.
+    ...(probe
+      ? [
+          `  note           api_key is EMPTY on every build since upstream #14311 and is`,
+          `                 not asserted either way — the provider above is the axis (#1274).`,
+        ]
+      : []),
     ...(lastReadError ? [`  last read err  ${lastReadError}`] : []),
     ``,
     `  verdict        ${verdict}`,

--- a/tests/helpers/flows/agent-credential-settle.ts
+++ b/tests/helpers/flows/agent-credential-settle.ts
@@ -427,14 +427,23 @@ export function formatCredentialSettleFailure(
     `  observed       ${observed}`,
     `  waited         ${(elapsedMs / 1000).toFixed(1)}s over ${reads} read(s)`,
     // Said once, here, because every reader of this message arrives knowing the old
-    // behaviour and would otherwise read the empty api_key as the finding. Printed
-    // only when an api_key was actually OBSERVED: on `read-failed` / `no-agent-node`
-    // nothing was, and a note about a field nobody saw is the same unobserved claim
-    // this module exists to avoid.
+    // behaviour and would otherwise read the api_key line as the finding.
+    //
+    // It states what this guard DOES, not what the field contains. An earlier draft
+    // said "api_key is EMPTY on every build since #14311", which is false on exactly
+    // the builds this module is documented as still supporting: `manual.yml` can
+    // dispatch a pre-#14311 Langflow, where the field IS written — and there the note
+    // would have contradicted the `observed` line printed directly above it.
+    //
+    // Printed only when a probe was actually read: on `read-failed` /
+    // `no-agent-node` no api_key was observed, and commenting on a field nobody saw
+    // is the same unobserved claim this module exists to avoid.
     ...(probe
       ? [
-          `  note           api_key is EMPTY on every build since upstream #14311 and is`,
-          `                 not asserted either way — the provider above is the axis (#1274).`,
+          `  note           api_key is NOT asserted in either direction — the provider`,
+          `                 above is the axis (#1274). Upstream #14311 stopped writing`,
+          `                 this field on the 1.12 line, so an empty value here is`,
+          `                 expected and is not the finding.`,
         ]
       : []),
     ...(lastReadError ? [`  last read err  ${lastReadError}`] : []),

--- a/tests/helpers/flows/agent-credential-settle.ts
+++ b/tests/helpers/flows/agent-credential-settle.ts
@@ -23,15 +23,62 @@
 //
 // It is pure over the flow payload, which is what lets the `node --test` lane cover
 // the classification instead of re-deriving it from a daily's artifacts.
+//
+// #1274 — WHY THIS NO LONGER READS `api_key`, AND WHY IT IS STILL CALLED
+// `agent-credential-settle`
+//
+// Upstream #14311 ("stop automatic provider field binding", `646bdd6b`, on the 1.12
+// line since 2026-08-04) deleted the block that wrote the variable name into
+// `api_key`. Measured on `1.12.0.dev16`: after selecting a Google model the persisted
+// node reads `api_key: ""`, `load_from_db: false`, on every read from mount onward —
+// so the transition this module used to wait for cannot happen, and 14 `@stable`
+// specs failed the guard on the 2026-08-05 daily waiting 20s for it.
+//
+// The credential is no longer stored, but it is still DETERMINED — by the provider of
+// the selected model. With `api_key` empty, `get_api_key_for_provider`
+// (`lfx/base/models/unified_models/credentials.py`) resolves
+// `get_provider_secret_variable_key(provider)` from the user's global variables. So
+// this module now checks `model.value[0].provider`, which is not a weaker proxy for
+// the credential — it is the input the runtime derives it from.
+//
+// The race #751 exists for is UNCHANGED and still real, which is why the guard is
+// re-pointed rather than deleted. Same measurement, read 0: a freshly mounted node
+// carries `{ name: "claude-opus-5", provider: "Anthropic" }` — the selector's default
+// — and only later flips to the requested `{ name: "gemini-2.5-flash", provider:
+// "Google Generative AI" }`. A caller that opens the Playground in between runs the
+// DEFAULT provider's model, which is the original #744 signature (and, with the
+// Anthropic key drained, an immediate hard failure).
+//
+// `api_key` is not asserted in either direction. Requiring it empty would swap one
+// dated premise for another and break the `manual.yml` lanes that can still dispatch
+// a pre-#14311 build; the field is simply no longer evidence about anything.
+//
+// The FILENAME and the `#751`/`#1072` references stay: both numbers appear in issue
+// bodies, triage comments and error text already in circulation, and renaming the
+// module would cost that traceability to buy an accurate noun.
 
 /** The provider binding of the Agent node, as persisted in a flow payload. */
 export interface AgentCredentialProbe {
   /**
    * `template.api_key.value` — the NAME of the Langflow global variable holding
-   * the key (e.g. `"OPENAI_API_KEY"`), never the secret itself. Empty string on a
-   * freshly instantiated template, before any provider is configured.
+   * the key (e.g. `"OPENAI_API_KEY"`), never the secret itself.
+   *
+   * **Reported, never classified on (#1274).** Since #14311 this is `""` on every
+   * read, so it cannot separate any two states; it stays on the probe because the
+   * failure diagnostic prints it, and a reader who knows the old behaviour needs to
+   * see that it really is empty rather than wonder whether it was checked.
    */
   credential: string;
+  /**
+   * The `provider` of every model selected on the unified `ModelInput` selector —
+   * Langflow's own spelling, e.g. `"Google Generative AI"`, `"Anthropic"`,
+   * `"Ollama"` (see `langflowProviderName`).
+   *
+   * This is the axis the guard settles on. With `api_key` empty the runtime derives
+   * the credential from exactly this field, so it is what proves the flow will run
+   * against the provider the caller asked for.
+   */
+  selectedProviders: string[];
   /**
    * The `name` of every model selected on the unified `ModelInput` selector.
    *
@@ -47,22 +94,28 @@ export interface AgentCredentialProbe {
 }
 
 export type CredentialSettleVerdict =
-  /** Credential AND (when known) model are both applied — nothing to wait for. */
+  /** Provider AND (when pinned) model are both applied — nothing to wait for. */
   | "settled"
   /**
-   * The credential is right but the requested model is not applied yet. The
-   * dropdown's default binding IS the expected credential — i.e. the caller asked
-   * for anthropic — so the credential axis alone proves nothing here.
+   * The provider matches and a pinned model was expected, but NO model name is
+   * observable — a degenerate payload (an entry carrying `provider` and no `name`).
+   * Kept separate from `model-not-applied` because there is no other model to name
+   * in the diagnostic, so "a DIFFERENT model is persisted" would be a claim about
+   * something nobody saw.
    */
   | "model-pending"
   /**
-   * The requested model is applied but the credential still is not: the selection
-   * registered and only the rebind has yet to be persisted. Waiting helps.
+   * A DIFFERENT provider is persisted than the one asked for (#1274). This is the
+   * state the old `credential-pending` used to describe, moved onto the axis that
+   * still exists: the selection has not landed, so the run would resolve the WRONG
+   * provider's key. Waiting can help — the mount-time default sits here until the
+   * autosave carries the pick.
    */
-  | "credential-pending"
+  | "provider-pending"
   /**
-   * A DIFFERENT, non-empty model is persisted: the provider-setup step selected
-   * something other than what the caller asked for. Waiting cannot fix it.
+   * A DIFFERENT, non-empty model is persisted under the RIGHT provider: the
+   * provider-setup step selected something other than what the caller asked for.
+   * Waiting cannot fix it.
    */
   | "model-not-applied"
   /** No model is persisted at all — nothing has carried the selection. */
@@ -101,15 +154,32 @@ function credentialOf(node: FlowNodeLike): string {
  * degrade to "no model" rather than throw inside a poll.
  */
 function selectedModelsOf(node: FlowNodeLike): string[] {
+  return modelFieldStrings(node, "name");
+}
+
+/**
+ * The `provider` of each selected model, out of the same `template.model.value`.
+ *
+ * A bare-string entry (the pre-unified-selector shape) yields no provider — the
+ * field carried only a model name then — so such a payload degrades to "no provider
+ * observed" rather than to a wrong one.
+ */
+function selectedProvidersOf(node: FlowNodeLike): string[] {
+  return modelFieldStrings(node, "provider");
+}
+
+/** One string field out of every entry in `template.model.value`. */
+function modelFieldStrings(node: FlowNodeLike, key: "name" | "provider"): string[] {
   const value = node.data?.node?.template?.model?.value;
   const entries = Array.isArray(value) ? value : [value];
   return entries
     .map((entry) => {
-      if (typeof entry === "string") return entry;
-      const name = (entry as { name?: unknown } | null)?.name;
-      return typeof name === "string" ? name : "";
+      // A bare string is a model NAME; it says nothing about the provider.
+      if (typeof entry === "string") return key === "name" ? entry : "";
+      const field = (entry as Record<string, unknown> | null)?.[key];
+      return typeof field === "string" ? field : "";
     })
-    .filter((name) => name.length > 0);
+    .filter((field) => field.length > 0);
 }
 
 /**
@@ -136,6 +206,7 @@ export function readAgentCredentialProbe(
   if (!agent) return null;
   return {
     credential: credentialOf(agent),
+    selectedProviders: selectedProvidersOf(agent),
     selectedModels: selectedModelsOf(agent),
   };
 }
@@ -143,23 +214,19 @@ export function readAgentCredentialProbe(
 /**
  * Which state the probe is in.
  *
- * The credential is NOT sufficient on its own. `ANTHROPIC_API_KEY` is both the
- * dropdown's default auto-binding and the expected credential of the `anthropic`
- * provider, so a credential-only check returns "settled" for every anthropic
- * caller the instant the default binding persists — before the requested model is
- * applied at all. That is why `load()`'s contract ("every caller starts settled")
- * did not hold for anthropic, and why the issue's anthropic row
- * (`agent-max-iterations.spec.ts:255`) could never have been this guard's
- * expected/received mismatch: for anthropic the mismatch is unreachable.
- *
- * `expectedModel` is optional — a caller may let the provider-setup helper pick the
- * first available model, leaving no name to compare. Most agent specs are
- * parametrized from `models.json` and do pass one, but three load without a model
+ * **The provider is the primary axis (#1274), and it is always available.** Every
+ * caller of `load()` names a provider, so — unlike the credential this used to read,
+ * and unlike `expectedModel` — there is no caller for which this check degrades to
+ * nothing. That matters for the three specs that load WITHOUT pinning a model
  * (`model-provider-model-toggle`, `general-bugs-agent-images-playground`,
- * `agent-model-connection-isolation`), and so does any spec whose `models.json`
- * came back empty. For those the model axis is simply unavailable — see
- * `CREDENTIAL_PENDING_NO_MODEL_GUIDANCE`, which is what keeps the reported
- * guidance from claiming a check that did not happen.
+ * `agent-model-connection-isolation`), plus any spec whose `models.json` came back
+ * empty: on the credential axis those would now settle on the first read and prove
+ * nothing, because `api_key` is `""` from mount onward. On the provider axis they
+ * still block on a real transition, since a freshly mounted node carries the
+ * selector's DEFAULT provider (`"Anthropic"`, measured on `1.12.0.dev16`).
+ *
+ * `expectedModel` stays optional and stays a real check when supplied: same provider
+ * with the wrong model still means the setup step clicked the wrong option.
  *
  * Gating on the model is only sound because a pinned model is never silently
  * substituted on this path: `setup-openai`, `setup-anthropic` and `setup-google`
@@ -170,29 +237,41 @@ export function readAgentCredentialProbe(
  * and never through `SimpleAgentTemplatePage`. Wiring that option through
  * `providerSetupMap` would make this comparison fail on a legitimately substituted
  * model, so it must arrive with a way to tell the guard what was actually picked.
+ *
+ * `expectedProvider` is Langflow's own spelling of the provider name, which callers
+ * get from `langflowProviderName()` — never this repo's `Provider` key, which does
+ * not appear in the payload.
  */
 export function classifyCredentialSettle(
   probe: AgentCredentialProbe | null,
-  expectedCredential: string,
+  expectedProvider: string,
   expectedModel?: string,
 ): CredentialSettleVerdict {
   if (!probe) return "no-agent-node";
 
+  // Nothing persisted at all is its own verdict, and it is checked FIRST: an empty
+  // model list also has an empty provider list, so testing the provider before this
+  // would report "a different provider is persisted" about a node carrying none.
+  if (probe.selectedModels.length === 0 && probe.selectedProviders.length === 0) {
+    return "nothing-persisted";
+  }
+
+  if (!probe.selectedProviders.includes(expectedProvider)) return "provider-pending";
+
   const modelApplied =
     !expectedModel || probe.selectedModels.includes(expectedModel);
-
-  if (probe.credential === expectedCredential) {
-    return modelApplied ? "settled" : "model-pending";
-  }
-  if (probe.selectedModels.length === 0) return "nothing-persisted";
-  if (!modelApplied) return "model-not-applied";
-  return "credential-pending";
+  if (modelApplied) return "settled";
+  // The provider is right, so the credential the run resolves is right; only the
+  // pick within that provider is wrong. `model-not-applied` is the sharper of the
+  // two when we can see a concrete other model.
+  return probe.selectedModels.length > 0 ? "model-not-applied" : "model-pending";
 }
 
 export interface CredentialSettleFailure {
   flowId: string;
   provider: string;
-  expectedCredential: string;
+  /** Langflow's own spelling of the provider — see `langflowProviderName`. */
+  expectedProvider: string;
   expectedModel?: string;
   /** The last probe read, or `null` when the flow had no Agent node / was never read. */
   probe: AgentCredentialProbe | null;
@@ -214,38 +293,38 @@ const VERDICT_GUIDANCE: Record<
   string
 > = {
   "model-pending":
-    "The credential matches but the requested model is not applied, so nothing " +
-    "here says the model selection worked. Read the credential before concluding: " +
-    "when it is the selector's DEFAULT binding (ANTHROPIC_API_KEY) the match is " +
-    "free and proves nothing — this verdict exists because a credential-only check " +
-    "declared such a load settled. When it is any other provider's, the rebind did " +
-    "land and only the selection has not. Either way, look at the provider setup " +
-    "step for this provider, not at the credential.",
-  "credential-pending":
-    "The requested model IS applied, so the selection registered and only the " +
-    "credential rebind is missing from the persisted flow. The rebind is computed " +
-    "by `POST /api/v1/custom_component/update` and persisted by the editor's " +
-    "debounced autosave `PATCH /api/v1/flows/{id}`; a saturated backend delays " +
-    "both (#1077). Note this line prints only AFTER the budget expired, so " +
-    "retrying did NOT help within it — and a persisted credential belonging to a " +
-    "THIRD provider is a real misbinding, not slowness. Compare the observed " +
-    "credential against the provider before concluding load.",
+    "The provider matches, so the credential the run resolves is already the right " +
+    "one, but no model NAME is observable in the persisted selection while a " +
+    "provider is. That is a degenerate payload, not a normal pending state — read " +
+    "the `observed` line: if `models=[]` while a provider is present, the entry " +
+    "carries a provider and no name, which no current build produces on the happy " +
+    "path. Suspect a partially written autosave or a shape change in " +
+    "`template.model.value`.",
+  "provider-pending":
+    "A DIFFERENT provider than the one requested is persisted on the Agent, so the " +
+    "run would resolve the WRONG provider's key. Since #14311 the credential is not " +
+    "stored at all — it is derived at run time from exactly this field (#1274) — so " +
+    "this is the state that used to read as `credential-pending`. TWO causes fit and " +
+    "the observed provider separates them: when it is the selector's mount-time " +
+    "DEFAULT (`Anthropic`), the model pick has not been carried by the editor's " +
+    "debounced autosave `PATCH /api/v1/flows/{id}` yet and waiting is the right " +
+    "response (a saturated backend delays it — #1077). When it is some THIRD " +
+    "provider, the setup step selected the wrong option and waiting cannot fix it. " +
+    "Note this line prints only AFTER the budget expired, so retrying did NOT help " +
+    "within it.",
   "model-not-applied":
-    "A DIFFERENT model is persisted than the one requested. TWO states look like " +
-    "this and the observed model tells them apart: the provider-setup step selected " +
-    "the wrong option (waiting cannot fix it — look at the setup helper: dropdown " +
-    "intercepted, option missing, panel still animating), OR nothing was saved " +
-    "after the click at all, leaving the node's mount-time prefill in place — on a " +
-    "google/openai load that prefill IS `ANTHROPIC_API_KEY` plus the default " +
-    "Claude model, so this verdict is also what a wedged save path (#1077) looks " +
-    "like. If the observed pair is exactly that default, suspect the save, not the " +
-    "click.",
+    "The provider is right but a DIFFERENT model is persisted under it, so the run " +
+    "would use the correct credential with the wrong model. Waiting cannot fix it: " +
+    "look at the provider-setup helper for this provider (dropdown intercepted, " +
+    "option missing, panel still animating). Before #1274 this verdict also covered " +
+    "the wedged-save case, where the node kept its mount-time default; that state is " +
+    "now `provider-pending`, because the default belongs to a different provider.",
   "nothing-persisted":
-    "No model is persisted at all, so nothing carried the selection. Two causes " +
-    "fit and this guard cannot separate them: the model click never registered " +
-    "(provider setup), or the rebind never completed. Check the run for " +
-    "`POST /api/v1/custom_component/update` — that is the request that computes " +
-    "the binding; the flows PATCH only persists its result.",
+    "No model and no provider are persisted at all, so nothing carried the " +
+    "selection. Two causes fit and this guard cannot separate them: the model click " +
+    "never registered (provider setup), or the save never completed. Check the run " +
+    "for `POST /api/v1/custom_component/update` — that is the request that refreshes " +
+    "the field; the flows PATCH only persists its result.",
   "no-agent-node":
     "The persisted flow was read and has no Agent node: the Simple Agent template " +
     "did not instantiate as expected, or the id belongs to a different flow.",
@@ -256,29 +335,15 @@ const VERDICT_GUIDANCE: Record<
 };
 
 /**
- * `credential-pending` with no pinned model.
+ * The guidance for this failure.
  *
- * The verdict is the same — the credential is not there — but its usual guidance
- * ("the requested model IS applied, so the selection registered") asserts something
- * that was never checked: with no `expectedModel` the model axis is unavailable, so
- * ANY wrong-credential read with a non-empty model list lands on that verdict.
- * Three specs load without pinning a model (`model-provider-model-toggle`,
- * `general-bugs-agent-images-playground`, `agent-model-connection-isolation`), plus
- * any spec whose `models.json` came back empty.
+ * There is no longer a per-caller special case here. The old one existed because
+ * `credential-pending`'s text asserted "the requested model IS applied" even for the
+ * three callers that pin no model, where the model axis was unavailable. The primary
+ * axis is now the provider, which EVERY caller supplies (#1274), so one string per
+ * verdict is true for every caller.
  */
-const CREDENTIAL_PENDING_NO_MODEL_GUIDANCE =
-  "The credential is missing from the persisted flow, and the caller pinned no " +
-  "model — so nothing here says whether the model selection registered. Read the " +
-  "`observed` models against what the provider-setup helper would have picked " +
-  "before concluding. The rebind is computed by " +
-  "`POST /api/v1/custom_component/update` and persisted by the editor's debounced " +
-  "autosave; a saturated backend delays both (#1077).";
-
-/** The guidance for this failure, including the cases the verdict alone cannot carry. */
 function guidanceFor(failure: CredentialSettleFailure): string {
-  if (failure.verdict === "credential-pending" && !failure.expectedModel) {
-    return CREDENTIAL_PENDING_NO_MODEL_GUIDANCE;
-  }
   return VERDICT_GUIDANCE[
     failure.verdict as Exclude<CredentialSettleVerdict, "settled">
   ];
@@ -296,7 +361,7 @@ export function formatCredentialSettleFailure(
   const {
     flowId,
     provider,
-    expectedCredential,
+    expectedProvider,
     expectedModel,
     probe,
     verdict,
@@ -306,7 +371,8 @@ export function formatCredentialSettleFailure(
   } = failure;
 
   const observed = probe
-    ? `api_key="${probe.credential}" models=[${probe.selectedModels.join(", ")}]`
+    ? `providers=[${probe.selectedProviders.join(", ")}] ` +
+      `models=[${probe.selectedModels.join(", ")}] api_key="${probe.credential}"`
     : verdict === "read-failed"
       ? "no successful read of the persisted flow"
       : "the flow was read and carries no Agent node";
@@ -315,10 +381,14 @@ export function formatCredentialSettleFailure(
     `Agent credential never settled on the persisted flow (#751 guard, #1072).`,
     ``,
     `  flow           ${flowId}`,
-    `  provider       ${provider} (expected credential "${expectedCredential}")`,
+    `  provider       ${provider} (expected "${expectedProvider}" on the persisted model)`,
     `  model wanted   ${expectedModel ?? "(caller let the setup helper choose)"}`,
     `  observed       ${observed}`,
     `  waited         ${(elapsedMs / 1000).toFixed(1)}s over ${reads} read(s)`,
+    // Said once, here, because every reader of this message arrives knowing the old
+    // behaviour and would otherwise read the empty api_key as the finding.
+    `  note           api_key is EMPTY on every build since upstream #14311 and is`,
+    `                 not asserted either way — the provider above is the axis (#1274).`,
     ...(lastReadError ? [`  last read err  ${lastReadError}`] : []),
     ``,
     `  verdict        ${verdict}`,

--- a/tests/helpers/provider-setup/index.ts
+++ b/tests/helpers/provider-setup/index.ts
@@ -16,6 +16,7 @@ export {
   providerConfigMap,
   keyedProviders,
   keyedProviderNames,
+  langflowProviderName,
 } from "./provider-config";
 
 // Derivado de provider-config.ts — edite lá para alterar as chaves de ambiente

--- a/tests/helpers/provider-setup/index.ts
+++ b/tests/helpers/provider-setup/index.ts
@@ -19,7 +19,7 @@ export {
   langflowProviderName,
 } from "./provider-config";
 
-// Derivado de provider-config.ts — edite lá para alterar as chaves de ambiente
+// Derived from provider-config.ts — edit it there to change the env keys
 export const providerEnvKeyMap: Record<string, string[]> = Object.fromEntries(
   (Object.keys(providerConfigMap) as (keyof typeof providerConfigMap)[]).map((p) => [
     p,

--- a/tests/helpers/provider-setup/provider-config.test.ts
+++ b/tests/helpers/provider-setup/provider-config.test.ts
@@ -22,6 +22,7 @@ import * as path from "path";
 import {
   keyedProviderNames,
   keyedProviders,
+  langflowProviderName,
   providerConfigMap,
   type Provider,
 } from "./provider-config";
@@ -93,4 +94,55 @@ test("the key-subject consumers iterate keyedProviders, never the full map", () 
       `${path.basename(file)} iterates providerConfigMap directly — use keyedProviders (#1187)`,
     );
   }
+});
+
+// ─── langflowProviderName (#1274) ────────────────────────────────────────────
+//
+// This one line decides the string the #751 guard compares against on every
+// `SimpleAgentTemplatePage.load()`, i.e. on 29 spec files. Review found it had ZERO
+// coverage: replacing the body with `return providerTestId` — which yields
+// `"provider-item-OpenAI"`, a string the product never persists — passed all 436
+// unit tests, while making the guard wait its full 20 s and hard-fail for every
+// dependent spec. The values below are not conventions; they were verified three
+// ways on 1.12.0.dev16: `GET /api/v1/models/providers`, the upstream constants in
+// `lfx/components/agentics/constants.py`, and the frontend's
+// `data-testid={`provider-item-${provider.provider}`}` template.
+test("langflowProviderName returns the name Langflow itself persists", () => {
+  assert.equal(langflowProviderName("openai"), "OpenAI");
+  assert.equal(langflowProviderName("anthropic"), "Anthropic");
+  assert.equal(langflowProviderName("google"), "Google Generative AI");
+  assert.equal(langflowProviderName("ollama"), "Ollama");
+});
+
+test("langflowProviderName never returns the testid prefix", () => {
+  // The mutation that survived: the raw testid is a plausible-looking string that
+  // is wrong everywhere it matters.
+  for (const provider of Object.keys(providerConfigMap) as Provider[]) {
+    const name = langflowProviderName(provider);
+    assert.doesNotMatch(
+      name,
+      /^provider-item-/,
+      `${provider}: the display name must have the testid prefix stripped`,
+    );
+    assert.ok(name.length > 0, `${provider}: empty display name`);
+    assert.equal(
+      providerConfigMap[provider].providerTestId,
+      `provider-item-${name}`,
+      `${provider}: the testid must remain derivable from the display name`,
+    );
+  }
+});
+
+test("langflowProviderName fails loudly if the testid convention breaks", () => {
+  // The throw exists so that an upstream rename fails for every provider at once,
+  // with a message naming the fix — rather than silently yielding a wrong string
+  // that reads as a 20 s guard timeout in 29 specs.
+  const original = providerConfigMap.openai.providerTestId;
+  try {
+    (providerConfigMap.openai as { providerTestId: string }).providerTestId = "OpenAI";
+    assert.throws(() => langflowProviderName("openai"), /does not start with/);
+  } finally {
+    (providerConfigMap.openai as { providerTestId: string }).providerTestId = original;
+  }
+  assert.equal(langflowProviderName("openai"), "OpenAI", "the guard must not leak state");
 });

--- a/tests/helpers/provider-setup/provider-config.ts
+++ b/tests/helpers/provider-setup/provider-config.ts
@@ -38,10 +38,10 @@ export interface BaseUrlProviderConfig extends ProviderConfigBase {
 
 export type ProviderConfig = ApiKeyProviderConfig | BaseUrlProviderConfig;
 
-// ─── Fonte única de configuração por provider ─────────────────────────────────
-// Ao adicionar um novo provider, inclua uma entrada aqui.
-// Todos os demais arquivos (index.ts, collect-models.ts, specs) derivam seus
-// dados a partir deste mapa — nenhuma mudança adicional é necessária nesses arquivos.
+// ─── Single source of per-provider configuration ──────────────────────────────
+// When adding a new provider, add an entry here.
+// Every other file (index.ts, collect-models.ts, specs) derives its data from
+// this map — no further change is needed in those files.
 //
 // ORDER IS LOAD-BEARING: several specs fall back to `Object.keys(providerConfigMap)[0]`
 // when a target carries no provider, so `openai` must stay first. Keyless providers

--- a/tests/helpers/provider-setup/provider-config.ts
+++ b/tests/helpers/provider-setup/provider-config.ts
@@ -124,3 +124,38 @@ export const keyedProviders: Array<[KeyedProvider, ApiKeyProviderConfig]> = (
 export const keyedProviderNames: KeyedProvider[] = keyedProviders.map(
   ([provider]) => provider,
 );
+
+/**
+ * The provider name as Langflow itself spells it — what a persisted Agent node
+ * carries in `template.model.value[0].provider`.
+ *
+ * It is NOT this repo's `Provider` key: measured on `1.12.0.dev16`, selecting
+ * `gemini-2.5-flash` persists `provider: "Google Generative AI"`, and a freshly
+ * mounted node carries `provider: "Anthropic"`. That string is what
+ * `get_api_key_for_provider` resolves the runtime key from (`lfx/base/models/
+ * unified_models/credentials.py`), so it is the axis the `#751` guard has to check
+ * now that #14311 stopped writing `api_key` at all (#1274).
+ *
+ * DERIVED from `providerTestId` rather than listed again: the panel's testid is
+ * `provider-item-<the same display name>` — `provider-item-Google Generative AI`,
+ * `provider-item-Anthropic`, `provider-item-Ollama`. Both come from Langflow's
+ * provider metadata, so one table cannot drift from the other. A second hardcoded
+ * map is exactly what #1043 and #1184 had to remove after it drifted; if upstream
+ * ever decouples the two, this derivation fails loudly for every provider at once
+ * rather than for one, which is the cheaper failure to notice.
+ */
+const PROVIDER_ITEM_TESTID_PREFIX = "provider-item-";
+
+export function langflowProviderName(provider: Provider): string {
+  const { providerTestId } = providerConfigMap[provider];
+  if (!providerTestId.startsWith(PROVIDER_ITEM_TESTID_PREFIX)) {
+    throw new Error(
+      `langflowProviderName: providerTestId for "${provider}" is ` +
+        `"${providerTestId}", which does not start with ` +
+        `"${PROVIDER_ITEM_TESTID_PREFIX}" — the display name can no longer be ` +
+        `derived from it. Either restore the convention or give ProviderConfig an ` +
+        `explicit display-name field (do NOT add a second lookup table: #1043/#1184).`,
+    );
+  }
+  return providerTestId.slice(PROVIDER_ITEM_TESTID_PREFIX.length);
+}

--- a/tests/pages/SimpleAgentTemplatePage.ts
+++ b/tests/pages/SimpleAgentTemplatePage.ts
@@ -10,6 +10,7 @@ import {
   type AgentCredentialProbe,
 } from "../helpers/flows/agent-credential-settle";
 import {
+  langflowProviderName,
   providerConfigMap,
   providerSetupMap,
   hasProviderEnvKeys,
@@ -94,37 +95,34 @@ export class SimpleAgentTemplatePage extends BasePage {
     await adjustScreenView(this.page);
     await providerSetupMap[provider](this.page, model);
 
-    // #751: on the 1.11+ unified model selector the Agent node prefills its
-    // `api_key` with the DEFAULT credential (ANTHROPIC_API_KEY) when it MOUNTS —
-    // not when the dropdown opens; picking the target provider's model rebinds it
-    // to that provider's credential ASYNCHRONOUSLY. A caller that opens the Playground
-    // and sends a message before the rebind settles builds the selected model
-    // with the wrong provider's key — surfacing as
-    // "Flow build failed: Incorrect API key provided" and a `div-chat-message`
-    // that never renders (the daily-#744 signature). Block until the PERSISTED
-    // flow shows BOTH that credential and the requested model, so every caller
-    // starts settled — the credential alone does not prove it (#1072, see the
-    // classifier's note on the anthropic default).
-    // A KEYLESS provider expects an EMPTY `api_key`, and that is a real assertion
-    // rather than a vacuous one (#1187). The Agent node prefills `api_key` with the
-    // default credential (`ANTHROPIC_API_KEY`) when it MOUNTS — so on an instance
-    // where Anthropic is also configured, the node starts out carrying a credential
-    // and selecting an Ollama model must CLEAR it. Measured on 1.12.0.dev10 after
-    // selecting `Ollama-llama3.1:latest`: `api_key.value === ""` with
-    // `model.value[0] = { name: "llama3.1:latest", provider: "Ollama" }`. So `""` is
-    // the settled state to wait for.
-    // But what carries the proof for a keyless provider is the MODEL axis, and the
-    // caller has to supply it. `credentialOf()` returns `""` for an absent field
-    // too, and on the lane this exists for — every hosted key dead, so nothing
-    // prefills `api_key` at mount — `""` is ALSO the state before anything was
-    // selected. With `model` passed the guard still blocks on a real transition,
-    // and the routed path always pins one (`OLLAMA_TEST_MODEL` is mandatory in
-    // `resolveTestTargets`); called for a keyless provider WITHOUT a model it
-    // would settle on the first read and prove nothing.
-    const config = providerConfigMap[provider];
+    // #751: the Agent node mounts on the model selector's DEFAULT model — measured
+    // on 1.12.0.dev16 as `{ name: "claude-opus-5", provider: "Anthropic" }` — and
+    // only flips to the requested model once the editor's debounced autosave
+    // `PATCH /api/v1/flows/{id}` carries the pick. A caller that opens the Playground
+    // and sends a message in between runs the DEFAULT provider's model with that
+    // provider's key, surfacing as "Flow build failed: Incorrect API key provided"
+    // and a `div-chat-message` that never renders (the daily-#744 signature). Block
+    // until the PERSISTED flow shows the requested provider, so every caller starts
+    // settled.
+    //
+    // The axis is the PROVIDER of the persisted model, not `api_key` (#1274). Upstream
+    // #14311 stopped writing that field — it reads `""` from mount onward on every
+    // 1.12 build — so waiting on it could only ever time out, which is what failed 14
+    // @stable specs on the 2026-08-05 daily. The provider is not a weaker substitute:
+    // with `api_key` empty the runtime resolves the key FROM it
+    // (`get_api_key_for_provider`), so it is the input that decides which credential
+    // the run uses.
+    //
+    // This also fixes what the credential axis could not express for a KEYLESS
+    // provider (#1187): `""` was both the settled state and the pre-selection state,
+    // so the guard leaned on the caller passing a model. `provider: "Ollama"` is a
+    // positive assertion, which is why no `credential === "base-url"` special case
+    // survives here — and why the three callers that pin no model
+    // (`model-provider-model-toggle`, `general-bugs-agent-images-playground`,
+    // `agent-model-connection-isolation`) still block on a real transition.
     await this.waitForAgentCredentialSettled(
       flowId,
-      config.credential === "base-url" ? "" : config.envKeys[0],
+      langflowProviderName(provider),
       { provider, model },
     );
 
@@ -132,8 +130,8 @@ export class SimpleAgentTemplatePage extends BasePage {
   }
 
   /**
-   * Block until the persisted flow shows the Agent bound to `expectedCredential`
-   * AND carrying the requested model. #751, reworked in #1072.
+   * Block until the persisted flow shows the Agent carrying `expectedProvider`
+   * AND the requested model. #751, reworked in #1072, re-pointed in #1274.
    *
    * What #1072 changed, and what it deliberately did not:
    *
@@ -161,7 +159,7 @@ export class SimpleAgentTemplatePage extends BasePage {
    */
   private async waitForAgentCredentialSettled(
     flowId: string,
-    expectedCredential: string,
+    expectedProvider: string,
     expected: { provider: Provider; model?: string },
   ): Promise<void> {
     const startedAt = Date.now();
@@ -218,7 +216,7 @@ export class SimpleAgentTemplatePage extends BasePage {
           probe = readAgentCredentialProbe(body);
           lastReadError = undefined;
           if (
-            classifyCredentialSettle(probe, expectedCredential, expected.model) ===
+            classifyCredentialSettle(probe, expectedProvider, expected.model) ===
             "settled"
           ) {
             const elapsedMs = Date.now() - startedAt;
@@ -257,14 +255,14 @@ export class SimpleAgentTemplatePage extends BasePage {
       formatCredentialSettleFailure({
         flowId,
         provider: expected.provider,
-        expectedCredential,
+        expectedProvider,
         expectedModel: expected.model,
         probe,
         // A binding nobody managed to read is UNKNOWN, not absent: collapsing the
         // two would make the guard assert "this flow has no Agent node" about a
         // flow it never fetched — the shape of every read on daily 30444299314.
         verdict: everRead
-          ? classifyCredentialSettle(probe, expectedCredential, expected.model)
+          ? classifyCredentialSettle(probe, expectedProvider, expected.model)
           : "read-failed",
         elapsedMs: Date.now() - startedAt,
         reads,

--- a/tests/pages/SimpleAgentTemplatePage.ts
+++ b/tests/pages/SimpleAgentTemplatePage.ts
@@ -11,7 +11,6 @@ import {
 } from "../helpers/flows/agent-credential-settle";
 import {
   langflowProviderName,
-  providerConfigMap,
   providerSetupMap,
   hasProviderEnvKeys,
   missingProviderEnvKeys,
@@ -45,12 +44,15 @@ export interface LoadSimpleAgentOptions {
  *    nothing in flight at attach time — so it expires first. Measured locally: it
  *    resolved at ~0.7 s on a settle that completed at 1.5 s, having tracked no
  *    request at all. Under load it degenerates into a 700 ms sleep.
- *  - **Waiting on the rebind POST itself** (armable in `load()` before the setup
+ *  - **Waiting on the refresh POST itself** (armable in `load()` before the setup
  *    call, so no change to the setup helpers). The disqualifier is that the same
- *    POST has ALREADY fired once when the Agent node mounted — the `api_key`
- *    prefill — so a single `waitForResponse` resolves on the prefill, not on the
- *    rebind, and telling them apart means inspecting bodies for a value this guard
- *    can read directly from the flow.
+ *    POST has ALREADY fired once when the Agent node mounted, so a single
+ *    `waitForResponse` resolves on that one rather than on the selection, and
+ *    telling them apart means inspecting bodies for a value this guard reads
+ *    directly from the flow. (Pre-#1274 this rationale named the `api_key` prefill
+ *    as what the first POST carried; #14311 removed that prefill, but the first
+ *    POST still fires at mount — the mount-time DEFAULT model is what it applies —
+ *    so the disqualifier stands on the same mechanism.)
  */
 const CREDENTIAL_SETTLE_TIMEOUT_MS = 20_000;
 
@@ -107,7 +109,7 @@ export class SimpleAgentTemplatePage extends BasePage {
     //
     // The axis is the PROVIDER of the persisted model, not `api_key` (#1274). Upstream
     // #14311 stopped writing that field — it reads `""` from mount onward on every
-    // 1.12 build — so waiting on it could only ever time out, which is what failed 14
+    // 1.12 build — so waiting on it could only ever time out, which is what failed 13
     // @stable specs on the 2026-08-05 daily. The provider is not a weaker substitute:
     // with `api_key` empty the runtime resolves the key FROM it
     // (`get_api_key_for_provider`), so it is the input that decides which credential
@@ -147,15 +149,18 @@ export class SimpleAgentTemplatePage extends BasePage {
    *    wait mechanisms measured and rejected here.
    *
    * Why the PERSISTED flow and not a UI signal, which directive (c) of #1072 asks
-   * about: the model widget (`model_model`) does settle earlier — it renders from
-   * the in-memory store, and `modelInputComponent.spec.ts` already reads it — but
-   * it only covers the axis that is not the risk. The risk #751 exists for is the
-   * credential, and that has no non-modal surface: on the running nightly the
-   * Agent's `api_key` is `show: true, advanced: true` (check it with `GET
-   * /api/v1/all` → `.models_and_agents.Agent.template.api_key`), so reading it off the canvas
-   * means opening the node's advanced-settings modal — an extra interaction on the
-   * very canvas whose state is being measured. One persisted read covers both axes
-   * and is the only observable that PROVES the rebind instead of proxying it.
+   * about: because the RUN builds the persisted flow, and the widget and the
+   * database disagreed on every failing run this guard was added for. The widget
+   * (`model_model`) settles earlier — it renders from the in-memory store, and
+   * `modelInputComponent.spec.ts` reads it — so gating on it would return before
+   * the autosave landed, which is the race itself.
+   *
+   * Pre-#1274 this paragraph argued it differently: that the risk was the
+   * credential, which had no non-modal surface (`api_key` is `show: true,
+   * advanced: true`). That reasoning is void — #14311 removed the field, and the
+   * widget does show the provider-qualified pick. The conclusion is unchanged, but
+   * it now rests on persistence, not on field visibility; a reader sent hunting
+   * `api_key` on the canvas would be chasing nothing.
    */
   private async waitForAgentCredentialSettled(
     flowId: string,
@@ -220,6 +225,21 @@ export class SimpleAgentTemplatePage extends BasePage {
             "settled"
           ) {
             const elapsedMs = Date.now() - startedAt;
+            // Settling on the FIRST read with no pinned model means both available
+            // checks were already true at mount, so nothing was proved — the
+            // inherited hole documented in `classifyCredentialSettle`. Reachable
+            // when the expected provider is the selector's default (anthropic). Said
+            // out loud rather than left silent: a green run is not evidence the
+            // guard did anything here (#1012).
+            if (reads === 1 && !expected.model) {
+              console.warn(
+                `⚠️  agent credential guard: settled on the FIRST read of flow ` +
+                  `${flowId} with no pinned model, so no transition was observed — ` +
+                  `for ${expected.provider} the mount-time default may already ` +
+                  `satisfy it. This load is UNGUARDED; pin a model to make it a ` +
+                  `real check (#1274).`,
+              );
+            }
             if (elapsedMs > CREDENTIAL_SETTLE_SLOW_MS) {
               console.warn(
                 `⚠️  agent credential settled slowly: ${(elapsedMs / 1000).toFixed(1)}s ` +

--- a/tests/pages/SimpleAgentTemplatePage.ts
+++ b/tests/pages/SimpleAgentTemplatePage.ts
@@ -137,11 +137,13 @@ export class SimpleAgentTemplatePage extends BasePage {
    *
    * What #1072 changed, and what it deliberately did not:
    *
-   *  - **The check is no longer credential-only.** For `provider: "anthropic"` the
-   *    expected credential IS the selector's default auto-binding, so the old
-   *    check returned "settled" before the model selection had been applied at
-   *    all — `load()`'s contract did not hold for that provider. See
-   *    `classifyCredentialSettle`.
+   *  - **The check is not credential-based at all since #1274.** #1072 widened a
+   *    credential-only check to credential+model, because for `provider:
+   *    "anthropic"` the expected credential WAS the selector's default binding, so
+   *    the old check settled before the selection applied. #14311 then removed the
+   *    binding entirely, so the axis is now the PROVIDER of the persisted model.
+   *    See `classifyCredentialSettle` — including the one combination (anthropic +
+   *    no pinned model) that remains unguarded and is warned about below.
    *  - **The failure is now self-describing** rather than a bare `toBe` mismatch
    *    that reads as a provider-wiring bug (which is how it was triaged twice).
    *  - **The budget is unchanged.** The recorded flakes are load-induced and the


### PR DESCRIPTION
Closes #1274

## What broke

Upstream #14311 ("stop automatic provider field binding", `646bdd6b`) deleted the block that wrote the credential variable name into the Agent node's `api_key`. It reached the 1.12 line on **2026-08-04** (`b65e195eb1`, merge of `release-1.11.2` into `release-1.12.0`), and the **2026-08-05** daily was the first nightly carrying it: **13 `@stable` specs** failed the `#751` credential-settle guard, each after waiting its full 20 s for a transition that can no longer happen.

Measured on `1.12.0.dev16` (local nightly; auto-bind confirmed absent from the image itself):

| read | `api_key` | `model.value[0]` |
|---|---|---|
| 0 | `""` (`load_from_db: false`) | `{name: "claude-opus-5", provider: "Anthropic"}` ← mount default |
| 1–7 | `""` | `{name: "gemini-2.5-flash", provider: "Google Generative AI"}` |

## The fix, and why it is not a capitulation

The credential is no longer **stored**, but it is still **determined** — by the provider of the selected model. With `api_key` empty, `get_api_key_for_provider` (`lfx/base/models/unified_models/credentials.py`) resolves `get_provider_secret_variable_key(provider)` from the user's global variables. So the guard settles on `template.model.value[0].provider`: not a weaker proxy for the credential, but the input the runtime derives it from.

**The race #751 exists for is unchanged and still real**, which is why the guard is re-pointed rather than deleted — read 0 above is the mount-time default, and a caller that opens the Playground in between runs the *default* provider's model (the original #744 signature).

`api_key` is asserted in **neither** direction. Requiring it empty would swap one dated premise for another and break `manual.yml` lanes that can dispatch a pre-#14311 build.

The provider string is Langflow's own spelling, **derived** from `providerTestId` rather than listed again (the panel testid is `provider-item-<the same name>`; both come from Langflow's provider metadata). A second hardcoded table is what #1043 and #1184 had to remove after it drifted.

This also fixes what the credential axis could not express for a **keyless** provider (#1187): `""` was both the settled state and the pre-selection state, so the guard leaned on the caller pinning a model. `provider: "Ollama"` is a positive assertion — which is also why the three callers that pin no model keep a real check instead of settling on the first read.

## Two commits, on purpose

`95ad238` is the change; `48aeebd` applies an **independent adversarial review** run with clean context. Two of its eight findings were real errors in the first commit's own claims:

- **The #1072 vacuity was not closed, and the docstring said it was.** For `anthropic` + no pinned model the mount state already satisfies both checks, so the first read settles and nothing is proved. The pre-#1274 code had the identical hole by the identical route, so it is inherited rather than introduced — but the claim was wrong. Closing it needs an observable this module does not have (default vs. deliberate pick), so the vacuum is made **visible**: the Page Object warns when it settles on the first read with no pinned model. Matters on the anthropic rotation day (#1185).
- **Provider and model were compared on two independent arrays**, so a payload whose entries each carry half of the wanted pair classified as `settled` for a combination no entry contains. The probe now carries **paired** entries. The test fixture takes `[provider, model]` tuples, because the parallel-array fixture could not express the bug it was meant to catch.

Also from the review: `provider-pending` asserted a provider nobody observed when `providers=[]` (new `provider-unobservable` verdict); **`langflowProviderName` had zero coverage** — replacing its body with `return providerTestId` passed all 436 unit tests while making the guard time out for all 29 dependent specs, and that mutation now fails three tests; "14 specs" was 13; a dead import; four comments contradicted by the code; and the `api_key is EMPTY` note printed even where no api_key was observed.

The review also **closed two gaps the first commit admitted**, by measuring what it could not: the unverified `"OpenAI"` and `"Ollama"` strings are correct (checked against `GET /api/v1/models/providers` on the live nightly, the upstream `agentics/constants.py`, and the frontend's testid template — the derivation is structural, not a convention), and `model.value[0]` already carries `provider` at v1.10.0 through v1.11.1, so the backward-compatibility claim holds.

## Validation

Against the local nightly `1.12.0.dev16`. **Only google has credit here** — openai and anthropic both return `insufficient_quota` from the providers themselves — so live coverage is single-provider; the other three rest on the measured/derived evidence above.

- `model-provider-model-toggle.spec.ts` → **1 passed** (a no-pinned-model caller, and one of the 13)
- `google-provider.spec.ts` → **2 passed**, including the end-to-end Agent execution — which is what proves the runtime credential fallback works with `api_key: ""`
- **Forced failure**: expected provider replaced with a bogus string → the guard fails with `provider-pending` and prints `observed providers=[Google Generative AI] models=[gemini-3.5-flash-lite] api_key=""`. Not a false positive.
- Re-validated after the classifier rework; the new vacuity warning does not fire for google (correct — google is not the selector's default).
- Gates: `typecheck` clean, `lint` 0 errors, `test:units` **442**, `test:scripts` **702**, both QA-CHECKLIST guards.

## Deliberately NOT in this PR

Two specs assert the old contract **themselves**, outside the shared guard, so this change does not reach them. Both need their spec doc updated first (the repo's SDD gate), which is why they are not bundled here:

- `mcp/client/mcp-client-agent.spec.ts:86` — carries a **private copy** of the guard with `expect(...api_key?.value).toBe(expectedCredential)`. Found by the review; my own blast-radius claim had missed it because a private copy matches no import of the shared module. It is `@mcp @agents @regression` with **no `@stable`**, so the daily gives no signal on it.
- `openai-compatible-provider-setup.spec.ts:620` — `@stable`, still red on this root cause; its spec doc explicitly declares `template.api_key.value`.

**So the daily stays red on one `@stable` spec after this merges**, and that is stated rather than discovered later.

One unrelated failure seen while validating, not caused by and not fixed here: `agent-system-prompt.spec.ts` got past the guard and the model answered, then failed on a **truncated sentinel** (`…PINEAPPLE-1785939935193-2` vs `…-2XPDFN`) on `gemini-2.5-flash`.
