### PR TITLE
fix(project-management): address a project by its id, not its name (#1363)

### DIFF
--- a/docs/core-functionality/project-management/bulk-actions.md
+++ b/docs/core-functionality/project-management/bulk-actions.md
@@ -1,6 +1,6 @@
 # Project Management – Bulk Actions on Flows
 
-**Last validated:** Langflow 1.11.x
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev20`)
 
 ---
 
@@ -52,7 +52,7 @@ The test creates its 3 flows in a **dedicated project/folder** via the REST API 
 
 ## External dependencies *(required)*
 
-- Home listing UI testids: `list-card`, `checkbox-*`, `flow-name-div`, `download-bulk-btn`, `delete-bulk-btn`, and the folder sidebar entry (`sidebar-nav-<folderName>`).
+- Home listing UI testids: `list-card`, `checkbox-*`, `flow-name-div`, `download-bulk-btn`, `delete-bulk-btn`, and the folder sidebar entry, addressed through `helpers/ui/project-sidebar.ts` — `sidebar-nav-<project id>` on the nightly, `sidebar-nav-<name>` on `main` / `1.11.x` (#1363).
 - REST API `POST /api/v1/projects/` + `DELETE /api/v1/projects/{id}` for the dedicated folder, `POST /api/v1/flows/` (via the `createFlow` helper, with `folder_id`) for flow creation, and `DELETE /api/v1/flows/{id}` for ID-scoped cleanup (auth via `getAuthToken`).
 - No starter template or LLM/provider API key required — flows are created empty via the API.
 

--- a/docs/core-functionality/project-management/flow-navigation-between-folders.md
+++ b/docs/core-functionality/project-management/flow-navigation-between-folders.md
@@ -1,6 +1,6 @@
 # Project Management – Navigate Between Folders
 
-**Last validated:** Langflow 1.12.x
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev20`)
 
 ---
 
@@ -42,7 +42,7 @@ list.
 2. Create folder **B** via `POST /api/v1/projects/` (unique name `nav-folderB-<timestamp>`); capture `folderBId`.
 3. Create flow **A** via `POST /api/v1/flows/` with `folder_id = folderAId` (unique name `nav-flowA-<timestamp>`); assert the echoed `folder_id` matches; capture `flowAId`.
 4. Create flow **B** via `POST /api/v1/flows/` with `folder_id = folderBId` (unique name `nav-flowB-<timestamp>`); assert the echoed `folder_id` matches; capture `flowBId`.
-5. Bootstrap the session (`awaitBootstrapTest(page, { skipModal: true })`); assert both `sidebar-nav-<folderA>` and `sidebar-nav-<folderB>` are visible.
+5. Bootstrap the session (`awaitBootstrapTest(page, { skipModal: true })`); assert both folders' sidebar entries are visible.
 6. `clickProject(folderA)` → assert flow **A** name is visible **and** flow **B** name is hidden (`toBeHidden` / `toHaveCount(0)`).
 7. `clickProject(folderB)` → assert flow **B** name is visible **and** flow **A** name is hidden.
 8. **Cleanup (finally):** delete `flowAId`, `flowBId` (id-scoped, ignored if already gone), then folders `folderAId`, `folderBId` via `DELETE /api/v1/projects/{id}`.
@@ -63,7 +63,7 @@ timestamped names make each `getByText` unambiguous under `fullyParallel`.
 
 ## External dependencies *(required)*
 
-- Home sidebar testids: `project-sidebar`, `sidebar-nav-<name>` (via `MainPage.clickProject`), `mainpage_title`.
+- Home sidebar testids: `project-sidebar`, `mainpage_title`, and the project entry addressed through `helpers/ui/project-sidebar.ts` (via `MainPage.clickProject`) — `sidebar-nav-<project id>` on the nightly, `sidebar-nav-<name>` on `main` / `1.11.x` (#1363).
 - Flow listing surface: the flow name rendered on the home grid (asserted via `page.getByText(<flowName>)`, the same surface `folder-crud.spec.ts` uses after `clickProject`).
 - REST API: `POST`/`DELETE /api/v1/projects/` (folders), `POST`/`DELETE /api/v1/flows/` with `folder_id` (auth via `getAuthToken`).
 - No LLM or provider API key required (model-independent).

--- a/docs/core-functionality/project-management/folder-crud.md
+++ b/docs/core-functionality/project-management/folder-crud.md
@@ -1,6 +1,6 @@
 # Project Management – Folder (Project) CRUD
 
-**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev9`)
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev20`)
 
 ---
 
