### PR TITLE
fix(ui-ux): separate the two causes behind the global-variables grid flake (#1303)

### DIFF
--- a/docs/ui-ux/global-variables-crud.md
+++ b/docs/ui-ux/global-variables-crud.md
@@ -1,6 +1,6 @@
 # Global Variables — CRUD via the Settings page
 
-**Last validated:** Langflow 1.11.x (nightly `1.11.0.dev49`)
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev16`)
 
 ---
 
@@ -43,6 +43,44 @@ broke in two ways, so the tests were moved to the canonical Settings CRUD page:
 The Settings page has none of these hazards: a single-render data table
 (`treegrid`), no node binding, no 400, and stable testids.
 
+### dev16 — why the row assertion scrolls, and why the list refetch is awaited (#1303)
+
+The table is **ag-grid with row virtualization**, and a newly created variable
+is appended at the **end** of the list. Once the list is longer than the
+rendered window — measured at **18 rows** on the default 1280×720 viewport CI
+also uses — the new row is in the grid's data model but **not in the DOM**, so
+`getByRole("treegrid").getByText(name)` never becomes visible. Measured on
+`1.12.0.dev16`: creates 1–11 satisfy the assert in ~106 ms each; the 12th (19th
+row overall) burns the full 15 s with `rendered=18`, `row-index=[0..17]`,
+`scrollHeight=798` against `clientHeight=324`. Scrolling `.ag-body-viewport` to
+the bottom renders it (`row-index=[1..18]`, row found). **The test could
+therefore fail against a perfectly healthy product**, purely as a function of
+how many variables the account happens to hold — which is the shape of the
+recurring flake #1303 was filed for (2026-07-15, 07-17, 08-05).
+
+Two consequences, both encoded in the steps below:
+
+- The row assertion **scrolls the grid to the end** before asserting, re-scrolling
+  on each poll. This is what a user does; no assertion is weakened by it.
+- `getByRole("treegrid")` reports `element(s) not found` for *both* "the row is
+  below the fold" and "the grid has no rows at all", which is why the failure
+  read as "the variable was never created". The create step now **waits for the
+  `GET /api/v1/variables/` that carries the new name**, so the two states are
+  separated at the point of failure: a missing refetch fails as a missing
+  refetch, and only a row the frontend demonstrably received can fail as a
+  rendering problem.
+
+**Open, and deliberately not fixed here:** on the 2026-08-05 daily
+(run 30997773754, shard 1) the failure was *not* virtualization. The captured
+page snapshot shows ag-grid's `No Data Available` overlay — the grid held **zero**
+rows for the full 15 s after a 201 create, with the modal already closed, the
+backend measurably healthy across the whole window (liveness probes 2–45 ms;
+nearest failed probe one minute earlier) and no HTTP error logged. That state
+did not reproduce on `1.12.0.dev16` in 22 attempts (10 normal + 12 under 8×
+CPU throttling) with the list forced empty at page load. It remains unexplained;
+the awaited refetch above exists so the next occurrence names its own cause
+instead of being absorbed into this one. Tracked on #1303.
+
 ---
 
 ## Tags *(required)*
@@ -63,24 +101,43 @@ gate.
 2. Select the type tab (`generic-tab` / `credential-tab`) BEFORE filling.
 3. Fill name (`Enter a name for the variable...`) and value
    (`Enter a value for the variable...`).
-4. Click `save-variable-btn` and **wait for `POST /api/v1/variables/`** (the
-   deterministic completion signal — no fixed timeout). Capture the created id
-   from the response for API teardown.
+4. Arm two waiters **before** clicking save, so neither can be missed:
+   `POST /api/v1/variables/`, and the `GET /api/v1/variables/` **whose payload
+   contains the new name** (the list the grid renders from).
+5. Click `save-variable-btn`.
+6. Assert the POST returned **201** and a non-empty `id`; capture the id for API
+   teardown. A non-2xx create fails here, naming the status — it is no longer
+   swallowed into a 15 s wait on a row that was never created.
+7. Await the list response. If it never arrives the test fails as *"the
+   variables list was never refetched with `<name>`"*, which is a different
+   verdict from a row that failed to render.
+
+**Shared row helper (`revealVariableRow`)** — scrolls `.ag-body-viewport` to the
+bottom (where a newly appended row lives) and re-scrolls on every poll, then
+returns the `treegrid` cell locator for the name. Defeats row virtualization
+without weakening what is asserted; see the dev16 note above.
 
 **Test 1 — create Generic variable**
 1. Setup → `createVariable({ type: "generic" })`.
-2. Assert the name is visible in the `treegrid`.
+2. `revealVariableRow` → assert the name is visible in the `treegrid`.
 
 **Test 2 — delete variable removes it from the list**
-1. Setup → `createVariable({ type: "generic" })`, assert visible.
+1. Setup → `createVariable({ type: "generic" })`, reveal + assert visible.
 2. Delete is a bulk action: click the row's selection checkbox
    (`.ag-selection-checkbox`), then click `delete-row-button` ("Delete selected
    items", disabled until a row is selected).
-3. Assert the name has `count() === 0` in the `treegrid`.
+3. Wait for the `GET /api/v1/variables/` whose payload **no longer contains**
+   the name — the backend-side proof of removal, symmetric with step 1.
+4. Assert the name has `count() === 0` in the `treegrid`. On a virtualized grid
+   a count of 0 is also what an off-screen row yields, so step 3 is what makes
+   this assertion mean "deleted" rather than "not rendered".
 
 **Test 3 — Credential variable value is hidden from the list**
 1. Setup → `createVariable({ type: "credential", value: SECRET-SENTINEL-… })`.
-2. Sanity: assert the name is visible in the `treegrid`.
+2. Sanity: `revealVariableRow` → assert the name is visible in the `treegrid`.
+   This gate is load-bearing: the leak assertion in step 3 passes trivially on a
+   page that renders no variable at all, so it must not run until the row is
+   provably on screen.
 3. Critical: assert `getByText(sentinelValue)` (substring, no `exact`) has
    `count() === 0` — the value must not surface as rendered text anywhere
    (the table shows it masked as `*****`).
@@ -89,10 +146,14 @@ gate.
 
 ## Validation criterion *(required)*
 
-- Variable name appears in the table after creation (Test 1).
-- Variable name has count 0 after deletion (Test 2).
+- The create returns **201** with an `id`, and a subsequent
+  `GET /api/v1/variables/` carries the new name (all three tests).
+- Variable name appears in the table after creation, with the grid scrolled to
+  where the row lives (Test 1).
+- A `GET /api/v1/variables/` after the delete no longer carries the name, and
+  the name has count 0 in the table (Test 2).
 - Credential sentinel value has substring-text count 0 anywhere on the page
-  after save (Test 3).
+  after save, asserted only once the row is provably on screen (Test 3).
 
 ## Guarding against false positives *(how)*
 
@@ -100,12 +161,21 @@ gate.
   can satisfy an assert.
 - **Deterministic save** (`waitForResponse` on the create POST) — the list
   assertion never races an in-flight save.
+- **A failed create fails as a failed create** — the POST status is asserted
+  (201 + `id`) instead of being swallowed by `.catch(() => {})`, so a create
+  that never happened cannot be reported as a row that never rendered.
+- **The row assert cannot pass or fail on grid geometry** — the grid is scrolled
+  to the appended row on every poll, so neither result depends on how many
+  variables the account holds (#1303).
 - **API-id teardown in `afterEach`** — variables are deleted by the id captured
   at creation, never a UI trash click; this stops a failed teardown from
   leaking a variable that would poison later tests.
 - **Force-failure checks** (CONTRIBUTING §2): create → assert a bogus name ⇒
   fails; delete → skip the delete click ⇒ count-0 assert fails; credential →
-  expect the sentinel count 1 ⇒ fails (it is masked).
+  expect the sentinel count 1 ⇒ fails (it is masked). For the #1303 mechanisms:
+  removing the scroll from `revealVariableRow` ⇒ the row assert fails once the
+  account holds more than the rendered window; accepting a non-201 create ⇒ the
+  create assert stops firing.
 
 ---
 
@@ -144,6 +214,23 @@ gate.
 
 ## Notes *(optional)*
 
+- **#1303 flake verdict (test-side for the reproduced mechanism; one CI
+  observation still open):** ag-grid row virtualization makes the row assertion
+  depend on the account's variable count — reproduced deterministically on
+  `1.12.0.dev16` and fixed by scrolling to the appended row. The 2026-08-05
+  daily failure is a *different* state (grid with zero rows, healthy backend)
+  that does not reproduce and is not explained by this change; the awaited list
+  refetch is there so it reports itself distinctly rather than being absorbed.
+  `@stable` is restored for the reproduced defect, not for the open one — see
+  the dev16 section above and #1303.
+- **Relationship to #1235** (same surface, kept separate): #1235 is a row
+  *interaction* that does not produce its state (the edit modal never opens, the
+  delete button never enables) — rows are present and a click is ignored. #1303
+  is one step earlier: no interaction has happened and the row itself is not in
+  the DOM. The mechanism found here (virtualization on append) cannot produce
+  #1235's symptoms, since those specs act on rows they already located. Kept
+  separate; revisit only if #1235's investigation lands on a shared refresh
+  mechanism.
 - **#810 flake verdict (test-side, not a product regression):** the product
   correctly masks Credential values (verified: the table Value cell shows
   `*****`, the sentinel never renders). The recurring failure was the old

--- a/tests/tests-automations/regression/ui-ux/global-variables-crud.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/global-variables-crud.spec.ts
@@ -22,6 +22,27 @@ import { getAuthToken } from "../../../helpers/auth/get-auth-token";
  * click: a UI teardown that fails under load leaks the variable, and a leaked
  * Credential variable poisons later tests — the real driver of the recurring
  * #810 flake.
+ *
+ * dev16 note (#1303) — the table is ag-grid with ROW VIRTUALIZATION and a new
+ * variable is appended at the END of the list, so past the rendered window
+ * (measured: 18 rows on the 1280x720 viewport CI uses) the row is in the grid's
+ * data model but not in the DOM. `getByRole("treegrid").getByText(name)` then
+ * reports `element(s) not found` — the same message it reports when the grid
+ * has no rows at all, which is why the recurring flake read as "the variable
+ * was never created". Two mechanisms are therefore separated here:
+ *
+ *   - `createVariable` asserts the POST returned 201 with an id, and waits for
+ *     the `GET /api/v1/variables/` that CARRIES the new name. A create that
+ *     failed, or a list the frontend never received, now fails as itself.
+ *   - `revealVariableRow` scrolls the grid to the appended row before asserting
+ *     it, so neither a pass nor a failure depends on how many variables the
+ *     account happens to hold.
+ *
+ * Still open on #1303: on the 2026-08-05 daily the grid held ZERO rows for the
+ * full timeout after a 201 create, with the backend measurably healthy — a
+ * different state from virtualization that did not reproduce locally. The list
+ * wait above exists so its next occurrence names itself instead of being read
+ * as this one.
  */
 
 const createdVariableIds: string[] = [];
@@ -52,9 +73,47 @@ interface NewVariable {
   value: string;
 }
 
-// Create a variable through the "Add New" dialog and block until the create
-// round-trip lands (`POST /api/v1/variables/`) — deterministic under load,
-// unlike a fixed wait. The created id is tracked for API teardown.
+/**
+ * Wait for the list request the grid renders from — `GET /api/v1/variables/`
+ * with no query string (the category-scoped variant is a different list) —
+ * whose payload does or does not carry `name`.
+ *
+ * This is the frontend-side proof that the data reached the page, which is what
+ * separates "the row did not render" from "the row was never in the list".
+ */
+function waitForVariablesList(
+  page: Page,
+  name: string,
+  shouldContain: boolean,
+): Promise<Error | null> {
+  // Settled, never rejecting: an assertion between arming this waiter and
+  // awaiting it can fail first, and a rejected waiter left dangling is then
+  // reported as a second "page.waitForResponse: Test ended" error on top of the
+  // real one. The caller decides what a timeout means.
+  return page
+    .waitForResponse(
+      async (response) => {
+        if (response.request().method() !== "GET") return false;
+        const url = new URL(response.url());
+        if (!url.pathname.endsWith("/api/v1/variables/")) return false;
+        if (url.search) return false;
+        if (!response.ok()) return false;
+        const body = await response.json().catch(() => null);
+        if (!Array.isArray(body)) return false;
+        const present = body.some(
+          (variable: { name?: string }) => variable?.name === name,
+        );
+        return present === shouldContain;
+      },
+      { timeout: 30000 },
+    )
+    .then(() => null)
+    .catch((error: Error) => error);
+}
+
+// Create a variable through the "Add New" dialog. Both round-trips are armed
+// BEFORE the save click so neither can be missed: the create POST, and the list
+// refetch that carries the new name.
 async function createVariable(page: Page, v: NewVariable): Promise<void> {
   await page.getByTestId("api-key-button-store").click(); // "Add New"
   // Select the type tab BEFORE filling, so the value lands on the right field.
@@ -70,14 +129,35 @@ async function createVariable(page: Page, v: NewVariable): Promise<void> {
       resp.request().method() === "POST",
     { timeout: 30000 },
   );
+  const listed = waitForVariablesList(page, v.name, true);
   await page.getByTestId("save-variable-btn").click();
+
   const resp = await saved;
-  await resp
-    .json()
-    .then((body: { id?: string }) => {
-      if (body?.id) createdVariableIds.push(body.id);
-    })
-    .catch(() => {});
+  const body = (await resp.json().catch(() => null)) as { id?: string } | null;
+  expect(
+    resp.status(),
+    `create of "${v.name}" must return 201 (got ${resp.status()})`,
+  ).toBe(201);
+  expect(body?.id, `create of "${v.name}" returned no id`).toBeTruthy();
+  if (body?.id) createdVariableIds.push(body.id);
+
+  // A create that succeeded but never reached the list is a distinct verdict
+  // from a row that failed to render — fail it as itself.
+  await assertListRefetched(
+    listed,
+    `the variables list was never refetched with "${v.name}" after a 201 create`,
+  );
+}
+
+// Resolve a `waitForVariablesList` waiter, turning a timeout into a verdict of
+// its own. Lives outside the test bodies so the branch is not a conditional in
+// a test (`playwright/no-conditional-in-test`).
+async function assertListRefetched(
+  listed: Promise<Error | null>,
+  message: string,
+): Promise<void> {
+  const timedOut = await listed;
+  if (timedOut) throw new Error(message);
 }
 
 // The data table row for a given variable name.
@@ -89,6 +169,36 @@ function variableRow(page: Page, name: string) {
 // Settings page — no node-binding duplicate).
 function variableInTable(page: Page, name: string) {
   return page.getByRole("treegrid").getByText(name, { exact: true });
+}
+
+/**
+ * Bring a newly created variable's row into the rendered window and return its
+ * cell locator. ag-grid only keeps the visible rows plus a buffer in the DOM,
+ * and a new variable is appended last, so the row has to be scrolled to before
+ * it can be asserted — see the dev16 note above (#1303).
+ */
+async function revealVariableRow(page: Page, name: string) {
+  const cell = variableInTable(page, name);
+  await expect
+    .poll(
+      async () => {
+        await page
+          .locator(".ag-body-viewport")
+          .evaluate((el) => {
+            el.scrollTop = el.scrollHeight;
+          })
+          .catch(() => {
+            /* the grid is not rendered yet — reported by the poll below */
+          });
+        return cell.count();
+      },
+      {
+        timeout: 15000,
+        message: `"${name}" never rendered in the variables table (the list request carried it, so the grid did not render it)`,
+      },
+    )
+    .toBeGreaterThan(0);
+  return cell;
 }
 
 test(
@@ -105,7 +215,7 @@ test(
     });
 
     // The variable must appear in the data table after creation.
-    await expect(variableInTable(page, varName)).toBeVisible({
+    await expect(await revealVariableRow(page, varName)).toBeVisible({
       timeout: 15000,
     });
   },
@@ -123,7 +233,7 @@ test(
       type: "generic",
       value: "to-be-deleted",
     });
-    await expect(variableInTable(page, varName)).toBeVisible({
+    await expect(await revealVariableRow(page, varName)).toBeVisible({
       timeout: 15000,
     });
 
@@ -132,7 +242,16 @@ test(
     await variableRow(page, varName).locator(".ag-selection-checkbox").click();
     const deleteButton = page.getByTestId("delete-row-button");
     await expect(deleteButton).toBeEnabled({ timeout: 5000 });
+
+    // Armed before the click: the list the grid re-renders from, without the
+    // variable. On a virtualized grid a count of 0 is also what an off-screen
+    // row yields, so this is what makes the assertion below mean "deleted".
+    const listedWithout = waitForVariablesList(page, varName, false);
     await deleteButton.click();
+    await assertListRefetched(
+      listedWithout,
+      `the variables list was never refetched without "${varName}" after the delete`,
+    );
 
     // The variable must no longer be in the table.
     await expect(variableInTable(page, varName)).toHaveCount(0, {
@@ -141,13 +260,9 @@ test(
   },
 );
 
-test.fixme(
+test(
   "Credential variable value is hidden from the variable list",
-  // Quarantined at triage (#1296): recurrent flake 3x (2026-07-15, 2026-07-17,
-  // 2026-08-05) — the variable the test just created never appears in the grid,
-  // so the sanity assertion fails before the secret-leak assertion is reached.
-  // Restore (`test` + `@stable`) in #1303.
-  { tag: ["@release", "@workspace", "@regression"] },
+  { tag: ["@stable", "@release", "@workspace", "@regression"] },
   async ({ page }) => {
     await openGlobalVariablesSettings(page);
 
@@ -161,8 +276,10 @@ test.fixme(
       value: sentinelValue,
     });
 
-    // Sanity: the variable name IS in the table.
-    await expect(variableInTable(page, varName)).toBeVisible({
+    // Sanity, and load-bearing: the leak assertion below passes trivially on a
+    // page that renders no variable at all, so it must not run until the row is
+    // provably on screen.
+    await expect(await revealVariableRow(page, varName)).toBeVisible({
       timeout: 15000,
     });
 

--- a/tests/tests-automations/regression/ui-ux/global-variables-crud.spec.ts
+++ b/tests/tests-automations/regression/ui-ux/global-variables-crud.spec.ts
@@ -151,13 +151,16 @@ async function createVariable(page: Page, v: NewVariable): Promise<void> {
 
 // Resolve a `waitForVariablesList` waiter, turning a timeout into a verdict of
 // its own. Lives outside the test bodies so the branch is not a conditional in
-// a test (`playwright/no-conditional-in-test`).
+// a test (`playwright/no-conditional-in-test`). The underlying error is kept
+// on the message: "the list never arrived" is the verdict, but a closed page or
+// a navigation reaches this the same way a plain timeout does, and only the
+// original says which.
 async function assertListRefetched(
   listed: Promise<Error | null>,
   message: string,
 ): Promise<void> {
-  const timedOut = await listed;
-  if (timedOut) throw new Error(message);
+  const failure = await listed;
+  if (failure) throw new Error(`${message} — ${failure.message}`);
 }
 
 // The data table row for a given variable name.
@@ -176,6 +179,10 @@ function variableInTable(page: Page, name: string) {
  * cell locator. ag-grid only keeps the visible rows plus a buffer in the DOM,
  * and a new variable is appended last, so the row has to be scrolled to before
  * it can be asserted — see the dev16 note above (#1303).
+ *
+ * The poll settles on VISIBILITY, not on presence in the DOM, so the caller's
+ * own `toBeVisible` resolves immediately instead of opening a second 15 s
+ * window on a row that is attached but not shown.
  */
 async function revealVariableRow(page: Page, name: string) {
   const cell = variableInTable(page, name);
@@ -190,14 +197,14 @@ async function revealVariableRow(page: Page, name: string) {
           .catch(() => {
             /* the grid is not rendered yet — reported by the poll below */
           });
-        return cell.count();
+        return cell.isVisible();
       },
       {
         timeout: 15000,
         message: `"${name}" never rendered in the variables table (the list request carried it, so the grid did not render it)`,
       },
     )
-    .toBeGreaterThan(0);
+    .toBe(true);
   return cell;
 }
 


### PR DESCRIPTION
Refs #1303 — **the issue stays open on purpose**; see *What this does NOT close* below.

## Problem

`global-variables-crud.spec.ts` flaked on the Credential test on 2026-07-15, 2026-07-17 and
2026-08-05 (three same-signature hits in the 30-day window), always on the **sanity** assertion that
precedes the secret-leak check:
`getByRole("treegrid").getByText("<name>", { exact: true })` → `element(s) not found` after 15 s.
It was quarantined at triage (`test.fixme`, `@stable` removed) in #1296.

That locator reports the **same string** for two different states — "the row is below the fold" and
"the grid has no rows at all" — which is why the failure read as *the variable was never created*.
The investigation found both, and only one of them reproduces.

### Cause 1 — ag-grid row virtualization (reproduced, deterministic)

The table virtualizes rows and a new variable is appended **last**, so past the rendered window the
row is in the grid's data model and not in the DOM. Measured on `1.12.0.dev16`:

| create | result | grid state |
|---|---|---|
| 1–11 | assert satisfied in ~106 ms each | `rendered=18`, `row-index=[0..17]` |
| 12th (19th row overall) | **full 15 s timeout** | `rendered=18` unchanged, `scrollHeight=798` vs `clientHeight=324` |
| same row, after scrolling `.ag-body-viewport` to the bottom | **found** | window shifts to `row-index=[1..18]` |

18 rows is the threshold on the 1280×720 viewport — Playwright's default, and CI's, since
`playwright.config.ts` sets no `viewport`. **The assertion could therefore fail against a healthy
product**, purely as a function of how many variables the account holds at that moment.

### Cause 2 — the 2026-08-05 failure itself, which is *not* virtualization

The shard-1 blob of run 30997773754 has the failing attempt's page snapshot: it shows ag-grid's
**`No Data Available`** overlay — **zero** rows for the full 15 s, dialog already closed. Around it:
the create returned 201 (the modal only closes in `onSuccess`, and `afterEach` deleted the captured
id); shard 1's liveness recorder logs probes of **2–45 ms across the entire window** (10:49:19 →
10:50:09, assertion at 10:49:41–10:49:56; nearest failed probe 10:48:39, a minute earlier); no HTTP
error was logged; and the concurrent worker was on `minimize.spec.ts` / `settings-theme-toggle.spec.ts`,
neither of which touches variables. Forcing that shape locally (first list response emptied) then
creating: **22/22 the row appeared** — 10 normal, 12 under 8× CPU throttling. Unexplained.

## Fix

- **`revealVariableRow`** scrolls `.ag-body-viewport` to the appended row, re-scrolling on every
  poll, and **all three tests** use it — the same exposure applies to every create in the file, not
  just the Credential one. This is what a user does; no assertion is weakened by it.
- **`createVariable` asserts the create** — 201 + a non-empty `id`. It was swallowed by
  `.catch(() => {})`, so a create that never happened was reported as a row that never rendered.
- **`createVariable` waits for the `GET /api/v1/variables/` that carries the new name**, so cause 2
  reports itself: under an always-empty list the test now fails as *"the variables list was never
  refetched with `<name>` after a 201 create"*, not as a missing row.
- **The delete test gets the symmetric wait** (a list that no longer carries the name). Without it,
  its `toHaveCount(0)` is also what an off-screen row yields — that assertion was weak before this
  PR and is only weaker once scrolling is introduced.
- **`test.fixme` removed and `@stable` restored** on the Credential test.

Rejected alternatives: raising the 15 s timeout (cause 1 is not slow, the row is absent — it never
arrives); asserting the variable through the API instead of the grid (that is the create round-trip,
not the rendering this spec exists to cover); sorting the grid so the new row lands first (ordering
by name is not stable across the mixed-case names the account holds).

One incidental find, fixed in place: leaving the list waiter dangling made a failing create report a
second `page.waitForResponse: Test ended` error on top of the real one, so the waiter is settled
(never rejecting) and the caller decides what a timeout means.

## Scope note

No assertion was weakened or removed. The leak check itself — `getByText(sentinel)` substring,
`count() === 0` — is unchanged; what changed is that it cannot now run before the row is provably on
screen, since it passes trivially on a page that renders no variable at all.

## Validation (nightly `1.12.0.dev16`, `--retries=0`)

- **5 clean bursts, 3 passed each** — 3 with 27 variables seeded (past the virtualization threshold),
  2 at the account's 7-variable baseline
- **Force-fail executed per test, isolated with `--grep`:**
  - `FF-A` remove the scroll from `revealVariableRow`, 27 variables → **all 3 tests fail** with
    `"<name>" never rendered in the variables table`; restore it → all 3 pass on the same 27. This is
    what proves the fix load-bearing rather than incidental.
  - `FF-B` create POST forced to 500 → fails as `create of "…" must return 201 (got 500)`
  - `FF-C` list forced permanently empty (the 2026-08-05 shape) → fails as
    `the variables list was never refetched with "…" after a 201 create`
  - `FF-1` assert a bogus name → fails · `FF-2` skip the delete click → fails as
    `never refetched without "…"` · `FF-3` expect the sentinel `count 1` → fails (it is masked)
  - Revert proven: `grep MUTATION` → 0 hits, plus a final green run
- `npm run typecheck` ✅ · `npm run lint` **0 errors and no new warning on this file** ✅ ·
  `npm run test:units` **442 pass** ✅
- `--trace=on` ✅ (12.1 s — the known hang is the Simple Agent template family, not this spec)
- Zero `🚨 Backend Error` outside `FF-B`, where it was the point ✅
- No residue: the local instance is back to its 7 pre-existing variables; this spec creates no flows

## What this does NOT close

**Cause 2.** It was observed once, on a real scheduled run, with the backend measurably healthy, and
nothing here explains it. Closing #1303 on the reproduced half would be closing on a test-side mute,
which that issue's own *Done when* rules out. `@stable` is restored for cause 1 — a calculated call,
made safe by the fact that cause 2 now surfaces as a **different** failure (a missing refetch) that
cannot be mistaken for this one.

**#1235 is deliberately not merged into.** It is a row *interaction* that does not produce its state
(rows present, click ignored — its delete case shows the button found and retried for 20 s as *not
enabled*). This is one step earlier: no interaction has happened and the row is absent from the DOM.
Virtualization-on-append cannot produce #1235's symptoms, since those specs act on rows they already
located. Reason recorded in the spec doc; revisit only if #1235 lands on a shared refresh mechanism.

**`QA-CHECKLIST.md` is untouched** — the bullet for this spec is already `[x]` and stays true once
`@stable` is restored; the generated blocks regenerate on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
