### PR TITLE
docs(a2a): correct what the orphaned API key actually is

### DIFF
--- a/docs/core-functionality/a2a/a2a-server-auth-apikey.md
+++ b/docs/core-functionality/a2a/a2a-server-auth-apikey.md
@@ -201,8 +201,21 @@ creates is deleted by id in `finally`.
   it is caught here because the first run of this test left one orphan key on the
   shared account, and the daily would have added one per day forever.
   `createProjectViaApi`'s teardown therefore sweeps keys matching the project's
-  (unique) generated name. **Candidate product defect — a project-scoped
-  credential outliving its project — not filed; recorded here.**
+  (unique) generated name.
+
+  **What the orphan actually is, measured rather than inferred:** the key is
+  scoped to the **user**, not to the project — `MCP Project <name>` is a label,
+  and the row carries `user_id`, `is_active: true` and `expires_at: null`. So it
+  is an ordinary account API key that grants whatever the user grants, not a
+  residual project credential. It is also **not** an exploitable leak: the
+  plaintext is returned only at creation time, and creating the project through
+  the API does not return it (the response carries only `auth_settings`,
+  `description`, `id`, `name`, `parent_id`) while the listing masks it
+  (`sk-sCiKY****…`). Nobody holds it. What accumulates is an active, never-expiring
+  credential per restricted project ever created, belonging to no project and
+  known to no one. **Candidate product defect — deleting a project should revoke
+  the key its creation minted — low severity, no user-facing impact today. Not
+  filed; recorded here.**
 
 ---
 


### PR DESCRIPTION
Follow-up to #1353 / #1356. The correction was committed after #1356 had already merged, so it never reached `main` — the imprecise text is published.

## What was wrong

The measurement note in `a2a-server-auth-apikey.md` called the orphaned key **"a project-scoped credential outliving its project"**. Measured on `1.12.0.dev18`, that is wrong in a way that changes the severity.

## What it actually is

The key carries `user_id`, `is_active: true` and `expires_at: null` — so `MCP Project <name>` is a **label**, and the credential is an ordinary **account** key granting whatever the user grants, not a residual project credential.

It is also **not an exploitable leak**. The plaintext is returned only at creation time; creating the project through the API does not return it (the response carries only `auth_settings`, `description`, `id`, `name`, `parent_id`) and the listing masks it (`sk-sCiKY****…`). Nobody holds the orphan.

What accumulates is an **active, never-expiring credential per restricted project ever created**, belonging to no project and known to no one. Restated as: *deleting a project should revoke the key its creation minted* — low severity, no user-facing impact today.

## Scope

Documentation only. The teardown sweep in `createProjectViaApi` is unchanged — this corrects the record, not the behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)