### PR TITLE
fix(fixtures): credit every declaration a known defect matches (#1322)

### DIFF
--- a/tests/fixtures/fixtures.ts
+++ b/tests/fixtures/fixtures.ts
@@ -448,13 +448,32 @@ export const test = base.extend({
     // Account for every declared known defect (#1008). A declaration is a claim
     // about the product — "this filed bug still fires here" — so it is checked
     // like one, in both directions.
+    //
+    // Grouped by the pair that decides a match, because duplicate declarations
+    // of one defect all carry the SAME count — they are credited together — and
+    // printing a line each would read as two defects firing once, not one firing
+    // once. Distinct reasons are all printed: they are what a reader judges the
+    // exemption by, and two declarations may justify themselves differently.
+    const summaryByDefect = new Map<
+      string,
+      { defect: KnownHttpDefect; hits: number; reasons: string[] }
+    >();
     for (const defect of declaredDefects) {
       const hits = declaredDefectHits.get(defect) ?? 0;
-      if (hits > 0) {
-        console.log(
-          `\n📌 ${hits}× declared known backend defect: ${defect.status} ${defect.pathname} — NOT counted as a backend error.\n   ${defect.reason}`,
-        );
+      if (hits === 0) continue;
+      const key = `${defect.status} ${defect.pathname}`;
+      const group = summaryByDefect.get(key);
+      if (!group) {
+        summaryByDefect.set(key, { defect, hits, reasons: [defect.reason] });
+      } else if (!group.reasons.includes(defect.reason)) {
+        group.reasons.push(defect.reason);
       }
+    }
+    for (const { defect, hits, reasons } of summaryByDefect.values()) {
+      console.log(
+        `\n📌 ${hits}× declared known backend defect: ${defect.status} ${defect.pathname} — NOT counted as a backend error.\n` +
+          reasons.map((reason) => `   ${reason}`).join("\n"),
+      );
     }
 
     // Check for errors and fail test if not allowed

--- a/tests/fixtures/fixtures.ts
+++ b/tests/fixtures/fixtures.ts
@@ -86,6 +86,10 @@ export type PageWithErrorHooks = Page & {
    * Call it **before** the test reaches the state that fires the defect —
    * declarations are not retroactive, so a late call gets the worst of both: the
    * response already reported as an error, and the declaration counted as stale.
+   *
+   * Declaring the same `(pathname, status)` twice is harmless: every matching
+   * declaration is credited, so a shared helper and an inline call cannot leave
+   * one of them looking stale.
    */
   expectKnownHttpError: (defect: KnownHttpDefect) => void;
 };
@@ -230,9 +234,32 @@ export const test = base.extend({
           // The occurrence count goes in the teardown summary instead: a defect
           // that fires 40× is a different observation from one that fires once,
           // and 40 identical lines is the noise #1084 was raised about.
-          const seen = declaredDefectHits.get(verdict.knownDefect) ?? 0;
-          declaredDefectHits.set(verdict.knownDefect, seen + 1);
-          if (seen === 0) {
+          //
+          // Credited to EVERY declaration this response matches, not only the
+          // one `classifyHttpError` returned. That function resolves with
+          // `find()`, so two declarations of the same (pathname, status) — a
+          // helper that declares plus an inline call, the same defect declared
+          // in `beforeEach` and again in the body — are distinct objects and
+          // only the first would ever be credited. The second would then be
+          // reported stale and FAIL a test whose defect did fire, with a message
+          // saying the opposite of what happened. Matching on the declaration's
+          // own `pathname` rather than re-parsing the URL: the policy already
+          // proved they are equal, and re-parsing is a second place to disagree.
+          const matched = declaredDefects.filter(
+            (candidate) =>
+              candidate.status === status &&
+              candidate.pathname === verdict.knownDefect.pathname,
+          );
+          const firstOccurrence = matched.every(
+            (candidate) => (declaredDefectHits.get(candidate) ?? 0) === 0,
+          );
+          for (const candidate of matched) {
+            declaredDefectHits.set(
+              candidate,
+              (declaredDefectHits.get(candidate) ?? 0) + 1,
+            );
+          }
+          if (firstOccurrence) {
             console.log(
               `📌 Known backend defect (declared by this test): ${status} ${response.statusText()} - ${url}`,
             );

--- a/tests/fixtures/http-error-gate.spec.ts
+++ b/tests/fixtures/http-error-gate.spec.ts
@@ -245,6 +245,35 @@ test.describe("fixture declared-known-defect hatch", () => {
   );
 
   test(
+    "two declarations of the same defect are both credited",
+    { tag: ["@stable", "@regression"] },
+    async ({ page }) => {
+      // `classifyHttpError` resolves a response to ONE declaration with `find()`,
+      // so a defect declared twice — a shared helper plus an inline call, or a
+      // `beforeEach` plus a body — produces two distinct objects competing for
+      // the same response. Crediting only the one `find()` returned leaves the
+      // other at zero hits, and the teardown then fails this test with "did NOT
+      // occur" about a defect that fired. The passing of this test IS the
+      // assertion: reverting the fixture to credit a single declaration turns it
+      // red in teardown.
+      const hooked = page as PageWithErrorHooks;
+      const viaHelper: KnownHttpDefect = { ...DECLARED };
+      const viaBody: KnownHttpDefect = { ...DECLARED };
+      expect(
+        viaHelper,
+        "the two declarations must be distinct objects — identical ones would pass on the bug",
+      ).not.toBe(viaBody);
+
+      hooked.expectKnownHttpError(viaHelper);
+      hooked.expectKnownHttpError(viaBody);
+
+      await page.goto(`${origin}/`);
+      expect(await fetchFromPage(hooked, DECLARED_PATH)).toBe(422);
+      await page.waitForTimeout(1000);
+    },
+  );
+
+  test(
     "a declared defect that never fires fails the test",
     { tag: ["@stable", "@regression"] },
     async ({ page }) => {

--- a/tests/fixtures/http-error-gate.spec.ts
+++ b/tests/fixtures/http-error-gate.spec.ts
@@ -256,6 +256,13 @@ test.describe("fixture declared-known-defect hatch", () => {
       // occur" about a defect that fired. The passing of this test IS the
       // assertion: reverting the fixture to credit a single declaration turns it
       // red in teardown.
+      //
+      // The teardown SUMMARY is deduplicated by (status, pathname) for the same
+      // reason, and that half is NOT pinned here: the summary is printed after
+      // the test that would have to assert it, the same structural limit
+      // `flow-error-gate.spec.ts` records for its own mid-test interrupt.
+      // Measured by hand instead — one `📌 1×` line with the grouping, two
+      // without it, which would read as two defects firing once each.
       const hooked = page as PageWithErrorHooks;
       const viaHelper: KnownHttpDefect = { ...DECLARED };
       const viaBody: KnownHttpDefect = { ...DECLARED };


### PR DESCRIPTION
Closes #1322. Follow-up to #1294, found reviewing it.

## Problem

`classifyHttpError` resolves a response to **one** declaration with `find()`, and the fixture
credited the hit to exactly that object. Two declarations of the same `(pathname, status)` are
distinct objects, so the second stayed at **zero hits** however often the defect fired, and the
teardown's self-retirement check reported it stale:

```
1 declared known backend defect(s) did NOT occur:
  - 422 /api/v1/projects/undefined
That is good news about Langflow and a stale exemption here. …
```

A green body, a red test, and a message telling the reader to delete a declaration for a defect that
is still firing — so the reader's next move is the wrong one.

No current caller reaches it (`folder-deletion-integrity.spec.ts` declares once). The shapes that do
are ordinary: a helper that declares plus an inline call, a `beforeEach` plus a body, or two specs
sharing a module-scoped defect a helper spreads (`{...DEFECT}`) — the spread is what makes them
distinct objects while looking identical at the call site. Identical *objects* were already safe:
the hit map is keyed by identity.

## Fix

Credit **every** declaration a response matches, announcing on the first occurrence across that set —
so the log is byte-identical for the single-declaration case, which is every caller today. Matching
uses the resolved declaration's own `pathname` rather than re-parsing the URL: the policy already
proved they are equal, and re-parsing would be a second place for the two to disagree.

`expectKnownHttpError`'s doc now states that duplicate declarations are safe, so the next reader does
not have to derive it from the implementation.

## Validation

- **Mutation-checked**: reverting to `const matched = [verdict.knownDefect]` fails the new test in
  teardown with the misleading `did NOT occur`, and fails **only** it — 4 of the 5 gate tests still
  pass, so it is that case and not another that covers this.
- `tests/fixtures/http-error-gate.spec.ts` **5 passed**, `flow-error-gate.spec.ts` included in the
  same run: **8 passed** total
- `npm run typecheck` clean · `npm run lint` 0 errors · `npm run test:units` **477 pass**

## Scope

Behaviour for a single declaration is unchanged in every observable way — same log lines, same
counts, same stale check. The only difference is which objects a hit is credited to when more than
one declaration matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)