### PR TITLE
ci(triage): bill the agent to the subscription, not the shared key

### DIFF
--- a/.github/workflows/triage-dispatch.yml
+++ b/.github/workflows/triage-dispatch.yml
@@ -105,7 +105,28 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Subscription auth, not the API key. This job is axis A of #1183 — the
+          # measured ~10x of the whole spec suite — and on 2026-08-07 one propose
+          # run billed $1.78 (28 turns, 2.9M tokens against `claude-sonnet-5`,
+          # cache reads dominating). It fires on essentially every red daily, so
+          # the recurring cost is ~$1.78 per business day and steps up ~50% on
+          # 2026-09-01 when the Sonnet introductory band expires, with no change
+          # in consumption. `claude_code_oauth_token` is the action's documented
+          # alternative to `anthropic_api_key`, and it draws on a Claude Code
+          # subscription that is already paid for, so the marginal dollar cost of
+          # this job becomes zero.
+          #
+          # What it costs instead, so nobody rediscovers it as a surprise:
+          #   - the run consumes the SUBSCRIPTION's rate-limit window, shared with
+          #     interactive sessions. The daily fires ~09:20 BRT.
+          #   - this spend leaves the Console usage dashboard. `ANTHROPIC_API_KEY`
+          #     still exists for the specs' provider calls (tens of thousands of
+          #     tokens a day, per reports/token-history.jsonl) — so a spike there
+          #     is now unambiguously the specs, never the agent.
+          #   - the OAuth token EXPIRES. When it does, this step fails and the red
+          #     daily goes untriaged until a human notices. Re-mint with
+          #     `claude setup-token` and `gh secret set CLAUDE_CODE_OAUTH_TOKEN`.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: "/langflow-e2e-triage --phase propose ${{ inputs.issue && format('--issue {0}', inputs.issue) || '' }}"
           # --model pinned (#1178): the action's default is `claude-opus-5[1m]`, and
           # nothing here needs Opus-tier reasoning at Opus-tier price. Sonnet 5
@@ -144,7 +165,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Same subscription auth as propose, and for the same reason — see the
+          # long note on that step. This one runs at --max-turns 40, so it is the
+          # more expensive of the two whenever a human approves a plan.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: "/langflow-e2e-triage --phase execute --issue ${{ github.event.issue.number }}"
           # Same pin as propose (#1178). NOT gated on a report: execute is triggered
           # by a human "pode abrir" on a plan that already exists, so it has


### PR DESCRIPTION
Closes #1367.

## What this changes

Two lines of auth in `.github/workflows/triage-dispatch.yml` — `propose` and `execute` both move from `anthropic_api_key` to `claude_code_oauth_token`. Nothing else: same triggers, same gates, same `--model claude-sonnet-5` pin, same `--allowedTools "Read,Bash"`, same turn caps.

## Why

The Console breakdown for 2026-08-07 showed **2,885,814 tokens on `claude-sonnet-5`**, 98.5% of the day. It was **one run** — `Propose triage plan`, [31165533824](https://github.com/oriontech-me/langflow-e2e/actions/runs/31165533824), `num_turns: 28`, **`total_cost_usd: 1.7802987`**, cache reads dominating a job whose entire input is CI logs.

The spec suite over the same period spent **8,741 tokens** (`reports/token-history.jsonl`), on `gpt-4o-mini` / `gemini-flash-latest`. The chart's `claude-haiku-4-5` 41,551 is the specs; its `claude-opus-5` **862** proves local Claude Code is not billing this key at all.

That is **axis A of #1183** measured again and higher — the historical mean was ~$1.05/run. `propose` auto-fires on every red scheduled daily and the daily is red on essentially every business day (9 agent runs across the 9 business days to 08-07), so the standing cost is **~$1.78/business day**, stepping up ~50% on **2026-09-01** when the Sonnet introductory band expires with no change in consumption.

`claude_code_oauth_token` is the action's own documented alternative to `anthropic_api_key` (`anthropics/claude-code-action@v1`, `action.yml`), drawing on a subscription that is already paid for. Marginal dollar cost of this job → **zero**.

## What it costs instead

Relocated, not eliminated. All three are recorded at the call site so they are not rediscovered as surprises:

1. The run consumes the **subscription's rate-limit window**, shared with interactive sessions. The daily fires ~09:20 BRT and this run was 2.9M tokens.
2. The spend **leaves the Console dashboard**. `ANTHROPIC_API_KEY` stays for the specs' provider calls, so a future spike there is unambiguously the specs.
3. **The OAuth token expires.** The step then fails and a red daily goes untriaged until someone reads the failed run. Re-mint with `claude setup-token`.

## ⚠️ Do not merge before the secret exists

`gh secret list` shows no `CLAUDE_CODE_OAUTH_TOKEN` today. Merging first breaks both agent jobs.

```bash
claude setup-token
gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo oriontech-me/langflow-e2e
```

## Alternatives rejected

- **Drop the CI agent, run `/langflow-e2e-triage` locally** — also $0, but loses the reason propose exists: the plan is already on the umbrella when someone opens the day.
- **Keep the key, cut consumption** (gate the trigger on a changed failure signature, truncate the logs the agent reads, A/B haiku) — reduces without zeroing, and #1178 is explicit that a cheaper model must be validated rather than assumed.

## Verification

YAML parses and both jobs carry the new key, with no residual reference to the old one:

```
propose ['claude_code_oauth_token', 'prompt', 'claude_args']
execute ['claude_code_oauth_token', 'prompt', 'claude_args']
triggers: ['workflow_run', 'issue_comment', 'workflow_dispatch']
```

No unit guard references `anthropic_api_key` for this workflow (grepped `scripts/**/*.test.{mjs,ts}`), so nothing structural pins the old spelling.

**End-to-end proof is only available post-merge** — `workflow_run` and `issue_comment` triggers fire exclusively from the default-branch copy of the workflow file, as this workflow's own header comment records. Once the secret is set and this merges, the honest check is a `workflow_dispatch` of `propose` against an existing umbrella issue.

## Not covered here

Nothing detects the token expiring except a human reading a failed workflow run. Worth a follow-up if that turns out to bite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)