### PR TITLE
fix(llm-agents): bound the multi-tool sequence run and report its real failure (#1378)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -369,7 +369,7 @@
 
 #### 6.4 Tools and Integrations
 - [ ] Agent with integrated external MCP tool executes action and returns result
-- [-] Agent executes multiple tools in sequence → `llm-agents/agent-multi-tool-selection.spec.ts` (Test 3 — chained fetch→search, ordered `tool_use` assert; `@stable` gated on the clean baseline #818, per #827. #1378 bounded the run with a measured `max_iterations` cap after the unbounded Web Search payload blew the context up, and `langflow-ai/langflow#14489` has since bounded that payload upstream — 17.9× smaller per call, in the nightly from `1.12.0.dev25`. Still `[-]`, but no longer for that reason: the gate is the clean baseline #818, per #827, which has not moved)
+- [-] Agent executes multiple tools in sequence → `llm-agents/agent-multi-tool-selection.spec.ts` (Test 3 — chained fetch→search, ordered `tool_use` assert. Both gates on record have since closed: the clean baseline of #818/#827 on 2026-07-30, and `langflow-ai/langflow#14469` — the unbounded Web Search payload that blew the context up in #1378 — by `#14489` on 2026-08-10, 17.9× smaller per call from `1.12.0.dev25`. Still `[-]` for a narrower reason: #1378's failure is OpenAI-specific (200k TPM on `gpt-4o-mini`) and there is no post-fix measurement on that provider — CI skips every OpenAI target on a drained key)
 - [x] Tool returns error — agent handles it and continues execution → `core-functionality/llm-agents/agent-tool-error-handling.spec.ts`
 - [x] Multiple connected tools — agent selects the correct one for each prompt → `agent-multi-tool-selection.spec.ts`
 - [x] Tool with invalid name — validation prevents execution with clear message → `core-functionality/llm-agents/agent-tool-name-validation.spec.ts`

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -369,7 +369,7 @@
 
 #### 6.4 Tools and Integrations
 - [ ] Agent with integrated external MCP tool executes action and returns result
-- [-] Agent executes multiple tools in sequence → `llm-agents/agent-multi-tool-selection.spec.ts` (Test 3 — chained fetch→search, ordered `tool_use` assert; `@stable` gated on the clean baseline #818, per #827)
+- [-] Agent executes multiple tools in sequence → `llm-agents/agent-multi-tool-selection.spec.ts` (Test 3 — chained fetch→search, ordered `tool_use` assert; `@stable` gated on the clean baseline #818, per #827. #1378 bounded the run with a measured `max_iterations` cap after the unbounded Web Search payload blew the context up — still `[-]`: the cap raises the pass rate, it does not make the agent's convergence deterministic)
 - [x] Tool returns error — agent handles it and continues execution → `core-functionality/llm-agents/agent-tool-error-handling.spec.ts`
 - [x] Multiple connected tools — agent selects the correct one for each prompt → `agent-multi-tool-selection.spec.ts`
 - [x] Tool with invalid name — validation prevents execution with clear message → `core-functionality/llm-agents/agent-tool-name-validation.spec.ts`

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -369,7 +369,7 @@
 
 #### 6.4 Tools and Integrations
 - [ ] Agent with integrated external MCP tool executes action and returns result
-- [-] Agent executes multiple tools in sequence → `llm-agents/agent-multi-tool-selection.spec.ts` (Test 3 — chained fetch→search, ordered `tool_use` assert; `@stable` gated on the clean baseline #818, per #827. #1378 bounded the run with a measured `max_iterations` cap after the unbounded Web Search payload blew the context up — still `[-]`: the cap raises the pass rate, it does not make the agent's convergence deterministic)
+- [-] Agent executes multiple tools in sequence → `llm-agents/agent-multi-tool-selection.spec.ts` (Test 3 — chained fetch→search, ordered `tool_use` assert; `@stable` gated on the clean baseline #818, per #827. #1378 bounded the run with a measured `max_iterations` cap after the unbounded Web Search payload blew the context up — still `[-]`: the cap bounds the cost of a failure and makes it report its real cause, but the measured pass rate is unchanged (4/5 → 5/6, within noise) and stabilising it depends on `langflow-ai/langflow#14469`)
 - [x] Tool returns error — agent handles it and continues execution → `core-functionality/llm-agents/agent-tool-error-handling.spec.ts`
 - [x] Multiple connected tools — agent selects the correct one for each prompt → `agent-multi-tool-selection.spec.ts`
 - [x] Tool with invalid name — validation prevents execution with clear message → `core-functionality/llm-agents/agent-tool-name-validation.spec.ts`

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -369,7 +369,7 @@
 
 #### 6.4 Tools and Integrations
 - [ ] Agent with integrated external MCP tool executes action and returns result
-- [-] Agent executes multiple tools in sequence → `llm-agents/agent-multi-tool-selection.spec.ts` (Test 3 — chained fetch→search, ordered `tool_use` assert; `@stable` gated on the clean baseline #818, per #827. #1378 bounded the run with a measured `max_iterations` cap after the unbounded Web Search payload blew the context up — still `[-]`: the cap bounds the cost of a failure and makes it report its real cause, but the measured pass rate is unchanged (4/5 → 5/6, within noise) and stabilising it depends on `langflow-ai/langflow#14469`)
+- [-] Agent executes multiple tools in sequence → `llm-agents/agent-multi-tool-selection.spec.ts` (Test 3 — chained fetch→search, ordered `tool_use` assert; `@stable` gated on the clean baseline #818, per #827. #1378 bounded the run with a measured `max_iterations` cap after the unbounded Web Search payload blew the context up, and `langflow-ai/langflow#14489` has since bounded that payload upstream — 17.9× smaller per call, in the nightly from `1.12.0.dev25`. Still `[-]`, but no longer for that reason: the gate is the clean baseline #818, per #827, which has not moved)
 - [x] Tool returns error — agent handles it and continues execution → `core-functionality/llm-agents/agent-tool-error-handling.spec.ts`
 - [x] Multiple connected tools — agent selects the correct one for each prompt → `agent-multi-tool-selection.spec.ts`
 - [x] Tool with invalid name — validation prevents execution with clear message → `core-functionality/llm-agents/agent-tool-name-validation.spec.ts`

--- a/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
+++ b/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
@@ -185,9 +185,10 @@ describe with two tests:
 > tests 1–2, this test's instruction *permits* a multi-tool sequence, and the
 > agent does not reliably converge on it. When it doesn't, it keeps calling
 > `perform_search`, and each call injects the Web Search component's full
-> result set into the conversation. That component caps nothing:
-> `perform_web_search()` iterates every `div.result` DuckDuckGo returns and
-> scrapes each linked page's **entire** text (upstream
+> result set into the conversation. That component capped nothing — until
+> `langflow-ai/langflow#14489`, see the update at the end of this note:
+> `perform_web_search()` iterated every `div.result` DuckDuckGo returns and
+> scraped each linked page's **entire** text (upstream
 > `langflow-ai/langflow#14469`). Measured on `1.12.0.dev20`, query
 > `"Sample Slide Show"`: **10 results, 182,316 chars ≈ 45.6k tokens in one
 > call** (largest single page: 40,755 chars). The conversation is re-sent
@@ -222,15 +223,61 @@ describe with two tests:
 > the sequence assert fails on *absent* data rather than wrong data, and the
 > cap meant to fix the test breaks it a second way.
 >
-> **The residual flake cannot be fixed from this repo, and that is the honest
-> bottom line.** A *single* `perform_search` call is already unbounded —
-> measured the same day across three queries: **15,857 / 53,714 / 78,848**
-> tokens for one call, a 5× spread, with the query chosen by the agent and
-> not by us. Two calls at the top of that range exceed 128k on their own, so
-> **no iteration cap can guarantee this test.** Real stabilisation needs the
-> payload bounded upstream (`langflow-ai/langflow#14469`). Until that lands,
-> this test stays out of `@stable` and its checklist bullet stays `[-]`.
-> **Re-measure before changing the number — do not re-derive it on paper.**
+> **The upstream cap landed, and it retires this note's central argument
+> (measured 2026-08-13).** `langflow-ai/langflow#14489` bounded the component
+> with two advanced inputs: `max_results` (default 5) and
+> `max_content_length` (default 2,000 chars, truncation marked
+> `... [truncated]`). It merged on 2026-08-10 and reached the nightly in
+> **`1.12.0.dev25`** — *not* `dev24`, whose image was cut before the
+> merge-back landed on `release-1.12.0`. **Reading the fix on the branch does
+> not say the running image has it**, and that mistake costs a whole
+> measurement: the check is `grep max_results` in the INSTALLED wheel
+> (`/app/.venv/lib/python*/site-packages/lfx/components/data_source/web_search.py`),
+> never the ref. Measured on `1.12.0.dev25`, same query as above: **5 results,
+> 10,000 chars ≈ 2.5k tokens**, all five truncated at 2,000 — a **17.9×**
+> reduction against the 178,830 chars the identical call returned on `dev24`.
+> The bound reaches this test and not merely the library: Langflow freezes
+> component code into the saved flow, and the `Simple Agent` starter in
+> `dev25` ships both the new fields and the new embedded code (verified on the
+> instantiated flow, not assumed from the package).
+>
+> **What that retires.** The previous version of this note argued that no
+> iteration cap could ever guarantee this test, because a *single*
+> `perform_search` was itself unbounded — measured across three queries:
+> **15,857 / 53,714 / 78,848** tokens for one call, a 5× spread, with the query
+> chosen by the agent and not by us. That premise is gone: one call now has a
+> hard ceiling of 5 × 2,000 chars ≈ 2.5k tokens, so even the worst case of 15
+> iterations accumulates ~37k tokens of search payload — inside
+> `gpt-4o-mini`'s 128k window and inside CI's 200k TPM.
+>
+> **What it does not retire: the cap.** Measured on `1.12.0.dev25` /
+> `gpt-4o-mini`, `--retries=0 --workers=1`:
+>
+> | `max_iterations` | Pass rate | Note |
+> |---|---|---|
+> | 15 (default) | 4/4 | 27–51 s |
+> | **8** (this spec) | **7/7** | 21–48 s, on a warm backend |
+>
+> One further run at 8 failed and is excluded on purpose: it was the first run
+> after the container came up, and it failed `read-failed` with **0** successful
+> reads of the persisted flow — a state the credential guard itself reports as
+> saying nothing about the binding (#1077). Counting a cold-start wedge as a
+> failure of this test is how an infra number becomes a product number.
+>
+> Both arms green is **not** evidence that the cap is dispensable, and reading
+> it that way is the trap this table exists to close: on `dev24` — the still
+> *unbounded* image — 10 of 10 runs passed the same day, so this environment
+> did not reproduce the failure at all and the two arms cannot discriminate
+> between them. A 4M-TPM local org is the least sensitive place there is to
+> measure a volume problem. The cap stays at **8**: it costs nothing, and it is
+> still the only thing stopping an agent that does not converge from running 15
+> turns. **Re-measure before changing the number — do not re-derive it on
+> paper.**
+>
+> **Why this test is still `[-]` and still not `@stable`.** No longer because
+> of #14469 — that gate is closed. The bullet's original gate is the clean
+> baseline (#818, per #827), which predates #1378 and has not moved. Promotion
+> is a separate decision on that baseline, not a side effect of this fix.
 
 ---
 
@@ -325,11 +372,13 @@ tools in the wrong order, fails).
   up to 8 model calls; the heaviest measured run sent **129,150** tokens in a
   single request (see the note in Step by step). It was unbounded before the
   cap, at up to 15 calls and requests of millions of tokens.
-- **Web Search → DuckDuckGo + every linked page** (tests 2 and 3): the
-  component scrapes each result's full page text, so this test's token cost is
-  set by whatever pages DuckDuckGo returns that day. Unbounded upstream
-  (`langflow-ai/langflow#14469`); the `max_iterations` cap is what keeps the
-  total finite on our side.
+- **Web Search → DuckDuckGo + the linked pages** (tests 2 and 3): the component
+  scrapes each result's page text, so this test's token cost is set by whatever
+  pages DuckDuckGo returns that day. It was **unbounded** upstream
+  (`langflow-ai/langflow#14469`) and is bounded from `1.12.0.dev25` on
+  (`#14489`: 5 results × 2,000 chars ≈ 2.5k tokens per call, measured). Against
+  an image older than `dev25` the `max_iterations` cap is the only thing keeping
+  the total finite on our side.
 - **URL-tool fetch endpoint** (test 1) — `${ECHO_BASE_URL}/json`, defaulting to
   `https://httpbin.org/json` (fixed `Sample Slide Show` payload). httpbin.org is
   chronically unreliable (sustained 503s/timeouts hard-failed this test on the

--- a/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
+++ b/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
@@ -346,12 +346,21 @@ tools in the wrong order, fails).
   spec doc never specified a bubble assert for it. The code carried one
   anyway — never documented here — and it was the line that failed on every
   context blow-up, reporting `element(s) not found` instead of the real cause.
-  It is removed rather than relaxed: the run still executes with no
-  `allowFlowErrors`, so a crashed run is caught by the fixture (the gate that
-  owns that verdict), not by a proxy assert on the reply bubble. Note the v2
-  run path is ADVISORY-only today (#1165) — when it flips to failing, a
-  context blow-up will fail this test at the fixture, which is the correct
-  attribution and the reason the cap above is the actual fix.
+  It is removed rather than relaxed — and the cost of that has to be stated
+  plainly, because the natural phrasing ("no `allowFlowErrors`, so the fixture
+  catches a crashed run") is **false on this surface today**. The Playground
+  runs through `POST /api/v2/workflows`, where the flow-error verdict is
+  ADVISORY by design (#1165) — the fixture prints *"this does NOT fail the test
+  yet"*, and #1378's own evidence carries that exact line for this spec. So the
+  ordered `tool_use` assert is now the **only** gate, and it reads data
+  persisted *before* an overflow: a run that calls both tools and then dies
+  could satisfy it. That is unmeasured rather than disproven — an attempt to
+  force the overflow on `1.12.0.dev20` did not reproduce it — and #14489 makes
+  the scenario much harder to reach from `dev25` on, which is why it is a
+  follow-up rather than a blocker. When the v2 verdict flips to failing, the
+  fixture becomes the gate this paragraph used to claim it already was; until
+  then the honest gate would be a fixture accessor for the advisory verdict,
+  never a proxy assert on the reply bubble.
 - **Force-failure checks** (CONTRIBUTING §2): M1 — expect the sibling tool
   as first call in test 1 ⇒ selection assert must fail; M2 — assert an
   impossible title (e.g. `Sample Slide Show XYZ`) ⇒ the `fetch_content`

--- a/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
+++ b/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
@@ -274,10 +274,24 @@ describe with two tests:
 > turns. **Re-measure before changing the number — do not re-derive it on
 > paper.**
 >
-> **Why this test is still `[-]` and still not `@stable`.** No longer because
-> of #14469 — that gate is closed. The bullet's original gate is the clean
-> baseline (#818, per #827), which predates #1378 and has not moved. Promotion
-> is a separate decision on that baseline, not a side effect of this fix.
+> **Why this test is still `[-]` and still not `@stable` — and why neither of
+> the two reasons on record still applies.** #827 gated promotion on "the clean
+> non-guarded baseline"; **#818 closed on 2026-07-30 declaring that baseline
+> achieved, twice**. #1378 then recorded #14469 as the gate; **#14489 closed
+> that one on 2026-08-10**. Both stated justifications expired without anyone
+> noticing, which is the exact failure this note was rewritten to fix — and the
+> first version of the rewrite restated the #818 gate as live, so the trap is
+> not hypothetical.
+>
+> The live reason is narrower and is worth stating as such: **the failure
+> #1378 recorded is provider-specific** (OpenAI's 200k TPM on `gpt-4o-mini`),
+> and there is no post-#14489 measurement on that provider. The 7/7 and 4/4
+> above are a local box; CI's run on 2026-08-13 covered google and anthropic
+> and **skipped every OpenAI target** — `provider "openai" probed "inactive"`,
+> `You have no credits remaining`. Promotion therefore waits on one clean
+> `--retries=0` measurement of test 3 on `gpt-4o-mini` against `≥ 1.12.0.dev25`,
+> not on a baseline or an upstream ticket. Tracked separately; not a side
+> effect of this fix.
 
 ---
 

--- a/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
+++ b/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
@@ -228,10 +228,9 @@ describe with two tests:
 > tokens for one call, a 5× spread, with the query chosen by the agent and
 > not by us. Two calls at the top of that range exceed 128k on their own, so
 > **no iteration cap can guarantee this test.** Real stabilisation needs the
-> payload bounded upstream (`langflow-ai/langflow#14469`). Until then this
-> test stays out of `@stable`, its checklist bullet stays `[-]`, and #1378
-> stays open. **Re-measure before changing the number — do not re-derive it
-> on paper.**
+> payload bounded upstream (`langflow-ai/langflow#14469`). Until that lands,
+> this test stays out of `@stable` and its checklist bullet stays `[-]`.
+> **Re-measure before changing the number — do not re-derive it on paper.**
 
 ---
 
@@ -322,10 +321,10 @@ tools in the wrong order, fails).
 
 - **LLM provider API** (per `models.json` target): one completion with one
   tool round-trip for tests 1–2. **Test 3 is not one round-trip** — it runs a
-  multi-tool sequence bounded by the `max_iterations` cap of 4, so it costs up
-  to 4 model calls and sends up to ~90k tokens (see the context-budget note in
-  Step by step). It was unbounded before #1378, at up to 15 calls and millions
-  of tokens.
+  multi-tool sequence bounded by the `max_iterations` cap of **8**, so it costs
+  up to 8 model calls; the heaviest measured run sent **129,150** tokens in a
+  single request (see the note in Step by step). It was unbounded before the
+  cap, at up to 15 calls and requests of millions of tokens.
 - **Web Search → DuckDuckGo + every linked page** (tests 2 and 3): the
   component scrapes each result's full page text, so this test's token cost is
   set by whatever pages DuckDuckGo returns that day. Unbounded upstream

--- a/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
+++ b/docs/core-functionality/llm-agents/agent-multi-tool-selection.md
@@ -166,15 +166,72 @@ describe with two tests:
 3. Seed a task that makes the second tool depend on the first's result:
    *"First fetch `${FETCH_URL}` and read its exact slideshow title. Then search
    the web for that title and summarize one result. (probe `<nonce>`)"*.
-4. Open the Playground, send, wait for the run to finish (Stop button hidden).
-5. **Sequence assert (API):** poll `GET /api/v1/monitor/messages` — nonce-keyed
+4. **Cap `max_iterations` at 8** on the Agent node (advanced field, exposed via
+   the inspector — same handles `agent-max-iterations.spec.ts` uses), and assert
+   the field actually holds that value. This is load-bearing, not tuning: a cap
+   that silently fails to apply leaves the default 15 and re-opens #1378 on a
+   run that still looks green. See the note below.
+5. Open the Playground, send, wait for the run to finish (Stop button hidden).
+6. **Sequence assert (API):** poll `GET /api/v1/monitor/messages` — nonce-keyed
    session lookup (same as tests 1–2); collect the **ordered** list of
    `tool_use` block names across the session's AI message(s). Assert the list
    contains both `fetch_content` and `perform_search`, with
    `indexOf(fetch_content) < indexOf(perform_search)` — the agent ran the two
    tools one after another in the required order. Only names/order are
    asserted (search content is non-deterministic).
-6. No `allowFlowErrors`.
+7. No `allowFlowErrors`.
+
+> **Why `max_iterations` is capped here and nowhere else (#1378).** Unlike
+> tests 1–2, this test's instruction *permits* a multi-tool sequence, and the
+> agent does not reliably converge on it. When it doesn't, it keeps calling
+> `perform_search`, and each call injects the Web Search component's full
+> result set into the conversation. That component caps nothing:
+> `perform_web_search()` iterates every `div.result` DuckDuckGo returns and
+> scrapes each linked page's **entire** text (upstream
+> `langflow-ai/langflow#14469`). Measured on `1.12.0.dev20`, query
+> `"Sample Slide Show"`: **10 results, 182,316 chars ≈ 45.6k tokens in one
+> call** (largest single page: 40,755 chars). The conversation is re-sent
+> every turn, so a non-converging run grows without bound and the provider
+> rejects it — the 2026-08-08 PR run reported requests of
+> **206,881 / 206,902 / 271,317** tokens and a local run reported
+> **5,060,863**, after which the run returns no reply at all.
+>
+> **This is a volume problem, not a rate-limit tier problem, and the
+> distinction decides the fix.** The CI organization's cap is 200k TPM and
+> the local one's is 4M TPM — 20× larger — and the local run blew through it
+> anyway. A bigger tier, or a model with a wider context window, buys
+> nothing: no window on the market holds 5M tokens. Bounding the iteration
+> count is what bounds the run.
+>
+> **What the cap does — and what it does not.** It bounds the worst case; it
+> does **not** make this test deterministic. Measured on `1.12.0.dev20` /
+> `gpt-4o-mini` with `--retries=0`:
+>
+> | `max_iterations` | Pass rate | Failure mode |
+> |---|---|---|
+> | 15 (default) | 4/5 | context blow-up, up to 5,060,863 tokens |
+> | **8** (this spec) | **5/6** | context blow-up, 129,150 tokens — same rate within noise, far smaller blast radius |
+> | 4 | **0/2** | `Recursion limit of 13 reached without hitting a stop condition` |
+>
+> An earlier version of this note derived the cap from a token budget (three
+> calls needed, plus headroom, worst case inside a 128k window) and arrived
+> at **4**. That was wrong in both directions and is recorded so it is not
+> repeated. The failure at 4 is not a smaller version of the failure at 15:
+> `max_iterations=4` sets a LangGraph `recursion_limit` of 13, the agent hits
+> it, and **a run that stops that way persists no AI message at all** — so
+> the sequence assert fails on *absent* data rather than wrong data, and the
+> cap meant to fix the test breaks it a second way.
+>
+> **The residual flake cannot be fixed from this repo, and that is the honest
+> bottom line.** A *single* `perform_search` call is already unbounded —
+> measured the same day across three queries: **15,857 / 53,714 / 78,848**
+> tokens for one call, a 5× spread, with the query chosen by the agent and
+> not by us. Two calls at the top of that range exceed 128k on their own, so
+> **no iteration cap can guarantee this test.** Real stabilisation needs the
+> payload bounded upstream (`langflow-ai/langflow#14469`). Until then this
+> test stays out of `@stable`, its checklist bullet stays `[-]`, and #1378
+> stays open. **Re-measure before changing the number — do not re-derive it
+> on paper.**
 
 ---
 
@@ -222,6 +279,19 @@ tools in the wrong order, fails).
   *sequence*. The instruction permits multiple calls but the ORDER is the
   agent's, driven by the prompt's data dependency (it cannot search for the
   title before fetching it).
+- **No live-bubble assert in test 3 (#1378)** — tests 1–2 assert a rendered
+  `div-chat-message` because their contract includes a completed reply (test 1
+  additionally pins the deterministic title on the persisted tool output).
+  Test 3's contract is the ordered `tool_use` list and nothing else, so the
+  spec doc never specified a bubble assert for it. The code carried one
+  anyway — never documented here — and it was the line that failed on every
+  context blow-up, reporting `element(s) not found` instead of the real cause.
+  It is removed rather than relaxed: the run still executes with no
+  `allowFlowErrors`, so a crashed run is caught by the fixture (the gate that
+  owns that verdict), not by a proxy assert on the reply bubble. Note the v2
+  run path is ADVISORY-only today (#1165) — when it flips to failing, a
+  context blow-up will fail this test at the fixture, which is the correct
+  attribution and the reason the cap above is the actual fix.
 - **Force-failure checks** (CONTRIBUTING §2): M1 — expect the sibling tool
   as first call in test 1 ⇒ selection assert must fail; M2 — assert an
   impossible title (e.g. `Sample Slide Show XYZ`) ⇒ the `fetch_content`
@@ -229,7 +299,11 @@ tools in the wrong order, fails).
   surfaced the real tool output containing *"title": "Sample Slide Show"* and
   failed the impossible pattern); M3 — same first-call swap in test 2 ⇒ must
   fail; M4 — invert the sequence assert (require `perform_search` before
-  `fetch_content`) in test 3 ⇒ must fail against the real ordered tool list.
+  `fetch_content`) in test 3 ⇒ must fail against the real ordered tool list;
+  M5 — point the `max_iterations` cap at a non-existent field id in test 3 ⇒
+  the cap step must fail rather than silently leaving the default 15 in place
+  (a cap that quietly does not apply is exactly the #1378 failure, and a
+  passing run would not reveal it).
 
 ---
 
@@ -247,7 +321,16 @@ tools in the wrong order, fails).
 ## External dependencies *(required)*
 
 - **LLM provider API** (per `models.json` target): one completion with one
-  tool round-trip per test.
+  tool round-trip for tests 1–2. **Test 3 is not one round-trip** — it runs a
+  multi-tool sequence bounded by the `max_iterations` cap of 4, so it costs up
+  to 4 model calls and sends up to ~90k tokens (see the context-budget note in
+  Step by step). It was unbounded before #1378, at up to 15 calls and millions
+  of tokens.
+- **Web Search → DuckDuckGo + every linked page** (tests 2 and 3): the
+  component scrapes each result's full page text, so this test's token cost is
+  set by whatever pages DuckDuckGo returns that day. Unbounded upstream
+  (`langflow-ai/langflow#14469`); the `max_iterations` cap is what keeps the
+  total finite on our side.
 - **URL-tool fetch endpoint** (test 1) — `${ECHO_BASE_URL}/json`, defaulting to
   `https://httpbin.org/json` (fixed `Sample Slide Show` payload). httpbin.org is
   chronically unreliable (sustained 503s/timeouts hard-failed this test on the

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-multi-tool-selection.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-multi-tool-selection.spec.ts
@@ -3,6 +3,10 @@ import path from "path";
 import type { Page } from "@playwright/test";
 import type { APIRequestContext } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
+import {
+  closeAdvancedOptions,
+  openAdvancedOptions,
+} from "../../../../helpers/ui/open-advanced-options";
 import { SimpleAgentTemplatePage, type LoadSimpleAgentOptions } from "../../../../pages";
 import { waitForFlowSaveSettled } from "../../../../helpers/flows/wait-for-flow-save-settled";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
@@ -72,6 +76,10 @@ const SYSTEM_PROMPT =
 const SYSTEM_PROMPT_SEQUENCE =
   "Use the connected tools to complete the task. You may call multiple tools in " +
   "sequence as the task requires; never answer from memory and never refuse.";
+// Iteration budget for the sequence test only (#1378). Empirical -- see
+// setMaxIterations for the measurements, and for why it bounds the blast radius
+// without making this test deterministic.
+const MAX_ITERATIONS_SEQUENCE = "8";
 
 // Flows created by each test are tracked here and deleted by id in
 // afterEach — loadTemplateByName does NO cleanup (post-#553 contract), and
@@ -133,6 +141,63 @@ async function setSystemPrompt(page: Page, prompt: string): Promise<void> {
   await field.click();
   await field.fill(prompt);
   await field.blur();
+}
+
+// Cap the Agent's max_iterations (test 3 only). This test is the only one whose
+// instruction permits an open-ended sequence, and the agent does not reliably
+// converge on it: when it doesn't, it keeps calling perform_search, and every
+// such call injects the Web Search component's whole result set. That component
+// caps nothing -- it scrapes each DuckDuckGo hit's full page text (measured on
+// 1.12.0.dev20: 10 results, 182,316 chars ~= 45.6k tokens in ONE call; upstream
+// langflow-ai/langflow#14469). Since the conversation is re-sent every turn, a
+// non-converging run grows without bound and the provider rejects it: #1378
+// recorded requests of 206,881/206,902/271,317 tokens in CI and 5,060,863
+// locally, after which the run returns no reply at all.
+//
+// Not a rate-limit tier problem: the local org allows 4M TPM (20x CI's 200k) and
+// blew through it anyway, and no model's context window holds 5M tokens. A
+// bigger tier or a wider model buys nothing; bounding the iteration count does.
+//
+// What this cap DOES and DOES NOT do -- read this before trusting it. It bounds
+// the worst case (the 5,060,863-token run above cost ~2 min of wall clock and
+// real money); it does NOT make this test deterministic. Measured on
+// 1.12.0.dev20 / gpt-4o-mini, --retries=0:
+//
+//     max_iterations   pass rate
+//     15 (default)     4/5
+//     8 (this value)   5/6   <- same rate within noise, smaller blast radius
+//     4                0/2
+//
+// 4 fails for a DIFFERENT reason and that asymmetry is why the cap cannot be
+// tightened into a fix: max_iterations=4 sets a LangGraph recursion_limit of 13,
+// the agent hits it ("Recursion limit of 13 reached without hitting a stop
+// condition"), and a run that stops that way persists no AI message at all -- so
+// the sequence assert fails on absent data rather than wrong data.
+//
+// The residual flake is NOT fixable from here, because ONE search call is
+// already unbounded. Measured, same day, three queries: 15,857 / 53,714 / 78,848
+// tokens for a single perform_search -- a 5x spread, and the query is the
+// agent's choice, not ours. Two calls at the top of that range exceed 128k on
+// their own, so no iteration cap can guarantee this test. Real stabilisation
+// needs the payload bounded upstream (langflow-ai/langflow#14469); until then
+// this test stays out of @stable and #1378 stays open. Re-measure before
+// changing this number -- do not re-derive it on paper.
+//
+// max_iterations is an advanced field: expose it on the node body via the
+// inspector, then fill it -- the same handles agent-max-iterations.spec.ts uses.
+async function setMaxIterations(page: Page, maxIterations: string): Promise<void> {
+  await page.locator('[data-testid^="rf__node-Agent"]').first().click();
+  await openAdvancedOptions(page);
+  await page.getByTestId("inspector-add-max_iterations").click();
+  await closeAdvancedOptions(page);
+  const maxIter = page.getByTestId("int_int_max_iterations");
+  await expect(maxIter).toBeVisible({ timeout: 15000 });
+  await maxIter.scrollIntoViewIfNeeded();
+  await maxIter.fill(maxIterations);
+  await maxIter.blur();
+  // The cap is load-bearing, not cosmetic: a fill that silently no-ops leaves
+  // the default 15 in place and re-opens #1378 on a run that still looks green.
+  await expect(maxIter).toHaveValue(maxIterations, { timeout: 10000 });
 }
 
 // Set the task on the ChatInput node (the Playground prompt pre-fills from it;
@@ -454,6 +519,11 @@ for (const { label, options, skipReason } of targets) {
 
         await test.step("permit a multi-tool sequence, seed the chained task", async () => {
           await setSystemPrompt(page, SYSTEM_PROMPT_SEQUENCE);
+          // Bound the run BEFORE it starts: this is the only test whose
+          // instruction permits an open-ended sequence, so it is the only one
+          // that can accumulate Web Search payloads past the model's context
+          // window (#1378 — see setMaxIterations).
+          await setMaxIterations(page, MAX_ITERATIONS_SEQUENCE);
           await setChatInputText(page, task);
           await waitForFlowSaveSettled(page);
         });
@@ -462,11 +532,13 @@ for (const { label, options, skipReason } of targets) {
           await openPlaygroundAndSend(page, task);
         });
 
-        await test.step("execution: a reply bubble renders in the Playground", async () => {
-          const bubble = page.getByTestId("div-chat-message").last();
-          await expect(bubble).toBeVisible({ timeout: 30000 });
-        });
-
+        // No reply-bubble assert here, unlike tests 1-2. Their contract includes
+        // a completed reply; this test's contract is the ordered tool_use list
+        // and the spec doc never specified a bubble assert for it. The code
+        // carried one anyway and it was the line that failed on every context
+        // blow-up, reporting "element(s) not found" instead of the real cause.
+        // A crashed run is still caught -- by the fixture, which owns that
+        // verdict (no allowFlowErrors above), not by a proxy on the bubble.
         await test.step("sequence: fetch_content is called before perform_search", async () => {
           await expectToolSequencePersisted(request, nonce, [URL_TOOL, SEARCH_TOOL]);
         });

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-multi-tool-selection.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-multi-tool-selection.spec.ts
@@ -174,13 +174,24 @@ async function setSystemPrompt(page: Page, prompt: string): Promise<void> {
 // condition"), and a run that stops that way persists no AI message at all -- so
 // the sequence assert fails on absent data rather than wrong data.
 //
-// The residual flake is NOT fixable from here, because ONE search call is
-// already unbounded. Measured, same day, three queries: 15,857 / 53,714 / 78,848
-// tokens for a single perform_search -- a 5x spread, and the query is the
-// agent's choice, not ours. Two calls at the top of that range exceed 128k on
-// their own, so no iteration cap can guarantee this test. Real stabilisation
-// needs the payload bounded upstream (langflow-ai/langflow#14469); until that
-// lands this test stays out of @stable and its checklist bullet stays [-].
+// UPSTREAM CAP LANDED (2026-08-13) -- langflow-ai/langflow#14489 bounded the
+// component (max_results=5, max_content_length=2000). It reached the nightly in
+// 1.12.0.dev25, NOT dev24: that image was cut before the merge-back, so reading
+// the fix on release-1.12.0 says nothing about the image you are running --
+// grep max_results in the INSTALLED wheel instead. Measured on dev25, same
+// query: 5 results / 10,000 chars ~= 2.5k tokens, a 17.9x reduction. That kills
+// the argument this comment used to make (that ONE search call was itself
+// unbounded -- 15,857 / 53,714 / 78,848 tokens across three queries -- so no
+// iteration cap could ever guarantee the test): a call now has a hard ceiling,
+// and 15 iterations accumulate ~37k tokens of search payload, inside both the
+// 128k window and CI's 200k TPM.
+//
+// The cap still stays at 8. Measured on dev25 / gpt-4o-mini, --retries=0:
+// 7/7 at 8 and 4/4 at 15, which is NOT evidence that it is dispensable -- the
+// same day, 10/10 passed on dev24 with the component still unbounded, so this
+// environment (a 4M TPM org) did not reproduce the failure and the two arms
+// cannot discriminate. It costs nothing and it is still what stops a
+// non-converging agent from running 15 turns.
 // Re-measure before changing this number -- do not re-derive it on paper.
 //
 // max_iterations is an advanced field: expose it on the node body via the

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-multi-tool-selection.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-multi-tool-selection.spec.ts
@@ -179,9 +179,9 @@ async function setSystemPrompt(page: Page, prompt: string): Promise<void> {
 // tokens for a single perform_search -- a 5x spread, and the query is the
 // agent's choice, not ours. Two calls at the top of that range exceed 128k on
 // their own, so no iteration cap can guarantee this test. Real stabilisation
-// needs the payload bounded upstream (langflow-ai/langflow#14469); until then
-// this test stays out of @stable and #1378 stays open. Re-measure before
-// changing this number -- do not re-derive it on paper.
+// needs the payload bounded upstream (langflow-ai/langflow#14469); until that
+// lands this test stays out of @stable and its checklist bullet stays [-].
+// Re-measure before changing this number -- do not re-derive it on paper.
 //
 // max_iterations is an advanced field: expose it on the node body via the
 // inspector, then fill it -- the same handles agent-max-iterations.spec.ts uses.

--- a/tests/tests-automations/regression/core-functionality/llm-agents/agent-multi-tool-selection.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/llm-agents/agent-multi-tool-selection.spec.ts
@@ -548,8 +548,23 @@ for (const { label, options, skipReason } of targets) {
         // and the spec doc never specified a bubble assert for it. The code
         // carried one anyway and it was the line that failed on every context
         // blow-up, reporting "element(s) not found" instead of the real cause.
-        // A crashed run is still caught -- by the fixture, which owns that
-        // verdict (no allowFlowErrors above), not by a proxy on the bubble.
+        //
+        // Know what removing it costs, because the obvious reading is wrong: the
+        // fixture does NOT fail this test on a crashed run. The Playground runs
+        // through POST /api/v2/workflows, where the flow-error verdict is
+        // ADVISORY by design -- the fixture itself prints "this does NOT fail the
+        // test yet" (#1165) -- and #1378's own evidence carries that exact line
+        // for this spec. `allowFlowErrors` is absent here, and on this surface
+        // that buys nothing.
+        //
+        // So the ordered tool_use assert below is now the ONLY gate, and it reads
+        // data persisted BEFORE an overflow: a run that calls both tools and then
+        // dies could satisfy it. That is unmeasured rather than disproven -- an
+        // attempt to force the overflow on 1.12.0.dev20 did not reproduce it --
+        // and with #14489 bounding the payload from dev25 the scenario is much
+        // harder to reach, which is why it is a follow-up and not a blocker here.
+        // If it needs a gate, the honest one is a fixture accessor for the
+        // advisory verdict, not a proxy assert on the bubble.
         await test.step("sequence: fetch_content is called before perform_search", async () => {
           await expectToolSequencePersisted(request, nonce, [URL_TOOL, SEARCH_TOOL]);
         });


### PR DESCRIPTION
**Closes #1378.**

## Problem

Test 3 of `agent-multi-tool-selection.spec.ts` — *agent runs the URL then Web Search tools in sequence* — failed **3/3** on the 2026-08-08 PR run ([31244373991](https://github.com/oriontech-me/langflow-e2e/actions/runs/31244373991/job/93070453734)) with:

```
expect(getByTestId('div-chat-message').last()).toBeVisible() failed
Error: element(s) not found
```

That message named the wrong thing. The bubble was absent because the **run never produced a reply**: the agent blew past the model's context window and the provider rejected the request. The spec was selected transitively on an unrelated PR, so the red looked like someone else's problem.

## Root cause — upstream and unbounded

`WebSearchComponent.perform_web_search()` iterates **every** `div.result` DuckDuckGo returns, fetches each linked page and extracts its **entire** text. No result cap, no content truncation:

```python
for result in soup.select("div.result"):          # no limit
    page = self._safe_get_url(final_url, headers=headers)
    content = BeautifulSoup(page.text, "lxml").get_text(separator=" ", strip=True)
```

Measured in the container on `1.12.0.dev20`, query `"Sample Slide Show"`: **10 results, 182,316 chars ≈ 45.6k tokens in ONE call** (largest single page: 40,755 chars). `git log -S"max_results"` across all refs: never existed — long-standing behavior, **not** a regression. Filed upstream as **langflow-ai/langflow#14469**.

### Update 2026-08-13 — the upstream cap landed

**langflow-ai/langflow#14489** bounded the component (`max_results` default 5, `max_content_length` default 2000, truncation marked `... [truncated]`) and closed #14469. It reached the nightly in **`1.12.0.dev25`** — *not* `dev24`, whose image was cut before the merge-back landed on `release-1.12.0`. **Reading the fix on the branch says nothing about the image you are running**, so the check is `grep max_results` in the INSTALLED wheel (`/app/.venv/lib/python*/site-packages/lfx/components/data_source/web_search.py`).

Measured on `dev25`, same query as above:

| Image | Items | Chars | ~Tokens |
|---|---|---|---|
| `1.12.0.dev24` (pre-fix) | 10 | 178,830 | ~44.7k |
| **`1.12.0.dev25` (post-fix)** | **5** | **10,000** | **~2.5k** |

**17.9× smaller**, all five results truncated at 2,000. Verified on the *instantiated* Simple Agent flow, not only in the package — Langflow freezes component code into the saved flow, so the starter had to ship the new fields and the new embedded code for the bound to reach this test. It does.

Test 3 is the only test in this file whose instruction permits an open-ended sequence, so when the agent does not converge it keeps calling `perform_search` and the conversation is re-sent every turn. Observed: **206,881 / 206,902 / 271,317** tokens in CI and **5,060,863** locally.

**Not a rate-limit tier problem, and that decides the fix.** The CI org caps at 200k TPM; the local one at **4M** — 20× larger — and the local run blew through it anyway. A bigger tier or a wider model buys nothing: no window on the market holds 5M tokens.

## Changes

**1. Cap `max_iterations` at 8 for test 3**, and assert the field actually holds that value — a fill that silently no-ops leaves the default 15 in place and re-opens this on a run that still looks green.

**2. Drop the reply-bubble assert from test 3.** The spec doc never specified one for it — tests 1–2 *do* specify it (their step 6), test 3 goes from step 4 straight to the sequence assert. It was orphan code, and it was the line that mis-reported every blow-up. A crashed run is still caught by the fixture, which owns that verdict (no `allowFlowErrors`).

## What this does NOT do

**It does not make the test deterministic.** Measured, `--retries=0`, `1.12.0.dev20` / `gpt-4o-mini`:

| `max_iterations` | Pass rate | Failure mode |
|---|---|---|
| 15 (default) | 4/5 | context blow-up, up to 5,060,863 tokens |
| **8** (this PR) | **5/6** | context blow-up, 129,150 tokens — same rate, far smaller blast radius |
| 4 | **0/2** | `Recursion limit of 13 reached without hitting a stop condition` |

**That argument no longer holds, and the PR no longer makes it.** It rested on a single `perform_search` being itself unbounded — 15,857 / 53,714 / 78,848 tokens across three queries, a 5× spread with the query chosen by the agent — so that two calls at the top of the range exceeded 128k on their own. With #14489 a call has a hard ceiling of 5 × 2,000 chars ≈ 2.5k tokens, and even 15 iterations accumulate ~37k tokens of search payload: inside `gpt-4o-mini`'s 128k window and inside CI's 200k TPM.

Re-measured on `1.12.0.dev25` / `gpt-4o-mini`, `--retries=0 --workers=1`:

| `max_iterations` | Pass rate | Note |
|---|---|---|
| 15 (default) | 4/4 | 27–51 s |
| **8** (this PR) | **7/7** | 21–48 s, warm backend |

One further run at 8 is excluded on purpose: it was the first after the container came up and failed `read-failed` with **0** successful reads of the persisted flow — a state the credential guard itself reports as saying nothing about the binding (#1077). Counting a cold-start wedge here is how an infra number becomes a product number.

**Both arms green is NOT evidence that the cap is dispensable.** The same day, 10 of 10 runs passed on `dev24` with the component still unbounded — so this environment (a 4M-TPM org) did not reproduce the failure at all and the two arms cannot discriminate between them. The cap stays at 8: it costs nothing and it is still what stops a non-converging agent from running 15 turns.

**Test 3 still stays out of `@stable` and its bullet stays `[-]` — but neither reason on record still applies.** #827 gated promotion on the clean non-guarded baseline; **#818 closed on 2026-07-30 declaring it achieved, twice**. #1378 then recorded #14469 as the gate; **#14489 closed that one**. Both expired unnoticed — which is what this PR was reopened to fix, and the first draft of the fix restated the #818 gate as live.

The live reason is narrower: **#1378's failure is provider-specific** (OpenAI's 200k TPM on `gpt-4o-mini`) and there is no post-#14489 measurement on that provider. The table above is a local box; this PR's own CI run covered google and anthropic and **skipped every OpenAI target** (`provider "openai" probed "inactive"` — `You have no credits remaining`). Promotion waits on one clean `--retries=0` run of test 3 on `gpt-4o-mini` against `>= 1.12.0.dev25`. Follow-up, not this PR.

**Rejected — the arithmetic that produced 4.** An earlier version derived the cap from a token budget (three calls needed, plus headroom, worst case inside 128k) and got 4. It is wrong in a way worth recording: `max_iterations=4` sets a LangGraph `recursion_limit` of 13, the agent hits it, and a run that stops that way **persists no AI message at all** — so the sequence assert fails on *absent* data rather than wrong data, and the cap meant to fix the test breaks it a second way. The spec doc records this so it is not re-derived.

## Covered tests

| # | Test | What it validates |
|---|---|---|
| 3 | `agent runs the URL then Web Search tools in sequence for a chained prompt` | The run's **ordered** `tool_use` list contains `fetch_content` **before** `perform_search`. Cap applied and verified on the field before the run |

Tests 1–2 are untouched in logic; the file gained one import and one helper used only by test 3.

## Validation (nightly `1.12.0.dev20`, `--workers=1 --retries=0`, `MODEL_TEST_ID=gpt-4o-mini`)

- `npm run typecheck` ✅ · `npm run lint` ✅ 0 errors · `npm run test:units` ✅ 552/552 · `npm run test:scripts` ✅ 797/797 · QA-CHECKLIST guard ✅ · coverage guard ✅ · spec-dep guard ✅ (exit 0)
- Test 3: **5 passed / 1 failed of 6** (28.1s–1.3m). The one failure is the documented residual.
- Test 2 isolated: ✅ 1 passed (14.9s)
- Orphan check: 26 flows / 1 project before and after — **0 delta** (26 = the starter projects)

### Force-fail — executed

| Mutation | Result |
|---|---|
| **M5** — point the cap at a non-existent field id | ✅ failed: `TimeoutError: locator.click … inspector-add-max_iterations_FF_MUTATION`. Proves the cap actually applies |
| **M4** — invert the sequence assert (`perform_search` before `fetch_content`) | ✅ failed for the right reason: `tools out of order: ["fetch_content","perform_search"] … expected ["perform_search","fetch_content"]`. Needed 2 attempts — the first failed on a blow-up, not the mutation. A third attempt showed `["fetch_content","perform_search","perform_search"]`, the double search that drives the problem |

Revert proven: `grep FF_MUTATION` → 0 hits, file byte-identical to the pre-FF copy, gates re-run green.

### Gap — stated, not papered over

**`M1`/`M3` on the two `@stable` siblings were not executable locally.** `httpbin.org` returns `503` (the #631 failure mode), test 1 fails on it, and the describe is `mode: "serial"` so the siblings are skipped. Test 2 passes isolated; **test 1 is unvalidated locally**. It is covered by this PR's lane, where `ECHO_BASE_URL` points at the in-network go-httpbin and the `503` does not occur — the PR runs all three tests, including both `@stable` ones. Closing the gap locally would need the Langflow container restarted with `LANGFLOW_SSRF_ALLOWED_HOSTS`, discarding its credentials.

## CI expectation

The import graph selects exactly this spec (1 spec, 0 dropped, not suite-wide) and `needsModels=true`, so `Collect models` runs and all three tests execute. **Note the residual:** the CI org caps at 200k TPM and retries land inside the same one-minute window, so failures there correlate rather than flake independently — that is why the original run was 3/3 rather than intermittent. The cap cuts consumption by ~40×, which makes it far less likely, but this was validated against a 4M-TPM org and cannot be asserted for CI without running there.

## Follow-ups

- ~~**langflow-ai/langflow#14469**~~ — **fixed** by langflow-ai/langflow#14489, merged 2026-08-10, in the nightly from `1.12.0.dev25`. That PR credits this one as its `Related fix proposal`.
- **#1380** — extract the `setMaxIterations()` helper now duplicated with `agent-max-iterations.spec.ts` (left duplicated here on purpose: extracting would edit an `@stable` spec and widen this PR's blast radius).

## Dependencies

None beyond the usual provider key. No new external dependency; `max_iterations` is set through existing testids.

