### PR TITLE
Cover per-project MCP tool exposure over the protocol

### DIFF
--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -747,9 +747,8 @@
 - [-] Resource exposed by server is accessible via URI — flow files are exposed as MCP resources: `resources/list` is `@stable`; `resources/read` blocked by a live Langflow regression on 1.12.x (`AttributeError: 'str' object has no attribute 'hex'`, filed upstream **LE-2012**) — kept as a guard, not promoted → `mcp/server/mcp-server-resources.spec.ts`
 - [ ] Install this project into an MCP client — `GET /{project_id}/installed` reports the current state, `POST /{project_id}/install` performs it, and the UI reflects both (the user-facing way an MCP Server is actually consumed; no bullet covered this before 2026-08-06)
 - [ ] `GET /{project_id}/composer-url` returns a URL that resolves, and the copy control in the UI yields the same value
-- [ ] Per-project MCP configuration — `GET`/`PATCH /{project_id}` selects which flows are exposed as tools, and a de-selected flow disappears from `tools/list` over the protocol
+- [x] Per-project MCP configuration — `GET`/`PATCH /{project_id}` selects which flows are exposed as tools, and a de-selected flow disappears from `tools/list` over the protocol (invocation after de-selection is a separate finding, #1408) → `mcp/server/mcp-server-project-config.spec.ts`
 - [x] A registered server is read back individually via `GET /servers/{name}` with the same fields it was created with, and `PATCH /servers/{name}` updates them — merging per top-level key and refusing to rename (#1397) → `mcp/server/mcp-server.spec.ts`
-- [x] Per-project tool exposure — `PATCH`/`GET /api/v1/mcp/project/{id}` selects which flows are exposed, and a de-selected flow disappears from `tools/list` **over the protocol** (invocation after de-selection is a separate finding, #1408) → `mcp/server/mcp-server-project-config.spec.ts`
 - [ ] Prompt exposed by server returns correct template (no product surface on 1.11.x — MCP server `prompts/list` returns `[]`; #829)
 
 ---

--- a/QA-CHECKLIST.md
+++ b/QA-CHECKLIST.md
@@ -749,6 +749,7 @@
 - [ ] `GET /{project_id}/composer-url` returns a URL that resolves, and the copy control in the UI yields the same value
 - [ ] Per-project MCP configuration — `GET`/`PATCH /{project_id}` selects which flows are exposed as tools, and a de-selected flow disappears from `tools/list` over the protocol
 - [x] A registered server is read back individually via `GET /servers/{name}` with the same fields it was created with, and `PATCH /servers/{name}` updates them — merging per top-level key and refusing to rename (#1397) → `mcp/server/mcp-server.spec.ts`
+- [x] Per-project tool exposure — `PATCH`/`GET /api/v1/mcp/project/{id}` selects which flows are exposed, and a de-selected flow disappears from `tools/list` **over the protocol** (invocation after de-selection is a separate finding, #1408) → `mcp/server/mcp-server-project-config.spec.ts`
 - [ ] Prompt exposed by server returns correct template (no product surface on 1.11.x — MCP server `prompts/list` returns `[]`; #829)
 
 ---

--- a/docs/mcp/server/mcp-server-project-config.md
+++ b/docs/mcp/server/mcp-server-project-config.md
@@ -238,15 +238,20 @@ project). Teardown deletes the flow and then the project.
   client can call. Measured on `1.12.0.dev20`. Not asserted here — this spec's subject
   is the selection, and MCP tool naming deserves a spec of its own — but it is why the
   guard above is a hard failure rather than a comment.
-- **The project's name prefix is six characters, and that is load-bearing.**
+- **The project's name prefix must be at most six characters, and that is load-bearing.**
   Creating a project derives an MCP server named `lf-${sanitize_mcp_name(name)[:26]}`
   (`MAX_MCP_SERVER_NAME_LENGTH` is 30 minus the `lf-` prefix) and that derived name
   must be unique per user, while `createProjectViaApi` appends a 20-character
-  `-${Date.now()}-${rand5}`. A longer prefix pushes the unique part past the cut, and
-  every project this spec creates then collides with the previous one:
-  `POST /api/v1/projects/` → **409** `MCP server name conflict:
-  'lf-e2e_mcp_project_config_178' already exists for a different project`. That is
-  how the first version of this spec failed under `--workers=4 --repeat-each=3`.
+  `-${Date.now()}-${rand5}`. Six or fewer is what **guarantees** the whole unique part
+  stays inside the cut. Past six the suffix is truncated from the right and the
+  conflict risk grows with the prefix rather than becoming certain at once — at seven
+  characters four of the five random characters still survive — whereas the
+  22-character prefix the first version of this spec used (`e2e_mcp_project_config`)
+  left nothing past the first three digits of the timestamp, so there every project it
+  created collided with the previous one: `POST /api/v1/projects/` → **409**
+  `MCP server name conflict: 'lf-e2e_mcp_project_config_178' already exists for a
+  different project`. That is how that version failed under
+  `--workers=4 --repeat-each=3`.
   **This is a product behaviour, not a test artefact** — reproduced with two ordinary
   names on `1.12.0.dev20`: `Marketing Automation Project Alpha` creates, and
   `Marketing Automation Project Beta` is refused, because they share their first 26

--- a/docs/mcp/server/mcp-server-project-config.md
+++ b/docs/mcp/server/mcp-server-project-config.md
@@ -1,0 +1,236 @@
+# MCP Server — per-project tool exposure (`GET`/`PATCH /{project_id}`) and what the protocol serves
+
+**Last validated:** Langflow 1.12.x (nightly `1.12.0.dev20`)
+
+---
+
+## What this test validates *(required)*
+
+The **selection surface** of a project's MCP server (QA-CHECKLIST §14.1): which of a
+project's flows are exposed as MCP tools, and whether the protocol agrees with that
+selection.
+
+1. **The selection round-trips.** `PATCH /api/v1/mcp/project/{project_id}` sets a
+   flow's `mcp_enabled`, `action_name` and `action_description`, and
+   `GET /api/v1/mcp/project/{project_id}` reads them back — listing the **enabled**
+   flows by default, and the **disabled** ones under `?mcp_enabled=false`.
+2. **Selecting exposes it over the protocol, for real.** The enabled flow appears in
+   `tools/list` on the project's own streamable endpoint under its `action_name`,
+   described by its `action_description`, and `tools/call` actually runs it — so the
+   listing is backed by a working capability, not just a string.
+3. **De-selecting withdraws it from the protocol.** After `mcp_enabled: false`, the
+   action is gone from `tools/list` — the assertion is made over the MCP protocol, not
+   against the REST listing the UI renders, because those are two different code paths
+   (`handle_list_project_tools` passes `mcp_enabled_only=True`; the REST endpoint
+   filters in its own query).
+4. **Exposure is scoped to the project that owns the flow.** Everything runs against a
+   project this test creates, so a pass cannot be produced by another project's flows.
+
+If this fails, the per-project tool selection no longer controls what an MCP client
+discovers: either the settings do not persist, or the protocol serves a set that
+disagrees with them.
+
+---
+
+## Tags *(required)*
+
+`@stable` `@api` `@mcp`
+
+- `@stable` — pure API and protocol, no browser navigation, no LLM key and no external
+  network; validated per `CONTRIBUTING.md` before the PR.
+- `@api` — drives `GET`/`PATCH /api/v1/mcp/project/{id}` and the JSON-RPC endpoint
+  directly; there is no UI step.
+- `@mcp` — the MCP server area (`tests/.../mcp/`, area-local `CLAUDE.md`).
+- **No `@regression`** — that tag means "test for a previously fixed bug"
+  (`CLAUDE.md`), and this is new coverage of a path with no bug history.
+
+---
+
+## Preconditions *(optional)*
+
+- Langflow running at `PLAYWRIGHT_BASE_URL`; auto-login superuser.
+- No provider key, no npm registry, no external MCP server: the flow under test is a
+  Chat Input → Chat Output passthrough created from
+  `tests/assets/flows/chat-io-ok-trace-fixture.json`.
+- The test creates its **own** project and its own flow inside it, and deletes both.
+  It never touches the default project, so it cannot race
+  `mcp-server-protocol.spec.ts`, which mutates the default project's MCP settings.
+
+---
+
+## Step by step *(required)*
+
+Shared setup (`beforeAll`): resolve the auth token, create a project via
+`createProjectViaApi`, and create a passthrough flow inside it (`folder_id` = the new
+project). Teardown deletes the flow and then the project.
+
+### 1 — `project MCP settings round-trip through GET and PATCH`
+
+1. `GET /api/v1/mcp/project/{project}`: assert a freshly created project exposes
+   **nothing** (`tools: []`) — the baseline every later assertion is measured against.
+2. `PATCH` the project with `settings: [{ id: flow, mcp_enabled: true, action_name,
+   action_description }]`; assert 200.
+3. `GET` again: assert exactly **one** entry, and that it carries the flow's id,
+   `mcp_enabled: true`, the `action_name` and `action_description` just written, plus
+   the flow's own `name`/`description` (the endpoint returns both pairs and they are
+   not the same thing).
+
+### 2 — `an exposed flow is served over the protocol, and de-selecting withdraws it`
+
+1. `initialize` against `/api/v1/mcp/project/{project}/streamable` and assert the
+   server identifies itself as this project (`langflow-mcp-project-{id}`) — a
+   handshake against the wrong endpoint would otherwise pass every later step.
+2. `tools/list`: assert the `action_name` is present and that its `description` is the
+   **action** description, not the flow's. The action name is kept **short on
+   purpose** — see *Notes*, the protocol truncates at 30 characters.
+3. `tools/call` with a unique sentinel: assert `isError: false` and that the echoed
+   text is the sentinel — the listing is backed by a real capability.
+4. `PATCH` the same flow to `mcp_enabled: false`; assert 200.
+5. `tools/list` again: assert the `action_name` is **gone**.
+6. `GET /api/v1/mcp/project/{project}`: assert `tools: []`, and that
+   `?mcp_enabled=false` now returns the flow with `mcp_enabled: false` — the query
+   parameter selects which set is listed, it does not toggle anything.
+
+---
+
+## Validation criterion *(required)*
+
+- A newly created project exposes no tools, and after one `PATCH` it exposes exactly
+  the flow named in that `PATCH`, with the action name and description that were sent.
+- The MCP protocol agrees with the REST selection **in both directions**: the enabled
+  action is listed and callable; after de-selection it is absent from `tools/list`.
+- `tools/call` on the enabled action returns the exact sentinel that was sent, so the
+  exposure is a working tool rather than an advertised name.
+- The `?mcp_enabled=false` listing returns the de-selected flow — proving the flow was
+  not deleted or detached, only withdrawn from exposure.
+
+## Guarding against false positives *(how)*
+
+- **Its own project and its own flow**, created per run with a unique name. No
+  assertion can be satisfied by a flow another spec (or a previous run) exposed, and
+  nothing this test writes can disturb the default project other specs use.
+- **A unique per-run `action_name`**, so `tools/list` containment is about this run.
+- **The de-selection assertion is made over the protocol** (`tools/list`), not against
+  the REST listing. The REST endpoint and the MCP handler filter `mcp_enabled` in two
+  different places, so asserting the REST side alone would not prove what an MCP
+  client sees — which is the whole point of the bullet.
+- **`tools/call` before de-selection** anchors the positive case in behaviour: a build
+  that listed the tool but could not run it would pass a containment-only test.
+- **The handshake asserts the project identity**, so a misdirected endpoint fails at
+  step 1 instead of producing an empty `tools/list` that looks like correct
+  de-selection.
+- **A fixture guard on the action name's length** fails in `beforeAll`, naming the
+  30-character cap, rather than as a `tools/list` miss that reads like a product
+  defect (see *Notes*).
+- **Force-failure check** (CONTRIBUTING §2) executed per assertion during VERIFY.
+
+---
+
+## What this test does not cover *(optional)*
+
+- **`tools/call` after de-selection — because it currently succeeds.** Measured on
+  `1.12.0.dev20`: a flow whose `mcp_enabled` is `false` is absent from `tools/list`
+  yet still executes over `tools/call` under its `action_name`, returning
+  `isError: false`. It is not a cache — a tool that was **never** called while enabled
+  behaves the same, while a genuinely unknown name answers
+  `isError: true, "Flow with name '…' not found"`. Source-confirmed: the list handler
+  passes `mcp_enabled_only=True` (`api/v1/mcp_projects.py`), while
+  `handle_call_tool` (`api/v1/mcp_utils.py`) resolves by action name, checks the
+  project and enforces `FlowAction.EXECUTE`, and never reads `mcp_enabled`. So the
+  per-project selection is a **discovery** control, not an invocation control.
+  Filed as its own product-finding issue (#1408); asserting the corrected behaviour
+  here would ship a durably red `@stable` test, which triage strips within a day.
+- **Auth settings** (`auth_settings` on the same `PATCH`) — a separate surface; the
+  API-key variant is exercised by the A2A/project-auth specs.
+- **The MCP Server tab UI** that drives this API — `mcp-server-tab.spec.ts`.
+- **The generated endpoint and tool execution on the default project** —
+  `mcp-server-protocol.spec.ts`. This spec asserts a call only to anchor the positive
+  case; it is not the execution coverage.
+- **Resources and prompts** — `mcp-server-resources.spec.ts`; `prompts/list` returns
+  `[]` (no product surface, #829).
+- **Installing the project into an MCP client** — #1395.
+- **How the protocol derives a tool name from a long or exotic `action_name`.** The
+  cap and the sanitizer are documented in *Notes* because they cost this spec a red
+  run, but the transformation itself (emoji/diacritic stripping, collapsing,
+  de-duplication via `get_unique_name`) is a naming contract of its own and is left
+  to a spec that takes it as its subject.
+
+---
+
+## External dependencies *(required)*
+
+- `src/backend/base/langflow/api/v1/mcp_projects.py` — `list_project_tools`
+  (`GET /{project_id}`, including the `mcp_enabled` query filter),
+  `update_project_mcp_settings` (`PATCH /{project_id}`, which merges **per flow id**
+  and leaves flows it does not name untouched), `_build_project_tools_response`, and
+  the `ProjectMCPServer` handlers that register `handle_list_project_tools`
+  (`mcp_enabled_only=True`) and `handle_call_project_tool`.
+- `src/backend/base/langflow/api/v1/mcp_utils.py` — `handle_call_tool`, which resolves
+  a tool by action name and is where the missing `mcp_enabled` check lives (#1408).
+- `tests/helpers/mcp/mcp-streamable-client.ts` — `mcpHandshake` / `mcpCall`, the
+  repo's minimal streamable-HTTP JSON-RPC client (reused rather than hand-rolled, as
+  #1396 requires).
+- `tests/helpers/flows/create-project-via-api.ts`, `tests/helpers/flows/create-flow.ts`,
+  `tests/helpers/flows/delete-flow.ts`, `tests/helpers/flows/delete-project.ts`,
+  `tests/helpers/auth/get-auth-token.ts`.
+- `tests/assets/flows/chat-io-ok-trace-fixture.json` — the passthrough flow.
+
+---
+
+## When to review this test *(optional)*
+
+- If `MCPProjectUpdateRequest` gains or drops a field, or `PATCH` stops merging per
+  flow id (a whole-project replace would silently disable flows this test never named).
+- If `GET /{project_id}` changes shape — it currently returns
+  `{ tools: [...], auth_settings }`, and each tool entry carries **both** the action
+  pair and the flow's own name/description.
+- If `?mcp_enabled` stops being a filter over the listing.
+- If the streamable endpoint's `serverInfo.name` stops being
+  `langflow-mcp-project-{id}`.
+- If #1408 is fixed: add the post-de-selection `tools/call` assertion here and move
+  the paragraph out of *What this test does not cover*.
+
+---
+
+## Notes *(optional)*
+
+- **Why its own project.** `mcp-server-protocol.spec.ts` mutates the **default**
+  project's MCP settings and says so in a comment anticipating a second project-MCP
+  spec. Creating a project here removes the shared-state question entirely instead of
+  relying on serial execution across files, which Playwright does not provide — and
+  per-project scoping is the subject of the bullet anyway.
+- **Why the flow is created inline rather than through
+  `createRunnableChatFlowViaApi`.** That helper does not accept a `folder_id`, and it
+  has **29 call sites across 21 specs**: extending it would pull every one of those
+  specs into this PR's impacted-E2E lane (the import-graph selection, #1054) in
+  exchange for two lines. The file-local helper reads the same fixture and calls the
+  same `createFlow`.
+- **The protocol does not serve `action_name` verbatim, and that cost a red run.**
+  `tools/list` serves `get_unique_name(sanitize_mcp_name(action_name), 30, …)` —
+  `MAX_MCP_TOOL_NAME_LENGTH` is **30** (`src/lfx/src/lfx/base/mcp/constants.py`) —
+  while `GET /api/v1/mcp/project/{id}` returns the stored `action_name` untouched.
+  The first version of this spec used a 35-character name: the REST round trip
+  passed, and `tools/list` then answered with the name cut at 30
+  (`e2e_project_cfg_1786413140760_`), which reads exactly like the tool having
+  failed to publish. Measured on `1.12.0.dev20`. The action name is now ~21
+  characters and a `beforeAll` guard fails if that stops being true.
+- **The project's name prefix is six characters, and that is load-bearing.**
+  Creating a project derives an MCP server named `lf-${sanitize_mcp_name(name)[:26]}`
+  (`MAX_MCP_SERVER_NAME_LENGTH` is 30 minus the `lf-` prefix) and that derived name
+  must be unique per user, while `createProjectViaApi` appends a 20-character
+  `-${Date.now()}-${rand5}`. A longer prefix pushes the unique part past the cut, and
+  every project this spec creates then collides with the previous one:
+  `POST /api/v1/projects/` → **409** `MCP server name conflict:
+  'lf-e2e_mcp_project_config_178' already exists for a different project`. That is
+  how the first version of this spec failed under `--workers=4 --repeat-each=3`.
+  **This is a product behaviour, not a test artefact** — reproduced with two ordinary
+  names on `1.12.0.dev20`: `Marketing Automation Project Alpha` creates, and
+  `Marketing Automation Project Beta` is refused, because they share their first 26
+  characters. Worth knowing before adding another project-creating spec: of the
+  prefixes the suite uses today, `a2a-authgate` (12 chars) truncates to exactly the
+  timestamp boundary, so it survives only because two projects are unlikely to be
+  created in the same millisecond.
+- **`PATCH` merges per flow id.** `update_project_mcp_settings` iterates the project's
+  flows and touches only those named in `settings`, so this test cannot disable
+  anything it did not create — worth knowing before reusing this pattern against a
+  project that is not disposable.

--- a/docs/mcp/server/mcp-server-project-config.md
+++ b/docs/mcp/server/mcp-server-project-config.md
@@ -13,7 +13,8 @@ selection.
 1. **The selection round-trips.** `PATCH /api/v1/mcp/project/{project_id}` sets a
    flow's `mcp_enabled`, `action_name` and `action_description`, and
    `GET /api/v1/mcp/project/{project_id}` reads them back — listing the **enabled**
-   flows by default, and the **disabled** ones under `?mcp_enabled=false`.
+   flows by default, and **every** flow in the project under `?mcp_enabled=false`,
+   which removes the filter rather than inverting it.
 2. **Selecting exposes it over the protocol, for real.** The enabled flow appears in
    `tools/list` on the project's own streamable endpoint under its `action_name`,
    described by its `action_description`, and `tools/call` actually runs it — so the
@@ -88,8 +89,10 @@ project). Teardown deletes the flow and then the project.
 4. `PATCH` the same flow to `mcp_enabled: false`; assert 200.
 5. `tools/list` again: assert the `action_name` is **gone**.
 6. `GET /api/v1/mcp/project/{project}`: assert `tools: []`, and that
-   `?mcp_enabled=false` now returns the flow with `mcp_enabled: false` — the query
-   parameter selects which set is listed, it does not toggle anything.
+   `?mcp_enabled=false` returns the flow with `mcp_enabled: false`. That parameter
+   **removes** the `WHERE mcp_enabled = true` clause rather than inverting it
+   (`mcp_projects.py:301`), so on a project holding one flow the two readings are
+   "the exposed set" and "the whole project".
 
 ---
 
@@ -101,8 +104,9 @@ project). Teardown deletes the flow and then the project.
   action is listed and callable; after de-selection it is absent from `tools/list`.
 - `tools/call` on the enabled action returns the exact sentinel that was sent, so the
   exposure is a working tool rather than an advertised name.
-- The `?mcp_enabled=false` listing returns the de-selected flow — proving the flow was
-  not deleted or detached, only withdrawn from exposure.
+- The unfiltered listing (`?mcp_enabled=false`) still returns the flow, now with
+  `mcp_enabled: false` — proving it was withdrawn from exposure rather than deleted or
+  detached from the project.
 
 ## Guarding against false positives *(how)*
 
@@ -118,10 +122,17 @@ project). Teardown deletes the flow and then the project.
   that listed the tool but could not run it would pass a containment-only test.
 - **The handshake asserts the project identity**, so a misdirected endpoint fails at
   step 1 instead of producing an empty `tools/list` that looks like correct
-  de-selection.
+  de-selection. That single assertion is byte-identical to one in
+  `mcp-server-protocol.spec.ts`, and the repetition is deliberate: there it is the
+  coverage, here it is the precondition that makes an *absence* meaningful.
 - **A fixture guard on the action name's length** fails in `beforeAll`, naming the
   30-character cap, rather than as a `tools/list` miss that reads like a product
   defect (see *Notes*).
+- **Both `tools/list` calls check the JSON-RPC response before reading it.** Reading
+  `resp.result?.tools ?? []` would turn any failed call into an empty list, and the
+  de-selection assertion — the one this spec exists for — would then pass for exactly
+  the wrong reason. Proven by mutation: with the guard removed, pointing that step at a
+  bogus JSON-RPC method left the spec green.
 - **Force-failure check** (CONTRIBUTING §2) executed per assertion during VERIFY.
 
 ---
@@ -184,7 +195,9 @@ project). Teardown deletes the flow and then the project.
 - If `GET /{project_id}` changes shape — it currently returns
   `{ tools: [...], auth_settings }`, and each tool entry carries **both** the action
   pair and the flow's own name/description.
-- If `?mcp_enabled` stops being a filter over the listing.
+- If `?mcp_enabled` stops behaving as an on/off for the `mcp_enabled = true` filter —
+  note it never selected the disabled set, and a build that made it do so would change
+  what step 6 means without failing it on a single-flow project.
 - If the streamable endpoint's `serverInfo.name` stops being
   `langflow-mcp-project-{id}`.
 - If #1408 is fixed: add the post-de-selection `tools/call` assertion here and move
@@ -205,15 +218,26 @@ project). Teardown deletes the flow and then the project.
   specs into this PR's impacted-E2E lane (the import-graph selection, #1054) in
   exchange for two lines. The file-local helper reads the same fixture and calls the
   same `createFlow`.
-- **The protocol does not serve `action_name` verbatim, and that cost a red run.**
-  `tools/list` serves `get_unique_name(sanitize_mcp_name(action_name), 30, …)` —
-  `MAX_MCP_TOOL_NAME_LENGTH` is **30** (`src/lfx/src/lfx/base/mcp/constants.py`) —
-  while `GET /api/v1/mcp/project/{id}` returns the stored `action_name` untouched.
-  The first version of this spec used a 35-character name: the REST round trip
-  passed, and `tools/list` then answered with the name cut at 30
-  (`e2e_project_cfg_1786413140760_`), which reads exactly like the tool having
-  failed to publish. Measured on `1.12.0.dev20`. The action name is now ~21
-  characters and a `beforeAll` guard fails if that stops being true.
+- **Neither endpoint echoes `action_name` verbatim, and the difference cost a red
+  run.** The REST listing serves `sanitize_mcp_name(action_name)` at the sanitizer's
+  default cap of **46** (`mcp_projects.py:314`), while `tools/list` serves
+  `get_unique_name(sanitize_mcp_name(action_name), 30, …)` — `MAX_MCP_TOOL_NAME_LENGTH`
+  is **30** (`src/lfx/src/lfx/base/mcp/constants.py`). The two therefore agree only for
+  a name that is already lowercase `[a-z0-9_]` **and** within 30 characters. The first
+  version of this spec used a 35-character name: the REST round trip passed and
+  `tools/list` answered with the name cut at 30 (`e2e_project_cfg_1786413140760_`),
+  which reads exactly like the tool having failed to publish. Both halves measured on
+  `1.12.0.dev20` — an `E2E-Probe-…` name comes back from `GET` lowercased and
+  underscored, not as sent. The action name is now ~21 characters and a `beforeAll`
+  guard asserts **both** the cap and the character class.
+- **A truncated tool name is not merely renamed — it is uninvocable.** `tools/call`
+  with the exact name `tools/list` itself served for a 37-character action
+  (`e2e_probe_action_name_that_is_`) answers
+  `isError: true, "Flow with name 'e2e_probe_action_name_that_is_' not found"`: the
+  listing truncates while the lookup does not, so the server advertises a tool no
+  client can call. Measured on `1.12.0.dev20`. Not asserted here — this spec's subject
+  is the selection, and MCP tool naming deserves a spec of its own — but it is why the
+  guard above is a hard failure rather than a comment.
 - **The project's name prefix is six characters, and that is load-bearing.**
   Creating a project derives an MCP server named `lf-${sanitize_mcp_name(name)[:26]}`
   (`MAX_MCP_SERVER_NAME_LENGTH` is 30 minus the `lf-` prefix) and that derived name
@@ -226,10 +250,11 @@ project). Teardown deletes the flow and then the project.
   **This is a product behaviour, not a test artefact** — reproduced with two ordinary
   names on `1.12.0.dev20`: `Marketing Automation Project Alpha` creates, and
   `Marketing Automation Project Beta` is refused, because they share their first 26
-  characters. Worth knowing before adding another project-creating spec: of the
+  characters. Filed as **#1409**. Worth knowing before adding another project-creating spec: of the
   prefixes the suite uses today, `a2a-authgate` (12 chars) truncates to exactly the
   timestamp boundary, so it survives only because two projects are unlikely to be
-  created in the same millisecond.
+  created in the same millisecond. This spec's own prefix is five characters, one
+  inside the cut.
 - **`PATCH` merges per flow id.** `update_project_mcp_settings` iterates the project's
   flows and touches only those named in `settings`, so this test cannot disable
   anything it did not create — worth knowing before reusing this pattern against a

--- a/tests/tests-automations/regression/mcp/server/mcp-server-project-config.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-project-config.spec.ts
@@ -90,15 +90,18 @@ test.describe("MCP Server — per-project tool exposure", () => {
   // Unique per run, and a valid MCP tool name (snake_case): `tools/list`
   // containment is then an assertion about THIS run's flow.
   //
-  // Deliberately SHORT. The protocol does not serve `action_name` verbatim — it
-  // serves `get_unique_name(sanitize_mcp_name(action_name), 30, …)`, and
-  // `MAX_MCP_TOOL_NAME_LENGTH` is 30 (`src/lfx/src/lfx/base/mcp/constants.py`),
-  // while the REST endpoint returns the stored name untouched. A 35-character
-  // name therefore round-trips through `GET` and comes back **truncated** in
-  // `tools/list`, which reads exactly like the tool having failed to publish.
-  // Measured on 1.12.0.dev20 while writing this spec. Base-36 keeps it ~21 chars
-  // and inside the sanitizer's character class, so the name reaching the client
-  // is the one written here.
+  // Deliberately SHORT, and deliberately already in the sanitizer's normal form.
+  // Neither endpoint echoes `action_name` verbatim: the REST listing serves
+  // `sanitize_mcp_name(action_name)` at its default cap of 46
+  // (`mcp_projects.py:314`), and the protocol serves
+  // `get_unique_name(sanitize_mcp_name(action_name), 30, …)` —
+  // `MAX_MCP_TOOL_NAME_LENGTH` is 30 (`src/lfx/src/lfx/base/mcp/constants.py`).
+  // So the two agree only for a name that is ALREADY lowercase `[a-z0-9_]` and
+  // within 30 characters; a 35-character one comes back whole from `GET` and
+  // **truncated** from `tools/list`, which reads exactly like a tool that failed
+  // to publish. Measured on 1.12.0.dev20 while writing this spec — it cost a red
+  // run. Base-36 keeps this ~21 characters and inside the character class, so
+  // the name the client sees is the one written here.
   const actionName = `e2e_cfg_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
   const actionDescription = "E2E per-project exposure tool";
 
@@ -112,16 +115,23 @@ test.describe("MCP Server — per-project tool exposure", () => {
     headers = { Authorization: authorization };
 
     // Fixture guard, not product coverage: the assertions below compare the
-    // protocol's tool name to `actionName` for equality, which only holds while
-    // it survives the 30-char cap. Fails here, naming the cap, rather than as a
-    // confusing tools/list miss if someone lengthens the prefix.
+    // served tool name to `actionName` for equality, which holds only while the
+    // name survives BOTH transformations unchanged — the 30-char cap and the
+    // sanitizer's character class. Fails here, naming the rule, rather than as a
+    // confusing tools/list miss if someone lengthens the prefix or writes a
+    // hyphen or a capital into it.
     expect(
       actionName.length,
       `the action name must stay within MAX_MCP_TOOL_NAME_LENGTH (30) or the ` +
         `protocol will serve a truncated name: ${actionName}`,
     ).toBeLessThanOrEqual(30);
+    expect(
+      actionName,
+      `the action name must already be in sanitize_mcp_name's normal form ` +
+        `(lowercase, [a-z0-9_]) or both endpoints will serve a different string`,
+    ).toMatch(/^[a-z][a-z0-9_]*$/);
 
-    // The prefix is SIX characters, and that is load-bearing rather than terse.
+    // The prefix is FIVE characters, and that is load-bearing rather than terse.
     // Creating a project derives an MCP server named
     // `lf-${sanitize_mcp_name(name)[:26]}` (`MAX_MCP_SERVER_NAME_LENGTH` is 30,
     // minus the `lf-` prefix), and that derived name must be unique per user.
@@ -131,10 +141,11 @@ test.describe("MCP Server — per-project tool exposure", () => {
     // `POST /api/v1/projects/` → 409 "MCP server name conflict:
     // 'lf-e2e_mcp_project_config_178' already exists for a different project".
     // Measured on 1.12.0.dev20 with `--workers=4 --repeat-each=3`, which is how
-    // the first version of this spec failed. At six characters the whole
-    // timestamp and random suffix survive the truncation.
+    // the first version of this spec failed. Filed as #1409 — it reproduces with
+    // two ordinary project names. Five characters give 5+1+13+1+5 = 25, one
+    // character inside the cut, so the whole suffix survives with slack.
     const project = await createProjectViaApi(request, headers, {
-      namePrefix: "e2ecfg",
+      namePrefix: "e2ecf",
       description: "Per-project MCP exposure (#1396)",
     });
     projectId = project.projectId;
@@ -148,12 +159,29 @@ test.describe("MCP Server — per-project tool exposure", () => {
     // The afterAll's own live `request`: Playwright forbids reusing the
     // beforeAll one. Flow first, then the project — deleting a project with a
     // flow still in it is a different, untested path.
+    //
+    // Errors are collected rather than swallowed: `deleteFlow` and
+    // `deleteProject` are written to THROW so a cleanup regression stays visible
+    // (#545/#965), and a bare `.catch(() => {})` re-introduces exactly the silent
+    // leak they guard against — here a leak is two things, a project and the
+    // `lf-<name>` entry it registers in the shared MCP server list that
+    // `mcp-server-starter-projects.spec.ts` asserts on. Collecting also keeps the
+    // second cleanup running when the first fails, which a bare `await` would not.
+    const failures: string[] = [];
     if (flowId) {
-      await deleteFlow(request, flowId, { headers }).catch(() => {});
+      await deleteFlow(request, flowId, { headers }).catch((e) =>
+        failures.push(`flow ${flowId}: ${e}`),
+      );
     }
     if (deleteProjectFn) {
-      await deleteProjectFn(request).catch(() => {});
+      await deleteProjectFn(request).catch((e) =>
+        failures.push(`project ${projectId}: ${e}`),
+      );
     }
+    expect(
+      failures,
+      `teardown left state on the shared instance: ${failures.join(" | ")}`,
+    ).toEqual([]);
   });
 
   test("project MCP settings round-trip through GET and PATCH", { tag: ["@stable", "@api", "@mcp"] },
@@ -235,8 +263,17 @@ test.describe("MCP Server — per-project tool exposure", () => {
           undefined,
           2,
         );
+        // Checked, not defaulted: `resp.result?.tools ?? []` turns ANY failed
+        // response into an empty list, which passes the de-selection assertion
+        // below for entirely the wrong reason. Verified by mutation — pointing
+        // this step at a bogus JSON-RPC method left the spec green.
+        expect(resp.error, JSON.stringify(resp.error)).toBeUndefined();
+        expect(
+          Array.isArray(resp.result?.tools),
+          `tools/list must answer with a tools array; got ${JSON.stringify(resp.result)}`,
+        ).toBe(true);
         const tools: Array<{ name: string; description?: string }> =
-          resp.result?.tools ?? [];
+          resp.result.tools;
         const tool = tools.find((t) => t.name === actionName);
         expect(
           tool,
@@ -292,7 +329,14 @@ test.describe("MCP Server — per-project tool exposure", () => {
           undefined,
           4,
         );
-        const names: string[] = (resp.result?.tools ?? []).map(
+        // The load-bearing guard of this spec: an absent action proves
+        // de-selection ONLY if the call itself succeeded.
+        expect(resp.error, JSON.stringify(resp.error)).toBeUndefined();
+        expect(
+          Array.isArray(resp.result?.tools),
+          `tools/list must answer with a tools array; got ${JSON.stringify(resp.result)}`,
+        ).toBe(true);
+        const names: string[] = resp.result.tools.map(
           (t: { name: string }) => t.name,
         );
         expect(
@@ -309,9 +353,13 @@ test.describe("MCP Server — per-project tool exposure", () => {
         expect(enabled.status(), await enabled.text()).toBe(200);
         expect((await enabled.json()).tools).toEqual([]);
 
-        // The query parameter selects WHICH set is listed — it does not toggle
-        // anything — and this half also proves the flow was withdrawn from
-        // exposure rather than deleted or detached from the project.
+        // `?mcp_enabled=false` does not invert the filter — it removes it.
+        // `_build_project_tools_response` adds `WHERE mcp_enabled = true` ONLY
+        // when the parameter is truthy (`mcp_projects.py:301`), so `false`
+        // returns every flow in the project. This project holds exactly one, so
+        // the assertion below is about that flow either way, and what it proves
+        // is that the flow was withdrawn from exposure rather than deleted or
+        // detached from the project.
         const disabled = await request.get(
           `/api/v1/mcp/project/${projectId}?mcp_enabled=false`,
           { headers },

--- a/tests/tests-automations/regression/mcp/server/mcp-server-project-config.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-project-config.spec.ts
@@ -131,19 +131,23 @@ test.describe("MCP Server — per-project tool exposure", () => {
         `(lowercase, [a-z0-9_]) or both endpoints will serve a different string`,
     ).toMatch(/^[a-z][a-z0-9_]*$/);
 
-    // The prefix is FIVE characters, and that is load-bearing rather than terse.
-    // Creating a project derives an MCP server named
-    // `lf-${sanitize_mcp_name(name)[:26]}` (`MAX_MCP_SERVER_NAME_LENGTH` is 30,
-    // minus the `lf-` prefix), and that derived name must be unique per user.
-    // `createProjectViaApi` appends `-${Date.now()}-${rand5}` — 20 characters —
-    // so a prefix longer than 6 pushes the unique part past the cut and every
-    // project this spec creates collides with the previous one:
-    // `POST /api/v1/projects/` → 409 "MCP server name conflict:
+    // The prefix LENGTH is load-bearing rather than terse. Creating a project
+    // derives an MCP server named `lf-${sanitize_mcp_name(name)[:26]}`
+    // (`MAX_MCP_SERVER_NAME_LENGTH` is 30, minus the `lf-` prefix), and that
+    // derived name must be unique per user. `createProjectViaApi` appends
+    // `-${Date.now()}-${rand5}` — 20 characters — so **≤6 is what guarantees the
+    // whole unique part survives the cut**. Past 6 the suffix is truncated from
+    // the right and the conflict risk grows with the prefix rather than becoming
+    // certain at once: at 7 characters four of the five random characters still
+    // survive, while the 22-character prefix the first version of this spec used
+    // (`e2e_mcp_project_config`) left nothing past the first three digits of the
+    // timestamp — so there every project it created collided with the previous
+    // one: `POST /api/v1/projects/` → 409 "MCP server name conflict:
     // 'lf-e2e_mcp_project_config_178' already exists for a different project".
     // Measured on 1.12.0.dev20 with `--workers=4 --repeat-each=3`, which is how
-    // the first version of this spec failed. Filed as #1409 — it reproduces with
-    // two ordinary project names. Five characters give 5+1+13+1+5 = 25, one
-    // character inside the cut, so the whole suffix survives with slack.
+    // that version failed. Filed as #1409 — it reproduces with two ordinary
+    // project names. Five characters give 5+1+13+1+5 = 25, one inside the cut, so
+    // the whole suffix survives with slack.
     const project = await createProjectViaApi(request, headers, {
       namePrefix: "e2ecf",
       description: "Per-project MCP exposure (#1396)",

--- a/tests/tests-automations/regression/mcp/server/mcp-server-project-config.spec.ts
+++ b/tests/tests-automations/regression/mcp/server/mcp-server-project-config.spec.ts
@@ -1,0 +1,330 @@
+import { readFileSync } from "fs";
+import type { APIRequestContext } from "@playwright/test";
+import { expect, test } from "../../../../fixtures/fixtures";
+import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
+import { createFlow } from "../../../../helpers/flows/create-flow";
+import { createProjectViaApi } from "../../../../helpers/flows/create-project-via-api";
+import { deleteFlow } from "../../../../helpers/flows/delete-flow";
+import {
+  mcpCall,
+  mcpHandshake,
+} from "../../../../helpers/mcp/mcp-streamable-client";
+
+/**
+ * MCP Server — per-project tool exposure (QA-CHECKLIST §14.1, #1396).
+ * Spec doc: `docs/mcp/server/mcp-server-project-config.md`.
+ *
+ * The selection surface: `PATCH /api/v1/mcp/project/{id}` decides which of a
+ * project's flows are exposed as MCP tools, `GET` reads that selection back, and
+ * the project's own streamable endpoint is what an MCP client actually sees.
+ *
+ * Two things make this more than a REST round trip:
+ *
+ *  - **The de-selection assertion is made over the protocol**, not against the
+ *    REST listing the UI renders. They are different code paths — the REST
+ *    endpoint filters in its own query, while the MCP server registers
+ *    `handle_list_project_tools` with `mcp_enabled_only=True` — so asserting the
+ *    REST side would not prove what a client discovers, which is the bullet.
+ *  - **The positive case is anchored with a `tools/call`.** A build that listed
+ *    a tool it could not run would pass a containment-only test.
+ *
+ * NOT asserted, and #1408 is why: `tools/call` on a **de-selected** flow still
+ * runs it (measured on 1.12.0.dev20 — `isError: false`, and not a cache: a tool
+ * never called while enabled behaves the same, while an unknown name answers
+ * `Flow with name '…' not found`). `handle_call_tool` resolves by action name and
+ * never reads `mcp_enabled`, so the selection is a discovery control only.
+ * Asserting the corrected behaviour would ship a durably red `@stable` test.
+ *
+ * Everything runs against a project this spec creates, so it cannot race
+ * `mcp-server-protocol.spec.ts` — which mutates the DEFAULT project's MCP
+ * settings and carries a comment anticipating exactly this second spec.
+ */
+
+// Serial: test 1 leaves the flow exposed and test 2 starts from that state,
+// then withdraws it. The two halves of one selection lifecycle, split so a
+// failure names which half broke.
+test.describe.configure({ mode: "serial" });
+
+// The same passthrough flow the protocol spec runs (Chat Input -> Chat Output,
+// no LLM, echoes its input verbatim).
+const CHAT_FLOW_FIXTURE = "tests/assets/flows/chat-io-ok-trace-fixture.json";
+
+/**
+ * Create the passthrough flow INSIDE a given project.
+ *
+ * File-local rather than an extension of `createRunnableChatFlowViaApi`, which
+ * takes no `folder_id`: that helper has 29 call sites across 21 specs, and the
+ * import-graph selection (#1054) would pull every one of them into this PR's
+ * impacted-E2E lane in exchange for two lines. Same fixture, same `createFlow`.
+ */
+async function createChatFlowInProject(
+  request: APIRequestContext,
+  headers: Record<string, string>,
+  projectId: string,
+): Promise<string> {
+  const fixture = JSON.parse(readFileSync(CHAT_FLOW_FIXTURE, "utf-8"));
+  // Unique name: Langflow enforces unique flow names per user and its auto-rename
+  // fallback is not transaction-safe (#588) — same convention as the shared helper.
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+  return createFlow(
+    request,
+    {
+      name: `MCP project-config flow ${unique}`,
+      description: "Chat Input -> Chat Output passthrough for MCP exposure tests",
+      data: fixture.data,
+      is_component: false,
+      folder_id: projectId,
+    },
+    { headers },
+  );
+}
+
+test.describe("MCP Server — per-project tool exposure", () => {
+  let authorization: string;
+  let headers: Record<string, string>;
+  let projectId: string;
+  let deleteProjectFn: (req?: APIRequestContext) => Promise<void>;
+  let flowId: string;
+  let streamableUrl: string;
+
+  // Unique per run, and a valid MCP tool name (snake_case): `tools/list`
+  // containment is then an assertion about THIS run's flow.
+  //
+  // Deliberately SHORT. The protocol does not serve `action_name` verbatim — it
+  // serves `get_unique_name(sanitize_mcp_name(action_name), 30, …)`, and
+  // `MAX_MCP_TOOL_NAME_LENGTH` is 30 (`src/lfx/src/lfx/base/mcp/constants.py`),
+  // while the REST endpoint returns the stored name untouched. A 35-character
+  // name therefore round-trips through `GET` and comes back **truncated** in
+  // `tools/list`, which reads exactly like the tool having failed to publish.
+  // Measured on 1.12.0.dev20 while writing this spec. Base-36 keeps it ~21 chars
+  // and inside the sanitizer's character class, so the name reaching the client
+  // is the one written here.
+  const actionName = `e2e_cfg_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
+  const actionDescription = "E2E per-project exposure tool";
+
+  test.beforeAll(async ({ request }) => {
+    authorization = await getAuthToken(request);
+    expect(
+      authorization,
+      "Auth token is empty — every assertion below would fail for an auth " +
+        "reason rather than for the contract",
+    ).toBeTruthy();
+    headers = { Authorization: authorization };
+
+    // Fixture guard, not product coverage: the assertions below compare the
+    // protocol's tool name to `actionName` for equality, which only holds while
+    // it survives the 30-char cap. Fails here, naming the cap, rather than as a
+    // confusing tools/list miss if someone lengthens the prefix.
+    expect(
+      actionName.length,
+      `the action name must stay within MAX_MCP_TOOL_NAME_LENGTH (30) or the ` +
+        `protocol will serve a truncated name: ${actionName}`,
+    ).toBeLessThanOrEqual(30);
+
+    // The prefix is SIX characters, and that is load-bearing rather than terse.
+    // Creating a project derives an MCP server named
+    // `lf-${sanitize_mcp_name(name)[:26]}` (`MAX_MCP_SERVER_NAME_LENGTH` is 30,
+    // minus the `lf-` prefix), and that derived name must be unique per user.
+    // `createProjectViaApi` appends `-${Date.now()}-${rand5}` — 20 characters —
+    // so a prefix longer than 6 pushes the unique part past the cut and every
+    // project this spec creates collides with the previous one:
+    // `POST /api/v1/projects/` → 409 "MCP server name conflict:
+    // 'lf-e2e_mcp_project_config_178' already exists for a different project".
+    // Measured on 1.12.0.dev20 with `--workers=4 --repeat-each=3`, which is how
+    // the first version of this spec failed. At six characters the whole
+    // timestamp and random suffix survive the truncation.
+    const project = await createProjectViaApi(request, headers, {
+      namePrefix: "e2ecfg",
+      description: "Per-project MCP exposure (#1396)",
+    });
+    projectId = project.projectId;
+    deleteProjectFn = project.deleteProject;
+    streamableUrl = `/api/v1/mcp/project/${projectId}/streamable`;
+
+    flowId = await createChatFlowInProject(request, headers, projectId);
+  });
+
+  test.afterAll(async ({ request }) => {
+    // The afterAll's own live `request`: Playwright forbids reusing the
+    // beforeAll one. Flow first, then the project — deleting a project with a
+    // flow still in it is a different, untested path.
+    if (flowId) {
+      await deleteFlow(request, flowId, { headers }).catch(() => {});
+    }
+    if (deleteProjectFn) {
+      await deleteProjectFn(request).catch(() => {});
+    }
+  });
+
+  test("project MCP settings round-trip through GET and PATCH", { tag: ["@stable", "@api", "@mcp"] },
+    async ({ request }) => {
+      await test.step("a freshly created project exposes nothing", async () => {
+        // The baseline every later assertion is measured against: without it, a
+        // build that exposed every flow by default would still pass step 2.
+        const res = await request.get(`/api/v1/mcp/project/${projectId}`, {
+          headers,
+        });
+        expect(res.status(), await res.text()).toBe(200);
+        const body = await res.json();
+        expect(
+          body.tools,
+          "a new project must expose no MCP tools before anything is selected",
+        ).toEqual([]);
+      });
+
+      await test.step("PATCH selects the flow as an exposed tool", async () => {
+        const res = await request.patch(`/api/v1/mcp/project/${projectId}`, {
+          headers,
+          data: {
+            settings: [
+              {
+                id: flowId,
+                mcp_enabled: true,
+                action_name: actionName,
+                action_description: actionDescription,
+              },
+            ],
+          },
+        });
+        expect(res.status(), await res.text()).toBe(200);
+      });
+
+      await test.step("GET reads the selection back", async () => {
+        const res = await request.get(`/api/v1/mcp/project/${projectId}`, {
+          headers,
+        });
+        expect(res.status(), await res.text()).toBe(200);
+        const body = await res.json();
+
+        expect(
+          body.tools,
+          "exactly the one flow just selected must be listed",
+        ).toHaveLength(1);
+        // The endpoint returns BOTH the action pair and the flow's own
+        // name/description; they are not the same thing and a build that echoed
+        // the flow name as the action name would pass a laxer check.
+        expect(body.tools[0]).toMatchObject({
+          id: flowId,
+          mcp_enabled: true,
+          action_name: actionName,
+          action_description: actionDescription,
+        });
+        expect(
+          body.tools[0].name,
+          "the flow's own name must survive alongside the action name",
+        ).toContain("MCP project-config flow");
+      });
+    },
+  );
+
+  test("an exposed flow is served over the protocol, and de-selecting withdraws it", { tag: ["@stable", "@api", "@mcp"] },
+    async ({ request }) => {
+      await test.step("the handshake identifies THIS project's MCP server", async () => {
+        // Asserted first: a misdirected endpoint would otherwise produce an
+        // empty tools/list that reads exactly like correct de-selection.
+        const info = await mcpHandshake(request, streamableUrl, authorization);
+        expect(info.serverInfo.name).toBe(`langflow-mcp-project-${projectId}`);
+      });
+
+      await test.step("tools/list exposes the selected flow under its action name", async () => {
+        const resp = await mcpCall(
+          request,
+          streamableUrl,
+          authorization,
+          "tools/list",
+          undefined,
+          2,
+        );
+        const tools: Array<{ name: string; description?: string }> =
+          resp.result?.tools ?? [];
+        const tool = tools.find((t) => t.name === actionName);
+        expect(
+          tool,
+          `tools/list must expose ${actionName}; got ${JSON.stringify(tools.map((t) => t.name))}`,
+        ).toBeDefined();
+        expect(
+          tool?.description,
+          "the tool is described by its ACTION description, not the flow's",
+        ).toBe(actionDescription);
+      });
+
+      await test.step("tools/call runs it — the listing is a working capability", async () => {
+        // Unique sentinel: a canned or cached response cannot echo this exact
+        // string, so a pass proves the call round-tripped through the flow.
+        const sentinel = `mcp-cfg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const resp = await mcpCall(
+          request,
+          streamableUrl,
+          authorization,
+          "tools/call",
+          { name: actionName, arguments: { input_value: sentinel } },
+          3,
+        );
+        expect(resp.error, JSON.stringify(resp.error)).toBeUndefined();
+        expect(resp.result?.isError).toBe(false);
+        expect(resp.result?.content?.[0]?.text).toBe(sentinel);
+      });
+
+      await test.step("PATCH de-selects the flow", async () => {
+        const res = await request.patch(`/api/v1/mcp/project/${projectId}`, {
+          headers,
+          data: {
+            settings: [
+              {
+                id: flowId,
+                mcp_enabled: false,
+                action_name: actionName,
+                action_description: actionDescription,
+              },
+            ],
+          },
+        });
+        expect(res.status(), await res.text()).toBe(200);
+      });
+
+      await test.step("the protocol no longer serves it", async () => {
+        // The assertion the bullet is about, made where a client would see it.
+        const resp = await mcpCall(
+          request,
+          streamableUrl,
+          authorization,
+          "tools/list",
+          undefined,
+          4,
+        );
+        const names: string[] = (resp.result?.tools ?? []).map(
+          (t: { name: string }) => t.name,
+        );
+        expect(
+          names,
+          "a de-selected flow must be gone from tools/list over the protocol",
+        ).not.toContain(actionName);
+      });
+
+      await test.step("GET agrees, and ?mcp_enabled=false still finds the flow", async () => {
+        const enabled = await request.get(
+          `/api/v1/mcp/project/${projectId}`,
+          { headers },
+        );
+        expect(enabled.status(), await enabled.text()).toBe(200);
+        expect((await enabled.json()).tools).toEqual([]);
+
+        // The query parameter selects WHICH set is listed — it does not toggle
+        // anything — and this half also proves the flow was withdrawn from
+        // exposure rather than deleted or detached from the project.
+        const disabled = await request.get(
+          `/api/v1/mcp/project/${projectId}?mcp_enabled=false`,
+          { headers },
+        );
+        expect(disabled.status(), await disabled.text()).toBe(200);
+        const body = await disabled.json();
+        expect(body.tools).toHaveLength(1);
+        expect(body.tools[0]).toMatchObject({
+          id: flowId,
+          mcp_enabled: false,
+          action_name: actionName,
+        });
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #1396

## Why

`PATCH`/`GET /api/v1/mcp/project/{id}` decide which of a project's flows are exposed as MCP tools, and nothing asserted that the **protocol** agrees with that selection: `mcp-server-tab.spec.ts` covers the UI, and `mcp-server-protocol.spec.ts` covers a flow that is already exposed on the default project. QA-CHECKLIST §14.1.

## What lands

Two tests, pure API + JSON-RPC — no browser, no LLM key, no npm registry:

- **The selection round-trips.** A freshly created project exposes nothing; one `PATCH` exposes exactly the flow it names; `GET` reads back both the action pair and the flow's own name/description, which are not the same thing.
- **The protocol reflects it, both ways.** The action appears in `tools/list` under its action name and its **action** description, `tools/call` runs it and echoes a unique sentinel — so the listing is a working capability, not a string — and after `mcp_enabled: false` it is **gone from `tools/list`**, which is where the issue asks for the assertion. `GET` agrees, and the unfiltered listing still finds the flow, proving it was withdrawn rather than deleted.

It creates its **own project and flow**, so it cannot race `mcp-server-protocol.spec.ts` (which mutates the default project and carries a comment anticipating exactly this second spec). The protocol client is the repo's `mcp-streamable-client.ts`, as the issue requires. The flow is created by a file-local helper rather than by extending `createRunnableChatFlowViaApi` with a `folder_id`: that helper has 29 call sites across 21 specs, and the import-graph selection (#1054) would pull every one of them into this PR's E2E lane for two lines.

## Three product behaviours measured on the way — two shaped the spec, one is a filed defect

**A de-selected flow is unlisted but still callable.** `tools/call` on a flow whose `mcp_enabled` is false runs it and returns `isError: false`. Not a cache: a tool never called while enabled behaves the same, while an unknown name answers `Flow with name '…' not found`. `handle_list_project_tools` passes `mcp_enabled_only=True`; `handle_call_tool` resolves by action name, checks the project, enforces `FlowAction.EXECUTE` — and never reads `mcp_enabled`. **The per-project selection is a discovery control, not an invocation control.** Filed as **#1408**; recorded under *What this test does not cover* rather than asserted, since asserting the corrected behaviour ships a durably red `@stable` test that triage strips within a day.

**Two projects whose names share their first 26 characters cannot coexist** — `POST /api/v1/projects/` answers 409 naming an `lf-…` MCP server the user never created. This spec's first version hit it (`namePrefix: "e2e-mcp-project-config"` pushed the uniqueness suffix past the cut), and it only appeared under `--workers=4 --repeat-each=3`. It is not a test artefact: `Marketing Automation Project Alpha` creates and `… Beta` is refused. Filed as **#1409**.

**A truncated tool name is uninvocable.** `tools/list` caps the served name at 30 while the lookup does not, so a 37-character action is advertised under a name that `tools/call` answers `not found` for. Recorded in the spec doc; MCP tool naming deserves its own spec.

## Validation

Against Langflow Nightly **1.12.0.dev20**, per CONTRIBUTING:

- typecheck ✓ · lint 0 errors ✓ · both checklist guards ✓ · `validate:specs` counts the doc as declaring its dependencies ✓
- 3× `--retries=0` burst green (~0.9 s each) · `--trace=on` green · `--workers=4 --repeat-each=3` → 6 expected / 0 unexpected · alongside `mcp-server-protocol.spec.ts` at `--workers=4` → 4 passed, no interference
- **Eight force-failure / mutation checks** across both rounds, each failing for the right reason; no `🚨 Backend Error`; instance left byte-identical (1 project, 28 flows, 2 MCP servers), including after a run where teardown was forced to fail.

## Commits

1. `472cde9` — the spec, the spec doc, the checklist bullet.
2. `80914fd` — **independent-review fixes**, and the first two are the ones worth reading:
   - the de-selection assertion **could pass vacuously** — `resp.result?.tools ?? []` turned any failed JSON-RPC call into an empty list, so a broken protocol would have reported green. Both `tools/list` calls now verify the response first; the reviewer's mutation fails against the fix.
   - `?mcp_enabled=false` **does not list the disabled flows** — it removes the filter entirely, returning every flow in the project. My doc claimed a contract the endpoint does not have.
   - `GET` does not return `action_name` untouched — it sanitizes at cap 46 against the protocol's 30, so the `beforeAll` guard now checks the character class as well as the length.
   - a **duplicate checklist bullet**: §14.1 already carried this behaviour as `[ ]` and I appended a second. The existing one is now checked. *(The same defect was in PR #1405 and is fixed there — `b2f0bf7`.)*
   - teardown no longer swallows cleanup failures.