### PR TITLE
fix(collect-models): stop the anthropic stall from taking google down with it (#1385)

### DIFF
--- a/docs/collect-models.md
+++ b/docs/collect-models.md
@@ -338,6 +338,68 @@ The daily makes the opposite trade deliberately (`continue-on-error: true`, #980
 — a day of coverage outweighs a diagnostic red). That asymmetry is intentional and
 is now stated in both workflows rather than implied by one of them.
 
+### The shared budget was solved against the wrong clock (#1385)
+
+Defect 2 above is right about the arithmetic and wrong about its **input**. It
+sized the sweep's shared budget at `210 s = the 300 s test timeout minus a ~90 s
+reserve` — and 300 s is `playwright.config.ts`'s default for a **product** spec.
+Nothing about it was ever derived from what this sweep costs, so a suite-wide
+default became the bound on how many providers get configured.
+
+On [run 31373880200](https://github.com/oriontech-me/langflow-e2e/actions/runs/31373880200)
+(2026-08-10) that produced, on **3 of 4 shards**, in this order:
+
+```
+no credential write observed for provider "anthropic" within 176s of clicking Save
+skipped waiting for provider "anthropic" … the sweep's shared budget is down to 30s
+Models found (anthropic): []
+the "Save" button for provider "google" never became actionable after 30.1s over 117 poll(s)
+Models found (google): []
+```
+
+Google's 30 s was the whole of its reserve, and its **first** wait spent it — the
+`Save`-idle wait, which is the one wait that is about the *previous* provider.
+Google therefore never clicked Save at all, and 5 of the run's 6 skips followed
+across three areas. Shard 1, which did not stall, collected all three.
+
+Every anthropic credential write CI has measured since the wait existed:
+
+| date | shard results |
+|---|---|
+| 2026-08-07 ([31163810520](https://github.com/oriontech-me/langflow-e2e/actions/runs/31163810520)) | 111.1 s ✅, 176.2 s ✅, >180 s ✗, >180 s ✗ |
+| 2026-08-10 ([31373880200](https://github.com/oriontech-me/langflow-e2e/actions/runs/31373880200)) | 105.8 s ✅, >176 s ✗, >176 s ✗, >175 s ✗ |
+
+So the 180 s ceiling sat in the **middle** of the distribution, 2 % above the
+largest success. The duration is **contention, not a fixed cost**: the same save
+measures **5.9 s** against an idle local backend with two providers already
+configured (1.12.0.dev22, `Disconnect` 0.5 s behind the 201). The lanes run
+`LANGFLOW_WORKERS=1` and the openai pass ahead of it enables 41 models.
+
+Four changes, each unit-covered and each verified by mutation:
+
+1. **The pre-flight owns its own clock.** `tests/collect-models.spec.ts` sets
+   `test.setTimeout(12 min)`, and the budget is sized from the sweep's worst
+   measured shape (~450 s of post-Save waits) instead of from a product default.
+   It costs nothing on a healthy run — the whole sweep measures ~55 s on CI.
+2. **The reserve is a whole PASS per remaining provider** (30 s → 60 s). 30 s was
+   sized against one wait, google's 15.7 s write; a provider's pass is three.
+3. **The `Save`-idle wait may take at most half of what its provider can
+   afford.** The reserve protects the *next* provider; nothing protected a
+   provider from its own first wait, which is precisely how google lost its 30 s.
+4. **The credential ceiling moves 180 s → 240 s**, past the observed tail.
+
+**And the diagnostic no longer over-claims.** Both verdict lines were wrong on
+that one sweep, in opposite directions. Shard 2 printed `still BUSY` for a wait
+clipped to 30.0 s of its 60 s ceiling; shards 3 and 4 printed `aria-busy
+(absent) / aria-disabled (absent) / enabled false` and concluded *"a state this
+helper does not model"*, sending the reader to the panel markup. That second
+state is reproducible in one step — it is the `Save` button with an **empty key
+field** (measured on 1.12.0.dev22; with the key typed the same button is
+actionable on poll 1). The message now reports what the sweep can support, in
+that order: a budget-shortened wait says so **and names who spent it**, an empty
+key field is named as such, and the markup claim is the last resort rather than
+the default.
+
 ---
 
 ## External dependencies *(required)*

--- a/tests/collect-models.spec.ts
+++ b/tests/collect-models.spec.ts
@@ -40,6 +40,26 @@ test(
   "collect providers status and models from UI",
   { tag: ["@stable", "@model-provider", "@settings"] },
   async ({ page }) => {
+    // This pre-flight owns its own clock (#1385).
+    //
+    // `playwright.config.ts` sets 5 minutes, and that number is the default for a
+    // PRODUCT spec — nothing about it was ever derived from what this sweep
+    // costs. #1370 nonetheless sized the sweep's shared post-Save budget from it
+    // (210 s = 300 s minus a ~90 s reserve), which made the suite-wide default
+    // the binding constraint on how many providers get configured: against an
+    // anthropic credential write measured at 105–180 s+ on CI, 30 s was left for
+    // google, google's Save-idle wait spent it before a Save was ever clicked,
+    // and 5 of the run's 6 skips on 2026-08-10 followed from that on 3 of 4
+    // shards.
+    //
+    // 12 minutes is the sweep's worst measured shape (~450 s of post-Save waits,
+    // see SWEEP_SAVE_BUDGET_MS) plus the ~90 s of build axis, navigation, toggle
+    // sweeps, key probes and file writes, with room over. It costs nothing on a
+    // healthy run — the whole sweep measures ~55 s on CI and ~24 s locally — and
+    // it is still far below the lanes' own `timeout-minutes` (90 on the daily),
+    // so a wedged pre-flight is bounded here rather than by the job.
+    test.setTimeout(12 * 60 * 1000);
+
     await page.goto("/");
     await page.waitForSelector('[data-testid="mainpage_title"]', { timeout: 30000 });
 

--- a/tests/helpers/provider-setup/collect-models.test.ts
+++ b/tests/helpers/provider-setup/collect-models.test.ts
@@ -34,10 +34,15 @@ import * as path from "path";
 import {
   classifyWaitFailure,
   COLLECTOR_STALL_PREFIX,
+  formatBudgetSpend,
   formatSaveBusyFailure,
   isCollectorStallReason,
   NO_MODELS_COLLECTED,
+  planConfiguredWait,
+  planCredentialWait,
+  planIdleWait,
   planSaveWait,
+  sweepSaveBudgetMs,
   rankCandidates,
   resolveRequiredProviders,
   validateProviderWithFallback,
@@ -569,6 +574,133 @@ test("#1355: a button busy past the deadline gives up and reports WHY, naming th
   );
 });
 
+// ─── What the failure message is ALLOWED to claim (#1385) ────────────────────
+//
+// Both verdict lines were wrong on run 31373880200, in opposite directions, on
+// the same sweep. Shard 2 printed `aria-busy true … still BUSY` for a wait that
+// had been clipped to 30.0s of its 60s ceiling; shards 3 and 4 printed
+// `(absent)/(absent)/enabled false … a state this helper does not model` and
+// sent the reader to the panel markup. That second state is reproducible in one
+// step — it is the Save button with an EMPTY key field (measured on
+// 1.12.0.dev22; with the key typed the same button is actionable on poll 1).
+
+/** The verdict for google exactly as run 31373880200 shard 4 measured it. */
+const GOOGLE_20260810 = {
+  idle: false,
+  ariaBusy: null,
+  ariaDisabled: null,
+  enabled: false,
+  waitedMs: 30_100,
+  polls: 117,
+};
+
+test("#1385: a wait the BUDGET shortened says so, and claims nothing about the markup", () => {
+  const message = formatSaveBusyFailure("google", GOOGLE_20260810, {
+    grantedMs: 30_000,
+    ceilingMs: 60_000,
+    remainingBudgetMs: 30_000,
+    spentBefore: [
+      { provider: "openai", ms: 4_000 },
+      { provider: "anthropic", ms: 176_000 },
+    ],
+    keyFieldChars: 0,
+  });
+
+  assert.match(message, /BUDGET, not the panel/);
+  assert.match(message, /shortened to 30\.0s of its\n\s+60\.0s ceiling/);
+  assert.match(message, /"anthropic" 176\.0s/, "the collateral is unreadable without naming who spent it");
+  assert.doesNotMatch(
+    message,
+    /does not model/,
+    "the shipped message pointed at the panel markup for a wait that was never given its ceiling",
+  );
+  assert.doesNotMatch(message, /still BUSY/);
+});
+
+test("#1385: the budget verdict OUTRANKS the empty key field", () => {
+  // Both were true on 2026-08-10. Only one of them is a claim this sweep can
+  // support: with 30s of a 60s ceiling, the wait never established anything
+  // about the field either.
+  const message = formatSaveBusyFailure("google", GOOGLE_20260810, {
+    grantedMs: 30_000,
+    ceilingMs: 60_000,
+    remainingBudgetMs: 30_000,
+    spentBefore: [{ provider: "anthropic", ms: 176_000 }],
+    keyFieldChars: 0,
+  });
+  assert.match(message, /BUDGET, not the panel/);
+  assert.doesNotMatch(message, /API-key field is EMPTY/);
+  assert.match(message, /key field\s+0 character\(s\)/, "still REPORTED, just not made the verdict");
+});
+
+test("#1385: a full-ceiling wait on an empty key field names the field, not the markup", () => {
+  const message = formatSaveBusyFailure("google", GOOGLE_20260810, {
+    grantedMs: 60_000,
+    ceilingMs: 60_000,
+    remainingBudgetMs: 300_000,
+    spentBefore: [{ provider: "anthropic", ms: 20_000 }],
+    keyFieldChars: 0,
+  });
+  assert.match(message, /API-key field is EMPTY/);
+  assert.match(message, /did not reach the field/);
+  assert.doesNotMatch(message, /does not model/);
+});
+
+test("#1385: an unreadable key field is UNKNOWN, and cannot become the empty-field verdict", () => {
+  // #1012's rule: a field nobody could read is not a field that was empty.
+  const message = formatSaveBusyFailure("google", GOOGLE_20260810, {
+    grantedMs: 60_000,
+    ceilingMs: 60_000,
+    remainingBudgetMs: 300_000,
+    spentBefore: [],
+    keyFieldChars: null,
+  });
+  assert.match(message, /unreadable — unknown, not empty/);
+  assert.doesNotMatch(message, /API-key field is EMPTY/);
+  assert.match(message, /does not model/, "no supportable claim left — the last resort is the right one here");
+});
+
+test("#1385: a populated field, a full ceiling and a busy button still get the #1355 verdict", () => {
+  const message = formatSaveBusyFailure(
+    "google",
+    { idle: false, ariaBusy: "true", ariaDisabled: "true", enabled: false, waitedMs: 60_000, polls: 240 },
+    {
+      grantedMs: 60_000,
+      ceilingMs: 60_000,
+      remainingBudgetMs: 300_000,
+      spentBefore: [{ provider: "anthropic", ms: 20_000 }],
+      keyFieldChars: 108,
+    },
+  );
+  assert.match(message, /still BUSY/);
+  assert.match(message, /PREVIOUS provider's/);
+  assert.doesNotMatch(message, /BUDGET, not the panel/);
+});
+
+test("#1385: with no context at all the message is exactly the #1355 one", () => {
+  // The context is optional so the helper stays callable from anywhere; a caller
+  // that has nothing to add must not be made to invent it.
+  const message = formatSaveBusyFailure("google", GOOGLE_20260810);
+  assert.match(message, /does not model/);
+  assert.doesNotMatch(message, /key field/);
+  assert.doesNotMatch(message, /wait granted/);
+});
+
+test("#1385: the spend ledger renders who took the budget, and states an empty one", () => {
+  assert.equal(
+    formatBudgetSpend([
+      { provider: "openai", ms: 4_000 },
+      { provider: "anthropic", ms: 176_000 },
+    ]),
+    '"openai" 4.0s, "anthropic" 176.0s',
+  );
+  assert.match(
+    formatBudgetSpend([]),
+    /first provider of the sweep/,
+    "an empty ledger is a finding, not an empty string",
+  );
+});
+
 test("#1355: aria-disabled alone is not idle, and reads as the not-modelled state", async () => {
   const clock = fakeClock();
   const verdict = await waitForButtonIdle(fakeButton([{ ariaDisabled: "true" }]), {
@@ -740,37 +872,87 @@ test("#1370: the detail is the FIRST line, so a Playwright call log does not flo
 // that can end the run. Attempt 2 died at exactly 5 minutes; attempt 3 survived
 // the same stall with 3s to spare.
 
+// Every case below passes `reservePerProviderMs: 30_000` EXPLICITLY. It was the
+// default when #1370 shipped and #1385 has since raised it to 60s, so pinning it
+// here keeps these tests replaying the incident they were written from rather
+// than silently re-deriving against whatever today's constant is. The live
+// defaults get their own replay at the bottom of the #1385 block.
+const RESERVE_1370 = { reservePerProviderMs: 30_000 };
+
 test("#1370: the FIRST provider of three cannot spend the whole budget", () => {
   // 210s budget, two providers still to come, 30s reserved for each: 150s, not
   // the 180s ceiling. That gap is the mechanism, not a rounding artifact — the
   // ceiling is what ONE wait may cost, the budget is what the sweep may cost,
   // and before #1370 only the first of those existed.
-  const plan = planSaveWait({ ceilingMs: 180_000, remainingMs: 210_000, providersLeftAfterThis: 2 });
-  assert.deepEqual(plan, { wait: true, timeoutMs: 150_000 });
+  const plan = planSaveWait({
+    ceilingMs: 180_000,
+    remainingMs: 210_000,
+    providersLeftAfterThis: 2,
+    ...RESERVE_1370,
+  });
+  assert.deepEqual(plan, {
+    wait: true,
+    timeoutMs: 150_000,
+    ceilingMs: 180_000,
+    shortenedByBudget: true,
+  });
 });
 
 test("#1370: the ceiling still binds when the budget is ample", () => {
-  const plan = planSaveWait({ ceilingMs: 180_000, remainingMs: 600_000, providersLeftAfterThis: 2 });
-  assert.deepEqual(plan, { wait: true, timeoutMs: 180_000 }, "a wait must never outlive its own ceiling");
+  const plan = planSaveWait({
+    ceilingMs: 180_000,
+    remainingMs: 600_000,
+    providersLeftAfterThis: 2,
+    ...RESERVE_1370,
+  });
+  assert.deepEqual(
+    plan,
+    { wait: true, timeoutMs: 180_000, ceilingMs: 180_000, shortenedByBudget: false },
+    "a wait must never outlive its own ceiling",
+  );
 });
 
 test("#1370: the ceiling is capped by what the budget can still afford", () => {
   // anthropic has already spent most of the sweep; the last provider is what the
   // reserve protects.
-  const plan = planSaveWait({ ceilingMs: 180_000, remainingMs: 100_000, providersLeftAfterThis: 1 });
-  assert.deepEqual(plan, { wait: true, timeoutMs: 70_000 }, "100s minus a 30s reserve for the one still to come");
+  const plan = planSaveWait({
+    ceilingMs: 180_000,
+    remainingMs: 100_000,
+    providersLeftAfterThis: 1,
+    ...RESERVE_1370,
+  });
+  assert.deepEqual(
+    plan,
+    { wait: true, timeoutMs: 70_000, ceilingMs: 180_000, shortenedByBudget: true },
+    "100s minus a 30s reserve for the one still to come",
+  );
 });
 
 test("#1370: the LAST provider reserves nothing and may spend the remainder", () => {
-  const plan = planSaveWait({ ceilingMs: 180_000, remainingMs: 40_000, providersLeftAfterThis: 0 });
-  assert.deepEqual(plan, { wait: true, timeoutMs: 40_000 });
+  const plan = planSaveWait({
+    ceilingMs: 180_000,
+    remainingMs: 40_000,
+    providersLeftAfterThis: 0,
+    ...RESERVE_1370,
+  });
+  assert.deepEqual(plan, {
+    wait: true,
+    timeoutMs: 40_000,
+    ceilingMs: 180_000,
+    shortenedByBudget: true,
+  });
 });
 
 test("#1370: an exhausted budget SKIPS the wait instead of shortening it to zero", () => {
   // Load-bearing: Playwright reads `timeout: 0` as NO timeout, so an exhausted
   // budget arriving as a number would wait forever — the exact opposite of the
   // budget's purpose. The discriminated result makes that unreachable.
-  const plan = planSaveWait({ ceilingMs: 180_000, remainingMs: 30_000, providersLeftAfterThis: 1 });
+  const plan = planSaveWait({
+    ceilingMs: 180_000,
+    remainingMs: 30_000,
+    providersLeftAfterThis: 1,
+    ...RESERVE_1370,
+  });
   assert.equal(plan.wait, false);
   assert.match((plan as { reason: string }).reason, /budget is down to 30s/);
   assert.match((plan as { reason: string }).reason, /1 provider\(s\) still to configure/);
@@ -778,15 +960,24 @@ test("#1370: an exhausted budget SKIPS the wait instead of shortening it to zero
 
 test("#1370: no reachable input yields a zero or negative timeout", () => {
   // The property, not one example: whatever the budget state, either the wait is
-  // refused or it carries a timeout Playwright will honour as a deadline.
-  for (const remainingMs of [-50_000, 0, 1, 4_999, 5_000, 29_999, 210_000]) {
+  // refused or it carries a timeout Playwright will honour as a deadline. The
+  // share is swept too (#1385) — a fraction is a second way to reach zero.
+  for (const remainingMs of [-50_000, 0, 1, 4_999, 5_000, 29_999, 210_000, 450_000]) {
     for (const providersLeftAfterThis of [0, 1, 2, 5]) {
-      const plan = planSaveWait({ ceilingMs: 180_000, remainingMs, providersLeftAfterThis });
-      if (plan.wait) {
-        assert.ok(
-          plan.timeoutMs >= 5_000,
-          `remaining=${remainingMs} left=${providersLeftAfterThis} produced timeoutMs=${plan.timeoutMs}`,
-        );
+      for (const shareOfRemaining of [undefined, 1, 0.5, 0.1, 0]) {
+        const plan = planSaveWait({
+          ceilingMs: 180_000,
+          remainingMs,
+          providersLeftAfterThis,
+          shareOfRemaining,
+        });
+        if (plan.wait) {
+          assert.ok(
+            plan.timeoutMs >= 5_000,
+            `remaining=${remainingMs} left=${providersLeftAfterThis} share=${shareOfRemaining} ` +
+              `produced timeoutMs=${plan.timeoutMs}`,
+          );
+        }
       }
     }
   }
@@ -801,6 +992,7 @@ test("#1370: the two waits share one budget — 180 + 60 can no longer both be s
     ceilingMs: 180_000,
     remainingMs: budget.remainingMs,
     providersLeftAfterThis: 1,
+    ...RESERVE_1370,
   });
   assert.equal(credential.wait, true);
   budget.remainingMs -= (credential as { timeoutMs: number }).timeoutMs;
@@ -809,11 +1001,166 @@ test("#1370: the two waits share one budget — 180 + 60 can no longer both be s
     ceilingMs: 60_000,
     remainingMs: budget.remainingMs,
     providersLeftAfterThis: 1,
+    ...RESERVE_1370,
   });
   assert.equal(configured.wait, false, "30s left, all of it reserved for the provider still to come");
 
   const spent = 210_000 - budget.remainingMs;
   assert.ok(spent <= 180_000, `one provider must not be able to spend 240s of a 210s budget, spent ${spent}`);
+});
+
+// ─── The share cap and the collateral stall (#1385) ──────────────────────────
+//
+// #1370's reserve answers "will the NEXT provider have anything left". It cannot
+// answer "will THIS provider's own remaining waits", and on 2026-08-10 that gap
+// cost google every one of its 30s: the Save-idle wait — the one wait that is
+// about the PREVIOUS provider, not this one — spent the whole reserve before a
+// Save was ever clicked, so google was recorded as a stall having never been
+// configured, on 3 of 4 shards.
+
+test("#1385: the idle wait cannot spend a provider's whole allowance on the previous one", () => {
+  // google's exact position on run 31373880200: last provider, 30s left.
+  const withoutShare = planSaveWait({
+    ceilingMs: 60_000,
+    remainingMs: 30_000,
+    providersLeftAfterThis: 0,
+  });
+  assert.deepEqual(
+    withoutShare,
+    { wait: true, timeoutMs: 30_000, ceilingMs: 60_000, shortenedByBudget: true },
+    "the shipped behaviour: every remaining millisecond goes to waiting on anthropic",
+  );
+
+  const withShare = planSaveWait({
+    ceilingMs: 60_000,
+    remainingMs: 30_000,
+    providersLeftAfterThis: 0,
+    shareOfRemaining: 0.5,
+  });
+  assert.equal(withShare.wait, true);
+  assert.equal((withShare as { timeoutMs: number }).timeoutMs, 15_000);
+});
+
+test("#1385: the share narrows a wait, it never widens one past its ceiling", () => {
+  const plan = planSaveWait({
+    ceilingMs: 60_000,
+    remainingMs: 450_000,
+    providersLeftAfterThis: 0,
+    shareOfRemaining: 0.5,
+  });
+  assert.equal((plan as { timeoutMs: number }).timeoutMs, 60_000, "half of 450s is 225s — the ceiling still binds");
+  assert.equal((plan as { shortenedByBudget: boolean }).shortenedByBudget, false);
+});
+
+test("#1385: a plan reports whether the BUDGET shortened it, not just the number", () => {
+  // The flag is what lets the failure message separate "this button is broken"
+  // from "this wait was never given the time to find out".
+  const full = planSaveWait({ ceilingMs: 60_000, remainingMs: 450_000, providersLeftAfterThis: 0 });
+  assert.equal((full as { shortenedByBudget: boolean }).shortenedByBudget, false);
+
+  const clipped = planSaveWait({ ceilingMs: 60_000, remainingMs: 40_000, providersLeftAfterThis: 0 });
+  assert.equal((clipped as { shortenedByBudget: boolean }).shortenedByBudget, true);
+  assert.equal((clipped as { ceilingMs: number }).ceilingMs, 60_000, "the plan carries what it WOULD have had");
+});
+
+test("#1385: only the IDLE wait is share-capped — the write that configures a provider is not", () => {
+  // Pins the call site, not the arithmetic: `planSaveWait` cannot tell which of
+  // the three waits it is serving, so dropping the share at the call site would
+  // pass every test above it. 40s left, last provider, nothing reserved.
+  const idle = planIdleWait(40_000, 0);
+  const credential = planCredentialWait(40_000, 0);
+  const configured = planConfiguredWait(40_000, 0);
+
+  assert.equal((idle as { timeoutMs: number }).timeoutMs, 20_000, "half — the previous provider's overhang");
+  assert.equal((credential as { timeoutMs: number }).timeoutMs, 40_000, "all of it — this is the wait that saves");
+  assert.equal((configured as { timeoutMs: number }).timeoutMs, 40_000);
+});
+
+test("#1385: the live ceilings are the measured ones, not the ones that were exceeded", () => {
+  // A ceiling reachable only through a plan, so the numbers cannot drift apart
+  // from the call site. 180s sat in the middle of the observed anthropic
+  // distribution (largest success 176.2s, two shards past 180s).
+  const ample = 10 * 60 * 1000;
+  assert.equal((planCredentialWait(ample, 0) as { ceilingMs: number }).ceilingMs, 240_000);
+  assert.equal((planIdleWait(ample, 0) as { ceilingMs: number }).ceilingMs, 60_000);
+  assert.equal((planConfiguredWait(ample, 0) as { ceilingMs: number }).ceilingMs, 60_000);
+  assert.equal(sweepSaveBudgetMs, 450_000);
+});
+
+test("#1385: the live reserve is a whole PASS per remaining provider, not one wait", () => {
+  // Only observable where it binds — with 450s of budget it usually does not, so
+  // a near-exhausted state is what pins it. 100s left with one provider to come:
+  // 60s is held back, so this wait may have 40s. At #1370's 30s reserve it would
+  // be 70s, which is the arithmetic that left google unable to click Save at all.
+  const plan = planCredentialWait(100_000, 1);
+  assert.equal(
+    (plan as { timeoutMs: number }).timeoutMs,
+    40_000,
+    "the provider still to come needs idle + write + configured-state, not just a write",
+  );
+});
+
+test("#1385: run 31373880200 replayed on the LIVE defaults — google keeps a usable allowance", () => {
+  // The whole incident, in the arithmetic that produced it, driven through the
+  // functions the sweep itself calls. anthropic takes its full credential
+  // ceiling; the question is what google has left afterwards. Lowering
+  // SWEEP_SAVE_BUDGET_MS, the reserve or the ceilings fails HERE rather than on
+  // a shard three days later.
+  const budget = { remainingMs: sweepSaveBudgetMs };
+
+  // openai — fast in every run measured (~5s write), with two providers to come.
+  budget.remainingMs -= 5_000;
+
+  // anthropic: spends its entire ceiling and still leaves the sweep solvent.
+  const anthropic = planCredentialWait(budget.remainingMs, 1);
+  assert.equal(anthropic.wait, true);
+  assert.equal(
+    (anthropic as { timeoutMs: number }).timeoutMs,
+    240_000,
+    "a slow anthropic must reach its full ceiling — 176.2s succeeded once and 180s was exceeded twice",
+  );
+  budget.remainingMs -= (anthropic as { timeoutMs: number }).timeoutMs;
+
+  // google's idle wait — the one that got 30s and spent all of it on 2026-08-10.
+  const googleIdle = planIdleWait(budget.remainingMs, 0);
+  assert.equal(googleIdle.wait, true);
+  assert.equal(
+    (googleIdle as { timeoutMs: number }).timeoutMs,
+    60_000,
+    "google's Save-idle wait gets its FULL ceiling even after anthropic spends 240s",
+  );
+  budget.remainingMs -= (googleIdle as { timeoutMs: number }).timeoutMs;
+
+  // …and google's own credential write, which never happened at all on 3 of 4
+  // shards, still comfortably clears its measured 10.5–18.8s cost.
+  const googleWrite = planCredentialWait(budget.remainingMs, 0);
+  assert.equal(googleWrite.wait, true);
+  assert.ok(
+    (googleWrite as { timeoutMs: number }).timeoutMs >= 60_000,
+    `google's credential write must not be squeezed by a stalling anthropic; got ` +
+      `${(googleWrite as { timeoutMs: number }).timeoutMs}ms`,
+  );
+});
+
+test("#1385: the sweep budget fits inside the pre-flight's own test timeout", () => {
+  // The constraint #1370 got backwards. The budget is only meaningful if the
+  // test outlives it, and `tests/collect-models.spec.ts` is now what guarantees
+  // that — 12 minutes against ~450s of waits plus the ~90s of build axis,
+  // navigation, toggle sweeps, key probes and file writes.
+  const PREFLIGHT_TIMEOUT_MS = 12 * 60 * 1000;
+  const NON_WAIT_RESERVE_MS = 90_000;
+  assert.ok(
+    sweepSaveBudgetMs + NON_WAIT_RESERVE_MS < PREFLIGHT_TIMEOUT_MS,
+    `${sweepSaveBudgetMs}ms of waits plus ${NON_WAIT_RESERVE_MS}ms of everything else must fit in ` +
+      `${PREFLIGHT_TIMEOUT_MS}ms, or the budget is decorative and the test timeout is the real bound`,
+  );
+
+  const spec = fs.readFileSync(path.join(__dirname, "../../collect-models.spec.ts"), "utf-8");
+  assert.match(
+    spec,
+    /test\.setTimeout\(12 \* 60 \* 1000\)/,
+    "the spec must set the timeout this budget was sized against — the config default is 5 minutes",
+  );
 });
 
 // ─── The collector-stall verdict (#1370) ─────────────────────────────────────

