### PR TITLE
fix(flow-functionality): re-open the flow under test by id, not by name (#1336)

### DIFF
--- a/docs/flow-functionality/auto-save-off.md
+++ b/docs/flow-functionality/auto-save-off.md
@@ -1,6 +1,6 @@
 # Manual Save With Auto-Save Disabled — §12.2 View and Edit Flow
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x
 
 ---
 
@@ -43,25 +43,34 @@ across a full exit/re-open. `@components` — drives a canvas component.
 Setup: mock `/api/v1/config` to `auto_saving: false`, bootstrap the app
 (`awaitBootstrapTest`), open a blank flow. Every flow this page creates is
 captured from its `POST /api/v1/flows → 201` response and deleted id-scoped in
-`afterEach`.
+`afterEach`. The **id of the flow under test** is read from the URL right after
+the blank-flow navigation (never before it — the bootstrap parks the page on a
+placeholder flow Langflow then deletes) and cross-checked against the ids this
+page created; every re-open below is pinned to that id.
+
+Every exit asserts the editor was actually left (the URL leaves `/flow/…`)
+before anything else runs.
 
 1. Add a **Chat Input** component to the canvas (sidebar search → hover entry →
    `add-component-button-chat-input`)
 2. Assert the on-canvas **`save-flow-button`** is enabled (auto-save off ⇒ manual
    save is available)
 3. Leave via the back button (`icon-ChevronLeft`); the unsaved-changes dialog
-   ("Unsaved changes will be permanently lost.") appears — click **Exit Anyway**
-4. Re-open the flow (via the flow card's open button); assert the canvas has
-   **0** nodes (`div-generic-node` count = 0) — the edit was discarded
+   ("Unsaved changes will be permanently lost.") appears — click **Exit Anyway**;
+   assert the editor was left
+4. Re-open the flow **by id** (`/flow/<id>`, waiting for its
+   `GET /api/v1/flows/<id>` to resolve and the canvas to mount); assert the
+   canvas has **0** nodes (`div-generic-node` count = 0) — the edit was discarded
 5. Add the Chat Input component again (hover the sidebar entry →
    `add-component-button-chat-input`)
-6. Leave via the back button; click **Save And Exit**
+6. Leave via the back button; click **Save And Exit**; assert the editor was left
 7. Re-open the flow; assert **`title-Chat Input`** is visible — the edit persisted
 8. Add a **Chat Output** component (hover the sidebar entry →
    `add-component-button-chat-output`), click **`save-flow-button`** (the
    on-canvas manual save), leave via the back button. The exit-guard dialog is
    timing-dependent here — if the manual save settled, the exit is clean;
-   otherwise **Save And Exit** appears and is clicked. Either path persists.
+   otherwise **Save And Exit** appears and is clicked. Either path persists, and
+   either way the editor must be left
 9. Re-open the flow; assert both `title-Chat Input` and `title-Chat Output` are
    visible and `div-generic-node` count = **2**
 
@@ -98,9 +107,8 @@ fails if either save did not persist (see Notes on the hardening).
   search. Adds use the draggable wrapper hover → add button (the sidebar row is
   briefly `pointer-events-none`; dragging it is unreliable).
 - `data-testid="title-Chat Input"` / `div-generic-node` — node presence on canvas.
-- `data-testid="list-card"` / `flow-name-div` / `list-card-open-button` —
-  re-open a flow from the list (the `/flows` a11y refactor made `flow-name-div`
-  `pointer-events-none`; open via the card overlay button — Langflow #13891).
+- `GET /api/v1/flows/{id}` and the `/flow/{id}` route — the re-open path (see the
+  #1336 note below for why this is not the flows-list card).
 - No API key — the Chat Input / Chat Output components are added to the graph,
   never executed.
 
@@ -116,6 +124,33 @@ fails if either save did not persist (see Notes on the hardening).
 
 ## Notes *(optional)*
 
+- **#1336 (the re-open opened the WRONG flow).** Recurrent flake on the
+  2026-07-22 and 2026-08-06 dailies: `locator.click: Timeout 45000ms exceeded`
+  re-opening the just-created flow's card. Not a product regression, and not a
+  tight wait either — the spec was **driving another worker's flow**. It clicked
+  the first `list-card` whose name contained "New Flow", and Langflow names every
+  blank flow "New Flow"/"New Flow (N)", so under `fullyParallel` the list holds
+  one per worker. Proved on nightly 1.12.0.dev18 by logging the page's own
+  network: the page created ids `8e767306` and `ee8e0ab9`, and the re-open landed
+  on `164b3c19` — an id it never created. When that flow's real owner ran its
+  id-scoped cleanup, the save `PATCH /api/v1/flows/{id}` came back **404**, so the
+  editor never navigated back to the list and the next re-open burned its 45 s on
+  a card that had no reason to exist. That is also the CI artifact's state: the
+  failure screenshot is the *canvas*, not the list, with the flow saved and the
+  same two 404s in the advisory log. Reproduced **3/8 at `--workers=4`**;
+  **8/8 green** after the fix under the identical burst.
+  Two further findings shaped the fix. The card cannot be selected by id either:
+  the list is **paginated at 12 and ordered by `updated_at DESC`**, and under load
+  this test's own card is routinely off page 1 (measured: 12 of 12 slots taken by
+  fresher flows) — so the old spec's "success" depended on *some* other worker's
+  "New Flow" being on top, which also made the discard assertion (`count === 0`)
+  vacuous whenever it opened a stranger's fresh blank flow. And the id must be
+  read **after** the blank-flow navigation: `awaitBootstrapTest` reaches the
+  templates modal through "New Flow", which parks the page on a placeholder flow
+  that Langflow deletes as soon as the modal navigates elsewhere (#490/#681
+  again, from the other side). The re-open is therefore by URL, and each exit now
+  asserts the editor was left — verified by forcing the save PATCH to 500, which
+  now fails at the exit step instead of 45 s later on an unrelated locator.
 - **#790 (load-collateral, critical clicks hardened).** On load-degraded /
   guard-tripped dailies (2026-07-15/16) the spec failed with
   `locator.click: Timeout 20000ms exceeded` on a manual-save click target. Not a

--- a/tests/tests-automations/regression/flow-functionality/auto-save-off.spec.ts
+++ b/tests/tests-automations/regression/flow-functionality/auto-save-off.spec.ts
@@ -39,30 +39,87 @@ test.afterEach(async ({ request }) => {
   }
 });
 
-// The /flows a11y refactor (Langflow #13891) makes `flow-name-div`
-// `pointer-events-none`; open the flow via the card's overlay button.
-async function reopenNewFlow(page: Page): Promise<void> {
-  // Explicit timeout above the 20s default actionTimeout: this heavy spec (two
-  // bootstraps + repeated exit/re-open cycles) blew the default card-open click
-  // under CI saturation on load-degraded dailies (#790). The extra headroom
-  // absorbs transient load without masking a real regression.
-  await page
-    .getByTestId("list-card")
-    .filter({
-      has: page.getByTestId("flow-name-div").filter({ hasText: "New Flow" }),
-    })
-    .getByTestId("list-card-open-button")
-    .first()
-    .click({ timeout: 45000 });
+/**
+ * The id of the flow currently open in the editor, cross-checked against the
+ * flows THIS page created.
+ *
+ * The cross-check is the point: an id in the URL that this page never created
+ * means the spec is driving somebody else's flow — the state #1336 spent two
+ * dailies failing on, and one better named here than six steps later as a
+ * 45 s timeout.
+ */
+async function editorFlowId(page: Page): Promise<string> {
+  const id = new URL(page.url()).pathname.match(/\/flow\/([0-9a-f-]{36})/)?.[1];
+  // The POST body is parsed asynchronously, so the entry can land a tick after
+  // the navigation; poll briefly rather than racing it.
+  await expect
+    .poll(() => createdFlowIds.includes(id ?? ""), { timeout: 10000 })
+    .toBe(true);
+  return id!;
 }
 
-// Quarantined: recurrent flake on the daily (2026-07-22, 2026-08-06, same
-// signature) — reopening the just-created flow through its
-// `list-card-open-button` times out at 45 s. Tracked in #1336; lifting the
-// quarantine (remove `test.fixme` + restore `@stable`) is a deliverable there.
-test.fixme(
+/**
+ * Leaving the canvas is itself part of the contract under test, so assert it
+ * instead of inferring it from whatever the next step happens to find. When the
+ * save behind "Save And Exit" fails, the editor simply stays put — under the
+ * old spec that surfaced 45 s later as a card-click timeout on the flows list
+ * (#1336), which named neither the step nor the cause. Verified by forcing the
+ * save PATCH to 500: the failure now lands on this call.
+ */
+async function expectLeftEditor(page: Page): Promise<void> {
+  await page.waitForURL((url) => !url.pathname.startsWith("/flow/"), {
+    timeout: 30000,
+  });
+}
+
+/**
+ * Re-open THIS test's flow by id and wait until its graph has been applied to
+ * the canvas.
+ *
+ * Why by id and not through the flows-list card (#1336). The spec used to click
+ * the first `list-card` whose name contained "New Flow". Langflow names every
+ * blank flow "New Flow"/"New Flow (N)", so under `fullyParallel` the list holds
+ * one per worker — and the flows list is **paginated at 12, ordered by
+ * `updated_at DESC`**. Both halves bite:
+ *
+ *  - the card that filter resolved was routinely ANOTHER worker's flow (proved
+ *    on nightly 1.12.0.dev18: the page created ids `8e767306` and `ee8e0ab9`
+ *    and the re-open landed on `164b3c19`, which it never created). When that
+ *    worker's own id-scoped cleanup deleted it mid-test, the save PATCH came
+ *    back 404, the editor never navigated back to the list, and the next
+ *    re-open waited out its 45 s — the exact 2026-07-22 / 2026-08-06 daily
+ *    signature, reproduced 3/8 at `--workers=4`;
+ *  - this test's own card is frequently NOT on page 1 at all (measured: 12 of
+ *    12 slots taken by fresher flows), so no card-based selector — not even the
+ *    id-scoped `flow-name-<uuid>` testid the card carries — can find it.
+ *
+ * Opening by URL removes both. The trade-off is deliberate: what this spec
+ * validates is server-side persistence across an exit/re-open, and a full
+ * reload proves that more strictly than an SPA route change. The
+ * "open a flow from its list card" path stays covered by the specs whose
+ * subject it is (`bulk-actions`, `mcp-server`).
+ */
+async function reopenFlow(page: Page, flowId: string): Promise<void> {
+  // The graph is applied to the canvas only after this GET resolves; waiting on
+  // it is what keeps the `div-generic-node` counts below from reading an empty
+  // canvas that simply had not rendered yet.
+  const flowLoaded = page.waitForResponse(
+    (resp) =>
+      new URL(resp.url()).pathname === `/api/v1/flows/${flowId}` &&
+      resp.request().method() === "GET" &&
+      resp.status() === 200,
+    { timeout: 45000 },
+  );
+  await page.goto(`/flow/${flowId}`);
+  await flowLoaded;
+  await page.waitForSelector('[data-testid="canvas_controls_dropdown"]', {
+    timeout: 45000,
+  });
+}
+
+test(
   "user should be able to manually save a flow when the auto_save is off",
-  { tag: ["@release", "@api", "@database", "@components"] },
+  { tag: ["@stable", "@release", "@api", "@database", "@components"] },
   async ({ page }) => {
     trackCreatedFlows(page);
 
@@ -88,7 +145,24 @@ test.fixme(
       timeout: 5000,
     });
 
+    // `awaitBootstrapTest` reaches the templates modal through the "New Flow"
+    // entry point, which already parked the page on a freshly created
+    // PLACEHOLDER flow — and Langflow deletes that placeholder as soon as the
+    // modal navigates elsewhere. So the id has to be read after the blank-flow
+    // navigation, never from the URL standing before it (#490/#681).
+    const placeholderUrl = page.url();
     await page.getByTestId("blank-flow").click();
+    await page.waitForURL(
+      (url) =>
+        /\/flow\/[0-9a-f-]{36}/.test(url.pathname) &&
+        url.toString() !== placeholderUrl,
+      { timeout: 30000 },
+    );
+
+    // Resolve the flow under test once, before any edit: every re-open below is
+    // pinned to this id, so the spec can never drive a parallel worker's
+    // identically-named "New Flow" (#1336).
+    const flowUnderTest = await editorFlowId(page);
 
     await page.getByTestId("sidebar-search-input").click();
     await page.getByTestId("sidebar-search-input").fill("chat input");
@@ -131,8 +205,9 @@ test.fixme(
       page.getByText("Unsaved changes will be permanently lost."),
     ).toBeVisible({ timeout: 10000 });
     await page.getByText("Exit Anyway", { exact: true }).click();
+    await expectLeftEditor(page);
 
-    await reopenNewFlow(page);
+    await reopenFlow(page, flowUnderTest);
 
     await page.waitForSelector('[data-testid="sidebar-search-input"]', {
       timeout: 5000,
@@ -167,8 +242,9 @@ test.fixme(
     const saveAndExit = page.getByText("Save And Exit", { exact: true }).last();
     await expect(saveAndExit).toBeVisible({ timeout: 10000 });
     await saveAndExit.click();
+    await expectLeftEditor(page);
 
-    await reopenNewFlow(page);
+    await reopenFlow(page, flowUnderTest);
 
     await page.waitForSelector("text=loading", {
       state: "hidden",
@@ -219,8 +295,9 @@ test.fixme(
     ) {
       await saveAndExit2.click();
     }
+    await expectLeftEditor(page);
 
-    await reopenNewFlow(page);
+    await reopenFlow(page, flowUnderTest);
 
     await page.waitForSelector('[data-testid="sidebar-search-input"]', {
       timeout: 5000,


### PR DESCRIPTION
**Fixes #1336.** Closes #1336.

## Problem

The `@stable` manual-save test flaked on the 2026-07-22 and 2026-08-06 dailies with the same signature — `locator.click: Timeout 45000ms exceeded` re-opening "the just-created flow" through its `list-card-open-button`. 45 s on a card the test itself created is not a tight wait, and the product is fine here: the spec was **driving another worker's flow**.

`reopenNewFlow` clicked the first `list-card` whose name contained `"New Flow"`. Langflow names every blank flow `New Flow`/`New Flow (N)`, so under `fullyParallel` the list holds one per worker. Proved on nightly `1.12.0.dev18` by logging the page's own network:

```
POST /api/v1/flows/ -> 201   (8e767306)   ← bootstrap placeholder
POST /api/v1/flows/ -> 201   (ee8e0ab9)   ← the blank flow this test edits
...
NAV /flow/164b3c19-...                    ← the re-open, an id this page NEVER created
PATCH /api/v1/flows/164b3c19-... -> 404   ← its real owner's id-scoped cleanup got there first
```

With the save 404'd the editor never navigates back to the list, so the next re-open waits out its full 45 s on a card that has no reason to exist. That is exactly the CI artifact's state: the failure screenshot is the **canvas**, not the flows list, with the flow saved and those two 404s in the advisory log. Reproduced **3/8 at `--workers=4 --retries=0`**.

Two further findings shaped the fix:

- **Selecting the card by id does not fix it.** The flows list is paginated at **12** and ordered by `updated_at DESC` (`pageSize = 12` in `homePage`, `stmt.order_by(Flow.updated_at.desc())` in `projects.py`). Under load this test's own card is routinely **off page 1** — measured at the failure: 12 of 12 slots taken by fresher flows. So the old spec's "success" depended on *some* other worker's blank flow being on top, which also made the discard assertion (`div-generic-node` count `=== 0`) **vacuous** whenever it opened a stranger's fresh blank flow.
- **The id must be read after the blank-flow navigation.** `awaitBootstrapTest` reaches the templates modal through the "New Flow" entry point, which parks the page on a placeholder flow that Langflow deletes as soon as the modal navigates elsewhere (`flow-builder-welcome-mount.tsx`). Reading `page.url()` before the click captures that placeholder — #490/#681 from the other side, and the first draft of this fix hit it.

## Fix

- **Re-open by id** (`/flow/<id>`), waiting for `GET /api/v1/flows/<id>` to resolve and the canvas to mount. Immune to pagination, ordering and to workers next door. The wait on the flow GET also stops the `div-generic-node` counts from reading a canvas that simply had not rendered yet.
- **Every exit now asserts the editor was left** (`expectLeftEditor`). This is the attribution the flake lacked: a failed save leaves the editor in place, and that surfaced 45 s later as a card-click timeout naming neither the step nor the cause.
- **`editorFlowId` cross-checks** the URL id against the ids this page created, so "the spec is driving somebody else's flow" fails where it happens instead of six steps later.
- Quarantine lifted: `test.fixme` removed, `@stable` restored.

Rejected alternatives: keeping the card click scoped by the card's own id-scoped `flow-name-<uuid>` testid (does not survive pagination — the card is absent, not mis-selected); keying on the exact flow name (names *are* unique per user via `UniqueConstraint("user_id", "name")`, but the card is still off page 1); narrowing the list via its search box (adds a debounced server filter as a new failure surface to a spec whose subject is persistence).

## Scope note

Every assertion in the test is unchanged in kind and strictly stronger in practice — the discard count, the two `title-*` visibility checks and the final `count === 2` now run against the flow this test actually saved. The re-open is a full reload rather than an SPA route change, which proves server-side persistence more strictly; the "open a flow from its list card" path stays covered by the specs whose subject it is (`bulk-actions`, `mcp-server`).

Descriptive, out of scope: under an artificial 8× same-spec burst, `POST /api/v1/flows/` and `DELETE /api/v1/flows/` returned **500** (`"An internal error occurred while creating the flow"`) — probable unique-name race. Never observed in serial execution.

## Validation (nightly `1.12.0.dev18`, `--retries=0`)

- `npm run typecheck` ✅ · `npx eslint <spec>` ✅ (0 errors; 15 pre-existing style warnings)
- **5/5** clean serial runs (`--workers=1 --repeat-each=5`, 55 s) ✅
- **8/8** under the adversarial burst that produced 3/8 failures before the fix (`--workers=4 --repeat-each=8`), twice ✅
- `--trace=on` ✅ (13 s, trace captured — this spec is not in the hanging family)
- zero `🚨 Backend Error` on the serial runs ✅
- flow cleanup verified via `GET /api/v1/flows/`: 28 before → 28 after a run (zero leak); the pre-existing orphan was purged ✅
- force-fail, executed:
  - `expect(chatInputNode).toBe(0)` → `toBe(1)` ⇒ failed (`Expected: 1, Received: 0`)
  - `expect(nodeCount).toBe(2)` → `toBe(3)` ⇒ failed (`Expected: 3, Received: 2`)
  - behavioral: `PATCH /api/v1/flows/{id}` forced to 500 ⇒ failed at `expectLeftEditor` on the second exit, not 45 s later on a card click
  - mutations reverted (`grep FFMUT` → 0 hits) + final green run ✅

Follow-up filed for the same `hasText: "New Flow"` hazard still present in `mcp/server/mcp-server.spec.ts` (lines 963, 1083).
