### PR TITLE
fix(mcp): re-open the flow under test by id in mcp-server (#1340)

### DIFF
--- a/docs/mcp/server/mcp-server.md
+++ b/docs/mcp/server/mcp-server.md
@@ -121,10 +121,15 @@ round-tripped; then deletes it.
 4. Settings → MCP Servers → Edit: assert `command` is `npx` and `args[0]` is the
    sequential-thinking package, then **edit `args[0]`** to
    `@modelcontextprotocol/server-everything` (server **B**) and save.
-5. Return to the flow, re-select the server on the node, and assert the tool
-   list now exposes `echo-0-option` — the refresh, not the cached A list.
-6. Delete the server; assert it is gone; re-register it as **A** again and assert
-   the node's tool list is back to `sequentialthinking-0-option`.
+5. Return to the flow **by id** (`openFlowById`), re-select the server on the
+   node, and assert the tool list now exposes `echo-0-option` — the refresh, not
+   the cached A list.
+6. Delete the server; assert it is gone; re-register it as **A** again, return to
+   the flow by id, and assert the node's tool list is back to
+   `sequentialthinking-0-option`.
+
+Both re-opens address the flow by **id**, never by the card whose name contains
+"New Flow" (#1340) — see the note below.
 
 ### 6 — `Streamable HTTP MCP server with server-everything should load tools correctly`
 
@@ -247,6 +252,35 @@ Unchanged by #1091 (no stdio surface). Derives the project's own
 ---
 
 ## Notes *(optional)*
+
+- **#1340 — test 5 re-opened a flow by NAME, and it opened the wrong one.** Both
+  re-opens clicked the first `list-card` whose name contained "New Flow".
+  Langflow names every blank flow "New Flow"/"New Flow (N)", so under
+  `fullyParallel` the shared project holds one per worker and `.first()` resolves
+  whichever the list puts first. Measured on nightly `1.12.0.dev18`: in isolation
+  the test's own flow ranks first and the click is correct (which is why this
+  never appeared in the daily history — no recorded failure on this test), but
+  seeding **one** competing `New Flow …` in the same project before the list
+  fetch is enough to flip it — the rendered order became
+  `["New Flow probeB-…", "New Flow (1)", "Basic Prompting"]`, the click opened
+  the competitor, and the test then died on the `text="MCP Tools"` wait at 30 s,
+  blaming the node for a flow it was never in. The same locator, in
+  `auto-save-off.spec.ts`, cost two dailies before it was diagnosed (#1336). Both
+  re-opens now use `openFlowById` (#1214), the repo's by-id entry, which also
+  seeds the assistant-onboarding flag and gates on the flow being writable —
+  neither of which the card click did (#1005). The flow id is read AFTER the
+  blank-flow navigation, never before it: the bootstrap parks the page on a
+  placeholder flow Langflow deletes as soon as the modal navigates elsewhere
+  (#490/#681).
+- **Pre-existing flake, NOT introduced by #1340: `openAddMcpServerModal`.** This
+  test fails roughly 1 run in 3 locally at
+  `helpers/mcp/open-add-mcp-server-modal.ts:10` (`mcp-server-dropdown`,
+  `locator.click: Timeout 3000ms exceeded`) — the #1335 signature, in a second
+  file. Confirmed by a control run of the unmodified spec: same 2/3, same step.
+  Raising that budget to 30 s locally did not help under `--workers=2+`, where
+  the dropdown simply never becomes clickable; a 4-worker burst of this spec
+  fails 3/4 there, always before the re-open. That budget belongs to #1335 and is
+  deliberately untouched here — it is a shared MCP helper with other callers.
 
 - **Why `npx` and not `uvx` for the servers that must really start.** Before
   #1091 tests 1/2/5 registered `uvx mcp-server-fetch` / `mcp-server-time`.

--- a/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
@@ -6,6 +6,7 @@ import { openAddMcpServerModal } from "../../../../helpers/mcp/open-add-mcp-serv
 import { zoomOut } from "../../../../helpers/ui/zoom-out";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { openFlowById } from "../../../../helpers/flows/open-flow-by-id";
 
 /**
  * Add-MCP-Server modal: stdio / HTTP registration, field persistence and tool
@@ -790,7 +791,22 @@ test(
     await page.waitForSelector('[data-testid="blank-flow"]', {
       timeout: 30000,
     });
+    // The flow under test has to be addressed by id from here on (#1340). The
+    // id is read AFTER this navigation, never before it: `awaitBootstrapTest`
+    // reaches the templates modal through "New Flow", which parks the page on a
+    // placeholder flow Langflow deletes as soon as the modal navigates
+    // elsewhere (#490/#681).
+    const placeholderUrl = page.url();
     await page.getByTestId("blank-flow").click();
+    await page.waitForURL(
+      (url) =>
+        /\/flow\/[0-9a-f-]{36}/.test(url.pathname) &&
+        url.toString() !== placeholderUrl,
+      { timeout: 30000 },
+    );
+    const flowUnderTest = new URL(page.url()).pathname.match(
+      /\/flow\/([0-9a-f-]{36})/,
+    )![1];
     await page.getByTestId("sidebar-nav-mcp").click();
     await page.waitForSelector(
       '[data-testid="add-component-button-lf-starter_project"]',
@@ -955,17 +971,16 @@ test(
 
     await awaitBootstrapTest(page, { skipModal: true });
 
-    // The /flows a11y refactor (Langflow #13891) makes `flow-name-div`
-    // `pointer-events-none`; open the flow via the card's overlay button.
-    const flowOpenButton = page
-      .getByTestId("list-card")
-      .filter({
-        has: page.getByTestId("flow-name-div").filter({ hasText: "New Flow" }),
-      })
-      .getByTestId("list-card-open-button")
-      .first();
-    await flowOpenButton.waitFor({ state: "visible", timeout: 10000 });
-    await flowOpenButton.click();
+    // By id, never a name-filtered `list-card` + `.first()` (#1340). Langflow
+    // names every blank flow "New Flow"/"New Flow (N)", so under `fullyParallel`
+    // that filter resolves whichever card the shared project's list puts first.
+    // Measured on nightly 1.12.0.dev18: seeding ONE competing "New Flow …" in
+    // this project before the list fetch is enough — the click opened the
+    // competitor, and the test then died on the `text="MCP Tools"` wait below,
+    // blaming the node for a flow it was never in. `openFlowById` also seeds the
+    // assistant-onboarding flag and gates on the flow being writable, which the
+    // card click never did (#1214/#1005).
+    await openFlowById(page, flowUnderTest);
 
     // Wait for the MCP Tools component to be visible on canvas
     await page.waitForSelector('text="MCP Tools"', {
@@ -1076,16 +1091,8 @@ test(
 
     await awaitBootstrapTest(page, { skipModal: true });
 
-    // See note above: open the flow via the card's overlay button.
-    const flowOpenButton2 = page
-      .getByTestId("list-card")
-      .filter({
-        has: page.getByTestId("flow-name-div").filter({ hasText: "New Flow" }),
-      })
-      .getByTestId("list-card-open-button")
-      .first();
-    await flowOpenButton2.waitFor({ state: "visible", timeout: 10000 });
-    await flowOpenButton2.click();
+    // See note above: by id, not by name.
+    await openFlowById(page, flowUnderTest);
 
     // Wait for the MCP Tools component to be visible on canvas
     await page.waitForSelector('text="MCP Tools"', {

--- a/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
@@ -791,22 +791,48 @@ test(
     await page.waitForSelector('[data-testid="blank-flow"]', {
       timeout: 30000,
     });
-    // The flow under test has to be addressed by id from here on (#1340). The
-    // id is read AFTER this navigation, never before it: `awaitBootstrapTest`
-    // reaches the templates modal through "New Flow", which parks the page on a
-    // placeholder flow Langflow deletes as soon as the modal navigates
-    // elsewhere (#490/#681).
-    const placeholderUrl = page.url();
-    await page.getByTestId("blank-flow").click();
-    await page.waitForURL(
-      (url) =>
-        /\/flow\/[0-9a-f-]{36}/.test(url.pathname) &&
-        url.toString() !== placeholderUrl,
-      { timeout: 30000 },
-    );
-    const flowUnderTest = new URL(page.url()).pathname.match(
+    // The flow under test has to be addressed by id from here on (#1340), and
+    // the id has to satisfy BOTH sources — neither alone is enough here:
+    //
+    //  - `page.url()` alone is the documented trap. `awaitBootstrapTest` reaches
+    //    the templates modal through "New Flow", so before the blank-flow
+    //    navigation the URL still carries the bootstrap PLACEHOLDER — the flow
+    //    Langflow deletes the moment the modal navigates elsewhere, and the one
+    //    authoring-conventions Pattern A warns about (#681/#505).
+    //  - the tracked `POST /flows` 201 ids alone do not say which flow the editor
+    //    ended up on: this page creates the placeholder AND the blank flow, so
+    //    picking one means trusting arrival order of two async body reads, and
+    //    the wrong pick is precisely the id that gets deleted.
+    //
+    // So: poll until the editor's URL carries an id this page is known to have
+    // created and that is not the placeholder. A transient or client-only id
+    // cannot satisfy the membership test, and a blank-flow click that never
+    // navigates fails HERE, naming the cause, instead of surfacing later as an
+    // unattributed timeout. Measured on nightly 1.12.0.dev18: the click issues
+    // its own `POST /flows` 201 and the URL changes every time (5/5) — the
+    // placeholder is never reused — so this is about attribution, not a defect.
+    const placeholderId = new URL(page.url()).pathname.match(
       /\/flow\/([0-9a-f-]{36})/,
-    )![1];
+    )?.[1];
+    await page.getByTestId("blank-flow").click();
+    const editorFlowId = () =>
+      new URL(page.url()).pathname.match(/\/flow\/([0-9a-f-]{36})/)?.[1];
+    await expect
+      .poll(
+        () => {
+          const id = editorFlowId();
+          return !!id && id !== placeholderId && createdFlowIds.includes(id);
+        },
+        {
+          timeout: 30000,
+          message:
+            "the blank-flow click never landed the editor on a newly created " +
+            "flow: the URL still holds the bootstrap placeholder, or its id is " +
+            "not among this page's POST /api/v1/flows 201 responses",
+        },
+      )
+      .toBe(true);
+    const flowUnderTest = editorFlowId()!;
     await page.getByTestId("sidebar-nav-mcp").click();
     await page.waitForSelector(
       '[data-testid="add-component-button-lf-starter_project"]',


### PR DESCRIPTION
**Fixes #1340.** Closes #1340.

## Problem

Both re-opens in test 5 (`mcp server tools should be refreshed when editing a server`, `@stable`) clicked the first `list-card` whose name contained `"New Flow"`. Langflow names every blank flow `New Flow`/`New Flow (N)`, so under `fullyParallel` the shared project holds one per worker and `.first()` resolves whichever card the list puts first.

The issue asked to **measure before assuming**, and the measurement is the interesting part:

- **In isolation the test is correct.** On a quiet instance its own flow ranks first (autosave keeps bumping `updated_at`), both re-opens land on the right id, and the daily history holds **no recorded failure** for this test. Latent, exactly as filed.
- **One competitor is enough.** Seeding a single `New Flow …` in the same project *before the list fetch* flips it. Rendered order became `["New Flow probeB-p0d7n", "New Flow (1)", "Basic Prompting"]`; the click opened the competitor (`match=false`), and the test then died on `page.waitForSelector('text="MCP Tools"')` at 30 s — an error blaming the MCP Tools node for a flow the test was never in. That is the same locator, and the same misdirected symptom, that cost `auto-save-off.spec.ts` two dailies before it was diagnosed (#1336).

Two dead ends worth recording, because both produced a *false negative* on the first try: a competitor created without `folder_id` lands in another project and never reaches this list, and a competitor created *after* the page's list fetch never triggers a refetch. Neither is a property of the spec — they were bugs in the probe.

## Fix

Use **`openFlowById`** (#1214) for both re-opens. It is the repo's canonical by-id entry, and its own header already states the rule this spec was breaking: *"Addressing the flow by id — never `list-card.first()` or a name-filtered `list-card-open-button` click — is what makes the entry parallel-safe."* It also brings two guarantees the card click never had:

- it seeds the assistant-onboarding flag before the document load;
- it gates on the flow being **writable**, i.e. the #1005 window where a mutation issued while `POST /api/v1/authz/me/permissions` is in flight is silently swallowed. This test mutates the flow it re-opens, so the gate is wanted.

The flow id is read **after** the blank-flow navigation, never before it: the bootstrap reaches the templates modal through "New Flow", which parks the page on a placeholder flow Langflow deletes as soon as the modal navigates elsewhere (#490/#681).

The two `awaitBootstrapTest(page, { skipModal: true })` hops are kept as-is. They are now redundant with `openFlowById`'s own document load, but removing them would change how the test leaves the canvas — out of scope for a locator fix.

## Scope note

No assertion changed. What the test proves is identical; it now proves it about the flow it actually created. `helpers/mcp/open-add-mcp-server-modal.ts` is deliberately **not** touched — see below.

## Validation (nightly `1.12.0.dev18`, `--retries=0`)

- `npm run typecheck` ✅ · `npx eslint <spec>` ✅ (0 errors; 103 pre-existing style warnings)
- Behavioral force-fail, the pair that matters:
  - **pre-fix + one seeded competitor ⇒ FAILED 1/1** — opened the competitor, died at `text="MCP Tools"` (30 s)
  - **post-fix + the same seeding ⇒ PASSED 3/3**
- Serial runs that reach the re-open: **all passed**; both re-opens verified landing on the created id (`match=true`) by instrumentation
- No leak: 0 `New Flow` orphans and no `test_server_*` left on the instance after the runs (`GET /api/v1/flows/`, `GET /api/v2/mcp/servers`)

**Honest caveat on the burst the issue asked for.** A `--workers=4` burst of this spec cannot validate the re-open, and did not: 3 of 4 runs failed at `helpers/mcp/open-add-mcp-server-modal.ts:10` (`mcp-server-dropdown`, `locator.click` timeout) — **always before** the changed code. This is pre-existing and separately filed as #1335. Confirmed by a control run of the **unmodified** spec on `main`: same 2/3 pass rate, same step. Raising that budget from 3 s to 30 s locally did not help under `--workers=2+` — the dropdown simply never becomes clickable when copies of this MCP spec run concurrently, which is a self-inflicted condition (the daily runs it once). That budget belongs to #1335 and to a shared helper with other callers, so it stays untouched here; the measurement is posted on #1335.
