### PR TITLE
fix(provider-setup): freeze the model catalog per run (#1386)

### DIFF
--- a/docs/mcp/client/mcp-client-agent-gemini-tool-regression.md
+++ b/docs/mcp/client/mcp-client-agent-gemini-tool-regression.md
@@ -60,6 +60,16 @@ check encodes the expected #440 state.
 > **`@stable` — promoted under #947** after #440 was confirmed fixed on
 > 1.12.0.dev5 and the positive assertion (Gemini invokes `echo`) ran clean
 > `--workers=1 --retries=0` with a per-test force-failure check.
+>
+> **Removed and restored under #1386.** The daily of 2026-08-10 (run 31373880200)
+> auto-removed the tag on a failure that never executed the test: this file's
+> `test.describe` title interpolates `resolveGeminiModel()`, resolved at module
+> load, and the shard's own `collect-models.spec.ts` rewrote `models.json` after
+> the runner had computed the title — so the worker reported `Test not found in
+> the worker process` with `duration 0` and `workerIndex -1`. The cause is fixed
+> at the source (the catalog is frozen for the whole run —
+> `tests/helpers/provider-setup/catalog-snapshot.ts`), and the assertion itself
+> was re-validated 3/3 with `--retries=0` on 1.12.0.dev22 with Google configured.
 
 ---
 

--- a/tests/globalSetup.ts
+++ b/tests/globalSetup.ts
@@ -13,6 +13,7 @@ import {
   writeProviderHealth,
 } from "./helpers/provider-setup/provider-health";
 import { preconfigureRoutedProvider } from "./helpers/provider-setup/preconfigure-routed-provider";
+import { freezeModelCatalog } from "./helpers/provider-setup/catalog-snapshot";
 import {
   catalogVerdict,
   type CatalogSnapshot,
@@ -336,7 +337,42 @@ async function reportCatalogDrift(ctx: APIRequestContext): Promise<void> {
   );
 }
 
+/**
+ * Freeze the model catalog for this run (#1386).
+ *
+ * Runs FIRST and touches no network, because it must hold even on the paths where the
+ * rest of this file gives up: it is what keeps the runner's view of `models.json` and
+ * every worker's view identical, and 18 specs derive their `test.describe` title from
+ * that file. `globalSetup` precedes the load task, so this lands before the first
+ * title is computed. See `helpers/provider-setup/catalog-snapshot.ts` for why the
+ * catalog is a run-scoped value rather than a file each process re-reads.
+ *
+ * Never fatal: an unreadable catalog is exactly the state the resolvers already
+ * handle, and reporting it here means the cause is named before the specs skip
+ * (#1012) rather than aborting a whole shard over a file that is gitignored by design.
+ */
+function freezeCatalog(): void {
+  const verdict = freezeModelCatalog();
+  if (verdict.reason) {
+    console.warn(`[preflight] WARNING: ${verdict.reason}`);
+  }
+  if (verdict.kind === "absent") {
+    console.log(
+      "[preflight] models.json absent — the EMPTY catalog is frozen for this run. " +
+        "Provider-parametrized specs will report the fallback target; run " +
+        "`npx playwright test tests/collect-models.spec.ts` first to populate it.",
+    );
+    return;
+  }
+  console.log(
+    `[preflight] model catalog frozen for this run` +
+      (verdict.count === undefined ? "" : ` — ${verdict.count} models`) +
+      ". A mid-run write to models.json can no longer change a test's title (#1386).",
+  );
+}
+
 export default async function globalSetup(): Promise<void> {
+  freezeCatalog();
   const ctx = await playwrightRequest.newContext({ baseURL: BASE_URL });
   try {
     await assertBackendHealthy(ctx);

--- a/tests/helpers/provider-setup/catalog-snapshot.test.ts
+++ b/tests/helpers/provider-setup/catalog-snapshot.test.ts
@@ -1,0 +1,199 @@
+// Unit tests for the run-scoped model-catalog snapshot (issue #1386).
+// Run with: npm run test:units
+//
+// What rides on this: the TITLE of 19 spec files. 18 derive it from
+// `resolveTestTargets()` and one from `resolveGeminiModel()`, and a title is a test's
+// identity — the runner computes it at collection, each worker recomputes it at load.
+// When those two disagree Playwright reports `Test not found in the worker process`
+// with `duration 0` and never opens a browser, which on the daily of 2026-08-10 was
+// then read by the auto-removal path as a hard failure and cost an `@stable` tag.
+//
+// The disagreement is not hypothetical and does not need a rare race: the writer is
+// `tests/collect-models.spec.ts`, which is `@stable` and therefore partitioned into a
+// shard's own spec list, and it rewrites `models.json` from inside the run.
+//
+// So the assertions below are all one property, stated from different sides: **what a
+// resolver returns must not depend on when it is called.**
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  CATALOG_SNAPSHOT_ENV,
+  MODELS_PATH,
+  freezeModelCatalog,
+  readCatalogText,
+} from "./catalog-snapshot";
+import { resolveGeminiModel } from "./resolve-gemini-model";
+import { resolveGptModel } from "./resolve-gpt-model";
+import { resolveTestTargets } from "./test-targets";
+
+const OPENAI_ONLY = [{ provider: "openai", model: "gpt-4o-mini" }];
+const WITH_GOOGLE = [
+  { provider: "openai", model: "gpt-4o-mini" },
+  { provider: "google", model: "gemini-flash-latest" },
+];
+
+/** A temp file standing in for `models.json`, seeded with `records`. */
+function tempCatalog(records: unknown, name = "models.json"): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "catalog-snapshot-"));
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, JSON.stringify(records));
+  return file;
+}
+
+/**
+ * Run `fn` with the real `PW_MODELS_SNAPSHOT` replaced, then restore it. The tests
+ * that exercise the REAL resolvers (which read `process.env` and the real path) have
+ * to go through the env, never through the repo's own `models.json` — that file is
+ * gitignored, so it is absent in the unit lane and present locally, and a test that
+ * reads it passes on one and ENOENTs on the other (#1287).
+ */
+function withSnapshot(value: string | undefined, fn: () => void): void {
+  const previous = process.env[CATALOG_SNAPSHOT_ENV];
+  if (value === undefined) delete process.env[CATALOG_SNAPSHOT_ENV];
+  else process.env[CATALOG_SNAPSHOT_ENV] = value;
+  try {
+    fn();
+  } finally {
+    if (previous === undefined) delete process.env[CATALOG_SNAPSHOT_ENV];
+    else process.env[CATALOG_SNAPSHOT_ENV] = previous;
+  }
+}
+
+// ─── The regression itself ────────────────────────────────────────────────────
+
+test("a frozen catalog survives a mid-run rewrite of the file", () => {
+  const file = tempCatalog(OPENAI_ONLY);
+  const env: NodeJS.ProcessEnv = {};
+
+  const verdict = freezeModelCatalog(env, file);
+  assert.equal(verdict.kind, "frozen");
+  assert.equal(verdict.count, 1);
+
+  // What `collect-models.spec.ts` does from inside the run.
+  fs.writeFileSync(file, JSON.stringify(WITH_GOOGLE));
+
+  assert.deepEqual(JSON.parse(env[CATALOG_SNAPSHOT_ENV] as string), OPENAI_ONLY);
+});
+
+test("the resolver that feeds a describe title reads the frozen catalog, not the disk", () => {
+  // The exact shape of the daily's failure: the runner listed
+  // `… [google / default]` because google was absent, then the file gained a google
+  // model and the worker resolved `… [google / gemini-flash-latest]`.
+  withSnapshot(JSON.stringify(OPENAI_ONLY), () => {
+    assert.equal(resolveGeminiModel(), undefined);
+  });
+  withSnapshot(JSON.stringify(WITH_GOOGLE), () => {
+    assert.equal(resolveGeminiModel(), "gemini-flash-latest");
+  });
+});
+
+test("resolveGptModel reads the frozen catalog too", () => {
+  withSnapshot(JSON.stringify(WITH_GOOGLE), () => {
+    assert.equal(resolveGptModel(), "gpt-4o-mini");
+  });
+  withSnapshot(JSON.stringify([{ provider: "google", model: "gemini-flash-latest" }]), () => {
+    assert.equal(resolveGptModel(), undefined);
+  });
+});
+
+test("resolveTestTargets parametrizes from the frozen catalog", () => {
+  withSnapshot(JSON.stringify(WITH_GOOGLE), () => {
+    const targets = resolveTestTargets({ tier: "tool-calling", env: {}, skipReasons: new Map() });
+    assert.deepEqual(
+      targets.map((t) => t.label),
+      ["openai / gpt-4o-mini", "google / gemini-flash-latest"],
+    );
+  });
+});
+
+// ─── Freeze verdicts ──────────────────────────────────────────────────────────
+
+test("an absent catalog freezes the EMPTY one, not nothing", () => {
+  // Without a sentinel, "no file" would fall through to a live read in the workers —
+  // the same identity mismatch from the other direction, on a run whose pre-flight
+  // failed entirely but whose in-shard collect-models succeeded.
+  const env: NodeJS.ProcessEnv = {};
+  const missing = path.join(os.tmpdir(), "definitely-absent-models-1386.json");
+  const verdict = freezeModelCatalog(env, missing);
+  assert.equal(verdict.kind, "absent");
+  assert.equal(env[CATALOG_SNAPSHOT_ENV], "[]");
+});
+
+test("an unreadable catalog is reported, and still freezes the empty one", () => {
+  const env: NodeJS.ProcessEnv = {};
+  // A directory reads as EISDIR — exists, cannot be read.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "catalog-snapshot-"));
+  const verdict = freezeModelCatalog(env, dir);
+  assert.equal(verdict.kind, "unreadable");
+  assert.match(verdict.reason ?? "", /EISDIR|EPERM|EACCES/);
+  assert.equal(env[CATALOG_SNAPSHOT_ENV], "[]");
+});
+
+test("a malformed catalog is frozen VERBATIM so the readers still fail loud", () => {
+  // Parsing here would move #1035's deliberate throw into globalSetup, where it would
+  // abort the whole run instead of failing at the one place that must decide.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "catalog-snapshot-"));
+  const file = path.join(dir, "models.json");
+  fs.writeFileSync(file, "{ not json");
+  const env: NodeJS.ProcessEnv = {};
+  const verdict = freezeModelCatalog(env, file);
+  assert.equal(verdict.kind, "frozen");
+  assert.match(verdict.reason ?? "", /not valid JSON/);
+  assert.equal(env[CATALOG_SNAPSHOT_ENV], "{ not json");
+});
+
+test("a catalog that is valid JSON but not an array is reported", () => {
+  const file = tempCatalog({ openai: "gpt-4o-mini" });
+  const env: NodeJS.ProcessEnv = {};
+  const verdict = freezeModelCatalog(env, file);
+  assert.equal(verdict.kind, "frozen");
+  assert.match(verdict.reason ?? "", /not an array/);
+});
+
+test("freezing overwrites a stale value inherited from a parent process", () => {
+  const file = tempCatalog(OPENAI_ONLY);
+  const env: NodeJS.ProcessEnv = { [CATALOG_SNAPSHOT_ENV]: JSON.stringify(WITH_GOOGLE) };
+  freezeModelCatalog(env, file);
+  assert.deepEqual(JSON.parse(env[CATALOG_SNAPSHOT_ENV] as string), OPENAI_ONLY);
+});
+
+// ─── readCatalogText ──────────────────────────────────────────────────────────
+
+test("the snapshot stands in for the real path only", () => {
+  const file = tempCatalog(OPENAI_ONLY);
+  const env: NodeJS.ProcessEnv = { [CATALOG_SNAPSHOT_ENV]: JSON.stringify(WITH_GOOGLE) };
+
+  // An injected fixture is never shadowed by whatever the ambient run froze — this is
+  // what keeps every `catalogPath:` unit-test seam meaningful.
+  assert.deepEqual(JSON.parse(readCatalogText(file, env) as string), OPENAI_ONLY);
+  // The real path resolves to the snapshot.
+  assert.deepEqual(JSON.parse(readCatalogText(MODELS_PATH, env) as string), WITH_GOOGLE);
+});
+
+test("with no snapshot, readCatalogText is the file — and undefined when absent", () => {
+  const file = tempCatalog(OPENAI_ONLY);
+  assert.deepEqual(JSON.parse(readCatalogText(file, {}) as string), OPENAI_ONLY);
+  assert.equal(
+    readCatalogText(path.join(os.tmpdir(), "definitely-absent-models-1386.json"), {}),
+    undefined,
+  );
+});
+
+// ─── Structural: the freeze must stay wired, and stay first ───────────────────
+
+test("globalSetup freezes the catalog before it does anything else", () => {
+  // The whole mechanism is one call. A refactor that drops it, or moves it after a
+  // step that can throw (the backend health poll fails on every local run with no
+  // instance up), silently restores the race — and the symptom is a `Test not found`
+  // on an unrelated spec three weeks later.
+  const source = fs.readFileSync(path.join(__dirname, "..", "..", "globalSetup.ts"), "utf-8");
+  const body = source.slice(source.indexOf("export default async function globalSetup"));
+  const freezeAt = body.indexOf("freezeCatalog()");
+  const contextAt = body.indexOf("playwrightRequest.newContext");
+  assert.ok(freezeAt > -1, "globalSetup must call freezeCatalog()");
+  assert.ok(contextAt > -1, "globalSetup must still create the request context");
+  assert.ok(freezeAt < contextAt, "freezeCatalog() must run before any network work");
+});

