### PR TITLE
fix(mcp): repair the swallowed sidebar add behind the MCP-server flake (#1335)

### DIFF
--- a/docs/mcp/server/mcp-server-tab.md
+++ b/docs/mcp/server/mcp-server-tab.md
@@ -68,9 +68,10 @@ longer be added and have its tools discovered — a core MCP-server UI regressio
    assert its `args` SSE URL matches.
 7. Assert the **setup guide** link points at the documented MCP-server anchor.
 8. Bootstrap again; add an **MCP-starter-project** component to a new flow
-   (`add-component-button-lf-starter_project`); open the **Add MCP Server** modal
-   (`openAddMcpServerModal`); paste the Linux config with a unique server name
-   substituted; click `add-mcp-server-button`.
+   (`add-component-button-lf-starter_project`, via
+   `addComponentFromSidebarWithoutSearch` — the add is repaired, see Notes);
+   open the **Add MCP Server** modal (`openAddMcpServerModal`); paste the Linux
+   config with a unique server name substituted; click `add-mcp-server-button`.
 9. Assert the `dropdown_str_tool` selector becomes enabled and, when opened,
    exposes at least one tool option (`[data-testid*="-option"]`).
 
@@ -117,6 +118,8 @@ longer be added and have its tools discovered — a core MCP-server UI regressio
   (`icon-copy`, API-key generation).
 - Add-MCP-server modal (`add-mcp-server-simple-button` / `mcp-server-dropdown` →
   `add-mcp-server-button`, `json-input`) via `helpers/mcp/open-add-mcp-server-modal.ts`.
+- `helpers/flows/add-component-from-sidebar.ts`
+  (`addComponentFromSidebarWithoutSearch`) — the repairing sidebar add.
 - The `lf-starter_project` MCP starter (`add-component-button-lf-starter_project`).
 - API Request component (`data_sourceAPI Request`) — the tool exposed on the flow.
 - `helpers/other/await-bootstrap-test.ts`, `helpers/ui/adjust-screen-view.ts`.
@@ -139,6 +142,34 @@ longer be added and have its tools discovered — a core MCP-server UI regressio
   limitation); step verification relies on `--retries=0` bursts + force-fail.
 - The API-key generation is branch-guarded because the button only appears when
   no key exists yet; both branches assert a valid end state.
-- No flows are left behind by design — the flows created live in the default
-  project and the test does not persist named artifacts requiring id-scoped
-  cleanup; folder CRUD is exercised by the sibling starter-projects spec.
+- **Cleanup is id-scoped, never a wipe** (#553), and it was added in #1335 —
+  the claim it replaces ("no flows are left behind by design") was false. The
+  test creates TWO flows per run and registered a fresh `test_server_<random>`
+  every time, deleting neither: measured on the local nightly while working
+  #1335, 14 orphan `test_server_*` registrations had accumulated (alongside 58
+  orphan "New Flow" flows, which this spec shares with every other blank-flow
+  spec). The servers are not merely litter — their count decides which branch
+  the widget under test renders (an empty list shows
+  `add-mcp-server-simple-button`, a populated one `mcp-server-dropdown`), so
+  leaving them behind quietly stopped the spec from ever taking the empty-list
+  path again. Flow ids come from `POST /api/v1/flows` 201 bodies, not from the
+  canvas URL, which still holds the stale bootstrap id (#681). Folder CRUD is
+  exercised by the sibling starter-projects spec.
+- **The step-8 add is repaired, and that is what #1335 was** (recurrent flake on
+  the 2026-08-05 and 2026-08-06 dailies). The failure named
+  `mcp-server-dropdown` — `locator.click: Timeout 3000ms exceeded` — and the
+  issue read it as a widget too slow for a 3 s budget. It was not: the failing
+  attempt's `error-context.md` shows an empty `application "Flow canvas"` with
+  "Minimize all" disabled, i.e. Langflow had swallowed the sidebar click and
+  there was no MCP component at all. Both of the modal's entry points hang off
+  that node, so **no wait budget could have fixed it** — measured on nightly
+  1.12.0.dev17: **4 of 8** first clicks on the MCP tab produced no node within
+  12 s, all 4 repaired by an identical second click (the #1304 class, whose
+  Components-tab rate was 4/20), while a landed add rendered in 91–108 ms and
+  its entry point became visible 6–15 ms later, enabled, in 8 of 8.
+- Consequently `openAddMcpServerModal` no longer decides its branch from a snap
+  read: `isVisible({ timeout: 1000 })` looks like a wait but Playwright ignores
+  that option, so the helper committed to the dropdown branch before the widget
+  had painted — and in the no-servers case that locator never appears at all. It
+  now waits for **either** entry point and, when neither arrives, fails naming
+  the canvas node count so an empty canvas is never reported as a slow dropdown.

--- a/docs/mcp/server/mcp-server-tab.md
+++ b/docs/mcp/server/mcp-server-tab.md
@@ -50,7 +50,8 @@ longer be added and have its tools discovered — a core MCP-server UI regressio
 ## Step by step *(required)*
 
 1. Bootstrap; create a blank flow and drag an **API Request** component onto the
-   canvas (gives the flow a tool to expose), then exit the flow.
+   canvas (`data_sourceAPI Request`, via `dragComponentFromSidebar` — the drag is
+   repaired, see Notes), giving the flow a tool to expose; then exit the flow.
 2. Open the **MCP Server tab** (`mcp-btn`); assert `mcp-server-title` and the
    "Flows/Tools" header are visible.
 3. Open **Edit Tools** (`button_open_actions`) → the "MCP Server Tools" modal.
@@ -118,8 +119,9 @@ longer be added and have its tools discovered — a core MCP-server UI regressio
   (`icon-copy`, API-key generation).
 - Add-MCP-server modal (`add-mcp-server-simple-button` / `mcp-server-dropdown` →
   `add-mcp-server-button`, `json-input`) via `helpers/mcp/open-add-mcp-server-modal.ts`.
-- `helpers/flows/add-component-from-sidebar.ts`
-  (`addComponentFromSidebarWithoutSearch`) — the repairing sidebar add.
+- `helpers/flows/add-component-from-sidebar.ts` — both repairing adds this spec
+  needs: `dragComponentFromSidebar` (step 1, drag) and
+  `addComponentFromSidebarWithoutSearch` (step 8, click on a tab with no search).
 - The `lf-starter_project` MCP starter (`add-component-button-lf-starter_project`).
 - API Request component (`data_sourceAPI Request`) — the tool exposed on the flow.
 - `helpers/other/await-bootstrap-test.ts`, `helpers/ui/adjust-screen-view.ts`.
@@ -173,3 +175,17 @@ longer be added and have its tools discovered — a core MCP-server UI regressio
   had painted — and in the no-servers case that locator never appears at all. It
   now waits for **either** entry point and, when neither arrives, fails naming
   the canvas node count so an empty canvas is never reported as a slow dropdown.
