### PR TITLE
test(memory): register a memory base end-to-end (#1399)

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -950,7 +950,8 @@
 
 #### 20.3 Registration End-to-End (item 1 of 2)
 
-- [ ] Completing the form creates a memory base that is present **both** in `GET /api/v1/knowledge_bases` and in the panel (the panel alone could render optimistic local state). Needs a provider exposing an **embedding** model; with none the picker reads `No Models Enabled` and the test must skip with that reason, never pass silently
+- [x] Completing the form creates a memory base that is present **both** in the panel and in the API — asserted against **`GET /api/v1/memories?flow_id=<id>`** (the endpoint the panel lists from) with the server-assigned `id` and `kb_name` (`<sanitized name>_<8 hex>`), plus the panel re-read **after a full page reload**, which is what separates persisted state from an optimistic local render. Needs a provider exposing an **embedding** model; with none the test skips naming that state, never passing silently. **Measured correction:** a configured key is not the whole precondition — every embeddings model ships **disabled** in `GET /api/v1/models/enabled_models` (which is what the picker lists from), so the picker reads `No Models Enabled` until one is enabled; the test enables one via `POST /api/v1/models/enabled_models` before the page loads (an additive merge) and restores the flag in cleanup → `core-functionality/memory/memory-base-registration.spec.ts`
+- [x] A registered memory base is exposed through the Memory Base API and **not** through the generic knowledge-base list — its `kb_name` is absent from `GET /api/v1/knowledge_bases`. This is the shipped design (`list_knowledge_bases` skips KBs managed by a Memory Base), so the presence check the wave item asked for would fail forever; the absence is the falsifiable form. Provider-free, so this half has coverage even on an instance where the registration test skips → `core-functionality/memory/memory-base-registration.spec.ts`
 
 #### 20.4 Ingestion (item 2 of 2 — separate wave item)
 

--- a/docs/core-functionality/memory/memory-base-registration.md
+++ b/docs/core-functionality/memory/memory-base-registration.md
@@ -1,191 +1,189 @@
-# Memory Base — registration from the FlowPage Memories panel
+# Memory Base — registering a memory base end-to-end
 
-**File:** `tests/tests-automations/regression/core-functionality/memory/memory-base-registration.spec.ts`
-**Last validated:** `1.12.x`
-**Status:** SPEC — awaiting confirmation, no test code written yet
+**Last validated:** Langflow 1.12.x
 
 ---
 
-## What this test validates
+## What this test validates *(required)*
 
-The **Memory Base** surface introduced in 1.12: the `Memories` panel inside the
-Flow editor and the `Create Memory` modal that registers one. A memory base is a
-Knowledge Base (`/api/v1/knowledge_bases`) bound to a flow, storing vectors in a
-configured vector database.
+The write half of the memory-base surface: **completing the Create Memory form
+actually registers a memory base**, and the registration is real server state
+rather than optimistic UI. The read half — the panel, the modal's controls,
+defaults and submit gate — is `memory-base-panel.spec.ts` (issue #1398) and is
+deliberately not repeated here.
 
-This area has **no coverage today** — no spec, no checklist bullet. It was missed
-because "memory" was already taken in our vocabulary by the Agent's conversation
-memory (Message History, session isolation, `context_id`), which is unrelated.
+1. **should register a memory base from the Create Memory modal** — with an
+   embeddings provider configured, filling Name and selecting an Embedding Model
+   enables `Create Memory`; submitting it answers `201` on
+   `POST /api/v1/memories`, the memory appears in the Memories panel, and
+   `GET /api/v1/memories?flow_id=<id>` reports it with a server-assigned `id`
+   and `kb_name`. The panel is then re-read **after a full page reload**, which
+   is what distinguishes persisted state from an optimistic local render.
+   Skips, naming the state, when no configured provider exposes an embeddings
+   model.
+2. **should expose a registered memory base through the Memory Base API only,
+   never through the generic knowledge-base list** — a memory base created
+   through `POST /api/v1/memories` is listed by `GET /api/v1/memories` and its
+   `kb_name` is **absent** from `GET /api/v1/knowledge_bases`. Provider-free, so
+   this half of the file has coverage on any instance.
 
-## Tags
+---
 
-`@regression` `@workspace` (cross-cutting) + `@files` (functional).
+## Tags *(required)*
 
-`@files` is the closest existing functional tag — the surface is knowledge/vector
-ingestion. **Not `@stable`** on the first delivery: `@stable` is added only after
-team validation.
+Test 1: `@release` `@workspace` (cross-cutting) + `@ui-ux` `@model-provider`
+(functional).
+Test 2: `@api` `@workspace` (cross-cutting) + `@files` (functional).
 
-Scenario 5 additionally carries `@model-provider`, because it is the only one
-that needs an embedding provider.
+`@model-provider` is on test 1 only — it is the only one that resolves a model.
+`@files` on test 2 is the repo's functional tag for the knowledge/vector
+ingestion family, which is the resource boundary that test asserts.
 
-## Validation criterion
+**`@stable` decision:** proposed for both. Test 2 is provider-free and fully
+deterministic. Test 1 skips loudly rather than failing when the daily's provider
+key is drained (a state this account has been in three times — #772, #1029,
+#1169), so it cannot redden the daily for a credential reason. Confirm with the
+team before the PR; a `@stable` test must not be `@destructive`, and neither is.
 
-The suite passes when, on a flow with no memory base:
+---
 
-1. The `Memories` panel opens from the flow sidebar and shows its empty state.
-2. The `Create Memory` modal exposes its five documented controls and its
-   defaults.
-3. `Create Memory` stays **disabled** until every required field is filled.
-4. `Cancel` closes the modal and creates nothing — asserted against
-   `GET /api/v1/knowledge_bases`, not against the UI alone.
-5. *(provider-dependent)* Completing the form creates a memory base that appears
-   both in the panel and in `GET /api/v1/knowledge_bases`.
+## Validation criterion *(required)*
 
-## External dependencies
+- **The API axis is `/api/v1/memories`, not `/api/v1/knowledge_bases` — the
+  issue's wording is wrong here and the correction is load-bearing, not
+  cosmetic.** Issue #1399 asks for the memory base to be present "both in
+  `GET /api/v1/knowledge_bases` and in the panel". Measured on 1.12.0.dev22: a
+  memory base created through the API leaves `GET /api/v1/knowledge_bases/`
+  answering `[]`. This is **by design**, stated in the shipped source
+  (`langflow/api/v1/knowledge_bases.py`, in `list_knowledge_bases`): *"Skip KBs
+  that are managed by a Memory Base — those are exposed through the Memory Base
+  APIs, not the generic KB list."* Asserting presence in `knowledge_bases` would
+  therefore fail forever; asserting *absence* there is the falsifiable statement
+  the issue was reaching for, and it is the one this spec makes.
+- **The two-sided check the issue asks for is kept, on the right pair.** The
+  panel could render optimistic local state, so the panel assertion is paired
+  with `GET /api/v1/memories?flow_id=<id>` — the endpoint the panel itself lists
+  from — and the panel is additionally re-read after `page.reload()`. A memory
+  written only into client state survives neither.
+- **The created record is asserted by its server-assigned shape, not just by
+  name.** `POST /api/v1/memories` returns `id`, `flow_id` equal to the flow the
+  test created, and `kb_name` matching `^<sanitized name>_[0-9a-f]{8}$` — the
+  auto-generated backing KB name documented in `create_memory_base`. Asserting
+  the `kb_name` pattern is what lets test 2 look the KB up by the exact string
+  the server chose, instead of by a name the test invented.
+- **The provider precondition is decided by an API probe before the browser
+  opens, never by a `count()` on the control.** `GET /api/v1/models`, looking
+  for a provider that is `is_configured` **and** `is_enabled` **and** carries a
+  model whose `metadata.model_type` is `embeddings`. The Embedding Model picker
+  is the shared model widget rendered **without** `showEmptyState`, so with no
+  configured provider at all the control is absent from the DOM entirely — a
+  `count() === 0` check would read a genuine regression that removes the control
+  as "no provider configured". The skip reason names the measured state.
+- **A configured key is NOT the whole precondition — the embeddings model must
+  also be enabled, and none is by default.** Measured on 1.12.0.dev22 with
+  `OPENAI_API_KEY` configured: `GET /api/v1/models` reports openai
+  `is_configured: true`, `is_enabled: true` with three embeddings models, while
+  `GET /api/v1/models/enabled_models` reports **all three `false`** — and the
+  open picker lists exactly one option, `No Models Enabled` (the string issue
+  #1399 predicts, reached by this route rather than by an absent key). The
+  picker lists from `/api/v1/models/enabled_models`, not from `/api/v1/models`.
+  The test therefore **enables one embeddings model itself** through
+  `POST /api/v1/models/enabled_models` before the page loads, and restores the
+  model's previous flag in cleanup. That is setup, not a weakened assertion: the
+  registration behaviour under test is unaffected, and without it the test would
+  skip on every instance the suite ever runs against, which is coverage of
+  nothing. The write is **additive** (measured: the handler merges the update
+  into the user's enabled/disabled variable lists rather than replacing the map),
+  so it cannot disturb a parallel worker's model enablement.
+- **The enablement must precede the page load.** The frontend caches the model
+  list: enabling a model while the modal is open leaves the picker reading
+  `No Models Enabled` until `refresh-model-list` is clicked (measured). The
+  spec avoids the refresh path entirely by doing the API write first.
+- **A skip is never a silent pass.** Test 1 skips with the concrete reason; test
+  2 runs regardless, so the file always executes at least one falsifiable
+  assertion about registration.
+- **No embedding call is made.** Registration writes the KB directory and
+  `embedding_metadata.json`; ingestion — which would call the provider — is out
+  of scope (§20.4). The provider only needs to be *configured*, so a drained key
+  still satisfies test 1.
+
+---
+
+## External dependencies *(required)*
 
 - A running Langflow **1.12.x** instance with the Memories panel
-  (`sidebar-nav-memories`).
-- **Scenarios 1–4: none.** No provider, no key, no network beyond the instance.
-- **Scenario 5 only:** a configured provider exposing an **embedding** model.
-  With none, the picker renders `No Models Enabled` and the scenario `test.skip`s
-  with that reason — never a silent pass.
+  (`sidebar-nav-memories`) and the `/api/v1/memories` router.
+- **Test 1 only:** a configured, enabled provider exposing an **embedding**
+  model (e.g. OpenAI's `text-embedding-3-small`). No inference call is made, so
+  a configured-but-drained key is sufficient. With no such provider, test 1
+  skips with that reason. The model's own enablement is not a precondition —
+  the test writes it (see Validation criterion) via
+  `POST /api/v1/models/enabled_models` and `GET /api/v1/models/enabled_models`.
+- **Test 2: none** — it creates its memory base through the API with an
+  `embedding_model` string and no provider configured (measured: `201`).
 - The default vector database is **Chroma Local**, bundled with the instance, so
-  scenario 5 needs no external vector service.
-
-**Note — the API is absent from the instance's OpenAPI schema.** `GET /openapi.json`
-lists 104 paths and none is `knowledge_bases`, yet the endpoint answers `200`.
-Assertions therefore target observed responses, not the published schema.
-
----
-
-## Scenarios
-
-### 1.1 Memories panel opens with its empty state [ ]
-
-**File:** `core-functionality/memory/memory-base-registration.spec.ts`
-**Objective:** The panel is reachable from the flow editor and reports "no memory"
-honestly, so later scenarios start from a known state.
-**Precondition:** A flow open in the editor with no memory base registered.
-
-**Step by step**
-
-1. Create a flow via `POST /api/v1/flows/` and open it (repo pattern: `goto("/")`
-   then open the card by name — `page.goto("/flow/{id}")` races the SPA cache).
-2. Click `sidebar-nav-memories`.
-
-**Validation:** The `Memories` heading is visible, the empty state reads
-`No memory selected` / `Select a memory from the sidebar to view details`, and a
-`Create` control is present.
+  no external vector service is required.
+- `POST /api/v1/flows/` + `DELETE /api/v1/flows/{id}` (flow lifecycle),
+  `POST /api/v1/memories`, `GET /api/v1/memories?flow_id=<id>`,
+  `DELETE /api/v1/memories/{id}` (`204`) and `GET /api/v1/knowledge_bases/`.
+- **`/api/v1/memories` is absent from `/openapi.json`** — it answers `403`
+  unauthenticated and `200` with the session. Do not conclude from the published
+  schema that the route does not exist.
 
 ---
 
-### 1.2 Create Memory modal exposes its contract [ ]
+## Cleanup *(required)*
 
-**Objective:** Pin the form's shape and defaults, so an upstream change to either
-is caught rather than absorbed.
-**Precondition:** Scenario 1.1 state, modal closed.
-
-**Step by step**
-
-1. Click `Create` in the Memories panel.
-2. Read the modal.
-
-**Validation:** The dialog titles `Create Memory` and scopes itself to the flow
-(`Create a memory for "<flow name>"`). It exposes:
-
-| Control | Selector | Expectation |
-|---|---|---|
-| Name | `input#memory-name` | required, placeholder `Memory name` |
-| Embedding Model | `memory-embedding-model` | required, empty (`Select a model`) |
-| Vector Database | `memory-db-provider` | required, **defaults to `Chroma Local`** |
-| Batch Size | `input#memory-batch-size` | required, placeholder `1` |
-| LLM Preprocessing | checkbox | optional, off by default |
-| Cancel | `btn-cancel-modal` | enabled |
-
-The flow-name assertion is the load-bearing one: it proves a memory base is
-**scoped to a flow**, not global.
+Every test creates its own flow (`POST /api/v1/flows/`) and its own memory base,
+and deletes both id-scoped in `afterEach`: `DELETE /api/v1/memories/{id}` first
+(the record and its on-disk KB directory), then `deleteFlow`, leaving the editor
+via `unmountEditorForCleanup` before the flow goes so the editor's polls cannot
+404 into the fixture's HTTP log. The memory-base id comes from the `POST`
+response (test 2) or from `GET /api/v1/memories?flow_id=<id>` (test 1), never
+from a name lookup and never from a delete-all sweep (#553/#520) — the account
+is shared with parallel workers.
 
 ---
 
-### 1.3 Create is gated on the required fields [ ]
+## What this test does not cover *(optional)*
 
-**Objective:** The primary action cannot submit an incomplete registration.
-**Precondition:** Modal open, untouched.
-
-**Step by step**
-
-1. Assert `Create Memory` is disabled with the form empty.
-2. Fill `#memory-name` with a per-run sentinel.
-3. Assert it is **still** disabled — Name alone is not enough (Embedding Model
-   has no value and no default).
-
-**Validation:** The button is disabled in both states. Asserting the second state
-is what makes this a gate test rather than a render test.
-
-> **Known limitation.** `Create Memory` carries **no `data-testid`** — it is
-> located by role+name. Same for the Name and Batch Size inputs (`id` only), the
-> search field and the empty state. Only the two dropdowns and Cancel have
-> testids. This is worth raising upstream; until then the spec documents the
-> weaker locators rather than inventing testids that do not exist.
+- The panel, the modal's controls, its defaults and its disabled gate —
+  `memory-base-panel.spec.ts` (§20.1–20.2).
+- Ingestion, chunk preview, run history, cancel and connectors — §20.4, a
+  separate wave item, and where all three known upstream defects live.
+- The LLM Preprocessing branch (`preprocessing: true` + `preproc_model`), which
+  the API answers `422` for when the model is missing.
+- Non-`chroma` vector databases (Chroma Cloud, OpenSearch, pgvector), which need
+  DB Providers configured.
+- Duplicate-name handling (`409`), `PATCH`, `/flush`, `/regenerate` and
+  `/mismatch`.
+- The Agent's conversation memory (§6.3) — a different surface sharing the word.
 
 ---
 
-### 1.4 Cancel creates nothing [ ]
+## Notes *(optional)*
 
-**Objective:** Abandoning the form leaves no server-side record — the failure mode
-a UI-only assertion would miss.
-**Precondition:** Modal open with `#memory-name` filled.
-
-**Step by step**
-
-1. Record `GET /api/v1/knowledge_bases` (baseline).
-2. Click `btn-cancel-modal`.
-3. Re-read `GET /api/v1/knowledge_bases`.
-
-**Validation:** The modal closes, the panel is back to its empty state, and the
-API list is byte-identical to the baseline.
-
----
-
-### 1.5 Registering a memory base end-to-end [ ] — provider-dependent
-
-**Objective:** The happy path the feature exists for.
-**Precondition:** A provider with an **embedding** model configured. If
-`memory-embedding-model` offers `No Models Enabled`, `test.skip` with that reason.
-
-**Step by step**
-
-1. Open the modal, fill `#memory-name` with a per-run sentinel.
-2. Select an embedding model via `value-dropdown-memory-embedding-model`.
-3. Leave Vector Database at `Chroma Local` and Batch Size at its default.
-4. Assert `Create Memory` is now **enabled**, then click it.
-5. Wait for the `POST` to `/api/v1/knowledge_bases` to answer `201`.
-
-**Validation:** The sentinel appears in the Memories sidebar **and** in
-`GET /api/v1/knowledge_bases`. Both are required: the panel alone could render
-optimistic local state.
-
-**Cleanup:** `DELETE /api/v1/knowledge_bases/{name}` in `afterEach`, plus the
-flow. The suite has a documented history of cross-worker damage from destructive
-cleanup (#519/#562), so cleanup deletes **only** the sentinel it created — never
-"all memory bases".
-
----
-
-## Open decisions for the team
-
-1. **Area placement.** This spec proposes a new
-   `core-functionality/memory/` area. The alternative is folding it into
-   `core-functionality/knowledge-ingestion-management/` (§5, 8 bullets, all
-   validated), which today covers the **component-based** ingestion path (Split
-   Text, vector store components) — a different mechanism reaching a similar
-   outcome. Separate area recommended; §5 covers components, this covers a
-   managed platform object.
-2. **Is this surface in the team's scope at all?** Bundles and data migration
-   were both scoped out to other owners this cycle. This is a platform feature
-   and the same question applies before the tests are written.
-3. **Deferred deliberately:** ingestion (`POST /{kb_name}/ingest`), chunk preview,
-   run history (`/runs`), cancel, connectors and the `memory base association`
-   guards (5 routes carry `_check_memory_base_association`). Those are a second
-   spec once registration is covered — this one stops at *registering* it, which
-   is what was asked.
+- **This doc supersedes its own earlier draft.** The version written during the
+  §20 audit described all five scenarios of the surface and asserted them
+  against `GET /api/v1/knowledge_bases`. Scenarios 1–4 shipped as
+  `memory-base-panel.spec.ts`, and that spec's own measurement contradicted the
+  endpoint; the source read above settles it.
+- **Measured facts, 1.12.0.dev22** (`langflowai/langflow-nightly:latest`):
+  `POST /api/v1/memories` with `{name, flow_id, embedding_model, threshold}`
+  answers `201` with `backend_type: "chroma"`, `backend_config: {}`,
+  `auto_capture: true` and `kb_name: "<sanitized>_<8 hex>"`;
+  `GET /api/v1/knowledge_bases/` answers `200 []` with that memory base
+  present; `DELETE /api/v1/memories/{id}` answers `204` and the list returns to
+  `total: 0`.
+- **The UI path, measured end to end on 1.12.0.dev22** with one embeddings model
+  enabled: opening the picker lists the enabled model as a `role=option`;
+  choosing it sets `#memory-embedding-model` to the model id and renders
+  `Provider: OpenAI`; `Create Memory` becomes enabled once Name is filled;
+  clicking it fires `POST /api/v1/memories/` → `201`, closes the dialog, and the
+  panel lists the name. After `reload()` and reopening the panel the name is
+  still there. The submit button and the panel's list item carry **no**
+  `data-testid` (the item is a plain `div`), so they resolve by role+name and by
+  exact text inside the panel's `aside`.
+- **Batch Size is `threshold` on the wire** — the modal's `#memory-batch-size`
+  maps to the `threshold` field (default `50` in the model, `1` in the modal).
+  Worth knowing before reading a payload and concluding a field is missing.

--- a/tests/tests-automations/regression/core-functionality/memory/memory-base-registration.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/memory/memory-base-registration.spec.ts
@@ -1,0 +1,371 @@
+import type { APIRequestContext, Page } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { createFlow } from "../../../../helpers/flows/create-flow";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import { openFlowById } from "../../../../helpers/flows/open-flow-by-id";
+import { unmountEditorForCleanup } from "../../../../helpers/flows/unmount-editor-for-cleanup";
+
+// Memory Base — registering a memory base end-to-end (QA-CHECKLIST §20.3).
+// Spec doc: docs/core-functionality/memory/memory-base-registration.md
+//
+// The WRITE half of the memory-base surface. The panel, the modal's controls,
+// its defaults and its submit gate are memory-base-panel.spec.ts (#1398) and are
+// deliberately not repeated here.
+//
+// The issue asks for the created memory base to be present "both in
+// GET /api/v1/knowledge_bases and in the panel". Measured on 1.12.0.dev22: it is
+// NOT in that list, and by design — `list_knowledge_bases` in the shipped source
+// skips "KBs that are managed by a Memory Base — those are exposed through the
+// Memory Base APIs, not the generic KB list". So the two-sided check the issue
+// wanted is made against `/api/v1/memories` (the endpoint the panel itself lists
+// from), and the knowledge-base half is asserted as the ABSENCE that the design
+// states — which is falsifiable, where presence would fail forever.
+const MEMORIES_API = "/api/v1/memories";
+const KNOWLEDGE_BASES_API = "/api/v1/knowledge_bases/";
+const ENABLED_MODELS_API = "/api/v1/models/enabled_models";
+
+interface EmbeddingChoice {
+  /** Provider display name, as `enabled_models` keys it (e.g. `OpenAI`). */
+  provider: string;
+  /** Model id as the picker lists it (e.g. `text-embedding-3-small`). */
+  modelId: string;
+  /** The model's enabled flag BEFORE this spec touched it. */
+  wasEnabled: boolean;
+}
+
+/**
+ * An embeddings model this instance could offer the Create Memory picker, or
+ * `null` when no provider can.
+ *
+ * Probed through the API before the browser opens (repo convention): the
+ * Embedding Model control is the shared model widget rendered WITHOUT
+ * `showEmptyState`, so with no configured provider it is absent from the DOM
+ * entirely — a `count() === 0` check inside the test would read a genuine
+ * regression removing the control as "no provider configured".
+ *
+ * Two endpoints, because they answer different questions and only the pair is
+ * enough (measured on 1.12.0.dev22 with `OPENAI_API_KEY` configured):
+ *
+ *  - `GET /api/v1/models` says whether a provider is `is_configured` and
+ *    `is_enabled` and carries a `metadata.model_type === "embeddings"` model.
+ *    That is the environment precondition this spec cannot create for itself.
+ *  - `GET /api/v1/models/enabled_models` says whether that model is enabled,
+ *    which is what the picker actually lists from — and every embeddings model
+ *    ships `false` there even with the key configured, which is how the picker
+ *    reaches the `No Models Enabled` state issue #1399 predicts.
+ */
+async function findEmbeddingModel(
+  request: APIRequestContext,
+  token: string,
+): Promise<EmbeddingChoice | null> {
+  const modelsRes = await request.get("/api/v1/models", {
+    headers: { Authorization: token },
+  });
+  if (modelsRes.status() !== 200) return null;
+  const providers = (await modelsRes.json()) as Array<{
+    provider?: string;
+    is_configured?: boolean;
+    is_enabled?: boolean;
+    models?: Array<{
+      model_name?: string;
+      metadata?: { model_type?: string; deprecated?: boolean };
+    }>;
+  }>;
+
+  const enabledRes = await request.get(ENABLED_MODELS_API, {
+    headers: { Authorization: token },
+  });
+  if (enabledRes.status() !== 200) return null;
+  const enabledMap = ((await enabledRes.json()) as {
+    enabled_models?: Record<string, Record<string, boolean>>;
+  }).enabled_models ?? {};
+
+  for (const provider of providers) {
+    if (provider.is_configured !== true || provider.is_enabled !== true) continue;
+    const providerName = provider.provider;
+    if (!providerName) continue;
+    for (const model of provider.models ?? []) {
+      if (model.metadata?.model_type !== "embeddings") continue;
+      if (model.metadata?.deprecated === true) continue;
+      const modelId = model.model_name;
+      if (!modelId) continue;
+      return {
+        provider: providerName,
+        modelId,
+        wasEnabled: enabledMap[providerName]?.[modelId] === true,
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * Flips one model's enablement, additively.
+ *
+ * The handler merges the update into the user's own enabled/disabled variable
+ * lists rather than replacing the map (read from the shipped source and
+ * measured), so this cannot disturb a parallel worker's model enablement — and
+ * the caller restores the previous flag regardless.
+ */
+async function setModelEnabled(
+  request: APIRequestContext,
+  token: string,
+  choice: EmbeddingChoice,
+  enabled: boolean,
+): Promise<void> {
+  const res = await request.post(ENABLED_MODELS_API, {
+    headers: { Authorization: token },
+    data: [
+      {
+        provider: choice.provider,
+        model_id: choice.modelId,
+        enabled,
+        model_type: "embeddings",
+      },
+    ],
+  });
+  expect(
+    res.status(),
+    `POST ${ENABLED_MODELS_API} (${choice.modelId} -> ${enabled})`,
+  ).toBe(200);
+}
+
+/** The Memories panel, scoped to the `aside` carrying its own heading. */
+function memoriesPanel(page: Page) {
+  return page
+    .locator("aside")
+    .filter({ has: page.getByRole("heading", { name: "Memories" }) });
+}
+
+/** Opens the Memories panel from the flow editor's left nav. */
+async function openMemoriesPanel(page: Page): Promise<void> {
+  await page.getByTestId("sidebar-nav-memories").click();
+  await expect(memoriesPanel(page)).toBeVisible({ timeout: 15000 });
+}
+
+/** Opens the Create Memory modal from the panel and returns its dialog. */
+async function openCreateMemoryModal(page: Page) {
+  await memoriesPanel(page)
+    .getByRole("button", { name: "Create", exact: true })
+    .click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible({ timeout: 15000 });
+  return dialog;
+}
+
+interface MemoryBaseRecord {
+  id: string;
+  name: string;
+  flow_id: string;
+  kb_name: string;
+  embedding_model: string;
+}
+
+/** Every memory base registered against one flow. */
+async function listMemoryBases(
+  request: APIRequestContext,
+  token: string,
+  flowId: string,
+): Promise<MemoryBaseRecord[]> {
+  const res = await request.get(
+    `${MEMORIES_API}?flow_id=${flowId}&page=1&size=50`,
+    { headers: { Authorization: token } },
+  );
+  expect(res.status(), `GET ${MEMORIES_API}?flow_id=${flowId}`).toBe(200);
+  return ((await res.json()) as { items: MemoryBaseRecord[] }).items;
+}
+
+/**
+ * `kb_name` is auto-generated by the server as `<sanitized name>_<8 hex>`, where
+ * the sanitizer lowercases and replaces runs of whitespace/hyphens with `_`.
+ * Asserting the shape is what lets the knowledge-base check look the backing KB
+ * up by the exact string the server chose, rather than by a name we invented.
+ */
+function expectedKbNamePattern(memoryName: string): RegExp {
+  const sanitized = memoryName.trim().toLowerCase().replace(/[\s-]+/g, "_");
+  return new RegExp(`^${sanitized}_[0-9a-f]{8}$`);
+}
+
+test.describe("core-functionality/memory — registering a memory base", () => {
+  let token: string;
+  let flowId: string;
+  let flowName: string;
+  /** Memory bases this test registered, deleted id-scoped in afterEach. */
+  let createdMemoryIds: string[];
+  /** Set only when the test flipped a model's enablement, to restore it. */
+  let flippedModel: EmbeddingChoice | null;
+
+  test.beforeEach(async ({ request }) => {
+    token = await getAuthToken(request);
+    createdMemoryIds = [];
+    flippedModel = null;
+    flowName = `memory-reg-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+    flowId = await createFlow(
+      request,
+      {
+        name: flowName,
+        description: "Empty flow for the §20.3 memory-base registration tests",
+        data: { nodes: [], edges: [], viewport: { x: 0, y: 0, zoom: 1 } },
+        is_component: false,
+      },
+      { headers: { Authorization: token } },
+    );
+  });
+
+  test.afterEach(async ({ page, request }) => {
+    // Leave the editor BEFORE deleting the flow: an editor mounted over a
+    // deleted flow 404s its own polls into the fixture's HTTP log.
+    await unmountEditorForCleanup(page);
+    for (const memoryId of createdMemoryIds) {
+      const res = await request.delete(`${MEMORIES_API}/${memoryId}`, {
+        headers: { Authorization: token },
+      });
+      expect(res.status(), `DELETE ${MEMORIES_API}/${memoryId}`).toBe(204);
+    }
+    if (flippedModel) {
+      await setModelEnabled(request, token, flippedModel, flippedModel.wasEnabled);
+    }
+    await deleteFlow(request, flowId, { headers: { Authorization: token } });
+  });
+
+  test("registering a memory base from the Create Memory modal persists it",
+    { tag: ["@stable", "@release", "@workspace", "@ui-ux", "@model-provider"] },
+    async ({ page, request }) => {
+      const choice = await findEmbeddingModel(request, token);
+      test.skip(
+        choice === null,
+        "no configured, enabled provider exposes an embeddings model on this instance — the Embedding Model picker cannot offer one, so registration is unreachable here",
+      );
+      const embedding = choice as EmbeddingChoice;
+
+      // Enabled BEFORE the page loads: the frontend caches the model list, so
+      // enabling it later leaves the picker reading `No Models Enabled` until
+      // `refresh-model-list` is clicked. Restored in afterEach.
+      if (!embedding.wasEnabled) {
+        await setModelEnabled(request, token, embedding, true);
+        flippedModel = embedding;
+      }
+
+      const memoryName = `mb-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+
+      await openFlowById(page, flowId);
+      await openMemoriesPanel(page);
+      const dialog = await openCreateMemoryModal(page);
+      const submit = dialog.getByRole("button", { name: "Create Memory" });
+
+      await test.step("the form is completed with a name and an embedding model", async () => {
+        await page.locator("#memory-name").fill(memoryName);
+        await page.locator("#memory-embedding-model").click();
+        await page
+          .getByRole("option", { name: embedding.modelId, exact: true })
+          .click();
+        // Both halves of "a model is chosen": the trigger carries the id, and
+        // the `Provider:` line renders only once one is.
+        await expect(page.locator("#memory-embedding-model")).toHaveText(
+          embedding.modelId,
+          { timeout: 15000 },
+        );
+        await expect(dialog.getByText(/^Provider: /)).toBeVisible();
+      });
+
+      await test.step("Create Memory becomes enabled and answers 201", async () => {
+        // The gate the sibling spec pins as disabled with Name alone: what
+        // released it here is the embedding model, and nothing else changed.
+        await expect(submit).toBeEnabled({ timeout: 15000 });
+        const [created] = await Promise.all([
+          page.waitForResponse(
+            (res) =>
+              res.url().includes(MEMORIES_API) &&
+              res.request().method() === "POST",
+            { timeout: 30000 },
+          ),
+          submit.click(),
+        ]);
+        expect(created.status()).toBe(201);
+        const body = (await created.json()) as MemoryBaseRecord;
+        createdMemoryIds.push(body.id);
+        expect(body.name).toBe(memoryName);
+        expect(body.flow_id).toBe(flowId);
+        expect(body.embedding_model).toBe(embedding.modelId);
+        // The server-assigned backing KB name, not one the test could predict.
+        expect(body.kb_name).toMatch(expectedKbNamePattern(memoryName));
+        await expect(dialog).toBeHidden({ timeout: 15000 });
+      });
+
+      await test.step("the memory base is listed in the panel", async () => {
+        await expect(
+          memoriesPanel(page).getByText(memoryName, { exact: true }),
+        ).toBeVisible({ timeout: 15000 });
+      });
+
+      await test.step("the API reports it for this flow", async () => {
+        // The endpoint the panel lists from — the panel alone could be showing
+        // optimistic local state, which is the failure mode #1399 names.
+        const items = await listMemoryBases(request, token, flowId);
+        expect(items).toHaveLength(1);
+        expect(items[0].id).toBe(createdMemoryIds[0]);
+        expect(items[0].name).toBe(memoryName);
+        expect(items[0].kb_name).toMatch(expectedKbNamePattern(memoryName));
+      });
+
+      await test.step("it survives a full page reload", async () => {
+        // The decisive half: client state cannot survive a reload, so a memory
+        // base rendered only into the store disappears here.
+        await page.reload();
+        await openMemoriesPanel(page);
+        await expect(
+          memoriesPanel(page).getByText(memoryName, { exact: true }),
+        ).toBeVisible({ timeout: 30000 });
+      });
+    });
+
+  test("a registered memory base is exposed through the Memory Base API, never through the knowledge-base list",
+    { tag: ["@stable", "@api", "@workspace", "@files"] },
+    async ({ request }) => {
+      // Registered through the API rather than the UI: this assertion is about
+      // the resource boundary, not about the form, and creating it this way
+      // needs no provider — so this half of the file has coverage on every
+      // instance, including one where test 1 skips.
+      const memoryName = `mb-api-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+      let kbName = "";
+
+      await test.step("POST /api/v1/memories registers it", async () => {
+        const res = await request.post(MEMORIES_API, {
+          headers: { Authorization: token },
+          data: {
+            name: memoryName,
+            flow_id: flowId,
+            embedding_model: "text-embedding-3-small",
+            threshold: 1,
+          },
+        });
+        expect(res.status()).toBe(201);
+        const body = (await res.json()) as MemoryBaseRecord;
+        createdMemoryIds.push(body.id);
+        kbName = body.kb_name;
+        expect(kbName).toMatch(expectedKbNamePattern(memoryName));
+      });
+
+      await test.step("the Memory Base API lists it", async () => {
+        const items = await listMemoryBases(request, token, flowId);
+        expect(items.map((item) => item.name)).toContain(memoryName);
+      });
+
+      await test.step("the generic knowledge-base list does not", async () => {
+        // Documented upstream behaviour, asserted rather than assumed:
+        // `list_knowledge_bases` skips KBs managed by a Memory Base. Issue #1399
+        // asks for the opposite; if upstream ever starts surfacing them here,
+        // this fails and the spec doc is revisited — which is the point.
+        const res = await request.get(KNOWLEDGE_BASES_API, {
+          headers: { Authorization: token },
+        });
+        expect(res.status()).toBe(200);
+        const kbs = (await res.json()) as Array<{ name?: string }>;
+        // By kb_name, the exact string the server assigned — matching on the
+        // memory's own name would pass even if the KB were listed under it.
+        expect(kbs.map((kb) => kb.name)).not.toContain(kbName);
+        expect(await res.text()).not.toContain(memoryName);
+      });
+    });
+});


### PR DESCRIPTION
Closes #1399.

Closes the `[ ] Registration End-to-End` gap in `QA-CHECKLIST.md` § 20.3 — the **write** half of the Memory Base surface. Its sibling `memory-base-panel.spec.ts` (#1398) owns the read half (panel, modal shape, defaults, submit gate) and creates no memory base; nothing here repeats it.

## 1. Covered tests

| # | Test | What it validates |
|---|------|-------------------|
| 1 | `registering a memory base from the Create Memory modal persists it` | Choosing an embedding model releases the submit gate the sibling spec pins as disabled; `POST /api/v1/memories/` answers **201** with `name`/`flow_id`/`embedding_model` as submitted and a server-assigned `kb_name` matching `^<sanitized name>_[0-9a-f]{8}$`; the dialog closes, the sentinel is listed in the Memories panel, `GET /api/v1/memories?flow_id=<id>` reports exactly that record, and the sentinel is **still in the panel after a full `page.reload()`**. Catches a registration that only ever existed in client state, and any drift in the created record's shape. Skips, naming the state, when no configured provider exposes an embeddings model |
| 2 | `a registered memory base is exposed through the Memory Base API, never through the knowledge-base list` | A memory base created through `POST /api/v1/memories` is listed by `GET /api/v1/memories` and its `kb_name` is **absent** from `GET /api/v1/knowledge_bases/`. Catches the resource boundary moving — if upstream starts surfacing memory-managed KBs in the generic list, this goes red and the spec doc is revisited |

## 2. How the test was built

**Two corrections to the issue's premise, both measured on the running nightly — they are the reason the spec looks different from what #1399 describes.**

- **`GET /api/v1/knowledge_bases` will never list a memory base.** Creating one leaves that list `[]`. It is deliberate, stated in the shipped source (`langflow/api/v1/knowledge_bases.py`, `list_knowledge_bases`): *"Skip KBs that are managed by a Memory Base — those are exposed through the Memory Base APIs, not the generic KB list."* Asserting presence there would fail forever, so the two-sided check the issue asked for is made against `/api/v1/memories` (the endpoint the panel itself lists from) **plus a page reload**, and the knowledge-base half is asserted as the absence the design states — falsifiable in the direction that can actually change.
- **A configured provider key is not the whole precondition.** With `OPENAI_API_KEY` configured, `GET /api/v1/models` reports openai `is_configured`/`is_enabled` with three embeddings models while `GET /api/v1/models/enabled_models` reports **all three `false`** — and the picker lists from the latter, which is how it reaches the `No Models Enabled` state the issue predicts. The spec enables one embeddings model through `POST /api/v1/models/enabled_models` **before the page loads** (the frontend caches the list; enabling later needs `refresh-model-list`) and restores the previous flag in cleanup. The write is an additive merge into the user's own enabled/disabled variable lists — read from the shipped source and measured — so it cannot disturb a parallel worker's model enablement.

**Setup:** an empty flow per test via `POST /api/v1/flows/` (`createFlow`), opened with `openFlowById` (seeds the assistant-onboarding flag so the welcome overlay cannot leave the editor chrome present-but-hidden). Test 2 registers its memory base through the API rather than the UI — the assertion is about the resource boundary, not the form, and that keeps this half of the file covering something on an instance where test 1 skips.

**Live-confirmed selectors** (harvested with `playwright-cli` against 1.12.0.dev22, none invented): `sidebar-nav-memories`; the panel scoped as the `aside` carrying the `Memories` heading; `#memory-name`; `#memory-embedding-model` (also `data-testid="memory-embedding-model"` / `value-dropdown-memory-embedding-model`); the model options as `role=option` named by model id. The submit button and the panel's list item carry **no** `data-testid` (the item is a plain `div`), so they resolve by role+name and by exact text scoped to the panel.

**Assertion rationale:** the panel alone could be optimistic local state — the failure mode #1399 names — so it is paired with the API list *and* re-read after a reload, which client state cannot survive. The `kb_name` pattern is asserted because it is what lets test 2 look the backing KB up by the exact string the server chose rather than by a name the test invented. The provider precondition is an API probe before the browser opens, never a `count()` on the control: that control is the shared model widget rendered without `showEmptyState`, so a `count() === 0` check would read a genuine regression removing it as "no provider configured".

## 3. Dependencies

- **Test 1:** a configured, enabled provider exposing an embedding model. **No inference call is made** — registration writes the KB directory and `embedding_metadata.json`; ingestion is out of scope (§20.4) — so a configured-but-drained key is sufficient. Without one it skips naming that state, never passing silently.
- **Test 2:** none. `POST /api/v1/memories` answers 201 with no provider configured (measured).
- Vector database is the bundled **Chroma Local** default; no external vector service.
- Parallel-safe: every test owns its flow and its memory base and deletes both id-scoped.

## Validation (nightly `1.12.0.dev22`, `--retries=0 --workers=1`)

- `npm run typecheck` ✅ · `npm run lint` ✅ (2 warnings, both the provider-dependent skip the issue requires: `playwright/no-skipped-test`, `playwright/no-conditional-in-test`)
- **3/3 clean burst runs**, `expected=2 unexpected=0 flaky=0`, zero `🚨 Backend Error` ✅
- **Force-fail, both tests** ✅ — (1) deleting the created memory base through the API right after the 201, before the panel/API/reload assertions read it → `unexpected=1`; (2) inverting the knowledge-base assertion to the issue's original premise (expect the `kb_name` to *be* listed) → `unexpected=1`. Both reverted, final green run `expected=2` with no `FF-MUTATION` marker left
- Cleanup audited after the runs: 0 flows, 0 memory bases, `knowledge_bases: []`, the embedding-model flag back to its prior value ✅

`@stable` from the first PR, on the same grounds as the sibling: test 2 is provider-free and deterministic, and test 1 skips loudly rather than failing when the daily's key is drained, so it cannot redden the daily for a credential reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