--- a/tests/helpers/provider-setup/catalog-snapshot.ts
+++ b/tests/helpers/provider-setup/catalog-snapshot.ts
@@ -1,0 +1,164 @@
+// The model catalog, frozen for the lifetime of ONE Playwright run (#1386).
+//
+// ## The invariant this exists to hold
+//
+// A test's identity in Playwright is its TITLE, and the title is computed twice, in
+// two different processes, at two different moments:
+//
+//   1. the runner loads every spec file to build the test tree (the `load` task), and
+//   2. each worker RE-loads the file it was handed and matches by title.
+//
+// Nineteen specs derive that title from `models.json` at module load — 18 through
+// `resolveTestTargets()` (`[${label}]` = `provider / model`) and
+// `mcp-client-agent-gemini-tool-regression.spec.ts` through `resolveGeminiModel()`.
+// So for those files the title is a pure function of the FILE CONTENT AT READ TIME,
+// and anything that writes the file between (1) and (2) changes the test's identity
+// underneath it. Playwright then reports, from the worker:
+//
+//     Test not found in the worker process. Make sure test title does not change.
+//
+// with `duration 0` and `workerIndex -1` — no browser, no assertion, nothing about
+// the spec's subject. On the daily of 2026-08-10 (run 31373880200) that cost
+// `mcp-client-agent-gemini-tool-regression` its `@stable` tag through the automatic
+// removal path, on a failure that never executed a line of the test.
+//
+// There IS such a writer, and it is inside the run: `tests/collect-models.spec.ts` is
+// `@stable`, so it is collected by the daily's `--grep @stable --list` and partitioned
+// into some shard's spec list like any other file. On shard 3 the pre-flight sweep had
+// finished with `Models found (google): []` (a drained key — the sibling issue), and
+// the in-shard copy then re-ran, succeeded, and rewrote `models.json` WITH google
+// 32 seconds later. The runner had listed `… [google / default]`; the worker resolved
+// `… [google / gemini-flash-latest]`.
+//
+// ## Why freezing, and not the alternatives
+//
+//  - **Keep the model out of the title.** It cannot go: under `ALL_MODELS`/
+//    `MODEL_TEST_PROVIDER` a spec parametrizes one describe PER MODEL, so the model is
+//    what makes those titles distinct. Dropping it collapses them into duplicates.
+//  - **Keep `collect-models.spec.ts` out of the shard that reads its output.** That is
+//    a scheduling constraint the partitioner would have to keep true forever, on every
+//    lane, and it does not help a local `npx playwright test tests/` at all. It is also
+//    not the invariant: the defect is that identity depends on mutable state, not that
+//    one particular file mutates it.
+//  - **Freeze the catalog for the run.** One value, resolved before the tree is built,
+//    read identically by the runner and by every worker. Nothing downstream has to know
+//    the file can change, and no future writer can reopen the hole.
+//
+// ## Mechanics
+//
+// `globalSetup` runs BEFORE the load task — `createGlobalSetupTasks` precedes
+// `createLoadTask` in Playwright's CLI task list (`runner/testRunner.js`) — so the
+// snapshot is in place before the first title is computed. Workers are forked after
+// that and inherit `process.env`, which is why the env var reaches both sides while a
+// module-level cache could not (they are separate processes).
+//
+// The snapshot carries the file's RAW TEXT, not a parsed array: `readCatalog()` in
+// `test-targets.ts` throws on a malformed catalog on purpose (#1035 — an undecidable
+// catalog must not degrade to the fallback), and parsing here would move that failure
+// into `globalSetup`, where it would abort the whole run instead of failing at the one
+// place that has to make a decision. Measured size of a real three-provider catalog:
+// 5.2 KB — orders of magnitude below any `ARG_MAX` concern for the forked workers.
+//
+// A run whose `models.json` is ABSENT freezes `[]`. That is not a detail: without a
+// sentinel, "no file" would fall through to a live read in the workers, and a run
+// whose pre-flight failed entirely but whose in-shard `collect-models` succeeded would
+// hit exactly the same identity mismatch from the other direction.
+//
+// Deliberately NOT frozen: `providers.json`. It is read through
+// `providerSkipReasons()` and only ever feeds a `skipReason`, never a title or the
+// number of targets — so a mid-run change there makes a test skip or run, which is a
+// coverage question (the sibling collect-models issue), not an identity one. Freezing
+// it would also fight `globalSetup`'s own credential-degradation path (#1058), which
+// WRITES that file.
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Where the frozen catalog travels from the runner to the workers.
+ *
+ * `PW_`-prefixed like the suite's other run-scoped switches (`PW_DESTRUCTIVE`,
+ * `PW_SHARD_FILE_LEVEL`, `PW_HTTP_ERROR_DEBUG`).
+ */
+export const CATALOG_SNAPSHOT_ENV = "PW_MODELS_SNAPSHOT";
+
+/** The one path the snapshot stands in for. */
+export const MODELS_PATH = path.join(__dirname, "data", "models.json");
+
+export interface FreezeVerdict {
+  /**
+   * `frozen` — the file was read and its text is in the env.
+   * `absent` — no file; the empty catalog was frozen instead (see the header).
+   * `unreadable` — the file exists but could not be read; the empty catalog was
+   *   frozen and the reason is reported. Never silent (#1012).
+   */
+  kind: "frozen" | "absent" | "unreadable";
+  /** Number of records, when the text parsed as an array. `undefined` otherwise. */
+  count?: number;
+  /** Present on `unreadable`, and on a `frozen` catalog that does not parse. */
+  reason?: string;
+}
+
+/**
+ * Freeze `models.json` into `env` for this run. Call once, from `globalSetup`.
+ *
+ * Idempotent by construction — the file cannot change between two calls in the same
+ * `globalSetup` — but it deliberately does NOT preserve a pre-existing value: a stale
+ * `PW_MODELS_SNAPSHOT` inherited from a parent process would silently pin a catalog
+ * from another run.
+ */
+export function freezeModelCatalog(
+  env: NodeJS.ProcessEnv = process.env,
+  jsonPath: string = MODELS_PATH,
+): FreezeVerdict {
+  let text: string;
+  try {
+    text = fs.readFileSync(jsonPath, "utf-8");
+  } catch (e) {
+    const absent = (e as NodeJS.ErrnoException)?.code === "ENOENT";
+    env[CATALOG_SNAPSHOT_ENV] = "[]";
+    return absent
+      ? { kind: "absent", count: 0 }
+      : { kind: "unreadable", count: 0, reason: String(e) };
+  }
+
+  env[CATALOG_SNAPSHOT_ENV] = text;
+  try {
+    const parsed = JSON.parse(text);
+    if (Array.isArray(parsed)) return { kind: "frozen", count: parsed.length };
+    return {
+      kind: "frozen",
+      reason: `${jsonPath} is not an array of { provider, model } records (got ${
+        parsed === null ? "null" : typeof parsed
+      }) — the specs that read it will fail at collection.`,
+    };
+  } catch (e) {
+    // Frozen as-is: the readers own this failure, and moving it here would abort the
+    // run in globalSetup instead (see the header).
+    return {
+      kind: "frozen",
+      reason: `${jsonPath} is not valid JSON (${String(e)}) — the specs that read it ` +
+        `will fail at collection.`,
+    };
+  }
+}
+
+/**
+ * The catalog text every resolver must read: the run's frozen snapshot when there is
+ * one, the file otherwise. `undefined` means "no catalog at all", which each caller
+ * already handles in its own way.
+ *
+ * The snapshot stands in for exactly ONE path. A caller that passes some other file —
+ * every unit test does — reads that file, so injecting a fixture is never shadowed by
+ * whatever the ambient run froze.
+ */
+export function readCatalogText(
+  jsonPath: string = MODELS_PATH,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  if (path.resolve(jsonPath) === path.resolve(MODELS_PATH)) {
+    const frozen = env[CATALOG_SNAPSHOT_ENV];
+    if (frozen !== undefined) return frozen;
+  }
+  if (!fs.existsSync(jsonPath)) return undefined;
+  return fs.readFileSync(jsonPath, "utf-8");
+}

