### PR TITLE
fix(migration): report a drained provider as a credential state, not a migration failure (#1295)

### DIFF
--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -52,6 +52,27 @@ jobs:
         with:
           python-version: "3.12"
 
+      # Presence is not usability, and this step used to check only the former (#1295).
+      # Run #124 passed a non-empty-secret check, spent 1 min 40 s installing the
+      # Playwright browser and another minute installing Langflow, and then died on a
+      # drained OpenAI account — reported as a *migration* failure, on the
+      # `migration-test` tracker, in a run that never executed the witness flow at all.
+      #
+      # One token answers it here, before the job installs anything. Fail-open by
+      # design: only a billing / key-rot verdict aborts (exit 1); a network blip or an
+      # unrecognised response warns and lets the run reach its own conclusion — the
+      # authoritative verdict on a migration is the migration. It also drops the
+      # marker the report and the issue-routing steps below read.
+      #
+      # First step after `Setup Python` on purpose: every step it precedes is one a
+      # drained key would have wasted. Stdlib only, so it needs no `pip install`.
+      - name: Verify OPENAI_API_KEY is usable (not just present)
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          python tests/github-workflows/migration/provider_credentials.py \
+            --probe --phase "pre-flight/pip"
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
@@ -77,21 +98,6 @@ jobs:
 
       - name: Create virtual environment
         run: uv venv .venv
-
-      - name: Verify OPENAI_API_KEY secret is configured
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: |
-          # Fail fast: this workflow's flow-execution and migration-verification
-          # steps require a real OpenAI key. Without it `${{ secrets.X }}` resolves
-          # to an empty string, Langflow silently skips the credential auto-import,
-          # and the run only fails 5+ minutes later with a misleading
-          # "Missing credentials" error.
-          if [[ -z "$OPENAI_API_KEY" ]]; then
-            echo "::error::OPENAI_API_KEY repository secret is not configured. Set it in Settings → Secrets and variables → Actions before running this workflow."
-            exit 1
-          fi
-          echo "OPENAI_API_KEY secret is configured."
 
       - name: Generate ephemeral secret key for this run
         run: |
@@ -298,6 +304,7 @@ jobs:
             /tmp/migration-test-state.json
             /tmp/latest-digest.txt
             /tmp/nightly-digest.txt
+            /tmp/credential-verdict.json
 
       # Scoped to the default branch (#1145). This step used to fire on ANY green
       # run, so a `workflow_dispatch` on a branch closed the issue that tracks a bug
@@ -312,13 +319,25 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const { data: existing } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: 'migration-test',
-              state: 'open',
-            });
-            if (existing.length > 0) {
+            // A green run proves two separate things, so it closes two separate
+            // trackers (#1295) — each with wording about what it actually proved. The
+            // old version said "Migration test passed" on whatever open
+            // `migration-test` issue it found, which is how a billing outage filed
+            // there would have been closed as a fixed migration bug.
+            const CLOSING = {
+              'migration-test': 'Migration test passed. Closing this issue.',
+              'provider-credentials':
+                'This run reached the model provider and executed the witness flow, so the ' +
+                'credential that blocked it is usable again. Closing.',
+            };
+            for (const [label, message] of Object.entries(CLOSING)) {
+              const { data: existing } = await github.rest.issues.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: label,
+                state: 'open',
+              });
+              if (existing.length === 0) continue;
               const issue = existing[0];
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
@@ -327,7 +346,7 @@ jobs:
                 body: [
                   `## ✅ Run #${context.runNumber} — ${new Date().toISOString().split('T')[0]}`,
                   '',
-                  'Migration test passed. Closing this issue.',
+                  message,
                   '',
                   `[Workflow Run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
                 ].join('\n'),
@@ -357,18 +376,68 @@ jobs:
               console.log('Report not available:', e.message);
             }
 
+            // #1295: a run the provider's billing state stopped carries NO migration
+            // signal — the witness flow never executed, so nothing about alembic or the
+            // Fernet round-trip was measured. Filing that on the `migration-test`
+            // tracker is what run #124 did, and the next green run would have closed it
+            // with "Migration test passed", leaving a Langflow bug in the history that
+            // never existed. The marker is written by
+            // tests/github-workflows/migration/provider_credentials.py; its ABSENCE is
+            // the normal case and keeps this step exactly as it was.
+            let credential = null;
+            try {
+              credential = JSON.parse(fs.readFileSync('/tmp/credential-verdict.json', 'utf8'));
+            } catch (e) {
+              console.log('No credential verdict for this run:', e.message);
+            }
+            const blocked = credential && ['billing', 'key-rot'].includes(credential.verdict);
+            const label = blocked ? credential.label : 'migration-test';
+            const title = blocked
+              ? credential.title
+              : 'Langflow Migration Test Failed (latest → nightly)';
+
+            if (blocked) {
+              // Self-provisioning so a drained account does not also need a manual
+              // label; idempotent, and a failure here must not lose the report.
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label,
+                  color: 'd93f0b',
+                  description: 'Provider credential/billing state blocked a scheduled run (no product signal)',
+                });
+              } catch (e) {
+                console.log(`Label ${label} already exists or could not be created:`, e.message);
+              }
+            }
+
             const { data: existing } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: 'migration-test',
+              labels: label,
               state: 'open',
             });
+
+            const preamble = blocked
+              ? [
+                  `> **This is not a migration verdict.** The witness flow could not reach the`,
+                  `> model provider (\`${credential.verdict}\`, at \`${credential.phase}\`), so`,
+                  `> **nothing about the migration was measured** in this run.`,
+                  '',
+                  `**Reason:** ${credential.reason}`,
+                  '',
+                  `**What to do:** ${credential.action}`,
+                  '',
+                ]
+              : [];
 
             const body = [
               `## Run #${context.runNumber} — ${new Date().toISOString().split('T')[0]}`,
               '',
               `**Ref:** \`${context.ref}\` · **Event:** \`${context.eventName}\``,
               '',
+              ...preamble,
               report,
               '',
               `[Workflow Run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
@@ -387,9 +456,9 @@ jobs:
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                title: `Langflow Migration Test Failed (latest → nightly)`,
+                title,
                 body,
-                labels: ['migration-test', 'automated'],
+                labels: [label, 'automated'],
               });
             }
 
@@ -413,15 +482,17 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Verify OPENAI_API_KEY secret is configured
+      # Same pre-flight as the API job above (#1295) — see the long comment there. This
+      # job is the cheaper half to protect and the more expensive one to waste: run #124
+      # pulled 941 MB of images before reaching the same drained-account 429. No
+      # `setup-python` here on purpose: the module is stdlib-only, so the runner's
+      # `python3` is enough.
+      - name: Verify OPENAI_API_KEY is usable (not just present)
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          if [[ -z "$OPENAI_API_KEY" ]]; then
-            echo "::error::OPENAI_API_KEY repository secret is required."
-            exit 1
-          fi
-          echo "OPENAI_API_KEY is configured."
+          python3 tests/github-workflows/migration/provider_credentials.py \
+            --probe --phase "pre-flight/compose"
 
       - name: Generate ephemeral SECRET_KEY
         run: |
@@ -609,6 +680,14 @@ jobs:
           if [[ "$HTTP" != "200" ]]; then
             echo "::error::Source flow execution returned HTTP $HTTP"
             head -c 2000 /tmp/run-source.json
+            # Attribute it before dying (#1295): the account can drain between the
+            # pre-flight and here, and a provider 429 quoted inside a Langflow 500 is
+            # not a migration verdict. `|| true` because attribution must never
+            # replace the real error with a crash of its own — and this classifier
+            # deliberately does not change the exit code below.
+            python3 tests/github-workflows/migration/provider_credentials.py \
+              --classify-file /tmp/run-source.json --status "$HTTP" \
+              --phase "compose/source-execute" || true
             exit 1
           fi
           echo "Source flow execution OK"
@@ -679,6 +758,12 @@ jobs:
           if [[ "$HTTP" != "200" ]]; then
             echo "::error::Target flow execution returned HTTP $HTTP (Fernet/migration regression)"
             head -c 2000 /tmp/run-target.json
+            # The one place where the distinction matters most: this step's whole
+            # purpose is to catch a Fernet/migration regression, and a drained account
+            # here would have filed exactly that against Langflow (#1295).
+            python3 tests/github-workflows/migration/provider_credentials.py \
+              --classify-file /tmp/run-target.json --status "$HTTP" \
+              --phase "compose/target-execute" || true
             exit 1
           fi
           if grep -iE 'api[ _-]?key.{0,30}(required|missing|not[ _]?found)|fernet|cannot[ _]decrypt' /tmp/run-target.json; then
@@ -755,6 +840,7 @@ jobs:
             /tmp/witness-id.txt
             /tmp/run-source.json
             /tmp/run-target.json
+            /tmp/credential-verdict.json
           retention-days: 30
 
       # Same default-branch scope as the API job above (#1145).
@@ -763,13 +849,21 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const { data: existing } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: 'migration-test',
-              state: 'open',
-            });
-            if (existing.length > 0) {
+            // Two trackers, same reasoning as the API job above (#1295).
+            const CLOSING = {
+              'migration-test': 'docker-compose migration test passed. Closing.',
+              'provider-credentials':
+                'This run reached the model provider and executed the witness flow, so the ' +
+                'credential that blocked it is usable again. Closing.',
+            };
+            for (const [label, message] of Object.entries(CLOSING)) {
+              const { data: existing } = await github.rest.issues.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: label,
+                state: 'open',
+              });
+              if (existing.length === 0) continue;
               const issue = existing[0];
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
@@ -778,7 +872,7 @@ jobs:
                 body: [
                   `## ✅ Run #${context.runNumber} — ${new Date().toISOString().split('T')[0]}`,
                   '',
-                  'docker-compose migration test passed. Closing.',
+                  message,
                   '',
                   `[Workflow Run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
                 ].join('\n'),
@@ -796,19 +890,65 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
+            // Same routing as the API job (#1295) — see the long comment there. Run
+            // #124's `migration-test` issue was OPENED by this job (the compose body is
+            // the issue body) while the API job commented its report onto it, so both
+            // halves have to route on the verdict or the misattribution survives in one.
+            const fs = require('fs');
+            let credential = null;
+            try {
+              credential = JSON.parse(fs.readFileSync('/tmp/credential-verdict.json', 'utf8'));
+            } catch (e) {
+              console.log('No credential verdict for this run:', e.message);
+            }
+            const blocked = credential && ['billing', 'key-rot'].includes(credential.verdict);
+            const label = blocked ? credential.label : 'migration-test';
+            const title = blocked
+              ? credential.title
+              : 'Langflow Migration Test Failed (latest → nightly)';
+
+            if (blocked) {
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label,
+                  color: 'd93f0b',
+                  description: 'Provider credential/billing state blocked a scheduled run (no product signal)',
+                });
+              } catch (e) {
+                console.log(`Label ${label} already exists or could not be created:`, e.message);
+              }
+            }
+
             const { data: existing } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: 'migration-test',
+              labels: label,
               state: 'open',
             });
+
+            const what = blocked
+              ? [
+                  `> **This is not a migration verdict.** The witness flow could not reach the`,
+                  `> model provider (\`${credential.verdict}\`, at \`${credential.phase}\`), so`,
+                  `> **nothing about the docker-compose migration was measured** in this run.`,
+                  '',
+                  `**Reason:** ${credential.reason}`,
+                  '',
+                  `**What to do:** ${credential.action}`,
+                ]
+              : [
+                  `docker-compose migration test failed. Source: \`langflowai/langflow:latest\` → Target: \`langflowai/langflow-nightly:latest\`.`,
+                  `Compose file: pinned to upstream main of \`langflow-ai/langflow/docker_example/docker-compose.yml\`.`,
+                ];
+
             const body = [
               `## Run #${context.runNumber} — ${new Date().toISOString().split('T')[0]}`,
               '',
               `**Ref:** \`${context.ref}\` · **Event:** \`${context.eventName}\``,
               '',
-              `docker-compose migration test failed. Source: \`langflowai/langflow:latest\` → Target: \`langflowai/langflow-nightly:latest\`.`,
-              `Compose file: pinned to upstream main of \`langflow-ai/langflow/docker_example/docker-compose.yml\`.`,
+              ...what,
               '',
               `[Workflow Run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
               '',
@@ -826,8 +966,8 @@ jobs:
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                title: 'Langflow Migration Test Failed (latest → nightly)',
+                title,
                 body,
-                labels: ['migration-test', 'automated'],
+                labels: [label, 'automated'],
               });
             }

--- a/tests/github-workflows/migration/README.md
+++ b/tests/github-workflows/migration/README.md
@@ -6,6 +6,10 @@ Python tests that verify whether the Langflow database migrates correctly from `
 
 The workflow starts two Docker containers sequentially against the same PostgreSQL database, simulating a real production upgrade.
 
+### Phase 0 — Credential pre-flight
+
+0. Spends **one token** on `OPENAI_API_KEY` before installing anything (`provider_credentials.py --probe`). Presence is not usability: run #124 passed a non-empty-secret check and then died on a drained OpenAI account *after* installing Playwright and Langflow, and filed the result as a migration failure (#1295). A `billing` / `key-rot` verdict aborts the job here; anything the probe cannot classify (network blip, unexpected response) only warns — the authoritative verdict on a migration is the migration.
+
 ### Phase 1 — Langflow Latest
 
 1. Starts `langflowai/langflow:latest` with an empty PostgreSQL database.
@@ -39,9 +43,18 @@ Two scripts verify that the migration did not break anything:
 
 ### Phase 4 — Report
 
-`generate_report.py` consolidates the collected state into `/tmp/migration-report.md` with status per phase and step (`PASS` / `FAIL` / `WARN` / `SKIP`).
+`generate_report.py` consolidates the collected state into `/tmp/migration-report.md` with status per phase and step (`PASS` / `FAIL` / `WARN` / `SKIP` / `BLOCK`).
 
-On failure, the workflow opens or updates an issue in the repository with the `migration-test` label, including the full report and a link to the run.
+On failure, the workflow opens or updates an issue in the repository, including the full report and a link to the run. **Which tracker it writes to depends on the verdict (#1295):**
+
+| Verdict | Tracker | Meaning |
+|---|---|---|
+| `FAILED` | `migration-test` | Something about the migration is broken — a claim about Langflow. |
+| `BLOCKED (provider credentials)` | `provider-credentials` | The witness flow never reached the model provider, so **nothing about the migration was measured**. Not a claim about Langflow; fix the account or the key. |
+
+The split exists because both are red and only one is about the product. A billing outage filed under `migration-test` gets closed by the next green run with *"Migration test passed"*, leaving a migration bug in the history that never existed. A green run closes **both** trackers, each with wording about what it actually proved.
+
+Attribution happens in three places, all through `provider_credentials.py`: the pre-flight probe (Phase 0), the two API flow executions (`setup_latest.py`, `verify_migration_api.py`), and the compose job's two `curl` executions (`--classify-file`). A blocking verdict leaves `/tmp/credential-verdict.json`, which the report and the issue-routing steps read; its **absence** is the normal case and leaves every other verdict untouched.
 
 ## Generated artifacts
 
@@ -54,6 +67,7 @@ On failure, the workflow opens or updates an issue in the repository with the `m
 | `/tmp/migration-test-state.json` | Raw state collected between phases |
 | `/tmp/latest-digest.txt` | Digest of the latest image used |
 | `/tmp/nightly-digest.txt` | Digest of the nightly image used |
+| `/tmp/credential-verdict.json` | Credential verdict — present **only** when one was reached (#1295) |
 
 ## How to run manually
 

--- a/tests/github-workflows/migration/generate_report.py
+++ b/tests/github-workflows/migration/generate_report.py
@@ -39,6 +39,23 @@ So the workflow also hands over `JOB_STATUS` (`job.status`). A red job whose rep
 found nothing wrong is itself an integrity problem: the failure is real and lives
 outside every phase this report can see. Reconciling the job status covers the
 steps that exist today *and* any added later, which per-step `id`s would not.
+
+## Why `blocked` is not `fail` (#1295)
+
+A step whose only problem is that the provider stopped paying measured **nothing**
+about the migration. Run #124 reported `Result: FAILED` under the title *"Langflow
+Migration Test Failed (latest → nightly)"* when the witness flow had never executed
+on the source — a drained OpenAI account, quoted inside a Langflow 500. So a step
+that `provider_credentials.classify()` attributes to billing or key rot records
+`blocked`, and the verdict becomes `BLOCKED` — red, never green (there is no
+migration signal to be had, so this must not read as a pass), but not a claim about
+Langflow. A real migration failure alongside it still wins the verdict: `blocked`
+only decides the wording when it is the *only* thing wrong.
+
+`blocked` also counts as an accounted failure in the #1120 reconciliation above.
+Without that, a phase the runner saw fail whose only bad step was `blocked` would be
+reported as "crashed before writing its result" — the exact false verdict that
+mechanism exists to prevent, arriving through the fix for another one.
 """
 
 import json
@@ -50,13 +67,25 @@ from typing import Optional
 
 STATE_FILE = os.environ.get("STATE_FILE", "/tmp/migration-test-state.json")
 REPORT_FILE = os.environ.get("REPORT_FILE", "/tmp/migration-report.md")
+# Written by `provider_credentials.py` when the pre-flight probe (or a mid-run
+# classification) attributes the failure to the provider's billing state or the key
+# itself. Read here because the pre-flight aborts BEFORE any phase runs, so the state
+# file is empty and the report would otherwise say "verified nothing" without saying
+# why (#1295).
+CREDENTIAL_VERDICT_FILE = os.environ.get("CREDENTIAL_VERDICT_FILE", "/tmp/credential-verdict.json")
 
 STATUS_ICON = {
     "pass": "PASS",
     "fail": "FAIL",
     "warn": "WARN",
     "skip": "SKIP",
+    "blocked": "BLOCK",
 }
+
+# Statuses that mean the step did not do what it was there to do. `blocked` is one of
+# them for the #1120 reconciliation (a phase owning a blocked step is accounted for),
+# while carrying a different verdict — see the module docstring.
+NOT_OK_STATUSES = ("fail", "blocked")
 
 # Per-phase step outcomes handed in by the workflow, as
 # `PHASE_OUTCOME_<phase>=success|failure|skipped|cancelled` — GitHub's
@@ -73,6 +102,7 @@ JOB_STATUS_NOT_OK = {"failure", "cancelled"}
 RESULT_FAILED = "FAILED"
 RESULT_PASSED = "PASSED"
 RESULT_PASSED_WARN = "PASSED (with warnings)"
+RESULT_BLOCKED = "BLOCKED (provider credentials — no migration signal)"
 
 
 def load_state() -> dict:
@@ -81,6 +111,23 @@ def load_state() -> dict:
             return json.load(f)
     except FileNotFoundError:
         return {"phases": {}}
+
+
+def load_credential_verdict(path: Optional[str] = None) -> Optional[dict]:
+    """The credential verdict for this run, or `None` when there is none.
+
+    Absence is the normal case and must leave every other verdict untouched — a
+    malformed or unreadable marker is treated the same way, because a crash here
+    would replace the report with its own failure.
+    """
+    try:
+        with open(CREDENTIAL_VERDICT_FILE if path is None else path) as f:
+            payload = json.load(f)
+    except (OSError, ValueError):
+        return None
+    if not isinstance(payload, dict) or not payload.get("verdict"):
+        return None
+    return payload
 
 
 def load_digest(path: str) -> str:
@@ -111,10 +158,15 @@ def job_status(environ=None) -> Optional[str]:
     return value or None
 
 
-def assess(state: dict, declared: dict, job: Optional[str] = None) -> dict:
+def assess(
+    state: dict,
+    declared: dict,
+    job: Optional[str] = None,
+    credential: Optional[dict] = None,
+) -> dict:
     """Decide the overall result, and surface anything that makes the report untrustworthy.
 
-    Returns `{"result", "failures", "warnings", "integrity"}`. `integrity` holds
+    Returns `{"result", "failures", "warnings", "integrity", "blocked"}`. `integrity` holds
     mismatches between what the runner observed and what the phase recorded — the
     #1120 class. Those count as failures: a report that cannot account for a phase
     must not claim that phase passed.
@@ -122,12 +174,17 @@ def assess(state: dict, declared: dict, job: Optional[str] = None) -> dict:
     `job` is the runner's verdict on the whole job (`job.status`). It catches the
     #1141 case: a failure in a step no phase covers, which otherwise left the report
     saying `PASSED` on a red run.
+
+    `credential` is the marker `provider_credentials.py` leaves behind (#1295). It is
+    the only attribution available when the **pre-flight** aborts, since no phase has
+    run at that point and the state file is empty.
     """
     phases = state.get("phases", {}) or {}
 
     failures = []
     warnings = []
     integrity = []
+    blocked = []
 
     for phase_name, phase_data in phases.items():
         for step_name, step_data in (phase_data.get("steps", {}) or {}).items():
@@ -135,13 +192,15 @@ def assess(state: dict, declared: dict, job: Optional[str] = None) -> dict:
             detail = str((step_data or {}).get("detail", "no detail"))[:200]
             if status == "fail":
                 failures.append(f"- **{phase_name}/{step_name}**: {detail}")
+            elif status == "blocked":
+                blocked.append(f"- **{phase_name}/{step_name}**: {detail}")
             elif status == "warn":
                 warnings.append(f"- **{phase_name}/{step_name}**: {detail}")
 
     for phase_name, outcome in sorted(declared.items()):
         recorded_steps = (phases.get(phase_name) or {}).get("steps", {}) or {}
         recorded_fail = any(
-            (s or {}).get("status") == "fail" for s in recorded_steps.values()
+            (s or {}).get("status") in NOT_OK_STATUSES for s in recorded_steps.values()
         )
 
         if outcome == "failure" and not recorded_fail:
@@ -158,9 +217,22 @@ def assess(state: dict, declared: dict, job: Optional[str] = None) -> dict:
                 f"absent from the state file, so nothing about it was verified."
             )
 
+    # The pre-flight abort: the credential verdict is the whole story, and there are
+    # no phases to attach it to.
+    if credential:
+        where = credential.get("phase") or "pre-flight"
+        blocked.append(
+            f"- **{where}**: {credential.get('reason') or credential.get('verdict')}"
+        )
+        action = credential.get("action")
+        if action:
+            blocked.append(f"- **What to do**: {action}")
+
     # A state file with no phases at all is the strongest form of the same problem:
-    # it used to render as a clean PASS.
-    if not phases:
+    # it used to render as a clean PASS. Skipped when the credential verdict already
+    # attributes the run — same rule as the #1141 branch below, which stays quiet once
+    # something else owns the cause.
+    if not phases and not credential:
         integrity.append(
             "- **(all phases)**: the state file records no phases at all, so this report "
             "verified nothing. Treated as a failure rather than an empty pass."
@@ -169,7 +241,7 @@ def assess(state: dict, declared: dict, job: Optional[str] = None) -> dict:
     # #1141: the job is red but nothing above accounts for it — the failing step is
     # one this report does not cover. Only reported when there is no attribution yet;
     # a phase that already owns the failure says it better than this can.
-    if job in JOB_STATUS_NOT_OK and not failures and not integrity:
+    if job in JOB_STATUS_NOT_OK and not failures and not integrity and not blocked:
         integrity.append(
             f"- **(outside every phase)**: the runner reports this job `{job}`, but no "
             f"verification phase recorded or was declared a failure — so the cause is a "
@@ -178,8 +250,12 @@ def assess(state: dict, declared: dict, job: Optional[str] = None) -> dict:
             f"report cannot attribute it."
         )
 
+    # A real failure outranks a blocked step: if anything about the migration itself
+    # went wrong, that is the verdict, and the credential state is a footnote.
     if failures or integrity:
         result = RESULT_FAILED
+    elif blocked:
+        result = RESULT_BLOCKED
     elif warnings:
         result = RESULT_PASSED_WARN
     else:
@@ -190,6 +266,7 @@ def assess(state: dict, declared: dict, job: Optional[str] = None) -> dict:
         "failures": failures,
         "warnings": warnings,
         "integrity": integrity,
+        "blocked": blocked,
     }
 
 
@@ -207,17 +284,22 @@ def format_step(name: str, step: dict) -> str:
 
 
 def generate_report(
-    state: dict, declared: Optional[dict] = None, job: Optional[str] = None
+    state: dict,
+    declared: Optional[dict] = None,
+    job: Optional[str] = None,
+    credential: Optional[dict] = None,
 ) -> str:
     if declared is None:
         declared = declared_outcomes()
     if job is None:
         job = job_status()
+    if credential is None:
+        credential = load_credential_verdict()
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     latest_digest = load_digest("/tmp/latest-digest.txt")
     nightly_digest = load_digest("/tmp/nightly-digest.txt")
 
-    verdict = assess(state, declared, job)
+    verdict = assess(state, declared, job, credential)
 
     lines = [
         "# Langflow Migration Test Report",
@@ -243,6 +325,20 @@ def generate_report(
         lines.append("## Unaccounted failures")
         lines.append("")
         lines.extend(verdict["integrity"])
+        lines.append("")
+
+    # Also right under the verdict, and for the same reason: a reader who stops after
+    # the first screen must not walk away thinking Langflow's migration broke (#1295).
+    if verdict["blocked"]:
+        lines.append("## Blocked on provider credentials — not a migration verdict")
+        lines.append("")
+        lines.append(
+            "The witness flow could not reach the model provider, so **nothing about "
+            "the migration was measured** by the step(s) below. Fix the account or the "
+            "key, then re-run; no change in this repo can make this pass."
+        )
+        lines.append("")
+        lines.extend(verdict["blocked"])
         lines.append("")
 
     for phase_name, phase_data in state.get("phases", {}).items():

--- a/tests/github-workflows/migration/provider_credentials.py
+++ b/tests/github-workflows/migration/provider_credentials.py
@@ -1,0 +1,345 @@
+"""Classify an OpenAI credential failure, and probe the key before the run pays for it.
+
+## Why this exists (#1295)
+
+On run #124 both jobs of `migration-test.yml` died in their **source** phase with
+
+    HTTP 500 … Error building Component Language Model … Error code: 429 -
+    {'error': {'message': 'You have no credits remaining. Add credits to continue
+    using the API …', 'type': 'insufficient_quota',
+    'code': 'credit_balance_exhausted'}}
+
+The account was drained. Three separate things went wrong with how that was
+reported, and none of them is about migration:
+
+1. **The witness never ran on the source**, so *nothing* about the migration was
+   exercised — no alembic, no Fernet round-trip, no volume. The run carried zero
+   migration signal, and the issue it filed was titled *"Langflow Migration Test
+   Failed (latest → nightly)"*.
+2. **It wrote to the `migration-test` tracker.** The next green run's `Close issue
+   on success` step comments *"Migration test passed. Closing this issue."*, so the
+   history reads as a migration bug that appeared and got fixed. It never existed.
+3. **The pre-flight only checked that the secret was non-empty.** Its own comment
+   already makes this argument one level up ("the run only fails 5+ minutes later
+   with a misleading error") — a present-but-unusable key reproduced exactly that,
+   after installing Langflow (2 min 50 s) and pulling 941 MB of images (1 min 53 s).
+
+So this module answers one question — *is the failure the provider's billing state,
+the key itself, or something we should not blame on either?* — for both jobs, and
+the workflow routes the report on the answer.
+
+## Fail-open, on purpose
+
+The authoritative verdict on a run is the run. This module is an **attributor and
+an optimiser**, not a gate: only `BILLING` and `KEY_ROT` (`BLOCKING`) abort a job
+early, and everything it cannot classify is `INCONCLUSIVE` → announced with a
+`::warning::` and the run proceeds to reach its own conclusion. Aborting on an
+unrecognised 4xx would block the migration test for a reason that has nothing to do
+with migration; letting it through costs one run that was going to fail anyway,
+with the real cause in the log. A verdict is never silent either way (#1012).
+
+## Divergence from `collect-models.spec.ts`'s `BILLING_OR_QUOTA` (#955)
+
+That regex — the canonical one for this error class — includes a bare `\\b429\\b`.
+Here it must not: a plain `rate_limit_exceeded` is also 429, and in
+`collect-models` both branches only ever *warn*, so conflating them was free.
+Here `BILLING` **aborts the job**, and a rate limit is transient and retryable —
+calling it billing would abort a run that would have passed on the next attempt.
+So a body that names a rate limit and carries none of the strong billing markers is
+`INCONCLUSIVE`, and the run continues. Everything else about the pattern mirrors
+`collect-models.spec.ts` (which is TypeScript, so the pattern cannot be shared —
+keep the two in sync by hand; both are unit-tested).
+
+Stdlib only: the PR-validation unit lane installs `pytest` and nothing else, so
+this module must be importable without `requests`.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from typing import Callable, Optional, Tuple
+
+LIVE = "live"
+BILLING = "billing"
+KEY_ROT = "key-rot"
+INCONCLUSIVE = "inconclusive"
+
+# The two verdicts that stop a job before it can produce a migration signal, and
+# that route the report away from the `migration-test` tracker.
+BLOCKING = (BILLING, KEY_ROT)
+
+MARKER_FILE = os.environ.get("CREDENTIAL_VERDICT_FILE", "/tmp/credential-verdict.json")
+
+DEFAULT_MODEL = os.environ.get("WITNESS_MODEL", "gpt-4o-mini")
+COMPLETIONS_URL = os.environ.get(
+    "OPENAI_COMPLETIONS_URL", "https://api.openai.com/v1/chat/completions"
+)
+
+# Markers that mean "the account cannot pay for this call". `credit_balance_exhausted`
+# and `no credits remaining` are OpenAI's 2026-08 wording, measured on the drained
+# key that produced #1295.
+_STRONG_BILLING = re.compile(
+    r"credit[_ ]balance[_ ]exhausted"
+    r"|credit balance is too low"
+    r"|no credits remaining"
+    r"|insufficient[_ ]?quota"
+    r"|exceeded your current quota"
+    r"|payment required"
+    r"|spend(?:ing)?[ _-]?cap"
+    r"|\b402\b",
+    re.IGNORECASE,
+)
+
+# Weaker markers: real for this class, but also present in messages that are not a
+# billing state at all — which is why a rate limit is checked first.
+_WEAK_BILLING = re.compile(
+    r"\bquota\b|resource[_ ]?exhausted|billing",
+    re.IGNORECASE,
+)
+
+_RATE_LIMIT = re.compile(r"rate[_ ]?limit", re.IGNORECASE)
+
+# Key rot / config: the key is wrong, revoked, or has no access to the model. A real
+# defect someone must fix in the repo secret — reported apart from billing because
+# the action differs (rotate the secret vs. top up the account).
+_KEY_ROT = re.compile(
+    r"invalid[_ ]?api[_ ]?key"
+    r"|incorrect api key"
+    r"|invalid[_ ]authentication"
+    r"|\bunauthorized\b"
+    r"|model[_ ]not[_ ]found"
+    r"|does not (?:exist|have access)"
+    r"|permission[_ ]?denied",
+    re.IGNORECASE,
+)
+
+_HTTP_KEY_ROT_STATUS = (401, 403)
+
+_TITLES = {
+    BILLING: "Migration test blocked: OpenAI account has no credits (no migration signal)",
+    KEY_ROT: "Migration test blocked: OpenAI key rejected (no migration signal)",
+}
+
+_ACTIONS = {
+    BILLING: (
+        "Top up the OpenAI account (or point the `OPENAI_API_KEY` secret at a funded "
+        "one). No code change in this repo can make this run pass."
+    ),
+    KEY_ROT: (
+        "Set or rotate the `OPENAI_API_KEY` repository secret (Settings → Secrets and "
+        "variables → Actions) — the current one is missing, rejected, or has no access "
+        "to the witness model."
+    ),
+}
+
+# The label the report is routed to when the verdict is blocking. Kept off
+# `migration-test` so a later green run cannot close it with "Migration test
+# passed", which would read as a migration bug that never existed.
+ISSUE_LABEL = "provider-credentials"
+
+
+def classify(status: Optional[int], body: str) -> Tuple[str, str]:
+    """Return `(verdict, reason)` for an OpenAI response or an error string.
+
+    `status` is the HTTP status when one is known (the pre-flight probe, or the
+    `curl` code the compose job captured) and `None` when the only evidence is text
+    — e.g. the migration helper's `"HTTP 500: {…}"` detail, where the provider's own
+    429 is quoted *inside* a Langflow 500 body.
+    """
+    text = body or ""
+    snippet = " ".join(text.split())[:300]
+
+    if status is not None and 200 <= status < 300:
+        return LIVE, f"HTTP {status} — the key answered a 1-token completion"
+
+    strong_billing = bool(_STRONG_BILLING.search(text))
+
+    # Order matters: a rate limit is 429 too, and aborting the job for it would
+    # throw away a run that the next attempt would have completed.
+    if _RATE_LIMIT.search(text) and not strong_billing:
+        return (
+            INCONCLUSIVE,
+            f"rate limit, not a billing state — transient, letting the run proceed: {snippet}",
+        )
+
+    if strong_billing or _WEAK_BILLING.search(text):
+        return BILLING, f"provider billing/quota exhausted: {snippet}"
+
+    if _KEY_ROT.search(text) or status in _HTTP_KEY_ROT_STATUS:
+        return KEY_ROT, f"the key was rejected: HTTP {status} {snippet}".strip()
+
+    if status is None:
+        return (
+            INCONCLUSIVE,
+            f"no HTTP status and no recognised credential marker: {snippet}"
+            if snippet
+            else "no HTTP status and no response text — nothing to attribute",
+        )
+
+    if status >= 500:
+        return INCONCLUSIVE, f"provider-side HTTP {status} — not a credential verdict: {snippet}"
+
+    return INCONCLUSIVE, f"unrecognised HTTP {status} — not attributed to credentials: {snippet}"
+
+
+def probe(
+    api_key: str,
+    model: str = DEFAULT_MODEL,
+    url: str = COMPLETIONS_URL,
+    timeout: int = 30,
+    transport: Optional[Callable[[urllib.request.Request, int], Tuple[int, str]]] = None,
+) -> Tuple[str, str]:
+    """Spend one token to find out whether the key can be used at all.
+
+    Presence is not usability — that is the whole finding of #1295. `transport` is
+    injectable so the unit tests never touch the network; the default sends the
+    real request through `urllib` (stdlib, see the module docstring).
+    """
+    if not api_key:
+        return KEY_ROT, "OPENAI_API_KEY is empty — the secret is not configured"
+
+    payload = json.dumps(
+        {
+            "model": model,
+            "max_tokens": 1,
+            "messages": [{"role": "user", "content": "ping"}],
+        }
+    ).encode()
+    request = urllib.request.Request(
+        url,
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+
+    send = transport or _send
+    try:
+        status, body = send(request, timeout)
+    except Exception as exc:  # transport failure: no verdict, never a blocking one
+        return INCONCLUSIVE, f"could not reach the provider ({type(exc).__name__}: {exc})"
+
+    verdict, reason = classify(status, body)
+    return verdict, f"{reason} [model={model}]"
+
+
+def _send(request: urllib.request.Request, timeout: int) -> Tuple[int, str]:
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.status, response.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as err:
+        # The body is where the verdict lives — `insufficient_quota` vs a rate limit
+        # are both 429.
+        return err.code, err.read().decode("utf-8", "replace")
+
+
+def marker_payload(verdict: str, reason: str, phase: str) -> dict:
+    return {
+        "verdict": verdict,
+        "reason": reason,
+        "phase": phase,
+        "title": _TITLES.get(verdict, ""),
+        "action": _ACTIONS.get(verdict, ""),
+        "label": ISSUE_LABEL,
+    }
+
+
+def write_marker(verdict: str, reason: str, phase: str, path: str = MARKER_FILE) -> Optional[str]:
+    """Record a blocking verdict for the workflow's issue-routing step.
+
+    Only `BLOCKING` verdicts are written: the file's **presence** is the signal, and
+    its absence means "no credential verdict", which keeps the routing default (the
+    `migration-test` tracker) untouched for every other failure.
+    """
+    if verdict not in BLOCKING:
+        return None
+    with open(path, "w") as handle:
+        json.dump(marker_payload(verdict, reason, phase), handle, indent=2)
+    return path
+
+
+def step_status(detail: str, phase: str, marker: Optional[str] = None) -> str:
+    """The status a failed flow execution should record: `"blocked"` or `"fail"`.
+
+    The mid-run half of #1295, shared by `setup_latest.py` and
+    `verify_migration_api.py` so both call sites are a single line and the decision
+    itself is unit-tested. `detail` is the migration helper's `"HTTP 500: {…}"`
+    string, where the provider's own error is quoted inside Langflow's — hence no
+    status to pass. A blocking verdict is announced and recorded on the way out; any
+    other failure keeps its original `"fail"` and this function stays silent.
+    """
+    verdict, reason = classify(None, detail)
+    if verdict not in BLOCKING:
+        return "fail"
+    print(announce(verdict, reason, phase))
+    write_marker(verdict, reason, phase, MARKER_FILE if marker is None else marker)
+    return "blocked"
+
+
+def announce(verdict: str, reason: str, phase: str) -> str:
+    """The workflow-log line for a verdict. Nothing here is ever silent (#1012)."""
+    if verdict == LIVE:
+        return f"OpenAI credential probe: live — {reason}"
+    if verdict == INCONCLUSIVE:
+        return f"::warning::OpenAI credential probe inconclusive ({phase}) — {reason}"
+    return (
+        f"::error::{_TITLES[verdict]} — {reason}. {_ACTIONS[verdict]} "
+        f"This run produced NO migration signal: the witness flow never executed, so "
+        f"nothing about the alembic migration or the Fernet round-trip was verified."
+    )
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--probe",
+        action="store_true",
+        help="spend one token on OPENAI_API_KEY before the job installs anything",
+    )
+    parser.add_argument(
+        "--classify-file",
+        metavar="PATH",
+        help="classify a saved response body (the compose job's /tmp/run-*.json)",
+    )
+    parser.add_argument("--status", type=int, default=None, help="HTTP status for --classify-file")
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--phase", default="pre-flight", help="where the verdict was reached")
+    parser.add_argument("--marker", default=MARKER_FILE)
+    args = parser.parse_args(argv)
+
+    if args.probe == bool(args.classify_file):
+        parser.error("pass exactly one of --probe or --classify-file")
+
+    if args.probe:
+        verdict, reason = probe(os.environ.get("OPENAI_API_KEY", ""), model=args.model)
+    else:
+        try:
+            with open(args.classify_file) as handle:
+                body = handle.read()
+        except OSError as exc:
+            # Attribution must never replace the real error with its own crash.
+            print(f"::warning::could not read {args.classify_file} ({exc}) — no credential verdict")
+            return 0
+        verdict, reason = classify(args.status, body)
+
+    print(announce(verdict, reason, args.phase))
+    written = write_marker(verdict, reason, args.phase, args.marker)
+    if written:
+        print(f"Recorded credential verdict in {written}")
+
+    # `--probe` runs before the job spends anything, so a blocking verdict stops it
+    # there. `--classify-file` runs *after* the step that already failed — it only
+    # attributes, and must not change that step's exit code.
+    if args.probe and verdict in BLOCKING:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/github-workflows/migration/setup_latest.py
+++ b/tests/github-workflows/migration/setup_latest.py
@@ -4,6 +4,7 @@ import os
 import sys
 import time
 
+import provider_credentials as credentials
 from helpers import (
     create_flow,
     create_variable,
@@ -106,7 +107,12 @@ def main():
     # 5. Execute the flow
     print("── Executing flow on latest...")
     success, detail = run_flow_safe(token, flow_id)
-    status = "pass" if success else "fail"
+    # A drained account reaches here as a Langflow 500 quoting the provider's own 429,
+    # and reporting that as a migration failure is #1295. The pre-flight probe catches
+    # the common case before this job installs anything; this covers the account
+    # draining mid-run, and records `blocked` — a state the report renders apart from
+    # FAILED, and the workflow routes to the credentials tracker, not `migration-test`.
+    status = "pass" if success else credentials.step_status(detail, "latest/execute_flow")
     print(f"   {status.upper()}: {detail[:120]}")
     phase["steps"]["execute_flow"] = {"status": status, "detail": detail}
 
@@ -119,7 +125,14 @@ def main():
     save_state(state)
 
     if not success:
-        print("\nERROR: Flow execution failed on latest. Cannot establish migration baseline.")
+        if status == "blocked":
+            print(
+                "\nBLOCKED: the provider credential, not Langflow, stopped the witness "
+                "flow on latest. No migration baseline, and nothing to attribute to the "
+                "migration."
+            )
+        else:
+            print("\nERROR: Flow execution failed on latest. Cannot establish migration baseline.")
         sys.exit(1)
 
 

--- a/tests/github-workflows/migration/test_generate_report.py
+++ b/tests/github-workflows/migration/test_generate_report.py
@@ -8,6 +8,8 @@ run #115 is the first test below.
 Run with: pytest tests/github-workflows/migration/test_generate_report.py
 """
 
+import json
+
 from . import generate_report as gr
 import pytest
 
@@ -260,6 +262,117 @@ def test_the_rendered_report_still_lists_every_step():
 
     for step in ("auth", "execute_flow", "flow_exists", "execute_flow_api_post_update"):
         assert step in body
+
+
+# ── blocked on provider credentials (#1295) ──────────────────────────────────
+
+# Run #124's shape: the witness never executed on the source, because the OpenAI
+# account had no credits. Everything before it passed; nothing about the migration
+# was measured.
+RUN_124_STATE = {
+    "flow_id": "ee302ee6-8f20-4811-8937-3bfcd94d1115",
+    "flow_name": "Migration Test Agent",
+    "phases": {
+        "latest": {
+            "duration_s": 19.1,
+            "steps": {
+                "auth": {"status": "pass"},
+                "create_flow": {"status": "pass"},
+                "execute_flow": {
+                    "status": "blocked",
+                    "detail": "HTTP 500: … 429 … insufficient_quota … no credits remaining",
+                },
+            },
+        }
+    },
+}
+
+
+def test_a_credential_block_is_not_reported_as_a_migration_failure():
+    verdict = gr.assess(RUN_124_STATE, {"latest": "failure"}, job="failure")
+
+    assert verdict["result"] == gr.RESULT_BLOCKED
+    assert verdict["failures"] == []
+    assert len(verdict["blocked"]) == 1
+    # The #1120 reconciliation must accept `blocked` as the phase's own account of
+    # itself — otherwise the fix for #1295 reintroduces "crashed before writing its
+    # result" on every drained day.
+    assert verdict["integrity"] == []
+
+
+def test_a_credential_block_is_never_a_pass():
+    # There is no migration signal in a blocked run, so it must not read as green.
+    verdict = gr.assess(RUN_124_STATE, {"latest": "failure"}, job="failure")
+    assert verdict["result"] not in (gr.RESULT_PASSED, gr.RESULT_PASSED_WARN)
+
+
+def test_a_real_migration_failure_outranks_a_credential_block():
+    state = {
+        "phases": {
+            "latest": {"steps": {"execute_flow": {"status": "blocked", "detail": "no credits"}}},
+            "nightly_api": {"steps": {"flow_exists": {"status": "fail", "detail": "404"}}},
+        }
+    }
+    verdict = gr.assess(state, {"latest": "failure", "nightly_api": "failure"}, job="failure")
+
+    assert verdict["result"] == gr.RESULT_FAILED
+    assert len(verdict["failures"]) == 1 and len(verdict["blocked"]) == 1
+
+
+PREFLIGHT_MARKER = {
+    "verdict": "billing",
+    "reason": "provider billing/quota exhausted: no credits remaining …",
+    "phase": "pre-flight/pip",
+    "title": "Migration test blocked: OpenAI account has no credits (no migration signal)",
+    "action": "Top up the OpenAI account …",
+    "label": "provider-credentials",
+}
+
+
+def test_a_preflight_abort_is_attributed_instead_of_verified_nothing():
+    # The pre-flight stops the job before any phase runs, so the state file is empty.
+    # Without the marker this rendered as "the state file records no phases at all, so
+    # this report verified nothing" — true, and useless: it does not say why.
+    verdict = gr.assess({"phases": {}}, {}, job="failure", credential=PREFLIGHT_MARKER)
+
+    assert verdict["result"] == gr.RESULT_BLOCKED
+    assert verdict["integrity"] == [], "the credential verdict already owns the cause"
+    assert any("no credits remaining" in line for line in verdict["blocked"])
+    assert any("Top up" in line for line in verdict["blocked"])
+
+
+def test_an_empty_state_with_no_credential_marker_is_still_an_integrity_failure():
+    # The #1120 guarantee must survive the #1295 fix untouched.
+    verdict = gr.assess({"phases": {}}, {}, job="failure", credential=None)
+
+    assert verdict["result"] == gr.RESULT_FAILED
+    assert "verified nothing" in verdict["integrity"][0]
+
+
+def test_a_missing_or_malformed_marker_reads_as_no_verdict(tmp_path):
+    assert gr.load_credential_verdict(str(tmp_path / "absent.json")) is None
+
+    broken = tmp_path / "broken.json"
+    broken.write_text("{not json")
+    assert gr.load_credential_verdict(str(broken)) is None
+
+    empty = tmp_path / "empty.json"
+    empty.write_text("{}")
+    assert gr.load_credential_verdict(str(empty)) is None, "no verdict field ⇒ no verdict"
+
+    good = tmp_path / "good.json"
+    good.write_text(json.dumps(PREFLIGHT_MARKER))
+    assert gr.load_credential_verdict(str(good))["verdict"] == "billing"
+
+
+def test_the_rendered_report_says_the_block_is_not_a_migration_verdict():
+    body = gr.generate_report(RUN_124_STATE, {"latest": "failure"}, job="failure")
+
+    assert "## Result: " + gr.RESULT_BLOCKED in body
+    assert "not a migration verdict" in body
+    assert "nothing about the migration was measured" in body.lower()
+    # The blocked step is still rendered in its phase table, with its own icon.
+    assert "| BLOCK | execute_flow |" in body
 
 
 if __name__ == "__main__":

--- a/tests/github-workflows/migration/test_provider_credentials.py
+++ b/tests/github-workflows/migration/test_provider_credentials.py
@@ -1,0 +1,398 @@
+"""Unit tests for the credential verdict that routes the migration report (#1295).
+
+Why these exist: the verdict decides whether a run is reported as a **migration**
+failure or as a **provider billing** state, and whether the job is aborted before it
+installs Langflow. Both mistakes are expensive in opposite directions — calling a
+transient rate limit "billing" throws away a run that would have passed, and calling
+a drained account "migration failed" files a bug against Langflow that does not
+exist (exactly what run #124 did).
+
+The first test is the real payload from that run, byte for byte.
+
+Run with: pytest tests/github-workflows/migration/test_provider_credentials.py
+"""
+
+import json
+
+from . import provider_credentials as pc
+
+# The exact body OpenAI returned on 2026-08-05, reproduced locally against the same
+# drained key while diagnosing #1295.
+RUN_124_BODY = json.dumps(
+    {
+        "error": {
+            "message": (
+                "You have no credits remaining. Add credits to continue using the API "
+                "at https://platform.openai.com/settings/organization/billing/."
+            ),
+            "type": "insufficient_quota",
+            "param": None,
+            "code": "credit_balance_exhausted",
+        }
+    }
+)
+
+# How that same failure reaches the pip job: the provider's 429 quoted inside a
+# Langflow 500, with no HTTP status of its own available to the caller.
+RUN_124_DETAIL = (
+    'HTTP 500: {"detail":"{\\"message\\":\\"Error running graph: Error building '
+    "Component Language Model: \\n\\nError code: 429 - {'error': {'message': 'You have "
+    "no credits remaining. Add credits to continue using the API at "
+    "https://platform.openai.com/settings/organization/billing/.', 'type': "
+    "'insufficient_quota', 'param': None, 'code': 'credit_balance_exhausted'}}\\\"}\"}"
+)
+
+
+def test_run_124_probe_body_is_billing():
+    verdict, reason = pc.classify(429, RUN_124_BODY)
+    assert verdict == pc.BILLING
+    assert "no credits remaining" in reason
+
+
+def test_run_124_langflow_500_detail_is_billing_without_a_status():
+    # The mid-run path: the only evidence is text, and the 500 belongs to Langflow —
+    # attributing it to the migration is the #1295 defect.
+    verdict, _ = pc.classify(None, RUN_124_DETAIL)
+    assert verdict == pc.BILLING
+
+
+def test_every_strong_billing_marker_stands_on_its_own():
+    """Each marker alone must decide `billing`.
+
+    The run #124 payload carries three of them at once (`credit_balance_exhausted`,
+    `insufficient_quota`, `no credits remaining`), so a test built only on that body
+    passes even after a marker is deleted — measured: removing
+    `credit_balance_exhausted` from the pattern changed no test. Providers reword
+    these messages (that is the whole #1011 spend-cap lesson), and the next one may
+    arrive carrying exactly one.
+    """
+    for marker in (
+        "credit_balance_exhausted",
+        "Your credit balance is too low to access the API",
+        "You have no credits remaining",
+        "insufficient_quota",
+        "You exceeded your current quota",
+        "Payment Required",
+        "monthly spending cap",
+        "spend-cap reached",
+        "HTTP 402 returned by the provider",
+    ):
+        verdict, _ = pc.classify(None, marker)
+        assert verdict == pc.BILLING, f"{marker!r} must classify as billing on its own"
+
+
+def test_a_strong_marker_wins_even_over_a_rate_limit_body():
+    # The same markers, one at a time, against the branch that would otherwise send
+    # them to INCONCLUSIVE and let a drained run continue.
+    # `exceeded your current quota` is here for a reason a marker-only test cannot
+    # show: `\bquota\b` is *also* a weak marker, so deleting the strong one still
+    # yields BILLING everywhere — except against a body that names a rate limit,
+    # where the rate-limit branch would then win and a drained account would be
+    # waved through as transient. This assertion is the only thing that pins it.
+    for marker in (
+        "insufficient_quota",
+        "no credits remaining",
+        "credit_balance_exhausted",
+        "You exceeded your current quota",
+    ):
+        verdict, _ = pc.classify(429, f"Rate limit reached. {marker}")
+        assert verdict == pc.BILLING, f"{marker!r} must outrank a rate-limit mention"
+
+
+def test_anthropic_wording_is_billing_too():
+    # collect-models' canonical pattern covers this one; keep the two in sync.
+    verdict, _ = pc.classify(400, "Your credit balance is too low to access the Anthropic API")
+    assert verdict == pc.BILLING
+
+
+def test_google_spend_cap_is_billing():
+    verdict, _ = pc.classify(429, "Your project has exceeded its monthly spending cap.")
+    assert verdict == pc.BILLING
+
+
+def test_plain_rate_limit_is_inconclusive_not_billing():
+    # THE divergence from collect-models.spec.ts's `\b429\b` (see the module
+    # docstring): here BILLING aborts the job, and a rate limit is retryable — so it
+    # must let the run proceed.
+    verdict, reason = pc.classify(
+        429,
+        json.dumps(
+            {
+                "error": {
+                    "message": (
+                        "Rate limit reached for gpt-4o-mini in organization org-x on "
+                        "requests per min (RPM): Limit 3, Used 3, Requested 1."
+                    ),
+                    "type": "rate_limit_exceeded",
+                }
+            }
+        ),
+    )
+    assert verdict == pc.INCONCLUSIVE
+    assert "transient" in reason
+
+
+def test_a_rate_limit_message_that_also_names_credit_exhaustion_is_billing():
+    # Both markers present: the strong billing marker wins, so a drained account
+    # cannot hide behind the word "rate limit".
+    verdict, _ = pc.classify(
+        429, "Rate limit reached. You have no credits remaining. Add credits to continue"
+    )
+    assert verdict == pc.BILLING
+
+
+def test_invalid_key_is_key_rot_not_billing():
+    verdict, reason = pc.classify(
+        401, json.dumps({"error": {"message": "Incorrect API key provided: sk-xxx"}})
+    )
+    assert verdict == pc.KEY_ROT
+    assert "rotate" in pc._ACTIONS[verdict].lower()
+
+
+def test_no_model_access_is_key_rot():
+    verdict, _ = pc.classify(
+        403, json.dumps({"error": {"message": "The model `gpt-9` does not exist or you do "
+                                              "not have access to it."}})
+    )
+    assert verdict == pc.KEY_ROT
+
+
+def test_2xx_is_live_regardless_of_body():
+    verdict, reason = pc.classify(200, json.dumps({"choices": [{"message": {"content": "p"}}]}))
+    assert verdict == pc.LIVE
+    assert "200" in reason
+
+
+def test_provider_5xx_is_inconclusive():
+    verdict, _ = pc.classify(503, "upstream connect error")
+    assert verdict == pc.INCONCLUSIVE
+
+
+def test_unrecognised_4xx_is_inconclusive_so_the_run_still_decides():
+    # Fail-open: aborting here would block the migration test for a reason that has
+    # nothing to do with migration.
+    verdict, reason = pc.classify(400, json.dumps({"error": {"message": "max_tokens is not "
+                                                                       "supported"}}))
+    assert verdict == pc.INCONCLUSIVE
+    assert "400" in reason
+
+
+def test_empty_evidence_is_inconclusive_and_says_so():
+    verdict, reason = pc.classify(None, "")
+    assert verdict == pc.INCONCLUSIVE
+    assert "nothing to attribute" in reason
+
+
+def test_blocking_is_exactly_billing_and_key_rot():
+    # The routing contract: only these two divert the report off `migration-test`
+    # and abort a job early.
+    assert set(pc.BLOCKING) == {pc.BILLING, pc.KEY_ROT}
+    assert pc.LIVE not in pc.BLOCKING and pc.INCONCLUSIVE not in pc.BLOCKING
+
+
+# ── probe ────────────────────────────────────────────────────────────────────
+
+
+def _transport(status, body):
+    def send(request, timeout):
+        assert request.method == "POST"
+        payload = json.loads(request.data.decode())
+        assert payload["max_tokens"] == 1, "the probe must not spend more than one token"
+        return status, body
+
+    return send
+
+
+def test_probe_reports_billing_on_the_drained_key():
+    verdict, reason = pc.probe("sk-test", transport=_transport(429, RUN_124_BODY))
+    assert verdict == pc.BILLING
+    assert "model=gpt-4o-mini" in reason
+
+
+def test_probe_reports_live_on_a_funded_key():
+    verdict, _ = pc.probe("sk-test", transport=_transport(200, '{"choices":[]}'))
+    assert verdict == pc.LIVE
+
+
+def test_probe_sends_the_witness_model():
+    seen = {}
+
+    def send(request, timeout):
+        seen.update(json.loads(request.data.decode()))
+        return 200, "{}"
+
+    pc.probe("sk-test", model="gpt-4.1-mini", transport=send)
+    # The probe must ask about the model the witness will use — a key with no access
+    # to *that* model is a KEY_ROT the run would otherwise discover 3 minutes later.
+    assert seen["model"] == "gpt-4.1-mini"
+
+
+def test_probe_never_sends_the_key_in_the_body():
+    def send(request, timeout):
+        assert "sk-secret" not in request.data.decode()
+        return 200, "{}"
+
+    pc.probe("sk-secret", transport=send)
+
+
+def test_an_empty_secret_is_key_rot_without_a_request():
+    def send(request, timeout):  # pragma: no cover — must not be reached
+        raise AssertionError("probe must not call the provider without a key")
+
+    verdict, reason = pc.probe("", transport=send)
+    assert verdict == pc.KEY_ROT
+    assert "not configured" in reason
+
+
+def test_a_transport_failure_is_inconclusive_never_blocking():
+    def send(request, timeout):
+        raise OSError("connection reset")
+
+    verdict, reason = pc.probe("sk-test", transport=send)
+    assert verdict == pc.INCONCLUSIVE
+    assert "OSError" in reason
+
+
+# ── marker + announcements ───────────────────────────────────────────────────
+
+
+def test_marker_is_written_only_for_blocking_verdicts(tmp_path):
+    path = tmp_path / "verdict.json"
+    assert pc.write_marker(pc.LIVE, "fine", "pre-flight", str(path)) is None
+    assert pc.write_marker(pc.INCONCLUSIVE, "unclear", "pre-flight", str(path)) is None
+    assert not path.exists(), "absence of the marker is what keeps the default routing"
+
+    assert pc.write_marker(pc.BILLING, "drained", "pre-flight", str(path)) == str(path)
+    payload = json.loads(path.read_text())
+    assert payload["verdict"] == pc.BILLING
+    assert payload["label"] == pc.ISSUE_LABEL
+    assert payload["label"] != "migration-test", (
+        "routing a billing state to the migration tracker is #1295 — a later green "
+        "run would close it with 'Migration test passed'"
+    )
+    assert payload["title"] and payload["action"]
+
+
+def test_a_blocking_announcement_states_there_was_no_migration_signal():
+    line = pc.announce(pc.BILLING, "drained", "pre-flight")
+    assert line.startswith("::error::")
+    assert "NO migration signal" in line
+
+
+def test_an_inconclusive_announcement_warns_and_does_not_error():
+    line = pc.announce(pc.INCONCLUSIVE, "network blip", "pre-flight")
+    assert line.startswith("::warning::")
+    assert "::error::" not in line
+
+
+# ── step_status: the mid-run decision both API scripts share ─────────────────
+
+
+def test_a_billing_detail_records_blocked_and_leaves_a_marker(tmp_path, capsys):
+    marker = tmp_path / "verdict.json"
+
+    status = pc.step_status(RUN_124_DETAIL, "latest/execute_flow", marker=str(marker))
+
+    assert status == "blocked"
+    assert json.loads(marker.read_text())["phase"] == "latest/execute_flow"
+    assert "::error::" in capsys.readouterr().out
+
+
+def test_both_api_scripts_route_their_execution_failure_through_step_status():
+    """Structural, and labelled as such: the alternative needs a live Langflow.
+
+    It cannot tell whether the call site is *correct* — the tests above do that — but
+    the realistic regression here is the wiring being dropped while the module keeps
+    passing its own tests, and that is exactly what this catches.
+    """
+    import pathlib
+
+    here = pathlib.Path(__file__).parent
+    for name in ("setup_latest.py", "verify_migration_api.py"):
+        source = (here / name).read_text()
+        assert "credentials.step_status(" in source, (
+            f"{name} no longer classifies a failed flow execution — a drained provider "
+            f"would be filed as a migration failure again (#1295)"
+        )
+
+
+def test_any_other_failure_still_records_fail_and_says_nothing(tmp_path, capsys):
+    marker = tmp_path / "verdict.json"
+
+    # The migration failures this workflow exists to catch must be untouched by the
+    # #1295 fix — including the ones whose text mentions a model or a 500.
+    for detail in (
+        'HTTP 404: {"detail":"Flow identifier 152131bd not found"}',
+        'HTTP 500: {"detail":"A model selection is required"}',
+        "HTTP 500: cannot decrypt variable (Fernet)",
+    ):
+        assert pc.step_status(detail, "latest/execute_flow", marker=str(marker)) == "fail", detail
+
+    assert not marker.exists(), "a migration failure must not be filed as a credential state"
+    assert capsys.readouterr().out == ""
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+
+def test_probe_mode_exits_nonzero_on_billing(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(pc, "_send", _transport(429, RUN_124_BODY))
+    marker = tmp_path / "verdict.json"
+
+    code = pc.main(["--probe", "--marker", str(marker)])
+
+    assert code == 1, "a blocking pre-flight must stop the job before it installs anything"
+    assert "::error::" in capsys.readouterr().out
+    assert marker.exists()
+
+
+def test_probe_mode_exits_zero_when_inconclusive(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(pc, "_send", _transport(503, "bad gateway"))
+
+    code = pc.main(["--probe", "--marker", str(tmp_path / "verdict.json")])
+
+    assert code == 0, "fail-open: the run itself is the authoritative verdict"
+    assert "::warning::" in capsys.readouterr().out
+
+
+def test_classify_file_mode_attributes_without_changing_the_exit_code(tmp_path, capsys):
+    body = tmp_path / "run-source.json"
+    body.write_text(RUN_124_BODY)
+    marker = tmp_path / "verdict.json"
+
+    code = pc.main(
+        [
+            "--classify-file",
+            str(body),
+            "--status",
+            "500",
+            "--phase",
+            "compose-source",
+            "--marker",
+            str(marker),
+        ]
+    )
+
+    # The step that produced this body already failed; attribution must not become a
+    # second, competing exit code.
+    assert code == 0
+    assert json.loads(marker.read_text())["phase"] == "compose-source"
+    assert "::error::" in capsys.readouterr().out
+
+
+def test_an_unreadable_body_file_never_masks_the_real_failure(tmp_path, capsys):
+    code = pc.main(["--classify-file", str(tmp_path / "absent.json")])
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "::warning::" in out and "no credential verdict" in out
+
+
+def test_probe_and_classify_file_are_mutually_exclusive(tmp_path):
+    import pytest
+
+    with pytest.raises(SystemExit):
+        pc.main(["--probe", "--classify-file", str(tmp_path / "x.json")])
+    with pytest.raises(SystemExit):
+        pc.main([])

--- a/tests/github-workflows/migration/verify_migration_api.py
+++ b/tests/github-workflows/migration/verify_migration_api.py
@@ -3,6 +3,7 @@
 import sys
 import time
 
+import provider_credentials as credentials
 from helpers import (
     get_auth_token,
     get_flow,
@@ -79,7 +80,13 @@ def main():
     # 5. Execute flow on nightly via API
     print("── Executing flow on nightly via API...")
     success, detail = run_flow_safe(token, flow_id)
-    status = "pass" if success else "fail"
+    # Same attribution as the source phase (#1295): the account can drain between the
+    # two, and "the provider stopped paying" is not a migration verdict. The
+    # migration-specific checks above (flow preserved, variables preserved) still ran
+    # and still fail on their own terms if they are broken.
+    status = (
+        "pass" if success else credentials.step_status(detail, "nightly_api/execute_flow_api")
+    )
     print(f"   {status.upper()}: {detail[:120]}")
     phase["steps"]["execute_flow_api"] = {"status": status, "detail": detail}
     if not success:


### PR DESCRIPTION
Closes the infra half of #1295 — an **automated scheduled-run failure issue**, the same exception class as a `daily-failure` triage issue under `CLAUDE.md` → *What to work on*. The other half is not code: the OpenAI account has to be topped up (see **What this PR does not fix** below).

## What happened

Run [#124](https://github.com/oriontech-me/langflow-e2e/actions/runs/30993477849) filed *"Langflow Migration Test Failed (latest → nightly)"* for a run in which **the witness flow never executed**. Both jobs died in their SOURCE phase:

```
HTTP 500 … Error building Component Language Model … Error code: 429 -
{'error': {'message': 'You have no credits remaining. Add credits to continue using the API …',
           'type': 'insufficient_quota', 'code': 'credit_balance_exhausted'}}
```

Reproduced locally against the same key while diagnosing, so this is measured, not inferred. Three things went wrong, none of them about migration:

1. **No migration signal at all.** No alembic, no Fernet round-trip, no named volume — yet the report said `Result: FAILED` under a migration title.
2. **It wrote to the `migration-test` tracker.** The next green run's `Close issue on success` step comments *"Migration test passed. Closing this issue."* — leaving a Langflow bug in the history that never existed.
3. **The pre-flight only checked that the secret was non-empty.** Its own comment already makes this argument one level up (*"the run only fails 5+ minutes later with a misleading error"*). Presence is not usability: the check passed, then the job spent 1 min 40 s installing the Playwright browser and another minute installing Langflow — and the compose job pulled 941 MB of images — before reaching the 429.

The source phase failing has always been a *pre-condition* failure, never a migration one: #905/#1004 were model selection, #1172 a flow 404, this one credit.

## What changed

| File | Change |
|---|---|
| `provider_credentials.py` **(new)** | Classifies a provider response or error text as `live` / `billing` / `key-rot` / `inconclusive`. Three entry points: `--probe` (one token), `--classify-file` (the compose job's `curl` bodies), `step_status()` (the mid-run decision both API scripts share). Stdlib only — the PR-validation lane installs `pytest` and nothing else. |
| `migration-test.yml` | Both jobs probe the key **before installing anything** (first step after `Setup Python` in the pip job; before the image pull in the compose job), replacing the non-empty-secret check. Both compose `curl` steps classify before dying. All four `github-script` steps route on the verdict. Marker added to both artifact uploads. |
| `setup_latest.py`, `verify_migration_api.py` | One line each: the account can drain *after* the pre-flight. |
| `generate_report.py` | New `blocked` status → `Result: BLOCKED (provider credentials — no migration signal)`, its own section right under the verdict, and it reads the marker (a pre-flight abort has no phase to attach to). |
| `README.md` | Phase 0, the verdict → tracker table, and why the split exists. |

### Design decisions worth reviewing

- **Fail-open.** Only `billing` / `key-rot` abort. A network blip or an unrecognised 4xx warns and lets the run reach its own conclusion — the authoritative verdict on a migration is the migration, and aborting there would block this workflow for a reason unrelated to migration. Never silent either way (#1012).
- **Red, never green.** A blocked run has no migration signal, so it must not read as a pass (#570/#1012). It is red with the right attribution, on the right tracker.
- **A separate tracker (`provider-credentials`, label self-provisioned).** Both states are red; only one is a claim about Langflow. A green run closes *both* trackers, each with wording about what it actually proved — that is honest, since a green run does prove the key is live.
- **A real migration failure outranks a credential block.** `blocked` only decides the wording when it is the only thing wrong.
- **`blocked` counts as an accounted failure in the #1120 reconciliation.** Without that, a phase whose only bad step was `blocked` would be reported as *"crashed before writing its result"* — the fix for #1295 reintroducing the defect #1120 exists to prevent.
- **A bare 429 is deliberately NOT a billing marker here**, diverging from `collect-models.spec.ts`'s canonical `BILLING_OR_QUOTA` (#955). A plain `rate_limit_exceeded` is 429 too; there both branches only warn, here `billing` aborts the job. A body naming a rate limit with no strong billing marker is `inconclusive` and the run continues. The two patterns are otherwise mirrors and are kept in sync by hand — both unit-tested.

### Rejected

Routing the witness to a keyless local model (Ollama). The auto-imported `OPENAI_API_KEY` Credential *is* the Fernet assertion — a keyless run would execute without decrypting it and quietly weaken the thing this workflow exists to catch.

## Validation

| Check | Result |
|---|---|
| Python unit lane (the one `pr-validation.yml` runs) | **66 passed** — 39 new (27 before) |
| Forced mutations | **12 attempted, 12 killed.** Two survived first and were closed: the strong billing markers were not pinned individually (run #124's body carries three at once, so deleting one changed no test), and `exceeded your current quota` is only distinguishable from the weak `\bquota\b` against a body that *also* names a rate limit |
| Pre-flight, live, against the actually-drained key | `exit 1`, correct `::error::`, `billing` marker written |
| `--classify-file` on run #124's real response body | `billing`, `exit 0` — attribution never steals the failing step's exit code |
| `npm run test:scripts` / `test:units` | 785 / 484 passed |
| `npm run typecheck` / `npm run lint` | clean / 0 errors |
| Workflow YAML | parses; step order inspected in both jobs |

**No local proof exists for the YAML** — its final proof is the next scheduled run (or a dispatch on this branch). Expected with the account still drained: both jobs abort in ~30 s with `::error::` naming billing, and the issue lands on `provider-credentials`, not `migration-test`. One bug caught in review of this diff: `#` inside `upload-artifact`'s literal `path:` block is not a comment — it would be read as a path pattern; removed.

## Checklist notes

- No `.spec.ts` touched → no spec doc, no `@stable`, no `QA-CHECKLIST.md` bullet in scope. Nothing under `tests/tests-automations/` changed, so no flow-cleanup surface either.
- The `provider-credentials` label does not exist yet; the workflow creates it idempotently on first use, so no manual step.
- Not deduped away: #955 (closed) supplied the classification semantics, reused here; #976 (open) is key-level fallback — a different lever, and this pre-flight will simply probe whatever canonical key #976 resolves.

## What this PR does not fix

#1295's failure cannot be made green by code. The OpenAI account is drained account-wide — the same account that took down today's daily `@stable` (#1296) and `Collect models`. Until it is topped up (or `OPENAI_API_KEY` points at a funded account), this workflow will keep going red — now in 30 seconds, with the cause named, on a tracker that does not accuse Langflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
