### PR TITLE
fix(model-provider): restore @stable on the Google Agent execution spec (#1261)

### DIFF
--- a/docs/core-functionality/model-provider/google-provider.md
+++ b/docs/core-functionality/model-provider/google-provider.md
@@ -1,6 +1,6 @@
 # Google Provider — configure key, select Gemini
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x
 
 ---
 
@@ -196,3 +196,29 @@ nightly. `@model-provider` (area) · `@settings` (Test 1 navigates Settings) ·
   **POST 201**, PATCH-only waiter → timeout. Backend healthy (no hang/5xx): a
   **test defect**, not a product bug. Fix: match `POST` **or** `PATCH`. Same fix
   in `openai-provider.spec.ts`.
+- **#1261 — `@stable` auto-removed 2026-08-04, restored here; nothing about Google
+  was ever observed.** The issue was filed as "the Agent never settles a Gemini
+  model/credential on the persisted flow", grouping Test 2 with
+  `mcp-client-agent-gemini-tool-regression.spec.ts` on that shared state. The run
+  artifact refutes the premise: **every** failing attempt on both specs, across the
+  2026-08-03 and 2026-08-04 dailies, carries the settle guard's own `read-failed`
+  verdict — `0 read(s)`, `last read err apiRequestContext.get: Timeout 20000ms
+  exceeded` on `GET /api/v1/flows/{id}`. The guard states the consequence itself:
+  *"No read of the persisted flow succeeded, so the binding is UNKNOWN — nothing
+  here says anything about the credential."* So the Gemini binding was never
+  measured, let alone found broken; the finding is the unanswered read (the mid-run
+  wedge, #1030/#1048, relief tracked in #1077), and it is provider-independent —
+  Google clustered only because its specs pin a model and therefore sit on the
+  guard longest.
+  Two further causes, neither Google-shaped, complete the picture and explain why
+  the auto-removal was not exempted as wedge collateral: the deciding attempt
+  (attempt 2, the one `lastFailureError` classifies) failed in
+  `openNewFlowTemplatesModal` on the welcome-panel predicate — **#966 / LE-2019**,
+  a UI signature deliberately excluded from `infra-signature-patterns.json` — and
+  the 2026-08-05 recurrence was the line-wide stale-premise break of the guard
+  itself (**#1274**, fixed in PR #1315 by settling on the model's `provider`).
+  Re-measured on `1.12.0.dev17` with the fixed guard: this file **5/5 rounds green
+  (10/10 tests)**, sentinel echoed 5/5; the MCP sibling 4/5, its single failure
+  being MCP server registration (`GET /api/v2/mcp/servers` 20 s, **#1266**), a step
+  that never reaches the credential guard. No product regression, no wait-strategy
+  change needed.

--- a/tests/tests-automations/regression/core-functionality/model-provider/google-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/google-provider.spec.ts
@@ -154,7 +154,7 @@ test.describe("Google Provider", () => {
 
   test(
     "configured Google selects a Gemini model in the Agent and executes the flow",
-    { tag: ["@model-provider", "@agents", "@playground"] },
+    { tag: ["@stable", "@model-provider", "@agents", "@playground"] },
     async ({ page }) => {
       test.skip(
         !hasProviderEnvKeys(PROVIDER),


### PR DESCRIPTION
Closes #1261.

## What this changes

Lifts the quarantine on `google-provider.spec.ts` Test 2 — an exact revert of the
`@stable` hunk auto-removed by `d401743` (daily #30901311395). One line of test
code, plus the spec doc's `Last validated` and a durable record of the cause.

## Root cause — the issue's premise is refuted by its own run artifacts

#1261 was filed as *"the Agent never settles a Gemini model/credential on the
persisted flow"*, grouping two specs on that shared state. The JSON artifacts of
runs `30809091241` (08-03) and `30901311395` (08-04) show **every** failing
attempt of **both** specs carrying the settle guard's own `read-failed` verdict:

```
observed       no successful read of the persisted flow
waited         20.0s over 0 read(s)
last read err  apiRequestContext.get: Timeout 20000ms exceeded.
verdict        read-failed
               No read of the persisted flow succeeded, so the binding is
               UNKNOWN — nothing here says anything about the credential.
```

**Zero successful reads.** The Gemini binding was never measured, let alone found
broken. The finding is the unanswered `GET /api/v1/flows/{id}` — the mid-run
wedge (#1030/#1048, relief tracked in #1077) — and it is provider-independent.
Google clustered only because its specs pin a model and therefore sit on the
guard longest.

Three separate non-Google causes account for the whole record:

| Day | What actually failed |
|---|---|
| 08-03, 08-04 attempt 0 | wedge — flow read never answered (`read-failed`, #1077) |
| 08-04 attempt 2 (the deciding one) | welcome-panel predicate in `openNewFlowTemplatesModal` — **#966 / LE-2019** |
| 08-05 | line-wide stale premise of the guard itself — **#1274**, fixed in #1315 |

That middle row also explains why auto-removal did not exempt this as wedge
collateral: `lastFailureError` classifies the LAST failed attempt, and a UI
predicate timeout is deliberately excluded from `infra-signature-patterns.json`.
The mechanism behaved as designed — no infra change proposed here.

**Verdict: transient/environment. No product regression, no wait-strategy change.**

**Grouping re-checked live (a #1261 deliverable):** the two specs do share the
guard, but the shared state was the flow read, not a Gemini binding. The causal
grouping does not hold.

## Validation

Langflow **`1.12.0.dev17`** (`langflowai/langflow-nightly:latest`), `--retries=0 --workers=1`.

| Spec | Result |
|---|---|
| `google-provider.spec.ts` | **5/5 rounds green (10/10 tests)**, sentinel echoed 5/5 |
| `mcp-client-agent-gemini-tool-regression.spec.ts` | **4/5** — single failure was MCP server registration (`GET /api/v2/mcp/servers` 20s, **#1266**), a step that never reaches the credential guard |
| daily 2026-08-06 (first after #1315) | MCP sibling ran as `@stable` and **passed**; credential-settle signature absent from the run |

Checklist:

- [x] Steps verified against live runs — `--trace=on` **skipped**: this is a
      Simple Agent–template spec, the documented local trace hang (#490/#518).
      Covered instead by 5 clean `--retries=0` rounds + 3 force-fails.
- [x] **Force-failed — executed, not assumed** (isolated with `--grep`, since
      serial mode masks siblings after a failure):
      **FF-A** model regex → `/MUTANT_NOT_A_MODEL/i` → failed with
      `Received string: "gemini-flash-latest"`, proving both that the assert is
      live and that the Gemini model *does* settle on dev17;
      **FF-B** `button-send` click suppressed → failed on `div-chat-message`
      `element(s) not found`;
      **FF-C** key replaced with an invalid value → failed on
      `page.waitForResponse: Timeout 60000ms` (with a bad key the frontend never
      fires the persist, so a no-op save cannot pass).
      Revert proven: zero `MUTANT` markers, final run **2 passed (29.6s)**.
- [x] `npm run typecheck` clean · `npm run lint` **0 errors** (1319 pre-existing warnings)
- [x] Backend errors reviewed: only advisory `500` on the cleanup
      `DELETE /api/v1/flows/` — the known ambient delete-path 500, not raised by
      this change.
- [x] Flow cleanup verified: baseline 0 → 2 orphans (both timestamped inside
      run 1 only, starter flows on an empty account; the 12 later runs added
      none, so id-scoped cleanup works) → **purged, 0 remaining**.
- [x] `QA-CHECKLIST.md` untouched — §7.4 bullets already `[x]` with the spec
      path; generated blocks regenerate on merge (#741).

## Suggested issue disposition

Close #1261 as **no product regression**, absorbed by #1077 (wedge),
#966/LE-2019 (welcome panel) and #1274 (guard premise), with the grouping
explicitly refuted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)