--- a/tests/helpers/provider-setup/resolve-gemini-model.ts
+++ b/tests/helpers/provider-setup/resolve-gemini-model.ts
@@ -1,5 +1,4 @@
-import path from "path";
-import fs from "fs";
+import { readCatalogText } from "./catalog-snapshot";
 
 // Resolve a Gemini flash chat model from models.json, preferring fast, cheap,
 // non-image/non-tts/non-preview ones. Returns undefined if none/absent — then
@@ -8,9 +7,14 @@ import fs from "fs";
 // language-model-regression.spec.ts (#596): tests must pin a deterministic
 // Gemini model instead of depending on catalog/dropdown ordering.
 export function resolveGeminiModel(): string | undefined {
-  const jsonPath = path.resolve(__dirname, "data/models.json");
-  if (!fs.existsSync(jsonPath)) return undefined;
-  const models = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as Array<{
+  // The run's FROZEN catalog when there is one (#1386). This value reaches a
+  // `test.describe` title in `mcp-client-agent-gemini-tool-regression.spec.ts`, so it
+  // must be identical in the runner (collection) and in the worker (execution) —
+  // reading the file directly made it depend on when each process happened to look,
+  // and `collect-models.spec.ts` rewrites that file from inside the same run.
+  const raw = readCatalogText();
+  if (raw === undefined) return undefined;
+  const models = JSON.parse(raw) as Array<{
     provider: string;
     model: string;
   }>;

--- a/tests/helpers/provider-setup/resolve-gpt-model.ts
+++ b/tests/helpers/provider-setup/resolve-gpt-model.ts
@@ -1,5 +1,4 @@
-import path from "path";
-import fs from "fs";
+import { readCatalogText } from "./catalog-snapshot";
 
 // Resolve a GPT chat model from models.json, preferring small general-purpose
 // (vision-capable) ones. Returns undefined if none/absent — setup-openai then
@@ -9,9 +8,13 @@ import fs from "fs";
 // of depending on catalog/dropdown ordering (same move as resolveGeminiModel
 // for #596).
 export function resolveGptModel(): string | undefined {
-  const jsonPath = path.resolve(__dirname, "data/models.json");
-  if (!fs.existsSync(jsonPath)) return undefined;
-  const models = JSON.parse(fs.readFileSync(jsonPath, "utf-8")) as Array<{
+  // The run's FROZEN catalog when there is one (#1386) — the sibling of
+  // `resolveGeminiModel`, kept on the same source so a run resolves ONE catalog. No
+  // title depends on this one today, but a consumer that starts interpolating it
+  // would otherwise silently reintroduce the identity race.
+  const raw = readCatalogText();
+  if (raw === undefined) return undefined;
+  const models = JSON.parse(raw) as Array<{
     provider: string;
     model: string;
   }>;

--- a/tests/helpers/provider-setup/test-targets.ts
+++ b/tests/helpers/provider-setup/test-targets.ts
@@ -79,8 +79,7 @@
 // which is precisely why `scripts/select-pr-model-target.mjs` never emits one without
 // the other. Narrowing it here instead would contradict three documents and change 15
 // specs; that trade was weighed for #1184 and declined.
-import * as fs from "fs";
-import * as path from "path";
+import { MODELS_PATH, readCatalogText } from "./catalog-snapshot";
 import { providerConfigMap, type Provider } from "./provider-config";
 import { providerSkipReasons } from "./provider-health";
 import { ollamaTestModel } from "./ollama-endpoint";
@@ -176,8 +175,6 @@ export interface ResolveTestTargetsOptions {
   catalogPath?: string;
 }
 
-const MODELS_PATH = path.join(__dirname, "data", "models.json");
-
 // Model families that cannot serve a chat completion. Verbatim from
 // agent-markdown-output.spec.ts.
 const NON_CHAT = /embedding|tts|audio|whisper|realtime|image|moderation|search/i;
@@ -218,7 +215,13 @@ const CAPABILITY_MISSING_REASON: Record<ModelCapability, (p: string) => string> 
 };
 
 function readCatalog(jsonPath: string = MODELS_PATH): ModelRecord[] {
-  if (!fs.existsSync(jsonPath)) {
+  // Reads the run's FROZEN catalog, not the file, whenever `globalSetup` took a
+  // snapshot (#1386). The title of 18 specs is derived from what this returns, and
+  // the runner and the workers must derive it from the same bytes — see
+  // `catalog-snapshot.ts`. With no snapshot (a `--list`, a unit test, a direct
+  // import) this is the file, exactly as before.
+  const raw = readCatalogText(jsonPath);
+  if (raw === undefined) {
     console.warn("models.json not found — run collect-models.spec.ts first.");
     return [];
   }
@@ -228,7 +231,7 @@ function readCatalog(jsonPath: string = MODELS_PATH): ModelRecord[] {
   // different suite than the one intended while reporting as normal (#1035). The
   // pre-#1184 copies threw here too (`JSON.parse` with no `try`), so failing loud
   // restores that rather than inventing it.
-  const parsed = JSON.parse(fs.readFileSync(jsonPath, "utf-8"));
+  const parsed = JSON.parse(raw);
   if (!Array.isArray(parsed)) {
     throw new Error(
       `${jsonPath} must be an array of { provider, model } records, got ` +

--- a/tests/tests-automations/regression/mcp/client/mcp-client-agent-gemini-tool-regression.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-agent-gemini-tool-regression.spec.ts
@@ -138,7 +138,15 @@ test.describe(`MCP Client – Gemini tool regression (#440) [${PROVIDER} / ${gem
 
   test(
     "Gemini invokes the echo MCP tool (regression for fixed upstream #440)",
-    { tag: ["@mcp", "@agents", "@regression", "@model-provider"] },
+    // `@stable` was auto-removed by the daily of 2026-08-10 (commit c954cd9, run
+    // 31373880200) on a failure that never ran this test: the shard's own
+    // `collect-models.spec.ts` rewrote `models.json` after the runner had computed
+    // this file's titles, so the worker could not find the test by title
+    // (`duration 0`, `workerIndex -1`, no browser). Restored with the cause fixed at
+    // the source — the catalog is now frozen per run, see
+    // `helpers/provider-setup/catalog-snapshot.ts` (#1386) — and the assertion itself
+    // re-validated 3/3 with `--retries=0` on 1.12.0.dev22 with google configured.
+    { tag: ["@mcp", "@agents", "@regression", "@model-provider", "@stable"] },
     async ({ page, request }) => {
       test.skip(!!skipReason, skipReason ?? "");
       test.skip(

--- a/tests/tests-automations/regression/mcp/client/mcp-client-agent-gemini-tool-regression.spec.ts
+++ b/tests/tests-automations/regression/mcp/client/mcp-client-agent-gemini-tool-regression.spec.ts
@@ -191,19 +191,59 @@ test.describe(`MCP Client – Gemini tool regression (#440) [${PROVIDER} / ${gem
           page.getByTestId(`add-component-button-${MCP_SERVER_NAME}`),
         ).toBeVisible({ timeout: 30000 });
 
+        // `action_count=true` makes the backend START every registered stdio MCP
+        // server to count its actions, so its cost grows with how many are
+        // registered on the instance and with how cold the `npx` cache is —
+        // measured at 9-15 s with the two servers Langflow registers for its own
+        // projects, and past the suite's 20 s `actionTimeout` while THIS server is
+        // still spinning up. A probe that times out THROWS, and `expect.poll`
+        // propagates the throw instead of polling again, so one slow probe used to
+        // abort the whole 90 s window on the first attempt — the poll could not
+        // tolerate the very slowness it exists to wait out. A failed probe is now
+        // "not ready yet" (and says so), while the assertion below is unchanged: if
+        // the server never reports a tool count, the poll still times out red.
+        let lastProbeError = "";
         await expect
           .poll(
             async () => {
-              const resp = await page.request.get(
-                "/api/v2/mcp/servers?action_count=true",
-              );
-              const servers: Array<{ name: string; toolsCount: number | null }> =
-                await resp.json();
-              return servers.find((s) => s.name === MCP_SERVER_NAME)?.toolsCount ?? null;
+              try {
+                const resp = await page.request.get(
+                  "/api/v2/mcp/servers?action_count=true",
+                  { timeout: 45000 },
+                );
+                if (!resp.ok()) {
+                  lastProbeError = `HTTP ${resp.status()}`;
+                  return null;
+                }
+                const servers: Array<{ name: string; toolsCount: number | null }> =
+                  await resp.json();
+                return servers.find((s) => s.name === MCP_SERVER_NAME)?.toolsCount ?? null;
+              } catch (e) {
+                lastProbeError = String(e);
+                return null;
+              }
             },
-            { timeout: 90000, intervals: [3000] },
+            {
+              timeout: 150000,
+              intervals: [3000],
+              message:
+                `MCP server "${MCP_SERVER_NAME}" never reported a tool count. A probe ` +
+                `that keeps failing is named in the last-probe warning printed below.`,
+            },
           )
-          .not.toBeNull();
+          .not.toBeNull()
+          .catch((e) => {
+            // Never silent (#1012): the assertion message cannot carry a value
+            // captured during the poll, so the last probe failure is printed
+            // alongside it — the difference between "the server never started" and
+            // "every probe timed out" is the whole diagnosis.
+            if (lastProbeError) {
+              console.warn(
+                `[mcp] last probe of /api/v2/mcp/servers?action_count=true failed: ${lastProbeError}`,
+              );
+            }
+            throw e;
+          });
       });
 
       await test.step("Add MCPTools component to canvas", async () => {


### PR DESCRIPTION
**Fixes #1386.**

## Problem

A test's identity in Playwright is its **title**, and the title is computed **twice, in two processes, at two moments**: the runner when it builds the test tree (the `load` task), each worker when it reloads the file it was handed. Nineteen specs derive that title from `models.json` **at module load** — 18 through `resolveTestTargets()` (`` `[${label}]` `` = `provider / model`) and `mcp-client-agent-gemini-tool-regression.spec.ts` through `resolveGeminiModel()`. So for those files the title is a pure function of the file content at read time, and anything writing that file between the two reads changes the test's identity underneath it.

There is such a writer, and it is **inside the run**: `tests/collect-models.spec.ts` is `@stable`, so it is collected by the daily's `--grep @stable --list` and partitioned into a shard's spec list like any other file (verified: 187 `@stable` files, `collect-models.spec.ts` among them).

On the daily of 2026-08-10 (run [31373880200](https://github.com/oriontech-me/langflow-e2e/actions/runs/31373880200)), shard 3:

- `09:25:47` — pre-flight `Collect models` finishes with `Models found (google): []` and writes `models.json` with openai only.
- `09:26:19` — the in-shard `collect-models.spec.ts` runs as a test, succeeds, and rewrites `models.json` **with** google.

The runner had listed `… [google / default]`; the worker resolved `… [google / gemini-flash-latest]`. Result, three attempts: `duration 0`, `workerIndex -1`, `Test not found in the worker process. Make sure test title does not change.` No browser opened, no assertion ran — and the auto-removal path took `@stable` off the spec (commit `c954cd9`) on the strength of that.

Reproduced in an isolated two-spec harness (no Langflow): a writer rewriting a JSON that a sibling interpolates into its `describe` title yields the byte-identical signature.

## Fix

`globalSetup` freezes the catalog's **raw text** into `PW_MODELS_SNAPSHOT` before the load task — `createGlobalSetupTasks` precedes `createLoadTask` in Playwright's CLI task list — workers inherit `process.env`, and every title-feeding resolver reads the snapshot instead of the file. The mid-run write still happens and is picked up by the next run; it can no longer change a title, whatever writes it and whichever shard it lands in.

New: `tests/helpers/provider-setup/catalog-snapshot.ts` (+ 12 unit tests). Wired into `test-targets.ts`, `resolve-gemini-model.ts`, `resolve-gpt-model.ts`.

**Rejected alternatives** (argued in the new file's header, not left to look like oversights):

- *Keep the model out of the title.* It cannot go: under `ALL_MODELS` / `MODEL_TEST_PROVIDER` a spec parametrizes one describe **per model**, so the model is what makes those titles distinct — dropping it collapses them into duplicates.
- *Keep `collect-models.spec.ts` out of the shard that reads its output.* A scheduling constraint the partitioner would have to keep true forever on every lane, useless for a local `npx playwright test tests/`, and not the invariant: the defect is that identity depends on mutable state, not that one particular file mutates it.

Four decisions worth reading before changing this:

- An **absent** `models.json` freezes `[]`. Without a sentinel, "no file" would fall through to a live read in the workers — the same mismatch from the other direction, on a run whose pre-flight failed entirely but whose in-shard collect succeeded.
- A **malformed** catalog is frozen **verbatim**, so #1035's deliberate throw stays in the reader instead of aborting the whole run inside `globalSetup`.
- `providers.json` is deliberately **not** frozen: it only ever feeds a `skipReason`, never a title or the number of targets, and `globalSetup` itself **writes** it on the credential-degradation path (#1058).
- The snapshot stands in for **one** path, so every `catalogPath:` unit-test seam keeps injecting its own fixture.

## Scope note

No spec logic changed. Label parity was confirmed on a live run: `Agent Tool Name Validation [openai / gpt-4o-mini]` — identical to the pre-change title. The only spec edit is restoring `@stable` on the Gemini/MCP test (auto-removed in `c954cd9` on a failure that never ran it), plus the record in its spec doc. The generated `QA-CHECKLIST.md` blocks are untouched — they regenerate on merge; the manual Part II bullet already existed (line 728).

**Also found, filed nowhere yet** (issue directive item 3, descriptive): `collect-models.spec.ts` runs **twice** on the shard that owns it — once as that job's pre-flight, once as a test. With this fix that is no longer a correctness problem, but the second execution is a duplicated sweep that can wedge the backend (#922/#927) with **no health gate after it**. Worth a follow-up issue.

## Validation (nightly 1.12.0.dev22, `--retries=0`)

- `npm run typecheck` ✅ · `npm run lint` ✅ (0 errors) · `npm run test:scripts` ✅ 797/797 · `npm run test:units` ✅ 564/564
- `npm run check:checklist-coverage` ✅ · QA-CHECKLIST guard ✅ (no generated block edited)
- `mcp-client-agent-gemini-tool-regression.spec.ts` — **3/3 clean** with `--workers=1 --retries=0` and google configured (30.5s / 27.7s / 34.5s)
- `agent-tool-name-validation.spec.ts` (`--grep "an invalid tool name blocks execution"`) — 1 passed, label unchanged
- **Force-fail, executed:**
  - `readCatalogText` mutated to ignore the snapshot → real run (writer + Gemini spec) **failed** with `Test not found in the worker process. Make sure test title does not change.`; unmutated, **2 passed**.
  - Same mutation against the unit lane → **4 of 12 failed** (exactly the frozen-read assertions). Reverted: 12/12, `grep -c FF-1386` = 0.
  - End-to-end scenario with `models.json` seeded openai-only and a writer running first: title stayed `[google / default]` on both sides and the test **executed** — the daily's exact scenario.
- Zero `🚨 Backend Error` on the three clean Gemini runs except one known ambient bulk `DELETE /api/v1/flows/` 500 (advisory, unrelated to this change).
- `--trace=on` skipped for the Gemini spec: it loads the Simple Agent template, the family where tracing hangs locally (documented limitation).
- Flow cleanup audited via `GET /api/v1/flows/`: one leaked `Simple Agent` from a run that died inside `load()` before the id was captured, purged by id (`DELETE → 200`). No orphan MCP servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up commit — `fix(mcp): make the tool-count poll survive a slow action_count probe`

Surfaced while reproducing this PR on a second local instance, and it is a
**different** defect from the one above: the test ran (browser open, title
resolved `[google / gemini-flash-latest]`, 38.4 s) and died on
`apiRequestContext.get: Timeout 20000ms exceeded` for
`GET /api/v2/mcp/servers?action_count=true` — where #1386's signature is
`Test not found in the worker process`, `duration 0`, no browser at all.

That endpoint makes the backend **start every registered stdio MCP server** to
count its actions, so its cost scales with how many are registered and with how
cold the `npx` cache is: measured 9-15 s against an instance carrying only the
two servers Langflow registers for its own projects, and past the suite's 20 s
`actionTimeout` while this spec's own server is still spinning up. A probe that
times out **throws**, and `expect.poll` propagates the throw instead of polling
again — so one slow probe aborted the whole 90 s window on its first attempt.
The poll could not tolerate the very slowness it exists to wait out. CI does not
see it because its instance is fresh.

A failed probe is now "not ready yet": explicit 45 s per-probe timeout, 150 s
window, and the last probe failure printed alongside the assertion message
(#1012 — "the server never started" and "every probe timed out" are different
diagnoses). The assertion itself is unchanged.

Validation: 3 clean runs `--workers=1 --retries=0` (32.6 s / 31.3 s / 28.8 s) ·
typecheck ✅ · eslint ✅ (0 errors) · force-failed both ways — polling for a
server name that never appears fails with the new message, and pointing the
probe at a 404 path fails **and** prints `last probe … failed: HTTP 404`.
