### PR TITLE
test(memory): cover the Memories panel and Create Memory modal (#1398)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -937,16 +937,16 @@
 
 #### 20.1 Memories Panel
 
-- [ ] The Memories panel opens from the flow editor (`sidebar-nav-memories`) and shows its empty state (`No memory selected`) rather than a blank panel
-- [ ] The panel offers registration (`Create`) and a memory search field
+- [x] The Memories panel opens from the flow editor (`sidebar-nav-memories`) and shows its empty state rather than a blank panel — asserted by element id (`#no-memory-selected-title` / `#no-memory-selected-description`), not by the i18n text, which moves under a locale change (§18) → `core-functionality/memory/memory-base-panel.spec.ts`
+- [x] The panel offers registration (`Create`, asserted **enabled** — it renders disabled without a `currentFlowId`) and a `Search memories...` field; neither carries a `data-testid`, so both resolve by role/placeholder → `core-functionality/memory/memory-base-panel.spec.ts`
 
 #### 20.2 Create Memory Modal
 
-- [ ] The modal is **scoped to the flow** — it titles `Create a memory for "<flow name>"`, proving a memory base belongs to a flow rather than being global
-- [ ] It exposes its five controls: Name (`#memory-name`), Embedding Model (`memory-embedding-model`), Vector Database (`memory-db-provider`), Batch Size (`#memory-batch-size`) and the LLM Preprocessing toggle
-- [ ] Vector Database defaults to `Chroma Local` (bundled, so no external vector service is needed) and Embedding Model has **no** default
-- [ ] `Create Memory` is disabled with an empty form **and stays disabled with only the Name filled** — the gate, not just the initial render
-- [ ] Cancelling closes the modal and creates nothing, asserted against `GET /api/v1/knowledge_bases` rather than against the UI alone
+- [x] The modal is **scoped to the flow**, proving a memory base belongs to a flow rather than being global — heading `Create Memory` plus the **description** `Create a memory for "<flow name>"` (measured: the flow-scoped string is the description, not the title, and `Create Memory` is also the submit label) naming the exact flow the test created → `core-functionality/memory/memory-base-panel.spec.ts`
+- [x] It exposes its five controls: Name (`#memory-name`), Embedding Model (`#memory-embedding-model`), Vector Database (`#memory-db-provider`), Batch Size (`#memory-batch-size`) and the LLM Preprocessing toggle (`#llm-preprocessing-switch`), with the preprocessing branch's two extra required fields absent while the toggle is off → `core-functionality/memory/memory-base-panel.spec.ts`
+- [x] Vector Database defaults to `Chroma Local` (bundled, so no external vector service is needed) and Batch Size to `1`; Embedding Model has **no** default — two mutually exclusive tests decided by an API probe (`GET /api/v1/models` → a provider that is `is_configured` **and** `is_enabled` **and** exposes a `metadata.model_type=embeddings` model): with one, the control renders unset and no `Provider:` line shows; with none, the required label renders with **no control** under it. **Product gap recorded, not filed:** that picker is the shared model widget rendered without `showEmptyState`, so a memory base cannot be created and nothing says why, while the Knowledge Base modal passes `showEmptyState: true` and renders `No Models Enabled` + `Manage Model Providers` → `core-functionality/memory/memory-base-panel.spec.ts`
+- [x] `Create Memory` is disabled with an empty form **and stays disabled with only the Name filled** — the gate, not just the initial render (the required Embedding Model is what holds it, since Vector Database and Batch Size carry defaults) → `core-functionality/memory/memory-base-panel.spec.ts`
+- [x] Cancelling closes the modal and creates nothing, asserted against the API rather than against the UI alone — **`GET /api/v1/memories?flow_id=<id>` → `total: 0`**, which is the endpoint the panel actually lists from (measured: opening it fires exactly that one request); `GET /api/v1/knowledge_bases` is a different resource this surface never calls, kept only as a secondary check that the flow's name is absent → `core-functionality/memory/memory-base-panel.spec.ts`
 
 #### 20.3 Registration End-to-End (item 1 of 2)
 

--- a/docs/core-functionality/memory/memory-base-panel.md
+++ b/docs/core-functionality/memory/memory-base-panel.md
@@ -1,0 +1,217 @@
+# Memory Base — Memories panel and Create Memory modal
+
+**Last validated:** Langflow 1.12.x
+
+---
+
+## What this test validates *(required)*
+
+The read-only surface of the flow editor's **Memories** panel and the shape of
+its **Create Memory** modal — the entry point to a memory base. Nothing here
+creates a memory base (that is `memory-base-registration.spec.ts`, issue #1399);
+this spec pins the panel, the modal's controls, its defaults and its submit
+gate, so a rename or a dropped field is caught before the registration spec
+fails on it for the wrong reason.
+
+1. **should open the Memories panel with its empty state, Create action and
+   search field** — clicking `sidebar-nav-memories` in the flow editor renders
+   the panel with the `No memory selected` empty state (`#no-memory-selected-title`
+   / `#no-memory-selected-description`), a `Create` button and the
+   `Search memories...` input — not a blank panel.
+2. **should scope the Create Memory modal to the current flow** — the modal's
+   title reads `Create Memory` and its description reads
+   `Create a memory for "<flow name>"`, naming the flow the spec created.
+3. **should expose the five Create Memory controls** — Name (`#memory-name`),
+   Embedding Model (`#memory-embedding-model`), Vector Database
+   (`#memory-db-provider`), Batch Size (`#memory-batch-size`) and the LLM
+   Preprocessing toggle (`#llm-preprocessing-switch`) all render.
+4. **should default Vector Database to Chroma Local and Batch Size to 1** — both
+   shipped defaults, on an instance with nothing configured under DB Providers.
+5. **should show Embedding Model carrying no default model when a provider
+   offers embeddings** — the control renders reading its unset placeholder and
+   the modal shows no `Provider:` line. Skips, naming the state, when no
+   configured provider exposes an embeddings model.
+6. **should show the Embedding Model control absent when no provider offers
+   embeddings** — the required label renders with **no control** under it
+   (`#memory-embedding-model` and `value-dropdown-memory-embedding-model` both
+   absent) and nothing defaulted in its place. Skips when a provider does offer
+   embeddings. See Notes — this is a product gap, asserted rather than skipped
+   past.
+7. **should keep Create Memory disabled with an empty form and with only the
+   Name filled** — the submit button is disabled on open **and stays disabled**
+   after Name is filled, which is the gate (a required Embedding Model), not the
+   initial render.
+8. **should create no memory base when the Create Memory modal is cancelled** —
+   after `Cancel` the modal is gone and `GET /api/v1/memories?flow_id=<id>`
+   still answers `total: 0`, asserted against the API, not the panel alone.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@release` `@workspace` `@ui-ux`
+
+`@stable` from the first PR, on the same grounds as the `a2a` specs: every
+assertion is LLM-free and provider-free (no embedding model is ever selected),
+each test creates and deletes its own flow id-scoped, and the pipeline's
+VALIDATE burst runs the file three times at `--retries=0 --workers=1`.
+
+No new functional tag is introduced — `@workspace` covers the flow-editor
+panel and `@ui-ux` its modal chrome. The area is identified by its path
+(`core-functionality/memory/`), as the `knowledge-ingestion-management` specs
+are.
+
+---
+
+## Validation criterion *(required)*
+
+- **The panel's empty state is asserted by id, not by text** —
+  `#no-memory-selected-title` and `#no-memory-selected-description` are real
+  element ids in 1.12.0.dev19; the visible strings come from the
+  `memory.noMemorySelected*` i18n keys and would move under a locale change
+  (#1400). The `Create` button and the search input carry **no** `data-testid`
+  at all (measured), so they resolve by role/name and by placeholder.
+- **The flow-scoping assertion names the flow the test created**, not a
+  substring of the label: the modal's description is
+  `Create a memory for "<flow name>"` with the exact name passed to
+  `POST /api/v1/flows/`. A test asserting only the literal prefix would pass
+  against any flow and prove nothing about scoping.
+- **The Embedding Model default is covered by two mutually exclusive tests, one
+  per environment state, decided by an API probe before the browser opens** —
+  `GET /api/v1/models`, looking for a provider that is `is_configured` **and**
+  `is_enabled` **and** carries a model whose `metadata.model_type` is
+  `embeddings`. Written as two tests rather than one branching test so neither
+  state is silently accepted: whichever the instance is in, one test asserts
+  something falsifiable and the other's skip reason names why it stood down. The
+  probe is deliberately **not** a `count() === 0` check on the control itself —
+  that would read a genuine regression removing the control as "no provider
+  configured", which is exactly the false negative this spec exists to prevent.
+  In the configured state the trigger must match neither a model id nor a
+  `Provider:` line; the pair is what makes "unset" falsifiable, since the
+  `Provider:` line renders only once a model is chosen.
+- **The Vector Database default is the opposite case and is asserted
+  literally**: `Chroma Local`, which the frontend ships as `defaultEnabled` with
+  no config fields, so it holds on any instance. Batch Size likewise reads `1`.
+- **The disabled gate is asserted in two states, not one** — empty form and
+  Name-only. Only the second distinguishes a real required-field gate from a
+  button that is simply disabled until first input.
+- **"Cancel creates nothing" is asserted against
+  `GET /api/v1/memories?flow_id=<id>`** — `total: 0` for the flow the test owns.
+  This is the endpoint the panel itself lists from (measured: opening the panel
+  fires exactly one request, `GET /api/v1/memories?flow_id=…&page=1&size=50`).
+  `GET /api/v1/knowledge_bases` — named in issue #1398 — is a **different
+  resource** (`kb_name`, `/ingest`, `/chunks`) and is never touched by this
+  surface, so asserting it empty would be vacuous. It is asserted as a
+  secondary, flow-independent check only.
+
+---
+
+## External dependencies *(required)*
+
+- A running Langflow instance with the flow editor reachable — **no provider key
+  and no LLM call**. Every test runs on an instance with zero providers
+  configured; the provider state only decides **which** of the two Embedding
+  Model tests runs (see Validation criterion), never whether the file has
+  coverage.
+- `GET /api/v1/models` for that probe: it reports `is_configured` / `is_enabled`
+  per provider plus each model's `metadata.model_type`, and needs no inference
+  call, so a configured-but-drained key still reads as configured (which is the
+  correct answer here — the picker lists models without calling the provider).
+- `POST /api/v1/flows/` (flow creation), `DELETE /api/v1/flows/{id}` (cleanup)
+  and `GET /api/v1/memories?flow_id=<id>` (the panel's own list).
+  `/api/v1/memories` is **absent from `/openapi.json`** on 1.12.0.dev19 (it
+  answers `403` unauthenticated, `200` with the session) — do not conclude from
+  the schema that the route does not exist.
+- The `Memories` nav item requires a flow to be open: the panel's `Create`
+  button is disabled without a `currentFlowId`.
+
+---
+
+## Cleanup *(required)*
+
+Each test creates its own flow through `POST /api/v1/flows/` and deletes it
+id-scoped in `afterEach` (`deleteFlow`), leaving the editor first via
+`unmountEditorForCleanup` so the deleted flow's editor poll cannot 404 into the
+fixture's HTTP log. No memory base is ever created, so there is nothing else to
+remove — the cancel test asserts exactly that. Never name-based, never
+delete-all (#553/#520).
+
+---
+
+## What this test does not cover *(optional)*
+
+- Actually registering a memory base (completing the form) — issue #1399,
+  `memory-base-registration.spec.ts`; it needs a provider exposing an
+  **embedding** model and must skip loudly without one.
+- The LLM Preprocessing branch's extra fields (`#memory-preprocessing-model`,
+  `#preprocessing-prompt`), which only render with the toggle on.
+- Memory detail views, message/session tables, auto-capture, refresh and
+  delete of an existing memory base.
+- Non-`chroma` vector databases (Chroma Cloud, OpenSearch, Postgres pgvector),
+  which require DB Providers configuration.
+- The Agent's conversation memory (§6.3) — a different surface that shares the
+  word "memory".
+
+---
+
+## Notes *(optional)*
+
+- **Where the selectors come from.** Every selector here was harvested twice
+  rather than copied from the sibling doc: from the shipped frontend bundle
+  inside the running container (`langflow/frontend/assets/index-*.js`) and then
+  confirmed live against a running nightly with a throwaway scout. That is what
+  produced the endpoint correction below.
+- **This doc disagrees with `memory-base-registration.md` on one point, and this
+  one is the measured side.** That doc (the §20 audit, and the reference issue
+  #1398 names) states the surface is asserted against
+  `GET /api/v1/knowledge_bases`. The panel lists from
+  `GET /api/v1/memories?flow_id=<id>` — opening it fires exactly that one request
+  and no `knowledge_bases` call at all — and the modal submits to
+  `POST /api/v1/memories/`. A memory base may well be backed by a knowledge base
+  underneath, which is presumably where that reading came from, but the
+  account-wide `knowledge_bases` list is not the flow-scoped observable a
+  "created nothing" assertion needs. Whether registration also writes a
+  `knowledge_bases` row is #1399's measurement to make, on the endpoint it
+  actually observes.
+- **Three corrections to the issue's wording**, each verified live:
+  (a) `Create a memory for "<flow name>"` is the modal's **description**; its
+  **title** is `Create Memory` (which is also the submit button's label — assert
+  the two by role, not by text alone);
+  (b) the panel lists from `/api/v1/memories`, not `/api/v1/knowledge_bases`
+  (see Validation criterion);
+  (c) Batch Size also has a default (`1`), so "Vector Database defaults, Embedding
+  Model does not" is not the whole picture — Embedding Model is the only unset
+  required control.
+- **Product gap found while validating this spec — the Create Memory modal has
+  no empty state for its required Embedding Model, and the Knowledge Base modal
+  does.** The picker is the shared model widget, rendered **without**
+  `showEmptyState` (which defaults to `false`), so on an instance where no
+  configured, enabled provider exposes an `embeddings` model the control is
+  **absent from the DOM entirely** — while the label `Embedding Model` and its
+  required `*` still render, the placeholder text `Select embedding model` shows
+  as dead text, and `Create Memory` stays disabled forever with nothing
+  explaining why. Registering a memory base is therefore a dead end with no
+  message, no link and no affordance. The sibling Knowledge Base modal passes
+  `showEmptyState: true` on the same widget (`#kb-embedding-model`) and renders
+  `No Models Enabled` plus `Manage Model Providers`, which is the working
+  behaviour this one is missing. Measured on `1.12.0.dev22` with every provider
+  `is_configured: false`, and again with `OPENAI_API_KEY` configured (3
+  embeddings models), where the control appears reading `Select a model`. Both
+  states are asserted — see tests 5 and 6 — so if upstream adds the empty state,
+  test 6 fails and this doc is updated. **Candidate defect, not yet filed.**
+- **The instance's provider state is part of the measurement, not background.**
+  The first version of this spec asserted `#memory-embedding-model` present
+  unconditionally and was green three times on `1.12.0.dev19` — an instance that
+  happened to carry credentials from an earlier `collect-models`. Restarting on
+  the current nightly (a fresh container, no credentials) turned two tests red.
+  The version bump was not the cause; the provider state was.
+- **The submit gate, from the bundle:**
+  `disabled = !name.trim() || embedding.length === 0 || !backendConfigured ||
+  (preprocessing && preprocModel.length === 0) || (preprocessing && !prompt.trim())`.
+  `backendConfigured` is true for `chroma` out of the box, which is why the
+  Name-only state is disabled by the embedding model alone.
+- **Checklist placement.** The bullets flip the existing `## memory/ — Memory
+  Base Registration (1.12)` §20.1–§20.2 entries in place; the section and its
+  `MODULES` entry in `scripts/coverage-summary.ts` already landed with the audit
+  that opened this issue. §20.3 stays open for #1399 and §20.4 (ingestion) is a
+  separate wave item.

--- a/tests/tests-automations/regression/core-functionality/memory/memory-base-panel.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/memory/memory-base-panel.spec.ts
@@ -1,0 +1,381 @@
+import type { APIRequestContext, Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { createFlow } from "../../../../helpers/flows/create-flow";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { openFlowById } from "../../../../helpers/flows/open-flow-by-id";
+import { unmountEditorForCleanup } from "../../../../helpers/flows/unmount-editor-for-cleanup";
+
+// Memory Base — Memories panel and Create Memory modal (QA-CHECKLIST §20.1–20.2).
+// Spec doc: docs/core-functionality/memory/memory-base-panel.md
+//
+// The read-only half of the memory-base surface: the flow editor's Memories
+// panel, and the SHAPE of the Create Memory modal — controls, defaults, submit
+// gate, cancel. Nothing here registers a memory base, so nothing here needs a
+// provider, an embedding model or an LLM.
+//
+// Sibling coverage, deliberately not duplicated:
+// - memory-base-registration.spec.ts (issue #1399) completes the form and
+//   asserts the created memory base against the API; it needs an embeddings
+//   provider and skips loudly without one.
+// - The Agent's conversation memory is a different surface that shares the word
+//   (llm-agents/memory-history-regression.spec.ts, §6.3).
+
+// The panel lists from `/api/v1/memories`, NOT `/api/v1/knowledge_bases` — the
+// latter is the Knowledge Base resource (`kb_name`, `/ingest`, `/chunks`) and is
+// never touched here, so asserting it empty would prove nothing about a memory
+// base. Measured on 1.12.0.dev19: opening the panel fires exactly one request,
+// `GET /api/v1/memories?flow_id=…&page=1&size=50`. The route is absent from
+// `/openapi.json` — that is not evidence it does not exist.
+const MEMORIES_API = "/api/v1/memories";
+const KNOWLEDGE_BASES_API = "/api/v1/knowledge_bases/";
+
+// The Embedding Model trigger's text when a model COULD be chosen but none is.
+// Two strings because the shared widget reads `No Models Enabled` when its
+// options are empty and `Select a model` when they are not — both mean unset.
+const UNSET_EMBEDDING_MODEL = /^(Select a model|No Models Enabled)$/;
+
+// Whether the instance can offer an embedding model at all.
+//
+// This is a real precondition, not defensive coding: the Embedding Model control
+// is rendered by the shared model widget WITHOUT `showEmptyState`, which defaults
+// to false — so with no configured provider exposing an `embeddings` model, the
+// control is not in the DOM at all. Its label and placeholder text still render,
+// the required marker still shows and the submit button stays disabled forever,
+// with nothing saying why (the sibling Knowledge Base modal passes
+// `showEmptyState: true` and does render `No Models Enabled` + "Manage Model
+// Providers"). Measured on 1.12.0.dev22 with every provider `is_configured:false`,
+// and on 1.12.0.dev19 with credentials present, where the control renders.
+//
+// Probed through the API before the browser opens (repo convention), so the two
+// states are decided by the environment rather than by whatever the DOM happens
+// to show — a `count() === 0` check inside the test would read a genuine
+// regression that removes the control as "no provider configured".
+async function embeddingModelAvailable(
+  request: APIRequestContext,
+  token: string,
+): Promise<boolean> {
+  const res = await request.get("/api/v1/models", {
+    headers: { Authorization: token },
+  });
+  if (res.status() !== 200) return false;
+  const providers = (await res.json()) as Array<{
+    is_configured?: boolean;
+    is_enabled?: boolean;
+    models?: Array<{ metadata?: { model_type?: string } }>;
+  }>;
+  return providers.some(
+    (p) =>
+      p.is_configured === true &&
+      p.is_enabled === true &&
+      (p.models ?? []).some((m) => m.metadata?.model_type === "embeddings"),
+  );
+}
+
+/**
+ * The Memories panel, scoped to the `aside` that carries its own heading.
+ *
+ * Scoped rather than page-global because the panel's `Create` button and its
+ * search input carry NO `data-testid` at all (measured on 1.12.0.dev19), so both
+ * resolve by role/placeholder — handles that a second "Create" elsewhere in the
+ * editor chrome could collide with.
+ */
+function memoriesPanel(page: Page) {
+  return page
+    .locator("aside")
+    .filter({ has: page.getByRole("heading", { name: "Memories" }) });
+}
+
+/** Opens the Memories panel from the flow editor's left nav. */
+async function openMemoriesPanel(page: Page): Promise<void> {
+  await page.getByTestId("sidebar-nav-memories").click();
+  await expect(memoriesPanel(page)).toBeVisible({ timeout: 15000 });
+}
+
+/** Opens the Create Memory modal from the panel and returns its dialog. */
+async function openCreateMemoryModal(page: Page) {
+  await memoriesPanel(page)
+    .getByRole("button", { name: "Create", exact: true })
+    .click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible({ timeout: 15000 });
+  return dialog;
+}
+
+test.describe("core-functionality/memory — Memories panel and Create Memory modal", () => {
+  let token: string;
+  let flowId: string;
+  let flowName: string;
+
+  test.beforeEach(async ({ page, request }) => {
+    token = await getAuthToken(request);
+    // Unique name per test: the modal's description echoes it, which is what
+    // makes the flow-scoping assertion falsifiable rather than a prefix match.
+    flowName = `memory-panel-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+    flowId = await createFlow(
+      request,
+      {
+        name: flowName,
+        description: "Empty flow for the §20.1–20.2 Memories panel tests",
+        data: { nodes: [], edges: [], viewport: { x: 0, y: 0, zoom: 1 } },
+        is_component: false,
+      },
+      { headers: { Authorization: token } },
+    );
+
+    // openFlowById seeds the assistant-onboarding flag before the load (the
+    // welcome overlay otherwise leaves the editor chrome present-but-hidden) and
+    // gates on the canvas plus the writable header.
+    await openFlowById(page, flowId);
+    await openMemoriesPanel(page);
+  });
+
+  test.afterEach(async ({ page, request }) => {
+    // Leave the editor BEFORE deleting: an editor mounted over a deleted flow
+    // 404s its own polls into the fixture's HTTP log.
+    await unmountEditorForCleanup(page);
+    await deleteFlow(request, flowId, { headers: { Authorization: token } });
+  });
+
+  test("the Memories panel opens with its empty state, a Create action and a search field",
+    { tag: ["@stable", "@release", "@workspace", "@ui-ux"] },
+    async ({ page }) => {
+      const panel = memoriesPanel(page);
+
+      await test.step("the empty state renders, not a blank panel", async () => {
+        // Asserted by element id, not by text: the visible strings come from the
+        // `memory.noMemorySelected*` i18n keys and move under a locale change
+        // (#1400), while these ids are in the shipped markup.
+        await expect(page.locator("#no-memory-selected-title")).toBeVisible({
+          timeout: 15000,
+        });
+        await expect(page.locator("#no-memory-selected-title")).toHaveText(
+          "No memory selected",
+        );
+        await expect(
+          page.locator("#no-memory-selected-description"),
+        ).toBeVisible();
+      });
+
+      await test.step("the panel offers Create and a search field", async () => {
+        await expect(
+          panel.getByRole("button", { name: "Create", exact: true }),
+        ).toBeVisible();
+        // Enabled is the assertion that matters: the button is rendered
+        // `disabled` without a `currentFlowId`, so this also pins that the panel
+        // knows which flow it is in.
+        await expect(
+          panel.getByRole("button", { name: "Create", exact: true }),
+        ).toBeEnabled();
+        await expect(
+          panel.getByPlaceholder("Search memories..."),
+        ).toBeVisible();
+      });
+    });
+
+  test("the Create Memory modal is scoped to the current flow",
+    { tag: ["@stable", "@release", "@workspace", "@ui-ux"] },
+    async ({ page }) => {
+      const dialog = await openCreateMemoryModal(page);
+
+      await test.step("the modal titles itself Create Memory", async () => {
+        // The submit button carries the same label, so the title is asserted as
+        // a heading — never as page text, which both would satisfy.
+        await expect(
+          dialog.getByRole("heading", { name: /Create Memory/ }),
+        ).toBeVisible();
+      });
+
+      await test.step("the description names THIS flow", async () => {
+        // The exact name this test created, not the literal prefix: a prefix
+        // match would pass against any flow and prove nothing about scoping.
+        await expect(
+          dialog.getByText(`Create a memory for "${flowName}"`, {
+            exact: true,
+          }),
+        ).toBeVisible({ timeout: 15000 });
+      });
+    });
+
+  test("the Create Memory modal exposes its five controls",
+    { tag: ["@stable", "@release", "@workspace", "@ui-ux"] },
+    async ({ page }) => {
+      const dialog = await openCreateMemoryModal(page);
+
+      await test.step("all five controls are labelled as required", async () => {
+        // The labels are asserted for all five — including Embedding Model,
+        // whose CONTROL is provider-dependent (see embeddingModelAvailable) but
+        // whose label and required marker render unconditionally.
+        for (const label of [
+          "Name",
+          "Embedding Model",
+          "Vector Database",
+          "Batch Size",
+          "LLM Preprocessing",
+        ]) {
+          await expect(
+            dialog.getByText(label, { exact: false }).first(),
+          ).toBeVisible({ timeout: 15000 });
+        }
+      });
+
+      await test.step("the four provider-independent controls render", async () => {
+        await expect(page.locator("#memory-name")).toBeVisible({
+          timeout: 15000,
+        });
+        await expect(page.locator("#memory-db-provider")).toBeVisible();
+        await expect(page.locator("#memory-batch-size")).toBeVisible();
+        await expect(page.locator("#llm-preprocessing-switch")).toBeVisible();
+      });
+
+      await test.step("the preprocessing branch stays collapsed while the toggle is off", async () => {
+        // The two extra required fields only exist with the toggle on. Asserted
+        // as absent so test 5's Name-only gate cannot be explained by them.
+        await expect(page.locator("#llm-preprocessing-switch")).toHaveAttribute(
+          "data-state",
+          "unchecked",
+        );
+        await expect(
+          page.locator("#memory-preprocessing-model"),
+        ).toHaveCount(0);
+        await expect(page.locator("#preprocessing-prompt")).toHaveCount(0);
+      });
+    });
+
+  test("Vector Database defaults to Chroma Local and Batch Size to 1",
+    { tag: ["@stable", "@release", "@workspace", "@ui-ux"] },
+    async ({ page }) => {
+      await openCreateMemoryModal(page);
+
+      await test.step("both defaults are the shipped ones", async () => {
+        // `chroma` ships `defaultEnabled` with no config fields, so this holds
+        // on an instance with nothing configured under DB Providers.
+        await expect(page.locator("#memory-db-provider")).toHaveText(
+          "Chroma Local",
+          { timeout: 15000 },
+        );
+        await expect(page.locator("#memory-batch-size")).toHaveValue("1");
+      });
+    });
+
+  // The Embedding Model default is covered by TWO tests, one per environment
+  // state, each skipping with the concrete reason when the other one's state
+  // holds. Written this way rather than as one branching test so that neither
+  // state is silently accepted: whichever the instance is in, one of the two
+  // runs and asserts something falsifiable, and the skip reason names the state.
+  test("Embedding Model carries no default model when a provider offers embeddings",
+    { tag: ["@stable", "@release", "@workspace", "@ui-ux"] },
+    async ({ page, request }) => {
+      const available = await embeddingModelAvailable(request, token);
+      test.skip(
+        !available,
+        "no configured, enabled provider exposes an embeddings model — the control is not rendered at all on this instance (see the sibling test)",
+      );
+
+      const dialog = await openCreateMemoryModal(page);
+
+      await test.step("the control renders with no model chosen", async () => {
+        // The absence of the `Provider:` line is the second half of "unset" — it
+        // renders only once a model is selected, so a picker pre-filled with a
+        // provider's default could not pass both assertions.
+        await expect(page.locator("#memory-embedding-model")).toHaveText(
+          UNSET_EMBEDDING_MODEL,
+          { timeout: 15000 },
+        );
+        await expect(dialog.getByText(/^Provider: /)).toHaveCount(0);
+      });
+    });
+
+  test("the Embedding Model control is absent when no provider offers embeddings",
+    { tag: ["@stable", "@release", "@workspace", "@ui-ux"] },
+    async ({ page, request }) => {
+      const available = await embeddingModelAvailable(request, token);
+      test.skip(
+        available,
+        "a configured provider exposes an embeddings model, so the control renders — covered by the sibling test",
+      );
+
+      const dialog = await openCreateMemoryModal(page);
+
+      // The product gap, asserted for what it is rather than skipped past: the
+      // required field's label and marker render while the control does not, so
+      // the modal is a dead end with nothing saying why. If upstream starts
+      // passing `showEmptyState` (as the Knowledge Base modal already does),
+      // this test fails and the spec is updated — which is the point.
+      await test.step("the required label renders with no control under it", async () => {
+        await expect(
+          dialog.locator("label").filter({ hasText: "Embedding Model" }),
+        ).toBeVisible({ timeout: 15000 });
+        await expect(page.locator("#memory-embedding-model")).toHaveCount(0);
+        await expect(
+          page.getByTestId("value-dropdown-memory-embedding-model"),
+        ).toHaveCount(0);
+      });
+
+      await test.step("nothing is defaulted in its place", async () => {
+        await expect(dialog.getByText(/^Provider: /)).toHaveCount(0);
+      });
+    });
+
+  test("Create Memory stays disabled with an empty form and with only the Name filled",
+    { tag: ["@stable", "@release", "@workspace", "@ui-ux"] },
+    async ({ page }) => {
+      const dialog = await openCreateMemoryModal(page);
+      const submit = dialog.getByRole("button", { name: "Create Memory" });
+
+      await test.step("the submit button is disabled on open", async () => {
+        await expect(submit).toBeDisabled({ timeout: 15000 });
+      });
+
+      await test.step("it stays disabled after the Name is filled", async () => {
+        await page.locator("#memory-name").fill(`memory-${Date.now()}`);
+        // The fill is observed before the gate is re-read, so a still-disabled
+        // button cannot be explained by the value never landing.
+        await expect(page.locator("#memory-name")).not.toHaveValue("");
+        // This is the gate, not the initial render: Name is filled, Vector
+        // Database and Batch Size hold their defaults, and the only unset
+        // required control left is the Embedding Model.
+        await expect(submit).toBeDisabled();
+      });
+    });
+
+  test("cancelling the Create Memory modal creates no memory base",
+    { tag: ["@stable", "@release", "@workspace", "@ui-ux"] },
+    async ({ page, request }) => {
+      const dialog = await openCreateMemoryModal(page);
+
+      await test.step("a filled Name is discarded by Cancel", async () => {
+        await page.locator("#memory-name").fill(`cancelled-${Date.now()}`);
+        await page.getByTestId("btn-cancel-modal").click();
+        await expect(dialog).toBeHidden({ timeout: 15000 });
+      });
+
+      await test.step("no memory base exists for this flow, per the API", async () => {
+        // Asserted against the endpoint the panel itself lists from — the UI
+        // alone could be rendering nothing simply because it never refetched.
+        const listed = await request.get(
+          `${MEMORIES_API}?flow_id=${flowId}&page=1&size=50`,
+          { headers: { Authorization: token } },
+        );
+        expect(listed.status()).toBe(200);
+        const body = (await listed.json()) as {
+          items: unknown[];
+          total: number;
+        };
+        expect(body.total).toBe(0);
+        expect(body.items).toEqual([]);
+      });
+
+      await test.step("no knowledge base was created either", async () => {
+        // Secondary and flow-independent: this endpoint is a DIFFERENT resource
+        // that a memory base would eventually back onto, and it is account-wide,
+        // so the assertion is only that THIS flow's name is absent from it —
+        // never that the list is empty (parallel workers own rows here).
+        const kbs = await request.get(KNOWLEDGE_BASES_API, {
+          headers: { Authorization: token },
+        });
+        expect(kbs.status()).toBe(200);
+        expect(await kbs.text()).not.toContain(flowName);
+      });
+    });
+});


### PR DESCRIPTION
Closes #1398.

Closes the seven `[ ]` bullets in `QA-CHECKLIST.md` §20.1–20.2 (`## memory/ — Memory Base Registration`) — the **read-only half** of the memory-base surface. Distinct from §20.3 (#1399), which completes the form and needs a provider exposing an embedding model: nothing here registers anything, so nothing here needs a provider, an embedding model or an LLM call. Also distinct from §6.3, the Agent's conversation memory, which only shares the word.

## 1. Covered tests

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `the Memories panel opens with its empty state, a Create action and a search field` | `sidebar-nav-memories` renders the panel with `#no-memory-selected-title` (text `No memory selected`) and `#no-memory-selected-description`, not a blank panel; inside the panel `aside`, the `Create` button is visible **and enabled** (it renders disabled without a `currentFlowId`, so this also pins that the panel knows its flow) and the `Search memories...` input is present. Catches a panel that mounts empty, and a `Create` that is dead because the flow id never reached it |
| 2 | `the Create Memory modal is scoped to the current flow` | Heading `Create Memory` (as a heading — the submit button carries the same label) plus the exact description `Create a memory for \"<the flow this test created>\"`. Catches a memory base becoming global, and is falsifiable: the flow name is unique per test, so a prefix-only match cannot pass |
| 3 | `the Create Memory modal exposes its five controls` | All five required labels render, and the four provider-independent controls exist (`#memory-name`, `#memory-db-provider`, `#memory-batch-size`, `#llm-preprocessing-switch`); the toggle reads `data-state=unchecked` and the preprocessing branch's two extra required fields have `count 0`, so test 7's Name-only gate cannot be explained by them |
| 4 | `Vector Database defaults to Chroma Local and Batch Size to 1` | `#memory-db-provider` reads `Chroma Local` and `#memory-batch-size` reads `1` — the shipped defaults, on an instance with nothing configured under DB Providers. Catches a default that silently moves to a provider needing external configuration |
| 5 | `Embedding Model carries no default model when a provider offers embeddings` | With an embeddings-capable provider configured, the control reads its unset placeholder **and** the modal shows no `Provider:` line (that line renders only once a model is chosen). Catches a picker pre-filled with a provider default |
| 6 | `the Embedding Model control is absent when no provider offers embeddings` | With none configured, the required `<label>` renders while `#memory-embedding-model` and `value-dropdown-memory-embedding-model` both have `count 0`, and nothing is defaulted in its place. Asserts the product gap below rather than skipping past it |
| 7 | `Create Memory stays disabled with an empty form and with only the Name filled` | Submit is disabled on open and **stays** disabled after `#memory-name` is filled (with the value confirmed non-empty first, so a still-disabled button cannot be blamed on the fill). This is the required-Embedding-Model gate, not the initial render — the two other required controls hold defaults |
| 8 | `cancelling the Create Memory modal creates no memory base` | After `btn-cancel-modal` the dialog is hidden and `GET /api/v1/memories?flow_id=<id>` answers `200` with `total: 0` / `items: []`. Catches a Cancel that persists, which the UI alone cannot rule out (it could simply have not refetched) |

## 2. How the test was built

- **Setup:** each test creates its own flow through `POST /api/v1/flows/` (unique name — the modal echoes it, which is what makes test 2 falsifiable) and enters via `openFlowById`, which seeds the assistant-onboarding flag before the load and gates on `canvas_controls_dropdown` + a writable header. No UI flow creation, so no dependency on the New Flow path.
- **Live-confirmed selectors, harvested twice** — from the shipped frontend bundle inside the running container and then confirmed live with a throwaway scout (its flows deleted). Notable findings encoded: the panel's `Create` button and search input carry **no** `data-testid` at all, so they resolve by role/placeholder scoped to the panel `aside`; the empty state is asserted by **element id**, since the visible strings are i18n keys that move under §18; `#memory-embedding-model`, `#memory-db-provider` and `#llm-preprocessing-switch` are the real handles.
- **Three corrections to the audit's wording**, each measured: the flow-scoped string is the modal's **description**, not its title; the panel lists from **`/api/v1/memories`** (one request on open, no `knowledge_bases` call at all) and the modal submits to `POST /api/v1/memories/`, so asserting `knowledge_bases` empty would have been vacuous — it is kept only as a secondary, flow-independent check that the flow's name is absent; and **Batch Size also defaults** (`1`).
- **The submit gate, read from the bundle rather than guessed:** `disabled = !name.trim() || embedding.length === 0 || !backendConfigured || (preprocessing && …)`. `backendConfigured` is true for `chroma` out of the box, which is why the Name-only state is held by the embedding model alone.
- **Product gap found while validating, asserted in both directions.** The Embedding Model picker is the shared model widget rendered **without** `showEmptyState` (default `false`), so on an instance where no configured, enabled provider exposes an `embeddings` model the control is **absent from the DOM entirely** — while its label, its required `*` and the placeholder text still render, and `Create Memory` stays disabled forever with nothing explaining why. The sibling Knowledge Base modal passes `showEmptyState: true` on the same widget (`#kb-embedding-model`) and renders `No Models Enabled` + `Manage Model Providers`. Measured in both states on 1.12.0.dev22. Recorded in the spec doc's Notes and the §20.2 bullet; **not filed** (nothing regressed — the empty state never existed here), so no `REGRESSIONS.md` row. If upstream adds it, test 6 fails and the doc gets updated.
- **Why two tests instead of one branch:** the state is decided by an API probe (`GET /api/v1/models` → `is_configured` && `is_enabled` && a `metadata.model_type=embeddings` model) before the browser opens, so whichever state the instance is in, one test asserts something falsifiable and the other's skip reason names why it stood down. The probe is deliberately **not** a `count() === 0` check on the control itself, which would read a genuine regression removing the control as \"no provider configured\".
- **Cleanup:** id-scoped `deleteFlow` in `afterEach`, after `unmountEditorForCleanup` so the editor cannot 404 its own polls into the fixture's log. No memory base is ever created — test 8 asserts exactly that.

## 3. Dependencies

- **None external.** No provider key, no LLM call, no network beyond the instance. The provider state only decides **which** of tests 5/6 runs, never whether the file has coverage.
- `GET /api/v1/models` for the probe (no inference call, so a configured-but-drained key still reads as configured — the correct answer, since the picker lists the catalog without calling the provider).
- **Parallel-safe:** every artifact is per-test and id-scoped, and no assertion reads account-wide state (the `knowledge_bases` secondary check asserts the absence of this flow's name, never an empty list).
- `/api/v1/memories` is **absent from `/openapi.json`** on 1.12.0.dev22 — it answers `403` unauthenticated and `200` with the session. Not evidence the route does not exist.

## Validation (nightly 1.12.0.dev22, `--retries=0 --workers=1`)

- typecheck ✅ · eslint ✅ (only the 2 documented `playwright/no-skipped-test` warnings for the probe-gated pair) · `check:checklist-coverage` ✅ · `coverage:summary` regenerates without throwing ✅
- **3 clean runs, no flake** ✅ — `expected=7 unexpected=0 flaky=0 backendErrors=false` each (the 8th test skips by design, the pair being mutually exclusive), plus a 4th clean run after the rebase onto `origin/main`
- **force-fail 8/8** ✅ — one mutation per test, each verified red then reverted (0 `FF-MUTATION` markers remain, final green run clean): empty-state text → nonexistent string; description → wrong flow name; label list → nonexistent `Batch Sizes`; default → `Chroma Cloud`; unset matcher → concrete model id; absence → `toHaveCount(1)` (run with every provider `is_configured=false`); Name-only gate → `toBeEnabled()`; API → `total === 1`
- **behavioral cleanup force-fail** ✅ — delete no-oped ⇒ 1 surviving orphan, reverted ⇒ 0; instance ends at **0 user flows, 0 memory bases**
- zero `🚨 Backend Error` ✅
- `--trace=on` ⚠️ **not obtained locally** — the run hangs past 600 s (the known local `--trace=on` limitation), killed rather than reported as passing. Step evidence comes instead from the per-test force-fails and the JSON-reporter stats above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