+- **The step-1 API Request add is repaired too, and it is a SECOND surface.**
+  Fixing the MCP-tab click left the spec at 4 of 5, and the one failure was not
+  the #1335 signature at all: the *drag* at the top of the test was swallowed,
+  and surfaced 30 s later as `waitForSelector: generic-node-title-arrangement`
+  timing out — naming the node that was never created rather than the gesture
+  that failed to create it, which is the same mis-attribution #1335 was filed
+  under, one surface over. Measured on nightly 1.12.0.dev18: **1 of 5** drags
+  swallowed while the repaired MCP-tab click was 5 of 5 clean. It now goes
+  through `dragComponentFromSidebar`, which re-issues the drag once. The gesture
+  is re-issued rather than swapped for a click: dragging out of the sidebar is an
+  interaction Langflow ships, and a spec that quietly stops exercising it stops
+  covering it. The comment this replaced ("use dragTo which is more reliable than
+  click on add-component-button") predates the #1304 repair — neither gesture is
+  reliable bare, and both are reliable repaired.

--- a/docs/mcp/server/mcp-server.md
+++ b/docs/mcp/server/mcp-server.md
@@ -234,7 +234,9 @@ Unchanged by #1091 (no stdio surface). Derives the project's own
 - MCPTools node (`dropdown_str_tool`, `mcp-server-dropdown`, `list_item_<name>`).
 - `GET`/`DELETE /api/v2/mcp/servers[/{name}]`, `helpers/auth/get-auth-token.ts`,
   `helpers/other/await-bootstrap-test.ts`, `helpers/ui/adjust-screen-view.ts`,
-  `helpers/ui/zoom-out.ts`, `helpers/flows/delete-flow.ts`.
+  `helpers/ui/zoom-out.ts`, `helpers/flows/delete-flow.ts`,
+  `helpers/flows/add-component-from-sidebar.ts`
+  (`addComponentFromSidebarWithoutSearch`).
 
 ---
 
@@ -323,3 +325,14 @@ Unchanged by #1091 (no stdio surface). Derives the project's own
   force-fail.
 - A commented-out seventh block (SSE against a public Cloudflare MCP endpoint)
   remains at the bottom of the file, untouched by #1091.
+- **The three MCP-starter adds are repaired, not bare clicks** (#1335). Langflow
+  swallows that sidebar click on the MCP tab roughly half the time on nightly
+  1.12.0.dev17 (measured 4/8, all 4 repaired by an identical second click), and
+  every entry point of the add-server modal hangs off the node it should have
+  created. Measured locally on dev17 before and after: this file failed 3 of its
+  6 runnable tests with the bare clicks — including the `@stable` tests 3
+  ("STDIO … fields should persist") and 5 ("tools should be refreshed …") — and 1
+  of 6 with `addComponentFromSidebarWithoutSearch`. The remaining failure is test
+  6 ("Streamable HTTP … server-everything"), which registers through the sidebar
+  page rather than the modal, fails identically with and without this change, and
+  is not `@stable`.

--- a/tests/helpers/flows/add-component-from-sidebar.test.ts
+++ b/tests/helpers/flows/add-component-from-sidebar.test.ts
@@ -116,6 +116,39 @@ test("the swallowed-click message reports the observed sidebar state", () => {
   assert.match(msg, /node count: 0 before, 0 after/);
 });
 
+test("a tab with no search box reports no term and no input, not an empty one", () => {
+  // #1335: the MCP tab (`sidebar-nav-mcp`) adds entries straight from its list,
+  // so there is no term to name and no input to read back. `search input: ""` is
+  // a real observation on the Components tab (the input was reset) and must not
+  // read the same as "this tab has no input" — otherwise the reader is told the
+  // search was cleared by a surface that never had one.
+  const msg = swallowedAddMessage({
+    ...DETAIL,
+    searchTerm: null,
+    searchValue: null,
+    addButtonTestId: "add-component-button-lf-starter_project",
+  });
+
+  assert.match(msg, /no search box/i);
+  assert.match(msg, /search input: <none on this tab>/);
+  assert.doesNotMatch(msg, /after filling the sidebar search/);
+  assert.doesNotMatch(msg, /search input: ""/);
+  // Still names the click and the budget — the two facts the message exists for.
+  assert.match(msg, /add-component-button-lf-starter_project/);
+  assert.match(msg, /2 attempt/);
+});
+
+test("the no-search message stays unclassifiable as infra, like the search one", () => {
+  // Same rule as below: a swallowed add on the MCP tab is a real add regression
+  // and must stay eligible for @stable auto-removal (#1262).
+  assert.equal(
+    classifyInfraError(
+      swallowedAddMessage({ ...DETAIL, searchTerm: null, searchValue: null }),
+    ),
+    null,
+  );
+});
+
 test("the swallowed-click message is NOT classifiable as an infra failure", () => {
   // Same rule as the page-entry barrier (#1262): claiming infra here would exempt
   // the failure from @stable auto-removal and hide a genuine add regression.

--- a/tests/helpers/flows/add-component-from-sidebar.test.ts
+++ b/tests/helpers/flows/add-component-from-sidebar.test.ts
@@ -116,6 +116,50 @@ test("the swallowed-click message reports the observed sidebar state", () => {
   assert.match(msg, /node count: 0 before, 0 after/);
 });
 
+test("a swallowed DRAG is reported as a drag, on its own measured evidence", () => {
+  // #1335, second half. Same product defect, different gesture — and the reader
+  // has to be sent to the right line. Naming the click would point at a "+"
+  // button the spec never touches.
+  const msg = swallowedAddMessage({
+    ...DETAIL,
+    gesture: "drag",
+    addButtonTestId: "data_sourceAPI Request",
+    searchTerm: "api request",
+  });
+
+  assert.match(msg, /drag add was swallowed/);
+  assert.match(msg, /dragTo\(\) from getByTestId\("data_sourceAPI Request"\)/);
+  assert.match(msg, /onto the canvas/);
+  // The click path's 4/20 was measured on the click surface; quoting it for a
+  // drag would attribute a number to a surface it was never taken on.
+  assert.match(msg, /1\/5 on nightly 1\.12\.0\.dev18/);
+  assert.doesNotMatch(msg, /4\/20/);
+  assert.doesNotMatch(msg, /The click\(s\) were accepted/);
+  // A drag has no "+" button to report on.
+  assert.doesNotMatch(msg, /"\+" button still visible/);
+  assert.match(msg, /sidebar entry still visible/);
+});
+
+test("the gesture defaults to click, so the pre-#1335 message is unchanged", () => {
+  // The 34 existing call sites never pass a gesture. If the default drifted, all
+  // of them would start reporting a drag they never performed.
+  const withoutGesture = swallowedAddMessage(DETAIL);
+  const explicitClick = swallowedAddMessage({ ...DETAIL, gesture: "click" });
+
+  assert.equal(withoutGesture, explicitClick);
+  assert.match(withoutGesture, /click add was swallowed/);
+  assert.match(withoutGesture, /4\/20/);
+});
+
+test("a swallowed drag stays unclassifiable as infra, like the click one", () => {
+  // #1262's rule reaches the new gesture too: a real add regression must stay
+  // eligible for @stable auto-removal.
+  assert.equal(
+    classifyInfraError(swallowedAddMessage({ ...DETAIL, gesture: "drag" })),
+    null,
+  );
+});
+
 test("a tab with no search box reports no term and no input, not an empty one", () => {
   // #1335: the MCP tab (`sidebar-nav-mcp`) adds entries straight from its list,
   // so there is no term to name and no input to read back. `search input: ""` is

--- a/tests/helpers/flows/add-component-from-sidebar.ts
+++ b/tests/helpers/flows/add-component-from-sidebar.ts
@@ -6,8 +6,9 @@ import { type Page } from "@playwright/test";
  * not return until a node actually landed.
  *
  * It used to be a deliberately "dumb" primitive that performed the mechanism and
- * asserted nothing, leaving the post-condition to each caller. Twenty-three spec
- * files call it, and Langflow drops that click outright a measurable fraction of
+ * asserted nothing, leaving the post-condition to each caller. 34 call sites
+ * across 27 spec files reach it, and Langflow drops that click outright a
+ * measurable fraction of
  * the time: the DOM click is accepted, no node is created, and no flow write
  * follows. Measured on nightly 1.12.0.dev17 with an instrumented scout — 4 of 20
  * adds of the Language Model component produced no node within 4 s, and in ALL 4
@@ -86,6 +87,13 @@ export function classifyAddOutcome(
   return newNodeIds(before, after).length > 0 ? "landed" : "swallowed";
 }
 
+/**
+ * Which gesture issued the add. Both are swallowed by the same product defect,
+ * but they are reported apart because they are repaired apart and a reader who
+ * is told "click" while the spec drags will look at the wrong line.
+ */
+export type AddGesture = "click" | "drag";
+
 type AddFailureDetail = {
   /** `null` when the sidebar tab has no search box — see #1335. */
   searchTerm: string | null;
@@ -97,31 +105,48 @@ type AddFailureDetail = {
   buttonStillVisible: boolean;
   /** `null` when there was no search box to read. */
   searchValue: string | null;
+  /** Defaults to `"click"` — the only gesture before #1335's second half. */
+  gesture?: AddGesture;
 };
 
 export function swallowedAddMessage(d: AddFailureDetail): string {
+  const gesture = d.gesture ?? "click";
+  const isDrag = gesture === "drag";
+
   // The MCP tab (#1335) lists its entries without a search box, so there is no
   // term to name and no input to report. Kept as two explicit clauses rather
   // than an empty string: `sidebar search input: ""` is a real observation (the
   // input was reset) and must not read the same as "there is no input".
+  const target = isDrag
+    ? `dragTo() from getByTestId("${d.addButtonTestId}") onto the canvas`
+    : `getByTestId("${d.addButtonTestId}")`;
   const trigger =
     d.searchTerm === null
-      ? `getByTestId("${d.addButtonTestId}") on a sidebar tab with no search box`
-      : `getByTestId("${d.addButtonTestId}") after filling the sidebar search ` +
-        `with "${d.searchTerm}"`;
+      ? `${target} on a sidebar tab with no search box`
+      : `${target} after filling the sidebar search with "${d.searchTerm}"`;
   const searchState =
     d.searchValue === null
       ? `sidebar search input: <none on this tab>`
       : `sidebar search input: "${d.searchValue}"`;
+  // The click rate is #1304's own 4/20 measurement; quoting it for a drag would
+  // attribute a number to a surface it was never taken on.
+  const evidence = isDrag
+    ? `The drag(s) completed and the app never registered the add (issue #1304's ` +
+      `class on the drag surface — measured 1/5 on nightly 1.12.0.dev18 in ` +
+      `mcp-server-tab.spec.ts, #1335)`
+    : `The click(s) were accepted by the DOM and the app never registered the ` +
+      `add (issue #1304 — measured 4/20 on nightly 1.12.0.dev17, the ` +
+      `swallowed-click class of #420/#966 on the sidebar surface of #537)`;
+  const visibility = isDrag
+    ? `sidebar entry still visible: ${d.buttonStillVisible ? "yes" : "no"}`
+    : `"+" button still visible: ${d.buttonStillVisible ? "yes" : "no"}`;
 
   return (
-    `the sidebar add was swallowed: no new node reached the canvas after ` +
-    `${d.attempts} attempt(s) of ${d.perAttemptMs}ms each on ` +
-    `${trigger}. The click(s) were accepted by the DOM and the app never ` +
-    `registered the add (issue #1304 — measured 4/20 on nightly 1.12.0.dev17, ` +
-    `the swallowed-click class of #420/#966 on the sidebar surface of #537). ` +
+    `the sidebar ${gesture} add was swallowed: no new node reached the canvas ` +
+    `after ${d.attempts} attempt(s) of ${d.perAttemptMs}ms each on ` +
+    `${trigger}. ${evidence}. ` +
     `Observed: node count: ${d.beforeCount} before, ${d.afterCount} after; ` +
-    `"+" button still visible: ${d.buttonStillVisible ? "yes" : "no"}; ` +
+    `${visibility}; ` +
     `${searchState}. This is NOT a slow surface — a ` +
     `longer wait cannot fix it — so treat a reproducible failure here as a real ` +
     `defect in adding components, not as a flake to re-run.`
@@ -138,13 +163,24 @@ const nodeIds = async (page: Page): Promise<string[]> =>
       ),
     );
 
+/** Default drop target — the ReactFlow pane, addressed the way the specs do. */
+const CANVAS_SELECTOR = '//*[@id="react-flow-id"]';
+
 const issueAdd = async (
   page: Page,
   searchTerm: string | null,
   addButtonTestId: string,
+  gesture: AddGesture,
+  canvasSelector: string,
 ) => {
   if (searchTerm !== null) {
     await page.getByTestId("sidebar-search-input").fill(searchTerm);
+  }
+  if (gesture === "drag") {
+    await page
+      .getByTestId(addButtonTestId)
+      .dragTo(page.locator(canvasSelector));
+    return;
   }
   await page.getByTestId(addButtonTestId).click();
 };
@@ -169,7 +205,7 @@ export const addComponentFromSidebar = async (
   page: Page,
   searchTerm: string,
   addButtonTestId: string,
-) => addWithRepair(page, searchTerm, addButtonTestId);
+) => addWithRepair(page, searchTerm, addButtonTestId, "click");
 
 /**
  * Same swallowed-click repair, for a sidebar tab that has no search box — today
@@ -186,28 +222,57 @@ export const addComponentFromSidebar = async (
  * 91–108 ms, so the 12 s budget is only ever paid by a genuine drop.
  *
  * Split from `addComponentFromSidebar` rather than made an optional third
- * argument: 23 call sites pass the search term positionally, and the two tabs
- * differ in the post-failure evidence there is to report (there is no input to
- * read back here), not merely in whether one line runs.
+ * argument: 34 call sites across 27 files pass the search term positionally, and
+ * the two tabs differ in the post-failure evidence there is to report (there is
+ * no input to read back here), not merely in whether one line runs.
  */
 export const addComponentFromSidebarWithoutSearch = async (
   page: Page,
   addButtonTestId: string,
-) => addWithRepair(page, null, addButtonTestId);
+) => addWithRepair(page, null, addButtonTestId, "click");
+
+/**
+ * Same swallowed-add repair, for a component put on the canvas by **dragging**
+ * it out of the sidebar rather than clicking its "+".
+ *
+ * The drag surface needed its own repair because it is dropped too, and the
+ * click repair does not reach it. Measured on nightly 1.12.0.dev18: the first
+ * add in `mcp-server-tab.spec.ts` — an API Request component dragged onto the
+ * pane — was swallowed **1 time in 5** while the MCP-tab click add (repaired in
+ * the same PR) was 5 of 5 clean. The failure surfaced 30 s later as
+ * `waitForSelector: generic-node-title-arrangement` timing out, naming the node
+ * that was never created rather than the gesture that failed to create it —
+ * the exact mis-attribution #1335 was filed under, one surface over.
+ *
+ * The gesture is re-issued rather than swapped for a click: dragging a component
+ * out of the sidebar is an interaction Langflow ships, and a spec that quietly
+ * stops exercising it stops covering it. The comment this replaced in
+ * `mcp-server-tab.spec.ts` ("use dragTo which is more reliable than click on
+ * add-component-button") predates the #1304 repair and its premise no longer
+ * holds — neither gesture is reliable bare, and both are reliable repaired.
+ */
+export const dragComponentFromSidebar = async (
+  page: Page,
+  searchTerm: string,
+  componentTestId: string,
+  canvasSelector: string = CANVAS_SELECTOR,
+) => addWithRepair(page, searchTerm, componentTestId, "drag", canvasSelector);
 
 const addWithRepair = async (
   page: Page,
   searchTerm: string | null,
   addButtonTestId: string,
+  gesture: AddGesture,
+  canvasSelector: string = CANVAS_SELECTOR,
 ) => {
   const before = await nodeIds(page);
 
-  await issueAdd(page, searchTerm, addButtonTestId);
+  await issueAdd(page, searchTerm, addButtonTestId, gesture, canvasSelector);
   let after = await waitForNewNode(page, before, ADD_LANDED_TIMEOUT_MS);
   let attempts = 1;
 
   if (classifyAddOutcome(before, after) === "swallowed") {
-    await issueAdd(page, searchTerm, addButtonTestId);
+    await issueAdd(page, searchTerm, addButtonTestId, gesture, canvasSelector);
     after = await waitForNewNode(page, before, ADD_LANDED_TIMEOUT_MS);
     attempts = 2;
   }
@@ -224,6 +289,7 @@ const addWithRepair = async (
       beforeCount: before.length,
       afterCount: after.length,
       attempts,
+      gesture,
       perAttemptMs: ADD_LANDED_TIMEOUT_MS,
       buttonStillVisible: await page
         .getByTestId(addButtonTestId)

--- a/tests/helpers/flows/add-component-from-sidebar.ts
+++ b/tests/helpers/flows/add-component-from-sidebar.ts
@@ -87,27 +87,42 @@ export function classifyAddOutcome(
 }
 
 type AddFailureDetail = {
-  searchTerm: string;
+  /** `null` when the sidebar tab has no search box — see #1335. */
+  searchTerm: string | null;
   addButtonTestId: string;
   beforeCount: number;
   afterCount: number;
   attempts: number;
   perAttemptMs: number;
   buttonStillVisible: boolean;
-  searchValue: string;
+  /** `null` when there was no search box to read. */
+  searchValue: string | null;
 };
 
 export function swallowedAddMessage(d: AddFailureDetail): string {
+  // The MCP tab (#1335) lists its entries without a search box, so there is no
+  // term to name and no input to report. Kept as two explicit clauses rather
+  // than an empty string: `sidebar search input: ""` is a real observation (the
+  // input was reset) and must not read the same as "there is no input".
+  const trigger =
+    d.searchTerm === null
+      ? `getByTestId("${d.addButtonTestId}") on a sidebar tab with no search box`
+      : `getByTestId("${d.addButtonTestId}") after filling the sidebar search ` +
+        `with "${d.searchTerm}"`;
+  const searchState =
+    d.searchValue === null
+      ? `sidebar search input: <none on this tab>`
+      : `sidebar search input: "${d.searchValue}"`;
+
   return (
     `the sidebar add was swallowed: no new node reached the canvas after ` +
     `${d.attempts} attempt(s) of ${d.perAttemptMs}ms each on ` +
-    `getByTestId("${d.addButtonTestId}") after filling the sidebar search with ` +
-    `"${d.searchTerm}". The click(s) were accepted by the DOM and the app never ` +
+    `${trigger}. The click(s) were accepted by the DOM and the app never ` +
     `registered the add (issue #1304 — measured 4/20 on nightly 1.12.0.dev17, ` +
     `the swallowed-click class of #420/#966 on the sidebar surface of #537). ` +
     `Observed: node count: ${d.beforeCount} before, ${d.afterCount} after; ` +
     `"+" button still visible: ${d.buttonStillVisible ? "yes" : "no"}; ` +
-    `sidebar search input: "${d.searchValue}". This is NOT a slow surface — a ` +
+    `${searchState}. This is NOT a slow surface — a ` +
     `longer wait cannot fix it — so treat a reproducible failure here as a real ` +
     `defect in adding components, not as a flake to re-run.`
   );
@@ -125,10 +140,12 @@ const nodeIds = async (page: Page): Promise<string[]> =>
 
 const issueAdd = async (
   page: Page,
-  searchTerm: string,
+  searchTerm: string | null,
   addButtonTestId: string,
 ) => {
-  await page.getByTestId("sidebar-search-input").fill(searchTerm);
+  if (searchTerm !== null) {
+    await page.getByTestId("sidebar-search-input").fill(searchTerm);
+  }
   await page.getByTestId(addButtonTestId).click();
 };
 
@@ -151,6 +168,36 @@ const waitForNewNode = async (
 export const addComponentFromSidebar = async (
   page: Page,
   searchTerm: string,
+  addButtonTestId: string,
+) => addWithRepair(page, searchTerm, addButtonTestId);
+
+/**
+ * Same swallowed-click repair, for a sidebar tab that has no search box — today
+ * the **MCP** tab (`sidebar-nav-mcp`), whose entries are added straight from the
+ * list by testid.
+ *
+ * Added for #1335, whose whole failure was this class on that tab: the
+ * `@stable` `mcp-server-tab` spec clicked `add-component-button-lf-starter_project`
+ * bare and then failed downstream on `mcp-server-dropdown`, a widget that hangs
+ * off the node the click never created. **Measured on nightly 1.12.0.dev17 with
+ * an instrumented probe: 4 of 8 first clicks produced no node within 12 s, and
+ * all 4 were repaired by an identical second click** — the same shape as #1304's
+ * 4/20 on the Components tab, and worse here. A landed add rendered its node in
+ * 91–108 ms, so the 12 s budget is only ever paid by a genuine drop.
+ *
+ * Split from `addComponentFromSidebar` rather than made an optional third
+ * argument: 23 call sites pass the search term positionally, and the two tabs
+ * differ in the post-failure evidence there is to report (there is no input to
+ * read back here), not merely in whether one line runs.
+ */
+export const addComponentFromSidebarWithoutSearch = async (
+  page: Page,
+  addButtonTestId: string,
+) => addWithRepair(page, null, addButtonTestId);
+
+const addWithRepair = async (
+  page: Page,
+  searchTerm: string | null,
   addButtonTestId: string,
 ) => {
   const before = await nodeIds(page);
@@ -182,10 +229,13 @@ export const addComponentFromSidebar = async (
         .getByTestId(addButtonTestId)
         .isVisible()
         .catch(() => false),
-      searchValue: await page
-        .getByTestId("sidebar-search-input")
-        .inputValue()
-        .catch(() => "<gone>"),
+      searchValue:
+        searchTerm === null
+          ? null
+          : await page
+              .getByTestId("sidebar-search-input")
+              .inputValue()
+              .catch(() => "<gone>"),
     }),
   );
 };

--- a/tests/helpers/mcp/open-add-mcp-server-modal.test.ts
+++ b/tests/helpers/mcp/open-add-mcp-server-modal.test.ts
@@ -1,0 +1,72 @@
+// Unit tests for the missing-entry-point attribution (issue #1335).
+// Run with: npm run test:units
+//
+// What rides on this function: whether the failure names the cause or repeats the
+// mis-attribution that cost two dailies. The 3 s `click()` it replaced produced a
+// call log of exactly one line — `waiting for getByTestId('mcp-server-dropdown')`
+// — which reads as "the dropdown is late" and led the issue to propose raising
+// the budget to 15–30 s. The failing attempt's own error-context snapshot showed
+// an empty `application "Flow canvas"` with "Minimize all" disabled: there was no
+// MCP component node, so neither entry point could ever render and no budget
+// would have helped. Measured on nightly 1.12.0.dev17: 4 of 8 sidebar adds on the
+// MCP tab were swallowed, all 4 repaired by an identical second click, while a
+// landed add's entry point appeared 6–15 ms later, enabled, in 8 of 8.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { classifyInfraError } from "../../../scripts/lib/infra-signatures";
+import {
+  MCP_SERVER_ENTRY_TIMEOUT_MS,
+  missingMcpServerEntryMessage,
+} from "./open-add-mcp-server-modal";
+
+test("an empty canvas is reported as a swallowed add, not as a slow widget", () => {
+  const msg = missingMcpServerEntryMessage({
+    waitedMs: MCP_SERVER_ENTRY_TIMEOUT_MS,
+    canvasNodes: 0,
+  });
+
+  assert.match(msg, /NO node on the canvas/);
+  assert.match(msg, /swallowed/i);
+  // The reader must be pointed at the repair, since waiting is the wrong answer.
+  assert.match(msg, /add-component-from-sidebar/);
+  assert.match(msg, /no wait fixes it/i);
+});
+
+test("a populated canvas is reported as a widget change, not as a swallowed add", () => {
+  // The other side of the split: with the node present, the entry point really is
+  // missing from the component's server field — a Langflow change, and telling the
+  // reader to repair the add would send them at the wrong layer.
+  const msg = missingMcpServerEntryMessage({
+    waitedMs: MCP_SERVER_ENTRY_TIMEOUT_MS,
+    canvasNodes: 2,
+  });
+
+  assert.match(msg, /2 node\(s\) are on the canvas/);
+  assert.match(msg, /Langflow change/);
+  assert.doesNotMatch(msg, /swallowed/i);
+});
+
+test("the message names both entry points and the budget actually waited", () => {
+  // Naming both is what tells a reader the wait covered the empty-list branch too
+  // — the previous failure named only the dropdown, which does not exist when no
+  // server is registered.
+  const msg = missingMcpServerEntryMessage({ waitedMs: 15000, canvasNodes: 0 });
+
+  assert.match(msg, /add-mcp-server-simple-button/);
+  assert.match(msg, /mcp-server-dropdown/);
+  assert.match(msg, /15000ms/);
+  assert.match(msg, /openAddMcpServerModal/);
+});
+
+test("neither verdict is classifiable as an infra failure", () => {
+  // Same rule as the sidebar-add message (#1262): claiming infra would exempt the
+  // failure from @stable auto-removal and hide a genuine MCP regression.
+  for (const canvasNodes of [0, 3]) {
+    assert.equal(
+      classifyInfraError(
+        missingMcpServerEntryMessage({ waitedMs: 15000, canvasNodes }),
+      ),
+      null,
+    );
+  }
+});

--- a/tests/helpers/mcp/open-add-mcp-server-modal.ts
+++ b/tests/helpers/mcp/open-add-mcp-server-modal.ts
@@ -1,13 +1,101 @@
-import type { Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 
+const NODE_SELECTOR = '[data-testid^="rf__node-"]';
+
+/**
+ * Budget for the MCP component's server widget to render one of its two entry
+ * points, and for the dropdown to leave its loading state.
+ *
+ * Generous relative to what it costs: measured on nightly 1.12.0.dev17 over 8
+ * runs, the entry point was visible 6–15 ms after the node landed and the
+ * dropdown was never observed disabled. So this budget is only ever paid on the
+ * way to a failure, which is exactly where the extra seconds are worth having.
+ */
+export const MCP_SERVER_ENTRY_TIMEOUT_MS = 15000;
+
+/**
+ * Names the cause when neither entry point renders — issue #1335.
+ *
+ * The 3 s `click()` this replaced could not: its call log read only
+ * `waiting for getByTestId('mcp-server-dropdown')`, which says the locator never
+ * resolved and nothing about WHY. The why, on the 2026-08-05 and 2026-08-06
+ * dailies, was that there was no MCP component on the canvas at all — the
+ * sidebar add had been swallowed (#1304 class), and the failing attempt's
+ * error-context snapshot shows an empty `application "Flow canvas"` with
+ * "Minimize all" disabled. Both of the widget's branches hang off the component
+ * node, so with no node there is nothing to wait for and no budget can help.
+ * The node count is therefore the first fact this message carries.
+ */
+export function missingMcpServerEntryMessage(d: {
+  waitedMs: number;
+  canvasNodes: number;
+}): string {
+  const cause =
+    d.canvasNodes === 0
+      ? `There is NO node on the canvas, so the MCP component was never added ` +
+        `and neither entry point could ever render — the sidebar add was ` +
+        `swallowed (#1304/#1335 class, not a slow surface: no wait fixes it). ` +
+        `Add the component through a helper that repairs a dropped click ` +
+        `(helpers/flows/add-component-from-sidebar.ts).`
+      : `${d.canvasNodes} node(s) are on the canvas, so the component is there ` +
+        `but its server widget never rendered an entry point — treat this as a ` +
+        `Langflow change to the MCP component's server field, not as a wait.`;
+
+  return (
+    `[openAddMcpServerModal] neither "add-mcp-server-simple-button" (no servers ` +
+    `registered yet) nor "mcp-server-dropdown" (one or more registered) became ` +
+    `visible within ${d.waitedMs}ms. ${cause}`
+  );
+}
+
+/**
+ * Opens the "Add MCP Server" modal from an MCP component on the canvas.
+ *
+ * The component renders exactly ONE of two mutually exclusive entry points
+ * (verified in the 1.12.0.dev17 frontend bundle, a single ternary): the plain
+ * `add-mcp-server-simple-button` once the servers query has resolved to an empty
+ * list, and `mcp-server-dropdown` otherwise — including while that query is in
+ * flight, where it renders DISABLED with a "Loading servers…" label.
+ *
+ * So the branch cannot be decided from a snap read of the DOM, which is what the
+ * previous version did: `isVisible({ timeout: 1000 })` looks like a 1 s wait but
+ * Playwright IGNORES that option (`@deprecated This option is ignored`), so the
+ * probe returned in ~1 ms and committed to the dropdown branch whenever the
+ * widget had not painted yet — then spent its whole 3 s budget on a locator that
+ * in the empty-list case would never appear at all. Waiting for either entry
+ * point FIRST and branching on the settled state removes both halves of that.
+ */
 export async function openAddMcpServerModal(page: Page) {
-  // Try the simple button first (when no servers exist)
   const simpleButton = page.getByTestId("add-mcp-server-simple-button");
-  if (await simpleButton.isVisible({ timeout: 1000 }).catch(() => false)) {
+  const dropdown = page.getByTestId("mcp-server-dropdown");
+
+  // No `.first()`: the two are mutually exclusive branches, so `.or()` matches
+  // exactly one and the #599 caveat (a hidden earlier-in-DOM match pinning the
+  // wait to the full timeout) cannot apply. A build that ever rendered both
+  // would fail here as a strict-mode violation — loudly, which is correct.
+  try {
+    await expect(simpleButton.or(dropdown)).toBeVisible({
+      timeout: MCP_SERVER_ENTRY_TIMEOUT_MS,
+    });
+  } catch {
+    throw new Error(
+      missingMcpServerEntryMessage({
+        waitedMs: MCP_SERVER_ENTRY_TIMEOUT_MS,
+        canvasNodes: await page.locator(NODE_SELECTOR).count(),
+      }),
+    );
+  }
+
+  if (await simpleButton.isVisible()) {
     await simpleButton.click();
   } else {
-    // Otherwise use the dropdown
-    await page.getByTestId("mcp-server-dropdown").click({ timeout: 3000 });
+    // The dropdown is rendered disabled until GET /api/v2/mcp/servers answers.
+    // Asserted separately from the click so an unclearing loading state reports
+    // itself as "still disabled" instead of a bare click timeout.
+    await expect(dropdown).toBeEnabled({
+      timeout: MCP_SERVER_ENTRY_TIMEOUT_MS,
+    });
+    await dropdown.click();
     await page.getByText("Add MCP Server", { exact: true }).last().click({
       timeout: 5000,
     });

--- a/tests/tests-automations/regression/mcp/server/mcp-server-tab.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-tab.spec.ts
@@ -1,15 +1,98 @@
 import { expect, test } from "../../../../fixtures/fixtures";
+import { addComponentFromSidebarWithoutSearch } from "../../../../helpers/flows/add-component-from-sidebar";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { openAddMcpServerModal } from "../../../../helpers/mcp/open-add-mcp-server-modal";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 
-// Quarantined: recurrent flake on the daily (2026-08-05, 2026-08-06, same
-// signature) — `mcp-server-dropdown` is not clickable within the 3 s budget in
-// `helpers/mcp/open-add-mcp-server-modal.ts`. Tracked in #1335; lifting the
-// quarantine (remove `test.fixme` + restore `@stable`) is a deliverable there.
-test.fixme(
+// Flow ids observed on `POST /api/v1/flows` 201, plus the MCP server this run
+// registered. Pattern A from authoring-conventions and the same tracker as the
+// sibling `mcp-server.spec.ts`: `awaitBootstrapTest` runs before every
+// blank-flow click, so the canvas URL id is the stale bootstrap one (#681) and
+// only the response ids are trustworthy.
+//
+// This test creates TWO flows per run and used to delete neither, while
+// registering a fresh `test_server_<random>` every time. The server name is
+// unique to this spec, so its accumulation is measurable and was measured: 14
+// orphan `test_server_*` registrations on the local nightly while working #1335
+// (alongside 58 orphan "New Flow" flows, which this spec shares with every other
+// blank-flow spec). The servers are not just litter — the count decides which
+// branch the widget under test renders (an empty list shows
+// `add-mcp-server-simple-button`, a populated one `mcp-server-dropdown`), so
+// leaving them behind quietly stops the spec from ever taking the empty-list
+// path again.
+const createdFlowIds: string[] = [];
+const registeredServers: string[] = [];
+
+test.beforeEach(async ({ page }) => {
+  createdFlowIds.length = 0;
+  registeredServers.length = 0;
+  page.on("response", (resp) => {
+    if (
+      resp.url().includes("/api/v1/flows") &&
+      resp.request().method() === "POST" &&
+      resp.status() === 201
+    ) {
+      resp
+        .json()
+        .then((body: { id?: string }) => {
+          if (body?.id) createdFlowIds.push(body.id);
+        })
+        .catch(() => {}); // non-JSON / batch payloads
+    }
+  });
+});
+
+// Id-scoped cleanup — never a wipe (#553). Servers are listed first so a name
+// this run never managed to register does not produce a 404 delete.
+test.afterEach(async ({ request }) => {
+  const names = registeredServers.splice(0);
+  const ids = createdFlowIds.splice(0);
+  if (names.length === 0 && ids.length === 0) return;
+
+  const bearer = await getAuthToken(request);
+  const options = bearer ? { headers: { Authorization: bearer } } : undefined;
+
+  if (names.length > 0) {
+    const resp = await request.get("/api/v2/mcp/servers", options);
+    const existing: string[] = resp.ok()
+      ? ((await resp.json()) as Array<{ name: string }>).map((s) => s.name)
+      : names;
+    for (const name of names) {
+      if (existing.includes(name)) {
+        const del = await request.delete(
+          `/api/v2/mcp/servers/${name}`,
+          options,
+        );
+        // Warn rather than throw: the flow cleanup below still has to run, and a
+        // silent failure here is what let the registrations accumulate.
+        if (!del.ok()) {
+          console.warn(
+            `⚠️  MCP server cleanup failed: ${name} — ${del.status()} ${await del.text()}`,
+          );
+        }
+      }
+    }
+  }
+
+  // Not swallowed: `deleteFlow` throws, so a cleanup regression is visible
+  // instead of silent. A transient id 404s, which it treats as done.
+  for (const id of ids) {
+    await deleteFlow(request, id, options);
+  }
+});
+
+// Quarantine lifted (#1335). The recurrent daily flake (2026-08-05, 2026-08-06)
+// reported itself as `mcp-server-dropdown` not clickable within the shared
+// helper's 3 s budget, but the budget was never the cause: the sidebar add was
+// being swallowed, so there was no MCP component on the canvas and neither of
+// the widget's two entry points could ever render. Both halves are fixed above —
+// the add goes through the repairing helper, and the helper now waits for either
+// entry point and names the node count when neither arrives.
+test(
   "user should be able to manage MCP server tools and configuration",
-  { tag: ["@release", "@workspace", "@components", "@mcp"] },
+  { tag: ["@stable", "@release", "@workspace", "@components", "@mcp"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
 
@@ -245,7 +328,15 @@ test.fixme(
         timeout: 30000,
       },
     );
-    await page.getByTestId("add-component-button-lf-starter_project").click();
+    // Repairing add, not a bare click (#1335): Langflow swallows this click on
+    // the MCP tab 4 times out of 8 on nightly 1.12.0.dev17, and every entry point
+    // of the step below hangs off the node it should have created — which is how
+    // this test failed the 2026-08-05 and 2026-08-06 dailies against an empty
+    // canvas, with the error naming `mcp-server-dropdown`.
+    await addComponentFromSidebarWithoutSearch(
+      page,
+      "add-component-button-lf-starter_project",
+    );
 
     await adjustScreenView(page, { numberOfZoomOut: 3 });
 
@@ -258,6 +349,9 @@ test.fixme(
 
     const randomSuffix = Math.floor(Math.random() * 90000) + 10000;
     const testName = `test_server_${randomSuffix}`;
+    // Tracked BEFORE the registration request, so a run that dies mid-add still
+    // cleans up a server the backend did create.
+    registeredServers.push(testName);
 
     await page
       .getByTestId("json-input")

--- a/tests/tests-automations/regression/mcp/server/mcp-server-tab.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-tab.spec.ts
@@ -1,5 +1,8 @@
 import { expect, test } from "../../../../fixtures/fixtures";
-import { addComponentFromSidebarWithoutSearch } from "../../../../helpers/flows/add-component-from-sidebar";
+import {
+  addComponentFromSidebarWithoutSearch,
+  dragComponentFromSidebar,
+} from "../../../../helpers/flows/add-component-from-sidebar";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { openAddMcpServerModal } from "../../../../helpers/mcp/open-add-mcp-server-modal";
@@ -105,10 +108,18 @@ test(
       timeout: 30000,
     });
 
-    // Use dragTo which is more reliable than click on add-component-button
-    await page
-      .getByTestId("data_sourceAPI Request")
-      .dragTo(page.locator('//*[@id="react-flow-id"]'));
+    // Repairing drag, not a bare one (#1335). Langflow swallows this drop too —
+    // measured 1 in 5 on nightly 1.12.0.dev18 — and the drop surfaced 30 s later
+    // as the `generic-node-title-arrangement` wait below timing out, naming the
+    // node that was never created instead of the gesture that failed to create
+    // it. The helper returns only once a node that was not there before is, so
+    // that wait is now a redundant-but-cheap post-condition rather than the
+    // place the failure lands.
+    await dragComponentFromSidebar(
+      page,
+      "api request",
+      "data_sourceAPI Request",
+    );
 
     await page.waitForSelector(
       '[data-testid="generic-node-title-arrangement"]',

--- a/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "../../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { openAddMcpServerModal } from "../../../../helpers/mcp/open-add-mcp-server-modal";
+import { addComponentFromSidebarWithoutSearch } from "../../../../helpers/flows/add-component-from-sidebar";
 import { zoomOut } from "../../../../helpers/ui/zoom-out";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
@@ -437,7 +438,10 @@ test(
         timeout: 30000,
       },
     );
-    await page.getByTestId("add-component-button-lf-starter_project").click();
+    await addComponentFromSidebarWithoutSearch(
+      page,
+      "add-component-button-lf-starter_project",
+    );
 
     await adjustScreenView(page, { numberOfZoomOut: 3 });
 
@@ -600,7 +604,10 @@ test(
         timeout: 30000,
       },
     );
-    await page.getByTestId("add-component-button-lf-starter_project").click();
+    await addComponentFromSidebarWithoutSearch(
+      page,
+      "add-component-button-lf-starter_project",
+    );
 
     await adjustScreenView(page, { numberOfZoomOut: 3 });
 
@@ -840,7 +847,10 @@ test(
         timeout: 30000,
       },
     );
-    await page.getByTestId("add-component-button-lf-starter_project").click();
+    await addComponentFromSidebarWithoutSearch(
+      page,
+      "add-component-button-lf-starter_project",
+    );
 
     await adjustScreenView(page, { numberOfZoomOut: 3 });
 


### PR DESCRIPTION
Closes #1335.

## Verdict: test-side, but not the one the issue proposed

#1335 read the failure as a wait-strategy problem — `mcp-server-dropdown` not clickable within the shared helper's 3 s budget — and its investigation directive proposed raising that budget to 15–30 s. **The budget was never the cause, and raising it would have fixed nothing.**

The failing attempt's own `error-context.md` shows an empty `application "Flow canvas"` with "Minimize all" disabled: there was **no MCP component on the canvas at all**. Both of the add-server widget's entry points hang off that node, so with no node there is nothing to wait for and no budget can help. The sidebar add had been swallowed — the #1304 class.

Measured on nightly 1.12.0.dev17 with an instrumented probe:

| Observation | Measurement |
|---|---|
| First clicks on the MCP tab producing no node within 12 s | **4 of 8** |
| Of those, repaired by an identical second click | **4 of 4** |
| A landed add's node render time | 91–108 ms |
| Its entry point visible after the node lands | 6–15 ms, enabled, 8 of 8 |

The same class as #1304's 4/20 on the Components tab, and worse here. The product is not exonerated by this PR — the swallowed click is a real Langflow defect (#1304) and this only makes the suite survive it and name it.

## What changed

**1. `addComponentFromSidebarWithoutSearch`** — the repair helper could only serve tabs that have a search box, because it unconditionally fills `sidebar-search-input`. The MCP tab has none, so every MCP spec clicked bare and inherited no repair. Split into its own export rather than an optional third argument: 34 call sites across 27 files pass the term positionally, and the two tabs differ in the post-failure *evidence* there is to report, not merely in whether one line runs. `searchTerm`/`searchValue` become nullable so the message can distinguish `<none on this tab>` from `""` (a real observation on the Components tab — the input was reset). `addComponentFromSidebar` is behaviourally unchanged; it delegates to the same `addWithRepair` with a non-null term.

**2. `openAddMcpServerModal`** — decided its branch from a snap read. `isVisible({ timeout: 1000 })` looks like a 1 s wait, but Playwright **ignores** that option, so the probe returned in ~1 ms and committed to the dropdown branch whenever the widget had not painted — then spent its whole 3 s budget on a locator that, in the no-servers case, never appears at all. It now waits for **either** entry point (`.or()`, no `.first()` — the branches are mutually exclusive, so a build rendering both fails loudly as a strict-mode violation) and branches on the settled state. The disabled "Loading servers…" state is asserted separately, so an unclearing load says "still disabled" instead of producing a bare click timeout.

**3. The failure now names the cause.** The old 3 s `click()` produced a call log of exactly one line — `waiting for getByTestId('mcp-server-dropdown')` — which reads as "the dropdown is late" and is what sent the issue after the budget. The new failure reports the canvas node count first and splits on it: 0 nodes points at the swallowed add and says a wait cannot fix it; a populated canvas points at a Langflow change to the component's server field. Covered by unit tests on both branches.

**4. Cleanup that never existed.** The spec doc claimed "no flows are left behind by design". False: the test creates **two** flows per run and registered a fresh `test_server_<random>` every time, deleting neither — **14 orphan `test_server_*` registrations** had accumulated locally. Not merely litter: their count decides which branch the widget under test renders, so leaving them behind quietly stopped the spec from ever taking the empty-list path again. It also feeds #1266 — `GET /api/v2/mcp/servers?action_count=true` takes **7.3 s for two servers** on this instance. Cleanup is id-scoped, never a wipe (#553); flow ids come from `POST /api/v1/flows` 201 bodies, not the canvas URL, which holds the stale bootstrap id (#681).

**5. Quarantine lifted** — `test.fixme` → `test`, `@stable` restored, per `938c547`'s stated deliverable.

## Validation

Nightly **1.12.0.dev18**, all `--workers=1 --retries=0`:

```
mcp-server-tab.spec.ts  --repeat-each=10  10 passed (6.6m)
mcp-server.spec.ts      full file          5 passed, 1 skipped, 1 failed
npm run test:units                       493 passed
typecheck / eslint                       clean (0 errors)
QA-CHECKLIST guard + coverage guard      pass
```

Orphans after 10 consecutive runs: **0** `test_server_*` and **0** `New Flow*` (measured against the API).

### The click fix alone was not enough, and the second sample is why

Fixing the MCP-tab click measured 5/5 here. An independent `--repeat-each=5` on the same branch came back **4/5** — and the one failure was **not** the #1335 signature. It landed 30 s later on `waitForSelector: generic-node-title-arrangement`: the API Request **drag** at the top of the test had been swallowed. Same product defect (#1304), a surface the click repair does not reach, and the same mis-attribution #1335 was filed under — a wait blamed for a gesture that never registered.

| Configuration | Result |
|---|---|
| bare drag + repaired click | **4 / 5** (the failure is the drag) |
| repaired drag + repaired click | **10 / 10** |

`dragComponentFromSidebar` re-issues the drag once. The gesture is **re-issued, not swapped for a click**: dragging out of the sidebar is an interaction Langflow ships, and a spec that quietly stops exercising it stops covering it. The comment it replaces — *"use dragTo which is more reliable than click on add-component-button"* — predates the #1304 repair; neither gesture is reliable bare, both are reliable repaired.

`swallowedAddMessage` gained a `gesture` field rather than a second function. It defaults to `"click"`, so the 34 existing call sites are byte-identical — pinned by a unit assertion, since a drifting default would have all of them reporting a drag they never performed. What does differ is branched: the trigger names `dragTo() … onto the canvas`; the evidence quotes **1/5 on dev18** rather than #1304's 4/20, which was measured on the click surface; and there is no `"+"` button, so it reads "sidebar entry still visible".

**Force-fail** — the add was removed on purpose so the canvas stayed empty; the failure is the attributed message naming the node count and pointing at the repair helper, not a `mcp-server-dropdown` timeout. (See the run output quoted in the PR discussion.)

### The one failure is not this change's

`Streamable HTTP MCP server with server-everything` — **not `@stable`** (auto-removed in `cb3082d`), already filed as **#1332**, and its body is byte-identical here and on `origin/main`: this PR's only edits to that file are one import and three call swaps, none inside that test.

It fails on both sides, but **not at the same point**, measured back-to-back against the same backend, `--grep server-everything`, three attempts per side:

| Ref | Result | Point of failure |
|---|---|---|
| `origin/main` | 3/3 fail | `add-mcp-server-button` visibility — `element(s) not found` after 15 s (**#1332**'s exact signature) |
| this branch | 3/3 fail | later, at the `toolsCount` poll — null after 60 s (the `?action_count=true` slowness behind **#1266**) |

Both signatures map to already-open issues. What is **not** established is why the point splits so cleanly by side when the test body does not differ; the likeliest reason is that its line 1207 carries the same ignored-`isVisible({ timeout })` race this PR fixes elsewhere, making the outcome state-dependent. Recorded as an observation for #1332 rather than a claim.

## Reach of the shared helpers (#1335's last deliverable)

- `helpers/mcp/open-add-mcp-server-modal.ts` → exactly **2** specs: `mcp-server-tab.spec.ts`, `mcp-server.spec.ts`. Both validated above.
- `helpers/flows/add-component-from-sidebar.ts` → **34 call sites across 27 files**, none of which move: the change is additive and `addComponentFromSidebar`'s behaviour is identical for a non-null term (pinned by the unit lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