--- a/tests/helpers/provider-setup/collect-models.ts
+++ b/tests/helpers/provider-setup/collect-models.ts
@@ -405,7 +405,7 @@ const TOGGLE_CONFIRM_BUDGET_MS = 60_000;
 const TOGGLE_CONFIRM_POLL_MS = 100;
 
 /**
- * Ceiling for the credential write a `Save` click issues (#1355).
+ * Ceiling for the credential write a `Save` click issues (#1355, resized #1385).
  *
  * Measured, not guessed: with a funded OpenAI key, `POST /api/v1/variables/`
  * answered 201 for all three providers, but anthropic's did not return until
@@ -414,19 +414,37 @@ const TOGGLE_CONFIRM_POLL_MS = 100;
  * flight. The cost grows with how many providers are already configured, so the
  * ceiling is set well clear of the worst measurement rather than just above it.
  *
+ * 180 s was that clearance, and the daily has since measured past it. Every
+ * anthropic credential write observed on CI since the wait existed:
+ *
+ * | date | shard results |
+ * |---|---|
+ * | 2026-08-07 (run 31163810520) | 111.1 s ✅, 176.2 s ✅, >180 s ✗, >180 s ✗ |
+ * | 2026-08-10 (run 31373880200) | 105.8 s ✅, >176 s ✗, >176 s ✗, >175 s ✗ |
+ *
+ * So the ceiling sat in the MIDDLE of the observed distribution — the largest
+ * success (176.2 s) is 2 % under it. 240 s is set past the tail instead.
+ *
+ * The duration is CONTENTION, not a fixed cost, and that is why raising the
+ * ceiling is the right move rather than a mask: the same save measured **5.9 s**
+ * locally against an idle backend with two providers already configured
+ * (probe on 1.12.0.dev22, `Disconnect` 0.5 s behind the 201). The lanes run
+ * `LANGFLOW_WORKERS=1`, and the openai pass that precedes this one enables 41
+ * models — the write queues behind that burst.
+ *
  * It is a backstop, not the mechanism: the wait ends when the response lands.
  *
  * It is also a CEILING and not a promise: what a provider actually gets is
  * whatever {@link planSaveWait} can still afford out of the sweep-wide budget
  * below.
  */
