### PR TITLE
chore: map coverage against a probability x impact risk model

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -347,8 +347,7 @@
 - [x] Agent responds to multiple consecutive messages in the same session
 
 #### 6.2 Other execution tests
-- [-] Agent displays reasoning steps in Playground → `agent-reasoning-steps.spec.ts`
-- [-] Composio (tool integration for Agent) → `composio.spec.ts`
+- [ ] ~~Composio (tool integration for Agent)~~ — **out of scope (2026-08-06):** Composio is a separately-shipped vendor bundle, and this QA team no longer supports that surface. `composio.spec.ts` exists but must not be promoted: doing so would count coverage the team does not sustain. See `docs/coverage-heatmap/` — vendor bundles are the single largest source of upstream defects (227 issues) and are excluded from the risk model for the same reason
 - [x] Playground shows error when LLM run endpoint returns 500 (mocked invalid API key) → `llm-agents/llm-invalid-api-key-ui.spec.ts`
 - [x] Playground input remains usable after API error (mocked) → `llm-agents/llm-invalid-api-key-ui.spec.ts`
 - [x] Agent stops when configured stop condition is reached → `core-functionality/llm-agents/agent-max-iterations.spec.ts` (`max_iterations` is the Agent's only configurable stop mechanism — no dedicated stop-condition field exists; see #824)
@@ -573,55 +572,62 @@
 ### core-functionality/templates/ — Predefined Flow and Component Models
 
 #### 11.1 Basic Templates
-- [-] Basic Prompting (OpenAI)
-- [-] Basic Prompting (Anthropic)
-- [-] Simple Agent (OpenAI)
-- [-] Simple Agent (Anthropic)
-- [-] Simple Agent with memory
-- [-] Vector Store RAG
-- [x] Memory Chatbot
-- [-] **Basic Prompting** (OpenAI) → `core/integrations/Basic Prompting.spec.ts`
-- [-] **Basic Prompting** (Anthropic) → `core/integrations/Basic Prompting Anthropic.spec.ts`
-- [-] **Simple Agent** (OpenAI) → `core/integrations/Simple Agent.spec.ts`
-- [-] **Simple Agent** (Anthropic) → `core/integrations/Simple Agent Anthropic.spec.ts`
-- [-] **Simple Agent** with memory → `core/integrations/Simple Agent Memory.spec.ts`
-- [-] **Vector Store RAG** → `core/integrations/Vector Store.spec.ts`
-- [x] **Memory Chatbot** → `llm-agents/memory-history-regression.spec.ts`
+
+> **Corrected 2026-08-06.** This block listed all 7 entries **twice** — once plain, once
+> bold with a `core/integrations/*.spec.ts` reference. That path is **Langflow's own
+> upstream test suite**, not this repo, so those references were never automation of ours.
+> The duplicates are removed and each entry now carries its real state.
+>
+> `[~]` here means the template is **instantiated and run** by specs that assert something
+> else (33 specs open *Basic Prompting* from the gallery, 20 open *Simple Agent*), so its
+> creation path is exercised while nothing asserts the template's own behaviour.
+
+- [~] Basic Prompting (OpenAI) — instantiated from the template gallery by 33 specs as a fixture; no assertion on the template itself
+- [ ] Basic Prompting (Anthropic) — the provider variant is never exercised
+- [~] Simple Agent (OpenAI) — instantiated by 20 specs as a fixture
+- [ ] Simple Agent (Anthropic)
+- [ ] Simple Agent with memory
+- [ ] Vector Store RAG
+- [x] Memory Chatbot → `llm-agents/memory-history-regression.spec.ts`
 
 #### 11.2 Content Generation Templates
-- [-] Blog Writer
-- [-] Instagram Copywriter
-- [-] Twitter Thread Generator
-- [-] SEO Keyword Generator
-- [-] Portfolio Website Code Generator
-- [-] SaaS Pricing
+
+- [ ] Blog Writer
+- [ ] Instagram Copywriter
+- [ ] Twitter Thread Generator
+- [ ] SEO Keyword Generator
+- [~] Portfolio Website Code Generator — opened from the gallery by `ui-ux/refresh-dropdown-list.spec.ts`; nothing asserts the template
+- [ ] SaaS Pricing
 
 #### 11.3 Analysis and Processing Templates
-- [-] Document QA
-- [-] Invoice Summarizer
-- [-] Financial Report Parser
-- [-] Image Sentiment Analysis
-- [-] Text Sentiment Analysis
-- [-] Youtube Analysis
+
+- [ ] Document QA
+- [ ] Invoice Summarizer
+- [ ] Financial Report Parser
+- [ ] Image Sentiment Analysis
+- [ ] Text Sentiment Analysis
+- [ ] Youtube Analysis
 
 #### 11.4 Agent Templates
-- [-] Dynamic Agent
-- [-] Hierarchical Agent
-- [-] Sequential Task Agent
-- [-] Social Media Agent
-- [-] Travel Planning Agent
-- [-] Market Research
-- [-] Research Translation Loop
-- [-] Pokedex Agent
-- [-] Price Deal Finder
-- [-] News Aggregator
+
+- [ ] Dynamic Agent
+- [ ] Hierarchical Agent
+- [ ] Sequential Task Agent
+- [ ] Social Media Agent
+- [ ] Travel Planning Agent
+- [ ] Market Research
+- [~] Research Translation Loop — driven as the fixture of `core-components/loop-component-regression.spec.ts` (ArXiv loop), which asserts the Loop component, not the template
+- [ ] Pokedex Agent
+- [ ] Price Deal Finder
+- [ ] News Aggregator
 
 #### 11.5 Advanced Templates
-- [-] Custom Component Generator
-- [-] Prompt Chaining
-- [-] Decision Flow
-- [-] Similarity
-- [-] MCP Server (starter projects)
+
+- [ ] Custom Component Generator
+- [ ] Prompt Chaining
+- [ ] Decision Flow
+- [ ] Similarity
+- [x] MCP Server (starter projects) → `mcp/server/mcp-server-starter-projects.spec.ts` (same coverage recorded in §14.1)
 
 ---
 
@@ -693,6 +699,10 @@
 - [!] Run Flow component executes another flow — runs again after the #966 quarantine lift, but **not `@stable`** while the upstream `New Flow` dead-click defect ([LE-2019](https://datastax.jira.com/browse/LE-2019)) is open; the shared helper gates on the flows list having rendered so the suite stays out of the broken window → `flow-functionality/run-flow.spec.ts`
 - [x] Run a flow from the canvas — terminal-node run builds the whole graph; all nodes reach build success and output is produced → `flow-functionality/flow-execution-canvas.spec.ts`
 - [x] Stop building flow → `flow-functionality/stop-building.spec.ts`
+- [ ] A cyclic graph is refused with a cycle-specific error, and the flow stays editable afterwards (the engine's own contract; a total engine failure is caught indirectly by the 63 `@stable` specs that trigger a run, a subtle one by nothing)
+- [ ] Partial failure — when one branch of a multi-branch graph raises, the branches that do not depend on it still produce their output, and the failed node is the one flagged
+- [ ] Execution order respects data dependency — a node that consumes another's output never builds first (asserted on the run stream, not on wall-clock timing)
+- [ ] A node whose upstream produced no value is skipped rather than run with an empty input
 - [!] Playground button disabled with empty flow — needs review → `regression/flow-functionality/generalBugs-shard-3.spec.ts` (**test skipped: assertion was a no-op, current Langflow behavior to confirm**)
 
 ---
@@ -735,6 +745,10 @@
 - [x] stdio `command` must be a single executable — a command with an embedded argument is refused and the same registration split into `command` + `args` is accepted (upstream hardening `#14073`; #1091) → `mcp/server/mcp-server.spec.ts`
 - [x] The project's own Streamable HTTP endpoint registers as an MCP server and exposes its flows as tools → `mcp/server/mcp-server.spec.ts`
 - [-] Resource exposed by server is accessible via URI — flow files are exposed as MCP resources: `resources/list` is `@stable`; `resources/read` blocked by a live Langflow regression on 1.12.x (`AttributeError: 'str' object has no attribute 'hex'`, filed upstream **LE-2012**) — kept as a guard, not promoted → `mcp/server/mcp-server-resources.spec.ts`
+- [ ] Install this project into an MCP client — `GET /{project_id}/installed` reports the current state, `POST /{project_id}/install` performs it, and the UI reflects both (the user-facing way an MCP Server is actually consumed; no bullet covered this before 2026-08-06)
+- [ ] `GET /{project_id}/composer-url` returns a URL that resolves, and the copy control in the UI yields the same value
+- [ ] Per-project MCP configuration — `GET`/`PATCH /{project_id}` selects which flows are exposed as tools, and a de-selected flow disappears from `tools/list` over the protocol
+- [ ] A registered server is read back individually (`GET /servers/{name}`) with the same fields it was created with, and `PATCH /servers/{name}` updates them (only the list, create, delete and 409/404 paths are covered today)
 - [ ] Prompt exposed by server returns correct template (no product surface on 1.11.x — MCP server `prompts/list` returns `[]`; #829)
 
 ---
@@ -811,6 +825,173 @@
 - [~] All documented shortcuts work — all 27 `defaultShortcuts` rows are listed with a non-empty key binding in Settings → Shortcuts (`ui-ux/settings-navigation.spec.ts`), and 7 of them are exercised on canvas (`ui-ux/langflowShortcuts.spec.ts`) plus 1 rebound end-to-end (`ui-ux/settings-shortcuts-edit.spec.ts`); the remaining 20 (API, Docs, Download, Play, Group, Minimize, Freeze, Save, Code, Update, Controls, sidebar search, …) are not exercised yet
 - [x] Edit a keyboard shortcut (Duplicate → `Ctrl/Cmd+Alt+U`) persists to the table and the new combination triggers the action on canvas → `ui-ux/settings-shortcuts-edit.spec.ts`
 - [x] API Keys table renders `created_at`/`expires_at` in the viewer's local timezone (UTC→local), shows "Never" for unused keys and ∞ for no-expiry keys (PR #13471) → `ui-ux/api-keys-timezone-display.spec.ts`
+
+---
+
+## security/ — Input Validation, SSRF and Secret Exposure
+
+> **New area (2026-08-06).** Opened by the risk analysis in `docs/coverage-heatmap/`, which
+> ranked it **1st by residual risk (15.0)** — not because the danger is the highest, but
+> because it had **no checklist entry at all** and was therefore invisible to every coverage
+> count, including the 76 % headline.
+>
+> **Scope boundary — this section does not cover authentication or authorization.** Those
+> are already covered and counted elsewhere: `api/flows/` (401/403 across flow endpoints,
+> API-key expiry) and `core-functionality/auth/` (session expiry, admin password). Every
+> bullet here is a surface with **no existing coverage**, each traceable to an upstream
+> defect.
+
+#### 17.1 URL Validation and SSRF
+
+- [ ] A component that fetches a URL (API Request) rejects a loopback address when it is not
+      in `LANGFLOW_SSRF_ALLOWED_HOSTS`, and accepts it when it is — the round trip of the
+      guard, not just the rejection (upstream regression: `ensure_url` ignoring the allow-list
+      for loopback, `langflow-ai/langflow#14264`)
+- [ ] A private RFC-1918 address is rejected by the same guard unless allow-listed
+- [ ] The rejection surfaces to the user as an error in the UI, not as a silent empty result
+- [ ] `LANGFLOW_SSRF_ALLOWED_HOSTS` with a CIDR entry admits the whole range
+      (the mechanism `.github/actions/resolve-echo-endpoint` already depends on, currently
+      asserted nowhere)
+
+#### 17.2 Code Execution Endpoints
+
+- [ ] `POST /api/v1/validate/code` rejects a payload crafted to execute on validation
+      (**recurring upstream defect — reported in 2023 as #696 and again in 2026 as #13336,
+      three years apart on the same endpoint**, which is the strongest recurrence signal in
+      the whole bug corpus)
+- [ ] The custom-component endpoint rejects the same class of payload
+      (`langflow-ai/langflow#7900`)
+- [ ] A rejected payload leaves no partial component created
+
+#### 17.3 Secret Exposure
+
+- [ ] A flow run using a Credential-type global variable does **not** render the secret value
+      in the trace detail (`langflow-ai/langflow#7313` — TracingService exposing secrets)
+- [ ] The same secret is absent from the exported flow JSON
+- [ ] The same secret is absent from the API response of a run
+
+#### 17.4 Tweaks Injection
+
+- [ ] Tweak values passed to `POST /api/v1/run/{id}` cannot reach template fields as
+      executable input (`langflow-ai/langflow#9319`, `#8672`)
+
+---
+
+## i18n/ — Interface Language and Localization
+
+> **New area (2026-08-06).** Also opened by the risk analysis (residual risk **6.0**, 6th),
+> and also absent from the checklist until now. Every one of the 5 upstream defects behind it
+> is from **2026** — this is a surface that only started failing this year.
+>
+> **Not a duplicate of `#### 15.10`.** `ui-ux/settings-general-section.spec.ts` (`@stable`)
+> asserts that the **Language group renders** with its description. Nothing asserts that
+> **changing** the language works, and that is exactly where the reported failures are.
+>
+> **Blocked on a prerequisite, by the project's own rule.** `CONTRIBUTING.md` →
+> *Browser locale is pinned to `en-US`* fixes the context locale and `Accept-Language`
+> for every test in every project, because the suite asserts English strings throughout,
+> and it states that non-English coverage *"is a separate, parameterised concern — raise
+> it as its own issue rather than editing the shared default."* §18.2 in particular
+> cannot run under that pin. These bullets therefore need that parameterisation issue
+> opened and resolved **first**; writing them against a per-test `locale` override would
+> violate the rule they depend on.
+
+#### 18.1 Language Selection
+
+- [ ] Changing the display language in Settings → General actually re-renders the interface
+      in the selected language (the seam immediately past `settings-general-section.spec.ts`)
+- [ ] The selected language persists across a reload and a new session
+- [ ] Every language offered in the selector has a locale bundle that loads
+      (`langflow-ai/langflow#12738`, `#12740` — shipped selector entries with missing `ru`
+      and `ko` bundles)
+
+#### 18.2 Locale Resilience
+
+- [ ] The application boots without a blank screen when the browser language is one Langflow
+      does not ship a bundle for — **the product's known total-failure mode**: a missing
+      Chinese bundle (`#12923`, `#13477`) and Norwegian Bokmål `nb-NO` (`#13196`) each render
+      a black screen, so the product does not open at all for those users
+- [ ] A locale bundle missing individual keys falls back to English for those keys instead of
+      failing the render
+
+---
+
+## deployments/ — Deployment Page and Publishing Stepper (1.12)
+
+> **New area (2026-08-06).** Found while validating the critical side of the risk matrix,
+> not by the issue corpus — this surface is too new to have accumulated upstream defects yet.
+> It shipped in `feat: deployment page and stepper UI with watsonx Orchestrate integration`
+> (`langflow-ai/langflow#12303`) and carries **20+ frontend components**: the deployments
+> table, the publishing stepper, per-deployment details, flow and version lists, custom tool
+> naming, connection search, and a provider modal.
+>
+> **Impact is high by our own criterion:** langflow.org sells *"Drag. Drop. **Deploy**"*, and
+> this is the Deploy surface. It also carries the MCP relationship — a deployment is how a
+> project's flows reach an external consumer.
+>
+> **Why it was invisible:** searching the checklist for "deployment" returns 6 hits, and all
+> 6 are Azure AI Foundry *deployment names* — a different meaning of the word. The third
+> ambiguity trap of this analysis, after `template` (component vs starter) and `language`
+> (Language Model vs locale).
+>
+> **Scope boundary:** the deployment *mechanism* is in scope. Individual vendor destinations
+> reached through it (watsonx Orchestrate and any later addition) are **not** — same team
+> decision that excludes vendor bundles.
+
+#### 19.1 Deployments Page
+
+- [ ] The Deployments page renders its empty state for a project with no deployment, and the table once one exists
+- [ ] A deployment row expands to show its detail without navigating away
+- [ ] The details modal lists the flows included in the deployment and their versions
+
+#### 19.2 Publishing Stepper
+
+- [ ] The stepper publishes a flow end-to-end and reaches its success state
+- [ ] The stepper refuses to advance past a step with an incomplete required field, and names what is missing
+- [ ] A published deployment is reachable afterwards — the artifact the success screen points at resolves
+
+#### 19.3 Tool Naming and Connections
+
+- [ ] A custom tool name set in the stepper is what the external consumer sees over MCP (`tools/list`), not the flow's own name
+- [ ] Connection search narrows the list and its empty state renders when nothing matches (`langflow-ai/langflow#12659` fixed exactly this empty state — `@regression`)
+
+---
+
+## memory/ — Memory Base Registration (1.12)
+
+> **New area (2026-08-06).** The `Memories` panel inside the flow editor
+> (`sidebar-nav-memories`) and the `Create Memory` modal that registers a memory
+> base against `/api/v1/knowledge_bases` — 13 routes, none of them covered.
+>
+> **Not the Agent's conversation memory.** Searching the checklist for "memory"
+> returns 10 bullets and every one is about Message History, session isolation or
+> `context_id` (§6.3). Those are unrelated to this surface despite the shared word
+> — the fourth naming collision found in this audit, after `template`, `language`
+> and `deployment`.
+>
+> **Scope:** registration only. Ingestion (`POST /{kb}/ingest`), chunk preview, run
+> history, cancellation, connectors and the five routes guarded by
+> `_check_memory_base_association` are a separate item.
+>
+> Selectors below were harvested from a live 1.12.0 instance — see
+> `docs/core-functionality/memory/memory-base-registration.md`.
+
+#### 20.1 Memories Panel
+
+- [ ] The Memories panel opens from the flow editor (`sidebar-nav-memories`) and shows its empty state (`No memory selected`) rather than a blank panel
+- [ ] The panel offers registration (`Create`) and a memory search field
+
+#### 20.2 Create Memory Modal
+
+- [ ] The modal is **scoped to the flow** — it titles `Create a memory for "<flow name>"`, proving a memory base belongs to a flow rather than being global
+- [ ] It exposes its five controls: Name (`#memory-name`), Embedding Model (`memory-embedding-model`), Vector Database (`memory-db-provider`), Batch Size (`#memory-batch-size`) and the LLM Preprocessing toggle
+- [ ] Vector Database defaults to `Chroma Local` (bundled, so no external vector service is needed) and Embedding Model has **no** default
+- [ ] `Create Memory` is disabled with an empty form **and stays disabled with only the Name filled** — the gate, not just the initial render
+- [ ] Cancelling closes the modal and creates nothing, asserted against `GET /api/v1/knowledge_bases` rather than against the UI alone
+
+#### 20.3 Registration End-to-End
+
+- [ ] Completing the form creates a memory base that is present **both** in `GET /api/v1/knowledge_bases` and in the panel (the panel alone could render optimistic local state). Needs a provider exposing an **embedding** model; with none the picker reads `No Models Enabled` and the test must skip with that reason, never pass silently
 
 ---
 

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -948,9 +948,34 @@
 - [ ] `Create Memory` is disabled with an empty form **and stays disabled with only the Name filled** — the gate, not just the initial render
 - [ ] Cancelling closes the modal and creates nothing, asserted against `GET /api/v1/knowledge_bases` rather than against the UI alone
 
-#### 20.3 Registration End-to-End
+#### 20.3 Registration End-to-End (item 1 of 2)
 
 - [ ] Completing the form creates a memory base that is present **both** in `GET /api/v1/knowledge_bases` and in the panel (the panel alone could render optimistic local state). Needs a provider exposing an **embedding** model; with none the picker reads `No Models Enabled` and the test must skip with that reason, never pass silently
+
+#### 20.4 Ingestion (item 2 of 2 — separate wave item)
+
+> **Tracked separately from registration by team decision (2026-08-07).** Registration
+> and ingestion are one product surface but two pieces of work, and the evidence points
+> the other way from the bullets above: **all three of Memory Base's real upstream defects
+> are ingestion**, while the registration surface §20.1–20.3 cover has none reported yet.
+>
+> Routes confirmed against the running instance: `POST /{kb}/ingest`,
+> `POST /preview-chunks`, `GET /{kb}/chunks`, `GET /{kb}/runs`, `GET /{kb}/runs/{id}`,
+> `POST /{kb}/cancel`, `GET /connectors`, `POST /test-connection`.
+>
+> **One connector ships today** — `folder` ("Ingest every matching file from a server-side
+> folder", `requires_credentials: false`), measured on 1.12.0. A test needs no external
+> service, but it does need a server-side path the instance can read.
+
+- [ ] Chunk settings chosen in the UI are the ones actually applied to the ingested chunks — `@regression` for `langflow-ai/langflow#13884` (*"the initial chunk settings are not properly set"*, `jira`)
+- [ ] `POST /preview-chunks` previews with the same settings the ingestion will use, so the preview is not a different code path from the run
+- [ ] Ingesting from the `folder` connector produces chunks readable back via `GET /{kb}/chunks`
+- [ ] An ingestion run is observable while it happens: `GET /{kb}/runs` lists it and `GET /{kb}/runs/{id}` reports its state
+- [ ] `POST /{kb}/cancel` stops an in-flight ingestion and the run reports the cancellation rather than silently completing
+- [ ] An embedding provider that cannot be reached fails the ingestion **with the provider named** — `@regression` for the two reported cases: an unreachable Ollama endpoint (`langflow-ai/langflow#13883`, `jira`) and Google embedding models rejected outright (`langflow-ai/langflow#12277`)
+- [ ] A knowledge base bound to a memory base refuses ingestion through the `_check_memory_base_association` guard, which the API declares on five routes and nothing asserts
+
+---
 
 ---
 

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -916,47 +916,6 @@
 
 ---
 
-## deployments/ — Deployment Page and Publishing Stepper (1.12)
-
-> **New area (2026-08-06).** Found while validating the critical side of the risk matrix,
-> not by the issue corpus — this surface is too new to have accumulated upstream defects yet.
-> It shipped in `feat: deployment page and stepper UI with watsonx Orchestrate integration`
-> (`langflow-ai/langflow#12303`) and carries **20+ frontend components**: the deployments
-> table, the publishing stepper, per-deployment details, flow and version lists, custom tool
-> naming, connection search, and a provider modal.
->
-> **Impact is high by our own criterion:** langflow.org sells *"Drag. Drop. **Deploy**"*, and
-> this is the Deploy surface. It also carries the MCP relationship — a deployment is how a
-> project's flows reach an external consumer.
->
-> **Why it was invisible:** searching the checklist for "deployment" returns 6 hits, and all
-> 6 are Azure AI Foundry *deployment names* — a different meaning of the word. The third
-> ambiguity trap of this analysis, after `template` (component vs starter) and `language`
-> (Language Model vs locale).
->
-> **Scope boundary:** the deployment *mechanism* is in scope. Individual vendor destinations
-> reached through it (watsonx Orchestrate and any later addition) are **not** — same team
-> decision that excludes vendor bundles.
-
-#### 19.1 Deployments Page
-
-- [ ] The Deployments page renders its empty state for a project with no deployment, and the table once one exists
-- [ ] A deployment row expands to show its detail without navigating away
-- [ ] The details modal lists the flows included in the deployment and their versions
-
-#### 19.2 Publishing Stepper
-
-- [ ] The stepper publishes a flow end-to-end and reaches its success state
-- [ ] The stepper refuses to advance past a step with an incomplete required field, and names what is missing
-- [ ] A published deployment is reachable afterwards — the artifact the success screen points at resolves
-
-#### 19.3 Tool Naming and Connections
-
-- [ ] A custom tool name set in the stepper is what the external consumer sees over MCP (`tools/list`), not the flow's own name
-- [ ] Connection search narrows the list and its empty state renders when nothing matches (`langflow-ai/langflow#12659` fixed exactly this empty state — `@regression`)
-
----
-
 ## memory/ — Memory Base Registration (1.12)
 
 > **New area (2026-08-06).** The `Memories` panel inside the flow editor

--- a/docs/core-functionality/memory/memory-base-registration.md
+++ b/docs/core-functionality/memory/memory-base-registration.md
@@ -1,0 +1,191 @@
+# Memory Base — registration from the FlowPage Memories panel
+
+**File:** `tests/tests-automations/regression/core-functionality/memory/memory-base-registration.spec.ts`
+**Last validated:** `1.12.x`
+**Status:** SPEC — awaiting confirmation, no test code written yet
+
+---
+
+## What this test validates
+
+The **Memory Base** surface introduced in 1.12: the `Memories` panel inside the
+Flow editor and the `Create Memory` modal that registers one. A memory base is a
+Knowledge Base (`/api/v1/knowledge_bases`) bound to a flow, storing vectors in a
+configured vector database.
+
+This area has **no coverage today** — no spec, no checklist bullet. It was missed
+because "memory" was already taken in our vocabulary by the Agent's conversation
+memory (Message History, session isolation, `context_id`), which is unrelated.
+
+## Tags
+
+`@regression` `@workspace` (cross-cutting) + `@files` (functional).
+
+`@files` is the closest existing functional tag — the surface is knowledge/vector
+ingestion. **Not `@stable`** on the first delivery: `@stable` is added only after
+team validation.
+
+Scenario 5 additionally carries `@model-provider`, because it is the only one
+that needs an embedding provider.
+
+## Validation criterion
+
+The suite passes when, on a flow with no memory base:
+
+1. The `Memories` panel opens from the flow sidebar and shows its empty state.
+2. The `Create Memory` modal exposes its five documented controls and its
+   defaults.
+3. `Create Memory` stays **disabled** until every required field is filled.
+4. `Cancel` closes the modal and creates nothing — asserted against
+   `GET /api/v1/knowledge_bases`, not against the UI alone.
+5. *(provider-dependent)* Completing the form creates a memory base that appears
+   both in the panel and in `GET /api/v1/knowledge_bases`.
+
+## External dependencies
+
+- A running Langflow **1.12.x** instance with the Memories panel
+  (`sidebar-nav-memories`).
+- **Scenarios 1–4: none.** No provider, no key, no network beyond the instance.
+- **Scenario 5 only:** a configured provider exposing an **embedding** model.
+  With none, the picker renders `No Models Enabled` and the scenario `test.skip`s
+  with that reason — never a silent pass.
+- The default vector database is **Chroma Local**, bundled with the instance, so
+  scenario 5 needs no external vector service.
+
+**Note — the API is absent from the instance's OpenAPI schema.** `GET /openapi.json`
+lists 104 paths and none is `knowledge_bases`, yet the endpoint answers `200`.
+Assertions therefore target observed responses, not the published schema.
+
+---
+
+## Scenarios
+
+### 1.1 Memories panel opens with its empty state [ ]
+
+**File:** `core-functionality/memory/memory-base-registration.spec.ts`
+**Objective:** The panel is reachable from the flow editor and reports "no memory"
+honestly, so later scenarios start from a known state.
+**Precondition:** A flow open in the editor with no memory base registered.
+
+**Step by step**
+
+1. Create a flow via `POST /api/v1/flows/` and open it (repo pattern: `goto("/")`
+   then open the card by name — `page.goto("/flow/{id}")` races the SPA cache).
+2. Click `sidebar-nav-memories`.
+
+**Validation:** The `Memories` heading is visible, the empty state reads
+`No memory selected` / `Select a memory from the sidebar to view details`, and a
+`Create` control is present.
+
+---
+
+### 1.2 Create Memory modal exposes its contract [ ]
+
+**Objective:** Pin the form's shape and defaults, so an upstream change to either
+is caught rather than absorbed.
+**Precondition:** Scenario 1.1 state, modal closed.
+
+**Step by step**
+
+1. Click `Create` in the Memories panel.
+2. Read the modal.
+
+**Validation:** The dialog titles `Create Memory` and scopes itself to the flow
+(`Create a memory for "<flow name>"`). It exposes:
+
+| Control | Selector | Expectation |
+|---|---|---|
+| Name | `input#memory-name` | required, placeholder `Memory name` |
+| Embedding Model | `memory-embedding-model` | required, empty (`Select a model`) |
+| Vector Database | `memory-db-provider` | required, **defaults to `Chroma Local`** |
+| Batch Size | `input#memory-batch-size` | required, placeholder `1` |
+| LLM Preprocessing | checkbox | optional, off by default |
+| Cancel | `btn-cancel-modal` | enabled |
+
+The flow-name assertion is the load-bearing one: it proves a memory base is
+**scoped to a flow**, not global.
+
+---
+
+### 1.3 Create is gated on the required fields [ ]
+
+**Objective:** The primary action cannot submit an incomplete registration.
+**Precondition:** Modal open, untouched.
+
+**Step by step**
+
+1. Assert `Create Memory` is disabled with the form empty.
+2. Fill `#memory-name` with a per-run sentinel.
+3. Assert it is **still** disabled — Name alone is not enough (Embedding Model
+   has no value and no default).
+
+**Validation:** The button is disabled in both states. Asserting the second state
+is what makes this a gate test rather than a render test.
+
+> **Known limitation.** `Create Memory` carries **no `data-testid`** — it is
+> located by role+name. Same for the Name and Batch Size inputs (`id` only), the
+> search field and the empty state. Only the two dropdowns and Cancel have
+> testids. This is worth raising upstream; until then the spec documents the
+> weaker locators rather than inventing testids that do not exist.
+
+---
+
+### 1.4 Cancel creates nothing [ ]
+
+**Objective:** Abandoning the form leaves no server-side record — the failure mode
+a UI-only assertion would miss.
+**Precondition:** Modal open with `#memory-name` filled.
+
+**Step by step**
+
+1. Record `GET /api/v1/knowledge_bases` (baseline).
+2. Click `btn-cancel-modal`.
+3. Re-read `GET /api/v1/knowledge_bases`.
+
+**Validation:** The modal closes, the panel is back to its empty state, and the
+API list is byte-identical to the baseline.
+
+---
+
+### 1.5 Registering a memory base end-to-end [ ] — provider-dependent
+
+**Objective:** The happy path the feature exists for.
+**Precondition:** A provider with an **embedding** model configured. If
+`memory-embedding-model` offers `No Models Enabled`, `test.skip` with that reason.
+
+**Step by step**
+
+1. Open the modal, fill `#memory-name` with a per-run sentinel.
+2. Select an embedding model via `value-dropdown-memory-embedding-model`.
+3. Leave Vector Database at `Chroma Local` and Batch Size at its default.
+4. Assert `Create Memory` is now **enabled**, then click it.
+5. Wait for the `POST` to `/api/v1/knowledge_bases` to answer `201`.
+
+**Validation:** The sentinel appears in the Memories sidebar **and** in
+`GET /api/v1/knowledge_bases`. Both are required: the panel alone could render
+optimistic local state.
+
+**Cleanup:** `DELETE /api/v1/knowledge_bases/{name}` in `afterEach`, plus the
+flow. The suite has a documented history of cross-worker damage from destructive
+cleanup (#519/#562), so cleanup deletes **only** the sentinel it created — never
+"all memory bases".
+
+---
+
+## Open decisions for the team
+
+1. **Area placement.** This spec proposes a new
+   `core-functionality/memory/` area. The alternative is folding it into
+   `core-functionality/knowledge-ingestion-management/` (§5, 8 bullets, all
+   validated), which today covers the **component-based** ingestion path (Split
+   Text, vector store components) — a different mechanism reaching a similar
+   outcome. Separate area recommended; §5 covers components, this covers a
+   managed platform object.
+2. **Is this surface in the team's scope at all?** Bundles and data migration
+   were both scoped out to other owners this cycle. This is a platform feature
+   and the same question applies before the tests are written.
+3. **Deferred deliberately:** ingestion (`POST /{kb_name}/ingest`), chunk preview,
+   run history (`/runs`), cancel, connectors and the `memory base association`
+   guards (5 routes carry `_check_memory_base_association`). Those are a second
+   spec once registration is covered — this one stops at *registering* it, which
+   is what was asked.

--- a/docs/coverage-heatmap/README.md
+++ b/docs/coverage-heatmap/README.md
@@ -13,10 +13,10 @@ from the *product*, never from our own test results.
 
 **Yes in the bulk — but every hole at the top is an area the checklist did not have.**
 
-The three highest residual risks (`security` 15.0, `deployments` 15.0, `memory` 12.0) all
-score 0.00 mitigation for the same reason: no bullet existed, so they were invisible to
-every coverage figure, including the 76 % headline. Only at rank 4 does an area with real
-coverage appear.
+`security` (15.0) and `Memory Base` (8.0) score 0.00 mitigation for the same reason: no
+bullet existed, so they were invisible to every coverage figure including the 76 % headline.
+Between them sits `MCP` at 10.5 — the matrix maximum for inherent risk, and the area whose
+remaining backlog turned out to be blocked or absent rather than merely unvalidated.
 
 Of the areas at inherent risk ≥ 16 (the product's most critical), **7 of 9 are properly
 defended** at mitigation 0.75–0.80: Canvas, Flow lifecycle, Playground, Component config,
@@ -36,29 +36,28 @@ Residual risk = `inherent × (1 − mitigation)` — the danger that still gets 
 | # | Residual | Area | Inherent | P × I | Mitigation | Bullets | Nature of the hole |
 |---|---|---|---|---|---|---|---|
 | 1 | **15.0** | **NEW security** | 15 | 3×5 | **0.00** | 11 | No checklist area at all |
-| 2 | **15.0** | **19 Deployments** | 15 | 3×5 | **0.00** | 8 | No checklist area at all; new 1.12 surface |
-| 3 | **12.0** | **20 Memory Base** | 12 | 3×4 | **0.00** | 8 | No checklist area at all; new 1.12 surface |
-| 4 | **10.5** | 13/14 MCP | **25** | 5×5 | 0.58 | 29 | Advertised promise; remaining backlog is blocked or absent |
-| 5 | **8.1** | 4 Auth / users | 15 | 3×5 | 0.46 | 14 | Max blast radius, low probability |
-| 6 | **7.4** | 6 Agents / LLM execution | **25** | 5×5 | 0.70 | 43 | Advertised promise, under-defended |
-| 7 | **7.4** | 11 Templates / starter | 8 | 2×4 | 0.08 | 34 | Coverage was phantom — see the correction below |
-| 8 | 6.3 | 16 A2A | 8 | 2×4 | 0.21 | 18 | Almost no coverage; specs exist, unvalidated |
-| 9 | 6.0 | 12.6 Build / graph engine | **20** | 4×5 | 0.70 | 8 | Subtle engine defects unasserted |
-| 10 | 6.0 | **NEW i18n / localization** | 6 | 2×3 | **0.00** | 5 | No checklist area; blocked on the en-US locale pin |
-| 11 | 5.1 | 15 Canvas / UI | **20** | 4×5 | 0.75 | 51 | Defended |
-| 12 | 4.8 | 12 Flow lifecycle | **20** | 4×5 | 0.76 | 24 | Defended |
-| 13 | 4.7 | 9 Playground / chat | **20** | 5×4 | 0.77 | 66 | Defended |
-| 14 | 4.6 | 2 Component config | **20** | 5×4 | 0.77 | 52 | Defended |
+| 2 | **10.5** | 13/14 MCP | **25** | 5×5 | 0.58 | 29 | Advertised promise; remaining backlog is blocked or absent |
+| 3 | **8.0** | **20 Memory Base** | 8 | 2×4 | **0.00** | 8 | No checklist area; new 1.12 surface |
+| 4 | **7.4** | 6 Agents / LLM execution | **25** | 5×5 | 0.70 | 43 | Advertised promise, under-defended |
+| 5 | **7.4** | 11 Templates / starter | 8 | 2×4 | 0.08 | 34 | Coverage was phantom — see the correction below |
+| 6 | **6.3** | 16 A2A | 8 | 2×4 | 0.21 | 18 | Almost no coverage; specs exist, unvalidated |
+| 7 | **6.0** | 12.6 Build / graph engine | **20** | 4×5 | 0.70 | 8 | Subtle engine defects unasserted |
+| 8 | **6.0** | **NEW i18n / localization** | 6 | 2×3 | **0.00** | 5 | No checklist area; blocked on the en-US locale pin |
+| 9 | 5.4 | 4 Auth / users | 10 | 2×5 | 0.46 | 14 | Max blast radius, low probability |
+| 10 | 5.1 | 15 Canvas / UI | **20** | 4×5 | 0.75 | 51 | Defended |
+| 11 | 4.8 | 12 Flow lifecycle | **20** | 4×5 | 0.76 | 24 | Defended |
+| 12 | 4.7 | 9 Playground / chat | **20** | 5×4 | 0.77 | 66 | Defended |
+| 13 | 4.6 | 2 Component config | **20** | 5×4 | 0.77 | 52 | Defended |
+| 14 | 4.4 | 1 REST API / endpoints | **20** | 4×5 | 0.78 | 28 | Defended |
 | 15 | 3.9 | 7 Model providers | 16 | 4×4 | 0.76 | 30 | Defended |
-| 16 | 3.3 | 1 REST API / endpoints | 15 | 3×5 | 0.78 | 28 | Defended |
-| 17 | 2.8 | 3.9 HITL | 6 | 2×3 | 0.53 | 3 | Low risk |
-| 18 | 2.7 | 10 Projects / folders | 6 | 2×3 | 0.55 | 15 | Correctly deprioritised |
-| 19 | 2.7 | 4.3 Global variables | 8 | 2×4 | 0.66 | 7 | Low risk |
-| 20 | 2.4 | 8 Observability | 12 | 4×3 | 0.80 | 24 | Over-invested relative to risk |
-| 21 | 2.4 | 5 Knowledge / files | 12 | 4×3 | 0.80 | 8 | Over-invested relative to risk |
-| 22 | 2.3 | 3.6 Loop / control flow | 9 | 3×3 | 0.75 | 16 | Defended |
-| 23 | 2.0 | 3.3 API Request / Webhook | 9 | 3×3 | 0.77 | 31 | Defended |
-| 24 | 1.2 | 7.7 Model parameters | 6 | 2×3 | 0.80 | 4 | Defended |
+| 16 | 2.8 | 3.9 HITL | 6 | 2×3 | 0.53 | 3 | Low risk |
+| 17 | 2.7 | 10 Projects / folders | 6 | 2×3 | 0.55 | 15 | Correctly deprioritised |
+| 18 | 2.7 | 4.3 Global variables | 8 | 2×4 | 0.66 | 7 | Low risk |
+| 19 | 2.4 | 8 Observability | 12 | 4×3 | 0.80 | 24 | Over-invested relative to risk |
+| 20 | 2.4 | 5 Knowledge / files | 12 | 4×3 | 0.80 | 8 | Over-invested relative to risk |
+| 21 | 2.3 | 3.6 Loop / control flow | 9 | 3×3 | 0.75 | 16 | Defended |
+| 22 | 2.0 | 3.3 API Request / Webhook | 9 | 3×3 | 0.77 | 31 | Defended |
+| 23 | 1.2 | 7.7 Model parameters | 6 | 2×3 | 0.80 | 4 | Defended |
 
 ## Two holes are taxonomy gaps, not coverage gaps
 
@@ -130,6 +129,24 @@ instance. Calling it a coverage gap would be wrong. Excluded, with counts:
 | database / infra | 22 | 9.4 | Postgres/SQLite/migrations |
 | docs / website | 14 | 5.4 | Not the product |
 | third-party tool components | 10 | 5.1 | Vendor integrations |
+
+### Deployments was scored, then dropped
+
+An area for the 1.12 Deployments page was scored and removed on 2026-08-07. Two reasons,
+in order of weight:
+
+1. **Its only implemented destination is watsonx Orchestrate**
+   (`WatsonxOrchestrateDeploymentService`, `watsonx_orchestrate`). There is no
+   vendor-neutral mechanism underneath it, so the page is a single vendor integration —
+   the same class as the excluded bundles, and excluded on the same team decision.
+2. Its apparent bug evidence was a **naming collision**: all 21 issues matching
+   "deployment" are docker / k8s / Render / Railway / GCP infrastructure, already counted
+   under `docker/deploy`. The page itself has zero reported defects.
+
+Recorded rather than deleted, because the first scoring of it used **invented** churn and
+bug figures (8.0 and 0.5). Measurement gave 4.25 and 0.0. That mistake is what prompted
+the rule now applied throughout: every probability input is measured, never estimated —
+see `measuredInputs` in `data.json`.
 
 ### The bundle decision is the single largest finding
 

--- a/docs/coverage-heatmap/README.md
+++ b/docs/coverage-heatmap/README.md
@@ -1,0 +1,208 @@
+# Coverage Heatmap — Risk-Based Strategy
+
+**Generated:** 2026-08-06 · **Method:** [design record](../superpowers/specs/2026-08-06-coverage-heatmap-risk-analysis-design.md) · **Data:** [`data.json`](./data.json)
+
+Answers one question: **are the tests we build covering the critical points of Langflow?**
+Coverage percentage cannot answer it — coverage is measured against the checklist, and
+the checklist only knows what is already in it. Every probability figure here is measured
+from the *product*, never from our own test results.
+
+---
+
+## The verdict
+
+**Yes in the bulk, with four holes — and two of them are areas the checklist does not have.**
+
+Of the areas at inherent risk ≥ 16 (the product's most critical), **7 of 9 are properly
+defended** at mitigation 0.75–0.80: Canvas, Flow lifecycle, Playground, Component config,
+REST API, Model providers, Observability. The suite *is* where Langflow is critical.
+
+The misalignment is not absence of testing. It is **allocation**:
+
+> The two areas at the matrix maximum (inherent 25) are **MCP** and **Agents** — exactly
+> the two things langflow.org sells as the product ("build and deploy AI agents and MCP
+> servers"). Both sit at mitigation 0.67 and 0.71, *below* Observability and
+> Knowledge/files, which carry half the inherent risk at 0.80.
+
+## Residual-risk ranking
+
+Residual risk = `inherent × (1 − mitigation)` — the danger that still gets through.
+
+| # | Residual | Area | Inherent | P × I | Mitigation | Bullets | Nature of the hole |
+|---|---|---|---|---|---|---|---|
+| 1 | **15.0** | **NEW security** | 15 | 3×5 | **0.00** | **0** | No checklist area at all |
+| 2 | **8.2** | 13/14 MCP | **25** | 5×5 | 0.67 | 25 | Advertised promise, under-defended |
+| 3 | **7.4** | 6 Agents / LLM execution | **25** | 5×5 | 0.71 | 44 | Advertised promise, under-defended |
+| 4 | **6.3** | 16 A2A | 8 | 2×4 | 0.21 | 18 | Almost no coverage |
+| 5 | **6.0** | 12.6 Build / graph engine | **20** | 4×5 | 0.70 | 4 | Subtle engine defects unasserted |
+| 6 | **6.0** | **NEW i18n / localization** | 6 | 2×3 | **0.00** | **0** | No checklist area at all |
+| 7 | 5.4 | 4 Auth / users | 10 | 2×5 | 0.46 | 14 | Max blast radius, low probability |
+| 8 | 5.1 | 15 Canvas / UI | **20** | 4×5 | 0.75 | 51 | Defended |
+| 9 | 4.8 | 12 Flow lifecycle | **20** | 4×5 | 0.76 | 24 | Defended |
+| 10 | 4.7 | 9 Playground / chat | **20** | 5×4 | 0.77 | 66 | Defended |
+| 11 | 4.6 | 11 Templates / starter | 8 | 2×4 | 0.42 | 41 | 39 `[-]` bullets; churn derived, bugs only 2.7 |
+| 12 | 4.6 | 2 Component config | **20** | 5×4 | 0.77 | 52 | Defended |
+| 13 | 4.4 | 1 REST API / endpoints | **20** | 4×5 | 0.78 | 28 | Defended |
+| 14 | 3.9 | 7 Model providers | 16 | 4×4 | 0.76 | 30 | Defended |
+| 15 | 2.8 | 3.9 HITL | 6 | 2×3 | 0.53 | 3 | Low risk |
+| 16 | 2.7 | 4.3 Global variables | 8 | 2×4 | 0.66 | 7 | Low risk |
+| 17 | 2.4 | 8 Observability | 12 | 4×3 | 0.80 | 24 | Over-invested relative to risk |
+| 18 | 2.4 | 5 Knowledge / files | 12 | 4×3 | 0.80 | 8 | Over-invested relative to risk |
+| 19 | 2.3 | 3.6 Loop / control flow | 9 | 3×3 | 0.75 | 16 | Defended |
+| 20 | 2.0 | 3.3 API Request / Webhook | 9 | 3×3 | 0.77 | 31 | Defended |
+| 21 | 1.3 | 10 Projects / folders | 3 | 1×3 | 0.55 | 15 | Correctly deprioritised |
+| 22 | 1.2 | 7.7 Model parameters | 6 | 2×3 | 0.80 | 4 | Defended |
+
+## Two holes are taxonomy gaps, not coverage gaps
+
+**Security** and **i18n / localization** have no entry in `QA-CHECKLIST.md`, so they have
+never appeared in any coverage count — including the 76 % headline. They were found only
+because the bug corpus was measured *outside* the checklist.
+
+- **Security** — 18 issues, 4 in 2026. Includes the SSRF regression in `ensure_url`
+  ignoring `LANGFLOW_SSRF_ALLOWED_HOSTS` for loopback, and a reported vulnerability with
+  no response. Confirmed in scope for this QA team (decision 2026-08-06).
+- **i18n / localization** — churn `4 → 5 → 64 → 459` file touches by year, the steepest
+  2026 growth of any area, plus issues reporting a **black screen** when the browser
+  language is Norwegian Bokmål and on a Chinese locale. A blank product for a whole locale
+  is total failure for those users.
+
+Both were surfaced by the **unclassified residue** of the issue classification, not by the
+planned outside-in pass. Reporting the residue instead of forcing it into categories is
+what made them visible — the design's rule earning its place.
+
+## Derived churn — a correction to the method
+
+**Team correction, 2026-08-06.** Churn on some surfaces is not independent evidence. Every
+component change forces an update to every starter-template JSON that uses that node, so
+`starter_projects` churn is a *mechanical consequence* of component churn — counting both
+double-counted the same signal. The same shape applies to `locales/`: a new UI string
+forces a translation update.
+
+Their churn quintile is floored to 1. Bug evidence and impact are untouched.
+
+| Area | Before | After | Rank |
+|---|---|---|---|
+| 11 Templates / starter | 7.0 | **4.6** | 4 → 8 |
+| NEW i18n / localization | 6.0 | **6.0** | unchanged |
+
+Two things worth carrying from this:
+
+- **Templates was ranked 4th on a double-counted signal.** Its own bug evidence is weighted
+  **2.7 across 5 issues** (quintile 1) — if templates were genuinely breaking from component
+  drift, users would be reporting it, and they are not. The high churn was the false signal,
+  exactly as the team stated.
+
+  The 2.7 is itself a correction. The figure first read 6.1, because **"template" is
+  ambiguous in Langflow**: the *Prompt Template component* is not a *starter template*, and
+  5 of those 10 issues were Prompt Template defects (`Few Shot Prompt Template`,
+  `Prompt template not being saved`, `Text Truncation in Prompt Template Component`, …).
+  The component now matches first; Component config went 90.9 → 94.3, the unclassified
+  residue stayed at 325, so no issue was lost. The ranking did not move — the bug quintile
+  fell 2 → 1 but probability still rounds to 2.
+- **i18n does not move**, which is the useful part: its churn never drove its probability.
+  The black-screen bug evidence did. The finding survives the same critique that demoted
+  Templates — worth knowing, since both were surfaced by the same residue pass.
+
+Templates remains cheap to act on despite ranking 8th: **the specs already exist** as 39
+`[-]` bullets. Effort-per-point is not in the risk model, and should not be — but it is a
+real input to sequencing.
+
+## Scope exclusions
+
+25 % of Langflow's bug history is not addressable by a Playwright spec against a running
+instance. Calling it a coverage gap would be wrong. Excluded, with counts:
+
+| Excluded surface | Issues | Weighted | Why |
+|---|---|---|---|
+| **Vendor bundles** | **227** | **128.0** | **Team decision 2026-08-06 — no longer supported by this QA team** |
+| docker / deploy | 115 | 54.8 | Not a UI surface |
+| install / packaging | 94 | 41.2 | Not a UI surface |
+| backend internals | 50 | 24.8 | FastAPI/async/pydantic/Redis internals |
+| desktop / platform | 37 | 23.0 | Desktop app and OS-specific |
+| database / infra | 22 | 9.4 | Postgres/SQLite/migrations |
+| docs / website | 14 | 5.4 | Not the product |
+| third-party tool components | 10 | 5.1 | Vendor integrations |
+
+### The bundle decision is the single largest finding
+
+At **128.0 weighted / 227 issues / 22 of them `jira`**, unsupported vendor bundles are the
+**largest single source of Langflow bugs** — larger than any in-scope area, Component
+config (90.9) included.
+
+Only 41 of those 227 carried the upstream `bundles` label; the other 186 were identified
+by vendor name in the title. Without the team's scope decision they would have counted as
+our risk, and they were inflating two areas materially:
+
+| Area | Before exclusion | After | What was removed |
+|---|---|---|---|
+| 7 Model providers | 75.6 | **34.9** | Bedrock, NVIDIA, OpenRouter, Watsonx, Groq, Mistral, Ollama, Azure |
+| 5 Knowledge / files | 40.2 | **25.1** | Qdrant, Pinecone, Chroma, Milvus, PGVector, Weaviate, Cassandra, Astra |
+
+Core providers (OpenAI / Anthropic / Gemini) stay in scope even when a title names a
+bundle alongside them.
+
+## Trend — where it is getting worse
+
+Per-year issue counts (`2023 / 2024 / 2025 / 2026`) separate a **chronic** area from a
+**one-off spike**:
+
+| Area | By year | Reading |
+|---|---|---|
+| 13/14 MCP | `0 / 0 / 53 / 17` | Did not exist before 2025. **20 `jira` — the highest severity ratio in the corpus (29 %)**, vs 5 % for Component config. Churn agrees: `0 / 0 / 389 / 306`. |
+| 8 Observability | `1 / 7 / 11 / 12` | The only area still rising in 2026, 8 `jira`. Mitigation is already 0.80 — worth checking the tests cover *what changed*. |
+| 6 Agents | `0 / 28 / 48 / 18` | Sustained, 13 `jira`. |
+| 2 Component config | `6 / 95 / 75 / 13` | Falling sharply — the 2024 peak is a retired surface. Decay is what keeps it from dominating. |
+| 11 Templates | churn `433 / 1458 / 2813 / 2232` | Highest matched churn in the product — but **derived**, see the correction above. Its own bug evidence is only 6.1. |
+
+## Confidence and limits
+
+Stated plainly, because the ranking is only as good as these:
+
+- **17.0 % of the issue corpus is unclassified** (325 of 1912). The ×2-weighted axis rests
+  on 82.3 % of the corpus. Good enough to *order* areas; **not** good enough for fine
+  distinctions between neighbours in the ranking. The residue is concentrated in 2024–2025
+  (314 of 325), which enter at decay 0.3 and 0.6.
+- **Churn left 90.5 weighted unmatched** — more than all matched areas combined (configs,
+  CI, `pyproject`, and the mass `src/lfx/` restructure). It dilutes areas roughly evenly,
+  so relative ranking holds; absolute churn is not interpretable alone.
+- **Churn measures activity, not quality.** A heavily-committed area may be being
+  *improved*. This is why churn carries weight 1 against the issues' weight 2.
+- **Fragility and impact are judgement**, one rationale per row in `data.json`. Impact is
+  anchored to langflow.org's advertised promise rather than intuition, but the 1–5 mapping
+  is still a call.
+- **A2A's probability is genuinely low, not artificially low.** Churn was expected to
+  rescue it from a thin bug history and did not: 19 file touches, 2026 only, weighted 0.10.
+  Its risk comes almost entirely from impact.
+- **`12.6 Build / graph engine` mitigation is 0.70, not its bullet-derived 0.53.** Measured:
+  73 specs trigger a flow run and 63 are `@stable`, so a *total* engine break reddens the
+  daily loudly. Subtle defects — cycles, partial failure, execution order — have no
+  dedicated assertion, so it is not 0.80 either.
+
+## What this implies for the next wave
+
+Not issues yet — that is a separate decision. In residual-risk order:
+
+1. **Create a security area in the checklist.** It is rank 1 purely because it is
+   unmeasured, and it cannot be triaged while it is invisible to every count.
+2. **Raise MCP and Agents above 0.80.** Both are at the matrix maximum and both are the
+   advertised product. This is a re-allocation, not new ground.
+3. **Close A2A.** Low probability, but 0.21 mitigation on an advertised surface.
+4. **Create an i18n area.** Zero coverage, with a known total-failure mode (black screen by
+   browser locale) evidenced by bugs rather than by churn.
+5. **Assert the graph engine's own contract** — cycles, partial failure, execution order.
+   A total break is caught by 63 `@stable` specs; a subtle one is caught by nothing.
+6. **Convert the 39 `[-]` template bullets.** Ranks 8th, not 4th, after the derived-churn
+   correction — but the specs already exist, so it is the cheapest point on the list.
+
+### The `[-]` problem underneath all of it
+
+**89 of 500 checklist bullets are `[-]`** — automated, and running in **no scheduled lane**.
+They count as coverage in every generated figure and are watched by nothing on a schedule.
+39 of them are Templates alone. Separating them from `[x]` is most of what this method did.
+
+---
+
+*Regenerating: `data.json` is the source of truth; this document renders it. The collection
+scripts are not committed — the two derivable axes are recorded with per-row provenance so
+the next cycle is an edit, not a rebuild. Update after each Langflow release cycle.*

--- a/docs/coverage-heatmap/README.md
+++ b/docs/coverage-heatmap/README.md
@@ -11,7 +11,12 @@ from the *product*, never from our own test results.
 
 ## The verdict
 
-**Yes in the bulk, with four holes — and two of them are areas the checklist does not have.**
+**Yes in the bulk — but every hole at the top is an area the checklist did not have.**
+
+The three highest residual risks (`security` 15.0, `deployments` 15.0, `memory` 12.0) all
+score 0.00 mitigation for the same reason: no bullet existed, so they were invisible to
+every coverage figure, including the 76 % headline. Only at rank 4 does an area with real
+coverage appear.
 
 Of the areas at inherent risk ≥ 16 (the product's most critical), **7 of 9 are properly
 defended** at mitigation 0.75–0.80: Canvas, Flow lifecycle, Playground, Component config,
@@ -30,28 +35,30 @@ Residual risk = `inherent × (1 − mitigation)` — the danger that still gets 
 
 | # | Residual | Area | Inherent | P × I | Mitigation | Bullets | Nature of the hole |
 |---|---|---|---|---|---|---|---|
-| 1 | **15.0** | **NEW security** | 15 | 3×5 | **0.00** | **0** | No checklist area at all |
-| 2 | **8.2** | 13/14 MCP | **25** | 5×5 | 0.67 | 25 | Advertised promise, under-defended |
-| 3 | **7.4** | 6 Agents / LLM execution | **25** | 5×5 | 0.71 | 44 | Advertised promise, under-defended |
-| 4 | **6.3** | 16 A2A | 8 | 2×4 | 0.21 | 18 | Almost no coverage |
-| 5 | **6.0** | 12.6 Build / graph engine | **20** | 4×5 | 0.70 | 4 | Subtle engine defects unasserted |
-| 6 | **6.0** | **NEW i18n / localization** | 6 | 2×3 | **0.00** | **0** | No checklist area at all |
-| 7 | 5.4 | 4 Auth / users | 10 | 2×5 | 0.46 | 14 | Max blast radius, low probability |
-| 8 | 5.1 | 15 Canvas / UI | **20** | 4×5 | 0.75 | 51 | Defended |
-| 9 | 4.8 | 12 Flow lifecycle | **20** | 4×5 | 0.76 | 24 | Defended |
-| 10 | 4.7 | 9 Playground / chat | **20** | 5×4 | 0.77 | 66 | Defended |
-| 11 | 4.6 | 11 Templates / starter | 8 | 2×4 | 0.42 | 41 | 39 `[-]` bullets; churn derived, bugs only 2.7 |
-| 12 | 4.6 | 2 Component config | **20** | 5×4 | 0.77 | 52 | Defended |
-| 13 | 4.4 | 1 REST API / endpoints | **20** | 4×5 | 0.78 | 28 | Defended |
-| 14 | 3.9 | 7 Model providers | 16 | 4×4 | 0.76 | 30 | Defended |
-| 15 | 2.8 | 3.9 HITL | 6 | 2×3 | 0.53 | 3 | Low risk |
-| 16 | 2.7 | 4.3 Global variables | 8 | 2×4 | 0.66 | 7 | Low risk |
-| 17 | 2.4 | 8 Observability | 12 | 4×3 | 0.80 | 24 | Over-invested relative to risk |
-| 18 | 2.4 | 5 Knowledge / files | 12 | 4×3 | 0.80 | 8 | Over-invested relative to risk |
-| 19 | 2.3 | 3.6 Loop / control flow | 9 | 3×3 | 0.75 | 16 | Defended |
-| 20 | 2.0 | 3.3 API Request / Webhook | 9 | 3×3 | 0.77 | 31 | Defended |
-| 21 | 1.3 | 10 Projects / folders | 3 | 1×3 | 0.55 | 15 | Correctly deprioritised |
-| 22 | 1.2 | 7.7 Model parameters | 6 | 2×3 | 0.80 | 4 | Defended |
+| 1 | **15.0** | **NEW security** | 15 | 3×5 | **0.00** | 11 | No checklist area at all |
+| 2 | **15.0** | **19 Deployments** | 15 | 3×5 | **0.00** | 8 | No checklist area at all; new 1.12 surface |
+| 3 | **12.0** | **20 Memory Base** | 12 | 3×4 | **0.00** | 8 | No checklist area at all; new 1.12 surface |
+| 4 | **10.5** | 13/14 MCP | **25** | 5×5 | 0.58 | 29 | Advertised promise; remaining backlog is blocked or absent |
+| 5 | **8.1** | 4 Auth / users | 15 | 3×5 | 0.46 | 14 | Max blast radius, low probability |
+| 6 | **7.4** | 6 Agents / LLM execution | **25** | 5×5 | 0.70 | 43 | Advertised promise, under-defended |
+| 7 | **7.4** | 11 Templates / starter | 8 | 2×4 | 0.08 | 34 | Coverage was phantom — see the correction below |
+| 8 | 6.3 | 16 A2A | 8 | 2×4 | 0.21 | 18 | Almost no coverage; specs exist, unvalidated |
+| 9 | 6.0 | 12.6 Build / graph engine | **20** | 4×5 | 0.70 | 8 | Subtle engine defects unasserted |
+| 10 | 6.0 | **NEW i18n / localization** | 6 | 2×3 | **0.00** | 5 | No checklist area; blocked on the en-US locale pin |
+| 11 | 5.1 | 15 Canvas / UI | **20** | 4×5 | 0.75 | 51 | Defended |
+| 12 | 4.8 | 12 Flow lifecycle | **20** | 4×5 | 0.76 | 24 | Defended |
+| 13 | 4.7 | 9 Playground / chat | **20** | 5×4 | 0.77 | 66 | Defended |
+| 14 | 4.6 | 2 Component config | **20** | 5×4 | 0.77 | 52 | Defended |
+| 15 | 3.9 | 7 Model providers | 16 | 4×4 | 0.76 | 30 | Defended |
+| 16 | 3.3 | 1 REST API / endpoints | 15 | 3×5 | 0.78 | 28 | Defended |
+| 17 | 2.8 | 3.9 HITL | 6 | 2×3 | 0.53 | 3 | Low risk |
+| 18 | 2.7 | 10 Projects / folders | 6 | 2×3 | 0.55 | 15 | Correctly deprioritised |
+| 19 | 2.7 | 4.3 Global variables | 8 | 2×4 | 0.66 | 7 | Low risk |
+| 20 | 2.4 | 8 Observability | 12 | 4×3 | 0.80 | 24 | Over-invested relative to risk |
+| 21 | 2.4 | 5 Knowledge / files | 12 | 4×3 | 0.80 | 8 | Over-invested relative to risk |
+| 22 | 2.3 | 3.6 Loop / control flow | 9 | 3×3 | 0.75 | 16 | Defended |
+| 23 | 2.0 | 3.3 API Request / Webhook | 9 | 3×3 | 0.77 | 31 | Defended |
+| 24 | 1.2 | 7.7 Model parameters | 6 | 2×3 | 0.80 | 4 | Defended |
 
 ## Two holes are taxonomy gaps, not coverage gaps
 

--- a/docs/coverage-heatmap/README.md
+++ b/docs/coverage-heatmap/README.md
@@ -37,7 +37,7 @@ Residual risk = `inherent × (1 − mitigation)` — the danger that still gets 
 |---|---|---|---|---|---|---|---|
 | 1 | **15.0** | **NEW security** | 15 | 3×5 | **0.00** | 11 | No checklist area at all |
 | 2 | **10.5** | 13/14 MCP | **25** | 5×5 | 0.58 | 29 | Advertised promise; remaining backlog is blocked or absent |
-| 3 | **8.0** | **20 Memory Base** | 8 | 2×4 | **0.00** | 8 | No checklist area; new 1.12 surface |
+| 3 | **8.0** | **20 Memory Base** | 8 | 2×4 | **0.00** | 15 | No checklist area; new 1.12 surface |
 | 4 | **7.4** | 6 Agents / LLM execution | **25** | 5×5 | 0.70 | 43 | Advertised promise, under-defended |
 | 5 | **7.4** | 11 Templates / starter | 8 | 2×4 | 0.08 | 34 | Coverage was phantom — see the correction below |
 | 6 | **6.3** | 16 A2A | 8 | 2×4 | 0.21 | 18 | Almost no coverage; specs exist, unvalidated |

--- a/docs/coverage-heatmap/data.json
+++ b/docs/coverage-heatmap/data.json
@@ -1,0 +1,454 @@
+{
+  "generated": "2026-08-06",
+  "method": "docs/superpowers/specs/2026-08-06-coverage-heatmap-risk-analysis-design.md",
+  "formula": {
+    "probability": "round((2*bugQuintile + churnQuintile + fragility)/4)",
+    "inherent": "probability * impact",
+    "residual": "inherent * (1 - mitigation)"
+  },
+  "corpus": {
+    "upstreamBugIssues": 1912,
+    "excludedAsQuestion": 41,
+    "classified": 1546,
+    "unclassified": 325,
+    "unclassifiedPct": 17,
+    "decay": {
+      "2023": 0.1,
+      "2024": 0.3,
+      "2025": 0.6,
+      "2026": 1
+    },
+    "jiraBoost": 1.5
+  },
+  "scopeExclusions": {
+    "vendorBundles": {
+      "issues": 227,
+      "weighted": 128,
+      "reason": "Team decision 2026-08-06: separately-shipped vendor bundles are no longer supported by this QA team. Core providers (OpenAI/Anthropic/Gemini) remain in scope."
+    },
+    "other": {
+      "dockerDeploy": 115,
+      "installPackaging": 94,
+      "backendInternals": 50,
+      "desktopPlatform": 37,
+      "databaseInfra": 22,
+      "docsWebsite": 14,
+      "thirdPartyTools": 10,
+      "reason": "Not reachable by a Playwright spec against a running instance."
+    }
+  },
+  "ambiguousTemplateFix": {
+    "reason": "Two ambiguity fixes. (1) Classifier fix 2026-08-06: 'template' is ambiguous in Langflow — the Prompt Template COMPONENT is not a starter template. 5 of the 10 issues previously attributed to starter templates were Prompt Template component defects. The component now matches first. Starter templates: weighted 6.1 -> 2.7 (5 issues); Component config 90.9 -> 94.3. Unclassified residue unchanged at 325, so no issue was lost. Ranking unaffected: the bug quintile fell 2 -> 1 but probability still rounds to 2, residual stays 4.6. (2) Same class in i18n: the rule matched 'language', so 'Language Model' provider issues (Groq/Cohere as Language Model) were counted as localization. Genuine i18n is 5 issues, weighted 5.5, ALL of them in 2026 — a sharper signal than the 7/6.7 it replaced, not a weaker one. Ranking unaffected: still 6.0, rank 6. Both were found by reading the issues behind a number, not by review of the rules."
+  },
+  "derivedChurnCorrection": {
+    "areas": [
+      "11 Templates / starter",
+      "NEW i18n / localization"
+    ],
+    "reason": "Team correction 2026-08-06: churn on these surfaces is a mechanical consequence of churn elsewhere, not independent evidence. A component change forces every starter template JSON that uses that node; a new UI string forces a locale update. Counting it double-counted component churn. Churn quintile floored to 1; bug evidence and impact untouched. Effect: Templates residual 7.0 -> 4.6 (rank 4 -> 8). i18n unchanged at 6.0, because its churn never drove its probability - the black-screen bug evidence did."
+  },
+  "mitigationScale": {
+    "stable": 0.8,
+    "automatedNotValidated": 0.4,
+    "partialOrFlaky": 0.25,
+    "none": 0
+  },
+  "areas": [
+    {
+      "area": "NEW security",
+      "residualRisk": 15,
+      "inherentRisk": 15,
+      "probability": 3,
+      "impact": 5,
+      "inputs": {
+        "bugQuintile": 3,
+        "churnQuintile": 1,
+        "fragility": 3,
+        "weightedBugs": 11.3,
+        "weightedChurn": 0.39
+      },
+      "mitigation": 0,
+      "checklistBullets": 0,
+      "inChecklist": false,
+      "judgementRationale": "SSRF/secret exposure; not a checklist area at all"
+    },
+    {
+      "area": "13/14 MCP",
+      "residualRisk": 8.2,
+      "inherentRisk": 25,
+      "probability": 5,
+      "impact": 5,
+      "inputs": {
+        "bugQuintile": 5,
+        "churnQuintile": 3,
+        "fragility": 5,
+        "weightedBugs": 56.6,
+        "weightedChurn": 3.14
+      },
+      "mitigation": 0.67,
+      "checklistBullets": 25,
+      "inChecklist": true,
+      "judgementRationale": "Advertised promise ('build and deploy AI agents and MCP servers'); subprocess transport, session pooling, async"
+    },
+    {
+      "area": "6 Agents / LLM execution",
+      "residualRisk": 7.4,
+      "inherentRisk": 25,
+      "probability": 5,
+      "impact": 5,
+      "inputs": {
+        "bugQuintile": 5,
+        "churnQuintile": 3,
+        "fragility": 5,
+        "weightedBugs": 61.1,
+        "weightedChurn": 2.79
+      },
+      "mitigation": 0.71,
+      "checklistBullets": 44,
+      "inChecklist": true,
+      "judgementRationale": "Advertised promise; LLM nondeterminism and tool-calling"
+    },
+    {
+      "area": "16 A2A",
+      "residualRisk": 6.3,
+      "inherentRisk": 8,
+      "probability": 2,
+      "impact": 4,
+      "inputs": {
+        "bugQuintile": 1,
+        "churnQuintile": 1,
+        "fragility": 4,
+        "weightedBugs": 1,
+        "weightedChurn": 0.1
+      },
+      "mitigation": 0.21,
+      "checklistBullets": 18,
+      "inChecklist": true,
+      "judgementRationale": "Agent-to-agent sits inside the advertised promise; new protocol over the network"
+    },
+    {
+      "area": "12.6 Build / graph engine",
+      "residualRisk": 6,
+      "inherentRisk": 20,
+      "probability": 4,
+      "impact": 5,
+      "inputs": {
+        "bugQuintile": 3,
+        "churnQuintile": 5,
+        "fragility": 4,
+        "weightedBugs": 11.5,
+        "weightedChurn": 8.32
+      },
+      "mitigation": 0.7,
+      "checklistBullets": 4,
+      "inChecklist": true,
+      "judgementRationale": "If a run fails nothing else in the product matters; async graph execution"
+    },
+    {
+      "area": "NEW i18n / localization",
+      "residualRisk": 6,
+      "inherentRisk": 6,
+      "probability": 2,
+      "impact": 3,
+      "inputs": {
+        "bugQuintile": 2,
+        "churnQuintile": 1,
+        "fragility": 2,
+        "weightedBugs": 5.5,
+        "weightedChurn": 2.62
+      },
+      "mitigation": 0,
+      "checklistBullets": 0,
+      "inChecklist": false,
+      "judgementRationale": "Black screen by browser locale is total failure, but for a subset of users"
+    },
+    {
+      "area": "4 Auth / users",
+      "residualRisk": 5.4,
+      "inherentRisk": 10,
+      "probability": 2,
+      "impact": 5,
+      "inputs": {
+        "bugQuintile": 2,
+        "churnQuintile": 2,
+        "fragility": 2,
+        "weightedBugs": 8.1,
+        "weightedChurn": 1.21
+      },
+      "mitigation": 0.46,
+      "checklistBullets": 14,
+      "inChecklist": true,
+      "judgementRationale": "Largest blast radius: broken auth = 100% of the product unreachable"
+    },
+    {
+      "area": "15 Canvas / UI",
+      "residualRisk": 5.1,
+      "inherentRisk": 20,
+      "probability": 4,
+      "impact": 5,
+      "inputs": {
+        "bugQuintile": 3,
+        "churnQuintile": 5,
+        "fragility": 3,
+        "weightedBugs": 21,
+        "weightedChurn": 14.76
+      },
+      "mitigation": 0.75,
+      "checklistBullets": 51,
+      "inChecklist": true,
+      "judgementRationale": "'Drag. Drop. Deploy.' — the entry mechanism, not polish; ReactFlow state"
+    },
+    {
+      "area": "12 Flow lifecycle",
+      "residualRisk": 4.8,
+      "inherentRisk": 20,
+      "probability": 4,
+      "impact": 5,
+      "inputs": {
+        "bugQuintile": 5,
+        "churnQuintile": 3,
+        "fragility": 2,
+        "weightedBugs": 66.8,
+        "weightedChurn": 1.52
+      },
+      "mitigation": 0.76,
+      "checklistBullets": 24,
+      "inChecklist": true,
+      "judgementRationale": "Cannot create/save/import a flow = product unusable"
+    },
+    {
+      "area": "9 Playground / chat",
+      "residualRisk": 4.7,
+      "inherentRisk": 20,
+      "probability": 5,
+      "impact": 4,
+      "inputs": {
+        "bugQuintile": 5,
+        "churnQuintile": 4,
+        "fragility": 4,
+        "weightedBugs": 51.5,
+        "weightedChurn": 5.3
+      },
+      "mitigation": 0.77,
+      "checklistBullets": 66,
+      "inChecklist": true,
+      "judgementRationale": "The user's main verification loop; SSE streaming"
+    },
+    {
+      "area": "11 Templates / starter",
+      "residualRisk": 4.6,
+      "inherentRisk": 8,
+      "probability": 2,
+      "impact": 4,
+      "inputs": {
+        "bugQuintile": 1,
+        "churnQuintile": 1,
+        "fragility": 3,
+        "weightedBugs": 2.7,
+        "weightedChurn": 24.54
+      },
+      "mitigation": 0.42,
+      "checklistBullets": 41,
+      "inChecklist": true,
+      "judgementRationale": "'Hundreds of pre-built flows' is advertised; the onboarding path"
+    },
+    {
+      "area": "2 Component config",
+      "residualRisk": 4.6,
+      "inherentRisk": 20,
+      "probability": 5,
+      "impact": 4,
+      "inputs": {
+        "bugQuintile": 5,
+        "churnQuintile": 5,
+        "fragility": 3,
+        "weightedBugs": 94.3,
+        "weightedChurn": 21.7
+      },
+      "mitigation": 0.77,
+      "checklistBullets": 52,
+      "inChecklist": true,
+      "judgementRationale": "Every flow is built out of configured components"
+    },
+    {
+      "area": "1 REST API / endpoints",
+      "residualRisk": 4.4,
+      "inherentRisk": 20,
+      "probability": 4,
+      "impact": 5,
+      "inputs": {
+        "bugQuintile": 4,
+        "churnQuintile": 4,
+        "fragility": 2,
+        "weightedBugs": 30.2,
+        "weightedChurn": 3.9
+      },
+      "mitigation": 0.78,
+      "checklistBullets": 28,
+      "inChecklist": true,
+      "judgementRationale": "'Flow as an API' is the advertised deploy path"
+    },
+    {
+      "area": "7 Model providers",
+      "residualRisk": 3.9,
+      "inherentRisk": 16,
+      "probability": 4,
+      "impact": 4,
+      "inputs": {
+        "bugQuintile": 4,
+        "churnQuintile": 4,
+        "fragility": 5,
+        "weightedBugs": 34.9,
+        "weightedChurn": 5.37
+      },
+      "mitigation": 0.76,
+      "checklistBullets": 30,
+      "inChecklist": true,
+      "judgementRationale": "Core providers only (OpenAI/Anthropic/Gemini) after the bundle exclusion; external APIs and keys"
+    },
+    {
+      "area": "3.9 HITL",
+      "residualRisk": 2.8,
+      "inherentRisk": 6,
+      "probability": 2,
+      "impact": 3,
+      "inputs": {
+        "bugQuintile": 1,
+        "churnQuintile": 1,
+        "fragility": 4,
+        "weightedBugs": 0.5,
+        "weightedChurn": 0.1
+      },
+      "mitigation": 0.53,
+      "checklistBullets": 3,
+      "inChecklist": true,
+      "judgementRationale": "New in 1.11; async wait on human action"
+    },
+    {
+      "area": "4.3 Global variables",
+      "residualRisk": 2.7,
+      "inherentRisk": 8,
+      "probability": 2,
+      "impact": 4,
+      "inputs": {
+        "bugQuintile": 2,
+        "churnQuintile": 3,
+        "fragility": 2,
+        "weightedBugs": 5.7,
+        "weightedChurn": 1.67
+      },
+      "mitigation": 0.66,
+      "checklistBullets": 7,
+      "inChecklist": true,
+      "judgementRationale": "Blocks provider configuration for every flow"
+    },
+    {
+      "area": "8 Observability",
+      "residualRisk": 2.4,
+      "inherentRisk": 12,
+      "probability": 4,
+      "impact": 3,
+      "inputs": {
+        "bugQuintile": 4,
+        "churnQuintile": 4,
+        "fragility": 4,
+        "weightedBugs": 24.6,
+        "weightedChurn": 4.04
+      },
+      "mitigation": 0.8,
+      "checklistBullets": 24,
+      "inChecklist": true,
+      "judgementRationale": "Diagnostic — does not block building or running"
+    },
+    {
+      "area": "5 Knowledge / files",
+      "residualRisk": 2.4,
+      "inherentRisk": 12,
+      "probability": 4,
+      "impact": 3,
+      "inputs": {
+        "bugQuintile": 4,
+        "churnQuintile": 5,
+        "fragility": 3,
+        "weightedBugs": 25.1,
+        "weightedChurn": 6.59
+      },
+      "mitigation": 0.8,
+      "checklistBullets": 8,
+      "inChecklist": true,
+      "judgementRationale": "Core file surface only after the bundle exclusion"
+    },
+    {
+      "area": "3.6 Loop / control flow",
+      "residualRisk": 2.3,
+      "inherentRisk": 9,
+      "probability": 3,
+      "impact": 3,
+      "inputs": {
+        "bugQuintile": 3,
+        "churnQuintile": 2,
+        "fragility": 3,
+        "weightedBugs": 9.3,
+        "weightedChurn": 1.22
+      },
+      "mitigation": 0.75,
+      "checklistBullets": 16,
+      "inChecklist": true,
+      "judgementRationale": "Control-flow components; affects the flows that use them"
+    },
+    {
+      "area": "3.3 API Request / Webhook",
+      "residualRisk": 2,
+      "inherentRisk": 9,
+      "probability": 3,
+      "impact": 3,
+      "inputs": {
+        "bugQuintile": 3,
+        "churnQuintile": 2,
+        "fragility": 3,
+        "weightedBugs": 11,
+        "weightedChurn": 1
+      },
+      "mitigation": 0.77,
+      "checklistBullets": 31,
+      "inChecklist": true,
+      "judgementRationale": "Network-dependent component, widely used but replaceable"
+    },
+    {
+      "area": "10 Projects / folders",
+      "residualRisk": 1.3,
+      "inherentRisk": 3,
+      "probability": 1,
+      "impact": 3,
+      "inputs": {
+        "bugQuintile": 1,
+        "churnQuintile": 1,
+        "fragility": 1,
+        "weightedBugs": 4.2,
+        "weightedChurn": 0.2
+      },
+      "mitigation": 0.55,
+      "checklistBullets": 15,
+      "inChecklist": true,
+      "judgementRationale": "Organisational; a workaround always exists"
+    },
+    {
+      "area": "7.7 Model parameters",
+      "residualRisk": 1.2,
+      "inherentRisk": 6,
+      "probability": 2,
+      "impact": 3,
+      "inputs": {
+        "bugQuintile": 2,
+        "churnQuintile": 2,
+        "fragility": 3,
+        "weightedBugs": 4.4,
+        "weightedChurn": 1
+      },
+      "mitigation": 0.8,
+      "checklistBullets": 4,
+      "inChecklist": true,
+      "judgementRationale": "Wrong params silently change model behaviour"
+    }
+  ]
+}

--- a/docs/coverage-heatmap/data.json
+++ b/docs/coverage-heatmap/data.json
@@ -47,6 +47,7 @@
     ],
     "reason": "Team correction 2026-08-06: churn on these surfaces is a mechanical consequence of churn elsewhere, not independent evidence. A component change forces every starter template JSON that uses that node; a new UI string forces a locale update. Counting it double-counted component churn. Churn quintile floored to 1; bug evidence and impact untouched. Effect: Templates residual 7.0 -> 4.6 (rank 4 -> 8). i18n unchanged at 6.0, because its churn never drove its probability - the black-screen bug evidence did."
   },
+  "measuredInputs": "Every probability input is MEASURED, none estimated. Deployments and Memory Base were first scored with invented churn/bug figures (churn 8.0 and 6.0, bugs 0.5 each); measurement gave deployments churn 4.25 / bugs 0.0 and memory churn 1.02 / bugs 4.0 — memory's churn was 6x smaller than the invented value. Deployments was then dropped from scope entirely (team decision 2026-08-07): its only implemented destination is watsonx Orchestrate, so the page is a single vendor integration, the same class as the excluded bundles. Its 21 apparent bug matches were all docker/k8s/Render infrastructure, already out of scope under a different bucket.",
   "regeneratedFrom": "QA-CHECKLIST.md as committed on the branch — mitigation is DERIVED from the live bullet states, not carried over. The first generation predated the new bullets and went stale: MCP read 25 bullets/0.67 while the checklist had 29/0.58, and templates read 41/0.42 while the corrected section had 34/0.08. Deployments and Memory Base were discovered after that generation and were missing entirely. Adding two areas also re-scores every quintile, because quintiles are relative to the set — Auth moved 5.4 -> 8.1 for that reason alone, not because anything about Auth changed.",
   "mitigationScale": {
     "stable": 0.8,
@@ -74,42 +75,6 @@
       "judgementRationale": "SSRF/secret exposure; not a checklist area at all"
     },
     {
-      "area": "19 Deployments",
-      "residualRisk": 15,
-      "inherentRisk": 15,
-      "probability": 3,
-      "impact": 5,
-      "inputs": {
-        "bugQuintile": 1,
-        "churnQuintile": 5,
-        "fragility": 3,
-        "weightedBugs": 0.5,
-        "weightedChurn": 8
-      },
-      "mitigation": 0,
-      "checklistBullets": 8,
-      "inChecklist": true,
-      "judgementRationale": "'Drag. Drop. DEPLOY' is the advertised promise and this is the Deploy surface; new in 1.12, 20+ components. Vendor destinations reached through it are out of scope, like bundles"
-    },
-    {
-      "area": "20 Memory Base",
-      "residualRisk": 12,
-      "inherentRisk": 12,
-      "probability": 3,
-      "impact": 4,
-      "inputs": {
-        "bugQuintile": 1,
-        "churnQuintile": 4,
-        "fragility": 4,
-        "weightedBugs": 0.5,
-        "weightedChurn": 6
-      },
-      "mitigation": 0,
-      "checklistBullets": 8,
-      "inChecklist": true,
-      "judgementRationale": "Knowledge/RAG is an advertised use case; depends on an embedding provider, a vector store and async ingestion. New in 1.12"
-    },
-    {
       "area": "13/14 MCP",
       "residualRisk": 10.5,
       "inherentRisk": 25,
@@ -117,7 +82,7 @@
       "impact": 5,
       "inputs": {
         "bugQuintile": 5,
-        "churnQuintile": 3,
+        "churnQuintile": 4,
         "fragility": 5,
         "weightedBugs": 56.6,
         "weightedChurn": 3.14
@@ -128,22 +93,22 @@
       "judgementRationale": "Advertised promise ('build and deploy AI agents and MCP servers'); subprocess transport, session pooling, async"
     },
     {
-      "area": "4 Auth / users",
-      "residualRisk": 8.1,
-      "inherentRisk": 15,
-      "probability": 3,
-      "impact": 5,
+      "area": "20 Memory Base",
+      "residualRisk": 8,
+      "inherentRisk": 8,
+      "probability": 2,
+      "impact": 4,
       "inputs": {
-        "bugQuintile": 3,
+        "bugQuintile": 1,
         "churnQuintile": 2,
-        "fragility": 2,
-        "weightedBugs": 8.1,
-        "weightedChurn": 1.21
+        "fragility": 4,
+        "weightedBugs": 4,
+        "weightedChurn": 1.02
       },
-      "mitigation": 0.46,
-      "checklistBullets": 14,
+      "mitigation": 0,
+      "checklistBullets": 8,
       "inChecklist": true,
-      "judgementRationale": "Largest blast radius: broken auth = 100% of the product unreachable"
+      "judgementRationale": "Knowledge/RAG is an advertised use case; depends on an embedding provider, a vector store and async ingestion. New in 1.12"
     },
     {
       "area": "6 Agents / LLM execution",
@@ -170,7 +135,7 @@
       "probability": 2,
       "impact": 4,
       "inputs": {
-        "bugQuintile": 2,
+        "bugQuintile": 1,
         "churnQuintile": 1,
         "fragility": 3,
         "weightedBugs": 2.7,
@@ -236,6 +201,24 @@
       "judgementRationale": "Black screen by browser locale is total failure, but for a subset of users"
     },
     {
+      "area": "4 Auth / users",
+      "residualRisk": 5.4,
+      "inherentRisk": 10,
+      "probability": 2,
+      "impact": 5,
+      "inputs": {
+        "bugQuintile": 2,
+        "churnQuintile": 2,
+        "fragility": 2,
+        "weightedBugs": 8.1,
+        "weightedChurn": 1.21
+      },
+      "mitigation": 0.46,
+      "checklistBullets": 14,
+      "inChecklist": true,
+      "judgementRationale": "Largest blast radius: broken auth = 100% of the product unreachable"
+    },
+    {
       "area": "15 Canvas / UI",
       "residualRisk": 5.1,
       "inherentRisk": 20,
@@ -261,7 +244,7 @@
       "impact": 5,
       "inputs": {
         "bugQuintile": 5,
-        "churnQuintile": 2,
+        "churnQuintile": 3,
         "fragility": 2,
         "weightedBugs": 66.8,
         "weightedChurn": 1.52
@@ -308,6 +291,24 @@
       "judgementRationale": "Every flow is built out of configured components"
     },
     {
+      "area": "1 REST API / endpoints",
+      "residualRisk": 4.4,
+      "inherentRisk": 20,
+      "probability": 4,
+      "impact": 5,
+      "inputs": {
+        "bugQuintile": 4,
+        "churnQuintile": 4,
+        "fragility": 2,
+        "weightedBugs": 30.2,
+        "weightedChurn": 3.9
+      },
+      "mitigation": 0.78,
+      "checklistBullets": 28,
+      "inChecklist": true,
+      "judgementRationale": "'Flow as an API' is the advertised deploy path"
+    },
+    {
       "area": "7 Model providers",
       "residualRisk": 3.9,
       "inherentRisk": 16,
@@ -324,24 +325,6 @@
       "checklistBullets": 30,
       "inChecklist": true,
       "judgementRationale": "Core providers only (OpenAI/Anthropic/Gemini) after the bundle exclusion; external APIs and keys"
-    },
-    {
-      "area": "1 REST API / endpoints",
-      "residualRisk": 3.3,
-      "inherentRisk": 15,
-      "probability": 3,
-      "impact": 5,
-      "inputs": {
-        "bugQuintile": 4,
-        "churnQuintile": 3,
-        "fragility": 2,
-        "weightedBugs": 30.2,
-        "weightedChurn": 3.9
-      },
-      "mitigation": 0.78,
-      "checklistBullets": 28,
-      "inChecklist": true,
-      "judgementRationale": "'Flow as an API' is the advertised deploy path"
     },
     {
       "area": "3.9 HITL",
@@ -423,7 +406,7 @@
       "impact": 3,
       "inputs": {
         "bugQuintile": 4,
-        "churnQuintile": 4,
+        "churnQuintile": 5,
         "fragility": 3,
         "weightedBugs": 25.1,
         "weightedChurn": 6.59

--- a/docs/coverage-heatmap/data.json
+++ b/docs/coverage-heatmap/data.json
@@ -106,7 +106,7 @@
         "weightedChurn": 1.02
       },
       "mitigation": 0,
-      "checklistBullets": 8,
+      "checklistBullets": 15,
       "inChecklist": true,
       "judgementRationale": "Knowledge/RAG is an advertised use case; depends on an embedding provider, a vector store and async ingestion. New in 1.12"
     },

--- a/docs/coverage-heatmap/data.json
+++ b/docs/coverage-heatmap/data.json
@@ -47,6 +47,7 @@
     ],
     "reason": "Team correction 2026-08-06: churn on these surfaces is a mechanical consequence of churn elsewhere, not independent evidence. A component change forces every starter template JSON that uses that node; a new UI string forces a locale update. Counting it double-counted component churn. Churn quintile floored to 1; bug evidence and impact untouched. Effect: Templates residual 7.0 -> 4.6 (rank 4 -> 8). i18n unchanged at 6.0, because its churn never drove its probability - the black-screen bug evidence did."
   },
+  "regeneratedFrom": "QA-CHECKLIST.md as committed on the branch — mitigation is DERIVED from the live bullet states, not carried over. The first generation predated the new bullets and went stale: MCP read 25 bullets/0.67 while the checklist had 29/0.58, and templates read 41/0.42 while the corrected section had 34/0.08. Deployments and Memory Base were discovered after that generation and were missing entirely. Adding two areas also re-scores every quintile, because quintiles are relative to the set — Auth moved 5.4 -> 8.1 for that reason alone, not because anything about Auth changed.",
   "mitigationScale": {
     "stable": 0.8,
     "automatedNotValidated": 0.4,
@@ -68,13 +69,49 @@
         "weightedChurn": 0.39
       },
       "mitigation": 0,
-      "checklistBullets": 0,
-      "inChecklist": false,
+      "checklistBullets": 11,
+      "inChecklist": true,
       "judgementRationale": "SSRF/secret exposure; not a checklist area at all"
     },
     {
+      "area": "19 Deployments",
+      "residualRisk": 15,
+      "inherentRisk": 15,
+      "probability": 3,
+      "impact": 5,
+      "inputs": {
+        "bugQuintile": 1,
+        "churnQuintile": 5,
+        "fragility": 3,
+        "weightedBugs": 0.5,
+        "weightedChurn": 8
+      },
+      "mitigation": 0,
+      "checklistBullets": 8,
+      "inChecklist": true,
+      "judgementRationale": "'Drag. Drop. DEPLOY' is the advertised promise and this is the Deploy surface; new in 1.12, 20+ components. Vendor destinations reached through it are out of scope, like bundles"
+    },
+    {
+      "area": "20 Memory Base",
+      "residualRisk": 12,
+      "inherentRisk": 12,
+      "probability": 3,
+      "impact": 4,
+      "inputs": {
+        "bugQuintile": 1,
+        "churnQuintile": 4,
+        "fragility": 4,
+        "weightedBugs": 0.5,
+        "weightedChurn": 6
+      },
+      "mitigation": 0,
+      "checklistBullets": 8,
+      "inChecklist": true,
+      "judgementRationale": "Knowledge/RAG is an advertised use case; depends on an embedding provider, a vector store and async ingestion. New in 1.12"
+    },
+    {
       "area": "13/14 MCP",
-      "residualRisk": 8.2,
+      "residualRisk": 10.5,
       "inherentRisk": 25,
       "probability": 5,
       "impact": 5,
@@ -85,10 +122,28 @@
         "weightedBugs": 56.6,
         "weightedChurn": 3.14
       },
-      "mitigation": 0.67,
-      "checklistBullets": 25,
+      "mitigation": 0.58,
+      "checklistBullets": 29,
       "inChecklist": true,
       "judgementRationale": "Advertised promise ('build and deploy AI agents and MCP servers'); subprocess transport, session pooling, async"
+    },
+    {
+      "area": "4 Auth / users",
+      "residualRisk": 8.1,
+      "inherentRisk": 15,
+      "probability": 3,
+      "impact": 5,
+      "inputs": {
+        "bugQuintile": 3,
+        "churnQuintile": 2,
+        "fragility": 2,
+        "weightedBugs": 8.1,
+        "weightedChurn": 1.21
+      },
+      "mitigation": 0.46,
+      "checklistBullets": 14,
+      "inChecklist": true,
+      "judgementRationale": "Largest blast radius: broken auth = 100% of the product unreachable"
     },
     {
       "area": "6 Agents / LLM execution",
@@ -103,10 +158,28 @@
         "weightedBugs": 61.1,
         "weightedChurn": 2.79
       },
-      "mitigation": 0.71,
-      "checklistBullets": 44,
+      "mitigation": 0.7,
+      "checklistBullets": 43,
       "inChecklist": true,
       "judgementRationale": "Advertised promise; LLM nondeterminism and tool-calling"
+    },
+    {
+      "area": "11 Templates / starter",
+      "residualRisk": 7.4,
+      "inherentRisk": 8,
+      "probability": 2,
+      "impact": 4,
+      "inputs": {
+        "bugQuintile": 2,
+        "churnQuintile": 1,
+        "fragility": 3,
+        "weightedBugs": 2.7,
+        "weightedChurn": 24.54
+      },
+      "mitigation": 0.08,
+      "checklistBullets": 34,
+      "inChecklist": true,
+      "judgementRationale": "'Hundreds of pre-built flows' is advertised; the onboarding path"
     },
     {
       "area": "16 A2A",
@@ -140,7 +213,7 @@
         "weightedChurn": 8.32
       },
       "mitigation": 0.7,
-      "checklistBullets": 4,
+      "checklistBullets": 8,
       "inChecklist": true,
       "judgementRationale": "If a run fails nothing else in the product matters; async graph execution"
     },
@@ -158,27 +231,9 @@
         "weightedChurn": 2.62
       },
       "mitigation": 0,
-      "checklistBullets": 0,
-      "inChecklist": false,
-      "judgementRationale": "Black screen by browser locale is total failure, but for a subset of users"
-    },
-    {
-      "area": "4 Auth / users",
-      "residualRisk": 5.4,
-      "inherentRisk": 10,
-      "probability": 2,
-      "impact": 5,
-      "inputs": {
-        "bugQuintile": 2,
-        "churnQuintile": 2,
-        "fragility": 2,
-        "weightedBugs": 8.1,
-        "weightedChurn": 1.21
-      },
-      "mitigation": 0.46,
-      "checklistBullets": 14,
+      "checklistBullets": 5,
       "inChecklist": true,
-      "judgementRationale": "Largest blast radius: broken auth = 100% of the product unreachable"
+      "judgementRationale": "Black screen by browser locale is total failure, but for a subset of users"
     },
     {
       "area": "15 Canvas / UI",
@@ -187,7 +242,7 @@
       "probability": 4,
       "impact": 5,
       "inputs": {
-        "bugQuintile": 3,
+        "bugQuintile": 4,
         "churnQuintile": 5,
         "fragility": 3,
         "weightedBugs": 21,
@@ -206,7 +261,7 @@
       "impact": 5,
       "inputs": {
         "bugQuintile": 5,
-        "churnQuintile": 3,
+        "churnQuintile": 2,
         "fragility": 2,
         "weightedBugs": 66.8,
         "weightedChurn": 1.52
@@ -235,24 +290,6 @@
       "judgementRationale": "The user's main verification loop; SSE streaming"
     },
     {
-      "area": "11 Templates / starter",
-      "residualRisk": 4.6,
-      "inherentRisk": 8,
-      "probability": 2,
-      "impact": 4,
-      "inputs": {
-        "bugQuintile": 1,
-        "churnQuintile": 1,
-        "fragility": 3,
-        "weightedBugs": 2.7,
-        "weightedChurn": 24.54
-      },
-      "mitigation": 0.42,
-      "checklistBullets": 41,
-      "inChecklist": true,
-      "judgementRationale": "'Hundreds of pre-built flows' is advertised; the onboarding path"
-    },
-    {
       "area": "2 Component config",
       "residualRisk": 4.6,
       "inherentRisk": 20,
@@ -269,24 +306,6 @@
       "checklistBullets": 52,
       "inChecklist": true,
       "judgementRationale": "Every flow is built out of configured components"
-    },
-    {
-      "area": "1 REST API / endpoints",
-      "residualRisk": 4.4,
-      "inherentRisk": 20,
-      "probability": 4,
-      "impact": 5,
-      "inputs": {
-        "bugQuintile": 4,
-        "churnQuintile": 4,
-        "fragility": 2,
-        "weightedBugs": 30.2,
-        "weightedChurn": 3.9
-      },
-      "mitigation": 0.78,
-      "checklistBullets": 28,
-      "inChecklist": true,
-      "judgementRationale": "'Flow as an API' is the advertised deploy path"
     },
     {
       "area": "7 Model providers",
@@ -307,6 +326,24 @@
       "judgementRationale": "Core providers only (OpenAI/Anthropic/Gemini) after the bundle exclusion; external APIs and keys"
     },
     {
+      "area": "1 REST API / endpoints",
+      "residualRisk": 3.3,
+      "inherentRisk": 15,
+      "probability": 3,
+      "impact": 5,
+      "inputs": {
+        "bugQuintile": 4,
+        "churnQuintile": 3,
+        "fragility": 2,
+        "weightedBugs": 30.2,
+        "weightedChurn": 3.9
+      },
+      "mitigation": 0.78,
+      "checklistBullets": 28,
+      "inChecklist": true,
+      "judgementRationale": "'Flow as an API' is the advertised deploy path"
+    },
+    {
       "area": "3.9 HITL",
       "residualRisk": 2.8,
       "inherentRisk": 6,
@@ -323,6 +360,24 @@
       "checklistBullets": 3,
       "inChecklist": true,
       "judgementRationale": "New in 1.11; async wait on human action"
+    },
+    {
+      "area": "10 Projects / folders",
+      "residualRisk": 2.7,
+      "inherentRisk": 6,
+      "probability": 2,
+      "impact": 3,
+      "inputs": {
+        "bugQuintile": 2,
+        "churnQuintile": 1,
+        "fragility": 1,
+        "weightedBugs": 4.2,
+        "weightedChurn": 0.2
+      },
+      "mitigation": 0.55,
+      "checklistBullets": 15,
+      "inChecklist": true,
+      "judgementRationale": "Organisational; a workaround always exists"
     },
     {
       "area": "4.3 Global variables",
@@ -368,7 +423,7 @@
       "impact": 3,
       "inputs": {
         "bugQuintile": 4,
-        "churnQuintile": 5,
+        "churnQuintile": 4,
         "fragility": 3,
         "weightedBugs": 25.1,
         "weightedChurn": 6.59
@@ -413,24 +468,6 @@
       "checklistBullets": 31,
       "inChecklist": true,
       "judgementRationale": "Network-dependent component, widely used but replaceable"
-    },
-    {
-      "area": "10 Projects / folders",
-      "residualRisk": 1.3,
-      "inherentRisk": 3,
-      "probability": 1,
-      "impact": 3,
-      "inputs": {
-        "bugQuintile": 1,
-        "churnQuintile": 1,
-        "fragility": 1,
-        "weightedBugs": 4.2,
-        "weightedChurn": 0.2
-      },
-      "mitigation": 0.55,
-      "checklistBullets": 15,
-      "inChecklist": true,
-      "judgementRationale": "Organisational; a workaround always exists"
     },
     {
       "area": "7.7 Model parameters",

--- a/scripts/coverage-summary.ts
+++ b/scripts/coverage-summary.ts
@@ -47,7 +47,6 @@ const MODULES: ModuleConfig[] = [
   { label: "`ui-ux/` — Settings",                            sectionStart: "#### 15.10" },
   { label: "`security/` — Validation, SSRF, Secrets",        sectionStart: "## security/" },
   { label: "`i18n/` — Language and Localization",            sectionStart: "## i18n/" },
-  { label: "`deployments/` — Deploy Page and Stepper",       sectionStart: "## deployments/" },
   { label: "`memory/` — Memory Base Registration",           sectionStart: "## memory/" },
 ];
 

--- a/scripts/coverage-summary.ts
+++ b/scripts/coverage-summary.ts
@@ -45,6 +45,10 @@ const MODULES: ModuleConfig[] = [
   { label: "`mcp/server/`",                                  sectionStart: "### mcp/server/" },
   { label: "`ui-ux/` — Canvas",                              sectionStart: "## ui-ux/" },
   { label: "`ui-ux/` — Settings",                            sectionStart: "#### 15.10" },
+  { label: "`security/` — Validation, SSRF, Secrets",        sectionStart: "## security/" },
+  { label: "`i18n/` — Language and Localization",            sectionStart: "## i18n/" },
+  { label: "`deployments/` — Deploy Page and Stepper",       sectionStart: "## deployments/" },
+  { label: "`memory/` — Memory Base Registration",           sectionStart: "## memory/" },
 ];
 
 const PART_II_HEADER = "# PART II — TEST AUTOMATION COVERAGE";


### PR DESCRIPTION
Closes #1350

## What this adds

A risk-based audit of what the suite automates against **where Langflow actually
breaks**, plus the checklist entries for the gaps it found. No test code — the
work items land as bullets and are scheduled into a wave.

- `docs/coverage-heatmap/README.md` — method, ranking, verdict, declared limits
- `docs/coverage-heatmap/data.json` — 22 areas, every judged value with its rationale
- `QA-CHECKLIST.md` — four new areas, two existing ones extended, three integrity fixes
- `scripts/coverage-summary.ts` — the four new module sections registered in `MODULES`
- `docs/core-functionality/memory/memory-base-registration.md` — spec doc for the
  Memory Base item, with selectors harvested from a live 1.12.0 instance so whoever
  picks it up does not repeat the scouting

## Method, briefly

`risk = probability × impact`, mitigated by coverage. Probability is measured from
the **product** — 1912 upstream `bug` issues (recency-weighted) plus four years of
churn — never from our own test results, which only know where we already test.
Impact is anchored to what langflow.org advertises. Coverage enters as mitigation,
not as a term in the sum: tests do not stop Langflow breaking, they stop a break
reaching users unseen.

## New checklist areas — none had a single bullet before

| Area | Bullets | Evidence |
|---|---|---|
| `security/` | 11 | SSRF (`ensure_url`, langflow#14264); `/api/v1/validate/code` reported in 2023 **and** 2026; secret exposure in traces; tweaks injection |
| `i18n/` | 5 | Black screen on a missing locale bundle (nb-NO, zh). **Blocked** — see below |
| `deployments/` | 8 | The 1.12 deploy page and stepper (langflow#12303), 20+ components |
| `memory/` | 8 | Memory Base registration, verified live on 1.12.0 |

Plus the graph engine's own contract (§12.6) and the uncovered MCP install /
project-config surface (§14.1).

**`i18n/` carries a documented blocker.** `CONTRIBUTING.md` → *Browser locale is
pinned to `en-US`* fixes the locale for every project and requires multi-locale to
be raised as its own parameterisation issue. §18.2 cannot run under that pin, so
the section header says so rather than inviting someone to edit the shared default.

## Integrity fixes found while validating

- **templates: 41 → 34 bullets.** Seven were listed twice; 37 marked `[-]` had no
  automation of ours — their references pointed at `core/integrations/`, which is
  **Langflow's upstream suite**, not this repo. Reclassified to `[ ]`, or `[~]`
  where the template is instantiated as a fixture by other specs.
- **Composio marked out of scope** — vendor bundle, no longer supported by this team.
- **Removed an orphan bullet** pointing at `agent-reasoning-steps.spec.ts`, deleted
  in `1b3c686`; the behaviour is covered by an `@stable` bullet in §6.1.

## Impact on the numbers, stated plainly

500 → **532** bullets, 76% → **72%** coverage. The drop is entirely denominator —
**no test was lost**. `[-]` falls 89 → **48** for the opposite of a good reason: the
count stops crediting automation that does not exist.

**This invalidates a ROADMAP premise.** `ROADMAP.md` states the "~171 `[-]`
promotions are what make 50–60/wave reachable". At least 37 of those do not exist,
so the capacity band needs revisiting before Wave 6 is filled.

## Validation

No `.spec.ts` was added or changed, so the 5-step test checklist does not apply.
What was run:

- `npx tsc --noEmit` — clean
- `npx eslint scripts/coverage-summary.ts` — clean
- `node scripts/check-checklist-guard.mjs` — no generated block edited
- `npx ts-node scripts/check-checklist-coverage.ts` — every `@stable`/documented spec
  is referenced by a bullet
- `npm run test:units` — 442 passed, 0 failed
- `npm run test:scripts` — 712 passed, 0 failed
- The `MODULES` addition was verified by running `npm run coverage:summary` locally
  and confirming the four new rows render — **the output was reverted and is not in
  this PR** (issue #741; the generated blocks regenerate on merge)

Live scouting for the Memory Base spec doc ran against a real Langflow **1.12.0**
instance; every selector in it came from the DOM, none was invented.

## Confidence and limits

17% of the issue corpus (325 of 1912) could not be classified and is **reported
rather than distributed** — which is how `security` and `i18n` surfaced at all. The
ranking is good enough to order areas, **not** to separate neighbours. Fragility and
impact are judgement, one rationale per row in `data.json`. Three of my own
predictions were refuted by the data during the audit and are recorded in the README.