@@ -17,9 +17,12 @@ the `MainPage` folder helpers (`addProject` / `renameProject` / `deleteProject` 
    `New Project (N)` whenever one already exists, so the literal was a bet on the
    instance having no other folder by that name (#1023).
 2. **Rename** — double-clicking the folder and committing a new name updates the
-   sidebar entry to `sidebar-nav-<new name>`. We assert only the new unique entry
-   (not the absence of `New Project`), since other specs may create `New Project`
-   folders in parallel against the same backend.
+   entry's text. We assert only that this project's entry now reads the new
+   unique name (not the absence of `New Project`), since other specs may create
+   `New Project` folders in parallel against the same backend. The text, not the
+   testid, is the observable: since #1363 the entry's testid is the project id
+   and does not change with a rename, so asserting on it would pass whether the
+   rename landed or not.
 3. **Delete (empty)** — the folder's more-options → delete → confirm flow removes
    the folder and surfaces a "Project deleted successfully" notification.
 4. **Delete (with a flow inside)** — a second test sets up a folder containing a
@@ -44,11 +47,10 @@ which is required for safety under `fullyParallel`.
 
 1. Bootstrap the session without the templates modal (`awaitBootstrapTest(page, { skipModal: true })`).
 2. Create the folder with `createProjectThroughSidebar(page)`; it clicks
-   `add-project-button`, captures the `201` body and asserts
-   `sidebar-nav-<assigned name>` is visible. The id it returns is what teardown
-   deletes.
-3. Rename the folder to a unique name (`crud-folder-<timestamp>`); assert the new
-   `sidebar-nav-<name>` is visible (the unique entry alone proves the rename
+   `add-project-button`, captures the `201` body and asserts the project's
+   sidebar entry is visible. The id it returns is what teardown deletes.
+3. Rename the folder to a unique name (`crud-folder-<timestamp>`); assert the
+   entry now CONTAINS that name (the unique text alone proves the rename
    committed — see note above on parallel `New Project` collisions).
 4. Delete the folder via its more-options menu and confirm; assert the
    "Project deleted successfully" notification and that the sidebar entry is gone.
@@ -60,7 +62,7 @@ which is required for safety under `fullyParallel`.
 1. Create a folder via `POST /api/v1/folders/`; capture `folderId`.
 2. Create a flow inside it via `POST /api/v1/flows/` with `folder_id`; assert the
    echoed `folder_id` matches and capture `flowId`.
-3. Bootstrap the session (`skipModal: true`); assert `sidebar-nav-<folder>` is
+3. Bootstrap the session (`skipModal: true`); assert the folder's sidebar entry is
    visible, open it and assert the flow name is listed.
 4. Delete the folder through the UI; assert the "Project deleted successfully"
    notification and that the sidebar entry is gone.
@@ -105,8 +107,11 @@ the UI really did delete it) as done. The UI assertions are unchanged.
 ## External dependencies *(required)*
 
 - Home sidebar testids: `add-project-button`, `project-sidebar`, `input-project`,
-  `sidebar-nav-<name>`, `more-options-button_<slug>`, `btn-delete-project`, and
-  the "Delete" confirmation control.
+  `btn-delete-project`, the "Delete" confirmation control, and the project entry
+  plus its kebab — both addressed through `helpers/ui/project-sidebar.ts`, which
+  matches `sidebar-nav-<project id>` / `more-options-button_<project id>` (the
+  nightly, since upstream `23f91d8587`) and the older `sidebar-nav-<name>` /
+  `more-options-button_<slug>` still rendered by `main` and `1.11.x` (#1363).
 - REST API `POST`/`GET`/`DELETE /api/v1/projects/` (folders) and `/api/v1/flows/`
   (auth via `getAuthToken`). `/api/v1/folders/` is a legacy alias of `/projects/`.
 - No LLM or provider API key required.

--- a/docs/core-functionality/project-management/folder-deletion-integrity.md
+++ b/docs/core-functionality/project-management/folder-deletion-integrity.md
@@ -1,6 +1,6 @@
 # Folder Deletion Integrity
 
-**Last validated:** Langflow 1.12.x (`1.12.0.dev10`)
+**Last validated:** Langflow 1.12.x (`1.12.0.dev20`)
 
 ---
 
@@ -52,10 +52,10 @@ see *The destructive lane* below.
 **Test 1 — `deleting a folder should update the folder list immediately`**
 1. Create the target folder via `POST /api/v1/projects/` (API setup, so the
    deletion target is deterministic and the UI create flow is not re-tested here)
-2. `awaitBootstrapTest(page, { skipModal: true })`; assert `sidebar-nav-{name}` is visible
+2. `awaitBootstrapTest(page, { skipModal: true })`; assert the folder's sidebar entry is visible
 3. Delete it through the UI via `MainPage.deleteProject(name)`
 4. Assert the `"Project deleted successfully"` toast
-5. Assert `sidebar-nav-{name}` is **no longer visible** — the no-stale-data observable
+5. Assert the folder's sidebar entry is **no longer visible** — the no-stale-data observable
 6. Assert `add-project-button` is still visible (the page did not break)
 7. `finally`: if the UI deletion did not complete, remove the folder through
    `deleteProject()` so a failed assertion cannot leak a project (#965)
@@ -66,7 +66,7 @@ see *The destructive lane* below.
    `createProjectThroughSidebar` (`add-project-button`, then rename the entry the
    backend reports → type the name → Enter)
 3. Assert both sidebar entries exist
-4. Delete the alpha folder via its `more-options-button_<name>` → `btn-delete-project` → confirm
+4. Delete the alpha folder via its kebab → `btn-delete-project` → confirm
 5. Assert the toast, assert the alpha entry is gone and the beta one is still visible
 6. Click the beta folder and assert `mainpage_title` renders — the survivor is still usable
 7. Delete it (cleanup through the same UI path; afterEach still removes both ids)
@@ -75,7 +75,7 @@ see *The destructive lane* below.
 1. Bootstrap, template round-trip, create `folder-one-<stamp>` through the UI
 2. Delete it, assert the toast and that its sidebar entry is gone
 3. **Immediately** create `folder-two-<stamp>` through the same UI path
-4. Assert it appears and `sidebar-nav-folder-two-<stamp>` is visible — proves no
+4. Assert it appears and the `folder-two-<stamp>` entry is visible — proves no
    stale-cache collision between the deletion and the next creation
 5. Delete it (cleanup)
 
@@ -85,7 +85,7 @@ see *The destructive lane* below.
    against real content rather than only empty folders
 2. Bootstrap with `skipModal: true`
 3. Loop: count `sidebar-nav-*` entries in `project-sidebar`, delete the first one
-   through the UI (hover → `more-options-button_{kebab}` → `btn-delete-project` →
+   through the UI (hover → its kebab → `btn-delete-project` →
    confirm → toast), re-count; repeat until zero
 4. Assert the count reached `0`
 5. Assert the sidebar shows `"Start creating a project or flow"`
@@ -427,7 +427,7 @@ seeded on the same instance:
   the `project-sidebar` and its `sidebar-nav-*` entries; the loop in test 4 and
   every visibility assertion depend on those testids.
 - `src/frontend/src/pages/MainPage/components/dropdown/` — the
-  `more-options-button_{name}` → `btn-delete-project` → confirm path used by
+  the kebab → `btn-delete-project` → confirm path used by
   tests 2, 3 and 4.
 - `src/frontend/src/pages/MainPage/pages/emptyPage/` — the empty-project screen:
   the `"Start creating a project or flow"` copy and `new_project_btn_empty_page`

--- a/docs/mcp/server/mcp-server-starter-projects.md
+++ b/docs/mcp/server/mcp-server-starter-projects.md
@@ -1,6 +1,6 @@
 # MCP Server — starter projects & project folder CRUD (UI)
 
-**Last validated:** Langflow 1.12.x
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev20`)
 
 ---
 
@@ -122,8 +122,10 @@ is out of sync with the project folder), or the duplicate-server guard is gone.
 - Settings → MCP Servers page (`mcp_server_name_<index>`, `add-mcp-server-button-page`,
   `add-mcp-server-button`, `json-input`) via `helpers/ui/go-to-settings.ts`
   (`navigateSettingsPages`).
-- Project folder CRUD (`add-project-button`, `more-options-button_<name>`,
-  Rename/Delete, `input-project`, `sidebar-nav-<name>`).
+- Project folder CRUD (`add-project-button`, Rename/Delete, `input-project`, and
+  the project entry plus its kebab — addressed through
+  `helpers/ui/project-sidebar.ts`, which matches the id-derived testids of the
+  nightly and the name-derived ones of `main` / `1.11.x`, #1363).
 - `helpers/filesystem/clean-old-folders.ts`, `helpers/filesystem/convert-test-name.ts`,
   `helpers/other/await-bootstrap-test.ts`.
 - Basic Prompting template + the flow MCP tab (Test 2).

--- a/tests/helpers/filesystem/clean-old-folders.test.ts
+++ b/tests/helpers/filesystem/clean-old-folders.test.ts
@@ -1,0 +1,176 @@
+// Unit tests for cleanOldFolders (#1363).
+// Run with: npm run test:units
+//
+// This helper is cleanup, so nothing asserts on it — which is exactly how it
+// stopped working without anyone noticing. It drove the sidebar kebab through
+// the project's NAME, upstream re-keyed that testid on the project id in
+// `23f91d8587`, and from then on the helper deleted nothing and merely timed out
+// on a click. The daily's own retries recorded the consequence — `New Project`
+// through `New Project (5)` accumulating across six attempts of one test — and
+// the run stayed green on that helper, because a cleanup that deletes nothing
+// looks identical to a cleanup with nothing to do.
+//
+// Hence a unit test rather than a one-off measurement: the properties below are
+// the ones a reader cannot confirm from a passing spec.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { Page } from "@playwright/test";
+import { cleanOldFolders } from "./clean-old-folders";
+
+interface Call {
+  method: string;
+  url: string;
+}
+
+/**
+ * A fake `page.request` over a project list. Deletions mutate the list, so a
+ * test asserts on the END STATE of the account, not only on the calls made —
+ * the distinction that separates "it issued a DELETE" from "the folder is gone".
+ */
+function fakePage(
+  opts: {
+    projects?: Array<{ id: string; name: string }>;
+    listStatus?: number;
+    listBodyIsWrapped?: boolean;
+    deleteStatus?: number;
+  } = {},
+) {
+  const {
+    projects = [],
+    listStatus = 200,
+    listBodyIsWrapped = false,
+    deleteStatus = 204,
+  } = opts;
+
+  const calls: Call[] = [];
+  const live = [...projects];
+
+  const res = (status: number, body: unknown) => ({
+    ok: () => status >= 200 && status < 300,
+    status: () => status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  });
+
+  const request = {
+    get: async (url: string) => {
+      calls.push({ method: "GET", url });
+      return res(listStatus, listBodyIsWrapped ? { folders: live } : live);
+    },
+    delete: async (url: string) => {
+      calls.push({ method: "DELETE", url });
+      if (deleteStatus < 300 || deleteStatus === 404) {
+        const id = url.split("/").pop()!;
+        const i = live.findIndex((p) => p.id === id);
+        if (i >= 0) live.splice(i, 1);
+      }
+      return res(deleteStatus, {});
+    },
+  };
+
+  return {
+    page: { request } as unknown as Page,
+    calls,
+    liveProjects: () => live,
+  };
+}
+
+test("deletes every leftover New Project* and leaves everything else alone", async () => {
+  const fake = fakePage({
+    projects: [
+      { id: "p1", name: "New Project" },
+      { id: "p2", name: "New Project (1)" },
+      { id: "p3", name: "New Project (5)" },
+      { id: "keep1", name: "Starter Project" },
+      { id: "keep2", name: "bulk-actions-folder-1754" },
+    ],
+  });
+
+  await cleanOldFolders(fake.page);
+
+  assert.deepEqual(
+    fake.liveProjects().map((p) => p.id),
+    ["keep1", "keep2"],
+    "the three New Project* leftovers must be gone, the other two untouched",
+  );
+});
+
+test("deletes by ID, never through the sidebar", async () => {
+  // The regression this file exists for: the helper used to hover the entry and
+  // click `more-options-button_<slugified name>`. Cleanup runs before the test
+  // it precedes has asserted anything, so it must not depend on the UI state
+  // that test is about to read.
+  const fake = fakePage({ projects: [{ id: "p1", name: "New Project" }] });
+
+  await cleanOldFolders(fake.page);
+
+  assert.deepEqual(
+    fake.calls.filter((c) => c.method === "DELETE").map((c) => c.url),
+    ["/api/v1/projects/p1"],
+  );
+});
+
+test("reads the wrapped { folders: [...] } response shape too", async () => {
+  // `/api/v1/projects/` answers a bare array on some builds and `{ folders }` on
+  // others; reading only one shape makes the sweep silently a no-op on the other.
+  const fake = fakePage({
+    projects: [{ id: "p1", name: "New Project" }],
+    listBodyIsWrapped: true,
+  });
+
+  await cleanOldFolders(fake.page);
+
+  assert.equal(fake.liveProjects().length, 0);
+});
+
+test("a failed list is reported and does not throw", async () => {
+  // Cleanup must never fail the test whose assertions have not run yet.
+  const fake = fakePage({ projects: [{ id: "p1", name: "New Project" }], listStatus: 500 });
+
+  await cleanOldFolders(fake.page);
+
+  assert.equal(
+    fake.calls.filter((c) => c.method === "DELETE").length,
+    0,
+    "nothing can be deleted from a list that never arrived",
+  );
+});
+
+test("a project that survives every retry does not abort the sweep", async () => {
+  // `deleteProject` retries the #965 contention 500 and then throws. One
+  // undeletable leftover must not stop the others from being cleared.
+  const fake = fakePage({
+    projects: [
+      { id: "p1", name: "New Project" },
+      { id: "p2", name: "New Project (1)" },
+    ],
+    deleteStatus: 500,
+  });
+
+  await cleanOldFolders(fake.page);
+
+  assert.deepEqual(
+    fake.calls.filter((c) => c.method === "DELETE").map((c) => c.url),
+    [
+      // 3 attempts each, per deleteProject's retry contract — both projects tried.
+      "/api/v1/projects/p1",
+      "/api/v1/projects/p1",
+      "/api/v1/projects/p1",
+      "/api/v1/projects/p2",
+      "/api/v1/projects/p2",
+      "/api/v1/projects/p2",
+    ],
+  );
+});
+
+test("a name that merely CONTAINS 'New Project' is not swept", async () => {
+  // The sweep owns the button's default name, not every project mentioning it —
+  // a spec's own `keep-New Project-fixture` must survive its neighbours' cleanup.
+  const fake = fakePage({
+    projects: [{ id: "p1", name: "keep-New Project-fixture" }],
+  });
+
+  await cleanOldFolders(fake.page);
+
+  assert.equal(fake.liveProjects().length, 1);
+});

--- a/tests/helpers/filesystem/clean-old-folders.ts
+++ b/tests/helpers/filesystem/clean-old-folders.ts
@@ -1,28 +1,50 @@
 import type { Page } from "@playwright/test";
-import { convertTestName } from "./convert-test-name";
+import { deleteProject } from "../flows/delete-project";
 
+/**
+ * Deletes every leftover `New Project*` folder on the account.
+ *
+ * This is teardown of the PREVIOUS run, not a step of the test that calls it —
+ * so it goes through the REST API and must not depend on the UI state the test
+ * is about to assert on. The sibling `removeLeftoverRenamedProject` in
+ * `mcp-server-starter-projects.spec.ts` already makes that argument; this helper
+ * was the last cleanup still driving the sidebar.
+ *
+ * It was doing so through the kebab's **name-derived** testid
+ * (`more-options-button_<slug>`), which upstream renamed to the project id in
+ * `23f91d8587` — so from `1.12.0.dev20` on it deleted nothing and merely timed
+ * out on a click. That is the second defect riding on #1363: the daily's retries
+ * show `New Project` → `New Project (5)` accumulating across six attempts of the
+ * same test, because nothing was clearing them between attempts.
+ *
+ * `deleteProject` retries the `500` the endpoint answers under contention (#965)
+ * and treats `404` as the desired end state. A folder that survives every retry
+ * is reported and skipped: cleanup must never fail the test whose assertions
+ * have not run yet, but it must not be silent either (#1012).
+ */
 export const cleanOldFolders = async (page: Page) => {
-  let numberOfFolders = await page.getByText("New Project").count();
-
-  while (numberOfFolders > 0) {
-    const getFirstFolderName = convertTestName(
-      (await page.getByText("New Project").first().textContent()) as string,
+  const response = await page.request.get("/api/v1/projects/");
+  if (!response.ok()) {
+    console.warn(
+      `⚠️ cleanOldFolders could not list projects: ${response.status()}`,
     );
+    return;
+  }
 
-    await page
-      .getByText("New Project")
-      .first()
-      .hover()
-      .then(async () => {
-        await page
-          .getByTestId(`more-options-button_${getFirstFolderName}`)
-          .last()
-          .click();
-        await page.getByText("Delete", { exact: true }).last().click();
-        await page.getByText("Delete", { exact: true }).last().click();
-      });
+  // The /api/v1/projects/ response shape varies (sometimes a bare array,
+  // sometimes `{ folders: [...] }`) — normalized the same way the MCP specs do.
+  const raw = await response.json();
+  const projects: Array<{ id: string; name: string }> = Array.isArray(raw)
+    ? raw
+    : (raw.folders ?? []);
 
-    await page.waitForTimeout(500);
-    numberOfFolders--;
+  for (const project of projects.filter((p) =>
+    p.name?.startsWith("New Project"),
+  )) {
+    await deleteProject(page.request, project.id).catch((error) => {
+      console.warn(
+        `⚠️ Leftover project left behind (${project.id} "${project.name}"): ${error}`,
+      );
+    });
   }
 };

--- a/tests/helpers/flows/create-project-through-sidebar.ts
+++ b/tests/helpers/flows/create-project-through-sidebar.ts
@@ -1,6 +1,10 @@
 import { expect, type Page } from "@playwright/test";
+import {
+  projectSidebarEntry,
+  type ProjectRef,
+} from "../ui/project-sidebar";
 
-export type CreatedProject = { id: string; name: string };
+export type CreatedProject = ProjectRef;
 
 /**
  * Creates a project (folder) through the home sidebar's `add-project-button`
@@ -37,27 +41,36 @@ export async function createProjectThroughSidebar(
   await page.getByTestId("add-project-button").click();
 
   const project = (await (await created).json()) as CreatedProject;
-  await expect(page.getByTestId(`sidebar-nav-${project.name}`)).toBeVisible({
-    timeout: 15000,
-  });
-  return { id: project.id, name: project.name };
+  const ref = { id: project.id, name: project.name };
+  await expect(projectSidebarEntry(page, ref)).toBeVisible({ timeout: 15000 });
+  return ref;
 }
 
 /**
- * Renames a project through the sidebar's inline input, addressing it by its
- * `sidebar-nav-<name>` testid rather than by a substring text match — the same
- * ambiguity described above, on the rename side. Double-clicking the testid
- * opens `input-project` (confirmed live on `1.12.0.dev9`).
+ * Renames a project through the sidebar's inline input, addressing it by the
+ * id/name pair rather than by a substring text match — the same ambiguity
+ * described above, on the rename side. Double-clicking the entry opens
+ * `input-project` (confirmed live on `1.12.0.dev20`).
+ *
+ * Returns the project under its NEW name, which is what every later assertion
+ * has to address it by: on `1.11.x` the entry's testid is name-derived and
+ * therefore changes with the rename, while on the nightly it is the id and does
+ * not (#1363). Asserting on the returned ref's text is what proves the rename
+ * committed on both lines — the id-derived testid alone would be visible
+ * whether the rename landed or not.
  */
 export async function renameProjectThroughSidebar(
   page: Page,
-  currentName: string,
+  project: ProjectRef,
   newName: string,
-): Promise<void> {
-  await page.getByTestId(`sidebar-nav-${currentName}`).dblclick();
+): Promise<ProjectRef> {
+  await projectSidebarEntry(page, project).dblclick();
   await page.getByTestId("input-project").fill(newName);
   await page.keyboard.press("Enter");
-  await expect(page.getByTestId(`sidebar-nav-${newName}`)).toBeVisible({
+
+  const renamed = { id: project.id, name: newName };
+  await expect(projectSidebarEntry(page, renamed)).toContainText(newName, {
     timeout: 15000,
   });
+  return renamed;
 }

--- a/tests/helpers/ui/project-sidebar.test.ts
+++ b/tests/helpers/ui/project-sidebar.test.ts
@@ -1,0 +1,119 @@
+// Unit tests for the project-sidebar selector builders (issue #1363).
+// Run with: npm run test:units
+//
+// These builders decide whether SEVEN `@stable` tests across four specs can find
+// a project at all, and they have to hold on two upstream spellings at once —
+// the id-derived testid the nightly renders and the name-derived one `main` and
+// the `1.11.x` release candidates still render. A string-equality test would
+// pass every mutation that keeps the shape, so the assertions below run the
+// compiled selector against elements instead: `selects()` answers the only
+// question that matters — given an element carrying THIS `data-testid`, does the
+// selector select it?
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  projectOptionsButtonSelector,
+  projectSidebarEntrySelector,
+} from "./project-sidebar";
+
+/**
+ * Does `selector` (a comma-separated list of `[data-testid="…"]` fragments)
+ * select an element whose `data-testid` is exactly `testId`?
+ *
+ * Hand-parsed rather than regex-split on `", "`, because a project name may
+ * legitimately contain a comma — splitting on it would silently mis-parse the
+ * very input the escaping exists for.
+ */
+function selects(selector: string, testId: string): boolean {
+  const values: string[] = [];
+  let i = 0;
+  while (i < selector.length) {
+    const open = selector.indexOf('[data-testid="', i);
+    if (open === -1) break;
+    let j = open + '[data-testid="'.length;
+    let value = "";
+    while (j < selector.length) {
+      const ch = selector[j];
+      if (ch === "\\") {
+        value += selector[j + 1];
+        j += 2;
+        continue;
+      }
+      if (ch === '"') break;
+      value += ch;
+      j += 1;
+    }
+    assert.equal(selector[j], '"', `unterminated attribute value in ${selector}`);
+    assert.equal(selector[j + 1], "]", `malformed fragment in ${selector}`);
+    values.push(value);
+    i = j + 2;
+  }
+  assert.ok(values.length > 0, `no fragment parsed out of ${selector}`);
+  return values.includes(testId);
+}
+
+const PROJECT = {
+  id: "ced80faf-e13c-400d-872f-e207bd0f82f5",
+  name: "New Project (3)",
+};
+
+test("the entry selector matches the id-derived testid the nightly renders", () => {
+  // Measured live on 1.12.0.dev20 — `sidebar-nav-<uuid>`.
+  assert.ok(
+    selects(projectSidebarEntrySelector(PROJECT), `sidebar-nav-${PROJECT.id}`),
+  );
+});
+
+test("the entry selector still matches the name-derived testid of main / 1.11.x", () => {
+  // `manual.yml` runs the @stable set against 1.11.x release candidates before
+  // sign-off; dropping this branch trades one lane's red for another's.
+  assert.ok(
+    selects(
+      projectSidebarEntrySelector(PROJECT),
+      `sidebar-nav-${PROJECT.name}`,
+    ),
+  );
+});
+
+test("the kebab selector matches the id on 1.12 and the SLUGIFIED name on 1.11", () => {
+  const selector = projectOptionsButtonSelector(PROJECT);
+  assert.ok(selects(selector, `more-options-button_${PROJECT.id}`));
+  // 1.11 built this one through `convertTestName` — spaces to dashes, lowercased.
+  assert.ok(selects(selector, "more-options-button_new-project-(3)"));
+  // The raw name is NOT the 1.11 spelling; matching it would mean the slug was
+  // dropped, which is how the kebab silently resolves to nothing on that line.
+  assert.equal(
+    selects(selector, `more-options-button_${PROJECT.name}`),
+    false,
+  );
+});
+
+test("a project is never matched by another project's id or name", () => {
+  const other = { id: "7c7a4e0f-26e6-479e-b220-5d5035ede368", name: "Starter" };
+  const selector = projectSidebarEntrySelector(PROJECT);
+  assert.equal(selects(selector, `sidebar-nav-${other.id}`), false);
+  assert.equal(selects(selector, `sidebar-nav-${other.name}`), false);
+});
+
+test("matching is exact, so a name that is a PREFIX of another does not match it", () => {
+  // The state every failing daily attempt landed in: `New Project`,
+  // `New Project (1)`, … accumulating because cleanup stopped deleting. A
+  // prefix match here would delete or assert on the wrong folder.
+  const prefix = { id: "aaaaaaaa-0000-0000-0000-000000000000", name: "New Project" };
+  assert.equal(
+    selects(projectSidebarEntrySelector(prefix), "sidebar-nav-New Project (3)"),
+    false,
+  );
+});
+
+test("a name carrying a quote or a backslash still yields a well-formed selector", () => {
+  const awkward = {
+    id: "bbbbbbbb-0000-0000-0000-000000000000",
+    name: 'we"ird\\name',
+  };
+  // `selects()` asserts the fragment is terminated and closed, so an unescaped
+  // quote fails here rather than reaching Playwright as an unparsable selector.
+  assert.ok(
+    selects(projectSidebarEntrySelector(awkward), `sidebar-nav-${awkward.name}`),
+  );
+});

--- a/tests/helpers/ui/project-sidebar.ts
+++ b/tests/helpers/ui/project-sidebar.ts
@@ -1,0 +1,89 @@
+import type { Locator, Page } from "@playwright/test";
+import { convertTestName } from "../filesystem/convert-test-name";
+
+/**
+ * A project as the backend returns it — the only pair that addresses its home
+ * sidebar entry on every Langflow line this suite runs against.
+ */
+export type ProjectRef = { id: string; name: string };
+
+/**
+ * Addressing a project in the home sidebar.
+ *
+ * Upstream changed the hook from the project's NAME to its ID in
+ * `23f91d8587` ("fix(authz): support scoped project visibility", #14429), on
+ * the `release-1.12.0` line the nightly is cut from:
+ *
+ *   sidebar-nav-${item.name}                 →  sidebar-nav-${item.id}
+ *   more-options-button_${convertTestName(item.name)}
+ *                                            →  more-options-button_${item.id}
+ *
+ * Measured live on `1.12.0.dev20`: the entry renders
+ * `data-testid="sidebar-nav-<uuid>"` and the kebab
+ * `data-testid="more-options-button_<uuid>" aria-label="Options for <name>"`.
+ * The name is still the entry's text and the kebab's accessible name, so
+ * nothing a user or a screen reader observes was lost — this is an internal
+ * rename of an automation hook, not a product regression (#1363).
+ *
+ * **Both spellings are matched on purpose.** `main` still renders the
+ * name-derived testid, and `manual.yml` dispatches the `@stable` set against
+ * `1.11.x` release candidates before every sign-off — pinning the id alone
+ * would trade seven tests red on the nightly for seven tests red on the lane
+ * that signs releases off. The two selectors can never both match: an entry
+ * carries exactly one testid, and a project's name is never another project's
+ * uuid. **Delete the name branch when `1.11.x` leaves the support window** —
+ * `projectSidebarEntrySelector` and `projectOptionsButtonSelector` are the only
+ * two places that spell it.
+ *
+ * Scoped to `[data-testid="project-sidebar"]` (both elements live inside it,
+ * confirmed live) so an unrelated `sidebar-nav-*` — the flow editor's own tab
+ * strip uses that prefix too — can never satisfy a project assertion.
+ */
+const PROJECT_SIDEBAR = '[data-testid="project-sidebar"]';
+
+/** Quotes a CSS attribute value, escaping `"` and `\` — project names are free text. */
+function quote(value: string): string {
+  return `"${value.replace(/(["\\])/g, "\\$1")}"`;
+}
+
+/** CSS matching the project's sidebar entry under either upstream spelling. */
+export function projectSidebarEntrySelector(project: ProjectRef): string {
+  return [
+    `[data-testid=${quote(`sidebar-nav-${project.id}`)}]`,
+    `[data-testid=${quote(`sidebar-nav-${project.name}`)}]`,
+  ].join(", ");
+}
+
+/** CSS matching the project's kebab (options) button under either spelling. */
+export function projectOptionsButtonSelector(project: ProjectRef): string {
+  return [
+    `[data-testid=${quote(`more-options-button_${project.id}`)}]`,
+    `[data-testid=${quote(`more-options-button_${convertTestName(project.name)}`)}]`,
+  ].join(", ");
+}
+
+/** The project's entry in the home sidebar. */
+export function projectSidebarEntry(page: Page, project: ProjectRef): Locator {
+  return page
+    .locator(PROJECT_SIDEBAR)
+    .locator(projectSidebarEntrySelector(project));
+}
+
+/** The project's kebab (options) button in the home sidebar. */
+export function projectOptionsButton(page: Page, project: ProjectRef): Locator {
+  return page
+    .locator(PROJECT_SIDEBAR)
+    .locator(projectOptionsButtonSelector(project));
+}
+
+/**
+ * Opens the project's kebab menu, hovering the entry first — the icon inside
+ * the trigger is `hidden` until the row is hovered or is the active path.
+ */
+export async function openProjectOptions(
+  page: Page,
+  project: ProjectRef,
+): Promise<void> {
+  await projectSidebarEntry(page, project).last().hover();
+  await projectOptionsButton(page, project).last().click();
+}

--- a/tests/pages/MainPage.ts
+++ b/tests/pages/MainPage.ts
@@ -3,6 +3,11 @@ import { BasePage } from "./BasePage";
 import { SidebarComponent } from "./SidebarComponent";
 import { addFlowToTestOnEmptyLangflow } from "../helpers/flows/add-flow-to-test-on-empty-langflow";
 import { waitForPageEntry } from "../helpers/other/page-entry-barrier";
+import {
+  openProjectOptions,
+  projectSidebarEntry,
+  type ProjectRef,
+} from "../helpers/ui/project-sidebar";
 
 export class MainPage extends BasePage {
   readonly sidebar: SidebarComponent;
@@ -90,19 +95,20 @@ export class MainPage extends BasePage {
     });
   }
 
-  async deleteProject(name: string) {
-    const slug = name.toLowerCase().replace(/\s+/g, "-");
-    await this.page.getByTestId(`sidebar-nav-${name}`).last().hover();
-    await this.page.getByTestId(`more-options-button_${slug}`).click();
+  /**
+   * Deletes a project through the sidebar kebab, addressing it by the pair the
+   * create response returns — see `helpers/ui/project-sidebar.ts` for why both
+   * the id- and the name-derived testid are matched (#1363).
+   */
+  async deleteProject(project: ProjectRef) {
+    await openProjectOptions(this.page, project);
     await this.page.getByTestId("btn-delete-project").click();
     await this.page.getByText("Delete").last().click();
   }
 
-  async uploadFlowByDragDrop(projectName: string, jsonContent: string) {
-    await this.page.waitForSelector(
-      `[data-testid="sidebar-nav-${projectName}"]`,
-      { timeout: 100000 },
-    );
+  async uploadFlowByDragDrop(project: ProjectRef, jsonContent: string) {
+    const entry = projectSidebarEntry(this.page, project);
+    await entry.first().waitFor({ state: "visible", timeout: 100000 });
     const dataTransfer = await this.page.evaluateHandle((data) => {
       const dt = new DataTransfer();
       const file = new File([data], "flowtest.json", {
@@ -112,9 +118,7 @@ export class MainPage extends BasePage {
       return dt;
     }, jsonContent);
 
-    await this.page
-      .getByTestId(`sidebar-nav-${projectName}`)
-      .dispatchEvent("drop", { dataTransfer });
+    await entry.first().dispatchEvent("drop", { dataTransfer });
     await this.page.waitForTimeout(1000);
   }
 
@@ -125,7 +129,7 @@ export class MainPage extends BasePage {
     await this.page.mouse.up();
   }
 
-  async clickProject(name: string) {
-    await this.page.getByTestId(`sidebar-nav-${name}`).click();
+  async clickProject(project: ProjectRef) {
+    await projectSidebarEntry(this.page, project).click();
   }
 }

--- a/tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/bulk-actions.spec.ts
@@ -4,12 +4,11 @@ import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { createFlow } from "../../../../helpers/flows/create-flow";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { deleteProject } from "../../../../helpers/flows/delete-project";
+import { projectSidebarEntry } from "../../../../helpers/ui/project-sidebar";
 
-// Quarantined at triage (daily #1361): the project's sidebar entry never
-// resolves under the name-derived testid this spec clicks — see #1363.
-test.fixme(
+test(
   "user should be able to select flows with different methods and perform bulk actions",
-  { tag: ["@release", "@workspace", "@mainpage", "@regression"] },
+  { tag: ["@stable", "@release", "@workspace", "@mainpage", "@regression"] },
   async ({ page, request }) => {
     // Track the IDs of the 3 flows + the dedicated folder we create so cleanup
     // deletes ONLY those via the API, never sibling specs' flows.
@@ -71,7 +70,7 @@ test.fixme(
       // too — so no part of the historically flaky modal path (#723) is
       // exercised. The folder view (`/all/folder/<id>`) shows ONLY these 3 flows.
       await awaitBootstrapTest(page, { skipModal: true });
-      await page.getByTestId(`sidebar-nav-${folderName}`).click();
+      await projectSidebarEntry(page, { id: folderId, name: folderName }).click();
 
       // Determinism guard: the folder listing must hold exactly the 3 flows we
       // created — nothing else can be here, so this confirms isolation before any

--- a/tests/tests-automations/regression/core-functionality/project-management/flow-navigation-between-folders.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/flow-navigation-between-folders.spec.ts
@@ -3,6 +3,10 @@ import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-te
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { deleteProject } from "../../../../helpers/flows/delete-project";
+import {
+  projectSidebarEntry,
+  type ProjectRef,
+} from "../../../../helpers/ui/project-sidebar";
 import { MainPage } from "../../../../pages/MainPage";
 
 /**
@@ -78,24 +82,29 @@ test(
 
       const mainPage = new MainPage(page);
 
+      // Addressed by the id/name pair the create response returns: the nightly
+      // keys the sidebar testid on the id, 1.11.x on the name (#1363).
+      const projectA: ProjectRef = { id: folderAId!, name: folderAName };
+      const projectB: ProjectRef = { id: folderBId!, name: folderBName };
+
       await test.step("Both folders are listed in the project sidebar", async () => {
         await awaitBootstrapTest(page, { skipModal: true });
-        await expect(
-          page.getByTestId(`sidebar-nav-${folderAName}`),
-        ).toBeVisible({ timeout: 15000 });
-        await expect(
-          page.getByTestId(`sidebar-nav-${folderBName}`),
-        ).toBeVisible({ timeout: 15000 });
+        await expect(projectSidebarEntry(page, projectA)).toBeVisible({
+          timeout: 15000,
+        });
+        await expect(projectSidebarEntry(page, projectB)).toBeVisible({
+          timeout: 15000,
+        });
       });
 
       await test.step("Folder A shows flow A and not flow B", async () => {
-        await mainPage.clickProject(folderAName);
+        await mainPage.clickProject(projectA);
         await expect(page.getByText(flowAName)).toBeVisible({ timeout: 15000 });
         await expect(page.getByText(flowBName)).toHaveCount(0);
       });
 
       await test.step("Folder B shows flow B and not flow A", async () => {
-        await mainPage.clickProject(folderBName);
+        await mainPage.clickProject(projectB);
         await expect(page.getByText(flowBName)).toBeVisible({ timeout: 15000 });
         await expect(page.getByText(flowAName)).toHaveCount(0);
       });

--- a/tests/tests-automations/regression/core-functionality/project-management/folder-crud.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/folder-crud.spec.ts
@@ -7,6 +7,10 @@ import {
 } from "../../../../helpers/flows/create-project-through-sidebar";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { deleteProject } from "../../../../helpers/flows/delete-project";
+import {
+  projectSidebarEntry,
+  type ProjectRef,
+} from "../../../../helpers/ui/project-sidebar";
 import { MainPage } from "../../../../pages/MainPage";
 
 /**
@@ -23,50 +27,54 @@ import { MainPage } from "../../../../pages/MainPage";
  * folder-drag-drop-flow) and are intentionally not repeated here.
  */
 
-// Quarantined at triage (daily #1361): the project's sidebar entry never
-// resolves under the name-derived testid this spec waits on — see #1363.
-test.fixme(
+test(
   "creates, renames and deletes an empty project folder via the UI",
-  { tag: ["@release", "@workspace", "@mainpage"] },
+  { tag: ["@stable", "@release", "@workspace", "@mainpage"] },
   async ({ page, request }) => {
     await awaitBootstrapTest(page, { skipModal: true });
 
     const mainPage = new MainPage(page);
     const renamedFolder = `crud-folder-${Date.now()}`;
     let createdId: string | undefined;
-    let createdName = "";
+    let project: ProjectRef | undefined;
 
     try {
       await test.step("Create a new folder from the sidebar", async () => {
-        // `createProjectThroughSidebar` returns the name the backend assigned —
-        // "New Project" only while that name is free, `New Project (N)`
-        // otherwise. Asserting on the literal `sidebar-nav-New Project` was a
-        // bet on the instance having no other folder by that name (#1023).
-        const created = await createProjectThroughSidebar(page);
-        createdId = created.id;
-        createdName = created.name;
+        // `createProjectThroughSidebar` returns the id AND the name the backend
+        // assigned — "New Project" only while that name is free, `New Project
+        // (N)` otherwise. Asserting on the literal `sidebar-nav-New Project` was
+        // a bet on the instance having no other folder by that name (#1023);
+        // since #1363 the entry is addressed by that pair, because the nightly
+        // keys the testid on the id and 1.11.x still keys it on the name.
+        project = await createProjectThroughSidebar(page);
+        createdId = project.id;
       });
 
       await test.step("Rename the folder to a unique name", async () => {
-        await renameProjectThroughSidebar(page, createdName, renamedFolder);
+        project = await renameProjectThroughSidebar(
+          page,
+          project!,
+          renamedFolder,
+        );
         // Asserting on the unique renamed entry is enough to prove the rename
         // committed. We deliberately do NOT assert that "New Project" is gone:
         // several specs create folders via the UI in parallel against the same
         // backend, so a generic "New Project" entry from another worker may
         // legitimately exist at the same time.
-        await expect(
-          page.getByTestId(`sidebar-nav-${renamedFolder}`),
-        ).toBeVisible({ timeout: 15000 });
+        await expect(projectSidebarEntry(page, project)).toContainText(
+          renamedFolder,
+          { timeout: 15000 },
+        );
       });
 
       await test.step("Delete the folder", async () => {
-        await mainPage.deleteProject(renamedFolder);
+        await mainPage.deleteProject(project!);
         await expect(
           page.getByText("Project deleted successfully"),
         ).toBeVisible({ timeout: 15000 });
-        await expect(
-          page.getByTestId(`sidebar-nav-${renamedFolder}`),
-        ).not.toBeVisible({ timeout: 10000 });
+        await expect(projectSidebarEntry(page, project!)).not.toBeVisible({
+          timeout: 10000,
+        });
       });
     } finally {
       // The UI delete above is the assertion, NOT the cleanup (#1023): the
@@ -85,11 +93,9 @@ test.fixme(
   },
 );
 
-// Quarantined at triage (daily #1361): the project's sidebar entry never
-// resolves under the name-derived testid this spec waits on — see #1363.
-test.fixme(
+test(
   "deleting a folder that contains a flow removes the flow with it",
-  { tag: ["@release", "@workspace", "@mainpage"] },
+  { tag: ["@stable", "@release", "@workspace", "@mainpage"] },
   async ({ page, request }) => {
     const authToken = await getAuthToken(request);
     const folderName = `crud-del-folder-${Date.now()}`;
@@ -124,22 +130,24 @@ test.fixme(
       await awaitBootstrapTest(page, { skipModal: true });
       const mainPage = new MainPage(page);
 
+      const project: ProjectRef = { id: folderId, name: folderName };
+
       await test.step("The folder and its flow are listed", async () => {
-        await expect(
-          page.getByTestId(`sidebar-nav-${folderName}`),
-        ).toBeVisible({ timeout: 15000 });
-        await mainPage.clickProject(folderName);
+        await expect(projectSidebarEntry(page, project)).toBeVisible({
+          timeout: 15000,
+        });
+        await mainPage.clickProject(project);
         await expect(page.getByText(flowName)).toBeVisible({ timeout: 15000 });
       });
 
       await test.step("Delete the folder", async () => {
-        await mainPage.deleteProject(folderName);
+        await mainPage.deleteProject(project);
         await expect(
           page.getByText("Project deleted successfully"),
         ).toBeVisible({ timeout: 15000 });
-        await expect(
-          page.getByTestId(`sidebar-nav-${folderName}`),
-        ).not.toBeVisible({ timeout: 10000 });
+        await expect(projectSidebarEntry(page, project)).not.toBeVisible({
+          timeout: 10000,
+        });
         folderDeleted = true;
       });
 

--- a/tests/tests-automations/regression/core-functionality/project-management/folder-deletion-integrity.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/folder-deletion-integrity.spec.ts
@@ -12,6 +12,12 @@ import {
 } from "../../../../helpers/flows/create-project-through-sidebar";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { deleteProject } from "../../../../helpers/flows/delete-project";
+import {
+  openProjectOptions,
+  projectOptionsButton,
+  projectSidebarEntry,
+  type ProjectRef,
+} from "../../../../helpers/ui/project-sidebar";
 import { MainPage } from "../../../../pages/MainPage";
 
 /**
@@ -163,11 +169,9 @@ async function openTemplateAndReturnToFolders(page: Page) {
   });
 }
 
-// Quarantined at triage (daily #1361): the project's sidebar entry never
-// resolves under the name-derived testid this spec waits on — see #1363.
-test.fixme(
+test(
   "deleting a folder should update the folder list immediately",
-  { tag: ["@release", "@api"] },
+  { tag: ["@stable", "@release", "@api"] },
   async ({ page, request }) => {
     // Registered even though this test opens no template: on an instance with no
     // flows left (the `@destructive` sibling empties it in its own lane)
@@ -190,10 +194,12 @@ test.fixme(
       await awaitBootstrapTest(page, { skipModal: true });
       const mainPage = new MainPage(page);
 
-      const folderBeforeDelete = page.getByTestId(`sidebar-nav-${folderName}`);
-      await expect(folderBeforeDelete).toBeVisible({ timeout: 15000 });
+      const project: ProjectRef = { id: folderId, name: folderName };
+      await expect(projectSidebarEntry(page, project)).toBeVisible({
+        timeout: 15000,
+      });
 
-      await mainPage.deleteProject(folderName);
+      await mainPage.deleteProject(project);
 
       // Verify success message
       await expect(page.getByText("Project deleted successfully")).toBeVisible({
@@ -201,9 +207,9 @@ test.fixme(
       });
 
       // Verify the folder is removed from the sidebar immediately (no stale data)
-      await expect(
-        page.getByTestId(`sidebar-nav-${folderName}`),
-      ).not.toBeVisible({ timeout: 10000 });
+      await expect(projectSidebarEntry(page, project)).not.toBeVisible({
+        timeout: 10000,
+      });
 
       // Verify the page is still functional by checking for the add project button
       await expect(page.getByTestId("add-project-button")).toBeVisible({
@@ -226,11 +232,9 @@ test.fixme(
   },
 );
 
-// Quarantined at triage (daily #1361): the project's sidebar entry never
-// resolves under the name-derived testid this spec waits on — see #1363.
-test.fixme(
+test(
   "deleting one folder should not affect other folders",
-  { tag: ["@release", "@api"] },
+  { tag: ["@stable", "@release", "@api"] },
   async ({ page }) => {
     trackCreatedFlows(page);
     await awaitBootstrapTest(page);
@@ -249,26 +253,32 @@ test.fixme(
     // Create both folders. `createProjectThroughSidebar` returns the name the
     // backend actually assigned, so the rename addresses THIS folder instead of
     // guessing with `getByText("New Project").last()` — see the helper's note.
-    const alphaProject = await createProjectThroughSidebar(page);
-    createdProjectIds.add(alphaProject.id);
-    await renameProjectThroughSidebar(page, alphaProject.name, alpha);
+    const alphaCreated = await createProjectThroughSidebar(page);
+    createdProjectIds.add(alphaCreated.id);
+    const alphaProject = await renameProjectThroughSidebar(
+      page,
+      alphaCreated,
+      alpha,
+    );
 
-    const betaProject = await createProjectThroughSidebar(page);
-    createdProjectIds.add(betaProject.id);
-    await renameProjectThroughSidebar(page, betaProject.name, beta);
+    const betaCreated = await createProjectThroughSidebar(page);
+    createdProjectIds.add(betaCreated.id);
+    const betaProject = await renameProjectThroughSidebar(
+      page,
+      betaCreated,
+      beta,
+    );
 
     // Verify both folders exist
-    await expect(page.getByTestId(`sidebar-nav-${alpha}`)).toBeVisible({
+    await expect(projectSidebarEntry(page, alphaProject)).toBeVisible({
       timeout: 5000,
     });
-    await expect(page.getByTestId(`sidebar-nav-${beta}`)).toBeVisible({
+    await expect(projectSidebarEntry(page, betaProject)).toBeVisible({
       timeout: 5000,
     });
 
     // Delete the first folder
-    const folderAlpha = page.getByTestId(`sidebar-nav-${alpha}`);
-    await folderAlpha.hover();
-    await page.getByTestId(`more-options-button_${alpha}`).click();
+    await openProjectOptions(page, alphaProject);
     await page.getByTestId("btn-delete-project").click();
     await page.getByText("Delete").last().click();
 
@@ -278,12 +288,12 @@ test.fixme(
     });
 
     // Verify the deleted folder is removed
-    await expect(page.getByTestId(`sidebar-nav-${alpha}`)).not.toBeVisible({
+    await expect(projectSidebarEntry(page, alphaProject)).not.toBeVisible({
       timeout: 5000,
     });
 
     // Verify the sibling folder still exists and is accessible
-    const folderBeta = page.getByTestId(`sidebar-nav-${beta}`);
+    const folderBeta = projectSidebarEntry(page, betaProject);
     await expect(folderBeta).toBeVisible({ timeout: 5000 });
 
     // Click it to ensure the app is functional
@@ -297,8 +307,7 @@ test.fixme(
     // Clean up - delete the remaining folder through the same UI path. afterEach
     // still deletes both ids via the API: this UI delete can 500 silently
     // (#965), and the toast alone does not prove the folder is gone.
-    await folderBeta.hover();
-    await page.getByTestId(`more-options-button_${beta}`).click();
+    await openProjectOptions(page, betaProject);
     await page.getByTestId("btn-delete-project").click();
     await page.getByText("Delete").last().click();
 
@@ -308,11 +317,9 @@ test.fixme(
   },
 );
 
-// Quarantined at triage (daily #1361): the project's sidebar entry never
-// resolves under the name-derived testid this spec waits on — see #1363.
-test.fixme(
+test(
   "creating a new folder after deletion should work correctly",
-  { tag: ["@release", "@api"] },
+  { tag: ["@stable", "@release", "@api"] },
   async ({ page }) => {
     trackCreatedFlows(page);
     await awaitBootstrapTest(page);
@@ -328,14 +335,12 @@ test.fixme(
     const two = `folder-two-${stamp}`;
 
     // Create the first folder
-    const oneProject = await createProjectThroughSidebar(page);
-    createdProjectIds.add(oneProject.id);
-    await renameProjectThroughSidebar(page, oneProject.name, one);
+    const oneCreated = await createProjectThroughSidebar(page);
+    createdProjectIds.add(oneCreated.id);
+    const oneProject = await renameProjectThroughSidebar(page, oneCreated, one);
 
     // Delete it
-    const folderOne = page.getByTestId(`sidebar-nav-${one}`);
-    await folderOne.hover();
-    await page.getByTestId(`more-options-button_${one}`).click();
+    await openProjectOptions(page, oneProject);
     await page.getByTestId("btn-delete-project").click();
     await page.getByText("Delete").last().click();
 
@@ -344,23 +349,22 @@ test.fixme(
     });
 
     // Verify folder is deleted
-    await expect(page.getByTestId(`sidebar-nav-${one}`)).not.toBeVisible({
+    await expect(projectSidebarEntry(page, oneProject)).not.toBeVisible({
       timeout: 5000,
     });
 
     // Create a new folder immediately after the deletion — the assertion under
     // test: no stale-cache collision between a deletion and the next creation.
-    const twoProject = await createProjectThroughSidebar(page);
-    createdProjectIds.add(twoProject.id);
-    await renameProjectThroughSidebar(page, twoProject.name, two);
+    const twoCreated = await createProjectThroughSidebar(page);
+    createdProjectIds.add(twoCreated.id);
+    const twoProject = await renameProjectThroughSidebar(page, twoCreated, two);
 
-    const folderTwo = page.getByTestId(`sidebar-nav-${two}`);
+    const folderTwo = projectSidebarEntry(page, twoProject);
     await expect(folderTwo).toBeVisible({ timeout: 5000 });
 
     // Clean up through the UI; afterEach still deletes both ids via the API
     // because this delete can 500 silently (#965).
-    await folderTwo.hover();
-    await page.getByTestId(`more-options-button_${two}`).click();
+    await openProjectOptions(page, twoProject);
     await page.getByTestId("btn-delete-project").click();
     await page.getByText("Delete").last().click();
 
@@ -461,27 +465,18 @@ test(
         break;
       }
 
-      // Extract folder name from testid (e.g., "sidebar-nav-Starter Project" -> "starter-project")
-      const folderName = folderTestId.replace("sidebar-nav-", "");
-      const kebabName = folderName.toLowerCase().replace(/\s+/g, "-");
+      // The entry's testid suffix is whatever upstream keys it on — the project
+      // id on the nightly, its name on 1.11.x (#1363). Feeding it as BOTH halves
+      // of the ref makes `projectOptionsButton` try both kebab spellings as one
+      // locator, which is what the `isVisible()` fallback here used to do by
+      // hand — and it fell through to `more-options-button_*`.first() when
+      // neither matched, i.e. it could delete a folder other than the one it had
+      // just hovered.
+      const suffix = folderTestId.replace("sidebar-nav-", "");
+      const project = { id: suffix, name: suffix };
 
-      // Hover and click more options
       await firstFolder.hover();
-
-      // Try to find and click the more options button
-      const moreOptionsButton = page.getByTestId(
-        `more-options-button_${kebabName}`,
-      );
-
-      if (await moreOptionsButton.isVisible()) {
-        await moreOptionsButton.click();
-      } else {
-        // Try with the original name format
-        const altMoreOptions = page
-          .locator(`[data-testid^="more-options-button_"]`)
-          .first();
-        await altMoreOptions.click();
-      }
+      await projectOptionsButton(page, project).click();
 
       await page.getByTestId("btn-delete-project").click();
       await page.getByText("Delete").last().click();

--- a/tests/tests-automations/regression/core-functionality/project-management/folder-drag-drop-flow.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/project-management/folder-drag-drop-flow.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { projectSidebarEntry } from "../../../../helpers/ui/project-sidebar";
 
 test(
   "creating a flow in a specific folder via API places it in that folder",
@@ -111,13 +112,17 @@ test(
       // Navigate to the home page and wait for it to load
       await awaitBootstrapTest(page, { skipModal: true });
 
-      // The folder must appear in the left sidebar
-      await expect(
-        page.getByTestId(`sidebar-nav-${folderName}`),
-      ).toBeVisible({ timeout: 15000 });
+      // The folder must appear in the left sidebar. Addressed by the id/name
+      // pair: the nightly keys the testid on the project id, 1.11.x on its
+      // name (#1363).
+      const folder = projectSidebarEntry(page, {
+        id: folderId,
+        name: folderName,
+      });
+      await expect(folder).toBeVisible({ timeout: 15000 });
 
       // Click the folder in the sidebar
-      await page.getByTestId(`sidebar-nav-${folderName}`).click();
+      await folder.click();
 
       // The flow we created must appear in the main content area
       await expect(page.getByText(flowName)).toBeVisible({ timeout: 15000 });

--- a/tests/tests-automations/regression/mcp/server/mcp-server-starter-projects.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-starter-projects.spec.ts
@@ -2,9 +2,10 @@ import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
 import { cleanOldFolders } from "../../../../helpers/filesystem/clean-old-folders";
-import { convertTestName } from "../../../../helpers/filesystem/convert-test-name";
+import { createProjectThroughSidebar } from "../../../../helpers/flows/create-project-through-sidebar";
 import { deleteProject } from "../../../../helpers/flows/delete-project";
 import { navigateSettingsPages } from "../../../../helpers/ui/go-to-settings";
+import { openProjectOptions } from "../../../../helpers/ui/project-sidebar";
 
 /** The name test 1 renames its first project to. */
 const RENAMED_PROJECT = "renamed_project";
@@ -58,11 +59,9 @@ const removeLeftoverRenamedProject = async (page: Page) => {
   }
 };
 
-// Quarantined at triage (daily #1361): the project kebab never resolves under
-// the name-derived `more-options-button_<name>` testid — see #1363.
-test.fixme(
+test(
   "user must be able to see starter projects for mcp servers",
-  { tag: ["@release", "@workspace", "@components", "@mcp"] },
+  { tag: ["@stable", "@release", "@workspace", "@components", "@mcp"] },
   async ({ page }) => {
     //starter mcp project
 
@@ -81,8 +80,12 @@ test.fixme(
 
     //add new folders
 
-    await page.getByTestId("add-project-button").click();
-    await page.getByTestId("add-project-button").click();
+    // Created through the helper rather than two bare `add-project-button`
+    // clicks, so the test holds the id AND the backend-assigned name of each
+    // project. Both are needed to address the sidebar entry and its kebab: the
+    // nightly keys those testids on the project id, 1.11.x on its name (#1363).
+    const firstProject = await createProjectThroughSidebar(page);
+    await createProjectThroughSidebar(page);
 
     await navigateSettingsPages(page, "Settings", "MCP Servers");
 
@@ -103,24 +106,17 @@ test.fixme(
 
     //rename a folder
 
-    const getFirstFolderName = convertTestName(
-      (await page.getByText("New Project").first().textContent()) as string,
-    );
+    // Renamed through the kebab's own "Rename" entry (the double-click path is
+    // covered by folder-crud.spec.ts), addressing the project this test created
+    // instead of "whichever entry reads 'New Project' first" — a sibling worker
+    // creating its own project mid-run could otherwise be the one renamed.
+    await openProjectOptions(page, firstProject);
+    await page.getByText("Rename", { exact: true }).last().click();
+    await page.getByTestId("input-project").last().fill(RENAMED_PROJECT);
+    await page.keyboard.press("Enter");
+    await page.waitForTimeout(1000);
 
-    await page
-      .getByText("New Project")
-      .first()
-      .hover()
-      .then(async () => {
-        await page
-          .getByTestId(`more-options-button_${getFirstFolderName}`)
-          .last()
-          .click();
-        await page.getByText("Rename", { exact: true }).last().click();
-        await page.getByTestId("input-project").last().fill(RENAMED_PROJECT);
-        await page.keyboard.press("Enter");
-        await page.waitForTimeout(1000);
-      });
+    const renamedProject = { id: firstProject.id, name: RENAMED_PROJECT };
 
     await navigateSettingsPages(page, "Settings", "MCP Servers");
 
@@ -133,18 +129,10 @@ test.fixme(
     //delete a folder
 
     await page.getByTestId("icon-ChevronLeft").first().click();
-    await page
-      .getByTestId("sidebar-nav-renamed_project")
-      .hover()
-      .then(async () => {
-        await page
-          .getByTestId("more-options-button_renamed_project")
-          .last()
-          .click();
-        await page.getByText("Delete", { exact: true }).last().click();
-        await page.getByText("Delete", { exact: true }).last().click();
-        await page.waitForTimeout(1000);
-      });
+    await openProjectOptions(page, renamedProject);
+    await page.getByText("Delete", { exact: true }).last().click();
+    await page.getByText("Delete", { exact: true }).last().click();
+    await page.waitForTimeout(1000);
 
     await navigateSettingsPages(page, "Settings", "MCP Servers");
 


### PR DESCRIPTION
**Closes #1363.**

## Problem

Seven `@stable` tests across four specs hard-failed on the 2026-08-07 daily ([run 31163810520](https://github.com/oriontech-me/langflow-e2e/actions/runs/31163810520)) with one shape: a project the backend confirms exists (`POST /api/v1/projects` → `201`) never resolves in the home sidebar. Every one failed on **all three attempts**, across both shards and worker indices 2–17, outside the run's 108 s outage window — so not environmental. They were quarantined manually at triage (`@stable` removed **and** `test.fixme` added).

Upstream `23f91d8587` (`fix(authz): support scoped project visibility`, langflow-ai/langflow#14429) re-keyed both testids from the project **name** to its **id**, on the `release-1.12.0` line the nightly is cut from:

```diff
- data-testid={`sidebar-nav-${item.name}`}
+ data-testid={`sidebar-nav-${item.id}`}
- "more-options-button" + `_${convertTestName(item?.name ?? "")}`
+ data-testid={`more-options-button_${item.id}`}
```

## Verdict: internal rename of an automation hook — NOT a product regression

Read from the live DOM on `1.12.0.dev20`, not inferred from the commit:

```
entry   data-testid="sidebar-nav-<uuid>"           id="sidebar-nav-<uuid>"
kebab   data-testid="more-options-button_<uuid>"   aria-label="Options for <name>"
wrapper data-project-id="<uuid>"
```

The name is still the entry's **text** and the kebab's **accessible name**, so nothing a user or a screen reader perceives was lost — `data-testid` is a test hook, not a product contract. Keying on the id is also the more correct choice under the change that introduced it: visibility is now per-principal, and a project name is not unique across principals while its id is. No `REGRESSIONS.md` row is owed and no upstream ticket is filed. Full reasoning recorded on the issue.

Ruled out rather than assumed: the `ProjectRenamePermission` wrapper the same commit adds is `children(can(projectId, "write"))` — it always renders its child, and `canRename` only guards `onDoubleClick`. Both projects render live.

## Fix

Addressing lives in one place — `tests/helpers/ui/project-sidebar.ts` — matching **both** spellings as a single locator.

That is not a hedge. `main` still renders the name-derived testid, and `manual.yml` dispatches the `@stable` set against `1.11.x` release candidates before every sign-off — pinning the id alone would trade seven tests red on the nightly for seven red on the lane that signs releases off. The two branches can never both match: an entry carries exactly one testid, and a project's name is never another project's uuid. The name branch carries its own deletion trigger, and it is the only place that spells it.

**Rejected:** editing each spec in place. The issue's own directive puts the fix in the shared layer, and addressing by the id the create response already returns removes the #1023 ambiguity instead of trading one name for another.

Consumers updated: `MainPage` (`deleteProject` / `clickProject` / `uploadFlowByDragDrop`), `createProjectThroughSidebar` / `renameProjectThroughSidebar`, `cleanOldFolders`, the four quarantined specs, and the two latent ones.

### Second defect, riding on the first

`cleanOldFolders` drove the kebab through the name-derived testid, so from `dev20` on it deleted **nothing** and merely timed out on a click — the mechanism behind the `New Project` → `New Project (5)` accumulation the daily's retries recorded *inside a single test*. It now sweeps through the REST API: this is teardown of the **previous** run and must not depend on the UI state the test it precedes is about to assert on, the argument `removeLeftoverRenamedProject` already makes in the same file.

Measured on `1.12.0.dev20`: 3 `New Project*` projects seeded via `POST /api/v1/projects/`, spec run once — **0 of 3 survived**.

### One observable had to change

The id-derived testid does **not** change with a rename, so asserting on it would pass whether the rename committed or not. `renameProjectThroughSidebar` now asserts the entry's **text**, and returns the project under its new name (which is what later assertions must address it by on `1.11.x`, where the testid *does* change).

## Scope notes

- **Quarantine lifted** on all 7 tests — `test.fixme` removed and `@stable` restored.
- The two specs carrying the same addressing but no `@stable`, hence latently broken and invisible to the daily, are fixed here as the issue requires: `folder-drag-drop-flow.spec.ts`, `flow-navigation-between-folders.spec.ts`.
- The `@destructive` loop kept its assertions; its `isVisible()` fallback to `more-options-button_*.first()` is gone — it could delete a folder other than the one it had just hovered. The `#1008` known-defect declaration still fires.
- No assertion was weakened anywhere; every changed line is addressing, not verdict.
- **Out of scope, filed separately:** #1376 — `mcp-server-starter-projects` leaks one flow and one project per run, masked by the next run's `cleanOldFolders`. A cleanup defect, not an addressing one.

## Covered tests

| # | Test | What it validates |
|---|---|---|
| 1 | `creates, renames and deletes an empty project folder via the UI` | entry visible after create; entry **text** becomes the new unique name; `Project deleted successfully`; entry gone |
| 2 | `deleting a folder that contains a flow removes the flow with it` | flow listed inside the folder; after the UI delete, `GET /api/v1/flows/{id}` → **404** |
| 3 | `deleting a folder should update the folder list immediately` | entry gone within 10 s (no stale data) and `add-project-button` still functional |
| 4 | `deleting one folder should not affect other folders` | alpha gone, **beta still visible and clickable**, `mainpage_title` renders |
| 5 | `creating a new folder after deletion should work correctly` | the second folder's entry appears — no stale-cache collision between a deletion and the next creation |
| 6 | `deleting every folder lands on the empty project screen` *(`@destructive`)* | `folderCount === 0`, sidebar empty message, `new_project_btn_empty_page`; the `#1008` `422` still fires as declared |
| 7 | `user should be able to select flows … bulk actions` | all 3 checkboxes checked, download toast, listing equals exactly the 3 created names |
| 8 | `user must be able to see starter projects for mcp servers` | `lf-starter_project` count 1; `lf-new_project` / `lf-new_project_1` appear; `lf-renamed_project` appears then count 0 after delete |
| 9 | `navigating between two folders scopes the listing to each folder's flows` | **mutual exclusion** — folder A shows flow A and `toHaveCount(0)` of flow B, and vice versa |
| 10 | `folder listing shows flows correctly via UI` | the folder appears in the sidebar and clicking it lists its flow |

## Unit coverage (`npm run test:units`)

`project-sidebar.test.ts` asserts by **selection**, not string equality — each case compiles the selector and runs it against a `data-testid`: it matches the id spelling (nightly) and the name spelling (`main`/`1.11.x`); the kebab matches the id and the **slugified** name and not the raw one; matching is exact, so `New Project` does not match `New Project (3)`; a name carrying `"` or `\` still yields a well-formed selector.

`clean-old-folders.test.ts` pins the sweep's end state, not its calls: it deletes every `New Project*` and nothing else, deletes **by id** and never through the sidebar, reads both response shapes, does not throw on a failed list, does not abort on one undeletable leftover, and does not sweep a name that merely *contains* "New Project".

## Validation (nightly `1.12.0.dev20`, `--workers=1 --retries=0`)

- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors) · `npm run test:units` ✅ 531/531 · `npm run test:scripts` ✅ 795/795
- **5 clean runs** of the six specs, `11 passed` each (~39 s); `@destructive` green isolated (`1 passed`)
- `--trace=on` ✅ — ran normally (23 s), no sign of the Simple Agent-family hang
- **Zero `🚨 Backend Error`** attributable to this change. Two advisory entries appear, both from `mcp-server-starter-projects` test 2, which this PR does not touch and which reproduces them on `main`: the `409 Server already exists.` **is that test's own assertion**, and the intermittent `500` on `DELETE /api/v1/flows/` is `sqlite3.OperationalError: database is locked` in the cascade delete — the already-filed #965/LE-2020 contention class, read from the container's traceback.
- Orphan check: flows and projects counted via `GET /api/v1/flows/?get_all=true` and `GET /api/v1/projects/` before and after a clean run — **0 delta** for all five `project-management` specs. The `+1/+1` on the MCP spec is pre-existing and filed as #1376.

### Force-fail — executed, one mutation per test in scope

| Mutation | Result |
|---|---|
| **A** — drop the id branch from both selector builders (i.e. the pre-#1363 addressing) | **9 of 9** UI tests failed (1–5, 7–10); the two API-only tests and the untouched siblings passed |
| **B** — drop the name branch | unit `516`, `517`, `520` failed — the `1.11.x` half is guarded, not decorative |
| **C** — `cleanOldFolders` filter matches nothing | unit `109`, `110`, `111`, `113` failed |
| **D** — `renameProjectThroughSidebar` stops filling the input (no rename happens) | tests 1, 4, 5 failed on `toContainText`; tests 2 and 3, which do not rename, passed — this is what proves the new observable detects a rename that did not commit |
| **E** — mutate `flow.folder_id` and `numberOfErrors` | the two untouched tests inside touched files failed |
| **F** — `@destructive` kebab pointed at a non-existent id | `TimeoutError: locator.click`. It needed its own mutation: **A does not break it**, because it derives the suffix from the DOM and is therefore spelling-agnostic by construction |

Revert proven: `grep FF_MUTATION` over `tests/` returns **0**, followed by a final green run.

## Dependencies

None — pure UI plus REST. No LLM, no provider key. Parallel-safe: every test addresses only projects it created, and cleanup is id-scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
