### PR TITLE
Parameterise the browser locale — prerequisite for non-English coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,3 +240,12 @@ Key settings in `playwright.config.ts`:
 - Fully parallel, 5-minute timeout per test
 - 3 retries locally, 2 retries in CI; trace captured on first retry
 - HTML reporter locally, blob reporter in CI
+- Browser locale `en-US` by default, resolved by `tests/fixtures/locale.ts` rather than
+  hardcoded (#1400): a spec opts out with `test.use(withLocale("pt-BR"))`, a whole run
+  with `PW_LOCALE`, and an invalid tag aborts the config instead of falling back to
+  English. **It does not decide the language Langflow renders** — measured on
+  `1.12.0.dev20`, the UI reads `localStorage.languagePreference` and never
+  `navigator.language`, and the frontend pins `Accept-Language: i18n.language` on every
+  `/api/**` call, so the context locale reaches neither the UI strings nor the backend's
+  `set_locale` middleware. It governs `Intl` formatting and the document `Accept-Language`
+  only; `CONTRIBUTING.md` → *Browser locale* has the three-axis table

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,7 +245,13 @@ Key settings in `playwright.config.ts`:
   with `PW_LOCALE`, and an invalid tag aborts the config instead of falling back to
   English. **It does not decide the language Langflow renders** — measured on
   `1.12.0.dev20`, the UI reads `localStorage.languagePreference` and never
-  `navigator.language`, and the frontend pins `Accept-Language: i18n.language` on every
-  `/api/**` call, so the context locale reaches neither the UI strings nor the backend's
-  `set_locale` middleware. It governs `Intl` formatting and the document `Accept-Language`
-  only; `CONTRIBUTING.md` → *Browser locale* has the three-axis table
+  `navigator.language`, so under `pt-BR` every string stays English and `<html lang>`
+  stays `en`. What it does govern is `Intl` formatting and the document
+  `Accept-Language`. The backend's `set_locale` middleware is a **partial** third axis,
+  not a "no": Langflow localises by `Accept-Language` (`/api/v1/flows/basic_examples/` →
+  `Sugestões básicas` under `pt`), and while the frontend pins the header on the calls
+  that pass through its axios interceptors — 17 of 20 on the home screen — the other 3
+  (a `/api/` subresource, two `/api/v9/invites/` XHRs) carry the context locale, so a
+  spec asserting on the backend's locale must set the header itself. `CONTRIBUTING.md` →
+  *Browser locale* has the three-axis table and the measurement. Pinned behaviourally by
+  `tests/fixtures/locale-gate.spec.ts`, the sibling of the two error-policy gates

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,11 +131,36 @@ Use the maintained core equivalents instead. The canonical case:
 
 ---
 
-## Browser locale is pinned to `en-US`
+## Browser locale — `en-US` by default, opt-in per spec
 
-`playwright.config.ts` pins the browser context locale (and the `Accept-Language` header) to `en-US` for every test in every project. The suite asserts on English strings throughout — toast titles, button labels, status messages, upstream error text — so the locale must stay fixed regardless of host machine settings, CI runner defaults, or future i18n locale detection in Langflow.
+`playwright.config.ts` runs every test in every project under `en-US` (#225). The suite asserts on English strings throughout — toast titles, button labels, status messages, upstream error text — so the default must stay fixed regardless of host machine settings or CI runner defaults, and **changing it is not a per-spec decision**.
 
-Do **not** override `locale` per test or per project. If a test ever needs a non-English locale (e.g. deliberate multi-locale coverage), that is a separate, parameterised concern — raise it as its own issue rather than editing the shared default.
+Do **not** write `test.use({ locale })` directly. A spec that genuinely needs a different browser locale opts in through the one sanctioned helper (#1400), which validates the tag at collection time and keeps every opt-out findable with a single grep:
+
+```ts
+import { withLocale } from "../../../fixtures/locale";
+
+test.describe("date rendering under a non-English locale", () => {
+  test.use(withLocale("pt-BR"));
+  // …
+});
+```
+
+A whole run can be moved with `PW_LOCALE=pt-BR npx playwright test …`. The config announces the override on stderr and **refuses** an invalid tag (including the POSIX spelling `pt_BR`) rather than falling back to English behind your back.
+
+### What the locale does and does not change
+
+Measured on Langflow Nightly `1.12.0.dev20`, two browser contexts identical except `locale` (#1400). Non-English behaviour has **three independent axes**, and this option governs only the middle one:
+
+| Axis | Controlled by | Changes with `locale`? |
+|---|---|---|
+| The language the UI renders | `localStorage.languagePreference`, written by the language selector in the app header and in Settings → General | **No.** `<html lang>` stays `en` and every string stays English |
+| `Intl` formatting + the document/asset `Accept-Language` | the browser context `locale` | **Yes.** The same instant renders `12/31/1969, 9:00:00 PM` vs `31/12/1969, 21:00:00` |
+| The locale the backend's `set_locale` middleware sees | the frontend pins `Accept-Language: i18n.language` on every `/api/**` call | **No.** A spec that needs this sets `extraHTTPHeaders` on a direct API request |
+
+`src/frontend/src/i18n.ts` reads `localStorage.getItem("languagePreference")` (default `"en"`) and never consults `navigator.language` — there is no language-detector plugin. So a test that needs a **translated UI** must drive the language selector or seed that key; changing the browser locale will not do it, and assuming it does is how such a spec fails and gets misdiagnosed as a product bug.
+
+For the same reason `withLocale()` sets **only** `locale`: bundling `extraHTTPHeaders: { "Accept-Language": … }` into it would override the header the frontend sets per request, leaving the app announcing one language to the backend while rendering another — a state no product build can reach.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,11 +156,13 @@ Measured on Langflow Nightly `1.12.0.dev20`, two browser contexts identical exce
 |---|---|---|
 | The language the UI renders | `localStorage.languagePreference`, written by the language selector in the app header and in Settings → General | **No.** `<html lang>` stays `en` and every string stays English |
 | `Intl` formatting + the document/asset `Accept-Language` | the browser context `locale` | **Yes.** The same instant renders `12/31/1969, 9:00:00 PM` vs `31/12/1969, 21:00:00` |
-| The locale the backend's `set_locale` middleware sees | the frontend pins `Accept-Language: i18n.language` on every `/api/**` call | **No.** A spec that needs this sets `extraHTTPHeaders` on a direct API request |
+| The locale the backend's `set_locale` middleware sees | the frontend pins `Accept-Language: i18n.language` on the calls that go through its axios interceptors — but not on everything | **Partly, by leakage.** 17 of the 20 `/api/` requests the home screen makes sent `en` under `locale: "pt-BR"`; 3 carried `pt-BR` |
 
 `src/frontend/src/i18n.ts` reads `localStorage.getItem("languagePreference")` (default `"en"`) and never consults `navigator.language` — there is no language-detector plugin. So a test that needs a **translated UI** must drive the language selector or seed that key; changing the browser locale will not do it, and assuming it does is how such a spec fails and gets misdiagnosed as a product bug.
 
-For the same reason `withLocale()` sets **only** `locale`: bundling `extraHTTPHeaders: { "Accept-Language": … }` into it would override the header the frontend sets per request, leaving the app announcing one language to the backend while rendering another — a state no product build can reach.
+The third row cuts both ways, so do not rely on it in either direction. The backend really does localise — `GET /api/v1/flows/basic_examples/` returns `Basic Prompting` under `Accept-Language: en` and `Sugestões básicas` under `pt` — and the context locale really does reach it on the requests the interceptor never sees: a browser-issued subresource (`/api/v1/files/profile_pictures/…svg`) and two `/api/v9/invites/…` XHRs, in that measurement. **A spec whose subject is the backend's locale must set `Accept-Language` explicitly** via `extraHTTPHeaders` on a direct API request rather than infer it from the context.
+
+That split is also why `withLocale()` sets **only** `locale`. Bundling `extraHTTPHeaders: { "Accept-Language": … }` into it would change those leaked requests, and its precedence against the header the interceptor assigns per request is unmeasured — turning the language the backend sees into a per-request race between two layers, inside a helper whose whole job is to make one axis explicit.
 
 ---
 

--- a/playwright.config.test.ts
+++ b/playwright.config.test.ts
@@ -45,9 +45,15 @@ const PLAYWRIGHT_CLI = path.join(REPO_ROOT, "node_modules", "@playwright", "test
  *    invisibly. That means requiring the config by absolute path and pointing
  *    ts-node at the repo tsconfig explicitly, since it resolves from cwd too.
  */
-function importConfig(env: Record<string, string> = {}): { stdout: string; stderr: string } {
+function importConfig(
+  env: Record<string, string> = {},
+  { allowFailure = false }: { allowFailure?: boolean } = {},
+): { stdout: string; stderr: string; status: number | null } {
   const base = { ...process.env };
   delete base.PW_DESTRUCTIVE;
+  // Same hermetic reason as PW_DESTRUCTIVE: the locale override (#1400) is an
+  // exported variable a developer may well have set in the shell that runs these.
+  delete base.PW_LOCALE;
 
   const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "config-1024-"));
   try {
@@ -72,8 +78,48 @@ function importConfig(env: Record<string, string> = {}): { stdout: string; stder
         },
       },
     );
-    assert.equal(run.status, 0, `importing the config failed: ${run.stderr}`);
-    return { stdout: run.stdout, stderr: run.stderr };
+    if (!allowFailure) {
+      assert.equal(run.status, 0, `importing the config failed: ${run.stderr}`);
+    }
+    return { stdout: run.stdout, stderr: run.stderr, status: run.status };
+  } finally {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
+}
+
+/**
+ * The resolved `use.locale` of a real config import (#1400).
+ *
+ * Reads the value the runner would actually consume rather than re-deriving it
+ * from `resolveRunLocale` — `locale.test.ts` already covers the resolution, and
+ * what is unproven without this is the WIRING: that the config still puts it in
+ * `use`, under the key Playwright reads.
+ */
+function configLocale(env: Record<string, string> = {}): string {
+  const base = { ...process.env };
+  delete base.PW_DESTRUCTIVE;
+  delete base.PW_LOCALE;
+
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "config-1400-"));
+  try {
+    return execFileSync(
+      process.execPath,
+      [
+        "--require",
+        require.resolve("ts-node/register"),
+        "-e",
+        `const c = require(${JSON.stringify(path.join(REPO_ROOT, "playwright.config.ts"))});` +
+          `process.stdout.write(String((c.default ?? c).use.locale));`,
+      ],
+      {
+        cwd,
+        encoding: "utf-8",
+        env: { ...base, ...env, TS_NODE_PROJECT: path.join(REPO_ROOT, "tsconfig.json") },
+        // stderr piped and dropped: the config announces the @destructive
+        // exclusion on every import, and this reader is only after the value.
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
   } finally {
     fs.rmSync(cwd, { recursive: true, force: true });
   }
@@ -102,6 +148,47 @@ test("stdout stays clean in the destructive lane too", () => {
   assert.equal(stdout, "");
   // Inside the lane there is nothing to announce — the tests are running.
   assert.doesNotMatch(stderr, /@destructive tests are excluded/);
+});
+
+// --- Browser locale (#1400) -------------------------------------------------
+// The suite's default must survive the parameterisation: every English-string
+// assertion depends on `use.locale` still being en-US when nothing asks otherwise.
+
+test("the default run is still pinned to en-US", () => {
+  assert.equal(configLocale(), "en-US");
+});
+
+test("PW_LOCALE reaches use.locale", () => {
+  // Canonicalised on the way through, so a lowercase dispatch value works.
+  assert.equal(configLocale({ PW_LOCALE: "pt-br" }), "pt-BR");
+});
+
+test("an override announces itself on stderr, and stdout stays clean", () => {
+  // Same contract as the @destructive notice (#1010/#1024): visible in the log,
+  // off the data path the daily's shard matrix parses.
+  const { stdout, stderr } = importConfig({ PW_LOCALE: "pt-BR" });
+  assert.equal(
+    stdout,
+    "",
+    `the locale notice must not reach stdout — it would break the shard-matrix ` +
+      `JSON contract. Got: ${JSON.stringify(stdout)}`,
+  );
+  assert.match(stderr, /browser locale overridden to pt-BR/);
+  assert.match(stderr, /PW_LOCALE/);
+});
+
+test("a run at the default locale says nothing about locale at all", () => {
+  const { stderr } = importConfig();
+  assert.doesNotMatch(stderr, /browser locale overridden/);
+});
+
+test("an unusable PW_LOCALE aborts the config with the cause named", () => {
+  // Fail-closed: the alternative is the whole suite silently running in en-US
+  // under a command line that asked for something else.
+  const { status, stderr } = importConfig({ PW_LOCALE: "pt_BR" }, { allowFailure: true });
+  assert.notEqual(status, 0, "an invalid locale must abort, not fall back");
+  assert.match(stderr, /PW_LOCALE/);
+  assert.match(stderr, /pt_BR/);
 });
 
 test("the daily's prep command produces parseable JSON", () => {

--- a/playwright.config.test.ts
+++ b/playwright.config.test.ts
@@ -163,6 +163,45 @@ test("PW_LOCALE reaches use.locale", () => {
   assert.equal(configLocale({ PW_LOCALE: "pt-br" }), "pt-BR");
 });
 
+test("no project shadows the resolved locale", () => {
+  // The two tests above read the GLOBAL `use`, and Playwright resolves
+  // `project.use` over it — so a `locale` added to any project (easy to do next
+  // to the `...devices["Desktop Chrome"]` spread, which carries no locale key of
+  // its own today) would pin every run to that value with both of them still
+  // green, and PW_LOCALE would silently stop working. Assert the absence
+  // directly; `tests/fixtures/locale-gate.spec.ts` catches the same mutation from
+  // the browser side, and neither is redundant: this one runs with no backend.
+  const projects = JSON.parse(
+    execFileSync(
+      process.execPath,
+      [
+        "--require",
+        require.resolve("ts-node/register"),
+        "-e",
+        `const c = require(${JSON.stringify(path.join(REPO_ROOT, "playwright.config.ts"))});` +
+          `process.stdout.write(JSON.stringify(((c.default ?? c).projects ?? []).map((p) => ` +
+          `({ name: p.name, locale: (p.use ?? {}).locale ?? null }))));`,
+      ],
+      {
+        cwd: REPO_ROOT,
+        encoding: "utf-8",
+        env: { ...process.env, TS_NODE_PROJECT: path.join(REPO_ROOT, "tsconfig.json") },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    ),
+  ) as Array<{ name: string; locale: string | null }>;
+
+  assert.ok(projects.length > 0, "the config declares no projects at all");
+  for (const project of projects) {
+    assert.equal(
+      project.locale,
+      null,
+      `project "${project.name}" sets its own locale, which overrides the ` +
+        `resolved one and makes PW_LOCALE a no-op`,
+    );
+  }
+});
+
 test("an override announces itself on stderr, and stdout stays clean", () => {
   // Same contract as the @destructive notice (#1010/#1024): visible in the log,
   // off the data path the daily's shard matrix parses.

--- a/playwright.config.test.ts
+++ b/playwright.config.test.ts
@@ -27,6 +27,9 @@ const REPO_ROOT = __dirname;
 /** The local CLI entrypoint. NOT `npx`, which downloads from the registry when the
  *  binary is missing instead of failing — a test must not be able to reach the network. */
 const PLAYWRIGHT_CLI = path.join(REPO_ROOT, "node_modules", "@playwright", "test", "cli.js");
+/** Absolute: every child below runs from an empty cwd, so a relative specifier
+ *  would resolve against that instead of the repo. */
+const CONFIG_PATH = path.join(REPO_ROOT, "playwright.config.ts");
 
 /**
  * Import the config in a FRESH process and hand back what each stream received.
@@ -66,7 +69,7 @@ function importConfig(
         // Absolute: a bare specifier would be resolved against the empty cwd.
         require.resolve("ts-node/register"),
         "-e",
-        `require(${JSON.stringify(path.join(REPO_ROOT, "playwright.config.ts"))});`,
+        `require(${JSON.stringify(CONFIG_PATH)});`,
       ],
       {
         cwd,
@@ -88,14 +91,22 @@ function importConfig(
 }
 
 /**
- * The resolved `use.locale` of a real config import (#1400).
+ * Evaluate `expr` against a real config import in a FRESH process and hand back
+ * whatever it wrote to stdout. `expr` reads the imported config as `config`.
  *
- * Reads the value the runner would actually consume rather than re-deriving it
- * from `resolveRunLocale` — `locale.test.ts` already covers the resolution, and
- * what is unproven without this is the WIRING: that the config still puts it in
- * `use`, under the key Playwright reads.
+ * Hermetic in exactly the two ways `importConfig` is, and every reader below
+ * needs both: `PW_LOCALE`/`PW_DESTRUCTIVE` are stripped from the inherited env
+ * and the child runs from an EMPTY cwd, since `playwright.config.ts` calls
+ * `dotenv.config()` and would otherwise pick the same variables out of the
+ * developer-local, git-ignored `.env`. A locale exported in the shell shadows the
+ * value one reader asserts on, and an INVALID one (`pt_BR` — the very shape the
+ * fail-closed test feeds on purpose) aborts the import, which would fail the
+ * project reader for a reason that has nothing to do with what it checks.
  */
-function configLocale(env: Record<string, string> = {}): string {
+function readFromConfig(
+  expr: string,
+  env: Record<string, string> = {},
+): string {
   const base = { ...process.env };
   delete base.PW_DESTRUCTIVE;
   delete base.PW_LOCALE;
@@ -108,21 +119,34 @@ function configLocale(env: Record<string, string> = {}): string {
         "--require",
         require.resolve("ts-node/register"),
         "-e",
-        `const c = require(${JSON.stringify(path.join(REPO_ROOT, "playwright.config.ts"))});` +
-          `process.stdout.write(String((c.default ?? c).use.locale));`,
+        `const c = require(${JSON.stringify(CONFIG_PATH)});` +
+          `const config = c.default ?? c;` +
+          `process.stdout.write(String(${expr}));`,
       ],
       {
         cwd,
         encoding: "utf-8",
         env: { ...base, ...env, TS_NODE_PROJECT: path.join(REPO_ROOT, "tsconfig.json") },
         // stderr piped and dropped: the config announces the @destructive
-        // exclusion on every import, and this reader is only after the value.
+        // exclusion on every import, and these readers are only after the value.
         stdio: ["ignore", "pipe", "pipe"],
       },
     );
   } finally {
     fs.rmSync(cwd, { recursive: true, force: true });
   }
+}
+
+/**
+ * The resolved `use.locale` of a real config import (#1400).
+ *
+ * Reads the value the runner would actually consume rather than re-deriving it
+ * from `resolveRunLocale` — `locale.test.ts` already covers the resolution, and
+ * what is unproven without this is the WIRING: that the config still puts it in
+ * `use`, under the key Playwright reads.
+ */
+function configLocale(env: Record<string, string> = {}): string {
+  return readFromConfig("config.use.locale", env);
 }
 
 test("importing playwright.config.ts writes NOTHING to stdout", () => {
@@ -171,23 +195,14 @@ test("no project shadows the resolved locale", () => {
   // green, and PW_LOCALE would silently stop working. Assert the absence
   // directly; `tests/fixtures/locale-gate.spec.ts` catches the same mutation from
   // the browser side, and neither is redundant: this one runs with no backend.
+  //
+  // Through the same hermetic reader as `configLocale`: what this asserts is
+  // independent of the resolved locale, so an exported PW_LOCALE must not be able
+  // to decide whether it passes.
   const projects = JSON.parse(
-    execFileSync(
-      process.execPath,
-      [
-        "--require",
-        require.resolve("ts-node/register"),
-        "-e",
-        `const c = require(${JSON.stringify(path.join(REPO_ROOT, "playwright.config.ts"))});` +
-          `process.stdout.write(JSON.stringify(((c.default ?? c).projects ?? []).map((p) => ` +
-          `({ name: p.name, locale: (p.use ?? {}).locale ?? null }))));`,
-      ],
-      {
-        cwd: REPO_ROOT,
-        encoding: "utf-8",
-        env: { ...process.env, TS_NODE_PROJECT: path.join(REPO_ROOT, "tsconfig.json") },
-        stdio: ["ignore", "pipe", "pipe"],
-      },
+    readFromConfig(
+      `JSON.stringify((config.projects ?? []).map((p) => ` +
+        `({ name: p.name, locale: (p.use ?? {}).locale ?? null })))`,
     ),
   ) as Array<{ name: string; locale: string | null }>;
 
@@ -234,10 +249,25 @@ test("the daily's prep command produces parseable JSON", () => {
   // The end-to-end assertion, run exactly as `daily-stable.yml`'s `prep` job does
   // (line 81) rather than trusting the unit checks above to imply it. Kept to
   // `--list`, so nothing executes and no backend is needed.
+  //
+  // cwd stays REPO_ROOT — running as the daily runs is the whole point — but the
+  // inherited PW_LOCALE/PW_DESTRUCTIVE go, for the reason `readFromConfig`
+  // documents: the daily sets neither, and an invalid locale exported in the
+  // developer's shell aborts the config, turning a stdout-contract failure into
+  // one about the shell.
+  const prepEnv = { ...process.env };
+  delete prepEnv.PW_LOCALE;
+  delete prepEnv.PW_DESTRUCTIVE;
   const listed = execFileSync(
     process.execPath,
     [PLAYWRIGHT_CLI, "test", "--grep", "@stable", "--list", "--reporter=json"],
-    { cwd: REPO_ROOT, encoding: "utf-8", maxBuffer: 64 * 1024 * 1024, stdio: ["ignore", "pipe", "ignore"] },
+    {
+      cwd: REPO_ROOT,
+      encoding: "utf-8",
+      env: prepEnv,
+      maxBuffer: 64 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "ignore"],
+    },
   );
 
   const report = JSON.parse(listed) as { suites?: unknown[] };

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig, devices } from "@playwright/test";
 import * as dotenv from "dotenv";
+import { resolveRunLocale } from "./tests/fixtures/locale";
 
 dotenv.config();
 
@@ -47,6 +48,17 @@ if (!DESTRUCTIVE_LANE) {
   console.error(
     "[lane] @destructive tests are excluded from this run — run them with: PW_DESTRUCTIVE=1 npx playwright test --grep @destructive",
   );
+}
+
+/**
+ * Browser locale for this run (#1400). `en-US` unless PW_LOCALE asks otherwise;
+ * an unusable value throws here instead of falling back to English, and a real
+ * override announces itself — on stderr, never stdout (#1024, see the notice's
+ * doc in `tests/fixtures/locale.ts`).
+ */
+const RUN_LOCALE = resolveRunLocale();
+if (RUN_LOCALE.notice) {
+  console.error(RUN_LOCALE.notice);
 }
 
 export default defineConfig({
@@ -120,10 +132,15 @@ export default defineConfig({
 
   use: {
     baseURL: BASE_URL,
-    // Pin the browser context locale (and Accept-Language header) so the
-    // English-string assertions throughout the suite stay stable regardless
-    // of host machine settings or future i18n locale detection. See issue #225.
-    locale: "en-US",
+    // The browser context locale (and the document `Accept-Language`), pinned so
+    // the English-string assertions throughout the suite stay stable regardless
+    // of host machine or CI runner settings (#225). It is a resolved value rather
+    // than a literal since #1400: a spec opts out per describe with
+    // `test.use(withLocale("pt-BR"))`, and a whole run with PW_LOCALE. It does
+    // NOT decide the language Langflow renders — that comes from
+    // localStorage.languagePreference; `tests/fixtures/locale.ts` has the
+    // measurement and the other two axes.
+    locale: RUN_LOCALE.locale,
     actionTimeout: 20000,
     trace: "on-first-retry",
     screenshot: process.env.CI ? "only-on-failure" : "off",

--- a/tests/fixtures/locale-gate.spec.ts
+++ b/tests/fixtures/locale-gate.spec.ts
@@ -72,9 +72,17 @@ test.describe("browser locale — withLocale() opts a describe block out", () =>
       // Asserted through `Intl` as well as `navigator.language`: the option is
       // only worth having because it changes formatting, and a stub that set the
       // navigator property alone would pass the line above.
-      expect(await page.evaluate(() => new Date(0).toLocaleString())).toContain(
-        "31/12/1969",
-      );
+      //
+      // NUMBER formatting, not a date. The first version of this gate asserted
+      // `new Date(0).toLocaleString()` contained "31/12/1969" — which is true
+      // only in a negative-UTC-offset zone. It passed on a UTC-3 laptop and
+      // failed on the UTC CI runner, where epoch 0 is "01/01/1970, 00:00:00":
+      // a locale assertion that was really reading the TIMEZONE. Number grouping
+      // and the decimal separator differ between en-US (1,234.5) and pt-BR
+      // (1.234,5) with no clock involved.
+      expect(
+        await page.evaluate(() => new Intl.NumberFormat().format(1234.5)),
+      ).toBe("1.234,5");
     },
   );
 });

--- a/tests/fixtures/locale-gate.spec.ts
+++ b/tests/fixtures/locale-gate.spec.ts
@@ -1,0 +1,80 @@
+// Behavioural gate for the browser-locale parameterisation (#1400).
+//
+// The pure resolution lives next door in `locale.test.ts`, where
+// `npm run test:units` covers it, and `playwright.config.test.ts` pins the
+// wiring at config level. What THIS pins is the only half neither can reach:
+// that the resolved value actually arrives in a **browser context**, and that
+// `withLocale()` overrides it there.
+//
+// Both sibling policy modules in this directory ship exactly this pairing —
+// `http-error-policy.ts` + `http-error-gate.spec.ts`, `flow-error-policy.ts` +
+// `flow-error-gate.spec.ts`. Without it the runtime half is provable only by a
+// throwaway script somebody runs once by hand, and nothing in CI notices the day
+// Playwright renames the option or a project-level `use` starts shadowing it.
+//
+// It navigates nowhere and needs no Langflow state: `navigator.language` and
+// `Intl` are answerable on the blank page every test starts on.
+//
+// TWO THINGS IT DELIBERATELY DOES NOT ASSERT:
+//  - that Langflow's UI stays English under a non-default locale. It does
+//    (measured on 1.12.0.dev20, and `CONTRIBUTING.md` records why), but the day
+//    upstream adds locale detection that becomes a product change worth a
+//    dedicated i18n spec's verdict — not a red in the daily's fixture gate.
+//  - the `Accept-Language` the backend ends up seeing. That is a per-request
+//    split between the frontend's axios interceptor and the context locale
+//    (17 / 3 on the home screen); a spec whose subject is the backend's locale
+//    sets the header explicitly. See `locale.ts`, axis 3.
+import { expect, test } from "./fixtures";
+import { DEFAULT_LOCALE, resolveRunLocale, withLocale } from "./locale";
+
+// Not hardcoded to en-US: under `PW_LOCALE=pt-BR` the whole run legitimately
+// moves, and a gate asserting the constant would fail the exact scenario the
+// parameterisation exists for. This is also what catches a project-level
+// `use.locale`, which would shadow the resolved value while every unit test
+// stays green.
+const EXPECTED_RUN_LOCALE = resolveRunLocale().locale;
+
+test.describe("browser locale — the resolved default reaches the context", () => {
+  test(
+    "the run executes under the resolved locale",
+    { tag: ["@stable", "@regression"] },
+    async ({ page }) => {
+      expect(await page.evaluate(() => navigator.language)).toBe(
+        EXPECTED_RUN_LOCALE,
+      );
+    },
+  );
+
+  test(
+    "an untouched run is en-US",
+    { tag: ["@stable", "@regression"] },
+    async ({ page }) => {
+      // The suite's English-string assertions depend on this, so it is asserted
+      // as itself rather than inferred from the test above — but skipped when the
+      // operator asked for something else, which is not a failure.
+      test.skip(
+        EXPECTED_RUN_LOCALE !== DEFAULT_LOCALE,
+        `PW_LOCALE moved this run to ${EXPECTED_RUN_LOCALE}`,
+      );
+      expect(await page.evaluate(() => navigator.language)).toBe("en-US");
+    },
+  );
+});
+
+test.describe("browser locale — withLocale() opts a describe block out", () => {
+  test.use(withLocale("pt-BR"));
+
+  test(
+    "the opted-in block runs under its own locale, whatever the run's is",
+    { tag: ["@stable", "@regression"] },
+    async ({ page }) => {
+      expect(await page.evaluate(() => navigator.language)).toBe("pt-BR");
+      // Asserted through `Intl` as well as `navigator.language`: the option is
+      // only worth having because it changes formatting, and a stub that set the
+      // navigator property alone would pass the line above.
+      expect(await page.evaluate(() => new Date(0).toLocaleString())).toContain(
+        "31/12/1969",
+      );
+    },
+  );
+});

--- a/tests/fixtures/locale.test.ts
+++ b/tests/fixtures/locale.test.ts
@@ -1,0 +1,123 @@
+// Unit tests for the browser-locale parameterisation (#1400).
+// Run with: npm run test:units
+//
+// The whole point of extracting this from `playwright.config.ts` is that these
+// branches are answerable without launching a browser: what a run resolves to,
+// what it announces, and what it refuses. The wiring half — that the config
+// actually puts this value in `use.locale` and prints the notice off stdout —
+// lives in `playwright.config.test.ts`, because only a real config import can
+// prove it.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_LOCALE,
+  LANGFLOW_UI_LANGUAGES,
+  LOCALE_ENV_VAR,
+  canonicalLocale,
+  resolveRunLocale,
+  withLocale,
+} from "./locale";
+
+test("an unset, empty or whitespace PW_LOCALE resolves to the default", () => {
+  // Empty is the shell's idea of "not set" (`export PW_LOCALE=`), and must not be
+  // read as a request for an invalid locale.
+  for (const env of [{}, { [LOCALE_ENV_VAR]: "" }, { [LOCALE_ENV_VAR]: "  " }]) {
+    const resolved = resolveRunLocale(env);
+    assert.equal(resolved.locale, DEFAULT_LOCALE);
+    assert.equal(resolved.source, "default");
+    assert.equal(
+      resolved.notice,
+      undefined,
+      "a default run must announce nothing — the notice marks a changed run",
+    );
+  }
+});
+
+test("the default is en-US", () => {
+  // Pinned as its own assertion: every English-string assertion in the suite
+  // depends on it, so a change here has to be a deliberate edit to this test too.
+  assert.equal(DEFAULT_LOCALE, "en-US");
+  assert.equal(resolveRunLocale({}).locale, "en-US");
+});
+
+test("PW_LOCALE overrides the run and is canonicalised", () => {
+  const resolved = resolveRunLocale({ [LOCALE_ENV_VAR]: "pt-br" });
+  assert.equal(resolved.locale, "pt-BR");
+  assert.equal(resolved.source, "env");
+});
+
+test("an override announces what it changed, and how to undo it", () => {
+  // #1010's rule: a run whose meaning changed must say so. The three facts a
+  // reader needs are the locale, that English assertions now run under it, and
+  // that this does NOT translate the Langflow UI — the misreading this whole
+  // mechanism exists to prevent.
+  const notice = resolveRunLocale({ [LOCALE_ENV_VAR]: "pt-BR" }).notice ?? "";
+  assert.match(notice, /pt-BR/);
+  assert.match(notice, new RegExp(LOCALE_ENV_VAR));
+  assert.match(notice, /English-string assertion/);
+  assert.match(notice, /languagePreference/);
+  assert.match(notice, /en-US/, "the notice must name the way back");
+});
+
+test("asking for the default explicitly changes nothing and announces nothing", () => {
+  const resolved = resolveRunLocale({ [LOCALE_ENV_VAR]: "en-US" });
+  assert.equal(resolved.locale, DEFAULT_LOCALE);
+  assert.equal(resolved.source, "env");
+  assert.equal(resolved.notice, undefined);
+});
+
+test("an unusable PW_LOCALE throws instead of falling back to English", () => {
+  // Fail-closed (#1012): the alternative is a full suite running in en-US under a
+  // command line that asked for something else, with nothing in the log saying so.
+  for (const bad of ["pt_BR", "en-US-", "!", "en US"]) {
+    assert.throws(
+      () => resolveRunLocale({ [LOCALE_ENV_VAR]: bad }),
+      (err: Error) =>
+        err.message.includes(LOCALE_ENV_VAR) &&
+        err.message.includes(JSON.stringify(bad)),
+      `${bad} must be rejected, naming the variable and the value`,
+    );
+  }
+});
+
+test("the POSIX spelling is called out by name", () => {
+  // The one slip this is actually likely to see, and the one whose fix is not
+  // obvious from a RangeError.
+  assert.throws(
+    () => resolveRunLocale({ [LOCALE_ENV_VAR]: "pt_BR" }),
+    /pt_BR/,
+  );
+});
+
+test("withLocale returns a canonicalised, test.use-shaped object", () => {
+  assert.deepEqual(withLocale("pt-br"), { locale: "pt-BR" });
+  assert.deepEqual(withLocale("  ja  "), { locale: "ja" });
+});
+
+test("withLocale sets ONLY locale", () => {
+  // Load-bearing, not cosmetic. Measured on 1.12.0.dev20: the frontend pins
+  // `Accept-Language: i18n.language` on every /api/** call, so adding
+  // `extraHTTPHeaders` here would override it and leave the app announcing one
+  // language to the backend while rendering another — a state no product build
+  // can reach, and therefore a test asserting nothing real.
+  assert.deepEqual(Object.keys(withLocale("de-DE")), ["locale"]);
+});
+
+test("withLocale names itself when the tag is unusable", () => {
+  assert.throws(() => withLocale("pt_BR"), /withLocale\(\)/);
+  assert.throws(() => withLocale(""), /withLocale\(\)/);
+});
+
+test("the browser locale is not validated against Langflow's UI bundles", () => {
+  // The two are independent axes (see locale.ts). A locale with no bundle is a
+  // legitimate ask — it changes Intl formatting — and one WITH a bundle still
+  // does not translate the UI, so validating against this list would be wrong in
+  // both directions.
+  assert.deepEqual(withLocale("it-IT"), { locale: "it-IT" });
+  assert.ok(!LANGFLOW_UI_LANGUAGES.includes("it" as never));
+  assert.ok(LANGFLOW_UI_LANGUAGES.includes("pt"));
+});
+
+test("canonicalLocale reports the source it was given", () => {
+  assert.throws(() => canonicalLocale("nope_NOPE", "some caller"), /some caller/);
+});

--- a/tests/fixtures/locale.test.ts
+++ b/tests/fixtures/locale.test.ts
@@ -24,7 +24,6 @@ test("an unset, empty or whitespace PW_LOCALE resolves to the default", () => {
   for (const env of [{}, { [LOCALE_ENV_VAR]: "" }, { [LOCALE_ENV_VAR]: "  " }]) {
     const resolved = resolveRunLocale(env);
     assert.equal(resolved.locale, DEFAULT_LOCALE);
-    assert.equal(resolved.source, "default");
     assert.equal(
       resolved.notice,
       undefined,
@@ -41,9 +40,7 @@ test("the default is en-US", () => {
 });
 
 test("PW_LOCALE overrides the run and is canonicalised", () => {
-  const resolved = resolveRunLocale({ [LOCALE_ENV_VAR]: "pt-br" });
-  assert.equal(resolved.locale, "pt-BR");
-  assert.equal(resolved.source, "env");
+  assert.equal(resolveRunLocale({ [LOCALE_ENV_VAR]: "pt-br" }).locale, "pt-BR");
 });
 
 test("an override announces what it changed, and how to undo it", () => {
@@ -62,7 +59,6 @@ test("an override announces what it changed, and how to undo it", () => {
 test("asking for the default explicitly changes nothing and announces nothing", () => {
   const resolved = resolveRunLocale({ [LOCALE_ENV_VAR]: "en-US" });
   assert.equal(resolved.locale, DEFAULT_LOCALE);
-  assert.equal(resolved.source, "env");
   assert.equal(resolved.notice, undefined);
 });
 
@@ -95,12 +91,21 @@ test("withLocale returns a canonicalised, test.use-shaped object", () => {
 });
 
 test("withLocale sets ONLY locale", () => {
-  // Load-bearing, not cosmetic. Measured on 1.12.0.dev20: the frontend pins
-  // `Accept-Language: i18n.language` on every /api/** call, so adding
-  // `extraHTTPHeaders` here would override it and leave the app announcing one
-  // language to the backend while rendering another — a state no product build
-  // can reach, and therefore a test asserting nothing real.
+  // Load-bearing, not cosmetic. Measured on 1.12.0.dev20: 17 of the 20 /api/
+  // requests the home screen makes carry the header the frontend's axios
+  // interceptor pins, and 3 carry the context locale. Adding `extraHTTPHeaders`
+  // here would change those 3 and race the interceptor on the other 17 — see
+  // locale.ts, axis 3.
   assert.deepEqual(Object.keys(withLocale("de-DE")), ["locale"]);
+});
+
+test("the one well-formed tag Chromium refuses is rejected here", () => {
+  // `und` passes Intl.getCanonicalLocales but kills newContext() with
+  // "Protocol error (Emulation.setLocaleOverride): Invalid locale name" — the
+  // opaque browser-launch failure this validation claims to prevent. Measured
+  // against the repo's pinned Chromium.
+  assert.throws(() => withLocale("und"), /Chromium refuses/);
+  assert.throws(() => resolveRunLocale({ [LOCALE_ENV_VAR]: "und" }), /und/);
 });
 
 test("withLocale names itself when the tag is unusable", () => {

--- a/tests/fixtures/locale.ts
+++ b/tests/fixtures/locale.ts
@@ -29,17 +29,27 @@
  * 2. **`Intl` formatting and the document/asset `Accept-Language` ARE.** The same
  *    instant renders `12/31/1969, 9:00:00 PM` under en-US and `31/12/1969,
  *    21:00:00` under pt-BR. This is the axis the option exists for.
- * 3. **The backend's locale is NOT.** Langflow's `set_locale` middleware
- *    (`src/backend/base/langflow/main.py`) reads `Accept-Language`, but the
- *    frontend's axios layer pins `Accept-Language: i18n.language` on every
- *    `/api/**` call, so it always sent `en` regardless of the context locale. A
- *    spec that needs a localised backend response sets `extraHTTPHeaders` on a
- *    direct API request.
+ * 3. **The backend's locale is reached, but only by leakage — do not rely on it
+ *    in either direction.** Langflow's `set_locale` middleware
+ *    (`src/backend/base/langflow/main.py`) reads `Accept-Language` and really does
+ *    answer in it: `GET /api/v1/flows/basic_examples/` returns "Basic Prompting"
+ *    under `en` and "Sugestões básicas" under `pt`. The frontend pins
+ *    `Accept-Language: i18n.language` on the calls that go through its axios
+ *    interceptors, so most requests send `en` whatever the context locale is —
+ *    **17 of the 20 `/api/` requests the home screen makes** under `locale:
+ *    "pt-BR"`. The other **3 carry the context locale**: a browser-issued
+ *    subresource (`/api/v1/files/profile_pictures/…svg`) never passes through the
+ *    interceptor, and neither did two `/api/v9/invites/…` XHRs. A spec whose
+ *    subject is the backend's locale must therefore set `Accept-Language`
+ *    explicitly via `extraHTTPHeaders` on a direct API request rather than infer
+ *    it from the context.
  *
- * That measurement is why `withLocale()` returns **only** `locale`: bundling
- * `extraHTTPHeaders: { "Accept-Language": … }` into it would override the header
- * the frontend sets per request, leaving the app announcing one language to the
- * backend while rendering another — a state no product build can reach.
+ * That split is why `withLocale()` returns **only** `locale`. Adding
+ * `extraHTTPHeaders: { "Accept-Language": … }` would at minimum change those 3
+ * leaked requests, and its precedence against the header the axios interceptor
+ * assigns per request is **unmeasured** — so the language the backend sees would
+ * become a per-request race between two layers, in a helper whose whole job is to
+ * make one axis explicit.
  */
 
 /**
@@ -72,16 +82,29 @@ export const LANGFLOW_UI_LANGUAGES = [
 ] as const;
 
 /**
+ * The one well-formed tag Chromium refuses. `Intl.getCanonicalLocales("und")`
+ * returns `["und"]` — it is valid BCP-47 for "undetermined" — but
+ * `newContext({ locale: "und" })` dies with `Protocol error
+ * (Emulation.setLocaleOverride): Invalid locale name`, which is exactly the
+ * opaque browser-launch failure this validation exists to prevent. (`"root"` is
+ * rejected by `Intl` itself, so it needs no entry here. Both measured against the
+ * repo's pinned Chromium.)
+ */
+const BROWSER_REJECTED_LOCALES = new Set(["und"]);
+
+/**
  * Validate and canonicalise a BCP-47 tag, naming the caller in the failure.
  *
  * Fail-closed on purpose: an unusable value must abort with its cause named
  * rather than fall back to `en-US`, which would run the whole suite in English
  * under a command line that asked for something else (#1012's rule).
  *
- * The check is **syntactic** — `Intl.getCanonicalLocales` accepts any
- * well-formed tag, so `"xx"` passes and only the browser will tell you it is not
- * a real language. It does catch the slip this is most likely to see: the POSIX
- * spelling `pt_BR`, which is a `RangeError`.
+ * The check is **syntactic**, with one measured exception (`und`, above). A
+ * well-formed tag for a language that does not exist is NOT caught and does not
+ * announce itself anywhere: `xx` and `zz-ZZ` both launch, and Chromium silently
+ * renders an ISO-ish fallback (`1969-12-31 21:00:00`) instead of erroring. What
+ * this does catch is the slip it is actually likely to see — the POSIX spelling
+ * `pt_BR`, a `RangeError`.
  */
 export function canonicalLocale(value: string, source: string): string {
   const trimmed = value.trim();
@@ -90,6 +113,14 @@ export function canonicalLocale(value: string, source: string): string {
     canonical = Intl.getCanonicalLocales(trimmed);
   } catch {
     canonical = [];
+  }
+  if (canonical.length === 1 && BROWSER_REJECTED_LOCALES.has(canonical[0])) {
+    throw new Error(
+      `${source}: ${JSON.stringify(value)} is a well-formed BCP-47 tag that ` +
+        `Chromium refuses ("Invalid locale name"), which would kill every test ` +
+        `in the run with a browser-launch error instead of this one. Pick a real ` +
+        `language tag such as "pt-BR".`,
+    );
   }
   if (canonical.length !== 1) {
     throw new Error(
@@ -113,9 +144,11 @@ export function canonicalLocale(value: string, source: string): string {
  * ```
  *
  * A bare `test.use({ locale })` is what `CONTRIBUTING.md` bans, and the ban is
- * worth keeping for two reasons this helper preserves: the tag is validated at
- * collection time instead of producing a confusing browser-launch failure, and
- * every opt-out in the suite is findable with one grep.
+ * worth keeping for two reasons this helper preserves: the tag is checked at
+ * collection time — including `und`, the one well-formed tag that would otherwise
+ * kill the run with an opaque `Emulation.setLocaleOverride` error — and every
+ * opt-out in the suite is findable with one grep. It cannot vouch for the tag
+ * being a real language: see `canonicalLocale`.
  *
  * Returns only `locale` — see the header for the measurement behind that.
  */
@@ -126,8 +159,6 @@ export function withLocale(locale: string): { locale: string } {
 export interface RunLocale {
   /** The value `playwright.config.ts` puts in `use.locale`. */
   locale: string;
-  /** Where it came from — `env` only when `PW_LOCALE` carried a usable value. */
-  source: "default" | "env";
   /**
    * Set only when the effective locale differs from `DEFAULT_LOCALE`. The config
    * prints it on **stderr**: an override changes what every English-string
@@ -153,18 +184,17 @@ export function resolveRunLocale(
   // already reads PLAYWRIGHT_RETRIES — an exported-but-blank variable is the
   // shell's idea of "not set", not a request for an invalid locale.
   if (raw === undefined || raw.trim() === "") {
-    return { locale: DEFAULT_LOCALE, source: "default" };
+    return { locale: DEFAULT_LOCALE };
   }
 
   const locale = canonicalLocale(raw, LOCALE_ENV_VAR);
   if (locale === DEFAULT_LOCALE) {
     // Asked for the default explicitly: nothing changed, nothing to announce.
-    return { locale, source: "env" };
+    return { locale };
   }
 
   return {
     locale,
-    source: "env",
     notice:
       `[lane] browser locale overridden to ${locale} via ${LOCALE_ENV_VAR} — ` +
       `every English-string assertion in this run executes under it, and the ` +

--- a/tests/fixtures/locale.ts
+++ b/tests/fixtures/locale.ts
@@ -1,0 +1,175 @@
+/**
+ * Decides the browser context locale every test runs under, and provides the one
+ * sanctioned way for a spec to opt out of it (#1400).
+ *
+ * ## Why this is a module and not a literal in the config
+ *
+ * `playwright.config.ts` pinned `locale: "en-US"` inline (#225) and
+ * `CONTRIBUTING.md` forbade overriding it anywhere, which is the right default —
+ * the suite asserts on English strings throughout — but it left non-English
+ * coverage with no route at all: the i18n checklist bullets could not be written,
+ * because the only mechanism available (`test.use({ locale })`) was exactly what
+ * the rule banned. Parameterising it here keeps the default untouched, gives the
+ * opt-in a single validated entry point, and makes both testable by
+ * `npm run test:units` instead of by reading a terminal.
+ *
+ * ## What the locale actually controls — measured, because the obvious reading is wrong
+ *
+ * Measured on Langflow Nightly `1.12.0.dev20`, two browser contexts identical
+ * except for `locale` (en-US vs pt-BR). Non-English behaviour has **three
+ * independent axes**, and this option governs exactly one of them:
+ *
+ * 1. **The UI language is NOT one of them.** `src/frontend/src/i18n.ts` reads
+ *    `localStorage.getItem("languagePreference")` (default `"en"`) and never
+ *    consults `navigator.language` — there is no language-detector plugin. Under
+ *    `locale: "pt-BR"` the app still renders English and `<html lang>` still reads
+ *    `en`. A spec that needs a translated UI must drive the language selector (app
+ *    header, or Settings → General) or seed that key; changing the locale will not
+ *    do it, and assuming otherwise is how such a spec fails and gets misdiagnosed.
+ * 2. **`Intl` formatting and the document/asset `Accept-Language` ARE.** The same
+ *    instant renders `12/31/1969, 9:00:00 PM` under en-US and `31/12/1969,
+ *    21:00:00` under pt-BR. This is the axis the option exists for.
+ * 3. **The backend's locale is NOT.** Langflow's `set_locale` middleware
+ *    (`src/backend/base/langflow/main.py`) reads `Accept-Language`, but the
+ *    frontend's axios layer pins `Accept-Language: i18n.language` on every
+ *    `/api/**` call, so it always sent `en` regardless of the context locale. A
+ *    spec that needs a localised backend response sets `extraHTTPHeaders` on a
+ *    direct API request.
+ *
+ * That measurement is why `withLocale()` returns **only** `locale`: bundling
+ * `extraHTTPHeaders: { "Accept-Language": … }` into it would override the header
+ * the frontend sets per request, leaving the app announcing one language to the
+ * backend while rendering another — a state no product build can reach.
+ */
+
+/**
+ * The locale every spec runs under unless it opts out. Changing this changes the
+ * meaning of every English-string assertion in the suite (#225).
+ */
+export const DEFAULT_LOCALE = "en-US";
+
+/** Run-wide override, read by `playwright.config.ts`. Empty/unset means the default. */
+export const LOCALE_ENV_VAR = "PW_LOCALE";
+
+/**
+ * The languages Langflow ships a translation bundle for
+ * (`src/frontend/src/locales/*.json`, identical on `main` and `release-1.12.0`).
+ *
+ * Recorded for the reader, NOT used as a validation list: the browser locale and
+ * the UI bundle are independent axes (see the header), so `withLocale("it-IT")` is
+ * legitimate — it changes `Intl` formatting — even though Langflow ships no
+ * Italian bundle, and `withLocale("pt-BR")` does NOT produce a Portuguese UI even
+ * though it ships a Portuguese one.
+ */
+export const LANGFLOW_UI_LANGUAGES = [
+  "en",
+  "de",
+  "es",
+  "fr",
+  "ja",
+  "pt",
+  "zh-Hans",
+] as const;
+
+/**
+ * Validate and canonicalise a BCP-47 tag, naming the caller in the failure.
+ *
+ * Fail-closed on purpose: an unusable value must abort with its cause named
+ * rather than fall back to `en-US`, which would run the whole suite in English
+ * under a command line that asked for something else (#1012's rule).
+ *
+ * The check is **syntactic** — `Intl.getCanonicalLocales` accepts any
+ * well-formed tag, so `"xx"` passes and only the browser will tell you it is not
+ * a real language. It does catch the slip this is most likely to see: the POSIX
+ * spelling `pt_BR`, which is a `RangeError`.
+ */
+export function canonicalLocale(value: string, source: string): string {
+  const trimmed = value.trim();
+  let canonical: string[];
+  try {
+    canonical = Intl.getCanonicalLocales(trimmed);
+  } catch {
+    canonical = [];
+  }
+  if (canonical.length !== 1) {
+    throw new Error(
+      `${source}: ${JSON.stringify(value)} is not a valid BCP-47 locale tag. ` +
+        `Use a hyphenated tag such as "en-US" or "pt-BR" — the POSIX form ` +
+        `"pt_BR" and an empty value are both rejected here rather than ` +
+        `silently falling back to ${DEFAULT_LOCALE}.`,
+    );
+  }
+  return canonical[0];
+}
+
+/**
+ * The sanctioned per-spec opt-in. Use it in a `test.use()` at describe level:
+ *
+ * ```ts
+ * test.describe("date rendering under a non-English locale", () => {
+ *   test.use(withLocale("pt-BR"));
+ *   …
+ * });
+ * ```
+ *
+ * A bare `test.use({ locale })` is what `CONTRIBUTING.md` bans, and the ban is
+ * worth keeping for two reasons this helper preserves: the tag is validated at
+ * collection time instead of producing a confusing browser-launch failure, and
+ * every opt-out in the suite is findable with one grep.
+ *
+ * Returns only `locale` — see the header for the measurement behind that.
+ */
+export function withLocale(locale: string): { locale: string } {
+  return { locale: canonicalLocale(locale, "withLocale()") };
+}
+
+export interface RunLocale {
+  /** The value `playwright.config.ts` puts in `use.locale`. */
+  locale: string;
+  /** Where it came from — `env` only when `PW_LOCALE` carried a usable value. */
+  source: "default" | "env";
+  /**
+   * Set only when the effective locale differs from `DEFAULT_LOCALE`. The config
+   * prints it on **stderr**: an override changes what every English-string
+   * assertion in the suite is running against, and a run whose meaning changed
+   * must say so (#1010) — but stdout is a machine contract for the daily's shard
+   * matrix and must stay clean (#1024).
+   */
+  notice?: string;
+}
+
+/**
+ * Resolve the run-wide locale from the environment.
+ *
+ * Pure, so the config stays a wiring layer: `playwright.config.ts` reads the
+ * result and prints the notice, and every branch below is covered by
+ * `npm run test:units` without launching a browser.
+ */
+export function resolveRunLocale(
+  env: NodeJS.ProcessEnv = process.env,
+): RunLocale {
+  const raw = env[LOCALE_ENV_VAR];
+  // Empty and whitespace-only are treated as unset, mirroring how the config
+  // already reads PLAYWRIGHT_RETRIES — an exported-but-blank variable is the
+  // shell's idea of "not set", not a request for an invalid locale.
+  if (raw === undefined || raw.trim() === "") {
+    return { locale: DEFAULT_LOCALE, source: "default" };
+  }
+
+  const locale = canonicalLocale(raw, LOCALE_ENV_VAR);
+  if (locale === DEFAULT_LOCALE) {
+    // Asked for the default explicitly: nothing changed, nothing to announce.
+    return { locale, source: "env" };
+  }
+
+  return {
+    locale,
+    source: "env",
+    notice:
+      `[lane] browser locale overridden to ${locale} via ${LOCALE_ENV_VAR} — ` +
+      `every English-string assertion in this run executes under it, and the ` +
+      `Langflow UI stays English regardless (its language comes from ` +
+      `localStorage.languagePreference, not the browser locale). ` +
+      `Unset ${LOCALE_ENV_VAR} to restore ${DEFAULT_LOCALE}.`,
+  };
+}


### PR DESCRIPTION
Closes #1400

## Why

`playwright.config.ts` hardcoded `locale: "en-US"` (#225) and `CONTRIBUTING.md` banned overriding it anywhere. The default is right — the suite asserts English strings throughout — but it left non-English coverage with no route at all: the only mechanism available (`test.use({ locale })`) was exactly what the rule banned, which is why the i18n checklist bullets could not be written.

## What lands

- **`tests/fixtures/locale.ts`** — the default, the validated per-spec opt-in (`withLocale`) and the run-wide `PW_LOCALE` resolution, as pure functions. It lives under `tests/fixtures/` deliberately: that prefix is the only one `impacted-specs-by-import.mjs` already treats as suite-wide, which is what a file governing `use.locale` for every spec must be.
- **`playwright.config.ts`** — `locale` is a resolved value instead of a literal. The default is unchanged.
- **Fail-closed both ways.** An unusable tag aborts the config naming the value and the POSIX slip (`pt_BR`) rather than falling back to en-US under a command line that asked for something else; a real override announces itself on stderr, never stdout — that stream is the daily's shard-matrix contract (#1024).
- **`tests/fixtures/locale-gate.spec.ts`** — the behavioural gate, sibling to `http-error-gate.spec.ts` / `flow-error-gate.spec.ts`: it pins that the resolved locale reaches a real browser context and that `withLocale()` overrides it there.
- **Docs** — `CONTRIBUTING.md` and `CLAUDE.md` record the default, the sanctioned opt-in, and the three-axis measurement below.

Usage:

```ts
test.describe("date rendering under a non-English locale", () => {
  test.use(withLocale("pt-BR"));
});
```

```bash
PW_LOCALE=pt-BR npx playwright test …   # whole run, announced on stderr
```

## The measurement, because the obvious reading is wrong

Measured on Langflow Nightly `1.12.0.dev20`, two browser contexts identical except `locale`. **The browser locale does not decide the language Langflow renders.** `src/frontend/src/i18n.ts` reads `localStorage.languagePreference` (default `"en"`) and never consults `navigator.language` — under pt-BR the UI stays English and `<html lang>` stays `en`.

| Axis | Changes with `locale`? |
|---|---|
| The language the UI renders (`localStorage.languagePreference`) | **No** |
| `Intl` formatting + the document/asset `Accept-Language` | **Yes** — `12/31/1969, 9:00:00 PM` → `31/12/1969, 21:00:00` |
| The locale the backend's `set_locale` middleware sees | **Partly, by leakage** — 17 of the 20 `/api/` requests the home screen makes send `en` (the frontend pins `Accept-Language: i18n.language` on the calls that pass through its axios interceptors); 3 carry the context locale, and the backend really does localise (`/api/v1/flows/basic_examples/` → `Sugestões básicas` under `pt`) |

That is why `withLocale()` returns **only** `locale`, and why `CONTRIBUTING.md` tells a spec whose subject is the backend's locale to set `Accept-Language` explicitly. Whoever writes the §18.x i18n bullets needs this: a spec asserting "the UI follows the browser locale" would be built on a false premise.

## Validation

- `npm run test:units` 571 ✓ · `npm run test:scripts` 797 ✓ · `typecheck` ✓ · `lint` 0 errors ✓ · `check:checklist-coverage` ✓
- `npx playwright test --grep @stable --list --reporter=json` still parses; `partition-shards.mjs matrix` → 4 shards (185 files). Same with `PW_LOCALE=pt-BR`; with `PW_LOCALE=pt_BR` it exits 1 with 0 bytes on stdout and the cause named.
- The 3 CI canary specs 10/10 green against 1.12.0.dev20; the new gate green in both modes (3 passed by default; 2 passed + 1 skipped under `PW_LOCALE=pt-BR`).
- **Mutation-checked**, since a guard that survives its own mutation guards nothing: reverting the config to a literal, dropping the validation throw, suppressing the notice, moving it to stdout, adding a project-level `locale`, and making `withLocale()` ignore its argument each fail a named test.
- An independent review of the first commit refuted one factual claim in the docs and found the wiring guard asserted the wrong level; `98bca32` fixes both, with the measurement in the commit body.

## Note for the reviewer

Touches `playwright.config.ts` + `tests/fixtures/**`, so `pr-validation.yml` classifies it suite-wide and raises the full-run warning — the issue predicted this. Final proof is a `manual.yml` dispatch.

`ROADMAP.md` still marks Wave 5 `◀ CURRENT` while Wave 5 closed with 0 open issues and Wave 6 is the only milestone with open `roadmap` items — pre-existing staleness, not this PR's, but worth a separate fix.