### PR TITLE
chore(triage): quarantine 9 tests from the 2026-08-07 daily (#1361)

### DIFF
--- a/tests/tests-automations/regression/core-components/full-custom-component.spec.ts
+++ b/tests/tests-automations/regression/core-components/full-custom-component.spec.ts
@@ -63,9 +63,11 @@ class CustomComponent(Component):
     def build_output(self) -> Message:
         return Message(text=self.input_value)`;
 
-test(
+// Quarantined at triage (daily #1361): recurrent flake — `code-button-modal`
+// never becomes visible after the custom component is added — see #1365.
+test.fixme(
   "a full custom component built from code exposes its declared interface",
-  { tag: ["@stable", "@release", "@components"] },
+  { tag: ["@release", "@components"] },
   async ({ page }) => {
     trackCreatedFlows(page);
 

--- a/tests/tests-automations/regression/core-functionality/model-provider/openai-compatible-provider-setup.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/openai-compatible-provider-setup.spec.ts
@@ -555,9 +555,12 @@ test.describe("OpenAI Compatible — unified provider setup", () => {
     },
   );
 
-  test(
+  // Quarantined at triage (daily #1361): discovery stopped registering each
+  // served model twice, so `num_models` reads 124 where the contract is 248
+  // — see #1364.
+  test.fixme(
     "the configured provider discovers exactly the models its endpoint serves",
-    { tag: ["@stable", "@api", "@model-provider", "@settings"] },
+    { tag: ["@api", "@model-provider", "@settings"] },
     async ({ page, request }) => {
       const probe = await probeEndpoint(request);
       test.skip(!probe.usable, `OpenAI-compatible endpoint not usable: ${probe.reason}`);

--- a/tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts
@@ -5,9 +5,11 @@ import { createFlow } from "../../../../helpers/flows/create-flow";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { deleteProject } from "../../../../helpers/flows/delete-project";
 
-test(
+// Quarantined at triage (daily #1361): the project's sidebar entry never
+// resolves under the name-derived testid this spec clicks — see #1363.
+test.fixme(
   "user should be able to select flows with different methods and perform bulk actions",
-  { tag: ["@stable", "@release", "@workspace", "@mainpage", "@regression"] },
+  { tag: ["@release", "@workspace", "@mainpage", "@regression"] },
   async ({ page, request }) => {
     // Track the IDs of the 3 flows + the dedicated folder we create so cleanup
     // deletes ONLY those via the API, never sibling specs' flows.

--- a/tests/tests-automations/regression/core-functionality/project-management/folder-crud.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/folder-crud.spec.ts
@@ -23,9 +23,11 @@ import { MainPage } from "../../../../pages/MainPage";
  * folder-drag-drop-flow) and are intentionally not repeated here.
  */
 
-test(
+// Quarantined at triage (daily #1361): the project's sidebar entry never
+// resolves under the name-derived testid this spec waits on — see #1363.
+test.fixme(
   "creates, renames and deletes an empty project folder via the UI",
-  { tag: ["@stable", "@release", "@workspace", "@mainpage"] },
+  { tag: ["@release", "@workspace", "@mainpage"] },
   async ({ page, request }) => {
     await awaitBootstrapTest(page, { skipModal: true });
 
@@ -83,9 +85,11 @@ test(
   },
 );
 
-test(
+// Quarantined at triage (daily #1361): the project's sidebar entry never
+// resolves under the name-derived testid this spec waits on — see #1363.
+test.fixme(
   "deleting a folder that contains a flow removes the flow with it",
-  { tag: ["@stable", "@release", "@workspace", "@mainpage"] },
+  { tag: ["@release", "@workspace", "@mainpage"] },
   async ({ page, request }) => {
     const authToken = await getAuthToken(request);
     const folderName = `crud-del-folder-${Date.now()}`;

--- a/tests/tests-automations/regression/core-functionality/project-management/folder-deletion-integrity.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/folder-deletion-integrity.spec.ts
@@ -163,9 +163,11 @@ async function openTemplateAndReturnToFolders(page: Page) {
   });
 }
 
-test(
+// Quarantined at triage (daily #1361): the project's sidebar entry never
+// resolves under the name-derived testid this spec waits on — see #1363.
+test.fixme(
   "deleting a folder should update the folder list immediately",
-  { tag: ["@stable", "@release", "@api"] },
+  { tag: ["@release", "@api"] },
   async ({ page, request }) => {
     // Registered even though this test opens no template: on an instance with no
     // flows left (the `@destructive` sibling empties it in its own lane)
@@ -224,9 +226,11 @@ test(
   },
 );
 
-test(
+// Quarantined at triage (daily #1361): the project's sidebar entry never
+// resolves under the name-derived testid this spec waits on — see #1363.
+test.fixme(
   "deleting one folder should not affect other folders",
-  { tag: ["@stable", "@release", "@api"] },
+  { tag: ["@release", "@api"] },
   async ({ page }) => {
     trackCreatedFlows(page);
     await awaitBootstrapTest(page);
@@ -304,9 +308,11 @@ test(
   },
 );
 
-test(
+// Quarantined at triage (daily #1361): the project's sidebar entry never
+// resolves under the name-derived testid this spec waits on — see #1363.
+test.fixme(
   "creating a new folder after deletion should work correctly",
-  { tag: ["@stable", "@release", "@api"] },
+  { tag: ["@release", "@api"] },
   async ({ page }) => {
     trackCreatedFlows(page);
     await awaitBootstrapTest(page);

--- a/tests/tests-automations/regression/mcp/server/mcp-server-starter-projects.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-starter-projects.spec.ts
@@ -58,9 +58,11 @@ const removeLeftoverRenamedProject = async (page: Page) => {
   }
 };
 
-test(
+// Quarantined at triage (daily #1361): the project kebab never resolves under
+// the name-derived `more-options-button_<name>` testid — see #1363.
+test.fixme(
   "user must be able to see starter projects for mcp servers",
-  { tag: ["@stable", "@release", "@workspace", "@components", "@mcp"] },
+  { tag: ["@release", "@workspace", "@components", "@mcp"] },
   async ({ page }) => {
     //starter mcp project
 


### PR DESCRIPTION
Quarantine dispatched by the triage of daily-failure umbrella #1361 (run [31163810520](https://github.com/oriontech-me/langflow-e2e/actions/runs/31163810520), 2026-08-07, `langflowai/langflow-nightly:latest`).

The mass-failure guard tripped (8 hard failures against a threshold of 5), so `daily-stable.yml` auto-removed `@stable` from nothing. The triage's verdict on the day is that it was **not** environmental — 7 of the 8 hard failures survived every retry across worker indices 2–17 and outside the run's single 108 s outage window — which under the Guard-Tripped Rule makes them a **manual** quarantine.

**This PR closes no issue.** It is prevention, not a fix: lifting each quarantine (remove `test.fixme` + restore `@stable`, re-validated per `CONTRIBUTING.md`) is a deliverable of the owning issue below.

## What is quarantined

Each test gets **both** edits together — `@stable` removed **and** `test.fixme` added — so it stops running in every context, not just the daily. Tag removal alone would leave it red on the `pr-validation.yml` impacted-specs gate, which selects by file diff rather than by tag (#871).

| Test | Owner |
|---|---|
| `tests/tests-automations/regression/core-functionality/project-management/folder-deletion-integrity.spec.ts:166` | #1363 |
| `tests/tests-automations/regression/core-functionality/project-management/folder-deletion-integrity.spec.ts:227` | #1363 |
| `tests/tests-automations/regression/core-functionality/project-management/folder-deletion-integrity.spec.ts:307` | #1363 |
| `tests/tests-automations/regression/core-functionality/project-management/folder-crud.spec.ts:26` | #1363 |
| `tests/tests-automations/regression/core-functionality/project-management/folder-crud.spec.ts:86` | #1363 |
| `tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts:8` | #1363 |
| `tests/tests-automations/regression/mcp/server/mcp-server-starter-projects.spec.ts:61` | #1363 |
| `tests/tests-automations/regression/core-functionality/model-provider/openai-compatible-provider-setup.spec.ts:558` | #1364 |
| `tests/tests-automations/regression/core-components/full-custom-component.spec.ts:66` | #1365 |

## Notes for review

- **`QA-CHECKLIST.md` is deliberately untouched.** The generated blocks are regenerated on merge to `main` by `update-coverage-summary.yml`; committing regenerated counts here is the recurring collision (#741). Both guards pass locally: no generated block edited, and every `@stable`/documented spec still carries a Part II bullet.
- **#1363 is filed against a default.** The Guard-Tripped Rule notes today-only collateral rather than filing it, and the automated proposal on #1361 classified this cluster that way. The triage diverged because the rule's premise — that the failure vanishes when the instance recovers — does not hold here, and because a `test.fixme` needs an owning issue to reference. Reasoning is recorded on #1361 and #1363.
- **No cause is asserted anywhere.** #1363 carries an upstream lead as an explicit hypothesis to rule out; the verdict belongs to the investigation.