### PR TITLE
Cover the MCP single-server read-back and update API

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -744,6 +744,7 @@
 - [x] Tool list refreshes when a registered server is edited to run a different package → `mcp/server/mcp-server.spec.ts`
 - [x] stdio `command` must be a single executable — a command with an embedded argument is refused and the same registration split into `command` + `args` is accepted (upstream hardening `#14073`; #1091) → `mcp/server/mcp-server.spec.ts`
 - [x] The project's own Streamable HTTP endpoint registers as an MCP server and exposes its flows as tools → `mcp/server/mcp-server.spec.ts`
+- [x] A registered server is read back individually via `GET /servers/{name}` with the fields it was created with, and `PATCH /servers/{name}` updates them — merging per top-level key and refusing to rename (#1397) → `mcp/server/mcp-server.spec.ts`
 - [-] Resource exposed by server is accessible via URI — flow files are exposed as MCP resources: `resources/list` is `@stable`; `resources/read` blocked by a live Langflow regression on 1.12.x (`AttributeError: 'str' object has no attribute 'hex'`, filed upstream **LE-2012**) — kept as a guard, not promoted → `mcp/server/mcp-server-resources.spec.ts`
 - [ ] Install this project into an MCP client — `GET /{project_id}/installed` reports the current state, `POST /{project_id}/install` performs it, and the UI reflects both (the user-facing way an MCP Server is actually consumed; no bullet covered this before 2026-08-06)
 - [ ] `GET /{project_id}/composer-url` returns a URL that resolves, and the copy control in the UI yields the same value

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -744,12 +744,11 @@
 - [x] Tool list refreshes when a registered server is edited to run a different package → `mcp/server/mcp-server.spec.ts`
 - [x] stdio `command` must be a single executable — a command with an embedded argument is refused and the same registration split into `command` + `args` is accepted (upstream hardening `#14073`; #1091) → `mcp/server/mcp-server.spec.ts`
 - [x] The project's own Streamable HTTP endpoint registers as an MCP server and exposes its flows as tools → `mcp/server/mcp-server.spec.ts`
-- [x] A registered server is read back individually via `GET /servers/{name}` with the fields it was created with, and `PATCH /servers/{name}` updates them — merging per top-level key and refusing to rename (#1397) → `mcp/server/mcp-server.spec.ts`
 - [-] Resource exposed by server is accessible via URI — flow files are exposed as MCP resources: `resources/list` is `@stable`; `resources/read` blocked by a live Langflow regression on 1.12.x (`AttributeError: 'str' object has no attribute 'hex'`, filed upstream **LE-2012**) — kept as a guard, not promoted → `mcp/server/mcp-server-resources.spec.ts`
 - [ ] Install this project into an MCP client — `GET /{project_id}/installed` reports the current state, `POST /{project_id}/install` performs it, and the UI reflects both (the user-facing way an MCP Server is actually consumed; no bullet covered this before 2026-08-06)
 - [ ] `GET /{project_id}/composer-url` returns a URL that resolves, and the copy control in the UI yields the same value
 - [ ] Per-project MCP configuration — `GET`/`PATCH /{project_id}` selects which flows are exposed as tools, and a de-selected flow disappears from `tools/list` over the protocol
-- [ ] A registered server is read back individually (`GET /servers/{name}`) with the same fields it was created with, and `PATCH /servers/{name}` updates them (only the list, create, delete and 409/404 paths are covered today)
+- [x] A registered server is read back individually via `GET /servers/{name}` with the same fields it was created with, and `PATCH /servers/{name}` updates them — merging per top-level key and refusing to rename (#1397) → `mcp/server/mcp-server.spec.ts`
 - [ ] Prompt exposed by server returns correct template (no product surface on 1.11.x — MCP server `prompts/list` returns `[]`; #829)
 
 ---

--- a/docs/mcp/server/mcp-server.md
+++ b/docs/mcp/server/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP Server — add-server modal: stdio / HTTP registration, field persistence & tool refresh
 
-**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev9`)
+**Last validated:** Langflow 1.12.x (tests 1–7 on nightly `1.12.0.dev9`; tests 8–9 on `1.12.0.dev20`)
 
 ---
 
@@ -25,24 +25,34 @@ enforces (QA-CHECKLIST §14.1):
 5. **Streamable HTTP against Langflow itself** — a project's own
    `/api/v1/mcp/project/{id}/streamable` endpoint registers as an MCP server and
    exposes the project's flows as tools.
+6. **The single-server read-back and update API** (#1397) — a registered server
+   is readable on its own at `GET /api/v2/mcp/servers/{name}` with exactly the
+   fields it was created with, and `PATCH /api/v2/mcp/servers/{name}` updates
+   them, merging at the top level and refusing to rename.
 
 If this fails, external MCP servers can no longer be registered from the UI, the
-modal loses field state, the tool list serves stale data after an edit, or the
+modal loses field state, the tool list serves stale data after an edit, the
 stdio input-shape validation that keeps every policy layer seeing the same argv
-has been dropped.
+has been dropped, or the API the modal's edit path is built on stops returning
+what it stored.
 
 ---
 
 ## Tags *(required)*
 
 `@release` `@workspace` `@components` `@mcp` `@stable`
-(plus `@regression` on the command/args contract test)
+(plus `@regression` on the command/args contract test, and
+`@api` `@regression` on the read-back/update tests)
 
 - `@stable` — promoted under #1091 after the file was brought back to green on
   nightly `1.12.0.dev9` with repeated `--workers=1 --retries=0` runs and a
   per-test force-failure check. Before #1091 the file carried no `@stable` and
   therefore ran in **no automated lane**, which is why every stdio registration
-  in it had been broken since 2026-07-15 without a single red run.
+  in it had been broken since 2026-07-15 without a single red run. Tests 8 and 9
+  ship `@stable` from the start (#1397): they are pure API, need no subprocess,
+  no npm registry and no LLM, and were validated per CONTRIBUTING before the PR.
+- `@api` — on tests 8 and 9 only; they exercise
+  `GET`/`PATCH /api/v2/mcp/servers/{name}` directly and never drive the modal.
 - `@regression` — on the contract test only: it guards an intentional upstream
   security change (see *External dependencies*), so a silent removal of that
   validation must fail the suite.
@@ -57,7 +67,9 @@ has been dropped.
 - The default MCP starter project exists (`lf-starter_project`).
 - **Network egress to the npm registry** — the stdio tests run real MCP servers
   via `npx`. A cold container downloads the package on first use; see the
-  timeout budgets below.
+  timeout budgets below. **Tests 8 and 9 are exempt**: registration is
+  persist-only, so they register a non-existent package and never start a
+  subprocess.
 - `npx` on `PATH` inside the Langflow container (it ships there; verified on the
   nightly image).
 - No LLM / provider key required — no agent executes.
@@ -153,6 +165,38 @@ Unchanged by #1091 (no stdio surface). Derives the project's own
    `args === ["@modelcontextprotocol/server-everything"]`.
 6. Delete the server via the API.
 
+### 8 — `a registered MCP server is read back individually with the fields it was created with` *(new, #1397)*
+
+Pure API, no browser navigation and no subprocess: registration is persist-only,
+so a **deliberately non-existent package** is used (the same reasoning as test 3)
+and nothing is fetched from the npm registry.
+
+1. Pre-clean the per-worker name (a crashed retry could have left it behind).
+2. `POST /api/v2/mcp/servers/{name}` with `command: npx`,
+   `args: ["mcp-server-read-back-probe"]` and one `env` pair; assert 2xx.
+3. `GET /api/v2/mcp/servers/{name}`: assert **200** and that the body is exactly
+   the config that was posted — `command`, `args` and `env` equal, and no extra
+   keys. The `env` value round-trips through the encrypted column, so this also
+   covers decryption on read.
+4. Assert the single read carries **no `name`** field: the name is owned by the
+   URL path, not the body (this is the same rule test 9 pins from the write side).
+5. Assert the server is also listed by `GET /api/v2/mcp/servers`, so a single-read
+   endpoint that answered from somewhere the list does not see would fail.
+
+### 9 — `PATCH updates a registered server, merges at the top level, and refuses to rename it` *(new, #1397)*
+
+1. Register the same shape as test 8.
+2. `PATCH` with `command` + a **different** `args` package: assert 200, then
+   assert the change through a fresh `GET` — the response body alone would pass
+   even if nothing were persisted.
+3. Assert `env` **survived** the args-only change: the merge is per top-level key.
+4. `PATCH` with only `env` (a different single pair): assert `command`/`args`
+   survive and the previous `env` pair is **gone** — the merge replaces a key's
+   value wholesale, it does not deep-merge into it.
+5. `PATCH` with a body `name` that disagrees with the URL: assert **422** and a
+   detail matching `/name is immutable/i`, then assert via `GET` that the stored
+   config is untouched and carries no stray `name` key.
+
 ---
 
 ## Validation criterion *(required)*
@@ -175,6 +219,15 @@ Unchanged by #1091 (no stdio surface). Derives the project's own
 - **The tool list refreshes on edit**: after changing `args[0]` from
   sequential-thinking to server-everything, the node exposes `echo-0-option`;
   after reverting, `sequentialthinking-0-option`.
+- **The single-server read returns what was stored, and only that.**
+  `GET /api/v2/mcp/servers/{name}` answers 200 with a body deep-equal to the
+  posted config — including the `env` pair, decrypted — with no `name` key and no
+  extra keys, and the same server appears in the list endpoint.
+- **`PATCH` persists, merges per top-level key, and cannot rename.** A changed
+  `args` is visible on a subsequent `GET` and leaves `env` intact; a subsequent
+  `env`-only patch leaves `command`/`args` intact and *replaces* the whole `env`
+  object; a body `name` disagreeing with the URL is refused with 422 and changes
+  nothing.
 
 ## Guarding against false positives *(how)*
 
@@ -191,6 +244,15 @@ Unchanged by #1091 (no stdio surface). Derives the project's own
 - **Canvas-controls postcondition gate** (`zoom_out` hidden) in test 5 fails at
   the canvas controls instead of ~60 lines later as `<html> intercepts pointer
   events` (#576/#997/#1053).
+- **Tests 8 and 9 assert through a fresh `GET`, never through the write's own
+  response body.** `POST` and `PATCH` both echo the config back, so an endpoint
+  that validated and returned without persisting would pass an echo-only assert.
+- **Test 9 asserts a refusal next to a success**, the same argument as test 7: a
+  422-only assert would still pass against an endpoint that refused *every*
+  patch, and the merge assertions prove it is discriminating.
+- **Deep equality, not field spot-checks**, on the read-back: an endpoint that
+  quietly added a `name`, a `transport` label or a stray body key would pass a
+  per-field check and fail this one.
 - **Force-failure check** (CONTRIBUTING §2) executed per test during VERIFY.
 
 ---
@@ -203,6 +265,22 @@ Unchanged by #1091 (no stdio surface). Derives the project's own
 - Protocol-level tool listing/execution — `mcp-server-protocol.spec.ts`.
 - Flow-file **resources** — `mcp-server-resources.spec.ts`.
 - Registration **status codes** (409/404) — `mcp/client/mcp-server-registration-status-codes.spec.ts`.
+- **The read/update paths for a name that does not exist.** Measured on nightly
+  `1.12.0.dev20` and deliberately left unasserted, because both look wrong and
+  asserting either way would be a decision this spec should not make on its own:
+  `GET /api/v2/mcp/servers/{unknown}` answers **200 `null`** rather than the 404
+  its sibling `DELETE` returns (upstream `#14005` fixed the delete path and left
+  this one), and `PATCH /api/v2/mcp/servers/{unknown}` answers **200 and creates
+  the server** — so a typo'd name silently registers a ghost instead of failing.
+  Asserting today's behaviour would enshrine it; asserting the corrected
+  behaviour would ship a durably red `@stable` test, which the current triage
+  policy strips within a day. Both belong in a product-finding issue first.
+- **The stdio security policy on the PATCH path.** Also measured: a merge patch
+  that sends `args` **without** `command` is validated with no command in scope,
+  so `{"args": ["-y", "…"]}` is refused with 422 (`dangerous keyword '-y'`) while
+  the identical args are accepted by `POST` alongside `command: npx`. Tests 8/9
+  avoid `-y` entirely and always send `command` with `args`; the asymmetry itself
+  is not asserted here.
 - The rest of the stdio security policy — the arg blocklist
   (`DANGEROUS_KEYWORDS`), shell-metacharacter rejection, the docker-arg policy
   and the env blocklist are **not** covered here; test 7 covers only the
@@ -232,7 +310,17 @@ Unchanged by #1091 (no stdio surface). Derives the project's own
   `add-mcp-server-button-page`, `mcp-server-menu-button-<name>`,
   `btn_delete_delete_confirmation_modal`).
 - MCPTools node (`dropdown_str_tool`, `mcp-server-dropdown`, `list_item_<name>`).
-- `GET`/`DELETE /api/v2/mcp/servers[/{name}]`, `helpers/auth/get-auth-token.ts`,
+- `src/backend/base/langflow/api/v2/mcp.py` — the MCP v2 server API behind tests
+  8 and 9: `get_server_endpoint` (the single read, which returns the *decrypted*
+  config), `update_server(..., merge_existing=True)` (the PATCH merge and its
+  version guard) and `_enforce_immutable_server_name` (the 422 whose detail test 9
+  matches).
+- `src/backend/base/langflow/api/v2/schemas.py` — `MCPServerConfig`, the PATCH/POST
+  request model. Its `extra="allow"` is precisely why the immutable-name rule has
+  to exist, and its `_validate_stdio_security` validator is what refuses an
+  args-only patch (see *What this test does not cover*).
+- `GET`/`PATCH`/`POST`/`DELETE /api/v2/mcp/servers[/{name}]`,
+  `helpers/auth/get-auth-token.ts`,
   `helpers/other/await-bootstrap-test.ts`, `helpers/ui/adjust-screen-view.ts`,
   `helpers/ui/zoom-out.ts`, `helpers/flows/delete-flow.ts`,
   `helpers/flows/add-component-from-sidebar.ts`
@@ -250,6 +338,11 @@ Unchanged by #1091 (no stdio surface). Derives the project's own
 - If the MCPTools node's tool-input testid derivation changes (integers are
   lowercased into `int_int_<name>`; strings keep their case in
   `popover-anchor-input-<name>`).
+- If `MCPServerConfig` gains or drops a field, or the single read starts
+  returning a wrapper (a `name`, a transport label) instead of the bare config —
+  test 8's deep equality is the assertion that will say so.
+- If the PATCH merge changes granularity (deep-merging `env` instead of
+  replacing it), or `_enforce_immutable_server_name` stops answering 422.
 
 ---
 

--- a/docs/mcp/server/mcp-server.md
+++ b/docs/mcp/server/mcp-server.md
@@ -41,8 +41,8 @@ what it stored.
 ## Tags *(required)*
 
 `@release` `@workspace` `@components` `@mcp` `@stable`
-(plus `@regression` on the command/args contract test, and
-`@api` `@regression` on the read-back/update tests)
+(plus `@regression` on the command/args contract test, and `@api` on the
+read-back/update tests)
 
 - `@stable` — promoted under #1091 after the file was brought back to green on
   nightly `1.12.0.dev9` with repeated `--workers=1 --retries=0` runs and a
@@ -53,6 +53,11 @@ what it stored.
   no npm registry and no LLM, and were validated per CONTRIBUTING before the PR.
 - `@api` — on tests 8 and 9 only; they exercise
   `GET`/`PATCH /api/v2/mcp/servers/{name}` directly and never drive the modal.
+  They carry **no** `@regression`: that tag means "test for a previously fixed
+  bug" (`CLAUDE.md`), which is earned by the contract test below and by the
+  409/404 sibling spec, but these two are new coverage of a path with no bug
+  history. `@api` + `@stable` (cross-cutting) and `@mcp` (functional) satisfy the
+  tagging rule on their own.
 - `@regression` — on the contract test only: it guards an intentional upstream
   security change (see *External dependencies*), so a silent removal of that
   validation must fail the suite.
@@ -186,10 +191,12 @@ and nothing is fetched from the npm registry.
 ### 9 — `PATCH updates a registered server, merges at the top level, and refuses to rename it` *(new, #1397)*
 
 1. Register the same shape as test 8.
-2. `PATCH` with `command` + a **different** `args` package: assert 200, then
+2. `PATCH` with a **different** `args` package and nothing else: assert 200, then
    assert the change through a fresh `GET` — the response body alone would pass
    even if nothing were persisted.
-3. Assert `env` **survived** the args-only change: the merge is per top-level key.
+3. Assert `command` **and** `env` survived: neither was mentioned by the patch, so
+   both surviving is the evidence that the merge is per top-level key rather than
+   a whole-document replace.
 4. `PATCH` with only `env` (a different single pair): assert `command`/`args`
    survive and the previous `env` pair is **gone** — the merge replaces a key's
    value wholesale, it does not deep-merge into it.
@@ -227,7 +234,8 @@ and nothing is fetched from the npm registry.
   `args` is visible on a subsequent `GET` and leaves `env` intact; a subsequent
   `env`-only patch leaves `command`/`args` intact and *replaces* the whole `env`
   object; a body `name` disagreeing with the URL is refused with 422 and changes
-  nothing.
+  nothing. Each patch names as few keys as possible, so what survives is evidence
+  about the merge rather than about the patch echoing itself back.
 
 ## Guarding against false positives *(how)*
 
@@ -278,9 +286,9 @@ and nothing is fetched from the npm registry.
 - **The stdio security policy on the PATCH path.** Also measured: a merge patch
   that sends `args` **without** `command` is validated with no command in scope,
   so `{"args": ["-y", "…"]}` is refused with 422 (`dangerous keyword '-y'`) while
-  the identical args are accepted by `POST` alongside `command: npx`. Tests 8/9
-  avoid `-y` entirely and always send `command` with `args`; the asymmetry itself
-  is not asserted here.
+  the identical args are accepted by `POST` alongside `command: npx`. An
+  args-only patch is otherwise fine — measured 200 — so test 9 sends one
+  deliberately and simply avoids `-y`; the asymmetry itself is not asserted here.
 - The rest of the stdio security policy — the arg blocklist
   (`DANGEROUS_KEYWORDS`), shell-metacharacter rejection, the docker-arg policy
   and the env blocklist are **not** covered here; test 7 covers only the

--- a/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
@@ -1413,9 +1413,8 @@ async function mcpApiHeaders(page: Page): Promise<Record<string, string>> {
   };
 }
 
-test(
-  "a registered MCP server is read back individually with the fields it was created with",
-  { tag: ["@regression", "@api", "@mcp", "@stable"] },
+test("a registered MCP server is read back individually with the fields it was created with",
+  { tag: ["@api", "@mcp", "@stable"] },
   async ({ page }) => {
     const serverName = `read-back-${API_PROBE_UNIQUE}`;
     const path = `/api/v2/mcp/servers/${serverName}`;
@@ -1436,11 +1435,16 @@ test(
 
     await test.step("Register the server through the v2 API", async () => {
       const created = await page.request.post(path, { headers, data: config });
+      // Registered for `afterEach` BEFORE the assertion: a POST that commits the
+      // row and then answers non-2xx would otherwise abort this step with the
+      // name unknown to the cleanup, leaking a server nothing can reclaim (the
+      // suffix has moved on). An unnecessary push is free — `afterEach` lists
+      // first and only deletes names it actually finds.
+      registeredServers.push(serverName);
       expect(
         created.status(),
         `Registering a fresh name should succeed (2xx). Body: ${await created.text()}`,
       ).toBeLessThan(300);
-      registeredServers.push(serverName);
     });
 
     await test.step("GET /servers/{name} returns exactly the stored config", async () => {
@@ -1448,20 +1452,22 @@ test(
       expect(resp.status(), "the single-server read must answer 200").toBe(200);
 
       const stored = (await resp.json()) as Record<string, unknown>;
+
+      // FIRST, so it can actually be the assertion that reports: the deep
+      // equality below subsumes it, and placed after it this could never fail.
+      // The name is owned by the URL path — the same rule the update test pins
+      // from the write side (422 on a body `name`).
+      expect(
+        Object.keys(stored),
+        "the config must not carry a `name` — it lives in the URL",
+      ).not.toContain("name");
+
       expect(
         stored,
         "the single read must return the config as posted. Deep equality, not " +
           "per-field checks: a body that quietly gained a `name`, a transport " +
           "label or any other key must fail here",
       ).toEqual(config);
-
-      // Implied by the equality above, asserted on its own for the failure
-      // message: the name is owned by the URL path, which is the same rule the
-      // update test pins from the write side (422 on a body `name`).
-      expect(
-        Object.keys(stored),
-        "the config must not carry a `name` — it lives in the URL",
-      ).not.toContain("name");
     });
 
     await test.step("The same server is visible in the list endpoint", async () => {
@@ -1472,9 +1478,8 @@ test(
   },
 );
 
-test(
-  "PATCH updates a registered server, merges at the top level, and refuses to rename it",
-  { tag: ["@regression", "@api", "@mcp", "@stable"] },
+test("PATCH updates a registered server, merges at the top level, and refuses to rename it",
+  { tag: ["@api", "@mcp", "@stable"] },
   async ({ page }) => {
     const serverName = `update-${API_PROBE_UNIQUE}`;
     const path = `/api/v2/mcp/servers/${serverName}`;
@@ -1482,7 +1487,17 @@ test(
     const readStored = async (): Promise<Record<string, unknown>> => {
       const resp = await page.request.get(path, { headers });
       expect(resp.status(), "the read-back must answer 200").toBe(200);
-      return (await resp.json()) as Record<string, unknown>;
+      const body = (await resp.json()) as Record<string, unknown> | null;
+      // Checked, not assumed (the convention `listMcpServerNames` sets above):
+      // this endpoint answers 200 with a `null` body for a name it does not
+      // know, so an unguarded read would die as `Cannot read properties of
+      // null` inside whichever assertion called this, hiding the fact that the
+      // server went missing mid-test.
+      expect(
+        body,
+        "the server vanished mid-test — GET answered 200 with a null body",
+      ).not.toBeNull();
+      return body as Record<string, unknown>;
     };
 
     await test.step("Pre-clean: drop anything a crashed retry left under this name", async () => {
@@ -1498,21 +1513,24 @@ test(
           env: { MCP_PROBE_TOKEN: "probe-value" },
         },
       });
+      // Registered before the assertion, for the reason spelled out in the
+      // read-back test above.
+      registeredServers.push(serverName);
       expect(
         created.status(),
         `Registering a fresh name should succeed (2xx). Body: ${await created.text()}`,
       ).toBeLessThan(300);
-      registeredServers.push(serverName);
     });
 
     await test.step("PATCH changes args and the change is persisted, not just echoed", async () => {
-      // `command` is sent alongside `args` on purpose: the stdio policy validates
-      // the patch body on its own, so an args-only patch is checked with no
-      // command in scope (see the spec doc — that asymmetry is not this test's
-      // subject, and sending both keeps this assertion about the merge).
+      // args ONLY, no `command`: that is what makes the next two assertions
+      // evidence of a merge rather than of an echo — both surviving keys are
+      // keys this patch never mentioned. Measured 200 on 1.12.0.dev20; the
+      // stdio policy refuses an args-only patch only when the args carry a
+      // dangerous keyword (`-y`), which these deliberately do not.
       const patched = await page.request.patch(path, {
         headers,
-        data: { command: NPX, args: [PKG_PROBE_B] },
+        data: { args: [PKG_PROBE_B] },
       });
       expect(
         patched.status(),
@@ -1523,7 +1541,10 @@ test(
       expect(stored.args, "the new args must be readable back").toEqual([
         PKG_PROBE_B,
       ]);
-      expect(stored.command, "command must survive its own patch").toBe(NPX);
+      expect(
+        stored.command,
+        "command must survive a patch that never mentioned it",
+      ).toBe(NPX);
       expect(
         stored.env,
         "a key the patch did not mention must survive — the merge is per " +
@@ -1536,7 +1557,10 @@ test(
         headers,
         data: { env: { MCP_PROBE_OTHER: "second-value" } },
       });
-      expect(patched.status()).toBe(200);
+      expect(
+        patched.status(),
+        `an env-only PATCH must succeed. Body: ${await patched.text()}`,
+      ).toBe(200);
 
       const stored = await readStored();
       expect(

--- a/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
@@ -139,8 +139,7 @@ test.afterEach(async ({ request }) => {
 // exemption: a spec that keeps appearing as collateral while others do not).
 // Lifting the quarantine (remove test.fixme + restore @stable) is a
 // deliverable of #1266.
-test.fixme(
-  "user must be able to change mode of MCP tools without any issues",
+test.fixme("user must be able to change mode of MCP tools without any issues",
   { tag: ["@release", "@workspace", "@components", "@mcp"] },
   async ({ page }) => {
     (page as any).allowFlowErrors();
@@ -336,8 +335,7 @@ test.fixme(
   },
 );
 
-test(
-  "user must be able to add and delete MCP server from sidebar",
+test("user must be able to add and delete MCP server from sidebar",
   { tag: ["@release", "@workspace", "@components", "@mcp", "@stable"] },
   async ({ page }) => {
     (page as any).allowFlowErrors();
@@ -422,8 +420,7 @@ test(
   },
 );
 
-test(
-  "STDIO MCP server fields should persist after saving and editing",
+test("STDIO MCP server fields should persist after saving and editing",
   { tag: ["@release", "@workspace", "@components", "@mcp", "@stable"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
@@ -588,8 +585,7 @@ test(
   },
 );
 
-test(
-  "HTTP/SSE MCP server fields should persist after saving and editing",
+test("HTTP/SSE MCP server fields should persist after saving and editing",
   { tag: ["@release", "@workspace", "@components", "@mcp", "@stable"] },
   async ({ page }) => {
     await awaitBootstrapTest(page);
@@ -781,8 +777,7 @@ test(
   },
 );
 
-test(
-  "mcp server tools should be refreshed when editing a server",
+test("mcp server tools should be refreshed when editing a server",
   { tag: ["@release", "@workspace", "@components", "@mcp", "@stable"] },
   async ({ page }) => {
     // Three `TOOL_LIST_TIMEOUT` waits (register A, edit to B, re-register A)
@@ -1169,8 +1164,7 @@ test(
   },
 );
 
-test(
-  "Streamable HTTP MCP server with server-everything should load tools correctly",
+test("Streamable HTTP MCP server with server-everything should load tools correctly",
   { tag: ["@release", "@workspace", "@components", "@mcp"] },
   async ({ page }) => {
     (page as any).allowFlowErrors();
@@ -1273,8 +1267,7 @@ test(
   },
 );
 
-test(
-  "stdio command with an embedded argument is refused, and command plus args is accepted",
+test("stdio command with an embedded argument is refused, and command plus args is accepted",
   { tag: ["@regression", "@workspace", "@components", "@mcp", "@stable"] },
   async ({ page }) => {
     // The refused registration is a deliberate 422. The fixture only FAILS a

--- a/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server.spec.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import type { Page } from "@playwright/test";
 import { expect, test } from "../../../../fixtures/fixtures";
 import { adjustScreenView } from "../../../../helpers/ui/adjust-screen-view";
@@ -1358,6 +1359,225 @@ test(
       ).json();
       expect(stored.command).toBe(NPX);
       expect(stored.args).toEqual([PKG_EVERYTHING]);
+    });
+  },
+);
+
+// ─── Single-server read-back and update (#1397) ──────────────────────────────
+//
+// The two tests below are the API half of this file: every test above registers
+// through the modal and spot-checks the result, while `GET /servers/{name}` and
+// `PATCH /servers/{name}` — the endpoints the modal's own edit path is built on —
+// had no coverage of their own. Only list / create / delete and the 409/404 pair
+// (`mcp/client/mcp-server-registration-status-codes.spec.ts`) did.
+//
+// Three deliberate choices, all measured on nightly 1.12.0.dev20:
+//
+//  1. **No subprocess, no npm registry.** Registration persists the config
+//     without probing it, so these register a deliberately non-existent package —
+//     the same reasoning as the `uvx mcp-server-test` persistence test above.
+//     That is what lets them be `@stable` from the start: nothing here can flake
+//     on a cold `npx` download.
+//  2. **Every assertion reads back with a fresh GET**, never the write's own
+//     response body. `POST` and `PATCH` both echo the config, so an endpoint that
+//     validated and returned without persisting would pass an echo-only check.
+//  3. **Pure `page.request`.** The deliberate 422 in the update test runs outside
+//     the browser page, so it never reaches the fixture's `page.on("response")`
+//     backend-error monitor — no `allowHttpErrors()` needed. Same reasoning as
+//     the sibling status-codes spec.
+//
+// NOT asserted here, and the spec doc says why: `GET` of an unknown name answers
+// 200 `null` rather than the 404 its sibling `DELETE` returns, and `PATCH` of an
+// unknown name answers 200 and CREATES the server. Both look wrong; asserting
+// today's behaviour would enshrine it and asserting the corrected behaviour would
+// ship a durably red `@stable` test. They belong in a product-finding issue.
+
+// Worker index + timestamp disambiguate parallel workers; the UUID also rules out
+// two independent invocations against the same instance colliding in the same
+// millisecond (a local run against the instance the daily is using).
+const API_PROBE_UNIQUE = `${process.env.TEST_WORKER_INDEX ?? "0"}-${Date.now()}-${randomUUID().slice(0, 8)}`;
+const PKG_PROBE_A = "mcp-server-read-back-probe";
+const PKG_PROBE_B = "mcp-server-updated-probe";
+
+/** Auth + JSON headers for the v2 MCP API, asserted non-empty. */
+async function mcpApiHeaders(page: Page): Promise<Record<string, string>> {
+  const authHeader = await getAuthToken(page.request);
+  expect(
+    authHeader,
+    "Auth token is empty — the instance returned no access_token, so the " +
+      "assertions below would fail for an auth reason, not for the contract",
+  ).toBeTruthy();
+  return {
+    Authorization: authHeader,
+    "Content-Type": "application/json",
+  };
+}
+
+test(
+  "a registered MCP server is read back individually with the fields it was created with",
+  { tag: ["@regression", "@api", "@mcp", "@stable"] },
+  async ({ page }) => {
+    const serverName = `read-back-${API_PROBE_UNIQUE}`;
+    const path = `/api/v2/mcp/servers/${serverName}`;
+    // `env` is stored encrypted and returned decrypted, so asserting it here also
+    // covers that round trip — a read that returned the ciphertext would fail.
+    const config = {
+      command: NPX,
+      args: [PKG_PROBE_A],
+      env: { MCP_PROBE_TOKEN: "probe-value" },
+    };
+    const headers = await mcpApiHeaders(page);
+
+    await test.step("Pre-clean: drop anything a crashed retry left under this name", async () => {
+      // The name is stable within a worker process, so a retry that died after
+      // registering would otherwise hit 409 on the POST below.
+      await page.request.delete(path, { headers });
+    });
+
+    await test.step("Register the server through the v2 API", async () => {
+      const created = await page.request.post(path, { headers, data: config });
+      expect(
+        created.status(),
+        `Registering a fresh name should succeed (2xx). Body: ${await created.text()}`,
+      ).toBeLessThan(300);
+      registeredServers.push(serverName);
+    });
+
+    await test.step("GET /servers/{name} returns exactly the stored config", async () => {
+      const resp = await page.request.get(path, { headers });
+      expect(resp.status(), "the single-server read must answer 200").toBe(200);
+
+      const stored = (await resp.json()) as Record<string, unknown>;
+      expect(
+        stored,
+        "the single read must return the config as posted. Deep equality, not " +
+          "per-field checks: a body that quietly gained a `name`, a transport " +
+          "label or any other key must fail here",
+      ).toEqual(config);
+
+      // Implied by the equality above, asserted on its own for the failure
+      // message: the name is owned by the URL path, which is the same rule the
+      // update test pins from the write side (422 on a body `name`).
+      expect(
+        Object.keys(stored),
+        "the config must not carry a `name` — it lives in the URL",
+      ).not.toContain("name");
+    });
+
+    await test.step("The same server is visible in the list endpoint", async () => {
+      // A single-read endpoint answering from a store the list does not see would
+      // otherwise pass every assertion above.
+      expect(await listMcpServerNames(page)).toContain(serverName);
+    });
+  },
+);
+
+test(
+  "PATCH updates a registered server, merges at the top level, and refuses to rename it",
+  { tag: ["@regression", "@api", "@mcp", "@stable"] },
+  async ({ page }) => {
+    const serverName = `update-${API_PROBE_UNIQUE}`;
+    const path = `/api/v2/mcp/servers/${serverName}`;
+    const headers = await mcpApiHeaders(page);
+    const readStored = async (): Promise<Record<string, unknown>> => {
+      const resp = await page.request.get(path, { headers });
+      expect(resp.status(), "the read-back must answer 200").toBe(200);
+      return (await resp.json()) as Record<string, unknown>;
+    };
+
+    await test.step("Pre-clean: drop anything a crashed retry left under this name", async () => {
+      await page.request.delete(path, { headers });
+    });
+
+    await test.step("Register the server through the v2 API", async () => {
+      const created = await page.request.post(path, {
+        headers,
+        data: {
+          command: NPX,
+          args: [PKG_PROBE_A],
+          env: { MCP_PROBE_TOKEN: "probe-value" },
+        },
+      });
+      expect(
+        created.status(),
+        `Registering a fresh name should succeed (2xx). Body: ${await created.text()}`,
+      ).toBeLessThan(300);
+      registeredServers.push(serverName);
+    });
+
+    await test.step("PATCH changes args and the change is persisted, not just echoed", async () => {
+      // `command` is sent alongside `args` on purpose: the stdio policy validates
+      // the patch body on its own, so an args-only patch is checked with no
+      // command in scope (see the spec doc — that asymmetry is not this test's
+      // subject, and sending both keeps this assertion about the merge).
+      const patched = await page.request.patch(path, {
+        headers,
+        data: { command: NPX, args: [PKG_PROBE_B] },
+      });
+      expect(
+        patched.status(),
+        `PATCH of a registered server must succeed. Body: ${await patched.text()}`,
+      ).toBe(200);
+
+      const stored = await readStored();
+      expect(stored.args, "the new args must be readable back").toEqual([
+        PKG_PROBE_B,
+      ]);
+      expect(stored.command, "command must survive its own patch").toBe(NPX);
+      expect(
+        stored.env,
+        "a key the patch did not mention must survive — the merge is per " +
+          "top-level key, not a whole-document replace",
+      ).toEqual({ MCP_PROBE_TOKEN: "probe-value" });
+    });
+
+    await test.step("PATCH replaces a key's value wholesale rather than deep-merging it", async () => {
+      const patched = await page.request.patch(path, {
+        headers,
+        data: { env: { MCP_PROBE_OTHER: "second-value" } },
+      });
+      expect(patched.status()).toBe(200);
+
+      const stored = await readStored();
+      expect(
+        stored.env,
+        "env must be REPLACED by the patched object, not merged into it — a " +
+          "deep merge would leave MCP_PROBE_TOKEN behind",
+      ).toEqual({ MCP_PROBE_OTHER: "second-value" });
+      expect(stored.command, "command must survive an env-only patch").toBe(NPX);
+      expect(stored.args, "args must survive an env-only patch").toEqual([
+        PKG_PROBE_B,
+      ]);
+    });
+
+    await test.step("PATCH cannot rename the server, and a refused patch changes nothing", async () => {
+      // The refusal is asserted next to the successful patches above for the same
+      // reason the command/args contract test asserts both directions: a 422-only
+      // check would pass against an endpoint that refused every patch.
+      const renamed = await page.request.patch(path, {
+        headers,
+        data: { name: `${serverName}-renamed` },
+      });
+      expect(
+        renamed.status(),
+        "a body `name` disagreeing with the URL must be refused with 422",
+      ).toBe(422);
+      const detail = (await renamed.json()) as { detail?: unknown };
+      expect(
+        typeof detail?.detail === "string" ? detail.detail : "",
+        "the 422 must be the immutable-name rule, not an unrelated validation error",
+      ).toMatch(/name is immutable/i);
+
+      const stored = await readStored();
+      expect(
+        stored,
+        "a refused patch must leave the stored config untouched and must not " +
+          "persist the rejected `name` as stray config",
+      ).toEqual({
+        command: NPX,
+        args: [PKG_PROBE_B],
+        env: { MCP_PROBE_OTHER: "second-value" },
+      });
     });
   },
 );


### PR DESCRIPTION
Closes #1397

## Why

Every test in `mcp/server/mcp-server.spec.ts` registers through the Add MCP Server modal and spot-checks the result. `GET /api/v2/mcp/servers/{name}` and `PATCH /api/v2/mcp/servers/{name}` — the endpoints the modal's own edit path is built on — had no coverage of their own; only list / create / delete and the 409/404 pair (`mcp/client/mcp-server-registration-status-codes.spec.ts`) did. QA-CHECKLIST §14.1, one new bullet.

## What the two tests assert

**Read-back.** A server registered with `command` + `args` + `env` reads back through the single-server endpoint with a body **deep-equal** to what was posted — including the `env` pair, which round-trips through the encrypted column and comes back decrypted — carrying no `name` key (the name is owned by the URL path), and the same server is visible in the list endpoint.

**Update.** A `PATCH` carrying `args` **and nothing else** is visible on a subsequent `GET` while `command` and `env` — two keys the patch never mentioned — survive; an `env`-only patch leaves `command`/`args` intact and *replaces* the whole `env` object rather than deep-merging into it; a body `name` disagreeing with the URL is refused 422 (`name is immutable`) and changes nothing, not even as stray config.

Three design choices, each measured on nightly `1.12.0.dev20` rather than assumed:

- **No subprocess, no npm registry.** Registration persists the config without probing it, so both tests register a deliberately non-existent package — the same reasoning as the `uvx mcp-server-test` persistence test in the same file. That is what lets them ship `@stable` with nothing to flake on.
- **Every assertion reads back with a fresh `GET`**, never the write's own response body: `POST` and `PATCH` both echo the config, so an endpoint that validated without persisting would pass an echo-only check.
- **Pure `page.request`**, so the deliberate 422 never reaches the fixture's `page.on("response")` monitor and needs no `allowHttpErrors()`. Proven by contrast in a full-file run: the browser-driven contract test prints `🚨 Backend Error: 422`, these two print nothing.

## Two product behaviours found and deliberately NOT asserted

Both measured, both documented in the spec doc under *What this test does not cover*:

- `GET /api/v2/mcp/servers/{unknown}` answers **200 `null`** rather than the 404 its sibling `DELETE` returns (upstream #14005 fixed the delete path and left this one).
- `PATCH /api/v2/mcp/servers/{unknown}` answers **200 and creates the server** — a typo'd name silently registers a ghost.

Asserting today's behaviour would enshrine something that looks wrong; asserting the corrected behaviour would ship a durably red `@stable` test that triage strips within a day. **These want a product-finding issue** — happy to open one on request.

A third asymmetry is recorded the same way: a merge patch carrying `args` without `command` is validated with no command in scope, so `{"args": ["-y", …]}` is refused 422 while the identical args are accepted by `POST` alongside `command: npx`.

## Validation

Against Langflow Nightly **1.12.0.dev20**, per CONTRIBUTING:

- `typecheck` ✓ · `lint` 0 errors ✓ · `check:checklist-coverage` ✓ · `check-checklist-guard` ✓ · `validate:specs` exit 0 (and this doc left the "no `src/` paths" advisory list — its dependency entries now lead with the backticked path, the shape that checker reads).
- `--retries=0` runs green, 3× burst, `--trace=on` green, and `--workers=4 --repeat-each=3` → 6 passed with the server list back to its prior two entries.
- **Seven force-failure / mutation checks** across the two rounds — a mutated expectation, a dropped `env` on the POST, a PATCH that persists nothing, a rename sent with the matching name, a merge that drops `command`, an extra key in the stored config, and the reachability of the relocated `name` assertion — each failing for the right reason. (A first attempt mutated a constant used on *both* sides of the round trip, proved nothing, and was redone.)
- No `🚨 Backend Error` from either test; no leaked MCP servers afterwards.
- Full-file run: 7 passed, 1 skipped (the #1266 `test.fixme` quarantine), 1 failed — test 6 "Streamable HTTP … server-everything", which is not `@stable`, fails on the #1335 `add-mcp-server-button` signature, and which the spec doc already records as failing identically with and without a change. The independent reviewer's own full-file run had it **passing**, which fits a registry/timing difference; the diff is additive and 200 lines below it either way.

## Commits

1. `ed60c31` — the two tests, the spec doc, the checklist bullet.
2. `5b31038` — independent-review fixes: `@regression` dropped (it means "previously fixed bug"; these are new coverage), the cleanup registration moved **before** the status assertion so a commit-then-non-2xx POST cannot leak a server, the `name`-absence assertion moved above the deep equality where it can actually report, and the first PATCH reduced to `args` only after measurement refuted the comment justifying `command` alongside it.
3. `0a7ad8a` — whitespace only: `authoring-conventions.md` requires the test title on the `test(` line and asks for a retrofit when editing a file that wraps them. `--list` reports the same 9 tests with the same titles before and after.