### PR TITLE
fix(model-provider): guard the Ollama node's config before the run (#1302)

### DIFF
--- a/docs/core-functionality/model-provider/ollama-provider.md
+++ b/docs/core-functionality/model-provider/ollama-provider.md
@@ -68,7 +68,8 @@ a selected local model no longer executes.
 ## Tags *(required)*
 
 Test 1: `@stable` `@model-provider` `@settings`
-Test 2: `@stable` `@regression` `@model-provider` `@components` `@playground`
+Test 2: `@regression` `@model-provider` `@components` `@playground`
+— **`@stable` withheld again, see the #1302 gate below.**
 
 `@stable` added after 4 clean `--retries=0` runs against the local Ollama
 (issue #498's "Done when"). In environments without a local Ollama, both
@@ -98,7 +99,19 @@ the shard, is simply far slower than the ~13 s this spec takes locally. So a
 local green says nothing about the daily, and `@stable` restored on local
 evidence alone would predictably redden it again for an unrelated reason.
 
-**Restoration gate — SATISFIED.** The bar was a green sequence in the real CI
+**Restoration gate for #1302 (the CURRENT one — the block below it is the
+satisfied #931 gate, kept for the record).** `@stable` was removed again and
+`test.fixme` added at triage on 2026-08-06 (#1296 → #1302). It is restored only
+on evidence from the **real CI environment**, because the failure mode is a
+flow-state race that a dev box cannot reproduce at all — worse than in #931's
+case, since this spec now cannot even RUN locally on an arm64 Mac (see
+*Preconditions → local reproduction*). The bar: a `manual.yml` dispatch on the
+branch, `-f test_grep="Ollama"`, `-f retries=0`, green across several
+consecutive runs, with the guard in place. A local green is not admissible
+evidence here and neither is a single CI green — the mechanism fired on 2 of 26
+dailies, so one run proves nothing about it.
+
+**Restoration gate — SATISFIED (#931, historical).** The bar was a green sequence in the real CI
 environment, not on a dev box, via `manual.yml` dispatched on the branch (it
 carries the same `ollama` service container and SSRF allowlist):
 
@@ -122,11 +135,15 @@ dropped: `daily-stable.yml` runs `--grep @stable`, and `nightly.yml` (the only
 full-suite workflow) is disabled — so while untagged, this test ran in **no**
 recurring workflow at all.
 
-**Residual known flake:** on a dev box the execute test still failed ~1 in 8
-runs with no playground reply in 180 s (measured while authoring this). It did
-not reproduce across the 4 CI runs. Watch it in the daily; if it returns, the
-root cause to chase is whether the run starts at all (`POST /api/v2/workflows`,
-SSE) versus the Ollama node failing to build.
+**Residual known flake — it returned, and the fork this note named was the
+right one (#1302).** The prediction stood: *"the root cause to chase is whether
+the run starts at all versus the Ollama node failing to build"*. **The run never
+starts.** It recurred on the 2026-07-30 and 2026-08-05 dailies with the same
+signature, the spec was quarantined at triage (#1296), and the artifacts settle
+it — see the *Why the run never starts* section below. What is NOT the cause is
+the 180 s budget, which the issue's preliminary read proposed raising: the
+budget is untouched here on purpose, and the measurements that justify leaving
+it are recorded in that section.
 
 **Model resolution — the image is the source of truth (#931).** The model the
 CI exercises is BAKED into a dedicated image by
@@ -154,6 +171,60 @@ wait for the reply — which is exactly how a slow-starting CI run produces the
 hidden AND `button-send` visible**, with a window sized for CPU inference, so
 a slow run is waited out instead of being mistaken for a finished one.
 
+**Why the run never starts, and what guards it (#1302).** The failing attempt
+waits 180 s for `div-chat-message` and sees 0 elements 183 times. Three
+independent readings of the artifacts show that is not slowness:
+
+| Evidence | Measurement |
+|---|---|
+| The retry, same run, same runner (07-30 / 08-05) | attempt 0 **180 445 / 180 482 ms failed**, attempt 1 **5 644 / 5 559 ms passed** |
+| Green dailies, attempt 0 on a **freshly created** (therefore cold) Ollama container (08-04 / 08-03) | **5 408 / 6 503 ms passed** — there is no cold-start penalty |
+| `div-chat-message` in the dev18 bundle | wraps `chat-message-${sender_name}-${index}` — it counts the **user's** bubble too, so 0 means the typed message never rendered |
+
+The failure DOM says why: the Ollama node on the canvas has reverted to its
+defaults — `Model Name` reads *"Select an option"* and `Ollama API URL` reads
+`http://localhost:11434`, while the daily injects `http://ollama:11434`. The
+model **was** selected and asserted one step earlier (that step passed in
+1 059 ms). `Model Name` is required, so the run cannot start; consistently, the
+token artifact holds one flow trace for two attempts and the failing attempt
+logged zero backend errors in 191 s.
+
+The mechanism is the one `helpers/flows/wait-for-flow-save-settled.ts`
+documents: `PATCH /api/v1/flows/{id}` has no version check and the frontend
+applies whichever response lands LAST, so a stale autosave overwrites the store
+and the database (the root of #358, #357, #995). The spec already calls that
+barrier; it guarantees PATCH quiescence for 700 ms and nothing about what
+persisted. **Which write reverts it is not pinned** — a stale autosave and the
+bulk `DELETE /api/v1/flows/` that appears mid-test under `actualWorkers: 2` are
+both candidates, and the artifacts do not separate them.
+
+**The guard reads the WIDGET, not the API, and that is measured rather than
+conventional:** the run is dispatched as `POST /api/v2/workflows` with a
+**66 801-byte body** — the frontend's in-memory graph, not a reference to the
+persisted flow. A guard that queried `GET /api/v1/flows/{id}` could therefore
+pass while the run executes the reverted state.
+
+It does two things, in this order:
+
+1. **Converge** — after selecting the model, wait for the node's configuration
+   to hold (widget value stable, no flow-save PATCH in flight), re-applying the
+   selection at most once. This is condition-based waiting on a known product
+   race, not a blind retry of a failed interaction.
+2. **Attribute** — immediately before `button-send`, assert the node still
+   carries the model. If it does not, fail **there**, naming the revert and the
+   two fields observed, in ~1 s instead of 180 s.
+
+Step 2 does not mask the defect: a persistent revert still fails the test, just
+quickly and with the cause named instead of as a bare `toHaveCount` timeout on a
+locator three layers downstream.
+
+**The 180 s budget is deliberately unchanged.** #1302's directive asks for a
+measured replacement *if the budget is the cause*; it is not. Recorded so the
+question is not reopened: the playground step costs **5 408 / 5 559 / 5 644 /
+6 503 ms** across four dailies, cold and warm, and the run request itself
+(`POST /api/v2/workflows`) took **4 063 ms**. Any budget above ~10 s is
+equivalent for the healthy path, and for the broken path no budget works.
+
 ---
 
 ## Preconditions *(optional)*
@@ -177,6 +248,22 @@ a slow run is waited out instead of being mistaken for a finished one.
   model-list fetch — start the Langflow container with
   `-e LANGFLOW_SSRF_ALLOWED_HOSTS=host.docker.internal` (discovered live on
   1.11.0.dev36 while authoring this spec).
+- **Local reproduction is NOT possible on an arm64 Mac (measured 2026-08-06 on
+  1.12.0.dev18)** — treat this spec as CI-only there and do not spend the cycle.
+  A dockerized Langflow could not reach any Ollama in either topology (host
+  instance via `host.docker.internal`; a sibling `ollama/ollama` container on a
+  shared network with the CI's exact allowlist). Setting
+  `LANGFLOW_SSRF_ALLOWED_HOSTS` makes it worse rather than better: **without**
+  it the layer answers `resolves to blocked IP address(es)` (so the name
+  resolved), **with** it the same name answers `DNS resolution failed` — for a
+  name `getent` and `socket.getaddrinfo` resolve inside that same container.
+  Independently: `validate_model_provider_key("Ollama", …)` called directly in
+  that container validates and connects, while `POST
+  /api/v1/models/validate-provider` with the same argument does not — the
+  allowlist is honoured by the library and not by the endpoint. The escapes are
+  closed too: the amd64 image dies with `Fatal glibc error: CPU does not support
+  x86-64-v3`, and `start-langflow-pip.sh` installs the stable release, not the
+  nightly line.
 - If the probe fails, both tests skip with the reason — no false red.
 - No collect-models / cloud key needed (local provider).
 - **How CI satisfies all of the above** (`daily-stable.yml`): an `ollama`
@@ -215,14 +302,20 @@ a slow run is waited out instead of being mistaken for a finished one.
    refresh/open the `model_name` dropdown.
 4. **Assert (configure/connectivity):** the dropdown lists
    `OLLAMA_TEST_MODEL` — the component genuinely enumerated the local
-   instance's models. Select it.
-5. Open the Playground, send a per-run sentinel prompt, and wait for the run
+   instance's models. Select it, then **wait for the selection to converge**
+   (#1302): the widget still shows it with no flow-save PATCH in flight,
+   re-applying at most once.
+5. Open the Playground. **Immediately before sending, assert the Ollama node
+   still carries the model** (#1302) — the run ships the frontend's in-memory
+   graph, so a reverted node produces no message at all and the 180 s wait
+   below would otherwise absorb it unattributed.
+6. Send a per-run sentinel prompt, and wait for the run
    to COMPLETE on the deterministic signal — `button-stop` hidden **and**
    `button-send` visible — never on a short "did Stop appear?" probe.
-6. **Assert (execute):** the AI reply is non-empty (hard); log whether the
+7. **Assert (execute):** the AI reply is non-empty (hard); log whether the
    sentinel round-tripped (soft, family pattern — model obedience is not the
    contract).
-7. No `allowFlowErrors`.
+8. No `allowFlowErrors`.
 
 ---
 
@@ -253,12 +346,22 @@ reply presence — never model wording.
   distribution is an image-packaging regression, so it must stay red and
   attributed (#931). Contrast with Groq/Mistral, absent by design ⇒ skip
   (#1039).
+- **Pre-run configuration guard (#1302)** — a node that reverted to its
+  defaults cannot produce any message, so without this the spec spends its
+  whole 180 s budget on a locator that will never resolve and reports a
+  `toHaveCount` timeout three layers away from the cause. The guard reads the
+  widget, not the API, because the run ships the in-memory graph.
 - **Force-failure checks** (CONTRIBUTING §2): M1 — test 1 asserts the
   validate-provider body reports `valid === false` (inverted) ⇒ must fail;
   M2 — test 2 expects a never-pulled model name in the live dropdown ⇒ must
   fail; M3 — test 2 asserts the reply is empty (inverted) ⇒ must fail; M4 —
   the pre-flight probe token is changed to a family absent from the build
-  (e.g. `groq`) ⇒ must fail on the attributed pre-flight message.
+  (e.g. `groq`) ⇒ must fail on the attributed pre-flight message; **M5 (#1302)
+  — the model selection is cleared right before the pre-run guard ⇒ the guard
+  must fail there, naming the revert, NOT 180 s later on
+  `div-chat-message`.** M5 is the one that proves the guard is load-bearing:
+  without it the same mutation still fails the test, but as the unattributed
+  timeout this issue was filed under.
 
   M1 was previously documented as "test 1 expects a **4xx** validate-provider
   (inverted)". That mutation could not fail as described: the endpoint answers

--- a/tests/helpers/flows/node-config-guard.test.ts
+++ b/tests/helpers/flows/node-config-guard.test.ts
@@ -1,0 +1,116 @@
+// Unit tests for the node-configuration guard (issue #1302).
+// Run with: npm run test:units
+//
+// What rides on these: whether a node that silently reverted reports itself as
+// such, or as the thing #1302 was filed under — `expect(locator).toHaveCount`
+// timing out after 180 s on `div-chat-message`, three layers downstream of the
+// cause, which read as "the model was slow" and sent the issue after the wait
+// budget. The budget was never the cause: the same step costs 5 408-6 503 ms on
+// the four dailies measured, cold container or warm.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { classifyInfraError } from "../../../scripts/lib/infra-signatures";
+import {
+  classifyConfigOutcome,
+  revertedConfigMessage,
+} from "./node-config-guard";
+
+const DETAIL = {
+  field: "Model Name",
+  expected: "llama3.2:1b",
+  observed: "Select an option",
+  valueTestId: "value-dropdown-dropdown_str_model_name",
+};
+
+test("a widget still showing the value HELD, even inside a larger label", () => {
+  // These widgets render the selection among other text — the spec's own
+  // assertion uses toContainText for the same reason. Equality here would call
+  // a perfectly good selection a revert.
+  assert.equal(classifyConfigOutcome("llama3.2:1b", "llama3.2:1b"), "held");
+  assert.equal(
+    classifyConfigOutcome("llama3.2:1b", "Model: llama3.2:1b (local)"),
+    "held",
+  );
+});
+
+test("the reverted states are the default label, empty, and a missing widget", () => {
+  // "Select an option" is what the #1302 DOM actually showed; the other two are
+  // the states the same revert can leave behind while the canvas re-renders.
+  assert.equal(
+    classifyConfigOutcome("llama3.2:1b", "Select an option"),
+    "reverted",
+  );
+  assert.equal(classifyConfigOutcome("llama3.2:1b", ""), "reverted");
+  assert.equal(classifyConfigOutcome("llama3.2:1b", null), "reverted");
+});
+
+test("a DIFFERENT model is reverted, not held — the run would use the wrong one", () => {
+  // Not hypothetical: the drop-to-workspace-default class (#491/#596) replaces
+  // the selection rather than clearing it, and that run executes green against
+  // a model the test never chose.
+  assert.equal(
+    classifyConfigOutcome("llama3.2:1b", "qwen2.5:0.5b"),
+    "reverted",
+  );
+});
+
+test("the message names the field, both values, and the testid it read", () => {
+  const msg = revertedConfigMessage(DETAIL);
+
+  assert.match(msg, /Model Name/);
+  assert.match(msg, /llama3\.2:1b/);
+  assert.match(msg, /Select an option/);
+  assert.match(msg, /value-dropdown-dropdown_str_model_name/);
+});
+
+test("an empty widget is reported as empty, not as a missing one", () => {
+  // Same distinction the sidebar-add message draws: `""` is a real observation
+  // (the field was reset) and must not read the same as "the widget is gone",
+  // which points at a re-render instead.
+  const empty = revertedConfigMessage({ ...DETAIL, observed: "" });
+  const gone = revertedConfigMessage({ ...DETAIL, observed: null });
+
+  assert.match(empty, /EMPTY/);
+  assert.doesNotMatch(empty, /GONE/);
+  assert.match(gone, /GONE/);
+  assert.doesNotMatch(gone, /EMPTY/);
+});
+
+test("the companion field is what distinguishes one widget from a whole-node reset", () => {
+  // In #1302 BOTH the model and the base URL were back at their defaults. A
+  // message about the dropdown alone would understate it as a selection glitch.
+  const msg = revertedConfigMessage({
+    ...DETAIL,
+    companion: {
+      field: "Ollama API URL",
+      expected: "http://ollama:11434",
+      observed: "http://localhost:11434",
+    },
+  });
+
+  assert.match(msg, /Ollama API URL/);
+  assert.match(msg, /http:\/\/ollama:11434/);
+  assert.match(msg, /http:\/\/localhost:11434/);
+  assert.match(msg, /the whole node was reset/);
+});
+
+test("without a companion the message makes no claim about other fields", () => {
+  assert.doesNotMatch(revertedConfigMessage(DETAIL), /whole node was reset/);
+});
+
+test("the message points at the cause and forbids the wrong reading", () => {
+  // The two sentences that exist to stop #1302 being re-diagnosed as a budget:
+  // it names the flow-save race, and it says outright that this is not slowness.
+  const msg = revertedConfigMessage(DETAIL);
+
+  assert.match(msg, /wait-for-flow-save-settled/);
+  assert.match(msg, /no version check/);
+  assert.match(msg, /in-memory graph/);
+  assert.match(msg, /NOT read this as a slow model or a short timeout/);
+});
+
+test("the reverted-config message is NOT classifiable as an infra failure", () => {
+  // #1262's rule: claiming infra would exempt this from @stable auto-removal
+  // and hide a node that silently drops its configuration.
+  assert.equal(classifyInfraError(revertedConfigMessage(DETAIL)), null);
+});

--- a/tests/helpers/flows/node-config-guard.ts
+++ b/tests/helpers/flows/node-config-guard.ts
@@ -1,0 +1,209 @@
+import { expect, type Page } from "@playwright/test";
+import { waitForFlowSaveSettled } from "./wait-for-flow-save-settled";
+
+/**
+ * Guards a node's configuration against the flow-save race, for specs that
+ * configure a node on the canvas and then RUN the flow.
+ *
+ * Why this exists (#1302). `ollama-provider.spec.ts` selected the model,
+ * asserted the widget showed it, opened the Playground, sent a prompt — and
+ * waited 180 s for a chat message that never came. The failing attempt's DOM
+ * shows the Ollama node reverted to its DEFAULTS: `Model Name` back to
+ * "Select an option" and the base URL back to `http://localhost:11434`, while
+ * the daily had typed `http://ollama:11434`. `Model Name` is required, so the
+ * run could not start — consistently, that attempt produced no flow trace at
+ * all and logged zero backend errors in 191 s.
+ *
+ * The mechanism is the one `wait-for-flow-save-settled.ts` documents:
+ * `PATCH /api/v1/flows/{id}` has no version check and the frontend applies
+ * whichever response lands LAST, so a stale autosave overwrites the store and
+ * the database (the root of #358, #357, #995). That barrier guarantees PATCH
+ * quiescence; it says nothing about whether what persisted still carries the
+ * selection, and the Playground is opened after it.
+ *
+ * **This reads the WIDGET, never the API, and that is measured rather than
+ * conventional:** the run is dispatched as `POST /api/v2/workflows` with a
+ * 66 801-byte body — the frontend's in-memory graph, not a reference to the
+ * persisted flow. A guard querying `GET /api/v1/flows/{id}` could therefore
+ * pass while the run executes the reverted state.
+ *
+ * Deliberately NOT claimed as infra (the #1262 rule): a node that silently
+ * loses its configuration is a real defect and must stay eligible for
+ * `@stable` auto-removal, so the message carries no `INFRA_PREFIX` and is
+ * pinned as unclassifiable in the unit tests.
+ */
+
+/**
+ * How long the configuration must hold before the run is allowed to start.
+ *
+ * Generous relative to its cost, because it is only ever paid on the way to a
+ * failure: on the four dailies measured for #1302 the whole playground step —
+ * open, send, generate, render — costs 5 408-6 503 ms, so a node whose value
+ * is still absent after 15 s is not a slow surface.
+ */
+export const NODE_CONFIG_SETTLE_TIMEOUT_MS = 15000;
+
+/** Quiet window with no flow-save PATCH in flight before the value is trusted. */
+export const NODE_CONFIG_QUIET_MS = 700;
+
+export type ConfigOutcome = "held" | "reverted";
+
+/**
+ * Did the widget keep what the test put in it?
+ *
+ * Substring rather than equality on purpose: these value widgets render the
+ * selection inside a larger label (the model dropdown shows the model name
+ * among other text), which is the same reason the spec's own assertion uses
+ * `toContainText`. An EMPTY observed value is the reverted case that matters —
+ * a reverted dropdown reads "Select an option", which contains nothing the
+ * caller asked for.
+ */
+export function classifyConfigOutcome(
+  expected: string,
+  observed: string | null,
+): ConfigOutcome {
+  if (observed === null) return "reverted";
+  return observed.includes(expected) ? "held" : "reverted";
+}
+
+export type RevertedConfigDetail = {
+  /** Human name of the field, e.g. "Model Name". */
+  field: string;
+  /** What the test selected/typed. */
+  expected: string;
+  /** What the widget shows now — `null` when the widget is gone entirely. */
+  observed: string | null;
+  /** Testid read, so the reader can find it without grepping the spec. */
+  valueTestId: string;
+  /** Optional second field read at the same moment (e.g. the base URL). */
+  companion?: { field: string; expected: string; observed: string | null };
+};
+
+export function revertedConfigMessage(d: RevertedConfigDetail): string {
+  const shown =
+    d.observed === null
+      ? "the widget is GONE from the DOM"
+      : d.observed.trim() === ""
+        ? 'it is EMPTY ("")'
+        : `it now reads "${d.observed}"`;
+
+  // Naming the companion field is what separates "one dropdown misbehaved" from
+  // "the whole node reverted" — in #1302 BOTH the model and the base URL were
+  // back at their defaults, which is why the run could not start rather than
+  // merely running with the wrong model.
+  const companion = d.companion
+    ? ` Read at the same moment, "${d.companion.field}" expected ` +
+      `"${d.companion.expected}" and ` +
+      (d.companion.observed === null
+        ? "is GONE"
+        : `reads "${d.companion.observed}"`) +
+      ` — if BOTH reverted, the whole node was reset, not one widget.`
+    : "";
+
+  return (
+    `[node-config-guard] the node lost its configuration before the run: ` +
+    `"${d.field}" was set to "${d.expected}" (asserted at selection time) but ` +
+    `${shown}, read from getByTestId("${d.valueTestId}") immediately before ` +
+    `sending.${companion} The run ships the frontend's in-memory graph ` +
+    `(POST /api/v2/workflows, ~66KB), so it would execute THIS state — a ` +
+    `required field left empty means no run starts and no chat message can ` +
+    `ever arrive (#1302). This is the flow-save race documented in ` +
+    `helpers/flows/wait-for-flow-save-settled.ts: PATCH /api/v1/flows/{id} has ` +
+    `no version check and the LAST response wins, so a stale autosave can ` +
+    `overwrite the selection in both the store and the database (#358/#357/` +
+    `#995). Do NOT read this as a slow model or a short timeout.`
+  );
+}
+
+const readValue = async (
+  page: Page,
+  valueTestId: string,
+): Promise<string | null> =>
+  page
+    .getByTestId(valueTestId)
+    .innerText()
+    .catch(() => null);
+
+/**
+ * Waits until the node's configuration is settled: the widget shows what the
+ * caller set AND no flow-save PATCH is in flight.
+ *
+ * When it does not hold, `reapply` is invoked ONCE and the check repeats. The
+ * re-apply is bounded and deliberate: this is a known product race that
+ * overwrites a value that was already applied and asserted, so re-issuing the
+ * selection is recovering from a lost write, not retrying a failed
+ * interaction. If it does not hold after that, the caller's guard fails
+ * attributed rather than the run being started against a reverted node.
+ */
+export async function waitForNodeConfigSettled(
+  page: Page,
+  opts: {
+    valueTestId: string;
+    expected: string;
+    reapply?: () => Promise<void>;
+    timeoutMs?: number;
+  },
+): Promise<void> {
+  const timeout = opts.timeoutMs ?? NODE_CONFIG_SETTLE_TIMEOUT_MS;
+
+  await expect(page.getByTestId(opts.valueTestId)).toContainText(opts.expected, {
+    timeout,
+  });
+  await waitForFlowSaveSettled(page, { quietMs: NODE_CONFIG_QUIET_MS });
+
+  if (
+    classifyConfigOutcome(
+      opts.expected,
+      await readValue(page, opts.valueTestId),
+    ) === "held"
+  ) {
+    return;
+  }
+
+  if (opts.reapply) {
+    await opts.reapply();
+    await expect(page.getByTestId(opts.valueTestId)).toContainText(
+      opts.expected,
+      { timeout },
+    );
+    await waitForFlowSaveSettled(page, { quietMs: NODE_CONFIG_QUIET_MS });
+  }
+}
+
+/**
+ * Fails, attributed, when the node no longer carries its configuration.
+ *
+ * Call this immediately before the interaction that STARTS the run. Placing it
+ * anywhere earlier leaves the very window #1302 is about — the revert was
+ * observed with the Playground already open and the canvas node behind it.
+ */
+export async function assertNodeConfigHeld(
+  page: Page,
+  opts: {
+    valueTestId: string;
+    expected: string;
+    field: string;
+    companion?: { valueTestId: string; expected: string; field: string };
+  },
+): Promise<void> {
+  const observed = await readValue(page, opts.valueTestId);
+  if (classifyConfigOutcome(opts.expected, observed) === "held") return;
+
+  const companion = opts.companion
+    ? {
+        field: opts.companion.field,
+        expected: opts.companion.expected,
+        observed: await readValue(page, opts.companion.valueTestId),
+      }
+    : undefined;
+
+  throw new Error(
+    revertedConfigMessage({
+      field: opts.field,
+      expected: opts.expected,
+      observed,
+      valueTestId: opts.valueTestId,
+      companion,
+    }),
+  );
+}

--- a/tests/tests-automations/regression/core-functionality/model-provider/ollama-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/ollama-provider.spec.ts
@@ -4,12 +4,15 @@ import type { APIRequestContext, Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { SettingsPage } from "../../../../pages";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
-import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
 import { zoomOut } from "../../../../helpers/ui/zoom-out";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { isProviderComponentAvailable } from "../../../../helpers/provider-setup/probe-component-available";
+import {
+  assertNodeConfigHeld,
+  waitForNodeConfigSettled,
+} from "../../../../helpers/flows/node-config-guard";
 
 /**
  * Ollama provider path (QA-CHECKLIST §7.6 "Configure and execute flow with
@@ -221,18 +224,23 @@ test.describe("Ollama Provider", () => {
     },
   );
 
-  test.fixme(
+  test(
     "the Ollama component lists the local model live and executes the flow",
     {
-      // Quarantined at triage (#1296): recurrent flake 2x same-signature
-      // (2026-07-30, 2026-08-05), 6 occurrences in the 30-day window — no
-      // `div-chat-message` arrives within the 180s budget (the locator resolved
-      // to 0 elements 183 times). Restore (`test` + `@stable`) in #1302.
+      // `test.fixme` lifted (#1302). The quarantine (#1296) read the failure as
+      // "no `div-chat-message` within the 180s budget"; the artifacts refute
+      // that budget reading three ways — the retry did the same step in 5.5s on
+      // the same runner, green dailies do it in 5.4-6.5s on a COLD container,
+      // and `div-chat-message` counts the user's own bubble, so 0 elements for
+      // 183 polls means the typed message never rendered. The failing DOM shows
+      // the Ollama node reverted to its defaults (Model Name empty, base URL
+      // back to localhost), which is why no run could start. Guarded above and
+      // below by `helpers/flows/node-config-guard.ts`.
       //
-      // This supersedes the #931 restoration rationale that stood here: @stable
-      // had been restored after 4 consecutive green `manual.yml` runs on the
-      // branch, on the grounds that the rebuilt run-completion wait held under
-      // runner-speed inference. It does not hold on the daily.
+      // `@stable` stays OFF until a `manual.yml` dispatch measures this green in
+      // the real CI environment — the mechanism fired on 2 of 26 dailies and
+      // cannot be reproduced locally at all (see the spec doc's Preconditions),
+      // so neither a local green nor a single CI green is admissible evidence.
       tag: ["@regression", "@model-provider", "@components", "@playground"],
     },
     async ({ page, request }) => {
@@ -328,7 +336,7 @@ test.describe("Ollama Provider", () => {
           await updatePromise;
         });
 
-        await test.step("the LIVE model dropdown lists the locally pulled model — select it", async () => {
+        const selectModel = async () => {
           await page.getByTestId("dropdown_str_model_name").click();
           const option = page
             .locator('[data-testid$="-option"]')
@@ -340,11 +348,23 @@ test.describe("Ollama Provider", () => {
           // instance actually serves, so this cannot drift from the CI image.
           await expect(option).toBeVisible({ timeout: 15000 });
           await option.click();
+        };
+
+        await test.step("the LIVE model dropdown lists the locally pulled model — select it", async () => {
+          await selectModel();
           await expect(page.getByTestId("value-dropdown-dropdown_str_model_name")).toContainText(
             probe.model,
             { timeout: 10000 },
           );
-          await waitForFlowSaveSettled(page);
+          // Not just `waitForFlowSaveSettled` (#1302): that barrier proves no
+          // flow-save PATCH is in flight, and says nothing about whether the
+          // selection survived one that already landed. This re-reads the widget
+          // after the quiet window and re-applies once if the value is gone.
+          await waitForNodeConfigSettled(page, {
+            valueTestId: "value-dropdown-dropdown_str_model_name",
+            expected: probe.model,
+            reapply: selectModel,
+          });
         });
 
         await test.step("execute the flow through the Playground", async () => {
@@ -352,6 +372,24 @@ test.describe("Ollama Provider", () => {
           const chatInput = page.getByTestId("input-chat-playground").last();
           await expect(chatInput).toBeVisible({ timeout: 30000 });
           await chatInput.fill(`Repeat this token exactly and nothing else: ${token}`);
+
+          // Immediately before the send, never earlier (#1302): the revert was
+          // observed with the Playground already OPEN and the canvas node behind
+          // it, and the run ships the in-memory graph — so this is the last
+          // moment at which what will execute can still be read. Without it the
+          // spec spends its whole 180 s budget on a `div-chat-message` that a
+          // node missing its required Model Name can never produce.
+          await assertNodeConfigHeld(page, {
+            valueTestId: "value-dropdown-dropdown_str_model_name",
+            expected: probe.model,
+            field: "Model Name",
+            companion: {
+              valueTestId: "popover-anchor-input-base_url",
+              expected: OLLAMA_BASE_URL_FROM_LANGFLOW,
+              field: "Ollama API URL",
+            },
+          });
+
           await page.getByTestId("button-send").last().click();
           await waitForRunToFinish(page);
 


### PR DESCRIPTION
Refs #1302. **Deliberately does not close it** — see *What stays open*.

## Verdict: the node loses its configuration before the run. It is not the budget.

#1302 reads the failure as a 180 s budget too short for CPU inference, and its directive asks for a measured replacement. The artifacts refute that three independent ways, so **step 2 of the directive should not be actioned**:

| Evidence | Measurement |
|---|---|
| The retry — same run, same runner | **180 445 ms failed → 5 644 ms passed** (07-30) · **180 482 ms failed → 5 559 ms passed** (08-05) |
| Green dailies, attempt 0 on a **freshly created** (therefore cold) Ollama container | **5 408 ms** (08-04) · **6 503 ms** (08-03) — there is no cold-start penalty |
| `div-chat-message` in the dev18 bundle | wraps `chat-message-${sender_name}-${index}` — it counts the **user's** bubble too |

So the cost is 5–6.5 s cold or warm, and the failure is **binary**: either ~5 s, or nothing at all for 180 s. That is not a distribution with a long tail. And "0 elements 183 times" does not mean the model was slow — it means **the message the test typed never rendered**.

The failing attempt's `error-context.md` says why. The Ollama node on the canvas, behind the open Playground:

```yaml
Model Name*
  combobox: "Select an option"        # empty
Ollama API URL
  textbox: "http://localhost:11434"   # the component default
```

The daily injects `OLLAMA_BASE_URL_FROM_LANGFLOW: http://ollama:11434`, and the step that selects the model **passed in 1 059 ms**, asserting `value-dropdown-dropdown_str_model_name`. So the model was selected, verified, and then lost. `Model Name` is required ⇒ the run cannot start. Everything agrees: the token artifact holds **one** flow trace for **two** attempts, and the failing attempt logged **zero** backend errors in 191 s.

This also confirms the fork the spec doc named after #931 — *"the root cause to chase is whether the run starts at all versus the Ollama node failing to build"*. It is the first.

## The fix

The mechanism is already documented in this repo, in `helpers/flows/wait-for-flow-save-settled.ts`: `PATCH /api/v1/flows/{id}` has no version check and the frontend applies whichever response lands **last**, so a stale autosave overwrites the selection in both the store and the database (the root of #358, #357, #995). The spec already called that barrier — it proves PATCH quiescence and says nothing about what persisted, and the Playground opens after it.

`tests/helpers/flows/node-config-guard.ts` adds the two halves the barrier cannot give:

- **`waitForNodeConfigSettled`** — after selecting, re-reads the widget past the quiet window and re-applies the selection **at most once**. Bounded and deliberate: this recovers a write the product lost *after* it was applied and asserted; it is not a blind retry of a failed interaction.
- **`assertNodeConfigHeld`** — runs immediately before `button-send`, never earlier (the revert was observed with the Playground already **open**), and fails naming both fields it read. A persistent revert still fails the test — in ~1 s with the cause named, instead of as a `toHaveCount` timeout three layers downstream, which is precisely how this got filed as a budget problem.

**It reads the WIDGET, not the API, and that is measured rather than conventional:** the run is dispatched as `POST /api/v2/workflows` with a **66 801-byte body** — the frontend's in-memory graph, not a reference to the persisted flow. A guard querying `GET /api/v1/flows/{id}` could pass while the run executes the reverted state.

**The 180 s budget is unchanged on purpose.** The directive asks for a measured budget *if the budget is the cause*; it is not. The numbers are recorded in the spec doc so the question is not reopened: 5 408 / 5 559 / 5 644 / 6 503 ms across four dailies, and the run request itself took 4 063 ms.

## The four earlier occurrences (a deliverable of the issue)

They are **two** causes, not one unsettled month — the line number separates them, because #931 rebuilt the file:

| Date | Line | Signature | Cause |
|---|---|---|---|
| 07-15, 07-22 | 172 | `expect(locator).toBeVisible() failed` | same mechanism as now, pre-#931 assertion shape |
| 07-23, 07-24 | 172 | `page.waitForSelector: Timeout 30000ms` | **different** — `lfx-ollama` absent from the image; already covered by the `isProviderComponentAvailable` pre-flight |
| 07-30, 08-05 | 224 | `expect(locator).toHaveCount(expected) failed` | same mechanism, post-#931 |

## Validation

```
npm run test:units          502 passed  (+9 for the new guard)
npm run typecheck           clean
eslint (touched files)      0 errors
orphans after the runs      0 test_* MCP servers, 0 "New Flow*" flows
```

**Force-fails — executed, both directions:**

- **FF-1** — `classifyConfigOutcome` mutated to always return `"held"` ⇒ **2 of the 9 unit tests fail** (`the reverted states…`, `a DIFFERENT model…`). Reverted, 0 markers left.
- **FF-2a** *(browser, real DOM)* — the guard pointed at a value not present ⇒ throws the attributed message: *"…was set to "VALOR-QUE-NAO-EXISTE-NO-DOM" … but it now reads "MCP Server" … Do NOT read this as a slow model or a short timeout."*
- **FF-2b** *(the other direction, which matters as much)* — the same guard pointed at the real value ⇒ **1 passed (36.1 s)**, no false fire.

FF-2 was run against `mcp-server-tab.spec.ts` rather than this spec, because **this spec cannot run on an arm64 Mac at all** — see below. The probe was reverted and the tree verified clean.

### This spec is CI-only on arm64 (measured on 1.12.0.dev18)

Recorded in the spec doc's Preconditions so the next person does not spend the cycle. A dockerized Langflow could not reach any Ollama in either topology (host instance via `host.docker.internal`; a sibling `ollama/ollama` container on a shared network with the CI's exact allowlist). Setting `LANGFLOW_SSRF_ALLOWED_HOSTS` makes it **worse**: without it the layer answers `resolves to blocked IP address(es)` (so the name resolved), with it the same name answers `DNS resolution failed` — for a name `getent` and `socket.getaddrinfo` resolve inside that same container. The amd64 image cannot run here (`Fatal glibc error: CPU does not support x86-64-v3`), and `start-langflow-pip.sh` installs the stable release rather than the nightly line.

Worth flagging on its own: inside one container with the allowlist set, `validate_model_provider_key("Ollama", …)` called directly **validates and connects**, while `POST /api/v1/models/validate-provider` with the same argument returns `DNS resolution failed`. The allowlist is honoured by the library and not by the endpoint.

## What stays open

- **`@stable` is NOT restored.** `test.fixme` is lifted so the test runs again, but the mechanism fired on 2 of 26 dailies and cannot be reproduced locally, so neither a local green nor a single CI green is admissible evidence. The gate is written into the spec doc: several consecutive green `manual.yml` dispatches with `-f retries=0`. **#1302 stays open for that**, which is why this PR says `Refs` and not `Closes`.

  ```bash
  gh workflow run manual.yml --repo oriontech-me/langflow-e2e \
    --ref fix/issue-1302-ollama-node-config-revert \
    -f langflow_target=latest -f langflow_image=nightly \
    -f test_grep="Ollama" -f retries=0
  ```

- **Which write reverts the node is not pinned.** A stale autosave and the bulk `DELETE /api/v1/flows/` that appears mid-test under `actualWorkers: 2` are both candidates, and the artifacts do not separate them. The spec doc says so in those words rather than picking a culprit — if it turns out to be the delete, the fix belongs to the **wiper**, not here (`triage-verdicts.md` verdict 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
