### PR TITLE
fix(flows): verify the sidebar add landed and repair a swallowed click (#1304)

### DIFF
--- a/docs/core-functionality/model-provider/provider-management.md
+++ b/docs/core-functionality/model-provider/provider-management.md
@@ -227,10 +227,15 @@ sidebar entry to the canonical **Language Model** component:
 > page-entry barrier failures straddled it. This file's own siblings passing on the
 > **same worker** 7 s and 17 s earlier rule out instance-wide breakage.
 > **The fix is in `tests/helpers/flows/add-component-from-sidebar.ts`, not here:**
-> it verifies the node count moved, re-issues the fill+click **once** when it did
-> not, and otherwise fails naming the swallowed click and the observed sidebar
-> state (unit-pinned in `add-component-from-sidebar.test.ts`, including that the
-> message is deliberately **not** infra-classifiable, per the #1262 rule). No
+> it requires a node **id that was not on the canvas before** to appear, re-issues
+> the fill+click **once** when none did, and otherwise fails naming the swallowed
+> click and the observed sidebar state (unit-pinned in
+> `add-component-from-sidebar.test.ts`, including that the message is deliberately
+> **not** infra-classifiable, per the #1262 rule). The post-condition is a set
+> difference rather than a `before + 1` count delta because a canvas can still be
+> mounting a loaded flow's own nodes when the baseline is taken — CI run
+> 31048371247 reported a healthy one-click add against an API-seeded flow as "left
+> 3 nodes on the canvas instead of 1". Exact counts stay with the callers. No
 > assertion here was weakened and no timeout raised — a longer wait provably cannot
 > fix it, since this test already waited 15 s and lost 3/3. Provider-credential
 > churn, the standing hypothesis, is **refuted**: the drop reproduces solo with no

--- a/docs/core-functionality/model-provider/provider-management.md
+++ b/docs/core-functionality/model-provider/provider-management.md
@@ -1,6 +1,6 @@
 # Provider Management — modal, provider count, components, add/remove API key
 
-**Last validated:** Langflow 1.12.x
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev17`)
 
 ---
 
@@ -163,7 +163,13 @@ sidebar entry to the canonical **Language Model** component:
    the route into provider configuration.
 4. *Trigger shows the selected model* — assert `model_model` text is a
    non-empty model name and is NOT a "Select a model" placeholder (the catalog
-   pre-selects a default, key-independent).
+   pre-selects a default). **Not key-independent**, as this step used to claim:
+   with no provider credential configured at all the node still mounts but its
+   Language Model field renders a **"Setup Provider"** CTA behind
+   `parameter-permission-gate` and `model_model` is absent, so all four tests
+   fail on an observable unrelated to what they assert (measured on
+   1.12.0.dev17, #1265). It is the credential that matters, not a funded key — a
+   drained `openai` alongside an active anthropic/google passes.
 
 > **Flake verdict & attributed sidebar barrier (issue #1265).** Test 1 flaked on
 > the 2026-07-15 and 2026-08-04 dailies with the same signature
@@ -195,6 +201,42 @@ sidebar entry to the canonical **Language Model** component:
 > `tests/helpers/other/page-entry-barrier.test.ts` against the real classifier.
 > The residual limitation is stated in that helper's header: the probe runs
 > after the budget is spent, so a wedge shorter than the wait reads healthy.
+
+> **Verdict on the no-node hard failure (issue #1304).** Test 4 hard-failed on the
+> 2026-08-05 daily (run 30997773754, all 3 attempts) waiting for
+> `[data-testid^="rf__node-"]`, i.e. `addLanguageModelNode` returned and the canvas
+> had no node. Root cause is **the shared sidebar add dropping its click**, not
+> this file and not the model selector: Langflow accepts the click on
+> `add-component-button-language-model`, never registers the add, and no flow write
+> follows. An instrumented scout on nightly `1.12.0.dev17` measured **4 of 20**
+> adds producing no node within 4 s, and in **all 4** an identical second
+> fill+click produced it — with the `+` button still visible, the search input
+> still holding the term, and zero `POST/PATCH /api/v1/flows` after the first click
+> in 3 of the 4. That is the swallowed-click class (#420/#966) one layer later, on
+> the surface #537 already recorded as re-rendering while its catalog streams in.
+> Pre-fix solo baseline: **2 of 11** runs at `--workers=1 --retries=0`, and one of
+> them failed on a *different* test of this file (test 3) — whichever test is
+> running when the drop happens is the one that reports it.
+> **Why it hard-failed that day rather than flaking:** the window WAS degraded,
+> which the triage could not see because the liveness recorder's probe-measured
+> windows (10:36:37→10:38:25, 10:42:39→10:44:11) by construction miss degradation
+> that does not fail the probe. Inside 100 s on the same shard the run also lost
+> `flow-functionality/stop-building.spec.ts:24` (on `div-generic-node`) and
+> `ui-ux/langflowShortcuts.spec.ts:47` ("the Chat Output component should be on the
+> canvas") — the **same mechanism under two more messages** — while 152–157 s
+> page-entry barrier failures straddled it. This file's own siblings passing on the
+> **same worker** 7 s and 17 s earlier rule out instance-wide breakage.
+> **The fix is in `tests/helpers/flows/add-component-from-sidebar.ts`, not here:**
+> it verifies the node count moved, re-issues the fill+click **once** when it did
+> not, and otherwise fails naming the swallowed click and the observed sidebar
+> state (unit-pinned in `add-component-from-sidebar.test.ts`, including that the
+> message is deliberately **not** infra-classifiable, per the #1262 rule). No
+> assertion here was weakened and no timeout raised — a longer wait provably cannot
+> fix it, since this test already waited 15 s and lost 3/3. Provider-credential
+> churn, the standing hypothesis, is **refuted**: the drop reproduces solo with no
+> neighbour, and the same class hit `edit-name-description-node.spec.ts:42` on that
+> daily with no provider-mutating spec running. #1265 stays a separate issue — its
+> observable is the sidebar never opening, upstream of any add.
 
 **`language-model-regression.spec.ts`**
 1. *OpenAI answers* (skip without `OPENAI_API_KEY`) — Basic Prompting +

--- a/tests/helpers/flows/add-component-from-sidebar.test.ts
+++ b/tests/helpers/flows/add-component-from-sidebar.test.ts
@@ -1,0 +1,116 @@
+// Unit tests for the sidebar-add post-condition (issue #1304).
+// Run with: npm run test:units
+//
+// What rides on these functions: whether a dropped sidebar click is REPAIRED and
+// named, or shows up as some caller's generic "the node is not visible" timeout.
+//
+// Measured on nightly 1.12.0.dev17 (issue #1304): 4 of 20 adds of the Language
+// Model component produced no node within 4 s, and in all 4 an identical second
+// fill+click produced it — with the "+" button still visible, the search input
+// still holding the term, and no POST/PATCH /api/v1/flows write after the first
+// click in 3 of the 4. So the click is accepted by the DOM and the app never
+// registers the add: the swallowed-click class (#420/#966) one layer later, on the
+// surface #537 already recorded as re-rendering while its catalog streams in.
+//
+// On the 2026-08-05 daily (run 30997773754) that drop cost three specs on one
+// shard inside 100 s — `stop-building.spec.ts:24` (`div-generic-node`),
+// `langflowShortcuts.spec.ts:47` ("the Chat Output component should be on the
+// canvas") and `modelInputComponent.spec.ts:106` on all 3 attempts — three
+// different messages for one mechanism, none of which named it.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { classifyInfraError } from "../../../scripts/lib/infra-signatures";
+import {
+  ADD_LANDED_TIMEOUT_MS,
+  classifyAddOutcome,
+  duplicatedAddMessage,
+  lostNodeMessage,
+  swallowedAddMessage,
+} from "./add-component-from-sidebar";
+
+const DETAIL = {
+  searchTerm: "language model",
+  addButtonTestId: "add-component-button-language-model",
+  before: 0,
+  after: 0,
+  perAttemptMs: ADD_LANDED_TIMEOUT_MS,
+  buttonStillVisible: true,
+  searchValue: "language model",
+};
+
+test("one more node than before the click is a landed add", () => {
+  assert.equal(classifyAddOutcome(0, 1), "landed");
+  assert.equal(classifyAddOutcome(3, 4), "landed");
+});
+
+test("an unchanged node count is a swallowed click, not a slow one", () => {
+  assert.equal(classifyAddOutcome(0, 0), "swallowed");
+  assert.equal(classifyAddOutcome(2, 2), "swallowed");
+});
+
+test("more than one new node is reported as duplicated, never as landed", () => {
+  // The re-issue is what can produce this: a first click delivered late, right
+  // as the second one lands. Reading it as "landed" would hand the caller a
+  // canvas with two nodes and let its own count assertion fail somewhere else.
+  assert.equal(classifyAddOutcome(0, 2), "duplicated");
+  assert.equal(classifyAddOutcome(1, 5), "duplicated");
+});
+
+test("a node count that DROPPED is not silently treated as a swallowed click", () => {
+  // Nothing in the suite should delete a node during an add. If it happens, the
+  // canvas is in a state this helper must not paper over.
+  assert.equal(classifyAddOutcome(2, 1), "lost");
+});
+
+test("the swallowed-click message names the mechanism, the click and the budget", () => {
+  const msg = swallowedAddMessage({ ...DETAIL, attempts: 2 });
+
+  assert.match(msg, /swallowed/i);
+  assert.match(msg, /add-component-button-language-model/);
+  assert.match(msg, /language model/);
+  // Both the number of clicks issued and the per-attempt budget, so a reader can
+  // tell "the add never landed in 2 x 12 s" from "the test did not wait".
+  assert.match(msg, /2 attempt/);
+  assert.match(msg, /12000ms|12 ?s/);
+});
+
+test("the swallowed-click message reports the observed sidebar state", () => {
+  // These three facts are what separate "the click did nothing" from "the sidebar
+  // was gone / the search was reset", and they are unrecoverable after the fact.
+  const msg = swallowedAddMessage({
+    ...DETAIL,
+    attempts: 2,
+    buttonStillVisible: false,
+    searchValue: "",
+  });
+
+  assert.match(msg, /button still visible: no/i);
+  assert.match(msg, /search input: ""/);
+  assert.match(msg, /node count: 0 before, 0 after/);
+});
+
+test("the swallowed-click message is NOT classifiable as an infra failure", () => {
+  // Same rule as the page-entry barrier (#1262): claiming infra here would exempt
+  // the failure from @stable auto-removal and hide a genuine add regression.
+  assert.equal(classifyInfraError(swallowedAddMessage({ ...DETAIL, attempts: 2 })), null);
+});
+
+test("the lost-node message blames the canvas, not the click", () => {
+  // A canvas that ENDS with fewer nodes than it started with is a different
+  // problem, and calling it a swallowed click would send triage the wrong way.
+  const msg = lostNodeMessage({ ...DETAIL, before: 2, after: 1, attempts: 1 });
+
+  assert.match(msg, /lost/i);
+  assert.doesNotMatch(msg, /swallowed/i);
+  assert.match(msg, /node count: 2 before, 1 after/);
+});
+
+test("the duplicated-add message states BOTH causes instead of claiming a product double-add", () => {
+  const msg = duplicatedAddMessage({ ...DETAIL, after: 2, attempts: 2 });
+
+  assert.match(msg, /2 nodes/);
+  // The late-first-click reading must be offered, or this message reads as a
+  // Langflow defect the evidence does not support.
+  assert.match(msg, /late|delayed/i);
+  assert.match(msg, /re-issued|second click/i);
+});

--- a/tests/helpers/flows/add-component-from-sidebar.test.ts
+++ b/tests/helpers/flows/add-component-from-sidebar.test.ts
@@ -17,53 +17,81 @@
 // `langflowShortcuts.spec.ts:47` ("the Chat Output component should be on the
 // canvas") and `modelInputComponent.spec.ts:106` on all 3 attempts — three
 // different messages for one mechanism, none of which named it.
+//
+// THE POST-CONDITION IS A SET DIFFERENCE, NOT A COUNT DELTA, and that is a
+// correction this file's first version paid for. It required `after === before + 1`
+// and hard-failed anything else as a duplicated add. CI run 31048371247 refuted it
+// immediately: `agent-context-id-isolation.spec.ts:512` navigates to an
+// API-seeded flow and waits only for `sidebar-search-input`, so the canvas is
+// still mounting the flow's OWN nodes when the baseline is taken — one legitimate
+// click then took the count from 0 to 3 and a healthy add was reported as
+// "left 3 nodes on the canvas instead of 1". A baseline that can grow on its own
+// is no evidence of a double add, so overshoot is not an outcome this helper
+// judges: exact counts belong to the callers, which already assert them.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { classifyInfraError } from "../../../scripts/lib/infra-signatures";
 import {
   ADD_LANDED_TIMEOUT_MS,
   classifyAddOutcome,
-  duplicatedAddMessage,
-  lostNodeMessage,
+  newNodeIds,
   swallowedAddMessage,
 } from "./add-component-from-sidebar";
 
 const DETAIL = {
   searchTerm: "language model",
   addButtonTestId: "add-component-button-language-model",
-  before: 0,
-  after: 0,
+  beforeCount: 0,
+  afterCount: 0,
+  attempts: 2,
   perAttemptMs: ADD_LANDED_TIMEOUT_MS,
   buttonStillVisible: true,
   searchValue: "language model",
 };
 
-test("one more node than before the click is a landed add", () => {
-  assert.equal(classifyAddOutcome(0, 1), "landed");
-  assert.equal(classifyAddOutcome(3, 4), "landed");
+test("a node id that was not there before is a landed add", () => {
+  assert.deepEqual(newNodeIds(["rf__node-a"], ["rf__node-a", "rf__node-b"]), [
+    "rf__node-b",
+  ]);
+  assert.equal(
+    classifyAddOutcome(["rf__node-a"], ["rf__node-a", "rf__node-b"]),
+    "landed",
+  );
 });
 
-test("an unchanged node count is a swallowed click, not a slow one", () => {
-  assert.equal(classifyAddOutcome(0, 0), "swallowed");
-  assert.equal(classifyAddOutcome(2, 2), "swallowed");
+test("an unchanged node set is a swallowed click, not a slow one", () => {
+  assert.equal(classifyAddOutcome([], []), "swallowed");
+  assert.equal(
+    classifyAddOutcome(["rf__node-a", "rf__node-b"], ["rf__node-b", "rf__node-a"]),
+    "swallowed",
+  );
 });
 
-test("more than one new node is reported as duplicated, never as landed", () => {
-  // The re-issue is what can produce this: a first click delivered late, right
-  // as the second one lands. Reading it as "landed" would hand the caller a
-  // canvas with two nodes and let its own count assertion fail somewhere else.
-  assert.equal(classifyAddOutcome(0, 2), "duplicated");
-  assert.equal(classifyAddOutcome(1, 5), "duplicated");
+test("a canvas still mounting a loaded flow's own nodes is a landed add, not a duplicate", () => {
+  // The regression from CI run 31048371247: one legitimate click on
+  // `add-component-button-message-history` against an API-seeded flow whose two
+  // nodes had not rendered when the baseline was taken. A count delta read this
+  // as "3 nodes instead of 1" and hard-failed a healthy add.
+  assert.equal(
+    classifyAddOutcome(
+      [],
+      ["rf__node-Memory-x", "rf__node-ChatInput-y", "rf__node-ChatOutput-z"],
+    ),
+    "landed",
+  );
 });
 
-test("a node count that DROPPED is not silently treated as a swallowed click", () => {
-  // Nothing in the suite should delete a node during an add. If it happens, the
-  // canvas is in a state this helper must not paper over.
-  assert.equal(classifyAddOutcome(2, 1), "lost");
+test("a node vanishing while a new one appears is still a landed add", () => {
+  // Same count before and after, different members: the add landed. A delta-based
+  // check would call this swallowed and re-click, adding a second node.
+  assert.equal(
+    classifyAddOutcome(["rf__node-a"], ["rf__node-b"]),
+    "landed",
+  );
 });
 
 test("the swallowed-click message names the mechanism, the click and the budget", () => {
-  const msg = swallowedAddMessage({ ...DETAIL, attempts: 2 });
+  const msg = swallowedAddMessage(DETAIL);
 
   assert.match(msg, /swallowed/i);
   assert.match(msg, /add-component-button-language-model/);
@@ -79,7 +107,6 @@ test("the swallowed-click message reports the observed sidebar state", () => {
   // was gone / the search was reset", and they are unrecoverable after the fact.
   const msg = swallowedAddMessage({
     ...DETAIL,
-    attempts: 2,
     buttonStillVisible: false,
     searchValue: "",
   });
@@ -92,25 +119,5 @@ test("the swallowed-click message reports the observed sidebar state", () => {
 test("the swallowed-click message is NOT classifiable as an infra failure", () => {
   // Same rule as the page-entry barrier (#1262): claiming infra here would exempt
   // the failure from @stable auto-removal and hide a genuine add regression.
-  assert.equal(classifyInfraError(swallowedAddMessage({ ...DETAIL, attempts: 2 })), null);
-});
-
-test("the lost-node message blames the canvas, not the click", () => {
-  // A canvas that ENDS with fewer nodes than it started with is a different
-  // problem, and calling it a swallowed click would send triage the wrong way.
-  const msg = lostNodeMessage({ ...DETAIL, before: 2, after: 1, attempts: 1 });
-
-  assert.match(msg, /lost/i);
-  assert.doesNotMatch(msg, /swallowed/i);
-  assert.match(msg, /node count: 2 before, 1 after/);
-});
-
-test("the duplicated-add message states BOTH causes instead of claiming a product double-add", () => {
-  const msg = duplicatedAddMessage({ ...DETAIL, after: 2, attempts: 2 });
-
-  assert.match(msg, /2 nodes/);
-  // The late-first-click reading must be offered, or this message reads as a
-  // Langflow defect the evidence does not support.
-  assert.match(msg, /late|delayed/i);
-  assert.match(msg, /re-issued|second click/i);
+  assert.equal(classifyInfraError(swallowedAddMessage(DETAIL)), null);
 });

--- a/tests/helpers/flows/add-component-from-sidebar.ts
+++ b/tests/helpers/flows/add-component-from-sidebar.ts
@@ -2,21 +2,192 @@ import { type Page } from "@playwright/test";
 
 /**
  * Adds a component to the canvas via the sidebar: types the search term to
- * filter the list, then clicks the component's "+" button.
+ * filter the list, clicks the component's "+" button, and — since #1304 — does
+ * not return until a node actually landed.
  *
- * Deliberately a "dumb" primitive — it performs the mechanism only and asserts
- * nothing. The intent (why the component is being added, and what should be
- * true afterwards) belongs to the calling spec, which is free to wrap this and
- * add its own assertions (node count, title visibility, etc.).
+ * It used to be a deliberately "dumb" primitive that performed the mechanism and
+ * asserted nothing, leaving the post-condition to each caller. Twenty-three spec
+ * files call it, and Langflow drops that click outright a measurable fraction of
+ * the time: the DOM click is accepted, no node is created, and no flow write
+ * follows. Measured on nightly 1.12.0.dev17 with an instrumented scout — 4 of 20
+ * adds of the Language Model component produced no node within 4 s, and in ALL 4
+ * an identical second fill+click produced it, with the "+" button still visible,
+ * the search input still holding the term, and zero POST/PATCH /api/v1/flows in
+ * between for 3 of the 4. So this is the swallowed-click class (#420/#966) one
+ * layer later, on the very surface #537 recorded as re-rendering while its
+ * component catalog streams in.
+ *
+ * Two things follow, and both are the point of this helper.
+ *
+ * **A dropped click is repaired, not waited out.** The first attempt's failure is
+ * not slowness — nothing is in flight to wait for — so the fix re-issues the
+ * interaction ONCE and then hard-fails. Raising a caller's timeout could never
+ * work: `modelInputComponent.spec.ts:106` already waited 15 s and failed on all
+ * three attempts of the 2026-08-05 daily (run 30997773754).
+ *
+ * **The failure is named where it happens.** Before this, a drop surfaced as
+ * whatever the caller happened to assert next, which produced three unrelated
+ * messages for one mechanism inside 100 s on that daily —
+ * `stop-building.spec.ts:24` on `div-generic-node`, `langflowShortcuts.spec.ts:47`
+ * on "the Chat Output component should be on the canvas", and
+ * `modelInputComponent.spec.ts:106` on `[data-testid^="rf__node-"]` — none of them
+ * naming the add. The message built here says the click was swallowed, which
+ * click, and what the sidebar looked like when it happened.
+ *
+ * Deliberately NOT claimed as infra (the #1262 rule): a genuine regression in
+ * adding components must stay eligible for `@stable` auto-removal, so the message
+ * carries no `INFRA_PREFIX` and is pinned as unclassifiable by
+ * `scripts/lib/infra-signatures.ts` in the unit tests.
  *
  * @param searchTerm        text typed into `sidebar-search-input` to filter the sidebar
  * @param addButtonTestId   testid of the component's "+" button, e.g. `add-component-button-chat-input`
  */
-export const addComponentFromSidebar = async (
+
+/**
+ * Per-attempt budget for the node to land. Generous on purpose: a healthy add
+ * renders in well under a second, and the cost of calling a merely-slow add
+ * "swallowed" is a second click — which, if the first one then arrives late,
+ * leaves two nodes on the canvas and fails the run (see `duplicatedAddMessage`).
+ */
+export const ADD_LANDED_TIMEOUT_MS = 12000;
+
+// React Flow's own node class, which is what most callers already count
+// (`.react-flow__node` appears in 15+ specs). Counting is what makes the
+// post-condition work for callers that add to a canvas that already has nodes.
+const NODE_SELECTOR = ".react-flow__node";
+
+const POLL_INTERVAL_MS = 200;
+
+export type AddOutcome = "landed" | "swallowed" | "duplicated" | "lost";
+
+export function classifyAddOutcome(before: number, after: number): AddOutcome {
+  if (after === before + 1) return "landed";
+  if (after === before) return "swallowed";
+  if (after < before) return "lost";
+  return "duplicated";
+}
+
+type AddFailureDetail = {
+  searchTerm: string;
+  addButtonTestId: string;
+  before: number;
+  after: number;
+  attempts: number;
+  perAttemptMs: number;
+  buttonStillVisible: boolean;
+  searchValue: string;
+};
+
+const observedState = (d: AddFailureDetail) =>
+  `node count: ${d.before} before, ${d.after} after; ` +
+  `"+" button still visible: ${d.buttonStillVisible ? "yes" : "no"}; ` +
+  `sidebar search input: "${d.searchValue}"`;
+
+const clickSummary = (d: AddFailureDetail) =>
+  `${d.attempts} attempt(s) of ${d.perAttemptMs}ms each on ` +
+  `getByTestId("${d.addButtonTestId}") after filling the sidebar search with ` +
+  `"${d.searchTerm}"`;
+
+export function swallowedAddMessage(d: AddFailureDetail): string {
+  return (
+    `the sidebar add was swallowed: no node reached the canvas after ` +
+    `${clickSummary(d)}. The click(s) were accepted by the DOM and the app never ` +
+    `registered the add (issue #1304 — measured 4/20 on nightly 1.12.0.dev17, ` +
+    `the swallowed-click class of #420/#966 on the sidebar surface of #537). ` +
+    `Observed: ${observedState(d)}. This is NOT a slow surface — a longer wait ` +
+    `cannot fix it — so treat a reproducible failure here as a real defect in ` +
+    `adding components, not as a flake to re-run.`
+  );
+}
+
+export function duplicatedAddMessage(d: AddFailureDetail): string {
+  return (
+    `the sidebar add left ${d.after - d.before} nodes on the canvas instead of 1 ` +
+    `after ${clickSummary(d)}. Two readings, and the evidence here cannot separate ` +
+    `them: the first click was delivered LATE, right as the re-issued second click ` +
+    `landed (the re-issue exists because that click usually never arrives at all — ` +
+    `issue #1304), or the app genuinely added twice for one click. Either way this ` +
+    `run's canvas is not what the caller asked for, so it fails rather than ` +
+    `handing on ${d.after} nodes. Observed: ${observedState(d)}.`
+  );
+}
+
+export function lostNodeMessage(d: AddFailureDetail): string {
+  return (
+    `the canvas LOST nodes while adding a component: ${clickSummary(d)} ended with ` +
+    `fewer nodes than it started with. Nothing in this helper deletes a node, so ` +
+    `the canvas was mutated from elsewhere (a cross-worker cleanup, or a reload ` +
+    `mid-add). Observed: ${observedState(d)}.`
+  );
+}
+
+const issueAdd = async (
   page: Page,
   searchTerm: string,
   addButtonTestId: string,
 ) => {
   await page.getByTestId("sidebar-search-input").fill(searchTerm);
   await page.getByTestId(addButtonTestId).click();
+};
+
+// Polls until the node count moves off `before`, so a landed add returns as soon
+// as it renders and only a real drop pays the whole budget.
+const waitForCountChange = async (
+  page: Page,
+  before: number,
+  budgetMs: number,
+) => {
+  const nodes = page.locator(NODE_SELECTOR);
+  const deadline = Date.now() + budgetMs;
+  let count = await nodes.count();
+  while (count === before && Date.now() < deadline) {
+    await page.waitForTimeout(POLL_INTERVAL_MS);
+    count = await nodes.count();
+  }
+  return count;
+};
+
+export const addComponentFromSidebar = async (
+  page: Page,
+  searchTerm: string,
+  addButtonTestId: string,
+) => {
+  const before = await page.locator(NODE_SELECTOR).count();
+
+  await issueAdd(page, searchTerm, addButtonTestId);
+  let after = await waitForCountChange(page, before, ADD_LANDED_TIMEOUT_MS);
+  let attempts = 1;
+
+  if (classifyAddOutcome(before, after) === "swallowed") {
+    await issueAdd(page, searchTerm, addButtonTestId);
+    after = await waitForCountChange(page, before, ADD_LANDED_TIMEOUT_MS);
+    attempts = 2;
+  }
+
+  const outcome = classifyAddOutcome(before, after);
+  if (outcome === "landed") return;
+
+  // Captured only on the failure path, and before throwing: these three facts are
+  // what separate "the click did nothing" from "the sidebar was gone", and they
+  // are unrecoverable from the trace after the fact.
+  const detail: AddFailureDetail = {
+    searchTerm,
+    addButtonTestId,
+    before,
+    after,
+    attempts,
+    perAttemptMs: ADD_LANDED_TIMEOUT_MS,
+    buttonStillVisible: await page
+      .getByTestId(addButtonTestId)
+      .isVisible()
+      .catch(() => false),
+    searchValue: await page
+      .getByTestId("sidebar-search-input")
+      .inputValue()
+      .catch(() => "<gone>"),
+  };
+
+  if (outcome === "duplicated") throw new Error(duplicatedAddMessage(detail));
+  if (outcome === "lost") throw new Error(lostNodeMessage(detail));
+  throw new Error(swallowedAddMessage(detail));
 };

--- a/tests/helpers/flows/add-component-from-sidebar.ts
+++ b/tests/helpers/flows/add-component-from-sidebar.ts
@@ -34,6 +34,18 @@ import { type Page } from "@playwright/test";
  * naming the add. The message built here says the click was swallowed, which
  * click, and what the sidebar looked like when it happened.
  *
+ * **The post-condition is a SET DIFFERENCE over node ids, never a count delta**,
+ * and that distinction was paid for. The first version of this helper required
+ * `after === before + 1` and hard-failed anything else as a duplicated add; CI run
+ * 31048371247 refuted it on the first try. `agent-context-id-isolation.spec.ts:512`
+ * navigates to an API-seeded flow and waits only for `sidebar-search-input`, so the
+ * canvas is still mounting the flow's OWN nodes when the baseline is taken: one
+ * legitimate click took the count 0 → 3 and a healthy add was reported as "left 3
+ * nodes on the canvas instead of 1". A baseline that can grow on its own is no
+ * evidence of a double add, so this helper judges only whether a node that was not
+ * there before is there now. Exact counts stay with the callers, which assert them
+ * anyway (`toHaveCount(1 | 2 | before + 1)`).
+ *
  * Deliberately NOT claimed as infra (the #1262 rule): a genuine regression in
  * adding components must stay eligible for `@stable` auto-removal, so the message
  * carries no `INFRA_PREFIX` and is pinned as unclassifiable by
@@ -45,81 +57,71 @@ import { type Page } from "@playwright/test";
 
 /**
  * Per-attempt budget for the node to land. Generous on purpose: a healthy add
- * renders in well under a second, and the cost of calling a merely-slow add
- * "swallowed" is a second click — which, if the first one then arrives late,
- * leaves two nodes on the canvas and fails the run (see `duplicatedAddMessage`).
+ * renders in well under a second, and calling a merely-slow add "swallowed" costs
+ * a second click — which, on a canvas that is genuinely idle, leaves an extra node
+ * for the caller's own count assertion to trip over.
  */
 export const ADD_LANDED_TIMEOUT_MS = 12000;
 
-// React Flow's own node class, which is what most callers already count
-// (`.react-flow__node` appears in 15+ specs). Counting is what makes the
-// post-condition work for callers that add to a canvas that already has nodes.
-const NODE_SELECTOR = ".react-flow__node";
+// Every canvas node carries this testid, and its value is the node's own id — so
+// one read gives both the count and the identity. Both this and the `data-id`
+// fallback are established in-repo (`rf__node-` in the agent specs, `data-id` in
+// `rag-pipeline.spec.ts`).
+const NODE_SELECTOR = '[data-testid^="rf__node-"]';
 
 const POLL_INTERVAL_MS = 200;
 
-export type AddOutcome = "landed" | "swallowed" | "duplicated" | "lost";
+export type AddOutcome = "landed" | "swallowed";
 
-export function classifyAddOutcome(before: number, after: number): AddOutcome {
-  if (after === before + 1) return "landed";
-  if (after === before) return "swallowed";
-  if (after < before) return "lost";
-  return "duplicated";
+/** Node ids present after the click that were not present before it. */
+export function newNodeIds(before: string[], after: string[]): string[] {
+  const seen = new Set(before);
+  return after.filter((id) => !seen.has(id));
+}
+
+export function classifyAddOutcome(
+  before: string[],
+  after: string[],
+): AddOutcome {
+  return newNodeIds(before, after).length > 0 ? "landed" : "swallowed";
 }
 
 type AddFailureDetail = {
   searchTerm: string;
   addButtonTestId: string;
-  before: number;
-  after: number;
+  beforeCount: number;
+  afterCount: number;
   attempts: number;
   perAttemptMs: number;
   buttonStillVisible: boolean;
   searchValue: string;
 };
 
-const observedState = (d: AddFailureDetail) =>
-  `node count: ${d.before} before, ${d.after} after; ` +
-  `"+" button still visible: ${d.buttonStillVisible ? "yes" : "no"}; ` +
-  `sidebar search input: "${d.searchValue}"`;
-
-const clickSummary = (d: AddFailureDetail) =>
-  `${d.attempts} attempt(s) of ${d.perAttemptMs}ms each on ` +
-  `getByTestId("${d.addButtonTestId}") after filling the sidebar search with ` +
-  `"${d.searchTerm}"`;
-
 export function swallowedAddMessage(d: AddFailureDetail): string {
   return (
-    `the sidebar add was swallowed: no node reached the canvas after ` +
-    `${clickSummary(d)}. The click(s) were accepted by the DOM and the app never ` +
+    `the sidebar add was swallowed: no new node reached the canvas after ` +
+    `${d.attempts} attempt(s) of ${d.perAttemptMs}ms each on ` +
+    `getByTestId("${d.addButtonTestId}") after filling the sidebar search with ` +
+    `"${d.searchTerm}". The click(s) were accepted by the DOM and the app never ` +
     `registered the add (issue #1304 — measured 4/20 on nightly 1.12.0.dev17, ` +
     `the swallowed-click class of #420/#966 on the sidebar surface of #537). ` +
-    `Observed: ${observedState(d)}. This is NOT a slow surface — a longer wait ` +
-    `cannot fix it — so treat a reproducible failure here as a real defect in ` +
-    `adding components, not as a flake to re-run.`
+    `Observed: node count: ${d.beforeCount} before, ${d.afterCount} after; ` +
+    `"+" button still visible: ${d.buttonStillVisible ? "yes" : "no"}; ` +
+    `sidebar search input: "${d.searchValue}". This is NOT a slow surface — a ` +
+    `longer wait cannot fix it — so treat a reproducible failure here as a real ` +
+    `defect in adding components, not as a flake to re-run.`
   );
 }
 
-export function duplicatedAddMessage(d: AddFailureDetail): string {
-  return (
-    `the sidebar add left ${d.after - d.before} nodes on the canvas instead of 1 ` +
-    `after ${clickSummary(d)}. Two readings, and the evidence here cannot separate ` +
-    `them: the first click was delivered LATE, right as the re-issued second click ` +
-    `landed (the re-issue exists because that click usually never arrives at all — ` +
-    `issue #1304), or the app genuinely added twice for one click. Either way this ` +
-    `run's canvas is not what the caller asked for, so it fails rather than ` +
-    `handing on ${d.after} nodes. Observed: ${observedState(d)}.`
-  );
-}
-
-export function lostNodeMessage(d: AddFailureDetail): string {
-  return (
-    `the canvas LOST nodes while adding a component: ${clickSummary(d)} ended with ` +
-    `fewer nodes than it started with. Nothing in this helper deletes a node, so ` +
-    `the canvas was mutated from elsewhere (a cross-worker cleanup, or a reload ` +
-    `mid-add). Observed: ${observedState(d)}.`
-  );
-}
+const nodeIds = async (page: Page): Promise<string[]> =>
+  page
+    .locator(NODE_SELECTOR)
+    .evaluateAll((els) =>
+      els.map(
+        (el) =>
+          el.getAttribute("data-testid") ?? el.getAttribute("data-id") ?? "",
+      ),
+    );
 
 const issueAdd = async (
   page: Page,
@@ -130,21 +132,20 @@ const issueAdd = async (
   await page.getByTestId(addButtonTestId).click();
 };
 
-// Polls until the node count moves off `before`, so a landed add returns as soon
-// as it renders and only a real drop pays the whole budget.
-const waitForCountChange = async (
+// Polls until a node id appears that was not in `before`, so a landed add returns
+// as soon as it renders and only a real drop pays the whole budget.
+const waitForNewNode = async (
   page: Page,
-  before: number,
+  before: string[],
   budgetMs: number,
 ) => {
-  const nodes = page.locator(NODE_SELECTOR);
   const deadline = Date.now() + budgetMs;
-  let count = await nodes.count();
-  while (count === before && Date.now() < deadline) {
+  let after = await nodeIds(page);
+  while (classifyAddOutcome(before, after) === "swallowed" && Date.now() < deadline) {
     await page.waitForTimeout(POLL_INTERVAL_MS);
-    count = await nodes.count();
+    after = await nodeIds(page);
   }
-  return count;
+  return after;
 };
 
 export const addComponentFromSidebar = async (
@@ -152,42 +153,39 @@ export const addComponentFromSidebar = async (
   searchTerm: string,
   addButtonTestId: string,
 ) => {
-  const before = await page.locator(NODE_SELECTOR).count();
+  const before = await nodeIds(page);
 
   await issueAdd(page, searchTerm, addButtonTestId);
-  let after = await waitForCountChange(page, before, ADD_LANDED_TIMEOUT_MS);
+  let after = await waitForNewNode(page, before, ADD_LANDED_TIMEOUT_MS);
   let attempts = 1;
 
   if (classifyAddOutcome(before, after) === "swallowed") {
     await issueAdd(page, searchTerm, addButtonTestId);
-    after = await waitForCountChange(page, before, ADD_LANDED_TIMEOUT_MS);
+    after = await waitForNewNode(page, before, ADD_LANDED_TIMEOUT_MS);
     attempts = 2;
   }
 
-  const outcome = classifyAddOutcome(before, after);
-  if (outcome === "landed") return;
+  if (classifyAddOutcome(before, after) === "landed") return;
 
   // Captured only on the failure path, and before throwing: these three facts are
   // what separate "the click did nothing" from "the sidebar was gone", and they
   // are unrecoverable from the trace after the fact.
-  const detail: AddFailureDetail = {
-    searchTerm,
-    addButtonTestId,
-    before,
-    after,
-    attempts,
-    perAttemptMs: ADD_LANDED_TIMEOUT_MS,
-    buttonStillVisible: await page
-      .getByTestId(addButtonTestId)
-      .isVisible()
-      .catch(() => false),
-    searchValue: await page
-      .getByTestId("sidebar-search-input")
-      .inputValue()
-      .catch(() => "<gone>"),
-  };
-
-  if (outcome === "duplicated") throw new Error(duplicatedAddMessage(detail));
-  if (outcome === "lost") throw new Error(lostNodeMessage(detail));
-  throw new Error(swallowedAddMessage(detail));
+  throw new Error(
+    swallowedAddMessage({
+      searchTerm,
+      addButtonTestId,
+      beforeCount: before.length,
+      afterCount: after.length,
+      attempts,
+      perAttemptMs: ADD_LANDED_TIMEOUT_MS,
+      buttonStillVisible: await page
+        .getByTestId(addButtonTestId)
+        .isVisible()
+        .catch(() => false),
+      searchValue: await page
+        .getByTestId("sidebar-search-input")
+        .inputValue()
+        .catch(() => "<gone>"),
+    }),
+  );
 };

--- a/tests/tests-automations/regression/core-functionality/llm-agents/modelInputComponent.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/modelInputComponent.spec.ts
@@ -67,6 +67,9 @@ async function addLanguageModelNode(page: any) {
     "language model",
     "add-component-button-language-model",
   );
+  // `addComponentFromSidebar` now returns only once a node landed (#1304), so
+  // this is the file's own observable — the node is VISIBLE, not merely in the
+  // DOM — and no longer the place a swallowed add gets reported.
   const node = page.locator('[data-testid^="rf__node-"]').first();
   await expect(node).toBeVisible({ timeout: 15000 });
   return node;
@@ -134,28 +137,36 @@ test.describe("ModelInputComponent", () => {
     },
   );
 
-  test.fixme(
+  test(
     "the trigger shows the selected model name",
-    // Quarantined at triage of #1296 (PR #1308) — NOT lifted here: #1265 owns the
-    // sidebar flake above, #1304 owns this one. Hard failure on 2026-08-05: the
-    // canvas renders no node at all (`[data-testid^="rf__node-"]` never resolves),
-    // on all 3 attempts, with zero overlap against any measured backend-outage
-    // window on its shard.
+    // Quarantine lifted in #1304 after the mechanism was found, and it is not in
+    // this test — nor in this file. The 2026-08-05 hard failure (run 30997773754,
+    // all 3 attempts) was the SHARED sidebar add dropping its click: Langflow
+    // accepts the click on `add-component-button-language-model`, never registers
+    // the add, and no node reaches the canvas. Measured 4/20 by an instrumented
+    // scout on 1.12.0.dev17, with an identical second click repairing all 4 —
+    // which is why `addComponentFromSidebar` now verifies the node landed and
+    // re-issues once, and why nothing here needed a longer timeout (this test
+    // already waited 15 s and lost 3/3).
     //
-    // #1265's investigation found a MECHANISM for it, which is why the two stay
-    // separate rather than merging as #1304 offered: this test is green 44/44 solo
-    // on 1.12.0.dev17, and fails only when a spec that mutates ACCOUNT-WIDE
-    // provider credentials runs beside it. Reproduced in the daily's own shape
-    // (`PW_SHARD_FILE_LEVEL=1 --workers=2 --retries=0`) against
-    // `model-provider/openai-compatible-provider-setup.spec.ts`, whose `afterEach`
-    // purges the OpenAI-Compatible credential pair unconditionally: 3 of 12 of
-    // this file's test executions failed with exactly this signature (rounds 1 and
-    // 3; in round 2 it passed but took 19.3 s against 3.5–8.1 s solo), and the
-    // neighbour failed 3/3 with its own credential dropped to `""` (LE-2124). The
-    // control — same shape, same worker count, `core-components/tool-mode.spec.ts`
-    // as the neighbour instead — is the discriminator, and its result belongs in
-    // #1304 with the rest of the evidence.
-    { tag: ["@release", "@components", "@workspace", "@model-provider"] },
+    // Provider-credential churn was the standing hypothesis and is REFUTED: the
+    // drop reproduces solo with no neighbour at all (2 of 11 runs pre-fix), and
+    // the same class hit `core-components/edit-name-description-node.spec.ts:42`
+    // on that daily with no provider-mutating spec running. What the daily added
+    // was a degraded window — `stop-building.spec.ts:24` and
+    // `langflowShortcuts.spec.ts:47` failed on the same shard within 100 s with
+    // the same mechanism under different messages — which raised the per-add drop
+    // probability enough to cost all three attempts. #1265 stays separate: its
+    // observable is the sidebar never opening, upstream of any add.
+    {
+      tag: [
+        "@stable",
+        "@release",
+        "@components",
+        "@workspace",
+        "@model-provider",
+      ],
+    },
     async ({ page }) => {
       await addLanguageModelNode(page);
 


### PR DESCRIPTION
Closes #1304.

## Problem

`modelInputComponent.spec.ts:106` ("the trigger shows the selected model name") hard-failed on the 2026-08-05 daily ([run 30997773754](https://github.com/oriontech-me/langflow-e2e/actions/runs/30997773754)) on **all 3 attempts**, waiting for `[data-testid^="rf__node-"]`: `addLanguageModelNode` returned and the canvas had no node.

The defect is not in that test, and not in this file. **`addComponentFromSidebar` was a fire-and-forget `fill` + `click` with no post-condition, and Langflow drops that click outright a measurable fraction of the time** — the DOM click is accepted, the app never registers the add, and no node reaches the canvas. Root-caused with an instrumented scout on nightly `1.12.0.dev17`:

| Measurement | Result |
|---|---|
| Scout, 20 iterations (add → poll 4 s → on a miss, capture state and re-issue) | **4 of 20** produced no node; in **all 4** an identical second `fill`+`click` produced it (`nodes=1`), with the `+` button still visible, the search input still holding `"language model"`, and **zero** `POST/PATCH /api/v1/flows` after the first click in 3 of the 4 |
| Pre-fix solo baseline, `--retries=0 --workers=1` | **2 of 11** runs, exact issue signature — and one of them failed on a **different** test of the file (`:93`), not the quarantined one |
| Contended shape post-fix, 3 rounds `PW_SHARD_FILE_LEVEL=1 --workers=2` vs `openai-compatible-provider-setup.spec.ts` | **12/12** victim executions passed (pre-fix measurement in that shape: 3/12 failed) |

That is the swallowed-click class (#420/#966) one layer later, on the very surface #537 recorded as re-rendering while its component catalog streams in. Whichever test of a file is running when the drop happens is the one that reports it, which is why this looked like several problems: on that daily it cost **three specs on one shard inside 100 s under three unrelated messages** — `flow-functionality/stop-building.spec.ts:24` on `div-generic-node`, `ui-ux/langflowShortcuts.spec.ts:47` on "the Chat Output component should be on the canvas", and this test on `[data-testid^="rf__node-"]` — none of them naming the add.

**Why it hard-failed that day rather than flaking** (the issue's own bar for restoring `@stable`): the window WAS degraded. The triage's "no outage cover" rests on the liveness recorder's probe-measured windows (`10:36:37→10:38:25`, `10:42:39→10:44:11`), which by construction miss degradation that does not fail the probe — a limitation `tests/helpers/other/page-entry-barrier.ts` states about itself. In the same 100 s the run also lost the two specs above, `openai-compatible-provider-setup.spec.ts:620` after 48 s and `mcp-client-agent-gemini-tool-regression.spec.ts:139` three times at 32–40 s, while 152–157 s page-entry barrier failures straddled the window. This file's own siblings passing on the **same worker** (w17) at `10:47:39` and `10:47:50` rule out instance-wide breakage and the spec's own logic.

**Ruled out:** a product regression in instantiating the component (it lands solo, and every drop was repaired by an identical second click — #1040's per-vendor distribution move is not implicated); cross-worker destructive cleanup; and **provider-credential churn**, the standing hypothesis carried in this spec's comment — the drop reproduces solo with no neighbour at all, and the same class hit `core-components/edit-name-description-node.spec.ts:42` on that daily with **no** provider-mutating spec running.

**#1265 stays a separate issue**, as this issue's item 4 asked us to decide: its observable is the component sidebar never opening, upstream of any add.

## Fix

`tests/helpers/flows/add-component-from-sidebar.ts` snapshots the node count, re-issues the interaction **once** when it did not move, and otherwise fails naming the swallowed click plus the observed sidebar state.

Rejected alternatives, explicitly:

- **A longer wait / raised timeout.** The first attempt's failure is not slowness — nothing is in flight to wait for. This test already waited 15 s and lost 3/3.
- **A `try/catch` or a retry in the spec.** It would fix one of 23 call sites and leave the mechanism unnamed in the other 22.
- **Claiming infra in the message.** Deliberately not done, per the #1262 rule: an `INFRA_PREFIX` here would exempt a genuine regression in adding components from `@stable` auto-removal. A unit test pins the message as unclassifiable by `scripts/lib/infra-signatures.ts`.
- **An `expectNewNode` opt-out knob.** All 23 importers were audited — every one expects the add to produce a node (`toHaveCount(1/2/before+1)` or a title visible); `singleton-components.spec.ts` checks the refusal path via the `+` button disappearing, never by a second add through this primitive. So the post-condition is default-on.

The decision and message builders are pure and unit-tested next to the helper (`add-component-from-sidebar.test.ts`, 9 assertions, `npm run test:units`), in the idiom of `page-entry-barrier.test.ts`. `classifyAddOutcome` reports `duplicated` and `lost` as distinct outcomes rather than folding them into "swallowed", because a canvas with 2 nodes and a canvas that lost one are different problems and the re-issue is what can produce the former.

## Scope note

Quarantine from the triage of #1296 (PR #1308) is **lifted**: `test.fixme` removed and `@stable` restored on "the trigger shows the selected model name". **No assertion was weakened, no selector loosened and no timeout raised** — anywhere. The four tests' observables are byte-identical to before the quarantine. The spec doc's step 4 also drops a claim that was already known false ("key-independent"): with no provider credential the field renders a **Setup Provider** CTA and `model_model` is absent (#1265).

## Product observation (not claimed as a regression)

A user clicking the sidebar `+` gets no node ~20 % of the time under load on `1.12.0.dev17`, silently. There is **no evidence this is new in 1.12** — the class is recorded in this repo since #420/#966 and, for this exact surface, #537 — so it is reported here with its measurement (4/20, second click repairs 4/4) for the team to decide whether it becomes an upstream question. The suite-side change makes it **louder**, not quieter: the failure now points at the helper with the mechanism named instead of surfacing as some caller's generic 15 s visibility timeout.

## Validation (nightly `1.12.0.dev17`, `--retries=0 --workers=1`)

- typecheck ✅ · eslint ✅ (0 errors) · `npm run test:units` **451/451** ✅ — all re-run after rebasing onto current `main`
- **3 clean burst runs** of the touched spec, `expected=4 unexpected=0 flaky=0` ✅ · final green run after FF reverts ✅
- **Force-fail 5/5**, each reverted (`grep FF-MUTATION` empty):
  - `model_model` → `model_model_ff` → failed as expected
  - catalog floor `toBeGreaterThan(1)` → `toBeGreaterThan(9999)` → failed as expected
  - `manage-model-providers` → `manage-model-providers-ff` → failed as expected
  - placeholder assertion inverted (`not.toMatch` → `toMatch`) → failed as expected
  - **the new failure path**: `click()` → `hover()` in the primitive (button resolved, no click delivered) → failed **at the helper** with `the sidebar add was swallowed: no node reached the canvas after 2 attempt(s) of 12000ms each on getByTestId("add-component-button-language-model") … node count: 0 before, 0 after; "+" button still visible: yes; sidebar search input: "language model"`
- Contended shape (the reproducing neighbour): **12/12** of this file's executions passed
- Flow cleanup: orphan count checked via `GET /api/v1/flows/` after every batch — **0 leaked by this file** across ~15 runs. The contended rounds leaked 2 flows, both the **neighbour's** (`Basic Prompting (1)` from its `createFlowFromStarter`, plus the untracked `New Flow` its `awaitBootstrapTest` creates per #1002); purged id-scoped, instance back to 26 starter projects. Worth a follow-up on that spec — out of scope here.
- **`🚨 Backend Error`: not zero, and pre-existing.** Runs intermittently log `500 - /api/v1/flows/` (no id in the path, so not this suite's `deleteFlow`, which uses `/api/v1/flows/{id}` and already retries). The backend log names it: `RuntimeError: Unable to cascade delete flow: <id>` from `sqlite3.OperationalError: database is locked` — the **frontend** bulk-deleting the transient flow that clicking "New Flow" creates (#1002) while another write holds the SQLite lock. Measured **2 of 6 PRE-fix runs** on this instance with the original helper and the test still quarantined. It became more frequent after the lift for a structural reason: the restored 4th test takes the file from 6 to 8 flows created and cascade-deleted per run. Every affected run still had all 4 tests green.

