### PR TITLE
fix(collect-models): wait for the credential write, not for a clock (#1355)

### DIFF
--- a/tests/helpers/provider-setup/collect-models.test.ts
+++ b/tests/helpers/provider-setup/collect-models.test.ts
@@ -32,8 +32,10 @@ import assert from "node:assert/strict";
 import * as fs from "fs";
 import * as path from "path";
 import {
+  formatSaveBusyFailure,
   rankCandidates,
   validateProviderWithFallback,
+  waitForButtonIdle,
   type ProviderRecord,
 } from "./collect-models";
 
@@ -476,4 +478,123 @@ test("google is unchanged — its entries are already the flash tier", () => {
 test("an unknown provider falls back to raw catalog order rather than dropping models", () => {
   const catalog = ["b", "a", "c"];
   assert.deepEqual(rankCandidates("groq", catalog), catalog);
+});
+
+// ─── waitForButtonIdle / formatSaveBusyFailure (#1355) ────────────────────────
+//
+// The incident these cover: `Collect models` failed twice in a row with
+// `locator.click: Timeout 20000ms exceeded` on a `Save` button the log itself
+// showed as `aria-busy="true" aria-disabled="true"` — the PREVIOUS provider's
+// validation still in flight. The click's own actionability wait is capped
+// below the ~35s a Google validation takes, so a slow-but-healthy save read as
+// a broken button, and the error named the wrong step.
+//
+// Driven with an injected clock and a fake locator: the real failure needs a
+// funded key and a slow backend, neither of which a unit lane has. What IS
+// unit-testable is the decision — when the wait gives up, and what it reports.
+
+/** A locator whose attribute/enabled readings are scripted per poll. */
+function fakeButton(states: Array<{ ariaBusy?: string | null; ariaDisabled?: string | null; enabled?: boolean }>) {
+  let poll = -1;
+  const at = () => states[Math.min(poll, states.length - 1)] ?? {};
+  return {
+    reads: () => poll + 1,
+    getAttribute: async (name: string) => {
+      // aria-busy is read first in each poll, so advance the cursor there.
+      if (name === "aria-busy") poll += 1;
+      const s = at();
+      return name === "aria-busy" ? (s.ariaBusy ?? null) : (s.ariaDisabled ?? null);
+    },
+    isEnabled: async () => at().enabled ?? true,
+  };
+}
+
+/** A clock that only advances when the code under test sleeps. */
+function fakeClock() {
+  let t = 0;
+  return {
+    now: () => t,
+    sleep: async (ms: number) => {
+      t += ms;
+    },
+  };
+}
+
+test("#1355: an already-idle button is answered on the first poll, without sleeping", async () => {
+  const clock = fakeClock();
+  const verdict = await waitForButtonIdle(fakeButton([{}]), { ...clock, timeoutMs: 60_000 });
+  assert.equal(verdict.idle, true);
+  assert.equal(verdict.polls, 1);
+  assert.equal(verdict.waitedMs, 0, "a ready button must not cost the caller any wall clock");
+});
+
+test("#1355: a busy button that settles is waited out rather than failed", async () => {
+  const clock = fakeClock();
+  const button = fakeButton([
+    { ariaBusy: "true", ariaDisabled: "true" },
+    { ariaBusy: "true", ariaDisabled: "true" },
+    {},
+  ]);
+  const verdict = await waitForButtonIdle(button, { ...clock, timeoutMs: 60_000, pollMs: 250 });
+  assert.equal(verdict.idle, true);
+  assert.equal(verdict.polls, 3);
+  assert.equal(verdict.waitedMs, 500, "two sleeps of 250ms — this is the ~35s validation being ridden out");
+});
+
+test("#1355: a button busy past the deadline gives up and reports WHY, naming the provider", async () => {
+  const clock = fakeClock();
+  const verdict = await waitForButtonIdle(fakeButton([{ ariaBusy: "true", ariaDisabled: "true" }]), {
+    ...clock,
+    timeoutMs: 1_000,
+    pollMs: 250,
+  });
+  assert.equal(verdict.idle, false);
+  assert.equal(verdict.ariaBusy, "true");
+
+  const message = formatSaveBusyFailure("anthropic", verdict);
+  assert.match(message, /provider "anthropic"/);
+  assert.match(message, /aria-busy\s+true/);
+  assert.match(message, /still BUSY/);
+  assert.match(
+    message,
+    /PREVIOUS provider's/,
+    "the whole point of the message: the busy button is a symptom of the provider before it",
+  );
+});
+
+test("#1355: aria-disabled alone is not idle, and reads as the not-modelled state", async () => {
+  const clock = fakeClock();
+  const verdict = await waitForButtonIdle(fakeButton([{ ariaDisabled: "true" }]), {
+    ...clock,
+    timeoutMs: 500,
+    pollMs: 250,
+  });
+  assert.equal(verdict.idle, false);
+  const message = formatSaveBusyFailure("google", verdict);
+  assert.match(message, /not busy, but not actionable/);
+  assert.doesNotMatch(message, /still BUSY/);
+});
+
+test("#1355: clean aria attributes with a really-disabled button is still not idle", async () => {
+  const clock = fakeClock();
+  const verdict = await waitForButtonIdle(fakeButton([{ enabled: false }]), {
+    ...clock,
+    timeoutMs: 500,
+    pollMs: 250,
+  });
+  assert.equal(
+    verdict.idle,
+    false,
+    "aria-disabled is advisory markup and isEnabled() reads the real state — either alone blocks the click",
+  );
+  assert.equal(verdict.enabled, false);
+});
+
+test("#1355: a zero timeout still OBSERVES once instead of reporting a state it never read", async () => {
+  const clock = fakeClock();
+  const button = fakeButton([{ ariaBusy: "true" }]);
+  const verdict = await waitForButtonIdle(button, { ...clock, timeoutMs: 0, pollMs: 250 });
+  assert.equal(verdict.polls, 1, "#1012: an unobserved state is unknown, never clean");
+  assert.equal(verdict.idle, false);
+  assert.equal(verdict.ariaBusy, "true");
 });

--- a/tests/helpers/provider-setup/collect-models.test.ts
+++ b/tests/helpers/provider-setup/collect-models.test.ts
@@ -36,6 +36,7 @@ import {
   rankCandidates,
   validateProviderWithFallback,
   waitForButtonIdle,
+  waitForToggleChecked,
   type ProviderRecord,
 } from "./collect-models";
 
@@ -597,4 +598,72 @@ test("#1355: a zero timeout still OBSERVES once instead of reporting a state it 
   assert.equal(verdict.polls, 1, "#1012: an unobserved state is unknown, never clean");
   assert.equal(verdict.idle, false);
   assert.equal(verdict.ariaBusy, "true");
+});
+
+// ─── waitForToggleChecked (#1355, second half) ────────────────────────────────
+//
+// The measured cause behind the busy Save: enabling a model is a WRITE, and the
+// collector enables every model of every provider. With a funded OpenAI key the
+// panel exposes 41 visible models where a drained key exposed none worth
+// toggling, so one provider went from ~0 writes to 41 against a backend the
+// lanes run with LANGFLOW_WORKERS=1 — and the NEXT provider's Save queued behind
+// them and never settled. Confirming each toggle is what serialises them.
+
+/** A toggle whose `aria-checked` readings are scripted per poll. */
+function fakeToggle(readings: Array<string | null>) {
+  let i = -1;
+  return {
+    getAttribute: async () => {
+      i += 1;
+      return readings[Math.min(i, readings.length - 1)] ?? null;
+    },
+  };
+}
+
+test("#1355: a toggle already checked confirms on the first poll, without sleeping", async () => {
+  const clock = fakeClock();
+  const result = await waitForToggleChecked(fakeToggle(["true"]), { ...clock, timeoutMs: 5_000 });
+  assert.equal(result.checked, true);
+  assert.equal(result.polls, 1);
+  assert.equal(result.waitedMs, 0, "the healthy path must not add wall clock per model");
+});
+
+test("#1355: a toggle that lands a moment later is waited out, serialising the write", async () => {
+  const clock = fakeClock();
+  const result = await waitForToggleChecked(fakeToggle(["false", "false", "true"]), {
+    ...clock,
+    timeoutMs: 5_000,
+    pollMs: 100,
+  });
+  assert.equal(result.checked, true);
+  assert.equal(result.polls, 3);
+  assert.equal(result.waitedMs, 200);
+});
+
+test("#1355: a toggle that never confirms gives up at its own timeout and says so", async () => {
+  const clock = fakeClock();
+  const result = await waitForToggleChecked(fakeToggle(["false"]), {
+    ...clock,
+    timeoutMs: 500,
+    pollMs: 100,
+  });
+  assert.equal(result.checked, false);
+  assert.ok(result.waitedMs >= 500, "must not return before its own deadline");
+});
+
+test("#1355: waitedMs is what lets the caller bound the SUM, not just each write", async () => {
+  // The per-item timeout never sees the total. 41 toggles each taking 5s would
+  // spend 205s and blow the spec's own 5-minute budget, so the caller subtracts
+  // `waitedMs` from an aggregate budget — this asserts the field it needs to do
+  // that is real, and measured, not a constant.
+  const clock = fakeClock();
+  const slow = await waitForToggleChecked(fakeToggle(["false", "false", "true"]), {
+    ...clock,
+    timeoutMs: 5_000,
+    pollMs: 250,
+  });
+  const fast = await waitForToggleChecked(fakeToggle(["true"]), { ...fakeClock(), timeoutMs: 5_000 });
+  assert.equal(slow.waitedMs, 500);
+  assert.equal(fast.waitedMs, 0);
+  assert.ok(slow.waitedMs > fast.waitedMs, "a slow confirmation must cost the budget more than a fast one");
 });

--- a/tests/helpers/provider-setup/collect-models.ts
+++ b/tests/helpers/provider-setup/collect-models.ts
@@ -384,6 +384,20 @@ const TOGGLE_CONFIRM_TIMEOUT_MS = 5_000;
 const TOGGLE_CONFIRM_BUDGET_MS = 60_000;
 const TOGGLE_CONFIRM_POLL_MS = 100;
 
+/**
+ * Ceiling for the credential write a `Save` click issues (#1355).
+ *
+ * Measured, not guessed: with a funded OpenAI key, `POST /api/v1/variables/`
+ * answered 201 for all three providers, but anthropic's did not return until
+ * past 60s — which is exactly how long the previous version of this code spent
+ * waiting on the button before giving up on a request that was merely in
+ * flight. The cost grows with how many providers are already configured, so the
+ * ceiling is set well clear of the worst measurement rather than just above it.
+ *
+ * It is a backstop, not the mechanism: the wait ends when the response lands.
+ */
+const CREDENTIAL_SAVE_TIMEOUT_MS = 180_000;
+
 /** The `Locator` surface {@link waitForButtonIdle} reads — narrow so the unit lane can drive it with a fake. */
 export interface ButtonStateLocator {
   getAttribute(name: string): Promise<string | null>;
@@ -562,7 +576,60 @@ async function collectModelsForProvider(
       // click, for a provider that was never the problem.
       const verdict = await waitForButtonIdle(saveBtn);
       if (!verdict.idle) throw new Error(formatSaveBusyFailure(providerName, verdict));
+
+      // Wait for the credential WRITE itself, not for a clock (#1355).
+      //
+      // This is the measurement that settled it, taken locally with a funded
+      // OpenAI key and every `/api/v1/variables/` response logged: all three
+      // saves answer **201** — none is rejected — but anthropic's POST does not
+      // come back until AFTER the 60s the previous version of this code spent
+      // waiting on the button. So the request was never failing; it was in
+      // flight, and the form stays busy for as long as it is. Every fixed
+      // timeout here is a guess at a duration that grows with the number of
+      // providers already configured.
+      //
+      // Registered BEFORE the click, or the response can land first and be
+      // missed. Resolves to `null` on timeout rather than throwing: the save may
+      // still have succeeded, the `Disconnect` check below is the second opinion,
+      // and this helper's job is to report rather than to abort the pre-flight.
+      const savePending = page
+        .waitForResponse(
+          (r) => {
+            const method = r.request().method();
+            return (
+              /^\/api\/v1\/variables\/?$/.test(new URL(r.url()).pathname) &&
+              (method === "POST" || method === "PATCH" || method === "PUT")
+            );
+          },
+          { timeout: CREDENTIAL_SAVE_TIMEOUT_MS },
+        )
+        .catch(() => null);
+      const startedAt = Date.now();
       await saveBtn.click();
+      const saveResponse = await savePending;
+      const elapsedMs = Date.now() - startedAt;
+
+      if (!saveResponse) {
+        console.warn(
+          `⚠️  collect-models: no credential write observed for provider "${providerName}" within ` +
+            `${CREDENTIAL_SAVE_TIMEOUT_MS / 1000}s of clicking Save. The panel stays busy while a write is ` +
+            `in flight, so the NEXT provider is what pays for this (#1355).`,
+        );
+      } else if (!saveResponse.ok()) {
+        console.warn(
+          `⚠️  collect-models: the credential write for provider "${providerName}" answered ` +
+            `HTTP ${saveResponse.status()} after ${(elapsedMs / 1000).toFixed(1)}s. Its models will not ` +
+            `collect (#1355).`,
+        );
+      } else if (elapsedMs > 10_000) {
+        // Not a failure — a trend. The save cost grows with how many providers
+        // are already configured, and this line is what makes that visible
+        // before it crosses the ceiling again.
+        console.log(
+          `   collect-models: provider "${providerName}" credential write took ` +
+            `${(elapsedMs / 1000).toFixed(1)}s (HTTP ${saveResponse.status()}).`,
+        );
+      }
     }
 
     // Provider validation can take ~35s (Google) — wait for the configured state
@@ -600,18 +667,19 @@ async function collectModelsForProvider(
   const models: ModelRecord[] = [];
 
   // Each enable is a WRITE, and this loop used to fire them as fast as the clicks
-  // land (#1355). That is what wedges the panel: with a funded OpenAI key the
-  // provider exposes 41 visible models where a drained one exposed none worth
-  // toggling, so a single provider went from ~0 writes to 41 against a backend
-  // the lanes run with `LANGFLOW_WORKERS=1`. The NEXT provider's Save then queues
-  // behind them and never settles — measured as anthropic never reaching its
-  // configured state within 60s, and google's Save still `aria-busy` 60s after
-  // that.
+  // land. Confirming each one before moving on serialises them.
   //
-  // Confirming each toggle before moving on is what serialises them. The pair of
-  // bounds mirrors the token-attribution sidecar (#1197 §4.4): a per-toggle
-  // timeout bounds ONE write, and an aggregate budget bounds the sum — a
-  // per-item timeout alone would let 41 slow-but-succeeding writes spend
+  // Honest about what this is worth: it was added believing these 41 writes were
+  // what wedged the next provider's Save, and the very next CI run REFUTED that —
+  // the failure was byte-identical with the serialisation in place. The measured
+  // cause is the credential write above, which stays in flight past 60s. This is
+  // kept because a burst of 41 unconfirmed writes against a backend the lanes run
+  // with `LANGFLOW_WORKERS=1` is worth avoiding on its own and costs nothing
+  // measurable (23.9s against 24.9s locally) — not because it fixed anything.
+  //
+  // The pair of bounds mirrors the token-attribution sidecar (#1197 §4.4): a
+  // per-toggle timeout bounds ONE write, and an aggregate budget bounds the sum —
+  // a per-item timeout alone would let 41 slow-but-succeeding writes spend
   // 41 x TIMEOUT and blow the spec's own 5-minute budget.
   //
   // Past the budget the clicks CONTINUE unconfirmed: enabling a model is still

--- a/tests/helpers/provider-setup/collect-models.ts
+++ b/tests/helpers/provider-setup/collect-models.ts
@@ -357,6 +357,121 @@ async function collectProviders(
 
 // ─── Model collection (UI navigation) ─────────────────────────────────────────
 
+/**
+ * How long to wait for the `Save` button to become actionable (#1355).
+ *
+ * Sized against the validation this file already documents as the slowest
+ * (~35s for Google), not against Playwright's actionability ceiling: the click
+ * that used to happen here carried the default 20s, which is SHORTER than a
+ * provider validation, so a save that was merely slow read as a broken button.
+ *
+ * Over-waiting is nearly free — the wait only costs time on a run that is
+ * already headed for a red, and the alternative is the whole lane aborting.
+ */
+const SAVE_IDLE_TIMEOUT_MS = 60_000;
+const SAVE_IDLE_POLL_MS = 250;
+
+/** The `Locator` surface {@link waitForButtonIdle} reads — narrow so the unit lane can drive it with a fake. */
+export interface ButtonStateLocator {
+  getAttribute(name: string): Promise<string | null>;
+  isEnabled(): Promise<boolean>;
+}
+
+export interface ButtonIdleVerdict {
+  /** Every condition held: not busy, not aria-disabled, and enabled. */
+  idle: boolean;
+  ariaBusy: string | null;
+  ariaDisabled: string | null;
+  enabled: boolean;
+  waitedMs: number;
+  polls: number;
+}
+
+/**
+ * Poll a button until it is genuinely actionable, and REPORT what it observed
+ * either way (#1355).
+ *
+ * Why this exists rather than leaning on `click()`'s own actionability check:
+ * the providers panel marks `Save` with `aria-busy="true" aria-disabled="true"`
+ * while a save/validation is in flight — including the PREVIOUS provider's,
+ * since this file walks the providers in a loop. `click()` does wait for
+ * "enabled and stable", but with a ceiling shorter than the validation and,
+ * when it expires, an error naming the CLICK. That sent the reader to the wrong
+ * line: the button was fine, the provider before it had not settled.
+ *
+ * It returns a verdict instead of throwing so the caller can name the provider
+ * — this function does not know which one it is looking at — and so the whole
+ * decision is unit-testable without a browser.
+ *
+ * `enabled` is read LAST and only when the aria attributes look clean: the two
+ * are different claims (`aria-disabled` is advisory markup, `isEnabled()` reads
+ * the real disabled state) and a button can carry either alone.
+ */
+export async function waitForButtonIdle(
+  button: ButtonStateLocator,
+  options: {
+    timeoutMs?: number;
+    pollMs?: number;
+    now?: () => number;
+    sleep?: (ms: number) => Promise<void>;
+  } = {},
+): Promise<ButtonIdleVerdict> {
+  const timeoutMs = options.timeoutMs ?? SAVE_IDLE_TIMEOUT_MS;
+  const pollMs = options.pollMs ?? SAVE_IDLE_POLL_MS;
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+
+  const startedAt = now();
+  let polls = 0;
+  let ariaBusy: string | null = null;
+  let ariaDisabled: string | null = null;
+  let enabled = false;
+
+  // A do/while, so a button that is already idle is answered on the first poll
+  // and a zero timeout still measures once rather than reporting a state it
+  // never looked at (#1012: an unobserved state is unknown, not clean).
+  do {
+    polls += 1;
+    ariaBusy = await button.getAttribute("aria-busy");
+    ariaDisabled = await button.getAttribute("aria-disabled");
+    enabled = ariaBusy !== "true" && ariaDisabled !== "true" ? await button.isEnabled() : false;
+    if (ariaBusy !== "true" && ariaDisabled !== "true" && enabled) {
+      return { idle: true, ariaBusy, ariaDisabled, enabled, waitedMs: now() - startedAt, polls };
+    }
+    if (now() - startedAt >= timeoutMs) break;
+    await sleep(pollMs);
+  } while (now() - startedAt < timeoutMs);
+
+  return { idle: false, ariaBusy, ariaDisabled, enabled, waitedMs: now() - startedAt, polls };
+}
+
+/**
+ * The message for a `Save` that never became actionable (#1355).
+ *
+ * Names the provider, the attribute state observed and — the part the old
+ * generic click timeout could not say — that the likely cause is the PREVIOUS
+ * provider's validation, so the reader does not go looking for a broken button.
+ */
+export function formatSaveBusyFailure(providerName: string, verdict: ButtonIdleVerdict): string {
+  const busy = verdict.ariaBusy === "true";
+  return [
+    `collect-models: the "Save" button for provider "${providerName}" never became actionable ` +
+      `after ${(verdict.waitedMs / 1000).toFixed(1)}s over ${verdict.polls} poll(s).`,
+    ``,
+    `  aria-busy      ${verdict.ariaBusy ?? "(absent)"}`,
+    `  aria-disabled  ${verdict.ariaDisabled ?? "(absent)"}`,
+    `  enabled        ${verdict.enabled}`,
+    ``,
+    busy
+      ? `  verdict        still BUSY — a save/validation is in flight. This panel is walked one\n` +
+        `                 provider at a time, so the usual cause is the PREVIOUS provider's\n` +
+        `                 validation not having settled, not this provider's key (#1355).`
+      : `  verdict        not busy, but not actionable either — the form is in a state this\n` +
+        `                 helper does not model. Check the panel markup before assuming a key\n` +
+        `                 problem (#1355).`,
+  ].join("\n");
+}
+
 async function collectModelsForProvider(
   page: Page,
   providerTestId: string,
@@ -385,15 +500,37 @@ async function collectModelsForProvider(
 
     const saveBtn = page.getByRole("button", { name: "Save", exact: true });
     if ((await saveBtn.count()) > 0) {
+      // BEFORE the click, and fail-loud (#1355): the panel marks `Save`
+      // `aria-busy="true" aria-disabled="true"` while a validation is in flight,
+      // including the previous provider's. `click()`'s own actionability wait is
+      // capped at 20s — shorter than the ~35s validation named below — so a busy
+      // button produced `locator.click: Timeout 20000ms exceeded` pointing at the
+      // click, for a provider that was never the problem.
+      const verdict = await waitForButtonIdle(saveBtn);
+      if (!verdict.idle) throw new Error(formatSaveBusyFailure(providerName, verdict));
       await saveBtn.click();
     }
 
     // Provider validation can take ~35s (Google) — wait for the configured state
     // (Disconnect button) rather than a fixed shorter timeout that would expire mid-validation.
-    await page
+    //
+    // The outcome is READ now instead of being swallowed (#1355). A save that
+    // never reaches the configured state is why the next steps collect zero
+    // models, and `.catch(() => {})` made "never configured" and "configured
+    // fine" the same observation — so the empty collection downstream looked
+    // like a provider with no models rather than a save that did not land.
+    const configured = await page
       .getByRole("button", { name: "Disconnect", exact: true })
       .waitFor({ state: "visible", timeout: 60000 })
-      .catch(() => {});
+      .then(() => true)
+      .catch(() => false);
+    if (!configured) {
+      console.warn(
+        `⚠️  collect-models: provider "${providerName}" never showed the configured state ` +
+          `("Disconnect") within 60s of Save. Whatever this run collects for it is suspect — ` +
+          `an empty model list below is that, not a provider without models (#1355).`,
+      );
+    }
   }
 
   // Wait for model toggles to load after provider is configured
@@ -421,6 +558,21 @@ async function collectModelsForProvider(
   }
 
   console.log(`Models found (${providerName}):`, models.map((m) => m.model));
+
+  // An empty collection for a provider whose key IS set is a failure, and it used
+  // to print exactly like a healthy result (#1355). It is also the state that
+  // produces the SILENT daily: `Collect models` is `continue-on-error` there
+  // (#980), so a `models.json` missing this provider makes `resolveTestTargets()`
+  // resolve nothing and every parametrized spec skip — green by absence, the
+  // #570/#1012 trap. Warn rather than throw: the run is more useful finishing with
+  // the providers it did collect, and the PR lane fails on the Save above anyway.
+  if (apiKey && models.length === 0) {
+    console.warn(
+      `⚠️  collect-models: provider "${providerName}" has a key configured but collected ZERO models. ` +
+        `Its parametrized specs will SKIP wherever this models.json is used — a green run after this ` +
+        `line tested nothing for it (#1355).`,
+    );
+  }
 
   await page.getByTestId("sidebar-nav-Model Providers").click();
 

--- a/tests/helpers/provider-setup/collect-models.ts
+++ b/tests/helpers/provider-setup/collect-models.ts
@@ -371,10 +371,64 @@ async function collectProviders(
 const SAVE_IDLE_TIMEOUT_MS = 60_000;
 const SAVE_IDLE_POLL_MS = 250;
 
+/**
+ * Per-toggle and whole-provider ceilings for confirming a model was enabled (#1355).
+ *
+ * Two bounds, not one, for the reason the token-attribution sidecar gives (#1197
+ * §4.4): the per-item timeout bounds ONE write and never sees the sum, so 41
+ * slow-but-succeeding confirmations would spend 41 x TIMEOUT and blow the spec's
+ * own 5-minute budget. The aggregate bounds that sum. Against a healthy panel a
+ * confirmation costs tens of milliseconds, so neither fires.
+ */
+const TOGGLE_CONFIRM_TIMEOUT_MS = 5_000;
+const TOGGLE_CONFIRM_BUDGET_MS = 60_000;
+const TOGGLE_CONFIRM_POLL_MS = 100;
+
 /** The `Locator` surface {@link waitForButtonIdle} reads — narrow so the unit lane can drive it with a fake. */
 export interface ButtonStateLocator {
   getAttribute(name: string): Promise<string | null>;
   isEnabled(): Promise<boolean>;
+}
+
+/**
+ * Wait for a model toggle to report itself enabled after a click (#1355).
+ *
+ * This is the serialiser. Enabling a model is a write, and the collector enables
+ * every model of every provider; firing those as fast as the clicks land is what
+ * queues up behind the next provider's Save. Waiting for `aria-checked="true"`
+ * makes each write land before the next is issued.
+ *
+ * Reports rather than throws, for the same reason {@link waitForButtonIdle}
+ * does: an unconfirmed toggle is worth counting, not worth failing the whole
+ * pre-flight over — the model may well be enabled anyway, and the run is more
+ * useful finishing.
+ */
+export async function waitForToggleChecked(
+  toggle: Pick<ButtonStateLocator, "getAttribute">,
+  options: {
+    timeoutMs?: number;
+    pollMs?: number;
+    now?: () => number;
+    sleep?: (ms: number) => Promise<void>;
+  } = {},
+): Promise<{ checked: boolean; waitedMs: number; polls: number }> {
+  const timeoutMs = options.timeoutMs ?? TOGGLE_CONFIRM_TIMEOUT_MS;
+  const pollMs = options.pollMs ?? TOGGLE_CONFIRM_POLL_MS;
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+
+  const startedAt = now();
+  let polls = 0;
+  do {
+    polls += 1;
+    if ((await toggle.getAttribute("aria-checked")) === "true") {
+      return { checked: true, waitedMs: now() - startedAt, polls };
+    }
+    if (now() - startedAt >= timeoutMs) break;
+    await sleep(pollMs);
+  } while (now() - startedAt < timeoutMs);
+
+  return { checked: false, waitedMs: now() - startedAt, polls };
 }
 
 export interface ButtonIdleVerdict {
@@ -545,6 +599,26 @@ async function collectModelsForProvider(
   const toggleCount = await toggles.count();
   const models: ModelRecord[] = [];
 
+  // Each enable is a WRITE, and this loop used to fire them as fast as the clicks
+  // land (#1355). That is what wedges the panel: with a funded OpenAI key the
+  // provider exposes 41 visible models where a drained one exposed none worth
+  // toggling, so a single provider went from ~0 writes to 41 against a backend
+  // the lanes run with `LANGFLOW_WORKERS=1`. The NEXT provider's Save then queues
+  // behind them and never settles — measured as anthropic never reaching its
+  // configured state within 60s, and google's Save still `aria-busy` 60s after
+  // that.
+  //
+  // Confirming each toggle before moving on is what serialises them. The pair of
+  // bounds mirrors the token-attribution sidecar (#1197 §4.4): a per-toggle
+  // timeout bounds ONE write, and an aggregate budget bounds the sum — a
+  // per-item timeout alone would let 41 slow-but-succeeding writes spend
+  // 41 x TIMEOUT and blow the spec's own 5-minute budget.
+  //
+  // Past the budget the clicks CONTINUE unconfirmed: enabling a model is still
+  // worth attempting, and the count of unconfirmed ones is reported below rather
+  // than silently dropped (#1012).
+  let unconfirmed = 0;
+  let confirmBudgetLeft = TOGGLE_CONFIRM_BUDGET_MS;
   for (let i = 0; i < toggleCount; i++) {
     const toggle = toggles.nth(i);
     const modelName = await toggle.locator("..").locator("span.text-sm").textContent();
@@ -554,7 +628,24 @@ async function collectModelsForProvider(
     const isChecked = (await toggle.getAttribute("aria-checked")) === "true";
     if (!isChecked) {
       await toggle.click();
+      if (confirmBudgetLeft > 0) {
+        const confirm = await waitForToggleChecked(toggle, {
+          timeoutMs: Math.min(TOGGLE_CONFIRM_TIMEOUT_MS, confirmBudgetLeft),
+        });
+        confirmBudgetLeft -= confirm.waitedMs;
+        if (!confirm.checked) unconfirmed += 1;
+      } else {
+        unconfirmed += 1;
+      }
     }
+  }
+
+  if (unconfirmed > 0) {
+    console.warn(
+      `⚠️  collect-models: ${unconfirmed} of ${toggleCount} model toggle(s) for provider ` +
+        `"${providerName}" were clicked but never confirmed enabled within the budget. The panel ` +
+        `is slow or wedged, and the NEXT provider's Save is what pays for it (#1355).`,
+    );
   }
 
   console.log(`Models found (${providerName}):`, models.map((m) => m.model));


### PR DESCRIPTION
Closes #1355.

> **This PR's framing changed twice while it was open, both times because a run refuted it.** The history is kept in the commits on purpose — the first commit's instrumentation is what produced the diagnosis the third one fixes. What follows is the final, measured version.

## The measurement

Reproduced locally with a funded OpenAI key, a fresh container and every `/api/v1/variables/` response logged:

```
collect-models: provider "anthropic" credential write took 103.1s (HTTP 201)
```

**All three credential writes answer `201`.** None is rejected, none is refused. anthropic's simply does not come back for ~103 s — and the providers panel keeps its `Save` marked `aria-busy` for as long as a write is in flight. The next provider's click then lands on a busy button.

So the failure was never a broken button, a bad key, or a rejected save. It was a **fixed clock waiting on a variable duration**, and that duration grows with how many providers are already configured.

## What it looked like before

```
Models found (openai):    [41 models]
⚠️  provider "anthropic" never showed the configured state ("Disconnect") within 60s of Save
⚠️  provider "anthropic" has a key configured but collected ZERO models
Models found (anthropic): []
Error: the "Save" button for provider "google" never became actionable after 60.0s over 232 poll(s)
```

Why it started now: the CI `OPENAI_API_KEY` was replaced with a funded key. A drained key failed fast; a funded one makes the save real, and the panel exposes 41 visible models (`52` counting the collapsed deprecated ones) where it exposed none worth toggling.

## The fix

`page.waitForResponse` for the credential write, registered **before** the click (or the response can land first and be missed), resolving the moment the write answers. The 180 s backstop is set well clear of the worst measurement rather than just above it, precisely because a fixed clock here is what failed.

The outcome is reported three ways, none silent: no write observed, a write that answered non-2xx, and a write that succeeded but took over 10 s. The last one is a **trend line** — the next time this cost approaches the ceiling, it is visible before it crosses it.

Two supporting changes from the earlier commits stay:

- **The warnings** — a provider that never reaches its configured state, and a provider with a key that collects **zero** models. These are what produced the diagnosis above, and the zero-models one matters beyond this bug: `Collect models` is `continue-on-error` in `daily-stable.yml` (#980), so a missing provider makes every parametrized LLM spec skip and the daily reports green having tested no agent — #570/#1012's green-by-absence.
- **The toggle serialisation**, with its comment corrected to say what it actually is: added on a hypothesis the next CI run refuted, it fixed nothing, and it is kept only because a burst of 41 unconfirmed writes against a `LANGFLOW_WORKERS=1` backend is worth avoiding at a measured cost of ~0 (23.9 s against 24.9 s).

## Verification

- **Fresh container, `--retries=0`**: `1 passed (2.6m)`, all three providers collected — where the same command previously left anthropic at zero models and died on google's Save. This is the reproduction *and* the proof, on the same machine.
- **28 unit tests** pass; mutation checks kill 5 of 6 and 3 of 4 on the two waits.
- `tsc --noEmit` clean; ESLint 0 errors (7 pre-existing `any` warnings in this file).

The lane's own `Collect models` is the CI-side confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)