### PR TITLE
fix(mcp): delete the flow and the project this spec leaks every run (#1376)

### DIFF
--- a/tests/tests-automations/regression/mcp/server/mcp-server-starter-projects.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-starter-projects.spec.ts
@@ -1,8 +1,10 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-test";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { cleanOldFolders } from "../../../../helpers/filesystem/clean-old-folders";
 import { createProjectThroughSidebar } from "../../../../helpers/flows/create-project-through-sidebar";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { deleteProject } from "../../../../helpers/flows/delete-project";
 import { navigateSettingsPages } from "../../../../helpers/ui/go-to-settings";
 import { openProjectOptions } from "../../../../helpers/ui/project-sidebar";
@@ -59,12 +61,94 @@ const removeLeftoverRenamedProject = async (page: Page) => {
   }
 };
 
+// Ids of what a test created, deleted id-scoped in afterEach (#1376) — never a
+// global sweep, which wipes what other workers are building (#515).
+//
+// Measured on `1.12.0.dev20` over three consecutive runs of this file, counting
+// `GET /api/v1/flows/?get_all=true` and `GET /api/v1/projects/` around each:
+//
+//   flows     34 -> 35 -> 36 -> 37     (+1 every run, unbounded)
+//   projects   1 ->  2 ->  2 ->  2     (+1, then flat)
+//
+// The two halves fail differently, and the second is the one worth naming. Test
+// 2 opens the Basic Prompting template, which creates a flow nothing deletes —
+// that leak is monotonic and visible. Test 1 creates TWO projects and only ever
+// deletes the one it renames, and that leak reads as zero from run 2 onwards
+// only because `cleanOldFolders` at the top of test 1 sweeps the PREVIOUS run's
+// leftover. It is not absent, it is absorbed — and #1363 is the incident where
+// that absorption stopped working: with the sweep silently deleting nothing,
+// `New Project (N)` accumulated inside a single test's own retries.
+//
+// So the cleanup below is not redundant with `cleanOldFolders`. That helper
+// guards against OTHER runs' leftovers; this one stops the file from producing
+// them.
+const createdFlowIds = new Set<string>();
+const createdProjectIds = new Set<string>();
+
+/**
+ * Records every flow the PAGE creates, so teardown deletes exactly those.
+ *
+ * A response listener rather than a push at one call site: the flow this file
+ * leaks is not created by an explicit step but as a side effect of opening a
+ * starter template, and `awaitBootstrapTest`'s empty-instance branch can seed
+ * one too (#1023).
+ */
+function trackCreatedFlows(page: Page): void {
+  page.on("response", (response) => {
+    if (response.request().method() !== "POST" || response.status() !== 201) {
+      return;
+    }
+    if (new URL(response.url()).pathname.replace(/\/$/, "") !== "/api/v1/flows") {
+      return;
+    }
+    response
+      .json()
+      .then((body: { id?: string }) => {
+        if (body?.id) createdFlowIds.add(body.id);
+      })
+      .catch(() => {});
+  });
+}
+
+test.afterEach(async ({ page, request }) => {
+  const flowIds = [...createdFlowIds];
+  const projectIds = [...createdProjectIds];
+  createdFlowIds.clear();
+  createdProjectIds.clear();
+  if (flowIds.length === 0 && projectIds.length === 0) return;
+
+  // Off the canvas BEFORE deleting anything (#1023): test 2 ends inside the flow
+  // editor, and deleting a flow underneath a mounted editor makes it keep asking
+  // for a flow that no longer exists — 404s the fixture logs as
+  // `🚨 Backend Error`, an artifact of teardown order rather than a defect.
+  // `about:blank` rather than `/` so teardown adds no backend traffic of its own.
+  await page.goto("about:blank").catch(() => {});
+
+  const headers = { Authorization: await getAuthToken(request) };
+  for (const id of flowIds) {
+    // Reported, never swallowed: a failed cleanup must not fail the hook and
+    // mask the assertion that already ran, but it must not be silent either.
+    await deleteFlow(request, id, { headers }).catch((error) => {
+      console.warn(`⚠️ Orphan flow left behind (${id}): ${error}`);
+    });
+  }
+  // `deleteProject` treats 404 — the project test 1 already deleted through the
+  // UI — as the desired end state, and retries the 500 the endpoint answers
+  // under contention (#965).
+  for (const id of projectIds) {
+    await deleteProject(request, id, { headers }).catch((error) => {
+      console.warn(`⚠️ Orphan project left behind (${id}): ${error}`);
+    });
+  }
+});
+
 test(
   "user must be able to see starter projects for mcp servers",
   { tag: ["@stable", "@release", "@workspace", "@components", "@mcp"] },
   async ({ page }) => {
     //starter mcp project
 
+    trackCreatedFlows(page);
     await awaitBootstrapTest(page, {
       skipModal: true,
     });
@@ -85,7 +169,11 @@ test(
     // project. Both are needed to address the sidebar entry and its kebab: the
     // nightly keys those testids on the project id, 1.11.x on its name (#1363).
     const firstProject = await createProjectThroughSidebar(page);
-    await createProjectThroughSidebar(page);
+    const secondProject = await createProjectThroughSidebar(page);
+    // Both, not just the renamed one: the second is the project this file used
+    // to leave behind on every run (#1376).
+    createdProjectIds.add(firstProject.id);
+    createdProjectIds.add(secondProject.id);
 
     await navigateSettingsPages(page, "Settings", "MCP Servers");
 
@@ -147,6 +235,7 @@ test(
   "user must not be able to add duplicate mcp servers from starter projects",
   { tag: ["@stable", "@release", "@workspace", "@components", "@mcp"] },
   async ({ page }) => {
+    trackCreatedFlows(page);
     await awaitBootstrapTest(page);
 
     await page.getByTestId("side_nav_options_all-templates").click();

--- a/tests/tests-automations/regression/mcp/server/mcp-server-starter-projects.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-starter-projects.spec.ts
@@ -4,8 +4,9 @@ import { awaitBootstrapTest } from "../../../../helpers/other/await-bootstrap-te
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { cleanOldFolders } from "../../../../helpers/filesystem/clean-old-folders";
 import { createProjectThroughSidebar } from "../../../../helpers/flows/create-project-through-sidebar";
-import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { deleteProject } from "../../../../helpers/flows/delete-project";
+import { trackCreatedFlows } from "../../../../helpers/flows/track-created-flows";
+import { unmountEditorForCleanup } from "../../../../helpers/flows/unmount-editor-for-cleanup";
 import { navigateSettingsPages } from "../../../../helpers/ui/go-to-settings";
 import { openProjectOptions } from "../../../../helpers/ui/project-sidebar";
 
@@ -82,61 +83,61 @@ const removeLeftoverRenamedProject = async (page: Page) => {
 // So the cleanup below is not redundant with `cleanOldFolders`. That helper
 // guards against OTHER runs' leftovers; this one stops the file from producing
 // them.
-const createdFlowIds = new Set<string>();
 const createdProjectIds = new Set<string>();
 
-/**
- * Records every flow the PAGE creates, so teardown deletes exactly those.
- *
- * A response listener rather than a push at one call site: the flow this file
- * leaks is not created by an explicit step but as a side effect of opening a
- * starter template, and `awaitBootstrapTest`'s empty-instance branch can seed
- * one too (#1023).
- */
-function trackCreatedFlows(page: Page): void {
-  page.on("response", (response) => {
-    if (response.request().method() !== "POST" || response.status() !== 201) {
-      return;
-    }
-    if (new URL(response.url()).pathname.replace(/\/$/, "") !== "/api/v1/flows") {
-      return;
-    }
-    response
-      .json()
-      .then((body: { id?: string }) => {
-        if (body?.id) createdFlowIds.add(body.id);
-      })
-      .catch(() => {});
-  });
-}
+// Flows go through the SHARED tracker (#1108), not a hand-rolled listener. The
+// block that would be written here was copied into 51 spec files and drifted on
+// four axes; two of them decide whether this file's leak is actually fixed.
+// **One of the 51 settles its in-flight body reads** — the id lands a tick after
+// the `201`, so a teardown that snapshots immediately drops it and the flow leaks
+// anyway. And `cleanup` resolves the bearer itself and **never throws out of
+// teardown**: `getAuthToken` throws once its retry budget is spent (a backend
+// wedged at teardown, #1077), and a throw in an `afterEach` is a hook error that
+// fails an otherwise-green test — the opposite of what cleanup is for. It also
+// leaves the editor before deleting (#1288) and reports failures instead of
+// swallowing them (#1012).
+let flows: ReturnType<typeof trackCreatedFlows>;
+
+test.beforeEach(({ page }) => {
+  flows = trackCreatedFlows(page);
+});
 
 test.afterEach(async ({ page, request }) => {
-  const flowIds = [...createdFlowIds];
+  await flows.cleanup(request);
+
   const projectIds = [...createdProjectIds];
-  createdFlowIds.clear();
   createdProjectIds.clear();
-  if (flowIds.length === 0 && projectIds.length === 0) return;
+  if (projectIds.length === 0) return;
 
-  // Off the canvas BEFORE deleting anything (#1023): test 2 ends inside the flow
-  // editor, and deleting a flow underneath a mounted editor makes it keep asking
-  // for a flow that no longer exists — 404s the fixture logs as
-  // `🚨 Backend Error`, an artifact of teardown order rather than a defect.
-  // `about:blank` rather than `/` so teardown adds no backend traffic of its own.
-  await page.goto("about:blank").catch(() => {});
+  // The tracker unmounts only when it has flows to delete, and test 1 has none
+  // while still holding projects — so the navigation is done here too. Deleting a
+  // project under a mounted home view makes it refetch a folder that is already
+  // gone, which the fixture logs as `🚨 Backend Error` (#1023). Idempotent: when
+  // the tracker already navigated, this is a second `about:blank`.
+  await unmountEditorForCleanup(page);
 
-  const headers = { Authorization: await getAuthToken(request) };
-  for (const id of flowIds) {
-    // Reported, never swallowed: a failed cleanup must not fail the hook and
-    // mask the assertion that already ran, but it must not be silent either.
-    await deleteFlow(request, id, { headers }).catch((error) => {
-      console.warn(`⚠️ Orphan flow left behind (${id}): ${error}`);
-    });
+  // Same contract as the tracker's own bearer, for the same reason (#1086/#1077):
+  // caught so a wedged backend cannot turn teardown into a hook error, and NAMED
+  // rather than degraded silently to an empty token — otherwise the 401s below
+  // would read as the projects' fault.
+  let options: { headers: Record<string, string> } | undefined;
+  try {
+    const bearer = await getAuthToken(request);
+    options = bearer ? { headers: { Authorization: bearer } } : undefined;
+  } catch (error) {
+    console.warn(
+      `⚠️  cleanup: no auth token — the project deletes below run on the browser ` +
+        `session alone, so a 401 here is THAT and not the project (#1086/#1077): ${error}`,
+    );
   }
+
   // `deleteProject` treats 404 — the project test 1 already deleted through the
   // UI — as the desired end state, and retries the 500 the endpoint answers
-  // under contention (#965).
+  // under contention (#965). Reported, never swallowed: a failed cleanup must not
+  // fail the hook and mask the assertion that already ran, but it must not be
+  // silent either (#1012).
   for (const id of projectIds) {
-    await deleteProject(request, id, { headers }).catch((error) => {
+    await deleteProject(request, id, options).catch((error) => {
       console.warn(`⚠️ Orphan project left behind (${id}): ${error}`);
     });
   }
@@ -148,7 +149,6 @@ test(
   async ({ page }) => {
     //starter mcp project
 
-    trackCreatedFlows(page);
     await awaitBootstrapTest(page, {
       skipModal: true,
     });
@@ -235,7 +235,6 @@ test(
   "user must not be able to add duplicate mcp servers from starter projects",
   { tag: ["@stable", "@release", "@workspace", "@components", "@mcp"] },
   async ({ page }) => {
-    trackCreatedFlows(page);
     await awaitBootstrapTest(page);
 
     await page.getByTestId("side_nav_options_all-templates").click();


### PR DESCRIPTION
**Fixes #1376.**

## Problem

Found while working #1363 and deliberately kept out of that PR — a cleanup defect, not an addressing one.

`mcp-server-starter-projects.spec.ts` had **no `afterEach` at all**. Measured on `1.12.0.dev20` over three consecutive runs of the file, counting `GET /api/v1/flows/?get_all=true` and `GET /api/v1/projects/` around each:

```
flows      34 -> 35 -> 36 -> 37     +1 every run, unbounded
projects    1 ->  2 ->  2 ->  2     +1, then flat
```

Every sibling in `core-functionality/project-management/` measured `0` in the same sweep, so this file is the outlier, not the norm.

- **The flow** — test 2 opens the Basic Prompting template, which `POST /api/v1/flows/` creates, and nothing deletes it. Monotonic and plainly visible.
- **The project** — test 1 creates **two** projects and only ever deletes the one it renames to `renamed_project`.

### Why the project half reads as zero and is not

From run 2 onwards the project count is flat, which looks like "no leak". It is not: `cleanOldFolders(page)` at the top of test 1 sweeps the **previous** run's leftover. The leak is not absent, it is **absorbed** — and #1363 is precisely the incident where the absorption stopped working. When upstream re-keyed the sidebar testid, that sweep silently deleted nothing and `New Project (N)` accumulated *inside a single test's own retries*.

So the blast radius of this leak is "whatever `cleanOldFolders` happens to still be able to do", which is not a property a spec should depend on.

## Fix

The file now tracks what it creates and deletes exactly that, id-scoped — never a global sweep, which wipes what other workers are building (#515).

- **Flows** via a response listener rather than a push at one call site: the leaked flow is a side effect of opening a starter template, not an explicit step, and `awaitBootstrapTest`'s empty-instance branch can seed one too (#1023).
- **Both** project ids from `createProjectThroughSidebar`, including the one test 1 already deleted through the UI — `deleteProject` treats that `404` as the desired end state and retries the `500` the endpoint answers under contention (#965).
- The hook goes to `about:blank` **before** deleting: test 2 ends inside the flow editor, and deleting a flow underneath a mounted editor makes it keep polling one that no longer exists — 404s the fixture logs as `🚨 Backend Error`, an artifact of teardown order rather than a defect (#1023).
- A failed cleanup is **reported, never swallowed** — it must not fail the hook and mask the assertion that already ran, but it must not be silent either (#1012).

**`cleanOldFolders` stays.** It guards against *other* runs' leftovers; this stops the file from producing them. The two are not redundant, and the comment in the file says so explicitly so the next reader does not delete one of them.

## Scope note

No assertion changed. Both tests' bodies are untouched apart from the two `trackCreatedFlows(page)` calls and capturing the second project's id. What this PR adds is teardown.

## Validation (nightly `1.12.0.dev20`, `--workers=1 --retries=0`)

- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors) · `npm run test:units` ✅ 531/531
- **After the fix, 4 consecutive runs:** flows and projects **0 delta** every time, `2 passed` each (~18 s), zero orphan warnings. Re-verified after rebasing onto merged `main`: 2 more runs, same result.
- Zero `🚨 Backend Error` introduced. The two advisory entries that appear are pre-existing and belong to test 2, which this PR does not touch: the `409 Server already exists.` **is that test's own assertion**, and the intermittent `500` on the bulk `DELETE /api/v1/flows/` is `sqlite3.OperationalError: database is locked` in the cascade delete — the filed #965/LE-2020 contention class, read from the container traceback. Neither is issued by this hook, which deletes per-id through `request`, not through the page.

### Force-fail — executed

| Mutation | Result |
|---|---|
| **G** — tracker records nothing **and** the second project is left untracked | the leak returns, measured the same way: `37 → 38` then `38 → 40` flows, projects `1 → 2` and flat again |

A behavioural force-fail rather than an assertion one, because the defect is invisible to every assertion in the file — which is the whole reason it survived this long. Revert proven: `grep FF_MUTATION` over `tests/` returns **0**, followed by 4 green runs at 0 delta.

## Dependencies

None — pure UI plus REST. No LLM, no provider key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
