### PR TITLE
fix(mcp): settle the agent guard on the provider, not a credential upstream stopped writing (#1371)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -714,7 +714,7 @@
 - [x] Execute numeric tool with inputs and verify result → `mcp/client/mcp-client-regression.spec.ts`
 - [x] Duplicate MCP server registration returns 409 Conflict → `mcp/client/mcp-server-registration-status-codes.spec.ts`
 - [x] Deleting a non-existent MCP server returns 404 Not Found → `mcp/client/mcp-server-registration-status-codes.spec.ts`
-- [x] Agent uses MCPTools as tool and calls echo via MCP → `mcp/client/mcp-client-agent.spec.ts`
+- [-] Agent uses MCPTools as tool and calls echo via MCP → `mcp/client/mcp-client-agent.spec.ts` (automated, not `@stable` — no lane runs it, so it cannot report a regression; #1371)
 - [x] Gemini × MCP tool-calling regression — agent invokes the echo MCP tool (regression for fixed upstream #440) → `mcp/client/mcp-client-agent-gemini-tool-regression.spec.ts`
 - [ ] List available resources via MCP protocol (client not-implementable on 1.11.x — MCPTools component and v2 client API expose tools only; server-side resources covered in §14.1 → `mcp/server/mcp-server-resources.spec.ts`)
 - [ ] Consume resource URI and inject content into flow (client not-implementable on 1.11.x — no client resource surface; server-side read covered in §14.1 → `mcp/server/mcp-server-resources.spec.ts`)

--- a/docs/mcp/client/mcp-client-agent.md
+++ b/docs/mcp/client/mcp-client-agent.md
@@ -1,6 +1,6 @@
 # MCP Client – Agent Using MCPTools
 
-**Last validated:** Langflow 1.12.x
+**Last validated:** Langflow 1.12.x (1.12.0.dev19)
 
 ---
 
@@ -18,7 +18,7 @@ Validates that an LLM agent can discover and call an MCP tool mid-conversation v
 
 ## Step by step *(required)*
 
-1. Load Simple Agent template via `SimpleAgentTemplatePage` (parameterized by `models.json`)
+1. Load the Simple Agent template with this spec's **own** `loadAgent` (parameterized by `models.json`) — *not* `SimpleAgentTemplatePage.load()`, for the reason in *Why this spec loads the agent itself* below — then block until the Agent node's persisted **provider binding** has settled
 2. Delete any existing `everything` MCP server via API, then register via JSON tab
 3. Poll `GET /api/v2/mcp/servers?action_count=true` until `toolsCount` is non-null
 4. Add MCPTools component to canvas
@@ -35,6 +35,7 @@ Validates that an LLM agent can discover and call an MCP tool mid-conversation v
 ## Validation criterion *(required)*
 
 - The Playground renders a tool-invocation block for the `echo` tool (Proofs #1–#2) AND the agent's final response contains `"hello mcp"` (Proof #3) — together confirming the MCP echo tool was called and its result returned to the user.
+- **Precondition, asserted rather than assumed:** before the Playground is opened, the persisted Agent node names the **provider** of the requested model. A failure here is reported with the shared verdict taxonomy (`settled` / `default-provider` / `no-model` / `read-failed` / …) rather than a bare mismatch, so a run that never managed to read the flow is not reported as a wrong binding (#1371, the `read-failed` distinction #1261 needed).
 
 > **1.12 rendering (why the locators changed).** Through ~1.11 the tool call surfaced as a `.cursor-pointer` accordion row reading `"Called tool ECHO"`; on 1.12 the Playground renders it as a **testid** `tool_echo` inside `div-tools_tools_metadata` under an **"Agent Steps"** block, and the AI message container moved from `div-chat-message` to `chat-message-AI-<text>`. The tool round-trip itself is unchanged and healthy — verified on `1.12.0.dev0` via `GET /api/v1/monitor/messages` (`content_blocks: ["tool_use|text|text"]`, `tool_use name=echo`, `text="Echo: hello mcp"`). The old text-based selectors were stale drift (#894), not a product regression.
 
@@ -48,7 +49,8 @@ Validates that an LLM agent can discover and call an MCP tool mid-conversation v
 - `src/frontend/src/components/core/parameterRenderComponent/components/mcpComponent/index.tsx` — tool mode toggle and toolset handle
 - `src/frontend/src/components/core/chatComponents/ContentBlockDisplay.tsx` (+ the Playground tool-metadata renderer) — emits the `div-tools_tools_metadata` / `tool_<name>` testids and the "Agent Steps" block asserted by Proofs #1–#2
 - npm package `@modelcontextprotocol/server-everything` — launched via `npx`
-- `tests/pages/SimpleAgentTemplatePage.ts` — loads Simple Agent template with configured provider/model
+- `tests/helpers/flows/agent-credential-settle.ts` — the shared probe, verdict taxonomy and failure formatter this spec's load guard settles on (#1274/#1371). Only the pure functions are shared; the wait loop is this spec's own
+- `tests/helpers/flows/load-template-by-name.ts` — loads the Simple Agent template and returns the created flow id
 - `tests/helpers/provider-setup/` — provider env key validation and model parameterization
 
 ---
@@ -71,8 +73,48 @@ Validates that an LLM agent can discover and call an MCP tool mid-conversation v
 
 ## Notes *(optional)*
 
-- `SimpleAgentTemplatePage.load()` deletes all existing flows before loading the template. MCP server registration must happen after the template loads, as server data lives in a separate DB table and survives the cleanup.
+- MCP server registration happens after the template loads; server data lives in a separate DB table and survives flow teardown.
 - The test is parameterized: one describe block is generated per active provider in `models.json`. Run with `--workers=1` to prevent parallel workers from deleting each other's flows.
+
+### Why this spec loads the agent itself, and what its guard settles on (#1371)
+
+This spec does **not** call `SimpleAgentTemplatePage.load()`, and until #1371 this
+document said three times that it did — in step 1, in the dependency list and here.
+That staleness is part of how the defect below survived two sweeps: a reader checking
+whether this spec used the shared, already-migrated guard would read the doc, see the
+page object named, and conclude it did.
+
+**Why it loads the agent itself.** `SimpleAgentTemplatePage.load()` always runs
+`providerSetupMap[provider]`, which opens the Model Providers panel and enables *every*
+model of the provider — each enable is a live synchronous credential validation that
+blocks the single-worker backend for ~35 s when the provider throttles it (#922/#927).
+This spec's `selectPinnedModel` picks the pinned model straight from the Agent dropdown
+and falls back to the shared setup only when the model is not offered. Adopting `load()`
+outright would delete the divergence at the cost of that, so the guard is re-pointed onto
+the shared axis while the cheap load path stays.
+
+**What the guard settles on.** The **provider of the persisted model**
+(`model.value[0].provider`), never `template.api_key.value`. Upstream
+[#14311](https://github.com/langflow-ai/langflow/pull/14311) (*"stop automatic provider
+field binding"*, on the 1.12 line since 2026-08-04) deleted the block that wrote the
+credential variable name into `api_key`; measured on `1.12.0.dev18`/`dev19` it reads
+`{value: "", load_from_db: false}` from mount onward on **every** build, for every
+provider. A guard waiting for that transition cannot settle — it can only spend its
+budget and fail. This spec carried the last surviving assertion on that field, missed by
+#1274 (which migrated the shared helper and 19 `@stable` specs with it) and by #1334
+(whose sweep grepped `credential:`, a spelling this copy does not use).
+
+The provider is not a weaker proxy for the credential: with `api_key` empty the runtime
+resolves the key **from** it — `instantiation.py` reads `model.value[0].provider` and
+calls `get_api_key_for_provider`, which falls through to
+`get_provider_secret_variable_key(provider)`. #1334 proved that causally: dropping only
+that provider's own credential turns the run into `401 … Incorrect API key provided:
+EMPTY` while the binding is unchanged.
+
+The race #751 exists for is unchanged and still real, which is why the guard is
+re-pointed rather than deleted: a freshly mounted Agent node carries the selector's
+default (`claude-opus-5` / Anthropic) and only later flips to the requested model, so a
+caller that reaches the Playground in between runs the wrong provider's model.
 
 - **Test title changed in #1184 when `MODEL_TEST_ID` is set.** This spec used to carry its own copy of the target resolver, and that copy labelled the pinned target `model:<id>` rather than `<provider> / <id>`. Under the shared `resolveTestTargets()` it matches every other parametrized spec:
 

--- a/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-agent.spec.ts
@@ -5,11 +5,18 @@ import { expect, test } from "../../../../fixtures/fixtures";
 import type { LoadSimpleAgentOptions } from "../../../../pages";
 import {
   hasProviderEnvKeys,
+  langflowProviderName,
   missingProviderEnvKeys,
   providerConfigMap,
   providerSetupMap,
   type Provider,
 } from "../../../../helpers/provider-setup";
+import {
+  classifyCredentialSettle,
+  formatCredentialSettleFailure,
+  readAgentCredentialProbe,
+  type AgentCredentialProbe,
+} from "../../../../helpers/flows/agent-credential-settle";
 import { resolveTestTargets } from "../../../../helpers/provider-setup/test-targets";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { loadTemplateByName } from "../../../../helpers/flows/load-template-by-name";
@@ -67,24 +74,95 @@ async function selectPinnedModel(page: Page, model: string): Promise<boolean> {
   return true;
 }
 
-// #751: the model selection rebinds `api_key` via a debounced autosave — running the
-// Playground before it lands builds with the wrong provider's key.
+/** Budget for the settle guard below — the pre-#1371 value, deliberately unchanged. */
+const CREDENTIAL_SETTLE_TIMEOUT_MS = 20_000;
+
+/**
+ * Block until the Agent node's persisted **provider binding** has settled (#751).
+ *
+ * The race is real and unchanged: the node mounts on the model selector's DEFAULT
+ * model — measured `{ name: "claude-opus-5", provider: "Anthropic" }` — and only
+ * flips to the requested one once the editor's debounced autosave
+ * `PATCH /api/v1/flows/{id}` carries the pick. A caller that reaches the Playground
+ * in between runs the wrong provider's model with the wrong provider's key.
+ *
+ * **The axis is the provider, never `api_key` (#1371).** This function used to
+ * assert `template.api_key.value === "<PROVIDER>_API_KEY"`, and upstream
+ * [#14311](https://github.com/langflow-ai/langflow/pull/14311) deleted the block
+ * that wrote it. Measured on `1.12.0.dev19` before this change: `Expected
+ * "OPENAI_API_KEY" / Received ""`, 3 runs out of 3, always inside the load step —
+ * the field is empty from mount onward on every build, so the transition could
+ * only ever time out. This was the THIRD copy of that premise: #1274 migrated the
+ * shared helper and 19 `@stable` specs with it, #1334 migrated the inline copy in
+ * `openai-compatible-provider-setup.spec.ts`, and this one survived both because
+ * its sweep grepped `credential:`, a spelling this file never used.
+ *
+ * The provider is not a weaker proxy: with `api_key` empty the runtime resolves the
+ * key FROM it — `instantiation.py` reads `model.value[0].provider` and calls
+ * `get_api_key_for_provider`, which falls through to
+ * `get_provider_secret_variable_key(provider)`.
+ *
+ * Classification and the failure text come from the SHARED module so this file
+ * cannot drift off the axis again; only the wait loop is local, because this spec
+ * loads the agent its own way (see `loadAgent`).
+ */
 async function waitForAgentCredentialSettled(
   page: Page,
   flowId: string,
-  expectedCredential: string,
+  expectedProvider: string,
+  expectedModel?: string,
 ): Promise<void> {
   const auth = await getAuthToken(page.request);
   const headers = auth ? { Authorization: auth } : undefined;
-  await expect(async () => {
-    const res = await page.request.get(`/api/v1/flows/${flowId}`, { headers });
-    expect(res.ok()).toBe(true);
-    const flow = await res.json();
-    const agent = (flow?.data?.nodes ?? []).find(
-      (n: { data?: { type?: string } }) => n?.data?.type === "Agent",
+
+  const startedAt = Date.now();
+  let probe: AgentCredentialProbe | null = null;
+  let reads = 0;
+  let lastReadError: string | undefined;
+
+  try {
+    await expect(async () => {
+      let flow: unknown;
+      try {
+        const res = await page.request.get(`/api/v1/flows/${flowId}`, { headers });
+        expect(res.ok()).toBe(true);
+        flow = await res.json();
+      } catch (e: any) {
+        // Tracked, not swallowed: a guard that never managed to READ the flow must
+        // not report "the binding is wrong" about a payload nobody saw (#1261).
+        lastReadError = e?.message ?? String(e);
+        throw e;
+      }
+      reads += 1;
+      lastReadError = undefined;
+      probe = readAgentCredentialProbe(flow);
+      expect(classifyCredentialSettle(probe, expectedProvider, expectedModel)).toBe(
+        "settled",
+      );
+    }).toPass({
+      timeout: CREDENTIAL_SETTLE_TIMEOUT_MS,
+      intervals: [500, 1000, 2000],
+    });
+  } catch {
+    // Re-thrown as the shared, self-describing diagnostic. A bare `toBe` mismatch
+    // here reads as a provider-wiring bug and was triaged as one twice (#1072).
+    throw new Error(
+      formatCredentialSettleFailure({
+        flowId,
+        provider: expectedProvider,
+        expectedProvider,
+        expectedModel,
+        probe,
+        verdict:
+          reads === 0
+            ? "read-failed"
+            : classifyCredentialSettle(probe, expectedProvider, expectedModel),
+        elapsedMs: Date.now() - startedAt,
+        reads,
+        lastReadError,
+      }),
     );
-    expect(agent?.data?.node?.template?.api_key?.value).toBe(expectedCredential);
-  }).toPass({ timeout: 20000, intervals: [500, 1000, 2000] });
+  }
 }
 
 async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<void> {
@@ -102,10 +180,13 @@ async function loadAgent(page: Page, options: LoadSimpleAgentOptions): Promise<v
       await providerSetupMap[provider](page, options.model);
     }
 
+    // Langflow's own spelling of the provider — the payload never carries this
+    // repo's `Provider` key, so the comparison has to go through the mapper.
     await waitForAgentCredentialSettled(
       page,
       createdFlowId,
-      providerConfigMap[provider].envKeys[0],
+      langflowProviderName(provider),
+      options.model,
     );
   } catch (e: any) {
     if (e?.message?.startsWith("MODEL_NOT_AVAILABLE")) test.skip(true, e.message);


### PR DESCRIPTION
Closes #1371

## The defect

`mcp-client-agent.spec.ts` carried the **third** copy of a premise upstream removed — and the first that no sweep had touched.

```
Expected: "OPENAI_API_KEY"
Received: ""
  86 |  expect(agent?.data?.node?.template?.api_key?.value).toBe(expectedCredential);
    at waitForAgentCredentialSettled (mcp-client-agent.spec.ts:87:6)
```

Measured on `1.12.0.dev19`, **3 runs out of 3**, always inside the load step and always at ~30 s — the guard's 20 s `toPass` budget burned in full. Upstream [#14311](https://github.com/langflow-ai/langflow/pull/14311) (*"stop automatic provider field binding"*, on the 1.12 line since 2026-08-04) deleted the block that wrote the credential variable name into `api_key`; the field is empty from mount onward on every build, for every provider. The transition this guard waited for **cannot occur**.

Deterministic, not a flake — which is why 3 runs settle it where a rate measurement would be the wrong instrument.

## Why two sweeps missed it

#1274 migrated the shared helper and 19 `@stable` specs with it. #1334 migrated the remaining inline copy and its grep — for `credential:` — reported that as the last one. **This copy spells the same read `api_key?.value`**, so that grep could not see it.

Sweeping for the **read** rather than a spelling confirms this was the only surviving *assertion*:

| Location | Nature |
|---|---|
| `mcp-client-agent.spec.ts:86` | **assertion** — the one fixed here |
| `openai-compatible-provider-setup.spec.ts:377` | read, **reported** never asserted (#1334) |
| `agent-credential-settle.ts:165` | read on the probe, reported never classified (#1274) |
| `probe-component-buildable.ts:250` | neutralises `SecretStrInput` — unrelated |

## What it settles on now

The **provider of the persisted model**, through the shared module's pure functions (`readAgentCredentialProbe`, `classifyCredentialSettle`, `formatCredentialSettleFailure`) — so this file cannot drift off the axis again, and a failure arrives as a **named verdict** instead of a bare `toBe` mismatch (which was triaged as a provider-wiring bug twice, #1072). The `read-failed` verdict is part of that: a run that never managed to *read* the flow is no longer reported as a wrong binding.

The provider is not a weaker proxy. With `api_key` empty the runtime resolves the key **from** it — `instantiation.py` reads `model.value[0].provider` and calls `get_api_key_for_provider`, falling through to `get_provider_secret_variable_key(provider)`. #1334 proved that causally.

The race #751 exists for is unchanged, so the guard is **re-pointed rather than deleted**: a freshly mounted node carries the selector's default (`claude-opus-5` / Anthropic) and only later flips.

## Why not `SimpleAgentTemplatePage.load()`

The issue asks this explicitly. `load()` always runs `providerSetupMap`, which opens the Model Providers panel and enables **every** model of the provider — each a live synchronous credential validation that blocks the single-worker backend ~35 s when throttled (#922/#927). That is exactly what this spec's `selectPinnedModel` exists to avoid. Adopting it would delete a divergence at the cost of the spec's cost and stability, so only the pure functions are shared.

## Two records corrected — the same defect one layer up

- **The spec doc claimed three times that this spec uses `SimpleAgentTemplatePage`.** It never did. That is part of how the copy survived: a reader checking whether the shared, already-migrated guard was in use would read the doc and conclude it was.
- **The `QA-CHECKLIST.md` bullet read `[x]`** — *"validated (`@stable`)"* — for a spec carrying no `@stable` that no lane runs. Now `[-]`, automated and awaiting validation, which is what it is.

## Not promoted to `@stable`, deliberately

The fix is proven, but promotion needs measurement somewhere other than a laptop this work has been saturating, and one real failure (`toBeVisible` / `element(s) not found`) was observed and never reproduced or characterised. Promoting with that open would put an undiagnosed flake into the daily.

## Validation

**Langflow `1.12.0.dev19`** (nightly)

```
burst        3/3 clean, expected=1 each
post-fix     7 recorded runs, ZERO with a failing test (unexpected=0 on all)
FF           guard expects a provider the node can never carry → unexpected=1;
             reverted; final green run after reverts ✓
typecheck=0  lint=0
orphans      26 flows, 0 non-starter
```

**Four of those runs were classified `real-failure` with `expected=1 unexpected=0` — no test failed.** They carry `🚨 Backend Error: 500 - POST /api/v1/flows/`, the contention defect already filed as `docs/upstream-bugs/UPSTREAM-BUG-concurrent-flow-create-500.md`. It is not this change: every hunk of this diff is in the imports or the guard body, and `loadTemplateByName` is untouched.

**Three further measurements were discarded, and the reason is recorded rather than smoothed over:** extra runs produced `apiRequestContext.get: Timeout 20000ms` twice, with the passing run taking **1.2 m** against the usual 26 s — the backend wedged under sustained local load (#922/#927), answering in 326 ms again minutes later. An environment abort is not a spec result; the instance was restarted before continuing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
