### PR TITLE
fix(collect-models): stop one stalling provider from costing the PR lane its whole E2E run (#1370)

### DIFF
--- a/.github/workflows/daily-stable.yml
+++ b/.github/workflows/daily-stable.yml
@@ -396,6 +396,18 @@ jobs:
       - name: Collect models
         id: collect_models
         run: npx playwright test tests/collect-models.spec.ts --reporter=line
+        # NOT a hard gate here, deliberately, and the asymmetry with
+        # pr-validation.yml is intentional rather than an oversight (#1370 asked
+        # for it in writing). There this step gates the job: a red sweep means
+        # the impacted specs never run, which is right, because a spec that needs
+        # a model must not run without one (#1152). Here a red sweep costs the
+        # provider's parametrized specs and nothing else, and losing a scheduled
+        # day of @stable coverage to a drained key is the worse trade (#980).
+        #
+        # COLLECT_REQUIRED_PROVIDERS is therefore deliberately UNSET below: this
+        # lane rotates providers by weekday (#1185) and owes multi-provider
+        # coverage, so every env-keyed provider stays required. Narrowing it is
+        # the PR lane's move, and only because that lane pins itself to one.
         continue-on-error: true
         env:
           CI: "true"

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -616,6 +616,14 @@ jobs:
       # Read by the sidecar only; the poller has its own TOKENS_MAX_SECONDS.
       TOKENS_BUDGET_MS: "15000"
 
+      # The single provider this lane runs its LLM specs against (#1169), named
+      # ONCE because two steps depend on it and they must not drift: "Collect
+      # models" below fails only on this provider, and "Pin the lane to a single
+      # provider's settled model" resolves this provider's settled model. Two
+      # literals would let a future change to one of them silently gate on a
+      # provider the lane no longer runs (#1370).
+      PR_LANE_PROVIDER: openai
+
     steps:
       - uses: actions/checkout@v7
 
@@ -700,6 +708,24 @@ jobs:
           # backend; the health gate below is what covers that case.
           PLAYWRIGHT_RETRIES: "0"
           PLAYWRIGHT_BASE_URL: "http://localhost:7860/"
+          # Which provider a COLLECTOR stall may fail this step on (#1370).
+          #
+          # A provider the collector never managed to configure is recorded
+          # `inactive` having never been probed at all — a collector verdict, not
+          # a key one — and every such provider used to fail this step. On a lane
+          # that pins itself to ONE provider (below), a stalled anthropic changes
+          # no spec this job will execute, and yet it exits here non-zero, which
+          # on THIS lane is a hard gate: the impacted-specs step never runs and
+          # the PR gets no E2E coverage of its own diff. Measured 2026-08-07 on
+          # run 31188034419, where anthropic stalled on all three attempts and
+          # two of them cost the whole lane.
+          #
+          # This narrows the COLLECTOR-stall verdict only. Every other failure —
+          # a dead key, a provider the image cannot build, a total wipeout, a
+          # broken Model Providers UI — still fails this step for every provider,
+          # unchanged. Unset elsewhere (daily-stable.yml, manual.yml, local), so
+          # every env-keyed provider stays required there.
+          COLLECT_REQUIRED_PROVIDERS: ${{ env.PR_LANE_PROVIDER }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -784,7 +810,9 @@ jobs:
       # with no sweep there is no settled model to read.
       - name: Pin the lane to a single provider's settled model
         if: needs.detect-specs.outputs.needs_models == 'true'
-        run: node scripts/select-pr-model-target.mjs --provider openai
+        # Same provider the Collect models step gates on, read from one place so
+        # the two cannot drift apart (#1370).
+        run: node scripts/select-pr-model-target.mjs --provider "$PR_LANE_PROVIDER"
 
       # In-run token consumption recorder, extended to this lane (#1183 — measure
       # the suite's real LLM spend per lane/provider). Same mechanism as

--- a/docs/collect-models.md
+++ b/docs/collect-models.md
@@ -275,7 +275,7 @@ turned one slow write into a **lost PR lane**, each with its own fix and its own
 unit coverage. Read them in this order; the third is the one that costs coverage.
 
 **1 — A wait that never ran must not report a measurement.** The two waits after
-Save (the credential response, and the panel reaching `Disconnect`) ended in
+the Save click (the credential response, and the panel reaching `Disconnect`) ended in
 `.catch(() => null)` / `.catch(() => false)`, which makes *"the deadline expired"*
 and *"the page was closed under me"* the same observation. On run
 [31188034419](https://github.com/oriontech-me/langflow-e2e/actions/runs/31188034419)
@@ -295,14 +295,22 @@ negatives — which is why the issue's own preliminary question ("is 180 s simpl
 short?") is unanswerable from those runs. An aborted wait is **unknown**, not a
 negative (#1012, and the same `read-failed` distinction #1261 needed).
 
-**2 — Per-provider ceilings that the test's own budget cannot pay.** 180 s
-(write) + 60 s (`Disconnect`) + 15 s (toggles) is **255 s spent on a single
-provider**, inside a spec whose timeout is **300 s**. One stall therefore
-consumes the run by arithmetic, before any judgement about whether the wait was
-right. The sweep needs the same pair of bounds the toggle confirmation already
-has (`TOGGLE_CONFIRM_BUDGET_MS`, mirroring #1197 §4.4): a per-item timeout bounds
-ONE write and can never see the sum. Attempt 2 died exactly this way; attempt 3
-survived with ~15 s to spare while collecting all three providers.
+**2 — Per-provider ceilings that the test's own budget cannot pay.** 60 s
+(waiting for `Save` to become actionable) + 180 s (write) + 60 s (`Disconnect`) +
+15 s (toggles) is **315 s spent on a single provider**, inside a spec whose
+timeout is **300 s**. One stall therefore consumes the run by arithmetic, before
+any judgement about whether any single wait was right. The sweep needs the same
+pair of bounds the toggle confirmation already has (`TOGGLE_CONFIRM_BUDGET_MS`,
+mirroring #1197 §4.4): a per-item timeout bounds ONE wait and can never see the
+sum. Attempt 2 died exactly this way; attempt 3 survived with ~3 s to spare.
+
+The first of those three waits is also the one that used to **throw**, and that
+half was found on this fix's own first CI run rather than in the original
+incident: with anthropic's write still in flight, google's `Save` never became
+actionable inside its own fixed 60 s, and `collect-models` ended there. A busy
+`Save` is now recorded as that provider's stall and the sweep moves on — which
+loses no signal, because a stall still fails the gate on every lane that requires
+the provider, and on the daily that is all of them.
 
 **3 — `no models collected` is a collector verdict, not a key verdict.** When the
 panel never confirms the credential, `validateProviderWithFallback` receives

--- a/docs/collect-models.md
+++ b/docs/collect-models.md
@@ -1,6 +1,6 @@
 # Collect Models
 
-**Last validated:** Langflow 1.12.x
+**Last validated:** Langflow 1.12.x (1.12.0.dev19)
 
 ---
 
@@ -67,8 +67,11 @@ surface (the #505 lesson).
 3. For each configured provider (OpenAI, Anthropic, Google):
    a. Click the provider entry to open its configuration panel
    b. If an API key is present in the environment and the panel is visible, enter the key and click Save / Replace
-   c. Wait for model toggles to load; enable any that are unchecked
-   d. Record each model name paired with the provider
+   c. Wait for the credential **write** to answer and for the panel to reach the
+      configured state, both **against a sweep-wide deadline** rather than a
+      per-provider clock — see *A stalling provider must not cost the sweep* below
+   d. Wait for model toggles to load; enable any that are unchecked
+   e. Record each model name paired with the provider
 4. Write the collected model list to `data/models.json`
 5. **Probe the KEY axis:** for each provider, call its API directly to confirm the
    key is active. The probe walks the collected catalog in preference order rather
@@ -97,7 +100,10 @@ contract; the SPEC now verifies the outcome):
   Settings UI collection broke — the exact silent failure the old contract
   hid);
 - every provider with its env key set that came back `inactive` carries a
-  non-empty `error` (the probe's reason is visible, never silently dropped).
+  non-empty `error` (the probe's reason is visible, never silently dropped);
+- a provider the **collector** never managed to configure is reported as that,
+  and never as a key/account/config failure — see *A stalling provider must not
+  cost the sweep* (#1370).
 
 A provider with a key that genuinely fails its probe (e.g. a model the
 account cannot access) is a legitimate `inactive` — recorded, logged, not a
@@ -258,6 +264,71 @@ exists to prevent. Two consequences, both load-bearing:
   reports the **most frequent** error instead of the last, on the same signal the
   early exit uses: a model-scoped message names its model and so occurs once,
   while an account-scoped one occurs for every candidate.
+
+### A stalling provider must not cost the sweep (#1370)
+
+One provider's credential write can stay in flight far longer than the others' —
+measured at **103 s** locally (#1355/#1357) and past **240 s** in CI, always
+anthropic, whichever position it holds in the loop. That is a backend cost this
+spec does not control. What it does control is the three separate defects that
+turned one slow write into a **lost PR lane**, each with its own fix and its own
+unit coverage. Read them in this order; the third is the one that costs coverage.
+
+**1 — A wait that never ran must not report a measurement.** The two waits after
+Save (the credential response, and the panel reaching `Disconnect`) ended in
+`.catch(() => null)` / `.catch(() => false)`, which makes *"the deadline expired"*
+and *"the page was closed under me"* the same observation. On run
+[31188034419](https://github.com/oriontech-me/langflow-e2e/actions/runs/31188034419)
+attempt 2 the test hit its own 5-minute Playwright timeout, the context closed,
+and both pending waits rejected at once:
+
+```
+14:49:14.871  ⚠️ anthropic ... collected ZERO models
+14:49:30.036  ⚠️ no credential write observed for provider "google" within 180s
+14:49:30.048  ⚠️ provider "google" never showed the configured state ("Disconnect") within 60s
+14:49:30.088  Error: locator.count: Target page, context or browser has been closed
+```
+
+A 180 s wait and a 60 s wait completed **12 ms apart**, at most 15.2 s after the
+click. Neither observed anything. The log nonetheless read as two measured
+negatives — which is why the issue's own preliminary question ("is 180 s simply
+short?") is unanswerable from those runs. An aborted wait is **unknown**, not a
+negative (#1012, and the same `read-failed` distinction #1261 needed).
+
+**2 — Per-provider ceilings that the test's own budget cannot pay.** 180 s
+(write) + 60 s (`Disconnect`) + 15 s (toggles) is **255 s spent on a single
+provider**, inside a spec whose timeout is **300 s**. One stall therefore
+consumes the run by arithmetic, before any judgement about whether the wait was
+right. The sweep needs the same pair of bounds the toggle confirmation already
+has (`TOGGLE_CONFIRM_BUDGET_MS`, mirroring #1197 §4.4): a per-item timeout bounds
+ONE write and can never see the sum. Attempt 2 died exactly this way; attempt 3
+survived with ~15 s to spare while collecting all three providers.
+
+**3 — `no models collected` is a collector verdict, not a key verdict.** When the
+panel never confirms the credential, `validateProviderWithFallback` receives
+**zero candidates** and records
+`error: "no models collected from the providers panel"`. That string does not
+match `BILLING_OR_QUOTA`, so it lands in `hardFailures` and fails the spec under
+the message *"real key/account/config problem"* — for a provider whose key was
+**never probed at all** and whose build axis reported ✅. It is the #1011 mistake
+in a new place: the loud failure names the wrong layer. A provider the collector
+never managed to configure gets its own verdict, distinct from both a working key
+and a rotten one, and the spec asserts on it separately.
+
+**What follows for the PR lane, and why this is not a weakened assertion.**
+`pr-validation.yml` pins its run to one provider's settled model (`PR lane pinned
+to openai / gpt-4o-mini`, #1169); the daily rotates and keeps the multi-provider
+coverage. So on the PR lane a stalled anthropic changes **no spec that lane will
+execute**, and yet it exits the shared `Collect models` pre-flight non-zero, which
+on that lane is a hard gate — the impacted-specs step never runs and the PR gets
+no E2E coverage of its own diff. #570's guarantee is preserved where it bites: a
+provider that silently collects nothing still fails **any lane that would have
+used it**, and a total wipeout still fails everywhere. What changes is that the
+gate stops failing on a provider the lane has already excluded from its own run.
+
+The daily makes the opposite trade deliberately (`continue-on-error: true`, #980
+— a day of coverage outweighs a diagnostic red). That asymmetry is intentional and
+is now stated in both workflows rather than implied by one of them.
 
 ---
 

--- a/scripts/select-pr-model-target.test.mjs
+++ b/scripts/select-pr-model-target.test.mjs
@@ -206,3 +206,71 @@ test("pr-validation.yml still runs the pin between the health gate and the specs
   assert.ok(pin > gate, "the model pin must follow the health gate");
   assert.ok(run > pin, "the model pin must precede the impacted-specs run");
 });
+
+test("pr-validation.yml gates and pins on ONE provider name, not two literals (#1370)", () => {
+  // What this pins is an ABSENCE, like the --grep composition guard (#1275): no
+  // provider name spelled twice. It cannot prove the lane behaves correctly —
+  // the tests above and collect-models.test.ts do that — but the defect it
+  // guards is drift between two independent literals, which is exactly the class
+  // a structural read catches.
+  //
+  // Why it matters: `Collect models` now fails a COLLECTOR stall only on the
+  // provider this lane pins itself to. If a later change moves the pin to
+  // anthropic and leaves the gate on openai, the lane would gate on a provider
+  // it does not run and run one it does not gate — reopening #1370 from the
+  // other side, with every check green.
+  const yaml = fs.readFileSync(
+    path.join(REPO_ROOT, ".github/workflows/pr-validation.yml"),
+    "utf-8",
+  );
+
+  assert.match(
+    yaml,
+    /^\s*PR_LANE_PROVIDER:\s*\S+/m,
+    "the lane's provider must be declared once, at job level",
+  );
+  assert.match(
+    yaml,
+    /COLLECT_REQUIRED_PROVIDERS:\s*\$\{\{\s*env\.PR_LANE_PROVIDER\s*\}\}/,
+    "the collector-stall gate must read the lane's provider, not a literal",
+  );
+  assert.match(
+    yaml,
+    /select-pr-model-target\.mjs --provider "\$PR_LANE_PROVIDER"/,
+    "the model pin must read the lane's provider, not a literal",
+  );
+  // The literal may appear exactly once in EXECUTABLE yaml — as the value of
+  // PR_LANE_PROVIDER itself. A second occurrence is a second source of truth.
+  // Comment lines are excluded on purpose: the surrounding prose names the
+  // provider several times while explaining the trade, and a guard that forbade
+  // that would be answered by deleting the explanation.
+  const declared = yaml.match(/^\s*PR_LANE_PROVIDER:\s*(\S+)/m)[1];
+  const executable = yaml
+    .split("\n")
+    .filter((line) => !/^\s*#/.test(line))
+    .join("\n");
+  const occurrences = executable.split(new RegExp(`\\b${declared}\\b`)).length - 1;
+  assert.equal(
+    occurrences,
+    1,
+    `"${declared}" appears ${occurrences}x outside comments in pr-validation.yml — it must be ` +
+      "spelled once, as PR_LANE_PROVIDER's value, or the gate and the pin can drift apart",
+  );
+});
+
+test("daily-stable.yml does NOT narrow the collector-stall gate (#1370)", () => {
+  // The asymmetry is deliberate and this is the half that can regress silently.
+  // The daily rotates providers by weekday (#1185) and owes multi-provider
+  // coverage, so every env-keyed provider stays required there; copying the PR
+  // lane's narrowing across would let a stalled provider go unreported on the
+  // one lane whose whole job is to notice.
+  const yaml = fs.readFileSync(
+    path.join(REPO_ROOT, ".github/workflows/daily-stable.yml"),
+    "utf-8",
+  );
+  assert.doesNotMatch(
+    yaml,
+    /COLLECT_REQUIRED_PROVIDERS:/,
+    "daily-stable.yml must leave the collector-stall gate at its default (every env-keyed provider)",
+  );
+});

--- a/tests/collect-models.spec.ts
+++ b/tests/collect-models.spec.ts
@@ -2,7 +2,11 @@ import * as dotenv from "dotenv";
 import path from "path";
 import fs from "fs";
 import { expect, test } from "./fixtures/fixtures";
-import { collectAll } from "./helpers/provider-setup/collect-models";
+import {
+  collectAll,
+  isCollectorStallReason,
+  resolveRequiredProviders,
+} from "./helpers/provider-setup/collect-models";
 import type { ProviderRecord } from "./helpers/provider-setup/collect-models";
 import { keyedProviderNames, providerConfigMap, type Provider } from "./helpers/provider-setup";
 import { isBuildAxisReason } from "./helpers/provider-setup/probe-component-buildable";
@@ -148,6 +152,10 @@ test(
         const envKeys = providerConfigMap[p.provider as Provider]?.envKeys ?? [];
         const hasEnvKey = envKeys.some((k: string) => !!process.env[k]);
         if (!hasEnvKey || p.status === "active") continue;
+        // A provider the COLLECTOR never configured is not a key/account/config
+        // verdict at all — its key was never probed (#1370). It gets its own
+        // step below, which is what decides whether it is fatal on THIS lane.
+        if (isCollectorStallReason(p.error)) continue;
         if (BILLING_OR_QUOTA.test(p.error ?? "")) {
           console.warn(
             `⚠️  provider "${p.provider}" inactive for a TRANSIENT billing/quota reason — ` +
@@ -171,6 +179,62 @@ test(
         activeCount,
         "no provider probed active — every configured key failed; collection is unusable",
       ).toBeGreaterThan(0);
+    });
+
+    await test.step("a provider the COLLECTOR never configured fails the lanes that need it", async () => {
+      // Separate from the step above because it is a different verdict about a
+      // different layer (#1370). A stalled save hands
+      // `validateProviderWithFallback` zero candidates, so the provider is
+      // recorded `inactive` having never been probed — and under the old
+      // classification that landed in `hardFailures` and failed the spec as a
+      // "real key/account/config problem", for a provider whose build axis had
+      // reported OK and whose key was never touched.
+      //
+      // Why it is scoped rather than always fatal: `pr-validation.yml` pins its
+      // own run to ONE provider (`select-pr-model-target.mjs --provider openai`,
+      // #1169), so a stalled anthropic there changes no spec that lane will
+      // execute — and yet it exited this pre-flight non-zero, which on that lane
+      // is a hard gate, so the PR got no E2E coverage of its own diff at all.
+      // Unset (the daily, manual.yml, every local run) still requires every
+      // env-keyed provider, so #570's guarantee is unchanged where it bites.
+      const providers = JSON.parse(fs.readFileSync(PROVIDERS_PATH, "utf-8")) as ProviderRecord[];
+      const keyed = providers
+        .filter((p) => {
+          const envKeys = providerConfigMap[p.provider as Provider]?.envKeys ?? [];
+          return envKeys.some((k: string) => !!process.env[k]);
+        })
+        .map((p) => p.provider);
+
+      const { required, unrecognised } = resolveRequiredProviders(
+        process.env.COLLECT_REQUIRED_PROVIDERS,
+        keyed,
+      );
+      // A typo in a workflow must not quietly require nothing — that is how a
+      // gate disappears for good (#1012).
+      expect(
+        unrecognised,
+        `COLLECT_REQUIRED_PROVIDERS names provider(s) this run has no key for — either a typo or an ` +
+          `unset secret. Providers with a key this run: ${keyed.join(", ") || "<none>"}`,
+      ).toEqual([]);
+
+      const stalled = providers.filter((p) => isCollectorStallReason(p.error));
+      // Reported whether or not it is fatal here: an unconfigured provider still
+      // makes every spec parametrized on it skip, wherever this models.json is
+      // consumed (#570/#1012).
+      for (const p of stalled) {
+        console.warn(
+          `⚠️  provider "${p.provider}" was never configured by the collector — its parametrized specs ` +
+            `will SKIP wherever this models.json is used: ${p.error}`,
+        );
+      }
+
+      const fatal = stalled.filter((p) => required.includes(p.provider));
+      expect(
+        fatal.map((p) => p.provider),
+        `provider(s) this lane cannot run without were never configured by the collector — this is NOT a ` +
+          `key or account problem, the key was never probed: ` +
+          fatal.map((p) => `${p.provider} — ${p.error}`).join(" | "),
+      ).toEqual([]);
     });
   },
 );

--- a/tests/helpers/provider-setup/collect-models.test.ts
+++ b/tests/helpers/provider-setup/collect-models.test.ts
@@ -830,6 +830,31 @@ test("#1370: a collector stall is recognisable, and a key verdict is not mistake
   assert.equal(isCollectorStallReason(undefined), false);
 });
 
+test("#1370: a Save that never went idle becomes a stall, and cannot launder into a billing warning", async () => {
+  // Found on this fix's own first CI run: anthropic's write was still in flight
+  // when google's turn came, google's Save never became actionable inside its
+  // own fixed 60s, and `waitForButtonIdle`'s caller THREW — ending the sweep
+  // over one provider's backend cost, which is the defect this issue is about.
+  // It is now recorded as a stall, and this pins both halves of what that has to
+  // mean: recognisable as a collector stall, and NOT downgradable to the
+  // transient billing/quota warning, which would make it disappear on every lane.
+  const clock = fakeClock();
+  const verdict = await waitForButtonIdle(fakeButton([{ ariaBusy: "true", ariaDisabled: "true" }]), {
+    ...clock,
+    timeoutMs: 60_000,
+    pollMs: 250,
+  });
+  assert.equal(verdict.idle, false);
+
+  const recorded = `${COLLECTOR_STALL_PREFIX}${formatSaveBusyFailure("google", verdict)}`;
+  assert.equal(isCollectorStallReason(recorded), true);
+  assert.equal(
+    BILLING_OR_QUOTA.test(recorded),
+    false,
+    `a busy Save must not classify as a billing/quota outage, got: ${recorded}`,
+  );
+});
+
 test("#1370: the empty-candidates path still produces the exact string the stall verdict replaces", async () => {
   // The link between the two files is a string comparison, so this pins that
   // `validateProviderWithFallback` keeps emitting the literal `collectProviders`

--- a/tests/helpers/provider-setup/collect-models.test.ts
+++ b/tests/helpers/provider-setup/collect-models.test.ts
@@ -32,8 +32,14 @@ import assert from "node:assert/strict";
 import * as fs from "fs";
 import * as path from "path";
 import {
+  classifyWaitFailure,
+  COLLECTOR_STALL_PREFIX,
   formatSaveBusyFailure,
+  isCollectorStallReason,
+  NO_MODELS_COLLECTED,
+  planSaveWait,
   rankCandidates,
+  resolveRequiredProviders,
   validateProviderWithFallback,
   waitForButtonIdle,
   waitForToggleChecked,
@@ -649,6 +655,239 @@ test("#1355: a toggle that never confirms gives up at its own timeout and says s
   });
   assert.equal(result.checked, false);
   assert.ok(result.waitedMs >= 500, "must not return before its own deadline");
+});
+
+// ─── classifyWaitFailure (#1370) ─────────────────────────────────────────────
+//
+// The incident: on run 31188034419 attempt 2 the spec hit its own 5-minute
+// timeout, the context closed, and the two pending post-Save waits — one of
+// 180s, one of 60s — both rejected at once. Their `.catch(() => null)` /
+// `.catch(() => false)` reported that as two MEASURED negatives, 12 ms apart,
+// at most 15.2s after the click. The log therefore said "no credential write
+// observed within 180s" about a wait that never ran, which is why the question
+// the issue asked ("is 180s simply short?") could not be answered from it.
+//
+// The strings below are VERBATIM from a live Playwright probe of both surfaces
+// (`page.waitForResponse` and `locator.waitFor`), not from memory: an aborted
+// wait rejects with a plain `Error`, an expired one with a `TimeoutError`.
+
+/** What Playwright throws when the context closes under a pending wait. */
+const ABORTED_RESPONSE = Object.assign(
+  new Error("page.waitForResponse: Target page, context or browser has been closed"),
+  { name: "Error" },
+);
+const ABORTED_LOCATOR = Object.assign(
+  new Error("locator.waitFor: Target page, context or browser has been closed"),
+  { name: "Error" },
+);
+
+/** What it throws when the deadline genuinely passes. */
+const EXPIRED_RESPONSE = Object.assign(
+  new Error('page.waitForResponse: Timeout 800ms exceeded while waiting for event "response"'),
+  { name: "TimeoutError" },
+);
+const EXPIRED_LOCATOR = Object.assign(new Error("locator.waitFor: Timeout 800ms exceeded."), {
+  name: "TimeoutError",
+});
+
+test("#1370: a wait cut short by the closing context is ABORTED, never an expiry", () => {
+  // The whole defect in one assertion: reading this as `expired` is what printed
+  // "no credential write observed within 180s" 12 ms after the previous warning.
+  assert.equal(classifyWaitFailure(ABORTED_RESPONSE).kind, "aborted");
+  assert.equal(classifyWaitFailure(ABORTED_LOCATOR).kind, "aborted");
+});
+
+test("#1370: a genuine deadline is EXPIRED on both wait surfaces", () => {
+  assert.equal(classifyWaitFailure(EXPIRED_RESPONSE).kind, "expired");
+  assert.equal(classifyWaitFailure(EXPIRED_LOCATOR).kind, "expired");
+});
+
+test("#1370: the aborted case is matched by MESSAGE, because its name is a plain Error", () => {
+  // Keying on `name` alone is the tempting shortcut and it fails here: a closed
+  // context does not produce a TimeoutError, so `name !== "TimeoutError"` would
+  // have to mean "aborted", which would then swallow every unrecognised error
+  // as a confident claim about the page closing.
+  assert.equal(ABORTED_RESPONSE.name, "Error");
+  assert.equal(classifyWaitFailure(ABORTED_RESPONSE).kind, "aborted");
+});
+
+test("#1370: an unrecognised failure is UNKNOWN — neither a measurement nor a cause", () => {
+  const verdict = classifyWaitFailure(new Error("net::ERR_CONNECTION_RESET at http://localhost:7860"));
+  assert.equal(verdict.kind, "unknown", "#1012: an unevaluated wait is unknown, never clean and never negative");
+  assert.match(verdict.detail, /ERR_CONNECTION_RESET/, "an unknown must never be anonymous");
+});
+
+test("#1370: a non-Error rejection does not crash the classifier", () => {
+  assert.equal(classifyWaitFailure("something odd").kind, "unknown");
+  assert.equal(classifyWaitFailure(undefined).kind, "unknown");
+});
+
+test("#1370: the detail is the FIRST line, so a Playwright call log does not flood the warning", () => {
+  const noisy = Object.assign(
+    new Error(
+      "locator.waitFor: Timeout 60000ms exceeded.\nCall log:\n  - waiting for getByRole('button')\n  - locator resolved to <button>",
+    ),
+    { name: "TimeoutError" },
+  );
+  assert.equal(classifyWaitFailure(noisy).detail, "locator.waitFor: Timeout 60000ms exceeded.");
+});
+
+// ─── planSaveWait (#1370) ────────────────────────────────────────────────────
+//
+// The arithmetic nobody did: 180s (credential write) + 60s (configured state) +
+// 15s (toggles) is 255s spent on ONE provider inside a 300s test timeout. The
+// ceilings were each sized against a measurement and none against the only clock
+// that can end the run. Attempt 2 died at exactly 5 minutes; attempt 3 survived
+// the same stall with 3s to spare.
+
+test("#1370: the FIRST provider of three cannot spend the whole budget", () => {
+  // 210s budget, two providers still to come, 30s reserved for each: 150s, not
+  // the 180s ceiling. That gap is the mechanism, not a rounding artifact — the
+  // ceiling is what ONE wait may cost, the budget is what the sweep may cost,
+  // and before #1370 only the first of those existed.
+  const plan = planSaveWait({ ceilingMs: 180_000, remainingMs: 210_000, providersLeftAfterThis: 2 });
+  assert.deepEqual(plan, { wait: true, timeoutMs: 150_000 });
+});
+
+test("#1370: the ceiling still binds when the budget is ample", () => {
+  const plan = planSaveWait({ ceilingMs: 180_000, remainingMs: 600_000, providersLeftAfterThis: 2 });
+  assert.deepEqual(plan, { wait: true, timeoutMs: 180_000 }, "a wait must never outlive its own ceiling");
+});
+
+test("#1370: the ceiling is capped by what the budget can still afford", () => {
+  // anthropic has already spent most of the sweep; the last provider is what the
+  // reserve protects.
+  const plan = planSaveWait({ ceilingMs: 180_000, remainingMs: 100_000, providersLeftAfterThis: 1 });
+  assert.deepEqual(plan, { wait: true, timeoutMs: 70_000 }, "100s minus a 30s reserve for the one still to come");
+});
+
+test("#1370: the LAST provider reserves nothing and may spend the remainder", () => {
+  const plan = planSaveWait({ ceilingMs: 180_000, remainingMs: 40_000, providersLeftAfterThis: 0 });
+  assert.deepEqual(plan, { wait: true, timeoutMs: 40_000 });
+});
+
+test("#1370: an exhausted budget SKIPS the wait instead of shortening it to zero", () => {
+  // Load-bearing: Playwright reads `timeout: 0` as NO timeout, so an exhausted
+  // budget arriving as a number would wait forever — the exact opposite of the
+  // budget's purpose. The discriminated result makes that unreachable.
+  const plan = planSaveWait({ ceilingMs: 180_000, remainingMs: 30_000, providersLeftAfterThis: 1 });
+  assert.equal(plan.wait, false);
+  assert.match((plan as { reason: string }).reason, /budget is down to 30s/);
+  assert.match((plan as { reason: string }).reason, /1 provider\(s\) still to configure/);
+});
+
+test("#1370: no reachable input yields a zero or negative timeout", () => {
+  // The property, not one example: whatever the budget state, either the wait is
+  // refused or it carries a timeout Playwright will honour as a deadline.
+  for (const remainingMs of [-50_000, 0, 1, 4_999, 5_000, 29_999, 210_000]) {
+    for (const providersLeftAfterThis of [0, 1, 2, 5]) {
+      const plan = planSaveWait({ ceilingMs: 180_000, remainingMs, providersLeftAfterThis });
+      if (plan.wait) {
+        assert.ok(
+          plan.timeoutMs >= 5_000,
+          `remaining=${remainingMs} left=${providersLeftAfterThis} produced timeoutMs=${plan.timeoutMs}`,
+        );
+      }
+    }
+  }
+});
+
+test("#1370: the two waits share one budget — 180 + 60 can no longer both be spent", () => {
+  // The 255s-in-a-300s-test arithmetic, replayed. The credential wait takes its
+  // full ceiling on the second of three providers, and the configured-state wait
+  // that follows is then bounded by what is left rather than by its own 60s.
+  const budget = { remainingMs: 210_000 };
+  const credential = planSaveWait({
+    ceilingMs: 180_000,
+    remainingMs: budget.remainingMs,
+    providersLeftAfterThis: 1,
+  });
+  assert.equal(credential.wait, true);
+  budget.remainingMs -= (credential as { timeoutMs: number }).timeoutMs;
+
+  const configured = planSaveWait({
+    ceilingMs: 60_000,
+    remainingMs: budget.remainingMs,
+    providersLeftAfterThis: 1,
+  });
+  assert.equal(configured.wait, false, "30s left, all of it reserved for the provider still to come");
+
+  const spent = 210_000 - budget.remainingMs;
+  assert.ok(spent <= 180_000, `one provider must not be able to spend 240s of a 210s budget, spent ${spent}`);
+});
+
+// ─── The collector-stall verdict (#1370) ─────────────────────────────────────
+
+test("#1370: a collector stall is recognisable, and a key verdict is not mistaken for one", () => {
+  assert.equal(isCollectorStallReason(`${COLLECTOR_STALL_PREFIX}no credential write answered within 180s`), true);
+  assert.equal(isCollectorStallReason(NO_MODELS_COLLECTED), false);
+  assert.equal(
+    isCollectorStallReason("Incorrect API key provided: sk-proj-***"),
+    false,
+    "a dead key must keep failing the env-keyed step",
+  );
+  assert.equal(isCollectorStallReason(null), false);
+  assert.equal(isCollectorStallReason(undefined), false);
+});
+
+test("#1370: the empty-candidates path still produces the exact string the stall verdict replaces", async () => {
+  // The link between the two files is a string comparison, so this pins that
+  // `validateProviderWithFallback` keeps emitting the literal `collectProviders`
+  // matches on. Reword one side only and the stall verdict silently stops
+  // firing — the provider goes back to failing as a "key/account/config problem".
+  const { validate } = fakeValidator("anthropic", new Map());
+  const result = await quiet(() => validateProviderWithFallback("anthropic", [], validate));
+  assert.equal(result.error, NO_MODELS_COLLECTED);
+});
+
+// ─── resolveRequiredProviders (#1370) ────────────────────────────────────────
+
+test("#1370: unset requires every provider this run has a key for — today's behaviour", () => {
+  assert.deepEqual(resolveRequiredProviders(undefined, ["openai", "anthropic", "google"]), {
+    required: ["openai", "anthropic", "google"],
+    unrecognised: [],
+  });
+  assert.deepEqual(resolveRequiredProviders("", ["openai"]), { required: ["openai"], unrecognised: [] });
+  assert.deepEqual(resolveRequiredProviders("   ", ["openai"]), { required: ["openai"], unrecognised: [] });
+});
+
+test("#1370: the PR lane requires only the provider it pins itself to", () => {
+  // A stalled anthropic changes no spec that lane runs — it pins openai
+  // (#1169) — and yet it used to exit this pre-flight non-zero and cost the PR
+  // its entire E2E run.
+  assert.deepEqual(resolveRequiredProviders("openai", ["openai", "anthropic", "google"]), {
+    required: ["openai"],
+    unrecognised: [],
+  });
+});
+
+test("#1370: a typo is reported, never silently required-nothing", () => {
+  // The failure mode this guards: `openai ` misspelt filters to an empty
+  // `required`, the gate matches nothing, and it is gone with every check green.
+  const verdict = resolveRequiredProviders("openia", ["openai", "anthropic"]);
+  assert.deepEqual(verdict.required, []);
+  assert.deepEqual(verdict.unrecognised, ["openia"]);
+});
+
+test("#1370: naming a provider whose secret is unset is reported the same way", () => {
+  // Indistinguishable from a typo at this layer, and it must be: a lane that
+  // requires openai on a run with no OPENAI_API_KEY has a broken configuration,
+  // not a satisfied gate.
+  assert.deepEqual(resolveRequiredProviders("openai", ["anthropic"]), {
+    required: [],
+    unrecognised: ["openai"],
+  });
+});
+
+test("#1370: separators and case do not change the selection", () => {
+  assert.deepEqual(
+    resolveRequiredProviders(" OpenAI, anthropic ", ["openai", "anthropic", "google"]).required,
+    ["openai", "anthropic"],
+  );
+  assert.deepEqual(resolveRequiredProviders("openai google", ["openai", "google"]).required, [
+    "openai",
+    "google",
+  ]);
 });
 
 test("#1355: waitedMs is what lets the caller bound the SUM, not just each write", async () => {

--- a/tests/helpers/provider-setup/collect-models.ts
+++ b/tests/helpers/provider-setup/collect-models.ts
@@ -775,6 +775,10 @@ async function collectModelsForProvider(
   providersLeftAfterThis: number,
 ): Promise<ProviderCollection> {
   let stall: string | null = null;
+  // Whether a Save was actually issued. Without it the configured-state wait
+  // below would run for a provider this pass never saved — burning budget the
+  // remaining providers need, to answer a question nobody asked (#1370).
+  let saveClicked = false;
   await page.getByTestId(providerTestId).click();
 
   const apiKeyInput = page.getByPlaceholder(apiKeyPlaceholder);
@@ -796,15 +800,46 @@ async function collectModelsForProvider(
 
     const saveBtn = page.getByRole("button", { name: "Save", exact: true });
     if ((await saveBtn.count()) > 0) {
-      // BEFORE the click, and fail-loud (#1355): the panel marks `Save`
-      // `aria-busy="true" aria-disabled="true"` while a validation is in flight,
-      // including the previous provider's. `click()`'s own actionability wait is
-      // capped at 20s — shorter than the ~35s validation named below — so a busy
-      // button produced `locator.click: Timeout 20000ms exceeded` pointing at the
+      // BEFORE the click (#1355): the panel marks `Save` `aria-busy="true"
+      // aria-disabled="true"` while a validation is in flight, including the
+      // PREVIOUS provider's. `click()`'s own actionability wait is capped at 20s
+      // — shorter than the ~35s validation named below — so a busy button
+      // produced `locator.click: Timeout 20000ms exceeded` pointing at the
       // click, for a provider that was never the problem.
-      const verdict = await waitForButtonIdle(saveBtn);
-      if (!verdict.idle) throw new Error(formatSaveBusyFailure(providerName, verdict));
+      //
+      // This wait draws on the sweep's budget like the two below it, and it
+      // REPORTS instead of throwing (#1370). Both were found the hard way, on
+      // this fix's own first CI run: anthropic's write was still in flight when
+      // google's turn came, google's Save never went idle inside its own fixed
+      // 60s, and the throw ended the sweep — one provider's backend cost taking
+      // the whole pre-flight, which is the thing this issue is about. Recording
+      // it as a stall loses no signal: a stall still fails the gate on every
+      // lane that requires that provider, which on the daily is all of them.
+      const idlePlan = planSaveWait({
+        ceilingMs: SAVE_IDLE_TIMEOUT_MS,
+        remainingMs: budget.remainingMs,
+        providersLeftAfterThis,
+      });
+      const idleStartedAt = Date.now();
+      const verdict = idlePlan.wait
+        ? await waitForButtonIdle(saveBtn, { timeoutMs: idlePlan.timeoutMs })
+        : null;
+      budget.remainingMs -= Date.now() - idleStartedAt;
 
+      if (!idlePlan.wait) {
+        stall = `the "Save" button was never waited on — ${idlePlan.reason}`;
+        console.warn(
+          `⚠️  collect-models: skipped configuring provider "${providerName}" — ${idlePlan.reason}. ` +
+            `It is left unconfigured rather than clicked blind (#1370).`,
+        );
+      } else if (verdict && !verdict.idle) {
+        stall = formatSaveBusyFailure(providerName, verdict);
+        console.warn(`⚠️  collect-models: ${stall}`);
+      }
+    }
+
+    // The save itself, issued only when the button was observed actionable.
+    if (stall === null && (await saveBtn.count()) > 0) {
       // Wait for the credential WRITE itself, not for a clock (#1355).
       //
       // This is the measurement that settled it, taken locally with a funded
@@ -900,6 +935,7 @@ async function collectModelsForProvider(
           );
         }
       }
+      saveClicked = true;
     }
 
     // Provider validation can take ~35s (Google) — wait for the configured state
@@ -912,11 +948,13 @@ async function collectModelsForProvider(
     // like a provider with no models rather than a save that did not land.
     // Bounded by the same shared budget as the write above (#1370). It is the
     // second half of the 255 s a single stalling provider used to spend.
-    const configuredPlan = planSaveWait({
-      ceilingMs: CONFIGURED_STATE_TIMEOUT_MS,
-      remainingMs: budget.remainingMs,
-      providersLeftAfterThis,
-    });
+    const configuredPlan: SaveWaitPlan = saveClicked
+      ? planSaveWait({
+          ceilingMs: CONFIGURED_STATE_TIMEOUT_MS,
+          remainingMs: budget.remainingMs,
+          providersLeftAfterThis,
+        })
+      : { wait: false, reason: "no Save was issued for this provider" };
 
     if (!configuredPlan.wait) {
       stall ??= `the configured state was never waited for — ${configuredPlan.reason}`;

--- a/tests/helpers/provider-setup/collect-models.ts
+++ b/tests/helpers/provider-setup/collect-models.ts
@@ -245,6 +245,15 @@ function mostCommonError(counts: Map<string, number>): { error: string; count: n
   return { error, count };
 }
 
+/**
+ * Recorded when the panel handed the probe nothing to probe. Named so
+ * `collectProviders` can recognise the state and, when the collector also
+ * reported a stall, replace it with a verdict that names the right layer
+ * (#1370) — a string comparison against a literal spelled twice is how that
+ * link silently breaks.
+ */
+export const NO_MODELS_COLLECTED = "no models collected from the providers panel";
+
 export async function validateProviderWithFallback(
   provider: string,
   candidates: string[],
@@ -255,7 +264,7 @@ export async function validateProviderWithFallback(
       provider,
       model: null,
       status: "inactive",
-      error: "no models collected from the providers panel",
+      error: NO_MODELS_COLLECTED,
       checkedAt: new Date().toISOString(),
     };
   }
@@ -322,6 +331,7 @@ export async function validateProviderWithFallback(
 async function collectProviders(
   models: ModelRecord[],
   buildAxis: Record<string, ProviderVerdict>,
+  stalls: Map<string, string>,
 ): Promise<ProviderRecord[]> {
   console.log("Validating providers via API (key axis)...");
 
@@ -342,6 +352,16 @@ async function collectProviders(
       // provider cannot run either way, and the reason must name the layer that
       // is missing rather than blaming the key.
       return { ...r, status: "inactive" as const, error: axis.reason ?? "build axis failed" };
+    }
+    // A provider the collector never configured has NO key verdict to report:
+    // `validateProviderWithFallback` was handed zero candidates and never probed
+    // anything. Saying "real key/account/config problem" about it names the
+    // wrong layer, which is what cost the PR lane its E2E run (#1370). Applied
+    // only to that exact state — a provider that collected models despite a
+    // stalled wait was genuinely probed, and its verdict stands.
+    const stall = stalls.get(r.provider);
+    if (stall && r.error === NO_MODELS_COLLECTED) {
+      return { ...r, error: `${COLLECTOR_STALL_PREFIX}${stall}` };
     }
     return r;
   });
@@ -395,8 +415,198 @@ const TOGGLE_CONFIRM_POLL_MS = 100;
  * ceiling is set well clear of the worst measurement rather than just above it.
  *
  * It is a backstop, not the mechanism: the wait ends when the response lands.
+ *
+ * It is also a CEILING and not a promise: what a provider actually gets is
+ * whatever {@link planSaveWait} can still afford out of the sweep-wide budget
+ * below.
  */
 const CREDENTIAL_SAVE_TIMEOUT_MS = 180_000;
+
+/** Ceiling for the panel reaching the configured state (`Disconnect`) after a save. */
+const CONFIGURED_STATE_TIMEOUT_MS = 60_000;
+
+/**
+ * Budget shared by every post-Save wait in the sweep (#1370).
+ *
+ * The per-provider ceilings above were each sized against a measurement and
+ * NONE of them against the spec's own 5-minute timeout
+ * (`playwright.config.ts`), which is the only clock that can actually end the
+ * run. 180 s + 60 s + 15 s is **255 s spent on one provider** out of 300 s, so a
+ * single stalling provider consumed the run by arithmetic — measured on
+ * run 31188034419 attempt 2, which died at exactly 5 minutes with two waits
+ * completing 12 ms apart because the context had closed under them. Attempt 3
+ * survived the same anthropic stall with **3 s** to spare.
+ *
+ * Same pair of bounds the toggle confirmation already uses
+ * ({@link TOGGLE_CONFIRM_BUDGET_MS}, mirroring #1197 §4.4): a per-item timeout
+ * bounds ONE wait and can never see the sum.
+ *
+ * 210 s is the 300 s test timeout minus ~90 s reserved for everything that is
+ * NOT a post-Save wait — the build axis, the Settings navigation, the per-
+ * provider toggle sweeps (bounded at 15 s each), the key probes and the two file
+ * writes. Measured at ~55 s on the CI attempt above and ~24 s locally, so the
+ * reserve is deliberately generous: over-reserving costs a stalling provider its
+ * models, under-reserving costs the whole run.
+ */
+const SWEEP_SAVE_BUDGET_MS = 210_000;
+
+/**
+ * Floor kept back for each provider still to be configured.
+ *
+ * Without it the first stalling provider spends the entire budget and every
+ * provider after it gets nothing — which is the failure this budget exists to
+ * prevent, just moved one provider along. Google's credential write measured
+ * 15.7 s on the CI run, so 30 s leaves a healthy provider room.
+ */
+const SAVE_RESERVE_PER_PROVIDER_MS = 30_000;
+
+/**
+ * Below this, the wait is skipped instead of shortened.
+ *
+ * Load-bearing, not cosmetic: Playwright reads `timeout: 0` as **no timeout at
+ * all**, so an exhausted budget arriving at `waitForResponse` as `0` would wait
+ * forever — the exact opposite of what the budget is for. {@link planSaveWait}
+ * therefore returns a discriminated "don't wait" rather than a small number, so
+ * a zero can never reach Playwright by construction.
+ */
+const MIN_SAVE_WAIT_MS = 5_000;
+
+/**
+ * Why a wait ended without an answer — `expired` and `aborted` are NOT the same
+ * observation (#1370).
+ *
+ * The two post-Save waits used to end in `.catch(() => null)` / `.catch(() =>
+ * false)`, which made "my deadline passed" and "the page was closed under me"
+ * indistinguishable. On run 31188034419 attempt 2 the test hit its own 5-minute
+ * timeout and both pending waits rejected at once:
+ *
+ *     14:49:30.036  ⚠️ no credential write observed for provider "google" within 180s
+ *     14:49:30.048  ⚠️ provider "google" never showed the configured state within 60s
+ *     14:49:30.088  Error: locator.count: Target page, context or browser has been closed
+ *
+ * A 180 s wait and a 60 s wait, 12 ms apart, at most 15.2 s after the click.
+ * Neither measured anything, and the log read as two measured negatives — which
+ * is why the question "is 180 s simply too short?" was unanswerable from those
+ * runs. An aborted wait is UNKNOWN, never a negative (#1012).
+ */
+export type WaitFailureKind = "expired" | "aborted" | "unknown";
+
+export interface WaitFailure {
+  kind: WaitFailureKind;
+  /** First line of the underlying error, so an `unknown` is never anonymous. */
+  detail: string;
+}
+
+/**
+ * Classify why a Playwright wait rejected.
+ *
+ * The discriminator is measured, not assumed — both `page.waitForResponse` and
+ * `locator.waitFor` behave identically:
+ *
+ * | ended by | `name` | message |
+ * |---|---|---|
+ * | context closed | `Error` | `… Target page, context or browser has been closed` |
+ * | deadline | `TimeoutError` | `… Timeout 800ms exceeded …` |
+ *
+ * The closed-context case is tested FIRST and by message: it rejects with a
+ * plain `Error`, so keying on `name` alone would file it under `unknown`.
+ */
+export function classifyWaitFailure(error: unknown): WaitFailure {
+  const named = error as { name?: unknown; message?: unknown } | null;
+  const name = typeof named?.name === "string" ? named.name : "";
+  const message = typeof named?.message === "string" ? named.message : String(error ?? "");
+  const detail = message.split("\n")[0]?.trim() ?? "";
+
+  if (/target (?:page, context or browser|closed)|has been closed|test ended/i.test(message)) {
+    return { kind: "aborted", detail };
+  }
+  if (name === "TimeoutError" || /timeout \d+\s*m?s exceeded/i.test(message)) {
+    return { kind: "expired", detail };
+  }
+  // Neither signature matched. Reporting it as an expiry would invent a
+  // measurement; reporting it as an abort would invent a cause.
+  return { kind: "unknown", detail };
+}
+
+export type SaveWaitPlan = { wait: true; timeoutMs: number } | { wait: false; reason: string };
+
+/**
+ * Decide what one post-Save wait may spend out of the sweep's shared budget.
+ *
+ * Pure, so the arithmetic that #1370 got wrong is testable without a browser.
+ * The returned `timeoutMs` is never `0` — see {@link MIN_SAVE_WAIT_MS}.
+ */
+export function planSaveWait(options: {
+  ceilingMs: number;
+  remainingMs: number;
+  providersLeftAfterThis: number;
+  reservePerProviderMs?: number;
+  minWaitMs?: number;
+}): SaveWaitPlan {
+  const reservePerProvider = options.reservePerProviderMs ?? SAVE_RESERVE_PER_PROVIDER_MS;
+  const minWaitMs = options.minWaitMs ?? MIN_SAVE_WAIT_MS;
+  const reserved = Math.max(0, options.providersLeftAfterThis) * reservePerProvider;
+  const allowed = Math.min(options.ceilingMs, options.remainingMs - reserved);
+
+  if (allowed < minWaitMs) {
+    return {
+      wait: false,
+      reason:
+        `the sweep's shared budget is down to ${Math.max(0, Math.round(options.remainingMs / 1000))}s ` +
+        `with ${Math.max(0, options.providersLeftAfterThis)} provider(s) still to configure, so waiting ` +
+        `here would leave them nothing`,
+    };
+  }
+  return { wait: true, timeoutMs: allowed };
+}
+
+/**
+ * Marks a provider the COLLECTOR never managed to configure — as opposed to one
+ * whose key was probed and rejected (#1370).
+ *
+ * Same convention as the `build axis: ` prefix, and for the same reason: a
+ * verdict has to name the layer it is about. Without it, a stalled save reached
+ * `validateProviderWithFallback` with zero candidates, recorded
+ * `no models collected from the providers panel`, and the spec failed it under
+ * "real key/account/config problem" — for a provider whose key was never probed
+ * at all and whose build axis had reported OK. The #1011 mistake in a new place.
+ */
+export const COLLECTOR_STALL_PREFIX = "collector stall: ";
+
+export function isCollectorStallReason(error: string | null | undefined): boolean {
+  return typeof error === "string" && error.startsWith(COLLECTOR_STALL_PREFIX);
+}
+
+/**
+ * Which providers this LANE cannot run without (#1370).
+ *
+ * Unset — the daily, `manual.yml` and every local run — means every provider
+ * whose env key is set, i.e. today's behaviour unchanged. `pr-validation.yml`
+ * sets it to the one provider that lane already pins itself to
+ * (`select-pr-model-target.mjs --provider openai`, #1169), because a stalled
+ * anthropic there changes no spec that lane will execute and yet exits the
+ * shared pre-flight non-zero, taking the PR's whole E2E run with it.
+ *
+ * A name that is not among the providers this run has a key for is returned as
+ * `unrecognised` rather than dropped: silently requiring nothing is how a typo
+ * in a workflow disables a gate for good (#1012).
+ */
+export function resolveRequiredProviders(
+  raw: string | undefined,
+  keyedAndConfigured: readonly string[],
+): { required: string[]; unrecognised: string[] } {
+  const listed = (raw ?? "")
+    .split(/[\s,]+/)
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry) => entry.length > 0);
+  if (listed.length === 0) return { required: [...keyedAndConfigured], unrecognised: [] };
+
+  const known = new Set(keyedAndConfigured);
+  return {
+    required: listed.filter((entry) => known.has(entry)),
+    unrecognised: listed.filter((entry) => !known.has(entry)),
+  };
+}
 
 /** The `Locator` surface {@link waitForButtonIdle} reads — narrow so the unit lane can drive it with a fake. */
 export interface ButtonStateLocator {
@@ -540,13 +750,31 @@ export function formatSaveBusyFailure(providerName: string, verdict: ButtonIdleV
   ].join("\n");
 }
 
+/** Mutable remainder of {@link SWEEP_SAVE_BUDGET_MS}, threaded through the loop. */
+interface SweepBudget {
+  remainingMs: number;
+}
+
+/**
+ * What one provider's pass produced: its models, and — when the collector never
+ * managed to configure it — the reason, so the verdict downstream can name the
+ * collector instead of blaming the key (#1370).
+ */
+interface ProviderCollection {
+  models: ModelRecord[];
+  stall: string | null;
+}
+
 async function collectModelsForProvider(
   page: Page,
   providerTestId: string,
   providerName: string,
   apiKeyPlaceholder: string,
   apiKeyEnvVar: string,
-): Promise<ModelRecord[]> {
+  budget: SweepBudget,
+  providersLeftAfterThis: number,
+): Promise<ProviderCollection> {
+  let stall: string | null = null;
   await page.getByTestId(providerTestId).click();
 
   const apiKeyInput = page.getByPlaceholder(apiKeyPlaceholder);
@@ -589,46 +817,88 @@ async function collectModelsForProvider(
       // providers already configured.
       //
       // Registered BEFORE the click, or the response can land first and be
-      // missed. Resolves to `null` on timeout rather than throwing: the save may
-      // still have succeeded, the `Disconnect` check below is the second opinion,
-      // and this helper's job is to report rather than to abort the pre-flight.
-      const savePending = page
-        .waitForResponse(
-          (r) => {
-            const method = r.request().method();
-            return (
-              /^\/api\/v1\/variables\/?$/.test(new URL(r.url()).pathname) &&
-              (method === "POST" || method === "PATCH" || method === "PUT")
-            );
-          },
-          { timeout: CREDENTIAL_SAVE_TIMEOUT_MS },
-        )
-        .catch(() => null);
-      const startedAt = Date.now();
-      await saveBtn.click();
-      const saveResponse = await savePending;
-      const elapsedMs = Date.now() - startedAt;
+      // missed. Never throws: the save may still have succeeded, the
+      // `Disconnect` check below is the second opinion, and this helper's job is
+      // to report rather than to abort the pre-flight.
+      //
+      // What it may SPEND is the sweep's, not this provider's (#1370): the
+      // ceiling alone let one stalling provider eat a 300 s test budget in
+      // 255 s of waits.
+      const plan = planSaveWait({
+        ceilingMs: CREDENTIAL_SAVE_TIMEOUT_MS,
+        remainingMs: budget.remainingMs,
+        providersLeftAfterThis,
+      });
 
-      if (!saveResponse) {
+      if (!plan.wait) {
+        stall = `the credential write was never waited for — ${plan.reason}`;
         console.warn(
-          `⚠️  collect-models: no credential write observed for provider "${providerName}" within ` +
-            `${CREDENTIAL_SAVE_TIMEOUT_MS / 1000}s of clicking Save. The panel stays busy while a write is ` +
-            `in flight, so the NEXT provider is what pays for this (#1355).`,
+          `⚠️  collect-models: skipped waiting for provider "${providerName}"'s credential write — ` +
+            `${plan.reason}. Whatever it collects below is unverified (#1370).`,
         );
-      } else if (!saveResponse.ok()) {
-        console.warn(
-          `⚠️  collect-models: the credential write for provider "${providerName}" answered ` +
-            `HTTP ${saveResponse.status()} after ${(elapsedMs / 1000).toFixed(1)}s. Its models will not ` +
-            `collect (#1355).`,
-        );
-      } else if (elapsedMs > 10_000) {
-        // Not a failure — a trend. The save cost grows with how many providers
-        // are already configured, and this line is what makes that visible
-        // before it crosses the ceiling again.
-        console.log(
-          `   collect-models: provider "${providerName}" credential write took ` +
-            `${(elapsedMs / 1000).toFixed(1)}s (HTTP ${saveResponse.status()}).`,
-        );
+        await saveBtn.click();
+      } else {
+        const savePending = page
+          .waitForResponse(
+            (r) => {
+              const method = r.request().method();
+              return (
+                /^\/api\/v1\/variables\/?$/.test(new URL(r.url()).pathname) &&
+                (method === "POST" || method === "PATCH" || method === "PUT")
+              );
+            },
+            { timeout: plan.timeoutMs },
+          )
+          .then((response) => ({ response, failure: null as WaitFailure | null }))
+          .catch((error: unknown) => ({ response: null, failure: classifyWaitFailure(error) }));
+        const startedAt = Date.now();
+        await saveBtn.click();
+        const { response: saveResponse, failure } = await savePending;
+        const elapsedMs = Date.now() - startedAt;
+        budget.remainingMs -= elapsedMs;
+
+        if (failure?.kind === "aborted") {
+          // The wait never ran. Printing "no write observed within Ns" here is
+          // what made run 31188034419 attempt 2 unreadable — two waits totalling
+          // 240 s reported as measured negatives 12 ms apart, because the test
+          // had already timed out and closed the context (#1370, #1012).
+          stall = `the credential write was never observed — the wait was cut short (${failure.detail})`;
+          console.warn(
+            `⚠️  collect-models: the credential-write wait for provider "${providerName}" was CUT SHORT ` +
+              `after ${(elapsedMs / 1000).toFixed(1)}s — the page or context closed under it ` +
+              `(${failure.detail}). This run gives NO signal about that write; it is unknown, not absent (#1370).`,
+          );
+        } else if (failure?.kind === "unknown") {
+          stall = `the credential write was never observed — the wait failed for an unrecognised reason (${failure.detail})`;
+          console.warn(
+            `⚠️  collect-models: the credential-write wait for provider "${providerName}" failed after ` +
+              `${(elapsedMs / 1000).toFixed(1)}s for a reason this code does not recognise ` +
+              `(${failure.detail}). Treated as no signal rather than as a measurement (#1370).`,
+          );
+        } else if (!saveResponse) {
+          stall = `no credential write answered within ${(plan.timeoutMs / 1000).toFixed(0)}s of clicking Save`;
+          console.warn(
+            `⚠️  collect-models: no credential write observed for provider "${providerName}" within ` +
+              `${(plan.timeoutMs / 1000).toFixed(0)}s of clicking Save. The panel stays busy while a write is ` +
+              `in flight, so the NEXT provider is what pays for this (#1355).`,
+          );
+        } else if (!saveResponse.ok()) {
+          stall = `the credential write answered HTTP ${saveResponse.status()}`;
+          console.warn(
+            `⚠️  collect-models: the credential write for provider "${providerName}" answered ` +
+              `HTTP ${saveResponse.status()} after ${(elapsedMs / 1000).toFixed(1)}s. Its models will not ` +
+              `collect (#1355).`,
+          );
+        } else if (elapsedMs > 10_000) {
+          // Not a failure — a trend. The save cost grows with how many providers
+          // are already configured, and this line is what makes that visible
+          // before it crosses the ceiling again.
+          console.log(
+            `   collect-models: provider "${providerName}" credential write took ` +
+              `${(elapsedMs / 1000).toFixed(1)}s (HTTP ${saveResponse.status()}), leaving ` +
+              `${Math.max(0, Math.round(budget.remainingMs / 1000))}s of the sweep's shared budget.`,
+          );
+        }
       }
     }
 
@@ -640,17 +910,62 @@ async function collectModelsForProvider(
     // models, and `.catch(() => {})` made "never configured" and "configured
     // fine" the same observation — so the empty collection downstream looked
     // like a provider with no models rather than a save that did not land.
-    const configured = await page
-      .getByRole("button", { name: "Disconnect", exact: true })
-      .waitFor({ state: "visible", timeout: 60000 })
-      .then(() => true)
-      .catch(() => false);
-    if (!configured) {
+    // Bounded by the same shared budget as the write above (#1370). It is the
+    // second half of the 255 s a single stalling provider used to spend.
+    const configuredPlan = planSaveWait({
+      ceilingMs: CONFIGURED_STATE_TIMEOUT_MS,
+      remainingMs: budget.remainingMs,
+      providersLeftAfterThis,
+    });
+
+    if (!configuredPlan.wait) {
+      stall ??= `the configured state was never waited for — ${configuredPlan.reason}`;
       console.warn(
-        `⚠️  collect-models: provider "${providerName}" never showed the configured state ` +
-          `("Disconnect") within 60s of Save. Whatever this run collects for it is suspect — ` +
-          `an empty model list below is that, not a provider without models (#1355).`,
+        `⚠️  collect-models: skipped waiting for provider "${providerName}" to reach the configured ` +
+          `state ("Disconnect") — ${configuredPlan.reason}. Whatever it collects below is unverified (#1370).`,
       );
+    } else {
+      const configuredAt = Date.now();
+      const configured = await page
+        .getByRole("button", { name: "Disconnect", exact: true })
+        .waitFor({ state: "visible", timeout: configuredPlan.timeoutMs })
+        .then(() => ({ ok: true, failure: null as WaitFailure | null }))
+        .catch((error: unknown) => ({ ok: false, failure: classifyWaitFailure(error) }));
+      budget.remainingMs -= Date.now() - configuredAt;
+
+      if (!configured.ok && configured.failure?.kind !== "expired") {
+        // `aborted` and `unknown` are both "no signal", but they are not the
+        // same claim and the warning must not pick one for the reader: an
+        // aborted wait names the page closing, an unknown one names nothing at
+        // all. Saying "cut short" about an unrecognised error would invent the
+        // cause, which is the mirror of the defect this whole branch exists for.
+        const observed =
+          configured.failure?.kind === "aborted"
+            ? "was CUT SHORT — the page or context closed under it"
+            : "failed for a reason this code does not recognise";
+        const detail = configured.failure?.detail ?? "no detail";
+        stall ??= `the configured state was never observed — the wait ${
+          configured.failure?.kind === "aborted" ? "was cut short" : "failed unrecognisably"
+        } (${detail})`;
+        console.warn(
+          `⚠️  collect-models: the configured-state wait for provider "${providerName}" ${observed} ` +
+            `(${detail}). This run gives NO signal about whether the save landed; it is unknown, not a ` +
+            `failed save (#1370).`,
+        );
+      } else if (!configured.ok) {
+        stall ??= `the panel never reached the configured state ("Disconnect") within ${(configuredPlan.timeoutMs / 1000).toFixed(0)}s of Save`;
+        console.warn(
+          `⚠️  collect-models: provider "${providerName}" never showed the configured state ` +
+            `("Disconnect") within ${(configuredPlan.timeoutMs / 1000).toFixed(0)}s of Save. Whatever this ` +
+            `run collects for it is suspect — an empty model list below is that, not a provider without ` +
+            `models (#1355).`,
+        );
+      } else {
+        // The save landed after all, so nothing the waits above recorded is a
+        // stall any more. Leaving it set would report a configured provider as
+        // one the collector never reached.
+        stall = null;
+      }
     }
   }
 
@@ -735,32 +1050,43 @@ async function collectModelsForProvider(
 
   await page.getByTestId("sidebar-nav-Model Providers").click();
 
-  return models;
+  return { models, stall };
 }
 
-async function collectModels(page: Page): Promise<ModelRecord[]> {
+async function collectModels(page: Page): Promise<{
+  models: ModelRecord[];
+  stalls: Map<string, string>;
+}> {
   const settingsPage = new SettingsPage(page);
   await settingsPage.navigate();
   await page.getByTestId("sidebar-nav-Model Providers").click();
 
   const allModels: ModelRecord[] = [];
+  const stalls = new Map<string, string>();
+
+  // One budget for the whole sweep, spent down as each provider's post-Save
+  // waits actually run (#1370).
+  const budget: SweepBudget = { remainingMs: SWEEP_SAVE_BUDGET_MS };
+  const providers = [...keyedProviders];
 
   // Keyed providers only. This sweep SAVES an API key per provider through the
   // Settings UI, so a keyless one (Ollama, #1187) has nothing for it to do here —
   // and its model list is the live instance's, not a catalog to collect.
-  for (const [provider, config] of keyedProviders) {
-    allModels.push(
-      ...(await collectModelsForProvider(
-        page,
-        config.providerTestId,
-        provider,
-        config.keyPlaceholder,
-        config.envKeys[0],
-      )),
+  for (const [index, [provider, config]] of providers.entries()) {
+    const collection = await collectModelsForProvider(
+      page,
+      config.providerTestId,
+      provider,
+      config.keyPlaceholder,
+      config.envKeys[0],
+      budget,
+      providers.length - 1 - index,
     );
+    allModels.push(...collection.models);
+    if (collection.stall) stalls.set(provider, collection.stall);
   }
 
-  return allModels;
+  return { models: allModels, stalls };
 }
 
 // ─── Main export ───────────────────────────────────────────────────────────────
@@ -809,10 +1135,10 @@ export async function collectAll(page: Page): Promise<void> {
   const buildAxis = await probeBuildAxis(page.request, keyedProviderNames);
 
   // Step 2: Collect models from UI via Settings
-  const models = await collectModels(page);
+  const { models, stalls } = await collectModels(page);
 
   // Step 3: Validate the key axis and merge both verdicts
-  const providers = await collectProviders(models, buildAxis);
+  const providers = await collectProviders(models, buildAxis, stalls);
   fs.writeFileSync(PROVIDERS_PATH, JSON.stringify(providers, null, 2), "utf-8");
   console.log(`providers.json saved with ${providers.length} providers.`);
 


### PR DESCRIPTION
Closes #1370

## The problem

`Collect models` is a **hard gate** on `pr-validation.yml`: when it exits non-zero the impacted-specs step never runs and the PR gets **no E2E coverage of its own diff**. It did that twice on 2026-08-07 across two branches, and the warning it printed was not describing the failure it caused.

## What the investigation found

Read off the job logs of **all three attempts** of [run 31188034419](https://github.com/oriontech-me/langflow-e2e/actions/runs/31188034419), not inferred from the deadline expiring. Two premises died on the way — one the issue's, one mine.

**The issue says the stalling provider moves between attempts.** It does not. anthropic stalled **3 of 3**; google never stalled. What looked like a second provider was defect 1 lying.

**The deadline expiring is not the failure.** Attempt 3 printed the *same* two anthropic warnings and **passed**, 90 models, ~242 s after Save. The 180 s warning fires on a green run.

### 1 — A wait that never ran must not report a measurement

Both post-Save waits ended in `.catch(() => null)` / `.catch(() => false)`, so *"my deadline passed"* and *"the page closed under me"* were the same observation. On attempt 2 the spec hit its own 5-minute timeout and both pending waits rejected at once:

```
14:49:30.036  ⚠️ no credential write observed for provider "google" within 180s
14:49:30.048  ⚠️ provider "google" never showed the configured state ("Disconnect") within 60s
14:49:30.088  Error: locator.count: Target page, context or browser has been closed
```

A **180 s** wait and a **60 s** wait completing **12 ms apart**, at most 15.2 s after the click. Neither observed anything — and that is why the issue's own question ("is 180 s simply short?") is unanswerable from those runs.

The discriminator was measured directly against both surfaces, not remembered:

| ended by | `name` | message |
|---|---|---|
| context closed | `Error` | `… Target page, context or browser has been closed` |
| deadline | `TimeoutError` | `… Timeout 800ms exceeded …` |

Now classified instead of discarded, with a third `unknown` state so an unrecognised failure invents neither a measurement nor a cause (#1012).

### 2 — Per-provider ceilings the test's own budget cannot pay

180 s (credential write) + 60 s (configured state) + 15 s (toggles) is **255 s spent on one provider** inside a **300 s** test timeout (`playwright.config.ts:89`). A single stall consumes the run by arithmetic. Attempt 2 died at exactly 5 minutes; attempt 3 survived with **3 s** to spare.

`planSaveWait` gives the sweep the pair of bounds the toggle confirmation already has (#1197 §4.4) — a per-item timeout bounds ONE wait and can never see the sum. It returns a discriminated *"don't wait"* rather than a small number, because Playwright reads `timeout: 0` as **no timeout at all**.

### 3 — `no models collected` is a collector verdict, not a key verdict

A stalled save hands `validateProviderWithFallback` **zero candidates**, so the provider is recorded `inactive` having never been probed — and that landed in `hardFailures`, failing the spec as *"real key/account/config problem"* for a provider whose build axis reported ✅ and whose key was never touched. The #1011 mistake in a new place. It now carries a `collector stall: ` prefix (mirroring `build axis: `) and gets its own step.

## Why this is not a weakened assertion

The new step is scoped by `COLLECT_REQUIRED_PROVIDERS`, and this is the half worth reading carefully.

`pr-validation.yml` pins its own run to one provider (`select-pr-model-target.mjs --provider openai`, #1169, gated on the same `needs_models` as the sweep), so a stalled anthropic there changes **no spec that lane will execute** — and yet it cost the lane everything.

- **Unset** (daily, `manual.yml`, every local run) still requires **every env-keyed provider** — #570's guarantee unchanged where it bites.
- **Nothing else narrows**: a dead key, an image that cannot build a component, a total wipeout and a broken Model Providers UI all still fail for every provider on every lane.
- A name the run has no key for is **reported**, never dropped — silently requiring nothing is how a typo disables a gate for good.

`PR_LANE_PROVIDER` is declared once at job level: the gate and the pin must not drift, or the lane would gate on a provider it does not run and run one it does not gate. The daily's opposite trade (`continue-on-error`, #980) is now stated in that file rather than implied by the other one — deliverable 3.

## What it costs, stated rather than buried

With the budget in place, attempt 3's anthropic would have collected **zero** models instead of 13. It passed by luck, 3 s from the timeout. The trade is one stalling provider's collection against the whole run.

The underlying slowness (anthropic's write >240 s in CI, 103 s locally per #1357) is a backend cost this PR does **not** explain. It makes the lane survive it.

## Validation

**Langflow `1.12.0.dev19`** (nightly, `langflowai/langflow-nightly:latest`)

```
run 1/3 : clean expected=1  160s
run 2/3 : clean expected=1  123s
run 3/3 : clean expected=1   17s
typecheck=0  lint=0   units 539/539   scripts 797/797
FF coverage: complete · no FF-MUTATION markers in diff ✓ · final green run after reverts ✓
```

Run 1 started from a fresh container and exercised the full save path for all three providers; run 3 took the `alreadyConfigured` short-circuit.

**The first burst was rejected, and why matters.** It read `clean expected=1 / clean expected=0 / clean expected=0`. Runs 2 and 3 lasted `128292 ms` and `128257 ms` — **35 ms apart**, a fixed clock: `HEALTH_TIMEOUT_MS = 120_000` in `tests/globalSetup.ts:77`. Run 1's sweep wedged the local backend (#922/#927) and the next two aborted in `globalSetup` without getting a test to the browser. They were nonetheless recorded **clean**, because that classification checks `unexpected === 0` and never `expected > 0` — a zero-test run counting as proof of stability, the `runguard`/#1012 lesson missing one layer up. Container restarted, burst re-run on a clean target; the three `expected=1` above are that burst. Filed separately — it is out of this branch's scope.

**Force-fail:** every provider record rewritten to carry a collector-stall reason ⇒ the new step's `fatal` list non-empty → `unexpected=1`; reverted; final green confirmed.

**Unit mutation** (a test that cannot fail proves nothing): deleting the `aborted` branch kills 2 tests; disabling the budget's skip branch kills 3.

**Orphan flows:** 26, all starter templates seeded by the fresh container. Zero leaked.

## Coverage

18 unit tests in `collect-models.test.ts` plus a structural guard in `select-pr-model-target.test.mjs` that pins an **absence** — no provider name spelled twice outside comments — the same shape as the `--grep` composition guard (#1275). The stall itself needs a loaded CI runner and is not reproducible on demand, so what is tested is the decision: when it gives up, what it reports, and what it fails on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