-const CREDENTIAL_SAVE_TIMEOUT_MS = 180_000;
+const CREDENTIAL_SAVE_TIMEOUT_MS = 240_000;
 
 /** Ceiling for the panel reaching the configured state (`Disconnect`) after a save. */
 const CONFIGURED_STATE_TIMEOUT_MS = 60_000;
 
 /**
- * Budget shared by every post-Save wait in the sweep (#1370).
+ * Budget shared by every post-Save wait in the sweep (#1370, resized #1385).
  *
  * The per-provider ceilings above were each sized against a measurement and
  * NONE of them against the spec's own 5-minute timeout
@@ -441,24 +459,61 @@ const CONFIGURED_STATE_TIMEOUT_MS = 60_000;
  * ({@link TOGGLE_CONFIRM_BUDGET_MS}, mirroring #1197 §4.4): a per-item timeout
  * bounds ONE wait and can never see the sum.
  *
- * 210 s is the 300 s test timeout minus ~90 s reserved for everything that is
- * NOT a post-Save wait — the build axis, the Settings navigation, the per-
- * provider toggle sweeps (bounded at 15 s each), the key probes and the two file
- * writes. Measured at ~55 s on the CI attempt above and ~24 s locally, so the
- * reserve is deliberately generous: over-reserving costs a stalling provider its
- * models, under-reserving costs the whole run.
+ * #1370 sized this at 210 s = the 300 s test timeout minus a ~90 s reserve. That
+ * arithmetic was right and the INPUT was wrong: 300 s is
+ * `playwright.config.ts`'s default for a PRODUCT spec, and nothing about it was
+ * ever derived from what this sweep costs. Against a 240 s anthropic write it
+ * leaves 30 s for google — which google's `Save`-idle wait then spends before a
+ * Save is ever clicked, so google is recorded as a stall having never been
+ * configured. That is what turned one anthropic problem into 5 of the run's 6
+ * skips across three areas on 2026-08-10, on 3 of 4 shards (#1385).
+ *
+ * So the pre-flight now sets its own timeout (`tests/collect-models.spec.ts`)
+ * and this budget is sized from the measurements instead:
+ *
+ *     openai   ~5 s write      + ~10 s toggles
+ *     anthropic 240 s ceiling  + 60 s configured-state
+ *     google   ~19 s write     + 60 s idle (contended) + 60 s configured-state
+ *     ----------------------------------------------------------------
+ *     ~450 s of post-Save waits in the WORST case, ~35 s in the healthy one
+ *
+ * Over-sizing is nearly free — the budget is only ever spent by waits that
+ * actually run, so a healthy sweep still finishes in well under a minute of it
+ * and the extra clock is only consumed on a run already headed for a red.
  */
