### PR TITLE
fix(model-provider): gate the OpenAI execution test on provider health, not env-key presence (#1333)

### DIFF
--- a/docs/core-functionality/model-provider/openai-provider.md
+++ b/docs/core-functionality/model-provider/openai-provider.md
@@ -38,6 +38,13 @@ PR #775 — the key had no quota, not the test — and **restored in #992** once
 the quota was confirmed back (live HTTP 200 completion on `gpt-4o-mini`) and
 the test ran clean at `--retries=0`.
 
+It was auto-removed a **second** time on the 2026-08-06 daily (commit `cb3082d`,
+run 31093877484) for the same underlying reason — the account had no credits —
+and **restored in #1333**, again on a live HTTP 200 completion plus 5 clean
+`--retries=0` runs. The recurrence is what motivated the provider-health gate
+below: without it, a dead-but-present key produces a hard failure that reads
+like a product regression and costs the tag every time the account drains.
+
 ---
 
 ## Preconditions *(optional)*
@@ -45,7 +52,10 @@ the test ran clean at `--retries=0`.
 - Langflow running at `PLAYWRIGHT_BASE_URL`.
 - `OPENAI_API_KEY` set in `.env` (both tests self-skip without it).
 - `models.json` / `providers.json` generated via
-  `npx playwright test tests/collect-models.spec.ts`.
+  `npx playwright test tests/collect-models.spec.ts`. **Test 2 additionally gates
+  on the health `collect-models` recorded there** — see the gate note below. A
+  local run with no `providers.json` fails OPEN (nothing skips); a stale
+  `inactive` record is bypassed with `IGNORE_PROVIDER_HEALTH=1`.
 - Run with `--workers=1` (Test 2 loads a named template via
   `SimpleAgentTemplatePage`; agent-family convention). File is serial.
 
@@ -79,6 +89,11 @@ the test ran clean at `--retries=0`.
 
 **Test 2 — configured OpenAI is selectable in the Agent and executes** (§7.2.2 + §7.2.3)
 
+0. **Provider-health gate** — `providerSkipGate("openai")` skips the test when
+   `collect-models` recorded OpenAI `inactive` (drained balance, revoked key,
+   spend cap), quoting the collected reason. This test makes a live completion
+   call, so a dead key cannot produce a verdict about Langflow — see the gate
+   note below.
 1. `SimpleAgentTemplatePage.load({ provider: "openai", model })` — with the key
    configured, this selects a **GPT** model in the Agent's `model_model`
    dropdown (bullet §7.2.2). `model` resolves from `models.json` (a GPT chat
@@ -186,6 +201,31 @@ the test ran clean at `--retries=0`.
   runs (not deleted by `cleanAllFlows`). Test 1 is therefore idempotent — it
   re-saves the same key and asserts the configured state rather than assuming a
   fresh, unconfigured start.
+- **Provider-health gate on Test 2 only (#1333, mechanism from #1029):** the two
+  tests gate differently on purpose. Both require `OPENAI_API_KEY` to be *set*;
+  only Test 2 also requires the provider to be *usable*. `hasProviderEnvKeys`
+  measures presence, never health — so on the 2026-08-06 daily, where the account
+  had no credits (`collect-models` recorded `openai inactive — You have no
+  credits remaining`, and 6 of that run's 9 skips quoted it), Test 2 ran anyway:
+  the Agent's run never completed, the Stop button stayed visible past the 120 s
+  wait, no `div-chat-message` ever rendered, all three attempts hard-failed and
+  the workflow auto-removed `@stable` (`cb3082d`). A red that says nothing about
+  Langflow, for the second time (cf. #772/#775). `providerSkipGate("openai")`
+  reads the same `providers.json` the provider-**parametrized** specs already
+  honour, so a dead key now yields a skip quoting the measured reason.
+  **Test 1 is deliberately NOT gated:** it makes no completion call, and
+  `POST /api/v1/models/validate-provider` answers 2xx on a credit-less key
+  (OpenAI authenticates the key without checking balance — `GET /v1/models`
+  behaves the same, which is why the probe cannot see a drained account and only
+  the real call returns 429 `no credits remaining`). Test 1 therefore still
+  passes and still covers the Settings save path on a day the account is dry;
+  gating it would trade real coverage for nothing. **This is a resilience fix,
+  not a root-cause fix** — the account still has to be funded for §7.2.3 to be
+  exercised at all. The general remedy (probe candidate keys and resolve a live
+  one before the suite, fail loud when every candidate is dead) is tracked at
+  **#976**; this gate only stops the outage from being reported as a product
+  regression in the meantime. The same gap exists in `anthropic-provider.spec.ts`
+  and `google-provider.spec.ts`, tracked at **#1415**.
 - **#636 flake (fixed 2026-07-14):** the persist waiter matched `PATCH` only, but
   the frontend fires `POST /variables/` (create, 201) when the key does not yet
   exist and `PATCH /variables/{id}` (update, 200) when it does. On a fresh CI

--- a/tests/tests-automations/regression/core-functionality/model-provider/openai-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/openai-provider.spec.ts
@@ -9,6 +9,7 @@ import {
   hasProviderEnvKeys,
   missingProviderEnvKeys,
 } from "../../../../helpers/provider-setup";
+import { providerSkipGate } from "../../../../helpers/provider-setup/provider-health";
 import { getAuthToken } from "../../../../helpers/auth/get-auth-token";
 import { deleteFlow } from "../../../../helpers/flows/delete-flow";
 import { resolveGptModel } from "../../../../helpers/provider-setup/resolve-gpt-model";
@@ -200,12 +201,23 @@ test.describe("OpenAI Provider", () => {
 
   test(
     "configured OpenAI selects a GPT model in the Agent and executes the flow",
-    { tag: ["@model-provider", "@agents", "@playground"] },
+    { tag: ["@stable", "@model-provider", "@agents", "@playground"] },
     async ({ page, request }) => {
-      test.skip(
-        !hasProviderEnvKeys(PROVIDER),
-        `Missing env vars for provider "${PROVIDER}": ${missingProviderEnvKeys(PROVIDER).join(", ")}`,
-      );
+      // Health, not mere presence (#1029's gate, applied here by #1333). This
+      // test makes a live completion call, so a key that EXISTS but is dead
+      // cannot produce a verdict about Langflow: on the 2026-08-06 daily the
+      // account had no credits, the Agent's run never completed, Stop stayed
+      // visible past the 120 s wait, no `div-chat-message` ever rendered, all
+      // three attempts hard-failed and the workflow auto-removed @stable
+      // (cb3082d) — for the second time (cf. #772/#775). `providerSkipGate`
+      // reads the same providers.json the provider-parametrized specs honour,
+      // so the same outage now skips with the reason collect-models measured.
+      // Test 1 is deliberately left on the env-presence gate: it makes no
+      // completion call and `validate-provider` answers 2xx on a credit-less
+      // key, so it still passes and still covers the Settings save path on a
+      // dry day. Resilience only — funding the account is #976.
+      const providerGate = providerSkipGate(PROVIDER);
+      test.skip(providerGate.skip, providerGate.reason);
 
       // Per-run sentinel: a match proves THIS execution produced the output.
       const token = `OPENAI-${Date.now()}`;


### PR DESCRIPTION
Closes #1333.

## What was failing

The `@stable` test that runs an Agent on a configured OpenAI model hard-failed on all three attempts of the 2026-08-06 daily ([run 31093877484](https://github.com/oriontech-me/langflow-e2e/actions/runs/31093877484)): attempt 0 waited out 120 s with the **Stop button still visible**, attempts 1 and 2 never saw a `div-chat-message` at all. `@stable` was auto-removed by the workflow (`cb3082d`).

## Verdict: environment (drained OpenAI account)

The single measurement the issue asked for. Environment `langflowai/langflow-nightly:latest` = **1.12.0.dev23**. The key was confirmed live *before* the runs with a real completion — not `GET /v1/models`, which answers 200 on a credit-less account and is exactly why the probe cannot see a drained balance:

```
POST https://api.openai.com/v1/chat/completions  ->  HTTP 200, gpt-4o-mini-2024-07-18
```

**5 consecutive `--retries=0 --workers=1` runs of the whole file, all green:** 2 passed in 26.9s / 22.2s / 23.3s / 20.3s / 29.1s.

The chain reconstructs exactly: that run's own `collect-models` recorded `openai inactive — You have no credits remaining` (6 of its 9 skips quote it), #1329/#1328 record the same account state the same day, and a run that cannot call the API produces precisely the two observations above. Not a product regression, not a wait-strategy defect.

## What this PR changes, and why it is not a mute

The actionable half is *why the spec ran at all*.

`providerSkipGate()` is the health gate #1029 built **specifically for provider-hardcoded specs**: it reads the same `providers.json` the provider-parametrized specs honour and skips with the reason `collect-models` measured. **18 specs use it. The three provider-centric specs never adopted it** — they gate on:

```ts
test.skip(!hasProviderEnvKeys(PROVIDER), ...)   // presence of OPENAI_API_KEY, never its health
```

So on 2026-08-06 the parametrized specs skipped correctly while this one made a live call against a dead key, blocked out its 120 s wait, and cost the tag — for the **second** time (cf. #772/#775). A billing outage reported as a product regression, one triage cycle per occurrence.

- **Test 2** (the only one making a live completion call) now gates on `providerSkipGate("openai")`.
- **Test 1 is deliberately NOT gated.** It makes no completion call, and `POST /api/v1/models/validate-provider` answers 2xx on a credit-less key (the provider authenticates the key without checking balance). It still passes and still covers the Settings save path on a day the account is dry; gating it would trade real coverage for nothing. The asymmetry is argued in the spec doc and in a comment at the call site.
- **`@stable` restored** on Test 2.

**This is resilience, not a root-cause fix** — the account still has to be funded for §7.2.3 to be exercised at all. The general remedy (probe candidate keys, resolve a live one before the suite, fail loud when every candidate is dead) remains **#976**. The same gap in `anthropic-provider.spec.ts` and `google-provider.spec.ts` is tracked at **#1415**.

## Validation

Nightly **1.12.0.dev23**, local Docker, live OpenAI key.

- [x] **5/5 clean `--retries=0 --workers=1` runs before the change** — 26.9s / 22.2s / 23.3s / 20.3s / 29.1s
- [x] **3/3 clean `--retries=0 --workers=1` runs after the change** — 27.1s / 24.6s / 23.6s
- [x] **Force-failure executed for every test in the file** (isolated per test with `--grep` — the file is serial, so a first failure would mask the rest):

  | # | Mutation | Result |
  |---|---|---|
  | A | Test 1 — `expect(persistResp.ok()).toBe(false)` | ❌ failed as designed |
  | B | Test 2 — model assert `/gpt/i` → `/claude/i` | ❌ failed — `Received string: "gpt-4o-mini"` |
  | C | Test 2 — persisted-reply sentinel corrupted | ❌ failed — `user message with token not persisted yet` |
  | D | Test 2 — live-bubble sentinel corrupted | ❌ failed — `Received string: "OPENAI-1786421545948"` |
  | E | **behavioural, on the new gate** — `providers.json` set to `openai inactive` | Test 2 → `skipped`, reason `Provider "openai" inactive — You have no credits remaining`; Test 1 → `passed` — the intended asymmetry, with an `openai: active` baseline running both |

  Revert proved: 0 mutation markers in the diff, file byte-identical to the pre-mutation copy, plus a final green run.
- [x] **Zero `🚨 Backend Error`** on the final clean run
- [x] **Zero leaked flows** — `GET /api/v1/flows/` 28 before → 28 after
- [x] `npm run typecheck` clean · `eslint` **0 errors** on the touched spec (warnings are the repo-wide pre-existing classes) · QA-CHECKLIST generated-block guard ✓ · QA-CHECKLIST coverage guard ✓
- [ ] `--trace=on` — **not run**: known limitation, tracing any spec that loads the Simple Agent template hangs indefinitely on this stack (#490/#518). Step verification is covered by the `--retries=0` bursts and the force-fail matrix above.

`QA-CHECKLIST.md` is untouched — the §7.2 Part II bullets are already `[x]` and reference this spec; the `Phase 0 — Validated` block regenerates on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
