### PR TITLE
chore(flow-functionality): quarantine the auto-save-off spec as a recurrent flake (#1336)

### DIFF
--- a/tests/tests-automations/regression/flow-functionality/auto-save-off.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/auto-save-off.spec.ts
@@ -56,9 +56,13 @@ async function reopenNewFlow(page: Page): Promise<void> {
     .click({ timeout: 45000 });
 }
 
-test(
+// Quarantined: recurrent flake on the daily (2026-07-22, 2026-08-06, same
+// signature) — reopening the just-created flow through its
+// `list-card-open-button` times out at 45 s. Tracked in #1336; lifting the
+// quarantine (remove `test.fixme` + restore `@stable`) is a deliverable there.
+test.fixme(
   "user should be able to manually save a flow when the auto_save is off",
-  { tag: ["@stable", "@release", "@api", "@database", "@components"] },
+  { tag: ["@release", "@api", "@database", "@components"] },
   async ({ page }) => {
     trackCreatedFlows(page);
 


### PR DESCRIPTION
Quarantines `auto-save-off.spec.ts:59` ("user should be able to manually save a flow when the auto_save is off") as prevention, per `CONTRIBUTING.md` → *Triage protocol*, step 2.

Spun out of daily-failure triage #1330 (run [31093877484](https://github.com/oriontech-me/langflow-e2e/actions/runs/31093877484), 2026-08-06). The investigation is tracked in #1336 — this PR does not fix anything.

## Why

Recurrent flake: same signature on two dailies inside the 30-day window.

| Daily | Signature |
|---|---|
| 2026-07-22 | `TimeoutError: locator.click: Timeout 45000ms exceeded.` |
| 2026-08-06 | `TimeoutError: locator.click: Timeout 45000ms exceeded.` |

The wait is a 45 s click on the just-created flow's `list-card-open-button` on the flows list. The same test also has hits on 2026-07-15 and 2026-07-16 under a **different** signature — a different cause, not counted toward the criterion.

## Why both edits, not just the tag

`@stable` removal alone only stops the daily. `pr-validation.yml` selects specs by **file diff**, not by tag (#871) — so the test would still run red on the impacted-specs gate, starting with this very PR. `test.fixme` skips it in every context, which is what makes the quarantine hold and this PR merge green.

## Not touched

- `QA-CHECKLIST.md` bullets: the spec still exists and still has a mirrored doc, so `check:checklist-coverage` still requires them. Generated blocks are regenerated on merge by `update-coverage-summary.yml`.
- The spec doc: per `CONTRIBUTING.md`, the traceability record for a quarantine cycle is the triage issue + the dedicated issue + the restoration PR.

Lifting the quarantine (remove `test.fixme` + restore `@stable`, re-validated) is a deliverable of #1336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)