-const SWEEP_SAVE_BUDGET_MS = 210_000;
+const SWEEP_SAVE_BUDGET_MS = 450_000;
 
 /**
  * Floor kept back for each provider still to be configured.
  *
  * Without it the first stalling provider spends the entire budget and every
  * provider after it gets nothing — which is the failure this budget exists to
- * prevent, just moved one provider along. Google's credential write measured
- * 15.7 s on the CI run, so 30 s leaves a healthy provider room.
+ * prevent, just moved one provider along.
+ *
+ * 30 s (#1370) was sized against ONE wait — google's credential write, measured
+ * at 15.7 s. A provider's pass is three waits, and on 2026-08-10 the first of
+ * them spent the whole reserve: google's `Save` sat non-actionable for the full
+ * 30 s while anthropic's write was still in flight, so the reserve bought a
+ * diagnostic and no configuration at all. 60 s is sized against the whole pass
+ * (idle + write + configured-state) at the worst per-wait figures the daily has
+ * measured for a provider that is NOT the one stalling (#1385).
  */
-const SAVE_RESERVE_PER_PROVIDER_MS = 30_000;
+const SAVE_RESERVE_PER_PROVIDER_MS = 60_000;
+
+/**
+ * Cap on what the `Save`-idle wait may take out of one provider's own allowance
+ * (#1385).
+ *
+ * The idle wait is the only one of the three that is about the PREVIOUS
+ * provider: it waits for the panel to stop being busy with a write this provider
+ * did not issue. Letting it draw the provider's full allowance is how google
+ * reached its own Save with nothing left — the reserve protected google from
+ * anthropic and then google's first wait spent it anyway.
+ *
+ * A half share leaves the credential write, which is the wait that actually
+ * configures the provider, at least as much as the wait for someone else's.
+ */
+const SAVE_IDLE_SHARE_OF_REMAINING = 0.5;
 
 /**
  * Below this, the wait is skipped instead of shortened.
@@ -528,13 +583,26 @@ export function classifyWaitFailure(error: unknown): WaitFailure {
   return { kind: "unknown", detail };
 }
 
-export type SaveWaitPlan = { wait: true; timeoutMs: number } | { wait: false; reason: string };
+export type SaveWaitPlan =
+  | { wait: true; timeoutMs: number; ceilingMs: number; shortenedByBudget: boolean }
+  | { wait: false; reason: string };
 
 /**
  * Decide what one post-Save wait may spend out of the sweep's shared budget.
  *
  * Pure, so the arithmetic that #1370 got wrong is testable without a browser.
  * The returned `timeoutMs` is never `0` — see {@link MIN_SAVE_WAIT_MS}.
+ *
+ * `shareOfRemaining` bounds a wait to a FRACTION of what this provider can
+ * afford, on top of the reserve that protects the providers after it (#1385).
+ * The reserve and the share answer different questions — "will the NEXT provider
+ * have anything left" versus "will THIS provider's own remaining waits" — and
+ * google needed both: the reserve gave it 30 s, and its first wait spent all of
+ * it before a Save was ever clicked.
+ *
+ * The plan carries the ceiling it was measured against, so a caller reporting a
+ * failure can say whether the wait got its full ceiling or a shortened slice of
+ * it. Without that, a budget-exhausted wait prints a verdict about the panel.
  */
 export function planSaveWait(options: {
   ceilingMs: number;
@@ -542,11 +610,14 @@ export function planSaveWait(options: {
   providersLeftAfterThis: number;
   reservePerProviderMs?: number;
   minWaitMs?: number;
+  shareOfRemaining?: number;
 }): SaveWaitPlan {
   const reservePerProvider = options.reservePerProviderMs ?? SAVE_RESERVE_PER_PROVIDER_MS;
   const minWaitMs = options.minWaitMs ?? MIN_SAVE_WAIT_MS;
+  const share = options.shareOfRemaining ?? 1;
   const reserved = Math.max(0, options.providersLeftAfterThis) * reservePerProvider;
-  const allowed = Math.min(options.ceilingMs, options.remainingMs - reserved);
+  const affordable = options.remainingMs - reserved;
+  const allowed = Math.min(options.ceilingMs, affordable, Math.floor(affordable * share));
 
   if (allowed < minWaitMs) {
     return {
@@ -557,8 +628,55 @@ export function planSaveWait(options: {
         `here would leave them nothing`,
     };
   }
-  return { wait: true, timeoutMs: allowed };
+  return {
+    wait: true,
+    timeoutMs: allowed,
+    ceilingMs: options.ceilingMs,
+    shortenedByBudget: allowed < options.ceilingMs,
+  };
 }
+
+/**
+ * The three post-Save waits, each bound to its own ceiling and share (#1385).
+ *
+ * They exist as named functions rather than three inline `planSaveWait` calls
+ * because the call site is where the fix actually lives and a `Page` is not
+ * something the unit lane can drive: pinning the arithmetic alone would pin a
+ * spelling, not a behaviour (#1226's lesson). With these, "the idle wait is
+ * share-capped and the credential write is not" is an assertion instead of a
+ * code-reading exercise, and so are the live ceilings.
+ */
+export function planIdleWait(remainingMs: number, providersLeftAfterThis: number): SaveWaitPlan {
+  return planSaveWait({
+    ceilingMs: SAVE_IDLE_TIMEOUT_MS,
+    remainingMs,
+    providersLeftAfterThis,
+    // The one wait that is about the PREVIOUS provider — see
+    // SAVE_IDLE_SHARE_OF_REMAINING.
+    shareOfRemaining: SAVE_IDLE_SHARE_OF_REMAINING,
+  });
+}
+
+export function planCredentialWait(remainingMs: number, providersLeftAfterThis: number): SaveWaitPlan {
+  // No share: this is the wait that actually configures the provider, so it may
+  // take everything the reserve leaves it.
+  return planSaveWait({
+    ceilingMs: CREDENTIAL_SAVE_TIMEOUT_MS,
+    remainingMs,
+    providersLeftAfterThis,
+  });
+}
+
+export function planConfiguredWait(remainingMs: number, providersLeftAfterThis: number): SaveWaitPlan {
+  return planSaveWait({
+    ceilingMs: CONFIGURED_STATE_TIMEOUT_MS,
+    remainingMs,
+    providersLeftAfterThis,
+  });
+}
+
+/** The sweep's starting budget, exported so a test asserts the live value. */
+export const sweepSaveBudgetMs = SWEEP_SAVE_BUDGET_MS;
 
 /**
  * Marks a provider the COLLECTOR never managed to configure — as opposed to one
@@ -723,36 +841,164 @@ export async function waitForButtonIdle(
   return { idle: false, ariaBusy, ariaDisabled, enabled, waitedMs: now() - startedAt, polls };
 }
 
+/** One provider's post-Save spend out of the sweep budget, in walk order. */
+export interface BudgetSpend {
+  provider: string;
+  ms: number;
+}
+
 /**
- * The message for a `Save` that never became actionable (#1355).
+ * What the sweep can say about the wait itself, as opposed to the button
+ * (#1385). Optional so the unit lane can exercise the button-only message.
+ */
+export interface SaveBusyContext {
+  /** What the wait was actually granted, and what it would have had unshortened. */
+  grantedMs: number;
+  ceilingMs: number;
+  /** Budget left when the wait was planned, and who had already spent it. */
+  remainingBudgetMs: number;
+  spentBefore: readonly BudgetSpend[];
+  /**
+   * Characters in the API-key field when the wait ran. `null` when it could not
+   * be read — an unread field is unknown, not empty (#1012).
+   */
+  keyFieldChars: number | null;
+}
+
+/**
+ * The message for a `Save` that never became actionable (#1355, re-attributed
+ * #1385).
  *
  * Names the provider, the attribute state observed and — the part the old
  * generic click timeout could not say — that the likely cause is the PREVIOUS
  * provider's validation, so the reader does not go looking for a broken button.
+ *
+ * Both of the original verdict lines were WRONG on 2026-08-10, in opposite
+ * directions, and on the same sweep:
+ *
+ *   - The wait had been shortened to 30.0 s of its 60 s ceiling because
+ *     anthropic had spent 176 s of the shared budget. Neither branch could say
+ *     that, so a budget verdict was printed as a panel verdict.
+ *   - Two of the three shards printed `aria-busy (absent) / aria-disabled
+ *     (absent) / enabled false` and concluded "a state this helper does not
+ *     model", pointing the reader at the panel markup. That state is
+ *     reproducible in one step: it is the `Save` button with an EMPTY key field
+ *     (measured locally on 1.12.0.dev22 — with the key typed, the same button
+ *     is actionable on the first poll). The panel is fine; the key did not reach
+ *     the field.
+ *
+ * So the budget is reported FIRST when it shortened the wait, and the key field
+ * is reported whenever it was readable — a claim about markup is the last
+ * resort, not the default.
  */
-export function formatSaveBusyFailure(providerName: string, verdict: ButtonIdleVerdict): string {
+export function formatSaveBusyFailure(
+  providerName: string,
+  verdict: ButtonIdleVerdict,
+  context?: SaveBusyContext,
+): string {
   const busy = verdict.ariaBusy === "true";
-  return [
+  const lines = [
     `collect-models: the "Save" button for provider "${providerName}" never became actionable ` +
       `after ${(verdict.waitedMs / 1000).toFixed(1)}s over ${verdict.polls} poll(s).`,
     ``,
     `  aria-busy      ${verdict.ariaBusy ?? "(absent)"}`,
     `  aria-disabled  ${verdict.ariaDisabled ?? "(absent)"}`,
     `  enabled        ${verdict.enabled}`,
-    ``,
-    busy
-      ? `  verdict        still BUSY — a save/validation is in flight. This panel is walked one\n` +
+  ];
+
+  if (context) {
+    lines.push(
+      `  key field      ${
+        context.keyFieldChars === null
+          ? "(unreadable — unknown, not empty)"
+          : `${context.keyFieldChars} character(s)`
+      }`,
+    );
+    lines.push(
+      `  wait granted   ${(context.grantedMs / 1000).toFixed(1)}s of a ${(context.ceilingMs / 1000).toFixed(1)}s ceiling`,
+    );
+  }
+  lines.push(``);
+
+  // Ordered by what the evidence can actually support. A shortened wait is a
+  // fact about this sweep; an empty key field is a fact about this panel; the
+  // markup claim is what is left when neither applies.
+  if (context && context.grantedMs < context.ceilingMs) {
+    lines.push(
+      `  verdict        BUDGET, not the panel — this wait was shortened to ` +
+        `${(context.grantedMs / 1000).toFixed(1)}s of its\n` +
+        `                 ${(context.ceilingMs / 1000).toFixed(1)}s ceiling because the sweep's shared budget was down to ` +
+        `${Math.max(0, Math.round(context.remainingBudgetMs / 1000))}s.\n` +
+        `                 Spent before this provider: ${formatBudgetSpend(context.spentBefore)}.\n` +
+        `                 Do NOT read the attributes above as a verdict about the form (#1385).`,
+    );
+  } else if (context && context.keyFieldChars === 0) {
+    lines.push(
+      `  verdict        the API-key field is EMPTY, so "Save" is correctly disabled — this is not\n` +
+        `                 a panel-markup problem and not a key problem. The key was typed before\n` +
+        `                 this wait, so it did not reach the field (a re-render under load will do\n` +
+        `                 it). Retype before assuming anything about the button (#1385).`,
+    );
+  } else if (busy) {
+    lines.push(
+      `  verdict        still BUSY — a save/validation is in flight. This panel is walked one\n` +
         `                 provider at a time, so the usual cause is the PREVIOUS provider's\n` +
-        `                 validation not having settled, not this provider's key (#1355).`
-      : `  verdict        not busy, but not actionable either — the form is in a state this\n` +
-        `                 helper does not model. Check the panel markup before assuming a key\n` +
-        `                 problem (#1355).`,
-  ].join("\n");
+        `                 validation not having settled, not this provider's key (#1355).`,
+    );
+  } else {
+    // The last resort, and it must not borrow authority it does not have: the
+    // "everything else was ruled out" clause is only true when a context was
+    // supplied to rule things out WITH. Without one this is the #1355 message
+    // unchanged, which is exactly what it is.
+    const ruledOut =
+      context && context.keyFieldChars !== null
+        ? `not busy, not budget-limited, and the key field holds ` +
+          `${context.keyFieldChars} character(s) — but not actionable either.\n` +
+          `                 The form`
+        : `not busy, but not actionable either — the form`;
+    lines.push(
+      `  verdict        ${ruledOut} is in a state this helper does not model. Check the panel\n` +
+        `                 markup before assuming a key problem (#1355).`,
+    );
+  }
+
+  return lines.join("\n");
 }
 
-/** Mutable remainder of {@link SWEEP_SAVE_BUDGET_MS}, threaded through the loop. */
+/**
+ * Render who spent the shared budget before this provider (#1385).
+ *
+ * Exported because it is the sentence that makes a collateral stall readable —
+ * "google never got a Save" means nothing without "anthropic spent 176.0s".
+ * An empty list is stated rather than rendered as an empty string: nothing spent
+ * before this provider is itself a finding, since it means the budget went
+ * somewhere this record does not see.
+ */
+export function formatBudgetSpend(spent: readonly BudgetSpend[]): string {
+  if (spent.length === 0) return "nothing (this is the first provider of the sweep)";
+  return spent.map((s) => `"${s.provider}" ${(s.ms / 1000).toFixed(1)}s`).join(", ");
+}
+
+/**
+ * Mutable remainder of {@link SWEEP_SAVE_BUDGET_MS}, threaded through the loop.
+ *
+ * `spent` is the per-provider ledger (#1385). The budget alone answers "is there
+ * time left"; the ledger answers "who took it", which is the whole of what makes
+ * a collateral stall readable — the 2026-08-10 daily reported google as an
+ * unexplained non-actionable button and never named the 176 s anthropic had
+ * spent one line earlier.
+ */
 interface SweepBudget {
   remainingMs: number;
+  spent: BudgetSpend[];
+}
+
+/** Deduct from the shared budget and record it against the provider that spent it. */
+function chargeBudget(budget: SweepBudget, provider: string, ms: number): void {
+  budget.remainingMs -= ms;
+  const existing = budget.spent.find((entry) => entry.provider === provider);
+  if (existing) existing.ms += ms;
+  else budget.spent.push({ provider, ms });
 }
 
 /**
@@ -815,25 +1061,44 @@ async function collectModelsForProvider(
       // the whole pre-flight, which is the thing this issue is about. Recording
       // it as a stall loses no signal: a stall still fails the gate on every
       // lane that requires that provider, which on the daily is all of them.
-      const idlePlan = planSaveWait({
-        ceilingMs: SAVE_IDLE_TIMEOUT_MS,
-        remainingMs: budget.remainingMs,
-        providersLeftAfterThis,
-      });
+      // The idle wait is bounded by a SHARE of what this provider can afford, not
+      // by the whole of it (#1385): it waits out the previous provider's write,
+      // and on 2026-08-10 it spent google's entire 30 s allowance doing so, so
+      // google reached its own Save with nothing left and was never configured.
+      const idlePlan = planIdleWait(budget.remainingMs, providersLeftAfterThis);
+      // Snapshot BEFORE the wait: the ledger and the remainder are what the
+      // failure message needs to attribute a shortened wait, and both move as
+      // soon as this wait is charged.
+      const spentBefore = budget.spent.map((entry) => ({ ...entry }));
+      const remainingBeforeIdle = budget.remainingMs;
       const idleStartedAt = Date.now();
       const verdict = idlePlan.wait
         ? await waitForButtonIdle(saveBtn, { timeoutMs: idlePlan.timeoutMs })
         : null;
-      budget.remainingMs -= Date.now() - idleStartedAt;
+      chargeBudget(budget, providerName, Date.now() - idleStartedAt);
 
       if (!idlePlan.wait) {
         stall = `the "Save" button was never waited on — ${idlePlan.reason}`;
         console.warn(
           `⚠️  collect-models: skipped configuring provider "${providerName}" — ${idlePlan.reason}. ` +
-            `It is left unconfigured rather than clicked blind (#1370).`,
+            `It is left unconfigured rather than clicked blind (#1370). Spent before it: ` +
+            `${formatBudgetSpend(spentBefore)}.`,
         );
       } else if (verdict && !verdict.idle) {
-        stall = formatSaveBusyFailure(providerName, verdict);
+        // Read the field the button's disabled state actually depends on. It is
+        // one call, only on the failure path, and it is what separates "the
+        // markup is unmodelled" from "the key never landed in the input".
+        const keyFieldChars = await apiKeyInput
+          .inputValue()
+          .then((value) => value.length)
+          .catch(() => null);
+        stall = formatSaveBusyFailure(providerName, verdict, {
+          grantedMs: idlePlan.timeoutMs,
+          ceilingMs: idlePlan.ceilingMs,
+          remainingBudgetMs: remainingBeforeIdle,
+          spentBefore,
+          keyFieldChars,
+        });
         console.warn(`⚠️  collect-models: ${stall}`);
       }
     }
@@ -859,11 +1124,7 @@ async function collectModelsForProvider(
       // What it may SPEND is the sweep's, not this provider's (#1370): the
       // ceiling alone let one stalling provider eat a 300 s test budget in
       // 255 s of waits.
-      const plan = planSaveWait({
-        ceilingMs: CREDENTIAL_SAVE_TIMEOUT_MS,
-        remainingMs: budget.remainingMs,
-        providersLeftAfterThis,
-      });
+      const plan = planCredentialWait(budget.remainingMs, providersLeftAfterThis);
 
       if (!plan.wait) {
         stall = `the credential write was never waited for — ${plan.reason}`;
@@ -890,7 +1151,7 @@ async function collectModelsForProvider(
         await saveBtn.click();
         const { response: saveResponse, failure } = await savePending;
         const elapsedMs = Date.now() - startedAt;
-        budget.remainingMs -= elapsedMs;
+        chargeBudget(budget, providerName, elapsedMs);
 
         if (failure?.kind === "aborted") {
           // The wait never ran. Printing "no write observed within Ns" here is
@@ -949,11 +1210,7 @@ async function collectModelsForProvider(
     // Bounded by the same shared budget as the write above (#1370). It is the
     // second half of the 255 s a single stalling provider used to spend.
     const configuredPlan: SaveWaitPlan = saveClicked
-      ? planSaveWait({
-          ceilingMs: CONFIGURED_STATE_TIMEOUT_MS,
-          remainingMs: budget.remainingMs,
-          providersLeftAfterThis,
-        })
+      ? planConfiguredWait(budget.remainingMs, providersLeftAfterThis)
       : { wait: false, reason: "no Save was issued for this provider" };
 
     if (!configuredPlan.wait) {
@@ -969,7 +1226,7 @@ async function collectModelsForProvider(
         .waitFor({ state: "visible", timeout: configuredPlan.timeoutMs })
         .then(() => ({ ok: true, failure: null as WaitFailure | null }))
         .catch((error: unknown) => ({ ok: false, failure: classifyWaitFailure(error) }));
-      budget.remainingMs -= Date.now() - configuredAt;
+      chargeBudget(budget, providerName, Date.now() - configuredAt);
 
       if (!configured.ok && configured.failure?.kind !== "expired") {
         // `aborted` and `unknown` are both "no signal", but they are not the
@@ -1103,8 +1360,9 @@ async function collectModels(page: Page): Promise<{
   const stalls = new Map<string, string>();
 
   // One budget for the whole sweep, spent down as each provider's post-Save
-  // waits actually run (#1370).
-  const budget: SweepBudget = { remainingMs: SWEEP_SAVE_BUDGET_MS };
+  // waits actually run (#1370), with a per-provider ledger so a collateral stall
+  // can name who spent it (#1385).
+  const budget: SweepBudget = { remainingMs: SWEEP_SAVE_BUDGET_MS, spent: [] };
   const providers = [...keyedProviders];
 
   // Keyed providers only. This sweep SAVES an API key per provider through the
@@ -1123,6 +1381,16 @@ async function collectModels(page: Page): Promise<{
     allModels.push(...collection.models);
     if (collection.stall) stalls.set(provider, collection.stall);
   }
+
+  // Printed on EVERY sweep, not only a failing one (#1385). The budget is the
+  // mechanism that decides whether a provider gets configured at all, and it was
+  // invisible until it had already cost one: a healthy line here is what makes a
+  // creeping write cost readable before it crosses the ceiling.
+  console.log(
+    `   collect-models: post-Save waits spent ` +
+      `${Math.round((SWEEP_SAVE_BUDGET_MS - budget.remainingMs) / 1000)}s of the sweep's ` +
+      `${Math.round(SWEEP_SAVE_BUDGET_MS / 1000)}s shared budget — ${formatBudgetSpend(budget.spent)}.`,
+  );
 
   return { models: allModels, stalls };
 }


### PR DESCRIPTION
Closes #1385.

## Verdict

**Test/wait-strategy, not a product regression and not a key problem.** The sweep's
shared post-Save budget was solved against the wrong clock: #1370 sized it at
`210 s = the 300 s test timeout minus a ~90 s reserve`, and 300 s is
`playwright.config.ts`'s default for a **product** spec. Nothing about it was ever
derived from what this sweep costs, so a suite-wide default became the bound on how
many providers get configured.

## What actually happened on run 31373880200

On **3 of 4 shards**, in this order:

```
no credential write observed for provider "anthropic" within 176s of clicking Save
skipped waiting for provider "anthropic" … the sweep's shared budget is down to 30s
Models found (anthropic): []
the "Save" button for provider "google" never became actionable after 30.1s over 117 poll(s)
Models found (google): []
```

Google's 30 s was the whole of its reserve, and its **first** wait spent it — the
`Save`-idle wait, which is the one wait that is about the *previous* provider.
Google therefore never clicked Save at all, and 5 of the run's 6 skips followed
across three areas. Shard 1, which did not stall, collected all three.

## The write is not failing — it is queued

Every anthropic credential write CI has measured since the wait existed:

| date | shard results |
|---|---|
| 2026-08-07 ([31163810520](https://github.com/oriontech-me/langflow-e2e/actions/runs/31163810520)) | 111.1 s ✅, 176.2 s ✅, >180 s ✗, >180 s ✗ |
| 2026-08-10 ([31373880200](https://github.com/oriontech-me/langflow-e2e/actions/runs/31373880200)) | 105.8 s ✅, >176 s ✗, >176 s ✗, >175 s ✗ |

So the 180 s ceiling sat in the **middle** of the distribution, 2 % above the
largest success. It is **contention, not a fixed cost**, measured on 1.12.0.dev22:

- anthropic saved alone against an idle backend, two providers already configured:
  **5.9 s** (`Disconnect` lands 0.5 s after the 201);
- anthropic saved in the real sweep order, right after openai's 41 model toggles:
  **78.9 s** locally, 105–180 s+ on CI (the lanes run `LANGFLOW_WORKERS=1`).

Anything that measures the write in isolation will fail to reproduce this.

## Changes

- **The pre-flight owns its own clock.** `tests/collect-models.spec.ts` sets
  `test.setTimeout(12 min)`, and the budget is sized from the sweep's worst measured
  shape (450 s) instead of a product default. A healthy sweep still measures ~55 s on
  CI, so this costs nothing until a run is already headed for a red.
- **The reserve is a whole PASS per remaining provider**, 30 s → 60 s. 30 s was sized
  against one wait (google's 15.7 s write); a provider's pass is three.
- **The `Save`-idle wait may take at most half of what its provider can afford.** The
  reserve protects the *next* provider; nothing protected a provider from its own
  first wait, which is exactly how google lost its 30 s.
- **The credential ceiling moves 180 s → 240 s**, past the observed tail.

### The diagnostic stops over-claiming

Both verdict lines were wrong on that one sweep, in opposite directions. Shard 2
printed `still BUSY` for a wait clipped to 30.0 s of its 60 s ceiling; shards 3 and 4
printed `aria-busy (absent) / aria-disabled (absent) / enabled false` and concluded
*"a state this helper does not model"*, sending the reader at the panel markup.

That second state is reproducible in one step: it is the `Save` button with an
**empty key field** (measured locally — with the key typed, the same button is
actionable on the first poll). The message now reports what the sweep can support, in
that order — a budget-shortened wait says so **and names who spent the budget**, an
empty key field is named as such, an unreadable one stays `unknown` (#1012), and the
markup claim is the last resort rather than the default.

The budget also carries a **per-provider ledger**, printed on *every* sweep rather
than only a failing one:

```
collect-models: post-Save waits spent 92s of the sweep's 450s shared budget
  — "openai" 5.7s, "anthropic" 79.2s, "google" 7.4s.
```

### Why the three waits became named functions

`planIdleWait` / `planCredentialWait` / `planConfiguredWait` replace three inline
`planSaveWait` calls. The call site is where the fix lives and a `Page` is not
something the unit lane can drive, so pinning the arithmetic alone would pin a
spelling, not a behaviour (#1226's lesson). "The idle wait is share-capped and the
credential write is not" is now an assertion.

## Validation

- `npm run typecheck` ✅ · `npm run lint` 0 errors · `npm run test:units` **579 pass**
  · `npm run test:scripts` **797 pass** · QA-CHECKLIST coverage guard ✅
- **Six mutations, each caught**: share `0.5 → 1`, reserve `60s → 30s`, budget
  `450s → 210s`, ceiling `240s → 180s`, the call site dropping the share, and the spec
  dropping its own `test.setTimeout`.
- **End-to-end against a fresh `langflow-nightly` container**, exercising the Save path
  and reproducing the stall: openai 5.7 s, anthropic **78.9 s (HTTP 201)**, google
  7.4 s — 92 s of the 450 s budget, all three providers collected, `1 passed (2.1m)`.

```bash
docker run -d --name lf-1385 -p 7863:7860 \
  -e LANGFLOW_AUTO_LOGIN=true -e LANGFLOW_SUPERUSER=langflow \
  -e LANGFLOW_SUPERUSER_PASSWORD=langflow123 -e LANGFLOW_WORKERS=1 \
  -e LANGFLOW_ALLOW_CUSTOM_COMPONENTS=true -e LANGFLOW_A2A_ENABLED=true \
  -e LANGFLOW_DEACTIVATE_TRACING=true langflowai/langflow-nightly:latest
until curl -s -o /dev/null -w '%{http_code}' http://localhost:7863/api/v1/auto_login | grep -q 200; do sleep 5; done
PLAYWRIGHT_BASE_URL=http://localhost:7863/ npx playwright test tests/collect-models.spec.ts --workers=1 --retries=0 --reporter=line
docker rm -f lf-1385
```

## What this PR does NOT prove

- The four specs named in the issue were **skipping, not failing**. Their proof is a
  subsequent daily observing them run, which no local run can stand in for — the
  local OpenAI key has no credits, so `agent-component-regression` would skip here
  regardless.
- The local reproduction (78.9 s) is lighter than CI (>176 s). The fix covers the tail
  by sizing, not because the laptop reached it.
- No workflow changed, so there is no CI evidence yet. Watch the next
  `daily-stable.yml` run's `Collect models` step for the new ledger line and for
  anthropic + google both collecting.

## Follow-up worth filing separately

`tests/collect-models.spec.ts` is `@stable`, so the `@stable` suite runs a **second**
sweep inside the same job — visible on shard 3 of the target run, where that second
sweep found anthropic already configured and collected all three.
