### PR TITLE
fix(model-provider): gate the Anthropic and Google execution tests on provider health (#1415)

### DIFF
--- a/docs/core-functionality/model-provider/anthropic-provider.md
+++ b/docs/core-functionality/model-provider/anthropic-provider.md
@@ -44,6 +44,12 @@ nightly. `@model-provider` (area) · `@settings` (Test 1 navigates Settings) ·
   execution with a billing error — see Notes).
 - `models.json` / `providers.json` generated via
   `npx playwright test tests/collect-models.spec.ts` (Anthropic must be `active`).
+  **Tests 2–3 additionally gate on the health `collect-models` recorded there**
+  (#1415) — a provider recorded `inactive` skips them with the collected reason
+  instead of making a live call against a dead key. A local run with no
+  `providers.json` fails OPEN (nothing skips); a stale `inactive` record is
+  bypassed with `IGNORE_PROVIDER_HEALTH=1`. **Test 1 is deliberately not gated**
+  — see the gate note below.
 - Run with `--workers=1` (Tests 2–3 load a named template via
   `SimpleAgentTemplatePage`; agent-family convention). File is serial.
 
@@ -204,12 +210,24 @@ nightly. `@model-provider` (area) · `@settings` (Test 1 navigates Settings) ·
   cost per run (and Opus is the most expensive tier) for no extra mechanism
   coverage — the switch mechanism is identical per family and
   execution-after-switch is already proven on Sonnet.
-- **Zero-credit trap (found live during #503):** a valid-but-unfunded key
-  passes Langflow's configure/validate and lists all 12 Claude models, but
-  every real inference fails with "credit balance is too low". The spec
-  requires an *active* provider (`providers.json`), which collect-models
-  verifies with a real 1-token inference — that gate, not the configure step,
-  is what catches an unfunded key before the agent tests burn retries.
+- **Zero-credit trap (found live during #503; the gate was only added in #1415):**
+  a valid-but-unfunded key passes Langflow's configure/validate and lists all 12
+  Claude models, but every real inference fails with "credit balance is too low".
+  The reason is in the backend: `validate_model_provider_key`
+  (`lfx/base/models/unified_models.py`) does make a real `llm.invoke("test")`
+  with `max_tokens=1`, but it only raises when the error message contains `401`,
+  `authentication` or `api key` — every other failure hits a bare `return`
+  ("allow saving despite minor errors"). A drained account raises
+  `credit balance is too low`, which matches none of those, so
+  `POST /api/v1/models/validate-provider` answers `{valid: true}` and the
+  configure step passes. **This note used to claim the spec "requires an active
+  provider (providers.json)" — it did not.** Nothing here read `providers.json`
+  until #1415; the mechanism was documented but never implemented, and the cost
+  was measured on the 2026-07-27 daily
+  ([run 30261409427](https://github.com/oriontech-me/langflow-e2e/actions/runs/30261409427)),
+  where the Anthropic account was drained: Test 1 passed, Test 2 hard-failed
+  3/3, and Test 3 never ran (serial mode skips after a failure). Tests 2–3 now
+  gate on `providerSkipGate("anthropic")`.
 - **Flow cleanup (id-scoped):** Tests 2–3 create a flow via
   `SimpleAgentTemplatePage.load()`, which does NO cleanup (post-#553 contract —
   the id is discarded by the POM). The spec tracks every
@@ -222,3 +240,14 @@ nightly. `@model-provider` (area) · `@settings` (Test 1 navigates Settings) ·
 - **Shared global key:** the Anthropic key is global and persists across runs.
   Test 1 is idempotent — it re-saves and asserts the request outcomes, not a
   fresh start.
+- **Why the gate is per test, not per file (#1415, mechanism from #1029):** only
+  Tests 2–3 make a live completion call, so only they are gated. Test 1 keeps
+  the env-presence gate on purpose: on a drained account it still passes (the
+  backend code path above), so it still covers the Settings save path on a day
+  the account is dry — gating it would trade real coverage for nothing. This is
+  the asymmetry #1333 settled for the OpenAI copy of the same bug, applied here
+  after confirming the premise holds for Anthropic in two independent ways: the
+  shared backend code path, and the 2026-07-27 daily, where Test 1 passed on the
+  drained account while Test 2 hard-failed. **Resilience, not a root-cause fix**
+  — the account still has to be funded for §7.3.2/§7.3.3 to be exercised at all;
+  the general remedy is **#976**.

--- a/docs/core-functionality/model-provider/google-provider.md
+++ b/docs/core-functionality/model-provider/google-provider.md
@@ -41,6 +41,12 @@ nightly. `@model-provider` (area) · `@settings` (Test 1 navigates Settings) ·
 - `GOOGLE_API_KEY` set in `.env` (both tests self-skip without it).
 - `models.json` / `providers.json` generated via
   `npx playwright test tests/collect-models.spec.ts` (Google must be `active`).
+  **Test 2 additionally gates on the health `collect-models` recorded there**
+  (#1415) — a provider recorded `inactive` skips it with the collected reason
+  instead of making a live call against a dead key. A local run with no
+  `providers.json` fails OPEN (nothing skips); a stale `inactive` record is
+  bypassed with `IGNORE_PROVIDER_HEALTH=1`. **Test 1 is deliberately not gated**
+  — see the gate note below.
 - Run with `--workers=1` (Test 2 loads a named template via
   `SimpleAgentTemplatePage`; agent-family convention). File is serial.
 
@@ -186,6 +192,25 @@ nightly. `@model-provider` (area) · `@settings` (Test 1 navigates Settings) ·
 - **Per-run sentinel** proves *this* execution produced the output.
 - **Shared global key:** the Google key is global and persists across runs. Test 1
   is idempotent — it re-saves and asserts the request outcomes, not a fresh start.
+- **Provider-health gate on Test 2 only (#1415, mechanism from #1029):** only
+  Test 2 makes a live completion call, so only it is gated on
+  `providerSkipGate("google")`. `hasProviderEnvKeys` measures presence of the env
+  var and never its health, so a key that exists but is dead — drained balance,
+  revoked key, **or a monthly spending cap, which is exactly what happened to
+  this provider on run 30374528125 and is why #1029 built the gate** — used to
+  run the test anyway: the Agent's run never completes, the Stop button stays
+  visible past the 120 s wait, no `div-chat-message` renders, and the workflow
+  auto-removes `@stable`. A billing outage reported as a product regression.
+  Measured on the OpenAI copy of the same bug twice (#772/#775, then #1333).
+  **Test 1 is deliberately NOT gated:** `validate_model_provider_key`
+  (`lfx/base/models/unified_models.py`) makes a real `llm.invoke("test")` but
+  only raises when the error message contains `401`, `authentication` or
+  `api key` — every other failure hits a bare `return` ("allow saving despite
+  minor errors"), so a quota/billing failure still answers `{valid: true}` and
+  Test 1 still passes. It therefore keeps covering the Settings save path on a
+  day the account is dry; gating it would trade real coverage for nothing.
+  **Resilience, not a root-cause fix** — the key still has to be usable for
+  §7.4.2 to be exercised at all; the general remedy is **#976**.
 - **#636 flake (fixed 2026-07-14):** the persist waiter matched `PATCH` only, but
   the frontend fires `POST /variables/` (create, 201) when the key does not yet
   exist and `PATCH /variables/{id}` (update, 200) when it does. On a fresh CI

--- a/tests/tests-automations/regression/core-functionality/model-provider/anthropic-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/anthropic-provider.spec.ts
@@ -13,6 +13,7 @@ import {
   hasProviderEnvKeys,
   missingProviderEnvKeys,
 } from "../../../../helpers/provider-setup";
+import { providerSkipGate } from "../../../../helpers/provider-setup/provider-health";
 
 /**
  * Anthropic (Claude) provider path (QA-CHECKLIST §7.3) as a provider-centric journey:
@@ -182,6 +183,15 @@ test.describe("Anthropic Provider", () => {
     "Anthropic API key is configured via Settings → Model Providers",
     { tag: ["@stable", "@model-provider", "@settings"] },
     async ({ page }) => {
+      // Env presence, NOT provider health — deliberate (#1415). This test makes
+      // no completion call, and the backend's validate_model_provider_key
+      // (lfx/base/models/unified_models.py) only rejects a key when the error
+      // message contains "401"/"authentication"/"api key"; every other failure
+      // hits a bare `return` ("allow saving despite minor errors"), so a drained
+      // account still answers {valid: true} and this test still passes. Measured
+      // on the 2026-07-27 daily: Anthropic was dry, this test passed, Test 2
+      // hard-failed. Gating it would trade real coverage of the Settings save
+      // path for nothing on exactly the days the account is down.
       test.skip(
         !hasProviderEnvKeys(PROVIDER),
         `Missing env vars for provider "${PROVIDER}": ${missingProviderEnvKeys(PROVIDER).join(", ")}`,
@@ -240,10 +250,14 @@ test.describe("Anthropic Provider", () => {
     "configured Anthropic selects a Claude model in the Agent and executes the flow",
     { tag: ["@stable", "@model-provider", "@agents", "@playground"] },
     async ({ page }) => {
-      test.skip(
-        !hasProviderEnvKeys(PROVIDER),
-        `Missing env vars for provider "${PROVIDER}": ${missingProviderEnvKeys(PROVIDER).join(", ")}`,
-      );
+      // Health, not mere presence (#1029's gate, applied here by #1415). This
+      // test makes a live completion call, so a key that EXISTS but is dead
+      // cannot produce a verdict about Langflow. Measured on the 2026-07-27
+      // daily (run 30261409427), where the Anthropic account was drained: THIS
+      // test hard-failed 3/3 while Test 1 passed — see the comment on Test 1.
+      // Test 3 carries the same gate; Test 1 deliberately does not.
+      const providerGate = providerSkipGate(PROVIDER);
+      test.skip(providerGate.skip, providerGate.reason);
 
       // Per-run sentinel: a match proves THIS execution produced the output.
       const token = `ANTHROPIC-${Date.now()}`;
@@ -270,10 +284,10 @@ test.describe("Anthropic Provider", () => {
     "switches between Claude model families (Haiku → Sonnet → Opus)",
     { tag: ["@stable", "@model-provider", "@agents", "@playground"] },
     async ({ page }) => {
-      test.skip(
-        !hasProviderEnvKeys(PROVIDER),
-        `Missing env vars for provider "${PROVIDER}": ${missingProviderEnvKeys(PROVIDER).join(", ")}`,
-      );
+      // Same live-completion gate as Test 2 — the switch is proven by executing
+      // on the switched-to Sonnet model, so a dead key wedges this one too.
+      const providerGate = providerSkipGate(PROVIDER);
+      test.skip(providerGate.skip, providerGate.reason);
 
       const haiku = resolveClaudeModel("haiku");
       const sonnet = resolveClaudeModel("sonnet");

--- a/tests/tests-automations/regression/core-functionality/model-provider/google-provider.spec.ts
+++ b/tests/tests-automations/regression/core-functionality/model-provider/google-provider.spec.ts
@@ -11,6 +11,7 @@ import {
   hasProviderEnvKeys,
   missingProviderEnvKeys,
 } from "../../../../helpers/provider-setup";
+import { providerSkipGate } from "../../../../helpers/provider-setup/provider-health";
 import { resolveGeminiModel } from "../../../../helpers/provider-setup/resolve-gemini-model";
 
 /**
@@ -96,6 +97,15 @@ test.describe("Google Provider", () => {
         `Missing env vars for provider "${PROVIDER}": ${missingProviderEnvKeys(PROVIDER).join(", ")}`,
       );
 
+      // The gate above is env presence, NOT provider health — deliberate
+      // (#1415). This test makes no completion call, and the backend's
+      // validate_model_provider_key (lfx/base/models/unified_models.py) only
+      // rejects a key when the error message contains "401"/"authentication"/
+      // "api key"; every other failure hits a bare `return` ("allow saving
+      // despite minor errors"), so a spend-capped or drained key still answers
+      // {valid: true} and this test still passes. Gating it would trade real
+      // coverage of the Settings save path for nothing on exactly the days the
+      // account is down. Test 2, which does call the model, IS gated.
       await awaitBootstrapTest(page, { skipModal: true });
 
       await test.step("open Settings → Model Providers → Google Generative AI", async () => {
@@ -156,10 +166,16 @@ test.describe("Google Provider", () => {
     "configured Google selects a Gemini model in the Agent and executes the flow",
     { tag: ["@stable", "@model-provider", "@agents", "@playground"] },
     async ({ page }) => {
-      test.skip(
-        !hasProviderEnvKeys(PROVIDER),
-        `Missing env vars for provider "${PROVIDER}": ${missingProviderEnvKeys(PROVIDER).join(", ")}`,
-      );
+      // Health, not mere presence (#1029's gate, applied here by #1415). This
+      // test makes a live completion call, so a key that EXISTS but is dead
+      // cannot produce a verdict about Langflow — and this is the provider the
+      // gate was BUILT for: on run 30374528125 the Google key had exceeded its
+      // monthly spending cap, models.json still listed all 36 Google models (it
+      // mirrors the Langflow catalog, not the validation), and the live calls
+      // that followed blocked past gunicorn's 300 s timeout. Test 1 deliberately
+      // stays on the env-presence gate — see the comment there.
+      const providerGate = providerSkipGate(PROVIDER);
+      test.skip(providerGate.skip, providerGate.reason);
 
       // Per-run sentinel: a match proves THIS execution produced the output.
       const token = `GOOGLE-${Date.now()}`;


### PR DESCRIPTION
Closes #1415.

Applies to the two remaining provider-centric specs the asymmetry #1333 settled for the OpenAI copy of the same bug.

## The gap

`providerSkipGate()` is the health gate #1029 built **specifically for provider-hardcoded specs**: it reads the same `providers.json` the provider-parametrized specs honour and skips with the reason `collect-models` measured. 18 specs used it; these two gated on:

```ts
test.skip(!hasProviderEnvKeys(PROVIDER), ...)   // presence of the env var, never its health
```

So a key that exists but is dead made a live call anyway: the Agent's run never completes, the Stop button stays visible past the 120 s wait, no `div-chat-message` renders, all attempts hard-fail, and the workflow auto-removes `@stable`. A billing outage reported as a product regression, one triage cycle per occurrence. Measured on the OpenAI copy twice (#772/#775, then #1333) — and on **Google** specifically, this is the provider the gate was *built* for: on run 30374528125 its key had exceeded its monthly spending cap, `models.json` still listed all 36 Google models (it mirrors the Langflow catalog, not the validation), and the live calls that followed blocked past gunicorn's 300 s timeout.

## The audit — the gate is per test, not per file

| Spec | Test | Live completion call? | Gate |
|---|---|---|---|
| anthropic | 1. `Anthropic API key is configured…` | no | env presence (unchanged) |
| anthropic | 2. `…selects a Claude model … executes the flow` | **yes** | `providerSkipGate("anthropic")` |
| anthropic | 3. `switches between Claude model families` | **yes** — the switch is proven by executing on the switched-to Sonnet | `providerSkipGate("anthropic")` |
| google | 1. `Google API key is configured…` | no | env presence (unchanged) |
| google | 2. `…selects a Gemini model … executes the flow` | **yes** | `providerSkipGate("google")` |

**Both Test 1s are deliberately left ungated, and the premise was measured rather than carried over from #1333** — two independent ways:

1. **The backend code path.** `validate_model_provider_key` (`lfx/base/models/unified_models.py`) does make a real `llm.invoke("test")` with `max_tokens=1`, but it only raises when the error message contains `401`, `authentication` or `api key`; every other failure hits a bare `return` — the source comment is literally *"allow saving despite minor errors"*. A drained balance (`credit balance is too low`, `insufficient_quota`) or a spend cap matches none of those, so `POST /api/v1/models/validate-provider` answers `{valid: true}` and the configure test passes. Same code path for all three providers.
2. **The historical record.** `reports/daily-history.jsonl`, 2026-07-27 — the drained-Anthropic day ([run 30261409427](https://github.com/oriontech-me/langflow-e2e/actions/runs/30261409427), the one that motivated #976): only Test 2 (line 239) failed. Test 1 passed; Test 3 never ran (serial mode skips after a failure).

So both Test 1s keep covering the Settings save path on exactly the days the account is down. Gating them would trade real coverage for nothing.

## A spec doc that documented a mechanism which did not exist

The anthropic **"Zero-credit trap"** note claimed the spec *"requires an active provider (`providers.json`)"*. Nothing in it read `providers.json` until this PR — the mechanism was documented but never implemented, and the cost is the 2026-07-27 daily above. The note now states the real backend reason and says explicitly that the gate arrived in #1415.

**Resilience, not a root-cause fix** — the accounts still have to be funded for §7.3.2/§7.3.3/§7.4.2 to be exercised at all. The general remedy (probe candidate keys, resolve a live one before the suite, fail loud when every candidate is dead) is **#976**.

## Validation

Nightly **1.12.0.dev23**, local Docker, live Anthropic and Google keys.

- [x] **anthropic 3/3 clean `--retries=0 --workers=1`** — 39.5s / 42.8s / 42.3s
- [x] **google 3/3 clean `--retries=0 --workers=1`** — 24.5s / 19.8s / 20.3s
- [x] **Force-failure executed for every test in both files** — 10 mutations, isolated per test with `--grep` (both files are serial, so a first failure would mask the rest):

  | # | Mutation | Result |
  |---|---|---|
  | A1 | anthropic T1 — `expect(persistResp.ok()).toBe(false)` | ❌ `Expected: false, Received: true` |
  | A2 | anthropic T2 — `/claude/i` → `/gpt/i` | ❌ `Received string: "claude-haiku-4-5"` |
  | A3 | anthropic T2+T3 — shared non-empty-reply assert | ❌ `Expected: -1, Received: 283` |
  | A4 | anthropic T3 — the switched-to model name assert | ❌ `Received string: "claude-sonnet-5"` |
  | A5 | anthropic T3 — the Haiku load assert | ❌ `Received string: "claude-haiku-4-5"` |
  | G1 | google T1 — persist assertion | ❌ `Expected: false, Received: true` |
  | G2 | google T2 — `/gemini\|gemma/i` → `/claude/i` | ❌ `Received string: "gemini-flash-latest"` |
  | G3 | google T2 — non-empty-reply assert | ❌ `Expected: -1, Received: 20` |
  | E-anthropic | **behavioural, on the new gate** — `providers.json` set to `anthropic inactive` | T2 **and** T3 `skipped` quoting `Provider "anthropic" inactive — Your credit balance is too low…`; T1 `passed`. T3 skips on **its own** gate — the reason shown is the gate's, not a serial cascade |
  | E-google | **behavioural** — `providers.json` set to `google inactive` | T2 `skipped` quoting `Provider "google" inactive — Provider exceeded its monthly spending cap`; T1 `passed` |

  Revert proved on both files: `diff` against the pre-mutation copy returns identical, 0 mutation markers in the diff.
- [x] **Final clean runs: `3 passed` / `2 passed`, zero `🚨 Backend Error`**
- [x] **Zero leaked flows** — `GET /api/v1/flows/` 28 before → 28 after
- [x] `npm run typecheck` clean · `eslint` **0 errors** on both specs · `npm run test:units` **fail 0** · QA-CHECKLIST generated-block guard ✓ · coverage guard ✓
- [ ] `--trace=on` — **not run**: known limitation, tracing any spec that loads the Simple Agent template hangs indefinitely on this stack (#490/#518). Step verification is covered by the `--retries=0` bursts and the force-fail matrix above.

`QA-CHECKLIST.md` is untouched — the §7.3/§7.4 Part II bullets already reference both specs, and no tag changed.

## Two side findings, deliberately NOT fixed here

1. **`expect(validateResp.ok()).toBe(true)` cannot distinguish a good key from a bad one**, in all three provider specs. `POST /api/v1/models/validate-provider` returns **200 always** — the verdict is in the body (`{"valid":false,"error":"Invalid API key for OpenAI"}`, measured directly). It is **not** a false positive: run with a garbage key, Test 1 still fails, because `valid:false` stops the frontend from persisting and the `/api/v1/variables/` waiter times out. The defect is that the failure surfaces as an opaque `waitForResponse: Timeout 30000ms` instead of "the key was rejected", and the spec docs claim the 2xx proves the key authenticates — it does not. Fixing it properly means restructuring the `Promise.all` and touching a file outside this issue's scope (`openai-provider.spec.ts`). Happy to file it.
2. **Ambient 500 on the bulk `DELETE /api/v1/flows/`** — seen in 3 of 6 runs. Attributed by running the **pre-change** version (`git show HEAD:`): same 500, 2/2, so it is not caused by this PR. Container log: `OperationalError: database is locked` (SQLite) in `delete_multiple_flows` → `cascade_delete_flow`, triggered by the delete-all inside `SimpleAgentTemplatePage.load()`. Same class as #965 but on flows. Non-fatal — the fixture only logs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
