### PR TITLE
chore(mcp): quarantine the MCP-server-tab spec as a recurrent flake (#1335)

### DIFF
--- a/tests/tests-automations/regression/mcp/server/mcp-server-tab.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-tab.spec.ts
@@ -3,9 +3,13 @@ import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { openAddMcpServerModal } from "../../../../helpers/mcp/open-add-mcp-server-modal";
 
-test(
+// Quarantined: recurrent flake on the daily (2026-08-05, 2026-08-06, same
+// signature) — `mcp-server-dropdown` is not clickable within the 3 s budget in
+// `helpers/mcp/open-add-mcp-server-modal.ts`. Tracked in #1335; lifting the
+// quarantine (remove `test.fixme` + restore `@stable`) is a deliverable there.
+test.fixme(
   "user should be able to manage MCP server tools and configuration",
-  { tag: ["@stable", "@release", "@workspace", "@components", "@mcp"] },
+  { tag: ["@release", "@workspace", "@components", "@mcp"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 


### PR DESCRIPTION
Quarantines `mcp-server-tab.spec.ts:6` ("user should be able to manage MCP server tools and configuration") as prevention, per `CONTRIBUTING.md` → *Triage protocol*, step 2.

Spun out of daily-failure triage #1330 (run [31093877484](https://github.com/oriontech-me/langflow-e2e/actions/runs/31093877484), 2026-08-06). The investigation is tracked in #1335 — this PR does not fix anything.

## Why

Recurrent flake: same signature on two dailies inside the 30-day window.

| Daily | Signature |
|---|---|
| 2026-08-05 | `TimeoutError: locator.click: Timeout 3000ms exceeded.` |
| 2026-08-06 | `TimeoutError: locator.click: Timeout 3000ms exceeded.` |

The wait is a 3 s click budget on `mcp-server-dropdown` in the shared helper `tests/helpers/mcp/open-add-mcp-server-modal.ts:10`. (A third hit on 2026-07-27 carries a **different** signature and does not count toward the criterion.)

## Why both edits, not just the tag

`@stable` removal alone only stops the daily. `pr-validation.yml` selects specs by **file diff**, not by tag (#871) — so the test would still run red on the impacted-specs gate, starting with this very PR. `test.fixme` skips it in every context, which is what makes the quarantine hold and this PR merge green.

## Not touched

- `QA-CHECKLIST.md` bullets: the spec still exists and still has a mirrored doc, so `check:checklist-coverage` still requires them. Generated blocks are regenerated on merge by `update-coverage-summary.yml`.
- The spec doc: per `CONTRIBUTING.md`, the traceability record for a quarantine cycle is the triage issue + the dedicated issue + the restoration PR.

Lifting the quarantine (remove `test.fixme` + restore `@stable`, re-validated) is a deliverable of #1335.

🤖 Generated with [Claude Code](https://claude.com/claude-code)